### PR TITLE
Disallow destroying timer from timer task (C++)

### DIFF
--- a/cpp/include/Ice/Timer.h
+++ b/cpp/include/Ice/Timer.h
@@ -40,8 +40,7 @@ namespace Ice
         Timer();
         virtual ~Timer() = default;
 
-        // Destroy the timer and detach its execution thread if the calling thread
-        // is the timer thread, join the timer execution thread otherwise.
+        // Destroy the timer and join the timer execution thread. Must not be called from a timer task.
         void destroy();
 
         // Schedule task for execution after a given delay.

--- a/cpp/src/Ice/Timer.cpp
+++ b/cpp/src/Ice/Timer.cpp
@@ -20,6 +20,10 @@ Timer::Timer() : _destroyed(false), _wakeUpTime(chrono::steady_clock::time_point
 void
 Timer::destroy()
 {
+    if (std::this_thread::get_id() == _worker.get_id())
+    {
+        throw std::runtime_error("a timer task cannot destroy the timer");
+    }
     {
         std::lock_guard lock(_mutex);
         if (_destroyed)
@@ -31,15 +35,7 @@ Timer::destroy()
         _tokens.clear();
         _condition.notify_one();
     }
-
-    if (std::this_thread::get_id() == _worker.get_id())
-    {
-        _worker.detach();
-    }
-    else if (_worker.joinable())
-    {
-        _worker.join();
-    }
+    _worker.join();
 }
 
 bool

--- a/cpp/test/IceUtil/timer/Client.cpp
+++ b/cpp/test/IceUtil/timer/Client.cpp
@@ -101,7 +101,15 @@ public:
     virtual void runTimerTask()
     {
         lock_guard lock(_mutex);
-        _timer->destroy();
+        try
+        {
+            _timer->destroy();
+            test(false);
+        }
+        catch (const std::runtime_error&)
+        {
+            // Expected.
+        }
         _run = true;
         _condition.notify_one();
     }
@@ -233,6 +241,7 @@ Client::run(int, char*[])
             {
                 // Expected;
             }
+            timer->destroy();
         }
         {
             auto timer = make_shared<Ice::Timer>();


### PR DESCRIPTION
This PR disallow destroying the timer from a timer task.

Doing so is not correct, because we detach the timer worker thread, and this thread can then loop back and use the timer after it's been destructed. (I was able to produce a "destroy busy mutex" failure by adding a sleep in Timer.cpp).

This is an attempt at fixing #2695. However, I could not reproduce this failure, and it's unclear how the "unlock unowned mutex" can happen as we never call unlock in this code. 

Fixes #2695.