### PR TITLE
Move proxy functions to ProxyFunctions.cpp

### DIFF
--- a/cpp/include/Ice/Comparable.h
+++ b/cpp/include/Ice/Comparable.h
@@ -5,7 +5,8 @@
 #ifndef ICE_COMPARABLE_H
 #define ICE_COMPARABLE_H
 
-#include <functional>
+#include <tuple>
+#include <type_traits>
 
 namespace Ice
 {
@@ -113,80 +114,91 @@ namespace Ice
         }
     };
 
-    //
-    // Relational operators for generated structs and classes
-    //
-
-    /**
-     * Relational operator for generated structs and classes.
-     * @param lhs The left-hand side.
-     * @param rhs The right-hand side.
-     * @return True if the left-hand side compares less than the right-hand side, false otherwise.
-     */
-    template<class C, typename = std::enable_if<std::is_member_function_pointer<decltype(&C::ice_tuple)>::value>>
-    bool operator<(const C& lhs, const C& rhs)
+    namespace Tuple
     {
-        return lhs.ice_tuple() < rhs.ice_tuple();
-    }
+        /**
+         * Relational operator for generated structs and classes.
+         * @param lhs The left-hand side.
+         * @param rhs The right-hand side.
+         * @return True if the left-hand side compares less than the right-hand side, false otherwise.
+         */
+        template<
+            class C,
+            std::enable_if_t<std::is_member_function_pointer<decltype(&C::ice_tuple)>::value, bool> = true>
+        bool operator<(const C& lhs, const C& rhs)
+        {
+            return lhs.ice_tuple() < rhs.ice_tuple();
+        }
 
-    /**
-     * Relational operator for generated structs and classes.
-     * @param lhs The left-hand side.
-     * @param rhs The right-hand side.
-     * @return True if the left-hand side compares less than or equal to the right-hand side, false otherwise.
-     */
-    template<class C, typename = std::enable_if<std::is_member_function_pointer<decltype(&C::ice_tuple)>::value>>
-    bool operator<=(const C& lhs, const C& rhs)
-    {
-        return lhs.ice_tuple() <= rhs.ice_tuple();
-    }
+        /**
+         * Relational operator for generated structs and classes.
+         * @param lhs The left-hand side.
+         * @param rhs The right-hand side.
+         * @return True if the left-hand side compares less than or equal to the right-hand side, false otherwise.
+         */
+        template<
+            class C,
+            std::enable_if_t<std::is_member_function_pointer<decltype(&C::ice_tuple)>::value, bool> = true>
+        bool operator<=(const C& lhs, const C& rhs)
+        {
+            return lhs.ice_tuple() <= rhs.ice_tuple();
+        }
 
-    /**
-     * Relational operator for generated structs and classes.
-     * @param lhs The left-hand side.
-     * @param rhs The right-hand side.
-     * @return True if the left-hand side compares greater than the right-hand side, false otherwise.
-     */
-    template<class C, typename = std::enable_if<std::is_member_function_pointer<decltype(&C::ice_tuple)>::value>>
-    bool operator>(const C& lhs, const C& rhs)
-    {
-        return lhs.ice_tuple() > rhs.ice_tuple();
-    }
+        /**
+         * Relational operator for generated structs and classes.
+         * @param lhs The left-hand side.
+         * @param rhs The right-hand side.
+         * @return True if the left-hand side compares greater than the right-hand side, false otherwise.
+         */
+        template<
+            class C,
+            std::enable_if_t<std::is_member_function_pointer<decltype(&C::ice_tuple)>::value, bool> = true>
+        bool operator>(const C& lhs, const C& rhs)
+        {
+            return lhs.ice_tuple() > rhs.ice_tuple();
+        }
 
-    /**
-     * Relational operator for generated structs and classes.
-     * @param lhs The left-hand side.
-     * @param rhs The right-hand side.
-     * @return True if the left-hand side compares greater than or equal to the right-hand side, false otherwise.
-     */
-    template<class C, typename = std::enable_if<std::is_member_function_pointer<decltype(&C::ice_tuple)>::value>>
-    bool operator>=(const C& lhs, const C& rhs)
-    {
-        return lhs.ice_tuple() >= rhs.ice_tuple();
-    }
+        /**
+         * Relational operator for generated structs and classes.
+         * @param lhs The left-hand side.
+         * @param rhs The right-hand side.
+         * @return True if the left-hand side compares greater than or equal to the right-hand side, false otherwise.
+         */
+        template<
+            class C,
+            std::enable_if_t<std::is_member_function_pointer<decltype(&C::ice_tuple)>::value, bool> = true>
+        bool operator>=(const C& lhs, const C& rhs)
+        {
+            return lhs.ice_tuple() >= rhs.ice_tuple();
+        }
 
-    /**
-     * Relational operator for generated structs and classes.
-     * @param lhs The left-hand side.
-     * @param rhs The right-hand side.
-     * @return True if the left-hand side compares equal to the right-hand side, false otherwise.
-     */
-    template<class C, typename = std::enable_if<std::is_member_function_pointer<decltype(&C::ice_tuple)>::value>>
-    bool operator==(const C& lhs, const C& rhs)
-    {
-        return lhs.ice_tuple() == rhs.ice_tuple();
-    }
+        /**
+         * Relational operator for generated structs and classes.
+         * @param lhs The left-hand side.
+         * @param rhs The right-hand side.
+         * @return True if the left-hand side compares equal to the right-hand side, false otherwise.
+         */
+        template<
+            class C,
+            std::enable_if_t<std::is_member_function_pointer<decltype(&C::ice_tuple)>::value, bool> = true>
+        bool operator==(const C& lhs, const C& rhs)
+        {
+            return lhs.ice_tuple() == rhs.ice_tuple();
+        }
 
-    /**
-     * Relational operator for generated structs and classes.
-     * @param lhs The left-hand side.
-     * @param rhs The right-hand side.
-     * @return True if the left-hand side is not equal to the right-hand side, false otherwise.
-     */
-    template<class C, typename = std::enable_if<std::is_member_function_pointer<decltype(&C::ice_tuple)>::value>>
-    bool operator!=(const C& lhs, const C& rhs)
-    {
-        return lhs.ice_tuple() != rhs.ice_tuple();
+        /**
+         * Relational operator for generated structs and classes.
+         * @param lhs The left-hand side.
+         * @param rhs The right-hand side.
+         * @return True if the left-hand side is not equal to the right-hand side, false otherwise.
+         */
+        template<
+            class C,
+            std::enable_if_t<std::is_member_function_pointer<decltype(&C::ice_tuple)>::value, bool> = true>
+        bool operator!=(const C& lhs, const C& rhs)
+        {
+            return lhs.ice_tuple() != rhs.ice_tuple();
+        }
     }
 }
 

--- a/cpp/include/Ice/Object.h
+++ b/cpp/include/Ice/Object.h
@@ -9,6 +9,7 @@
 #include "ObjectF.h"
 #include "OutgoingResponse.h"
 
+#include <functional>
 #include <string_view>
 
 namespace Ice

--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -16,6 +16,7 @@
 #include "RequestHandlerF.h"
 
 #include <chrono>
+#include <functional>
 #include <future>
 #include <iosfwd>
 #include <optional>

--- a/cpp/include/Ice/ProxyFunctions.h
+++ b/cpp/include/Ice/ProxyFunctions.h
@@ -160,8 +160,8 @@ namespace Ice
         return proxy ? checkedCast<Prx>(proxy->ice_facet(std::move(facet)), context) : std::nullopt;
     }
 
-    ICE_API bool operator<(const ObjectPrx&, const ObjectPrx&) noexcept;
-    ICE_API bool operator==(const ObjectPrx&, const ObjectPrx&) noexcept;
+    ICE_API bool operator<(const ObjectPrx& lhs, const ObjectPrx& rhs) noexcept;
+    ICE_API bool operator==(const ObjectPrx& lhs, const ObjectPrx& rhs) noexcept;
 
     inline bool operator>(const ObjectPrx& lhs, const ObjectPrx& rhs) noexcept { return rhs < lhs; }
     inline bool operator<=(const ObjectPrx& lhs, const ObjectPrx& rhs) noexcept { return !(lhs > rhs); }

--- a/cpp/src/Ice/BatchRequestQueue.h
+++ b/cpp/src/Ice/BatchRequestQueue.h
@@ -11,6 +11,7 @@
 #include "Ice/OutputStream.h"
 
 #include <condition_variable>
+#include <functional>
 #include <mutex>
 
 namespace IceInternal

--- a/cpp/src/Ice/Proxy.cpp
+++ b/cpp/src/Ice/Proxy.cpp
@@ -1,16 +1,11 @@
-//
-// Copyright (c) ZeroC, Inc. All rights reserved.
-//
+// Copyright (c) ZeroC, Inc.
 
 #include "Ice/Proxy.h"
 #include "CheckIdentity.h"
 #include "ConnectionI.h"
 #include "EndpointI.h"
-#include "Ice/Communicator.h"
-#include "Ice/Comparable.h"
-#include "Ice/Current.h"
+#include "Ice/Initialize.h"
 #include "Ice/LocalExceptions.h"
-#include "Ice/ObjectAdapter.h"
 #include "Instance.h"
 #include "LocatorInfo.h"
 #include "Reference.h"
@@ -18,7 +13,6 @@
 #include "RequestHandlerCache.h"
 #include "RouterInfo.h"
 
-#include <sstream>
 #include <stdexcept>
 
 using namespace std;
@@ -578,107 +572,5 @@ Ice::ObjectPrx::_twoway() const
     else
     {
         return _reference->changeMode(Reference::ModeTwoway);
-    }
-}
-
-// TODO: move the code below to ProxyFunctions.cpp
-
-void
-IceInternal::throwNullProxyMarshalException(const char* file, int line, const Current& current)
-{
-    ostringstream os;
-    os << "null proxy passed to " << current.operation << " on object "
-       << current.adapter->getCommunicator()->identityToString(current.id);
-    throw MarshalException{file, line, os.str()};
-}
-
-namespace Ice
-{
-    bool operator<(const ObjectPrx& lhs, const ObjectPrx& rhs) noexcept
-    {
-        return targetLess(lhs._getReference(), rhs._getReference());
-    }
-
-    bool operator==(const ObjectPrx& lhs, const ObjectPrx& rhs) noexcept
-    {
-        return targetEqualTo(lhs._getReference(), rhs._getReference());
-    }
-}
-
-bool
-Ice::proxyIdentityLess(const optional<ObjectPrx>& lhs, const optional<ObjectPrx>& rhs) noexcept
-{
-    return lhs && rhs ? lhs->ice_getIdentity() < rhs->ice_getIdentity()
-                      : std::less<bool>()(static_cast<bool>(lhs), static_cast<bool>(rhs));
-}
-
-bool
-Ice::proxyIdentityEqual(const optional<ObjectPrx>& lhs, const optional<ObjectPrx>& rhs) noexcept
-{
-    return lhs && rhs ? lhs->ice_getIdentity() == rhs->ice_getIdentity()
-                      : std::equal_to<bool>()(static_cast<bool>(lhs), static_cast<bool>(rhs));
-}
-
-bool
-Ice::proxyIdentityAndFacetLess(const optional<ObjectPrx>& lhs, const optional<ObjectPrx>& rhs) noexcept
-{
-    if (lhs && rhs)
-    {
-        Identity lhsIdentity = lhs->ice_getIdentity();
-        Identity rhsIdentity = rhs->ice_getIdentity();
-
-        if (lhsIdentity < rhsIdentity)
-        {
-            return true;
-        }
-        else if (rhsIdentity < lhsIdentity)
-        {
-            return false;
-        }
-
-        string lhsFacet = lhs->ice_getFacet();
-        string rhsFacet = rhs->ice_getFacet();
-
-        if (lhsFacet < rhsFacet)
-        {
-            return true;
-        }
-        else if (rhsFacet < lhsFacet)
-        {
-            return false;
-        }
-
-        return false;
-    }
-    else
-    {
-        return std::less<bool>()(static_cast<bool>(lhs), static_cast<bool>(rhs));
-    }
-}
-
-bool
-Ice::proxyIdentityAndFacetEqual(const optional<ObjectPrx>& lhs, const optional<ObjectPrx>& rhs) noexcept
-{
-    if (lhs && rhs)
-    {
-        Identity lhsIdentity = lhs->ice_getIdentity();
-        Identity rhsIdentity = rhs->ice_getIdentity();
-
-        if (lhsIdentity == rhsIdentity)
-        {
-            string lhsFacet = lhs->ice_getFacet();
-            string rhsFacet = rhs->ice_getFacet();
-
-            if (lhsFacet == rhsFacet)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-    else
-    {
-        return std::equal_to<bool>()(static_cast<bool>(lhs), static_cast<bool>(rhs));
     }
 }

--- a/cpp/src/Ice/ProxyFunctions.cpp
+++ b/cpp/src/Ice/ProxyFunctions.cpp
@@ -1,0 +1,113 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "Ice/ProxyFunctions.h"
+#include "Ice/Communicator.h"
+#include "Ice/Current.h"
+#include "Ice/ObjectAdapter.h"
+#include "Reference.h"
+
+#include <sstream>
+
+using namespace std;
+using namespace Ice;
+using namespace IceInternal;
+
+void
+IceInternal::throwNullProxyMarshalException(const char* file, int line, const Current& current)
+{
+    ostringstream os;
+    os << "null proxy passed to " << current.operation << " on object "
+       << current.adapter->getCommunicator()->identityToString(current.id);
+    throw MarshalException{file, line, os.str()};
+}
+
+namespace Ice
+{
+    bool operator<(const ObjectPrx& lhs, const ObjectPrx& rhs) noexcept
+    {
+        return targetLess(lhs._getReference(), rhs._getReference());
+    }
+
+    bool operator==(const ObjectPrx& lhs, const ObjectPrx& rhs) noexcept
+    {
+        return targetEqualTo(lhs._getReference(), rhs._getReference());
+    }
+}
+
+bool
+Ice::proxyIdentityLess(const optional<ObjectPrx>& lhs, const optional<ObjectPrx>& rhs) noexcept
+{
+    return lhs && rhs ? lhs->ice_getIdentity() < rhs->ice_getIdentity()
+                      : std::less<bool>()(static_cast<bool>(lhs), static_cast<bool>(rhs));
+}
+
+bool
+Ice::proxyIdentityEqual(const optional<ObjectPrx>& lhs, const optional<ObjectPrx>& rhs) noexcept
+{
+    return lhs && rhs ? lhs->ice_getIdentity() == rhs->ice_getIdentity()
+                      : std::equal_to<bool>()(static_cast<bool>(lhs), static_cast<bool>(rhs));
+}
+
+bool
+Ice::proxyIdentityAndFacetLess(const optional<ObjectPrx>& lhs, const optional<ObjectPrx>& rhs) noexcept
+{
+    if (lhs && rhs)
+    {
+        Identity lhsIdentity = lhs->ice_getIdentity();
+        Identity rhsIdentity = rhs->ice_getIdentity();
+
+        if (lhsIdentity < rhsIdentity)
+        {
+            return true;
+        }
+        else if (rhsIdentity < lhsIdentity)
+        {
+            return false;
+        }
+
+        string lhsFacet = lhs->ice_getFacet();
+        string rhsFacet = rhs->ice_getFacet();
+
+        if (lhsFacet < rhsFacet)
+        {
+            return true;
+        }
+        else if (rhsFacet < lhsFacet)
+        {
+            return false;
+        }
+
+        return false;
+    }
+    else
+    {
+        return std::less<bool>()(static_cast<bool>(lhs), static_cast<bool>(rhs));
+    }
+}
+
+bool
+Ice::proxyIdentityAndFacetEqual(const optional<ObjectPrx>& lhs, const optional<ObjectPrx>& rhs) noexcept
+{
+    if (lhs && rhs)
+    {
+        Identity lhsIdentity = lhs->ice_getIdentity();
+        Identity rhsIdentity = rhs->ice_getIdentity();
+
+        if (lhsIdentity == rhsIdentity)
+        {
+            string lhsFacet = lhs->ice_getFacet();
+            string rhsFacet = rhs->ice_getFacet();
+
+            if (lhsFacet == rhsFacet)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+    else
+    {
+        return std::equal_to<bool>()(static_cast<bool>(lhs), static_cast<bool>(rhs));
+    }
+}

--- a/cpp/src/Ice/ProxyFunctions.cpp
+++ b/cpp/src/Ice/ProxyFunctions.cpp
@@ -21,17 +21,16 @@ IceInternal::throwNullProxyMarshalException(const char* file, int line, const Cu
     throw MarshalException{file, line, os.str()};
 }
 
-namespace Ice
+bool
+Ice::operator<(const ObjectPrx& lhs, const ObjectPrx& rhs) noexcept
 {
-    bool operator<(const ObjectPrx& lhs, const ObjectPrx& rhs) noexcept
-    {
-        return targetLess(lhs._getReference(), rhs._getReference());
-    }
+    return targetLess(lhs._getReference(), rhs._getReference());
+}
 
-    bool operator==(const ObjectPrx& lhs, const ObjectPrx& rhs) noexcept
-    {
-        return targetEqualTo(lhs._getReference(), rhs._getReference());
-    }
+bool
+Ice::operator==(const ObjectPrx& lhs, const ObjectPrx& rhs) noexcept
+{
+    return targetEqualTo(lhs._getReference(), rhs._getReference());
 }
 
 bool

--- a/cpp/src/Ice/ProxyFunctions.cpp
+++ b/cpp/src/Ice/ProxyFunctions.cpp
@@ -37,7 +37,7 @@ bool
 Ice::proxyIdentityLess(const optional<ObjectPrx>& lhs, const optional<ObjectPrx>& rhs) noexcept
 {
     return lhs && rhs ? lhs->ice_getIdentity() < rhs->ice_getIdentity()
-                      : std::less<bool>()(static_cast<bool>(lhs), static_cast<bool>(rhs));
+                      : std::less<bool>()(lhs.has_value(), rhs.has_value());
 }
 
 bool
@@ -67,16 +67,7 @@ Ice::proxyIdentityAndFacetLess(const optional<ObjectPrx>& lhs, const optional<Ob
         string lhsFacet = lhs->ice_getFacet();
         string rhsFacet = rhs->ice_getFacet();
 
-        if (lhsFacet < rhsFacet)
-        {
-            return true;
-        }
-        else if (rhsFacet < lhsFacet)
-        {
-            return false;
-        }
-
-        return false;
+        return lhsFacet < rhsFacet;
     }
     else
     {
@@ -89,21 +80,7 @@ Ice::proxyIdentityAndFacetEqual(const optional<ObjectPrx>& lhs, const optional<O
 {
     if (lhs && rhs)
     {
-        Identity lhsIdentity = lhs->ice_getIdentity();
-        Identity rhsIdentity = rhs->ice_getIdentity();
-
-        if (lhsIdentity == rhsIdentity)
-        {
-            string lhsFacet = lhs->ice_getFacet();
-            string rhsFacet = rhs->ice_getFacet();
-
-            if (lhsFacet == rhsFacet)
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return lhs->ice_getIdentity() == rhs->ice_getIdentity() && lhs->ice_getFacet() == rhs->ice_getFacet();
     }
     else
     {

--- a/cpp/src/Ice/msbuild/ice/ice.vcxproj
+++ b/cpp/src/Ice/msbuild/ice/ice.vcxproj
@@ -174,6 +174,7 @@
     <ClCompile Include="..\..\MarshaledResult.cpp" />
     <ClCompile Include="..\..\Properties.cpp" />
     <ClCompile Include="..\..\ProxyAsync.cpp" />
+    <ClCompile Include="..\..\ProxyFunctions.cpp" />
     <ClCompile Include="..\..\RequestHandlerCache.cpp" />
     <ClCompile Include="..\..\SSL\DistinguishedName.cpp" />
     <ClCompile Include="..\..\SSL\RFC2253.cpp" />

--- a/cpp/src/Ice/msbuild/ice/ice.vcxproj.filters
+++ b/cpp/src/Ice/msbuild/ice/ice.vcxproj.filters
@@ -559,6 +559,9 @@
     <ClCompile Include="..\..\ProxyAsync.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\ProxyFunctions.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\TimeUtil.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -2000,17 +2000,16 @@ Slice::Gen::DataDefVisitor::visitModuleStart(const ModulePtr& p)
 }
 
 void
-Slice::Gen::DataDefVisitor::visitModuleEnd(const ModulePtr& p)
+Slice::Gen::DataDefVisitor::visitModuleEnd(const ModulePtr&)
 {
-    if (p->contains<Struct>())
-    {
-        H << sp << nl << "using Ice::operator<;";
-        H << nl << "using Ice::operator<=;";
-        H << nl << "using Ice::operator>;";
-        H << nl << "using Ice::operator>=;";
-        H << nl << "using Ice::operator==;";
-        H << nl << "using Ice::operator!=;";
-    }
+    // Always generated when this module contains a struct, class, or exception.
+    H << sp;
+    H << nl << "using Ice::Tuple::operator<;";
+    H << nl << "using Ice::Tuple::operator<=;";
+    H << nl << "using Ice::Tuple::operator>;";
+    H << nl << "using Ice::Tuple::operator>=;";
+    H << nl << "using Ice::Tuple::operator==;";
+    H << nl << "using Ice::Tuple::operator!=;";
     H << sp << nl << '}';
     _useWstring = resetUseWstring(_useWstringHist);
 }


### PR DESCRIPTION
This PR moves the implementation of the proxy functions to their own .cpp file + related fixes.