### PR TITLE
Reintroduce redefinition checks

### DIFF
--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1559,7 +1559,6 @@ Slice::Python::CodeVisitor::visitEnum(const EnumPtr& p)
 void
 Slice::Python::CodeVisitor::visitConst(const ConstPtr& p)
 {
-
     _out << sp << nl << "if " << getDictLookup(p) << ':';
     _out.inc();
 


### PR DESCRIPTION
This PR brings back the redefinition checks removed in e2afab0e4b2da98288b23aa504fb56d53390b35e because they are required when using the `--all` slice2py compiler option.