### PR TITLE
Rework C++ user exceptions

### DIFF
--- a/cpp/include/Ice/Exception.h
+++ b/cpp/include/Ice/Exception.h
@@ -57,18 +57,20 @@ namespace Ice
         const char* what() const noexcept override;
 
         /**
-         * Returns the type ID of this exception. This corresponds to the Slice
-         * type ID for Slice-defined exceptions, and to a similar fully scoped name
-         * for other exceptions. For example "::Ice::CommunicatorDestroyedException".
+         * Returns the type ID of this exception. This corresponds to the Slice type ID for Slice-defined exceptions,
+         * and to a similar fully scoped name for other exceptions. For example "::Ice::CommunicatorDestroyedException".
          * @return The type ID of this exception
          */
         virtual const char* ice_id() const noexcept = 0;
 
         /**
-         * Outputs a description of this exception to a stream.
+         * Outputs a description of this exception to a stream. This function is called by operator<<(std::ostream&,
+         * const Ice::Exception&). The default implementation outputs ice_id(). The application can override the
+         * ice_print of a user exception to produce a more detailed description, with typically the ice_id() plus
+         * additional information.
          * @param os The output stream.
          */
-        virtual void ice_print(std::ostream& os) const;
+        virtual void ice_print(std::ostream& os) const { os << ice_id(); }
 
         /**
          * Returns the name of the file where this exception was constructed.
@@ -89,6 +91,8 @@ namespace Ice
         std::string ice_stackTrace() const;
 
     private:
+        friend std::ostream& operator<<(std::ostream&, const Exception&);
+
         const char* _file;                                // can be nullptr
         int _line;                                        // not used when _file is nullptr
         std::shared_ptr<std::string> _whatString;         // shared storage for custom _what message.

--- a/cpp/include/Ice/Exception.h
+++ b/cpp/include/Ice/Exception.h
@@ -91,7 +91,7 @@ namespace Ice
         std::string ice_stackTrace() const;
 
     private:
-        friend std::ostream& operator<<(std::ostream&, const Exception&);
+        friend ICE_API std::ostream& operator<<(std::ostream&, const Exception&);
 
         const char* _file;                                // can be nullptr
         int _line;                                        // not used when _file is nullptr

--- a/cpp/include/Ice/UserException.h
+++ b/cpp/include/Ice/UserException.h
@@ -22,15 +22,9 @@ namespace Ice
     {
     public:
         /**
-         * Default constructor.
+         * Default constructor. The file, line and what message are never set for user exceptions.
          */
         UserException() : Exception(nullptr, 0) {}
-
-        /**
-         * Obtains the Slice type ID of this exception.
-         * @return The fully-scoped type ID.
-         */
-        static std::string_view ice_staticId() noexcept;
 
         /**
          * Throws this exception.

--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -78,9 +78,7 @@ using namespace IceInternal;
 
 namespace IceInternal
 {
-    extern bool nullHandleAbort;
     extern bool printStackTraces;
-
 };
 
 namespace

--- a/cpp/src/Ice/LoggerUtil.cpp
+++ b/cpp/src/Ice/LoggerUtil.cpp
@@ -11,11 +11,6 @@
 
 using namespace std;
 
-namespace IceInternal
-{
-    extern bool printStackTraces;
-}
-
 string
 Ice::LoggerOutputBase::str() const
 {
@@ -38,14 +33,7 @@ Ice::operator<<(Ice::LoggerOutputBase& out, ios_base& (*val)(ios_base&))
 Ice::LoggerOutputBase&
 Ice::loggerInsert(Ice::LoggerOutputBase& out, const Ice::Exception& ex)
 {
-    if (IceInternal::printStackTraces)
-    {
-        out._stream() << ex.what() << '\n' << ex.ice_stackTrace();
-    }
-    else
-    {
-        out._stream() << ex.what();
-    }
+    out._stream() << ex;
     return out;
 }
 

--- a/cpp/src/Ice/OutgoingResponse.cpp
+++ b/cpp/src/Ice/OutgoingResponse.cpp
@@ -15,11 +15,6 @@ using namespace std;
 using namespace Ice;
 using namespace IceInternal;
 
-namespace IceInternal
-{
-    extern bool printStackTraces;
-}
-
 namespace
 {
     // The "core" implementation of makeOutgoingResponse for exceptions. Note that it can throw an exception.
@@ -136,10 +131,6 @@ namespace
             replyStatus = ReplyStatus::UnknownLocalException;
             ostringstream str;
             str << ex; // this includes more details than ex.what()
-            if (IceInternal::printStackTraces)
-            {
-                str << '\n' << ex.ice_stackTrace();
-            }
             exceptionMessage = str.str();
         }
         catch (const Exception& ex)
@@ -148,10 +139,6 @@ namespace
             replyStatus = ReplyStatus::UnknownException;
             ostringstream str;
             str << ex; // this includes more details than ex.what()
-            if (IceInternal::printStackTraces)
-            {
-                str << '\n' << ex.ice_stackTrace();
-            }
             exceptionMessage = str.str();
         }
         catch (const std::exception& ex)

--- a/cpp/src/Ice/UserException.cpp
+++ b/cpp/src/Ice/UserException.cpp
@@ -9,13 +9,6 @@
 using namespace std;
 using namespace Ice;
 
-std::string_view
-Ice::UserException::ice_staticId() noexcept
-{
-    static constexpr string_view typeId = "::Ice::UserException";
-    return typeId;
-}
-
 void
 Ice::UserException::_write(OutputStream* os) const
 {

--- a/cpp/test/Ice/background/AllTests.cpp
+++ b/cpp/test/Ice/background/AllTests.cpp
@@ -356,7 +356,6 @@ initializeTests(
     catch (const Ice::LocalException& ex)
     {
         cerr << ex << endl;
-        cerr << "stack: " << ex.ice_stackTrace() << endl;
         test(false);
     }
     background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
@@ -420,7 +419,6 @@ initializeTests(
     catch (const Ice::LocalException& ex)
     {
         cerr << ex << endl;
-        cerr << "stack: " << ex.ice_stackTrace() << endl;
         test(false);
     }
     background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
@@ -434,7 +432,6 @@ initializeTests(
     catch (const Ice::LocalException& ex)
     {
         cerr << ex << endl;
-        cerr << "stack: " << ex.ice_stackTrace() << endl;
         test(false);
     }
     background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
@@ -469,7 +466,6 @@ initializeTests(
     catch (const Ice::LocalException& ex)
     {
         cerr << ex << endl;
-        cerr << "stack: " << ex.ice_stackTrace() << endl;
         test(false);
     }
     background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
@@ -507,7 +503,7 @@ initializeTests(
         catch (const Ice::LocalException& ex)
         {
             cerr << ex << endl;
-            cerr << "stack: " << ex.ice_stackTrace() << endl;
+
             test(false);
         }
 
@@ -530,7 +526,6 @@ initializeTests(
         catch (const Ice::LocalException& ex)
         {
             cerr << ex << endl;
-            cerr << "stack: " << ex.ice_stackTrace() << endl;
             test(false);
         }
 
@@ -557,7 +552,6 @@ initializeTests(
         catch (const Ice::LocalException& ex)
         {
             cerr << ex << endl;
-            cerr << "stack: " << ex.ice_stackTrace() << endl;
             test(false);
         }
 
@@ -576,7 +570,6 @@ initializeTests(
         catch (const Ice::LocalException& ex)
         {
             cerr << ex << endl;
-            cerr << "stack: " << ex.ice_stackTrace() << endl;
             test(false);
         }
     }
@@ -618,7 +611,6 @@ validationTests(
     catch (const Ice::LocalException& ex)
     {
         cerr << ex << endl;
-        cerr << "stack: " << ex.ice_stackTrace() << endl;
         test(false);
     }
 
@@ -651,7 +643,6 @@ validationTests(
         catch (const Ice::LocalException& ex)
         {
             cerr << ex << endl;
-            cerr << "stack: " << ex.ice_stackTrace() << endl;
             test(false);
         }
         background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
@@ -673,7 +664,6 @@ validationTests(
         catch (const Ice::LocalException& ex)
         {
             cerr << ex << endl;
-            cerr << "stack: " << ex.ice_stackTrace() << endl;
             test(false);
         }
 
@@ -756,7 +746,6 @@ validationTests(
         catch (const Ice::LocalException& ex)
         {
             cerr << ex << endl;
-            cerr << "stack: " << ex.ice_stackTrace() << endl;
             test(false);
         }
 
@@ -770,7 +759,6 @@ validationTests(
         catch (const Ice::LocalException& ex)
         {
             cerr << ex << endl;
-            cerr << "stack: " << ex.ice_stackTrace() << endl;
             test(false);
         }
         background->ice_getConnection()->close(Ice::ConnectionClose::GracefullyWithWait);
@@ -791,7 +779,6 @@ validationTests(
         catch (const Ice::LocalException& ex)
         {
             cerr << ex << endl;
-            cerr << "stack: " << ex.ice_stackTrace() << endl;
             test(false);
         }
 #if defined(ICE_USE_IOCP) || defined(ICE_USE_CFSTREAM)
@@ -819,7 +806,6 @@ validationTests(
     catch (const Ice::LocalException& ex)
     {
         cerr << ex << endl;
-        cerr << "stack: " << ex.ice_stackTrace() << endl;
         test(false);
     }
 
@@ -839,7 +825,6 @@ validationTests(
     catch (const Ice::LocalException& ex)
     {
         cerr << ex << endl;
-        cerr << "stack: " << ex.ice_stackTrace() << endl;
         test(false);
     }
 
@@ -879,7 +864,6 @@ readWriteTests(
     catch (const Ice::LocalException& ex)
     {
         cerr << ex << endl;
-        cerr << "stack: " << ex.ice_stackTrace() << endl;
         test(false);
     }
 
@@ -993,7 +977,6 @@ readWriteTests(
         catch (const Ice::LocalException& ex)
         {
             cerr << ex << endl;
-            cerr << "stack: " << ex.ice_stackTrace() << endl;
             test(false);
         }
 

--- a/cpp/test/Ice/exceptions/AllTests.cpp
+++ b/cpp/test/Ice/exceptions/AllTests.cpp
@@ -49,11 +49,13 @@ allTests(Test::TestHelper* helper)
 
         Ice::OperationNotExistException opNotExist("thisFile", 99);
         string opNotExistWhat = "dispatch failed with OperationNotExistException";
-        string opNotExistPrint = "thisFile:99 ::Ice::OperationNotExistException " + opNotExistWhat;
+        string opNotExistPrint = opNotExist.ice_id();
+        string opNotExistStream = "thisFile:99 " + opNotExistPrint + " " + opNotExistWhat;
 
         string customMessage = "custom message";
         Ice::UnknownLocalException customUle("thisFile", 199, customMessage);
-        string customUlePrint = "thisFile:199 ::Ice::UnknownLocalException " + customMessage;
+        string customUlePrint = customUle.ice_id();
+        string customUleStream = "thisFile:199 " + customUlePrint + " " + customMessage;
 
         //
         // Test ice_print().
@@ -80,17 +82,17 @@ allTests(Test::TestHelper* helper)
         {
             stringstream str;
             str << a;
-            test(str.str() == aMsg);
+            test(str.str().substr(0, aMsg.size()) == aMsg);
         }
         {
             stringstream str;
-            str << opNotExistPrint;
-            test(str.str() == opNotExistPrint);
+            str << opNotExist;
+            test(str.str().substr(0, opNotExistStream.size()) == opNotExistStream);
         }
         {
             stringstream str;
             str << customUle;
-            test(str.str() == customUlePrint);
+            test(str.str().substr(0, customUleStream.size()) == customUleStream);
         }
 
         //
@@ -518,7 +520,6 @@ allTests(Test::TestHelper* helper)
         catch (const Ice::Exception& ex)
         {
             cout << ex << endl;
-            cout << ex.ice_stackTrace() << endl;
             test(false);
         }
         catch (...)
@@ -976,7 +977,6 @@ allTests(Test::TestHelper* helper)
             catch (const Ice::Exception& ex)
             {
                 cout << ex << endl;
-                cout << ex.ice_stackTrace() << endl;
                 test(false);
             }
             catch (...)


### PR DESCRIPTION
This is a small update to user exceptions in C++.

The main changes are:
 -  `ice_print` is no longer equivalent to  `stream << ex` - it's just printing a message, and defaults to printing ice_id().
 - `operator<<` now includes the stack trace when "print stack trace" is enabled

This update should be highly compatible for existing code that sets a custom message via the ice_print metadata.