### PR TITLE
Finish improving Parameter Names in the Slice Parser

### DIFF
--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -2158,7 +2158,7 @@ yyreduce:
 {
     auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
     ContainerPtr cont = currentUnit->currentContainer();
-    ContainedPtr contained = cont->lookupException(scoped->v);
+    ContainedPtr contained = cont->lookupException(scoped->v, true);
     cont->checkIntroduced(scoped->v);
     yyval = contained;
 }
@@ -3280,7 +3280,7 @@ yyreduce:
 {
     auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
     ContainerPtr cont = currentUnit->currentContainer();
-    ExceptionPtr exception = cont->lookupException(scoped->v);
+    ExceptionPtr exception = cont->lookupException(scoped->v, true);
     if (!exception)
     {
         exception = cont->createException(Ice::generateUUID(), 0, Dummy); // Dummy
@@ -3527,7 +3527,7 @@ yyreduce:
 #line 1723 "src/Slice/Grammar.y"
 {
     auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
-    ContainedList cl = currentUnit->currentContainer()->lookupContained(scoped->v);
+    ContainedList cl = currentUnit->currentContainer()->lookupContained(scoped->v, true);
     IntegerTokPtr tok;
     if (!cl.empty())
     {

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -516,7 +516,7 @@ exception_extends
 {
     auto scoped = dynamic_pointer_cast<StringTok>($2);
     ContainerPtr cont = currentUnit->currentContainer();
-    ContainedPtr contained = cont->lookupException(scoped->v);
+    ContainedPtr contained = cont->lookupException(scoped->v, true);
     cont->checkIntroduced(scoped->v);
     $$ = contained;
 }
@@ -1515,7 +1515,7 @@ exception
 {
     auto scoped = dynamic_pointer_cast<StringTok>($1);
     ContainerPtr cont = currentUnit->currentContainer();
-    ExceptionPtr exception = cont->lookupException(scoped->v);
+    ExceptionPtr exception = cont->lookupException(scoped->v, true);
     if (!exception)
     {
         exception = cont->createException(Ice::generateUUID(), 0, Dummy); // Dummy
@@ -1722,7 +1722,7 @@ enumerator_initializer
 | scoped_name
 {
     auto scoped = dynamic_pointer_cast<StringTok>($1);
-    ContainedList cl = currentUnit->currentContainer()->lookupContained(scoped->v);
+    ContainedList cl = currentUnit->currentContainer()->lookupContained(scoped->v, true);
     IntegerTokPtr tok;
     if (!cl.empty())
     {

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -403,7 +403,11 @@ namespace Slice
         InterfaceDeclPtr createInterfaceDecl(const std::string& name);
         ExceptionPtr createException(const std::string& name, const ExceptionPtr& base, NodeType nodeType = Real);
         StructPtr createStruct(const std::string& name, NodeType nodeType = Real);
-        SequencePtr createSequence(const std::string& name, const TypePtr& type, const StringList& metadata, NodeType nodeType = Real);
+        SequencePtr createSequence(
+            const std::string& name,
+            const TypePtr& type,
+            const StringList& metadata,
+            NodeType nodeType = Real);
         DictionaryPtr createDictionary(
             const std::string& name,
             const TypePtr& keyType,
@@ -419,10 +423,10 @@ namespace Slice
             const SyntaxTreeBasePtr& valueType,
             const std::string& value,
             NodeType nodeType = Real);
-        TypeList lookupType(const std::string& identifier, bool emitErrors = true);
-        TypeList lookupTypeNoBuiltin(const std::string& identifier, bool emitErrors = true, bool ignoreUndefined = false);
-        ContainedList lookupContained(const std::string& identifier, bool emitErrors = true);
-        ExceptionPtr lookupException(const std::string& identifier, bool emitErrors = true);
+        TypeList lookupType(const std::string& identifier);
+        TypeList lookupTypeNoBuiltin(const std::string& identifier, bool emitErrors, bool ignoreUndefined = false);
+        ContainedList lookupContained(const std::string& identifier, bool emitErrors);
+        ExceptionPtr lookupException(const std::string& identifier, bool emitErrors);
         UnitPtr unit() const;
         ModuleList modules() const;
         ClassList classes() const;
@@ -462,7 +466,12 @@ namespace Slice
         }
 
     protected:
-        bool validateConstant(const std::string& name, const TypePtr& type, SyntaxTreeBasePtr& valueType, const std::string& valueString, bool isConstant);
+        bool validateConstant(
+            const std::string& name,
+            const TypePtr& type,
+            SyntaxTreeBasePtr& valueType,
+            const std::string& valueString,
+            bool isConstant);
 
         ContainedList _contents;
         std::map<std::string, ContainedPtr, CICompare> _introducedMap;
@@ -592,9 +601,16 @@ namespace Slice
         typedef std::list<StringList> StringPartitionList;
 
         static bool isInList(const GraphPartitionList& gpl, const InterfaceDefPtr& interfaceDef);
-        static void addPartition(GraphPartitionList& gpl, GraphPartitionList::reverse_iterator tail, const InterfaceDefPtr& base);
-        static StringPartitionList toStringPartitionList(const GraphPartitionList& gpl);
-        static void checkPairIntersections(const StringPartitionList& list, const std::string& name, const UnitPtr& unit);
+
+        static void addPartition(
+            GraphPartitionList& partitions,
+            GraphPartitionList::reverse_iterator tail,
+            const InterfaceDefPtr& base);
+        static StringPartitionList toStringPartitionList(const GraphPartitionList& partitions);
+        static void checkPairIntersections(
+            const StringPartitionList& stringPartitions,
+            const std::string& name,
+            const UnitPtr& unit);
     };
 
     // ----------------------------------------------------------------------
@@ -621,7 +637,10 @@ namespace Slice
         int returnTag() const;
         Mode mode() const;
         bool hasMarshaledResult() const;
-        ParamDeclPtr createParamDecl(const std::string& name, const TypePtr& type, bool isOutParam, bool isOptional, int tag);
+
+        ParamDeclPtr
+        createParamDecl(const std::string& name, const TypePtr& type, bool isOutParam, bool isOptional, int tag);
+
         ParamDeclList parameters() const;
         ParamDeclList inParameters() const;
         void inParameters(ParamDeclList& required, ParamDeclList& optional) const;
@@ -664,7 +683,12 @@ namespace Slice
     public:
         InterfaceDef(const ContainerPtr& container, const std::string& name, const InterfaceList& bases);
         void destroy() final;
-        OperationPtr createOperation(const std::string& name, const TypePtr& returnType, bool isOptional, int tag, Operation::Mode mode = Operation::Normal);
+        OperationPtr createOperation(
+            const std::string& name,
+            const TypePtr& returnType,
+            bool isOptional,
+            int tag,
+            Operation::Mode mode = Operation::Normal);
 
         InterfaceDeclPtr declaration() const;
         InterfaceList bases() const;
@@ -758,7 +782,11 @@ namespace Slice
     class Sequence final : public virtual Constructed
     {
     public:
-        Sequence(const ContainerPtr& container, const std::string& name, const TypePtr& type, const StringList& typeMetadata);
+        Sequence(
+            const ContainerPtr& container,
+            const std::string& name,
+            const TypePtr& type,
+            const StringList& typeMetadata);
         TypePtr type() const;
         StringList typeMetadata() const;
         bool usesClasses() const final;
@@ -898,7 +926,13 @@ namespace Slice
     class ParamDecl final : public virtual Contained
     {
     public:
-        ParamDecl(const ContainerPtr& container, const std::string& name, const TypePtr& type, bool isOutParam, bool isOptional, int tag);
+        ParamDecl(
+            const ContainerPtr& container,
+            const std::string& name,
+            const TypePtr& type,
+            bool isOutParam,
+            bool isOptional,
+            int tag);
         TypePtr type() const;
         bool isOutParam() const;
         bool optional() const;

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -314,7 +314,7 @@ Slice::JsVisitor::writeMarshalDataMembers(
     const ContainedPtr& contained)
 {
     bool isStruct = dynamic_pointer_cast<Struct>(contained) != nullptr;
-    bool isLegalKeyType = Dictionary::legalKeyType(dynamic_pointer_cast<Struct>(contained));
+    bool isLegalKeyType = Dictionary::isLegalKeyType(dynamic_pointer_cast<Struct>(contained));
 
     for (DataMemberList::const_iterator q = dataMembers.begin(); q != dataMembers.end(); ++q)
     {
@@ -346,7 +346,7 @@ Slice::JsVisitor::writeUnmarshalDataMembers(
     const ContainedPtr& contained)
 {
     bool isStruct = dynamic_pointer_cast<Struct>(contained) != nullptr;
-    bool isLegalKeyType = Dictionary::legalKeyType(dynamic_pointer_cast<Struct>(contained));
+    bool isLegalKeyType = Dictionary::isLegalKeyType(dynamic_pointer_cast<Struct>(contained));
 
     for (DataMemberList::const_iterator q = dataMembers.begin(); q != dataMembers.end(); ++q)
     {
@@ -375,7 +375,7 @@ void
 Slice::JsVisitor::writeInitDataMembers(const DataMemberList& dataMembers, const ContainedPtr& contained)
 {
     bool isStruct = dynamic_pointer_cast<Struct>(contained) != nullptr;
-    bool isLegalKeyType = Dictionary::legalKeyType(dynamic_pointer_cast<Struct>(contained));
+    bool isLegalKeyType = Dictionary::isLegalKeyType(dynamic_pointer_cast<Struct>(contained));
 
     for (DataMemberList::const_iterator q = dataMembers.begin(); q != dataMembers.end(); ++q)
     {
@@ -1815,7 +1815,7 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     //
     // Only generate hashCode if this structure type is a legal dictionary key type.
     //
-    bool legalKeyType = Dictionary::legalKeyType(p);
+    bool legalKeyType = Dictionary::isLegalKeyType(p);
 
     _out << sp;
     _out << nl << "Ice.defineStruct(" << localScope << '.' << name << ", " << (legalKeyType ? "true" : "false") << ", "
@@ -2907,7 +2907,7 @@ Slice::Gen::TypeScriptVisitor::visitStructStart(const StructPtr& p)
     //
     // Only generate hashCode if this structure type is a legal dictionary key type.
     //
-    bool isLegalKeyType = Dictionary::legalKeyType(p);
+    bool isLegalKeyType = Dictionary::isLegalKeyType(p);
     if (isLegalKeyType)
     {
         _out << sp;

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1334,7 +1334,7 @@ Slice::Python::CodeVisitor::visitStructStart(const StructPtr& p)
     //
     // Only generate __hash__ and the comparison operators if this structure type is a legal dictionary key type.
     //
-    if (Dictionary::legalKeyType(p))
+    if (Dictionary::isLegalKeyType(p))
     {
         _out << sp << nl << "def __hash__(self):";
         _out.inc();

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -489,7 +489,7 @@ Gen::TypesVisitor::visitStructStart(const StructPtr& p)
 {
     const string swiftModule = getSwiftModule(getTopLevelModule(dynamic_pointer_cast<Contained>(p)));
     const string name = fixIdent(getUnqualified(getAbsolute(p), swiftModule));
-    bool legalKeyType = Dictionary::legalKeyType(p);
+    bool isLegalKeyType = Dictionary::isLegalKeyType(p);
     const DataMemberList members = p->dataMembers();
     const string optionalFormat = getOptionalFormat(p);
 
@@ -500,7 +500,7 @@ Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     out << nl << "public " << (usesClasses ? "class " : "struct ") << name;
 
     // Only generate Hashable if this struct is a legal dictionary key type.
-    if (legalKeyType)
+    if (isLegalKeyType)
     {
         out << ": Swift.Hashable";
     }


### PR DESCRIPTION
This is the final PR of adding parameter names to the header files of the Slice compiler.
While doing so, I also updated some less-than-great names we had in the corresponding source files.

Of course, parameter names are matching in the source and header files.
Because of this, reviewing the header file is sufficient; but of course feel free to also review the cpp file.
But the placement of `InterfaceDef` in the `.cpp` didn't match the placement in the `.h`.
I moved it, so now all the definitions are in the same order. Git seems to of handled this poorly.