### PR TITLE
Update idle check in C# to work with an exhausted (flow controlled) thread pool

### DIFF
--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1446,7 +1446,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                 {
                     rescheduleTimer();
 
-                    if (_instance.traceLevels().network >=3)
+                    if (_instance.traceLevels().network >= 3)
                     {
                         _instance.initializationData().logger.trace(
                             _instance.traceLevels().networkCat,

--- a/csharp/src/Ice/Internal/IdleTimeoutTransceiverDecorator.cs
+++ b/csharp/src/Ice/Internal/IdleTimeoutTransceiverDecorator.cs
@@ -9,6 +9,8 @@ namespace Ice.Internal;
 
 internal sealed class IdleTimeoutTransceiverDecorator : Transceiver
 {
+    public bool isWaitingToBeRead => _decoratee.isWaitingToBeRead;
+
     private readonly Transceiver _decoratee;
     private readonly TimeSpan _idleTimeout;
     private readonly System.Threading.Timer? _readTimer;
@@ -106,7 +108,7 @@ internal sealed class IdleTimeoutTransceiverDecorator : Transceiver
 
         if (enableIdleCheck)
         {
-            _readTimer = new System.Threading.Timer(_ => connection.idleCheck(_idleTimeout));
+            _readTimer = new System.Threading.Timer(_ => connection.idleCheck(_idleTimeout, rescheduleReadTimer));
         }
 
         _writeTimer = new System.Threading.Timer(_ => connection.sendHeartbeat());

--- a/csharp/src/Ice/Internal/TcpTransceiver.cs
+++ b/csharp/src/Ice/Internal/TcpTransceiver.cs
@@ -8,6 +8,8 @@ namespace Ice.Internal;
 
 internal sealed class TcpTransceiver : Transceiver
 {
+    public bool isWaitingToBeRead => _stream.isWaitingToBeRead;
+
     public Socket fd()
     {
         return _stream.fd();

--- a/csharp/src/Ice/Internal/Transceiver.cs
+++ b/csharp/src/Ice/Internal/Transceiver.cs
@@ -6,6 +6,11 @@ namespace Ice.Internal;
 
 public interface Transceiver
 {
+    /// <summary>
+    /// Checks if this transceiver is waiting to be read, typically because it has bytes readily available for reading.
+    /// </summary>
+    bool isWaitingToBeRead { get; }
+
     Socket fd();
     int initialize(Buffer readBuffer, Buffer writeBuffer, ref bool hasMoreData);
     int closing(bool initiator, Ice.LocalException ex);

--- a/csharp/src/Ice/Internal/UdpTransceiver.cs
+++ b/csharp/src/Ice/Internal/UdpTransceiver.cs
@@ -9,6 +9,15 @@ namespace Ice.Internal;
 
 internal sealed class UdpTransceiver : Transceiver
 {
+    public bool isWaitingToBeRead
+    {
+        get
+        {
+            Debug.Fail("UdpTransceiver does not implement isWaitingToBeRead");
+            return false;
+        }
+    }
+
     public Socket fd()
     {
         return _fd;

--- a/csharp/src/Ice/Internal/WSTransceiver.cs
+++ b/csharp/src/Ice/Internal/WSTransceiver.cs
@@ -9,6 +9,8 @@ namespace Ice.Internal;
 
 internal sealed class WSTransceiver : Transceiver
 {
+    public bool isWaitingToBeRead => _readBuffer.b.position() > _readBufferPos || _delegate.isWaitingToBeRead;
+
     public Socket fd()
     {
         return _delegate.fd();

--- a/csharp/test/Ice/background/Transceiver.cs
+++ b/csharp/test/Ice/background/Transceiver.cs
@@ -5,6 +5,9 @@ using System.Net.Sockets;
 
 internal class Transceiver : Ice.Internal.Transceiver
 {
+    public bool isWaitingToBeRead =>
+        (_buffered && (_readBuffer.b.position() - _readBufferPos > 0)) || _transceiver.isWaitingToBeRead;
+
     public Socket fd()
     {
         return _transceiver.fd();

--- a/csharp/test/Ice/idleTimeout/AllTests.cs
+++ b/csharp/test/Ice/idleTimeout/AllTests.cs
@@ -14,8 +14,7 @@ internal class AllTests : global::Test.AllTests
 
         string proxyString3s = $"test: {helper.getTestEndpoint(1)}";
 
-        // TODO: this test no longer works with the thread pool fix, idle timeout implementation needs fixing.
-        // await testIdleCheckDoesNotAbortConnectionWhenThreadPoolIsExhausted(p, helper.getWriter());
+        await testIdleCheckDoesNotAbortConnectionWhenThreadPoolIsExhausted(p, helper.getWriter());
         await testConnectionAbortedByIdleCheck(proxyString, communicator.getProperties(), helper.getWriter());
         await testEnableDisableIdleCheck(true, proxyString3s, communicator.getProperties(), helper.getWriter());
         await testEnableDisableIdleCheck(false, proxyString3s, communicator.getProperties(), helper.getWriter());
@@ -39,7 +38,10 @@ internal class AllTests : global::Test.AllTests
         // Establish connection.
         await p.ice_pingAsync();
 
-        await p.sleepAsync(2000); // the implementation in the server sleeps for 2,000ms
+        await p.sleepAsync(4000); // the implementation in the server sleeps for 2,000ms
+
+        // close connection
+        p.ice_getConnection().close(ConnectionClose.GracefullyWithWait);
         output.WriteLine("ok");
     }
 

--- a/csharp/test/Ice/idleTimeout/Client.cs
+++ b/csharp/test/Ice/idleTimeout/Client.cs
@@ -8,6 +8,9 @@ public class Client : global::Test.TestHelper
     {
         var properties = createTestProperties(ref args);
         properties.setProperty("Ice.Connection.IdleTimeout", "1");
+
+        // TODO: temporary work-around for IceSSL always sending messages asynchronously.
+        properties.setProperty("Ice.Connection.EnableIdleCheck", "0");
         using var communicator = initialize(properties);
         await AllTests.allTests(this);
     }

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/Transceiver.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/Transceiver.java
@@ -39,8 +39,7 @@ public interface Transceiver {
 
   /**
    * Checks if this transceiver is waiting to be read, typically because it has bytes readily
-   * available for reading. The caller must ensure the transceiver is not closed when calling this
-   * method.
+   * available for reading.
    *
    * @return true if this transceiver is waiting to be read, false otherwise.
    */


### PR DESCRIPTION
Fixes #2581. The logic is similar to the logic in C++ and Java.