### PR TITLE
Remove Ice.Override.Timeout in C++

### DIFF
--- a/cpp/src/Ice/ConnectionFactory.cpp
+++ b/cpp/src/Ice/ConnectionFactory.cpp
@@ -170,18 +170,13 @@ IceInternal::OutgoingConnectionFactory::waitUntilFinished()
 
 void
 IceInternal::OutgoingConnectionFactory::createAsync(
-    const vector<EndpointIPtr>& endpts,
+    vector<EndpointIPtr> endpoints,
     bool hasMore,
     Ice::EndpointSelectionType selType,
     function<void(Ice::ConnectionIPtr, bool)> response,
     function<void(std::exception_ptr)> exception)
 {
-    assert(!endpts.empty());
-
-    //
-    // Apply the overrides.
-    //
-    vector<EndpointIPtr> endpoints = applyOverrides(endpts);
+    assert(!endpoints.empty());
 
     //
     // Try to find a connection to one of the given endpoints.
@@ -236,14 +231,6 @@ IceInternal::OutgoingConnectionFactory::setRouterInfo(const RouterInfoPtr& route
     for (vector<EndpointIPtr>::const_iterator p = endpoints.begin(); p != endpoints.end(); ++p)
     {
         EndpointIPtr endpoint = *p;
-
-        //
-        // Modify endpoints with overrides.
-        //
-        if (_instance->defaultsAndOverrides()->overrideTimeout)
-        {
-            endpoint = endpoint->timeout(_instance->defaultsAndOverrides()->overrideTimeoutValue);
-        }
 
         //
         // The Connection object does not take the compression flag of
@@ -348,24 +335,6 @@ IceInternal::OutgoingConnectionFactory::~OutgoingConnectionFactory()
     assert(_connectionsByEndpoint.empty());
     assert(_pending.empty());
     assert(_pendingConnectCount == 0);
-}
-
-vector<EndpointIPtr>
-IceInternal::OutgoingConnectionFactory::applyOverrides(const vector<EndpointIPtr>& endpts)
-{
-    DefaultsAndOverridesPtr defaultsAndOverrides = _instance->defaultsAndOverrides();
-    vector<EndpointIPtr> endpoints = endpts;
-    for (vector<EndpointIPtr>::iterator p = endpoints.begin(); p != endpoints.end(); ++p)
-    {
-        //
-        // Modify endpoints with overrides.
-        //
-        if (defaultsAndOverrides->overrideTimeout)
-        {
-            *p = (*p)->timeout(defaultsAndOverrides->overrideTimeoutValue);
-        }
-    }
-    return endpoints;
 }
 
 ConnectionIPtr
@@ -1662,11 +1631,6 @@ IceInternal::IncomingConnectionFactory::stopAcceptor()
 void
 IceInternal::IncomingConnectionFactory::initialize()
 {
-    if (_instance->defaultsAndOverrides()->overrideTimeout)
-    {
-        _endpoint = _endpoint->timeout(_instance->defaultsAndOverrides()->overrideTimeoutValue);
-    }
-
     if (_instance->defaultsAndOverrides()->overrideCompress)
     {
         _endpoint = _endpoint->compress(_instance->defaultsAndOverrides()->overrideCompressValue);

--- a/cpp/src/Ice/ConnectionFactory.h
+++ b/cpp/src/Ice/ConnectionFactory.h
@@ -50,7 +50,7 @@ namespace IceInternal
         void waitUntilFinished();
 
         void createAsync(
-            const std::vector<EndpointIPtr>&,
+            std::vector<EndpointIPtr>,
             bool,
             Ice::EndpointSelectionType,
             std::function<void(Ice::ConnectionIPtr, bool)>,
@@ -126,7 +126,6 @@ namespace IceInternal
         using ConnectCallbackPtr = std::shared_ptr<ConnectCallback>;
         friend class ConnectCallback;
 
-        std::vector<EndpointIPtr> applyOverrides(const std::vector<EndpointIPtr>&);
         Ice::ConnectionIPtr findConnection(const std::vector<EndpointIPtr>&, bool&);
         void incPendingConnectCount();
         void decPendingConnectCount();

--- a/cpp/src/Ice/DefaultsAndOverrides.cpp
+++ b/cpp/src/Ice/DefaultsAndOverrides.cpp
@@ -12,9 +12,7 @@ using namespace Ice;
 using namespace IceInternal;
 
 IceInternal::DefaultsAndOverrides::DefaultsAndOverrides(const PropertiesPtr& properties, const LoggerPtr& logger)
-    : overrideTimeout(false),
-      overrideTimeoutValue(-1),
-      overrideCompress(false),
+    : overrideCompress(false),
       overrideCompressValue(false),
       overrideSecure(false),
       overrideSecureValue(false)
@@ -35,20 +33,6 @@ IceInternal::DefaultsAndOverrides::DefaultsAndOverrides(const PropertiesPtr& pro
                 __FILE__,
                 __LINE__,
                 "invalid IP address set for Ice.Default.SourceAddress: `" + value + "'");
-        }
-    }
-
-    value = properties->getIceProperty("Ice.Override.Timeout");
-    if (!value.empty())
-    {
-        const_cast<bool&>(overrideTimeout) = true;
-        const_cast<int32_t&>(overrideTimeoutValue) = properties->getIcePropertyAsInt("Ice.Override.Timeout");
-        if (overrideTimeoutValue < 1 && overrideTimeoutValue != -1)
-        {
-            const_cast<int32_t&>(overrideTimeoutValue) = -1;
-            Warning out(logger);
-            out << "invalid value for Ice.Override.Timeout `" << properties->getIceProperty("Ice.Override.Timeout")
-                << "': defaulting to -1";
         }
     }
 

--- a/cpp/src/Ice/DefaultsAndOverrides.h
+++ b/cpp/src/Ice/DefaultsAndOverrides.h
@@ -32,8 +32,6 @@ namespace IceInternal
         Ice::EncodingVersion defaultEncoding;
         Ice::FormatType defaultFormat;
 
-        bool overrideTimeout;
-        std::int32_t overrideTimeoutValue;
         bool overrideCompress;
         bool overrideCompressValue;
         bool overrideSecure;

--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -817,9 +817,7 @@ IceInternal::RoutableReference::RoutableReference(
       _cacheConnection(cacheConnection),
       _preferSecure(preferSecure),
       _endpointSelection(endpointSelection),
-      _locatorCacheTimeout(locatorCacheTimeout),
-      _overrideTimeout(false),
-      _timeout(-1)
+      _locatorCacheTimeout(locatorCacheTimeout)
 {
     assert(_adapterId.empty() || _endpoints.empty());
     setBatchRequestQueue();
@@ -1590,7 +1588,7 @@ IceInternal::RoutableReference::createConnectionAsync(
     {
         // Get an existing connection or create one if there's no existing connection to one of the given endpoints.
         factory->createAsync(
-            endpoints,
+            std::move(endpoints),
             false,
             getEndpointSelection(),
             std::move(createConnectionSucceded),

--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -817,7 +817,9 @@ IceInternal::RoutableReference::RoutableReference(
       _cacheConnection(cacheConnection),
       _preferSecure(preferSecure),
       _endpointSelection(endpointSelection),
-      _locatorCacheTimeout(locatorCacheTimeout)
+      _locatorCacheTimeout(locatorCacheTimeout),
+      _overrideTimeout(false),
+      _timeout(-1)
 {
     assert(_adapterId.empty() || _endpoints.empty());
     setBatchRequestQueue();

--- a/cpp/test/IceSSL/configuration/AllTests.cpp
+++ b/cpp/test/IceSSL/configuration/AllTests.cpp
@@ -2466,7 +2466,6 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             InitializationData initData;
             initData.properties = createClientProps(defaultProps, false);
             initData.properties->setProperty("IceSSL.DefaultDir", "");
-            initData.properties->setProperty("Ice.Override.Timeout", "5000"); // 5s timeout
             initData.properties->setProperty("IceSSL.CheckCertName", "2");
             CommunicatorPtr comm = initialize(initData);
             Ice::ObjectPrx p(comm, "Glacier2/router:wss -p 443 -h zeroc.com -r /demo-proxy/chat/glacier2");
@@ -2508,7 +2507,6 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             InitializationData initData;
             initData.properties = createClientProps(defaultProps, false);
             initData.properties->setProperty("IceSSL.DefaultDir", "");
-            initData.properties->setProperty("Ice.Override.Timeout", "5000"); // 5s timeout
             initData.properties->setProperty("IceSSL.UsePlatformCAs", "1");
             initData.properties->setProperty("IceSSL.CheckCertName", "2");
             CommunicatorPtr comm = initialize(initData);


### PR DESCRIPTION
This PR removes Ice.Override.Timeout in C++.

As a reminder, "endpoint timeouts", better known as "connection timeouts" (the -t option in stringified endpoints) no longer have any timeout effect on main in C++.

You can however still get/set the timeout option of your endpoints and by extension of your proxy for backwards compatibility. The effect is limited to:
 - if you marshal the endpoint (as part a proxy), you'll send the timeout you've set
 - the communicator considers two endpoints with different timeout values different and will create separate connections for each

I didn't remove Ice.Default.Timeout. It remains the endpoint timeout you get when you parse a proxy string that doesn't specify timeouts for some of its endpoints.


 