### PR TITLE
Map struct to record classes (and structs), use default Equals/GetHas…

### DIFF
--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -136,11 +136,6 @@ namespace Slice
             virtual void visitEnum(const EnumPtr&);
             virtual void visitConst(const ConstPtr&);
             virtual void visitDataMember(const DataMemberPtr&);
-
-        private:
-            // For Slice structs mapped to C# classes
-            void writeMemberHashCode(const DataMemberList&);
-            void writeMemberEquals(const DataMemberList&);
         };
 
         class ResultVisitor : public CsVisitor

--- a/csharp/src/Ice/Internal/Reference.cs
+++ b/csharp/src/Ice/Internal/Reference.cs
@@ -153,7 +153,7 @@ public abstract class Reference : IEquatable<Reference>
         }
         Reference r = _instance.referenceFactory().copy(this);
         // Identity is a reference type, therefore we make a copy of newIdentity.
-        r._identity = newIdentity.Clone();
+        r._identity = newIdentity with { };
         return r;
     }
 

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -857,7 +857,7 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// Returns the identity embedded in this proxy.
     /// <returns>The identity of the target object.</returns>
     /// </summary>
-    public Identity ice_getIdentity() => _reference.getIdentity().Clone();
+    public Identity ice_getIdentity() => _reference.getIdentity() with { };
 
     /// <summary>
     /// Creates a new proxy that is identical to this proxy, except for the per-proxy context.

--- a/csharp/src/Ice/UtilInternal/Collections.cs
+++ b/csharp/src/Ice/UtilInternal/Collections.cs
@@ -5,26 +5,10 @@ using System.Diagnostics;
 
 namespace Ice.UtilInternal;
 
-public sealed class Collections
+public static class Collections
 {
-    // Just like Enumerable.SequenceEqual except it also handles null sequences.
-    // TODO: Note that this code would be removed by proposal #2115.
-    public static bool NullableSequenceEqual<TSource>(IEnumerable<TSource> lhs, IEnumerable<TSource> rhs)
-    {
-        if (lhs is null)
-        {
-            return rhs is null || !rhs.Any();
-        }
-        if (rhs is null)
-        {
-            return !lhs.Any();
-        }
-
-        return lhs.SequenceEqual(rhs);
-    }
-
     // Seq is a nullable seq.
-    public static void HashCodeAdd<TSource>(ref HashCode hash, IEnumerable<TSource> seq)
+    internal static void HashCodeAdd<TSource>(ref HashCode hash, IEnumerable<TSource> seq)
     {
         if (seq is not null)
         {
@@ -35,7 +19,7 @@ public sealed class Collections
         }
     }
 
-    public static bool DictionaryEquals(IDictionary d1, IDictionary d2)
+    internal static bool DictionaryEquals(IDictionary d1, IDictionary d2)
     {
         if (ReferenceEquals(d1, d2))
         {
@@ -77,7 +61,7 @@ public sealed class Collections
         return false;
     }
 
-    public static void HashCodeAdd<TKey, TValue>(ref HashCode hash, IDictionary<TKey, TValue> d) where TKey : notnull
+    internal static void HashCodeAdd<TKey, TValue>(ref HashCode hash, IDictionary<TKey, TValue> d) where TKey : notnull
     {
         if (d is not null)
         {
@@ -107,7 +91,7 @@ public sealed class Collections
         }
     }
 
-    public static void Sort<T>(ref List<T> array, IComparer<T> comparator)
+    internal static void Sort<T>(ref List<T> array, IComparer<T> comparator)
     {
         //
         // This Sort method implements the merge sort algorithm

--- a/csharp/test/Ice/objects/AllTests.cs
+++ b/csharp/test/Ice/objects/AllTests.cs
@@ -46,7 +46,7 @@ namespace Ice
                 }
             }
 
-            public partial class SC1
+            public partial record class SC1
             {
                 partial void ice_initialize()
                 {

--- a/csharp/test/Slice/structure/Client.cs
+++ b/csharp/test/Slice/structure/Client.cs
@@ -6,7 +6,7 @@ public class Client : TestHelper
 {
     private static void allTests(Ice.Communicator communicator)
     {
-        Console.Out.Write("testing equals() for Slice structures... ");
+        Console.Out.Write("testing operator== for Slice structures... ");
         Console.Out.Flush();
 
         //
@@ -28,40 +28,38 @@ public class Client : TestHelper
         {
             S2 v;
 
-            v = def_s2.Clone();
-            test(v.Equals(def_s2));
+            v = def_s2 with { };
+            test(v == def_s2);
 
-            v = def_s2.Clone();
-            v.bo = false;
-            test(!v.Equals(def_s2));
+            v = def_s2 with { bo = false };
+            test(v != def_s2);
 
-            v = def_s2.Clone();
+            v = def_s2 with { };
             v.by--;
-            test(!v.Equals(def_s2));
+            test(v != def_s2);
 
-            v = def_s2.Clone();
+            v = def_s2 with { };
             v.sh--;
-            test(!v.Equals(def_s2));
+            test(v != def_s2);
 
-            v = def_s2.Clone();
+            v = def_s2 with { };
             v.i--;
-            test(!v.Equals(def_s2));
+            test(v != def_s2);
 
-            v = def_s2.Clone();
+            v = def_s2 with { };
             v.l--;
-            test(!v.Equals(def_s2));
+            test(v != def_s2);
 
-            v = def_s2.Clone();
+            v = def_s2 with { };
             v.f--;
-            test(!v.Equals(def_s2));
+            test(v != def_s2);
 
-            v = def_s2.Clone();
+            v = def_s2 with { };
             v.d--;
-            test(!v.Equals(def_s2));
+            test(v != def_s2);
 
-            v = def_s2.Clone();
-            v.str = "";
-            test(!v.Equals(def_s2));
+            v = def_s2 with { str = "" };
+            test(v != def_s2);
         }
 
         //
@@ -70,25 +68,20 @@ public class Client : TestHelper
         {
             S2 v1, v2;
 
-            v1 = def_s2.Clone();
-            v1.str = (string)def_s2.str.Clone();
-            test(v1.Equals(def_s2));
+            v1 = def_s2 with { str = (string)def_s2.str.Clone() };
+            test(v1 == def_s2);
 
-            v1 = def_s2.Clone();
-            v2 = def_s2.Clone();
-            v1.str = null;
-            test(!v1.Equals(v2));
+            v1 = def_s2 with { str = ""};
+            v2 = def_s2 with { };
+            test(v1 != v2);
 
-            v1 = def_s2.Clone();
-            v2 = def_s2.Clone();
-            v2.str = null;
-            test(!v1.Equals(v2));
+            v1 = def_s2 with { };
+            v2 = def_s2 with { str = ""};
+            test(v1 != v2);
 
-            v1 = def_s2.Clone();
-            v2 = def_s2.Clone();
-            v1.str = null;
-            v2.str = null;
-            test(v1.Equals(v2));
+            v1 = def_s2 with { str = "" };
+            v2 = def_s2 with { str = "" };
+            test(v1 == v2);
         }
 
         //
@@ -97,19 +90,16 @@ public class Client : TestHelper
         {
             S2 v1, v2;
 
-            v1 = def_s2.Clone();
-            v1.ss = (string[])def_s2.ss.Clone();
-            test(v1.Equals(def_s2));
+            v1 = def_s2 with { ss = (string[])def_s2.ss.Clone() };
+            test(v1 != def_s2);
 
-            v1 = def_s2.Clone();
-            v2 = def_s2.Clone();
-            v1.ss = null;
-            test(!v1.Equals(v2));
+            v1 = def_s2 with { ss = Array.Empty<string>() };
+            v2 = def_s2 with { };
+            test(v1 != v2);
 
-            v1 = def_s2.Clone();
-            v2 = def_s2.Clone();
-            v2.ss = null;
-            test(!v1.Equals(v2));
+            v1 = def_s2 with { };
+            v2 = def_s2 with { ss = Array.Empty<string>()};
+            test(v1 != v2);
         }
 
         //
@@ -118,77 +108,48 @@ public class Client : TestHelper
         {
             S2 v1, v2;
 
-            v1 = def_s2.Clone();
-            v1.il = new List<int>(def_s2.il);
-            test(v1.Equals(def_s2));
+            v1 = def_s2 with { il = new List<int>(def_s2.il) };
+            test(v1 != def_s2);
 
-            v1 = def_s2.Clone();
-            v1.il = new List<int> { 0, 0, 0 };
-            test(!v1.Equals(def_s2));
+            v1 = def_s2 with { il = new List<int> { 0, 0, 0 } };
+            test(v1 != def_s2);
 
-            v1 = def_s2.Clone();
-            v2 = def_s2.Clone();
-            v1.il = null;
-            test(!v1.Equals(v2));
+            v1 = def_s2 with { il = new List<int>()};
+            v2 = def_s2 with {  };
+            test(v1 != v2);
 
-            v1 = def_s2.Clone();
-            v2 = def_s2.Clone();
-            v2.il = null;
-            test(!v1.Equals(v2));
+            v1 = def_s2 with { };
+            v2 = def_s2 with {il = new List<int>() };
+            test(v1 != v2);
         }
 
         //
         // Dictionary member
         //
         {
-            S2 v1, v2;
+            S2 v1;
 
-            v1 = def_s2.Clone();
-            v1.sd = new Dictionary<string, string>(def_s2.sd);
-            test(v1.Equals(def_s2));
+            v1 = def_s2 with { sd = new Dictionary<string, string>(def_s2.sd) };
+            test(v1 != def_s2);
 
-            v1 = def_s2.Clone();
-            v1.sd = new Dictionary<string, string>();
-            test(!v1.Equals(def_s2));
-
-            v1 = def_s2.Clone();
-            v2 = def_s2.Clone();
-            v1.sd = null;
-            test(!v1.Equals(v2));
-
-            v1 = def_s2.Clone();
-            v2 = def_s2.Clone();
-            v2.sd = null;
-            test(!v1.Equals(v2));
+            v1 = def_s2 with { sd = new Dictionary<string, string>() };
+            test(v1 != def_s2);
         }
 
         //
         // Struct member
         //
         {
-            S2 v1, v2;
+            S2 v1;
 
-            v1 = def_s2.Clone();
-            v1.s = def_s2.s.Clone();
-            test(v1.Equals(def_s2));
+            v1 = def_s2 with { s = def_s2.s with { } };
+            test(v1 == def_s2);
 
-            v1 = def_s2.Clone();
-            v1.s = new S1("name");
-            test(v1.Equals(def_s2));
+            v1 = def_s2 with { s = new S1("name") };
+            test(v1 == def_s2);
 
-            v1 = def_s2.Clone();
-            v1.s = new S1("noname");
-            test(!v1.Equals(def_s2));
-
-            v1 = def_s2.Clone();
-            v2 = def_s2.Clone();
-            v1.s = null;
-            test(!v1.Equals(v2));
-
-            v1 = def_s2.Clone();
-            v2 = def_s2.Clone();
-            v2.s = null;
-            test(!v1.Equals(v2));
+            v1 = def_s2 with { s = new S1("noname") };
+            test(v1 != def_s2);
         }
 
         //
@@ -197,19 +158,16 @@ public class Client : TestHelper
         {
             S2 v1, v2;
 
-            v1 = def_s2.Clone();
-            v1.cls = (C)def_s2.cls.Clone();
-            test(!v1.Equals(def_s2));
+            v1 = def_s2 with { cls = (C)def_s2.cls.Clone() };
+            test(v1 != def_s2);
 
-            v1 = def_s2.Clone();
-            v2 = def_s2.Clone();
-            v1.cls = null;
-            test(!v1.Equals(v2));
+            v1 = def_s2 with { cls = null };
+            v2 = def_s2 with { };
+            test(v1 != v2);
 
-            v1 = def_s2.Clone();
-            v2 = def_s2.Clone();
-            v2.cls = null;
-            test(!v1.Equals(v2));
+            v1 = def_s2 with { };
+            v2 = def_s2 with { cls = null };
+            test(v1 != v2);
         }
 
         //
@@ -218,23 +176,19 @@ public class Client : TestHelper
         {
             S2 v1, v2;
 
-            v1 = def_s2.Clone();
-            v1.prx = communicator.stringToProxy("test");
-            test(v1.Equals(def_s2));
+            v1 = def_s2 with { prx = communicator.stringToProxy("test") };
+            test(v1 == def_s2);
 
-            v1 = def_s2.Clone();
-            v1.prx = communicator.stringToProxy("test2");
-            test(!v1.Equals(def_s2));
+            v1 = def_s2 with { prx = communicator.stringToProxy("test2") };
+            test(v1 != def_s2);
 
-            v1 = def_s2.Clone();
-            v2 = def_s2.Clone();
-            v1.prx = null;
-            test(!v1.Equals(v2));
+            v1 = def_s2 with { prx = null};
+            v2 = def_s2 with { };
+            test(v1 != v2);
 
-            v1 = def_s2.Clone();
-            v2 = def_s2.Clone();
-            v2.prx = null;
-            test(!v1.Equals(v2));
+            v1 = def_s2 with { };
+            v2 = def_s2 with { prx = null };
+            test(v1 != v2);
         }
 
         Console.Out.WriteLine("ok");

--- a/csharp/test/Slice/structure/Client.cs
+++ b/csharp/test/Slice/structure/Client.cs
@@ -71,12 +71,12 @@ public class Client : TestHelper
             v1 = def_s2 with { str = (string)def_s2.str.Clone() };
             test(v1 == def_s2);
 
-            v1 = def_s2 with { str = ""};
+            v1 = def_s2 with { str = "" };
             v2 = def_s2 with { };
             test(v1 != v2);
 
             v1 = def_s2 with { };
-            v2 = def_s2 with { str = ""};
+            v2 = def_s2 with { str = "" };
             test(v1 != v2);
 
             v1 = def_s2 with { str = "" };
@@ -98,7 +98,7 @@ public class Client : TestHelper
             test(v1 != v2);
 
             v1 = def_s2 with { };
-            v2 = def_s2 with { ss = Array.Empty<string>()};
+            v2 = def_s2 with { ss = Array.Empty<string>() };
             test(v1 != v2);
         }
 
@@ -114,12 +114,12 @@ public class Client : TestHelper
             v1 = def_s2 with { il = new List<int> { 0, 0, 0 } };
             test(v1 != def_s2);
 
-            v1 = def_s2 with { il = new List<int>()};
-            v2 = def_s2 with {  };
+            v1 = def_s2 with { il = new List<int>() };
+            v2 = def_s2 with { };
             test(v1 != v2);
 
             v1 = def_s2 with { };
-            v2 = def_s2 with {il = new List<int>() };
+            v2 = def_s2 with { il = new List<int>() };
             test(v1 != v2);
         }
 
@@ -182,7 +182,7 @@ public class Client : TestHelper
             v1 = def_s2 with { prx = communicator.stringToProxy("test2") };
             test(v1 != def_s2);
 
-            v1 = def_s2 with { prx = null};
+            v1 = def_s2 with { prx = null };
             v2 = def_s2 with { };
             test(v1 != v2);
 


### PR DESCRIPTION
…hCode

This PR changes the struct-to-C# class mapping: the mapped class is not a (read-write) record class with its default Equals and GetHashCode implementation.

Fixes #2214.