### PR TITLE
Fix Logic for Escaping Swift Keywords

### DIFF
--- a/swift/test/Slice/escape/Key.ice
+++ b/swift/test/Slice/escape/Key.ice
@@ -55,14 +55,12 @@ exception as extends return
     int static; int switch;
 }
 
-/* TODO: reenable when #1617 is fixed
 interface friend
 {
-    guard goto(continue if, guard d, defer inline, switch private, do mutable, break* namespace,
-              func* new, switch* not, do* operator, int or, int protected, int public, int register)
+    guard goto(continue if, guard d, defer inline, switch private, do* mutable, break* namespace,
+               func* new, switch not, do* operator, int or, int protected, int public, int register)
         throws return, as;
 }
-*/
 
 const int is = 0;
 const int self = 0;


### PR DESCRIPTION
This PR fixes the Swift escaping bugs alluded to in #1617.

There were a two separate problems:
1) There were two places where we forgot to call the escaping function completely
2) The function that performs the escaping assumed that it was being passed Slice identifiers (`Foo::Bar`), when actually, we were always passing in Swift identifiers (`Foo.Bar`). This caused it to never escape scoped identifiers.