### PR TITLE
Add support for ClassGraphDepthMax in Ice for Java

### DIFF
--- a/cpp/test/Ice/objects/AllTests.cpp
+++ b/cpp/test/Ice/objects/AllTests.cpp
@@ -306,36 +306,21 @@ allTests(Test::TestHelper* helper)
 
     cout << "testing recursive type... " << flush;
     RecursivePtr top = make_shared<Recursive>();
-    int depth = 0;
     try
     {
         RecursivePtr p = top;
-#if defined(NDEBUG) || !defined(__APPLE__)
-        const int maxDepth = 2000;
-#else
-        // With debug, marshaling a graph of 2000 elements can cause a stack overflow on macOS
-        const int maxDepth = 1500;
-#endif
-        for (; depth <= maxDepth; ++depth)
+        int maxDepth = 100;
+        for (int i = 0; i <= maxDepth; i++)
         {
             p->v = make_shared<Recursive>();
             p = p->v;
-            if ((depth < 10 && (depth % 10) == 0) || (depth < 1000 && (depth % 100) == 0) ||
-                (depth < 10000 && (depth % 1000) == 0) || (depth % 10000) == 0)
-            {
-                initial->setRecursive(top);
-            }
         }
-        test(!initial->supportsClassGraphDepthMax());
+        initial->setRecursive(top);
+        test(false);
     }
     catch (const Ice::UnknownLocalException&)
     {
         // Expected marshal exception from the server (max class graph depth reached)
-        test(depth == 100); // The default is 100.
-    }
-    catch (const Ice::UnknownException&)
-    {
-        // Expected stack overflow from the server (Java only)
     }
     initial->setRecursive(make_shared<Recursive>());
     cout << "ok" << endl;

--- a/cpp/test/Ice/objects/AllTests.cpp
+++ b/cpp/test/Ice/objects/AllTests.cpp
@@ -306,15 +306,21 @@ allTests(Test::TestHelper* helper)
 
     cout << "testing recursive type... " << flush;
     RecursivePtr top = make_shared<Recursive>();
+    RecursivePtr bottom = top;
+    int maxDepth = 99;
+    for (int i = 0; i < maxDepth; i++)
+    {
+        bottom->v = make_shared<Recursive>();
+        bottom = bottom->v;
+    }
+    initial->setRecursive(top);
+
+    // Adding one more level would exceed the max class graph depth
+    bottom->v = make_shared<Recursive>();
+    bottom = bottom->v;
+
     try
     {
-        RecursivePtr p = top;
-        int maxDepth = 100;
-        for (int i = 0; i <= maxDepth; i++)
-        {
-            p->v = make_shared<Recursive>();
-            p = p->v;
-        }
         initial->setRecursive(top);
         test(false);
     }
@@ -322,7 +328,6 @@ allTests(Test::TestHelper* helper)
     {
         // Expected marshal exception from the server (max class graph depth reached)
     }
-    initial->setRecursive(make_shared<Recursive>());
     cout << "ok" << endl;
 
     cout << "testing compact ID..." << flush;

--- a/cpp/test/Ice/objects/Test.ice
+++ b/cpp/test/Ice/objects/Test.ice
@@ -216,7 +216,6 @@ interface Initial
     F getF();
 
     void setRecursive(Recursive p);
-    bool supportsClassGraphDepthMax();
 
     void setCycle(Recursive r);
     bool acceptsClassCycles();

--- a/cpp/test/Ice/objects/TestI.cpp
+++ b/cpp/test/Ice/objects/TestI.cpp
@@ -164,12 +164,6 @@ InitialI::setRecursive(RecursivePtr, const Current&)
 {
 }
 
-bool
-InitialI::supportsClassGraphDepthMax(const Current&)
-{
-    return true;
-}
-
 void
 InitialI::setCycle(RecursivePtr r, const Current&)
 {

--- a/cpp/test/Ice/objects/TestI.h
+++ b/cpp/test/Ice/objects/TestI.h
@@ -63,7 +63,6 @@ public:
     Test::FPtr getF(const Ice::Current&) final;
 
     void setRecursive(Test::RecursivePtr, const Ice::Current&) final;
-    bool supportsClassGraphDepthMax(const Ice::Current&) final;
 
     void setCycle(Test::RecursivePtr, const Ice::Current&) final;
     bool acceptsClassCycles(const Ice::Current&) final;

--- a/csharp/test/Ice/objects/AllTests.cs
+++ b/csharp/test/Ice/objects/AllTests.cs
@@ -309,15 +309,20 @@ namespace Ice
                     output.Write("testing recursive type... ");
                     output.Flush();
                     var top = new Test.Recursive();
-                    var p = top;
-                    int maxDepth = 100;
+                    var bottom = top;
+                    int maxDepth = 99;
+                    for (int i = 0; i < maxDepth; i++)
+                    {
+                        bottom.v = new Test.Recursive();
+                        bottom = bottom.v;
+                    }
+                    initial.setRecursive(top);
+
+                    // Adding one more level would exceed the max class graph depth
+                    bottom.v = new Test.Recursive();
+                    bottom = bottom.v;
                     try
                     {
-                        for (int i = 0; i <= maxDepth; i++)
-                        {
-                            p.v = new Test.Recursive();
-                            p = p.v;
-                        }
                         initial.setRecursive(top);
                         test(false);
                     }

--- a/csharp/test/Ice/objects/AllTests.cs
+++ b/csharp/test/Ice/objects/AllTests.cs
@@ -310,30 +310,20 @@ namespace Ice
                     output.Flush();
                     var top = new Test.Recursive();
                     var p = top;
-                    int depth = 0;
+                    int maxDepth = 100;
                     try
                     {
-                        for (; depth <= 1000; ++depth)
+                        for (int i = 0; i <= maxDepth; i++)
                         {
                             p.v = new Test.Recursive();
                             p = p.v;
-                            if ((depth < 10 && (depth % 10) == 0) ||
-                              (depth < 1000 && (depth % 100) == 0) ||
-                              (depth < 10000 && (depth % 1000) == 0) ||
-                              (depth % 10000) == 0)
-                            {
-                                initial.setRecursive(top);
-                            }
                         }
-                        test(!initial.supportsClassGraphDepthMax());
+                        initial.setRecursive(top);
+                        test(false);
                     }
                     catch (Ice.UnknownLocalException)
                     {
                         // Expected marshal exception from the server(max class graph depth reached)
-                    }
-                    catch (Ice.UnknownException)
-                    {
-                        // Expected stack overflow from the server(Java only)
                     }
                     initial.setRecursive(new Test.Recursive());
                     output.WriteLine("ok");

--- a/csharp/test/Ice/objects/InitialI.cs
+++ b/csharp/test/Ice/objects/InitialI.cs
@@ -98,11 +98,6 @@ namespace Ice
             {
             }
 
-            public override bool supportsClassGraphDepthMax(Ice.Current current)
-            {
-                return true;
-            }
-
             public override void setCycle(Test.Recursive r, Ice.Current current)
             {
             }

--- a/csharp/test/Ice/objects/Test.ice
+++ b/csharp/test/Ice/objects/Test.ice
@@ -195,7 +195,6 @@ interface Initial
     F getF();
 
     void setRecursive(Recursive p);
-    bool supportsClassGraphDepthMax();
 
     void setCycle(Recursive r);
     bool acceptsClassCycles();

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -238,6 +238,7 @@ public class InputStream {
 
     _instance = instance;
     _traceSlicing = _instance.traceLevels().slicing > 0;
+    _classGraphDepthMax = _instance.classGraphDepthMax();
 
     _valueFactoryManager = _instance.initializationData().valueFactoryManager;
     _logger = _instance.initializationData().logger;
@@ -250,6 +251,7 @@ public class InputStream {
     _encapsStack = null;
     _encapsCache = null;
     _traceSlicing = false;
+    _classGraphDepthMax = 0x7fffffff;
     _closure = null;
     _sliceValues = true;
     _startSeq = -1;
@@ -349,6 +351,19 @@ public class InputStream {
   }
 
   /**
+   * Set the maximum depth allowed for graph of Slice class instances.
+   *
+   * @param classGraphDepthMax The maximum depth.
+   */
+  public void setClassGraphDepthMax(int classGraphDepthMax) {
+    if (classGraphDepthMax < 1) {
+      _classGraphDepthMax = 0x7fffffff;
+    } else {
+      _classGraphDepthMax = classGraphDepthMax;
+    }
+  }
+
+  /**
    * Retrieves the closure object associated with this stream.
    *
    * @return The closure object.
@@ -400,6 +415,10 @@ public class InputStream {
     boolean tmpSliceValues = other._sliceValues;
     other._sliceValues = _sliceValues;
     _sliceValues = tmpSliceValues;
+
+    int tmpClassGraphDepthMax = other._classGraphDepthMax;
+    other._classGraphDepthMax = _classGraphDepthMax;
+    _classGraphDepthMax = tmpClassGraphDepthMax;
 
     //
     // Swap is never called for streams that have encapsulations being read. However,
@@ -1831,13 +1850,27 @@ public class InputStream {
   }
 
   private abstract static class EncapsDecoder {
+
+    protected class PatchEntry {
+      public PatchEntry(java.util.function.Consumer<Value> cb, int classGraphDepth) {
+        this.cb = cb;
+        this.classGraphDepth = classGraphDepth;
+      }
+
+      public java.util.function.Consumer<Value> cb;
+      public int classGraphDepth;
+    }
+
     EncapsDecoder(
         InputStream stream,
         boolean sliceValues,
+        int classGraphDepthMax,
         ValueFactoryManager f,
         java.util.function.Function<String, Class<?>> cr) {
       _stream = stream;
       _sliceValues = sliceValues;
+      _classGraphDepthMax = classGraphDepthMax;
+      _classGraphDepth = 0;
       _valueFactoryManager = f;
       _classResolver = cr;
       _typeIdIndex = 0;
@@ -1971,7 +2004,7 @@ public class InputStream {
       // the callback will be called when the instance is
       // unmarshaled.
       //
-      java.util.LinkedList<java.util.function.Consumer<Value>> l = _patchMap.get(index);
+      java.util.LinkedList<PatchEntry> l = _patchMap.get(index);
       if (l == null) {
         //
         // We have no outstanding instances to be patched for this
@@ -1984,7 +2017,7 @@ public class InputStream {
       //
       // Append a patch entry for this instance.
       //
-      l.add(cb);
+      l.add(new PatchEntry(cb, _classGraphDepth));
     }
 
     protected void unmarshal(int index, Value v) {
@@ -2003,15 +2036,15 @@ public class InputStream {
         //
         // Patch all instances now that the instance is unmarshaled.
         //
-        java.util.LinkedList<java.util.function.Consumer<Value>> l = _patchMap.get(index);
+        java.util.LinkedList<PatchEntry> l = _patchMap.get(index);
         if (l != null) {
           assert (l.size() > 0);
 
           //
           // Patch all pointers that refer to the instance.
           //
-          for (java.util.function.Consumer<Value> cb : l) {
-            cb.accept(v);
+          for (PatchEntry entry : l) {
+            entry.cb.accept(v);
           }
 
           //
@@ -2061,14 +2094,15 @@ public class InputStream {
 
     protected final InputStream _stream;
     protected final boolean _sliceValues;
+    protected final int _classGraphDepthMax;
+    protected int _classGraphDepth;
     protected ValueFactoryManager _valueFactoryManager;
     protected java.util.function.Function<String, Class<?>> _classResolver;
 
     //
     // Encapsulation attributes for value unmarshaling.
     //
-    protected java.util.TreeMap<Integer, java.util.LinkedList<java.util.function.Consumer<Value>>>
-        _patchMap;
+    protected java.util.TreeMap<Integer, java.util.LinkedList<PatchEntry>> _patchMap;
     private java.util.TreeMap<Integer, Value> _unmarshaledMap;
     private java.util.TreeMap<Integer, String> _typeIdMap;
     private int _typeIdIndex;
@@ -2080,9 +2114,10 @@ public class InputStream {
     EncapsDecoder10(
         InputStream stream,
         boolean sliceValues,
+        int classGraphDepthMax,
         ValueFactoryManager f,
         java.util.function.Function<String, Class<?>> cr) {
-      super(stream, sliceValues, f, cr);
+      super(stream, sliceValues, classGraphDepthMax, f, cr);
       _sliceType = SliceType.NoSlice;
     }
 
@@ -2315,6 +2350,26 @@ public class InputStream {
       }
 
       //
+      // Compute the biggest class graph depth of this object. To compute this,
+      // we get the class graph depth of each ancestor from the patch map and
+      // keep the biggest one.
+      //
+      _classGraphDepth = 0;
+      var l = _patchMap != null ? _patchMap.get(index) : null;
+      if (l != null) {
+        assert (l.size() > 0);
+        for (PatchEntry entry : l) {
+          if (entry.classGraphDepth > _classGraphDepth) {
+            _classGraphDepth = entry.classGraphDepth;
+          }
+        }
+      }
+
+      if (++_classGraphDepth > _classGraphDepthMax) {
+        throw new MarshalException("maximum class graph depth reached");
+      }
+
+      //
       // Unmarshal the instance and add it to the map of unmarshaled instances.
       //
       unmarshal(index, v);
@@ -2333,10 +2388,11 @@ public class InputStream {
     EncapsDecoder11(
         InputStream stream,
         boolean sliceValues,
+        int classGraphDepthMax,
         ValueFactoryManager f,
         java.util.function.Function<String, Class<?>> cr,
         java.util.function.IntFunction<String> r) {
-      super(stream, sliceValues, f, cr);
+      super(stream, sliceValues, classGraphDepthMax, f, cr);
       _compactIdResolver = r;
       _current = null;
       _valueIdIndex = 1;
@@ -2767,10 +2823,16 @@ public class InputStream {
         startSlice(); // Read next Slice header for next iteration.
       }
 
+      if (++_classGraphDepth > _classGraphDepthMax) {
+        throw new MarshalException("maximum class graph depth reached");
+      }
+
       //
       // Unmarshal the instance.
       //
       unmarshal(index, v);
+
+      --_classGraphDepth;
 
       if (_current == null && _patchMap != null && !_patchMap.isEmpty()) {
         //
@@ -2917,11 +2979,17 @@ public class InputStream {
     {
       if (_encapsStack.encoding_1_0) {
         _encapsStack.decoder =
-            new EncapsDecoder10(this, _sliceValues, _valueFactoryManager, _classResolver);
+            new EncapsDecoder10(
+                this, _sliceValues, _classGraphDepthMax, _valueFactoryManager, _classResolver);
       } else {
         _encapsStack.decoder =
             new EncapsDecoder11(
-                this, _sliceValues, _valueFactoryManager, _classResolver, _compactIdResolver);
+                this,
+                _sliceValues,
+                _classGraphDepthMax,
+                _valueFactoryManager,
+                _classResolver,
+                _compactIdResolver);
       }
     }
   }
@@ -2945,6 +3013,7 @@ public class InputStream {
   }
 
   private boolean _sliceValues;
+  private int _classGraphDepthMax;
   private boolean _traceSlicing;
 
   private int _startSeq;

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/Instance.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/Instance.java
@@ -308,6 +308,11 @@ public final class Instance implements java.util.function.Function<String, Class
     return _batchAutoFlushSize;
   }
 
+  public int classGraphDepthMax() {
+    // No mutex lock, immutable.
+    return _classGraphDepthMax;
+  }
+
   public com.zeroc.Ice.ToStringMode toStringMode() {
     // No mutex lock, immutable
     return _toStringMode;
@@ -811,6 +816,15 @@ public final class Instance implements java.util.function.Function<String, Class
         } else {
           _batchAutoFlushSize =
               num * 1024; // Property is in kilobytes, _batchAutoFlushSize in bytes
+        }
+      }
+
+      {
+        var num = properties.getIcePropertyAsInt("Ice.ClassGraphDepthMax");
+        if (num < 1 || num > 0x7fffffff) {
+          _classGraphDepthMax = 0x7fffffff;
+        } else {
+          _classGraphDepthMax = num;
         }
       }
 
@@ -1516,6 +1530,7 @@ public final class Instance implements java.util.function.Function<String, Class
   private DefaultsAndOverrides _defaultsAndOverrides; // Immutable, not reset by destroy().
   private int _messageSizeMax; // Immutable, not reset by destroy().
   private int _batchAutoFlushSize; // Immutable, not reset by destroy().
+  private int _classGraphDepthMax; // Immutable, not reset by destroy().
   private com.zeroc.Ice.ToStringMode _toStringMode; // Immutable, not reset by destroy().
   private int _cacheMessageBuffers; // Immutable, not reset by destroy().
   private com.zeroc.Ice.ImplicitContextI _implicitContext;

--- a/java/test/src/main/java/test/Ice/objects/AllTests.java
+++ b/java/test/src/main/java/test/Ice/objects/AllTests.java
@@ -267,25 +267,16 @@ public class AllTests {
     out.flush();
     Recursive top = new Recursive();
     Recursive p = top;
-    int depth = 0;
+    int maxDepth = 100;
     try {
-      for (; depth <= 20000; ++depth) {
+      for (int i = 0; i <= maxDepth; ++i) {
         p.v = new Recursive();
         p = p.v;
-        if ((depth < 10 && (depth % 10) == 0)
-            || (depth < 1000 && (depth % 100) == 0)
-            || (depth < 10000 && (depth % 1000) == 0)
-            || (depth % 10000) == 0) {
-          initial.setRecursive(top);
-        }
       }
-      test(!initial.supportsClassGraphDepthMax());
+      initial.setRecursive(top);
+      test(false);
     } catch (com.zeroc.Ice.UnknownLocalException ex) {
       // Expected marshal exception from the server (max class graph depth reached)
-    } catch (com.zeroc.Ice.UnknownException ex) {
-      // Expected stack overflow from the server (Java only)
-    } catch (java.lang.StackOverflowError ex) {
-      // Stack overflow while writing instances
     }
     initial.setRecursive(new Recursive());
     out.println("ok");

--- a/java/test/src/main/java/test/Ice/objects/AllTests.java
+++ b/java/test/src/main/java/test/Ice/objects/AllTests.java
@@ -266,19 +266,24 @@ public class AllTests {
     out.print("testing recursive type... ");
     out.flush();
     Recursive top = new Recursive();
-    Recursive p = top;
-    int maxDepth = 100;
+    Recursive bottom = top;
+    int maxDepth = 99;
+    for (int i = 0; i < maxDepth; ++i) {
+      bottom.v = new Recursive();
+      bottom = bottom.v;
+    }
+    initial.setRecursive(top);
+
+    // Adding one more level would exceed the max class graph depth
+    bottom.v = new Recursive();
+    bottom = bottom.v;
+
     try {
-      for (int i = 0; i <= maxDepth; ++i) {
-        p.v = new Recursive();
-        p = p.v;
-      }
       initial.setRecursive(top);
       test(false);
     } catch (com.zeroc.Ice.UnknownLocalException ex) {
       // Expected marshal exception from the server (max class graph depth reached)
     }
-    initial.setRecursive(new Recursive());
     out.println("ok");
 
     out.print("testing compact ID...");

--- a/java/test/src/main/java/test/Ice/objects/InitialI.java
+++ b/java/test/src/main/java/test/Ice/objects/InitialI.java
@@ -94,11 +94,6 @@ public final class InitialI implements Initial {
   public void setRecursive(Recursive r, com.zeroc.Ice.Current current) {}
 
   @Override
-  public boolean supportsClassGraphDepthMax(com.zeroc.Ice.Current current) {
-    return false;
-  }
-
-  @Override
   public void setCycle(Recursive r, com.zeroc.Ice.Current current) {}
 
   @Override

--- a/java/test/src/main/java/test/Ice/objects/Test.ice
+++ b/java/test/src/main/java/test/Ice/objects/Test.ice
@@ -196,7 +196,6 @@ interface Initial
     F getF();
 
     void setRecursive(Recursive p);
-    bool supportsClassGraphDepthMax();
 
     void setCycle(Recursive r);
     bool acceptsClassCycles();

--- a/js/test/Ice/objects/Client.ts
+++ b/js/test/Ice/objects/Client.ts
@@ -253,28 +253,18 @@ export class Client extends TestHelper {
 
         const top = new Test.Recursive();
         let p = top;
-        let depth = 0;
+        let maxDepth = 100;
 
         try {
-            for (; depth <= 1000; ++depth) {
+            for (let i = 0; i <= maxDepth; ++i) {
                 p.v = new Test.Recursive();
                 p = p.v;
-                if (
-                    (depth < 10 && depth % 10 == 0) ||
-                    (depth < 1000 && depth % 100 == 0) ||
-                    (depth < 10000 && depth % 1000 == 0) ||
-                    depth % 10000 == 0
-                ) {
-                    await initial!.setRecursive(top);
-                }
             }
-            test(!(await initial!.supportsClassGraphDepthMax()));
+            await initial!.setRecursive(top);
+            test(false);
         } catch (ex) {
-            //
             // Ice.UnknownLocalException: Expected marshal exception from the server (max class graph depth reached)
-            // Ice.UnknownException: Expected stack overflow from the server (Java only)
-            //
-            test(ex instanceof Ice.UnknownLocalException || ex instanceof Ice.UnknownException, ex);
+            test(ex instanceof Ice.UnknownLocalException, ex);
         }
         await initial!.setRecursive(new Test.Recursive());
         out.writeLine("ok");

--- a/js/test/Ice/objects/InitialI.ts
+++ b/js/test/Ice/objects/InitialI.ts
@@ -168,10 +168,6 @@ export class InitialI extends Test.Initial {
 
     setRecursive(r: Test.Recursive, current: Ice.Current) {}
 
-    supportsClassGraphDepthMax(current: Ice.Current) {
-        return true;
-    }
-
     setCycle(r: Test.Recursive, current: Ice.Current) {}
 
     acceptsClassCycles(current: Ice.Current) {

--- a/js/test/Ice/objects/Test.ice
+++ b/js/test/Ice/objects/Test.ice
@@ -197,7 +197,6 @@ interface Initial
     F getF();
 
     void setRecursive(Recursive p);
-    bool supportsClassGraphDepthMax();
 
     void setCycle(Recursive r);
     bool acceptsClassCycles();

--- a/matlab/test/Ice/objects/AllTests.m
+++ b/matlab/test/Ice/objects/AllTests.m
@@ -184,17 +184,17 @@ classdef AllTests
             p = top;
             depth = 0;
             try
-                for depth = 0:20000
+                for depth = 0:100
                     p.v = Recursive();
                     p = p.v;
-                    os = communicator.createOutputStream();
-                    os.writeValue(top);
-                    os.writePendingValues();
-                    is = os.createInputStream();
-                    h = IceInternal.ValueHolder();
-                    is.readValue(@(v) h.set(v), 'Test.Recursive');
-                    is.readPendingValues();
                 end
+                os = communicator.createOutputStream();
+                os.writeValue(top);
+                os.writePendingValues();
+                is = os.createInputStream();
+                h = IceInternal.ValueHolder();
+                is.readValue(@(v) h.set(v), 'Test.Recursive');
+                is.readPendingValues();
                 assert(false);
             catch ex
                 if isa(ex, 'Ice.MarshalException')

--- a/matlab/test/Ice/objects/AllTests.m
+++ b/matlab/test/Ice/objects/AllTests.m
@@ -181,20 +181,19 @@ classdef AllTests
 
             fprintf('testing recursive type... ');
             top = Recursive();
-            p = top;
+            bottom = top;
             depth = 0;
+            for depth = 0:99
+                bottom.v = Recursive();
+                bottom = bottom.v;
+            end
+            initial.setRecursive(top);
+
             try
-                for depth = 0:100
-                    p.v = Recursive();
-                    p = p.v;
-                end
-                os = communicator.createOutputStream();
-                os.writeValue(top);
-                os.writePendingValues();
-                is = os.createInputStream();
-                h = IceInternal.ValueHolder();
-                is.readValue(@(v) h.set(v), 'Test.Recursive');
-                is.readPendingValues();
+                % Adding one more level would exceed the max class graph depth
+                bottom.v = Recursive();
+                bottom = bottom.v;
+                initial.setRecursive(top);
                 assert(false);
             catch ex
                 if isa(ex, 'Ice.MarshalException')
@@ -203,7 +202,6 @@ classdef AllTests
                     rethrow(ex);
                 end
             end
-            initial.setRecursive(Recursive());
             fprintf('ok\n');
 
             fprintf('testing compact ID... ');

--- a/matlab/test/Ice/objects/Test.ice
+++ b/matlab/test/Ice/objects/Test.ice
@@ -195,7 +195,6 @@ interface Initial
     F getF();
 
     void setRecursive(Recursive p);
-    bool supportsClassGraphDepthMax();
 
     void setCycle(Recursive r);
     bool acceptsClassCycles();

--- a/php/test/Ice/objects/Client.php
+++ b/php/test/Ice/objects/Client.php
@@ -362,16 +362,21 @@ function allTests($helper)
     echo "testing recursive type... ";
     flush();
     $top = new Test\Recursive();
-    $p = $top;
-    $depth = 0;
+    $bottom = $top;
+    $maxDepth = 99;
+    for ($i = 0; $i < $maxDepth; $i++)
+    {
+        $bottom->v = new Test\Recursive();
+        $bottom = $bottom->v;
+    }
+    $initial->setRecursive($top);
+
+    // Adding one more level would exceed the max class graph depth
+    $bottom->v = new Test\Recursive();
+    $bottom = $bottom->v;
+
     try
     {
-        while($depth <= 100)
-        {
-            $p->v = new Test\Recursive();
-            $p = $p->v;
-            $depth += 1;
-        }
         $initial->setRecursive($top);
         test(false);
     }
@@ -386,7 +391,6 @@ function allTests($helper)
             throw $ex;
         }
     }
-    $initial->setRecursive(new Test\Recursive());
     echo "ok\n";
 
     echo "testing compact ID... ";

--- a/php/test/Ice/objects/Client.php
+++ b/php/test/Ice/objects/Client.php
@@ -366,30 +366,20 @@ function allTests($helper)
     $depth = 0;
     try
     {
-        while($depth <= 700)
+        while($depth <= 100)
         {
             $p->v = new Test\Recursive();
             $p = $p->v;
-            if(($depth < 10 && ($depth % 10) == 0) ||
-               ($depth < 1000 && ($depth % 100) == 0) ||
-               ($depth < 10000 && ($depth % 1000) == 0) ||
-               ($depth % 10000) == 0)
-            {
-                $initial->setRecursive($top);
-            }
             $depth += 1;
         }
-        test(!$initial->supportsClassGraphDepthMax());
+        $initial->setRecursive($top);
+        test(false);
     }
     catch(Exception $ex)
     {
         if($ex instanceof Ice\UnknownLocalException)
         {
             // Expected marshal exception from the server (max class graph depth reached)
-        }
-        else if($ex instanceof Ice\UnknownException)
-        {
-            // Expected stack overflow from the server (Java only)
         }
         else
         {

--- a/php/test/Ice/objects/Test.ice
+++ b/php/test/Ice/objects/Test.ice
@@ -160,7 +160,6 @@ interface Initial
     F getF();
 
     void setRecursive(Recursive p);
-    bool supportsClassGraphDepthMax();
 
     void setCycle(Recursive r);
     bool acceptsClassCycles();

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -3035,8 +3035,7 @@ IcePy::TypedServantWrapper::ice_invokeAsync(
             _iceCheckMode(op->mode, current.mode);
         }
 
-        UpcallPtr up =
-            make_shared<TypedUpcall>(op, std::move(response), error, current.adapter->getCommunicator());
+        UpcallPtr up = make_shared<TypedUpcall>(op, std::move(response), error, current.adapter->getCommunicator());
         up->dispatch(_servant, inParams, current);
     }
     catch (...)

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -3036,7 +3036,7 @@ IcePy::TypedServantWrapper::ice_invokeAsync(
         }
 
         UpcallPtr up =
-            make_shared<TypedUpcall>(op, std::move(response), std::move(error), current.adapter->getCommunicator());
+            make_shared<TypedUpcall>(op, std::move(response), error, current.adapter->getCommunicator());
         up->dispatch(_servant, inParams, current);
     }
     catch (...)
@@ -3060,7 +3060,7 @@ IcePy::BlobjectServantWrapper::ice_invokeAsync(
     AdoptThread adoptThread; // Ensure the current thread is able to call into Python.
     try
     {
-        UpcallPtr up = make_shared<BlobjectUpcall>(std::move(response), std::move(error));
+        UpcallPtr up = make_shared<BlobjectUpcall>(std::move(response), error);
         up->dispatch(_servant, inParams, current);
     }
     catch (...)

--- a/python/test/Ice/objects/AllTests.py
+++ b/python/test/Ice/objects/AllTests.py
@@ -214,13 +214,19 @@ def allTests(helper, communicator):
     sys.stdout.write("testing recursive type... ")
     sys.stdout.flush()
     top = Test.Recursive()
-    p = top
-    depth = 0
+    bottom = top
+    maxDepth = 99
+
+    for _ in range(maxDepth):
+        bottom.v = Test.Recursive()
+        bottom = bottom.v
+    initial.setRecursive(top)
+
+    # Adding one more level would exceed the max class graph depth
+    bottom.v = Test.Recursive()
+    bottom = bottom.v
+
     try:
-        while depth <= 100:
-            p.v = Test.Recursive()
-            p = p.v
-            depth += 1
         initial.setRecursive(top)
         test(False)
     except Ice.UnknownLocalException:

--- a/python/test/Ice/objects/AllTests.py
+++ b/python/test/Ice/objects/AllTests.py
@@ -217,23 +217,14 @@ def allTests(helper, communicator):
     p = top
     depth = 0
     try:
-        while depth <= 700:
+        while depth <= 100:
             p.v = Test.Recursive()
             p = p.v
-            if (
-                (depth < 10 and (depth % 10) == 0)
-                or (depth < 1000 and (depth % 100) == 0)
-                or (depth < 10000 and (depth % 1000) == 0)
-                or (depth % 10000) == 0
-            ):
-                initial.setRecursive(top)
             depth += 1
-        test(not initial.supportsClassGraphDepthMax())
+        initial.setRecursive(top)
+        test(False)
     except Ice.UnknownLocalException:
         # Expected marshal exception from the server (max class graph depth reached)
-        pass
-    except Ice.UnknownException:
-        # Expected stack overflow from the server (Java only)
         pass
     initial.setRecursive(Test.Recursive())
     print("ok")

--- a/python/test/Ice/objects/Test.ice
+++ b/python/test/Ice/objects/Test.ice
@@ -195,7 +195,6 @@ interface Initial
     F getF();
 
     void setRecursive(Recursive p);
-    bool supportsClassGraphDepthMax();
 
     void setCycle(Recursive r);
     bool acceptsClassCycles();

--- a/python/test/Ice/objects/TestI.py
+++ b/python/test/Ice/objects/TestI.py
@@ -119,9 +119,6 @@ class InitialI(Test.Initial):
     def setRecursive(self, r, current):
         pass
 
-    def supportsClassGraphDepthMax(self, current):
-        return True
-
     def setCycle(self, r, current):
         pass
 

--- a/ruby/test/Ice/objects/AllTests.rb
+++ b/ruby/test/Ice/objects/AllTests.rb
@@ -247,18 +247,13 @@ def allTests(helper, communicator)
     p = top;
     depth = 0;
     begin
-        while depth <= 700
+        while depth <= 100
             p.v = Test::Recursive.new
             p = p.v;
-            if (depth < 10 && (depth % 10) == 0) || \
-               (depth < 1000 && (depth % 100) == 0) || \
-               (depth < 10000 && (depth % 1000) == 0) || \
-               (depth % 10000) == 0
-                initial.setRecursive(top)
-            end
             depth += 1
         end
-        test(!initial.supportsClassGraphDepthMax())
+        initial.setRecursive(top)
+        test(false)
     rescue Ice::UnknownLocalException
         # Expected marshal exception from the server (max class graph depth reached)
     rescue Ice::UnknownException

--- a/ruby/test/Ice/objects/AllTests.rb
+++ b/ruby/test/Ice/objects/AllTests.rb
@@ -244,20 +244,24 @@ def allTests(helper, communicator)
     print "testing recursive type... "
     STDOUT.flush
     top = Test::Recursive.new
-    p = top;
-    depth = 0;
+    bottom = top;
+    maxDepth = 99;
+
+    maxDepth.times do |_|
+        bottom.v = Test::Recursive.new
+        bottom = bottom.v;
+    end
+    initial.setRecursive(top)
+
+    # Adding one more level would exceed the max class graph depth
+    bottom.v = Test::Recursive.new
+    bottom = bottom.v;
+
     begin
-        while depth <= 100
-            p.v = Test::Recursive.new
-            p = p.v;
-            depth += 1
-        end
         initial.setRecursive(top)
         test(false)
     rescue Ice::UnknownLocalException
         # Expected marshal exception from the server (max class graph depth reached)
-    rescue Ice::UnknownException
-        # Expected stack overflow from the server (Java only)
     end
     initial.setRecursive(Test::Recursive.new)
     puts "ok"

--- a/ruby/test/Ice/objects/Test.ice
+++ b/ruby/test/Ice/objects/Test.ice
@@ -165,7 +165,6 @@ interface Initial
     F getF();
 
     void setRecursive(Recursive p);
-    bool supportsClassGraphDepthMax();
 
     void setCycle(Recursive r);
     bool acceptsClassCycles();

--- a/swift/test/Ice/objects/AllTests.swift
+++ b/swift/test/Ice/objects/AllTests.swift
@@ -205,12 +205,17 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
 
     output.write("testing recursive type... ")
     let top = Recursive()
-    var p = top
+    var bottom = top
+    for _ in 0...100 {
+        bottom.v = Recursive()
+        bottom = bottom.v!
+    }
+    try initial.setRecursive(top)
+
+    // Adding one more level would exceed the max class graph depth
+    bottom.v = Recursive()
+    bottom = bottom.v!
     do {
-        for _ in 0...100 {
-            p.v = Recursive()
-            p = p.v!
-        }
         try initial.setRecursive(top)
         try test(false)
     } catch is Ice.UnknownLocalException {

--- a/swift/test/Ice/objects/AllTests.swift
+++ b/swift/test/Ice/objects/AllTests.swift
@@ -207,20 +207,14 @@ func allTests(_ helper: TestHelper) throws -> InitialPrx {
     let top = Recursive()
     var p = top
     do {
-        for depth in 0..<1000 {
+        for _ in 0...100 {
             p.v = Recursive()
             p = p.v!
-            if (depth < 10 && (depth % 10) == 0) || (depth < 1000 && (depth % 100) == 0)
-                || (depth < 10000 && (depth % 1000) == 0) || (depth % 10000) == 0
-            {
-                try initial.setRecursive(top)
-            }
         }
-        try test(!initial.supportsClassGraphDepthMax())
+        try initial.setRecursive(top)
+        try test(false)
     } catch is Ice.UnknownLocalException {
         // Expected marshal exception from the server(max class graph depth reached)
-    } catch is Ice.UnknownException {
-        // Expected stack overflow from the server(Java only)
     }
     try initial.setRecursive(Recursive())
     output.writeLine("ok")

--- a/swift/test/Ice/objects/Test.ice
+++ b/swift/test/Ice/objects/Test.ice
@@ -199,7 +199,6 @@ interface Initial
     F getF();
 
     void setRecursive(Recursive p);
-    bool supportsClassGraphDepthMax();
 
     void setCycle(Recursive r);
     bool acceptsClassCycles();

--- a/swift/test/Ice/objects/TestI.swift
+++ b/swift/test/Ice/objects/TestI.swift
@@ -150,10 +150,6 @@ class InitialI: Initial {
 
     func setRecursive(p _: Recursive?, current _: Ice.Current) {}
 
-    func supportsClassGraphDepthMax(current _: Ice.Current) throws -> Bool {
-        return true
-    }
-
     func setCycle(r: Recursive?, current _: Ice.Current) {
         precondition(r != nil)
         precondition(r!.v === r)


### PR DESCRIPTION
This PR implements ClassGraphDepthMax in Java and simplifies the recursive class test in all language mappings.

Fixes #2295