### PR TITLE
Fixes #2334

### DIFF
--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -1582,7 +1582,7 @@ ConnectionI::upcall(
 void
 Ice::ConnectionI::finished(ThreadPoolCurrent& current, bool close)
 {
-    // Lock the connection here to ensure setState() completes before the code bellow is executed. This method can be
+    // Lock the connection here to ensure setState() completes before the code below is executed. This method can be
     // called by the thread pool as soon as setState() calls _threadPool->finish(...). There's no need to lock the mutex
     // for the remainder of the code because the data members accessed by finish() are immutable once _state ==
     // StateClosed (and we don't want to hold the mutex when calling upcalls).

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -1582,6 +1582,15 @@ ConnectionI::upcall(
 void
 Ice::ConnectionI::finished(ThreadPoolCurrent& current, bool close)
 {
+    // Lock the connection here to ensure setState() completes before the code bellow is executed. This method can be
+    // called by the thread pool as soon as setState() calls _threadPool->finish(...). There's no need to lock the mutex
+    // for the remainder of the code because the data members accessed by finish() are immutable once _state ==
+    // StateClosed (and we don't want to hold the mutex when calling upcalls).
+    {
+        std::lock_guard lock(_mutex);
+        assert(_state == StateClosed);
+    }
+
     // If there are no callbacks to call, we don't call ioCompleted() since we're not going to call code that will
     // potentially block (this avoids promoting a new leader and unecessary thread creation, especially if this is
     // called on shutdown).

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1216,7 +1216,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
 
     public override void finished(ref ThreadPoolCurrent current)
     {
-        // Lock the connection here to ensure setState() completes before the code bellow is executed. This method can
+        // Lock the connection here to ensure setState() completes before the code below is executed. This method can
         // be called by the thread pool as soon as setState() calls _threadPool->finish(...). There's no need to lock
         // the mutex for the remainder of the code because the data members accessed by finish() are immutable once
         // _state == StateClosed (and we don't want to hold the mutex when calling upcalls).

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1216,6 +1216,15 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
 
     public override void finished(ref ThreadPoolCurrent current)
     {
+        // Lock the connection here to ensure setState() completes before the code bellow is executed. This method can
+        // be called by the thread pool as soon as setState() calls _threadPool->finish(...). There's no need to lock
+        // the mutex for the remainder of the code because the data members accessed by finish() are immutable once
+        // _state == StateClosed (and we don't want to hold the mutex when calling upcalls).
+        lock (this)
+        {
+            Debug.Assert(_state == StateClosed);
+        }
+
         //
         // If there are no callbacks to call, we don't call ioCompleted() since we're not going
         // to call code that will potentially block (this avoids promoting a new leader and

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -956,6 +956,17 @@ public final class ConnectionI extends com.zeroc.IceInternal.EventHandler
 
   @Override
   public void finished(com.zeroc.IceInternal.ThreadPoolCurrent current, final boolean close) {
+    // Lock the connection here to ensure setState() completes before
+    // the code bellow is executed. This method can be called by the
+    // thread pool as soon as setState() calls _threadPool->finish(...).
+    // There's no need to lock the mutex for the remainder of the code
+    // because the data members accessed by finish() are immutable once
+    // _state == StateClosed (and we don't want to hold the mutex when
+    // calling upcalls).
+    synchronized (this) {
+      assert _state == StateClosed;
+    }
+
     if (_instance.queueRequests()) {
       _instance
           .getQueueExecutor()

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -957,7 +957,7 @@ public final class ConnectionI extends com.zeroc.IceInternal.EventHandler
   @Override
   public void finished(com.zeroc.IceInternal.ThreadPoolCurrent current, final boolean close) {
     // Lock the connection here to ensure setState() completes before
-    // the code bellow is executed. This method can be called by the
+    // the code below is executed. This method can be called by the
     // thread pool as soon as setState() calls _threadPool->finish(...).
     // There's no need to lock the mutex for the remainder of the code
     // because the data members accessed by finish() are immutable once


### PR DESCRIPTION
This PR fixes #2334 by just adding locking at the top of the finished method implementation. Holding the lock for the remainder of the method is not really useful.