### PR TITLE
Remove ice_timeout in C#

### DIFF
--- a/cpp/test/Ice/metrics/AllTests.cpp
+++ b/cpp/test/Ice/metrics/AllTests.cpp
@@ -783,9 +783,7 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         string expected = protocol + " -h localhost -p " + port + " -t 500";
 
         testAttribute(clientMetrics, clientProps, update.get(), "EndpointLookup", "id", expected, c);
-
         testAttribute(clientMetrics, clientProps, update.get(), "EndpointLookup", "endpoint", expected, c);
-
         testAttribute(clientMetrics, clientProps, update.get(), "EndpointLookup", "endpointType", type, c);
         testAttribute(clientMetrics, clientProps, update.get(), "EndpointLookup", "endpointIsDatagram", "false", c);
         testAttribute(clientMetrics, clientProps, update.get(), "EndpointLookup", "endpointIsSecure", isSecure, c);

--- a/csharp/src/Glacier2/SessionFactoryHelper.cs
+++ b/csharp/src/Glacier2/SessionFactoryHelper.cs
@@ -177,34 +177,6 @@ public class SessionFactoryHelper
     }
 
     /// <summary>
-    /// Sets the connect and connection timeout for the Glacier2 router.
-    /// </summary>
-    /// <param name="timeoutMillisecs">The timeout in milliseconds. A zero
-    /// or negative timeout value indicates that the router proxy has no
-    /// associated timeout.</param>
-    public void
-    setTimeout(int timeoutMillisecs)
-    {
-        lock (this)
-        {
-            _timeout = timeoutMillisecs;
-        }
-    }
-
-    /// <summary>
-    /// Returns the connect and connection timeout associated with the Glacier2 router.
-    /// </summary>
-    /// <returns>The timeout.</returns>
-    public int
-    getTimeout()
-    {
-        lock (this)
-        {
-            return _timeout;
-        }
-    }
-
-    /// <summary>
     /// Sets the Glacier2 router port to connect to.
     /// </summary>
     /// <param name="port">The port. If 0, then the default port (4063 for TCP or

--- a/csharp/src/Glacier2/SessionFactoryHelper.cs
+++ b/csharp/src/Glacier2/SessionFactoryHelper.cs
@@ -340,11 +340,6 @@ public class SessionFactoryHelper
         sb.Append(" -h \"");
         sb.Append(_routerHost);
         sb.Append('"');
-        if (_timeout > 0)
-        {
-            sb.Append(" -t ");
-            sb.Append(_timeout);
-        }
         return sb.ToString();
     }
 
@@ -360,7 +355,6 @@ public class SessionFactoryHelper
     private Ice.Identity _identity;
     private string _protocol = "ssl";
     private int _port;
-    private int _timeout = 10000;
     private Dictionary<string, string> _context;
     private bool _useCallbacks = true;
     private static int GLACIER2_SSL_PORT = 4064;

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -172,12 +172,6 @@ namespace Ice
         string type();
 
         /// <summary>
-        /// Get the timeout for the connection.
-        /// </summary>
-        /// <returns>The connection's timeout.</returns>
-        int timeout();
-
-        /// <summary>
         /// Return a description of the connection as human readable text, suitable for logging or error messages.
         /// </summary>
         /// <returns>The description of the connection as human readable text.</returns>

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1377,11 +1377,6 @@ public sealed class ConnectionI : Ice.Internal.EventHandler, CancellationHandler
         return _type; // No mutex lock, _type is immutable.
     }
 
-    public int timeout()
-    {
-        return _endpoint.timeout(); // No mutex protection necessary, _endpoint is immutable.
-    }
-
     public ConnectionInfo getInfo()
     {
         lock (this)

--- a/csharp/src/Ice/Internal/ConnectionFactory.cs
+++ b/csharp/src/Ice/Internal/ConnectionFactory.cs
@@ -267,8 +267,10 @@ public sealed class OutgoingConnectionFactory
             DefaultsAndOverrides defaultsAndOverrides = _instance.defaultsAndOverrides();
             Debug.Assert(endpoints.Count > 0);
 
-            foreach (EndpointI endpoint in endpoints)
+            foreach (EndpointI proxyEndpoint in endpoints)
             {
+                EndpointI endpoint = proxyEndpoint.timeout(-1); // Clear the timeout
+
                 ICollection<Ice.ConnectionI> connectionList = null;
                 if (!_connectionsByEndpoint.TryGetValue(endpoint, out connectionList))
                 {
@@ -277,7 +279,7 @@ public sealed class OutgoingConnectionFactory
 
                 foreach (Ice.ConnectionI connection in connectionList)
                 {
-                    if (connection.isActiveOrHolding()) // Don't return destroyed or unvalidated connections
+                    if (connection.isActiveOrHolding()) // Don't return destroyed or un-validated connections
                     {
                         if (defaultsAndOverrides.overrideCompress)
                         {
@@ -467,7 +469,7 @@ public sealed class OutgoingConnectionFactory
                     _instance,
                     transceiver,
                     ci.connector,
-                    ci.endpoint.compress(false),
+                    ci.endpoint.compress(false).timeout(-1),
                     adapter: null,
                     removeConnection,
                     _connectionOptions);

--- a/csharp/src/Ice/Internal/Reference.cs
+++ b/csharp/src/Ice/Internal/Reference.cs
@@ -97,7 +97,6 @@ public abstract class Reference : IEquatable<Reference>
     public abstract Ice.EndpointSelectionType getEndpointSelection();
     public abstract int getLocatorCacheTimeout();
     public abstract string getConnectionId();
-    public abstract int? getTimeout();
     public abstract ThreadPool getThreadPool();
 
     //
@@ -213,7 +212,6 @@ public abstract class Reference : IEquatable<Reference>
     public abstract Reference changeEndpointSelection(Ice.EndpointSelectionType newType);
     public abstract Reference changeLocatorCacheTimeout(int newTimeout);
 
-    public abstract Reference changeTimeout(int newTimeout);
     public abstract Reference changeConnectionId(string connectionId);
     public abstract Reference changeConnection(Ice.ConnectionI connection);
 
@@ -562,11 +560,6 @@ public class FixedReference : Reference
         return "";
     }
 
-    public override int? getTimeout()
-    {
-        return null;
-    }
-
     public override ThreadPool getThreadPool()
     {
         return _fixedConnection.getThreadPool();
@@ -613,11 +606,6 @@ public class FixedReference : Reference
     }
 
     public override Reference changeLocatorCacheTimeout(int newTimeout)
-    {
-        throw new Ice.FixedProxyException();
-    }
-
-    public override Reference changeTimeout(int newTimeout)
     {
         throw new Ice.FixedProxyException();
     }
@@ -789,11 +777,6 @@ public class RoutableReference : Reference
         return _connectionId;
     }
 
-    public override int? getTimeout()
-    {
-        return _overrideTimeout ? _timeout : null;
-    }
-
     public override Reference changeMode(Mode newMode)
     {
         Reference r = base.changeMode(newMode);
@@ -937,28 +920,6 @@ public class RoutableReference : Reference
         }
         RoutableReference r = (RoutableReference)getInstance().referenceFactory().copy(this);
         r._locatorCacheTimeout = newTimeout;
-        return r;
-    }
-
-    public override Reference changeTimeout(int newTimeout)
-    {
-        if (_overrideTimeout && _timeout == newTimeout)
-        {
-            return this;
-        }
-
-        RoutableReference r = (RoutableReference)getInstance().referenceFactory().copy(this);
-        r._timeout = newTimeout;
-        r._overrideTimeout = true;
-        if (_endpoints.Length > 0)
-        {
-            EndpointI[] newEndpoints = new EndpointI[_endpoints.Length];
-            for (int i = 0; i < _endpoints.Length; i++)
-            {
-                newEndpoints[i] = _endpoints[i].timeout(newTimeout);
-            }
-            r._endpoints = newEndpoints;
-        }
         return r;
     }
 
@@ -1141,8 +1102,6 @@ public class RoutableReference : Reference
             _preferSecure == rhs._preferSecure &&
             _endpointSelection == rhs._endpointSelection &&
             _locatorCacheTimeout == rhs._locatorCacheTimeout &&
-            _overrideTimeout == rhs._overrideTimeout &&
-            (!_overrideTimeout || _timeout == rhs._timeout) &&
             _connectionId == rhs._connectionId &&
             _adapterId == rhs._adapterId &&
             _endpoints.SequenceEqual(rhs._endpoints);
@@ -1343,8 +1302,6 @@ public class RoutableReference : Reference
         _preferSecure = preferSecure;
         _endpointSelection = endpointSelection;
         _locatorCacheTimeout = locatorCacheTimeout;
-        _overrideTimeout = false;
-        _timeout = -1;
 
         if (_endpoints == null)
         {
@@ -1368,10 +1325,6 @@ public class RoutableReference : Reference
             if (overrideCompress_)
             {
                 endpts[i] = endpts[i].compress(compress_);
-            }
-            if (_overrideTimeout)
-            {
-                endpts[i] = endpts[i].timeout(_timeout);
             }
         }
     }
@@ -1653,7 +1606,5 @@ public class RoutableReference : Reference
     private Ice.EndpointSelectionType _endpointSelection;
     private int _locatorCacheTimeout;
 
-    private bool _overrideTimeout;
-    private int _timeout; // Only used if _overrideTimeout == true
     private string _connectionId = "";
 }

--- a/csharp/src/Ice/Internal/RouterInfo.cs
+++ b/csharp/src/Ice/Internal/RouterInfo.cs
@@ -175,32 +175,12 @@ public sealed class RouterInfo : IEquatable<RouterInfo>
     {
         lock (this)
         {
-            if (_clientEndpoints == null)
+            if (_clientEndpoints is null)
             {
                 _hasRoutingTable = hasRoutingTable;
-                if (clientProxy == null)
-                {
-                    //
-                    // If getClientProxy() return nil, use router endpoints.
-                    //
-                    _clientEndpoints = ((Ice.ObjectPrxHelperBase)_router).iceReference().getEndpoints();
-                }
-                else
-                {
-                    clientProxy = clientProxy.ice_router(null); // The client proxy cannot be routed.
-
-                    //
-                    // In order to avoid creating a new connection to the
-                    // router, we must use the same timeout as the already
-                    // existing connection.
-                    //
-                    if (_router.ice_getConnection() != null)
-                    {
-                        clientProxy = clientProxy.ice_timeout(_router.ice_getConnection().timeout());
-                    }
-
-                    _clientEndpoints = ((Ice.ObjectPrxHelperBase)clientProxy).iceReference().getEndpoints();
-                }
+                _clientEndpoints = clientProxy is null ?
+                    ((ObjectPrxHelperBase)_router).iceReference().getEndpoints() :
+                    ((ObjectPrxHelperBase)clientProxy).iceReference().getEndpoints();
             }
             return _clientEndpoints;
         }

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -406,20 +406,6 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     bool? ice_getCompress();
 
     /// <summary>
-    /// Creates a new proxy that is identical to this proxy, except for its timeout setting.
-    /// </summary>
-    /// <param name="t">The timeout for the new proxy in milliseconds.</param>
-    /// <returns>A new proxy with the specified timeout.</returns>
-    ObjectPrx ice_timeout(int t);
-
-    /// <summary>
-    /// Obtains the timeout override of this proxy.
-    /// </summary>
-    /// <returns>The timeout override. If no optional value is present, no override is set. Otherwise,
-    /// returns the timeout override value.</returns>
-    int? ice_getTimeout();
-
-    /// <summary>
     /// Creates a new proxy that is identical to this proxy, except for its connection ID.
     /// </summary>
     /// <param name="connectionId">The connection ID for the new proxy. An empty string removes the
@@ -1413,38 +1399,6 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     public bool? ice_getCompress()
     {
         return _reference.getCompress();
-    }
-
-    /// <summary>
-    /// Creates a new proxy that is identical to this proxy, except for its timeout setting.
-    /// </summary>
-    /// <param name="t">The timeout for the new proxy in milliseconds.</param>
-    /// <returns>A new proxy with the specified timeout.</returns>
-    public ObjectPrx ice_timeout(int t)
-    {
-        if (t < 1 && t != -1)
-        {
-            throw new ArgumentException("invalid value passed to ice_timeout: " + t);
-        }
-        var @ref = _reference.changeTimeout(t);
-        if (@ref == _reference)
-        {
-            return this;
-        }
-        else
-        {
-            return iceNewInstance(@ref);
-        }
-    }
-
-    /// <summary>
-    /// Obtains the timeout override of this proxy.
-    /// </summary>
-    /// <returns>The timeout override. If no optional value is present, no override is set. Otherwise,
-    /// returns the timeout override value.</returns>
-    public int? ice_getTimeout()
-    {
-        return _reference.getTimeout();
     }
 
     /// <summary>

--- a/csharp/test/Ice/adapterDeactivation/AllTests.cs
+++ b/csharp/test/Ice/adapterDeactivation/AllTests.cs
@@ -187,7 +187,7 @@ namespace Ice
                 output.Flush();
                 try
                 {
-                    obj.ice_timeout(100).ice_ping(); // Use timeout to speed up testing on Windows
+                    obj.ice_invocationTimeout(100).ice_ping(); // Use timeout to speed up testing on Windows
                     test(false);
                 }
                 catch (Ice.LocalException)

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -705,18 +705,18 @@ public class AllTests : Test.AllTests
             // TODO: this appears necessary on slow macos VMs to give time to the server to clean-up the connection.
             Thread.Sleep(100);
 
-            MetricsPrx m = (MetricsPrx)metrics.ice_timeout(500).ice_connectionId("Con1");
+            MetricsPrx m = (MetricsPrx)metrics.ice_connectionId("Con1");
             m.ice_ping();
 
             testAttribute(clientMetrics, clientProps, update, "Connection", "parent", "Communicator", output);
             //testAttribute(clientMetrics, clientProps, update, "Connection", "id", "");
             testAttribute(clientMetrics, clientProps, update, "Connection", "endpoint",
-                          endpoint + " -t 500", output);
+                          endpoint + " -t infinite", output);
 
             testAttribute(clientMetrics, clientProps, update, "Connection", "endpointType", type, output);
             testAttribute(clientMetrics, clientProps, update, "Connection", "endpointIsDatagram", "False", output);
             testAttribute(clientMetrics, clientProps, update, "Connection", "endpointIsSecure", isSecure, output);
-            testAttribute(clientMetrics, clientProps, update, "Connection", "endpointTimeout", "500", output);
+            testAttribute(clientMetrics, clientProps, update, "Connection", "endpointTimeout", "-1", output);
             testAttribute(clientMetrics, clientProps, update, "Connection", "endpointCompress", "False", output);
             testAttribute(clientMetrics, clientProps, update, "Connection", "endpointHost", host, output);
             testAttribute(clientMetrics, clientProps, update, "Connection", "endpointPort", port, output);
@@ -755,7 +755,7 @@ public class AllTests : Test.AllTests
             controller.hold();
             try
             {
-                communicator.stringToProxy("test:tcp -h 127.0.0.1 -p " + port).ice_timeout(10).ice_ping();
+                communicator.stringToProxy("test:tcp -h 127.0.0.1 -p " + port).ice_connectionId("con2").ice_ping();
                 test(false);
             }
             catch (Ice.ConnectTimeoutException)
@@ -842,12 +842,11 @@ public class AllTests : Test.AllTests
 
             c = () => { connect(prx); };
 
-            testAttribute(clientMetrics, clientProps, update, "EndpointLookup", "parent", "Communicator", c, output);
-            testAttribute(clientMetrics, clientProps, update, "EndpointLookup", "id",
-                          prx.ice_getConnection().getEndpoint().ToString(), c, output);
-            testAttribute(clientMetrics, clientProps, update, "EndpointLookup", "endpoint",
-                          prx.ice_getConnection().getEndpoint().ToString(), c, output);
+            string expected = $"{protocol} -h localhost -p {port} -t 500";
 
+            testAttribute(clientMetrics, clientProps, update, "EndpointLookup", "parent", "Communicator", c, output);
+            testAttribute(clientMetrics, clientProps, update, "EndpointLookup", "id", expected, c, output);
+            testAttribute(clientMetrics, clientProps, update, "EndpointLookup", "endpoint", expected, c, output);
             testAttribute(clientMetrics, clientProps, update, "EndpointLookup", "endpointType", type, c, output);
             testAttribute(clientMetrics, clientProps, update, "EndpointLookup", "endpointIsDatagram", "False", c, output);
             testAttribute(clientMetrics, clientProps, update, "EndpointLookup", "endpointIsSecure", isSecure, c, output);

--- a/csharp/test/Ice/operations/Client.cs
+++ b/csharp/test/Ice/operations/Client.cs
@@ -24,7 +24,7 @@ namespace Ice
                     myClass.shutdown();
                     try
                     {
-                        myClass.ice_timeout(100).ice_ping(); // Use timeout to speed up testing on Windows
+                        myClass.ice_invocationTimeout(100).ice_ping(); // Use timeout to speed up testing on Windows
                         test(false);
                     }
                     catch (Ice.LocalException)

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -584,33 +584,6 @@ namespace Ice
 
                 try
                 {
-                    baseProxy.ice_timeout(0);
-                    test(false);
-                }
-                catch (ArgumentException)
-                {
-                }
-
-                try
-                {
-                    baseProxy.ice_timeout(-1);
-                }
-                catch (ArgumentException)
-                {
-                    test(false);
-                }
-
-                try
-                {
-                    baseProxy.ice_timeout(-2);
-                    test(false);
-                }
-                catch (ArgumentException)
-                {
-                }
-
-                try
-                {
                     baseProxy.ice_invocationTimeout(0);
                     test(false);
                 }
@@ -704,13 +677,6 @@ namespace Ice
                 test(!compObj.ice_getCompress().HasValue);
                 test(compObj.ice_compress(true).ice_getCompress().Value == true);
                 test(compObj.ice_compress(false).ice_getCompress().Value == false);
-
-                test(compObj.ice_timeout(20).Equals(compObj.ice_timeout(20)));
-                test(!compObj.ice_timeout(10).Equals(compObj.ice_timeout(20)));
-
-                test(!compObj.ice_getTimeout().HasValue);
-                test(compObj.ice_timeout(10).ice_getTimeout().Value == 10);
-                test(compObj.ice_timeout(20).ice_getTimeout().Value == 20);
 
                 Ice.LocatorPrx loc1 = Ice.LocatorPrxHelper.uncheckedCast(communicator.stringToProxy("loc1:default -p 10000"));
                 Ice.LocatorPrx loc2 = Ice.LocatorPrxHelper.uncheckedCast(communicator.stringToProxy("loc2:default -p 10000"));
@@ -822,7 +788,6 @@ namespace Ice
                         test(cl.ice_invocationTimeout(10).ice_fixed(connection).ice_getInvocationTimeout() == 10);
                         test(cl.ice_fixed(connection).ice_getConnection() == connection);
                         test(cl.ice_fixed(connection).ice_fixed(connection).ice_getConnection() == connection);
-                        test(!cl.ice_fixed(connection).ice_getTimeout().HasValue);
                         test(cl.ice_compress(true).ice_fixed(connection).ice_getCompress().Value);
                         Ice.Connection fixedConnection = cl.ice_connectionId("ice_fixed").ice_getConnection();
                         test(cl.ice_fixed(connection).ice_fixed(fixedConnection).ice_getConnection() == fixedConnection);


### PR DESCRIPTION
This PR removes Proxy ice_timeout, Connection's timeout and related code in C#.