### PR TITLE
Fix mapping for optional proxies in MATLAB

### DIFF
--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -577,7 +577,7 @@ namespace
         }
         else if (m->optional())
         {
-            return "IceInternal.UnsetI.Instance";
+            return isProxyType(m->type()) ? "[]" : "IceInternal.UnsetI.Instance";
         }
         else
         {
@@ -1948,14 +1948,8 @@ CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     }
     for (const auto& dm : optionalMembers)
     {
-        if (dm->type()->isClassType())
-        {
-            unmarshal(out, "is", "@obj.iceSetMember_" + fixIdent(dm->name()), dm->type(), true, dm->tag());
-        }
-        else
-        {
-            unmarshal(out, "is", "obj." + fixIdent(dm->name()), dm->type(), true, dm->tag());
-        }
+        assert(!dm->type()->isClassType());
+        unmarshal(out, "is", "obj." + fixIdent(dm->name()), dm->type(), true, dm->tag());
     }
     out << nl << "is.endSlice();";
     if (base)
@@ -4244,12 +4238,7 @@ CodeVisitor::unmarshal(
         const string typeS = getAbsolute(prx, "", "Prx");
         if (optional)
         {
-            out << nl << "if " << stream << ".readOptional(" << tag << ", " << getOptionalFormat(type) << ")";
-            out.inc();
-            out << nl << stream << ".skip(4);";
-            out << nl << v << " = " << typeS << ".ice_read(" << stream << ");";
-            out.dec();
-            out << nl << "end";
+            out << nl << v << " = " << stream << ".readProxyOpt(" << tag << ", '" << typeS << "');";
         }
         else
         {

--- a/matlab/lib/+Ice/InputStream.m
+++ b/matlab/lib/+Ice/InputStream.m
@@ -657,12 +657,16 @@ classdef InputStream < handle
                 r = Ice.ObjectPrx(obj.communicator, '', impl);
             end
         end
-        function r = readProxyOpt(obj, tag)
+        function r = readProxyOpt(obj, tag, cls)
             if obj.readOptional(tag, Ice.OptionalFormat.FSize)
                 obj.skip(4);
-                r = obj.readProxy();
+                if nargin == 1
+                    r = obj.readProxy();
+                else
+                    r = obj.readProxy(cls);
+                end
             else
-                r = IceInternal.UnsetI.Instance;
+                r = [];
             end
         end
         function r = readEnum(obj, maxValue)

--- a/matlab/lib/+Ice/OutputStream.m
+++ b/matlab/lib/+Ice/OutputStream.m
@@ -300,7 +300,7 @@ classdef OutputStream < handle
             end
         end
         function writeProxyOpt(obj, tag, v)
-            if v ~= Ice.Unset && obj.writeOptional(tag, Ice.OptionalFormat.FSize)
+            if ~isempty(v) && obj.writeOptional(tag, Ice.OptionalFormat.FSize)
                 pos = obj.startSize();
                 obj.writeProxy(v);
                 obj.endSize(pos);

--- a/matlab/test/Ice/optional/AllTests.m
+++ b/matlab/test/Ice/optional/AllTests.m
@@ -31,7 +31,7 @@ classdef AllTests
             assert(mo1.g == Ice.Unset);
             assert(mo1.h == Ice.Unset);
             assert(mo1.i == Ice.Unset);
-            assert(mo1.j == Ice.Unset);
+            assert(isempty(mo1.j));
             assert(mo1.bs == Ice.Unset);
             assert(mo1.ss == Ice.Unset);
             assert(mo1.iid == Ice.Unset);
@@ -132,7 +132,7 @@ classdef AllTests
             assert(mo4.g == Ice.Unset);
             assert(mo4.h == Ice.Unset);
             assert(mo4.i == Ice.Unset);
-            % assert(mo4.j == Ice.Unset);
+            assert(isempty(mo4.j)); % we don't use Unset for optional proxies
             assert(mo4.bs == Ice.Unset);
             assert(mo4.ss == Ice.Unset);
             assert(mo4.iid == Ice.Unset);
@@ -258,12 +258,12 @@ classdef AllTests
             assert(mo9.g == mo1.g);
             assert(mo9.h == Ice.Unset);
             assert(mo9.i == mo1.i);
-            % assert(mo9.j == Ice.Unset);
+            assert(isempty(mo9.j)); % optional proxy
             assert(mo9.bs == Ice.Unset);
             assert(isequal(mo9.ss, mo1.ss));
             assert(mo9.iid == Ice.Unset);
             assert(mo9.sid('test') == 10);
-            % assert(mo9.fs == Ice.Unset);
+            assert(isempty(mo9.j)); % optional proxy
             assert(mo9.vs == mo1.vs);
 
             assert(mo9.shs == Ice.Unset);
@@ -504,14 +504,14 @@ classdef AllTests
             [p2, p3] = f.fetchOutputs();
             assert(p2.a == p1.a && p3.a == p1.a);
 
-            % [p2, p3] = initial.opMyInterfaceProxy(Ice.Unset);
-            % assert(p2 == Ice.Unset && p3 == Ice.Unset);
-            % p1 = communicator.stringToProxy('test');
-            % [p2, p3] = initial.opMyInterfaceProxy(p1);
-            % assert(p2 == p1 && p3 == p1);
-            % f = initial.opMyInterfaceProxyAsync(p1);
-            % [p2, p3] = f.fetchOutputs();
-            % assert(p2 == p1 && p3 == p1);
+            [p2, p3] = initial.opMyInterfaceProxy([]);
+            assert(isempty(p2) && isempty(p3));
+            p1 = MyInterfacePrx(communicator, 'test');
+            [p2, p3] = initial.opMyInterfaceProxy(p1);
+            assert(p2 == p1 && p3 == p1);
+            f = initial.opMyInterfaceProxyAsync(p1);
+            [p2, p3] = f.fetchOutputs();
+            assert(p2 == p1 && p3 == p1);
 
             [p2, p3] = initial.opByteSeq(Ice.Unset);
             assert(p2 == Ice.Unset && p3 == Ice.Unset);


### PR DESCRIPTION
Fixes #1634.

Both null proxies and unset proxies are now mapped to empty arrays in MATLAB.