### PR TITLE
deprecated metadata and deprecated doc-comments

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -704,26 +704,13 @@ Slice::Contained::parseComment(bool stripMarkup) const
 CommentPtr
 Slice::Contained::parseComment(const string& text, bool stripMarkup) const
 {
-    CommentPtr comment = make_shared<Comment>();
-
-    comment->_isDeprecated = isDeprecated(false);
-
-    //
-    // First check metadata for a deprecated tag.
-    //
-    if (auto reason = getDeprecationReason(false))
-    {
-        comment->_deprecated.push_back(IceInternal::trim(*reason));
-    }
-
-    if (!comment->_isDeprecated && text.empty())
+    if (text.empty())
     {
         return nullptr;
     }
 
-    //
-    // Split up the comment into lines.
-    //
+    // Split up the comment text into lines.
+    CommentPtr comment = make_shared<Comment>();
     StringList lines = splitComment(text, stripMarkup);
 
     StringList::const_iterator i;

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -360,12 +360,14 @@ namespace
         return ostr.str();
     }
 
-    enum class GenerateDeprecated { Yes, No };
+    enum class GenerateDeprecated
+    {
+        Yes,
+        No
+    };
 
-    void writeDocSummary(
-        Output& out,
-        const ContainedPtr& p,
-        GenerateDeprecated generateDeprecated = GenerateDeprecated::Yes)
+    void
+    writeDocSummary(Output& out, const ContainedPtr& p, GenerateDeprecated generateDeprecated = GenerateDeprecated::Yes)
     {
         if (p->comment().empty())
         {
@@ -1703,7 +1705,16 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     {
         StringList postParams;
         postParams.push_back(contextDoc);
-        writeOpDocSummary(H, p, comment, OpDocAllParams, true, GenerateDeprecated::Yes, StringList(), postParams, comment->returns());
+        writeOpDocSummary(
+            H,
+            p,
+            comment,
+            OpDocAllParams,
+            true,
+            GenerateDeprecated::Yes,
+            StringList(),
+            postParams,
+            comment->returns());
     }
     H << nl << deprecatedSymbol << retS << ' ' << fixKwd(name) << spar << paramsDecl << contextDecl << epar
       << " const;";
@@ -1760,7 +1771,16 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
         StringList postParams, returns;
         postParams.push_back(contextDoc);
         returns.push_back(futureDoc);
-        writeOpDocSummary(H, p, comment, OpDocInParams, false, GenerateDeprecated::Yes, StringList(), postParams, returns);
+        writeOpDocSummary(
+            H,
+            p,
+            comment,
+            OpDocInParams,
+            false,
+            GenerateDeprecated::Yes,
+            StringList(),
+            postParams,
+            returns);
     }
 
     H << nl << deprecatedSymbol << "[[nodiscard]] ::std::future<" << futureT << "> " << name << "Async" << spar
@@ -1796,7 +1816,16 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
         postParams.push_back("@param " + sentParam + " The sent callback.");
         postParams.push_back(contextDoc);
         returns.push_back("A function that can be called to cancel the invocation locally.");
-        writeOpDocSummary(H, p, comment, OpDocInParams, false, GenerateDeprecated::Yes, StringList(), postParams, returns);
+        writeOpDocSummary(
+            H,
+            p,
+            comment,
+            OpDocInParams,
+            false,
+            GenerateDeprecated::Yes,
+            StringList(),
+            postParams,
+            returns);
     }
     H << nl;
     H << deprecatedSymbol;

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -360,7 +360,12 @@ namespace
         return ostr.str();
     }
 
-    void writeDocSummary(Output& out, const ContainedPtr& p)
+    enum class GenerateDeprecated { Yes, No };
+
+    void writeDocSummary(
+        Output& out,
+        const ContainedPtr& p,
+        GenerateDeprecated generateDeprecated = GenerateDeprecated::Yes)
     {
         if (p->comment().empty())
         {
@@ -386,16 +391,19 @@ namespace
             writeSeeAlso(out, doc->seeAlso());
         }
 
-        if (!doc->deprecated().empty())
+        if (generateDeprecated == GenerateDeprecated::Yes)
         {
-            out << nl << " *";
-            out << nl << " * @deprecated ";
-            writeDocLines(out, doc->deprecated(), false);
-        }
-        else if (doc->isDeprecated())
-        {
-            out << nl << " *";
-            out << nl << " * @deprecated";
+            if (!doc->deprecated().empty())
+            {
+                out << nl << " *";
+                out << nl << " * @deprecated ";
+                writeDocLines(out, doc->deprecated(), false);
+            }
+            else if (doc->isDeprecated())
+            {
+                out << nl << " *";
+                out << nl << " * @deprecated";
+            }
         }
 
         if (dynamic_pointer_cast<ClassDef>(p) || dynamic_pointer_cast<ClassDecl>(p) ||
@@ -489,6 +497,7 @@ namespace
         const CommentPtr& doc,
         OpDocParamType type,
         bool showExceptions,
+        GenerateDeprecated generateDeprecated = GenerateDeprecated::Yes,
         const StringList& preParams = StringList(),
         const StringList& postParams = StringList(),
         const StringList& returns = StringList())
@@ -526,18 +535,22 @@ namespace
             writeSeeAlso(out, seeAlso);
         }
 
-        const auto& deprecated = doc->deprecated();
-        if (!deprecated.empty())
+        if (generateDeprecated == GenerateDeprecated::Yes)
         {
-            out << nl << " *";
-            out << nl << " * @deprecated ";
-            writeDocLines(out, deprecated, false);
+            const auto& deprecated = doc->deprecated();
+            if (!deprecated.empty())
+            {
+                out << nl << " *";
+                out << nl << " * @deprecated ";
+                writeDocLines(out, deprecated, false);
+            }
+            else if (doc->isDeprecated())
+            {
+                out << nl << " *";
+                out << nl << " * @deprecated";
+            }
         }
-        else if (doc->isDeprecated())
-        {
-            out << nl << " *";
-            out << nl << " * @deprecated";
-        }
+        // we don't generate the @deprecated doc-comment for servants
 
         out << nl << " */";
     }
@@ -1690,7 +1703,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     {
         StringList postParams;
         postParams.push_back(contextDoc);
-        writeOpDocSummary(H, p, comment, OpDocAllParams, true, StringList(), postParams, comment->returns());
+        writeOpDocSummary(H, p, comment, OpDocAllParams, true, GenerateDeprecated::Yes, StringList(), postParams, comment->returns());
     }
     H << nl << deprecatedSymbol << retS << ' ' << fixKwd(name) << spar << paramsDecl << contextDecl << epar
       << " const;";
@@ -1747,7 +1760,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
         StringList postParams, returns;
         postParams.push_back(contextDoc);
         returns.push_back(futureDoc);
-        writeOpDocSummary(H, p, comment, OpDocInParams, false, StringList(), postParams, returns);
+        writeOpDocSummary(H, p, comment, OpDocInParams, false, GenerateDeprecated::Yes, StringList(), postParams, returns);
     }
 
     H << nl << deprecatedSymbol << "[[nodiscard]] ::std::future<" << futureT << "> " << name << "Async" << spar
@@ -1783,7 +1796,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
         postParams.push_back("@param " + sentParam + " The sent callback.");
         postParams.push_back(contextDoc);
         returns.push_back("A function that can be called to cancel the invocation locally.");
-        writeOpDocSummary(H, p, comment, OpDocInParams, false, StringList(), postParams, returns);
+        writeOpDocSummary(H, p, comment, OpDocInParams, false, GenerateDeprecated::Yes, StringList(), postParams, returns);
     }
     H << nl;
     H << deprecatedSymbol;
@@ -2695,7 +2708,7 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     InterfaceList bases = p->bases();
 
     H << sp;
-    writeDocSummary(H, p);
+    writeDocSummary(H, p, GenerateDeprecated::No);
     H << nl << "class " << _dllExport << name << " : ";
     H.useCurrentPosAsIndent();
     if (bases.empty())
@@ -3079,7 +3092,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
             returns = comment->returns();
         }
         postParams.push_back("@param " + currentParam + " The Current object for the invocation.");
-        writeOpDocSummary(H, p, comment, pt, true, StringList(), postParams, returns);
+        writeOpDocSummary(H, p, comment, pt, true, GenerateDeprecated::No, StringList(), postParams, returns);
     }
     H << nl << "virtual " << retS << ' ' << opName << spar << params << epar << isConst << " = 0;";
     H << nl << "/// \\cond INTERNAL";

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1734,9 +1734,7 @@ Slice::Gen::TypesVisitor::visitOperation(const OperationPtr& op)
     }
     else
     {
-        writeDocComment(
-            op,
-            "<param name=\"" + args.back() + "\">The Current object for the dispatch.</param>");
+        writeDocComment(op, "<param name=\"" + args.back() + "\">The Current object for the dispatch.</param>");
     }
     emitAttributes(op);
     emitObsoleteAttribute(op, _out);
@@ -2442,9 +2440,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
         //
         string context = getEscapedParamName(p, "context");
         _out << sp;
-        writeDocComment(
-            p,
-            "<param name=\"" + context + "\">The Context map to send with the invocation.</param>");
+        writeDocComment(p, "<param name=\"" + context + "\">The Context map to send with the invocation.</param>");
         emitObsoleteAttribute(p, _out);
         _out << nl << retS << " " << name << spar << getParams(p, ns)
              << ("global::System.Collections.Generic.Dictionary<string, string>? " + context + " = null") << epar

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -59,7 +59,7 @@ namespace Slice
         StringList splitIntoLines(const std::string&);
         void splitComment(const ContainedPtr&, StringList&, StringList&);
         StringList getSummary(const ContainedPtr&);
-        void writeDocComment(const ContainedPtr&, const std::string&, const std::string& = "");
+        void writeDocComment(const ContainedPtr&, const std::string& = "");
         void writeDocCommentOp(const OperationPtr&);
 
         enum ParamDir
@@ -70,13 +70,11 @@ namespace Slice
         void writeDocCommentAMI(
             const OperationPtr&,
             ParamDir,
-            const std::string&,
             const std::string& = "",
             const std::string& = "",
             const std::string& = "");
         void writeDocCommentTaskAsyncAMI(
             const OperationPtr&,
-            const std::string&,
             const std::string& = "",
             const std::string& = "",
             const std::string& = "");

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -1292,10 +1292,6 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
 
         out << sp;
         writeServantDocComment(out, op, package, dc, amd);
-        if (dc && dc->isDeprecated())
-        {
-            out << nl << "@Deprecated";
-        }
 
         if (amd)
         {
@@ -2207,16 +2203,6 @@ Slice::JavaVisitor::writeServantDocComment(
         }
     }
 
-    if (!dc->deprecated().empty())
-    {
-        out << nl << " * @deprecated ";
-        writeDocCommentLines(out, dc->deprecated());
-    }
-    else if (dc->isDeprecated())
-    {
-        out << nl << " * @deprecated";
-    }
-
     out << nl << " **/";
 }
 
@@ -2612,10 +2598,6 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     out << sp;
     writeDocComment(out, p->unit(), dc);
-    if (dc && dc->isDeprecated())
-    {
-        out << nl << "@Deprecated";
-    }
 
     out << nl << "public interface " << fixKwd(name) << " extends ";
     InterfaceList::const_iterator q = bases.begin();

--- a/cpp/src/slice2js/Gen.h
+++ b/cpp/src/slice2js/Gen.h
@@ -31,7 +31,7 @@ namespace Slice
         writeConstantValue(const std::string&, const TypePtr&, const SyntaxTreeBasePtr&, const std::string&);
 
         static StringList splitComment(const ContainedPtr&);
-        void writeDocCommentFor(const ContainedPtr&);
+        void writeDocCommentFor(const ContainedPtr& p, bool includeDeprecated = true);
 
         ::IceInternal::Output& _out;
 


### PR DESCRIPTION
This PR fixes the following:

a) in the Slice parser, the deprecated metadata no longer inserts "deprecated" in the associated doc-comment, if any. This insertion was incorrect.

b) in the Slice compilers, we no longer generate a language-specific @deprecated doc-comment for servants and servant operations.

Note: the `@deprecated` doc-comment tag was implemented in Ice 3.7 (and maybe before), but is not documented.

Fixes #2963.