### PR TITLE
Remove Unused List Types from the Slice Compiler

### DIFF
--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -2178,9 +2178,7 @@ yyreduce:
 {
     auto type = dynamic_pointer_cast<Type>(yyvsp[-1]);
     auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
-    auto typestring = make_shared<TypeStringTok>();
-    typestring->v = make_pair(type, ident->v);
-    yyval = typestring;
+    yylval = make_shared<TypeStringTok>(type, ident->v);
 }
 #line 2186 "src/Slice/Grammar.cpp"
     break;
@@ -2312,8 +2310,8 @@ yyreduce:
 {
     auto m = dynamic_pointer_cast<OptionalDefTok>(yyvsp[-1]);
     auto ts = dynamic_pointer_cast<TypeStringTok>(yyvsp[0]);
-    m->type = ts->v.first;
-    m->name = ts->v.second;
+    m->type = ts->type;
+    m->name = ts->name;
 
     // It's safe to perform this check in the parser, since we already have enough information to know whether a type
     // can be optional. This is because the only types that can be forward declared (classes/interfaces) have constant
@@ -2333,8 +2331,8 @@ yyreduce:
 {
     auto ts = dynamic_pointer_cast<TypeStringTok>(yyvsp[0]);
     auto m = make_shared<OptionalDefTok>(-1);
-    m->type = ts->v.first;
-    m->name = ts->v.second;
+    m->type = ts->type;
+    m->name = ts->name;
     yyval = m;
 }
 #line 2341 "src/Slice/Grammar.cpp"

--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -2178,7 +2178,7 @@ yyreduce:
 {
     auto type = dynamic_pointer_cast<Type>(yyvsp[-1]);
     auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
-    yylval = make_shared<TypeStringTok>(type, ident->v);
+    yyval = make_shared<TypeStringTok>(type, ident->v);
 }
 #line 2186 "src/Slice/Grammar.cpp"
     break;

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -533,9 +533,7 @@ type_id
 {
     auto type = dynamic_pointer_cast<Type>($1);
     auto ident = dynamic_pointer_cast<StringTok>($2);
-    auto typestring = make_shared<TypeStringTok>();
-    typestring->v = make_pair(type, ident->v);
-    $$ = typestring;
+    $$ = make_shared<TypeStringTok>(type, ident->v);
 }
 ;
 
@@ -657,8 +655,8 @@ optional_type_id
 {
     auto m = dynamic_pointer_cast<OptionalDefTok>($1);
     auto ts = dynamic_pointer_cast<TypeStringTok>($2);
-    m->type = ts->v.first;
-    m->name = ts->v.second;
+    m->type = ts->type;
+    m->name = ts->name;
 
     // It's safe to perform this check in the parser, since we already have enough information to know whether a type
     // can be optional. This is because the only types that can be forward declared (classes/interfaces) have constant
@@ -674,8 +672,8 @@ optional_type_id
 {
     auto ts = dynamic_pointer_cast<TypeStringTok>($1);
     auto m = make_shared<OptionalDefTok>(-1);
-    m->type = ts->v.first;
-    m->name = ts->v.second;
+    m->type = ts->type;
+    m->name = ts->name;
     $$ = m;
 }
 ;

--- a/cpp/src/Slice/GrammarUtil.h
+++ b/cpp/src/Slice/GrammarUtil.h
@@ -25,8 +25,9 @@ namespace Slice
 
     struct TypeStringTok final : public GrammarBase
     {
-        TypeStringTok() {}
-        TypeString v;
+        TypeStringTok(TypePtr type, std::string name) : type(type), name(name) {}
+        TypePtr type;
+        std::string name;
     };
 
     struct IntegerTok final : public GrammarBase

--- a/cpp/src/Slice/GrammarUtil.h
+++ b/cpp/src/Slice/GrammarUtil.h
@@ -8,6 +8,14 @@
 #include <cassert>
 #include <memory>
 
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wshadow"
+#endif
+
 namespace Slice
 {
     struct StringTok final : public GrammarBase
@@ -109,5 +117,11 @@ namespace Slice
     using FloatingTokPtr = std::shared_ptr<FloatingTok>;
     using ConstDefTokPtr = std::shared_ptr<ConstDefTok>;
 }
+
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1898,51 +1898,6 @@ Slice::Container::exceptions() const
     return result;
 }
 
-StructList
-Slice::Container::structs() const
-{
-    StructList result;
-    for (const auto& p : _contents)
-    {
-        StructPtr q = dynamic_pointer_cast<Struct>(p);
-        if (q)
-        {
-            result.push_back(q);
-        }
-    }
-    return result;
-}
-
-SequenceList
-Slice::Container::sequences() const
-{
-    SequenceList result;
-    for (const auto& p : _contents)
-    {
-        SequencePtr q = dynamic_pointer_cast<Sequence>(p);
-        if (q)
-        {
-            result.push_back(q);
-        }
-    }
-    return result;
-}
-
-DictionaryList
-Slice::Container::dictionaries() const
-{
-    DictionaryList result;
-    for (const auto& p : _contents)
-    {
-        DictionaryPtr q = dynamic_pointer_cast<Dictionary>(p);
-        if (q)
-        {
-            result.push_back(q);
-        }
-    }
-    return result;
-}
-
 EnumList
 Slice::Container::enums() const
 {
@@ -2025,21 +1980,6 @@ Slice::Container::enumerators(const string& identifier) const
         }
     }
 
-    return result;
-}
-
-ConstList
-Slice::Container::consts() const
-{
-    ConstList result;
-    for (const auto& p : _contents)
-    {
-        ConstPtr q = dynamic_pointer_cast<Const>(p);
-        if (q)
-        {
-            result.push_back(q);
-        }
-    }
     return result;
 }
 

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -92,20 +92,13 @@ namespace Slice
     bool containedEqual(const ContainedPtr& lhs, const ContainedPtr& rhs);
 
     using TypeList = std::list<TypePtr>;
-    using StringSet = std::set<std::string>;
     using StringList = std::list<std::string>;
-    using TypeString = std::pair<TypePtr, std::string>;
-    using TypeStringList = std::list<TypeString>;
     using ContainedList = std::list<ContainedPtr>;
     using ModuleList = std::list<ModulePtr>;
     using ClassList = std::list<ClassDefPtr>;
     using InterfaceList = std::list<InterfaceDefPtr>;
     using ExceptionList = std::list<ExceptionPtr>;
-    using StructList = std::list<StructPtr>;
-    using SequenceList = std::list<SequencePtr>;
-    using DictionaryList = std::list<DictionaryPtr>;
     using EnumList = std::list<EnumPtr>;
-    using ConstList = std::list<ConstPtr>;
     using OperationList = std::list<OperationPtr>;
     using DataMemberList = std::list<DataMemberPtr>;
     using ParamDeclList = std::list<ParamDeclPtr>;
@@ -432,13 +425,9 @@ namespace Slice
         ClassList classes() const;
         InterfaceList interfaces() const;
         ExceptionList exceptions() const;
-        StructList structs() const;
-        SequenceList sequences() const;
-        DictionaryList dictionaries() const;
         EnumList enums() const;
         EnumeratorList enumerators() const;
         EnumeratorList enumerators(const std::string& identifier) const;
-        ConstList consts() const;
         ContainedList contents() const;
         std::string thisScope() const;
         void visit(ParserVisitor* visitor) override;

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2318,10 +2318,9 @@ namespace
             }
         }
 
-        ModuleList modules = p->modules();
-        for (ModuleList::const_iterator i = modules.begin(); i != modules.end(); ++i)
+        for (const auto& module : p->modules())
         {
-            if (hasResultType(*i))
+            if (hasResultType(module))
             {
                 return true;
             }

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -880,7 +880,7 @@ CodeVisitor::visitEnum(const EnumPtr& p)
     string name = getName(p);
     string type = getTypeVar(p);
     string abs = getAbsolute(p);
-    EnumeratorList enums = p->enumerators();
+    EnumeratorList enumerators = p->enumerators();
 
     startNamespace(p);
 
@@ -889,10 +889,9 @@ CodeVisitor::visitEnum(const EnumPtr& p)
     _out << sb;
 
     {
-        long i = 0;
-        for (EnumeratorList::iterator q = enums.begin(); q != enums.end(); ++q, ++i)
+        for (const auto& enumerator : enumerators)
         {
-            _out << nl << "const " << fixIdent((*q)->name()) << " = " << (*q)->value() << ';';
+            _out << nl << "const " << fixIdent(enumerator->name()) << " = " << enumerator->value() << ';';
         }
     }
 
@@ -900,9 +899,9 @@ CodeVisitor::visitEnum(const EnumPtr& p)
 
     // Emit the type information.
     _out << sp << nl << type << " = IcePHP_defineEnum('" << scoped << "', array(";
-    for (EnumeratorList::iterator q = enums.begin(); q != enums.end(); ++q)
+    for (EnumeratorList::iterator q = enumerators.begin(); q != enumerators.end(); ++q)
     {
-        if (q != enums.begin())
+        if (q != enumerators.begin())
         {
             _out << ", ";
         }
@@ -1077,8 +1076,8 @@ CodeVisitor::writeDefaultValue(const DataMemberPtr& m)
     EnumPtr en = dynamic_pointer_cast<Enum>(p);
     if (en)
     {
-        EnumeratorList enums = en->enumerators();
-        _out << getAbsolute(en) << "::" << fixIdent(enums.front()->name());
+        string firstEnumerator = en->enumerators().front()->name();
+        _out << getAbsolute(en) << "::" << fixIdent(firstEnumerator);
         return;
     }
 

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -888,18 +888,16 @@ CodeVisitor::visitEnum(const EnumPtr& p)
     _out << nl << "class " << name;
     _out << sb;
 
+    for (const auto& enumerator : enumerators)
     {
-        for (const auto& enumerator : enumerators)
-        {
-            _out << nl << "const " << fixIdent(enumerator->name()) << " = " << enumerator->value() << ';';
-        }
+        _out << nl << "const " << fixIdent(enumerator->name()) << " = " << enumerator->value() << ';';
     }
 
     _out << eb;
 
     // Emit the type information.
     _out << sp << nl << type << " = IcePHP_defineEnum('" << scoped << "', array(";
-    for (EnumeratorList::iterator q = enumerators.begin(); q != enumerators.end(); ++q)
+    for (EnumeratorList::const_iterator q = enumerators.begin(); q != enumerators.end(); ++q)
     {
         if (q != enumerators.begin())
         {

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1639,7 +1639,7 @@ Slice::Python::CodeVisitor::visitEnum(const EnumPtr& p)
              << enumerator->value() << ')';
     }
     _out << nl << name << "._enumerators = { ";
-    for (EnumeratorList::iterator q = enumerators.begin(); q != enumerators.end(); ++q)
+    for (EnumeratorList::const_iterator q = enumerators.begin(); q != enumerators.end(); ++q)
     {
         if (q != enumerators.begin())
         {

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -940,7 +940,7 @@ Slice::Ruby::CodeVisitor::visitEnum(const EnumPtr& p)
 {
     string scoped = p->scoped();
     string name = fixIdent(p->name(), IdentToUpper);
-    EnumeratorList enums = p->enumerators();
+    EnumeratorList enumerators = p->enumerators();
 
     _out << sp << nl << "if not defined?(" << getAbsolute(p, IdentToUpper) << ')';
     _out.inc();
@@ -960,7 +960,7 @@ Slice::Ruby::CodeVisitor::visitEnum(const EnumPtr& p)
     {
         _out << sp << nl << "def " << name << ".from_int(val)";
         ostringstream sz;
-        sz << enums.size() - 1;
+        sz << enumerators.size() - 1;
         _out.inc();
         _out << nl << "@@_enumerators[val]"; // Evaluates to nil if the key is not found
         _out.dec();
@@ -1018,7 +1018,7 @@ Slice::Ruby::CodeVisitor::visitEnum(const EnumPtr& p)
     //
     _out << sp;
     int i = 0;
-    for (EnumeratorList::iterator q = enums.begin(); q != enums.end(); ++q, ++i)
+    for (EnumeratorList::iterator q = enumerators.begin(); q != enumerators.end(); ++q, ++i)
     {
         ostringstream idx;
         idx << i;
@@ -1027,9 +1027,9 @@ Slice::Ruby::CodeVisitor::visitEnum(const EnumPtr& p)
     }
 
     _out << sp << nl << "@@_enumerators = {";
-    for (EnumeratorList::iterator q = enums.begin(); q != enums.end(); ++q)
+    for (EnumeratorList::iterator q = enumerators.begin(); q != enumerators.end(); ++q)
     {
-        if (q != enums.begin())
+        if (q != enumerators.begin())
         {
             _out << ", ";
         }
@@ -1184,8 +1184,8 @@ Slice::Ruby::CodeVisitor::getInitializer(const DataMemberPtr& m)
     EnumPtr en = dynamic_pointer_cast<Enum>(p);
     if (en)
     {
-        EnumeratorList enums = en->enumerators();
-        return getAbsolute(en, IdentToUpper) + "::" + fixIdent(enums.front()->name(), IdentToUpper);
+        string firstEnumerator = en->enumerators().front()->name();
+        return getAbsolute(en, IdentToUpper) + "::" + fixIdent(firstEnumerator, IdentToUpper);
     }
 
     StructPtr st = dynamic_pointer_cast<Struct>(p);

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -1018,7 +1018,7 @@ Slice::Ruby::CodeVisitor::visitEnum(const EnumPtr& p)
     //
     _out << sp;
     int i = 0;
-    for (EnumeratorList::iterator q = enumerators.begin(); q != enumerators.end(); ++q, ++i)
+    for (EnumeratorList::const_iterator q = enumerators.begin(); q != enumerators.end(); ++q, ++i)
     {
         ostringstream idx;
         idx << i;
@@ -1027,7 +1027,7 @@ Slice::Ruby::CodeVisitor::visitEnum(const EnumPtr& p)
     }
 
     _out << sp << nl << "@@_enumerators = {";
-    for (EnumeratorList::iterator q = enumerators.begin(); q != enumerators.end(); ++q)
+    for (EnumeratorList::const_iterator q = enumerators.begin(); q != enumerators.end(); ++q)
     {
         if (q != enumerators.begin())
         {


### PR DESCRIPTION
This is just a cleanup PR which:
- Removes some unused type-aliases we defined (for sets and lists)
- Removes the uncalled functions which returned them
- Updates some `for` loops to be `ranged-for` loops
- We used the identifier `enums` to refer to lists of enums and lists of enumerators...
   I fixed the enumerator lists to be called `enumerators`.