### PR TITLE
Remove ICE_GEM macro

### DIFF
--- a/cpp/src/Ice/RegisterPluginsInit.cpp
+++ b/cpp/src/Ice/RegisterPluginsInit.cpp
@@ -21,18 +21,17 @@ IceInternal::RegisterPluginsInit::RegisterPluginsInit()
     Ice::registerPluginFactory("IceSSL", createIceSSL, true);
 
     //
-    // Only include the UDP and WS transport plugins with non-static builds or Gem/PyPI/Swift
-    // builds.
+    // Only include the UDP and WS transport plugins with non-static builds or PyPI/Swift builds.
     //
-#if !defined(ICE_STATIC_LIBS) || defined(ICE_GEM) || defined(ICE_PYPI) || defined(ICE_SWIFT)
+#if !defined(ICE_STATIC_LIBS) || defined(ICE_PYPI) || defined(ICE_SWIFT)
     Ice::registerPluginFactory("IceUDP", createIceUDP, true);
     Ice::registerPluginFactory("IceWS", createIceWS, true);
 #endif
 
     //
-    // Also include IceStringConverter in Gem/PyPI builds.
+    // Also include IceStringConverter in PyPI builds.
     //
-#if defined(ICE_GEM) || defined(ICE_PYPI)
+#if defined(ICE_PYPI)
     Ice::registerPluginFactory("IceStringConverter", createStringConverter, false);
 #endif
 }


### PR DESCRIPTION
It was not used: the Ice Ruby extension doesn't use static libraries.

See also #2473.