### PR TITLE
Remove LocalObject from Python extension

### DIFF
--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -3098,20 +3098,9 @@ IcePy::ClassInfo::print(PyObject* value, IceInternal::Output& out, PrintObjectHi
         {
             PyObjectHandle iceType = getAttr(value, "_ice_type", false);
             ClassInfoPtr info;
-            if (!iceType.get())
-            {
-                //
-                // The _ice_type attribute will be missing in an instance of LocalObject
-                // that does not derive from a user-defined type.
-                //
-                assert(id == "::Ice::LocalObject");
-                info = shared_from_this();
-            }
-            else
-            {
-                info = dynamic_pointer_cast<ClassInfo>(getType(iceType.get()));
-                assert(info);
-            }
+            assert(iceType.get());
+            info = dynamic_pointer_cast<ClassInfo>(getType(iceType.get()));
+            assert(info);
             out << "object #" << history->index << " (" << info->id << ')';
             history->objects.insert(map<PyObject*, int>::value_type(value, history->index));
             ++history->index;

--- a/python/python/Ice/__init__.py
+++ b/python/python/Ice/__init__.py
@@ -71,7 +71,6 @@ from .UnknownSlicedValue import UnknownSlicedValue, SlicedData, SliceInfo
 IcePy._t_Object = IcePy.declareClass("::Ice::Object")
 IcePy._t_Value = IcePy.declareValue("::Ice::Object")
 IcePy._t_ObjectPrx = IcePy.declareProxy("::Ice::Object")
-IcePy._t_LocalObject = IcePy.declareValue("::Ice::LocalObject")
 
 #
 # Import "local slice" and generated Ice modules.
@@ -199,10 +198,6 @@ Object._op_ice_id = IcePy.Operation(
     (),
     ((), IcePy._t_string, False, 0),
     (),
-)
-
-IcePy._t_LocalObject = IcePy.defineValue(
-    "::Ice::LocalObject", object, -1, (), False, None, ()
 )
 
 IcePy._t_UnknownSlicedValue = IcePy.defineValue(


### PR DESCRIPTION
LocalObject is no longer relevant for the Python extension.