### PR TITLE
Refactor Python local exceptions

### DIFF
--- a/python/modules/IcePy/Util.cpp
+++ b/python/modules/IcePy/Util.cpp
@@ -716,7 +716,7 @@ namespace
 }
 
 PyObject*
-IcePy::convertException(std::exception_ptr ex)
+IcePy::convertException(std::exception_ptr exPtr)
 {
     const char* const localExceptionTypeId = "::Ice::LocalException";
 
@@ -724,7 +724,7 @@ IcePy::convertException(std::exception_ptr ex)
     // exception, we do our best to _return_ an appropriate Python exception.
     try
     {
-        rethrow_exception(ex);
+        rethrow_exception(exPtr);
     }
     // First handle exceptions with extra fields we want to provide to Python users.
     catch (const Ice::RequestFailedException& ex)

--- a/python/modules/IcePy/Util.cpp
+++ b/python/modules/IcePy/Util.cpp
@@ -685,7 +685,10 @@ IcePy::createExceptionInstance(PyObject* type)
 namespace
 {
     template<size_t N>
-    PyObject* createPythonException(const char* typeId, std::array<IcePy::PyObjectHandle, N> args, bool fallbackToLocalException = false)
+    PyObject* createPythonException(
+        const char* typeId,
+        std::array<IcePy::PyObjectHandle, N> args,
+        bool fallbackToLocalException = false)
     {
         PyObject* type = IcePy::lookupType(scopedToName(typeId));
         if (!type)

--- a/python/python/Ice/LocalException.py
+++ b/python/python/Ice/LocalException.py
@@ -6,8 +6,5 @@
 class LocalException(Exception):
     """The base class for all Ice run-time exceptions."""
 
-    def __init__(self, args=""):
-        self.args = args
-
     __module__ = "Ice"
     __class__ = "LocalException"

--- a/python/python/Ice/LocalExceptions.py
+++ b/python/python/Ice/LocalExceptions.py
@@ -3,24 +3,214 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-import Ice
 from .LocalException import LocalException
 
-class InitializationException(LocalException):
+class RequestFailedException(LocalException):
     """
-        This exception is raised when a failure occurs during initialization.
+        This exception is raised if a request failed. This exception, and all exceptions derived from
+        RequestFailedException, are transmitted by the Ice protocol, even though they are declared
+        local.
     Members:
-    reason --  The reason for the failure.
+    id --  The identity of the Ice Object to which the request was sent.
+    facet --  The facet to which the request was sent.
+    operation --  The operation name of the request.
     """
 
-    def __init__(self, reason=""):
-        self.reason = reason
-
-    def __str__(self):
-        return "::Ice::InitializationException"
+    def __init__(self, id=None, facet= "", operation="", msg=""):
+        LocalException.__init__(self, msg)
+        self.id = id
+        self.facet = facet
+        self.operation = operation
 
     __module__ = "Ice"
-    __class__ = "InitializationException"
+
+class ObjectNotExistException(RequestFailedException):
+    """
+    This exception is raised if an object does not exist on the server, that is, if no facets with the given identity
+    exist.
+    """
+
+    __module__ = "Ice"
+
+
+class FacetNotExistException(RequestFailedException):
+    """
+    This exception is raised if no facet with the given name exists, but at least one facet with the given identity
+    exists.
+    """
+
+    __module__ = "Ice"
+
+
+class OperationNotExistException(RequestFailedException):
+    """
+    This exception is raised if an operation for a given object does not exist on the server. Typically this is caused
+    by either the client or the server using an outdated Slice specification.
+    """
+
+    __module__ = "Ice"
+
+class UnknownException(LocalException):
+    """
+        This exception is raised if an operation call on a server raises an unknown exception. For example, for C++, this
+        exception is raised if the server throws a C++ exception that is not directly or indirectly derived from
+        Ice::LocalException or Ice::UserException.
+    """
+
+    __module__ = "Ice"
+
+
+class UnknownLocalException(UnknownException):
+    """
+    This exception is raised if an operation call on a server raises a  local exception. Because local exceptions are
+    not transmitted by the Ice protocol, the client receives all local exceptions raised by the server as
+    UnknownLocalException. The only exception to this rule are all exceptions derived from
+    RequestFailedException, which are transmitted by the Ice protocol even though they are declared
+    local.
+    """
+
+    __module__ = "Ice"
+
+
+class UnknownUserException(UnknownException):
+    """
+    An operation raised an incorrect user exception. This exception is raised if an operation raises a user exception
+    that is not declared in the exception's throws clause. Such undeclared exceptions are not transmitted
+    from the server to the client by the Ice protocol, but instead the client just gets an UnknownUserException.
+    This is necessary in order to not violate the contract established by an operation's signature: Only local
+    exceptions and user exceptions declared in the throws clause can be raised.
+    """
+
+    __module__ = "Ice"
+
+
+class ProtocolException(LocalException):
+    """
+        A generic exception base for all kinds of protocol error conditions.
+    """
+
+    __module__ = "Ice"
+
+
+class CloseConnectionException(ProtocolException):
+    """
+    This exception indicates that the connection has been gracefully shut down by the server. The operation call that
+    caused this exception has not been executed by the server. In most cases you will not get this exception, because
+    the client will automatically retry the operation call in case the server shut down the connection. However, if
+    upon retry the server shuts down the connection again, and the retry limit has been reached, then this exception is
+    propagated to the application code.
+    """
+
+    __module__ = "Ice"
+
+
+class ConnectionManuallyClosedException(LocalException):
+    """
+        This exception is raised by an operation call if the application closes the connection locally using
+        Connection#close.
+    """
+
+    __module__ = "Ice"
+
+
+class DatagramLimitException(ProtocolException):
+    """
+    A datagram exceeds the configured size. This exception is raised if a datagram exceeds the configured send or
+    receive buffer size, or exceeds the maximum payload size of a UDP packet (65507 bytes).
+    """
+
+    __module__ = "Ice"
+
+
+class MarshalException(ProtocolException):
+    """
+    This exception is raised for errors during marshaling or unmarshaling data.
+    """
+
+    __module__ = "Ice"
+
+
+class TimeoutException(LocalException):
+    """
+    This exception indicates a timeout condition.
+    """
+
+    __module__ = "Ice"
+
+
+class ConnectTimeoutException(TimeoutException):
+    """
+    This exception indicates a connection establishment timeout condition.
+    """
+
+    __module__ = "Ice"
+
+
+class CloseTimeoutException(TimeoutException):
+    """
+    This exception indicates a connection closure timeout condition.
+    """
+
+    __module__ = "Ice"
+
+
+class InvocationTimeoutException(TimeoutException):
+    """
+    This exception indicates that an invocation failed because it timed out.
+    """
+
+    __module__ = "Ice"
+
+
+class SyscallException(LocalException):
+    """
+        This exception is raised if a system error occurred in the server or client process. There are many possible causes
+        for such a system exception.
+    """
+
+    __module__ = "Ice"
+
+
+class DNSException(SyscallException):
+    """
+        This exception indicates a DNS problem.
+    """
+
+    __module__ = "Ice"
+
+
+class SocketException(SyscallException):
+    """
+    This exception indicates socket errors.
+    """
+
+    __module__ = "Ice"
+    __class__ = "SocketException"
+
+
+class ConnectFailedException(SocketException):
+    """
+    This exception indicates connection failures.
+    """
+
+    __module__ = "Ice"
+    __class__ = "ConnectFailedException"
+
+
+class ConnectionLostException(SocketException):
+    """
+    This exception indicates a lost connection.
+    """
+
+    __module__ = "Ice"
+
+
+class ConnectionRefusedException(ConnectFailedException):
+    """
+    This exception indicates a connection failure for which the server host actively refuses a connection.
+    """
+
+    __module__ = "Ice"
 
 
 class AlreadyRegisteredException(LocalException):
@@ -34,15 +224,70 @@ class AlreadyRegisteredException(LocalException):
     id --  The ID (or name) of the object that is registered already.
     """
 
-    def __init__(self, kindOfObject="", id=""):
+    def __init__(self, kindOfObject, id, msg):
+        LocalException.__init__(self, msg)
         self.kindOfObject = kindOfObject
         self.id = id
 
-    def __str__(self):
-        return "::Ice::AlreadyRegisteredException"
+    __module__ = "Ice"
+
+
+class CommunicatorDestroyedException(LocalException):
+    """
+    This exception is raised if the Communicator has been destroyed.
+    """
 
     __module__ = "Ice"
-    __class__ = "AlreadyRegisteredException"
+
+
+class ConnectionIdleException(LocalException):
+    """
+    This exception indicates that a connection was aborted by the idle check.
+    """
+
+    __module__ = "Ice"
+
+
+class FeatureNotSupportedException(LocalException):
+    """
+        This exception is raised if an unsupported feature is used.
+    """
+
+    __module__ = "Ice"
+
+
+class FixedProxyException(LocalException):
+    """
+    This exception indicates that an attempt has been made to change the connection properties of a fixed proxy.
+    """
+
+    __module__ = "Ice"
+
+
+class InitializationException(LocalException):
+    """
+        This exception is raised when a failure occurs during initialization.
+    Members:
+    reason --  The reason for the failure.
+    """
+
+    __module__ = "Ice"
+
+
+class InvocationCanceledException(LocalException):
+    """
+    This exception indicates that an asynchronous invocation failed because it was canceled explicitly by the user.
+    """
+
+    __module__ = "Ice"
+
+
+class NoEndpointException(LocalException):
+    """
+        This exception is raised if no suitable endpoint is available.
+    """
+
+    __module__ = "Ice"
 
 
 class NotRegisteredException(LocalException):
@@ -58,15 +303,51 @@ class NotRegisteredException(LocalException):
     id --  The ID (or name) of the object that could not be removed.
     """
 
-    def __init__(self, kindOfObject="", id=""):
+    def __init__(self, kindOfObject, id, msg):
+        LocalException.__init__(self, msg)
         self.kindOfObject = kindOfObject
         self.id = id
 
-    def __str__(self):
-        return "::Ice::NotRegisteredException"
+    __module__ = "Ice"
+
+
+class ObjectAdapterDeactivatedException(LocalException):
+    """
+        This exception is raised if an attempt is made to use a deactivated ObjectAdapter.
+    """
+
+    def __init__(self, msg):
+        LocalException.__init__(self, msg)
 
     __module__ = "Ice"
-    __class__ = "NotRegisteredException"
+
+
+class ObjectAdapterIdInUseException(LocalException):
+    """
+        This exception is raised if an ObjectAdapter cannot be activated. This happens if the Locator
+        detects another active ObjectAdapter with the same adapter id.
+    """
+
+    def __init__(self, msg):
+        LocalException.__init__(self, msg)
+
+    __module__ = "Ice"
+
+
+class ParseException(LocalException):
+    """
+        This exception is raised if there was an error while parsing a string.
+    """
+
+    __module__ = "Ice"
+
+
+class SecurityException(LocalException):
+    """
+        This exception indicates a failure in a security subsystem, such as the SSL transport.
+    """
+
+    __module__ = "Ice"
 
 
 class TwowayOnlyException(LocalException):
@@ -74,605 +355,6 @@ class TwowayOnlyException(LocalException):
         The operation can only be invoked with a twoway request. This exception is raised if an attempt is made to invoke
         an operation with ice_oneway, ice_batchOneway, ice_datagram, or
         ice_batchDatagram and the operation has a return value, out-parameters, or an exception specification.
-    Members:
-    operation --  The name of the operation that was invoked.
     """
-
-    def __init__(self, operation=""):
-        self.operation = operation
-
-    def __str__(self):
-            return "::Ice::TwowayOnlyException"
 
     __module__ = "Ice"
-    __class__ = "TwowayOnlyException"
-
-
-class UnknownException(LocalException):
-    """
-        This exception is raised if an operation call on a server raises an unknown exception. For example, for C++, this
-        exception is raised if the server throws a C++ exception that is not directly or indirectly derived from
-        Ice::LocalException or Ice::UserException.
-    Members:
-    unknown --  This field is set to the textual representation of the unknown exception if available.
-    """
-
-    def __init__(self, unknown=""):
-        self.unknown = unknown
-
-    def __str__(self):
-        return "::Ice::UnknownException"
-
-    __module__ = "Ice"
-    __class__ = "UnknownException"
-
-
-class UnknownLocalException(UnknownException):
-    """
-    This exception is raised if an operation call on a server raises a  local exception. Because local exceptions are
-    not transmitted by the Ice protocol, the client receives all local exceptions raised by the server as
-    UnknownLocalException. The only exception to this rule are all exceptions derived from
-    RequestFailedException, which are transmitted by the Ice protocol even though they are declared
-    local.
-    """
-
-    def __init__(self, unknown=""):
-        UnknownException.__init__(self, unknown)
-
-    def __str__(self):
-        return "::Ice::UnknownLocalException"
-
-    __module__ = "Ice"
-    __class__ = "UnknownLocalException"
-
-
-class UnknownUserException(UnknownException):
-    """
-    An operation raised an incorrect user exception. This exception is raised if an operation raises a user exception
-    that is not declared in the exception's throws clause. Such undeclared exceptions are not transmitted
-    from the server to the client by the Ice protocol, but instead the client just gets an UnknownUserException.
-    This is necessary in order to not violate the contract established by an operation's signature: Only local
-    exceptions and user exceptions declared in the throws clause can be raised.
-    """
-
-    def __init__(self, unknown=""):
-        UnknownException.__init__(self, unknown)
-
-    def __str__(self):
-        return "::Ice::UnknownUserException"
-
-    __module__ = "Ice"
-    __class__ = "UnknownUserException"
-
-
-class CommunicatorDestroyedException(LocalException):
-    """
-    This exception is raised if the Communicator has been destroyed.
-    """
-
-    def __init__(self):
-        pass
-
-    def __str__(self):
-        return "::Ice::CommunicatorDestroyedException"
-
-    __module__ = "Ice"
-    __class__ = "CommunicatorDestroyedException"
-
-
-class ObjectAdapterDeactivatedException(LocalException):
-    """
-        This exception is raised if an attempt is made to use a deactivated ObjectAdapter.
-    Members:
-    name --  Name of the adapter.
-    """
-
-    def __init__(self, name=""):
-        self.name = name
-
-    def __str__(self):
-        return "::Ice::ObjectAdapterDeactivatedException"
-
-    __module__ = "Ice"
-    __class__ = "ObjectAdapterDeactivatedException"
-
-
-class ObjectAdapterIdInUseException(LocalException):
-    """
-        This exception is raised if an ObjectAdapter cannot be activated. This happens if the Locator
-        detects another active ObjectAdapter with the same adapter id.
-    Members:
-    id --  Adapter ID.
-    """
-
-    def __init__(self, id=""):
-        self.id = id
-
-    def __str__(self):
-        return "::Ice::ObjectAdapterIdInUseException"
-
-    __module__ = "Ice"
-    __class__ = "ObjectAdapterIdInUseException"
-
-
-class NoEndpointException(LocalException):
-    """
-        This exception is raised if no suitable endpoint is available.
-    Members:
-    proxy --  The stringified proxy for which no suitable endpoint is available.
-    """
-
-    def __init__(self, proxy=""):
-        self.proxy = proxy
-
-    def __str__(self):
-        return "::Ice::NoEndpointException"
-
-    __module__ = "Ice"
-    __class__ = "NoEndpointException"
-
-
-class ParseException(LocalException):
-    """
-        This exception is raised if there was an error while parsing a string.
-    Members:
-    str --  Describes the failure and includes the string that could not be parsed.
-    """
-
-    def __init__(self, str=""):
-        self.str = str
-
-    def __str__(self):
-        return "::Ice::ParseException"
-
-    __module__ = "Ice"
-    __class__ = "ParseException"
-
-
-class IllegalIdentityException(LocalException):
-    """
-        This exception is raised if an identity with an empty name is encountered.
-    """
-
-    def __init__(self):
-        pass
-
-    def __str__(self):
-        return "::Ice::IllegalIdentityException"
-
-    __module__ = "Ice"
-    __class__ = "IllegalIdentityException"
-
-
-class IllegalServantException(LocalException):
-    """
-        This exception is raised to reject an illegal servant (typically a null servant).
-    Members:
-    reason --  Describes why this servant is illegal.
-    """
-
-    def __init__(self, reason=""):
-        self.reason = reason
-
-    def __str__(self):
-        return "::Ice::IllegalServantException"
-
-    __module__ = "Ice"
-    __class__ = "IllegalServantException"
-
-
-class RequestFailedException(LocalException):
-    """
-        This exception is raised if a request failed. This exception, and all exceptions derived from
-        RequestFailedException, are transmitted by the Ice protocol, even though they are declared
-        local.
-    Members:
-    id --  The identity of the Ice Object to which the request was sent.
-    facet --  The facet to which the request was sent.
-    operation --  The operation name of the request.
-    """
-
-    def __init__(self, id=None, facet="", operation=""):
-        if id is None:
-            self.id = Ice.Identity()
-        else:
-            self.id = id
-        self.facet = facet
-        self.operation = operation
-
-    def __str__(self):
-        return "::Ice::RequestFailedException"
-
-    __module__ = "Ice"
-    __class__ = "RequestFailedException"
-
-
-class ObjectNotExistException(RequestFailedException):
-    """
-    This exception is raised if an object does not exist on the server, that is, if no facets with the given identity
-    exist.
-    """
-
-    def __init__(self, id=None, facet="", operation=""):
-        RequestFailedException.__init__(self, id, facet, operation)
-
-    def __str__(self):
-        return "::Ice::ObjectNotExistException"
-
-    __module__ = "Ice"
-    __class__ = "ObjectNotExistException"
-
-
-class FacetNotExistException(RequestFailedException):
-    """
-    This exception is raised if no facet with the given name exists, but at least one facet with the given identity
-    exists.
-    """
-
-    def __init__(self, id=None, facet="", operation=""):
-        RequestFailedException.__init__(self, id, facet, operation)
-
-    def __str__(self):
-        return "::Ice::FacetNotExistException"
-
-    __module__ = "Ice"
-    __class__ = "FacetNotExistException"
-
-
-class OperationNotExistException(RequestFailedException):
-    """
-    This exception is raised if an operation for a given object does not exist on the server. Typically this is caused
-    by either the client or the server using an outdated Slice specification.
-    """
-
-    def __init__(self, id=None, facet="", operation=""):
-        RequestFailedException.__init__(self, id, facet, operation)
-
-    def __str__(self):
-        return "::Ice::OperationNotExistException"
-
-    __module__ = "Ice"
-    __class__ = "OperationNotExistException"
-
-
-class SyscallException(LocalException):
-    """
-        This exception is raised if a system error occurred in the server or client process. There are many possible causes
-        for such a system exception. For details on the cause, SyscallException#error should be inspected.
-    Members:
-    error --  The error number describing the system exception. For C++ and Unix, this is equivalent to errno.
-        For C++ and Windows, this is the value returned by GetLastError() or
-        WSAGetLastError().
-    """
-
-    def __init__(self, error=0):
-        self.error = error
-
-    def __str__(self):
-        return "::Ice::SyscallException"
-
-    __module__ = "Ice"
-    __class__ = "SyscallException"
-
-
-class SocketException(SyscallException):
-    """
-    This exception indicates socket errors.
-    """
-
-    def __init__(self, error=0):
-        SyscallException.__init__(self, error)
-
-    def __str__(self):
-        return "::Ice::SocketException"
-
-    __module__ = "Ice"
-    __class__ = "SocketException"
-
-
-class FileException(SyscallException):
-    """
-        This exception indicates file errors.
-    Members:
-    path --  The path of the file responsible for the error.
-    """
-
-    def __init__(self, error=0, path=""):
-        SyscallException.__init__(self, error)
-        self.path = path
-
-    def __str__(self):
-        return "::Ice::FileException"
-
-    __module__ = "Ice"
-    __class__ = "FileException"
-
-
-class ConnectFailedException(SocketException):
-    """
-    This exception indicates connection failures.
-    """
-
-    def __init__(self, error=0):
-        SocketException.__init__(self, error)
-
-    def __str__(self):
-        return "::Ice::ConnectFailedException"
-
-    __module__ = "Ice"
-    __class__ = "ConnectFailedException"
-
-
-class ConnectionRefusedException(ConnectFailedException):
-    """
-    This exception indicates a connection failure for which the server host actively refuses a connection.
-    """
-
-    def __init__(self, error=0):
-        ConnectFailedException.__init__(self, error)
-
-    def __str__(self):
-        return "::Ice::ConnectionRefusedException"
-
-    __module__ = "Ice"
-    __class__ = "ConnectionRefusedException"
-
-
-class ConnectionLostException(SocketException):
-    """
-    This exception indicates a lost connection.
-    """
-
-    def __init__(self, error=0):
-        SocketException.__init__(self, error)
-
-    def __str__(self):
-        return "::Ice::ConnectionLostException"
-
-    __module__ = "Ice"
-    __class__ = "ConnectionLostException"
-
-
-class DNSException(LocalException):
-    """
-        This exception indicates a DNS problem. For details on the cause, DNSException#error should be inspected.
-    Members:
-    error --  The error number describing the DNS problem. For C++ and Unix, this is equivalent to h_errno. For
-        C++ and Windows, this is the value returned by WSAGetLastError().
-    host --  The host name that could not be resolved.
-    """
-
-    def __init__(self, error=0, host=""):
-        self.error = error
-        self.host = host
-
-    def __str__(self):
-        return "::Ice::DNSException"
-
-    __module__ = "Ice"
-    __class__ = "DNSException"
-
-
-class ConnectionIdleException(LocalException):
-    """
-    This exception indicates that a connection was aborted by the idle check.
-    """
-
-    def __init__(self):
-        pass
-
-    def __str__(self):
-        return "::Ice::ConnectionIdleException"
-
-    __module__ = "Ice"
-    __class__ = "ConnectionIdleException"
-
-
-class TimeoutException(LocalException):
-    """
-    This exception indicates a timeout condition.
-    """
-
-    def __init__(self):
-        pass
-
-    def __str__(self):
-        return "::Ice::TimeoutException"
-
-    __module__ = "Ice"
-    __class__ = "TimeoutException"
-
-
-class ConnectTimeoutException(TimeoutException):
-    """
-    This exception indicates a connection establishment timeout condition.
-    """
-
-    def __init__(self):
-        TimeoutException.__init__(self)
-
-    def __str__(self):
-        return "::Ice::ConnectTimeoutException"
-
-    __module__ = "Ice"
-    __class__ = "ConnectTimeoutException"
-
-
-class CloseTimeoutException(TimeoutException):
-    """
-    This exception indicates a connection closure timeout condition.
-    """
-
-    def __init__(self):
-        TimeoutException.__init__(self)
-
-    def __str__(self):
-        return "::Ice::CloseTimeoutException"
-
-    __module__ = "Ice"
-    __class__ = "CloseTimeoutException"
-
-
-class InvocationTimeoutException(TimeoutException):
-    """
-    This exception indicates that an invocation failed because it timed out.
-    """
-
-    def __init__(self):
-        TimeoutException.__init__(self)
-
-    def __str__(self):
-        return "::Ice::InvocationTimeoutException"
-
-    __module__ = "Ice"
-    __class__ = "InvocationTimeoutException"
-
-
-class InvocationCanceledException(LocalException):
-    """
-    This exception indicates that an asynchronous invocation failed because it was canceled explicitly by the user.
-    """
-
-    def __init__(self):
-        pass
-
-    def __str__(self):
-        return "::Ice::InvocationCanceledException"
-
-    __module__ = "Ice"
-    __class__ = "InvocationCanceledException"
-
-
-class ProtocolException(LocalException):
-    """
-        A generic exception base for all kinds of protocol error conditions.
-    Members:
-    reason --  The reason for the failure.
-    """
-
-    def __init__(self, reason=""):
-        self.reason = reason
-
-    def __str__(self):
-        return "::Ice::ProtocolException"
-
-    __module__ = "Ice"
-    __class__ = "ProtocolException"
-
-
-class CloseConnectionException(ProtocolException):
-    """
-    This exception indicates that the connection has been gracefully shut down by the server. The operation call that
-    caused this exception has not been executed by the server. In most cases you will not get this exception, because
-    the client will automatically retry the operation call in case the server shut down the connection. However, if
-    upon retry the server shuts down the connection again, and the retry limit has been reached, then this exception is
-    propagated to the application code.
-    """
-
-    def __init__(self, reason=""):
-        ProtocolException.__init__(self, reason)
-
-    def __str__(self):
-        return "::Ice::CloseConnectionException"
-
-    __module__ = "Ice"
-    __class__ = "CloseConnectionException"
-
-
-class ConnectionManuallyClosedException(LocalException):
-    """
-        This exception is raised by an operation call if the application closes the connection locally using
-        Connection#close.
-    Members:
-    graceful --  True if the connection was closed gracefully, false otherwise.
-    """
-
-    def __init__(self, graceful=False):
-        self.graceful = graceful
-
-    def __str__(self):
-        return "::Ice::ConnectionManuallyClosedException"
-
-    __module__ = "Ice"
-    __class__ = "ConnectionManuallyClosedException"
-
-
-class DatagramLimitException(ProtocolException):
-    """
-    A datagram exceeds the configured size. This exception is raised if a datagram exceeds the configured send or
-    receive buffer size, or exceeds the maximum payload size of a UDP packet (65507 bytes).
-    """
-
-    def __init__(self, reason=""):
-        ProtocolException.__init__(self, reason)
-
-    def __str__(self):
-        return "::Ice::DatagramLimitException"
-
-    __module__ = "Ice"
-    __class__ = "DatagramLimitException"
-
-
-class MarshalException(ProtocolException):
-    """
-    This exception is raised for errors during marshaling or unmarshaling data.
-    """
-
-    def __init__(self, reason=""):
-        ProtocolException.__init__(self, reason)
-
-    def __str__(self):
-        return "::Ice::MarshalException"
-
-    __module__ = "Ice"
-    __class__ = "MarshalException"
-
-
-class FeatureNotSupportedException(LocalException):
-    """
-        This exception is raised if an unsupported feature is used. The unsupported feature string contains the name of the
-        unsupported feature.
-    Members:
-    unsupportedFeature --  The name of the unsupported feature.
-    """
-
-    def __init__(self, unsupportedFeature=""):
-        self.unsupportedFeature = unsupportedFeature
-
-    def __str__(self):
-        return "::Ice::FeatureNotSupportedException"
-
-    __module__ = "Ice"
-    __class__ = "FeatureNotSupportedException"
-
-
-class SecurityException(LocalException):
-    """
-        This exception indicates a failure in a security subsystem, such as the IceSSL plug-in.
-    Members:
-    reason --  The reason for the failure.
-    """
-
-    def __init__(self, reason=""):
-        self.reason = reason
-
-    def __str__(self):
-        return "::Ice::SecurityException"
-
-    __module__ = "Ice"
-    __class__ = "SecurityException"
-
-
-class FixedProxyException(LocalException):
-    """
-    This exception indicates that an attempt has been made to change the connection properties of a fixed proxy.
-    """
-
-    def __init__(self):
-        pass
-
-    def __str__(self):
-        return "::Ice::FixedProxyException"
-
-    __module__ = "Ice"
-    __class__ = "FixedProxyException"

--- a/python/python/Ice/LocalExceptions.py
+++ b/python/python/Ice/LocalExceptions.py
@@ -5,11 +5,20 @@
 
 from .LocalException import LocalException
 
+from typing import final
+
+__name__ = "Ice"
+
+#
+# The 6 (7 with the RequestFailedException base class) special local exceptions that can be marshaled in an Ice
+# reply message. Other local exceptions can't be marshaled.
+#
+
 class RequestFailedException(LocalException):
     """
-        This exception is raised if a request failed. This exception, and all exceptions derived from
-        RequestFailedException, are transmitted by the Ice protocol, even though they are declared
-        local.
+    This exception is raised if a request failed. This exception, and all exceptions derived from
+    RequestFailedException, are transmitted by the Ice protocol, even though they are declared
+    local.
     Members:
     id --  The identity of the Ice Object to which the request was sent.
     facet --  The facet to which the request was sent.
@@ -18,37 +27,42 @@ class RequestFailedException(LocalException):
 
     def __init__(self, id=None, facet= "", operation="", msg=""):
         LocalException.__init__(self, msg)
-        self.id = id
-        self.facet = facet
-        self.operation = operation
+        self.__id = id
+        self.__facet = facet
+        self.__operation = operation
 
-    __module__ = "Ice"
+    @property
+    def id(self):
+        return self.__id
 
+    @property
+    def facet(self):
+        return self.__facet
+
+    @property
+    def operation(self):
+        return self.__operation
+
+@final
 class ObjectNotExistException(RequestFailedException):
     """
     This exception is raised if an object does not exist on the server, that is, if no facets with the given identity
     exist.
     """
 
-    __module__ = "Ice"
-
-
+@final
 class FacetNotExistException(RequestFailedException):
     """
     This exception is raised if no facet with the given name exists, but at least one facet with the given identity
     exists.
     """
 
-    __module__ = "Ice"
-
-
+@final
 class OperationNotExistException(RequestFailedException):
     """
     This exception is raised if an operation for a given object does not exist on the server. Typically this is caused
     by either the client or the server using an outdated Slice specification.
     """
-
-    __module__ = "Ice"
 
 class UnknownException(LocalException):
     """
@@ -57,9 +71,7 @@ class UnknownException(LocalException):
         Ice::LocalException or Ice::UserException.
     """
 
-    __module__ = "Ice"
-
-
+@final
 class UnknownLocalException(UnknownException):
     """
     This exception is raised if an operation call on a server raises a  local exception. Because local exceptions are
@@ -69,9 +81,7 @@ class UnknownLocalException(UnknownException):
     local.
     """
 
-    __module__ = "Ice"
-
-
+@final
 class UnknownUserException(UnknownException):
     """
     An operation raised an incorrect user exception. This exception is raised if an operation raises a user exception
@@ -81,17 +91,16 @@ class UnknownUserException(UnknownException):
     exceptions and user exceptions declared in the throws clause can be raised.
     """
 
-    __module__ = "Ice"
-
+#
+# Protocol exceptions
+#
 
 class ProtocolException(LocalException):
     """
-        A generic exception base for all kinds of protocol error conditions.
+    A generic exception base for all kinds of protocol error conditions.
     """
 
-    __module__ = "Ice"
-
-
+@final
 class CloseConnectionException(ProtocolException):
     """
     This exception indicates that the connection has been gracefully shut down by the server. The operation call that
@@ -101,118 +110,93 @@ class CloseConnectionException(ProtocolException):
     propagated to the application code.
     """
 
-    __module__ = "Ice"
-
-
-class ConnectionManuallyClosedException(LocalException):
-    """
-        This exception is raised by an operation call if the application closes the connection locally using
-        Connection#close.
-    """
-
-    __module__ = "Ice"
-
-
+@final
 class DatagramLimitException(ProtocolException):
     """
     A datagram exceeds the configured size. This exception is raised if a datagram exceeds the configured send or
     receive buffer size, or exceeds the maximum payload size of a UDP packet (65507 bytes).
     """
 
-    __module__ = "Ice"
-
-
+@final
 class MarshalException(ProtocolException):
     """
     This exception is raised for errors during marshaling or unmarshaling data.
     """
 
-    __module__ = "Ice"
-
+#
+# Timeout exceptions
+#
 
 class TimeoutException(LocalException):
     """
     This exception indicates a timeout condition.
     """
 
-    __module__ = "Ice"
-
-
+@final
 class ConnectTimeoutException(TimeoutException):
     """
     This exception indicates a connection establishment timeout condition.
     """
 
-    __module__ = "Ice"
-
-
+@final
 class CloseTimeoutException(TimeoutException):
     """
     This exception indicates a connection closure timeout condition.
     """
 
-    __module__ = "Ice"
-
-
+@final
 class InvocationTimeoutException(TimeoutException):
     """
     This exception indicates that an invocation failed because it timed out.
     """
 
-    __module__ = "Ice"
-
+#
+# Syscall exceptions
+#
 
 class SyscallException(LocalException):
     """
-        This exception is raised if a system error occurred in the server or client process. There are many possible causes
-        for such a system exception.
+    This exception is raised if a system error occurred in the server or client process. There are many possible causes
+    for such a system exception.
     """
 
-    __module__ = "Ice"
-
-
+@final
 class DNSException(SyscallException):
     """
-        This exception indicates a DNS problem.
+    This exception indicates a DNS problem.
     """
 
-    __module__ = "Ice"
-
+#
+# Socket exceptions
+#
 
 class SocketException(SyscallException):
     """
     This exception indicates socket errors.
     """
 
-    __module__ = "Ice"
-    __class__ = "SocketException"
-
-
 class ConnectFailedException(SocketException):
     """
     This exception indicates connection failures.
     """
 
-    __module__ = "Ice"
-    __class__ = "ConnectFailedException"
-
-
+@final
 class ConnectionLostException(SocketException):
     """
     This exception indicates a lost connection.
     """
 
-    __module__ = "Ice"
-
-
+@final
 class ConnectionRefusedException(ConnectFailedException):
     """
     This exception indicates a connection failure for which the server host actively refuses a connection.
     """
 
-    __module__ = "Ice"
+#
+# Other leaf local exceptions in alphabetical order.
+#
 
-
+@final
 class AlreadyRegisteredException(LocalException):
     """
         An attempt was made to register something more than once with the Ice run time. This exception is raised if an
@@ -226,44 +210,49 @@ class AlreadyRegisteredException(LocalException):
 
     def __init__(self, kindOfObject, id, msg):
         LocalException.__init__(self, msg)
-        self.kindOfObject = kindOfObject
-        self.id = id
+        self.__kindOfObject = kindOfObject
+        self.__id = id
 
-    __module__ = "Ice"
+    @property
+    def kindOfObject(self):
+        return self.__kindOfObject
 
+    @property
+    def id(self):
+        return self.__id
 
+@final
 class CommunicatorDestroyedException(LocalException):
     """
     This exception is raised if the Communicator has been destroyed.
     """
 
-    __module__ = "Ice"
-
-
+@final
 class ConnectionIdleException(LocalException):
     """
     This exception indicates that a connection was aborted by the idle check.
     """
 
-    __module__ = "Ice"
+@final
+class ConnectionManuallyClosedException(LocalException):
+    """
+    This exception is raised by an operation call if the application closes the connection locally using
+    Connection#close.
+    """
 
-
+@final
 class FeatureNotSupportedException(LocalException):
     """
         This exception is raised if an unsupported feature is used.
     """
 
-    __module__ = "Ice"
-
-
+@final
 class FixedProxyException(LocalException):
     """
     This exception indicates that an attempt has been made to change the connection properties of a fixed proxy.
     """
 
-    __module__ = "Ice"
-
-
+@final
 class InitializationException(LocalException):
     """
         This exception is raised when a failure occurs during initialization.
@@ -271,25 +260,18 @@ class InitializationException(LocalException):
     reason --  The reason for the failure.
     """
 
-    __module__ = "Ice"
-
-
 class InvocationCanceledException(LocalException):
     """
     This exception indicates that an asynchronous invocation failed because it was canceled explicitly by the user.
     """
 
-    __module__ = "Ice"
-
-
+@final
 class NoEndpointException(LocalException):
     """
-        This exception is raised if no suitable endpoint is available.
+    This exception is raised if no suitable endpoint is available.
     """
 
-    __module__ = "Ice"
-
-
+@final
 class NotRegisteredException(LocalException):
     """
         An attempt was made to find or deregister something that is not registered with the Ice run time or Ice locator.
@@ -305,56 +287,46 @@ class NotRegisteredException(LocalException):
 
     def __init__(self, kindOfObject, id, msg):
         LocalException.__init__(self, msg)
-        self.kindOfObject = kindOfObject
-        self.id = id
+        self.__kindOfObject = kindOfObject
+        self.__id = id
 
-    __module__ = "Ice"
+    @property
+    def kindOfObject(self):
+        return self.__kindOfObject
 
+    @property
+    def id(self):
+        return self.__id
 
+@final
 class ObjectAdapterDeactivatedException(LocalException):
     """
         This exception is raised if an attempt is made to use a deactivated ObjectAdapter.
     """
 
-    def __init__(self, msg):
-        LocalException.__init__(self, msg)
-
-    __module__ = "Ice"
-
-
+@final
 class ObjectAdapterIdInUseException(LocalException):
     """
         This exception is raised if an ObjectAdapter cannot be activated. This happens if the Locator
         detects another active ObjectAdapter with the same adapter id.
     """
 
-    def __init__(self, msg):
-        LocalException.__init__(self, msg)
-
-    __module__ = "Ice"
-
-
+@final
 class ParseException(LocalException):
     """
         This exception is raised if there was an error while parsing a string.
     """
 
-    __module__ = "Ice"
-
-
+@final
 class SecurityException(LocalException):
     """
         This exception indicates a failure in a security subsystem, such as the SSL transport.
     """
 
-    __module__ = "Ice"
-
-
+@final
 class TwowayOnlyException(LocalException):
     """
         The operation can only be invoked with a twoway request. This exception is raised if an attempt is made to invoke
         an operation with ice_oneway, ice_batchOneway, ice_datagram, or
         ice_batchDatagram and the operation has a return value, out-parameters, or an exception specification.
     """
-
-    __module__ = "Ice"

--- a/python/python/Ice/LocalExceptions.py
+++ b/python/python/Ice/LocalExceptions.py
@@ -66,9 +66,9 @@ class OperationNotExistException(RequestFailedException):
 
 class UnknownException(LocalException):
     """
-        This exception is raised if an operation call on a server raises an unknown exception. For example, for C++, this
-        exception is raised if the server throws a C++ exception that is not directly or indirectly derived from
-        Ice::LocalException or Ice::UserException.
+    This exception is raised if an operation call on a server raises an unknown exception. For example, for C++, this
+    exception is raised if the server throws a C++ exception that is not directly or indirectly derived from
+    Ice::LocalException or Ice::UserException.
     """
 
 @final

--- a/python/test/Ice/ami/AllTests.py
+++ b/python/test/Ice/ami/AllTests.py
@@ -441,8 +441,8 @@ def allTests(helper, communicator, collocated):
         try:
             f.result()
             test(False)
-        except Ice.ConnectionManuallyClosedException as ex:
-            test(ex.graceful)
+        except Ice.ConnectionManuallyClosedException:
+            pass
         p.finishDispatch()
 
         #
@@ -477,8 +477,8 @@ def allTests(helper, communicator, collocated):
         try:
             f.result()
             test(False)
-        except Ice.ConnectionManuallyClosedException as ex:
-            test(not ex.graceful)
+        except Ice.ConnectionManuallyClosedException:
+            pass
         p.finishDispatch()
 
         #

--- a/python/test/Ice/blobject/Client.py
+++ b/python/test/Ice/blobject/Client.py
@@ -48,7 +48,7 @@ class Client(TestHelper):
             )
             test(False)
         except Ice.UnknownLocalException as e:
-            test(e.unknown.find("ConnectionRefusedException"))
+            test(str(e).find("ConnectionRefusedException"))
             if sync:
                 hello.shutdown()
 

--- a/python/test/Ice/exceptions/AllTests.py
+++ b/python/test/Ice/exceptions/AllTests.py
@@ -234,13 +234,13 @@ def allTests(helper, communicator):
     try:
         adapter.add(obj, Ice.Identity("", ""))
         test(False)
-    except Ice.IllegalIdentityException:
+    except Ice.LocalException:
         pass
 
     try:
         adapter.add(None, Ice.stringToIdentity("x"))
         test(False)
-    except Ice.IllegalServantException:
+    except Ice.LocalException:
         pass
 
     adapter.remove(Ice.stringToIdentity("x"))
@@ -838,15 +838,15 @@ def allTests(helper, communicator):
         try:
             thrower.throwMarshalException(context={"response": ""})
         except Ice.UnknownLocalException as ex:
-            test("::Ice::UnknownLocalException" in str(ex))
+            test("cannot marshal result" in str(ex))
         try:
             thrower.throwMarshalException(context={"param": ""})
         except Ice.UnknownLocalException as ex:
-            test("::Ice::UnknownLocalException" in str(ex))
+            test("cannot marshal result" in str(ex))
         try:
             thrower.throwMarshalException()
         except Ice.UnknownLocalException as ex:
-            test("::Ice::UnknownLocalException" in str(ex))
+            test("cannot marshal result" in str(ex))
     except Ice.OperationNotExistException:
         pass
     print("ok")

--- a/python/test/Ice/objects/AllTests.py
+++ b/python/test/Ice/objects/AllTests.py
@@ -266,8 +266,8 @@ def allTests(helper, communicator):
             uoet.op()
             test(False)
         except Ice.MarshalException as ex:
-            test("::Test::AlsoEmpty" in ex.reason)
-            test("::Test::Empty" in ex.reason)
+            test("::Test::AlsoEmpty" in str(ex))
+            test("::Test::Empty" in str(ex))
         except Ice.Exception as ex:
             print(ex)
             test(False)

--- a/python/test/Ice/properties/Client.py
+++ b/python/test/Ice/properties/Client.py
@@ -98,6 +98,16 @@ class Client(TestHelper):
 
         print("ok")
 
+        sys.stdout.write("testing load properties exception... ")
+        sys.stdout.flush()
+        try:
+            properties = Ice.createProperties()
+            properties.load("./config/xxx_client.config")
+            test(False)
+        except Ice.LocalException as ex:
+            test(str(ex) == "::Ice::FileException") # temporary C++ what() message
+        print("ok")
+
         sys.stdout.write(
             "testing that getting an unknown ice property throws an exception..."
         )

--- a/python/test/Ice/properties/Client.py
+++ b/python/test/Ice/properties/Client.py
@@ -106,7 +106,7 @@ class Client(TestHelper):
             properties = Ice.createProperties()
             properties.getIceProperty("Ice.UnknownProperty")
             test(False)
-        except Ice.UnknownException:
+        except Ice.LocalException:
             # We dont' have a specific exception for unknown properties
             pass
         print("ok")

--- a/python/test/Ice/servantLocator/AllTests.py
+++ b/python/test/Ice/servantLocator/AllTests.py
@@ -27,7 +27,7 @@ def testExceptions(obj):
         obj.unknownUserException()
         test(False)
     except Ice.UnknownUserException as ex:
-        test(ex.unknown == "reason")
+        test("reason" == str(ex))
     except Exception:
         test(False)
 
@@ -35,7 +35,7 @@ def testExceptions(obj):
         obj.unknownLocalException()
         test(False)
     except Ice.UnknownLocalException as ex:
-        test(ex.unknown == "reason")
+        test("reason" == str(ex))
     except Exception:
         test(False)
 
@@ -43,14 +43,14 @@ def testExceptions(obj):
         obj.unknownException()
         test(False)
     except Ice.UnknownException as ex:
-        test(ex.unknown == "reason")
+        test("reason" == str(ex))
         pass
 
     try:
         obj.userException()
         test(False)
     except Ice.UnknownUserException as ex:
-        test(ex.unknown.find("::Test::TestIntfUserException") >= 0)
+        test("::Test::TestIntfUserException" in str(ex))
     except Ice.OperationNotExistException:
         pass
     except AttributeError:
@@ -63,8 +63,8 @@ def testExceptions(obj):
         test(False)
     except Ice.UnknownLocalException as ex:
         test(
-            ex.unknown.find("Ice.SocketException") >= 0
-            or ex.unknown.find("Ice::SocketException") >= 0
+            "Ice.SocketException" in str(ex)
+            or "Ice::SocketException" in str(ex)
         )
     except Exception:
         test(False)
@@ -73,7 +73,7 @@ def testExceptions(obj):
         obj.pythonException()
         test(False)
     except Ice.UnknownException as ex:
-        test(ex.unknown.find("RuntimeError: message") >= 0)
+        test("RuntimeError: message" in str(ex))
     except Ice.OperationNotExistException:
         pass
     except AttributeError:
@@ -85,7 +85,7 @@ def testExceptions(obj):
         obj.unknownExceptionWithServantException()
         test(False)
     except Ice.UnknownException as ex:
-        test(ex.unknown == "reason")
+        test("reason" in str(ex))
     except Exception:
         test(False)
 
@@ -149,7 +149,7 @@ def allTests(helper, communicator):
         obj.ice_ids()
         test(False)
     except Ice.UnknownUserException as ex:
-        test(ex.unknown == "::Test::TestIntfUserException")
+        test("::Test::TestIntfUserException" in str(ex))
     except Exception:
         test(False)
 
@@ -160,7 +160,7 @@ def allTests(helper, communicator):
         obj.ice_ids()
         test(False)
     except Ice.UnknownUserException as ex:
-        test(ex.unknown == "::Test::TestIntfUserException")
+        test("::Test::TestIntfUserException" in str(ex))
     except Exception:
         test(False)
     print("ok")

--- a/python/test/Ice/slicing/objects/AllTests.py
+++ b/python/test/Ice/slicing/objects/AllTests.py
@@ -72,7 +72,7 @@ class Callback(CallbackBase):
 
     def exception_SUnknownAsObject10(self, f):
         test(f.exception() is not None)
-        test(str(f.exception()) == "::Ice::MarshalException")
+        test("cannot find value factory for type ID '::Test::SUnknown'" in str(f.exception()))
         self.called()
 
     def response_SUnknownAsObject11(self, f):
@@ -757,9 +757,7 @@ def allTests(helper, communicator):
         test(b2.ice_id() == "::Test::B")  # No factory, must be sliced
         test(b2.sb == "D2.sb")
         test(b2.pb == b1)
-    except Ice.Exception as ex:
-        sys.stdout.write("failed: {0}\n".format(ex))
-        sys.stdout.flush()
+    except Ice.Exception:
         test(False)
     print("ok")
 


### PR DESCRIPTION
This PR simplifies the conversion of C++ exceptions to Python exceptions, similar to changes done by @bernardnormier to MATLAB, Ruby, and PHP