### PR TITLE
Simplify gen code for user exceptions and values in Swift

### DIFF
--- a/cpp/src/slice2swift/Gen.h
+++ b/cpp/src/slice2swift/Gen.h
@@ -59,7 +59,6 @@ namespace Slice
         public:
             TypesVisitor(IceInternal::Output&);
 
-            bool visitClassDefStart(const ClassDefPtr&) final;
             bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
             bool visitExceptionStart(const ExceptionPtr&) final;
             bool visitStructStart(const StructPtr&) final;

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -1435,8 +1435,7 @@ SwiftGenerator::writeMemberwiseInitializer(
     const DataMemberList& baseMembers,
     const DataMemberList& allMembers,
     const ContainedPtr& p,
-    bool rootClass,
-    const StringPairList& extraParams)
+    bool rootClass)
 {
     if (!members.empty())
     {
@@ -1449,10 +1448,6 @@ SwiftGenerator::writeMemberwiseInitializer(
             out
                 << (fixIdent(m->name()) + ": " +
                     typeToString(m->type(), p, m->getMetaData(), m->optional(), TypeContextInParam));
-        }
-        for (StringPairList::const_iterator q = extraParams.begin(); q != extraParams.end(); ++q)
-        {
-            out << (q->first + ": " + q->second);
         }
         out << epar;
         out << sb;
@@ -1470,10 +1465,6 @@ SwiftGenerator::writeMemberwiseInitializer(
             {
                 const string name = fixIdent((*i)->name());
                 out << (name + ": " + name);
-            }
-            for (StringPairList::const_iterator q = extraParams.begin(); q != extraParams.end(); ++q)
-            {
-                out << (q->first + ": " + q->first);
             }
             out << epar;
         }

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -130,8 +130,7 @@ namespace Slice
             const DataMemberList&,
             const DataMemberList&,
             const ContainedPtr&,
-            bool rootClass = false,
-            const StringPairList& = StringPairList());
+            bool rootClass);
         void writeMembers(IceInternal::Output&, const DataMemberList&, const ContainedPtr&, int = 0);
 
         void writeMarshalUnmarshalCode(

--- a/swift/src/Ice/Object.swift
+++ b/swift/src/Ice/Object.swift
@@ -3,7 +3,7 @@
 import IceImpl
 import PromiseKit
 
-/// A SliceTraits struct describes a Slice interface, class or exception.
+/// A SliceTraits struct describes a Slice interface.
 public protocol SliceTraits {
     /// List of all type-ids.
     static var staticIds: [String] { get }

--- a/swift/src/Ice/UnknownSlicedValue.swift
+++ b/swift/src/Ice/UnknownSlicedValue.swift
@@ -5,7 +5,7 @@ public final class UnknownSlicedValue: Value {
     private let unknownTypeId: String
 
     public required init() {
-        unknownTypeId = ""
+        fatalError("UnknownSlicedValue must be initialized with an id")
     }
 
     public init(unknownTypeId: String) {

--- a/swift/src/Ice/UserException.swift
+++ b/swift/src/Ice/UserException.swift
@@ -2,11 +2,11 @@
 
 /// Base class for Ice user exceptions.
 open class UserException: Exception {
+    public required init() {}
+
     /// Gets the type ID of the class.
     /// - Returns: The type ID of the class.
     open class func ice_staticId() -> String { "::Ice::UserException" }
-
-    public required init() {}
 
     open func _iceReadImpl(from _: InputStream) throws {}
     open func _iceWriteImpl(to _: OutputStream) {}

--- a/swift/src/Ice/Value.swift
+++ b/swift/src/Ice/Value.swift
@@ -6,12 +6,13 @@ open class Value {
 
     public required init() {}
 
-    /// Returns the Slice type ID of the most-derived interface supported by this object.
-    ///
-    /// - returns: `String` - The Slice type ID.
-    open func ice_id() -> String {
-        return ObjectTraits.staticId
-    }
+    /// Gets the type ID of the class.
+    /// - Returns: The type ID of the class.
+    open class func ice_staticId() -> String { "::Ice::Object" }
+
+    /// Gets the type ID of this Ice value
+    /// - Returns: The type ID of this Ice value.
+    open func ice_id() -> String { type(of: self).ice_staticId() }
 
     open func _iceReadImpl(from _: InputStream) throws {}
 
@@ -44,12 +45,5 @@ open class Value {
         os.startValue(data: slicedData)
         _iceWriteImpl(to: os)
         os.endValue()
-    }
-
-    /// Returns the Slice type ID of this object.
-    ///
-    /// - returns: `String` - The Slice type ID.
-    open class func ice_staticId() -> String {
-        return ObjectTraits.staticId
     }
 }


### PR DESCRIPTION
This PR takes advantage of initializer inheritance and removes the leftover "traits" in mapped classes.