### PR TITLE
Update Javascript to not use 'CICompare' for Keyword Escaping

### DIFF
--- a/cpp/src/slice2js/JsUtil.cpp
+++ b/cpp/src/slice2js/JsUtil.cpp
@@ -93,11 +93,7 @@ lookupKwd(const string& name)
         "interface", "let",    "new",      "null",   "package",    "private", "protected", "public",
         "return",    "static", "super",    "switch", "this",       "throw",   "true",      "try",
         "typeof",    "var",    "void",     "while",  "with",       "yield"};
-    bool found = binary_search(
-        &keywordList[0],
-        &keywordList[sizeof(keywordList) / sizeof(*keywordList)],
-        name,
-        Slice::CICompare());
+    bool found = binary_search(&keywordList[0], &keywordList[sizeof(keywordList) / sizeof(*keywordList)], name);
     if (found)
     {
         return "_" + name;

--- a/js/test/Slice/macros/Client.ts
+++ b/js/test/Slice/macros/Client.ts
@@ -13,7 +13,7 @@ export class Client extends TestHelper {
         const out = this.getWriter();
         out.write("testing Slice predefined macros... ");
 
-        const d = new Test._Default();
+        const d = new Test.Default();
         test(d.x == 10);
         test(d.y == 10);
 


### PR DESCRIPTION
Originally, this PR was going to finish updating the keyword lists for JavaScript, MATLAB, and Ruby... but it turned out that those keyword lists were already up to date*.

So instead I removed the last place where we were using `CICompare` in the code generators (we still use it internally in the parser).

----

\* Interestingly it looks like Ruby actually _removed_ some keywords... but I just left the list alone to play it safe.