### PR TITLE
Remove Redundant Virtual Implementations from the Compiler

### DIFF
--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -994,11 +994,6 @@ Slice::Gen::MetaDataVisitor::visitModuleStart(const ModulePtr& p)
 }
 
 void
-Slice::Gen::MetaDataVisitor::visitModuleEnd(const ModulePtr&)
-{
-}
-
-void
 Slice::Gen::MetaDataVisitor::visitClassDecl(const ClassDeclPtr& p)
 {
     StringList metaData = validate(p, p->getMetaData(), p->file(), p->line());
@@ -1013,11 +1008,6 @@ Slice::Gen::MetaDataVisitor::visitClassDefStart(const ClassDefPtr& p)
     return true;
 }
 
-void
-Slice::Gen::MetaDataVisitor::visitClassDefEnd(const ClassDefPtr&)
-{
-}
-
 bool
 Slice::Gen::MetaDataVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
@@ -1026,22 +1016,12 @@ Slice::Gen::MetaDataVisitor::visitExceptionStart(const ExceptionPtr& p)
     return true;
 }
 
-void
-Slice::Gen::MetaDataVisitor::visitExceptionEnd(const ExceptionPtr&)
-{
-}
-
 bool
 Slice::Gen::MetaDataVisitor::visitStructStart(const StructPtr& p)
 {
     StringList metaData = validate(p, p->getMetaData(), p->file(), p->line());
     p->setMetaData(metaData);
     return true;
-}
-
-void
-Slice::Gen::MetaDataVisitor::visitStructEnd(const StructPtr&)
-{
 }
 
 void

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -210,14 +210,10 @@ namespace Slice
         public:
             bool visitUnitStart(const UnitPtr&) final;
             bool visitModuleStart(const ModulePtr&) final;
-            void visitModuleEnd(const ModulePtr&) final;
             void visitClassDecl(const ClassDeclPtr&) final;
             bool visitClassDefStart(const ClassDefPtr&) final;
-            void visitClassDefEnd(const ClassDefPtr&) final;
             bool visitExceptionStart(const ExceptionPtr&) final;
-            void visitExceptionEnd(const ExceptionPtr&) final;
             bool visitStructStart(const StructPtr&) final;
-            void visitStructEnd(const StructPtr&) final;
             void visitOperation(const OperationPtr&) final;
             void visitDataMember(const DataMemberPtr&) final;
             void visitSequence(const SequencePtr&) final;

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -2052,11 +2052,6 @@ Slice::CsGenerator::MetaDataVisitor::visitModuleStart(const ModulePtr& p)
 }
 
 void
-Slice::CsGenerator::MetaDataVisitor::visitModuleEnd(const ModulePtr&)
-{
-}
-
-void
 Slice::CsGenerator::MetaDataVisitor::visitClassDecl(const ClassDeclPtr& p)
 {
     validate(p);
@@ -2069,11 +2064,6 @@ Slice::CsGenerator::MetaDataVisitor::visitClassDefStart(const ClassDefPtr& p)
     return true;
 }
 
-void
-Slice::CsGenerator::MetaDataVisitor::visitClassDefEnd(const ClassDefPtr&)
-{
-}
-
 bool
 Slice::CsGenerator::MetaDataVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
@@ -2081,21 +2071,11 @@ Slice::CsGenerator::MetaDataVisitor::visitExceptionStart(const ExceptionPtr& p)
     return true;
 }
 
-void
-Slice::CsGenerator::MetaDataVisitor::visitExceptionEnd(const ExceptionPtr&)
-{
-}
-
 bool
 Slice::CsGenerator::MetaDataVisitor::visitStructStart(const StructPtr& p)
 {
     validate(p);
     return true;
-}
-
-void
-Slice::CsGenerator::MetaDataVisitor::visitStructEnd(const StructPtr&)
-{
 }
 
 void

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -117,14 +117,10 @@ namespace Slice
         public:
             virtual bool visitUnitStart(const UnitPtr&);
             virtual bool visitModuleStart(const ModulePtr&);
-            virtual void visitModuleEnd(const ModulePtr&);
             virtual void visitClassDecl(const ClassDeclPtr&);
             virtual bool visitClassDefStart(const ClassDefPtr&);
-            virtual void visitClassDefEnd(const ClassDefPtr&);
             virtual bool visitExceptionStart(const ExceptionPtr&);
-            virtual void visitExceptionEnd(const ExceptionPtr&);
             virtual bool visitStructStart(const StructPtr&);
-            virtual void visitStructEnd(const StructPtr&);
             virtual void visitOperation(const OperationPtr&);
             virtual void visitParamDecl(const ParamDeclPtr&);
             virtual void visitDataMember(const DataMemberPtr&);

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -1264,11 +1264,6 @@ Slice::Gen::TypesVisitor::visitModuleStart(const ModulePtr& p)
     return true;
 }
 
-void
-Slice::Gen::TypesVisitor::visitModuleEnd(const ModulePtr&)
-{
-}
-
 bool
 Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 {

--- a/cpp/src/slice2js/Gen.h
+++ b/cpp/src/slice2js/Gen.h
@@ -97,7 +97,6 @@ namespace Slice
             TypesVisitor(::IceUtilInternal::Output&, std::vector<std::string>, bool);
 
             virtual bool visitModuleStart(const ModulePtr&);
-            virtual void visitModuleEnd(const ModulePtr&);
             virtual bool visitClassDefStart(const ClassDefPtr&);
             virtual bool visitInterfaceDefStart(const InterfaceDefPtr&);
             virtual bool visitExceptionStart(const ExceptionPtr&);

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -1087,11 +1087,6 @@ Gen::ProxyVisitor::visitModuleStart(const ModulePtr& p)
     return p->hasInterfaceDefs();
 }
 
-void
-Gen::ProxyVisitor::visitModuleEnd(const ModulePtr&)
-{
-}
-
 bool
 Gen::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
@@ -1425,23 +1420,7 @@ Gen::ValueVisitor::visitClassDefEnd(const ClassDefPtr&)
     out << eb;
 }
 
-void
-Gen::ValueVisitor::visitOperation(const OperationPtr&)
-{
-}
-
 Gen::ObjectVisitor::ObjectVisitor(::IceUtilInternal::Output& o) : out(o) {}
-
-bool
-Gen::ObjectVisitor::visitModuleStart(const ModulePtr&)
-{
-    return true;
-}
-
-void
-Gen::ObjectVisitor::visitModuleEnd(const ModulePtr&)
-{
-}
 
 bool
 Gen::ObjectVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
@@ -1615,17 +1594,6 @@ Gen::ObjectVisitor::visitOperation(const OperationPtr& op)
 }
 
 Gen::ObjectExtVisitor::ObjectExtVisitor(::IceUtilInternal::Output& o) : out(o) {}
-
-bool
-Gen::ObjectExtVisitor::visitModuleStart(const ModulePtr&)
-{
-    return true;
-}
-
-void
-Gen::ObjectExtVisitor::visitModuleEnd(const ModulePtr&)
-{
-}
 
 bool
 Gen::ObjectExtVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)

--- a/cpp/src/slice2swift/Gen.h
+++ b/cpp/src/slice2swift/Gen.h
@@ -78,7 +78,6 @@ namespace Slice
             ProxyVisitor(::IceUtilInternal::Output&);
 
             virtual bool visitModuleStart(const ModulePtr&);
-            virtual void visitModuleEnd(const ModulePtr&);
             virtual bool visitInterfaceDefStart(const InterfaceDefPtr&);
             virtual void visitInterfaceDefEnd(const InterfaceDefPtr&);
             virtual void visitOperation(const OperationPtr&);
@@ -94,7 +93,6 @@ namespace Slice
 
             virtual bool visitClassDefStart(const ClassDefPtr&);
             virtual void visitClassDefEnd(const ClassDefPtr&);
-            virtual void visitOperation(const OperationPtr&);
 
         private:
             IceUtilInternal::Output& out;
@@ -105,8 +103,6 @@ namespace Slice
         public:
             ObjectVisitor(::IceUtilInternal::Output&);
 
-            virtual bool visitModuleStart(const ModulePtr&);
-            virtual void visitModuleEnd(const ModulePtr&);
             virtual bool visitInterfaceDefStart(const InterfaceDefPtr&);
             virtual void visitInterfaceDefEnd(const InterfaceDefPtr&);
             virtual void visitOperation(const OperationPtr&);
@@ -120,8 +116,6 @@ namespace Slice
         public:
             ObjectExtVisitor(::IceUtilInternal::Output&);
 
-            virtual bool visitModuleStart(const ModulePtr&);
-            virtual void visitModuleEnd(const ModulePtr&);
             virtual bool visitInterfaceDefStart(const InterfaceDefPtr&);
             virtual void visitInterfaceDefEnd(const InterfaceDefPtr&);
             virtual void visitOperation(const OperationPtr&);


### PR DESCRIPTION
The base class for all these visitors (`ParserVisitor`) provides default implementations for these functions.
So overriding them with these no-op implementations is pointless.