### PR TITLE
'checkedCast' no Longer Eats 'FacetNotExistException' in Java

### DIFF
--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -4266,16 +4266,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "@return A proxy for this type, or null if the object does not support this type.");
     out << nl << "static " << prxName << " checkedCast(com.zeroc.Ice.ObjectPrx obj, " << contextParam << ')';
     out << sb;
-    out << nl << "if (obj != null)";
-    out << sb;
-    out << nl << "try";
-    out << sb;
-    out << nl << "boolean ok = obj.ice_isA(ice_staticId(), context);";
-    out << nl << "return ok ? new " << prxIName << "(obj) : null;";
-    out << eb;
-    out << nl << "catch (com.zeroc.Ice.FacetNotExistException ex)" << sb << eb;
-    out << eb;
-    out << nl << "return null;";
+    out << nl << "return (obj != null && obj.ice_isA(ice_staticId(), context)) ? new " << prxIName << "(obj) : null;";
     out << eb;
 
     out << sp;

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
@@ -677,14 +677,7 @@ public interface ObjectPrx {
    * @return <code>obj</code>.
    */
   static ObjectPrx checkedCast(ObjectPrx obj, java.util.Map<String, String> context) {
-    if (obj != null) {
-      try {
-        boolean ok = obj.ice_isA(ice_staticId, context);
-        return ok ? obj : null;
-      } catch (FacetNotExistException ex) {
-      }
-    }
-    return null;
+    return (obj != null && obj.ice_isA(ice_staticId, context)) ? obj : null;
   }
 
   /**

--- a/java/test/src/main/java/test/Ice/admin/AllTests.java
+++ b/java/test/src/main/java/test/Ice/admin/AllTests.java
@@ -4,6 +4,7 @@
 
 package test.Ice.admin;
 
+import com.zeroc.Ice.FacetNotExistException;
 import com.zeroc.Ice.LogMessageType;
 import com.zeroc.Ice.ProcessPrx;
 import com.zeroc.Ice.PropertiesAdminPrx;
@@ -442,10 +443,19 @@ public class AllTests {
       props.put("Ice.Admin.Facets", "Properties");
       RemoteCommunicatorPrx rcom = factory.createCommunicator(props);
       com.zeroc.Ice.ObjectPrx obj = rcom.getAdmin();
-      ProcessPrx proc = ProcessPrx.checkedCast(obj, "Process");
-      test(proc == null);
-      TestFacetPrx tf = TestFacetPrx.checkedCast(obj, "TestFacet");
-      test(tf == null);
+
+      try {
+        ProcessPrx.checkedCast(obj, "Process");
+        test(false);
+      } catch (FacetNotExistException ex) {
+        // expected
+      }
+      try {
+        TestFacetPrx.checkedCast(obj, "TestFacet");
+        test(false);
+      } catch (FacetNotExistException ex) {
+        // expected
+      }
       rcom.destroy();
     }
     {
@@ -459,10 +469,20 @@ public class AllTests {
       props.put("Ice.Admin.Facets", "Process");
       RemoteCommunicatorPrx rcom = factory.createCommunicator(props);
       com.zeroc.Ice.ObjectPrx obj = rcom.getAdmin();
-      PropertiesAdminPrx pa = PropertiesAdminPrx.checkedCast(obj, "Properties");
-      test(pa == null);
-      TestFacetPrx tf = TestFacetPrx.checkedCast(obj, "TestFacet");
-      test(tf == null);
+
+      try {
+        PropertiesAdminPrx.checkedCast(obj, "Properties");
+        test(false);
+      } catch (FacetNotExistException ex) {
+        // expected
+      }
+      try {
+        TestFacetPrx.checkedCast(obj, "TestFacet");
+        test(false);
+      } catch (FacetNotExistException ex) {
+        // expected
+      }
+
       rcom.destroy();
     }
     {
@@ -476,10 +496,18 @@ public class AllTests {
       props.put("Ice.Admin.Facets", "TestFacet");
       RemoteCommunicatorPrx rcom = factory.createCommunicator(props);
       com.zeroc.Ice.ObjectPrx obj = rcom.getAdmin();
-      PropertiesAdminPrx pa = PropertiesAdminPrx.checkedCast(obj, "Properties");
-      test(pa == null);
-      ProcessPrx proc = ProcessPrx.checkedCast(obj, "Process");
-      test(proc == null);
+      try {
+        PropertiesAdminPrx.checkedCast(obj, "Properties");
+        test(false);
+      } catch (FacetNotExistException ex) {
+        // expected
+      }
+      try {
+        ProcessPrx.checkedCast(obj, "Process");
+        test(false);
+      } catch (FacetNotExistException ex) {
+        // expected
+      }
       rcom.destroy();
     }
     {
@@ -497,8 +525,12 @@ public class AllTests {
       test(pa.getProperty("Ice.Admin.InstanceName").equals("Test"));
       TestFacetPrx tf = TestFacetPrx.checkedCast(obj, "TestFacet");
       tf.op();
-      ProcessPrx proc = ProcessPrx.checkedCast(obj, "Process");
-      test(proc == null);
+      try {
+        ProcessPrx.checkedCast(obj, "Process");
+        test(false);
+      } catch (FacetNotExistException ex) {
+        // expected
+      }
       rcom.destroy();
     }
     {
@@ -512,8 +544,12 @@ public class AllTests {
       props.put("Ice.Admin.Facets", "TestFacet, Process");
       RemoteCommunicatorPrx rcom = factory.createCommunicator(props);
       com.zeroc.Ice.ObjectPrx obj = rcom.getAdmin();
-      PropertiesAdminPrx pa = PropertiesAdminPrx.checkedCast(obj, "Properties");
-      test(pa == null);
+      try {
+        PropertiesAdminPrx.checkedCast(obj, "Properties");
+        test(false);
+      } catch (FacetNotExistException ex) {
+        // expected
+      }
       TestFacetPrx tf = TestFacetPrx.checkedCast(obj, "TestFacet");
       tf.op();
       ProcessPrx proc = ProcessPrx.checkedCast(obj, "Process");

--- a/java/test/src/main/java/test/Ice/proxy/AllTests.java
+++ b/java/test/src/main/java/test/Ice/proxy/AllTests.java
@@ -6,6 +6,7 @@ package test.Ice.proxy;
 
 import com.zeroc.Ice.EncodingVersion;
 import com.zeroc.Ice.EndpointSelectionType;
+import com.zeroc.Ice.FacetNotExistException;
 import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.Util;
 import java.io.PrintWriter;
@@ -811,7 +812,12 @@ public class AllTests {
     test(cl.equals(base));
     test(derived.equals(base));
     test(cl.equals(derived));
-    test(MyDerivedClassPrx.checkedCast(cl, "facet") == null);
+    try {
+      MyDerivedClassPrx.checkedCast(cl, "facet");
+      test(false);
+    } catch (FacetNotExistException ex) {
+      // expected
+    }
     out.println("ok");
 
     out.print("testing checked cast with context... ");


### PR DESCRIPTION
This PR implements #2323 for Java, and keeps it in sync with C#.