### PR TITLE
Do not use refcount with Python immortal objects

### DIFF
--- a/python/modules/IcePy/BatchRequestInterceptor.cpp
+++ b/python/modules/IcePy/BatchRequestInterceptor.cpp
@@ -121,7 +121,6 @@ batchRequestEnqueue(BatchRequestObject* self, PyObject* /*args*/)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 

--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -396,7 +396,6 @@ communicatorDestroy(CommunicatorObject* self, PyObject* /*args*/)
     }
     else
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 }
@@ -416,7 +415,6 @@ communicatorShutdown(CommunicatorObject* self, PyObject* /*args*/)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -460,7 +458,7 @@ communicatorWaitForShutdown(CommunicatorObject* self, PyObject* args)
                 AllowThreads allowThreads; // Release Python's global interpreter lock during blocking calls.
                 if (self->shutdownFuture->wait_for(std::chrono::milliseconds(timeout)) == std::future_status::timeout)
                 {
-                    PyRETURN_FALSE;
+                    return Py_False;
                 }
             }
 
@@ -496,7 +494,7 @@ communicatorWaitForShutdown(CommunicatorObject* self, PyObject* args)
         }
     }
 
-    PyRETURN_TRUE;
+    return Py_True;
 }
 
 extern "C" PyObject*
@@ -514,7 +512,7 @@ communicatorIsShutdown(CommunicatorObject* self, PyObject* /*args*/)
         return 0;
     }
 
-    PyRETURN_BOOL(isShutdown);
+    return isShutdown ? Py_True : Py_False;
 }
 
 extern "C" PyObject*
@@ -548,7 +546,6 @@ communicatorStringToProxy(CommunicatorObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -614,7 +611,6 @@ communicatorPropertyToProxy(CommunicatorObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -725,7 +721,6 @@ communicatorFlushBatchRequests(CommunicatorObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -843,7 +838,6 @@ communicatorGetAdmin(CommunicatorObject* self, PyObject* /*args*/)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -881,7 +875,6 @@ communicatorAddAdminFacet(CommunicatorObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -934,7 +927,6 @@ communicatorFindAdminFacet(CommunicatorObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -1026,7 +1018,6 @@ communicatorRemoveAdminFacet(CommunicatorObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -1043,7 +1034,6 @@ communicatorSetWrapper(CommunicatorObject* self, PyObject* args)
     self->wrapper = wrapper;
     Py_INCREF(self->wrapper);
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -1120,7 +1110,6 @@ communicatorGetImplicitContext(CommunicatorObject* self, PyObject* /*args*/)
 
     if (implicitContext == 0)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 
@@ -1286,7 +1275,6 @@ communicatorGetDefaultRouter(CommunicatorObject* self, PyObject* /*args*/)
 
     if (!router)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 
@@ -1323,7 +1311,6 @@ communicatorSetDefaultRouter(CommunicatorObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -1344,7 +1331,6 @@ communicatorGetDefaultLocator(CommunicatorObject* self, PyObject* /*args*/)
 
     if (!locator)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 
@@ -1381,7 +1367,6 @@ communicatorSetDefaultLocator(CommunicatorObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -1608,7 +1593,6 @@ IcePy::getCommunicatorWrapper(const Ice::CommunicatorPtr& communicator)
         //
         // Communicator must have been destroyed already.
         //
-        Py_INCREF(Py_None);
         return Py_None;
     }
 }

--- a/python/modules/IcePy/Connection.cpp
+++ b/python/modules/IcePy/Connection.cpp
@@ -183,7 +183,7 @@ connectionCompare(ConnectionObject* c1, PyObject* other, int op)
         }
     }
 
-    return result ? incTrue() : incFalse();
+    return result ? Py_True : Py_False;
 }
 
 extern "C" long
@@ -218,7 +218,6 @@ connectionClose(ConnectionObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -284,7 +283,6 @@ connectionSetAdapter(ConnectionObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -311,7 +309,6 @@ connectionGetAdapter(ConnectionObject* self, PyObject* /*args*/)
     }
     else
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 }
@@ -342,7 +339,6 @@ connectionFlushBatchRequests(ConnectionObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -436,7 +432,6 @@ connectionSetCloseCallback(ConnectionObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -529,7 +524,6 @@ connectionSetBufferSize(ConnectionObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -547,7 +541,6 @@ connectionThrowException(ConnectionObject* self, PyObject* /*args*/)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 

--- a/python/modules/IcePy/ConnectionInfo.cpp
+++ b/python/modules/IcePy/ConnectionInfo.cpp
@@ -42,7 +42,7 @@ connectionInfoGetUnderlying(ConnectionInfoObject* self, PyObject* /*args*/)
 extern "C" PyObject*
 connectionInfoGetIncoming(ConnectionInfoObject* self, PyObject* /*args*/)
 {
-    return (*self->connectionInfo)->incoming ? incTrue() : incFalse();
+    return (*self->connectionInfo)->incoming ? Py_True : Py_False;
 }
 
 extern "C" PyObject*
@@ -579,7 +579,6 @@ IcePy::createConnectionInfo(const Ice::ConnectionInfoPtr& connectionInfo)
 {
     if (!connectionInfo)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 

--- a/python/modules/IcePy/Dispatcher.cpp
+++ b/python/modules/IcePy/Dispatcher.cpp
@@ -42,7 +42,7 @@ dispatcherCallInvoke(DispatcherCallObject* self, PyObject* /*args*/, PyObject* /
         return 0;
     }
 
-    return incRef(Py_None);
+    return Py_None;
 }
 
 namespace IcePy

--- a/python/modules/IcePy/Endpoint.cpp
+++ b/python/modules/IcePy/Endpoint.cpp
@@ -79,7 +79,7 @@ endpointCompare(EndpointObject* p1, PyObject* other, int op)
         }
     }
 
-    return result ? incTrue() : incFalse();
+    return result ? Py_True : Py_False;
 }
 
 extern "C" PyObject*

--- a/python/modules/IcePy/EndpointInfo.cpp
+++ b/python/modules/IcePy/EndpointInfo.cpp
@@ -60,7 +60,7 @@ endpointInfoDatagram(EndpointInfoObject* self, PyObject* /*args*/)
     PyObject* b;
     try
     {
-        b = (*self->endpointInfo)->datagram() ? getTrue() : getFalse();
+        b = (*self->endpointInfo)->datagram() ? Py_True : Py_False;
     }
     catch (...)
     {
@@ -82,7 +82,7 @@ endpointInfoSecure(EndpointInfoObject* self, PyObject* /*args*/)
     PyObject* b;
     try
     {
-        b = (*self->endpointInfo)->secure() ? getTrue() : getFalse();
+        b = (*self->endpointInfo)->secure() ? Py_True : Py_False;
     }
     catch (...)
     {
@@ -109,7 +109,7 @@ endpointInfoGetTimeout(EndpointInfoObject* self, PyObject* /*args*/)
 extern "C" PyObject*
 endpointInfoGetCompress(EndpointInfoObject* self, PyObject* /*args*/)
 {
-    return (*self->endpointInfo)->compress ? incTrue() : incFalse();
+    return (*self->endpointInfo)->compress ? Py_True : Py_False;
 }
 
 extern "C" PyObject*
@@ -641,7 +641,6 @@ IcePy::createEndpointInfo(const Ice::EndpointInfoPtr& endpointInfo)
 {
     if (!endpointInfo)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 

--- a/python/modules/IcePy/ImplicitContext.cpp
+++ b/python/modules/IcePy/ImplicitContext.cpp
@@ -88,7 +88,7 @@ implicitContextCompare(ImplicitContextObject* c1, PyObject* other, int op)
         }
     }
 
-    return result ? incTrue() : incFalse();
+    return result ? Py_True : Py_False;
 }
 
 extern "C" PyObject*
@@ -127,7 +127,6 @@ implicitContextSetContext(ImplicitContextObject* self, PyObject* args)
 
     (*self->implicitContext)->setContext(ctx);
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -157,7 +156,7 @@ implicitContextContainsKey(ImplicitContextObject* self, PyObject* args)
         return 0;
     }
 
-    PyRETURN_BOOL(containsKey);
+    return containsKey ? Py_True : Py_False;
 }
 
 extern "C" PyObject*

--- a/python/modules/IcePy/Logger.cpp
+++ b/python/modules/IcePy/Logger.cpp
@@ -150,7 +150,6 @@ loggerPrint(LoggerObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -186,7 +185,6 @@ loggerTrace(LoggerObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -216,7 +214,6 @@ loggerWarning(LoggerObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -246,7 +243,6 @@ loggerError(LoggerObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -467,6 +463,5 @@ IcePy_setProcessLogger(PyObject* /*self*/, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }

--- a/python/modules/IcePy/ObjectAdapter.cpp
+++ b/python/modules/IcePy/ObjectAdapter.cpp
@@ -368,7 +368,6 @@ adapterActivate(ObjectAdapterObject* self, PyObject* /*args*/)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -386,7 +385,6 @@ adapterHold(ObjectAdapterObject* self, PyObject* /*args*/)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -431,7 +429,7 @@ adapterWaitForHold(ObjectAdapterObject* self, PyObject* args)
                 AllowThreads allowThreads; // Release Python's global interpreter lock during blocking calls.
                 if (self->holdFuture->wait_for(std::chrono::milliseconds(timeout)) == std::future_status::timeout)
                 {
-                    PyRETURN_FALSE;
+                    return Py_False;
                 }
             }
 
@@ -467,7 +465,7 @@ adapterWaitForHold(ObjectAdapterObject* self, PyObject* args)
         }
     }
 
-    PyRETURN_TRUE;
+    return Py_True;
 }
 
 extern "C" PyObject*
@@ -485,7 +483,6 @@ adapterDeactivate(ObjectAdapterObject* self, PyObject* /*args*/)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -529,7 +526,7 @@ adapterWaitForDeactivate(ObjectAdapterObject* self, PyObject* args)
                 AllowThreads allowThreads; // Release Python's global interpreter lock during blocking calls.
                 if (self->deactivateFuture->wait_for(std::chrono::milliseconds(timeout)) == std::future_status::timeout)
                 {
-                    PyRETURN_FALSE;
+                    return Py_False;
                 }
             }
 
@@ -565,7 +562,7 @@ adapterWaitForDeactivate(ObjectAdapterObject* self, PyObject* args)
         }
     }
 
-    PyRETURN_TRUE;
+    return Py_True;
 }
 
 extern "C" PyObject*
@@ -582,7 +579,6 @@ adapterIsDeactivated(ObjectAdapterObject* self, PyObject* /*args*/)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -601,7 +597,6 @@ adapterDestroy(ObjectAdapterObject* self, PyObject* /*args*/)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -788,7 +783,6 @@ adapterAddDefaultServant(ObjectAdapterObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -822,7 +816,6 @@ adapterRemove(ObjectAdapterObject* self, PyObject* args)
 
     if (!obj)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 
@@ -868,7 +861,6 @@ adapterRemoveFacet(ObjectAdapterObject* self, PyObject* args)
 
     if (!obj)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 
@@ -954,7 +946,6 @@ adapterRemoveDefaultServant(ObjectAdapterObject* self, PyObject* args)
 
     if (!obj)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 
@@ -993,7 +984,6 @@ adapterFind(ObjectAdapterObject* self, PyObject* args)
 
     if (!obj)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 
@@ -1039,7 +1029,6 @@ adapterFindFacet(ObjectAdapterObject* self, PyObject* args)
 
     if (!obj)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 
@@ -1125,7 +1114,6 @@ adapterFindByProxy(ObjectAdapterObject* self, PyObject* args)
 
     if (!obj)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 
@@ -1163,7 +1151,6 @@ adapterFindDefaultServant(ObjectAdapterObject* self, PyObject* args)
 
     if (!obj)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 
@@ -1201,7 +1188,6 @@ adapterAddServantLocator(ObjectAdapterObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -1234,7 +1220,6 @@ adapterRemoveServantLocator(ObjectAdapterObject* self, PyObject* args)
 
     if (!locator)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 
@@ -1272,7 +1257,6 @@ adapterFindServantLocator(ObjectAdapterObject* self, PyObject* args)
 
     if (!locator)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 
@@ -1403,7 +1387,6 @@ adapterSetLocator(ObjectAdapterObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -1424,7 +1407,6 @@ adapterGetLocator(ObjectAdapterObject* self, PyObject* /*args*/)
 
     if (!locator)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 
@@ -1480,7 +1462,6 @@ adapterRefreshPublishedEndpoints(ObjectAdapterObject* self, PyObject* /*args*/)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -1555,7 +1536,6 @@ adapterSetPublishedEndpoints(ObjectAdapterObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -427,7 +427,7 @@ operationDeprecate(OperationObject* self, PyObject* args)
     assert(self->op);
     (*self->op)->deprecate(msg);
 
-    return incRef(Py_None);
+    return Py_None;
 }
 
 //
@@ -475,7 +475,7 @@ dispatchCallbackResponse(DispatchCallbackObject* self, PyObject* args)
         assert(false);
     }
 
-    return incRef(Py_None);
+    return Py_None;
 }
 
 extern "C" PyObject*
@@ -501,7 +501,7 @@ dispatchCallbackException(DispatchCallbackObject* self, PyObject* args)
         assert(false);
     }
 
-    return incRef(Py_None);
+    return Py_None;
 }
 
 //
@@ -541,7 +541,7 @@ asyncInvocationContextCancel(AsyncInvocationContextObject* self, PyObject* /*arg
         assert(false);
     }
 
-    return incRef(Py_None);
+    return Py_None;
 }
 
 extern "C" PyObject*
@@ -601,7 +601,7 @@ asyncInvocationContextCallLater(AsyncInvocationContextObject* self, PyObject* ar
         assert(false);
     }
 
-    return incRef(Py_None);
+    return Py_None;
 }
 
 //
@@ -1511,7 +1511,7 @@ IcePy::Invocation::unmarshalException(const OperationPtr& op, pair<const byte*, 
     }
     assert(false);
     // Never reached.
-    return incRef(Py_None);
+    return Py_None;
 }
 
 bool
@@ -1662,7 +1662,7 @@ IcePy::SyncTypedInvocation::invoke(PyObject* args, PyObject* /* kwds */)
         return 0;
     }
 
-    return incRef(Py_None);
+    return Py_None;
 }
 
 //
@@ -1754,7 +1754,7 @@ IcePy::AsyncInvocation::invoke(PyObject* args, PyObject* kwds)
     {
         if (_sent)
         {
-            PyObjectHandle tmp = callMethod(future.get(), "set_sent", _sentSynchronously ? getTrue() : getFalse());
+            PyObjectHandle tmp = callMethod(future.get(), "set_sent", _sentSynchronously ? Py_True : Py_False);
             if (PyErr_Occurred())
             {
                 return 0;
@@ -1915,7 +1915,7 @@ IcePy::AsyncInvocation::sent(bool sentSynchronously)
         Py_INCREF(_future);
     }
 
-    PyObjectHandle tmp = callMethod(future.get(), "set_sent", sentSynchronously ? getTrue() : getFalse());
+    PyObjectHandle tmp = callMethod(future.get(), "set_sent", sentSynchronously ? Py_True : Py_False);
     if (PyErr_Occurred())
     {
         handleException();
@@ -2024,7 +2024,7 @@ IcePy::AsyncTypedInvocation::handleResponse(PyObject* future, bool ok, pair<cons
             PyObjectHandle r;
             if (PyTuple_GET_SIZE(args.get()) == 0)
             {
-                r = incRef(Py_None);
+                r = Py_None;
             }
             else if (PyTuple_GET_SIZE(args.get()) == 1)
             {
@@ -2111,7 +2111,7 @@ IcePy::SyncBlobjectInvocation::invoke(PyObject* args, PyObject* /* kwds */)
             throwPythonException();
         }
 
-        PyTuple_SET_ITEM(result.get(), 0, ok ? incTrue() : incFalse());
+        PyTuple_SET_ITEM(result.get(), 0, ok ? Py_True : Py_False);
 
         PyObjectHandle op;
         if (out.empty())
@@ -2202,7 +2202,7 @@ IcePy::AsyncBlobjectInvocation::handleResponse(PyObject* future, bool ok, pair<c
         return;
     }
 
-    PyTuple_SET_ITEM(args.get(), 0, ok ? incTrue() : incFalse());
+    PyTuple_SET_ITEM(args.get(), 0, ok ? Py_True : Py_False);
 
     Py_ssize_t sz = results.second - results.first;
     PyObjectHandle op;
@@ -2705,7 +2705,7 @@ IcePy::FlushAsyncCallback::setFuture(PyObject* future)
     }
     else if (_sent)
     {
-        PyObjectHandle tmp = callMethod(future, "set_sent", _sentSynchronously ? getTrue() : getFalse());
+        PyObjectHandle tmp = callMethod(future, "set_sent", _sentSynchronously ? Py_True : Py_False);
         PyErr_Clear();
         //
         // We consider the invocation complete when sent.
@@ -2757,7 +2757,7 @@ IcePy::FlushAsyncCallback::sent(bool sentSynchronously)
         return;
     }
 
-    PyObjectHandle tmp = callMethod(_future, "set_sent", _sentSynchronously ? getTrue() : getFalse());
+    PyObjectHandle tmp = callMethod(_future, "set_sent", _sentSynchronously ? Py_True : Py_False);
     PyErr_Clear();
     //
     // We consider the invocation complete when sent.

--- a/python/modules/IcePy/Properties.cpp
+++ b/python/modules/IcePy/Properties.cpp
@@ -541,7 +541,6 @@ propertiesSetProperty(PropertiesObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -686,7 +685,6 @@ propertiesLoad(PropertiesObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 

--- a/python/modules/IcePy/PropertiesAdmin.cpp
+++ b/python/modules/IcePy/PropertiesAdmin.cpp
@@ -77,7 +77,6 @@ nativePropertiesAdminAddUpdateCB(NativePropertiesAdminObject* self, PyObject* ar
     (*self->callbacks).push_back(make_pair(callback, remover));
     Py_INCREF(callback);
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -102,7 +101,6 @@ nativePropertiesAdminRemoveUpdateCB(NativePropertiesAdminObject* self, PyObject*
         callbacks.erase(p);
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 

--- a/python/modules/IcePy/Proxy.cpp
+++ b/python/modules/IcePy/Proxy.cpp
@@ -130,7 +130,7 @@ proxyCompare(ProxyObject* p1, PyObject* other, int op)
         }
     }
 
-    return result ? incTrue() : incFalse();
+    return result ? Py_True : Py_False;
 }
 
 extern "C" PyObject*
@@ -685,7 +685,7 @@ proxyIceIsConnectionCached(ProxyObject* self, PyObject* /*args*/)
     PyObject* b;
     try
     {
-        b = (*self->proxy)->ice_isConnectionCached() ? getTrue() : getFalse();
+        b = (*self->proxy)->ice_isConnectionCached() ? Py_True : Py_False;
     }
     catch (...)
     {
@@ -818,7 +818,7 @@ proxyIceIsSecure(ProxyObject* self, PyObject* /*args*/)
     PyObject* b;
     try
     {
-        b = (*self->proxy)->ice_isSecure() ? getTrue() : getFalse();
+        b = (*self->proxy)->ice_isSecure() ? Py_True : Py_False;
     }
     catch (...)
     {
@@ -922,7 +922,7 @@ proxyIceIsPreferSecure(ProxyObject* self, PyObject* /*args*/)
     PyObject* b;
     try
     {
-        b = (*self->proxy)->ice_isPreferSecure() ? getTrue() : getFalse();
+        b = (*self->proxy)->ice_isPreferSecure() ? Py_True : Py_False;
     }
     catch (...)
     {
@@ -983,7 +983,6 @@ proxyIceGetRouter(ProxyObject* self, PyObject* /*args*/)
 
     if (!router)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 
@@ -1043,7 +1042,6 @@ proxyIceGetLocator(ProxyObject* self, PyObject* /*args*/)
 
     if (!locator)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 
@@ -1112,7 +1110,7 @@ proxyIceIsTwoway(ProxyObject* self, PyObject* /*args*/)
     PyObject* b;
     try
     {
-        b = (*self->proxy)->ice_isTwoway() ? getTrue() : getFalse();
+        b = (*self->proxy)->ice_isTwoway() ? Py_True : Py_False;
     }
     catch (...)
     {
@@ -1151,7 +1149,7 @@ proxyIceIsOneway(ProxyObject* self, PyObject* /*args*/)
     PyObject* b;
     try
     {
-        b = (*self->proxy)->ice_isOneway() ? getTrue() : getFalse();
+        b = (*self->proxy)->ice_isOneway() ? Py_True : Py_False;
     }
     catch (...)
     {
@@ -1190,7 +1188,7 @@ proxyIceIsBatchOneway(ProxyObject* self, PyObject* /*args*/)
     PyObject* b;
     try
     {
-        b = (*self->proxy)->ice_isBatchOneway() ? getTrue() : getFalse();
+        b = (*self->proxy)->ice_isBatchOneway() ? Py_True : Py_False;
     }
     catch (...)
     {
@@ -1229,7 +1227,7 @@ proxyIceIsDatagram(ProxyObject* self, PyObject* /*args*/)
     PyObject* b;
     try
     {
-        b = (*self->proxy)->ice_isDatagram() ? getTrue() : getFalse();
+        b = (*self->proxy)->ice_isDatagram() ? Py_True : Py_False;
     }
     catch (...)
     {
@@ -1268,7 +1266,7 @@ proxyIceIsBatchDatagram(ProxyObject* self, PyObject* /*args*/)
     PyObject* b;
     try
     {
-        b = (*self->proxy)->ice_isBatchDatagram() ? getTrue() : getFalse();
+        b = (*self->proxy)->ice_isBatchDatagram() ? Py_True : Py_False;
     }
     catch (...)
     {
@@ -1322,7 +1320,7 @@ proxyIceGetCompress(ProxyObject* self, PyObject* /*args*/)
         optional<bool> compress = (*self->proxy)->ice_getCompress();
         if (compress)
         {
-            b = *compress ? getTrue() : getFalse();
+            b = *compress ? Py_True : Py_False;
         }
         else
         {
@@ -1346,7 +1344,7 @@ proxyIceIsCollocationOptimized(ProxyObject* self, PyObject* /*args*/)
     PyObject* b;
     try
     {
-        b = (*self->proxy)->ice_isCollocationOptimized() ? getTrue() : getFalse();
+        b = (*self->proxy)->ice_isCollocationOptimized() ? Py_True : Py_False;
     }
     catch (...)
     {
@@ -1464,7 +1462,7 @@ proxyIceIsFixed(ProxyObject* self, PyObject* /*args*/)
     PyObject* b;
     try
     {
-        b = (*self->proxy)->ice_isFixed() ? getTrue() : getFalse();
+        b = (*self->proxy)->ice_isFixed() ? Py_True : Py_False;
     }
     catch (...)
     {
@@ -1498,7 +1496,6 @@ proxyIceGetConnection(ProxyObject* self, PyObject* /*args*/)
     }
     else
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 }
@@ -1561,7 +1558,6 @@ proxyIceGetCachedConnection(ProxyObject* self, PyObject* /*args*/)
     }
     else
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 }
@@ -1582,7 +1578,6 @@ proxyIceFlushBatchRequests(ProxyObject* self, PyObject* /*args*/)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -1679,7 +1674,6 @@ checkedCastImpl(ProxyObject* p, const string& id, PyObject* facet, PyObject* ctx
         return createProxy(target.value(), *p->communicator, type);
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -1701,7 +1695,6 @@ proxyIceCheckedCast(PyObject* type, PyObject* args)
 
     if (obj == Py_None)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 
@@ -1757,7 +1750,6 @@ proxyIceUncheckedCast(PyObject* type, PyObject* args)
 
     if (obj == Py_None)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 
@@ -1792,7 +1784,6 @@ proxyCheckedCast(PyObject* /*self*/, PyObject* args)
 
     if (obj == Py_None)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 
@@ -1866,7 +1857,6 @@ proxyUncheckedCast(PyObject* /*self*/, PyObject* args)
 
     if (obj == Py_None)
     {
-        Py_INCREF(Py_None);
         return Py_None;
     }
 

--- a/python/modules/IcePy/Slice.cpp
+++ b/python/modules/IcePy/Slice.cpp
@@ -183,7 +183,6 @@ IcePy_loadSlice(PyObject* /*self*/, PyObject* args)
         }
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 

--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -430,7 +430,7 @@ IcePy::StreamUtil::setSlicedDataMember(PyObject* obj, const Ice::SlicedDataPtr& 
         //
         // hasOptionalMembers
         //
-        PyObject* hasOptionalMembers = (*p)->hasOptionalMembers ? getTrue() : getFalse();
+        PyObject* hasOptionalMembers = (*p)->hasOptionalMembers ? Py_True : Py_False;
         if (PyObject_SetAttrString(slice.get(), "hasOptionalMembers", hasOptionalMembers) < 0)
         {
             assert(PyErr_Occurred());
@@ -440,7 +440,7 @@ IcePy::StreamUtil::setSlicedDataMember(PyObject* obj, const Ice::SlicedDataPtr& 
         //
         // isLastSlice
         //
-        PyObject* isLastSlice = (*p)->isLastSlice ? getTrue() : getFalse();
+        PyObject* isLastSlice = (*p)->isLastSlice ? Py_True : Py_False;
         if (PyObject_SetAttrString(slice.get(), "isLastSlice", isLastSlice) < 0)
         {
             assert(PyErr_Occurred());
@@ -873,11 +873,11 @@ IcePy::PrimitiveInfo::unmarshal(
             is->read(b);
             if (b)
             {
-                cb->unmarshaled(getTrue(), target, closure);
+                cb->unmarshaled(Py_True, target, closure);
             }
             else
             {
-                cb->unmarshaled(getFalse(), target, closure);
+                cb->unmarshaled(Py_False, target, closure);
             }
             break;
         }
@@ -2101,11 +2101,10 @@ IcePy::SequenceInfo::createSequenceFromMemory(
     Py_ssize_t size,
     BuiltinType type)
 {
-    PyObjectHandle memoryview;
     char* buf = const_cast<char*>(size == 0 ? emptySeq : buffer);
-    memoryview = PyMemoryView_FromMemory(buf, size, PyBUF_READ);
+    PyObjectHandle memoryView = PyMemoryView_FromMemory(buf, size, PyBUF_READ);
 
-    if (!memoryview.get())
+    if (!memoryView.get())
     {
         assert(PyErr_Occurred());
         throw AbortMarshaling();
@@ -2121,9 +2120,9 @@ IcePy::SequenceInfo::createSequenceFromMemory(
     AdoptThread adoptThread; // Ensure the current thread is able to call into Python.
 
     PyObjectHandle args = PyTuple_New(3);
-    PyTuple_SET_ITEM(args.get(), 0, incRef(memoryview.get()));
-    PyTuple_SET_ITEM(args.get(), 1, incRef(builtinType.get()));
-    PyTuple_SET_ITEM(args.get(), 2, incTrue());
+    PyTuple_SET_ITEM(args.get(), 0, memoryView.release());
+    PyTuple_SET_ITEM(args.get(), 1, builtinType.release());
+    PyTuple_SET_ITEM(args.get(), 2, Py_True);
     PyObjectHandle result = PyObject_Call(sm->factory, args.get(), 0);
 
     if (!result.get())
@@ -2173,7 +2172,7 @@ IcePy::SequenceInfo::unmarshalPrimitiveSequence(
 
                 for (int i = 0; i < sz; ++i)
                 {
-                    sm->setItem(result.get(), i, p.first[i] ? getTrue() : getFalse());
+                    sm->setItem(result.get(), i, p.first[i] ? Py_True : Py_False);
                 }
             }
             break;

--- a/python/modules/IcePy/Util.cpp
+++ b/python/modules/IcePy/Util.cpp
@@ -740,12 +740,12 @@ IcePy::convertException(std::exception_ptr exPtr)
     }
     catch (const Ice::ConnectionAbortedException& ex)
     {
-        std::array args{ex.closedByApplication() ? incTrue() : incFalse(), IcePy::createString(ex.what())};
+        std::array args{ex.closedByApplication() ? Py_True : Py_False, IcePy::createString(ex.what())};
         return createPythonException(ex.ice_id(), std::move(args));
     }
     catch (const Ice::ConnectionClosedException& ex)
     {
-        std::array args{ex.closedByApplication() ? incTrue() : incFalse(), IcePy::createString(ex.what())};
+        std::array args{ex.closedByApplication() ? Py_True : Py_False, IcePy::createString(ex.what())};
         return createPythonException(ex.ice_id(), std::move(args));
     }
     catch (const Ice::RequestFailedException& ex)

--- a/python/modules/IcePy/Util.h
+++ b/python/modules/IcePy/Util.h
@@ -8,20 +8,6 @@
 #include "Config.h"
 #include "Ice/Ice.h"
 
-//
-// These macros replace Py_RETURN_FALSE and Py_RETURN_TRUE. We use these
-// instead of the standard ones in order to avoid GCC warnings about
-// strict aliasing and type punning.
-//
-#define PyRETURN_FALSE return incFalse()
-#define PyRETURN_TRUE return incTrue()
-
-#define PyRETURN_BOOL(b)                                                                                               \
-    if (b)                                                                                                             \
-        PyRETURN_TRUE;                                                                                                 \
-    else                                                                                                               \
-        PyRETURN_FALSE
-
 namespace IcePy
 {
     inline PyObject* incRef(PyObject* obj)
@@ -29,28 +15,6 @@ namespace IcePy
         Py_XINCREF(obj);
         return obj;
     }
-
-    //
-    // This should be used instead of Py_False to avoid GCC compiler warnings.
-    //
-    inline PyObject* getFalse()
-    {
-        PyLongObject* i = &_Py_FalseStruct;
-        return reinterpret_cast<PyObject*>(i);
-    }
-
-    //
-    // This should be used instead of Py_True to avoid GCC compiler warnings.
-    //
-    inline PyObject* getTrue()
-    {
-        PyLongObject* i = &_Py_TrueStruct;
-        return reinterpret_cast<PyObject*>(i);
-    }
-
-    inline PyObject* incFalse() { return incRef(getFalse()); }
-
-    inline PyObject* incTrue() { return incRef(getTrue()); }
 
     //
     // Create a string object.

--- a/python/modules/IcePy/ValueFactoryManager.cpp
+++ b/python/modules/IcePy/ValueFactoryManager.cpp
@@ -125,7 +125,6 @@ IcePy::ValueFactoryManager::findValueFactory(string_view id) const
         return p->second->getValueFactory();
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 
@@ -280,7 +279,6 @@ valueFactoryManagerAdd(ValueFactoryManagerObject* self, PyObject* args)
         return 0;
     }
 
-    Py_INCREF(Py_None);
     return Py_None;
 }
 


### PR DESCRIPTION
As of Python 3.12, Py_None, Py_True, and Py_False are immortal objects, and there is no need to manage their reference counts manually.

For more information, see:
- https://docs.python.org/3/c-api/none.html
- https://docs.python.org/3/c-api/bool.html
- https://peps.python.org/pep-0683/