### PR TITLE
Remove support for select in Networking code, ICE_USE_SELECT

### DIFF
--- a/cpp/src/Ice/Network.h
+++ b/cpp/src/Ice/Network.h
@@ -39,17 +39,12 @@ typedef int ssize_t;
 
 #if defined(__linux__) && !defined(ICE_NO_EPOLL)
 #    define ICE_USE_EPOLL 1
-#elif (defined(__APPLE__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)) && TARGET_OS_IPHONE == 0 &&          \
-    !defined(ICE_NO_KQUEUE)
+#elif (defined(__APPLE__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)) && TARGET_OS_IPHONE == 0
 #    define ICE_USE_KQUEUE 1
-#elif defined(__APPLE__) && !defined(ICE_NO_CFSTREAM)
+#elif defined(__APPLE__)
 #    define ICE_USE_CFSTREAM 1
 #elif defined(_WIN32)
-#    if !defined(ICE_NO_IOCP)
-#        define ICE_USE_IOCP 1
-#    else
-#        define ICE_USE_SELECT 1
-#    endif
+#    define ICE_USE_IOCP 1
 #else
 #    define ICE_USE_POLL 1
 #endif

--- a/cpp/src/Ice/Selector.h
+++ b/cpp/src/Ice/Selector.h
@@ -74,7 +74,7 @@ namespace IceInternal
         HANDLE _handle;
     };
 
-#elif defined(ICE_USE_KQUEUE) || defined(ICE_USE_EPOLL) || defined(ICE_USE_SELECT) || defined(ICE_USE_POLL)
+#elif defined(ICE_USE_KQUEUE) || defined(ICE_USE_EPOLL) || defined(ICE_USE_POLL)
 
     class Selector final
     {
@@ -121,27 +121,6 @@ namespace IceInternal
         std::vector<struct kevent> _events;
         std::vector<struct kevent> _changes;
         int _queueFd;
-#    elif defined(ICE_USE_SELECT)
-        std::vector<std::pair<EventHandler*, SocketOperation>> _changes;
-        std::map<SOCKET, EventHandler*> _handlers;
-
-        fd_set _readFdSet;
-        fd_set _writeFdSet;
-        fd_set _errorFdSet;
-        fd_set _selectedReadFdSet;
-        fd_set _selectedWriteFdSet;
-        fd_set _selectedErrorFdSet;
-
-        fd_set* fdSetCopy(fd_set& dest, fd_set& src)
-        {
-            if (src.fd_count > 0)
-            {
-                dest.fd_count = src.fd_count;
-                memcpy(dest.fd_array, src.fd_array, sizeof(SOCKET) * src.fd_count);
-                return &dest;
-            }
-            return 0;
-        }
 #    elif defined(ICE_USE_POLL)
         std::vector<std::pair<EventHandler*, SocketOperation>> _changes;
         std::map<SOCKET, EventHandler*> _handlers;


### PR DESCRIPTION
This PR removes support for building Ice with ICE_USE_SELECT. This code is never used with our builds.

See also #1595