### PR TITLE
Minor Gradle Configuration Improvements

### DIFF
--- a/java/src/Glacier2/build.gradle
+++ b/java/src/Glacier2/build.gradle
@@ -17,7 +17,7 @@ sourceSets {
 
 slice {
     java {
-        files = fileTree(dir: "$project.ext.topSrcDir/slice/Glacier2", includes:['*.ice'], excludes:["*F.ice"])
+        srcDir = "$project.ext.topSrcDir/slice/Glacier2"
     }
 }
 

--- a/java/src/Ice/build.gradle
+++ b/java/src/Ice/build.gradle
@@ -9,8 +9,7 @@ project.ext.description = "Ice is a comprehensive RPC framework that helps you b
 
 slice {
     java {
-        files = fileTree(dir: "$project.ext.topSrcDir/slice", includes:['Ice/*.ice'],
-                excludes:['Ice/*F.ice'])
+        srcDir = "$project.ext.topSrcDir/slice/Ice"
     }
 }
 

--- a/java/src/IceBT/build.gradle
+++ b/java/src/IceBT/build.gradle
@@ -8,7 +8,7 @@ project.ext.description = "Bluetooth support for Ice"
 
 slice {
     java {
-        files = fileTree(dir: "$project.ext.topSrcDir/slice/IceBT", includes:['*.ice'], excludes:["*F.ice"])
+        srcDir = "$project.ext.topSrcDir/slice/IceBT"
     }
 }
 

--- a/java/src/IceBox/build.gradle
+++ b/java/src/IceBox/build.gradle
@@ -8,7 +8,7 @@ project.ext.description = "IceBox is an easy-to-use framework for Ice applicatio
 
 slice {
     java {
-        files = fileTree(dir: "$project.ext.topSrcDir/slice/IceBox", includes:['*.ice'], excludes:["*F.ice"])
+        srcDir = "$project.ext.topSrcDir/slice/IceBox"
     }
 }
 

--- a/java/src/IceDiscovery/build.gradle
+++ b/java/src/IceDiscovery/build.gradle
@@ -8,7 +8,7 @@ project.ext.description = "Allow Ice applications to discover objects and object
 
 slice {
     java {
-        files = fileTree(dir: "$project.ext.topSrcDir/slice/IceDiscovery", includes:['*.ice'], excludes:["*F.ice"])
+        srcDir = "$project.ext.topSrcDir/slice/IceDiscovery"
     }
 }
 

--- a/java/src/IceGrid/build.gradle
+++ b/java/src/IceGrid/build.gradle
@@ -8,7 +8,7 @@ project.ext.description = "Locate, deploy, and manage Ice servers"
 
 slice {
     java {
-        files = fileTree(dir: "$project.ext.topSrcDir/slice/IceGrid", includes:['*.ice'], excludes:["*F.ice"])
+        srcDir = "$project.ext.topSrcDir/slice/IceGrid"
     }
 }
 

--- a/java/src/IceLocatorDiscovery/build.gradle
+++ b/java/src/IceLocatorDiscovery/build.gradle
@@ -8,7 +8,7 @@ project.ext.description = "Ice plug-in that enables the discovery of IceGrid and
 
 slice {
     java {
-        files = fileTree(dir: "$project.ext.topSrcDir/slice/IceLocatorDiscovery", includes:['*.ice'], excludes:["*F.ice"])
+        srcDir = "$project.ext.topSrcDir/slice/IceLocatorDiscovery"
     }
 }
 

--- a/java/src/IceStorm/build.gradle
+++ b/java/src/IceStorm/build.gradle
@@ -17,7 +17,7 @@ sourceSets {
 
 slice {
     java {
-        files = fileTree(dir: "$project.ext.topSrcDir/slice/IceStorm", includes:['*.ice'], excludes:["*F.ice"])
+        srcDir = "$project.ext.topSrcDir/slice/IceStorm"
     }
 }
 

--- a/java/test/plugins/build.gradle
+++ b/java/test/plugins/build.gradle
@@ -5,14 +5,6 @@
 // Don't generate javadoc
 javadoc.enabled = false
 
-sourceSets {
-    main {
-        java {
-            srcDirs "$rootProject.projectDir/test/plugins"
-        }
-    }
-}
-
 dependencies {
     implementation localDependency('ice')
 }


### PR DESCRIPTION
Now that we've removed all the `*F.ice` files, we no longer need to filter them out in the gradle build system.

It also looked like we're specifying a nested srcDir for the plugins test? So I removed it.
Before removing this, I couldn't get the VSCode extension to correctly load the projects.
This removal seems to of had no impact on the build/tests, but it does look like this recursiveness was intentionally added 10 years ago: https://github.com/zeroc-ice/ice/commit/310ebbba56f3a069f4f7f2b6244f9da05e67e3ef#diff-ee23610eaafcce0a64b45b457ed96fbc58eb8bb17e8adc84adc8d56a7c4941ed

Any ideas why we'd do this?

----

It's nested because the `testPlugins` project root is `java/test/plugins`, and we're also setting this folder as the `srcDir`.
It's also just weird looking. The source directory _should_ be `java/test/plugins/src/main/java`, just like everything else we do.