### PR TITLE
Ruby Proxy cleanup

### DIFF
--- a/ruby/ruby/Ice/Proxy.rb
+++ b/ruby/ruby/Ice/Proxy.rb
@@ -10,10 +10,6 @@ module Ice
     # Provide some common functionality for proxy classes
     module Proxy_mixin
         module ClassMethods
-            def inspect
-                ::Ice::__stringify(self, self.class::ICE_TYPE)
-            end
-
             def ice_staticId()
                 self::ICE_ID
             end

--- a/ruby/ruby/Ice/Proxy.rb
+++ b/ruby/ruby/Ice/Proxy.rb
@@ -21,10 +21,6 @@ module Ice
             def checkedCast(proxy, facetOrContext=nil, context=nil)
                 ice_checkedCast(proxy, self::ICE_ID, facetOrContext, context)
             end
-
-            def uncheckedCast(proxy, facet=nil)
-                ice_uncheckedCast(proxy, facet)
-            end
         end
 
       def self.included(base)

--- a/ruby/src/IceRuby/Proxy.cpp
+++ b/ruby/src/IceRuby/Proxy.cpp
@@ -189,19 +189,19 @@ IceRuby_ObjectPrx_ice_getIdentity(VALUE self)
 extern "C" VALUE
 IceRuby_ObjectPrx_ice_identity(VALUE self, VALUE args)
 {
-    VALUE cls = Qnil;
-    long len = RARRAY_LEN(args);
-    if (len > 2 || len == 0)
-    {
-        rb_raise(rb_eArgError, "wrong number of arguments");
-    }
-    if (len == 2)
-    {
-        cls = rb_ary_entry(args, 1);
-    }
-
     ICE_RUBY_TRY
     {
+         VALUE cls = Qnil;
+        long len = RARRAY_LEN(args);
+        if (len > 2 || len == 0)
+        {
+            throw RubyException(rb_eArgError, "ice_identity requires one or two arguments");
+        }
+        if (len == 2)
+        {
+            cls = rb_ary_entry(args, 1);
+        }
+
         Ice::ObjectPrx p = getProxy(self);
         Ice::Identity ident = getIdentity(rb_ary_entry(args, 0));
         return createProxy(p->ice_identity(ident), cls);
@@ -256,19 +256,19 @@ IceRuby_ObjectPrx_ice_getFacet(VALUE self)
 extern "C" VALUE
 IceRuby_ObjectPrx_ice_facet(VALUE self, VALUE args)
 {
-    VALUE cls = Qnil;
-    long len = RARRAY_LEN(args);
-    if (len > 2 || len == 0)
-    {
-        rb_raise(rb_eArgError, "wrong number of arguments");
-    }
-    if (len == 2)
-    {
-        cls = rb_ary_entry(args, 1);
-    }
-
     ICE_RUBY_TRY
     {
+        VALUE cls = Qnil;
+        long len = RARRAY_LEN(args);
+        if (len > 2 || len == 0)
+        {
+            throw RubyException(rb_eArgError, "ice_facet requires one or two arguments");
+        }
+        if (len == 2)
+        {
+            cls = rb_ary_entry(args, 1);
+        }
+
         Ice::ObjectPrx p = getProxy(self);
         string f = getString(rb_ary_entry(args, 0));
         return createProxy(p->ice_facet(f), cls);
@@ -1033,47 +1033,6 @@ IceRuby_ObjectPrx_checkedCast(int argc, VALUE* args, VALUE /*self*/)
 }
 
 extern "C" VALUE
-IceRuby_ObjectPrx_uncheckedCast(int argc, VALUE* args, VALUE /*self*/)
-{
-    ICE_RUBY_TRY
-    {
-        if (argc < 1 || argc > 2)
-        {
-            throw RubyException(rb_eArgError, "uncheckedCast requires a proxy argument and an optional facet");
-        }
-
-        if (NIL_P(args[0]))
-        {
-            return Qnil;
-        }
-
-        if (!checkProxy(args[0]))
-        {
-            throw RubyException(rb_eArgError, "uncheckedCast requires a proxy argument");
-        }
-
-        volatile VALUE facet = Qnil;
-        if (argc == 2)
-        {
-            facet = args[1];
-        }
-
-        Ice::ObjectPrx p = getProxy(args[0]);
-
-        if (!NIL_P(facet))
-        {
-            return createProxy(p->ice_facet(getString(facet)));
-        }
-        else
-        {
-            return createProxy(p);
-        }
-    }
-    ICE_RUBY_CATCH
-    return Qnil;
-}
-
-extern "C" VALUE
 IceRuby_ObjectPrx_ice_checkedCast(VALUE self, VALUE obj, VALUE id, VALUE facetOrContext, VALUE ctx)
 {
     //
@@ -1126,10 +1085,23 @@ IceRuby_ObjectPrx_ice_checkedCast(VALUE self, VALUE obj, VALUE id, VALUE facetOr
 }
 
 extern "C" VALUE
-IceRuby_ObjectPrx_ice_uncheckedCast(VALUE self, VALUE obj, VALUE facet)
+IceRuby_ObjectPrx_uncheckedCast(VALUE self, VALUE args)
 {
     ICE_RUBY_TRY
     {
+        VALUE facet = Qnil;
+        long len = RARRAY_LEN(args);
+        if (len > 2 || len == 0)
+        {
+            throw RubyException(rb_eArgError, "uncheckedCast requires one or two arguments");
+        }
+
+        VALUE obj = rb_ary_entry(args, 0);
+        if (len == 2)
+        {
+            facet = rb_ary_entry(args, 1);
+        }
+
         if (NIL_P(obj))
         {
             return Qnil;
@@ -1264,9 +1236,8 @@ IceRuby::initProxy(VALUE iceModule)
     // Static methods.
     //
     rb_define_singleton_method(_proxyClass, "checkedCast", CAST_METHOD(IceRuby_ObjectPrx_checkedCast), -1);
-    rb_define_singleton_method(_proxyClass, "uncheckedCast", CAST_METHOD(IceRuby_ObjectPrx_uncheckedCast), -1);
+    rb_define_singleton_method(_proxyClass, "uncheckedCast", CAST_METHOD(IceRuby_ObjectPrx_uncheckedCast), -2);
     rb_define_singleton_method(_proxyClass, "ice_checkedCast", CAST_METHOD(IceRuby_ObjectPrx_ice_checkedCast), 4);
-    rb_define_singleton_method(_proxyClass, "ice_uncheckedCast", CAST_METHOD(IceRuby_ObjectPrx_ice_uncheckedCast), 2);
     rb_define_singleton_method(_proxyClass, "ice_staticId", CAST_METHOD(IceRuby_ObjectPrx_ice_staticId), 0);
     rb_define_singleton_method(_proxyClass, "new", CAST_METHOD(IceRuby_ObjectPrx_new), 2);
 }

--- a/ruby/src/IceRuby/Proxy.cpp
+++ b/ruby/src/IceRuby/Proxy.cpp
@@ -187,13 +187,24 @@ IceRuby_ObjectPrx_ice_getIdentity(VALUE self)
 }
 
 extern "C" VALUE
-IceRuby_ObjectPrx_ice_identity(VALUE self, VALUE id)
+IceRuby_ObjectPrx_ice_identity(VALUE self, VALUE args)
 {
+    VALUE cls = Qnil;
+    long len = RARRAY_LEN(args);
+    if (len > 2 || len == 0)
+    {
+        rb_raise(rb_eArgError, "wrong number of arguments");
+    }
+    if (len == 2)
+    {
+        cls = rb_ary_entry(args, 1);
+    }
+
     ICE_RUBY_TRY
     {
         Ice::ObjectPrx p = getProxy(self);
-        Ice::Identity ident = getIdentity(id);
-        return createProxy(p->ice_identity(ident));
+        Ice::Identity ident = getIdentity(rb_ary_entry(args, 0));
+        return createProxy(p->ice_identity(ident), cls);
     }
     ICE_RUBY_CATCH
     return Qnil;
@@ -243,13 +254,24 @@ IceRuby_ObjectPrx_ice_getFacet(VALUE self)
 }
 
 extern "C" VALUE
-IceRuby_ObjectPrx_ice_facet(VALUE self, VALUE facet)
+IceRuby_ObjectPrx_ice_facet(VALUE self, VALUE args)
 {
+    VALUE cls = Qnil;
+    long len = RARRAY_LEN(args);
+    if (len > 2 || len == 0)
+    {
+        rb_raise(rb_eArgError, "wrong number of arguments");
+    }
+    if (len == 2)
+    {
+        cls = rb_ary_entry(args, 1);
+    }
+
     ICE_RUBY_TRY
     {
         Ice::ObjectPrx p = getProxy(self);
-        string f = getString(facet);
-        return createProxy(p->ice_facet(f));
+        string f = getString(rb_ary_entry(args, 0));
+        return createProxy(p->ice_facet(f), cls);
     }
     ICE_RUBY_CATCH
     return Qnil;
@@ -1172,11 +1194,11 @@ IceRuby::initProxy(VALUE iceModule)
     rb_define_method(_proxyClass, "ice_ids", CAST_METHOD(IceRuby_ObjectPrx_ice_ids), -1);
     rb_define_method(_proxyClass, "ice_id", CAST_METHOD(IceRuby_ObjectPrx_ice_id), -1);
     rb_define_method(_proxyClass, "ice_getIdentity", CAST_METHOD(IceRuby_ObjectPrx_ice_getIdentity), 0);
-    rb_define_method(_proxyClass, "ice_identity", CAST_METHOD(IceRuby_ObjectPrx_ice_identity), 1);
+    rb_define_method(_proxyClass, "ice_identity", CAST_METHOD(IceRuby_ObjectPrx_ice_identity), -2);
     rb_define_method(_proxyClass, "ice_getContext", CAST_METHOD(IceRuby_ObjectPrx_ice_getContext), 0);
     rb_define_method(_proxyClass, "ice_context", CAST_METHOD(IceRuby_ObjectPrx_ice_context), 1);
     rb_define_method(_proxyClass, "ice_getFacet", CAST_METHOD(IceRuby_ObjectPrx_ice_getFacet), 0);
-    rb_define_method(_proxyClass, "ice_facet", CAST_METHOD(IceRuby_ObjectPrx_ice_facet), 1);
+    rb_define_method(_proxyClass, "ice_facet", CAST_METHOD(IceRuby_ObjectPrx_ice_facet), -2);
     rb_define_method(_proxyClass, "ice_getAdapterId", CAST_METHOD(IceRuby_ObjectPrx_ice_getAdapterId), 0);
     rb_define_method(_proxyClass, "ice_adapterId", CAST_METHOD(IceRuby_ObjectPrx_ice_adapterId), 1);
     rb_define_method(_proxyClass, "ice_getEndpoints", CAST_METHOD(IceRuby_ObjectPrx_ice_getEndpoints), 0);

--- a/ruby/test/Ice/exceptions/AllTests.rb
+++ b/ruby/test/Ice/exceptions/AllTests.rb
@@ -49,7 +49,7 @@ def allTests(helper, communicator)
 
     print "testing checked cast... "
     STDOUT.flush
-    thrower = Test::ThrowerPrx::checkedCast(base)
+    thrower = Test::ThrowerPrx.checkedCast(base)
     test(thrower)
     test(thrower == base)
     puts "ok"

--- a/ruby/test/Ice/exceptions/AllTests.rb
+++ b/ruby/test/Ice/exceptions/AllTests.rb
@@ -291,7 +291,7 @@ def allTests(helper, communicator)
 
     id = Ice::stringToIdentity("does not exist")
     begin
-        thrower2 = Test::ThrowerPrx::uncheckedCast(thrower.ice_identity(id))
+        thrower2 = thrower.ice_identity(id, Test::ThrowerPrx)
         thrower2.throwAasA(1)
 #       thrower2.ice_ping()
         test(false)
@@ -306,11 +306,10 @@ def allTests(helper, communicator)
 
     print "catching facet not exist exception... "
     STDOUT.flush
-
     begin
-        thrower2 = Test::ThrowerPrx::uncheckedCast(thrower, "no such facet")
+        thrower2 = thrower.ice_facet("no such facet", Test::ThrowerPrx)
         begin
-            thrower2.ice_ping()
+            thrower2.throwAasA(1)
             test(false)
         rescue Ice::FacetNotExistException => ex
             test(ex.facet == "no such facet")

--- a/ruby/test/Ice/facets/AllTests.rb
+++ b/ruby/test/Ice/facets/AllTests.rb
@@ -60,21 +60,21 @@ def allTests(helper, communicator)
 
     print "testing checked cast... "
     STDOUT.flush
-    obj = Ice::ObjectPrx::checkedCast(db)
+    obj = Ice::ObjectPrx.checkedCast(db)
     test(obj.ice_getFacet() == "")
-    obj = Ice::ObjectPrx::checkedCast(db, "facetABCD")
+    obj = Ice::ObjectPrx.checkedCast(db, "facetABCD")
     test(obj.ice_getFacet() == "facetABCD")
-    obj2 = Ice::ObjectPrx::checkedCast(obj)
+    obj2 = Ice::ObjectPrx.checkedCast(obj)
     test(obj2.ice_getFacet() == "facetABCD")
-    obj3 = Ice::ObjectPrx::checkedCast(obj, "")
+    obj3 = Ice::ObjectPrx.checkedCast(obj, "")
     test(obj3.ice_getFacet() == "")
-    d = Test::DPrx::checkedCast(db)
+    d = Test::DPrx.checkedCast(db)
     test(d.ice_getFacet() == "")
-    df = Test::DPrx::checkedCast(db, "facetABCD")
+    df = Test::DPrx.checkedCast(db, "facetABCD")
     test(df.ice_getFacet() == "facetABCD")
-    df2 = Test::DPrx::checkedCast(df)
+    df2 = Test::DPrx.checkedCast(df)
     test(df2.ice_getFacet() == "facetABCD")
-    df3 = Test::DPrx::checkedCast(df, "")
+    df3 = Test::DPrx.checkedCast(df, "")
     test(df3.ice_getFacet() == "")
     puts "ok"
 
@@ -88,7 +88,7 @@ def allTests(helper, communicator)
 
     print "testing facets A, B, C, and D... "
     STDOUT.flush
-    df = Test::DPrx::checkedCast(d, "facetABCD")
+    df = Test::DPrx.checkedCast(d, "facetABCD")
     test(df)
     test(df.callA() == "A")
     test(df.callB() == "B")
@@ -98,7 +98,7 @@ def allTests(helper, communicator)
 
     print "testing facets E and F... "
     STDOUT.flush
-    ff = Test::FPrx::checkedCast(d, "facetEF")
+    ff = Test::FPrx.checkedCast(d, "facetEF")
     test(ff)
     test(ff.callE() == "E")
     test(ff.callF() == "F")
@@ -106,14 +106,14 @@ def allTests(helper, communicator)
 
     print "testing facet G... "
     STDOUT.flush
-    gf = Test::GPrx::checkedCast(ff, "facetGH")
+    gf = Test::GPrx.checkedCast(ff, "facetGH")
     test(gf)
     test(gf.callG() == "G")
     puts "ok"
 
     print "testing whether casting preserves the facet... "
     STDOUT.flush
-    hf = Test::HPrx::checkedCast(gf)
+    hf = Test::HPrx.checkedCast(gf)
     test(hf)
     test(hf.callG() == "G")
     test(hf.callH() == "H")

--- a/ruby/test/Ice/info/AllTests.rb
+++ b/ruby/test/Ice/info/AllTests.rb
@@ -69,13 +69,12 @@ def allTests(helper, communicator)
     defaultHost = communicator.getProperties().getProperty("Ice.Default.Host")
     tcpEndpoint = helper.getTestEndpoint()
     udpEndpoint = helper.getTestEndpoint(protocol:"udp")
-    base = communicator.stringToProxy("test:#{tcpEndpoint}:#{udpEndpoint}")
-    testIntf = Test::TestIntfPrx::checkedCast(base)
+    testIntf = Test::TestIntfPrx.new(communicator, "test:#{tcpEndpoint}:#{udpEndpoint}")
 
     print "test connection endpoint information..."
     STDOUT.flush
     port = helper.getTestPort()
-    tcpinfo = getTCPEndpointInfo(base.ice_getConnection().getEndpoint().getInfo())
+    tcpinfo = getTCPEndpointInfo(testIntf.ice_getConnection().getEndpoint().getInfo())
     test(tcpinfo.port == port)
     test(!tcpinfo.compress)
     test(tcpinfo.host == defaultHost)
@@ -86,7 +85,7 @@ def allTests(helper, communicator)
     port = Integer(ctx["port"])
     test(port > 0)
 
-    udp = base.ice_datagram().ice_getConnection().getEndpoint().getInfo()
+    udp = testIntf.ice_datagram().ice_getConnection().getEndpoint().getInfo()
     test(udp.port == port)
     test(udp.host == defaultHost)
 
@@ -95,7 +94,7 @@ def allTests(helper, communicator)
     print "testing connection information..."
     STDOUT.flush
 
-    connection = base.ice_getConnection()
+    connection = testIntf.ice_getConnection()
     connection.setBufferSize(1024, 2048)
 
     info = connection.getInfo()
@@ -119,7 +118,7 @@ def allTests(helper, communicator)
     test(ctx["remotePort"] == tcpinfo.localPort.to_s())
     test(ctx["localPort"] == tcpinfo.remotePort.to_s())
 
-    if base.ice_getConnection().type() == "ws" || base.ice_getConnection().type() == "wss"
+    if testIntf.ice_getConnection().type() == "ws" || testIntf.ice_getConnection().type() == "wss"
         test(info.is_a?(Ice::WSConnectionInfo))
 
         test(info.headers["Upgrade"] == "websocket")

--- a/ruby/test/Ice/location/AllTests.rb
+++ b/ruby/test/Ice/location/AllTests.rb
@@ -10,9 +10,8 @@ end
 
 def allTests(helper, communicator)
     ref =  "ServerManager:#{helper.getTestEndpoint()}"
-    manager = Test::ServerManagerPrx::checkedCast(communicator.stringToProxy(ref))
+    manager = Test::ServerManagerPrx.new(communicator, ref)
     locator = communicator.getDefaultLocator()
-    test(manager)
 
     print "testing stringToProxy... "
     STDOUT.flush
@@ -62,18 +61,18 @@ def allTests(helper, communicator)
 
     print "testing checked cast... "
     STDOUT.flush
-    obj = Test::TestIntfPrx::checkedCast(base)
-    obj = Test::TestIntfPrx::checkedCast(communicator.stringToProxy("test@TestAdapter"))
-    obj = Test::TestIntfPrx::checkedCast(communicator.stringToProxy("test   @TestAdapter"))
-    obj = Test::TestIntfPrx::checkedCast(communicator.stringToProxy("test@   TestAdapter"))
+    obj = Test::TestIntfPrx.checkedCast(base)
+    obj = Test::TestIntfPrx.checkedCast(communicator.stringToProxy("test@TestAdapter"))
+    obj = Test::TestIntfPrx.checkedCast(communicator.stringToProxy("test   @TestAdapter"))
+    obj = Test::TestIntfPrx.checkedCast(communicator.stringToProxy("test@   TestAdapter"))
     test(obj)
-    obj2 = Test::TestIntfPrx::checkedCast(base2)
+    obj2 = Test::TestIntfPrx.checkedCast(base2)
     test(obj2)
-    obj3 = Test::TestIntfPrx::checkedCast(base3)
+    obj3 = Test::TestIntfPrx.checkedCast(base3)
     test(obj3)
-    obj4 = Test::ServerManagerPrx::checkedCast(base4)
+    obj4 = Test::ServerManagerPrx.checkedCast(base4)
     test(obj4)
-    obj5 = Test::TestIntfPrx::checkedCast(base5)
+    obj5 = Test::TestIntfPrx.checkedCast(base5)
     test(obj5)
     puts "ok"
 
@@ -82,7 +81,7 @@ def allTests(helper, communicator)
     obj.shutdown()
     manager.startServer()
     begin
-        obj2 = Test::TestIntfPrx::checkedCast(base2)
+        obj2 = Test::TestIntfPrx.checkedCast(base2)
         obj2.ice_ping()
     rescue Ice::LocalException
         test(false)
@@ -94,13 +93,13 @@ def allTests(helper, communicator)
     obj.shutdown()
     manager.startServer()
     begin
-        obj3 = Test::TestIntfPrx::checkedCast(base3)
+        obj3 = Test::TestIntfPrx.checkedCast(base3)
         obj3.ice_ping()
     rescue Ice::LocalException
         test(false)
     end
     begin
-        obj2 = Test::TestIntfPrx::checkedCast(base2)
+        obj2 = Test::TestIntfPrx.checkedCast(base2)
         obj2.ice_ping()
     rescue Ice::LocalException
         test(false)
@@ -108,13 +107,13 @@ def allTests(helper, communicator)
     obj.shutdown()
     manager.startServer()
     begin
-        obj2 = Test::TestIntfPrx::checkedCast(base2)
+        obj2 = Test::TestIntfPrx.checkedCast(base2)
         obj2.ice_ping()
     rescue Ice::LocalException
         test(false)
     end
     begin
-        obj3 = Test::TestIntfPrx::checkedCast(base3)
+        obj3 = Test::TestIntfPrx.checkedCast(base3)
         obj3.ice_ping()
     rescue Ice::LocalException
         test(false)
@@ -123,7 +122,7 @@ def allTests(helper, communicator)
     manager.startServer()
 
     begin
-        obj2 = Test::TestIntfPrx::checkedCast(base2)
+        obj2 = Test::TestIntfPrx.checkedCast(base2)
         obj2.ice_ping()
     rescue Ice::LocalException
         test(false)
@@ -131,7 +130,7 @@ def allTests(helper, communicator)
     obj.shutdown()
     manager.startServer()
     begin
-        obj3 = Test::TestIntfPrx::checkedCast(base3)
+        obj3 = Test::TestIntfPrx.checkedCast(base3)
         obj3.ice_ping()
     rescue Ice::LocalException
         test(false)
@@ -139,7 +138,7 @@ def allTests(helper, communicator)
     obj.shutdown()
     manager.startServer()
     begin
-        obj2 = Test::TestIntfPrx::checkedCast(base2)
+        obj2 = Test::TestIntfPrx.checkedCast(base2)
         obj2.ice_ping()
     rescue Ice::LocalException
         test(false)
@@ -148,7 +147,7 @@ def allTests(helper, communicator)
     manager.startServer()
 
     begin
-        obj5 = Test::TestIntfPrx::checkedCast(base5)
+        obj5 = Test::TestIntfPrx.checkedCast(base5)
         obj5.ice_ping()
     rescue Ice::LocalException
         test(false)
@@ -194,7 +193,7 @@ def allTests(helper, communicator)
 
     print "testing object migration... "
     STDOUT.flush
-    hello = Test::HelloPrx::checkedCast(communicator.stringToProxy("hello"))
+    hello = Test::HelloPrx.checkedCast(communicator.stringToProxy("hello"))
     obj.migrateHello()
     hello.sayHello()
     obj.migrateHello()

--- a/ruby/test/Ice/objects/AllTests.rb
+++ b/ruby/test/Ice/objects/AllTests.rb
@@ -50,19 +50,7 @@ def allTests(helper, communicator)
     valueFactoryManager.add(factory, '::Test::I')
     valueFactoryManager.add(factory, '::Test::J')
 
-    print "testing stringToProxy... "
-    STDOUT.flush
-    ref = "initial:#{helper.getTestEndpoint()}"
-    base = communicator.stringToProxy(ref)
-    test(base)
-    puts "ok"
-
-    print "testing checked cast... "
-    STDOUT.flush
-    initial = Test::InitialPrx::checkedCast(base)
-    test(initial)
-    test(initial == base)
-    puts "ok"
+    initial = Test::InitialPrx.new(communicator, "initial:#{helper.getTestEndpoint()}")
 
     print "getting B1... "
     STDOUT.flush

--- a/ruby/test/Ice/operations/AllTests.rb
+++ b/ruby/test/Ice/operations/AllTests.rb
@@ -8,7 +8,7 @@ require './BatchOneways'
 def allTests(helper, communicator)
     ref = "test:#{helper.getTestEndpoint()}"
     cl = Test::MyClassPrx.new(communicator, ref)
-    derived = Test::MyDerivedClassPrx::checkedCast(cl)
+    derived = Test::MyDerivedClassPrx.checkedCast(cl)
 
     print "testing twoway operations... "
     STDOUT.flush

--- a/ruby/test/Ice/operations/Twoways.rb
+++ b/ruby/test/Ice/operations/Twoways.rb
@@ -1159,7 +1159,7 @@ def twoways(helper, communicator, p)
     test(p.ice_getContext().length == 0)
     test(r == ctx)
 
-    p2 = Test::MyClassPrx::checkedCast(p.ice_context(ctx))
+    p2 = p.ice_context(ctx)
     test(p2.ice_getContext() == ctx)
     r = p2.opContext()
     test(r == ctx)
@@ -1183,7 +1183,9 @@ def twoways(helper, communicator, p)
     test(p.opStringS2(nil).length == 0)
     test(p.opByteBoolD2(nil).length == 0)
 
-    d = Test::MyDerivedClassPrx::uncheckedCast(p)
+    d = Test::MyDerivedClassPrx.uncheckedCast(p)
+    test(d.class == Test::MyDerivedClassPrx)
+
     s = Test::MyStruct1.new
     s.tesT = "Test.MyStruct1.s"
     s.myClass = nil

--- a/ruby/test/Ice/proxy/AllTests.rb
+++ b/ruby/test/Ice/proxy/AllTests.rb
@@ -586,28 +586,28 @@ def allTests(helper, communicator)
 
     print "testing checked cast... "
     STDOUT.flush
-    cl = Test::MyClassPrx::checkedCast(base)
+    cl = Test::MyClassPrx.checkedCast(base)
     test(cl)
 
-    derived = Test::MyDerivedClassPrx::checkedCast(cl)
+    derived = Test::MyDerivedClassPrx.checkedCast(cl)
     test(derived)
     test(cl == base)
     test(derived == base)
     test(cl == derived)
     begin
-        Test::MyDerivedClassPrx::checkedCast(cl, "facet")
+        Test::MyDerivedClassPrx.checkedCast(cl, "facet")
         test(false)
     rescue Ice::FacetNotExistException
     end
 
-    loc = Ice::LocatorPrx::checkedCast(base)
+    loc = Ice::LocatorPrx.checkedCast(base)
     test(loc == nil)
 
     #
     # Upcasting
     #
-    cl2 = Test::MyClassPrx::checkedCast(derived)
-    obj = Ice::ObjectPrx::checkedCast(derived)
+    cl2 = Test::MyClassPrx.checkedCast(derived)
+    obj = Ice::ObjectPrx.checkedCast(derived)
     test(cl2)
     test(obj)
     test(cl2 == obj)
@@ -617,14 +617,14 @@ def allTests(helper, communicator)
 
     print "testing checked cast with context... "
     STDOUT.flush
-    tccp = Test::MyClassPrx::checkedCast(base)
+    tccp = Test::MyClassPrx.checkedCast(base)
     c = tccp.getContext()
     test(c == nil || c.length == 0)
 
     c = { }
     c["one"] = "hello"
     c["two"] =  "world"
-    tccp = Test::MyClassPrx::checkedCast(base, c)
+    tccp = Test::MyClassPrx.checkedCast(base, c)
     c2 = tccp.getContext()
     test(c == c2)
     puts "ok"

--- a/ruby/test/Ice/scope/AllTests.rb
+++ b/ruby/test/Ice/scope/AllTests.rb
@@ -7,7 +7,7 @@ def allTests(helper, communicator)
     print "test using same type name in different Slice modules... "
     STDOUT.flush
 
-    i1 = Test::IPrx::checkedCast(communicator.stringToProxy("i1:#{helper.getTestEndpoint()}"))
+    i1 = Test::IPrx.new(communicator, "i1:#{helper.getTestEndpoint()}")
 
     s1 = Test::S.new(0)
     s2, s3 = i1.opS(s1)
@@ -50,7 +50,7 @@ def allTests(helper, communicator)
     c = i1.opC1(Test::C1.new("C1"))
     test(c.s == "C1")
 
-    i2 = Test::Inner::Inner2::IPrx::checkedCast(Ice::ObjectPrx.new(communicator, "i2:#{helper.getTestEndpoint()}"))
+    i2 = Test::Inner::Inner2::IPrx.new(communicator, "i2:#{helper.getTestEndpoint()}")
 
     s1 = Test::Inner::Inner2::S.new(0)
     s2, s3 = i2.opS(s1)
@@ -84,7 +84,7 @@ def allTests(helper, communicator)
     test(cmap2["a"].s == s1)
     test(cmap3["a"].s == s1)
 
-    i3 = Test::Inner::IPrx::checkedCast(communicator.stringToProxy("i3:#{helper.getTestEndpoint()}"))
+    i3 = Test::Inner::IPrx.new(communicator, "i3:#{helper.getTestEndpoint()}")
 
     s1 = Test::Inner::Inner2::S.new(0)
     s2, s3 = i3.opS(s1)
@@ -118,7 +118,7 @@ def allTests(helper, communicator)
     test(cmap2["a"].s == s1)
     test(cmap3["a"].s == s1)
 
-    i4 = Inner::Test::Inner2::IPrx::checkedCast(communicator.stringToProxy("i4:#{helper.getTestEndpoint()}"))
+    i4 = Inner::Test::Inner2::IPrx.new(communicator, "i4:#{helper.getTestEndpoint()}")
 
     s1 = Test::S.new(0)
     s2, s3 = i4.opS(s1)

--- a/ruby/test/Ice/timeout/AllTests.rb
+++ b/ruby/test/Ice/timeout/AllTests.rb
@@ -17,9 +17,7 @@ def connect(prx)
 end
 
 def allTests(helper, communicator)
-    controller = Test::ControllerPrx::checkedCast(
-        Ice::ObjectPrx.new(communicator,"controller:#{helper.getTestEndpoint(num:1)}"))
-    test(controller)
+    controller = Test::ControllerPrx.new(communicator, "controller:#{helper.getTestEndpoint(num:1)}")
     begin
         allTestsWithController(helper, communicator, controller)
     rescue


### PR DESCRIPTION
This PR includes various Proxy-related cleanups in Ruby.

In particular, both ice_facet and ice_identity now accepts an optional type as second parameter - the type of the proxy they return.