### PR TITLE
Ran clang-format ci on Ubuntu

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -10,18 +10,10 @@ on:
 
 jobs:
   clang-format:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Install Clang Format
-        run: |
-          # Make sure we're using the latest Homebrew package list.
-          brew update
-          brew install clang-format
-          clang-format --version
-        if: runner.os == 'macOS'
 
       - name: Install Clang Format
         run: |
@@ -36,5 +28,5 @@ jobs:
 
       - name: Run Clang Format
         run: |
-          find . -name "*.h" -o -name "*.c" -o -name "*.cpp" -o -name "*.mm" | xargs clang-format --style=file --fallback-style=none --Werror --dry-run
-          find cpp -name "*.m" | xargs clang-format --style=file --fallback-style=none --Werror --dry-run
+          find . -name "*.h" -o -name "*.c" -o -name "*.cpp" -o -name "*.mm" | xargs clang-format-18 --style=file --fallback-style=none --Werror --dry-run
+          find cpp -name "*.m" | xargs clang-format-18 --style=file --fallback-style=none --Werror --dry-run


### PR DESCRIPTION
Back to running on Ubuntu, things seemed to have stabilized now and the Ubuntu runners are more available than macOS. 