### PR TITLE
Better VS Code Java formatting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
-        "ZeroCInc.slice"
+        "ZeroCInc.slice",
+        "josevseb.google-java-format-for-vs-code"
     ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
     "recommendations": [
         "ZeroCInc.slice",
-        "josevseb.google-java-format-for-vs-code"
+        "josevseb.google-java-format-for-vs-code",
+        "asf.apache-netbeans-java"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,7 @@
         "editor.defaultFormatter": "josevseb.google-java-format-for-vs-code"
     },
     "java.format.settings.google.extra": "--aosp",
+    "java.format.settings.google.version": "1.24.0", // should match version in ice.gradle
     "gradle.nestedProjects": true,
     "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m -Xlog:disable"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,10 @@
         "unregisters",
         "Upcall"
     ],
+    "[java]": {
+        "editor.defaultFormatter": "josevseb.google-java-format-for-vs-code"
+    },
+    "java.format.settings.google.extra": "--aosp",
     "gradle.nestedProjects": true,
     "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m -Xlog:disable"
 }

--- a/java/gradle/ice.gradle
+++ b/java/gradle/ice.gradle
@@ -81,6 +81,9 @@ spotless {
   }
 }
 
+// Run spotlessApply before compiling Java code
+compileJava.dependsOn 'spotlessApply'
+
 // Android does not have a compileJava task
 if(!(project.hasProperty('android') && project.android.sourceSets)) {
     compileJava {

--- a/java/gradle/ice.gradle
+++ b/java/gradle/ice.gradle
@@ -69,13 +69,14 @@ spotless {
 
     // Remove any unused imports, then ensure the remaining imports are correctly ordered.
     removeUnusedImports()
-    importOrder()
 
     // Linting
     cleanthat()
 
-    // Formatting
-    googleJavaFormat().aosp()
+    // We use google-java-format to format our Java code. We also set reorderImports and formatJavadoc to true to
+    // match the default behavior of the google-java-format tool.
+    // When updating the versio be sure to update the version in `.vscode/settings.json` as well.
+    googleJavaFormat("1.24.0").aosp().reorderImports(true).formatJavadoc(true)
     formatAnnotations()
   }
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -5,6 +5,7 @@
 package com.zeroc.Ice;
 
 import com.zeroc.Ice.Instrumentation.ConnectionState;
+
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -5,6 +5,7 @@
 package com.zeroc.Ice;
 
 import com.zeroc.Ice.Instrumentation.ThreadState;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
@@ -4,6 +4,7 @@ package com.zeroc.Ice;
 
 import com.zeroc.Ice.Instrumentation.CommunicatorObserver;
 import com.zeroc.Ice.SSL.SSLEngineFactory;
+
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ObserverMiddleware.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ObserverMiddleware.java
@@ -4,6 +4,7 @@ package com.zeroc.Ice;
 
 import com.zeroc.Ice.Instrumentation.CommunicatorObserver;
 import com.zeroc.Ice.Instrumentation.DispatchObserver;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/OpaqueEndpointI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/OpaqueEndpointI.java
@@ -5,6 +5,7 @@
 package com.zeroc.Ice;
 
 import com.zeroc.Ice.SSL.SSLEngineFactory;
+
 import java.util.Collections;
 
 final class OpaqueEndpointI extends EndpointI {

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/Options.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/Options.java
@@ -137,7 +137,7 @@ public final class Options {
                                         break;
                                     }
                                     switch (c = line.charAt(++i)) {
-                                            // Single-letter escape sequences.
+                                        // Single-letter escape sequences.
                                         case 'a':
                                             {
                                                 arg.append('\007');
@@ -189,7 +189,7 @@ public final class Options {
                                                 break;
                                             }
 
-                                            // Process up to three octal digits.
+                                        // Process up to three octal digits.
                                         case '0':
                                         case '1':
                                         case '2':
@@ -216,7 +216,7 @@ public final class Options {
                                                 break;
                                             }
 
-                                            // Process up to two hex digits.
+                                        // Process up to two hex digits.
                                         case 'x':
                                             {
                                                 final String hexDigits = "0123456789abcdefABCDEF";
@@ -251,7 +251,7 @@ public final class Options {
                                                 break;
                                             }
 
-                                            // Process control-chars.
+                                        // Process control-chars.
                                         case 'c':
                                             {
                                                 c = line.charAt(++i);
@@ -280,11 +280,11 @@ public final class Options {
                                                 break;
                                             }
 
-                                            // If inside an ANSI-quoted string, a backslash isn't
-                                            // followed by
-                                            // one of the recognized characters, both the backslash
-                                            // and the
-                                            // character are preserved.
+                                        // If inside an ANSI-quoted string, a backslash isn't
+                                        // followed by
+                                        // one of the recognized characters, both the backslash
+                                        // and the
+                                        // character are preserved.
                                         default:
                                             {
                                                 arg.append('\\');

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
@@ -5,10 +5,12 @@
 package com.zeroc.Ice.SSL;
 
 import com.zeroc.Ice.InitializationException;
+
 import java.io.InputStream;
 import java.security.cert.*;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLParameters;

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/SSL/TransceiverI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/SSL/TransceiverI.java
@@ -6,7 +6,9 @@ package com.zeroc.Ice.SSL;
 
 import com.zeroc.Ice.ConnectionLostException;
 import com.zeroc.Ice.SocketOperation;
+
 import java.nio.*;
+
 import javax.net.ssl.*;
 import javax.net.ssl.SSLEngineResult.*;
 

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/WSEndpoint.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/WSEndpoint.java
@@ -5,6 +5,7 @@
 package com.zeroc.Ice;
 
 import com.zeroc.Ice.SSL.SSLEngineFactory;
+
 import java.util.stream.Collectors;
 
 final class WSEndpoint extends EndpointI {

--- a/java/src/IceBT/src/main/java/com/zeroc/IceBT/AcceptorI.java
+++ b/java/src/IceBT/src/main/java/com/zeroc/IceBT/AcceptorI.java
@@ -4,11 +4,13 @@ package com.zeroc.IceBT;
 
 import android.bluetooth.BluetoothServerSocket;
 import android.bluetooth.BluetoothSocket;
+
 import com.zeroc.Ice.Acceptor;
 import com.zeroc.Ice.ReadyCallback;
 import com.zeroc.Ice.SocketException;
 import com.zeroc.Ice.SocketOperation;
 import com.zeroc.Ice.Transceiver;
+
 import java.util.UUID;
 
 final class AcceptorI implements Acceptor {

--- a/java/src/IceBT/src/main/java/com/zeroc/IceBT/EndpointI.java
+++ b/java/src/IceBT/src/main/java/com/zeroc/IceBT/EndpointI.java
@@ -3,6 +3,7 @@
 package com.zeroc.IceBT;
 
 import android.bluetooth.BluetoothAdapter;
+
 import com.zeroc.Ice.Acceptor;
 import com.zeroc.Ice.Connector;
 import com.zeroc.Ice.EndpointI_connectors;
@@ -12,6 +13,7 @@ import com.zeroc.Ice.InputStream;
 import com.zeroc.Ice.OutputStream;
 import com.zeroc.Ice.ParseException;
 import com.zeroc.Ice.Transceiver;
+
 import java.util.Collections;
 import java.util.UUID;
 

--- a/java/src/IceBT/src/main/java/com/zeroc/IceBT/Instance.java
+++ b/java/src/IceBT/src/main/java/com/zeroc/IceBT/Instance.java
@@ -3,6 +3,7 @@
 package com.zeroc.IceBT;
 
 import android.bluetooth.BluetoothAdapter;
+
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.PluginInitializationException;
 

--- a/java/src/IceBT/src/main/java/com/zeroc/IceBT/TransceiverI.java
+++ b/java/src/IceBT/src/main/java/com/zeroc/IceBT/TransceiverI.java
@@ -5,12 +5,14 @@ package com.zeroc.IceBT;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothSocket;
+
 import com.zeroc.Ice.Buffer;
 import com.zeroc.Ice.LocalException;
 import com.zeroc.Ice.ReadyCallback;
 import com.zeroc.Ice.SocketException;
 import com.zeroc.Ice.SocketOperation;
 import com.zeroc.Ice.Transceiver;
+
 import java.nio.ByteBuffer;
 import java.nio.channels.*;
 import java.util.UUID;

--- a/java/src/IceBox/src/main/java/com/zeroc/IceBox/ServiceManagerI.java
+++ b/java/src/IceBox/src/main/java/com/zeroc/IceBox/ServiceManagerI.java
@@ -5,6 +5,7 @@ package com.zeroc.IceBox;
 import com.zeroc.Ice.Current;
 import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
+
 import java.net.URLEncoder;
 
 // NOTE: the class isn't final on purpose to allow users to eventually extend it.

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/AdapterObserverI.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/AdapterObserverI.java
@@ -3,6 +3,7 @@
 package com.zeroc.IceGridGUI;
 
 import com.zeroc.IceGrid.*;
+
 import javax.swing.SwingUtilities;
 
 class AdapterObserverI implements AdapterObserver {

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/AbstractServerEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/AbstractServerEditor.java
@@ -3,6 +3,7 @@
 package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.*;
+
 import javax.swing.JOptionPane;
 
 /** Base class for ServerEditor and ServerInstanceEditor */

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Adapter.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Adapter.java
@@ -4,7 +4,9 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.Component;
+
 import javax.swing.JTree;
 import javax.swing.tree.DefaultTreeCellRenderer;
 

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/AdapterEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/AdapterEditor.java
@@ -6,9 +6,11 @@ import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.CellConstraints;
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.event.ActionEvent;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.DefaultComboBoxModel;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ApplicationEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ApplicationEditor.java
@@ -6,6 +6,7 @@ import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.CellConstraints;
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ArrayMapField.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ArrayMapField.java
@@ -3,7 +3,9 @@
 package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.event.ActionEvent;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JTable;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Communicator.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Communicator.java
@@ -4,7 +4,9 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.util.Enumeration;
+
 import javax.swing.JOptionPane;
 import javax.swing.tree.DefaultTreeModel;
 

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/CommunicatorSubEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/CommunicatorSubEditor.java
@@ -6,6 +6,7 @@ import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.CellConstraints;
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Editor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Editor.java
@@ -6,8 +6,10 @@ import com.jgoodies.forms.builder.ButtonBarBuilder;
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.factories.Borders;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
+
 import javax.swing.AbstractAction;
 import javax.swing.JButton;
 import javax.swing.JComponent;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ListTextField.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ListTextField.java
@@ -3,6 +3,7 @@
 package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGridGUI.*;
+
 import javax.swing.JTextField;
 
 /** A special field used to show/edit a list of strings separated by whitespace */

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ListTreeNode.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ListTreeNode.java
@@ -3,7 +3,9 @@
 package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGridGUI.*;
+
 import java.util.Enumeration;
+
 import javax.swing.tree.DefaultTreeModel;
 
 /** An editable TreeNode that holds a list of children */

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Node.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Node.java
@@ -4,8 +4,10 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.Component;
 import java.util.Enumeration;
+
 import javax.swing.Icon;
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/NodeEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/NodeEditor.java
@@ -6,6 +6,7 @@ import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.CellConstraints;
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Nodes.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Nodes.java
@@ -4,6 +4,7 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
 

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ParameterValuesField.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ParameterValuesField.java
@@ -3,6 +3,7 @@
 package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGridGUI.*;
+
 import javax.swing.DefaultCellEditor;
 import javax.swing.JComboBox;
 import javax.swing.JTable;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ParametersField.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ParametersField.java
@@ -3,6 +3,7 @@
 package com.zeroc.IceGridGUI.Application;
 
 import java.awt.event.ActionEvent;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.DefaultCellEditor;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PlainServer.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PlainServer.java
@@ -4,7 +4,9 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.Component;
+
 import javax.swing.Icon;
 import javax.swing.JPopupMenu;
 import javax.swing.JTree;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PlainService.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PlainService.java
@@ -4,7 +4,9 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.Component;
+
 import javax.swing.JPopupMenu;
 import javax.swing.JTree;
 import javax.swing.tree.DefaultTreeCellRenderer;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PropertiesField.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PropertiesField.java
@@ -4,7 +4,9 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.event.ActionEvent;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JTable;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PropertySet.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PropertySet.java
@@ -4,7 +4,9 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.Component;
+
 import javax.swing.JTree;
 import javax.swing.tree.DefaultTreeCellRenderer;
 

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PropertySetEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PropertySetEditor.java
@@ -6,6 +6,7 @@ import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.CellConstraints;
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PropertySets.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PropertySets.java
@@ -4,6 +4,7 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import javax.swing.JPopupMenu;
 
 class PropertySets extends ListTreeNode implements PropertySetParent {

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ReplicaGroup.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ReplicaGroup.java
@@ -4,7 +4,9 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.Component;
+
 import javax.swing.JTree;
 import javax.swing.tree.DefaultTreeCellRenderer;
 

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ReplicaGroupEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ReplicaGroupEditor.java
@@ -6,8 +6,10 @@ import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.CellConstraints;
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
+
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ReplicaGroups.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ReplicaGroups.java
@@ -4,6 +4,7 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import javax.swing.JPopupMenu;
 
 class ReplicaGroups extends ListTreeNode {

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Root.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Root.java
@@ -4,9 +4,11 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.Component;
 import java.awt.Cursor;
 import java.io.File;
+
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
 import javax.swing.JTree;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServerInstance.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServerInstance.java
@@ -4,7 +4,9 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.Component;
+
 import javax.swing.Icon;
 import javax.swing.JPopupMenu;
 import javax.swing.JTree;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServerInstanceEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServerInstanceEditor.java
@@ -6,7 +6,9 @@ import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.CellConstraints;
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.event.ActionEvent;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JButton;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServerInstancePropertySetEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServerInstancePropertySetEditor.java
@@ -3,6 +3,7 @@
 package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGridGUI.*;
+
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServerSubEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServerSubEditor.java
@@ -6,7 +6,9 @@ import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.CellConstraints;
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.event.ActionEvent;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JCheckBox;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServerTemplate.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServerTemplate.java
@@ -4,7 +4,9 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.Component;
+
 import javax.swing.Icon;
 import javax.swing.JPopupMenu;
 import javax.swing.JTree;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServerTemplates.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServerTemplates.java
@@ -4,6 +4,7 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import javax.swing.JPopupMenu;
 
 class ServerTemplates extends Templates {

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServiceInstance.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServiceInstance.java
@@ -4,7 +4,9 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.Component;
+
 import javax.swing.JPopupMenu;
 import javax.swing.JTree;
 import javax.swing.tree.DefaultTreeCellRenderer;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServiceInstanceEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServiceInstanceEditor.java
@@ -6,7 +6,9 @@ import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.CellConstraints;
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.event.ActionEvent;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JButton;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServiceSubEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServiceSubEditor.java
@@ -5,6 +5,7 @@ package com.zeroc.IceGridGUI.Application;
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import javax.swing.JTextField;
 
 class ServiceSubEditor extends CommunicatorSubEditor {

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServiceTemplate.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServiceTemplate.java
@@ -4,7 +4,9 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.Component;
+
 import javax.swing.JPopupMenu;
 import javax.swing.JTree;
 import javax.swing.tree.DefaultTreeCellRenderer;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServiceTemplates.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServiceTemplates.java
@@ -4,6 +4,7 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import javax.swing.JPopupMenu;
 
 class ServiceTemplates extends Templates {

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/SimpleMapField.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/SimpleMapField.java
@@ -3,7 +3,9 @@
 package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.event.ActionEvent;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JTable;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/TemplateEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/TemplateEditor.java
@@ -5,6 +5,7 @@ package com.zeroc.IceGridGUI.Application;
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.CellConstraints;
 import com.zeroc.IceGrid.*;
+
 import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
 import javax.swing.JTextField;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/TreeNode.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/TreeNode.java
@@ -4,6 +4,7 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.util.Enumeration;
 
 public abstract class TreeNode extends TreeNodeBase {

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/ApplicationActions.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/ApplicationActions.java
@@ -3,7 +3,9 @@
 package com.zeroc.IceGridGUI;
 
 import com.zeroc.IceGridGUI.Application.*;
+
 import java.awt.event.ActionEvent;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/ApplicationObserverI.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/ApplicationObserverI.java
@@ -3,6 +3,7 @@
 package com.zeroc.IceGridGUI;
 
 import com.zeroc.IceGrid.*;
+
 import javax.swing.SwingUtilities;
 
 class ApplicationObserverI implements ApplicationObserver {

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/ApplicationPane.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/ApplicationPane.java
@@ -6,9 +6,11 @@ import com.jgoodies.forms.factories.Borders;
 import com.zeroc.IceGridGUI.Application.Editor;
 import com.zeroc.IceGridGUI.Application.Root;
 import com.zeroc.IceGridGUI.Application.TreeNode;
+
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.TreeSelectionEvent;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/CellRenderer.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/CellRenderer.java
@@ -3,6 +3,7 @@
 package com.zeroc.IceGridGUI;
 
 import java.awt.Component;
+
 import javax.swing.JTree;
 import javax.swing.tree.DefaultTreeCellRenderer;
 import javax.swing.tree.TreeCellRenderer;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Coordinator.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Coordinator.java
@@ -13,6 +13,7 @@ import com.jgoodies.looks.plastic.PlasticLookAndFeel;
 import com.zeroc.Ice.LocatorFinderPrx;
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.LiveDeployment.MetricsViewEditor.MetricsViewTransferableData;
+
 import java.awt.*;
 import java.awt.event.*;
 import java.io.BufferedReader;
@@ -34,6 +35,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.prefs.Preferences;
+
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
 import javax.net.ssl.KeyManager;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/EditorBase.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/EditorBase.java
@@ -6,7 +6,9 @@ import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.factories.Borders;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.util.LayoutStyle;
+
 import java.awt.BorderLayout;
+
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveActions.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveActions.java
@@ -3,7 +3,9 @@
 package com.zeroc.IceGridGUI;
 
 import com.zeroc.IceGridGUI.LiveDeployment.*;
+
 import java.awt.event.ActionEvent;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Adapter.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Adapter.java
@@ -4,7 +4,9 @@ package com.zeroc.IceGridGUI.LiveDeployment;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.Component;
+
 import javax.swing.Icon;
 import javax.swing.JTree;
 import javax.swing.tree.DefaultTreeCellRenderer;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/AdapterEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/AdapterEditor.java
@@ -6,6 +6,7 @@ import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.CellConstraints;
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import javax.swing.JCheckBox;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ApplicationDetailsDialog.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ApplicationDetailsDialog.java
@@ -7,7 +7,9 @@ import com.jgoodies.forms.factories.Borders;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.util.LayoutStyle;
 import com.zeroc.IceGrid.*;
+
 import java.awt.Container;
+
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JTextField;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Communicator.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Communicator.java
@@ -3,6 +3,7 @@
 package com.zeroc.IceGridGUI.LiveDeployment;
 
 import java.util.Enumeration;
+
 import javax.swing.SwingUtilities;
 
 public abstract class Communicator extends TreeNode {

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/CommunicatorEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/CommunicatorEditor.java
@@ -6,7 +6,9 @@ import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.CellConstraints;
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.event.ActionEvent;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JButton;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/GraphView.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/GraphView.java
@@ -14,6 +14,22 @@ import com.zeroc.IceGridGUI.LiveDeployment.MetricsViewEditor.FormattedNumberRend
 import com.zeroc.IceGridGUI.LiveDeployment.MetricsViewEditor.MetricsCell;
 import com.zeroc.IceGridGUI.LiveDeployment.MetricsViewEditor.MetricsViewInfo;
 import com.zeroc.IceGridGUI.LiveDeployment.MetricsViewEditor.MetricsViewTransferableData;
+
+import javafx.application.Platform;
+import javafx.embed.swing.JFXPanel;
+import javafx.event.EventHandler;
+import javafx.scene.Scene;
+import javafx.scene.chart.LineChart;
+import javafx.scene.chart.NumberAxis;
+import javafx.scene.chart.XYChart;
+import javafx.scene.input.DataFormat;
+import javafx.scene.input.DragEvent;
+import javafx.scene.input.Dragboard;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.input.TransferMode;
+import javafx.util.StringConverter;
+
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -39,20 +55,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
-import javafx.application.Platform;
-import javafx.embed.swing.JFXPanel;
-import javafx.event.EventHandler;
-import javafx.scene.Scene;
-import javafx.scene.chart.LineChart;
-import javafx.scene.chart.NumberAxis;
-import javafx.scene.chart.XYChart;
-import javafx.scene.input.DataFormat;
-import javafx.scene.input.DragEvent;
-import javafx.scene.input.Dragboard;
-import javafx.scene.input.MouseButton;
-import javafx.scene.input.MouseEvent;
-import javafx.scene.input.TransferMode;
-import javafx.util.StringConverter;
+
 import javax.swing.AbstractAction;
 import javax.swing.AbstractCellEditor;
 import javax.swing.Action;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/LogFilterDialog.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/LogFilterDialog.java
@@ -9,8 +9,10 @@ import com.jgoodies.forms.layout.CellConstraints;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.util.LayoutStyle;
 import com.zeroc.Ice.LogMessageType;
+
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/LogPrefsDialog.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/LogPrefsDialog.java
@@ -7,8 +7,10 @@ import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.factories.Borders;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.util.LayoutStyle;
+
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JComponent;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/MetricsView.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/MetricsView.java
@@ -3,7 +3,9 @@
 package com.zeroc.IceGridGUI.LiveDeployment;
 
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.Component;
+
 import javax.swing.Icon;
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/MetricsViewEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/MetricsViewEditor.java
@@ -5,6 +5,7 @@
 package com.zeroc.IceGridGUI.LiveDeployment;
 
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Cursor;
@@ -26,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.prefs.Preferences;
+
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JComponent;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Node.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Node.java
@@ -4,9 +4,11 @@ package com.zeroc.IceGridGUI.LiveDeployment;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.Component;
 import java.awt.Cursor;
 import java.text.NumberFormat;
+
 import javax.swing.Icon;
 import javax.swing.JPopupMenu;
 import javax.swing.JTree;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/NodeEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/NodeEditor.java
@@ -5,7 +5,9 @@ package com.zeroc.IceGridGUI.LiveDeployment;
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.CellConstraints;
 import com.zeroc.IceGrid.*;
+
 import java.awt.event.ActionEvent;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JButton;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ObjectDialog.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ObjectDialog.java
@@ -8,9 +8,11 @@ import com.jgoodies.forms.factories.Borders;
 import com.jgoodies.forms.layout.CellConstraints;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.util.LayoutStyle;
+
 import java.awt.Container;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JComboBox;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/RegistryEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/RegistryEditor.java
@@ -5,9 +5,11 @@ package com.zeroc.IceGridGUI.LiveDeployment;
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.CellConstraints;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.event.ActionEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JMenuItem;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Root.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Root.java
@@ -4,8 +4,10 @@ package com.zeroc.IceGridGUI.LiveDeployment;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.Component;
 import java.util.prefs.Preferences;
+
 import javax.swing.Icon;
 import javax.swing.JDialog;
 import javax.swing.JOptionPane;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Server.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Server.java
@@ -4,7 +4,9 @@ package com.zeroc.IceGridGUI.LiveDeployment;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.Component;
+
 import javax.swing.Icon;
 import javax.swing.JMenu;
 import javax.swing.JOptionPane;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ServerEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ServerEditor.java
@@ -10,7 +10,9 @@ import com.jgoodies.looks.Options;
 import com.jgoodies.looks.plastic.PlasticLookAndFeel;
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.event.ActionEvent;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JButton;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Service.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Service.java
@@ -4,7 +4,9 @@ package com.zeroc.IceGridGUI.LiveDeployment;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.Component;
+
 import javax.swing.Icon;
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ServiceEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ServiceEditor.java
@@ -9,6 +9,7 @@ import com.jgoodies.looks.Options;
 import com.jgoodies.looks.plastic.PlasticLookAndFeel;
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import javax.swing.JCheckBox;
 import javax.swing.JTextField;
 import javax.swing.JToolBar;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ShowIceLogDialog.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ShowIceLogDialog.java
@@ -12,6 +12,7 @@ import com.zeroc.Ice.LogMessage;
 import com.zeroc.Ice.LogMessageType;
 import com.zeroc.Ice.RemoteLoggerPrx;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -19,6 +20,7 @@ import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.util.prefs.Preferences;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.ButtonGroup;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ShowLogFileDialog.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ShowLogFileDialog.java
@@ -8,10 +8,12 @@ import com.jgoodies.looks.Options;
 import com.jgoodies.looks.plastic.PlasticLookAndFeel;
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.util.prefs.Preferences;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.ButtonGroup;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Slave.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Slave.java
@@ -4,8 +4,10 @@ package com.zeroc.IceGridGUI.LiveDeployment;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.Component;
 import java.awt.Cursor;
+
 import javax.swing.Icon;
 import javax.swing.JPopupMenu;
 import javax.swing.JTree;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/SlaveEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/SlaveEditor.java
@@ -4,6 +4,7 @@ package com.zeroc.IceGridGUI.LiveDeployment;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.zeroc.IceGrid.*;
+
 import javax.swing.JTextField;
 
 class SlaveEditor extends CommunicatorEditor {

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/TableField.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/TableField.java
@@ -4,6 +4,7 @@ package com.zeroc.IceGridGUI.LiveDeployment;
 
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import javax.swing.JTable;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/TreeNode.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/TreeNode.java
@@ -3,6 +3,7 @@
 package com.zeroc.IceGridGUI.LiveDeployment;
 
 import com.zeroc.IceGridGUI.*;
+
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/WriteMessageDialog.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/WriteMessageDialog.java
@@ -9,9 +9,11 @@ import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.util.LayoutStyle;
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceGridGUI.*;
+
 import java.awt.Container;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeploymentPane.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeploymentPane.java
@@ -6,9 +6,11 @@ import com.jgoodies.forms.factories.Borders;
 import com.zeroc.IceGridGUI.LiveDeployment.Editor;
 import com.zeroc.IceGridGUI.LiveDeployment.Root;
 import com.zeroc.IceGridGUI.LiveDeployment.TreeNode;
+
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.TreeSelectionEvent;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Main.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Main.java
@@ -5,6 +5,7 @@ package com.zeroc.IceGridGUI;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.util.prefs.Preferences;
+
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/NodeObserverI.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/NodeObserverI.java
@@ -3,6 +3,7 @@
 package com.zeroc.IceGridGUI;
 
 import com.zeroc.IceGrid.*;
+
 import javax.swing.SwingUtilities;
 
 class NodeObserverI implements NodeObserver {

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/ObjectObserverI.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/ObjectObserverI.java
@@ -3,6 +3,7 @@
 package com.zeroc.IceGridGUI;
 
 import com.zeroc.IceGrid.*;
+
 import javax.swing.SwingUtilities;
 
 class ObjectObserverI implements ObjectObserver {

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/RegistryObserverI.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/RegistryObserverI.java
@@ -3,6 +3,7 @@
 package com.zeroc.IceGridGUI;
 
 import com.zeroc.IceGrid.*;
+
 import javax.swing.SwingUtilities;
 
 class RegistryObserverI implements RegistryObserver {

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SessionKeeper.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SessionKeeper.java
@@ -11,6 +11,7 @@ import com.jgoodies.forms.util.LayoutStyle;
 import com.zeroc.IceGrid.*;
 import com.zeroc.IceLocatorDiscovery.Plugin;
 import com.zeroc.IceLocatorDiscovery.PluginFactory;
+
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Component;
@@ -39,6 +40,7 @@ import java.util.Formatter;
 import java.util.Iterator;
 import java.util.List;
 import java.util.prefs.Preferences;
+
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
 import javax.swing.*;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SimpleInternalFrame.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SimpleInternalFrame.java
@@ -31,7 +31,9 @@
 package com.zeroc.IceGridGUI;
 
 import com.jgoodies.common.base.SystemUtils;
+
 import java.awt.*;
+
 import javax.swing.*;
 import javax.swing.border.AbstractBorder;
 

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/TreeNodeBase.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/TreeNodeBase.java
@@ -4,6 +4,7 @@ package com.zeroc.IceGridGUI;
 
 import java.awt.Component;
 import java.util.Enumeration;
+
 import javax.swing.JPopupMenu;
 import javax.swing.JTree;
 import javax.swing.tree.DefaultTreeModel;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Utils.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Utils.java
@@ -3,6 +3,7 @@
 package com.zeroc.IceGridGUI;
 
 import com.zeroc.IceGrid.*;
+
 import java.awt.Graphics2D;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
@@ -12,6 +13,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
+
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JComponent;

--- a/java/src/IceLocatorDiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
+++ b/java/src/IceLocatorDiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
@@ -3,6 +3,7 @@
 package com.zeroc.IceLocatorDiscovery;
 
 import com.zeroc.Ice.Network;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/java/test/src/main/java/test/Glacier2/router/Client.java
+++ b/java/test/src/main/java/test/Glacier2/router/Client.java
@@ -2,11 +2,12 @@
 
 package test.Glacier2.router;
 
-import java.io.PrintWriter;
-import java.util.stream.Stream;
 import test.Glacier2.router.Test.CallbackException;
 import test.Glacier2.router.Test.CallbackPrx;
 import test.Glacier2.router.Test.CallbackReceiverPrx;
+
+import java.io.PrintWriter;
+import java.util.stream.Stream;
 
 public class Client extends test.TestHelper {
     public void run(String[] args) {

--- a/java/test/src/main/java/test/Ice/adapterDeactivation/AllTests.java
+++ b/java/test/src/main/java/test/Ice/adapterDeactivation/AllTests.java
@@ -7,8 +7,10 @@ package test.Ice.adapterDeactivation;
 import com.zeroc.Ice.EndpointInfo;
 import com.zeroc.Ice.IPEndpointInfo;
 import com.zeroc.Ice.ObjectAdapter;
-import java.util.Arrays;
+
 import test.Ice.adapterDeactivation.Test.TestIntfPrx;
+
+import java.util.Arrays;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/admin/AllTests.java
+++ b/java/test/src/main/java/test/Ice/admin/AllTests.java
@@ -8,8 +8,10 @@ import com.zeroc.Ice.FacetNotExistException;
 import com.zeroc.Ice.LogMessageType;
 import com.zeroc.Ice.ProcessPrx;
 import com.zeroc.Ice.PropertiesAdminPrx;
-import java.io.PrintWriter;
+
 import test.Ice.admin.Test.*;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/ami/AllTests.java
+++ b/java/test/src/main/java/test/Ice/ami/AllTests.java
@@ -7,6 +7,12 @@ package test.Ice.ami;
 import com.zeroc.Ice.CompressBatch;
 import com.zeroc.Ice.InvocationFuture;
 import com.zeroc.Ice.Util;
+
+import test.Ice.ami.Test.PingReplyPrx;
+import test.Ice.ami.Test.TestIntfControllerPrx;
+import test.Ice.ami.Test.TestIntfException;
+import test.Ice.ami.Test.TestIntfPrx;
+
 import java.io.PrintWriter;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -14,10 +20,6 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import test.Ice.ami.Test.PingReplyPrx;
-import test.Ice.ami.Test.TestIntfControllerPrx;
-import test.Ice.ami.Test.TestIntfException;
-import test.Ice.ami.Test.TestIntfPrx;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/ami/TestI.java
+++ b/java/test/src/main/java/test/Ice/ami/TestI.java
@@ -4,11 +4,12 @@
 
 package test.Ice.ami;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import test.Ice.ami.Test.PingReplyPrx;
 import test.Ice.ami.Test.TestIntf;
 import test.Ice.ami.Test.TestIntfException;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 public class TestI implements TestIntf {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/background/AllTests.java
+++ b/java/test/src/main/java/test/Ice/background/AllTests.java
@@ -8,11 +8,13 @@ import com.zeroc.Ice.ConnectionLostException;
 import com.zeroc.Ice.InvocationFuture;
 import com.zeroc.Ice.SocketOperation;
 import com.zeroc.Ice.Util;
+
+import test.Ice.background.Test.BackgroundControllerPrx;
+import test.Ice.background.Test.BackgroundPrx;
+
 import java.io.PrintWriter;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import test.Ice.background.Test.BackgroundControllerPrx;
-import test.Ice.background.Test.BackgroundPrx;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/background/Server.java
+++ b/java/test/src/main/java/test/Ice/background/Server.java
@@ -4,9 +4,10 @@
 
 package test.Ice.background;
 
+import test.Ice.background.PluginFactory.PluginI;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import test.Ice.background.PluginFactory.PluginI;
 
 public class Server extends test.TestHelper {
     public static class LocatorI implements com.zeroc.Ice.Locator {

--- a/java/test/src/main/java/test/Ice/binding/AllTests.java
+++ b/java/test/src/main/java/test/Ice/binding/AllTests.java
@@ -6,10 +6,12 @@ package test.Ice.binding;
 
 import com.zeroc.Ice.Endpoint;
 import com.zeroc.Ice.EndpointSelectionType;
-import java.io.PrintWriter;
+
 import test.Ice.binding.Test.RemoteCommunicatorPrx;
 import test.Ice.binding.Test.RemoteObjectAdapterPrx;
 import test.Ice.binding.Test.TestIntfPrx;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/classLoader/AllTests.java
+++ b/java/test/src/main/java/test/Ice/classLoader/AllTests.java
@@ -4,10 +4,11 @@
 
 package test.Ice.classLoader;
 
-import java.io.PrintWriter;
 import test.Ice.classLoader.Test.ConcreteClass;
 import test.Ice.classLoader.Test.E;
 import test.Ice.classLoader.Test.InitialPrx;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     private static class MyClassLoader extends ClassLoader {

--- a/java/test/src/main/java/test/Ice/custom/AllTests.java
+++ b/java/test/src/main/java/test/Ice/custom/AllTests.java
@@ -4,6 +4,12 @@
 
 package test.Ice.custom;
 
+import test.Ice.custom.Test.A;
+import test.Ice.custom.Test.E;
+import test.Ice.custom.Test.S;
+import test.Ice.custom.Test.TestIntf;
+import test.Ice.custom.Test.TestIntfPrx;
+
 import java.io.PrintWriter;
 import java.nio.ByteBuffer;
 import java.nio.DoubleBuffer;
@@ -17,11 +23,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import test.Ice.custom.Test.A;
-import test.Ice.custom.Test.E;
-import test.Ice.custom.Test.S;
-import test.Ice.custom.Test.TestIntf;
-import test.Ice.custom.Test.TestIntfPrx;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/custom/TestI.java
+++ b/java/test/src/main/java/test/Ice/custom/TestI.java
@@ -4,6 +4,11 @@
 
 package test.Ice.custom;
 
+import test.Ice.custom.Test.A;
+import test.Ice.custom.Test.E;
+import test.Ice.custom.Test.S;
+import test.Ice.custom.Test.TestIntf;
+
 import java.nio.ByteBuffer;
 import java.nio.DoubleBuffer;
 import java.nio.FloatBuffer;
@@ -14,10 +19,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import test.Ice.custom.Test.A;
-import test.Ice.custom.Test.E;
-import test.Ice.custom.Test.S;
-import test.Ice.custom.Test.TestIntf;
 
 public final class TestI implements TestIntf {
     public TestI(com.zeroc.Ice.Communicator communicator) {

--- a/java/test/src/main/java/test/Ice/defaultServant/AllTests.java
+++ b/java/test/src/main/java/test/Ice/defaultServant/AllTests.java
@@ -4,8 +4,9 @@
 
 package test.Ice.defaultServant;
 
-import java.io.PrintWriter;
 import test.Ice.defaultServant.Test.MyObjectPrx;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/defaultValue/AllTests.java
+++ b/java/test/src/main/java/test/Ice/defaultValue/AllTests.java
@@ -4,8 +4,9 @@
 
 package test.Ice.defaultValue;
 
-import java.io.PrintWriter;
 import test.Ice.defaultValue.Test.*;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/echo/BlobjectI.java
+++ b/java/test/src/main/java/test/Ice/echo/BlobjectI.java
@@ -6,6 +6,7 @@ package test.Ice.echo;
 
 import com.zeroc.Ice.Current;
 import com.zeroc.Ice.ObjectPrx;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 

--- a/java/test/src/main/java/test/Ice/enums/AllTests.java
+++ b/java/test/src/main/java/test/Ice/enums/AllTests.java
@@ -5,8 +5,10 @@
 package test.Ice.enums;
 
 import com.zeroc.Ice.MarshalException;
-import java.io.PrintWriter;
+
 import test.Ice.enums.Test.*;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/exceptions/AMDThrowerI.java
+++ b/java/test/src/main/java/test/Ice/exceptions/AMDThrowerI.java
@@ -4,13 +4,14 @@
 
 package test.Ice.exceptions;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import test.Ice.exceptions.AMD.Test.A;
 import test.Ice.exceptions.AMD.Test.B;
 import test.Ice.exceptions.AMD.Test.C;
 import test.Ice.exceptions.AMD.Test.D;
 import test.Ice.exceptions.AMD.Test.Thrower;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 public final class AMDThrowerI implements Thrower {
     public AMDThrowerI() {}

--- a/java/test/src/main/java/test/Ice/exceptions/AllTests.java
+++ b/java/test/src/main/java/test/Ice/exceptions/AllTests.java
@@ -5,14 +5,16 @@
 package test.Ice.exceptions;
 
 import com.zeroc.Ice.ConnectionLostException;
-import java.io.PrintWriter;
-import java.util.concurrent.CompletionException;
+
 import test.Ice.exceptions.Test.A;
 import test.Ice.exceptions.Test.B;
 import test.Ice.exceptions.Test.C;
 import test.Ice.exceptions.Test.D;
 import test.Ice.exceptions.Test.ThrowerPrx;
 import test.Ice.exceptions.Test.WrongOperationPrx;
+
+import java.io.PrintWriter;
+import java.util.concurrent.CompletionException;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/executor/AllTests.java
+++ b/java/test/src/main/java/test/Ice/executor/AllTests.java
@@ -5,10 +5,12 @@
 package test.Ice.executor;
 
 import com.zeroc.Ice.InvocationFuture;
-import java.io.PrintWriter;
-import java.util.concurrent.CompletableFuture;
+
 import test.Ice.executor.Test.TestIntfControllerPrx;
 import test.Ice.executor.Test.TestIntfPrx;
+
+import java.io.PrintWriter;
+import java.util.concurrent.CompletableFuture;
 
 public class AllTests {
     private static class Callback {

--- a/java/test/src/main/java/test/Ice/facets/AllTests.java
+++ b/java/test/src/main/java/test/Ice/facets/AllTests.java
@@ -5,11 +5,13 @@
 package test.Ice.facets;
 
 import com.zeroc.Ice.ObjectPrx;
-import java.io.PrintWriter;
+
 import test.Ice.facets.Test.DPrx;
 import test.Ice.facets.Test.FPrx;
 import test.Ice.facets.Test.GPrx;
 import test.Ice.facets.Test.HPrx;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/faultTolerance/AllTests.java
+++ b/java/test/src/main/java/test/Ice/faultTolerance/AllTests.java
@@ -4,8 +4,9 @@
 
 package test.Ice.faultTolerance;
 
-import java.io.PrintWriter;
 import test.Ice.faultTolerance.Test.TestIntfPrx;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     public static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/hash/Client.java
+++ b/java/test/src/main/java/test/Ice/hash/Client.java
@@ -8,8 +8,10 @@ import com.zeroc.Ice.Endpoint;
 import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.ProxyIdentityFacetKey;
 import com.zeroc.Ice.ProxyIdentityKey;
-import java.io.PrintWriter;
+
 import test.Ice.hash.Test.*;
+
+import java.io.PrintWriter;
 
 public class Client extends test.TestHelper {
     public void run(String[] args) {

--- a/java/test/src/main/java/test/Ice/hold/AllTests.java
+++ b/java/test/src/main/java/test/Ice/hold/AllTests.java
@@ -5,9 +5,11 @@
 package test.Ice.hold;
 
 import com.zeroc.Ice.InvocationFuture;
+
+import test.Ice.hold.Test.HoldPrx;
+
 import java.io.PrintWriter;
 import java.util.concurrent.CompletableFuture;
-import test.Ice.hold.Test.HoldPrx;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/idleTimeout/AllTests.java
+++ b/java/test/src/main/java/test/Ice/idleTimeout/AllTests.java
@@ -8,8 +8,10 @@ import com.zeroc.Ice.ConnectionLostException;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
-import java.io.PrintWriter;
+
 import test.Ice.idleTimeout.Test.TestIntfPrx;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     static void allTests(test.TestHelper helper) {

--- a/java/test/src/main/java/test/Ice/idleTimeout/TestIntfI.java
+++ b/java/test/src/main/java/test/Ice/idleTimeout/TestIntfI.java
@@ -3,6 +3,7 @@
 package test.Ice.idleTimeout;
 
 import com.zeroc.Ice.Current;
+
 import test.Ice.idleTimeout.Test.TestIntf;
 
 class TestIntfI implements TestIntf {

--- a/java/test/src/main/java/test/Ice/inactivityTimeout/AllTests.java
+++ b/java/test/src/main/java/test/Ice/inactivityTimeout/AllTests.java
@@ -7,8 +7,10 @@ import com.zeroc.Ice.Connection;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
-import java.io.PrintWriter;
+
 import test.Ice.inactivityTimeout.Test.TestIntfPrx;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     static void allTests(test.TestHelper helper) {

--- a/java/test/src/main/java/test/Ice/inactivityTimeout/TestIntfI.java
+++ b/java/test/src/main/java/test/Ice/inactivityTimeout/TestIntfI.java
@@ -3,6 +3,7 @@
 package test.Ice.inactivityTimeout;
 
 import com.zeroc.Ice.Current;
+
 import test.Ice.inactivityTimeout.Test.TestIntf;
 
 class TestIntfI implements TestIntf {

--- a/java/test/src/main/java/test/Ice/info/AllTests.java
+++ b/java/test/src/main/java/test/Ice/info/AllTests.java
@@ -19,8 +19,10 @@ import com.zeroc.Ice.WSConnectionInfo;
 import com.zeroc.Ice.WSEndpointInfo;
 import com.zeroc.Ice.WSEndpointType;
 import com.zeroc.Ice.WSSEndpointType;
-import java.io.PrintWriter;
+
 import test.Ice.info.Test.TestIntfPrx;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/inheritance/AllTests.java
+++ b/java/test/src/main/java/test/Ice/inheritance/AllTests.java
@@ -4,12 +4,13 @@
 
 package test.Ice.inheritance;
 
-import java.io.PrintWriter;
 import test.Ice.inheritance.Test.InitialPrx;
 import test.Ice.inheritance.Test.MA.IAPrx;
 import test.Ice.inheritance.Test.MA.ICPrx;
 import test.Ice.inheritance.Test.MB.IB1Prx;
 import test.Ice.inheritance.Test.MB.IB2Prx;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/interrupt/AllTests.java
+++ b/java/test/src/main/java/test/Ice/interrupt/AllTests.java
@@ -7,6 +7,11 @@ package test.Ice.interrupt;
 import com.zeroc.Ice.CompressBatch;
 import com.zeroc.Ice.InvocationFuture;
 import com.zeroc.Ice.Util;
+
+import test.Ice.interrupt.Test.CannotInterruptException;
+import test.Ice.interrupt.Test.TestIntfControllerPrx;
+import test.Ice.interrupt.Test.TestIntfPrx;
+
 import java.io.PrintWriter;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -14,9 +19,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import test.Ice.interrupt.Test.CannotInterruptException;
-import test.Ice.interrupt.Test.TestIntfControllerPrx;
-import test.Ice.interrupt.Test.TestIntfPrx;
 
 public class AllTests {
     private static class Callback {

--- a/java/test/src/main/java/test/Ice/invoke/AllTests.java
+++ b/java/test/src/main/java/test/Ice/invoke/AllTests.java
@@ -7,10 +7,12 @@ package test.Ice.invoke;
 import com.zeroc.Ice.InputStream;
 import com.zeroc.Ice.OperationMode;
 import com.zeroc.Ice.OutputStream;
-import java.io.PrintWriter;
-import java.util.concurrent.CompletableFuture;
+
 import test.Ice.invoke.Test.MyClassPrx;
 import test.Ice.invoke.Test.MyException;
+
+import java.io.PrintWriter;
+import java.util.concurrent.CompletableFuture;
 
 public class AllTests {
     static final String testString = "This is a test string";

--- a/java/test/src/main/java/test/Ice/invoke/BlobjectAsyncI.java
+++ b/java/test/src/main/java/test/Ice/invoke/BlobjectAsyncI.java
@@ -4,9 +4,10 @@
 
 package test.Ice.invoke;
 
+import test.Ice.invoke.Test.MyException;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import test.Ice.invoke.Test.MyException;
 
 public class BlobjectAsyncI implements com.zeroc.Ice.BlobjectAsync {
     @Override

--- a/java/test/src/main/java/test/Ice/location/AllTests.java
+++ b/java/test/src/main/java/test/Ice/location/AllTests.java
@@ -6,14 +6,16 @@ package test.Ice.location;
 
 import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.Util;
-import java.io.PrintWriter;
-import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
+
 import test.Ice.location.Test.HelloPrx;
 import test.Ice.location.Test.ServerManagerPrx;
 import test.Ice.location.Test.TestIntfPrx;
 import test.Ice.location.Test.TestLocatorPrx;
 import test.Ice.location.Test.TestLocatorRegistryPrx;
+
+import java.io.PrintWriter;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/location/ServerLocator.java
+++ b/java/test/src/main/java/test/Ice/location/ServerLocator.java
@@ -5,9 +5,11 @@
 package test.Ice.location;
 
 import com.zeroc.Ice.ObjectPrx;
+
+import test.Ice.location.Test.TestLocator;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import test.Ice.location.Test.TestLocator;
 
 public class ServerLocator implements TestLocator {
     public ServerLocator(

--- a/java/test/src/main/java/test/Ice/location/ServerLocatorRegistry.java
+++ b/java/test/src/main/java/test/Ice/location/ServerLocatorRegistry.java
@@ -6,9 +6,11 @@ package test.Ice.location;
 
 import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.ObjectPrx;
+
+import test.Ice.location.Test.TestLocatorRegistry;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import test.Ice.location.Test.TestLocatorRegistry;
 
 public class ServerLocatorRegistry implements TestLocatorRegistry {
     @Override

--- a/java/test/src/main/java/test/Ice/logger/Client.java
+++ b/java/test/src/main/java/test/Ice/logger/Client.java
@@ -5,6 +5,7 @@
 package test.Ice.logger;
 
 import com.zeroc.Ice.Communicator;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/java/test/src/main/java/test/Ice/maxConnections/AllTests.java
+++ b/java/test/src/main/java/test/Ice/maxConnections/AllTests.java
@@ -4,8 +4,10 @@ package test.Ice.maxConnections;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Connection;
-import java.io.PrintWriter;
+
 import test.Ice.maxConnections.Test.TestIntfPrx;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     static void allTests(test.TestHelper helper) {

--- a/java/test/src/main/java/test/Ice/maxConnections/TestIntfI.java
+++ b/java/test/src/main/java/test/Ice/maxConnections/TestIntfI.java
@@ -3,6 +3,7 @@
 package test.Ice.maxConnections;
 
 import com.zeroc.Ice.Current;
+
 import test.Ice.maxConnections.Test.TestIntf;
 
 class TestIntfI implements TestIntf {

--- a/java/test/src/main/java/test/Ice/maxDispatches/AllTests.java
+++ b/java/test/src/main/java/test/Ice/maxDispatches/AllTests.java
@@ -3,11 +3,13 @@
 package test.Ice.maxDispatches;
 
 import com.zeroc.Ice.Communicator;
+
+import test.Ice.maxDispatches.Test.ResponderPrx;
+import test.Ice.maxDispatches.Test.TestIntfPrx;
+
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
-import test.Ice.maxDispatches.Test.ResponderPrx;
-import test.Ice.maxDispatches.Test.TestIntfPrx;
 
 public class AllTests {
     static void allTests(test.TestHelper helper) {

--- a/java/test/src/main/java/test/Ice/maxDispatches/ResponderI.java
+++ b/java/test/src/main/java/test/Ice/maxDispatches/ResponderI.java
@@ -3,6 +3,7 @@
 package test.Ice.maxDispatches;
 
 import com.zeroc.Ice.Current;
+
 import test.Ice.maxDispatches.Test.Responder;
 
 class ResponderI implements Responder {

--- a/java/test/src/main/java/test/Ice/maxDispatches/TestIntfI.java
+++ b/java/test/src/main/java/test/Ice/maxDispatches/TestIntfI.java
@@ -3,9 +3,11 @@
 package test.Ice.maxDispatches;
 
 import com.zeroc.Ice.Current;
+
+import test.Ice.maxDispatches.Test.TestIntf;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import test.Ice.maxDispatches.Test.TestIntf;
 
 class TestIntfI implements TestIntf {
     private int _dispatchCount;

--- a/java/test/src/main/java/test/Ice/metrics/AMDMetricsI.java
+++ b/java/test/src/main/java/test/Ice/metrics/AMDMetricsI.java
@@ -4,9 +4,10 @@
 
 package test.Ice.metrics;
 
+import test.Ice.metrics.AMD.Test.*;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import test.Ice.metrics.AMD.Test.*;
 
 public final class AMDMetricsI implements Metrics {
     public AMDMetricsI() {}

--- a/java/test/src/main/java/test/Ice/metrics/AllTests.java
+++ b/java/test/src/main/java/test/Ice/metrics/AllTests.java
@@ -6,11 +6,13 @@ package test.Ice.metrics;
 
 import com.zeroc.Ice.ConnectionLostException;
 import com.zeroc.Ice.IceMX.*;
+
+import test.Ice.metrics.Test.*;
+
 import java.io.PrintWriter;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import test.Ice.metrics.Test.*;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/middleware/AllTests.java
+++ b/java/test/src/main/java/test/Ice/middleware/AllTests.java
@@ -3,13 +3,15 @@
 package test.Ice.middleware;
 
 import com.zeroc.Ice.*;
+
+import test.Ice.middleware.Test.*;
+
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import test.Ice.middleware.Test.*;
 
 public class AllTests {
 

--- a/java/test/src/main/java/test/Ice/middleware/MyObjectI.java
+++ b/java/test/src/main/java/test/Ice/middleware/MyObjectI.java
@@ -2,9 +2,10 @@
 
 package test.Ice.middleware;
 
+import test.Ice.middleware.Test.*;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import test.Ice.middleware.Test.*;
 
 final class MyObjectI implements MyObject {
     @Override

--- a/java/test/src/main/java/test/Ice/networkProxy/AllTests.java
+++ b/java/test/src/main/java/test/Ice/networkProxy/AllTests.java
@@ -4,8 +4,9 @@
 
 package test.Ice.networkProxy;
 
-import java.io.PrintWriter;
 import test.Ice.networkProxy.Test.TestIntfPrx;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/objects/AllTests.java
+++ b/java/test/src/main/java/test/Ice/objects/AllTests.java
@@ -4,7 +4,6 @@
 
 package test.Ice.objects;
 
-import java.io.PrintWriter;
 import test.Ice.objects.Test.A1;
 import test.Ice.objects.Test.B;
 import test.Ice.objects.Test.Base;
@@ -30,6 +29,8 @@ import test.Ice.objects.Test.Recursive;
 import test.Ice.objects.Test.S;
 import test.Ice.objects.Test.StructKey;
 import test.Ice.objects.Test.UnexpectedObjectExceptionTestPrx;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/objects/InitialI.java
+++ b/java/test/src/main/java/test/Ice/objects/InitialI.java
@@ -4,9 +4,10 @@
 
 package test.Ice.objects;
 
+import test.Ice.objects.Test.*;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import test.Ice.objects.Test.*;
 
 public final class InitialI implements Initial {
     public InitialI(com.zeroc.Ice.ObjectAdapter adapter) {

--- a/java/test/src/main/java/test/Ice/operations/AMDMyDerivedClassI.java
+++ b/java/test/src/main/java/test/Ice/operations/AMDMyDerivedClassI.java
@@ -5,10 +5,12 @@
 package test.Ice.operations;
 
 import com.zeroc.Ice.Current;
+
+import test.Ice.operations.AMD.Test.*;
+
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import test.Ice.operations.AMD.Test.*;
 
 public final class AMDMyDerivedClassI implements MyDerivedClass {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/operations/AllTests.java
+++ b/java/test/src/main/java/test/Ice/operations/AllTests.java
@@ -4,9 +4,10 @@
 
 package test.Ice.operations;
 
-import java.io.PrintWriter;
 import test.Ice.operations.Test.MyClassPrx;
 import test.Ice.operations.Test.MyDerivedClassPrx;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     public static MyClassPrx allTests(test.TestHelper helper) {

--- a/java/test/src/main/java/test/Ice/operations/BatchOneways.java
+++ b/java/test/src/main/java/test/Ice/operations/BatchOneways.java
@@ -4,8 +4,9 @@
 
 package test.Ice.operations;
 
-import java.io.PrintWriter;
 import test.Ice.operations.Test.MyClassPrx;
+
+import java.io.PrintWriter;
 
 class BatchOneways {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/operations/BatchOnewaysAMI.java
+++ b/java/test/src/main/java/test/Ice/operations/BatchOnewaysAMI.java
@@ -5,8 +5,10 @@
 package test.Ice.operations;
 
 import com.zeroc.Ice.Util;
-import java.io.PrintWriter;
+
 import test.Ice.operations.Test.MyClassPrx;
+
+import java.io.PrintWriter;
 
 class BatchOnewaysAMI {
     private static class Callback {

--- a/java/test/src/main/java/test/Ice/operations/MyDerivedClassI.java
+++ b/java/test/src/main/java/test/Ice/operations/MyDerivedClassI.java
@@ -5,8 +5,10 @@
 package test.Ice.operations;
 
 import com.zeroc.Ice.Current;
-import java.util.*;
+
 import test.Ice.operations.Test.*;
+
+import java.util.*;
 
 public final class MyDerivedClassI implements MyDerivedClass {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/operations/OnewaysAMI.java
+++ b/java/test/src/main/java/test/Ice/operations/OnewaysAMI.java
@@ -5,8 +5,10 @@
 package test.Ice.operations;
 
 import com.zeroc.Ice.Util;
-import java.util.concurrent.CompletableFuture;
+
 import test.Ice.operations.Test.MyClassPrx;
+
+import java.util.concurrent.CompletableFuture;
 
 class OnewaysAMI {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/operations/Twoways.java
+++ b/java/test/src/main/java/test/Ice/operations/Twoways.java
@@ -5,11 +5,13 @@
 package test.Ice.operations;
 
 import com.zeroc.Ice.*;
+
+import test.Ice.operations.Test.*;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import test.Ice.operations.Test.*;
 
 class Twoways {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/operations/TwowaysAMI.java
+++ b/java/test/src/main/java/test/Ice/operations/TwowaysAMI.java
@@ -4,11 +4,12 @@
 
 package test.Ice.operations;
 
+import test.Ice.operations.Test.*;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import test.Ice.operations.Test.*;
 
 class TwowaysAMI {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/optional/AMDInitialI.java
+++ b/java/test/src/main/java/test/Ice/optional/AMDInitialI.java
@@ -5,13 +5,15 @@
 package test.Ice.optional;
 
 import com.zeroc.Ice.Current;
+
+import test.Ice.optional.AMD.Test.*;
+
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import test.Ice.optional.AMD.Test.*;
 
 public final class AMDInitialI implements Initial {
     @Override

--- a/java/test/src/main/java/test/Ice/optional/AllTests.java
+++ b/java/test/src/main/java/test/Ice/optional/AllTests.java
@@ -8,12 +8,14 @@ import com.zeroc.Ice.InputStream;
 import com.zeroc.Ice.OperationMode;
 import com.zeroc.Ice.OptionalFormat;
 import com.zeroc.Ice.OutputStream;
+
+import test.Ice.optional.Test.*;
+
 import java.io.PrintWriter;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
-import test.Ice.optional.Test.*;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/optional/InitialI.java
+++ b/java/test/src/main/java/test/Ice/optional/InitialI.java
@@ -5,11 +5,13 @@
 package test.Ice.optional;
 
 import com.zeroc.Ice.Current;
+
+import test.Ice.optional.Test.*;
+
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
-import test.Ice.optional.Test.*;
 
 public final class InitialI implements Initial {
     @Override

--- a/java/test/src/main/java/test/Ice/packagemd/AllTests.java
+++ b/java/test/src/main/java/test/Ice/packagemd/AllTests.java
@@ -4,13 +4,14 @@
 
 package test.Ice.packagemd;
 
-import java.io.PrintWriter;
 import test.Ice.packagemd.Test.InitialPrx;
 import test.Ice.packagemd.Test1.C1;
 import test.Ice.packagemd.Test1.C2;
 import test.Ice.packagemd.Test1.E1;
 import test.Ice.packagemd.Test1.E2;
 import test.Ice.packagemd.Test1._notify;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/proxy/AMDMyDerivedClassI.java
+++ b/java/test/src/main/java/test/Ice/proxy/AMDMyDerivedClassI.java
@@ -4,9 +4,10 @@
 
 package test.Ice.proxy;
 
+import test.Ice.proxy.AMD.Test.MyDerivedClass;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import test.Ice.proxy.AMD.Test.MyDerivedClass;
 
 public final class AMDMyDerivedClassI implements MyDerivedClass {
     public AMDMyDerivedClassI() {}

--- a/java/test/src/main/java/test/Ice/proxy/AllTests.java
+++ b/java/test/src/main/java/test/Ice/proxy/AllTests.java
@@ -10,11 +10,13 @@ import com.zeroc.Ice.FacetNotExistException;
 import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.ParseException;
 import com.zeroc.Ice.Util;
-import java.io.PrintWriter;
-import java.time.Duration;
+
 import test.Ice.proxy.Test.DiamondClassPrx;
 import test.Ice.proxy.Test.MyClassPrx;
 import test.Ice.proxy.Test.MyDerivedClassPrx;
+
+import java.io.PrintWriter;
+import java.time.Duration;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/retry/AllTests.java
+++ b/java/test/src/main/java/test/Ice/retry/AllTests.java
@@ -4,8 +4,9 @@
 
 package test.Ice.retry;
 
-import java.io.PrintWriter;
 import test.Ice.retry.Test.RetryPrx;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/retry/RetryI.java
+++ b/java/test/src/main/java/test/Ice/retry/RetryI.java
@@ -5,6 +5,7 @@
 package test.Ice.retry;
 
 import com.zeroc.Ice.ConnectionLostException;
+
 import test.Ice.retry.Test.Retry;
 
 public final class RetryI implements Retry {

--- a/java/test/src/main/java/test/Ice/seqMapping/AMDMyClassI.java
+++ b/java/test/src/main/java/test/Ice/seqMapping/AMDMyClassI.java
@@ -4,10 +4,11 @@
 
 package test.Ice.seqMapping;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import test.Ice.seqMapping.AMD.Test.*;
 import test.Ice.seqMapping.Serialize.*;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 public final class AMDMyClassI implements MyClass {
     @Override

--- a/java/test/src/main/java/test/Ice/seqMapping/AllTests.java
+++ b/java/test/src/main/java/test/Ice/seqMapping/AllTests.java
@@ -4,8 +4,9 @@
 
 package test.Ice.seqMapping;
 
-import java.io.PrintWriter;
 import test.Ice.seqMapping.Test.*;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     public static MyClassPrx allTests(test.TestHelper helper, boolean collocated) {

--- a/java/test/src/main/java/test/Ice/serialize/AllTests.java
+++ b/java/test/src/main/java/test/Ice/serialize/AllTests.java
@@ -4,8 +4,9 @@
 
 package test.Ice.serialize;
 
-import java.io.*;
 import test.Ice.serialize.Test.*;
+
+import java.io.*;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/serialize/InitialI.java
+++ b/java/test/src/main/java/test/Ice/serialize/InitialI.java
@@ -4,8 +4,9 @@
 
 package test.Ice.serialize;
 
-import java.io.*;
 import test.Ice.serialize.Test.*;
+
+import java.io.*;
 
 public final class InitialI implements Initial {
     InitialI(com.zeroc.Ice.ObjectAdapter adapter, com.zeroc.Ice.Identity ident) {

--- a/java/test/src/main/java/test/Ice/servantLocator/AMDServantLocatorI.java
+++ b/java/test/src/main/java/test/Ice/servantLocator/AMDServantLocatorI.java
@@ -11,6 +11,7 @@ import com.zeroc.Ice.UnknownException;
 import com.zeroc.Ice.UnknownLocalException;
 import com.zeroc.Ice.UnknownUserException;
 import com.zeroc.Ice.UserException;
+
 import test.Ice.servantLocator.AMD.Test.TestImpossibleException;
 import test.Ice.servantLocator.AMD.Test.TestIntfUserException;
 

--- a/java/test/src/main/java/test/Ice/servantLocator/AMDTestI.java
+++ b/java/test/src/main/java/test/Ice/servantLocator/AMDTestI.java
@@ -4,11 +4,12 @@
 
 package test.Ice.servantLocator;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import test.Ice.servantLocator.AMD.Test.TestImpossibleException;
 import test.Ice.servantLocator.AMD.Test.TestIntf;
 import test.Ice.servantLocator.AMD.Test.TestIntfUserException;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 public final class AMDTestI implements TestIntf {
     @Override

--- a/java/test/src/main/java/test/Ice/servantLocator/AllTests.java
+++ b/java/test/src/main/java/test/Ice/servantLocator/AllTests.java
@@ -9,11 +9,13 @@ import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.UnknownException;
 import com.zeroc.Ice.UnknownLocalException;
 import com.zeroc.Ice.UnknownUserException;
-import java.io.PrintWriter;
+
 import test.Ice.servantLocator.Test.TestActivationPrx;
 import test.Ice.servantLocator.Test.TestImpossibleException;
 import test.Ice.servantLocator.Test.TestIntfPrx;
 import test.Ice.servantLocator.Test.TestIntfUserException;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/servantLocator/ServantLocatorI.java
+++ b/java/test/src/main/java/test/Ice/servantLocator/ServantLocatorI.java
@@ -11,6 +11,7 @@ import com.zeroc.Ice.UnknownException;
 import com.zeroc.Ice.UnknownLocalException;
 import com.zeroc.Ice.UnknownUserException;
 import com.zeroc.Ice.UserException;
+
 import test.Ice.servantLocator.Test.TestImpossibleException;
 import test.Ice.servantLocator.Test.TestIntfUserException;
 

--- a/java/test/src/main/java/test/Ice/slicing/exceptions/AMDTestI.java
+++ b/java/test/src/main/java/test/Ice/slicing/exceptions/AMDTestI.java
@@ -4,9 +4,10 @@
 
 package test.Ice.slicing.exceptions;
 
+import test.Ice.slicing.exceptions.serverAMD.Test.*;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import test.Ice.slicing.exceptions.serverAMD.Test.*;
 
 public final class AMDTestI implements TestIntf {
     @Override

--- a/java/test/src/main/java/test/Ice/slicing/objects/AMDTestI.java
+++ b/java/test/src/main/java/test/Ice/slicing/objects/AMDTestI.java
@@ -4,9 +4,10 @@
 
 package test.Ice.slicing.objects;
 
+import test.Ice.slicing.objects.serverAMD.Test.*;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import test.Ice.slicing.objects.serverAMD.Test.*;
 
 public final class AMDTestI implements TestIntf {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/slicing/objects/AllTests.java
+++ b/java/test/src/main/java/test/Ice/slicing/objects/AllTests.java
@@ -6,8 +6,10 @@ package test.Ice.slicing.objects;
 
 import com.zeroc.Ice.OperationNotExistException;
 import com.zeroc.Ice.Util;
-import java.io.PrintWriter;
+
 import test.Ice.slicing.objects.client.Test.*;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/slicing/objects/TestI.java
+++ b/java/test/src/main/java/test/Ice/slicing/objects/TestI.java
@@ -4,9 +4,10 @@
 
 package test.Ice.slicing.objects;
 
+import test.Ice.slicing.objects.server.Test.*;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import test.Ice.slicing.objects.server.Test.*;
 
 public final class TestI implements TestIntf {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/stream/Client.java
+++ b/java/test/src/main/java/test/Ice/stream/Client.java
@@ -6,8 +6,10 @@ package test.Ice.stream;
 
 import com.zeroc.Ice.InputStream;
 import com.zeroc.Ice.OutputStream;
-import java.io.PrintWriter;
+
 import test.Ice.stream.Test.*;
+
+import java.io.PrintWriter;
 
 public class Client extends test.TestHelper {
     private static class TestObjectWriter extends com.zeroc.Ice.Value {

--- a/java/test/src/main/java/test/Ice/timeout/AllTests.java
+++ b/java/test/src/main/java/test/Ice/timeout/AllTests.java
@@ -6,10 +6,12 @@ package test.Ice.timeout;
 
 import com.zeroc.Ice.ConnectTimeoutException;
 import com.zeroc.Ice.InitializationData;
-import java.io.PrintWriter;
-import java.util.concurrent.CompletionException;
+
 import test.Ice.timeout.Test.ControllerPrx;
 import test.Ice.timeout.Test.TimeoutPrx;
+
+import java.io.PrintWriter;
+import java.util.concurrent.CompletionException;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Ice/udp/AllTests.java
+++ b/java/test/src/main/java/test/Ice/udp/AllTests.java
@@ -4,8 +4,9 @@
 
 package test.Ice.udp;
 
-import java.io.PrintWriter;
 import test.Ice.udp.Test.*;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/IceBox/configuration/AllTests.java
+++ b/java/test/src/main/java/test/IceBox/configuration/AllTests.java
@@ -2,8 +2,9 @@
 
 package test.IceBox.configuration;
 
-import java.io.PrintWriter;
 import test.IceBox.configuration.Test.TestIntfPrx;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/IceDiscovery/simple/AllTests.java
+++ b/java/test/src/main/java/test/IceDiscovery/simple/AllTests.java
@@ -2,11 +2,12 @@
 
 package test.IceDiscovery.simple;
 
+import test.IceDiscovery.simple.Test.*;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import test.IceDiscovery.simple.Test.*;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/IceGrid/simple/AllTests.java
+++ b/java/test/src/main/java/test/IceGrid/simple/AllTests.java
@@ -2,8 +2,9 @@
 
 package test.IceGrid.simple;
 
-import java.io.PrintWriter;
 import test.IceGrid.simple.Test.TestIntfPrx;
+
+import java.io.PrintWriter;
 
 public class AllTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/IceSSL/configuration/AllTests.java
+++ b/java/test/src/main/java/test/IceSSL/configuration/AllTests.java
@@ -6,9 +6,11 @@ import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.ConnectionLostException;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.Util;
-import java.io.PrintWriter;
+
 import test.IceSSL.configuration.Test.ServerFactoryPrx;
 import test.IceSSL.configuration.Test.ServerPrx;
+
+import java.io.PrintWriter;
 
 // NOTE: This test is not interoperable with other language mappings.
 

--- a/java/test/src/main/java/test/IceSSL/configuration/PlatformTests.java
+++ b/java/test/src/main/java/test/IceSSL/configuration/PlatformTests.java
@@ -4,19 +4,22 @@ package test.IceSSL.configuration;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.ObjectPrx;
+
+import test.IceSSL.configuration.Test.ServerPrx;
+import test.TestHelper;
+
 import java.io.FileInputStream;
 import java.io.PrintWriter;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
+
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509ExtendedKeyManager;
-import test.IceSSL.configuration.Test.ServerPrx;
-import test.TestHelper;
 
 public class PlatformTests {
     private static void test(boolean b) {

--- a/java/test/src/main/java/test/Slice/structure/Client.java
+++ b/java/test/src/main/java/test/Slice/structure/Client.java
@@ -2,12 +2,13 @@
 
 package test.Slice.structure;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
 import test.Slice.structure.Test.C;
 import test.Slice.structure.Test.S1;
 import test.Slice.structure.Test.S2;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 public class Client extends test.TestHelper {
     private static void allTests(com.zeroc.Ice.Communicator communicator) {


### PR DESCRIPTION
This PR improves the Java formatting in VS code.

- We know recommend a plugin that uses the same Google formatter we use in spotless and adds a configuration for it
- Synchronizes settings between the two. Previously we were using spotless' sorter, which was slightly different from the Google one.
- Added recommendation for the [Language Server for Java by Apache NetBeans](https://marketplace.visualstudio.com/items?itemName=ASF.apache-netbeans-java) extension. Seems to work much better than the RedHat one (its formatter doesn't seem to to use the new Google one). 

Due to this I've also reformatted the Java code.