### PR TITLE
Generate Ice for JavaScript documentation using TypeDoc

### DIFF
--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -2592,7 +2592,7 @@ Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << nl << " * @param prx - The proxy to clone.";
     _out << nl << " * @returns The new " << prx << " proxy.";
     _out << nl << " */";
-    _out << nl << "constructor(other: " << _iceImportPrefix << "Ice.ObjectPrx);";
+    _out << nl << "constructor(prx: " << _iceImportPrefix << "Ice.ObjectPrx);";
 
     for (const auto& op : p->allOperations())
     {

--- a/js/.gitignore
+++ b/js/.gitignore
@@ -1,5 +1,6 @@
 dist
 lib
+docs
 node_modules
 npm-debug.log
 server-languages.json

--- a/js/Makefile
+++ b/js/Makefile
@@ -21,4 +21,9 @@ lint: npminstall
 	$(NPM) run lint
 
 npminstall:
-	$(NPM) install --omit=optional
+	$(NPM) install
+
+doc: srcs
+	mkdir -p dist
+	node dts-bundle.js
+	npx typedoc dist/bundle.d.ts --disableGit --disableSources

--- a/js/dts-bundle.js
+++ b/js/dts-bundle.js
@@ -1,0 +1,72 @@
+//
+// Copyright (c) ZeroC, Inc. All rights reserved.
+//
+
+// A helper script to bundle TypeScript declarations into a single file and remove __global_ alias.
+// This process is necessary for generating Ice for JavaScript documentation using TypeDoc.
+
+import fs from "fs";
+import path from "path";
+import * as ts from "typescript";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const entryFilePath = path.resolve(__dirname, "src/index.d.ts");
+const outputFilePath = path.resolve(__dirname, "dist/bundle.d.ts");
+
+const visitedFiles = new Set();
+const moduleDeclarations = new Map();
+
+function collectReferences(filePath) {
+    if (visitedFiles.has(filePath)) {
+        return;
+    }
+    visitedFiles.add(filePath);
+
+    const fileContent = fs.readFileSync(filePath, "utf-8");
+    const sourceFile = ts.createSourceFile(filePath, fileContent, ts.ScriptTarget.Latest, true);
+
+    sourceFile.referencedFiles.forEach((reference) => {
+        const referencePath = path.resolve(path.dirname(filePath), reference.fileName);
+        collectReferences(referencePath);
+    });
+
+    sourceFile.forEachChild((node) => {
+        if (ts.isModuleDeclaration(node)) {
+            const moduleName = node.name.getText();
+            const moduleBody = node.body;
+
+            if (moduleBody && ts.isModuleBlock(moduleBody)) {
+                const moduleContent = moduleBody.statements
+                    .filter((stmt) => !ts.isImportEqualsDeclaration(stmt))
+                    .map((stmt) => stmt.getText())
+                    .join("\n");
+
+                if (!moduleDeclarations.has(moduleName)) {
+                    moduleDeclarations.set(moduleName, []);
+                }
+                moduleDeclarations.get(moduleName).push(moduleContent);
+            }
+        }
+    });
+}
+
+function mergeModules() {
+    let output = "";
+
+    for (const [moduleName, moduleContents] of moduleDeclarations) {
+        output += `declare module ${moduleName} {\n`;
+        for (const moduleContent of moduleContents) {
+            output += `  ${moduleContent.replace(/__global_/g, "")}\n`;
+        }
+        output += "}\n";
+    }
+
+    return output;
+}
+
+collectReferences(entryFilePath);
+const mergedContent = mergeModules();
+
+fs.writeFileSync(outputFilePath, mergedContent, "utf-8");

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -19,7 +19,8 @@
                 "jshint": "^2.13.6",
                 "prettier": "^3.3.2",
                 "pump": "^3.0.0",
-                "typescript": "^5.4.5",
+                "typedoc": "^0.26.3",
+                "typescript": "^5.5.3",
                 "typescript-formatter": "^7.2.2",
                 "vinyl": "^3.0.0",
                 "vinyl-paths": "^5.0.0"
@@ -78,6 +79,13 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/@shikijs/core": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.10.1.tgz",
+            "integrity": "sha512-qdiJS5a/QGCff7VUFIqd0hDdWly9rDp8lhVmXVrS11aazX8LOTRLHAXkkEeONNsS43EcCd7gax9LLoOz4vlFQA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/node": {
             "version": "20.14.2",
@@ -173,6 +181,13 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "license": "Python-2.0"
         },
         "node_modules/arr-diff": {
             "version": "4.0.0",
@@ -2382,6 +2397,16 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/linkify-it": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "uc.micro": "^2.0.0"
+            }
+        },
         "node_modules/lodash": {
             "version": "4.17.21",
             "dev": true,
@@ -2396,6 +2421,13 @@
                 "yallist": "^2.1.2"
             }
         },
+        "node_modules/lunr": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/map-cache": {
             "version": "0.2.2",
             "dev": true,
@@ -2403,6 +2435,44 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/markdown-it": {
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+            "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1",
+                "entities": "^4.4.0",
+                "linkify-it": "^5.0.0",
+                "mdurl": "^2.0.0",
+                "punycode.js": "^2.3.1",
+                "uc.micro": "^2.1.0"
+            },
+            "bin": {
+                "markdown-it": "bin/markdown-it.mjs"
+            }
+        },
+        "node_modules/markdown-it/node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/mdurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -2795,6 +2865,16 @@
                 "once": "^1.3.1"
             }
         },
+        "node_modules/punycode.js": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/qs": {
             "version": "6.12.1",
             "dev": true,
@@ -3076,6 +3156,16 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/shiki": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.10.1.tgz",
+            "integrity": "sha512-uafV7WCgN4YYrccH6yxpnps6k38sSTlFRrwc4jycWmhWxJIm9dPrk+XkY1hZ2t0I7jmacMNb15Lf2fspa/Y3lg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/core": "1.10.1"
+            }
+        },
         "node_modules/side-channel": {
             "version": "1.0.6",
             "dev": true,
@@ -3354,8 +3444,59 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/typedoc": {
+            "version": "0.26.3",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.3.tgz",
+            "integrity": "sha512-6d2Sw9disvvpdk4K7VNjKr5/3hzijtfQVHRthhDqJgnhMHy1wQz4yPMJVKXElvnZhFr0nkzo+GzjXDTRV5yLpg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "lunr": "^2.3.9",
+                "markdown-it": "^14.1.0",
+                "minimatch": "^9.0.5",
+                "shiki": "^1.9.1",
+                "yaml": "^2.4.5"
+            },
+            "bin": {
+                "typedoc": "bin/typedoc"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x"
+            }
+        },
+        "node_modules/typedoc/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/typedoc/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/typescript": {
-            "version": "5.4.5",
+            "version": "5.5.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+            "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -3383,6 +3524,13 @@
             "peerDependencies": {
                 "typescript": "^2.1.6 || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev"
             }
+        },
+        "node_modules/uc.micro": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/unc-path-regex": {
             "version": "0.1.2",
@@ -3616,6 +3764,19 @@
             "version": "2.1.2",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/yaml": {
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+            "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
         },
         "node_modules/yargs": {
             "version": "16.2.0",

--- a/js/package.json
+++ b/js/package.json
@@ -28,7 +28,8 @@
         "jshint": "^2.13.6",
         "prettier": "^3.3.2",
         "pump": "^3.0.0",
-        "typescript": "^5.4.5",
+        "typedoc": "^0.26.3",
+        "typescript": "^5.5.3",
         "typescript-formatter": "^7.2.2",
         "vinyl": "^3.0.0",
         "vinyl-paths": "^5.0.0"

--- a/js/src/Ice/Communicator.d.ts
+++ b/js/src/Ice/Communicator.d.ts
@@ -14,9 +14,9 @@ declare module "ice" {
          */
         interface Communicator {
             /**
-             * Destroy the communicator. This operation calls {@link #shutdown} implicitly. Calling {@link #destroy} cleans up
+             * Destroy the communicator. This operation calls {@link Communicator#shutdown} implicitly. Calling {@link Communicator#destroy} cleans up
              * memory, and shuts down this communicator's client functionality and destroys all object adapters. Subsequent
-             * calls to {@link #destroy} are ignored.
+             * calls to {@link Communicator#destroy} are ignored.
              * @return The asynchronous result object for the invocation.
              * @see #shutdown
              * @see ObjectAdapter#destroy
@@ -27,7 +27,7 @@ declare module "ice" {
              * Attempts to use a deactivated object adapter raise ObjectAdapterDeactivatedException. Subsequent calls to
              * shutdown are ignored.
              * After shutdown returns, no new requests are processed. However, requests that have been started before shutdown
-             * was called might still be active. You can use {@link #waitForShutdown} to wait for the completion of all
+             * was called might still be active. You can use {@link Communicator#waitForShutdown} to wait for the completion of all
              * requests.
              * @return The asynchronous result object for the invocation.
              * @see #destroy
@@ -36,12 +36,12 @@ declare module "ice" {
              */
             shutdown(): AsyncResultBase<void>;
             /**
-             * Wait until the application has called {@link #shutdown} (or {@link #destroy}). On the server side, this
+             * Wait until the application has called {@link Communicator#shutdown} (or {@link Communicator#destroy}). On the server side, this
              * operation blocks the calling thread until all currently-executing operations have completed. On the client
-             * side, the operation simply blocks until another thread has called {@link #shutdown} or {@link #destroy}.
+             * side, the operation simply blocks until another thread has called {@link Communicator#shutdown} or {@link Communicator#destroy}.
              * A typical use of this operation is to call it from the main thread, which then waits until some other thread
-             * calls {@link #shutdown}. After shut-down is complete, the main thread returns and can do some cleanup work
-             * before it finally calls {@link #destroy} to shut down the client functionality, and then exits the application.
+             * calls {@link Communicator#shutdown}. After shut-down is complete, the main thread returns and can do some cleanup work
+             * before it finally calls {@link Communicator#destroy} to shut down the client functionality, and then exits the application.
              * @return The asynchronous result object for the invocation.
              * @see #shutdown
              * @see #destroy
@@ -123,7 +123,7 @@ declare module "ice" {
             createObjectAdapter(name: string): AsyncResultBase<Ice.ObjectAdapter>;
             /**
              * Create a new object adapter with endpoints. This operation sets the property
-             * <code><em>name</em>.Endpoints</code>, and then calls {@link #createObjectAdapter}. It is provided as a
+             * <code><em>name</em>.Endpoints</code>, and then calls {@link Communicator#createObjectAdapter}. It is provided as a
              * convenience function. Calling this operation with an empty name will result in a UUID being generated for the
              * name.
              * @param name The object adapter name.

--- a/js/src/Ice/ImplicitContext.d.ts
+++ b/js/src/Ice/ImplicitContext.d.ts
@@ -42,7 +42,7 @@ declare module "ice" {
             containsKey(key: string): boolean;
             /**
              * Get the value associated with the given key in the underlying context. Returns an empty string if no value is
-             * associated with the key. {@link #containsKey} allows you to distinguish between an empty-string value and no
+             * associated with the key. {@link ImplicitContext#containsKey} allows you to distinguish between an empty-string value and no
              * value at all.
              * @param key The key.
              * @return The value associated with the key.

--- a/js/src/Ice/ObjectAdapter.d.ts
+++ b/js/src/Ice/ObjectAdapter.d.ts
@@ -27,26 +27,26 @@ declare module "ice" {
              * Activate all endpoints that belong to this object adapter. After activation, the object adapter can dispatch
              * requests received through its endpoints.
              * @return @returns The asynchronous result object for the invocation.
-             * @see #hold
-             * @see #deactivate
+             * @see ObjectAdapter#hold
+             * @see ObjectAdapter#deactivate
              */
             activate(): AsyncResultBase<void>;
             /**
              * Temporarily hold receiving and dispatching requests. The object adapter can be reactivated with the
-             * {@link #activate} operation. <p class="Note"> Holding is not immediate, i.e., after {@link #hold} returns, the
-             * object adapter might still be active for some time. You can use {@link #waitForHold} to wait until holding is
+             * {@link ObjectAdapter#activate} operation. <p class="Note"> Holding is not immediate, i.e., after {@link ObjectAdapter#hold} returns, the
+             * object adapter might still be active for some time. You can use {@link ObjectAdapter#waitForHold} to wait until holding is
              * complete.
-             * @see #activate
-             * @see #deactivate
-             * @see #waitForHold
+             * @see ObjectAdapter#activate
+             * @see ObjectAdapter#deactivate
+             * @see ObjectAdapter#waitForHold
              */
             hold(): void;
             /**
-             * Wait until the object adapter holds requests. Calling {@link #hold} initiates holding of requests, and
-             * {@link #waitForHold} only returns when holding of requests has been completed.
+             * Wait until the object adapter holds requests. Calling {@link ObjectAdapter#hold} initiates holding of requests, and
+             * {@link ObjectAdapter#waitForHold} only returns when holding of requests has been completed.
              * @return @returns The asynchronous result object for the invocation.
-             * @see #hold
-             * @see #waitForDeactivate
+             * @see ObjectAdapter#hold
+             * @see ObjectAdapter#waitForDeactivate
              * @see Communicator#waitForShutdown
              */
             waitForHold(): AsyncResultBase<void>;
@@ -54,25 +54,25 @@ declare module "ice" {
              * Deactivate all endpoints that belong to this object adapter. After deactivation, the object adapter stops
              * receiving requests through its endpoints. Object adapters that have been deactivated must not be reactivated
              * again, and cannot be used otherwise. Attempts to use a deactivated object adapter raise
-             * {@link ObjectAdapterDeactivatedException} however, attempts to {@link #deactivate} an already deactivated
+             * {@link ObjectAdapterDeactivatedException} however, attempts to {@link ObjectAdapter#deactivate} an already deactivated
              * object adapter are ignored and do nothing. Once deactivated, it is possible to destroy the adapter to clean up
              * resources and then create and activate a new adapter with the same name.
-             * <p class="Note"> After {@link #deactivate} returns, no new requests are processed by the object adapter.
-             * However, requests that have been started before {@link #deactivate} was called might still be active. You can
-             * use {@link #waitForDeactivate} to wait for the completion of all requests for this object adapter.
+             * <p class="Note"> After {@link ObjectAdapter#deactivate} returns, no new requests are processed by the object adapter.
+             * However, requests that have been started before {@link ObjectAdapter#deactivate} was called might still be active. You can
+             * use {@link ObjectAdapter#waitForDeactivate} to wait for the completion of all requests for this object adapter.
              * @return @returns The asynchronous result object for the invocation.
-             * @see #activate
-             * @see #hold
-             * @see #waitForDeactivate
+             * @see ObjectAdapter#activate
+             * @see ObjectAdapter#hold
+             * @see ObjectAdapter#waitForDeactivate
              * @see Communicator#shutdown
              */
             deactivate(): AsyncResultBase<void>;
             /**
-             * Wait until the object adapter has deactivated. Calling {@link #deactivate} initiates object adapter
-             * deactivation, and {@link #waitForDeactivate} only returns when deactivation has been completed.
+             * Wait until the object adapter has deactivated. Calling {@link ObjectAdapter#deactivate} initiates object adapter
+             * deactivation, and {@link ObjectAdapter#waitForDeactivate} only returns when deactivation has been completed.
              * @return @returns The asynchronous result object for the invocation.
-             * @see #deactivate
-             * @see #waitForHold
+             * @see ObjectAdapter#deactivate
+             * @see ObjectAdapter#waitForHold
              * @see Communicator#waitForShutdown
              */
             waitForDeactivate(): AsyncResultBase<void>;
@@ -88,8 +88,8 @@ declare module "ice" {
              * calls to destroy are ignored. Once destroy has returned, it is possible to create another object adapter with
              * the same name.
              * @return @returns The asynchronous result object for the invocation.
-             * @see #deactivate
-             * @see #waitForDeactivate
+             * @see ObjectAdapter#deactivate
+             * @see ObjectAdapter#waitForDeactivate
              * @see Communicator#destroy
              */
             destroy(): AsyncResultBase<void>;
@@ -101,24 +101,24 @@ declare module "ice" {
              * @param id The identity of the Ice object that is implemented by the servant.
              * @return A proxy that matches the given identity and this object adapter.
              * @see Identity
-             * @see #addFacet
-             * @see #addWithUUID
-             * @see #remove
-             * @see #find
+             * @see ObjectAdapter#addFacet
+             * @see ObjectAdapter#addWithUUID
+             * @see ObjectAdapter#remove
+             * @see ObjectAdapter#find
              */
             add(servant: Ice.Object, id: Identity): Ice.ObjectPrx;
             /**
-             * Like {@link #add}, but with a facet. Calling <code>add(servant, id)</code> is equivalent to calling
-             * {@link #addFacet} with an empty facet.
+             * Like {@link ObjectAdapter#add}, but with a facet. Calling <code>add(servant, id)</code> is equivalent to calling
+             * {@link ObjectAdapter#addFacet} with an empty facet.
              * @param servant The servant to add.
              * @param id The identity of the Ice object that is implemented by the servant.
              * @param facet The facet. An empty facet means the default facet.
              * @return A proxy that matches the given identity, facet, and this object adapter.
              * @see Identity
-             * @see #add
-             * @see #addFacetWithUUID
-             * @see #removeFacet
-             * @see #findFacet
+             * @see ObjectAdapter#add
+             * @see ObjectAdapter#addFacetWithUUID
+             * @see ObjectAdapter#removeFacet
+             * @see ObjectAdapter#findFacet
              */
             addFacet(servant: Ice.Object, id: Identity, facet: string): Ice.ObjectPrx;
             /**
@@ -128,23 +128,23 @@ declare module "ice" {
              * @param servant The servant to add.
              * @return A proxy that matches the generated UUID identity and this object adapter.
              * @see Identity
-             * @see #add
-             * @see #addFacetWithUUID
-             * @see #remove
-             * @see #find
+             * @see ObjectAdapter#add
+             * @see ObjectAdapter#addFacetWithUUID
+             * @see ObjectAdapter#remove
+             * @see ObjectAdapter#find
              */
             addWithUUID(servant: Ice.Object): Ice.ObjectPrx;
             /**
-             * Like {@link #addWithUUID}, but with a facet. Calling <code>addWithUUID(servant)</code> is equivalent to calling
-             * {@link #addFacetWithUUID} with an empty facet.
+             * Like {@link ObjectAdapter#addWithUUID}, but with a facet. Calling <code>addWithUUID(servant)</code> is equivalent to calling
+             * {@link ObjectAdapter#addFacetWithUUID} with an empty facet.
              * @param servant The servant to add.
              * @param facet The facet. An empty facet means the default facet.
              * @return A proxy that matches the generated UUID identity, facet, and this object adapter.
              * @see Identity
-             * @see #addFacet
-             * @see #addWithUUID
-             * @see #removeFacet
-             * @see #findFacet
+             * @see ObjectAdapter#addFacet
+             * @see ObjectAdapter#addWithUUID
+             * @see ObjectAdapter#removeFacet
+             * @see ObjectAdapter#findFacet
              */
             addFacetWithUUID(servant: Ice.Object, facet: string): Ice.ObjectPrx;
             /**
@@ -164,30 +164,30 @@ declare module "ice" {
              * @param servant The default servant.
              * @param category The category for which the default servant is registered. An empty category means it will
              * handle all categories.
-             * @see #removeDefaultServant
-             * @see #findDefaultServant
+             * @see ObjectAdapter#removeDefaultServant
+             * @see ObjectAdapter#findDefaultServant
              */
             addDefaultServant(servant: Ice.Object, category: string): void;
             /**
              * Remove a servant (that is, the default facet) from the object adapter's Active Servant Map.
              * @param id The identity of the Ice object that is implemented by the servant. If the servant implements multiple
-             * Ice objects, {@link #remove} has to be called for all those Ice objects. Removing an identity that is not in
+             * Ice objects, {@link ObjectAdapter#remove} has to be called for all those Ice objects. Removing an identity that is not in
              * the map throws {@link NotRegisteredException}.
              * @return The removed servant.
              * @see Identity
-             * @see #add
-             * @see #addWithUUID
+             * @see ObjectAdapter#add
+             * @see ObjectAdapter#addWithUUID
              */
             remove(id: Identity): Ice.Object;
             /**
-             * Like {@link #remove}, but with a facet. Calling <code>remove(id)</code> is equivalent to calling
-             * {@link #removeFacet} with an empty facet.
+             * Like {@link ObjectAdapter#remove}, but with a facet. Calling <code>remove(id)</code> is equivalent to calling
+             * {@link ObjectAdapter#removeFacet} with an empty facet.
              * @param id The identity of the Ice object that is implemented by the servant.
              * @param facet The facet. An empty facet means the default facet.
              * @return The removed servant.
              * @see Identity
-             * @see #addFacet
-             * @see #addFacetWithUUID
+             * @see ObjectAdapter#addFacet
+             * @see ObjectAdapter#addFacetWithUUID
              */
             removeFacet(id: Identity, facet: string): Ice.Object;
             /**
@@ -196,8 +196,8 @@ declare module "ice" {
              * {@link NotRegisteredException}.
              * @param id The identity of the Ice object to be removed.
              * @return A collection containing all the facet names and servants of the removed Ice object.
-             * @see #remove
-             * @see #removeFacet
+             * @see ObjectAdapter#remove
+             * @see ObjectAdapter#removeFacet
              */
             removeAllFacets(id: Identity): Map<string, Ice.Object>;
             /**
@@ -205,8 +205,8 @@ declare module "ice" {
              * is not registered throws {@link NotRegisteredException}.
              * @param category The category of the default servant to remove.
              * @return The default servant.
-             * @see #addDefaultServant
-             * @see #findDefaultServant
+             * @see ObjectAdapter#addDefaultServant
+             * @see ObjectAdapter#findDefaultServant
              */
             removeDefaultServant(category: string): Ice.Object;
             /**
@@ -217,20 +217,20 @@ declare module "ice" {
              * @return The servant that implements the Ice object with the given identity, or null if no such servant has been
              * found.
              * @see Identity
-             * @see #findFacet
-             * @see #findByProxy
+             * @see ObjectAdapter#findFacet
+             * @see ObjectAdapter#findByProxy
              */
             find(id: Identity): Ice.Object;
             /**
-             * Like {@link #find}, but with a facet. Calling <code>find(id)</code> is equivalent to calling {@link #findFacet}
+             * Like {@link ObjectAdapter#find}, but with a facet. Calling <code>find(id)</code> is equivalent to calling {@link ObjectAdapter#findFacet}
              * with an empty facet.
              * @param id The identity of the Ice object for which the servant should be returned.
              * @param facet The facet. An empty facet means the default facet.
              * @return The servant that implements the Ice object with the given identity and facet, or null if no such
              * servant has been found.
              * @see Identity
-             * @see #find
-             * @see #findByProxy
+             * @see ObjectAdapter#find
+             * @see ObjectAdapter#findByProxy
              */
             findFacet(id: Identity, facet: string): Ice.Object;
             /**
@@ -238,8 +238,8 @@ declare module "ice" {
              * @param id The identity of the Ice object for which the facets should be returned.
              * @return A collection containing all the facet names and servants that have been found, or an empty map if there
              * is no facet for the given identity.
-             * @see #find
-             * @see #findFacet
+             * @see ObjectAdapter#find
+             * @see ObjectAdapter#findFacet
              */
             findAllFacets(id: Identity): Map<string, Ice.Object>;
             /**
@@ -248,8 +248,8 @@ declare module "ice" {
              * find a servant by using any installed {@link ServantLocator}.
              * @param proxy The proxy for which the servant should be returned.
              * @return The servant that matches the proxy, or null if no such servant has been found.
-             * @see #find
-             * @see #findFacet
+             * @see ObjectAdapter#find
+             * @see ObjectAdapter#findFacet
              */
             findByProxy(proxy: Ice.ObjectPrx): Ice.Object;
             /**
@@ -273,8 +273,8 @@ declare module "ice" {
              * @param category The category for which the Servant Locator can locate servants, or an empty string if the
              * Servant Locator does not belong to any specific category.
              * @see Identity
-             * @see #removeServantLocator
-             * @see #findServantLocator
+             * @see ObjectAdapter#removeServantLocator
+             * @see ObjectAdapter#findServantLocator
              * @see ServantLocator
              */
             addServantLocator(locator: Ice.ServantLocator, category: string): void;
@@ -285,8 +285,8 @@ declare module "ice" {
              * @return The Servant Locator, or throws {@link NotRegisteredException} if no Servant Locator was found for the
              * given category.
              * @see Identity
-             * @see #addServantLocator
-             * @see #findServantLocator
+             * @see ObjectAdapter#addServantLocator
+             * @see ObjectAdapter#findServantLocator
              * @see ServantLocator
              */
             removeServantLocator(category: string): Ice.ServantLocator;
@@ -296,8 +296,8 @@ declare module "ice" {
              * Servant Locator does not belong to any specific category.
              * @return The Servant Locator, or null if no Servant Locator was found for the given category.
              * @see Identity
-             * @see #addServantLocator
-             * @see #removeServantLocator
+             * @see ObjectAdapter#addServantLocator
+             * @see ObjectAdapter#removeServantLocator
              * @see ServantLocator
              */
             findServantLocator(category: string): Ice.ServantLocator;
@@ -305,8 +305,8 @@ declare module "ice" {
              * Find the default servant for a specific category.
              * @param category The category of the default servant to find.
              * @return The default servant or null if no default servant was registered for the category.
-             * @see #addDefaultServant
-             * @see #removeDefaultServant
+             * @see ObjectAdapter#addDefaultServant
+             * @see ObjectAdapter#removeDefaultServant
              */
             findDefaultServant(category: string): Ice.Object;
             /**
@@ -342,7 +342,7 @@ declare module "ice" {
              * adapter will contain the adapter identifier instead of its endpoints. The adapter identifier must be configured
              * using the AdapterId property.
              * @param loc The locator used by this object adapter.
-             * @see #createDirectProxy
+             * @see ObjectAdapter#createDirectProxy
              * @see Locator
              * @see LocatorRegistry
              */
@@ -351,7 +351,7 @@ declare module "ice" {
              * Get the Ice locator used by this object adapter.
              * @return The locator used by this object adapter, or null if no locator is used by this object adapter.
              * @see Locator
-             * @see #setLocator
+             * @see ObjectAdapter#setLocator
              */
             getLocator(): LocatorPrx;
             /**
@@ -371,14 +371,14 @@ declare module "ice" {
             /**
              * Get the set of endpoints that proxies created by this object adapter will contain.
              * @return The set of published endpoints.
-             * @see #refreshPublishedEndpoints
+             * @see ObjectAdapter#refreshPublishedEndpoints
              * @see Endpoint
              */
             getPublishedEndpoints(): Endpoint[];
             /**
              * Set of the endpoints that proxies created by this object adapter will contain.
              * @param newEndpoints The new set of endpoints that the object adapter will embed in proxies.
-             * @see #refreshPublishedEndpoints
+             * @see ObjectAdapter#refreshPublishedEndpoints
              * @see Endpoint
              */
             setPublishedEndpoints(newEndpoints: Ice.Endpoint[]): void;

--- a/js/src/Ice/ObjectPrx.d.ts
+++ b/js/src/Ice/ObjectPrx.d.ts
@@ -26,7 +26,7 @@ declare module "ice" {
 
             /**
              * Tests whether this object supports a specific Slice interface.
-             * @param typeId The type ID of the Slice interface to test against.
+             * @param id The type ID of the Slice interface to test against.
              * @param context The context map for the invocation.
              * @return The asynchronous result object for the invocation.
              */
@@ -122,7 +122,7 @@ declare module "ice" {
              * @param context The context for the new proxy.
              * @return A proxy with the new per-proxy context.
              */
-            ice_context(ctx: Map<string, string>): this;
+            ice_context(context: Map<string, string>): this;
 
             /**
              * Obtains the per-proxy context for this proxy.
@@ -220,10 +220,10 @@ declare module "ice" {
             /**
              * Obtains a proxy that is identical to this proxy, except for the encoding used to marshal
              * parameters.
-             * @param version The encoding version to use to marshal request parameters.
+             * @param encodingVersion The encoding version to use to marshal request parameters.
              * @return A proxy with the specified encoding version.
              */
-            ice_encodingVersion(encoding: EncodingVersion): this;
+            ice_encodingVersion(encodingVersion: EncodingVersion): this;
 
             /**
              * Determines whether this proxy uses only secure endpoints.
@@ -250,7 +250,7 @@ declare module "ice" {
             /**
              * Obtains a proxy that is identical to this proxy, except for its compression setting which
              * overrides the compression setting from the proxy endpoints.
-             * @param b True enables compression for the new proxy, false disables compression.
+             * @param compress True enables compression for the new proxy, false disables compression.
              * @return A proxy with the specified compression override setting.
              */
             ice_compress(compress: boolean): this;
@@ -330,7 +330,7 @@ declare module "ice" {
 
             /**
              * Obtains a proxy that is identical to this proxy, except for its connection ID.
-             * @param id The connection ID for the new proxy. An empty string removes the
+             * @param connectionId The connection ID for the new proxy. An empty string removes the
              * connection ID.
              * @return A proxy with the specified connection ID.
              */
@@ -348,7 +348,7 @@ declare module "ice" {
              * @param connection The fixed proxy connection.
              * @return A fixed proxy bound to the given connection.
              */
-            ice_fixed(conn: Connection): this;
+            ice_fixed(connection: Connection): this;
 
             /**
              * Returns whether this proxy is a fixed proxy.
@@ -398,7 +398,7 @@ declare module "ice" {
              * @param inParams An encapsulation containing the encoded in-parameters for the operation.
              * @return The asynchronous result object for the invocation .
              */
-            ice_invoke(operation: string, mode: OperationMode, inEncaps: Uint8Array): AsyncResult<[]>;
+            ice_invoke(operation: string, mode: OperationMode, inParams: Uint8Array): AsyncResult<[]>;
 
             /**
              * Compare two proxies for equality
@@ -422,7 +422,7 @@ declare module "ice" {
              * @return A proxy with the requested type and facet, or nil if the target proxy is nil or the target
              * object does not support the requested type.
              */
-            static checkedCast(prx: ObjectPrx, facet?: string, contex?: Map<string, string>): AsyncResult<ObjectPrx>;
+            static checkedCast(prx: ObjectPrx, facet?: string, context?: Map<string, string>): AsyncResult<ObjectPrx>;
         }
     }
 }

--- a/js/src/Ice/Promise.d.ts
+++ b/js/src/Ice/Promise.d.ts
@@ -2,18 +2,18 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-export class P<T> extends Promise<T> {
-    constructor(executor?: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason: any) => void) => void);
-    delay(ms: number): P<T>;
-    resolve<T>(value?: T | PromiseLike<T>): void;
-    reject<T>(reason: any): void;
-    static delay(ms: number): P<void>;
-    static delay<T>(ms: number, value: T): P<T>;
-    static try<T>(cb: () => T | PromiseLike<T>): P<T>;
-}
-
 declare module "ice" {
     namespace Ice {
-        export { P as Promise };
+        class Promise<T> extends globalThis.Promise<T> {
+            constructor(
+                executor?: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason: any) => void) => void,
+            );
+            delay(ms: number): Promise<T>;
+            resolve<T>(value?: T | PromiseLike<T>): void;
+            reject<T>(reason: any): void;
+            static delay(ms: number): Promise<void>;
+            static delay<T>(ms: number, value: T): Promise<T>;
+            static try<T>(cb: () => T | PromiseLike<T>): Promise<T>;
+        }
     }
 }

--- a/js/src/Ice/Protocol.d.ts
+++ b/js/src/Ice/Protocol.d.ts
@@ -122,7 +122,7 @@ declare module "ice" {
         /**
          * Converts a protocol version to a string.
          *
-         * @param v The protocol version to convert.
+         * @param version The protocol version to convert.
          *
          * @return The converted string.
          **/
@@ -131,7 +131,7 @@ declare module "ice" {
         /**
          * Converts an encoding version to a string.
          *
-         * @param v The encoding version to convert.
+         * @param version The encoding version to convert.
          *
          * @return The converted string.
          **/


### PR DESCRIPTION
This PR adds a `make doc` target to generate JavaScript API documentation using TypeDoc.

The documentation is generated from the `.d.ts` definitions and not from the .js doc comments. This is because the JavaScript code generates code at runtime that would be undocumented. (Ice.defineXxx methods).

The API is the same for JavaScript and TypeScript so this should work well for both JavaScript and TypeScript developers.

TypeDoc has some limitations in the supported features, for example, it doesn't automatically merge ambient modules in declaration files. I added a helper script that bundles the declarations so that TypeDoc can consume it when generating the docs.

After this PR is merged would be good to set up CI to deploy the docs, and easily review them.