### PR TITLE
Refactor User Exceptions in Java

### DIFF
--- a/java/src/Ice/src/main/java/com/zeroc/Ice/UserException.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/UserException.java
@@ -6,12 +6,6 @@ package com.zeroc.Ice;
 
 /** Base class for exceptions defined in Slice. */
 public abstract class UserException extends java.lang.Exception implements Cloneable {
-  public UserException() {}
-
-  public UserException(Throwable cause) {
-    super(cause);
-  }
-
   /**
    * Creates a copy of this exception.
    *


### PR DESCRIPTION
This PR refactors user-exceptions in Java, like we did in C# and C++ (see #2504).
Most notably, it removes the `Throwable cause` parameter from all `UserException`s.