### PR TITLE
Add support for DataStorm multicast testing

### DIFF
--- a/cpp/src/DataStorm/Instance.cpp
+++ b/cpp/src/DataStorm/Instance.cpp
@@ -56,6 +56,7 @@ Instance::Instance(const Ice::CommunicatorPtr& communicator) : _communicator(com
     if (properties->getPropertyAsIntWithDefault("DataStorm.Node.Multicast.Enabled", 1) > 0)
     {
         properties->setProperty("DataStorm.Node.Adapters.Multicast.Endpoints", "udp -h 239.255.0.1 -p 10000");
+        properties->setProperty("DataStorm.Node.Adapters.Multicast.PublishedHost", "239.255.0.1");
         properties->setProperty("DataStorm.Node.Adapters.Multicast.ProxyOptions", "-d");
         properties->setProperty("DataStorm.Node.Adapters.Multicast.ThreadPool.SizeMax", "1");
 

--- a/cpp/test/DataStorm/callbacks/test.py
+++ b/cpp/test/DataStorm/callbacks/test.py
@@ -11,6 +11,20 @@ traceProps = {
     "DataStorm.Trace.Data" : 2,
 }
 
+multicastProps = { "DataStorm.Node.Multicast.Enabled" : 1 }
+
 TestSuite(
     __file__,
-    [ ClientServerTestCase(client = Writer(), server = Reader(), traceProps=traceProps) ])
+    [
+        ClientServerTestCase(
+            name = "Writer/Reader",
+            client = Writer(),
+            server = Reader(),
+            traceProps=traceProps),
+        ClientServerTestCase(
+            name = "Writer/Reader multicast enabled",
+            client = Writer(props = multicastProps),
+            server = Reader(props = multicastProps),
+            traceProps=traceProps),
+    ],
+)

--- a/cpp/test/DataStorm/config/test.py
+++ b/cpp/test/DataStorm/config/test.py
@@ -11,6 +11,20 @@ traceProps = {
     "DataStorm.Trace.Data" : 2,
 }
 
+multicastProps = { "DataStorm.Node.Multicast.Enabled" : 1 }
+
 TestSuite(
     __file__,
-    [ ClientServerTestCase(client = Writer(), server = Reader(), traceProps=traceProps) ])
+    [
+        ClientServerTestCase(
+            name = "Writer/Reader",
+            client = Writer(),
+            server = Reader(),
+            traceProps=traceProps),
+        ClientServerTestCase(
+            name = "Writer/Reader multicast enabled",
+            client = Writer(props = multicastProps),
+            server = Reader(props = multicastProps),
+            traceProps=traceProps),
+    ],
+)

--- a/cpp/test/DataStorm/events/test.py
+++ b/cpp/test/DataStorm/events/test.py
@@ -13,6 +13,20 @@ traceProps = {
     "Ice.Trace.Network" : 2
 }
 
+multicastProps = { "DataStorm.Node.Multicast.Enabled" : 1 }
+
 TestSuite(
     __file__,
-    [ ClientServerTestCase(client = Writer(), server = Reader(), traceProps=traceProps) ])
+    [
+        ClientServerTestCase(
+            name = "Writer/Reader",
+            client = Writer(),
+            server = Reader(),
+            traceProps=traceProps),
+        ClientServerTestCase(
+            name = "Writer/Reader multicast enabled",
+            client = Writer(props = multicastProps),
+            server = Reader(props = multicastProps),
+            traceProps=traceProps),
+    ],
+)

--- a/cpp/test/DataStorm/partial/test.py
+++ b/cpp/test/DataStorm/partial/test.py
@@ -11,6 +11,20 @@ traceProps = {
     "DataStorm.Trace.Data" : 2
 }
 
+multicastProps = { "DataStorm.Node.Multicast.Enabled" : 1 }
+
 TestSuite(
     __file__,
-    [ ClientServerTestCase(client = Writer(), server = Reader(), traceProps=traceProps) ])
+    [
+        ClientServerTestCase(
+            name = "Writer/Reader",
+            client = Writer(),
+            server = Reader(),
+            traceProps=traceProps),
+        ClientServerTestCase(
+            name = "Writer/Reader multicast enabled",
+            client = Writer(props = multicastProps),
+            server = Reader(props = multicastProps),
+            traceProps=traceProps),
+    ],
+)

--- a/cpp/test/DataStorm/types/test.py
+++ b/cpp/test/DataStorm/types/test.py
@@ -11,7 +11,20 @@ traceProps = {
     "DataStorm.Trace.Data" : 2
 }
 
+multicastProps = { "DataStorm.Node.Multicast.Enabled" : 1 }
+
 TestSuite(
     __file__,
-    [ ClientServerTestCase(client = Writer(), server = Reader(), traceProps=traceProps) ],
-    runOnMainThread=True)
+    [
+        ClientServerTestCase(
+            name = "Writer/Reader",
+            client = Writer(),
+            server = Reader(),
+            traceProps=traceProps),
+        ClientServerTestCase(
+            name = "Writer/Reader multicast enabled",
+            client = Writer(props = multicastProps),
+            server = Reader(props = multicastProps),
+            traceProps=traceProps),
+    ],
+)

--- a/scripts/DataStormUtil.py
+++ b/scripts/DataStormUtil.py
@@ -39,6 +39,7 @@ class Writer(Client, DataStormProcess):
             # Default properties for tests that don't specify any DataStorm.Node.* properties
             props.update(
                 {
+                    "DataStorm.Node.Multicast.Enabled": 0,
                     "DataStorm.Node.Server.Enabled": 0,
                     "DataStorm.Node.ConnectTo": f"tcp -p {current.driver.getTestPort(10)}"
                 })
@@ -56,6 +57,7 @@ class Reader(Server, DataStormProcess):
             # Default properties for tests that don't specify any DataStorm.Node.* properties
             props.update(
                 {
+                    "DataStorm.Node.Multicast.Enabled": 0,
                     "DataStorm.Node.Server.Endpoints": f"tcp -p {current.driver.getTestPort(10)}"
                 })
         return props


### PR DESCRIPTION
Fix #2920

One potential issue is that we are using a fixed port for multicast and test can end up failing when running in parallel.

I going to add a fix for #2921 here.