### PR TITLE
Fix IceGrid Glacier2 session managers to keep sessions alive

### DIFF
--- a/cpp/src/IceGrid/AdminSessionI.cpp
+++ b/cpp/src/IceGrid/AdminSessionI.cpp
@@ -116,6 +116,12 @@ AdminSessionI::~AdminSessionI()
 {
 }
 
+void
+AdminSessionI::ice_ping(const Ice::Current& current) const
+{
+    const_cast<AdminSessionI*>(this)->keepAlive(current);
+}
+
 Ice::ObjectPrx
 AdminSessionI::_register(const SessionServantManagerPtr& servantManager, const Ice::ConnectionPtr& con)
 {

--- a/cpp/src/IceGrid/AdminSessionI.h
+++ b/cpp/src/IceGrid/AdminSessionI.h
@@ -28,6 +28,8 @@ public:
 
     Ice::ObjectPrx _register(const SessionServantManagerPtr&, const Ice::ConnectionPtr&);
 
+    virtual void ice_ping(const Ice::Current&) const;
+
     virtual void keepAlive(const Ice::Current& current) { BaseSessionI::keepAlive(current); }
 
     virtual AdminPrx getAdmin(const Ice::Current&) const;

--- a/cpp/src/IceGrid/SessionI.cpp
+++ b/cpp/src/IceGrid/SessionI.cpp
@@ -155,6 +155,12 @@ SessionI::~SessionI()
 {
 }
 
+void
+SessionI::ice_ping(const Ice::Current& current) const
+{
+    const_cast<SessionI*>(this)->keepAlive(current);
+}
+
 Ice::ObjectPrx
 SessionI::_register(const SessionServantManagerPtr& servantManager, const Ice::ConnectionPtr& con)
 {

--- a/cpp/src/IceGrid/SessionI.h
+++ b/cpp/src/IceGrid/SessionI.h
@@ -73,7 +73,7 @@ public:
 
     Ice::ObjectPrx _register(const SessionServantManagerPtr&, const Ice::ConnectionPtr&);
 
-    void ice_ping(const Ice::Current&) const;
+    virtual void ice_ping(const Ice::Current&) const;
 
     virtual void keepAlive(const Ice::Current& current) { BaseSessionI::keepAlive(current); }
 

--- a/cpp/src/IceGrid/SessionI.h
+++ b/cpp/src/IceGrid/SessionI.h
@@ -73,6 +73,8 @@ public:
 
     Ice::ObjectPrx _register(const SessionServantManagerPtr&, const Ice::ConnectionPtr&);
 
+    void ice_ping(const Ice::Current&) const;
+
     virtual void keepAlive(const Ice::Current& current) { BaseSessionI::keepAlive(current); }
 
     virtual void allocateObjectById_async(const AMD_Session_allocateObjectByIdPtr&, const Ice::Identity&,


### PR DESCRIPTION
This PR fix the Glacier2 session managers implemented in IceGrid to correctly keep sessions alive.