### PR TITLE
Fix Escaping Bug in C++

### DIFF
--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -502,7 +502,7 @@ Slice::typeToString(
     ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
     if (cl)
     {
-        return getUnqualified(cl->scoped(), scope) + "Ptr";
+        return getUnqualified(fixKwd(cl->scoped() + "Ptr"), scope);
     }
 
     StructPtr st = dynamic_pointer_cast<Struct>(type);
@@ -804,8 +804,7 @@ Slice::writeStreamHelpers(Output& out, const ContainedPtr& c, DataMemberList dat
     };
     optionalMembers.sort(SortFn::compare);
 
-    string scoped = c->scoped();
-    string fullName = fixKwd(scoped);
+    string fullName = fixKwd(c->scoped());
     string holder = "v.";
 
     //

--- a/cpp/test/Slice/escape/Client.cpp
+++ b/cpp/test/Slice/escape/Client.cpp
@@ -51,30 +51,28 @@ public:
     virtual void foo(const _cpp_and::charPrx&, int32_t&, const ::Ice::Current&) {}
 };
 
-/*
-TODO: reenable once bug #1617 is fixed.
-
 class friendI : public _cpp_and::_cpp_friend
 {
 public:
-    virtual _cpp_and::_cpp_auto
-    _cpp_goto(_cpp_and::_cpp_continue,
-              const _cpp_and::_cpp_auto&,
-              const _cpp_and::_cpp_delete&,
-              const _cpp_and::switchPtr&,
-              const ::std::shared_ptr<::Ice::Value>&,
-              const optional<_cpp_and::breakPrx>&,
-              const optional<_cpp_and::charPrx>&,
-              const optional<::Ice::ObjectPrx>&,
-              const optional<_cpp_and::doPrx>&,
-              ::int32_t, ::int32_t,
-              ::int32_t, ::int32_t,
-              const ::Ice::Current&)
+    _cpp_and::_cpp_auto _cpp_goto(
+        _cpp_and::_cpp_continue,
+        _cpp_and::_cpp_auto,
+        _cpp_and::_cpp_delete,
+        _cpp_and::switchPtr,
+        optional<_cpp_and::doPrx>,
+        optional<_cpp_and::breakPrx>,
+        optional<_cpp_and::charPrx>,
+        _cpp_and::switchPtr,
+        optional<_cpp_and::doPrx>,
+        ::int32_t,
+        ::int32_t,
+        ::int32_t,
+        ::int32_t,
+        const ::Ice::Current&) override
     {
         return _cpp_and::_cpp_auto();
     }
 };
-*/
 
 //
 // This section of the test is present to ensure that the C++ types
@@ -129,8 +127,7 @@ testtypes(const Ice::CommunicatorPtr& communicator)
     k._cpp_switch = 1;
     k._cpp_signed = 2;
 
-    // TODO: reenable once bug #1617 is fixed.
-    // _cpp_and::friendPtr l = std::make_shared<friendI>();
+    _cpp_and::friendPtr l = std::make_shared<friendI>();
 
     const int m = _cpp_and::_cpp_template;
     test(m == _cpp_and::_cpp_template);

--- a/cpp/test/Slice/escape/Key.ice
+++ b/cpp/test/Slice/escape/Key.ice
@@ -57,16 +57,12 @@ exception sizeof extends return
     int static; int switch;
 }
 
-/*
-TODO: reenable once bug #1617 is fixed.
-
 interface friend
 {
-    auto goto(continue if, auto d, delete inline, switch private, do mutable, break* namespace,
-              char* new, switch* not, do* operator, int or, int protected, int public, int register)
+    auto goto(continue if, auto d, delete inline, switch private, do* mutable, break* namespace,
+              char* new, switch not, do* operator, int or, int protected, int public, int register)
         throws return, sizeof;
 }
-*/
 
 const int template = 0;
 const int this = 0;


### PR DESCRIPTION
This PR fixes the C++ side of #1617.
We were just forgetting to escape class names in one place where we should of been.
I checked everywhere in `slice2cpp` where we emit names, and this was the only place I saw where we forgot to escape.

----

That issue references another escaping issue in Swift, but the cause of that is a little more elusive.
And that code could use a little untangling before I start trying to track down the problem.