### PR TITLE
Simplify/fix inactivity timeout check in C++

### DIFF
--- a/cpp/include/IceUtil/Timer.h
+++ b/cpp/include/IceUtil/Timer.h
@@ -156,6 +156,9 @@ namespace IceUtil
         //
         bool cancel(const TimerTaskPtr&);
 
+        // Checks if this timer task is scheduled.
+        bool isScheduled(const TimerTaskPtr&);
+
     protected:
         virtual void runTimerTask(const IceUtil::TimerTaskPtr&);
 

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -2321,11 +2321,10 @@ Ice::ConnectionI::inactivityCheck() noexcept
 {
     // Called by the InactivityTimerTask.
     std::lock_guard lock(_mutex);
-    if (_state == StateActive &&
-        _inactivityTimerTaskScheduled &&              // it's false if some other thread canceled the timer while we
-                                                      // were waiting for _mutex
-        !_timer->isScheduled(_inactivityTimerTask))   // make sure this timer task was not rescheduled for later while
-                                                      // we were waiting for _mutex (unlikely but may as well check)
+    if (_state == StateActive && _inactivityTimerTaskScheduled && // it's false if some other thread canceled the timer
+                                                                  // while we were waiting for _mutex
+        !_timer->isScheduled(_inactivityTimerTask)) // make sure this timer task was not rescheduled for later while
+                                                    // we were waiting for _mutex (unlikely but may as well check)
     {
         setState(
             StateClosing,
@@ -2775,8 +2774,7 @@ Ice::ConnectionI::sendMessage(OutgoingMessage& message)
     // If we're sending a heartbeat, there is a chance the connection is inactive and that we need to schedule the
     // inactivity timer task.
     // It's ok to do this before actually sending the heartbeat since the heartbeat does not count as an "activity".
-    if (isHeartbeat &&
-        _inactivityTimerTask &&                // null when the inactivity timeout is infinite
+    if (isHeartbeat && _inactivityTimerTask && // null when the inactivity timeout is infinite
         !_inactivityTimerTaskScheduled &&      // we never reschedule this task
         _state == StateActive &&               // only schedule the task if the connection is active
         _dispatchCount == 0 &&                 // no pending dispatch

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -2770,16 +2770,16 @@ Ice::ConnectionI::sendMessage(OutgoingMessage& message)
     {
         cancelInactivityTimerTask();
     }
-
     // If we're sending a heartbeat, there is a chance the connection is inactive and that we need to schedule the
     // inactivity timer task.
     // It's ok to do this before actually sending the heartbeat since the heartbeat does not count as an "activity".
-    if (isHeartbeat && _inactivityTimerTask && // null when the inactivity timeout is infinite
-        !_inactivityTimerTaskScheduled &&      // we never reschedule this task
-        _state == StateActive &&               // only schedule the task if the connection is active
-        _dispatchCount == 0 &&                 // no pending dispatch
-        _asyncRequests.empty())                // no pending invocation
-
+    else if (
+        _inactivityTimerTask &&           // null when the inactivity timeout is infinite
+        !_inactivityTimerTaskScheduled && // we never reschedule this task
+        _state == StateActive &&          // only schedule the task if the connection is active
+        _dispatchCount == 0 &&            // no pending dispatch
+        _asyncRequests.empty() &&         // no pending invocation
+        _readHeader)                      // we're not waiting for the remainder of an incoming message
     {
         bool isInactive = true;
 

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -646,12 +646,6 @@ Ice::ConnectionI::sendAsyncRequest(const OutgoingAsyncBasePtr& out, bool compres
     AsyncStatus status = AsyncStatusQueued;
     try
     {
-        if (isAtRest())
-        {
-            // If we were at rest, we're not anymore since we're sending a request.
-            cancelInactivityTimerTask();
-        }
-
         OutgoingMessage message(out, os, compress, requestId);
         status = sendMessage(message);
     }
@@ -666,11 +660,6 @@ Ice::ConnectionI::sendAsyncRequest(const OutgoingAsyncBasePtr& out, bool compres
     {
         _asyncRequestsHint =
             _asyncRequests.insert(_asyncRequests.end(), pair<const int32_t, OutgoingAsyncBasePtr>(requestId, out));
-    }
-    else if (isAtRest())
-    {
-        // A oneway invocation is considered completed as soon as sendMessage returns.
-        scheduleInactivityTimerTask();
     }
     return status;
 }
@@ -865,22 +854,15 @@ Ice::ConnectionI::asyncRequestCanceled(const OutgoingAsyncBasePtr& outAsync, exc
         {
             if (o->requestId)
             {
-                bool removed = false;
                 if (_asyncRequestsHint != _asyncRequests.end() &&
                     _asyncRequestsHint->second == dynamic_pointer_cast<OutgoingAsync>(outAsync))
                 {
                     _asyncRequests.erase(_asyncRequestsHint);
                     _asyncRequestsHint = _asyncRequests.end();
-                    removed = true;
                 }
                 else
                 {
-                    removed = _asyncRequests.erase(o->requestId) == 1;
-                }
-
-                if (removed && isAtRest())
-                {
-                    scheduleInactivityTimerTask();
+                    _asyncRequests.erase(o->requestId);
                 }
             }
 
@@ -935,11 +917,6 @@ Ice::ConnectionI::asyncRequestCanceled(const OutgoingAsyncBasePtr& outAsync, exc
                     _asyncRequests.erase(_asyncRequestsHint);
                     _asyncRequestsHint = _asyncRequests.end();
 
-                    if (isAtRest())
-                    {
-                        scheduleInactivityTimerTask();
-                    }
-
                     if (outAsync->exception(ex))
                     {
                         outAsync->invokeExceptionAsync();
@@ -965,11 +942,6 @@ Ice::ConnectionI::asyncRequestCanceled(const OutgoingAsyncBasePtr& outAsync, exc
                 {
                     assert(p != _asyncRequestsHint);
                     _asyncRequests.erase(p);
-
-                    if (isAtRest())
-                    {
-                        scheduleInactivityTimerTask();
-                    }
 
                     if (outAsync->exception(ex))
                     {
@@ -1011,10 +983,6 @@ Ice::ConnectionI::dispatchException(exception_ptr ex, int requestCount)
             }
 
             _dispatchCount -= requestCount;
-            if (isAtRest())
-            {
-                scheduleInactivityTimerTask();
-            }
         }
     }
     if (finished && _removeFromFactory)
@@ -1765,10 +1733,7 @@ Ice::ConnectionI::finish(bool close)
             o->completed(_exception);
             if (o->requestId) // Make sure finished isn't called twice.
             {
-                if (_asyncRequests.erase(o->requestId) == 1 && isAtRest())
-                {
-                    scheduleInactivityTimerTask();
-                }
+                _asyncRequests.erase(o->requestId);
             }
         }
 
@@ -1896,6 +1861,7 @@ Ice::ConnectionI::ConnectionI(
       _closeTimeout(options.closeTimeout), // not used for datagram connections
       // suppress inactivity timeout for datagram connections
       _inactivityTimeout(endpoint->datagram() ? chrono::seconds::zero() : options.inactivityTimeout),
+      _inactivityTimerTaskScheduled(false),
       _removeFromFactory(std::move(removeFromFactory)),
       _warn(_instance->initializationData().properties->getIcePropertyAsInt("Ice.Warn.Connections") > 0),
       _warnUdp(_instance->initializationData().properties->getIcePropertyAsInt("Ice.Warn.Datagrams") > 0),
@@ -2260,13 +2226,6 @@ Ice::ConnectionI::setState(State state)
             setState(StateClosed, current_exception());
         }
     }
-
-    if (isAtRest())
-    {
-        // If the connection became active and there is no outstanding invocation or dispatch (very common case), we
-        // schedule the inactivity timer task.
-        scheduleInactivityTimerTask();
-    }
 }
 
 void
@@ -2362,7 +2321,11 @@ Ice::ConnectionI::inactivityCheck() noexcept
 {
     // Called by the InactivityTimerTask.
     std::lock_guard lock(_mutex);
-    if (isAtRest())
+    if (_state == StateActive &&
+        _inactivityTimerTaskScheduled &&              // it's false if some other thread canceled the timer while we
+                                                      // were waiting for _mutex
+        !_timer->isScheduled(_inactivityTimerTask))   // make sure this timer task was not rescheduled for later while
+                                                      // we were waiting for _mutex (unlikely but may as well check)
     {
         setState(
             StateClosing,
@@ -2480,10 +2443,6 @@ Ice::ConnectionI::sendResponse(OutgoingResponse response, uint8_t compress)
             }
 
             --_dispatchCount;
-            if (isAtRest())
-            {
-                scheduleInactivityTimerTask();
-            }
         }
         catch (const LocalException&)
         {
@@ -2807,6 +2766,12 @@ Ice::ConnectionI::sendMessage(OutgoingMessage& message)
     assert(_state >= StateActive);
     assert(_state < StateClosed);
 
+    bool isHeartbeat = static_cast<uint8_t>(message.stream->b[8]) == IceInternal::validateConnectionMsg;
+    if (!isHeartbeat)
+    {
+        cancelInactivityTimerTask();
+    }
+
     message.stream->i = 0; // Reset the message stream iterator before starting sending the message.
 
     if (!_sendStreams.empty())
@@ -2814,6 +2779,20 @@ Ice::ConnectionI::sendMessage(OutgoingMessage& message)
         _sendStreams.push_back(message);
         _sendStreams.back().adopt(0);
         return AsyncStatusQueued;
+    }
+
+    // If we're sending a heartbeat, there is a chance the connection is inactive and that we need to schedule the
+    // inactivity timer task.
+    // It's ok to do this before actually sending the heartbeat since the heartbeat does not count as an "activity".
+    if (isHeartbeat &&
+        _inactivityTimerTask &&                // null when the inactivity timeout is infinite
+        !_inactivityTimerTaskScheduled &&      // we never reschedule this task
+        _state == StateActive &&               // only schedule the task if the connection is active
+        _dispatchCount == 0 &&                 // no pending dispatch
+        _asyncRequests.empty() &&              // no pending invocation
+        _sendStreams.empty())                  // no message in the send queue
+    {
+        scheduleInactivityTimerTask();
     }
 
     //
@@ -3185,10 +3164,7 @@ Ice::ConnectionI::parseMessage(int32_t& upcallCount, function<bool(InputStream&)
                     };
                     ++upcallCount;
 
-                    if (isAtRest())
-                    {
-                        cancelInactivityTimerTask();
-                    }
+                    cancelInactivityTimerTask();
                     ++_dispatchCount;
                 }
                 break;
@@ -3226,10 +3202,7 @@ Ice::ConnectionI::parseMessage(int32_t& upcallCount, function<bool(InputStream&)
                     };
                     upcallCount += requestCount;
 
-                    if (isAtRest())
-                    {
-                        cancelInactivityTimerTask();
-                    }
+                    cancelInactivityTimerTask();
                     _dispatchCount += requestCount;
                 }
                 break;
@@ -3269,11 +3242,6 @@ Ice::ConnectionI::parseMessage(int32_t& upcallCount, function<bool(InputStream&)
                     else
                     {
                         _asyncRequests.erase(q);
-                    }
-
-                    if (isAtRest())
-                    {
-                        scheduleInactivityTimerTask();
                     }
 
                     // The message stream is adopted by the outgoing.
@@ -3497,20 +3465,20 @@ void
 ConnectionI::scheduleInactivityTimerTask()
 {
     // Called with the ConnectionI mutex locked.
-    if (_inactivityTimeout > chrono::seconds::zero())
-    {
-        assert(_inactivityTimerTask);
-        _timer->schedule(_inactivityTimerTask, _inactivityTimeout);
-    }
+    assert(!_inactivityTimerTaskScheduled);
+    assert(_inactivityTimerTask);
+
+    _inactivityTimerTaskScheduled = true;
+    _timer->schedule(_inactivityTimerTask, _inactivityTimeout);
 }
 
 void
 ConnectionI::cancelInactivityTimerTask()
 {
     // Called with the ConnectionI mutex locked.
-    if (_inactivityTimeout > chrono::seconds::zero())
+    if (_inactivityTimerTaskScheduled && _inactivityTimerTask)
     {
-        assert(_inactivityTimerTask);
+        _inactivityTimerTaskScheduled = false;
         _timer->cancel(_inactivityTimerTask);
     }
 }

--- a/cpp/src/Ice/Timer.cpp
+++ b/cpp/src/Ice/Timer.cpp
@@ -49,6 +49,17 @@ Timer::cancel(const TimerTaskPtr& task)
     return cancelNoSync(task);
 }
 
+bool
+Timer::isScheduled(const TimerTaskPtr& task)
+{
+    lock_guard lock(_mutex);
+    if (_destroyed)
+    {
+        return false;
+    }
+    return _tasks.find(task) != _tasks.end();
+}
+
 void
 Timer::run()
 {

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1417,8 +1417,7 @@ Slice::Gen::DefaultFactoryVisitor::visitClassDefStart(const ClassDefPtr& p)
     }
 
     C << nl << "const ::IceInternal::DefaultValueFactoryInit<" << fixKwd(p->scoped()) << "> ";
-    C << "iceC" + p->flattenedScope() + p->name() + "_init"
-      << "(\"" << p->scoped() << "\");";
+    C << "iceC" + p->flattenedScope() + p->name() + "_init" << "(\"" << p->scoped() << "\");";
 
     if (p->compactId() >= 0)
     {
@@ -1439,8 +1438,7 @@ Slice::Gen::DefaultFactoryVisitor::visitExceptionStart(const ExceptionPtr& p)
         _factoryTableInitDone = true;
     }
     C << nl << "const ::IceInternal::DefaultUserExceptionFactoryInit<" << fixKwd(p->scoped()) << "> ";
-    C << "iceC" + p->flattenedScope() + p->name() + "_init"
-      << "(\"" << p->scoped() << "\");";
+    C << "iceC" + p->flattenedScope() + p->name() + "_init" << "(\"" << p->scoped() << "\");";
     return false;
 }
 
@@ -1822,8 +1820,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
 
     C << nl << "return ::IceInternal::makeLambdaOutgoing<" << lambdaT << ">" << spar;
 
-    C << "::std::move(" + (lambdaOutParams.size() > 1 ? string("responseCb") : "response") + ")"
-      << "::std::move(ex)"
+    C << "::std::move(" + (lambdaOutParams.size() > 1 ? string("responseCb") : "response") + ")" << "::std::move(ex)"
       << "::std::move(sent)"
       << "this";
     C << string("&" + getUnqualified(scoped, interfaceScope.substr(2)) + lambdaImplPrefix + name);

--- a/cpp/test/Ice/inactivityTimeout/Client.cpp
+++ b/cpp/test/Ice/inactivityTimeout/Client.cpp
@@ -18,9 +18,10 @@ Client::run(int argc, char** argv)
 {
     Ice::InitializationData initData;
     initData.properties = createTestProperties(argc, argv);
-    // We configure a low idle timeout to make sure we send heartbeats frequently.
+    // We configure a low idle timeout to make sure we send heartbeats frequently. It's the sending
+    // of the heartbeats that schedules the inactivity timer task.
     initData.properties->setProperty("Ice.Connection.IdleTimeout", "1");
-    initData.properties->setProperty("Ice.Connection.InactivityTimeout", "1");
+    initData.properties->setProperty("Ice.Connection.InactivityTimeout", "3");
     Ice::CommunicatorHolder communicator = initialize(argc, argv, initData);
 
     void allTests(Test::TestHelper*);

--- a/cpp/test/Ice/inactivityTimeout/Server.cpp
+++ b/cpp/test/Ice/inactivityTimeout/Server.cpp
@@ -18,22 +18,23 @@ Server::run(int argc, char** argv)
 {
     Ice::InitializationData initData;
     initData.properties = createTestProperties(argc, argv);
-    // We configure a low idle timeout to make sure we send heartbeats frequently.
+    // We configure a low idle timeout to make sure we send heartbeats frequently. It's the sending
+    // of the heartbeats that schedules the inactivity timer task.
     initData.properties->setProperty("Ice.Connection.IdleTimeout", "1");
-    initData.properties->setProperty("TestAdapter.Connection.InactivityTimeout", "2");
-    initData.properties->setProperty("TestAdapter1s.Connection.InactivityTimeout", "1");
+    initData.properties->setProperty("TestAdapter.Connection.InactivityTimeout", "5");
+    initData.properties->setProperty("TestAdapter3s.Connection.InactivityTimeout", "3");
 
     Ice::CommunicatorHolder communicator = initialize(argc, argv, initData);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
-    communicator->getProperties()->setProperty("TestAdapter1s.Endpoints", getTestEndpoint(1));
+    communicator->getProperties()->setProperty("TestAdapter3s.Endpoints", getTestEndpoint(1));
 
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
     adapter->activate();
 
-    Ice::ObjectAdapterPtr adapter1s = communicator->createObjectAdapter("TestAdapter1s");
-    adapter1s->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
-    adapter1s->activate();
+    Ice::ObjectAdapterPtr adapter3s = communicator->createObjectAdapter("TestAdapter3s");
+    adapter3s->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
+    adapter3s->activate();
 
     serverReady();
     communicator->waitForShutdown();


### PR DESCRIPTION
This PR implements my inactivity timeout simplification proposal (see #2222).

With this PR, we only schedule the inactivity timer task in one spot - sendMessage - when we send a heartbeat and when various other conditions are met.

