### PR TITLE
Disable relational operators for classes and exceptions C++

### DIFF
--- a/cpp/include/Ice/Comparable.h
+++ b/cpp/include/Ice/Comparable.h
@@ -117,84 +117,96 @@ namespace Ice
     namespace Tuple
     {
         /**
-         * Relational operator for generated structs and classes.
+         * Relational operator for generated structs.
          * @param lhs The left-hand side.
          * @param rhs The right-hand side.
          * @return True if the left-hand side compares less than the right-hand side, false otherwise.
          */
         template<
             class C,
-            std::enable_if_t<std::is_member_function_pointer<decltype(&C::ice_tuple)>::value, bool> = true>
+            std::enable_if_t<
+                std::is_member_function_pointer<decltype(&C::ice_tuple)>::value && !std::is_polymorphic_v<C>,
+                bool> = true>
         bool operator<(const C& lhs, const C& rhs)
         {
             return lhs.ice_tuple() < rhs.ice_tuple();
         }
 
         /**
-         * Relational operator for generated structs and classes.
+         * Relational operator for generated structs.
          * @param lhs The left-hand side.
          * @param rhs The right-hand side.
          * @return True if the left-hand side compares less than or equal to the right-hand side, false otherwise.
          */
         template<
             class C,
-            std::enable_if_t<std::is_member_function_pointer<decltype(&C::ice_tuple)>::value, bool> = true>
+            std::enable_if_t<
+                std::is_member_function_pointer<decltype(&C::ice_tuple)>::value && !std::is_polymorphic_v<C>,
+                bool> = true>
         bool operator<=(const C& lhs, const C& rhs)
         {
             return lhs.ice_tuple() <= rhs.ice_tuple();
         }
 
         /**
-         * Relational operator for generated structs and classes.
+         * Relational operator for generated structs.
          * @param lhs The left-hand side.
          * @param rhs The right-hand side.
          * @return True if the left-hand side compares greater than the right-hand side, false otherwise.
          */
         template<
             class C,
-            std::enable_if_t<std::is_member_function_pointer<decltype(&C::ice_tuple)>::value, bool> = true>
+            std::enable_if_t<
+                std::is_member_function_pointer<decltype(&C::ice_tuple)>::value && !std::is_polymorphic_v<C>,
+                bool> = true>
         bool operator>(const C& lhs, const C& rhs)
         {
             return lhs.ice_tuple() > rhs.ice_tuple();
         }
 
         /**
-         * Relational operator for generated structs and classes.
+         * Relational operator for generated structs.
          * @param lhs The left-hand side.
          * @param rhs The right-hand side.
          * @return True if the left-hand side compares greater than or equal to the right-hand side, false otherwise.
          */
         template<
             class C,
-            std::enable_if_t<std::is_member_function_pointer<decltype(&C::ice_tuple)>::value, bool> = true>
+            std::enable_if_t<
+                std::is_member_function_pointer<decltype(&C::ice_tuple)>::value && !std::is_polymorphic_v<C>,
+                bool> = true>
         bool operator>=(const C& lhs, const C& rhs)
         {
             return lhs.ice_tuple() >= rhs.ice_tuple();
         }
 
         /**
-         * Relational operator for generated structs and classes.
+         * Relational operator for generated structs.
          * @param lhs The left-hand side.
          * @param rhs The right-hand side.
          * @return True if the left-hand side compares equal to the right-hand side, false otherwise.
          */
         template<
             class C,
-            std::enable_if_t<std::is_member_function_pointer<decltype(&C::ice_tuple)>::value, bool> = true>
+            std::enable_if_t<
+                std::is_member_function_pointer<decltype(&C::ice_tuple)>::value && !std::is_polymorphic_v<C>,
+                bool> = true>
         bool operator==(const C& lhs, const C& rhs)
         {
             return lhs.ice_tuple() == rhs.ice_tuple();
         }
 
         /**
-         * Relational operator for generated structs and classes.
+         * Relational operator for generated structs.
          * @param lhs The left-hand side.
          * @param rhs The right-hand side.
          * @return True if the left-hand side is not equal to the right-hand side, false otherwise.
          */
         template<
             class C,
-            std::enable_if_t<std::is_member_function_pointer<decltype(&C::ice_tuple)>::value, bool> = true>
+            std::enable_if_t<
+                std::is_member_function_pointer<decltype(&C::ice_tuple)>::value && !std::is_polymorphic_v<C>,
+                bool> = true>
         bool operator!=(const C& lhs, const C& rhs)
         {
             return lhs.ice_tuple() != rhs.ice_tuple();

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -2000,16 +2000,20 @@ Slice::Gen::DataDefVisitor::visitModuleStart(const ModulePtr& p)
 }
 
 void
-Slice::Gen::DataDefVisitor::visitModuleEnd(const ModulePtr&)
+Slice::Gen::DataDefVisitor::visitModuleEnd(const ModulePtr& p)
 {
-    // Always generated when this module contains a struct, class, or exception.
-    H << sp;
-    H << nl << "using Ice::Tuple::operator<;";
-    H << nl << "using Ice::Tuple::operator<=;";
-    H << nl << "using Ice::Tuple::operator>;";
-    H << nl << "using Ice::Tuple::operator>=;";
-    H << nl << "using Ice::Tuple::operator==;";
-    H << nl << "using Ice::Tuple::operator!=;";
+    if (p->contains<Struct>())
+    {
+        // Bring in relational operators for structs.
+        H << sp;
+        H << nl << "using Ice::Tuple::operator<;";
+        H << nl << "using Ice::Tuple::operator<=;";
+        H << nl << "using Ice::Tuple::operator>;";
+        H << nl << "using Ice::Tuple::operator>=;";
+        H << nl << "using Ice::Tuple::operator==;";
+        H << nl << "using Ice::Tuple::operator!=;";
+    }
+
     H << sp << nl << '}';
     _useWstring = resetUseWstring(_useWstringHist);
 }

--- a/cpp/test/Ice/objects/AllTests.cpp
+++ b/cpp/test/Ice/objects/AllTests.cpp
@@ -66,17 +66,13 @@ allTests(Test::TestHelper* helper)
     test(ba2->theS.str == "hello");
     test(ba2->str == "hi");
 
-    test(*ba1 < *ba2);
-    test(*ba2 > *ba1);
-    test(*ba1 != *ba2);
+    auto [s2, str2] = ba2->ice_tuple();
+    test(s2 == s);
+    test(str2 == "hi");
 
     ba1 = ba2->ice_clone();
     test(ba1->theS.str == "hello");
     test(ba1->str == "hi");
-
-    test(*ba1 == *ba2);
-    test(*ba1 >= *ba2);
-    test(*ba1 <= *ba2);
 
     BasePtr bp1 = make_shared<Base>();
     bp1 = ba2->ice_clone();

--- a/cpp/test/Ice/scope/AllTests.cpp
+++ b/cpp/test/Ice/scope/AllTests.cpp
@@ -105,24 +105,24 @@ allTests(Test::TestHelper* helper)
         Test::CPtr c1 = make_shared<Test::C>(s1);
         {
             auto result = i->opCAsync(c1).get();
-            test(Ice::targetEqualTo(std::get<0>(result), c1));
-            test(Ice::targetEqualTo(std::get<1>(result), c1));
+            test(std::get<0>(result)->ice_tuple() == c1->ice_tuple());
+            test(std::get<1>(result)->ice_tuple() == c1->ice_tuple());
         }
 
         Test::CSeq cseq1;
         cseq1.push_back(c1);
         {
             auto result = i->opCSeqAsync(cseq1).get();
-            test(Ice::targetEqualTo(std::get<0>(result)[0], c1));
-            test(Ice::targetEqualTo(std::get<1>(result)[0], c1));
+            test(std::get<0>(result)[0]->ice_tuple() == c1->ice_tuple());
+            test(std::get<1>(result)[0]->ice_tuple() == c1->ice_tuple());
         }
 
         Test::CMap cmap1;
         cmap1["a"] = c1;
         {
             auto result = i->opCMapAsync(cmap1).get();
-            test(Ice::targetEqualTo(std::get<0>(result)["a"], c1));
-            test(Ice::targetEqualTo(std::get<1>(result)["a"], c1));
+            test(std::get<0>(result)["a"]->ice_tuple() == c1->ice_tuple());
+            test(std::get<1>(result)["a"]->ice_tuple() == c1->ice_tuple());
         }
 
         {
@@ -235,8 +235,8 @@ allTests(Test::TestHelper* helper)
                 c1,
                 [&p, &c1](Test::CPtr c2, Test::CPtr c3)
                 {
-                    test(Ice::targetEqualTo(c2, c1));
-                    test(Ice::targetEqualTo(c3, c1));
+                    test(c2->ice_tuple() == c1->ice_tuple());
+                    test(c3->ice_tuple() == c1->ice_tuple());
                     p.set_value();
                 },
                 [&p](exception_ptr e) { p.set_exception(e); });
@@ -261,8 +261,8 @@ allTests(Test::TestHelper* helper)
                 cseq1,
                 [&p, c1](Test::CSeq c2, Test::CSeq c3)
                 {
-                    test(Ice::targetEqualTo(c2[0], c1));
-                    test(Ice::targetEqualTo(c3[0], c1));
+                    test(c2[0]->ice_tuple() == c1->ice_tuple());
+                    test((c3[0]->ice_tuple() == c1->ice_tuple()));
                     p.set_value();
                 },
                 [&p](exception_ptr e) { p.set_exception(e); });
@@ -287,8 +287,8 @@ allTests(Test::TestHelper* helper)
                 cmap1,
                 [&p, c1](Test::CMap c2, Test::CMap c3)
                 {
-                    test(Ice::targetEqualTo(c2["a"], c1));
-                    test(Ice::targetEqualTo(c3["a"], c1));
+                    test(c2["a"]->ice_tuple() == c1->ice_tuple());
+                    test((c3["a"]->ice_tuple() == c1->ice_tuple()));
                     p.set_value();
                 },
                 [&p](exception_ptr e) { p.set_exception(e); });
@@ -454,24 +454,24 @@ allTests(Test::TestHelper* helper)
         Test::Inner::Inner2::CPtr c1 = make_shared<Test::Inner::Inner2::C>(s1);
         {
             auto result = i->opCAsync(c1).get();
-            test(Ice::targetEqualTo(std::get<0>(result), c1));
-            test(Ice::targetEqualTo(std::get<1>(result), c1));
+            test(std::get<0>(result)->ice_tuple() == c1->ice_tuple());
+            test(std::get<1>(result)->ice_tuple() == c1->ice_tuple());
         }
 
         Test::Inner::Inner2::CSeq cseq1;
         cseq1.push_back(c1);
         {
             auto result = i->opCSeqAsync(cseq1).get();
-            test(Ice::targetEqualTo(std::get<0>(result)[0], c1));
-            test(Ice::targetEqualTo(std::get<1>(result)[0], c1));
+            test(std::get<0>(result)[0]->ice_tuple() == c1->ice_tuple());
+            test(std::get<1>(result)[0]->ice_tuple() == c1->ice_tuple());
         }
 
         Test::Inner::Inner2::CMap cmap1;
         cmap1["a"] = c1;
         {
             auto result = i->opCMapAsync(cmap1).get();
-            test(Ice::targetEqualTo(std::get<0>(result)["a"], c1));
-            test(Ice::targetEqualTo(std::get<1>(result)["a"], c1));
+            test(std::get<0>(result)["a"]->ice_tuple() == c1->ice_tuple());
+            test(std::get<1>(result)["a"]->ice_tuple() == c1->ice_tuple());
         }
     }
 
@@ -567,8 +567,8 @@ allTests(Test::TestHelper* helper)
                 c1,
                 [&p, &c1](shared_ptr<Test::Inner::Inner2::C> c2, shared_ptr<Test::Inner::Inner2::C> c3)
                 {
-                    test(Ice::targetEqualTo(c2, c1));
-                    test(Ice::targetEqualTo(c3, c1));
+                    test(c2->ice_tuple() == c1->ice_tuple());
+                    test((c3->ice_tuple() == c1->ice_tuple()));
                     p.set_value();
                 },
                 [&p](exception_ptr e) { p.set_exception(e); });
@@ -593,8 +593,8 @@ allTests(Test::TestHelper* helper)
                 cseq1,
                 [&p, c1](Test::Inner::Inner2::CSeq c2, Test::Inner::Inner2::CSeq c3)
                 {
-                    test(Ice::targetEqualTo(c2[0], c1));
-                    test(Ice::targetEqualTo(c3[0], c1));
+                    test(c2[0]->ice_tuple() == c1->ice_tuple());
+                    test((c3[0]->ice_tuple() == c1->ice_tuple()));
                     p.set_value();
                 },
                 [&p](exception_ptr e) { p.set_exception(e); });
@@ -619,8 +619,8 @@ allTests(Test::TestHelper* helper)
                 cmap1,
                 [&p, c1](Test::Inner::Inner2::CMap c2, Test::Inner::Inner2::CMap c3)
                 {
-                    test(Ice::targetEqualTo(c2["a"], c1));
-                    test(Ice::targetEqualTo(c3["a"], c1));
+                    test(c2["a"]->ice_tuple() == c1->ice_tuple());
+                    test((c3["a"]->ice_tuple() == c1->ice_tuple()));
                     p.set_value();
                 },
                 [&p](exception_ptr e) { p.set_exception(e); });
@@ -715,24 +715,24 @@ allTests(Test::TestHelper* helper)
         Test::Inner::Inner2::CPtr c1 = make_shared<Test::Inner::Inner2::C>(s1);
         {
             auto result = i->opCAsync(c1).get();
-            test(Ice::targetEqualTo(std::get<0>(result), c1));
-            test(Ice::targetEqualTo(std::get<1>(result), c1));
+            test(std::get<0>(result)->ice_tuple() == c1->ice_tuple());
+            test(std::get<1>(result)->ice_tuple() == c1->ice_tuple());
         }
 
         Test::Inner::Inner2::CSeq cseq1;
         cseq1.push_back(c1);
         {
             auto result = i->opCSeqAsync(cseq1).get();
-            test(Ice::targetEqualTo(std::get<0>(result)[0], c1));
-            test(Ice::targetEqualTo(std::get<1>(result)[0], c1));
+            test(std::get<0>(result)[0]->ice_tuple() == c1->ice_tuple());
+            test(std::get<1>(result)[0]->ice_tuple() == c1->ice_tuple());
         }
 
         Test::Inner::Inner2::CMap cmap1;
         cmap1["a"] = c1;
         {
             auto result = i->opCMapAsync(cmap1).get();
-            test(Ice::targetEqualTo(std::get<0>(result)["a"], c1));
-            test(Ice::targetEqualTo(std::get<1>(result)["a"], c1));
+            test(std::get<0>(result)["a"]->ice_tuple() == c1->ice_tuple());
+            test(std::get<1>(result)["a"]->ice_tuple() == c1->ice_tuple());
         }
     }
 
@@ -828,8 +828,8 @@ allTests(Test::TestHelper* helper)
                 c1,
                 [&p, &c1](shared_ptr<Test::Inner::Inner2::C> c2, shared_ptr<Test::Inner::Inner2::C> c3)
                 {
-                    test(Ice::targetEqualTo(c2, c1));
-                    test(Ice::targetEqualTo(c3, c1));
+                    test(c2->ice_tuple() == c1->ice_tuple());
+                    test(c3->ice_tuple() == c1->ice_tuple());
                     p.set_value();
                 },
                 [&p](exception_ptr e) { p.set_exception(e); });
@@ -854,8 +854,8 @@ allTests(Test::TestHelper* helper)
                 cseq1,
                 [&p, c1](Test::Inner::Inner2::CSeq c2, Test::Inner::Inner2::CSeq c3)
                 {
-                    test(Ice::targetEqualTo(c2[0], c1));
-                    test(Ice::targetEqualTo(c3[0], c1));
+                    test(c2[0]->ice_tuple() == c1->ice_tuple());
+                    test(c3[0]->ice_tuple() == c1->ice_tuple());
                     p.set_value();
                 },
                 [&p](exception_ptr e) { p.set_exception(e); });
@@ -880,8 +880,8 @@ allTests(Test::TestHelper* helper)
                 cmap1,
                 [&p, c1](Test::Inner::Inner2::CMap c2, Test::Inner::Inner2::CMap c3)
                 {
-                    test(Ice::targetEqualTo(c2["a"], c1));
-                    test(Ice::targetEqualTo(c3["a"], c1));
+                    test(c2["a"]->ice_tuple() == c1->ice_tuple());
+                    test(c3["a"]->ice_tuple() == c1->ice_tuple());
                     p.set_value();
                 },
                 [&p](exception_ptr e) { p.set_exception(e); });
@@ -976,24 +976,24 @@ allTests(Test::TestHelper* helper)
         Test::CPtr c1 = make_shared<Test::C>(s1);
         {
             auto result = i->opCAsync(c1).get();
-            test(Ice::targetEqualTo(std::get<0>(result), c1));
-            test(Ice::targetEqualTo(std::get<1>(result), c1));
+            test(std::get<0>(result)->ice_tuple() == c1->ice_tuple());
+            test(std::get<1>(result)->ice_tuple() == c1->ice_tuple());
         }
 
         Test::CSeq cseq1;
         cseq1.push_back(c1);
         {
             auto result = i->opCSeqAsync(cseq1).get();
-            test(Ice::targetEqualTo(std::get<0>(result)[0], c1));
-            test(Ice::targetEqualTo(std::get<1>(result)[0], c1));
+            test(std::get<0>(result)[0]->ice_tuple() == c1->ice_tuple());
+            test(std::get<1>(result)[0]->ice_tuple() == c1->ice_tuple());
         }
 
         Test::CMap cmap1;
         cmap1["a"] = c1;
         {
             auto result = i->opCMapAsync(cmap1).get();
-            test(Ice::targetEqualTo(std::get<0>(result)["a"], c1));
-            test(Ice::targetEqualTo(std::get<1>(result)["a"], c1));
+            test(std::get<0>(result)["a"]->ice_tuple() == c1->ice_tuple());
+            test(std::get<1>(result)["a"]->ice_tuple() == c1->ice_tuple());
         }
     }
 
@@ -1089,8 +1089,8 @@ allTests(Test::TestHelper* helper)
                 c1,
                 [&p, &c1](shared_ptr<Test::C> c2, shared_ptr<Test::C> c3)
                 {
-                    test(Ice::targetEqualTo(c2, c1));
-                    test(Ice::targetEqualTo(c3, c1));
+                    test(c2->ice_tuple() == c1->ice_tuple());
+                    test(c3->ice_tuple() == c1->ice_tuple());
                     p.set_value();
                 },
                 [&p](exception_ptr e) { p.set_exception(e); });
@@ -1115,8 +1115,8 @@ allTests(Test::TestHelper* helper)
                 cseq1,
                 [&p, c1](Test::CSeq c2, Test::CSeq c3)
                 {
-                    test(Ice::targetEqualTo(c2[0], c1));
-                    test(Ice::targetEqualTo(c3[0], c1));
+                    test(c2[0]->ice_tuple() == c1->ice_tuple());
+                    test(c3[0]->ice_tuple() == c1->ice_tuple());
                     p.set_value();
                 },
                 [&p](exception_ptr e) { p.set_exception(e); });
@@ -1141,8 +1141,8 @@ allTests(Test::TestHelper* helper)
                 cmap1,
                 [&p, c1](Test::CMap c2, Test::CMap c3)
                 {
-                    test(Ice::targetEqualTo(c2["a"], c1));
-                    test(Ice::targetEqualTo(c3["a"], c1));
+                    test(c2["a"]->ice_tuple() == c1->ice_tuple());
+                    test(c3["a"]->ice_tuple() == c1->ice_tuple());
                     p.set_value();
                 },
                 [&p](exception_ptr e) { p.set_exception(e); });


### PR DESCRIPTION
This PR disables the relational operators for classes and exceptions in C++.

Prior to this PR, they were enabled and implemented using ice_tuple, we could lead to unexpected results, in particular two classes with different types could compare equal (since the comparison slices to the common base type).

 