### PR TITLE
Update checkedCast in Python

### DIFF
--- a/python/modules/IcePy/Proxy.cpp
+++ b/python/modules/IcePy/Proxy.cpp
@@ -1697,10 +1697,6 @@ checkedCastImpl(ProxyObject* p, const string& id, PyObject* facet, PyObject* ctx
         AllowThreads allowThreads; // Release Python's global interpreter lock during remote invocations.
         b = target->ice_isA(id, (ctx == 0 || ctx == Py_None) ? Ice::noExplicitContext : c);
     }
-    catch (const Ice::FacetNotExistException&)
-    {
-        // Ignore.
-    }
     catch (...)
     {
         setPythonException(current_exception());

--- a/python/test/Ice/admin/AllTests.py
+++ b/python/test/Ice/admin/AllTests.py
@@ -262,10 +262,18 @@ def allTests(helper, communicator):
     com = factory.createCommunicator(props)
     obj = com.getAdmin()
 
-    proc = Ice.ProcessPrx.checkedCast(obj, "Process")
-    test(proc is None)
-    tf = Test.TestFacetPrx.checkedCast(obj, "TestFacet")
-    test(tf is None)
+    try:
+        Ice.ProcessPrx.checkedCast(obj, "Process")
+        test(False)
+    except Ice.FacetNotExistException:
+        pass
+
+    try:
+        Test.TestFacetPrx.checkedCast(obj, "TestFacet")
+        test(False)
+    except Ice.FacetNotExistException:
+        pass
+
     com.destroy()
 
     #
@@ -279,10 +287,17 @@ def allTests(helper, communicator):
     com = factory.createCommunicator(props)
     obj = com.getAdmin()
 
-    pa = Ice.PropertiesAdminPrx.checkedCast(obj, "Properties")
-    test(pa is None)
-    tf = Test.TestFacetPrx.checkedCast(obj, "TestFacet")
-    test(tf is None)
+    try:
+        Ice.PropertiesAdminPrx.checkedCast(obj, "Properties")
+        test(False)
+    except Ice.FacetNotExistException:
+        pass
+
+    try:
+        Test.TestFacetPrx.checkedCast(obj, "TestFacet")
+        test(False)
+    except Ice.FacetNotExistException:
+        pass
 
     com.destroy()
 
@@ -297,11 +312,17 @@ def allTests(helper, communicator):
     com = factory.createCommunicator(props)
     obj = com.getAdmin()
 
-    pa = Ice.PropertiesAdminPrx.checkedCast(obj, "Properties")
-    test(pa is None)
+    try:
+        Ice.PropertiesAdminPrx.checkedCast(obj, "Properties")
+        test(False)
+    except Ice.FacetNotExistException:
+        pass
 
-    proc = Ice.ProcessPrx.checkedCast(obj, "Process")
-    test(proc is None)
+    try:
+        Ice.ProcessPrx.checkedCast(obj, "Process")
+        test(False)
+    except Ice.FacetNotExistException:
+        pass
 
     com.destroy()
 
@@ -320,8 +341,12 @@ def allTests(helper, communicator):
     tf = Test.TestFacetPrx.checkedCast(obj, "TestFacet")
     tf.op()
 
-    proc = Ice.ProcessPrx.checkedCast(obj, "Process")
-    test(proc is None)
+    try:
+        Ice.ProcessPrx.checkedCast(obj, "Process")
+        test(False)
+    except Ice.FacetNotExistException:
+        pass
+
     com.destroy()
 
     #
@@ -335,8 +360,11 @@ def allTests(helper, communicator):
     com = factory.createCommunicator(props)
     obj = com.getAdmin()
 
-    pa = Ice.PropertiesAdminPrx.checkedCast(obj, "Properties")
-    test(pa is None)
+    try:
+        Ice.PropertiesAdminPrx.checkedCast(obj, "Properties")
+        test(False)
+    except Ice.FacetNotExistException:
+        pass
 
     tf = Test.TestFacetPrx.checkedCast(obj, "TestFacet")
     tf.op()

--- a/python/test/Ice/facets/AllTests.py
+++ b/python/test/Ice/facets/AllTests.py
@@ -141,7 +141,11 @@ def allTests(helper, communicator):
     test(df2.ice_getFacet() == "facetABCD")
     df3 = Test.DPrx.checkedCast(df, "")
     test(df3.ice_getFacet() == "")
-    test(Test.DPrx.checkedCast(df, "bogus") is None)
+    try:
+        Test.DPrx.checkedCast(df, "bogus")
+        test(False)
+    except Ice.FacetNotExistException:
+        pass
     print("ok")
 
     sys.stdout.write("testing non-facets A, B, C, and D... ")

--- a/python/test/Ice/proxy/AllTests.py
+++ b/python/test/Ice/proxy/AllTests.py
@@ -777,7 +777,12 @@ def allTests(helper, communicator, collocated):
     test(cl == base)
     test(derived == base)
     test(cl == derived)
-    test(Test.MyDerivedClassPrx.checkedCast(cl, "facet") is None)
+
+    try:
+        Test.MyDerivedClassPrx.checkedCast(cl, "facet")
+        test(False)
+    except Ice.FacetNotExistException:
+        pass
 
     loc = Ice.LocatorPrx.checkedCast(base)
     test(loc is None)


### PR DESCRIPTION
This PR updates checkedCast in Python.

With this PR, `checkedCast(p, facet)` is equivalent to `checkedCast(p.ice_facet(facet))` in Python.

See #2323.