### PR TITLE
Remove ICE_BUILDING_SRC macro

### DIFF
--- a/cpp/config/Make.rules
+++ b/cpp/config/Make.rules
@@ -73,7 +73,7 @@ define make-cpp-src-project
 ifeq ($(filter all cpp,$(ICE_BIN_DIST)),)
 $1_slicecompiler        := slice2cpp
 $1_sliceflags           += -I$(slicedir)
-$1_cppflags             += -I$1/generated -I$(includedir) -I$(includedir)/generated -DICE_BUILDING_SRC
+$1_cppflags             += -I$1/generated -I$(includedir) -I$(includedir)/generated
 $(make-project)
 srcs:: $1
 endif

--- a/cpp/include/Ice/RegisterPlugins.h
+++ b/cpp/include/Ice/RegisterPlugins.h
@@ -10,9 +10,8 @@
 //
 // Register functions for Ice plugins are declared here.
 //
-// These functions can be used to explicitly link with a plugin rather
-// than relying on the loading of the plugin at runtime. The application
-// must call the register function before initializing the communicator.
+// These functions can be used to explicitly link with a plugin rather than relying on the loading of the plugin at
+// runtime. The application must call the register function before initializing the communicator.
 //
 
 #ifndef ICE_PLUGIN_REGISTER_DECLSPEC_IMPORT
@@ -22,8 +21,7 @@
 namespace Ice
 {
     //
-    // Checking for the API_EXPORTS macro is necessary to prevent
-    // inconsistent DLL linkage errors on Windows.
+    // Checking for the API_EXPORTS macro is necessary to prevent inconsistent DLL linkage errors on Windows.
     //
 
 #ifndef ICE_API_EXPORTS
@@ -94,10 +92,6 @@ namespace Ice
 #    endif
 #endif
 
-#if defined(_MSC_VER) && !defined(ICE_BUILDING_SRC)
-#    pragma comment(lib, ICE_LIBNAME("IceDiscovery"))
-#    pragma comment(lib, ICE_LIBNAME("IceLocatorDiscovery"))
-#endif
 }
 
 #endif

--- a/cpp/msbuild/ice.cpp.props
+++ b/cpp/msbuild/ice.cpp.props
@@ -115,9 +115,6 @@
       Definitions when building the Ice C++ sources (as opposed to the test suite).
   -->
   <ItemDefinitionGroup Condition="'$(IceBuildingSrc)' == 'yes'">
-    <ClCompile>
-      <PreprocessorDefinitions Condition="'$(IceLanguageMapping)' == 'cpp'">ICE_BUILDING_SRC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(IceHome)\cpp\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>

--- a/cpp/src/icegriddb/msbuild/icegriddb.vcxproj
+++ b/cpp/src/icegriddb/msbuild/icegriddb.vcxproj
@@ -70,25 +70,21 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>$(Platform)\$(Configuration)\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>ICE_BUILDING_SRC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>$(Platform)\$(Configuration)\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>ICE_BUILDING_SRC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>$(Platform)\$(Configuration)\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>ICE_BUILDING_SRC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>$(Platform)\$(Configuration)\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>ICE_BUILDING_SRC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Label="IceBuilder">

--- a/cpp/test/IceDiscovery/simple/Client.cpp
+++ b/cpp/test/IceDiscovery/simple/Client.cpp
@@ -19,10 +19,12 @@ public:
 void
 Client::run(int argc, char** argv)
 {
+#ifdef ICE_STATIC_LIBS
     //
     // Explicitly register the IceDiscovery plugin to test registerIceDiscovery.
     //
     Ice::registerIceDiscovery();
+#endif
 
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     int num = argc == 2 ? atoi(argv[1]) : 1;

--- a/cpp/test/IceGrid/simple/AllTests.cpp
+++ b/cpp/test/IceGrid/simple/AllTests.cpp
@@ -75,7 +75,7 @@ allTests(Test::TestHelper* helper)
             // handles failure to find a locator. Also test
             // Ice::registerIceLocatorDiscovery()
             //
-#ifndef ICE_STATIC_LIBS
+#ifdef ICE_STATIC_LIBS
             Ice::registerIceLocatorDiscovery();
             initData.properties->setProperty("Ice.Plugin.IceLocatorDiscovery", "");
 #else

--- a/cpp/test/IceGrid/simple/AllTests.cpp
+++ b/cpp/test/IceGrid/simple/AllTests.cpp
@@ -71,15 +71,11 @@ allTests(Test::TestHelper* helper)
             com->destroy();
 
             //
-            // Now, ensure that the IceGrid discovery locator correctly
-            // handles failure to find a locator. Also test
+            // Now, ensure that the IceGrid discovery locator correctly handles failure to find a locator. Also test
             // Ice::registerIceLocatorDiscovery()
             //
 #ifdef ICE_STATIC_LIBS
             Ice::registerIceLocatorDiscovery();
-            initData.properties->setProperty("Ice.Plugin.IceLocatorDiscovery", "");
-#else
-            initData.properties->setProperty("Ice.Plugin.IceLocatorDiscovery", "1");
 #endif
             initData.properties->setProperty("IceLocatorDiscovery.InstanceName", "unknown");
             initData.properties->setProperty("IceLocatorDiscovery.RetryCount", "1");

--- a/matlab/src/Init.cpp
+++ b/matlab/src/Init.cpp
@@ -7,6 +7,12 @@
 #include "Util.h"
 #include "ice.h"
 
+// Link with IceDiscovery and IceLocatorDiscovery on Windows
+#if defined(_MSC_VER)
+#    pragma comment(lib, ICE_LIBNAME("IceDiscovery"))
+#    pragma comment(lib, ICE_LIBNAME("IceLocatorDiscovery"))
+#endif
+
 using namespace std;
 using namespace IceMatlab;
 

--- a/python/modules/IcePy/Init.cpp
+++ b/python/modules/IcePy/Init.cpp
@@ -22,6 +22,12 @@
 #include "Types.h"
 #include "ValueFactoryManager.h"
 
+// Link with IceDiscovery and IceLocatorDiscovery on Windows for "shared" builds.
+#if defined(_MSC_VER) && !defined(ICE_BUILDING_ICE)
+#    pragma comment(lib, ICE_LIBNAME("IceDiscovery"))
+#    pragma comment(lib, ICE_LIBNAME("IceLocatorDiscovery"))
+#endif
+
 using namespace std;
 using namespace IcePy;
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -61,7 +61,6 @@ else:
 # Define macros used during the build process
 # All the /**/ macros are necessary only on Windows
 define_macros = [
-    ('ICE_BUILDING_SRC', None),
     ('ICE_BUILDING_ICE', None),
     ('ICE_BUILDING_ICE_LOCATOR_DISCOVERY', None),
     ('ICE_API', '/**/'),


### PR DESCRIPTION
This PR removes ICE_BUILDING_SRC from the C++ builds. It's not immediately clear what the use-case for this macro was.