### PR TITLE
Random Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,8 +60,6 @@ generated
 .depend
 
 # MSBuild Build System
-Cpp11-Debug/
-Cpp11-Release/
 [Dd]ebug/
 [Dd]ebugPublic/
 [Rr]elease/

--- a/cpp/doxygen/Doxyfile
+++ b/cpp/doxygen/Doxyfile
@@ -999,7 +999,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = ../include/generated/cpp98
+EXCLUDE                =
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2878,10 +2878,8 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     OperationList ops = p->allOperations();
 
-    for (OperationList::const_iterator r = ops.begin(); r != ops.end(); ++r)
+    for (const auto& op : ops)
     {
-        OperationPtr op = *r;
-        InterfaceDefPtr interface = op->interface();
         string opName = fixId(op->name(), DotNet::ICloneable, true);
         TypePtr ret = op->returnType();
         string retS = typeToString(ret, ns, op->returnIsOptional());
@@ -2890,9 +2888,6 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         vector<string> args = getArgs(op);
         vector<string> argsAMI = getInArgs(op);
 
-        string deprecateReason = getDeprecationMessageForComment(op, "operation");
-
-        ParamDeclList inParams = op->inParameters();
         ParamDeclList outParams = op->outParameters();
 
         ExceptionList throws = op->throws();
@@ -2968,11 +2963,8 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     }
 
     // Async invocation
-    for (OperationList::const_iterator r = ops.begin(); r != ops.end(); ++r)
+    for (const auto& op : ops)
     {
-        OperationPtr op = *r;
-
-        InterfaceDefPtr interface = op->interface();
         vector<string> paramsAMI = getInParams(op, ns);
         vector<string> argsAMI = getInArgs(op);
 
@@ -2986,8 +2978,6 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         string progress = getEscapedParamName(op, "progress");
 
         TypePtr ret = op->returnType();
-
-        string retS = typeToString(ret, ns, op->returnIsOptional());
 
         string returnTypeS = resultType(op, ns);
 
@@ -3455,13 +3445,11 @@ Slice::Gen::DispatcherVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     _out << sb;
 
-    OperationList ops = p->operations();
-
-    for (OperationList::const_iterator i = ops.begin(); i != ops.end(); ++i)
+    for (const auto& op : p->operations())
     {
         string retS;
         vector<string> params, args;
-        string opName = getDispatchParams(*i, retS, params, args, ns);
+        string opName = getDispatchParams(op, retS, params, args, ns);
         _out << sp << nl << "public abstract " << retS << " " << opName << spar << params << epar << ';';
     }
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2885,7 +2885,6 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         string retS = typeToString(ret, ns, op->returnIsOptional());
 
         vector<string> params = getParams(op, ns);
-        vector<string> args = getArgs(op);
         vector<string> argsAMI = getInArgs(op);
 
         ParamDeclList outParams = op->outParameters();

--- a/cpp/test/Ice/inheritance/msbuild/server/server.vcxproj.filters
+++ b/cpp/test/Ice/inheritance/msbuild/server/server.vcxproj.filters
@@ -72,12 +72,6 @@
     <ClInclude Include="..\..\TestI.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Cpp11-Debug\Test.h">
-      <Filter>Header Files\x64\Cpp11-Debug</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Cpp11-Debug\Test.h">
-      <Filter>Header Files\Win32\Cpp11-Debug</Filter>
-    </ClInclude>
     <ClInclude Include="x64\Debug\Test.h">
       <Filter>Header Files\x64\Debug</Filter>
     </ClInclude>
@@ -89,12 +83,6 @@
     </ClInclude>
     <ClInclude Include="Win32\Release\Test.h">
       <Filter>Header Files\Win32\Release</Filter>
-    </ClInclude>
-    <ClInclude Include="x64\Cpp11-Release\Test.h">
-      <Filter>Header Files\x64\Cpp11-Release</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32\Cpp11-Release\Test.h">
-      <Filter>Header Files\Win32\Cpp11-Release</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/cpp/test/Ice/library/msbuild/gencode/gencode.vcxproj.filters
+++ b/cpp/test/Ice/library/msbuild/gencode/gencode.vcxproj.filters
@@ -49,22 +49,14 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="Win32\Cpp11-Debug\Test.cpp" />
-    <ClCompile Include="Win32\Cpp11-Release\Test.cpp" />
     <ClCompile Include="Win32\Debug\Test.cpp" />
     <ClCompile Include="Win32\Release\Test.cpp" />
-    <ClCompile Include="x64\Cpp11-Debug\Test.cpp" />
-    <ClCompile Include="x64\Cpp11-Release\Test.cpp" />
     <ClCompile Include="x64\Debug\Test.cpp" />
     <ClCompile Include="x64\Release\Test.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Win32\Cpp11-Debug\Test.h" />
-    <ClInclude Include="Win32\Cpp11-Release\Test.h" />
     <ClInclude Include="Win32\Debug\Test.h" />
     <ClInclude Include="Win32\Release\Test.h" />
-    <ClInclude Include="x64\Cpp11-Debug\Test.h" />
-    <ClInclude Include="x64\Cpp11-Release\Test.h" />
     <ClInclude Include="x64\Debug\Test.h" />
     <ClInclude Include="x64\Release\Test.h" />
   </ItemGroup>

--- a/cpp/test/IceStorm/persistent/Client.cpp
+++ b/cpp/test/IceStorm/persistent/Client.cpp
@@ -64,7 +64,7 @@ Client::run(int argc, char** argv)
         //
         // Create a subscriber for each topic
         //
-        cerr << "create a susbscriber for each topic... ";
+        cerr << "create a subscriber for each topic... ";
         for (int i = 0; i < 10; ++i)
         {
             ostringstream topicName;

--- a/java/test/src/main/java/test/Ice/stream/Test.ice
+++ b/java/test/src/main/java/test/Ice/stream/Test.ice
@@ -83,8 +83,6 @@ sequence<MyClassS> MyClassSS;
 dictionary<long, float> LongFloatD;
 dictionary<string, string> StringStringD;
 
-class Bar;
-
 class MyClass
 {
     MyClass c;

--- a/matlab/BUILDING.md
+++ b/matlab/BUILDING.md
@@ -94,7 +94,7 @@ We recommend using the following build environments:
 ### Build Instructions
 
 The MATLAB extension depends on Ice for C++ components from the cpp subdirectory, and those need to be built, using the
-`cpp11-shared` configuration, if you have not built the C++ distribution first review [cpp/README.md](../cpp/README.md).
+`shared` configuration, if you have not built the C++ distribution first review [cpp/README.md](../cpp/README.md).
 
 In a command window, change to the matlab subdirectory:
 

--- a/python/modules/IcePy/Slice.cpp
+++ b/python/modules/IcePy/Slice.cpp
@@ -14,7 +14,7 @@
 // Python headers needed for PyEval_EvalCode.
 //
 #include <compile.h>
-// Use ceval.h instead of eval.h with Pyhthon 3.11 and greater
+// Use ceval.h instead of eval.h with Python 3.11 and greater
 #if PY_VERSION_HEX >= 0x030B0000
 #    include <ceval.h>
 #else

--- a/python/modules/IcePy/Util.cpp
+++ b/python/modules/IcePy/Util.cpp
@@ -214,7 +214,7 @@ IcePy::getFunction()
     //
     // Get name of current function.
     //
-    // Use PyEval_GetFrame with Pyhthon >= 3.11
+    // Use PyEval_GetFrame with Python >= 3.11
 #if PY_VERSION_HEX >= 0x030B0000
     PyFrameObject* f = PyEval_GetFrame();
 #else

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -806,7 +806,7 @@ extension InputStream {
     /// Reads an optional base proxy from the stream.
     ///
     /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
-    /// 
+    ///
     /// - returns: `ObjectPrx?` - The proxy read from the stream.
     public func read(tag: Int32, type _: ObjectPrx.Protocol) throws -> ObjectPrx? {
         return try read(tag: tag) as ObjectPrxI?


### PR DESCRIPTION
This PR removes all the remaining references to the old `cpp11` and `cpp98` mappings.
It also:
- fixes some typos,
- removes a random control character from a doc-comment in Swift,
- removes an unused class `class Bar;` from the stream test (only in Java?),
- deletes some unused variables from the `slice2cs` source code.

After this PR, we only mention `cpp98` is completely gone, and we only mention `cpp11` in 3 places.
I'm not sure what to do about them, **so feel free to advise!**

1) in `cpp/test/IceUtil/stacktrace/test.py` We set this option: `TestSuite(__name__, options={"cpp11": [False]})`
Can I just delete this option? This whole file?

2) in `cpp/test/Ice/scope/AllTests.cpp` We have 4 of these comments in the test: "// C++ 11 Future-Based Async Function"
I guess it's referring to the language version, and not the mapping, so I left it alone.

3) in `Make.project.rules` we have a comment which gives this outdated example:
```
# Check for platform and configuration specific variable. For example, if variable
# is `objdir', for the configuration `cpp11-static' and the `osx' platform, the
# resulting value will be: $(osx_objdir) $(cpp11_objdir) $(static_objdir).
```
The make file scares me, and I'm not sure how to update the example.
