### PR TITLE
Remove `includeOptional` Flags from Various Class-Related Functions

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -3860,11 +3860,11 @@ Slice::Exception::containedType() const
 }
 
 bool
-Slice::Exception::usesClasses(bool includeOptional) const
+Slice::Exception::usesClasses() const
 {
     for (const auto& i : dataMembers())
     {
-        if (i->type()->usesClasses() && (includeOptional || !i->optional()))
+        if (i->type()->usesClasses())
         {
             return true;
         }
@@ -3872,7 +3872,7 @@ Slice::Exception::usesClasses(bool includeOptional) const
 
     if (_base)
     {
-        return _base->usesClasses(includeOptional);
+        return _base->usesClasses();
     }
     return false;
 }
@@ -4872,11 +4872,11 @@ Slice::Operation::containedType() const
 }
 
 bool
-Slice::Operation::sendsClasses(bool includeOptional) const
+Slice::Operation::sendsClasses() const
 {
     for (const auto& i : parameters())
     {
-        if (!i->isOutParam() && i->type()->usesClasses() && (includeOptional || !i->optional()))
+        if (!i->isOutParam() && i->type()->usesClasses())
         {
             return true;
         }
@@ -4885,17 +4885,17 @@ Slice::Operation::sendsClasses(bool includeOptional) const
 }
 
 bool
-Slice::Operation::returnsClasses(bool includeOptional) const
+Slice::Operation::returnsClasses() const
 {
     TypePtr t = returnType();
-    if (t && t->usesClasses() && (includeOptional || !_returnIsOptional))
+    if (t && t->usesClasses())
     {
         return true;
     }
 
     for (const auto& i : parameters())
     {
-        if (i->isOutParam() && i->type()->usesClasses() && (includeOptional || !i->optional()))
+        if (i->isOutParam() && i->type()->usesClasses())
         {
             return true;
         }

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -691,8 +691,8 @@ namespace Slice
         ExceptionList throws() const;
         void setExceptionList(const ExceptionList&);
         virtual ContainedType containedType() const;
-        bool sendsClasses(bool) const;
-        bool returnsClasses(bool) const;
+        bool sendsClasses() const;
+        bool returnsClasses() const;
         bool returnsData() const;
         bool returnsMultipleValues() const;
         bool sendsOptionals() const;
@@ -779,7 +779,7 @@ namespace Slice
         ExceptionList allBases() const;
         virtual bool isBaseOf(const ExceptionPtr&) const;
         virtual ContainedType containedType() const;
-        bool usesClasses(bool) const;
+        bool usesClasses() const;
         bool hasDefaultValues() const;
         bool inheritsMetaData(const std::string&) const;
         bool hasBaseDataMembers() const;

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -200,7 +200,7 @@ namespace
             C << "[&](" << getUnqualified("::Ice::OutputStream*", scope) << " ostr)";
             C << sb;
             writeMarshalCode(C, inParams, nullptr);
-            if (p->sendsClasses(false))
+            if (p->sendsClasses())
             {
                 C << nl << "ostr->writePendingValues();";
             }
@@ -1938,14 +1938,14 @@ Slice::Gen::ProxyVisitor::emitOperationImpl(
 
         writeUnmarshalCode(C, outParams, p);
 
-        if (p->returnsClasses(false))
+        if (p->returnsClasses())
         {
             C << nl << "istr->readPendingValues();";
         }
         C << nl << "return v;";
         C << eb;
     }
-    else if (outParamsHasOpt || p->returnsClasses(false))
+    else if (outParamsHasOpt || p->returnsClasses())
     {
         //
         // If there's only one optional ret/out parameter, we still need to generate
@@ -1958,7 +1958,7 @@ Slice::Gen::ProxyVisitor::emitOperationImpl(
         writeAllocateCode(C, outParams, p, interfaceScope, _useWstring);
         writeUnmarshalCode(C, outParams, p);
 
-        if (p->returnsClasses(false))
+        if (p->returnsClasses())
         {
             C << nl << "istr->readPendingValues();";
         }
@@ -2224,9 +2224,9 @@ Slice::Gen::DataDefVisitor::visitExceptionStart(const ExceptionPtr& p)
     C << nl << "throw *this;";
     C << eb;
 
-    if (p->usesClasses(false))
+    if (p->usesClasses())
     {
-        if (!base || !base->usesClasses(false))
+        if (!base || !base->usesClasses())
         {
             H << sp;
             H << nl << "/// \\cond STREAM";
@@ -3073,7 +3073,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
         C << nl << "::Ice::OutputStream* ostr = &_ostr;";
         C << nl << "ostr->startEncapsulation(current.encoding, " << opFormatTypeToString(p) << ");";
         writeMarshalCode(C, outParams, p);
-        if (p->returnsClasses(false))
+        if (p->returnsClasses())
         {
             C << nl << "ostr->writePendingValues();";
         }
@@ -3130,7 +3130,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
         C << nl << "istr->startEncapsulation();";
         writeAllocateCode(C, inParams, nullptr, interfaceScope, _useWstring | TypeContext::UnmarshalParamZeroCopy);
         writeUnmarshalCode(C, inParams, nullptr);
-        if (p->sendsClasses(false))
+        if (p->sendsClasses())
         {
             C << nl << "istr->readPendingValues();";
         }
@@ -3174,7 +3174,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
                 C.inc();
                 C << sb;
                 writeMarshalCode(C, outParams, p);
-                if (p->returnsClasses(false))
+                if (p->returnsClasses())
                 {
                     C << nl << "ostr->writePendingValues();";
                 }
@@ -3208,7 +3208,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
             C << nl << "[&](::Ice::OutputStream* ostr)";
             C << sb;
             writeMarshalCode(C, outParams, p);
-            if (p->returnsClasses(false))
+            if (p->returnsClasses())
             {
                 C << nl << "ostr->writePendingValues();";
             }

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -2224,24 +2224,21 @@ Slice::Gen::DataDefVisitor::visitExceptionStart(const ExceptionPtr& p)
     C << nl << "throw *this;";
     C << eb;
 
-    if (p->usesClasses())
+    if (p->usesClasses() && !(base && base->usesClasses()))
     {
-        if (!base || !base->usesClasses())
-        {
-            H << sp;
-            H << nl << "/// \\cond STREAM";
-            H << nl << _dllMemberExport << "bool _usesClasses() const override;";
-            H << nl << "/// \\endcond";
+        H << sp;
+        H << nl << "/// \\cond STREAM";
+        H << nl << _dllMemberExport << "bool _usesClasses() const override;";
+        H << nl << "/// \\endcond";
 
-            C << sp;
-            C << nl << "/// \\cond STREAM";
-            C << nl << "bool";
-            C << nl << scoped.substr(2) << "::_usesClasses() const";
-            C << sb;
-            C << nl << "return true;";
-            C << eb;
-            C << nl << "/// \\endcond";
-        }
+        C << sp;
+        C << nl << "/// \\cond STREAM";
+        C << nl << "bool";
+        C << nl << scoped.substr(2) << "::_usesClasses() const";
+        C << sb;
+        C << nl << "return true;";
+        C << eb;
+        C << nl << "/// \\endcond";
     }
 
     if (!dataMembers.empty())

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2086,7 +2086,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
     }
     _out << eb;
 
-    if ((!base || (base && !base->usesClasses(false))) && p->usesClasses(false))
+    if ((!base || (base && !base->usesClasses())) && p->usesClasses())
     {
         _out << sp;
         emitGeneratedCodeAttribute();
@@ -2517,7 +2517,7 @@ Slice::Gen::ResultVisitor::visitOperation(const OperationPtr& p)
         _out << nl << "_ostr = Ice.CurrentExtensions.startReplyStream(current);";
         _out << nl << "_ostr.startEncapsulation(current.encoding, " << opFormatTypeToString(p) << ");";
         writeMarshalUnmarshalParams(outParams, p, true, ns, false, true, "_ostr");
-        if (p->returnsClasses(false))
+        if (p->returnsClasses())
         {
             _out << nl << "_ostr.writePendingValues();";
         }
@@ -2725,7 +2725,7 @@ Slice::Gen::DispatchAdapterVisitor::visitOperation(const OperationPtr& op)
             _out << nl << typeS << ' ' << param << (pli->type()->isClassType() ? " = null;" : ";");
         }
         writeMarshalUnmarshalParams(inParams, 0, false, ns);
-        if (op->sendsClasses(false))
+        if (op->sendsClasses())
         {
             _out << nl << "istr.readPendingValues();";
         }
@@ -2786,7 +2786,7 @@ Slice::Gen::DispatchAdapterVisitor::visitOperation(const OperationPtr& op)
             _out << nl << "static (ostr, " << resultParam << ") =>";
             _out << sb;
             writeMarshalUnmarshalParams(outParams, op, true, ns, true);
-            if (op->returnsClasses(false))
+            if (op->returnsClasses())
             {
                 _out << nl << "ostr.writePendingValues();";
             }
@@ -2828,7 +2828,7 @@ Slice::Gen::DispatchAdapterVisitor::visitOperation(const OperationPtr& op)
             _out << nl << "var ostr = Ice.CurrentExtensions.startReplyStream(request.current);";
             _out << nl << "ostr.startEncapsulation(request.current.encoding, " << opFormatTypeToString(op) << ");";
             writeMarshalUnmarshalParams(outParams, op, true, ns);
-            if (op->returnsClasses(false))
+            if (op->returnsClasses())
             {
                 _out << nl << "ostr.writePendingValues();";
             }
@@ -3095,7 +3095,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             _out << nl << "write: (Ice.OutputStream ostr) =>";
             _out << sb;
             writeMarshalUnmarshalParams(inParams, 0, true, ns);
-            if (op->sendsClasses(false))
+            if (op->sendsClasses())
             {
                 _out << nl << "ostr.writePendingValues();";
             }
@@ -3152,7 +3152,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             }
 
             writeMarshalUnmarshalParams(outParams, op, false, ns, true);
-            if (op->returnsClasses(false))
+            if (op->returnsClasses())
             {
                 _out << nl << "istr.readPendingValues();";
             }

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2086,7 +2086,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
     }
     _out << eb;
 
-    if ((!base || (base && !base->usesClasses())) && p->usesClasses())
+    if (p->usesClasses() && !(base && base->usesClasses()))
     {
         _out << sp;
         emitGeneratedCodeAttribute();

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -715,7 +715,7 @@ Slice::JavaVisitor::writeMarshaledResultType(
             op->getMetaData());
     }
 
-    if (op->returnsClasses(false))
+    if (op->returnsClasses())
     {
         out << nl << "_ostr.writePendingValues();";
     }
@@ -988,7 +988,7 @@ Slice::JavaVisitor::writeMarshalProxyParams(
             (*pli)->getMetaData());
     }
 
-    if (op->sendsClasses(false))
+    if (op->sendsClasses())
     {
         out << nl << "ostr.writePendingValues();";
     }
@@ -1006,7 +1006,7 @@ Slice::JavaVisitor::writeUnmarshalProxyResults(Output& out, const string& packag
         string resultType = getResultType(op, package, false, false);
         out << nl << resultType << ' ' << name << " = new " << resultType << "();";
         out << nl << name << ".read(istr);";
-        if (op->returnsClasses(false))
+        if (op->returnsClasses())
         {
             out << nl << "istr.readPendingValues();";
         }
@@ -1083,7 +1083,7 @@ Slice::JavaVisitor::writeUnmarshalProxyResults(Output& out, const string& packag
                 patchParams);
         }
 
-        if (op->returnsClasses(false))
+        if (op->returnsClasses())
         {
             out << nl << "istr.readPendingValues();";
         }
@@ -1140,7 +1140,7 @@ Slice::JavaVisitor::writeMarshalServantResults(
         writeMarshalUnmarshalCode(out, package, type, mode, true, tag, param, true, iter, "", metaData);
     }
 
-    if (op->returnsClasses(false))
+    if (op->returnsClasses())
     {
         out << nl << "ostr.writePendingValues();";
     }
@@ -1488,7 +1488,7 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
                     param->getMetaData(),
                     patchParams);
             }
-            if (op->sendsClasses(false))
+            if (op->sendsClasses())
             {
                 out << nl << "istr.readPendingValues();";
             }
@@ -3183,9 +3183,9 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
     }
     out << eb;
 
-    if (p->usesClasses(false))
+    if (p->usesClasses())
     {
-        if (!base || (base && !base->usesClasses(false)))
+        if (!base || (base && !base->usesClasses()))
         {
             out << sp;
             writeHiddenDocComment(out);

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -3183,18 +3183,15 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
     }
     out << eb;
 
-    if (p->usesClasses())
+    if (p->usesClasses() && !(base && base->usesClasses()))
     {
-        if (!base || (base && !base->usesClasses()))
-        {
-            out << sp;
-            writeHiddenDocComment(out);
-            out << nl << "@Override";
-            out << nl << "public boolean _usesClasses()";
-            out << sb;
-            out << nl << "return true;";
-            out << eb;
-        }
+        out << sp;
+        writeHiddenDocComment(out);
+        out << nl << "@Override";
+        out << nl << "public boolean _usesClasses()";
+        out << sb;
+        out << nl << "return true;";
+        out << eb;
     }
 
     out << sp;

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -1825,7 +1825,7 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
         _out << eb;
     }
 
-    if (p->usesClasses() && (!base || (base && !base->usesClasses())))
+    if (p->usesClasses() && !(base && base->usesClasses()))
     {
         _out << sp;
         _out << nl << "_usesClasses()";

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -1661,13 +1661,13 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             }
             _out << ", ";
 
-            if (op->sendsClasses(false))
+            if (op->sendsClasses())
             {
                 _out << "true";
             }
             _out << ", ";
 
-            if (op->returnsClasses(false))
+            if (op->returnsClasses())
             {
                 _out << "true";
             }
@@ -1825,7 +1825,7 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
         _out << eb;
     }
 
-    if (p->usesClasses(false) && (!base || (base && !base->usesClasses(false))))
+    if (p->usesClasses() && (!base || (base && !base->usesClasses())))
     {
         _out << sp;
         _out << nl << "_usesClasses()";

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -2180,7 +2180,7 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             {
                 marshal(out, "os_", r->fixedName, r->type, r->optional, r->tag);
             }
-            if (op->sendsClasses(false))
+            if (op->sendsClasses())
             {
                 out << nl << "os_.writePendingValues();";
             }
@@ -2287,7 +2287,7 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                     convertParams.push_back(*r);
                 }
             }
-            if (op->returnsClasses(false))
+            if (op->returnsClasses())
             {
                 out << nl << "is_.readPendingValues();";
             }
@@ -2343,7 +2343,7 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             {
                 marshal(out, "os_", r->fixedName, r->type, r->optional, r->tag);
             }
-            if (op->sendsClasses(false))
+            if (op->sendsClasses())
             {
                 out << nl << "os_.writePendingValues();";
             }
@@ -2414,7 +2414,7 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                 }
                 unmarshal(out, "is_", param, r->type, r->optional, r->tag);
             }
-            if (op->returnsClasses(false))
+            if (op->returnsClasses())
             {
                 out << nl << "is_.readPendingValues();";
             }
@@ -2785,7 +2785,7 @@ CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
                 string m = "obj." + q->fixedName;
                 convertValueType(out, m, m, q->dataMember->type(), q->dataMember->optional());
             }
-            if (base && base->usesClasses(true))
+            if (base && base->usesClasses())
             {
                 out << nl << "obj = icePostUnmarshal@" << getAbsolute(base) << "(obj);";
             }

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -526,7 +526,7 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     }
     out << eb;
 
-    if (p->usesClasses(false) && (!base || (base && !base->usesClasses(false))))
+    if (p->usesClasses() && (!base || (base && !base->usesClasses())))
     {
         out << sp;
         out << nl << "open override func _usesClasses() -> Swift.Bool" << sb;

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -526,7 +526,7 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     }
     out << eb;
 
-    if (p->usesClasses() && (!base || !base->usesClasses()))
+    if (p->usesClasses() && !(base && base->usesClasses()))
     {
         out << sp;
         out << nl << "open override func _usesClasses() -> Swift.Bool" << sb;

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -526,7 +526,7 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     }
     out << eb;
 
-    if (p->usesClasses() && (!base || (base && !base->usesClasses())))
+    if (p->usesClasses() && (!base || !base->usesClasses()))
     {
         out << sp;
         out << nl << "open override func _usesClasses() -> Swift.Bool" << sb;

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -2167,7 +2167,7 @@ SwiftGenerator::writeMarshalInParams(::IceUtilInternal::Output& out, const Opera
         writeMarshalUnmarshalCode(out, q->type, op, "iceP_" + q->name, true, q->tag);
     }
 
-    if (op->sendsClasses(false))
+    if (op->sendsClasses())
     {
         out << nl << "ostr.writePendingValues()";
     }
@@ -2199,7 +2199,7 @@ SwiftGenerator::writeMarshalOutParams(::IceUtilInternal::Output& out, const Oper
         writeMarshalUnmarshalCode(out, q->type, op, "iceP_" + q->name, true, q->tag);
     }
 
-    if (op->returnsClasses(false))
+    if (op->returnsClasses())
     {
         out << nl << "ostr.writePendingValues()";
     }
@@ -2232,7 +2232,7 @@ SwiftGenerator::writeMarshalAsyncOutParams(::IceUtilInternal::Output& out, const
         writeMarshalUnmarshalCode(out, q->type, op, "iceP_" + q->name, true, q->tag);
     }
 
-    if (op->returnsClasses(false))
+    if (op->returnsClasses())
     {
         out << nl << "ostr.writePendingValues()";
     }
@@ -2286,7 +2286,7 @@ SwiftGenerator::writeUnmarshalOutParams(::IceUtilInternal::Output& out, const Op
         writeMarshalUnmarshalCode(out, q->type, op, param, false, q->tag);
     }
 
-    if (op->returnsClasses(false))
+    if (op->returnsClasses())
     {
         out << nl << "try istr.readPendingValues()";
     }
@@ -2365,7 +2365,7 @@ SwiftGenerator::writeUnmarshalInParams(::IceUtilInternal::Output& out, const Ope
         writeMarshalUnmarshalCode(out, q->type, op, param, false, q->tag);
     }
 
-    if (op->sendsClasses(false))
+    if (op->sendsClasses())
     {
         out << nl << "try istr.readPendingValues()";
     }

--- a/php/src/Types.cpp
+++ b/php/src/Types.cpp
@@ -1219,10 +1219,12 @@ bool
 IcePHP::StructInfo::usesClasses() const
 {
     for (const auto& dm : members)
+    {
         if (dm->type->usesClasses())
         {
             return true;
         }
+    }
     return false;
 }
 

--- a/php/src/Types.cpp
+++ b/php/src/Types.cpp
@@ -3591,7 +3591,7 @@ ZEND_FUNCTION(IcePHP_defineException)
     ex->usesClasses = false;
 
     // Only examine the required members to see if any use classes.
-    for (const auto& dm : members)
+    for (const auto& dm : ex->members)
     {
         if (!ex->usesClasses)
         {

--- a/php/src/Types.cpp
+++ b/php/src/Types.cpp
@@ -1218,13 +1218,11 @@ IcePHP::StructInfo::optionalFormat() const
 bool
 IcePHP::StructInfo::usesClasses() const
 {
-    for (DataMemberList::const_iterator p = members.begin(); p != members.end(); ++p)
-    {
-        if ((*p)->type->usesClasses())
+    for (const auto& dm : members)
+        if (dm->type->usesClasses())
         {
             return true;
         }
-    }
     return false;
 }
 
@@ -3593,11 +3591,11 @@ ZEND_FUNCTION(IcePHP_defineException)
     ex->usesClasses = false;
 
     // Only examine the required members to see if any use classes.
-    for (DataMemberList::iterator p = ex->members.begin(); p != ex->members.end(); ++p)
+    for (const auto& dm : members)
     {
         if (!ex->usesClasses)
         {
-            ex->usesClasses = (*p)->type->usesClasses();
+            ex->usesClasses = dm->type->usesClasses();
         }
     }
 

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -794,10 +794,7 @@ IcePy::Operation::Operation(
     if (ret != Py_None)
     {
         returnType = convertParam(ret, 0);
-        if (!returnType->optional)
-        {
-            returnsClasses = returnType->type->usesClasses();
-        }
+        returnsClasses = returnType->type->usesClasses();
     }
 
     //

--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -1276,9 +1276,9 @@ IcePy::StructInfo::optionalFormat() const
 bool
 IcePy::StructInfo::usesClasses() const
 {
-    for (DataMemberList::const_iterator p = members.begin(); p != members.end(); ++p)
+    for (const auto& dm : members)
     {
-        if ((*p)->type->usesClasses())
+        if (dm->type->usesClasses())
         {
             return true;
         }
@@ -4800,11 +4800,11 @@ IcePy_defineException(PyObject*, PyObject* args)
     //
     // Only examine the required members to see if any use classes.
     //
-    for (DataMemberList::iterator p = info->members.begin(); p != info->members.end(); ++p)
+    for (const auto& dm : info->members)
     {
         if (!info->usesClasses)
         {
-            info->usesClasses = (*p)->type->usesClasses();
+            info->usesClasses = dm->type->usesClasses();
         }
     }
 

--- a/ruby/src/IceRuby/Operation.cpp
+++ b/ruby/src/IceRuby/Operation.cpp
@@ -197,10 +197,7 @@ IceRuby::OperationI::OperationI(
     if (!NIL_P(returnType))
     {
         _returnType = convertParam(returnType, 0);
-        if (!_returnType->optional)
-        {
-            _returnsClasses = _returnType->type->usesClasses();
-        }
+        _returnsClasses = _returnType->type->usesClasses();
     }
 
     //

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -967,9 +967,9 @@ IceRuby::StructInfo::optionalFormat() const
 bool
 IceRuby::StructInfo::usesClasses() const
 {
-    for (DataMemberList::const_iterator p = members.begin(); p != members.end(); ++p)
+    for (const auto& dm : members)
     {
-        if ((*p)->type->usesClasses())
+        if (dm->type->usesClasses())
         {
             return true;
         }
@@ -3011,11 +3011,11 @@ IceRuby_defineException(VALUE /*self*/, VALUE id, VALUE type, VALUE base, VALUE 
         //
         // Only examine the required members to see if any use classes.
         //
-        for (DataMemberList::iterator p = info->members.begin(); p != info->members.end(); ++p)
+        for (const auto& dm : info->members)
         {
             if (!info->usesClasses)
             {
-                info->usesClasses = (*p)->type->usesClasses();
+                info->usesClasses = dm->type->usesClasses();
             }
         }
 


### PR DESCRIPTION
Within the compiler, we have a handful of functions for determining whether something uses/sends/returns classes.
Some of these had an `includeOptional` flag which is dead now; since there's no longer any optional classes to include!

These functions were almost always called with `false` anyways. The flag was added in 493caea19fd83663eb03b4eeaf7714f99ac07b97 to fix a bug with the scripting languages.

We also had analogs of these functions in the wrapper languages. I slightly cleaned them up while I was searching around.