### PR TITLE
Removed Unused Code from the Slice Compiler

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,9 @@
+cpp/src/Slice/Grammar.h
+cpp/src/Slice/Grammar.cpp
+cpp/src/Slice/Scanner.cpp
+cpp/src/IceGrid/Grammar.h
+cpp/src/IceGrid/Grammar.cpp
+cpp/src/IceGrid/Scanner.cpp
+cpp/src/IceStorm/Grammar.h
+cpp/src/IceStorm/Grammar.cpp
+cpp/src/IceStorm/Scanner.cpp

--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -2562,7 +2562,7 @@ yyreduce:
             DataMemberPtr dm;
             if (cl)
             {
-                dm = cl->createDataMember(def->name, def->type, def->isOptional, def->tag, 0, "", "");
+                dm = cl->createDataMember(def->name, def->type, def->isOptional, def->tag, 0, "");
             }
             auto st = dynamic_pointer_cast<Struct>(currentUnit->currentContainer());
             if (st)
@@ -2570,17 +2570,17 @@ yyreduce:
                 if (def->isOptional)
                 {
                     currentUnit->error("optional data members are not supported in structs");
-                    dm = st->createDataMember(def->name, def->type, false, 0, 0, "", ""); // Dummy
+                    dm = st->createDataMember(def->name, def->type, false, 0, 0, ""); // Dummy
                 }
                 else
                 {
-                    dm = st->createDataMember(def->name, def->type, false, -1, 0, "", "");
+                    dm = st->createDataMember(def->name, def->type, false, -1, 0, "");
                 }
             }
             auto ex = dynamic_pointer_cast<Exception>(currentUnit->currentContainer());
             if (ex)
             {
-                dm = ex->createDataMember(def->name, def->type, def->isOptional, def->tag, 0, "", "");
+                dm = ex->createDataMember(def->name, def->type, def->isOptional, def->tag, 0, "");
             }
             currentUnit->currentContainer()->checkIntroduced(def->name, dm);
             yyval = dm;
@@ -2603,8 +2603,7 @@ yyreduce:
                     def->isOptional,
                     def->tag,
                     value->v,
-                    value->valueAsString,
-                    value->valueAsLiteral);
+                    value->valueAsString);
             }
             auto st = dynamic_pointer_cast<Struct>(currentUnit->currentContainer());
             if (st)
@@ -2612,7 +2611,7 @@ yyreduce:
                 if (def->isOptional)
                 {
                     currentUnit->error("optional data members are not supported in structs");
-                    dm = st->createDataMember(def->name, def->type, false, 0, 0, "", ""); // Dummy
+                    dm = st->createDataMember(def->name, def->type, false, 0, 0, ""); // Dummy
                 }
                 else
                 {
@@ -2622,8 +2621,7 @@ yyreduce:
                         false,
                         -1,
                         value->v,
-                        value->valueAsString,
-                        value->valueAsLiteral);
+                        value->valueAsString);
                 }
             }
             auto ex = dynamic_pointer_cast<Exception>(currentUnit->currentContainer());
@@ -2635,8 +2633,7 @@ yyreduce:
                     def->isOptional,
                     def->tag,
                     value->v,
-                    value->valueAsString,
-                    value->valueAsLiteral);
+                    value->valueAsString);
             }
             currentUnit->currentContainer()->checkIntroduced(def->name, dm);
             yyval = dm;
@@ -2652,17 +2649,17 @@ yyreduce:
             auto cl = dynamic_pointer_cast<ClassDef>(currentUnit->currentContainer());
             if (cl)
             {
-                yyval = cl->createDataMember(name, type, false, 0, 0, "", ""); // Dummy
+                yyval = cl->createDataMember(name, type, false, 0, 0, ""); // Dummy
             }
             auto st = dynamic_pointer_cast<Struct>(currentUnit->currentContainer());
             if (st)
             {
-                yyval = st->createDataMember(name, type, false, 0, 0, "", ""); // Dummy
+                yyval = st->createDataMember(name, type, false, 0, 0, ""); // Dummy
             }
             auto ex = dynamic_pointer_cast<Exception>(currentUnit->currentContainer());
             if (ex)
             {
-                yyval = ex->createDataMember(name, type, false, 0, 0, "", ""); // Dummy
+                yyval = ex->createDataMember(name, type, false, 0, 0, ""); // Dummy
             }
             assert(yyval);
             currentUnit->error("keyword `" + name + "' cannot be used as data member name");
@@ -2677,17 +2674,17 @@ yyreduce:
             auto cl = dynamic_pointer_cast<ClassDef>(currentUnit->currentContainer());
             if (cl)
             {
-                yyval = cl->createDataMember(Ice::generateUUID(), type, false, 0, 0, "", ""); // Dummy
+                yyval = cl->createDataMember(Ice::generateUUID(), type, false, 0, 0, ""); // Dummy
             }
             auto st = dynamic_pointer_cast<Struct>(currentUnit->currentContainer());
             if (st)
             {
-                yyval = st->createDataMember(Ice::generateUUID(), type, false, 0, 0, "", ""); // Dummy
+                yyval = st->createDataMember(Ice::generateUUID(), type, false, 0, 0, ""); // Dummy
             }
             auto ex = dynamic_pointer_cast<Exception>(currentUnit->currentContainer());
             if (ex)
             {
-                yyval = ex->createDataMember(Ice::generateUUID(), type, false, 0, 0, "", ""); // Dummy
+                yyval = ex->createDataMember(Ice::generateUUID(), type, false, 0, 0, ""); // Dummy
             }
             assert(yyval);
             currentUnit->error("missing data member name");
@@ -3072,7 +3069,7 @@ yyreduce:
 #line 1456 "src/Slice/Grammar.y"
         {
             currentUnit->error("illegal inheritance from type Value");
-            yyval = make_shared<ClassListTok>(); // Dummy
+            yyval = make_shared<InterfaceListTok>(); // Dummy
         }
 #line 3210 "src/Slice/Grammar.cpp"
         break;
@@ -3800,7 +3797,7 @@ yyreduce:
             auto intVal = dynamic_pointer_cast<IntegerTok>(yyvsp[0]);
             ostringstream sstr;
             sstr << intVal->v;
-            auto def = make_shared<ConstDefTok>(type, sstr.str(), intVal->literal);
+            auto def = make_shared<ConstDefTok>(type, sstr.str());
             yyval = def;
         }
 #line 3929 "src/Slice/Grammar.cpp"
@@ -3813,7 +3810,7 @@ yyreduce:
             auto floatVal = dynamic_pointer_cast<FloatingTok>(yyvsp[0]);
             ostringstream sstr;
             sstr << floatVal->v;
-            auto def = make_shared<ConstDefTok>(type, sstr.str(), floatVal->literal);
+            auto def = make_shared<ConstDefTok>(type, sstr.str());
             yyval = def;
         }
 #line 3942 "src/Slice/Grammar.cpp"
@@ -3828,7 +3825,7 @@ yyreduce:
             if (cl.empty())
             {
                 // Could be an enumerator
-                def = make_shared<ConstDefTok>(nullptr, scoped->v, scoped->v);
+                def = make_shared<ConstDefTok>(nullptr, scoped->v);
             }
             else
             {
@@ -3837,12 +3834,12 @@ yyreduce:
                 if (enumerator)
                 {
                     currentUnit->currentContainer()->checkIntroduced(scoped->v, enumerator);
-                    def = make_shared<ConstDefTok>(enumerator, scoped->v, scoped->v);
+                    def = make_shared<ConstDefTok>(enumerator, scoped->v);
                 }
                 else if (constant)
                 {
                     currentUnit->currentContainer()->checkIntroduced(scoped->v, constant);
-                    def = make_shared<ConstDefTok>(constant, constant->value(), constant->value());
+                    def = make_shared<ConstDefTok>(constant, constant->value());
                 }
                 else
                 {
@@ -3863,7 +3860,7 @@ yyreduce:
         {
             BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindString);
             auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
-            auto def = make_shared<ConstDefTok>(type, literal->v, literal->literal);
+            auto def = make_shared<ConstDefTok>(type, literal->v);
             yyval = def;
         }
 #line 3992 "src/Slice/Grammar.cpp"
@@ -3874,7 +3871,7 @@ yyreduce:
         {
             BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindBool);
             auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
-            auto def = make_shared<ConstDefTok>(type, "false", "false");
+            auto def = make_shared<ConstDefTok>(type, "false");
             yyval = def;
         }
 #line 4003 "src/Slice/Grammar.cpp"
@@ -3885,7 +3882,7 @@ yyreduce:
         {
             BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindBool);
             auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
-            auto def = make_shared<ConstDefTok>(type, "true", "true");
+            auto def = make_shared<ConstDefTok>(type, "true");
             yyval = def;
         }
 #line 4014 "src/Slice/Grammar.cpp"
@@ -3903,8 +3900,7 @@ yyreduce:
                 const_type,
                 metadata->v,
                 value->v,
-                value->valueAsString,
-                value->valueAsLiteral);
+                value->valueAsString);
         }
 #line 4027 "src/Slice/Grammar.cpp"
         break;
@@ -3922,7 +3918,6 @@ yyreduce:
                 metadata->v,
                 value->v,
                 value->valueAsString,
-                value->valueAsLiteral,
                 Dummy); // Dummy
         }
 #line 4040 "src/Slice/Grammar.cpp"

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -1020,7 +1020,7 @@ data_member
     DataMemberPtr dm;
     if (cl)
     {
-        dm = cl->createDataMember(def->name, def->type, def->isOptional, def->tag, 0, "", "");
+        dm = cl->createDataMember(def->name, def->type, def->isOptional, def->tag, 0, "");
     }
     auto st = dynamic_pointer_cast<Struct>(currentUnit->currentContainer());
     if (st)
@@ -1028,17 +1028,17 @@ data_member
         if (def->isOptional)
         {
             currentUnit->error("optional data members are not supported in structs");
-            dm = st->createDataMember(def->name, def->type, false, 0, 0, "", ""); // Dummy
+            dm = st->createDataMember(def->name, def->type, false, 0, 0, ""); // Dummy
         }
         else
         {
-            dm = st->createDataMember(def->name, def->type, false, -1, 0, "", "");
+            dm = st->createDataMember(def->name, def->type, false, -1, 0, "");
         }
     }
     auto ex = dynamic_pointer_cast<Exception>(currentUnit->currentContainer());
     if (ex)
     {
-        dm = ex->createDataMember(def->name, def->type, def->isOptional, def->tag, 0, "", "");
+        dm = ex->createDataMember(def->name, def->type, def->isOptional, def->tag, 0, "");
     }
     currentUnit->currentContainer()->checkIntroduced(def->name, dm);
     $$ = dm;
@@ -1051,8 +1051,7 @@ data_member
     DataMemberPtr dm;
     if (cl)
     {
-        dm = cl->createDataMember(def->name, def->type, def->isOptional, def->tag, value->v,
-                                  value->valueAsString, value->valueAsLiteral);
+        dm = cl->createDataMember(def->name, def->type, def->isOptional, def->tag, value->v, value->valueAsString);
     }
     auto st = dynamic_pointer_cast<Struct>(currentUnit->currentContainer());
     if (st)
@@ -1060,19 +1059,17 @@ data_member
         if (def->isOptional)
         {
             currentUnit->error("optional data members are not supported in structs");
-            dm = st->createDataMember(def->name, def->type, false, 0, 0, "", ""); // Dummy
+            dm = st->createDataMember(def->name, def->type, false, 0, 0, ""); // Dummy
         }
         else
         {
-            dm = st->createDataMember(def->name, def->type, false, -1, value->v,
-                                      value->valueAsString, value->valueAsLiteral);
+            dm = st->createDataMember(def->name, def->type, false, -1, value->v, value->valueAsString);
         }
     }
     auto ex = dynamic_pointer_cast<Exception>(currentUnit->currentContainer());
     if (ex)
     {
-        dm = ex->createDataMember(def->name, def->type, def->isOptional, def->tag, value->v,
-                                  value->valueAsString, value->valueAsLiteral);
+        dm = ex->createDataMember(def->name, def->type, def->isOptional, def->tag, value->v, value->valueAsString);
     }
     currentUnit->currentContainer()->checkIntroduced(def->name, dm);
     $$ = dm;
@@ -1084,17 +1081,17 @@ data_member
     auto cl = dynamic_pointer_cast<ClassDef>(currentUnit->currentContainer());
     if (cl)
     {
-        $$ = cl->createDataMember(name, type, false, 0, 0, "", ""); // Dummy
+        $$ = cl->createDataMember(name, type, false, 0, 0, ""); // Dummy
     }
     auto st = dynamic_pointer_cast<Struct>(currentUnit->currentContainer());
     if (st)
     {
-        $$ = st->createDataMember(name, type, false, 0, 0, "", ""); // Dummy
+        $$ = st->createDataMember(name, type, false, 0, 0, ""); // Dummy
     }
     auto ex = dynamic_pointer_cast<Exception>(currentUnit->currentContainer());
     if (ex)
     {
-        $$ = ex->createDataMember(name, type, false, 0, 0, "", ""); // Dummy
+        $$ = ex->createDataMember(name, type, false, 0, 0, ""); // Dummy
     }
     assert($$);
     currentUnit->error("keyword `" + name + "' cannot be used as data member name");
@@ -1105,17 +1102,17 @@ data_member
     auto cl = dynamic_pointer_cast<ClassDef>(currentUnit->currentContainer());
     if (cl)
     {
-        $$ = cl->createDataMember(Ice::generateUUID(), type, false, 0, 0, "", ""); // Dummy
+        $$ = cl->createDataMember(Ice::generateUUID(), type, false, 0, 0, ""); // Dummy
     }
     auto st = dynamic_pointer_cast<Struct>(currentUnit->currentContainer());
     if (st)
     {
-        $$ = st->createDataMember(Ice::generateUUID(), type, false, 0, 0, "", ""); // Dummy
+        $$ = st->createDataMember(Ice::generateUUID(), type, false, 0, 0, ""); // Dummy
     }
     auto ex = dynamic_pointer_cast<Exception>(currentUnit->currentContainer());
     if (ex)
     {
-        $$ = ex->createDataMember(Ice::generateUUID(), type, false, 0, 0, "", ""); // Dummy
+        $$ = ex->createDataMember(Ice::generateUUID(), type, false, 0, 0, ""); // Dummy
     }
     assert($$);
     currentUnit->error("missing data member name");
@@ -1453,7 +1450,7 @@ interface_list
 | ICE_VALUE
 {
     currentUnit->error("illegal inheritance from type Value");
-    $$ = make_shared<ClassListTok>(); // Dummy
+    $$ = make_shared<InterfaceListTok>(); // Dummy
 }
 ;
 
@@ -2021,7 +2018,7 @@ const_initializer
     auto intVal = dynamic_pointer_cast<IntegerTok>($1);
     ostringstream sstr;
     sstr << intVal->v;
-    auto def = make_shared<ConstDefTok>(type, sstr.str(), intVal->literal);
+    auto def = make_shared<ConstDefTok>(type, sstr.str());
     $$ = def;
 }
 | ICE_FLOATING_POINT_LITERAL
@@ -2030,7 +2027,7 @@ const_initializer
     auto floatVal = dynamic_pointer_cast<FloatingTok>($1);
     ostringstream sstr;
     sstr << floatVal->v;
-    auto def = make_shared<ConstDefTok>(type, sstr.str(), floatVal->literal);
+    auto def = make_shared<ConstDefTok>(type, sstr.str());
     $$ = def;
 }
 | scoped_name
@@ -2041,7 +2038,7 @@ const_initializer
     if (cl.empty())
     {
         // Could be an enumerator
-        def = make_shared<ConstDefTok>(nullptr, scoped->v, scoped->v);
+        def = make_shared<ConstDefTok>(nullptr, scoped->v);
     }
     else
     {
@@ -2050,12 +2047,12 @@ const_initializer
         if (enumerator)
         {
             currentUnit->currentContainer()->checkIntroduced(scoped->v, enumerator);
-            def = make_shared<ConstDefTok>(enumerator, scoped->v, scoped->v);
+            def = make_shared<ConstDefTok>(enumerator, scoped->v);
         }
         else if (constant)
         {
             currentUnit->currentContainer()->checkIntroduced(scoped->v, constant);
-            def = make_shared<ConstDefTok>(constant, constant->value(), constant->value());
+            def = make_shared<ConstDefTok>(constant, constant->value());
         }
         else
         {
@@ -2072,21 +2069,21 @@ const_initializer
 {
     BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindString);
     auto literal = dynamic_pointer_cast<StringTok>($1);
-    auto def = make_shared<ConstDefTok>(type, literal->v, literal->literal);
+    auto def = make_shared<ConstDefTok>(type, literal->v);
     $$ = def;
 }
 | ICE_FALSE
 {
     BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindBool);
     auto literal = dynamic_pointer_cast<StringTok>($1);
-    auto def = make_shared<ConstDefTok>(type, "false", "false");
+    auto def = make_shared<ConstDefTok>(type, "false");
     $$ = def;
 }
 | ICE_TRUE
 {
     BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindBool);
     auto literal = dynamic_pointer_cast<StringTok>($1);
-    auto def = make_shared<ConstDefTok>(type, "true", "true");
+    auto def = make_shared<ConstDefTok>(type, "true");
     $$ = def;
 }
 ;
@@ -2101,7 +2098,7 @@ const_def
     auto ident = dynamic_pointer_cast<StringTok>($4);
     auto value = dynamic_pointer_cast<ConstDefTok>($6);
     $$ = currentUnit->currentContainer()->createConst(ident->v, const_type, metadata->v, value->v,
-                                               value->valueAsString, value->valueAsLiteral);
+                                                      value->valueAsString);
 }
 | ICE_CONST metadata type '=' const_initializer
 {
@@ -2110,7 +2107,7 @@ const_def
     auto value = dynamic_pointer_cast<ConstDefTok>($5);
     currentUnit->error("missing constant name");
     $$ = currentUnit->currentContainer()->createConst(Ice::generateUUID(), const_type, metadata->v, value->v,
-                                               value->valueAsString, value->valueAsLiteral, Dummy); // Dummy
+                                                      value->valueAsString, Dummy); // Dummy
 }
 ;
 

--- a/cpp/src/Slice/GrammarUtil.h
+++ b/cpp/src/Slice/GrammarUtil.h
@@ -10,189 +10,79 @@
 
 namespace Slice
 {
-    class StringTok;
-    class StringListTok;
-    class TypeStringTok;
-    class TypeStringListTok;
-    class BoolTok;
-    class IntegerTok;
-    class FloatingTok;
-    class ExceptionListTok;
-    class ClassListTok;
-    class InterfaceListTok;
-    class EnumeratorListTok;
-    class ConstDefTok;
-    class OptionalDefTok;
-    class ClassIdTok;
-
-    using StringTokPtr = std::shared_ptr<StringTok>;
-    using StringListTokPtr = std::shared_ptr<StringListTok>;
-    using TypeStringTokPtr = std::shared_ptr<TypeStringTok>;
-    using TypeStringListTokPtr = std::shared_ptr<TypeStringListTok>;
-    using BoolTokPtr = std::shared_ptr<BoolTok>;
-    using IntegerTokPtr = std::shared_ptr<IntegerTok>;
-    using FloatingTokPtr = std::shared_ptr<FloatingTok>;
-    using ExceptionListTokPtr = std::shared_ptr<ExceptionListTok>;
-    using ClassListTokPtr = std::shared_ptr<ClassListTok>;
-    using InterfaceListTokPtr = std::shared_ptr<InterfaceListTok>;
-    using EnumeratorListTokPtr = std::shared_ptr<EnumeratorListTok>;
-    using ConstDefTokPtr = std::shared_ptr<ConstDefTok>;
-    using OptionalDefTokPtr = std::shared_ptr<OptionalDefTok>;
-    using ClassIdTokPtr = std::shared_ptr<ClassIdTok>;
-
-    // ----------------------------------------------------------------------
-    // StringTok
-    // ----------------------------------------------------------------------
-
-    class StringTok final : public GrammarBase
+    struct StringTok final : public GrammarBase
     {
-    public:
         StringTok() {}
         std::string v;
         std::string literal;
     };
 
-    // ----------------------------------------------------------------------
-    // StringListTok
-    // ----------------------------------------------------------------------
-
-    class StringListTok final : public GrammarBase
+    struct StringListTok final : public GrammarBase
     {
-    public:
         StringListTok() {}
         StringList v;
     };
 
-    // ----------------------------------------------------------------------
-    // TypeStringTok
-    // ----------------------------------------------------------------------
-
-    class TypeStringTok final : public GrammarBase
+    struct TypeStringTok final : public GrammarBase
     {
-    public:
         TypeStringTok() {}
         TypeString v;
     };
 
-    // ----------------------------------------------------------------------
-    // TypeStringListTok
-    // ----------------------------------------------------------------------
-
-    class TypeStringListTok final : public GrammarBase
+    struct IntegerTok final : public GrammarBase
     {
-    public:
-        TypeStringListTok() {}
-        TypeStringList v;
-    };
-
-    // ----------------------------------------------------------------------
-    // IntegerTok
-    // ----------------------------------------------------------------------
-
-    class IntegerTok final : public GrammarBase
-    {
-    public:
         IntegerTok() : v(0) {}
         std::int64_t v;
         std::string literal;
     };
 
-    // ----------------------------------------------------------------------
-    // FloatingTok
-    // ----------------------------------------------------------------------
-
-    class FloatingTok final : public GrammarBase
+    struct FloatingTok final : public GrammarBase
     {
-    public:
         FloatingTok() : v(0) {}
         double v;
         std::string literal;
     };
 
-    // ----------------------------------------------------------------------
-    // BoolTok
-    // ----------------------------------------------------------------------
-
-    class BoolTok final : public GrammarBase
+    struct BoolTok final : public GrammarBase
     {
-    public:
         BoolTok() : v(false) {}
         bool v;
     };
 
-    // ----------------------------------------------------------------------
-    // ExceptionListTok
-    // ----------------------------------------------------------------------
-
-    class ExceptionListTok final : public GrammarBase
+    struct ExceptionListTok final : public GrammarBase
     {
-    public:
         ExceptionListTok() {}
         ExceptionList v;
     };
 
-    // ----------------------------------------------------------------------
-    // ClassListTok
-    // ----------------------------------------------------------------------
-
-    class ClassListTok final : public GrammarBase
+    struct InterfaceListTok final : public GrammarBase
     {
-    public:
-        ClassListTok() {}
-        ClassList v;
-    };
-
-    // ----------------------------------------------------------------------
-    // InterfaceListTok
-    // ----------------------------------------------------------------------
-
-    class InterfaceListTok final : public GrammarBase
-    {
-    public:
         InterfaceListTok() {}
         InterfaceList v;
     };
 
-    // ----------------------------------------------------------------------
-    // EnumeratorListTok
-    // ----------------------------------------------------------------------
-
-    class EnumeratorListTok final : public GrammarBase
+    struct EnumeratorListTok final : public GrammarBase
     {
-    public:
         EnumeratorListTok() {}
         EnumeratorList v;
     };
 
-    // ----------------------------------------------------------------------
-    // ConstDefTok
-    // ----------------------------------------------------------------------
-
-    class ConstDefTok final : public GrammarBase
+    struct ConstDefTok final : public GrammarBase
     {
-    public:
         ConstDefTok() {}
-        ConstDefTok(SyntaxTreeBasePtr value, std::string stringValue, std::string literalValue)
+        ConstDefTok(SyntaxTreeBasePtr value, std::string stringValue)
             : v(value),
-              valueAsString(stringValue),
-              valueAsLiteral(literalValue)
+              valueAsString(stringValue)
         {
         }
 
         SyntaxTreeBasePtr v;
         std::string valueAsString;
-        std::string valueAsLiteral;
     };
 
-    // ----------------------------------------------------------------------
-    // OptionalDefTok
-    // ----------------------------------------------------------------------
-
-    class OptionalDefTok final : public GrammarBase
+    struct OptionalDefTok final : public GrammarBase
     {
-    public:
         OptionalDefTok() : isOptional(false), tag(0) {}
-
         OptionalDefTok(int t) : isOptional(t >= 0), tag(t) {}
 
         TypePtr type;
@@ -201,21 +91,12 @@ namespace Slice
         int tag;
     };
 
-    // ----------------------------------------------------------------------
-    // ClassIdTok
-    // ----------------------------------------------------------------------
-
-    class ClassIdTok final : public GrammarBase
+    struct ClassIdTok final : public GrammarBase
     {
-    public:
         ClassIdTok() : t(0) {}
         std::string v;
         int t;
     };
-
-    // ----------------------------------------------------------------------
-    // TokenContext: stores the location of tokens.
-    // ----------------------------------------------------------------------
 
     struct TokenContext
     {
@@ -225,6 +106,11 @@ namespace Slice
         int lastColumn;
         std::string filename;
     };
+
+    using StringTokPtr = std::shared_ptr<StringTok>;
+    using IntegerTokPtr = std::shared_ptr<IntegerTok>;
+    using FloatingTokPtr = std::shared_ptr<FloatingTok>;
+    using ConstDefTokPtr = std::shared_ptr<ConstDefTok>;
 }
 
 #endif

--- a/cpp/src/Slice/GrammarUtil.h
+++ b/cpp/src/Slice/GrammarUtil.h
@@ -70,11 +70,7 @@ namespace Slice
     struct ConstDefTok final : public GrammarBase
     {
         ConstDefTok() {}
-        ConstDefTok(SyntaxTreeBasePtr value, std::string stringValue)
-            : v(value),
-              valueAsString(stringValue)
-        {
-        }
+        ConstDefTok(SyntaxTreeBasePtr value, std::string stringValue) : v(value), valueAsString(stringValue) {}
 
         SyntaxTreeBasePtr v;
         std::string valueAsString;

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -2631,8 +2631,14 @@ Slice::ClassDef::createDataMember(
         }
     }
 
-    DataMemberPtr member = make_shared<
-        DataMember>(dynamic_pointer_cast<Container>(shared_from_this()), name, type, optional, tag, dlt, dv);
+    DataMemberPtr member = make_shared<DataMember>(
+        dynamic_pointer_cast<Container>(shared_from_this()),
+        name,
+        type,
+        optional,
+        tag,
+        dlt,
+        dv);
     member->init();
     _contents.push_back(member);
     return member;
@@ -3342,8 +3348,14 @@ Slice::Exception::createDataMember(
         }
     }
 
-    DataMemberPtr p = make_shared<
-        DataMember>(dynamic_pointer_cast<Container>(shared_from_this()), name, type, optional, tag, dlt, dv);
+    DataMemberPtr p = make_shared<DataMember>(
+        dynamic_pointer_cast<Container>(shared_from_this()),
+        name,
+        type,
+        optional,
+        tag,
+        dlt,
+        dv);
     p->init();
     _contents.push_back(p);
     return p;
@@ -3575,8 +3587,14 @@ Slice::Struct::createDataMember(
         }
     }
 
-    DataMemberPtr p = make_shared<
-        DataMember>(dynamic_pointer_cast<Container>(shared_from_this()), name, type, optional, tag, dlt, dv);
+    DataMemberPtr p = make_shared<DataMember>(
+        dynamic_pointer_cast<Container>(shared_from_this()),
+        name,
+        type,
+        optional,
+        tag,
+        dlt,
+        dv);
     p->init();
     _contents.push_back(p);
     return p;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -104,7 +104,6 @@ namespace Slice
     bool containedEqual(const ContainedPtr& lhs, const ContainedPtr& rhs);
 
     using TypeList = std::list<TypePtr>;
-    using ExceptionList = std::list<ExceptionPtr>;
     using StringSet = std::set<std::string>;
     using StringList = std::list<std::string>;
     using TypeString = std::pair<TypePtr, std::string>;
@@ -123,22 +122,6 @@ namespace Slice
     using DataMemberList = std::list<DataMemberPtr>;
     using ParamDeclList = std::list<ParamDeclPtr>;
     using EnumeratorList = std::list<EnumeratorPtr>;
-
-    struct ConstDef
-    {
-        TypePtr type;
-        SyntaxTreeBasePtr value;
-        std::string valueAsString;
-        std::string valueAsLiteral;
-    };
-
-    struct OptionalDef
-    {
-        TypePtr type;
-        std::string name;
-        bool optional;
-        int tag;
-    };
 
     // ----------------------------------------------------------------------
     // CICompare -- function object to do case-insensitive string comparison.
@@ -210,8 +193,7 @@ namespace Slice
         void setFilename(const std::string&);
         void setSeenDefinition();
 
-        bool hasMetadata() const;
-        bool hasMetadataDirective(const std::string&) const;
+        bool hasMetadata(const std::string&) const;
         void setMetadata(const StringList&);
         std::string findMetadata(const std::string&) const;
         StringList getMetadata() const;
@@ -381,7 +363,6 @@ namespace Slice
         CommentPtr parseComment(bool) const;
 
         int includeLevel() const;
-        void updateIncludeLevel();
 
         bool hasMetadata(const std::string&) const;
         bool findMetadata(const std::string&, std::string&) const;
@@ -448,7 +429,6 @@ namespace Slice
             const StringList&,
             const SyntaxTreeBasePtr&,
             const std::string&,
-            const std::string&,
             NodeType = Real);
         TypeList lookupType(const std::string&, bool = true);
         TypeList lookupTypeNoBuiltin(const std::string&, bool = true, bool = false);
@@ -468,8 +448,6 @@ namespace Slice
         ConstList consts() const;
         ContainedList contents() const;
         std::string thisScope() const;
-        void sort();
-        void sortContents(bool);
         void visit(ParserVisitor*) override;
 
         bool checkIntroduced(const std::string&, ContainedPtr = 0);
@@ -572,7 +550,6 @@ namespace Slice
             bool,
             int,
             const SyntaxTreeBasePtr&,
-            const std::string&,
             const std::string&);
         ClassDeclPtr declaration() const;
         ClassDefPtr base() const;
@@ -583,9 +560,6 @@ namespace Slice
         DataMemberList classDataMembers() const;
         DataMemberList allClassDataMembers() const;
         bool canBeCyclic() const;
-        bool isA(const std::string&) const;
-        bool hasDataMembers() const;
-        bool hasDefaultValues() const;
         bool inheritsMetadata(const std::string&) const;
         bool hasBaseDataMembers() const;
         void visit(ParserVisitor*) final;
@@ -596,7 +570,6 @@ namespace Slice
         friend class Container;
 
         ClassDeclPtr _declaration;
-        bool _hasDataMembers;
         ClassDefPtr _base;
         int _compactId;
     };
@@ -710,7 +683,6 @@ namespace Slice
         InterfaceList allBases() const;
         OperationList operations() const;
         OperationList allOperations() const;
-        bool isA(const std::string&) const;
         bool hasOperations() const;
         bool inheritsMetadata(const std::string&) const;
         std::string kindOf() const final;
@@ -743,7 +715,6 @@ namespace Slice
             bool,
             int,
             const SyntaxTreeBasePtr&,
-            const std::string&,
             const std::string&);
         DataMemberList dataMembers() const;
         DataMemberList orderedOptionalDataMembers() const;
@@ -754,7 +725,6 @@ namespace Slice
         ExceptionList allBases() const;
         bool isBaseOf(const ExceptionPtr&) const;
         bool usesClasses() const;
-        bool hasDefaultValues() const;
         bool inheritsMetadata(const std::string&) const;
         bool hasBaseDataMembers() const;
         std::string kindOf() const final;
@@ -780,7 +750,6 @@ namespace Slice
             bool,
             int,
             const SyntaxTreeBasePtr&,
-            const std::string&,
             const std::string&);
         DataMemberList dataMembers() const;
         DataMemberList classDataMembers() const;
@@ -788,7 +757,6 @@ namespace Slice
         size_t minWireSize() const final;
         std::string getOptionalFormat() const final;
         bool isVariableLength() const final;
-        bool hasDefaultValues() const;
         std::string kindOf() const final;
         void visit(ParserVisitor*) final;
 
@@ -918,13 +886,11 @@ namespace Slice
             const TypePtr&,
             const StringList&,
             const SyntaxTreeBasePtr&,
-            const std::string&,
             const std::string&);
         TypePtr type() const;
         StringList typeMetadata() const;
         SyntaxTreeBasePtr valueType() const;
         std::string value() const;
-        std::string literal() const;
         std::string kindOf() const final;
         void visit(ParserVisitor*) final;
 
@@ -935,7 +901,6 @@ namespace Slice
         StringList _typeMetadata;
         SyntaxTreeBasePtr _valueType;
         std::string _value;
-        std::string _literal;
     };
 
     // ----------------------------------------------------------------------
@@ -976,13 +941,11 @@ namespace Slice
             bool,
             int,
             const SyntaxTreeBasePtr&,
-            const std::string&,
             const std::string&);
         TypePtr type() const;
         bool optional() const;
         int tag() const;
         std::string defaultValue() const;
-        std::string defaultLiteral() const;
         SyntaxTreeBasePtr defaultValueType() const;
         std::string kindOf() const final;
         void visit(ParserVisitor*) final;
@@ -997,7 +960,6 @@ namespace Slice
         int _tag;
         SyntaxTreeBasePtr _defaultValueType;
         std::string _defaultValue;
-        std::string _defaultLiteral;
     };
 
     // ----------------------------------------------------------------------
@@ -1033,8 +995,6 @@ namespace Slice
         void popContainer();
 
         DefinitionContextPtr currentDefinitionContext() const;
-        void pushDefinitionContext();
-        void popDefinitionContext();
         DefinitionContextPtr findDefinitionContext(const std::string&) const;
 
         void addContent(const ContainedPtr&);
@@ -1042,7 +1002,6 @@ namespace Slice
 
         void addTypeId(int, const std::string&);
         std::string getTypeId(int) const;
-        bool hasCompactTypeId() const;
 
         //
         // Returns the path names of the files included directly by the top-level file.
@@ -1066,6 +1025,9 @@ namespace Slice
         std::set<std::string> getTopLevelModules(const std::string& file) const;
 
     private:
+        void pushDefinitionContext();
+        void popDefinitionContext();
+
         void init();
 
         bool _all;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -550,7 +550,7 @@ namespace Slice
             bool,
             int,
             const SyntaxTreeBasePtr&,
-            const std::string&);
+            const std::string& defaultValue);
         ClassDeclPtr declaration() const;
         ClassDefPtr base() const;
         ClassList allBases() const;
@@ -715,7 +715,7 @@ namespace Slice
             bool,
             int,
             const SyntaxTreeBasePtr&,
-            const std::string&);
+            const std::string& defaultValue);
         DataMemberList dataMembers() const;
         DataMemberList orderedOptionalDataMembers() const;
         DataMemberList allDataMembers() const;
@@ -750,7 +750,7 @@ namespace Slice
             bool,
             int,
             const SyntaxTreeBasePtr&,
-            const std::string&);
+            const std::string& defaultValue);
         DataMemberList dataMembers() const;
         DataMemberList classDataMembers() const;
         bool usesClasses() const final;

--- a/cpp/src/Slice/Scanner.cpp
+++ b/cpp/src/Slice/Scanner.cpp
@@ -967,8 +967,8 @@ namespace Slice
     using StringTokenMap = map<string, int>;
     StringTokenMap keywordMap;
 
-    int checkKeyword(string&);
-    int checkIsScoped(const string&);
+    int checkKeyword(string& identifier);
+    int checkIsScoped(const string& identifier);
 }
 
 // Stores the scanner's current column position. Flex also automatically
@@ -979,11 +979,11 @@ string yyfilename;
 
 namespace
 {
-    void nextLine(int = 1);
-    int scanPosition(const char*);
-    void setLocation(TokenContext*);
-    void startLocation(TokenContext*);
-    void endLocation(TokenContext*);
+    void nextLine(int count = 1);
+    int scanPosition(const char* s);
+    void setLocation(TokenContext* location);
+    void startLocation(TokenContext* location);
+    void endLocation(TokenContext* location);
 
     void initScanner();
     void preAction();
@@ -3000,27 +3000,27 @@ namespace Slice
     // If the identifier is a keyword, return the
     // corresponding keyword token; otherwise, return
     // an identifier token.
-    int checkKeyword(string& id)
+    int checkKeyword(string& identifier)
     {
-        const auto pos = keywordMap.find(id);
+        const auto pos = keywordMap.find(identifier);
         if (pos != keywordMap.end())
         {
-            if (pos->first != id)
+            if (pos->first != identifier)
             {
                 currentUnit->error(
-                    "illegal identifier: `" + id + "' differs from keyword `" + pos->first +
+                    "illegal identifier: `" + identifier + "' differs from keyword `" + pos->first +
                     "' only in capitalization");
-                id = pos->first;
+                identifier = pos->first;
             }
             return pos->second;
         }
-        return checkIsScoped(id);
+        return checkIsScoped(identifier);
     }
 
     // Checks if an identifier is scoped or not, and returns the corresponding token.
-    int checkIsScoped(const string& id)
+    int checkIsScoped(const string& identifier)
     {
-        return id.find("::") == string::npos ? ICE_IDENTIFIER : ICE_SCOPED_IDENTIFIER;
+        return identifier.find("::") == string::npos ? ICE_IDENTIFIER : ICE_SCOPED_IDENTIFIER;
     }
 }
 

--- a/cpp/src/Slice/Scanner.l
+++ b/cpp/src/Slice/Scanner.l
@@ -25,8 +25,8 @@ namespace Slice
     using StringTokenMap = map<string, int>;
     StringTokenMap keywordMap;
 
-    int checkKeyword(string&);
-    int checkIsScoped(const string&);
+    int checkKeyword(string& identifier);
+    int checkIsScoped(const string& identifier);
 }
 
 // Stores the scanner's current column position. Flex also automatically
@@ -37,11 +37,11 @@ string yyfilename;
 
 namespace
 {
-    void nextLine(int = 1);
-    int scanPosition(const char*);
-    void setLocation(TokenContext*);
-    void startLocation(TokenContext*);
-    void endLocation(TokenContext*);
+    void nextLine(int count = 1);
+    int scanPosition(const char* s);
+    void setLocation(TokenContext* location);
+    void startLocation(TokenContext* location);
+    void endLocation(TokenContext* location);
 
     void initScanner();
     void preAction();
@@ -542,27 +542,27 @@ namespace Slice
     // If the identifier is a keyword, return the
     // corresponding keyword token; otherwise, return
     // an identifier token.
-    int checkKeyword(string& id)
+    int checkKeyword(string& identifier)
     {
-        const auto pos = keywordMap.find(id);
+        const auto pos = keywordMap.find(identifier);
         if (pos != keywordMap.end())
         {
-            if (pos->first != id)
+            if (pos->first != identifier)
             {
                 currentUnit->error(
-                    "illegal identifier: `" + id + "' differs from keyword `" + pos->first +
+                    "illegal identifier: `" + identifier + "' differs from keyword `" + pos->first +
                     "' only in capitalization");
-                id = pos->first;
+                identifier = pos->first;
             }
             return pos->second;
         }
-        return checkIsScoped(id);
+        return checkIsScoped(identifier);
     }
 
     // Checks if an identifier is scoped or not, and returns the corresponding token.
-    int checkIsScoped(const string& id)
+    int checkIsScoped(const string& identifier)
     {
-        return id.find("::") == string::npos ? ICE_IDENTIFIER : ICE_SCOPED_IDENTIFIER;
+        return identifier.find("::") == string::npos ? ICE_IDENTIFIER : ICE_SCOPED_IDENTIFIER;
     }
 }
 

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -731,7 +731,7 @@ Slice::Gen::generate(const UnitPtr& p)
 
     H << "\n#include <Ice/PushDisableWarnings.h>";
 
-    if (!dc->hasMetadataDirective("cpp:no-default-include"))
+    if (!dc->hasMetadata("cpp:no-default-include"))
     {
         H << "\n#include <Ice/Ice.h>";
     }
@@ -794,7 +794,7 @@ Slice::Gen::generate(const UnitPtr& p)
         dc->setMetadata(fileMetadata);
     }
 
-    if (!dc->hasMetadataDirective("cpp:no-default-include"))
+    if (!dc->hasMetadata("cpp:no-default-include"))
     {
         // For simplicity, we include these extra headers all the time.
 
@@ -844,7 +844,7 @@ Slice::Gen::generate(const UnitPtr& p)
         InterfaceVisitor interfaceVisitor(H, C, _dllExport);
         p->visit(&interfaceVisitor);
 
-        if (!dc->hasMetadataDirective("cpp:no-stream"))
+        if (!dc->hasMetadata("cpp:no-stream"))
         {
             StreamVisitor streamVisitor(H);
             p->visit(&streamVisitor);

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -592,7 +592,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     writeConstructorParams(allMembers);
     _out << "):";
     _out.inc();
-    if (!base && !p->hasDataMembers())
+    if (!base && p->dataMembers().empty())
     {
         _out << nl << "pass";
     }


### PR DESCRIPTION
I started adding better parameter names in the compiler, but while doing so, there was so much unnecessary code I found, I've split it's removal into it's own PR (this one).

In addition to cleaning up stuff, it also fixes the parameter names in `Scanner.l` and `Scanner.cpp`.