### PR TITLE
Restructure CI setup dependencies

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -13,61 +13,20 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # ———— Linux and macOS ———— #
-    - name: Set Linux MAKEFLAGS
-      run: echo "MAKEFLAGS=-j$(nproc) V=1" >> $GITHUB_ENV
-      shell: bash
-      if: runner.os == 'Linux'
-
-    - name: Set macOS MAKEFLAGS
-      run: echo "MAKEFLAGS=-j$(sysctl -n hw.ncpu) V=1" >> $GITHUB_ENV
-      shell: bash
-      if: runner.os == 'macOS'
-
-    - name: Install brew dependencies
-      run: brew install node php lmdb mcpp || true
-      shell: bash
-      if: runner.os == 'macOS'
-
-    # - name: Add Ruby and Python interpreters from brew to PATH
-    #   run: |
-    #     echo "$(brew --prefix ruby)/bin" >> $GITHUB_PATH
-    #     echo "$(brew --prefix python3)/bin" >> $GITHUB_PATH
-    #   shell: bash
-    #   if: runner.os == 'macOS'
-
+    #
+    # General Setup (Python, Ruby, Node, Java, .NET, etc.)
+    #
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
-      if: runner.os == 'macOS'
+        python-version: "3.13"
 
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: "3.3"
-      if: runner.os == 'macOS'
 
-    - name: Install testing dependencies from pip
-      run: python3 -m pip install --break-system-packages --user passlib cryptography numpy
-      shell: bash
-      if: runner.os == 'macOS'
-
-    - name: Install xcodesdk dependencies
-      run: |
-        # We should consider removing the dependency on ice-xcode-builder
-        brew install zeroc-ice/tap/ice-builder-xcode
-      shell: bash
-      if: (runner.os == 'macOS') && (matrix.config == 'xcodesdk')
-
-    - name: Install apt dependencies
-      run: |
-        sudo apt-get update && sudo apt-get install -y \
-            python3 python3-pip nodejs libbz2-dev libssl-dev libffi-dev \
-            libmcpp-dev libedit-dev liblmdb-dev libexpat1-dev libsystemd-dev \
-            ruby ruby-dev php-cli php-dev \
-            libbluetooth-dev libdbus-1-dev \
-            libsystemd-dev
-      shell: bash
-      if: runner.os == 'Linux'
+    - uses: actions/setup-node@v4
+      with:
+        node-version: "20"
 
     - name: Setup Oracle Java 17
       uses: actions/setup-java@v4
@@ -81,21 +40,55 @@ runs:
         dotnet-version: 8.x
 
     - name: Install testing dependencies from pip
-      run: python3 -m pip install --break-system-packages passlib cryptography numpy
+      run: python3 -m pip install passlib cryptography numpy
+      shell: bash
+
+    #
+    # macOS
+    #
+    - name: Set macOS MAKEFLAGS
+      run: echo "MAKEFLAGS=-j$(sysctl -n hw.ncpu) V=1" >> $GITHUB_ENV
+      shell: bash
+      if: runner.os == 'macOS'
+
+    - name: Install brew dependencies
+      run: brew install php lmdb mcpp
+      shell: bash
+      if: runner.os == 'macOS'
+
+    - name: Install xcodesdk dependencies
+      run: |
+        # We should consider removing the dependency on ice-xcode-builder
+        brew install zeroc-ice/tap/ice-builder-xcode
+      shell: bash
+      if: (runner.os == 'macOS') && (matrix.config == 'xcodesdk')
+
+    #
+    # Linux
+    #
+    - name: Set Linux MAKEFLAGS
+      run: echo "MAKEFLAGS=-j$(nproc) V=1" >> $GITHUB_ENV
       shell: bash
       if: runner.os == 'Linux'
 
-    # ———— Windows ———— #
+    - name: Install apt dependencies
+      run: |
+        sudo apt-get update && sudo apt-get install -y \
+            libbz2-dev libssl-dev libffi-dev \
+            libmcpp-dev libedit-dev liblmdb-dev libexpat1-dev libsystemd-dev \
+            php-cli php-dev \
+            libbluetooth-dev libdbus-1-dev \
+            libsystemd-dev
+      shell: bash
+      if: runner.os == 'Linux'
+
+    #
+    # Windows
+    #
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2
       with:
         msbuild-architecture: x64
-      if: runner.os == 'Windows'
-
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.12"
       if: runner.os == 'Windows'
 
     - name: Configure Windows Python Environment
@@ -104,18 +97,9 @@ runs:
       shell: powershell
       if: runner.os == 'Windows'
 
-    # # This choco install will overwrite the existing Python installation
-    # - name: Setup Debug Python
-    #   run: |
-    #     choco install python312 --installargs='/quiet Include_debug=1' -y --no-progress
-    #   shell: powershell
-    #   if: runner.os == 'Windows' && matrix.config == 'debug'
-    - name: Install testing dependencies from pip
-      run: python3 -m pip install passlib cryptography numpy
-      shell: powershell
-      if: runner.os == 'Windows'
-
-    # ———— MATLAB ———— #
+    #
+    # MATLAB
+    #
     - name: Setup MATLAB
       id: setup-matlab
       uses: matlab-actions/setup-matlab@v2
@@ -161,7 +145,9 @@ runs:
       shell: powershell
       if: runner.os == 'Windows' && matrix.config == 'matlab'
 
-    # ———— Cache ———— #
+    #
+    # Cache
+    #
     - name: Setup ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:


### PR DESCRIPTION
Restructure the dependency setup to move setup of python, ruby, node, etc near each other and to use the generally recommended setup actions.