### PR TITLE
Simplify user exceptions in C#

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1910,7 +1910,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
         vector<string> secondaryCtorMemberNames;
         vector<string> secondaryCtorBaseParamNames;
 
-         for (const auto& q : allDataMembers)
+        for (const auto& q : allDataMembers)
         {
             string memberName = fixId(q->name(), DotNet::Exception);
             string memberType = typeToString(q->type(), ns, q->optional());
@@ -1961,7 +1961,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
         _out << eb;
 
         // Secondary constructor. Can be parameterless.
-         if (secondaryCtorParams.size() != paramDecl.size())
+        if (secondaryCtorParams.size() != paramDecl.size())
         {
             _out << sp;
             emitGeneratedCodeAttribute();

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -124,18 +124,6 @@ namespace
         return name;
     }
 
-    string getEscapedParamName(const DataMemberList& params, const string& name)
-    {
-        for (DataMemberList::const_iterator i = params.begin(); i != params.end(); ++i)
-        {
-            if ((*i)->name() == name)
-            {
-                return name + "_";
-            }
-        }
-        return name;
-    }
-
     string resultStructReturnValueName(const ParamDeclList& outParams)
     {
         for (ParamDeclList::const_iterator i = outParams.begin(); i != outParams.end(); ++i)
@@ -1721,7 +1709,7 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
         _out << nl << "ice_initialize();";
         _out << eb;
 
-        // Non-primary constructor. Can be parameterless.
+        // Secondary constructor. Can be parameterless.
         if (secondaryCtorParams.size() != paramDecl.size())
         {
             _out << sp;
@@ -1757,21 +1745,11 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
     }
 
     _out << sp;
-    _out << nl << "private const string _id = \"" << p->scoped() << "\";";
-
-    _out << sp;
     emitGeneratedCodeAttribute();
-    _out << nl << "public static new string ice_staticId()";
-    _out << sb;
-    _out << nl << "return _id;";
-    _out << eb;
+    _out << nl << "public static new string ice_staticId() => \"" << p->scoped() << "\";";
 
     emitGeneratedCodeAttribute();
-    _out << nl << "public override string ice_id()";
-    _out << sb;
-    _out << nl << "return _id;";
-    _out << eb;
-
+    _out << nl << "public override string ice_id() => ice_staticId();";
     writeMarshaling(p);
 
     _out << eb;
@@ -1888,7 +1866,8 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     emitAttributes(p);
     emitComVisibleAttribute();
     //
-    // Suppress FxCop diagnostic about a missing constructor MyException(String).
+    // Suppress diagnostic about missing constructors:
+    // https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1032
     //
     _out << nl << "[global::System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Design\", \"CA1032\")]";
 
@@ -1918,122 +1897,105 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
     DataMemberList classMembers = p->classDataMembers();
     DataMemberList optionalMembers = p->orderedOptionalDataMembers();
     ExceptionPtr base = p->base();
-    string exParam = getEscapedParamName(allDataMembers, "innerException");
 
-    // Primary constructor.
-    _out << sp;
-    emitGeneratedCodeAttribute();
-    _out << nl << "public " << name << spar;
-
-    vector<string> paramDecl;
-    vector<string> secondaryCtorParams;
-    vector<string> secondaryCtorMemberNames;
-    vector<string> secondaryCtorBaseParamNames;
-    bool hideParameterlessCtor = false;
-
-    for (const auto& q : allDataMembers)
+    if (!allDataMembers.empty())
     {
-        string memberName = fixId(q->name(), DotNet::Exception);
-        string memberType = typeToString(q->type(), ns, q->optional());
-        paramDecl.push_back(memberType + " " + memberName);
-
-        // Look for required fields to be initialized by the secondary constructor.
-        if (isMappedToRequiredField(q))
-        {
-            secondaryCtorParams.push_back(memberType + " " + memberName);
-            if (find(dataMembers.begin(), dataMembers.end(), q) != dataMembers.end())
-            {
-                secondaryCtorMemberNames.push_back(memberName);
-            }
-            hideParameterlessCtor = true;
-        }
-    }
-    // Add exception for inner exception. It's defaulted to null only if it's not the only parameter.
-    if (paramDecl.size() > 0)
-    {
-        paramDecl.push_back("global::System.Exception? " + exParam + " = null");
-    }
-    else
-    {
-        paramDecl.push_back("global::System.Exception? " + exParam);
-    }
-    if (secondaryCtorParams.size() > 0)
-    {
-        secondaryCtorParams.push_back("global::System.Exception? " + exParam + " = null");
-    }
-    else
-    {
-        secondaryCtorParams.push_back("global::System.Exception? " + exParam);
-    }
-
-    _out << paramDecl << epar;
-    _out << " : base" << spar;
-    vector<string> baseParamNames;
-    if (base)
-    {
-        DataMemberList baseDataMembers = base->allDataMembers();
-        for (const auto& q : baseDataMembers)
-        {
-            string memberName = fixId(q->name(), DotNet::Exception);
-            baseParamNames.push_back(memberName);
-
-            // Look for required fields
-            if (isMappedToRequiredField(q))
-            {
-                secondaryCtorBaseParamNames.push_back(memberName);
-            }
-        }
-    }
-    baseParamNames.push_back(exParam);
-    secondaryCtorBaseParamNames.push_back(exParam);
-
-    _out << baseParamNames << epar;
-    _out << sb;
-    for (const auto& q : dataMembers)
-    {
-        const string memberName = fixId(q->name(), DotNet::Exception);
-        if (isMappedToNonNullableReference(q))
-        {
-            _out << nl << "global::System.ArgumentNullException.ThrowIfNull(" << memberName << ");";
-        }
-        _out << nl << "this." << memberName << " = " << memberName << ';';
-    }
-    _out << eb;
-
-    // Non-primary constructor. If generated, it has at least one parameter without a default value.
-    if (secondaryCtorParams.size() != paramDecl.size())
-    {
+        // Primary constructor.
         _out << sp;
         emitGeneratedCodeAttribute();
-        _out << nl << "public " << name << spar << secondaryCtorParams << epar;
-        _out << " : base" << spar << secondaryCtorBaseParamNames << epar;
-        _out << sb;
-        for (const auto& q : secondaryCtorMemberNames)
+        _out << nl << "public " << name << spar;
+
+        vector<string> paramDecl;
+        vector<string> secondaryCtorParams;
+        vector<string> secondaryCtorMemberNames;
+        vector<string> secondaryCtorBaseParamNames;
+
+         for (const auto& q : allDataMembers)
         {
-            _out << nl << "global::System.ArgumentNullException.ThrowIfNull(" << q << ");";
-            _out << nl << "this." << q << " = " << q << ';';
+            string memberName = fixId(q->name(), DotNet::Exception);
+            string memberType = typeToString(q->type(), ns, q->optional());
+            paramDecl.push_back(memberType + " " + memberName);
+
+            // The secondary constructor initializes the fields that would be marked "required" if we generated the
+            // required keyword.
+            if (isMappedToRequiredField(q))
+            {
+                secondaryCtorParams.push_back(memberType + " " + memberName);
+
+                if (find(dataMembers.begin(), dataMembers.end(), q) != dataMembers.end())
+                {
+                    secondaryCtorMemberNames.push_back(memberName);
+                }
+            }
+        }
+        _out << paramDecl << epar;
+
+        if (base && allDataMembers.size() != dataMembers.size())
+        {
+            _out << " : base" << spar;
+            vector<string> baseParamNames;
+            DataMemberList baseDataMembers = base->allDataMembers();
+            for (const auto& q : baseDataMembers)
+            {
+                string memberName = fixId(q->name(), DotNet::Exception);
+                baseParamNames.push_back(memberName);
+
+                // Look for required fields
+                if (isMappedToRequiredField(q))
+                {
+                    secondaryCtorBaseParamNames.push_back(memberName);
+                }
+            }
+            _out << baseParamNames << epar;
+        }
+        _out << sb;
+        for (const auto& q : dataMembers)
+        {
+            const string memberName = fixId(q->name(), DotNet::Exception);
+            if (isMappedToNonNullableReference(q))
+            {
+                _out << nl << "global::System.ArgumentNullException.ThrowIfNull(" << memberName << ");";
+            }
+            _out << nl << "this." << memberName << " = " << memberName << ';';
         }
         _out << eb;
+
+        // Secondary constructor. Can be parameterless.
+         if (secondaryCtorParams.size() != paramDecl.size())
+        {
+            _out << sp;
+            emitGeneratedCodeAttribute();
+            _out << nl << "public " << name << spar << secondaryCtorParams << epar;
+            if (base && secondaryCtorBaseParamNames.size() > 0)
+            {
+                _out << " : base" << spar << secondaryCtorBaseParamNames << epar;
+            }
+            _out << sb;
+            for (const auto& q : secondaryCtorMemberNames)
+            {
+                // All these parameters/fields are non-nullable and we don't tolerate null values.
+                _out << nl << "global::System.ArgumentNullException.ThrowIfNull(" << q << ");";
+                _out << nl << "this." << q << " = " << q << ';';
+            }
+            _out << eb;
+        }
+
+        // Parameterless constructor. Required for unmarshaling.
+        if (secondaryCtorParams.size() > 0)
+        {
+            _out << sp;
+            emitGeneratedCodeAttribute();
+            emitNonBrowsableAttribute();
+            _out << nl << "public " << name << "()";
+            _out << sb;
+            writeDataMemberInitializers(dataMembers, DotNet::Exception);
+            _out << eb;
+        }
     }
 
-    // Parameterless constructor. Required for unmarshaling.
     _out << sp;
     emitGeneratedCodeAttribute();
-    if (hideParameterlessCtor)
-    {
-        emitNonBrowsableAttribute();
-    }
-    _out << nl << "public " << name << "()";
-    _out << sb;
-    writeDataMemberInitializers(dataMembers, DotNet::Exception);
-    _out << eb;
-
-    _out << sp;
-    emitGeneratedCodeAttribute();
-    _out << nl << "public override string ice_id()";
-    _out << sb;
-    _out << nl << "return \"" << p->scoped() << "\";";
-    _out << eb;
+    _out << nl << "public override string ice_id() => \"" << p->scoped() << "\";";
 
     string scoped = p->scoped();
 

--- a/csharp/src/Ice/UserException.cs
+++ b/csharp/src/Ice/UserException.cs
@@ -26,10 +26,10 @@ public abstract class UserException : Ice.Exception
     public virtual bool iceUsesClasses() => false;
 
     /// <summary>
-    /// Constructs an Ice user exception.
+    /// Parameterless constructor.
     /// </summary>
-    protected UserException(System.Exception? innerException = null)
-        : base(message: null, innerException)
+    protected UserException()
+        : base(message: null, innerException: null)
     {
     }
 


### PR DESCRIPTION
User exceptions in C# are now more like mapped classes. In particular, I removed in the innerException parameter.