### PR TITLE
Added Java transceiver interface comments

### DIFF
--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/ReadyCallback.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/ReadyCallback.java
@@ -5,5 +5,13 @@
 package com.zeroc.IceInternal;
 
 public interface ReadyCallback {
+  /**
+   * Sets the transceiver read or write readiness status. This method is used by a transceiver
+   * implementation to notify the thread pool that it's ready or not to write or read data.
+   *
+   * @param op The transceiver read or write operation
+   * @param value The status of the operation readiness, true if the transceiver operation is ready,
+   *     false otherwise.
+   */
   void ready(int op, boolean value);
 }

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/Transceiver.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/Transceiver.java
@@ -16,13 +16,12 @@ public interface Transceiver {
 
   /**
    * Sets the transceiver ready callback. This method is called by the thread pool to provide
-   * a ready callback object that the transceiver can use to notify the thread pool's
-   * selector that more data is ready to be read or written by this transceiver. The
-   * transceiver implementation typically uses this mechanism when it buffers data read from
-   * the selectable channel define above or when there's no the transceiver doesn't provide
-   * a selectable channel (the fd() method above returns null).
+   * a callback object that the transceiver can use to notify the thread pool's selector when
+   * more data is ready to be read or written by this transceiver.
    *
    * @param callback The ready callback provided by the thread pool's selector.
+   * @remark  The transceiver implementation typically uses this callback when it buffers
+   * data read from the selectable channel of if it doesn't use a selectable channel.
    */
   void setReadyCallback(ReadyCallback callback);
 

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/Transceiver.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/Transceiver.java
@@ -5,8 +5,25 @@
 package com.zeroc.IceInternal;
 
 public interface Transceiver {
+  /**
+   * Returns the selectable channel used by the thread pool's selector to wait for read or
+   * write readiness.
+   *
+   * @return The selectable channel that will be registered with the thread pool's selector
+   * or null if the transceiver doesn't use a selectable channel.
+   */
   java.nio.channels.SelectableChannel fd();
 
+  /**
+   * Sets the transceiver ready callback. This method is called by the thread pool to provide
+   * a ready callback object that the transceiver can use to notify the thread pool's
+   * selector that more data is ready to be read or written by this transceiver. The
+   * transceiver implementation typically uses this mechanism when it buffers data read from
+   * the selectable channel define above or when there's no the transceiver doesn't provide
+   * a selectable channel (the fd() method above returns null).
+   *
+   * @param callback The ready callback provided by the thread pool's selector.
+   */
   void setReadyCallback(ReadyCallback callback);
 
   int initialize(Buffer readBuffer, Buffer writeBuffer);

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/Transceiver.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/Transceiver.java
@@ -6,22 +6,22 @@ package com.zeroc.IceInternal;
 
 public interface Transceiver {
   /**
-   * Returns the selectable channel used by the thread pool's selector to wait for read or
-   * write readiness.
+   * Returns the selectable channel used by the thread pool's selector to wait for read or write
+   * readiness.
    *
-   * @return The selectable channel that will be registered with the thread pool's selector
-   * or null if the transceiver doesn't use a selectable channel.
+   * @return The selectable channel that will be registered with the thread pool's selector or null
+   *     if the transceiver doesn't use a selectable channel.
    */
   java.nio.channels.SelectableChannel fd();
 
   /**
-   * Sets the transceiver ready callback. This method is called by the thread pool to provide
-   * a callback object that the transceiver can use to notify the thread pool's selector when
-   * more data is ready to be read or written by this transceiver.
+   * Sets the transceiver ready callback. This method is called by the thread pool to provide a
+   * callback object that the transceiver can use to notify the thread pool's selector when more
+   * data is ready to be read or written by this transceiver.
    *
    * @param callback The ready callback provided by the thread pool's selector.
-   * @remark  The transceiver implementation typically uses this callback when it buffers
-   * data read from the selectable channel of if it doesn't use a selectable channel.
+   * @remark The transceiver implementation typically uses this callback when it buffers data read
+   *     from the selectable channel if it doesn't use a selectable channel.
    */
   void setReadyCallback(ReadyCallback callback);
 

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/Transceiver.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/Transceiver.java
@@ -17,11 +17,11 @@ public interface Transceiver {
   /**
    * Sets the transceiver ready callback. This method is called by the thread pool to provide a
    * callback object that the transceiver can use to notify the thread pool's selector when more
-   * data is ready to be read or written by this transceiver.
+   * data is ready to be read or written by this transceiver. A transceiver implementation typically
+   * uses this callback when it buffers data read from the selectable channel if it doesn't use a
+   * selectable channel.
    *
    * @param callback The ready callback provided by the thread pool's selector.
-   * @remark The transceiver implementation typically uses this callback when it buffers data read
-   *     from the selectable channel if it doesn't use a selectable channel.
    */
   void setReadyCallback(ReadyCallback callback);
 
@@ -39,10 +39,10 @@ public interface Transceiver {
 
   /**
    * Checks if this transceiver is waiting to be read, typically because it has bytes readily
-   * available for reading.
+   * available for reading. The caller must ensure the transceiver is not closed when calling this
+   * method.
    *
    * @return true if this transceiver is waiting to be read, false otherwise.
-   * @remark The caller must ensure the transceiver is not closed when calling this method.
    */
   boolean isWaitingToBeRead();
 


### PR DESCRIPTION
This PR adds comments for the `setReadyCallback` and `fd` methods on the `Transceiver` interface.