### PR TITLE
Make sure OutgoingMessage's output stream owns its memory

### DIFF
--- a/cpp/include/Ice/Buffer.h
+++ b/cpp/include/Ice/Buffer.h
@@ -82,6 +82,8 @@ namespace IceInternal
 
             bool empty() const { return !_size; }
 
+            bool ownsMemory() const noexcept { return _owned; }
+
             void swap(Container&);
 
             void clear();

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -259,7 +259,7 @@ Ice::ConnectionI::OutgoingMessage::adopt(OutputStream* str)
         if (str)
         {
             delete stream;
-            stream = 0;
+            stream = nullptr;
             adopted = false;
         }
         else
@@ -276,13 +276,13 @@ Ice::ConnectionI::OutgoingMessage::adopt(OutputStream* str)
         else
         {
             str = stream; // Adopt this stream
-            stream = 0;
+            stream = nullptr;
         }
     }
 
     assert(str);
-    stream = new OutputStream(str->instance(), currentProtocolEncoding);
-    stream->swap(*str);
+    assert(str->b.ownsMemory());
+    stream = new OutputStream(std::move(*str));
     adopted = true;
 }
 
@@ -290,10 +290,10 @@ void
 Ice::ConnectionI::OutgoingMessage::canceled(bool adoptStream)
 {
     assert(outAsync); // Only requests can timeout.
-    outAsync = 0;
+    outAsync = nullptr;
     if (adoptStream)
     {
-        adopt(0); // Adopt the request stream
+        adopt(nullptr); // Adopt the request stream
     }
     else
     {

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -89,6 +89,10 @@ namespace Ice
                   receivedReply(false)
 #endif
             {
+                assert(stream);
+                // The outgoing message can be sent asynchronously. If the stream doesn't own its memory, the memory
+                // owner could release it before the message is sent.
+                assert(stream->b.ownsMemory());
             }
 
             OutgoingMessage(const IceInternal::OutgoingAsyncBasePtr& o, Ice::OutputStream* str, bool comp, int rid)
@@ -104,6 +108,8 @@ namespace Ice
                   receivedReply(false)
 #endif
             {
+                assert(stream);
+                assert(stream->b.ownsMemory());
             }
 
             void adopt(Ice::OutputStream*);


### PR DESCRIPTION
This PR updates Ice C++ to make sure the OutputStream held by an OutgoingMessage (see ConnectionI.h) owns its memory.

It's possible to create an OutputStream that doesn't own its memory with:
https://github.com/zeroc-ice/ice/blob/e72309cdc7d1f4da178aa6b08d62b7ef0b183820/cpp/include/Ice/OutputStream.h#L65

It would be dangerous to construct an OutgoingResponse (or other outgoing message) with such an OutputStream as it may be sent later on, asynchronously, without copying of the memory.