### PR TITLE
Remove 'Is firewall enabled?' message

### DIFF
--- a/cpp/test/Ice/udp/AllTests.cpp
+++ b/cpp/test/Ice/udp/AllTests.cpp
@@ -162,14 +162,9 @@ allTests(Test::TestHelper* helper)
         replyI = std::make_shared<PingReplyI>();
         reply = adapter->addWithUUID<PingReplyPrx>(replyI)->ice_datagram();
     }
-    if (!ret)
-    {
-        cout << "failed (is a firewall enabled?)" << endl;
-    }
-    else
-    {
-        cout << "ok" << endl;
-    }
+    test(ret);
+    cout << "ok" << endl;
+
 #endif
 
     cout << "testing udp bi-dir connection... " << flush;

--- a/csharp/test/Ice/udp/AllTests.cs
+++ b/csharp/test/Ice/udp/AllTests.cs
@@ -194,14 +194,8 @@ namespace Ice
                     replyI = new PingReplyI();
                     reply = (Test.PingReplyPrx)Test.PingReplyPrxHelper.uncheckedCast(adapter.addWithUUID(replyI)).ice_datagram();
                 }
-                if (!ret)
-                {
-                    Console.Out.WriteLine("failed(is a firewall enabled?)");
-                }
-                else
-                {
-                    Console.Out.WriteLine("ok");
-                }
+                test(ret);
+                Console.Out.WriteLine("ok");
 
                 Console.Out.Write("testing udp bi-dir connection... ");
                 Console.Out.Flush();
@@ -223,36 +217,6 @@ namespace Ice
                 }
                 test(ret);
                 Console.Out.WriteLine("ok");
-
-                //
-                // Sending the replies back on the multicast UDP connection doesn't work for most
-                // platform(it works for macOS Leopard but not Snow Leopard, doesn't work on SLES,
-                // Windows...). For Windows, see UdpTransceiver constructor for the details. So
-                // we don't run this test.
-                //
-                //         Console.Out.Write("testing udp bi-dir connection... ");
-                //         nRetry = 5;
-                //         while(nRetry-- > 0)
-                //         {
-                //             replyI.reset();
-                //             objMcast.pingBiDir(reply.ice_getIdentity());
-                //             ret = replyI.waitReply(5, 2000);
-                //             if(ret)
-                //             {
-                //                 break; // Success
-                //             }
-                //             replyI = new PingReplyI();
-                //             reply =(PingReplyPrx)PingReplyPrxHelper.uncheckedCast(adapter.addWithUUID(replyI)).ice_datagram();
-                //         }
-
-                //         if(!ret)
-                //         {
-                //             Console.Out.WriteLine("failed(is a firewall enabled?)");
-                //         }
-                //         else
-                //         {
-                //             Console.Out.WriteLine("ok");
-                //         }
             }
         }
     }

--- a/java/test/src/main/java/test/Ice/udp/AllTests.java
+++ b/java/test/src/main/java/test/Ice/udp/AllTests.java
@@ -173,11 +173,9 @@ public class AllTests {
                 replyI = new PingReplyI();
                 reply = PingReplyPrx.uncheckedCast(adapter.addWithUUID(replyI)).ice_datagram();
             }
-            if (!ret) {
-                out.println("failed (is a firewall enabled?)");
-            } else {
-                out.println("ok");
-            }
+
+            test(ret);
+            out.println("ok");
 
             out.print("testing udp bi-dir connection... ");
             out.flush();
@@ -198,36 +196,5 @@ public class AllTests {
             test(ret);
         }
         out.println("ok");
-
-        //
-        // Sending the replies back on the multicast UDP connection doesn't work for most
-        // platform (it works for macOS Leopard but not Snow Leopard, doesn't work on SLES,
-        // Windows...). For Windows, see UdpTransceiver constructor for the details. So
-        // we don't run this test.
-        //
-        //         out.print("testing udp bi-dir connection... ");
-        //         nRetry = 5;
-        //         while(nRetry-- > 0)
-        //         {
-        //             replyI.reset();
-        //             objMcast.pingBiDir(reply.ice_getIdentity());
-        //             ret = replyI.waitReply(5, 2000);
-        //             if(ret)
-        //             {
-        //                 break; // Success
-        //             }
-        //             replyI = new PingReplyI();
-        //             reply =
-        // PingReplyPrx.uncheckedCast(adapter.addWithUUID(replyI)).ice_datagram();
-        //         }
-
-        //         if(!ret)
-        //         {
-        //             out.println("failed (is a firewall enabled?)");
-        //         }
-        //         else
-        //         {
-        //             out.println("ok");
-        //         }
     }
 }

--- a/swift/test/Ice/udp/AllTests.swift
+++ b/swift/test/Ice/udp/AllTests.swift
@@ -155,11 +155,8 @@ public func allTests(_ helper: TestHelper) async throws {
             type: PingReplyPrx.self)
     }
 
-    if ret {
-        output.writeLine("ok")
-    } else {
-        output.writeLine("failed(is a firewall enabled?)")
-    }
+    try test(ret)
+    output.writeLine("ok")
 
     output.write("testing udp bi-dir connection... ")
     try await obj.ice_getConnection()!.setAdapter(adapter)


### PR DESCRIPTION
We have a handful of tests that can fail silently due to the user potentially having a firewall enabled. I've removed this message and the check. It's better to just fail.