### PR TITLE
Fix close implementation

### DIFF
--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -872,6 +872,11 @@ Ice::ConnectionI::asyncRequestCanceled(const OutgoingAsyncBasePtr& outAsync, exc
                     outAsync->invokeExceptionAsync();
                 }
             }
+
+            if (_closeRequested && _state < StateClosing && _asyncRequests.empty())
+            {
+                doApplicationClose();
+            }
             return;
         }
     }
@@ -899,6 +904,11 @@ Ice::ConnectionI::asyncRequestCanceled(const OutgoingAsyncBasePtr& outAsync, exc
                     {
                         outAsync->invokeExceptionAsync();
                     }
+                }
+
+                if (_closeRequested && _state < StateClosing && _asyncRequests.empty())
+                {
+                    doApplicationClose();
                 }
                 return;
             }

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -500,6 +500,11 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                         outAsync.invokeExceptionAsync();
                     }
                 }
+
+                if (_closeRequested && _state < StateClosing && _asyncRequests.Count == 0)
+                {
+                    doApplicationClose();
+                }
                 return;
             }
 
@@ -520,6 +525,11 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                             {
                                 outAsync.invokeExceptionAsync();
                             }
+                        }
+
+                        if (_closeRequested && _state < StateClosing && _asyncRequests.Count == 0)
+                        {
+                            doApplicationClose();
                         }
                         return;
                     }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -422,6 +422,10 @@ public final class ConnectionI extends com.zeroc.IceInternal.EventHandler
             outAsync.invokeCompletedAsync();
           }
         }
+
+        if (_closeRequested && _state < StateClosing && _asyncRequests.isEmpty()) {
+          doApplicationClose();
+        }
         return;
       }
     }
@@ -437,6 +441,10 @@ public final class ConnectionI extends com.zeroc.IceInternal.EventHandler
             if (outAsync.completed(ex)) {
               outAsync.invokeCompletedAsync();
             }
+          }
+
+          if (_closeRequested && _state < StateClosing && _asyncRequests.isEmpty()) {
+            doApplicationClose();
           }
           return;
         }
@@ -2120,7 +2128,7 @@ public final class ConnectionI extends com.zeroc.IceInternal.EventHandler
             TraceUtil.traceRecv(info.stream, _logger, _traceLevels);
             info.requestId = info.stream.readInt();
 
-            OutgoingAsyncBase outAsync = _asyncRequests.remove(info.requestId);
+            var outAsync = _asyncRequests.remove(info.requestId);
             if (outAsync != null && outAsync.completed(info.stream)) {
               info.outAsync = outAsync;
               ++info.messageDispatchCount;


### PR DESCRIPTION
This PR fixes to close implementation in C++, C# and Java to take into account request cancellation.

It also updates the JS implementation to be more like the C++/C#/Java implementations.

Fixes #2698 