### PR TITLE
Disable debug Swift Ice/optional test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
             config: "debug"
             build_flags: "OPTIMIZE=no"
             # https://github.com/zeroc-ice/ice/issues/2061
-            test_flags: "--swift-config=debug --rfilter=csharp/Ice/adapterDeactivation"
+            test_flags: "--swift-config=debug --rfilter=csharp/Ice/adapterDeactivation --rfilter=swift/Ice/optional"
           - os: ubuntu-24.04
             config: "debug"
             build_flags: "OPTIMIZE=no"

--- a/swift/test/Package.swift
+++ b/swift/test/Package.swift
@@ -102,8 +102,18 @@ func testPathToTargetName(_ path: String) -> String {
     return path.replacingOccurrences(of: "/", with: "_")
 }
 
+func filterDebugTest(_ key: String, _ value: TestConfig) -> Bool {
+    let skipDebugTests = [
+        // "Ice/operations",
+        "Ice/optional",
+    ]
+    let debugBuild = ProcessInfo.processInfo.environment["OPTIMIZE"] == "no"
+
+    return !debugBuild || !skipDebugTests.contains(key)
+}
+
 var testDriverDependencies = [Target.Dependency]()
-let testTargets = testDirectories.map { (testPath, testConfig) in
+let testTargets = testDirectories.filter(filterDebugTest).map { (testPath, testConfig) in
 
     var targets = [Target]()
 

--- a/swift/test/Package.swift
+++ b/swift/test/Package.swift
@@ -105,7 +105,7 @@ func testPathToTargetName(_ path: String) -> String {
 func filterDebugTest(_ key: String, _ value: TestConfig) -> Bool {
     let skipDebugTests = [
         // "Ice/operations",
-        "Ice/optional",
+        "Ice/optional"
     ]
     let debugBuild = ProcessInfo.processInfo.environment["OPTIMIZE"] == "no"
 


### PR DESCRIPTION
Disable the Swift debug optional test as the compiler often crashes in CI. Maybe it's running out of memory?