### PR TITLE
Rename js Makefile dist target to srcs

### DIFF
--- a/js/Makefile
+++ b/js/Makefile
@@ -9,7 +9,7 @@ endif
 all: npminstall
 	$(NPM) run build
 
-dist: npminstall
+srcs: npminstall
 	$(NPM) run dist
 
 install:


### PR DESCRIPTION
A minor fix for JavaScript build, we use `srcs` as the target name for building the sources everywhere except in this Makefile.

After this fix you can use `make srcs` in the top-level to build all srcs targets.