### PR TITLE
Consolidate flushBatchRequests and ice_getConnection to be async only

### DIFF
--- a/swift/src/Ice/Communicator.swift
+++ b/swift/src/Ice/Communicator.swift
@@ -166,15 +166,7 @@ public protocol Communicator: AnyObject {
     ///
     /// - parameter _: `CompressBatch` Specifies whether or not the queued batch requests should be compressed before
     /// being sent over the wire.
-    func flushBatchRequests(_ compress: CompressBatch) throws
-
-    /// Flush any pending batch requests for this communicator. This means all batch requests invoked on fixed proxies
-    /// for all connections associated with the communicator. Any errors that occur while flushing a connection are
-    /// ignored.
-    ///
-    /// - parameter _: `CompressBatch` Specifies whether or not the queued batch requests should be compressed before
-    /// being sent over the wire.
-    func flushBatchRequestsAsync(
+    func flushBatchRequests(
         _ compress: CompressBatch
     ) async throws
 

--- a/swift/src/Ice/Connection.swift
+++ b/swift/src/Ice/Connection.swift
@@ -191,14 +191,7 @@ public protocol Connection: AnyObject, CustomStringConvertible {
     ///
     /// - parameter _: `CompressBatch` Specifies whether or not the queued batch requests should be compressed before
     /// being sent over the wire.
-    func flushBatchRequests(_ compress: CompressBatch) throws
-
-    /// Flush any pending batch requests for this connection. This means all batch requests invoked on fixed proxies
-    /// associated with the connection.
-    ///
-    /// - parameter _: `CompressBatch` Specifies whether or not the queued batch requests should be compressed before
-    /// being sent over the wire.
-    func flushBatchRequestsAsync(
+    func flushBatchRequests(
         _ compress: CompressBatch
     ) async throws
 

--- a/swift/src/Ice/ConnectionI.swift
+++ b/swift/src/Ice/ConnectionI.swift
@@ -3,20 +3,6 @@
 import IceImpl
 
 extension Connection {
-    public func flushBatchRequestsAsync(
-        _ compress: CompressBatch
-    ) async throws {
-        let impl = self as! ConnectionI
-        return try await withCheckedThrowingContinuation { continuation in
-            impl.handle.flushBatchRequestsAsync(
-                compress.rawValue,
-                exception: { error in continuation.resume(throwing: error) },
-                sent: { _ in
-                    continuation.resume(returning: ())
-                })
-        }
-    }
-
     // CustomStringConvertible implementation
     public var description: String {
         return toString()
@@ -58,9 +44,16 @@ class ConnectionI: LocalObject<ICEConnection>, Connection {
         }
     }
 
-    func flushBatchRequests(_ compress: CompressBatch) throws {
-        return try autoreleasepool {
-            try handle.flushBatchRequests(compress.rawValue)
+    func flushBatchRequests(
+        _ compress: CompressBatch
+    ) async throws {
+        return try await withCheckedThrowingContinuation { continuation in
+            handle.flushBatchRequests(
+                compress.rawValue,
+                exception: { error in continuation.resume(throwing: error) },
+                sent: { _ in
+                    continuation.resume(returning: ())
+                })
         }
     }
 

--- a/swift/src/Ice/Proxy.swift
+++ b/swift/src/Ice/Proxy.swift
@@ -612,26 +612,10 @@ extension ObjectPrx {
     /// Returns the connection for this proxy. If the proxy does not yet have an established connection,
     /// it first attempts to create a connection.
     ///
-    /// - returns: `Ice.Connection?` - The Connection for this proxy.
-    public func ice_getConnection() throws -> Connection? {
-        return try autoreleasepool {
-            //
-            // Returns Any which is either NSNull or ICEConnection
-            //
-            guard let handle = try _impl.handle.ice_getConnection() as? ICEConnection else {
-                return nil
-            }
-            return handle.getSwiftObject(ConnectionI.self) { ConnectionI(handle: handle) }
-        }
-    }
-
-    /// Returns the connection for this proxy. If the proxy does not yet have an established connection,
-    /// it first attempts to create a connection.
-    ///
     /// - returns: `Ice.Connection?` - The result of the invocation.
-    public func ice_getConnectionAsync() async throws -> Connection? {
+    public func ice_getConnection() async throws -> Connection? {
         return try await withCheckedThrowingContinuation { continuation in
-            self._impl.handle.ice_getConnectionAsync(
+            self._impl.handle.ice_getConnection(
                 { connection in
                     continuation.resume(
                         returning:
@@ -642,17 +626,10 @@ extension ObjectPrx {
         }
     }
 
-    /// Flushes any pending batched requests for this communicator. The call blocks until the flush is complete.
-    public func ice_flushBatchRequests() throws {
-        return try autoreleasepool {
-            try _impl.handle.ice_flushBatchRequests()
-        }
-    }
-
     /// Asynchronously flushes any pending batched requests for this proxy.
-    public func ice_flushBatchRequestsAsync() async throws {
+    public func ice_flushBatchRequests() async throws {
         return try await withCheckedThrowingContinuation { continuation in
-            _impl.handle.ice_flushBatchRequestsAsync(
+            _impl.handle.ice_flushBatchRequests(
                 exception: {
                     continuation.resume(throwing: $0)
                 },

--- a/swift/src/IceImpl/Communicator.mm
+++ b/swift/src/IceImpl/Communicator.mm
@@ -220,21 +220,7 @@
     }
 }
 
-- (BOOL)flushBatchRequests:(std::uint8_t)compress error:(NSError**)error
-{
-    try
-    {
-        self.communicator->flushBatchRequests(Ice::CompressBatch(compress));
-        return YES;
-    }
-    catch (...)
-    {
-        *error = convertException(std::current_exception());
-        return NO;
-    }
-}
-
-- (void)flushBatchRequestsAsync:(std::uint8_t)compress
+- (void)flushBatchRequests:(std::uint8_t)compress
                       exception:(void (^)(NSError*))exception
                            sent:(void (^_Nullable)(bool))sent
 {

--- a/swift/src/IceImpl/Communicator.mm
+++ b/swift/src/IceImpl/Communicator.mm
@@ -221,8 +221,8 @@
 }
 
 - (void)flushBatchRequests:(std::uint8_t)compress
-                      exception:(void (^)(NSError*))exception
-                           sent:(void (^_Nullable)(bool))sent
+                 exception:(void (^)(NSError*))exception
+                      sent:(void (^_Nullable)(bool))sent
 {
     try
     {

--- a/swift/src/IceImpl/Communicator.mm
+++ b/swift/src/IceImpl/Communicator.mm
@@ -233,10 +233,7 @@
                     exception(convertException(e));
                 }
             },
-            [sent](bool sentSynchronously)
-            {
-                sent(sentSynchronously);
-            });
+            [sent](bool sentSynchronously) { sent(sentSynchronously); });
     }
     catch (...)
     {

--- a/swift/src/IceImpl/Communicator.mm
+++ b/swift/src/IceImpl/Communicator.mm
@@ -220,9 +220,7 @@
     }
 }
 
-- (void)flushBatchRequests:(std::uint8_t)compress
-                 exception:(void (^)(NSError*))exception
-                      sent:(void (^_Nullable)(bool))sent
+- (void)flushBatchRequests:(std::uint8_t)compress exception:(void (^)(NSError*))exception sent:(void (^)(bool))sent
 {
     try
     {
@@ -237,10 +235,7 @@
             },
             [sent](bool sentSynchronously)
             {
-                if (sent)
-                {
-                    sent(sentSynchronously);
-                }
+                sent(sentSynchronously);
             });
     }
     catch (...)

--- a/swift/src/IceImpl/Connection.mm
+++ b/swift/src/IceImpl/Connection.mm
@@ -62,9 +62,7 @@
     return [ICEEndpoint getHandle:endpoint];
 }
 
-- (void)flushBatchRequests:(std::uint8_t)compress
-                 exception:(void (^)(NSError*))exception
-                      sent:(void (^_Nullable)(bool))sent
+- (void)flushBatchRequests:(std::uint8_t)compress exception:(void (^)(NSError*))exception sent:(void (^)(bool))sent
 {
     try
     {
@@ -77,13 +75,7 @@
                     exception(convertException(e));
                 }
             },
-            [sent](bool sentSynchronously)
-            {
-                if (sent)
-                {
-                    sent(sentSynchronously);
-                }
-            });
+            [sent](bool sentSynchronously) { sent(sentSynchronously); });
     }
     catch (...)
     {

--- a/swift/src/IceImpl/Connection.mm
+++ b/swift/src/IceImpl/Connection.mm
@@ -63,8 +63,8 @@
 }
 
 - (void)flushBatchRequests:(std::uint8_t)compress
-                      exception:(void (^)(NSError*))exception
-                           sent:(void (^_Nullable)(bool))sent
+                 exception:(void (^)(NSError*))exception
+                      sent:(void (^_Nullable)(bool))sent
 {
     try
     {

--- a/swift/src/IceImpl/Connection.mm
+++ b/swift/src/IceImpl/Connection.mm
@@ -62,21 +62,7 @@
     return [ICEEndpoint getHandle:endpoint];
 }
 
-- (BOOL)flushBatchRequests:(std::uint8_t)compress error:(NSError**)error
-{
-    try
-    {
-        self.connection->flushBatchRequests(Ice::CompressBatch(compress));
-        return YES;
-    }
-    catch (...)
-    {
-        *error = convertException(std::current_exception());
-        return NO;
-    }
-}
-
-- (void)flushBatchRequestsAsync:(std::uint8_t)compress
+- (void)flushBatchRequests:(std::uint8_t)compress
                       exception:(void (^)(NSError*))exception
                            sent:(void (^_Nullable)(bool))sent
 {

--- a/swift/src/IceImpl/ObjectPrx.mm
+++ b/swift/src/IceImpl/ObjectPrx.mm
@@ -418,22 +418,7 @@
     return _prx->ice_isFixed();
 }
 
-- (id)ice_getConnection:(NSError**)error
-{
-    try
-    {
-        auto cppConnection = _prx->ice_getConnection();
-        ICEConnection* connection = [ICEConnection getHandle:cppConnection];
-        return connection ? connection : [NSNull null];
-    }
-    catch (...)
-    {
-        *error = convertException(std::current_exception());
-        return nil;
-    }
-}
-
-- (void)ice_getConnectionAsync:(void (^)(ICEConnection* _Nullable))response exception:(void (^)(NSError*))exception
+- (void)ice_getConnection:(void (^)(ICEConnection* _Nullable))response exception:(void (^)(NSError*))exception
 {
     try
     {
@@ -467,21 +452,7 @@
     return [ICEConnection getHandle:cppConnection];
 }
 
-- (BOOL)ice_flushBatchRequests:(NSError**)error
-{
-    try
-    {
-        _prx->ice_flushBatchRequests();
-        return YES;
-    }
-    catch (...)
-    {
-        *error = convertException(std::current_exception());
-        return NO;
-    }
-}
-
-- (void)ice_flushBatchRequestsAsync:(void (^)(NSError*))exception sent:(void (^_Nullable)(bool))sent
+- (void)ice_flushBatchRequests:(void (^)(NSError*))exception sent:(void (^_Nullable)(bool))sent
 {
     try
     {

--- a/swift/src/IceImpl/ObjectPrx.mm
+++ b/swift/src/IceImpl/ObjectPrx.mm
@@ -452,7 +452,7 @@
     return [ICEConnection getHandle:cppConnection];
 }
 
-- (void)ice_flushBatchRequests:(void (^)(NSError*))exception sent:(void (^_Nullable)(bool))sent
+- (void)ice_flushBatchRequests:(void (^)(NSError*))exception sent:(void (^)(bool))sent
 {
     try
     {
@@ -464,13 +464,7 @@
                     exception(convertException(e));
                 }
             },
-            [sent](bool sentSynchronously)
-            {
-                if (sent)
-                {
-                    sent(sentSynchronously);
-                }
-            });
+            [sent](bool sentSynchronously) { sent(sentSynchronously); });
     }
     catch (...)
     {

--- a/swift/src/IceImpl/include/Communicator.h
+++ b/swift/src/IceImpl/include/Communicator.h
@@ -39,7 +39,7 @@ ICEIMPL_API @interface ICECommunicator : ICELocalObject
 - (BOOL)setDefaultRouter:(ICEObjectPrx* _Nullable)router error:(NSError* _Nullable* _Nullable)error;
 - (nullable ICEObjectPrx*)getDefaultLocator;
 - (BOOL)setDefaultLocator:(ICEObjectPrx* _Nullable)locator error:(NSError* _Nullable* _Nullable)error;
-- (void)flushBatchRequests:(uint8_t)compress exception:(void (^)(NSError*))exception sent:(void (^_Nullable)(bool))sent;
+- (void)flushBatchRequests:(uint8_t)compress exception:(void (^)(NSError*))exception sent:(void (^)(bool))sent;
 - (nullable ICEObjectPrx*)createAdmin:(ICEObjectAdapter* _Nullable)adminAdapter
                                  name:(NSString*)name
                              category:(NSString*)category

--- a/swift/src/IceImpl/include/Communicator.h
+++ b/swift/src/IceImpl/include/Communicator.h
@@ -39,10 +39,7 @@ ICEIMPL_API @interface ICECommunicator : ICELocalObject
 - (BOOL)setDefaultRouter:(ICEObjectPrx* _Nullable)router error:(NSError* _Nullable* _Nullable)error;
 - (nullable ICEObjectPrx*)getDefaultLocator;
 - (BOOL)setDefaultLocator:(ICEObjectPrx* _Nullable)locator error:(NSError* _Nullable* _Nullable)error;
-- (BOOL)flushBatchRequests:(uint8_t)compress error:(NSError* _Nullable* _Nullable)error;
-- (void)flushBatchRequestsAsync:(uint8_t)compress
-                      exception:(void (^)(NSError*))exception
-                           sent:(void (^_Nullable)(bool))sent;
+- (void)flushBatchRequests:(uint8_t)compress exception:(void (^)(NSError*))exception sent:(void (^_Nullable)(bool))sent;
 - (nullable ICEObjectPrx*)createAdmin:(ICEObjectAdapter* _Nullable)adminAdapter
                                  name:(NSString*)name
                              category:(NSString*)category

--- a/swift/src/IceImpl/include/Connection.h
+++ b/swift/src/IceImpl/include/Connection.h
@@ -15,10 +15,7 @@ ICEIMPL_API @interface ICEConnection : ICELocalObject
 - (BOOL)setAdapter:(ICEObjectAdapter* _Nullable)oa error:(NSError* _Nullable* _Nullable)error;
 - (nullable ICEObjectAdapter*)getAdapter;
 - (ICEEndpoint*)getEndpoint;
-- (BOOL)flushBatchRequests:(uint8_t)compress error:(NSError* _Nullable* _Nullable)error;
-- (void)flushBatchRequestsAsync:(uint8_t)compress
-                      exception:(void (^)(NSError*))exception
-                           sent:(void (^_Nullable)(bool))sent;
+- (void)flushBatchRequests:(uint8_t)compress exception:(void (^)(NSError*))exception sent:(void (^_Nullable)(bool))sent;
 - (BOOL)setCloseCallback:(nullable void (^)(ICEConnection*))callback error:(NSError* _Nullable* _Nullable)error;
 
 - (NSString*)type;

--- a/swift/src/IceImpl/include/Connection.h
+++ b/swift/src/IceImpl/include/Connection.h
@@ -15,7 +15,7 @@ ICEIMPL_API @interface ICEConnection : ICELocalObject
 - (BOOL)setAdapter:(ICEObjectAdapter* _Nullable)oa error:(NSError* _Nullable* _Nullable)error;
 - (nullable ICEObjectAdapter*)getAdapter;
 - (ICEEndpoint*)getEndpoint;
-- (void)flushBatchRequests:(uint8_t)compress exception:(void (^)(NSError*))exception sent:(void (^_Nullable)(bool))sent;
+- (void)flushBatchRequests:(uint8_t)compress exception:(void (^)(NSError*))exception sent:(void (^)(bool))sent;
 - (BOOL)setCloseCallback:(nullable void (^)(ICEConnection*))callback error:(NSError* _Nullable* _Nullable)error;
 
 - (NSString*)type;

--- a/swift/src/IceImpl/include/ObjectPrx.h
+++ b/swift/src/IceImpl/include/ObjectPrx.h
@@ -68,7 +68,7 @@ ICEIMPL_API @interface ICEObjectPrx : NSObject
 - (void)ice_getConnection:(void (^)(ICEConnection* _Nullable))response exception:(void (^)(NSError*))exception;
 - (nullable ICEConnection*)ice_getCachedConnection;
 - (void)ice_flushBatchRequests:(void (^)(NSError*))exception
-                          sent:(void (^_Nullable)(bool))sent NS_SWIFT_NAME(ice_flushBatchRequests(exception:sent:));
+                          sent:(void (^)(bool))sent NS_SWIFT_NAME(ice_flushBatchRequests(exception:sent:));
 - (bool)ice_isCollocationOptimized;
 - (nullable instancetype)ice_collocationOptimized:(bool)collocated error:(NSError* _Nullable* _Nullable)error;
 

--- a/swift/src/IceImpl/include/ObjectPrx.h
+++ b/swift/src/IceImpl/include/ObjectPrx.h
@@ -65,13 +65,10 @@ ICEIMPL_API @interface ICEObjectPrx : NSObject
 - (nonnull instancetype)ice_compress:(bool)compress;
 - (nullable instancetype)ice_fixed:(ICEConnection*)connection error:(NSError* _Nullable* _Nullable)error;
 - (bool)ice_isFixed;
-- (nullable id)ice_getConnection:(NSError* _Nullable* _Nullable)error; // Either NSNull or ICEConnection
-- (void)ice_getConnectionAsync:(void (^)(ICEConnection* _Nullable))response exception:(void (^)(NSError*))exception;
+- (void)ice_getConnection:(void (^)(ICEConnection* _Nullable))response exception:(void (^)(NSError*))exception;
 - (nullable ICEConnection*)ice_getCachedConnection;
-- (BOOL)ice_flushBatchRequests:(NSError* _Nullable* _Nullable)error;
-- (void)ice_flushBatchRequestsAsync:(void (^)(NSError*))exception
-                               sent:(void (^_Nullable)(bool))sent
-    NS_SWIFT_NAME(ice_flushBatchRequestsAsync(exception:sent:));
+- (void)ice_flushBatchRequests:(void (^)(NSError*))exception
+                          sent:(void (^_Nullable)(bool))sent NS_SWIFT_NAME(ice_flushBatchRequests(exception:sent:));
 - (bool)ice_isCollocationOptimized;
 - (nullable instancetype)ice_collocationOptimized:(bool)collocated error:(NSError* _Nullable* _Nullable)error;
 

--- a/swift/test/Ice/adapterDeactivation/AllTests.swift
+++ b/swift/test/Ice/adapterDeactivation/AllTests.swift
@@ -101,11 +101,12 @@ func allTests(_ helper: TestHelper) async throws {
     if try await obj.ice_getConnection() != nil {
         output.write("testing object adapter with bi-dir connection... ")
         let adapter = try communicator.createObjectAdapter("")
-        try await obj.ice_getConnection()!.setAdapter(adapter)
-        try await obj.ice_getConnection()!.setAdapter(nil)
+        let connection = try await obj.ice_getConnection()!
+        try connection.setAdapter(adapter)
+        try connection.setAdapter(nil)
         adapter.deactivate()
         do {
-            try await obj.ice_getConnection()!.setAdapter(adapter)
+            try connection.setAdapter(adapter)
             try test(false)
         } catch is Ice.ObjectAdapterDeactivatedException {}
         output.writeLine("ok")

--- a/swift/test/Ice/adapterDeactivation/AllTests.swift
+++ b/swift/test/Ice/adapterDeactivation/AllTests.swift
@@ -98,14 +98,14 @@ func allTests(_ helper: TestHelper) async throws {
     }
     output.writeLine("ok")
 
-    if try obj.ice_getConnection() != nil {
+    if try await obj.ice_getConnection() != nil {
         output.write("testing object adapter with bi-dir connection... ")
         let adapter = try communicator.createObjectAdapter("")
-        try obj.ice_getConnection()!.setAdapter(adapter)
-        try obj.ice_getConnection()!.setAdapter(nil)
+        try await obj.ice_getConnection()!.setAdapter(adapter)
+        try await obj.ice_getConnection()!.setAdapter(nil)
         adapter.deactivate()
         do {
-            try obj.ice_getConnection()!.setAdapter(adapter)
+            try await obj.ice_getConnection()!.setAdapter(adapter)
             try test(false)
         } catch is Ice.ObjectAdapterDeactivatedException {}
         output.writeLine("ok")

--- a/swift/test/Ice/binding/AllTests.swift
+++ b/swift/test/Ice/binding/AllTests.swift
@@ -42,14 +42,14 @@ func allTests(_ helper: TestHelper) async throws {
         let test1 = try adapter.getTestIntf()!
         let test2 = try adapter.getTestIntf()!
 
-        try test(test1.ice_getConnection() === test2.ice_getConnection())
+        try await test(test1.ice_getConnection() === test2.ice_getConnection())
 
         try test1.ice_ping()
         try test2.ice_ping()
 
         try com.deactivateObjectAdapter(adapter)
 
-        try test(test1.ice_getConnection() === test2.ice_getConnection())
+        try await test(test1.ice_getConnection() === test2.ice_getConnection())
 
         do {
             try test1.ice_ping()
@@ -84,12 +84,12 @@ func allTests(_ helper: TestHelper) async throws {
             adpts.shuffle()
             let test3 = try createTestIntfPrx(adpts)
             try test1.ice_ping()
-            try test(test1.ice_getConnection() === test2.ice_getConnection())
-            try test(test2.ice_getConnection() === test3.ice_getConnection())
+            try await test(test1.ice_getConnection() === test2.ice_getConnection())
+            try await test(test2.ice_getConnection() === test3.ice_getConnection())
 
             let adapterName = try test1.getAdapterName()
             names.removeAll(where: { $0 == adapterName })
-            try test1.ice_getConnection()!.close(.GracefullyWithWait)
+            try await test1.ice_getConnection()!.close(.GracefullyWithWait)
         }
 
         //
@@ -112,7 +112,7 @@ func allTests(_ helper: TestHelper) async throws {
             try test(i == nRetry)
 
             for adpt in adapters {
-                try adpt.getTestIntf()!.ice_getConnection()!.close(.GracefullyWithWait)
+                try await adpt.getTestIntf()!.ice_getConnection()!.close(.GracefullyWithWait)
             }
         }
 
@@ -133,13 +133,13 @@ func allTests(_ helper: TestHelper) async throws {
             adpts.shuffle()
             let test3 = try createTestIntfPrx(adpts)
 
-            try test(test1.ice_getConnection() === test2.ice_getConnection())
-            try test(test2.ice_getConnection() === test3.ice_getConnection())
+            try await test(test1.ice_getConnection() === test2.ice_getConnection())
+            try await test(test2.ice_getConnection() === test3.ice_getConnection())
 
             let adapterName = try test1.getAdapterName()
             names.removeAll(where: { $0 == adapterName })
 
-            try test1.ice_getConnection()!.close(.GracefullyWithWait)
+            try await test1.ice_getConnection()!.close(.GracefullyWithWait)
         }
 
         //
@@ -206,7 +206,7 @@ func allTests(_ helper: TestHelper) async throws {
 
             for a in adapters {
                 do {
-                    try a.getTestIntf()!.ice_getConnection()!.close(.GracefullyWithWait)
+                    try await a.getTestIntf()!.ice_getConnection()!.close(.GracefullyWithWait)
                 } catch is Ice.LocalException {}  // Expected if adapter is down.
             }
         }
@@ -235,12 +235,12 @@ func allTests(_ helper: TestHelper) async throws {
             adpts.shuffle()
             let test3 = try createTestIntfPrx(adpts)
             try test1.ice_ping()
-            try test(test1.ice_getConnection() === test2.ice_getConnection())
-            try test(test2.ice_getConnection() === test3.ice_getConnection())
+            try await test(test1.ice_getConnection() === test2.ice_getConnection())
+            try await test(test2.ice_getConnection() === test3.ice_getConnection())
 
             let adapterName = try test1.getAdapterName()
             names.removeAll(where: { $0 == adapterName })
-            try test1.ice_getConnection()!.close(.GracefullyWithWait)
+            try await test1.ice_getConnection()!.close(.GracefullyWithWait)
         }
 
         //
@@ -262,7 +262,7 @@ func allTests(_ helper: TestHelper) async throws {
             try test(i == nRetry)
 
             for adpt in adapters {
-                try adpt.getTestIntf()!.ice_getConnection()!.close(.GracefullyWithWait)
+                try await adpt.getTestIntf()!.ice_getConnection()!.close(.GracefullyWithWait)
             }
         }
 
@@ -281,12 +281,12 @@ func allTests(_ helper: TestHelper) async throws {
             adpts.shuffle()
             let test3 = try createTestIntfPrx(adpts)
 
-            try test(test1.ice_getConnection() === test2.ice_getConnection())
-            try test(test2.ice_getConnection() === test3.ice_getConnection())
+            try await test(test1.ice_getConnection() === test2.ice_getConnection())
+            try await test(test2.ice_getConnection() === test3.ice_getConnection())
 
             let adapterName = try test1.getAdapterName()
             names.removeAll(where: { $0 == adapterName })
-            try test1.ice_getConnection()!.close(.GracefullyWithWait)
+            try await test1.ice_getConnection()!.close(.GracefullyWithWait)
         }
 
         //
@@ -316,7 +316,7 @@ func allTests(_ helper: TestHelper) async throws {
         while names.count > 0 {
             let adapterName = try obj.getAdapterName()
             names.removeAll(where: { $0 == adapterName })
-            try obj.ice_getConnection()!.close(.GracefullyWithWait)
+            try await obj.ice_getConnection()!.close(.GracefullyWithWait)
         }
 
         obj = obj.ice_endpointSelection(.Random)
@@ -329,7 +329,7 @@ func allTests(_ helper: TestHelper) async throws {
         while names.count > 0 {
             let adapterName = try obj.getAdapterName()
             names.removeAll(where: { $0 == adapterName })
-            try obj.ice_getConnection()!.close(.GracefullyWithWait)
+            try await obj.ice_getConnection()!.close(.GracefullyWithWait)
         }
 
         try deactivate(communicator: com, adapters: adapters)
@@ -397,7 +397,7 @@ func allTests(_ helper: TestHelper) async throws {
             i += 1
         }
         try test(i == nRetry)
-        try obj.ice_getConnection()!.close(.GracefullyWithWait)
+        try await obj.ice_getConnection()!.close(.GracefullyWithWait)
 
         try adapters.append(
             com.createObjectAdapter(name: "Adapter35", endpoints: endpoints[1].toString())!)
@@ -406,7 +406,7 @@ func allTests(_ helper: TestHelper) async throws {
             i += 1
         }
         try test(i == nRetry)
-        try obj.ice_getConnection()!.close(.GracefullyWithWait)
+        try await obj.ice_getConnection()!.close(.GracefullyWithWait)
 
         try adapters.append(
             com.createObjectAdapter(name: "Adapter34", endpoints: endpoints[0].toString())!)
@@ -428,15 +428,16 @@ func allTests(_ helper: TestHelper) async throws {
         let test2 = try adapter.getTestIntf()!.ice_connectionCached(false)
         try test(!test1.ice_isConnectionCached())
         try test(!test2.ice_isConnectionCached())
-        try test(test1.ice_getConnection() != nil && test2.ice_getConnection() != nil)
-        try test(test1.ice_getConnection() === test2.ice_getConnection())
+        try await test(test1.ice_getConnection() != nil)
+        try await test(test2.ice_getConnection() != nil)
+        try await test(test1.ice_getConnection() === test2.ice_getConnection())
 
         try test1.ice_ping()
 
         try com.deactivateObjectAdapter(adapter)
 
         do {
-            _ = try test1.ice_getConnection()
+            _ = try await test1.ice_getConnection()
             try test(false)
         } catch is Ice.ConnectFailedException {
             // expected
@@ -692,7 +693,7 @@ func allTests(_ helper: TestHelper) async throws {
         try test(obj.getAdapterName() == "Adapter71")
 
         let testUDP = obj.ice_datagram()
-        try test(obj.ice_getConnection() !== testUDP.ice_getConnection())
+        try await test(obj.ice_getConnection() !== testUDP.ice_getConnection())
         do {
             _ = try testUDP.getAdapterName()
         } catch is Ice.TwowayOnlyException {}
@@ -710,7 +711,7 @@ func allTests(_ helper: TestHelper) async throws {
             let obj = try createTestIntfPrx(adapters)
             for _ in 0..<5 {
                 try test(obj.getAdapterName() == "Adapter82")
-                try obj.ice_getConnection()!.close(.GracefullyWithWait)
+                try await obj.ice_getConnection()!.close(.GracefullyWithWait)
             }
 
             var testSecure = obj.ice_secure(true)
@@ -719,13 +720,13 @@ func allTests(_ helper: TestHelper) async throws {
             try test(!testSecure.ice_isSecure())
             testSecure = obj.ice_secure(true)
             try test(testSecure.ice_isSecure())
-            try test(obj.ice_getConnection() !== testSecure.ice_getConnection())
+            try await test(obj.ice_getConnection() !== testSecure.ice_getConnection())
 
             try com.deactivateObjectAdapter(adapters[1])
 
             for _ in 0..<5 {
                 try test(obj.getAdapterName() == "Adapter81")
-                try obj.ice_getConnection()!.close(.GracefullyWithWait)
+                try await obj.ice_getConnection()!.close(.GracefullyWithWait)
             }
 
             // Reactive tcp OA.
@@ -734,7 +735,7 @@ func allTests(_ helper: TestHelper) async throws {
 
             for _ in 0..<5 {
                 try test(obj.getAdapterName() == "Adapter83")
-                try obj.ice_getConnection()!.close(.GracefullyWithWait)
+                try await obj.ice_getConnection()!.close(.GracefullyWithWait)
             }
 
             try com.deactivateObjectAdapter(adapters[0])

--- a/swift/test/Ice/exceptions/AllTests.swift
+++ b/swift/test/Ice/exceptions/AllTests.swift
@@ -246,7 +246,7 @@ func allTests(_ helper: TestHelper) async throws -> ThrowerPrx {
         output.writeLine("ok")
     }
 
-    let conn = try thrower.ice_getConnection()
+    let conn = try await thrower.ice_getConnection()
     if conn != nil {
         output.write("testing memory limit marshal exception...")
         do {

--- a/swift/test/Ice/info/AllTests.swift
+++ b/swift/test/Ice/info/AllTests.swift
@@ -153,7 +153,7 @@ func allTests(_ helper: TestHelper) async throws {
 
     output.write("test connection endpoint information... ")
     do {
-        var info = try base.ice_getConnection()!.getEndpoint().getInfo()!
+        var info = try await base.ice_getConnection()!.getEndpoint().getInfo()!
         let tcpinfo = getTCPEndpointInfo(info)!
         try test(tcpinfo.port == endpointPort)
         try test(!tcpinfo.compress)
@@ -165,7 +165,7 @@ func allTests(_ helper: TestHelper) async throws {
         let port = Int(ctx["port"]!)!
         try test(port > 0)
 
-        info = try base.ice_datagram().ice_getConnection()!.getEndpoint().getInfo()!
+        info = try await base.ice_datagram().ice_getConnection()!.getEndpoint().getInfo()!
         let udp = (info as? Ice.UDPEndpointInfo)!
         try test(udp.port == endpointPort)
         try test(udp.host == defaultHost)
@@ -174,7 +174,7 @@ func allTests(_ helper: TestHelper) async throws {
 
     output.write("testing connection information... ")
     do {
-        var connection = try base.ice_getConnection()!
+        var connection = try await base.ice_getConnection()!
         try connection.setBufferSize(rcvSize: 1024, sndSize: 2048)
 
         let info = try connection.getInfo()
@@ -199,7 +199,7 @@ func allTests(_ helper: TestHelper) async throws {
         try test(ctx["remotePort"] == "\(ipInfo.localPort)")
         try test(ctx["localPort"] == "\(ipInfo.remotePort)")
 
-        if try base.ice_getConnection()!.type() == "ws" || base.ice_getConnection()!.type() == "wss" {
+        if try await ["ws", "wss"].contains(base.ice_getConnection()!.type()) {
             let headers = (info as? Ice.WSConnectionInfo)!.headers
 
             try test(headers["Upgrade"] == "websocket")
@@ -214,7 +214,7 @@ func allTests(_ helper: TestHelper) async throws {
             try test(ctx["ws.Sec-WebSocket-Key"] != nil)
         }
 
-        connection = try base.ice_datagram().ice_getConnection()!
+        connection = try await base.ice_datagram().ice_getConnection()!
         try connection.setBufferSize(rcvSize: 2048, sndSize: 1024)
 
         let udpInfo = try (connection.getInfo() as? Ice.UDPConnectionInfo)!

--- a/swift/test/Ice/invoke/AllTests.swift
+++ b/swift/test/Ice/invoke/AllTests.swift
@@ -33,7 +33,7 @@ func allTests(_ helper: TestHelper) async throws -> MyClassPrx {
         try test(batchOneway.ice_invoke(operation: "opOneway", mode: .Normal, inEncaps: Data()).ok)
         try test(batchOneway.ice_invoke(operation: "opOneway", mode: .Normal, inEncaps: Data()).ok)
 
-        try batchOneway.ice_flushBatchRequests()
+        try await batchOneway.ice_flushBatchRequests()
         let outS = Ice.OutputStream(communicator: communicator)
         outS.startEncapsulation()
         outS.write(testString)

--- a/swift/test/Ice/location/AllTests.swift
+++ b/swift/test/Ice/location/AllTests.swift
@@ -461,7 +461,7 @@ func allTests(_ helper: TestHelper) async throws {
     output.write("testing object migration... ")
     hello = try makeProxy(communicator: communicator, proxyString: "hello", type: HelloPrx.self)
     try obj.migrateHello()
-    try hello.ice_getConnection()!.close(.GracefullyWithWait)
+    try await hello.ice_getConnection()!.close(.GracefullyWithWait)
     try hello.sayHello()
     try obj.migrateHello()
     try hello.sayHello()
@@ -530,11 +530,11 @@ func allTests(_ helper: TestHelper) async throws {
 
     // Ensure that calls on the indirect proxy (with adapter ID) is collocated
     var helloPrx = try checkedCast(prx: adapter.createIndirectProxy(ident), type: HelloPrx.self)!
-    try test(helloPrx.ice_getConnection() == nil)
+    try await test(helloPrx.ice_getConnection() == nil)
 
     // Ensure that calls on the direct proxy is collocated
     helloPrx = try checkedCast(prx: adapter.createDirectProxy(ident), type: HelloPrx.self)!
-    try test(helloPrx.ice_getConnection() == nil)
+    try await test(helloPrx.ice_getConnection() == nil)
 
     output.writeLine("ok")
 

--- a/swift/test/Ice/operations/AllTests.swift
+++ b/swift/test/Ice/operations/AllTests.swift
@@ -16,8 +16,8 @@ func allTests(helper: TestHelper) async throws -> MyClassPrx {
     let derivedProxy = try checkedCast(prx: cl, type: MyDerivedClassPrx.self)!
 
     output.write("testing twoway operations... ")
-    try twoways(helper, cl)
-    try twoways(helper, derivedProxy)
+    try await twoways(helper, cl)
+    try await twoways(helper, derivedProxy)
     try derivedProxy.opDerived()
     output.writeLine("ok")
 
@@ -38,13 +38,13 @@ func allTests(helper: TestHelper) async throws -> MyClassPrx {
     output.writeLine("ok")
 
     output.write("testing batch oneway operations... ")
-    try batchOneways(helper, cl)
-    try batchOneways(helper, derivedProxy)
+    try await batchOneways(helper, cl)
+    try await batchOneways(helper, derivedProxy)
     output.writeLine("ok")
 
     output.write("testing batch oneway operations with AMI... ")
-    try batchOneways(helper, cl)
-    try batchOneways(helper, derivedProxy)
+    try await batchOneways(helper, cl)
+    try await batchOneways(helper, derivedProxy)
     output.writeLine("ok")
 
     return cl

--- a/swift/test/Ice/operations/BatchOnewaysAMI.swift
+++ b/swift/test/Ice/operations/BatchOnewaysAMI.swift
@@ -12,7 +12,7 @@ func batchOnewaysAMI(_ helper: TestHelper, _ p: MyClassPrx) async throws {
     let bs1 = ByteSeq(repeating: 0, count: 10 * 1024)
     let batch = p.ice_batchOneway()
 
-    try await batch.ice_flushBatchRequestsAsync()
+    try await batch.ice_flushBatchRequests()
 
     for _ in 0..<30 {
         async let _ = try batch.opByteSOnewayAsync(bs1)
@@ -24,23 +24,23 @@ func batchOnewaysAMI(_ helper: TestHelper, _ p: MyClassPrx) async throws {
         usleep(100)
     }
 
-    let conn = try batch.ice_getConnection()
+    let conn = try await batch.ice_getConnection()
     if conn != nil {
         let batch1 = uncheckedCast(prx: p.ice_batchOneway(), type: MyClassPrx.self)
         let batch2 = uncheckedCast(prx: p.ice_batchOneway(), type: MyClassPrx.self)
 
         async let _ = try batch1.ice_pingAsync()
         async let _ = try batch2.ice_pingAsync()
-        try await batch1.ice_flushBatchRequestsAsync()
-        try batch1.ice_getConnection()!.close(Ice.ConnectionClose.GracefullyWithWait)
+        try await batch1.ice_flushBatchRequests()
+        try await batch1.ice_getConnection()!.close(Ice.ConnectionClose.GracefullyWithWait)
         async let _ = try batch1.ice_pingAsync()
         async let _ = try batch2.ice_pingAsync()
 
-        _ = try batch1.ice_getConnection()
-        _ = try batch2.ice_getConnection()
+        _ = try await batch1.ice_getConnection()
+        _ = try await batch2.ice_getConnection()
 
         async let _ = try batch1.ice_pingAsync()
-        try batch1.ice_getConnection()!.close(Ice.ConnectionClose.GracefullyWithWait)
+        try await batch1.ice_getConnection()!.close(Ice.ConnectionClose.GracefullyWithWait)
 
         async let _ = try batch1.ice_pingAsync()
         async let _ = try batch2.ice_pingAsync()
@@ -48,11 +48,11 @@ func batchOnewaysAMI(_ helper: TestHelper, _ p: MyClassPrx) async throws {
 
     let batch3 = batch.ice_identity(Ice.Identity(name: "invalid", category: ""))
     async let _ = try batch3.ice_pingAsync()
-    try await batch3.ice_flushBatchRequestsAsync()
+    try await batch3.ice_flushBatchRequests()
 
     // Make sure that a bogus batch request doesn't cause troubles to other ones.
     async let _ = try batch3.ice_pingAsync()
     async let _ = try batch.ice_pingAsync()
-    try await batch.ice_flushBatchRequestsAsync()
+    try await batch.ice_flushBatchRequests()
     async let _ = try batch.ice_pingAsync()
 }

--- a/swift/test/Ice/operations/Twoways.swift
+++ b/swift/test/Ice/operations/Twoways.swift
@@ -4,7 +4,7 @@ import Ice
 import TestCommon
 
 // temporary work-around for issue #816
-func twoways(_ helper: TestHelper, _ p: MyClassPrx) throws {
+func twoways(_ helper: TestHelper, _ p: MyClassPrx) async throws {
     func test(_ value: Bool, file: String = #file, line: Int = #line) throws {
         try helper.test(value, file: file, line: line)
     }
@@ -1088,7 +1088,7 @@ func twoways(_ helper: TestHelper, _ p: MyClassPrx) throws {
         }
     }
 
-    let conn = try p.ice_getConnection()
+    let conn = try await p.ice_getConnection()
     if conn != nil {
         //
         // Test implicit context propagation

--- a/swift/test/Ice/operations/TwowaysAMI.swift
+++ b/swift/test/Ice/operations/TwowaysAMI.swift
@@ -812,7 +812,7 @@ func twowaysAMI(_ helper: TestHelper, _ p: MyClassPrx) async throws {
     //
     // Test implicit context propagation with async result
     //
-    let conn = try p.ice_getConnection()
+    let conn = try await p.ice_getConnection()
     if conn != nil {
         var initData = Ice.InitializationData()
         let properties = communicator.getProperties().clone()

--- a/swift/test/Ice/proxy/AllTests.swift
+++ b/swift/test/Ice/proxy/AllTests.swift
@@ -3,7 +3,7 @@
 import Ice
 import TestCommon
 
-public func allTests(_ helper: TestHelper) throws -> MyClassPrx {
+public func allTests(_ helper: TestHelper) async throws -> MyClassPrx {
     func test(_ value: Bool, file: String = #file, line: Int = #line) throws {
         try helper.test(value, file: file, line: line)
     }
@@ -340,8 +340,8 @@ public func allTests(_ helper: TestHelper) throws -> MyClassPrx {
 
     try test(b1 == b2)
 
-    if try b1.ice_getConnection() != nil {  // not colloc-optimized target
-        b2 = try b1.ice_getConnection()!.createProxy(Ice.stringToIdentity("fixed"))
+    if try await b1.ice_getConnection() != nil {  // not colloc-optimized target
+        b2 = try await b1.ice_getConnection()!.createProxy(Ice.stringToIdentity("fixed"))
         let str = communicator.proxyToString(b2)
         try test(b2.ice_toString() == str)
         let str2 = b1.ice_identity(b2.ice_getIdentity()).ice_secure(b2.ice_isSecure()).ice_toString()
@@ -655,9 +655,9 @@ public func allTests(_ helper: TestHelper) throws -> MyClassPrx {
         endpts1[0] == communicator.stringToProxy("foo:tcp -h 127.0.0.1 -p 10000")!.ice_getEndpoints()[0]
     )
 
-    let baseConnection = try baseProxy.ice_getConnection()
+    let baseConnection = try await baseProxy.ice_getConnection()
     if baseConnection != nil {
-        let baseConnection2 = try baseProxy.ice_connectionId("base2").ice_getConnection()
+        let baseConnection2 = try await baseProxy.ice_connectionId("base2").ice_getConnection()
         compObj1 = compObj1!.ice_fixed(baseConnection!)
         compObj2 = compObj2!.ice_fixed(baseConnection2!)
         try test(compObj1 != compObj2)
@@ -683,7 +683,7 @@ public func allTests(_ helper: TestHelper) throws -> MyClassPrx {
 
     writer.write("testing ice_fixed... ")
     do {
-        let connection = try cl.ice_getConnection()
+        let connection = try await cl.ice_getConnection()
         if connection != nil {
             let prx = cl.ice_fixed(connection!)
             try prx.ice_ping()
@@ -695,11 +695,11 @@ public func allTests(_ helper: TestHelper) throws -> MyClassPrx {
             try test(cl.ice_context(ctx).ice_fixed(connection!).ice_getContext().count == 2)
             try test(cl.ice_fixed(connection!).ice_getInvocationTimeout() == -1)
             try test(cl.ice_invocationTimeout(10).ice_fixed(connection!).ice_getInvocationTimeout() == 10)
-            try test(cl.ice_fixed(connection!).ice_getConnection() === connection)
-            try test(cl.ice_fixed(connection!).ice_fixed(connection!).ice_getConnection() === connection)
+            try await test(cl.ice_fixed(connection!).ice_getConnection() === connection)
+            try await test(cl.ice_fixed(connection!).ice_fixed(connection!).ice_getConnection() === connection)
             try test(cl.ice_compress(true).ice_fixed(connection!).ice_getCompress()!)
-            let fixedConnection = try cl.ice_connectionId("ice_fixed").ice_getConnection()
-            try test(
+            let fixedConnection = try await cl.ice_connectionId("ice_fixed").ice_getConnection()
+            try await test(
                 cl.ice_fixed(connection!).ice_fixed(fixedConnection!).ice_getConnection()
                     === fixedConnection)
             do {

--- a/swift/test/Ice/proxy/Client.swift
+++ b/swift/test/Ice/proxy/Client.swift
@@ -10,7 +10,7 @@ class Client: TestHelperI {
             defer {
                 communicator.destroy()
             }
-            let cl = try allTests(self)
+            let cl = try await allTests(self)
             try cl.shutdown()
         }
     }

--- a/swift/test/Ice/proxy/Collocated.swift
+++ b/swift/test/Ice/proxy/Collocated.swift
@@ -21,6 +21,6 @@ class Collocated: TestHelperI {
             servant: MyDerivedClassDisp(MyDerivedClassI()),
             id: Ice.stringToIdentity("test"))
         // try adapter.activate() // Don't activate OA to ensure collocation is used.
-        _ = try allTests(self)
+        _ = try await allTests(self)
     }
 }

--- a/swift/test/Ice/timeout/AllTests.swift
+++ b/swift/test/Ice/timeout/AllTests.swift
@@ -4,16 +4,16 @@ import Foundation
 import Ice
 import TestCommon
 
-func connect(_ prx: Ice.ObjectPrx) throws -> Ice.Connection {
+func connect(_ prx: Ice.ObjectPrx) async throws -> Ice.Connection {
     for _ in 0..<10 {
         do {
-            _ = try prx.ice_getConnection()
+            _ = try await prx.ice_getConnection()
             break
         } catch is Ice.ConnectTimeoutException {
             // Can sporadically occur with slow machines
         }
     }
-    return try prx.ice_getConnection()!
+    return try await prx.ice_getConnection()!
 }
 
 public func allTests(helper: TestHelper) async throws {
@@ -76,22 +76,22 @@ public func allTestsWithController(helper: TestHelper, controller: ControllerPrx
 
     output.write("testing invocation timeout... ")
     do {
-        let connection = try obj.ice_getConnection()
+        let connection = try await obj.ice_getConnection()
         var to = timeout.ice_invocationTimeout(100)
-        try test(connection === to.ice_getConnection())
+        try await test(connection === to.ice_getConnection())
         do {
             try to.sleep(1000)
             try test(false)
         } catch is Ice.InvocationTimeoutException {}
         try obj.ice_ping()
         to = timeout.ice_invocationTimeout(1000)
-        try test(connection === to.ice_getConnection())
+        try await test(connection === to.ice_getConnection())
         do {
             try to.sleep(100)
         } catch is Ice.InvocationTimeoutException {
             try test(false)
         }
-        try test(connection === to.ice_getConnection())
+        try await test(connection === to.ice_getConnection())
     }
 
     do {
@@ -122,7 +122,7 @@ public func allTestsWithController(helper: TestHelper, controller: ControllerPrx
     output.write("testing close timeout... ")
     do {
         let to = timeout
-        let connection = try connect(to)
+        let connection = try await connect(to)
         try controller.holdAdapter(-1)
         try connection.close(.GracefullyWithWait)
         do {

--- a/swift/test/Ice/udp/AllTests.swift
+++ b/swift/test/Ice/udp/AllTests.swift
@@ -40,7 +40,7 @@ class PingReplyI: PingReply {
     }
 }
 
-public func allTests(_ helper: TestHelper) throws {
+public func allTests(_ helper: TestHelper) async throws {
     func test(_ value: Bool, file: String = #file, line: Int = #line) throws {
         try helper.test(value, file: file, line: line)
     }
@@ -104,7 +104,7 @@ public func allTests(_ helper: TestHelper) throws {
             //
             try test(seq.count > 16384)
         }
-        try obj.ice_getConnection()!.close(.GracefullyWithWait)
+        try await obj.ice_getConnection()!.close(.GracefullyWithWait)
         communicator.getProperties().setProperty(key: "Ice.UDP.SndSize", value: "64000")
         seq = ByteSeq(repeating: 0, count: 50000)
         do {
@@ -162,7 +162,7 @@ public func allTests(_ helper: TestHelper) throws {
     }
 
     output.write("testing udp bi-dir connection... ")
-    try obj.ice_getConnection()!.setAdapter(adapter)
+    try await obj.ice_getConnection()!.setAdapter(adapter)
     for _ in 0..<5 {
         replyI.reset()
         try obj.pingBiDir(reply.ice_getIdentity())

--- a/swift/test/Ice/udp/Client.swift
+++ b/swift/test/Ice/udp/Client.swift
@@ -15,7 +15,7 @@ class Client: TestHelperI {
             defer {
                 communicator.destroy()
             }
-            try allTests(self)
+            try await allTests(self)
 
             let num = restArgs.count == 4 ? Int(restArgs[3]) : 1
             for i in 0..<(num ?? 1) {


### PR DESCRIPTION
- Consolidate `flushBatchRequests` and `flushBatchRequestsAsync` on Proxy, Communicator, and Connection into one async function, `flushBatchRequests`
- Consolidate `ice_getConnection` and `ice_getConnectionAsync` into one async function, `ice_getConnection`