### PR TITLE
Simplify string conversion in MATLAB

### DIFF
--- a/matlab/src/msbuild/ice/ice.vcxproj
+++ b/matlab/src/msbuild/ice/ice.vcxproj
@@ -39,12 +39,6 @@
     <TargetExt>.mexw64</TargetExt>
     <TargetName>ice</TargetName>
   </PropertyGroup>
-  <ItemDefinitionGroup>
-    <ClCompile>
-      <!-- COMPILERFIX: codecvt is deprecated in C++17 -->
-      <PreprocessorDefinitions>_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PreprocessorDefinitions>ICE_MATLAB_API_EXPORTS;MX_COMPAT_32;MATLAB_MEX_FILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
We can use the UTF-8 support introduced in MATLAB R2020b.