### PR TITLE
Disallow Sequences as Dictionary Key Types

### DIFF
--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -873,7 +873,7 @@ namespace Slice
         virtual std::string kindOf() const;
         virtual void visit(ParserVisitor*, bool);
 
-        static bool legalKeyType(const TypePtr&, bool&);
+        static bool legalKeyType(const TypePtr&);
 
     protected:
         friend class Container;

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2253,11 +2253,6 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
 }
 
 void
-Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr&)
-{
-}
-
-void
 Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 {
     string name = fixId(p->name());

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -132,7 +132,6 @@ namespace Slice
             virtual bool visitStructStart(const StructPtr&);
             virtual void visitStructEnd(const StructPtr&);
             virtual void visitSequence(const SequencePtr&);
-            virtual void visitDictionary(const DictionaryPtr&);
             virtual void visitEnum(const EnumPtr&);
             virtual void visitConst(const ConstPtr&);
             virtual void visitDataMember(const DataMemberPtr&);

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -1922,8 +1922,7 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     //
     // Only generate hashCode if this structure type is a legal dictionary key type.
     //
-    bool containsSequence = false;
-    bool legalKeyType = Dictionary::legalKeyType(p, containsSequence);
+    bool legalKeyType = Dictionary::legalKeyType(p);
 
     _out << sp;
     _out << nl << "Slice.defineStruct(" << localScope << '.' << name << ", " << (legalKeyType ? "true" : "false")
@@ -2935,9 +2934,7 @@ Slice::Gen::TypeScriptVisitor::visitStructStart(const StructPtr& p)
     //
     // Only generate hashCode if this structure type is a legal dictionary key type.
     //
-    bool containsSequence = false;
-    bool legalKeyType = Dictionary::legalKeyType(p, containsSequence);
-    if (legalKeyType)
+    if (Dictionary::legalKeyType(p))
     {
         _out << nl << "hashCode():number;";
     }

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -868,6 +868,7 @@ CodeVisitor::visitDictionary(const DictionaryPtr& p)
     else if (!dynamic_pointer_cast<Enum>(keyType))
     {
         // TODO: using 'InvalidMetadata' as our warning category for an unsupported key type feels weird.
+        // See https://github.com/zeroc-ice/ice/issues/254
         dc->warning(InvalidMetaData, p->file(), p->line(), "dictionary key type not supported in PHP");
     }
 

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -847,22 +847,18 @@ CodeVisitor::visitDictionary(const DictionaryPtr& p)
     {
         switch (b->kind())
         {
+            // These types are acceptable as dictionary keys.
             case Slice::Builtin::KindBool:
             case Slice::Builtin::KindByte:
             case Slice::Builtin::KindShort:
             case Slice::Builtin::KindInt:
             case Slice::Builtin::KindLong:
             case Slice::Builtin::KindString:
-                // These types are acceptable as dictionary keys.
                 break;
 
+            // These types have already been rejected as illegal key types by the parser.
             case Slice::Builtin::KindFloat:
             case Slice::Builtin::KindDouble:
-            {
-                dc->warning(InvalidMetaData, p->file(), p->line(), "dictionary key type not supported in PHP");
-                break;
-            }
-
             case Slice::Builtin::KindObject:
             case Slice::Builtin::KindObjectProxy:
             case Slice::Builtin::KindValue:
@@ -871,6 +867,7 @@ CodeVisitor::visitDictionary(const DictionaryPtr& p)
     }
     else if (!dynamic_pointer_cast<Enum>(keyType))
     {
+        // TODO: using 'InvalidMetadata' as our warning category for an unsupported key type feels weird.
         dc->warning(InvalidMetaData, p->file(), p->line(), "dictionary key type not supported in PHP");
     }
 

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1216,11 +1216,9 @@ Slice::Python::CodeVisitor::visitStructStart(const StructPtr& p)
     _out.dec();
 
     //
-    // Only generate __hash__ and the comparison operators if this structure type
-    // is a legal dictionary key type.
+    // Only generate __hash__ and the comparison operators if this structure type is a legal dictionary key type.
     //
-    bool containsSequence = false;
-    if (Dictionary::legalKeyType(p, containsSequence))
+    if (Dictionary::legalKeyType(p))
     {
         _out << sp << nl << "def __hash__(self):";
         _out.inc();

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -543,8 +543,7 @@ Gen::TypesVisitor::visitStructStart(const StructPtr& p)
 {
     const string swiftModule = getSwiftModule(getTopLevelModule(dynamic_pointer_cast<Contained>(p)));
     const string name = fixIdent(getUnqualified(getAbsolute(p), swiftModule));
-    bool containsSequence;
-    bool legalKeyType = Dictionary::legalKeyType(p, containsSequence);
+    bool legalKeyType = Dictionary::legalKeyType(p);
     const DataMemberList members = p->dataMembers();
     const string optionalFormat = getOptionalFormat(p);
 
@@ -553,6 +552,8 @@ Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     writeDocSummary(out, p);
     writeSwiftAttributes(out, p->getMetaData());
     out << nl << "public " << (isClass ? "class " : "struct ") << name;
+
+    // Only generate Hashable if this struct is a legal dictionary key type.
     if (legalKeyType)
     {
         out << ": Swift.Hashable";

--- a/cpp/test/Slice/errorDetection/IllegalDictionary.err
+++ b/cpp/test/Slice/errorDetection/IllegalDictionary.err
@@ -2,9 +2,6 @@ IllegalDictionary.ice:15: dictionary `b1' uses an illegal key type
 IllegalDictionary.ice:16: dictionary `b2' uses an illegal key type
 IllegalDictionary.ice:17: dictionary `b3' uses an illegal key type
 IllegalDictionary.ice:18: dictionary `b4' uses an illegal key type
-IllegalDictionary.ice:22: warning: use of sequences in dictionary keys has been deprecated
-IllegalDictionary.ice:25: dictionary `b6' uses an illegal key type
-IllegalDictionary.ice:28: warning: use of sequences in dictionary keys has been deprecated
-IllegalDictionary.ice:42: dictionary `b8' uses an illegal key type
-IllegalDictionary.ice:48: warning: use of sequences in dictionary keys has been deprecated
-IllegalDictionary.ice:50: dictionary `b9' uses an illegal key type
+IllegalDictionary.ice:22: dictionary `d7' uses an illegal key type
+IllegalDictionary.ice:36: dictionary `b8' uses an illegal key type
+IllegalDictionary.ice:41: dictionary `b9' uses an illegal key type

--- a/cpp/test/Slice/errorDetection/IllegalDictionary.ice
+++ b/cpp/test/Slice/errorDetection/IllegalDictionary.ice
@@ -19,13 +19,7 @@ dictionary<Object*, long> b4;           // Bad
 // dictionary<LocalObject, long> b5;       // Bad
 
 sequence<byte> s1;
-dictionary<s1, long> d7;                // Deprecated
-
-sequence<float> s2;
-dictionary<s2, long> b6;                // Bad
-
-sequence<s1> s3;
-dictionary<s3, long> b7;                // Deprecated
+dictionary<s1, long> d7;                // Bad
 
 struct st1
 {
@@ -43,9 +37,6 @@ dictionary<st2, long> b8;               // Bad
 
 enum e { e1, e2 }
 dictionary<e, long> d9;                 // OK
-
-sequence<e> s4;
-dictionary<s4, long> d10;               // Deprecated
 
 dictionary<d9, long> b9;                // Bad
 

--- a/cpp/test/Slice/errorDetection/WrongProxyType.err
+++ b/cpp/test/Slice/errorDetection/WrongProxyType.err
@@ -1,4 +1,3 @@
-WrongProxyType.ice:9: warning: use of sequences in dictionary keys has been deprecated
 WrongProxyType.ice:13: `Seq' must be an interface
 WrongProxyType.ice:14: `Seq' must be an interface
 WrongProxyType.ice:15: `Seq' must be an interface

--- a/cpp/test/Slice/errorDetection/WrongProxyType.ice
+++ b/cpp/test/Slice/errorDetection/WrongProxyType.ice
@@ -6,7 +6,7 @@ module Test
 {
 
 sequence<int> Seq;
-dictionary<Seq, int> Dict;
+dictionary<bool, int> Dict;
 
 interface I
 {


### PR DESCRIPTION
Slice supports using sequence types as a dictionary key:
```
sequence<byte> S;
dictionary<S, byte>;
```
But it's been deprecated since Ice 3.3

This PR fully removes the functionality. It's now a hard error to do this.