### PR TITLE
Fix java package version

### DIFF
--- a/java/gradle.properties
+++ b/java/gradle.properties
@@ -5,7 +5,7 @@
 //
 // Version used in JAR files
 //
-iceVersion = 3.8.0-alpha0
+iceVersion = 3.8.0-alpha.0
 
 //
 // Select an installation base directory. The directory will be created


### PR DESCRIPTION
`slice2java` uses `3.8.0-alpha.0` which is also what the gradle plugin uses to find the Ice for Java. Our Java packages are using `3.8.0-alpha0`. I've updated the Java package to be in sync with `slice2java`