### PR TITLE
Remove incorrect synchronized from ConnectionI.setAdapter (java)

### DIFF
--- a/java-compat/src/Ice/src/main/java/Ice/ConnectionI.java
+++ b/java-compat/src/Ice/src/main/java/Ice/ConnectionI.java
@@ -970,8 +970,8 @@ public final class ConnectionI extends IceInternal.EventHandler
     {
         if(adapter != null)
         {
-            // Go through the adapter to set the adapter and servant manager on this connection
-            // to ensure the object adapter is still active.
+            // Go through the adapter to set the adapter on this connection to ensure the
+            // object adapter is still active and to ensure proper locking order.
             ((ObjectAdapterI)adapter).setAdapterOnConnection(this);
         }
         else

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -871,12 +871,12 @@ public final class ConnectionI extends com.zeroc.IceInternal.EventHandler
     }
 
     @Override
-    public synchronized void setAdapter(ObjectAdapter adapter)
+    public void setAdapter(ObjectAdapter adapter)
     {
         if(adapter != null)
         {
-            // Go through the adapter to set the adapter and servant manager on this connection
-            // to ensure the object adapter is still active.
+            // Go through the adapter to set the adapter on this connection to ensure the
+            // object adapter is still active and to ensure proper locking order.
             ((ObjectAdapterI)adapter).setAdapterOnConnection(this);
         }
         else


### PR DESCRIPTION
This PR back-ports #2937 to the 3.7 branch.

Note that java-compat was not affected by this bug.