### PR TITLE
Change return type of getSocketErrno on Windows

### DIFF
--- a/cpp/include/Ice/LocalExceptions.h
+++ b/cpp/include/Ice/LocalExceptions.h
@@ -481,7 +481,7 @@ namespace Ice
         SocketException(const char* file, int line, std::string messagePrefix, ErrorCode error);
 
         /**
-         * Constructs a SocketException without a generic message.
+         * Constructs a SocketException with a generic message.
          * @param file The file where this exception is constructed. This C string is not copied.
          * @param line The line where this exception is constructed.
          * @param error The error code.

--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -1624,11 +1624,12 @@ IceInternal::getNumericAddress(const std::string& address)
     }
 }
 
-int
+SyscallException::ErrorCode
 IceInternal::getSocketErrno()
 {
 #if defined(_WIN32)
-    return WSAGetLastError();
+    // We standardize on DWORD aka unsigned long for all system error codes on Windows.
+    return static_cast<SyscallException::ErrorCode>(WSAGetLastError());
 #else
     return errno;
 #endif
@@ -2174,7 +2175,7 @@ IceInternal::getHostName()
     char name[256];
     if (gethostname(name, sizeof(name)) != 0)
     {
-        throw SocketException(__FILE__, __LINE__, getSocketErrno());
+        throw SocketException{__FILE__, __LINE__, getSocketErrno()};
     }
     return name;
 }

--- a/cpp/src/Ice/Network.h
+++ b/cpp/src/Ice/Network.h
@@ -250,7 +250,7 @@ namespace IceInternal
 
     ICE_API void createPipe(SOCKET fds[2]);
 
-    ICE_API int getSocketErrno();
+    ICE_API Ice::SyscallException::ErrorCode getSocketErrno();
 
     ICE_API Address getNumericAddress(const std::string&);
 


### PR DESCRIPTION
It used to be an int, it's now a DWORD = unsigned long.