### PR TITLE
Add typed proxy factory methods to C#

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2567,15 +2567,17 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << nl << "public interface " << name << "Prx : ";
 
     vector<string> baseInterfaces;
-    for (InterfaceList::const_iterator q = bases.begin(); q != bases.end(); ++q)
+    for (const auto& q : bases)
     {
-        baseInterfaces.push_back(getUnqualified(*q, ns, "", "Prx"));
+        baseInterfaces.push_back(getUnqualified(q, ns, "", "Prx"));
     }
 
     if (baseInterfaces.empty())
     {
         baseInterfaces.push_back("Ice.ObjectPrx");
     }
+
+    baseInterfaces.push_back("Ice.ProxyFactoryMethods<" + name + "Prx>");
 
     for (vector<string>::const_iterator q = baseInterfaces.begin(); q != baseInterfaces.end();)
     {

--- a/csharp/src/Ice/ProxyFactoryMethods.cs
+++ b/csharp/src/Ice/ProxyFactoryMethods.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ZeroC, Inc.
+
+#nullable enable
+
+namespace Ice;
+
+public interface ProxyFactoryMethods<TProxy> : ObjectPrx where TProxy : class, ObjectPrx
+{
+    public new TProxy ice_oneway()
+    {
+        ObjectPrx obj = this;
+        return (TProxy)obj.ice_oneway();
+    }
+}

--- a/csharp/test/Glacier2/router/Client.cs
+++ b/csharp/test/Glacier2/router/Client.cs
@@ -231,8 +231,8 @@ public class Client : Test.TestHelper
             {
                 Console.Out.Write("testing oneway callback... ");
                 Console.Out.Flush();
-                CallbackPrx oneway = CallbackPrxHelper.uncheckedCast(twoway.ice_oneway());
-                CallbackReceiverPrx onewayR = CallbackReceiverPrxHelper.uncheckedCast(twowayR.ice_oneway());
+                CallbackPrx oneway = twoway.ice_oneway();
+                CallbackReceiverPrx onewayR = twowayR.ice_oneway();
                 Dictionary<string, string> context = new Dictionary<string, string>();
                 context["_fwd"] = "o";
                 oneway.initiateCallback(onewayR, context);

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -409,8 +409,7 @@ namespace Ice
                     //
                     try
                     {
-                        logger.attachRemoteLogger(Ice.RemoteLoggerPrxHelper.uncheckedCast(myProxy.ice_oneway()),
-                                                  messageTypes, categories, 4);
+                        logger.attachRemoteLogger(myProxy.ice_oneway(), messageTypes, categories, 4);
                         test(false);
                     }
                     catch (Ice.RemoteLoggerAlreadyAttachedException)

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -203,7 +203,7 @@ namespace Ice
 
                     try
                     {
-                        _ = ((Test.TestIntfPrx)p.ice_oneway()).opWithResultAsync();
+                        _ = p.ice_oneway().opWithResultAsync();
                         test(false);
                     }
                     catch (TwowayOnlyException)

--- a/csharp/test/Ice/background/AllTests.cs
+++ b/csharp/test/Ice/background/AllTests.cs
@@ -32,7 +32,7 @@ public class AllTests
     {
         internal OpThread(BackgroundPrx background)
         {
-            _background = BackgroundPrxHelper.uncheckedCast(background.ice_oneway());
+            _background = background.ice_oneway();
             Start();
         }
 
@@ -271,7 +271,7 @@ public class AllTests
             {
                 configuration.connectException(new Ice.SocketException());
             }
-            BackgroundPrx prx = (i == 1 || i == 3) ? background : (BackgroundPrx)background.ice_oneway();
+            BackgroundPrx prx = (i == 1 || i == 3) ? background : background.ice_oneway();
 
             try
             {
@@ -372,7 +372,7 @@ public class AllTests
             {
                 continue;
             }
-            BackgroundPrx prx = (i == 1 || i == 3) ? background : (BackgroundPrx)background.ice_oneway();
+            BackgroundPrx prx = (i == 1 || i == 3) ? background : background.ice_oneway();
 
             try
             {
@@ -536,7 +536,7 @@ public class AllTests
         for (int i = 0; i < 2; ++i)
         {
             configuration.readException(new Ice.SocketException());
-            BackgroundPrx prx = i == 0 ? background : (BackgroundPrx)background.ice_oneway();
+            BackgroundPrx prx = i == 0 ? background : background.ice_oneway();
             var progress = new Progress();
             var t = prx.opAsync(progress: progress);
             test(!progress.SentSynchronously);
@@ -729,7 +729,7 @@ public class AllTests
 
         for (int i = 0; i < 2; ++i)
         {
-            BackgroundPrx prx = i == 0 ? background : (BackgroundPrx)background.ice_oneway();
+            BackgroundPrx prx = i == 0 ? background : background.ice_oneway();
 
             try
             {
@@ -827,7 +827,7 @@ public class AllTests
 
         for (int i = 0; i < 2; ++i)
         {
-            BackgroundPrx prx = i == 0 ? background : (BackgroundPrx)background.ice_oneway();
+            BackgroundPrx prx = i == 0 ? background : background.ice_oneway();
 
             background.ice_ping();
             configuration.writeReady(false);
@@ -900,7 +900,7 @@ public class AllTests
 
         background.ice_ping(); // Establish the connection
 
-        BackgroundPrx backgroundOneway = BackgroundPrxHelper.uncheckedCast(background.ice_oneway());
+        BackgroundPrx backgroundOneway = background.ice_oneway();
         test(backgroundOneway.ice_getConnection() == background.ice_getConnection());
 
         ctl.holdAdapter(); // Hold to block in request send.

--- a/csharp/test/Ice/hold/AllTests.cs
+++ b/csharp/test/Ice/hold/AllTests.cs
@@ -137,7 +137,7 @@ namespace Ice
                     Task result = null;
 
                     // We use the same proxy for all oneway calls.
-                    holdSerializedOneway = (Test.HoldPrx)holdSerialized.ice_oneway();
+                    holdSerializedOneway = holdSerialized.ice_oneway();
 
                     for (int i = 0; i < 10000; ++i)
                     {

--- a/csharp/test/Ice/invoke/AllTests.cs
+++ b/csharp/test/Ice/invoke/AllTests.cs
@@ -13,7 +13,7 @@ namespace Ice
                 Ice.Communicator communicator = helper.communicator();
                 Ice.ObjectPrx baseProxy = communicator.stringToProxy("test:" + helper.getTestEndpoint(0));
                 var cl = Test.MyClassPrxHelper.checkedCast(baseProxy);
-                var oneway = Test.MyClassPrxHelper.uncheckedCast(cl.ice_oneway());
+                var oneway = cl.ice_oneway();
                 var batchOneway = Test.MyClassPrxHelper.uncheckedCast(cl.ice_batchOneway());
 
                 var output = helper.getWriter();

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -1168,7 +1168,7 @@ public class AllTests : Test.AllTests
         props["IceMX.Metrics.View.Map.Invocation.Map.Remote.GroupBy"] = "localPort";
         updateProps(clientProps, serverProps, update, props, "Invocation");
 
-        MetricsPrx metricsOneway = (MetricsPrx)metrics.ice_oneway();
+        MetricsPrx metricsOneway = metrics.ice_oneway();
         metricsOneway.op();
         await metricsOneway.opAsync();
 

--- a/csharp/test/Ice/operations/Oneways.cs
+++ b/csharp/test/Ice/operations/Oneways.cs
@@ -17,7 +17,7 @@ namespace Ice
             internal static void oneways(global::Test.TestHelper helper, Test.MyClassPrx p)
             {
                 Ice.Communicator communicator = helper.communicator();
-                p = Test.MyClassPrxHelper.uncheckedCast(p.ice_oneway());
+                p = p.ice_oneway();
 
                 {
                     p.ice_ping();

--- a/csharp/test/Ice/operations/OnewaysAMI.cs
+++ b/csharp/test/Ice/operations/OnewaysAMI.cs
@@ -16,7 +16,7 @@ namespace Ice
 
             internal static async Task onewaysAMI(Test.MyClassPrx proxy)
             {
-                Test.MyClassPrx p = Test.MyClassPrxHelper.uncheckedCast(proxy.ice_oneway());
+                Test.MyClassPrx p = proxy.ice_oneway();
 
                 await p.ice_pingAsync();
 


### PR DESCRIPTION
This PR adds one typed factory method (ice_oneway).

If it's approved, I'll add all factory methods (and doc-comments) in a follow-up PR.

Note that C# currently does not allow covariant return types for interface methods. Only for class methods.