### PR TITLE
Proxy creation in MATLAB

### DIFF
--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -2516,27 +2516,7 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     out.dec();
     out << nl << "end";
 
-    /*
-    if (bases.size() > 1)
-    {
-        //
-        // Constructor.
-        //
-        out << nl << "methods(Hidden=true)";
-        out.inc();
-        out << nl << "function obj = " << prxName << "(communicator, encoding, impl, bytes)";
-        out.inc();
-        out << nl << "fprintf('******************* calling ctor ***************');" << nl;
-        for (const auto& q : bases)
-        {
-            out << nl << "obj@" << getAbsolute(q, "", "Prx") << "(communicator, encoding, impl, bytes);";
-        }
-        out.dec();
-        out << nl << "end";
-        out.dec();
-        out << nl << "end";
-    }
-    */
+    // The constructor is inherited, even with multiple inheritance.
 
     if (hasExceptions)
     {

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -2516,29 +2516,27 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     out.dec();
     out << nl << "end";
 
-    //
-    // Constructor.
-    //
-    out << nl << "methods(Hidden=true)";
-    out.inc();
-    out << nl << "function obj = " << prxName << "(communicator, encoding, impl, bytes)";
-    out.inc();
-
-    if (bases.empty())
+    /*
+    if (bases.size() > 1)
     {
-        out << nl << "obj@Ice.ObjectPrx(communicator, encoding, impl, bytes);";
-    }
-    else
-    {
-        for (InterfaceList::const_iterator q = bases.begin(); q != bases.end(); ++q)
+        //
+        // Constructor.
+        //
+        out << nl << "methods(Hidden=true)";
+        out.inc();
+        out << nl << "function obj = " << prxName << "(communicator, encoding, impl, bytes)";
+        out.inc();
+        out << nl << "fprintf('******************* calling ctor ***************');" << nl;
+        for (const auto& q : bases)
         {
-            out << nl << "obj@" << getAbsolute(*q, "", "Prx") << "(communicator, encoding, impl, bytes);";
+            out << nl << "obj@" << getAbsolute(q, "", "Prx") << "(communicator, encoding, impl, bytes);";
         }
+        out.dec();
+        out << nl << "end";
+        out.dec();
+        out << nl << "end";
     }
-    out.dec();
-    out << nl << "end";
-    out.dec();
-    out << nl << "end";
+    */
 
     if (hasExceptions)
     {

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -2526,13 +2526,13 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     if (bases.empty())
     {
-        out << nl << "obj = obj@Ice.ObjectPrx(communicator, encoding, impl, bytes);";
+        out << nl << "obj@Ice.ObjectPrx(communicator, encoding, impl, bytes);";
     }
     else
     {
         for (InterfaceList::const_iterator q = bases.begin(); q != bases.end(); ++q)
         {
-            out << nl << "obj = obj@" << getAbsolute(*q, "", "Prx") << "(communicator, encoding, impl, bytes);";
+            out << nl << "obj@" << getAbsolute(*q, "", "Prx") << "(communicator, encoding, impl, bytes);";
         }
     }
     out.dec();

--- a/matlab/lib/+Ice/+SSL/ConnectionInfo.m
+++ b/matlab/lib/+Ice/+SSL/ConnectionInfo.m
@@ -18,7 +18,7 @@ classdef ConnectionInfo < Ice.ConnectionInfo
                 connectionId = '';
                 peerCertificate = '';
             end
-            obj = obj@Ice.ConnectionInfo(underlying, incoming, adapterName, connectionId);
+            obj@Ice.ConnectionInfo(underlying, incoming, adapterName, connectionId);
             obj.peerCertificate = peerCertificate;
         end
     end

--- a/matlab/lib/+Ice/+SSL/EndpointInfo.m
+++ b/matlab/lib/+Ice/+SSL/EndpointInfo.m
@@ -12,7 +12,7 @@ classdef EndpointInfo < Ice.EndpointInfo
                 timeout = 0;
                 compress = false;
             end
-            obj = obj@Ice.EndpointInfo(type, false, secure, underlying, timeout, compress);
+            obj@Ice.EndpointInfo(type, false, secure, underlying, timeout, compress);
         end
     end
 end

--- a/matlab/lib/+Ice/AlreadyRegisteredException.m
+++ b/matlab/lib/+Ice/AlreadyRegisteredException.m
@@ -30,7 +30,7 @@ classdef (Sealed) AlreadyRegisteredException < Ice.LocalException
                 superArgs = {'Ice:AlreadyRegisteredException', sprintf('Another %s is already registered with ID ''%s''.', ...
                     kindOfObject, id)};
             end
-            obj = obj@Ice.LocalException(superArgs{:});
+            obj@Ice.LocalException(superArgs{:});
             obj.kindOfObject = kindOfObject;
             obj.id = id;
         end

--- a/matlab/lib/+Ice/Communicator.m
+++ b/matlab/lib/+Ice/Communicator.m
@@ -95,7 +95,7 @@ classdef Communicator < IceInternal.WrapperObject
             if isNull(impl)
                 r = [];
             else
-                r = Ice.ObjectPrx(obj, obj.encoding, impl, []);
+                r = Ice.ObjectPrx(obj, '', obj.encoding, impl, []);
             end
         end
         function r = proxyToString(~, proxy)
@@ -140,7 +140,7 @@ classdef Communicator < IceInternal.WrapperObject
             if isNull(impl)
                 r = [];
             else
-                r = Ice.ObjectPrx(obj, obj.encoding, impl, []);
+                r = Ice.ObjectPrx(obj, '', obj.encoding, impl, []);
             end
         end
         function r = proxyToProperty(obj, proxy, prop)
@@ -217,7 +217,7 @@ classdef Communicator < IceInternal.WrapperObject
             impl = libpointer('voidPtr');
             obj.iceCall('getDefaultRouter', impl);
             if ~isNull(impl)
-                r = Ice.RouterPrx(impl, obj);
+                r = Ice.RouterPrx(obj, '', obj.encoding, impl, []);
             else
                 r = [];
             end
@@ -252,7 +252,7 @@ classdef Communicator < IceInternal.WrapperObject
             impl = libpointer('voidPtr');
             obj.iceCall('getDefaultLocator', impl);
             if ~isNull(impl)
-                r = Ice.LocatorPrx(impl, obj);
+                r = Ice.LocatorPrx(obj, '', obj.encoding, impl, []);
             else
                 r = [];
             end

--- a/matlab/lib/+Ice/Communicator.m
+++ b/matlab/lib/+Ice/Communicator.m
@@ -35,7 +35,7 @@ classdef Communicator < IceInternal.WrapperObject
             if ~isa(impl, 'lib.pointer')
                 throw(LocalException('Ice:ArgumentException', 'invalid argument'));
             end
-            obj = obj@IceInternal.WrapperObject(impl);
+            obj@IceInternal.WrapperObject(impl);
             obj.initData = initData;
 
             obj.valueFactoryManager = IceInternal.ValueFactoryManagerI();

--- a/matlab/lib/+Ice/Communicator.m
+++ b/matlab/lib/+Ice/Communicator.m
@@ -95,7 +95,7 @@ classdef Communicator < IceInternal.WrapperObject
             if isNull(impl)
                 r = [];
             else
-                r = Ice.ObjectPrx(obj, obj.encoding, impl);
+                r = Ice.ObjectPrx(obj, obj.encoding, impl, []);
             end
         end
         function r = proxyToString(~, proxy)
@@ -140,7 +140,7 @@ classdef Communicator < IceInternal.WrapperObject
             if isNull(impl)
                 r = [];
             else
-                r = Ice.ObjectPrx(obj, obj.encoding, impl);
+                r = Ice.ObjectPrx(obj, obj.encoding, impl, []);
             end
         end
         function r = proxyToProperty(obj, proxy, prop)

--- a/matlab/lib/+Ice/Connection.m
+++ b/matlab/lib/+Ice/Connection.m
@@ -28,7 +28,7 @@ classdef Connection < IceInternal.WrapperObject
             if ~isa(impl, 'lib.pointer')
                 throw(LocalException('Ice:ArgumentException', 'invalid argument'));
             end
-            obj = obj@IceInternal.WrapperObject(impl);
+            obj@IceInternal.WrapperObject(impl);
             obj.communicator = communicator;
         end
         function r = eq(obj, other)

--- a/matlab/lib/+Ice/Connection.m
+++ b/matlab/lib/+Ice/Connection.m
@@ -87,7 +87,7 @@ classdef Connection < IceInternal.WrapperObject
 
             proxy = libpointer('voidPtr');
             obj.iceCall('createProxy', id, proxy);
-            r = Ice.ObjectPrx(obj.communicator, obj.communicator.getEncoding(), proxy, []);
+            r = Ice.ObjectPrx(obj.communicator, '', obj.communicator.getEncoding(), proxy, []);
         end
         function r = getEndpoint(obj)
             % getEndpoint   Get the endpoint from which the connection was

--- a/matlab/lib/+Ice/Connection.m
+++ b/matlab/lib/+Ice/Connection.m
@@ -87,7 +87,7 @@ classdef Connection < IceInternal.WrapperObject
 
             proxy = libpointer('voidPtr');
             obj.iceCall('createProxy', id, proxy);
-            r = Ice.ObjectPrx(obj.communicator, obj.communicator.getEncoding(), proxy);
+            r = Ice.ObjectPrx(obj.communicator, obj.communicator.getEncoding(), proxy, []);
         end
         function r = getEndpoint(obj)
             % getEndpoint   Get the endpoint from which the connection was

--- a/matlab/lib/+Ice/ConnectionAbortedException.m
+++ b/matlab/lib/+Ice/ConnectionAbortedException.m
@@ -22,7 +22,7 @@ classdef ConnectionAbortedException < Ice.LocalException
                 superArgs = {errID, what};
             end
 
-            obj = obj@Ice.LocalException(superArgs{:});
+            obj@Ice.LocalException(superArgs{:});
             obj.closedByApplication = closedByApplication;
         end
     end

--- a/matlab/lib/+Ice/ConnectionClosedException.m
+++ b/matlab/lib/+Ice/ConnectionClosedException.m
@@ -22,7 +22,7 @@ classdef ConnectionClosedException < Ice.LocalException
                 superArgs = {errID, what};
             end
 
-            obj = obj@Ice.LocalException(superArgs{:});
+            obj@Ice.LocalException(superArgs{:});
             obj.closedByApplication = closedByApplication;
         end
     end

--- a/matlab/lib/+Ice/Endpoint.m
+++ b/matlab/lib/+Ice/Endpoint.m
@@ -14,7 +14,7 @@ classdef Endpoint < IceInternal.WrapperObject
             if ~isa(impl, 'lib.pointer')
                 throw(LocalException('Ice:ArgumentException', 'invalid argument'));
             end
-            obj = obj@IceInternal.WrapperObject(impl);
+            obj@IceInternal.WrapperObject(impl);
         end
         %
         % Override == operator.

--- a/matlab/lib/+Ice/Future.m
+++ b/matlab/lib/+Ice/Future.m
@@ -49,7 +49,7 @@ classdef Future < IceInternal.WrapperObject
             %
             persistent nextId;
 
-            obj = obj@IceInternal.WrapperObject(impl, type);
+            obj@IceInternal.WrapperObject(impl, type);
             obj.Operation = op;
             obj.NumOutputArguments = numOutArgs;
             obj.fetchFunc = fetchFunc;

--- a/matlab/lib/+Ice/IPConnectionInfo.m
+++ b/matlab/lib/+Ice/IPConnectionInfo.m
@@ -24,7 +24,7 @@ classdef IPConnectionInfo < Ice.ConnectionInfo
                 remoteAddress = '';
                 remotePort = 0;
             end
-            obj = obj@Ice.ConnectionInfo(underlying, incoming, adapterName, connectionId);
+            obj@Ice.ConnectionInfo(underlying, incoming, adapterName, connectionId);
             obj.localAddress = localAddress;
             obj.localPort = localPort;
             obj.remoteAddress = remoteAddress;

--- a/matlab/lib/+Ice/IPEndpointInfo.m
+++ b/matlab/lib/+Ice/IPEndpointInfo.m
@@ -20,7 +20,7 @@ classdef IPEndpointInfo < Ice.EndpointInfo
                 port = 0;
                 sourceAddress = '';
             end
-            obj = obj@Ice.EndpointInfo(type, datagram, secure, underlying, timeout, compress);
+            obj@Ice.EndpointInfo(type, datagram, secure, underlying, timeout, compress);
             obj.host = host;
             obj.port = port;
             obj.sourceAddress = sourceAddress;

--- a/matlab/lib/+Ice/ImplicitContext.m
+++ b/matlab/lib/+Ice/ImplicitContext.m
@@ -38,7 +38,7 @@ classdef ImplicitContext < IceInternal.WrapperObject
             if ~isa(impl, 'lib.pointer')
                 throw(LocalException('Ice:ArgumentException', 'invalid argument'));
             end
-            obj = obj@IceInternal.WrapperObject(impl);
+            obj@IceInternal.WrapperObject(impl);
         end
         function r = getContext(obj)
             % getContext - Get a copy of the underlying context.

--- a/matlab/lib/+Ice/InputStream.m
+++ b/matlab/lib/+Ice/InputStream.m
@@ -686,9 +686,9 @@ classdef InputStream < handle
                 % Instantiate a proxy of the requested type.
                 %
                 constructor = str2func(cls);
-                r = constructor(obj.communicator, obj.getEncoding(), [], bytes);
+                r = constructor(obj.communicator, '', obj.getEncoding(), [], bytes);
             else
-                r = Ice.ObjectPrx(obj.communicator, obj.getEncoding(), [], bytes);
+                r = Ice.ObjectPrx(obj.communicator, '', obj.getEncoding(), [], bytes);
             end
         end
         function r = readProxyOpt(obj, tag)

--- a/matlab/lib/+Ice/LocalException.m
+++ b/matlab/lib/+Ice/LocalException.m
@@ -15,7 +15,7 @@ classdef LocalException < Ice.Exception
                 % the msg.
                 superArgs = {errID, '%s', what};
             end
-            obj = obj@Ice.Exception(superArgs{:});
+            obj@Ice.Exception(superArgs{:});
         end
     end
 end

--- a/matlab/lib/+Ice/Logger.m
+++ b/matlab/lib/+Ice/Logger.m
@@ -18,7 +18,7 @@ classdef Logger < IceInternal.WrapperObject
             if ~isa(impl, 'lib.pointer')
                 throw(LocalException('Ice:ArgumentException', 'invalid argument'));
             end
-            obj = obj@IceInternal.WrapperObject(impl);
+            obj@IceInternal.WrapperObject(impl);
         end
         function print(obj, message)
             % print - Print a message. The message is printed literally, without

--- a/matlab/lib/+Ice/MarshalException.m
+++ b/matlab/lib/+Ice/MarshalException.m
@@ -14,7 +14,7 @@ classdef (Sealed) MarshalException < Ice.ProtocolException
                 assert(nargin == 1, 'Invalid number of arguments');
                 superArgs = {'Ice:MarshalException', what};
             end
-            obj = obj@Ice.ProtocolException(superArgs{:});
+            obj@Ice.ProtocolException(superArgs{:});
         end
     end
 end

--- a/matlab/lib/+Ice/NotRegisteredException.m
+++ b/matlab/lib/+Ice/NotRegisteredException.m
@@ -32,7 +32,7 @@ classdef NotRegisteredException < Ice.LocalException
                 superArgs = {'Ice:NotRegisteredException', sprintf('No %s is registered with ID ''%s''.', ...
                     kindOfObject, id)};
             end
-            obj = obj@Ice.LocalException(superArgs{:});
+            obj@Ice.LocalException(superArgs{:});
             obj.kindOfObject = kindOfObject;
             obj.id = id;
         end

--- a/matlab/lib/+Ice/ObjectPrx.m
+++ b/matlab/lib/+Ice/ObjectPrx.m
@@ -111,20 +111,34 @@ classdef ObjectPrx < IceInternal.WrapperObject
     % Copyright (c) ZeroC, Inc. All rights reserved.
 
     methods
-        function obj = ObjectPrx(communicator, encoding, impl, bytes)
-            if nargin == 0 % default constructor
+        function obj = ObjectPrx(communicator, proxyString, encoding, impl, bytes)
+            if nargin == 0 % default constructor, typically called with multiple inheritance
                 superArgs = {};
+            elseif nargin == 2
+                encoding = communicator.getEncoding();
+                impl = libpointer('voidPtr');
+                communicator.iceCall('stringToProxy', proxyString, impl);
+                assert(~isNull(impl), 'Invalid proxy string');
+                bytes = [];
+                superArgs = {impl, 'Ice_ObjectPrx'};
             else
-                assert(nargin == 4, 'Invalid number of arguments');
+                assert(nargin == 5, 'Invalid number of arguments');
+                assert(isempty(proxyString), 'proxyString must be empty');
+                assert(~isempty(encoding), 'encoding must be non-empty');
                 superArgs = {impl, 'Ice_ObjectPrx'};
             end
             obj@IceInternal.WrapperObject(superArgs{:});
 
             if nargin > 0
+                if isempty(bytes)
+                    assert(~isempty(impl), 'impl must be non-empty when bytes is empty');
+                end
+
                 obj.communicator = communicator;
                 obj.encoding = encoding;
                 obj.bytes = bytes;
                 if ~isempty(impl)
+                    assert(~isNull(impl), 'Invalid null proxy');
                     obj.isTwoway = obj.iceCallWithResult('ice_isTwoway');
                 end
             end
@@ -601,7 +615,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
             if isNull(v)
                 r = [];
             else
-                r = Ice.RouterPrx(obj.communicator, obj.encoding, v, []);
+                r = Ice.RouterPrx(obj.communicator, '', obj.encoding, v, []);
             end
         end
 
@@ -635,7 +649,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
             if isNull(v)
                 r = [];
             else
-                r = Ice.LocatorPrx(obj.communicator, obj.encoding, v, []);
+                r = Ice.LocatorPrx(obj.communicator, '', obj.encoding, v, []);
             end
         end
 
@@ -1197,11 +1211,9 @@ classdef ObjectPrx < IceInternal.WrapperObject
                     if hasFacet
                         p = p.ice_facet(facet);
                     end
-                    if isa(p, cls)
-                        r = p;
-                    elseif p.ice_isA(id, context{:})
+                    if p.ice_isA(id, context{:})
                         constructor = str2func(cls);
-                        r = constructor(p.communicator, p.encoding, p.clone_(), []);
+                        r = constructor(p.communicator, '', p.encoding, p.clone_(), []);
                     else
                         r = [];
                     end
@@ -1234,7 +1246,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
                     r = p;
                 else
                     constructor = str2func(cls);
-                    r = constructor(p.communicator, p.encoding, p.clone_(), []);
+                    r = constructor(p.communicator, '', p.encoding, p.clone_(), []);
                 end
             else
                 r = p;
@@ -1285,7 +1297,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
                 %
                 % We don't retain the proxy's existing type for a couple of factory functions.
                 %
-                r = Ice.ObjectPrx(obj.communicator, obj.encoding, newImpl, []);
+                r = Ice.ObjectPrx(obj.communicator, '', obj.encoding, newImpl, []);
             end
         end
 
@@ -1294,7 +1306,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
             % Return a new instance of this proxy type.
             %
             constructor = str2func(class(obj)); % Obtain the constructor for this class
-            r = constructor(obj.communicator, obj.encoding, impl, []); % Call the constructor
+            r = constructor(obj.communicator, '', obj.encoding, impl, []); % Call the constructor
         end
 
         function r = clone_(obj)

--- a/matlab/lib/+Ice/ObjectPrx.m
+++ b/matlab/lib/+Ice/ObjectPrx.m
@@ -112,7 +112,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
 
     methods
         function obj = ObjectPrx(communicator, encoding, impl, bytes)
-            obj = obj@IceInternal.WrapperObject(impl, 'Ice_ObjectPrx');
+            obj@IceInternal.WrapperObject(impl, 'Ice_ObjectPrx');
             obj.communicator = communicator;
             obj.encoding = encoding;
             if nargin == 4

--- a/matlab/lib/+Ice/ObjectPrx.m
+++ b/matlab/lib/+Ice/ObjectPrx.m
@@ -112,16 +112,24 @@ classdef ObjectPrx < IceInternal.WrapperObject
 
     methods
         function obj = ObjectPrx(communicator, encoding, impl, bytes)
-            obj@IceInternal.WrapperObject(impl, 'Ice_ObjectPrx');
-            obj.communicator = communicator;
-            obj.encoding = encoding;
-            if nargin == 4
-                obj.bytes = bytes;
+            if nargin == 0 % default constructor
+                superArgs = {};
+            else
+                assert(nargin == 4, 'Invalid number of arguments');
+                superArgs = {impl, 'Ice_ObjectPrx'};
             end
+            obj@IceInternal.WrapperObject(superArgs{:});
 
-            if ~isempty(impl)
-                obj.isTwoway = obj.iceCallWithResult('ice_isTwoway');
+            if nargin > 0
+                obj.communicator = communicator;
+                obj.encoding = encoding;
+                obj.bytes = bytes;
+                if ~isempty(impl)
+                    obj.isTwoway = obj.iceCallWithResult('ice_isTwoway');
+                end
             end
+            % else, we leave the properties unset as they may be already set by another call to the same constructor
+            % when using multiple inheritance.
         end
 
         function delete(obj)
@@ -1277,7 +1285,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
                 %
                 % We don't retain the proxy's existing type for a couple of factory functions.
                 %
-                r = Ice.ObjectPrx(obj.communicator, obj.encoding, newImpl);
+                r = Ice.ObjectPrx(obj.communicator, obj.encoding, newImpl, []);
             end
         end
 
@@ -1305,6 +1313,6 @@ classdef ObjectPrx < IceInternal.WrapperObject
         encoding
         isTwoway
         cachedInputStream % Only used for synchronous invocations
-        bytes
+        bytes % The marshaled form of the proxy
     end
 end

--- a/matlab/lib/+Ice/OpaqueEndpointInfo.m
+++ b/matlab/lib/+Ice/OpaqueEndpointInfo.m
@@ -12,7 +12,7 @@ classdef OpaqueEndpointInfo < Ice.EndpointInfo
 
     methods
         function obj = OpaqueEndpointInfo(type, underlying, timeout, compress, rawEncoding, rawBytes)
-            obj = obj@Ice.EndpointInfo(type, false, false, underlying, timeout, compress);
+            obj@Ice.EndpointInfo(type, false, false, underlying, timeout, compress);
             obj.rawEncoding = rawEncoding;
             obj.rawBytes = rawBytes;
         end

--- a/matlab/lib/+Ice/Properties.m
+++ b/matlab/lib/+Ice/Properties.m
@@ -35,7 +35,7 @@ classdef Properties < IceInternal.WrapperObject
             if ~isa(impl, 'lib.pointer')
                 throw(LocalException('Ice:ArgumentException', 'invalid argument'));
             end
-            obj = obj@IceInternal.WrapperObject(impl);
+            obj@IceInternal.WrapperObject(impl);
         end
         function r = getProperty(obj, key)
             % getProperty - Get a property by key. If the property is not set,

--- a/matlab/lib/+Ice/RequestFailedException.m
+++ b/matlab/lib/+Ice/RequestFailedException.m
@@ -32,7 +32,7 @@ classdef RequestFailedException < Ice.LocalException
                 superArgs = {errID, what};
             end
 
-            obj = obj@Ice.LocalException(superArgs{:});
+            obj@Ice.LocalException(superArgs{:});
             obj.id = id;
             obj.facet = facet;
             obj.operation = operation;

--- a/matlab/lib/+Ice/TCPConnectionInfo.m
+++ b/matlab/lib/+Ice/TCPConnectionInfo.m
@@ -24,7 +24,7 @@ classdef TCPConnectionInfo < Ice.IPConnectionInfo
                 rcvSize = 0;
                 sndSize = 0;
             end
-            obj = obj@Ice.IPConnectionInfo(underlying, incoming, adapterName, connectionId, localAddress, ...
+            obj@Ice.IPConnectionInfo(underlying, incoming, adapterName, connectionId, localAddress, ...
                                            localPort, remoteAddress, remotePort);
             obj.rcvSize = rcvSize;
             obj.sndSize = sndSize;

--- a/matlab/lib/+Ice/TCPEndpointInfo.m
+++ b/matlab/lib/+Ice/TCPEndpointInfo.m
@@ -15,7 +15,7 @@ classdef TCPEndpointInfo < Ice.IPEndpointInfo
                 port = 0;
                 sourceAddress = '';
             end
-            obj = obj@Ice.IPEndpointInfo(type, false, secure, underlying, timeout, compress, host, port, sourceAddress);
+            obj@Ice.IPEndpointInfo(type, false, secure, underlying, timeout, compress, host, port, sourceAddress);
         end
     end
 end

--- a/matlab/lib/+Ice/TwowayOnlyException.m
+++ b/matlab/lib/+Ice/TwowayOnlyException.m
@@ -17,7 +17,7 @@ classdef (Sealed) TwowayOnlyException < Ice.LocalException
                 superArgs = {'Ice:TwowayOnlyException', sprintf('operation ''%s'' can only be invoked with a twoway proxy',...
                     operation)};
             end
-            obj = obj@Ice.LocalException(superArgs{:});
+            obj@Ice.LocalException(superArgs{:});
         end
     end
 end

--- a/matlab/lib/+Ice/UDPConnectionInfo.m
+++ b/matlab/lib/+Ice/UDPConnectionInfo.m
@@ -28,7 +28,7 @@ classdef UDPConnectionInfo < Ice.IPConnectionInfo
                 rcvSize = 0;
                 sndSize = 0;
             end
-            obj = obj@Ice.IPConnectionInfo(underlying, incoming, adapterName, connectionId, localAddress, ...
+            obj@Ice.IPConnectionInfo(underlying, incoming, adapterName, connectionId, localAddress, ...
                                            localPort, remoteAddress, remotePort);
             obj.mcastAddress = mcastAddress;
             obj.mcastPort = mcastPort;

--- a/matlab/lib/+Ice/UDPEndpointInfo.m
+++ b/matlab/lib/+Ice/UDPEndpointInfo.m
@@ -22,7 +22,7 @@ classdef UDPEndpointInfo < Ice.IPEndpointInfo
                 mcastInterface = '';
                 mcastTtl = 0;
             end
-            obj = obj@Ice.IPEndpointInfo(type, true, false, underlying, timeout, compress, host, port, sourceAddress);
+            obj@Ice.IPEndpointInfo(type, true, false, underlying, timeout, compress, host, port, sourceAddress);
             obj.mcastInterface = mcastInterface;
             obj.mcastTtl = mcastTtl;
         end

--- a/matlab/lib/+Ice/UnknownUserException.m
+++ b/matlab/lib/+Ice/UnknownUserException.m
@@ -21,7 +21,7 @@ classdef (Sealed) UnknownUserException < Ice.UnknownException
                 assert(nargin == 2, 'Invalid number of arguments');
                 superArgs = {errID, what}; % we ignore typeID in this case
             end
-            obj = obj@Ice.UnknownException(superArgs{:});
+            obj@Ice.UnknownException(superArgs{:});
         end
     end
 end

--- a/matlab/lib/+Ice/WSConnectionInfo.m
+++ b/matlab/lib/+Ice/WSConnectionInfo.m
@@ -17,7 +17,7 @@ classdef WSConnectionInfo < Ice.ConnectionInfo
                 connectionId = '';
                 headers = containers.Map('KeyType', 'char', 'ValueType', 'char');
             end
-            obj = obj@Ice.ConnectionInfo(underlying, incoming, adapterName, connectionId);
+            obj@Ice.ConnectionInfo(underlying, incoming, adapterName, connectionId);
             obj.headers = headers;
         end
     end

--- a/matlab/lib/+Ice/WSEndpointInfo.m
+++ b/matlab/lib/+Ice/WSEndpointInfo.m
@@ -16,7 +16,7 @@ classdef WSEndpointInfo < Ice.EndpointInfo
                 compress = false;
                 resource = '';
             end
-            obj = obj@Ice.EndpointInfo(type, false, secure, underlying, timeout, compress);
+            obj@Ice.EndpointInfo(type, false, secure, underlying, timeout, compress);
             obj.resource = resource;
         end
     end

--- a/matlab/lib/+IceInternal/EncapsDecoder10.m
+++ b/matlab/lib/+IceInternal/EncapsDecoder10.m
@@ -5,7 +5,7 @@
 classdef EncapsDecoder10 < IceInternal.EncapsDecoder
     methods
         function obj = EncapsDecoder10(is, encaps, sliceValues, valueFactoryManager, classResolver, classGraphDepthMax)
-            obj = obj@IceInternal.EncapsDecoder(is, encaps, sliceValues, valueFactoryManager, classResolver, ...
+            obj@IceInternal.EncapsDecoder(is, encaps, sliceValues, valueFactoryManager, classResolver, ...
                                                 classGraphDepthMax);
             obj.sliceType = IceInternal.SliceType.NoSlice;
         end

--- a/matlab/lib/+IceInternal/EncapsDecoder11.m
+++ b/matlab/lib/+IceInternal/EncapsDecoder11.m
@@ -5,7 +5,7 @@
 classdef EncapsDecoder11 < IceInternal.EncapsDecoder
     methods
         function obj = EncapsDecoder11(is, encaps, sliceValues, valueFactoryManager, classResolver, classGraphDepthMax)
-            obj = obj@IceInternal.EncapsDecoder(is, encaps, sliceValues, valueFactoryManager, classResolver, ...
+            obj@IceInternal.EncapsDecoder(is, encaps, sliceValues, valueFactoryManager, classResolver, ...
                                                 classGraphDepthMax);
             obj.current = [];
             obj.valueIdIndex = 1;

--- a/matlab/lib/+IceInternal/EncapsEncoder10.m
+++ b/matlab/lib/+IceInternal/EncapsEncoder10.m
@@ -5,7 +5,7 @@
 classdef EncapsEncoder10 < IceInternal.EncapsEncoder
     methods
         function obj = EncapsEncoder10(os, encaps)
-            obj = obj@IceInternal.EncapsEncoder(os, encaps);
+            obj@IceInternal.EncapsEncoder(os, encaps);
             obj.sliceType = IceInternal.SliceType.NoSlice;
             obj.valueIdIndex = 0;
             obj.toBeMarshaledMap = containers.Map('KeyType', 'int32', 'ValueType', 'any');

--- a/matlab/lib/+IceInternal/EncapsEncoder11.m
+++ b/matlab/lib/+IceInternal/EncapsEncoder11.m
@@ -5,7 +5,7 @@
 classdef EncapsEncoder11 < IceInternal.EncapsEncoder
     methods
         function obj = EncapsEncoder11(os, encaps)
-            obj = obj@IceInternal.EncapsEncoder(os, encaps);
+            obj@IceInternal.EncapsEncoder(os, encaps);
             obj.current = [];
             obj.valueIdIndex = 1;
             obj.marshaledMap = containers.Map('KeyType', 'int32', 'ValueType', 'int32');

--- a/matlab/lib/+IceInternal/WrapperObject.m
+++ b/matlab/lib/+IceInternal/WrapperObject.m
@@ -5,15 +5,17 @@
 classdef (Abstract) WrapperObject < handle
     methods
         function obj = WrapperObject(impl, type)
-            %
-            % If no type was supplied, we convert the class name into the prefix that we'll use for invoking
-            % external C functions.
-            %
-            if nargin == 1
-                type = strrep(class(obj), '.', '_'); % E.g., Ice.Communicator -> Ice_Communicator
+            if nargin > 0 % don't do anything for the default constructor
+                %
+                % If no type was supplied, we convert the class name into the prefix that we'll use for invoking
+                % external C functions.
+                %
+                if nargin == 1
+                    type = strrep(class(obj), '.', '_'); % E.g., Ice.Communicator -> Ice_Communicator
+                end
+                obj.impl_ = impl;
+                obj.type_ = type;
             end
-            obj.impl_ = impl;
-            obj.type_ = type;
         end
     end
     methods(Hidden)

--- a/matlab/test/Ice/ami/AllTests.m
+++ b/matlab/test/Ice/ami/AllTests.m
@@ -10,16 +10,10 @@ classdef AllTests
             communicator = helper.communicator();
 
             sref = ['test:', helper.getTestEndpoint()];
-            obj = communicator.stringToProxy(sref);
-            assert(~isempty(obj));
-
-            p = TestIntfPrx.uncheckedCast(obj);
+            p = TestIntfPrx(communicator, sref);
 
             sref = ['testController:', helper.getTestEndpoint(1)];
-            obj = communicator.stringToProxy(sref);
-            assert(~isempty(obj));
-
-            testController = TestIntfControllerPrx.uncheckedCast(obj);
+            testController = TestIntfControllerPrx(communicator, sref);
 
             fprintf('testing begin/end invocation... ');
 

--- a/matlab/test/Ice/binding/AllTests.m
+++ b/matlab/test/Ice/binding/AllTests.m
@@ -33,7 +33,7 @@ classdef AllTests
             communicator = helper.communicator();
 
             ref = ['communicator:', helper.getTestEndpoint()];
-            rcom = RemoteCommunicatorPrx.uncheckedCast(communicator.stringToProxy(ref));
+            rcom = RemoteCommunicatorPrx(communicator, ref);
 
             fprintf('testing binding with single endpoint... ');
 
@@ -48,9 +48,7 @@ classdef AllTests
 
             rcom.deactivateObjectAdapter(adapter);
 
-            test3 = TestIntfPrx.uncheckedCast(test1);
-            assert(test3.ice_getConnection() == test1.ice_getConnection());
-            assert(test3.ice_getConnection() == test2.ice_getConnection());
+            test3 = test1;
 
             try
                 test3.ice_ping();
@@ -472,7 +470,7 @@ classdef AllTests
 
             rcom.deactivateObjectAdapter(adapter);
 
-            test3 = TestIntfPrx.uncheckedCast(test1);
+            test3 = test1;
             try
                 assert(test3.ice_getConnection() == test1.ice_getConnection());
                 assert(false);

--- a/matlab/test/Ice/enums/AllTests.m
+++ b/matlab/test/Ice/enums/AllTests.m
@@ -10,10 +10,7 @@ classdef AllTests
             communicator = helper.communicator();
 
             ref = ['test:', helper.getTestEndpoint()];
-            obj = communicator.stringToProxy(ref);
-            assert(~isempty(obj));
-            proxy = TestIntfPrx.checkedCast(obj);
-            assert(~isempty(proxy));
+            proxy = TestIntfPrx(communicator, ref);
 
             fprintf('testing enum values... ');
 

--- a/matlab/test/Ice/exceptions/AllTests.m
+++ b/matlab/test/Ice/exceptions/AllTests.m
@@ -233,8 +233,7 @@ classdef AllTests
                 end
 
                 try
-                    thrower2 = ThrowerPrx.uncheckedCast(...
-                        communicator.stringToProxy(['thrower:', helper.getTestEndpoint(1)]));
+                    thrower2 = ThrowerPrx(communicator, ['thrower:', helper.getTestEndpoint(1)]);
                     try
                         thrower2.throwMemoryLimitException(zeros(1, 2 * 1024 * 1024)); % 2MB (no limits)
                     catch ex
@@ -242,8 +241,7 @@ classdef AllTests
                             rethrow(ex);
                         end
                     end
-                    thrower3 = ThrowerPrx.uncheckedCast(...
-                        communicator.stringToProxy(['thrower:', helper.getTestEndpoint(2)]));
+                    thrower3 = ThrowerPrx(communicator, ['thrower:', helper.getTestEndpoint(2)]);
                     try
                         thrower3.throwMemoryLimitException(zeros(1, 1024)); % 1KB limit
                         assert(false);

--- a/matlab/test/Ice/info/AllTests.m
+++ b/matlab/test/Ice/info/AllTests.m
@@ -54,8 +54,7 @@ classdef AllTests
 
             fprintf('ok\n');
 
-            base = communicator.stringToProxy(['test:', helper.getTestEndpoint(), ':', helper.getTestEndpoint('udp')]);
-            testIntf = TestIntfPrx.checkedCast(base);
+            testIntf = TestIntfPrx(communicator, ['test:', helper.getTestEndpoint(), ':', helper.getTestEndpoint('udp')]);
 
             endpointPort = helper.getTestPort();
 

--- a/matlab/test/Ice/info/AllTests.m
+++ b/matlab/test/Ice/info/AllTests.m
@@ -61,7 +61,7 @@ classdef AllTests
             defaultHost = communicator.getProperties().getProperty('Ice.Default.Host');
             fprintf('test connection endpoint information... ');
 
-            info = base.ice_getConnection().getEndpoint().getInfo();
+            info = testIntf.ice_getConnection().getEndpoint().getInfo();
             tcpinfo = getTCPEndpointInfo(info);
             assert(tcpinfo.port == endpointPort);
             assert(~tcpinfo.compress);
@@ -73,7 +73,7 @@ classdef AllTests
             port = str2num(ctx('port'));
             assert(port > 0);
 
-            info = base.ice_datagram().ice_getConnection().getEndpoint().getInfo();
+            info = testIntf.ice_datagram().ice_getConnection().getEndpoint().getInfo();
             udp = info;
             assert(udp.port == endpointPort);
             assert(strcmp(udp.host, defaultHost));
@@ -82,7 +82,7 @@ classdef AllTests
 
             fprintf('testing connection information... ');
 
-            connection = base.ice_getConnection();
+            connection = testIntf.ice_getConnection();
             connection.setBufferSize(1024, 2048);
 
             info = getTCPConnectionInfo(connection.getInfo());
@@ -105,8 +105,8 @@ classdef AllTests
             assert(strcmp(ctx('remotePort'), num2str(info.localPort)));
             assert(strcmp(ctx('localPort'), num2str(info.remotePort)));
 
-            type = base.ice_getConnection().type();
-            if strcmp(base, 'ws') || strcmp(base, 'wss')
+            type = testIntf.ice_getConnection().type();
+            if strcmp(testIntf, 'ws') || strcmp(testIntf, 'wss')
                 headers = connection.getInfo().headers;
                 assert(strcmp(headers('Upgrade'), 'websocket'));
                 assert(strcmp(headers('Connection'), 'Upgrade'));
@@ -120,7 +120,7 @@ classdef AllTests
                 assert(ctx.isKey('ws.Sec-WebSocket-Key'));
             end
 
-            connection = base.ice_datagram().ice_getConnection();
+            connection = testIntf.ice_datagram().ice_getConnection();
             connection.setBufferSize(2048, 1024);
 
             udpinfo = connection.getInfo();

--- a/matlab/test/Ice/inheritance/Test.ice
+++ b/matlab/test/Ice/inheritance/Test.ice
@@ -4,51 +4,43 @@
 
 #pragma once
 
+module Test::MA
+{
+    interface IA
+    {
+        IA* iaop(IA* p);
+    }
+}
+
+module Test::MB
+{
+    interface IB1 extends MA::IA
+    {
+        IB1* ib1op(IB1* p);
+    }
+
+    interface IB2 extends MA::IA
+    {
+        IB2* ib2op(IB2* p);
+    }
+}
+
+module Test::MA
+{
+    interface IC extends MB::IB1, MB::IB2
+    {
+        IC* icop(IC* p);
+    }
+}
+
 module Test
 {
-
-module MA
-{
-
-interface IA
-{
-    IA* iaop(IA* p);
-}
-
-}
-
-module MB
-{
-
-interface IB1 extends MA::IA
-{
-    IB1* ib1op(IB1* p);
-}
-
-interface IB2 extends MA::IA
-{
-    IB2* ib2op(IB2* p);
-}
-
-}
-
-module MA
-{
-
-interface IC extends MB::IB1, MB::IB2
-{
-    IC* icop(IC* p);
-}
-
-}
-
-interface Initial
-{
-    void shutdown();
-    MA::IA* iaop();
-    MB::IB1* ib1op();
-    MB::IB2* ib2op();
-    MA::IC* icop();
-}
-
+    interface Initial
+    {
+        void shutdown();
+        MA::IA* iaop();
+        MB::IB1* ib1op();
+        MB::IB2* ib2op();
+        MA::IC* icop();
+    }
 }

--- a/matlab/test/Ice/objects/AllTests.m
+++ b/matlab/test/Ice/objects/AllTests.m
@@ -9,8 +9,7 @@ classdef AllTests
 
             communicator = helper.communicator();
             ref = ['initial:', helper.getTestEndpoint()];
-            base = communicator.stringToProxy(ref);
-            initial = InitialPrx.checkedCast(base);
+            initial = InitialPrx(communicator, ref);
 
             fprintf('getting B1... ');
             b1 = initial.getB1();
@@ -215,10 +214,7 @@ classdef AllTests
 
             fprintf('testing UnexpectedObjectException... ');
             ref = ['uoet:', helper.getTestEndpoint()];
-            base = communicator.stringToProxy(ref);
-            assert(~isempty(base));
-            uoet = UnexpectedObjectExceptionTestPrx.uncheckedCast(base);
-            assert(~isempty(uoet));
+            uoet = UnexpectedObjectExceptionTestPrx(communicator, ref);
             try
                 uoet.op();
                 assert(false);
@@ -276,7 +272,7 @@ classdef AllTests
             assert(strcmp(f12.name, 'F12'));
 
             ref = ['F21:', helper.getTestEndpoint()];
-            [f21, f22] = initial.opF2(F2Prx.uncheckedCast(communicator.stringToProxy(ref)));
+            [f21, f22] = initial.opF2(F2Prx(communicator, ref));
             assert(strcmp(f21.ice_getIdentity().name, 'F21'));
             f21.op();
             assert(strcmp(f22.ice_getIdentity().name, 'F22'));

--- a/matlab/test/Ice/objects/EI.m
+++ b/matlab/test/Ice/objects/EI.m
@@ -5,7 +5,7 @@
 classdef EI < Test.E
     methods
         function obj = EI()
-            obj = obj@Test.E(1, 'hello');
+            obj@Test.E(1, 'hello');
         end
 
         function r = checkValues(obj)

--- a/matlab/test/Ice/objects/FI.m
+++ b/matlab/test/Ice/objects/FI.m
@@ -8,7 +8,7 @@ classdef FI < Test.F
             if nargin == 0
                 e = [];
             end
-            obj = obj@Test.F(e, e);
+            obj@Test.F(e, e);
         end
 
         function r = checkValues(obj)

--- a/matlab/test/Ice/operations/AllTests.m
+++ b/matlab/test/Ice/operations/AllTests.m
@@ -10,8 +10,7 @@ classdef AllTests
 
             communicator = helper.communicator();
             ref = ['test:', helper.getTestEndpoint()];
-            base = communicator.stringToProxy(ref);
-            cl = MyClassPrx.checkedCast(base);
+            cl = MyClassPrx(communicator, ref);
             derived = MyDerivedClassPrx.checkedCast(cl);
 
             fprintf('testing twoway operations... ');

--- a/matlab/test/Ice/operations/BatchOneways.m
+++ b/matlab/test/Ice/operations/BatchOneways.m
@@ -73,10 +73,11 @@ classdef BatchOneways
 
             p.ice_ping();
             if ~isempty(p.ice_getConnection()) && isempty(properties.getProperty('Ice.Override.Compress'))
-                prx = p.ice_getConnection().createProxy(p.ice_getIdentity()).ice_batchOneway();
+                prx = MyClassPrx.uncheckedCast(...
+                    p.ice_getConnection().createProxy(p.ice_getIdentity()).ice_batchOneway());
 
-                batchC1 = MyClassPrx.uncheckedCast(prx.ice_compress(false));
-                batchC2 = MyClassPrx.uncheckedCast(prx.ice_compress(true));
+                batchC1 = prx.ice_compress(false);
+                batchC2 = prx.ice_compress(true);
                 batchC3 = MyClassPrx.uncheckedCast(prx.ice_identity(identity));
 
                 batchC1.opByteSOneway(bs1);

--- a/matlab/test/Ice/operations/Twoways.m
+++ b/matlab/test/Ice/operations/Twoways.m
@@ -1289,7 +1289,7 @@ classdef Twoways
             assert(p.ice_getContext().Count == 0);
             assert(isequal(r, ctx));
 
-            p2 = MyClassPrx.checkedCast(p.ice_context(ctx));
+            p2 = p.ice_context(ctx);
             assert(isequal(p2.ice_getContext(), ctx));
             r = p2.opContext();
             assert(isequal(r, ctx));
@@ -1311,7 +1311,7 @@ classdef Twoways
                 ctx('two') = 'TWO';
                 ctx('three') = 'THREE';
 
-                p3 = MyClassPrx.uncheckedCast(ic.stringToProxy(['test:', helper.getTestEndpoint()]));
+                p3 = MyClassPrx(ic, ['test:', helper.getTestEndpoint()]);
 
                 ic.getImplicitContext().setContext(ctx);
                 assert(isequal(ic.getImplicitContext().getContext(), ctx));

--- a/matlab/test/Ice/operations/TwowaysAMI.m
+++ b/matlab/test/Ice/operations/TwowaysAMI.m
@@ -1130,7 +1130,7 @@ classdef TwowaysAMI
             assert(p.ice_getContext().Count == 0);
             assert(isequal(r, ctx));
 
-            p2 = MyClassPrx.checkedCast(p.ice_context(ctx));
+            p2 = p.ice_context(ctx);
             assert(isequal(p2.ice_getContext(), ctx));
             r = p2.opContext();
             assert(isequal(r, ctx));
@@ -1152,7 +1152,7 @@ classdef TwowaysAMI
                 ctx('two') = 'TWO';
                 ctx('three') = 'THREE';
 
-                p3 = MyClassPrx.uncheckedCast(ic.stringToProxy(['test:', helper.getTestEndpoint()]));
+                p3 = MyClassPrx(ic, ['test:', helper.getTestEndpoint()]);
 
                 ic.getImplicitContext().setContext(ctx);
                 assert(isequal(ic.getImplicitContext().getContext(), ctx));

--- a/matlab/test/Ice/optional/AllTests.m
+++ b/matlab/test/Ice/optional/AllTests.m
@@ -10,8 +10,7 @@ classdef AllTests
             communicator = helper.communicator();
 
             ref = ['initial:', helper.getTestEndpoint()];
-            base = communicator.stringToProxy(ref);
-            initial = InitialPrx.checkedCast(base);
+            initial = InitialPrx(communicator, ref);
 
             fprintf('testing optional data members... ');
 
@@ -67,12 +66,12 @@ classdef AllTests
             ivsd = containers.Map('KeyType', 'int32', 'ValueType', 'any');
             ivsd(5) = vs;
             imipd = containers.Map('KeyType', 'int32', 'ValueType', 'any');
-            imipd(5) = MyInterfacePrx.uncheckedCast(communicator.stringToProxy('test'));
+            imipd(5) = MyInterfacePrx(communicator, 'test');
             mo1 = MultiOptional(15, true, 19, 78, 99, 5.5, 1.0, 'test', MyEnum.MyEnumMember, ...
-                                     MyInterfacePrx.uncheckedCast(communicator.stringToProxy('test')), ...
+                                     MyInterfacePrx(communicator, 'test'), ...
                                      [5], {'test', 'test2'}, iid, sid, fs, vs, [1], ...
                                      [MyEnum.MyEnumMember, MyEnum.MyEnumMember], ...
-                                     [ fs ], [ vs ], { MyInterfacePrx.uncheckedCast(communicator.stringToProxy('test')) }, ...
+                                     [ fs ], [ vs ], { MyInterfacePrx(communicator, 'test') }, ...
                                      ied, ifsd, ivsd, imipd, [false, true, false], []);
 
             assert(mo1.a == 15);

--- a/matlab/test/Ice/optional/AllTests.m
+++ b/matlab/test/Ice/optional/AllTests.m
@@ -290,7 +290,7 @@ classdef AllTests
             assert(r.gg2Opt.a == 20);
             assert(strcmp(r.gg1.a, 'gg1'));
 
-            initial2 = Initial2Prx.uncheckedCast(base);
+            initial2 = Initial2Prx.uncheckedCast(initial);
             initial2.opVoid(15, 'test');
 
             fprintf('ok\n');
@@ -384,7 +384,7 @@ classdef AllTests
 
                 fprintf('testing operations with unknown optionals... ');
 
-                initial2 = Initial2Prx.uncheckedCast(base);
+                initial2 = Initial2Prx.uncheckedCast(initial);
                 ovs = VarStruct('test');
                 initial2.opClassAndUnknownOptional(A(), ovs);
 

--- a/matlab/test/Ice/proxy/AllTests.m
+++ b/matlab/test/Ice/proxy/AllTests.m
@@ -313,22 +313,22 @@ classdef AllTests
             b1 = b1.ice_invocationTimeout(1234);
             b1 = b1.ice_encodingVersion(Ice.EncodingVersion(1, 0));
 
-            router = communicator.stringToProxy('router');
+            router = Ice.RouterPrx(communicator, 'router');
             router = router.ice_connectionCached(true);
             router = router.ice_preferSecure(true);
             router = router.ice_endpointSelection(Ice.EndpointSelectionType.Random);
             router = router.ice_locatorCacheTimeout(200);
             router = router.ice_invocationTimeout(1500);
 
-            locator = communicator.stringToProxy('locator');
+            locator = Ice.LocatorPrx(communicator, 'locator');
             locator = locator.ice_connectionCached(false);
             locator = locator.ice_preferSecure(true);
             locator = locator.ice_endpointSelection(Ice.EndpointSelectionType.Random);
             locator = locator.ice_locatorCacheTimeout(300);
             locator = locator.ice_invocationTimeout(1500);
 
-            locator = locator.ice_router(Ice.RouterPrx.uncheckedCast(router));
-            b1 = b1.ice_locator(Ice.LocatorPrx.uncheckedCast(locator));
+            locator = locator.ice_router(router);
+            b1 = b1.ice_locator(locator);
 
             proxyProps = communicator.proxyToProperty(b1, 'Test');
             assert(length(proxyProps) == 21);
@@ -513,8 +513,8 @@ classdef AllTests
             assert(compObj.ice_compress(true).ice_getCompress() == true);
             assert(compObj.ice_compress(false).ice_getCompress() == false);
 
-            loc1 = Ice.LocatorPrx.uncheckedCast(communicator.stringToProxy('loc1:default -p 10000'));
-            loc2 = Ice.LocatorPrx.uncheckedCast(communicator.stringToProxy('loc2:default -p 10000'));
+            loc1 = Ice.LocatorPrx(communicator, 'loc1:default -p 10000');
+            loc2 = Ice.LocatorPrx(communicator, 'loc2:default -p 10000');
             assert(compObj.ice_locator([]) == compObj.ice_locator([]));
             assert(compObj.ice_locator(loc1) == compObj.ice_locator(loc1));
             assert(compObj.ice_locator(loc1) ~= compObj.ice_locator([]));
@@ -525,8 +525,8 @@ classdef AllTests
             %assert(compObj.ice_locator(loc1) < compObj.ice_locator(loc2));
             %assert(~(compObj.ice_locator(loc2) < compObj.ice_locator(loc1)));
 
-            rtr1 = Ice.RouterPrx.uncheckedCast(communicator.stringToProxy('rtr1:default -p 10000'));
-            rtr2 = Ice.RouterPrx.uncheckedCast(communicator.stringToProxy('rtr2:default -p 10000'));
+            rtr1 = Ice.RouterPrx(communicator, 'rtr1:default -p 10000');
+            rtr2 = Ice.RouterPrx(communicator, 'rtr2:default -p 10000');
             assert(compObj.ice_router([]) == compObj.ice_router([]));
             assert(compObj.ice_router(rtr1) == compObj.ice_router(rtr1));
             assert(compObj.ice_router(rtr1) ~= compObj.ice_router([]));
@@ -698,7 +698,7 @@ classdef AllTests
 
             fprintf('testing encoding versioning... ');
             ref20 = 'test -e 2.0:default -p 12010';
-            cl20 = MyClassPrx.uncheckedCast(communicator.stringToProxy(ref20));
+            cl20 = MyClassPrx(communicator, ref20);
             try
                 cl20.ice_ping();
                 assert(false);
@@ -708,7 +708,7 @@ classdef AllTests
             end
 
             ref10 = 'test -e 1.0:default -p 12010';
-            cl10 = MyClassPrx.uncheckedCast(communicator.stringToProxy(ref10));
+            cl10 = MyClassPrx(communicator, ref10);
             cl10.ice_ping();
             cl10.ice_encodingVersion(Ice.EncodingVersion(1, 0)).ice_ping();
             cl.ice_encodingVersion(Ice.EncodingVersion(1, 0)).ice_ping();

--- a/matlab/test/Ice/timeout/AllTests.m
+++ b/matlab/test/Ice/timeout/AllTests.m
@@ -24,9 +24,7 @@ classdef AllTests
         function allTests(helper)
             import Test.*;
 
-            controller = ControllerPrx.checkedCast(...
-                helper.communicator().stringToProxy(['controller:', helper.getTestEndpoint(1)]));
-            assert(~isempty(controller));
+            controller = ControllerPrx(helper.communicator(), ['controller:', helper.getTestEndpoint(1)]);
             try
                 AllTests.allTestsWithController(helper, controller);
             catch ex
@@ -42,15 +40,11 @@ classdef AllTests
             communicator = helper.communicator();
 
             sref = ['timeout:', helper.getTestEndpoint()];
-            obj = communicator.stringToProxy(sref);
-            assert(~isempty(obj));
-
-            timeout = TimeoutPrx.checkedCast(obj);
-            assert(~isempty(timeout));
+            timeout = TimeoutPrx(communicator, sref);
 
             fprintf('testing invocation timeout... ');
 
-            connection = obj.ice_getConnection();
+            connection = timeout.ice_getConnection();
             to = timeout.ice_invocationTimeout(100);
             assert(connection == to.ice_getConnection());
             try
@@ -59,8 +53,8 @@ classdef AllTests
             catch ex
                 assert(isa(ex, 'Ice.InvocationTimeoutException'));
             end
-            obj.ice_ping();
-            to = TimeoutPrx.checkedCast(obj.ice_invocationTimeout(500));
+            timeout.ice_ping();
+            to = timeout.ice_invocationTimeout(500);
             assert(connection == to.ice_getConnection());
             try
                 to.sleep(100);
@@ -83,7 +77,7 @@ classdef AllTests
             catch ex
                 assert(isa(ex, 'Ice.TimeoutException'));
             end
-            obj.ice_ping();
+            timeout.ice_ping();
 
             %
             % Expect success.


### PR DESCRIPTION
This PR improves the MATLAB mapping. You can now create a proxy with simply:

```matlab
proxy = GreeterPrx(communicator, 'greeter:tcp -h localhost -p 4061');
```

This PR also fixes #199 for MATLAB.