### PR TITLE
Add new ErrorObserverMiddleware in Java

### DIFF
--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -2125,19 +2125,17 @@ public final class ConnectionI extends com.zeroc.IceInternal.EventHandler
           CompletionStage<OutgoingResponse> response = null;
           try {
             response = dispatcher.dispatch(request);
-          } catch (RuntimeException | UserException ex) {
-            sendResponse(request.current.createOutgoingResponse(ex), isTwoWay, (byte) 0);
-          } catch (java.lang.Error ex) {
-            // TODO: should we catch/handle Errors at all? Only some errors?
+          } catch (Throwable ex) { // UserException or an unchecked exception
             sendResponse(request.current.createOutgoingResponse(ex), isTwoWay, (byte) 0);
           }
           if (response != null) {
             response.whenComplete(
-                (r, ex) -> {
-                  if (ex != null) {
-                    sendResponse(request.current.createOutgoingResponse(ex), isTwoWay, (byte) 0);
+                (result, exception) -> {
+                  if (exception != null) {
+                    sendResponse(
+                        request.current.createOutgoingResponse(exception), isTwoWay, (byte) 0);
                   } else {
-                    sendResponse(r, isTwoWay, compress);
+                    sendResponse(result, isTwoWay, compress);
                   }
                   // Any exception thrown by this closure is effectively ignored.
                 });
@@ -2155,32 +2153,20 @@ public final class ConnectionI extends com.zeroc.IceInternal.EventHandler
 
     } catch (LocalException ex) {
       dispatchException(ex, requestCount);
-    } catch (java.lang.Error ex) {
-      //
-      // An Error was raised outside of servant code (i.e., by Ice code).
-      // Attempt to log the error and clean up. This may still fail
-      // depending on the severity of the error.
-      //
-      // Note that this does NOT send a response to the client.
-      //
-      UnknownException uex = new UnknownException(ex);
-      java.io.StringWriter sw = new java.io.StringWriter();
-      java.io.PrintWriter pw = new java.io.PrintWriter(sw);
+    } catch (RuntimeException | java.lang.Error ex) {
+      // A runtime exception or an error was thrown outside of servant code (i.e., by Ice code).
+      // Note
+      // that this does NOT
+      // send a response to the client.
+      var uex = new UnknownException(ex);
+      var sw = new java.io.StringWriter();
+      var pw = new java.io.PrintWriter(sw);
       ex.printStackTrace(pw);
       pw.flush();
       uex.unknown = sw.toString();
       _logger.error(uex.unknown);
       dispatchException(uex, requestCount);
-      //
-      // Suppress AssertionError and OutOfMemoryError, rethrow everything else.
-      //
-      if (!(ex instanceof java.lang.AssertionError
-          || ex instanceof java.lang.OutOfMemoryError
-          || ex instanceof java.lang.StackOverflowError)) {
-        throw ex;
-      }
     }
-    // Any other exception is not handled and kills the thread.
   }
 
   private void sendResponse(OutgoingResponse response, boolean isTwoWay, byte compress) {

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -2155,9 +2155,7 @@ public final class ConnectionI extends com.zeroc.IceInternal.EventHandler
       dispatchException(ex, requestCount);
     } catch (RuntimeException | java.lang.Error ex) {
       // A runtime exception or an error was thrown outside of servant code (i.e., by Ice code).
-      // Note
-      // that this does NOT
-      // send a response to the client.
+      // Note that this code does NOT send a response to the client.
       var uex = new UnknownException(ex);
       var sw = new java.io.StringWriter();
       var pw = new java.io.PrintWriter(sw);

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ErrorObserverMiddleware.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ErrorObserverMiddleware.java
@@ -33,7 +33,7 @@ public final class ErrorObserverMiddleware implements Object {
           .dispatch(request)
           .exceptionally(
               exception -> {
-                // _errorHandler can throw an exception that effectively replaces exception for
+                // _errorObserver can throw an exception that effectively replaces exception for
                 // dependent completion stages.
                 if (exception instanceof java.lang.Error error) {
                   _errorObserver.accept(error);

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ErrorObserverMiddleware.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ErrorObserverMiddleware.java
@@ -1,0 +1,63 @@
+// Copyright (c) ZeroC, Inc.
+
+package com.zeroc.Ice;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
+
+/**
+ * Provides a simple middleware that allows applications to observe java.lang.Error thrown by the
+ * dispatch of an incoming request.
+ */
+public final class ErrorObserverMiddleware implements Object {
+  private final Object _next;
+  private final Consumer<java.lang.Error> _errorObserver;
+
+  /**
+   * Constructs a new ErrorObserverMiddleware.
+   *
+   * @param next The next dispatcher in the chain.
+   * @param errorObserver The error observer. If error observer throws an exception while observing
+   *     an error, this exception replaces the error for the remainder of the dispatch.
+   */
+  public ErrorObserverMiddleware(Object next, Consumer<java.lang.Error> errorObserver) {
+    _next = next;
+    _errorObserver = errorObserver;
+  }
+
+  @Override
+  public CompletionStage<OutgoingResponse> dispatch(IncomingRequest request) throws UserException {
+    try {
+      return _next
+          .dispatch(request)
+          .exceptionally(
+              exception -> {
+                // _errorHandler can throw an exception that effectively replaces exception for
+                // dependent completion stages.
+                if (exception instanceof java.lang.Error error) {
+                  _errorObserver.accept(error);
+                  throw error;
+                } else if (exception instanceof CompletionException completionException
+                    && completionException.getCause() instanceof java.lang.Error error) {
+                  // This can occur when the closure of a parent completion stage throws an error.
+                  _errorObserver.accept(error);
+                }
+
+                if (exception instanceof RuntimeException runtimeException) {
+                  // Rethrow as-is. Note that Java does not wrap CompletionException in
+                  // CompletionException.
+                  throw runtimeException;
+                }
+
+                // exception is a Throwable that is not an Error or a RuntimeException. We can't
+                // throw it so we marshal this exception into a response.
+                return request.current.createOutgoingResponse(exception);
+              });
+    } catch (java.lang.Error error) {
+      // synchronous error
+      _errorObserver.accept(error);
+      throw error;
+    }
+  }
+}

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
@@ -4,6 +4,7 @@
 
 package com.zeroc.Ice;
 
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -116,7 +117,7 @@ public interface ObjectAdapter {
   void destroy();
 
   /**
-   * Install a middleware in this object adapter.
+   * Install a middleware in this object adapter's dispatch pipeline.
    *
    * @param middleware The middleware to install.
    * @return This object adapter.
@@ -125,6 +126,19 @@ public interface ObjectAdapter {
    *     incoming request.
    */
   public ObjectAdapter use(Function<Object, Object> middleware);
+
+  /**
+   * Install the error observer middleware in this object adapter.
+   *
+   * @param errorObserver The error observer. It receives any java.lang.Error thrown by the
+   *     dispatch.
+   * @return This object adapter.
+   * @throws IllegalStateException Thrown if the object adapter's dispatch pipeline has already been
+   *     created. This creation typically occurs the first time the object adapter dispatches an
+   *     incoming request.
+   * @see ErrorObserverMiddleware
+   */
+  public ObjectAdapter useErrorObserver(Consumer<java.lang.Error> errorObserver);
 
   /**
    * Add a servant to this object adapter's Active Servant Map. Note that one servant can implement

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
@@ -4,7 +4,6 @@
 
 package com.zeroc.Ice;
 
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -126,19 +125,6 @@ public interface ObjectAdapter {
    *     incoming request.
    */
   public ObjectAdapter use(Function<Object, Object> middleware);
-
-  /**
-   * Install the error observer middleware in this object adapter.
-   *
-   * @param errorObserver The error observer. It receives any java.lang.Error thrown by the
-   *     dispatch.
-   * @return This object adapter.
-   * @throws IllegalStateException Thrown if the object adapter's dispatch pipeline has already been
-   *     created. This creation typically occurs the first time the object adapter dispatches an
-   *     incoming request.
-   * @see ErrorObserverMiddleware
-   */
-  public ObjectAdapter useErrorObserver(Consumer<java.lang.Error> errorObserver);
 
   /**
    * Add a servant to this object adapter's Active Servant Map. Note that one servant can implement

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectAdapterI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectAdapterI.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 public final class ObjectAdapterI implements ObjectAdapter {
@@ -320,6 +321,11 @@ public final class ObjectAdapterI implements ObjectAdapter {
     }
     _middlewareStack.push(middleware);
     return this;
+  }
+
+  @Override
+  public ObjectAdapter useErrorObserver(Consumer<java.lang.Error> errorObserver) {
+    return use(next -> new ErrorObserverMiddleware(next, errorObserver));
   }
 
   @Override

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectAdapterI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectAdapterI.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 public final class ObjectAdapterI implements ObjectAdapter {
@@ -321,11 +320,6 @@ public final class ObjectAdapterI implements ObjectAdapter {
     }
     _middlewareStack.push(middleware);
     return this;
-  }
-
-  @Override
-  public ObjectAdapter useErrorObserver(Consumer<java.lang.Error> errorObserver) {
-    return use(next -> new ErrorObserverMiddleware(next, errorObserver));
   }
 
   @Override

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/CollocatedRequestHandler.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/CollocatedRequestHandler.java
@@ -234,9 +234,7 @@ public class CollocatedRequestHandler implements RequestHandler {
       dispatchException(ex, requestId, false); // Fatal dispatch exception
     } catch (RuntimeException | java.lang.Error ex) {
       // A runtime exception or an error was thrown outside of servant code (i.e., by Ice code).
-      // Note
-      // that this does NOT
-      // send a response to the client. = new com.zeroc.Ice.UnknownException(ex);
+      // Note that this code does NOT send a response to the client.
       var uex = new UnknownException(ex);
       var sw = new java.io.StringWriter();
       var pw = new java.io.PrintWriter(sw);

--- a/java/test/src/main/java/test/Ice/middleware/AllTests.java
+++ b/java/test/src/main/java/test/Ice/middleware/AllTests.java
@@ -45,7 +45,7 @@ public class AllTests {
     private final boolean _throwError;
 
     @Override
-    public CompletionStage<String> getNameAsync(com.zeroc.Ice.Current current) {
+    public CompletionStage<String> getNameAsync(Current current) {
       if (_throwError) {
         return CompletableFuture.failedFuture(new java.lang.StackOverflowError());
       } else {
@@ -54,7 +54,7 @@ public class AllTests {
     }
 
     @Override
-    public void ice_ping(com.zeroc.Ice.Current current) {
+    public void ice_ping(Current current) {
       if (_throwError) {
         throw new java.lang.StackOverflowError();
       }

--- a/java/test/src/main/java/test/Ice/middleware/AllTests.java
+++ b/java/test/src/main/java/test/Ice/middleware/AllTests.java
@@ -127,7 +127,7 @@ public class AllTests {
 
     ObjectAdapter oa = communicator.createObjectAdapter("");
     ObjectPrx obj = oa.add(new MyFragileObject(withError), new Identity("test", ""));
-    oa.useErrorObserver(error -> errorHolder.error = error);
+    oa.use(next -> new ErrorObserverMiddleware(next, error -> errorHolder.error = error));
     var p = MyObjectPrx.uncheckedCast(obj);
 
     // Act

--- a/java/test/src/main/java/test/Ice/middleware/MyObjectI.java
+++ b/java/test/src/main/java/test/Ice/middleware/MyObjectI.java
@@ -2,11 +2,13 @@
 
 package test.Ice.middleware;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import test.Ice.middleware.Test.*;
 
 final class MyObjectI implements MyObject {
   @Override
-  public String getName(com.zeroc.Ice.Current current) {
-    return "Foo";
+  public CompletionStage<String> getNameAsync(com.zeroc.Ice.Current current) {
+    return CompletableFuture.completedFuture("Foo");
   }
 }

--- a/java/test/src/main/java/test/Ice/middleware/Test.ice
+++ b/java/test/src/main/java/test/Ice/middleware/Test.ice
@@ -7,6 +7,6 @@ module Test
 {
     interface MyObject
     {
-        string getName();
+        ["amd"] string getName();
     }
 }


### PR DESCRIPTION
This PR adds a new error observer middleware in Java. 

This middleware allows the application to observe java.lang.Error thrown by the dispatch. It receives errors thrown synchronously and errors reported through the `CompletionStage<OutgoingResponse>` returned by the dispatch.
In this latter case, the error can be reported by a call in the dispatch thread or in another thread.

The error observer callback (Java `Consumer<java.lang.Error>`) typically logs the error or alert the user in some way. I chose the term "observer" because it's not expected to "handle" the error.
Nevertheless, if this callback throws an exception while observing an error, this exception becomes the new outcome of the dispatch.

A limitation of this middleware is it doesn't see and therefore can't observe errors thrown/reported higher-up in the dispatch, namely by ConnectionI/CollocatedRequestHandler and the two built-in internal middleware (Logger and the DispatchObserver middleware used for Metrics). It's fortunately unlikely these higher-up elements throw any error - they don't do that much. 

Finally, I updated the logic in ConnectionI/CollocatedRequestHandler to rethrow any error. All errors and RuntimeException thrown synchronously by the dispatch are now handled. No error is let through to the ThreadPool code.

Fixes #2276.