### PR TITLE
Additional connect timeout test

### DIFF
--- a/cpp/test/Ice/timeout/AllTests.cpp
+++ b/cpp/test/Ice/timeout/AllTests.cpp
@@ -56,7 +56,17 @@ allTestsWithController(Test::TestHelper* helper, const ControllerPrx& controller
         controller->holdAdapter(-1);
         try
         {
-            timeout->op();
+            timeout->ice_connectionId("connection-1")->op();
+            test(false);
+        }
+        catch (const Ice::ConnectTimeoutException&)
+        {
+            // Expected.
+        }
+
+        try
+        {
+            timeout->ice_connectionId("connection-2")->op();
             test(false);
         }
         catch (const Ice::ConnectTimeoutException&)
@@ -64,7 +74,8 @@ allTestsWithController(Test::TestHelper* helper, const ControllerPrx& controller
             // Expected.
         }
         controller->resumeAdapter();
-        timeout->op(); // Ensure adapter is active.
+        // Retrying with a new connection.
+        timeout->ice_connectionId("connection-3")->op();
     }
     {
         //

--- a/csharp/test/Ice/timeout/AllTests.cs
+++ b/csharp/test/Ice/timeout/AllTests.cs
@@ -61,15 +61,30 @@ public class AllTests : global::Test.AllTests
             controller.holdAdapter(-1);
             try
             {
-                timeout.op();
+                Test.TimeoutPrxHelper.uncheckedCast(timeout.ice_connectionId("connection-1")).op();
                 test(false);
             }
             catch (ConnectTimeoutException)
             {
                 // Expected.
             }
+
+            if (!Ice.Internal.AssemblyUtil.isMacOS)
+            {
+                // Workaround for macOS bug
+                // See: https://github.com/dotnet/runtime/issues/102663
+                try
+                {
+                    Test.TimeoutPrxHelper.uncheckedCast(timeout.ice_connectionId("connection-2")).op();
+                    test(false);
+                }
+                catch (ConnectTimeoutException)
+                {
+                    // Expected.
+                }
+            }
             controller.resumeAdapter();
-            timeout.op(); // Ensure adapter is active.
+            Test.TimeoutPrxHelper.uncheckedCast(timeout.ice_connectionId("connection-3")).op(); // Ensure adapter is active.
         }
         {
             //

--- a/java/test/src/main/java/test/Ice/timeout/AllTests.java
+++ b/java/test/src/main/java/test/Ice/timeout/AllTests.java
@@ -50,13 +50,21 @@ public class AllTests {
       //
       controller.holdAdapter(-1);
       try {
-        timeout.op();
+        TimeoutPrx.uncheckedCast(timeout.ice_connectionId("connection-1")).op();
+        test(false);
+      } catch (com.zeroc.Ice.ConnectTimeoutException ex) {
+        // Expected.
+      }
+
+      try {
+        TimeoutPrx.uncheckedCast(timeout.ice_connectionId("connection-2")).op();
         test(false);
       } catch (com.zeroc.Ice.ConnectTimeoutException ex) {
         // Expected.
       }
       controller.resumeAdapter();
-      timeout.op(); // Ensure adapter is active.
+      // Retrying with a new connection.
+      TimeoutPrx.uncheckedCast(timeout.ice_connectionId("connection-3")).op();
     }
     {
       //


### PR DESCRIPTION
This PR updates the connect timeout test with the modifications from https://github.com/zeroc-ice/ice/issues/2677

These shows that the bug accepting IPv6 connections after a connect timeout only affects C# on macOS.