### PR TITLE
Fix Leaking of Slice UUIDs for Global Redefinitions

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1125,7 +1125,7 @@ Slice::Container::createClassDef(const string& name, int id, const ClassDefPtr& 
         return nullptr;
     }
 
-    if (!checkIdentifier(name) || !checkForGlobalDef(name, "class"))
+    if (!checkIdentifier(name) || !checkForGlobalDefinition("classes"))
     {
         return nullptr;
     }
@@ -1190,7 +1190,7 @@ Slice::Container::createClassDecl(const string& name)
         return nullptr;
     }
 
-    if (!checkIdentifier(name) || !checkForGlobalDef(name, "class"))
+    if (!checkIdentifier(name) || !checkForGlobalDefinition("classes"))
     {
         return nullptr;
     }
@@ -1276,7 +1276,7 @@ Slice::Container::createInterfaceDef(const string& name, const InterfaceList& ba
         return nullptr;
     }
 
-    if (!checkIdentifier(name) || !checkForGlobalDef(name, "interface"))
+    if (!checkIdentifier(name) || !checkForGlobalDefinition("interfaces"))
     {
         return nullptr;
     }
@@ -1343,7 +1343,7 @@ Slice::Container::createInterfaceDecl(const string& name)
         return nullptr;
     }
 
-    if (!checkIdentifier(name) || !checkForGlobalDef(name, "interface"))
+    if (!checkIdentifier(name) || !checkForGlobalDefinition("interfaces"))
     {
         return nullptr;
     }
@@ -1404,7 +1404,7 @@ Slice::Container::createException(const string& name, const ExceptionPtr& base, 
 
     if (nodeType == Real)
     {
-        checkForGlobalDef(name, "exception"); // Don't return here -- we create the exception anyway
+        checkForGlobalDefinition("exceptions"); // Don't return here -- we create the exception anyway
     }
 
     ExceptionPtr p = make_shared<Exception>(dynamic_pointer_cast<Container>(shared_from_this()), name, base);
@@ -1439,7 +1439,7 @@ Slice::Container::createStruct(const string& name, NodeType nodeType)
 
     if (nodeType == Real)
     {
-        checkForGlobalDef(name, "structure"); // Don't return here -- we create the struct anyway.
+        checkForGlobalDefinition("structs"); // Don't return here -- we create the struct anyway.
     }
 
     StructPtr p = make_shared<Struct>(dynamic_pointer_cast<Container>(shared_from_this()), name);
@@ -1474,7 +1474,7 @@ Slice::Container::createSequence(const string& name, const TypePtr& type, const 
 
     if (nodeType == Real)
     {
-        checkForGlobalDef(name, "sequence"); // Don't return here -- we create the sequence anyway.
+        checkForGlobalDefinition("sequences"); // Don't return here -- we create the sequence anyway.
     }
 
     SequencePtr p = make_shared<Sequence>(dynamic_pointer_cast<Container>(shared_from_this()), name, type, metadata);
@@ -1515,7 +1515,7 @@ Slice::Container::createDictionary(
 
     if (nodeType == Real)
     {
-        checkForGlobalDef(name, "dictionary"); // Don't return here -- we create the dictionary anyway.
+        checkForGlobalDefinition("dictionaries"); // Don't return here -- we create the dictionary anyway.
 
         if (!Dictionary::isLegalKeyType(keyType))
         {
@@ -1564,7 +1564,7 @@ Slice::Container::createEnum(const string& name, NodeType nodeType)
 
     if (nodeType == Real)
     {
-        checkForGlobalDef(name, "enumeration"); // Don't return here -- we create the enumeration anyway.
+        checkForGlobalDefinition("enums"); // Don't return here -- we create the enumeration anyway.
     }
 
     EnumPtr p = make_shared<Enum>(dynamic_pointer_cast<Container>(shared_from_this()), name);
@@ -1605,7 +1605,7 @@ Slice::Container::createConst(
 
     if (nodeType == Real)
     {
-        checkForGlobalDef(name, "constant"); // Don't return here -- we create the constant anyway.
+        checkForGlobalDefinition("constants"); // Don't return here -- we create the constant anyway.
     }
 
     SyntaxTreeBasePtr resolvedValueType = valueType;
@@ -2164,12 +2164,12 @@ Slice::Container::checkIntroduced(const string& scopedName, ContainedPtr namedTh
 }
 
 bool
-Slice::Container::checkForGlobalDef(const string& name, const char* definitionKind)
+Slice::Container::checkForGlobalDefinition(const char* definitionKindPlural)
 {
-    if (dynamic_cast<Unit*>(this) && strcmp(definitionKind, "module"))
+    if (dynamic_cast<Unit*>(this))
     {
         ostringstream os;
-        os << "`" << name << "': " << prependA(definitionKind) << " can be defined only at module scope";
+        os << definitionKindPlural << " can only be defined within a module";
         _unit->error(os.str());
         return false;
     }

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -444,7 +444,11 @@ namespace Slice
         void visit(ParserVisitor* visitor) override;
 
         bool checkIntroduced(const std::string& scopedName, ContainedPtr namedThing = 0);
-        bool checkForGlobalDef(const std::string& name, const char* definitionKind);
+
+        /// Returns true if this container is the global scope (ie. it's of type `Unit`), and false otherwise.
+        /// If false, we emit an error message. So this function should only be called for types which cannot appear at
+        /// global scope... so everything except for `Module`s.
+        bool checkForGlobalDefinition(const char* definitionKindPlural);
 
         /// Returns true if this contains elements of the specified type.
         /// This check is recursive, so it will still return true even if the type is only contained indirectly.

--- a/cpp/test/Slice/errorDetection/DummyAtGlobalLevel.err
+++ b/cpp/test/Slice/errorDetection/DummyAtGlobalLevel.err
@@ -1,8 +1,8 @@
-DummyAtGlobalLevel.ice:6: `Foo': an interface can be defined only at module scope
+DummyAtGlobalLevel.ice:6: interfaces can only be defined within a module
 DummyAtGlobalLevel.ice:7: `UndefinedException' is not defined
 DummyAtGlobalLevel.ice:8: keyword `class' cannot be used as exception name
-DummyAtGlobalLevel.ice:11: `IntSeq': a sequence can be defined only at module scope
-DummyAtGlobalLevel.ice:14: `S': a structure can be defined only at module scope
-DummyAtGlobalLevel.ice:18: `StringDict': a dictionary can be defined only at module scope
-DummyAtGlobalLevel.ice:20: `E': an enumeration can be defined only at module scope
-DummyAtGlobalLevel.ice:22: `x': a constant can be defined only at module scope
+DummyAtGlobalLevel.ice:11: sequences can only be defined within a module
+DummyAtGlobalLevel.ice:14: structs can only be defined within a module
+DummyAtGlobalLevel.ice:18: dictionaries can only be defined within a module
+DummyAtGlobalLevel.ice:20: enums can only be defined within a module
+DummyAtGlobalLevel.ice:22: constants can only be defined within a module

--- a/cpp/test/Slice/errorDetection/IdentAsKeyword.err
+++ b/cpp/test/Slice/errorDetection/IdentAsKeyword.err
@@ -1,76 +1,76 @@
 IdentAsKeyword.ice:8: syntax error
-IdentAsKeyword.ice:10: `Void': an exception can be defined only at module scope
+IdentAsKeyword.ice:10: exceptions can only be defined within a module
 IdentAsKeyword.ice:11: keyword `int' cannot be used as exception name
-IdentAsKeyword.ice:11: `int': an exception can be defined only at module scope
-IdentAsKeyword.ice:13: `OUT': a structure can be defined only at module scope
+IdentAsKeyword.ice:11: exceptions can only be defined within a module
+IdentAsKeyword.ice:13: structs can only be defined within a module
 IdentAsKeyword.ice:14: keyword `double' cannot be used as struct name
-IdentAsKeyword.ice:14: `double': a structure can be defined only at module scope
-IdentAsKeyword.ice:16: `s1': a structure can be defined only at module scope
-IdentAsKeyword.ice:17: `s2': a structure can be defined only at module scope
+IdentAsKeyword.ice:14: structs can only be defined within a module
+IdentAsKeyword.ice:16: structs can only be defined within a module
+IdentAsKeyword.ice:17: structs can only be defined within a module
 IdentAsKeyword.ice:17: keyword `byte' cannot be used as data member name
-IdentAsKeyword.ice:18: `s3': a structure can be defined only at module scope
-IdentAsKeyword.ice:19: `s4': a structure can be defined only at module scope
+IdentAsKeyword.ice:18: structs can only be defined within a module
+IdentAsKeyword.ice:19: structs can only be defined within a module
 IdentAsKeyword.ice:19: keyword `byte' cannot be used as data member name
-IdentAsKeyword.ice:21: `inTERface': a class can be defined only at module scope
+IdentAsKeyword.ice:21: classes can only be defined within a module
 IdentAsKeyword.ice:22: keyword `interface' cannot be used as class name
-IdentAsKeyword.ice:22: `interface': a class can be defined only at module scope
-IdentAsKeyword.ice:24: `MOdule': a class can be defined only at module scope
+IdentAsKeyword.ice:22: classes can only be defined within a module
+IdentAsKeyword.ice:24: classes can only be defined within a module
 IdentAsKeyword.ice:25: keyword `module' cannot be used as class name
-IdentAsKeyword.ice:25: `module': a class can be defined only at module scope
-IdentAsKeyword.ice:27: `C': a class can be defined only at module scope
-IdentAsKeyword.ice:28: `C': a class can be defined only at module scope
+IdentAsKeyword.ice:25: classes can only be defined within a module
+IdentAsKeyword.ice:27: classes can only be defined within a module
+IdentAsKeyword.ice:28: classes can only be defined within a module
 IdentAsKeyword.ice:28: keyword `extends' cannot be used as data member name
-IdentAsKeyword.ice:29: `D': a class can be defined only at module scope
+IdentAsKeyword.ice:29: classes can only be defined within a module
 IdentAsKeyword.ice:29: keyword `extends' cannot be used as data member name
 IdentAsKeyword.ice:31: keyword `idempotent' cannot be used as interface name
-IdentAsKeyword.ice:31: `idempotent': an interface can be defined only at module scope
-IdentAsKeyword.ice:32: `IDEMPOTENT': an interface can be defined only at module scope
+IdentAsKeyword.ice:31: interfaces can only be defined within a module
+IdentAsKeyword.ice:32: interfaces can only be defined within a module
 IdentAsKeyword.ice:34: keyword `Object' cannot be used as interface name
-IdentAsKeyword.ice:34: `Object': an interface can be defined only at module scope
-IdentAsKeyword.ice:35: `object': an interface can be defined only at module scope
+IdentAsKeyword.ice:34: interfaces can only be defined within a module
+IdentAsKeyword.ice:35: interfaces can only be defined within a module
 IdentAsKeyword.ice:36: keyword `long' cannot be used as interface name
-IdentAsKeyword.ice:36: `long': an interface can be defined only at module scope
-IdentAsKeyword.ice:38: `impLEments': a sequence can be defined only at module scope
+IdentAsKeyword.ice:36: interfaces can only be defined within a module
+IdentAsKeyword.ice:38: sequences can only be defined within a module
 IdentAsKeyword.ice:39: sequence `implements' differs only in capitalization from sequence `impLEments'
-IdentAsKeyword.ice:40: `short': a sequence can be defined only at module scope
+IdentAsKeyword.ice:40: sequences can only be defined within a module
 IdentAsKeyword.ice:40: keyword `short' cannot be used as sequence name
 IdentAsKeyword.ice:42: syntax error
 IdentAsKeyword.ice:43: `moDule' is not defined
-IdentAsKeyword.ice:45: `throws': a dictionary can be defined only at module scope
+IdentAsKeyword.ice:45: dictionaries can only be defined within a module
 IdentAsKeyword.ice:45: keyword `throws' cannot be used as dictionary name
 IdentAsKeyword.ice:46: dictionary `thRows' differs only in capitalization from dictionary `throws'
-IdentAsKeyword.ice:47: `LOCALobject': a dictionary can be defined only at module scope
+IdentAsKeyword.ice:47: dictionaries can only be defined within a module
 IdentAsKeyword.ice:49: syntax error
 IdentAsKeyword.ice:50: `MODULE' is not defined
 IdentAsKeyword.ice:52: syntax error
-IdentAsKeyword.ice:53: `d4': a dictionary can be defined only at module scope
+IdentAsKeyword.ice:53: dictionaries can only be defined within a module
 IdentAsKeyword.ice:55: syntax error
 IdentAsKeyword.ice:56: `VOID' is an exception, which cannot be used as a type
 IdentAsKeyword.ice:58: keyword `idempotent' cannot be used as enumeration name
-IdentAsKeyword.ice:58: `idempotent': an enumeration can be defined only at module scope
+IdentAsKeyword.ice:58: enums can only be defined within a module
 IdentAsKeyword.ice:59: enumeration `IDEMPOTENT' differs only in capitalization from enumeration `idempotent'
-IdentAsKeyword.ice:61: `e1': an enumeration can be defined only at module scope
+IdentAsKeyword.ice:61: enums can only be defined within a module
 IdentAsKeyword.ice:61: keyword `long' cannot be used as enumerator
 IdentAsKeyword.ice:61: keyword `byte' cannot be used as enumerator
-IdentAsKeyword.ice:62: `e2': an enumeration can be defined only at module scope
-IdentAsKeyword.ice:64: `i1': an interface can be defined only at module scope
-IdentAsKeyword.ice:65: `i2': an interface can be defined only at module scope
-IdentAsKeyword.ice:67: `i3': an interface can be defined only at module scope
-IdentAsKeyword.ice:68: `i4': an interface can be defined only at module scope
-IdentAsKeyword.ice:70: `i5': an interface can be defined only at module scope
+IdentAsKeyword.ice:62: enums can only be defined within a module
+IdentAsKeyword.ice:64: interfaces can only be defined within a module
+IdentAsKeyword.ice:65: interfaces can only be defined within a module
+IdentAsKeyword.ice:67: interfaces can only be defined within a module
+IdentAsKeyword.ice:68: interfaces can only be defined within a module
+IdentAsKeyword.ice:70: interfaces can only be defined within a module
 IdentAsKeyword.ice:70: syntax error
-IdentAsKeyword.ice:71: `i6': an interface can be defined only at module scope
-IdentAsKeyword.ice:73: `i7': an interface can be defined only at module scope
-IdentAsKeyword.ice:74: `i8': an interface can be defined only at module scope
-IdentAsKeyword.ice:76: `i9': an interface can be defined only at module scope
-IdentAsKeyword.ice:77: `i10': an interface can be defined only at module scope
-IdentAsKeyword.ice:79: `true': an interface can be defined only at module scope
+IdentAsKeyword.ice:71: interfaces can only be defined within a module
+IdentAsKeyword.ice:73: interfaces can only be defined within a module
+IdentAsKeyword.ice:74: interfaces can only be defined within a module
+IdentAsKeyword.ice:76: interfaces can only be defined within a module
+IdentAsKeyword.ice:77: interfaces can only be defined within a module
+IdentAsKeyword.ice:79: interfaces can only be defined within a module
 IdentAsKeyword.ice:81: illegal leading underscore in identifier `_a'
 IdentAsKeyword.ice:82: illegal leading underscore in identifier `_true'
 IdentAsKeyword.ice:83: illegal leading underscore in identifier `_true'
 IdentAsKeyword.ice:85: illegal trailing underscore in identifier `b_'
 IdentAsKeyword.ice:87: illegal double underscore in identifier `b__c'
 IdentAsKeyword.ice:88: illegal double underscore in identifier `b___c'
-IdentAsKeyword.ice:90: `a_b': an interface can be defined only at module scope
-IdentAsKeyword.ice:91: `a_b_c': an interface can be defined only at module scope
+IdentAsKeyword.ice:90: interfaces can only be defined within a module
+IdentAsKeyword.ice:91: interfaces can only be defined within a module
 IdentAsKeyword.ice:93: syntax error


### PR DESCRIPTION
This PR fixes the symptoms of #2662 by no longer emitting identifiers in the error message for global definitions.
To be fair, I don't think including the name was adding much value, and the current message sounds weird to me anyways.

In fixing this I also tweaked the type names in the messages. So now we talk about `structs` instead of `structures` and `enums` instead of `enumerations`. This seems consistent with how we talk about these things in most other places.