### PR TITLE
Update 'serialVersionUID' Fields in Java

### DIFF
--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -4727,7 +4727,6 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
          << "Prx";
     outi << sb;
     outi << sp;
-    writeHiddenDocComment(outi);
     outi << nl << "private static final long serialVersionUID = 0L;";
     outi << eb;
     close();

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -4728,7 +4728,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     outi << sb;
     outi << sp;
     writeHiddenDocComment(outi);
-    outi << nl << "public static final long serialVersionUID = 0L;";
+    outi << nl << "private static final long serialVersionUID = 0L;";
     outi << eb;
     close();
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/AlreadyRegisteredException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/AlreadyRegisteredException.java
@@ -57,8 +57,5 @@ public class AlreadyRegisteredException extends LocalException {
   /** The ID (or name) of the object that is registered already. */
   public String id;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 392587231034664196L;
+  private static final long serialVersionUID = 392587231034664196L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/BadMagicException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/BadMagicException.java
@@ -45,8 +45,5 @@ public class BadMagicException extends ProtocolException {
   /** A sequence containing the first four bytes of the incorrect message. */
   public byte[] badMagic;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -3934807911473944716L;
+  private static final long serialVersionUID = -3934807911473944716L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/CloseConnectionException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/CloseConnectionException.java
@@ -44,8 +44,5 @@ public class CloseConnectionException extends ProtocolException {
     return "::Ice::CloseConnectionException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 4166975853591251903L;
+  private static final long serialVersionUID = 4166975853591251903L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/CloseTimeoutException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/CloseTimeoutException.java
@@ -29,8 +29,5 @@ public class CloseTimeoutException extends TimeoutException {
     return "::Ice::CloseTimeoutException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -702193953324375086L;
+  private static final long serialVersionUID = -702193953324375086L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/CommunicatorDestroyedException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/CommunicatorDestroyedException.java
@@ -31,8 +31,5 @@ public class CommunicatorDestroyedException extends LocalException {
     return "::Ice::CommunicatorDestroyedException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 752535633703849L;
+  private static final long serialVersionUID = 752535633703849L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/CompressionException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/CompressionException.java
@@ -37,8 +37,5 @@ public class CompressionException extends ProtocolException {
     return "::Ice::CompressionException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -3980762816174249071L;
+  private static final long serialVersionUID = -3980762816174249071L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectFailedException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectFailedException.java
@@ -37,8 +37,5 @@ public class ConnectFailedException extends SocketException {
     return "::Ice::ConnectFailedException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 3367444083227777090L;
+  private static final long serialVersionUID = 3367444083227777090L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectTimeoutException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectTimeoutException.java
@@ -29,8 +29,5 @@ public class ConnectTimeoutException extends TimeoutException {
     return "::Ice::ConnectTimeoutException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -1271371420507272518L;
+  private static final long serialVersionUID = -1271371420507272518L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionInfo.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionInfo.java
@@ -51,9 +51,4 @@ public class ConnectionInfo implements java.lang.Cloneable {
     }
     return c;
   }
-
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -8138441397879390442L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionLostException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionLostException.java
@@ -37,8 +37,5 @@ public class ConnectionLostException extends SocketException {
     return "::Ice::ConnectionLostException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -7871526265585148499L;
+  private static final long serialVersionUID = -7871526265585148499L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionManuallyClosedException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionManuallyClosedException.java
@@ -44,8 +44,5 @@ public class ConnectionManuallyClosedException extends LocalException {
   /** True if the connection was closed gracefully, false otherwise. */
   public boolean graceful;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 1412128468475443570L;
+  private static final long serialVersionUID = 1412128468475443570L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionNotValidatedException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionNotValidatedException.java
@@ -39,8 +39,5 @@ public class ConnectionNotValidatedException extends ProtocolException {
     return "::Ice::ConnectionNotValidatedException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 1338347369471941150L;
+  private static final long serialVersionUID = 1338347369471941150L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionRefusedException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionRefusedException.java
@@ -40,8 +40,5 @@ public class ConnectionRefusedException extends ConnectFailedException {
     return "::Ice::ConnectionRefusedException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 2368977428979563391L;
+  private static final long serialVersionUID = 2368977428979563391L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionTimeoutException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionTimeoutException.java
@@ -32,8 +32,5 @@ public class ConnectionTimeoutException extends TimeoutException {
     return "::Ice::ConnectionTimeoutException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 1630370601897802194L;
+  private static final long serialVersionUID = 1630370601897802194L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/DNSException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/DNSException.java
@@ -56,8 +56,5 @@ public class DNSException extends LocalException {
   /** The host name that could not be resolved. */
   public String host;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 824453629913156786L;
+  private static final long serialVersionUID = 824453629913156786L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/DatagramLimitException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/DatagramLimitException.java
@@ -41,8 +41,5 @@ public class DatagramLimitException extends ProtocolException {
     return "::Ice::DatagramLimitException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -783492847222783613L;
+  private static final long serialVersionUID = -783492847222783613L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/EncapsulationException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/EncapsulationException.java
@@ -37,8 +37,5 @@ public class EncapsulationException extends MarshalException {
     return "::Ice::EncapsulationException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 6924075986153135793L;
+  private static final long serialVersionUID = 6924075986153135793L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/EndpointInfo.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/EndpointInfo.java
@@ -62,9 +62,4 @@ public abstract class EndpointInfo implements java.lang.Cloneable {
     }
     return c;
   }
-
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -7228250335304066764L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/EndpointParseException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/EndpointParseException.java
@@ -42,8 +42,5 @@ public class EndpointParseException extends LocalException {
   /** Describes the failure and includes the string that could not be parsed. */
   public String str;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 2726204311748106167L;
+  private static final long serialVersionUID = 2726204311748106167L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/EndpointSelectionTypeParseException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/EndpointSelectionTypeParseException.java
@@ -42,8 +42,5 @@ public class EndpointSelectionTypeParseException extends LocalException {
   /** Describes the failure and includes the string that could not be parsed. */
   public String str;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 5767960053089269935L;
+  private static final long serialVersionUID = 5767960053089269935L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/Exception.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/Exception.java
@@ -58,5 +58,5 @@ public abstract class Exception extends RuntimeException implements Cloneable {
     return sw.toString();
   }
 
-  public static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/FacetNotExistException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/FacetNotExistException.java
@@ -40,8 +40,5 @@ public class FacetNotExistException extends RequestFailedException {
     return "::Ice::FacetNotExistException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -584705670010603188L;
+  private static final long serialVersionUID = -584705670010603188L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/FeatureNotSupportedException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/FeatureNotSupportedException.java
@@ -45,8 +45,5 @@ public class FeatureNotSupportedException extends LocalException {
   /** The name of the unsupported feature. */
   public String unsupportedFeature;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -4629958372080397318L;
+  private static final long serialVersionUID = -4629958372080397318L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/FileException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/FileException.java
@@ -44,8 +44,5 @@ public class FileException extends SyscallException {
   /** The path of the file responsible for the error. */
   public String path;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 8755315548941623583L;
+  private static final long serialVersionUID = 8755315548941623583L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/FixedProxyException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/FixedProxyException.java
@@ -30,8 +30,5 @@ public class FixedProxyException extends LocalException {
     return "::Ice::FixedProxyException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 3198117120780643493L;
+  private static final long serialVersionUID = 3198117120780643493L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/IPConnectionInfo.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/IPConnectionInfo.java
@@ -56,9 +56,4 @@ public class IPConnectionInfo extends ConnectionInfo {
   public IPConnectionInfo clone() {
     return (IPConnectionInfo) super.clone();
   }
-
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 8533006463792298184L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/IPEndpointInfo.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/IPEndpointInfo.java
@@ -52,9 +52,4 @@ public abstract class IPEndpointInfo extends EndpointInfo {
   public IPEndpointInfo clone() {
     return (IPEndpointInfo) super.clone();
   }
-
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 1740540942649122045L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/IdentityParseException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/IdentityParseException.java
@@ -42,8 +42,5 @@ public class IdentityParseException extends LocalException {
   /** Describes the failure and includes the string that could not be parsed. */
   public String str;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 8547577763521735682L;
+  private static final long serialVersionUID = 8547577763521735682L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/IllegalIdentityException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/IllegalIdentityException.java
@@ -42,8 +42,5 @@ public class IllegalIdentityException extends LocalException {
   /** The illegal identity. */
   public Identity id;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -2349418144702375351L;
+  private static final long serialVersionUID = -2349418144702375351L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/IllegalMessageSizeException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/IllegalMessageSizeException.java
@@ -37,8 +37,5 @@ public class IllegalMessageSizeException extends ProtocolException {
     return "::Ice::IllegalMessageSizeException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 3581741698610780247L;
+  private static final long serialVersionUID = 3581741698610780247L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/IllegalServantException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/IllegalServantException.java
@@ -42,8 +42,5 @@ public class IllegalServantException extends LocalException {
   /** Describes why this servant is illegal. */
   public String reason;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 1134807368810099935L;
+  private static final long serialVersionUID = 1134807368810099935L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/InitializationException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/InitializationException.java
@@ -42,8 +42,5 @@ public class InitializationException extends LocalException {
   /** The reason for the failure. */
   public String reason;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 578611869232039264L;
+  private static final long serialVersionUID = 578611869232039264L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/InterfaceByValue.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/InterfaceByValue.java
@@ -42,10 +42,7 @@ public class InterfaceByValue extends Value {
     istr.endSlice();
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 0L;
-
   private String _id;
+
+  private static final long serialVersionUID = 7776480078901488923L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/InvocationCanceledException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/InvocationCanceledException.java
@@ -30,8 +30,5 @@ public class InvocationCanceledException extends LocalException {
     return "::Ice::InvocationCanceledException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -6429704142271073768L;
+  private static final long serialVersionUID = -6429704142271073768L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/InvocationTimeoutException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/InvocationTimeoutException.java
@@ -29,8 +29,5 @@ public class InvocationTimeoutException extends TimeoutException {
     return "::Ice::InvocationTimeoutException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -4956443780705036860L;
+  private static final long serialVersionUID = -4956443780705036860L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/LocalException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/LocalException.java
@@ -12,5 +12,5 @@ public abstract class LocalException extends Exception {
     super(cause);
   }
 
-  public static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/MarshalException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/MarshalException.java
@@ -37,8 +37,5 @@ public class MarshalException extends ProtocolException {
     return "::Ice::MarshalException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -1332260000897066889L;
+  private static final long serialVersionUID = -1332260000897066889L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/MemoryLimitException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/MemoryLimitException.java
@@ -40,8 +40,5 @@ public class MemoryLimitException extends MarshalException {
     return "::Ice::MemoryLimitException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 8256664949263546187L;
+  private static final long serialVersionUID = 8256664949263546187L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/NoEndpointException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/NoEndpointException.java
@@ -42,8 +42,5 @@ public class NoEndpointException extends LocalException {
   /** The stringified proxy for which no suitable endpoint is available. */
   public String proxy;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -5026638954785808518L;
+  private static final long serialVersionUID = -5026638954785808518L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/NoValueFactoryException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/NoValueFactoryException.java
@@ -52,8 +52,5 @@ public class NoValueFactoryException extends MarshalException {
   /** The Slice type ID of the class instance for which no factory could be found. */
   public String type;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -4888152001471748622L;
+  private static final long serialVersionUID = -4888152001471748622L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/NotRegisteredException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/NotRegisteredException.java
@@ -59,8 +59,5 @@ public class NotRegisteredException extends LocalException {
   /** The ID (or name) of the object that could not be removed. */
   public String id;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 3335358291266771447L;
+  private static final long serialVersionUID = 3335358291266771447L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectAdapterDeactivatedException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectAdapterDeactivatedException.java
@@ -47,8 +47,5 @@ public class ObjectAdapterDeactivatedException extends LocalException {
   /** Name of the adapter. */
   public String name;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -1946575462194055987L;
+  private static final long serialVersionUID = -1946575462194055987L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectAdapterIdInUseException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectAdapterIdInUseException.java
@@ -45,8 +45,5 @@ public class ObjectAdapterIdInUseException extends LocalException {
   /** Adapter ID. */
   public String id;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 609699148378869554L;
+  private static final long serialVersionUID = 609699148378869554L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectNotExistException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectNotExistException.java
@@ -40,8 +40,5 @@ public class ObjectNotExistException extends RequestFailedException {
     return "::Ice::ObjectNotExistException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 5680607485723114764L;
+  private static final long serialVersionUID = 5680607485723114764L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/OpaqueEndpointInfo.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/OpaqueEndpointInfo.java
@@ -46,9 +46,4 @@ public abstract class OpaqueEndpointInfo extends EndpointInfo {
   public OpaqueEndpointInfo clone() {
     return (OpaqueEndpointInfo) super.clone();
   }
-
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 2439699764526521524L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/OperationInterruptedException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/OperationInterruptedException.java
@@ -27,8 +27,5 @@ public class OperationInterruptedException extends LocalException {
     return "::Ice::OperationInterruptedException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -1099536335133286580L;
+  private static final long serialVersionUID = -1099536335133286580L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/OperationNotExistException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/OperationNotExistException.java
@@ -41,8 +41,5 @@ public class OperationNotExistException extends RequestFailedException {
     return "::Ice::OperationNotExistException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 3973646568523472620L;
+  private static final long serialVersionUID = 3973646568523472620L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/PluginInitializationException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/PluginInitializationException.java
@@ -42,8 +42,5 @@ public class PluginInitializationException extends LocalException {
   /** The reason for the failure. */
   public String reason;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 1589933368626096169L;
+  private static final long serialVersionUID = 1589933368626096169L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ProtocolException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ProtocolException.java
@@ -42,8 +42,5 @@ public class ProtocolException extends LocalException {
   /** The reason for the failure. */
   public String reason;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 6046324714700663302L;
+  private static final long serialVersionUID = 6046324714700663302L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ProxyParseException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ProxyParseException.java
@@ -42,8 +42,5 @@ public class ProxyParseException extends LocalException {
   /** Describes the failure and includes the string that could not be parsed. */
   public String str;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 1426520612608626840L;
+  private static final long serialVersionUID = 1426520612608626840L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ProxyUnmarshalException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ProxyUnmarshalException.java
@@ -37,8 +37,5 @@ public class ProxyUnmarshalException extends MarshalException {
     return "::Ice::ProxyUnmarshalException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 2987361361391436704L;
+  private static final long serialVersionUID = 2987361361391436704L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/RequestFailedException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/RequestFailedException.java
@@ -60,8 +60,5 @@ public class RequestFailedException extends LocalException {
   /** The operation name of the request. */
   public String operation;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 4181164754424262091L;
+  private static final long serialVersionUID = 4181164754424262091L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/SSL/ConnectionInfo.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/SSL/ConnectionInfo.java
@@ -37,9 +37,4 @@ public class ConnectionInfo extends com.zeroc.Ice.ConnectionInfo {
   public ConnectionInfo clone() {
     return (ConnectionInfo) super.clone();
   }
-
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 8227416448029738634L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/SSL/EndpointInfo.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/SSL/EndpointInfo.java
@@ -17,9 +17,4 @@ public abstract class EndpointInfo extends com.zeroc.Ice.EndpointInfo {
   public EndpointInfo clone() {
     return (EndpointInfo) super.clone();
   }
-
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 5490788644436785361L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/SSL/RFC2253.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/SSL/RFC2253.java
@@ -22,7 +22,7 @@ class RFC2253 {
 
     public String reason;
 
-    public static final long serialVersionUID = 0L;
+    private static final long serialVersionUID = 6648623149548446986L;
   }
 
   static class RDNPair {

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/SecurityException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/SecurityException.java
@@ -42,8 +42,5 @@ public class SecurityException extends LocalException {
   /** The reason for the failure. */
   public String reason;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 7929245908983964710L;
+  private static final long serialVersionUID = 7929245908983964710L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/SocketException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/SocketException.java
@@ -37,8 +37,5 @@ public class SocketException extends SyscallException {
     return "::Ice::SocketException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -7634050967564791782L;
+  private static final long serialVersionUID = -7634050967564791782L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/SyscallException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/SyscallException.java
@@ -50,8 +50,5 @@ public class SyscallException extends LocalException {
    */
   public int error;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -2440066513892919497L;
+  private static final long serialVersionUID = -2440066513892919497L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/TCPConnectionInfo.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/TCPConnectionInfo.java
@@ -56,9 +56,4 @@ public class TCPConnectionInfo extends IPConnectionInfo {
   public TCPConnectionInfo clone() {
     return (TCPConnectionInfo) super.clone();
   }
-
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 991962771996026865L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/TCPEndpointInfo.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/TCPEndpointInfo.java
@@ -38,9 +38,4 @@ public abstract class TCPEndpointInfo extends IPEndpointInfo {
   public TCPEndpointInfo clone() {
     return (TCPEndpointInfo) super.clone();
   }
-
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -7607491251938374557L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/TimeoutException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/TimeoutException.java
@@ -27,8 +27,5 @@ public class TimeoutException extends LocalException {
     return "::Ice::TimeoutException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 1390295317871659332L;
+  private static final long serialVersionUID = 1390295317871659332L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/TwowayOnlyException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/TwowayOnlyException.java
@@ -47,8 +47,5 @@ public class TwowayOnlyException extends LocalException {
   /** The name of the operation that was invoked. */
   public String operation;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -7036652448391478186L;
+  private static final long serialVersionUID = -7036652448391478186L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/UDPConnectionInfo.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/UDPConnectionInfo.java
@@ -68,9 +68,4 @@ public class UDPConnectionInfo extends IPConnectionInfo {
   public UDPConnectionInfo clone() {
     return (UDPConnectionInfo) super.clone();
   }
-
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -8596817245040015144L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/UDPEndpointInfo.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/UDPEndpointInfo.java
@@ -49,9 +49,4 @@ public abstract class UDPEndpointInfo extends IPEndpointInfo {
   public UDPEndpointInfo clone() {
     return (UDPEndpointInfo) super.clone();
   }
-
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 6545930812316183136L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/UnexpectedObjectException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/UnexpectedObjectException.java
@@ -58,8 +58,5 @@ public class UnexpectedObjectException extends MarshalException {
   /** The Slice type ID that was expected by the receiving operation. */
   public String expectedType;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -5786936875383180611L;
+  private static final long serialVersionUID = -5786936875383180611L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/UnknownException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/UnknownException.java
@@ -47,8 +47,5 @@ public class UnknownException extends LocalException {
   /** This field is set to the textual representation of the unknown exception if available. */
   public String unknown;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 4845487294380422868L;
+  private static final long serialVersionUID = 4845487294380422868L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/UnknownLocalException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/UnknownLocalException.java
@@ -43,8 +43,5 @@ public class UnknownLocalException extends UnknownException {
     return "::Ice::UnknownLocalException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 1374449481624773050L;
+  private static final long serialVersionUID = 1374449481624773050L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/UnknownMessageException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/UnknownMessageException.java
@@ -37,8 +37,5 @@ public class UnknownMessageException extends ProtocolException {
     return "::Ice::UnknownMessageException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 1625154579332341724L;
+  private static final long serialVersionUID = 1625154579332341724L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/UnknownReplyStatusException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/UnknownReplyStatusException.java
@@ -37,8 +37,5 @@ public class UnknownReplyStatusException extends ProtocolException {
     return "::Ice::UnknownReplyStatusException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -6816121886863135119L;
+  private static final long serialVersionUID = -6816121886863135119L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/UnknownSlicedValue.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/UnknownSlicedValue.java
@@ -27,8 +27,5 @@ public final class UnknownSlicedValue extends Value {
 
   private final String _unknownTypeId;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = -3199177633147630863L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/UnknownUserException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/UnknownUserException.java
@@ -44,8 +44,5 @@ public class UnknownUserException extends UnknownException {
     return "::Ice::UnknownUserException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -6046568406824082586L;
+  private static final long serialVersionUID = -6046568406824082586L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/UnmarshalOutOfBoundsException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/UnmarshalOutOfBoundsException.java
@@ -37,8 +37,5 @@ public class UnmarshalOutOfBoundsException extends MarshalException {
     return "::Ice::UnmarshalOutOfBoundsException";
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -1750105256021843030L;
+  private static final long serialVersionUID = -1750105256021843030L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/UnsupportedEncodingException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/UnsupportedEncodingException.java
@@ -53,8 +53,5 @@ public class UnsupportedEncodingException extends ProtocolException {
   /** The version of the encoding that is supported. */
   public EncodingVersion supported;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -4128311673376608852L;
+  private static final long serialVersionUID = -4128311673376608852L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/UnsupportedProtocolException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/UnsupportedProtocolException.java
@@ -53,8 +53,5 @@ public class UnsupportedProtocolException extends ProtocolException {
   /** The version of the protocol that is supported. */
   public ProtocolVersion supported;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 811091383730564025L;
+  private static final long serialVersionUID = 811091383730564025L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/UserException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/UserException.java
@@ -94,8 +94,5 @@ public abstract class UserException extends java.lang.Exception implements Clone
    */
   protected abstract void _readImpl(InputStream is);
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/Value.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/Value.java
@@ -90,10 +90,7 @@ public abstract class Value implements java.lang.Cloneable, java.io.Serializable
    */
   protected void _iceReadImpl(InputStream istr) {}
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 0L;
-
   private SlicedData _slicedData;
+
+  private static final long serialVersionUID = 0L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ValueReader.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ValueReader.java
@@ -29,8 +29,5 @@ public abstract class ValueReader extends Value {
     read(is);
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ValueWriter.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ValueWriter.java
@@ -29,8 +29,5 @@ public abstract class ValueWriter extends Value {
     assert (false);
   }
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/VersionParseException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/VersionParseException.java
@@ -42,8 +42,5 @@ public class VersionParseException extends LocalException {
   /** Describes the failure and includes the string that could not be parsed. */
   public String str;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 8839069742920598766L;
+  private static final long serialVersionUID = 8839069742920598766L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/WSConnectionInfo.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/WSConnectionInfo.java
@@ -37,9 +37,4 @@ public class WSConnectionInfo extends ConnectionInfo {
   public WSConnectionInfo clone() {
     return (WSConnectionInfo) super.clone();
   }
-
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 9085761366886580254L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/WSEndpointInfo.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/WSEndpointInfo.java
@@ -33,9 +33,4 @@ public abstract class WSEndpointInfo extends EndpointInfo {
   public WSEndpointInfo clone() {
     return (WSEndpointInfo) super.clone();
   }
-
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 6685502615474659064L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/_ObjectPrxI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/_ObjectPrxI.java
@@ -557,5 +557,5 @@ public class _ObjectPrxI implements ObjectPrx, java.io.Serializable {
   private transient com.zeroc.IceInternal.RequestHandler _requestHandler;
   private transient com.zeroc.IceInternal.BatchRequestQueue _batchRequestQueue;
   private transient List<StreamPair> _streamCache;
-  public static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/OutgoingConnectionFactory.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/OutgoingConnectionFactory.java
@@ -32,7 +32,7 @@ public final class OutgoingConnectionFactory {
       return v;
     }
 
-    public static final long serialVersionUID = 0L;
+    private static final long serialVersionUID = -8109942200313578944L;
   }
 
   interface CreateConnectionCallback {

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/RetryException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/RetryException.java
@@ -15,5 +15,5 @@ public class RetryException extends Exception {
 
   private com.zeroc.Ice.LocalException _ex;
 
-  public static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = -8555917196921366848L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/Selector.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/Selector.java
@@ -6,7 +6,7 @@ package com.zeroc.IceInternal;
 
 public final class Selector {
   static final class TimeoutException extends Exception {
-    public static final long serialVersionUID = 0L;
+    private static final long serialVersionUID = 7885765825975312023L;
   }
 
   Selector(Instance instance) {

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/ThreadPool.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/ThreadPool.java
@@ -61,7 +61,7 @@ public final class ThreadPool implements java.util.concurrent.Executor {
   // Exception raised by the thread pool work queue when the thread pool is destroyed.
   //
   static final class DestroyedException extends RuntimeException {
-    public static final long serialVersionUID = 0L;
+    private static final long serialVersionUID = -6665535975321237670L;
   }
 
   public ThreadPool(Instance instance, String prefix, int timeout) {

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/WebSocketException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/WebSocketException.java
@@ -17,5 +17,5 @@ final class WebSocketException extends java.lang.RuntimeException {
     super(cause);
   }
 
-  public static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 133989672864895760L;
 }

--- a/java/src/Ice/src/main/java/com/zeroc/IceUtilInternal/Options.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceUtilInternal/Options.java
@@ -10,7 +10,7 @@ public final class Options {
       super(message);
     }
 
-    public static final long serialVersionUID = 0L;
+    private static final long serialVersionUID = 6480189184773557516L;
   }
 
   public static String[] split(String line) throws BadQuote {

--- a/java/src/IceBT/src/main/java/com/zeroc/IceBT/BluetoothException.java
+++ b/java/src/IceBT/src/main/java/com/zeroc/IceBT/BluetoothException.java
@@ -42,8 +42,5 @@ public class BluetoothException extends com.zeroc.Ice.LocalException {
   /** Provides more information about the failure. */
   public String reason;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -2714934297616925968L;
+  private static final long serialVersionUID = -2714934297616925968L;
 }

--- a/java/src/IceBT/src/main/java/com/zeroc/IceBT/ConnectionInfo.java
+++ b/java/src/IceBT/src/main/java/com/zeroc/IceBT/ConnectionInfo.java
@@ -74,9 +74,4 @@ public class ConnectionInfo extends com.zeroc.Ice.ConnectionInfo {
   public ConnectionInfo clone() {
     return (ConnectionInfo) super.clone();
   }
-
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -1320122761309365325L;
 }

--- a/java/src/IceBT/src/main/java/com/zeroc/IceBT/EndpointInfo.java
+++ b/java/src/IceBT/src/main/java/com/zeroc/IceBT/EndpointInfo.java
@@ -43,9 +43,4 @@ public abstract class EndpointInfo extends com.zeroc.Ice.EndpointInfo {
   public EndpointInfo clone() {
     return (EndpointInfo) super.clone();
   }
-
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = 4825481358879091449L;
 }

--- a/java/src/IceBox/src/main/java/com/zeroc/IceBox/FailureException.java
+++ b/java/src/IceBox/src/main/java/com/zeroc/IceBox/FailureException.java
@@ -46,8 +46,5 @@ public class FailureException extends com.zeroc.Ice.LocalException {
   /** The reason for the failure. */
   public String reason;
 
-  /**
-   * @hidden
-   */
-  public static final long serialVersionUID = -7740030157337496059L;
+  private static final long serialVersionUID = -7740030157337496059L;
 }

--- a/java/src/IceGridGUI/icegridgui.pro
+++ b/java/src/IceGridGUI/icegridgui.pro
@@ -72,7 +72,7 @@
 -dontobfuscate
 
 -keepclassmembers class * implements java.io.Serializable {
-    static final long serialVersionUID;
+    private static final long serialVersionUID;
     private void writeObject(java.io.ObjectOutputStream);
     private void readObject(java.io.ObjectInputStream);
     java.lang.Object writeReplace();

--- a/java/test/src/main/java/test/Ice/optional/SerializableClass.java
+++ b/java/test/src/main/java/test/Ice/optional/SerializableClass.java
@@ -19,5 +19,5 @@ public class SerializableClass implements java.io.Serializable {
   }
 
   private int _v;
-  public static final long serialVersionUID = 1;
+  private static final long serialVersionUID = 1;
 }


### PR DESCRIPTION
This PR is the 2nd half in implementing #283 (following after #2307).
It updates all of the `serialVersionUID` fields we have in the non-generated code.

1) There were some classes that weren't even serializable which had this field... so I deleted the field there.
2) There were some places where we were setting a UID of `0`, presumably out of laziness. These were updated with real values.
An exception to this is abstract classes; abstract classes can never be serialized (since they cannot be instantiated), but it's still seen as good practice to provide a UID, so for those classes, I left the value of `0` alone. It's fine.
3) All of the fields were made `private` instead of `public`.

----

### For future people

The JDK includes a tool for computing these UIDs, which can be invoked as follows:
```java
PS D:\ice\java> serialver -classpath "src\Ice\build\classes\java\main" com.zeroc.Ice.UnknownSlicedValue
com.zeroc.Ice.UnknownSlicedValue:    private static final long serialVersionUID = -3199177633147630863L;
```
and will also inform you when the field shouldn't be present:
```java
PS D:\ice\java> serialver -classpath "src\Ice\build\classes\java\main" com.zeroc.Ice.OpaqueEndpointInfo
Class com.zeroc.Ice.OpaqueEndpointInfo is not Serializable.
```

Theoretically, whenever we update the fields of a serializable class, we should be re-computing it's `serialVersionUID`.