### PR TITLE
Simplify Ice.Current implementation in Python extension

### DIFF
--- a/python/modules/IcePy/Current.cpp
+++ b/python/modules/IcePy/Current.cpp
@@ -11,7 +11,8 @@
 using namespace std;
 using namespace IcePy;
 
-PyObject* IcePy::createCurrent(const Ice::Current& current)
+PyObject*
+IcePy::createCurrent(const Ice::Current& current)
 {
     PyObject* currentType = lookupType("Ice.Current");
 
@@ -61,7 +62,7 @@ PyObject* IcePy::createCurrent(const Ice::Current& current)
 
     PyObject* operationModeType = lookupType("Ice.OperationMode");
     assert(operationModeType);
-    const char * enumerator = nullptr;
+    const char* enumerator = nullptr;
     switch (current.mode)
     {
         case Ice::OperationMode::Normal:

--- a/python/modules/IcePy/Current.cpp
+++ b/python/modules/IcePy/Current.cpp
@@ -7,313 +7,95 @@
 #include "Ice/ObjectAdapter.h"
 #include "ObjectAdapter.h"
 #include "Util.h"
-#include <structmember.h>
 
 using namespace std;
 using namespace IcePy;
 
-namespace IcePy
+PyObject* IcePy::createCurrent(const Ice::Current& current)
 {
-    struct CurrentObject
-    {
-        PyObject_HEAD Ice::Current* current;
-        PyObject* adapter;
-        PyObject* con;
-        PyObject* id;
-        PyObject* facet;
-        PyObject* operation;
-        PyObject* mode;
-        PyObject* ctx;
-        PyObject* requestId;
-        PyObject* encoding;
-    };
+    PyObject* currentType = lookupType("Ice.Current");
 
-    //
-    // Member identifiers.
-    //
-    const Py_ssize_t CURRENT_ADAPTER = 0;
-    const Py_ssize_t CURRENT_CONNECTION = 1;
-    const Py_ssize_t CURRENT_ID = 2;
-    const Py_ssize_t CURRENT_FACET = 3;
-    const Py_ssize_t CURRENT_OPERATION = 4;
-    const Py_ssize_t CURRENT_MODE = 5;
-    const Py_ssize_t CURRENT_CTX = 6;
-    const Py_ssize_t CURRENT_REQUEST_ID = 7;
-    const Py_ssize_t CURRENT_ENCODING = 8;
-}
+    PyObjectHandle args = PyTuple_New(9);
 
-extern "C" CurrentObject*
-currentNew(PyTypeObject* type, PyObject* /*args*/, PyObject* /*kwds*/)
-{
-    CurrentObject* self = reinterpret_cast<CurrentObject*>(type->tp_alloc(type, 0));
-    if (!self)
+    PyObject* adapter = wrapObjectAdapter(current.adapter);
+    if (!adapter)
     {
         return nullptr;
     }
+    PyTuple_SetItem(args.get(), 0, adapter);
 
-    self->current = new Ice::Current;
-    self->adapter = 0;
-    self->con = 0;
-    self->id = 0;
-    self->facet = 0;
-    self->operation = 0;
-    self->mode = 0;
-    self->ctx = 0;
-    self->requestId = 0;
-    self->encoding = 0;
-
-    return self;
-}
-
-extern "C" void
-currentDealloc(CurrentObject* self)
-{
-    Py_XDECREF(self->adapter);
-    Py_XDECREF(self->con);
-    Py_XDECREF(self->id);
-    Py_XDECREF(self->facet);
-    Py_XDECREF(self->operation);
-    Py_XDECREF(self->mode);
-    Py_XDECREF(self->ctx);
-    Py_XDECREF(self->requestId);
-    Py_XDECREF(self->encoding);
-    delete self->current;
-    Py_TYPE(self)->tp_free(reinterpret_cast<PyObject*>(self));
-}
-
-extern "C" PyObject*
-currentGetter(CurrentObject* self, void* closure)
-{
-    //
-    // This function intercepts requests for attributes of a Current object. We use this
-    // lazy initialization in order to minimize the cost of translating Ice::Current into a
-    // Python object for every upcall.
-    //
-    PyObject* result = 0;
-
-    assert(self->current);
-
-    Py_ssize_t field = reinterpret_cast<Py_ssize_t>(closure);
-    switch (field)
+    if (current.con)
     {
-        case CURRENT_ADAPTER:
+        PyObject* connection = createConnection(current.con, current.adapter->getCommunicator());
+        if (!connection)
         {
-            if (!self->adapter)
-            {
-                self->adapter = wrapObjectAdapter(self->current->adapter);
-                if (!self->adapter)
-                {
-                    return nullptr;
-                }
-            }
-            Py_INCREF(self->adapter);
-            result = self->adapter;
-            break;
+            return nullptr;
         }
-        case CURRENT_CONNECTION:
-        {
-            if (!self->con)
-            {
-                self->con = createConnection(self->current->con, self->current->adapter->getCommunicator());
-                if (!self->con)
-                {
-                    return nullptr;
-                }
-            }
-            Py_INCREF(self->con);
-            result = self->con;
-            break;
-        }
-        case CURRENT_ID:
-        {
-            if (!self->id)
-            {
-                self->id = createIdentity(self->current->id);
-            }
-            Py_INCREF(self->id);
-            result = self->id;
-            break;
-        }
-        case CURRENT_FACET:
-        {
-            if (!self->facet)
-            {
-                self->facet = createString(self->current->facet);
-            }
-            Py_INCREF(self->facet);
-            result = self->facet;
-            break;
-        }
-        case CURRENT_OPERATION:
-        {
-            if (!self->operation)
-            {
-                self->operation = createString(self->current->operation);
-            }
-            Py_INCREF(self->operation);
-            result = self->operation;
-            break;
-        }
-        case CURRENT_MODE:
-        {
-            if (!self->mode)
-            {
-                PyObject* type = lookupType("Ice.OperationMode");
-                assert(type);
-                const char* enumerator = 0;
-                switch (self->current->mode)
-                {
-                    case Ice::OperationMode::Normal:
-                        enumerator = "Normal";
-                        break;
-                    case Ice::OperationMode::Nonmutating:
-                        enumerator = "Nonmutating";
-                        break;
-                    case Ice::OperationMode::Idempotent:
-                        enumerator = "Idempotent";
-                        break;
-                }
-                self->mode = getAttr(type, enumerator, false);
-                assert(self->mode);
-            }
-            Py_INCREF(self->mode);
-            result = self->mode;
-            break;
-        }
-        case CURRENT_CTX:
-        {
-            if (!self->ctx)
-            {
-                self->ctx = PyDict_New();
-                if (self->ctx && !contextToDictionary(self->current->ctx, self->ctx))
-                {
-                    Py_DECREF(self->ctx);
-                    self->ctx = 0;
-                    break;
-                }
-            }
-            Py_INCREF(self->ctx);
-            result = self->ctx;
-            break;
-        }
-        case CURRENT_REQUEST_ID:
-        {
-            if (!self->requestId)
-            {
-                self->requestId = PyLong_FromLong(self->current->requestId);
-                assert(self->requestId);
-            }
-            Py_INCREF(self->requestId);
-            result = self->requestId;
-            break;
-        }
-        case CURRENT_ENCODING:
-        {
-            if (!self->encoding)
-            {
-                self->encoding = IcePy::createEncodingVersion(self->current->encoding);
-                assert(self->encoding);
-            }
-            Py_INCREF(self->encoding);
-            result = self->encoding;
-            break;
-        }
+        PyTuple_SetItem(args.get(), 1, connection);
+    }
+    else
+    {
+        PyTuple_SetItem(args.get(), 1, Py_None);
     }
 
-    return result;
-}
-
-static PyGetSetDef CurrentGetSetters[] = {
-    {"adapter", reinterpret_cast<getter>(currentGetter), 0, "object adapter", reinterpret_cast<void*>(CURRENT_ADAPTER)},
-    {"con", reinterpret_cast<getter>(currentGetter), 0, "connection info", reinterpret_cast<void*>(CURRENT_CONNECTION)},
-    {"id", reinterpret_cast<getter>(currentGetter), 0, "identity", reinterpret_cast<void*>(CURRENT_ID)},
-    {"facet", reinterpret_cast<getter>(currentGetter), 0, "facet name", reinterpret_cast<void*>(CURRENT_FACET)},
-    {"operation",
-     reinterpret_cast<getter>(currentGetter),
-     0,
-     "operation name",
-     reinterpret_cast<void*>(CURRENT_OPERATION)},
-    {"mode", reinterpret_cast<getter>(currentGetter), 0, "operation mode", reinterpret_cast<void*>(CURRENT_MODE)},
-    {"ctx", reinterpret_cast<getter>(currentGetter), 0, "context", reinterpret_cast<void*>(CURRENT_CTX)},
-    {"requestId", reinterpret_cast<getter>(currentGetter), 0, "requestId", reinterpret_cast<void*>(CURRENT_REQUEST_ID)},
-    {"encoding", reinterpret_cast<getter>(currentGetter), 0, "encoding", reinterpret_cast<void*>(CURRENT_ENCODING)},
-    {0} /* Sentinel */
-};
-
-namespace IcePy
-{
-    PyTypeObject CurrentType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.Current", /* tp_name */
-        sizeof(CurrentObject),                       /* tp_basicsize */
-        0,                                           /* tp_itemsize */
-        /* methods */
-        reinterpret_cast<destructor>(currentDealloc), /* tp_dealloc */
-        0,                                            /* tp_print */
-        0,                                            /* tp_getattr */
-        0,                                            /* tp_setattr */
-        0,                                            /* tp_reserved */
-        0,                                            /* tp_repr */
-        0,                                            /* tp_as_number */
-        0,                                            /* tp_as_sequence */
-        0,                                            /* tp_as_mapping */
-        0,                                            /* tp_hash */
-        0,                                            /* tp_call */
-        0,                                            /* tp_str */
-        0,                                            /* tp_getattro */
-        0,                                            /* tp_setattro */
-        0,                                            /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT,                           /* tp_flags */
-        0,                                            /* tp_doc */
-        0,                                            /* tp_traverse */
-        0,                                            /* tp_clear */
-        0,                                            /* tp_richcompare */
-        0,                                            /* tp_weaklistoffset */
-        0,                                            /* tp_iter */
-        0,                                            /* tp_iternext */
-        0,                                            /* tp_methods */
-        0,                                            /* tp_members */
-        CurrentGetSetters,                            /* tp_getset */
-        0,                                            /* tp_base */
-        0,                                            /* tp_dict */
-        0,                                            /* tp_descr_get */
-        0,                                            /* tp_descr_set */
-        0,                                            /* tp_dictoffset */
-        0,                                            /* tp_init */
-        0,                                            /* tp_alloc */
-        reinterpret_cast<newfunc>(currentNew),        /* tp_new */
-        0,                                            /* tp_free */
-        0,                                            /* tp_is_gc */
-    };
-}
-
-bool
-IcePy::initCurrent(PyObject* module)
-{
-    if (PyType_Ready(&CurrentType) < 0)
+    PyObject* id = createIdentity(current.id);
+    if (!id)
     {
-        return false;
+        return nullptr;
     }
-    PyTypeObject* type = &CurrentType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "Current", reinterpret_cast<PyObject*>(type)) < 0)
-    {
-        return false;
-    }
+    PyTuple_SetItem(args.get(), 2, id);
 
-    return true;
-}
-
-PyObject*
-IcePy::createCurrent(const Ice::Current& current)
-{
-    //
-    // Return an instance of IcePy.Current to hold the current information.
-    //
-    CurrentObject* obj = currentNew(&CurrentType, 0, 0);
-    if (obj)
+    PyObject* facet = createString(current.facet);
+    if (!facet)
     {
-        *obj->current = current;
+        return nullptr;
     }
-    return reinterpret_cast<PyObject*>(obj);
+    PyTuple_SetItem(args.get(), 3, facet);
+
+    PyObject* operation = createString(current.operation);
+    if (!operation)
+    {
+        return nullptr;
+    }
+    PyTuple_SetItem(args.get(), 4, operation);
+
+    PyObject* operationModeType = lookupType("Ice.OperationMode");
+    assert(operationModeType);
+    const char * enumerator = nullptr;
+    switch (current.mode)
+    {
+        case Ice::OperationMode::Normal:
+            enumerator = "Normal";
+            break;
+        case Ice::OperationMode::Nonmutating:
+            enumerator = "Nonmutating";
+            break;
+        case Ice::OperationMode::Idempotent:
+            enumerator = "Idempotent";
+            break;
+    }
+    PyTuple_SetItem(args.get(), 5, getAttr(operationModeType, enumerator, false));
+
+    PyObjectHandle ctx = PyDict_New();
+    if (!contextToDictionary(current.ctx, ctx.get()))
+    {
+        return nullptr;
+    }
+    PyTuple_SetItem(args.get(), 6, ctx.release());
+
+    PyObject* requestId = PyLong_FromLong(current.requestId);
+    if (!requestId)
+    {
+        return nullptr;
+    }
+    PyTuple_SetItem(args.get(), 7, requestId);
+
+    PyObject* encoding = IcePy::createEncodingVersion(current.encoding);
+    if (!encoding)
+    {
+        return nullptr;
+    }
+    PyTuple_SetItem(args.get(), 8, encoding);
+
+    return PyObject_CallObject(currentType, args.get());
 }

--- a/python/modules/IcePy/Current.h
+++ b/python/modules/IcePy/Current.h
@@ -10,10 +10,6 @@
 
 namespace IcePy
 {
-    extern PyTypeObject CurrentType;
-
-    bool initCurrent(PyObject*);
-
     PyObject* createCurrent(const Ice::Current&);
 }
 

--- a/python/modules/IcePy/Init.cpp
+++ b/python/modules/IcePy/Init.cpp
@@ -6,7 +6,6 @@
 #include "Communicator.h"
 #include "Connection.h"
 #include "ConnectionInfo.h"
-#include "Current.h"
 #include "Dispatcher.h"
 #include "Endpoint.h"
 #include "EndpointInfo.h"
@@ -172,10 +171,6 @@ PyInit_IcePy(void)
         return nullptr;
     }
     if (!initCommunicator(module))
-    {
-        return nullptr;
-    }
-    if (!initCurrent(module))
     {
         return nullptr;
     }

--- a/python/python/Ice/Current.py
+++ b/python/python/Ice/Current.py
@@ -1,0 +1,82 @@
+# Copyright (c) ZeroC, Inc. All rights reserved.
+
+class Current:
+    """
+    Provides information about an incoming request being dispatched.
+    """
+
+    def __init__(self, adapter, con, id, facet, operation, mode, ctx, requestId, encoding):
+        self._adapter = adapter
+        self._con = con
+        self._id = id
+        self._facet = facet
+        self._operation = operation
+        self._mode = mode
+        self._ctx = ctx
+        self._requestId = requestId
+        self._encoding = encoding
+
+    @property
+    def adapter(self):
+        """
+        Ice.ObjectAdapter: The object adapter that received the request.
+        """
+        return self._adapter
+
+    @property
+    def con(self):
+        """
+        Optional[Ice.Connection]: The connection that received the request. It's None when the invocation and dispatch are collocated.
+        """
+        return self._con
+
+    @property
+    def id(self):
+        """
+        Ice.Identity: The identity of the target Ice object.
+        """
+        return self._id
+
+    @property
+    def facet(self):
+        """
+        str: The facet of the target Ice object.
+        """
+        return self._facet
+
+    @property
+    def operation(self):
+        """
+        str: The name of the operation.
+        """
+        return self._operation
+
+    @property
+    def mode(self):
+        """
+        OperationMode: The operation mode (idempotent or not).
+        """
+        return self._mode
+
+    @property
+    def ctx(self):
+        """
+        dict: The request context.
+        """
+        return self._ctx
+
+    @property
+    def requestId(self):
+        """
+        int: The request ID. 0 means the request is a one-way request.
+        """
+        return self._requestId
+
+    @property
+    def encoding(self):
+        """
+        EncodingVersion: The encoding of the request payload.
+        """
+        return self._encoding
+
+    __module__ = "Ice"

--- a/python/python/Ice/__init__.py
+++ b/python/python/Ice/__init__.py
@@ -36,6 +36,7 @@ IcePy._t_ObjectPrx = IcePy.declareProxy("::Ice::Object")
 #
 # Import local definitions that are part of the Ice module public API.
 #
+from .Current import *
 from .Future import *
 from .InvocationFuture import *
 from .Value import *

--- a/python/test/Ice/current/AllTests.py
+++ b/python/test/Ice/current/AllTests.py
@@ -1,0 +1,73 @@
+#
+# Copyright (c) ZeroC, Inc. All rights reserved.
+#
+
+import Ice
+import Test
+import sys
+
+
+def test(b):
+    if not b:
+        raise RuntimeError("test assertion failed")
+
+
+def allTests(helper, communicator, collocated):
+    proxy = Test.TestIntfPrx(communicator, f"test:{helper.getTestEndpoint()}")
+
+    sys.stdout.write("testing current.adapter... ")
+    sys.stdout.flush()
+    test(proxy.getAdapterName() == "TestAdapter")
+    print("ok")
+
+    sys.stdout.write("testing current.con... ")
+    sys.stdout.flush()
+    # TODO why is there a IcePy.Connection for collocated tests?
+    test("IcePy.Connection" in proxy.getConnection())
+    print("ok")
+
+    sys.stdout.write("testing current.id... ")
+    sys.stdout.flush()
+    test(Ice.Identity("test", "") == proxy.getIdentity())
+    print("ok")
+
+    sys.stdout.write("testing current.facet... ")
+    sys.stdout.flush()
+    test("foo" == Test.TestIntfPrx.uncheckedCast(proxy.ice_facet("foo")).getFacet())
+    print("ok")
+
+    sys.stdout.write("testing current.operation... ")
+    sys.stdout.flush()
+    test("getOperation" == proxy.getOperation())
+    print("ok")
+
+
+    sys.stdout.write("testing current.mode... ")
+    sys.stdout.flush()
+    test("Normal" == proxy.getMode())
+    print("ok")
+
+    sys.stdout.write("testing current.ctx... ")
+    sys.stdout.flush()
+    ctx = { "foo" : "bar" }
+    test(ctx == proxy.getContext(ctx))
+    print("ok")
+
+    sys.stdout.write("testing current.requestId... ")
+    sys.stdout.flush()
+    if collocated:
+        test(7 == proxy.getRequestId())
+    else:
+        proxy.ice_getConnection().close(Ice.ConnectionClose.GracefullyWithWait)
+        test(1 == proxy.getRequestId())
+    print("ok")
+
+    sys.stdout.write("testing current.encoding... ")
+    sys.stdout.flush()
+    test(str(proxy.ice_getEncodingVersion()) == proxy.getEncoding())
+    print("ok")
+
+    proxy.shutdown()
+
+    communicator.shutdown()
+    communicator.waitForShutdown()

--- a/python/test/Ice/current/AllTests.py
+++ b/python/test/Ice/current/AllTests.py
@@ -22,8 +22,10 @@ def allTests(helper, communicator, collocated):
 
     sys.stdout.write("testing current.con... ")
     sys.stdout.flush()
-    # TODO why is there a IcePy.Connection for collocated tests?
-    test("IcePy.Connection" in proxy.getConnection())
+    if collocated:
+        test(proxy.getConnection() == "")
+    else:
+        test("IcePy.Connection" in proxy.getConnection())
     print("ok")
 
     sys.stdout.write("testing current.id... ")

--- a/python/test/Ice/current/Client.py
+++ b/python/test/Ice/current/Client.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) ZeroC, Inc. All rights reserved.
+#
+
+from TestHelper import TestHelper
+
+TestHelper.loadSlice("Test.ice")
+import AllTests
+
+
+class Client(TestHelper):
+    def run(self, args):
+        with self.initialize(args=args) as communicator:
+            AllTests.allTests(self, communicator, False)

--- a/python/test/Ice/current/Collocated.py
+++ b/python/test/Ice/current/Collocated.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) ZeroC, Inc. All rights reserved.
+#
+
+from TestHelper import TestHelper
+
+TestHelper.loadSlice("Test.ice")
+import Ice
+import TestI
+import AllTests
+
+
+class Collocated(TestHelper):
+    def run(self, args):
+        with self.initialize(args=args) as communicator:
+            communicator.getProperties().setProperty(
+                "TestAdapter.Endpoints",
+                self.getTestEndpoint()
+            )
+            adapter = communicator.createObjectAdapter("TestAdapter")
+            adapter.add(TestI.MyClassI(), Ice.stringToIdentity("test"))
+            adapter.addFacet(TestI.MyClassI(), Ice.stringToIdentity("test"), "foo")
+            # Don't activate OA to ensure collocation is used.
+            # adapter.activate()
+            AllTests.allTests(self, communicator, True)

--- a/python/test/Ice/current/Server.py
+++ b/python/test/Ice/current/Server.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) ZeroC, Inc. All rights reserved.
+#
+
+from TestHelper import TestHelper
+
+TestHelper.loadSlice("Test.ice")
+import Ice
+import TestI
+
+
+class Server(TestHelper):
+    def run(self, args):
+        with self.initialize(args=args) as communicator:
+            communicator.getProperties().setProperty(
+                "TestAdapter.Endpoints",
+                self.getTestEndpoint()
+            )
+            adapter = communicator.createObjectAdapter("TestAdapter")
+            adapter.add(TestI.MyClassI(), Ice.stringToIdentity("test"))
+            adapter.addFacet(TestI.MyClassI(), Ice.stringToIdentity("test"), "foo")
+            adapter.activate()
+            communicator.waitForShutdown()

--- a/python/test/Ice/current/Test.ice
+++ b/python/test/Ice/current/Test.ice
@@ -1,0 +1,28 @@
+//
+// Copyright (c) ZeroC, Inc. All rights reserved.
+//
+
+#pragma once
+
+#include "Ice/Context.ice"
+#include "Ice/Identity.ice"
+
+module Test
+{
+
+interface TestIntf
+{
+    string getAdapterName();
+    string getConnection();
+    Ice::Identity getIdentity();
+    string getFacet();
+    string getOperation();
+    string getMode();
+    Ice::Context getContext();
+    int getRequestId();
+    string getEncoding();
+
+    void shutdown();
+}
+
+}

--- a/python/test/Ice/current/TestI.py
+++ b/python/test/Ice/current/TestI.py
@@ -1,0 +1,38 @@
+#
+# Copyright (c) ZeroC, Inc. All rights reserved.
+#
+
+import Ice
+import Test
+
+class MyClassI(Test.TestIntf):
+
+    def getAdapterName(self, current):
+        return current.adapter.getName()
+
+    def getConnection(self, current):
+        return str(current.con) if current.con else ""
+
+    def getIdentity(self, current):
+        return current.id
+
+    def getFacet(self, current):
+        return current.facet
+
+    def getOperation(self, current):
+        return current.operation
+
+    def getMode(self, current):
+        return str(current.mode)
+
+    def getContext(self, current):
+        return current.ctx
+
+    def getRequestId(self, current):
+        return current.requestId
+
+    def getEncoding(self, current):
+        return str(current.encoding)
+
+    def shutdown(self, current=None):
+        current.adapter.getCommunicator().shutdown()

--- a/python/test/Ice/current/TestI.py
+++ b/python/test/Ice/current/TestI.py
@@ -2,7 +2,6 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-import Ice
 import Test
 
 class MyClassI(Test.TestIntf):


### PR DESCRIPTION
This PR replaces IcePy.Current object in the C++ extension by a plain Ice.Current python class. It also adds a test for current attributes.