### PR TITLE
Add forwarding adapter test to Java Metrics test

### DIFF
--- a/java/test/src/main/java/test/Ice/metrics/AMDServer.java
+++ b/java/test/src/main/java/test/Ice/metrics/AMDServer.java
@@ -20,7 +20,13 @@ public class AMDServer extends test.TestHelper {
       adapter.add(new AMDMetricsI(), com.zeroc.Ice.Util.stringToIdentity("metrics"));
       adapter.activate();
 
-      communicator.getProperties().setProperty("ControllerAdapter.Endpoints", getTestEndpoint(1));
+      communicator.getProperties().setProperty("ForwardingAdapter.Endpoints", getTestEndpoint(1));
+      com.zeroc.Ice.ObjectAdapter forwardingAdapter =
+          communicator.createObjectAdapter("ForwardingAdapter");
+      forwardingAdapter.addDefaultServant(adapter.dispatchPipeline(), "");
+      forwardingAdapter.activate();
+
+      communicator.getProperties().setProperty("ControllerAdapter.Endpoints", getTestEndpoint(2));
       com.zeroc.Ice.ObjectAdapter controllerAdapter =
           communicator.createObjectAdapter("ControllerAdapter");
       controllerAdapter.add(

--- a/java/test/src/main/java/test/Ice/metrics/Collocated.java
+++ b/java/test/src/main/java/test/Ice/metrics/Collocated.java
@@ -33,7 +33,12 @@ public class Collocated extends test.TestHelper {
       adapter.add(new MetricsI(), com.zeroc.Ice.Util.stringToIdentity("metrics"));
       // adapter.activate(); // Don't activate OA to ensure collocation is used.
 
-      communicator.getProperties().setProperty("ControllerAdapter.Endpoints", getTestEndpoint(1));
+      communicator.getProperties().setProperty("ForwardingAdapter.Endpoints", getTestEndpoint(1));
+      com.zeroc.Ice.ObjectAdapter forwardingAdapter =
+          communicator.createObjectAdapter("ForwardingAdapter");
+      forwardingAdapter.addDefaultServant(adapter.dispatchPipeline(), "");
+
+      communicator.getProperties().setProperty("ControllerAdapter.Endpoints", getTestEndpoint(2));
       com.zeroc.Ice.ObjectAdapter controllerAdapter =
           communicator.createObjectAdapter("ControllerAdapter");
       controllerAdapter.add(

--- a/java/test/src/main/java/test/Ice/metrics/Server.java
+++ b/java/test/src/main/java/test/Ice/metrics/Server.java
@@ -21,7 +21,13 @@ public class Server extends test.TestHelper {
       adapter.add(new MetricsI(), com.zeroc.Ice.Util.stringToIdentity("metrics"));
       adapter.activate();
 
-      communicator.getProperties().setProperty("ControllerAdapter.Endpoints", getTestEndpoint(1));
+      communicator.getProperties().setProperty("ForwardingAdapter.Endpoints", getTestEndpoint(1));
+      com.zeroc.Ice.ObjectAdapter forwardingAdapter =
+          communicator.createObjectAdapter("ForwardingAdapter");
+      forwardingAdapter.addDefaultServant(adapter.dispatchPipeline(), "");
+      forwardingAdapter.activate();
+
+      communicator.getProperties().setProperty("ControllerAdapter.Endpoints", getTestEndpoint(2));
       com.zeroc.Ice.ObjectAdapter controllerAdapter =
           communicator.createObjectAdapter("ControllerAdapter");
       controllerAdapter.add(


### PR DESCRIPTION
This PR synchronizes the Java Metrics test with its C++ and C# counterparts.