### PR TITLE
Cleanup and document DataStorm Slice definitions

### DIFF
--- a/cpp/src/DataStorm/Contract.ice
+++ b/cpp/src/DataStorm/Contract.ice
@@ -4,244 +4,284 @@
 #pragma once
 
 #include <Ice/Identity.ice>
+#include <Ice/BuiltinSequences.ice>
 #include <DataStorm/Sample.ice>
 
 [["cpp:include:deque"]]
 
 module DataStormContract
 {
+    enum ClearHistoryPolicy
+    {
+        OnAdd,
+        OnRemove,
+        OnAll,
+        OnAllExceptPartialUpdate,
+        Never
+    };
 
-enum ClearHistoryPolicy
-{
-    OnAdd,
-    OnRemove,
-    OnAll,
-    OnAllExceptPartialUpdate,
-    Never
-};
+    /// A dictionary of <long, long>
+    dictionary<long, long> LongLongDict;
 
-/** A sequence of bytes use to hold the encoded key or value */
-sequence<byte> ByteSeq;
+    struct DataSample
+    {
+        /// The sample id.
+        long id;
 
-/** A sequence of long */
-sequence<long> LongSeq;
+        /// The key id.
+        long keyId;
 
-/** A sequence of strings */
-sequence<string> StringSeq;
+        /// The key value if the key ID <= 0.
+        Ice::ByteSeq keyValue;
 
-/** A dictionary of <long, long> */
-dictionary<long, long> LongLongDict;
+        /// The timestamp of the sample (write time).
+        long timestamp;
 
-struct DataSample
-{
-    /** The sample id. */
-    long id;
+        /// The update tag if the sample event is PartialUpdate.
+        long tag;
 
-    /** The key id. */
-    long keyId;
+        /// The sample event.
+        DataStorm::SampleEvent event;
 
-    /** The key value if the key ID <= 0. */
-    ByteSeq keyValue;
+        /// The value of the sample.
+        Ice::ByteSeq value;
+    }
 
-    /** The timestamp of the sample (write time). */
-    long timestamp;
+    // A queue of DataSample
+    ["cpp:type:std::deque<DataSample>"] sequence<DataSample> DataSampleSeq;
 
-    /** The update tag if the sample event is PartialUpdate. */
-    long tag;
+    struct DataSamples
+    {
+        /// The id of the writer or reader.
+        long id;
 
-    /** The sample event. */
-    DataStorm::SampleEvent event;
+        /// The samples.
+        DataSampleSeq samples;
+    }
+    sequence<DataSamples> DataSamplesSeq;
 
-    /** The value of the sample. */
-    ByteSeq value;
-}
-["cpp:type:std::deque<DataSample>"] sequence<DataSample> DataSampleSeq;
+    struct ElementInfo
+    {
+        /// The key or filter id.
+        long id;
 
-struct DataSamples
-{
-    /** The id of the writer or reader. */
-    long id;
+        /// The filter name.
+        string name;
 
-    /** The samples. */
-    DataSampleSeq samples;
-}
-sequence<DataSamples> DataSamplesSeq;
+        /// The key or filter value.
+        Ice::ByteSeq value;
+    }
+    sequence<ElementInfo> ElementInfoSeq;
 
-struct ElementInfo
-{
-    /** The key or filter id. */
-    long id;
+    struct TopicInfo
+    {
+        /// The topic name.
+        string name;
 
-    /** The filter name. */
-    string name;
+        /// The id of topic writers or readers.
+        Ice::LongSeq ids;
+    }
+    sequence<TopicInfo> TopicInfoSeq;
 
-    /** The key or filter value. */
-    ByteSeq value;
-}
-sequence<ElementInfo> ElementInfoSeq;
+    struct TopicSpec
+    {
+        /// The id of the topic.
+        long id;
 
-struct TopicInfo
-{
-    /** The topic name. */
-    string name;
+        /// The name of the topic.
+        string name;
 
-    /** The id of topic writers or readers. */
-    LongSeq ids;
-}
-sequence<TopicInfo> TopicInfoSeq;
+        /// The topic keys or filters.
+        ElementInfoSeq elements;
 
-struct TopicSpec
-{
-    /** The id of the topic. */
-    long id;
+        /// The topic update tags.
+        ElementInfoSeq tags;
+    };
 
-    /* The name of the topic. */
-    string name;
+    struct FilterInfo
+    {
+        string name;
+        Ice::ByteSeq criteria;
+    };
 
-    /** The topic keys or filters. */
-    ElementInfoSeq elements;
+    class ElementConfig(1)
+    {
+        optional(1) string facet;
+        optional(2) FilterInfo sampleFilter;
+        optional(3) string name;
+        optional(4) int priority;
 
-    /** The topic update tags. */
-    ElementInfoSeq tags;
-};
+        optional(10) int sampleCount;
+        optional(11) int sampleLifetime;
+        optional(12) ClearHistoryPolicy clearHistory;
+    };
 
-struct FilterInfo
-{
-    string name;
-    ByteSeq criteria;
-};
+    struct ElementData
+    {
+        /// The id of the writer or reader.
+        long id;
 
-class ElementConfig(1)
-{
-    optional(1) string facet;
-    optional(2) FilterInfo sampleFilter;
-    optional(3) string name;
-    optional(4) int priority;
+        /// The config of the writer or reader.
+        ElementConfig config;
 
-    optional(10) int sampleCount;
-    optional(11) int sampleLifetime;
-    optional(12) ClearHistoryPolicy clearHistory;
-};
+        /// The lastIds received by the reader.
+        LongLongDict lastIds;
+    }
+    sequence<ElementData> ElementDataSeq;
 
-struct ElementData
-{
-    /** The id of the writer or reader */
-    long id;
+    struct ElementSpec
+    {
+        /// The readers and writers associated with the key or filter.
+        ElementDataSeq elements;
 
-    /** The config of the writer or reader */
-    ElementConfig config;
+        /// The id of the key or filter.
+        long id;
 
-    /** The lastIds received by the reader. */
-    LongLongDict lastIds;
-}
-sequence<ElementData> ElementDataSeq;
+        /// The name of the filter.
+        string name;
 
-struct ElementSpec
-{
-    /** The readers and writers associated with the key or filter. */
-    ElementDataSeq elements;
+        /// The value of the key or filter.
+        Ice::ByteSeq value;
 
-    /** The id of the key or filter */
-    long id;
+        /// The id of the key or filter from the peer.
+        long peerId;
 
-    /** The name of the filter. */
-    string name;
+        /// The name of the filter from the peer.
+        string peerName;
+    }
+    sequence<ElementSpec> ElementSpecSeq;
 
-    /** The value of the key or filter. */
-    ByteSeq value;
+    struct ElementDataAck
+    {
+        /// The id of the writer or filter.
+        long id;
 
-    /** The id of the key or filter from the peer. */
-    long peerId;
+        /// The config of the writer or reader.
+        ElementConfig config;
 
-    /** The name of the filter from the peer. */
-    string peerName;
-}
-sequence<ElementSpec> ElementSpecSeq;
+        /// The lastIds received by the reader.
+        LongLongDict lastIds;
 
-struct ElementDataAck
-{
-    /** The id of the writer or filter. */
-    long id;
+        /// The samples of the writer or reader.
+        DataSampleSeq samples;
 
-    /** The config of the writer or reader */
-    ElementConfig config;
+        /// The id of the writer or reader on the peer.
+        long peerId;
+    }
+    sequence<ElementDataAck> ElementDataAckSeq;
 
-    /** The lastIds received by the reader. */
-    LongLongDict lastIds;
+    struct ElementSpecAck
+    {
+        /// The readers or writers associated with the key or filter.
+        ElementDataAckSeq elements;
 
-    /** The samples of the writer or reader */
-    DataSampleSeq samples;
+        /// The id of the key or filter.
+        long id;
 
-    /** The id of the writer or reader on the peer. */
-    long peerId;
-}
-sequence<ElementDataAck> ElementDataAckSeq;
+        /// The name of the filter.
+        string name;
 
-struct ElementSpecAck
-{
-    /** The readers or writers associated with the key or filter. */
-    ElementDataAckSeq elements;
+        /// The key or filter value.
+        Ice::ByteSeq value;
 
-    /** The id of the key or filter. */
-    long id;
+        /// The id of the key or filter on the peer.
+        long peerId;
 
-    /** The name of the filter. */
-    string name;
+        /// The name of the filter on the peer.
+        string peerName;
+    }
+    sequence<ElementSpecAck> ElementSpecAckSeq;
 
-    /** The key or filter value. */
-    ByteSeq value;
+    interface Session
+    {
+        void announceTopics(TopicInfoSeq topics, bool initialize);
+        void attachTopic(TopicSpec topic);
+        void detachTopic(long topic);
 
-    /** The id of the key or filter on the peer. */
-    long peerId;
+        void attachTags(long topic, ElementInfoSeq tags, bool initialize);
+        void detachTags(long topic, Ice::LongSeq tags);
 
-    /** The name of the filter on the peer. */
-    string peerName;
-}
-sequence<ElementSpecAck> ElementSpecAckSeq;
+        void announceElements(long topic, ElementInfoSeq keys);
+        void attachElements(long topic, ElementSpecSeq elements, bool initialize);
+        void attachElementsAck(long topic, ElementSpecAckSeq elements);
+        void detachElements(long topic, Ice::LongSeq keys);
 
-interface Session
-{
-    void announceTopics(TopicInfoSeq topics, bool initialize);
-    void attachTopic(TopicSpec topic);
-    void detachTopic(long topic);
+        void initSamples(long topic, DataSamplesSeq samples);
 
-    void attachTags(long topic, ElementInfoSeq tags, bool initialize);
-    void detachTags(long topic, LongSeq tags);
+        void disconnected();
+    }
 
-    void announceElements(long topic, ElementInfoSeq keys);
-    void attachElements(long topic, ElementSpecSeq elements, bool initialize);
-    void attachElementsAck(long topic, ElementSpecAckSeq elements);
-    void detachElements(long topic, LongSeq keys);
+    interface PublisherSession extends Session
+    {
+    }
 
-    void initSamples(long topic, DataSamplesSeq samples);
+    interface SubscriberSession extends Session
+    {
+        void s(long topicId, long elementId, DataSample sample);
+    }
 
-    void disconnected();
-}
+    /// The Node interface allows DataStorm nodes to create publisher and subscriber sessions with each other.
+    ///
+    /// When a node has a writer for a topic that another node is reading, the node initiates the creation of a
+    /// publisher session. Likewise, when a node has a reader for a topic that another node is writing, the node
+    /// initiates the creation of a subscriber session.
+    ///
+    /// The publisher node hosts the publisher session servant, which is accessed by the subscriber node through a
+    /// PublisherSession proxy. The subscriber node hosts the subscriber session servant, which is accessed by the
+    /// publisher node through a SubscriberSession proxy.
+    interface Node
+    {
+        /// Initiate the creation of a publisher session with a node, after
+        /// the target node has announced a topic reader for which this node has a corresponding topic writer.
+        ///
+        /// @param publisher The publisher node initiating the session. The proxy is never null.
+        /// @see Lookup::announceTopicReader
+        void initiateCreateSession(Node* publisher);
 
-interface PublisherSession extends Session
-{
-}
+        /// Initiate the creation of a subscriber session with a node, after
+        /// the target node has announced a topic writer for which this node has a corresponding topic reader,
+        /// or after the node has called Node::initiateCreateSession.
+        ///
+        /// @param subscriber The subscriber node initiating the session. The proxy is never null.
+        /// @param session The subscriber session being created. The proxy is never null.
+        /// @param fromRelay Indicates if the session is being created from a relay node.
+        void createSession(Node* subscriber, SubscriberSession* session, bool fromRelay);
 
-interface SubscriberSession extends Session
-{
-    void s(long topicId, long elementId, DataSample sample);
-}
+        /// Confirm the creation of a publisher session with a node.
+        ///
+        /// @param publisher The publisher node confirming the session. The proxy is never null.
+        /// @param session The publisher session being confirmed. The proxy is never null.
+        void confirmCreateSession(Node* publisher, PublisherSession* session);
+    }
 
-interface Node
-{
-    void initiateCreateSession(Node* publisher);
-    void createSession(Node* subscriber, SubscriberSession* session, bool fromRelay);
-    void confirmCreateSession(Node* publisher, PublisherSession* session);
-}
+    /// The lookup interface is used by DataStorm nodes to announce their topic readers and writers to other connected
+    /// nodes. When multicast is enabled, the lookup interface also broadcasts these announcements.
+    /// Each DataStorm node hosts a lookup servant with the identity "DataStorm/Lookup".
+    interface Lookup
+    {
+        /// Announce a topic reader.
+        ///
+        /// @param topic The name of the topic.
+        /// @param node The node reading the topic. The proxy is never null.
+        idempotent void announceTopicReader(string topic, Node* node);
 
-interface Lookup
-{
-    idempotent void announceTopicReader(string topic, Node* node);
-    idempotent void announceTopicWriter(string topic, Node* node);
+        /// Announce a topic writer.
+        ///
+        /// @param topic The name of the topic.
+        /// @param node The node writing the topic. The proxy is never null.
+        idempotent void announceTopicWriter(string topic, Node* node);
 
-    idempotent void announceTopics(StringSeq readers, StringSeq writers, Node* node);
+        /// Announce a set of topic readers and writers.
+        ///
+        /// @param readers A sequence of topic names for readers.
+        /// @param writers A sequence of topic names for writers.
+        /// @param node The node reading or writing the topics. The proxy is never null.
+        idempotent void announceTopics(Ice::StringSeq readers, Ice::StringSeq writers, Node* node);
 
-    Node* createSession(Node* node);
-}
-
+        /// Establish a connection between this node and another node.
+        ///
+        /// @param node The node initiating the connection. The proxy is never null.
+        /// @return A proxy to this node. The proxy is never null.
+        Node* createSession(Node* node);
+    }
 }

--- a/cpp/src/DataStorm/Contract.ice
+++ b/cpp/src/DataStorm/Contract.ice
@@ -18,9 +18,8 @@ module DataStormContract
         OnAll,
         OnAllExceptPartialUpdate,
         Never
-    };
+    }
 
-    /// A dictionary of <long, long>
     dictionary<long, long> LongLongDict;
 
     struct DataSample

--- a/cpp/src/DataStorm/LookupI.cpp
+++ b/cpp/src/DataStorm/LookupI.cpp
@@ -43,7 +43,7 @@ LookupI::announceTopicWriter(string name, optional<NodePrx> proxy, const Ice::Cu
 }
 
 void
-LookupI::announceTopics(StringSeq readers, StringSeq writers, optional<NodePrx> proxy, const Ice::Current& current)
+LookupI::announceTopics(Ice::StringSeq readers, Ice::StringSeq writers, optional<NodePrx> proxy, const Ice::Current& current)
 {
     if (proxy)
     {

--- a/cpp/src/DataStorm/LookupI.cpp
+++ b/cpp/src/DataStorm/LookupI.cpp
@@ -43,7 +43,11 @@ LookupI::announceTopicWriter(string name, optional<NodePrx> proxy, const Ice::Cu
 }
 
 void
-LookupI::announceTopics(Ice::StringSeq readers, Ice::StringSeq writers, optional<NodePrx> proxy, const Ice::Current& current)
+LookupI::announceTopics(
+    Ice::StringSeq readers,
+    Ice::StringSeq writers,
+    optional<NodePrx> proxy,
+    const Ice::Current& current)
 {
     if (proxy)
     {

--- a/cpp/src/DataStorm/LookupI.h
+++ b/cpp/src/DataStorm/LookupI.h
@@ -24,8 +24,8 @@ namespace DataStormI
         announceTopicWriter(std::string, std::optional<DataStormContract::NodePrx>, const Ice::Current&) override;
 
         virtual void announceTopics(
-            DataStormContract::StringSeq,
-            DataStormContract::StringSeq,
+            Ice::StringSeq,
+            Ice::StringSeq,
             std::optional<DataStormContract::NodePrx>,
             const Ice::Current&) override;
 

--- a/cpp/src/DataStorm/LookupI.h
+++ b/cpp/src/DataStorm/LookupI.h
@@ -23,11 +23,9 @@ namespace DataStormI
         virtual void
         announceTopicWriter(std::string, std::optional<DataStormContract::NodePrx>, const Ice::Current&) override;
 
-        virtual void announceTopics(
-            Ice::StringSeq,
-            Ice::StringSeq,
-            std::optional<DataStormContract::NodePrx>,
-            const Ice::Current&) override;
+        virtual void
+        announceTopics(Ice::StringSeq, Ice::StringSeq, std::optional<DataStormContract::NodePrx>, const Ice::Current&)
+            override;
 
         virtual std::optional<DataStormContract::NodePrx>
         createSession(std::optional<DataStormContract::NodePrx>, const Ice::Current&) override;

--- a/cpp/src/DataStorm/NodeSessionManager.cpp
+++ b/cpp/src/DataStorm/NodeSessionManager.cpp
@@ -219,8 +219,8 @@ NodeSessionManager::announceTopicWriter(const string& topic, NodePrx node, const
 
 void
 NodeSessionManager::announceTopics(
-    const StringSeq& readers,
-    const StringSeq& writers,
+    const Ice::StringSeq& readers,
+    const Ice::StringSeq& writers,
     NodePrx node,
     const Ice::ConnectionPtr& connection) const
 {

--- a/cpp/src/DataStorm/NodeSessionManager.h
+++ b/cpp/src/DataStorm/NodeSessionManager.h
@@ -34,8 +34,8 @@ namespace DataStormI
         announceTopicWriter(const std::string&, DataStormContract::NodePrx, const Ice::ConnectionPtr& = nullptr) const;
 
         void announceTopics(
-            const DataStormContract::StringSeq&,
-            const DataStormContract::StringSeq&,
+            const Ice::StringSeq&,
+            const Ice::StringSeq&,
             DataStormContract::NodePrx,
             const Ice::ConnectionPtr& = nullptr) const;
 

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -242,7 +242,7 @@ SessionI::attachTags(int64_t topicId, ElementInfoSeq tags, bool initialize, cons
 }
 
 void
-SessionI::detachTags(int64_t topicId, LongSeq tags, const Ice::Current&)
+SessionI::detachTags(int64_t topicId, Ice::LongSeq tags, const Ice::Current&)
 {
     lock_guard<mutex> lock(_mutex);
     if (!_session)
@@ -369,7 +369,7 @@ SessionI::attachElementsAck(int64_t id, ElementSpecAckSeq elements, const Ice::C
                 out << _id << ": attaching elements ack `[" << elements << "]@" << id << "' on topic `" << topic << "'";
             }
 
-            LongSeq removedIds;
+            Ice::LongSeq removedIds;
             auto samples = topic->attachElementsAck(id, elements, shared_from_this(), *_session, now, removedIds);
             if (!samples.empty())
             {
@@ -391,7 +391,7 @@ SessionI::attachElementsAck(int64_t id, ElementSpecAckSeq elements, const Ice::C
 }
 
 void
-SessionI::detachElements(int64_t id, LongSeq elements, const Ice::Current&)
+SessionI::detachElements(int64_t id, Ice::LongSeq elements, const Ice::Current&)
 {
     lock_guard<mutex> lock(_mutex);
     if (!_session)

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -248,14 +248,14 @@ namespace DataStormI
         virtual void detachTopic(std::int64_t, const Ice::Current&) override;
 
         virtual void attachTags(std::int64_t, DataStormContract::ElementInfoSeq, bool, const Ice::Current&) override;
-        virtual void detachTags(std::int64_t, DataStormContract::LongSeq, const Ice::Current&) override;
+        virtual void detachTags(std::int64_t, Ice::LongSeq, const Ice::Current&) override;
 
         virtual void announceElements(std::int64_t, DataStormContract::ElementInfoSeq, const Ice::Current&) override;
         virtual void
         attachElements(std::int64_t, DataStormContract::ElementSpecSeq, bool, const Ice::Current&) override;
         virtual void
         attachElementsAck(std::int64_t, DataStormContract::ElementSpecAckSeq, const Ice::Current&) override;
-        virtual void detachElements(std::int64_t, DataStormContract::LongSeq, const Ice::Current&) override;
+        virtual void detachElements(std::int64_t, Ice::LongSeq, const Ice::Current&) override;
 
         virtual void initSamples(std::int64_t, DataStormContract::DataSamplesSeq, const Ice::Current&) override;
 

--- a/cpp/src/DataStorm/TopicFactoryI.cpp
+++ b/cpp/src/DataStorm/TopicFactoryI.cpp
@@ -259,11 +259,11 @@ TopicFactoryI::getTopicWriters() const
     return writers;
 }
 
-DataStormContract::StringSeq
+Ice::StringSeq
 TopicFactoryI::getTopicReaderNames() const
 {
     lock_guard<mutex> lock(_mutex);
-    DataStormContract::StringSeq readers;
+    Ice::StringSeq readers;
     readers.reserve(_readers.size());
     for (const auto& p : _readers)
     {
@@ -272,11 +272,11 @@ TopicFactoryI::getTopicReaderNames() const
     return readers;
 }
 
-DataStormContract::StringSeq
+Ice::StringSeq
 TopicFactoryI::getTopicWriterNames() const
 {
     lock_guard<mutex> lock(_mutex);
-    DataStormContract::StringSeq writers;
+    Ice::StringSeq writers;
     writers.reserve(_writers.size());
     for (const auto& p : _writers)
     {

--- a/cpp/src/DataStorm/TopicFactoryI.h
+++ b/cpp/src/DataStorm/TopicFactoryI.h
@@ -57,8 +57,8 @@ namespace DataStormI
         DataStormContract::TopicInfoSeq getTopicReaders() const;
         DataStormContract::TopicInfoSeq getTopicWriters() const;
 
-        DataStormContract::StringSeq getTopicReaderNames() const;
-        DataStormContract::StringSeq getTopicWriterNames() const;
+        Ice::StringSeq getTopicReaderNames() const;
+        Ice::StringSeq getTopicWriterNames() const;
 
         void shutdown() const;
 

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -350,7 +350,7 @@ TopicI::attachElements(
                             {std::move(acks),
                              key->getId(),
                              "",
-                             spec.id < 0 ? key->encode(_instance->getCommunicator()) : ByteSeq(),
+                             spec.id < 0 ? key->encode(_instance->getCommunicator()) : Ice::ByteSeq(),
                              spec.id,
                              spec.name});
                     }
@@ -398,7 +398,7 @@ TopicI::attachElements(
                             {std::move(acks),
                              -filter->getId(),
                              filter->getName(),
-                             spec.id > 0 ? filter->encode(_instance->getCommunicator()) : ByteSeq(),
+                             spec.id > 0 ? filter->encode(_instance->getCommunicator()) : Ice::ByteSeq(),
                              spec.id,
                              spec.name});
                     }
@@ -416,7 +416,7 @@ TopicI::attachElementsAck(
     const shared_ptr<SessionI>& session,
     SessionPrx prx,
     const chrono::time_point<chrono::system_clock>& now,
-    LongSeq& removedIds)
+    Ice::LongSeq& removedIds)
 {
     DataSamplesSeq samples;
     vector<function<void()>> initCallbacks;

--- a/cpp/src/DataStorm/TopicI.h
+++ b/cpp/src/DataStorm/TopicI.h
@@ -74,7 +74,7 @@ namespace DataStormI
             const std::shared_ptr<SessionI>&,
             DataStormContract::SessionPrx,
             const std::chrono::time_point<std::chrono::system_clock>&,
-            DataStormContract::LongSeq&);
+            Ice::LongSeq&);
 
         virtual void setUpdater(const std::shared_ptr<Tag>&, Updater) override;
         const Updater& getUpdater(const std::shared_ptr<Tag>&) const;

--- a/slice/DataStorm/Sample.ice
+++ b/slice/DataStorm/Sample.ice
@@ -5,9 +5,8 @@
 
 module DataStorm
 {
-    /// The sample event matches the operation used by the DataWriter to update
-    /// the data element. It also provides information on what to expect from
-    /// the sample. A sample with the Add or Update event always provide a value
+    /// The sample event matches the operation used by the DataWriter to update the data element. It also provides
+    /// information on what to expect from the sample. A sample with the Add or Update event always provide a value
     /// while a sample with the Remove type doesn't.
     enum SampleEvent
     {

--- a/slice/DataStorm/Sample.ice
+++ b/slice/DataStorm/Sample.ice
@@ -5,34 +5,25 @@
 
 module DataStorm
 {
+    /// The sample event matches the operation used by the DataWriter to update
+    /// the data element. It also provides information on what to expect from
+    /// the sample. A sample with the Add or Update event always provide a value
+    /// while a sample with the Remove type doesn't.
+    enum SampleEvent
+    {
+        /// The element has been added.
+        Add,
 
-/**
- * The sample event.
- *
- * The sample event matches the operation used by the DataWriter to update
- * the data element. It also provides information on what to expect from
- * the sample. A sample with the Add or Update event always provide a value
- * while a sample with the Remove type doesn't.
- *
- */
-enum SampleEvent
-{
-    /** The element has been added. */
-    Add,
+        /// The element has been updated.
+        Update,
 
-    /** The element has been updated. */
-    Update,
+        /// The element has been partially updated.
+        PartialUpdate,
 
-    /** The element has been partially updated. */
-    PartialUpdate,
+        /// The element has been removed.
+        Remove,
+    }
 
-    /** The element has been removed. */
-    Remove,
-}
-
-/**
- * A sequence of sample type enumeration.
- */
-sequence<SampleEvent> SampleEventSeq;
-
+    /// A sequence of sample event.
+    sequence<SampleEvent> SampleEventSeq;
 }


### PR DESCRIPTION
This PR reformats the DataStorm Slice definitions and adds Doc comments. I didn't document all the interfaces yet.