### PR TITLE
Switch 'findMetadata' to Return an 'optional'

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -136,7 +136,7 @@ Slice::DefinitionContext::setSeenDefinition()
 bool
 Slice::DefinitionContext::hasMetadata(const string& directive) const
 {
-    return findMetadata(directive) == directive;
+    return findMetadata(directive).has_value();
 }
 
 void
@@ -146,7 +146,7 @@ Slice::DefinitionContext::setMetadata(const StringList& metadata)
     initSuppressedWarnings();
 }
 
-string
+optional<string>
 Slice::DefinitionContext::findMetadata(const string& prefix) const
 {
     for (const auto& p : _metadata)
@@ -156,7 +156,7 @@ Slice::DefinitionContext::findMetadata(const string& prefix) const
             return p;
         }
     }
-    return string();
+    return nullopt;
 }
 
 StringList
@@ -186,39 +186,42 @@ Slice::DefinitionContext::initSuppressedWarnings()
 {
     _suppressedWarnings.clear();
     const string prefix = "suppress-warning";
-    string value = findMetadata(prefix);
-    if (value == prefix)
+    if (auto meta = findMetadata(prefix))
     {
-        _suppressedWarnings.insert(All);
-    }
-    else if (!value.empty())
-    {
-        assert(value.length() > prefix.length());
-        if (value[prefix.length()] == ':')
+        string value = *meta;
+        if (value == prefix)
         {
-            value = value.substr(prefix.length() + 1);
-            vector<string> result;
-            IceInternal::splitString(value, ",", result);
-            for (const auto& p : result)
+            _suppressedWarnings.insert(All);
+        }
+        else
+        {
+            assert(value.length() > prefix.length());
+            if (value[prefix.length()] == ':')
             {
-                string s = IceInternal::trim(p);
-                if (s == "all")
+                value = value.substr(prefix.length() + 1);
+                vector<string> result;
+                IceInternal::splitString(value, ",", result);
+                for (const auto& p : result)
                 {
-                    _suppressedWarnings.insert(All);
-                }
-                else if (s == "deprecated")
-                {
-                    _suppressedWarnings.insert(Deprecated);
-                }
-                else if (s == "invalid-metadata")
-                {
-                    _suppressedWarnings.insert(InvalidMetadata);
-                }
-                else
-                {
-                    ostringstream os;
-                    os << "invalid category `" << s << "' in file metadata suppress-warning";
-                    warning(InvalidMetadata, "", -1, os.str());
+                    string s = IceInternal::trim(p);
+                    if (s == "all")
+                    {
+                        _suppressedWarnings.insert(All);
+                    }
+                    else if (s == "deprecated")
+                    {
+                        _suppressedWarnings.insert(Deprecated);
+                    }
+                    else if (s == "invalid-metadata")
+                    {
+                        _suppressedWarnings.insert(InvalidMetadata);
+                    }
+                    else
+                    {
+                        ostringstream os;
+                        os << "invalid category `" << s << "' in file metadata suppress-warning";
+                        warning(InvalidMetadata, "", -1, os.str());
+                    }
                 }
             }
         }
@@ -881,38 +884,36 @@ Slice::Contained::includeLevel() const
 bool
 Slice::Contained::hasMetadata(const string& directive) const
 {
-    return find(_metadata.begin(), _metadata.end(), directive) != _metadata.end();
+    return findMetadata(directive).has_value();
 }
 
-bool
-Slice::Contained::findMetadata(const string& prefix, string& output) const
+optional<string>
+Slice::Contained::findMetadata(const string& prefix) const
 {
     for (const auto& p : _metadata)
     {
         if (p.find(prefix) == 0)
         {
-            output = p;
-            return true;
+            return p;
         }
     }
-
-    return false;
+    return nullopt;
 }
 
-list<string>
+StringList
 Slice::Contained::getMetadata() const
 {
     return _metadata;
 }
 
 void
-Slice::Contained::setMetadata(const list<string>& metadata)
+Slice::Contained::setMetadata(const StringList& metadata)
 {
     _metadata = metadata;
 }
 
 std::optional<FormatType>
-Slice::Contained::parseFormatMetadata(const list<string>& metadata)
+Slice::Contained::parseFormatMetadata(const StringList& metadata)
 {
     std::optional<FormatType> result;
 
@@ -952,31 +953,40 @@ Slice::Contained::isDeprecated(bool checkParent) const
 {
     const string prefix1 = "deprecate";
     const string prefix2 = "deprecated";
-    string metadata;
     ContainedPtr parent = checkParent ? dynamic_pointer_cast<Contained>(_container) : nullptr;
 
-    return (findMetadata(prefix1, metadata) || (parent && parent->findMetadata(prefix1, metadata))) ||
-           (findMetadata(prefix2, metadata) || (parent && parent->findMetadata(prefix2, metadata)));
+    return (hasMetadata(prefix1) || (parent && parent->hasMetadata(prefix1))) ||
+           (hasMetadata(prefix2) || (parent && parent->hasMetadata(prefix2)));
 }
 
 optional<string>
 Slice::Contained::getDeprecationReason(bool checkParent) const
 {
-    string metadata;
-    ContainedPtr parent = checkParent ? dynamic_pointer_cast<Contained>(_container) : nullptr;
-
     const string prefix1 = "deprecate:";
-    if (findMetadata(prefix1, metadata) || (parent && parent->findMetadata(prefix1, metadata)))
+    const string prefix2 = "deprecated:";
+
+    // First, we check if the element itself is deprecated.
+    if (auto meta = findMetadata(prefix1))
     {
-        assert(metadata.find(prefix1) == 0);
-        return metadata.substr(prefix1.size());
+        return (*meta).substr(prefix1.size());
+    }
+    if (auto meta = findMetadata(prefix2))
+    {
+        return (*meta).substr(prefix2.size());
     }
 
-    const string prefix2 = "deprecated:";
-    if (findMetadata(prefix2, metadata) || (parent && parent->findMetadata(prefix2, metadata)))
+    // Then, if necessary, we check if the container it's within is deprecated.
+    ContainedPtr parent = checkParent ? dynamic_pointer_cast<Contained>(_container) : nullptr;
+    if (checkParent && parent)
     {
-        assert(metadata.find(prefix2) == 0);
-        return metadata.substr(prefix2.size());
+        if (auto meta = parent->findMetadata(prefix1))
+        {
+            return (*meta).substr(prefix1.size());
+        }
+        if (auto meta = parent->findMetadata(prefix2))
+        {
+            return (*meta).substr(prefix2.size());
+        }
     }
 
     return nullopt;

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -968,11 +968,11 @@ Slice::Contained::getDeprecationReason(bool checkParent) const
     // First, we check if the element itself is deprecated.
     if (auto meta = findMetadata(prefix1))
     {
-        return (*meta).substr(prefix1.size());
+        return meta->substr(prefix1.size());
     }
     if (auto meta = findMetadata(prefix2))
     {
-        return (*meta).substr(prefix2.size());
+        return meta->substr(prefix2.size());
     }
 
     // Then, if necessary, we check if the container it's within is deprecated.
@@ -981,11 +981,11 @@ Slice::Contained::getDeprecationReason(bool checkParent) const
     {
         if (auto meta = parent->findMetadata(prefix1))
         {
-            return (*meta).substr(prefix1.size());
+            return meta->substr(prefix1.size());
         }
         if (auto meta = parent->findMetadata(prefix2))
         {
-            return (*meta).substr(prefix2.size());
+            return meta->substr(prefix2.size());
         }
     }
 

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -176,7 +176,7 @@ namespace Slice
 
         bool hasMetadata(const std::string& directive) const;
         void setMetadata(const StringList& metadata);
-        std::string findMetadata(const std::string& prefix) const;
+        std::optional<std::string> findMetadata(const std::string& prefix) const;
         StringList getMetadata() const;
 
         /// Emits a warning unless it should be filtered out by a [["suppress-warning"]].
@@ -347,11 +347,11 @@ namespace Slice
         int includeLevel() const;
 
         bool hasMetadata(const std::string& directive) const;
-        bool findMetadata(const std::string& prefix, std::string& output) const;
-        std::list<std::string> getMetadata() const;
-        void setMetadata(const std::list<std::string>& metadata);
+        std::optional<std::string> findMetadata(const std::string& prefix) const;
+        StringList getMetadata() const;
+        void setMetadata(const StringList& metadata);
 
-        static std::optional<FormatType> parseFormatMetadata(const std::list<std::string>& metadata);
+        static std::optional<FormatType> parseFormatMetadata(const StringList& metadata);
 
         /// Returns true if this item is deprecated (due to the presence of 'deprecated' metadata).
         /// @param checkParent If true, this item's immediate container will also be checked for 'deprecated' metadata.

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -108,11 +108,10 @@ namespace
 
         static const string prefix = "cs:namespace:";
 
-        string q;
-        if (m->findMetadata(prefix, q))
+        if (auto meta = m->findMetadata(prefix))
         {
             hasCSharpNamespaceAttribute = true;
-            return q.substr(prefix.size()) + "." + csharpNamespace;
+            return (*meta).substr(prefix.size()) + "." + csharpNamespace;
         }
         else
         {

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -111,7 +111,7 @@ namespace
         if (auto meta = m->findMetadata(prefix))
         {
             hasCSharpNamespaceAttribute = true;
-            return (*meta).substr(prefix.size()) + "." + csharpNamespace;
+            return meta->substr(prefix.size()) + "." + csharpNamespace;
         }
         else
         {

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -784,15 +784,15 @@ Slice::writeAllocateCode(
     const string& clScope,
     TypeContext typeCtx)
 {
-    for (ParamDeclList::const_iterator p = params.begin(); p != params.end(); ++p)
+    for (const auto& param : params)
     {
         writeParamAllocateCode(
             out,
-            (*p)->type(),
-            (*p)->optional(),
+            param->type(),
+            param->optional(),
             clScope,
-            fixKwd(paramPrefix + (*p)->name()),
-            (*p)->getMetadata(),
+            fixKwd(paramPrefix + param->name()),
+            param->getMetadata(),
             typeCtx);
     }
 
@@ -973,32 +973,6 @@ Slice::writeIceTuple(::IceInternal::Output& out, DataMemberList dataMembers, Typ
         out << fixKwd((*pi)->name());
     }
     out << ");" << eb;
-}
-
-bool
-Slice::findMetadata(const string& prefix, const ClassDeclPtr& cl, string& value)
-{
-    if (findMetadata(prefix, cl->getMetadata(), value))
-    {
-        return true;
-    }
-
-    ClassDefPtr def = cl->definition();
-    return def ? findMetadata(prefix, def->getMetadata(), value) : false;
-}
-
-bool
-Slice::findMetadata(const string& prefix, const StringList& metadata, string& value)
-{
-    for (const auto& s : metadata)
-    {
-        if (s.find(prefix) == 0)
-        {
-            value = s.substr(prefix.size());
-            return true;
-        }
-    }
-    return false;
 }
 
 string

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -70,8 +70,6 @@ namespace Slice
     void writeStreamHelpers(::IceInternal::Output&, const ContainedPtr&, DataMemberList, bool);
     void writeIceTuple(::IceInternal::Output&, DataMemberList, TypeContext);
 
-    bool findMetadata(const std::string&, const ClassDeclPtr&, std::string&);
-    bool findMetadata(const std::string&, const StringList&, std::string&);
     std::string findMetadata(const StringList&, TypeContext = TypeContext::None);
     bool inWstringModule(const SequencePtr&);
 }

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -407,10 +407,9 @@ namespace
             static const string prefix = "cpp:doxygen:include:";
             DefinitionContextPtr dc = unt->findDefinitionContext(file);
             assert(dc);
-            string q = dc->findMetadata(prefix);
-            if (!q.empty())
+            if (auto meta = dc->findMetadata(prefix))
             {
-                out << nl << " * \\headerfile " << q.substr(prefix.size());
+                out << nl << " * \\headerfile " << (*meta).substr(prefix.size());
             }
         }
 
@@ -662,10 +661,9 @@ Slice::Gen::generate(const UnitPtr& p)
     if (_dllExport.empty())
     {
         static const string dllExportPrefix = "cpp:dll-export:";
-        string meta = dc->findMetadata(dllExportPrefix);
-        if (meta.size() > dllExportPrefix.size())
+        if (auto meta = dc->findMetadata(dllExportPrefix))
         {
-            _dllExport = meta.substr(dllExportPrefix.size());
+            _dllExport = (*meta).substr(dllExportPrefix.size());
         }
     }
 
@@ -1200,31 +1198,27 @@ Slice::Gen::resetUseWstring(list<TypeContext>& hist)
 string
 Slice::Gen::getHeaderExt(const string& file, const UnitPtr& ut)
 {
-    string ext;
     static const string headerExtPrefix = "cpp:header-ext:";
     DefinitionContextPtr dc = ut->findDefinitionContext(file);
     assert(dc);
-    string meta = dc->findMetadata(headerExtPrefix);
-    if (meta.size() > headerExtPrefix.size())
+    if (auto meta = dc->findMetadata(headerExtPrefix))
     {
-        ext = meta.substr(headerExtPrefix.size());
+        return (*meta).substr(headerExtPrefix.size());
     }
-    return ext;
+    return "";
 }
 
 string
 Slice::Gen::getSourceExt(const string& file, const UnitPtr& ut)
 {
-    string ext;
     static const string sourceExtPrefix = "cpp:source-ext:";
     DefinitionContextPtr dc = ut->findDefinitionContext(file);
     assert(dc);
-    string meta = dc->findMetadata(sourceExtPrefix);
-    if (meta.size() > sourceExtPrefix.size())
+    if (auto meta = dc->findMetadata(sourceExtPrefix))
     {
-        ext = meta.substr(sourceExtPrefix.size());
+        return (*meta).substr(sourceExtPrefix.size());
     }
-    return ext;
+    return "";
 }
 
 Slice::Gen::ForwardDeclVisitor::ForwardDeclVisitor(Output& h) : H(h), _useWstring(TypeContext::None) {}

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -409,7 +409,7 @@ namespace
             assert(dc);
             if (auto meta = dc->findMetadata(prefix))
             {
-                out << nl << " * \\headerfile " << (*meta).substr(prefix.size());
+                out << nl << " * \\headerfile " << meta->substr(prefix.size());
             }
         }
 
@@ -663,7 +663,7 @@ Slice::Gen::generate(const UnitPtr& p)
         static const string dllExportPrefix = "cpp:dll-export:";
         if (auto meta = dc->findMetadata(dllExportPrefix))
         {
-            _dllExport = (*meta).substr(dllExportPrefix.size());
+            _dllExport = meta->substr(dllExportPrefix.size());
         }
     }
 
@@ -1203,7 +1203,7 @@ Slice::Gen::getHeaderExt(const string& file, const UnitPtr& ut)
     assert(dc);
     if (auto meta = dc->findMetadata(headerExtPrefix))
     {
-        return (*meta).substr(headerExtPrefix.size());
+        return meta->substr(headerExtPrefix.size());
     }
     return "";
 }
@@ -1216,7 +1216,7 @@ Slice::Gen::getSourceExt(const string& file, const UnitPtr& ut)
     assert(dc);
     if (auto meta = dc->findMetadata(sourceExtPrefix))
     {
-        return (*meta).substr(sourceExtPrefix.size());
+        return meta->substr(sourceExtPrefix.size());
     }
     return "";
 }

--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -215,7 +215,7 @@ compile(const vector<string>& argv)
             assert(dc);
             if (auto meta = dc->findMetadata(headerExtPrefix))
             {
-                ext = (*meta).substr(headerExtPrefix.size());
+                ext = meta->substr(headerExtPrefix.size());
             }
 
             u->destroy();

--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -213,10 +213,9 @@ compile(const vector<string>& argv)
             static const string headerExtPrefix = "cpp:header-ext:";
             DefinitionContextPtr dc = u->findDefinitionContext(u->topLevelFile());
             assert(dc);
-            string meta = dc->findMetadata(headerExtPrefix);
-            if (meta.size() > headerExtPrefix.size())
+            if (auto meta = dc->findMetadata(headerExtPrefix))
             {
-                ext = meta.substr(headerExtPrefix.size());
+                ext = (*meta).substr(headerExtPrefix.size());
             }
 
             u->destroy();

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1159,8 +1159,8 @@ Slice::CsGenerator::writeSequenceMarshalUnmarshalCode(
 
     const string genericPrefix = "cs:generic:";
     string genericType;
-    bool isGeneric = false;
     string addMethod = "Add";
+    bool isGeneric = false;
     bool isStack = false;
     bool isList = false;
     bool isLinkedList = false;

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -81,13 +81,11 @@ Slice::CsGenerator::getNamespacePrefix(const ContainedPtr& cont)
     assert(m);
 
     static const string prefix = "cs:namespace:";
-
-    string q;
-    if (m->findMetadata(prefix, q))
+    if (auto meta = m->findMetadata(prefix))
     {
-        q = q.substr(prefix.size());
+        return (*meta).substr(prefix.size());
     }
-    return q;
+    return "";
 }
 
 string
@@ -360,10 +358,9 @@ Slice::CsGenerator::typeToString(const TypePtr& type, const string& package, boo
     if (seq)
     {
         string prefix = "cs:generic:";
-        string meta;
-        if (seq->findMetadata(prefix, meta))
+        if (auto meta = seq->findMetadata(prefix))
         {
-            string customType = meta.substr(prefix.size());
+            string customType = (*meta).substr(prefix.size());
             if (customType == "List" || customType == "LinkedList" || customType == "Queue" || customType == "Stack")
             {
                 return "global::System.Collections.Generic." + customType + "<" + typeToString(seq->type(), package) +
@@ -382,11 +379,10 @@ Slice::CsGenerator::typeToString(const TypePtr& type, const string& package, boo
     if (d)
     {
         string prefix = "cs:generic:";
-        string meta;
         string typeName;
-        if (d->findMetadata(prefix, meta))
+        if (auto meta = d->findMetadata(prefix))
         {
-            typeName = meta.substr(prefix.size());
+            typeName = (*meta).substr(prefix.size());
         }
         else
         {
@@ -1163,15 +1159,16 @@ Slice::CsGenerator::writeSequenceMarshalUnmarshalCode(
 
     const string genericPrefix = "cs:generic:";
     string genericType;
+    bool isGeneric = false;
     string addMethod = "Add";
-    const bool isGeneric = seq->findMetadata(genericPrefix, genericType);
     bool isStack = false;
     bool isList = false;
     bool isLinkedList = false;
     bool isCustom = false;
-    if (isGeneric)
+    if (auto meta = seq->findMetadata(genericPrefix))
     {
-        genericType = genericType.substr(genericPrefix.size());
+        isGeneric = true;
+        genericType = (*meta).substr(genericPrefix.size());
         if (genericType == "LinkedList")
         {
             addMethod = "AddLast";
@@ -1788,8 +1785,7 @@ Slice::CsGenerator::writeOptionalSequenceMarshalUnmarshalCode(
     const string typeS = typeToString(type, scope);
     const string seqS = typeToString(seq, scope);
 
-    string meta;
-    const bool isArray = !seq->findMetadata("cs:generic:", meta);
+    const bool isArray = !seq->hasMetadata("cs:generic:");
     const string length = isArray ? param + ".Length" : param + ".Count";
 
     BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -83,7 +83,7 @@ Slice::CsGenerator::getNamespacePrefix(const ContainedPtr& cont)
     static const string prefix = "cs:namespace:";
     if (auto meta = m->findMetadata(prefix))
     {
-        return (*meta).substr(prefix.size());
+        return meta->substr(prefix.size());
     }
     return "";
 }
@@ -360,7 +360,7 @@ Slice::CsGenerator::typeToString(const TypePtr& type, const string& package, boo
         string prefix = "cs:generic:";
         if (auto meta = seq->findMetadata(prefix))
         {
-            string customType = (*meta).substr(prefix.size());
+            string customType = meta->substr(prefix.size());
             if (customType == "List" || customType == "LinkedList" || customType == "Queue" || customType == "Stack")
             {
                 return "global::System.Collections.Generic." + customType + "<" + typeToString(seq->type(), package) +
@@ -382,7 +382,7 @@ Slice::CsGenerator::typeToString(const TypePtr& type, const string& package, boo
         string typeName;
         if (auto meta = d->findMetadata(prefix))
         {
-            typeName = (*meta).substr(prefix.size());
+            typeName = meta->substr(prefix.size());
         }
         else
         {
@@ -1168,7 +1168,7 @@ Slice::CsGenerator::writeSequenceMarshalUnmarshalCode(
     if (auto meta = seq->findMetadata(genericPrefix))
     {
         isGeneric = true;
-        genericType = (*meta).substr(genericPrefix.size());
+        genericType = meta->substr(genericPrefix.size());
         if (genericType == "LinkedList")
         {
             addMethod = "AddLast";

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -3163,10 +3163,9 @@ Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
     _out << eb;
 
     string prefix = "cs:generic:";
-    string meta;
-    if (p->findMetadata(prefix, meta))
+    if (auto meta = p->findMetadata(prefix))
     {
-        string type = meta.substr(prefix.size());
+        string type = (*meta).substr(prefix.size());
         if (type == "List" || type == "LinkedList" || type == "Queue" || type == "Stack")
         {
             return;
@@ -3200,17 +3199,15 @@ Slice::Gen::HelperVisitor::visitDictionary(const DictionaryPtr& p)
     TypePtr key = p->keyType();
     TypePtr value = p->valueType();
 
-    string meta;
-
     string prefix = "cs:generic:";
     string genericType;
-    if (!p->findMetadata(prefix, meta))
+    if (auto meta = p->findMetadata(prefix))
     {
-        genericType = "Dictionary";
+        genericType = (*meta).substr(prefix.size());
     }
     else
     {
-        genericType = meta.substr(prefix.size());
+        genericType = "Dictionary";
     }
 
     string ns = getNamespace(p);

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -3165,7 +3165,7 @@ Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
     string prefix = "cs:generic:";
     if (auto meta = p->findMetadata(prefix))
     {
-        string type = (*meta).substr(prefix.size());
+        string type = meta->substr(prefix.size());
         if (type == "List" || type == "LinkedList" || type == "Queue" || type == "Stack")
         {
             return;
@@ -3203,7 +3203,7 @@ Slice::Gen::HelperVisitor::visitDictionary(const DictionaryPtr& p)
     string genericType;
     if (auto meta = p->findMetadata(prefix))
     {
-        genericType = (*meta).substr(prefix.size());
+        genericType = meta->substr(prefix.size());
     }
     else
     {

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -3762,13 +3762,12 @@ Slice::Gen::HelperVisitor::HelperVisitor(const string& dir) : JavaVisitor(dir) {
 void
 Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
 {
-    string meta;
     BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(p->type());
     if (!hasTypeMetadata(p) && builtin && builtin->kind() <= Builtin::KindString)
     {
         return; // No helpers for sequence of primitive types
     }
-    else if (hasTypeMetadata(p) && !p->findMetadata("java:type", meta))
+    else if (hasTypeMetadata(p) && !p->hasMetadata("java:type"))
     {
         return; // No helpers for custom metadata other than java:type
     }

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -911,7 +911,7 @@ Slice::JavaGenerator::getPackagePrefix(const ContainedPtr& cont) const
 
     if (auto meta = m->findMetadata(prefix))
     {
-        return (*meta).substr(prefix.size());
+        return meta->substr(prefix.size());
     }
 
     string file = cont->file();
@@ -919,7 +919,7 @@ Slice::JavaGenerator::getPackagePrefix(const ContainedPtr& cont) const
     assert(dc);
     if (auto meta = dc->findMetadata(prefix))
     {
-        return (*meta).substr(prefix.size());
+        return meta->substr(prefix.size());
     }
 
     return "";
@@ -2446,7 +2446,7 @@ Slice::JavaGenerator::getSequenceTypes(
             string prefix = "java:serializable:";
             if (auto meta = seq->findMetadata(prefix))
             {
-                instanceType = formalType = (*meta).substr(prefix.size());
+                instanceType = formalType = meta->substr(prefix.size());
                 return true;
             }
         }

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -515,10 +515,10 @@ Slice::getSerialVersionUID(const ContainedPtr& p)
     optional<std::int64_t> serialVersionUID = nullopt;
 
     // Check if the user provided their own UID value with metadata.
-    string metadata;
-    if (p->findMetadata("java:serialVersionUID", metadata))
+    if (auto meta = p->findMetadata("java:serialVersionUID"))
     {
-        string::size_type pos = metadata.rfind(":") + 1;
+        string value = *meta;
+        string::size_type pos = value.rfind(":") + 1;
         if (pos == string::npos)
         {
             ostringstream os;
@@ -531,8 +531,8 @@ Slice::getSerialVersionUID(const ContainedPtr& p)
         {
             try
             {
-                metadata = metadata.substr(pos);
-                serialVersionUID = std::stoll(metadata, nullptr, 0);
+                value = value.substr(pos);
+                serialVersionUID = std::stoll(value, nullptr, 0);
             }
             catch (const std::exception&)
             {
@@ -909,24 +909,20 @@ Slice::JavaGenerator::getPackagePrefix(const ContainedPtr& cont) const
     //
     static const string prefix = "java:package:";
 
-    string q;
-    if (!m->findMetadata(prefix, q))
+    if (auto meta = m->findMetadata(prefix))
     {
-        UnitPtr ut = cont->unit();
-        string file = cont->file();
-        assert(!file.empty());
-
-        DefinitionContextPtr dc = ut->findDefinitionContext(file);
-        assert(dc);
-        q = dc->findMetadata(prefix);
+        return (*meta).substr(prefix.size());
     }
 
-    if (!q.empty())
+    string file = cont->file();
+    DefinitionContextPtr dc = cont->unit()->findDefinitionContext(file);
+    assert(dc);
+    if (auto meta = dc->findMetadata(prefix))
     {
-        q = q.substr(prefix.size());
+        return (*meta).substr(prefix.size());
     }
 
-    return q;
+    return "";
 }
 
 string
@@ -1545,7 +1541,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(
                     return;
                 }
             }
-            else if (findMetadata("java:serializable", seq->getMetadata(), ignored))
+            else if (seq->hasMetadata("java:serializable"))
             {
                 if (marshal)
                 {
@@ -1560,7 +1556,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(
                 }
             }
             else if (
-                !hasTypeMetadata(seq, metadata) || findMetadata("java:type", seq->getMetadata(), ignored) ||
+                !hasTypeMetadata(seq, metadata) || seq->hasMetadata("java:type") ||
                 findMetadata("java:type", metadata, ignored))
             {
                 string instanceType, formalType, origInstanceType, origFormalType;
@@ -1614,8 +1610,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(
                     {
                         string ignored2;
                         out << nl << "final int optSize = " << s << " == null ? 0 : ";
-                        if (findMetadata("java:buffer", seq->getMetadata(), ignored2) ||
-                            findMetadata("java:buffer", metadata, ignored2))
+                        if (seq->hasMetadata("java:buffer") || findMetadata("java:buffer", metadata, ignored2))
                         {
                             out << s << ".remaining() / " << sz << ";";
                         }
@@ -1876,9 +1871,8 @@ Slice::JavaGenerator::writeSequenceMarshalUnmarshalCode(
     BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(seq->type());
     if (builtin && builtin->kind() == Builtin::KindByte)
     {
-        string meta;
         static const string serializable = "java:serializable:";
-        if (seq->findMetadata(serializable, meta))
+        if (seq->hasMetadata(serializable))
         {
             if (marshal)
             {
@@ -1900,7 +1894,7 @@ Slice::JavaGenerator::writeSequenceMarshalUnmarshalCode(
     {
         string meta;
         static const string bytebuffer = "java:buffer";
-        if (seq->findMetadata(bytebuffer, meta) || findMetadata(bytebuffer, metadata, meta))
+        if (seq->hasMetadata(bytebuffer) || findMetadata(bytebuffer, metadata, meta))
         {
             if (marshal)
             {
@@ -2450,10 +2444,9 @@ Slice::JavaGenerator::getSequenceTypes(
         if (builtin->kind() == Builtin::KindByte)
         {
             string prefix = "java:serializable:";
-            string meta;
-            if (seq->findMetadata(prefix, meta))
+            if (auto meta = seq->findMetadata(prefix))
             {
-                instanceType = formalType = meta.substr(prefix.size());
+                instanceType = formalType = (*meta).substr(prefix.size());
                 return true;
             }
         }
@@ -2463,9 +2456,8 @@ Slice::JavaGenerator::getSequenceTypes(
              builtin->kind() == Builtin::KindFloat || builtin->kind() == Builtin::KindDouble))
         {
             string prefix = "java:buffer";
-            string meta;
             string ignored;
-            if (seq->findMetadata(prefix, meta) || findMetadata(prefix, metadata, ignored))
+            if (seq->hasMetadata(prefix) || findMetadata(prefix, metadata, ignored))
             {
                 instanceType = formalType = typeToBufferString(seq->type());
                 return true;

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -1987,12 +1987,11 @@ namespace
     string getDefinedIn(const ContainedPtr& p)
     {
         const string prefix = "js:defined-in:";
-        string meta;
-        if (p->findMetadata(prefix, meta))
+        if (auto meta = p->findMetadata(prefix))
         {
-            return meta.substr(prefix.size());
+            return (*meta).substr(prefix.size());
         }
-        return meta;
+        return "";
     }
 }
 

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -1989,7 +1989,7 @@ namespace
         const string prefix = "js:defined-in:";
         if (auto meta = p->findMetadata(prefix))
         {
-            return (*meta).substr(prefix.size());
+            return meta->substr(prefix.size());
         }
         return "";
     }

--- a/cpp/src/slice2js/JsUtil.cpp
+++ b/cpp/src/slice2js/JsUtil.cpp
@@ -145,8 +145,8 @@ Slice::getJavaScriptModule(const DefinitionContextPtr& dc)
     // Check if the file contains the js:module file metadata.-
     assert(dc);
     const string prefix = "js:module:";
-    const string value = dc->findMetadata(prefix);
-    return value.empty() ? value : value.substr(prefix.size());
+    const optional<string> value = dc->findMetadata(prefix);
+    return value.has_value() ? (*value).substr(prefix.size()) : "";
 }
 
 //
@@ -194,21 +194,6 @@ Slice::JsGenerator::fixDataMemberName(const std::string& name, bool isStruct, bo
         return "_" + name;
     }
     return Slice::JsGenerator::fixId(name);
-}
-
-bool
-Slice::JsGenerator::findMetadata(const string& prefix, const StringList& metadata, string& value)
-{
-    for (StringList::const_iterator i = metadata.begin(); i != metadata.end(); i++)
-    {
-        string s = *i;
-        if (s.find(prefix) == 0)
-        {
-            value = s.substr(prefix.size());
-            return true;
-        }
-    }
-    return false;
 }
 
 string

--- a/cpp/src/slice2js/JsUtil.h
+++ b/cpp/src/slice2js/JsUtil.h
@@ -24,7 +24,6 @@ namespace Slice
         JsGenerator& operator=(const JsGenerator&) = delete;
         static std::string fixDataMemberName(const std::string&, bool, bool);
         static std::string fixId(const std::string&);
-        static bool findMetadata(const std::string&, const StringList&, std::string&);
 
         static std::string getUnqualified(const std::string&, const std::string&, const std::string&);
 

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -1676,13 +1676,13 @@ CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
             //
             out << nl << "properties(Access=protected)";
             out.inc();
-            for (DataMemberList::const_iterator q = members.begin(); q != members.end(); ++q)
+            for (const auto& member : members)
             {
-                writeMemberDoc(out, *q);
-                out << nl << fixIdent((*q)->name());
-                if (declarePropertyType((*q)->type(), (*q)->optional()))
+                writeMemberDoc(out, member);
+                out << nl << fixIdent(member->name());
+                if (declarePropertyType(member->type(), member->optional()))
                 {
-                    out << " " << typeToString((*q)->type());
+                    out << " " << typeToString(member->type());
                 }
             }
             out.dec();
@@ -1691,15 +1691,15 @@ CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
         else
         {
             DataMemberList prot, pub;
-            for (DataMemberList::const_iterator q = members.begin(); q != members.end(); ++q)
+            for (const auto& member : members)
             {
-                if ((*q)->hasMetadata("protected"))
+                if (member->hasMetadata("protected"))
                 {
-                    prot.push_back(*q);
+                    prot.push_back(member);
                 }
                 else
                 {
-                    pub.push_back(*q);
+                    pub.push_back(member);
                 }
             }
             if (!pub.empty())

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -254,10 +254,10 @@ CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     {
         _out << sp;
         bool isProtected = p->hasMetadata("protected");
-        for (DataMemberList::iterator q = members.begin(); q != members.end(); ++q)
+        for (const auto& member : members)
         {
             _out << nl;
-            if (isProtected || (*q)->hasMetadata("protected"))
+            if (isProtected || member->hasMetadata("protected"))
             {
                 _out << "protected ";
             }
@@ -265,7 +265,7 @@ CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
             {
                 _out << "public ";
             }
-            _out << "$" << fixIdent((*q)->name()) << ";";
+            _out << "$" << fixIdent(member->name()) << ";";
         }
     }
 

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2742,7 +2742,7 @@ Slice::Python::getPackageDirectory(const string& file, const UnitPtr& ut)
     if (auto meta = dc->findMetadata(prefix))
     {
         // The metadata is present, so the generated file was placed in the specified directory.
-        return (*meta).substr(prefix.size());
+        return meta->substr(prefix.size());
     }
     return "";
 }
@@ -2898,7 +2898,7 @@ Slice::Python::getPackageMetadata(const ContainedPtr& cont)
     static const string prefix = "python:package:";
     if (auto meta = m->findMetadata(prefix))
     {
-        return (*meta).substr(prefix.size());
+        return meta->substr(prefix.size());
     }
 
     string file = cont->file();
@@ -2906,7 +2906,7 @@ Slice::Python::getPackageMetadata(const ContainedPtr& cont)
     assert(dc);
     if (auto meta = dc->findMetadata(prefix))
     {
-        return (*meta).substr(prefix.size());
+        return meta->substr(prefix.size());
     }
     
     return "";

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2908,7 +2908,7 @@ Slice::Python::getPackageMetadata(const ContainedPtr& cont)
     {
         return meta->substr(prefix.size());
     }
-    
+
     return "";
 }
 

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2014,21 +2014,19 @@ Slice::Python::CodeVisitor::collectClassMembers(const ClassDefPtr& p, MemberInfo
         collectClassMembers(base, allMembers, true);
     }
 
-    DataMemberList members = p->dataMembers();
-
-    for (DataMemberList::iterator q = members.begin(); q != members.end(); ++q)
+    for (const auto& member : p->dataMembers())
     {
         MemberInfo m;
-        if (p->hasMetadata("protected") || (*q)->hasMetadata("protected"))
+        if (p->hasMetadata("protected") || member->hasMetadata("protected"))
         {
-            m.fixedName = "_" + fixIdent((*q)->name());
+            m.fixedName = "_" + fixIdent(member->name());
         }
         else
         {
-            m.fixedName = fixIdent((*q)->name());
+            m.fixedName = fixIdent(member->name());
         }
         m.inherited = inherited;
-        m.dataMember = *q;
+        m.dataMember = member;
         allMembers.push_back(m);
     }
 }
@@ -2741,16 +2739,12 @@ Slice::Python::getPackageDirectory(const string& file, const UnitPtr& ut)
     DefinitionContextPtr dc = ut->findDefinitionContext(file);
     assert(dc);
     const string prefix = "python:pkgdir:";
-    string pkgdir = dc->findMetadata(prefix);
-    if (!pkgdir.empty())
+    if (auto meta = dc->findMetadata(prefix))
     {
-        //
         // The metadata is present, so the generated file was placed in the specified directory.
-        //
-        pkgdir = pkgdir.substr(prefix.size());
-        assert(!pkgdir.empty()); // This situation should have been caught by MetadataVisitor.
+        return (*meta).substr(prefix.size());
     }
-    return pkgdir;
+    return "";
 }
 
 string
@@ -2902,25 +2896,20 @@ Slice::Python::getPackageMetadata(const ContainedPtr& cont)
     // The python:package metadata can be defined as file metadata or applied to a top-level module.
     // We check for the metadata at the top-level module first and then fall back to the global scope.
     static const string prefix = "python:package:";
-
-    string q;
-    if (!m->findMetadata(prefix, q))
+    if (auto meta = m->findMetadata(prefix))
     {
-        UnitPtr ut = cont->unit();
-        string file = cont->file();
-        assert(!file.empty());
-
-        DefinitionContextPtr dc = ut->findDefinitionContext(file);
-        assert(dc);
-        q = dc->findMetadata(prefix);
+        return (*meta).substr(prefix.size());
     }
 
-    if (!q.empty())
+    string file = cont->file();
+    DefinitionContextPtr dc = cont->unit()->findDefinitionContext(file);
+    assert(dc);
+    if (auto meta = dc->findMetadata(prefix))
     {
-        q = q.substr(prefix.size());
+        return (*meta).substr(prefix.size());
     }
-
-    return q;
+    
+    return "";
 }
 
 string

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -546,13 +546,13 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     {
         _out << sp;
     }
-    for (OperationList::iterator s = ops.begin(); s != ops.end(); ++s)
+    for (const auto& op : ops)
     {
-        ParamDeclList params = (*s)->parameters();
-        ParamDeclList::iterator t;
+        ParamDeclList params = op->parameters();
+        ParamDeclList::const_iterator t;
         int count;
         string format;
-        optional<FormatType> opFormat = (*s)->format();
+        optional<FormatType> opFormat = op->format();
         if (opFormat)
         {
             switch (*opFormat)
@@ -572,9 +572,9 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             format = "nil";
         }
 
-        _out << nl << name << "Prx_mixin::OP_" << (*s)->name() << " = ::Ice::__defineOperation('" << (*s)->name()
+        _out << nl << name << "Prx_mixin::OP_" << op->name() << " = ::Ice::__defineOperation('" << op->name()
              << "', ";
-        switch ((*s)->mode())
+        switch (op->mode())
         {
             case Operation::Normal:
                 _out << "::Ice::OperationMode::Normal";
@@ -583,7 +583,7 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                 _out << "::Ice::OperationMode::Idempotent";
                 break;
         }
-        _out << ", " << ((p->hasMetadata("amd") || (*s)->hasMetadata("amd")) ? "true" : "false") << ", " << format
+        _out << ", " << ((p->hasMetadata("amd") || op->hasMetadata("amd")) ? "true" : "false") << ", " << format
              << ", [";
         for (t = params.begin(), count = 0; t != params.end(); ++t)
         {
@@ -617,7 +617,7 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             }
         }
         _out << "], ";
-        TypePtr returnType = (*s)->returnType();
+        TypePtr returnType = op->returnType();
         if (returnType)
         {
             //
@@ -627,15 +627,15 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             //
             _out << '[';
             writeType(returnType);
-            _out << ", " << ((*s)->returnIsOptional() ? "true" : "false") << ", "
-                 << ((*s)->returnIsOptional() ? (*s)->returnTag() : 0) << ']';
+            _out << ", " << (op->returnIsOptional() ? "true" : "false") << ", "
+                 << (op->returnIsOptional() ? op->returnTag() : 0) << ']';
         }
         else
         {
             _out << "nil";
         }
         _out << ", [";
-        ExceptionList exceptions = (*s)->throws();
+        ExceptionList exceptions = op->throws();
         for (ExceptionList::iterator u = exceptions.begin(); u != exceptions.end(); ++u)
         {
             if (u != exceptions.begin())
@@ -646,11 +646,11 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         }
         _out << "])";
 
-        if ((*s)->isDeprecated(true))
+        if (op->isDeprecated(true))
         {
             // Get the deprecation reason if present, or default to an empty string.
-            string reason = (*s)->getDeprecationReason(true).value_or("");
-            _out << nl << name << "Prx_mixin::OP_" << (*s)->name() << ".deprecate(\"" << reason << "\")";
+            string reason = op->getDeprecationReason(true).value_or("");
+            _out << nl << name << "Prx_mixin::OP_" << op->name() << ".deprecate(\"" << reason << "\")";
         }
     }
 

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -572,8 +572,7 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             format = "nil";
         }
 
-        _out << nl << name << "Prx_mixin::OP_" << op->name() << " = ::Ice::__defineOperation('" << op->name()
-             << "', ";
+        _out << nl << name << "Prx_mixin::OP_" << op->name() << " = ::Ice::__defineOperation('" << op->name() << "', ";
         switch (op->mode())
         {
             case Operation::Normal:

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -29,7 +29,7 @@ namespace
         static const string classResolverPrefix = "swift:class-resolver-prefix:";
         if (auto meta = dc->findMetadata(classResolverPrefix))
         {
-            return (*meta).substr(classResolverPrefix.size());
+            return meta->substr(classResolverPrefix.size());
         }
         return "";
     }

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -27,12 +27,11 @@ namespace
         assert(dc);
 
         static const string classResolverPrefix = "swift:class-resolver-prefix:";
-        string result = dc->findMetadata(classResolverPrefix);
-        if (!result.empty())
+        if (auto meta = dc->findMetadata(classResolverPrefix))
         {
-            result = result.substr(classResolverPrefix.size());
+            return (*meta).substr(classResolverPrefix.size());
         }
-        return result;
+        return "";
     }
 }
 

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -191,15 +191,15 @@ Slice::getSwiftModule(const ModulePtr& module, string& swiftPrefix)
 
     string swiftModule;
 
-    if (module->findMetadata(modulePrefix, swiftModule))
+    if (auto meta = module->findMetadata(modulePrefix))
     {
-        swiftModule = swiftModule.substr(modulePrefix.size());
+        swiftModule = (*meta).substr(modulePrefix.size());
 
         size_t pos = swiftModule.find(':');
         if (pos != string::npos)
         {
-            swiftPrefix = swiftModule.substr(pos + 1);
             swiftModule = swiftModule.substr(0, pos);
+            swiftPrefix = swiftModule.substr(pos + 1);
         }
     }
     else
@@ -1668,26 +1668,8 @@ SwiftGenerator::MetadataVisitor::visitModuleStart(const ModulePtr& p)
         // top-level module
         const UnitPtr unit = p->unit();
 
-        const string modulePrefix = "swift:module:";
-
-        string swiftModule;
         string swiftPrefix;
-
-        if (p->findMetadata(modulePrefix, swiftModule))
-        {
-            swiftModule = swiftModule.substr(modulePrefix.size());
-
-            size_t pos = swiftModule.find(':');
-            if (pos != string::npos)
-            {
-                swiftPrefix = swiftModule.substr(pos + 1);
-                swiftModule = swiftModule.substr(0, pos);
-            }
-        }
-        else
-        {
-            swiftModule = p->name();
-        }
+        string swiftModule = getSwiftModule(p, swiftPrefix);
 
         const string filename = p->definitionContext()->filename();
         ModuleMap::const_iterator current = _modules.find(filename);

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -198,8 +198,8 @@ Slice::getSwiftModule(const ModulePtr& module, string& swiftPrefix)
         size_t pos = swiftModule.find(':');
         if (pos != string::npos)
         {
-            swiftModule = swiftModule.substr(0, pos);
             swiftPrefix = swiftModule.substr(pos + 1);
+            swiftModule = swiftModule.substr(0, pos);
         }
     }
     else

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -193,7 +193,7 @@ Slice::getSwiftModule(const ModulePtr& module, string& swiftPrefix)
 
     if (auto meta = module->findMetadata(modulePrefix))
     {
-        swiftModule = (*meta).substr(modulePrefix.size());
+        swiftModule = meta->substr(modulePrefix.size());
 
         size_t pos = swiftModule.find(':');
         if (pos != string::npos)


### PR DESCRIPTION
This PR is a preliminary step in improving metadata validation by first improving the metadata APIs.
The biggest change is that instead of `findMetadata` using an out-parameter, it now returns an `optional`.

Also, we have 2 sets of metadata functions (one on `Contained` and one on `DefinitionContext`).
This PR also brings their implementations into alignment, whereas right now, they're actually pretty different.

----

The next step is to add a dedicated `Metadata` grammar element.
This can store a pre-parsed form of the metadata (to skip all the `meta.substr(prefix.length())` you'll see in this PR),
and to let us store it's location (to fix #2021).