### PR TITLE
Cleanup Ice Python and Ice Ruby packaging

### DIFF
--- a/cpp/src/Ice/RegisterPluginsInit.cpp
+++ b/cpp/src/Ice/RegisterPluginsInit.cpp
@@ -24,7 +24,7 @@ IceInternal::RegisterPluginsInit::RegisterPluginsInit()
     // Only include the UDP and WS transport plugins with non-static builds or Gem/PyPI/Swift
     // builds.
     //
-#if !defined(ICE_STATIC_LIBS) || defined(ICE_GEM) || defined(ICE_PYPI)
+#if !defined(ICE_STATIC_LIBS)
     Ice::registerPluginFactory("IceUDP", createIceUDP, true);
     Ice::registerPluginFactory("IceWS", createIceWS, true);
 #endif

--- a/cpp/src/Ice/RegisterPluginsInit.cpp
+++ b/cpp/src/Ice/RegisterPluginsInit.cpp
@@ -21,8 +21,7 @@ IceInternal::RegisterPluginsInit::RegisterPluginsInit()
     Ice::registerPluginFactory("IceSSL", createIceSSL, true);
 
     //
-    // Only include the UDP and WS transport plugins with non-static builds or Gem/PyPI/Swift
-    // builds.
+    // Only include the UDP and WS transport plugins with non-static builds.
     //
 #if !defined(ICE_STATIC_LIBS)
     Ice::registerPluginFactory("IceUDP", createIceUDP, true);

--- a/python/modules/IcePy/Init.cpp
+++ b/python/modules/IcePy/Init.cpp
@@ -130,7 +130,6 @@ PyMODINIT_FUNC
 #else
 PyMODINIT_FUNC ICE_DECLSPEC_EXPORT
 #endif
-
 PyInit_IcePy(void)
 {
     PyObject* module;
@@ -138,6 +137,8 @@ PyInit_IcePy(void)
     Ice::registerIceSSL(false);
     Ice::registerIceDiscovery(false);
     Ice::registerIceLocatorDiscovery(false);
+    Ice::registerIceUDP(true);
+    Ice::registerIceWS(true);
 
     //
     // Create the module.

--- a/python/modules/IcePy/Init.cpp
+++ b/python/modules/IcePy/Init.cpp
@@ -134,11 +134,10 @@ PyInit_IcePy(void)
 {
     PyObject* module;
 
-    Ice::registerIceSSL(false);
-    Ice::registerIceDiscovery(false);
-    Ice::registerIceLocatorDiscovery(false);
     Ice::registerIceUDP(true);
     Ice::registerIceWS(true);
+    Ice::registerIceDiscovery(false);
+    Ice::registerIceLocatorDiscovery(false);
 
     //
     // Create the module.

--- a/python/setup.py
+++ b/python/setup.py
@@ -61,7 +61,6 @@ else:
 # Define macros used during the build process
 define_macros = [
     ('ICE_STATIC_LIBS', None),
-    ('ICE_PYPI', None),
     ('ICE_BUILDING_SRC', None),
     ('ICE_BUILDING_ICE', None),
     ('ICE_BUILDING_ICE_LOCATOR_DISCOVERY', None)]
@@ -155,34 +154,26 @@ class CustomBuildExtCommand(_build_ext):
 # Customize the sdist command to ensure that the third-party sources and the generated sources are included in the
 # source distribution.
 class CustomSdistCommand(_sdist):
-    def run(self):
-        global sources  # Use the global sources list
 
-        sources = []  # Clear the sources list
-
-        def include_file(filename):
-            filename = os.path.normpath(filename)
-            # For Windows, ensure we only include generated files for the current platform
-            if pathlib.Path(filename).suffix.lower() not in ['.c', '.cpp', '.h']:
+    def include_file(self, filename):
+        filename = os.path.normpath(filename)
+        # For Windows, ensure we only include generated files for the current platform
+        if pathlib.Path(filename).suffix.lower() not in ['.c', '.cpp', '.h', '.ice', '.py']:
+            return False
+        if sys.platform == 'win32':
+            if "generated" in filename and os.path.join(platform, configuration) not in filename:
                 return False
-            if sys.platform == 'win32':
-                if "generated" in filename and os.path.join(platform, configuration) not in filename:
-                    return False
-                elif "msbuild" in filename and os.path.join(platform, configuration) not in filename:
-                    return False
-            return True
+            elif "msbuild" in filename and os.path.join(platform, configuration) not in filename:
+                return False
+        return True
 
+    def pre_build(self):
         # MCPP sources
         if not os.path.exists(mcpp_local_filename):
             with urllib.request.urlopen(mcpp_url) as response:
                 with open(mcpp_local_filename, 'wb') as f:
                     f.write(response.read())
             os.system(f"tar -xzf {mcpp_local_filename} -C dist")
-
-        for root, dirs, files in os.walk(f"dist/mcpp-{mcpp_version}"):
-            for file in files:
-                if include_file(os.path.join(root, file)):
-                    sources.append(os.path.join(root, file))
 
         # Bzip2 sources
         if not os.path.exists(bzip2_local_filename):
@@ -191,21 +182,27 @@ class CustomSdistCommand(_sdist):
                     f.write(response.read())
             os.system(f"tar -xzf {bzip2_local_filename} -C dist")
 
-        for root, dirs, files in os.walk(f"dist/bzip2-{bzip2_version}"):
-            for file in files:
-                if include_file(os.path.join(root, file)):
-                    sources.append(os.path.join(root, file))
-
         # Ice sources
         if sys.platform == 'win32':
-            os.system(f"MSBuild msbuild/ice.proj /p:Configuration={configuration} /p:Platform={platform} /t:BuildDist")
+            # Build slice2cpp and slice2py required to generate the C++ and Python sources included in the pip source dist
+            msbuild_args = f"/p:Configuration={configuration} /p:Platform={platform}"
+            solution_path = "../cpp/msbuild/ice.sln"
+            os.system(f"MSBuild /m {solution_path} {msbuild_args} /t:slice2cpp;slice2py")
+            # Build the SliceCompile target to generate the Ice, IceDiscovery, and IceLocatorDiscovery
+            # sources included in the pip source dist
+            for project in ["Ice", "IceDiscovery", "IceLocatorDiscovery"]:
+                project_path = f"../cpp/src/{project}/{project}/{project}.vcxproj"
+                os.system(f"MSBuild {project_path} {msbuild_args} /t:SliceCompile")
+
         else:
-            os.system('make srcs OPTIMIZE=yes -C ' + os.path.join(script_directory, '..', 'cpp'))
+            cpp_source_dir = os.path.join(script_directory, '..', 'cpp')
+            cpp_targets = "slice2cpp slice2py generate-srcs"
+            os.system(f"make OPTIMIZE=yes -C {cpp_source_dir} {cpp_targets} {cpp_source_dir}")
 
         for source_dir in ice_cpp_sources:
             for root, dirs, files in os.walk(source_dir):
                 for file in files:
-                    if include_file(os.path.join(root, file)):
+                    if self.include_file(os.path.join(root, file)):
                         source_file = os.path.join(root, file)
                         relative_path = os.path.relpath(source_file, '..')
                         target_file = os.path.join(script_directory, 'dist/ice', relative_path)
@@ -213,7 +210,6 @@ class CustomSdistCommand(_sdist):
                         if not os.path.exists(target_dir):
                             os.makedirs(target_dir)
                         shutil.copy(source_file, target_file)
-                        sources.append(os.path.relpath(target_file, script_directory))
 
         # IcePy sources
         for root, dirs, files in os.walk("modules/IcePy"):
@@ -226,26 +222,23 @@ class CustomSdistCommand(_sdist):
                     if not os.path.exists(target_dir):
                         os.makedirs(target_dir)
                     shutil.copy(source_file, target_file)
-                    sources.append(os.path.relpath(target_file, script_directory))
 
         # Slice sources
         for root, dirs, files in os.walk("../slice"):
             for file in files:
-                if file.endswith('.ice') and "IceDiscovery" not in root and "IceLocatorDiscovery" not in root:
-                    source_file = os.path.join(root, file)
-                    relative_path = os.path.relpath(source_file, '..')
-                    target_file = os.path.join(script_directory, 'dist/lib', relative_path)
-                    target_dir = os.path.dirname(target_file)
-                    if not os.path.exists(target_dir):
-                        os.makedirs(target_dir)
-                    shutil.copy(source_file, target_file)
-                    sources.append(os.path.relpath(target_file, script_directory))
+                source_file = os.path.join(root, file)
+                relative_path = os.path.relpath(source_file, '..')
+                target_file = os.path.join(script_directory, 'dist/lib', relative_path)
+                target_dir = os.path.dirname(target_file)
+                if not os.path.exists(target_dir):
+                    os.makedirs(target_dir)
+                shutil.copy(source_file, target_file)
 
         # Python sources
         if sys.platform == 'win32':
-            os.system(f"MSbuild msbuild/ice.proj /p:Configuration={configuration} /p:Platform={platform} /t:BuildDist")
+            os.system(f"MSBuild msbuild/ice.proj /t:SliceCompile /p:Configuration={configuration} /p:Platform={platform}")
         else:
-            os.system('make OPTIMIZE=yes')
+            os.system("make generate-srcs")
 
         for root, dirs, files in os.walk("python"):
             for file in files:
@@ -257,7 +250,18 @@ class CustomSdistCommand(_sdist):
                     if not os.path.exists(target_dir):
                         os.makedirs(target_dir)
                     shutil.copy(source_file, target_file)
-                    sources.append(os.path.relpath(target_file, script_directory))
+
+    def run(self):
+        if os.path.exists("../cpp"):
+            self.pre_build()
+
+        global sources  # Use the global sources list
+        sources = []  # Clear the sources list
+        for root, dirs, files in os.walk("dist"):
+            for file in files:
+                if self.include_file(os.path.join(root, file)):
+                    sources.append(os.path.join(root, file))
+
         self.distribution.ext_modules[0].sources = sources
         _sdist.run(self)
 

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -43,8 +43,8 @@ task :generate_sources do
         end
     end
 
-    # Ensure C++ srcs  have been built
-    system('make srcs OPTIMIZE=yes -C ../cpp')
+    # Ensure C++ generated sources and the required Slice compilers have been built.
+    system('make slice2cpp slice2rb generate-srcs OPTIMIZE=yes -C ../cpp')
 
     # Define source directories for Ice C++
     ice_cpp_sources = [
@@ -116,7 +116,7 @@ task :generate_sources do
     end
 
     # Ruby sources
-    system('make srcs OPTIMIZE=yes')
+    system('make generate-srcs OPTIMIZE=yes')
     ice_ruby_sources = ["ruby", "ruby/Ice"]
     for source_dir in ice_ruby_sources do
         Dir.foreach(source_dir) do |entry|

--- a/ruby/extconf.rb
+++ b/ruby/extconf.rb
@@ -32,7 +32,6 @@ $INCFLAGS << ' -Idist/ice/cpp/src/IceDiscovery/generated'
 $INCFLAGS << ' -Idist/ice/cpp/src/IceLocatorDiscovery/generated'
 
 $CPPFLAGS << ' -DICE_STATIC_LIBS'
-$CPPFLAGS << ' -DICE_GEM'
 $CPPFLAGS << ' -w'
 
 if RUBY_PLATFORM =~ /darwin/

--- a/ruby/src/IceRuby/Init.cpp
+++ b/ruby/src/IceRuby/Init.cpp
@@ -25,11 +25,10 @@ extern "C"
 {
     void ICE_DECLSPEC_EXPORT Init_IceRuby()
     {
-        Ice::registerIceSSL(false);
-        Ice::registerIceDiscovery(false);
-        Ice::registerIceLocatorDiscovery(false);
         Ice::registerIceUDP(true);
         Ice::registerIceWS(true);
+        Ice::registerIceDiscovery(false);
+        Ice::registerIceLocatorDiscovery(false);
 
         iceModule = rb_define_module("Ice");
         initCommunicator(iceModule);

--- a/ruby/src/IceRuby/Init.cpp
+++ b/ruby/src/IceRuby/Init.cpp
@@ -28,6 +28,8 @@ extern "C"
         Ice::registerIceSSL(false);
         Ice::registerIceDiscovery(false);
         Ice::registerIceLocatorDiscovery(false);
+        Ice::registerIceUDP(true);
+        Ice::registerIceWS(true);
 
         iceModule = rb_define_module("Ice");
         initCommunicator(iceModule);


### PR DESCRIPTION
This PR simplifies Ruby and Python packaging by:
- Removing ICE_GEM and ICE_PYPI macros
- Updating gem and pip package creation to build only the necessary compilers and sources
- Fixing pip package to perform pre_build only when generating src distribution from Ice source distribution