### PR TITLE
Remove StreamWriters and most StreamReaders

### DIFF
--- a/cpp/include/Ice/StreamHelpers.h
+++ b/cpp/include/Ice/StreamHelpers.h
@@ -70,16 +70,12 @@ namespace Ice
     //
 
     /**
-     * Reader used/generated for structs, classes and exceptions. slice2cpp generates specializations as needed, in
-     * particular, it always generates a specialization for structs and for classes/exceptions with fields.
+     * Reader used/generated for structs.
      * \headerfile Ice/Ice.h
      */
     template<typename T> struct StreamReader
     {
-        static void read(InputStream*, T&)
-        {
-            // Default is to read nothing
-        }
+        static void read(InputStream*, T&); // not implemented, always specialized
     };
 
     /**

--- a/cpp/include/Ice/StreamHelpers.h
+++ b/cpp/include/Ice/StreamHelpers.h
@@ -70,12 +70,11 @@ namespace Ice
     //
 
     /**
-     * Reader used/generated for structs.
+     * Reader used/generated for structs. Always specialized.
      * \headerfile Ice/Ice.h
      */
     template<typename T> struct StreamReader
     {
-        static void read(InputStream*, T&); // not implemented, always specialized
     };
 
     /**
@@ -84,7 +83,7 @@ namespace Ice
      */
     template<typename T> struct StreamHelper<T, StreamHelperCategoryStruct>
     {
-        static void write(OutputStream* stream, const T& v) { stream->writeAll(v.ice_tuple());  }
+        static void write(OutputStream* stream, const T& v) { stream->writeAll(v.ice_tuple()); }
 
         static void read(InputStream* stream, T& v) { StreamReader<T>::read(stream, v); }
     };

--- a/cpp/include/Ice/StreamHelpers.h
+++ b/cpp/include/Ice/StreamHelpers.h
@@ -70,7 +70,8 @@ namespace Ice
     //
 
     /**
-     * General reader. slice2cpp generates specializations as needed.
+     * Reader used/generated for structs, classes and exceptions. slice2cpp generates specializations as needed, in
+     * particular, it always generates a specialization for structs and for classes/exceptions with fields.
      * \headerfile Ice/Ice.h
      */
     template<typename T> struct StreamReader
@@ -82,21 +83,12 @@ namespace Ice
     };
 
     /**
-     * General writer. slice2cpp generates specializations as needed.
-     * \headerfile Ice/Ice.h
-     */
-    template<typename T> struct StreamWriter
-    {
-        static void write(OutputStream* stream, const T& v) { stream->writeAll(v.ice_tuple()); }
-    };
-
-    /**
      * Helper for structs.
      * \headerfile Ice/Ice.h
      */
     template<typename T> struct StreamHelper<T, StreamHelperCategoryStruct>
     {
-        static void write(OutputStream* stream, const T& v) { StreamWriter<T>::write(stream, v); }
+        static void write(OutputStream* stream, const T& v) { stream->writeAll(v.ice_tuple());  }
 
         static void read(InputStream* stream, T& v) { StreamReader<T>::read(stream, v); }
     };

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -113,9 +113,7 @@ namespace
 
         // Sort optional data members
         optionalMembers.sort([](const DataMemberPtr& lhs, const DataMemberPtr& rhs)
-        {
-            return lhs->tag() < rhs->tag();
-        });
+                             { return lhs->tag() < rhs->tag(); });
 
         return {requiredMembers, optionalMembers};
     }

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -859,21 +859,26 @@ Slice::writeMarshalUnmarshalAllInHolder(
     {
         ostringstream os;
         os << "{";
-        for (DataMemberList::const_iterator q = dataMembers.begin(); q != dataMembers.end(); ++q)
+        bool firstElement = true;
+        for (const auto& q : dataMembers)
         {
-            if (q != dataMembers.begin())
+            if (firstElement)
+            {
+                firstElement = false;
+            }
+            else
             {
                 os << ", ";
             }
-            os << (*q)->tag();
+            os << q->tag();
         }
         os << "}";
         out << os.str();
     }
 
-    for (DataMemberList::const_iterator q = dataMembers.begin(); q != dataMembers.end(); ++q)
+    for (const auto& q : dataMembers)
     {
-        out << holder + fixKwd((*q)->name());
+        out << holder + fixKwd(q->name());
     }
 
     out << epar << ";";

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -67,9 +67,12 @@ namespace Slice
         TypeContext);
 
     void writeMarshalUnmarshalAllInHolder(IceInternal::Output&, const std::string&, const DataMemberList&, bool, bool);
-    void writeStreamHelpers(::IceInternal::Output&, const ContainedPtr&, DataMemberList, bool);
 
-    // Writes the data members of a class or exceptions slice.
+    // Writes the StreamReader specialization for a struct.
+    void writeStreamReader(IceInternal::Output&, const StructPtr&, DataMemberList);
+
+    // Reads or writes the data members of a class or exceptions slice.
+    void readDataMembers(IceInternal::Output&, DataMemberList);
     void writeDataMembers(IceInternal::Output&, DataMemberList);
 
     void writeIceTuple(::IceInternal::Output&, DataMemberList, TypeContext);

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -69,13 +69,13 @@ namespace Slice
     void writeMarshalUnmarshalAllInHolder(IceInternal::Output&, const std::string&, const DataMemberList&, bool, bool);
 
     // Writes the StreamReader specialization for a struct.
-    void writeStreamReader(IceInternal::Output&, const StructPtr&, DataMemberList);
+    void writeStreamReader(IceInternal::Output&, const StructPtr&, const DataMemberList&);
 
     // Reads or writes the data members of a class or exceptions slice.
-    void readDataMembers(IceInternal::Output&, DataMemberList);
-    void writeDataMembers(IceInternal::Output&, DataMemberList);
+    void readDataMembers(IceInternal::Output&, const DataMemberList&);
+    void writeDataMembers(IceInternal::Output&, const DataMemberList&);
 
-    void writeIceTuple(::IceInternal::Output&, DataMemberList, TypeContext);
+    void writeIceTuple(::IceInternal::Output&, const DataMemberList&, TypeContext);
 
     bool findMetadata(const std::string&, const ClassDeclPtr&, std::string&);
     bool findMetadata(const std::string&, const StringList&, std::string&);

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -66,6 +66,7 @@ namespace Slice
         const std::string&,
         TypeContext);
 
+    // TODO: remove from header file.
     void writeMarshalUnmarshalAllInHolder(IceInternal::Output&, const std::string&, const DataMemberList&, bool, bool);
 
     // Writes the StreamReader specialization for a struct.

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -68,6 +68,10 @@ namespace Slice
 
     void writeMarshalUnmarshalAllInHolder(IceInternal::Output&, const std::string&, const DataMemberList&, bool, bool);
     void writeStreamHelpers(::IceInternal::Output&, const ContainedPtr&, DataMemberList, bool);
+
+    // Writes the data members of a class or exceptions slice.
+    void writeDataMembers(IceInternal::Output&, DataMemberList);
+
     void writeIceTuple(::IceInternal::Output&, DataMemberList, TypeContext);
 
     bool findMetadata(const std::string&, const ClassDeclPtr&, std::string&);

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -2290,7 +2290,7 @@ Slice::Gen::DataDefVisitor::visitExceptionEnd(const ExceptionPtr& p)
     C << nl << "istr->startSlice();";
     if (!dataMembers.empty())
     {
-        C << nl << "::Ice::StreamReader<" << name << ">::read(istr, *this);";
+        readDataMembers(C, dataMembers);
     }
     C << nl << "istr->endSlice();";
     if (base)
@@ -2409,7 +2409,6 @@ Slice::Gen::DataDefVisitor::visitClassDefEnd(const ClassDefPtr& p)
     // Emit data members. Access visibility may be specified by metadata.
     //
     bool inProtected = false;
-    bool generateFriend = false;
     DataMemberList dataMembers = p->dataMembers();
     bool prot = p->hasMetadata("protected");
     bool needSp = true;
@@ -2426,7 +2425,6 @@ Slice::Gen::DataDefVisitor::visitClassDefEnd(const ClassDefPtr& p)
                 inProtected = true;
                 needSp = false;
             }
-            generateFriend = true;
         }
         else
         {
@@ -2461,13 +2459,6 @@ Slice::Gen::DataDefVisitor::visitClassDefEnd(const ClassDefPtr& p)
         inProtected = true;
     }
 
-    if (generateFriend)
-    {
-        H << nl << "template<typename T>";
-        H << nl << "friend struct Ice::StreamReader;";
-        H << sp;
-    }
-
     H << nl << name << "(const " << name << "&) = default;";
     H << sp << nl << _dllMemberExport << "::Ice::ValuePtr _iceCloneImpl() const override;";
     C << sp;
@@ -2500,7 +2491,7 @@ Slice::Gen::DataDefVisitor::visitClassDefEnd(const ClassDefPtr& p)
     C << nl << "istr->startSlice();";
     if (!dataMembers.empty())
     {
-        C << nl << "::Ice::StreamReader<" << name << ">::read(istr, *this);";
+        readDataMembers(C, dataMembers);
     }
     C << nl << "istr->endSlice();";
     if (base)
@@ -3269,22 +3260,8 @@ Slice::Gen::StreamVisitor::visitStructStart(const StructPtr& p)
     H << nl << "static const bool fixedLength = " << (p->isVariableLength() ? "false" : "true") << ";";
     H << eb << ";" << nl;
 
-    writeStreamHelpers(H, p, p->dataMembers(), false);
-
+    writeStreamReader(H, p, p->dataMembers());
     return false;
-}
-
-bool
-Slice::Gen::StreamVisitor::visitClassDefStart(const ClassDefPtr& c)
-{
-    writeStreamHelpers(H, c, c->dataMembers(), c->hasBaseDataMembers());
-    return false;
-}
-
-void
-Slice::Gen::StreamVisitor::visitExceptionEnd(const ExceptionPtr& p)
-{
-    writeStreamHelpers(H, p, p->dataMembers(), p->hasBaseDataMembers());
 }
 
 void

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -2275,7 +2275,7 @@ Slice::Gen::DataDefVisitor::visitExceptionEnd(const ExceptionPtr& p)
     C << nl << "ostr->startSlice(ice_staticId(), -1, " << (base ? "false" : "true") << ");";
     if (!dataMembers.empty())
     {
-        C << nl << "::Ice::StreamWriter<" << name << ">::write(ostr, *this);";
+        writeDataMembers(C, dataMembers);
     }
     C << nl << "ostr->endSlice();";
     if (base)
@@ -2464,8 +2464,6 @@ Slice::Gen::DataDefVisitor::visitClassDefEnd(const ClassDefPtr& p)
     if (generateFriend)
     {
         H << nl << "template<typename T>";
-        H << nl << "friend struct Ice::StreamWriter;";
-        H << nl << "template<typename T>";
         H << nl << "friend struct Ice::StreamReader;";
         H << sp;
     }
@@ -2487,7 +2485,7 @@ Slice::Gen::DataDefVisitor::visitClassDefEnd(const ClassDefPtr& p)
     C << nl << "ostr->startSlice(ice_staticId(), -1, " << (base ? "false" : "true") << ");";
     if (!dataMembers.empty())
     {
-        C << nl << "::Ice::StreamWriter<" << name << ">::write(ostr, *this);";
+        writeDataMembers(C, dataMembers);
     }
     C << nl << "ostr->endSlice();";
     if (base)

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -185,7 +185,7 @@ namespace Slice
             std::list<TypeContext> _useWstringHist;
         };
 
-        // Generates internal StreamHelper template specializations for enums, structs, classes and exceptions.
+        // Generates internal StreamHelper template specializations for enums and structs.
         class StreamVisitor final : public ParserVisitor
         {
         public:
@@ -195,8 +195,6 @@ namespace Slice
             bool visitModuleStart(const ModulePtr&) final;
             void visitModuleEnd(const ModulePtr&) final;
             bool visitStructStart(const StructPtr&) final;
-            bool visitClassDefStart(const ClassDefPtr&) final;
-            void visitExceptionEnd(const ExceptionPtr&) final;
             void visitEnum(const EnumPtr&) final;
 
         private:


### PR DESCRIPTION
Prior to this PR, we used StreamReader and StreamWriter template specializations to marshal/unmarshal structs, classes and exceptions.

After this PR, we only use StreamReader specializations for structs. We don't need StreamWriter for structs since the marshaling for structs is always the same, namely:
```cpp
static void write(OutputStream* stream, const T& v) { stream->writeAll(v.ice_tuple());  }
```

The StreamReader/StreamWriter were not needed for classes & exceptions, and on the contrary made the generated code more much complicated with extra generated code in header files and the need for friend template classes when generating protected fields. 