### PR TITLE
Install middleware in ObjectAdapter (Swift)

### DIFF
--- a/swift/Rakefile
+++ b/swift/Rakefile
@@ -33,6 +33,7 @@ $tests = [
     "Ice/inheritance",
     "Ice/invoke",
     "Ice/location",
+    "Ice/middleware",
     "Ice/objects",
     "Ice/operations",
     "Ice/optional",

--- a/swift/src/Ice/Exception.swift
+++ b/swift/src/Ice/Exception.swift
@@ -1,4 +1,5 @@
 // Copyright (c) ZeroC, Inc.
+
 /// Base protocol for Ice exceptions.
 public protocol Exception: Error {
     /// Returns the type id of this exception.

--- a/swift/src/Ice/ObjectAdapter.swift
+++ b/swift/src/Ice/ObjectAdapter.swift
@@ -65,9 +65,8 @@ public protocol ObjectAdapter: AnyObject {
     /// - Returns: This object adapter.
     /// - Throws: `Ice.InitializationException` if the object adapter's dispatch pipeline has already been created. This
     /// creation typically occurs the first time the object adapter dispatches an incoming request.
-    // TODO: should the middleware function throw?
     @discardableResult
-    func use(_: @escaping (Dispatcher) -> Dispatcher) throws -> Self
+    func use(_ middleware: @escaping (Dispatcher) -> Dispatcher) throws -> Self
 
     /// Add a servant to this object adapter's Active Servant Map. Note that one servant can implement several Ice
     /// objects by registering the servant with multiple identities. Adding a servant with an identity that is in the

--- a/swift/src/Ice/ObjectAdapter.swift
+++ b/swift/src/Ice/ObjectAdapter.swift
@@ -60,13 +60,17 @@ public protocol ObjectAdapter: AnyObject {
     /// the same name.
     func destroy()
 
-    /// Install a middleware in this object adapter.
-    /// - Parameter middleware: The middleware to install.
+    /// Add a middleware to the dispatch pipeline of this object adapter.
+    ///
+    /// - Parameter middlewareFactory: The middleware factory that creates the new middleware when this object adapter
+    /// creates its dispatch pipeline. A middleware factory is a function that takes a dispatcher (the next element in
+    /// the dispatch pipeline) and returns a new dispatcher (the middleware you want to install in the pipeline).
     /// - Returns: This object adapter.
-    /// - Throws: `Ice.InitializationException` if the object adapter's dispatch pipeline has already been created. This
-    /// creation typically occurs the first time the object adapter dispatches an incoming request.
+    ///
+    /// - Note: All middleware must be installed before the first dispatch.
+    /// - Note: The middleware are executed in the order they are installed.
     @discardableResult
-    func use(_ middleware: @escaping (Dispatcher) -> Dispatcher) throws -> Self
+    func use(_ middlewareFactory: @escaping (_ next: Dispatcher) -> Dispatcher) -> Self
 
     /// Add a servant to this object adapter's Active Servant Map. Note that one servant can implement several Ice
     /// objects by registering the servant with multiple identities. Adding a servant with an identity that is in the

--- a/swift/src/Ice/ObjectAdapter.swift
+++ b/swift/src/Ice/ObjectAdapter.swift
@@ -6,6 +6,10 @@ import Foundation
 /// object adapter is responsible for receiving requests from endpoints, and for mapping between servants, identities,
 /// and proxies.
 public protocol ObjectAdapter: AnyObject {
+
+    /// Get the dispatch pipeline of this object adapter.
+    var dispatchPipeline: Dispatcher { get }
+
     /// Get the name of this object adapter.
     ///
     /// - returns: `String` - This object adapter's name.
@@ -55,6 +59,15 @@ public protocol ObjectAdapter: AnyObject {
     /// calls to destroy are ignored. Once destroy has returned, it is possible to create another object adapter with
     /// the same name.
     func destroy()
+
+    /// Install a middleware in this object adapter.
+    /// - Parameter middleware: The middleware to install.
+    /// - Returns: This object adapter.
+    /// - Throws: `Ice.InitializationException` if the object adapter's dispatch pipeline has already been created. This
+    /// creation typically occurs the first time the object adapter dispatches an incoming request.
+    // TODO: should the middleware function throw?
+    @discardableResult
+    func use(_: @escaping (Dispatcher) -> Dispatcher) throws -> Self
 
     /// Add a servant to this object adapter's Active Servant Map. Note that one servant can implement several Ice
     /// objects by registering the servant with multiple identities. Adding a servant with an identity that is in the

--- a/swift/src/Ice/ObjectAdapterI.swift
+++ b/swift/src/Ice/ObjectAdapterI.swift
@@ -27,7 +27,6 @@ class ObjectAdapterI: LocalObject<ICEObjectAdapter>, ObjectAdapter, ICEDispatchA
     init(handle: ICEObjectAdapter, communicator: Communicator) {
         self.communicator = communicator
         servantManager = ServantManager(adapterName: handle.getName(), communicator: communicator)
-
         super.init(handle: handle)
         handle.registerDispatchAdapter(self)
     }

--- a/swift/test/Ice/middleware/AllTests.swift
+++ b/swift/test/Ice/middleware/AllTests.swift
@@ -1,0 +1,85 @@
+// Copyright (c) ZeroC, Inc.
+
+import Ice
+import PromiseKit
+import TestCommon
+
+func allTests(_ helper: TestHelper) throws {
+    func test(_ value: Bool, file: String = #file, line: Int = #line) throws {
+        try helper.test(value, file: file, line: line)
+    }
+
+    let communicator = helper.communicator()
+    let output = helper.getWriter()
+
+    try testMiddlewareExecutionOrder(communicator, output)
+
+    // Verifies the middleware execute in installation order.
+    func testMiddlewareExecutionOrder(_ communicator: Communicator, _ output: TextWriter) throws {
+        output.write("testing middleware execution order... ")
+
+        // Arrange
+        let oa = try communicator.createObjectAdapterWithEndpoints(name: "MyOA", endpoints: "tcp -h 127.0.0.1 -p 0")
+        let log = MiddlewareLog()
+
+        let objPrx = try oa.add(servant: MyObjectDisp(MyObjectI()), id: Ice.stringToIdentity("test"))
+        try oa.use { next in
+            Middleware(next, "A", log)
+        }.use { next in
+            Middleware(next, "B", log)
+        }.use { next in
+            Middleware(next, "C", log)
+        }
+
+        // We're actually using colloc so no need to activate oa.
+
+        let p = uncheckedCast(prx: objPrx, type: MyObjectPrx.self)
+
+        // Act
+        try p.ice_ping()
+
+        // Assert
+        try test(log.inLog == ["A", "B", "C"])
+        try test(log.outLog == ["C", "B", "A"])
+
+        output.writeLine("ok")
+        oa.deactivate()
+    }
+
+    final class Middleware: Dispatcher {
+        private let next: Dispatcher
+        private let name: String
+        private var log: MiddlewareLog
+
+        func dispatch(_ request: IncomingRequest) -> Promise<OutgoingResponse> {
+            log.inLog.append(name)
+
+            return next.dispatch(request).map { response in
+                self.log.outLog.append(self.name)
+                return response
+            }
+        }
+
+        init(_ next: Dispatcher, _ name: String, _ log: MiddlewareLog) {
+            self.next = next
+            self.name = name
+            self.log = log
+        }
+    }
+
+    final class MiddlewareLog {
+        var inLog: [String]
+        var outLog: [String]
+
+        init() {
+            inLog = []
+            outLog = []
+        }
+    }
+
+    final class MyObjectI: MyObject {
+        func getName(current: Ice.Current) throws -> String {
+            "Foo"
+        }
+    }
+}

--- a/swift/test/Ice/middleware/AllTests.swift
+++ b/swift/test/Ice/middleware/AllTests.swift
@@ -68,13 +68,8 @@ func allTests(_ helper: TestHelper) throws {
     }
 
     final class MiddlewareLog {
-        var inLog: [String]
-        var outLog: [String]
-
-        init() {
-            inLog = []
-            outLog = []
-        }
+        var inLog: [String] = []
+        var outLog: [String] = []
     }
 
     final class MyObjectI: MyObject {

--- a/swift/test/Ice/middleware/AllTests.swift
+++ b/swift/test/Ice/middleware/AllTests.swift
@@ -23,7 +23,7 @@ func allTests(_ helper: TestHelper) throws {
         let log = MiddlewareLog()
 
         let objPrx = try oa.add(servant: MyObjectDisp(MyObjectI()), id: Ice.stringToIdentity("test"))
-        try oa.use { next in
+        oa.use { next in
             Middleware(next, "A", log)
         }.use { next in
             Middleware(next, "B", log)

--- a/swift/test/Ice/middleware/Client.swift
+++ b/swift/test/Ice/middleware/Client.swift
@@ -1,0 +1,14 @@
+// Copyright (c) ZeroC, Inc.
+
+import Ice
+import TestCommon
+
+class Client: TestHelperI {
+    override public func run(args: [String]) throws {
+        let communicator = try initialize(args)
+        defer {
+            communicator.destroy()
+        }
+        try allTests(self)
+    }
+}

--- a/swift/test/Ice/middleware/Test.ice
+++ b/swift/test/Ice/middleware/Test.ice
@@ -1,0 +1,10 @@
+// Copyright (c) ZeroC, Inc.
+#pragma once
+
+module Test
+{
+    interface MyObject
+    {
+        string getName();
+    }
+}


### PR DESCRIPTION
This PR improves ObjectAdapter in Swift to allow users to install middleware and construct the dispatch pipeline for the ObjectAdapter.

This is the Swift counterpart of #2277.