### PR TITLE
Replace FormatType's DefaultFormat by null

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -949,10 +949,10 @@ Slice::Contained::setMetaData(const list<string>& metaData)
     _metaData = metaData;
 }
 
-FormatType
+std::optional<FormatType>
 Slice::Contained::parseFormatMetaData(const list<string>& metaData)
 {
-    FormatType result = DefaultFormat;
+    std::optional<FormatType> result;
 
     string tag;
     string prefix = "format:";
@@ -4670,11 +4670,11 @@ Slice::Operation::sendsOptionals() const
     return false;
 }
 
-FormatType
+std::optional<FormatType>
 Slice::Operation::format() const
 {
-    FormatType format = parseFormatMetaData(getMetaData());
-    if (format == DefaultFormat)
+    std::optional<FormatType> format = parseFormatMetaData(getMetaData());
+    if (!format)
     {
         ContainedPtr cont = dynamic_pointer_cast<Contained>(container());
         assert(cont);

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -36,11 +36,10 @@ namespace Slice
     };
 
     //
-    // Format preference for classes and exceptions.
+    // Format to use when marshaling a class instance.
     //
     enum FormatType
     {
-        DefaultFormat, // No preference was specified.
         CompactFormat, // Minimal format.
         SlicedFormat   // Full format.
     };
@@ -390,7 +389,7 @@ namespace Slice
         std::list<std::string> getMetaData() const;
         void setMetaData(const std::list<std::string>&);
 
-        static FormatType parseFormatMetaData(const std::list<std::string>&);
+        static std::optional<FormatType> parseFormatMetaData(const std::list<std::string>&);
 
         /// Returns true if this item is deprecated (due to the presence of 'deprecated' metadata).
         /// @param checkParent If true, this item's immediate container will also be checked for 'deprecated' metadata.
@@ -677,7 +676,7 @@ namespace Slice
         bool returnsData() const;
         bool returnsMultipleValues() const;
         bool sendsOptionals() const;
-        FormatType format() const;
+        std::optional<FormatType> format() const;
         std::string kindOf() const final;
         void visit(ParserVisitor*, bool) final;
 

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -604,7 +604,7 @@ Slice::operationModeToString(Operation::Mode mode)
 string
 Slice::opFormatTypeToString(const OperationPtr& op)
 {
-    std::optional<FormatType> opFormat = op->format();
+    optional<FormatType> opFormat = op->format();
     if (opFormat)
     {
         switch (*opFormat)

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -604,20 +604,25 @@ Slice::operationModeToString(Operation::Mode mode)
 string
 Slice::opFormatTypeToString(const OperationPtr& op)
 {
-    switch (op->format())
+    std::optional<FormatType> opFormat = op->format();
+    if (opFormat)
     {
-        case DefaultFormat:
-            return "::std::nullopt";
-        case CompactFormat:
-            return "::Ice::FormatType::CompactFormat";
-        case SlicedFormat:
-            return "::Ice::FormatType::SlicedFormat";
+        switch (*opFormat)
+        {
+            case CompactFormat:
+                return "::Ice::FormatType::CompactFormat";
+            case SlicedFormat:
+                return "::Ice::FormatType::SlicedFormat";
 
-        default:
-            assert(false);
+            default:
+                assert(false);
+                return "???";
+        }
     }
-
-    return "???";
+    else
+    {
+        return "::std::nullopt";
+    }
 }
 
 //

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -3168,7 +3168,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
                 }
                 C << eb << ",";
                 C << nl << "request.current()";
-                if (p->format() != DefaultFormat)
+                if (p->format())
                 {
                     C << ",";
                     C << nl << opFormatTypeToString(p);
@@ -3201,7 +3201,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
                 C << nl << "ostr->writePendingValues();";
             }
             C << eb;
-            if (p->format() != DefaultFormat)
+            if (p->format())
             {
                 C << ",";
                 C << nl << opFormatTypeToString(p);

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -55,27 +55,24 @@ namespace
 
     string opFormatTypeToString(const OperationPtr& op)
     {
-        switch (op->format())
+        std::optional<FormatType> opFormat = op->format();
+        if (opFormat)
         {
-            case DefaultFormat:
+            switch (*opFormat)
             {
-                return "null";
-            }
-            case CompactFormat:
-            {
-                return "Ice.FormatType.CompactFormat";
-            }
-            case SlicedFormat:
-            {
-                return "Ice.FormatType.SlicedFormat";
-            }
-            default:
-            {
-                assert(false);
+                case CompactFormat:
+                    return "Ice.FormatType.CompactFormat";
+                case SlicedFormat:
+                    return "Ice.FormatType.SlicedFormat";
+                default:
+                    assert(false);
+                    return "???";
             }
         }
-
-        return "???";
+        else
+        {
+            return "null";
+        }
     }
 
     string getDeprecationMessageForComment(const ContainedPtr& p1, const string& type)
@@ -2753,7 +2750,7 @@ Slice::Gen::DispatchAdapterVisitor::visitOperation(const OperationPtr& op)
                 _out << nl << "ostr.writePendingValues();";
             }
             _out << eb;
-            if (op->format() != DefaultFormat)
+            if (op->format())
             {
                 _out << "," << nl << opFormatTypeToString(op);
             }

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -55,7 +55,7 @@ namespace
 
     string opFormatTypeToString(const OperationPtr& op)
     {
-        std::optional<FormatType> opFormat = op->format();
+        optional<FormatType> opFormat = op->format();
         if (opFormat)
         {
             switch (*opFormat)

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -37,23 +37,25 @@ namespace
 
     string opFormatTypeToString(const OperationPtr& op)
     {
-        string format = "com.zeroc.Ice.FormatType.";
-        switch (op->format())
+        // TODO: remove DefaultFormat.
+        std::optional<FormatType> opFormat = op->format();
+        if (opFormat)
         {
-            case DefaultFormat:
-                format += "DefaultFormat";
-                break;
-            case CompactFormat:
-                format += "CompactFormat";
-                break;
-            case SlicedFormat:
-                format += "SlicedFormat";
-                break;
-            default:
-                assert(false);
-                break;
+            switch (*opFormat)
+            {
+                case CompactFormat:
+                    return "com.zeroc.Ice.FormatType.CompactFormat";
+                case SlicedFormat:
+                    return "com.zeroc.Ice.FormatType.SlicedFormat";
+                default:
+                    assert(false);
+                    return "???";
+            }
         }
-        return format;
+        else
+        {
+            return "com.zeroc.Ice.FormatType.DefaultFormat";
+        }
     }
 
     string getEscapedParamName(const OperationPtr& p, const string& name)

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -37,7 +37,6 @@ namespace
 
     string opFormatTypeToString(const OperationPtr& op)
     {
-        // TODO: remove DefaultFormat.
         std::optional<FormatType> opFormat = op->format();
         if (opFormat)
         {
@@ -54,7 +53,7 @@ namespace
         }
         else
         {
-            return "com.zeroc.Ice.FormatType.DefaultFormat";
+            return "null";
         }
     }
 

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -37,7 +37,7 @@ namespace
 
     string opFormatTypeToString(const OperationPtr& op)
     {
-        std::optional<FormatType> opFormat = op->format();
+        optional<FormatType> opFormat = op->format();
         if (opFormat)
         {
             switch (*opFormat)

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -70,26 +70,17 @@ namespace
         return "???";
     }
 
-    string opFormatTypeToString(const OperationPtr& op)
+    string opFormatTypeToString(FormatType opFormat)
     {
-        // TODO: update JS format type and rework this code.
-        std::optional<FormatType> opFormat = op->format();
-        if (opFormat)
+        switch (opFormat)
         {
-            switch (*opFormat)
-            {
-                case CompactFormat:
-                    return "1";
-                case SlicedFormat:
-                    return "2";
-                default:
-                    assert(false);
-                    return "???";
-            }
-        }
-        else
-        {
-            return "0";
+            case CompactFormat:
+                return "0";
+            case SlicedFormat:
+                return "1";
+            default:
+                assert(false);
+                return "???";
         }
     }
 
@@ -1495,7 +1486,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
             if (op->format())
             {
-                _out << opFormatTypeToString(op); // Format.
+                _out << opFormatTypeToString(*op->format()); // Format.
             }
             _out << ", ";
 

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -72,19 +72,25 @@ namespace
 
     string opFormatTypeToString(const OperationPtr& op)
     {
-        switch (op->format())
+        // TODO: update JS format type and rework this code.
+        std::optional<FormatType> opFormat = op->format();
+        if (opFormat)
         {
-            case DefaultFormat:
-                return "0";
-            case CompactFormat:
-                return "1";
-            case SlicedFormat:
-                return "2";
-            default:
-                assert(false);
+            switch (*opFormat)
+            {
+                case CompactFormat:
+                    return "1";
+                case SlicedFormat:
+                    return "2";
+                default:
+                    assert(false);
+                    return "???";
+            }
         }
-
-        return "???";
+        else
+        {
+            return "0";
+        }
     }
 
     void printHeader(IceInternal::Output& out)
@@ -1487,7 +1493,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             }
             _out << ", ";
 
-            if (op->format() != DefaultFormat)
+            if (op->format())
             {
                 _out << opFormatTypeToString(op); // Format.
             }

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -2152,13 +2152,13 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
         if (!allInParams.empty())
         {
-            if (op->format() == DefaultFormat)
+            if (op->format())
             {
-                out << nl << "os_ = " << self << ".iceStartWriteParams([]);";
+                out << nl << "os_ = " << self << ".iceStartWriteParams(" << getFormatType(*op->format()) << ");";
             }
             else
             {
-                out << nl << "os_ = " << self << ".iceStartWriteParams(" << getFormatType(op->format()) << ");";
+                out << nl << "os_ = " << self << ".iceStartWriteParams([]);";
             }
             for (ParamInfoList::const_iterator r = requiredInParams.begin(); r != requiredInParams.end(); ++r)
             {
@@ -2315,13 +2315,13 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
         if (!allInParams.empty())
         {
-            if (op->format() == DefaultFormat)
+            if (op->format())
             {
-                out << nl << "os_ = " << self << ".iceStartWriteParams([]);";
+                out << nl << "os_ = " << self << ".iceStartWriteParams(" << getFormatType(*op->format()) << ");";
             }
             else
             {
-                out << nl << "os_ = " << self << ".iceStartWriteParams(" << getFormatType(op->format()) << ");";
+                out << nl << "os_ = " << self << ".iceStartWriteParams([]);";
             }
             for (ParamInfoList::const_iterator r = requiredInParams.begin(); r != requiredInParams.end(); ++r)
             {
@@ -3851,17 +3851,14 @@ CodeVisitor::getFormatType(FormatType type)
 {
     switch (type)
     {
-        case DefaultFormat:
-            return "Ice.FormatType.DefaultFormat";
         case CompactFormat:
             return "Ice.FormatType.CompactFormat";
         case SlicedFormat:
             return "Ice.FormatType.SlicedFormat";
         default:
             assert(false);
+            return "???";
     }
-
-    return "???";
 }
 
 void

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -432,6 +432,7 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     //
     // where InParams and OutParams are arrays of type descriptions, and Exceptions
     // is an array of exception type ids.
+
     if (!ops.empty())
     {
         _out << sp;
@@ -466,8 +467,16 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             ParamDeclList::iterator t;
             int count;
 
+            // We encode nullopt as -1.
+            optional<FormatType> opFormat = (*oli)->format();
+            int phpFormat = -1;
+            if (opFormat)
+            {
+                phpFormat = static_cast<int>(*opFormat);
+            }
+
             _out << nl << "IcePHP_defineOperation(" << prxType << ", '" << (*oli)->name() << "', "
-                 << getOperationMode((*oli)->mode()) << ", " << static_cast<int>((*oli)->format()) << ", ";
+                 << getOperationMode((*oli)->mode()) << ", " << phpFormat << ", ";
             for (t = params.begin(), count = 0; t != params.end(); ++t)
             {
                 if (!(*t)->isOutParam())

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -939,17 +939,24 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         ParamDeclList::iterator t;
         int count;
         string format;
-        switch (operation->format())
+         std::optional<FormatType> opFormat = operation->format();
+        if (opFormat)
         {
-            case DefaultFormat:
-                format = "None";
-                break;
-            case CompactFormat:
-                format = "Ice.FormatType.CompactFormat";
-                break;
-            case SlicedFormat:
-                format = "Ice.FormatType.SlicedFormat";
-                break;
+            switch (*opFormat)
+            {
+                case CompactFormat:
+                    format = "Ice.FormatType.CompactFormat";
+                    break;
+                case SlicedFormat:
+                    format = "Ice.FormatType.SlicedFormat";
+                    break;
+                default:
+                    assert(false);
+            }
+        }
+        else
+        {
+            format = "None";
         }
 
         _out << nl << className << "._op_" << operation->name() << " = IcePy.Operation('" << operation->name() << "', "

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -939,7 +939,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         ParamDeclList::iterator t;
         int count;
         string format;
-         std::optional<FormatType> opFormat = operation->format();
+        std::optional<FormatType> opFormat = operation->format();
         if (opFormat)
         {
             switch (*opFormat)

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -939,7 +939,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         ParamDeclList::iterator t;
         int count;
         string format;
-        std::optional<FormatType> opFormat = operation->format();
+        optional<FormatType> opFormat = operation->format();
         if (opFormat)
         {
             switch (*opFormat)

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -552,7 +552,7 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         ParamDeclList::iterator t;
         int count;
         string format;
-        std::optional<FormatType> opFormat = (*s)->format();
+        optional<FormatType> opFormat = (*s)->format();
         if (opFormat)
         {
             switch (*opFormat)

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -552,17 +552,24 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         ParamDeclList::iterator t;
         int count;
         string format;
-        switch ((*s)->format())
+        std::optional<FormatType> opFormat = (*s)->format();
+        if (opFormat)
         {
-            case DefaultFormat:
-                format = "nil";
-                break;
-            case CompactFormat:
-                format = "::Ice::FormatType::CompactFormat";
-                break;
-            case SlicedFormat:
-                format = "::Ice::FormatType::SlicedFormat";
-                break;
+            switch (*opFormat)
+            {
+                case CompactFormat:
+                    format = "::Ice::FormatType::CompactFormat";
+                    break;
+                case SlicedFormat:
+                    format = "::Ice::FormatType::SlicedFormat";
+                    break;
+                default:
+                    assert(false);
+            }
+        }
+        else
+        {
+            format = "nil";
         }
 
         _out << nl << name << "Prx_mixin::OP_" << (*s)->name() << " = ::Ice::__defineOperation('" << (*s)->name()

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -130,7 +130,7 @@ namespace
 
     string opFormatTypeToString(const OperationPtr& op)
     {
-        std::optional<FormatType> opFormat = op->format();
+        optional<FormatType> opFormat = op->format();
         if (opFormat)
         {
             switch (*opFormat)

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -130,7 +130,6 @@ namespace
 
     string opFormatTypeToString(const OperationPtr& op)
     {
-        // TODO: remove DefaultFormat.
         std::optional<FormatType> opFormat = op->format();
         if (opFormat)
         {
@@ -147,7 +146,7 @@ namespace
         }
         else
         {
-            return ".DefaultFormat";
+            return "nil";
         }
     }
 }
@@ -2609,7 +2608,7 @@ SwiftGenerator::writeDispatchOperation(::IceInternal::Output& out, const Operati
         }
         else
         {
-            out << nl << "return request.current.makeOutgoingResponse(result, formatType:" << opFormatTypeToString(op)
+            out << nl << "return request.current.makeOutgoingResponse(result, formatType: " << opFormatTypeToString(op)
                 << ")";
             out << sb;
             out << " ostr, value in ";

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -130,26 +130,25 @@ namespace
 
     string opFormatTypeToString(const OperationPtr& op)
     {
-        switch (op->format())
+        // TODO: remove DefaultFormat.
+        std::optional<FormatType> opFormat = op->format();
+        if (opFormat)
         {
-            case DefaultFormat:
+            switch (*opFormat)
             {
-                return ".DefaultFormat";
-            }
-            case CompactFormat:
-            {
-                return ".CompactFormat";
-            }
-            case SlicedFormat:
-            {
-                return ".SlicedFormat";
-            }
-            default:
-            {
-                assert(false);
+                case CompactFormat:
+                    return ".CompactFormat";
+                case SlicedFormat:
+                    return ".SlicedFormat";
+                default:
+                    assert(false);
+                    return "???";
             }
         }
-        return "???";
+        else
+        {
+            return ".DefaultFormat";
+        }
     }
 }
 
@@ -2435,7 +2434,7 @@ SwiftGenerator::writeProxyOperation(::IceInternal::Output& out, const OperationP
     out << "operation: \"" << op->name() << "\",";
     out << nl << "mode: " << modeToString(op->mode()) << ",";
 
-    if (op->format() != DefaultFormat)
+    if (op->format())
     {
         out << nl << "format: " << opFormatTypeToString(op);
         out << ",";
@@ -2522,7 +2521,7 @@ SwiftGenerator::writeProxyAsyncOperation(::IceInternal::Output& out, const Opera
     out << "operation: \"" << op->name() << "\",";
     out << nl << "mode: " << modeToString(op->mode()) << ",";
 
-    if (op->format() != DefaultFormat)
+    if (op->format())
     {
         out << nl << "format: " << opFormatTypeToString(op);
         out << ",";

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/FormatType.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/FormatType.java
@@ -6,8 +6,6 @@ package com.zeroc.Ice;
 
 /** This enumeration describes the possible formats for classes and exceptions. */
 public enum FormatType {
-  /** Indicates that no preference was specified. */
-  DefaultFormat,
   /** A minimal format that eliminates the possibility for slicing unrecognized types. */
   CompactFormat,
   /** Allow slicing and preserve slices for unknown types. */

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/Object.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/Object.java
@@ -124,7 +124,7 @@ public interface Object {
     boolean ret = obj.ice_isA(iceP_id, request.current);
     return CompletableFuture.completedFuture(
         request.current.createOutgoingResponse(
-            ret, (ostr, value) -> ostr.writeBool(value), FormatType.DefaultFormat));
+            ret, (ostr, value) -> ostr.writeBool(value), FormatType.CompactFormat));
   }
 
   /**
@@ -144,7 +144,7 @@ public interface Object {
     String[] ret = obj.ice_ids(request.current);
     return CompletableFuture.completedFuture(
         request.current.createOutgoingResponse(
-            ret, (ostr, value) -> ostr.writeStringSeq(value), FormatType.DefaultFormat));
+            ret, (ostr, value) -> ostr.writeStringSeq(value), FormatType.CompactFormat));
   }
 
   /**
@@ -155,7 +155,7 @@ public interface Object {
     String ret = obj.ice_id(request.current);
     return CompletableFuture.completedFuture(
         request.current.createOutgoingResponse(
-            ret, (ostr, value) -> ostr.writeString(value), FormatType.DefaultFormat));
+            ret, (ostr, value) -> ostr.writeString(value), FormatType.CompactFormat));
   }
 
   /**

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/OutputStream.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/OutputStream.java
@@ -323,7 +323,7 @@ public class OutputStream {
     if (_encapsStack != null) {
       startEncapsulation(_encapsStack.encoding, _encapsStack.format);
     } else {
-      startEncapsulation(_encoding, FormatType.DefaultFormat);
+      startEncapsulation(_encoding, null);
     }
   }
 
@@ -331,7 +331,7 @@ public class OutputStream {
    * Writes the start of an encapsulation to the stream.
    *
    * @param encoding The encoding version of the encapsulation.
-   * @param format Specify the compact or sliced format.
+   * @param format Specify the compact or sliced format, or null.
    */
   public void startEncapsulation(EncodingVersion encoding, FormatType format) {
     com.zeroc.IceInternal.Protocol.checkSupportedEncoding(encoding);
@@ -2036,7 +2036,7 @@ public class OutputStream {
     }
 
     int start;
-    FormatType format = FormatType.DefaultFormat;
+    FormatType format = null;
     EncodingVersion encoding;
     boolean encoding_1_0;
 
@@ -2072,7 +2072,7 @@ public class OutputStream {
       _encapsStack.setEncoding(_encoding);
     }
 
-    if (_encapsStack.format == FormatType.DefaultFormat) {
+    if (_encapsStack.format == null) {
       _encapsStack.format = _format;
     }
 

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/OpaqueEndpointI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/OpaqueEndpointI.java
@@ -36,7 +36,7 @@ final class OpaqueEndpointI extends EndpointI {
   //
   @Override
   public void streamWrite(com.zeroc.Ice.OutputStream s) {
-    s.startEncapsulation(_rawEncoding, com.zeroc.Ice.FormatType.DefaultFormat);
+    s.startEncapsulation(_rawEncoding, null);
     s.writeBlob(_rawBytes);
     s.endEncapsulation();
   }

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/OutgoingAsync.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/OutgoingAsync.java
@@ -55,10 +55,6 @@ public class OutgoingAsync<T> extends ProxyOutgoingAsyncBaseI<T> {
       throw new com.zeroc.Ice.TwowayOnlyException(_operation);
     }
 
-    if (format == null) {
-      format = FormatType.DefaultFormat;
-    }
-
     try {
       prepare(ctx);
 

--- a/java/test/src/main/java/test/Ice/objects/UnexpectedObjectExceptionTestI.java
+++ b/java/test/src/main/java/test/Ice/objects/UnexpectedObjectExceptionTestI.java
@@ -13,7 +13,7 @@ public final class UnexpectedObjectExceptionTestI implements com.zeroc.Ice.Blobj
     com.zeroc.Ice.Object.Ice_invokeResult r = new com.zeroc.Ice.Object.Ice_invokeResult();
     com.zeroc.Ice.Communicator communicator = current.adapter.getCommunicator();
     com.zeroc.Ice.OutputStream out = new com.zeroc.Ice.OutputStream(communicator);
-    out.startEncapsulation(current.encoding, com.zeroc.Ice.FormatType.DefaultFormat);
+    out.startEncapsulation(current.encoding, com.zeroc.Ice.FormatType.SlicedFormat);
     out.writeValue(new AlsoEmpty());
     out.writePendingValues();
     out.endEncapsulation();

--- a/js/src/Ice/CurrentExtensions.js
+++ b/js/src/Ice/CurrentExtensions.js
@@ -24,7 +24,7 @@ import { Protocol } from "./Protocol.js";
 import { Ice as Ice_BuiltinSequences } from "./BuiltinSequences.js";
 const { StringSeqHelper } = Ice_BuiltinSequences;
 
-Current.prototype.createOutgoingResponseWithResult = function (marshal, formatType = FormatType.DefaultFormat) {
+Current.prototype.createOutgoingResponseWithResult = function (marshal, formatType = null) {
     const ostr = startReplyStream(this);
     if (this.requestId != 0) {
         try {

--- a/js/src/Ice/FormatType.d.ts
+++ b/js/src/Ice/FormatType.d.ts
@@ -5,7 +5,6 @@
 declare module "ice" {
     namespace Ice {
         class FormatType {
-            static readonly DefaultFormat: FormatType;
             static readonly CompactFormat: FormatType;
             static readonly SlicedFormat: FormatType;
 

--- a/js/src/Ice/FormatType.js
+++ b/js/src/Ice/FormatType.js
@@ -5,7 +5,6 @@
 import { defineEnum } from "./EnumBase.js";
 
 export const FormatType = defineEnum([
-    ["DefaultFormat", 0],
-    ["CompactFormat", 1],
-    ["SlicedFormat", 2],
+    ["CompactFormat", 0],
+    ["SlicedFormat", 1],
 ]);

--- a/js/src/Ice/OpaqueEndpoint.js
+++ b/js/src/Ice/OpaqueEndpoint.js
@@ -24,7 +24,7 @@ export class OpaqueEndpointI extends EndpointI {
     // Marshal the endpoint
     //
     streamWrite(s) {
-        s.startEncapsulation(this._rawEncoding, FormatType.DefaultFormat);
+        s.startEncapsulation(this._rawEncoding, null);
         s.writeBlob(this._rawBytes);
         s.endEncapsulation();
     }

--- a/js/src/Ice/Operation.js
+++ b/js/src/Ice/Operation.js
@@ -77,7 +77,7 @@ function parseOperation(name, arr) {
     r.name = name;
     r.servantMethod = arr[0] ? arr[0] : name;
     r.mode = arr[1] ? OperationMode.valueOf(arr[1]) : OperationMode.Normal;
-    r.format = arr[2] ? FormatType.valueOf(arr[2]) : FormatType.DefaultFormat;
+    r.format = arr[2] ? FormatType.valueOf(arr[2]) : null;
 
     let ret;
     if (arr[3]) {

--- a/js/src/Ice/Stream.js
+++ b/js/src/Ice/Stream.js
@@ -2270,7 +2270,7 @@ EncapsEncoder11.InstanceData = class {
 class WriteEncaps {
     constructor() {
         this.start = 0;
-        this.format = FormatType.DefaultFormat;
+        this.format = null;
         this.encoding = null;
         this.encoding_1_0 = false;
         this.encoder = null;
@@ -2417,7 +2417,7 @@ export class OutputStream {
                 format = this._encapsStack.format;
             } else {
                 encoding = this._encoding;
-                format = FormatType.DefaultFormat;
+                format = null;
             }
         }
 
@@ -2709,7 +2709,7 @@ export class OutputStream {
             this._encapsStack.setEncoding(this._encoding);
         }
 
-        if (this._encapsStack.format === FormatType.DefaultFormat) {
+        if (this._encapsStack.format === null) {
             this._encapsStack.format = this._instance.defaultsAndOverrides().defaultFormat;
         }
 

--- a/matlab/lib/+Ice/FormatType.m
+++ b/matlab/lib/+Ice/FormatType.m
@@ -7,14 +7,11 @@ classdef FormatType < uint32
 
     % Don't use an enumeration as comparing enumerators with integral values is significantly slower.
     properties(Constant)
-        % DefaultFormat   Indicates that no preference was specified.
-        DefaultFormat = uint8(0)
-
         % CompactFormat   A minimal format that eliminates the possibility
         %   for slicing unrecognized types.
-        CompactFormat = uint8(1)
+        CompactFormat = uint8(0)
 
         % SlicedFormat   Allow slicing and preserve slices for unknown types.
-        SlicedFormat = uint8(2)
+        SlicedFormat = uint8(1)
     end
 end

--- a/matlab/lib/+Ice/OutputStream.m
+++ b/matlab/lib/+Ice/OutputStream.m
@@ -353,9 +353,6 @@ classdef OutputStream < handle
                 end
             else
                 encoding = obj.encoding;
-                if isempty(format)
-                    format = Ice.FormatType.DefaultFormat;
-                end
             end
 
             curr = obj.encapsCache;
@@ -502,7 +499,7 @@ classdef OutputStream < handle
                 obj.encapsStack.encoding = obj.encoding;
             end
 
-            if obj.encapsStack.format == Ice.FormatType.DefaultFormat
+            if isempty(obj.encapsStack.format)
                 obj.encapsStack.format = obj.format;
             end
 

--- a/matlab/lib/+IceInternal/WriteEncaps.m
+++ b/matlab/lib/+IceInternal/WriteEncaps.m
@@ -5,7 +5,7 @@
 classdef WriteEncaps < handle
     properties
         start
-        format = Ice.FormatType.DefaultFormat
+        format
         encoding
         encoder
         next

--- a/php/src/Operation.cpp
+++ b/php/src/Operation.cpp
@@ -726,11 +726,11 @@ ZEND_FUNCTION(IcePHP_defineOperation)
     TypeInfoPtr type = Wrapper<TypeInfoPtr>::value(cls);
     auto c = dynamic_pointer_cast<ProxyInfo>(type);
     assert(c);
-    // format is a Slice metadata format, where 0 = default, 1 = compact, 2 = sliced
+    // we encode nullopt as -1.
     std::optional<Ice::FormatType> cppFormat;
-    if (format != 0)
+    if (format != -1)
     {
-        cppFormat = static_cast<Ice::FormatType>(format - 1);
+        cppFormat = static_cast<Ice::FormatType>(format);
     }
 
     auto op = make_shared<OperationI>(

--- a/swift/src/Ice/CurrentExtensions.swift
+++ b/swift/src/Ice/CurrentExtensions.swift
@@ -9,7 +9,7 @@ extension Current {
     ///   - formatType: The class format.
     ///   - marshal: The action that marshals result into an output stream.
     /// - Returns: The outgoing response.
-    public func makeOutgoingResponse<T>(_ result: T, formatType: FormatType, marshal: (OutputStream, T) -> Void)
+    public func makeOutgoingResponse<T>(_ result: T, formatType: FormatType?, marshal: (OutputStream, T) -> Void)
         -> OutgoingResponse
     {
         precondition(requestId != 0, "A one-way request cannot return a response")

--- a/swift/src/Ice/FormatType.swift
+++ b/swift/src/Ice/FormatType.swift
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 /// This enumeration describes the possible formats for classes and exceptions.
 public enum FormatType: UInt8 {
-    case DefaultFormat = 0
-    case CompactFormat = 1
-    case SlicedFormat = 2
+    case CompactFormat = 0
+    case SlicedFormat = 1
 }

--- a/swift/src/Ice/Object.swift
+++ b/swift/src/Ice/Object.swift
@@ -47,7 +47,7 @@ extension Object {
     public func _iceD_ice_id(_ request: IncomingRequest) throws -> OutgoingResponse {
         _ = try request.inputStream.skipEmptyEncapsulation()
         let returnValue = try ice_id(current: request.current)
-        return request.current.makeOutgoingResponse(returnValue, formatType: .DefaultFormat) { ostr, value in
+        return request.current.makeOutgoingResponse(returnValue, formatType: .CompactFormat) { ostr, value in
             ostr.write(value)
         }
     }
@@ -55,7 +55,7 @@ extension Object {
     public func _iceD_ice_ids(_ request: IncomingRequest) throws -> OutgoingResponse {
         _ = try request.inputStream.skipEmptyEncapsulation()
         let returnValue = try ice_ids(current: request.current)
-        return request.current.makeOutgoingResponse(returnValue, formatType: .DefaultFormat) { ostr, value in
+        return request.current.makeOutgoingResponse(returnValue, formatType: .CompactFormat) { ostr, value in
             ostr.write(value)
         }
     }
@@ -65,7 +65,7 @@ extension Object {
         _ = try istr.startEncapsulation()
         let identity: String = try istr.read()
         let returnValue = try ice_isA(id: identity, current: request.current)
-        return request.current.makeOutgoingResponse(returnValue, formatType: .DefaultFormat) { ostr, value in
+        return request.current.makeOutgoingResponse(returnValue, formatType: .CompactFormat) { ostr, value in
             ostr.write(value)
         }
     }

--- a/swift/src/Ice/OutputStream.swift
+++ b/swift/src/Ice/OutputStream.swift
@@ -30,7 +30,7 @@ public class OutputStream {
 
     /// Writes the start of an encapsulation to the stream.
     public func startEncapsulation() {
-        startEncapsulation(encoding: encoding, format: FormatType.DefaultFormat)
+        startEncapsulation(encoding: encoding, format: nil)
     }
 
     /// Writes the start of an encapsulation to the stream.
@@ -38,7 +38,7 @@ public class OutputStream {
     /// - parameter encoding: `Ice.EncodingVersion` - The encoding version of the encapsulation.
     ///
     /// - parameter format: `Ice.FormatType` - Specify the compact or sliced format.
-    public func startEncapsulation(encoding: EncodingVersion, format: FormatType) {
+    public func startEncapsulation(encoding: EncodingVersion, format: FormatType?) {
         precondition(encaps == nil, "Nested or sequential encapsulations are not supported")
         encaps = Encaps(encoding: encoding, format: format, start: data.count)
         write(Int32(0))  // Placeholder for the encapsulation length.
@@ -112,7 +112,7 @@ public class OutputStream {
     private func initEncaps() {
         if encaps == nil {
             encaps = Encaps(encoding: encoding, format: format, start: 0)
-        } else if encaps.format == .DefaultFormat {
+        } else if encaps.format == nil {
             encaps.format = format
         }
 
@@ -569,13 +569,13 @@ extension OutputStream: ICEOutputStreamHelper {
 
 private class Encaps {
     let start: Int
-    var format: FormatType
+    var format: FormatType?
     let encoding: EncodingVersion
     let encoding_1_0: Bool
 
     var encoder: EncapsEncoder!
 
-    init(encoding: EncodingVersion, format: FormatType, start: Int) {
+    init(encoding: EncodingVersion, format: FormatType?, start: Int) {
         self.start = start
         self.format = format
         self.encoding = encoding

--- a/swift/src/Ice/Proxy.swift
+++ b/swift/src/Ice/Proxy.swift
@@ -1148,7 +1148,7 @@ open class ObjectPrxI: ObjectPrx {
     public func _invoke(
         operation: String,
         mode: OperationMode,
-        format: FormatType = FormatType.DefaultFormat,
+        format: FormatType? = nil,
         write: ((OutputStream) -> Void)? = nil,
         userException: ((UserException) throws -> Void)? = nil,
         context: Context? = nil
@@ -1207,7 +1207,7 @@ open class ObjectPrxI: ObjectPrx {
     public func _invoke<T>(
         operation: String,
         mode: OperationMode,
-        format: FormatType = FormatType.DefaultFormat,
+        format: FormatType? = nil,
         write: ((OutputStream) -> Void)? = nil,
         read: @escaping (InputStream) throws -> T,
         userException: ((UserException) throws -> Void)? = nil,
@@ -1263,7 +1263,7 @@ open class ObjectPrxI: ObjectPrx {
     public func _invokeAsync(
         operation: String,
         mode: OperationMode,
-        format: FormatType = FormatType.DefaultFormat,
+        format: FormatType? = nil,
         write: ((OutputStream) -> Void)? = nil,
         userException: ((UserException) throws -> Void)? = nil,
         context: Context? = nil,
@@ -1358,7 +1358,7 @@ open class ObjectPrxI: ObjectPrx {
     public func _invokeAsync<T>(
         operation: String,
         mode: OperationMode,
-        format: FormatType = FormatType.DefaultFormat,
+        format: FormatType? = nil,
         write: ((OutputStream) -> Void)? = nil,
         read: @escaping (InputStream) throws -> T,
         userException: ((UserException) throws -> Void)? = nil,

--- a/swift/src/IceImpl/Communicator.mm
+++ b/swift/src/IceImpl/Communicator.mm
@@ -383,10 +383,8 @@
 
 - (std::uint8_t)getDefaultFormat
 {
-    // TODO: sychronize Swift and C++ FormatType.
     return static_cast<std::uint8_t>(
-               IceInternal::getInstance(self.communicator)->defaultsAndOverrides()->defaultFormat) +
-           1;
+        IceInternal::getInstance(self.communicator)->defaultsAndOverrides()->defaultFormat);
 }
 
 - (id<ICEDispatchAdapter>)facetToDispatchAdapter:(const Ice::ObjectPtr&)servant

--- a/swift/test/Ice/objects/TestI.swift
+++ b/swift/test/Ice/objects/TestI.swift
@@ -254,7 +254,7 @@ class UnexpectedObjectExceptionTestI: Ice.Blobject {
     func ice_invoke(inEncaps _: Data, current: Ice.Current) throws -> (ok: Bool, outParams: Data) {
         let communicator = current.adapter.getCommunicator()
         let ostr = Ice.OutputStream(communicator: communicator)
-        ostr.startEncapsulation(encoding: current.encoding, format: .DefaultFormat)
+        ostr.startEncapsulation(encoding: current.encoding, format: nil)
         let ae = AlsoEmpty()
         ostr.write(ae)
         ostr.writePendingValues()


### PR DESCRIPTION
This PR replaces FormatType::DefaultFormat by nullopt/null/nil in all remaining languages.