### PR TITLE
Compile with -fPIE on macos

### DIFF
--- a/config/Make.rules.Darwin
+++ b/config/Make.rules.Darwin
@@ -31,8 +31,8 @@ MCPP_HOME                      ?= $(shell brew --prefix mcpp)
 LMDB_HOME                      ?= $(shell brew --prefix lmdb)
 endif
 
-# If building objects for a shared library, enable fPIC
-shared_cppflags = $(if $(filter-out program,$($1_target)),-fPIC) -fvisibility=hidden
+# If building objects for a shared library build, enable PIC or PIE:
+shared_cppflags = $(if $(filter-out program,$($1_target)),-fPIC,-fPIE) -fvisibility=hidden
 
 cppflags        = -Wall -Wextra -Wshadow -Wshadow-all -Wredundant-decls -Wno-shadow-field \
                   -Wdeprecated -Wstrict-prototypes -Werror -Wconversion -Wdocumentation -pthread \


### PR DESCRIPTION
This PR updates the macos build settings to use -fPIE for shared executables, just like we already do on Linux.

Make.rules.Darwin is now in sync with Make.rules.Linux.