### PR TITLE
Small update to slice2cs

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -509,15 +509,12 @@ Slice::CsGenerator::isValueType(const TypePtr& type)
 }
 
 bool
-Slice::CsGenerator::isNonNullableReferenceType(const TypePtr& p, bool includeString)
+Slice::CsGenerator::isNonNullableReferenceType(const TypePtr& p)
 {
-    if (includeString)
+    BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(p);
+    if (builtin)
     {
-        BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(p);
-        if (builtin)
-        {
-            return builtin->kind() == Builtin::KindString;
-        }
+        return builtin->kind() == Builtin::KindString;
     }
 
     StructPtr st = dynamic_pointer_cast<Struct>(p);
@@ -527,6 +524,27 @@ Slice::CsGenerator::isNonNullableReferenceType(const TypePtr& p, bool includeStr
     }
 
     return dynamic_pointer_cast<Sequence>(p) || dynamic_pointer_cast<Dictionary>(p);
+}
+
+bool
+Slice::CsGenerator::isMappedToRequiredField(const DataMemberPtr& p)
+{
+    if (p->optional())
+    {
+        return false;
+    }
+
+    // String fields get a "" default.
+
+    TypePtr type = p->type();
+
+    StructPtr st = dynamic_pointer_cast<Struct>(type);
+    if (st)
+    {
+        return isMappedToClass(st);
+    }
+
+    return dynamic_pointer_cast<Sequence>(type) || dynamic_pointer_cast<Dictionary>(type);
 }
 
 void

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -509,21 +509,28 @@ Slice::CsGenerator::isValueType(const TypePtr& type)
 }
 
 bool
-Slice::CsGenerator::isNonNullableReferenceType(const TypePtr& p)
+Slice::CsGenerator::isMappedToNonNullableReference(const DataMemberPtr& p)
 {
-    BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(p);
+    if (p->optional())
+    {
+        return false;
+    }
+
+    TypePtr type = p->type();
+
+    BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
     if (builtin)
     {
         return builtin->kind() == Builtin::KindString;
     }
 
-    StructPtr st = dynamic_pointer_cast<Struct>(p);
+    StructPtr st = dynamic_pointer_cast<Struct>(type);
     if (st)
     {
         return isMappedToClass(st);
     }
 
-    return dynamic_pointer_cast<Sequence>(p) || dynamic_pointer_cast<Dictionary>(p);
+    return dynamic_pointer_cast<Sequence>(type) || dynamic_pointer_cast<Dictionary>(type);
 }
 
 bool

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -61,10 +61,11 @@ namespace Slice
         // Is this Slice struct mapped to a C# class?
         static bool isMappedToClass(const StructPtr& p) { return !isValueType(p); }
 
-        // Is this Slice field type mapped to a non-nullable C# reference type?
-        static bool isNonNullableReferenceType(const TypePtr& p);
+        // Is the mapped C# type for this field a non-nullable C# reference type?
+        static bool isMappedToNonNullableReference(const DataMemberPtr& p);
 
-        // Is this Slice field mapped to a required C# field? (class and exception only)
+        // Is the mapped C# type for this field a non-nullable reference type?
+        // string fields are not included since they have a "" default.
         static bool isMappedToRequiredField(const DataMemberPtr&);
 
         //

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -62,7 +62,10 @@ namespace Slice
         static bool isMappedToClass(const StructPtr& p) { return !isValueType(p); }
 
         // Is this Slice field type mapped to a non-nullable C# reference type?
-        static bool isNonNullableReferenceType(const TypePtr& p, bool includeString = true);
+        static bool isNonNullableReferenceType(const TypePtr& p);
+
+        // Is this Slice field mapped to a required C# field? (class and exception only)
+        static bool isMappedToRequiredField(const DataMemberPtr&);
 
         //
         // Generate code to marshal or unmarshal a type

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -743,7 +743,7 @@ Slice::CsVisitor::writeDataMemberInitializers(const DataMemberList& dataMembers,
     // Generates "= null!" for each non-optional collection and struct-mapped-to-a-class field.
     for (const auto& q : dataMembers)
     {
-        if (!q->optional() && isNonNullableReferenceType(q->type(), false))
+        if (isMappedToRequiredField(q))
         {
             _out << nl << "this." << fixId(q->name(), baseTypes) << " = null!;";
         }
@@ -1676,8 +1676,7 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
             paramDecl.push_back(memberType + " " + memberName);
 
             // Look for non-nullable fields to be initialized by the secondary constructor.
-            // false: we don't want to include strings since they are initialized to ""
-            if (!q->optional() && isNonNullableReferenceType(q->type(), false))
+            if (isMappedToRequiredField(q))
             {
                 secondaryCtorParams.push_back(memberType + " " + memberName);
 
@@ -1700,7 +1699,7 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
                 baseParamNames.push_back(memberName);
 
                 // Look for non-nullable fields
-                if (!q->optional() && isNonNullableReferenceType(q->type(), false))
+                if (isMappedToRequiredField(q))
                 {
                     secondaryCtorBaseParamNames.push_back(memberName);
                 }
@@ -1937,7 +1936,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
         paramDecl.push_back(memberType + " " + memberName);
 
         // Look for non-nullable fields to be initialized by the secondary constructor.
-        if (!q->optional() && isNonNullableReferenceType(q->type(), false))
+        if (isMappedToRequiredField(q))
         {
             secondaryCtorParams.push_back(memberType + " " + memberName);
             if (find(dataMembers.begin(), dataMembers.end(), q) != dataMembers.end())
@@ -1977,7 +1976,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
             baseParamNames.push_back(memberName);
 
             // Look for non-nullable fields
-            if (!q->optional() && isNonNullableReferenceType(q->type(), false))
+            if (isMappedToRequiredField(q))
             {
                 secondaryCtorBaseParamNames.push_back(memberName);
             }
@@ -2165,8 +2164,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
         vector<string> ctorParamNames;
         for (const auto& q : dataMembers)
         {
-            // false: we don't want to include strings since they are initialized to ""
-            if (isNonNullableReferenceType(q->type(), false))
+            if (isMappedToRequiredField(q))
             {
                 string memberName = fixId(q->name(), DotNet::ICloneable);
                 string memberType = typeToString(q->type(), ns, false);


### PR DESCRIPTION
This is a small update to slice2cs, which splits the helper function `isNonNullableReferenceType`/

I initially wanted to generate `required` fields, but it doesn't work because of the generics we use for Metrics.