### PR TITLE
Rework the constructors of OutputStream in C++

### DIFF
--- a/cpp/include/Ice/OutputStream.h
+++ b/cpp/include/Ice/OutputStream.h
@@ -38,40 +38,48 @@ namespace Ice
         typedef size_t size_type;
 
         /**
-         * Constructs an OutputStream using the latest encoding version, the compact format for
-         * class encoding, and the process string converters.
+         * Constructs an OutputStream.
+         * @param encoding The encoding version to use.
+         * @param format The class format to use.
+         * @param stringConverter The narrow string converter to use.
+         * @param wstringConverter The wide string converter to use.
          */
-        OutputStream();
+        OutputStream(
+            EncodingVersion encoding = currentEncoding,
+            FormatType format = FormatType::CompactFormat,
+            StringConverterPtr stringConverter = nullptr,
+            WstringConverterPtr wstringConverter = nullptr);
 
         /**
-         * Constructs a stream using the communicator's default encoding version.
-         * @param communicator The communicator to use for marshaling tasks.
+         * Constructs an OutputStream using the format, string converter and wstring converter provided by the
+         * communicator, and the specified encoding.
+         * @param communicator The communicator.
+         * @param encoding The encoding version to use.
+         */
+        OutputStream(const CommunicatorPtr& communicator, EncodingVersion encoding);
+
+        /**
+         * Constructs an OutputStream using the encoding, format, string converter and wstring converter provided by
+         * the communicator.
+         * @param communicator The communicator.
          */
         OutputStream(const CommunicatorPtr& communicator);
 
         /**
-         * Constructs a stream using the given communicator and encoding version.
-         * @param communicator The communicator to use for marshaling tasks.
-         * @param version The encoding version used to encode the data.
-         */
-        OutputStream(const CommunicatorPtr& communicator, const EncodingVersion& version);
-
-        /**
-         * Constructs a stream using the given communicator and encoding version.
-         * @param communicator The communicator to use for marshaling tasks.
-         * @param version The encoding version used to encode the data.
-         * @param bytes Application-supplied memory that the stream uses as its initial marshaling buffer. The
+         * Constructs an OutputStream over an application-supplied buffer.
+         * @param bytes Application-supplied memory that the OutputStream uses as its initial marshaling buffer. The
          * stream will reallocate if the size of the marshaled data exceeds the application's buffer.
+         * @param encoding The encoding version to use.
+         * @param format The class format to use.
+         * @param stringConverter The narrow string converter to use.
+         * @param wstringConverter The wide string converter to use.
          */
-        OutputStream(
-            const CommunicatorPtr& communicator,
-            const EncodingVersion& version,
-            std::pair<const std::byte*, const std::byte*> bytes);
-
         OutputStream(
             std::pair<const std::byte*, const std::byte*> bytes,
-            const EncodingVersion& version = currentEncoding,
-            FormatType format = FormatType::CompactFormat);
+            EncodingVersion encoding = currentEncoding,
+            FormatType format = FormatType::CompactFormat,
+            StringConverterPtr stringConverter = nullptr,
+            WstringConverterPtr wstringConverter = nullptr);
 
         /**
          * Move constructor.
@@ -94,23 +102,6 @@ namespace Ice
                 clear(); // Not inlined.
             }
         }
-
-        /**
-         * Initializes the stream to use the communicator's default encoding version, class
-         * encoding format and string converters. Use this method if you originally constructed
-         * the stream without a communicator.
-         * @param communicator The communicator to use for marshaling tasks.
-         */
-        void initialize(const CommunicatorPtr& communicator);
-
-        /**
-         * Initializes the stream to use the given encoding version and the communicator's
-         * default class encoding format and string converters. Use this method if you
-         * originally constructed the stream without a communicator.
-         * @param communicator The communicator to use for marshaling tasks.
-         * @param version The encoding version used to encode the data.
-         */
-        void initialize(const CommunicatorPtr& communicator, const EncodingVersion& version);
 
         /**
          * Releases any data retained by encapsulations.
@@ -785,14 +776,13 @@ namespace Ice
         std::pair<const std::byte*, const std::byte*> finished();
 
         /// \cond INTERNAL
-        OutputStream(IceInternal::Instance*, const EncodingVersion&);
-        void initialize(IceInternal::Instance*, const EncodingVersion&);
-
-        // Optionals
-        bool writeOptImpl(std::int32_t, OptionalFormat);
+        OutputStream(IceInternal::Instance*, EncodingVersion encoding);
         /// \endcond
 
     private:
+        // Optionals
+        bool writeOptImpl(std::int32_t, OptionalFormat);
+
         //
         // String
         //

--- a/cpp/include/Ice/OutputStream.h
+++ b/cpp/include/Ice/OutputStream.h
@@ -10,6 +10,7 @@
 #include "Ice/Format.h"
 #include "Ice/StringConverter.h"
 #include "Ice/Version.h"
+#include "Ice/VersionFunctions.h"
 #include "InstanceF.h"
 #include "SlicedDataF.h"
 #include "StreamableTraits.h"
@@ -66,6 +67,11 @@ namespace Ice
             const CommunicatorPtr& communicator,
             const EncodingVersion& version,
             std::pair<const std::byte*, const std::byte*> bytes);
+
+        OutputStream(
+            std::pair<const std::byte*, const std::byte*> bytes,
+            const EncodingVersion& version = currentEncoding,
+            FormatType format = FormatType::CompactFormat);
 
         /**
          * Move constructor.

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -1800,7 +1800,6 @@ Ice::ConnectionI::ConnectionI(
       _batchRequestQueue(new BatchRequestQueue(instance, endpoint->datagram())),
       _readStream(_instance.get(), Ice::currentProtocolEncoding),
       _readHeader(false),
-      _writeStream(_instance.get(), Ice::currentProtocolEncoding),
       _upcallCount(0),
       _state(StateNotInitialized),
       _shutdownInitiated(false),
@@ -2167,7 +2166,7 @@ Ice::ConnectionI::initiateShutdown()
         //
         // Before we shut down, we send a close connection message.
         //
-        OutputStream os(_instance.get(), Ice::currentProtocolEncoding);
+        OutputStream os{Ice::currentProtocolEncoding};
         os.write(magic[0]);
         os.write(magic[1]);
         os.write(magic[2]);
@@ -2328,7 +2327,7 @@ Ice::ConnectionI::sendHeartbeat() noexcept
         // _sendStreams message.
         if (_sendStreams.empty())
         {
-            OutputStream os(_instance.get(), Ice::currentProtocolEncoding);
+            OutputStream os{Ice::currentProtocolEncoding};
             os.write(magic[0]);
             os.write(magic[1]);
             os.write(magic[2]);
@@ -2662,7 +2661,7 @@ Ice::ConnectionI::sendNextMessages(vector<OutgoingMessage>& callbacks)
                 //
                 // Do compression.
                 //
-                OutputStream stream(_instance.get(), Ice::currentProtocolEncoding);
+                OutputStream stream{currentProtocolEncoding};
                 doCompress(*message->stream, stream);
 
                 traceSend(*message->stream, _instance, _logger, _traceLevels);
@@ -2778,7 +2777,7 @@ Ice::ConnectionI::sendMessage(OutgoingMessage& message)
         //
         // Do compression.
         //
-        OutputStream stream(_instance.get(), Ice::currentProtocolEncoding);
+        OutputStream stream{currentProtocolEncoding};
         doCompress(*message.stream, stream);
         stream.i = stream.b.begin();
 

--- a/cpp/src/Ice/EndpointFactoryManager.cpp
+++ b/cpp/src/Ice/EndpointFactoryManager.cpp
@@ -138,7 +138,7 @@ IceInternal::EndpointFactoryManager::create(const string& str, bool oaEndpoint) 
             // and ask the factory to read the endpoint data from that stream to create
             // the actual endpoint.
             //
-            OutputStream bs(_instance.get(), Ice::currentProtocolEncoding);
+            OutputStream bs;
             bs.write(ue->type());
             ue->streamWrite(&bs);
             InputStream is(_instance.get(), bs.getEncoding(), bs);

--- a/cpp/src/Ice/MarshaledResult.cpp
+++ b/cpp/src/Ice/MarshaledResult.cpp
@@ -12,7 +12,7 @@ using namespace IceInternal;
 
 // currentProtocolEncoding because we're writing the protocol header.
 MarshaledResult::MarshaledResult(const Current& current)
-    : _ostr(current.adapter->getCommunicator(), Ice::currentProtocolEncoding)
+    : _ostr(current.adapter->getCommunicator(), currentProtocolEncoding)
 {
     _ostr.writeBlob(replyHdr, sizeof(replyHdr));
     _ostr.write(current.requestId);

--- a/cpp/src/Ice/OutgoingResponse.cpp
+++ b/cpp/src/Ice/OutgoingResponse.cpp
@@ -55,7 +55,7 @@ namespace
     OutgoingResponse makeOutgoingResponseCore(std::exception_ptr exc, const Current& current)
     {
         assert(exc);
-        OutputStream ostr(current.adapter->getCommunicator(), Ice::currentProtocolEncoding);
+        OutputStream ostr{current.adapter->getCommunicator(), Ice::currentProtocolEncoding};
 
         if (current.requestId != 0)
         {
@@ -238,7 +238,7 @@ Ice::makeOutgoingResponse(
     std::optional<FormatType> format) noexcept
 {
     assert(marshal);
-    OutputStream ostr(current.adapter->getCommunicator(), Ice::currentProtocolEncoding);
+    OutputStream ostr{current.adapter->getCommunicator(), Ice::currentProtocolEncoding};
     if (current.requestId != 0)
     {
         try
@@ -288,7 +288,7 @@ Ice::makeEmptyOutgoingResponse(const Current& current) noexcept
 OutgoingResponse
 Ice::makeOutgoingResponse(bool ok, pair<const byte*, const byte*> encapsulation, const Current& current) noexcept
 {
-    OutputStream ostr(current.adapter->getCommunicator(), Ice::currentProtocolEncoding);
+    OutputStream ostr{current.adapter->getCommunicator(), Ice::currentProtocolEncoding};
     if (current.requestId != 0)
     {
         try

--- a/cpp/src/Ice/OutputStream.cpp
+++ b/cpp/src/Ice/OutputStream.cpp
@@ -91,6 +91,16 @@ Ice::OutputStream::OutputStream(
     b.reset();
 }
 
+Ice::OutputStream::OutputStream(pair<const byte*, const byte*> buf, const EncodingVersion& encoding, FormatType format)
+    : Buffer(buf.first, buf.second),
+      _closure(nullptr),
+      _currentEncaps(nullptr)
+{
+    _encoding = encoding;
+    _format = format;
+    b.reset();
+}
+
 Ice::OutputStream::OutputStream(Instance* instance, const EncodingVersion& encoding) : _closure(0), _currentEncaps(0)
 {
     initialize(instance, encoding);

--- a/cpp/src/IceDB/IceDB.h
+++ b/cpp/src/IceDB/IceDB.h
@@ -404,9 +404,10 @@ namespace IceDB
             in.read(t);
         }
 
-        static void write(const T& t, MDB_val& val, Ice::OutputStream& holder, const IceContext& ctx)
+        static void write(const T& t, MDB_val& val, Ice::OutputStream& holder, const IceContext&)
         {
-            holder.initialize(ctx.communicator, ctx.encoding);
+            // Since we use an OutputStream constructed with the default constructor, the encoding is 1.1 and
+            // the class format is Compact.
             holder.write(t);
             val.mv_size = holder.b.size();
             val.mv_data = &holder.b[0];

--- a/cpp/src/IceGrid/Database.cpp
+++ b/cpp/src/IceGrid/Database.cpp
@@ -221,10 +221,7 @@ Database::Database(
 {
     IceDB::ReadWriteTxn txn(_env);
 
-    IceDB::IceContext context;
-    context.communicator = _communicator;
-    context.encoding.major = 1;
-    context.encoding.minor = 1;
+    IceDB::IceContext context{_communicator};
 
     _applications = StringApplicationInfoMap(txn, applicationsDbName, context, MDB_CREATE);
 

--- a/cpp/src/IceStorm/IceStormDB.cpp
+++ b/cpp/src/IceStorm/IceStormDB.cpp
@@ -133,7 +133,7 @@ run(const shared_ptr<Ice::Communicator>& communicator, const Ice::StringSeq& arg
     {
         IceStorm::AllData data;
 
-        IceDB::IceContext dbContext = {communicator, {1, 1}};
+        IceDB::IceContext dbContext = {communicator};
 
         if (import)
         {
@@ -179,7 +179,7 @@ run(const shared_ptr<Ice::Communicator>& communicator, const Ice::StringSeq& arg
             string type;
             int version;
 
-            Ice::InputStream stream(communicator, dbContext.encoding, buf);
+            Ice::InputStream stream(communicator, Ice::currentEncoding, buf);
             stream.read(type);
             if (type != "IceStorm")
             {
@@ -302,7 +302,7 @@ run(const shared_ptr<Ice::Communicator>& communicator, const Ice::StringSeq& arg
                 env.close();
             }
 
-            Ice::OutputStream stream(communicator, dbContext.encoding);
+            Ice::OutputStream stream(communicator, Ice::currentEncoding);
             stream.write("IceStorm");
             stream.write(ICE_INT_VERSION);
             stream.write(data);

--- a/cpp/src/IceStorm/IceStormDB.cpp
+++ b/cpp/src/IceStorm/IceStormDB.cpp
@@ -302,7 +302,7 @@ run(const shared_ptr<Ice::Communicator>& communicator, const Ice::StringSeq& arg
                 env.close();
             }
 
-            Ice::OutputStream stream(communicator, Ice::currentEncoding);
+            Ice::OutputStream stream{Ice::currentEncoding};
             stream.write("IceStorm");
             stream.write(ICE_INT_VERSION);
             stream.write(data);

--- a/cpp/src/IceStorm/Instance.cpp
+++ b/cpp/src/IceStorm/Instance.cpp
@@ -312,8 +312,6 @@ PersistentInstance::PersistentInstance(
     try
     {
         dbContext.communicator = std::move(communicator);
-        dbContext.encoding.minor = 1;
-        dbContext.encoding.major = 1;
 
         IceDB::ReadWriteTxn txn(_dbEnv);
 

--- a/cpp/src/icegriddb/IceGridDB.cpp
+++ b/cpp/src/icegriddb/IceGridDB.cpp
@@ -493,7 +493,7 @@ run(const Ice::StringSeq& args)
                 env.close();
             }
 
-            Ice::OutputStream stream(communicator, Ice::currentEncoding);
+            Ice::OutputStream stream{Ice::currentEncoding};
             stream.write("IceGrid");
             stream.write(ICE_INT_VERSION);
             stream.write(data);

--- a/cpp/src/icegriddb/IceGridDB.cpp
+++ b/cpp/src/icegriddb/IceGridDB.cpp
@@ -176,10 +176,7 @@ run(const Ice::StringSeq& args)
     {
         IceGrid::AllData data;
 
-        IceDB::IceContext dbContext;
-        dbContext.communicator = communicator;
-        dbContext.encoding.major = 1;
-        dbContext.encoding.minor = 1;
+        IceDB::IceContext dbContext{communicator};
 
         if (import)
         {
@@ -233,7 +230,7 @@ run(const Ice::StringSeq& args)
                     IceGrid::IceBoxDescriptor::ice_staticId());
             }
 
-            Ice::InputStream stream(communicator, dbContext.encoding, buf);
+            Ice::InputStream stream(communicator, Ice::currentEncoding, buf);
 
             string type;
             int version;
@@ -496,7 +493,7 @@ run(const Ice::StringSeq& args)
                 env.close();
             }
 
-            Ice::OutputStream stream(communicator, dbContext.encoding);
+            Ice::OutputStream stream(communicator, Ice::currentEncoding);
             stream.write("IceGrid");
             stream.write(ICE_INT_VERSION);
             stream.write(data);

--- a/cpp/test/Ice/stream/Client.cpp
+++ b/cpp/test/Ice/stream/Client.cpp
@@ -1053,7 +1053,7 @@ allTests(Test::TestHelper* helper)
     {
         byte buf[128];
         pair<byte*, byte*> p(&buf[0], &buf[0] + sizeof(buf));
-        Ice::OutputStream out(communicator, Ice::currentEncoding, p);
+        Ice::OutputStream out(p);
         vector<byte> v;
         v.resize(127);
         out.write(v);
@@ -1063,7 +1063,7 @@ allTests(Test::TestHelper* helper)
     {
         byte buf[128];
         pair<byte*, byte*> p(&buf[0], &buf[0] + sizeof(buf));
-        Ice::OutputStream out(communicator, Ice::currentEncoding, p);
+        Ice::OutputStream out(p);
         vector<byte> v;
         v.resize(127);
         ::memset(&v[0], 0xFF, v.size());


### PR DESCRIPTION
This PR reduces the number of OutputStream constructor to 5 (including the move constructor) + one "internal" constructor.

It also simplifies IceDB a little bit. All encoding with IceDB is now 1.1.