### PR TITLE
Fix Ice/ami in C++, C#, Java, Python to wait for connection closure

### DIFF
--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -1172,6 +1172,8 @@ allTests(TestHelper* helper, bool collocated)
                             test(false);
                         }
                     }
+                    // Wait until the connection is closed.
+                    p->ice_getCachedConnection()->close().get();
                 }
             }
             cout << "ok" << endl;

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -760,6 +760,8 @@ namespace Ice
                             {
                                 await q;
                             }
+                            // Wait until the connection is closed.
+                            await p.ice_getCachedConnection().closeAsync();
                         }
                     }
                     output.WriteLine("ok");

--- a/java/test/src/main/java/test/Ice/ami/AllTests.java
+++ b/java/test/src/main/java/test/Ice/ami/AllTests.java
@@ -947,8 +947,8 @@ public class AllTests {
             q.join();
           }
         }
-        // Make sure the connection is closed.
-        p.ice_getConnection().close();
+        // Wait until the connection is closed.
+        p.ice_getCachedConnection().close();
       }
       out.println("ok");
 

--- a/python/test/Ice/ami/AllTests.py
+++ b/python/test/Ice/ami/AllTests.py
@@ -445,16 +445,14 @@ def allTests(helper, communicator, collocated):
         # Remote case: the server closes the connection gracefully, which means the connection
         # will not be closed until all pending dispatched requests have completed.
         #
-        con = p.ice_getConnection()
-        cb = CallbackBase()
-        con.setCloseCallback(lambda c: cb.called())
         f = p.sleepAsync(100)
         p.close(Test.CloseMode.Gracefully)  # Close is delayed until sleep completes.
-        cb.check()  # Ensure connection was closed.
         try:
             f.result()
         except Exception:
             test(False)
+
+        p.ice_getCachedConnection().close(True) # Wait until the connection is closed.
 
         print("ok")
 


### PR DESCRIPTION
This PR fixes the Ice/ami test to wait for connection in the "graceful close" test before proceeding to the abort test.

The Python test already included this logic; however I changed it to be consistent with the other language mappings.