### PR TITLE
GCC 13.2 build fixes

### DIFF
--- a/config/Make.rules.Linux
+++ b/config/Make.rules.Linux
@@ -143,7 +143,7 @@ ldflags         = -pthread
 gcc_version = $(shell $(CXX) -dumpversion 2>&1 | cut -f1 -d\.)
 
 # As of GCC 13.4, https://gcc.gnu.org/projects/cxx-status.html#cxx20 still describes C++20 support as "experimental".
-cppflags       += -std=c++20
+cppflags       += -std=c++17
 
 nodeprecatedwarnings-cppflags := -Wno-deprecated-declarations
 nounusedparameter-cppflags    := -Wno-unused-parameter

--- a/cpp/include/Ice/FactoryTable.h
+++ b/cpp/include/Ice/FactoryTable.h
@@ -12,6 +12,8 @@
 #include <cassert>
 #include <map>
 #include <mutex>
+#include <string>
+#include <string_view>
 #include <utility>
 
 namespace IceInternal

--- a/cpp/src/IceBT/DBus.h
+++ b/cpp/src/IceBT/DBus.h
@@ -6,6 +6,7 @@
 #define ICE_BT_DBUS_H
 
 #include <cassert>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <sstream>

--- a/python/setup.py
+++ b/python/setup.py
@@ -83,7 +83,7 @@ elif sys.platform == 'win32':
     libraries = ['dbghelp', 'Shlwapi', 'rpcrt4', 'advapi32', 'Iphlpapi', 'secur32', 'crypt32', 'ws2_32']
 else:
     extra_compile_args = ['-w']
-    cpp_extra_compile_args = ['-std=c++20']
+    cpp_extra_compile_args = ['-std=c++17']
     extra_link_args = []
     libraries = ['ssl', 'crypto', 'bz2', 'rt']
     if not sys.platform.startswith('freebsd'):


### PR DESCRIPTION
This PR fixes build failures with GCC 13.2 using C++17 mode.

I updated the build to C++20 when adding the Python package, but I am switching back to C++17 as C++20 is still experimental as mentioned in `Make.rules.Linux`.