### PR TITLE
Update FormatType in C++

### DIFF
--- a/cpp/include/Ice/AsyncResponseHandler.h
+++ b/cpp/include/Ice/AsyncResponseHandler.h
@@ -55,7 +55,7 @@ namespace IceInternal
 
         void sendResponse(
             std::function<void(Ice::OutputStream*)> marshal,
-            Ice::FormatType format = Ice::FormatType::DefaultFormat) noexcept
+            std::optional<Ice::FormatType> format = std::nullopt) noexcept
         {
             // It is critical to only call the _sendResponse function only once. Calling it multiple times results in an
             // incorrect dispatch count.

--- a/cpp/include/Ice/Format.h
+++ b/cpp/include/Ice/Format.h
@@ -15,10 +15,6 @@ namespace Ice
     enum class FormatType : std::uint8_t
     {
         /**
-         * Indicates that no preference was specified.
-         */
-        DefaultFormat,
-        /**
          * A minimal format that eliminates the possibility for slicing unrecognized types.
          */
         CompactFormat,

--- a/cpp/include/Ice/OutgoingAsync.h
+++ b/cpp/include/Ice/OutgoingAsync.h
@@ -201,12 +201,12 @@ namespace IceInternal
         void invoke(
             std::string_view,
             Ice::OperationMode,
-            Ice::FormatType,
+            std::optional<Ice::FormatType>,
             const Ice::Context&,
             std::function<void(Ice::OutputStream*)>);
         void throwUserException();
 
-        Ice::OutputStream* startWriteParams(Ice::FormatType format)
+        Ice::OutputStream* startWriteParams(std::optional<Ice::FormatType> format)
         {
             _os.startEncapsulation(_encoding, format);
             return &_os;
@@ -294,7 +294,7 @@ namespace IceInternal
         void invoke(
             std::string_view operation,
             Ice::OperationMode mode,
-            Ice::FormatType format,
+            std::optional<Ice::FormatType> format,
             const Ice::Context& ctx,
             std::function<void(Ice::OutputStream*)> write,
             std::function<void(const Ice::UserException&)> userException)
@@ -312,7 +312,7 @@ namespace IceInternal
         void invoke(
             std::string_view operation,
             Ice::OperationMode mode,
-            Ice::FormatType format,
+            std::optional<Ice::FormatType> format,
             const Ice::Context& ctx,
             std::function<void(Ice::OutputStream*)> write,
             std::function<void(const Ice::UserException&)> userException,
@@ -335,7 +335,7 @@ namespace IceInternal
         void invoke(
             std::string_view operation,
             Ice::OperationMode mode,
-            Ice::FormatType format,
+            std::optional<Ice::FormatType> format,
             const Ice::Context& ctx,
             std::function<void(Ice::OutputStream*)> write,
             std::function<void(const Ice::UserException&)> userException)

--- a/cpp/include/Ice/OutgoingResponse.h
+++ b/cpp/include/Ice/OutgoingResponse.h
@@ -140,7 +140,7 @@ namespace Ice
     ICE_API OutgoingResponse makeOutgoingResponse(
         std::function<void(OutputStream*)> marshal,
         const Current& current,
-        FormatType format = FormatType::DefaultFormat) noexcept;
+        std::optional<FormatType> format = std::nullopt) noexcept;
 
     /**
      * Create an OutgoingResponse object with the Ok reply status and an empty payload.

--- a/cpp/include/Ice/OutputStream.h
+++ b/cpp/include/Ice/OutputStream.h
@@ -120,12 +120,6 @@ namespace Ice
         /// \endcond
 
         /**
-         * Sets the class encoding format.
-         * @param format The encoding format.
-         */
-        void setFormat(FormatType format);
-
-        /**
          * Obtains the closure data associated with this stream.
          * @return The data as a void pointer.
          */
@@ -204,9 +198,10 @@ namespace Ice
          * Writes the start of an encapsulation using the given encoding version and
          * class encoding format.
          * @param encoding The encoding version to use for the encapsulation.
-         * @param format The class format to use for the encapsulation.
+         * @param format The class format to use for the encapsulation. nullopt is equivalent to the OutputStream's
+         * class format.
          */
-        void startEncapsulation(const EncodingVersion& encoding, FormatType format);
+        void startEncapsulation(const EncodingVersion& encoding, std::optional<FormatType> format);
 
         /**
          * Ends the current encapsulation.
@@ -966,7 +961,7 @@ namespace Ice
         class Encaps
         {
         public:
-            Encaps() : format(FormatType::DefaultFormat), encoder(0), previous(0)
+            Encaps() : format(FormatType::CompactFormat), encoder(0), previous(0)
             {
                 // Inlined for performance reasons.
             }
@@ -1005,7 +1000,7 @@ namespace Ice
         //
         EncodingVersion _encoding;
 
-        FormatType _format;
+        FormatType _format; // TODO: make it const
 
         Encaps* _currentEncaps;
 

--- a/cpp/include/Ice/OutputStream.h
+++ b/cpp/include/Ice/OutputStream.h
@@ -8,6 +8,7 @@
 #include "Buffer.h"
 #include "CommunicatorF.h"
 #include "Ice/Format.h"
+#include "Ice/StringConverter.h"
 #include "Ice/Version.h"
 #include "InstanceF.h"
 #include "SlicedDataF.h"
@@ -36,9 +37,8 @@ namespace Ice
         typedef size_t size_type;
 
         /**
-         * Constructs an OutputStream using the latest encoding version, the default format for
-         * class encoding, and the process string converters. You can supply a communicator later
-         * by calling initialize().
+         * Constructs an OutputStream using the latest encoding version, the compact format for
+         * class encoding, and the process string converters.
          */
         OutputStream();
 
@@ -110,14 +110,6 @@ namespace Ice
          * Releases any data retained by encapsulations.
          */
         void clear();
-
-        /// \cond INTERNAL
-        //
-        // Must return Instance*, because we don't hold an InstancePtr for
-        // optimization reasons (see comments below).
-        //
-        IceInternal::Instance* instance() const { return _instance; } // Inlined for performance reasons.
-        /// \endcond
 
         /**
          * Obtains the closure data associated with this stream.
@@ -800,11 +792,8 @@ namespace Ice
         //
         void writeConverted(const char*, size_t);
 
-        //
-        // Optimization. The instance may not be deleted while a
-        // stack-allocated stream still holds it.
-        //
-        IceInternal::Instance* _instance;
+        StringConverterPtr _stringConverter;
+        WstringConverterPtr _wstringConverter;
 
         //
         // The public stream API needs to attach data to a stream.

--- a/cpp/src/Ice/CollocatedRequestHandler.cpp
+++ b/cpp/src/Ice/CollocatedRequestHandler.cpp
@@ -143,12 +143,12 @@ CollocatedRequestHandler::invokeAsyncRequest(OutgoingAsyncBase* outAsync, int ba
         {
             fillInValue(os, headerSize, batchRequestCount);
         }
-        traceSend(*os, _logger, _traceLevels);
+        traceSend(*os, _reference->getInstance(), _logger, _traceLevels);
     }
 
     outAsync->attachCollocatedObserver(_adapter, requestId);
 
-    InputStream is(os->instance(), os->getEncoding(), *os);
+    InputStream is(_reference->getInstance().get(), os->getEncoding(), *os);
 
     if (batchRequestCount > 0)
     {
@@ -340,7 +340,7 @@ CollocatedRequestHandler::sendResponse(OutgoingResponse response)
                     fillInValue(os, 10, static_cast<int32_t>(os->b.size()));
                 }
 
-                InputStream is(os->instance(), os->getEncoding(), *os, true); // Adopting the OutputStream's buffer.
+                InputStream is(_reference->getInstance().get(), os->getEncoding(), *os, true); // Adopting the OutputStream's buffer.
                 is.pos(sizeof(replyHdr) + 4);
 
                 if (_traceLevels->protocol >= 1)

--- a/cpp/src/Ice/CollocatedRequestHandler.cpp
+++ b/cpp/src/Ice/CollocatedRequestHandler.cpp
@@ -340,7 +340,11 @@ CollocatedRequestHandler::sendResponse(OutgoingResponse response)
                     fillInValue(os, 10, static_cast<int32_t>(os->b.size()));
                 }
 
-                InputStream is(_reference->getInstance().get(), os->getEncoding(), *os, true); // Adopting the OutputStream's buffer.
+                InputStream is(
+                    _reference->getInstance().get(),
+                    os->getEncoding(),
+                    *os,
+                    true); // Adopting the OutputStream's buffer.
                 is.pos(sizeof(replyHdr) + 4);
 
                 if (_traceLevels->protocol >= 1)

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -2468,7 +2468,7 @@ Ice::ConnectionI::validate(SocketOperation operation)
                     static_cast<uint8_t>(0));   // Compression status (always zero for validate connection).
                 _writeStream.write(headerSize); // Message size.
                 _writeStream.i = _writeStream.b.begin();
-                traceSend(_writeStream, _logger, _traceLevels);
+                traceSend(_writeStream, _instance, _logger, _traceLevels);
             }
 
             if (_observer)
@@ -2676,7 +2676,7 @@ Ice::ConnectionI::sendNextMessages(vector<OutgoingMessage>& callbacks)
                 OutputStream stream(_instance.get(), Ice::currentProtocolEncoding);
                 doCompress(*message->stream, stream);
 
-                traceSend(*message->stream, _logger, _traceLevels);
+                traceSend(*message->stream, _instance, _logger, _traceLevels);
 
                 message->adopt(&stream); // Adopt the compressed stream.
                 message->stream->i = message->stream->b.begin();
@@ -2706,7 +2706,7 @@ Ice::ConnectionI::sendNextMessages(vector<OutgoingMessage>& callbacks)
                     copy(p, p + sizeof(int32_t), message->stream->b.begin() + 10);
                 }
                 message->stream->i = message->stream->b.begin();
-                traceSend(*message->stream, _logger, _traceLevels);
+                traceSend(*message->stream, _instance, _logger, _traceLevels);
 
 #ifdef ICE_HAS_BZIP2
             }
@@ -2793,7 +2793,7 @@ Ice::ConnectionI::sendMessage(OutgoingMessage& message)
         doCompress(*message.stream, stream);
         stream.i = stream.b.begin();
 
-        traceSend(*message.stream, _logger, _traceLevels);
+        traceSend(*message.stream, _instance, _logger, _traceLevels);
 
         if (_observer)
         {
@@ -2844,7 +2844,7 @@ Ice::ConnectionI::sendMessage(OutgoingMessage& message)
         }
         message.stream->i = message.stream->b.begin();
 
-        traceSend(*message.stream, _logger, _traceLevels);
+        traceSend(*message.stream, _instance, _logger, _traceLevels);
 
         if (_observer)
         {

--- a/cpp/src/Ice/EndpointFactoryManager.cpp
+++ b/cpp/src/Ice/EndpointFactoryManager.cpp
@@ -141,7 +141,7 @@ IceInternal::EndpointFactoryManager::create(const string& str, bool oaEndpoint) 
             OutputStream bs(_instance.get(), Ice::currentProtocolEncoding);
             bs.write(ue->type());
             ue->streamWrite(&bs);
-            InputStream is(bs.instance(), bs.getEncoding(), bs);
+            InputStream is(_instance.get(), bs.getEncoding(), bs);
             short type;
             is.read(type);
             is.startEncapsulation();

--- a/cpp/src/Ice/OpaqueEndpointI.cpp
+++ b/cpp/src/Ice/OpaqueEndpointI.cpp
@@ -70,7 +70,7 @@ OpaqueEndpointInfoI::OpaqueEndpointInfoI(int16_t type, const Ice::EncodingVersio
 void
 IceInternal::OpaqueEndpointI::streamWrite(OutputStream* s) const
 {
-    s->startEncapsulation(_rawEncoding, FormatType::DefaultFormat);
+    s->startEncapsulation(_rawEncoding, nullopt);
     s->writeBlob(_rawBytes);
     s->endEncapsulation();
 }

--- a/cpp/src/Ice/OutgoingAsync.cpp
+++ b/cpp/src/Ice/OutgoingAsync.cpp
@@ -1073,7 +1073,7 @@ void
 OutgoingAsync::invoke(
     string_view operation,
     OperationMode mode,
-    FormatType format,
+    optional<FormatType> format,
     const Context& context,
     function<void(OutputStream*)> write)
 {

--- a/cpp/src/Ice/OutgoingResponse.cpp
+++ b/cpp/src/Ice/OutgoingResponse.cpp
@@ -235,7 +235,7 @@ OutgoingResponse
 Ice::makeOutgoingResponse(
     std::function<void(OutputStream*)> marshal,
     const Current& current,
-    FormatType format) noexcept
+    std::optional<FormatType> format) noexcept
 {
     assert(marshal);
     OutputStream ostr(current.adapter->getCommunicator(), Ice::currentProtocolEncoding);

--- a/cpp/src/Ice/OutputStream.cpp
+++ b/cpp/src/Ice/OutputStream.cpp
@@ -180,12 +180,6 @@ Ice::OutputStream::clear()
     }
 }
 
-void
-Ice::OutputStream::setFormat(FormatType fmt)
-{
-    _format = fmt;
-}
-
 void*
 Ice::OutputStream::getClosure() const
 {
@@ -247,12 +241,12 @@ Ice::OutputStream::startEncapsulation()
     }
     else
     {
-        startEncapsulation(_encoding, Ice::FormatType::DefaultFormat);
+        startEncapsulation(_encoding, nullopt);
     }
 }
 
 void
-Ice::OutputStream::startEncapsulation(const EncodingVersion& encoding, FormatType format)
+Ice::OutputStream::startEncapsulation(const EncodingVersion& encoding, std::optional<FormatType> format)
 {
     IceInternal::checkSupportedEncoding(encoding);
 
@@ -266,7 +260,7 @@ Ice::OutputStream::startEncapsulation(const EncodingVersion& encoding, FormatTyp
         _currentEncaps = new Encaps();
         _currentEncaps->previous = oldEncaps;
     }
-    _currentEncaps->format = format;
+    _currentEncaps->format = format.value_or(_format);
     _currentEncaps->encoding = encoding;
     _currentEncaps->start = b.size();
 
@@ -1019,11 +1013,6 @@ Ice::OutputStream::initEncaps()
         _currentEncaps = &_preAllocatedEncaps;
         _currentEncaps->start = b.size();
         _currentEncaps->encoding = _encoding;
-    }
-
-    if (_currentEncaps->format == Ice::FormatType::DefaultFormat)
-    {
-        _currentEncaps->format = _format;
     }
 
     if (!_currentEncaps->encoder) // Lazy initialization.

--- a/cpp/src/Ice/ProxyAsync.cpp
+++ b/cpp/src/Ice/ProxyAsync.cpp
@@ -342,7 +342,7 @@ Ice::ObjectPrx::_iceI_isA(const shared_ptr<OutgoingAsyncT<bool>>& outAsync, stri
     outAsync->invoke(
         operationName,
         OperationMode::Idempotent,
-        FormatType::DefaultFormat,
+        nullopt,
         ctx,
         [&](Ice::OutputStream* os) { os->write(typeId, false); },
         nullptr);
@@ -380,7 +380,7 @@ void
 Ice::ObjectPrx::_iceI_ping(const shared_ptr<OutgoingAsyncT<void>>& outAsync, const Context& ctx) const
 {
     static constexpr string_view operationName = "ice_ping";
-    outAsync->invoke(operationName, OperationMode::Idempotent, FormatType::DefaultFormat, ctx, nullptr, nullptr);
+    outAsync->invoke(operationName, OperationMode::Idempotent, FormatType::CompactFormat, ctx, nullptr, nullptr);
 }
 
 vector<string>
@@ -419,7 +419,7 @@ Ice::ObjectPrx::_iceI_ids(const shared_ptr<OutgoingAsyncT<vector<string>>>& outA
     outAsync->invoke(
         operationName,
         OperationMode::Idempotent,
-        FormatType::DefaultFormat,
+        FormatType::CompactFormat,
         ctx,
         nullptr,
         nullptr,
@@ -467,7 +467,7 @@ Ice::ObjectPrx::_iceI_id(const shared_ptr<OutgoingAsyncT<string>>& outAsync, con
     outAsync->invoke(
         operationName,
         OperationMode::Idempotent,
-        FormatType::DefaultFormat,
+        FormatType::CompactFormat,
         ctx,
         nullptr,
         nullptr,

--- a/cpp/src/Ice/TraceUtil.cpp
+++ b/cpp/src/Ice/TraceUtil.cpp
@@ -392,7 +392,11 @@ IceInternal::traceSlicing(const char* kind, string_view typeId, const char* slic
 }
 
 void
-IceInternal::traceSend(const OutputStream& str, const InstancePtr& instance, const LoggerPtr& logger, const TraceLevelsPtr& tl)
+IceInternal::traceSend(
+    const OutputStream& str,
+    const InstancePtr& instance,
+    const LoggerPtr& logger,
+    const TraceLevelsPtr& tl)
 {
     if (tl->protocol >= 1)
     {

--- a/cpp/src/Ice/TraceUtil.cpp
+++ b/cpp/src/Ice/TraceUtil.cpp
@@ -392,12 +392,12 @@ IceInternal::traceSlicing(const char* kind, string_view typeId, const char* slic
 }
 
 void
-IceInternal::traceSend(const OutputStream& str, const LoggerPtr& logger, const TraceLevelsPtr& tl)
+IceInternal::traceSend(const OutputStream& str, const InstancePtr& instance, const LoggerPtr& logger, const TraceLevelsPtr& tl)
 {
     if (tl->protocol >= 1)
     {
         OutputStream& stream = const_cast<OutputStream&>(str);
-        InputStream is(stream.instance(), stream.getEncoding(), stream);
+        InputStream is(instance.get(), stream.getEncoding(), stream);
         is.i = is.b.begin();
 
         ostringstream s;
@@ -421,23 +421,6 @@ IceInternal::traceRecv(const InputStream& str, const LoggerPtr& logger, const Tr
 
         logger->trace(tl->protocolCat, "received " + getMessageTypeAsString(type) + " " + s.str());
         stream.i = p;
-    }
-}
-
-void
-IceInternal::trace(const char* heading, const OutputStream& str, const LoggerPtr& logger, const TraceLevelsPtr& tl)
-{
-    if (tl->protocol >= 1)
-    {
-        OutputStream& stream = const_cast<OutputStream&>(str);
-        InputStream is(stream.instance(), stream.getEncoding(), stream);
-        is.i = is.b.begin();
-
-        ostringstream s;
-        s << heading;
-        printMessage(s, is);
-
-        logger->trace(tl->protocolCat, s.str());
     }
 }
 

--- a/cpp/src/Ice/TraceUtil.h
+++ b/cpp/src/Ice/TraceUtil.h
@@ -5,6 +5,7 @@
 #ifndef ICE_TRACE_UTIL_H
 #define ICE_TRACE_UTIL_H
 
+#include "Ice/InstanceF.h"
 #include "Ice/Logger.h"
 #include "TraceLevelsF.h"
 
@@ -16,9 +17,10 @@ namespace Ice
 
 namespace IceInternal
 {
-    void traceSend(const Ice::OutputStream&, const Ice::LoggerPtr&, const TraceLevelsPtr&);
+    class Instance;
+
+    void traceSend(const Ice::OutputStream&, const InstancePtr& instance, const Ice::LoggerPtr&, const TraceLevelsPtr&);
     void traceRecv(const Ice::InputStream&, const Ice::LoggerPtr&, const TraceLevelsPtr&);
-    void trace(const char*, const Ice::OutputStream&, const Ice::LoggerPtr&, const TraceLevelsPtr&);
     void trace(const char*, const Ice::InputStream&, const Ice::LoggerPtr&, const TraceLevelsPtr&);
     void traceSlicing(const char*, std::string_view, const char*, const Ice::LoggerPtr&);
 }

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -607,7 +607,7 @@ Slice::opFormatTypeToString(const OperationPtr& op)
     switch (op->format())
     {
         case DefaultFormat:
-            return "::Ice::FormatType::DefaultFormat";
+            return "::std::nullopt";
         case CompactFormat:
             return "::Ice::FormatType::CompactFormat";
         case SlicedFormat:

--- a/cpp/test/Ice/objects/TestI.cpp
+++ b/cpp/test/Ice/objects/TestI.cpp
@@ -303,7 +303,7 @@ UnexpectedObjectExceptionTestI::ice_invoke(vector<byte>, vector<byte>& outParams
 {
     CommunicatorPtr communicator = current.adapter->getCommunicator();
     OutputStream out(communicator);
-    out.startEncapsulation(current.encoding, FormatType::DefaultFormat);
+    out.startEncapsulation(current.encoding, nullopt);
     AlsoEmptyPtr obj = make_shared<AlsoEmpty>();
     out.write(obj);
     out.writePendingValues();

--- a/php/lib/Ice/Value.php
+++ b/php/lib/Ice/Value.php
@@ -66,11 +66,4 @@ class SliceInfo
     public $isLastSlice;
 }
 
-class FormatType
-{
-    const DefaultFormat = 0;
-    const CompactFormat = 1;
-    const SlicedFormat = 2;
-}
-
 ?>

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -55,7 +55,7 @@ namespace IcePy
         string name;
         Ice::OperationMode mode;
         bool amd;
-        Ice::FormatType format;
+        std::optional<Ice::FormatType> format;
         Ice::StringSeq metaData;
         ParamInfoList inParams;
         ParamInfoList optionalInParams;
@@ -718,7 +718,7 @@ IcePy::Operation::Operation(
     //
     if (fmt == Py_None)
     {
-        format = Ice::FormatType::DefaultFormat;
+        format = std::nullopt;
     }
     else
     {

--- a/python/python/Ice/FormatType.py
+++ b/python/python/Ice/FormatType.py
@@ -8,6 +8,5 @@ class FormatType(object):
         assert val >= 0 and val < 3
         self.value = val
 
-FormatType.DefaultFormat = FormatType(0)
-FormatType.CompactFormat = FormatType(1)
-FormatType.SlicedFormat = FormatType(2)
+FormatType.CompactFormat = FormatType(0)
+FormatType.SlicedFormat = FormatType(1)

--- a/ruby/ruby/Ice/Value.rb
+++ b/ruby/ruby/Ice/Value.rb
@@ -50,12 +50,12 @@ module Ice
       include Comparable
 
       def initialize(val)
-          fail("invalid value #{val} for FormatType") unless(val >= 0 and val < 3)
+          fail("invalid value #{val} for FormatType") unless(val >= 0 and val < 2)
           @val = val
       end
 
       def FormatType.from_int(val)
-          raise IndexError, "#{val} is out of range 0..2" if(val < 0 || val > 2)
+          raise IndexError, "#{val} is out of range 0..1" if(val < 0 || val > 1)
           @@_values[val]
       end
 
@@ -84,12 +84,11 @@ module Ice
           @@_values.each(&block)
       end
 
-      @@_names = ['DefaultFormat', 'CompactFormat', 'SlicedFormat']
-      @@_values = [FormatType.new(0), FormatType.new(1), FormatType.new(2)]
+      @@_names = ['CompactFormat', 'SlicedFormat']
+      @@_values = [FormatType.new(0), FormatType.new(1)]
 
-      DefaultFormat = @@_values[0]
-      CompactFormat = @@_values[1]
-      SlicedFormat = @@_values[2]
+      CompactFormat = @@_values[0]
+      SlicedFormat = @@_values[1]
 
       private_class_method :new
     end

--- a/ruby/src/IceRuby/Operation.cpp
+++ b/ruby/src/IceRuby/Operation.cpp
@@ -49,7 +49,7 @@ namespace IceRuby
         string _name;
         Ice::OperationMode _mode;
         bool _amd;
-        Ice::FormatType _format;
+        std::optional<Ice::FormatType> _format;
         ParamInfoList _inParams;
         ParamInfoList _optionalInParams;
         ParamInfoList _outParams;
@@ -181,7 +181,7 @@ IceRuby::OperationI::OperationI(
     //
     if (format == Qnil)
     {
-        _format = Ice::FormatType::DefaultFormat;
+        _format = std::nullopt;
     }
     else
     {

--- a/swift/src/IceImpl/Communicator.mm
+++ b/swift/src/IceImpl/Communicator.mm
@@ -416,7 +416,8 @@
 {
     // TODO: sychronize Swift and C++ FormatType.
     return static_cast<std::uint8_t>(
-        IceInternal::getInstance(self.communicator)->defaultsAndOverrides()->defaultFormat) + 1;
+               IceInternal::getInstance(self.communicator)->defaultsAndOverrides()->defaultFormat) +
+           1;
 }
 
 - (id<ICEDispatchAdapter>)facetToDispatchAdapter:(const Ice::ObjectPtr&)servant

--- a/swift/src/IceImpl/Communicator.mm
+++ b/swift/src/IceImpl/Communicator.mm
@@ -414,8 +414,9 @@
 
 - (std::uint8_t)getDefaultFormat
 {
+    // TODO: sychronize Swift and C++ FormatType.
     return static_cast<std::uint8_t>(
-        IceInternal::getInstance(self.communicator)->defaultsAndOverrides()->defaultFormat);
+        IceInternal::getInstance(self.communicator)->defaultsAndOverrides()->defaultFormat) + 1;
 }
 
 - (id<ICEDispatchAdapter>)facetToDispatchAdapter:(const Ice::ObjectPtr&)servant


### PR DESCRIPTION
This PR removes the DefaultFormat enumerator in C++. It also removes _instance from OutputStream in C++.

It's a partial C++ equivalent of #2594.