### PR TITLE
Make unaligned unmarshaling opt-in in C++

### DIFF
--- a/CHANGELOG-3.8.md
+++ b/CHANGELOG-3.8.md
@@ -119,6 +119,12 @@ Ice 3.7. You can still define proxies with the usual syntax, `Greeter*`, where `
 - There is now a single C++ mapping, based on the C++11 mapping provided by Ice 3.7. This new C++ mapping requires a
 C++ compiler with support for std=c++17 or higher.
 
+- When unmarshaling an array of short, int, long, float, or double, you can now choose to use unaligned unmarshaling by
+defining ICE_UNALIGNED when building your application. This optimization requires the non-default array mapping for
+Slice sequences, enabled by the `cpp:array` metadata directive, and a compatible little endian platform. In Ice 3.7 and
+earlier releases, this unaligned unmarshaling was turned on automatically on x86 and x64 CPUs, and turned off on all
+other CPUs.
+
 ## Objective-C Changes
 
 - The Objective-C mapping was removed.

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -24,14 +24,6 @@
 #include <string>
 #include <string_view>
 
-// ICE_UNALIGNED means the platform is little endian and supports unaligned reads.
-// It's used only in this header file.
-#ifndef ICE_UNALIGNED
-#    if defined(__i386) || defined(_M_IX86) || defined(__x86_64) || defined(_M_X64)
-#        define ICE_UNALIGNED
-#    endif
-#endif
-
 namespace IceInternal::Ex
 {
     ICE_API void throwUOE(const char* file, int line, const std::string&, const Ice::ValuePtr&);

--- a/cpp/test/Ice/custom/AllTests.cpp
+++ b/cpp/test/Ice/custom/AllTests.cpp
@@ -54,6 +54,20 @@ allTests(TestHelper* helper)
     cout << "testing alternate sequences... " << flush;
 
     {
+        ShortSeq in(50);
+        for (size_t i = 0; i < in.size(); ++i)
+        {
+            in[i] = static_cast<int16_t>(i + 1);
+        }
+        pair<const int16_t*, const int16_t*> inPair(in.data(), in.data() + in.size());
+
+        ShortSeq out;
+        ShortSeq ret = t->opShortArray(inPair, out);
+        test(out == in);
+        test(ret == in);
+    }
+
+    {
         DoubleSeq in(5);
         in[0] = 3.14;
         in[1] = 1 / 3;
@@ -68,7 +82,7 @@ allTests(TestHelper* helper)
         pair<const double*, const double*> inPair(inArray, inArray + 5);
 
         DoubleSeq out;
-        DoubleSeq ret = t->opDoubleArray(inPair, out);
+        DoubleSeq ret = t->opDoubleArray(false, inPair, out);
         test(out == in);
         test(ret == in);
     }
@@ -529,6 +543,19 @@ allTests(TestHelper* helper)
     cout << "testing alternate sequences with AMI... " << flush;
     {
         {
+            ShortSeq in(50);
+            for (size_t i = 0; i < in.size(); ++i)
+            {
+                in[i] = static_cast<int16_t>(i + 1);
+            }
+            pair<const int16_t*, const int16_t*> inPair(in.data(), in.data() + in.size());
+
+            auto r = t->opShortArrayAsync(inPair).get();
+            test(std::get<1>(r) == in);
+            test(std::get<0>(r) == in);
+        }
+
+        {
             DoubleSeq in(5);
             in[0] = 3.14;
             in[1] = 1 / 3;
@@ -541,7 +568,7 @@ allTests(TestHelper* helper)
                 inArray[i] = in[i];
             }
             pair<const double*, const double*> inPair(inArray, inArray + 5);
-            auto r = t->opDoubleArrayAsync(inPair).get();
+            auto r = t->opDoubleArrayAsync(false, inPair).get();
             test(std::get<1>(r) == in);
             test(std::get<0>(r) == in);
         }
@@ -925,6 +952,7 @@ allTests(TestHelper* helper)
         promise<bool> done;
 
         t->opDoubleArrayAsync(
+            false,
             inPair,
             [&](pair<const double*, const double*> ret, pair<const double*, const double*> out)
             {

--- a/cpp/test/Ice/custom/Makefile.mk
+++ b/cpp/test/Ice/custom/Makefile.mk
@@ -25,8 +25,10 @@ $(test)_serveramd_sources       = ServerAMD.cpp \
                                   MyByteSeq.cpp \
                                   StringConverterI.cpp
 
-# For the include <MyByteSeq.h> in the generated code.
-$(test)_cppflags        := -I$(project)
+# Extra -I because we include <MyByteSeq.h> in the generated code.
+# ICE_UNALIGNED means enable unaligned decoding for integral types such as int32_t. It requires a little endian CPU.
+# TODO: should be turn on ICE_UNALIGNED only on some platforms?
+$(test)_cppflags        := -I$(project) -DICE_UNALIGNED
 
 #
 # Disable var tracking assignments for Linux with this test

--- a/cpp/test/Ice/custom/Test.ice
+++ b/cpp/test/Ice/custom/Test.ice
@@ -93,6 +93,7 @@ sequence<DPrxList> DPrxListSeq;
 ["cpp:type:std::list<::Test::DPrxSeq>"] sequence<DPrxSeq> DPrxSeqList;
 
 sequence<double> DoubleSeq;
+sequence<short> ShortSeq;
 
 ["cpp:type:Test::CustomMap<::std::int32_t, std::string>"] dictionary<int, string> IntStringDict;
 dictionary<long, long> LongLongDict;
@@ -123,7 +124,9 @@ struct BufferStruct
 
 interface TestIntf
 {
-    ["cpp:array"] DoubleSeq opDoubleArray(["cpp:array"] DoubleSeq inSeq, out ["cpp:array"] DoubleSeq outSeq);
+    ["cpp:array"] ShortSeq opShortArray(["cpp:array"] ShortSeq inSeq, out ["cpp:array"] ShortSeq outSeq);
+
+    ["cpp:array"] DoubleSeq opDoubleArray(bool padding, ["cpp:array"] DoubleSeq inSeq, out ["cpp:array"] DoubleSeq outSeq);
 
     ["cpp:array"] BoolSeq opBoolArray(["cpp:array"] BoolSeq inSeq, out ["cpp:array"] BoolSeq outSeq);
 

--- a/cpp/test/Ice/custom/TestAMD.ice
+++ b/cpp/test/Ice/custom/TestAMD.ice
@@ -90,6 +90,7 @@ sequence<DPrxList> DPrxListSeq;
 ["cpp:type:std::list<::Test::DPrxSeq>"] sequence<DPrxSeq> DPrxSeqList;
 
 sequence<double> DoubleSeq;
+sequence<short> ShortSeq;
 
 ["cpp:type:Test::CustomMap<std::int32_t, std::string>"] dictionary<int, string> IntStringDict;
 dictionary<long, long> LongLongDict;
@@ -120,7 +121,9 @@ struct BufferStruct
 
 ["amd"] interface TestIntf
 {
-    DoubleSeq opDoubleArray(["cpp:array"] DoubleSeq inSeq, out DoubleSeq outSeq);
+    ["cpp:array"] ShortSeq opShortArray(["cpp:array"] ShortSeq inSeq, out ["cpp:array"] ShortSeq outSeq);
+
+    DoubleSeq opDoubleArray(bool padding, ["cpp:array"] DoubleSeq inSeq, out DoubleSeq outSeq);
 
     BoolSeq opBoolArray(["cpp:array"] BoolSeq inSeq, out BoolSeq outSeq);
 

--- a/cpp/test/Ice/custom/TestAMDI.cpp
+++ b/cpp/test/Ice/custom/TestAMDI.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "TestAMDI.h"
+#include "TestHelper.h"
 #include "Ice/Communicator.h"
 
 using namespace std;
@@ -10,12 +11,37 @@ using namespace Ice;
 using namespace Test;
 
 void
+TestIntfI::opShortArrayAsync(
+    pair<const int16_t*, const int16_t*> inSeq,
+    function<void(pair<const int16_t*, const int16_t*>, pair<const int16_t*, const int16_t*>)> response,
+    function<void(exception_ptr)>,
+    const Current&)
+{
+#ifdef ICE_UNALIGNED
+    // Verify inSeq is not aligned and holds the expected values.
+    test(reinterpret_cast<size_t>(inSeq.first) % 8 != 0);
+    for(int i = 0; i < static_cast<int>(inSeq.second - inSeq.first); ++i)
+    {
+        test(inSeq.first[i] == i + 1);
+    }
+#endif
+    response(inSeq, inSeq);
+}
+
+void
 TestIntfI::opDoubleArrayAsync(
+    bool,
     pair<const double*, const double*> in,
     function<void(const DoubleSeq&, const DoubleSeq&)> response,
     function<void(exception_ptr)>,
     const Current&)
 {
+#ifdef ICE_UNALIGNED
+    // Verify inSeq is not aligned.
+    test(reinterpret_cast<size_t>(in.first) % 8 != 0);
+    test(*(in.first) == 3.14);
+#endif
+
     DoubleSeq out(in.first, in.second);
     response(out, out);
 }

--- a/cpp/test/Ice/custom/TestAMDI.cpp
+++ b/cpp/test/Ice/custom/TestAMDI.cpp
@@ -3,8 +3,8 @@
 //
 
 #include "TestAMDI.h"
-#include "TestHelper.h"
 #include "Ice/Communicator.h"
+#include "TestHelper.h"
 
 using namespace std;
 using namespace Ice;
@@ -20,7 +20,7 @@ TestIntfI::opShortArrayAsync(
 #ifdef ICE_UNALIGNED
     // Verify inSeq is not aligned and holds the expected values.
     test(reinterpret_cast<size_t>(inSeq.first) % 8 != 0);
-    for(int i = 0; i < static_cast<int>(inSeq.second - inSeq.first); ++i)
+    for (int i = 0; i < static_cast<int>(inSeq.second - inSeq.first); ++i)
     {
         test(inSeq.first[i] == i + 1);
     }

--- a/cpp/test/Ice/custom/TestAMDI.h
+++ b/cpp/test/Ice/custom/TestAMDI.h
@@ -12,7 +12,9 @@ class TestIntfI : public virtual Test::TestIntf
 public:
     void opShortArrayAsync(
         std::pair<const std::int16_t*, const std::int16_t*>,
-        std::function<void(std::pair<const std::int16_t*, const std::int16_t*>, std::pair<const std::int16_t*, const std::int16_t*>)>,
+        std::function<void(
+            std::pair<const std::int16_t*, const std::int16_t*>,
+            std::pair<const std::int16_t*, const std::int16_t*>)>,
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) override;
 

--- a/cpp/test/Ice/custom/TestAMDI.h
+++ b/cpp/test/Ice/custom/TestAMDI.h
@@ -10,7 +10,14 @@
 class TestIntfI : public virtual Test::TestIntf
 {
 public:
+    void opShortArrayAsync(
+        std::pair<const std::int16_t*, const std::int16_t*>,
+        std::function<void(std::pair<const std::int16_t*, const std::int16_t*>, std::pair<const std::int16_t*, const std::int16_t*>)>,
+        std::function<void(std::exception_ptr)>,
+        const Ice::Current&) override;
+
     void opDoubleArrayAsync(
+        bool,
         std::pair<const double*, const double*>,
         std::function<void(const Test::DoubleSeq&, const Test::DoubleSeq&)>,
         std::function<void(std::exception_ptr)>,

--- a/cpp/test/Ice/custom/TestI.cpp
+++ b/cpp/test/Ice/custom/TestI.cpp
@@ -3,8 +3,8 @@
 //
 
 #include "TestI.h"
-#include "TestHelper.h"
 #include "Ice/Communicator.h"
+#include "TestHelper.h"
 
 using namespace std;
 using namespace Ice;
@@ -16,7 +16,7 @@ TestIntfI::opShortArray(pair<const int16_t*, const int16_t*> inSeq, ShortSeq& ou
 #ifdef ICE_UNALIGNED
     // Verify inSeq is not aligned and holds the expected values.
     test(reinterpret_cast<size_t>(inSeq.first) % 8 != 0);
-    for(int i = 0; i < inSeq.second - inSeq.first; ++i)
+    for (int i = 0; i < inSeq.second - inSeq.first; ++i)
     {
         test(inSeq.first[i] == i + 1);
     }

--- a/cpp/test/Ice/custom/TestI.cpp
+++ b/cpp/test/Ice/custom/TestI.cpp
@@ -3,15 +3,38 @@
 //
 
 #include "TestI.h"
+#include "TestHelper.h"
 #include "Ice/Communicator.h"
 
 using namespace std;
 using namespace Ice;
 using namespace Test;
 
-DoubleSeq
-TestIntfI::opDoubleArray(pair<const double*, const double*> inSeq, DoubleSeq& outSeq, const Current&)
+ShortSeq
+TestIntfI::opShortArray(pair<const int16_t*, const int16_t*> inSeq, ShortSeq& outSeq, const Current&)
 {
+#ifdef ICE_UNALIGNED
+    // Verify inSeq is not aligned and holds the expected values.
+    test(reinterpret_cast<size_t>(inSeq.first) % 8 != 0);
+    for(int i = 0; i < inSeq.second - inSeq.first; ++i)
+    {
+        test(inSeq.first[i] == i + 1);
+    }
+#endif
+
+    ShortSeq(inSeq.first, inSeq.second).swap(outSeq);
+    return outSeq;
+}
+
+DoubleSeq
+TestIntfI::opDoubleArray(bool, pair<const double*, const double*> inSeq, DoubleSeq& outSeq, const Current&)
+{
+#ifdef ICE_UNALIGNED
+    // Verify inSeq is not aligned.
+    test(reinterpret_cast<size_t>(inSeq.first) % 8 != 0);
+    test(*(inSeq.first) == 3.14);
+#endif
+
     DoubleSeq(inSeq.first, inSeq.second).swap(outSeq);
     return outSeq;
 }

--- a/cpp/test/Ice/custom/TestI.h
+++ b/cpp/test/Ice/custom/TestI.h
@@ -10,7 +10,9 @@
 class TestIntfI final : public Test::TestIntf
 {
 public:
-    Test::DoubleSeq opDoubleArray(std::pair<const double*, const double*>, Test::DoubleSeq&, const Ice::Current&) final;
+    Test::ShortSeq opShortArray(std::pair<const std::int16_t*, const std::int16_t*>, Test::ShortSeq&, const Ice::Current&) final;
+
+    Test::DoubleSeq opDoubleArray(bool, std::pair<const double*, const double*>, Test::DoubleSeq&, const Ice::Current&) final;
 
     Test::BoolSeq opBoolArray(std::pair<const bool*, const bool*>, Test::BoolSeq&, const Ice::Current&) final;
 

--- a/cpp/test/Ice/custom/TestI.h
+++ b/cpp/test/Ice/custom/TestI.h
@@ -10,9 +10,11 @@
 class TestIntfI final : public Test::TestIntf
 {
 public:
-    Test::ShortSeq opShortArray(std::pair<const std::int16_t*, const std::int16_t*>, Test::ShortSeq&, const Ice::Current&) final;
+    Test::ShortSeq
+    opShortArray(std::pair<const std::int16_t*, const std::int16_t*>, Test::ShortSeq&, const Ice::Current&) final;
 
-    Test::DoubleSeq opDoubleArray(bool, std::pair<const double*, const double*>, Test::DoubleSeq&, const Ice::Current&) final;
+    Test::DoubleSeq
+    opDoubleArray(bool, std::pair<const double*, const double*>, Test::DoubleSeq&, const Ice::Current&) final;
 
     Test::BoolSeq opBoolArray(std::pair<const bool*, const bool*>, Test::BoolSeq&, const Ice::Current&) final;
 


### PR DESCRIPTION
This PR makes the unaligned unmarshaling of some cpp:array sequences opt-in in C++.

It also improves the custom test.