### PR TITLE
New makeProxy factory function in Swift

### DIFF
--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -1141,6 +1141,24 @@ Gen::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     out << eb;
 
     //
+    // makeProxy
+    //
+    out << sp;
+    out << nl << "/// Makes a new proxy from a communicator and a proxy string.";
+    out << nl << "///";
+    out << nl << "/// - Parameters:";
+    out << nl << "///    - communicator: The communicator of the new proxy.";
+    out << nl << "///    - proxyString: The proxy string to parse.";
+    out << nl << "///    - type: The type of the new proxy.";
+    out << nl << "/// - Throws: `Ice.ProxyParseException` if the proxy string is invalid.";
+    out << nl << "/// - Returns: A new proxy with the requested type.";
+    out << nl << "public func makeProxy(communicator: Ice.Communicator, proxyString: String, type: " << prx
+        << ".Protocol) throws -> " << prx;
+    out << sb;
+    out << nl << "try communicator.makeProxyImpl(proxyString) as " << prxI;
+    out << eb;
+
+    //
     // checkedCast
     //
     out << sp;

--- a/cpp/test/Ice/binding/AllTests.cpp
+++ b/cpp/test/Ice/binding/AllTests.cpp
@@ -397,7 +397,7 @@ allTests(Test::TestHelper* helper)
         int i;
 
         //
-        // Ensure that endpoints are tried in order by deactiving the adapters
+        // Ensure that endpoints are tried in order by deactivating the adapters
         // one after the other.
         //
         for (i = 0; i < nRetry && test->getAdapterName() == "Adapter31"; i++)
@@ -616,7 +616,7 @@ allTests(Test::TestHelper* helper)
         int i;
 
         //
-        // Ensure that endpoints are tried in order by deactiving the adapters
+        // Ensure that endpoints are tried in order by deactivating the adapters
         // one after the other.
         //
         for (i = 0; i < nRetry && test->getAdapterName() == "Adapter61"; i++)
@@ -707,7 +707,7 @@ allTests(Test::TestHelper* helper)
         int i;
 
         //
-        // Ensure that endpoints are tried in order by deactiving the adapters
+        // Ensure that endpoints are tried in order by deactivating the adapters
         // one after the other.
         //
         for (i = 0; i < nRetry && getAdapterNameWithAMI(test) == "AdapterAMI61"; i++)

--- a/csharp/test/Ice/binding/AllTests.cs
+++ b/csharp/test/Ice/binding/AllTests.cs
@@ -415,7 +415,7 @@ namespace Ice
                     int i;
 
                     //
-                    // Ensure that endpoints are tried in order by deactiving the adapters
+                    // Ensure that endpoints are tried in order by deactivating the adapters
                     // one after the other.
                     //
                     for (i = 0; i < nRetry && obj.getAdapterName() == "Adapter31"; i++) ;
@@ -585,7 +585,7 @@ namespace Ice
                     int i;
 
                     //
-                    // Ensure that endpoints are tried in order by deactiving the adapters
+                    // Ensure that endpoints are tried in order by deactivating the adapters
                     // one after the other.
                     //
                     for (i = 0; i < nRetry && obj.getAdapterName() == "Adapter61"; i++) ;
@@ -648,7 +648,7 @@ namespace Ice
                     int i;
 
                     //
-                    // Ensure that endpoints are tried in order by deactiving the adapters
+                    // Ensure that endpoints are tried in order by deactivating the adapters
                     // one after the other.
                     //
                     for (i = 0; i < nRetry && (await obj.getAdapterNameAsync()) == "AdapterAMI61"; i++) ;

--- a/java/test/src/main/java/test/Ice/binding/AllTests.java
+++ b/java/test/src/main/java/test/Ice/binding/AllTests.java
@@ -390,7 +390,7 @@ public class AllTests {
       int i;
 
       //
-      // Ensure that endpoints are tried in order by deactiving the adapters
+      // Ensure that endpoints are tried in order by deactivating the adapters
       // one after the other.
       //
       for (i = 0; i < nRetry && test.getAdapterName().equals("Adapter31"); i++)
@@ -566,7 +566,7 @@ public class AllTests {
       int i;
 
       //
-      // Ensure that endpoints are tried in order by deactiving the adapters
+      // Ensure that endpoints are tried in order by deactivating the adapters
       // one after the other.
       //
       for (i = 0; i < nRetry && test.getAdapterName().equals("Adapter61"); i++)
@@ -637,7 +637,7 @@ public class AllTests {
       int i;
 
       //
-      // Ensure that endpoints are tried in order by deactiving the adapters
+      // Ensure that endpoints are tried in order by deactivating the adapters
       // one after the other.
       //
       for (i = 0; i < nRetry && getAdapterNameWithAMI(test).equals("AdapterAMI61"); i++)

--- a/js/test/Ice/binding/Client.js
+++ b/js/test/Ice/binding/Client.js
@@ -356,7 +356,7 @@
                 const nRetry = 3;
 
                 //
-                // Ensure that endpoints are tried in order by deactiving the adapters
+                // Ensure that endpoints are tried in order by deactivating the adapters
                 // one after the other.
                 //
                 /* eslint-disable curly */
@@ -523,7 +523,7 @@
                 let i;
 
                 //
-                // Ensure that endpoints are tried in order by deactiving the adapters
+                // Ensure that endpoints are tried in order by deactivating the adapters
                 // one after the other.
                 //
 

--- a/js/test/typescript/Ice/binding/Client.ts
+++ b/js/test/typescript/Ice/binding/Client.ts
@@ -338,7 +338,7 @@ export class Client extends TestHelper
             const nRetry = 3;
 
             //
-            // Ensure that endpoints are tried in order by deactiving the adapters
+            // Ensure that endpoints are tried in order by deactivating the adapters
             // one after the other.
             //
             /* eslint-disable curly */
@@ -505,7 +505,7 @@ export class Client extends TestHelper
             let i;
 
             //
-            // Ensure that endpoints are tried in order by deactiving the adapters
+            // Ensure that endpoints are tried in order by deactivating the adapters
             // one after the other.
             //
 

--- a/matlab/test/Ice/binding/AllTests.m
+++ b/matlab/test/Ice/binding/AllTests.m
@@ -384,7 +384,7 @@ classdef AllTests
             assert(test.ice_getEndpointSelection() == Ice.EndpointSelectionType.Ordered);
 
             %
-            % Ensure that endpoints are tried in order by deactiving the adapters
+            % Ensure that endpoints are tried in order by deactivating the adapters
             % one after the other.
             %
             nRetry = 5;
@@ -581,7 +581,7 @@ classdef AllTests
             assert(~test.ice_isConnectionCached());
 
             %
-            % Ensure that endpoints are tried in order by deactiving the adapters
+            % Ensure that endpoints are tried in order by deactivating the adapters
             % one after the other.
             %
             nRetry = 5;
@@ -666,7 +666,7 @@ classdef AllTests
             assert(~test.ice_isConnectionCached());
 
             %
-            % Ensure that endpoints are tried in order by deactiving the adapters
+            % Ensure that endpoints are tried in order by deactivating the adapters
             % one after the other.
             %
             nRetry = 5;

--- a/php/test/Ice/binding/Client.php
+++ b/php/test/Ice/binding/Client.php
@@ -221,7 +221,7 @@ function allTests($helper)
         $nRetry = 5;
 
         //
-        // Ensure that endpoints are tried in order by deactiving the adapters
+        // Ensure that endpoints are tried in order by deactivating the adapters
         // one after the other.
         //
         for($i = 0; $i < $nRetry && $test->getAdapterName() == "Adapter31"; $i++);
@@ -358,7 +358,7 @@ function allTests($helper)
         $nRetry = 5;
 
         //
-        // Ensure that endpoints are tried in order by deactiving the adapters
+        // Ensure that endpoints are tried in order by deactivating the adapters
         // one after the other.
         //
         for($i = 0; $i < $nRetry && $test->getAdapterName() == "Adapter61"; $i++);

--- a/python/test/Ice/binding/AllTests.py
+++ b/python/test/Ice/binding/AllTests.py
@@ -487,7 +487,7 @@ def allTests(helper, communicator):
     nRetry = 5
 
     #
-    # Ensure that endpoints are tried in order by deactiving the adapters
+    # Ensure that endpoints are tried in order by deactivating the adapters
     # one after the other.
     #
     i = 0
@@ -561,7 +561,7 @@ def allTests(helper, communicator):
     nRetry = 5
 
     #
-    # Ensure that endpoints are tried in order by deactiving the adapters
+    # Ensure that endpoints are tried in order by deactivating the adapters
     # one after the other.
     #
     i = 0

--- a/ruby/test/Ice/binding/AllTests.rb
+++ b/ruby/test/Ice/binding/AllTests.rb
@@ -345,7 +345,7 @@ def allTests(helper, communicator)
     nRetry = 5
 
     #
-    # Ensure that endpoints are tried in order by deactiving the adapters
+    # Ensure that endpoints are tried in order by deactivating the adapters
     # one after the other.
     #
     i = 0

--- a/swift/src/Ice/Communicator.swift
+++ b/swift/src/Ice/Communicator.swift
@@ -255,4 +255,10 @@ public protocol Communicator: AnyObject {
     ///
     /// - returns: `Dispatch.DispatchQueue` - The dispatch queue associated wih the Communicator's server thread pool.
     func getServerDispatchQueue() throws -> Dispatch.DispatchQueue
+
+    /// Makes a new proxy. This is an internal operation used by the generated code.
+    ///
+    /// - Parameter proxyString: The stringified proxy.
+    /// - Returns: The new proxy.
+    func makeProxyImpl<ProxyImpl>(_ proxyString: String) throws -> ProxyImpl where ProxyImpl: ObjectPrxI
 }

--- a/swift/src/Ice/CommunicatorI.swift
+++ b/swift/src/Ice/CommunicatorI.swift
@@ -46,12 +46,7 @@ class CommunicatorI: LocalObject<ICECommunicator>, Communicator {
     }
 
     func stringToProxy(_ str: String) throws -> ObjectPrx? {
-        return try autoreleasepool {
-            guard let prxHandle = try handle.stringToProxy(str: str) as? ICEObjectPrx else {
-                return nil
-            }
-            return ObjectPrxI(handle: prxHandle, communicator: self)
-        }
+        try stringToProxyImpl(str)
     }
 
     func proxyToString(_ obj: ObjectPrx?) -> String {
@@ -254,6 +249,22 @@ class CommunicatorI: LocalObject<ICECommunicator>, Communicator {
     func getServerDispatchQueue() throws -> DispatchQueue {
         return try autoreleasepool {
             try handle.getServerDispatchQueue()
+        }
+    }
+
+    func makeProxyImpl<ProxyImpl>(_ proxyString: String) throws -> ProxyImpl where ProxyImpl: ObjectPrxI {
+        guard let proxy: ProxyImpl = try stringToProxyImpl(proxyString) else {
+            throw ProxyParseException(str: "Invalid empty proxy string")
+        }
+        return proxy
+    }
+
+    private func stringToProxyImpl<ProxyImpl>(_ str: String) throws -> ProxyImpl? where ProxyImpl: ObjectPrxI {
+        return try autoreleasepool {
+            guard let prxHandle = try handle.stringToProxy(str: str) as? ICEObjectPrx else {
+                return nil
+            }
+            return ProxyImpl(handle: prxHandle, communicator: self)
         }
     }
 }

--- a/swift/src/Ice/Proxy.swift
+++ b/swift/src/Ice/Proxy.swift
@@ -302,6 +302,19 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject {
     func ice_collocationOptimized(_ collocated: Bool) -> Self
 }
 
+/// Makes a new proxy from a communicator and a proxy string.
+///
+/// - Parameters:
+///    - communicator: The communicator of the new proxy.
+///    - proxyString: The proxy string to parse.
+///    - type: The type of the new proxy.
+/// - Throws: `Ice.ProxyParseException` if the proxy string is invalid.
+/// - Returns: A new proxy with the requested type.
+public func makeProxy(communicator: Ice.Communicator, proxyString: String, type: ObjectPrx.Protocol) throws -> ObjectPrx
+{
+    try communicator.makeProxyImpl(proxyString) as ObjectPrxI
+}
+
 /// Casts a proxy to `Ice.ObjectPrx`. This call contacts the server and will throw an Ice run-time exception
 /// if the target object does not exist or the server cannot be reached.
 ///
@@ -784,9 +797,8 @@ open class ObjectPrxI: ObjectPrx {
         isTwoway = impl.isTwoway
     }
 
-    func fromICEObjectPrx<ObjectPrxType>(_ h: ICEObjectPrx) -> ObjectPrxType
-    where ObjectPrxType: ObjectPrxI {
-        return ObjectPrxType(handle: h, communicator: communicator)
+    private func fromICEObjectPrx<ProxyImpl>(_ h: ICEObjectPrx) -> ProxyImpl where ProxyImpl: ObjectPrxI {
+        return ProxyImpl(handle: h, communicator: communicator)
     }
 
     static func fromICEObjectPrx(

--- a/swift/test/Ice/ami/AllTests.swift
+++ b/swift/test/Ice/ami/AllTests.swift
@@ -12,11 +12,13 @@ func allTests(_ helper: TestHelper, collocated: Bool = false) throws {
     let communicator = helper.communicator()
     let output = helper.getWriter()
 
-    var sref = "test:\(helper.getTestEndpoint(num: 0))"
-    var p = try makeProxy(communicator: communicator, proxyString: sref, type: TestIntfPrx.self)
+    var p = try makeProxy(
+        communicator: communicator, proxyString: "test:\(helper.getTestEndpoint(num: 0))", type: TestIntfPrx.self)
 
-    sref = "testController:\(helper.getTestEndpoint(num: 1))"
-    let testController = try makeProxy(communicator: communicator, proxyString: sref, type: TestIntfControllerPrx.self)
+    let testController = try makeProxy(
+        communicator: communicator,
+        proxyString: "testController:\(helper.getTestEndpoint(num: 1))",
+        type: TestIntfControllerPrx.self)
 
     output.write("testing async invocation...")
     do {

--- a/swift/test/Ice/binding/AllTests.swift
+++ b/swift/test/Ice/binding/AllTests.swift
@@ -348,7 +348,7 @@ func allTests(_ helper: TestHelper) throws {
         let nRetry = 3
 
         //
-        // Ensure that endpoints are tried in order by deactiving the adapters
+        // Ensure that endpoints are tried in order by deactivating the adapters
         // one after the other.
         //
         var i = 0

--- a/swift/test/Ice/binding/AllTests.swift
+++ b/swift/test/Ice/binding/AllTests.swift
@@ -49,6 +49,8 @@ func allTests(_ helper: TestHelper) throws {
 
         try com.deactivateObjectAdapter(adapter)
 
+        try test(test1.ice_getConnection() === test2.ice_getConnection())
+
         do {
             try test1.ice_ping()
             try test(false)

--- a/swift/test/Ice/binding/AllTests.swift
+++ b/swift/test/Ice/binding/AllTests.swift
@@ -29,8 +29,9 @@ func allTests(_ helper: TestHelper) throws {
     let communicator = helper.communicator()
     let output = helper.getWriter()
 
-    let com = try uncheckedCast(
-        prx: communicator.stringToProxy("communicator:\(helper.getTestEndpoint(num: 0))")!,
+    let com = try makeProxy(
+        communicator: communicator,
+        proxyString: "communicator:\(helper.getTestEndpoint(num: 0))",
         type: RemoteCommunicatorPrx.self)
 
     output.write("testing binding with single endpoint... ")
@@ -48,12 +49,8 @@ func allTests(_ helper: TestHelper) throws {
 
         try com.deactivateObjectAdapter(adapter)
 
-        let test3 = uncheckedCast(prx: test1, type: TestIntfPrx.self)
-        try test(test3.ice_getConnection() === test1.ice_getConnection())
-        try test(test3.ice_getConnection() === test2.ice_getConnection())
-
         do {
-            try test3.ice_ping()
+            try test1.ice_ping()
             try test(false)
         } catch is Ice.ConnectFailedException {
             // expected
@@ -318,7 +315,7 @@ func allTests(_ helper: TestHelper) throws {
             try obj.ice_getConnection()!.close(.GracefullyWithWait)
         }
 
-        obj = uncheckedCast(prx: obj.ice_endpointSelection(.Random), type: TestIntfPrx.self)
+        obj = obj.ice_endpointSelection(.Random)
         try test(obj.ice_getEndpointSelection() == .Random)
 
         names.append("Adapter21")
@@ -344,7 +341,7 @@ func allTests(_ helper: TestHelper) throws {
         ]
 
         var obj = try createTestIntfPrx(adapters)
-        obj = uncheckedCast(prx: obj.ice_endpointSelection(.Ordered), type: TestIntfPrx.self)
+        obj = obj.ice_endpointSelection(.Ordered)
         try test(obj.ice_getEndpointSelection() == .Ordered)
         let nRetry = 3
 
@@ -423,12 +420,8 @@ func allTests(_ helper: TestHelper) throws {
     do {
         let adapter = try com.createObjectAdapter(name: "Adapter41", endpoints: "default")!
 
-        let test1 = try uncheckedCast(
-            prx: adapter.getTestIntf()!.ice_connectionCached(false),
-            type: TestIntfPrx.self)
-        let test2 = try uncheckedCast(
-            prx: adapter.getTestIntf()!.ice_connectionCached(false),
-            type: TestIntfPrx.self)
+        let test1 = try adapter.getTestIntf()!.ice_connectionCached(false)
+        let test2 = try adapter.getTestIntf()!.ice_connectionCached(false)
         try test(!test1.ice_isConnectionCached())
         try test(!test2.ice_isConnectionCached())
         try test(test1.ice_getConnection() != nil && test2.ice_getConnection() != nil)
@@ -438,9 +431,8 @@ func allTests(_ helper: TestHelper) throws {
 
         try com.deactivateObjectAdapter(adapter)
 
-        let test3 = uncheckedCast(prx: test1, type: TestIntfPrx.self)
         do {
-            try test(test3.ice_getConnection() === test1.ice_getConnection())
+            _ = try test1.ice_getConnection()
             try test(false)
         } catch is Ice.ConnectFailedException {
             // expected
@@ -458,9 +450,7 @@ func allTests(_ helper: TestHelper) throws {
             com.createObjectAdapter(name: "Adapter53", endpoints: "default")!,
         ]
 
-        let obj = try uncheckedCast(
-            prx: createTestIntfPrx(adapters).ice_connectionCached(false),
-            type: TestIntfPrx.self)
+        let obj = try createTestIntfPrx(adapters).ice_connectionCached(false)
         try test(!obj.ice_isConnectionCached())
 
         var names = ["Adapter51", "Adapter52", "Adapter53"]
@@ -494,9 +484,7 @@ func allTests(_ helper: TestHelper) throws {
             com.createObjectAdapter(name: "AdapterAMI53", endpoints: "default")!,
         ]
 
-        let obj = try uncheckedCast(
-            prx: createTestIntfPrx(adapters).ice_connectionCached(false),
-            type: TestIntfPrx.self)
+        let obj = try createTestIntfPrx(adapters).ice_connectionCached(false)
         try test(!obj.ice_isConnectionCached())
 
         var names = ["AdapterAMI51", "AdapterAMI52", "AdapterAMI53"]
@@ -531,16 +519,14 @@ func allTests(_ helper: TestHelper) throws {
         ]
 
         var obj = try createTestIntfPrx(adapters)
-        obj = uncheckedCast(
-            prx: obj.ice_endpointSelection(.Ordered),
-            type: TestIntfPrx.self)
+        obj = obj.ice_endpointSelection(.Ordered)
         try test(obj.ice_getEndpointSelection() == .Ordered)
-        obj = uncheckedCast(prx: obj.ice_connectionCached(false), type: TestIntfPrx.self)
+        obj = obj.ice_connectionCached(false)
         try test(!obj.ice_isConnectionCached())
         let nRetry = 3
         var i = 0
         //
-        // Ensure that endpoints are tried in order by deactiving the adapters
+        // Ensure that endpoints are tried in order by deactivating the adapters
         // one after the other.
         //
         while try i < nRetry && obj.getAdapterName() == "Adapter61" {
@@ -616,16 +602,16 @@ func allTests(_ helper: TestHelper) throws {
         ]
 
         var obj = try createTestIntfPrx(adapters)
-        obj = uncheckedCast(prx: obj.ice_endpointSelection(.Ordered), type: TestIntfPrx.self)
+        obj = obj.ice_endpointSelection(.Ordered)
         try test(obj.ice_getEndpointSelection() == .Ordered)
-        obj = uncheckedCast(prx: obj.ice_connectionCached(false), type: TestIntfPrx.self)
+        obj = obj.ice_connectionCached(false)
         try test(!obj.ice_isConnectionCached())
 
         let nRetry = 3
         var i = 0
 
         //
-        // Ensure that endpoints are tried in order by deactiving the adapters
+        // Ensure that endpoints are tried in order by deactivating the adapters
         // one after the other.
         //
         while try i < nRetry && obj.getAdapterNameAsync().wait() == "AdapterAMI61" {
@@ -701,7 +687,7 @@ func allTests(_ helper: TestHelper) throws {
         let obj = try createTestIntfPrx(adapters)
         try test(obj.getAdapterName() == "Adapter71")
 
-        let testUDP = uncheckedCast(prx: obj.ice_datagram(), type: TestIntfPrx.self)
+        let testUDP = obj.ice_datagram()
         try test(obj.ice_getConnection() !== testUDP.ice_getConnection())
         do {
             _ = try testUDP.getAdapterName()
@@ -723,11 +709,11 @@ func allTests(_ helper: TestHelper) throws {
                 try obj.ice_getConnection()!.close(.GracefullyWithWait)
             }
 
-            var testSecure = uncheckedCast(prx: obj.ice_secure(true), type: TestIntfPrx.self)
+            var testSecure = obj.ice_secure(true)
             try test(testSecure.ice_isSecure())
-            testSecure = uncheckedCast(prx: obj.ice_secure(false), type: TestIntfPrx.self)
+            testSecure = obj.ice_secure(false)
             try test(!testSecure.ice_isSecure())
-            testSecure = uncheckedCast(prx: obj.ice_secure(true), type: TestIntfPrx.self)
+            testSecure = obj.ice_secure(true)
             try test(testSecure.ice_isSecure())
             try test(obj.ice_getConnection() !== testSecure.ice_getConnection())
 

--- a/swift/test/Ice/location/AllTests.swift
+++ b/swift/test/Ice/location/AllTests.swift
@@ -13,14 +13,14 @@ func allTests(_ helper: TestHelper) throws {
 
     let communicator = helper.communicator()
 
-    let manager = try checkedCast(
-        prx: communicator.stringToProxy("ServerManager:\(helper.getTestEndpoint(num: 0))")!,
+    let manager = try makeProxy(
+        communicator: communicator,
+        proxyString: "ServerManager:\(helper.getTestEndpoint(num: 0))",
         type: ServerManagerPrx.self
-    )!
+    )
 
     let locator = uncheckedCast(prx: communicator.getDefaultLocator()!, type: TestLocatorPrx.self)
-
-    let registry = try checkedCast(prx: locator.getRegistry()!, type: TestLocatorRegistryPrx.self)!
+    let registry = try uncheckedCast(prx: locator.getRegistry()!, type: TestLocatorRegistryPrx.self)
 
     output.write("testing stringToProxy... ")
     var base = try communicator.stringToProxy("test @ TestAdapter")!
@@ -34,9 +34,8 @@ func allTests(_ helper: TestHelper) throws {
     output.write("testing ice_locator and ice_getLocator... ")
     try test(
         base.ice_getLocator()!.ice_getIdentity() == communicator.getDefaultLocator()!.ice_getIdentity())
-    let anotherLocator = try uncheckedCast(
-        prx: communicator.stringToProxy("anotherLocator")!,
-        type: Ice.LocatorPrx.self)
+    let anotherLocator = try makeProxy(
+        communicator: communicator, proxyString: "anotherLocator", type: Ice.LocatorPrx.self)
     base = base.ice_locator(anotherLocator)
     try test(base.ice_getLocator()!.ice_getIdentity() == anotherLocator.ice_getIdentity())
     communicator.setDefaultLocator(nil)
@@ -55,12 +54,11 @@ func allTests(_ helper: TestHelper) throws {
     // test/Ice/router test?)
     //
     try test(base.ice_getRouter() == nil)
-    let anotherRouter = try uncheckedCast(
-        prx: communicator.stringToProxy("anotherRouter")!, type: Ice.RouterPrx.self)
+    let anotherRouter = try makeProxy(
+        communicator: communicator, proxyString: "anotherrouter", type: Ice.RouterPrx.self)
     base = base.ice_router(anotherRouter)
     try test(base.ice_getRouter()!.ice_getIdentity() == anotherRouter.ice_getIdentity())
-    let router = try uncheckedCast(
-        prx: communicator.stringToProxy("dummyrouter")!, type: Ice.RouterPrx.self)
+    let router = try makeProxy(communicator: communicator, proxyString: "dummyrouter", type: Ice.RouterPrx.self)
     communicator.setDefaultRouter(router)
     base = try communicator.stringToProxy("test @ TestAdapter")!
     try test(
@@ -227,8 +225,7 @@ func allTests(_ helper: TestHelper) throws {
     output.writeLine("ok")
 
     output.write("testing proxy from server... ")
-    obj = try checkedCast(
-        prx: communicator.stringToProxy("test@TestAdapter")!, type: TestIntfPrx.self)!
+    obj = try makeProxy(communicator: communicator, proxyString: "test@TestAdapter", type: TestIntfPrx.self)
     var hello = try obj.getHello()!
     try test(hello.ice_getAdapterId() == "TestAdapter")
     try hello.sayHello()
@@ -449,7 +446,7 @@ func allTests(_ helper: TestHelper) throws {
     output.writeLine("ok")
 
     output.write("testing object migration... ")
-    hello = try checkedCast(prx: communicator.stringToProxy("hello")!, type: HelloPrx.self)!
+    hello = try makeProxy(communicator: communicator, proxyString: "hello", type: HelloPrx.self)
     try obj.migrateHello()
     try hello.ice_getConnection()!.close(.GracefullyWithWait)
     try hello.sayHello()
@@ -460,7 +457,7 @@ func allTests(_ helper: TestHelper) throws {
     output.writeLine("ok")
 
     output.write("testing locator encoding resolution... ")
-    hello = try checkedCast(prx: communicator.stringToProxy("hello")!, type: HelloPrx.self)!
+    hello = try makeProxy(communicator: communicator, proxyString: "hello", type: HelloPrx.self)
     count = try locator.getRequestCount()
     try communicator.stringToProxy("test@TestAdapter")!.ice_encodingVersion(Ice.Encoding_1_1)
         .ice_ping()
@@ -499,7 +496,7 @@ func allTests(_ helper: TestHelper) throws {
 
     //
     // Set up test for calling a collocated object through an
-    // indirect, adapterless reference.
+    // indirect, adapter-less reference.
     //
     communicator.getProperties().setProperty(key: "Hello.AdapterId", value: UUID().uuidString)
     let adapter = try communicator.createObjectAdapterWithEndpoints(
@@ -510,13 +507,10 @@ func allTests(_ helper: TestHelper) throws {
     try adapter.add(servant: HelloDisp(HelloI()), id: ident)
 
     do {
-        // let helloPrx
-        _ = try checkedCast(
-            prx: communicator.stringToProxy("\"\(communicator.identityToString(ident))\"")!,
-            type: HelloPrx.self
-        )!
+        let helloPrx = try makeProxy(
+            communicator: communicator, proxyString: "\(communicator.identityToString(ident))", type: HelloPrx.self)
+        try helloPrx.ice_ping()
         try test(false)
-        // try test(helloPrx.ice_getConnection() == nil)
     } catch is Ice.NotRegisteredException {
         // Calls on the well-known proxy are not collocated because of issue #507
     }


### PR DESCRIPTION
This PR adds a new `makeProxy` factory function to Ice for Swift.

It's similar to the existing uncheckedCast and should be preferred over uncheckedCast (and checkedCast) in many situations, in particular in the demos.

It also updated 3 tests to use makeProxy.