### PR TITLE
Remove Ice.Default.Timeout in C++ and C#

### DIFF
--- a/cpp/src/Ice/DefaultsAndOverrides.cpp
+++ b/cpp/src/Ice/DefaultsAndOverrides.cpp
@@ -70,15 +70,6 @@ IceInternal::DefaultsAndOverrides::DefaultsAndOverrides(const PropertiesPtr& pro
             "illegal value `" + value + "'; expected `Random' or `Ordered'");
     }
 
-    const_cast<int&>(defaultTimeout) = properties->getIcePropertyAsInt("Ice.Default.Timeout");
-    if (defaultTimeout < 1 && defaultTimeout != -1)
-    {
-        const_cast<int32_t&>(defaultTimeout) = 60000;
-        Warning out(logger);
-        out << "invalid value for Ice.Default.Timeout `" << properties->getIceProperty("Ice.Default.Timeout")
-            << "': defaulting to 60000";
-    }
-
     const_cast<int&>(defaultInvocationTimeout) = properties->getIcePropertyAsInt("Ice.Default.InvocationTimeout");
     if (defaultInvocationTimeout < 1 && defaultInvocationTimeout != -1)
     {

--- a/cpp/src/Ice/DefaultsAndOverrides.h
+++ b/cpp/src/Ice/DefaultsAndOverrides.h
@@ -25,7 +25,6 @@ namespace IceInternal
         std::string defaultProtocol;
         bool defaultCollocationOptimization;
         Ice::EndpointSelectionType defaultEndpointSelection;
-        int defaultTimeout;
         int defaultInvocationTimeout;
         int defaultLocatorCacheTimeout;
         bool defaultPreferSecure;

--- a/cpp/src/Ice/ProtocolInstance.cpp
+++ b/cpp/src/Ice/ProtocolInstance.cpp
@@ -109,12 +109,6 @@ IceInternal::ProtocolInstance::defaultEncoding() const
     return _instance->defaultsAndOverrides()->defaultEncoding;
 }
 
-int
-IceInternal::ProtocolInstance::defaultTimeout() const
-{
-    return _instance->defaultsAndOverrides()->defaultTimeout;
-}
-
 NetworkProxyPtr
 IceInternal::ProtocolInstance::networkProxy() const
 {

--- a/cpp/src/Ice/ProtocolInstance.h
+++ b/cpp/src/Ice/ProtocolInstance.h
@@ -50,7 +50,6 @@ namespace IceInternal
         const Ice::EncodingVersion& defaultEncoding() const;
         NetworkProxyPtr networkProxy() const;
         size_t messageSizeMax() const;
-        int defaultTimeout() const;
 
         void resolve(
             const std::string&,

--- a/cpp/src/Ice/TcpEndpointI.cpp
+++ b/cpp/src/Ice/TcpEndpointI.cpp
@@ -47,7 +47,8 @@ IceInternal::TcpEndpointI::TcpEndpointI(
 
 IceInternal::TcpEndpointI::TcpEndpointI(const ProtocolInstancePtr& instance)
     : IPEndpointI(instance),
-      _timeout(instance->defaultTimeout()),
+      // The default timeout for TCP endpoints is 60,000 milliseconds. This timeout is not used in Ice 3.8 and greater.
+      _timeout(60000),
       _compress(false)
 {
 }

--- a/cpp/src/Ice/ios/StreamEndpointI.cpp
+++ b/cpp/src/Ice/ios/StreamEndpointI.cpp
@@ -123,7 +123,7 @@ IceObjC::StreamEndpointI::StreamEndpointI(
 IceObjC::StreamEndpointI::StreamEndpointI(const InstancePtr& instance)
     : IceInternal::IPEndpointI(instance),
       _streamInstance(instance),
-      _timeout(60,000), // the default timeout is 60,000 milliseconds
+      _timeout(60000), // the default timeout is 60,000 milliseconds
       _compress(false)
 {
 }

--- a/cpp/src/Ice/ios/StreamEndpointI.cpp
+++ b/cpp/src/Ice/ios/StreamEndpointI.cpp
@@ -123,7 +123,7 @@ IceObjC::StreamEndpointI::StreamEndpointI(
 IceObjC::StreamEndpointI::StreamEndpointI(const InstancePtr& instance)
     : IceInternal::IPEndpointI(instance),
       _streamInstance(instance),
-      _timeout(instance->defaultTimeout()),
+      _timeout(60,000), // the default timeout is 60,000 milliseconds
       _compress(false)
 {
 }

--- a/cpp/src/IceBT/EndpointI.cpp
+++ b/cpp/src/IceBT/EndpointI.cpp
@@ -48,7 +48,7 @@ IceBT::EndpointI::EndpointI(
 IceBT::EndpointI::EndpointI(const InstancePtr& instance)
     : _instance(instance),
       _channel(0),
-      _timeout(60,000), // the default timeout is 60,000 ms
+      _timeout(60000), // the default timeout is 60,000 ms
       _compress(false)
 {
 }

--- a/cpp/src/IceBT/EndpointI.cpp
+++ b/cpp/src/IceBT/EndpointI.cpp
@@ -48,7 +48,7 @@ IceBT::EndpointI::EndpointI(
 IceBT::EndpointI::EndpointI(const InstancePtr& instance)
     : _instance(instance),
       _channel(0),
-      _timeout(instance->defaultTimeout()),
+      _timeout(60,000), // the default timeout is 60,000 ms
       _compress(false)
 {
 }

--- a/csharp/src/Ice/Internal/DefaultsAndOverrides.cs
+++ b/csharp/src/Ice/Internal/DefaultsAndOverrides.cs
@@ -87,16 +87,6 @@ public sealed class DefaultsAndOverrides
             throw ex;
         }
 
-        defaultTimeout = properties.getIcePropertyAsInt("Ice.Default.Timeout");
-        if (defaultTimeout < 1 && defaultTimeout != -1)
-        {
-            defaultTimeout = 60000;
-            StringBuilder msg = new StringBuilder("invalid value for Ice.Default.Timeout `");
-            msg.Append(properties.getIceProperty("Ice.Default.Timeout"));
-            msg.Append("': defaulting to 60000");
-            logger.warning(msg.ToString());
-        }
-
         defaultLocatorCacheTimeout = properties.getIcePropertyAsInt("Ice.Default.LocatorCacheTimeout");
         if (defaultLocatorCacheTimeout < -1)
         {
@@ -133,7 +123,6 @@ public sealed class DefaultsAndOverrides
     public string defaultProtocol;
     public bool defaultCollocationOptimization;
     public Ice.EndpointSelectionType defaultEndpointSelection;
-    public int defaultTimeout;
     public int defaultLocatorCacheTimeout;
     public int defaultInvocationTimeout;
     public bool defaultPreferSecure;

--- a/csharp/src/Ice/Internal/ProtocolInstance.cs
+++ b/csharp/src/Ice/Internal/ProtocolInstance.cs
@@ -95,11 +95,6 @@ public class ProtocolInstance
         return instance_.defaultsAndOverrides().defaultEncoding;
     }
 
-    public int defaultTimeout()
-    {
-        return instance_.defaultsAndOverrides().defaultTimeout;
-    }
-
     public NetworkProxy networkProxy()
     {
         return instance_.networkProxy();

--- a/csharp/src/Ice/Internal/TcpEndpointI.cs
+++ b/csharp/src/Ice/Internal/TcpEndpointI.cs
@@ -20,7 +20,9 @@ internal sealed class TcpEndpointI : IPEndpointI
     public TcpEndpointI(ProtocolInstance instance) :
         base(instance)
     {
-        _timeout = instance.defaultTimeout();
+        // The default timeout for TCP endpoints is 60,000 milliseconds (1 minute).
+        // This timeout is not used in Ice 3.8 or greater.
+        _timeout = 60_000;
         _compress = false;
     }
 

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -491,7 +491,7 @@ public class AllTests : Test.AllTests
         string endpoint = $"{protocol} -h {host} -p {port}";
         string forwardingEndpoint = $"{protocol} -h {host} -p {helper.getTestPort(1)}";
 
-        string timeout = communicator.getProperties().getPropertyWithDefault("Ice.Default.Timeout", "60000");
+        const string defaultTimeout = "60000";
 
         MetricsPrx metrics = MetricsPrxHelper.checkedCast(communicator.stringToProxy("metrics:" + endpoint));
         bool collocated = metrics.ice_getConnection() == null;
@@ -776,14 +776,14 @@ public class AllTests : Test.AllTests
             testAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "parent", "Communicator", c, output);
             testAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "id", hostAndPort, c, output);
             testAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpoint",
-                          endpoint + " -t " + timeout, c, output);
+                          endpoint + " -t " + defaultTimeout, c, output);
 
             testAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointType", type, c, output);
             testAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointIsDatagram", "False",
                           c, output);
             testAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointIsSecure", isSecure,
                           c, output);
-            testAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointTimeout", timeout, c, output);
+            testAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointTimeout", defaultTimeout, c, output);
             testAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointCompress", "False",
                           c, output);
             testAttribute(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointHost", host, c, output);
@@ -1154,7 +1154,7 @@ public class AllTests : Test.AllTests
         testAttribute(clientMetrics, clientProps, update, "Invocation", "encoding", "1.1", op, output);
         testAttribute(clientMetrics, clientProps, update, "Invocation", "mode", "twoway", op, output);
         testAttribute(clientMetrics, clientProps, update, "Invocation", "proxy",
-                      "metrics -t -e 1.1:" + endpoint + " -t " + timeout, op, output);
+                      "metrics -t -e 1.1:" + endpoint + " -t " + defaultTimeout, op, output);
 
         testAttribute(clientMetrics, clientProps, update, "Invocation", "context.entry1", "test", op, output);
         testAttribute(clientMetrics, clientProps, update, "Invocation", "context.entry2", "", op, output);

--- a/swift/test/Ice/properties/Client.swift
+++ b/swift/test/Ice/properties/Client.swift
@@ -75,23 +75,23 @@ public class Client: TestHelperI {
 
         do {
             output.write("testing arg parsing...")
-            var args1 = ["--Foo=1", "--Ice.Default.Timeout=12345", "-T", "--Bar=2"]
+            var args1 = ["--Foo=1", "--Ice.Default.InvocationTimeout=12345", "-T", "--Bar=2"]
             let properties1 = try Ice.createProperties(args1)
             var properties2 = try Ice.createProperties(&args1)
-            try test(properties1.getPropertyAsInt("Ice.Default.Timeout") == 12345)
-            try test(properties2.getPropertyAsInt("Ice.Default.Timeout") == 12345)
+            try test(properties1.getPropertyAsInt("Ice.Default.InvocationTimeout") == 12345)
+            try test(properties2.getPropertyAsInt("Ice.Default.InvocationTimeout") == 12345)
             try test(args1 == ["--Foo=1", "-T", "--Bar=2"])
 
-            args1 = ["--Ice.Default.Timeout=10000"]
+            args1 = ["--Ice.Default.InvocationTimeout=10000"]
             properties2 = try Ice.createProperties(&args1)
             try test(args1 == [])
 
-            args1 = ["--Foo=1", "--Ice.Default.Timeout=12345", "-T", "--Bar=2"]
+            args1 = ["--Foo=1", "--Ice.Default.InvocationTimeout=12345", "-T", "--Bar=2"]
             let communicator = try Ice.initialize(&args1)
             defer {
                 communicator.destroy()
             }
-            try test(communicator.getProperties().getPropertyAsInt("Ice.Default.Timeout") == 12345)
+            try test(communicator.getProperties().getPropertyAsInt("Ice.Default.InvocationTimeout") == 12345)
             try test(args1 == ["--Foo=1", "-T", "--Bar=2"])
             output.writeLine("ok")
         }


### PR DESCRIPTION
We just hard-code the default (60,000 ms) for endpoints with a timeout.