### PR TITLE
Add new node.ice.soversion reserved variable in IceGrid

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,7 @@
         "Browsable",
         "istr",
         "ostr",
+        "soversion",
         "unregisters",
         "Upcall"
     ],

--- a/cpp/config/templates.xml
+++ b/cpp/config/templates.xml
@@ -27,7 +27,7 @@
       <parameter name="publish-endpoints" default="default"/>
       <parameter name="flush-timeout" default="1000"/>
 
-      <service name="${instance-name}" entry="IceStormService,38a0:createIceStorm">
+      <service name="${instance-name}" entry="IceStormService,${node.ice.soversion}:createIceStorm">
 
         <adapter name="IceStorm.TopicManager"
                  id="${instance-name}.TopicManager"
@@ -74,7 +74,7 @@
       <parameter name="publish-replica-group"/>
       <parameter name="topic-manager-replica-group"/>
 
-      <service name="${instance-name}${node-id}" entry="IceStormService,38a0:createIceStorm">
+      <service name="${instance-name}${node-id}" entry="IceStormService,${node.ice.soversion}:createIceStorm">
 
         <adapter name="IceStorm.TopicManager"
                  id="${instance-name}${node-id}.TopicManager"

--- a/cpp/src/IceGrid/DescriptorHelper.cpp
+++ b/cpp/src/IceGrid/DescriptorHelper.cpp
@@ -493,6 +493,11 @@ Resolver::Resolver(const shared_ptr<InternalNodeInfo>& info, const shared_ptr<Ic
     {
         setReserved("node.ice.soversion", *info->iceSoVersion);
     }
+    else
+    {
+        // Since the node didn't supply this info, we're guessing it's a 3.7 node, but we don't know for sure.
+        setReserved("node.ice.soversion", "37");
+    }
 }
 
 string
@@ -975,7 +980,7 @@ Resolver::getReserved()
     reserved["node.machine"] = "";
     reserved["node.datadir"] = "";
     reserved["node.data"] = "";
-    reserved["node.ice.soversion"] = ICE_SO_VERSION; // defaults to the Ice version in the IceGrid registry.
+    reserved["node.ice.soversion"] = "";
     reserved["session.id"] = "";
     reserved["server"] = "";
     reserved["server.data"] = "${node.data}/servers/${server}/data";

--- a/cpp/src/IceGrid/DescriptorHelper.cpp
+++ b/cpp/src/IceGrid/DescriptorHelper.cpp
@@ -365,6 +365,7 @@ Resolver::Resolver(
     _ignore.insert("node.machine");
     _ignore.insert("node.datadir");
     _ignore.insert("node.data");
+    _ignore.insert("node.ice.soversion");
 
     //
     // Deprecated variables
@@ -488,6 +489,10 @@ Resolver::Resolver(const shared_ptr<InternalNodeInfo>& info, const shared_ptr<Ic
     setReserved("node.machine", info->machine);
     setReserved("node.datadir", info->dataDir);
     setReserved("node.data", info->dataDir);
+    if (info->iceSoVersion)
+    {
+        setReserved("node.ice.soversion", *info->iceSoVersion);
+    }
 }
 
 string
@@ -958,11 +963,8 @@ Resolver::getProperties(const Ice::StringSeq& references, set<string>& resolved)
 map<string, string>
 Resolver::getReserved()
 {
-    //
-    // Allowed reserved variables (reserved variables can't be
-    // overrided, in this implementation an empty reserved variable is
-    // considered to be undefined (see getVariable))
-    //
+    // Allowed reserved variables (reserved variables can't be overridden, in this implementation an empty reserved
+    // variable is considered to be undefined (see getVariable))
     map<string, string> reserved;
     reserved["application"] = "";
     reserved["node"] = "";
@@ -973,6 +975,7 @@ Resolver::getReserved()
     reserved["node.machine"] = "";
     reserved["node.datadir"] = "";
     reserved["node.data"] = "";
+    reserved["node.ice.soversion"] = ICE_SO_VERSION; // defaults to the Ice version in the IceGrid registry.
     reserved["session.id"] = "";
     reserved["server"] = "";
     reserved["server.data"] = "${node.data}/servers/${server}/data";

--- a/cpp/src/IceGrid/Internal.ice
+++ b/cpp/src/IceGrid/Internal.ice
@@ -374,8 +374,8 @@ class InternalNodeInfo
     /// The path to the node data directory.
     string dataDir;
 
-    /// The Ice SO version, for example 38. It can be used to specify the version of an Ice plugin or of
-    /// the IceStorm service.
+    /// The Ice SO version of this node, for example 38. It is typically used to load the same version of the IceStorm
+    /// service in IceBox.
     optional(1) string iceSoVersion;
 }
 

--- a/cpp/src/IceGrid/Internal.ice
+++ b/cpp/src/IceGrid/Internal.ice
@@ -373,6 +373,10 @@ class InternalNodeInfo
 
     /// The path to the node data directory.
     string dataDir;
+
+    /// The Ice SO version, for example 38. It can be used to specify the version of an Ice plugin or of
+    /// the IceStorm service.
+    optional(1) string iceSoVersion;
 }
 
 /// Information about an IceGrid registry replica.

--- a/cpp/src/IceGrid/PlatformInfo.cpp
+++ b/cpp/src/IceGrid/PlatformInfo.cpp
@@ -135,7 +135,6 @@ namespace IceGrid
         info.machine = node->machine;
         info.nProcessors = node->nProcessors;
         info.dataDir = node->dataDir;
-        info.iceSoVersion = node->iceSoVersion.value_or("");
         return info;
     }
 }

--- a/cpp/src/IceGrid/PlatformInfo.cpp
+++ b/cpp/src/IceGrid/PlatformInfo.cpp
@@ -383,8 +383,16 @@ PlatformInfo::getRegistryInfo() const
 shared_ptr<InternalNodeInfo>
 PlatformInfo::getInternalNodeInfo() const
 {
-    return make_shared<
-        InternalNodeInfo>(_name, _os, _hostname, _release, _version, _machine, _nProcessorThreads, _dataDir, ICE_SO_VERSION);
+    return make_shared<InternalNodeInfo>(
+        _name,
+        _os,
+        _hostname,
+        _release,
+        _version,
+        _machine,
+        _nProcessorThreads,
+        _dataDir,
+        ICE_SO_VERSION);
 }
 
 shared_ptr<InternalReplicaInfo>

--- a/cpp/src/IceGrid/PlatformInfo.cpp
+++ b/cpp/src/IceGrid/PlatformInfo.cpp
@@ -135,6 +135,7 @@ namespace IceGrid
         info.machine = node->machine;
         info.nProcessors = node->nProcessors;
         info.dataDir = node->dataDir;
+        info.iceSoVersion = node->iceSoVersion.value_or("");
         return info;
     }
 }
@@ -384,7 +385,7 @@ shared_ptr<InternalNodeInfo>
 PlatformInfo::getInternalNodeInfo() const
 {
     return make_shared<
-        InternalNodeInfo>(_name, _os, _hostname, _release, _version, _machine, _nProcessorThreads, _dataDir);
+        InternalNodeInfo>(_name, _os, _hostname, _release, _version, _machine, _nProcessorThreads, _dataDir, ICE_SO_VERSION);
 }
 
 shared_ptr<InternalReplicaInfo>

--- a/slice/IceGrid/Admin.ice
+++ b/slice/IceGrid/Admin.ice
@@ -130,9 +130,6 @@ module IceGrid
 
         /// The path to the node data directory.
         string dataDir;
-
-        /// The Ice SO version used by this node, for example "38". An empty string means this version is unknown.
-        string iceSoVersion;
     }
 
     /// Information about an IceGrid registry replica.

--- a/slice/IceGrid/Admin.ice
+++ b/slice/IceGrid/Admin.ice
@@ -130,6 +130,9 @@ module IceGrid
 
         /// The path to the node data directory.
         string dataDir;
+
+        /// The Ice SO version used by this node, for example "38". An empty string means this version is unknown.
+        string iceSoVersion;
     }
 
     /// Information about an IceGrid registry replica.


### PR DESCRIPTION
This variable represents the Ice SO version used by the IceGrid node.

Fixes #127.
