### PR TITLE
Remove Dead 'supportsCsharpSerializable' Function

### DIFF
--- a/cpp/test/Ice/optional/Test.ice
+++ b/cpp/test/Ice/optional/Test.ice
@@ -286,8 +286,6 @@ interface Initial
                                                             out optional(3) StringIntDict p2);
 
     bool supportsJavaSerializable();
-
-    bool supportsCsharpSerializable();
 }
 
 }

--- a/cpp/test/Ice/optional/TestAMD.ice
+++ b/cpp/test/Ice/optional/TestAMD.ice
@@ -286,8 +286,6 @@ interface Initial
                                                             out optional(3) StringIntDict p2);
 
     bool supportsJavaSerializable();
-
-    bool supportsCsharpSerializable();
 }
 
 }

--- a/cpp/test/Ice/optional/TestAMDI.cpp
+++ b/cpp/test/Ice/optional/TestAMDI.cpp
@@ -470,12 +470,3 @@ InitialI::supportsJavaSerializableAsync(
 {
     response(true);
 }
-
-void
-InitialI::supportsCsharpSerializableAsync(
-    function<void(bool)> response,
-    function<void(exception_ptr)>,
-    const Ice::Current&)
-{
-    response(true);
-}

--- a/cpp/test/Ice/optional/TestAMDI.h
+++ b/cpp/test/Ice/optional/TestAMDI.h
@@ -294,11 +294,6 @@ public:
         std::function<void(bool)>,
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) final;
-
-    void supportsCsharpSerializableAsync(
-        std::function<void(bool)>,
-        std::function<void(std::exception_ptr)>,
-        const Ice::Current&) final;
 };
 
 #endif

--- a/cpp/test/Ice/optional/TestI.cpp
+++ b/cpp/test/Ice/optional/TestI.cpp
@@ -376,9 +376,3 @@ InitialI::supportsJavaSerializable(const Ice::Current&)
 {
     return true;
 }
-
-bool
-InitialI::supportsCsharpSerializable(const Ice::Current&)
-{
-    return true;
-}

--- a/cpp/test/Ice/optional/TestI.h
+++ b/cpp/test/Ice/optional/TestI.h
@@ -146,8 +146,6 @@ public:
     virtual OpMDict2MarshaledResult opMDict2(std::optional<Test::StringIntDict>, const Ice::Current&);
 
     virtual bool supportsJavaSerializable(const Ice::Current&);
-
-    virtual bool supportsCsharpSerializable(const Ice::Current&);
 };
 
 #endif

--- a/java/test/src/main/java/test/Ice/optional/AMDInitialI.java
+++ b/java/test/src/main/java/test/Ice/optional/AMDInitialI.java
@@ -311,9 +311,4 @@ public final class AMDInitialI implements Initial {
   public CompletionStage<Boolean> supportsJavaSerializableAsync(Current current) {
     return CompletableFuture.completedFuture(true);
   }
-
-  @Override
-  public CompletionStage<Boolean> supportsCsharpSerializableAsync(Current current) {
-    return CompletableFuture.completedFuture(false);
-  }
 }

--- a/java/test/src/main/java/test/Ice/optional/InitialI.java
+++ b/java/test/src/main/java/test/Ice/optional/InitialI.java
@@ -277,9 +277,4 @@ public final class InitialI implements Initial {
   public boolean supportsJavaSerializable(Current current) {
     return true;
   }
-
-  @Override
-  public boolean supportsCsharpSerializable(Current current) {
-    return false;
-  }
 }

--- a/java/test/src/main/java/test/Ice/optional/Test.ice
+++ b/java/test/src/main/java/test/Ice/optional/Test.ice
@@ -271,8 +271,6 @@ interface Initial
                                                             out optional(3) StringIntDict p2);
 
     bool supportsJavaSerializable();
-
-    bool supportsCsharpSerializable();
 }
 
 }

--- a/java/test/src/main/java/test/Ice/optional/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/optional/TestAMD.ice
@@ -272,8 +272,6 @@ interface Initial
                                                             out optional(3) StringIntDict p2);
 
     bool supportsJavaSerializable();
-
-    bool supportsCsharpSerializable();
 }
 
 }

--- a/js/test/Ice/optional/AMDInitialI.js
+++ b/js/test/Ice/optional/AMDInitialI.js
@@ -277,11 +277,6 @@
         {
             return false;
         }
-
-        supportsCsharpSerializable(current)
-        {
-            return false;
-        }
     }
 
     exports.AMDInitialI = AMDInitialI;

--- a/js/test/Ice/optional/InitialI.js
+++ b/js/test/Ice/optional/InitialI.js
@@ -277,11 +277,6 @@
         {
             return false;
         }
-
-        supportsCsharpSerializable(current)
-        {
-            return false;
-        }
     }
     exports.InitialI = InitialI;
 }(typeof global !== "undefined" && typeof global.process !== "undefined" ? module : undefined,

--- a/js/test/Ice/optional/Test.ice
+++ b/js/test/Ice/optional/Test.ice
@@ -270,8 +270,6 @@ interface Initial
                                                             out optional(3) StringIntDict p2);
 
     bool supportsJavaSerializable();
-
-    bool supportsCsharpSerializable();
 }
 
 interface Echo

--- a/js/test/typescript/Ice/optional/AMDInitialI.ts
+++ b/js/test/typescript/Ice/optional/AMDInitialI.ts
@@ -276,9 +276,4 @@ export class AMDInitialI extends Test.Initial
     {
         return false;
     }
-
-    supportsCsharpSerializable(current:Ice.Current):boolean
-    {
-        return false;
-    }
 }

--- a/js/test/typescript/Ice/optional/InitialI.ts
+++ b/js/test/typescript/Ice/optional/InitialI.ts
@@ -276,9 +276,4 @@ export class InitialI extends Test.Initial
     {
         return false;
     }
-
-    supportsCsharpSerializable(current:Ice.Current):boolean
-    {
-        return false;
-    }
 }

--- a/js/test/typescript/Ice/optional/Test.ice
+++ b/js/test/typescript/Ice/optional/Test.ice
@@ -272,8 +272,6 @@ interface Initial
                                                             out optional(3) StringIntDict p2);
 
     bool supportsJavaSerializable();
-
-    bool supportsCsharpSerializable();
 }
 
 interface Echo

--- a/matlab/test/Ice/optional/Test.ice
+++ b/matlab/test/Ice/optional/Test.ice
@@ -278,8 +278,6 @@ interface Initial
                                                             out optional(3) StringIntDict p2);
 
     bool supportsJavaSerializable();
-
-    bool supportsCsharpSerializable();
 }
 
 }

--- a/php/test/Ice/optional/Test.ice
+++ b/php/test/Ice/optional/Test.ice
@@ -268,8 +268,6 @@ interface Initial
                                                             out optional(3) StringIntDict p2);
 
     bool supportsJavaSerializable();
-
-    bool supportsCsharpSerializable();
 }
 
 }

--- a/python/test/Ice/optional/Server.py
+++ b/python/test/Ice/optional/Server.py
@@ -157,9 +157,6 @@ class InitialI(Test.Initial):
     def supportsJavaSerializable(self, current=None):
         return True
 
-    def supportsCsharpSerializable(self, current=None):
-        return True
-
 
 class Server(TestHelper):
     def run(self, args):

--- a/python/test/Ice/optional/ServerAMD.py
+++ b/python/test/Ice/optional/ServerAMD.py
@@ -171,9 +171,6 @@ class InitialI(Test.Initial):
     def supportsJavaSerializable(self, current=None):
         return Ice.Future.completed(True)
 
-    def supportsCsharpSerializable(self, current=None):
-        return Ice.Future.completed(False)
-
 
 class ServerAMD(TestHelper):
     def run(self, args):

--- a/python/test/Ice/optional/Test.ice
+++ b/python/test/Ice/optional/Test.ice
@@ -274,8 +274,6 @@ interface Initial
                                                             out optional(3) StringIntDict p2);
 
     bool supportsJavaSerializable();
-
-    bool supportsCsharpSerializable();
 }
 
 }

--- a/ruby/test/Ice/optional/Test.ice
+++ b/ruby/test/Ice/optional/Test.ice
@@ -270,8 +270,6 @@ interface Initial
                                                             out optional(3) StringIntDict p2);
 
     bool supportsJavaSerializable();
-
-    bool supportsCsharpSerializable();
 }
 
 }

--- a/swift/test/Ice/optional/Test.ice
+++ b/swift/test/Ice/optional/Test.ice
@@ -278,8 +278,6 @@ interface Initial
                                                             out optional(3) StringIntDict p2);
 
     bool supportsJavaSerializable();
-
-    bool supportsCsharpSerializable();
 }
 
 }

--- a/swift/test/Ice/optional/TestAMD.ice
+++ b/swift/test/Ice/optional/TestAMD.ice
@@ -273,8 +273,6 @@ interface Initial
                                                             out optional(3) StringIntDict p2);
 
     bool supportsJavaSerializable();
-
-    bool supportsCsharpSerializable();
 }
 
 }

--- a/swift/test/Ice/optional/TestAMDI.swift
+++ b/swift/test/Ice/optional/TestAMDI.swift
@@ -281,8 +281,4 @@ class InitialI: Initial {
     func supportsJavaSerializableAsync(current _: Current) -> Promise<Bool> {
         return Promise.value(false)
     }
-
-    func supportsCsharpSerializableAsync(current _: Current) -> Promise<Bool> {
-        return Promise.value(false)
-    }
 }

--- a/swift/test/Ice/optional/TestI.swift
+++ b/swift/test/Ice/optional/TestI.swift
@@ -244,10 +244,6 @@ class InitialI: Initial {
         return false
     }
 
-    func supportsCsharpSerializable(current _: Ice.Current) throws -> Bool {
-        return false
-    }
-
     func opMStruct1(current _: Current) throws -> SmallStruct? {
         return SmallStruct()
     }


### PR DESCRIPTION
In the 'Ice/optional' tests, we have this operation: `bool supportsCsharpSerializable();`
C# used to call this in the cross-tests to determine whether it should run tests involving serialization.
But... C# serialization support was removed 6 months ago in #1594

So, this function is never called anymore; so this PR removes it.