### PR TITLE
Remove difference between optional not-set and null in JavaScript.

### DIFF
--- a/js/src/Ice/EnumBase.js
+++ b/js/src/Ice/EnumBase.js
@@ -105,7 +105,7 @@ export function defineEnum(enumerators) {
     };
 
     type._writeOpt = function (os, tag, v) {
-        if (v !== undefined) {
+        if (v !== undefined && v !== null) {
             if (os.writeOptional(tag, OptionalFormat_Size)) {
                 type._write(os, v);
             }

--- a/js/src/Ice/Stream.js
+++ b/js/src/Ice/Stream.js
@@ -2672,7 +2672,7 @@ export class OutputStream {
     }
 
     writeOptionalProxy(tag, v) {
-        if (v !== undefined) {
+        if (v !== undefined && v !== null) {
             if (this.writeOptional(tag, OptionalFormat.FSize)) {
                 const pos = this.startSize();
                 this.writeProxy(v);

--- a/js/src/Ice/StreamHelpers.js
+++ b/js/src/Ice/StreamHelpers.js
@@ -12,7 +12,7 @@ export const StreamHelpers = {};
 
 StreamHelpers.FSizeOptHelper = function () {
     this.writeOptional = function (os, tag, v) {
-        if (v !== undefined && os.writeOptional(tag, OptionalFormat.FSize)) {
+        if (v !== undefined && v !== null && os.writeOptional(tag, OptionalFormat.FSize)) {
             const pos = os.startSize();
             this.write(os, v);
             os.endSize(pos);
@@ -31,7 +31,7 @@ StreamHelpers.FSizeOptHelper = function () {
 
 StreamHelpers.VSizeOptHelper = function () {
     this.writeOptional = function (os, tag, v) {
-        if (v !== undefined && os.writeOptional(tag, OptionalFormat.VSize)) {
+        if (v !== undefined && v !== null && os.writeOptional(tag, OptionalFormat.VSize)) {
             os.writeSize(this.minWireSize);
             this.write(os, v);
         }
@@ -49,7 +49,7 @@ StreamHelpers.VSizeOptHelper = function () {
 
 StreamHelpers.VSizeContainerOptHelper = function (elementSize) {
     this.writeOptional = function (os, tag, v) {
-        if (v !== undefined && os.writeOptional(tag, OptionalFormat.VSize)) {
+        if (v !== undefined && v !== null && os.writeOptional(tag, OptionalFormat.VSize)) {
             const sz = this.size(v);
             os.writeSize(sz > 254 ? sz * elementSize + 5 : sz * elementSize + 1);
             this.write(os, v);
@@ -68,7 +68,7 @@ StreamHelpers.VSizeContainerOptHelper = function (elementSize) {
 
 StreamHelpers.VSizeContainer1OptHelper = function () {
     this.writeOptional = function (os, tag, v) {
-        if (v !== undefined && os.writeOptional(tag, OptionalFormat.VSize)) {
+        if (v !== undefined && v !== null && os.writeOptional(tag, OptionalFormat.VSize)) {
             this.write(os, v);
         }
     };

--- a/js/test/Ice/optional/Client.ts
+++ b/js/test/Ice/optional/Client.ts
@@ -401,8 +401,8 @@ export class Client extends TestHelper {
             test(p1 === Test.MyEnum.MyEnumMember);
             test(p2 === Test.MyEnum.MyEnumMember);
             [p1, p2] = await initial.opMyEnum(null); // Test null enum
-            test(p1 === Test.MyEnum.MyEnumMember);
-            test(p2 === Test.MyEnum.MyEnumMember);
+            test(p1 === undefined);
+            test(p2 === undefined);
         }
 
         {
@@ -413,8 +413,8 @@ export class Client extends TestHelper {
             test(p1.equals(new Test.SmallStruct(56)));
             test(p2.equals(new Test.SmallStruct(56)));
             [p1, p2] = await initial.opSmallStruct(null); // Test null struct
-            test(p1.equals(new Test.SmallStruct(0)));
-            test(p2.equals(new Test.SmallStruct(0)));
+            test(p1 === undefined);
+            test(p2 === undefined);
         }
 
         {


### PR DESCRIPTION
This PR removes the difference between optional not-set and null in JavaScript. Related to #1643