### PR TITLE
Remove ice_timeout and related code from C++

### DIFF
--- a/cpp/include/Glacier2/SessionHelper.h
+++ b/cpp/include/Glacier2/SessionHelper.h
@@ -201,18 +201,6 @@ namespace Glacier2
         std::string getProtocol() const;
 
         /**
-         * Sets the timeout in milliseconds for the connection to the Glacier2 router.
-         * @param timeout The timeout in milliseconds.
-         */
-        void setTimeout(int timeout);
-
-        /**
-         * Obtains the timeout in milliseconds for the connection to the Glacier2 router.
-         * @return The timeout in milliseconds.
-         */
-        int getTimeout() const;
-
-        /**
          * Sets the port on which the Glacier2 router is listening.
          * @param port The router port.
          */
@@ -275,7 +263,6 @@ namespace Glacier2
         Ice::Identity _identity;
         std::string _protocol;
         int _port;
-        int _timeout;
         Ice::InitializationData _initData;
         SessionCallbackPtr _callback;
         std::map<std::string, std::string> _context;

--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -218,14 +218,6 @@ namespace Ice
         Prx ice_secure(bool b) const { return fromReference(asPrx()._secure(b)); }
 
         /**
-         * Obtains a proxy that is identical to this proxy, except for its connection timeout setting
-         * which overrides the timeout setting from the proxy endpoints.
-         * @param timeout The connection timeout override for the proxy (in milliseconds).
-         * @return A proxy with the specified timeout override.
-         */
-        Prx ice_timeout(int timeout) const { return fromReference(asPrx()._timeout(timeout)); }
-
-        /**
          * Obtains a proxy that is identical to this proxy, but uses twoway invocations.
          * @return A proxy that uses twoway invocations.
          */
@@ -712,13 +704,6 @@ namespace Ice
          * if compression is enabled, false otherwise.
          */
         std::optional<bool> ice_getCompress() const;
-
-        /**
-         * Obtains the timeout override of this proxy.
-         * @return The timeout override. If nullopt is returned, no override is set. Otherwise, returns
-         * the timeout override value.
-         */
-        std::optional<int> ice_getTimeout() const;
 
         /**
          * Obtains the connection ID of this proxy.

--- a/cpp/src/Glacier2Lib/SessionHelper.cpp
+++ b/cpp/src/Glacier2Lib/SessionHelper.cpp
@@ -566,7 +566,6 @@ Glacier2::SessionFactoryHelper::SessionFactoryHelper(const SessionCallbackPtr& c
     : _routerHost("localhost"),
       _protocol("ssl"),
       _port(0),
-      _timeout(10000),
       _callback(callback),
       _useCallbacks(true)
 {
@@ -580,7 +579,6 @@ Glacier2::SessionFactoryHelper::SessionFactoryHelper(
     : _routerHost("localhost"),
       _protocol("ssl"),
       _port(0),
-      _timeout(10000),
       _initData(initData),
       _callback(callback),
       _useCallbacks(true)
@@ -598,7 +596,6 @@ Glacier2::SessionFactoryHelper::SessionFactoryHelper(
     : _routerHost("localhost"),
       _protocol("ssl"),
       _port(0),
-      _timeout(10000),
       _callback(callback),
       _useCallbacks(true)
 {
@@ -723,20 +720,6 @@ Glacier2::SessionFactoryHelper::getProtocol() const
 }
 
 void
-Glacier2::SessionFactoryHelper::setTimeout(int timeout)
-{
-    lock_guard lock(_mutex);
-    _timeout = timeout;
-}
-
-int
-Glacier2::SessionFactoryHelper::getTimeout() const
-{
-    lock_guard lock(_mutex);
-    return _timeout;
-}
-
-void
 Glacier2::SessionFactoryHelper::setPort(int port)
 {
     lock_guard lock(_mutex);
@@ -856,11 +839,6 @@ Glacier2::SessionFactoryHelper::createProxyStr(const Ice::Identity& ident)
     ostringstream os;
     os << "\"" << identityToString(ident, Ice::ToStringMode::Unicode) << "\":" << _protocol << " -p "
        << getPortInternal() << " -h \"" << _routerHost << "\"";
-
-    if (_timeout > 0)
-    {
-        os << " -t " << _timeout;
-    }
     return os.str();
 }
 

--- a/cpp/src/Ice/Proxy.cpp
+++ b/cpp/src/Ice/Proxy.cpp
@@ -230,12 +230,6 @@ Ice::ObjectPrx::ice_getCompress() const
     return _reference->getCompress();
 }
 
-optional<int>
-Ice::ObjectPrx::ice_getTimeout() const
-{
-    return _reference->getTimeout();
-}
-
 string
 Ice::ObjectPrx::ice_getConnectionId() const
 {
@@ -580,26 +574,6 @@ Ice::ObjectPrx::_secure(bool b) const
     else
     {
         return _reference->changeSecure(b);
-    }
-}
-
-ReferencePtr
-Ice::ObjectPrx::_timeout(int t) const
-{
-    if (t < 1 && t != -1)
-    {
-        ostringstream s;
-        s << "invalid value passed to ice_timeout: " << t;
-        throw invalid_argument(s.str());
-    }
-    ReferencePtr ref = _reference->changeTimeout(t);
-    if (targetEqualTo(ref, _reference))
-    {
-        return _reference;
-    }
-    else
-    {
-        return ref;
     }
 }
 

--- a/cpp/src/Ice/Reference.h
+++ b/cpp/src/Ice/Reference.h
@@ -73,7 +73,6 @@ namespace IceInternal
         virtual Ice::EndpointSelectionType getEndpointSelection() const = 0;
         virtual int getLocatorCacheTimeout() const = 0;
         virtual std::string getConnectionId() const = 0;
-        virtual std::optional<int> getTimeout() const = 0;
 
         //
         // The change* methods (here and in derived classes) create
@@ -99,7 +98,6 @@ namespace IceInternal
         virtual ReferencePtr changePreferSecure(bool) const = 0;
         virtual ReferencePtr changeEndpointSelection(Ice::EndpointSelectionType) const = 0;
 
-        virtual ReferencePtr changeTimeout(int) const = 0;
         virtual ReferencePtr changeConnectionId(std::string) const = 0;
         virtual ReferencePtr changeConnection(Ice::ConnectionIPtr) const = 0;
 
@@ -201,7 +199,6 @@ namespace IceInternal
         Ice::EndpointSelectionType getEndpointSelection() const final;
         int getLocatorCacheTimeout() const final;
         std::string getConnectionId() const final;
-        std::optional<int> getTimeout() const final;
 
         ReferencePtr changeEndpoints(std::vector<EndpointIPtr>) const final;
         ReferencePtr changeAdapterId(std::string) const final;
@@ -213,7 +210,6 @@ namespace IceInternal
         ReferencePtr changeEndpointSelection(Ice::EndpointSelectionType) const final;
         ReferencePtr changeLocatorCacheTimeout(int) const final;
 
-        ReferencePtr changeTimeout(int) const final;
         ReferencePtr changeConnectionId(std::string) const final;
         ReferencePtr changeConnection(Ice::ConnectionIPtr) const final;
 
@@ -273,7 +269,6 @@ namespace IceInternal
         Ice::EndpointSelectionType getEndpointSelection() const final;
         int getLocatorCacheTimeout() const final;
         std::string getConnectionId() const final;
-        std::optional<int> getTimeout() const final;
 
         ReferencePtr changeEncoding(Ice::EncodingVersion) const final;
         ReferencePtr changeCompress(bool) const final;
@@ -288,7 +283,6 @@ namespace IceInternal
         ReferencePtr changeEndpointSelection(Ice::EndpointSelectionType) const final;
         ReferencePtr changeLocatorCacheTimeout(int) const final;
 
-        ReferencePtr changeTimeout(int) const final;
         ReferencePtr changeConnectionId(std::string) const final;
         ReferencePtr changeConnection(Ice::ConnectionIPtr) const final;
 
@@ -344,8 +338,6 @@ namespace IceInternal
         Ice::EndpointSelectionType _endpointSelection;
         int _locatorCacheTimeout;
 
-        bool _overrideTimeout;
-        int _timeout; // Only used if _overrideTimeout == true
         std::string _connectionId;
     };
 

--- a/cpp/src/IceGrid/AdminSessionI.cpp
+++ b/cpp/src/IceGrid/AdminSessionI.cpp
@@ -81,10 +81,8 @@ FileIteratorI::destroy(const Ice::Current& current)
 AdminSessionI::AdminSessionI(
     const string& id,
     const shared_ptr<Database>& db,
-    chrono::seconds timeout,
     const shared_ptr<RegistryI>& registry)
     : BaseSessionI(id, "admin", db),
-      _timeout(timeout),
       _replicaName(registry->getName()),
       _registry(registry)
 {
@@ -152,14 +150,12 @@ AdminSessionI::setObservers(
         throw Ice::ObjectNotExistException(__FILE__, __LINE__, current.id, "", "");
     }
 
-    const auto timeout = secondsToInt(_timeout);
-    assert(timeout != 0);
     const auto locator = _registry->getLocator();
     if (registryObserver)
     {
         setupObserverSubscription(
             TopicName::RegistryObserver,
-            addForwarder(registryObserver->ice_timeout(timeout)->ice_locator(locator)));
+            addForwarder(registryObserver->ice_locator(locator)));
     }
     else
     {
@@ -170,7 +166,7 @@ AdminSessionI::setObservers(
     {
         setupObserverSubscription(
             TopicName::NodeObserver,
-            addForwarder(nodeObserver->ice_timeout(timeout)->ice_locator(locator)));
+            addForwarder(nodeObserver->ice_locator(locator)));
     }
     else
     {
@@ -181,7 +177,7 @@ AdminSessionI::setObservers(
     {
         setupObserverSubscription(
             TopicName::ApplicationObserver,
-            addForwarder(appObserver->ice_timeout(timeout)->ice_locator(locator)));
+            addForwarder(appObserver->ice_locator(locator)));
     }
     else
     {
@@ -192,7 +188,7 @@ AdminSessionI::setObservers(
     {
         setupObserverSubscription(
             TopicName::AdapterObserver,
-            addForwarder(adapterObserver->ice_timeout(timeout)->ice_locator(locator)));
+            addForwarder(adapterObserver->ice_locator(locator)));
     }
     else
     {
@@ -203,7 +199,7 @@ AdminSessionI::setObservers(
     {
         setupObserverSubscription(
             TopicName::ObjectObserver,
-            addForwarder(objectObserver->ice_timeout(timeout)->ice_locator(locator)));
+            addForwarder(objectObserver->ice_locator(locator)));
     }
     else
     {
@@ -514,7 +510,7 @@ AdminSessionFactory::createGlacier2Session(const string& sessionId, const option
 shared_ptr<AdminSessionI>
 AdminSessionFactory::createSessionServant(const string& id)
 {
-    return make_shared<AdminSessionI>(id, _database, _timeout, _registry);
+    return make_shared<AdminSessionI>(id, _database, _registry);
 }
 
 const shared_ptr<TraceLevels>&

--- a/cpp/src/IceGrid/AdminSessionI.h
+++ b/cpp/src/IceGrid/AdminSessionI.h
@@ -21,7 +21,6 @@ namespace IceGrid
         AdminSessionI(
             const std::string&,
             const std::shared_ptr<Database>&,
-            std::chrono::seconds,
             const std::shared_ptr<RegistryI>&);
 
         Ice::ObjectPrx _register(const std::shared_ptr<SessionServantManager>&, const Ice::ConnectionPtr&);
@@ -75,7 +74,6 @@ namespace IceGrid
 
         void destroyImpl(bool) override;
 
-        const std::chrono::seconds _timeout;
         const std::string _replicaName;
         std::optional<AdminPrx> _admin;
         std::map<TopicName, std::pair<Ice::ObjectPrx, bool>> _observers;

--- a/cpp/src/IceGrid/SessionManager.h
+++ b/cpp/src/IceGrid/SessionManager.h
@@ -126,7 +126,7 @@ namespace IceGrid
                         assert(timeout != 0s);
                         using namespace std::chrono;
 
-                        registry = _registry->ice_timeout(secondsToInt(timeout));
+                        registry = _registry;
                         _nextAction = None;
                         _state = InProgress;
                         _condVar.notify_all();

--- a/cpp/test/Ice/proxy/AllTests.cpp
+++ b/cpp/test/Ice/proxy/AllTests.cpp
@@ -927,7 +927,6 @@ allTests(TestHelper* helper)
                 test(cl->ice_fixed(connection)->ice_getConnection() == connection);
                 test(cl->ice_fixed(connection)->ice_fixed(connection)->ice_getConnection() == connection);
                 test(*cl->ice_compress(true)->ice_fixed(connection)->ice_getCompress());
-                test(!cl->ice_fixed(connection)->ice_getTimeout());
                 Ice::ConnectionPtr fixedConnection = cl->ice_connectionId("ice_fixed")->ice_getConnection();
                 test(cl->ice_fixed(connection)->ice_fixed(fixedConnection)->ice_getConnection() == fixedConnection);
                 try


### PR DESCRIPTION
This PR completes the removal of ice_timeout from C++.