### PR TITLE
Remove sent callback in Swift

### DIFF
--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -712,18 +712,6 @@ SwiftGenerator::writeOpDocSummary(IceInternal::Output& out, const OperationPtr& 
 
     if (async)
     {
-        if (!dispatch)
-        {
-            out << nl << "///";
-            out << nl << "/// - parameter sentOn: `Dispatch.DispatchQueue?` - Optional dispatch queue used to";
-            out << nl << "///   dispatch the sent callback.";
-            out << nl << "///";
-            out << nl << "/// - parameter sentFlags: `Dispatch.DispatchWorkItemFlags?` - Optional dispatch flags used";
-            out << nl << "///   to dispatch the sent callback";
-            out << nl << "///";
-            out << nl << "/// - parameter sent: `((Swift.Bool) -> Swift.Void)` - Optional sent callback.";
-        }
-
         out << nl << "///";
         out << nl << "/// - returns: `" << operationReturnType(p, typeCtx) << "` - The result of the operation";
     }
@@ -2495,10 +2483,6 @@ SwiftGenerator::writeProxyAsyncOperation(::IceInternal::Output& out, const Opera
         }
     }
     out << "context: " + getUnqualified("Ice.Context", swiftModule) + "? = nil";
-    out << "sentOn: Dispatch.DispatchQueue? = nil";
-    out << "sentFlags: Dispatch.DispatchWorkItemFlags? = nil";
-    out << "sent: ((Swift.Bool) -> Swift.Void)? = nil";
-
     out << epar;
     out << " async throws -> ";
     if (allOutParams.empty())
@@ -2549,10 +2533,7 @@ SwiftGenerator::writeProxyAsyncOperation(::IceInternal::Output& out, const Opera
         out << ",";
     }
 
-    out << nl << "context: context,";
-    out << nl << "sentOn: sentOn,";
-    out << nl << "sentFlags: sentFlags,";
-    out << nl << "sent: sent)";
+    out << nl << "context: context)";
     out.restoreIndent();
 
     out << eb;

--- a/swift/src/Ice/Communicator.swift
+++ b/swift/src/Ice/Communicator.swift
@@ -174,19 +174,8 @@ public protocol Communicator: AnyObject {
     ///
     /// - parameter _: `CompressBatch` Specifies whether or not the queued batch requests should be compressed before
     /// being sent over the wire.
-    ///
-    /// - parameter sentOn: `Dispatch.DispatchQueue?` - Optional dispatch queue used to
-    ///   dispatch the sent callback.
-    ///
-    /// - parameter sentFlags: `Dispatch.DispatchWorkItemFlags?` - Optional dispatch flags used
-    ///   to dispatch the sent callback
-    ///
-    /// - parameter sent: `((Bool) -> Void)` - Optional sent callback.
     func flushBatchRequestsAsync(
-        _ compress: CompressBatch,
-        sentOn: Dispatch.DispatchQueue?,
-        sentFlags: Dispatch.DispatchWorkItemFlags?,
-        sent: ((Bool) -> Void)?
+        _ compress: CompressBatch
     ) async throws
 
     /// Add the Admin object with all its facets to the provided object adapter. If Ice.Admin.ServerId is

--- a/swift/src/Ice/CommunicatorI.swift
+++ b/swift/src/Ice/CommunicatorI.swift
@@ -258,23 +258,17 @@ class CommunicatorI: LocalObject<ICECommunicator>, Communicator {
 
 extension Communicator {
     public func flushBatchRequestsAsync(
-        _ compress: CompressBatch,
-        sentOn: DispatchQueue? = nil,
-        sentFlags: DispatchWorkItemFlags? = nil,
-        sent: ((Bool) -> Void)? = nil
+        _ compress: CompressBatch
     ) async throws {
         let impl = self as! CommunicatorI
-        let sentCB = createSentCallback(sentOn: sentOn, sentFlags: sentFlags, sent: sent)
         return try await withCheckedThrowingContinuation { continuation in
             impl.handle.flushBatchRequestsAsync(
                 compress.rawValue,
                 exception: { continuation.resume(throwing: $0) },
-                sent: {
+                sent: { _ in
                     continuation.resume(returning: ())
-                    if let sentCB = sentCB {
-                        sentCB($0)
-                    }
-                })
+                }
+            )
         }
     }
 

--- a/swift/src/Ice/Connection.swift
+++ b/swift/src/Ice/Connection.swift
@@ -198,19 +198,8 @@ public protocol Connection: AnyObject, CustomStringConvertible {
     ///
     /// - parameter _: `CompressBatch` Specifies whether or not the queued batch requests should be compressed before
     /// being sent over the wire.
-    ///
-    /// - parameter sentOn: `Dispatch.DispatchQueue?` - Optional dispatch queue used to
-    ///   dispatch the sent callback.
-    ///
-    /// - parameter sentFlags: `Dispatch.DispatchWorkItemFlags?` - Optional dispatch flags used
-    ///   to dispatch the sent callback
-    ///
-    /// - parameter sent: `((Bool) -> Void)` - Optional sent callback.
     func flushBatchRequestsAsync(
-        _ compress: CompressBatch,
-        sentOn: Dispatch.DispatchQueue?,
-        sentFlags: Dispatch.DispatchWorkItemFlags?,
-        sent: ((Bool) -> Void)?
+        _ compress: CompressBatch
     ) async throws
 
     /// Set a close callback on the connection. The callback is called by the connection when it's closed. The callback

--- a/swift/src/Ice/ConnectionI.swift
+++ b/swift/src/Ice/ConnectionI.swift
@@ -4,22 +4,15 @@ import IceImpl
 
 extension Connection {
     public func flushBatchRequestsAsync(
-        _ compress: CompressBatch,
-        sentOn: DispatchQueue? = nil,
-        sentFlags: DispatchWorkItemFlags? = nil,
-        sent: ((Bool) -> Void)? = nil
+        _ compress: CompressBatch
     ) async throws {
         let impl = self as! ConnectionI
-        let sentCB = createSentCallback(sentOn: sentOn, sentFlags: sentFlags, sent: sent)
         return try await withCheckedThrowingContinuation { continuation in
             impl.handle.flushBatchRequestsAsync(
                 compress.rawValue,
                 exception: { error in continuation.resume(throwing: error) },
                 sent: {
                     continuation.resume(returning: ())
-                    if let sentCB = sentCB {
-                        sentCB($0)
-                    }
                 })
         }
     }

--- a/swift/src/Ice/ConnectionI.swift
+++ b/swift/src/Ice/ConnectionI.swift
@@ -11,7 +11,7 @@ extension Connection {
             impl.handle.flushBatchRequestsAsync(
                 compress.rawValue,
                 exception: { error in continuation.resume(throwing: error) },
-                sent: {
+                sent: { _ in
                     continuation.resume(returning: ())
                 })
         }

--- a/swift/src/Ice/Proxy.swift
+++ b/swift/src/Ice/Proxy.swift
@@ -404,27 +404,13 @@ extension ObjectPrx {
     /// Sends ping request to the target object asynchronously.
     ///
     /// - parameter context: `Ice.Context` - The optional context dictionary for the invocation.
-    ///
-    /// - parameter sentOn: `Dispatch.DispatchQueue` - Optional dispatch queue used to
-    ///   dispatch the sent callback.
-    ///
-    /// - parameter sentFlags: `Dispatch.DispatchWorkItemFlags` - Optional dispatch flags used to
-    ///   dispatch sent callback
-    ///
-    /// - parameter sent: `((Bool) -> Void)` - Optional sent callback.
     public func ice_pingAsync(
-        context: Context? = nil,
-        sentOn: DispatchQueue? = nil,
-        sentFlags: DispatchWorkItemFlags? = nil,
-        sent: ((Bool) -> Void)? = nil
+        context: Context? = nil
     ) async throws {
         return try await _impl._invokeAsync(
             operation: "ice_ping",
             mode: .Idempotent,
-            context: context,
-            sentOn: sentOn,
-            sentFlags: sentFlags,
-            sent: sent)
+            context: context)
     }
 
     /// Tests whether this object supports a specific Slice interface.
@@ -452,20 +438,9 @@ extension ObjectPrx {
     ///
     /// - parameter context: `Ice.Context` - The optional context dictionary for the invocation.
     ///
-    /// - parameter sentOn: `Dispatch.DispatchQueue` - Optional dispatch queue used to
-    ///   dispatch the sent callback.
-    ///
-    /// - parameter sentFlags: `Dispatch.DispatchWorkItemFlags` - Optional dispatch flags used to
-    ///   dispatch sent callback
-    ///
-    /// - parameter sent: `((Bool) -> Void)` - Optional sent callback.
-    ///
     /// - returns: `Bool` - The result of the invocation.
     public func ice_isAAsync(
-        id: String, context: Context? = nil,
-        sentOn: DispatchQueue? = nil,
-        sentFlags: DispatchWorkItemFlags? = nil,
-        sent: ((Bool) -> Void)? = nil
+        id: String, context: Context? = nil
     ) async throws -> Bool {
         return try await _impl._invokeAsync(
             operation: "ice_isA",
@@ -474,10 +449,7 @@ extension ObjectPrx {
                 ostr.write(id)
             },
             read: { istr in try istr.read() as Bool },
-            context: context,
-            sentOn: sentOn,
-            sentFlags: sentFlags,
-            sent: sent)
+            context: context)
     }
 
     /// Returns the Slice type ID of the most-derived interface supported by the target object of this proxy.
@@ -497,29 +469,15 @@ extension ObjectPrx {
     ///
     /// - parameter context: `Ice.Context?` - The optional context dictionary for the invocation.
     ///
-    /// - parameter sentOn: `Dispatch.DispatchQueue` - Optional dispatch queue used to
-    ///   dispatch the sent callback.
-    ///
-    /// - parameter sentFlags: `Dispatch.DispatchWorkItemFlags` - Optional dispatch flags used to
-    ///   dispatch sent callback
-    ///
-    /// - parameter sent: `((Bool) -> Void)` - Optional sent callback.
-    ///
     /// - returns: `String` The result of the invocation.
     public func ice_idAsync(
-        context: Context? = nil,
-        sentOn: DispatchQueue? = nil,
-        sentFlags: DispatchWorkItemFlags? = nil,
-        sent: ((Bool) -> Void)? = nil
+        context: Context? = nil
     ) async throws -> String {
         return try await _impl._invokeAsync(
             operation: "ice_id",
             mode: .Idempotent,
             read: { istr in try istr.read() as String },
-            context: context,
-            sentOn: sentOn,
-            sentFlags: sentFlags,
-            sent: sent)
+            context: context)
     }
 
     /// Returns the Slice type IDs of the interfaces supported by the target object of this proxy.
@@ -540,29 +498,15 @@ extension ObjectPrx {
     ///
     /// - parameter context: `Ice.Context?` - The optional context dictionary for the invocation.
     ///
-    /// - parameter sentOn: `Dispatch.DispatchQueue` - Optional dispatch queue used to
-    ///   dispatch the sent callback.
-    ///
-    /// - parameter sentFlags: `Dispatch.DispatchWorkItemFlags` - Optional dispatch flags used to
-    ///   dispatch sent callback
-    ///
-    /// - parameter sent: `((Bool) -> Void)` - Optional sent callback.
-    ///
     /// - returns: `Ice.StringSeq` - The result of the invocation.
     public func ice_idsAsync(
-        context: Context? = nil,
-        sentOn: DispatchQueue? = nil,
-        sentFlags: DispatchWorkItemFlags? = nil,
-        sent: ((Bool) -> Void)? = nil
+        context: Context? = nil
     ) async throws -> StringSeq {
         return try await _impl._invokeAsync(
             operation: "ice_ids",
             mode: .Idempotent,
             read: { istr in try istr.read() as StringSeq },
-            context: context,
-            sentOn: sentOn,
-            sentFlags: sentFlags,
-            sent: sent)
+            context: context)
     }
 
     /// Invokes an operation dynamically.
@@ -615,25 +559,13 @@ extension ObjectPrx {
     ///
     /// - parameter context: `Ice.Context` - The context dictionary for the invocation.
     ///
-    /// - parameter sentOn: `Dispatch.DispatchQueue` - Optional dispatch queue used to
-    ///   dispatch the sent callback.
-    ///
-    /// - parameter sentFlags: `Dispatch.DispatchWorkItemFlags` - Optional dispatch flags used to
-    ///   dispatch the sent callback.
-    ///
-    /// - parameter sent: `((Bool) -> Void)` - Optional sent callback.
-    ///
     /// - returns: `(ok: Bool, outEncaps: Data)` - The result of the invocation.
     public func ice_invokeAsync(
         operation: String,
         mode: OperationMode,
         inEncaps: Data,
-        context: Context? = nil,
-        sentOn: DispatchQueue? = nil,
-        sentFlags: DispatchWorkItemFlags? = nil,
-        sent: ((Bool) -> Void)? = nil
+        context: Context? = nil
     ) async throws -> (ok: Bool, outEncaps: Data) {
-
         if _impl.isTwoway {
             return try await withCheckedThrowingContinuation { continuation in
                 _impl.handle.invokeAsync(
@@ -655,14 +587,9 @@ extension ObjectPrx {
                     },
                     exception: { error in
                         continuation.resume(throwing: error)
-                    },
-                    sent: createSentCallback(
-                        sentOn: sentOn,
-                        sentFlags: sentFlags,
-                        sent: sent))
+                    })
             }
         } else {
-            let sentCB = createSentCallback(sentOn: sentOn, sentFlags: sentFlags, sent: sent)
             return try await withCheckedThrowingContinuation { continuation in
                 _impl.handle.invokeAsync(
                     operation,
@@ -675,11 +602,8 @@ extension ObjectPrx {
                     exception: { error in
                         continuation.resume(throwing: error)
                     },
-                    sent: {
+                    sent: { _ in
                         continuation.resume(returning: (true, Data()))
-                        if let sentCB = sentCB {
-                            sentCB($0)
-                        }
                     })
             }
         }
@@ -726,30 +650,15 @@ extension ObjectPrx {
     }
 
     /// Asynchronously flushes any pending batched requests for this proxy.
-    ///
-    /// - parameter sentOn: `Dispatch.DispatchQueue` - Optional dispatch queue used to
-    ///   dispatch the sent callback.
-    ///
-    /// - parameter sentFlags: `Dispatch.DispatchWorkItemFlags` Optional dispatch flags used to
-    ///   dispatch the sent callback.
-    ///
-    /// - parameter sent: `((Bool) -> Void)` - Optional sent callback.
     public func ice_flushBatchRequestsAsync(
-        sentOn: DispatchQueue? = nil,
-        sentFlags: DispatchWorkItemFlags? = nil.self,
-        sent: ((Bool) -> Void)? = nil
     ) async throws {
-        let sentCB = createSentCallback(sentOn: sentOn, sentFlags: sentFlags, sent: sent)
         return try await withCheckedThrowingContinuation { continuation in
             _impl.handle.ice_flushBatchRequestsAsync(
                 exception: {
                     continuation.resume(throwing: $0)
                 },
-                sent: {
+                sent: { _ in
                     continuation.resume(returning: ())
-                    if let sentCB = sentCB {
-                        sentCB($0)
-                    }
                 }
             )
         }
@@ -1266,10 +1175,7 @@ open class ObjectPrxI: ObjectPrx {
         format: FormatType = FormatType.DefaultFormat,
         write: ((OutputStream) -> Void)? = nil,
         userException: ((UserException) throws -> Void)? = nil,
-        context: Context? = nil,
-        sentOn: DispatchQueue? = nil,
-        sentFlags: DispatchWorkItemFlags? = nil,
-        sent: ((Bool) -> Void)? = nil
+        context: Context? = nil
     ) async throws {
 
         if userException != nil, !isTwoway {
@@ -1309,8 +1215,7 @@ open class ObjectPrxI: ObjectPrx {
                     },
                     exception: { error in
                         continuation.resume(throwing: error)
-                    },
-                    sent: createSentCallback(sentOn: sentOn, sentFlags: sentFlags, sent: sent))
+                    })
             }
         } else {
             if ice_isBatchOneway() || ice_isBatchDatagram() {
@@ -1332,7 +1237,6 @@ open class ObjectPrxI: ObjectPrx {
                 }
             } else {
                 return try await withCheckedThrowingContinuation { continuation in
-                    let sentCB = createSentCallback(sentOn: sentOn, sentFlags: sentFlags, sent: sent)
                     handle.invokeAsync(
                         operation,
                         mode: mode.rawValue,
@@ -1344,11 +1248,8 @@ open class ObjectPrxI: ObjectPrx {
                         exception: { error in
                             continuation.resume(throwing: error)
                         },
-                        sent: {
+                        sent: { _ in
                             continuation.resume(returning: ())
-                            if let sentCB = sentCB {
-                                sentCB($0)
-                            }
                         })
                 }
             }
@@ -1362,10 +1263,7 @@ open class ObjectPrxI: ObjectPrx {
         write: ((OutputStream) -> Void)? = nil,
         read: @escaping (InputStream) throws -> T,
         userException: ((UserException) throws -> Void)? = nil,
-        context: Context? = nil,
-        sentOn: DispatchQueue? = nil,
-        sentFlags: DispatchWorkItemFlags? = nil,
-        sent: ((Bool) -> Void)? = nil
+        context: Context? = nil
     ) async throws -> T {
         if !isTwoway {
             throw TwowayOnlyException(operation: operation)
@@ -1407,8 +1305,7 @@ open class ObjectPrxI: ObjectPrx {
                 },
                 exception: { error in
                     continuation.resume(throwing: error)
-                },
-                sent: createSentCallback(sentOn: sentOn, sentFlags: sentFlags, sent: sent))
+                })
         }
     }
 

--- a/swift/src/Ice/Proxy.swift
+++ b/swift/src/Ice/Proxy.swift
@@ -650,8 +650,7 @@ extension ObjectPrx {
     }
 
     /// Asynchronously flushes any pending batched requests for this proxy.
-    public func ice_flushBatchRequestsAsync(
-    ) async throws {
+    public func ice_flushBatchRequestsAsync() async throws {
         return try await withCheckedThrowingContinuation { continuation in
             _impl.handle.ice_flushBatchRequestsAsync(
                 exception: {

--- a/swift/src/Ice/Util.swift
+++ b/swift/src/Ice/Util.swift
@@ -26,43 +26,6 @@ func stringToMajorMinor(_ s: String) throws -> (UInt8, UInt8) {
     return (major, minor)
 }
 
-func createSentCallback(
-    sentOn: DispatchQueue?,
-    sentFlags: DispatchWorkItemFlags?,
-    sent: ((Bool) -> Void)?
-) -> ((Bool) -> Void)? {
-    guard let s = sent else {
-        // If sent is nil, we keep it as-is
-        return sent
-    }
-
-    guard let q = sentOn else {
-        // If sentOn is nil, we just wrap sent in an autorelease pool
-        return { sentSynchronously in
-            autoreleasepool {
-                s(sentSynchronously)
-            }
-        }
-    }
-
-    //
-    // Create a closure to dispatch the sent callback in the specified queue
-    //
-    if let flags = sentFlags {
-        return { sentSynchronously in
-            q.async(flags: flags) {
-                s(sentSynchronously)
-            }
-        }
-    } else {
-        return { sentSynchronously in
-            q.async {
-                s(sentSynchronously)
-            }
-        }
-    }
-}
-
 func escapeString(string: String, special: String, communicator: Communicator) throws -> String {
     guard factoriesRegistered else {
         fatalError("Unable to initialize Ice")

--- a/swift/test/Ice/ami/AllTests.swift
+++ b/swift/test/Ice/ami/AllTests.swift
@@ -342,7 +342,7 @@ func allTests(_ helper: TestHelper, collocated: Bool = false) async throws {
                 // Ensure the request was sent before we close the connection. Oneway invocations are
                 // completed when the request is sent.
                 async let startDispatch: Void = p.startDispatchAsync()
-                try await Task.sleep(for: .milliseconds(100)) // Wait for the request to be sent.
+                try await Task.sleep(for: .milliseconds(100))  // Wait for the request to be sent.
                 try con.close(.Gracefully)
                 try await startDispatch
                 try test(false)
@@ -391,7 +391,7 @@ func allTests(_ helper: TestHelper, collocated: Bool = false) async throws {
             do {
                 try await startDispatch
                 try test(false)
-            }  catch let ex as Ice.ConnectionAbortedException {
+            } catch let ex as Ice.ConnectionAbortedException {
                 try test(ex.closedByApplication)
             }
             try p.finishDispatch()

--- a/swift/test/Ice/operations/OnewaysAMI.swift
+++ b/swift/test/Ice/operations/OnewaysAMI.swift
@@ -7,13 +7,10 @@ import TestCommon
 func onewaysAMI(_ helper: TestHelper, _ proxy: MyClassPrx) async throws {
     let p = uncheckedCast(prx: proxy.ice_oneway(), type: MyClassPrx.self)
 
-    try await withCheckedThrowingContinuation { continuation in
-        Task {
-            try! await p.opVoidAsync { _ in
-                continuation.resume(returning: ())
-            }
-        }
-    }
+    //
+    // NOTE: Oneway operations are completed when the request is sent
+    //
+    try await p.opVoidAsync()
 
     do {
         let _ = try await p.ice_isAAsync(id: ice_staticId(MyClassPrx.self))
@@ -25,22 +22,9 @@ func onewaysAMI(_ helper: TestHelper, _ proxy: MyClassPrx) async throws {
         try helper.test(false)
     } catch is Ice.TwowayOnlyException {}
 
-    try await withCheckedThrowingContinuation { continuation in
-        Task {
-            try! await p.opVoidAsync { _ in
-                continuation.resume(returning: ())
-            }
-        }
-    }
+    try await p.opVoidAsync()
 
-    try await withCheckedThrowingContinuation { continuation in
-        Task {
-            try! await p.opIdempotentAsync { _ in
-                continuation.resume(returning: ())
-            }
-        }
-
-    }
+    try await p.opIdempotentAsync()
 
     do {
         let _ = try await p.opByteAsync(p1: 0xFF, p2: 0x0F)


### PR DESCRIPTION
This PR remove's the sent callback from the Swift mapping.