### PR TITLE
Avoid using fixed ports in adapter tests

### DIFF
--- a/cpp/test/Ice/adapterDeactivation/AllTests.cpp
+++ b/cpp/test/Ice/adapterDeactivation/AllTests.cpp
@@ -186,7 +186,7 @@ allTests(Test::TestHelper* helper)
         // Two non-loopback endpoints
         communicator->getProperties()->setProperty(
             "PHAdapter.Endpoints",
-            "tcp -h * -p " + to_string(firstPort) +":default -h *");
+            "tcp -h * -p " + to_string(firstPort) + ":default -h *");
 
         communicator->getProperties()->setProperty("PHAdapter.PublishedHost", "");
         {
@@ -266,7 +266,9 @@ allTests(Test::TestHelper* helper)
         auto router = obj->ice_identity<Ice::RouterPrx>(routerId)->ice_connectionId("rc");
         Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapterWithRouter("", router);
         test(adapter->getPublishedEndpoints().size() == 1);
-        test(adapter->getPublishedEndpoints()[0]->toString() == "tcp -h localhost -p " + to_string(routerPort) + " -t 30000");
+        test(
+            adapter->getPublishedEndpoints()[0]->toString() ==
+            "tcp -h localhost -p " + to_string(routerPort) + " -t 30000");
         try
         {
             adapter->setPublishedEndpoints(router->ice_getEndpoints());

--- a/cpp/test/Ice/adapterDeactivation/Collocated.cpp
+++ b/cpp/test/Ice/adapterDeactivation/Collocated.cpp
@@ -28,7 +28,7 @@ Collocated::run(int argc, char** argv)
     communicator->getProperties()->setProperty("TestAdapter.ThreadPool.Size", "2");
 
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    ServantLocatorPtr locator = make_shared<ServantLocatorI>();
+    ServantLocatorPtr locator = make_shared<ServantLocatorI>(this);
     adapter->addServantLocator(locator, "");
 
     void allTests(TestHelper*);

--- a/cpp/test/Ice/adapterDeactivation/ServantLocatorI.cpp
+++ b/cpp/test/Ice/adapterDeactivation/ServantLocatorI.cpp
@@ -20,7 +20,9 @@ namespace
 
         optional<ObjectPrx> getServerProxy(const Current& c) const final
         {
-            return ObjectPrx(c.adapter->getCommunicator(), "dummy:tcp -h localhost -p " + to_string(_routerPort) + " -t 30000");
+            return ObjectPrx(
+                c.adapter->getCommunicator(),
+                "dummy:tcp -h localhost -p " + to_string(_routerPort) + " -t 30000");
         }
 
         ObjectProxySeq addProxies(ObjectProxySeq, const Current&) final { return ObjectProxySeq(); }
@@ -30,9 +32,9 @@ namespace
     };
 }
 
-ServantLocatorI::ServantLocatorI(Test::TestHelper* helper) :
-    _deactivated(false),
-    _router(make_shared<RouterI>(helper)) {}
+ServantLocatorI::ServantLocatorI(Test::TestHelper* helper) : _deactivated(false), _router(make_shared<RouterI>(helper))
+{
+}
 
 ServantLocatorI::~ServantLocatorI() { test(_deactivated); }
 

--- a/cpp/test/Ice/adapterDeactivation/ServantLocatorI.cpp
+++ b/cpp/test/Ice/adapterDeactivation/ServantLocatorI.cpp
@@ -15,18 +15,24 @@ namespace
     class RouterI final : public Router
     {
     public:
+        RouterI(Test::TestHelper* helper) : _routerPort(helper->getTestPort(5)) {}
         optional<ObjectPrx> getClientProxy(optional<bool>&, const Current&) const final { return nullopt; }
 
         optional<ObjectPrx> getServerProxy(const Current& c) const final
         {
-            return ObjectPrx(c.adapter->getCommunicator(), "dummy:tcp -h localhost -p 23456 -t 30000");
+            return ObjectPrx(c.adapter->getCommunicator(), "dummy:tcp -h localhost -p " + to_string(_routerPort) + " -t 30000");
         }
 
         ObjectProxySeq addProxies(ObjectProxySeq, const Current&) final { return ObjectProxySeq(); }
+
+    private:
+        int _routerPort;
     };
 }
 
-ServantLocatorI::ServantLocatorI() : _deactivated(false), _router(make_shared<RouterI>()) {}
+ServantLocatorI::ServantLocatorI(Test::TestHelper* helper) :
+    _deactivated(false),
+    _router(make_shared<RouterI>(helper)) {}
 
 ServantLocatorI::~ServantLocatorI() { test(_deactivated); }
 

--- a/cpp/test/Ice/adapterDeactivation/ServantLocatorI.h
+++ b/cpp/test/Ice/adapterDeactivation/ServantLocatorI.h
@@ -6,11 +6,12 @@
 #define SERVANT_LOCATOR_I_H
 
 #include "Ice/Ice.h"
+#include "TestHelper.h"
 
 class ServantLocatorI final : public Ice::ServantLocator
 {
 public:
-    ServantLocatorI();
+    ServantLocatorI(Test::TestHelper*);
     ~ServantLocatorI() final;
 
     Ice::ObjectPtr locate(const Ice::Current&, std::shared_ptr<void>&) final;

--- a/cpp/test/Ice/adapterDeactivation/Server.cpp
+++ b/cpp/test/Ice/adapterDeactivation/Server.cpp
@@ -20,7 +20,7 @@ Server::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    ServantLocatorPtr locator = make_shared<ServantLocatorI>();
+    ServantLocatorPtr locator = make_shared<ServantLocatorI>(this);
     adapter->addServantLocator(locator, "");
     adapter->activate();
     serverReady();


### PR DESCRIPTION
I got a address already in use with this test in the datastorm branch. DataStorm tests are using port 12345 by default (need to fix that too).

We should avoid using fixed ports and instead use the helpers. I will fix other languages in a separate PR.