### PR TITLE
Simplify decoding of proxies in MATLAB

### DIFF
--- a/matlab/lib/+Ice/Communicator.m
+++ b/matlab/lib/+Ice/Communicator.m
@@ -95,7 +95,7 @@ classdef Communicator < IceInternal.WrapperObject
             if isNull(impl)
                 r = [];
             else
-                r = Ice.ObjectPrx(obj, '', obj.encoding, impl, []);
+                r = Ice.ObjectPrx(obj, '', impl);
             end
         end
         function r = proxyToString(~, proxy)
@@ -140,7 +140,7 @@ classdef Communicator < IceInternal.WrapperObject
             if isNull(impl)
                 r = [];
             else
-                r = Ice.ObjectPrx(obj, '', obj.encoding, impl, []);
+                r = Ice.ObjectPrx(obj, '', impl);
             end
         end
         function r = proxyToProperty(obj, proxy, prop)
@@ -217,7 +217,7 @@ classdef Communicator < IceInternal.WrapperObject
             impl = libpointer('voidPtr');
             obj.iceCall('getDefaultRouter', impl);
             if ~isNull(impl)
-                r = Ice.RouterPrx(obj, '', obj.encoding, impl, []);
+                r = Ice.RouterPrx(obj, '', impl);
             else
                 r = [];
             end
@@ -252,7 +252,7 @@ classdef Communicator < IceInternal.WrapperObject
             impl = libpointer('voidPtr');
             obj.iceCall('getDefaultLocator', impl);
             if ~isNull(impl)
-                r = Ice.LocatorPrx(obj, '', obj.encoding, impl, []);
+                r = Ice.LocatorPrx(obj, '', impl);
             else
                 r = [];
             end

--- a/matlab/lib/+Ice/Connection.m
+++ b/matlab/lib/+Ice/Connection.m
@@ -87,7 +87,7 @@ classdef Connection < IceInternal.WrapperObject
 
             proxy = libpointer('voidPtr');
             obj.iceCall('createProxy', id, proxy);
-            r = Ice.ObjectPrx(obj.communicator, '', obj.communicator.getEncoding(), proxy, []);
+            r = Ice.ObjectPrx(obj.communicator, '', proxy, obj.communicator.getEncoding());
         end
         function r = getEndpoint(obj)
             % getEndpoint   Get the endpoint from which the connection was

--- a/matlab/lib/+Ice/InputStream.m
+++ b/matlab/lib/+Ice/InputStream.m
@@ -637,59 +637,20 @@ classdef InputStream < handle
             end
         end
         function r = readProxy(obj, cls)
-            %
-            % Manually unmarshal a proxy just to discover how many bytes it consumes.
-            %
-
-            start = obj.pos;
-
-            id = Ice.Identity.ice_read(obj);
-
-            %
-            % A nil proxy is marshaled as an identity with empty category and name.
-            %
-            if isempty(id.category) && isempty(id.name)
-                r = [];
-                return;
-            end
-
-            obj.readStringSeq();
-            obj.readByte();
-            obj.readBool();
-
-            %
-            % The versions are only included in encoding >= 1.1.
-            %
-            if ~obj.encoding_1_0
-                Ice.ProtocolVersion.ice_read(obj);
-                Ice.EncodingVersion.ice_read(obj);
-            end
-
-            numEndpoints = obj.readSize();
-
-            if numEndpoints > 0
-                for i = 1:numEndpoints
-                    obj.readShort();
-                    obj.skipEncapsulation();
-                end
-            else
-                obj.readString();
-            end
-
-            %
-            % Now that we've reached the end, extract all of the bytes representing the marshaled form of the proxy.
-            %
-            bytes = obj.buf(start:obj.pos - 1);
-
+            proxyBuf = obj.buf(obj.pos:obj.size);
+            proxyBufSize = obj.size - obj.pos + 1;
             impl = libpointer('voidPtr');
-            start = 0; % Starting position for a C-style pointer.
-            IceInternal.Util.call('Ice_ObjectPrx_read', obj.communicator.impl_, obj.encoding, bytes, ...
-                                      start, length(bytes), impl);
+            bytesRead = libpointer('int32Ptr', 0);
+            IceInternal.Util.call('Ice_ObjectPrx_read', obj.communicator.impl_, obj.encoding, ...
+                                    proxyBuf, proxyBufSize, impl, bytesRead);
 
-            if nargin == 2
-                %
+            % Skips bytes decoded by the C++ code
+            obj.skip(bytesRead.Value);
+
+            if isNull(impl) % decoded a null proxy
+                r = [];
+            elseif nargin == 2
                 % Instantiate a proxy of the requested type.
-                %
                 constructor = str2func(cls);
                 r = constructor(obj.communicator, '', impl);
             else
@@ -884,6 +845,6 @@ classdef InputStream < handle
         classGraphDepthMax = 0
     end
     properties(Constant,Access=private)
-        endOfBufferMessage = 'attempting to unmarshal past the end of the buffer'
+        endOfBufferMessage = 'attempting to unmarshal past the end of the InputStream buffer'
     end
 end

--- a/matlab/lib/+Ice/InputStream.m
+++ b/matlab/lib/+Ice/InputStream.m
@@ -681,14 +681,19 @@ classdef InputStream < handle
             %
             bytes = obj.buf(start:obj.pos - 1);
 
+            impl = libpointer('voidPtr');
+            start = 0; % Starting position for a C-style pointer.
+            IceInternal.Util.call('Ice_ObjectPrx_read', obj.communicator.impl_, obj.encoding, bytes, ...
+                                      start, length(bytes), impl);
+
             if nargin == 2
                 %
                 % Instantiate a proxy of the requested type.
                 %
                 constructor = str2func(cls);
-                r = constructor(obj.communicator, '', obj.getEncoding(), [], bytes);
+                r = constructor(obj.communicator, '', impl);
             else
-                r = Ice.ObjectPrx(obj.communicator, '', obj.getEncoding(), [], bytes);
+                r = Ice.ObjectPrx(obj.communicator, '', impl);
             end
         end
         function r = readProxyOpt(obj, tag)

--- a/matlab/lib/+IceInternal/WrapperObject.m
+++ b/matlab/lib/+IceInternal/WrapperObject.m
@@ -22,6 +22,7 @@ classdef (Abstract) WrapperObject < handle
         function delete(obj)
             if ~isempty(obj.impl_)
                 obj.iceCall('unref');
+                obj.impl_ = [];
             end
         end
         function iceCall(obj, fn, varargin)

--- a/matlab/src/ObjectPrx.cpp
+++ b/matlab/src/ObjectPrx.cpp
@@ -170,12 +170,12 @@ extern "C"
         }
     }
 
-    mxArray* Ice_ObjectPrx_read(void* communicator, mxArray* encoding, mxArray* buf, int start, int size, void** r)
+    mxArray* Ice_ObjectPrx_read(void* communicator, mxArray* encoding, mxArray* buf, int size, void** r, int* bytesRead)
     {
         assert(!mxIsEmpty(buf));
 
         pair<const byte*, const byte*> p;
-        p.first = reinterpret_cast<byte*>(mxGetData(buf)) + start;
+        p.first = reinterpret_cast<byte*>(mxGetData(buf));
         p.second = p.first + size;
 
         try
@@ -186,7 +186,8 @@ extern "C"
             Ice::InputStream in(deref<Ice::Communicator>(communicator), ev, p);
             std::optional<Ice::ObjectPrx> proxy;
             in.read(proxy);
-            *r = createProxy(std::move(proxy));
+            *r = createProxy(std::move(proxy)); // can return nullptr for a null proxy
+            *bytesRead = static_cast<int>(in.pos());
         }
         catch (...)
         {

--- a/matlab/src/ice.h
+++ b/matlab/src/ice.h
@@ -55,7 +55,7 @@ extern "C"
 
     ICE_MATLAB_API mxArray* Ice_ObjectPrx_unref(void*);
     ICE_MATLAB_API mxArray* Ice_ObjectPrx_equals(void*, void*);
-    ICE_MATLAB_API mxArray* Ice_ObjectPrx_read(void*, mxArray*, mxArray*, int, int, void**);
+    ICE_MATLAB_API mxArray* Ice_ObjectPrx_read(void*, mxArray*, mxArray*, int, void**, int*);
     ICE_MATLAB_API mxArray* Ice_ObjectPrx_write(void*, void*, mxArray*);
     ICE_MATLAB_API mxArray* Ice_ObjectPrx_ice_invoke(void*, const char*, int, mxArray*, unsigned int, mxArray*);
     ICE_MATLAB_API mxArray* Ice_ObjectPrx_ice_invokeNC(void*, const char*, int, mxArray*, unsigned int);

--- a/swift/src/Ice/Proxy.swift
+++ b/swift/src/Ice/Proxy.swift
@@ -1145,7 +1145,7 @@ open class ObjectPrxI: ObjectPrx {
                 bytesRead: &bytesRead) as? ICEObjectPrx
 
         // Since the proxy was read in C++ we need to skip over the bytes which were read
-        // We avoid using a defer statment for this since you can not throw from one
+        // We avoid using a defer statement for this since you can not throw from one
         try istr.skip(bytesRead)
 
         guard let handle = handleOpt else {


### PR DESCRIPTION
This PR simplifies the decoding of proxies in MATLAB.

Fixes #2479.