### PR TITLE
Add XxxPrxHelper::createProxy to PHP

### DIFF
--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -377,6 +377,11 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << sp << nl << "class " << prxName << "Helper";
     _out << sb;
 
+    _out << sp << nl << "public static function createProxy($communicator, $proxyString)";
+    _out << sb;
+    _out << nl << "return  $communicator->stringToProxy($proxyString, '" << scoped << "');";
+    _out << eb;
+
     _out << sp << nl << "public static function checkedCast($proxy, $facetOrContext=null, $context=null)";
     _out << sb;
     _out << nl << "return $proxy->ice_checkedCast('" << scoped << "', $facetOrContext, $context);";

--- a/php/README.md
+++ b/php/README.md
@@ -27,8 +27,7 @@ require_once 'Ice.php';
 require_once 'Hello.php';
 
 $communicator = Ice\initialize();
-$hello = Demo\HelloPrxHelper::uncheckedCast(
-    $communicator->stringToProxy("hello:default -h localhost -p 10000"));
+$hello = Demo\HelloPrxHelper::createProxy($communicator,"hello:default -h localhost -p 10000");
 $hello->sayHello();
 ```
 

--- a/php/lib/Ice/Proxy.php
+++ b/php/lib/Ice/Proxy.php
@@ -7,6 +7,11 @@ namespace Ice;
 
 class ObjectPrxHelper
 {
+    public static function createProxy($communicator, $proxyString)
+    {
+        return $communicator->stringToProxy($proxyString, '::Ice::Object');
+    }
+
     public static function checkedCast($proxy, $facetOrContext=null, $context=null)
     {
         return $proxy->ice_checkedCast('::Ice::Object', $facetOrContext, $context);

--- a/php/src/Communicator.cpp
+++ b/php/src/Communicator.cpp
@@ -316,6 +316,7 @@ ZEND_METHOD(Ice_Communicator, destroy)
 
 ZEND_BEGIN_ARG_INFO_EX(Ice_Communicator_stringToProxy_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(1))
 ZEND_ARG_INFO(0, str)
+ZEND_ARG_INFO(0, id)
 ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Ice_Communicator, stringToProxy)
@@ -323,20 +324,47 @@ ZEND_METHOD(Ice_Communicator, stringToProxy)
     CommunicatorInfoIPtr _this = Wrapper<CommunicatorInfoIPtr>::value(getThis());
     assert(_this);
 
+    // The second argument (the proxy type) is optional
+    if (ZEND_NUM_ARGS() < 1 || ZEND_NUM_ARGS() > 2)
+    {
+        WRONG_PARAM_COUNT;
+    }
+
     char* str;
     size_t strLen;
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), const_cast<char*>("s"), &str, &strLen) != SUCCESS)
+    char* id = nullptr; // the Slice type ID
+    size_t idLen = 0;
+
+    if (ZEND_NUM_ARGS() == 2)
+    {
+        if (zend_parse_parameters(ZEND_NUM_ARGS(), const_cast<char*>("s|s"), &str, &strLen, &id, &idLen) != SUCCESS)
+        {
+            RETURN_NULL();
+        }
+    }
+    else if (zend_parse_parameters(ZEND_NUM_ARGS(), const_cast<char*>("s"), &str, &strLen) != SUCCESS)
     {
         RETURN_NULL();
     }
-    string s(str, strLen);
+
+    string s{str, strLen};
+    ProxyInfoPtr proxyInfo;
+    if (id)
+    {
+        proxyInfo = getProxyInfo(id);
+        if (!proxyInfo)
+        {
+            invalidArgument(("unknown Slice interface type: " + string{id, idLen}).c_str());
+            RETURN_NULL();
+        }
+    }
 
     try
     {
         auto prx = _this->getCommunicator()->stringToProxy(s);
         if (prx)
         {
-            if (!createProxy(return_value, prx.value(), _this))
+            if (!createProxy(return_value, prx.value(), std::move(proxyInfo), _this))
             {
                 RETURN_NULL();
             }

--- a/php/test/Ice/binding/Client.php
+++ b/php/test/Ice/binding/Client.php
@@ -36,7 +36,7 @@ function allTests($helper)
     $communicator = $helper->communicator();
 
     $ref = sprintf("communicator:%s", $helper->getTestEndpoint());
-    $com = $communicator->stringToProxy($ref)->ice_uncheckedCast("::Test::RemoteCommunicator");
+    $com = $communicator->stringToProxy($ref, "::Test::RemoteCommunicator");
 
     echo "testing binding with single endpoint... ";
     flush();

--- a/php/test/Ice/enums/Client.php
+++ b/php/test/Ice/enums/Client.php
@@ -10,10 +10,7 @@ function allTests($helper)
 {
     $ref = sprintf("test:%s", $helper->getTestEndpoint());
     $communicator = $helper->communicator();
-    $obj = $communicator->stringToProxy($ref);
-    test($obj != null);
-    $proxy = $obj->ice_checkedCast("::Test::TestIntf");
-    test($proxy != null);
+    $proxy = Test\TestIntfPrxHelper::createProxy($communicator, $ref);
 
     echo "testing enum values... ";
     flush();

--- a/php/test/Ice/exceptions/Client.php
+++ b/php/test/Ice/exceptions/Client.php
@@ -43,19 +43,9 @@ function allTests($helper)
     }
     echo "ok\n";
 
-    echo "testing stringToProxy... ";
-    flush();
     $ref = sprintf("thrower:%s", $helper->getTestEndpoint());
     $communicator = $helper->communicator();
-    $base = $communicator->stringToProxy($ref);
-    test($base != null);
-    echo "ok\n";
-
-    echo "testing checked cast... ";
-    flush();
-    $thrower = $base->ice_checkedCast("::Test::Thrower");
-    test($thrower != null);
-    test($thrower == $base);
+    $thrower = Test\ThrowerPrxHelper::createProxy($communicator, $ref);
 
     echo "catching exact types... ";
     flush();
@@ -250,7 +240,7 @@ function allTests($helper)
     $id = Ice\stringToIdentity("does not exist");
     try
     {
-        $thrower2 = $thrower->ice_identity($id)->ice_uncheckedCast("::Test::Thrower");
+        $thrower2 = Test\ThrowerPrxHelper::uncheckedCast($thrower->ice_identity($id));
         $thrower2->throwAasA(1);
         test(false);
     }
@@ -265,7 +255,7 @@ function allTests($helper)
     flush();
 
     {
-        $thrower2 = $thrower->ice_uncheckedCast("::Test::Thrower", "no such facet");
+        $thrower2 = Test\ThrowerPrxHelper::uncheckedCast($thrower, "no such facet");
         try
         {
             $thrower2->ice_ping();
@@ -284,7 +274,7 @@ function allTests($helper)
 
     try
     {
-        $thrower2 = $thrower->ice_uncheckedCast("::Test::WrongOperation");
+        $thrower2 = Test\WrongOperationPrxHelper::uncheckedCast($thrower);
         $thrower2->noSuchOperation();
         test(false);
     }

--- a/php/test/Ice/info/Client.php
+++ b/php/test/Ice/info/Client.php
@@ -80,14 +80,13 @@ function allTests($helper)
     echo "ok\n";
 
     $defaultHost = $communicator->getProperties()->getProperty("Ice.Default.Host");
-    $base = $communicator->stringToProxy(
+    $testIntf = Test\TestIntfPrxHelper::createProxy($communicator,
         sprintf("test:%s:%s", $helper->getTestEndpoint(), $helper->getTestEndpoint("udp")));
-    $testIntf = $base->ice_checkedCast("::Test::TestIntf");
     $testPort = $helper->getTestPort();
     echo "test connection endpoint information... ";
     flush();
     {
-        $tcpinfo = getTCPEndpointInfo($base->ice_getConnection()->getEndpoint()->getInfo());
+        $tcpinfo = getTCPEndpointInfo($testIntf->ice_getConnection()->getEndpoint()->getInfo());
         test($tcpinfo instanceof Ice\TCPEndpointInfo);
         test($tcpinfo->port == $testPort);
         test(!$tcpinfo->compress);
@@ -98,7 +97,7 @@ function allTests($helper)
         test($ctx["compress"] == "false");
         test($ctx["port"] > 0);
 
-        $udpinfo = $base->ice_datagram()->ice_getConnection()->getEndpoint()->getInfo();
+        $udpinfo = $testIntf->ice_datagram()->ice_getConnection()->getEndpoint()->getInfo();
         test($udpinfo instanceof Ice\UDPEndpointInfo);
         test($udpinfo->port == $testPort);
         test($udpinfo->host == $defaultHost);
@@ -110,7 +109,7 @@ function allTests($helper)
     {
         $port = $helper->getTestPort();
 
-        $connection = $base->ice_getConnection();
+        $connection = $testIntf->ice_getConnection();
         $connection->setBufferSize(1024, 2048);
 
         $info = $connection->getInfo();
@@ -135,7 +134,7 @@ function allTests($helper)
         test($ctx["remotePort"] == $tcpinfo->localPort);
         test($ctx["localPort"] == $tcpinfo->remotePort);
 
-        if($base->ice_getConnection()->type() == "ws" || $base->ice_getConnection()->type() == "wss")
+        if($testIntf->ice_getConnection()->type() == "ws" || $testIntf->ice_getConnection()->type() == "wss")
         {
             test($info instanceof Ice\WSConnectionInfo);
 

--- a/php/test/Ice/inheritance/Client.php
+++ b/php/test/Ice/inheritance/Client.php
@@ -7,20 +7,9 @@ require_once('Test.php');
 
 function allTests($helper)
 {
-    echo "testing stringToProxy... ";
-    flush();
     $ref = sprintf("initial:%s", $helper->getTestEndpoint());
     $communicator = $helper->communicator();
-    $base = $communicator->stringToProxy($ref);
-    test($base != null);
-    echo "ok\n";
-
-    echo "testing checked cast... ";
-    flush();
-    $initial = $base->ice_checkedCast("::Test::Initial");
-    test($initial != null);
-    test($initial == $base);
-    echo "ok\n";
+    $initial = Test\InitialPrxHelper::createProxy($communicator, $ref);
 
     echo "getting proxies for interface hierarchy... ";
     flush();

--- a/php/test/Ice/objects/Client.php
+++ b/php/test/Ice/objects/Client.php
@@ -103,20 +103,9 @@ class MyValueFactory implements Ice\ValueFactory
 
 function allTests($helper)
 {
-    echo "testing stringToProxy... ";
-    flush();
     $ref = sprintf("initial:%s", $helper->getTestEndpoint());
     $communicator = $helper->communicator();
-    $base = $communicator->stringToProxy($ref);
-    test($base != null);
-    echo "ok\n";
-
-    echo "testing checked cast... ";
-    flush();
-    $initial = $base->ice_checkedCast("::Test::Initial");
-    test($initial != null);
-    test($initial == $base);
-    echo "ok\n";
+    $initial = Test\InitialPrxHelper::createProxy($communicator, $ref);
 
     echo "getting B1... ";
     flush();
@@ -416,10 +405,7 @@ function allTests($helper)
     echo "testing UnexpectedObjectException... ";
     flush();
     $ref = sprintf("uoet:%s", $helper->getTestEndpoint());
-    $base = $communicator->stringToProxy($ref);
-    test($base != null);
-    $uoet = $base->ice_uncheckedCast("::Test::UnexpectedObjectExceptionTest");
-    test($uoet != null);
+    $uoet = Test\UnexpectedObjectExceptionTestPrxHelper::createProxy($communicator, $ref);
     try
     {
         $uoet->op();
@@ -453,7 +439,7 @@ function allTests($helper)
 
     $f22 = null;
     $ref = sprintf("F21:%s", $helper->getTestEndpoint());
-    $f21 = $initial->opF2($communicator->stringToProxy($ref)->ice_uncheckedCast("::Test::F2"), $f22);
+    $f21 = $initial->opF2(Test\F2PrxHelper::createProxy($communicator, $ref), $f22);
     test($f21->ice_getIdentity()->name == "F21");
     $f21->op();
     test($f22->ice_getIdentity()->name == "F22");

--- a/php/test/Ice/operations/Client.php
+++ b/php/test/Ice/operations/Client.php
@@ -5,7 +5,7 @@
 
 require_once('Test.php');
 
-function twoways($communicator, $p, $bprx)
+function twoways($communicator, $p)
 {
     {
         $literals = $p->opStringLiterals();
@@ -1008,16 +1008,13 @@ function allTests($helper)
 {
     $ref = sprintf("test:%s", $helper->getTestEndpoint());
     $communicator = $helper->communicator();
-    $base = $communicator->stringToProxy($ref);
-    $cl = $base->ice_checkedCast("::Test::MyClass");
-    $derived = $cl->ice_checkedCast("::Test::MyDerivedClass");
-
-    $bprx = $communicator->stringToProxy(sprintf("b:%s", $helper->getTestEndpoint()))->ice_checkedCast("::M::B");
+    $cl = Test\MyClassPrxHelper::createProxy($communicator, $ref);
+    $derived = Test\MyDerivedClassPrxHelper::checkedCast($cl);
 
     echo "testing twoway operations... ";
     flush();
-    twoways($communicator, $cl, $bprx);
-    twoways($communicator, $derived, $bprx);
+    twoways($communicator, $cl);
+    twoways($communicator, $derived);
     $derived->opDerived();
     echo "ok\n";
 

--- a/php/test/Ice/optional/Client.php
+++ b/php/test/Ice/optional/Client.php
@@ -9,17 +9,9 @@ function allTests($helper)
 {
     global $Ice_Encoding_1_0;
 
-    echo "testing stringToProxy... ";
-    flush();
     $ref = sprintf("initial:%s", $helper->getTestEndpoint());
     $communicator = $helper->communicator();
-    $base = $communicator->stringToProxy($ref);
-    echo "ok\n";
-
-    echo "testing checked cast... ";
-    flush();
-    $initial = $base->ice_checkedCast("::Test::Initial");
-    echo "ok\n";
+    $initial = Test\InitialPrxHelper::createProxy($communicator, $ref);
 
     echo "testing optional data members... ";
     flush();
@@ -65,7 +57,7 @@ function allTests($helper)
     $ss = new Test\SmallStruct();
     $fs = new Test\FixedStruct(78);
     $vs = new Test\VarStruct("hello");
-    $prx = $communicator->stringToProxy("test")->ice_uncheckedCast("::Test::MyInterface");
+    $prx = Test\MyInterfacePrxHelper::createProxy($communicator, "test");
     $mo1 = new Test\MultiOptional(15, true, 19, 78, 99, 5.5, 1.0, 'test', Test\MyEnum::MyEnumMember,
                       $prx, array(5), array('test', 'test2'), array(4=>3), array('test'=>10),
                       $fs, $vs, array(1), array(Test\MyEnum::MyEnumMember, Test\MyEnum::MyEnumMember), array($fs), array($vs),
@@ -289,7 +281,7 @@ function allTests($helper)
     test($r->gg2Opt->a == 20);
     test($r->gg1->a == "gg1");
 
-    $initial2 = Test\Initial2PrxHelper::uncheckedCast($base);
+    $initial2 = Test\Initial2PrxHelper::uncheckedCast($initial);
     $initial2->opVoid(15, "test");
 
     echo "ok\n";
@@ -397,7 +389,7 @@ function allTests($helper)
         echo "testing operations with unknown optionals... ";
         flush();
 
-        $initial2 = Test\Initial2PrxHelper::uncheckedCast($base);
+        $initial2 = Test\Initial2PrxHelper::uncheckedCast($initial);
         $ovs = new Test\VarStruct("test");
         $initial2->opClassAndUnknownOptional(new Test\A, $ovs);
 

--- a/php/test/Ice/proxy/Client.php
+++ b/php/test/Ice/proxy/Client.php
@@ -322,22 +322,22 @@ function allTests($helper)
     $b1 = $b1->ice_locatorCacheTimeout(100);
     $b1 = $b1->ice_encodingVersion(new Ice\EncodingVersion(1, 0));
 
-    $router = $communicator->stringToProxy("router");
+    $router = Ice\RouterPrxHelper::createProxy($communicator, "router");
     //$router = $router->ice_collocationOptimized(false);
     $router = $router->ice_connectionCached(true);
     $router = $router->ice_preferSecure(true);
     $router = $router->ice_endpointSelection(Ice\EndpointSelectionType::Random);
     $router = $router->ice_locatorCacheTimeout(200);
 
-    $locator = $communicator->stringToProxy("locator");
+    $locator = Ice\LocatorPrxHelper::createProxy($communicator, "locator");
     //$locator = $locator->ice_collocationOptimized(true);
     $locator = $locator->ice_connectionCached(false);
     $locator = $locator->ice_preferSecure(true);
     $locator = $locator->ice_endpointSelection(Ice\EndpointSelectionType::Random);
     $locator = $locator->ice_locatorCacheTimeout(300);
 
-    $locator = $locator->ice_router($router->ice_uncheckedCast("::Ice::Router"));
-    $b1 = $b1->ice_locator($locator->ice_uncheckedCast("::Ice::Locator"));
+    $locator = $locator->ice_router($router);
+    $b1 = $b1->ice_locator($locator);
 
     $proxyProps = $communicator->proxyToProperty($b1, "Test");
     test(count($proxyProps) == 21);
@@ -422,9 +422,9 @@ function allTests($helper)
 
     echo "testing checked cast... ";
     flush();
-    $cl = $base->ice_checkedCast("::Test::MyClass");
+    $cl = Test\MyClassPrxHelper::checkedCast($base);
     test($cl != null);
-    $derived = $cl->ice_checkedCast("::Test::MyDerivedClass");
+    $derived = Test\MyDerivedClassPrxHelper::checkedCast($cl);
     test($derived != null);
     test($cl == $base);
     test($derived == $base);
@@ -432,7 +432,7 @@ function allTests($helper)
 
     try
     {
-        $base->ice_checkedCast("::Test::MyClass", "facet");
+        Test\MyClassPrxHelper::checkedCast($base, "facet");
         test(false);
     }
     catch(Ice\FacetNotExistException $ex)
@@ -449,6 +449,8 @@ function allTests($helper)
     $c["one"] = "hello";
     $c["two"] = "world";
     $clc = $base->ice_checkedCast("::Test::MyClass", $c);
+    // TODO: the following doesn't work:
+    // $clc = Test\MyClassPrxHelper::checkedCast($base, $c);
     $c2 = $clc->getContext();
     test($c == $c2);
 
@@ -508,7 +510,7 @@ function allTests($helper)
     echo "testing encoding versioning... ";
     flush();
     $ref20 = sprintf("test -e 2.0:%s", $helper->getTestEndpoint());
-    $cl20 = $communicator->stringToProxy($ref20)->ice_uncheckedCast("::Test::MyClass");
+    $cl20 = Test\MyClassPrxHelper::createProxy($communicator, $ref20);
     try
     {
         $cl20->ice_ping();
@@ -519,7 +521,7 @@ function allTests($helper)
         // Server 2.0 endpoint doesn't support 1.1 version.
     }
     $ref10 = sprintf("test -e 1.0:%s", $helper->getTestEndpoint());
-    $cl10 = $communicator->stringToProxy($ref10)->ice_uncheckedCast("::Test::MyClass");
+    $cl10 = Test\MyClassPrxHelper::createProxy($communicator, $ref10);
     $cl10->ice_ping();
     $cl10->ice_encodingVersion($Ice_Encoding_1_0)->ice_ping();
     $cl->ice_encodingVersion($Ice_Encoding_1_0)->ice_ping();

--- a/php/test/Ice/scope/Client.php
+++ b/php/test/Ice/scope/Client.php
@@ -9,8 +9,7 @@ function allTests($helper)
 {
     $communicator = $helper->communicator();
     {
-        $base = $communicator->stringToProxy(sprintf("i1:%s", $helper->getTestEndpoint()));
-        $i = $base->ice_checkedCast("::Test::I");
+        $i = Test\IPrxHelper::createProxy($communicator, sprintf("i1:%s", $helper->getTestEndpoint()));
 
         $s1 = new Test\S(0);
         $s2 = null;
@@ -42,8 +41,7 @@ function allTests($helper)
     }
 
     {
-        $base = $communicator->stringToProxy(sprintf("i2:%s", $helper->getTestEndpoint()));
-        $i = $base->ice_checkedCast("::Test::Inner::Inner2::I");
+        $i = Test\Inner\Inner2\IPrxHelper::createProxy($communicator, sprintf("i2:%s", $helper->getTestEndpoint()));
 
         $s1 = new Test\Inner\Inner2\S(0);
         $s2 = null;
@@ -65,8 +63,7 @@ function allTests($helper)
     }
 
     {
-        $base = $communicator->stringToProxy(sprintf("i3:%s", $helper->getTestEndpoint()));
-        $i = $base->ice_checkedCast("::Test::Inner::I");
+        $i = Test\Inner\IPrxHelper::createProxy($communicator, sprintf("i3:%s", $helper->getTestEndpoint()));
 
         $s1 = new Test\Inner\Inner2\S(0);
         $s2 = null;
@@ -88,8 +85,7 @@ function allTests($helper)
     }
 
     {
-        $base = $communicator->stringToProxy(sprintf("i4:%s", $helper->getTestEndpoint()));
-        $i = $base->ice_checkedCast("::Inner::Test::Inner2::I");
+        $i = Inner\Test\Inner2\IPrxHelper::createProxy($communicator, sprintf("i4:%s", $helper->getTestEndpoint()));
 
         $s1 = new Test\S(0);
         $s2 = null;
@@ -111,8 +107,7 @@ function allTests($helper)
     }
 
     {
-        $base = $communicator->stringToProxy(sprintf("i1:%s", $helper->getTestEndpoint()));
-        $i = $base->ice_checkedCast("::Test::I");
+        $i = Test\IPrxHelper::createProxy($communicator, sprintf("i1:%s", $helper->getTestEndpoint()));
         $i->shutdown();
     }
 }

--- a/php/test/Ice/slicing/exceptions/Client.php
+++ b/php/test/Ice/slicing/exceptions/Client.php
@@ -10,8 +10,7 @@ function allTests($helper)
     global $Ice_Encoding_1_0;
 
     $communicator = $helper->communicator();
-    $obj = $communicator->stringToProxy(sprintf("Test:%s", $helper->getTestEndpoint()));
-    $test = $obj->ice_checkedCast("::Test::TestIntf");
+    $test = Test\TestIntfPrxHelper::createProxy($communicator, sprintf("Test:%s", $helper->getTestEndpoint()));
 
     echo "base... ";
     flush();

--- a/php/test/Ice/slicing/objects/Client.php
+++ b/php/test/Ice/slicing/objects/Client.php
@@ -10,8 +10,7 @@ function allTests($helper)
     global $Ice_Encoding_1_0;
 
     $communicator = $helper->communicator();
-    $obj = $communicator->stringToProxy(sprintf("Test:%s", $helper->getTestEndpoint()));
-    $test = $obj->ice_checkedCast("::Test::TestIntf");
+    $test = Test\TestIntfPrxHelper::createProxy($communicator, sprintf("Test:%s", $helper->getTestEndpoint()));
 
     echo "base as Object... ";
     flush();

--- a/php/test/Ice/timeout/Client.php
+++ b/php/test/Ice/timeout/Client.php
@@ -35,9 +35,11 @@ function connect($prx)
 
 function allTests($helper)
 {
-    $controller = $helper->communicator()->stringToProxy(sprintf("controller:%s", $helper->getTestEndpoint(1)));
-    $controller = $controller->ice_checkedCast("::Test::Controller");
-    test($controller);
+    $communicator = $helper->communicator();
+    $controller = Test\ControllerPrxHelper::createProxy(
+        $communicator,
+        sprintf("controller:%s", $helper->getTestEndpoint(1)));
+
     try
     {
         allTestsWithController($helper, $controller);
@@ -55,11 +57,7 @@ function allTestsWithController($helper, $controller)
 {
     $communicator = $helper->communicator();
     $sref = sprintf("timeout:%s", $helper->getTestEndpoint());
-    $timeout = $communicator->stringToProxy($sref);
-    test($timeout);
-
-    $timeout = $timeout->ice_checkedCast("::Test::Timeout");
-    test($timeout);
+    $timeout = Test\TimeoutPrxHelper::createProxy($communicator, $sref);
 
     echo("testing invocation timeout... ");
     flush();
@@ -77,7 +75,7 @@ function allTestsWithController($helper, $controller)
         }
 
         $timeout->ice_ping();
-        $to = $timeout->ice_invocationTimeout(1000)->ice_checkedCast("::Test::Timeout");
+        $to = $timeout->ice_invocationTimeout(1000);
         test($connection == $to->ice_getConnection());
         $to->sleep(100);
         test($connection == $to->ice_getConnection());

--- a/php/test/Slice/escape/Client.php
+++ b/php/test/Slice/escape/Client.php
@@ -29,11 +29,10 @@ function allTests($helper)
     test($b->_use == 0);
     test($b->_var == 0);
     $communicator = $helper->communicator();
-    $p = $communicator->stringToProxy("test:tcp -p 10000");
-    $c = _and\functionPrxHelper::uncheckedCast($p);
-    $d = _and\diePrxHelper::uncheckedCast($p);
+    $c = _and\functionPrxHelper::createProxy($communicator, "test:tcp -p 10000");
+    $d = _and\diePrxHelper::uncheckedCast($c);
     $e1 = new echoI();
-    $f = _and\enddeclarePrxHelper::uncheckedCast($p);
+    $f = _and\enddeclarePrxHelper::uncheckedCast($c);
     $g = new _and\_endif();
     $h = new _and\_endwhile();
     echo "ok\n";


### PR DESCRIPTION
This PR adds a new createProxy method to the PHP mapping.

It allows you to create a typed proxy from a communicator and a proxy string, like in other language mappings.