### PR TITLE
Cleanup Class Logic in the Slice Compiler

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -381,6 +381,18 @@ Slice::SyntaxTreeBase::SyntaxTreeBase(const UnitPtr& unit) : _unit(unit)
 
 Slice::Type::Type(const UnitPtr& unit) : SyntaxTreeBase(unit) {}
 
+bool
+Slice::Type::isClassType() const
+{
+    return false;
+}
+
+bool
+Slice::Type::usesClasses() const
+{
+    return isClassType();
+}
+
 // ----------------------------------------------------------------------
 // Builtin
 // ----------------------------------------------------------------------
@@ -399,7 +411,7 @@ Slice::Builtin::typeId() const
 }
 
 bool
-Slice::Builtin::usesClasses() const
+Slice::Builtin::isClassType() const
 {
     return _kind == KindObject || _kind == KindValue;
 }
@@ -2818,7 +2830,7 @@ Slice::ClassDecl::containedType() const
 }
 
 bool
-Slice::ClassDecl::usesClasses() const
+Slice::ClassDecl::isClassType() const
 {
     return true;
 }
@@ -3185,12 +3197,6 @@ Contained::ContainedType
 Slice::InterfaceDecl::containedType() const
 {
     return ContainedTypeInterface;
-}
-
-bool
-Slice::InterfaceDecl::usesClasses() const
-{
-    return false;
 }
 
 size_t
@@ -4399,12 +4405,6 @@ Contained::ContainedType
 Slice::Enum::containedType() const
 {
     return ContainedTypeEnum;
-}
-
-bool
-Slice::Enum::usesClasses() const
-{
-    return false;
 }
 
 size_t

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -94,13 +94,7 @@ namespace
         // Returns true if the type contains data types which can be referenced by user code and mutated after a
         // dispatch returns.
 
-        if (dynamic_pointer_cast<ClassDecl>(type))
-        {
-            return true;
-        }
-
-        BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
-        if (builtin && builtin->usesClasses())
+        if (type->isClassType())
         {
             return true;
         }
@@ -3055,13 +3049,9 @@ Slice::ClassDef::classDataMembers() const
     for (const auto& p : _contents)
     {
         DataMemberPtr q = dynamic_pointer_cast<DataMember>(p);
-        if (q)
+        if (q && q->type()->isClassType())
         {
-            BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(q->type());
-            if ((builtin && builtin->usesClasses()) || dynamic_pointer_cast<ClassDecl>(q->type()))
-            {
-                result.push_back(q);
-            }
+            result.push_back(q);
         }
     }
     return result;
@@ -3805,13 +3795,9 @@ Slice::Exception::classDataMembers() const
     for (const auto& p : _contents)
     {
         DataMemberPtr q = dynamic_pointer_cast<DataMember>(p);
-        if (q)
+        if (q && q->type()->isClassType())
         {
-            BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(q->type());
-            if ((builtin && builtin->usesClasses()) || dynamic_pointer_cast<ClassDecl>(q->type()))
-            {
-                result.push_back(q);
-            }
+            result.push_back(q);
         }
     }
     return result;
@@ -4041,13 +4027,9 @@ Slice::Struct::classDataMembers() const
     for (const auto& p : _contents)
     {
         DataMemberPtr q = dynamic_pointer_cast<DataMember>(p);
-        if (q)
+        if (q && q->type()->isClassType())
         {
-            BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(q->type());
-            if ((builtin && builtin->usesClasses()) || dynamic_pointer_cast<ClassDecl>(q->type()))
-            {
-                result.push_back(q);
-            }
+            result.push_back(q);
         }
     }
     return result;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -316,7 +316,8 @@ namespace Slice
     public:
         Type(const UnitPtr&);
         virtual std::string typeId() const = 0;
-        virtual bool usesClasses() const = 0;
+        virtual bool isClassType() const;
+        virtual bool usesClasses() const;
         virtual size_t minWireSize() const = 0;
         virtual std::string getOptionalFormat() const = 0;
         virtual bool isVariableLength() const = 0;
@@ -347,7 +348,7 @@ namespace Slice
         Builtin(const UnitPtr&, Kind);
 
         virtual std::string typeId() const;
-        virtual bool usesClasses() const;
+        virtual bool isClassType() const;
         virtual size_t minWireSize() const;
         virtual std::string getOptionalFormat() const;
         virtual bool isVariableLength() const;
@@ -556,7 +557,7 @@ namespace Slice
         virtual void destroy();
         ClassDefPtr definition() const;
         virtual ContainedType containedType() const;
-        virtual bool usesClasses() const;
+        virtual bool isClassType() const;
         virtual size_t minWireSize() const;
         virtual std::string getOptionalFormat() const;
         virtual bool isVariableLength() const;
@@ -633,7 +634,6 @@ namespace Slice
         virtual void destroy();
         InterfaceDefPtr definition() const;
         virtual ContainedType containedType() const;
-        virtual bool usesClasses() const;
         virtual size_t minWireSize() const;
         virtual std::string getOptionalFormat() const;
         virtual bool isVariableLength() const;
@@ -897,7 +897,6 @@ namespace Slice
         int minValue() const;
         int maxValue() const;
         virtual ContainedType containedType() const;
-        virtual bool usesClasses() const;
         virtual size_t minWireSize() const;
         virtual std::string getOptionalFormat() const;
         virtual bool isVariableLength() const;

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -76,16 +76,6 @@ namespace
         return l;
     }
 
-    bool isClassType(const TypePtr& type)
-    {
-        if (dynamic_pointer_cast<ClassDecl>(type))
-        {
-            return true;
-        }
-        BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
-        return builtin && (builtin->kind() == Builtin::KindObject || builtin->kind() == Builtin::KindValue);
-    }
-
     static string getCSharpNamespace(const ContainedPtr& cont, bool& hasCSharpNamespaceAttribute)
     {
         // Traverse to the top-level module.
@@ -592,7 +582,7 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
         if (s.find(csGenericPrefix) == 0)
         {
             string type = s.substr(csGenericPrefix.size());
-            if ((type == "LinkedList" || type == "Queue" || type == "Stack") && isClassType(p->type()))
+            if ((type == "LinkedList" || type == "Queue" || type == "Stack") && p->type()->isClassType())
             {
                 continue; // Ignored for objects
             }

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -922,6 +922,12 @@ Slice::CsGenerator::writeOptionalMarshalUnmarshalCode(
                 }
                 break;
             }
+            case Builtin::KindObject:
+            case Builtin::KindValue:
+            {
+                // Unreachable because we reject all class types at the start of the function.
+                assert(false);
+            }
         }
         return;
     }

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -223,14 +223,11 @@ Slice::CsGenerator::getOptionalFormat(const TypePtr& type)
             {
                 return prefix + ".VSize";
             }
-            case Builtin::KindObject:
-            {
-                return prefix + ".Class";
-            }
             case Builtin::KindObjectProxy:
             {
                 return prefix + ".FSize";
             }
+            case Builtin::KindObject:
             case Builtin::KindValue:
             {
                 return prefix + ".Class";
@@ -295,10 +292,10 @@ Slice::CsGenerator::getOptionalFormat(const TypePtr& type)
 string
 Slice::CsGenerator::getStaticId(const TypePtr& type)
 {
+    assert(type->isClassType());
+
     BuiltinPtr b = dynamic_pointer_cast<Builtin>(type);
     ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
-
-    assert((b && b->usesClasses()) || cl);
 
     if (b)
     {

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -292,10 +292,10 @@ Slice::CsGenerator::getOptionalFormat(const TypePtr& type)
 string
 Slice::CsGenerator::getStaticId(const TypePtr& type)
 {
-    assert(type->isClassType());
-
     BuiltinPtr b = dynamic_pointer_cast<Builtin>(type);
     ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
+
+    assert((b && b->usesClasses()) || cl);
 
     if (b)
     {
@@ -684,8 +684,7 @@ Slice::CsGenerator::writeMarshalUnmarshalCode(
         return;
     }
 
-    ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
-    if (cl)
+    if (type->isClassType())
     {
         if (marshal)
         {

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -560,7 +560,7 @@ Slice::CsGenerator::writeMarshalUnmarshalCode(
                 {
                     out << nl << param << " = " << stream << ".readByte()" << ';';
                 }
-                break;
+                return;
             }
             case Builtin::KindBool:
             {
@@ -572,7 +572,7 @@ Slice::CsGenerator::writeMarshalUnmarshalCode(
                 {
                     out << nl << param << " = " << stream << ".readBool()" << ';';
                 }
-                break;
+                return;
             }
             case Builtin::KindShort:
             {
@@ -584,7 +584,7 @@ Slice::CsGenerator::writeMarshalUnmarshalCode(
                 {
                     out << nl << param << " = " << stream << ".readShort()" << ';';
                 }
-                break;
+                return;
             }
             case Builtin::KindInt:
             {
@@ -596,7 +596,7 @@ Slice::CsGenerator::writeMarshalUnmarshalCode(
                 {
                     out << nl << param << " = " << stream << ".readInt()" << ';';
                 }
-                break;
+                return;
             }
             case Builtin::KindLong:
             {
@@ -608,7 +608,7 @@ Slice::CsGenerator::writeMarshalUnmarshalCode(
                 {
                     out << nl << param << " = " << stream << ".readLong()" << ';';
                 }
-                break;
+                return;
             }
             case Builtin::KindFloat:
             {
@@ -620,7 +620,7 @@ Slice::CsGenerator::writeMarshalUnmarshalCode(
                 {
                     out << nl << param << " = " << stream << ".readFloat()" << ';';
                 }
-                break;
+                return;
             }
             case Builtin::KindDouble:
             {
@@ -632,7 +632,7 @@ Slice::CsGenerator::writeMarshalUnmarshalCode(
                 {
                     out << nl << param << " = " << stream << ".readDouble()" << ';';
                 }
-                break;
+                return;
             }
             case Builtin::KindString:
             {
@@ -644,7 +644,7 @@ Slice::CsGenerator::writeMarshalUnmarshalCode(
                 {
                     out << nl << param << " = " << stream << ".readString()" << ';';
                 }
-                break;
+                return;
             }
             case Builtin::KindObject:
             case Builtin::KindValue:
@@ -662,10 +662,9 @@ Slice::CsGenerator::writeMarshalUnmarshalCode(
                 {
                     out << nl << param << " = " << stream << ".readProxy()" << ';';
                 }
-                break;
+                return;
             }
         }
-        return;
     }
 
     InterfaceDeclPtr prx = dynamic_pointer_cast<InterfaceDecl>(type);

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -55,9 +55,6 @@ namespace Slice
         static std::string getStaticId(const TypePtr&);
         static std::string typeToString(const TypePtr&, const std::string&, bool = false);
 
-        // Is this Slice type a Slice class - also true for the built-in Value/Object type.
-        static bool isClassType(const TypePtr&);
-
         // Is this Slice type mapped to a C# value type?
         static bool isValueType(const TypePtr&);
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -181,7 +181,7 @@ Slice::CsVisitor::writeMarshalUnmarshalParams(
     {
         string param = paramPrefix.empty() && !publicNames ? "iceP_" + (*pli)->name() : fixId((*pli)->name());
         TypePtr type = (*pli)->type();
-        if (!marshal && isClassType(type))
+        if (!marshal && type->isClassType())
         {
             ostringstream os;
             os << '(' << typeToString(type, ns) << " v) => { " << paramPrefix << param << " = v; }";
@@ -208,7 +208,7 @@ Slice::CsVisitor::writeMarshalUnmarshalParams(
     {
         ret = op->returnType();
         string param;
-        if (!marshal && isClassType(ret))
+        if (!marshal && ret->isClassType())
         {
             ostringstream os;
             os << '(' << typeToString(ret, ns) << " v) => {" << paramPrefix << returnValueS << " = v; }";
@@ -244,7 +244,7 @@ Slice::CsVisitor::writeMarshalUnmarshalParams(
         if (checkReturnType && op->returnTag() < (*pli)->tag())
         {
             string param;
-            if (!marshal && isClassType(ret))
+            if (!marshal && ret->isClassType())
             {
                 ostringstream os;
                 os << '(' << typeToString(ret, ns) << " v) => {" << paramPrefix << returnValueS << " = v; }";
@@ -260,7 +260,7 @@ Slice::CsVisitor::writeMarshalUnmarshalParams(
 
         string param = paramPrefix.empty() && !publicNames ? "iceP_" + (*pli)->name() : fixId((*pli)->name());
         TypePtr type = (*pli)->type();
-        if (!marshal && isClassType(type))
+        if (!marshal && type->isClassType())
         {
             ostringstream os;
             os << '(' << typeToString(type, ns) << " v) => {" << paramPrefix << param << " = v; }";
@@ -277,7 +277,7 @@ Slice::CsVisitor::writeMarshalUnmarshalParams(
     if (checkReturnType)
     {
         string param;
-        if (!marshal && isClassType(ret))
+        if (!marshal && ret->isClassType())
         {
             ostringstream os;
             os << '(' << typeToString(ret, ns) << " v) => {" << paramPrefix << returnValueS << " = v; }";
@@ -324,7 +324,7 @@ Slice::CsVisitor::writeUnmarshalDataMember(
     bool forStruct)
 {
     string param = name;
-    if (isClassType(member->type()))
+    if (member->type()->isClassType())
     {
         ostringstream os;
         os << '(' << typeToString(member->type(), ns) << " v) => { this." << name << " = v; }";
@@ -2727,7 +2727,7 @@ Slice::Gen::DispatchAdapterVisitor::visitOperation(const OperationPtr& op)
             string param = "iceP_" + pli->name();
             string typeS = typeToString(pli->type(), ns, pli->optional());
 
-            _out << nl << typeS << ' ' << param << (isClassType(pli->type()) ? " = null;" : ";");
+            _out << nl << typeS << ' ' << param << (pli->type()->isClassType() ? " = null;" : ";");
         }
         writeMarshalUnmarshalParams(inParams, 0, false, ns);
         if (op->sendsClasses(false))
@@ -3142,7 +3142,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             _out << sb;
             if (outParams.empty())
             {
-                _out << nl << returnTypeS << " ret" << (isClassType(ret) ? " = null;" : ";");
+                _out << nl << returnTypeS << " ret" << (ret->isClassType() ? " = null;" : ";");
             }
             else if (ret || outParams.size() > 1)
             {
@@ -3153,7 +3153,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             {
                 TypePtr t = outParams.front()->type();
                 _out << nl << typeToString(t, ns, (outParams.front()->optional())) << " iceP_"
-                     << outParams.front()->name() << (isClassType(t) ? " = null;" : ";");
+                     << outParams.front()->name() << (t->isClassType() ? " = null;" : ";");
             }
 
             writeMarshalUnmarshalParams(outParams, op, false, ns, true);
@@ -3318,7 +3318,7 @@ Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
             return;
         }
 
-        if (!isClassType(p->type()))
+        if (!p->type()->isClassType())
         {
             return;
         }
@@ -3402,7 +3402,7 @@ Slice::Gen::HelperVisitor::visitDictionary(const DictionaryPtr& p)
     _out << nl << keyS << " k;";
     writeMarshalUnmarshalCode(_out, key, ns, "k", false);
 
-    if (isClassType(value))
+    if (value->isClassType())
     {
         ostringstream os;
         os << '(' << typeToString(value, ns) << " v) => { r[k] = v; }";

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -809,11 +809,7 @@ Slice::JavaVisitor::writeMarshaledResultType(
 }
 
 void
-Slice::JavaVisitor::allocatePatcher(
-    Output& out,
-    const TypePtr& type,
-    const string& package,
-    const string& name)
+Slice::JavaVisitor::allocatePatcher(Output& out, const TypePtr& type, const string& package, const string& name)
 {
     BuiltinPtr b = dynamic_pointer_cast<Builtin>(type);
     ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -83,13 +83,6 @@ namespace
         return name;
     }
 
-    bool isValue(const TypePtr& type)
-    {
-        BuiltinPtr b = dynamic_pointer_cast<Builtin>(type);
-        ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
-        return (b && b->usesClasses()) || cl;
-    }
-
     // Returns java.util.OptionalXXX.ofYYY depending on the type
     string ofFactory(const TypePtr& type)
     {
@@ -1052,7 +1045,7 @@ Slice::JavaVisitor::writeUnmarshalProxyResults(Output& out, const string& packag
             metaData = outParams.front()->getMetaData();
         }
 
-        const bool val = isValue(type);
+        const bool val = type->isClassType();
 
         int iter = 0;
 
@@ -1441,19 +1434,19 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
             // Declare 'in' parameters.
             //
             out << nl << getUnqualified("com.zeroc.Ice.InputStream", package) << " istr = inS.startReadParams();";
-            for (ParamDeclList::const_iterator pli = inParams.begin(); pli != inParams.end(); ++pli)
+            for (const auto& param : inParams)
             {
-                const TypePtr paramType = (*pli)->type();
-                if (isValue(paramType))
+                const TypePtr paramType = param->type();
+                if (paramType->isClassType())
                 {
-                    allocatePatcher(out, paramType, package, "icePP_" + (*pli)->name(), (*pli)->optional());
-                    values.push_back(*pli);
+                    allocatePatcher(out, paramType, package, "icePP_" + param->name(), param->optional());
+                    values.push_back(param);
                 }
                 else
                 {
-                    const string paramName = "iceP_" + (*pli)->name();
+                    const string paramName = "iceP_" + param->name();
                     const string typeS =
-                        typeToString(paramType, TypeModeIn, package, (*pli)->getMetaData(), true, (*pli)->optional());
+                        typeToString(paramType, TypeModeIn, package, param->getMetaData(), true, param->optional());
                     out << nl << typeS << ' ' << paramName << ';';
                 }
             }
@@ -1464,15 +1457,15 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
             ParamDeclList required, optional;
             op->inParameters(required, optional);
             int iter = 0;
-            for (ParamDeclList::const_iterator pli = required.begin(); pli != required.end(); ++pli)
+            for (const auto& param : required)
             {
                 const string paramName =
-                    isValue((*pli)->type()) ? ("icePP_" + (*pli)->name()) : "iceP_" + (*pli)->name();
-                const string patchParams = getPatcher((*pli)->type(), package, paramName + ".value");
+                    param->type()->isClassType() ? ("icePP_" + param->name()) : "iceP_" + param->name();
+                const string patchParams = getPatcher(param->type(), package, paramName + ".value");
                 writeMarshalUnmarshalCode(
                     out,
                     package,
-                    (*pli)->type(),
+                    param->type(),
                     OptionalNone,
                     false,
                     0,
@@ -1480,26 +1473,26 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
                     false,
                     iter,
                     "",
-                    (*pli)->getMetaData(),
+                    param->getMetaData(),
                     patchParams);
             }
-            for (ParamDeclList::const_iterator pli = optional.begin(); pli != optional.end(); ++pli)
+            for (const auto& param : optional)
             {
                 const string paramName =
-                    isValue((*pli)->type()) ? ("icePP_" + (*pli)->name()) : "iceP_" + (*pli)->name();
-                const string patchParams = getPatcher((*pli)->type(), package, paramName + ".value");
+                    param->type()->isClassType() ? ("icePP_" + param->name()) : "iceP_" + param->name();
+                const string patchParams = getPatcher(param->type(), package, paramName + ".value");
                 writeMarshalUnmarshalCode(
                     out,
                     package,
-                    (*pli)->type(),
+                    param->type(),
                     OptionalInParam,
                     true,
-                    (*pli)->tag(),
+                    param->tag(),
                     paramName,
                     false,
                     iter,
                     "",
-                    (*pli)->getMetaData(),
+                    param->getMetaData(),
                     patchParams);
             }
             if (op->sendsClasses(false))
@@ -3645,7 +3638,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
     const bool optional = p->optional();
     const TypePtr type = p->type();
     const BuiltinPtr b = dynamic_pointer_cast<Builtin>(type);
-    const bool classType = isValue(type);
+    const bool classType = type->isClassType();
 
     const string s = typeToString(type, TypeModeMember, getPackage(contained), metaData, true, false);
 

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -813,8 +813,7 @@ Slice::JavaVisitor::allocatePatcher(
     Output& out,
     const TypePtr& type,
     const string& package,
-    const string& name,
-    bool optionalMapping)
+    const string& name)
 {
     BuiltinPtr b = dynamic_pointer_cast<Builtin>(type);
     ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
@@ -828,10 +827,6 @@ Slice::JavaVisitor::allocatePatcher(
     else
     {
         clsName = getUnqualified(cl, package);
-    }
-    if (optionalMapping)
-    {
-        clsName = "java.util.Optional<" + clsName + ">";
     }
     out << nl << "final com.zeroc.IceInternal.Holder<" << clsName << "> " << name
         << " = new com.zeroc.IceInternal.Holder<>();";
@@ -1051,7 +1046,8 @@ Slice::JavaVisitor::writeUnmarshalProxyResults(Output& out, const string& packag
 
         if (val)
         {
-            allocatePatcher(out, type, package, name, optional);
+            assert(!optional); // Optional classes are disallowed by the parser.
+            allocatePatcher(out, type, package, name);
         }
         else
         {
@@ -1439,7 +1435,8 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
                 const TypePtr paramType = param->type();
                 if (paramType->isClassType())
                 {
-                    allocatePatcher(out, paramType, package, "icePP_" + param->name(), param->optional());
+                    assert(!param->optional()); // Optional classes are disallowed by the parser.
+                    allocatePatcher(out, paramType, package, "icePP_" + param->name());
                     values.push_back(param);
                 }
                 else

--- a/cpp/src/slice2java/Gen.h
+++ b/cpp/src/slice2java/Gen.h
@@ -32,7 +32,7 @@ namespace Slice
             const std::string&,
             const CommentPtr&);
 
-        void allocatePatcher(::IceUtilInternal::Output&, const TypePtr&, const std::string&, const std::string&, bool);
+        void allocatePatcher(::IceUtilInternal::Output&, const TypePtr&, const std::string&, const std::string&);
         std::string getPatcher(const TypePtr&, const std::string&, const std::string&);
 
         std::string getFutureType(const OperationPtr&, const std::string&);

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -1323,29 +1323,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(
             case Builtin::KindObject:
             case Builtin::KindValue:
             {
-                if (marshal)
-                {
-                    if (optionalParam)
-                    {
-                        out << nl << stream << ".writeValue(" << tag << ", " << param << ");";
-                    }
-                    else
-                    {
-                        out << nl << stream << ".writeValue(" << param << ");";
-                    }
-                }
-                else
-                {
-                    assert(!patchParams.empty());
-                    if (optionalParam)
-                    {
-                        out << nl << stream << ".readValue(" << tag << ", " << patchParams << ");";
-                    }
-                    else
-                    {
-                        out << nl << stream << ".readValue(" << patchParams << ");";
-                    }
-                }
+                // Handled by isClassType below.
                 break;
             }
             case Builtin::KindObjectProxy:
@@ -1416,31 +1394,17 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(
         return;
     }
 
-    ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
-    if (cl)
+    if (type->isClassType())
     {
+        assert(!optionalParam); // Optional classes are disallowed by the parser.
         if (marshal)
         {
-            if (optionalParam)
-            {
-                out << nl << stream << ".writeValue(" << tag << ", " << param << ");";
-            }
-            else
-            {
-                out << nl << stream << ".writeValue(" << param << ");";
-            }
+            out << nl << stream << ".writeValue(" << param << ");";
         }
         else
         {
             assert(!patchParams.empty());
-            if (optionalParam)
-            {
-                out << nl << stream << ".readValue(" << tag << ", " << patchParams << ");";
-            }
-            else
-            {
-                out << nl << stream << ".readValue(" << patchParams << ");";
-            }
+            out << nl << stream << ".readValue(" << patchParams << ");";
         }
         return;
     }

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -1314,7 +1314,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(
                         out << nl << param << " = " << stream << ".read" << s << "();";
                     }
                 }
-                break;
+                return;
             }
             case Builtin::KindObject:
             case Builtin::KindValue:
@@ -1351,10 +1351,9 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(
                         out << nl << param << " = " << stream << ".readProxy();";
                     }
                 }
-                break;
+                return;
             }
         }
-        return;
     }
 
     InterfaceDeclPtr prx = dynamic_pointer_cast<InterfaceDecl>(type);

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -1555,7 +1555,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             if (ret)
             {
                 _out << '[' << encodeTypeForOperation(ret);
-                const bool isObj = isClassType(ret);
+                const bool isObj = ret->isClassType();
                 if (isObj)
                 {
                     _out << ", true";
@@ -1586,7 +1586,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                     }
                     TypePtr t = (*pli)->type();
                     _out << '[' << encodeTypeForOperation(t);
-                    const bool isObj = isClassType(t);
+                    const bool isObj = t->isClassType();
                     if (isObj)
                     {
                         _out << ", true";
@@ -1619,7 +1619,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                     }
                     TypePtr t = (*pli)->type();
                     _out << '[' << encodeTypeForOperation(t);
-                    const bool isObj = isClassType(t);
+                    const bool isObj = t->isClassType();
                     if (isObj)
                     {
                         _out << ", true";
@@ -1704,7 +1704,7 @@ Slice::Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     _out << nl << "Slice.defineSequence(" << scope << ", \"" << propertyName << "\", "
          << "\"" << getHelper(type) << "\""
          << ", " << (fixed ? "true" : "false");
-    if (isClassType(type))
+    if (type->isClassType())
     {
         _out << ", \"" << typeToString(type) << "\"";
     }
@@ -1963,7 +1963,7 @@ Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
          << "\"" << getHelper(valueType) << "\", " << (fixed ? "true" : "false") << ", "
          << (keyUseEquals ? "Ice.HashMap.compareEquals" : "undefined");
 
-    if (isClassType(valueType))
+    if (valueType->isClassType())
     {
         _out << ", \"" << typeToString(valueType) << "\"";
     }

--- a/cpp/src/slice2js/JsUtil.h
+++ b/cpp/src/slice2js/JsUtil.h
@@ -21,7 +21,6 @@ namespace Slice
 
         JsGenerator& operator=(const JsGenerator&) = delete;
 
-        static bool isClassType(const TypePtr&);
         static std::string getDefinedIn(const ContainedPtr&);
         static std::string getModuleMetadata(const TypePtr&);
         static std::string getModuleMetadata(const ContainedPtr&);

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -4110,8 +4110,7 @@ CodeVisitor::marshal(
         return;
     }
 
-    ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
-    if (cl)
+    if (type->isClassType())
     {
         assert(!optional); // Optional classes are disallowed by the parser.
         out << nl << stream << ".writeValue(" << v << ");";

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -3988,7 +3988,7 @@ CodeVisitor::marshal(
                 {
                     out << nl << stream << ".writeByte(" << v << ");";
                 }
-                break;
+                return;
             }
             case Builtin::KindBool:
             {
@@ -4000,7 +4000,7 @@ CodeVisitor::marshal(
                 {
                     out << nl << stream << ".writeBool(" << v << ");";
                 }
-                break;
+                return;
             }
             case Builtin::KindShort:
             {
@@ -4012,7 +4012,7 @@ CodeVisitor::marshal(
                 {
                     out << nl << stream << ".writeShort(" << v << ");";
                 }
-                break;
+                return;
             }
             case Builtin::KindInt:
             {
@@ -4024,7 +4024,7 @@ CodeVisitor::marshal(
                 {
                     out << nl << stream << ".writeInt(" << v << ");";
                 }
-                break;
+                return;
             }
             case Builtin::KindLong:
             {
@@ -4036,7 +4036,7 @@ CodeVisitor::marshal(
                 {
                     out << nl << stream << ".writeLong(" << v << ");";
                 }
-                break;
+                return;
             }
             case Builtin::KindFloat:
             {
@@ -4048,7 +4048,7 @@ CodeVisitor::marshal(
                 {
                     out << nl << stream << ".writeFloat(" << v << ");";
                 }
-                break;
+                return;
             }
             case Builtin::KindDouble:
             {
@@ -4060,7 +4060,7 @@ CodeVisitor::marshal(
                 {
                     out << nl << stream << ".writeDouble(" << v << ");";
                 }
-                break;
+                return;
             }
             case Builtin::KindString:
             {
@@ -4072,7 +4072,7 @@ CodeVisitor::marshal(
                 {
                     out << nl << stream << ".writeString(" << v << ");";
                 }
-                break;
+                return;
             }
             case Builtin::KindObject:
             case Builtin::KindValue:
@@ -4090,10 +4090,9 @@ CodeVisitor::marshal(
                 {
                     out << nl << stream << ".writeProxy(" << v << ");";
                 }
-                break;
+                return;
             }
         }
-        return;
     }
 
     InterfaceDeclPtr prx = dynamic_pointer_cast<InterfaceDecl>(type);

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -4088,14 +4088,7 @@ CodeVisitor::marshal(
             case Builtin::KindObject:
             case Builtin::KindValue:
             {
-                if (optional)
-                {
-                    out << nl << stream << ".writeValueOpt(" << tag << ", " << v << ");";
-                }
-                else
-                {
-                    out << nl << stream << ".writeValue(" << v << ");";
-                }
+                // Handled by isClassType below.
                 break;
             }
             case Builtin::KindObjectProxy:
@@ -4131,14 +4124,8 @@ CodeVisitor::marshal(
     ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
     if (cl)
     {
-        if (optional)
-        {
-            out << nl << stream << ".writeValueOpt(" << tag << ", " << v << ");";
-        }
-        else
-        {
-            out << nl << stream << ".writeValue(" << v << ");";
-        }
+        assert(!optional); // Optional classes are disallowed by the parser.
+        out << nl << stream << ".writeValue(" << v << ");";
         return;
     }
 
@@ -4338,14 +4325,8 @@ CodeVisitor::unmarshal(
             case Builtin::KindObject:
             case Builtin::KindValue:
             {
-                if (optional)
-                {
-                    out << nl << stream << ".readValueOpt(" << tag << ", " << v << ", 'Ice.Value');";
-                }
-                else
-                {
-                    out << nl << stream << ".readValue(" << v << ", 'Ice.Value');";
-                }
+                assert(!optional); // Optional classes are disallowed by the parser.
+                out << nl << stream << ".readValue(" << v << ", 'Ice.Value');";
                 break;
             }
             case Builtin::KindObjectProxy:
@@ -4388,15 +4369,9 @@ CodeVisitor::unmarshal(
     ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
     if (cl)
     {
+        assert(!optional); // Optional classes are disallowed by the parser.
         const string cls = getAbsolute(cl);
-        if (optional)
-        {
-            out << nl << stream << ".readValueOpt(" << tag << ", " << v << ", '" << cls << "');";
-        }
-        else
-        {
-            out << nl << stream << ".readValue(" << v << ", '" << cls << "');";
-        }
+        out << nl << stream << ".readValue(" << v << ", '" << cls << "');";
         return;
     }
 

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -548,7 +548,7 @@ Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     const DataMemberList members = p->dataMembers();
     const string optionalFormat = getOptionalFormat(p);
 
-    bool isClass = containsClassMembers(p);
+    bool isClass = p->usesClasses();
     out << sp;
     writeDocSummary(out, p);
     writeSwiftAttributes(out, p->getMetaData());
@@ -702,7 +702,7 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     out << sb;
     out << nl << "let sz = try istr.readAndCheckSeqSize(minSize: " << p->type()->minWireSize() << ")";
 
-    if (isClassType(type))
+    if (type->isClassType())
     {
         out << nl << "var v = " << fixIdent(name) << "(repeating: nil, count: sz)";
         out << nl << "for i in 0 ..< sz";
@@ -847,7 +847,7 @@ Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     out << sb;
     out << nl << "let sz = try Swift.Int(istr.readSize())";
     out << nl << "var v = " << fixIdent(name) << "()";
-    if (isClassType(p->valueType()))
+    if (p->valueType()->isClassType())
     {
         out << nl << "let e = " << getUnqualified("Ice.DictEntryArray", swiftModule) << "<" << keyType << ", "
             << valueType << ">(size: sz)";

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -548,11 +548,11 @@ Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     const DataMemberList members = p->dataMembers();
     const string optionalFormat = getOptionalFormat(p);
 
-    bool isClass = p->usesClasses();
+    bool usesClasses = p->usesClasses();
     out << sp;
     writeDocSummary(out, p);
     writeSwiftAttributes(out, p->getMetaData());
-    out << nl << "public " << (isClass ? "class " : "struct ") << name;
+    out << nl << "public " << (usesClasses ? "class " : "struct ") << name;
     if (legalKeyType)
     {
         out << ": Swift.Hashable";
@@ -576,7 +576,7 @@ Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     out << nl << "/// - returns: `" << name << "` - The structured value read from the stream.";
     out << nl << "func read() throws -> " << name;
     out << sb;
-    out << nl << (isClass ? "let" : "var") << " v = " << name << "()";
+    out << nl << (usesClasses ? "let" : "var") << " v = " << name << "()";
     for (DataMemberList::const_iterator q = members.begin(); q != members.end(); ++q)
     {
         writeMarshalUnmarshalCode(out, (*q)->type(), p, "v." + fixIdent((*q)->name()), false);

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -1327,14 +1327,11 @@ SwiftGenerator::getOptionalFormat(const TypePtr& type)
             {
                 return ".VSize";
             }
-            case Builtin::KindObject:
-            {
-                return ".Class";
-            }
             case Builtin::KindObjectProxy:
             {
                 return ".FSize";
             }
+            case Builtin::KindObject:
             case Builtin::KindValue:
             {
                 return ".Class";
@@ -1663,19 +1660,15 @@ SwiftGenerator::writeMarshalUnmarshalCode(
         }
     }
 
-    if (dynamic_pointer_cast<ClassDecl>(type))
+    ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
+    if (cl)
     {
-        ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
         if (marshal)
         {
             out << nl << stream << ".write(" << args << ")";
         }
         else
         {
-            if (tag >= 0)
-            {
-                args += ", value: ";
-            }
             string memberType = getUnqualified(getAbsolute(type), swiftModule);
             string memberName;
             const string memberPrefix = "self.";

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -112,9 +112,6 @@ namespace Slice
 
         static bool isNullableType(const TypePtr&);
         bool isProxyType(const TypePtr&);
-        bool isClassType(const TypePtr&);
-
-        bool containsClassMembers(const StructPtr&);
 
         std::string getValue(const std::string&, const TypePtr&);
         void writeConstantValue(

--- a/cpp/test/Slice/errorDetection/OptionalMembers.err
+++ b/cpp/test/Slice/errorDetection/OptionalMembers.err
@@ -1,33 +1,39 @@
-OptionalMembers.ice:21: missing tag
-OptionalMembers.ice:22: missing tag
-OptionalMembers.ice:23: `abc' is not defined
-OptionalMembers.ice:24: tag is out of range
-OptionalMembers.ice:25: tag is out of range
-OptionalMembers.ice:26: tag is out of range
-OptionalMembers.ice:28: tag for optional data member `m8' is already in use
-OptionalMembers.ice:29: tag is out of range
-OptionalMembers.ice:29: invalid tag `C3'
-OptionalMembers.ice:30: tag is out of range
-OptionalMembers.ice:30: invalid tag `C4'
-OptionalMembers.ice:31: invalid tag `C5'
-OptionalMembers.ice:33: tag for optional data member `m13' is already in use
-OptionalMembers.ice:34: enumerator `e2' could designate `::Test::E::e2' or `::Test::Ebis::e2' or `::Test::Eter::e2'
-OptionalMembers.ice:35: warning: referencing enumerator `::Test::E::e3' without its enumeration's scope is deprecated
-OptionalMembers.ice:36: tag for optional data member `m16' is already in use
-OptionalMembers.ice:51: missing tag
-OptionalMembers.ice:52: missing tag
-OptionalMembers.ice:53: `abc' is not defined
-OptionalMembers.ice:54: tag is out of range
-OptionalMembers.ice:55: tag is out of range
-OptionalMembers.ice:56: tag is out of range
-OptionalMembers.ice:58: tag for optional data member `m8' is already in use
-OptionalMembers.ice:59: tag is out of range
-OptionalMembers.ice:59: invalid tag `C3'
-OptionalMembers.ice:60: tag is out of range
-OptionalMembers.ice:60: invalid tag `C4'
-OptionalMembers.ice:61: invalid tag `C5'
-OptionalMembers.ice:63: tag for optional data member `m13' is already in use
-OptionalMembers.ice:65: warning: referencing enumerator `::Test::E::e3' without its enumeration's scope is deprecated
-OptionalMembers.ice:66: tag for optional data member `m16' is already in use
-OptionalMembers.ice:81: optional data members are not supported in structs
-OptionalMembers.ice:82: optional data members are not supported in structs
+OptionalMembers.ice:36: missing tag
+OptionalMembers.ice:37: missing tag
+OptionalMembers.ice:38: `abc' is not defined
+OptionalMembers.ice:39: tag is out of range
+OptionalMembers.ice:40: tag is out of range
+OptionalMembers.ice:41: tag is out of range
+OptionalMembers.ice:43: tag for optional data member `m8' is already in use
+OptionalMembers.ice:44: tag is out of range
+OptionalMembers.ice:44: invalid tag `C3'
+OptionalMembers.ice:45: tag is out of range
+OptionalMembers.ice:45: invalid tag `C4'
+OptionalMembers.ice:46: invalid tag `C5'
+OptionalMembers.ice:48: tag for optional data member `m13' is already in use
+OptionalMembers.ice:49: enumerator `e2' could designate `::Test::E::e2' or `::Test::Ebis::e2' or `::Test::Eter::e2'
+OptionalMembers.ice:50: warning: referencing enumerator `::Test::E::e3' without its enumeration's scope is deprecated
+OptionalMembers.ice:51: tag for optional data member `m16' is already in use
+OptionalMembers.ice:66: missing tag
+OptionalMembers.ice:67: missing tag
+OptionalMembers.ice:68: `abc' is not defined
+OptionalMembers.ice:69: tag is out of range
+OptionalMembers.ice:70: tag is out of range
+OptionalMembers.ice:71: tag is out of range
+OptionalMembers.ice:73: tag for optional data member `m8' is already in use
+OptionalMembers.ice:74: tag is out of range
+OptionalMembers.ice:74: invalid tag `C3'
+OptionalMembers.ice:75: tag is out of range
+OptionalMembers.ice:75: invalid tag `C4'
+OptionalMembers.ice:76: invalid tag `C5'
+OptionalMembers.ice:78: tag for optional data member `m13' is already in use
+OptionalMembers.ice:80: warning: referencing enumerator `::Test::E::e3' without its enumeration's scope is deprecated
+OptionalMembers.ice:81: tag for optional data member `m16' is already in use
+OptionalMembers.ice:96: optional data members are not supported in structs
+OptionalMembers.ice:97: optional data members are not supported in structs
+OptionalMembers.ice:105: types that use classes cannot be marked with 'optional'
+OptionalMembers.ice:107: types that use classes cannot be marked with 'optional'
+OptionalMembers.ice:109: types that use classes cannot be marked with 'optional'
+OptionalMembers.ice:115: types that use classes cannot be marked with 'optional'
+OptionalMembers.ice:116: types that use classes cannot be marked with 'optional'
+OptionalMembers.ice:118: types that use classes cannot be marked with 'optional'

--- a/cpp/test/Slice/errorDetection/OptionalMembers.ice
+++ b/cpp/test/Slice/errorDetection/OptionalMembers.ice
@@ -16,6 +16,21 @@ enum E { e1, e2, e3 = 4 }
 enum Ebis { e2 }
 enum Eter { e2 }
 
+class C;
+
+struct ClassWrapper
+{
+    C c;
+}
+
+interface I {}
+
+sequence<bool> BoolSeq;
+sequence<C> ClassSeq;
+sequence<ClassWrapper> ClassWrapperSeq;
+dictionary<int, bool> BoolDict;
+dictionary<int, C> ClassDict;
+
 class C
 {
     optional string m1;             // missing tag
@@ -80,6 +95,27 @@ struct S
 {
     optional(1) int m1;             // not allowed in struct
     optional(2) int m2 = 2;         // not allowed in struct
+}
+
+class D
+{
+    optional(1) bool m1;            // ok
+    optional(2) float m2;           // ok
+    optional(3) string m3;          // ok
+    optional(4) Object m4;          // cannot tag class types
+    optional(5) Object* m5;         // ok
+    optional(6) Value m6;           // cannot tag class types
+
+    optional(7) C m7;               // cannot tag class types
+    optional(8) I* m8;              // ok
+    optional(9) S m9;               // ok
+    optional(10) E m10;             // ok
+
+    optional(11) BoolSeq m11;       // ok
+    optional(12) ClassSeq m12;      // cannot tag class types
+    optional(13) ClassWrapper m13;  // cannot tag class types
+    optional(14) BoolDict m14;      // ok
+    optional(15) ClassDict m15;     // cannot tag class types
 }
 
 }

--- a/cpp/test/Slice/errorDetection/OptionalParams.err
+++ b/cpp/test/Slice/errorDetection/OptionalParams.err
@@ -1,27 +1,15 @@
-OptionalParams.ice:20: missing tag
-OptionalParams.ice:21: missing tag
-OptionalParams.ice:22: `abc' is not defined
-OptionalParams.ice:23: tag is out of range
-OptionalParams.ice:24: tag is out of range
-OptionalParams.ice:25: tag is out of range
-OptionalParams.ice:27: tag is out of range
-OptionalParams.ice:27: invalid tag `C3'
-OptionalParams.ice:28: tag is out of range
-OptionalParams.ice:28: invalid tag `C4'
-OptionalParams.ice:29: invalid tag `C5'
-OptionalParams.ice:32: syntax error
+OptionalParams.ice:33: missing tag
 OptionalParams.ice:34: missing tag
-OptionalParams.ice:35: missing tag
-OptionalParams.ice:36: `abc' is not defined
+OptionalParams.ice:35: `abc' is not defined
+OptionalParams.ice:36: tag is out of range
 OptionalParams.ice:37: tag is out of range
 OptionalParams.ice:38: tag is out of range
-OptionalParams.ice:39: tag is out of range
+OptionalParams.ice:40: tag is out of range
+OptionalParams.ice:40: invalid tag `C3'
 OptionalParams.ice:41: tag is out of range
-OptionalParams.ice:41: invalid tag `C3'
-OptionalParams.ice:42: tag is out of range
-OptionalParams.ice:42: invalid tag `C4'
-OptionalParams.ice:43: invalid tag `C5'
-OptionalParams.ice:45: warning: referencing enumerator `::Test::E::e2' without its enumeration's scope is deprecated
+OptionalParams.ice:41: invalid tag `C4'
+OptionalParams.ice:42: invalid tag `C5'
+OptionalParams.ice:45: syntax error
 OptionalParams.ice:47: missing tag
 OptionalParams.ice:48: missing tag
 OptionalParams.ice:49: `abc' is not defined
@@ -33,8 +21,26 @@ OptionalParams.ice:54: invalid tag `C3'
 OptionalParams.ice:55: tag is out of range
 OptionalParams.ice:55: invalid tag `C4'
 OptionalParams.ice:56: invalid tag `C5'
-OptionalParams.ice:58: enumerator `e1' could designate `::Test::E::e1' or `::Test::Ebis::e1'
-OptionalParams.ice:62: tag for optional parameter `o' is already in use
-OptionalParams.ice:63: tag for optional parameter `o' is already in use
-OptionalParams.ice:64: tag for optional parameter `o' is already in use
-OptionalParams.ice:65: tag for optional parameter `o' is already in use
+OptionalParams.ice:58: warning: referencing enumerator `::Test::E::e2' without its enumeration's scope is deprecated
+OptionalParams.ice:60: missing tag
+OptionalParams.ice:61: missing tag
+OptionalParams.ice:62: `abc' is not defined
+OptionalParams.ice:63: tag is out of range
+OptionalParams.ice:64: tag is out of range
+OptionalParams.ice:65: tag is out of range
+OptionalParams.ice:67: tag is out of range
+OptionalParams.ice:67: invalid tag `C3'
+OptionalParams.ice:68: tag is out of range
+OptionalParams.ice:68: invalid tag `C4'
+OptionalParams.ice:69: invalid tag `C5'
+OptionalParams.ice:71: enumerator `e1' could designate `::Test::E::e1' or `::Test::Ebis::e1'
+OptionalParams.ice:75: tag for optional parameter `o' is already in use
+OptionalParams.ice:76: tag for optional parameter `o' is already in use
+OptionalParams.ice:77: tag for optional parameter `o' is already in use
+OptionalParams.ice:78: tag for optional parameter `o' is already in use
+OptionalParams.ice:83: types that use classes cannot be marked with 'optional'
+OptionalParams.ice:85: types that use classes cannot be marked with 'optional'
+OptionalParams.ice:86: types that use classes cannot be marked with 'optional'
+OptionalParams.ice:90: types that use classes cannot be marked with 'optional'
+OptionalParams.ice:91: types that use classes cannot be marked with 'optional'
+OptionalParams.ice:93: types that use classes cannot be marked with 'optional'

--- a/cpp/test/Slice/errorDetection/OptionalParams.ice
+++ b/cpp/test/Slice/errorDetection/OptionalParams.ice
@@ -15,6 +15,19 @@ const long C6 = 2;
 enum E { e1, e2, e3 }
 enum Ebis { e1 }
 
+class C;
+
+struct ClassWrapper
+{
+    C c;
+}
+
+sequence<bool> BoolSeq;
+sequence<C> ClassSeq;
+sequence<ClassWrapper> ClassWrapperSeq;
+dictionary<int, bool> BoolDict;
+dictionary<int, C> ClassDict;
+
 interface I
 {
     optional string r1();             // missing tag
@@ -63,6 +76,21 @@ interface I
     optional(1) int io4(out optional(2) int p, out optional(2) int o);  // duplicate tag
     optional(2) int io5(out optional(1) int p, out optional(2) int o);  // duplicate tag
     optional(C1) int io6(optional(E::e2) int p, out optional(E::e1) int o);   // duplicate tag
+
+    void t1(optional(7) bool m1);            // ok
+    void t2(optional(7) float m2);           // ok
+    void t3(optional(7) string m3);          // ok
+    void t4(optional(7) Object m4);          // cannot tag class types
+    void t5(optional(7) Object* m5);         // ok
+    void t6(optional(7) Value m6);           // cannot tag class types
+    void t7(optional(7) C m7);               // cannot tag class types
+    void t8(optional(7) I* m8);              // ok
+    void t10(optional(7) E m10);             // ok
+    void t11(optional(7) BoolSeq m11);       // ok
+    void t12(optional(7) ClassSeq m12);      // cannot tag class types
+    void t13(optional(7) ClassWrapper m13);  // cannot tag class types
+    void t14(optional(7) BoolDict m14);      // ok
+    void t15(optional(7) ClassDict m15);     // cannot tag class types
 }
 
 }


### PR DESCRIPTION
This PR removes any code-generation support for optional classes, replacing them with asserts to ensure the compiler never encounters an optional class type. This also lets us simplify our logic in some places.

It also adds a new `isClassType` function to the compiler. Every language had it's own version of this logic... So I deleted all those duplicate functions and we now use this single, centralized function instead.
The base implementation returns `false`, and it's overridden by `Class` and `Builtin` (for `Value` and `Object` keywords).

It also also adds some tests to ensure the compiler does correctly reject optional classes, and types which are using them.