### PR TITLE
Add Parameter Names to some Slice Compiler Header Files

### DIFF
--- a/cpp/src/Slice/FileTracker.cpp
+++ b/cpp/src/Slice/FileTracker.cpp
@@ -1,6 +1,4 @@
-//
-// Copyright (c) ZeroC, Inc. All rights reserved.
-//
+// Copyright (c) ZeroC, Inc.
 
 #include "FileTracker.h"
 #include "../Ice/ConsoleUtil.h"

--- a/cpp/src/Slice/FileTracker.h
+++ b/cpp/src/Slice/FileTracker.h
@@ -1,6 +1,4 @@
-//
-// Copyright (c) ZeroC, Inc. All rights reserved.
-//
+// Copyright (c) ZeroC, Inc.
 
 #ifndef FILE_TRACKER_H
 #define FILE_TRACKER_H
@@ -27,9 +25,9 @@ namespace Slice
 
         static FileTrackerPtr instance();
 
-        void setSource(const std::string&);
-        void addFile(const std::string&);
-        void addDirectory(const std::string&);
+        void setSource(const std::string& source);
+        void addFile(const std::string& file);
+        void addDirectory(const std::string& dir);
         void error();
         void cleanup();
         void dumpxml();

--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -3661,7 +3661,7 @@ yyreduce:
         case 160: /* type: ICE_OBJECT '*'  */
 #line 1905 "src/Slice/Grammar.y"
         {
-            yyval = currentUnit->builtin(Builtin::KindObjectProxy);
+            yyval = currentUnit->createBuiltin(Builtin::KindObjectProxy);
         }
 #line 3787 "src/Slice/Grammar.cpp"
         break;
@@ -3670,7 +3670,7 @@ yyreduce:
 #line 1909 "src/Slice/Grammar.y"
         {
             auto typeName = dynamic_pointer_cast<StringTok>(yyvsp[0]);
-            yyval = currentUnit->builtin(Builtin::kindFromString(typeName->v).value());
+            yyval = currentUnit->createBuiltin(Builtin::kindFromString(typeName->v).value());
         }
 #line 3796 "src/Slice/Grammar.cpp"
         break;
@@ -3787,7 +3787,7 @@ yyreduce:
         case 168: /* const_initializer: ICE_INTEGER_LITERAL  */
 #line 2014 "src/Slice/Grammar.y"
         {
-            BuiltinPtr type = currentUnit->builtin(Builtin::KindLong);
+            BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindLong);
             auto intVal = dynamic_pointer_cast<IntegerTok>(yyvsp[0]);
             ostringstream sstr;
             sstr << intVal->v;
@@ -3800,7 +3800,7 @@ yyreduce:
         case 169: /* const_initializer: ICE_FLOATING_POINT_LITERAL  */
 #line 2023 "src/Slice/Grammar.y"
         {
-            BuiltinPtr type = currentUnit->builtin(Builtin::KindDouble);
+            BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindDouble);
             auto floatVal = dynamic_pointer_cast<FloatingTok>(yyvsp[0]);
             ostringstream sstr;
             sstr << floatVal->v;
@@ -3852,7 +3852,7 @@ yyreduce:
         case 171: /* const_initializer: ICE_STRING_LITERAL  */
 #line 2067 "src/Slice/Grammar.y"
         {
-            BuiltinPtr type = currentUnit->builtin(Builtin::KindString);
+            BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindString);
             auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto def = make_shared<ConstDefTok>(type, literal->v, literal->literal);
             yyval = def;
@@ -3863,7 +3863,7 @@ yyreduce:
         case 172: /* const_initializer: ICE_FALSE  */
 #line 2074 "src/Slice/Grammar.y"
         {
-            BuiltinPtr type = currentUnit->builtin(Builtin::KindBool);
+            BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindBool);
             auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto def = make_shared<ConstDefTok>(type, "false", "false");
             yyval = def;
@@ -3874,7 +3874,7 @@ yyreduce:
         case 173: /* const_initializer: ICE_TRUE  */
 #line 2081 "src/Slice/Grammar.y"
         {
-            BuiltinPtr type = currentUnit->builtin(Builtin::KindBool);
+            BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindBool);
             auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
             auto def = make_shared<ConstDefTok>(type, "true", "true");
             yyval = def;

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -1,8 +1,6 @@
 %code top{
 
-//
-// Copyright (c) ZeroC, Inc. All rights reserved.
-//
+// Copyright (c) ZeroC, Inc.
 
 }
 
@@ -1903,12 +1901,12 @@ type
 // ----------------------------------------------------------------------
 : ICE_OBJECT '*'
 {
-    $$ = currentUnit->builtin(Builtin::KindObjectProxy);
+    $$ = currentUnit->createBuiltin(Builtin::KindObjectProxy);
 }
 | builtin
 {
     auto typeName = dynamic_pointer_cast<StringTok>($1);
-    $$ = currentUnit->builtin(Builtin::kindFromString(typeName->v).value());
+    $$ = currentUnit->createBuiltin(Builtin::kindFromString(typeName->v).value());
 }
 | scoped_name
 {
@@ -2012,7 +2010,7 @@ const_initializer
 // ----------------------------------------------------------------------
 : ICE_INTEGER_LITERAL
 {
-    BuiltinPtr type = currentUnit->builtin(Builtin::KindLong);
+    BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindLong);
     auto intVal = dynamic_pointer_cast<IntegerTok>($1);
     ostringstream sstr;
     sstr << intVal->v;
@@ -2021,7 +2019,7 @@ const_initializer
 }
 | ICE_FLOATING_POINT_LITERAL
 {
-    BuiltinPtr type = currentUnit->builtin(Builtin::KindDouble);
+    BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindDouble);
     auto floatVal = dynamic_pointer_cast<FloatingTok>($1);
     ostringstream sstr;
     sstr << floatVal->v;
@@ -2065,21 +2063,21 @@ const_initializer
 }
 | ICE_STRING_LITERAL
 {
-    BuiltinPtr type = currentUnit->builtin(Builtin::KindString);
+    BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindString);
     auto literal = dynamic_pointer_cast<StringTok>($1);
     auto def = make_shared<ConstDefTok>(type, literal->v, literal->literal);
     $$ = def;
 }
 | ICE_FALSE
 {
-    BuiltinPtr type = currentUnit->builtin(Builtin::KindBool);
+    BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindBool);
     auto literal = dynamic_pointer_cast<StringTok>($1);
     auto def = make_shared<ConstDefTok>(type, "false", "false");
     $$ = def;
 }
 | ICE_TRUE
 {
-    BuiltinPtr type = currentUnit->builtin(Builtin::KindBool);
+    BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindBool);
     auto literal = dynamic_pointer_cast<StringTok>($1);
     auto def = make_shared<ConstDefTok>(type, "true", "true");
     $$ = def;

--- a/cpp/src/Slice/GrammarUtil.h
+++ b/cpp/src/Slice/GrammarUtil.h
@@ -1,6 +1,4 @@
-//
-// Copyright (c) ZeroC, Inc. All rights reserved.
-//
+// Copyright (c) ZeroC, Inc.
 
 #ifndef SLICE_GRAMMAR_UTIL_H
 #define SLICE_GRAMMAR_UTIL_H

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1,6 +1,4 @@
-//
-// Copyright (c) ZeroC, Inc. All rights reserved.
-//
+// Copyright (c) ZeroC, Inc.
 
 #include "Parser.h"
 #include "GrammarUtil.h"
@@ -189,24 +187,7 @@ Slice::DefinitionContext::warning(WarningCategory category, const string& file, 
 }
 
 void
-Slice::DefinitionContext::warning(WarningCategory category, const string& file, const string& line, const string& msg)
-    const
-{
-    if (!suppressWarning(category))
-    {
-        emitWarning(file, line, msg);
-    }
-}
-
-void
 Slice::DefinitionContext::error(const string& file, int line, const string& msg) const
-{
-    emitError(file, line, msg);
-    throw CompilerException(__FILE__, __LINE__, msg);
-}
-
-void
-Slice::DefinitionContext::error(const string& file, const string& line, const string& msg) const
 {
     emitError(file, line, msg);
     throw CompilerException(__FILE__, __LINE__, msg);
@@ -256,7 +237,7 @@ Slice::DefinitionContext::initSuppressedWarnings()
                 {
                     ostringstream os;
                     os << "invalid category `" << s << "' in file metadata suppress-warning";
-                    warning(InvalidMetaData, "", "", os.str());
+                    warning(InvalidMetaData, "", -1, os.str());
                 }
             }
         }
@@ -577,7 +558,7 @@ Slice::Contained::file() const
     return _file;
 }
 
-string
+int
 Slice::Contained::line() const
 {
     return _line;
@@ -1039,7 +1020,7 @@ Slice::Contained::Contained(const ContainerPtr& container, const string& name)
     _scoped += "::" + _name;
     assert(_unit);
     _file = _unit->currentFile();
-    _line = std::to_string(_unit->currentLine());
+    _line = _unit->currentLine();
     _comment = _unit->currentComment();
     _includeLevel = _unit->currentIncludeLevel();
 }
@@ -1702,7 +1683,7 @@ Slice::Container::lookupType(const string& scoped, bool printError)
     auto kind = Builtin::kindFromString(sc);
     if (kind)
     {
-        return {_unit->builtin(kind.value())};
+        return {_unit->createBuiltin(kind.value())};
     }
 
     // Not a builtin type, try to look up a constructed type.
@@ -5244,7 +5225,7 @@ Slice::Unit::visit(ParserVisitor* visitor, bool all)
 }
 
 BuiltinPtr
-Slice::Unit::builtin(Builtin::Kind kind)
+Slice::Unit::createBuiltin(Builtin::Kind kind)
 {
     map<Builtin::Kind, BuiltinPtr>::const_iterator p = _builtins.find(kind);
     if (p != _builtins.end())

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -1,6 +1,4 @@
-//
-// Copyright (c) ZeroC, Inc. All rights reserved.
-//
+// Copyright (c) ZeroC, Inc.
 
 #ifndef SLICE_PARSER_H
 #define SLICE_PARSER_H
@@ -220,10 +218,8 @@ namespace Slice
         // Emit warning unless filtered out by [["suppress-warning"]]
         //
         void warning(WarningCategory, const std::string&, int, const std::string&) const;
-        void warning(WarningCategory, const std::string&, const std::string&, const std::string&) const;
 
         void error(const std::string&, int, const std::string&) const;
-        void error(const std::string&, const std::string&, const std::string&) const;
 
     private:
         bool suppressWarning(WarningCategory) const;
@@ -377,7 +373,7 @@ namespace Slice
         std::string scope() const;
         std::string flattenedScope() const;
         std::string file() const;
-        std::string line() const;
+        int line() const;
         std::string comment() const;
         CommentPtr parseComment(const std::string&, bool) const;
         CommentPtr parseComment(bool) const;
@@ -413,7 +409,7 @@ namespace Slice
         std::string _name;
         std::string _scoped;
         std::string _file;
-        std::string _line;
+        int _line;
         std::string _comment;
         int _includeLevel;
         std::list<std::string> _metaData;
@@ -1065,10 +1061,11 @@ namespace Slice
         void destroy() final;
         void visit(ParserVisitor*, bool) final;
 
-        BuiltinPtr builtin(Builtin::Kind); // Not const, as builtins are created on the fly. (Lazy initialization.)
+        // Not const, as builtins are created on the fly. (Lazy initialization.)
+        BuiltinPtr createBuiltin(Builtin::Kind kind);
 
-        void addTopLevelModule(const std::string&, const std::string&);
-        std::set<std::string> getTopLevelModules(const std::string&) const;
+        void addTopLevelModule(const std::string& file, const std::string& module);
+        std::set<std::string> getTopLevelModules(const std::string& file) const;
 
     private:
         void init();

--- a/cpp/src/Slice/Preprocessor.cpp
+++ b/cpp/src/Slice/Preprocessor.cpp
@@ -127,8 +127,7 @@ Slice::Preprocessor::normalizeIncludePath(const string& path)
 
 namespace
 {
-    vector<string>
-    baseArgs(vector<string> args, bool keepComments, const string& languageArg, const string& fileName)
+    vector<string> baseArgs(vector<string> args, bool keepComments, const string& languageArg, const string& fileName)
     {
         if (keepComments)
         {

--- a/cpp/src/Slice/Preprocessor.h
+++ b/cpp/src/Slice/Preprocessor.h
@@ -1,6 +1,4 @@
-//
-// Copyright (c) ZeroC, Inc. All rights reserved.
-//
+// Copyright (c) ZeroC, Inc.
 
 #ifndef PREPROCESSOR_H
 #define PREPROCESSOR_H
@@ -17,13 +15,15 @@ namespace Slice
     class Preprocessor final
     {
     public:
-        static PreprocessorPtr create(const std::string&, const std::string&, const std::vector<std::string>&);
+        static PreprocessorPtr create(
+            const std::string& path,
+            const std::string& fileName,
+            const std::vector<std::string>& args);
 
-        Preprocessor(const std::string&, const std::string&, const std::vector<std::string>&);
+        Preprocessor(const std::string& path, const std::string& fileName, const std::vector<std::string>& args);
         ~Preprocessor();
 
-        FILE* preprocess(bool, const std::string& = "");
-        FILE* preprocess(bool, const std::vector<std::string>&);
+        FILE* preprocess(bool keepComments, const std::string& languageArg = "");
         bool close();
 
         enum Language
@@ -43,25 +43,16 @@ namespace Slice
         };
 
         bool printMakefileDependencies(
-            std::ostream&,
-            Language,
-            const std::vector<std::string>&,
-            const std::string& = "",
-            const std::string& = "cpp",
-            const std::string& = "");
-        bool printMakefileDependencies(
-            std::ostream&,
-            Language,
-            const std::vector<std::string>&,
-            const std::vector<std::string>&,
-            const std::string& = "cpp",
-            const std::string& = "");
+            std::ostream& out,
+            Language lang,
+            const std::vector<std::string>& includePaths,
+            const std::string& languageArg = "",
+            const std::string& optValue = "");
 
         std::string getFileName();
         std::string getBaseName();
 
-        static std::string addQuotes(const std::string&);
-        static std::string normalizeIncludePath(const std::string&);
+        static std::string normalizeIncludePath(const std::string& path);
 
     private:
         bool checkInputFile();

--- a/cpp/src/Slice/Preprocessor.h
+++ b/cpp/src/Slice/Preprocessor.h
@@ -15,10 +15,8 @@ namespace Slice
     class Preprocessor final
     {
     public:
-        static PreprocessorPtr create(
-            const std::string& path,
-            const std::string& fileName,
-            const std::vector<std::string>& args);
+        static PreprocessorPtr
+        create(const std::string& path, const std::string& fileName, const std::vector<std::string>& args);
 
         Preprocessor(const std::string& path, const std::string& fileName, const std::vector<std::string>& args);
         ~Preprocessor();

--- a/cpp/src/Slice/Scanner.l
+++ b/cpp/src/Slice/Scanner.l
@@ -1,7 +1,5 @@
 %top{
-//
-// Copyright (c) ZeroC, Inc. All rights reserved.
-//
+// Copyright (c) ZeroC, Inc.
 
 #include "../Ice/ScannerConfig.h"
 #include <cstdint>

--- a/cpp/src/Slice/SliceUtil.cpp
+++ b/cpp/src/Slice/SliceUtil.cpp
@@ -1,6 +1,4 @@
-//
-// Copyright (c) ZeroC, Inc. All rights reserved.
-//
+// Copyright (c) ZeroC, Inc.
 
 #include "../Ice/ConsoleUtil.h"
 #include "../Ice/FileUtil.h"
@@ -242,36 +240,6 @@ Slice::emitWarning(const string& file, int line, const string& message)
 }
 
 void
-Slice::emitError(const string& file, const std::string& line, const string& message)
-{
-    if (!file.empty())
-    {
-        consoleErr << file;
-        if (!line.empty())
-        {
-            consoleErr << ':' << line;
-        }
-        consoleErr << ": ";
-    }
-    consoleErr << message << endl;
-}
-
-void
-Slice::emitWarning(const string& file, const std::string& line, const string& message)
-{
-    if (!file.empty())
-    {
-        consoleErr << file;
-        if (!line.empty())
-        {
-            consoleErr << ':' << line;
-        }
-        consoleErr << ": ";
-    }
-    consoleErr << "warning: " << message << endl;
-}
-
-void
 Slice::emitRaw(const char* message)
 {
     consoleErr << message << flush;
@@ -470,19 +438,19 @@ Slice::prependA(const string& s)
 }
 
 bool
-Slice::checkIdentifier(const string& id)
+Slice::checkIdentifier(const string& identifier)
 {
     // check whether the identifier is scoped
-    size_t scopeIndex = id.rfind("::");
+    size_t scopeIndex = identifier.rfind("::");
     bool isScoped = scopeIndex != string::npos;
     string name;
     if (isScoped)
     {
-        name = id.substr(scopeIndex + 2); // Only check the unscoped identifier for syntax
+        name = identifier.substr(scopeIndex + 2); // Only check the unscoped identifier for syntax
     }
     else
     {
-        name = id;
+        name = identifier;
     }
 
     assert(!name.empty());

--- a/cpp/src/Slice/StringLiteralUtil.cpp
+++ b/cpp/src/Slice/StringLiteralUtil.cpp
@@ -1,6 +1,4 @@
-//
-// Copyright (c) ZeroC, Inc. All rights reserved.
-//
+// Copyright (c) ZeroC, Inc.
 
 #include "Util.h"
 

--- a/cpp/src/Slice/Util.h
+++ b/cpp/src/Slice/Util.h
@@ -1,6 +1,4 @@
-//
-// Copyright (c) ZeroC, Inc. All rights reserved.
-//
+// Copyright (c) ZeroC, Inc.
 
 #ifndef SLICE_UTIL_H
 #define SLICE_UTIL_H
@@ -10,16 +8,17 @@
 
 namespace Slice
 {
-    std::string fullPath(const std::string&);
-    std::string changeInclude(const std::string&, const std::vector<std::string>&);
-    std::string removeExtension(const std::string&);
-    void emitError(const std::string&, int, const std::string&);
-    void emitWarning(const std::string&, int, const std::string&);
-    void emitError(const std::string&, const std::string&, const std::string&);
-    void emitWarning(const std::string&, const std::string&, const std::string&);
-    void emitRaw(const char*);
-    std::vector<std::string> filterMcppWarnings(const std::string&);
-    void printGeneratedHeader(IceInternal::Output& out, const std::string&, const std::string& commentStyle = "//");
+    std::string fullPath(const std::string& path);
+    std::string changeInclude(const std::string& path, const std::vector<std::string>& includePaths);
+    std::string removeExtension(const std::string& path);
+    void emitError(const std::string& file, int line, const std::string& message);
+    void emitWarning(const std::string& file, int line, const std::string& message);
+    void emitRaw(const char* message);
+    std::vector<std::string> filterMcppWarnings(const std::string& message);
+    void printGeneratedHeader(
+        IceInternal::Output& out,
+        const std::string& path,
+        const std::string& commentStyle = "//");
 #ifdef _WIN32
     std::vector<std::string> argvToArgs(int argc, wchar_t* argv[]);
 #else
@@ -46,17 +45,22 @@ namespace Slice
     //                        Matlab syntax, or ECMAScript 6-style UCNs with \u{...} for astral characters.
     // unsigned char cutOff: characters < cutOff other than the nonPrintableEscaped are generated as
     //                       octal escape sequences, regardless of escapeMode.
-    std::string toStringLiteral(const std::string&, const std::string&, const std::string&, EscapeMode, unsigned char);
+    std::string toStringLiteral(
+        const std::string& value,
+        const std::string& nonPrintableEscaped,
+        const std::string& printableEscaped,
+        EscapeMode escapeMode,
+        unsigned char cutOff);
 
-    void writeDependencies(const std::string&, const std::string&);
+    void writeDependencies(const std::string& dependencies, const std::string& dependFile);
 
-    std::vector<std::string> splitScopedName(const std::string&, bool = true);
+    std::vector<std::string> splitScopedName(const std::string& scoped, bool allowEmpty = true);
 
     // return a or an <s>
-    std::string prependA(const std::string&);
+    std::string prependA(const std::string& s);
 
-    // Checks an identifier for illegal syntax and reports any that is present.
-    bool checkIdentifier(const std::string&);
+    // Checks an identifier for illegal syntax and reports any errors that are present.
+    bool checkIdentifier(const std::string& identifier);
 
     bool isProxyType(const TypePtr& type);
 }

--- a/cpp/src/Slice/Util.h
+++ b/cpp/src/Slice/Util.h
@@ -15,10 +15,8 @@ namespace Slice
     void emitWarning(const std::string& file, int line, const std::string& message);
     void emitRaw(const char* message);
     std::vector<std::string> filterMcppWarnings(const std::string& message);
-    void printGeneratedHeader(
-        IceInternal::Output& out,
-        const std::string& path,
-        const std::string& commentStyle = "//");
+    void
+    printGeneratedHeader(IceInternal::Output& out, const std::string& path, const std::string& commentStyle = "//");
 #ifdef _WIN32
     std::vector<std::string> argvToArgs(int argc, wchar_t* argv[]);
 #else

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -885,16 +885,16 @@ Slice::Gen::validateMetaData(const UnitPtr& u)
 }
 
 bool
-Slice::Gen::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
+Slice::Gen::MetaDataVisitor::visitUnitStart(const UnitPtr& unit)
 {
     static const string prefix = "cpp:";
 
     //
     // Validate file metadata in the top-level file and all included files.
     //
-    for (const string& file : p->allFiles())
+    for (const string& file : unit->allFiles())
     {
-        DefinitionContextPtr dc = p->findDefinitionContext(file);
+        DefinitionContextPtr dc = unit->findDefinitionContext(file);
         StringList globalMetaData = dc->getMetaData();
         assert(dc);
         int headerExtension = 0;
@@ -1094,7 +1094,7 @@ Slice::Gen::MetaDataVisitor::validate(
     const SyntaxTreeBasePtr& cont,
     const StringList& metaData,
     const string& file,
-    const string& line,
+    int line,
     bool operation)
 {
     static const string cppPrefix = "cpp:";
@@ -1399,9 +1399,9 @@ Slice::Gen::ForwardDeclVisitor::visitConst(const ConstPtr& p)
 Slice::Gen::DefaultFactoryVisitor::DefaultFactoryVisitor(Output& c) : C(c), _factoryTableInitDone(false) {}
 
 bool
-Slice::Gen::DefaultFactoryVisitor::visitUnitStart(const UnitPtr& p)
+Slice::Gen::DefaultFactoryVisitor::visitUnitStart(const UnitPtr& unit)
 {
-    if (p->contains<ClassDef>() || p->contains<Exception>())
+    if (unit->contains<ClassDef>() || unit->contains<Exception>())
     {
         C << sp << nl << "namespace" << nl << "{";
         C.inc();

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -221,7 +221,7 @@ namespace Slice
 
         private:
             StringList
-            validate(const SyntaxTreeBasePtr&, const StringList&, const std::string&, const std::string&, bool = false);
+            validate(const SyntaxTreeBasePtr&, const StringList&, const std::string&, int, bool = false);
         };
 
         static void validateMetaData(const UnitPtr&);

--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -231,7 +231,6 @@ compile(const vector<string>& argv)
                     depend ? Preprocessor::CPlusPlus : Preprocessor::SliceXML,
                     includePaths,
                     "-D__SLICE2CPP__",
-                    sourceExtension,
                     ext))
             {
                 return EXIT_FAILURE;

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1989,16 +1989,12 @@ Slice::CsGenerator::validateMetaData(const UnitPtr& u)
 }
 
 bool
-Slice::CsGenerator::MetaDataVisitor::visitUnitStart(const UnitPtr& p)
+Slice::CsGenerator::MetaDataVisitor::visitUnitStart(const UnitPtr& unit)
 {
-    //
     // Validate file metadata in the top-level file and all included files.
-    //
-    StringList files = p->allFiles();
-    for (StringList::iterator q = files.begin(); q != files.end(); ++q)
+    for (const auto& file : unit->allFiles())
     {
-        string file = *q;
-        DefinitionContextPtr dc = p->findDefinitionContext(file);
+        DefinitionContextPtr dc = unit->findDefinitionContext(file);
         assert(dc);
         StringList globalMetaData = dc->getMetaData();
         StringList newGlobalMetaData;

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1540,26 +1540,25 @@ Slice::Gen::printHeader()
 Slice::Gen::UnitVisitor::UnitVisitor(IceInternal::Output& out) : CsVisitor(out) {}
 
 bool
-Slice::Gen::UnitVisitor::visitUnitStart(const UnitPtr& p)
+Slice::Gen::UnitVisitor::visitUnitStart(const UnitPtr& unit)
 {
-    DefinitionContextPtr dc = p->findDefinitionContext(p->topLevelFile());
+    DefinitionContextPtr dc = unit->findDefinitionContext(unit->topLevelFile());
     assert(dc);
-    StringList globalMetaData = dc->getMetaData();
 
     static const string attributePrefix = "cs:attribute:";
 
     bool sep = false;
-    for (StringList::const_iterator q = globalMetaData.begin(); q != globalMetaData.end(); ++q)
+    for (const auto metadata : dc->getMetaData())
     {
-        string::size_type pos = q->find(attributePrefix);
-        if (pos == 0 && q->size() > attributePrefix.size())
+        string::size_type pos = metadata.find(attributePrefix);
+        if (pos == 0 && metadata.size() > attributePrefix.size())
         {
             if (!sep)
             {
                 _out << sp;
                 sep = true;
             }
-            string attrib = q->substr(pos + attributePrefix.size());
+            string attrib = metadata.substr(pos + attributePrefix.size());
             _out << nl << '[' << attrib << ']';
         }
     }

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1548,7 +1548,7 @@ Slice::Gen::UnitVisitor::visitUnitStart(const UnitPtr& unit)
     static const string attributePrefix = "cs:attribute:";
 
     bool sep = false;
-    for (const auto metadata : dc->getMetaData())
+    for (const auto& metadata : dc->getMetaData())
     {
         string::size_type pos = metadata.find(attributePrefix);
         if (pos == 0 && metadata.size() > attributePrefix.size())

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -78,19 +78,14 @@ namespace
     class MetaDataVisitor final : public ParserVisitor
     {
     public:
-        bool visitUnitStart(const UnitPtr& p) final
+        bool visitUnitStart(const UnitPtr& unit) final
         {
             static const string prefix = "java:";
 
-            //
             // Validate file metadata in the top-level file and all included files.
-            //
-            StringList files = p->allFiles();
-
-            for (StringList::iterator q = files.begin(); q != files.end(); ++q)
+            for (const auto& file : unit->allFiles())
             {
-                string file = *q;
-                DefinitionContextPtr dc = p->findDefinitionContext(file);
+                DefinitionContextPtr dc = unit->findDefinitionContext(file);
                 assert(dc);
                 StringList globalMetaData = dc->getMetaData();
                 for (StringList::const_iterator r = globalMetaData.begin(); r != globalMetaData.end();)
@@ -105,7 +100,7 @@ namespace
                         }
                         else
                         {
-                            dc->warning(InvalidMetaData, file, "", "ignoring invalid file metadata `" + s + "'");
+                            dc->warning(InvalidMetaData, file, -1, "ignoring invalid file metadata `" + s + "'");
                             globalMetaData.remove(s);
                             continue;
                         }
@@ -219,7 +214,7 @@ namespace
             StringList newMetaData;
 
             const string file = p->file();
-            const string line = p->line();
+            int line = p->line();
             const UnitPtr unt = p->unit();
             const DefinitionContextPtr dc = unt->findDefinitionContext(file);
 
@@ -386,7 +381,7 @@ namespace
         }
 
         StringList
-        validateType(const SyntaxTreeBasePtr& p, const StringList& metaData, const string& file, const string& line)
+        validateType(const SyntaxTreeBasePtr& p, const StringList& metaData, const string& file, int line)
         {
             const UnitPtr unt = p->unit();
             const DefinitionContextPtr dc = unt->findDefinitionContext(file);
@@ -475,7 +470,7 @@ namespace
         }
 
         StringList
-        validateGetSet(const SyntaxTreeBasePtr& p, const StringList& metaData, const string& file, const string& line)
+        validateGetSet(const SyntaxTreeBasePtr& p, const StringList& metaData, const string& file, int line)
         {
             const UnitPtr unt = p->unit();
             const DefinitionContextPtr dc = unt->findDefinitionContext(file);
@@ -528,7 +523,7 @@ Slice::getSerialVersionUID(const ContainedPtr& p)
             os << "missing serialVersionUID value for " << p->kindOf() << " `" << p->scoped()
                << "'; generating default value";
             const DefinitionContextPtr dc = p->unit()->findDefinitionContext(p->file());
-            dc->warning(InvalidMetaData, "", "", os.str());
+            dc->warning(InvalidMetaData, "", -1, os.str());
         }
         else
         {
@@ -543,7 +538,7 @@ Slice::getSerialVersionUID(const ContainedPtr& p)
                 os << "ignoring invalid serialVersionUID for " << p->kindOf() << " `" << p->scoped()
                    << "'; generating default value";
                 const DefinitionContextPtr dc = p->unit()->findDefinitionContext(p->file());
-                dc->warning(InvalidMetaData, "", "", os.str());
+                dc->warning(InvalidMetaData, "", -1, os.str());
             }
         }
     }

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -380,8 +380,7 @@ namespace
             return result;
         }
 
-        StringList
-        validateType(const SyntaxTreeBasePtr& p, const StringList& metaData, const string& file, int line)
+        StringList validateType(const SyntaxTreeBasePtr& p, const StringList& metaData, const string& file, int line)
         {
             const UnitPtr unt = p->unit();
             const DefinitionContextPtr dc = unt->findDefinitionContext(file);
@@ -469,8 +468,7 @@ namespace
             return newMetaData;
         }
 
-        StringList
-        validateGetSet(const SyntaxTreeBasePtr& p, const StringList& metaData, const string& file, int line)
+        StringList validateGetSet(const SyntaxTreeBasePtr& p, const StringList& metaData, const string& file, int line)
         {
             const UnitPtr unt = p->unit();
             const DefinitionContextPtr dc = unt->findDefinitionContext(file);

--- a/cpp/src/slice2java/Main.cpp
+++ b/cpp/src/slice2java/Main.cpp
@@ -171,9 +171,6 @@ compile(const vector<string>& argv)
         os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<dependencies>" << endl;
     }
 
-    vector<string> cppOpts;
-    cppOpts.push_back("-D__SLICE2JAVA__");
-
     for (vector<string>::const_iterator i = args.begin(); i != args.end(); ++i)
     {
         //
@@ -188,7 +185,7 @@ compile(const vector<string>& argv)
         if (depend || dependxml)
         {
             PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
-            FILE* cppHandle = icecpp->preprocess(false, cppOpts);
+            FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2JAVA__");
 
             if (cppHandle == 0)
             {
@@ -208,7 +205,7 @@ compile(const vector<string>& argv)
                     os,
                     depend ? Preprocessor::Java : Preprocessor::SliceXML,
                     includePaths,
-                    cppOpts))
+                    "-D__SLICE2JAVA__"))
             {
                 return EXIT_FAILURE;
             }
@@ -223,7 +220,7 @@ compile(const vector<string>& argv)
             FileTracker::instance()->setSource(*i);
 
             PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
-            FILE* cppHandle = icecpp->preprocess(true, cppOpts);
+            FILE* cppHandle = icecpp->preprocess(true, "-D__SLICE2JAVA__");
 
             if (cppHandle == 0)
             {

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -2120,20 +2120,20 @@ Slice::Gen::TypeScriptImportVisitor::addImport(const ContainedPtr& definition)
 }
 
 bool
-Slice::Gen::TypeScriptImportVisitor::visitUnitStart(const UnitPtr& p)
+Slice::Gen::TypeScriptImportVisitor::visitUnitStart(const UnitPtr& unit)
 {
-    _module = getJavaScriptModule(p->findDefinitionContext(p->topLevelFile()));
-    _filename = p->topLevelFile();
+    _module = getJavaScriptModule(unit->findDefinitionContext(unit->topLevelFile()));
+    _filename = unit->topLevelFile();
     if (_module != "ice")
     {
         _importedModules.insert("ice");
     }
-    StringList includes = p->includeFiles();
+    StringList includes = unit->includeFiles();
     // Iterate all the included files and generate an import statement for each top-level module in the included file.
     for (const auto& included : includes)
     {
         // The JavaScript module corresponding to the "js:module:" metadata in the included file.
-        string jsImportedModule = getJavaScriptModule(p->findDefinitionContext(included));
+        string jsImportedModule = getJavaScriptModule(unit->findDefinitionContext(included));
 
         if (_module != jsImportedModule)
         {
@@ -2454,9 +2454,9 @@ Slice::Gen::TypeScriptVisitor::TypeScriptVisitor(
 }
 
 bool
-Slice::Gen::TypeScriptVisitor::visitUnitStart(const UnitPtr& p)
+Slice::Gen::TypeScriptVisitor::visitUnitStart(const UnitPtr& unit)
 {
-    _module = getJavaScriptModule(p->findDefinitionContext(p->topLevelFile()));
+    _module = getJavaScriptModule(unit->findDefinitionContext(unit->topLevelFile()));
     _iceImportPrefix = _module == "ice" ? "" : "__module_ice.";
     if (!_module.empty())
     {

--- a/cpp/src/slice2py/Python.cpp
+++ b/cpp/src/slice2py/Python.cpp
@@ -577,7 +577,6 @@ Slice::Python::compile(const vector<string>& argv)
                     depend ? Preprocessor::Python : Preprocessor::SliceXML,
                     includePaths,
                     "-D__SLICE2PY__",
-                    "",
                     prefix))
             {
                 return EXIT_FAILURE;

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -2504,10 +2504,9 @@ bool
 SwiftGenerator::MetaDataVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
     p->setMetaData(validate(p, p->getMetaData(), p->file(), p->line()));
-    DataMemberList members = p->dataMembers();
-    for (DataMemberList::iterator q = members.begin(); q != members.end(); ++q)
+    for (auto& member : p->dataMembers())
     {
-        (*q)->setMetaData(validate((*q)->type(), (*q)->getMetaData(), p->file(), (*q)->line()));
+        member->setMetaData(validate(member->type(), member->getMetaData(), p->file(), member->line()));
     }
     return true;
 }
@@ -2628,7 +2627,7 @@ SwiftGenerator::MetaDataVisitor::validate(
     const SyntaxTreeBasePtr& cont,
     const StringList& metaData,
     const string& file,
-    const string& line,
+    int line,
     bool local,
     bool operationParameter)
 {

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -170,7 +170,7 @@ namespace Slice
                 const SyntaxTreeBasePtr&,
                 const StringList&,
                 const std::string&,
-                const std::string&,
+                int,
                 bool local = false,
                 bool operationParameter = false);
 


### PR DESCRIPTION
This PR adds names to function parameters in header files, but only in the `cpp/src/Slice` directory,
and not including `Parser.h`. That file is going to be it's own PR, because it has 6000 lines of code in total, and  _many_ of the parameter names we do have are literally just `p`... So I'm going to also fix those names as well.

I did update some names which were bad in other files, but only when the logic was obvious at a glance.
I also deleted some dead code that I stumbled across.

Finally, we had 2 overloads for reporting errors/warnings, the only difference was that one took a `string lineNumber` and the other took an `int lineNumber`. 95% of the time, we'd pass an int, and an int is always sufficient. So I deleted the `string` versions, and switched the handful of places where it was used to pass `int` instead.