### PR TITLE
Add 'createProxy' Method

### DIFF
--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -4236,6 +4236,18 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     out << sp;
     writeDocComment(
         out,
+        "Creates a new proxy that implements {@link " + prxName + "}.\n"
+        "@param communicator The communicator of the new proxy.\n"
+        "@param proxyString The string representation of the proxy.\n"
+        "@return The new proxy.");
+    out << nl << "public static " << prxName << " createProxy(com.zeroc.Ice.Communicator communicator, String proxyString)";
+    out << sb;
+    out << nl << "return uncheckedCast(communicator.stringToProxy(proxyString));";
+    out << eb;
+
+    out << sp;
+    writeDocComment(
+        out,
         "Contacts the remote server to verify that the object implements this type.\n"
         "Raises a local exception if a communication error occurs.\n"
         "@param obj The untyped proxy.\n"

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -4236,11 +4236,13 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     out << sp;
     writeDocComment(
         out,
-        "Creates a new proxy that implements {@link " + prxName + "}.\n"
-        "@param communicator The communicator of the new proxy.\n"
-        "@param proxyString The string representation of the proxy.\n"
-        "@return The new proxy.");
-    out << nl << "public static " << prxName << " createProxy(com.zeroc.Ice.Communicator communicator, String proxyString)";
+        "Creates a new proxy that implements {@link " + prxName +
+            "}.\n"
+            "@param communicator The communicator of the new proxy.\n"
+            "@param proxyString The string representation of the proxy.\n"
+            "@return The new proxy.");
+    out << nl << "public static " << prxName
+        << " createProxy(com.zeroc.Ice.Communicator communicator, String proxyString)";
     out << sb;
     out << nl << "return uncheckedCast(communicator.stringToProxy(proxyString));";
     out << eb;

--- a/java/src/Glacier2/src/main/java/com/zeroc/Glacier2/SessionHelper.java
+++ b/java/src/Glacier2/src/main/java/com/zeroc/Glacier2/SessionHelper.java
@@ -353,9 +353,7 @@ public class SessionHelper {
               if (_communicator.getDefaultRouter() == null) {
                 com.zeroc.Ice.RouterFinderPrx finder = null;
                 try {
-                  finder =
-                      com.zeroc.Ice.RouterFinderPrx.uncheckedCast(
-                          _communicator.stringToProxy(_finderStr));
+                  finder = com.zeroc.Ice.RouterFinderPrx.createProxy(_communicator, _finderStr);
                   _communicator.setDefaultRouter(finder.getRouter());
                 } catch (final com.zeroc.Ice.CommunicatorDestroyedException ex) {
                   dispatchCallback(

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
@@ -640,6 +640,18 @@ public interface ObjectPrx {
   }
 
   /**
+   * Creates a new proxy that implements {@link ObjectPrx}.
+   *
+   * @param communicator The communicator of the new proxy.
+   * @param proxyString The string representation of the proxy.
+   * @return The new proxy.
+   * @throws ProxyParseException Thrown when <code>proxyString</code> is not a valid proxy string.
+   */
+  public static ObjectPrx createProxy(Communicator communicator, String proxyString) {
+    return communicator.stringToProxy(proxyString);
+  }
+
+  /**
    * Casts a proxy to {@link ObjectPrx}. For user-defined types, this call contacts the server and
    * will throw an Ice run-time exception if the target object does not exist or the server cannot
    * be reached.

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Coordinator.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Coordinator.java
@@ -1505,9 +1505,7 @@ public class Coordinator {
           .submit(
               () -> {
                 try {
-                  com.zeroc.Ice.RouterFinderPrx finder =
-                      com.zeroc.Ice.RouterFinderPrx.uncheckedCast(
-                          _communicator.stringToProxy(finderStr));
+                  var finder = com.zeroc.Ice.RouterFinderPrx.createProxy(_communicator, finderStr);
                   info.setInstanceName(finder.getRouter().ice_getIdentity().category);
                   info.save();
                   com.zeroc.Glacier2.RouterPrx router =
@@ -1674,8 +1672,7 @@ public class Coordinator {
               () -> {
                 synchronized (Coordinator.this) {
                   try {
-                    LocatorFinderPrx finder =
-                        LocatorFinderPrx.uncheckedCast(_communicator.stringToProxy(finderStr));
+                    var finder = LocatorFinderPrx.createProxy(_communicator, finderStr);
 
                     info.setInstanceName(finder.getLocator().ice_getIdentity().category);
                     info.save();
@@ -1734,9 +1731,9 @@ public class Coordinator {
                     masterRegistryId.name = "Registry";
 
                     cb.setRegistry(
-                        RegistryPrx.uncheckedCast(
-                            _communicator.stringToProxy(
-                                "\"" + _communicator.identityToString(masterRegistryId) + "\"")));
+                        RegistryPrx.createProxy(
+                            _communicator,
+                            "\"" + _communicator.identityToString(masterRegistryId) + "\""));
                   }
 
                   //

--- a/java/test/android/controller/src/main/java/com/zeroc/testcontroller/ControllerApp.java
+++ b/java/test/android/controller/src/main/java/com/zeroc/testcontroller/ControllerApp.java
@@ -182,15 +182,12 @@ public class ControllerApp extends Application {
       adapter.activate();
       ProcessControllerRegistryPrx registry;
       if (isEmulator()) {
-        registry =
-            ProcessControllerRegistryPrx.uncheckedCast(
-                _communicator.stringToProxy(
-                    "Util/ProcessControllerRegistry:tcp -h 10.0.2.2 -p 15001"));
+        registry = ProcessControllerRegistryPrx.createProxy(
+            _communicator,
+            "Util/ProcessControllerRegistry:tcp -h 10.0.2.2 -p 15001");
       } else {
         // Use IceDiscovery to find a process controller registry
-        registry =
-            ProcessControllerRegistryPrx.uncheckedCast(
-                _communicator.stringToProxy("Util/ProcessControllerRegistry"));
+        registry = ProcessControllerRegistryPrx.createProxy(_communicator, "Util/ProcessControllerRegistry");
       }
       registerProcessController(adapter, registry, processController);
       println("Android/ProcessController");

--- a/java/test/src/main/java/test/Glacier2/router/Client.java
+++ b/java/test/src/main/java/test/Glacier2/router/Client.java
@@ -41,9 +41,9 @@ public class Client extends test.TestHelper {
       {
         out.print("testing router finder... ");
         out.flush();
-        com.zeroc.Ice.RouterFinderPrx finder =
-            com.zeroc.Ice.RouterFinderPrx.uncheckedCast(
-                communicator.stringToProxy("Ice/RouterFinder:" + getTestEndpoint(50)));
+        var finder =
+            com.zeroc.Ice.RouterFinderPrx.createProxy(
+                communicator, "Ice/RouterFinder:" + getTestEndpoint(50));
         test(finder.getRouter().ice_getIdentity().equals(router.ice_getIdentity()));
         out.println("ok");
       }

--- a/java/test/src/main/java/test/Ice/adapterDeactivation/AllTests.java
+++ b/java/test/src/main/java/test/Ice/adapterDeactivation/AllTests.java
@@ -161,8 +161,7 @@ public class AllTests {
 
       try {
         router =
-            com.zeroc.Ice.RouterPrx.uncheckedCast(
-                communicator.stringToProxy("test:" + helper.getTestEndpoint(1)));
+            com.zeroc.Ice.RouterPrx.createProxy(communicator, "test:" + helper.getTestEndpoint(1));
         communicator.createObjectAdapterWithRouter("", router);
         test(false);
       } catch (com.zeroc.Ice.ConnectFailedException ex) {

--- a/java/test/src/main/java/test/Ice/admin/AllTests.java
+++ b/java/test/src/main/java/test/Ice/admin/AllTests.java
@@ -159,8 +159,7 @@ public class AllTests {
     out.println("ok");
 
     String ref = "factory:" + helper.getTestEndpoint(0) + " -t 10000";
-    RemoteCommunicatorFactoryPrx factory =
-        RemoteCommunicatorFactoryPrx.uncheckedCast(helper.communicator().stringToProxy(ref));
+    var factory = RemoteCommunicatorFactoryPrx.createProxy(helper.communicator(), ref);
 
     out.print("testing process facet... ");
     out.flush();

--- a/java/test/src/main/java/test/Ice/ami/AllTests.java
+++ b/java/test/src/main/java/test/Ice/ami/AllTests.java
@@ -1067,9 +1067,9 @@ public class AllTests {
     out.print("testing result struct... ");
     out.flush();
     {
-      test.Ice.ami.Test.Outer.Inner.TestIntfPrx q =
-          test.Ice.ami.Test.Outer.Inner.TestIntfPrx.uncheckedCast(
-              communicator.stringToProxy("test2:" + helper.getTestEndpoint(0)));
+      var q =
+          test.Ice.ami.Test.Outer.Inner.TestIntfPrx.createProxy(
+              communicator, "test2:" + helper.getTestEndpoint(0));
 
       q.opAsync(1)
           .whenComplete(

--- a/java/test/src/main/java/test/Ice/binding/AllTests.java
+++ b/java/test/src/main/java/test/Ice/binding/AllTests.java
@@ -45,8 +45,7 @@ public class AllTests {
     PrintWriter out = helper.getWriter();
 
     String ref = "communicator:" + helper.getTestEndpoint(0);
-    RemoteCommunicatorPrx rcom =
-        RemoteCommunicatorPrx.uncheckedCast(communicator.stringToProxy(ref));
+    var rcom = RemoteCommunicatorPrx.createProxy(communicator, ref);
 
     out.print("testing binding with single endpoint... ");
     out.flush();

--- a/java/test/src/main/java/test/Ice/exceptions/AllTests.java
+++ b/java/test/src/main/java/test/Ice/exceptions/AllTests.java
@@ -331,16 +331,12 @@ public class AllTests {
       }
 
       try {
-        ThrowerPrx thrower2 =
-            ThrowerPrx.uncheckedCast(
-                communicator.stringToProxy("thrower:" + helper.getTestEndpoint(1)));
+        var thrower2 = ThrowerPrx.createProxy(communicator, "thrower:" + helper.getTestEndpoint(1));
         try {
           thrower2.throwMemoryLimitException(new byte[2 * 1024 * 1024]); // 2MB (no limits)
         } catch (com.zeroc.Ice.MemoryLimitException ex) {
         }
-        ThrowerPrx thrower3 =
-            ThrowerPrx.uncheckedCast(
-                communicator.stringToProxy("thrower:" + helper.getTestEndpoint(2)));
+        var thrower3 = ThrowerPrx.createProxy(communicator, "thrower:" + helper.getTestEndpoint(2));
         try {
           thrower3.throwMemoryLimitException(new byte[1024]); // 1KB limit
           test(false);

--- a/java/test/src/main/java/test/Ice/idleTimeout/AllTests.java
+++ b/java/test/src/main/java/test/Ice/idleTimeout/AllTests.java
@@ -16,7 +16,7 @@ public class AllTests {
   static void allTests(test.TestHelper helper) {
     Communicator communicator = helper.communicator();
     String proxyString = "test: " + helper.getTestEndpoint();
-    TestIntfPrx p = TestIntfPrx.uncheckedCast(communicator.stringToProxy(proxyString));
+    var p = TestIntfPrx.createProxy(communicator, proxyString);
 
     String proxyString3s = "test: " + helper.getTestEndpoint(1);
 
@@ -70,7 +70,7 @@ public class AllTests {
     var initData = new InitializationData();
     initData.properties = properties;
     try (var communicator = Util.initialize(initData)) {
-      TestIntfPrx p = TestIntfPrx.uncheckedCast(communicator.stringToProxy(proxyString));
+      var p = TestIntfPrx.createProxy(communicator, proxyString);
 
       // Establish connection.
       var connection = p.ice_getConnection();
@@ -104,7 +104,7 @@ public class AllTests {
     var initData = new InitializationData();
     initData.properties = properties;
     try (var communicator = Util.initialize(initData)) {
-      TestIntfPrx p = TestIntfPrx.uncheckedCast(communicator.stringToProxy(proxyString));
+      var p = TestIntfPrx.createProxy(communicator, proxyString);
 
       var connection = p.ice_getConnection();
       test(connection != null);

--- a/java/test/src/main/java/test/Ice/location/AllTests.java
+++ b/java/test/src/main/java/test/Ice/location/AllTests.java
@@ -51,8 +51,7 @@ public class AllTests {
 
     out.print("testing ice_locator and ice_getLocator... ");
     test(Util.proxyIdentityCompare(base.ice_getLocator(), communicator.getDefaultLocator()) == 0);
-    com.zeroc.Ice.LocatorPrx anotherLocator =
-        com.zeroc.Ice.LocatorPrx.uncheckedCast(communicator.stringToProxy("anotherLocator"));
+    var anotherLocator = com.zeroc.Ice.LocatorPrx.createProxy(communicator, "anotherLocator");
     base = base.ice_locator(anotherLocator);
     test(Util.proxyIdentityCompare(base.ice_getLocator(), anotherLocator) == 0);
     communicator.setDefaultLocator(null);
@@ -69,12 +68,10 @@ public class AllTests {
     // test/Ice/router test?)
     //
     test(base.ice_getRouter() == null);
-    com.zeroc.Ice.RouterPrx anotherRouter =
-        com.zeroc.Ice.RouterPrx.uncheckedCast(communicator.stringToProxy("anotherRouter"));
+    var anotherRouter = com.zeroc.Ice.RouterPrx.createProxy(communicator, "anotherRouter");
     base = base.ice_router(anotherRouter);
     test(Util.proxyIdentityCompare(base.ice_getRouter(), anotherRouter) == 0);
-    com.zeroc.Ice.RouterPrx router =
-        com.zeroc.Ice.RouterPrx.uncheckedCast(communicator.stringToProxy("dummyrouter"));
+    var router = com.zeroc.Ice.RouterPrx.createProxy(communicator, "dummyrouter");
     communicator.setDefaultRouter(router);
     base = communicator.stringToProxy("test @ TestAdapter");
     test(Util.proxyIdentityCompare(base.ice_getRouter(), communicator.getDefaultRouter()) == 0);

--- a/java/test/src/main/java/test/Ice/objects/AllTests.java
+++ b/java/test/src/main/java/test/Ice/objects/AllTests.java
@@ -355,16 +355,14 @@ public class AllTests {
       test(opF1Result.f12.name.equals("F12"));
 
       Initial.OpF2Result opF2Result =
-          initial.opF2(
-              F2Prx.uncheckedCast(communicator.stringToProxy("F21:" + helper.getTestEndpoint())));
+          initial.opF2(F2Prx.createProxy(communicator, "F21:" + helper.getTestEndpoint()));
       test(opF2Result.returnValue.ice_getIdentity().name.equals("F21"));
       opF2Result.returnValue.op();
       test(opF2Result.f22.ice_getIdentity().name.equals("F22"));
 
       if (initial.hasF3()) {
         Initial.OpF3Result opF3Result =
-            initial.opF3(
-                new F3(new F1("F11"), F2Prx.uncheckedCast(communicator.stringToProxy("F21"))));
+            initial.opF3(new F3(new F1("F11"), F2Prx.createProxy(communicator, "F21")));
         test(opF3Result.returnValue.f1.name.equals("F11"));
         test(opF3Result.returnValue.f2.ice_getIdentity().name.equals("F21"));
 

--- a/java/test/src/main/java/test/Ice/objects/InitialI.java
+++ b/java/test/src/main/java/test/Ice/objects/InitialI.java
@@ -206,7 +206,7 @@ public final class InitialI implements Initial {
   public Initial.OpF2Result opF2(F2Prx f21, com.zeroc.Ice.Current current) {
     Initial.OpF2Result r = new Initial.OpF2Result();
     r.returnValue = f21;
-    r.f22 = F2Prx.uncheckedCast(current.adapter.getCommunicator().stringToProxy("F22"));
+    r.f22 = F2Prx.createProxy(current.adapter.getCommunicator(), "F22");
     return r;
   }
 
@@ -214,10 +214,7 @@ public final class InitialI implements Initial {
   public Initial.OpF3Result opF3(F3 f31, com.zeroc.Ice.Current current) {
     Initial.OpF3Result r = new Initial.OpF3Result();
     r.returnValue = f31;
-    r.f32 =
-        new F3(
-            new F1("F12"),
-            F2Prx.uncheckedCast(current.adapter.getCommunicator().stringToProxy("F22")));
+    r.f32 = new F3(new F1("F12"), F2Prx.createProxy(current.adapter.getCommunicator(), "F22"));
     return r;
   }
 

--- a/java/test/src/main/java/test/Ice/operations/BatchOneways.java
+++ b/java/test/src/main/java/test/Ice/operations/BatchOneways.java
@@ -124,7 +124,7 @@ class BatchOneways {
       BatchRequestInterceptorI interceptor = new BatchRequestInterceptorI();
       initData.batchRequestInterceptor = interceptor;
       try (com.zeroc.Ice.Communicator ic = helper.initialize(initData)) {
-        batch = MyClassPrx.uncheckedCast(ic.stringToProxy(p.toString())).ice_batchOneway();
+        batch = MyClassPrx.createProxy(ic, p.toString()).ice_batchOneway();
 
         test(interceptor.count() == 0);
         batch.ice_ping();

--- a/java/test/src/main/java/test/Ice/operations/Twoways.java
+++ b/java/test/src/main/java/test/Ice/operations/Twoways.java
@@ -1339,9 +1339,7 @@ class Twoways {
           ctx.put("two", "TWO");
           ctx.put("three", "THREE");
 
-          MyClassPrx p3 =
-              MyClassPrx.uncheckedCast(
-                  ic.stringToProxy("test:" + helper.getTestEndpoint(properties, 0)));
+          var p3 = MyClassPrx.createProxy(ic, "test:" + helper.getTestEndpoint(properties, 0));
 
           ic.getImplicitContext().setContext(ctx);
           test(ic.getImplicitContext().getContext().equals(ctx));

--- a/java/test/src/main/java/test/Ice/operations/TwowaysAMI.java
+++ b/java/test/src/main/java/test/Ice/operations/TwowaysAMI.java
@@ -1544,9 +1544,7 @@ class TwowaysAMI {
           ctx.put("two", "TWO");
           ctx.put("three", "THREE");
 
-          MyClassPrx p3 =
-              MyClassPrx.uncheckedCast(
-                  ic.stringToProxy("test:" + helper.getTestEndpoint(properties, 0)));
+          var p3 = MyClassPrx.createProxy(ic, "test:" + helper.getTestEndpoint(properties, 0));
 
           ic.getImplicitContext().setContext(ctx);
           test(ic.getImplicitContext().getContext().equals(ctx));

--- a/java/test/src/main/java/test/Ice/optional/AllTests.java
+++ b/java/test/src/main/java/test/Ice/optional/AllTests.java
@@ -68,7 +68,7 @@ public class AllTests {
     mo1.setG(1.0);
     mo1.setH("test");
     mo1.setI(MyEnum.MyEnumMember);
-    mo1.setJ(MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test")));
+    mo1.setJ(MyInterfacePrx.createProxy(communicator, "test"));
     mo1.setBs(new byte[] {(byte) 5});
     mo1.setSs(new String[] {"test", "test2"});
     mo1.setIid(new java.util.HashMap<>());
@@ -86,8 +86,7 @@ public class AllTests {
     mo1.setEs(new MyEnum[] {MyEnum.MyEnumMember, MyEnum.MyEnumMember});
     mo1.setFss(new FixedStruct[] {fs});
     mo1.setVss(new VarStruct[] {vs});
-    mo1.setMips(
-        new MyInterfacePrx[] {MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test"))});
+    mo1.setMips(new MyInterfacePrx[] {MyInterfacePrx.createProxy(communicator, "test")});
 
     mo1.setIed(new java.util.HashMap<>());
     mo1.getIed().put(4, MyEnum.MyEnumMember);
@@ -96,7 +95,7 @@ public class AllTests {
     mo1.setIvsd(new java.util.HashMap<>());
     mo1.getIvsd().put(5, vs);
     mo1.setImipd(new java.util.HashMap<>());
-    mo1.getImipd().put(5, MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test")));
+    mo1.getImipd().put(5, MyInterfacePrx.createProxy(communicator, "test"));
 
     mo1.setBos(new boolean[] {false, true, false});
 
@@ -989,7 +988,7 @@ public class AllTests {
       Initial.OpMyInterfaceProxyResult r = initial.opMyInterfaceProxy(p1);
       test(!r.returnValue.isPresent() && !r.p3.isPresent());
 
-      p1 = Optional.of(MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test")));
+      p1 = Optional.of(MyInterfacePrx.createProxy(communicator, "test"));
       r = initial.opMyInterfaceProxy(p1);
       test(r.returnValue.get().equals(p1.get()) && r.p3.get().equals(p1.get()));
       r = initial.opMyInterfaceProxyAsync(p1).join();

--- a/java/test/src/main/java/test/Ice/proxy/AllTests.java
+++ b/java/test/src/main/java/test/Ice/proxy/AllTests.java
@@ -729,20 +729,16 @@ public class AllTests {
     test(compObj.ice_compress(true).ice_getCompress().get() == true);
     test(compObj.ice_compress(false).ice_getCompress().get() == false);
 
-    com.zeroc.Ice.LocatorPrx loc1 =
-        com.zeroc.Ice.LocatorPrx.uncheckedCast(communicator.stringToProxy("loc1:tcp -p 10000"));
-    com.zeroc.Ice.LocatorPrx loc2 =
-        com.zeroc.Ice.LocatorPrx.uncheckedCast(communicator.stringToProxy("loc2:tcp -p 10000"));
+    var loc1 = com.zeroc.Ice.LocatorPrx.createProxy(communicator, "loc1:tcp -p 10000");
+    var loc2 = com.zeroc.Ice.LocatorPrx.createProxy(communicator, "loc2:tcp -p 10000");
     test(compObj.ice_locator(null).equals(compObj.ice_locator(null)));
     test(compObj.ice_locator(loc1).equals(compObj.ice_locator(loc1)));
     test(!compObj.ice_locator(loc1).equals(compObj.ice_locator(null)));
     test(!compObj.ice_locator(null).equals(compObj.ice_locator(loc2)));
     test(!compObj.ice_locator(loc1).equals(compObj.ice_locator(loc2)));
 
-    com.zeroc.Ice.RouterPrx rtr1 =
-        com.zeroc.Ice.RouterPrx.uncheckedCast(communicator.stringToProxy("rtr1:tcp -p 10000"));
-    com.zeroc.Ice.RouterPrx rtr2 =
-        com.zeroc.Ice.RouterPrx.uncheckedCast(communicator.stringToProxy("rtr2:tcp -p 10000"));
+    var rtr1 = com.zeroc.Ice.RouterPrx.createProxy(communicator, "rtr1:tcp -p 10000");
+    var rtr2 = com.zeroc.Ice.RouterPrx.createProxy(communicator, "rtr2:tcp -p 10000");
     test(compObj.ice_router(null).equals(compObj.ice_router(null)));
     test(compObj.ice_router(rtr1).equals(compObj.ice_router(rtr1)));
     test(!compObj.ice_router(rtr1).equals(compObj.ice_router(null)));
@@ -887,7 +883,7 @@ public class AllTests {
     out.print("testing encoding versioning... ");
     out.flush();
     String ref20 = "test -e 2.0:" + helper.getTestEndpoint(0);
-    MyClassPrx cl20 = MyClassPrx.uncheckedCast(communicator.stringToProxy(ref20));
+    var cl20 = MyClassPrx.createProxy(communicator, ref20);
     try {
       cl20.ice_ping();
       test(false);
@@ -896,7 +892,7 @@ public class AllTests {
     }
 
     String ref10 = "test -e 1.0:" + helper.getTestEndpoint(0);
-    MyClassPrx cl10 = MyClassPrx.uncheckedCast(communicator.stringToProxy(ref10));
+    var cl10 = MyClassPrx.createProxy(communicator, ref10);
     cl10.ice_ping();
     cl10.ice_encodingVersion(Util.Encoding_1_0).ice_ping();
     cl.ice_encodingVersion(Util.Encoding_1_0).ice_ping();
@@ -904,7 +900,7 @@ public class AllTests {
     // 1.3 isn't supported but since a 1.3 proxy supports 1.1, the
     // call will use the 1.1 encoding
     String ref13 = "test -e 1.3:" + helper.getTestEndpoint(0);
-    MyClassPrx cl13 = MyClassPrx.uncheckedCast(communicator.stringToProxy(ref13));
+    var cl13 = MyClassPrx.createProxy(communicator, ref13);
     cl13.ice_ping();
     cl13.ice_pingAsync().join();
 
@@ -945,7 +941,7 @@ public class AllTests {
     out.print("testing protocol versioning... ");
     out.flush();
     ref20 = "test -p 2.0:" + helper.getTestEndpoint(0);
-    cl20 = MyClassPrx.uncheckedCast(communicator.stringToProxy(ref20));
+    cl20 = MyClassPrx.createProxy(communicator, ref20);
     try {
       cl20.ice_ping();
       test(false);
@@ -954,13 +950,13 @@ public class AllTests {
     }
 
     ref10 = "test -p 1.0:" + helper.getTestEndpoint(0);
-    cl10 = MyClassPrx.uncheckedCast(communicator.stringToProxy(ref10));
+    cl10 = MyClassPrx.createProxy(communicator, ref10);
     cl10.ice_ping();
 
     // 1.3 isn't supported but since a 1.3 proxy supports 1.1, the
     // call will use the 1.1 protocol
     ref13 = "test -p 1.3:" + helper.getTestEndpoint(0);
-    cl13 = MyClassPrx.uncheckedCast(communicator.stringToProxy(ref13));
+    cl13 = MyClassPrx.createProxy(communicator, ref13);
     cl13.ice_ping();
     cl13.ice_pingAsync().join();
     out.println("ok");

--- a/java/test/src/main/java/test/Ice/stream/Client.java
+++ b/java/test/src/main/java/test/Ice/stream/Client.java
@@ -205,7 +205,7 @@ public class Client extends test.TestHelper {
         s.d = 6.0;
         s.str = "7";
         s.e = MyEnum.enum2;
-        s.p = MyInterfacePrx.uncheckedCast(communicator.stringToProxy("test:default"));
+        s.p = MyInterfacePrx.createProxy(communicator, "test:default");
         LargeStruct.ice_write(out, s);
         byte[] data = out.finished();
         in = new InputStream(communicator, data);

--- a/java/test/src/main/java/test/Ice/udp/Client.java
+++ b/java/test/src/main/java/test/Ice/udp/Client.java
@@ -25,9 +25,8 @@ public class Client extends test.TestHelper {
       }
 
       for (int i = 0; i < num; ++i) {
-        com.zeroc.Ice.ObjectPrx prx =
-            communicator().stringToProxy("control:" + getTestEndpoint(i, "tcp"));
-        TestIntfPrx.uncheckedCast(prx).shutdown();
+        var prx = TestIntfPrx.createProxy(communicator(), "control:" + getTestEndpoint(i, "tcp"));
+        prx.shutdown();
       }
     }
   }

--- a/java/test/src/main/java/test/IceBox/admin/Client.java
+++ b/java/test/src/main/java/test/IceBox/admin/Client.java
@@ -11,12 +11,11 @@ public class Client extends test.TestHelper {
     try (com.zeroc.Ice.Communicator communicator = initialize(properties)) {
       AllTests.allTests(this);
 
-      //
       // Shutdown the IceBox server.
-      //
-      com.zeroc.Ice.ProcessPrx.uncheckedCast(
-              communicator().stringToProxy("DemoIceBox/admin -f Process:default -p 9996"))
-          .shutdown();
+      var prx =
+          com.zeroc.Ice.ProcessPrx.createProxy(
+              communicator(), "DemoIceBox/admin -f Process:default -p 9996");
+      prx.shutdown();
     }
   }
 }

--- a/java/test/src/main/java/test/IceBox/configuration/AllTests.java
+++ b/java/test/src/main/java/test/IceBox/configuration/AllTests.java
@@ -17,14 +17,10 @@ public class AllTests {
   public static void allTests(test.TestHelper helper) {
     com.zeroc.Ice.Communicator communicator = helper.communicator();
     PrintWriter out = helper.getWriter();
-    TestIntfPrx service1 =
-        TestIntfPrx.uncheckedCast(communicator.stringToProxy("test:" + helper.getTestEndpoint(0)));
-    TestIntfPrx service2 =
-        TestIntfPrx.uncheckedCast(communicator.stringToProxy("test:" + helper.getTestEndpoint(1)));
-    TestIntfPrx service3 =
-        TestIntfPrx.uncheckedCast(communicator.stringToProxy("test:" + helper.getTestEndpoint(2)));
-    TestIntfPrx service4 =
-        TestIntfPrx.uncheckedCast(communicator.stringToProxy("test:" + helper.getTestEndpoint(3)));
+    var service1 = TestIntfPrx.createProxy(communicator, "test:" + helper.getTestEndpoint(0));
+    var service2 = TestIntfPrx.createProxy(communicator, "test:" + helper.getTestEndpoint(1));
+    var service3 = TestIntfPrx.createProxy(communicator, "test:" + helper.getTestEndpoint(2));
+    var service4 = TestIntfPrx.createProxy(communicator, "test:" + helper.getTestEndpoint(3));
 
     if (service1.getProperty("IceBox.InheritProperties").equals("")) {
       out.print("testing service properties... ");

--- a/java/test/src/main/java/test/IceBox/configuration/Client.java
+++ b/java/test/src/main/java/test/IceBox/configuration/Client.java
@@ -11,12 +11,11 @@ public class Client extends test.TestHelper {
     try (com.zeroc.Ice.Communicator communicator = initialize(properties)) {
       AllTests.allTests(this);
 
-      //
       // Shutdown the IceBox server.
-      //
-      com.zeroc.Ice.ProcessPrx.uncheckedCast(
-              communicator.stringToProxy("DemoIceBox/admin -f Process:default -p 9996"))
-          .shutdown();
+      var prx =
+          com.zeroc.Ice.ProcessPrx.createProxy(
+              communicator(), "DemoIceBox/admin -f Process:default -p 9996");
+      prx.shutdown();
     }
   }
 }

--- a/java/test/src/main/java/test/IceDiscovery/simple/AllTests.java
+++ b/java/test/src/main/java/test/IceDiscovery/simple/AllTests.java
@@ -24,9 +24,8 @@ public class AllTests {
     List<ControllerPrx> indirectProxies = new ArrayList<>();
     for (int i = 0; i < num; ++i) {
       String id = "controller" + i;
-      proxies.add(ControllerPrx.uncheckedCast(communicator.stringToProxy(id)));
-      indirectProxies.add(
-          ControllerPrx.uncheckedCast(communicator.stringToProxy(id + "@control" + i)));
+      proxies.add(ControllerPrx.createProxy(communicator, id));
+      indirectProxies.add(ControllerPrx.createProxy(communicator, id + "@control" + i));
     }
 
     System.out.print("testing indirect proxies... ");
@@ -142,7 +141,7 @@ public class AllTests {
       adapterIds.add("oa1");
       adapterIds.add("oa2");
       adapterIds.add("oa3");
-      TestIntfPrx intf = TestIntfPrx.uncheckedCast(communicator.stringToProxy("object"));
+      var intf = TestIntfPrx.createProxy(communicator, "object");
       intf = intf.ice_connectionCached(false).ice_locatorCacheTimeout(0);
       while (!adapterIds.isEmpty()) {
         adapterIds.remove(intf.getAdapterId());
@@ -152,9 +151,7 @@ public class AllTests {
         adapterIds.add("oa1");
         adapterIds.add("oa2");
         adapterIds.add("oa3");
-        intf =
-            TestIntfPrx.uncheckedCast(
-                communicator.stringToProxy("object @ rg").ice_connectionCached(false));
+        intf = TestIntfPrx.createProxy(communicator, "object @ rg").ice_connectionCached(false);
         int nRetry = 100;
         while (!adapterIds.isEmpty() && --nRetry > 0) {
           adapterIds.remove(intf.getAdapterId());
@@ -169,18 +166,12 @@ public class AllTests {
 
       proxies.get(0).deactivateObjectAdapter("oa");
       proxies.get(1).deactivateObjectAdapter("oa");
-      test(
-          TestIntfPrx.uncheckedCast(communicator.stringToProxy("object @ rg"))
-              .getAdapterId()
-              .equals("oa3"));
+      test(TestIntfPrx.createProxy(communicator, "object @ rg").getAdapterId().equals("oa3"));
       proxies.get(2).deactivateObjectAdapter("oa");
 
       proxies.get(0).activateObjectAdapter("oa", "oa1", "rg");
       proxies.get(0).addObject("oa", "object");
-      test(
-          TestIntfPrx.uncheckedCast(communicator.stringToProxy("object @ rg"))
-              .getAdapterId()
-              .equals("oa1"));
+      test(TestIntfPrx.createProxy(communicator, "object @ rg").getAdapterId().equals("oa1"));
       proxies.get(0).deactivateObjectAdapter("oa");
     }
     System.out.println("ok");

--- a/java/test/src/main/java/test/IceSSL/configuration/PlatformTests.java
+++ b/java/test/src/main/java/test/IceSSL/configuration/PlatformTests.java
@@ -125,8 +125,8 @@ public class PlatformTests {
         try (var clientCommunicator =
             createClient(helper, null, certificatesPath + "/cacert1.jks")) {
           var obj =
-              ServerPrx.uncheckedCast(
-                  clientCommunicator.stringToProxy("server:" + helper.getTestEndpoint(10, "ssl")));
+              ServerPrx.createProxy(
+                  clientCommunicator, "server:" + helper.getTestEndpoint(10, "ssl"));
           obj.ice_ping();
         }
       }
@@ -147,9 +147,9 @@ public class PlatformTests {
 
       try (var clientCommunicator = createClient(helper, null, null)) {
         var obj =
-            ObjectPrx.uncheckedCast(
-                clientCommunicator.stringToProxy(
-                    "Glacier2/router:wss -p 443 -h zeroc.com -r /demo-proxy/chat/glacier2"));
+            ObjectPrx.createProxy(
+                clientCommunicator,
+                "Glacier2/router:wss -p 443 -h zeroc.com -r /demo-proxy/chat/glacier2");
         obj.ice_ping();
       }
       out.println("ok");
@@ -171,8 +171,8 @@ public class PlatformTests {
         try (var clientCommunicator =
             createClient(helper, null, certificatesPath + "/cacert2.jks")) {
           var obj =
-              ServerPrx.uncheckedCast(
-                  clientCommunicator.stringToProxy("server:" + helper.getTestEndpoint(10, "ssl")));
+              ServerPrx.createProxy(
+                  clientCommunicator, "server:" + helper.getTestEndpoint(10, "ssl"));
 
           try {
             obj.ice_ping();
@@ -204,8 +204,8 @@ public class PlatformTests {
         try (var clientCommunicator =
             createClient(helper, clientCertificatePath, trustedStorePath)) {
           var obj =
-              ServerPrx.uncheckedCast(
-                  clientCommunicator.stringToProxy("server:" + helper.getTestEndpoint(10, "ssl")));
+              ServerPrx.createProxy(
+                  clientCommunicator, "server:" + helper.getTestEndpoint(10, "ssl"));
           obj.ice_ping();
         }
       }
@@ -232,8 +232,8 @@ public class PlatformTests {
         try (var clientCommunicator =
             createClient(helper, clientCertificatePath, trustedStorePath)) {
           var obj =
-              ServerPrx.uncheckedCast(
-                  clientCommunicator.stringToProxy("server:" + helper.getTestEndpoint(10, "ssl")));
+              ServerPrx.createProxy(
+                  clientCommunicator, "server:" + helper.getTestEndpoint(10, "ssl"));
 
           try {
             obj.ice_ping();
@@ -331,16 +331,16 @@ public class PlatformTests {
 
       try (var clientCommunicator = createClient(helper, null, certificatesPath + "/cacert1.jks")) {
         var obj =
-            ServerPrx.uncheckedCast(
-                clientCommunicator.stringToProxy("server:" + helper.getTestEndpoint(10, "ssl")));
+            ServerPrx.createProxy(
+                clientCommunicator, "server:" + helper.getTestEndpoint(10, "ssl"));
         obj.ice_ping();
       }
 
       // CA2 is not accepted with the initial configuration
       try (var clientCommunicator = createClient(helper, null, certificatesPath + "/cacert2.jks")) {
         var obj =
-            ServerPrx.uncheckedCast(
-                clientCommunicator.stringToProxy("server:" + helper.getTestEndpoint(10, "ssl")));
+            ServerPrx.createProxy(
+                clientCommunicator, "server:" + helper.getTestEndpoint(10, "ssl"));
         try {
           obj.ice_ping();
           test(false);
@@ -354,16 +354,16 @@ public class PlatformTests {
       // CA2 is accepted with the new configuration
       try (var clientCommunicator = createClient(helper, null, certificatesPath + "/cacert2.jks")) {
         var obj =
-            ServerPrx.uncheckedCast(
-                clientCommunicator.stringToProxy("server:" + helper.getTestEndpoint(10, "ssl")));
+            ServerPrx.createProxy(
+                clientCommunicator, "server:" + helper.getTestEndpoint(10, "ssl"));
         obj.ice_ping();
       }
 
       // CA1 is not accepted with the initial configuration
       try (var clientCommunicator = createClient(helper, null, certificatesPath + "/cacert1.jks")) {
         var obj =
-            ServerPrx.uncheckedCast(
-                clientCommunicator.stringToProxy("server:" + helper.getTestEndpoint(10, "ssl")));
+            ServerPrx.createProxy(
+                clientCommunicator, "server:" + helper.getTestEndpoint(10, "ssl"));
         try {
           obj.ice_ping();
           test(false);


### PR DESCRIPTION
This PR adds a new `createProxy` method on `ObjectPrx` and the generated proxies as well.
It also updates our source/tests to use it.

Right now it's a simple implementation which just calls `stringToProxy` and `uncheckedCast`.
This is just another step forward in proxy refactoring, and this implementation will be improved in a follow-up PR.