### PR TITLE
Simplify ObjectAdapter in JS

### DIFF
--- a/js/src/Ice/Communicator.d.ts
+++ b/js/src/Ice/Communicator.d.ts
@@ -48,7 +48,6 @@ declare module "ice" {
              *
              * @see {@link shutdown}
              * @see {@link destroy}
-             * @see {@link ObjectAdapter#waitForDeactivate}
              */
             waitForShutdown(): Promise<void>;
 

--- a/js/src/Ice/ObjectAdapter.d.ts
+++ b/js/src/Ice/ObjectAdapter.d.ts
@@ -31,86 +31,20 @@ declare module "ice" {
             getCommunicator(): Ice.Communicator;
 
             /**
-             * Activate all object adapter's endpoints.
+             * Deactivates this object adapter.
              *
-             * After activation, the object adapter can dispatch requests received through its endpoints.
-             *
-             * @returns The asynchronous result object for the invocation.
-             *
-             * @see {@link ObjectAdapter#hold}
-             * @see {@link ObjectAdapter#deactivate}
-             */
-            activate(): Promise<void>;
-
-            /**
-             * Temporarily hold receiving and dispatching requests.
-             *
-             * The object adapter can be reactivated with the {@link ObjectAdapter#activate} operation. Holding is not
-             * immediate, i.e., after {@link ObjectAdapter#hold} returns, the object adapter might still be active for
-             * some time. You can use {@link ObjectAdapter#waitForHold} to wait until holding is complete.
-             *
-             * @see {@link ObjectAdapter#activate}
-             * @see {@link ObjectAdapter#deactivate}
-             * @see {@link ObjectAdapter#waitForHold}
-             */
-            hold(): void;
-
-            /**
-             * Wait until the object adapter holds requests.
-             *
-             * Calling {@link ObjectAdapter#hold} initiates holding of requests, and {@link ObjectAdapter#waitForHold}
-             * only returns when holding of requests has been completed.
-             *
-             * @returns The asynchronous result object for the invocation.
-             *
-             * @see {@link ObjectAdapter#hold}
-             * @see {@link ObjectAdapter#waitForDeactivate}
-             * @see {@link Communicator#waitForShutdown}
-             */
-            waitForHold(): Promise<void>;
-
-            /**
-             * Deactivate all endpoints that belong to this object adapter.
-             *
-             * After deactivation, the object adapter stops receiving requests through its endpoints. Object adapters
-             * that have been deactivated must not be reactivated again, and cannot be used otherwise. Attempts to use
-             * a deactivated object adapter raise {@link ObjectAdapterDeactivatedException} however, attempts to
-             * deactivate an already deactivated object adapter are ignored and do nothing.
+             * After deactivation, the object adapter is disconnected from any outgoing connection.
              *
              * Once deactivated, it is possible to destroy the adapter to clean up resources and then create and
              * activate a new adapter with the same name.
              *
              * After {@link ObjectAdapter#deactivate} returns, no new requests are processed by the object adapter.
              * However, requests that have been started before {@link ObjectAdapter#deactivate} was called might still
-             * be active. You can use {@link ObjectAdapter#waitForDeactivate} to wait for the completion of all requests
-             * for this object adapter.
+             * be active.
              *
-             * @see {@link ObjectAdapter#activate}
-             * @see {@link ObjectAdapter#hold}
-             * @see {@link ObjectAdapter#waitForDeactivate}
              * @see {@link Communicator#shutdown}
              */
             deactivate(): void;
-
-            /**
-             * Wait until the object adapter has deactivated.
-             *
-             * @returns The asynchronous result object for the invocation.
-             *
-             * @see {@link ObjectAdapter#deactivate}
-             * @see {@link ObjectAdapter#waitForHold}
-             * @see {@link Communicator#waitForShutdown}
-             */
-            waitForDeactivate(): Promise<void>;
-
-            /**
-             * Check whether object adapter has been deactivated.
-             *
-             * @returns Whether adapter has been deactivated.
-             *
-             * @see {@link Communicator#shutdown}
-             */
-            isDeactivated(): boolean;
 
             /**
              * Destroys the object adapter and cleans up all resources held by the object adapter.
@@ -122,7 +56,6 @@ declare module "ice" {
              * @returns The asynchronous result object for the invocation.
              *
              * @see {@link ObjectAdapter#deactivate}
-             * @see {@link ObjectAdapter#waitForDeactivate}
              * @see {@link Communicator#destroy}
              */
             destroy(): Promise<void>;

--- a/js/src/Ice/ObjectAdapter.js
+++ b/js/src/Ice/ObjectAdapter.js
@@ -217,7 +217,7 @@ export class ObjectAdapter {
 
     deactivate() {
         if (this._state < StateDeactivated) {
-            this.setState(StateDeactivated);
+            this._state = StateDeactivated;
             this._instance.outgoingConnectionFactory().removeAdapter(this);
         }
     }
@@ -225,7 +225,7 @@ export class ObjectAdapter {
     destroy() {
         this.deactivate();
         if (this._state < StateDestroyed) {
-            this.setState(StateDestroyed);
+            this._state = StateDestroyed;
             this._servantManager.destroy();
             this._objectAdapterFactory.removeObjectAdapter(this);
             this._publishedEndpoints = [];
@@ -530,9 +530,5 @@ export class ObjectAdapter {
         }
 
         return noProps;
-    }
-
-    setState(state) {
-        this._state = state;
     }
 }

--- a/js/src/Ice/ObjectAdapterFactory.js
+++ b/js/src/Ice/ObjectAdapterFactory.js
@@ -24,15 +24,13 @@ export class ObjectAdapterFactory {
         if (this._instance !== null) {
             this._instance = null;
             this._communicator = null;
-            this._adapters.map(adapter => adapter.deactivate());
+            this._adapters.map(adapter => adapter.deactivate()); // deactivate is synchronous
             this._shutdownPromise.resolve();
         }
     }
 
     waitForShutdown() {
-        return this._shutdownPromise.then(() =>
-            Promise.all(this._adapters.map(adapter => adapter.waitForDeactivate())),
-        );
+        return this._shutdownPromise;
     }
 
     isShutdown() {

--- a/js/test/Common/ControllerI.js
+++ b/js/test/Common/ControllerI.js
@@ -183,7 +183,6 @@ export async function runController(clientOutput, serverOutput, scripts) {
         const adapter = await comm.createObjectAdapter("");
         const ident = new Ice.Identity("ProcessController", "Browser");
         const processController = adapter.add(new ProcessControllerI(out, serverOut, worker, scripts), ident);
-        adapter.activate();
         registerProcessController(adapter, registry, processController);
     } catch (ex) {
         out.writeLine("unexpected exception while creating controller:\n" + ex.toString());

--- a/js/test/Glacier2/router/Client.ts
+++ b/js/test/Glacier2/router/Client.ts
@@ -125,7 +125,6 @@ export class Client extends TestHelper {
 
         out.write("creating and activating callback receiver adapter... ");
         const adapter = await communicator.createObjectAdapterWithRouter("CallbackReceiverAdapter", router);
-        await adapter.activate();
         out.writeLine("ok");
 
         out.write("getting category from router... ");

--- a/js/test/Ice/adapterDeactivation/Client.ts
+++ b/js/test/Ice/adapterDeactivation/Client.ts
@@ -128,42 +128,6 @@ export class Client extends TestHelper {
         await obj!.deactivate();
         out.writeLine("ok");
 
-        out.write("testing adapter states... ");
-        {
-            const adpt = await communicator.createObjectAdapter("");
-            test(!adpt.isDeactivated());
-            await adpt.activate();
-            test(!adpt.isDeactivated());
-
-            let isHolding = false;
-            let p1 = adpt.waitForHold().then(() => {
-                isHolding = true;
-            });
-            test(!isHolding);
-            adpt.hold();
-            await adpt.waitForHold();
-            await p1;
-            test(isHolding);
-
-            isHolding = false;
-            p1 = adpt.waitForHold().then(() => {
-                isHolding = true;
-            });
-
-            let isDeactivated = false;
-            const p2 = adpt.waitForDeactivate().then(() => {
-                isDeactivated = true;
-            });
-            test(!isDeactivated);
-            await adpt.deactivate();
-            await adpt.waitForDeactivate();
-            await Promise.all([p1, p2]);
-            test(isDeactivated && isHolding);
-            test(adpt.isDeactivated());
-            await adpt.destroy();
-        }
-        out.writeLine("ok");
-
         out.write("testing whether server is gone... ");
         try {
             await obj!.ice_invocationTimeout(100).ice_ping(); // Use timeout to speed up testing on Windows

--- a/js/test/Ice/middleware/Client.ts
+++ b/js/test/Ice/middleware/Client.ts
@@ -14,6 +14,7 @@ export class Client extends TestHelper {
             [communicator] = this.initialize(properties);
 
             let prx = new Test.MyObjectPrx(communicator, `test: ${this.getTestEndpoint()}`);
+            await prx.getName();
             await prx.shutdown();
         } finally {
             if (communicator) {

--- a/js/test/Ice/middleware/Server.ts
+++ b/js/test/Ice/middleware/Server.ts
@@ -10,10 +10,14 @@ const test = TestHelper.test;
 
 class Middleware extends Ice.Object {
     async dispatch(request: Ice.IncomingRequest): Promise<Ice.OutgoingResponse> {
-        this._inLog.push(this._name);
-        var response = await this._next.dispatch(request);
-        this._outLog.push(this._name);
-        return response;
+        if (request.current.operation === "shutdown") {
+            return this._next.dispatch(request);
+        } else {
+            this._inLog.push(this._name);
+            var response = await this._next.dispatch(request);
+            this._outLog.push(this._name);
+            return response;
+        }
     }
 
     constructor(next: Ice.Object, name: string, inLog: string[], outLog: string[]) {
@@ -75,6 +79,7 @@ export class Server extends TestHelper {
             test(inLog[1] === "B");
             test(inLog[2] === "C");
 
+            out.write("outLog.length = " + outLog.length + "\n");
             test(outLog.length === 3);
             test(outLog[0] === "C");
             test(outLog[1] === "B");

--- a/js/test/Ice/middleware/Server.ts
+++ b/js/test/Ice/middleware/Server.ts
@@ -79,7 +79,6 @@ export class Server extends TestHelper {
             test(inLog[1] === "B");
             test(inLog[2] === "C");
 
-            out.write("outLog.length = " + outLog.length + "\n");
             test(outLog.length === 3);
             test(outLog[0] === "C");
             test(outLog[1] === "B");


### PR DESCRIPTION
This PR simplifies ObjectAdapter in JS by removing several methods:

- activate
You never need to activate an OA in JS since it can't accept connections. An OS in JS can only be associated with an outgoing connection.

- hold / waitForHold
hold has no effect on outgoing connections (in all languages)

- waitForDeactivate / isDeactivated
these are very uncommon methods, and not all that useful in JS since OA.deactivate is synchronous
