### PR TITLE
Move Proxy Factory Logic from `_Prx` to `_PrxI`

### DIFF
--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -4314,268 +4314,92 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     out << eb;
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, except for the per-proxy context.\n"
-        "@param newContext The context for the new proxy.\n"
-        "@return A proxy with the specified per-proxy context.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_context(java.util.Map<String, String> newContext)";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_context(newContext);";
-    out << eb;
+    out << nl << p->name() << "Prx ice_context(java.util.Map<String, String> newContext);";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, except for the adapter ID.\n"
-        "@param newAdapterId The adapter ID for the new proxy.\n"
-        "@return A proxy with the specified adapter ID.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_adapterId(String newAdapterId)";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_adapterId(newAdapterId);";
-    out << eb;
+    out << nl << p->name() << "Prx ice_adapterId(String newAdapterId);";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, except for the endpoints.\n"
-        "@param newEndpoints The endpoints for the new proxy.\n"
-        "@return A proxy with the specified endpoints.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_endpoints(com.zeroc.Ice.Endpoint[] newEndpoints)";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_endpoints(newEndpoints);";
-    out << eb;
+    out << nl << p->name() << "Prx ice_endpoints(com.zeroc.Ice.Endpoint[] newEndpoints);";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, except for the locator cache timeout.\n"
-        "@param newTimeout The new locator cache timeout (in seconds).\n"
-        "@return A proxy with the specified locator cache timeout.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_locatorCacheTimeout(int newTimeout)";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_locatorCacheTimeout(newTimeout);";
-    out << eb;
+    out << nl << p->name() << "Prx ice_locatorCacheTimeout(int newTimeout);";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, except for the invocation timeout.\n"
-        "@param newTimeout The new invocation timeout (in seconds).\n"
-        "@return A proxy with the specified invocation timeout.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_invocationTimeout(int newTimeout)";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_invocationTimeout(newTimeout);";
-    out << eb;
+    out << nl << p->name() << "Prx ice_invocationTimeout(int newTimeout);";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, except for connection caching.\n"
-        "@param newCache <code>true</code> if the new proxy should cache connections; <code>false</code> otherwise.\n"
-        "@return A proxy with the specified caching policy.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_connectionCached(boolean newCache)";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_connectionCached(newCache);";
-    out << eb;
+    out << nl << p->name() << "Prx ice_connectionCached(boolean newCache);";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, except for the endpoint selection policy.\n"
-        "@param newType The new endpoint selection policy.\n"
-        "@return A proxy with the specified endpoint selection policy.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_endpointSelection(com.zeroc.Ice.EndpointSelectionType newType)";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_endpointSelection(newType);";
-    out << eb;
+    out << nl << p->name() << "Prx ice_endpointSelection(com.zeroc.Ice.EndpointSelectionType newType);";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, except for how it selects endpoints.\n"
-        "@param b If <code>b</code> is <code>true</code>, only endpoints that use a secure transport are\n"
-        "used by the new proxy. If <code>b</code> is false, the returned proxy uses both secure and\n"
-        "insecure endpoints.\n"
-        "@return A proxy with the specified selection policy.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_secure(boolean b)";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_secure(b);";
-    out << eb;
+    out << nl << p->name() << "Prx ice_secure(boolean b);";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, except for the encoding used to marshal parameters.\n"
-        "@param e The encoding version to use to marshal request parameters.\n"
-        "@return A proxy with the specified encoding version.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_encodingVersion(com.zeroc.Ice.EncodingVersion e)";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_encodingVersion(e);";
-    out << eb;
+    out << nl << p->name() << "Prx ice_encodingVersion(com.zeroc.Ice.EncodingVersion e);";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, except for its endpoint selection policy.\n"
-        "@param b If <code>b</code> is <code>true</code>, the new proxy will use secure endpoints for invocations\n"
-        "and only use insecure endpoints if an invocation cannot be made via secure endpoints. If <code>b</code> is\n"
-        "<code>false</code>, the proxy prefers insecure endpoints to secure ones.\n"
-        "@return A proxy with the specified selection policy.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_preferSecure(boolean b)";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_preferSecure(b);";
-    out << eb;
+    out << nl << p->name() << "Prx ice_preferSecure(boolean b);";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, except for the router.\n"
-        "@param router The router for the new proxy.\n"
-        "@return A proxy with the specified router.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_router(com.zeroc.Ice.RouterPrx router)";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_router(router);";
-    out << eb;
+    out << nl << p->name() << "Prx ice_router(com.zeroc.Ice.RouterPrx router);";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, except for the locator.\n"
-        "@param locator The locator for the new proxy.\n"
-        "@return A proxy with the specified locator.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_locator(com.zeroc.Ice.LocatorPrx locator)";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_locator(locator);";
-    out << eb;
+    out << nl << p->name() << "Prx ice_locator(com.zeroc.Ice.LocatorPrx locator);";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, except for collocation optimization.\n"
-        "@param b <code>true</code> if the new proxy enables collocation optimization; <code>false</code> otherwise.\n"
-        "@return A proxy with the specified collocation optimization.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_collocationOptimized(boolean b)";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_collocationOptimized(b);";
-    out << eb;
+    out << nl << p->name() << "Prx ice_collocationOptimized(boolean b);";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, but uses twoway invocations.\n"
-        "@return A proxy that uses twoway invocations.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_twoway()";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_twoway();";
-    out << eb;
+    out << nl << p->name() << "Prx ice_twoway();";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, but uses oneway invocations.\n"
-        "@return A proxy that uses oneway invocations.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_oneway()";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_oneway();";
-    out << eb;
+    out << nl << p->name() << "Prx ice_oneway();";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, but uses batch oneway invocations.\n"
-        "@return A proxy that uses batch oneway invocations.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_batchOneway()";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_batchOneway();";
-    out << eb;
+    out << nl << p->name() << "Prx ice_batchOneway();";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, but uses datagram invocations.\n"
-        "@return A proxy that uses datagram invocations.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_datagram()";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_datagram();";
-    out << eb;
+    out << nl << p->name() << "Prx ice_datagram();";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, but uses batch datagram invocations.\n"
-        "@return A proxy that uses batch datagram invocations.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_batchDatagram()";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_batchDatagram();";
-    out << eb;
+    out << nl << p->name() << "Prx ice_batchDatagram();";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, except for compression.\n"
-        "@param co <code>true</code> enables compression for the new proxy; <code>false</code> disables compression.\n"
-        "@return A proxy with the specified compression setting.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_compress(boolean co)";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_compress(co);";
-    out << eb;
+    out << nl << p->name() << "Prx ice_compress(boolean co);";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, except for its connection timeout setting.\n"
-        "@param t The connection timeout for the proxy in milliseconds.\n"
-        "@return A proxy with the specified timeout.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_timeout(int t)";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_timeout(t);";
-    out << eb;
+    out << nl << p->name() << "Prx ice_timeout(int t);";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, except for its connection ID.\n"
-        "@param connectionId The connection ID for the new proxy. An empty string removes the connection ID.\n"
-        "@return A proxy with the specified connection ID.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_connectionId(String connectionId)";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_connectionId(connectionId);";
-    out << eb;
+    out << nl << p->name() << "Prx ice_connectionId(String connectionId);";
 
     out << sp;
-    writeDocComment(
-        out,
-        "Returns a proxy that is identical to this proxy, except it's a fixed proxy bound\n"
-        "the given connection."
-        "@param connection The fixed proxy connection.\n"
-        "@return A fixed proxy bound to the given connection.");
     out << nl << "@Override";
-    out << nl << "default " << p->name() << "Prx ice_fixed(com.zeroc.Ice.Connection connection)";
-    out << sb;
-    out << nl << "return (" << p->name() << "Prx)_ice_fixed(connection);";
-    out << eb;
+    out << nl << p->name() << "Prx ice_fixed(com.zeroc.Ice.Connection connection);";
 
     out << sp;
     out << nl << "static String ice_staticId()";
@@ -4601,6 +4425,161 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     outi << nl << "public class _" << p->name() << "PrxI extends com.zeroc.Ice._ObjectPrxI implements " << p->name()
          << "Prx";
     outi << sb;
+    
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_context(java.util.Map<String, String> newContext)";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_context(newContext);";
+    outi << eb;
+    
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_adapterId(String newAdapterId)";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_adapterId(newAdapterId);";
+    outi << eb;
+    
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_endpoints(com.zeroc.Ice.Endpoint[] newEndpoints)";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_endpoints(newEndpoints);";
+    outi << eb;
+    
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_locatorCacheTimeout(int newTimeout)";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_locatorCacheTimeout(newTimeout);";
+    outi << eb;
+    
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_invocationTimeout(int newTimeout)";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_invocationTimeout(newTimeout);";
+    outi << eb;
+    
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_connectionCached(boolean newCache)";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_connectionCached(newCache);";
+    outi << eb;
+    
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_endpointSelection(com.zeroc.Ice.EndpointSelectionType newType)";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_endpointSelection(newType);";
+    outi << eb;
+    
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_secure(boolean b)";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_secure(b);";
+    outi << eb;
+    
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_encodingVersion(com.zeroc.Ice.EncodingVersion e)";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_encodingVersion(e);";
+    outi << eb;
+    
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_preferSecure(boolean b)";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_preferSecure(b);";
+    outi << eb;
+    
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_router(com.zeroc.Ice.RouterPrx router)";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_router(router);";
+    outi << eb;
+    
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_locator(com.zeroc.Ice.LocatorPrx locator)";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_locator(locator);";
+    outi << eb;
+    
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_collocationOptimized(boolean b)";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_collocationOptimized(b);";
+    outi << eb;
+    
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_twoway()";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_twoway();";
+    outi << eb;
+    
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_oneway()";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_oneway();";
+    outi << eb;
+    
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_batchOneway()";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_batchOneway();";
+    outi << eb;
+    
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_datagram()";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_datagram();";
+    outi << eb;
+
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_batchDatagram()";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_batchDatagram();";
+    outi << eb;
+
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_compress(boolean co)";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_compress(co);";
+    outi << eb;
+
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_timeout(int t)";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_timeout(t);";
+    outi << eb;
+
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_connectionId(String connectionId)";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_connectionId(connectionId);";
+    outi << eb;
+
+    outi << sp;
+    outi << nl << "@Override";
+    outi << nl << "public " << p->name() << "Prx ice_fixed(com.zeroc.Ice.Connection connection)";
+    outi << sb;
+    outi << nl << "return (" << p->name() << "Prx)super.ice_fixed(connection);";
+    outi << eb;
+
     outi << sp;
     writeHiddenDocComment(outi);
     outi << nl << "public static final long serialVersionUID = 0L;";

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
@@ -226,9 +226,7 @@ public interface ObjectPrx {
    * @param newContext The context for the new proxy.
    * @return The proxy with the new per-proxy context.
    */
-  default ObjectPrx ice_context(java.util.Map<String, String> newContext) {
-    return _ice_context(newContext);
-  }
+  ObjectPrx ice_context(java.util.Map<String, String> newContext);
 
   /**
    * Returns the facet for this proxy.
@@ -260,9 +258,7 @@ public interface ObjectPrx {
    * @param newAdapterId The adapter ID for the new proxy.
    * @return The proxy with the new adapter ID.
    */
-  default ObjectPrx ice_adapterId(String newAdapterId) {
-    return _ice_adapterId(newAdapterId);
-  }
+  ObjectPrx ice_adapterId(String newAdapterId);
 
   /**
    * Returns the endpoints used by this proxy.
@@ -278,9 +274,7 @@ public interface ObjectPrx {
    * @param newEndpoints The endpoints for the new proxy.
    * @return The proxy with the new endpoints.
    */
-  default ObjectPrx ice_endpoints(Endpoint[] newEndpoints) {
-    return _ice_endpoints(newEndpoints);
-  }
+  ObjectPrx ice_endpoints(Endpoint[] newEndpoints);
 
   /**
    * Returns the locator cache timeout of this proxy.
@@ -311,9 +305,7 @@ public interface ObjectPrx {
    * @param connection The fixed proxy connection.
    * @return A fixed proxy bound to the given connection.
    */
-  default ObjectPrx ice_fixed(com.zeroc.Ice.Connection connection) {
-    return _ice_fixed(connection);
-  }
+  ObjectPrx ice_fixed(com.zeroc.Ice.Connection connection);
 
   /**
    * Returns whether this proxy is a fixed proxy.
@@ -329,9 +321,7 @@ public interface ObjectPrx {
    * @return The proxy with the new timeout.
    * @see Locator
    */
-  default ObjectPrx ice_locatorCacheTimeout(int newTimeout) {
-    return _ice_locatorCacheTimeout(newTimeout);
-  }
+  ObjectPrx ice_locatorCacheTimeout(int newTimeout);
 
   /**
    * Returns a proxy that is identical to this proxy, except for the invocation timeout.
@@ -339,9 +329,7 @@ public interface ObjectPrx {
    * @param newTimeout The new invocation timeout (in milliseconds).
    * @return The proxy with the new timeout.
    */
-  default ObjectPrx ice_invocationTimeout(int newTimeout) {
-    return _ice_invocationTimeout(newTimeout);
-  }
+  ObjectPrx ice_invocationTimeout(int newTimeout);
 
   /**
    * Returns whether this proxy caches connections.
@@ -357,9 +345,7 @@ public interface ObjectPrx {
    *     otherwise.
    * @return The proxy with the specified caching policy.
    */
-  default ObjectPrx ice_connectionCached(boolean newCache) {
-    return _ice_connectionCached(newCache);
-  }
+  ObjectPrx ice_connectionCached(boolean newCache);
 
   /**
    * Returns how this proxy selects endpoints (randomly or ordered).
@@ -376,9 +362,7 @@ public interface ObjectPrx {
    * @return The proxy with the specified endpoint selection policy.
    * @see EndpointSelectionType
    */
-  default ObjectPrx ice_endpointSelection(EndpointSelectionType newType) {
-    return _ice_endpointSelection(newType);
-  }
+  ObjectPrx ice_endpointSelection(EndpointSelectionType newType);
 
   /**
    * Returns whether this proxy uses only secure endpoints.
@@ -396,9 +380,7 @@ public interface ObjectPrx {
    *     insecure endpoints.
    * @return The proxy with the specified selection policy.
    */
-  default ObjectPrx ice_secure(boolean b) {
-    return _ice_secure(b);
-  }
+  ObjectPrx ice_secure(boolean b);
 
   /**
    * Returns a proxy that is identical to this proxy, except for the encoding used to marshal
@@ -407,9 +389,7 @@ public interface ObjectPrx {
    * @param e The encoding version to use to marshal request parameters.
    * @return The proxy with the specified encoding version.
    */
-  default ObjectPrx ice_encodingVersion(EncodingVersion e) {
-    return _ice_encodingVersion(e);
-  }
+  ObjectPrx ice_encodingVersion(EncodingVersion e);
 
   /**
    * Returns the encoding version used to marshal request parameters.
@@ -435,9 +415,7 @@ public interface ObjectPrx {
    *     secure ones.
    * @return The proxy with the specified selection policy.
    */
-  default ObjectPrx ice_preferSecure(boolean b) {
-    return _ice_preferSecure(b);
-  }
+  ObjectPrx ice_preferSecure(boolean b);
 
   /**
    * Returns the router for this proxy.
@@ -453,9 +431,7 @@ public interface ObjectPrx {
    * @param router The router for the new proxy.
    * @return The proxy with the specified router.
    */
-  default ObjectPrx ice_router(RouterPrx router) {
-    return _ice_router(router);
-  }
+  ObjectPrx ice_router(RouterPrx router);
 
   /**
    * Returns the locator for this proxy.
@@ -471,9 +447,7 @@ public interface ObjectPrx {
    * @param locator The locator for the new proxy.
    * @return The proxy with the specified locator.
    */
-  default ObjectPrx ice_locator(LocatorPrx locator) {
-    return _ice_locator(locator);
-  }
+  ObjectPrx ice_locator(LocatorPrx locator);
 
   /**
    * Returns whether this proxy uses collocation optimization.
@@ -490,18 +464,14 @@ public interface ObjectPrx {
    *     </code> otherwise.
    * @return The proxy with the specified collocation optimization.
    */
-  default ObjectPrx ice_collocationOptimized(boolean b) {
-    return _ice_collocationOptimized(b);
-  }
+  ObjectPrx ice_collocationOptimized(boolean b);
 
   /**
    * Returns a proxy that is identical to this proxy, but uses twoway invocations.
    *
    * @return A proxy that uses twoway invocations.
    */
-  default ObjectPrx ice_twoway() {
-    return _ice_twoway();
-  }
+  ObjectPrx ice_twoway();
 
   /**
    * Returns whether this proxy uses twoway invocations.
@@ -515,9 +485,7 @@ public interface ObjectPrx {
    *
    * @return A proxy that uses oneway invocations.
    */
-  default ObjectPrx ice_oneway() {
-    return _ice_oneway();
-  }
+  ObjectPrx ice_oneway();
 
   /**
    * Returns whether this proxy uses oneway invocations.
@@ -531,9 +499,7 @@ public interface ObjectPrx {
    *
    * @return A new proxy that uses batch oneway invocations.
    */
-  default ObjectPrx ice_batchOneway() {
-    return _ice_batchOneway();
-  }
+  ObjectPrx ice_batchOneway();
 
   /**
    * Returns whether this proxy uses batch oneway invocations.
@@ -548,9 +514,7 @@ public interface ObjectPrx {
    *
    * @return A new proxy that uses datagram invocations.
    */
-  default ObjectPrx ice_datagram() {
-    return _ice_datagram();
-  }
+  ObjectPrx ice_datagram();
 
   /**
    * Returns whether this proxy uses datagram invocations.
@@ -565,9 +529,7 @@ public interface ObjectPrx {
    *
    * @return A new proxy that uses batch datagram invocations.
    */
-  default ObjectPrx ice_batchDatagram() {
-    return _ice_batchDatagram();
-  }
+  ObjectPrx ice_batchDatagram();
 
   /**
    * Returns whether this proxy uses batch datagram invocations.
@@ -585,9 +547,7 @@ public interface ObjectPrx {
    *     compression.
    * @return A proxy with the specified compression setting.
    */
-  default ObjectPrx ice_compress(boolean co) {
-    return _ice_compress(co);
-  }
+  ObjectPrx ice_compress(boolean co);
 
   /**
    * Obtains the compression override setting of this proxy.
@@ -604,9 +564,7 @@ public interface ObjectPrx {
    * @param t The connection timeout for the proxy in milliseconds.
    * @return A proxy with the specified timeout.
    */
-  default ObjectPrx ice_timeout(int t) {
-    return _ice_timeout(t);
-  }
+  ObjectPrx ice_timeout(int t);
 
   /**
    * Obtains the timeout override of this proxy.
@@ -623,9 +581,7 @@ public interface ObjectPrx {
    *     ID.
    * @return A proxy with the specified connection ID.
    */
-  default ObjectPrx ice_connectionId(String connectionId) {
-    return _ice_connectionId(connectionId);
-  }
+  ObjectPrx ice_connectionId(String connectionId);
 
   /**
    * Returns the {@link Connection} for this proxy. If the proxy does not yet have an established
@@ -1017,314 +973,6 @@ public interface ObjectPrx {
    * @return -
    */
   ObjectPrx _newInstance(com.zeroc.IceInternal.Reference r);
-
-  /**
-   * @hidden
-   * @param newContext -
-   * @return -
-   */
-  default ObjectPrx _ice_context(java.util.Map<String, String> newContext) {
-    return _newInstance(_getReference().changeContext(newContext));
-  }
-
-  /**
-   * @hidden
-   * @param newAdapterId -
-   * @return -
-   */
-  default ObjectPrx _ice_adapterId(String newAdapterId) {
-    if (newAdapterId == null) {
-      newAdapterId = "";
-    }
-
-    if (newAdapterId.equals(_getReference().getAdapterId())) {
-      return this;
-    } else {
-      return _newInstance(_getReference().changeAdapterId(newAdapterId));
-    }
-  }
-
-  /**
-   * @hidden
-   * @param newEndpoints -
-   * @return -
-   */
-  default ObjectPrx _ice_endpoints(Endpoint[] newEndpoints) {
-    if (java.util.Arrays.equals(newEndpoints, _getReference().getEndpoints())) {
-      return this;
-    } else {
-      com.zeroc.IceInternal.EndpointI[] edpts =
-          new com.zeroc.IceInternal.EndpointI[newEndpoints.length];
-      edpts = java.util.Arrays.asList(newEndpoints).toArray(edpts);
-      return _newInstance(_getReference().changeEndpoints(edpts));
-    }
-  }
-
-  /**
-   * @hidden
-   * @param connection -
-   * @return -
-   */
-  default ObjectPrx _ice_fixed(com.zeroc.Ice.Connection connection) {
-    if (connection == null) {
-      throw new IllegalArgumentException("invalid null connection passed to ice_fixed");
-    }
-    if (!(connection instanceof com.zeroc.Ice.ConnectionI)) {
-      throw new IllegalArgumentException("invalid connection passed to ice_fixed");
-    }
-    if (connection == _getReference().getConnection()) {
-      return this;
-    } else {
-      return _newInstance(_getReference().changeConnection((com.zeroc.Ice.ConnectionI) connection));
-    }
-  }
-
-  /**
-   * @hidden
-   * @param newTimeout -
-   * @return -
-   */
-  default ObjectPrx _ice_locatorCacheTimeout(int newTimeout) {
-    if (newTimeout < -1) {
-      throw new IllegalArgumentException(
-          "invalid value passed to ice_locatorCacheTimeout: " + newTimeout);
-    }
-    if (newTimeout == _getReference().getLocatorCacheTimeout()) {
-      return this;
-    } else {
-      return _newInstance(_getReference().changeLocatorCacheTimeout(newTimeout));
-    }
-  }
-
-  /**
-   * @hidden
-   * @param newTimeout -
-   * @return -
-   */
-  default ObjectPrx _ice_invocationTimeout(int newTimeout) {
-    if (newTimeout < 1 && newTimeout != -1 && newTimeout != -2) {
-      throw new IllegalArgumentException(
-          "invalid value passed to ice_invocationTimeout: " + newTimeout);
-    }
-    if (newTimeout == _getReference().getInvocationTimeout()) {
-      return this;
-    } else {
-      return _newInstance(_getReference().changeInvocationTimeout(newTimeout));
-    }
-  }
-
-  /**
-   * @hidden
-   * @param newCache -
-   * @return -
-   */
-  default ObjectPrx _ice_connectionCached(boolean newCache) {
-    if (newCache == _getReference().getCacheConnection()) {
-      return this;
-    } else {
-      return _newInstance(_getReference().changeCacheConnection(newCache));
-    }
-  }
-
-  /**
-   * @hidden
-   * @param newType -
-   * @return -
-   */
-  default ObjectPrx _ice_endpointSelection(EndpointSelectionType newType) {
-    if (newType == _getReference().getEndpointSelection()) {
-      return this;
-    } else {
-      return _newInstance(_getReference().changeEndpointSelection(newType));
-    }
-  }
-
-  /**
-   * @hidden
-   * @param b -
-   * @return -
-   */
-  default ObjectPrx _ice_secure(boolean b) {
-    if (b == _getReference().getSecure()) {
-      return this;
-    } else {
-      return _newInstance(_getReference().changeSecure(b));
-    }
-  }
-
-  /**
-   * @hidden
-   * @param e -
-   * @return -
-   */
-  default ObjectPrx _ice_encodingVersion(EncodingVersion e) {
-    if (e.equals(_getReference().getEncoding())) {
-      return this;
-    } else {
-      return _newInstance(_getReference().changeEncoding(e));
-    }
-  }
-
-  /**
-   * @hidden
-   * @param b -
-   * @return -
-   */
-  default ObjectPrx _ice_preferSecure(boolean b) {
-    if (b == _getReference().getPreferSecure()) {
-      return this;
-    } else {
-      return _newInstance(_getReference().changePreferSecure(b));
-    }
-  }
-
-  /**
-   * @hidden
-   * @param router -
-   * @return -
-   */
-  default ObjectPrx _ice_router(RouterPrx router) {
-    com.zeroc.IceInternal.Reference ref = _getReference().changeRouter(router);
-    if (ref.equals(_getReference())) {
-      return this;
-    } else {
-      return _newInstance(ref);
-    }
-  }
-
-  /**
-   * @hidden
-   * @param locator -
-   * @return -
-   */
-  default ObjectPrx _ice_locator(LocatorPrx locator) {
-    com.zeroc.IceInternal.Reference ref = _getReference().changeLocator(locator);
-    if (ref.equals(_getReference())) {
-      return this;
-    } else {
-      return _newInstance(ref);
-    }
-  }
-
-  /**
-   * @hidden
-   * @param b -
-   * @return -
-   */
-  default ObjectPrx _ice_collocationOptimized(boolean b) {
-    if (b == _getReference().getCollocationOptimized()) {
-      return this;
-    } else {
-      return _newInstance(_getReference().changeCollocationOptimized(b));
-    }
-  }
-
-  /**
-   * @hidden
-   * @return -
-   */
-  default ObjectPrx _ice_twoway() {
-    if (_getReference().getMode() == com.zeroc.IceInternal.Reference.ModeTwoway) {
-      return this;
-    } else {
-      return _newInstance(_getReference().changeMode(com.zeroc.IceInternal.Reference.ModeTwoway));
-    }
-  }
-
-  /**
-   * @hidden
-   * @return -
-   */
-  default ObjectPrx _ice_oneway() {
-    if (_getReference().getMode() == com.zeroc.IceInternal.Reference.ModeOneway) {
-      return this;
-    } else {
-      return _newInstance(_getReference().changeMode(com.zeroc.IceInternal.Reference.ModeOneway));
-    }
-  }
-
-  /**
-   * @hidden
-   * @return -
-   */
-  default ObjectPrx _ice_batchOneway() {
-    if (_getReference().getMode() == com.zeroc.IceInternal.Reference.ModeBatchOneway) {
-      return this;
-    } else {
-      return _newInstance(
-          _getReference().changeMode(com.zeroc.IceInternal.Reference.ModeBatchOneway));
-    }
-  }
-
-  /**
-   * @hidden
-   * @return -
-   */
-  default ObjectPrx _ice_datagram() {
-    if (_getReference().getMode() == com.zeroc.IceInternal.Reference.ModeDatagram) {
-      return this;
-    } else {
-      return _newInstance(_getReference().changeMode(com.zeroc.IceInternal.Reference.ModeDatagram));
-    }
-  }
-
-  /**
-   * @hidden
-   * @return -
-   */
-  default ObjectPrx _ice_batchDatagram() {
-    if (_getReference().getMode() == com.zeroc.IceInternal.Reference.ModeBatchDatagram) {
-      return this;
-    } else {
-      return _newInstance(
-          _getReference().changeMode(com.zeroc.IceInternal.Reference.ModeBatchDatagram));
-    }
-  }
-
-  /**
-   * @hidden
-   * @param co -
-   * @return -
-   */
-  default ObjectPrx _ice_compress(boolean co) {
-    com.zeroc.IceInternal.Reference ref = _getReference().changeCompress(co);
-    if (ref.equals(_getReference())) {
-      return this;
-    } else {
-      return _newInstance(ref);
-    }
-  }
-
-  /**
-   * @hidden
-   * @param t -
-   * @return -
-   */
-  default ObjectPrx _ice_timeout(int t) {
-    if (t < 1 && t != -1) {
-      throw new IllegalArgumentException("invalid value passed to ice_timeout: " + t);
-    }
-    com.zeroc.IceInternal.Reference ref = _getReference().changeTimeout(t);
-    if (ref.equals(_getReference())) {
-      return this;
-    } else {
-      return _newInstance(ref);
-    }
-  }
-
-  /**
-   * @hidden
-   * @param connectionId -
-   * @return -
-   */
-  default ObjectPrx _ice_connectionId(String connectionId) {
-    com.zeroc.IceInternal.Reference ref = _getReference().changeConnectionId(connectionId);
-    if (ref.equals(_getReference())) {
-      return this;
-    } else {
-      return _newInstance(ref);
-    }
-  }
 
   /**
    * A special empty context that is indistinguishable from the absence of a context parameter. For

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/_ObjectPrxFactoryMethods.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/_ObjectPrxFactoryMethods.java
@@ -4,114 +4,119 @@
 
 package com.zeroc.Ice;
 
+// TODO: This entire file is actually dead code. But instead of deleting it, I'm keeping it so that
+// I can repurpose it's skeleton to remove boilerplate after my prx-method refactoring is complete.
+
 /**
  * @hidden Provides overloads of the proxy factory methods with covariant return types so that
  *     applications do not need to downcast to the derived proxy type.
  */
 @SuppressWarnings("unchecked")
 public interface _ObjectPrxFactoryMethods<T extends ObjectPrx> extends ObjectPrx {
-  @Override
-  default T ice_context(java.util.Map<String, String> newContext) {
-    return (T) ObjectPrx.super.ice_context(newContext);
-  }
+  /*
+    @Override
+    default T ice_context(java.util.Map<String, String> newContext) {
+      return (T) ObjectPrx.super.ice_context(newContext);
+    }
 
-  @Override
-  default T ice_adapterId(String newAdapterId) {
-    return (T) ObjectPrx.super.ice_adapterId(newAdapterId);
-  }
+    @Override
+    default T ice_adapterId(String newAdapterId) {
+      return (T) ObjectPrx.super.ice_adapterId(newAdapterId);
+    }
 
-  @Override
-  default T ice_endpoints(Endpoint[] newEndpoints) {
-    return (T) ObjectPrx.super.ice_endpoints(newEndpoints);
-  }
+    @Override
+    default T ice_endpoints(Endpoint[] newEndpoints) {
+      return (T) ObjectPrx.super.ice_endpoints(newEndpoints);
+    }
 
-  @Override
-  default T ice_locatorCacheTimeout(int newTimeout) {
-    return (T) ObjectPrx.super.ice_locatorCacheTimeout(newTimeout);
-  }
+    @Override
+    default T ice_locatorCacheTimeout(int newTimeout) {
+      return (T) ObjectPrx.super.ice_locatorCacheTimeout(newTimeout);
+    }
 
-  @Override
-  default T ice_invocationTimeout(int newTimeout) {
-    return (T) ObjectPrx.super.ice_invocationTimeout(newTimeout);
-  }
+    @Override
+    default T ice_invocationTimeout(int newTimeout) {
+      return (T) ObjectPrx.super.ice_invocationTimeout(newTimeout);
+    }
 
-  @Override
-  default T ice_connectionCached(boolean newCache) {
-    return (T) ObjectPrx.super.ice_connectionCached(newCache);
-  }
+    @Override
+    default T ice_connectionCached(boolean newCache) {
+      return (T) ObjectPrx.super.ice_connectionCached(newCache);
+    }
 
-  @Override
-  default T ice_endpointSelection(EndpointSelectionType newType) {
-    return (T) ObjectPrx.super.ice_endpointSelection(newType);
-  }
+    @Override
+    default T ice_endpointSelection(EndpointSelectionType newType) {
+      return (T) ObjectPrx.super.ice_endpointSelection(newType);
+    }
 
-  @Override
-  default T ice_secure(boolean b) {
-    return (T) ObjectPrx.super.ice_secure(b);
-  }
+    @Override
+    default T ice_secure(boolean b) {
+      return (T) ObjectPrx.super.ice_secure(b);
+    }
 
-  @Override
-  default T ice_encodingVersion(EncodingVersion e) {
-    return (T) ObjectPrx.super.ice_encodingVersion(e);
-  }
+    @Override
+    default T ice_encodingVersion(EncodingVersion e) {
+      return (T) ObjectPrx.super.ice_encodingVersion(e);
+    }
 
-  @Override
-  default T ice_preferSecure(boolean b) {
-    return (T) ObjectPrx.super.ice_preferSecure(b);
-  }
+    @Override
+    default T ice_preferSecure(boolean b) {
+      return (T) ObjectPrx.super.ice_preferSecure(b);
+    }
 
-  @Override
-  default T ice_router(RouterPrx router) {
-    return (T) ObjectPrx.super.ice_router(router);
-  }
+    @Override
+    default T ice_router(RouterPrx router) {
+      return (T) ObjectPrx.super.ice_router(router);
+    }
 
-  @Override
-  default T ice_locator(LocatorPrx locator) {
-    return (T) ObjectPrx.super.ice_locator(locator);
-  }
+    @Override
+    default T ice_locator(LocatorPrx locator) {
+      return (T) ObjectPrx.super.ice_locator(locator);
+    }
 
-  @Override
-  default T ice_collocationOptimized(boolean b) {
-    return (T) ObjectPrx.super.ice_collocationOptimized(b);
-  }
+    @Override
+    default T ice_collocationOptimized(boolean b) {
+      return (T) ObjectPrx.super.ice_collocationOptimized(b);
+    }
 
-  @Override
-  default T ice_twoway() {
-    return (T) ObjectPrx.super.ice_twoway();
-  }
+    @Override
+    default T ice_twoway() {
+      return (T) ObjectPrx.super.ice_twoway();
+    }
 
-  @Override
-  default T ice_oneway() {
-    return (T) ObjectPrx.super.ice_oneway();
-  }
+    @Override
+    default T ice_oneway() {
+      return (T) ObjectPrx.super.ice_oneway();
+    }
 
-  @Override
-  default T ice_batchOneway() {
-    return (T) ObjectPrx.super.ice_batchOneway();
-  }
+    @Override
+    default T ice_batchOneway() {
+      return (T) ObjectPrx.super.ice_batchOneway();
+    }
 
-  @Override
-  default T ice_datagram() {
-    return (T) ObjectPrx.super.ice_datagram();
-  }
+    @Override
+    default T ice_datagram() {
+      return (T) ObjectPrx.super.ice_datagram();
+    }
 
-  @Override
-  default T ice_batchDatagram() {
-    return (T) ObjectPrx.super.ice_batchDatagram();
-  }
+    @Override
+    default T ice_batchDatagram() {
+      return (T) ObjectPrx.super.ice_batchDatagram();
+    }
 
-  @Override
-  default T ice_compress(boolean co) {
-    return (T) ObjectPrx.super.ice_compress(co);
-  }
+    @Override
+    default T ice_compress(boolean co) {
+      return (T) ObjectPrx.super.ice_compress(co);
+    }
 
-  @Override
-  default T ice_timeout(int t) {
-    return (T) ObjectPrx.super.ice_timeout(t);
-  }
+    @Override
+    default T ice_timeout(int t) {
+      return (T) ObjectPrx.super.ice_timeout(t);
+    }
 
-  @Override
-  default T ice_connectionId(String connectionId) {
-    return (T) ObjectPrx.super.ice_connectionId(connectionId);
-  }
+    @Override
+    default T ice_connectionId(String connectionId) {
+      return (T) ObjectPrx.super.ice_connectionId(connectionId);
+    }
+  */
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/_ObjectPrxI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/_ObjectPrxI.java
@@ -388,6 +388,231 @@ public class _ObjectPrxI implements ObjectPrx, java.io.Serializable {
     }
   }
 
+  @Override
+  public ObjectPrx ice_context(java.util.Map<String, String> newContext) {
+    return _newInstance(_getReference().changeContext(newContext));
+  }
+
+  @Override
+  public ObjectPrx ice_adapterId(String newAdapterId) {
+    if (newAdapterId == null) {
+      newAdapterId = "";
+    }
+
+    if (newAdapterId.equals(_getReference().getAdapterId())) {
+      return this;
+    } else {
+      return _newInstance(_getReference().changeAdapterId(newAdapterId));
+    }
+  }
+
+  @Override
+  public ObjectPrx ice_endpoints(Endpoint[] newEndpoints) {
+    if (java.util.Arrays.equals(newEndpoints, _getReference().getEndpoints())) {
+      return this;
+    } else {
+      com.zeroc.IceInternal.EndpointI[] edpts =
+          new com.zeroc.IceInternal.EndpointI[newEndpoints.length];
+      edpts = java.util.Arrays.asList(newEndpoints).toArray(edpts);
+      return _newInstance(_getReference().changeEndpoints(edpts));
+    }
+  }
+
+  @Override
+  public ObjectPrx ice_fixed(com.zeroc.Ice.Connection connection) {
+    if (connection == null) {
+      throw new IllegalArgumentException("invalid null connection passed to ice_fixed");
+    }
+    if (!(connection instanceof com.zeroc.Ice.ConnectionI)) {
+      throw new IllegalArgumentException("invalid connection passed to ice_fixed");
+    }
+    if (connection == _getReference().getConnection()) {
+      return this;
+    } else {
+      return _newInstance(_getReference().changeConnection((com.zeroc.Ice.ConnectionI) connection));
+    }
+  }
+
+  @Override
+  public ObjectPrx ice_locatorCacheTimeout(int newTimeout) {
+    if (newTimeout < -1) {
+      throw new IllegalArgumentException(
+          "invalid value passed to ice_locatorCacheTimeout: " + newTimeout);
+    }
+    if (newTimeout == _getReference().getLocatorCacheTimeout()) {
+      return this;
+    } else {
+      return _newInstance(_getReference().changeLocatorCacheTimeout(newTimeout));
+    }
+  }
+
+  @Override
+  public ObjectPrx ice_invocationTimeout(int newTimeout) {
+    if (newTimeout < 1 && newTimeout != -1 && newTimeout != -2) {
+      throw new IllegalArgumentException(
+          "invalid value passed to ice_invocationTimeout: " + newTimeout);
+    }
+    if (newTimeout == _getReference().getInvocationTimeout()) {
+      return this;
+    } else {
+      return _newInstance(_getReference().changeInvocationTimeout(newTimeout));
+    }
+  }
+
+  @Override
+  public ObjectPrx ice_connectionCached(boolean newCache) {
+    if (newCache == _getReference().getCacheConnection()) {
+      return this;
+    } else {
+      return _newInstance(_getReference().changeCacheConnection(newCache));
+    }
+  }
+
+  @Override
+  public ObjectPrx ice_endpointSelection(EndpointSelectionType newType) {
+    if (newType == _getReference().getEndpointSelection()) {
+      return this;
+    } else {
+      return _newInstance(_getReference().changeEndpointSelection(newType));
+    }
+  }
+
+  @Override
+  public ObjectPrx ice_secure(boolean b) {
+    if (b == _getReference().getSecure()) {
+      return this;
+    } else {
+      return _newInstance(_getReference().changeSecure(b));
+    }
+  }
+
+  @Override
+  public ObjectPrx ice_encodingVersion(EncodingVersion e) {
+    if (e.equals(_getReference().getEncoding())) {
+      return this;
+    } else {
+      return _newInstance(_getReference().changeEncoding(e));
+    }
+  }
+
+  @Override
+  public ObjectPrx ice_preferSecure(boolean b) {
+    if (b == _getReference().getPreferSecure()) {
+      return this;
+    } else {
+      return _newInstance(_getReference().changePreferSecure(b));
+    }
+  }
+
+  @Override
+  public ObjectPrx ice_router(RouterPrx router) {
+    com.zeroc.IceInternal.Reference ref = _getReference().changeRouter(router);
+    if (ref.equals(_getReference())) {
+      return this;
+    } else {
+      return _newInstance(ref);
+    }
+  }
+
+  @Override
+  public ObjectPrx ice_locator(LocatorPrx locator) {
+    com.zeroc.IceInternal.Reference ref = _getReference().changeLocator(locator);
+    if (ref.equals(_getReference())) {
+      return this;
+    } else {
+      return _newInstance(ref);
+    }
+  }
+
+  @Override
+  public ObjectPrx ice_collocationOptimized(boolean b) {
+    if (b == _getReference().getCollocationOptimized()) {
+      return this;
+    } else {
+      return _newInstance(_getReference().changeCollocationOptimized(b));
+    }
+  }
+
+  @Override
+  public ObjectPrx ice_twoway() {
+    if (_getReference().getMode() == com.zeroc.IceInternal.Reference.ModeTwoway) {
+      return this;
+    } else {
+      return _newInstance(_getReference().changeMode(com.zeroc.IceInternal.Reference.ModeTwoway));
+    }
+  }
+
+  @Override
+  public ObjectPrx ice_oneway() {
+    if (_getReference().getMode() == com.zeroc.IceInternal.Reference.ModeOneway) {
+      return this;
+    } else {
+      return _newInstance(_getReference().changeMode(com.zeroc.IceInternal.Reference.ModeOneway));
+    }
+  }
+
+  @Override
+  public ObjectPrx ice_batchOneway() {
+    if (_getReference().getMode() == com.zeroc.IceInternal.Reference.ModeBatchOneway) {
+      return this;
+    } else {
+      return _newInstance(
+          _getReference().changeMode(com.zeroc.IceInternal.Reference.ModeBatchOneway));
+    }
+  }
+
+  @Override
+  public ObjectPrx ice_datagram() {
+    if (_getReference().getMode() == com.zeroc.IceInternal.Reference.ModeDatagram) {
+      return this;
+    } else {
+      return _newInstance(_getReference().changeMode(com.zeroc.IceInternal.Reference.ModeDatagram));
+    }
+  }
+
+  @Override
+  public ObjectPrx ice_batchDatagram() {
+    if (_getReference().getMode() == com.zeroc.IceInternal.Reference.ModeBatchDatagram) {
+      return this;
+    } else {
+      return _newInstance(
+          _getReference().changeMode(com.zeroc.IceInternal.Reference.ModeBatchDatagram));
+    }
+  }
+
+  @Override
+  public ObjectPrx ice_compress(boolean co) {
+    com.zeroc.IceInternal.Reference ref = _getReference().changeCompress(co);
+    if (ref.equals(_getReference())) {
+      return this;
+    } else {
+      return _newInstance(ref);
+    }
+  }
+
+  @Override
+  public ObjectPrx ice_timeout(int t) {
+    if (t < 1 && t != -1) {
+      throw new IllegalArgumentException("invalid value passed to ice_timeout: " + t);
+    }
+    com.zeroc.IceInternal.Reference ref = _getReference().changeTimeout(t);
+    if (ref.equals(_getReference())) {
+      return this;
+    } else {
+      return _newInstance(ref);
+    }
+  }
+
+  @Override
+  public ObjectPrx ice_connectionId(String connectionId) {
+    com.zeroc.IceInternal.Reference ref = _getReference().changeConnectionId(connectionId);
+    if (ref.equals(_getReference())) {
+      return this;
+    } else {
+      return _newInstance(ref);
+    }
+  }
+
   public StreamPair _getCachedMessageBuffers() {
     synchronized (this) {
       if (_streamCache != null && !_streamCache.isEmpty()) {


### PR DESCRIPTION
We provide a variety of factory functions for transforming proxies, proxies which themselves are split into 2 parts:
- A user-facing interface (like `GreeterPrx`)
- An 'internal' class which implements the interface (like `GreeterPrxI`)

All the logic for these factory functions is on the interface, instead of the class.
Which is kind of weird on it's own: usually implementation is done by classes, not interfaces.
But our setup is worse because the interface implementations all look like:
```java
default ObjectPrx ice_adapterId(...) { return _ice_adapterId(...); }
default ObjectPrx _ice_adapterId(...) { /*actual impl*/ }
```
Since they're interface methods, they're completely public, which is kind of lame.

----

This PR removes all the implementation logic from the interface side.
Now the interface just has: `ObjectPrx ice_adapterId(...);` a 'pure virtual function'.

And these implementations were moved into the corresponding class.
This completely eliminates these unfortunate hidden-underscore-methods.