### PR TITLE
Make the 'java/Ice/metrics' Test More Deterministic

### DIFF
--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -2507,7 +2507,8 @@ public final class ConnectionI extends com.zeroc.IceInternal.EventHandler
     }
   }
 
-  private synchronized void doApplicationClose() {
+  // Only public so that tests can initiate a closure without blocking on it to complete.
+  public synchronized void doApplicationClose() {
     assert (_state < StateClosing);
     setState(
         StateClosing,

--- a/java/test/src/main/java/test/Ice/metrics/AllTests.java
+++ b/java/test/src/main/java/test/Ice/metrics/AllTests.java
@@ -532,7 +532,7 @@ public class AllTests {
         method.setAccessible(true); // Transform a `private` method into a `public` one.
         method.invoke(metrics.ice_getConnection());
       } catch (ReflectiveOperationException | SecurityException ex) {
-        assert(false);
+        assert (false);
       }
 
       map = toMap(clientMetrics.getMetricsView("View").returnValue.get("Connection"));

--- a/java/test/src/main/java/test/Ice/metrics/AllTests.java
+++ b/java/test/src/main/java/test/Ice/metrics/AllTests.java
@@ -527,13 +527,7 @@ public class AllTests {
       // Calling `close` on a Connection blocks the calling thread until the closure is complete.
       // At which point the connection is in the `Closed` state. So to test the `Closing` state,
       // we directly call `doApplicationClose` to _initiate_ a closure, without having to wait.
-      try {
-        var method = com.zeroc.Ice.ConnectionI.class.getDeclaredMethod("doApplicationClose");
-        method.setAccessible(true); // Transform a `private` method into a `public` one.
-        method.invoke(metrics.ice_getConnection());
-      } catch (ReflectiveOperationException | SecurityException ex) {
-        assert (false);
-      }
+      ((com.zeroc.Ice.ConnectionI) metrics.ice_getConnection()).doApplicationClose();
 
       map = toMap(clientMetrics.getMetricsView("View").returnValue.get("Connection"));
       test(map.get("closing").current == 1);


### PR DESCRIPTION
Now that the `close` API in Java blocks until connection closure is completed, it is hard to test things involving the `Closing` state. As a workaround we'd start `close` in a separate thread, and wait a little, but this is too timing dependent to work reliably.

This PR fixes this by going back to the old semantics:
We trigger a connection closure, without waiting for it to complete... And we do this without altering the public API...
By directly calling into the private API of `Connection`.

This change makes the `metrics` test functionally identical to how it worked before I made my changes to the `Connection` API.
And all that it's _really_ doing is letting us `arrange` a specific state using APIs which are internal. But within the tests, I don't think accessing internal APIs is unforgivable, especially when I can't see any better way to get the connection in this state.