### PR TITLE
Simplify Generation of Checked and Unchecked Casts

### DIFF
--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -4230,6 +4230,8 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 
     const string package = getPackage(p);
     const string contextParam = "java.util.Map<String, String> context";
+    const string prxName = p->name() + "Prx";
+    const string prxIName = "_" + prxName + "I";
 
     out << sp;
     writeDocComment(
@@ -4238,10 +4240,9 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "Raises a local exception if a communication error occurs.\n"
         "@param obj The untyped proxy.\n"
         "@return A proxy for this type, or null if the object does not support this type.");
-    out << nl << "static " << p->name() << "Prx checkedCast(com.zeroc.Ice.ObjectPrx obj)";
+    out << nl << "static " << prxName << " checkedCast(com.zeroc.Ice.ObjectPrx obj)";
     out << sb;
-    out << nl << "return com.zeroc.Ice.ObjectPrx._checkedCast(obj, ice_staticId(), " << p->name() << "Prx.class, _"
-        << p->name() << "PrxI.class);";
+    out << nl << "return checkedCast(obj, noExplicitContext);";
     out << eb;
 
     out << sp;
@@ -4252,10 +4253,21 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "@param obj The untyped proxy.\n"
         "@param context The Context map to send with the invocation.\n"
         "@return A proxy for this type, or null if the object does not support this type.");
-    out << nl << "static " << p->name() << "Prx checkedCast(com.zeroc.Ice.ObjectPrx obj, " << contextParam << ')';
+    out << nl << "static " << prxName << " checkedCast(com.zeroc.Ice.ObjectPrx obj, " << contextParam << ')';
     out << sb;
-    out << nl << "return com.zeroc.Ice.ObjectPrx._checkedCast(obj, context, ice_staticId(), " << p->name()
-        << "Prx.class, _" << p->name() << "PrxI.class);";
+    out << nl << "if (obj != null)";
+    out << sb;
+    out << nl << "try";
+    out << sb;
+    out << nl << "boolean ok = obj.ice_isA(ice_staticId(), context);";
+    out << nl << "if (ok)";
+    out << sb;
+    out << nl << "return new " << prxIName << "(obj);";
+    out << eb;
+    out << eb;
+    out << nl << "catch (com.zeroc.Ice.FacetNotExistException ex)" << sb << eb;
+    out << eb;
+    out << nl << "return null;";
     out << eb;
 
     out << sp;
@@ -4266,10 +4278,9 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "@param obj The untyped proxy.\n"
         "@param facet The name of the desired facet.\n"
         "@return A proxy for this type, or null if the object does not support this type.");
-    out << nl << "static " << p->name() << "Prx checkedCast(com.zeroc.Ice.ObjectPrx obj, String facet)";
+    out << nl << "static " << prxName << " checkedCast(com.zeroc.Ice.ObjectPrx obj, String facet)";
     out << sb;
-    out << nl << "return com.zeroc.Ice.ObjectPrx._checkedCast(obj, facet, ice_staticId(), " << p->name()
-        << "Prx.class, _" << p->name() << "PrxI.class);";
+    out << nl << "return checkedCast(obj, facet, noExplicitContext);";
     out << eb;
 
     out << sp;
@@ -4281,11 +4292,10 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "@param facet The name of the desired facet.\n"
         "@param context The Context map to send with the invocation.\n"
         "@return A proxy for this type, or null if the object does not support this type.");
-    out << nl << "static " << p->name() << "Prx checkedCast(com.zeroc.Ice.ObjectPrx obj, String facet, " << contextParam
+    out << nl << "static " << prxName << " checkedCast(com.zeroc.Ice.ObjectPrx obj, String facet, " << contextParam
         << ')';
     out << sb;
-    out << nl << "return com.zeroc.Ice.ObjectPrx._checkedCast(obj, facet, context, ice_staticId(), " << p->name()
-        << "Prx.class, _" << p->name() << "PrxI.class);";
+    out << nl << "return (obj == null) ? null : checkedCast(obj.ice_facet(facet), context);";
     out << eb;
 
     out << sp;
@@ -4294,10 +4304,9 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "Downcasts the given proxy to this type without contacting the remote server.\n"
         "@param obj The untyped proxy.\n"
         "@return A proxy for this type.");
-    out << nl << "static " << p->name() << "Prx uncheckedCast(com.zeroc.Ice.ObjectPrx obj)";
+    out << nl << "static " << prxName << " uncheckedCast(com.zeroc.Ice.ObjectPrx obj)";
     out << sb;
-    out << nl << "return com.zeroc.Ice.ObjectPrx._uncheckedCast(obj, " << p->name() << "Prx.class, _" << p->name()
-        << "PrxI.class);";
+    out << nl << "return (obj == null) ? null : new " << prxIName << "(obj);";
     out << eb;
 
     out << sp;
@@ -4307,10 +4316,9 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "@param obj The untyped proxy.\n"
         "@param facet The name of the desired facet.\n"
         "@return A proxy for this type.");
-    out << nl << "static " << p->name() << "Prx uncheckedCast(com.zeroc.Ice.ObjectPrx obj, String facet)";
+    out << nl << "static " << prxName << " uncheckedCast(com.zeroc.Ice.ObjectPrx obj, String facet)";
     out << sb;
-    out << nl << "return com.zeroc.Ice.ObjectPrx._uncheckedCast(obj, facet, " << p->name() << "Prx.class, _"
-        << p->name() << "PrxI.class);";
+    out << nl << "return (obj == null) ? null : new " << prxIName << "(obj.ice_facet(facet));";
     out << eb;
 
     // Generate overrides for all the methods on `ObjectPrx` with covariant return types.
@@ -4342,7 +4350,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     {
         out << sp;
         out << nl << "@Override";
-        out << nl << p->name() << "Prx " << method << ";";
+        out << nl << prxName << " " << method << ";";
     }
 
     out << sp;
@@ -4366,10 +4374,25 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     {
         outi << nl << "@Deprecated";
     }
-    outi << nl << "public class _" << p->name() << "PrxI";
-    outi << " extends com.zeroc.Ice._ObjectPrxFactoryMethods<" << p->name() << "Prx>";
-    outi << " implements " << p->name() << "Prx";
+    outi << nl << "public class " << prxIName;
+    outi << " extends com.zeroc.Ice._ObjectPrxFactoryMethods<" << prxName << ">";
+    outi << " implements " << prxName;
     outi << sb;
+
+    // TODO: eventually remove this default constructor.
+    // Default constructor
+    outi << sp;
+    outi << nl << "public " << prxIName << "()";
+    outi << sb;
+    outi << "super();";
+    outi << eb;
+
+    // Copy constructor
+    outi << sp;
+    outi << nl << "public " << prxIName << "(com.zeroc.Ice.ObjectPrx obj)";
+    outi << sb;
+    outi << "super(obj);";
+    outi << eb;
 
     outi << sp;
     outi << nl << "private static final long serialVersionUID = 0L;";

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
@@ -665,7 +665,7 @@ public interface ObjectPrx {
    * @return <code>obj</code>.
    */
   static ObjectPrx checkedCast(ObjectPrx obj) {
-    return obj;
+    return checkedCast(obj, noExplicitContext);
   }
 
   /**
@@ -678,7 +678,16 @@ public interface ObjectPrx {
    * @return <code>obj</code>.
    */
   static ObjectPrx checkedCast(ObjectPrx obj, java.util.Map<String, String> context) {
-    return obj;
+    if (obj != null) {
+      try {
+        boolean ok = obj.ice_isA(ice_staticId, context);
+        if (ok) {
+          return new _ObjectPrxI(obj);
+        }
+      } catch (FacetNotExistException ex) {
+      }
+    }
+    return null;
   }
 
   /**
@@ -705,18 +714,7 @@ public interface ObjectPrx {
    * @return The new proxy with the specified facet.
    */
   static ObjectPrx checkedCast(ObjectPrx obj, String facet, java.util.Map<String, String> context) {
-    ObjectPrx r = null;
-    if (obj != null) {
-      ObjectPrx p = obj.ice_facet(facet);
-      try {
-        boolean ok = p.ice_isA(ice_staticId, context);
-        assert (ok);
-        r = new _ObjectPrxI();
-        r._copyFrom(p);
-      } catch (FacetNotExistException ex) {
-      }
-    }
-    return r;
+    return (obj == null) ? null : checkedCast(obj.ice_facet(facet), context);
   }
 
   /**
@@ -738,13 +736,7 @@ public interface ObjectPrx {
    * @return The new proxy with the specified facet.
    */
   static ObjectPrx uncheckedCast(ObjectPrx obj, String facet) {
-    ObjectPrx r = null;
-    if (obj != null) {
-      ObjectPrx p = obj.ice_facet(facet);
-      r = new _ObjectPrxI();
-      r._copyFrom(p);
-    }
-    return r;
+    return (obj == null) ? null : new _ObjectPrxI(obj.ice_facet(facet));
   }
 
   /**
@@ -769,197 +761,9 @@ public interface ObjectPrx {
 
   /**
    * @hidden
-   * @param <T> -
-   * @param obj -
-   * @param id -
-   * @param proxy -
-   * @param impl -
-   * @return -
-   */
-  static <T> T _checkedCast(ObjectPrx obj, String id, Class<T> proxy, Class<?> impl) {
-    return _checkedCast(obj, false, null, noExplicitContext, id, proxy, impl);
-  }
-
-  /**
-   * @hidden
-   * @param <T> -
-   * @param obj -
-   * @param ctx -
-   * @param id -
-   * @param proxy -
-   * @param impl -
-   * @return -
-   */
-  static <T> T _checkedCast(
-      ObjectPrx obj, java.util.Map<String, String> ctx, String id, Class<T> proxy, Class<?> impl) {
-    return _checkedCast(obj, false, null, ctx, id, proxy, impl);
-  }
-
-  /**
-   * @hidden
-   * @param <T> -
-   * @param obj -
-   * @param facet -
-   * @param id -
-   * @param proxy -
-   * @param impl -
-   * @return -
-   */
-  static <T> T _checkedCast(ObjectPrx obj, String facet, String id, Class<T> proxy, Class<?> impl) {
-    return _checkedCast(obj, true, facet, noExplicitContext, id, proxy, impl);
-  }
-
-  /**
-   * @hidden
-   * @param <T> -
-   * @param obj -
-   * @param facet -
-   * @param ctx -
-   * @param id -
-   * @param proxy -
-   * @param impl -
-   * @return -
-   */
-  static <T> T _checkedCast(
-      ObjectPrx obj,
-      String facet,
-      java.util.Map<String, String> ctx,
-      String id,
-      Class<T> proxy,
-      Class<?> impl) {
-    return _checkedCast(obj, true, facet, ctx, id, proxy, impl);
-  }
-
-  /**
-   * @hidden
-   * @param <T> -
-   * @param obj -
-   * @param explicitFacet -
-   * @param facet -
-   * @param ctx -
-   * @param id -
-   * @param proxy -
-   * @param impl -
-   * @return -
-   */
-  static <T> T _checkedCast(
-      ObjectPrx obj,
-      boolean explicitFacet,
-      String facet,
-      java.util.Map<String, String> ctx,
-      String id,
-      Class<T> proxy,
-      Class<?> impl) {
-    T r = null;
-    if (obj != null) {
-      if (explicitFacet) {
-        obj = obj.ice_facet(facet);
-      }
-      if (proxy.isInstance(obj)) {
-        r = proxy.cast(obj);
-      } else {
-        try {
-          boolean ok = obj.ice_isA(id, ctx);
-          if (ok) {
-            ObjectPrx h = null;
-            try {
-              h = _ObjectPrxI.class.cast(impl.getDeclaredConstructor().newInstance());
-            } catch (NoSuchMethodException ex) {
-              throw new SyscallException(ex);
-            } catch (java.lang.reflect.InvocationTargetException ex) {
-              throw new SyscallException(ex);
-            } catch (InstantiationException ex) {
-              throw new SyscallException(ex);
-            } catch (IllegalAccessException ex) {
-              throw new SyscallException(ex);
-            }
-            h._copyFrom(obj);
-            r = proxy.cast(h);
-          }
-        } catch (FacetNotExistException ex) {
-        }
-      }
-    }
-    return r;
-  }
-
-  /**
-   * @hidden
-   * @param <T> -
-   * @param obj -
-   * @param proxy -
-   * @param impl -
-   * @return -
-   */
-  static <T> T _uncheckedCast(ObjectPrx obj, Class<T> proxy, Class<?> impl) {
-    return _uncheckedCast(obj, false, null, proxy, impl);
-  }
-
-  /**
-   * @hidden
-   * @param <T> -
-   * @param obj -
-   * @param facet -
-   * @param proxy -
-   * @param impl -
-   * @return -
-   */
-  static <T> T _uncheckedCast(ObjectPrx obj, String facet, Class<T> proxy, Class<?> impl) {
-    return _uncheckedCast(obj, true, facet, proxy, impl);
-  }
-
-  /**
-   * @hidden
-   * @param <T> -
-   * @param obj -
-   * @param explicitFacet -
-   * @param facet -
-   * @param proxy -
-   * @param impl -
-   * @return -
-   */
-  static <T> T _uncheckedCast(
-      ObjectPrx obj, boolean explicitFacet, String facet, Class<T> proxy, Class<?> impl) {
-    T r = null;
-    if (obj != null) {
-      try {
-        if (explicitFacet) {
-          ObjectPrx h = _ObjectPrxI.class.cast(impl.getDeclaredConstructor().newInstance());
-          h._copyFrom(obj.ice_facet(facet));
-          r = proxy.cast(h);
-        } else {
-          if (proxy.isInstance(obj)) {
-            r = proxy.cast(obj);
-          } else {
-            ObjectPrx h = _ObjectPrxI.class.cast(impl.getDeclaredConstructor().newInstance());
-            h._copyFrom(obj);
-            r = proxy.cast(h);
-          }
-        }
-      } catch (NoSuchMethodException ex) {
-        throw new SyscallException(ex);
-      } catch (java.lang.reflect.InvocationTargetException ex) {
-        throw new SyscallException(ex);
-      } catch (InstantiationException ex) {
-        throw new SyscallException(ex);
-      } catch (IllegalAccessException ex) {
-        throw new SyscallException(ex);
-      }
-    }
-    return r;
-  }
-
-  /**
-   * @hidden
    * @param os -
    */
   void _write(OutputStream os);
-
-  /**
-   * @hidden
-   * @param p -
-   */
-  void _copyFrom(ObjectPrx p);
 
   /**
    * @hidden

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/_ObjectPrxFactoryMethods.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/_ObjectPrxFactoryMethods.java
@@ -8,6 +8,15 @@ package com.zeroc.Ice;
  */
 @SuppressWarnings("unchecked")
 public abstract class _ObjectPrxFactoryMethods<T extends ObjectPrx> extends _ObjectPrxI {
+  // TODO: delete this default constructor eventually.
+  public _ObjectPrxFactoryMethods() {
+    super();
+  }
+
+  public _ObjectPrxFactoryMethods(ObjectPrx obj) {
+    super(obj);
+  }
+
   @Override
   public T ice_context(java.util.Map<String, String> newContext) {
     return (T) super.ice_context(newContext);

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/_ObjectPrxI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/_ObjectPrxI.java
@@ -12,6 +12,15 @@ import java.util.concurrent.CompletableFuture;
 
 /** Concrete proxy implementation. */
 public class _ObjectPrxI implements ObjectPrx, java.io.Serializable {
+  // TODO: delete this default constructor eventually.
+  public _ObjectPrxI() {}
+
+  public _ObjectPrxI(ObjectPrx obj) {
+    _ObjectPrxI source = (_ObjectPrxI) obj;
+    _reference = source._reference;
+    _requestHandler = source._requestHandler;
+  }
+
   public Communicator ice_getCommunicator() {
     return _reference.getCommunicator();
   }
@@ -339,15 +348,6 @@ public class _ObjectPrxI implements ObjectPrx, java.io.Serializable {
   public void _write(OutputStream os) {
     _reference.getIdentity().ice_writeMembers(os);
     _reference.streamWrite(os);
-  }
-
-  @Override
-  public void _copyFrom(ObjectPrx p) {
-    synchronized (p) {
-      _ObjectPrxI h = (_ObjectPrxI) p;
-      _reference = h._reference;
-      _requestHandler = h._requestHandler;
-    }
   }
 
   @Override


### PR DESCRIPTION
This PR adds a constructor to all proxies, which allows them to be created from other proxies.
Previously, we would create an empty proxy, then call `copyFrom(other)` on it.

It also simplifies and changes some logic with respect to `checkedCast` and `uncheckedCast`.