### PR TITLE
Fix DataStorm code to not schedule tasks with a destroyed timer.

### DIFF
--- a/cpp/src/DataStorm/Instance.cpp
+++ b/cpp/src/DataStorm/Instance.cpp
@@ -156,6 +156,12 @@ Instance::waitForShutdown() const
 void
 Instance::destroy(bool ownsCommunicator)
 {
+    {
+        unique_lock<mutex> lock(_mutex);
+        _timer->destroy();
+        _timer = nullptr;
+    }
+
     if (ownsCommunicator)
     {
         _communicator->destroy();
@@ -174,7 +180,4 @@ Instance::destroy(bool ownsCommunicator)
     _executor->destroy();
     _connectionManager->destroy();
     _collocatedForwarder->destroy();
-    // Destroy the session manager before the timer to avoid scheduling new tasks after the timer has been destroyed.
-    _nodeSessionManager->destroy();
-    _timer->destroy();
 }

--- a/cpp/src/DataStorm/Instance.cpp
+++ b/cpp/src/DataStorm/Instance.cpp
@@ -156,10 +156,16 @@ Instance::waitForShutdown() const
 void
 Instance::destroy(bool ownsCommunicator)
 {
+    IceInternal::TimerPtr timer;
     {
         unique_lock<mutex> lock(_mutex);
-        _timer->destroy();
+        timer = _timer;
         _timer = nullptr;
+    }
+
+    if (timer)
+    {
+        timer->destroy();
     }
 
     if (ownsCommunicator)

--- a/cpp/src/DataStorm/NodeSessionManager.cpp
+++ b/cpp/src/DataStorm/NodeSessionManager.cpp
@@ -87,13 +87,6 @@ NodeSessionManager::init()
     }
 }
 
-void
-NodeSessionManager::destroy()
-{
-    unique_lock<mutex> lock(_mutex);
-    _instance.reset();
-}
-
 shared_ptr<NodeSessionI>
 NodeSessionManager::createOrGet(NodePrx node, const Ice::ConnectionPtr& connection, bool forwardAnnouncements)
 {
@@ -420,7 +413,7 @@ NodeSessionManager::disconnected(LookupPrx lookup)
     auto instance = _instance.lock();
     if (instance)
     {
-        instance->getTimer()->schedule(
+        instance->scheduleTimerTask(
             [=, this, self = shared_from_this()]
             {
                 auto instance = _instance.lock();

--- a/cpp/src/DataStorm/NodeSessionManager.h
+++ b/cpp/src/DataStorm/NodeSessionManager.h
@@ -23,7 +23,6 @@ namespace DataStormI
         NodeSessionManager(const std::shared_ptr<Instance>&, const std::shared_ptr<NodeI>&);
 
         void init();
-        void destroy();
 
         std::shared_ptr<NodeSessionI> createOrGet(DataStormContract::NodePrx, const Ice::ConnectionPtr&, bool);
 

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -557,7 +557,7 @@ SessionI::connected(SessionPrx session, const Ice::ConnectionPtr& connection, co
 
     if (_retryTask)
     {
-        _instance->getTimer()->cancel(_retryTask);
+        _instance->cancelTimerTask(_retryTask);
         _retryTask = nullptr;
     }
 
@@ -666,7 +666,7 @@ SessionI::retry(NodePrx node, exception_ptr exception)
     {
         if (_retryTask)
         {
-            _instance->getTimer()->cancel(_retryTask);
+            _instance->cancelTimerTask(_retryTask);
             _retryTask = nullptr;
         }
         _retryCount = 0;
@@ -686,7 +686,7 @@ SessionI::retry(NodePrx node, exception_ptr exception)
         }
 
         _retryTask = make_shared<IceInternal::InlineTimerTask>([self = shared_from_this()] { self->remove(); });
-        _instance->getTimer()->schedule(_retryTask, delay);
+        _instance->scheduleTimerTask(_retryTask, delay);
     }
     else
     {
@@ -730,7 +730,7 @@ SessionI::retry(NodePrx node, exception_ptr exception)
 
         _retryTask =
             make_shared<IceInternal::InlineTimerTask>([node, self = shared_from_this()] { self->reconnect(node); });
-        _instance->getTimer()->schedule(_retryTask, delay);
+        _instance->scheduleTimerTask(_retryTask, delay);
     }
     return true;
 }


### PR DESCRIPTION
Fix #2938

I added a few helper functions in DataStorm instance to avoid using a destroyed timer. The helpers methods ignore schedule calls if the timer is already destroyed, which is what we did with the original DataStorm timer.