### PR TITLE
No need to destroy endpoint factories in JavaScript

### DIFF
--- a/js/src/Ice/EndpointFactoryManager.js
+++ b/js/src/Ice/EndpointFactoryManager.js
@@ -110,9 +110,4 @@ export class EndpointFactoryManager {
         s.endEncapsulation();
         return e;
     }
-
-    destroy() {
-        this._factories.forEach(factory => factory.destroy());
-        this._factories = [];
-    }
 }

--- a/js/src/Ice/InstanceExtensions.js
+++ b/js/src/Ice/InstanceExtensions.js
@@ -360,9 +360,6 @@ Instance.prototype.destroy = async function () {
         if (this._locatorManager) {
             this._locatorManager.destroy();
         }
-        if (this._endpointFactoryManager) {
-            this._endpointFactoryManager.destroy();
-        }
 
         if (this._initData.properties.getPropertyAsInt("Ice.Warn.UnusedProperties") > 0) {
             const unusedProperties = this._initData.properties.getUnusedProperties();

--- a/js/src/Ice/TcpEndpointFactory.js
+++ b/js/src/Ice/TcpEndpointFactory.js
@@ -29,10 +29,6 @@ export class TcpEndpointFactory {
         return e;
     }
 
-    destroy() {
-        this._instance = null;
-    }
-
     clone(instance) {
         return new TcpEndpointFactory(instance);
     }

--- a/js/src/Ice/WSEndpointFactory.js
+++ b/js/src/Ice/WSEndpointFactory.js
@@ -29,9 +29,4 @@ export class WSEndpointFactory {
         e.initWithStream(s);
         return e;
     }
-
-    destroy() {
-        this._delegate.destroy();
-        this._instance = null;
-    }
 }


### PR DESCRIPTION
This PR removes `destroy` method of JavaScript endpoint factories, and endpoint factory manager. This was already fixed in other languages in https://github.com/zeroc-ice/ice/pull/2784