### PR TITLE
Use equals to compare endpoint objects in Java

### DIFF
--- a/java-compat/src/Ice/src/main/java/IceInternal/OutgoingConnectionFactory.java
+++ b/java-compat/src/Ice/src/main/java/IceInternal/OutgoingConnectionFactory.java
@@ -265,7 +265,7 @@ public final class OutgoingConnectionFactory
                 {
                     for(Ice.ConnectionI connection : connectionList)
                     {
-                        if(connection.endpoint() == endpoint)
+                        if(connection.endpoint().equals(endpoints))
                         {
                             connection.setAdapter(adapter);
                         }

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/OutgoingConnectionFactory.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/OutgoingConnectionFactory.java
@@ -273,7 +273,7 @@ public final class OutgoingConnectionFactory
                 {
                     for(ConnectionI connection : connectionList)
                     {
-                        if(connection.endpoint() == endpoint)
+                        if(connection.endpoint().equals(endpoint))
                         {
                             connection.setAdapter(adapter);
                         }


### PR DESCRIPTION
fix #2823