### PR TITLE
Simplify and Improve 'serialVersionUID' Code-Gen

### DIFF
--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -2579,49 +2579,7 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
 
     out << sp;
     writeHiddenDocComment(out);
-    out << nl << "public static final long serialVersionUID = ";
-    string serialVersionUID;
-    if (p->findMetaData("java:serialVersionUID", serialVersionUID))
-    {
-        const UnitPtr unt = p->unit();
-        const DefinitionContextPtr dc = unt->findDefinitionContext(p->file());
-        assert(dc);
-
-        string::size_type pos = serialVersionUID.rfind(":") + 1;
-        if (pos == string::npos)
-        {
-            ostringstream os;
-            os << "ignoring invalid serialVersionUID for class `" << p->scoped() << "'; generating default value";
-            dc->warning(InvalidMetaData, "", "", os.str());
-            out << computeSerialVersionUUID(p);
-        }
-        else
-        {
-            std::int64_t v = 0;
-            serialVersionUID = serialVersionUID.substr(pos);
-            if (serialVersionUID != "0")
-            {
-                try
-                {
-                    v = std::stoll(serialVersionUID, nullptr, 0);
-                }
-                catch (const std::exception&)
-                {
-                    ostringstream os;
-                    os << "ignoring invalid serialVersionUID for class `" << p->scoped()
-                       << "'; generating default value";
-                    dc->warning(InvalidMetaData, "", "", os.str());
-                    out << computeSerialVersionUUID(p);
-                }
-            }
-            out << v;
-        }
-    }
-    else
-    {
-        out << computeSerialVersionUUID(p);
-    }
-    out << "L;";
+    out << nl << getSerialVersionUID(p);
 
     writeMarshaling(out, p);
 
@@ -3097,49 +3055,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
 
     out << sp;
     writeHiddenDocComment(out);
-    out << nl << "public static final long serialVersionUID = ";
-    string serialVersionUID;
-    if (p->findMetaData("java:serialVersionUID", serialVersionUID))
-    {
-        const UnitPtr unt = p->unit();
-        const DefinitionContextPtr dc = unt->findDefinitionContext(p->file());
-        assert(dc);
-
-        string::size_type pos = serialVersionUID.rfind(":") + 1;
-        if (pos == string::npos)
-        {
-            ostringstream os;
-            os << "ignoring invalid serialVersionUID for exception `" << p->scoped() << "'; generating default value";
-            dc->warning(InvalidMetaData, "", "", os.str());
-            out << computeSerialVersionUUID(p);
-        }
-        else
-        {
-            std::int64_t v = 0;
-            serialVersionUID = serialVersionUID.substr(pos);
-            if (serialVersionUID != "0")
-            {
-                try
-                {
-                    v = std::stoll(serialVersionUID, nullptr, 0);
-                }
-                catch (const std::exception&)
-                {
-                    ostringstream os;
-                    os << "ignoring invalid serialVersionUID for exception `" << p->scoped()
-                       << "'; generating default value";
-                    dc->warning(InvalidMetaData, "", "", os.str());
-                    out << computeSerialVersionUUID(p);
-                }
-            }
-            out << v;
-        }
-    }
-    else
-    {
-        out << computeSerialVersionUUID(p);
-    }
-    out << "L;";
+    out << nl << getSerialVersionUID(p);
 
     out << eb;
     close();
@@ -3460,48 +3376,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
 
     out << sp;
     writeHiddenDocComment(out);
-    out << nl << "public static final long serialVersionUID = ";
-    string serialVersionUID;
-    if (p->findMetaData("java:serialVersionUID", serialVersionUID))
-    {
-        const UnitPtr unt = p->unit();
-        const DefinitionContextPtr dc = unt->findDefinitionContext(p->file());
-        assert(dc);
-        string::size_type pos = serialVersionUID.rfind(":") + 1;
-        if (pos == string::npos)
-        {
-            ostringstream os;
-            os << "ignoring invalid serialVersionUID for struct `" << p->scoped() << "'; generating default value";
-            dc->warning(InvalidMetaData, "", "", os.str());
-            out << computeSerialVersionUUID(p);
-        }
-        else
-        {
-            std::int64_t v = 0;
-            serialVersionUID = serialVersionUID.substr(pos);
-            if (serialVersionUID != "0")
-            {
-                try
-                {
-                    v = std::stoll(serialVersionUID, nullptr, 0);
-                }
-                catch (const std::exception&)
-                {
-                    ostringstream os;
-                    os << "ignoring invalid serialVersionUID for struct `" << p->scoped()
-                       << "'; generating default value";
-                    dc->warning(InvalidMetaData, "", "", os.str());
-                    out << computeSerialVersionUUID(p);
-                }
-            }
-            out << v;
-        }
-    }
-    else
-    {
-        out << computeSerialVersionUUID(p);
-    }
-    out << "L;";
+    out << nl << getSerialVersionUID(p);
 
     out << eb;
     close();

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -527,71 +527,89 @@ namespace
     };
 }
 
-long
-Slice::computeSerialVersionUUID(const ClassDefPtr& p)
+string
+Slice::getSerialVersionUID(const ContainedPtr& p)
 {
-    ostringstream os;
-    os << "Name: " << p->scoped();
+    optional<std::int64_t> serialVersionUID = nullopt;
 
-    os << " Base: [";
-    if (p->base())
+    // Check if the user provided their own UID value with metadata.
+    string metadata;
+    if (p->findMetaData("java:serialVersionUID", metadata))
     {
-        os << p->base()->scoped();
-    }
-    os << "]";
-
-    os << " Members: [";
-    DataMemberList members = p->dataMembers();
-    for (DataMemberList::const_iterator i = members.begin(); i != members.end();)
-    {
-        os << (*i)->name() << ":" << (*i)->type();
-        i++;
-        if (i != members.end())
+        string::size_type pos = metadata.rfind(":") + 1;
+        if (pos == string::npos)
         {
-            os << ", ";
+            ostringstream os;
+            os << "missing serialVersionUID value for " << p->kindOf() << " `" << p->scoped()
+               << "'; generating default value";
+            const DefinitionContextPtr dc = p->unit()->findDefinitionContext(p->file());
+            dc->warning(InvalidMetaData, "", "", os.str());
+        }
+        else
+        {
+            try
+            {
+                metadata = metadata.substr(pos);
+                serialVersionUID = std::stoll(metadata, nullptr, 0);
+            }
+            catch (const std::exception&)
+            {
+                ostringstream os;
+                os << "ignoring invalid serialVersionUID for " << p->kindOf() << " `" << p->scoped()
+                << "'; generating default value";
+                const DefinitionContextPtr dc = p->unit()->findDefinitionContext(p->file());
+                dc->warning(InvalidMetaData, "", "", os.str());
+            }
         }
     }
-    os << "]";
 
-    const string data = os.str();
-    long hashCode = 5381;
-    hashAdd(hashCode, data);
-    return hashCode;
+    // If the user didn't specify a UID through metadata (or it was malformed), compute a default UID instead.
+    if (!serialVersionUID)
+    {
+        serialVersionUID = computeDefaultSerialVersionUID(p);
+    }
+
+    ostringstream os;
+    os <<  "private static final long serialVersionUID = " << *serialVersionUID << "L;";
+    return os.str();
 }
 
 long
-Slice::computeSerialVersionUUID(const StructPtr& p)
+Slice::computeDefaultSerialVersionUID(const ContainedPtr& p)
 {
-    ostringstream os;
-
-    os << "Name: " << p->scoped();
-    os << " Members: [";
-    DataMemberList members = p->dataMembers();
-    for (DataMemberList::const_iterator i = members.begin(); i != members.end();)
+    string name;
+    DataMemberList members;
+    optional<string> baseName;
+    if (ClassDefPtr cl = dynamic_pointer_cast<ClassDef>(p))
     {
-        os << (*i)->name() << ":" << (*i)->type();
-        i++;
-        if (i != members.end())
-        {
-            os << ", ";
-        }
+        name = cl->scoped();
+        members = cl->dataMembers();
+        baseName = (cl->base())? cl->base()->scoped() : "";
     }
-    os << "]";
+    if (ExceptionPtr ex = dynamic_pointer_cast<Exception>(p))
+    {
+        name = ex->scoped();
+        members = ex->dataMembers();
+        baseName = nullopt;
+    }
+    if (StructPtr st = dynamic_pointer_cast<Struct>(p))
+    {
+        name = st->scoped();
+        members = st->dataMembers();
+        baseName = nullopt;
+    }
 
-    const string data = os.str();
-    long hashCode = 5381;
-    hashAdd(hashCode, data);
-    return hashCode;
-}
+    // Assert that this was called on either a class, exception, or struct.
+    assert(!name.empty());
 
-long
-Slice::computeSerialVersionUUID(const ExceptionPtr& p)
-{
+    // Actually compute the `SerialVersionUID` value.
     ostringstream os;
-
-    os << "Name: " << p->scoped();
+    os << "Name: " << name;
+    if (baseName)
+    {
+        os << " Base: [" << *baseName << "]";
+    }
     os << " Members: [";
-    DataMemberList members = p->dataMembers();
     for (DataMemberList::const_iterator i = members.begin(); i != members.end();)
     {
         os << (*i)->name() << ":" << (*i)->type();

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -556,7 +556,7 @@ Slice::getSerialVersionUID(const ContainedPtr& p)
             {
                 ostringstream os;
                 os << "ignoring invalid serialVersionUID for " << p->kindOf() << " `" << p->scoped()
-                << "'; generating default value";
+                   << "'; generating default value";
                 const DefinitionContextPtr dc = p->unit()->findDefinitionContext(p->file());
                 dc->warning(InvalidMetaData, "", "", os.str());
             }
@@ -577,30 +577,24 @@ Slice::getSerialVersionUID(const ContainedPtr& p)
 long
 Slice::computeDefaultSerialVersionUID(const ContainedPtr& p)
 {
-    string name;
+    string name = p->scoped();
     DataMemberList members;
     optional<string> baseName;
     if (ClassDefPtr cl = dynamic_pointer_cast<ClassDef>(p))
     {
-        name = cl->scoped();
         members = cl->dataMembers();
         baseName = (cl->base()) ? cl->base()->scoped() : "";
     }
     if (ExceptionPtr ex = dynamic_pointer_cast<Exception>(p))
     {
-        name = ex->scoped();
         members = ex->dataMembers();
         baseName = nullopt;
     }
     if (StructPtr st = dynamic_pointer_cast<Struct>(p))
     {
-        name = st->scoped();
         members = st->dataMembers();
         baseName = nullopt;
     }
-
-    // Assert that this was called on either a class, exception, or struct.
-    assert(!name.empty());
 
     // Actually compute the `SerialVersionUID` value.
     ostringstream os;

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -570,7 +570,7 @@ Slice::getSerialVersionUID(const ContainedPtr& p)
     }
 
     ostringstream os;
-    os <<  "private static final long serialVersionUID = " << *serialVersionUID << "L;";
+    os << "private static final long serialVersionUID = " << *serialVersionUID << "L;";
     return os.str();
 }
 
@@ -584,7 +584,7 @@ Slice::computeDefaultSerialVersionUID(const ContainedPtr& p)
     {
         name = cl->scoped();
         members = cl->dataMembers();
-        baseName = (cl->base())? cl->base()->scoped() : "";
+        baseName = (cl->base()) ? cl->base()->scoped() : "";
     }
     if (ExceptionPtr ex = dynamic_pointer_cast<Exception>(p))
     {

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -10,6 +10,11 @@
 
 namespace Slice
 {
+    //
+    // These functions should only be called for classes, exceptions, and structs.
+    // Enums automatically implement Serializable (Java just serializes the enumerator's identifier),
+    // and proxies get their implementation from `_ObjectPrxI`.
+    //
     std::string getSerialVersionUID(const ContainedPtr&);
     long computeDefaultSerialVersionUID(const ContainedPtr&);
 

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -10,20 +10,8 @@
 
 namespace Slice
 {
-    //
-    // Compute Java serialVersionUID for a Slice class
-    //
-    long computeSerialVersionUUID(const ClassDefPtr&);
-
-    //
-    // Compute Java serialVersionUID for a Slice class
-    //
-    long computeSerialVersionUUID(const ExceptionPtr&);
-
-    //
-    // Compute Java serialVersionUID for a Slice struct
-    //
-    long computeSerialVersionUUID(const StructPtr&);
+    std::string getSerialVersionUID(const ContainedPtr&);
+    long computeDefaultSerialVersionUID(const ContainedPtr&);
 
     //
     // Returns true if we can generate a method from the given data member list. A Java method


### PR DESCRIPTION
This PR simplifies the code-gen logic for adding `serialVersionUID` to Slice classes, exceptions, and structs.
Currently, we write out nearly identical logic 3 separate times, and have 3 separate functions for computing UIDs (1 for each type).

Since the logic is nearly identical, I moved it into a single central helper function.

The only changes in logic are:
- the generated field is now `private` instead of `public` (see: #283)
- if the user's metadata is missing the actual value (ie. `java:serialVersionUID` instead of `java:serialVersionUID:7979`),
  the emitted error used to say "ignoring invalid serialVerionUID...", now it says "missing serialVersionUID value..."
  (we still use the old "ignoring invalid" message if the user passes a legitimately invalid value)