### PR TITLE
Additional C# thread pool fixes

### DIFF
--- a/csharp/src/Ice/ConnectionFactory.cs
+++ b/csharp/src/Ice/ConnectionFactory.cs
@@ -1401,7 +1401,7 @@ namespace IceInternal
             return _state < StateClosed;
         }
 
-        public override void message(ref ThreadPoolCurrent current)
+        public override void message(ThreadPoolCurrent current)
         {
             Ice.ConnectionI connection = null;
 
@@ -1522,7 +1522,7 @@ namespace IceInternal
             connection.start(this);
         }
 
-        public override void finished(ref ThreadPoolCurrent current)
+        public override void finished(ThreadPoolCurrent current)
         {
             lock(this)
             {

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1168,7 +1168,7 @@ namespace Ice
             return _state < StateClosed;
         }
 
-        public override void message(ref ThreadPoolCurrent current)
+        public override void message(ThreadPoolCurrent current)
         {
             StartCallback startCB = null;
             Queue<OutgoingMessage> sentCBs = null;
@@ -1560,7 +1560,7 @@ namespace Ice
             }
         }
 
-        public override void finished(ref ThreadPoolCurrent current)
+        public override void finished(ThreadPoolCurrent current)
         {
             lock(this)
             {

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1102,6 +1102,11 @@ namespace Ice
 
         public override bool finishAsync(int operation)
         {
+            if(_state >= StateClosed)
+            {
+                return false;
+            }
+
             try
             {
                 if((operation & SocketOperation.Write) != 0)

--- a/csharp/src/Ice/EventHandler.cs
+++ b/csharp/src/Ice/EventHandler.cs
@@ -17,12 +17,12 @@ public abstract class EventHandler
     //
     // Called when there's a message ready to be processed.
     //
-    abstract public void message(ref ThreadPoolCurrent op);
+    abstract public void message(ThreadPoolCurrent op);
 
     //
     // Called when the event handler is unregistered.
     //
-    abstract public void finished(ref ThreadPoolCurrent op);
+    abstract public void finished(ThreadPoolCurrent op);
 
     internal int _ready = 0;
     internal int _pending = 0;

--- a/csharp/src/Ice/ThreadPool.cs
+++ b/csharp/src/Ice/ThreadPool.cs
@@ -361,7 +361,7 @@ namespace IceInternal
                         {
                             current.operation = SocketOperation.None;
                             current._handler = handler;
-                            handler.finished(ref current);
+                            handler.finished(current);
                         });
                     Monitor.Pulse(this);
                 }
@@ -472,7 +472,7 @@ namespace IceInternal
                         current.operation = operation;
                         try
                         {
-                            current._handler.message(ref current);
+                            current._handler.message(current);
                         }
                         catch(System.Exception ex)
                         {


### PR DESCRIPTION
This 3.7 PR fixes:
- unnecessary "ref" parameters for ThreadPoolCurrent
- the connection code to no longer call the transceiver finishXxx method if the connection is closed