### PR TITLE
Fix close for already closed connection in C++

### DIFF
--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -512,31 +512,46 @@ Ice::ConnectionI::close(function<void()> response, function<void(std::exception_
         }
     }
 
-    if (closeException) // already closed
+    if ((response || exception) && closeException) // already closed
     {
+        bool success = false;
         try
         {
             rethrow_exception(closeException);
         }
         catch (const ConnectionClosedException&)
         {
-            response();
+            success = true;
         }
         catch (const CloseConnectionException&)
         {
-            response();
+            success = true;
         }
         catch (const CommunicatorDestroyedException&)
         {
-            response();
+            success = true;
         }
         catch (const ObjectAdapterDeactivatedException&)
         {
-            response();
+            success = true;
         }
         catch (...)
         {
-            exception(closeException);
+        }
+
+        if (success)
+        {
+            if (response)
+            {
+                response();
+            }
+        }
+        else
+        {
+            if (exception)
+            {
+                exception(closeException);
+            }
         }
     }
 }

--- a/cpp/test/Ice/timeout/AllTests.cpp
+++ b/cpp/test/Ice/timeout/AllTests.cpp
@@ -196,6 +196,10 @@ allTestsWithController(Test::TestHelper* helper, const ControllerPrx& controller
         {
             // Expected.
         }
+
+        // Verify closing a closed connection is fine.
+        connection->close(nullptr, nullptr);
+
         controller->resumeAdapter();
         timeout->op(); // Ensure adapter is active.
     }


### PR DESCRIPTION
The implementation of `close(nullptr, nullptr)` was not correct in C++.

Fixes #2702
Fixes #2097 (likely).
