### PR TITLE
Simplify Compiler Error Emission and Fix `slice2swift` Metadata Check

### DIFF
--- a/cpp/src/Slice/FileTracker.h
+++ b/cpp/src/Slice/FileTracker.h
@@ -4,6 +4,7 @@
 #define FILE_TRACKER_H
 
 #include "Parser.h"
+#include "Ice/LocalException.h"
 
 namespace Slice
 {

--- a/cpp/src/Slice/FileTracker.h
+++ b/cpp/src/Slice/FileTracker.h
@@ -3,8 +3,8 @@
 #ifndef FILE_TRACKER_H
 #define FILE_TRACKER_H
 
-#include "Parser.h"
 #include "Ice/LocalException.h"
+#include "Parser.h"
 
 namespace Slice
 {

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -39,12 +39,6 @@ compareTag(const T& lhs, const T& rhs)
     return lhs->tag() < rhs->tag();
 }
 
-const char*
-Slice::CompilerException::ice_id() const noexcept
-{
-    return "::Slice::CompilerException";
-}
-
 // Forward declare things from Bison and Flex the parser can use.
 extern int slice_parse();
 extern int slice_lineno;
@@ -178,13 +172,6 @@ Slice::DefinitionContext::warning(WarningCategory category, const string& file, 
     {
         emitWarning(file, line, msg);
     }
-}
-
-void
-Slice::DefinitionContext::error(const string& file, int line, const string& msg) const
-{
-    emitError(file, line, msg);
-    throw CompilerException(__FILE__, __LINE__, msg);
 }
 
 bool
@@ -4867,9 +4854,15 @@ Slice::Unit::setSeenDefinition()
 }
 
 void
-Slice::Unit::error(const string& s)
+Slice::Unit::error(const string& message)
 {
-    emitError(currentFile(), currentLine(), s);
+    error(currentFile(), currentLine(), message);
+}
+
+void
+Slice::Unit::error(const string& file, int line, const string& message)
+{
+    emitError(file, line, message);
     _errors++;
 }
 

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -3,7 +3,6 @@
 #ifndef SLICE_PARSER_H
 #define SLICE_PARSER_H
 
-#include "Ice/LocalException.h"
 #include <array>
 #include <cstdint>
 #include <list>
@@ -19,14 +18,6 @@
 
 namespace Slice
 {
-    class CompilerException final : public Ice::LocalException
-    {
-    public:
-        using Ice::LocalException::LocalException;
-
-        const char* ice_id() const noexcept final;
-    };
-
     enum NodeType
     {
         Dummy,
@@ -202,8 +193,6 @@ namespace Slice
         // Emit warning unless filtered out by [["suppress-warning"]]
         //
         void warning(WarningCategory, const std::string&, int, const std::string&) const;
-
-        void error(const std::string&, int, const std::string&) const;
 
     private:
         bool suppressWarning(WarningCategory) const;
@@ -987,7 +976,8 @@ namespace Slice
 
         void setSeenDefinition();
 
-        void error(const std::string&); // Not const because error count is increased
+        void error(const std::string& message);
+        void error(const std::string& file, int line, const std::string& message);
         void warning(WarningCategory, const std::string&) const;
 
         ContainerPtr currentContainer() const;

--- a/cpp/src/slice2swift/Main.cpp
+++ b/cpp/src/slice2swift/Main.cpp
@@ -274,13 +274,6 @@ compile(const vector<string>& argv)
                         status = EXIT_FAILURE;
                         break;
                     }
-                    catch (const Slice::CompilerException&)
-                    {
-                        FileTracker::instance()->cleanup();
-                        u->destroy();
-                        status = EXIT_FAILURE;
-                        break;
-                    }
                 }
 
                 u->destroy();

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -1799,7 +1799,7 @@ SwiftGenerator::MetadataVisitor::visitModuleStart(const ModulePtr& p)
         else if (current->second != swiftModule)
         {
             ostringstream os;
-            os << "invalid module mapping:\n Slice module `" << p->scoped() << "' should be map to Swift module `"
+            os << "invalid module mapping:\n Slice module `" << p->scoped() << "' should map to Swift module `"
                << current->second << "'" << endl;
             unit->error(p->file(), p->line(), os.str());
         }
@@ -2502,7 +2502,7 @@ bool
 SwiftGenerator::MetadataVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
     p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
-    for (auto& member : p->dataMembers())
+    for (const auto& member : p->dataMembers())
     {
         member->setMetadata(validate(member->type(), member->getMetadata(), p->file(), member->line()));
     }
@@ -2536,7 +2536,7 @@ SwiftGenerator::MetadataVisitor::visitOperation(const OperationPtr& p)
         }
     }
     p->setMetadata(validate(p, metadata, p->file(), p->line()));
-    for (auto& param : p->parameters())
+    for (const auto& param : p->parameters())
     {
         param->setMetadata(validate(param->type(), param->getMetadata(), param->file(), param->line()));
     }
@@ -2546,7 +2546,7 @@ bool
 SwiftGenerator::MetadataVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
     p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
-    for (auto& member : p->dataMembers())
+    for (const auto& member : p->dataMembers())
     {
         member->setMetadata(validate(member->type(), member->getMetadata(), member->file(), member->line()));
     }
@@ -2557,7 +2557,7 @@ bool
 SwiftGenerator::MetadataVisitor::visitStructStart(const StructPtr& p)
 {
     p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
-    for (auto& member : p->dataMembers())
+    for (const auto& member : p->dataMembers())
     {
         member->setMetadata(validate(member->type(), member->getMetadata(), member->file(), member->line()));
     }
@@ -2590,7 +2590,7 @@ SwiftGenerator::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
             InvalidMetadata,
             p->file(),
             p->line(),
-            "ignoring invalid metadata `" + s + "' for dictionary key type");
+            "ignoring invalid metadata '" + s + "' for dictionary key type");
     }
 
     newMetadata = p->valueMetadata();
@@ -2607,7 +2607,7 @@ SwiftGenerator::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
             InvalidMetadata,
             p->file(),
             p->line(),
-            "ignoring invalid metadata `" + s + "' for dictionary value type");
+            "ignoring invalid metadata '" + s + "' for dictionary value type");
     }
 
     p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -2586,7 +2586,11 @@ SwiftGenerator::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
             continue;
         }
 
-        dc->warning(InvalidMetadata, p->file(), p->line(), "ignoring invalid metadata `" + s + "' for dictionary key type");
+        dc->warning(
+            InvalidMetadata,
+            p->file(),
+            p->line(),
+            "ignoring invalid metadata `" + s + "' for dictionary key type");
     }
 
     newMetadata = p->valueMetadata();
@@ -2599,7 +2603,11 @@ SwiftGenerator::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
             continue;
         }
 
-        dc->warning(InvalidMetadata, p->file(), p->line(), "ignoring invalid metadata `" + s + "' for dictionary value type");
+        dc->warning(
+            InvalidMetadata,
+            p->file(),
+            p->line(),
+            "ignoring invalid metadata `" + s + "' for dictionary value type");
     }
 
     p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -172,9 +172,7 @@ namespace Slice
                 const SyntaxTreeBasePtr&,
                 const StringList&,
                 const std::string&,
-                int,
-                bool local = false,
-                bool operationParameter = false);
+                int);
 
             typedef std::map<std::string, std::string> ModuleMap;
             typedef std::map<std::string, ModuleMap> ModulePrefix;

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -168,11 +168,7 @@ namespace Slice
             bool shouldVisitIncludedDefinitions() const final { return true; }
 
         private:
-            StringList validate(
-                const SyntaxTreeBasePtr&,
-                const StringList&,
-                const std::string&,
-                int);
+            StringList validate(const SyntaxTreeBasePtr&, const StringList&, const std::string&, int);
 
             typedef std::map<std::string, std::string> ModuleMap;
             typedef std::map<std::string, ModuleMap> ModulePrefix;


### PR DESCRIPTION
This PR does 2 things:

1) There are 2 paths to report an error in the compiler: through `Unit->error` and through `DefinitionContext->error`.
That second path is used in only 2 places... So I deleted it. Now there's a single path for reporting compiler errors.
This also lets us delete `CompilerException` (which of course inherited from `Ice::LocalException`).

2) While fixing that, I noticed a bug in `slice2swift`'s metadata validation introduced in #1627.
TL;DR we had a `validate` function, with a bunch of parameters. The 2nd to last was `bool local`.
This bool was removed from the call-sites, but not from the function itself, so the 'last' parameter was acidentally being passed in for that `local` bool.