### PR TITLE
Update Swift exceptions to be "@unchecked Sendable"

### DIFF
--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -393,6 +393,7 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     {
         out << getUnqualified("Ice.UserException", swiftModule);
     }
+    out << ", @unchecked Sendable";
     out << sb;
 
     const DataMemberList members = p->dataMembers();

--- a/swift/src/Ice/UserException.swift
+++ b/swift/src/Ice/UserException.swift
@@ -1,7 +1,9 @@
 // Copyright (c) ZeroC, Inc.
 
-/// Base class for Ice user exceptions.
-open class UserException: Exception {
+/// Base class for Ice user exceptions. User exceptions are marked as "@unchecked Sendable" as the error
+/// protocol requires them to be Sendable. However, the generated exception classes are not thread safe, and users
+/// should not share instances of user exceptions between threads.
+open class UserException: Exception, @unchecked Sendable {
     public required init() {}
 
     /// Gets the type ID of the class.


### PR DESCRIPTION
The Swift 6 compiler was issuing a warning that our about our generated exceptions (which are classes) are not sendable.

I've marked them as `@unchecked Sendable` to appease the compiler, however this doesn't make them thread safe. Users should still take care not to share an instance of one of these between threads.

If we really wanted we could update these generated exception classes to actually be thread safe, but I don't think it's worth it.