### PR TITLE
Remove ClassInfo from Python

### DIFF
--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -157,7 +157,6 @@ CodeVisitor::visitInterfaceDecl(const InterfaceDeclPtr& p)
         _out << nl << "global " << type << "Prx;";
         _out << nl << "if(!isset(" << type << "))";
         _out << sb;
-        _out << nl << type << " = IcePHP_declareClass('" << scoped << "');";
         _out << nl << type << "Prx = IcePHP_declareProxy('" << scoped << "');";
         _out << eb;
 

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -488,7 +488,6 @@ Slice::Python::CodeVisitor::visitInterfaceDecl(const InterfaceDeclPtr& p)
     {
         _out << sp << nl << "if " << getDictLookup(p) << ':';
         _out.inc();
-        _out << nl << "_M_" << getAbsolute(p, "_t_", "Disp") << " = IcePy.declareClass('" << scoped << "')";
         _out << nl << "_M_" << getAbsolute(p, "_t_", "Prx") << " = IcePy.declareProxy('" << scoped << "')";
         _out.dec();
         _classHistory.insert(scoped); // Avoid redundant declarations.
@@ -989,27 +988,6 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << sp << nl << "__repr__ = __str__";
 
     _out.dec();
-
-    _out << sp << nl << "_M_" << classType << " = IcePy.defineClass('" << scoped << "', " << className << ", ";
-    writeMetadata(p->getMetadata());
-    _out << ", None, (";
-
-    int interfaceCount = 0;
-    for (InterfaceList::const_iterator q = bases.begin(); q != bases.end(); ++q)
-    {
-        if (interfaceCount > 0)
-        {
-            _out << ", ";
-        }
-        _out << "_M_" << getAbsolute(*q, "_t_", "Disp");
-        ++interfaceCount;
-    }
-    if (interfaceCount == 1)
-    {
-        _out << ',';
-    }
-    _out << "))";
-    _out << nl << className << "._ice_type = _M_" << classType;
 
     //
     // Define each operation. The arguments to the IcePy.Operation constructor are:

--- a/python/modules/IcePy/Init.cpp
+++ b/python/modules/IcePy/Init.cpp
@@ -99,8 +99,6 @@ static PyMethodDef methods[] = {
      PyDoc_STR("internal function")},
     {"declareProxy", reinterpret_cast<PyCFunction>(IcePy_declareProxy), METH_VARARGS, PyDoc_STR("internal function")},
     {"defineProxy", reinterpret_cast<PyCFunction>(IcePy_defineProxy), METH_VARARGS, PyDoc_STR("internal function")},
-    {"declareClass", reinterpret_cast<PyCFunction>(IcePy_declareClass), METH_VARARGS, PyDoc_STR("internal function")},
-    {"defineClass", reinterpret_cast<PyCFunction>(IcePy_defineClass), METH_VARARGS, PyDoc_STR("internal function")},
     {"declareValue", reinterpret_cast<PyCFunction>(IcePy_declareValue), METH_VARARGS, PyDoc_STR("internal function")},
     {"defineValue", reinterpret_cast<PyCFunction>(IcePy_defineValue), METH_VARARGS, PyDoc_STR("internal function")},
     {"defineException",

--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -2917,21 +2917,11 @@ IcePy::ValueInfo::print(PyObject* value, IceInternal::Output& out, PrintObjectHi
         else
         {
             PyObjectHandle iceType{getAttr(value, "_ice_type", false)};
-            ValueInfoPtr info;
-            if (!iceType.get())
-            {
-                //
-                // The _ice_type attribute will be missing in an instance of LocalObject
-                // that does not derive from a user-defined type.
-                //
-                assert(id == "::Ice::LocalObject");
-                info = shared_from_this();
-            }
-            else
-            {
-                info = dynamic_pointer_cast<ValueInfo>(getType(iceType.get()));
-                assert(info);
-            }
+            assert(iceType.get());
+
+            ValueInfoPtr info = dynamic_pointer_cast<ValueInfo>(getType(iceType.get()));
+            assert(info);
+
             out << "object #" << history->index << " (" << info->id << ')';
             history->objects.insert(map<PyObject*, int>::value_type(value, history->index));
             ++history->index;

--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -26,9 +26,6 @@ using namespace IcePy;
 using namespace Ice;
 using namespace IceInternal;
 
-typedef map<string, ClassInfoPtr, std::less<>> ClassInfoMap;
-static ClassInfoMap _classInfoMap;
-
 typedef map<string, ValueInfoPtr, std::less<>> ValueInfoMap;
 static ValueInfoMap _valueInfoMap;
 
@@ -133,26 +130,6 @@ exceptionInfoDealloc(ExceptionInfoObject* self)
 {
     delete self->info;
     Py_TYPE(self)->tp_free(reinterpret_cast<PyObject*>(self));
-}
-
-//
-// addClassInfo()
-//
-static void
-addClassInfo(string_view id, const ClassInfoPtr& info)
-{
-    //
-    // Do not assert. An application may load statically-
-    // translated definitions and then dynamically load
-    // duplicate definitions.
-    //
-    //    assert(_classInfoMap.find(id) == _classInfoMap.end());
-    ClassInfoMap::iterator p = _classInfoMap.find(id);
-    if (p != _classInfoMap.end())
-    {
-        _classInfoMap.erase(p);
-    }
-    _classInfoMap.insert(ClassInfoMap::value_type(id, info));
 }
 
 //
@@ -2765,143 +2742,6 @@ IcePy::DictionaryInfo::destroy()
 }
 
 //
-// ClassInfo implementation.
-//
-IcePy::ClassInfo::ClassInfo(string ident) : id(std::move(ident)), defined(false) {}
-
-void
-IcePy::ClassInfo::init()
-{
-    typeObj = createType(shared_from_this());
-}
-
-void
-IcePy::ClassInfo::define(PyObject* t, PyObject* b, PyObject* i)
-{
-    assert(PyType_Check(t));
-    assert(PyTuple_Check(i));
-
-    if (b != Py_None)
-    {
-        const_cast<ClassInfoPtr&>(base) = dynamic_pointer_cast<ClassInfo>(getType(b));
-        assert(base);
-    }
-
-    Py_ssize_t n, sz;
-    sz = PyTuple_GET_SIZE(i);
-    for (n = 0; n < sz; ++n)
-    {
-        PyObject* o = PyTuple_GET_ITEM(i, n);
-        auto iface = dynamic_pointer_cast<ClassInfo>(getType(o));
-        assert(iface);
-        const_cast<ClassInfoList&>(interfaces).push_back(iface);
-    }
-
-    pythonType = t;
-
-    const_cast<bool&>(defined) = true;
-}
-
-string
-IcePy::ClassInfo::getId() const
-{
-    return id;
-}
-
-bool
-IcePy::ClassInfo::validate(PyObject*)
-{
-    assert(false);
-    return true;
-}
-
-bool
-IcePy::ClassInfo::variableLength() const
-{
-    assert(false);
-    return true;
-}
-
-int
-IcePy::ClassInfo::wireSize() const
-{
-    return 1;
-}
-
-Ice::OptionalFormat
-IcePy::ClassInfo::optionalFormat() const
-{
-    return Ice::OptionalFormat::Class;
-}
-
-bool
-IcePy::ClassInfo::usesClasses() const
-{
-    return true;
-}
-
-void
-IcePy::ClassInfo::marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq*)
-{
-    assert(false);
-    throw AbortMarshaling();
-}
-
-void
-IcePy::ClassInfo::unmarshal(
-    Ice::InputStream*,
-    const UnmarshalCallbackPtr&,
-    PyObject*,
-    void*,
-    bool,
-    const Ice::StringSeq*)
-{
-    assert(false);
-    throw AbortMarshaling();
-}
-
-void
-IcePy::ClassInfo::print(PyObject* value, IceInternal::Output& out, PrintObjectHistory* history)
-{
-    if (!validate(value))
-    {
-        out << "<invalid value - expected " << id << ">";
-        return;
-    }
-
-    if (value == Py_None)
-    {
-        out << "<nil>";
-    }
-    else
-    {
-        map<PyObject*, int>::iterator q = history->objects.find(value);
-        if (q != history->objects.end())
-        {
-            out << "<object #" << q->second << ">";
-        }
-        else
-        {
-            PyObjectHandle iceType{getAttr(value, "_ice_type", false)};
-            ClassInfoPtr info;
-            assert(iceType.get());
-            info = dynamic_pointer_cast<ClassInfo>(getType(iceType.get()));
-            assert(info);
-            out << "object #" << history->index << " (" << info->id << ')';
-            history->objects.insert(map<PyObject*, int>::value_type(value, history->index));
-            ++history->index;
-        }
-    }
-}
-
-void
-IcePy::ClassInfo::destroy()
-{
-    const_cast<ClassInfoPtr&>(base) = 0;
-    const_cast<ClassInfoList&>(interfaces).clear();
-}
-
-//
 // ValueInfo implementation.
 //
 IcePy::ValueInfo::ValueInfo(string ident) : id(std::move(ident)), compactId(-1), interface(false), defined(false) {}
@@ -3917,20 +3757,6 @@ IcePy::resolveCompactId(int32_t id)
 }
 
 //
-// lookupClassInfo()
-//
-IcePy::ClassInfoPtr
-IcePy::lookupClassInfo(string_view id)
-{
-    ClassInfoMap::iterator p = _classInfoMap.find(id);
-    if (p != _classInfoMap.end())
-    {
-        return p->second;
-    }
-    return nullptr;
-}
-
-//
 // lookupValueInfo()
 //
 IcePy::ValueInfoPtr
@@ -4321,67 +4147,6 @@ IcePy_defineProxy(PyObject*, PyObject* args)
 }
 
 extern "C" PyObject*
-IcePy_declareClass(PyObject*, PyObject* args)
-{
-    char* id;
-    if (!PyArg_ParseTuple(args, "s", &id))
-    {
-        return nullptr;
-    }
-
-    ClassInfoPtr info = lookupClassInfo(id);
-    if (!info)
-    {
-        info = make_shared<ClassInfo>(id);
-        info->init();
-        addClassInfo(id, info);
-        return info->typeObj; // Delegate ownership to the global "_t_XXX" variable.
-    }
-    else
-    {
-        Py_INCREF(info->typeObj);
-        return info->typeObj;
-    }
-}
-
-extern "C" PyObject*
-IcePy_defineClass(PyObject*, PyObject* args)
-{
-    char* id;
-    PyObject* type;
-    PyObject* meta; // Not currently used.
-    PyObject* base;
-    PyObject* interfaces;
-    if (!PyArg_ParseTuple(args, "sOOOO", &id, &type, &meta, &base, &interfaces))
-    {
-        return nullptr;
-    }
-
-    assert(PyTuple_Check(meta));
-
-    //
-    // A ClassInfo object will already exist for this id if a forward declaration
-    // was encountered, or if the Slice definition is being reloaded. In the latter
-    // case, we act as if it hasn't been defined yet.
-    //
-    ClassInfoPtr info = lookupClassInfo(id);
-    if (!info || info->defined)
-    {
-        info = make_shared<ClassInfo>(id);
-        info->init();
-        addClassInfo(id, info);
-        info->define(type, base, interfaces);
-        return info->typeObj; // Delegate ownership to the global "_t_XXX" variable.
-    }
-    else
-    {
-        info->define(type, base, interfaces);
-        Py_INCREF(info->typeObj);
-        return info->typeObj;
-    }
-}
-
-extern "C" PyObject*
 IcePy_declareValue(PyObject*, PyObject* args)
 {
     char* id;
@@ -4425,7 +4190,7 @@ IcePy_defineValue(PyObject*, PyObject* args)
     PyObject* r;
 
     //
-    // A ClassInfo object will already exist for this id if a forward declaration
+    // A ValueInfo object will already exist for this id if a forward declaration
     // was encountered, or if the Slice definition is being reloaded. In the latter
     // case, we act as if it hasn't been defined yet.
     //

--- a/python/modules/IcePy/Types.h
+++ b/python/modules/IcePy/Types.h
@@ -194,7 +194,13 @@ namespace IcePy
         Ice::OptionalFormat optionalFormat() const final;
 
         void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
-        void unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = nullptr) final;
+        void unmarshal(
+            Ice::InputStream*,
+            const UnmarshalCallbackPtr&,
+            PyObject*,
+            void*,
+            bool,
+            const Ice::StringSeq* = nullptr) final;
 
         void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
 
@@ -221,7 +227,13 @@ namespace IcePy
         Ice::OptionalFormat optionalFormat() const final;
 
         void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
-        void unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = nullptr) final;
+        void unmarshal(
+            Ice::InputStream*,
+            const UnmarshalCallbackPtr&,
+            PyObject*,
+            void*,
+            bool,
+            const Ice::StringSeq* = nullptr) final;
 
         void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
 
@@ -270,7 +282,13 @@ namespace IcePy
         bool usesClasses() const final;
 
         void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
-        void unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = nullptr) final;
+        void unmarshal(
+            Ice::InputStream*,
+            const UnmarshalCallbackPtr&,
+            PyObject*,
+            void*,
+            bool,
+            const Ice::StringSeq* = nullptr) final;
 
         void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
 
@@ -308,7 +326,13 @@ namespace IcePy
         bool usesClasses() const final;
 
         void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
-        void unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = nullptr) final;
+        void unmarshal(
+            Ice::InputStream*,
+            const UnmarshalCallbackPtr&,
+            PyObject*,
+            void*,
+            bool,
+            const Ice::StringSeq* = nullptr) final;
 
         void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
 
@@ -393,7 +417,13 @@ namespace IcePy
         bool usesClasses() const final;
 
         void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
-        void unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = nullptr) final;
+        void unmarshal(
+            Ice::InputStream*,
+            const UnmarshalCallbackPtr&,
+            PyObject*,
+            void*,
+            bool,
+            const Ice::StringSeq* = nullptr) final;
         void unmarshaled(PyObject*, PyObject*, void*) final;
 
         void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
@@ -439,7 +469,13 @@ namespace IcePy
         bool usesClasses() const final;
 
         void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
-        void unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = nullptr) final;
+        void unmarshal(
+            Ice::InputStream*,
+            const UnmarshalCallbackPtr&,
+            PyObject*,
+            void*,
+            bool,
+            const Ice::StringSeq* = nullptr) final;
 
         void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
 
@@ -476,7 +512,13 @@ namespace IcePy
         bool usesClasses() const final;
 
         void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
-        void unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = nullptr) final;
+        void unmarshal(
+            Ice::InputStream*,
+            const UnmarshalCallbackPtr&,
+            PyObject*,
+            void*,
+            bool,
+            const Ice::StringSeq* = nullptr) final;
 
         void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
 
@@ -515,7 +557,13 @@ namespace IcePy
         Ice::OptionalFormat optionalFormat() const final;
 
         void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
-        void unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = nullptr) final;
+        void unmarshal(
+            Ice::InputStream*,
+            const UnmarshalCallbackPtr&,
+            PyObject*,
+            void*,
+            bool,
+            const Ice::StringSeq* = nullptr) final;
 
         void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
 

--- a/python/modules/IcePy/Types.h
+++ b/python/modules/IcePy/Types.h
@@ -145,21 +145,21 @@ namespace IcePy
 
         virtual bool usesClasses() const; // Default implementation returns false.
 
-        virtual void unmarshaled(PyObject*, PyObject*, void*); // Default implementation is assert(false).
+        void unmarshaled(PyObject*, PyObject*, void*) override; // Default implementation is assert(false).
 
         virtual void destroy();
         //
         // The marshal and unmarshal functions can raise Ice exceptions, and may raise
         // AbortMarshaling if an error occurs.
         //
-        virtual void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = 0) = 0;
+        virtual void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) = 0;
         virtual void unmarshal(
             Ice::InputStream*,
             const UnmarshalCallbackPtr&,
             PyObject*,
             void*,
             bool,
-            const Ice::StringSeq* = 0) = 0;
+            const Ice::StringSeq* = nullptr) = 0;
 
         virtual void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) = 0;
     };
@@ -168,7 +168,7 @@ namespace IcePy
     //
     // Primitive type information.
     //
-    class PrimitiveInfo : public TypeInfo
+    class PrimitiveInfo final : public TypeInfo
     {
     public:
         enum Kind
@@ -185,19 +185,18 @@ namespace IcePy
 
         PrimitiveInfo(Kind);
 
-        virtual std::string getId() const;
+        std::string getId() const final;
 
-        virtual bool validate(PyObject*);
+        bool validate(PyObject*) final;
 
-        virtual bool variableLength() const;
-        virtual int wireSize() const;
-        virtual Ice::OptionalFormat optionalFormat() const;
+        bool variableLength() const final;
+        int wireSize() const final;
+        Ice::OptionalFormat optionalFormat() const final;
 
-        virtual void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = 0);
-        virtual void
-        unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = 0);
+        void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
+        void unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = nullptr) final;
 
-        virtual void print(PyObject*, IceInternal::Output&, PrintObjectHistory*);
+        void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
 
         const Kind kind;
     };
@@ -215,19 +214,18 @@ namespace IcePy
 
         std::string getId() const final;
 
-        virtual bool validate(PyObject*);
+        bool validate(PyObject*) final;
 
-        virtual bool variableLength() const;
-        virtual int wireSize() const;
-        virtual Ice::OptionalFormat optionalFormat() const;
+        bool variableLength() const final;
+        int wireSize() const final;
+        Ice::OptionalFormat optionalFormat() const final;
 
-        virtual void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = 0);
-        virtual void
-        unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = 0);
+        void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
+        void unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = nullptr) final;
 
-        virtual void print(PyObject*, IceInternal::Output&, PrintObjectHistory*);
+        void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
 
-        virtual void destroy();
+        void destroy() final;
 
         std::int32_t valueForEnumerator(PyObject*) const;
         PyObject* enumeratorForValue(std::int32_t) const;
@@ -239,10 +237,10 @@ namespace IcePy
     };
     using EnumInfoPtr = std::shared_ptr<EnumInfo>;
 
-    class DataMember : public UnmarshalCallback
+    class DataMember final : public UnmarshalCallback
     {
     public:
-        virtual void unmarshaled(PyObject*, PyObject*, void*);
+        void unmarshaled(PyObject*, PyObject*, void*) final;
 
         std::string name;
         std::vector<std::string> metadata;
@@ -256,28 +254,27 @@ namespace IcePy
     //
     // Struct information.
     //
-    class StructInfo : public TypeInfo
+    class StructInfo final : public TypeInfo
     {
     public:
         StructInfo(std::string, PyObject*, PyObject*);
 
-        virtual std::string getId() const;
+        std::string getId() const final;
 
-        virtual bool validate(PyObject*);
+        bool validate(PyObject*) final;
 
-        virtual bool variableLength() const;
-        virtual int wireSize() const;
-        virtual Ice::OptionalFormat optionalFormat() const;
+        bool variableLength() const final;
+        int wireSize() const final;
+        Ice::OptionalFormat optionalFormat() const final;
 
-        virtual bool usesClasses() const;
+        bool usesClasses() const final;
 
-        virtual void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = 0);
-        virtual void
-        unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = 0);
+        void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
+        void unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = nullptr) final;
 
-        virtual void print(PyObject*, IceInternal::Output&, PrintObjectHistory*);
+        void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
 
-        virtual void destroy();
+        void destroy() final;
 
         static PyObject* instantiate(PyObject*);
 
@@ -295,28 +292,27 @@ namespace IcePy
     //
     // Sequence information.
     //
-    class SequenceInfo : public TypeInfo
+    class SequenceInfo final : public TypeInfo
     {
     public:
         SequenceInfo(std::string, PyObject*, PyObject*);
 
-        virtual std::string getId() const;
+        std::string getId() const final;
 
-        virtual bool validate(PyObject*);
+        bool validate(PyObject*) final;
 
-        virtual bool variableLength() const;
-        virtual int wireSize() const;
-        virtual Ice::OptionalFormat optionalFormat() const;
+        bool variableLength() const final;
+        int wireSize() const final;
+        Ice::OptionalFormat optionalFormat() const final;
 
-        virtual bool usesClasses() const;
+        bool usesClasses() const final;
 
-        virtual void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = 0);
-        virtual void
-        unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = 0);
+        void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
+        void unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = nullptr) final;
 
-        virtual void print(PyObject*, IceInternal::Output&, PrintObjectHistory*);
+        void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
 
-        virtual void destroy();
+        void destroy() final;
 
         enum BuiltinType
         {
@@ -330,7 +326,7 @@ namespace IcePy
         };
 
     private:
-        struct SequenceMapping : public UnmarshalCallback
+        struct SequenceMapping final : public UnmarshalCallback
         {
             enum Type
             {
@@ -349,7 +345,7 @@ namespace IcePy
 
             static bool getType(const Ice::StringSeq&, Type&);
 
-            virtual void unmarshaled(PyObject*, PyObject*, void*);
+            void unmarshaled(PyObject*, PyObject*, void*) final;
 
             PyObject* createContainer(int) const;
             void setItem(PyObject*, int, PyObject*) const;
@@ -381,34 +377,33 @@ namespace IcePy
     //
     // Dictionary information.
     //
-    class DictionaryInfo : public TypeInfo, public std::enable_shared_from_this<DictionaryInfo>
+    class DictionaryInfo final : public TypeInfo, public std::enable_shared_from_this<DictionaryInfo>
     {
     public:
         DictionaryInfo(std::string, PyObject*, PyObject*);
 
-        virtual std::string getId() const;
+        std::string getId() const final;
 
-        virtual bool validate(PyObject*);
+        bool validate(PyObject*) final;
 
-        virtual bool variableLength() const;
-        virtual int wireSize() const;
-        virtual Ice::OptionalFormat optionalFormat() const;
+        bool variableLength() const final;
+        int wireSize() const final;
+        Ice::OptionalFormat optionalFormat() const final;
 
-        virtual bool usesClasses() const;
+        bool usesClasses() const final;
 
-        virtual void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = 0);
-        virtual void
-        unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = 0);
-        virtual void unmarshaled(PyObject*, PyObject*, void*);
+        void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
+        void unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = nullptr) final;
+        void unmarshaled(PyObject*, PyObject*, void*) final;
 
-        virtual void print(PyObject*, IceInternal::Output&, PrintObjectHistory*);
+        void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
 
-        virtual void destroy();
+        void destroy() final;
 
-        class KeyCallback : public UnmarshalCallback
+        class KeyCallback final : public UnmarshalCallback
         {
         public:
-            virtual void unmarshaled(PyObject*, PyObject*, void*);
+            void unmarshaled(PyObject*, PyObject*, void*) final;
 
             PyObjectHandle key;
         };
@@ -433,23 +428,22 @@ namespace IcePy
 
         void define(PyObject*, PyObject*, PyObject*);
 
-        virtual std::string getId() const;
+        std::string getId() const final;
 
-        virtual bool validate(PyObject*);
+        bool validate(PyObject*) final;
 
-        virtual bool variableLength() const;
-        virtual int wireSize() const;
-        virtual Ice::OptionalFormat optionalFormat() const;
+        bool variableLength() const final;
+        int wireSize() const final;
+        Ice::OptionalFormat optionalFormat() const final;
 
-        virtual bool usesClasses() const;
+        bool usesClasses() const final;
 
-        virtual void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = 0);
-        virtual void
-        unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = 0);
+        void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
+        void unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = nullptr) final;
 
-        virtual void print(PyObject*, IceInternal::Output&, PrintObjectHistory*);
+        void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
 
-        virtual void destroy();
+        void destroy() final;
 
         const std::string id;
         const ClassInfoPtr base;
@@ -471,23 +465,22 @@ namespace IcePy
 
         void define(PyObject*, int, bool, PyObject*, PyObject*);
 
-        virtual std::string getId() const;
+        std::string getId() const final;
 
-        virtual bool validate(PyObject*);
+        bool validate(PyObject*) final;
 
-        virtual bool variableLength() const;
-        virtual int wireSize() const;
-        virtual Ice::OptionalFormat optionalFormat() const;
+        bool variableLength() const final;
+        int wireSize() const final;
+        Ice::OptionalFormat optionalFormat() const final;
 
-        virtual bool usesClasses() const;
+        bool usesClasses() const final;
 
-        virtual void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = 0);
-        virtual void
-        unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = 0);
+        void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
+        void unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = nullptr) final;
 
-        virtual void print(PyObject*, IceInternal::Output&, PrintObjectHistory*);
+        void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
 
-        virtual void destroy();
+        void destroy() final;
 
         void printMembers(PyObject*, IceInternal::Output&, PrintObjectHistory*);
 
@@ -513,19 +506,18 @@ namespace IcePy
 
         void define(PyObject*);
 
-        virtual std::string getId() const;
+        std::string getId() const final;
 
-        virtual bool validate(PyObject*);
+        bool validate(PyObject*) final;
 
-        virtual bool variableLength() const;
-        virtual int wireSize() const;
-        virtual Ice::OptionalFormat optionalFormat() const;
+        bool variableLength() const final;
+        int wireSize() const final;
+        Ice::OptionalFormat optionalFormat() const final;
 
-        virtual void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = 0);
-        virtual void
-        unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = 0);
+        void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
+        void unmarshal(Ice::InputStream*, const UnmarshalCallbackPtr&, PyObject*, void*, bool, const Ice::StringSeq* = nullptr) final;
 
-        virtual void print(PyObject*, IceInternal::Output&, PrintObjectHistory*);
+        void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
 
         const std::string id;
         PyObject* pythonType; // Borrowed reference - the enclosing Python module owns the reference.
@@ -536,7 +528,7 @@ namespace IcePy
     //
     // Exception information.
     //
-    class ExceptionInfo : public std::enable_shared_from_this<ExceptionInfo>
+    class ExceptionInfo final : public std::enable_shared_from_this<ExceptionInfo>
     {
     public:
         void marshal(PyObject*, Ice::OutputStream*, ObjectMap*);
@@ -559,14 +551,14 @@ namespace IcePy
     //
     // ValueWriter wraps a Python object for marshaling.
     //
-    class ValueWriter : public Ice::Value
+    class ValueWriter final : public Ice::Value
     {
     public:
         ValueWriter(PyObject*, ObjectMap*, const ValueInfoPtr&);
-        virtual void ice_preMarshal();
+        void ice_preMarshal() final;
 
-        virtual void _iceWrite(Ice::OutputStream*) const;
-        virtual void _iceRead(Ice::InputStream*);
+        void _iceWrite(Ice::OutputStream*) const final;
+        void _iceRead(Ice::InputStream*) final;
 
     private:
         void writeMembers(Ice::OutputStream*, const DataMemberList&) const;
@@ -580,17 +572,17 @@ namespace IcePy
     //
     // ValueReader unmarshals the state of an Ice object.
     //
-    class ValueReader : public std::enable_shared_from_this<ValueReader>, public Ice::Value
+    class ValueReader final : public std::enable_shared_from_this<ValueReader>, public Ice::Value
     {
     public:
         ValueReader(PyObject*, const ValueInfoPtr&);
 
-        virtual void ice_postUnmarshal();
+        void ice_postUnmarshal() final;
 
-        virtual void _iceWrite(Ice::OutputStream*) const;
-        virtual void _iceRead(Ice::InputStream*);
+        void _iceWrite(Ice::OutputStream*) const final;
+        void _iceRead(Ice::InputStream*) final;
 
-        virtual ValueInfoPtr getInfo() const;
+        ValueInfoPtr getInfo() const;
 
         PyObject* getObject() const; // Borrowed reference.
 
@@ -620,7 +612,7 @@ namespace IcePy
         void _write(Ice::OutputStream*) const final;
         void _read(Ice::InputStream*) final;
 
-        virtual bool _usesClasses() const;
+        bool _usesClasses() const final;
 
     protected:
         void _writeImpl(Ice::OutputStream*) const final {}

--- a/python/modules/IcePy/Types.h
+++ b/python/modules/IcePy/Types.h
@@ -26,10 +26,6 @@ namespace IcePy
     using ExceptionInfoPtr = std::shared_ptr<ExceptionInfo>;
     using ExceptionInfoList = std::vector<ExceptionInfoPtr>;
 
-    class ClassInfo;
-    using ClassInfoPtr = std::shared_ptr<ClassInfo>;
-    using ClassInfoList = std::vector<ClassInfoPtr>;
-
     class ValueInfo;
     using ValueInfoPtr = std::shared_ptr<ValueInfo>;
 
@@ -450,45 +446,6 @@ namespace IcePy
     using DictionaryInfoPtr = std::shared_ptr<DictionaryInfo>;
     using TypeInfoList = std::vector<TypeInfoPtr>;
 
-    class ClassInfo final : public TypeInfo, public std::enable_shared_from_this<ClassInfo>
-    {
-    public:
-        ClassInfo(std::string);
-        void init();
-
-        void define(PyObject*, PyObject*, PyObject*);
-
-        std::string getId() const final;
-
-        bool validate(PyObject*) final;
-
-        bool variableLength() const final;
-        int wireSize() const final;
-        Ice::OptionalFormat optionalFormat() const final;
-
-        bool usesClasses() const final;
-
-        void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
-        void unmarshal(
-            Ice::InputStream*,
-            const UnmarshalCallbackPtr&,
-            PyObject*,
-            void*,
-            bool,
-            const Ice::StringSeq* = nullptr) final;
-
-        void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
-
-        void destroy() final;
-
-        const std::string id;
-        const ClassInfoPtr base;
-        const ClassInfoList interfaces;
-        PyObject* pythonType; // Borrowed reference - the enclosing Python module owns the reference.
-        PyObject* typeObj;    // Borrowed reference - the "_t_XXX" variable owns the reference.
-        const bool defined;
-    };
-
     //
     // Value type information
     //
@@ -702,7 +659,6 @@ namespace IcePy
 
     std::string resolveCompactId(std::int32_t id);
 
-    ClassInfoPtr lookupClassInfo(std::string_view);
     ValueInfoPtr lookupValueInfo(std::string_view);
     ExceptionInfoPtr lookupExceptionInfo(std::string_view);
 
@@ -723,8 +679,6 @@ extern "C" PyObject* IcePy_defineSequence(PyObject*, PyObject*);
 extern "C" PyObject* IcePy_defineDictionary(PyObject*, PyObject*);
 extern "C" PyObject* IcePy_declareProxy(PyObject*, PyObject*);
 extern "C" PyObject* IcePy_defineProxy(PyObject*, PyObject*);
-extern "C" PyObject* IcePy_declareClass(PyObject*, PyObject*);
-extern "C" PyObject* IcePy_defineClass(PyObject*, PyObject*);
 extern "C" PyObject* IcePy_declareValue(PyObject*, PyObject*);
 extern "C" PyObject* IcePy_defineValue(PyObject*, PyObject*);
 extern "C" PyObject* IcePy_defineException(PyObject*, PyObject*);

--- a/python/python/Ice/Object.py
+++ b/python/python/Ice/Object.py
@@ -141,9 +141,6 @@ class Object(object):
         except BaseException:
             cb.exception(sys.exc_info()[1])
 
-IcePy._t_Object = IcePy.defineClass("::Ice::Object", Object, (), None, ())
-Object._ice_type = IcePy._t_Object
-
 Object._op_ice_isA = IcePy.Operation(
     "ice_isA",
     Ice.OperationMode.Idempotent,

--- a/python/python/Ice/__init__.py
+++ b/python/python/Ice/__init__.py
@@ -29,7 +29,6 @@ AsyncInvocationContext = IcePy.AsyncInvocationContext
 #
 # Forward declarations.
 #
-IcePy._t_Object = IcePy.declareClass("::Ice::Object")
 IcePy._t_Value = IcePy.declareValue("::Ice::Object")
 IcePy._t_ObjectPrx = IcePy.declareProxy("::Ice::Object")
 


### PR DESCRIPTION
ClassInfo and associated code was used to track the "type" of servants, but servants have no type. It's most likely a leftover from the "interface by value" code.

In the Slice compilers for Python and JS, we use "Value" for class types, while in the Slice compilers for Ruby and PHP, we use "Class".