### PR TITLE
Call Swift connection close callback from global executor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,13 +111,6 @@ csharp/AppX
 cpp/AppX
 cpp/test/Slice/errorDetection/tmp
 
-Carthage
-
-# iOS builds
-
-**/objs-*/
-**/build-*/
-
 .classpath
 .project
 .settings

--- a/swift/src/Ice/Connection.swift
+++ b/swift/src/Ice/Connection.swift
@@ -141,13 +141,13 @@ public protocol ConnectionInfo: AnyObject {
     var connectionId: String { get set }
 }
 
-/// An application can implement this interface to receive notifications when a connection closes.
+/// An application can register a callback to be notified when a connection is closed.
 ///
 /// This method is called by the connection when the connection is closed. If the callback needs more information
 /// about the closure, it can call Connection.throwException.
 ///
 /// - parameter _: `Connection?` The connection that closed.
-public typealias CloseCallback = (Connection?) -> Void
+public typealias CloseCallback = (Connection?) async -> Void
 
 /// The user-level interface to a connection.
 public protocol Connection: AnyObject, CustomStringConvertible {
@@ -195,9 +195,8 @@ public protocol Connection: AnyObject, CustomStringConvertible {
         _ compress: CompressBatch
     ) async throws
 
-    /// Set a close callback on the connection. The callback is called by the connection when it's closed. The callback
-    /// is called from the Ice thread pool associated with the connection. If the callback needs more information about
-    /// the closure, it can call Connection.throwException.
+    /// Set a close callback on the connection. The callback is called (on the global executor) by the connection when
+    /// it's closed. If the callback needs more information about the closure, it can call Connection.throwException.
     ///
     /// - parameter _: `CloseCallback?` The close callback object.
     func setCloseCallback(_ callback: CloseCallback?) throws

--- a/swift/src/Ice/ConnectionI.swift
+++ b/swift/src/Ice/ConnectionI.swift
@@ -66,7 +66,9 @@ class ConnectionI: LocalObject<ICEConnection>, Connection {
 
             try handle.setCloseCallback { c in
                 precondition(c.getCachedSwiftObject(ConnectionI.self) === self)
-                cb(self)
+                Task {
+                    await cb(self)
+                }
             }
         }
     }

--- a/swift/src/IceImpl/Connection.mm
+++ b/swift/src/IceImpl/Connection.mm
@@ -91,7 +91,7 @@
     {
         if (callback)
         {
-             self.connection->setCloseCallback(
+            self.connection->setCloseCallback(
                 [callback](auto connection)
                 {
                     ICEConnection* conn = [ICEConnection getHandle:connection];
@@ -101,7 +101,6 @@
                         callback(conn);
                     }
                 });
-
         }
         else
         {

--- a/swift/src/IceImpl/Connection.mm
+++ b/swift/src/IceImpl/Connection.mm
@@ -89,13 +89,9 @@
 {
     try
     {
-        if (!callback)
+        if (callback)
         {
-            self.connection->setCloseCallback(nullptr);
-        }
-        else
-        {
-            self.connection->setCloseCallback(
+             self.connection->setCloseCallback(
                 [callback](auto connection)
                 {
                     ICEConnection* conn = [ICEConnection getHandle:connection];
@@ -105,6 +101,11 @@
                         callback(conn);
                     }
                 });
+
+        }
+        else
+        {
+            self.connection->setCloseCallback(nullptr);
         }
         return YES;
     }


### PR DESCRIPTION
This PR changes the behavior of the Connection close callback to call back from a Swift global executor thread and not a C++ thread pool thread. It also updates the callback to be async.

I think this is the last place where C++ threads could call into Swift user code.