### PR TITLE
Convert ForwarderManager::add into a template method

### DIFF
--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -54,8 +54,8 @@ DataElementI::DataElementI(TopicI* parent, const string& name, int64_t id, const
       _listenerCount(0),
       // The collocated forwarder is initalized here to avoid using a nullable proxy. The forwarder is only used by
       // the instance that owns it and is removed in destroy implementation.
-      _forwarder{Ice::uncheckedCast<SessionPrx>(parent->getInstance()->getCollocatedForwarder()->add(
-          [this](Ice::ByteSeq e, const Ice::Current& c) { forward(e, c); }))},
+      _forwarder{parent->getInstance()->getCollocatedForwarder()->add<SessionPrx>(
+          [this](Ice::ByteSeq e, const Ice::Current& c) { forward(e, c); })},
       _parent(parent->shared_from_this()),
       _waiters(0),
       _notified(0),

--- a/cpp/src/DataStorm/ForwarderManager.cpp
+++ b/cpp/src/DataStorm/ForwarderManager.cpp
@@ -14,33 +14,6 @@ ForwarderManager::ForwarderManager(const Ice::ObjectAdapterPtr& adapter, const s
 {
 }
 
-Ice::ObjectPrx
-ForwarderManager::add(function<void(Ice::ByteSeq, Response, Exception, const Ice::Current&)> forwarder)
-{
-    lock_guard<mutex> lock(_mutex);
-    const Ice::Identity id = {to_string(_nextId++), _category};
-    _forwarders.emplace(id.name, std::move(forwarder));
-    return _adapter->createProxy(std::move(id));
-}
-
-Ice::ObjectPrx
-ForwarderManager::add(function<void(Ice::ByteSeq, const Ice::Current&)> forwarder)
-{
-    return add(
-        [forwarder = std::move(forwarder)](auto inEncaps, auto response, auto exception, auto current)
-        {
-            try
-            {
-                forwarder(inEncaps, current);
-                response(true, Ice::ByteSeq());
-            }
-            catch (...)
-            {
-                exception(current_exception());
-            }
-        });
-}
-
 void
 ForwarderManager::remove(const Ice::Identity& id)
 {

--- a/cpp/src/DataStorm/ForwarderManager.h
+++ b/cpp/src/DataStorm/ForwarderManager.h
@@ -9,6 +9,7 @@
 #include "Ice/Ice.h"
 
 #include <functional>
+#include <mutex>
 #include <optional>
 
 namespace DataStormI
@@ -20,8 +21,38 @@ namespace DataStormI
         using Exception = std::function<void(std::exception_ptr)>;
 
         ForwarderManager(const Ice::ObjectAdapterPtr&, const std::string&);
-        Ice::ObjectPrx add(std::function<void(Ice::ByteSeq, Response, Exception, const Ice::Current&)>);
-        Ice::ObjectPrx add(std::function<void(Ice::ByteSeq, const Ice::Current&)>);
+
+        template<
+            typename Prx = Ice::ObjectPrx,
+            std::enable_if_t<std::is_base_of<Ice::ObjectPrx, Prx>::value, bool> = true>
+        Prx add(std::function<void(Ice::ByteSeq, Response, Exception, const Ice::Current&)> forwarder)
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            const Ice::Identity id = {std::to_string(_nextId++), _category};
+            _forwarders.emplace(id.name, std::move(forwarder));
+            return _adapter->createProxy<Prx>(std::move(id));
+        }
+
+        template<
+            typename Prx = Ice::ObjectPrx,
+            std::enable_if_t<std::is_base_of<Ice::ObjectPrx, Prx>::value, bool> = true>
+        Prx add(std::function<void(Ice::ByteSeq, const Ice::Current&)> forwarder)
+        {
+            return add<Prx>(
+                [forwarder = std::move(forwarder)](auto inEncaps, auto response, auto exception, auto current)
+                {
+                    try
+                    {
+                        forwarder(inEncaps, current);
+                        response(true, Ice::ByteSeq());
+                    }
+                    catch (...)
+                    {
+                        exception(std::current_exception());
+                    }
+                });
+        }
+
         void remove(const Ice::Identity&);
 
         void destroy();

--- a/cpp/src/DataStorm/NodeI.cpp
+++ b/cpp/src/DataStorm/NodeI.cpp
@@ -49,10 +49,10 @@ NodeI::NodeI(const shared_ptr<Instance>& instance)
       _proxy{instance->getObjectAdapter()->createProxy<NodePrx>({Ice::generateUUID(), ""})},
       // The subscriber and publisher collocated forwarders are initalized here to avoid using a nullable proxy. These
       // objects are only used after the node is initialized and are removed in destroy implementation.
-      _subscriberForwarder{Ice::uncheckedCast<SubscriberSessionPrx>(
-          instance->getCollocatedForwarder()->add([this](Ice::ByteSeq e, const Ice::Current& c) { forward(e, c); }))},
-      _publisherForwarder{Ice::uncheckedCast<PublisherSessionPrx>(
-          instance->getCollocatedForwarder()->add([this](Ice::ByteSeq e, const Ice::Current& c) { forward(e, c); }))},
+      _subscriberForwarder{instance->getCollocatedForwarder()->add<SubscriberSessionPrx>(
+          [this](Ice::ByteSeq e, const Ice::Current& c) { forward(e, c); })},
+      _publisherForwarder{instance->getCollocatedForwarder()->add<PublisherSessionPrx>(
+          [this](Ice::ByteSeq e, const Ice::Current& c) { forward(e, c); })},
       _nextSubscriberSessionId{0},
       _nextPublisherSessionId{0}
 {

--- a/cpp/src/DataStorm/NodeSessionManager.cpp
+++ b/cpp/src/DataStorm/NodeSessionManager.cpp
@@ -59,8 +59,8 @@ NodeSessionManager::NodeSessionManager(const shared_ptr<Instance>& instance, con
           instance->getCommunicator()->getProperties()->getPropertyAsInt(
               "DataStorm.Node.Server.ForwardDiscoveryToMulticast") > 0),
       _retryCount(0),
-      _forwarder(Ice::uncheckedCast<LookupPrx>(
-          instance->getCollocatedForwarder()->add([this](Ice::ByteSeq e, const Ice::Current& c) { forward(e, c); })))
+      _forwarder(instance->getCollocatedForwarder()->add<LookupPrx>([this](Ice::ByteSeq e, const Ice::Current& c)
+                                                                    { forward(e, c); }))
 {
 }
 

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -79,8 +79,8 @@ TopicI::TopicI(
       _instance(factory.lock()->getInstance()),
       _traceLevels(_instance->getTraceLevels()),
       _id(id),
-      _forwarder{Ice::uncheckedCast<SessionPrx>(
-          _instance->getCollocatedForwarder()->add([this](Ice::ByteSeq e, const Ice::Current& c) { forward(e, c); }))},
+      _forwarder{_instance->getCollocatedForwarder()->add<SessionPrx>([this](Ice::ByteSeq e, const Ice::Current& c)
+                                                                      { forward(e, c); })},
       _destroyed(false),
       _listenerCount(0),
       _waiters(0),


### PR DESCRIPTION
This PR refactors `ForwarderManager::add` into a template method, eliminating the need for callers to perform an uncheckedCast. 