### PR TITLE
Turn off inactivity timeout for connections with connection-bound sessions

### DIFF
--- a/cpp/src/Glacier2/Glacier2Router.cpp
+++ b/cpp/src/Glacier2/Glacier2Router.cpp
@@ -137,7 +137,7 @@ RouterService::start(int argc, char* argv[], int& status)
     const string clientEndpointsProperty = "Glacier2.Client.Endpoints";
     if (properties->getIceProperty(clientEndpointsProperty).empty())
     {
-        error("property `" + clientEndpointsProperty + "' is not set");
+        error("property '" + clientEndpointsProperty + "' is not set");
         return false;
     }
 
@@ -428,6 +428,13 @@ RouterService::initializeCommunicator(
     if (initData.properties->getProperty("Glacier2.Client.Connection.InactivityTimeout").empty())
     {
         initData.properties->setProperty("Glacier2.Client.Connection.InactivityTimeout", "0");
+    }
+
+    // Turn-off the inactivity timeout for outgoing connections unless the application sets this property.
+    // This is necessary for connections to session managers, like the session managers hosted by the IceGrid registry.
+    if (initData.properties->getProperty("Ice.Connection.Client.InactivityTimeout").empty())
+    {
+        initData.properties->setProperty("Ice.Connection.Client.InactivityTimeout", "0");
     }
 
     //

--- a/cpp/src/Glacier2/Glacier2Router.cpp
+++ b/cpp/src/Glacier2/Glacier2Router.cpp
@@ -430,13 +430,6 @@ RouterService::initializeCommunicator(
         initData.properties->setProperty("Glacier2.Client.Connection.InactivityTimeout", "0");
     }
 
-    // Turn-off the inactivity timeout for outgoing connections unless the application sets this property.
-    // This is necessary for connections to session managers, like the session managers hosted by the IceGrid registry.
-    if (initData.properties->getProperty("Ice.Connection.Client.InactivityTimeout").empty())
-    {
-        initData.properties->setProperty("Ice.Connection.Client.InactivityTimeout", "0");
-    }
-
     //
     // If Glacier2.PermissionsVerifier is not set and Glacier2.CryptPasswords is set,
     // load the Glacier2CryptPermissionsVerifier plug-in

--- a/cpp/src/IceGrid/Client.cpp
+++ b/cpp/src/IceGrid/Client.cpp
@@ -81,6 +81,10 @@ main(int argc, char* argv[])
         Ice::CtrlCHandler ctrlCHandler;
         auto defaultProps = Ice::createProperties();
         defaultProps->setProperty("IceGridAdmin.Server.Endpoints", "tcp -h localhost");
+
+        // Turn-off inactivity timeout for outgoing connections.
+        defaultProps->setProperty("Ice.Connection.Client.InactivityTimeout", "0");
+
         Ice::InitializationData id;
         id.properties = createProperties(args, defaultProps);
         id.properties->setProperty("Ice.Warn.Endpoints", "0");

--- a/cpp/src/IceGrid/IceGridRegistry.cpp
+++ b/cpp/src/IceGrid/IceGridRegistry.cpp
@@ -182,11 +182,19 @@ RegistryService::initializeCommunicator(
     initData.properties->setProperty("Ice.Admin.Endpoints", "");
 
     //
-    // Enable Admin unless explicitely disabled (or enabled) in configuration
+    // Enable Admin unless explicitly disabled (or enabled) in configuration
     //
     if (initData.properties->getProperty("Ice.Admin.Enabled").empty())
     {
         initData.properties->setProperty("Ice.Admin.Enabled", "1");
+    }
+
+    // Turn-off the inactivity timeout for the IceGrid.Registry.Client object adapter unless the application sets this
+    // property. That's because the IceGrid.Registry.Client object adapter hosts connection-bound sessions
+    // (admin sessions and resource allocation sessions).
+    if (initData.properties->getProperty("IceGrid.Registry.Client.Connection.InactivityTimeout").empty())
+    {
+        initData.properties->setProperty("IceGrid.Registry.Client.Connection.InactivityTimeout", "0");
     }
 
     //

--- a/cpp/src/IceGrid/RegistryI.cpp
+++ b/cpp/src/IceGrid/RegistryI.cpp
@@ -234,6 +234,11 @@ RegistryI::startImpl()
     properties->setProperty("IceGrid.Registry.Client.AdapterId", "");
     properties->setProperty("IceGrid.Registry.Server.AdapterId", "");
     properties->setProperty("IceGrid.Registry.SessionManager.AdapterId", "");
+
+    // Turn-off the inactivity timeout for incoming connections from Glacier2 router.
+    properties->setProperty("IceGrid.Registry.SessionManager.Connection.InactivityTimeout", "0");
+    properties->setProperty("IceGrid.Registry.AdminSessionManager.Connection.InactivityTimeout", "0");
+
     properties->setProperty("IceGrid.Registry.AdminSessionManager.AdapterId", "");
     properties->setProperty("IceGrid.Registry.Internal.AdapterId", "");
     if (properties->getProperty("IceGrid.Registry.Internal.MessageSizeMax").empty())

--- a/cpp/test/IceGrid/admin/test.py
+++ b/cpp/test/IceGrid/admin/test.py
@@ -172,6 +172,8 @@ def routerProps(process, current):
         "Glacier2.SessionManager": "TestIceGrid/AdminSessionManager",
         "Glacier2.PermissionsVerifier": "Glacier2/NullPermissionsVerifier",
         "Glacier2.SSLSessionManager": "TestIceGrid/AdminSSLSessionManager",
+        # we disable the inactivity timeout for outgoing connections when we use an IceGrid session manager
+        "Ice.Connection.Client.InactivityTimeout": "0",
         "Glacier2.SSLPermissionsVerifier": "Glacier2/NullSSLPermissionsVerifier",
         "Ice.Default.Locator": current.testcase.getLocator(current),
         "IceSSL.VerifyPeer": 1,

--- a/cpp/test/IceGrid/allocation/application.xml
+++ b/cpp/test/IceGrid/allocation/application.xml
@@ -13,6 +13,8 @@
         <property name="Glacier2.Server.Endpoints" value="tcp"/>
         <property name="Glacier2.SessionManager" value="${manager}"/>
         <property name="Glacier2.SSLSessionManager" value="TestIceGrid/SSLSessionManager"/>
+         <!-- we disable the inactivity timeout for outgoing connections when we use an IceGrid session manager -->
+        <property name="Ice.Connection.Client.InactivityTimeout" value="0"/>
         <property name="Glacier2.PermissionsVerifier" value="${verifier}"/>
         <property name="Glacier2.Client.Trace.Reject" value="0"/>
       </server>

--- a/cpp/test/IceGrid/session/application.xml
+++ b/cpp/test/IceGrid/session/application.xml
@@ -15,6 +15,8 @@
 
         <property name="Glacier2.SessionManager" value="${manager}"/>
         <property name="Glacier2.SSLSessionManager" value="${ssl-manager}"/>
+        <!-- we disable the inactivity timeout for outgoing connections when we use an IceGrid session manager -->
+        <property name="Ice.Connection.Client.InactivityTimeout" value="0"/>
         <property name="Glacier2.PermissionsVerifier" value="${verifier}"/>
         <property name="Glacier2.SSLPermissionsVerifier" value="SSLPermissionsVerifier"/>
         <property name="Glacier2.Client.Trace.Reject" value="0"/>

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Coordinator.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Coordinator.java
@@ -2257,10 +2257,11 @@ public class Coordinator {
             String[] args, java.util.List<String> rArgs) {
         com.zeroc.Ice.Properties properties = new com.zeroc.Ice.Properties();
 
-        //
         // Disable retries
-        //
         properties.setProperty("Ice.RetryIntervals", "-1");
+
+        // Turn-off inactivity timeout for outgoing connections
+        properties.setProperty("Ice.Connection.Client.InactivityTimeout", "0");
 
         return new com.zeroc.Ice.Properties(args, properties, rArgs);
     }


### PR DESCRIPTION
This PR turns off the inactivity timeout (always or by default) for a number of connections that can carry connection-bound sessions, namely:

- (Glacier2) outgoing connections (primary use case: IceGrid-hosted session managers and the sessions they create)
- (IceGrid registry) incoming connections to IceGrid.Registry.Client and the IceGrid session managers
- (IceGrid GUI, icegridadmin client) outgoing connections

The inactivity timeout was already turn off for incoming connections into Glacier2.Client.

