### PR TITLE
Use C locale for string representation of proxies and endpoints

### DIFF
--- a/cpp/src/Ice/IPEndpointI.cpp
+++ b/cpp/src/Ice/IPEndpointI.cpp
@@ -212,6 +212,7 @@ IceInternal::IPEndpointI::options() const
     // format of proxyToString() before changing this and related code.
     //
     ostringstream s;
+    s.imbue(locale::classic()); // Ensure we use the C locale for the number formatting.
 
     if (!_host.empty())
     {

--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -1094,11 +1094,13 @@ IceInternal::RoutableReference::toProperty(const string& prefix) const
         _endpointSelection == EndpointSelectionType::Random ? "Random" : "Ordered";
     {
         ostringstream s;
+        s.imbue(locale::classic()); // Ensure we use the C locale for the number formatting.
         s << _locatorCacheTimeout;
         properties[prefix + ".LocatorCacheTimeout"] = s.str();
     }
     {
         ostringstream s;
+        s.imbue(locale::classic()); // Ensure we use the C locale for the number formatting.
         s << getInvocationTimeout();
         properties[prefix + ".InvocationTimeout"] = s.str();
     }

--- a/cpp/src/Ice/TcpEndpointI.cpp
+++ b/cpp/src/Ice/TcpEndpointI.cpp
@@ -163,6 +163,7 @@ IceInternal::TcpEndpointI::options() const
     // format of proxyToString() before changing this and related code.
     //
     ostringstream s;
+    s.imbue(locale::classic()); // Ensure we use the C locale for the number formatting.
 
     s << IPEndpointI::options();
 

--- a/cpp/src/Ice/UdpEndpointI.cpp
+++ b/cpp/src/Ice/UdpEndpointI.cpp
@@ -222,6 +222,7 @@ IceInternal::UdpEndpointI::options() const
     // format of proxyToString() before changing this and related code.
     //
     ostringstream s;
+    s.imbue(locale::classic()); // Ensure we use the C locale for the number formatting.
     s << IPEndpointI::options();
 
     if (_mcastInterface.length() > 0)

--- a/cpp/src/Ice/WSEndpoint.cpp
+++ b/cpp/src/Ice/WSEndpoint.cpp
@@ -219,6 +219,7 @@ IceInternal::WSEndpoint::connectorsAsync(
     if (info)
     {
         ostringstream os;
+        os.imbue(locale::classic()); // Ensure we use the C locale for the number formatting.
         os << info->host << ":" << info->port;
         host = os.str();
     }
@@ -333,6 +334,7 @@ IceInternal::WSEndpoint::options() const
     // format of proxyToString() before changing this and related code.
     //
     ostringstream s;
+    s.imbue(locale::classic()); // Ensure we use the C locale for the number formatting.
     s << _delegate->options();
 
     if (!_resource.empty())

--- a/cpp/src/IceBT/EndpointI.cpp
+++ b/cpp/src/IceBT/EndpointI.cpp
@@ -378,7 +378,7 @@ IceBT::EndpointI::options() const
     // format of proxyToString() before changing this and related code.
     //
     ostringstream s;
-
+    s.imbue(locale::classic()); // Ensure we use the C locale for the number formatting.
     if (!_addr.empty())
     {
         s << " -a ";

--- a/cpp/src/IceIAP/EndpointI.mm
+++ b/cpp/src/IceIAP/EndpointI.mm
@@ -480,6 +480,7 @@ IceObjC::iAPEndpointI::options() const
     // format of proxyToString() before changing this and related code.
     //
     ostringstream s;
+    s.imbue(locale::classic()); // Ensure we use the C locale for the number formatting.
     if (!_manufacturer.empty())
     {
         s << " -m ";


### PR DESCRIPTION
Fix #197