### PR TITLE
Fix Ice/maxConnections in C# with small delay

### DIFF
--- a/csharp/test/Ice/maxConnections/AllTests.cs
+++ b/csharp/test/Ice/maxConnections/AllTests.cs
@@ -134,6 +134,12 @@ internal class AllTests : global::Test.AllTests
         {
             await postCloseDelay();
         }
+        else
+        {
+            // We need to wait a tiny bit to let the server remove the connection from its incoming connection
+            // factory.
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        }
 
         // Try again
         await p.ice_pingAsync();


### PR DESCRIPTION
Fixes #2968.

In theory, the same issue should affect other languages (C++, Java) but I can only reproduce it in C#. So I only added this delay in C#.
