### PR TITLE
Remove TypeContextLocal from slice2swift

### DIFF
--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -606,7 +606,6 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
 {
     const string swiftModule = getSwiftModule(getTopLevelModule(dynamic_pointer_cast<Contained>(p)));
     const string name = getUnqualified(getAbsolute(p), swiftModule);
-    int typeCtx = 0;
 
     const TypePtr type = p->type();
     BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(p->type());
@@ -621,7 +620,7 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     }
     else
     {
-        out << "[" << typeToString(p->type(), p, p->getMetadata(), false, typeCtx) << "]";
+        out << "[" << typeToString(p->type(), p, p->getMetadata(), false) << "]";
     }
 
     if (builtin && builtin->kind() <= Builtin::KindString)
@@ -764,10 +763,9 @@ Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
 {
     const string swiftModule = getSwiftModule(getTopLevelModule(dynamic_pointer_cast<Contained>(p)));
     const string name = getUnqualified(getAbsolute(p), swiftModule);
-    int typeCtx = 0;
 
-    const string keyType = typeToString(p->keyType(), p, p->keyMetadata(), false, typeCtx);
-    const string valueType = typeToString(p->valueType(), p, p->valueMetadata(), false, typeCtx);
+    const string keyType = typeToString(p->keyType(), p, p->keyMetadata(), false);
+    const string valueType = typeToString(p->valueType(), p, p->valueMetadata(), false);
     out << sp;
     writeDocSummary(out, p);
     out << nl << "public typealias " << fixIdent(name) << " = [" << keyType << ": " << valueType << "]";

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -14,7 +14,6 @@ namespace Slice
 {
     const int TypeContextInParam = 1;
     const int TypeContextProtocol = 2;
-    const int TypeContextLocal = 32;
 
     std::string getSwiftModule(const ModulePtr&, std::string&);
     std::string getSwiftModule(const ModulePtr&);
@@ -78,19 +77,18 @@ namespace Slice
         void writeMemberDoc(IceInternal::Output&, const DataMemberPtr&);
 
         std::string paramLabel(const std::string&, const ParamDeclList&);
-        std::string operationReturnType(const OperationPtr&, int typeCtx = 0);
+        std::string operationReturnType(const OperationPtr&);
         bool operationReturnIsTuple(const OperationPtr&);
         std::string operationReturnDeclaration(const OperationPtr&);
         std::string operationInParamsDeclaration(const OperationPtr&);
 
-        ParamInfoList getAllInParams(const OperationPtr&, int = 0);
+        ParamInfoList getAllInParams(const OperationPtr&);
         void getInParams(const OperationPtr&, ParamInfoList&, ParamInfoList&);
 
-        ParamInfoList getAllOutParams(const OperationPtr&, int = 0);
+        ParamInfoList getAllOutParams(const OperationPtr&);
         void getOutParams(const OperationPtr&, ParamInfoList&, ParamInfoList&);
 
-        std::string
-        typeToString(const TypePtr&, const ContainedPtr&, const StringList& = StringList(), bool = false, int = 0);
+        std::string typeToString(const TypePtr&, const ContainedPtr&, const StringList& = StringList(), bool = false);
 
         std::string getAbsolute(const TypePtr&);
         std::string getAbsolute(const ClassDeclPtr&);


### PR DESCRIPTION
Removing this unused type context allowed for some additional cleanup.

Closes #2766
