### PR TITLE
Update Glacier2 SessionControl::destroy impl to close the connection

### DIFF
--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -61,6 +61,10 @@ namespace Glacier2
         {
             _sessionRouter->destroySession(_connection);
             _filters->destroy();
+
+            // Initiate a graceful closure of the connection. Only initiate and graceful because the ultimate caller
+            // can be the Glacier2 client calling us over _connection.
+            _connection->close(ConnectionClose::Gracefully);
         }
 
     private:


### PR DESCRIPTION
We want SessionControl::destroy to close the client->router connection, to allow the client to get notified as soon as the session is destroyed.

The client can then cleanup  / establish a new session.