### PR TITLE
Fix NPE in C# dispatch pipeline

### DIFF
--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1355,7 +1355,6 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
     }
 
     internal ConnectionI(
-        Communicator communicator,
         Instance instance,
         Transceiver transceiver,
         Connector connector,
@@ -1364,7 +1363,6 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
         Action<ConnectionI> removeFromFactory, // can be null
         ConnectionOptions options)
     {
-        _communicator = communicator;
         _instance = instance;
         _desc = transceiver.ToString();
         _type = transceiver.protocol();
@@ -2433,7 +2431,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                 {
                     // Received request on a connection without an object adapter.
                     sendResponse(
-                        request.current.createOutgoingResponse(new ObjectNotExistException(), _communicator),
+                        request.current.createOutgoingResponse(new ObjectNotExistException()),
                         isTwoWay: !_endpoint.datagram() && requestId != 0,
                         compress: 0);
                 }
@@ -2823,7 +2821,6 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
         internal bool receivedReply;
     }
 
-    private Communicator _communicator;
     private Instance _instance;
     private readonly Transceiver _transceiver;
     private string _desc;

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1355,6 +1355,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
     }
 
     internal ConnectionI(
+        Communicator communicator,
         Instance instance,
         Transceiver transceiver,
         Connector connector,
@@ -1363,6 +1364,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
         Action<ConnectionI> removeFromFactory, // can be null
         ConnectionOptions options)
     {
+        _communicator = communicator;
         _instance = instance;
         _desc = transceiver.ToString();
         _type = transceiver.protocol();
@@ -2431,7 +2433,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                 {
                     // Received request on a connection without an object adapter.
                     sendResponse(
-                        request.current.createOutgoingResponse(new ObjectNotExistException()),
+                        request.current.createOutgoingResponse(new ObjectNotExistException(), _communicator),
                         isTwoWay: !_endpoint.datagram() && requestId != 0,
                         compress: 0);
                 }
@@ -2821,6 +2823,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
         internal bool receivedReply;
     }
 
+    private Communicator _communicator;
     private Instance _instance;
     private readonly Transceiver _transceiver;
     private string _desc;

--- a/csharp/src/Ice/CurrentExtensions.cs
+++ b/csharp/src/Ice/CurrentExtensions.cs
@@ -113,25 +113,29 @@ public static class CurrentExtensions
     /// <param name="current">The current object of the corresponding incoming request.</param>
     /// <param name="exception">The exception to marshal into the response payload.</param>
     /// <returns>A new outgoing response.</returns>
-    public static OutgoingResponse createOutgoingResponse(this Current current, System.Exception exception)
+    public static OutgoingResponse createOutgoingResponse(
+        this Current current,
+        System.Exception exception,
+        Communicator? communicator = null)
     {
+        communicator ??= current.adapter.getCommunicator() ?? throw new ArgumentNullException(nameof(communicator));
         try
         {
-            return createOutgoingResponseCore(exception);
+            return createOutgoingResponseCore(exception, communicator);
         }
         catch (System.Exception ex)
         {
             // Try a second time with the marshal exception. This should not fail.
-            return createOutgoingResponseCore(ex);
+            return createOutgoingResponseCore(ex, communicator);
         }
 
-        OutgoingResponse createOutgoingResponseCore(System.Exception exc)
+        OutgoingResponse createOutgoingResponseCore(System.Exception exc, Communicator communicator)
         {
             OutputStream ostr;
 
             if (current.requestId != 0)
             {
-                ostr = new OutputStream(current.adapter.getCommunicator(), Util.currentProtocolEncoding);
+                ostr = new OutputStream(communicator, Util.currentProtocolEncoding);
                 ostr.writeBlob(Protocol.replyHdr);
                 ostr.writeInt(current.requestId);
             }

--- a/csharp/src/Ice/CurrentExtensions.cs
+++ b/csharp/src/Ice/CurrentExtensions.cs
@@ -113,12 +113,8 @@ public static class CurrentExtensions
     /// <param name="current">The current object of the corresponding incoming request.</param>
     /// <param name="exception">The exception to marshal into the response payload.</param>
     /// <returns>A new outgoing response.</returns>
-    public static OutgoingResponse createOutgoingResponse(
-        this Current current,
-        System.Exception exception,
-        Communicator? communicator = null)
+    public static OutgoingResponse createOutgoingResponse(this Current current, System.Exception exception)
     {
-        communicator ??= current.adapter.getCommunicator() ?? throw new ArgumentNullException(nameof(communicator));
         try
         {
             return createOutgoingResponseCore(exception, communicator);
@@ -129,13 +125,13 @@ public static class CurrentExtensions
             return createOutgoingResponseCore(ex, communicator);
         }
 
-        OutgoingResponse createOutgoingResponseCore(System.Exception exc, Communicator communicator)
+        OutgoingResponse createOutgoingResponseCore(System.Exception exc)
         {
             OutputStream ostr;
 
             if (current.requestId != 0)
             {
-                ostr = new OutputStream(communicator, Util.currentProtocolEncoding);
+                ostr = new OutputStream(Util.currentProtocolEncoding);
                 ostr.writeBlob(Protocol.replyHdr);
                 ostr.writeInt(current.requestId);
             }

--- a/csharp/src/Ice/CurrentExtensions.cs
+++ b/csharp/src/Ice/CurrentExtensions.cs
@@ -117,12 +117,12 @@ public static class CurrentExtensions
     {
         try
         {
-            return createOutgoingResponseCore(exception, communicator);
+            return createOutgoingResponseCore(exception);
         }
         catch (System.Exception ex)
         {
             // Try a second time with the marshal exception. This should not fail.
-            return createOutgoingResponseCore(ex, communicator);
+            return createOutgoingResponseCore(ex);
         }
 
         OutgoingResponse createOutgoingResponseCore(System.Exception exc)

--- a/csharp/src/Ice/Internal/ConnectionFactory.cs
+++ b/csharp/src/Ice/Internal/ConnectionFactory.cs
@@ -466,6 +466,7 @@ public sealed class OutgoingConnectionFactory
                 }
 
                 connection = new Ice.ConnectionI(
+                    _communicator,
                     _instance,
                     transceiver,
                     ci.connector,
@@ -924,7 +925,7 @@ public sealed class OutgoingConnectionFactory
                 {
                     //
                     // A null return value from getConnection indicates that the connection
-                    // is being established and that everthing has been done to ensure that
+                    // is being established and that everything has been done to ensure that
                     // the callback will be notified when the connection establishment is
                     // done.
                     //
@@ -1392,6 +1393,7 @@ public sealed class IncomingConnectionFactory : EventHandler, Ice.ConnectionI.St
                 try
                 {
                     connection = new Ice.ConnectionI(
+                        _adapter.getCommunicator(),
                         _instance,
                         transceiver,
                         null,
@@ -1529,6 +1531,7 @@ public sealed class IncomingConnectionFactory : EventHandler, Ice.ConnectionI.St
                 _endpoint = _transceiver.bind();
 
                 Ice.ConnectionI connection = new Ice.ConnectionI(
+                    adapter.getCommunicator(),
                     _instance,
                     _transceiver,
                     connector: null,

--- a/csharp/src/Ice/Internal/ConnectionFactory.cs
+++ b/csharp/src/Ice/Internal/ConnectionFactory.cs
@@ -466,7 +466,6 @@ public sealed class OutgoingConnectionFactory
                 }
 
                 connection = new Ice.ConnectionI(
-                    _communicator,
                     _instance,
                     transceiver,
                     ci.connector,
@@ -1393,7 +1392,6 @@ public sealed class IncomingConnectionFactory : EventHandler, Ice.ConnectionI.St
                 try
                 {
                     connection = new Ice.ConnectionI(
-                        _adapter.getCommunicator(),
                         _instance,
                         transceiver,
                         null,
@@ -1531,7 +1529,6 @@ public sealed class IncomingConnectionFactory : EventHandler, Ice.ConnectionI.St
                 _endpoint = _transceiver.bind();
 
                 Ice.ConnectionI connection = new Ice.ConnectionI(
-                    adapter.getCommunicator(),
                     _instance,
                     _transceiver,
                     connector: null,

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -27,6 +27,10 @@ public class OutputStream
         _format = FormatType.CompactFormat;
     }
 
+    /// <summary>
+    /// Construct a new OutputStream with the given encoding version and the default format for class encoding.
+    /// </summary>
+    /// <param name="encoding">The encoding version for the output stream.</param>
     public OutputStream(EncodingVersion encoding)
     {
         _buf = new Ice.Internal.Buffer();

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -27,6 +27,15 @@ public class OutputStream
         _format = FormatType.CompactFormat;
     }
 
+    public OutputStream(EncodingVersion encoding)
+    {
+        _buf = new Ice.Internal.Buffer();
+        _instance = null;
+        _closure = null;
+        _encoding = encoding;
+        _format = FormatType.CompactFormat;
+    }
+
     /// <summary>
     /// This constructor uses the communicator's default encoding version.
     /// </summary>

--- a/js/src/Ice/CurrentExtensions.js
+++ b/js/src/Ice/CurrentExtensions.js
@@ -76,11 +76,11 @@ function startReplyStream(current, replyStatus = ReplyStatus.Ok) {
     }
 }
 
-function createOutgoingResponseCore(current, exception, communicator) {
+function createOutgoingResponseCore(current, exception) {
     let ostr;
 
     if (current.requestId != 0) {
-        ostr = new OutputStream(communicator, Protocol.currentProtocolEncoding);
+        ostr = new OutputStream(Protocol.currentProtocolEncoding);
         ostr.writeBlob(Protocol.replyHdr);
         ostr.writeInt(current.requestId);
     } else {


### PR DESCRIPTION
This PR fix NPE in C# dispatch pipeline, when handling a request from a connection that doesn't have an ObjectAdapter.

We probably need this fix in other languages, but let's first agree this is the correct fix.