### PR TITLE
Update macos build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -94,6 +94,7 @@ let package = Package(
                 "src/Ice/Ice.rc",
                 "src/Ice/Makefile.mk",
                 "src/Ice/DLLMain.cpp",
+                "src/Ice/RegisterPluginsInit_min.cpp",
                 "src/Ice/SSL/SchannelEngine.cpp",
                 "src/Ice/SSL/SchannelTransceiverI.cpp",
                 "src/Ice/SSL/OpenSSLTransceiverI.cpp",

--- a/config/Make.project.rules
+++ b/config/Make.project.rules
@@ -1118,7 +1118,6 @@ static_ldflags          += $$(call make-ldflags,$$(call get-all-deps,$4),make-st
 
 # Shared configuration for shared builds
 shared_projects         = %
-shared_objdir           = $(if $(filter-out program,$($1_target)),shared/pic,shared/pie)
 shared_targetrule       = $(if $(filter-out program,$($1_target)),shared)
 shared_cppflags         += $(strip $(call make-lib-cppflags,$4))
 shared_ldflags          += $$(call make-ldflags,$($4_dependencies),make-shared-dep-ldflags,$4,unique)\

--- a/config/Make.rules.Darwin
+++ b/config/Make.rules.Darwin
@@ -33,7 +33,6 @@ endif
 
 # On macos, objects are always PIC/PIE, and executables are always PIE. So there is no need to pass -fPIC or -fPIE to
 # the compiler.
-
 cppflags        = -fvisibility=hidden -Wall -Wextra -Wshadow -Wshadow-all -Wredundant-decls -Wno-shadow-field \
                   -Wdeprecated -Wstrict-prototypes -Werror -Wconversion -Wdocumentation -pthread \
                   $(if $(filter yes,$(OPTIMIZE)),-O2 -DNDEBUG,-g)
@@ -41,6 +40,10 @@ cppflags        = -fvisibility=hidden -Wall -Wextra -Wshadow -Wshadow-all -Wredu
 ifeq ($(MAXWARN),yes)
     cppflags	+=  -Wweak-vtables
 endif
+
+# We compile static and shared with the same flags so we want their .o to share directories.
+static_objdir   = obj
+shared_objdir   = obj
 
 clang_version = $(shell clang -dumpversion 2>&1 | cut -f1 -d\.)
 

--- a/config/Make.rules.Darwin
+++ b/config/Make.rules.Darwin
@@ -31,8 +31,9 @@ MCPP_HOME                      ?= $(shell brew --prefix mcpp)
 LMDB_HOME                      ?= $(shell brew --prefix lmdb)
 endif
 
-# If building objects for a shared library build, enable PIC or PIE:
-shared_cppflags = $(if $(filter-out program,$($1_target)),-fPIC,-fPIE) -fvisibility=hidden
+# On macos, objects are always PIC/PIE, and executables are always PIE. So there is no need to pass -fPIC or -fPIE to
+# the compiler.
+shared_cppflags = -fvisibility=hidden
 
 cppflags        = -Wall -Wextra -Wshadow -Wshadow-all -Wredundant-decls -Wno-shadow-field \
                   -Wdeprecated -Wstrict-prototypes -Werror -Wconversion -Wdocumentation -pthread \

--- a/config/Make.rules.Darwin
+++ b/config/Make.rules.Darwin
@@ -33,9 +33,8 @@ endif
 
 # On macos, objects are always PIC/PIE, and executables are always PIE. So there is no need to pass -fPIC or -fPIE to
 # the compiler.
-shared_cppflags = -fvisibility=hidden
 
-cppflags        = -Wall -Wextra -Wshadow -Wshadow-all -Wredundant-decls -Wno-shadow-field \
+cppflags        = -fvisibility=hidden -Wall -Wextra -Wshadow -Wshadow-all -Wredundant-decls -Wno-shadow-field \
                   -Wdeprecated -Wstrict-prototypes -Werror -Wconversion -Wdocumentation -pthread \
                   $(if $(filter yes,$(OPTIMIZE)),-O2 -DNDEBUG,-g)
 

--- a/config/Make.rules.Linux
+++ b/config/Make.rules.Linux
@@ -128,8 +128,9 @@ endif
 rpath-link-ldflag       = -Wl,-rpath-link,$1
 make-rpath-link-ldflags = $(foreach d,$(filter-out $2,$(call get-all-deps,$1)),$(call rpath-link-ldflag,$($d_targetdir)))
 
-# If building objects for a shared library build, enable PIC or PIE:
+# If building objects for a shared library build, enable PIC or PIE and segregate the objects
 shared_cppflags = $(if $(filter-out program,$($1_target)),-fPIC,-fPIE) -fvisibility=hidden
+shared_objdir   = $(if $(filter-out program,$($1_target)),shared/pic,shared/pie)
 
 # If we are linking a program, add -rpath-link to locate secondary libraries that aren't linked with the executable.
 shared_ldflags      = $(if $(filter-out program,$($1_target)),\

--- a/cpp/config/Make.rules
+++ b/cpp/config/Make.rules
@@ -51,6 +51,7 @@ static_components       = $(coreandstub_components)
 static_projects         = test/Common \
                           test/Ice/% \
                           test/IceSSL/% \
+                          test/IceUtil/stacktrace \
                           test/IceDiscovery/simple \
                           test/Glacier2/application \
                           test/IceGrid/simple

--- a/cpp/src/Glacier2CryptPermissionsVerifier/Makefile.mk
+++ b/cpp/src/Glacier2CryptPermissionsVerifier/Makefile.mk
@@ -6,7 +6,7 @@ $(project)_libraries                            += Glacier2CryptPermissionsVerif
 
 Glacier2CryptPermissionsVerifier_targetdir        := $(libdir)
 Glacier2CryptPermissionsVerifier_dependencies     := Glacier2 Ice
-Glacier2CryptPermissionsVerifier[shared]_cppflags := -DCRYPT_PERMISSIONS_VERIFIER_API_EXPORTS
+Glacier2CryptPermissionsVerifier_cppflags         := -DCRYPT_PERMISSIONS_VERIFIER_API_EXPORTS
 Glacier2CryptPermissionsVerifier_devinstall       := no
 
 projects += $(project)

--- a/cpp/src/Glacier2Lib/Makefile.mk
+++ b/cpp/src/Glacier2Lib/Makefile.mk
@@ -6,7 +6,7 @@ $(project)_libraries    := Glacier2
 
 Glacier2_targetdir              := $(libdir)
 Glacier2_dependencies           := Ice
-Glacier2[shared]_cppflags       := -DGLACIER2_API_EXPORTS
+Glacier2_cppflags               := -DGLACIER2_API_EXPORTS
 Glacier2_sliceflags             := --include-dir Glacier2
 
 projects += $(project)

--- a/cpp/src/Ice/Exception.cpp
+++ b/cpp/src/Ice/Exception.cpp
@@ -47,7 +47,7 @@
 #        endif
 #    endif
 
-#    if !defined(__FreeBSD__) && defined(ICE_API_EXPORTS)
+#    if !defined(__FreeBSD__)
 #        include <cxxabi.h>
 #        include <execinfo.h>
 #        include <stdint.h>

--- a/cpp/src/Ice/Makefile.mk
+++ b/cpp/src/Ice/Makefile.mk
@@ -5,8 +5,7 @@
 $(project)_libraries    = Ice
 
 Ice_targetdir           := $(libdir)
-Ice_cppflags            = $(IceUtil_cppflags)
-Ice[shared]_cppflags    := -DICE_API_EXPORTS
+Ice_cppflags            = -DICE_API_EXPORTS $(IceUtil_cppflags)
 
 Ice_sliceflags          := --include-dir Ice
 Ice_libs                := bz2
@@ -16,7 +15,11 @@ Ice_extra_sources       := $(filter-out src/Ice/SSL/OpenSSL%.cpp src/Ice/SSL/Sch
 else
 Ice_extra_sources       := $(filter-out src/Ice/SSL/SecureTransport%.cpp src/Ice/SSL/Schannel%.cpp, $(wildcard src/Ice/SSL/*.cpp))
 endif
+
 Ice_excludes            = src/Ice/DLLMain.cpp
+Ice[shared]_excludes    = src/Ice/RegisterPluginsInit_min.cpp
+Ice[xcodesdk]_excludes  = src/Ice/RegisterPluginsInit_min.cpp
+Ice[static]_excludes    = src/Ice/RegisterPluginsInit_all.cpp
 
 ifeq ($(os),Linux)
 ifeq ($(shell pkg-config --exists libsystemd 2> /dev/null && echo yes),yes)

--- a/cpp/src/Ice/RegisterPluginsInit_all.cpp
+++ b/cpp/src/Ice/RegisterPluginsInit_all.cpp
@@ -2,9 +2,9 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-#include "RegisterPluginsInit.h"
 #include "Ice/CommunicatorF.h"
 #include "Ice/Initialize.h"
+#include "RegisterPluginsInit.h"
 
 extern "C"
 {

--- a/cpp/src/Ice/RegisterPluginsInit_all.cpp
+++ b/cpp/src/Ice/RegisterPluginsInit_all.cpp
@@ -8,7 +8,6 @@
 
 extern "C"
 {
-    Ice::Plugin* createStringConverter(const Ice::CommunicatorPtr&, const std::string&, const Ice::StringSeq&);
     Ice::Plugin* createIceUDP(const Ice::CommunicatorPtr&, const std::string&, const Ice::StringSeq&);
     Ice::Plugin* createIceTCP(const Ice::CommunicatorPtr&, const std::string&, const Ice::StringSeq&);
     Ice::Plugin* createIceWS(const Ice::CommunicatorPtr&, const std::string&, const Ice::StringSeq&);
@@ -20,11 +19,7 @@ IceInternal::RegisterPluginsInit::RegisterPluginsInit()
     Ice::registerPluginFactory("IceTCP", createIceTCP, true);
     Ice::registerPluginFactory("IceSSL", createIceSSL, true);
 
-    //
-    // Include the UDP and WS transport plugins with non-static builds.
-    //
-#if defined(ICE_API_EXPORTS)
+    // Include the UDP and WS transport plugins with "shared" builds.
     Ice::registerPluginFactory("IceUDP", createIceUDP, true);
     Ice::registerPluginFactory("IceWS", createIceWS, true);
-#endif
 }

--- a/cpp/src/Ice/RegisterPluginsInit_min.cpp
+++ b/cpp/src/Ice/RegisterPluginsInit_min.cpp
@@ -2,9 +2,9 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-#include "RegisterPluginsInit.h"
 #include "Ice/CommunicatorF.h"
 #include "Ice/Initialize.h"
+#include "RegisterPluginsInit.h"
 
 extern "C"
 {

--- a/cpp/src/Ice/RegisterPluginsInit_min.cpp
+++ b/cpp/src/Ice/RegisterPluginsInit_min.cpp
@@ -1,0 +1,19 @@
+//
+// Copyright (c) ZeroC, Inc. All rights reserved.
+//
+
+#include "RegisterPluginsInit.h"
+#include "Ice/CommunicatorF.h"
+#include "Ice/Initialize.h"
+
+extern "C"
+{
+    Ice::Plugin* createIceTCP(const Ice::CommunicatorPtr&, const std::string&, const Ice::StringSeq&);
+    Ice::Plugin* createIceSSL(const Ice::CommunicatorPtr&, const std::string&, const Ice::StringSeq&);
+}
+
+IceInternal::RegisterPluginsInit::RegisterPluginsInit()
+{
+    Ice::registerPluginFactory("IceTCP", createIceTCP, true);
+    Ice::registerPluginFactory("IceSSL", createIceSSL, true);
+}

--- a/cpp/src/Ice/msbuild/ice/ice.vcxproj
+++ b/cpp/src/Ice/msbuild/ice/ice.vcxproj
@@ -563,7 +563,7 @@
     <ClCompile Include="..\..\Proxy.cpp" />
     <ClCompile Include="..\..\Reference.cpp" />
     <ClCompile Include="..\..\ReferenceFactory.cpp" />
-    <ClCompile Include="..\..\RegisterPluginsInit.cpp" />
+    <ClCompile Include="..\..\RegisterPluginsInit_all.cpp" />
     <ClCompile Include="..\..\RequestHandler.cpp" />
     <ClCompile Include="..\..\RetryQueue.cpp" />
     <ClCompile Include="..\..\RouterInfo.cpp" />

--- a/cpp/src/Ice/msbuild/ice/ice.vcxproj.filters
+++ b/cpp/src/Ice/msbuild/ice/ice.vcxproj.filters
@@ -399,7 +399,7 @@
     <ClCompile Include="..\..\ReferenceFactory.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\RegisterPluginsInit.cpp">
+    <ClCompile Include="..\..\RegisterPluginsInit_all.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\RequestHandler.cpp">

--- a/cpp/src/IceBT/Makefile.mk
+++ b/cpp/src/IceBT/Makefile.mk
@@ -11,7 +11,7 @@ $(project)_libraries    := IceBT
 IceBT_targetdir         := $(libdir)
 IceBT_dependencies      := Ice
 IceBT_cppflags          := $(shell pkg-config --cflags dbus-1)
-IceBT[shared]_cppflags  := -DICEBT_API_EXPORTS
+IceBT_cppflags          := -DICEBT_API_EXPORTS
 
 projects += $(project)
 endif

--- a/cpp/src/IceBT/Makefile.mk
+++ b/cpp/src/IceBT/Makefile.mk
@@ -10,8 +10,7 @@ $(project)_libraries    := IceBT
 
 IceBT_targetdir         := $(libdir)
 IceBT_dependencies      := Ice
-IceBT_cppflags          := $(shell pkg-config --cflags dbus-1)
-IceBT_cppflags          := -DICEBT_API_EXPORTS
+IceBT_cppflags          := -DICEBT_API_EXPORTS $(shell pkg-config --cflags dbus-1)
 
 projects += $(project)
 endif

--- a/cpp/src/IceDB/Makefile.mk
+++ b/cpp/src/IceDB/Makefile.mk
@@ -7,7 +7,7 @@ $(project)_libraries    = IceDB
 IceDB_targetdir         := $(libdir)
 IceDB_dependencies      := Ice
 IceDB_libs              := lmdb
-IceDB[shared]_cppflags  := -DICE_DB_API_EXPORTS
+IceDB_cppflags          := -DICE_DB_API_EXPORTS
 IceDB_devinstall        := no
 
 projects += $(project)

--- a/cpp/src/IceDiscovery/Makefile.mk
+++ b/cpp/src/IceDiscovery/Makefile.mk
@@ -6,6 +6,6 @@ $(project)_libraries := IceDiscovery
 
 IceDiscovery_targetdir                  := $(libdir)
 IceDiscovery_dependencies               := Ice
-IceDiscovery[shared]_cppflags           := -DICE_DISCOVERY_API_EXPORTS
+IceDiscovery_cppflags                   := -DICE_DISCOVERY_API_EXPORTS
 
 projects += $(project)

--- a/cpp/src/IceIAP/Makefile.mk
+++ b/cpp/src/IceIAP/Makefile.mk
@@ -9,6 +9,6 @@ IceIAP_platforms        := iphoneos iphonesimulator
 
 IceIAP_targetdir        := $(libdir)
 IceIAP_dependencies     := Ice
-IceIAP[shared]_cppflags := -DICEIAP_API_EXPORTS
+IceIAP_cppflags         := -DICEIAP_API_EXPORTS
 
 projects += $(project)

--- a/cpp/src/IceLocatorDiscovery/Makefile.mk
+++ b/cpp/src/IceLocatorDiscovery/Makefile.mk
@@ -6,6 +6,6 @@ $(project)_libraries := IceLocatorDiscovery
 
 IceLocatorDiscovery_targetdir                   := $(libdir)
 IceLocatorDiscovery_dependencies                := Ice
-IceLocatorDiscovery[shared]_cppflags            := -DICE_LOCATOR_DISCOVERY_API_EXPORTS
+IceLocatorDiscovery_cppflags                    := -DICE_LOCATOR_DISCOVERY_API_EXPORTS
 
 projects += $(project)

--- a/cpp/src/IceXML/Makefile.mk
+++ b/cpp/src/IceXML/Makefile.mk
@@ -6,7 +6,7 @@ $(project)_libraries    := IceXML
 
 IceXML_targetdir        := $(libdir)
 IceXML_dependencies     := Ice
-IceXML[shared]_cppflags := -DICE_XML_API_EXPORTS
+IceXML_cppflags         := -DICE_XML_API_EXPORTS
 IceXML_libs             := expat
 IceXML_devinstall       := no
 

--- a/cpp/test/Common/Makefile.mk
+++ b/cpp/test/Common/Makefile.mk
@@ -12,7 +12,6 @@ $(project)_caninstall   := no
 #
 TestCommon[shared]_targetdir    := $(call mappingdir,$(currentdir),lib)
 TestCommon_dependencies         := Ice
-TestCommon_cppflags             := -I$(includedir) -Itest/include
-TestCommon[shared]_cppflags     := -DTEST_API_EXPORTS
+TestCommon_cppflags             := -DTEST_API_EXPORTS -I$(includedir) -Itest/include
 
 projects += $(project)

--- a/cpp/test/IceUtil/stacktrace/Client.cpp
+++ b/cpp/test/IceUtil/stacktrace/Client.cpp
@@ -98,6 +98,7 @@ Client::run(int, char*[])
     }
     catch (const Ice::Exception& ex)
     {
+        // cerr << ex << endl;
         test(splitLines(ex.ice_stackTrace()).size() >= 3);
     }
     cout << "ok" << endl;

--- a/python/modules/IcePy/Init.cpp
+++ b/python/modules/IcePy/Init.cpp
@@ -133,8 +133,6 @@ PyInit_IcePy(void)
 {
     PyObject* module;
 
-    Ice::registerIceUDP(true);
-    Ice::registerIceWS(true);
     Ice::registerIceDiscovery(false);
     Ice::registerIceLocatorDiscovery(false);
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -98,6 +98,9 @@ def filter_source(filename):
     if "ios/" in filename:
         return False
 
+    if "RegisterPluginsInit_min" in filename:
+        return False
+
     # Bzip2lib sources
     bzip2sources = ["blocksort.c", "bzlib.c", "compress.c", "crctable.c", "decompress.c", "huffman.c", "randtable.c"]
     if "bzip2-" in filename and os.path.basename(filename) not in bzip2sources:

--- a/ruby/extconf.rb
+++ b/ruby/extconf.rb
@@ -51,7 +51,7 @@ Dir["*.cpp"].each do |f|
     $srcs << f
 end
 
-$excluded = ['DLLMain.cpp', 'Main.cpp']
+$excluded = ['DLLMain.cpp', 'Main.cpp', 'RegisterPluginsInit_min.cpp']
 
 def filter(f)
     # Filter sources for each platform.

--- a/ruby/src/IceRuby/Init.cpp
+++ b/ruby/src/IceRuby/Init.cpp
@@ -25,8 +25,6 @@ extern "C"
 {
     void ICE_DECLSPEC_EXPORT Init_IceRuby()
     {
-        Ice::registerIceUDP(true);
-        Ice::registerIceWS(true);
         Ice::registerIceDiscovery(false);
         Ice::registerIceLocatorDiscovery(false);
 

--- a/scripts/Component.py
+++ b/scripts/Component.py
@@ -98,6 +98,7 @@ class Ice(Util.Component):
                     "IceSSL/configuration",
                     "IceDiscovery/simple",
                     "IceGrid/simple",
+                    "IceUtil/stacktrace",
                     "Glacier2/application",
                 ],
                 ["Ice/library", "Ice/plugin"],

--- a/swift/src/IceImpl/IceUtil.mm
+++ b/swift/src/IceImpl/IceUtil.mm
@@ -17,12 +17,8 @@ namespace
     public:
         Init()
         {
-            //
             // Register plug-ins included in the Ice framework (a single binary file)
-            // See also RegisterPluginsInit_min/all.cpp in cpp/src/Ice
-            //
-            Ice::registerIceUDP(true);
-            Ice::registerIceWS(true);
+            // See also RegisterPluginsInit_all.cpp in cpp/src/Ice
             Ice::registerIceDiscovery(false);
             Ice::registerIceLocatorDiscovery(false);
 #if defined(__APPLE__) && TARGET_OS_IPHONE != 0

--- a/swift/src/IceImpl/IceUtil.mm
+++ b/swift/src/IceImpl/IceUtil.mm
@@ -19,7 +19,7 @@ namespace
         {
             //
             // Register plug-ins included in the Ice framework (a single binary file)
-            // See also RegisterPluginsInit.cpp in cpp/src/Ice
+            // See also RegisterPluginsInit_min/all.cpp in cpp/src/Ice
             //
             Ice::registerIceUDP(true);
             Ice::registerIceWS(true);


### PR DESCRIPTION
This PR reworks the build settings, primarily on macos.

On macos, -fPIC and -PIE are not necessary: they do nothing. This gives us the opportunity to use the compile static and shared `.o` with the same flags and reuse them in 'shared' and 'static' builds... and that's exactly what this PR does.

On Linux, we keep (for now) fPIC, fPIE and separate directories as before.