### PR TITLE
Remove registerIceSSL

### DIFF
--- a/cpp/include/Ice/RegisterPlugins.h
+++ b/cpp/include/Ice/RegisterPlugins.h
@@ -46,15 +46,6 @@ namespace Ice
      * plug-in property is set to 1.
      */
     ICE_PLUGIN_REGISTER_DECLSPEC_IMPORT void registerIceWS(bool loadOnInitialize = true);
-
-    /**
-     * When using static libraries, calling this function ensures the SSL transport is
-     * linked with the application.
-     * @param loadOnInitialize If true, the plug-in is loaded (created) during communicator initialization.
-     * If false, the plug-in is only loaded during communicator initialization if its corresponding
-     * plug-in property is set to 1.
-     */
-    ICE_PLUGIN_REGISTER_DECLSPEC_IMPORT void registerIceSSL(bool loadOnInitialize = true);
 #endif
 
 #ifndef ICE_DISCOVERY_API_EXPORTS

--- a/cpp/src/Ice/SSL/SSLEndpointI.cpp
+++ b/cpp/src/Ice/SSL/SSLEndpointI.cpp
@@ -34,14 +34,6 @@ extern "C"
     }
 }
 
-namespace Ice
-{
-    ICE_API void registerIceSSL(bool loadOnInitialize)
-    {
-        Ice::registerPluginFactory("IceSSL", createIceSSL, loadOnInitialize);
-    }
-}
-
 namespace
 {
     Ice::IPEndpointInfoPtr getIPEndpointInfo(const Ice::EndpointInfoPtr& info)

--- a/cpp/test/Common/TestHelper.cpp
+++ b/cpp/test/Common/TestHelper.cpp
@@ -133,7 +133,6 @@ Test::TestHelper::TestHelper(bool registerPlugins)
     if (registerPlugins)
     {
 #ifdef ICE_STATIC_LIBS
-        Ice::registerIceSSL(false);
         Ice::registerIceWS(true);
         Ice::registerIceUDP(true);
 #    ifdef ICE_HAS_BT

--- a/matlab/src/Init.cpp
+++ b/matlab/src/Init.cpp
@@ -17,7 +17,6 @@ namespace
     public:
         Init()
         {
-            Ice::registerIceSSL(false);
             Ice::registerIceDiscovery(false);
             Ice::registerIceLocatorDiscovery(false);
         }

--- a/php/src/Init.cpp
+++ b/php/src/Init.cpp
@@ -245,7 +245,6 @@ initIceGlobals(zend_ice_globals* g)
 
 ZEND_MINIT_FUNCTION(ice)
 {
-    Ice::registerIceSSL(false);
     Ice::registerIceDiscovery(false);
     Ice::registerIceLocatorDiscovery(false);
 


### PR DESCRIPTION
 SSL transport is now built-in and always available. No need to keep this register method.

Fix #2491