### PR TITLE
Prefer dynamic_pointer_cast over dynamic_cast when casting shared_ptr

### DIFF
--- a/cpp/include/Ice/MetricsAdminI.h
+++ b/cpp/include/Ice/MetricsAdminI.h
@@ -165,7 +165,7 @@ namespace IceInternal
                     m = p->second.first;
                 }
 
-                MetricsMapT<MemberMetricsType>* map = dynamic_cast<MetricsMapT<MemberMetricsType>*>(m.get());
+                auto map = std::dynamic_pointer_cast<MetricsMapT<MemberMetricsType>>(m);
                 assert(map);
                 return map->getMatching(helper);
             }

--- a/cpp/src/Ice/EndpointFactory.cpp
+++ b/cpp/src/Ice/EndpointFactory.cpp
@@ -121,7 +121,7 @@ IceInternal::UnderlyingEndpointFactory::initialize()
     EndpointFactoryPtr factory = _instance->getEndpointFactory(_type);
     if (factory)
     {
-        EndpointFactoryWithUnderlying* f = dynamic_cast<EndpointFactoryWithUnderlying*>(factory.get());
+        auto f = dynamic_pointer_cast<EndpointFactoryWithUnderlying>(factory);
         if (f)
         {
             _factory = f->cloneWithUnderlying(_instance, _underlying);

--- a/cpp/src/Ice/IPEndpointI.cpp
+++ b/cpp/src/Ice/IPEndpointI.cpp
@@ -151,7 +151,7 @@ IceInternal::IPEndpointI::withPublishedHost(string host) const
 bool
 IceInternal::IPEndpointI::equivalent(const EndpointIPtr& endpoint) const
 {
-    const IPEndpointI* ipEndpointI = dynamic_cast<const IPEndpointI*>(endpoint.get());
+    auto ipEndpointI = dynamic_pointer_cast<IPEndpointI>(endpoint);
     if (!ipEndpointI)
     {
         return false;

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -41,7 +41,7 @@ IceInternal::Ex::throwUOE(const char* file, int line, const string& expectedType
     // If the object is an unknown sliced object, we didn't find a
     // value factory, in this case raise a MarshalException instead.
     //
-    UnknownSlicedValue* usv = dynamic_cast<UnknownSlicedValue*>(v.get());
+    UnknownSlicedValuePtr usv = dynamic_pointer_cast<UnknownSlicedValue>(v);
     if (usv)
     {
         throw MarshalException{

--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -1337,7 +1337,7 @@ IceInternal::Instance::finishSetup(int& argc, const char* argv[], const Ice::Com
     // Load plug-ins.
     //
     assert(!_serverThreadPool);
-    PluginManagerI* pluginManagerImpl = dynamic_cast<PluginManagerI*>(_pluginManager.get());
+    auto pluginManagerImpl = dynamic_pointer_cast<PluginManagerI>(_pluginManager);
     assert(pluginManagerImpl);
     pluginManagerImpl->loadPlugins(argc, argv);
 

--- a/cpp/src/Ice/InstrumentationI.cpp
+++ b/cpp/src/Ice/InstrumentationI.cpp
@@ -58,11 +58,11 @@ namespace
         ThreadState newState;
     };
 
-    IPConnectionInfo* getIPConnectionInfo(const ConnectionInfoPtr& info)
+    IPConnectionInfoPtr getIPConnectionInfo(const ConnectionInfoPtr& info)
     {
         for (ConnectionInfoPtr p = info; p; p = p->underlying)
         {
-            IPConnectionInfo* ipInfo = dynamic_cast<IPConnectionInfo*>(p.get());
+            IPConnectionInfoPtr ipInfo = dynamic_pointer_cast<IPConnectionInfo>(p);
             if (ipInfo)
             {
                 return ipInfo;
@@ -101,7 +101,7 @@ namespace
             if (_id.empty())
             {
                 ostringstream os;
-                IPConnectionInfo* info = getIPConnectionInfo(_connectionInfo);
+                IPConnectionInfoPtr info = getIPConnectionInfo(_connectionInfo);
                 if (info)
                 {
                     os << info->localAddress << ':' << info->localPort;
@@ -850,7 +850,7 @@ CommunicatorObserverI::getConnectionObserver(
         try
         {
             ConnectionObserverPtr delegate;
-            ConnectionObserverI* o = dynamic_cast<ConnectionObserverI*>(observer.get());
+            auto o = dynamic_pointer_cast<ConnectionObserverI>(observer);
             if (_delegate)
             {
                 delegate = _delegate->getConnectionObserver(con, endpt, state, o ? o->getDelegate() : observer);
@@ -878,7 +878,7 @@ CommunicatorObserverI::getThreadObserver(
         try
         {
             ThreadObserverPtr delegate;
-            ThreadObserverI* o = dynamic_cast<ThreadObserverI*>(observer.get());
+            auto o = dynamic_pointer_cast<ThreadObserverI>(observer);
             if (_delegate)
             {
                 delegate = _delegate->getThreadObserver(parent, id, state, o ? o->getDelegate() : observer);

--- a/cpp/src/Ice/LoggerAdminI.cpp
+++ b/cpp/src/Ice/LoggerAdminI.cpp
@@ -565,9 +565,9 @@ namespace
         //
         // There is currently no way to have a null local logger
         //
-        assert(localLogger != 0);
+        assert(localLogger);
 
-        LoggerAdminLoggerI* wrapper = dynamic_cast<LoggerAdminLoggerI*>(localLogger.get());
+        auto wrapper = dynamic_pointer_cast<LoggerAdminLoggerI>(localLogger);
         if (wrapper)
         {
             // use the underlying local logger

--- a/cpp/src/Ice/OutgoingAsync.cpp
+++ b/cpp/src/Ice/OutgoingAsync.cpp
@@ -616,7 +616,7 @@ ProxyOutgoingAsyncBase::checkRetryAfterException(std::exception_ptr ex)
 
     // If it's a fixed proxy, retrying isn't useful as the proxy is tied to
     // the connection and the request will fail with the exception.
-    if (dynamic_cast<const FixedReference*>(ref.get()))
+    if (dynamic_pointer_cast<FixedReference>(ref))
     {
         rethrow_exception(ex);
     }

--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -1616,7 +1616,7 @@ IceInternal::RoutableReference::filterEndpoints(const vector<EndpointIPtr>& allE
         remove_if(
             endpoints.begin(),
             endpoints.end(),
-            [](const EndpointIPtr& p) { return dynamic_cast<OpaqueEndpointI*>(p.get()) != 0; }),
+            [](const EndpointIPtr& p) { return dynamic_pointer_cast<OpaqueEndpointI>(p) != nullptr; }),
         endpoints.end());
 
     // Filter out endpoints according to the mode of the reference.

--- a/cpp/src/Ice/SSL/SSLEndpointI.cpp
+++ b/cpp/src/Ice/SSL/SSLEndpointI.cpp
@@ -268,7 +268,7 @@ Ice::SSL::EndpointI::withPublishedHost(string host) const
 bool
 Ice::SSL::EndpointI::equivalent(const IceInternal::EndpointIPtr& endpoint) const
 {
-    const EndpointI* endpointI = dynamic_cast<const EndpointI*>(endpoint.get());
+    auto endpointI = dynamic_pointer_cast<EndpointI>(endpoint);
     if (!endpointI)
     {
         return false;

--- a/cpp/src/Ice/WSEndpoint.cpp
+++ b/cpp/src/Ice/WSEndpoint.cpp
@@ -289,7 +289,7 @@ IceInternal::WSEndpoint::withPublishedHost(string host) const
 bool
 IceInternal::WSEndpoint::equivalent(const EndpointIPtr& endpoint) const
 {
-    const WSEndpoint* wsEndpointI = dynamic_cast<const WSEndpoint*>(endpoint.get());
+    auto wsEndpointI = dynamic_pointer_cast<WSEndpoint>(endpoint);
     if (!wsEndpointI)
     {
         return false;

--- a/cpp/src/IceBT/EndpointI.cpp
+++ b/cpp/src/IceBT/EndpointI.cpp
@@ -212,7 +212,7 @@ IceBT::EndpointI::withPublishedHost(string) const
 bool
 IceBT::EndpointI::equivalent(const IceInternal::EndpointIPtr& endpoint) const
 {
-    const EndpointI* btEndpointI = dynamic_cast<const EndpointI*>(endpoint.get());
+    auto btEndpointI = dynamic_pointer_cast<EndpointI>(endpoint);
     if (!btEndpointI)
     {
         return false;

--- a/cpp/test/Ice/background/EndpointI.cpp
+++ b/cpp/test/Ice/background/EndpointI.cpp
@@ -214,7 +214,7 @@ EndpointI::withPublishedHost(string host) const
 bool
 EndpointI::equivalent(const IceInternal::EndpointIPtr& endpoint) const
 {
-    const EndpointI* testEndpointI = dynamic_cast<const EndpointI*>(endpoint.get());
+    auto testEndpointI = dynamic_pointer_cast<EndpointI>(endpoint);
     if (!testEndpointI)
     {
         return false;

--- a/cpp/test/Ice/metrics/InstrumentationI.h
+++ b/cpp/test/Ice/metrics/InstrumentationI.h
@@ -271,7 +271,7 @@ public:
         const Ice::Instrumentation::ConnectionObserverPtr& old) final
     {
         std::lock_guard lock(_mutex);
-        test(!old || dynamic_cast<ConnectionObserverI*>(old.get()));
+        test(!old || std::dynamic_pointer_cast<ConnectionObserverI>(old));
         if (!connectionObserver)
         {
             connectionObserver = std::make_shared<ConnectionObserverI>();
@@ -287,7 +287,7 @@ public:
         const Ice::Instrumentation::ThreadObserverPtr& old) final
     {
         std::lock_guard lock(_mutex);
-        test(!old || dynamic_cast<ThreadObserverI*>(old.get()));
+        test(!old || std::dynamic_pointer_cast<ThreadObserverI>(old));
         if (!threadObserver)
         {
             threadObserver = std::make_shared<ThreadObserverI>();

--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -608,7 +608,7 @@ allTests(Test::TestHelper* helper, bool)
         Ice::ValuePtr obj;
         in.read(obj);
         in.endEncapsulation();
-        test(obj && dynamic_cast<TestObjectReader*>(obj.get()));
+        test(obj && dynamic_pointer_cast<TestObjectReader>(obj));
     }
 
     {
@@ -623,7 +623,7 @@ allTests(Test::TestHelper* helper, bool)
         Ice::ValuePtr obj;
         in.read(obj);
         in.endEncapsulation();
-        test(obj && dynamic_cast<TestObjectReader*>(obj.get()));
+        test(obj && dynamic_pointer_cast<TestObjectReader>(obj));
         factory->setEnabled(false);
     }
 
@@ -693,7 +693,7 @@ allTests(Test::TestHelper* helper, bool)
         Ice::ValuePtr obj;
         in.read(obj);
         in.endEncapsulation();
-        test(obj && dynamic_cast<TestObjectReader*>(obj.get()));
+        test(obj && dynamic_pointer_cast<TestObjectReader>(obj));
         factory->setEnabled(false);
     }
 
@@ -759,7 +759,7 @@ allTests(Test::TestHelper* helper, bool)
         in.endEncapsulation();
         factory->setEnabled(false);
 
-        rf = dynamic_cast<FObjectReader*>(obj.get())->getF();
+        rf = dynamic_pointer_cast<FObjectReader>(obj)->getF();
         test(rf->fse.m == 56 && !rf->fsf);
     }
     cout << "ok" << endl;
@@ -795,7 +795,7 @@ allTests(Test::TestHelper* helper, bool)
                 Ice::ValuePtr obj;
                 in.read(obj);
                 in.endEncapsulation();
-                test(dynamic_cast<CObjectReader*>(obj.get()));
+                test(dynamic_pointer_cast<CObjectReader>(obj));
                 factory->setEnabled(false);
             }
 
@@ -813,8 +813,8 @@ allTests(Test::TestHelper* helper, bool)
                 Ice::ValuePtr obj;
                 in.read(obj);
                 in.endEncapsulation();
-                test(obj && dynamic_cast<DObjectReader*>(obj.get()));
-                dynamic_cast<DObjectReader*>(obj.get())->check();
+                test(obj && dynamic_pointer_cast<DObjectReader>(obj));
+                dynamic_pointer_cast<DObjectReader>(obj)->check();
                 factory->setEnabled(false);
             }
         }


### PR DESCRIPTION
Fixes #2896 