### PR TITLE
Install Ruby and Python for macOS using setup-LANG

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -43,7 +43,7 @@ runs:
 
     - uses: actions/setup-ruby@v1
       with:
-        python-version: "3.3"
+        ruby-version: "3.3"
       if: runner.os == 'macOS'
 
     - name: Install testing dependencies from pip

--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -24,17 +24,26 @@ runs:
       shell: bash
       if: runner.os == 'macOS'
 
-    # Python3 is already installed though Homebrew
     - name: Install brew dependencies
-      run: brew install ruby node php lmdb mcpp || true
+      run: brew install node php lmdb mcpp || true
       shell: bash
       if: runner.os == 'macOS'
 
-    - name: Add Ruby and Python interpreters from brew to PATH
-      run: |
-        echo "$(brew --prefix ruby)/bin" >> $GITHUB_PATH
-        echo "$(brew --prefix python3)/bin" >> $GITHUB_PATH
-      shell: bash
+    # - name: Add Ruby and Python interpreters from brew to PATH
+    #   run: |
+    #     echo "$(brew --prefix ruby)/bin" >> $GITHUB_PATH
+    #     echo "$(brew --prefix python3)/bin" >> $GITHUB_PATH
+    #   shell: bash
+    #   if: runner.os == 'macOS'
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+      if: runner.os == 'macOS'
+
+    - uses: actions/setup-ruby@v1
+      with:
+        python-version: "3.3"
       if: runner.os == 'macOS'
 
     - name: Install testing dependencies from pip

--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -41,7 +41,7 @@ runs:
         python-version: "3.12"
       if: runner.os == 'macOS'
 
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: "3.3"
       if: runner.os == 'macOS'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   ci:
-
     runs-on: macos-15
     steps:
       - name: Checkout repository
@@ -26,9 +25,6 @@ jobs:
 
       - name: Install doxygen and graphviz (a dependency of Doxygen for generating diagrams)
         run: brew install doxygen graphviz || true
-
-      - name: Install virtualenv for Python
-        run: pipx install virtualenv
 
       - name: Install docfx for C# API reference
         run: brew install docfx
@@ -66,8 +62,6 @@ jobs:
         run: |
           make -C ../../cpp slice2py Ice IceDiscovery IceLocatorDiscovery
           make -C ../
-          virtualenv .venv
-          source .venv/bin/activate
           pip install -r requirements.txt
           make html
           deactivate

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,7 +64,6 @@ jobs:
           make -C ../
           pip install -r requirements.txt
           make html
-          deactivate
 
       - name: Generate API reference for Swift
         run: |


### PR DESCRIPTION
This PR switches Python and Ruby installs on macOS CI to use the setup-XXX actions. CI is currently failing because brew updated to Python 3.13. 

Should we do this for the other operating systems? It's the generally recommend CI pattern but goes against our usual "test what comes with the os". 

Note that for Ruby, Python, Node, etc. the general recommendation is not really to install and use system packages.