### PR TITLE
Initial ice_timeout removal in C++

### DIFF
--- a/cpp/include/Ice/Connection.h
+++ b/cpp/include/Ice/Connection.h
@@ -265,12 +265,6 @@ namespace Ice
         virtual std::string type() const noexcept = 0;
 
         /**
-         * Get the timeout for the connection.
-         * @return The connection's timeout.
-         */
-        virtual int timeout() const noexcept = 0;
-
-        /**
          * Return a description of the connection as human readable text, suitable for logging or error messages.
          * @return The description of the connection as human readable text.
          */

--- a/cpp/include/Ice/OutgoingAsync.h
+++ b/cpp/include/Ice/OutgoingAsync.h
@@ -145,7 +145,6 @@ namespace IceInternal
         virtual AsyncStatus invokeCollocated(CollocatedRequestHandler*) = 0;
 
         virtual bool exception(std::exception_ptr);
-        virtual void cancelable(const CancellationHandlerPtr&);
 
         void retryException();
         void retry();

--- a/cpp/src/Ice/ConnectionFactory.cpp
+++ b/cpp/src/Ice/ConnectionFactory.cpp
@@ -351,8 +351,11 @@ IceInternal::OutgoingConnectionFactory::findConnection(const vector<EndpointIPtr
 
     for (const auto& p : endpoints)
     {
-        auto connection =
-            find(_connectionsByEndpoint, p, [](const ConnectionIPtr& conn) { return conn->isActiveOrHolding(); });
+        auto connection = find(
+            _connectionsByEndpoint,
+            p->timeout(-1), // clear the timeout
+            [](const ConnectionIPtr& conn) { return conn->isActiveOrHolding(); });
+
         if (connection)
         {
             if (defaultsAndOverrides->overrideCompress)
@@ -539,7 +542,7 @@ IceInternal::OutgoingConnectionFactory::createConnection(const TransceiverPtr& t
             _instance,
             transceiver,
             ci.connector,
-            ci.endpoint->compress(false),
+            ci.endpoint->compress(false)->timeout(-1),
             nullptr,
             [weakSelf = weak_from_this()](const ConnectionIPtr& closedConnection)
             {

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -1841,12 +1841,6 @@ Ice::ConnectionI::type() const noexcept
     return _type; // No mutex lock, _type is immutable.
 }
 
-int32_t
-Ice::ConnectionI::timeout() const noexcept
-{
-    return _endpoint->timeout(); // No mutex lock, _endpoint is immutable.
-}
-
 ConnectionInfoPtr
 Ice::ConnectionI::getInfo() const
 {

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -198,9 +198,8 @@ namespace Ice
         std::string toString() const noexcept final; // From Connection and EventHandler.
         IceInternal::NativeInfoPtr getNativeInfo() final;
 
-        std::string type() const noexcept final;     // From Connection.
-        std::int32_t timeout() const noexcept final; // From Connection.
-        ConnectionInfoPtr getInfo() const final;     // From Connection
+        std::string type() const noexcept final; // From Connection.
+        ConnectionInfoPtr getInfo() const final; // From Connection
 
         void setBufferSize(std::int32_t rcvSize, std::int32_t sndSize) final; // From Connection
 

--- a/cpp/src/Ice/DefaultsAndOverrides.cpp
+++ b/cpp/src/Ice/DefaultsAndOverrides.cpp
@@ -80,7 +80,7 @@ IceInternal::DefaultsAndOverrides::DefaultsAndOverrides(const PropertiesPtr& pro
     }
 
     const_cast<int&>(defaultInvocationTimeout) = properties->getIcePropertyAsInt("Ice.Default.InvocationTimeout");
-    if (defaultInvocationTimeout < 1 && defaultInvocationTimeout != -1 && defaultInvocationTimeout != -2)
+    if (defaultInvocationTimeout < 1 && defaultInvocationTimeout != -1)
     {
         const_cast<int32_t&>(defaultInvocationTimeout) = -1;
         Warning out(logger);

--- a/cpp/src/Ice/OutgoingAsync.cpp
+++ b/cpp/src/Ice/OutgoingAsync.cpp
@@ -324,11 +324,7 @@ ProxyOutgoingAsyncBase::exception(std::exception_ptr exc)
         _childObserver.detach();
     }
 
-    _cachedConnection = 0;
-    if (_proxy._getReference()->getInvocationTimeout() == -2)
-    {
-        _instance->timer()->cancel(shared_from_this());
-    }
+    _cachedConnection = nullptr;
 
     //
     // NOTE: at this point, synchronization isn't needed, no other threads should be
@@ -351,20 +347,6 @@ ProxyOutgoingAsyncBase::exception(std::exception_ptr exc)
     {
         return exceptionImpl(current_exception()); // No retries, we're done
     }
-}
-
-void
-ProxyOutgoingAsyncBase::cancelable(const CancellationHandlerPtr& handler)
-{
-    if (_proxy._getReference()->getInvocationTimeout() == -2 && _cachedConnection)
-    {
-        const int timeout = _cachedConnection->timeout();
-        if (timeout > 0)
-        {
-            _instance->timer()->schedule(shared_from_this(), chrono::milliseconds(timeout));
-        }
-    }
-    OutgoingAsyncBase::cancelable(handler);
 }
 
 void

--- a/cpp/src/Ice/Proxy.cpp
+++ b/cpp/src/Ice/Proxy.cpp
@@ -481,7 +481,7 @@ Ice::ObjectPrx::_fixed(ConnectionPtr connection) const
 ReferencePtr
 Ice::ObjectPrx::_invocationTimeout(int newTimeout) const
 {
-    if (newTimeout < 1 && newTimeout != -1 && newTimeout != -2)
+    if (newTimeout < 1 && newTimeout != -1)
     {
         ostringstream s;
         s << "invalid value passed to ice_invocationTimeout: " << newTimeout;

--- a/cpp/src/Ice/RouterInfo.cpp
+++ b/cpp/src/Ice/RouterInfo.cpp
@@ -229,29 +229,7 @@ IceInternal::RouterInfo::setClientEndpoints(const optional<ObjectPrx>& proxy, bo
     if (_clientEndpoints.empty())
     {
         _hasRoutingTable = hasRoutingTable;
-        if (!proxy)
-        {
-            //
-            // If getClientProxy() return nil, use router endpoints.
-            //
-            _clientEndpoints = _router->_getReference()->getEndpoints();
-        }
-        else
-        {
-            ObjectPrx clientProxy = proxy->ice_router(nullopt); // The client proxy cannot be routed.
-
-            //
-            // In order to avoid creating a new connection to the router,
-            // we must use the same timeout as the already existing
-            // connection.
-            //
-            if (_router->ice_getConnection())
-            {
-                clientProxy = clientProxy->ice_timeout(_router->ice_getConnection()->timeout());
-            }
-
-            _clientEndpoints = clientProxy->_getReference()->getEndpoints();
-        }
+        _clientEndpoints = proxy ? proxy->_getReference()->getEndpoints() : _router->_getReference()->getEndpoints();
     }
     return _clientEndpoints;
 }

--- a/cpp/src/IceGrid/IceGridNode.cpp
+++ b/cpp/src/IceGrid/IceGridNode.cpp
@@ -464,7 +464,7 @@ NodeService::startImpl(int argc, char* argv[], int& status)
     {
         try
         {
-            communicator()->getDefaultLocator()->ice_timeout(1000)->ice_ping();
+            communicator()->getDefaultLocator()->ice_invocationTimeout(1000)->ice_ping();
         }
         catch (const Ice::Exception& ex)
         {

--- a/cpp/src/IceGrid/RegistryI.cpp
+++ b/cpp/src/IceGrid/RegistryI.cpp
@@ -324,7 +324,7 @@ RegistryI::startImpl()
     {
         string endpoints = properties->getProperty("IceGrid.Registry.Client.Endpoints");
         string strPrx = _instanceName + "/Locator:" + endpoints;
-        _communicator->stringToProxy(strPrx)->ice_timeout(5000)->ice_ping();
+        _communicator->stringToProxy(strPrx)->ice_invocationTimeout(5000)->ice_ping();
 
         Error out(_communicator->getLogger());
         out << "an IceGrid registry is already running and listening on the client endpoints `" << endpoints << "'";

--- a/cpp/src/IceStorm/Subscriber.cpp
+++ b/cpp/src/IceStorm/Subscriber.cpp
@@ -303,8 +303,8 @@ namespace
 {
     SubscriberLink::SubscriberLink(const shared_ptr<Instance>& instance, const SubscriberRecord& rec)
         : Subscriber(instance, rec, nullopt, -1, 1),
-          _obj(TopicLinkPrx(
-              rec.obj->ice_collocationOptimized(false)->ice_timeout(static_cast<int>(instance->sendTimeout().count()))))
+          _obj(TopicLinkPrx(rec.obj->ice_collocationOptimized(false)->ice_invocationTimeout(
+              static_cast<int>(instance->sendTimeout().count()))))
     {
     }
 
@@ -410,11 +410,11 @@ Subscriber::create(const shared_ptr<Instance>& instance, const SubscriberRecord&
                 throw BadQoS("invalid reliability: " + reliability);
             }
 
-            // Override the timeout.
+            // Override the invocation timeout.
             optional<Ice::ObjectPrx> newObj;
             try
             {
-                newObj = rec.obj->ice_timeout(static_cast<int>(instance->sendTimeout().count()));
+                newObj = rec.obj->ice_invocationTimeout(static_cast<int>(instance->sendTimeout().count()));
             }
             catch (const Ice::FixedProxyException&)
             {

--- a/cpp/test/Ice/adapterDeactivation/AllTests.cpp
+++ b/cpp/test/Ice/adapterDeactivation/AllTests.cpp
@@ -175,7 +175,7 @@ allTests(Test::TestHelper* helper)
     try
     {
 #ifdef _WIN32
-        obj = obj->ice_timeout(100); // Workaround to speed up testing
+        obj = obj->ice_invocationTimeout(100); // Workaround to speed up testing
 #endif
         obj->ice_ping();
         test(false);

--- a/cpp/test/Ice/metrics/AllTests.cpp
+++ b/cpp/test/Ice/metrics/AllTests.cpp
@@ -614,16 +614,16 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         // TODO: this appears necessary on slow macos VMs to give time to the server to clean-up the connection.
         this_thread::sleep_for(chrono::milliseconds(100));
 
-        MetricsPrx m = metrics->ice_timeout(500)->ice_connectionId("Con1");
+        MetricsPrx m = metrics->ice_connectionId("Con1");
         m->ice_ping();
 
         testAttribute(clientMetrics, clientProps, update.get(), "Connection", "parent", "Communicator");
         // testAttribute(clientMetrics, clientProps, update.get(), "Connection", "id", "");
-        testAttribute(clientMetrics, clientProps, update.get(), "Connection", "endpoint", endpoint + " -t 500");
+        testAttribute(clientMetrics, clientProps, update.get(), "Connection", "endpoint", endpoint + " -t infinite");
         testAttribute(clientMetrics, clientProps, update.get(), "Connection", "endpointType", type);
         testAttribute(clientMetrics, clientProps, update.get(), "Connection", "endpointIsDatagram", "false");
         testAttribute(clientMetrics, clientProps, update.get(), "Connection", "endpointIsSecure", isSecure);
-        testAttribute(clientMetrics, clientProps, update.get(), "Connection", "endpointTimeout", "500");
+        testAttribute(clientMetrics, clientProps, update.get(), "Connection", "endpointTimeout", "-1");
         testAttribute(clientMetrics, clientProps, update.get(), "Connection", "endpointCompress", "false");
         testAttribute(clientMetrics, clientProps, update.get(), "Connection", "endpointHost", host);
         testAttribute(clientMetrics, clientProps, update.get(), "Connection", "endpointPort", port);
@@ -661,7 +661,7 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         controller->hold();
         try
         {
-            communicator->stringToProxy("test:" + endpoint)->ice_timeout(10)->ice_ping();
+            communicator->stringToProxy("test:" + endpoint)->ice_connectionId("Con2")->ice_ping();
             test(false);
         }
         catch (const Ice::ConnectTimeoutException&)
@@ -779,22 +779,12 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         c = Connect(prx);
 
         testAttribute(clientMetrics, clientProps, update.get(), "EndpointLookup", "parent", "Communicator", c);
-        testAttribute(
-            clientMetrics,
-            clientProps,
-            update.get(),
-            "EndpointLookup",
-            "id",
-            prx->ice_getConnection()->getEndpoint()->toString(),
-            c);
-        testAttribute(
-            clientMetrics,
-            clientProps,
-            update.get(),
-            "EndpointLookup",
-            "endpoint",
-            prx->ice_getConnection()->getEndpoint()->toString(),
-            c);
+
+        string expected = protocol + " -h localhost -p " + port + " -t 500";
+
+        testAttribute(clientMetrics, clientProps, update.get(), "EndpointLookup", "id", expected, c);
+
+        testAttribute(clientMetrics, clientProps, update.get(), "EndpointLookup", "endpoint", expected, c);
 
         testAttribute(clientMetrics, clientProps, update.get(), "EndpointLookup", "endpointType", type, c);
         testAttribute(clientMetrics, clientProps, update.get(), "EndpointLookup", "endpointIsDatagram", "false", c);

--- a/cpp/test/Ice/operations/Client.cpp
+++ b/cpp/test/Ice/operations/Client.cpp
@@ -36,7 +36,7 @@ Client::run(int argc, char** argv)
     try
     {
 #ifdef _WIN32
-        myClass = myClass->ice_timeout(100); // Workaround to speed up testing
+        myClass = myClass->ice_invocationTimeout(100); // Workaround to speed up testing
 #endif
         myClass->opVoid();
         test(false);

--- a/cpp/test/Ice/proxy/AllTests.cpp
+++ b/cpp/test/Ice/proxy/AllTests.cpp
@@ -637,33 +637,6 @@ allTests(TestHelper* helper)
 
     try
     {
-        base->ice_timeout(0);
-        test(false);
-    }
-    catch (const invalid_argument&)
-    {
-    }
-
-    try
-    {
-        base->ice_timeout(-1);
-    }
-    catch (const invalid_argument&)
-    {
-        test(false);
-    }
-
-    try
-    {
-        base->ice_timeout(-2);
-        test(false);
-    }
-    catch (const invalid_argument&)
-    {
-    }
-
-    try
-    {
         base->ice_invocationTimeout(0);
         test(false);
     }
@@ -674,7 +647,6 @@ allTests(TestHelper* helper)
     try
     {
         base->ice_invocationTimeout(-1);
-        base->ice_invocationTimeout(-2);
     }
     catch (const invalid_argument&)
     {
@@ -683,7 +655,7 @@ allTests(TestHelper* helper)
 
     try
     {
-        base->ice_invocationTimeout(-3);
+        base->ice_invocationTimeout(-2);
         test(false);
     }
     catch (const invalid_argument&)
@@ -776,15 +748,6 @@ allTests(TestHelper* helper)
     test(compObj->ice_getCompress() == nullopt);
     test(compObj->ice_compress(true)->ice_getCompress() == optional<bool>(true));
     test(compObj->ice_compress(false)->ice_getCompress() == optional<bool>(false));
-
-    test(compObj->ice_timeout(20) == compObj->ice_timeout(20));
-    test(compObj->ice_timeout(10) != compObj->ice_timeout(20));
-    test(compObj->ice_timeout(10) < compObj->ice_timeout(20));
-    test(compObj->ice_timeout(20) >= compObj->ice_timeout(10));
-
-    test(compObj->ice_getTimeout() == nullopt);
-    test(compObj->ice_timeout(10)->ice_getTimeout() == optional<int>(10));
-    test(compObj->ice_timeout(20)->ice_getTimeout() == optional<int>(20));
 
     Ice::LocatorPrx loc1(communicator, "loc1:default -p 10000");
     Ice::LocatorPrx loc2(communicator, "loc2:default -p 10000");

--- a/cpp/test/Ice/timeout/AllTests.cpp
+++ b/cpp/test/Ice/timeout/AllTests.cpp
@@ -211,16 +211,6 @@ allTestsWithController(Test::TestHelper* helper, const ControllerPrx& controller
         {
         }
 
-        try
-        {
-            timeout->ice_invocationTimeout(-2)->ice_ping();
-            timeout->ice_invocationTimeout(-2)->ice_pingAsync().get();
-        }
-        catch (const Ice::Exception&)
-        {
-            test(false);
-        }
-
         TimeoutPrx batchTimeout = timeout->ice_batchOneway();
         batchTimeout->ice_ping();
         batchTimeout->ice_ping();

--- a/matlab/lib/+Ice/Connection.m
+++ b/matlab/lib/+Ice/Connection.m
@@ -16,7 +16,6 @@ classdef Connection < IceInternal.WrapperObject
     %   heartbeat - Send a heartbeat message.
     %   heartbeatAsync - Send a heartbeat message.
     %   type - Return the connection type.
-    %   timeout - Get the timeout for the connection.
     %   toString - Return a description of the connection as human readable
     %     text, suitable for logging or error messages.
     %   getInfo - Returns the connection information.
@@ -156,13 +155,6 @@ classdef Connection < IceInternal.WrapperObject
             % Returns (char) - The type of the connection.
 
             r = obj.iceCallWithResult('type');
-        end
-        function r = timeout(obj)
-            % timeout   Get the timeout for the connection.
-            %
-            % Returns (int32) - The connection's timeout.
-
-            r = obj.iceCallWithResult('timeout');
         end
         function r = toString(obj)
             % toString   Return a description of the connection as human

--- a/matlab/lib/+Ice/ObjectPrx.m
+++ b/matlab/lib/+Ice/ObjectPrx.m
@@ -96,9 +96,6 @@ classdef ObjectPrx < IceInternal.WrapperObject
     %   ice_compress - Returns a proxy that is identical to this proxy,
     %     except for compression.
     %   ice_getCompress - Obtains the compression override setting of this proxy.
-    %   ice_timeout - Returns a proxy that is identical to this proxy,
-    %     except for its connection timeout setting.
-    %   ice_getTimeout - Obtains the timeout override of this proxy.
     %   ice_fixed - Obtains a proxy that is identical to this proxy, except it's
     %     a fixed proxy bound to the given connection.
     %   ice_isFixed - Returns whether this proxy is a fixed proxy.
@@ -832,36 +829,6 @@ classdef ObjectPrx < IceInternal.WrapperObject
 
             obj.instantiate_();
             opt = obj.iceCallWithResult('ice_getCompress');
-            if opt.hasValue
-                r = opt.value;
-            else
-                r = IceInternal.UnsetI.Instance;
-            end
-        end
-
-        function r = ice_timeout(obj, t)
-            % ice_timeout - Returns a proxy that is identical to this proxy,
-            %   except for its connection timeout setting which overrides the timeout
-            %   setting from the proxy endpoints.
-            %
-            % Parameters:
-            %   t (int32) - The connection override timeout for the proxy in
-            %     milliseconds.
-            %
-            % Returns - A proxy with the specified timeout.
-
-            r = obj.factory_('ice_timeout', true, t);
-        end
-
-        function r = ice_getTimeout(obj)
-            % ice_getTimeout - Obtains the timeout override of this proxy.
-            %
-            % Returns (optional int32) - The timeout override. If Ice.Unset
-            %   is returned, no override is set. Otherwise, returns the
-            %   timeout override value.
-
-            obj.instantiate_();
-            opt = obj.iceCallWithResult('ice_getTimeout');
             if opt.hasValue
                 r = opt.value;
             else

--- a/matlab/src/Connection.cpp
+++ b/matlab/src/Connection.cpp
@@ -294,18 +294,6 @@ extern "C"
         }
     }
 
-    mxArray* Ice_Connection_timeout(void* self)
-    {
-        try
-        {
-            return createResultValue(createInt(deref<Ice::Connection>(self)->timeout()));
-        }
-        catch (...)
-        {
-            return createResultException(convertException(std::current_exception()));
-        }
-    }
-
     mxArray* Ice_Connection_toString(void* self)
     {
         try

--- a/matlab/src/ObjectPrx.cpp
+++ b/matlab/src/ObjectPrx.cpp
@@ -884,34 +884,6 @@ extern "C"
         }
     }
 
-    mxArray* Ice_ObjectPrx_ice_timeout(void* self, void** r, int t)
-    {
-        try
-        {
-            auto proxy = restoreProxy(self);
-            auto newProxy = proxy->ice_timeout(t);
-            *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
-        }
-        catch (...)
-        {
-            return convertException(std::current_exception());
-        }
-        return 0;
-    }
-
-    mxArray* Ice_ObjectPrx_ice_getTimeout(void* self)
-    {
-        auto v = restoreProxy(self)->ice_getTimeout();
-        if (v.has_value())
-        {
-            return createResultValue(createOptionalValue(true, createInt(v.value())));
-        }
-        else
-        {
-            return createResultValue(createOptionalValue(false, 0));
-        }
-    }
-
     mxArray* Ice_ObjectPrx_ice_fixed(void* self, void** r, void* connection)
     {
         assert(connection); // Wrapper only calls this function for non-nil arguments.

--- a/matlab/src/ice.h
+++ b/matlab/src/ice.h
@@ -108,8 +108,6 @@ extern "C"
     ICE_MATLAB_API mxArray* Ice_ObjectPrx_ice_batchDatagram(void*, void**);
     ICE_MATLAB_API mxArray* Ice_ObjectPrx_ice_compress(void*, void**, unsigned char);
     ICE_MATLAB_API mxArray* Ice_ObjectPrx_ice_getCompress(void*);
-    ICE_MATLAB_API mxArray* Ice_ObjectPrx_ice_timeout(void*, void**, int);
-    ICE_MATLAB_API mxArray* Ice_ObjectPrx_ice_getTimeout(void*);
     ICE_MATLAB_API mxArray* Ice_ObjectPrx_ice_fixed(void*, void**, void*);
     ICE_MATLAB_API mxArray* Ice_ObjectPrx_ice_isFixed(void* self);
     ICE_MATLAB_API mxArray* Ice_ObjectPrx_ice_getConnection(void*, void**);
@@ -171,7 +169,6 @@ extern "C"
     ICE_MATLAB_API mxArray* Ice_Connection_heartbeat(void*);
     ICE_MATLAB_API mxArray* Ice_Connection_heartbeatAsync(void*, void**);
     ICE_MATLAB_API mxArray* Ice_Connection_type(void*);
-    ICE_MATLAB_API mxArray* Ice_Connection_timeout(void*);
     ICE_MATLAB_API mxArray* Ice_Connection_toString(void*);
     ICE_MATLAB_API mxArray* Ice_Connection_getInfo(void*);
     ICE_MATLAB_API mxArray* Ice_Connection_setBufferSize(void*, int, int);

--- a/matlab/test/Ice/operations/Client.m
+++ b/matlab/test/Ice/operations/Client.m
@@ -20,7 +20,7 @@ function client(args)
     fprintf('testing server shutdown... ');
     myClass.shutdown();
     try
-        myClass.ice_timeout(100).ice_ping(); % Use timeout to speed up testing on Windows
+        myClass.ice_invocationTimeout(100).ice_ping(); % Use timeout to speed up testing on Windows
         throw(MException());
     catch ex
         if isa(ex, 'Ice.LocalException')

--- a/matlab/test/Ice/proxy/AllTests.m
+++ b/matlab/test/Ice/proxy/AllTests.m
@@ -417,24 +417,6 @@ classdef AllTests
             assert(base.ice_encodingVersion(Ice.EncodingVersion(1, 0)).ice_getEncodingVersion() ~= Ice.EncodingVersion(1, 1));
 
             try
-                base.ice_timeout(0);
-                assert(false);
-            catch ex
-            end
-
-            try
-                base.ice_timeout(-1);
-            catch ex
-                assert(false);
-            end
-
-            try
-                base.ice_timeout(-2);
-                assert(false);
-            catch ex
-            end
-
-            try
                 base.ice_invocationTimeout(0);
                 assert(false);
             catch ex
@@ -530,15 +512,6 @@ classdef AllTests
             assert(compObj.ice_getCompress() == Ice.Unset);
             assert(compObj.ice_compress(true).ice_getCompress() == true);
             assert(compObj.ice_compress(false).ice_getCompress() == false);
-
-            assert(compObj.ice_timeout(20) == compObj.ice_timeout(20));
-            assert(compObj.ice_timeout(10) ~= compObj.ice_timeout(20));
-            %assert(compObj.ice_timeout(10) < compObj.ice_timeout(20));
-            %assert(~(compObj.ice_timeout(20) < compObj.ice_timeout(10)));
-
-            assert(compObj.ice_getTimeout() == Ice.Unset);
-            assert(compObj.ice_timeout(10).ice_getTimeout() == 10);
-            assert(compObj.ice_timeout(20).ice_getTimeout() == 20);
 
             loc1 = Ice.LocatorPrx.uncheckedCast(communicator.stringToProxy('loc1:default -p 10000'));
             loc2 = Ice.LocatorPrx.uncheckedCast(communicator.stringToProxy('loc2:default -p 10000'));
@@ -697,7 +670,6 @@ classdef AllTests
                 assert(cl.ice_fixed(connection).ice_getConnection() == connection);
                 assert(cl.ice_fixed(connection).ice_fixed(connection).ice_getConnection() == connection);
                 assert(cl.ice_compress(true).ice_fixed(connection).ice_getCompress() == true);
-                assert(cl.ice_fixed(connection).ice_getTimeout() == Ice.Unset);
                 fixedConnection = cl.ice_connectionId('ice_fixed').ice_getConnection();
                 assert(cl.ice_fixed(connection).ice_fixed(fixedConnection).ice_getConnection() == fixedConnection);
                 try

--- a/php/src/Connection.cpp
+++ b/php/src/Connection.cpp
@@ -197,27 +197,6 @@ ZEND_METHOD(Ice_Connection, type)
     }
 }
 
-ZEND_METHOD(Ice_Connection, timeout)
-{
-    if (ZEND_NUM_ARGS() != 0)
-    {
-        WRONG_PARAM_COUNT;
-    }
-
-    Ice::ConnectionPtr _this = Wrapper<Ice::ConnectionPtr>::value(getThis());
-    assert(_this);
-    try
-    {
-        int32_t timeout = _this->timeout();
-        ZVAL_LONG(return_value, static_cast<long>(timeout));
-    }
-    catch (...)
-    {
-        throwException(current_exception());
-        RETURN_NULL();
-    }
-}
-
 ZEND_METHOD(Ice_Connection, toString) { ZEND_MN(Ice_Connection___toString)(INTERNAL_FUNCTION_PARAM_PASSTHRU); }
 
 ZEND_METHOD(Ice_Connection, getInfo)
@@ -349,14 +328,11 @@ static zend_function_entry _connectionClassMethods[] = {
             flushBatchRequests,
             Ice_Connection_flushBatchRequests_arginfo,
             ZEND_ACC_PUBLIC) ZEND_ME(Ice_Connection, heartbeat, ice_void_arginfo, ZEND_ACC_PUBLIC)
-            ZEND_ME(Ice_Connection, type, ice_void_arginfo, ZEND_ACC_PUBLIC) ZEND_ME(
-                Ice_Connection,
-                timeout,
-                ice_void_arginfo,
-                ZEND_ACC_PUBLIC) ZEND_ME(Ice_Connection, toString, ice_void_arginfo, ZEND_ACC_PUBLIC)
-                ZEND_ME(Ice_Connection, getInfo, ice_void_arginfo, ZEND_ACC_PUBLIC)
-                    ZEND_ME(Ice_Connection, setBufferSize, Ice_Connection_setBufferSize_arginfo, ZEND_ACC_PUBLIC)
-                        ZEND_ME(Ice_Connection, throwException, ice_void_arginfo, ZEND_ACC_PUBLIC){0, 0, 0}};
+            ZEND_ME(Ice_Connection, type, ice_void_arginfo, ZEND_ACC_PUBLIC)
+                ZEND_ME(Ice_Connection, toString, ice_void_arginfo, ZEND_ACC_PUBLIC)
+                    ZEND_ME(Ice_Connection, getInfo, ice_void_arginfo, ZEND_ACC_PUBLIC)
+                        ZEND_ME(Ice_Connection, setBufferSize, Ice_Connection_setBufferSize_arginfo, ZEND_ACC_PUBLIC)
+                            ZEND_ME(Ice_Connection, throwException, ice_void_arginfo, ZEND_ACC_PUBLIC){0, 0, 0}};
 
 ZEND_METHOD(Ice_ConnectionInfo, __construct) { runtimeError("ConnectionInfo cannot be instantiated"); }
 

--- a/php/src/Proxy.cpp
+++ b/php/src/Proxy.cpp
@@ -1212,64 +1212,6 @@ ZEND_METHOD(Ice_ObjectPrx, ice_getCompress)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_timeout_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
-ZEND_ARG_INFO(0, timeout)
-ZEND_END_ARG_INFO()
-
-ZEND_METHOD(Ice_ObjectPrx, ice_timeout)
-{
-    ProxyPtr _this = Wrapper<ProxyPtr>::value(getThis());
-    assert(_this);
-
-    try
-    {
-        zend_long l;
-        if (zend_parse_parameters(ZEND_NUM_ARGS(), const_cast<char*>("l"), &l) != SUCCESS)
-        {
-            RETURN_NULL();
-        }
-        // TODO: range check?
-        if (!_this->clone(return_value, _this->proxy->ice_timeout(static_cast<int32_t>(l))))
-        {
-            RETURN_NULL();
-        }
-    }
-    catch (...)
-    {
-        throwException(current_exception());
-        RETURN_NULL();
-    }
-}
-
-ZEND_METHOD(Ice_ObjectPrx, ice_getTimeout)
-{
-    if (ZEND_NUM_ARGS() != 0)
-    {
-        WRONG_PARAM_COUNT;
-    }
-
-    ProxyPtr _this = Wrapper<ProxyPtr>::value(getThis());
-    assert(_this);
-
-    try
-    {
-        optional<int> timeout = _this->proxy->ice_getTimeout();
-        if (timeout)
-        {
-            ZVAL_LONG(return_value, static_cast<long>(*timeout));
-        }
-        else
-        {
-            assignUnset(return_value);
-        }
-    }
-    catch (...)
-    {
-        throwException(current_exception());
-        RETURN_NULL();
-    }
-}
-
 ZEND_BEGIN_ARG_INFO_EX(Ice_ObjectPrx_ice_invocationTimeout_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
 ZEND_ARG_INFO(0, invocationTiemout)
 ZEND_END_ARG_INFO()
@@ -1809,69 +1751,64 @@ static zend_function_entry _proxyMethods[] = {
                                                                     ice_compress,
                                                                     Ice_ObjectPrx_ice_compress_arginfo,
                                                                     ZEND_ACC_PUBLIC)
-                                                                    ZEND_ME(Ice_ObjectPrx, ice_getCompress, ice_void_arginfo, ZEND_ACC_PUBLIC) ZEND_ME(
+                                                                    ZEND_ME(
                                                                         Ice_ObjectPrx,
-                                                                        ice_timeout,
-                                                                        Ice_ObjectPrx_ice_timeout_arginfo,
+                                                                        ice_getCompress,
+                                                                        ice_void_arginfo,
                                                                         ZEND_ACC_PUBLIC)
                                                                         ZEND_ME(
                                                                             Ice_ObjectPrx,
-                                                                            ice_getTimeout,
-                                                                            ice_void_arginfo,
+                                                                            ice_invocationTimeout,
+                                                                            Ice_ObjectPrx_ice_invocationTimeout_arginfo,
                                                                             ZEND_ACC_PUBLIC)
                                                                             ZEND_ME(
                                                                                 Ice_ObjectPrx,
-                                                                                ice_invocationTimeout,
-                                                                                Ice_ObjectPrx_ice_invocationTimeout_arginfo,
+                                                                                ice_getInvocationTimeout,
+                                                                                ice_void_arginfo,
                                                                                 ZEND_ACC_PUBLIC)
                                                                                 ZEND_ME(
                                                                                     Ice_ObjectPrx,
-                                                                                    ice_getInvocationTimeout,
-                                                                                    ice_void_arginfo,
+                                                                                    ice_connectionId,
+                                                                                    Ice_ObjectPrx_ice_connectionId_arginfo,
                                                                                     ZEND_ACC_PUBLIC)
                                                                                     ZEND_ME(
                                                                                         Ice_ObjectPrx,
-                                                                                        ice_connectionId,
-                                                                                        Ice_ObjectPrx_ice_connectionId_arginfo,
+                                                                                        ice_fixed,
+                                                                                        Ice_ObjectPrx_ice_fixed_arginfo,
                                                                                         ZEND_ACC_PUBLIC)
                                                                                         ZEND_ME(
                                                                                             Ice_ObjectPrx,
-                                                                                            ice_fixed,
-                                                                                            Ice_ObjectPrx_ice_fixed_arginfo,
+                                                                                            ice_isFixed,
+                                                                                            ice_void_arginfo,
                                                                                             ZEND_ACC_PUBLIC)
                                                                                             ZEND_ME(
                                                                                                 Ice_ObjectPrx,
-                                                                                                ice_isFixed,
+                                                                                                ice_getConnection,
                                                                                                 ice_void_arginfo,
                                                                                                 ZEND_ACC_PUBLIC)
                                                                                                 ZEND_ME(
                                                                                                     Ice_ObjectPrx,
-                                                                                                    ice_getConnection,
+                                                                                                    ice_getCachedConnection,
                                                                                                     ice_void_arginfo,
                                                                                                     ZEND_ACC_PUBLIC)
                                                                                                     ZEND_ME(
                                                                                                         Ice_ObjectPrx,
-                                                                                                        ice_getCachedConnection,
+                                                                                                        ice_flushBatchRequests,
                                                                                                         ice_void_arginfo,
                                                                                                         ZEND_ACC_PUBLIC)
                                                                                                         ZEND_ME(
                                                                                                             Ice_ObjectPrx,
-                                                                                                            ice_flushBatchRequests,
-                                                                                                            ice_void_arginfo,
+                                                                                                            ice_uncheckedCast,
+                                                                                                            Ice_Proxy_do_cast_arginfo,
                                                                                                             ZEND_ACC_PUBLIC)
                                                                                                             ZEND_ME(
                                                                                                                 Ice_ObjectPrx,
-                                                                                                                ice_uncheckedCast,
+                                                                                                                ice_checkedCast,
                                                                                                                 Ice_Proxy_do_cast_arginfo,
-                                                                                                                ZEND_ACC_PUBLIC)
-                                                                                                                ZEND_ME(
-                                                                                                                    Ice_ObjectPrx,
-                                                                                                                    ice_checkedCast,
-                                                                                                                    Ice_Proxy_do_cast_arginfo,
-                                                                                                                    ZEND_ACC_PUBLIC){
-                                                                                                                    0,
-                                                                                                                    0,
-                                                                                                                    0}};
+                                                                                                                ZEND_ACC_PUBLIC){
+                                                                                                                0,
+                                                                                                                0,
+                                                                                                                0}};
 
 bool
 IcePHP::proxyInit(void)

--- a/php/test/Ice/proxy/Client.php
+++ b/php/test/Ice/proxy/Client.php
@@ -418,10 +418,6 @@ function allTests($helper)
     test($base->ice_compress(true)->ice_getCompress() == true);
     test($base->ice_compress(false)->ice_getCompress() == false);
 
-    test($base->ice_getTimeout() == Ice\None);
-    test($base->ice_timeout(10)->ice_getTimeout() == 10);
-    test($base->ice_timeout(20)->ice_getTimeout() == 20);
-
     echo "ok\n";
 
     echo "testing checked cast... ";
@@ -469,7 +465,6 @@ function allTests($helper)
         test($cl->ice_invocationTimeout(10)->ice_fixed($connection)->ice_getInvocationTimeout() == 10);
         test($cl->ice_fixed($connection)->ice_getConnection() == $connection);
         test($cl->ice_fixed($connection)->ice_fixed($connection)->ice_getConnection() == $connection);
-        test($cl->ice_fixed($connection)->ice_getTimeout() == Ice\None);
         $fixedConnection = $cl->ice_connectionId("ice_fixed")->ice_getConnection();
         test($cl->ice_fixed($connection)->ice_fixed($fixedConnection)->ice_getConnection() == $fixedConnection);
         try

--- a/python/modules/IcePy/Connection.cpp
+++ b/python/modules/IcePy/Connection.cpp
@@ -615,27 +615,6 @@ extern "C"
 extern "C"
 #endif
     static PyObject*
-    connectionTimeout(ConnectionObject* self, PyObject* /*args*/)
-{
-    assert(self->connection);
-    int timeout;
-    try
-    {
-        timeout = (*self->connection)->timeout();
-    }
-    catch (...)
-    {
-        setPythonException(current_exception());
-        return 0;
-    }
-
-    return PyLong_FromLong(timeout);
-}
-
-#ifdef WIN32
-extern "C"
-#endif
-    static PyObject*
     connectionToString(ConnectionObject* self, PyObject* /*args*/)
 {
     assert(self->connection);
@@ -781,10 +760,6 @@ static PyMethodDef ConnectionMethods[] = {
      reinterpret_cast<PyCFunction>(connectionType),
      METH_NOARGS,
      PyDoc_STR(STRCAST("type() -> string"))},
-    {STRCAST("timeout"),
-     reinterpret_cast<PyCFunction>(connectionTimeout),
-     METH_NOARGS,
-     PyDoc_STR(STRCAST("timeout() -> int"))},
     {STRCAST("toString"),
      reinterpret_cast<PyCFunction>(connectionToString),
      METH_NOARGS,

--- a/python/modules/IcePy/Proxy.cpp
+++ b/python/modules/IcePy/Proxy.cpp
@@ -1507,67 +1507,6 @@ extern "C"
 extern "C"
 #endif
     static PyObject*
-    proxyIceTimeout(ProxyObject* self, PyObject* args)
-{
-    int timeout;
-    if (!PyArg_ParseTuple(args, STRCAST("i"), &timeout))
-    {
-        return 0;
-    }
-
-    assert(self->proxy);
-
-    optional<Ice::ObjectPrx> newProxy;
-    try
-    {
-        newProxy = (*self->proxy)->ice_timeout(timeout);
-    }
-    catch (const invalid_argument& ex)
-    {
-        PyErr_Format(PyExc_RuntimeError, "%s", ex.what());
-        return 0;
-    }
-    catch (...)
-    {
-        setPythonException(current_exception());
-        return 0;
-    }
-
-    return createProxy(newProxy.value(), *self->communicator, reinterpret_cast<PyObject*>(Py_TYPE(self)));
-}
-
-#ifdef WIN32
-extern "C"
-#endif
-    static PyObject*
-    proxyIceGetTimeout(ProxyObject* self, PyObject* /*args*/)
-{
-    assert(self->proxy);
-
-    try
-    {
-        optional<int> timeout = (*self->proxy)->ice_getTimeout();
-        if (timeout)
-        {
-            return PyLong_FromLong(*timeout);
-        }
-        else
-        {
-            Py_INCREF(Unset);
-            return Unset;
-        }
-    }
-    catch (...)
-    {
-        setPythonException(current_exception());
-        return 0;
-    }
-}
-
-#ifdef WIN32
-extern "C"
-#endif
-    static PyObject*
     proxyIceIsCollocationOptimized(ProxyObject* self, PyObject* /*args*/)
 {
     assert(self->proxy);
@@ -2393,14 +2332,6 @@ static PyMethodDef ProxyMethods[] = {
      reinterpret_cast<PyCFunction>(proxyIceGetCompress),
      METH_VARARGS,
      PyDoc_STR(STRCAST("ice_getCompress() -> bool"))},
-    {STRCAST("ice_timeout"),
-     reinterpret_cast<PyCFunction>(proxyIceTimeout),
-     METH_VARARGS,
-     PyDoc_STR(STRCAST("ice_timeout(int) -> Ice.ObjectPrx"))},
-    {STRCAST("ice_getTimeout"),
-     reinterpret_cast<PyCFunction>(proxyIceGetTimeout),
-     METH_VARARGS,
-     PyDoc_STR(STRCAST("ice_getTimeout() -> int"))},
     {STRCAST("ice_connectionId"),
      reinterpret_cast<PyCFunction>(proxyIceConnectionId),
      METH_VARARGS,

--- a/python/test/Ice/adapterDeactivation/AllTests.py
+++ b/python/test/Ice/adapterDeactivation/AllTests.py
@@ -153,7 +153,7 @@ def allTests(helper, communicator):
     sys.stdout.write("testing whether server is gone... ")
     sys.stdout.flush()
     try:
-        obj.ice_timeout(100).ice_ping()  # Use timeout to speed up testing on Windows
+        obj.ice_invocationTimeout(100).ice_ping()  # Use timeout to speed up testing on Windows
         test(False)
     except Ice.LocalException:
         print("ok")

--- a/python/test/Ice/operations/AllTests.py
+++ b/python/test/Ice/operations/AllTests.py
@@ -62,7 +62,7 @@ def allTests(helper, communicator):
     sys.stdout.flush()
     cl.shutdown()
     try:
-        cl.ice_timeout(100).ice_ping()  # Use timeout to speed up testing on Windows
+        cl.ice_invocationTimeout(100).ice_ping()  # Use timeout to speed up testing on Windows
         test(False)
     except Ice.LocalException:
         print("ok")

--- a/python/test/Ice/proxy/AllTests.py
+++ b/python/test/Ice/proxy/AllTests.py
@@ -526,23 +526,6 @@ def allTests(helper, communicator, collocated):
     )
 
     try:
-        base.ice_timeout(0)
-        test(False)
-    except RuntimeError:
-        pass
-
-    try:
-        base.ice_timeout(-1)
-    except RuntimeError:
-        test(False)
-
-    try:
-        base.ice_timeout(-2)
-        test(False)
-    except RuntimeError:
-        pass
-
-    try:
         base.ice_invocationTimeout(0)
         test(False)
     except RuntimeError:
@@ -658,15 +641,6 @@ def allTests(helper, communicator, collocated):
     test(compObj.ice_getCompress() == Ice.Unset)
     test(compObj.ice_compress(True).ice_getCompress() is True)
     test(compObj.ice_compress(False).ice_getCompress() is False)
-
-    test(compObj.ice_timeout(20) == compObj.ice_timeout(20))
-    test(compObj.ice_timeout(10) != compObj.ice_timeout(20))
-    test(compObj.ice_timeout(10) < compObj.ice_timeout(20))
-    test(not (compObj.ice_timeout(20) < compObj.ice_timeout(10)))
-
-    test(compObj.ice_getTimeout() == Ice.Unset)
-    test(compObj.ice_timeout(10).ice_getTimeout() == 10)
-    test(compObj.ice_timeout(20).ice_getTimeout() == 20)
 
     loc1 = Ice.LocatorPrx.uncheckedCast(
         communicator.stringToProxy("loc1:default -p 10000")
@@ -861,7 +835,7 @@ def allTests(helper, communicator, collocated):
             cl.ice_fixed(connection).ice_fixed(connection).ice_getConnection()
             == connection
         )
-        test(cl.ice_fixed(connection).ice_getTimeout() == Ice.Unset)
+
         fixedConnection = cl.ice_connectionId("ice_fixed").ice_getConnection()
         test(
             cl.ice_fixed(connection).ice_fixed(fixedConnection).ice_getConnection()

--- a/ruby/src/IceRuby/Connection.cpp
+++ b/ruby/src/IceRuby/Connection.cpp
@@ -114,21 +114,6 @@ IceRuby_Connection_type(VALUE self)
 }
 
 extern "C" VALUE
-IceRuby_Connection_timeout(VALUE self)
-{
-    ICE_RUBY_TRY
-    {
-        Ice::ConnectionPtr* p = reinterpret_cast<Ice::ConnectionPtr*>(DATA_PTR(self));
-        assert(p);
-
-        int32_t timeout = (*p)->timeout();
-        return INT2FIX(timeout);
-    }
-    ICE_RUBY_CATCH
-    return Qnil;
-}
-
-extern "C" VALUE
 IceRuby_Connection_getInfo(VALUE self)
 {
     ICE_RUBY_TRY
@@ -327,7 +312,6 @@ IceRuby::initConnection(VALUE iceModule)
     rb_define_method(_connectionClass, "flushBatchRequests", CAST_METHOD(IceRuby_Connection_flushBatchRequests), 1);
     rb_define_method(_connectionClass, "heartbeat", CAST_METHOD(IceRuby_Connection_heartbeat), 0);
     rb_define_method(_connectionClass, "type", CAST_METHOD(IceRuby_Connection_type), 0);
-    rb_define_method(_connectionClass, "timeout", CAST_METHOD(IceRuby_Connection_timeout), 0);
     rb_define_method(_connectionClass, "getInfo", CAST_METHOD(IceRuby_Connection_getInfo), 0);
     rb_define_method(_connectionClass, "getEndpoint", CAST_METHOD(IceRuby_Connection_getEndpoint), 0);
     rb_define_method(_connectionClass, "setBufferSize", CAST_METHOD(IceRuby_Connection_setBufferSize), 2);

--- a/ruby/src/IceRuby/Proxy.cpp
+++ b/ruby/src/IceRuby/Proxy.cpp
@@ -791,46 +791,6 @@ IceRuby_ObjectPrx_ice_getCompress(VALUE self)
 }
 
 extern "C" VALUE
-IceRuby_ObjectPrx_ice_timeout(VALUE self, VALUE t)
-{
-    ICE_RUBY_TRY
-    {
-        try
-        {
-            Ice::ObjectPrx p = getProxy(self);
-            int32_t timeout = static_cast<int32_t>(getInteger(t));
-            return createProxy(p->ice_timeout(timeout), rb_class_of(self));
-        }
-        catch (const invalid_argument& ex)
-        {
-            throw RubyException(rb_eArgError, ex.what());
-        }
-    }
-    ICE_RUBY_CATCH
-    return Qnil;
-}
-
-extern "C" VALUE
-IceRuby_ObjectPrx_ice_getTimeout(VALUE self)
-{
-    ICE_RUBY_TRY
-    {
-        Ice::ObjectPrx p = getProxy(self);
-        optional<int> t = p->ice_getTimeout();
-        if (t)
-        {
-            return INT2FIX(*t);
-        }
-        else
-        {
-            return Unset;
-        }
-    }
-    ICE_RUBY_CATCH
-    return Qnil;
-}
-
-extern "C" VALUE
 IceRuby_ObjectPrx_ice_connectionId(VALUE self, VALUE id)
 {
     ICE_RUBY_TRY
@@ -1268,8 +1228,6 @@ IceRuby::initProxy(VALUE iceModule)
     rb_define_method(_proxyClass, "ice_isBatchDatagram", CAST_METHOD(IceRuby_ObjectPrx_ice_isBatchDatagram), 0);
     rb_define_method(_proxyClass, "ice_compress", CAST_METHOD(IceRuby_ObjectPrx_ice_compress), 1);
     rb_define_method(_proxyClass, "ice_getCompress", CAST_METHOD(IceRuby_ObjectPrx_ice_getCompress), 0);
-    rb_define_method(_proxyClass, "ice_timeout", CAST_METHOD(IceRuby_ObjectPrx_ice_timeout), 1);
-    rb_define_method(_proxyClass, "ice_getTimeout", CAST_METHOD(IceRuby_ObjectPrx_ice_getTimeout), 0);
     rb_define_method(_proxyClass, "ice_connectionId", CAST_METHOD(IceRuby_ObjectPrx_ice_connectionId), 1);
     rb_define_method(_proxyClass, "ice_fixed", CAST_METHOD(IceRuby_ObjectPrx_ice_fixed), 1);
     rb_define_method(_proxyClass, "ice_isFixed", CAST_METHOD(IceRuby_ObjectPrx_ice_isFixed), 0);

--- a/ruby/test/Ice/operations/Client.rb
+++ b/ruby/test/Ice/operations/Client.rb
@@ -22,7 +22,7 @@ class Client < ::TestHelper
             STDOUT.flush
             myClass.shutdown()
             begin
-                myClass.ice_timeout(100).ice_ping(); # Use timeout to speed up testing on Windows
+                myClass.ice_invocationTimeout(100).ice_ping(); # Use timeout to speed up testing on Windows
                 test(false)
             rescue Ice::LocalException
                 puts "ok"

--- a/ruby/test/Ice/proxy/AllTests.rb
+++ b/ruby/test/Ice/proxy/AllTests.rb
@@ -398,24 +398,6 @@ def allTests(helper, communicator)
     test(base.ice_encodingVersion(Ice::Encoding_1_0).ice_getEncodingVersion() != Ice::Encoding_1_1)
 
     begin
-        base.ice_timeout(0)
-        test(false)
-    rescue
-    end
-
-    begin
-        base.ice_timeout(-1)
-    rescue
-        test(false)
-    end
-
-    begin
-        base.ice_timeout(-2)
-        test(false)
-    rescue
-    end
-
-    begin
         base.ice_invocationTimeout(0)
         test(false)
     rescue
@@ -512,15 +494,6 @@ def allTests(helper, communicator)
     test(compObj.ice_getCompress() == Ice::Unset);
     test(compObj.ice_compress(true).ice_getCompress() == true);
     test(compObj.ice_compress(false).ice_getCompress() == false);
-
-    test(compObj.ice_timeout(20) == compObj.ice_timeout(20))
-    test(compObj.ice_timeout(10) != compObj.ice_timeout(20))
-    #test(compObj.ice_timeout(10) < compObj.ice_timeout(20))
-    #test(!(compObj.ice_timeout(20) < compObj.ice_timeout(10)))
-
-    test(compObj.ice_getTimeout() == Ice::Unset);
-    test(compObj.ice_timeout(10).ice_getTimeout() == 10);
-    test(compObj.ice_timeout(20).ice_getTimeout() == 20);
 
     loc1 = Ice::LocatorPrx::uncheckedCast(communicator.stringToProxy("loc1:default -p 10000"))
     loc2 = Ice::LocatorPrx::uncheckedCast(communicator.stringToProxy("loc2:default -p 10000"))
@@ -673,7 +646,6 @@ def allTests(helper, communicator)
         test(cl.ice_invocationTimeout(10).ice_fixed(connection).ice_getInvocationTimeout() == 10);
         test(cl.ice_fixed(connection).ice_getConnection() == connection)
         test(cl.ice_fixed(connection).ice_fixed(connection).ice_getConnection() == connection)
-        test(cl.ice_fixed(connection).ice_getTimeout() == Ice::Unset)
         fixedConnection = cl.ice_connectionId("ice_fixed").ice_getConnection()
         test(cl.ice_fixed(connection).ice_fixed(fixedConnection).ice_getConnection() == fixedConnection)
         begin

--- a/swift/src/Ice/Connection.swift
+++ b/swift/src/Ice/Connection.swift
@@ -275,11 +275,6 @@ public protocol Connection: Swift.AnyObject, Swift.CustomStringConvertible {
   /// - returns: `Swift.String` - The type of the connection.
   func type() -> Swift.String
 
-  /// Get the timeout for the connection.
-  ///
-  /// - returns: `Swift.Int32` - The connection's timeout.
-  func timeout() -> Swift.Int32
-
   /// Return a description of the connection as human readable text, suitable for logging or error messages.
   ///
   /// - returns: `Swift.String` - The description of the connection as human readable text.

--- a/swift/src/Ice/ConnectionI.swift
+++ b/swift/src/Ice/ConnectionI.swift
@@ -126,10 +126,6 @@ class ConnectionI: LocalObject<ICEConnection>, Connection {
     return handle.type()
   }
 
-  func timeout() -> Int32 {
-    return handle.timeout()
-  }
-
   func toString() -> String {
     return handle.toString()
   }

--- a/swift/src/Ice/Proxy.swift
+++ b/swift/src/Ice/Proxy.swift
@@ -266,19 +266,6 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject {
   /// - returns: A new proxy with the specified compression setting.
   func ice_compress(_ compress: Bool) -> Self
 
-  /// Obtains the timeout override of this proxy.
-  ///
-  /// - returns: `Int32?` - The timeout override. If no optional value is present, no override is set.
-  ///   Otherwise, returns the timeout override value.
-  func ice_getTimeout() -> Int32?
-
-  /// Creates a new proxy that is identical to this proxy, except for its timeout setting.
-  ///
-  /// - parameter _: `Int32` - The timeout for the new proxy in milliseconds.
-  ///
-  /// - returns: A new proxy with the specified timeout.
-  func ice_timeout(_ timeout: Int32) -> Self
-
   /// Returns a proxy that is identical to this proxy, except it's a fixed proxy bound
   /// to the given connection.
   ///
@@ -1079,25 +1066,6 @@ open class ObjectPrxI: ObjectPrx {
 
   public func ice_compress(_ compress: Bool) -> Self {
     return fromICEObjectPrx(handle.ice_compress(compress))
-  }
-
-  public func ice_getTimeout() -> Int32? {
-    guard let timeout = handle.ice_getTimeout() as? Int32? else {
-      preconditionFailure("Int32? type was expected")
-    }
-    return timeout
-  }
-
-  public func ice_timeout(_ timeout: Int32) -> Self {
-    precondition(!ice_isFixed(), "Cannot create a fixed proxy with a connection timeout")
-    precondition(timeout > 0 || timeout == -1, "Invalid connection timeout value")
-    do {
-      return try autoreleasepool {
-        try fromICEObjectPrx(handle.ice_timeout(timeout)) as Self
-      }
-    } catch {
-      fatalError("\(error)")
-    }
   }
 
   public func ice_fixed(_ connection: Connection) -> Self {

--- a/swift/src/IceImpl/Connection.h
+++ b/swift/src/IceImpl/Connection.h
@@ -28,7 +28,6 @@ ICEIMPL_API @interface ICEConnection : ICELocalObject
 - (void)heartbeatAsync:(void (^)(NSError*))exception
                   sent:(void (^_Nullable)(bool))sent NS_SWIFT_NAME(heartbeatAsync(exception:sent:));
 - (NSString*)type;
-- (int32_t)timeout;
 - (NSString*)toString;
 - (nullable id)getInfo:(NSError* _Nullable* _Nullable)error;
 - (BOOL)setBufferSize:(int32_t)rcvSize sndSize:(int32_t)sndSize error:(NSError* _Nullable* _Nullable)error;

--- a/swift/src/IceImpl/Connection.mm
+++ b/swift/src/IceImpl/Connection.mm
@@ -208,11 +208,6 @@
     return toNSString(self.connection->type());
 }
 
-- (int32_t)timeout
-{
-    return self.connection->timeout();
-}
-
 - (NSString*)toString
 {
     return toNSString(self.connection->toString());

--- a/swift/src/IceImpl/ObjectPrx.h
+++ b/swift/src/IceImpl/ObjectPrx.h
@@ -66,9 +66,6 @@ ICEIMPL_API @interface ICEObjectPrx : NSObject
 // id represents Any in Swift which we use as an Optional int32_t
 - (nullable id)ice_getCompress;
 - (nonnull instancetype)ice_compress:(bool)compress;
-// id represents Any in Swift which we use as an Optional int32_t
-- (nullable id)ice_getTimeout;
-- (nullable instancetype)ice_timeout:(int32_t)timeout error:(NSError* _Nullable* _Nullable)error;
 - (nullable instancetype)ice_fixed:(ICEConnection*)connection error:(NSError* _Nullable* _Nullable)error;
 - (bool)ice_isFixed;
 - (nullable id)ice_getConnection:(NSError* _Nullable* _Nullable)error; // Either NSNull or ICEConnection

--- a/swift/src/IceImpl/ObjectPrx.mm
+++ b/swift/src/IceImpl/ObjectPrx.mm
@@ -402,30 +402,6 @@
     return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
 }
 
-- (id)ice_getTimeout
-{
-    auto timeout = _prx->ice_getTimeout();
-    if (!timeout.has_value())
-    {
-        return nil;
-    }
-    return [NSNumber numberWithInt:timeout.value()];
-}
-
-- (instancetype)ice_timeout:(int32_t)timeout error:(NSError**)error
-{
-    try
-    {
-        auto prx = _prx->ice_timeout(timeout);
-        return _prx == prx ? self : [[ICEObjectPrx alloc] initWithCppObjectPrx:prx];
-    }
-    catch (...)
-    {
-        *error = convertException(std::current_exception());
-        return nil;
-    }
-}
-
 - (instancetype)ice_fixed:(ICEConnection*)connection error:(NSError**)error
 {
     try

--- a/swift/test/Ice/proxy/AllTests.swift
+++ b/swift/test/Ice/proxy/AllTests.swift
@@ -546,9 +546,7 @@ public func allTests(_ helper: TestHelper) throws -> MyClassPrx {
   try test(baseProxy.ice_preferSecure(true).ice_isPreferSecure())
   try test(!baseProxy.ice_preferSecure(false).ice_isPreferSecure())
 
-  try test(baseProxy.ice_timeout(-1).ice_getTimeout() == -1)
   try test(baseProxy.ice_invocationTimeout(-1).ice_getInvocationTimeout() == -1)
-  try test(baseProxy.ice_invocationTimeout(-2).ice_getInvocationTimeout() == -2)
   try test(baseProxy.ice_locatorCacheTimeout(0).ice_getLocatorCacheTimeout() == 0)
   try test(baseProxy.ice_locatorCacheTimeout(-1).ice_getLocatorCacheTimeout() == -1)
 
@@ -594,13 +592,6 @@ public func allTests(_ helper: TestHelper) throws -> MyClassPrx {
   try test(compObj!.ice_getCompress() == nil)
   try test(compObj!.ice_compress(true).ice_getCompress() == true)
   try test(compObj!.ice_compress(false).ice_getCompress() == false)
-
-  try test(compObj!.ice_timeout(20) == compObj!.ice_timeout(20))
-  try test(compObj!.ice_timeout(10) != compObj!.ice_timeout(20))
-
-  try test(compObj!.ice_getTimeout() == nil)
-  try test(compObj!.ice_timeout(10).ice_getTimeout() == 10)
-  try test(compObj!.ice_timeout(20).ice_getTimeout() == 20)
 
   let loc1 = try uncheckedCast(
     prx: communicator.stringToProxy("loc1:default -p 10000")!,
@@ -708,7 +699,6 @@ public func allTests(_ helper: TestHelper) throws -> MyClassPrx {
       try test(cl.ice_invocationTimeout(10).ice_fixed(connection!).ice_getInvocationTimeout() == 10)
       try test(cl.ice_fixed(connection!).ice_getConnection() === connection)
       try test(cl.ice_fixed(connection!).ice_fixed(connection!).ice_getConnection() === connection)
-      try test(cl.ice_fixed(connection!).ice_getTimeout() == nil)
       try test(cl.ice_compress(true).ice_fixed(connection!).ice_getCompress()!)
       let fixedConnection = try cl.ice_connectionId("ice_fixed").ice_getConnection()
       try test(

--- a/swift/test/Ice/retry/AllTests.swift
+++ b/swift/test/Ice/retry/AllTests.swift
@@ -97,16 +97,6 @@ public func allTests(helper: TestHelper, communicator2: Ice.Communicator, ref: S
     _ = try retry2.opIdempotent(-1)  // Reset the counter
   }
 
-  if try retry1.ice_getConnection() != nil {
-    // The timeout might occur on connection establishment or because of the sleep. What's
-    // important here is to make sure there are 4 retries and that no calls succeed to
-    // ensure retries with the old connection timeout semantics work.
-    let retryWithTimeout = retry1.ice_invocationTimeout(-2).ice_timeout(200)
-    do {
-      try retryWithTimeout.sleep(1000)
-      try test(false)
-    } catch is Ice.TimeoutException {}
-  }
   output.writeLine("ok")
   return retry1
 }

--- a/swift/test/Ice/timeout/AllTests.swift
+++ b/swift/test/Ice/timeout/AllTests.swift
@@ -50,7 +50,7 @@ public func allTestsWithController(helper: TestHelper, controller: ControllerPrx
     //
     // Expect ConnectTimeoutException.
     //
-    let to = timeout.ice_timeout(100)
+    let to = timeout.ice_connectionId("con1")
     try controller.holdAdapter(-1)
     do {
       try to.op()
@@ -66,7 +66,7 @@ public func allTestsWithController(helper: TestHelper, controller: ControllerPrx
     //
     // Expect success.
     //
-    let to = timeout.ice_timeout(-1)
+    let to = timeout.ice_connectionId("con2")
     try controller.holdAdapter(100)
     do {
       try to.op()
@@ -123,7 +123,7 @@ public func allTestsWithController(helper: TestHelper, controller: ControllerPrx
 
   output.write("testing close timeout... ")
   do {
-    let to = timeout.ice_timeout(250)
+    let to = timeout
     let connection = try connect(to)
     try controller.holdAdapter(-1)
     try connection.close(.GracefullyWithWait)
@@ -169,13 +169,6 @@ public func allTestsWithController(helper: TestHelper, controller: ControllerPrx
       try proxy.sleepAsync(500).wait()
       try test(false)
     } catch is Ice.InvocationTimeoutException {}
-
-    do {
-      try proxy.ice_invocationTimeout(-2).ice_ping()
-      try proxy.ice_invocationTimeout(-2).ice_pingAsync().wait()
-    } catch is Ice.Exception {
-      try test(false)
-    }
 
     let batchTimeout = proxy.ice_batchOneway()
     try batchTimeout.ice_ping()


### PR DESCRIPTION
This PR removes:
 - Connection::timeout in C++ and derived languages (Python, Ruby etc.)
 - Proxy ice_timeout and ice_getTimeout in derived languages (but not C++)

It also updates the logic in OutgoingConnectionFactory to always use / compare endpoints with "-1" for their timeout. As a result, two endpoints that differ only with their timeout values will share the same outgoing connection.

For a follow-up PR:
 - remove remaining ice_timeout usage in IceGrid code
 - remove ice_timeout and associated Reference code in C++
