### PR TITLE
C# cleanup analyzer warnings

### DIFF
--- a/csharp/msbuild/CodeAnalysis.Base.globalconfig
+++ b/csharp/msbuild/CodeAnalysis.Base.globalconfig
@@ -405,17 +405,11 @@ dotnet_diagnostic.SA1407.severity = none
 # SA1005: Single line comment should begin with a space
 dotnet_diagnostic.SA1005.severity = none
 
-# SA1117: The parameters should all be placed on the same line or each parameter should be placed on its own line
-dotnet_diagnostic.SA1117.severity = none
-
 # SA1128: Put constructor initializers on their own line
 dotnet_diagnostic.SA1128.severity = none
 
 # SA1116: The parameters should begin on the line after the declaration
 dotnet_diagnostic.SA1116.severity = none
-
-# SA1003: Operator ':' should not appear at the end of a line.
-dotnet_diagnostic.SA1003.severity = none
 
 # SA1516: Elements should be separated by blank line
 dotnet_diagnostic.SA1516.severity = none
@@ -459,17 +453,11 @@ dotnet_diagnostic.CA1304.severity = none
 # CA1305: Specify IFormatProvider
 dotnet_diagnostic.CA1305.severity = none
 
-# CA1307: Specify StringComparison for clarity
-dotnet_diagnostic.CA1307.severity = none
-
 # CA1309: Use ordinal StringComparison
 dotnet_diagnostic.CA1309.severity = none
 
 # CA1310: Specify StringComparison for correctness
 dotnet_diagnostic.CA1310.severity = none
-
-# CA1311: Specify a culture or use an invariant version
-dotnet_diagnostic.CA1311.severity = none
 
 # CA1710: Identifiers should have correct suffix
 dotnet_diagnostic.CA1710.severity = none

--- a/csharp/src/Glacier2/SessionHelper.cs
+++ b/csharp/src/Glacier2/SessionHelper.cs
@@ -279,7 +279,8 @@ public class SessionHelper
             connection.setCloseCallback(_ => destroy());
         }
 
-        dispatchCallback(() =>
+        dispatchCallback(
+            () =>
             {
                 try
                 {
@@ -289,7 +290,8 @@ public class SessionHelper
                 {
                     destroy();
                 }
-            }, conn);
+            },
+            conn);
     }
 
     private void
@@ -437,11 +439,13 @@ public class SessionHelper
         if (_initData.executor != null)
         {
             EventWaitHandle h = new ManualResetEvent(false);
-            _initData.executor(() =>
+            _initData.executor(
+                () =>
                 {
                     callback();
                     h.Set();
-                }, null);
+                },
+                null);
             h.WaitOne();
         }
         else

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -298,8 +298,11 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
         }
     }
 
-    internal int sendAsyncRequest(OutgoingAsyncBase og, bool compress, bool response,
-                                int batchRequestCount)
+    internal int sendAsyncRequest(
+        OutgoingAsyncBase og,
+        bool compress,
+        bool response,
+        int batchRequestCount)
     {
         OutputStream os = og.getOs();
 
@@ -433,7 +436,8 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                         {
                             _logger.error("connection callback exception:\n" + ex + '\n' + _desc);
                         }
-                    }, this);
+                    },
+                    this);
                 }
             }
             else
@@ -2174,8 +2178,10 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                 //
                 // Do compression.
                 //
-                Ice.Internal.Buffer cbuf = BZip2.compress(uncompressed.getBuffer(), Protocol.headerSize,
-                                                         _compressionLevel);
+                Ice.Internal.Buffer cbuf = BZip2.compress(
+                    uncompressed.getBuffer(),
+                    Protocol.headerSize,
+                    _compressionLevel);
                 if (cbuf is not null)
                 {
                     OutputStream cstream = new OutputStream(new Internal.Buffer(cbuf, true), uncompressed.getEncoding());
@@ -2252,8 +2258,10 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
             {
                 if (_compressionSupported)
                 {
-                    Ice.Internal.Buffer ubuf = BZip2.uncompress(info.stream.getBuffer(), Protocol.headerSize,
-                                                               _messageSizeMax);
+                    Ice.Internal.Buffer ubuf = BZip2.uncompress(
+                        info.stream.getBuffer(),
+                        Protocol.headerSize,
+                        _messageSizeMax);
                     info.stream = new InputStream(info.stream.instance(), info.stream.getEncoding(), ubuf, true);
                 }
                 else
@@ -2298,9 +2306,11 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                 {
                     if (_state >= StateClosing)
                     {
-                        TraceUtil.trace("received request during closing\n" +
-                                        "(ignored by server, client will retry)", info.stream, _logger,
-                                        _traceLevels);
+                        TraceUtil.trace(
+                            "received request during closing\n(ignored by server, client will retry)",
+                            info.stream,
+                            _logger,
+                            _traceLevels);
                     }
                     else
                     {
@@ -2320,9 +2330,11 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                 {
                     if (_state >= StateClosing)
                     {
-                        TraceUtil.trace("received batch request during closing\n" +
-                                        "(ignored by server, client will retry)", info.stream, _logger,
-                                        _traceLevels);
+                        TraceUtil.trace(
+                            "received batch request during closing\n(ignored by server, client will retry)",
+                            info.stream,
+                            _logger,
+                            _traceLevels);
                     }
                     else
                     {
@@ -2386,8 +2398,11 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
 
                 default:
                 {
-                    TraceUtil.trace("received unknown message\n(invalid, closing connection)",
-                                    info.stream, _logger, _traceLevels);
+                    TraceUtil.trace(
+                        "received unknown message\n(invalid, closing connection)",
+                        info.stream,
+                        _logger,
+                        _traceLevels);
 
                     throw new ProtocolException($"Received Ice protocol message with unknown type: {messageType}");
                 }

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -52,8 +52,8 @@ public class InputStream
         _buf = new Ice.Internal.Buffer(buf);
     }
 
-    public InputStream(Ice.Internal.Buffer buf) :
-        this(buf, false)
+    public InputStream(Ice.Internal.Buffer buf)
+        : this(buf, false)
     {
     }
 
@@ -90,8 +90,8 @@ public class InputStream
         _buf = new Ice.Internal.Buffer(buf);
     }
 
-    public InputStream(Communicator communicator, Ice.Internal.Buffer buf) :
-        this(communicator, buf, false)
+    public InputStream(Communicator communicator, Ice.Internal.Buffer buf)
+        : this(communicator, buf, false)
     {
     }
 
@@ -128,8 +128,8 @@ public class InputStream
         _buf = new Ice.Internal.Buffer(buf);
     }
 
-    public InputStream(EncodingVersion encoding, Ice.Internal.Buffer buf) :
-        this(encoding, buf, false)
+    public InputStream(EncodingVersion encoding, Ice.Internal.Buffer buf)
+        : this(encoding, buf, false)
     {
     }
 
@@ -168,8 +168,8 @@ public class InputStream
         _buf = new Ice.Internal.Buffer(buf);
     }
 
-    public InputStream(Communicator communicator, EncodingVersion encoding, Ice.Internal.Buffer buf) :
-        this(communicator, encoding, buf, false)
+    public InputStream(Communicator communicator, EncodingVersion encoding, Ice.Internal.Buffer buf)
+        : this(communicator, encoding, buf, false)
     {
     }
 
@@ -197,8 +197,8 @@ public class InputStream
         _buf = new Ice.Internal.Buffer(buf);
     }
 
-    public InputStream(Ice.Internal.Instance instance, EncodingVersion encoding, Ice.Internal.Buffer buf) :
-        this(instance, encoding, buf, false)
+    public InputStream(Ice.Internal.Instance instance, EncodingVersion encoding, Ice.Internal.Buffer buf)
+        : this(instance, encoding, buf, false)
     {
     }
 

--- a/csharp/src/Ice/Internal/BZip2.cs
+++ b/csharp/src/Ice/Internal/BZip2.cs
@@ -164,70 +164,156 @@ public static class BZip2
 
         if (AssemblyUtil.isWindows)
         {
-            _compressBuffer = (byte[] dest, ref int destLen, byte[] source, int sourceLen, int blockSize100k,
-                               int verbosity, int workFactor) =>
+            _compressBuffer = (
+                byte[] dest,
+                ref int destLen,
+                byte[] source,
+                int sourceLen,
+                int blockSize100k,
+                int verbosity,
+                int workFactor) =>
                 {
-                    return SafeNativeMethods.windowsBZ2_bzBuffToBuffCompress(dest, ref destLen, source, sourceLen,
-                                                                             blockSize100k, verbosity, workFactor);
+                    return SafeNativeMethods.windowsBZ2_bzBuffToBuffCompress(
+                        dest,
+                        ref destLen,
+                        source,
+                        sourceLen,
+                        blockSize100k,
+                        verbosity,
+                        workFactor);
                 };
 
-            _decompressBuffer = (byte[] dest, ref int destLen, byte[] source, int sourceLen, int small,
-                                 int verbosity) =>
+            _decompressBuffer = (
+                byte[] dest,
+                ref int destLen,
+                byte[] source,
+                int sourceLen,
+                int small,
+                int verbosity) =>
                 {
-                    return SafeNativeMethods.windowsBZ2_bzBuffToBuffDecompress(dest, ref destLen, source, sourceLen,
-                                                                               small, verbosity);
+                    return SafeNativeMethods.windowsBZ2_bzBuffToBuffDecompress(
+                        dest,
+                        ref destLen,
+                        source,
+                        sourceLen,
+                        small,
+                        verbosity);
                 };
         }
         else if (AssemblyUtil.isMacOS)
         {
-            _compressBuffer = (byte[] dest, ref int destLen, byte[] source, int sourceLen, int blockSize100k,
-                               int verbosity, int workFactor) =>
+            _compressBuffer = (
+                byte[] dest,
+                ref int destLen,
+                byte[] source,
+                int sourceLen,
+                int blockSize100k,
+                int verbosity,
+                int workFactor) =>
                 {
-                    return SafeNativeMethods.macOSBZ2_bzBuffToBuffCompress(dest, ref destLen, source, sourceLen,
-                                                                           blockSize100k, verbosity, workFactor);
+                    return SafeNativeMethods.macOSBZ2_bzBuffToBuffCompress(
+                        dest,
+                        ref destLen,
+                        source,
+                        sourceLen,
+                        blockSize100k,
+                        verbosity,
+                        workFactor);
                 };
 
-            _decompressBuffer = (byte[] dest, ref int destLen, byte[] source, int sourceLen, int small,
-                                 int verbosity) =>
+            _decompressBuffer = (
+                byte[] dest,
+                ref int destLen,
+                byte[] source,
+                int sourceLen,
+                int small,
+                int verbosity) =>
                 {
-                    return SafeNativeMethods.macOSBZ2_bzBuffToBuffDecompress(dest, ref destLen, source, sourceLen,
-                                                                             small, verbosity);
+                    return SafeNativeMethods.macOSBZ2_bzBuffToBuffDecompress(
+                        dest,
+                        ref destLen,
+                        source,
+                        sourceLen,
+                        small,
+                        verbosity);
                 };
         }
         else
         {
             if (_bzlibName == "libbz2.so.1.0")
             {
-                _compressBuffer = (byte[] dest, ref int destLen, byte[] source, int sourceLen, int blockSize100k,
-                                   int verbosity, int workFactor) =>
+                _compressBuffer = (
+                    byte[] dest,
+                    ref int destLen,
+                    byte[] source,
+                    int sourceLen,
+                    int blockSize100k,
+                    int verbosity,
+                    int workFactor) =>
                     {
-                        return SafeNativeMethods.unixBZ2_10_bzBuffToBuffCompress(dest, ref destLen, source,
-                                                                                 sourceLen, blockSize100k,
-                                                                                 verbosity, workFactor);
+                        return SafeNativeMethods.unixBZ2_10_bzBuffToBuffCompress(
+                            dest,
+                            ref destLen,
+                            source,
+                            sourceLen,
+                            blockSize100k,
+                            verbosity,
+                            workFactor);
                     };
 
-                _decompressBuffer = (byte[] dest, ref int destLen, byte[] source, int sourceLen, int small,
-                                     int verbosity) =>
+                _decompressBuffer = (
+                    byte[] dest,
+                    ref int destLen,
+                    byte[] source,
+                    int sourceLen,
+                    int small,
+                    int verbosity) =>
                     {
-                        return SafeNativeMethods.unixBZ2_10_bzBuffToBuffDecompress(dest, ref destLen, source,
-                                                                                   sourceLen, small, verbosity);
+                        return SafeNativeMethods.unixBZ2_10_bzBuffToBuffDecompress(
+                            dest,
+                            ref destLen,
+                            source,
+                            sourceLen,
+                            small,
+                            verbosity);
                     };
             }
             else
             {
-                _compressBuffer = (byte[] dest, ref int destLen, byte[] source, int sourceLen, int blockSize100k,
-                                   int verbosity, int workFactor) =>
+                _compressBuffer = (
+                    byte[] dest,
+                    ref int destLen,
+                    byte[] source,
+                    int sourceLen,
+                    int blockSize100k,
+                    int verbosity,
+                    int workFactor) =>
                     {
-                        return SafeNativeMethods.unixBZ2_1_bzBuffToBuffCompress(dest, ref destLen, source,
-                                                                                sourceLen, blockSize100k, verbosity,
-                                                                                workFactor);
+                        return SafeNativeMethods.unixBZ2_1_bzBuffToBuffCompress(
+                            dest,
+                            ref destLen,
+                            source,
+                            sourceLen,
+                            blockSize100k,
+                            verbosity,
+                            workFactor);
                     };
 
-                _decompressBuffer = (byte[] dest, ref int destLen, byte[] source, int sourceLen, int small,
-                                     int verbosity) =>
+                _decompressBuffer = (
+                    byte[] dest,
+                    ref int destLen,
+                    byte[] source,
+                    int sourceLen,
+                    int small,
+                    int verbosity) =>
                     {
-                        return SafeNativeMethods.unixBZ2_1_bzBuffToBuffDecompress(dest, ref destLen, source,
-                                                                                  sourceLen, small, verbosity);
+                        return SafeNativeMethods.unixBZ2_1_bzBuffToBuffDecompress(
+                            dest,
+                            ref destLen,
+                            source,
+                            sourceLen,
+                            small,
+                            verbosity);
                     };
             }
         }

--- a/csharp/src/Ice/Internal/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/Internal/CollocatedRequestHandler.cs
@@ -107,7 +107,8 @@ public class CollocatedRequestHandler : RequestHandler
                     {
                         dispatchAll(outAsync.getOs(), requestId, batchRequestCount);
                     }
-                }, null);
+                },
+                null);
         }
         else if (_executor)
         {
@@ -118,7 +119,8 @@ public class CollocatedRequestHandler : RequestHandler
                     {
                         dispatchAll(outAsync.getOs(), requestId, batchRequestCount);
                     }
-                }, null);
+                },
+                null);
         }
         else // Optimization: directly call invokeAll if there's no executor.
         {

--- a/csharp/src/Ice/Internal/ConnectionFactory.cs
+++ b/csharp/src/Ice/Internal/ConnectionFactory.cs
@@ -111,8 +111,11 @@ public sealed class OutgoingConnectionFactory
         }
     }
 
-    public void create(List<EndpointI> endpoints, bool hasMore, Ice.EndpointSelectionType selType,
-                       CreateConnectionCallback callback)
+    public void create(
+        List<EndpointI> endpoints,
+        bool hasMore,
+        Ice.EndpointSelectionType selType,
+        CreateConnectionCallback callback)
     {
         Debug.Assert(endpoints.Count > 0);
 
@@ -756,8 +759,12 @@ public sealed class OutgoingConnectionFactory
 
     private class ConnectCallback : Ice.ConnectionI.StartCallback, EndpointI_connectors
     {
-        internal ConnectCallback(OutgoingConnectionFactory f, List<EndpointI> endpoints, bool more,
-                                 CreateConnectionCallback cb, Ice.EndpointSelectionType selType)
+        internal ConnectCallback(
+            OutgoingConnectionFactory f,
+            List<EndpointI> endpoints,
+            bool more,
+            CreateConnectionCallback cb,
+            Ice.EndpointSelectionType selType)
         {
             _factory = f;
             _endpoints = endpoints;
@@ -1488,8 +1495,11 @@ public sealed class IncomingConnectionFactory : EventHandler, Ice.ConnectionI.St
         }
     }
 
-    public IncomingConnectionFactory(Instance instance, EndpointI endpoint, EndpointI publish,
-                                     Ice.ObjectAdapter adapter)
+    public IncomingConnectionFactory(
+        Instance instance,
+        EndpointI endpoint,
+        EndpointI publish,
+        Ice.ObjectAdapter adapter)
     {
         _instance = instance;
         _connectionOptions = instance.serverConnectionOptions(adapter.getName());

--- a/csharp/src/Ice/Internal/EndpointFactoryManager.cs
+++ b/csharp/src/Ice/Internal/EndpointFactoryManager.cs
@@ -78,7 +78,7 @@ public sealed class EndpointFactoryManager
             for (int i = 0; i < _factories.Count; i++)
             {
                 EndpointFactory f = _factories[i];
-                if (f.protocol().Equals(protocol))
+                if (f.protocol().Equals(protocol, StringComparison.Ordinal))
                 {
                     factory = f;
                 }

--- a/csharp/src/Ice/Internal/EndpointHostResolver.cs
+++ b/csharp/src/Ice/Internal/EndpointHostResolver.cs
@@ -17,8 +17,12 @@ public class EndpointHostResolver
                 instance.initializationData().properties.getIceProperty("Ice.ThreadPriority")));
     }
 
-    public void resolve(string host, int port, Ice.EndpointSelectionType selType, IPEndpointI endpoint,
-                        EndpointI_connectors callback)
+    public void resolve(
+        string host,
+        int port,
+        Ice.EndpointSelectionType selType,
+        IPEndpointI endpoint,
+        EndpointI_connectors callback)
     {
         //
         // Try to get the addresses without DNS lookup. If this doesn't work, we queue a resolve

--- a/csharp/src/Ice/Internal/HttpParser.cs
+++ b/csharp/src/Ice/Internal/HttpParser.cs
@@ -7,8 +7,8 @@ namespace Ice.Internal;
 
 public sealed class WebSocketException : System.Exception
 {
-    public WebSocketException(string message) :
-        base(message, null)
+    public WebSocketException(string message)
+        : base(message, null)
     {
     }
 }
@@ -308,7 +308,7 @@ internal sealed class HttpParser
                         {
                             str.Append((char)raw[i]);
                         }
-                        _headerName = str.ToString().ToLower();
+                        _headerName = str.ToString().ToLowerInvariant();
                         //
                         // Add a placeholder entry if necessary.
                         //
@@ -675,9 +675,9 @@ internal sealed class HttpParser
     internal string getHeader(string name, bool toLower)
     {
         string s = null;
-        if (_headers.TryGetValue(name.ToLower(), out s))
+        if (_headers.TryGetValue(name.ToLowerInvariant(), out s))
         {
-            return toLower ? s.Trim().ToLower() : s.Trim();
+            return toLower ? s.Trim().ToLowerInvariant() : s.Trim();
         }
 
         return null;

--- a/csharp/src/Ice/Internal/IPEndpointI.cs
+++ b/csharp/src/Ice/Internal/IPEndpointI.cs
@@ -88,7 +88,7 @@ public abstract class IPEndpointI : EndpointI
 
     public override EndpointI connectionId(string connectionId)
     {
-        if (connectionId.Equals(connectionId_))
+        if (connectionId.Equals(connectionId_, StringComparison.Ordinal))
         {
             return this;
         }
@@ -172,7 +172,9 @@ public abstract class IPEndpointI : EndpointI
             return false;
         }
         IPEndpointI ipEndpointI = (IPEndpointI)endpoint;
-        return ipEndpointI.type() == type() && ipEndpointI.host_.Equals(host_) && ipEndpointI.port_ == port_ &&
+        return ipEndpointI.type() == type() &&
+            ipEndpointI.host_.Equals(host_, StringComparison.Ordinal) &&
+            ipEndpointI.port_ == port_ &&
             Network.addressEquals(ipEndpointI.sourceAddr_, sourceAddr_);
     }
 
@@ -200,7 +202,7 @@ public abstract class IPEndpointI : EndpointI
         if (host_ != null && host_.Length > 0)
         {
             s += " -h ";
-            bool addQuote = host_.Contains(':');
+            bool addQuote = host_.Contains(':', StringComparison.Ordinal);
             if (addQuote)
             {
                 s += "\"";
@@ -217,7 +219,7 @@ public abstract class IPEndpointI : EndpointI
         if (sourceAddr_ != null)
         {
             string sourceAddr = Network.endpointAddressToString(sourceAddr_);
-            bool addQuote = sourceAddr.Contains(':');
+            bool addQuote = sourceAddr.Contains(':', StringComparison.Ordinal);
             s += " --sourceAddress ";
             if (addQuote)
             {
@@ -275,8 +277,10 @@ public abstract class IPEndpointI : EndpointI
             return 1;
         }
 
-        int rc = string.Compare(Network.endpointAddressToString(sourceAddr_),
-                                Network.endpointAddressToString(p.sourceAddr_), StringComparison.Ordinal);
+        int rc = string.Compare(
+            Network.endpointAddressToString(sourceAddr_),
+            Network.endpointAddressToString(p.sourceAddr_),
+            StringComparison.Ordinal);
         if (rc != 0)
         {
             return rc;

--- a/csharp/src/Ice/Internal/Instance.cs
+++ b/csharp/src/Ice/Internal/Instance.cs
@@ -646,7 +646,7 @@ public sealed class Instance
                     }
                     if (stdErr.Length > 0)
                     {
-                        if (stdErr.Equals(stdOut))
+                        if (stdErr.Equals(stdOut, StringComparison.Ordinal))
                         {
                             Console.SetError(outStream);
                         }

--- a/csharp/src/Ice/Internal/InstrumentationI.cs
+++ b/csharp/src/Ice/Internal/InstrumentationI.cs
@@ -686,8 +686,8 @@ public class RemoteInvocationHelper : MetricsHelper<RemoteMetrics>
 
     private static AttributeResolver _attributes = new AttributeResolverI();
 
-    public RemoteInvocationHelper(Ice.ConnectionInfo con, Ice.Endpoint endpt, int requestId, int size) :
-        base(_attributes)
+    public RemoteInvocationHelper(Ice.ConnectionInfo con, Ice.Endpoint endpt, int requestId, int size)
+        : base(_attributes)
     {
         _connectionInfo = con;
         _endpoint = endpt;
@@ -779,8 +779,8 @@ public class CollocatedInvocationHelper : MetricsHelper<CollocatedMetrics>
 
     private static AttributeResolver _attributes = new AttributeResolverI();
 
-    public CollocatedInvocationHelper(Ice.ObjectAdapter adapter, int requestId, int size) :
-        base(_attributes)
+    public CollocatedInvocationHelper(Ice.ObjectAdapter adapter, int requestId, int size)
+        : base(_attributes)
     {
         _id = adapter.getName();
         _requestId = requestId;
@@ -939,8 +939,11 @@ public class InvocationObserverI : ObserverWithDelegate<InvocationMetrics, Ice.I
         }
     }
 
-    public Ice.Instrumentation.RemoteObserver getRemoteObserver(Ice.ConnectionInfo con, Ice.Endpoint endpt,
-                                                                int requestId, int size)
+    public Ice.Instrumentation.RemoteObserver getRemoteObserver(
+        Ice.ConnectionInfo con,
+        Ice.Endpoint endpt,
+        int requestId,
+        int size)
     {
         Ice.Instrumentation.RemoteObserver del = null;
         if (delegate_ != null)
@@ -1127,9 +1130,11 @@ public class CommunicatorObserverI : Ice.Instrumentation.CommunicatorObserver
         return null;
     }
 
-    public Ice.Instrumentation.ThreadObserver getThreadObserver(string parent, string id,
-                                                                Ice.Instrumentation.ThreadState s,
-                                                                Ice.Instrumentation.ThreadObserver obsv)
+    public Ice.Instrumentation.ThreadObserver getThreadObserver(
+        string parent,
+        string id,
+        Ice.Instrumentation.ThreadState s,
+        Ice.Instrumentation.ThreadObserver obsv)
     {
         if (_threads.isEnabled())
         {
@@ -1151,8 +1156,10 @@ public class CommunicatorObserverI : Ice.Instrumentation.CommunicatorObserver
         return null;
     }
 
-    public Ice.Instrumentation.InvocationObserver getInvocationObserver(Ice.ObjectPrx prx, string operation,
-                                                                        Dictionary<string, string> ctx)
+    public Ice.Instrumentation.InvocationObserver getInvocationObserver(
+        Ice.ObjectPrx prx,
+        string operation,
+        Dictionary<string, string> ctx)
     {
         if (_invocations.isEnabled())
         {

--- a/csharp/src/Ice/Internal/LocatorInfo.cs
+++ b/csharp/src/Ice/Internal/LocatorInfo.cs
@@ -42,8 +42,10 @@ public sealed class LocatorInfo : IEquatable<LocatorInfo>
                     //
                     if (_ref.getInstance().traceLevels().location >= 1)
                     {
-                        locatorInfo.trace("retrieved adapter for well-known object from locator, " +
-                                          "adding to locator cache", _ref, r);
+                        locatorInfo.trace(
+                            "retrieved adapter for well-known object from locator, adding to locator cache",
+                            _ref,
+                            r);
                     }
                     locatorInfo.getEndpoints(r, _ref, _ttl, _callback);
                     return;
@@ -526,13 +528,17 @@ public sealed class LocatorInfo : IEquatable<LocatorInfo>
             {
                 if (@ref.isWellKnown())
                 {
-                    trace("retrieved endpoints for well-known proxy from locator, adding to locator cache",
-                          @ref, endpoints);
+                    trace(
+                        "retrieved endpoints for well-known proxy from locator, adding to locator cache",
+                        @ref,
+                        endpoints);
                 }
                 else
                 {
-                    trace("retrieved endpoints for adapter from locator, adding to locator cache",
-                          @ref, endpoints);
+                    trace(
+                        "retrieved endpoints for adapter from locator, adding to locator cache",
+                        @ref,
+                        endpoints);
                 }
             }
         }

--- a/csharp/src/Ice/Internal/LoggerAdminI.cs
+++ b/csharp/src/Ice/Internal/LoggerAdminI.cs
@@ -7,8 +7,12 @@ namespace Ice.Internal;
 internal sealed class LoggerAdminI : Ice.LoggerAdminDisp_
 {
     public override void
-    attachRemoteLogger(Ice.RemoteLoggerPrx prx, Ice.LogMessageType[] messageTypes, string[] categories,
-                       int messageMax, Ice.Current current)
+    attachRemoteLogger(
+        Ice.RemoteLoggerPrx prx,
+        Ice.LogMessageType[] messageTypes,
+        string[] categories,
+        int messageMax,
+        Ice.Current current)
     {
         if (prx == null)
         {
@@ -126,8 +130,12 @@ internal sealed class LoggerAdminI : Ice.LoggerAdminDisp_
     }
 
     public override Ice.LogMessage[]
-    getLog(Ice.LogMessageType[] messageTypes, string[] categories, int messageMax, out string prefix,
-           Ice.Current current)
+    getLog(
+        Ice.LogMessageType[] messageTypes,
+        string[] categories,
+        int messageMax,
+        out string prefix,
+        Ice.Current current)
     {
         LinkedList<Ice.LogMessage> logMessages = null;
         lock (this)
@@ -283,8 +291,8 @@ internal sealed class LoggerAdminI : Ice.LoggerAdminDisp_
         }
     }
 
-    internal void deadRemoteLogger(Ice.RemoteLoggerPrx remoteLogger, Ice.Logger logger, Ice.LocalException ex,
-                                   string operation)
+    internal void
+    deadRemoteLogger(Ice.RemoteLoggerPrx remoteLogger, Ice.Logger logger, Ice.LocalException ex, string operation)
     {
         //
         // No need to convert remoteLogger as we only use its identity
@@ -312,9 +320,11 @@ internal sealed class LoggerAdminI : Ice.LoggerAdminDisp_
         }
     }
 
-    private static void filterLogMessages(LinkedList<Ice.LogMessage> logMessages,
-                                          HashSet<Ice.LogMessageType> messageTypes,
-                                          HashSet<string> traceCategories, int messageMax)
+    private static void filterLogMessages(
+        LinkedList<Ice.LogMessage> logMessages,
+        HashSet<Ice.LogMessageType> messageTypes,
+        HashSet<string> traceCategories,
+        int messageMax)
     {
         Debug.Assert(logMessages.Count > 0 && messageMax != 0);
 

--- a/csharp/src/Ice/Internal/LoggerAdminLoggerI.cs
+++ b/csharp/src/Ice/Internal/LoggerAdminLoggerI.cs
@@ -186,8 +186,11 @@ internal sealed class LoggerAdminLoggerI : LoggerAdminLogger
                                 }
                                 if (ae.InnerException is Ice.LocalException)
                                 {
-                                    _loggerAdmin.deadRemoteLogger(p, _localLogger,
-                                                                  (Ice.LocalException)ae.InnerException, "log");
+                                    _loggerAdmin.deadRemoteLogger(
+                                        p,
+                                        _localLogger,
+                                        (Ice.LocalException)ae.InnerException,
+                                        "log");
                                 }
                             }
                         });

--- a/csharp/src/Ice/Internal/MetricsAdminI.cs
+++ b/csharp/src/Ice/Internal/MetricsAdminI.cs
@@ -431,7 +431,7 @@ public class MetricsMap<T> : IMetricsMap where T : IceMX.Metrics, new()
         //
         lock (this)
         {
-            if (previous != null && previous.getId().Equals(key))
+            if (previous != null && previous.getId().Equals(key, StringComparison.Ordinal))
             {
                 Debug.Assert(_objects[key] == previous);
                 return previous;
@@ -537,8 +537,11 @@ internal class MetricsViewI
         _name = name;
     }
 
-    internal bool addOrUpdateMap(Ice.Properties properties, string mapName, IMetricsMapFactory factory,
-                               Ice.Logger logger)
+    internal bool addOrUpdateMap(
+        Ice.Properties properties,
+        string mapName,
+        IMetricsMapFactory factory,
+        Ice.Logger logger)
     {
         //
         // Add maps to views configured with the given map.
@@ -742,7 +745,7 @@ public class MetricsAdminI : IceMX.MetricsAdminDisp_, Ice.PropertiesAdminUpdateC
             foreach (KeyValuePair<string, string> e in viewsProps)
             {
                 string viewName = e.Key.Substring(viewsPrefix.Length);
-                int dotPos = viewName.IndexOf('.');
+                int dotPos = viewName.IndexOf('.', StringComparison.Ordinal);
                 if (dotPos > 0)
                 {
                     viewName = viewName.Substring(0, dotPos);
@@ -837,8 +840,8 @@ public class MetricsAdminI : IceMX.MetricsAdminDisp_, Ice.PropertiesAdminUpdateC
         updateViews();
     }
 
-    override public Dictionary<string, IceMX.Metrics[]> getMetricsView(string viewName, out long timestamp,
-                                                                       Ice.Current current)
+    override public Dictionary<string, IceMX.Metrics[]>
+    getMetricsView(string viewName, out long timestamp, Ice.Current current)
     {
         lock (this)
         {
@@ -865,8 +868,11 @@ public class MetricsAdminI : IceMX.MetricsAdminDisp_, Ice.PropertiesAdminUpdateC
         }
     }
 
-    override public IceMX.MetricsFailures getMetricsFailures(string viewName, string mapName, string id,
-                                                             Ice.Current c)
+    override public IceMX.MetricsFailures getMetricsFailures(
+        string viewName,
+        string mapName,
+        string id,
+        Ice.Current c)
     {
         lock (this)
         {

--- a/csharp/src/Ice/Internal/Network.cs
+++ b/csharp/src/Ice/Internal/Network.cs
@@ -143,7 +143,7 @@ public sealed class Network
         // TODO: Instead of testing for an English substring, we need to examine the inner
         // exception (if there is one).
         //
-        return ex.Message.Contains("period of time");
+        return ex.Message.Contains("period of time", StringComparison.Ordinal);
     }
 
     public static bool noMoreFds(System.Exception ex)
@@ -407,14 +407,17 @@ public sealed class Network
         {
             if (family == AddressFamily.InterNetwork)
             {
-                socket.SetSocketOption(SocketOptionLevel.IP,
-                                       SocketOptionName.MulticastInterface,
-                                       getInterfaceAddress(iface, family).GetAddressBytes());
+                socket.SetSocketOption(
+                    SocketOptionLevel.IP,
+                    SocketOptionName.MulticastInterface,
+                    getInterfaceAddress(iface, family).GetAddressBytes());
             }
             else
             {
-                socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.MulticastInterface,
-                                       getInterfaceIndex(iface, family));
+                socket.SetSocketOption(
+                    SocketOptionLevel.IPv6,
+                    SocketOptionName.MulticastInterface,
+                    getInterfaceIndex(iface, family));
             }
         }
         catch (System.Exception ex)
@@ -591,11 +594,15 @@ public sealed class Network
         return true;
     }
 
-    public static IAsyncResult doConnectAsync(Socket fd, EndPoint addr, EndPoint sourceAddr, AsyncCallback callback,
-                                              object state)
+    public static IAsyncResult doConnectAsync(
+        Socket fd,
+        EndPoint addr,
+        EndPoint sourceAddr,
+        AsyncCallback callback,
+        object state)
     {
         //
-        // NOTE: It's the caller's responsability to close the socket upon
+        // NOTE: It's the caller's responsibility to close the socket upon
         // failure to connect. The socket isn't closed by this method.
         //
         EndPoint bindAddr = sourceAddr;
@@ -615,14 +622,16 @@ public sealed class Network
     repeatConnect:
         try
         {
-            return fd.BeginConnect(addr,
-                                   delegate (IAsyncResult result)
-                                   {
-                                       if (!result.CompletedSynchronously)
-                                       {
-                                           callback(result.AsyncState);
-                                       }
-                                   }, state);
+            return fd.BeginConnect(
+                addr,
+                (IAsyncResult result) =>
+                {
+                    if (!result.CompletedSynchronously)
+                    {
+                        callback(result.AsyncState);
+                    }
+                },
+                state);
         }
         catch (System.Net.Sockets.SocketException ex)
         {
@@ -705,8 +714,13 @@ public sealed class Network
         return getAddresses(host, port, protocol, Ice.EndpointSelectionType.Ordered, preferIPv6, true)[0];
     }
 
-    public static List<EndPoint> getAddresses(string host, int port, int protocol,
-                                              Ice.EndpointSelectionType selType, bool preferIPv6, bool blocking)
+    public static List<EndPoint> getAddresses(
+        string host,
+        int port,
+        int protocol,
+        Ice.EndpointSelectionType selType,
+        bool preferIPv6,
+        bool blocking)
     {
         List<EndPoint> addresses = new List<EndPoint>();
         if (host.Length == 0)
@@ -1106,7 +1120,7 @@ public sealed class Network
         //
         // The iface parameter must either be an IP address, an
         // index or the name of an interface. If it's an index we
-        // just return it. If it's an IP addess we search for an
+        // just return it. If it's an IP address we search for an
         // interface which has this IP address. If it's a name we
         // search an interface with this name.
         //
@@ -1268,8 +1282,13 @@ public sealed class Network
         EndPoint addr = null;
         if (!string.IsNullOrEmpty(sourceAddress))
         {
-            List<EndPoint> addrs = getAddresses(sourceAddress, 0, EnableBoth, Ice.EndpointSelectionType.Ordered,
-                                                false, false);
+            List<EndPoint> addrs = getAddresses(
+                sourceAddress,
+                0,
+                EnableBoth,
+                Ice.EndpointSelectionType.Ordered,
+                preferIPv6: false,
+                blocking: false);
             if (addrs.Count != 0)
             {
                 return addrs[0];

--- a/csharp/src/Ice/Internal/OpaqueEndpointI.cs
+++ b/csharp/src/Ice/Internal/OpaqueEndpointI.cs
@@ -61,8 +61,8 @@ internal sealed class OpaqueEndpointI : EndpointI
 
     private sealed class InfoI : Ice.OpaqueEndpointInfo
     {
-        public InfoI(short type, Ice.EncodingVersion rawEncoding, byte[] rawBytes) :
-            base(null, -1, false, rawEncoding, rawBytes)
+        public InfoI(short type, Ice.EncodingVersion rawEncoding, byte[] rawBytes)
+            : base(null, -1, false, rawEncoding, rawBytes)
         {
             _type = type;
         }

--- a/csharp/src/Ice/Internal/OutgoingAsync.cs
+++ b/csharp/src/Ice/Internal/OutgoingAsync.cs
@@ -224,8 +224,11 @@ public abstract class OutgoingAsyncBase
         return synchronous_;
     }
 
-    protected OutgoingAsyncBase(Instance instance, OutgoingAsyncCompletionCallback completionCallback,
-                                Ice.OutputStream os = null, Ice.InputStream iss = null)
+    protected OutgoingAsyncBase(
+        Instance instance,
+        OutgoingAsyncCompletionCallback completionCallback,
+        Ice.OutputStream os = null,
+        Ice.InputStream iss = null)
     {
         instance_ = instance;
         sentSynchronously_ = false;
@@ -487,11 +490,12 @@ public abstract class ProxyOutgoingAsyncBase : OutgoingAsyncBase, TimerTask
         }
     }
 
-    protected ProxyOutgoingAsyncBase(Ice.ObjectPrxHelperBase prx,
-                                     OutgoingAsyncCompletionCallback completionCallback,
-                                     Ice.OutputStream os = null,
-                                     Ice.InputStream iss = null) :
-        base(prx.iceReference().getInstance(), completionCallback, os, iss)
+    protected ProxyOutgoingAsyncBase(
+        Ice.ObjectPrxHelperBase prx,
+        OutgoingAsyncCompletionCallback completionCallback,
+        Ice.OutputStream os = null,
+        Ice.InputStream iss = null)
+        : base(prx.iceReference().getInstance(), completionCallback, os, iss)
     {
         proxy_ = prx;
         mode_ = Ice.OperationMode.Normal;
@@ -819,9 +823,12 @@ public abstract class ProxyOutgoingAsyncBase : OutgoingAsyncBase, TimerTask
 //
 public class OutgoingAsync : ProxyOutgoingAsyncBase
 {
-    public OutgoingAsync(Ice.ObjectPrxHelperBase prx, OutgoingAsyncCompletionCallback completionCallback,
-                         Ice.OutputStream os = null, Ice.InputStream iss = null) :
-        base(prx, completionCallback, os, iss)
+    public OutgoingAsync(
+        Ice.ObjectPrxHelperBase prx,
+        OutgoingAsyncCompletionCallback completionCallback,
+        Ice.OutputStream os = null,
+        Ice.InputStream iss = null)
+        : base(prx, completionCallback, os, iss)
     {
         encoding_ = Protocol.getCompatibleEncoding(proxy_.iceReference().getEncoding());
         synchronous_ = false;
@@ -1134,11 +1141,12 @@ public class OutgoingAsync : ProxyOutgoingAsyncBase
 
 public class OutgoingAsyncT<T> : OutgoingAsync
 {
-    public OutgoingAsyncT(Ice.ObjectPrxHelperBase prx,
-                          OutgoingAsyncCompletionCallback completionCallback,
-                          Ice.OutputStream os = null,
-                          Ice.InputStream iss = null) :
-        base(prx, completionCallback, os, iss)
+    public OutgoingAsyncT(
+        Ice.ObjectPrxHelperBase prx,
+        OutgoingAsyncCompletionCallback completionCallback,
+        Ice.OutputStream os = null,
+        Ice.InputStream iss = null)
+        : base(prx, completionCallback, os, iss)
     {
     }
 
@@ -1206,8 +1214,8 @@ public class OutgoingAsyncT<T> : OutgoingAsync
 //
 internal class ProxyFlushBatchAsync : ProxyOutgoingAsyncBase
 {
-    public ProxyFlushBatchAsync(Ice.ObjectPrxHelperBase prx, OutgoingAsyncCompletionCallback completionCallback) :
-        base(prx, completionCallback)
+    public ProxyFlushBatchAsync(Ice.ObjectPrxHelperBase prx, OutgoingAsyncCompletionCallback completionCallback)
+        : base(prx, completionCallback)
     {
     }
 
@@ -1266,8 +1274,8 @@ internal class ProxyFlushBatchAsync : ProxyOutgoingAsyncBase
 //
 internal class ProxyGetConnection : ProxyOutgoingAsyncBase
 {
-    public ProxyGetConnection(Ice.ObjectPrxHelperBase prx, OutgoingAsyncCompletionCallback completionCallback) :
-        base(prx, completionCallback)
+    public ProxyGetConnection(Ice.ObjectPrxHelperBase prx, OutgoingAsyncCompletionCallback completionCallback)
+        : base(prx, completionCallback)
     {
     }
 
@@ -1305,10 +1313,11 @@ internal class ProxyGetConnection : ProxyOutgoingAsyncBase
 
 internal class ConnectionFlushBatchAsync : OutgoingAsyncBase
 {
-    public ConnectionFlushBatchAsync(Ice.ConnectionI connection,
-                                     Instance instance,
-                                     OutgoingAsyncCompletionCallback completionCallback) :
-        base(instance, completionCallback)
+    public ConnectionFlushBatchAsync(
+        Ice.ConnectionI connection,
+        Instance instance,
+        OutgoingAsyncCompletionCallback completionCallback)
+        : base(instance, completionCallback)
     {
         _connection = connection;
     }
@@ -1387,9 +1396,11 @@ public class CommunicatorFlushBatchAsync : OutgoingAsyncBase
 {
     private class FlushBatch : OutgoingAsyncBase
     {
-        public FlushBatch(CommunicatorFlushBatchAsync outAsync,
-                          Instance instance,
-                          Ice.Instrumentation.InvocationObserver observer) : base(instance, null)
+        public FlushBatch(
+            CommunicatorFlushBatchAsync outAsync,
+            Instance instance,
+            Ice.Instrumentation.InvocationObserver observer)
+            : base(instance, null)
         {
             _outAsync = outAsync;
             _observer = observer;
@@ -1430,8 +1441,8 @@ public class CommunicatorFlushBatchAsync : OutgoingAsyncBase
         private Ice.Instrumentation.InvocationObserver _observer;
     };
 
-    public CommunicatorFlushBatchAsync(Instance instance, OutgoingAsyncCompletionCallback callback) :
-        base(instance, callback)
+    public CommunicatorFlushBatchAsync(Instance instance, OutgoingAsyncCompletionCallback callback)
+        : base(instance, callback)
     {
         //
         // _useCount is initialized to 1 to prevent premature callbacks.
@@ -1609,8 +1620,8 @@ public abstract class TaskCompletionCallback<T> : TaskCompletionSource<T>, Outgo
 
 public class OperationTaskCompletionCallback<T> : TaskCompletionCallback<T>
 {
-    public OperationTaskCompletionCallback(System.IProgress<bool> progress, CancellationToken cancellationToken) :
-        base(progress, cancellationToken)
+    public OperationTaskCompletionCallback(System.IProgress<bool> progress, CancellationToken cancellationToken)
+        : base(progress, cancellationToken)
     {
     }
 
@@ -1622,9 +1633,10 @@ public class OperationTaskCompletionCallback<T> : TaskCompletionCallback<T>
 
 public class FlushBatchTaskCompletionCallback : TaskCompletionCallback<object>
 {
-    public FlushBatchTaskCompletionCallback(System.IProgress<bool> progress = null,
-                                            CancellationToken cancellationToken = default) :
-        base(progress, cancellationToken)
+    public FlushBatchTaskCompletionCallback(
+        IProgress<bool> progress = null,
+        CancellationToken cancellationToken = default)
+        : base(progress, cancellationToken)
     {
     }
 

--- a/csharp/src/Ice/Internal/PropertiesAdminI.cs
+++ b/csharp/src/Ice/Internal/PropertiesAdminI.cs
@@ -60,7 +60,7 @@ internal sealed class PropertiesAdminI : Ice.PropertiesAdminDisp_, Ice.NativePro
                 else
                 {
                     string v;
-                    if (!old.TryGetValue(key, out v) || !value.Equals(v))
+                    if (!old.TryGetValue(key, out v) || !value.Equals(v, StringComparison.Ordinal))
                     {
                         if (value.Length == 0)
                         {

--- a/csharp/src/Ice/Internal/ProtocolInstance.cs
+++ b/csharp/src/Ice/Internal/ProtocolInstance.cs
@@ -105,8 +105,12 @@ public class ProtocolInstance
         return instance_.messageSizeMax();
     }
 
-    public void resolve(string host, int port, Ice.EndpointSelectionType type, IPEndpointI endpt,
-                        EndpointI_connectors callback)
+    public void resolve(
+        string host,
+        int port,
+        Ice.EndpointSelectionType type,
+        IPEndpointI endpt,
+        EndpointI_connectors callback)
     {
         instance_.endpointHostResolver().resolve(host, port, type, endpt, callback);
     }

--- a/csharp/src/Ice/Internal/Reference.cs
+++ b/csharp/src/Ice/Internal/Reference.cs
@@ -1432,8 +1432,11 @@ public class RoutableReference : Reference
             // Get an existing connection or create one if there's no
             // existing connection to one of the given endpoints.
             //
-            factory.create(endpoints.ToList(), false, getEndpointSelection(),
-                           new CreateConnectionCallback(this, null, callback));
+            factory.create(
+                endpoints.ToList(),
+                false,
+                getEndpointSelection(),
+                new CreateConnectionCallback(this, null, callback));
         }
         else
         {
@@ -1445,8 +1448,11 @@ public class RoutableReference : Reference
             // connection for one of the endpoints.
             //
 
-            factory.create(new List<EndpointI> { endpoints[0] }, true, getEndpointSelection(),
-                           new CreateConnectionCallback(this, endpoints, callback));
+            factory.create(
+                new List<EndpointI> { endpoints[0] },
+                true,
+                getEndpointSelection(),
+                new CreateConnectionCallback(this, endpoints, callback));
         }
     }
 

--- a/csharp/src/Ice/Internal/ReferenceFactory.cs
+++ b/csharp/src/Ice/Internal/ReferenceFactory.cs
@@ -16,8 +16,16 @@ public class ReferenceFactory
             return null;
         }
 
-        return create(ident, facet, tmpl.getMode(), tmpl.getSecure(), tmpl.getProtocol(), tmpl.getEncoding(),
-                      endpoints, null, null);
+        return create(
+            ident,
+            facet,
+            tmpl.getMode(),
+            tmpl.getSecure(),
+            tmpl.getProtocol(),
+            tmpl.getEncoding(),
+            endpoints,
+            null,
+            null);
     }
 
     public Reference
@@ -31,8 +39,16 @@ public class ReferenceFactory
         //
         // Create new reference
         //
-        return create(ident, facet, tmpl.getMode(), tmpl.getSecure(), tmpl.getProtocol(), tmpl.getEncoding(),
-                      null, adapterId, null);
+        return create(
+            ident,
+            facet,
+            tmpl.getMode(),
+            tmpl.getSecure(),
+            tmpl.getProtocol(),
+            tmpl.getEncoding(),
+            null,
+            adapterId,
+            null);
     }
 
     public Reference create(Ice.Identity ident, Ice.ConnectionI connection)

--- a/csharp/src/Ice/Internal/TcpAcceptor.cs
+++ b/csharp/src/Ice/Internal/TcpAcceptor.cs
@@ -42,13 +42,15 @@ internal class TcpAcceptor : Acceptor
     {
         try
         {
-            _result = _fd.BeginAccept(delegate (IAsyncResult result)
-                                      {
-                                          if (!result.CompletedSynchronously)
-                                          {
-                                              callback(result.AsyncState);
-                                          }
-                                      }, state);
+            _result = _fd.BeginAccept(
+                (IAsyncResult result) =>
+                {
+                    if (!result.CompletedSynchronously)
+                    {
+                        callback(result.AsyncState);
+                    }
+                },
+                state);
         }
         catch (System.Net.Sockets.SocketException ex)
         {

--- a/csharp/src/Ice/Internal/TcpConnector.cs
+++ b/csharp/src/Ice/Internal/TcpConnector.cs
@@ -19,8 +19,13 @@ internal sealed class TcpConnector : Connector
     //
     // Only for use by TcpEndpoint
     //
-    internal TcpConnector(ProtocolInstance instance, EndPoint addr, NetworkProxy proxy, EndPoint sourceAddr,
-                          int timeout, string connectionId)
+    internal TcpConnector(
+        ProtocolInstance instance,
+        EndPoint addr,
+        NetworkProxy proxy,
+        EndPoint sourceAddr,
+        int timeout,
+        string connectionId)
     {
         _instance = instance;
         _addr = addr;
@@ -53,7 +58,7 @@ internal sealed class TcpConnector : Connector
             return false;
         }
 
-        if (!_connectionId.Equals(p._connectionId))
+        if (!_connectionId.Equals(p._connectionId, StringComparison.Ordinal))
         {
             return false;
         }

--- a/csharp/src/Ice/Internal/TcpEndpointI.cs
+++ b/csharp/src/Ice/Internal/TcpEndpointI.cs
@@ -9,16 +9,22 @@ namespace Ice.Internal;
 
 internal sealed class TcpEndpointI : IPEndpointI
 {
-    public TcpEndpointI(ProtocolInstance instance, string ho, int po, EndPoint sourceAddr, int ti, string conId,
-                        bool co) :
-        base(instance, ho, po, sourceAddr, conId)
+    public TcpEndpointI(
+        ProtocolInstance instance,
+        string ho,
+        int po,
+        EndPoint sourceAddr,
+        int ti,
+        string conId,
+        bool co)
+        : base(instance, ho, po, sourceAddr, conId)
     {
         _timeout = ti;
         _compress = co;
     }
 
-    public TcpEndpointI(ProtocolInstance instance) :
-        base(instance)
+    public TcpEndpointI(ProtocolInstance instance)
+        : base(instance)
     {
         // The default timeout for TCP endpoints is 60,000 milliseconds (1 minute).
         // This timeout is not used in Ice 3.8 or greater.
@@ -26,8 +32,8 @@ internal sealed class TcpEndpointI : IPEndpointI
         _compress = false;
     }
 
-    public TcpEndpointI(ProtocolInstance instance, Ice.InputStream s) :
-        base(instance, s)
+    public TcpEndpointI(ProtocolInstance instance, Ice.InputStream s)
+        : base(instance, s)
     {
         _timeout = s.readInt();
         _compress = s.readBool();

--- a/csharp/src/Ice/Internal/UdpConnector.cs
+++ b/csharp/src/Ice/Internal/UdpConnector.cs
@@ -19,8 +19,13 @@ internal sealed class UdpConnector : Connector
     //
     // Only for use by UdpEndpointI
     //
-    internal UdpConnector(ProtocolInstance instance, EndPoint addr, EndPoint sourceAddr, string mcastInterface,
-                          int mcastTtl, string connectionId)
+    internal UdpConnector(
+        ProtocolInstance instance,
+        EndPoint addr,
+        EndPoint sourceAddr,
+        string mcastInterface,
+        int mcastTtl,
+        string connectionId)
     {
         _instance = instance;
         _addr = addr;
@@ -43,12 +48,12 @@ internal sealed class UdpConnector : Connector
         }
 
         UdpConnector p = (UdpConnector)obj;
-        if (!_connectionId.Equals(p._connectionId))
+        if (!_connectionId.Equals(p._connectionId, StringComparison.Ordinal))
         {
             return false;
         }
 
-        if (!_mcastInterface.Equals(p._mcastInterface))
+        if (!_mcastInterface.Equals(p._mcastInterface, StringComparison.Ordinal))
         {
             return false;
         }

--- a/csharp/src/Ice/Internal/UdpEndpointI.cs
+++ b/csharp/src/Ice/Internal/UdpEndpointI.cs
@@ -9,9 +9,17 @@ namespace Ice.Internal;
 
 internal sealed class UdpEndpointI : IPEndpointI
 {
-    public UdpEndpointI(ProtocolInstance instance, string ho, int po, EndPoint sourceAddr, string mcastInterface,
-                        int mttl, bool conn, string conId, bool co) :
-        base(instance, ho, po, sourceAddr, conId)
+    public UdpEndpointI(
+        ProtocolInstance instance,
+        string ho,
+        int po,
+        EndPoint sourceAddr,
+        string mcastInterface,
+        int mttl,
+        bool conn,
+        string conId,
+        bool co)
+        : base(instance, ho, po, sourceAddr, conId)
     {
         _mcastInterface = mcastInterface;
         _mcastTtl = mttl;
@@ -19,15 +27,15 @@ internal sealed class UdpEndpointI : IPEndpointI
         _compress = co;
     }
 
-    public UdpEndpointI(ProtocolInstance instance) :
-        base(instance)
+    public UdpEndpointI(ProtocolInstance instance)
+        : base(instance)
     {
         _connect = false;
         _compress = false;
     }
 
-    public UdpEndpointI(ProtocolInstance instance, Ice.InputStream s) :
-        base(instance, s)
+    public UdpEndpointI(ProtocolInstance instance, Ice.InputStream s)
+        : base(instance, s)
     {
         if (s.getEncoding().Equals(Ice.Util.Encoding_1_0))
         {
@@ -118,8 +126,16 @@ internal sealed class UdpEndpointI : IPEndpointI
         }
         else
         {
-            return new UdpEndpointI(instance_, host_, port_, sourceAddr_, _mcastInterface, _mcastTtl, _connect,
-                                    connectionId_, compress);
+            return new UdpEndpointI(
+                instance_,
+                host_,
+                port_,
+                sourceAddr_,
+                _mcastInterface,
+                _mcastTtl,
+                _connect,
+                connectionId_,
+                compress);
         }
     }
 
@@ -176,8 +192,16 @@ internal sealed class UdpEndpointI : IPEndpointI
         }
         else
         {
-            return new UdpEndpointI(instance_, host_, port, sourceAddr_, _mcastInterface, _mcastTtl, _connect,
-                                    connectionId_, _compress);
+            return new UdpEndpointI(
+                instance_,
+                host_,
+                port,
+                sourceAddr_,
+                _mcastInterface,
+                _mcastTtl,
+                _connect,
+                connectionId_,
+                _compress);
         }
     }
 
@@ -194,7 +218,7 @@ internal sealed class UdpEndpointI : IPEndpointI
 
         if (_mcastInterface.Length != 0)
         {
-            bool addQuote = _mcastInterface.Contains(':');
+            bool addQuote = _mcastInterface.Contains(':', StringComparison.Ordinal);
             s += " --interface ";
             if (addQuote)
             {
@@ -397,8 +421,16 @@ internal sealed class UdpEndpointI : IPEndpointI
 
     protected override IPEndpointI createEndpoint(string host, int port, string connectionId)
     {
-        return new UdpEndpointI(instance_, host, port, sourceAddr_, _mcastInterface, _mcastTtl, _connect,
-                                connectionId, _compress);
+        return new UdpEndpointI(
+            instance_,
+            host,
+            port,
+            sourceAddr_,
+            _mcastInterface,
+            _mcastTtl,
+            _connect,
+            connectionId,
+            _compress);
     }
 
     private string _mcastInterface = "";

--- a/csharp/src/Ice/Internal/UdpTransceiver.cs
+++ b/csharp/src/Ice/Internal/UdpTransceiver.cs
@@ -644,13 +644,16 @@ internal sealed class UdpTransceiver : Transceiver
         List<string> intfs;
         if (_mcastAddr == null)
         {
-            intfs = Network.getHostsForEndpointExpand(Network.endpointAddressToString(_addr),
-                                                      _instance.protocolSupport(), true);
+            intfs = Network.getHostsForEndpointExpand(
+                Network.endpointAddressToString(_addr),
+                _instance.protocolSupport(),
+                true);
         }
         else
         {
-            intfs = Network.getInterfacesForMulticast(_mcastInterface,
-                                                      Network.getProtocolSupport(_mcastAddr.Address));
+            intfs = Network.getInterfacesForMulticast(
+                _mcastInterface,
+                Network.getProtocolSupport(_mcastAddr.Address));
         }
         if (intfs.Count != 0)
         {
@@ -668,8 +671,12 @@ internal sealed class UdpTransceiver : Transceiver
     //
     // Only for use by UdpConnector.
     //
-    internal UdpTransceiver(ProtocolInstance instance, EndPoint addr, EndPoint sourceAddr, string mcastInterface,
-                            int mcastTtl)
+    internal UdpTransceiver(
+        ProtocolInstance instance,
+        EndPoint addr,
+        EndPoint sourceAddr,
+        string mcastInterface,
+        int mcastTtl)
     {
         _instance = instance;
         _addr = addr;
@@ -714,8 +721,13 @@ internal sealed class UdpTransceiver : Transceiver
     //
     // Only for use by UdpEndpoint.
     //
-    internal UdpTransceiver(UdpEndpointI endpoint, ProtocolInstance instance, string host, int port,
-                            string mcastInterface, bool connect)
+    internal UdpTransceiver(
+        UdpEndpointI endpoint,
+        ProtocolInstance instance,
+        string host,
+        int port,
+        string mcastInterface,
+        bool connect)
     {
         _endpoint = endpoint;
         _instance = instance;

--- a/csharp/src/Ice/Internal/ValueWriter.cs
+++ b/csharp/src/Ice/Internal/ValueWriter.cs
@@ -100,8 +100,8 @@ public sealed class ValueWriter
         }
     }
 
-    private static void writeFields(string name, object obj, System.Type c, Dictionary<Ice.Object, object> objectTable,
-                                    OutputBase output)
+    private static void
+    writeFields(string name, object obj, System.Type c, Dictionary<Ice.Object, object> objectTable, OutputBase output)
     {
         if (!c.Equals(typeof(object)))
         {

--- a/csharp/src/Ice/Internal/WSConnector.cs
+++ b/csharp/src/Ice/Internal/WSConnector.cs
@@ -40,7 +40,7 @@ internal sealed class WSConnector : Connector
             return false;
         }
 
-        if (!_resource.Equals(p._resource))
+        if (!_resource.Equals(p._resource, StringComparison.Ordinal))
         {
             return false;
         }

--- a/csharp/src/Ice/Internal/WSEndpoint.cs
+++ b/csharp/src/Ice/Internal/WSEndpoint.cs
@@ -109,7 +109,7 @@ internal sealed class WSEndpoint : EndpointI
 
     public override EndpointI connectionId(string connectionId)
     {
-        if (connectionId.Equals(_delegate.connectionId()))
+        if (connectionId.Equals(_delegate.connectionId(), StringComparison.Ordinal))
         {
             return this;
         }
@@ -262,7 +262,7 @@ internal sealed class WSEndpoint : EndpointI
         if (_resource != null && _resource.Length > 0)
         {
             s += " -r ";
-            bool addQuote = _resource.Contains(':');
+            bool addQuote = _resource.Contains(':', StringComparison.Ordinal);
             if (addQuote)
             {
                 s += "\"";

--- a/csharp/src/Ice/Internal/WSTransceiver.cs
+++ b/csharp/src/Ice/Internal/WSTransceiver.cs
@@ -566,8 +566,11 @@ internal sealed class WSTransceiver : Transceiver
         postRead(buf);
     }
 
-    public bool startWrite(Buffer buf, AsyncCallback callback, object state,
-                           out bool completed)
+    public bool startWrite(
+        Buffer buf,
+        AsyncCallback callback,
+        object state,
+        out bool completed)
     {
         _writePending = true;
         if (_state < StateOpened)
@@ -801,7 +804,7 @@ internal sealed class WSTransceiver : Transceiver
             }
             foreach (string p in protocols)
             {
-                if (!p.Trim().Equals(_iceProtocol))
+                if (!p.Trim().Equals(_iceProtocol, StringComparison.Ordinal))
                 {
                     throw new WebSocketException("unknown value `" + p + "' for WebSocket protocol");
                 }
@@ -935,7 +938,7 @@ internal sealed class WSTransceiver : Transceiver
         //  the WebSocket Connection_."
         //
         val = _parser.getHeader("Sec-WebSocket-Protocol", true);
-        if (val != null && !val.Equals(_iceProtocol))
+        if (val != null && !val.Equals(_iceProtocol, StringComparison.Ordinal))
         {
             throw new WebSocketException("invalid value `" + val + "' for WebSocket protocol");
         }
@@ -957,7 +960,7 @@ internal sealed class WSTransceiver : Transceiver
 
         string input = _key + _wsUUID;
         byte[] hash = SHA1.Create().ComputeHash(_utf8.GetBytes(input));
-        if (!val.Equals(Convert.ToBase64String(hash)))
+        if (!val.Equals(Convert.ToBase64String(hash), StringComparison.Ordinal))
         {
             throw new WebSocketException("invalid value `" + val + "' for Sec-WebSocket-Accept");
         }
@@ -1191,8 +1194,12 @@ internal sealed class WSTransceiver : Transceiver
                 if (_readPayloadLength > 0 && _readOpCode == OP_PING)
                 {
                     _pingPayload = new byte[_readPayloadLength];
-                    System.Buffer.BlockCopy(_readBuffer.b.rawBytes(), _readBufferPos, _pingPayload, 0,
-                                            _readPayloadLength);
+                    System.Buffer.BlockCopy(
+                        _readBuffer.b.rawBytes(),
+                        _readBufferPos,
+                        _pingPayload,
+                        0,
+                        _readPayloadLength);
                 }
 
                 _readBufferPos += _readPayloadLength;
@@ -1237,8 +1244,12 @@ internal sealed class WSTransceiver : Transceiver
                 }
                 if (n > 0)
                 {
-                    System.Buffer.BlockCopy(_readBuffer.b.rawBytes(), _readBufferPos, buf.b.rawBytes(),
-                                            buf.b.position(), n);
+                    System.Buffer.BlockCopy(
+                        _readBuffer.b.rawBytes(),
+                        _readBufferPos,
+                        buf.b.rawBytes(),
+                        buf.b.position(),
+                        n);
                     buf.b.position(buf.b.position() + n);
                     _readBufferPos += n;
                 }

--- a/csharp/src/Ice/LoggerI.cs
+++ b/csharp/src/Ice/LoggerI.cs
@@ -128,8 +128,8 @@ internal sealed class FileLoggerI : LoggerI
         _writer.Flush();
     }
 
-    internal FileLoggerI(string prefix, string file) :
-        base(prefix)
+    internal FileLoggerI(string prefix, string file)
+        : base(prefix)
     {
         _file = file;
         _writer = new StreamWriter(new FileStream(file, FileMode.Append, FileAccess.Write, FileShare.ReadWrite));

--- a/csharp/src/Ice/MetricsObserverI.cs
+++ b/csharp/src/Ice/MetricsObserverI.cs
@@ -106,8 +106,10 @@ public class MetricsHelper<T> where T : Metrics
 
         private class MemberFieldResolverI : Resolver
         {
-            internal MemberFieldResolverI(string name, System.Reflection.MethodInfo method,
-                                          System.Reflection.FieldInfo field)
+            internal MemberFieldResolverI(
+                string name,
+                System.Reflection.MethodInfo method,
+                System.Reflection.FieldInfo field)
                 : base(name)
             {
                 Debug.Assert(method != null && field != null);
@@ -152,8 +154,10 @@ public class MetricsHelper<T> where T : Metrics
 
         private class MemberMethodResolverI : Resolver
         {
-            internal MemberMethodResolverI(string name, System.Reflection.MethodInfo method,
-                                           System.Reflection.MethodInfo subMeth)
+            internal MemberMethodResolverI(
+                string name,
+                System.Reflection.MethodInfo method,
+                System.Reflection.MethodInfo subMeth)
                 : base(name)
             {
                 Debug.Assert(method != null && subMeth != null);

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -981,7 +981,8 @@ public sealed class ObjectAdapter
             // Proxy is local if the reference adapter id matches this
             // adapter id or replica group id.
             //
-            return r.getAdapterId().Equals(_id) || r.getAdapterId().Equals(_replicaGroupId);
+            return r.getAdapterId().Equals(_id, StringComparison.Ordinal) ||
+                r.getAdapterId().Equals(_replicaGroupId, StringComparison.Ordinal);
         }
         else
         {
@@ -1704,7 +1705,7 @@ public sealed class ObjectAdapter
             bool valid = false;
             for (int i = 0; i < _suffixes.Length; ++i)
             {
-                if (prop.Equals(prefix + _suffixes[i]))
+                if (prop.Equals(prefix + _suffixes[i], StringComparison.Ordinal))
                 {
                     noProps = false;
                     valid = true;

--- a/csharp/src/Ice/OutgoingResponse.cs
+++ b/csharp/src/Ice/OutgoingResponse.cs
@@ -65,8 +65,8 @@ public sealed class OutgoingResponse
     /// Constructs an OutgoingResponse object with the <see cref="ReplyStatus.Ok"/> status.
     /// </summary>
     /// <param name="outputStream">The output stream that holds the response.</param>
-    public OutgoingResponse(OutputStream outputStream) :
-        this(ReplyStatus.Ok, exceptionId: null, exceptionDetails: null, outputStream)
+    public OutgoingResponse(OutputStream outputStream)
+        : this(ReplyStatus.Ok, exceptionId: null, exceptionDetails: null, outputStream)
     {
     }
 }

--- a/csharp/src/Ice/PluginManagerI.cs
+++ b/csharp/src/Ice/PluginManagerI.cs
@@ -383,13 +383,13 @@ internal sealed class PluginManagerI : PluginManager
             //
             // Extract the assembly name and the class name.
             //
-            int sepPos = entryPoint!.IndexOf(':');
+            int sepPos = entryPoint!.IndexOf(':', StringComparison.Ordinal);
             if (sepPos != -1)
             {
                 const string driveLetters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
                 if (entryPoint.Length > 3 &&
                    sepPos == 1 &&
-                   driveLetters.Contains(entryPoint[0]) &&
+                   driveLetters.Contains(entryPoint[0], StringComparison.Ordinal) &&
                    (entryPoint[2] == '\\' || entryPoint[2] == '/'))
                 {
                     sepPos = entryPoint.IndexOf(':', 3);
@@ -491,7 +491,7 @@ internal sealed class PluginManagerI : PluginManager
     {
         foreach (PluginInfo p in _plugins)
         {
-            if (name.Equals(p.name))
+            if (name.Equals(p.name, StringComparison.Ordinal))
             {
                 return p.plugin;
             }

--- a/csharp/src/Ice/Properties.cs
+++ b/csharp/src/Ice/Properties.cs
@@ -777,7 +777,7 @@ public sealed class Properties
 
             // As a courtesy to the user, perform a case-insensitive match and suggest the correct property.
             // Otherwise no other warning is issued.
-            if (logWarnings && propPrefix.Equals(prefix, StringComparison.InvariantCultureIgnoreCase))
+            if (logWarnings && propPrefix.Equals(prefix, StringComparison.OrdinalIgnoreCase))
             {
                 logger.warning("unknown property: `" + key + "'; did you mean `" + propPrefix + "'?");
                 return null;

--- a/csharp/src/Ice/Properties.cs
+++ b/csharp/src/Ice/Properties.cs
@@ -73,7 +73,7 @@ public sealed class Properties
             if (args[i].StartsWith("--Ice.Config", StringComparison.Ordinal))
             {
                 string line = args[i];
-                if (!line.Contains('='))
+                if (!line.Contains('=', StringComparison.Ordinal))
                 {
                     line += "=1";
                 }
@@ -425,7 +425,7 @@ public sealed class Properties
             string opt = options[i];
             if (opt.StartsWith(pfx, StringComparison.Ordinal))
             {
-                if (!opt.Contains('='))
+                if (!opt.Contains('=', StringComparison.Ordinal))
                 {
                     opt += "=1";
                 }
@@ -742,7 +742,7 @@ public sealed class Properties
     {
         // Check if the property is a known Ice property and log warnings if necessary
         Logger logger = Util.getProcessLogger();
-        int dotPos = key.IndexOf('.');
+        int dotPos = key.IndexOf('.', StringComparison.Ordinal);
 
         // If the key doesn't contain a dot, it's not a valid Ice property
         if (dotPos == -1)
@@ -758,7 +758,7 @@ public sealed class Properties
         foreach (Property[]? validProps in PropertyNames.validProps)
         {
             string pattern = validProps[0].pattern;
-            dotPos = pattern.IndexOf('.');
+            dotPos = pattern.IndexOf('.', StringComparison.Ordinal);
 
             // Each top level prefix describes a non-empty
             // namespace. Having a string without a prefix followed by a
@@ -777,7 +777,7 @@ public sealed class Properties
 
             // As a courtesy to the user, perform a case-insensitive match and suggest the correct property.
             // Otherwise no other warning is issued.
-            if (logWarnings && propPrefix.ToUpper().Equals(prefix.ToUpper()))
+            if (logWarnings && propPrefix.Equals(prefix, StringComparison.InvariantCultureIgnoreCase))
             {
                 logger.warning("unknown property: `" + key + "'; did you mean `" + propPrefix + "'?");
                 return null;

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -36,10 +36,11 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <param name="progress">Sent progress provider.</param>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    Task<bool> ice_isAAsync(string id,
-                            Dictionary<string, string>? context = null,
-                            IProgress<bool>? progress = null,
-                            CancellationToken cancel = default);
+    Task<bool> ice_isAAsync(
+        string id,
+        Dictionary<string, string>? context = null,
+        IProgress<bool>? progress = null,
+        CancellationToken cancel = default);
 
     /// <summary>
     /// Tests whether the target object of this proxy can be reached.
@@ -54,9 +55,10 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <param name="progress">Sent progress provider.</param>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    Task ice_pingAsync(Dictionary<string, string>? context = null,
-                       IProgress<bool>? progress = null,
-                       CancellationToken cancel = default);
+    Task ice_pingAsync(
+        Dictionary<string, string>? context = null,
+        IProgress<bool>? progress = null,
+        CancellationToken cancel = default);
 
     /// <summary>
     /// Returns the Slice type IDs of the interfaces supported by the target object of this proxy.
@@ -73,9 +75,10 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <param name="progress">Sent progress provider.</param>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    Task<string[]> ice_idsAsync(Dictionary<string, string>? context = null,
-                                IProgress<bool>? progress = null,
-                                CancellationToken cancel = default);
+    Task<string[]> ice_idsAsync(
+        Dictionary<string, string>? context = null,
+        IProgress<bool>? progress = null,
+        CancellationToken cancel = default);
 
     /// <summary>
     /// Returns the Slice type ID of the most-derived interface supported by the target object of this proxy.
@@ -91,9 +94,10 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <param name="progress">Sent progress provider.</param>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    Task<string> ice_idAsync(Dictionary<string, string>? context = null,
-                             IProgress<bool>? progress = null,
-                             CancellationToken cancel = default);
+    Task<string> ice_idAsync(
+        Dictionary<string, string>? context = null,
+        IProgress<bool>? progress = null,
+        CancellationToken cancel = default);
 
     /// <summary>
     /// Invokes an operation dynamically.
@@ -109,8 +113,12 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// the return value is false; in this case, outEncaps
     /// contains the encoded user exception. If the operation raises a run-time exception,
     /// it throws it directly.</returns>
-    bool ice_invoke(string operation, OperationMode mode, byte[] inEncaps, out byte[] outEncaps,
-                    Dictionary<string, string>? context = null);
+    bool ice_invoke(
+        string operation,
+        OperationMode mode,
+        byte[] inEncaps,
+        out byte[] outEncaps,
+        Dictionary<string, string>? context = null);
 
     /// <summary>
     /// Invokes an operation dynamically.
@@ -123,12 +131,13 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
     Task<Object_Ice_invokeResult>
-    ice_invokeAsync(string operation,
-                    OperationMode mode,
-                    byte[] inEncaps,
-                    Dictionary<string, string>? context = null,
-                    IProgress<bool>? progress = null,
-                    CancellationToken cancel = default);
+    ice_invokeAsync(
+        string operation,
+        OperationMode mode,
+        byte[] inEncaps,
+        Dictionary<string, string>? context = null,
+        IProgress<bool>? progress = null,
+        CancellationToken cancel = default);
 
     /// <summary>
     /// Returns the identity embedded in this proxy.
@@ -471,8 +480,9 @@ public interface ObjectPrx : IEquatable<ObjectPrx>
     /// <param name="progress">Sent progress provider.</param>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    Task ice_flushBatchRequestsAsync(IProgress<bool>? progress = null,
-                                     CancellationToken cancel = default);
+    Task ice_flushBatchRequestsAsync(
+        IProgress<bool>? progress = null,
+        CancellationToken cancel = default);
 
     /// <summary>
     /// Write a proxy to the output stream.
@@ -568,17 +578,22 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     /// <param name="progress">Sent progress provider.</param>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    public Task<bool> ice_isAAsync(string id,
-                                   Dictionary<string, string>? context = null,
-                                   IProgress<bool>? progress = null,
-                                   CancellationToken cancel = default)
+    public Task<bool> ice_isAAsync(
+        string id,
+        Dictionary<string, string>? context = null,
+        IProgress<bool>? progress = null,
+        CancellationToken cancel = default)
     {
         return iceI_ice_isAAsync(id, context, progress, cancel, false);
     }
 
     private Task<bool>
-    iceI_ice_isAAsync(string id, Dictionary<string, string>? context, IProgress<bool>? progress, CancellationToken cancel,
-                      bool synchronous)
+    iceI_ice_isAAsync(
+        string id,
+        Dictionary<string, string>? context,
+        IProgress<bool>? progress,
+        CancellationToken cancel,
+        bool synchronous)
     {
         iceCheckTwowayOnly(_ice_isA_name);
         var completed = new OperationTaskCompletionCallback<bool>(progress, cancel);
@@ -588,10 +603,11 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
 
     private const string _ice_isA_name = "ice_isA";
 
-    private void iceI_ice_isA(string id,
-                              Dictionary<string, string>? context,
-                              OutgoingAsyncCompletionCallback completed,
-                              bool synchronous)
+    private void iceI_ice_isA(
+        string id,
+        Dictionary<string, string>? context,
+        OutgoingAsyncCompletionCallback completed,
+        bool synchronous)
     {
         iceCheckAsyncTwowayOnly(_ice_isA_name);
         getOutgoingAsync<bool>(completed).invoke(_ice_isA_name,
@@ -644,8 +660,10 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
 
     private const string _ice_ping_name = "ice_ping";
 
-    private void iceI_ice_ping(Dictionary<string, string>? context, OutgoingAsyncCompletionCallback completed,
-                                   bool synchronous)
+    private void iceI_ice_ping(
+        Dictionary<string, string>? context,
+        OutgoingAsyncCompletionCallback completed,
+        bool synchronous)
     {
         getOutgoingAsync<object>(completed).invoke(_ice_ping_name,
                                                    OperationMode.Idempotent,
@@ -687,8 +705,11 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
         return iceI_ice_idsAsync(context, progress, cancel, false);
     }
 
-    private Task<string[]> iceI_ice_idsAsync(Dictionary<string, string>? context, IProgress<bool>? progress, CancellationToken cancel,
-                                             bool synchronous)
+    private Task<string[]> iceI_ice_idsAsync(
+        Dictionary<string, string>? context,
+        IProgress<bool>? progress,
+        CancellationToken cancel,
+        bool synchronous)
     {
         iceCheckTwowayOnly(_ice_ids_name);
         var completed = new OperationTaskCompletionCallback<string[]>(progress, cancel);
@@ -698,16 +719,19 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
 
     private const string _ice_ids_name = "ice_ids";
 
-    private void iceI_ice_ids(Dictionary<string, string>? context, OutgoingAsyncCompletionCallback completed,
-                              bool synchronous)
+    private void iceI_ice_ids(
+        Dictionary<string, string>? context,
+        OutgoingAsyncCompletionCallback completed,
+        bool synchronous)
     {
         iceCheckAsyncTwowayOnly(_ice_ids_name);
-        getOutgoingAsync<string[]>(completed).invoke(_ice_ids_name,
-                                                     OperationMode.Idempotent,
-                                                     FormatType.CompactFormat,
-                                                     context,
-                                                     synchronous,
-                                                     read: (InputStream iss) => { return iss.readStringSeq(); });
+        getOutgoingAsync<string[]>(completed).invoke(
+            _ice_ids_name,
+            OperationMode.Idempotent,
+            FormatType.CompactFormat,
+            context,
+            synchronous,
+            read: (InputStream iss) => { return iss.readStringSeq(); });
     }
 
     /// <summary>
@@ -1656,8 +1680,12 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
         {
         }
 
-        public void invoke(string operation, OperationMode mode, byte[] inParams,
-                           Dictionary<string, string>? context, bool synchronous)
+        public void invoke(
+            string operation,
+            OperationMode mode,
+            byte[] inParams,
+            Dictionary<string, string>? context,
+            bool synchronous)
         {
             try
             {
@@ -1705,13 +1733,16 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
 
     private class InvokeTaskCompletionCallback : TaskCompletionCallback<Object_Ice_invokeResult>
     {
-        public InvokeTaskCompletionCallback(IProgress<bool>? progress, CancellationToken cancellationToken) :
-            base(progress, cancellationToken)
+        public InvokeTaskCompletionCallback(IProgress<bool>? progress, CancellationToken cancellationToken)
+            : base(progress, cancellationToken)
         {
         }
 
-        public override void handleInvokeSent(bool sentSynchronously, bool done, bool alreadySent,
-                                              OutgoingAsyncBase og)
+        public override void handleInvokeSent(
+            bool sentSynchronously,
+            bool done,
+            bool alreadySent,
+            OutgoingAsyncBase og)
         {
             if (progress_ != null && !alreadySent)
             {

--- a/csharp/src/Ice/SSL/EndpointI.cs
+++ b/csharp/src/Ice/SSL/EndpointI.cs
@@ -58,7 +58,7 @@ internal sealed class EndpointI : Ice.Internal.EndpointI
 
     public override Ice.Internal.EndpointI connectionId(string connectionId)
     {
-        if (connectionId.Equals(_delegate.connectionId()))
+        if (connectionId.Equals(_delegate.connectionId(), StringComparison.Ordinal))
         {
             return this;
         }

--- a/csharp/src/Ice/SSL/Instance.cs
+++ b/csharp/src/Ice/SSL/Instance.cs
@@ -7,8 +7,8 @@ namespace Ice.SSL;
 
 internal class Instance : Ice.Internal.ProtocolInstance
 {
-    internal Instance(SSLEngine engine, short type, string protocol) :
-        base(engine.communicator(), type, protocol, true) => _engine = engine;
+    internal Instance(SSLEngine engine, short type, string protocol)
+        : base(engine.communicator(), type, protocol, true) => _engine = engine;
 
     internal SSLEngine engine() => _engine;
 

--- a/csharp/src/Ice/SSL/RFC2253.cs
+++ b/csharp/src/Ice/SSL/RFC2253.cs
@@ -131,7 +131,7 @@ internal class RFC2253
                     {
                         throw new ParseException("unescape: invalid escape sequence");
                     }
-                    if (special.Contains(data[pos]) || data[pos] != '\\' || data[pos] != '"')
+                    if (special.Contains(data[pos], StringComparison.Ordinal) || data[pos] != '\\' || data[pos] != '"')
                     {
                         result.Append(data[pos]);
                         ++pos;
@@ -371,7 +371,7 @@ internal class RFC2253
                 {
                     result.Append(parsePair(data, ref pos));
                 }
-                else if (!special.Contains(data[pos]) && data[pos] != '"')
+                else if (!special.Contains(data[pos], StringComparison.Ordinal) && data[pos] != '"')
                 {
                     result.Append(data[pos]);
                     ++pos;
@@ -400,7 +400,7 @@ internal class RFC2253
             throw new ParseException("invalid escape format (unexpected end of data)");
         }
 
-        if (special.Contains(data[pos]) || data[pos] != '\\' ||
+        if (special.Contains(data[pos], StringComparison.Ordinal) || data[pos] != '\\' ||
            data[pos] != '"')
         {
             result += data[pos];
@@ -415,12 +415,12 @@ internal class RFC2253
     private static string parseHexPair(string data, ref int pos, bool allowEmpty)
     {
         string result = "";
-        if (pos < data.Length && hexvalid.Contains(data[pos]))
+        if (pos < data.Length && hexvalid.Contains(data[pos], StringComparison.Ordinal))
         {
             result += data[pos];
             ++pos;
         }
-        if (pos < data.Length && hexvalid.Contains(data[pos]))
+        if (pos < data.Length && hexvalid.Contains(data[pos], StringComparison.Ordinal))
         {
             result += data[pos];
             ++pos;

--- a/csharp/src/Ice/SSL/SSLEngine.cs
+++ b/csharp/src/Ice/SSL/SSLEngine.cs
@@ -387,7 +387,7 @@ internal class SSLEngine
         {
             if (value != "*")
             {
-                if (!value.Contains(':'))
+                if (!value.Contains(':', StringComparison.Ordinal))
                 {
                     throw new Ice.InitializationException($"IceSSL: no key in `{value}'");
                 }

--- a/csharp/src/Ice/SSL/TrustManager.cs
+++ b/csharp/src/Ice/SSL/TrustManager.cs
@@ -208,10 +208,10 @@ internal sealed class TrustManager
             bool found = false;
             foreach (RFC2253.RDNPair subjectRDN in subject)
             {
-                if (matchRDN.key.Equals(subjectRDN.key))
+                if (matchRDN.key.Equals(subjectRDN.key, StringComparison.Ordinal))
                 {
                     found = true;
-                    if (!matchRDN.value.Equals(subjectRDN.value))
+                    if (!matchRDN.value.Equals(subjectRDN.value, StringComparison.Ordinal))
                     {
                         return false;
                     }

--- a/csharp/src/Ice/Util.cs
+++ b/csharp/src/Ice/Util.cs
@@ -470,7 +470,7 @@ public sealed class Util
 
     static private void stringToMajorMinor(string str, out byte major, out byte minor)
     {
-        int pos = str.IndexOf('.');
+        int pos = str.IndexOf('.', StringComparison.Ordinal);
         if (pos == -1)
         {
             throw new ParseException($"malformed version value in '{str}'");

--- a/csharp/src/Ice/UtilInternal/Options.cs
+++ b/csharp/src/Ice/UtilInternal/Options.cs
@@ -95,7 +95,7 @@ public sealed class Options
                         }
                         default:
                         {
-                            if (IFS.Contains(l[i]))
+                            if (IFS.Contains(l[i], StringComparison.Ordinal))
                             {
                                 vec.Add(arg);
                                 arg = "";
@@ -103,7 +103,7 @@ public sealed class Options
                                 //
                                 // Move to start of next argument.
                                 //
-                                while (++i < l.Length && IFS.Contains(l[i]))
+                                while (++i < l.Length && IFS.Contains(l[i], StringComparison.Ordinal))
                                 {
                                     ;
                                 }
@@ -248,7 +248,7 @@ public sealed class Options
                                     const string octalDigits = "01234567";
                                     short s = 0;
                                     int j;
-                                    for (j = i; j < i + 3 && j < l.Length && octalDigits.Contains(c = l[j]); ++j)
+                                    for (j = i; j < i + 3 && j < l.Length && octalDigits.Contains(c = l[j], StringComparison.Ordinal); ++j)
                                     {
                                         s = (short)(s * 8 + c - '0');
                                     }
@@ -263,7 +263,7 @@ public sealed class Options
                                 case 'x':
                                 {
                                     const string hexDigits = "0123456789abcdefABCDEF";
-                                    if (i < l.Length - 1 && !hexDigits.Contains(l[i + 1]))
+                                    if (i < l.Length - 1 && !hexDigits.Contains(l[i + 1], StringComparison.Ordinal))
                                     {
                                         arg += '\\';
                                         arg += 'x';
@@ -273,7 +273,7 @@ public sealed class Options
                                     short s = 0;
                                     int j;
                                     for (j = i + 1;
-                                        j < i + 3 && j < l.Length && hexDigits.Contains(c = l[j]);
+                                        j < i + 3 && j < l.Length && hexDigits.Contains(c = l[j], StringComparison.Ordinal);
                                         ++j)
                                     {
                                         s *= 16;

--- a/csharp/src/Ice/UtilInternal/StringUtil.cs
+++ b/csharp/src/Ice/UtilInternal/StringUtil.cs
@@ -28,7 +28,7 @@ public sealed class StringUtil
         for (int i = start; i < len; i++)
         {
             char ch = str[i];
-            if (match.Contains(ch))
+            if (match.Contains(ch, StringComparison.Ordinal))
             {
                 return i;
             }
@@ -58,7 +58,7 @@ public sealed class StringUtil
         for (int i = start; i < len; i++)
         {
             char ch = str[i];
-            if (!match.Contains(ch))
+            if (!match.Contains(ch, StringComparison.Ordinal))
             {
                 return i;
             }
@@ -140,7 +140,7 @@ public sealed class StringUtil
             }
             default:
             {
-                if (special != null && special.Contains(c))
+                if (special != null && special.Contains(c, StringComparison.Ordinal))
                 {
                     sb.Append('\\');
                     sb.Append(c);
@@ -509,7 +509,7 @@ public sealed class StringUtil
                 }
                 default:
                 {
-                    if (string.IsNullOrEmpty(special) || !special.Contains(c))
+                    if (string.IsNullOrEmpty(special) || !special.Contains(c, StringComparison.Ordinal))
                     {
                         result.Append('\\'); // not in special, so we keep the backslash
                     }
@@ -596,7 +596,7 @@ public sealed class StringUtil
                 quoteChar = '\0';
                 continue; // Skip the quote.
             }
-            else if (delim.Contains(str[pos]))
+            else if (delim.Contains(str[pos], StringComparison.Ordinal))
             {
                 if (quoteChar == '\0')
                 {
@@ -668,16 +668,17 @@ public sealed class StringUtil
         //
         // If pattern does not contain a wildcard just compare strings.
         //
-        int beginIndex = pat.IndexOf('*');
+        int beginIndex = pat.IndexOf('*', StringComparison.Ordinal);
         if (beginIndex < 0)
         {
-            return s.Equals(pat);
+            return s.Equals(pat, StringComparison.Ordinal);
         }
 
         //
         // Make sure start of the strings match
         //
-        if (beginIndex > s.Length || !s.Substring(0, beginIndex).Equals(pat.Substring(0, beginIndex)))
+        if (beginIndex > s.Length ||
+            !s.Substring(0, beginIndex).Equals(pat.Substring(0, beginIndex), StringComparison.Ordinal))
         {
             return false;
         }
@@ -701,7 +702,8 @@ public sealed class StringUtil
         // Make sure end of the strings match
         //
         if (!s.Substring(endIndex, s.Length - endIndex).Equals(
-               pat.Substring(beginIndex + 1, pat.Length - beginIndex - 1)))
+               pat.Substring(beginIndex + 1, pat.Length - beginIndex - 1),
+               StringComparison.Ordinal))
         {
             return false;
         }

--- a/csharp/src/IceBoxNet/ServiceManagerI.cs
+++ b/csharp/src/IceBoxNet/ServiceManagerI.cs
@@ -56,7 +56,7 @@ internal class ServiceManagerI : ServiceManagerDisp_
             for (i = 0; i < _services.Count; ++i)
             {
                 info = _services[i];
-                if (info.name.Equals(name))
+                if (info.name.Equals(name, StringComparison.Ordinal))
                 {
                     if (_services[i].status != ServiceStatus.Stopped)
                     {
@@ -77,8 +77,10 @@ internal class ServiceManagerI : ServiceManagerDisp_
         bool started = false;
         try
         {
-            info.service.start(info.name, info.communicator == null ? _sharedCommunicator : info.communicator,
-                               info.args);
+            info.service.start(
+                info.name,
+                info.communicator == null ? _sharedCommunicator : info.communicator,
+                info.args);
             started = true;
         }
         catch (Exception e)
@@ -92,7 +94,7 @@ internal class ServiceManagerI : ServiceManagerDisp_
             for (i = 0; i < _services.Count; ++i)
             {
                 info = _services[i];
-                if (info.name.Equals(name))
+                if (info.name.Equals(name, StringComparison.Ordinal))
                 {
                     if (started)
                     {
@@ -128,7 +130,7 @@ internal class ServiceManagerI : ServiceManagerDisp_
             for (i = 0; i < _services.Count; ++i)
             {
                 info = _services[i];
-                if (info.name.Equals(name))
+                if (info.name.Equals(name, StringComparison.Ordinal))
                 {
                     if (info.status != ServiceStatus.Started)
                     {
@@ -163,7 +165,7 @@ internal class ServiceManagerI : ServiceManagerDisp_
             for (i = 0; i < _services.Count; ++i)
             {
                 info = _services[i];
-                if (info.name.Equals(name))
+                if (info.name.Equals(name, StringComparison.Ordinal))
                 {
                     if (stopped)
                     {
@@ -415,13 +417,13 @@ internal class ServiceManagerI : ServiceManagerDisp_
             // Extract the assembly name and the class name.
             //
             string err = "ServiceManager: unable to load service '" + entryPoint + "': ";
-            int sepPos = entryPoint.IndexOf(':');
+            int sepPos = entryPoint.IndexOf(':', StringComparison.Ordinal);
             if (sepPos != -1)
             {
                 const string driveLetters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
                 if (entryPoint.Length > 3 &&
                    sepPos == 1 &&
-                   driveLetters.Contains(entryPoint[0]) &&
+                   driveLetters.Contains(entryPoint[0], StringComparison.Ordinal) &&
                    (entryPoint[2] == '\\' || entryPoint[2] == '/'))
                 {
                     sepPos = entryPoint.IndexOf(':', 3);

--- a/csharp/src/IceDiscovery/LocatorI.cs
+++ b/csharp/src/IceDiscovery/LocatorI.cs
@@ -28,8 +28,11 @@ internal class LocatorRegistryI : Ice.LocatorRegistryDisp_
     }
 
     public override Task
-    setReplicatedAdapterDirectProxyAsync(string adapterId, string replicaGroupId, Ice.ObjectPrx proxy,
-                                         Ice.Current current)
+    setReplicatedAdapterDirectProxyAsync(
+        string adapterId,
+        string replicaGroupId,
+        Ice.ObjectPrx proxy,
+        Ice.Current current)
     {
         lock (this)
         {

--- a/csharp/src/IceDiscovery/LookupI.cs
+++ b/csharp/src/IceDiscovery/LookupI.cs
@@ -140,17 +140,19 @@ internal class AdapterRequest : Request<string>, Ice.Internal.TimerTask
 
     protected override void invokeWithLookup(string domainId, LookupPrx lookup, LookupReplyPrx lookupReply)
     {
-        lookup.findAdapterByIdAsync(domainId, _id, lookupReply).ContinueWith(task =>
-        {
-            try
+        lookup.findAdapterByIdAsync(domainId, _id, lookupReply).ContinueWith(
+            task =>
             {
-                task.Wait();
-            }
-            catch (AggregateException ex)
-            {
-                lookup_.adapterRequestException(this, ex.InnerException);
-            }
-        }, lookup.ice_scheduler());
+                try
+                {
+                    task.Wait();
+                }
+                catch (AggregateException ex)
+                {
+                    lookup_.adapterRequestException(this, ex.InnerException);
+                }
+            },
+            lookup.ice_scheduler());
     }
 
     private void sendResponse(Ice.ObjectPrx proxy)
@@ -199,17 +201,19 @@ internal class ObjectRequest : Request<Ice.Identity>, Ice.Internal.TimerTask
 
     protected override void invokeWithLookup(string domainId, LookupPrx lookup, LookupReplyPrx lookupReply)
     {
-        lookup.findObjectByIdAsync(domainId, _id, lookupReply).ContinueWith(task =>
-        {
-            try
+        lookup.findObjectByIdAsync(domainId, _id, lookupReply).ContinueWith(
+            task =>
             {
-                task.Wait();
-            }
-            catch (AggregateException ex)
-            {
-                lookup_.objectRequestException(this, ex.InnerException);
-            }
-        }, lookup.ice_scheduler());
+                try
+                {
+                    task.Wait();
+                }
+                catch (AggregateException ex)
+                {
+                    lookup_.objectRequestException(this, ex.InnerException);
+                }
+            },
+            lookup.ice_scheduler());
     }
 };
 
@@ -252,7 +256,8 @@ internal class LookupI : LookupDisp_
                 foreach (var q in lookupReply.ice_getEndpoints())
                 {
                     var r = q.getInfo();
-                    if (r is Ice.IPEndpointInfo && ((Ice.IPEndpointInfo)r).host.Equals(info.mcastInterface))
+                    if (r is Ice.IPEndpointInfo &&
+                        ((Ice.IPEndpointInfo)r).host.Equals(info.mcastInterface, StringComparison.Ordinal))
                     {
                         single[0] = q;
                         _lookups[key] = (LookupReplyPrx)lookupReply.ice_endpoints(single);
@@ -268,10 +273,9 @@ internal class LookupI : LookupDisp_
         }
     }
 
-    public override void findObjectById(string domainId, Ice.Identity id, LookupReplyPrx reply,
-                                        Ice.Current current)
+    public override void findObjectById(string domainId, Ice.Identity id, LookupReplyPrx reply, Ice.Current current)
     {
-        if (!domainId.Equals(_domainId))
+        if (!domainId.Equals(_domainId, StringComparison.Ordinal))
         {
             return; // Ignore
         }
@@ -293,10 +297,9 @@ internal class LookupI : LookupDisp_
         }
     }
 
-    public override void findAdapterById(string domainId, string adapterId, LookupReplyPrx reply,
-                                         Ice.Current current)
+    public override void findAdapterById(string domainId, string adapterId, LookupReplyPrx reply, Ice.Current current)
     {
-        if (!domainId.Equals(_domainId))
+        if (!domainId.Equals(_domainId, StringComparison.Ordinal))
         {
             return; // Ignore
         }

--- a/csharp/src/IceLocatorDiscovery/PluginI.cs
+++ b/csharp/src/IceLocatorDiscovery/PluginI.cs
@@ -173,7 +173,7 @@ internal class LocatorI : Ice.BlobjectAsync, Ice.Internal.TimerTask
     setLookupReply(LookupReplyPrx lookupReply)
     {
         //
-        // Use a lookup reply proxy whose address matches the interface used to send multicast datagram.
+        // Use a lookup reply proxy whose address matches the interface used to send multicast datagrams.
         //
         var single = new Ice.Endpoint[1];
         foreach (var key in new List<LookupPrx>(_lookups.Keys))

--- a/csharp/src/IceLocatorDiscovery/PluginI.cs
+++ b/csharp/src/IceLocatorDiscovery/PluginI.cs
@@ -127,8 +127,7 @@ internal class VoidLocatorI : Ice.LocatorDisp_
 internal class LocatorI : Ice.BlobjectAsync, Ice.Internal.TimerTask
 {
     public
-    LocatorI(string name, LookupPrx lookup, Ice.Properties properties, string instanceName,
-             Ice.LocatorPrx voidLocator)
+    LocatorI(string name, LookupPrx lookup, Ice.Properties properties, string instanceName, Ice.LocatorPrx voidLocator)
     {
         _lookup = lookup;
         _timeout = properties.getPropertyAsIntWithDefault(name + ".Timeout", 300);
@@ -174,7 +173,7 @@ internal class LocatorI : Ice.BlobjectAsync, Ice.Internal.TimerTask
     setLookupReply(LookupReplyPrx lookupReply)
     {
         //
-        // Use a lookup reply proxy whose adress matches the interface used to send multicast datagrams.
+        // Use a lookup reply proxy whose address matches the interface used to send multicast datagram.
         //
         var single = new Ice.Endpoint[1];
         foreach (var key in new List<LookupPrx>(_lookups.Keys))
@@ -185,7 +184,8 @@ internal class LocatorI : Ice.BlobjectAsync, Ice.Internal.TimerTask
                 foreach (var q in lookupReply.ice_getEndpoints())
                 {
                     var r = q.getInfo();
-                    if (r is Ice.IPEndpointInfo && ((Ice.IPEndpointInfo)r).host.Equals(info.mcastInterface))
+                    if (r is Ice.IPEndpointInfo &&
+                        ((Ice.IPEndpointInfo)r).host.Equals(info.mcastInterface, StringComparison.Ordinal))
                     {
                         single[0] = q;
                         _lookups[key] = (LookupReplyPrx)lookupReply.ice_endpoints(single);
@@ -270,7 +270,8 @@ internal class LocatorI : Ice.BlobjectAsync, Ice.Internal.TimerTask
                 return;
             }
 
-            if (_instanceName.Length > 0 && !locator.ice_getIdentity().category.Equals(_instanceName))
+            if (_instanceName.Length > 0 &&
+                !locator.ice_getIdentity().category.Equals(_instanceName, StringComparison.Ordinal))
             {
                 if (_traceLevel > 2)
                 {
@@ -287,7 +288,8 @@ internal class LocatorI : Ice.BlobjectAsync, Ice.Internal.TimerTask
             // has the same identity, otherwise ignore it.
             //
             if (_pendingRequests.Count > 0 &&
-               _locator != null && !locator.ice_getIdentity().category.Equals(_locator.ice_getIdentity().category))
+               _locator != null &&
+               !locator.ice_getIdentity().category.Equals(_locator.ice_getIdentity().category, StringComparison.Ordinal))
             {
                 if (!_warned)
                 {
@@ -432,17 +434,19 @@ internal class LocatorI : Ice.BlobjectAsync, Ice.Internal.TimerTask
 
                         foreach (var l in _lookups)
                         {
-                            l.Key.findLocatorAsync(_instanceName, l.Value).ContinueWith(t =>
-                            {
-                                try
+                            l.Key.findLocatorAsync(_instanceName, l.Value).ContinueWith(
+                                t =>
                                 {
-                                    t.Wait();
-                                }
-                                catch (AggregateException ex)
-                                {
-                                    exception(ex.InnerException);
-                                }
-                            }, l.Key.ice_scheduler()); // Send multicast request.
+                                    try
+                                    {
+                                        t.Wait();
+                                    }
+                                    catch (AggregateException ex)
+                                    {
+                                        exception(ex.InnerException);
+                                    }
+                                },
+                                l.Key.ice_scheduler()); // Send multicast request.
                         }
                         _timer.schedule(this, _timeout);
                     }
@@ -554,17 +558,19 @@ internal class LocatorI : Ice.BlobjectAsync, Ice.Internal.TimerTask
 
                     foreach (var l in _lookups)
                     {
-                        l.Key.findLocatorAsync(_instanceName, l.Value).ContinueWith(t =>
-                        {
-                            try
+                        l.Key.findLocatorAsync(_instanceName, l.Value).ContinueWith(
+                            t =>
                             {
-                                t.Wait();
-                            }
-                            catch (AggregateException ex)
-                            {
-                                exception(ex.InnerException);
-                            }
-                        }, l.Key.ice_scheduler()); // Send multicast request.
+                                try
+                                {
+                                    t.Wait();
+                                }
+                                catch (AggregateException ex)
+                                {
+                                    exception(ex.InnerException);
+                                }
+                            },
+                            l.Key.ice_scheduler()); // Send multicast request.
                     }
                     _timer.schedule(this, _timeout);
                     return;


### PR DESCRIPTION
This PR fixes a few of the warnings that are temporarily disabled in `CodeAnalysis.Base.globalconfig`.