### PR TITLE
Use factories instead of init in IceRuby C++ code

### DIFF
--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -1916,6 +1916,15 @@ IceRuby::DictionaryInfo::destroy()
 //
 // ClassInfo implementation.
 //
+
+ClassInfoPtr
+IceRuby::ClassInfo::create(VALUE ident)
+{
+    shared_ptr<ClassInfo> classInfo{new ClassInfo{ident}};
+    const_cast<VALUE&>(classInfo->typeObj) = createType(classInfo);
+    return classInfo;
+}
+
 IceRuby::ClassInfo::ClassInfo(VALUE ident)
     : compactId(-1),
       isBase(false),
@@ -1926,12 +1935,6 @@ IceRuby::ClassInfo::ClassInfo(VALUE ident)
 {
     const_cast<string&>(id) = getString(ident);
     const_cast<bool&>(isBase) = id == Ice::Value::ice_staticId();
-}
-
-void
-IceRuby::ClassInfo::init()
-{
-    const_cast<VALUE&>(typeObj) = createType(shared_from_this());
 }
 
 void
@@ -2193,16 +2196,19 @@ IceRuby::ClassInfo::isA(const ClassInfoPtr& info)
 //
 // ProxyInfo implementation.
 //
+
+ProxyInfoPtr
+IceRuby::ProxyInfo::create(VALUE ident)
+{
+    shared_ptr<ProxyInfo> proxyInfo{new ProxyInfo{ident}};
+    const_cast<VALUE&>(proxyInfo->typeObj) = createType(proxyInfo);
+    return proxyInfo;
+}
+
 IceRuby::ProxyInfo::ProxyInfo(VALUE ident) : isBase(false), rubyClass(Qnil), typeObj(Qnil)
 {
     const_cast<string&>(id) = getString(ident);
     const_cast<bool&>(isBase) = id == Ice::Object::ice_staticId();
-}
-
-void
-IceRuby::ProxyInfo::init()
-{
-    const_cast<VALUE&>(typeObj) = createType(shared_from_this());
 }
 
 void
@@ -2871,8 +2877,7 @@ IceRuby_declareProxy(VALUE /*self*/, VALUE id)
         ProxyInfoPtr info = lookupProxyInfo(proxyId);
         if (!info)
         {
-            info = make_shared<ProxyInfo>(id);
-            info->init();
+            info = ProxyInfo::create(id);
             addProxyInfo(proxyId, info);
         }
 
@@ -2891,8 +2896,7 @@ IceRuby_declareClass(VALUE /*self*/, VALUE id)
         ClassInfoPtr info = lookupClassInfo(idstr);
         if (!info)
         {
-            info = make_shared<ClassInfo>(id);
-            info->init();
+            info = ClassInfo::create(id);
             addClassInfo(idstr, info);
         }
 

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -1916,25 +1916,16 @@ IceRuby::DictionaryInfo::destroy()
 //
 // ClassInfo implementation.
 //
-IceRuby::ClassInfo::ClassInfo(VALUE ident, bool loc)
+IceRuby::ClassInfo::ClassInfo(VALUE ident)
     : compactId(-1),
       isBase(false),
-      isLocal(loc),
       interface(false),
       rubyClass(Qnil),
       typeObj(Qnil),
       defined(false)
 {
     const_cast<string&>(id) = getString(ident);
-    if (isLocal)
-    {
-        // We don't define LocalObject anymore.
-        assert(id != "::Ice::LocalObject");
-    }
-    else
-    {
-        const_cast<bool&>(isBase) = id == Ice::Value::ice_staticId();
-    }
+    const_cast<bool&>(isBase) = id == Ice::Value::ice_staticId();
 }
 
 void
@@ -2187,7 +2178,7 @@ IceRuby::ClassInfo::isA(const ClassInfoPtr& info)
     //
     // Return true if this class has an is-a relationship with info.
     //
-    if (info->isBase && isLocal == info->isLocal)
+    if (info->isBase)
     {
         return true;
     }
@@ -2900,7 +2891,7 @@ IceRuby_declareClass(VALUE /*self*/, VALUE id)
         ClassInfoPtr info = lookupClassInfo(idstr);
         if (!info)
         {
-            info = make_shared<ClassInfo>(id, false);
+            info = make_shared<ClassInfo>(id);
             info->init();
             addClassInfo(idstr, info);
         }

--- a/ruby/src/IceRuby/Types.h
+++ b/ruby/src/IceRuby/Types.h
@@ -356,7 +356,7 @@ namespace IceRuby
     class ClassInfo final : public TypeInfo, public std::enable_shared_from_this<ClassInfo>
     {
     public:
-        ClassInfo(VALUE, bool);
+        ClassInfo(VALUE);
         void init();
 
         void define(VALUE, VALUE, VALUE, VALUE, VALUE);
@@ -385,7 +385,6 @@ namespace IceRuby
         const std::string id;
         const std::int32_t compactId;
         const bool isBase; // Is this the ClassInfo for Value?
-        const bool isLocal;
         const bool interface;
         const ClassInfoPtr base;
         const DataMemberList members;

--- a/ruby/src/IceRuby/Types.h
+++ b/ruby/src/IceRuby/Types.h
@@ -139,7 +139,7 @@ namespace IceRuby
 
         virtual bool usesClasses() const; // Default implementation returns false.
 
-        virtual void unmarshaled(VALUE, VALUE, void*); // Default implementation is assert(false).
+        void unmarshaled(VALUE, VALUE, void*) override; // Default implementation is assert(false).
 
         virtual void destroy();
 
@@ -331,7 +331,7 @@ namespace IceRuby
         void print(VALUE, IceInternal::Output&, PrintObjectHistory*) final;
         void printElement(VALUE, VALUE, IceInternal::Output&, PrintObjectHistory*);
 
-        virtual void destroy();
+        void destroy() final;
 
         class KeyCallback final : public UnmarshalCallback
         {

--- a/ruby/src/IceRuby/Types.h
+++ b/ruby/src/IceRuby/Types.h
@@ -356,8 +356,7 @@ namespace IceRuby
     class ClassInfo final : public TypeInfo, public std::enable_shared_from_this<ClassInfo>
     {
     public:
-        ClassInfo(VALUE);
-        void init();
+        static ClassInfoPtr create(VALUE);
 
         void define(VALUE, VALUE, VALUE, VALUE, VALUE);
 
@@ -392,14 +391,16 @@ namespace IceRuby
         const VALUE rubyClass;
         const VALUE typeObj;
         const bool defined;
+
+    private:
+        ClassInfo(VALUE);
     };
 
     // Proxy information.
-    class ProxyInfo final : public TypeInfo, public std::enable_shared_from_this<ProxyInfo>
+    class ProxyInfo final : public TypeInfo
     {
     public:
-        ProxyInfo(VALUE);
-        void init();
+        static ProxyInfoPtr create(VALUE);
 
         void define(VALUE, VALUE, VALUE);
 
@@ -426,6 +427,9 @@ namespace IceRuby
         const ProxyInfoList interfaces;
         const VALUE rubyClass;
         const VALUE typeObj;
+
+    private:
+        ProxyInfo(VALUE);
     };
 
     // Exception information.


### PR DESCRIPTION
This PR cleans up the IceRuby C++ code per #1730.