### PR TITLE
Improve SSL error messages

### DIFF
--- a/csharp/src/Ice/SSL/SSLEngine.cs
+++ b/csharp/src/Ice/SSL/SSLEngine.cs
@@ -154,8 +154,6 @@ internal class SSLEngine
 
     internal X509Certificate2Collection caCerts() => _caCerts;
 
-    internal bool getCheckCertName() => _checkCertName;
-
     internal Ice.Communicator communicator() => _communicator;
 
     internal int securityTraceLevel() => _securityTraceLevel;
@@ -252,6 +250,7 @@ internal class SSLEngine
         {
             authenticationOptions.CertificateChainPolicy.VerificationFlags |= X509VerificationFlags.IgnoreInvalidName;
         }
+
         if (_checkCRL == 1)
         {
             authenticationOptions.CertificateChainPolicy.VerificationFlags |= X509VerificationFlags.IgnoreCertificateAuthorityRevocationUnknown;

--- a/csharp/src/Ice/SSL/TransceiverI.cs
+++ b/csharp/src/Ice/SSL/TransceiverI.cs
@@ -398,10 +398,10 @@ internal sealed class TransceiverI : Ice.Internal.Transceiver
         catch (AuthenticationException ex)
         {
             throw new SecurityException(
-                _errorDescription.Length == 0 ? "SSL authentication failure" : _errorDescription,
+                _errorDescription.Length == 0 ? "SSL authentication failure." : _errorDescription,
                 ex);
         }
-        catch (Exception ex)
+        catch (System.Exception ex)
         {
             throw new Ice.SyscallException(ex);
         }
@@ -460,18 +460,18 @@ internal sealed class TransceiverI : Ice.Internal.Transceiver
         Ice.Logger logger = _instance.logger();
         string message = "";
 
-        if (_incoming && (errors & (int)SslPolicyErrors.RemoteCertificateNotAvailable) > 0 && _verifyPeer <= 1)
+        if (_incoming && (errors & (int)SslPolicyErrors.RemoteCertificateNotAvailable) != 0 && _verifyPeer <= 1)
         {
             // The client certificate is optional when IceSSL.VerifyPeer = 1, and not required when IceSSL.VerifyPeer = 0
             errors ^= (int)SslPolicyErrors.RemoteCertificateNotAvailable;
         }
 
-        if ((errors & (int)SslPolicyErrors.RemoteCertificateNameMismatch) > 0)
+        if ((errors & (int)SslPolicyErrors.RemoteCertificateNameMismatch) != 0)
         {
             message += ": Remote certificate name mismatch";
         }
 
-        if ((errors & (int)SslPolicyErrors.RemoteCertificateNotAvailable) > 0)
+        if ((errors & (int)SslPolicyErrors.RemoteCertificateNotAvailable) != 0)
         {
             message += ": Remote certificate not available";
         }
@@ -483,7 +483,7 @@ internal sealed class TransceiverI : Ice.Internal.Transceiver
 
         if (errors != 0)
         {
-            _errorDescription = message.Length > 0 ? $"SSL authentication failure{message}" : "SSL authentication failure";
+            _errorDescription = message.Length > 0 ? $"SSL authentication failure{message}." : "SSL authentication failure.";
             if (traceLevel >= 1)
             {
                 logger.trace(traceCategory, _errorDescription);


### PR DESCRIPTION
Fix #2815

With this fix, check cert name error would result in this exception.

```
Ice.SecurityException: SSL authentication failure: Remote certificate name mismatch
 ---> System.Security.Authentication.AuthenticationException: The remote certificate was rejected by the provided RemoteCertificateValidationCallback.
   at Ice.SSL.TransceiverI.finishAuthenticate() in /Users/jose/Documents/3.8/ice/csharp/src/Ice/SSL/TransceiverI.cs:line 427
   --- End of inner exception stack trace ---
   at Ice.ObjectPrxHelperBase.ice_ping(Dictionary`2 context) in /Users/jose/Documents/3.8/ice/csharp/src/Ice/Proxy.cs:line 648
   at AllTests.allTests(TestHelper helper, String testDir) in /Users/jose/Documents/3.8/ice/csharp/test/IceSSL/configuration/AllTests.cs:line 518
```