### PR TITLE
Cleanup Type-String Generation in `slice2swift`

### DIFF
--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -306,8 +306,8 @@ bool
 Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     const string swiftModule = getSwiftModule(getTopLevelModule(dynamic_pointer_cast<Contained>(p)));
-    const string name = fixIdent(getUnqualified(getAbsolute(p), swiftModule));
-    const string traits = fixIdent(getUnqualified(getAbsolute(p), swiftModule) + "Traits");
+    const string name = fixIdent(getRelativeTypeString(p, swiftModule));
+    const string traits = fixIdent(getRelativeTypeString(p, swiftModule) + "Traits");
 
     StringList allIds = p->ids();
     ostringstream ids;
@@ -339,7 +339,7 @@ bool
 Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
     const string swiftModule = getSwiftModule(getTopLevelModule(dynamic_pointer_cast<Contained>(p)));
-    const string name = getUnqualified(getAbsolute(p), swiftModule);
+    const string name = getRelativeTypeString(p, swiftModule);
 
     ExceptionPtr base = p->base();
 
@@ -387,7 +387,7 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     out << nl << "open class " << fixIdent(name) << ": ";
     if (base)
     {
-        out << fixIdent(getUnqualified(getAbsolute(base), swiftModule));
+        out << fixIdent(getRelativeTypeString(base, swiftModule));
     }
     else
     {
@@ -489,7 +489,7 @@ bool
 Gen::TypesVisitor::visitStructStart(const StructPtr& p)
 {
     const string swiftModule = getSwiftModule(getTopLevelModule(dynamic_pointer_cast<Contained>(p)));
-    const string name = fixIdent(getUnqualified(getAbsolute(p), swiftModule));
+    const string name = fixIdent(getRelativeTypeString(p, swiftModule));
     bool isLegalKeyType = Dictionary::isLegalKeyType(p);
     const DataMemberList members = p->dataMembers();
     const string optionalFormat = getOptionalFormat(p);
@@ -606,7 +606,7 @@ void
 Gen::TypesVisitor::visitSequence(const SequencePtr& p)
 {
     const string swiftModule = getSwiftModule(getTopLevelModule(dynamic_pointer_cast<Contained>(p)));
-    const string name = getUnqualified(getAbsolute(p), swiftModule);
+    const string name = getRelativeTypeString(p, swiftModule);
 
     const TypePtr type = p->type();
     BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(p->type());
@@ -763,7 +763,7 @@ void
 Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
 {
     const string swiftModule = getSwiftModule(getTopLevelModule(dynamic_pointer_cast<Contained>(p)));
-    const string name = getUnqualified(getAbsolute(p), swiftModule);
+    const string name = getRelativeTypeString(p, swiftModule);
 
     const string keyType = typeToString(p->keyType(), p, p->keyMetadata(), false);
     const string valueType = typeToString(p->valueType(), p, p->valueMetadata(), false);
@@ -914,7 +914,7 @@ void
 Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 {
     const string swiftModule = getSwiftModule(getTopLevelModule(dynamic_pointer_cast<Contained>(p)));
-    const string name = fixIdent(getUnqualified(getAbsolute(p), swiftModule));
+    const string name = fixIdent(getRelativeTypeString(p, swiftModule));
     const EnumeratorList enumerators = p->enumerators();
     const string enumType = p->maxValue() <= 0xFF ? "Swift.UInt8" : "Swift.Int32";
     const string optionalFormat = getOptionalFormat(p);
@@ -1039,7 +1039,7 @@ Gen::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     InterfaceList bases = p->bases();
 
     const string swiftModule = getSwiftModule(getTopLevelModule(dynamic_pointer_cast<Contained>(p)));
-    const string name = getUnqualified(getAbsolute(p), swiftModule);
+    const string name = getRelativeTypeString(p, swiftModule);
     const string traits = name + "Traits";
     const string prx = name + "Prx";
     const string prxI = name + "PrxI";
@@ -1055,7 +1055,7 @@ Gen::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     {
         for (InterfaceList::const_iterator i = bases.begin(); i != bases.end();)
         {
-            out << " " << getUnqualified(getAbsolute(*i), swiftModule) << "Prx";
+            out << " " << getRelativeTypeString(*i, swiftModule) << "Prx";
             if (++i != bases.end())
             {
                 out << ",";
@@ -1227,7 +1227,7 @@ Gen::ValueVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
     const string prefix = getClassResolverPrefix(p->unit());
     const string swiftModule = getSwiftModule(getTopLevelModule(dynamic_pointer_cast<Contained>(p)));
-    const string name = getUnqualified(getAbsolute(p), swiftModule);
+    const string name = getRelativeTypeString(p, swiftModule);
 
     ClassDefPtr base = p->base();
 
@@ -1288,7 +1288,7 @@ Gen::ValueVisitor::visitClassDefStart(const ClassDefPtr& p)
     out << nl << "open class " << fixIdent(name) << ": ";
     if (base)
     {
-        out << fixIdent(getUnqualified(getAbsolute(base), swiftModule));
+        out << fixIdent(getRelativeTypeString(base, swiftModule));
     }
     else
     {
@@ -1384,9 +1384,9 @@ bool
 Gen::ObjectVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     const string swiftModule = getSwiftModule(getTopLevelModule(dynamic_pointer_cast<Contained>(p)));
-    const string disp = fixIdent(getUnqualified(getAbsolute(p), swiftModule) + "Disp");
-    const string traits = fixIdent(getUnqualified(getAbsolute(p), swiftModule) + "Traits");
-    const string servant = fixIdent(getUnqualified(getAbsolute(p), swiftModule));
+    const string disp = fixIdent(getRelativeTypeString(p, swiftModule) + "Disp");
+    const string traits = fixIdent(getRelativeTypeString(p, swiftModule) + "Traits");
+    const string servant = fixIdent(getRelativeTypeString(p, swiftModule));
 
     //
     // Disp struct
@@ -1463,7 +1463,7 @@ Gen::ObjectVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     StringList baseNames;
     for (InterfaceList::const_iterator i = bases.begin(); i != bases.end(); ++i)
     {
-        baseNames.push_back(fixIdent(getUnqualified(getAbsolute(*i), swiftModule)));
+        baseNames.push_back(fixIdent(getRelativeTypeString(*i, swiftModule)));
     }
 
     //
@@ -1542,7 +1542,7 @@ bool
 Gen::ObjectExtVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     const string swiftModule = getSwiftModule(getTopLevelModule(dynamic_pointer_cast<Contained>(p)));
-    const string name = getUnqualified(getAbsolute(p), swiftModule);
+    const string name = getRelativeTypeString(p, swiftModule);
 
     out << sp;
     writeServantDocSummary(out, p, swiftModule);

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -789,7 +789,7 @@ SwiftGenerator::writeProxyDocSummary(IceInternal::Output& out, const InterfaceDe
 {
     DocElements doc = parseComment(p);
 
-    const string name = getUnqualified(getAbsolute(p), swiftModule);
+    const string name = getRelativeTypeString(p, swiftModule);
     const string prx = name + "Prx";
 
     if (doc.overview.empty())
@@ -837,7 +837,7 @@ SwiftGenerator::writeServantDocSummary(IceInternal::Output& out, const Interface
 {
     DocElements doc = parseComment(p);
 
-    const string name = getUnqualified(getAbsolute(p), swiftModule);
+    const string name = getRelativeTypeString(p, swiftModule);
 
     if (doc.overview.empty())
     {
@@ -917,36 +917,32 @@ SwiftGenerator::validateMetadata(const UnitPtr& u)
     u->visit(&visitor);
 }
 
-//
-// Get the fully-qualified name of the given definition. If a suffix is provided,
-// it is prepended to the definition's unqualified name. If the nameSuffix
-// is provided, it is appended to the container's name.
-//
-namespace
+string
+SwiftGenerator::getRelativeTypeString(const ContainedPtr& contained, const string& currentModule)
 {
-    string getAbsoluteImpl(const ContainedPtr& cont, const string& prefix = "", const string& suffix = "")
+    string typeString = contained->scoped();
+
+    // Proxy types always end with "Prx".
+    if (dynamic_pointer_cast<InterfaceDecl>(contained))
     {
-        string swiftPrefix;
-        string swiftModule = getSwiftModule(getTopLevelModule(cont), swiftPrefix);
-
-        string str = cont->scope() + prefix + cont->name() + suffix;
-        if (str.find("::") == 0)
-        {
-            str.erase(0, 2);
-        }
-
-        size_t pos = str.find("::");
-        //
-        // Replace the definition top-level module by the corresponding Swift module
-        // and append the Swift prefix for the Slice module, then any remaining nested
-        // modules become a Swift prefix
-        //
-        if (pos != string::npos)
-        {
-            str = str.substr(pos + 2);
-        }
-        return swiftModule + "." + swiftPrefix + replace(str, "::", "");
+        typeString += "Prx";
     }
+
+    // Remove the leading '::' the Slice compiler always gives us.
+    assert(typeString.find("::") == 0);
+    typeString.erase(0, 2);
+    // Replace the definition top-level module by the corresponding Swift module
+    // and append the Swift prefix for the Slice module, then any remaining nested
+    // modules become a Swift prefix
+    size_t pos = typeString.find("::");
+    if (pos != string::npos)
+    {
+        typeString = typeString.substr(pos + 2);
+    }
+    string swiftPrefix;
+    string swiftModule = getSwiftModule(getTopLevelModule(contained), swiftPrefix);
+    auto absoluteIdent = swiftModule + "." + swiftPrefix + replace(typeString, "::", "");
+    return getUnqualified(absoluteIdent, currentModule);
 }
 
 string
@@ -993,19 +989,19 @@ SwiftGenerator::getValue(const string& swiftModule, const TypePtr& type)
     StructPtr st = dynamic_pointer_cast<Struct>(type);
     if (st)
     {
-        return getUnqualified(getAbsolute(type), swiftModule) + "()";
+        return getRelativeTypeString(st, swiftModule) + "()";
     }
 
     SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
     if (seq)
     {
-        return getUnqualified(getAbsolute(type), swiftModule) + "()";
+        return getRelativeTypeString(seq, swiftModule) + "()";
     }
 
     DictionaryPtr dict = dynamic_pointer_cast<Dictionary>(type);
     if (dict)
     {
-        return getUnqualified(getAbsolute(type), swiftModule) + "()";
+        return getRelativeTypeString(dict, swiftModule) + "()";
     }
 
     return "nil";
@@ -1024,7 +1020,7 @@ SwiftGenerator::writeConstantValue(
     ConstPtr constant = dynamic_pointer_cast<Const>(valueType);
     if (constant)
     {
-        out << getUnqualified(getAbsolute(constant), swiftModule);
+        out << getRelativeTypeString(constant, swiftModule);
     }
     else
     {
@@ -1043,7 +1039,7 @@ SwiftGenerator::writeConstantValue(
                 assert(valueType);
                 EnumeratorPtr enumerator = dynamic_pointer_cast<Enumerator>(valueType);
                 assert(enumerator);
-                out << getUnqualified(getAbsolute(ep), swiftModule) << "." << enumerator->name();
+                out << getRelativeTypeString(ep, swiftModule) << "." << enumerator->name();
             }
             else
             {
@@ -1113,15 +1109,15 @@ SwiftGenerator::typeToString(
 
     if (cl)
     {
-        t += fixIdent(getUnqualified(getAbsoluteImpl(cl), currentModule));
+        t += fixIdent(getRelativeTypeString(cl, currentModule));
     }
     else if (prx)
     {
-        t = getUnqualified(getAbsoluteImpl(prx, "", "Prx"), currentModule);
+        t = getRelativeTypeString(prx, currentModule);
     }
     else if (cont)
     {
-        t = fixIdent(getUnqualified(getAbsoluteImpl(cont), currentModule));
+        t = fixIdent(getRelativeTypeString(cont, currentModule));
     }
 
     if (!nonnull && (optional || isNullableType(type)))
@@ -1131,104 +1127,7 @@ SwiftGenerator::typeToString(
     return t;
 }
 
-string
-SwiftGenerator::getAbsolute(const TypePtr& type)
-{
-    static const char* builtinTable[] = {
-        "Swift.UInt8",
-        "Swift.Bool",
-        "Swift.Int16",
-        "Swift.Int32",
-        "Swift.Int64",
-        "Swift.Float",
-        "Swift.Double",
-        "Swift.String",
-        "Ice.Disp",      // Object
-        "Ice.ObjectPrx", // ObjectPrx
-        "Ice.Value"      // Value
-    };
-
-    BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
-    if (builtin)
-    {
-        return builtinTable[builtin->kind()];
-    }
-
-    InterfaceDeclPtr proxy = dynamic_pointer_cast<InterfaceDecl>(type);
-    if (proxy)
-    {
-        return getAbsoluteImpl(proxy, "", "Prx");
-    }
-
-    ContainedPtr cont = dynamic_pointer_cast<Contained>(type);
-    if (cont)
-    {
-        return getAbsoluteImpl(cont);
-    }
-
-    assert(false);
-    return "???";
-}
-
-string
-SwiftGenerator::getAbsolute(const ClassDeclPtr& cl)
-{
-    return getAbsoluteImpl(cl);
-}
-
-string
-SwiftGenerator::getAbsolute(const ClassDefPtr& cl)
-{
-    return getAbsoluteImpl(cl);
-}
-
-string
-SwiftGenerator::getAbsolute(const InterfaceDeclPtr& prx)
-{
-    return getAbsoluteImpl(prx, "", "Prx");
-}
-
-string
-SwiftGenerator::getAbsolute(const InterfaceDefPtr& interface)
-{
-    return getAbsoluteImpl(interface);
-}
-
-string
-SwiftGenerator::getAbsolute(const StructPtr& st)
-{
-    return getAbsoluteImpl(st);
-}
-
-string
-SwiftGenerator::getAbsolute(const ExceptionPtr& ex)
-{
-    return getAbsoluteImpl(ex);
-}
-
-string
-SwiftGenerator::getAbsolute(const EnumPtr& en)
-{
-    return getAbsoluteImpl(en);
-}
-
-string
-SwiftGenerator::getAbsolute(const ConstPtr& en)
-{
-    return getAbsoluteImpl(en);
-}
-
-string
-SwiftGenerator::getAbsolute(const SequencePtr& en)
-{
-    return getAbsoluteImpl(en);
-}
-
-string
-SwiftGenerator::getAbsolute(const DictionaryPtr& en)
-{
-    return getAbsoluteImpl(en);
-}
+// PUT IT HERE
 
 string
 SwiftGenerator::getUnqualified(const string& type, const string& localModule)
@@ -1589,7 +1488,7 @@ SwiftGenerator::writeMarshalUnmarshalCode(
                     {
                         args += ", type: ";
                     }
-                    args += getUnqualified(getAbsolute(type), swiftModule) + ".self";
+                    args += getUnqualified("Ice.ObjectPrx", swiftModule) + ".self";
 
                     out << nl << param << " = try " << stream << ".read(" << args << ")";
                 }
@@ -1624,7 +1523,7 @@ SwiftGenerator::writeMarshalUnmarshalCode(
         }
         else
         {
-            string memberType = getUnqualified(getAbsolute(type), swiftModule);
+            string memberType = getRelativeTypeString(cl, swiftModule);
             string memberName;
             const string memberPrefix = "self.";
             if (param.find(memberPrefix) == 0)
@@ -1678,7 +1577,7 @@ SwiftGenerator::writeMarshalUnmarshalCode(
                 args += ", type: ";
             }
 
-            args += getUnqualified(getAbsolute(type), swiftModule) + ".self";
+            args += getRelativeTypeString(prx, swiftModule) + ".self";
             out << nl << param << " = try " << stream << ".read(" << args << ")";
         }
         return;
@@ -1714,8 +1613,7 @@ SwiftGenerator::writeMarshalUnmarshalCode(
         }
         else
         {
-            string helper =
-                getUnqualified(getAbsoluteImpl(dynamic_pointer_cast<Contained>(type)), swiftModule) + "Helper";
+            string helper = getRelativeTypeString(seq, swiftModule) + "Helper";
             if (marshal)
             {
                 out << nl << helper << ".write(to: " << stream << ", " << args << ")";
@@ -1733,9 +1631,10 @@ SwiftGenerator::writeMarshalUnmarshalCode(
         return;
     }
 
-    if (dynamic_pointer_cast<Dictionary>(type))
+    DictionaryPtr dict = dynamic_pointer_cast<Dictionary>(type);
+    if (dict)
     {
-        string helper = getUnqualified(getAbsoluteImpl(dynamic_pointer_cast<Contained>(type)), swiftModule) + "Helper";
+        string helper = getRelativeTypeString(dict, swiftModule) + "Helper";
         if (marshal)
         {
             out << nl << helper << ".write(to: " << stream << ", " << args << ")";
@@ -2324,7 +2223,7 @@ SwiftGenerator::writeUnmarshalUserException(::IceInternal::Output& out, const Op
     out << eb;
     for (ExceptionList::const_iterator q = throws.begin(); q != throws.end(); ++q)
     {
-        out << " catch let error as " << getUnqualified(getAbsolute(*q), swiftModule) << sb;
+        out << " catch let error as " << getRelativeTypeString(*q, swiftModule) << sb;
         out << nl << "throw error";
         out << eb;
     }

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -1127,8 +1127,6 @@ SwiftGenerator::typeToString(
     return t;
 }
 
-// PUT IT HERE
-
 string
 SwiftGenerator::getUnqualified(const string& type, const string& localModule)
 {

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -90,24 +90,18 @@ namespace Slice
 
         std::string typeToString(const TypePtr&, const ContainedPtr&, const StringList& = StringList(), bool = false);
 
-        std::string getAbsolute(const TypePtr&);
-        std::string getAbsolute(const ClassDeclPtr&);
-        std::string getAbsolute(const ClassDefPtr&);
-        std::string getAbsolute(const InterfaceDeclPtr&);
-        std::string getAbsolute(const InterfaceDefPtr&);
-        std::string getAbsolute(const StructPtr&);
-        std::string getAbsolute(const ExceptionPtr&);
-        std::string getAbsolute(const EnumPtr&);
-        std::string getAbsolute(const ConstPtr&);
-        std::string getAbsolute(const SequencePtr&);
-        std::string getAbsolute(const DictionaryPtr&);
-
         std::string getUnqualified(const std::string&, const std::string&);
         std::string modeToString(Operation::Mode);
         std::string getOptionalFormat(const TypePtr&);
 
         static bool isNullableType(const TypePtr&);
         bool isProxyType(const TypePtr&);
+
+        /// Returns a string representing the Swift type `contained` maps to.
+        ///
+        /// If `currentModule` is _not_ provided, the type-string is fully qualified.
+        /// Otherwise, the type-string is qualified relative to `currentModule`.
+        std::string getRelativeTypeString(const ContainedPtr& contained, const std::string& currentModule = "");
 
         std::string getValue(const std::string&, const TypePtr&);
         void writeConstantValue(


### PR DESCRIPTION
This PR untangles some `slice2swift` code for emitting mapped identifiers,
in preparation for fixing #1617 (just so it's easier to follow). There should be truly 0 change to the logic.

1) We had 2 functions which were always called together: `getUnqualified(getAbsolute(p))`.
Instead of the caller needing to call both (and possibly forgetting), they're now a single function: `getRelativeTypeString`

2) `getAbsolute` had a complicated call heirarchy, where it's implemented once per type, and those would sometimes forward to other versions, eventually ending in a `getAbsoluteImpl`. All of this now lives in the single function `getRelativeTypeString`.

3) `getAbsolute` has fields for providing prefixes and suffixes. The prefix was never specified, and the suffix was only `Prx`.
I removed both. The new function adds `Prx` when the type is a proxy.