### PR TITLE
Update ObjectAdapter deactivate semantics in C++

### DIFF
--- a/cpp/include/Ice/Communicator.h
+++ b/cpp/include/Ice/Communicator.h
@@ -210,6 +210,23 @@ namespace Ice
         ObjectAdapterPtr createObjectAdapterWithRouter(const std::string& name, const RouterPrx& rtr);
 
         /**
+         * Gets the object adapter that is associated by default with new outgoing connections created by this
+         * communicator. This function returns null unless you set a non-null default object adapter using
+         * setDefaultObjectAdapter.
+         * @return The object adapter associated by default with new outgoing connections.
+         * @see Connection::getAdapter
+         */
+        ObjectAdapterPtr getDefaultObjectAdapter() const noexcept;
+
+        /**
+         * Sets the object adapter that will be associated with new outgoing connections created by this
+         * communicator. This function has no effect on existing outgoing connections, or on incoming connections.
+         * @param adapter The object adapter to associate with new outgoing connections.
+         * @see Connection::setAdapter
+         */
+        void setDefaultObjectAdapter(ObjectAdapterPtr adapter) noexcept;
+
+        /**
          * Get the implicit context associated with this communicator.
          * @return The implicit context associated with this communicator; returns null when the property
          * Ice.ImplicitContext is not set or is set to None.

--- a/cpp/include/Ice/Connection.h
+++ b/cpp/include/Ice/Connection.h
@@ -162,21 +162,19 @@ namespace Ice
         }
 
         /**
-         * Explicitly set an object adapter that dispatches requests that are received over this connection. A client
-         * can invoke an operation on a server using a proxy, and then set an object adapter for the outgoing connection
-         * that is used by the proxy in order to receive callbacks. This is useful if the server cannot establish a
-         * connection back to the client, for example because of firewalls.
-         * @param adapter The object adapter that should be used by this connection to dispatch requests. The object
-         * adapter must be activated. When the object adapter is deactivated, it is automatically removed from the
-         * connection. Attempts to use a deactivated object adapter raise {@link ObjectAdapterDeactivatedException}
-         * @see #createProxy
+         * Associates an object adapter with this connection. When a connection receives a request, it dispatches this
+         * request using its associated object adapter. If the associated object adapter is null, the connection
+         * rejects any incoming request with an ObjectNotExistException.
+         * The default object adapter of an incoming connection is the object adapter that created this connection;
+         * the default object adapter of an outgoing connection is the communicator's default object adapter.
+         * @see Communicator#getDefaultObjectAdapter
          * @see #getAdapter
          */
         virtual void setAdapter(const ObjectAdapterPtr& adapter) = 0;
 
         /**
-         * Get the object adapter that dispatches requests for this connection.
-         * @return The object adapter that dispatches requests for the connection, or null if no adapter is set.
+         * Gets the object adapter associated with this connection.
+         * @return The object adapter associated with this connection.
          * @see #setAdapter
          */
         virtual ObjectAdapterPtr getAdapter() const noexcept = 0;

--- a/cpp/include/Ice/LocalExceptions.h
+++ b/cpp/include/Ice/LocalExceptions.h
@@ -827,6 +827,27 @@ namespace Ice
     };
 
     /**
+     * This exception is raised if an attempt is made to use a destroyed ObjectAdapter.
+     * \headerfile Ice/Ice.h
+     */
+    class ICE_API ObjectAdapterDestroyedException final : public LocalException
+    {
+    public:
+        /**
+         * Constructs an ObjectAdapterDestroyedException.
+         * @param file The file where this exception is constructed. This C string is not copied.
+         * @param line The line where this exception is constructed.
+         * @param name The name of the object adapter that is destroyed.
+         */
+        ObjectAdapterDestroyedException(const char* file, int line, std::string_view name)
+            : LocalException(file, line, "object adapter '" + std::string{name} + "' is destroyed")
+        {
+        }
+
+        const char* ice_id() const noexcept final;
+    };
+
+    /**
      * This exception is raised if an {@link ObjectAdapter} cannot be activated. This happens if the {@link Locator}
      * detects another active {@link ObjectAdapter} with the same adapter id.
      * \headerfile Ice/Ice.h

--- a/cpp/include/Ice/ObjectAdapter.h
+++ b/cpp/include/Ice/ObjectAdapter.h
@@ -75,27 +75,21 @@ namespace Ice
         virtual void waitForHold() = 0;
 
         /**
-         * Deactivate all endpoints that belong to this object adapter. After deactivation, the object adapter stops
-         * receiving requests through its endpoints. Object adapters that have been deactivated must not be reactivated
-         * again, and cannot be used otherwise. Attempts to use a deactivated object adapter raise
-         * {@link ObjectAdapterDeactivatedException} however, attempts to {@link #deactivate} an already deactivated
-         * object adapter are ignored and do nothing. Once deactivated, it is possible to destroy the adapter to clean
-         * up resources and then create and activate a new adapter with the same name. <p class="Note"> After {@link
-         * #deactivate} returns, no new requests are processed by the object adapter. However, requests that have been
-         * started before {@link #deactivate} was called might still be active. You can use {@link #waitForDeactivate}
-         * to wait for the completion of all requests for this object adapter.
-         * @see #activate
-         * @see #hold
+         * Deactivates this object adapter: stop accepting new connections from clients and close gracefully all
+         * incoming connections created by this object adapter once all outstanding dispatches have completed. If this
+         * object adapter is indirect, this function also unregisters the object adapter from the Locator.
+         * This function does not cancel outstanding dispatches--it lets them execute until completion. A new incoming
+         * request on an existing connection will be accepted and can delay the closure of the connection.
+         * A deactivated object adapter cannot be reactivated again; it can only be destroyed.
          * @see #waitForDeactivate
          * @see Communicator#shutdown
          */
         virtual void deactivate() noexcept = 0;
 
         /**
-         * Wait until the object adapter has deactivated. Calling {@link #deactivate} initiates object adapter
-         * deactivation, and {@link #waitForDeactivate} only returns when deactivation has been completed.
+         * Wait until deactivate is called on this object adapter and all connections accepted by this object adapter
+         * are closed. A connection is closed only after all outstanding dispatches on this connection have completed.
          * @see #deactivate
-         * @see #waitForHold
          * @see Communicator#waitForShutdown
          */
         virtual void waitForDeactivate() noexcept = 0;
@@ -108,12 +102,8 @@ namespace Ice
         virtual bool isDeactivated() const noexcept = 0;
 
         /**
-         * Destroys the object adapter and cleans up all resources held by the object adapter. If the object adapter has
-         * not yet been deactivated, destroy implicitly initiates the deactivation and waits for it to finish.
-         * Subsequent calls to destroy are ignored. Once destroy has returned, it is possible to create another object
-         * adapter with the same name.
-         * @see #deactivate
-         * @see #waitForDeactivate
+         * Destroys this object adapter and cleans up all resources held by this object adapter.
+         * Once this function has returned, it is possible to create another object adapter with the same name.
          * @see Communicator#destroy
          */
         virtual void destroy() noexcept = 0;

--- a/cpp/src/Glacier2/Glacier2Router.cpp
+++ b/cpp/src/Glacier2/Glacier2Router.cpp
@@ -339,7 +339,7 @@ RouterService::start(int argc, char* argv[], int& status)
             _instance->serverObjectAdapter()->addServantLocator(make_shared<ServerLocator>(_sessionRouter), "");
         }
     }
-    catch (const Ice::ObjectAdapterDeactivatedException&)
+    catch (const Ice::ObjectAdapterDestroyedException&)
     {
         // Ignore.
     }

--- a/cpp/src/Ice/CollocatedRequestHandler.cpp
+++ b/cpp/src/Ice/CollocatedRequestHandler.cpp
@@ -238,7 +238,6 @@ CollocatedRequestHandler::dispatchAll(InputStream& is, int32_t requestId, int32_
     {
         while (requestCount > 0)
         {
-
             // Increase the direct count for the dispatch. We increase it again here for
             // each dispatch. It's important for the direct count to be > 0 until the last
             // collocated request response is sent to make sure the thread pool isn't

--- a/cpp/src/Ice/CollocatedRequestHandler.cpp
+++ b/cpp/src/Ice/CollocatedRequestHandler.cpp
@@ -238,17 +238,16 @@ CollocatedRequestHandler::dispatchAll(InputStream& is, int32_t requestId, int32_
     {
         while (requestCount > 0)
         {
-            //
+
             // Increase the direct count for the dispatch. We increase it again here for
             // each dispatch. It's important for the direct count to be > 0 until the last
             // collocated request response is sent to make sure the thread pool isn't
-            // destroyed before.
-            //
+            // destroyed before. It's decremented when processing the response.
             try
             {
                 _adapter->incDirectCount();
             }
-            catch (const ObjectAdapterDeactivatedException&)
+            catch (const ObjectAdapterDestroyedException&)
             {
                 handleException(requestId, current_exception());
                 break;

--- a/cpp/src/Ice/Communicator.cpp
+++ b/cpp/src/Ice/Communicator.cpp
@@ -4,6 +4,7 @@
 
 #include "Ice/Communicator.h"
 #include "CommunicatorFlushBatchAsync.h"
+#include "ConnectionFactory.h"
 #include "Instance.h"
 #include "ObjectAdapterFactory.h"
 #include "ReferenceFactory.h"
@@ -149,6 +150,18 @@ Ice::Communicator::createObjectAdapterWithRouter(const string& name, const Route
     }
 
     return _instance->objectAdapterFactory()->createObjectAdapter(oaName, router, nullopt);
+}
+
+ObjectAdapterPtr
+Ice::Communicator::getDefaultObjectAdapter() const noexcept
+{
+    return _instance->outgoingConnectionFactory()->getDefaultObjectAdapter();
+}
+
+void
+Ice::Communicator::setDefaultObjectAdapter(ObjectAdapterPtr adapter) noexcept
+{
+    return _instance->outgoingConnectionFactory()->setDefaultObjectAdapter(std::move(adapter));
 }
 
 PropertiesPtr

--- a/cpp/src/Ice/ConnectionFactory.cpp
+++ b/cpp/src/Ice/ConnectionFactory.cpp
@@ -269,7 +269,7 @@ IceInternal::OutgoingConnectionFactory::removeAdapter(const ObjectAdapterPtr& ad
     {
         if (p->second->getAdapter() == adapter)
         {
-            p->second->setAdapter(0);
+            p->second->setAdapter(nullptr);
         }
     }
 }
@@ -336,6 +336,20 @@ IceInternal::OutgoingConnectionFactory::~OutgoingConnectionFactory()
     assert(_connectionsByEndpoint.empty());
     assert(_pending.empty());
     assert(_pendingConnectCount == 0);
+}
+
+ObjectAdapterPtr
+IceInternal::OutgoingConnectionFactory::getDefaultObjectAdapter() const noexcept
+{
+    lock_guard lock(_mutex);
+    return _defaultObjectAdapter;
+}
+
+void
+IceInternal::OutgoingConnectionFactory::setDefaultObjectAdapter(ObjectAdapterPtr adapter) noexcept
+{
+    lock_guard lock(_mutex);
+    _defaultObjectAdapter = dynamic_pointer_cast<ObjectAdapterI>(adapter);
 }
 
 ConnectionIPtr
@@ -544,7 +558,7 @@ IceInternal::OutgoingConnectionFactory::createConnection(const TransceiverPtr& t
             transceiver,
             ci.connector,
             ci.endpoint->compress(false)->timeout(-1),
-            nullptr,
+            _defaultObjectAdapter,
             [weakSelf = weak_from_this()](const ConnectionIPtr& closedConnection)
             {
                 if (auto self = weakSelf.lock())

--- a/cpp/src/Ice/ConnectionFactory.h
+++ b/cpp/src/Ice/ConnectionFactory.h
@@ -62,6 +62,9 @@ namespace IceInternal
 
         void removeConnection(const Ice::ConnectionIPtr&) noexcept;
 
+        void setDefaultObjectAdapter(Ice::ObjectAdapterPtr adapter) noexcept;
+        Ice::ObjectAdapterPtr getDefaultObjectAdapter() const noexcept;
+
         OutgoingConnectionFactory(const Ice::CommunicatorPtr&, const InstancePtr&);
         ~OutgoingConnectionFactory();
         friend class Instance;
@@ -160,7 +163,8 @@ namespace IceInternal
         std::multimap<EndpointIPtr, Ice::ConnectionIPtr, Ice::TargetCompare<EndpointIPtr, std::less>>
             _connectionsByEndpoint;
         int _pendingConnectCount;
-        std::mutex _mutex;
+        Ice::ObjectAdapterIPtr _defaultObjectAdapter;
+        mutable std::mutex _mutex;
         std::condition_variable _conditionVariable;
     };
 

--- a/cpp/src/Ice/LocalExceptions.cpp
+++ b/cpp/src/Ice/LocalExceptions.cpp
@@ -417,6 +417,12 @@ Ice::ObjectAdapterDeactivatedException::ice_id() const noexcept
 }
 
 const char*
+Ice::ObjectAdapterDestroyedException::ice_id() const noexcept
+{
+    return "::Ice::ObjectAdapterDestroyedException";
+}
+
+const char*
 Ice::ObjectAdapterIdInUseException::ice_id() const noexcept
 {
     return "::Ice::ObjectAdapterIdInUseException";

--- a/cpp/src/Ice/ObjectAdapterFactory.cpp
+++ b/cpp/src/Ice/ObjectAdapterFactory.cpp
@@ -219,7 +219,7 @@ IceInternal::ObjectAdapterFactory::findObjectAdapter(const ReferencePtr& referen
                 return *p;
             }
         }
-        catch (const ObjectAdapterDeactivatedException&)
+        catch (const ObjectAdapterDestroyedException&)
         {
             // Ignore.
         }

--- a/cpp/src/Ice/ObjectAdapterI.h
+++ b/cpp/src/Ice/ObjectAdapterI.h
@@ -118,6 +118,7 @@ namespace Ice
         ObjectPrx newDirectProxy(const Identity&, const std::string&) const;
         ObjectPrx newIndirectProxy(const Identity&, const std::string&, const std::string&) const;
         void checkForDeactivation() const;
+        void checkForDestruction() const;
         std::vector<IceInternal::EndpointIPtr> parseEndpoints(const std::string&, bool) const;
         std::vector<IceInternal::EndpointIPtr> computePublishedEndpoints();
         void updateLocatorRegistry(const IceInternal::LocatorInfoPtr&, const std::optional<ObjectPrx>&);

--- a/cpp/src/Ice/OutgoingAsync.cpp
+++ b/cpp/src/Ice/OutgoingAsync.cpp
@@ -704,6 +704,10 @@ ProxyOutgoingAsyncBase::checkRetryAfterException(std::exception_ptr ex)
     {
         throw;
     }
+    catch (const ObjectAdapterDestroyedException&)
+    {
+        throw;
+    }
     catch (const ConnectionAbortedException& connectionAbortedException)
     {
         if (connectionAbortedException.closedByApplication())

--- a/cpp/src/Ice/RouterInfo.cpp
+++ b/cpp/src/Ice/RouterInfo.cpp
@@ -9,6 +9,8 @@
 #include "Ice/Router.h"
 #include "Reference.h"
 
+#include <cassert>
+
 using namespace std;
 using namespace Ice;
 using namespace IceInternal;
@@ -58,11 +60,11 @@ IceInternal::RouterManager::get(const RouterPrx& rtr)
     return _tableHint->second;
 }
 
-RouterInfoPtr
-IceInternal::RouterManager::erase(const RouterPrx& rtr)
+void
+IceInternal::RouterManager::erase(const RouterPrx& router)
 {
-    RouterInfoPtr info;
-    RouterPrx router = rtr->ice_router(nullopt); // The router cannot be routed.
+    assert(!router->ice_getRouter()); // The router cannot be routed.
+
     lock_guard lock(_mutex);
 
     RouterInfoTable::iterator p = _table.end();
@@ -79,11 +81,8 @@ IceInternal::RouterManager::erase(const RouterPrx& rtr)
 
     if (p != _table.end())
     {
-        info = p->second;
         _table.erase(p);
     }
-
-    return info;
 }
 
 IceInternal::RouterInfo::RouterInfo(const RouterPrx& router) : _router(router), _hasRoutingTable(false) {}

--- a/cpp/src/Ice/RouterInfo.h
+++ b/cpp/src/Ice/RouterInfo.h
@@ -35,7 +35,7 @@ namespace IceInternal
         // the router info if it doesn't exist yet.
         //
         RouterInfoPtr get(const Ice::RouterPrx&);
-        RouterInfoPtr erase(const Ice::RouterPrx&);
+        void erase(const Ice::RouterPrx&);
 
     private:
         using RouterInfoTable = std::map<Ice::RouterPrx, RouterInfoPtr>;

--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -403,6 +403,10 @@ IceInternal::WSTransceiver::closing(bool initiator, exception_ptr reason)
     {
         _closingReason = CLOSURE_SHUTDOWN;
     }
+    catch (const Ice::ObjectAdapterDestroyedException&)
+    {
+        _closingReason = CLOSURE_SHUTDOWN;
+    }
     catch (const Ice::CommunicatorDestroyedException&)
     {
         _closingReason = CLOSURE_SHUTDOWN;

--- a/cpp/src/IceBox/ServiceManagerI.cpp
+++ b/cpp/src/IceBox/ServiceManagerI.cpp
@@ -976,7 +976,7 @@ IceBox::ServiceManagerI::removeAdminFacets(const string& prefix)
     {
         // Ignored
     }
-    catch (const ObjectAdapterDeactivatedException&)
+    catch (const ObjectAdapterDestroyedException&)
     {
         // Ignored
     }

--- a/cpp/src/IceGrid/AdminSessionI.cpp
+++ b/cpp/src/IceGrid/AdminSessionI.cpp
@@ -344,7 +344,7 @@ AdminSessionI::setupObserverSubscription(TopicName name, const optional<Ice::Obj
                 // Unregister forwarder object
                 _registry->getRegistryAdapter()->remove(previousObserver->ice_getIdentity());
             }
-            catch (const Ice::ObjectAdapterDeactivatedException&)
+            catch (const Ice::ObjectAdapterDestroyedException&)
             {
             }
         }

--- a/cpp/src/IceGrid/InternalRegistryI.cpp
+++ b/cpp/src/IceGrid/InternalRegistryI.cpp
@@ -66,7 +66,7 @@ InternalRegistryI::registerNode(
         _reaper->add(make_shared<SessionReapable<NodeSessionI>>(logger, session), _nodeSessionTimeout);
         return session->getProxy();
     }
-    catch (const Ice::ObjectAdapterDeactivatedException&)
+    catch (const Ice::ObjectAdapterDestroyedException&)
     {
         throw Ice::ObjectNotExistException(__FILE__, __LINE__);
     }
@@ -97,7 +97,7 @@ InternalRegistryI::registerReplica(
         _reaper->add(make_shared<SessionReapable<ReplicaSessionI>>(logger, s), _replicaSessionTimeout);
         return s->getProxy();
     }
-    catch (const Ice::ObjectAdapterDeactivatedException&)
+    catch (const Ice::ObjectAdapterDestroyedException&)
     {
         throw Ice::ObjectNotExistException(__FILE__, __LINE__);
     }

--- a/cpp/src/IceGrid/NodeI.cpp
+++ b/cpp/src/IceGrid/NodeI.cpp
@@ -676,7 +676,7 @@ NodeI::checkConsistencyNoSync(const Ice::StringSeq& servers)
             ++p;
         }
     }
-    catch (const Ice::ObjectAdapterDeactivatedException&)
+    catch (const Ice::ObjectAdapterDestroyedException&)
     {
         //
         // Just return the server commands, we'll finish the
@@ -859,7 +859,7 @@ NodeI::loadServer(
                     added = true;
                 }
             }
-            catch (const Ice::ObjectAdapterDeactivatedException&)
+            catch (const Ice::ObjectAdapterDestroyedException&)
             {
                 // We throw an object not exist exception to avoid dispatch warnings. The registry will consider the
                 // node has being unreachable upon receipt of this exception (like any other Ice::LocalException). We
@@ -885,7 +885,7 @@ NodeI::loadServer(
                     {
                         _adapter->remove(id);
                     }
-                    catch (const Ice::ObjectAdapterDeactivatedException&)
+                    catch (const Ice::ObjectAdapterDestroyedException&)
                     {
                         // IGNORE
                     }
@@ -922,7 +922,7 @@ NodeI::destroyServer(
         {
             server = dynamic_pointer_cast<ServerI>(_adapter->find(createServerIdentity(serverId)));
         }
-        catch (const Ice::ObjectAdapterDeactivatedException&)
+        catch (const Ice::ObjectAdapterDestroyedException&)
         {
             // We throw an object not exist exception to avoid dispatch warnings. The registry will consider the node
             // has being unreachable upon receipt of this exception (like any other Ice::LocalException). We could also

--- a/cpp/src/IceGrid/NodeSessionI.cpp
+++ b/cpp/src/IceGrid/NodeSessionI.cpp
@@ -285,7 +285,7 @@ NodeSessionI::destroyImpl(bool shutdown)
         {
             _database->getInternalAdapter()->remove(_proxy->ice_getIdentity());
         }
-        catch (const Ice::ObjectAdapterDeactivatedException&)
+        catch (const Ice::ObjectAdapterDestroyedException&)
         {
         }
     }

--- a/cpp/src/IceGrid/ReplicaCache.cpp
+++ b/cpp/src/IceGrid/ReplicaCache.cpp
@@ -94,7 +94,7 @@ ReplicaCache::add(const string& name, const shared_ptr<ReplicaSessionI>& session
     {
         // Expected if the replica is being shutdown.
     }
-    catch (const Ice::ObjectAdapterDeactivatedException&)
+    catch (const Ice::ObjectAdapterDestroyedException&)
     {
         // Expected if the replica is being shutdown.
     }
@@ -137,7 +137,7 @@ ReplicaCache::remove(const string& name, bool shutdown)
         {
             // Expected if the replica is being shutdown.
         }
-        catch (const Ice::ObjectAdapterDeactivatedException&)
+        catch (const Ice::ObjectAdapterDestroyedException&)
         {
             // Expected if the replica is being shutdown.
         }
@@ -194,7 +194,7 @@ ReplicaCache::subscribe(const ReplicaObserverPrx& observer)
     {
         // The replica is being shutdown.
     }
-    catch (const Ice::ObjectAdapterDeactivatedException&)
+    catch (const Ice::ObjectAdapterDestroyedException&)
     {
         // Expected if the replica is being shutdown.
     }
@@ -216,7 +216,7 @@ ReplicaCache::unsubscribe(const ReplicaObserverPrx& observer)
     {
         _topic->unsubscribe(observer);
     }
-    catch (const Ice::ObjectAdapterDeactivatedException&)
+    catch (const Ice::ObjectAdapterDestroyedException&)
     {
         // The replica is being shutdown.
     }

--- a/cpp/src/IceGrid/ReplicaSessionI.cpp
+++ b/cpp/src/IceGrid/ReplicaSessionI.cpp
@@ -360,7 +360,7 @@ ReplicaSessionI::destroyImpl(bool shutdown)
         {
             _database->getInternalAdapter()->remove(_proxy->ice_getIdentity());
         }
-        catch (const Ice::ObjectAdapterDeactivatedException&)
+        catch (const Ice::ObjectAdapterDestroyedException&)
         {
         }
     }

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -1978,7 +1978,7 @@ ServerI::updateImpl(const shared_ptr<InternalServerDescriptor>& descriptor)
                     _serverLifetimeAdapters.insert(adpt->id);
                 }
             }
-            catch (const Ice::ObjectAdapterDeactivatedException&)
+            catch (const Ice::ObjectAdapterDestroyedException&)
             {
                 // IGNORE
             }
@@ -1997,7 +1997,7 @@ ServerI::updateImpl(const shared_ptr<InternalServerDescriptor>& descriptor)
             {
                 adpt.second->destroy();
             }
-            catch (const Ice::ObjectAdapterDeactivatedException&)
+            catch (const Ice::ObjectAdapterDestroyedException&)
             {
                 // IGNORE
             }
@@ -2679,7 +2679,7 @@ ServerI::setStateNoSync(InternalServerState st, const string& reason)
             assert(_this);
             _node->getAdapter()->remove(_this->ice_getIdentity());
         }
-        catch (const Ice::ObjectAdapterDeactivatedException&)
+        catch (const Ice::ObjectAdapterDestroyedException&)
         {
             // IGNORE
         }

--- a/cpp/src/IceGrid/Topics.cpp
+++ b/cpp/src/IceGrid/Topics.cpp
@@ -124,7 +124,7 @@ ObserverTopic::unsubscribe(const Ice::ObjectPrx& observer, const string& name)
     {
         q->second->unsubscribe(observer);
     }
-    catch (const Ice::ObjectAdapterDeactivatedException&)
+    catch (const Ice::ObjectAdapterDestroyedException&)
     {
     }
 

--- a/cpp/src/IceLocatorDiscovery/PluginI.cpp
+++ b/cpp/src/IceLocatorDiscovery/PluginI.cpp
@@ -368,6 +368,10 @@ Request::exception(std::exception_ptr ex)
     {
         _exceptionCallback(make_exception_ptr(Ice::ObjectNotExistException(__FILE__, __LINE__)));
     }
+    catch (const Ice::ObjectAdapterDestroyedException&)
+    {
+        _exceptionCallback(make_exception_ptr(Ice::ObjectNotExistException(__FILE__, __LINE__)));
+    }
     catch (...)
     {
         _exception = ex;

--- a/cpp/src/IceStorm/TransientTopicI.cpp
+++ b/cpp/src/IceStorm/TransientTopicI.cpp
@@ -351,7 +351,7 @@ TransientTopicImpl::destroy(const Ice::Current&)
         _instance->publishAdapter()->remove(_linkPrx->ice_getIdentity());
         _instance->publishAdapter()->remove(_publisherPrx->ice_getIdentity());
     }
-    catch (const Ice::ObjectAdapterDeactivatedException&)
+    catch (const Ice::ObjectAdapterDestroyedException&)
     {
         // Ignore -- this could occur on shutdown.
     }

--- a/cpp/src/IceStorm/TransientTopicManagerI.cpp
+++ b/cpp/src/IceStorm/TransientTopicManagerI.cpp
@@ -122,7 +122,7 @@ TransientTopicManagerImpl::reap()
             {
                 _instance->topicAdapter()->remove(id);
             }
-            catch (const Ice::ObjectAdapterDeactivatedException&)
+            catch (const Ice::ObjectAdapterDestroyedException&)
             {
                 // Ignore
             }

--- a/cpp/test/Ice/binding/TestI.cpp
+++ b/cpp/test/Ice/binding/TestI.cpp
@@ -72,13 +72,7 @@ RemoteObjectAdapterI::getTestIntf(const Current&)
 void
 RemoteObjectAdapterI::deactivate(const Current&)
 {
-    try
-    {
-        _adapter->destroy();
-    }
-    catch (const ObjectAdapterDeactivatedException&)
-    {
-    }
+    _adapter->destroy();
 }
 
 std::string

--- a/cpp/test/Ice/hold/TestI.cpp
+++ b/cpp/test/Ice/hold/TestI.cpp
@@ -34,7 +34,7 @@ HoldI::putOnHold(int32_t milliSeconds, const Ice::Current&)
                 _adapter->hold();
                 _adapter->activate();
             }
-            catch (const Ice::ObjectAdapterDeactivatedException&)
+            catch (const Ice::LocalException&)
             {
                 //
                 // This shouldn't occur. The test ensures all the waitForHold timers are
@@ -84,7 +84,7 @@ HoldI::waitForHold(const Ice::Current& current)
                 _adapter->waitForHold();
                 _adapter->activate();
             }
-            catch (const Ice::ObjectAdapterDeactivatedException&)
+            catch (const Ice::LocalException&)
             {
                 //
                 // This shouldn't occur. The test ensures all the waitForHold timers are

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -211,8 +211,8 @@ public sealed class Communicator : IDisposable
     public ObjectAdapter? getDefaultObjectAdapter() => instance.outgoingConnectionFactory().getDefaultObjectAdapter();
 
     /// <summary>
-    /// Sets the object adapter that will be associated with new outgoing connections created by this
-    /// communicator. This method has no effect on existing outgoing connections, or on incoming connections.
+    /// Sets the object adapter that will be associated with new outgoing connections created by this communicator. This
+    /// method has no effect on existing outgoing connections, or on incoming connections.
     /// </summary>
     /// <param name="adapter">The object adapter to associate with new outgoing connections.</param>
     /// <seealso cref="Connection.setAdapter" />

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -111,9 +111,10 @@ namespace Ice
         /// request using its associated object adapter. If the associated object adapter is null, the connection
         /// rejects any incoming request with an <see cref="ObjectNotExistException" />.
         /// The default object adapter of an incoming connection is the object adapter that created this connection;
-        /// the default object adapter of an outgoing connection is null.
+        /// the default object adapter of an outgoing connection is the communicator's default object adapter.
         /// </summary>
         /// <param name="adapter">The object adapter to associate with this connection.</param>
+        /// <seealso cref="Communicator.getDefaultObjectAdapter"/>
         void setAdapter(ObjectAdapter? adapter);
 
         /// <summary>

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -270,7 +270,8 @@ public sealed class ObjectAdapter
     /// <summary>
     /// Checks if this object adapter has been deactivated.
     /// </summary>
-    /// <returns><see langword="true" /> if <see cref="deactivate"/> was called; otherwise, <see langword="false" />.
+    /// <returns><see langword="true" /> if <see cref="deactivate"/> has been called on this object adapter; otherwise,
+    /// <see langword="false" />.
     /// </returns>
     public bool isDeactivated()
     {

--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -1453,7 +1453,7 @@ static PyMethodDef CommunicatorMethods[] = {
      reinterpret_cast<PyCFunction>(communicatorCreateObjectAdapterWithRouter),
      METH_VARARGS,
      PyDoc_STR("createObjectAdapterWithRouter(name, router) -> Ice.ObjectAdapter")},
-     {"getDefaultObjectAdapter",
+    {"getDefaultObjectAdapter",
      reinterpret_cast<PyCFunction>(communicatorGetDefaultObjectAdapter),
      METH_NOARGS,
      PyDoc_STR("getDefaultObjectAdapter() -> Ice.ObjectAdapter")},

--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -1259,6 +1259,46 @@ communicatorCreateObjectAdapterWithRouter(CommunicatorObject* self, PyObject* ar
 }
 
 extern "C" PyObject*
+communicatorGetDefaultObjectAdapter(CommunicatorObject* self, PyObject* /*args*/)
+{
+    assert(self->communicator);
+    Ice::ObjectAdapterPtr adapter = (*self->communicator)->getDefaultObjectAdapter();
+
+    if (adapter)
+    {
+        // Returns an Ice.ObjectAdapter
+        return wrapObjectAdapter(adapter);
+    }
+    else
+    {
+        return Py_None;
+    }
+}
+
+extern "C" PyObject*
+communicatorSetDefaultObjectAdapter(CommunicatorObject* self, PyObject* args)
+{
+    PyObject* adapter = Py_None;
+    if (!PyArg_ParseTuple(args, "O", &adapter))
+    {
+        return nullptr;
+    }
+
+    PyObject* adapterType = lookupType("Ice.ObjectAdapter");
+    if (adapter != Py_None && !PyObject_IsInstance(adapter, adapterType))
+    {
+        PyErr_Format(PyExc_TypeError, "value for 'adapter' argument must be None or an Ice.ObjectAdapter instance");
+        return nullptr;
+    }
+
+    Ice::ObjectAdapterPtr oa = adapter != Py_None ? unwrapObjectAdapter(adapter) : nullptr;
+
+    assert(self->communicator);
+    (*self->communicator)->setDefaultObjectAdapter(oa);
+    return Py_None;
+}
+
+extern "C" PyObject*
 communicatorGetDefaultRouter(CommunicatorObject* self, PyObject* /*args*/)
 {
     assert(self->communicator);
@@ -1413,6 +1453,14 @@ static PyMethodDef CommunicatorMethods[] = {
      reinterpret_cast<PyCFunction>(communicatorCreateObjectAdapterWithRouter),
      METH_VARARGS,
      PyDoc_STR("createObjectAdapterWithRouter(name, router) -> Ice.ObjectAdapter")},
+     {"getDefaultObjectAdapter",
+     reinterpret_cast<PyCFunction>(communicatorGetDefaultObjectAdapter),
+     METH_NOARGS,
+     PyDoc_STR("getDefaultObjectAdapter() -> Ice.ObjectAdapter")},
+    {"setDefaultObjectAdapter",
+     reinterpret_cast<PyCFunction>(communicatorSetDefaultObjectAdapter),
+     METH_VARARGS,
+     PyDoc_STR("setDefaultObjectAdapter(adapter) -> None")},
     {"getValueFactoryManager",
      reinterpret_cast<PyCFunction>(communicatorGetValueFactoryManager),
      METH_NOARGS,

--- a/python/modules/IcePy/Connection.cpp
+++ b/python/modules/IcePy/Connection.cpp
@@ -294,7 +294,7 @@ connectionSetAdapter(ConnectionObject* self, PyObject* args)
         return nullptr;
     }
 
-    Ice::ObjectAdapterPtr oa = adapter != Py_None ? unwrapObjectAdapter(adapter) : Ice::ObjectAdapterPtr();
+    Ice::ObjectAdapterPtr oa = adapter != Py_None ? unwrapObjectAdapter(adapter) : nullptr;
 
     assert(self->connection);
     assert(self->communicator);

--- a/python/python/Ice/Communicator.py
+++ b/python/python/Ice/Communicator.py
@@ -249,6 +249,29 @@ class Communicator:
         adapter = self._impl.createObjectAdapterWithRouter(name, router)
         return ObjectAdapter(adapter)
 
+    def getDefaultObjectAdapter(self):
+        """
+        Get the object adapter that is associated by default with new outgoing connections created by this
+        communicator. This method returns None unless you set a default object adapter using createDefaultObjectAdapter.
+
+        Returns
+        -------
+        Ice.ObjectAdapter or None
+            The object adapter associated by default with new outgoing connections.
+        """
+        return self._impl.getDefaultObjectAdapter()
+
+    def setDefaultObjectAdapter(self, adapter):
+        """
+        Set the object adapter that is associated by default with new outgoing connections created by this communicator.
+
+        Parameters
+        ----------
+        adapter : Ice.ObjectAdapter or None
+            The object adapter to associate with new outgoing connections.
+        """
+        self._impl.setDefaultObjectAdapter(adapter)
+
     def getImplicitContext(self):
         """
         Get the implicit context associated with this communicator.

--- a/python/python/Ice/LocalExceptions.py
+++ b/python/python/Ice/LocalExceptions.py
@@ -390,6 +390,12 @@ class ObjectAdapterDeactivatedException(LocalException):
     """
 
 @final
+class ObjectAdapterDestroyedException(LocalException):
+    """
+    This exception is raised if an attempt is made to use a destroyed ObjectAdapter.
+    """
+
+@final
 class ObjectAdapterIdInUseException(LocalException):
     """
     This exception is raised if an ObjectAdapter cannot be activated. This happens if the Locator detects another
@@ -449,6 +455,7 @@ __all__ = [
     'NoEndpointException',
     'NotRegisteredException',
     'ObjectAdapterDeactivatedException',
+    'ObjectAdapterDestroyedException',
     'ObjectAdapterIdInUseException',
     'ParseException',
     'SecurityException',

--- a/python/python/Ice/ObjectAdapter.py
+++ b/python/python/Ice/ObjectAdapter.py
@@ -75,26 +75,22 @@ class ObjectAdapter(object):
 
     def deactivate(self):
         """
-        Deactivate all endpoints that belong to this object adapter.
+        Deactivates this object adapter: stop accepting new connections from clients and close gracefully all incoming
+        connections created by this object adapter once all outstanding dispatches have completed.
 
-        After deactivation, the object adapter stops receiving requests through its endpoints. Object adapters that
-        have been deactivated must not be reactivated again, and cannot be used otherwise. Attempts to use a
-        deactivated object adapter raise `ObjectAdapterDeactivatedException`. However, attempts to deactivate
-        an already deactivated object adapter are ignored and do nothing. Once deactivated, it is possible to destroy
-        the adapter to clean up resources and then create and activate a new adapter with the same name.
-
-        After `deactivate` returns, no new requests are processed by the object adapter. However, requests that
-        have been started before `deactivate` was called might still be active. You can use `waitForDeactivate`
-        to wait for the completion of all requests for this object adapter.
+        If this object adapter is indirect, this method also unregisters the object adapter from the Locator.
+        This method does not cancel outstanding dispatches--it lets them execute until completion. A new incoming
+        request on an existing connection will be accepted and can delay the closure of the connection.
+        A deactivated object adapter cannot be reactivated again; it can only be destroyed.
         """
         self._impl.deactivate()
 
     def waitForDeactivate(self):
         """
-        Wait until the object adapter has deactivated.
+        Wait until `deactivate` is called on this object adapter and all connections accepted by this object adapter are
+        closed.
 
-        Calling `deactivate` initiates object adapter deactivation, and `waitForDeactivate` only returns when deactivation
-        has been completed.
+        A connection is closed only after all outstanding dispatches on this connection have completed.
         """
         #
         # TODO should be part of the documented behavior above. Should we add a timeout parameter with a default value?
@@ -108,22 +104,20 @@ class ObjectAdapter(object):
 
     def isDeactivated(self):
         """
-        Check whether the object adapter has been deactivated.
+        Checks if this object adapter has been deactivated.
 
         Returns
         -------
         bool
-            True if the object adapter has been deactivated, False otherwise.
+            True if `deactivate` has been called on this object adapter; otherwise, False.
         """
         self._impl.isDeactivated()
 
     def destroy(self):
         """
-        Destroy the object adapter and clean up all resources held by the object adapter.
+        Destroys this object adapter and cleans up all resources held by this object adapter.
 
-        If the object adapter has not yet been deactivated, `destroy` implicitly initiates the deactivation and waits for
-        it to finish. Subsequent calls to `destroy` are ignored. Once `destroy` has returned, it is possible to create
-        another object adapter with the same name.
+        Once this method has returned, it is possible to create another object adapter with the same name.
         """
         self._impl.destroy()
 

--- a/python/test/Ice/binding/TestI.py
+++ b/python/test/Ice/binding/TestI.py
@@ -46,10 +46,7 @@ class RemoteObjectAdapterI(Test.RemoteObjectAdapter):
         return self._testIntf
 
     def deactivate(self, current):
-        try:
-            self._adapter.destroy()
-        except Ice.ObjectAdapterDeactivatedException:
-            pass
+        self._adapter.destroy()
 
 
 class TestI(Test.TestIntf):

--- a/swift/src/Ice/Communicator.swift
+++ b/swift/src/Ice/Communicator.swift
@@ -111,6 +111,19 @@ public protocol Communicator: AnyObject {
     /// - returns: `ObjectAdapter` - The new object adapter.
     func createObjectAdapterWithRouter(name: String, rtr: RouterPrx) throws -> ObjectAdapter
 
+    /// Gets the object adapter that is associated by default with new outgoing connections created by this
+    /// communicator. This function returns nil unless you set a non-nil default object adapter using
+    /// setDefaultObjectAdapter.
+    ///
+    /// - returns: The object adapter associated by default with new outgoing connections.
+    func getDefaultObjectAdapter() -> ObjectAdapter?
+
+    /// Sets the object adapter that will be associated with new outgoing connections created by this communicator. This
+    /// function has no effect on existing outgoing connections, or on incoming connections.
+    ///
+    /// - parameter adapter: The object adapter to associate with new outgoing connections.<
+    func setDefaultObjectAdapter(_ adapter: ObjectAdapter?)
+
     /// Get the implicit context associated with this communicator.
     ///
     /// - returns: `ImplicitContext` - The implicit context associated with this communicator; returns null when the

--- a/swift/src/Ice/CommunicatorI.swift
+++ b/swift/src/Ice/CommunicatorI.swift
@@ -102,6 +102,17 @@ class CommunicatorI: LocalObject<ICECommunicator>, Communicator {
         }
     }
 
+    func getDefaultObjectAdapter() -> ObjectAdapter? {
+        guard let handle = self.handle.getDefaultObjectAdapter() else {
+            return nil
+        }
+        return handle.getCachedSwiftObject(ObjectAdapterI.self)
+    }
+
+    func setDefaultObjectAdapter(_ adapter: ObjectAdapter?) {
+        handle.setDefaultObjectAdapter((adapter as? ObjectAdapterI)?.handle)
+    }
+
     func getImplicitContext() -> ImplicitContext {
         let handle = self.handle.getImplicitContext()
         return handle.getSwiftObject(ImplicitContextI.self) {

--- a/swift/src/Ice/Connection.swift
+++ b/swift/src/Ice/Connection.swift
@@ -106,20 +106,18 @@ public protocol Connection: AnyObject, CustomStringConvertible {
     /// - returns: `ObjectPrx` - A proxy that matches the given identity and uses this connection.
     func createProxy(_ id: Identity) throws -> ObjectPrx
 
-    /// Explicitly set an object adapter that dispatches requests that are received over this connection. A client can
-    /// invoke an operation on a server using a proxy, and then set an object adapter for the outgoing connection that
-    /// is used by the proxy in order to receive callbacks. This is useful if the server cannot establish a connection
-    /// back to the client, for example because of firewalls.
+    /// Associates an object adapter with this connection. When a connection receives a request, it dispatches this
+    /// request using its associated object adapter. If the associated object adapter is null, the connection
+    /// rejects any incoming request with an ObjectNotExistException.
+    /// The default object adapter of an incoming connection is the object adapter that created this connection;
+    /// the default object adapter of an outgoing connection is the communicator's default object adapter.
     ///
-    /// - parameter _: `ObjectAdapter?` The object adapter that should be used by this connection to dispatch requests.
-    /// The object adapter must be activated. When the object adapter is deactivated, it is automatically removed from
-    /// the connection. Attempts to use a deactivated object adapter raise ObjectAdapterDeactivatedException
+    /// - parameter _: `ObjectAdapter?` The object adapter to associate with the connection.
     func setAdapter(_ adapter: ObjectAdapter?) throws
 
-    /// Get the object adapter that dispatches requests for this connection.
+    /// Gets the object adapter associated with this connection.
     ///
-    /// - returns: `ObjectAdapter?` - The object adapter that dispatches requests for the connection, or null if no
-    /// adapter is set.
+    /// - returns: `ObjectAdapter?` - The object adapter associated with this connection.
     func getAdapter() -> ObjectAdapter?
 
     /// Get the endpoint from which the connection was created.

--- a/swift/src/Ice/LocalExceptions.swift
+++ b/swift/src/Ice/LocalExceptions.swift
@@ -387,16 +387,10 @@ public final class NotRegisteredException: LocalException {
 }
 
 /// This exception is raised if an attempt is made to use a deactivated ObjectAdapter.
-public final class ObjectAdapterDeactivatedException: LocalException {
-    /// Creates an ObjectAdapterDeactivatedException.
-    /// - Parameters:
-    ///   - name: The name of the object adapter.
-    ///   - file: The file where the exception was thrown.
-    ///   - line: The line where the exception was thrown.
-    public convenience init(name: String, file: String = #fileID, line: Int32 = #line) {
-        self.init("object adapter '\(name)' is deactivated", file: file, line: line)
-    }
-}
+public final class ObjectAdapterDeactivatedException: LocalException {}
+
+/// This exception is raised if an attempt is made to use a destroyed ObjectAdapter.
+public final class ObjectAdapterDestroyedException: LocalException {}
 
 /// This exception is raised if an ObjectAdapter cannot be activated. This happens if the Locator
 /// detects another active ObjectAdapter with the same adapter id.

--- a/swift/src/Ice/ObjectAdapter.swift
+++ b/swift/src/Ice/ObjectAdapter.swift
@@ -34,30 +34,25 @@ public protocol ObjectAdapter: AnyObject {
     /// waitForHold only returns when holding of requests has been completed.
     func waitForHold()
 
-    /// Deactivate all endpoints that belong to this object adapter. After deactivation, the object adapter stops
-    /// receiving requests through its endpoints. Object adapters that have been deactivated must not be reactivated
-    /// again, and cannot be used otherwise. Attempts to use a deactivated object adapter raise
-    /// ObjectAdapterDeactivatedException however, attempts to deactivate an already deactivated
-    /// object adapter are ignored and do nothing. Once deactivated, it is possible to destroy the adapter to clean up
-    /// resources and then create and activate a new adapter with the same name.
-    /// After deactivate returns, no new requests are processed by the object adapter.
-    /// However, requests that have been started before deactivate was called might still be active. You can
-    /// use waitForDeactivate to wait for the completion of all requests for this object adapter.
+    /// Deactivates this object adapter: stop accepting new connections from clients and close gracefully all incoming
+    /// connections created by this object adapter once all outstanding dispatches have completed. If this object
+    /// adapter is indirect, this function also unregisters the object adapter from the Locator.
+    /// This function does not cancel outstanding dispatches--it lets them execute until completion. A new incoming
+    /// request on an existing connection will be accepted and can delay the closure of the connection.
+    /// A deactivated object adapter cannot be reactivated again; it can only be destroyed.
     func deactivate()
 
-    /// Wait until the object adapter has deactivated. Calling deactivate initiates object adapter
-    /// deactivation, and waitForDeactivate only returns when deactivation has been completed.
+    /// Wait until deactivate is called on this object adapter and all connections accepted by this object adapter are
+    /// closed. A connection is closed only after all outstanding dispatches on this connection have completed.
     func waitForDeactivate()
 
-    /// Check whether object adapter has been deactivated.
+    /// Checks if this object adapter has been deactivated.
     ///
     /// - returns: `Bool` - Whether adapter has been deactivated.
     func isDeactivated() -> Bool
 
-    /// Destroys the object adapter and cleans up all resources held by the object adapter. If the object adapter has
-    /// not yet been deactivated, destroy implicitly initiates the deactivation and waits for it to finish. Subsequent
-    /// calls to destroy are ignored. Once destroy has returned, it is possible to create another object adapter with
-    /// the same name.
+    /// Destroys this object adapter and cleans up all resources held by this object adapter.
+    /// Once this function has returned, it is possible to create another object adapter with the same name.
     func destroy()
 
     /// Add a middleware to the dispatch pipeline of this object adapter.

--- a/swift/src/IceImpl/Communicator.mm
+++ b/swift/src/IceImpl/Communicator.mm
@@ -136,6 +136,16 @@
     }
 }
 
+- (nullable ICEObjectAdapter*)getDefaultObjectAdapter
+{
+    return [ICEObjectAdapter getHandle:self.communicator->getDefaultObjectAdapter()];
+}
+
+- (void)setDefaultObjectAdapter:(ICEObjectAdapter* _Nullable)adapter
+{
+    self.communicator->setDefaultObjectAdapter(adapter == nil ? nullptr : [adapter objectAdapter]);
+}
+
 - (ICEImplicitContext*)getImplicitContext
 {
     auto implicitContext = self.communicator->getImplicitContext();

--- a/swift/src/IceImpl/include/Communicator.h
+++ b/swift/src/IceImpl/include/Communicator.h
@@ -33,6 +33,9 @@ ICEIMPL_API @interface ICECommunicator : ICELocalObject
                                                      router:(ICEObjectPrx*)router
                                                       error:(NSError**)error
     NS_SWIFT_NAME(createObjectAdapterWithRouter(name:router:));
+
+- (nullable ICEObjectAdapter*)getDefaultObjectAdapter;
+- (void)setDefaultObjectAdapter:(ICEObjectAdapter* _Nullable)adapter;
 - (ICEImplicitContext*)getImplicitContext;
 - (id<ICELoggerProtocol>)getLogger;
 - (nullable ICEObjectPrx*)getDefaultRouter;

--- a/swift/test/Ice/adapterDeactivation/AllTests.swift
+++ b/swift/test/Ice/adapterDeactivation/AllTests.swift
@@ -91,29 +91,29 @@ func allTests(_ helper: TestHelper) async throws {
 
     if try await obj.ice_getConnection() != nil {
         output.write("testing object adapter with bi-dir connection... ")
-        try test(communicator.getDefaultObjectAdapter() == nil);
-        try test(obj.ice_getCachedConnection()!.getAdapter() == nil);
+        try test(communicator.getDefaultObjectAdapter() == nil)
+        try test(obj.ice_getCachedConnection()!.getAdapter() == nil)
 
-        let adapter = try communicator.createObjectAdapter("");
+        let adapter = try communicator.createObjectAdapter("")
 
-        communicator.setDefaultObjectAdapter(adapter);
-        try test(communicator.getDefaultObjectAdapter() === adapter);
-
-        // create new connection
-        try await obj.ice_getCachedConnection()!.close();
-        try await obj.ice_ping();
-
-        try test(obj.ice_getCachedConnection()!.getAdapter() === adapter);
-        communicator.setDefaultObjectAdapter(nil);
+        communicator.setDefaultObjectAdapter(adapter)
+        try test(communicator.getDefaultObjectAdapter() === adapter)
 
         // create new connection
-        try await obj.ice_getCachedConnection()!.close();
-        try await obj.ice_ping();
+        try await obj.ice_getCachedConnection()!.close()
+        try await obj.ice_ping()
 
-        try test(obj.ice_getCachedConnection()!.getAdapter() == nil);
-        try obj.ice_getCachedConnection()!.setAdapter(adapter);
-        try test(obj.ice_getCachedConnection()!.getAdapter() === adapter);
-        try obj.ice_getCachedConnection()!.setAdapter(nil);
+        try test(obj.ice_getCachedConnection()!.getAdapter() === adapter)
+        communicator.setDefaultObjectAdapter(nil)
+
+        // create new connection
+        try await obj.ice_getCachedConnection()!.close()
+        try await obj.ice_ping()
+
+        try test(obj.ice_getCachedConnection()!.getAdapter() == nil)
+        try obj.ice_getCachedConnection()!.setAdapter(adapter)
+        try test(obj.ice_getCachedConnection()!.getAdapter() === adapter)
+        try obj.ice_getCachedConnection()!.setAdapter(nil)
 
         adapter.destroy()
         do {
@@ -183,7 +183,7 @@ func allTests(_ helper: TestHelper) async throws {
     output.writeLine("ok")
 
     output.write("testing whether server is gone... ")
-    if (try await obj.ice_getConnection() == nil) { // collocated
+    if try await obj.ice_getConnection() == nil {  // collocated
         try await obj.ice_ping()
         output.writeLine("ok")
     } else {


### PR DESCRIPTION
Also add Communicator::get/setDefaultObjectAdapter in C++, Swift and Python.

It's the C++ version of #2888 and #2894.
