### PR TITLE
Remove deprecated "inheritance" in Slice compilers

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -936,23 +936,17 @@ Slice::Contained::parseFormatMetadata(const StringList& metadata)
 }
 
 bool
-Slice::Contained::isDeprecated(bool checkParent) const
+Slice::Contained::isDeprecated() const
 {
-    const string prefix1 = "deprecate";
-    const string prefix2 = "deprecated";
-    ContainedPtr parent = checkParent ? dynamic_pointer_cast<Contained>(_container) : nullptr;
-
-    return (hasMetadata(prefix1) || (parent && parent->hasMetadata(prefix1))) ||
-           (hasMetadata(prefix2) || (parent && parent->hasMetadata(prefix2)));
+    return (hasMetadata("deprecate") || hasMetadata("deprecated"));
 }
 
 optional<string>
-Slice::Contained::getDeprecationReason(bool checkParent) const
+Slice::Contained::getDeprecationReason() const
 {
     const string prefix1 = "deprecate:";
     const string prefix2 = "deprecated:";
 
-    // First, we check if the element itself is deprecated.
     if (auto meta = findMetadata(prefix1))
     {
         return meta->substr(prefix1.size());
@@ -960,20 +954,6 @@ Slice::Contained::getDeprecationReason(bool checkParent) const
     if (auto meta = findMetadata(prefix2))
     {
         return meta->substr(prefix2.size());
-    }
-
-    // Then, if necessary, we check if the container it's within is deprecated.
-    ContainedPtr parent = checkParent ? dynamic_pointer_cast<Contained>(_container) : nullptr;
-    if (checkParent && parent)
-    {
-        if (auto meta = parent->findMetadata(prefix1))
-        {
-            return meta->substr(prefix1.size());
-        }
-        if (auto meta = parent->findMetadata(prefix2))
-        {
-            return meta->substr(prefix2.size());
-        }
     }
 
     return nullopt;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -349,17 +349,14 @@ namespace Slice
 
         static std::optional<FormatType> parseFormatMetadata(const StringList& metadata);
 
-        /// Returns true if this item is deprecated (due to the presence of 'deprecated' metadata).
-        /// @param checkParent If true, this item's immediate container will also be checked for 'deprecated' metadata.
-        /// @return True if this item (or possibly its container) has 'deprecated' metadata on it, false otherwise.
-        bool isDeprecated(bool checkParent) const;
+        /// Returns true if this item is deprecated, due to the presence of 'deprecated' metadata.
+        /// @return True if this item has 'deprecated' metadata on it, false otherwise.
+        bool isDeprecated() const;
 
         /// If this item is deprecated, return its deprecation message (if present).
         /// This is the string argument that can be optionally provided with 'deprecated' metadata.
-        /// @param checkParent If true, this item's immediate container will also be checked for 'deprecated' messages.
-        /// @return The message provided to the 'deprecated' metadata, if present. If 'checkParent' is true, and both
-        /// this item and its parent have 'deprecated' messages, the item's message is returned, not its container's.
-        std::optional<std::string> getDeprecationReason(bool checkParent) const;
+        /// @return The message provided to the 'deprecated' metadata, if present.
+        std::optional<std::string> getDeprecationReason() const;
 
         virtual std::string kindOf() const = 0;
 

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -74,9 +74,9 @@ namespace
     string getDeprecatedSymbol(const ContainedPtr& p1)
     {
         string deprecatedSymbol;
-        if (p1->isDeprecated(false)) // 'false' means: don't check the parent type.
+        if (p1->isDeprecated())
         {
-            if (auto reason = p1->getDeprecationReason(false))
+            if (auto reason = p1->getDeprecationReason())
             {
                 deprecatedSymbol = "[[deprecated(\"" + *reason + "\")]] ";
             }

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -77,9 +77,9 @@ namespace
 
     void emitObsoleteAttribute(const ContainedPtr& p1, Output& out)
     {
-        if (p1->isDeprecated(true))
+        if (p1->isDeprecated())
         {
-            if (auto reason = p1->getDeprecationReason(true))
+            if (auto reason = p1->getDeprecationReason())
             {
                 out << nl << "[global::System.Obsolete(\"" << *reason << "\")]";
             }

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -879,10 +879,10 @@ namespace
     {
         DocElements doc;
 
-        doc.deprecated = p->isDeprecated(false);
+        doc.deprecated = p->isDeprecated();
 
         // First check metadata for a deprecated tag.
-        if (auto reason = p->getDeprecationReason(false))
+        if (auto reason = p->getDeprecationReason())
         {
             doc.deprecateReason.push_back(IceInternal::trim(*reason));
         }

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1109,10 +1109,10 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         }
         _out << "))";
 
-        if (operation->isDeprecated(true))
+        if (operation->isDeprecated())
         {
             // Get the deprecation reason if present, or default to an empty string.
-            string reason = operation->getDeprecationReason(true).value_or("");
+            string reason = operation->getDeprecationReason().value_or("");
             _out << nl << className << "._op_" << operation->name() << ".deprecate(\"" << reason << "\")";
         }
     }

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -645,10 +645,10 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         }
         _out << "])";
 
-        if (op->isDeprecated(true))
+        if (op->isDeprecated())
         {
             // Get the deprecation reason if present, or default to an empty string.
-            string reason = op->getDeprecationReason(true).value_or("");
+            string reason = op->getDeprecationReason().value_or("");
             _out << nl << name << "Prx_mixin::OP_" << op->name() << ".deprecate(\"" << reason << "\")";
         }
     }

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -404,10 +404,10 @@ SwiftGenerator::parseComment(const ContainedPtr& p)
 {
     DocElements doc;
 
-    doc.deprecated = p->isDeprecated(false);
+    doc.deprecated = p->isDeprecated();
 
     // First check metadata for a deprecated tag.
-    if (auto reason = p->getDeprecationReason(false))
+    if (auto reason = p->getDeprecationReason())
     {
         doc.deprecateReason.push_back(IceInternal::trim(*reason));
     }


### PR DESCRIPTION
The deprecated metadata should not be inherited - and this PR fixes the Slice compilers to never inherit deprecated.

When you add `["deprecated"]` to an interface, it doesn't mean all its operations are deprecated. It means the proxy type is deprecated. Likewise, when you add `["deprecated"]` to a struct, it doesn't mean all its fields are deprecated.

See also: https://en.cppreference.com/w/cpp/language/attributes/deprecated
