### PR TITLE
Slice Parser cleanup

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1075,7 +1075,7 @@ Slice::Container::createModule(const string& name)
         return nullptr;
     }
 
-    ModulePtr q = make_shared<Module>(dynamic_pointer_cast<Container>(shared_from_this()), name);
+    ModulePtr q = make_shared<Module>(shared_from_this(), name);
     _unit->addContent(q);
     _contents.push_back(q);
     return q;
@@ -1134,7 +1134,7 @@ Slice::Container::createClassDef(const string& name, int id, const ClassDefPtr& 
         return nullptr;
     }
 
-    ClassDefPtr def = make_shared<ClassDef>(dynamic_pointer_cast<Container>(shared_from_this()), name, id, base);
+    ClassDefPtr def = make_shared<ClassDef>(shared_from_this(), name, id, base);
     _unit->addContent(def);
     _contents.push_back(def);
 
@@ -1220,7 +1220,7 @@ Slice::Container::createClassDecl(const string& name)
     }
 
     _unit->currentContainer();
-    ClassDeclPtr decl = make_shared<ClassDecl>(dynamic_pointer_cast<Container>(shared_from_this()), name);
+    ClassDeclPtr decl = make_shared<ClassDecl>(shared_from_this(), name);
     _unit->addContent(decl);
     _contents.push_back(decl);
 
@@ -1287,7 +1287,7 @@ Slice::Container::createInterfaceDef(const string& name, const InterfaceList& ba
 
     InterfaceDecl::checkBasesAreLegal(name, bases, _unit);
 
-    InterfaceDefPtr def = make_shared<InterfaceDef>(dynamic_pointer_cast<Container>(shared_from_this()), name, bases);
+    InterfaceDefPtr def = make_shared<InterfaceDef>(shared_from_this(), name, bases);
     _unit->addContent(def);
     _contents.push_back(def);
 
@@ -1370,7 +1370,7 @@ Slice::Container::createInterfaceDecl(const string& name)
     }
 
     _unit->currentContainer();
-    InterfaceDeclPtr decl = make_shared<InterfaceDecl>(dynamic_pointer_cast<Container>(shared_from_this()), name);
+    InterfaceDeclPtr decl = make_shared<InterfaceDecl>(shared_from_this(), name);
     _unit->addContent(decl);
     _contents.push_back(decl);
 
@@ -1411,7 +1411,7 @@ Slice::Container::createException(const string& name, const ExceptionPtr& base, 
         checkForGlobalDefinition("exceptions"); // Don't return here -- we create the exception anyway
     }
 
-    ExceptionPtr p = make_shared<Exception>(dynamic_pointer_cast<Container>(shared_from_this()), name, base);
+    ExceptionPtr p = make_shared<Exception>(shared_from_this(), name, base);
     _unit->addContent(p);
     _contents.push_back(p);
     return p;
@@ -1446,7 +1446,7 @@ Slice::Container::createStruct(const string& name, NodeType nodeType)
         checkForGlobalDefinition("structs"); // Don't return here -- we create the struct anyway.
     }
 
-    StructPtr p = make_shared<Struct>(dynamic_pointer_cast<Container>(shared_from_this()), name);
+    StructPtr p = make_shared<Struct>(shared_from_this(), name);
     _unit->addContent(p);
     _contents.push_back(p);
     return p;
@@ -1481,7 +1481,7 @@ Slice::Container::createSequence(const string& name, const TypePtr& type, const 
         checkForGlobalDefinition("sequences"); // Don't return here -- we create the sequence anyway.
     }
 
-    SequencePtr p = make_shared<Sequence>(dynamic_pointer_cast<Container>(shared_from_this()), name, type, metadata);
+    SequencePtr p = make_shared<Sequence>(shared_from_this(), name, type, metadata);
     _unit->addContent(p);
     _contents.push_back(p);
     return p;
@@ -1531,7 +1531,7 @@ Slice::Container::createDictionary(
     }
 
     DictionaryPtr p = make_shared<Dictionary>(
-        dynamic_pointer_cast<Container>(shared_from_this()),
+        shared_from_this(),
         name,
         keyType,
         keyMetadata,
@@ -1571,7 +1571,7 @@ Slice::Container::createEnum(const string& name, NodeType nodeType)
         checkForGlobalDefinition("enums"); // Don't return here -- we create the enumeration anyway.
     }
 
-    EnumPtr p = make_shared<Enum>(dynamic_pointer_cast<Container>(shared_from_this()), name);
+    EnumPtr p = make_shared<Enum>(shared_from_this(), name);
     _unit->addContent(p);
     _contents.push_back(p);
     return p;
@@ -1621,7 +1621,7 @@ Slice::Container::createConst(
     }
 
     ConstPtr p = make_shared<Const>(
-        dynamic_pointer_cast<Container>(shared_from_this()),
+        shared_from_this(),
         name,
         type,
         metadata,
@@ -1942,7 +1942,7 @@ Slice::Container::enumerators(const string& identifier) const
     if (lastColon == string::npos)
     {
         // check all enclosing scopes
-        ContainerPtr container = dynamic_pointer_cast<Container>(const_pointer_cast<GrammarBase>(shared_from_this()));
+        ContainerPtr container = const_pointer_cast<Container>(shared_from_this());
         do
         {
             EnumList enums = container->enums();
@@ -1962,7 +1962,7 @@ Slice::Container::enumerators(const string& identifier) const
     else
     {
         // Find the referenced scope
-        ContainerPtr container = dynamic_pointer_cast<Container>(const_pointer_cast<GrammarBase>(shared_from_this()));
+        ContainerPtr container = const_pointer_cast<Container>(shared_from_this());
         string scope = identifier.substr(0, identifier.rfind("::"));
         ContainedList cl = container->lookupContained(scope, false);
         if (!cl.empty())
@@ -1997,7 +1997,7 @@ string
 Slice::Container::thisScope() const
 {
     string s;
-    ContainedPtr contained = dynamic_pointer_cast<Contained>(const_pointer_cast<GrammarBase>(shared_from_this()));
+    ContainedPtr contained = dynamic_pointer_cast<Contained>(const_pointer_cast<Container>(shared_from_this()));
     if (contained)
     {
         s = contained->scoped();
@@ -2367,7 +2367,7 @@ Slice::Module::kindOf() const
 void
 Slice::Module::visit(ParserVisitor* visitor)
 {
-    auto self = dynamic_pointer_cast<Module>(Container::shared_from_this());
+    auto self = dynamic_pointer_cast<Module>(shared_from_this());
     if (visitor->visitModuleStart(self))
     {
         Container::visit(visitor);
@@ -2449,7 +2449,7 @@ Slice::ClassDecl::kindOf() const
 void
 Slice::ClassDecl::visit(ParserVisitor* visitor)
 {
-    visitor->visitClassDecl(dynamic_pointer_cast<ClassDecl>(shared_from_this()));
+    visitor->visitClassDecl(shared_from_this());
 }
 
 Slice::ClassDecl::ClassDecl(const ContainerPtr& container, const string& name)
@@ -2561,7 +2561,7 @@ Slice::ClassDef::createDataMember(
     }
 
     DataMemberPtr member = make_shared<DataMember>(
-        dynamic_pointer_cast<Container>(shared_from_this()),
+        shared_from_this(),
         name,
         type,
         isOptional,
@@ -2707,7 +2707,7 @@ Slice::ClassDef::kindOf() const
 void
 Slice::ClassDef::visit(ParserVisitor* visitor)
 {
-    auto self = dynamic_pointer_cast<ClassDef>(Container::shared_from_this());
+    auto self = dynamic_pointer_cast<ClassDef>(shared_from_this());
     if (visitor->visitClassDefStart(self))
     {
         Container::visit(visitor);
@@ -2778,7 +2778,7 @@ Slice::InterfaceDecl::kindOf() const
 void
 Slice::InterfaceDecl::visit(ParserVisitor* visitor)
 {
-    visitor->visitInterfaceDecl(dynamic_pointer_cast<InterfaceDecl>(shared_from_this()));
+    visitor->visitInterfaceDecl(shared_from_this());
 }
 
 void
@@ -3037,7 +3037,7 @@ Slice::InterfaceDef::createOperation(
 
     _hasOperations = true;
     OperationPtr op = make_shared<Operation>(
-        dynamic_pointer_cast<Container>(shared_from_this()),
+        shared_from_this(),
         name,
         returnType,
         isOptional,
@@ -3148,7 +3148,7 @@ Slice::InterfaceDef::kindOf() const
 void
 Slice::InterfaceDef::visit(ParserVisitor* visitor)
 {
-    auto self = dynamic_pointer_cast<InterfaceDef>(Container::shared_from_this());
+    auto self = dynamic_pointer_cast<InterfaceDef>(shared_from_this());
     if (visitor->visitInterfaceDefStart(self))
     {
         Container::visit(visitor);
@@ -3298,7 +3298,7 @@ Slice::Operation::createParamDecl(const string& name, const TypePtr& type, bool 
     }
 
     ParamDeclPtr p = make_shared<ParamDecl>(
-        dynamic_pointer_cast<Container>(shared_from_this()),
+        shared_from_this(),
         name,
         type,
         isOutParam,
@@ -3542,7 +3542,7 @@ Slice::Operation::kindOf() const
 void
 Slice::Operation::visit(ParserVisitor* visitor)
 {
-    visitor->visitOperation(dynamic_pointer_cast<Operation>(Container::shared_from_this()));
+    visitor->visitOperation(dynamic_pointer_cast<Operation>(shared_from_this()));
 }
 
 Slice::Operation::Operation(
@@ -3663,7 +3663,7 @@ Slice::Exception::createDataMember(
     }
 
     DataMemberPtr p = make_shared<DataMember>(
-        dynamic_pointer_cast<Container>(shared_from_this()),
+        shared_from_this(),
         name,
         type,
         isOptional,
@@ -3828,7 +3828,7 @@ Slice::Exception::kindOf() const
 void
 Slice::Exception::visit(ParserVisitor* visitor)
 {
-    auto self = dynamic_pointer_cast<Exception>(Container::shared_from_this());
+    auto self = dynamic_pointer_cast<Exception>(shared_from_this());
     if (visitor->visitExceptionStart(self))
     {
         Container::visit(visitor);
@@ -3902,7 +3902,7 @@ Slice::Struct::createDataMember(
     }
 
     DataMemberPtr p = make_shared<DataMember>(
-        dynamic_pointer_cast<Container>(shared_from_this()),
+        shared_from_this(),
         name,
         type,
         isOptional,
@@ -4001,7 +4001,7 @@ Slice::Struct::kindOf() const
 void
 Slice::Struct::visit(ParserVisitor* visitor)
 {
-    auto self = dynamic_pointer_cast<Struct>(Container::shared_from_this());
+    auto self = dynamic_pointer_cast<Struct>(shared_from_this());
     if (visitor->visitStructStart(self))
     {
         Container::visit(visitor);
@@ -4067,7 +4067,7 @@ Slice::Sequence::kindOf() const
 void
 Slice::Sequence::visit(ParserVisitor* visitor)
 {
-    visitor->visitSequence(dynamic_pointer_cast<Sequence>(shared_from_this()));
+    visitor->visitSequence(shared_from_this());
 }
 
 Slice::Sequence::Sequence(
@@ -4145,7 +4145,7 @@ Slice::Dictionary::kindOf() const
 void
 Slice::Dictionary::visit(ParserVisitor* visitor)
 {
-    visitor->visitDictionary(dynamic_pointer_cast<Dictionary>(shared_from_this()));
+    visitor->visitDictionary(shared_from_this());
 }
 
 // Checks whether the provided type is a legal dictionary key type.
@@ -4298,7 +4298,7 @@ Slice::Enum::createEnumerator(const string& name, optional<int> explicitValue)
     }
 
     // Create the enumerator.
-    ContainerPtr cont = dynamic_pointer_cast<Container>(shared_from_this());
+    ContainerPtr cont = shared_from_this();
     EnumeratorPtr p = make_shared<Enumerator>(cont, name, nextValue, explicitValue.has_value());
     _unit->addContent(p);
     _contents.push_back(p);
@@ -4351,7 +4351,7 @@ Slice::Enum::kindOf() const
 void
 Slice::Enum::visit(ParserVisitor* visitor)
 {
-    visitor->visitEnum(dynamic_pointer_cast<Enum>(Container::shared_from_this()));
+    visitor->visitEnum(dynamic_pointer_cast<Enum>(shared_from_this()));
 }
 
 Slice::Enum::Enum(const ContainerPtr& container, const string& name)
@@ -4440,7 +4440,7 @@ Slice::Const::kindOf() const
 void
 Slice::Const::visit(ParserVisitor* visitor)
 {
-    visitor->visitConst(dynamic_pointer_cast<Const>(shared_from_this()));
+    visitor->visitConst(shared_from_this());
 }
 
 Slice::Const::Const(
@@ -4496,7 +4496,7 @@ Slice::ParamDecl::kindOf() const
 void
 Slice::ParamDecl::visit(ParserVisitor* visitor)
 {
-    visitor->visitParamDecl(dynamic_pointer_cast<ParamDecl>(shared_from_this()));
+    visitor->visitParamDecl(shared_from_this());
 }
 
 Slice::ParamDecl::ParamDecl(
@@ -4558,7 +4558,7 @@ Slice::DataMember::kindOf() const
 void
 Slice::DataMember::visit(ParserVisitor* visitor)
 {
-    visitor->visitDataMember(dynamic_pointer_cast<DataMember>(shared_from_this()));
+    visitor->visitDataMember(shared_from_this());
 }
 
 Slice::DataMember::DataMember(
@@ -4942,7 +4942,7 @@ Slice::Unit::parse(const string& filename, FILE* file, bool debugMode)
     _currentComment = "";
     _currentIncludeLevel = 0;
     _topLevelFile = fullPath(filename);
-    pushContainer(dynamic_pointer_cast<Container>(shared_from_this()));
+    pushContainer(shared_from_this());
     pushDefinitionContext();
     setCurrentFile(_topLevelFile, 0);
 

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1530,13 +1530,7 @@ Slice::Container::createDictionary(
         }
     }
 
-    DictionaryPtr p = make_shared<Dictionary>(
-        shared_from_this(),
-        name,
-        keyType,
-        keyMetadata,
-        valueType,
-        valueMetadata);
+    DictionaryPtr p = make_shared<Dictionary>(shared_from_this(), name, keyType, keyMetadata, valueType, valueMetadata);
     _unit->addContent(p);
     _contents.push_back(p);
     return p;
@@ -1620,13 +1614,7 @@ Slice::Container::createConst(
         return nullptr;
     }
 
-    ConstPtr p = make_shared<Const>(
-        shared_from_this(),
-        name,
-        type,
-        metadata,
-        resolvedValueType,
-        valueString);
+    ConstPtr p = make_shared<Const>(shared_from_this(), name, type, metadata, resolvedValueType, valueString);
     _unit->addContent(p);
     _contents.push_back(p);
     return p;
@@ -2560,14 +2548,7 @@ Slice::ClassDef::createDataMember(
         }
     }
 
-    DataMemberPtr member = make_shared<DataMember>(
-        shared_from_this(),
-        name,
-        type,
-        isOptional,
-        tag,
-        dlt,
-        dv);
+    DataMemberPtr member = make_shared<DataMember>(shared_from_this(), name, type, isOptional, tag, dlt, dv);
     _unit->addContent(member);
     _contents.push_back(member);
     return member;
@@ -3036,13 +3017,7 @@ Slice::InterfaceDef::createOperation(
     }
 
     _hasOperations = true;
-    OperationPtr op = make_shared<Operation>(
-        shared_from_this(),
-        name,
-        returnType,
-        isOptional,
-        tag,
-        mode);
+    OperationPtr op = make_shared<Operation>(shared_from_this(), name, returnType, isOptional, tag, mode);
     _unit->addContent(op);
     _contents.push_back(op);
     return op;
@@ -3297,13 +3272,7 @@ Slice::Operation::createParamDecl(const string& name, const TypePtr& type, bool 
         }
     }
 
-    ParamDeclPtr p = make_shared<ParamDecl>(
-        shared_from_this(),
-        name,
-        type,
-        isOutParam,
-        isOptional,
-        tag);
+    ParamDeclPtr p = make_shared<ParamDecl>(shared_from_this(), name, type, isOutParam, isOptional, tag);
     _unit->addContent(p);
     _contents.push_back(p);
     return p;
@@ -3662,14 +3631,7 @@ Slice::Exception::createDataMember(
         }
     }
 
-    DataMemberPtr p = make_shared<DataMember>(
-        shared_from_this(),
-        name,
-        type,
-        isOptional,
-        tag,
-        dlt,
-        dv);
+    DataMemberPtr p = make_shared<DataMember>(shared_from_this(), name, type, isOptional, tag, dlt, dv);
     _unit->addContent(p);
     _contents.push_back(p);
     return p;
@@ -3901,14 +3863,7 @@ Slice::Struct::createDataMember(
         }
     }
 
-    DataMemberPtr p = make_shared<DataMember>(
-        shared_from_this(),
-        name,
-        type,
-        isOptional,
-        tag,
-        dlt,
-        dv);
+    DataMemberPtr p = make_shared<DataMember>(shared_from_this(), name, type, isOptional, tag, dlt, dv);
     _unit->addContent(p);
     _contents.push_back(p);
     return p;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -317,9 +317,7 @@ namespace Slice
         inline static const std::array<std::string, 11> builtinTable =
             {"byte", "bool", "short", "int", "long", "float", "double", "string", "Object", "Object*", "Value"};
 
-    protected:
-        friend class Unit;
-
+    private:
         const Kind _kind;
     };
 
@@ -330,8 +328,7 @@ namespace Slice
     class Contained : public virtual SyntaxTreeBase
     {
     public:
-        Contained(const ContainerPtr& container, const std::string& name);
-        virtual void init();
+        void init();
         ContainerPtr container() const;
         std::string name() const;
         std::string scoped() const;
@@ -368,7 +365,7 @@ namespace Slice
         virtual std::string kindOf() const = 0;
 
     protected:
-        friend class Container;
+        Contained(const ContainerPtr& container, const std::string& name);
 
         ContainerPtr _container;
         std::string _name;
@@ -480,8 +477,6 @@ namespace Slice
         Module(const ContainerPtr& container, const std::string& name);
         std::string kindOf() const final;
         void visit(ParserVisitor* visitor) final;
-
-        friend class Container;
     };
 
     // ----------------------------------------------------------------------
@@ -512,9 +507,8 @@ namespace Slice
         void visit(ParserVisitor* visitor) final;
         std::string kindOf() const final;
 
-    protected:
+    private:
         friend class Container;
-        friend class ClassDef;
 
         ClassDefPtr _definition;
     };
@@ -557,7 +551,7 @@ namespace Slice
         int compactId() const;
         std::string kindOf() const final;
 
-    protected:
+    private:
         friend class Container;
 
         ClassDeclPtr _declaration;
@@ -583,13 +577,11 @@ namespace Slice
 
         static void checkBasesAreLegal(const std::string& name, const InterfaceList& bases, const UnitPtr& unit);
 
-    protected:
+    private:
         friend class Container;
-        friend class InterfaceDef;
 
         InterfaceDefPtr _definition;
 
-    private:
         typedef std::list<InterfaceList> GraphPartitionList;
         typedef std::list<StringList> StringPartitionList;
 
@@ -650,9 +642,7 @@ namespace Slice
         std::string kindOf() const final;
         void visit(ParserVisitor* visitor) final;
 
-    protected:
-        friend class InterfaceDef;
-
+    private:
         TypePtr _returnType;
         bool _returnIsOptional;
         int _returnTag;
@@ -696,7 +686,7 @@ namespace Slice
         // Returns the type IDs of all the interfaces in the inheritance tree, in alphabetical order.
         StringList ids() const;
 
-    protected:
+    private:
         friend class Container;
 
         InterfaceDeclPtr _declaration;
@@ -735,9 +725,7 @@ namespace Slice
         std::string kindOf() const final;
         void visit(ParserVisitor* visitor) final;
 
-    protected:
-        friend class Container;
-
+    private:
         ExceptionPtr _base;
     };
 
@@ -764,8 +752,6 @@ namespace Slice
         bool isVariableLength() const final;
         std::string kindOf() const final;
         void visit(ParserVisitor* visitor) final;
-
-        friend class Container;
     };
 
     // ----------------------------------------------------------------------
@@ -789,9 +775,7 @@ namespace Slice
         std::string kindOf() const final;
         void visit(ParserVisitor* visitor) final;
 
-    protected:
-        friend class Container;
-
+    private:
         TypePtr _type;
         StringList _typeMetadata;
     };
@@ -823,9 +807,7 @@ namespace Slice
 
         static bool isLegalKeyType(const TypePtr& type);
 
-    protected:
-        friend class Container;
-
+    private:
         TypePtr _keyType;
         TypePtr _valueType;
         StringList _keyMetadata;
@@ -851,10 +833,7 @@ namespace Slice
         std::string kindOf() const final;
         void visit(ParserVisitor* visitor) final;
 
-    protected:
-        friend class Container;
-        friend class Enumerator;
-
+    private:
         bool _hasExplicitValues;
         std::int64_t _minValue;
         std::int64_t _maxValue;
@@ -875,9 +854,7 @@ namespace Slice
         bool hasExplicitValue() const;
         int value() const;
 
-    protected:
-        friend class Container;
-
+    private:
         bool _hasExplicitValue;
         int _value;
     };
@@ -903,9 +880,7 @@ namespace Slice
         std::string kindOf() const final;
         void visit(ParserVisitor* visitor) final;
 
-    protected:
-        friend class Container;
-
+    private:
         TypePtr _type;
         StringList _typeMetadata;
         SyntaxTreeBasePtr _valueType;
@@ -933,9 +908,7 @@ namespace Slice
         std::string kindOf() const final;
         void visit(ParserVisitor* visitor) final;
 
-    protected:
-        friend class Operation;
-
+    private:
         TypePtr _type;
         bool _isOutParam;
         bool _optional;
@@ -965,11 +938,7 @@ namespace Slice
         std::string kindOf() const final;
         void visit(ParserVisitor* visitor) final;
 
-    protected:
-        friend class ClassDef;
-        friend class Struct;
-        friend class Exception;
-
+    private:
         TypePtr _type;
         bool _optional;
         int _tag;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -219,6 +219,8 @@ namespace Slice
         std::map<std::string, StringList> exceptions() const;
 
     private:
+        friend class Contained;
+
         bool _isDeprecated;
         StringList _deprecated;
         StringList _overview;
@@ -228,8 +230,6 @@ namespace Slice
         StringList _returns;
         std::map<std::string, StringList> _parameters;
         std::map<std::string, StringList> _exceptions;
-
-        friend class Contained;
     };
     using CommentPtr = std::shared_ptr<Comment>;
 
@@ -328,7 +328,6 @@ namespace Slice
     class Contained : public virtual SyntaxTreeBase
     {
     public:
-        void init();
         ContainerPtr container() const;
         std::string name() const;
         std::string scoped() const;
@@ -955,8 +954,6 @@ namespace Slice
     public:
         static UnitPtr createUnit(bool all, const StringList& defaultFileMetadata = StringList());
 
-        Unit(bool all, const StringList& defaultFileMetadata);
-
         void setComment(const std::string& comment);
         void addToComment(const std::string& comment);
         std::string currentComment(); // Not const, as this function removes the current comment.
@@ -1006,10 +1003,10 @@ namespace Slice
         std::set<std::string> getTopLevelModules(const std::string& file) const;
 
     private:
+        Unit(bool all, const StringList& defaultFileMetadata);
+
         void pushDefinitionContext();
         void popDefinitionContext();
-
-        void init();
 
         bool _all;
         StringList _defaultFileMetadata;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -237,7 +237,7 @@ namespace Slice
     // GrammarBase
     // ----------------------------------------------------------------------
 
-    class GrammarBase : public virtual std::enable_shared_from_this<GrammarBase>
+    class GrammarBase
     {
     public:
         virtual ~GrammarBase() = default;
@@ -380,7 +380,7 @@ namespace Slice
     // Container
     // ----------------------------------------------------------------------
 
-    class Container : public virtual SyntaxTreeBase
+    class Container : public virtual SyntaxTreeBase, public std::enable_shared_from_this<Container>
     {
     public:
         Container(const UnitPtr& unit);
@@ -493,7 +493,7 @@ namespace Slice
     // ClassDecl
     // ----------------------------------------------------------------------
 
-    class ClassDecl final : public virtual Constructed
+    class ClassDecl final : public virtual Constructed, public std::enable_shared_from_this<ClassDecl>
     {
     public:
         ClassDecl(const ContainerPtr& container, const std::string& name);
@@ -562,7 +562,7 @@ namespace Slice
     // InterfaceDecl
     // ----------------------------------------------------------------------
 
-    class InterfaceDecl final : public virtual Constructed
+    class InterfaceDecl final : public virtual Constructed, public std::enable_shared_from_this<InterfaceDecl>
     {
     public:
         InterfaceDecl(const ContainerPtr& container, const std::string& name);
@@ -757,7 +757,7 @@ namespace Slice
     // Sequence
     // ----------------------------------------------------------------------
 
-    class Sequence final : public virtual Constructed
+    class Sequence final : public virtual Constructed, public std::enable_shared_from_this<Sequence>
     {
     public:
         Sequence(
@@ -783,7 +783,7 @@ namespace Slice
     // Dictionary
     // ----------------------------------------------------------------------
 
-    class Dictionary final : public virtual Constructed
+    class Dictionary final : public virtual Constructed, public std::enable_shared_from_this<Dictionary>
     {
     public:
         Dictionary(
@@ -862,7 +862,7 @@ namespace Slice
     // Const
     // ----------------------------------------------------------------------
 
-    class Const final : public virtual Contained
+    class Const final : public virtual Contained, public std::enable_shared_from_this<Const>
     {
     public:
         Const(
@@ -890,7 +890,7 @@ namespace Slice
     // ParamDecl
     // ----------------------------------------------------------------------
 
-    class ParamDecl final : public virtual Contained
+    class ParamDecl final : public virtual Contained, public std::enable_shared_from_this<ParamDecl>
     {
     public:
         ParamDecl(
@@ -918,7 +918,7 @@ namespace Slice
     // DataMember
     // ----------------------------------------------------------------------
 
-    class DataMember final : public virtual Contained
+    class DataMember final : public virtual Contained, public std::enable_shared_from_this<DataMember>
     {
     public:
         DataMember(


### PR DESCRIPTION
A small cleanup of the Slice Parser C++ code.

In particular, remove the init functions (see #1730).