### PR TITLE
Glacier2 header cleanup

### DIFF
--- a/cpp/include/Glacier2/Glacier2.h
+++ b/cpp/include/Glacier2/Glacier2.h
@@ -10,5 +10,6 @@
 #include "Glacier2/PermissionsVerifier.h"
 #include "Glacier2/Router.h"
 #include "Glacier2/Session.h"
+#include "Glacier2/SSLInfo.h"
 
 #endif

--- a/cpp/include/Glacier2/Glacier2.h
+++ b/cpp/include/Glacier2/Glacier2.h
@@ -9,7 +9,7 @@
 #include "Glacier2/Metrics.h"
 #include "Glacier2/PermissionsVerifier.h"
 #include "Glacier2/Router.h"
-#include "Glacier2/Session.h"
 #include "Glacier2/SSLInfo.h"
+#include "Glacier2/Session.h"
 
 #endif

--- a/cpp/src/Glacier2/Glacier2Router.cpp
+++ b/cpp/src/Glacier2/Glacier2Router.cpp
@@ -4,7 +4,7 @@
 
 #include "../Ice/ConsoleUtil.h"
 #include "../Ice/Options.h"
-#include "Glacier2/NullPermissionsVerifier.h"
+#include "../Glacier2Lib/NullPermissionsVerifier.h"
 #include "Glacier2/Session.h"
 #include "Ice/Ice.h"
 #include "Instance.h"

--- a/cpp/src/Glacier2/Glacier2Router.cpp
+++ b/cpp/src/Glacier2/Glacier2Router.cpp
@@ -2,9 +2,9 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+#include "../Glacier2Lib/NullPermissionsVerifier.h"
 #include "../Ice/ConsoleUtil.h"
 #include "../Ice/Options.h"
-#include "../Glacier2Lib/NullPermissionsVerifier.h"
 #include "Glacier2/Session.h"
 #include "Ice/Ice.h"
 #include "Instance.h"

--- a/cpp/src/Glacier2Lib/NullPermissionsVerifier.cpp
+++ b/cpp/src/Glacier2Lib/NullPermissionsVerifier.cpp
@@ -2,9 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-#include "Glacier2/NullPermissionsVerifier.h"
+#include "NullPermissionsVerifier.h"
 #include "Glacier2/PermissionsVerifier.h"
-#include "Ice/Ice.h"
 
 using namespace Ice;
 using namespace std;

--- a/cpp/src/Glacier2Lib/NullPermissionsVerifier.h
+++ b/cpp/src/Glacier2Lib/NullPermissionsVerifier.h
@@ -5,7 +5,7 @@
 #ifndef GLACIER2_NULL_PERMISSIONS_VERIFIER_H
 #define GLACIER2_NULL_PERMISSIONS_VERIFIER_H
 
-#include "Config.h"
+#include "Glacier2/Config.h"
 #include "Ice/Ice.h"
 
 #include <string>

--- a/cpp/src/Glacier2Lib/msbuild/glacier2/glacier2.vcxproj
+++ b/cpp/src/Glacier2Lib/msbuild/glacier2/glacier2.vcxproj
@@ -342,7 +342,6 @@
     </ClInclude>
     <ClInclude Include="..\..\..\..\include\Glacier2\Config.h" />
     <ClInclude Include="..\..\..\..\include\Glacier2\Glacier2.h" />
-    <ClInclude Include="..\..\..\..\include\Glacier2\NullPermissionsVerifier.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\Glacier2.rc" />

--- a/cpp/src/Glacier2Lib/msbuild/glacier2/glacier2.vcxproj.filters
+++ b/cpp/src/Glacier2Lib/msbuild/glacier2/glacier2.vcxproj.filters
@@ -126,9 +126,6 @@
     <ClInclude Include="..\..\..\..\include\Glacier2\Glacier2.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\..\include\Glacier2\NullPermissionsVerifier.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\..\..\include\generated\Win32\Debug\Glacier2\Metrics.h">
       <Filter>Header Files\Win32\Debug</Filter>
     </ClInclude>

--- a/cpp/src/IceGrid/RegistryI.cpp
+++ b/cpp/src/IceGrid/RegistryI.cpp
@@ -14,7 +14,7 @@
 #include "Database.h"
 #include "FileCache.h"
 #include "FileUserAccountMapperI.h"
-#include "Glacier2/NullPermissionsVerifier.h"
+#include "../Glacier2Lib/NullPermissionsVerifier.h"
 #include "Glacier2/PermissionsVerifier.h"
 #include "Ice/Ice.h"
 #include "Ice/UUID.h"

--- a/cpp/src/IceGrid/RegistryI.cpp
+++ b/cpp/src/IceGrid/RegistryI.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "RegistryI.h"
+#include "../Glacier2Lib/NullPermissionsVerifier.h"
 #include "../Ice/FileUtil.h"
 #include "../Ice/Network.h"
 #include "../Ice/ProtocolPluginFacade.h" // Just to get the hostname
@@ -14,7 +15,6 @@
 #include "Database.h"
 #include "FileCache.h"
 #include "FileUserAccountMapperI.h"
-#include "../Glacier2Lib/NullPermissionsVerifier.h"
 #include "Glacier2/PermissionsVerifier.h"
 #include "Ice/Ice.h"
 #include "Ice/UUID.h"


### PR DESCRIPTION
This is a small cleanup of the Glacier2 header files:
 - move the internal header NullPermissionsVerifier.h to src/Glacier2Lib
 - add generated Glacier2/SSLInfo.h to Glacier2/Glacier2.h