### PR TITLE
Rework IceGrid reaping of public sessions

### DIFF
--- a/config/PropertyNames.xml
+++ b/config/PropertyNames.xml
@@ -285,7 +285,6 @@
         <property name="Registry.Server" class="ObjectAdapter" languages="cpp" />
         <property name="Registry.SessionFilters" languages="cpp" default="0" />
         <property name="Registry.SessionManager" class="ObjectAdapter" languages="cpp" />
-        <property name="Registry.SessionTimeout" languages="cpp" default="30" />
         <property name="Registry.SSLPermissionsVerifier" class="Proxy" languages="cpp"/>
         <property name="Registry.Trace.Admin" languages="cpp" default="0" />
         <property name="Registry.Trace.Application" languages="cpp" default="0" />

--- a/cpp/src/Ice/PropertyNames.cpp
+++ b/cpp/src/Ice/PropertyNames.cpp
@@ -381,7 +381,6 @@ const Property IceGridPropsData[] =
     Property{"Registry.Server", "", false, false, &PropertyNames::ObjectAdapterProps},
     Property{"Registry.SessionFilters", "0", false, false, nullptr},
     Property{"Registry.SessionManager", "", false, false, &PropertyNames::ObjectAdapterProps},
-    Property{"Registry.SessionTimeout", "30", false, false, nullptr},
     Property{"Registry.SSLPermissionsVerifier", "", false, false, &PropertyNames::ProxyProps},
     Property{"Registry.Trace.Admin", "0", false, false, nullptr},
     Property{"Registry.Trace.Application", "0", false, false, nullptr},
@@ -405,7 +404,7 @@ const PropertyArray PropertyNames::IceGridProps
     "IceGrid",
     false,
     IceGridPropsData,
-    63
+    62
 };
 
 const Property IceSSLPropsData[] =

--- a/cpp/src/IceGrid/AdminSessionI.cpp
+++ b/cpp/src/IceGrid/AdminSessionI.cpp
@@ -447,7 +447,6 @@ AdminSessionFactory::AdminSessionFactory(
     const shared_ptr<RegistryI>& registry)
     : _servantManager(servantManager),
       _database(database),
-      _timeout(registry->getSessionTimeout(Ice::emptyCurrent)),
       _reaper(reaper),
       _registry(registry),
       _filters(false)
@@ -489,6 +488,7 @@ AdminSessionFactory::createGlacier2Session(const string& sessionId, const option
         }
     }
 
+    // TODO: how does this work? Who calls keepAlive on the AdminSession object?
     _reaper->add(make_shared<SessionReapable<AdminSessionI>>(_database->getTraceLevels()->logger, session), timeout);
     return Ice::uncheckedCast<Glacier2::SessionPrx>(proxy);
 }

--- a/cpp/src/IceGrid/AdminSessionI.h
+++ b/cpp/src/IceGrid/AdminSessionI.h
@@ -95,7 +95,6 @@ namespace IceGrid
     private:
         const std::shared_ptr<SessionServantManager> _servantManager;
         const std::shared_ptr<Database> _database;
-        const std::chrono::seconds _timeout;
         const std::shared_ptr<ReapThread> _reaper;
         const std::shared_ptr<RegistryI> _registry;
         const bool _filters;

--- a/cpp/src/IceGrid/AdminSessionI.h
+++ b/cpp/src/IceGrid/AdminSessionI.h
@@ -15,17 +15,17 @@ namespace IceGrid
     class RegistryI;
     class FileIteratorI;
 
-    class AdminSessionI : public BaseSessionI, public AdminSession
+    class AdminSessionI final : public BaseSessionI, public AdminSession
     {
     public:
         AdminSessionI(const std::string&, const std::shared_ptr<Database>&, const std::shared_ptr<RegistryI>&);
 
         Ice::ObjectPrx _register(const std::shared_ptr<SessionServantManager>&, const Ice::ConnectionPtr&);
 
-        void keepAlive(const Ice::Current& current) override { BaseSessionI::keepAlive(current); }
+        void keepAlive(const Ice::Current&) final {} // no-op
 
-        std::optional<AdminPrx> getAdmin(const Ice::Current&) const override;
-        std::optional<Ice::ObjectPrx> getAdminCallbackTemplate(const Ice::Current&) const override;
+        std::optional<AdminPrx> getAdmin(const Ice::Current&) const final;
+        std::optional<Ice::ObjectPrx> getAdminCallbackTemplate(const Ice::Current&) const final;
 
         void setObservers(
             std::optional<RegistryObserverPrx>,
@@ -33,7 +33,7 @@ namespace IceGrid
             std::optional<ApplicationObserverPrx>,
             std::optional<AdapterObserverPrx>,
             std::optional<ObjectObserverPrx>,
-            const Ice::Current&) override;
+            const Ice::Current&) final;
 
         void setObserversByIdentity(
             Ice::Identity,
@@ -41,24 +41,24 @@ namespace IceGrid
             Ice::Identity,
             Ice::Identity,
             Ice::Identity,
-            const Ice::Current&) override;
+            const Ice::Current&) final;
 
-        int startUpdate(const Ice::Current&) override;
-        void finishUpdate(const Ice::Current&) override;
+        int startUpdate(const Ice::Current&) final;
+        void finishUpdate(const Ice::Current&) final;
 
-        std::string getReplicaName(const Ice::Current&) const override;
+        std::string getReplicaName(const Ice::Current&) const final;
 
-        std::optional<FileIteratorPrx> openServerLog(std::string, std::string, int, const Ice::Current&) override;
-        std::optional<FileIteratorPrx> openServerStdOut(std::string, int, const Ice::Current&) override;
-        std::optional<FileIteratorPrx> openServerStdErr(std::string, int, const Ice::Current&) override;
+        std::optional<FileIteratorPrx> openServerLog(std::string, std::string, int, const Ice::Current&) final;
+        std::optional<FileIteratorPrx> openServerStdOut(std::string, int, const Ice::Current&) final;
+        std::optional<FileIteratorPrx> openServerStdErr(std::string, int, const Ice::Current&) final;
 
-        std::optional<FileIteratorPrx> openNodeStdOut(std::string, int, const Ice::Current&) override;
-        std::optional<FileIteratorPrx> openNodeStdErr(std::string, int, const Ice::Current&) override;
+        std::optional<FileIteratorPrx> openNodeStdOut(std::string, int, const Ice::Current&) final;
+        std::optional<FileIteratorPrx> openNodeStdErr(std::string, int, const Ice::Current&) final;
 
-        std::optional<FileIteratorPrx> openRegistryStdOut(std::string, int, const Ice::Current&) override;
-        std::optional<FileIteratorPrx> openRegistryStdErr(std::string, int, const Ice::Current&) override;
+        std::optional<FileIteratorPrx> openRegistryStdOut(std::string, int, const Ice::Current&) final;
+        std::optional<FileIteratorPrx> openRegistryStdErr(std::string, int, const Ice::Current&) final;
 
-        void destroy(const Ice::Current&) override;
+        void destroy(const Ice::Current&) final;
 
         void removeFileIterator(const Ice::Identity&, const Ice::Current&);
 
@@ -68,7 +68,7 @@ namespace IceGrid
         Ice::ObjectPrx addForwarder(Ice::ObjectPrx);
         FileIteratorPrx addFileIterator(FileReaderPrx, const std::string&, int, const Ice::Current&);
 
-        void destroyImpl(bool) override;
+        void destroyImpl(bool) final;
 
         const std::string _replicaName;
         std::optional<AdminPrx> _admin;

--- a/cpp/src/IceGrid/ReapThread.cpp
+++ b/cpp/src/IceGrid/ReapThread.cpp
@@ -52,13 +52,9 @@ ReapThread::run()
             {
                 try
                 {
-                    if (p->timeout == 0s)
-                    {
-                        p->item->timestamp(); // This should throw if the reapable is destroyed.
-                        ++p;
-                        continue;
-                    }
-                    else if ((chrono::steady_clock::now() - p->item->timestamp()) > p->timeout)
+                    auto timestamp = p->item->timestamp(); // throws ONE if the reapable is destroyed.
+
+                    if (p->timeout > 0s && (chrono::steady_clock::now() - timestamp > p->timeout))
                     {
                         reap.push_back(*p);
                         // and go to the code after the catch block
@@ -71,6 +67,7 @@ ReapThread::run()
                 }
                 catch (const Ice::ObjectNotExistException&)
                 {
+                    // already destroyed
                 }
 
                 // Remove the reapable

--- a/cpp/src/IceGrid/ReapThread.h
+++ b/cpp/src/IceGrid/ReapThread.h
@@ -17,15 +17,13 @@ namespace IceGrid
     public:
         virtual ~Reapable() = default;
 
-        virtual void heartbeat() const {}; // TODO: remove
-
         virtual std::chrono::steady_clock::time_point timestamp() const = 0;
         virtual void destroy(bool) = 0;
     };
 
     // We use this template with various Session servants to convert destroy(bool) calls into shutdown() or destroy()
     // on the servant.
-    template<class T> class SessionReapable : public Reapable
+    template<class T> class SessionReapable final : public Reapable
     {
     public:
         SessionReapable(const Ice::LoggerPtr& logger, const std::shared_ptr<T>& session)
@@ -34,9 +32,9 @@ namespace IceGrid
         {
         }
 
-        std::chrono::steady_clock::time_point timestamp() const override { return _session->timestamp(); }
+        std::chrono::steady_clock::time_point timestamp() const final { return _session->timestamp(); }
 
-        void destroy(bool shutdown) override
+        void destroy(bool shutdown) final
         {
             try
             {
@@ -59,7 +57,7 @@ namespace IceGrid
             }
         }
 
-    protected:
+    private:
         const Ice::LoggerPtr _logger;
         const std::shared_ptr<T> _session;
     };

--- a/cpp/src/IceGrid/RegistryI.cpp
+++ b/cpp/src/IceGrid/RegistryI.cpp
@@ -1071,8 +1071,12 @@ RegistryI::getSessionTimeout(const Ice::Current&) const
     PropertiesPtr properties = _communicator->getProperties();
 
     int serverIdleTimeout = properties->getIcePropertyAsInt("Ice.Connection.Server.IdleTimeout");
-    int adminSessionTimeout = properties->getPropertyAsIntWithDefault("IceGrid.Registry.AdminSessionManager.Connection.IdleTimeout", serverIdleTimeout);
-    int sessionTimeout = properties->getPropertyAsIntWithDefault("IceGrid.Registry.SessionManager.Connection.IdleTimeout", serverIdleTimeout);
+    int adminSessionTimeout = properties->getPropertyAsIntWithDefault(
+        "IceGrid.Registry.AdminSessionManager.Connection.IdleTimeout",
+        serverIdleTimeout);
+    int sessionTimeout = properties->getPropertyAsIntWithDefault(
+        "IceGrid.Registry.SessionManager.Connection.IdleTimeout",
+        serverIdleTimeout);
 
     // Users should not fine-tune the idle timeout so both timeouts are usually identical. In case they are different,
     // we return the min to the caller (an old Ice client, with Ice version <= 3.7). The caller may then send keep alive

--- a/cpp/src/IceGrid/RegistryI.cpp
+++ b/cpp/src/IceGrid/RegistryI.cpp
@@ -250,8 +250,6 @@ RegistryI::startImpl()
     _replicaName = properties->getIceProperty("IceGrid.Registry.ReplicaName");
     _master = _replicaName == "Master";
 
-    _sessionTimeout = chrono::seconds(properties->getIcePropertyAsInt("IceGrid.Registry.SessionTimeout"));
-
     if (!_initFromReplica.empty() && (_initFromReplica == _replicaName || (_master && _initFromReplica == "Master")))
     {
         Error out(_communicator->getLogger());
@@ -918,10 +916,7 @@ RegistryI::createSession(string user, string password, const Current& current)
 
     auto session = _clientSessionFactory->createSessionServant(user);
     auto proxy = session->_register(_servantManager, current.con);
-    _reaper->add(
-        make_shared<SessionReapableWithHeartbeat<SessionI>>(_traceLevels->logger, session),
-        _sessionTimeout,
-        current.con);
+    _reaper->add(make_shared<SessionReapable<SessionI>>(_traceLevels->logger, session), 0s, current.con);
     return uncheckedCast<SessionPrx>(proxy);
 }
 
@@ -967,10 +962,7 @@ RegistryI::createAdminSession(string user, string password, const Current& curre
 
     auto session = _adminSessionFactory->createSessionServant(user);
     auto proxy = session->_register(_servantManager, current.con);
-    _reaper->add(
-        make_shared<SessionReapableWithHeartbeat<AdminSessionI>>(_traceLevels->logger, session),
-        _sessionTimeout,
-        current.con);
+    _reaper->add(make_shared<SessionReapable<AdminSessionI>>(_traceLevels->logger, session), 0s, current.con);
     return uncheckedCast<AdminSessionPrx>(proxy);
 }
 
@@ -1023,10 +1015,7 @@ RegistryI::createSessionFromSecureConnection(const Current& current)
 
     auto session = _clientSessionFactory->createSessionServant(userDN);
     auto proxy = session->_register(_servantManager, current.con);
-    _reaper->add(
-        make_shared<SessionReapableWithHeartbeat<SessionI>>(_traceLevels->logger, session),
-        _sessionTimeout,
-        current.con);
+    _reaper->add(make_shared<SessionReapable<SessionI>>(_traceLevels->logger, session), 0s, current.con);
     return uncheckedCast<SessionPrx>(proxy);
 }
 
@@ -1072,17 +1061,23 @@ RegistryI::createAdminSessionFromSecureConnection(const Current& current)
     //
     auto session = _adminSessionFactory->createSessionServant(userDN);
     auto proxy = session->_register(_servantManager, current.con);
-    _reaper->add(
-        make_shared<SessionReapableWithHeartbeat<AdminSessionI>>(_traceLevels->logger, session),
-        _sessionTimeout,
-        current.con);
+    _reaper->add(make_shared<SessionReapable<AdminSessionI>>(_traceLevels->logger, session), 0s, current.con);
     return uncheckedCast<AdminSessionPrx>(proxy);
 }
 
 int
 RegistryI::getSessionTimeout(const Ice::Current&) const
 {
-    return secondsToInt(_sessionTimeout);
+    PropertiesPtr properties = _communicator->getProperties();
+
+    int serverIdleTimeout = properties->getIcePropertyAsInt("Ice.Connection.Server.IdleTimeout");
+    int adminSessionTimeout = properties->getPropertyAsIntWithDefault("IceGrid.Registry.AdminSessionManager.Connection.IdleTimeout", serverIdleTimeout);
+    int sessionTimeout = properties->getPropertyAsIntWithDefault("IceGrid.Registry.SessionManager.Connection.IdleTimeout", serverIdleTimeout);
+
+    // Users should not fine-tune the idle timeout so both timeouts are usually identical. In case they are different,
+    // we return the min to the caller (an old Ice client, with Ice version <= 3.7). The caller may then send keep alive
+    // more often than necessary (very minor).
+    return min(adminSessionTimeout, sessionTimeout);
 }
 
 string

--- a/cpp/src/IceGrid/RegistryI.h
+++ b/cpp/src/IceGrid/RegistryI.h
@@ -105,7 +105,6 @@ namespace IceGrid
         std::shared_ptr<ReapThread> _reaper;
         IceInternal::TimerPtr _timer;
         std::shared_ptr<SessionServantManager> _servantManager;
-        std::chrono::seconds _sessionTimeout;
         std::unique_ptr<ReplicaSessionManager> _session;
         mutable PlatformInfo _platform;
 

--- a/cpp/src/IceGrid/SessionI.cpp
+++ b/cpp/src/IceGrid/SessionI.cpp
@@ -53,31 +53,12 @@ BaseSessionI::BaseSessionI(const string& id, const string& prefix, const shared_
       _prefix(prefix),
       _traceLevels(database->getTraceLevels()),
       _database(database),
-      _destroyed(false),
-      _timestamp(chrono::steady_clock::now())
+      _destroyed(false)
 {
     if (_traceLevels && _traceLevels->session > 0)
     {
         Ice::Trace out(_traceLevels->logger, _traceLevels->sessionCat);
         out << _prefix << " session `" << _id << "' created";
-    }
-}
-
-void
-BaseSessionI::keepAlive(const Ice::Current&)
-{
-    lock_guard lock(_mutex);
-    if (_destroyed)
-    {
-        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
-    }
-
-    _timestamp = chrono::steady_clock::now();
-
-    if (_traceLevels->session > 1)
-    {
-        Ice::Trace out(_traceLevels->logger, _traceLevels->sessionCat);
-        out << _prefix << " session '" << _id << "' keep alive";
     }
 }
 
@@ -104,9 +85,10 @@ BaseSessionI::timestamp() const
     lock_guard lock(_mutex);
     if (_destroyed)
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+        // Just a "marker" exception here.
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
-    return _timestamp;
+    return std::chrono::steady_clock::time_point::min(); // not used
 }
 
 void
@@ -302,7 +284,6 @@ ClientSessionFactory::createGlacier2Session(const string& sessionId, const optio
     auto session = createSessionServant(sessionId);
     auto proxy = session->_register(_servantManager, nullptr);
 
-    chrono::seconds timeout = 0s;
     if (ctl)
     {
         try
@@ -312,7 +293,6 @@ ClientSessionFactory::createGlacier2Session(const string& sessionId, const optio
                 Ice::Identity queryId = {"Query", _database->getInstanceName()};
                 _servantManager->setSessionControl(session, *ctl, {std::move(queryId)});
             }
-            timeout = chrono::seconds(ctl->getSessionTimeout());
         }
         catch (const Ice::LocalException& e)
         {
@@ -325,8 +305,10 @@ ClientSessionFactory::createGlacier2Session(const string& sessionId, const optio
         }
     }
 
-    // TODO: how does this work? Who calls keepAlive on the Session object?
-    _reaper->add(make_shared<SessionReapable<SessionI>>(_database->getTraceLevels()->logger, session), timeout);
+    // We can't use a non-0 timeout such as the Glacier2 session timeout. As of Ice 3.8, heartbeats may not be sent
+    // at all on a busy connection. Furthermore, as of Ice 3.8, Glacier2 no longer "converts" heartbeats into
+    // keepAlive requests.
+    _reaper->add(make_shared<SessionReapable<SessionI>>(_database->getTraceLevels()->logger, session), 0s);
     return Ice::uncheckedCast<Glacier2::SessionPrx>(proxy);
 }
 

--- a/cpp/src/IceGrid/SessionI.cpp
+++ b/cpp/src/IceGrid/SessionI.cpp
@@ -300,7 +300,7 @@ ClientSessionFactory::createGlacier2Session(const string& sessionId, const optio
     assert(_servantManager);
 
     auto session = createSessionServant(sessionId);
-    auto proxy = session->_register(_servantManager, 0);
+    auto proxy = session->_register(_servantManager, nullptr);
 
     chrono::seconds timeout = 0s;
     if (ctl)
@@ -325,6 +325,7 @@ ClientSessionFactory::createGlacier2Session(const string& sessionId, const optio
         }
     }
 
+    // TODO: how does this work? Who calls keepAlive on the Session object?
     _reaper->add(make_shared<SessionReapable<SessionI>>(_database->getTraceLevels()->logger, session), timeout);
     return Ice::uncheckedCast<Glacier2::SessionPrx>(proxy);
 }

--- a/cpp/src/IceGrid/SessionI.h
+++ b/cpp/src/IceGrid/SessionI.h
@@ -24,9 +24,9 @@ namespace IceGrid
     public:
         virtual ~BaseSessionI() = default;
 
-        virtual void keepAlive(const Ice::Current&);
-
+        // Return value is never used. Just throws ONE when the session is destroyed.
         std::chrono::steady_clock::time_point timestamp() const;
+
         void shutdown();
         std::optional<Glacier2::IdentitySetPrx> getGlacier2IdentitySet();
         std::optional<Glacier2::StringSetPrx> getGlacier2AdapterIdSet();
@@ -43,7 +43,6 @@ namespace IceGrid
         const std::shared_ptr<Database> _database;
         std::shared_ptr<SessionServantManager> _servantManager;
         bool _destroyed;
-        std::chrono::steady_clock::time_point _timestamp;
 
         mutable std::mutex _mutex;
     };
@@ -59,7 +58,7 @@ namespace IceGrid
 
         Ice::ObjectPrx _register(const std::shared_ptr<SessionServantManager>&, const Ice::ConnectionPtr&);
 
-        void keepAlive(const Ice::Current& current) final { BaseSessionI::keepAlive(current); }
+        void keepAlive(const Ice::Current&) final {} // no-op
         void allocateObjectByIdAsync(
             Ice::Identity id,
             std::function<void(const std::optional<Ice::ObjectPrx>& returnValue)> response,
@@ -121,7 +120,7 @@ namespace IceGrid
         ClientSessionManagerI(const std::shared_ptr<ClientSessionFactory>&);
 
         std::optional<Glacier2::SessionPrx>
-        create(std::string, std::optional<Glacier2::SessionControlPrx>, const Ice::Current&) override;
+        create(std::string, std::optional<Glacier2::SessionControlPrx>, const Ice::Current&) final;
 
     private:
         const std::shared_ptr<ClientSessionFactory> _factory;
@@ -133,7 +132,7 @@ namespace IceGrid
         ClientSSLSessionManagerI(const std::shared_ptr<ClientSessionFactory>&);
 
         std::optional<Glacier2::SessionPrx>
-        create(Glacier2::SSLInfo, std::optional<Glacier2::SessionControlPrx>, const Ice::Current&) override;
+        create(Glacier2::SSLInfo, std::optional<Glacier2::SessionControlPrx>, const Ice::Current&) final;
 
     private:
         const std::shared_ptr<ClientSessionFactory> _factory;

--- a/cpp/test/IceGrid/allocation/AllTests.cpp
+++ b/cpp/test/IceGrid/allocation/AllTests.cpp
@@ -126,7 +126,7 @@ public:
             }
 
             assert(session);
-            session->keepAlive();
+            session->ice_ping();
 
             optional<ObjectPrx> object;
             switch (_rd() % (_destroySession ? 4 : 2))

--- a/cpp/test/IceGrid/replication/application.xml
+++ b/cpp/test/IceGrid/replication/application.xml
@@ -45,7 +45,6 @@
         <property name="IceGrid.Registry.PermissionsVerifier" value="RepTestIceGrid/NullPermissionsVerifier"/>
         <property name="IceGrid.Registry.SSLPermissionsVerifier" value="RepTestIceGrid/NullSSLPermissionsVerifier"/>
         <property name="IceGrid.Registry.AdminPermissionsVerifier" value="RepTestIceGrid/NullPermissionsVerifier"/>
-        <property name="IceGrid.Registry.SessionTimeout" value="0"/>
         <property name="IceGrid.Registry.DynamicRegistration" value="1"/>
         <property name="Ice.Default.Locator" value="RepTestIceGrid/Locator:default -p 12050:default -p 12051:default -p 12052"/>
         <property name="IceGrid.Registry.Trace.Replica" value="1"/>

--- a/scripts/IceGridUtil.py
+++ b/scripts/IceGridUtil.py
@@ -202,7 +202,6 @@ class IceGridRegistry(ProcessFromBinDir, Server):
             "IceGrid.Registry.Discovery.Port": current.driver.getTestPort(99),
             "IceGrid.Registry.SessionManager.Endpoints": "default",
             "IceGrid.Registry.AdminSessionManager.Endpoints": "default",
-            "IceGrid.Registry.SessionTimeout": 60,
             "IceGrid.Registry.ReplicaName": self.name,
             "Ice.ProgramName": self.name,
             "Ice.PrintAdapterReady": 1,

--- a/slice/IceGrid/Admin.ice
+++ b/slice/IceGrid/Admin.ice
@@ -752,9 +752,9 @@ module IceGrid
     /// @see Registry
     interface AdminSession extends Glacier2::Session
     {
-        /// Keep the session alive. Clients should call this operation regularly to prevent the server from reaping the
-        /// session.
-        /// @see Registry#getSessionTimeout
+        /// Keep the session alive.
+        /// As of Ice 3.8, there is no need to call this operation, and its implementation does nothing.
+        ["deprecated"]
         idempotent void keepAlive();
 
         /// Get the admin interface. The admin object returned by this operation can only be accessed by the session.

--- a/slice/IceGrid/Registry.ice
+++ b/slice/IceGrid/Registry.ice
@@ -109,10 +109,9 @@ module IceGrid
         AdminSession* createAdminSessionFromSecureConnection()
             throws PermissionDeniedException;
 
-        /// Returns the session timeout.
-        /// The IceGrid registry closes a session (or admin session) unless it receives a keepAlive request for this
-        /// session within this timeout. As of Ice 3.7, heartbeats that the Ice runtime sends automatically to keep the
-        /// connection alive are treated as keepAlive requests.
+        /// Gets the session timeout. An Ice 3.7 or earlier client can use this value to determine how often it needs to
+        /// send heartbeats (using ACM) or call {@link Session#keepAlive} (resp. {@link AdminSession#keepAlive}) to keep
+        /// a session alive in the IceGrid registry.
         /// @return The session timeout (in seconds).
         ["cpp:const", "deprecated"] idempotent int getSessionTimeout();
     }

--- a/slice/IceGrid/Registry.ice
+++ b/slice/IceGrid/Registry.ice
@@ -109,9 +109,12 @@ module IceGrid
         AdminSession* createAdminSessionFromSecureConnection()
             throws PermissionDeniedException;
 
-        /// TODO: update description or remove operation
+        /// Returns the session timeout.
+        /// The IceGrid registry closes a session (or admin session) unless it receives a keepAlive request for this
+        /// session within this timeout. As of Ice 3.7, heartbeats that the Ice runtime sends automatically to keep the
+        /// connection alive are treated as keepAlive requests.
         /// @return The session timeout (in seconds).
-        ["cpp:const"] idempotent int getSessionTimeout();
+        ["cpp:const", "deprecated"] idempotent int getSessionTimeout();
     }
 
     /// The IceGrid locator interface provides access to the {@link Query} and {@link Registry} object of the IceGrid

--- a/slice/IceGrid/Session.ice
+++ b/slice/IceGrid/Session.ice
@@ -25,9 +25,9 @@ module IceGrid
     /// @see Registry
     interface Session extends Glacier2::Session
     {
-        /// Keep the session alive. Clients should call this operation regularly to prevent the server from reaping the
-        /// session.
-        /// @see Registry#getSessionTimeout
+        /// Keep the session alive.
+        /// As of Ice 3.8, there is no need to call this operation, and its implementation does nothing.
+        ["deprecated"]
         idempotent void keepAlive();
 
         /// Allocate an object. Depending on the allocation timeout, this operation might hang until the object is


### PR DESCRIPTION
This PR reworks the reaping of public sessions (IceGrid::Session, IceGrid::AdminSession) by the IceGrid registry.

The idea is to:
a) keep the ReapThread mechanism to reap all sessions (public and internal), just like in Ice 3.7 (reap = server-side monitoring / disposal)
b) for public sessions: their lifetime is bound to the connection (since at least Ice 3.7), and the client doesn't use a "keep alive thread" (since at least Ice 3.7), we "add" to the ReapThread with a 0s timeout to disable "keepAlive" monitoring.
c) for internal sessions (node and replica sessions) that still use a "keep alive thread", we add to the reap thread with a > 0s timeout (like in Ice 3.7)

This PR focuses on (b). (c) is for a follow-up PR.