### PR TITLE
Fix diagnostic push/pop in C++

### DIFF
--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -14,6 +14,14 @@
 
 #include <regex>
 
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wshadow"
+#endif
+
 namespace DataStorm
 {
 
@@ -2072,4 +2080,11 @@ namespace DataStorm
     }
 
 }
+
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic pop
+#endif
+
 #endif

--- a/cpp/include/DataStorm/InternalI.h
+++ b/cpp/include/DataStorm/InternalI.h
@@ -13,12 +13,19 @@
 #include <string>
 #include <vector>
 
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wshadow"
+#endif
+
 //
 // Private abstract API used by the template based API and the internal DataStorm implementation.
 //
 namespace DataStormI
 {
-
     class Instance;
 
     class Filterable
@@ -271,6 +278,12 @@ namespace DataStormI
 
         virtual Ice::CommunicatorPtr getCommunicator() const = 0;
     };
-
 }
+
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic pop
+#endif
+
 #endif

--- a/cpp/include/DataStorm/InternalT.h
+++ b/cpp/include/DataStorm/InternalT.h
@@ -9,6 +9,14 @@
 #include "InternalI.h"
 #include "Types.h"
 
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wshadow"
+#endif
+
 namespace DataStorm
 {
     template<typename K, typename V, typename U> class Sample;
@@ -570,3 +578,9 @@ namespace DataStormI
         std::map<std::string, std::unique_ptr<Factory>> _factories;
     };
 }
+
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic pop
+#endif

--- a/cpp/include/DataStorm/Types.h
+++ b/cpp/include/DataStorm/Types.h
@@ -8,6 +8,14 @@
 #include "Config.h"
 #include "Ice/Ice.h"
 
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wshadow"
+#endif
+
 namespace DataStorm
 {
     /**
@@ -315,4 +323,11 @@ namespace DataStorm
         return v;
     }
 }
+
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic pop
+#endif
+
 #endif

--- a/cpp/include/Ice/SlicedData.h
+++ b/cpp/include/Ice/SlicedData.h
@@ -136,4 +136,10 @@ namespace Ice
     };
 }
 
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic pop
+#endif
+
 #endif

--- a/cpp/src/DataStorm/ConnectionManager.cpp
+++ b/cpp/src/DataStorm/ConnectionManager.cpp
@@ -75,9 +75,9 @@ ConnectionManager::remove(const Ice::ConnectionPtr& connection)
         {
             object.second(connection, ex);
         }
-        catch (const std::exception& ex)
+        catch (const std::exception& e)
         {
-            cerr << ex.what() << endl;
+            cerr << e.what() << endl;
             assert(false);
             throw;
         }

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -1311,7 +1311,7 @@ KeyDataWriterI::forward(const Ice::ByteSeq& inParams, const Ice::Current& curren
         if (!_sample || listener.matchOne(_sample, _keys.empty()))
         {
             // Forward the call using the listener's session proxy don't need to wait for the result.
-            auto _ = listener.proxy->ice_invokeAsync(
+            auto cancel = listener.proxy->ice_invokeAsync(
                 current.operation,
                 current.mode,
                 inParams,

--- a/cpp/src/DataStorm/DataElementI.h
+++ b/cpp/src/DataStorm/DataElementI.h
@@ -8,6 +8,14 @@
 #include "DataStorm/Contract.h"
 #include "DataStorm/InternalI.h"
 
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wshadow"
+#endif
+
 namespace DataStormI
 {
     class SessionI;
@@ -418,5 +426,11 @@ namespace DataStormI
         const std::shared_ptr<Filter> _filter;
     };
 }
+
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/cpp/src/DataStorm/NodeI.cpp
+++ b/cpp/src/DataStorm/NodeI.cpp
@@ -267,6 +267,10 @@ NodeI::createSubscriberSession(
         subscriber = getNodeWithExistingConnection(subscriber, connection);
 
         auto self = shared_from_this();
+#if defined(__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wshadow"
+#endif
         subscriber->ice_getConnectionAsync(
             [=, this](auto connection)
             {
@@ -280,6 +284,9 @@ NodeI::createSubscriberSession(
                     [=](auto ex) { self->removePublisherSession(subscriber, session, ex); });
             },
             [=](auto ex) { self->removePublisherSession(subscriber, session, ex); });
+#if defined(__GNUC__)
+#    pragma GCC diagnostic pop
+#endif
     }
     catch (const Ice::LocalException&)
     {

--- a/cpp/src/DataStorm/NodeSessionI.cpp
+++ b/cpp/src/DataStorm/NodeSessionI.cpp
@@ -33,8 +33,8 @@ namespace
             {
                 try
                 {
-                    optional<SessionPrx> session;
-                    updateNodeAndSessionProxy(*publisher, session, current);
+                    optional<SessionPrx> sessionPrx;
+                    updateNodeAndSessionProxy(*publisher, sessionPrx, current);
                     // Forward the call to the target Node object, don't need to wait for the result.
                     _node->initiateCreateSessionAsync(publisher, nullptr);
                 }

--- a/cpp/src/DataStorm/NodeSessionManager.cpp
+++ b/cpp/src/DataStorm/NodeSessionManager.cpp
@@ -407,13 +407,20 @@ NodeSessionManager::disconnected(LookupPrx lookup)
     if (instance)
     {
         instance->scheduleTimerTask(
-            [=, this, self = shared_from_this()]
+            [=, self = shared_from_this()]
             {
-                auto instance = _instance.lock();
+#if defined(__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wshadow"
+#endif
+                auto instance = self->_instance.lock();
                 if (instance)
                 {
-                    self->connect(lookup, _nodePrx);
+                    self->connect(lookup, self->_nodePrx);
                 }
+#if defined(__GNUC__)
+#    pragma GCC diagnostic pop
+#endif
             },
             instance->getRetryDelay(_retryCount++));
     }

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -533,6 +533,11 @@ SessionI::connected(SessionPrx session, const Ice::ConnectionPtr& connection, co
     if (connection)
     {
         auto self = shared_from_this();
+
+#if defined(__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wshadow"
+#endif
         _instance->getConnectionManager()->add(
             connection,
             self,
@@ -546,6 +551,9 @@ SessionI::connected(SessionPrx session, const Ice::ConnectionPtr& connection, co
                     }
                 }
             });
+#if defined(__GNUC__)
+#    pragma GCC diagnostic pop
+#endif
     }
 
     if (_retryTask)

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1108,16 +1108,16 @@ SessionI::subscriberInitialized(
     assert(_topics.find(topicId) != _topics.end());
     auto& subscriber = _topics.at(topicId).getSubscriber(element->getTopic());
     auto e = subscriber.get(elementId);
-    auto s = e->getSubscriber(element);
-    assert(s);
+    auto es = e->getSubscriber(element);
+    assert(es);
 
     if (_traceLevels->session > 1)
     {
         Trace out(_traceLevels, _traceLevels->sessionCat);
         out << _id << ": initialized `" << element << "' from `e" << elementId << '@' << topicId << "'";
     }
-    s->initialized = true;
-    s->lastId = samples.empty() ? 0 : samples.back().id;
+    es->initialized = true;
+    es->lastId = samples.empty() ? 0 : samples.back().id;
 
     vector<shared_ptr<Sample>> samplesI;
     samplesI.reserve(samples.size());

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -9,13 +9,12 @@
 #include "Ice/Ice.h"
 #include "NodeI.h"
 
-#if defined(_MSC_VER)
-#    pragma warning(push)
-#    pragma warning(disable : 4456) // ... : declaration of 'identifier' hides previous local declaration
-#    pragma warning(disable : 4458) // ... : declaration of 'identifier' hides class member
-#elif defined(__clang__)
+#if defined(__clang__)
 #    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wshadow"
+#    pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wshadow"
 #endif
 
 namespace DataStormI
@@ -159,12 +158,12 @@ namespace DataStormI
 
             std::map<std::int64_t, ElementSubscribers>& getAll() { return _elements; }
 
-            void reap(int sessionInstanceId)
+            void reap(int id)
             {
                 auto p = _elements.begin();
                 while (p != _elements.end())
                 {
-                    if (p->second.reap(sessionInstanceId))
+                    if (p->second.reap(id))
                     {
                         _elements.erase(p++);
                     }
@@ -373,4 +372,11 @@ namespace DataStormI
         void remove() final;
     };
 }
+
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic pop
+#endif
+
 #endif

--- a/cpp/src/DataStorm/TopicI.h
+++ b/cpp/src/DataStorm/TopicI.h
@@ -11,6 +11,14 @@
 #include "ForwarderManager.h"
 #include "Instance.h"
 
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wshadow"
+#endif
+
 namespace DataStormI
 {
     class SessionI;
@@ -218,4 +226,11 @@ namespace DataStormI
         DataStorm::WriterConfig _defaultConfig;
     };
 }
+
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic pop
+#endif
+
 #endif

--- a/cpp/src/DataStorm/TraceUtil.cpp
+++ b/cpp/src/DataStorm/TraceUtil.cpp
@@ -7,6 +7,14 @@
 using namespace std;
 using namespace DataStormI;
 
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wshadow"
+#endif
+
 TraceLevels::TraceLevels(const Ice::PropertiesPtr& properties, const Ice::LoggerPtr& logger)
     : topic(properties->getIcePropertyAsInt("DataStorm.Trace.Topic")),
       topicCat("Topic"),
@@ -17,3 +25,9 @@ TraceLevels::TraceLevels(const Ice::PropertiesPtr& properties, const Ice::Logger
       logger(logger)
 {
 }
+
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic pop
+#endif

--- a/cpp/src/IceGrid/ServerI.h
+++ b/cpp/src/IceGrid/ServerI.h
@@ -29,10 +29,6 @@ namespace IceGrid
     class ServerI final : public Server, public std::enable_shared_from_this<ServerI>
     {
     public:
-#if defined(__clang__)
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wshadow"
-#endif
         enum InternalServerState
         {
             Loading,
@@ -55,9 +51,6 @@ namespace IceGrid
             Manual,
             Disabled
         };
-#if defined(__clang__)
-#    pragma clang diagnostic pop
-#endif
 
         ServerI(const std::shared_ptr<NodeI>&, std::optional<ServerPrx>, const std::string&, const std::string&, int);
 

--- a/cpp/src/IceGrid/SessionManager.h
+++ b/cpp/src/IceGrid/SessionManager.h
@@ -16,10 +16,6 @@ namespace IceGrid
 {
     template<class TPrx> class SessionKeepAliveThread
     {
-#if defined(__clang__)
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wshadow"
-#endif
         enum State
         {
             Disconnected,
@@ -27,9 +23,6 @@ namespace IceGrid
             InProgress,
             Destroyed
         };
-#if defined(__clang__)
-#    pragma clang diagnostic pop
-#endif
 
         enum Action
         {

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -6,12 +6,6 @@
 
 #include <cassert>
 
-#if defined(__clang__)
-#    pragma clang diagnostic ignored "-Wshadow"
-#elif defined(__GNUC__)
-#    pragma GCC diagnostic ignored "-Wshadow"
-#endif
-
 using namespace std;
 using namespace Slice;
 using namespace IceInternal;

--- a/cpp/test/DataStorm/callbacks/Reader.cpp
+++ b/cpp/test/DataStorm/callbacks/Reader.cpp
@@ -8,6 +8,11 @@
 using namespace DataStorm;
 using namespace std;
 
+// GCC should allow "shadowing" in lambda expressions but doesn't.
+#if defined(__GNUC__) && !defined(__clang__)
+#    pragma GCC diagnostic ignored "-Wshadow"
+#endif
+
 int
 main(int argc, char* argv[])
 {

--- a/cpp/test/DataStorm/callbacks/Writer.cpp
+++ b/cpp/test/DataStorm/callbacks/Writer.cpp
@@ -8,6 +8,11 @@
 using namespace DataStorm;
 using namespace std;
 
+// GCC should allow "shadowing" in lambda expressions but doesn't.
+#if defined(__GNUC__) && !defined(__clang__)
+#    pragma GCC diagnostic ignored "-Wshadow"
+#endif
+
 int
 main(int argc, char* argv[])
 {

--- a/cpp/test/IceGrid/allocation/AllTests.cpp
+++ b/cpp/test/IceGrid/allocation/AllTests.cpp
@@ -126,7 +126,10 @@ public:
             }
 
             assert(session);
-            session->ice_ping();
+#include <Ice/PushDisableWarnings.h>
+            // keepAlive is deprecated.
+            session->keepAlive();
+#include <Ice/PopDisableWarnings.h>
 
             optional<ObjectPrx> object;
             switch (_rd() % (_destroySession ? 4 : 2))


### PR DESCRIPTION
This PR fixes #2962.

The main bug was in SlicedData.h, which was missing a pop.