### PR TITLE
Remove getUnqualified("com.zeroc.Ice... in slice2java

### DIFF
--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -362,7 +362,7 @@ Slice::JavaVisitor::writeResultType(Output& out, const OperationPtr& op, const s
     ParamDeclList required, optional;
     op->outParameters(required, optional);
 
-    out << sp << nl << "public void write(" << getUnqualified("com.zeroc.Ice.OutputStream", package) << " ostr)";
+    out << sp << nl << "public void write(com.zeroc.Ice.OutputStream ostr)";
     out << sb;
 
     int iter = 0;
@@ -445,7 +445,7 @@ Slice::JavaVisitor::writeResultType(Output& out, const OperationPtr& op, const s
 
     out << eb;
 
-    out << sp << nl << "public void read(" << getUnqualified("com.zeroc.Ice.InputStream", package) << " istr)";
+    out << sp << nl << "public void read(com.zeroc.Ice.InputStream istr)";
     out << sb;
 
     iter = 0;
@@ -565,13 +565,12 @@ Slice::JavaVisitor::writeMarshaledResultType(
 
     out << sp;
     writeDocComment(out, "Holds the marshaled result of operation " + op->name() + ".");
-    out << nl << "public static class " << opName << "MarshaledResult implements "
-        << getUnqualified("com.zeroc.Ice.MarshaledResult", package) << sb;
+    out << nl << "public static class " << opName << "MarshaledResult implements com.zeroc.Ice.MarshaledResult" << sb;
 
     const ParamDeclList outParams = op->outParameters();
     const string retval = getEscapedParamName(op, "returnValue");
     const string currentParamName = getEscapedParamName(op, "current");
-    const string currentParam = getUnqualified("com.zeroc.Ice.Current", package) + " " + currentParamName;
+    const string currentParam = "com.zeroc.Ice.Current " + currentParamName;
 
     out << sp;
 
@@ -799,11 +798,11 @@ Slice::JavaVisitor::writeMarshaledResultType(
     }
 
     out << sp;
-    out << nl << "@Override" << nl << "public " << getUnqualified("com.zeroc.Ice.OutputStream", package)
-        << " getOutputStream()" << sb << nl << "return _ostr;" << eb;
+    out << nl << "@Override" << nl << "public com.zeroc.Ice.OutputStream getOutputStream()" << sb << nl
+        << "return _ostr;" << eb;
 
     out << sp;
-    out << nl << "private " << getUnqualified("com.zeroc.Ice.OutputStream", package) << " _ostr;";
+    out << nl << "private com.zeroc.Ice.OutputStream _ostr;";
     out << eb;
 }
 
@@ -817,7 +816,7 @@ Slice::JavaVisitor::allocatePatcher(Output& out, const TypePtr& type, const stri
     string clsName;
     if (b)
     {
-        clsName = getUnqualified("com.zeroc.Ice.Value", package);
+        clsName = "com.zeroc.Ice.Value";
     }
     else
     {
@@ -838,7 +837,7 @@ Slice::JavaVisitor::getPatcher(const TypePtr& type, const string& package, const
         string clsName;
         if (b)
         {
-            clsName = getUnqualified("com.zeroc.Ice.Value", package);
+            clsName = "com.zeroc.Ice.Value";
         }
         else
         {
@@ -1153,7 +1152,7 @@ Slice::JavaVisitor::writeThrowsClause(const string& package, const ExceptionList
     if (op && (op->hasMetaData("java:UserException") || op->hasMetaData("UserException")))
     {
         out.inc();
-        out << nl << "throws " << getUnqualified("com.zeroc.Ice.UserException", package);
+        out << nl << "throws com.zeroc.Ice.UserException";
         out.dec();
     }
     else if (throws.size() > 0)
@@ -1296,8 +1295,7 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
     {
         CommentPtr dc = op->parseComment(false);
         vector<string> params = getParams(op, package);
-        const string currentParam =
-            getUnqualified("com.zeroc.Ice.Current", package) + " " + getEscapedParamName(op, "current");
+        const string currentParam = "com.zeroc.Ice.Current " + getEscapedParamName(op, "current");
 
         const bool amd = p->hasMetaData("amd") || op->hasMetaData("amd");
 
@@ -1345,14 +1343,12 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
     }
     out << eb << ';';
 
-    out << sp << nl << "@Override" << nl << "default String[] ice_ids("
-        << getUnqualified("com.zeroc.Ice.Current", package) << " current)";
+    out << sp << nl << "@Override" << nl << "default String[] ice_ids(com.zeroc.Ice.Current current)";
     out << sb;
     out << nl << "return _iceIds;";
     out << eb;
 
-    out << sp << nl << "@Override" << nl << "default String ice_id(" << getUnqualified("com.zeroc.Ice.Current", package)
-        << " current)";
+    out << sp << nl << "@Override" << nl << "default String ice_id(com.zeroc.Ice.Current current)";
     out << sb;
     out << nl << "return ice_staticId();";
     out << eb;
@@ -1380,14 +1376,12 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
         out << sp;
 
         writeHiddenDocComment(out);
-        out << nl << "static java.util.concurrent.CompletionStage<"
-            << getUnqualified("com.zeroc.Ice.OutgoingResponse", package) << "> _iceD_" << opName << '(';
-        out << name;
-        out << " obj, " << getUnqualified("com.zeroc.Ice.IncomingRequest", package) << " request)";
+        out << nl << "static java.util.concurrent.CompletionStage<com.zeroc.Ice.OutgoingResponse> _iceD_" << opName
+            << '(' << name << " obj, com.zeroc.Ice.IncomingRequest request)";
         if (!op->throws().empty() || op->hasMetaData("java:UserException") || op->hasMetaData("UserException"))
         {
             out.inc();
-            out << nl << "throws " << getUnqualified("com.zeroc.Ice.UserException", package);
+            out << nl << "throws com.zeroc.Ice.UserException";
             out.dec();
         }
         out << sb;
@@ -1398,8 +1392,8 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
         const ParamDeclList inParams = op->inParameters();
         const ParamDeclList outParams = op->outParameters();
 
-        out << nl << getUnqualified("com.zeroc.Ice.Object", package) << "._iceCheckMode("
-            << sliceModeToIceMode(op->mode()) << ", request.current.mode);";
+        out << nl << "com.zeroc.Ice.Object._iceCheckMode(" << sliceModeToIceMode(op->mode())
+            << ", request.current.mode);";
 
         if (!inParams.empty())
         {
@@ -1408,7 +1402,7 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
             //
             // Declare 'in' parameters.
             //
-            out << nl << getUnqualified("com.zeroc.Ice.InputStream", package) << " istr = request.inputStream;";
+            out << nl << "com.zeroc.Ice.InputStream istr = request.inputStream;";
             out << nl << "istr.startEncapsulation();";
             for (const auto& param : inParams)
             {
@@ -1610,7 +1604,7 @@ Slice::JavaVisitor::writeMarshaling(Output& out, const ClassDefPtr& p)
     out << sp;
     writeHiddenDocComment(out);
     out << nl << "@Override";
-    out << nl << "protected void _iceWriteImpl(" << getUnqualified("com.zeroc.Ice.OutputStream", package) << " ostr_)";
+    out << nl << "protected void _iceWriteImpl(com.zeroc.Ice.OutputStream ostr_)";
     out << sb;
     out << nl << "ostr_.startSlice(ice_staticId(), " << p->compactId() << (!base ? ", true" : ", false") << ");";
     iter = 0;
@@ -1638,7 +1632,7 @@ Slice::JavaVisitor::writeMarshaling(Output& out, const ClassDefPtr& p)
     out << sp;
     writeHiddenDocComment(out);
     out << nl << "@Override";
-    out << nl << "protected void _iceReadImpl(" << getUnqualified("com.zeroc.Ice.InputStream", package) << " istr_)";
+    out << nl << "protected void _iceReadImpl(com.zeroc.Ice.InputStream istr_)";
     out << sb;
     out << nl << "istr_.startSlice();";
 
@@ -2197,7 +2191,7 @@ Slice::JavaVisitor::writeServantDocComment(
 
     if (p->hasMetaData("java:UserException") || p->hasMetaData("UserException"))
     {
-        out << nl << " * @throws " << getUnqualified("com.zeroc.Ice.UserException", package);
+        out << nl << " * @throws com.zeroc.Ice.UserException";
     }
     else
     {
@@ -2387,7 +2381,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     }
     else
     {
-        out << " extends " << getUnqualified("com.zeroc.Ice.Value", package);
+        out << " extends com.zeroc.Ice.Value";
     }
 
     if (!implements.empty())
@@ -2683,7 +2677,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     out.useCurrentPosAsIndent();
     if (bases.empty())
     {
-        out << getUnqualified("com.zeroc.Ice.Object", package);
+        out << "com.zeroc.Ice.Object";
     }
     else if (q != bases.end())
     {
@@ -2769,7 +2763,7 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 
     if (!base)
     {
-        out << getUnqualified("com.zeroc.Ice.UserException", package);
+        out << "com.zeroc.Ice.UserException";
     }
     else
     {
@@ -3040,7 +3034,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
     out << sp;
     writeHiddenDocComment(out);
     out << nl << "@Override";
-    out << nl << "protected void _writeImpl(" << getUnqualified("com.zeroc.Ice.OutputStream", package) << " ostr_)";
+    out << nl << "protected void _writeImpl(com.zeroc.Ice.OutputStream ostr_)";
     out << sb;
     out << nl << "ostr_.startSlice(\"" << scoped << "\", -1, " << (!base ? "true" : "false") << ");";
     iter = 0;
@@ -3068,7 +3062,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
     out << sp;
     writeHiddenDocComment(out);
     out << nl << "@Override";
-    out << nl << "protected void _readImpl(" << getUnqualified("com.zeroc.Ice.InputStream", package) << " istr_)";
+    out << nl << "protected void _readImpl(com.zeroc.Ice.InputStream istr_)";
     out << sb;
     out << nl << "istr_.startSlice();";
     iter = 0;
@@ -3373,8 +3367,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     out << nl << "return c;";
     out << eb;
 
-    out << sp << nl << "public void ice_writeMembers(" << getUnqualified("com.zeroc.Ice.OutputStream", package)
-        << " ostr)";
+    out << sp << nl << "public void ice_writeMembers(com.zeroc.Ice.OutputStream ostr)";
     out << sb;
     iter = 0;
     for (DataMemberList::const_iterator d = members.begin(); d != members.end(); ++d)
@@ -3385,8 +3378,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
 
     DataMemberList classMembers = p->classDataMembers();
 
-    out << sp << nl << "public void ice_readMembers(" << getUnqualified("com.zeroc.Ice.InputStream", package)
-        << " istr)";
+    out << sp << nl << "public void ice_readMembers(com.zeroc.Ice.InputStream istr)";
     out << sb;
     iter = 0;
     for (DataMemberList::const_iterator d = members.begin(); d != members.end(); ++d)
@@ -3395,8 +3387,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     }
     out << eb;
 
-    out << sp << nl << "static public void ice_write(" << getUnqualified("com.zeroc.Ice.OutputStream", package)
-        << " ostr, " << name << " v)";
+    out << sp << nl << "static public void ice_write(com.zeroc.Ice.OutputStream ostr, " << name << " v)";
     out << sb;
     out << nl << "if(v == null)";
     out << sb;
@@ -3408,8 +3399,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     out << eb;
     out << eb;
 
-    out << sp << nl << "static public " << name << " ice_read(" << getUnqualified("com.zeroc.Ice.InputStream", package)
-        << " istr)";
+    out << sp << nl << "static public " << name << " ice_read(com.zeroc.Ice.InputStream istr)";
     out << sb;
     out << nl << name << " v = new " << name << "();";
     out << nl << "v.ice_readMembers(istr);";
@@ -3418,8 +3408,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
 
     string optName = "java.util.Optional<" + name + ">";
     out << sp;
-    out << nl << "static public void ice_write(" << getUnqualified("com.zeroc.Ice.OutputStream", package)
-        << " ostr, int tag, " << optName << " v)";
+    out << nl << "static public void ice_write(com.zeroc.Ice.OutputStream ostr, int tag, " << optName << " v)";
     out << sb;
     out << nl << "if(v != null && v.isPresent())";
     out << sb;
@@ -3428,8 +3417,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     out << eb;
 
     out << sp;
-    out << nl << "static public void ice_write(" << getUnqualified("com.zeroc.Ice.OutputStream", package)
-        << " ostr, int tag, " << name << " v)";
+    out << nl << "static public void ice_write(com.zeroc.Ice.OutputStream ostr, int tag, " << name << " v)";
     out << sb;
     out << nl << "if(ostr.writeOptional(tag, " << getOptionalFormat(p) << "))";
     out << sb;
@@ -3448,8 +3436,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     out << eb;
 
     out << sp;
-    out << nl << "static public " << optName << " ice_read(" << getUnqualified("com.zeroc.Ice.InputStream", package)
-        << " istr, int tag)";
+    out << nl << "static public " << optName << " ice_read(com.zeroc.Ice.InputStream istr, int tag)";
     out << sb;
     out << nl << "if(istr.readOptional(tag, " << getOptionalFormat(p) << "))";
     out << sb;
@@ -3882,13 +3869,12 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     out << nl << "_value = v;";
     out << eb;
 
-    out << sp << nl << "public void ice_write(" << getUnqualified("com.zeroc.Ice.OutputStream", package) << " ostr)";
+    out << sp << nl << "public void ice_write(com.zeroc.Ice.OutputStream ostr)";
     out << sb;
     out << nl << "ostr.writeEnum(_value, " << p->maxValue() << ");";
     out << eb;
 
-    out << sp << nl << "public static void ice_write(" << getUnqualified("com.zeroc.Ice.OutputStream", package)
-        << " ostr, " << name << " v)";
+    out << sp << nl << "public static void ice_write(com.zeroc.Ice.OutputStream ostr, " << name << " v)";
     out << sb;
     out << nl << "if(v == null)";
     out << sb;
@@ -3901,8 +3887,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     out << eb;
     out << eb;
 
-    out << sp << nl << "public static " << name << " ice_read(" << getUnqualified("com.zeroc.Ice.InputStream", package)
-        << " istr)";
+    out << sp << nl << "public static " << name << " ice_read(com.zeroc.Ice.InputStream istr)";
     out << sb;
     out << nl << "int v = istr.readEnum(" << p->maxValue() << ");";
     out << nl << "return validate(v);";
@@ -3910,8 +3895,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 
     string optName = "java.util.Optional<" + name + ">";
     out << sp;
-    out << nl << "public static void ice_write(" << getUnqualified("com.zeroc.Ice.OutputStream", package)
-        << " ostr, int tag, " << optName << " v)";
+    out << nl << "public static void ice_write(com.zeroc.Ice.OutputStream ostr, int tag, " << optName << " v)";
     out << sb;
     out << nl << "if(v != null && v.isPresent())";
     out << sb;
@@ -3920,8 +3904,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     out << eb;
 
     out << sp;
-    out << nl << "public static void ice_write(" << getUnqualified("com.zeroc.Ice.OutputStream", package)
-        << " ostr, int tag, " << name << " v)";
+    out << nl << "public static void ice_write(com.zeroc.Ice.OutputStream ostr, int tag, " << name << " v)";
     out << sb;
     out << nl << "if(ostr.writeOptional(tag, " << getOptionalFormat(p) << "))";
     out << sb;
@@ -3930,8 +3913,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     out << eb;
 
     out << sp;
-    out << nl << "public static " << optName << " ice_read(" << getUnqualified("com.zeroc.Ice.InputStream", package)
-        << " istr, int tag)";
+    out << nl << "public static " << optName << " ice_read(com.zeroc.Ice.InputStream istr, int tag)";
     out << sb;
     out << nl << "if(istr.readOptional(tag, " << getOptionalFormat(p) << "))";
     out << sb;
@@ -3948,8 +3930,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     out << nl << "final " << name << " e = valueOf(v);";
     out << nl << "if(e == null)";
     out << sb;
-    out << nl << "throw new " << getUnqualified("com.zeroc.Ice.MarshalException", package)
-        << "(\"enumerator value \" + v + \" is out of range\");";
+    out << nl << "throw new com.zeroc.Ice.MarshalException(\"enumerator value \" + v + \" is out of range\");";
     out << eb;
     out << nl << "return e;";
     out << eb;
@@ -4099,8 +4080,7 @@ Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
     out << nl << "public final class " << name << "Helper";
     out << sb;
 
-    out << nl << "public static void write(" << getUnqualified("com.zeroc.Ice.OutputStream", package) << " ostr, "
-        << typeS << " v)";
+    out << nl << "public static void write(com.zeroc.Ice.OutputStream ostr, " << typeS << " v)";
     out << sb;
     iter = 0;
     writeSequenceMarshalUnmarshalCode(out, package, p, "v", true, iter, false);
@@ -4111,8 +4091,7 @@ Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
     {
         out << nl << "@SuppressWarnings(\"unchecked\")";
     }
-    out << nl << "public static " << typeS << " read(" << getUnqualified("com.zeroc.Ice.InputStream", package)
-        << " istr)";
+    out << nl << "public static " << typeS << " read(com.zeroc.Ice.InputStream istr)";
     out << sb;
     out << nl << "final " << typeS << " v;";
     iter = 0;
@@ -4124,8 +4103,7 @@ Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
 
     string optTypeS = "java.util.Optional<" + typeS + ">";
     out << sp;
-    out << nl << "public static void write(" << getUnqualified("com.zeroc.Ice.OutputStream", package)
-        << " ostr, int tag, " << optTypeS << " v)";
+    out << nl << "public static void write(com.zeroc.Ice.OutputStream ostr, int tag, " << optTypeS << " v)";
     out << sb;
     if (!hasTypeMetaData(p) && builtin && builtin->kind() < Builtin::KindObject)
     {
@@ -4141,8 +4119,7 @@ Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
     out << eb;
 
     out << sp;
-    out << nl << "public static void write(" << getUnqualified("com.zeroc.Ice.OutputStream", package)
-        << " ostr, int tag, " << typeS << " v)";
+    out << nl << "public static void write(com.zeroc.Ice.OutputStream ostr, int tag, " << typeS << " v)";
     out << sb;
     if (!hasTypeMetaData(p) && builtin && builtin->kind() < Builtin::KindObject)
     {
@@ -4190,8 +4167,7 @@ Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
     out << eb;
 
     out << sp;
-    out << nl << "public static " << optTypeS << " read(" << getUnqualified("com.zeroc.Ice.InputStream", package)
-        << " istr, int tag)";
+    out << nl << "public static " << optTypeS << " read(com.zeroc.Ice.InputStream istr, int tag)";
     out << sb;
     if (!hasTypeMetaData(p) && builtin && builtin->kind() < Builtin::KindObject)
     {
@@ -4246,15 +4222,13 @@ Slice::Gen::HelperVisitor::visitDictionary(const DictionaryPtr& p)
     out << sp << nl << "public final class " << name << "Helper";
     out << sb;
 
-    out << nl << "public static void write(" << getUnqualified("com.zeroc.Ice.OutputStream", package) << " ostr, "
-        << formalType << " v)";
+    out << nl << "public static void write(com.zeroc.Ice.OutputStream ostr, " << formalType << " v)";
     out << sb;
     iter = 0;
     writeDictionaryMarshalUnmarshalCode(out, package, p, "v", true, iter, false);
     out << eb;
 
-    out << sp << nl << "public static " << formalType << " read("
-        << getUnqualified("com.zeroc.Ice.InputStream", package) << " istr)";
+    out << sp << nl << "public static " << formalType << " read(com.zeroc.Ice.InputStream istr)";
     out << sb;
     out << nl << formalType << " v;";
     iter = 0;
@@ -4264,8 +4238,7 @@ Slice::Gen::HelperVisitor::visitDictionary(const DictionaryPtr& p)
 
     string optTypeS = "java.util.Optional<" + formalType + ">";
     out << sp;
-    out << nl << "public static void write(" << getUnqualified("com.zeroc.Ice.OutputStream", package)
-        << " ostr, int tag, " << optTypeS << " v)";
+    out << nl << "public static void write(com.zeroc.Ice.OutputStream ostr, int tag, " << optTypeS << " v)";
     out << sb;
     out << nl << "if(v != null && v.isPresent())";
     out << sb;
@@ -4274,8 +4247,7 @@ Slice::Gen::HelperVisitor::visitDictionary(const DictionaryPtr& p)
     out << eb;
 
     out << sp;
-    out << nl << "public static void write(" << getUnqualified("com.zeroc.Ice.OutputStream", package)
-        << " ostr, int tag, " << formalType << " v)";
+    out << nl << "public static void write(com.zeroc.Ice.OutputStream ostr, int tag, " << formalType << " v)";
     out << sb;
     out << nl << "if(ostr.writeOptional(tag, " << getOptionalFormat(p) << "))";
     out << sb;
@@ -4298,8 +4270,7 @@ Slice::Gen::HelperVisitor::visitDictionary(const DictionaryPtr& p)
     out << eb;
 
     out << sp;
-    out << nl << "public static " << optTypeS << " read(" << getUnqualified("com.zeroc.Ice.InputStream", package)
-        << " istr, int tag)";
+    out << nl << "public static " << optTypeS << " read(com.zeroc.Ice.InputStream istr, int tag)";
     out << sb;
     out << nl << "if(istr.readOptional(tag, " << getOptionalFormat(p) << "))";
     out << sb;
@@ -4355,7 +4326,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     out.useCurrentPosAsIndent();
     if (bases.empty())
     {
-        out << getUnqualified("com.zeroc.Ice.ObjectPrx", package);
+        out << "com.zeroc.Ice.ObjectPrx";
     }
     else
     {
@@ -4392,11 +4363,10 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "Raises a local exception if a communication error occurs.\n"
         "@param obj The untyped proxy.\n"
         "@return A proxy for this type, or null if the object does not support this type.");
-    out << nl << "static " << p->name() << "Prx checkedCast(" << getUnqualified("com.zeroc.Ice.ObjectPrx", package)
-        << " obj)";
+    out << nl << "static " << p->name() << "Prx checkedCast(com.zeroc.Ice.ObjectPrx obj)";
     out << sb;
-    out << nl << "return " << getUnqualified("com.zeroc.Ice.ObjectPrx", package)
-        << "._checkedCast(obj, ice_staticId(), " << p->name() << "Prx.class, _" << p->name() << "PrxI.class);";
+    out << nl << "return com.zeroc.Ice.ObjectPrx._checkedCast(obj, ice_staticId(), " << p->name() << "Prx.class, _"
+        << p->name() << "PrxI.class);";
     out << eb;
 
     out << sp;
@@ -4407,11 +4377,10 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "@param obj The untyped proxy.\n"
         "@param context The Context map to send with the invocation.\n"
         "@return A proxy for this type, or null if the object does not support this type.");
-    out << nl << "static " << p->name() << "Prx checkedCast(" << getUnqualified("com.zeroc.Ice.ObjectPrx", package)
-        << " obj, " << contextParam << ')';
+    out << nl << "static " << p->name() << "Prx checkedCast(com.zeroc.Ice.ObjectPrx obj, " << contextParam << ')';
     out << sb;
-    out << nl << "return " << getUnqualified("com.zeroc.Ice.ObjectPrx", package)
-        << "._checkedCast(obj, context, ice_staticId(), " << p->name() << "Prx.class, _" << p->name() << "PrxI.class);";
+    out << nl << "return com.zeroc.Ice.ObjectPrx._checkedCast(obj, context, ice_staticId(), " << p->name()
+        << "Prx.class, _" << p->name() << "PrxI.class);";
     out << eb;
 
     out << sp;
@@ -4422,11 +4391,10 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "@param obj The untyped proxy.\n"
         "@param facet The name of the desired facet.\n"
         "@return A proxy for this type, or null if the object does not support this type.");
-    out << nl << "static " << p->name() << "Prx checkedCast(" << getUnqualified("com.zeroc.Ice.ObjectPrx", package)
-        << " obj, String facet)";
+    out << nl << "static " << p->name() << "Prx checkedCast(com.zeroc.Ice.ObjectPrx obj, String facet)";
     out << sb;
-    out << nl << "return " << getUnqualified("com.zeroc.Ice.ObjectPrx", package)
-        << "._checkedCast(obj, facet, ice_staticId(), " << p->name() << "Prx.class, _" << p->name() << "PrxI.class);";
+    out << nl << "return com.zeroc.Ice.ObjectPrx._checkedCast(obj, facet, ice_staticId(), " << p->name()
+        << "Prx.class, _" << p->name() << "PrxI.class);";
     out << eb;
 
     out << sp;
@@ -4438,12 +4406,11 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "@param facet The name of the desired facet.\n"
         "@param context The Context map to send with the invocation.\n"
         "@return A proxy for this type, or null if the object does not support this type.");
-    out << nl << "static " << p->name() << "Prx checkedCast(" << getUnqualified("com.zeroc.Ice.ObjectPrx", package)
-        << " obj, String facet, " << contextParam << ')';
+    out << nl << "static " << p->name() << "Prx checkedCast(com.zeroc.Ice.ObjectPrx obj, String facet, " << contextParam
+        << ')';
     out << sb;
-    out << nl << "return " << getUnqualified("com.zeroc.Ice.ObjectPrx", package)
-        << "._checkedCast(obj, facet, context, ice_staticId(), " << p->name() << "Prx.class, _" << p->name()
-        << "PrxI.class);";
+    out << nl << "return com.zeroc.Ice.ObjectPrx._checkedCast(obj, facet, context, ice_staticId(), " << p->name()
+        << "Prx.class, _" << p->name() << "PrxI.class);";
     out << eb;
 
     out << sp;
@@ -4452,11 +4419,10 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "Downcasts the given proxy to this type without contacting the remote server.\n"
         "@param obj The untyped proxy.\n"
         "@return A proxy for this type.");
-    out << nl << "static " << p->name() << "Prx uncheckedCast(" << getUnqualified("com.zeroc.Ice.ObjectPrx", package)
-        << " obj)";
+    out << nl << "static " << p->name() << "Prx uncheckedCast(com.zeroc.Ice.ObjectPrx obj)";
     out << sb;
-    out << nl << "return " << getUnqualified("com.zeroc.Ice.ObjectPrx", package) << "._uncheckedCast(obj, " << p->name()
-        << "Prx.class, _" << p->name() << "PrxI.class);";
+    out << nl << "return com.zeroc.Ice.ObjectPrx._uncheckedCast(obj, " << p->name() << "Prx.class, _" << p->name()
+        << "PrxI.class);";
     out << eb;
 
     out << sp;
@@ -4466,11 +4432,10 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "@param obj The untyped proxy.\n"
         "@param facet The name of the desired facet.\n"
         "@return A proxy for this type.");
-    out << nl << "static " << p->name() << "Prx uncheckedCast(" << getUnqualified("com.zeroc.Ice.ObjectPrx", package)
-        << " obj, String facet)";
+    out << nl << "static " << p->name() << "Prx uncheckedCast(com.zeroc.Ice.ObjectPrx obj, String facet)";
     out << sb;
-    out << nl << "return " << getUnqualified("com.zeroc.Ice.ObjectPrx", package) << "._uncheckedCast(obj, facet, "
-        << p->name() << "Prx.class, _" << p->name() << "PrxI.class);";
+    out << nl << "return com.zeroc.Ice.ObjectPrx._uncheckedCast(obj, facet, " << p->name() << "Prx.class, _"
+        << p->name() << "PrxI.class);";
     out << eb;
 
     out << sp;
@@ -4504,8 +4469,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "@param newEndpoints The endpoints for the new proxy.\n"
         "@return A proxy with the specified endpoints.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_endpoints(" << getUnqualified("com.zeroc.Ice.Endpoint", package)
-        << "[] newEndpoints)";
+    out << nl << "default " << p->name() << "Prx ice_endpoints(com.zeroc.Ice.Endpoint[] newEndpoints)";
     out << sb;
     out << nl << "return (" << p->name() << "Prx)_ice_endpoints(newEndpoints);";
     out << eb;
@@ -4553,8 +4517,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "@param newType The new endpoint selection policy.\n"
         "@return A proxy with the specified endpoint selection policy.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_endpointSelection("
-        << getUnqualified("com.zeroc.Ice.EndpointSelectionType", package) << " newType)";
+    out << nl << "default " << p->name() << "Prx ice_endpointSelection(com.zeroc.Ice.EndpointSelectionType newType)";
     out << sb;
     out << nl << "return (" << p->name() << "Prx)_ice_endpointSelection(newType);";
     out << eb;
@@ -4580,8 +4543,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "@param e The encoding version to use to marshal request parameters.\n"
         "@return A proxy with the specified encoding version.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_encodingVersion("
-        << getUnqualified("com.zeroc.Ice.EncodingVersion", package) << " e)";
+    out << nl << "default " << p->name() << "Prx ice_encodingVersion(com.zeroc.Ice.EncodingVersion e)";
     out << sb;
     out << nl << "return (" << p->name() << "Prx)_ice_encodingVersion(e);";
     out << eb;
@@ -4607,8 +4569,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "@param router The router for the new proxy.\n"
         "@return A proxy with the specified router.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_router(" << getUnqualified("com.zeroc.Ice.RouterPrx", package)
-        << " router)";
+    out << nl << "default " << p->name() << "Prx ice_router(com.zeroc.Ice.RouterPrx router)";
     out << sb;
     out << nl << "return (" << p->name() << "Prx)_ice_router(router);";
     out << eb;
@@ -4620,8 +4581,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "@param locator The locator for the new proxy.\n"
         "@return A proxy with the specified locator.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_locator(" << getUnqualified("com.zeroc.Ice.LocatorPrx", package)
-        << " locator)";
+    out << nl << "default " << p->name() << "Prx ice_locator(com.zeroc.Ice.LocatorPrx locator)";
     out << sb;
     out << nl << "return (" << p->name() << "Prx)_ice_locator(locator);";
     out << eb;
@@ -4763,8 +4723,8 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     {
         outi << nl << "@Deprecated";
     }
-    outi << nl << "public class _" << p->name() << "PrxI extends "
-         << getUnqualified("com.zeroc.Ice._ObjectPrxI", package) << " implements " << p->name() << "Prx";
+    outi << nl << "public class _" << p->name() << "PrxI extends com.zeroc.Ice._ObjectPrxI implements " << p->name()
+         << "Prx";
     outi << sb;
     outi << sp;
     writeHiddenDocComment(outi);
@@ -4872,10 +4832,9 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
             out << nl << "throw ex;";
             out << eb;
         }
-        out << nl << "catch(" << getUnqualified("com.zeroc.Ice.UserException", package) << " ex)";
+        out << nl << "catch(com.zeroc.Ice.UserException ex)";
         out << sb;
-        out << nl << "throw new " << getUnqualified("com.zeroc.Ice.UnknownUserException", package)
-            << "(ex.ice_id(), ex);";
+        out << nl << "throw new com.zeroc.Ice.UnknownUserException(ex.ice_id(), ex);";
         out << eb;
     }
     out << eb;
@@ -4941,10 +4900,9 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
                 out << nl << "throw ex;";
                 out << eb;
             }
-            out << nl << "catch(" << getUnqualified("com.zeroc.Ice.UserException", package) << " ex)";
+            out << nl << "catch(com.zeroc.Ice.UserException ex)";
             out << sb;
-            out << nl << "throw new " << getUnqualified("com.zeroc.Ice.UnknownUserException", package)
-                << "(ex.ice_id(), ex);";
+            out << nl << "throw new com.zeroc.Ice.UnknownUserException(ex.ice_id(), ex);";
             out << eb;
         }
         out << eb;
@@ -4987,9 +4945,8 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
         << getParamsProxy(p, package, false, true) << "java.util.Map<String, String> context"
         << "boolean sync" << epar;
     out << sb;
-    out << nl << futureImpl << " f = new " << getUnqualified("com.zeroc.IceInternal.OutgoingAsync", package)
-        << "<>(this, \"" << p->name() << "\", " << sliceModeToIceMode(p->mode()) << ", sync, "
-        << (throws.empty() ? "null" : "_iceE_" + p->name()) << ");";
+    out << nl << futureImpl << " f = new com.zeroc.IceInternal.OutgoingAsync<>(this, \"" << p->name() << "\", "
+        << sliceModeToIceMode(p->mode()) << ", sync, " << (throws.empty() ? "null" : "_iceE_" + p->name()) << ");";
 
     out << nl << "f.invoke(";
     out.useCurrentPosAsIndent();
@@ -5077,9 +5034,8 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
             << getParamsProxy(p, package, true, true) << "java.util.Map<String, String> context"
             << "boolean sync" << epar;
         out << sb;
-        out << nl << futureImpl << " f = new " << getUnqualified("com.zeroc.IceInternal.OutgoingAsync", package)
-            << "<>(this, \"" << p->name() << "\", " << sliceModeToIceMode(p->mode()) << ", sync, "
-            << (throws.empty() ? "null" : "_iceE_" + p->name()) << ");";
+        out << nl << futureImpl << " f = new com.zeroc.IceInternal.OutgoingAsync<>(this, \"" << p->name() << "\", "
+            << sliceModeToIceMode(p->mode()) << ", sync, " << (throws.empty() ? "null" : "_iceE_" + p->name()) << ");";
 
         out << nl << "f.invoke(";
         out.useCurrentPosAsIndent();

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -998,11 +998,11 @@ Slice::JavaGenerator::getStaticId(const TypePtr& type, const string& package) co
 
     if (b && b->kind() == Builtin::KindObject)
     {
-        return getUnqualified("com.zeroc.Ice.Object", package) + ".ice_staticId()";
+        return "com.zeroc.Ice.Object.ice_staticId()";
     }
     else if (b && b->kind() == Builtin::KindValue)
     {
-        return getUnqualified("com.zeroc.Ice.Value", package) + ".ice_staticId()";
+        return "com.zeroc.Ice.Value.ice_staticId()";
     }
     else
     {


### PR DESCRIPTION
This PR removes all getUnqualified("com.zeroc.Ice..." in slice2java. 

For fixed com.zeroc.Ice... symbols, we simply always fully qualify them in the generated code.