### PR TITLE
Add comment to Python thread hook

### DIFF
--- a/python/modules/IcePy/Thread.cpp
+++ b/python/modules/IcePy/Thread.cpp
@@ -29,6 +29,8 @@ IcePy::ThreadHook::ThreadHook(PyObject* threadStart, PyObject* threadStop)
         throw Ice::InitializationException(__FILE__, __LINE__, "threadStop must be a callable");
     }
 
+    // Increment the reference count of the Python objects to ensure they are not garbage collected.
+    // The reference count will be decremented in the destructor of PyObjectHandle, which holds them.
     Py_XINCREF(threadStart);
     Py_XINCREF(threadStop);
 }


### PR DESCRIPTION
Fix #1720. The code was already correct. I added a comment to clarify that the objects are managed by a `PyObjectHandle`, as this is not clear if you only look at the .cpp file. 