### PR TITLE
getConnection returns a nullable Connection in C#

### DIFF
--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -437,7 +437,7 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <summary>
     /// Gets the connection to the server that hosts the target object. This method establishes the connection to the
     /// server if it is not already established.
-    /// /// </summary>
+    /// </summary>
     /// <returns>The connection to the server that hosts the target object, or null when this proxy uses collocation
     /// optimization to communicate with the target object.</returns>
     Connection? ice_getConnection();

--- a/csharp/test/Ice/idleTimeout/AllTests.cs
+++ b/csharp/test/Ice/idleTimeout/AllTests.cs
@@ -41,7 +41,7 @@ internal class AllTests : global::Test.AllTests
         await p.sleepAsync(4000); // the implementation in the server sleeps for 2,000ms
 
         // close connection
-        p.ice_getConnection().close(ConnectionClose.GracefullyWithWait);
+        p.ice_getConnection()!.close(ConnectionClose.GracefullyWithWait);
         output.WriteLine("ok");
     }
 
@@ -65,7 +65,7 @@ internal class AllTests : global::Test.AllTests
         Test.TestIntfPrx p = Test.TestIntfPrxHelper.createProxy(communicator, proxyString);
 
         // Establish connection.
-        Connection connection = p.ice_getConnection();
+        Connection? connection = p.ice_getConnection();
         test(connection is not null);
 
         // The idle check on the server side aborts the connection because it doesn't get a heartbeat in a timely fashion.
@@ -101,7 +101,7 @@ internal class AllTests : global::Test.AllTests
         Communicator communicator = Util.initialize(new InitializationData { properties = properties });
         Test.TestIntfPrx p = Test.TestIntfPrxHelper.createProxy(communicator, proxyString);
 
-        Connection connection = await p.ice_getConnectionAsync();
+        Connection? connection = await p.ice_getConnectionAsync();
         test(connection is not null);
 
         try

--- a/csharp/test/Ice/inactivityTimeout/AllTests.cs
+++ b/csharp/test/Ice/inactivityTimeout/AllTests.cs
@@ -27,13 +27,13 @@ internal class AllTests : global::Test.AllTests
         output.Flush();
 
         await p.ice_pingAsync();
-        Connection connection = p.ice_getConnection();
+        Connection? connection = p.ice_getConnection();
         test(connection is not null);
 
         // The inactivity timeout is 3s on the client side and 5s on the server side. 4 seconds tests the client side.
         await Task.Delay(4000);
         await p.ice_pingAsync();
-        Connection connection2 = p.ice_getConnection();
+        Connection? connection2 = p.ice_getConnection();
         test(connection2 != connection);
         output.WriteLine("ok");
     }
@@ -50,13 +50,13 @@ internal class AllTests : global::Test.AllTests
         Test.TestIntfPrx p = Test.TestIntfPrxHelper.createProxy(communicator, proxyString);
 
         await p.ice_pingAsync();
-        Connection connection = p.ice_getConnection();
+        Connection? connection = p.ice_getConnection();
         test(connection is not null);
 
         // The inactivity timeout is 5s on the client side and 3s on the server side. 4 seconds tests the server side.
         await Task.Delay(4000);
         await p.ice_pingAsync();
-        Connection connection2 = p.ice_getConnection();
+        Connection? connection2 = p.ice_getConnection();
         test(connection2 != connection);
         output.WriteLine("ok");
     }
@@ -73,7 +73,7 @@ internal class AllTests : global::Test.AllTests
         }
 
         await p.ice_pingAsync();
-        Connection connection = p.ice_getConnection();
+        Connection? connection = p.ice_getConnection();
         test(connection is not null);
 
         // The inactivity timeout is 3s on the client side and 5s on the server side; 4 seconds tests only the
@@ -84,7 +84,7 @@ internal class AllTests : global::Test.AllTests
             await Task.Delay(4000);
         }
         await p.ice_pingAsync();
-        Connection connection2 = p.ice_getConnection();
+        Connection? connection2 = p.ice_getConnection();
 
         if (oneway)
         {


### PR DESCRIPTION
Fixes #2584.