### PR TITLE
Fix throwing of NotExist exceptions

### DIFF
--- a/cpp/src/Glacier2/ClientBlobject.cpp
+++ b/cpp/src/Glacier2/ClientBlobject.cpp
@@ -77,8 +77,8 @@ Glacier2::ClientBlobject::ice_invokeAsync(
     auto proxy = _routingTable->get(current.id);
     if (!proxy)
     {
-        // We use a special operation name to indicate to the client that the proxy for the Ice object has not been found
-        // in our routing table. This can happen if the proxy was evicted from the routing table.
+        // We use a special operation name to indicate to the client that the proxy for the Ice object has not been
+        // found in our routing table. This can happen if the proxy was evicted from the routing table.
         throw ObjectNotExistException{__FILE__, __LINE__, current.id, current.facet, "ice_add_proxy"};
     }
 

--- a/cpp/src/Glacier2/ClientBlobject.cpp
+++ b/cpp/src/Glacier2/ClientBlobject.cpp
@@ -77,7 +77,7 @@ Glacier2::ClientBlobject::ice_invokeAsync(
     auto proxy = _routingTable->get(current.id);
     if (!proxy)
     {
-        // We use a special operation name indicate to the client that the proxy for the Ice object has not been found
+        // We use a special operation name to indicate to the client that the proxy for the Ice object has not been found
         // in our routing table. This can happen if the proxy was evicted from the routing table.
         throw ObjectNotExistException{__FILE__, __LINE__, current.id, current.facet, "ice_add_proxy"};
     }

--- a/cpp/src/Glacier2/ClientBlobject.cpp
+++ b/cpp/src/Glacier2/ClientBlobject.cpp
@@ -77,13 +77,9 @@ Glacier2::ClientBlobject::ice_invokeAsync(
     auto proxy = _routingTable->get(current.id);
     if (!proxy)
     {
-        //
-        // We use a special operation name indicate to the client that
-        // the proxy for the Ice object has not been found in our
-        // routing table. This can happen if the proxy was evicted
-        // from the routing table.
-        //
-        throw ObjectNotExistException(__FILE__, __LINE__, current.id, current.facet, "ice_add_proxy");
+        // We use a special operation name indicate to the client that the proxy for the Ice object has not been found
+        // in our routing table. This can happen if the proxy was evicted from the routing table.
+        throw ObjectNotExistException{__FILE__, __LINE__, current.id, current.facet, "ice_add_proxy"};
     }
 
     string adapterId = proxy->ice_getAdapterId();
@@ -114,7 +110,7 @@ Glacier2::ClientBlobject::ice_invokeAsync(
             out << "identity: " << _instance->communicator()->identityToString(current.id);
         }
 
-        throw ObjectNotExistException(__FILE__, __LINE__, current.id, "", "");
+        throw ObjectNotExistException{__FILE__, __LINE__};
     }
 
     invoke(proxy.value(), inParams, std::move(response), std::move(error), current);

--- a/cpp/src/Glacier2/RoutingTable.cpp
+++ b/cpp/src/Glacier2/RoutingTable.cpp
@@ -62,7 +62,7 @@ Glacier2::RoutingTable::add(const ObjectProxySeq& unfiltered, const Current& cur
         if (!_verifier->verify(*prx))
         {
             current.con->abort();
-            throw ObjectNotExistException(__FILE__, __LINE__);
+            throw ObjectNotExistException{__FILE__, __LINE__};
         }
 
         ObjectPrx proxy = prx->ice_twoway()->ice_secure(false)->ice_facet(""); // We add proxies in default form.

--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -695,7 +695,7 @@ SessionRouterI::destroySession(const ConnectionPtr& connection)
 
         if (_destroy)
         {
-            throw ObjectNotExistException(__FILE__, __LINE__);
+            throw ObjectNotExistException{__FILE__, __LINE__};
         }
 
         map<ConnectionPtr, shared_ptr<RouterI>>::const_iterator p;
@@ -788,7 +788,7 @@ SessionRouterI::getServerBlobject(const string& category) const
 
     if (_destroy)
     {
-        throw ObjectNotExistException(__FILE__, __LINE__);
+        throw ObjectNotExistException{__FILE__, __LINE__};
     }
 
     if (_routersByCategoryHint != _routersByCategory.cend() && _routersByCategoryHint->first == category)
@@ -805,7 +805,7 @@ SessionRouterI::getServerBlobject(const string& category) const
     }
     else
     {
-        throw ObjectNotExistException(__FILE__, __LINE__);
+        throw ObjectNotExistException{__FILE__, __LINE__};
     }
 }
 
@@ -819,7 +819,7 @@ SessionRouterI::getRouterImpl(const ConnectionPtr& connection, const Ice::Identi
     //
     if (_destroy || !connection)
     {
-        throw ObjectNotExistException(__FILE__, __LINE__);
+        throw ObjectNotExistException{__FILE__, __LINE__};
     }
 
     if (_routersByConnectionHint != _routersByConnection.cend() && _routersByConnectionHint->first == connection)
@@ -843,7 +843,7 @@ SessionRouterI::getRouterImpl(const ConnectionPtr& connection, const Ice::Identi
             out << "identity: " << identityToString(id);
         }
         connection->abort();
-        throw ObjectNotExistException(__FILE__, __LINE__);
+        throw ObjectNotExistException{__FILE__, __LINE__};
     }
     return nullptr;
 }

--- a/cpp/src/Ice/LoggerAdminI.cpp
+++ b/cpp/src/Ice/LoggerAdminI.cpp
@@ -295,7 +295,7 @@ namespace
             {
                 if (_destroyed)
                 {
-                    throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+                    throw Ice::ObjectNotExistException{__FILE__, __LINE__};
                 }
 
                 _sendLogCommunicator =

--- a/cpp/src/Ice/Object.cpp
+++ b/cpp/src/Ice/Object.cpp
@@ -110,7 +110,7 @@ Ice::Object::dispatch(IncomingRequest& request, std::function<void(OutgoingRespo
 
     if (r.first == r.second)
     {
-        sendResponse(makeOutgoingResponse(make_exception_ptr(OperationNotExistException(__FILE__, __LINE__)), current));
+        sendResponse(makeOutgoingResponse(make_exception_ptr(OperationNotExistException{__FILE__, __LINE__}), current));
         return;
     }
 
@@ -140,7 +140,7 @@ Ice::Object::dispatch(IncomingRequest& request, std::function<void(OutgoingRespo
         {
             assert(false);
             sendResponse(
-                makeOutgoingResponse(make_exception_ptr(OperationNotExistException(__FILE__, __LINE__)), current));
+                makeOutgoingResponse(make_exception_ptr(OperationNotExistException{__FILE__, __LINE__}), current));
         }
     }
 }

--- a/cpp/src/IceGrid/AdminCallbackRouter.cpp
+++ b/cpp/src/IceGrid/AdminCallbackRouter.cpp
@@ -47,7 +47,7 @@ AdminCallbackRouter::ice_invokeAsync(
         auto p = _categoryToConnection.find(current.id.category);
         if (p == _categoryToConnection.end())
         {
-            throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+            throw Ice::ObjectNotExistException{__FILE__, __LINE__};
         }
         con = p->second;
     }
@@ -63,7 +63,7 @@ AdminCallbackRouter::ice_invokeAsync(
         inParams,
         std::move(response),
         [exception = std::move(exception)](exception_ptr)
-        { exception(make_exception_ptr(Ice::ObjectNotExistException(__FILE__, __LINE__))); },
+        { exception(make_exception_ptr(Ice::ObjectNotExistException{__FILE__, __LINE__})); },
         nullptr,
         current.ctx);
 }

--- a/cpp/src/IceGrid/AdminSessionI.cpp
+++ b/cpp/src/IceGrid/AdminSessionI.cpp
@@ -34,7 +34,7 @@ namespace
                 [exception = std::move(exception)](exception_ptr)
                 {
                     // Throw ObjectNotExistException, the subscriber is unreachable
-                    exception(make_exception_ptr(Ice::ObjectNotExistException(__FILE__, __LINE__)));
+                    exception(make_exception_ptr(Ice::ObjectNotExistException{__FILE__, __LINE__}));
                 },
                 nullptr,
                 current.ctx);
@@ -138,13 +138,13 @@ AdminSessionI::setObservers(
     optional<ApplicationObserverPrx> appObserver,
     optional<AdapterObserverPrx> adapterObserver,
     optional<ObjectObserverPrx> objectObserver,
-    const Ice::Current& current)
+    const Ice::Current&)
 {
     lock_guard lock(_mutex);
 
     if (_destroyed)
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__, current.id, "", "");
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
 
     const auto locator = _registry->getLocator();
@@ -207,7 +207,7 @@ AdminSessionI::setObserversByIdentity(
 
     if (_destroyed)
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__, current.id, "", "");
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
 
     setupObserverSubscription(TopicName::RegistryObserver, addForwarder(registryObserver, current), true);
@@ -218,13 +218,13 @@ AdminSessionI::setObserversByIdentity(
 }
 
 int
-AdminSessionI::startUpdate(const Ice::Current& current)
+AdminSessionI::startUpdate(const Ice::Current&)
 {
     lock_guard lock(_mutex);
 
     if (_destroyed)
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__, current.id, "", "");
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
 
     int serial = _database->lock(this, _id);
@@ -232,13 +232,13 @@ AdminSessionI::startUpdate(const Ice::Current& current)
 }
 
 void
-AdminSessionI::finishUpdate(const Ice::Current& current)
+AdminSessionI::finishUpdate(const Ice::Current&)
 {
     lock_guard lock(_mutex);
 
     if (_destroyed)
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__, current.id, "", "");
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
 
     _database->unlock(this);
@@ -375,13 +375,13 @@ AdminSessionI::addForwarder(Ice::ObjectPrx prx)
 }
 
 FileIteratorPrx
-AdminSessionI::addFileIterator(FileReaderPrx reader, const string& filename, int nLines, const Ice::Current& current)
+AdminSessionI::addFileIterator(FileReaderPrx reader, const string& filename, int nLines, const Ice::Current&)
 {
     lock_guard lock(_mutex);
 
     if (_destroyed)
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__, current.id, "", "");
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
 
     // Always call getOffsetFromEnd even if nLines < 0. This allows to throw right away if the file doesn't exit.

--- a/cpp/src/IceGrid/InternalRegistryI.cpp
+++ b/cpp/src/IceGrid/InternalRegistryI.cpp
@@ -67,7 +67,7 @@ InternalRegistryI::registerNode(
     }
     catch (const Ice::ObjectAdapterDestroyedException&)
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
 }
 
@@ -98,7 +98,7 @@ InternalRegistryI::registerReplica(
     }
     catch (const Ice::ObjectAdapterDestroyedException&)
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
 }
 

--- a/cpp/src/IceGrid/NodeAdminRouter.cpp
+++ b/cpp/src/IceGrid/NodeAdminRouter.cpp
@@ -37,7 +37,7 @@ NodeServerAdminRouter::ice_invokeAsync(
             out << "could not find Admin proxy for server `" << current.id.name << "'";
         }
 
-        throw ObjectNotExistException(__FILE__, __LINE__);
+        throw ObjectNotExistException{__FILE__, __LINE__};
     }
 
     //
@@ -53,7 +53,7 @@ NodeServerAdminRouter::ice_invokeAsync(
             out << "no Process proxy registered with server `" << current.id.name << "'";
         }
 
-        throw ObjectNotExistException(__FILE__, __LINE__);
+        throw ObjectNotExistException{__FILE__, __LINE__};
     }
 
     //

--- a/cpp/src/IceGrid/NodeI.cpp
+++ b/cpp/src/IceGrid/NodeI.cpp
@@ -843,7 +843,7 @@ NodeI::loadServer(
                 // We throw an object not exist exception to avoid dispatch warnings. The registry will consider the
                 // node has being unreachable upon receipt of this exception (like any other Ice::LocalException). We
                 // could also have disabled dispatch warnings but they can still useful to catch other issues.
-                throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+                throw Ice::ObjectNotExistException{__FILE__, __LINE__};
             }
 
             try
@@ -906,7 +906,7 @@ NodeI::destroyServer(
             // We throw an object not exist exception to avoid dispatch warnings. The registry will consider the node
             // has being unreachable upon receipt of this exception (like any other Ice::LocalException). We could also
             // have disabled dispatch warnings but they can still useful to catch other issues.
-            throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+            throw Ice::ObjectNotExistException{__FILE__, __LINE__};
         }
 
         if (!server)

--- a/cpp/src/IceGrid/NodeSessionI.cpp
+++ b/cpp/src/IceGrid/NodeSessionI.cpp
@@ -84,7 +84,7 @@ NodeSessionI::keepAlive(LoadInfo load, const Ice::Current&)
 
     if (_destroy)
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
 
     _timestamp = chrono::steady_clock::now();
@@ -192,7 +192,7 @@ NodeSessionI::timestamp() const
     lock_guard lock(_mutex);
     if (_destroy)
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
     return _timestamp;
 }
@@ -242,7 +242,7 @@ NodeSessionI::destroyImpl(bool shutdown)
         lock_guard lock(_mutex);
         if (_destroy)
         {
-            throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+            throw Ice::ObjectNotExistException{__FILE__, __LINE__};
         }
         _destroy = true;
     }

--- a/cpp/src/IceGrid/RegistryAdminRouter.cpp
+++ b/cpp/src/IceGrid/RegistryAdminRouter.cpp
@@ -44,7 +44,7 @@ namespace
 
         void synchronized(exception_ptr)
         {
-            _exception(make_exception_ptr(Ice::ObjectNotExistException(__FILE__, __LINE__)));
+            _exception(make_exception_ptr(Ice::ObjectNotExistException{__FILE__, __LINE__}));
         }
 
     private:
@@ -101,7 +101,7 @@ RegistryServerAdminRouter::ice_invokeAsync(
 
     if (target == nullopt)
     {
-        throw ObjectNotExistException(__FILE__, __LINE__);
+        throw ObjectNotExistException{__FILE__, __LINE__};
     }
     invokeOnTarget(target->ice_facet(current.facet), inParams, std::move(response), std::move(exception), current);
 }
@@ -148,7 +148,7 @@ RegistryNodeAdminRouter::ice_invokeAsync(
                 out << "could not find Admin proxy for node `" << current.id.name << "'";
             }
 
-            throw ObjectNotExistException(__FILE__, __LINE__);
+            throw ObjectNotExistException{__FILE__, __LINE__};
         }
     }
 
@@ -196,7 +196,7 @@ RegistryReplicaAdminRouter::ice_invokeAsync(
             out << "could not find Admin proxy for replica `" << current.id.name << "'";
         }
 
-        throw ObjectNotExistException(__FILE__, __LINE__);
+        throw ObjectNotExistException{__FILE__, __LINE__};
     }
     invokeOnTarget(target->ice_facet(current.facet), inParams, std::move(response), std::move(exception), current);
 }

--- a/cpp/src/IceGrid/ReplicaSessionI.cpp
+++ b/cpp/src/IceGrid/ReplicaSessionI.cpp
@@ -88,7 +88,7 @@ ReplicaSessionI::keepAlive(const Ice::Current&)
     lock_guard lock(_mutex);
     if (_destroy)
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
 
     _timestamp = chrono::steady_clock::now();
@@ -168,7 +168,7 @@ ReplicaSessionI::setDatabaseObserver(
         lock_guard lock(_mutex);
         if (_destroy)
         {
-            throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+            throw Ice::ObjectNotExistException{__FILE__, __LINE__};
         }
         _observer = observer;
 
@@ -189,7 +189,7 @@ ReplicaSessionI::setEndpoints(StringObjectProxyDict endpoints, const Ice::Curren
         lock_guard lock(_mutex);
         if (_destroy)
         {
-            throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+            throw Ice::ObjectNotExistException{__FILE__, __LINE__};
         }
         _replicaEndpoints = std::move(endpoints);
     }
@@ -204,7 +204,7 @@ ReplicaSessionI::registerWellKnownObjects(ObjectInfoSeq objects, const Ice::Curr
         lock_guard lock(_mutex);
         if (_destroy)
         {
-            throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+            throw Ice::ObjectNotExistException{__FILE__, __LINE__};
         }
         _replicaWellKnownObjects = objects;
         serial = _database->addOrUpdateRegistryWellKnownObjects(objects);
@@ -255,7 +255,7 @@ ReplicaSessionI::timestamp() const
     lock_guard lock(_mutex);
     if (_destroy)
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
     return _timestamp;
 }
@@ -309,7 +309,7 @@ ReplicaSessionI::destroyImpl(bool shutdown)
         lock_guard lock(_mutex);
         if (_destroy)
         {
-            throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+            throw Ice::ObjectNotExistException{__FILE__, __LINE__};
         }
         _destroy = true;
     }

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -1360,7 +1360,7 @@ ServerI::checkDestroyed() const
     if (_state == Destroyed)
     {
         assert(_this);
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__, _this->ice_getIdentity(), "", "");
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
 }
 

--- a/cpp/src/IceGrid/SessionI.cpp
+++ b/cpp/src/IceGrid/SessionI.cpp
@@ -68,7 +68,7 @@ BaseSessionI::destroyImpl(bool)
     lock_guard lock(_mutex);
     if (_destroyed)
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
     _destroyed = true;
 

--- a/cpp/src/IceLocatorDiscovery/PluginI.cpp
+++ b/cpp/src/IceLocatorDiscovery/PluginI.cpp
@@ -356,19 +356,19 @@ Request::exception(std::exception_ptr ex)
     }
     catch (const Ice::NoEndpointException&)
     {
-        _exceptionCallback(make_exception_ptr(Ice::ObjectNotExistException(__FILE__, __LINE__)));
+        _exceptionCallback(make_exception_ptr(Ice::ObjectNotExistException{__FILE__, __LINE__}));
     }
     catch (const Ice::CommunicatorDestroyedException&)
     {
-        _exceptionCallback(make_exception_ptr(Ice::ObjectNotExistException(__FILE__, __LINE__)));
+        _exceptionCallback(make_exception_ptr(Ice::ObjectNotExistException{__FILE__, __LINE__}));
     }
     catch (const Ice::ObjectAdapterDeactivatedException&)
     {
-        _exceptionCallback(make_exception_ptr(Ice::ObjectNotExistException(__FILE__, __LINE__)));
+        _exceptionCallback(make_exception_ptr(Ice::ObjectNotExistException{__FILE__, __LINE__}));
     }
     catch (const Ice::ObjectAdapterDestroyedException&)
     {
-        _exceptionCallback(make_exception_ptr(Ice::ObjectNotExistException(__FILE__, __LINE__)));
+        _exceptionCallback(make_exception_ptr(Ice::ObjectNotExistException{__FILE__, __LINE__}));
     }
     catch (...)
     {

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -664,7 +664,7 @@ TopicImpl::unlink(const TopicPrx& topic)
 
     if (_destroyed)
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
 
     Ice::Identity id = topic->ice_getIdentity();
@@ -775,7 +775,7 @@ TopicImpl::destroy()
 
     if (_destroyed)
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
     _destroyed = true;
 

--- a/cpp/src/IceStorm/TransientTopicI.cpp
+++ b/cpp/src/IceStorm/TransientTopicI.cpp
@@ -259,7 +259,7 @@ TransientTopicImpl::unlink(optional<TopicPrx> topic, const Ice::Current&)
 
     if (_destroyed)
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
 
     auto id = topic->ice_getIdentity();
@@ -335,7 +335,7 @@ TransientTopicImpl::destroy(const Ice::Current&)
 
     if (_destroyed)
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
     _destroyed = true;
 

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -2888,8 +2888,8 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         C << nl << "if(r.first == r.second)";
         C << sb;
         C << nl
-          << "sendResponse(::Ice::makeOutgoingResponse(::std::make_exception_ptr(::Ice::OperationNotExistException(__"
-             "FILE__, __LINE__)), current));";
+          << "sendResponse(::Ice::makeOutgoingResponse(::std::make_exception_ptr(::Ice::OperationNotExistException{__"
+             "FILE__, __LINE__}), current));";
         C << nl << "return;";
         C << eb;
         C << sp;
@@ -2908,8 +2908,8 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         C << sb;
         C << nl << "assert(false);";
         C << nl
-          << "sendResponse(::Ice::makeOutgoingResponse(::std::make_exception_ptr(::Ice::OperationNotExistException(__"
-             "FILE__, __LINE__)), current));";
+          << "sendResponse(::Ice::makeOutgoingResponse(::std::make_exception_ptr(::Ice::OperationNotExistException{__"
+             "FILE__, __LINE__}), current));";
         C << eb;
         C << eb;
         C << eb;

--- a/cpp/test/Glacier2/sessionControl/SessionI.cpp
+++ b/cpp/test/Glacier2/sessionControl/SessionI.cpp
@@ -21,7 +21,7 @@ SessionManagerI::create(
     }
     if (userId == "localexception")
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
     return current.adapter->addWithUUID<Glacier2::SessionPrx>(make_shared<SessionI>(sessionControl));
 }

--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -47,7 +47,7 @@ namespace
         {
             case ThrowType::LocalException:
             {
-                throw ObjectNotExistException(__FILE__, __LINE__);
+                throw ObjectNotExistException{__FILE__, __LINE__};
                 break;
             }
             case ThrowType::UserException:

--- a/cpp/test/Ice/defaultServant/TestI.cpp
+++ b/cpp/test/Ice/defaultServant/TestI.cpp
@@ -14,11 +14,11 @@ MyObjectI::ice_ping(const Ice::Current& current) const
 
     if (name == "ObjectNotExist")
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
     else if (name == "FacetNotExist")
     {
-        throw Ice::FacetNotExistException(__FILE__, __LINE__);
+        throw Ice::FacetNotExistException{__FILE__, __LINE__};
     }
 }
 
@@ -29,11 +29,11 @@ MyObjectI::getName(const Ice::Current& current)
 
     if (name == "ObjectNotExist")
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
     else if (name == "FacetNotExist")
     {
-        throw Ice::FacetNotExistException(__FILE__, __LINE__);
+        throw Ice::FacetNotExistException{__FILE__, __LINE__};
     }
 
     return name;

--- a/cpp/test/Ice/metrics/TestAMDI.cpp
+++ b/cpp/test/Ice/metrics/TestAMDI.cpp
@@ -38,7 +38,7 @@ MetricsI::opWithRequestFailedExceptionAsync(function<void()>, function<void(exce
 {
     try
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
     catch (...)
     {

--- a/cpp/test/Ice/metrics/TestI.cpp
+++ b/cpp/test/Ice/metrics/TestI.cpp
@@ -29,7 +29,7 @@ MetricsI::opWithUserException(const Current&)
 void
 MetricsI::opWithRequestFailedException(const Current&)
 {
-    throw ObjectNotExistException(__FILE__, __LINE__);
+    throw ObjectNotExistException{__FILE__, __LINE__};
 }
 
 void

--- a/cpp/test/Ice/servantLocator/ServantLocatorI.cpp
+++ b/cpp/test/Ice/servantLocator/ServantLocatorI.cpp
@@ -90,7 +90,7 @@ ServantLocatorI::exception(const Ice::Current& current)
     }
     else if (current.operation == "requestFailedException")
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
     else if (current.operation == "unknownUserException")
     {

--- a/cpp/test/Ice/servantLocator/TestAMDI.cpp
+++ b/cpp/test/Ice/servantLocator/TestAMDI.cpp
@@ -64,7 +64,7 @@ TestAMDI::unknownExceptionWithServantExceptionAsync(
 {
     try
     {
-        throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+        throw Ice::ObjectNotExistException{__FILE__, __LINE__};
     }
     catch (...)
     {
@@ -132,7 +132,7 @@ void
 TestAMDI::asyncResponseAsync(function<void()> response, function<void(exception_ptr)>, const Current&)
 {
     response();
-    throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+    throw Ice::ObjectNotExistException{__FILE__, __LINE__};
 }
 
 void
@@ -146,7 +146,7 @@ TestAMDI::asyncExceptionAsync(function<void()>, function<void(exception_ptr)> er
     {
         error(current_exception());
     }
-    throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+    throw Ice::ObjectNotExistException{__FILE__, __LINE__};
 }
 
 void

--- a/cpp/test/Ice/servantLocator/TestI.cpp
+++ b/cpp/test/Ice/servantLocator/TestI.cpp
@@ -51,7 +51,7 @@ TestI::cppException(const Current&)
 void
 TestI::unknownExceptionWithServantException(const Current&)
 {
-    throw Ice::ObjectNotExistException(__FILE__, __LINE__);
+    throw Ice::ObjectNotExistException{__FILE__, __LINE__};
 }
 
 string

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/AdminRouter.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/AdminRouter.java
@@ -9,8 +9,7 @@ class AdminRouter implements com.zeroc.Ice.Blobject {
     public com.zeroc.Ice.Object.Ice_invokeResult ice_invoke(
             byte[] inParams, com.zeroc.Ice.Current current) {
         if (_admin == null) {
-            throw new com.zeroc.Ice.ObjectNotExistException(
-                    current.id, current.facet, current.operation);
+            throw new com.zeroc.Ice.ObjectNotExistException();
         } else if (current.operation.equals("ice_id")
                 || current.operation.equals("ice_ids")
                 || current.operation.equals("ice_isA")
@@ -19,8 +18,7 @@ class AdminRouter implements com.zeroc.Ice.Blobject {
             return _admin.ice_invoke(current.operation, current.mode, inParams, current.ctx);
         } else {
             // Routing other operations could be a security risk
-            throw new com.zeroc.Ice.OperationNotExistException(
-                    current.id, current.facet, current.operation);
+            throw new com.zeroc.Ice.OperationNotExistException();
         }
     }
 

--- a/js/src/Ice/Operation.js
+++ b/js/src/Ice/Operation.js
@@ -498,7 +498,7 @@ export function defineOperations(classType, proxyType, ids, id, ops) {
         const method = getServantMethod(classType, request.current.operation);
 
         if (method === undefined || typeof method !== "function") {
-            throw new OperationNotExistException(request.current.id, request.current.facet, request.current.operation);
+            throw new OperationNotExistException();
         }
 
         return method.call(method, this, request);

--- a/python/modules/IcePy/Util.cpp
+++ b/python/modules/IcePy/Util.cpp
@@ -334,30 +334,30 @@ IcePy::PyException::raise()
 
             if (typeName == "Ice.ObjectNotExistException")
             {
-                throw Ice::ObjectNotExistException(
+                throw Ice::ObjectNotExistException{
                     __FILE__,
                     __LINE__,
                     std::move(id),
                     std::move(facet),
-                    std::move(operation));
+                    std::move(operation)};
             }
             else if (typeName == "Ice.OperationNotExistException")
             {
-                throw Ice::OperationNotExistException(
+                throw Ice::OperationNotExistException{
                     __FILE__,
                     __LINE__,
                     std::move(id),
                     std::move(facet),
-                    std::move(operation));
+                    std::move(operation)};
             }
             else if (typeName == "Ice.FacetNotExistException")
             {
-                throw Ice::FacetNotExistException(
+                throw Ice::FacetNotExistException{
                     __FILE__,
                     __LINE__,
                     std::move(id),
                     std::move(facet),
-                    std::move(operation));
+                    std::move(operation)};
             }
         }
 

--- a/swift/test/Ice/defaultServant/AllTests.swift
+++ b/swift/test/Ice/defaultServant/AllTests.swift
@@ -6,17 +6,17 @@ import TestCommon
 final class MyObjectI: ObjectI<MyObjectTraits>, MyObject {
     override func ice_ping(current: Ice.Current) async throws {
         if current.id.name == "ObjectNotExist" {
-            throw Ice.ObjectNotExistException(id: current.id, facet: "", operation: "ice_ping")
+            throw Ice.ObjectNotExistException()
         } else if current.id.name == "FacetNotExist" {
-            throw Ice.FacetNotExistException(id: current.id, facet: "", operation: "ice_ping")
+            throw Ice.FacetNotExistException()
         }
     }
 
     func getName(current: Ice.Current) async throws -> String {
         if current.id.name == "ObjectNotExist" {
-            throw Ice.ObjectNotExistException(id: current.id, facet: "", operation: "ice_ping")
+            throw Ice.ObjectNotExistException()
         } else if current.id.name == "FacetNotExist" {
-            throw Ice.FacetNotExistException(id: current.id, facet: "", operation: "ice_ping")
+            throw Ice.FacetNotExistException()
         }
         return current.id.name
     }

--- a/swift/test/Ice/invoke/TestI.swift
+++ b/swift/test/Ice/invoke/TestI.swift
@@ -55,10 +55,7 @@ class DispatcherI: Ice.Dispatcher {
                 }
             }
         } else {
-            throw Ice.OperationNotExistException(
-                id: current.id,
-                facet: current.facet,
-                operation: current.operation)
+            throw Ice.OperationNotExistException()
         }
     }
 }

--- a/swift/test/Ice/servantLocator/ServantLocatorI.swift
+++ b/swift/test/Ice/servantLocator/ServantLocatorI.swift
@@ -92,8 +92,7 @@ class ServantLocatorI: Ice.ServantLocator {
         if current.operation == "ice_ids" {
             throw TestIntfUserException()
         } else if current.operation == "requestFailedException" {
-            throw Ice.ObjectNotExistException(
-                id: current.id, facet: current.facet, operation: current.operation)
+            throw Ice.ObjectNotExistException()
         } else if current.operation == "unknownUserException" {
             throw Ice.UnknownUserException(badTypeId: "::Foo::BarException")
         } else if current.operation == "unknownLocalException" {

--- a/swift/test/Ice/servantLocator/TestI.swift
+++ b/swift/test/Ice/servantLocator/TestI.swift
@@ -18,10 +18,7 @@ class TestI: TestIntf {
     func userException(current _: Current) async throws {}
 
     func unknownExceptionWithServantException(current: Current) async throws {
-        throw ObjectNotExistException(
-            id: current.id,
-            facet: current.facet,
-            operation: current.operation)
+        throw ObjectNotExistException()
     }
 
     func impossibleException(throw t: Bool, current _: Current) async throws -> String {


### PR DESCRIPTION
This PR fixes the throwing of ObjectNotExistException, FacetNotExistException and OperationNotExistException.

Most of the time, you don't need to / should not specify id/facet/operation as they are filled-in automatically when the exception is encoded.

Fixes #2971.