### PR TITLE
Add delay after closing WS connection

### DIFF
--- a/cpp/test/Ice/maxConnections/AllTests.cpp
+++ b/cpp/test/Ice/maxConnections/AllTests.cpp
@@ -13,7 +13,7 @@ using namespace Test;
 
 // Verify that we can create connectionCount connections and send a ping on each connection.
 void
-testCreateConnections(TestIntfPrx p, int connectionCount)
+testCreateConnections(TestIntfPrx p, int connectionCount, function<void()> postCloseDelay)
 {
     cout << "testing the creation of " << connectionCount << " connections... " << flush;
     vector<ConnectionPtr> connectionList;
@@ -29,12 +29,18 @@ testCreateConnections(TestIntfPrx p, int connectionCount)
     {
         connection->close().get();
     }
+
+    if (postCloseDelay)
+    {
+        postCloseDelay();
+    }
+
     cout << "ok" << endl;
 }
 
 // Verify that we can create connectionCount connections and send a ping on each connection.
 void
-testCreateConnectionsWithMax(TestIntfPrx p, int max)
+testCreateConnectionsWithMax(TestIntfPrx p, int max, function<void()> postCloseDelay)
 {
     cout << "testing the creation of " << max << " connections with connection lost at " << (max + 1) << "... "
          << flush;
@@ -63,12 +69,18 @@ testCreateConnectionsWithMax(TestIntfPrx p, int max)
     {
         connection->close().get();
     }
+
+    if (postCloseDelay)
+    {
+        postCloseDelay();
+    }
+
     cout << "ok" << endl;
 }
 
 // Verify that we can create max connections, then connection lost, then recover.
 void
-testCreateConnectionsWithMaxAndRecovery(TestIntfPrx p, int max)
+testCreateConnectionsWithMaxAndRecovery(TestIntfPrx p, int max, function<void()> postCloseDelay)
 {
     cout << "testing the creation of " << max << " connections with connection lost at " << (max + 1)
          << " then recovery... " << flush;
@@ -96,6 +108,11 @@ testCreateConnectionsWithMaxAndRecovery(TestIntfPrx p, int max)
     connectionList.front()->close().get();
     connectionList.erase(connectionList.begin());
 
+    if (postCloseDelay)
+    {
+        postCloseDelay();
+    }
+
     // Try again
     try
     {
@@ -114,6 +131,11 @@ testCreateConnectionsWithMaxAndRecovery(TestIntfPrx p, int max)
     {
         connection->close().get();
     }
+
+    if (postCloseDelay)
+    {
+        postCloseDelay();
+    }
     cout << "ok" << endl;
 }
 
@@ -127,9 +149,19 @@ allTests(TestHelper* helper)
     string proxyStringMax10 = "test: " + helper->getTestEndpoint(1);
     TestIntfPrx pMax10(communicator, proxyStringMax10);
 
-    testCreateConnections(p, 100);
-    testCreateConnectionsWithMax(pMax10, 10);
-    testCreateConnectionsWithMaxAndRecovery(pMax10, 10);
+    string transport = helper->getTestProtocol();
+
+    // When the transport is WS or WSS, we need to wait a little bit: the server closes the connection after it
+    // gets a transport frame from the client.
+    function<void()> postCloseDelay;
+    if (transport.find("ws") == 0)
+    {
+        postCloseDelay = []() { this_thread::sleep_for(50ms); };
+    }
+
+    testCreateConnections(p, 100, postCloseDelay);
+    testCreateConnectionsWithMax(pMax10, 10, postCloseDelay);
+    testCreateConnectionsWithMaxAndRecovery(pMax10, 10, postCloseDelay);
 
     p->shutdown();
 }

--- a/cpp/test/Ice/maxConnections/Client.cpp
+++ b/cpp/test/Ice/maxConnections/Client.cpp
@@ -16,7 +16,11 @@ public:
 void
 Client::run(int argc, char** argv)
 {
-    Ice::CommunicatorHolder communicator = initialize(argc, argv);
+    auto properties = createTestProperties(argc, argv);
+    // We disable retries to make the logs clearer and avoid hiding potential issues.
+    properties->setProperty("Ice.RetryIntervals", "-1");
+
+    Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
 
     void allTests(Test::TestHelper*);
     allTests(this);

--- a/csharp/test/Ice/maxConnections/Client.cs
+++ b/csharp/test/Ice/maxConnections/Client.cs
@@ -8,7 +8,11 @@ public class Client : global::Test.TestHelper
 {
     public override async Task runAsync(string[] args)
     {
-        using var communicator = initialize(ref args);
+        Properties properties = createTestProperties(ref args);
+        // We disable retries to make the logs clearer and avoid hiding potential issues.
+        properties.setProperty("Ice.RetryIntervals", "-1");
+
+        using var communicator = initialize(properties);
         await AllTests.allTests(this);
     }
 

--- a/java/test/src/main/java/test/Ice/maxConnections/Client.java
+++ b/java/test/src/main/java/test/Ice/maxConnections/Client.java
@@ -8,6 +8,9 @@ public class Client extends test.TestHelper {
         var properties = createTestProperties(args);
         properties.setProperty("Ice.Package.Test", "test.Ice.maxConnections");
 
+        // We disable retries to make the logs clearer and avoid hiding potential issues.
+        properties.setProperty("Ice.RetryIntervals", "-1");
+
         try (var communicator = initialize(properties)) {
             AllTests.allTests(this);
         }


### PR DESCRIPTION
This PR adds a post-close delay in the maxConnections tests for ws[s] connections. Implemented in C++, C# and Java.

Fixes #2881.