### PR TITLE
More Minor Java Cleanup

### DIFF
--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/TcpAcceptor.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/TcpAcceptor.java
@@ -60,7 +60,7 @@ class TcpAcceptor implements Acceptor {
             _addr.getAddress().getHostAddress(), _instance.protocolSupport(), true);
     if (!intfs.isEmpty()) {
       s.append("\nlocal interfaces = ");
-      s.append(com.zeroc.IceUtilInternal.StringUtil.joinString(intfs, ", "));
+      s.append(String.join(", ", intfs));
     }
     return s.toString();
   }

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/UdpMulticastClientTransceiver.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/UdpMulticastClientTransceiver.java
@@ -147,7 +147,7 @@ final class UdpMulticastClientTransceiver implements Transceiver {
         Network.getInterfacesForMulticast(_mcastInterface, Network.getProtocolSupport(_addr));
     if (!intfs.isEmpty()) {
       s.append("\nlocal interfaces = ");
-      s.append(com.zeroc.IceUtilInternal.StringUtil.joinString(intfs, ", "));
+      s.append(String.join(", ", intfs));
     }
     return s.toString();
   }

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/UdpMulticastServerTransceiver.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/UdpMulticastServerTransceiver.java
@@ -159,7 +159,7 @@ final class UdpMulticastServerTransceiver implements Transceiver {
         Network.getInterfacesForMulticast(_mcastInterface, Network.getProtocolSupport(_addr));
     if (!intfs.isEmpty()) {
       s.append("\nlocal interfaces = ");
-      s.append(com.zeroc.IceUtilInternal.StringUtil.joinString(intfs, ", "));
+      s.append(String.join(", ", intfs));
     }
     return s.toString();
   }

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/UdpTransceiver.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/UdpTransceiver.java
@@ -237,7 +237,7 @@ final class UdpTransceiver implements Transceiver {
     }
     if (!intfs.isEmpty()) {
       s.append("\nlocal interfaces = ");
-      s.append(com.zeroc.IceUtilInternal.StringUtil.joinString(intfs, ", "));
+      s.append(String.join(", ", intfs));
     }
     return s.toString();
   }

--- a/java/src/Ice/src/main/java/com/zeroc/IceUtilInternal/Options.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceUtilInternal/Options.java
@@ -38,35 +38,20 @@ public final class Options {
             switch (c) {
               case '\\':
                 {
+                  // Ignore a backslash at the end of the string, and strip backslash-newline pairs.
                   //
-                  // Ignore a backslash at the end of the string,
-                  // and strip backslash-newline pairs. If a
-                  // backslash is followed by a space, single quote,
-                  // double quote, or dollar sign, we drop the backslash
-                  // and write the space, single quote, double quote,
-                  // or dollar sign. This is necessary to allow quotes
-                  // to be escaped. Dropping the backslash preceding a
-                  // space deviates from bash quoting rules, but is
-                  // necessary so we don't drop backslashes from Windows
-                  // path names.)
-                  //
+                  // If a backslash comes before a space, single quote, double quote, or dollar sign
+                  // we drop the backslash, but still write the the space, quote, or dollar sign.
+                  // This is necessary to allow quotes to be escaped. Dropping the backslash
+                  // preceding a space deviates from bash quoting rules, but is necessary so we
+                  // don't drop backslashes from Windows path names.
                   if (i < line.length() - 1 && line.charAt(++i) != '\n') {
-                    switch (line.charAt(i)) {
-                      case ' ':
-                      case '$':
-                      case '\\':
-                      case '"':
-                        {
-                          arg.append(line.charAt(i));
-                          break;
-                        }
-                      default:
-                        {
-                          arg.append('\\');
-                          arg.append(line.charAt(i));
-                          break;
-                        }
+                    char nextChar = line.charAt(i);
+                    // TODO: comment says we should be checking single quotes here, but we aren't?
+                    if (nextChar != ' ' && nextChar != '$' && nextChar != '\\' && nextChar != '"') {
+                      arg.append('\\');
                     }
+                    arg.append(nextChar);
                   }
                   break;
                 }
@@ -113,28 +98,15 @@ public final class Options {
           }
         case DoubleQuoteState:
           {
-            //
-            // Within double quotes, only backslash retains its special
-            // meaning, and only if followed by double quote, backslash,
-            // or newline. If not followed by one of these characters,
-            // both the backslash and the character are preserved.
-            //
+            // Within double quotes, only backslash retains its special meaning,
+            // and only if followed by a double quote, backslash, or newline.
+            // Both the backslash and the character are preserved for any other character.
             if (c == '\\' && i < line.length() - 1) {
-              switch (c = line.charAt(++i)) {
-                case '"':
-                case '\\':
-                case '\n':
-                  {
-                    arg.append(c);
-                    break;
-                  }
-                default:
-                  {
-                    arg.append('\\');
-                    arg.append(c);
-                    break;
-                  }
+              c = line.charAt(++i);
+              if (c != '"' && c != '\\' && c != '\n') {
+                arg.append('\\');
               }
+              arg.append(c);
             } else if (c == '"') // End of double-quote mode.
             {
               state = NormalState;

--- a/java/src/Ice/src/main/java/com/zeroc/IceUtilInternal/StringUtil.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceUtilInternal/StringUtil.java
@@ -479,22 +479,6 @@ public final class StringUtil {
   }
 
   //
-  // Join a list of strings using the given delimiter.
-  //
-  public static String joinString(java.util.List<String> values, String delimiter) {
-    StringBuffer s = new StringBuffer();
-    boolean first = true;
-    for (String v : values) {
-      if (!first) {
-        s.append(delimiter);
-      }
-      s.append(v);
-      first = false;
-    }
-    return s.toString();
-  }
-
-  //
   // Split string helper; returns null for unmatched quotes
   //
   public static String[] splitString(String str, String delim) {
@@ -545,10 +529,6 @@ public final class StringUtil {
       return null; // Unmatched quote.
     }
     return l.toArray(new String[0]);
-  }
-
-  public static int checkQuote(String s) {
-    return checkQuote(s, 0);
   }
 
   //

--- a/java/src/IceBox/src/main/java/com/zeroc/IceBox/ServiceManagerI.java
+++ b/java/src/IceBox/src/main/java/com/zeroc/IceBox/ServiceManagerI.java
@@ -919,9 +919,8 @@ public class ServiceManagerI implements ServiceManager {
         properties.setProperty("Ice.Admin.Enabled", "1");
 
         if (!facetNames.isEmpty()) {
-          // TODO: need joinString with escape!
-          properties.setProperty(
-              "Ice.Admin.Facets", com.zeroc.IceUtilInternal.StringUtil.joinString(facetNames, " "));
+          // TODO: need join with escape!
+          properties.setProperty("Ice.Admin.Facets", String.join(" ", facetNames));
         }
         return true;
       }

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/LogFilterDialog.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/LogFilterDialog.java
@@ -61,9 +61,8 @@ class LogFilterDialog extends JDialog {
     String[] traceCategoryFilter = dialog.getTraceCategoryFilter();
     if (traceCategoryFilter != null) {
       // TODO: join with escapes!
-      traceCategories.setText(
-          com.zeroc.IceUtilInternal.StringUtil.joinString(
-              java.util.Arrays.asList(traceCategoryFilter), ", "));
+      String s = String.join(", ", java.util.Arrays.asList(traceCategoryFilter));
+      traceCategories.setText(s);
     } else {
       traceCategories.setText(null);
     }


### PR DESCRIPTION
This PR:
- Replaces our own `StringUtil.joinString` with the built-in `String.join` method. I ran some test-cases and checked out logic against the docs, they are identical in functionality.
- Removes the `checkQuote` method (it was unused)
- Simplifies the logic of our `Options` parsing.

I was trying to see if we could eliminate `icebox`'s dependency on IceUtilInternal, but I couldn't quite get there.
`Options` is used by multiple things, and is too complex to consider duplicating...