### PR TITLE
Fix sendHeartbeat in C++, C# and Java

### DIFF
--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -2392,7 +2392,7 @@ Ice::ConnectionI::sendHeartbeat() noexcept
     assert(!_endpoint->datagram());
 
     lock_guard lock(_mutex);
-    if (_state == StateActive || _state == StateHolding)
+    if (_state == StateActive || _state == StateHolding || _state == StateClosing)
     {
         // We check if the connection has become inactive.
         if (_inactivityTimerTask &&           // null when the inactivity timeout is infinite
@@ -2832,10 +2832,7 @@ Ice::ConnectionI::sendNextMessages(vector<OutgoingMessage>& callbacks)
             // If the message was sent right away, loop to send the next queued message.
         }
 
-        //
-        // If all the messages were sent and we are in the closing state, we schedule the close timeout to wait for the
-        // peer to close the connection.
-        //
+        // Once the CloseConnection message is sent, we transition to the StateClosingPending state.
         if (_state == StateClosing && _shutdownInitiated)
         {
             setState(StateClosingPending);

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1496,7 +1496,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
 
         lock (_mutex)
         {
-            if (_state == StateActive || _state == StateHolding)
+            if (_state == StateActive || _state == StateHolding || _state == StateClosing)
             {
                 // We check if the connection has become inactive.
                 if (
@@ -2100,10 +2100,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                 // If the message was sent right away, loop to send the next queued message.
             }
 
-            //
-            // If all the messages were sent and we are in the closing state, we schedule the close timeout to wait for
-            // the peer to close the connection.
-            //
+            // Once the CloseConnection message is sent, we transition to the StateClosingPending state.
             if (_state == StateClosing && _shutdownInitiated)
             {
                 setState(StateClosingPending);

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -1217,7 +1217,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
             // write in turns creates a read on the peer, and resets the peer's idle check timer.
             // When _sendStream is not empty, there is already an outstanding write, so we don't
             // need to send a heartbeat. It's possible the first message of _sendStreams was
-            // already sent but  not yet removed from _sendStreams: it means the last write
+            // already sent but not yet removed from _sendStreams: it means the last write
             // occurred very recently, which is good enough with respect to the idle check.
             // As a result of this optimization, the only possible heartbeat in _sendStreams
             // is the first _sendStreams message.


### PR DESCRIPTION
This PR fixes #2868 in C++, C# and Java.

The JS code is different with no StateClosingPending state, so fixing JS is not as simple.