### PR TITLE
Rename 'SmallStruct' to 'LargeStruct'.

### DIFF
--- a/cpp/test/Ice/stream/Client.cpp
+++ b/cpp/test/Ice/stream/Client.cpp
@@ -228,7 +228,7 @@ allTests(Test::TestHelper* helper)
 
     {
         Ice::OutputStream out(communicator);
-        SmallStruct s;
+        LargeStruct s;
         s.bo = true;
         s.by = 1;
         s.sh = 2;
@@ -242,7 +242,7 @@ allTests(Test::TestHelper* helper)
         out.write(s);
         out.finished(data);
         Ice::InputStream in(communicator, data);
-        SmallStruct s2;
+        LargeStruct s2;
         in.read(s2);
         test(s2.p == s.p);
         s2.p = s.p; // otherwise the s2 == s below will fail
@@ -564,10 +564,10 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        SmallStructS arr;
+        LargeStructS arr;
         for (int i = 0; i < 4; ++i)
         {
-            SmallStruct s;
+            LargeStruct s;
             s.bo = true;
             s.by = 1;
             s.sh = 2;
@@ -585,21 +585,21 @@ allTests(Test::TestHelper* helper)
         out.writePendingValues();
         out.finished(data);
         Ice::InputStream in(communicator, data);
-        SmallStructS arr2;
+        LargeStructS arr2;
         in.read(arr2);
         in.readPendingValues();
         test(arr2.size() == arr.size());
 
-        for (SmallStructS::size_type j = 0; j < arr2.size(); ++j)
+        for (LargeStructS::size_type j = 0; j < arr2.size(); ++j)
         {
             test(arr[j].p == arr2[j].p);
             arr2[j].p = arr[j].p;
             test(arr[j] == arr2[j]);
         }
 
-        SmallStructSS arrS;
+        LargeStructSS arrS;
         arrS.push_back(arr);
-        arrS.push_back(SmallStructS());
+        arrS.push_back(LargeStructS());
         arrS.push_back(arr);
 
         Ice::OutputStream out2(communicator);
@@ -607,7 +607,7 @@ allTests(Test::TestHelper* helper)
         out2.finished(data);
 
         Ice::InputStream in2(communicator, data);
-        SmallStructSS arr2S;
+        LargeStructSS arr2S;
         in2.read(arr2S);
     }
 

--- a/cpp/test/Ice/stream/Test.ice
+++ b/cpp/test/Ice/stream/Test.ice
@@ -19,7 +19,7 @@ enum MyEnum
 interface MyInterface;
 class MyClass;
 
-struct SmallStruct
+struct LargeStruct
 {
     bool bo;
     byte by;
@@ -47,7 +47,7 @@ class OptionalClass
 }
 
 sequence<MyEnum> MyEnumS;
-sequence<SmallStruct> SmallStructS;
+sequence<LargeStruct> LargeStructS;
 sequence<MyClass> MyClassS;
 
 sequence<Ice::BoolSeq> BoolSS;
@@ -59,7 +59,7 @@ sequence<Ice::FloatSeq> FloatSS;
 sequence<Ice::DoubleSeq> DoubleSS;
 sequence<Ice::StringSeq> StringSS;
 sequence<MyEnumS> MyEnumSS;
-sequence<SmallStructS> SmallStructSS;
+sequence<LargeStructS> LargeStructSS;
 sequence<MyClassS> MyClassSS;
 
 dictionary<byte, bool> ByteBoolD;
@@ -72,7 +72,7 @@ class MyClass
 {
     MyClass c;
     Object o;
-    SmallStruct s;
+    LargeStruct s;
     Ice::BoolSeq seq1;
     Ice::ByteSeq seq2;
     Ice::ShortSeq seq3;

--- a/csharp/test/Ice/stream/AllTests.cs
+++ b/csharp/test/Ice/stream/AllTests.cs
@@ -260,7 +260,7 @@ namespace Ice
 
                 {
                     outS = new Ice.OutputStream(communicator);
-                    var s = new Test.SmallStruct();
+                    var s = new Test.LargeStruct();
                     s.bo = true;
                     s.by = 1;
                     s.sh = 2;
@@ -271,9 +271,9 @@ namespace Ice
                     s.str = "7";
                     s.e = Test.MyEnum.enum2;
                     s.p = Test.MyInterfacePrxHelper.uncheckedCast(communicator.stringToProxy("test:default"));
-                    Test.SmallStruct.ice_write(outS, s);
+                    Test.LargeStruct.ice_write(outS, s);
                     var data = outS.finished();
-                    var s2 = Test.SmallStruct.ice_read(new Ice.InputStream(communicator, data));
+                    var s2 = Test.LargeStruct.ice_read(new Ice.InputStream(communicator, data));
                     test(s2.Equals(s));
                 }
 
@@ -500,20 +500,20 @@ namespace Ice
                     test(Compare(arr2S, arrS));
                 }
 
-                var smallStructArray = new Test.SmallStruct[3];
-                for (int i = 0; i < smallStructArray.Length; ++i)
+                var largeStructArray = new Test.LargeStruct[3];
+                for (int i = 0; i < largeStructArray.Length; ++i)
                 {
-                    smallStructArray[i] = new Test.SmallStruct();
-                    smallStructArray[i].bo = true;
-                    smallStructArray[i].by = 1;
-                    smallStructArray[i].sh = 2;
-                    smallStructArray[i].i = 3;
-                    smallStructArray[i].l = 4;
-                    smallStructArray[i].f = 5.0f;
-                    smallStructArray[i].d = 6.0;
-                    smallStructArray[i].str = "7";
-                    smallStructArray[i].e = Test.MyEnum.enum2;
-                    smallStructArray[i].p = Test.MyInterfacePrxHelper.uncheckedCast(communicator.stringToProxy("test:default"));
+                    largeStructArray[i] = new Test.LargeStruct();
+                    largeStructArray[i].bo = true;
+                    largeStructArray[i].by = 1;
+                    largeStructArray[i].sh = 2;
+                    largeStructArray[i].i = 3;
+                    largeStructArray[i].l = 4;
+                    largeStructArray[i].f = 5.0f;
+                    largeStructArray[i].d = 6.0;
+                    largeStructArray[i].str = "7";
+                    largeStructArray[i].e = Test.MyEnum.enum2;
+                    largeStructArray[i].p = Test.MyInterfacePrxHelper.uncheckedCast(communicator.stringToProxy("test:default"));
                 }
 
                 var myClassArray = new Test.MyClass[4];
@@ -522,7 +522,7 @@ namespace Ice
                     myClassArray[i] = new Test.MyClass();
                     myClassArray[i].c = myClassArray[i];
                     myClassArray[i].o = myClassArray[i];
-                    myClassArray[i].s = new Test.SmallStruct();
+                    myClassArray[i].s = new Test.LargeStruct();
                     myClassArray[i].s.e = Test.MyEnum.enum2;
                     myClassArray[i].seq1 = new bool[] { true, false, true, false };
                     myClassArray[i].seq2 = new byte[] { 1, 2, 3, 4 };
@@ -608,7 +608,7 @@ namespace Ice
                 {
                     outS = new Ice.OutputStream(communicator);
                     var obj = new Test.MyClass();
-                    obj.s = new Test.SmallStruct();
+                    obj.s = new Test.LargeStruct();
                     obj.s.e = Test.MyEnum.enum2;
                     var writer = new TestValueWriter(obj);
                     outS.writeValue(writer);
@@ -636,7 +636,7 @@ namespace Ice
                     var c = new Test.MyClass();
                     c.c = c;
                     c.o = c;
-                    c.s = new Test.SmallStruct();
+                    c.s = new Test.LargeStruct();
                     c.s.e = Test.MyEnum.enum2;
                     c.seq1 = new bool[] { true, false, true, false };
                     c.seq2 = new byte[] { 1, 2, 3, 4 };
@@ -732,11 +732,11 @@ namespace Ice
                 {
                     var dict = new Dictionary<string, Test.MyClass>();
                     var c = new Test.MyClass();
-                    c.s = new Test.SmallStruct();
+                    c.s = new Test.LargeStruct();
                     c.s.e = Test.MyEnum.enum2;
                     dict.Add("key1", c);
                     c = new Test.MyClass();
-                    c.s = new Test.SmallStruct();
+                    c.s = new Test.LargeStruct();
                     c.s.e = Test.MyEnum.enum3;
                     dict.Add("key2", c);
                     outS = new Ice.OutputStream(communicator);
@@ -786,15 +786,15 @@ namespace Ice
 
                 {
                     outS = new Ice.OutputStream(communicator);
-                    var l = new List<Test.SmallStruct>(smallStructArray);
-                    Test.SmallStructListHelper.write(outS, l);
+                    var l = new List<Test.LargeStruct>(largeStructArray);
+                    Test.LargeStructListHelper.write(outS, l);
                     var data = outS.finished();
                     inS = new Ice.InputStream(communicator, data);
-                    var l2 = Test.SmallStructListHelper.read(inS);
+                    var l2 = Test.LargeStructListHelper.read(inS);
                     test(l2.Count == l.Count);
                     for (int i = 0; i < l2.Count; ++i)
                     {
-                        test(l2[i].Equals(smallStructArray[i]));
+                        test(l2[i].Equals(largeStructArray[i]));
                     }
                 }
 
@@ -875,11 +875,11 @@ namespace Ice
 
                 {
                     outS = new Ice.OutputStream(communicator);
-                    var l = new LinkedList<Test.SmallStruct>(smallStructArray);
-                    Test.SmallStructLinkedListHelper.write(outS, l);
+                    var l = new LinkedList<Test.LargeStruct>(largeStructArray);
+                    Test.LargeStructLinkedListHelper.write(outS, l);
                     var data = outS.finished();
                     inS = new Ice.InputStream(communicator, data);
-                    var l2 = Test.SmallStructLinkedListHelper.read(inS);
+                    var l2 = Test.LargeStructLinkedListHelper.read(inS);
                     test(l2.Count == l.Count);
                     var e = l.GetEnumerator();
                     var e2 = l2.GetEnumerator();
@@ -913,11 +913,11 @@ namespace Ice
 
                 {
                     outS = new Ice.OutputStream(communicator);
-                    var l = new Stack<Test.SmallStruct>(smallStructArray);
-                    Test.SmallStructStackHelper.write(outS, l);
+                    var l = new Stack<Test.LargeStruct>(largeStructArray);
+                    Test.LargeStructStackHelper.write(outS, l);
                     byte[] data = outS.finished();
                     inS = new Ice.InputStream(communicator, data);
-                    var l2 = Test.SmallStructStackHelper.read(inS);
+                    var l2 = Test.LargeStructStackHelper.read(inS);
                     test(l2.Count == l.Count);
                     var e = l.GetEnumerator();
                     var e2 = l2.GetEnumerator();
@@ -964,11 +964,11 @@ namespace Ice
 
                 {
                     outS = new Ice.OutputStream(communicator);
-                    var l = new Queue<Test.SmallStruct>(smallStructArray);
-                    Test.SmallStructQueueHelper.write(outS, l);
+                    var l = new Queue<Test.LargeStruct>(largeStructArray);
+                    Test.LargeStructQueueHelper.write(outS, l);
                     var data = outS.finished();
                     inS = new Ice.InputStream(communicator, data);
-                    var l2 = Test.SmallStructQueueHelper.read(inS);
+                    var l2 = Test.LargeStructQueueHelper.read(inS);
                     test(l2.Count == l.Count);
                     var e = l.GetEnumerator();
                     var e2 = l2.GetEnumerator();

--- a/csharp/test/Ice/stream/Test.ice
+++ b/csharp/test/Ice/stream/Test.ice
@@ -25,7 +25,7 @@ enum MyEnum
 class MyClass;
 interface MyInterface;
 
-struct SmallStruct
+struct LargeStruct
 {
     bool bo;
     byte by;
@@ -74,7 +74,7 @@ sequence<byte> ByteList;
 ["cs:generic:List"]
 sequence<MyEnum> MyEnumList;
 ["cs:generic:List"]
-sequence<SmallStruct> SmallStructList;
+sequence<LargeStruct> LargeStructList;
 ["cs:generic:List"]
 sequence<MyClass> MyClassList;
 ["cs:generic:List"]
@@ -87,14 +87,14 @@ sequence<int> IntLinkedList;
 ["cs:generic:LinkedList"]
 sequence<MyEnum> MyEnumLinkedList;
 ["cs:generic:LinkedList"]
-sequence<SmallStruct> SmallStructLinkedList;
+sequence<LargeStruct> LargeStructLinkedList;
 
 ["cs:generic:Stack"]
 sequence<long> LongStack;
 ["cs:generic:Stack"]
 sequence<float> FloatStack;
 ["cs:generic:Stack"]
-sequence<SmallStruct> SmallStructStack;
+sequence<LargeStruct> LargeStructStack;
 ["cs:generic:Stack"]
 sequence<MyInterface*> MyInterfaceProxyStack;
 
@@ -119,7 +119,7 @@ sequence<double> DoubleQueue;
 ["cs:generic:Queue"]
 sequence<string> StringQueue;
 ["cs:generic:Queue"]
-sequence<SmallStruct> SmallStructQueue;
+sequence<LargeStruct> LargeStructQueue;
 
 ["cs:generic:List"]
 sequence<Ice::StringSeq> StringSList;
@@ -133,7 +133,7 @@ class MyClass
 {
     MyClass c;
     Object o;
-    SmallStruct s;
+    LargeStruct s;
     Ice::BoolSeq seq1;
     Ice::ByteSeq seq2;
     Ice::ShortSeq seq3;

--- a/java/test/src/main/java/test/Ice/stream/Client.java
+++ b/java/test/src/main/java/test/Ice/stream/Client.java
@@ -195,7 +195,7 @@ public class Client extends test.TestHelper {
 
       {
         out = new OutputStream(communicator);
-        SmallStruct s = new SmallStruct();
+        LargeStruct s = new LargeStruct();
         s.bo = true;
         s.by = (byte) 1;
         s.sh = (short) 2;
@@ -206,10 +206,10 @@ public class Client extends test.TestHelper {
         s.str = "7";
         s.e = MyEnum.enum2;
         s.p = MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test:default"));
-        SmallStruct.ice_write(out, s);
+        LargeStruct.ice_write(out, s);
         byte[] data = out.finished();
         in = new InputStream(communicator, data);
-        SmallStruct s2 = SmallStruct.ice_read(in);
+        LargeStruct s2 = LargeStruct.ice_read(in);
         test(s2.equals(s));
       }
 
@@ -440,7 +440,7 @@ public class Client extends test.TestHelper {
           arr[i] = new MyClass();
           arr[i].c = arr[i];
           arr[i].o = arr[i];
-          arr[i].s = new SmallStruct();
+          arr[i].s = new LargeStruct();
           arr[i].s.e = MyEnum.enum2;
           arr[i].seq1 = new boolean[] {true, false, true, false};
           arr[i].seq2 = new byte[] {(byte) 1, (byte) 2, (byte) 3, (byte) 4};
@@ -515,7 +515,7 @@ public class Client extends test.TestHelper {
       {
         out = new OutputStream(communicator);
         MyClass obj = new MyClass();
-        obj.s = new SmallStruct();
+        obj.s = new LargeStruct();
         obj.s.e = MyEnum.enum2;
         TestObjectWriter writer = new TestObjectWriter(obj);
         out.writeValue(writer);
@@ -527,7 +527,7 @@ public class Client extends test.TestHelper {
       {
         out = new OutputStream(communicator);
         MyClass obj = new MyClass();
-        obj.s = new SmallStruct();
+        obj.s = new LargeStruct();
         obj.s.e = MyEnum.enum2;
         TestObjectWriter writer = new TestObjectWriter(obj);
         out.writeValue(writer);
@@ -554,7 +554,7 @@ public class Client extends test.TestHelper {
         MyClass c = new MyClass();
         c.c = c;
         c.o = c;
-        c.s = new SmallStruct();
+        c.s = new LargeStruct();
         c.s.e = MyEnum.enum2;
         c.seq1 = new boolean[] {true, false, true, false};
         c.seq2 = new byte[] {(byte) 1, (byte) 2, (byte) 3, (byte) 4};
@@ -646,11 +646,11 @@ public class Client extends test.TestHelper {
         java.util.Map<String, MyClass> dict = new java.util.HashMap<>();
         MyClass c;
         c = new MyClass();
-        c.s = new SmallStruct();
+        c.s = new LargeStruct();
         c.s.e = MyEnum.enum2;
         dict.put("key1", c);
         c = new MyClass();
-        c.s = new SmallStruct();
+        c.s = new LargeStruct();
         c.s.e = MyEnum.enum3;
         dict.put("key2", c);
         out = new OutputStream(communicator);

--- a/java/test/src/main/java/test/Ice/stream/Test.ice
+++ b/java/test/src/main/java/test/Ice/stream/Test.ice
@@ -22,7 +22,7 @@ interface MyInterface;
 
 ["java:serializable:test.Ice.stream.Serialize.Small"] sequence<byte> SerialSmall;
 
-struct SmallStruct
+struct LargeStruct
 {
     bool bo;
     byte by;
@@ -55,7 +55,7 @@ class OptionalClass
     byte by;
     optional(1) short sh;
     optional(2) int i;
-    optional(3) SmallStruct sm;
+    optional(3) LargeStruct s;
 
     optional(4) MyEnumS enumS4;
 
@@ -90,7 +90,7 @@ class MyClass
     MyClass c;
     MyInterface* prx;
     Object o;
-    SmallStruct s;
+    LargeStruct s;
     Ice::BoolSeq seq1;
     Ice::ByteSeq seq2;
     Ice::ShortSeq seq3;

--- a/js/test/Ice/stream/Client.js
+++ b/js/test/Ice/stream/Client.js
@@ -148,7 +148,7 @@
 
             {
                 outS = new Ice.OutputStream(communicator);
-                const s = new Test.SmallStruct();
+                const s = new Test.LargeStruct();
                 s.bo = true;
                 s.by = 1;
                 s.sh = 2;
@@ -159,9 +159,9 @@
                 s.str = "7";
                 s.e = Test.MyEnum.enum2;
                 s.p = Test.MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test:default"));
-                Test.SmallStruct.write(outS, s);
+                Test.LargeStruct.write(outS, s);
                 const data = outS.finished();
-                const s2 = Test.SmallStruct.read(new Ice.InputStream(communicator, data));
+                const s2 = Test.LargeStruct.read(new Ice.InputStream(communicator, data));
                 test(s2.equals(s));
             }
 
@@ -384,10 +384,10 @@
                 test(Ice.ArrayUtil.equals(arr2S, arrS));
             }
 
-            const smallStructArray = [];
+            const largeStructArray = [];
             for(let i = 0; i < 3; ++i)
             {
-                const s = new Test.SmallStruct();
+                const s = new Test.LargeStruct();
                 s.bo = true;
                 s.by = 1;
                 s.sh = 2;
@@ -398,7 +398,7 @@
                 s.str = "7";
                 s.e = Test.MyEnum.enum2;
                 s.p = Test.MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test:default"));
-                smallStructArray[i] = s;
+                largeStructArray[i] = s;
             }
 
             const myClassArray = [];
@@ -408,7 +408,7 @@
                 myClassArray[i] = c;
                 c.c = myClassArray[i];
                 c.o = myClassArray[i];
-                c.s = new Test.SmallStruct();
+                c.s = new Test.LargeStruct();
                 c.s.e = Test.MyEnum.enum2;
                 c.seq1 = [true, false, true, false];
                 c.seq2 = new Uint8Array([1, 2, 3, 4]);
@@ -475,7 +475,7 @@
                 const c = new Test.MyClass();
                 c.c = c;
                 c.o = c;
-                c.s = new Test.SmallStruct();
+                c.s = new Test.LargeStruct();
                 c.s.e = Test.MyEnum.enum2;
                 c.seq1 = [true, false, true, false];
                 c.seq2 = new Uint8Array([1, 2, 3, 4]);
@@ -570,11 +570,11 @@
             {
                 const dict = new Test.StringMyClassD();
                 let c = new Test.MyClass();
-                c.s = new Test.SmallStruct();
+                c.s = new Test.LargeStruct();
                 c.s.e = Test.MyEnum.enum2;
                 dict.set("key1", c);
                 c = new Test.MyClass();
-                c.s = new Test.SmallStruct();
+                c.s = new Test.LargeStruct();
                 c.s.e = Test.MyEnum.enum3;
                 dict.set("key2", c);
                 outS = new Ice.OutputStream(communicator);

--- a/js/test/Ice/stream/Test.ice
+++ b/js/test/Ice/stream/Test.ice
@@ -24,7 +24,7 @@ enum MyEnum
 class MyClass;
 interface MyInterface;
 
-struct SmallStruct
+struct LargeStruct
 {
     bool bo;
     byte by;
@@ -70,7 +70,7 @@ class MyClass
 {
     MyClass c;
     Object o;
-    SmallStruct s;
+    LargeStruct s;
     Ice::BoolSeq seq1;
     Ice::ByteSeq seq2;
     Ice::ShortSeq seq3;

--- a/js/test/typescript/Ice/stream/Client.ts
+++ b/js/test/typescript/Ice/stream/Client.ts
@@ -145,7 +145,7 @@ export class Client extends TestHelper
 
         {
             outS = new Ice.OutputStream(communicator);
-            const s = new Test.SmallStruct();
+            const s = new Test.LargeStruct();
             s.bo = true;
             s.by = 1;
             s.sh = 2;
@@ -156,9 +156,9 @@ export class Client extends TestHelper
             s.str = "7";
             s.e = Test.MyEnum.enum2;
             s.p = Test.MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test:default"));
-            Test.SmallStruct.write(outS, s);
+            Test.LargeStruct.write(outS, s);
             const data = outS.finished();
-            const s2 = Test.SmallStruct.read(new Ice.InputStream(communicator, data));
+            const s2 = Test.LargeStruct.read(new Ice.InputStream(communicator, data));
             test(s2.equals(s));
         }
 
@@ -381,10 +381,10 @@ export class Client extends TestHelper
             test(Ice.ArrayUtil.equals(arr2S, arrS));
         }
 
-        const smallStructArray = [];
+        const largeStructArray = [];
         for(let i = 0; i < 3; ++i)
         {
-            const s = new Test.SmallStruct();
+            const s = new Test.LargeStruct();
             s.bo = true;
             s.by = 1;
             s.sh = 2;
@@ -395,7 +395,7 @@ export class Client extends TestHelper
             s.str = "7";
             s.e = Test.MyEnum.enum2;
             s.p = Test.MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test:default"));
-            smallStructArray[i] = s;
+            largeStructArray[i] = s;
         }
 
         const myClassArray = [];
@@ -405,7 +405,7 @@ export class Client extends TestHelper
             myClassArray[i] = c;
             c.c = myClassArray[i];
             c.o = myClassArray[i];
-            c.s = new Test.SmallStruct();
+            c.s = new Test.LargeStruct();
             c.s.e = Test.MyEnum.enum2;
             c.seq1 = [true, false, true, false];
             c.seq2 = new Uint8Array([1, 2, 3, 4]);
@@ -472,7 +472,7 @@ export class Client extends TestHelper
             const c = new Test.MyClass();
             c.c = c;
             c.o = c;
-            c.s = new Test.SmallStruct();
+            c.s = new Test.LargeStruct();
             c.s.e = Test.MyEnum.enum2;
             c.seq1 = [true, false, true, false];
             c.seq2 = new Uint8Array([1, 2, 3, 4]);
@@ -567,11 +567,11 @@ export class Client extends TestHelper
         {
             const dict = new Test.StringMyClassD();
             let c = new Test.MyClass();
-            c.s = new Test.SmallStruct();
+            c.s = new Test.LargeStruct();
             c.s.e = Test.MyEnum.enum2;
             dict.set("key1", c);
             c = new Test.MyClass();
-            c.s = new Test.SmallStruct();
+            c.s = new Test.LargeStruct();
             c.s.e = Test.MyEnum.enum3;
             dict.set("key2", c);
             outS = new Ice.OutputStream(communicator);

--- a/js/test/typescript/Ice/stream/Test.ice
+++ b/js/test/typescript/Ice/stream/Test.ice
@@ -24,7 +24,7 @@ enum MyEnum
 class MyClass;
 interface MyInterface;
 
-struct SmallStruct
+struct LargeStruct
 {
     bool bo;
     byte by;
@@ -70,7 +70,7 @@ class MyClass
 {
     MyClass c;
     Object o;
-    SmallStruct s;
+    LargeStruct s;
     Ice::BoolSeq seq1;
     Ice::ByteSeq seq2;
     Ice::ShortSeq seq3;

--- a/swift/test/Ice/stream/Client.swift
+++ b/swift/test/Ice/stream/Client.swift
@@ -144,7 +144,7 @@ public class Client: TestHelperI {
 
         do {
             outS = Ice.OutputStream(communicator: communicator)
-            var s = SmallStruct()
+            var s = LargeStruct()
             s.bo = true
             s.by = 1
             s.sh = 2
@@ -160,7 +160,7 @@ public class Client: TestHelperI {
             outS.write(s)
             let data = outS.finished()
             inS = Ice.InputStream(communicator: communicator, bytes: data)
-            let s2: SmallStruct = try inS.read()
+            let s2: LargeStruct = try inS.read()
             try test(s2.bo == true)
             try test(s2.by == 1)
             try test(s2.sh == 2)
@@ -382,19 +382,19 @@ public class Client: TestHelperI {
             try test(arr2S == arrS)
         }
 
-        var smallStructArray = [SmallStruct]()
+        var largeStructArray = [LargeStruct]()
         for i in 0..<3 {
-            smallStructArray.append(SmallStruct())
-            smallStructArray[i].bo = true
-            smallStructArray[i].by = 1
-            smallStructArray[i].sh = 2
-            smallStructArray[i].i = 3
-            smallStructArray[i].l = 4
-            smallStructArray[i].f = 5.0
-            smallStructArray[i].d = 6.0
-            smallStructArray[i].str = "7"
-            smallStructArray[i].e = MyEnum.enum2
-            smallStructArray[i].p = try uncheckedCast(
+            largeStructArray.append(LargeStruct())
+            largeStructArray[i].bo = true
+            largeStructArray[i].by = 1
+            largeStructArray[i].sh = 2
+            largeStructArray[i].i = 3
+            largeStructArray[i].l = 4
+            largeStructArray[i].f = 5.0
+            largeStructArray[i].d = 6.0
+            largeStructArray[i].str = "7"
+            largeStructArray[i].e = MyEnum.enum2
+            largeStructArray[i].p = try uncheckedCast(
                 prx: communicator.stringToProxy("test:default")!,
                 type: MyInterfacePrx.self)
         }
@@ -404,7 +404,7 @@ public class Client: TestHelperI {
             myClassArray.append(MyClass())
             myClassArray[i].c = myClassArray[i]
             myClassArray[i].o = myClassArray[i]
-            myClassArray[i].s = SmallStruct()
+            myClassArray[i].s = LargeStruct()
             myClassArray[i].s.e = MyEnum.enum2
             myClassArray[i].seq1 = [true, false, true, false]
             myClassArray[i].seq2 = ByteSeq([1, 2, 3, 4])
@@ -548,11 +548,11 @@ public class Client: TestHelperI {
         do {
             var dict = StringMyClassD()
             var c = MyClass()
-            c.s = SmallStruct()
+            c.s = LargeStruct()
             c.s.e = MyEnum.enum2
             dict["key1"] = c
             c = MyClass()
-            c.s = SmallStruct()
+            c.s = LargeStruct()
             c.s.e = MyEnum.enum3
             dict["key2"] = c
             outS = Ice.OutputStream(communicator: communicator)

--- a/swift/test/Ice/stream/Test.ice
+++ b/swift/test/Ice/stream/Test.ice
@@ -25,7 +25,7 @@ enum MyEnum
 interface MyInterface;
 class MyClass;
 
-struct SmallStruct
+struct LargeStruct
 {
     bool bo;
     byte by;
@@ -48,7 +48,7 @@ class OptionalClass
 }
 
 sequence<MyEnum> MyEnumS;
-sequence<SmallStruct> SmallStructS;
+sequence<LargeStruct> LargeStructS;
 sequence<MyClass> MyClassS;
 
 sequence<Ice::BoolSeq> BoolSS;
@@ -60,7 +60,7 @@ sequence<Ice::FloatSeq> FloatSS;
 sequence<Ice::DoubleSeq> DoubleSS;
 sequence<Ice::StringSeq> StringSS;
 sequence<MyEnumS> MyEnumSS;
-sequence<SmallStructS> SmallStructSS;
+sequence<LargeStructS> LargeStructSS;
 sequence<MyClassS> MyClassSS;
 
 dictionary<byte, bool> ByteBoolD;
@@ -73,7 +73,7 @@ class MyClass
 {
     MyClass c;
     Object o;
-    SmallStruct s;
+    LargeStruct s;
     Ice::BoolSeq seq1;
     Ice::ByteSeq seq2;
     Ice::ShortSeq seq3;


### PR DESCRIPTION
#2211 off-handedly renamed one of our structs in the Ice/stream test from `SmallStruct` to `LargeStruct`.
We decided to spin that change off into it's own PR. That's what this PR is.

While these terms are ultimately relative, this struct has 11 fields, whereas in every other test we use the name `SmallStruct` it contains a single field, usually a single `byte`. So relative to our other structs, it's actually fairly large.

I was motivated to change the name because when removing optional classes, I completely skipped over this type:
"there's no way a small struct would hold a class" (it did).

----

For some reason the Java version of this test is out of parity with all the others...
I'm not sure why, but I didn't want to tackle it in this PR.