### PR TITLE
Improve the Parser's API and Storage of Metadata

### DIFF
--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -1778,7 +1778,7 @@ yyreduce:
     auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[0]);
     if (!metadata->v.empty())
     {
-        currentUnit->addFileMetadata(metadata->v);
+        currentUnit->addFileMetadata(std::move(metadata->v));
     }
 }
 #line 1785 "src/Slice/Grammar.cpp"
@@ -1791,7 +1791,7 @@ yyreduce:
     auto contained = dynamic_pointer_cast<Contained>(yyvsp[0]);
     if (contained && !metadata->v.empty())
     {
-        contained->setMetadata(metadata->v);
+        contained->setMetadata(std::move(metadata->v));
     }
 }
 #line 1798 "src/Slice/Grammar.cpp"
@@ -2672,7 +2672,7 @@ yyreduce:
     auto contained = dynamic_pointer_cast<Contained>(yyvsp[-2]);
     if (contained && !metadata->v.empty())
     {
-        contained->setMetadata(metadata->v);
+        contained->setMetadata(std::move(metadata->v));
     }
 }
 #line 2679 "src/Slice/Grammar.cpp"
@@ -3223,7 +3223,7 @@ yyreduce:
     auto contained = dynamic_pointer_cast<Contained>(yyvsp[-2]);
     if (contained && !metadata->v.empty())
     {
-        contained->setMetadata(metadata->v);
+        contained->setMetadata(std::move(metadata->v));
     }
 }
 #line 3230 "src/Slice/Grammar.cpp"
@@ -3306,7 +3306,7 @@ yyreduce:
     auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-3]);
     auto type = dynamic_pointer_cast<Type>(yyvsp[-2]);
     ContainerPtr cont = currentUnit->currentContainer();
-    yyval = cont->createSequence(ident->v, type, metadata->v);
+    yyval = cont->createSequence(ident->v, type, std::move(metadata->v));
 }
 #line 3312 "src/Slice/Grammar.cpp"
     break;
@@ -3318,7 +3318,7 @@ yyreduce:
     auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-3]);
     auto type = dynamic_pointer_cast<Type>(yyvsp[-2]);
     ContainerPtr cont = currentUnit->currentContainer();
-    yyval = cont->createSequence(ident->v, type, metadata->v); // Dummy
+    yyval = cont->createSequence(ident->v, type, std::move(metadata->v)); // Dummy
     currentUnit->error("keyword `" + ident->v + "' cannot be used as sequence name");
 }
 #line 3325 "src/Slice/Grammar.cpp"
@@ -3333,7 +3333,7 @@ yyreduce:
     auto valueMetadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-3]);
     auto valueType = dynamic_pointer_cast<Type>(yyvsp[-2]);
     ContainerPtr cont = currentUnit->currentContainer();
-    yyval = cont->createDictionary(ident->v, keyType, keyMetadata->v, valueType, valueMetadata->v);
+    yyval = cont->createDictionary(ident->v, keyType, std::move(keyMetadata->v), valueType, std::move(valueMetadata->v));
 }
 #line 3339 "src/Slice/Grammar.cpp"
     break;
@@ -3347,7 +3347,7 @@ yyreduce:
     auto valueMetadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-3]);
     auto valueType = dynamic_pointer_cast<Type>(yyvsp[-2]);
     ContainerPtr cont = currentUnit->currentContainer();
-    yyval = cont->createDictionary(ident->v, keyType, keyMetadata->v, valueType, valueMetadata->v); // Dummy
+    yyval = cont->createDictionary(ident->v, keyType, std::move(keyMetadata->v), valueType, std::move(valueMetadata->v)); // Dummy
     currentUnit->error("keyword `" + ident->v + "' cannot be used as dictionary name");
 }
 #line 3354 "src/Slice/Grammar.cpp"
@@ -3437,7 +3437,7 @@ yyreduce:
     auto enumerator = dynamic_pointer_cast<Enumerator>(yyvsp[-2]);
     if (enumerator && !metadata->v.empty())
     {
-        enumerator->setMetadata(metadata->v);
+        enumerator->setMetadata(std::move(metadata->v));
     }
     auto enumeratorList = dynamic_pointer_cast<EnumeratorListTok>(yyvsp[0]);
     enumeratorList->v.push_front(enumerator);
@@ -3453,7 +3453,7 @@ yyreduce:
     auto enumerator = dynamic_pointer_cast<Enumerator>(yyvsp[0]);
     if (enumerator && !metadata->v.empty())
     {
-        enumerator->setMetadata(metadata->v);
+        enumerator->setMetadata(std::move(metadata->v));
     }
     auto enumeratorList = make_shared<EnumeratorListTok>();
     enumeratorList->v.push_front(enumerator);
@@ -3601,7 +3601,7 @@ yyreduce:
         auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-1]);
         if (!metadata->v.empty())
         {
-            pd->setMetadata(metadata->v);
+            pd->setMetadata(std::move(metadata->v));
         }
     }
 }
@@ -3621,7 +3621,7 @@ yyreduce:
         auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-1]);
         if (!metadata->v.empty())
         {
-            pd->setMetadata(metadata->v);
+            pd->setMetadata(std::move(metadata->v));
         }
     }
 }
@@ -4017,7 +4017,7 @@ yyreduce:
     auto const_type = dynamic_pointer_cast<Type>(yyvsp[-3]);
     auto ident = dynamic_pointer_cast<StringTok>(yyvsp[-2]);
     auto value = dynamic_pointer_cast<ConstDefTok>(yyvsp[0]);
-    yyval = currentUnit->currentContainer()->createConst(ident->v, const_type, metadata->v, value->v,
+    yyval = currentUnit->currentContainer()->createConst(ident->v, const_type, std::move(metadata->v), value->v,
                                                       value->valueAsString);
 }
 #line 4024 "src/Slice/Grammar.cpp"
@@ -4030,8 +4030,8 @@ yyreduce:
     auto const_type = dynamic_pointer_cast<Type>(yyvsp[-2]);
     auto value = dynamic_pointer_cast<ConstDefTok>(yyvsp[0]);
     currentUnit->error("missing constant name");
-    yyval = currentUnit->currentContainer()->createConst(Ice::generateUUID(), const_type, metadata->v, value->v,
-                                                      value->valueAsString, Dummy); // Dummy
+    yyval = currentUnit->currentContainer()->createConst(Ice::generateUUID(), const_type, std::move(metadata->v),
+                                                      value->v, value->valueAsString, Dummy); // Dummy
 }
 #line 4037 "src/Slice/Grammar.cpp"
     break;

--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -320,7 +320,7 @@ enum yysymbol_kind_t
   YYSYMBOL_builtin = 124,                  /* builtin  */
   YYSYMBOL_type = 125,                     /* type  */
   YYSYMBOL_string_literal = 126,           /* string_literal  */
-  YYSYMBOL_string_list = 127,              /* string_list  */
+  YYSYMBOL_metadata_list = 127,            /* metadata_list  */
   YYSYMBOL_const_initializer = 128,        /* const_initializer  */
   YYSYMBOL_const_def = 129,                /* const_def  */
   YYSYMBOL_keyword = 130                   /* keyword  */
@@ -742,11 +742,11 @@ static const yytype_int16 yyrline[] =
     1671,  1680,  1686,  1704,  1716,  1720,  1761,  1767,  1778,  1781,
     1797,  1813,  1825,  1837,  1848,  1864,  1868,  1877,  1880,  1888,
     1889,  1890,  1891,  1892,  1893,  1894,  1895,  1896,  1897,  1902,
-    1906,  1911,  1942,  1978,  1984,  1992,  1999,  2011,  2020,  2029,
-    2064,  2071,  2078,  2090,  2099,  2113,  2114,  2115,  2116,  2117,
-    2118,  2119,  2120,  2121,  2122,  2123,  2124,  2125,  2126,  2127,
-    2128,  2129,  2130,  2131,  2132,  2133,  2134,  2135,  2136,  2137,
-    2138,  2139
+    1906,  1911,  1942,  1978,  1984,  1992,  2002,  2017,  2026,  2035,
+    2070,  2077,  2084,  2096,  2104,  2118,  2119,  2120,  2121,  2122,
+    2123,  2124,  2125,  2126,  2127,  2128,  2129,  2130,  2131,  2132,
+    2133,  2134,  2135,  2136,  2137,  2138,  2139,  2140,  2141,  2142,
+    2143,  2144
 };
 #endif
 
@@ -787,7 +787,7 @@ static const char *const yytname[] =
   "sequence_def", "dictionary_def", "enum_id", "enum_def", "@22", "@23",
   "enumerator_list", "enumerator", "enumerator_initializer",
   "out_qualifier", "parameters", "throws", "scoped_name", "builtin",
-  "type", "string_literal", "string_list", "const_initializer",
+  "type", "string_literal", "metadata_list", "const_initializer",
   "const_def", "keyword", YY_NULLPTR
 };
 
@@ -1748,7 +1748,7 @@ yyreduce:
 #line 1749 "src/Slice/Grammar.cpp"
     break;
 
-  case 5: /* file_metadata: ICE_FILE_METADATA_OPEN string_list ICE_FILE_METADATA_CLOSE  */
+  case 5: /* file_metadata: ICE_FILE_METADATA_OPEN metadata_list ICE_FILE_METADATA_CLOSE  */
 #line 202 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[-1];
@@ -1756,7 +1756,7 @@ yyreduce:
 #line 1757 "src/Slice/Grammar.cpp"
     break;
 
-  case 6: /* metadata: ICE_METADATA_OPEN string_list ICE_METADATA_CLOSE  */
+  case 6: /* metadata: ICE_METADATA_OPEN metadata_list ICE_METADATA_CLOSE  */
 #line 211 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[-1];
@@ -1767,7 +1767,7 @@ yyreduce:
   case 7: /* metadata: %empty  */
 #line 215 "src/Slice/Grammar.y"
 {
-    yyval = make_shared<StringListTok>();
+    yyval = make_shared<MetadataList>();
 }
 #line 1773 "src/Slice/Grammar.cpp"
     break;
@@ -1775,10 +1775,10 @@ yyreduce:
   case 8: /* definitions: definitions file_metadata  */
 #line 224 "src/Slice/Grammar.y"
 {
-    auto metadata = dynamic_pointer_cast<StringListTok>(yyvsp[0]);
-    if (!metadata->v.empty())
+    auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[0]);
+    if (!metadata->empty())
     {
-        currentUnit->addFileMetadata(metadata->v);
+        currentUnit->addFileMetadata(metadata);
     }
 }
 #line 1785 "src/Slice/Grammar.cpp"
@@ -1787,11 +1787,11 @@ yyreduce:
   case 9: /* definitions: definitions metadata definition  */
 #line 232 "src/Slice/Grammar.y"
 {
-    auto metadata = dynamic_pointer_cast<StringListTok>(yyvsp[-1]);
+    auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-1]);
     auto contained = dynamic_pointer_cast<Contained>(yyvsp[0]);
-    if (contained && !metadata->v.empty())
+    if (contained && !metadata->empty())
     {
-        contained->setMetadata(metadata->v);
+        contained->setMetadata(metadata);
     }
 }
 #line 1798 "src/Slice/Grammar.cpp"
@@ -2668,11 +2668,11 @@ yyreduce:
   case 80: /* data_members: metadata data_member ';' data_members  */
 #line 989 "src/Slice/Grammar.y"
 {
-    auto metadata = dynamic_pointer_cast<StringListTok>(yyvsp[-3]);
+    auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-3]);
     auto contained = dynamic_pointer_cast<Contained>(yyvsp[-2]);
-    if (contained && !metadata->v.empty())
+    if (contained && !metadata->empty())
     {
-        contained->setMetadata(metadata->v);
+        contained->setMetadata(metadata);
     }
 }
 #line 2679 "src/Slice/Grammar.cpp"
@@ -3219,11 +3219,11 @@ yyreduce:
   case 110: /* operations: metadata operation ';' operations  */
 #line 1470 "src/Slice/Grammar.y"
 {
-    auto metadata = dynamic_pointer_cast<StringListTok>(yyvsp[-3]);
+    auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-3]);
     auto contained = dynamic_pointer_cast<Contained>(yyvsp[-2]);
-    if (contained && !metadata->v.empty())
+    if (contained && !metadata->empty())
     {
-        contained->setMetadata(metadata->v);
+        contained->setMetadata(metadata);
     }
 }
 #line 3230 "src/Slice/Grammar.cpp"
@@ -3303,10 +3303,10 @@ yyreduce:
 #line 1536 "src/Slice/Grammar.y"
 {
     auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
-    auto metadata = dynamic_pointer_cast<StringListTok>(yyvsp[-3]);
+    auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-3]);
     auto type = dynamic_pointer_cast<Type>(yyvsp[-2]);
     ContainerPtr cont = currentUnit->currentContainer();
-    yyval = cont->createSequence(ident->v, type, metadata->v);
+    yyval = cont->createSequence(ident->v, type, metadata);
 }
 #line 3312 "src/Slice/Grammar.cpp"
     break;
@@ -3315,10 +3315,10 @@ yyreduce:
 #line 1544 "src/Slice/Grammar.y"
 {
     auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
-    auto metadata = dynamic_pointer_cast<StringListTok>(yyvsp[-3]);
+    auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-3]);
     auto type = dynamic_pointer_cast<Type>(yyvsp[-2]);
     ContainerPtr cont = currentUnit->currentContainer();
-    yyval = cont->createSequence(ident->v, type, metadata->v); // Dummy
+    yyval = cont->createSequence(ident->v, type, metadata); // Dummy
     currentUnit->error("keyword `" + ident->v + "' cannot be used as sequence name");
 }
 #line 3325 "src/Slice/Grammar.cpp"
@@ -3328,12 +3328,12 @@ yyreduce:
 #line 1558 "src/Slice/Grammar.y"
 {
     auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
-    auto keyMetadata = dynamic_pointer_cast<StringListTok>(yyvsp[-6]);
+    auto keyMetadata = dynamic_pointer_cast<MetadataList>(yyvsp[-6]);
     auto keyType = dynamic_pointer_cast<Type>(yyvsp[-5]);
-    auto valueMetadata = dynamic_pointer_cast<StringListTok>(yyvsp[-3]);
+    auto valueMetadata = dynamic_pointer_cast<MetadataList>(yyvsp[-3]);
     auto valueType = dynamic_pointer_cast<Type>(yyvsp[-2]);
     ContainerPtr cont = currentUnit->currentContainer();
-    yyval = cont->createDictionary(ident->v, keyType, keyMetadata->v, valueType, valueMetadata->v);
+    yyval = cont->createDictionary(ident->v, keyType, keyMetadata, valueType, valueMetadata);
 }
 #line 3339 "src/Slice/Grammar.cpp"
     break;
@@ -3342,12 +3342,12 @@ yyreduce:
 #line 1568 "src/Slice/Grammar.y"
 {
     auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
-    auto keyMetadata = dynamic_pointer_cast<StringListTok>(yyvsp[-6]);
+    auto keyMetadata = dynamic_pointer_cast<MetadataList>(yyvsp[-6]);
     auto keyType = dynamic_pointer_cast<Type>(yyvsp[-5]);
-    auto valueMetadata = dynamic_pointer_cast<StringListTok>(yyvsp[-3]);
+    auto valueMetadata = dynamic_pointer_cast<MetadataList>(yyvsp[-3]);
     auto valueType = dynamic_pointer_cast<Type>(yyvsp[-2]);
     ContainerPtr cont = currentUnit->currentContainer();
-    yyval = cont->createDictionary(ident->v, keyType, keyMetadata->v, valueType, valueMetadata->v); // Dummy
+    yyval = cont->createDictionary(ident->v, keyType, keyMetadata, valueType, valueMetadata); // Dummy
     currentUnit->error("keyword `" + ident->v + "' cannot be used as dictionary name");
 }
 #line 3354 "src/Slice/Grammar.cpp"
@@ -3433,11 +3433,11 @@ yyreduce:
   case 128: /* enumerator_list: metadata enumerator ',' enumerator_list  */
 #line 1648 "src/Slice/Grammar.y"
 {
-    auto metadata = dynamic_pointer_cast<StringListTok>(yyvsp[-3]);
+    auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-3]);
     auto enumerator = dynamic_pointer_cast<Enumerator>(yyvsp[-2]);
-    if (enumerator && !metadata->v.empty())
+    if (enumerator && !metadata->empty())
     {
-        enumerator->setMetadata(metadata->v);
+        enumerator->setMetadata(metadata);
     }
     auto enumeratorList = dynamic_pointer_cast<EnumeratorListTok>(yyvsp[0]);
     enumeratorList->v.push_front(enumerator);
@@ -3449,11 +3449,11 @@ yyreduce:
   case 129: /* enumerator_list: metadata enumerator  */
 #line 1660 "src/Slice/Grammar.y"
 {
-    auto metadata = dynamic_pointer_cast<StringListTok>(yyvsp[-1]);
+    auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-1]);
     auto enumerator = dynamic_pointer_cast<Enumerator>(yyvsp[0]);
-    if (enumerator && !metadata->v.empty())
+    if (enumerator && !metadata->empty())
     {
-        enumerator->setMetadata(metadata->v);
+        enumerator->setMetadata(metadata);
     }
     auto enumeratorList = make_shared<EnumeratorListTok>();
     enumeratorList->v.push_front(enumerator);
@@ -3598,10 +3598,10 @@ yyreduce:
     {
         ParamDeclPtr pd = op->createParamDecl(tsp->name, tsp->type, isOutParam->v, tsp->isOptional, tsp->tag);
         currentUnit->currentContainer()->checkIntroduced(tsp->name, pd);
-        auto metadata = dynamic_pointer_cast<StringListTok>(yyvsp[-1]);
-        if (!metadata->v.empty())
+        auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-1]);
+        if (!metadata->empty())
         {
-            pd->setMetadata(metadata->v);
+            pd->setMetadata(metadata);
         }
     }
 }
@@ -3618,10 +3618,10 @@ yyreduce:
     {
         ParamDeclPtr pd = op->createParamDecl(tsp->name, tsp->type, isOutParam->v, tsp->isOptional, tsp->tag);
         currentUnit->currentContainer()->checkIntroduced(tsp->name, pd);
-        auto metadata = dynamic_pointer_cast<StringListTok>(yyvsp[-1]);
-        if (!metadata->v.empty())
+        auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-1]);
+        if (!metadata->empty())
         {
-            pd->setMetadata(metadata->v);
+            pd->setMetadata(metadata);
         }
     }
 }
@@ -3884,30 +3884,36 @@ yyreduce:
 #line 3885 "src/Slice/Grammar.cpp"
     break;
 
-  case 165: /* string_list: string_list ',' string_literal  */
+  case 165: /* metadata_list: metadata_list ',' string_literal  */
 #line 1993 "src/Slice/Grammar.y"
 {
     auto str = dynamic_pointer_cast<StringTok>(yyvsp[0]);
-    auto stringList = dynamic_pointer_cast<StringListTok>(yyvsp[-2]);
-    stringList->v.push_back(str->v);
-    yyval = stringList;
+    auto metadataList = dynamic_pointer_cast<MetadataList>(yyvsp[-2]);
+
+    auto metadata = make_shared<Metadata>(str->v, currentUnit);
+    metadataList->push_back(metadata);
+
+    yyval = metadataList;
 }
-#line 3896 "src/Slice/Grammar.cpp"
+#line 3899 "src/Slice/Grammar.cpp"
     break;
 
-  case 166: /* string_list: string_literal  */
-#line 2000 "src/Slice/Grammar.y"
+  case 166: /* metadata_list: string_literal  */
+#line 2003 "src/Slice/Grammar.y"
 {
     auto str = dynamic_pointer_cast<StringTok>(yyvsp[0]);
-    auto stringList = make_shared<StringListTok>();
-    stringList->v.push_back(str->v);
-    yyval = stringList;
+    auto metadataList = make_shared<MetadataList>();
+
+    auto metadata = make_shared<Metadata>(str->v, currentUnit);
+    metadataList->push_back(metadata);
+
+    yyval = metadataList;
 }
-#line 3907 "src/Slice/Grammar.cpp"
+#line 3913 "src/Slice/Grammar.cpp"
     break;
 
   case 167: /* const_initializer: ICE_INTEGER_LITERAL  */
-#line 2012 "src/Slice/Grammar.y"
+#line 2018 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindLong);
     auto intVal = dynamic_pointer_cast<IntegerTok>(yyvsp[0]);
@@ -3916,11 +3922,11 @@ yyreduce:
     auto def = make_shared<ConstDefTok>(type, sstr.str());
     yyval = def;
 }
-#line 3920 "src/Slice/Grammar.cpp"
+#line 3926 "src/Slice/Grammar.cpp"
     break;
 
   case 168: /* const_initializer: ICE_FLOATING_POINT_LITERAL  */
-#line 2021 "src/Slice/Grammar.y"
+#line 2027 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindDouble);
     auto floatVal = dynamic_pointer_cast<FloatingTok>(yyvsp[0]);
@@ -3929,11 +3935,11 @@ yyreduce:
     auto def = make_shared<ConstDefTok>(type, sstr.str());
     yyval = def;
 }
-#line 3933 "src/Slice/Grammar.cpp"
+#line 3939 "src/Slice/Grammar.cpp"
     break;
 
   case 169: /* const_initializer: scoped_name  */
-#line 2030 "src/Slice/Grammar.y"
+#line 2036 "src/Slice/Grammar.y"
 {
     auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
     ConstDefTokPtr def;
@@ -3968,232 +3974,231 @@ yyreduce:
     }
     yyval = def;
 }
-#line 3972 "src/Slice/Grammar.cpp"
+#line 3978 "src/Slice/Grammar.cpp"
     break;
 
   case 170: /* const_initializer: ICE_STRING_LITERAL  */
-#line 2065 "src/Slice/Grammar.y"
+#line 2071 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindString);
     auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
     auto def = make_shared<ConstDefTok>(type, literal->v);
     yyval = def;
 }
-#line 3983 "src/Slice/Grammar.cpp"
+#line 3989 "src/Slice/Grammar.cpp"
     break;
 
   case 171: /* const_initializer: ICE_FALSE  */
-#line 2072 "src/Slice/Grammar.y"
+#line 2078 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindBool);
     auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
     auto def = make_shared<ConstDefTok>(type, "false");
     yyval = def;
 }
-#line 3994 "src/Slice/Grammar.cpp"
+#line 4000 "src/Slice/Grammar.cpp"
     break;
 
   case 172: /* const_initializer: ICE_TRUE  */
-#line 2079 "src/Slice/Grammar.y"
+#line 2085 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindBool);
     auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
     auto def = make_shared<ConstDefTok>(type, "true");
     yyval = def;
 }
-#line 4005 "src/Slice/Grammar.cpp"
+#line 4011 "src/Slice/Grammar.cpp"
     break;
 
   case 173: /* const_def: ICE_CONST metadata type ICE_IDENTIFIER '=' const_initializer  */
-#line 2091 "src/Slice/Grammar.y"
+#line 2097 "src/Slice/Grammar.y"
 {
-    auto metadata = dynamic_pointer_cast<StringListTok>(yyvsp[-4]);
+    auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-4]);
     auto const_type = dynamic_pointer_cast<Type>(yyvsp[-3]);
     auto ident = dynamic_pointer_cast<StringTok>(yyvsp[-2]);
     auto value = dynamic_pointer_cast<ConstDefTok>(yyvsp[0]);
-    yyval = currentUnit->currentContainer()->createConst(ident->v, const_type, metadata->v, value->v,
-                                                      value->valueAsString);
+    yyval = currentUnit->currentContainer()->createConst(ident->v, const_type, metadata, value->v, value->valueAsString);
 }
-#line 4018 "src/Slice/Grammar.cpp"
+#line 4023 "src/Slice/Grammar.cpp"
     break;
 
   case 174: /* const_def: ICE_CONST metadata type '=' const_initializer  */
-#line 2100 "src/Slice/Grammar.y"
+#line 2105 "src/Slice/Grammar.y"
 {
-    auto metadata = dynamic_pointer_cast<StringListTok>(yyvsp[-3]);
+    auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-3]);
     auto const_type = dynamic_pointer_cast<Type>(yyvsp[-2]);
     auto value = dynamic_pointer_cast<ConstDefTok>(yyvsp[0]);
     currentUnit->error("missing constant name");
-    yyval = currentUnit->currentContainer()->createConst(Ice::generateUUID(), const_type, metadata->v, value->v,
+    yyval = currentUnit->currentContainer()->createConst(Ice::generateUUID(), const_type, metadata, value->v,
                                                       value->valueAsString, Dummy); // Dummy
 }
-#line 4031 "src/Slice/Grammar.cpp"
+#line 4036 "src/Slice/Grammar.cpp"
     break;
 
   case 175: /* keyword: ICE_MODULE  */
-#line 2113 "src/Slice/Grammar.y"
+#line 2118 "src/Slice/Grammar.y"
              {}
-#line 4037 "src/Slice/Grammar.cpp"
+#line 4042 "src/Slice/Grammar.cpp"
     break;
 
   case 176: /* keyword: ICE_CLASS  */
-#line 2114 "src/Slice/Grammar.y"
+#line 2119 "src/Slice/Grammar.y"
             {}
-#line 4043 "src/Slice/Grammar.cpp"
+#line 4048 "src/Slice/Grammar.cpp"
     break;
 
   case 177: /* keyword: ICE_INTERFACE  */
-#line 2115 "src/Slice/Grammar.y"
+#line 2120 "src/Slice/Grammar.y"
                 {}
-#line 4049 "src/Slice/Grammar.cpp"
+#line 4054 "src/Slice/Grammar.cpp"
     break;
 
   case 178: /* keyword: ICE_EXCEPTION  */
-#line 2116 "src/Slice/Grammar.y"
+#line 2121 "src/Slice/Grammar.y"
                 {}
-#line 4055 "src/Slice/Grammar.cpp"
+#line 4060 "src/Slice/Grammar.cpp"
     break;
 
   case 179: /* keyword: ICE_STRUCT  */
-#line 2117 "src/Slice/Grammar.y"
+#line 2122 "src/Slice/Grammar.y"
              {}
-#line 4061 "src/Slice/Grammar.cpp"
+#line 4066 "src/Slice/Grammar.cpp"
     break;
 
   case 180: /* keyword: ICE_SEQUENCE  */
-#line 2118 "src/Slice/Grammar.y"
+#line 2123 "src/Slice/Grammar.y"
                {}
-#line 4067 "src/Slice/Grammar.cpp"
+#line 4072 "src/Slice/Grammar.cpp"
     break;
 
   case 181: /* keyword: ICE_DICTIONARY  */
-#line 2119 "src/Slice/Grammar.y"
+#line 2124 "src/Slice/Grammar.y"
                  {}
-#line 4073 "src/Slice/Grammar.cpp"
+#line 4078 "src/Slice/Grammar.cpp"
     break;
 
   case 182: /* keyword: ICE_ENUM  */
-#line 2120 "src/Slice/Grammar.y"
+#line 2125 "src/Slice/Grammar.y"
            {}
-#line 4079 "src/Slice/Grammar.cpp"
+#line 4084 "src/Slice/Grammar.cpp"
     break;
 
   case 183: /* keyword: ICE_OUT  */
-#line 2121 "src/Slice/Grammar.y"
+#line 2126 "src/Slice/Grammar.y"
           {}
-#line 4085 "src/Slice/Grammar.cpp"
+#line 4090 "src/Slice/Grammar.cpp"
     break;
 
   case 184: /* keyword: ICE_EXTENDS  */
-#line 2122 "src/Slice/Grammar.y"
+#line 2127 "src/Slice/Grammar.y"
               {}
-#line 4091 "src/Slice/Grammar.cpp"
+#line 4096 "src/Slice/Grammar.cpp"
     break;
 
   case 185: /* keyword: ICE_THROWS  */
-#line 2123 "src/Slice/Grammar.y"
+#line 2128 "src/Slice/Grammar.y"
              {}
-#line 4097 "src/Slice/Grammar.cpp"
+#line 4102 "src/Slice/Grammar.cpp"
     break;
 
   case 186: /* keyword: ICE_VOID  */
-#line 2124 "src/Slice/Grammar.y"
+#line 2129 "src/Slice/Grammar.y"
            {}
-#line 4103 "src/Slice/Grammar.cpp"
+#line 4108 "src/Slice/Grammar.cpp"
     break;
 
   case 187: /* keyword: ICE_BOOL  */
-#line 2125 "src/Slice/Grammar.y"
+#line 2130 "src/Slice/Grammar.y"
            {}
-#line 4109 "src/Slice/Grammar.cpp"
+#line 4114 "src/Slice/Grammar.cpp"
     break;
 
   case 188: /* keyword: ICE_BYTE  */
-#line 2126 "src/Slice/Grammar.y"
+#line 2131 "src/Slice/Grammar.y"
            {}
-#line 4115 "src/Slice/Grammar.cpp"
+#line 4120 "src/Slice/Grammar.cpp"
     break;
 
   case 189: /* keyword: ICE_SHORT  */
-#line 2127 "src/Slice/Grammar.y"
+#line 2132 "src/Slice/Grammar.y"
             {}
-#line 4121 "src/Slice/Grammar.cpp"
+#line 4126 "src/Slice/Grammar.cpp"
     break;
 
   case 190: /* keyword: ICE_INT  */
-#line 2128 "src/Slice/Grammar.y"
+#line 2133 "src/Slice/Grammar.y"
           {}
-#line 4127 "src/Slice/Grammar.cpp"
+#line 4132 "src/Slice/Grammar.cpp"
     break;
 
   case 191: /* keyword: ICE_LONG  */
-#line 2129 "src/Slice/Grammar.y"
+#line 2134 "src/Slice/Grammar.y"
            {}
-#line 4133 "src/Slice/Grammar.cpp"
+#line 4138 "src/Slice/Grammar.cpp"
     break;
 
   case 192: /* keyword: ICE_FLOAT  */
-#line 2130 "src/Slice/Grammar.y"
+#line 2135 "src/Slice/Grammar.y"
             {}
-#line 4139 "src/Slice/Grammar.cpp"
+#line 4144 "src/Slice/Grammar.cpp"
     break;
 
   case 193: /* keyword: ICE_DOUBLE  */
-#line 2131 "src/Slice/Grammar.y"
+#line 2136 "src/Slice/Grammar.y"
              {}
-#line 4145 "src/Slice/Grammar.cpp"
+#line 4150 "src/Slice/Grammar.cpp"
     break;
 
   case 194: /* keyword: ICE_STRING  */
-#line 2132 "src/Slice/Grammar.y"
+#line 2137 "src/Slice/Grammar.y"
              {}
-#line 4151 "src/Slice/Grammar.cpp"
+#line 4156 "src/Slice/Grammar.cpp"
     break;
 
   case 195: /* keyword: ICE_OBJECT  */
-#line 2133 "src/Slice/Grammar.y"
+#line 2138 "src/Slice/Grammar.y"
              {}
-#line 4157 "src/Slice/Grammar.cpp"
+#line 4162 "src/Slice/Grammar.cpp"
     break;
 
   case 196: /* keyword: ICE_CONST  */
-#line 2134 "src/Slice/Grammar.y"
+#line 2139 "src/Slice/Grammar.y"
             {}
-#line 4163 "src/Slice/Grammar.cpp"
+#line 4168 "src/Slice/Grammar.cpp"
     break;
 
   case 197: /* keyword: ICE_FALSE  */
-#line 2135 "src/Slice/Grammar.y"
+#line 2140 "src/Slice/Grammar.y"
             {}
-#line 4169 "src/Slice/Grammar.cpp"
+#line 4174 "src/Slice/Grammar.cpp"
     break;
 
   case 198: /* keyword: ICE_TRUE  */
-#line 2136 "src/Slice/Grammar.y"
+#line 2141 "src/Slice/Grammar.y"
            {}
-#line 4175 "src/Slice/Grammar.cpp"
+#line 4180 "src/Slice/Grammar.cpp"
     break;
 
   case 199: /* keyword: ICE_IDEMPOTENT  */
-#line 2137 "src/Slice/Grammar.y"
+#line 2142 "src/Slice/Grammar.y"
                  {}
-#line 4181 "src/Slice/Grammar.cpp"
+#line 4186 "src/Slice/Grammar.cpp"
     break;
 
   case 200: /* keyword: ICE_OPTIONAL  */
-#line 2138 "src/Slice/Grammar.y"
+#line 2143 "src/Slice/Grammar.y"
                {}
-#line 4187 "src/Slice/Grammar.cpp"
+#line 4192 "src/Slice/Grammar.cpp"
     break;
 
   case 201: /* keyword: ICE_VALUE  */
-#line 2139 "src/Slice/Grammar.y"
+#line 2144 "src/Slice/Grammar.y"
             {}
-#line 4193 "src/Slice/Grammar.cpp"
+#line 4198 "src/Slice/Grammar.cpp"
     break;
 
 
-#line 4197 "src/Slice/Grammar.cpp"
+#line 4202 "src/Slice/Grammar.cpp"
 
       default: break;
     }
@@ -4391,5 +4396,5 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 2142 "src/Slice/Grammar.y"
+#line 2147 "src/Slice/Grammar.y"
 

--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -743,10 +743,10 @@ static const yytype_int16 yyrline[] =
     1797,  1813,  1825,  1837,  1848,  1864,  1868,  1877,  1880,  1888,
     1889,  1890,  1891,  1892,  1893,  1894,  1895,  1896,  1897,  1902,
     1906,  1911,  1942,  1978,  1984,  1992,  2002,  2017,  2026,  2035,
-    2070,  2077,  2084,  2096,  2104,  2118,  2119,  2120,  2121,  2122,
-    2123,  2124,  2125,  2126,  2127,  2128,  2129,  2130,  2131,  2132,
-    2133,  2134,  2135,  2136,  2137,  2138,  2139,  2140,  2141,  2142,
-    2143,  2144
+    2070,  2077,  2084,  2096,  2105,  2119,  2120,  2121,  2122,  2123,
+    2124,  2125,  2126,  2127,  2128,  2129,  2130,  2131,  2132,  2133,
+    2134,  2135,  2136,  2137,  2138,  2139,  2140,  2141,  2142,  2143,
+    2144,  2145
 };
 #endif
 
@@ -1767,7 +1767,7 @@ yyreduce:
   case 7: /* metadata: %empty  */
 #line 215 "src/Slice/Grammar.y"
 {
-    yyval = make_shared<MetadataList>();
+    yyval = make_shared<MetadataListTok>();
 }
 #line 1773 "src/Slice/Grammar.cpp"
     break;
@@ -1775,10 +1775,10 @@ yyreduce:
   case 8: /* definitions: definitions file_metadata  */
 #line 224 "src/Slice/Grammar.y"
 {
-    auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[0]);
-    if (!metadata->empty())
+    auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[0]);
+    if (!metadata->v.empty())
     {
-        currentUnit->addFileMetadata(metadata);
+        currentUnit->addFileMetadata(metadata->v);
     }
 }
 #line 1785 "src/Slice/Grammar.cpp"
@@ -1787,11 +1787,11 @@ yyreduce:
   case 9: /* definitions: definitions metadata definition  */
 #line 232 "src/Slice/Grammar.y"
 {
-    auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-1]);
+    auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-1]);
     auto contained = dynamic_pointer_cast<Contained>(yyvsp[0]);
-    if (contained && !metadata->empty())
+    if (contained && !metadata->v.empty())
     {
-        contained->setMetadata(metadata);
+        contained->setMetadata(metadata->v);
     }
 }
 #line 1798 "src/Slice/Grammar.cpp"
@@ -2668,11 +2668,11 @@ yyreduce:
   case 80: /* data_members: metadata data_member ';' data_members  */
 #line 989 "src/Slice/Grammar.y"
 {
-    auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-3]);
+    auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-3]);
     auto contained = dynamic_pointer_cast<Contained>(yyvsp[-2]);
-    if (contained && !metadata->empty())
+    if (contained && !metadata->v.empty())
     {
-        contained->setMetadata(metadata);
+        contained->setMetadata(metadata->v);
     }
 }
 #line 2679 "src/Slice/Grammar.cpp"
@@ -3219,11 +3219,11 @@ yyreduce:
   case 110: /* operations: metadata operation ';' operations  */
 #line 1470 "src/Slice/Grammar.y"
 {
-    auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-3]);
+    auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-3]);
     auto contained = dynamic_pointer_cast<Contained>(yyvsp[-2]);
-    if (contained && !metadata->empty())
+    if (contained && !metadata->v.empty())
     {
-        contained->setMetadata(metadata);
+        contained->setMetadata(metadata->v);
     }
 }
 #line 3230 "src/Slice/Grammar.cpp"
@@ -3303,10 +3303,10 @@ yyreduce:
 #line 1536 "src/Slice/Grammar.y"
 {
     auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
-    auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-3]);
+    auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-3]);
     auto type = dynamic_pointer_cast<Type>(yyvsp[-2]);
     ContainerPtr cont = currentUnit->currentContainer();
-    yyval = cont->createSequence(ident->v, type, metadata);
+    yyval = cont->createSequence(ident->v, type, metadata->v);
 }
 #line 3312 "src/Slice/Grammar.cpp"
     break;
@@ -3315,10 +3315,10 @@ yyreduce:
 #line 1544 "src/Slice/Grammar.y"
 {
     auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
-    auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-3]);
+    auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-3]);
     auto type = dynamic_pointer_cast<Type>(yyvsp[-2]);
     ContainerPtr cont = currentUnit->currentContainer();
-    yyval = cont->createSequence(ident->v, type, metadata); // Dummy
+    yyval = cont->createSequence(ident->v, type, metadata->v); // Dummy
     currentUnit->error("keyword `" + ident->v + "' cannot be used as sequence name");
 }
 #line 3325 "src/Slice/Grammar.cpp"
@@ -3328,12 +3328,12 @@ yyreduce:
 #line 1558 "src/Slice/Grammar.y"
 {
     auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
-    auto keyMetadata = dynamic_pointer_cast<MetadataList>(yyvsp[-6]);
+    auto keyMetadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-6]);
     auto keyType = dynamic_pointer_cast<Type>(yyvsp[-5]);
-    auto valueMetadata = dynamic_pointer_cast<MetadataList>(yyvsp[-3]);
+    auto valueMetadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-3]);
     auto valueType = dynamic_pointer_cast<Type>(yyvsp[-2]);
     ContainerPtr cont = currentUnit->currentContainer();
-    yyval = cont->createDictionary(ident->v, keyType, keyMetadata, valueType, valueMetadata);
+    yyval = cont->createDictionary(ident->v, keyType, keyMetadata->v, valueType, valueMetadata->v);
 }
 #line 3339 "src/Slice/Grammar.cpp"
     break;
@@ -3342,12 +3342,12 @@ yyreduce:
 #line 1568 "src/Slice/Grammar.y"
 {
     auto ident = dynamic_pointer_cast<StringTok>(yyvsp[0]);
-    auto keyMetadata = dynamic_pointer_cast<MetadataList>(yyvsp[-6]);
+    auto keyMetadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-6]);
     auto keyType = dynamic_pointer_cast<Type>(yyvsp[-5]);
-    auto valueMetadata = dynamic_pointer_cast<MetadataList>(yyvsp[-3]);
+    auto valueMetadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-3]);
     auto valueType = dynamic_pointer_cast<Type>(yyvsp[-2]);
     ContainerPtr cont = currentUnit->currentContainer();
-    yyval = cont->createDictionary(ident->v, keyType, keyMetadata, valueType, valueMetadata); // Dummy
+    yyval = cont->createDictionary(ident->v, keyType, keyMetadata->v, valueType, valueMetadata->v); // Dummy
     currentUnit->error("keyword `" + ident->v + "' cannot be used as dictionary name");
 }
 #line 3354 "src/Slice/Grammar.cpp"
@@ -3433,11 +3433,11 @@ yyreduce:
   case 128: /* enumerator_list: metadata enumerator ',' enumerator_list  */
 #line 1648 "src/Slice/Grammar.y"
 {
-    auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-3]);
+    auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-3]);
     auto enumerator = dynamic_pointer_cast<Enumerator>(yyvsp[-2]);
-    if (enumerator && !metadata->empty())
+    if (enumerator && !metadata->v.empty())
     {
-        enumerator->setMetadata(metadata);
+        enumerator->setMetadata(metadata->v);
     }
     auto enumeratorList = dynamic_pointer_cast<EnumeratorListTok>(yyvsp[0]);
     enumeratorList->v.push_front(enumerator);
@@ -3449,11 +3449,11 @@ yyreduce:
   case 129: /* enumerator_list: metadata enumerator  */
 #line 1660 "src/Slice/Grammar.y"
 {
-    auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-1]);
+    auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-1]);
     auto enumerator = dynamic_pointer_cast<Enumerator>(yyvsp[0]);
-    if (enumerator && !metadata->empty())
+    if (enumerator && !metadata->v.empty())
     {
-        enumerator->setMetadata(metadata);
+        enumerator->setMetadata(metadata->v);
     }
     auto enumeratorList = make_shared<EnumeratorListTok>();
     enumeratorList->v.push_front(enumerator);
@@ -3598,10 +3598,10 @@ yyreduce:
     {
         ParamDeclPtr pd = op->createParamDecl(tsp->name, tsp->type, isOutParam->v, tsp->isOptional, tsp->tag);
         currentUnit->currentContainer()->checkIntroduced(tsp->name, pd);
-        auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-1]);
-        if (!metadata->empty())
+        auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-1]);
+        if (!metadata->v.empty())
         {
-            pd->setMetadata(metadata);
+            pd->setMetadata(metadata->v);
         }
     }
 }
@@ -3618,10 +3618,10 @@ yyreduce:
     {
         ParamDeclPtr pd = op->createParamDecl(tsp->name, tsp->type, isOutParam->v, tsp->isOptional, tsp->tag);
         currentUnit->currentContainer()->checkIntroduced(tsp->name, pd);
-        auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-1]);
-        if (!metadata->empty())
+        auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-1]);
+        if (!metadata->v.empty())
         {
-            pd->setMetadata(metadata);
+            pd->setMetadata(metadata->v);
         }
     }
 }
@@ -3888,10 +3888,10 @@ yyreduce:
 #line 1993 "src/Slice/Grammar.y"
 {
     auto str = dynamic_pointer_cast<StringTok>(yyvsp[0]);
-    auto metadataList = dynamic_pointer_cast<MetadataList>(yyvsp[-2]);
+    auto metadataList = dynamic_pointer_cast<MetadataListTok>(yyvsp[-2]);
 
-    auto metadata = make_shared<Metadata>(str->v, currentUnit);
-    metadataList->push_back(metadata);
+    auto metadata = make_shared<Metadata>(str->v, currentUnit->currentFile(), currentUnit->currentLine());
+    metadataList->v.push_back(metadata);
 
     yyval = metadataList;
 }
@@ -3902,10 +3902,10 @@ yyreduce:
 #line 2003 "src/Slice/Grammar.y"
 {
     auto str = dynamic_pointer_cast<StringTok>(yyvsp[0]);
-    auto metadataList = make_shared<MetadataList>();
+    auto metadataList = make_shared<MetadataListTok>();
 
-    auto metadata = make_shared<Metadata>(str->v, currentUnit);
-    metadataList->push_back(metadata);
+    auto metadata = make_shared<Metadata>(str->v, currentUnit->currentFile(), currentUnit->currentLine());
+    metadataList->v.push_back(metadata);
 
     yyval = metadataList;
 }
@@ -4013,192 +4013,193 @@ yyreduce:
   case 173: /* const_def: ICE_CONST metadata type ICE_IDENTIFIER '=' const_initializer  */
 #line 2097 "src/Slice/Grammar.y"
 {
-    auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-4]);
+    auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-4]);
     auto const_type = dynamic_pointer_cast<Type>(yyvsp[-3]);
     auto ident = dynamic_pointer_cast<StringTok>(yyvsp[-2]);
     auto value = dynamic_pointer_cast<ConstDefTok>(yyvsp[0]);
-    yyval = currentUnit->currentContainer()->createConst(ident->v, const_type, metadata, value->v, value->valueAsString);
+    yyval = currentUnit->currentContainer()->createConst(ident->v, const_type, metadata->v, value->v,
+                                                      value->valueAsString);
 }
-#line 4023 "src/Slice/Grammar.cpp"
+#line 4024 "src/Slice/Grammar.cpp"
     break;
 
   case 174: /* const_def: ICE_CONST metadata type '=' const_initializer  */
-#line 2105 "src/Slice/Grammar.y"
+#line 2106 "src/Slice/Grammar.y"
 {
-    auto metadata = dynamic_pointer_cast<MetadataList>(yyvsp[-3]);
+    auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-3]);
     auto const_type = dynamic_pointer_cast<Type>(yyvsp[-2]);
     auto value = dynamic_pointer_cast<ConstDefTok>(yyvsp[0]);
     currentUnit->error("missing constant name");
-    yyval = currentUnit->currentContainer()->createConst(Ice::generateUUID(), const_type, metadata, value->v,
+    yyval = currentUnit->currentContainer()->createConst(Ice::generateUUID(), const_type, metadata->v, value->v,
                                                       value->valueAsString, Dummy); // Dummy
 }
-#line 4036 "src/Slice/Grammar.cpp"
+#line 4037 "src/Slice/Grammar.cpp"
     break;
 
   case 175: /* keyword: ICE_MODULE  */
-#line 2118 "src/Slice/Grammar.y"
+#line 2119 "src/Slice/Grammar.y"
              {}
-#line 4042 "src/Slice/Grammar.cpp"
+#line 4043 "src/Slice/Grammar.cpp"
     break;
 
   case 176: /* keyword: ICE_CLASS  */
-#line 2119 "src/Slice/Grammar.y"
+#line 2120 "src/Slice/Grammar.y"
             {}
-#line 4048 "src/Slice/Grammar.cpp"
+#line 4049 "src/Slice/Grammar.cpp"
     break;
 
   case 177: /* keyword: ICE_INTERFACE  */
-#line 2120 "src/Slice/Grammar.y"
+#line 2121 "src/Slice/Grammar.y"
                 {}
-#line 4054 "src/Slice/Grammar.cpp"
+#line 4055 "src/Slice/Grammar.cpp"
     break;
 
   case 178: /* keyword: ICE_EXCEPTION  */
-#line 2121 "src/Slice/Grammar.y"
+#line 2122 "src/Slice/Grammar.y"
                 {}
-#line 4060 "src/Slice/Grammar.cpp"
+#line 4061 "src/Slice/Grammar.cpp"
     break;
 
   case 179: /* keyword: ICE_STRUCT  */
-#line 2122 "src/Slice/Grammar.y"
+#line 2123 "src/Slice/Grammar.y"
              {}
-#line 4066 "src/Slice/Grammar.cpp"
+#line 4067 "src/Slice/Grammar.cpp"
     break;
 
   case 180: /* keyword: ICE_SEQUENCE  */
-#line 2123 "src/Slice/Grammar.y"
+#line 2124 "src/Slice/Grammar.y"
                {}
-#line 4072 "src/Slice/Grammar.cpp"
+#line 4073 "src/Slice/Grammar.cpp"
     break;
 
   case 181: /* keyword: ICE_DICTIONARY  */
-#line 2124 "src/Slice/Grammar.y"
+#line 2125 "src/Slice/Grammar.y"
                  {}
-#line 4078 "src/Slice/Grammar.cpp"
+#line 4079 "src/Slice/Grammar.cpp"
     break;
 
   case 182: /* keyword: ICE_ENUM  */
-#line 2125 "src/Slice/Grammar.y"
+#line 2126 "src/Slice/Grammar.y"
            {}
-#line 4084 "src/Slice/Grammar.cpp"
+#line 4085 "src/Slice/Grammar.cpp"
     break;
 
   case 183: /* keyword: ICE_OUT  */
-#line 2126 "src/Slice/Grammar.y"
+#line 2127 "src/Slice/Grammar.y"
           {}
-#line 4090 "src/Slice/Grammar.cpp"
+#line 4091 "src/Slice/Grammar.cpp"
     break;
 
   case 184: /* keyword: ICE_EXTENDS  */
-#line 2127 "src/Slice/Grammar.y"
+#line 2128 "src/Slice/Grammar.y"
               {}
-#line 4096 "src/Slice/Grammar.cpp"
+#line 4097 "src/Slice/Grammar.cpp"
     break;
 
   case 185: /* keyword: ICE_THROWS  */
-#line 2128 "src/Slice/Grammar.y"
+#line 2129 "src/Slice/Grammar.y"
              {}
-#line 4102 "src/Slice/Grammar.cpp"
+#line 4103 "src/Slice/Grammar.cpp"
     break;
 
   case 186: /* keyword: ICE_VOID  */
-#line 2129 "src/Slice/Grammar.y"
+#line 2130 "src/Slice/Grammar.y"
            {}
-#line 4108 "src/Slice/Grammar.cpp"
+#line 4109 "src/Slice/Grammar.cpp"
     break;
 
   case 187: /* keyword: ICE_BOOL  */
-#line 2130 "src/Slice/Grammar.y"
+#line 2131 "src/Slice/Grammar.y"
            {}
-#line 4114 "src/Slice/Grammar.cpp"
+#line 4115 "src/Slice/Grammar.cpp"
     break;
 
   case 188: /* keyword: ICE_BYTE  */
-#line 2131 "src/Slice/Grammar.y"
+#line 2132 "src/Slice/Grammar.y"
            {}
-#line 4120 "src/Slice/Grammar.cpp"
+#line 4121 "src/Slice/Grammar.cpp"
     break;
 
   case 189: /* keyword: ICE_SHORT  */
-#line 2132 "src/Slice/Grammar.y"
+#line 2133 "src/Slice/Grammar.y"
             {}
-#line 4126 "src/Slice/Grammar.cpp"
+#line 4127 "src/Slice/Grammar.cpp"
     break;
 
   case 190: /* keyword: ICE_INT  */
-#line 2133 "src/Slice/Grammar.y"
+#line 2134 "src/Slice/Grammar.y"
           {}
-#line 4132 "src/Slice/Grammar.cpp"
+#line 4133 "src/Slice/Grammar.cpp"
     break;
 
   case 191: /* keyword: ICE_LONG  */
-#line 2134 "src/Slice/Grammar.y"
+#line 2135 "src/Slice/Grammar.y"
            {}
-#line 4138 "src/Slice/Grammar.cpp"
+#line 4139 "src/Slice/Grammar.cpp"
     break;
 
   case 192: /* keyword: ICE_FLOAT  */
-#line 2135 "src/Slice/Grammar.y"
+#line 2136 "src/Slice/Grammar.y"
             {}
-#line 4144 "src/Slice/Grammar.cpp"
+#line 4145 "src/Slice/Grammar.cpp"
     break;
 
   case 193: /* keyword: ICE_DOUBLE  */
-#line 2136 "src/Slice/Grammar.y"
+#line 2137 "src/Slice/Grammar.y"
              {}
-#line 4150 "src/Slice/Grammar.cpp"
+#line 4151 "src/Slice/Grammar.cpp"
     break;
 
   case 194: /* keyword: ICE_STRING  */
-#line 2137 "src/Slice/Grammar.y"
+#line 2138 "src/Slice/Grammar.y"
              {}
-#line 4156 "src/Slice/Grammar.cpp"
+#line 4157 "src/Slice/Grammar.cpp"
     break;
 
   case 195: /* keyword: ICE_OBJECT  */
-#line 2138 "src/Slice/Grammar.y"
+#line 2139 "src/Slice/Grammar.y"
              {}
-#line 4162 "src/Slice/Grammar.cpp"
+#line 4163 "src/Slice/Grammar.cpp"
     break;
 
   case 196: /* keyword: ICE_CONST  */
-#line 2139 "src/Slice/Grammar.y"
+#line 2140 "src/Slice/Grammar.y"
             {}
-#line 4168 "src/Slice/Grammar.cpp"
+#line 4169 "src/Slice/Grammar.cpp"
     break;
 
   case 197: /* keyword: ICE_FALSE  */
-#line 2140 "src/Slice/Grammar.y"
+#line 2141 "src/Slice/Grammar.y"
             {}
-#line 4174 "src/Slice/Grammar.cpp"
+#line 4175 "src/Slice/Grammar.cpp"
     break;
 
   case 198: /* keyword: ICE_TRUE  */
-#line 2141 "src/Slice/Grammar.y"
+#line 2142 "src/Slice/Grammar.y"
            {}
-#line 4180 "src/Slice/Grammar.cpp"
+#line 4181 "src/Slice/Grammar.cpp"
     break;
 
   case 199: /* keyword: ICE_IDEMPOTENT  */
-#line 2142 "src/Slice/Grammar.y"
+#line 2143 "src/Slice/Grammar.y"
                  {}
-#line 4186 "src/Slice/Grammar.cpp"
+#line 4187 "src/Slice/Grammar.cpp"
     break;
 
   case 200: /* keyword: ICE_OPTIONAL  */
-#line 2143 "src/Slice/Grammar.y"
+#line 2144 "src/Slice/Grammar.y"
                {}
-#line 4192 "src/Slice/Grammar.cpp"
+#line 4193 "src/Slice/Grammar.cpp"
     break;
 
   case 201: /* keyword: ICE_VALUE  */
-#line 2144 "src/Slice/Grammar.y"
+#line 2145 "src/Slice/Grammar.y"
             {}
-#line 4198 "src/Slice/Grammar.cpp"
+#line 4199 "src/Slice/Grammar.cpp"
     break;
 
 
-#line 4202 "src/Slice/Grammar.cpp"
+#line 4203 "src/Slice/Grammar.cpp"
 
       default: break;
     }
@@ -4396,5 +4397,5 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 2147 "src/Slice/Grammar.y"
+#line 2148 "src/Slice/Grammar.y"
 

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -225,7 +225,7 @@ definitions
     auto metadata = dynamic_pointer_cast<MetadataListTok>($2);
     if (!metadata->v.empty())
     {
-        currentUnit->addFileMetadata(metadata->v);
+        currentUnit->addFileMetadata(std::move(metadata->v));
     }
 }
 | definitions metadata definition
@@ -234,7 +234,7 @@ definitions
     auto contained = dynamic_pointer_cast<Contained>($3);
     if (contained && !metadata->v.empty())
     {
-        contained->setMetadata(metadata->v);
+        contained->setMetadata(std::move(metadata->v));
     }
 }
 | %empty
@@ -991,7 +991,7 @@ data_members
     auto contained = dynamic_pointer_cast<Contained>($2);
     if (contained && !metadata->v.empty())
     {
-        contained->setMetadata(metadata->v);
+        contained->setMetadata(std::move(metadata->v));
     }
 }
 | error ';' data_members
@@ -1472,7 +1472,7 @@ operations
     auto contained = dynamic_pointer_cast<Contained>($2);
     if (contained && !metadata->v.empty())
     {
-        contained->setMetadata(metadata->v);
+        contained->setMetadata(std::move(metadata->v));
     }
 }
 | error ';' operations
@@ -1538,7 +1538,7 @@ sequence_def
     auto metadata = dynamic_pointer_cast<MetadataListTok>($3);
     auto type = dynamic_pointer_cast<Type>($4);
     ContainerPtr cont = currentUnit->currentContainer();
-    $$ = cont->createSequence(ident->v, type, metadata->v);
+    $$ = cont->createSequence(ident->v, type, std::move(metadata->v));
 }
 | ICE_SEQUENCE '<' metadata type '>' keyword
 {
@@ -1546,7 +1546,7 @@ sequence_def
     auto metadata = dynamic_pointer_cast<MetadataListTok>($3);
     auto type = dynamic_pointer_cast<Type>($4);
     ContainerPtr cont = currentUnit->currentContainer();
-    $$ = cont->createSequence(ident->v, type, metadata->v); // Dummy
+    $$ = cont->createSequence(ident->v, type, std::move(metadata->v)); // Dummy
     currentUnit->error("keyword `" + ident->v + "' cannot be used as sequence name");
 }
 ;
@@ -1562,7 +1562,7 @@ dictionary_def
     auto valueMetadata = dynamic_pointer_cast<MetadataListTok>($6);
     auto valueType = dynamic_pointer_cast<Type>($7);
     ContainerPtr cont = currentUnit->currentContainer();
-    $$ = cont->createDictionary(ident->v, keyType, keyMetadata->v, valueType, valueMetadata->v);
+    $$ = cont->createDictionary(ident->v, keyType, std::move(keyMetadata->v), valueType, std::move(valueMetadata->v));
 }
 | ICE_DICTIONARY '<' metadata type ',' metadata type '>' keyword
 {
@@ -1572,7 +1572,7 @@ dictionary_def
     auto valueMetadata = dynamic_pointer_cast<MetadataListTok>($6);
     auto valueType = dynamic_pointer_cast<Type>($7);
     ContainerPtr cont = currentUnit->currentContainer();
-    $$ = cont->createDictionary(ident->v, keyType, keyMetadata->v, valueType, valueMetadata->v); // Dummy
+    $$ = cont->createDictionary(ident->v, keyType, std::move(keyMetadata->v), valueType, std::move(valueMetadata->v)); // Dummy
     currentUnit->error("keyword `" + ident->v + "' cannot be used as dictionary name");
 }
 ;
@@ -1650,7 +1650,7 @@ enumerator_list
     auto enumerator = dynamic_pointer_cast<Enumerator>($2);
     if (enumerator && !metadata->v.empty())
     {
-        enumerator->setMetadata(metadata->v);
+        enumerator->setMetadata(std::move(metadata->v));
     }
     auto enumeratorList = dynamic_pointer_cast<EnumeratorListTok>($4);
     enumeratorList->v.push_front(enumerator);
@@ -1662,7 +1662,7 @@ enumerator_list
     auto enumerator = dynamic_pointer_cast<Enumerator>($2);
     if (enumerator && !metadata->v.empty())
     {
-        enumerator->setMetadata(metadata->v);
+        enumerator->setMetadata(std::move(metadata->v));
     }
     auto enumeratorList = make_shared<EnumeratorListTok>();
     enumeratorList->v.push_front(enumerator);
@@ -1790,7 +1790,7 @@ parameters
         auto metadata = dynamic_pointer_cast<MetadataListTok>($2);
         if (!metadata->v.empty())
         {
-            pd->setMetadata(metadata->v);
+            pd->setMetadata(std::move(metadata->v));
         }
     }
 }
@@ -1806,7 +1806,7 @@ parameters
         auto metadata = dynamic_pointer_cast<MetadataListTok>($4);
         if (!metadata->v.empty())
         {
-            pd->setMetadata(metadata->v);
+            pd->setMetadata(std::move(metadata->v));
         }
     }
 }
@@ -2099,7 +2099,7 @@ const_def
     auto const_type = dynamic_pointer_cast<Type>($3);
     auto ident = dynamic_pointer_cast<StringTok>($4);
     auto value = dynamic_pointer_cast<ConstDefTok>($6);
-    $$ = currentUnit->currentContainer()->createConst(ident->v, const_type, metadata->v, value->v,
+    $$ = currentUnit->currentContainer()->createConst(ident->v, const_type, std::move(metadata->v), value->v,
                                                       value->valueAsString);
 }
 | ICE_CONST metadata type '=' const_initializer
@@ -2108,8 +2108,8 @@ const_def
     auto const_type = dynamic_pointer_cast<Type>($3);
     auto value = dynamic_pointer_cast<ConstDefTok>($5);
     currentUnit->error("missing constant name");
-    $$ = currentUnit->currentContainer()->createConst(Ice::generateUUID(), const_type, metadata->v, value->v,
-                                                      value->valueAsString, Dummy); // Dummy
+    $$ = currentUnit->currentContainer()->createConst(Ice::generateUUID(), const_type, std::move(metadata->v),
+                                                      value->v, value->valueAsString, Dummy); // Dummy
 }
 ;
 

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -198,7 +198,7 @@ opt_semicolon
 // ----------------------------------------------------------------------
 file_metadata
 // ----------------------------------------------------------------------
-: ICE_FILE_METADATA_OPEN string_list ICE_FILE_METADATA_CLOSE
+: ICE_FILE_METADATA_OPEN metadata_list ICE_FILE_METADATA_CLOSE
 {
     $$ = $2;
 }
@@ -207,13 +207,13 @@ file_metadata
 // ----------------------------------------------------------------------
 metadata
 // ----------------------------------------------------------------------
-: ICE_METADATA_OPEN string_list ICE_METADATA_CLOSE
+: ICE_METADATA_OPEN metadata_list ICE_METADATA_CLOSE
 {
     $$ = $2;
 }
 | %empty
 {
-    $$ = make_shared<StringListTok>();
+    $$ = make_shared<MetadataList>();
 }
 ;
 
@@ -222,19 +222,19 @@ definitions
 // ----------------------------------------------------------------------
 : definitions file_metadata
 {
-    auto metadata = dynamic_pointer_cast<StringListTok>($2);
-    if (!metadata->v.empty())
+    auto metadata = dynamic_pointer_cast<MetadataList>($2);
+    if (!metadata->empty())
     {
-        currentUnit->addFileMetadata(metadata->v);
+        currentUnit->addFileMetadata(metadata);
     }
 }
 | definitions metadata definition
 {
-    auto metadata = dynamic_pointer_cast<StringListTok>($2);
+    auto metadata = dynamic_pointer_cast<MetadataList>($2);
     auto contained = dynamic_pointer_cast<Contained>($3);
-    if (contained && !metadata->v.empty())
+    if (contained && !metadata->empty())
     {
-        contained->setMetadata(metadata->v);
+        contained->setMetadata(metadata);
     }
 }
 | %empty
@@ -987,11 +987,11 @@ data_members
 // ----------------------------------------------------------------------
 : metadata data_member ';' data_members
 {
-    auto metadata = dynamic_pointer_cast<StringListTok>($1);
+    auto metadata = dynamic_pointer_cast<MetadataList>($1);
     auto contained = dynamic_pointer_cast<Contained>($2);
-    if (contained && !metadata->v.empty())
+    if (contained && !metadata->empty())
     {
-        contained->setMetadata(metadata->v);
+        contained->setMetadata(metadata);
     }
 }
 | error ';' data_members
@@ -1468,11 +1468,11 @@ operations
 // ----------------------------------------------------------------------
 : metadata operation ';' operations
 {
-    auto metadata = dynamic_pointer_cast<StringListTok>($1);
+    auto metadata = dynamic_pointer_cast<MetadataList>($1);
     auto contained = dynamic_pointer_cast<Contained>($2);
-    if (contained && !metadata->v.empty())
+    if (contained && !metadata->empty())
     {
-        contained->setMetadata(metadata->v);
+        contained->setMetadata(metadata);
     }
 }
 | error ';' operations
@@ -1535,18 +1535,18 @@ sequence_def
 : ICE_SEQUENCE '<' metadata type '>' ICE_IDENTIFIER
 {
     auto ident = dynamic_pointer_cast<StringTok>($6);
-    auto metadata = dynamic_pointer_cast<StringListTok>($3);
+    auto metadata = dynamic_pointer_cast<MetadataList>($3);
     auto type = dynamic_pointer_cast<Type>($4);
     ContainerPtr cont = currentUnit->currentContainer();
-    $$ = cont->createSequence(ident->v, type, metadata->v);
+    $$ = cont->createSequence(ident->v, type, metadata);
 }
 | ICE_SEQUENCE '<' metadata type '>' keyword
 {
     auto ident = dynamic_pointer_cast<StringTok>($6);
-    auto metadata = dynamic_pointer_cast<StringListTok>($3);
+    auto metadata = dynamic_pointer_cast<MetadataList>($3);
     auto type = dynamic_pointer_cast<Type>($4);
     ContainerPtr cont = currentUnit->currentContainer();
-    $$ = cont->createSequence(ident->v, type, metadata->v); // Dummy
+    $$ = cont->createSequence(ident->v, type, metadata); // Dummy
     currentUnit->error("keyword `" + ident->v + "' cannot be used as sequence name");
 }
 ;
@@ -1557,22 +1557,22 @@ dictionary_def
 : ICE_DICTIONARY '<' metadata type ',' metadata type '>' ICE_IDENTIFIER
 {
     auto ident = dynamic_pointer_cast<StringTok>($9);
-    auto keyMetadata = dynamic_pointer_cast<StringListTok>($3);
+    auto keyMetadata = dynamic_pointer_cast<MetadataList>($3);
     auto keyType = dynamic_pointer_cast<Type>($4);
-    auto valueMetadata = dynamic_pointer_cast<StringListTok>($6);
+    auto valueMetadata = dynamic_pointer_cast<MetadataList>($6);
     auto valueType = dynamic_pointer_cast<Type>($7);
     ContainerPtr cont = currentUnit->currentContainer();
-    $$ = cont->createDictionary(ident->v, keyType, keyMetadata->v, valueType, valueMetadata->v);
+    $$ = cont->createDictionary(ident->v, keyType, keyMetadata, valueType, valueMetadata);
 }
 | ICE_DICTIONARY '<' metadata type ',' metadata type '>' keyword
 {
     auto ident = dynamic_pointer_cast<StringTok>($9);
-    auto keyMetadata = dynamic_pointer_cast<StringListTok>($3);
+    auto keyMetadata = dynamic_pointer_cast<MetadataList>($3);
     auto keyType = dynamic_pointer_cast<Type>($4);
-    auto valueMetadata = dynamic_pointer_cast<StringListTok>($6);
+    auto valueMetadata = dynamic_pointer_cast<MetadataList>($6);
     auto valueType = dynamic_pointer_cast<Type>($7);
     ContainerPtr cont = currentUnit->currentContainer();
-    $$ = cont->createDictionary(ident->v, keyType, keyMetadata->v, valueType, valueMetadata->v); // Dummy
+    $$ = cont->createDictionary(ident->v, keyType, keyMetadata, valueType, valueMetadata); // Dummy
     currentUnit->error("keyword `" + ident->v + "' cannot be used as dictionary name");
 }
 ;
@@ -1646,11 +1646,11 @@ enumerator_list
 // ----------------------------------------------------------------------
 : metadata enumerator ',' enumerator_list
 {
-    auto metadata = dynamic_pointer_cast<StringListTok>($1);
+    auto metadata = dynamic_pointer_cast<MetadataList>($1);
     auto enumerator = dynamic_pointer_cast<Enumerator>($2);
-    if (enumerator && !metadata->v.empty())
+    if (enumerator && !metadata->empty())
     {
-        enumerator->setMetadata(metadata->v);
+        enumerator->setMetadata(metadata);
     }
     auto enumeratorList = dynamic_pointer_cast<EnumeratorListTok>($4);
     enumeratorList->v.push_front(enumerator);
@@ -1658,11 +1658,11 @@ enumerator_list
 }
 | metadata enumerator
 {
-    auto metadata = dynamic_pointer_cast<StringListTok>($1);
+    auto metadata = dynamic_pointer_cast<MetadataList>($1);
     auto enumerator = dynamic_pointer_cast<Enumerator>($2);
-    if (enumerator && !metadata->v.empty())
+    if (enumerator && !metadata->empty())
     {
-        enumerator->setMetadata(metadata->v);
+        enumerator->setMetadata(metadata);
     }
     auto enumeratorList = make_shared<EnumeratorListTok>();
     enumeratorList->v.push_front(enumerator);
@@ -1787,10 +1787,10 @@ parameters
     {
         ParamDeclPtr pd = op->createParamDecl(tsp->name, tsp->type, isOutParam->v, tsp->isOptional, tsp->tag);
         currentUnit->currentContainer()->checkIntroduced(tsp->name, pd);
-        auto metadata = dynamic_pointer_cast<StringListTok>($2);
-        if (!metadata->v.empty())
+        auto metadata = dynamic_pointer_cast<MetadataList>($2);
+        if (!metadata->empty())
         {
-            pd->setMetadata(metadata->v);
+            pd->setMetadata(metadata);
         }
     }
 }
@@ -1803,10 +1803,10 @@ parameters
     {
         ParamDeclPtr pd = op->createParamDecl(tsp->name, tsp->type, isOutParam->v, tsp->isOptional, tsp->tag);
         currentUnit->currentContainer()->checkIntroduced(tsp->name, pd);
-        auto metadata = dynamic_pointer_cast<StringListTok>($4);
-        if (!metadata->v.empty())
+        auto metadata = dynamic_pointer_cast<MetadataList>($4);
+        if (!metadata->empty())
         {
-            pd->setMetadata(metadata->v);
+            pd->setMetadata(metadata);
         }
     }
 }
@@ -1987,21 +1987,27 @@ string_literal
 ;
 
 // ----------------------------------------------------------------------
-string_list
+metadata_list
 // ----------------------------------------------------------------------
-: string_list ',' string_literal
+: metadata_list ',' string_literal
 {
     auto str = dynamic_pointer_cast<StringTok>($3);
-    auto stringList = dynamic_pointer_cast<StringListTok>($1);
-    stringList->v.push_back(str->v);
-    $$ = stringList;
+    auto metadataList = dynamic_pointer_cast<MetadataList>($1);
+
+    auto metadata = make_shared<Metadata>(str->v, currentUnit);
+    metadataList->push_back(metadata);
+
+    $$ = metadataList;
 }
 | string_literal
 {
     auto str = dynamic_pointer_cast<StringTok>($1);
-    auto stringList = make_shared<StringListTok>();
-    stringList->v.push_back(str->v);
-    $$ = stringList;
+    auto metadataList = make_shared<MetadataList>();
+
+    auto metadata = make_shared<Metadata>(str->v, currentUnit);
+    metadataList->push_back(metadata);
+
+    $$ = metadataList;
 }
 ;
 
@@ -2089,20 +2095,19 @@ const_def
 // ----------------------------------------------------------------------
 : ICE_CONST metadata type ICE_IDENTIFIER '=' const_initializer
 {
-    auto metadata = dynamic_pointer_cast<StringListTok>($2);
+    auto metadata = dynamic_pointer_cast<MetadataList>($2);
     auto const_type = dynamic_pointer_cast<Type>($3);
     auto ident = dynamic_pointer_cast<StringTok>($4);
     auto value = dynamic_pointer_cast<ConstDefTok>($6);
-    $$ = currentUnit->currentContainer()->createConst(ident->v, const_type, metadata->v, value->v,
-                                                      value->valueAsString);
+    $$ = currentUnit->currentContainer()->createConst(ident->v, const_type, metadata, value->v, value->valueAsString);
 }
 | ICE_CONST metadata type '=' const_initializer
 {
-    auto metadata = dynamic_pointer_cast<StringListTok>($2);
+    auto metadata = dynamic_pointer_cast<MetadataList>($2);
     auto const_type = dynamic_pointer_cast<Type>($3);
     auto value = dynamic_pointer_cast<ConstDefTok>($5);
     currentUnit->error("missing constant name");
-    $$ = currentUnit->currentContainer()->createConst(Ice::generateUUID(), const_type, metadata->v, value->v,
+    $$ = currentUnit->currentContainer()->createConst(Ice::generateUUID(), const_type, metadata, value->v,
                                                       value->valueAsString, Dummy); // Dummy
 }
 ;

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -213,7 +213,7 @@ metadata
 }
 | %empty
 {
-    $$ = make_shared<MetadataList>();
+    $$ = make_shared<MetadataListTok>();
 }
 ;
 
@@ -222,19 +222,19 @@ definitions
 // ----------------------------------------------------------------------
 : definitions file_metadata
 {
-    auto metadata = dynamic_pointer_cast<MetadataList>($2);
-    if (!metadata->empty())
+    auto metadata = dynamic_pointer_cast<MetadataListTok>($2);
+    if (!metadata->v.empty())
     {
-        currentUnit->addFileMetadata(metadata);
+        currentUnit->addFileMetadata(metadata->v);
     }
 }
 | definitions metadata definition
 {
-    auto metadata = dynamic_pointer_cast<MetadataList>($2);
+    auto metadata = dynamic_pointer_cast<MetadataListTok>($2);
     auto contained = dynamic_pointer_cast<Contained>($3);
-    if (contained && !metadata->empty())
+    if (contained && !metadata->v.empty())
     {
-        contained->setMetadata(metadata);
+        contained->setMetadata(metadata->v);
     }
 }
 | %empty
@@ -987,11 +987,11 @@ data_members
 // ----------------------------------------------------------------------
 : metadata data_member ';' data_members
 {
-    auto metadata = dynamic_pointer_cast<MetadataList>($1);
+    auto metadata = dynamic_pointer_cast<MetadataListTok>($1);
     auto contained = dynamic_pointer_cast<Contained>($2);
-    if (contained && !metadata->empty())
+    if (contained && !metadata->v.empty())
     {
-        contained->setMetadata(metadata);
+        contained->setMetadata(metadata->v);
     }
 }
 | error ';' data_members
@@ -1468,11 +1468,11 @@ operations
 // ----------------------------------------------------------------------
 : metadata operation ';' operations
 {
-    auto metadata = dynamic_pointer_cast<MetadataList>($1);
+    auto metadata = dynamic_pointer_cast<MetadataListTok>($1);
     auto contained = dynamic_pointer_cast<Contained>($2);
-    if (contained && !metadata->empty())
+    if (contained && !metadata->v.empty())
     {
-        contained->setMetadata(metadata);
+        contained->setMetadata(metadata->v);
     }
 }
 | error ';' operations
@@ -1535,18 +1535,18 @@ sequence_def
 : ICE_SEQUENCE '<' metadata type '>' ICE_IDENTIFIER
 {
     auto ident = dynamic_pointer_cast<StringTok>($6);
-    auto metadata = dynamic_pointer_cast<MetadataList>($3);
+    auto metadata = dynamic_pointer_cast<MetadataListTok>($3);
     auto type = dynamic_pointer_cast<Type>($4);
     ContainerPtr cont = currentUnit->currentContainer();
-    $$ = cont->createSequence(ident->v, type, metadata);
+    $$ = cont->createSequence(ident->v, type, metadata->v);
 }
 | ICE_SEQUENCE '<' metadata type '>' keyword
 {
     auto ident = dynamic_pointer_cast<StringTok>($6);
-    auto metadata = dynamic_pointer_cast<MetadataList>($3);
+    auto metadata = dynamic_pointer_cast<MetadataListTok>($3);
     auto type = dynamic_pointer_cast<Type>($4);
     ContainerPtr cont = currentUnit->currentContainer();
-    $$ = cont->createSequence(ident->v, type, metadata); // Dummy
+    $$ = cont->createSequence(ident->v, type, metadata->v); // Dummy
     currentUnit->error("keyword `" + ident->v + "' cannot be used as sequence name");
 }
 ;
@@ -1557,22 +1557,22 @@ dictionary_def
 : ICE_DICTIONARY '<' metadata type ',' metadata type '>' ICE_IDENTIFIER
 {
     auto ident = dynamic_pointer_cast<StringTok>($9);
-    auto keyMetadata = dynamic_pointer_cast<MetadataList>($3);
+    auto keyMetadata = dynamic_pointer_cast<MetadataListTok>($3);
     auto keyType = dynamic_pointer_cast<Type>($4);
-    auto valueMetadata = dynamic_pointer_cast<MetadataList>($6);
+    auto valueMetadata = dynamic_pointer_cast<MetadataListTok>($6);
     auto valueType = dynamic_pointer_cast<Type>($7);
     ContainerPtr cont = currentUnit->currentContainer();
-    $$ = cont->createDictionary(ident->v, keyType, keyMetadata, valueType, valueMetadata);
+    $$ = cont->createDictionary(ident->v, keyType, keyMetadata->v, valueType, valueMetadata->v);
 }
 | ICE_DICTIONARY '<' metadata type ',' metadata type '>' keyword
 {
     auto ident = dynamic_pointer_cast<StringTok>($9);
-    auto keyMetadata = dynamic_pointer_cast<MetadataList>($3);
+    auto keyMetadata = dynamic_pointer_cast<MetadataListTok>($3);
     auto keyType = dynamic_pointer_cast<Type>($4);
-    auto valueMetadata = dynamic_pointer_cast<MetadataList>($6);
+    auto valueMetadata = dynamic_pointer_cast<MetadataListTok>($6);
     auto valueType = dynamic_pointer_cast<Type>($7);
     ContainerPtr cont = currentUnit->currentContainer();
-    $$ = cont->createDictionary(ident->v, keyType, keyMetadata, valueType, valueMetadata); // Dummy
+    $$ = cont->createDictionary(ident->v, keyType, keyMetadata->v, valueType, valueMetadata->v); // Dummy
     currentUnit->error("keyword `" + ident->v + "' cannot be used as dictionary name");
 }
 ;
@@ -1646,11 +1646,11 @@ enumerator_list
 // ----------------------------------------------------------------------
 : metadata enumerator ',' enumerator_list
 {
-    auto metadata = dynamic_pointer_cast<MetadataList>($1);
+    auto metadata = dynamic_pointer_cast<MetadataListTok>($1);
     auto enumerator = dynamic_pointer_cast<Enumerator>($2);
-    if (enumerator && !metadata->empty())
+    if (enumerator && !metadata->v.empty())
     {
-        enumerator->setMetadata(metadata);
+        enumerator->setMetadata(metadata->v);
     }
     auto enumeratorList = dynamic_pointer_cast<EnumeratorListTok>($4);
     enumeratorList->v.push_front(enumerator);
@@ -1658,11 +1658,11 @@ enumerator_list
 }
 | metadata enumerator
 {
-    auto metadata = dynamic_pointer_cast<MetadataList>($1);
+    auto metadata = dynamic_pointer_cast<MetadataListTok>($1);
     auto enumerator = dynamic_pointer_cast<Enumerator>($2);
-    if (enumerator && !metadata->empty())
+    if (enumerator && !metadata->v.empty())
     {
-        enumerator->setMetadata(metadata);
+        enumerator->setMetadata(metadata->v);
     }
     auto enumeratorList = make_shared<EnumeratorListTok>();
     enumeratorList->v.push_front(enumerator);
@@ -1787,10 +1787,10 @@ parameters
     {
         ParamDeclPtr pd = op->createParamDecl(tsp->name, tsp->type, isOutParam->v, tsp->isOptional, tsp->tag);
         currentUnit->currentContainer()->checkIntroduced(tsp->name, pd);
-        auto metadata = dynamic_pointer_cast<MetadataList>($2);
-        if (!metadata->empty())
+        auto metadata = dynamic_pointer_cast<MetadataListTok>($2);
+        if (!metadata->v.empty())
         {
-            pd->setMetadata(metadata);
+            pd->setMetadata(metadata->v);
         }
     }
 }
@@ -1803,10 +1803,10 @@ parameters
     {
         ParamDeclPtr pd = op->createParamDecl(tsp->name, tsp->type, isOutParam->v, tsp->isOptional, tsp->tag);
         currentUnit->currentContainer()->checkIntroduced(tsp->name, pd);
-        auto metadata = dynamic_pointer_cast<MetadataList>($4);
-        if (!metadata->empty())
+        auto metadata = dynamic_pointer_cast<MetadataListTok>($4);
+        if (!metadata->v.empty())
         {
-            pd->setMetadata(metadata);
+            pd->setMetadata(metadata->v);
         }
     }
 }
@@ -1992,20 +1992,20 @@ metadata_list
 : metadata_list ',' string_literal
 {
     auto str = dynamic_pointer_cast<StringTok>($3);
-    auto metadataList = dynamic_pointer_cast<MetadataList>($1);
+    auto metadataList = dynamic_pointer_cast<MetadataListTok>($1);
 
-    auto metadata = make_shared<Metadata>(str->v, currentUnit);
-    metadataList->push_back(metadata);
+    auto metadata = make_shared<Metadata>(str->v, currentUnit->currentFile(), currentUnit->currentLine());
+    metadataList->v.push_back(metadata);
 
     $$ = metadataList;
 }
 | string_literal
 {
     auto str = dynamic_pointer_cast<StringTok>($1);
-    auto metadataList = make_shared<MetadataList>();
+    auto metadataList = make_shared<MetadataListTok>();
 
-    auto metadata = make_shared<Metadata>(str->v, currentUnit);
-    metadataList->push_back(metadata);
+    auto metadata = make_shared<Metadata>(str->v, currentUnit->currentFile(), currentUnit->currentLine());
+    metadataList->v.push_back(metadata);
 
     $$ = metadataList;
 }
@@ -2095,19 +2095,20 @@ const_def
 // ----------------------------------------------------------------------
 : ICE_CONST metadata type ICE_IDENTIFIER '=' const_initializer
 {
-    auto metadata = dynamic_pointer_cast<MetadataList>($2);
+    auto metadata = dynamic_pointer_cast<MetadataListTok>($2);
     auto const_type = dynamic_pointer_cast<Type>($3);
     auto ident = dynamic_pointer_cast<StringTok>($4);
     auto value = dynamic_pointer_cast<ConstDefTok>($6);
-    $$ = currentUnit->currentContainer()->createConst(ident->v, const_type, metadata, value->v, value->valueAsString);
+    $$ = currentUnit->currentContainer()->createConst(ident->v, const_type, metadata->v, value->v,
+                                                      value->valueAsString);
 }
 | ICE_CONST metadata type '=' const_initializer
 {
-    auto metadata = dynamic_pointer_cast<MetadataList>($2);
+    auto metadata = dynamic_pointer_cast<MetadataListTok>($2);
     auto const_type = dynamic_pointer_cast<Type>($3);
     auto value = dynamic_pointer_cast<ConstDefTok>($5);
     currentUnit->error("missing constant name");
-    $$ = currentUnit->currentContainer()->createConst(Ice::generateUUID(), const_type, metadata, value->v,
+    $$ = currentUnit->currentContainer()->createConst(Ice::generateUUID(), const_type, metadata->v, value->v,
                                                       value->valueAsString, Dummy); // Dummy
 }
 ;

--- a/cpp/src/Slice/GrammarUtil.h
+++ b/cpp/src/Slice/GrammarUtil.h
@@ -25,6 +25,12 @@ namespace Slice
         std::string literal;
     };
 
+    struct MetadataListTok final : public GrammarBase
+    {
+        MetadataListTok() {}
+        MetadataList v;
+    };
+
     struct TypeStringTok final : public GrammarBase
     {
         TypeStringTok(TypePtr type, std::string name) : type(type), name(name) {}

--- a/cpp/src/Slice/GrammarUtil.h
+++ b/cpp/src/Slice/GrammarUtil.h
@@ -25,12 +25,6 @@ namespace Slice
         std::string literal;
     };
 
-    struct StringListTok final : public GrammarBase
-    {
-        StringListTok() {}
-        StringList v;
-    };
-
     struct TypeStringTok final : public GrammarBase
     {
         TypeStringTok(TypePtr type, std::string name) : type(type), name(name) {}

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -132,7 +132,7 @@ Slice::Metadata::parseRawMetadata(const string& rawMetadata)
     size_t firstColonPos = rawMetadata.find(':');
     if (firstColonPos == string::npos)
     {
-        return { rawMetadata, "" };
+        return {rawMetadata, ""};
     }
 
     // Otherwise, we check whether the colon is for a language prefix or for arguments and split the string accordingly.
@@ -142,13 +142,13 @@ Slice::Metadata::parseRawMetadata(const string& rawMetadata)
     {
         // If the metadata contains only 1 colon, we need to check if it's for a language prefix, or for arguments.
         // NOTE: It is important that this list is kept in alphabetical order!
-        static const string languages[] = { "cpp", "cs", "java", "js", "matlab", "php", "python", "ruby", "swift" };
+        static const string languages[] = {"cpp", "cs", "java", "js", "matlab", "php", "python", "ruby", "swift"};
         string prefix = rawMetadata.substr(0, firstColonPos);
         bool isLanguage = binary_search(&languages[0], &languages[sizeof(languages) / sizeof(*languages)], prefix);
         if (isLanguage)
         {
             // If the piece before the colon was a language prefix, don't split up the string.
-            return { rawMetadata, "" };
+            return {rawMetadata, ""};
         }
         else
         {
@@ -164,7 +164,7 @@ Slice::Metadata::parseRawMetadata(const string& rawMetadata)
 
     string directive = rawMetadata.substr(0, splitPos);
     string arguments = rawMetadata.substr(splitPos + 1);
-    return { directive, arguments };
+    return {directive, arguments};
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -4578,7 +4578,13 @@ Slice::DataMember::DataMember(
 UnitPtr
 Slice::Unit::createUnit(bool all, const StringList& defaultFileMetadata)
 {
-    UnitPtr unit{new Unit{all, defaultFileMetadata}};
+    MetadataList defaultMetadata;
+    for (const auto& metadataString : defaultFileMetadata)
+    {
+        defaultMetadata.push_back(make_shared<Metadata>(metadataString));
+    }
+
+    UnitPtr unit{new Unit{all, defaultMetadata}};
     unit->_unit = unit;
     return unit;
 }
@@ -4757,7 +4763,7 @@ Slice::Unit::currentIncludeLevel() const
 }
 
 void
-Slice::Unit::addFileMetadata(const StringList& metadata)
+Slice::Unit::addFileMetadata(const MetadataList& metadata)
 {
     DefinitionContextPtr dc = currentDefinitionContext();
     assert(dc);
@@ -4768,7 +4774,7 @@ Slice::Unit::addFileMetadata(const StringList& metadata)
     else
     {
         // Append the file metadata to any existing metadata (e.g., default file metadata).
-        StringList l = dc->getMetadata();
+        MetadataList l = dc->getMetadata();
         copy(metadata.begin(), metadata.end(), back_inserter(l));
         dc->setMetadata(l);
     }
@@ -5030,7 +5036,7 @@ Slice::Unit::getTopLevelModules(const string& file) const
     }
 }
 
-Slice::Unit::Unit(bool all, const StringList& defaultFileMetadata)
+Slice::Unit::Unit(bool all, MetadataList defaultFileMetadata)
     : SyntaxTreeBase(nullptr),
       Container(nullptr),
       _all(all),

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -136,7 +136,7 @@ Slice::Metadata::parseRawMetadata(const string& rawMetadata)
     }
 
     // Otherwise, we check whether the colon is for a language prefix or for arguments and split the string accordingly.
-    size_t secondColonPos = rawMetadata.find(':', firstColonPos);
+    size_t secondColonPos = rawMetadata.find(':', firstColonPos + 1);
     size_t splitPos;
     if (secondColonPos == string::npos)
     {
@@ -148,7 +148,7 @@ Slice::Metadata::parseRawMetadata(const string& rawMetadata)
         if (isLanguage)
         {
             // If the piece before the colon was a language prefix, don't split up the string.
-            splitPos = rawMetadata.size();
+            return { rawMetadata, "" };
         }
         else
         {
@@ -163,7 +163,7 @@ Slice::Metadata::parseRawMetadata(const string& rawMetadata)
     }
 
     string directive = rawMetadata.substr(0, splitPos);
-    string arguments = rawMetadata.substr(splitPos);
+    string arguments = rawMetadata.substr(splitPos + 1);
     return { directive, arguments };
 }
 
@@ -296,7 +296,7 @@ Slice::DefinitionContext::initSuppressedWarnings()
                 else
                 {
                     ostringstream os;
-                    os << "invalid category `" << s << "' in file metadata suppress-warning";
+                    os << "invalid category '" << s << "' in file metadata suppress-warning";
                     warning(InvalidMetadata, "", -1, os.str());
                 }
             }

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -113,7 +113,7 @@ Slice::Metadata::arguments() const
     return _arguments;
 }
 
-string_view
+string
 Slice::Metadata::file() const
 {
     return _file;

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1564,7 +1564,13 @@ Slice::Container::createDictionary(
         }
     }
 
-    DictionaryPtr p = make_shared<Dictionary>(shared_from_this(), name, keyType, std::move(keyMetadata), valueType, std::move(valueMetadata));
+    DictionaryPtr p = make_shared<Dictionary>(
+        shared_from_this(),
+        name,
+        keyType,
+        std::move(keyMetadata),
+        valueType,
+        std::move(valueMetadata));
     _unit->addContent(p);
     _contents.push_back(p);
     return p;
@@ -1648,7 +1654,8 @@ Slice::Container::createConst(
         return nullptr;
     }
 
-    ConstPtr p = make_shared<Const>(shared_from_this(), name, type, std::move(metadata), resolvedValueType, valueString);
+    ConstPtr p =
+        make_shared<Const>(shared_from_this(), name, type, std::move(metadata), resolvedValueType, valueString);
     _unit->addContent(p);
     _contents.push_back(p);
     return p;

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -94,11 +94,11 @@ namespace Slice
 // ----------------------------------------------------------------------
 // Metadata
 // ----------------------------------------------------------------------
-Slice::Metadata::Metadata(const string& rawMetadata, const UnitPtr& unit) : GrammarBase()
+Slice::Metadata::Metadata(const string& rawMetadata, const string& file, int line) : GrammarBase()
 {
     std::tie(_directive, _arguments) = parseRawMetadata(rawMetadata);
-    _file = unit->currentFile();
-    _line = unit->currentLine();
+    _file = file;
+    _line = line;
 }
 
 string_view
@@ -143,7 +143,7 @@ Slice::Metadata::parseRawMetadata(const string& rawMetadata)
         // If the metadata contains only 1 colon, we need to check if it's for a language prefix, or for arguments.
         // NOTE: It is important that this list is kept in alphabetical order!
         static const string languages[] = { "cpp", "cs", "java", "js", "matlab", "php", "python", "ruby", "swift" };
-        string_view prefix = rawMetadata.substr(0, firstColonPos);
+        string prefix = rawMetadata.substr(0, firstColonPos);
         bool isLanguage = binary_search(&languages[0], &languages[sizeof(languages) / sizeof(*languages)], prefix);
         if (isLanguage)
         {
@@ -4581,7 +4581,7 @@ Slice::Unit::createUnit(bool all, const StringList& defaultFileMetadata)
     MetadataList defaultMetadata;
     for (const auto& metadataString : defaultFileMetadata)
     {
-        defaultMetadata.push_back(make_shared<Metadata>(metadataString));
+        defaultMetadata.push_back(make_shared<Metadata>(metadataString, "<command-line>", 0));
     }
 
     UnitPtr unit{new Unit{all, defaultMetadata}};

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1014,14 +1014,11 @@ Slice::Contained::isDeprecated() const
 optional<string>
 Slice::Contained::getDeprecationReason() const
 {
-    const string prefix1 = "deprecate:";
-    const string prefix2 = "deprecated:";
-
-    if (auto reason = getMetadataArgs(prefix1))
+    if (auto reason = getMetadataArgs("deprecate"))
     {
         return *reason;
     }
-    if (auto reason = getMetadataArgs(prefix2))
+    if (auto reason = getMetadataArgs("deprecated"))
     {
         return *reason;
     }

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -201,7 +201,11 @@ namespace Slice
 
     inline std::ostream& operator<<(std::ostream &ostr, const Metadata &metadata)
     {
-        ostr << metadata._directive << ":" << metadata._arguments;
+        ostr << metadata._directive;
+        if (!metadata._arguments.empty())
+        {
+            ostr << ":" << metadata._arguments;
+        }
         return ostr;
     }
 

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -183,7 +183,7 @@ namespace Slice
         std::string_view directive() const;
         std::string_view arguments() const;
 
-        std::string_view file() const;
+        std::string file() const;
         int line() const;
 
         friend std::ostream& operator<<(std::ostream &out, const Metadata &metadata);

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -185,6 +185,8 @@ namespace Slice
         std::string_view file() const;
         int line() const;
 
+        friend std::ostream& operator<<(std::ostream &out, const Metadata &metadata);
+
     private:
         /// Parses a metadata string into a pair of (directive, arguments) strings.
         static std::pair<std::string, std::string> parseRawMetadata(const std::string& rawMetadata);
@@ -195,6 +197,12 @@ namespace Slice
         std::string _file;
         int _line;
     };
+
+    inline std::ostream& operator<<(std::ostream &ostr, const Metadata &metadata)
+    {
+        ostr << metadata._directive << ":" << metadata._arguments;
+        return ostr;
+    }
 
     // ----------------------------------------------------------------------
     // DefinitionContext
@@ -989,7 +997,7 @@ namespace Slice
         int setCurrentFile(const std::string& currentFile, int lineNumber);
         int currentIncludeLevel() const;
 
-        void addFileMetadata(const StringList& metadata);
+        void addFileMetadata(const MetadataList& metadata);
 
         void setSeenDefinition();
 
@@ -1028,13 +1036,13 @@ namespace Slice
         std::set<std::string> getTopLevelModules(const std::string& file) const;
 
     private:
-        Unit(bool all, const StringList& defaultFileMetadata);
+        Unit(bool all, const MetadataList& defaultFileMetadata);
 
         void pushDefinitionContext();
         void popDefinitionContext();
 
         bool _all;
-        StringList _defaultFileMetadata;
+        MetadataList _defaultFileMetadata;
         int _errors;
         std::string _currentComment;
         int _currentIncludeLevel;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -186,7 +186,7 @@ namespace Slice
         std::string file() const;
         int line() const;
 
-        friend std::ostream& operator<<(std::ostream &out, const Metadata &metadata);
+        friend std::ostream& operator<<(std::ostream& out, const Metadata& metadata);
 
     private:
         /// Parses a metadata string into a pair of (directive, arguments) strings.
@@ -199,7 +199,7 @@ namespace Slice
         int _line;
     };
 
-    inline std::ostream& operator<<(std::ostream &ostr, const Metadata &metadata)
+    inline std::ostream& operator<<(std::ostream& ostr, const Metadata& metadata)
     {
         ostr << metadata._directive;
         if (!metadata._arguments.empty())
@@ -430,11 +430,8 @@ namespace Slice
         InterfaceDeclPtr createInterfaceDecl(const std::string& name);
         ExceptionPtr createException(const std::string& name, const ExceptionPtr& base, NodeType nodeType = Real);
         StructPtr createStruct(const std::string& name, NodeType nodeType = Real);
-        SequencePtr createSequence(
-            const std::string& name,
-            const TypePtr& type,
-            MetadataList metadata,
-            NodeType nodeType = Real);
+        SequencePtr
+        createSequence(const std::string& name, const TypePtr& type, MetadataList metadata, NodeType nodeType = Real);
         DictionaryPtr createDictionary(
             const std::string& name,
             const TypePtr& keyType,

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -9,6 +9,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <ostream>
 #include <set>
 #include <stack>
 #include <stdio.h>
@@ -178,7 +179,7 @@ namespace Slice
     class Metadata final : public virtual GrammarBase
     {
     public:
-        Metadata(const std::string& rawMetadata, const UnitPtr& unit);
+        Metadata(const std::string& rawMetadata, const std::string& file, int line);
         std::string_view directive() const;
         std::string_view arguments() const;
 
@@ -577,7 +578,7 @@ namespace Slice
         DataMemberList classDataMembers() const;
         DataMemberList allClassDataMembers() const;
         bool canBeCyclic() const;
-        bool inheritsMetadata(string_view directive) const;
+        bool inheritsMetadata(std::string_view directive) const;
         bool hasBaseDataMembers() const;
         void visit(ParserVisitor* visitor) final;
         int compactId() const;
@@ -711,7 +712,7 @@ namespace Slice
         OperationList operations() const;
         OperationList allOperations() const;
         bool hasOperations() const;
-        bool inheritsMetadata(string_view directive) const;
+        bool inheritsMetadata(std::string_view directive) const;
         std::string kindOf() const final;
         void visit(ParserVisitor* visitor) final;
 
@@ -752,7 +753,7 @@ namespace Slice
         ExceptionList allBases() const;
         bool isBaseOf(const ExceptionPtr& otherException) const;
         bool usesClasses() const;
-        bool inheritsMetadata(string_view metadata) const;
+        bool inheritsMetadata(std::string_view metadata) const;
         bool hasBaseDataMembers() const;
         std::string kindOf() const final;
         void visit(ParserVisitor* visitor) final;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -42,6 +42,7 @@ namespace Slice
 
     class GrammarBase;
     class SyntaxTreeBase;
+    class Metadata;
     class Type;
     class Builtin;
     class Contained;
@@ -66,6 +67,7 @@ namespace Slice
 
     using GrammarBasePtr = std::shared_ptr<GrammarBase>;
     using SyntaxTreeBasePtr = std::shared_ptr<SyntaxTreeBase>;
+    using MetadataPtr = std::shared_ptr<Metadata>;
     using TypePtr = std::shared_ptr<Type>;
     using BuiltinPtr = std::shared_ptr<Builtin>;
     using ContainedPtr = std::shared_ptr<Contained>;
@@ -91,8 +93,9 @@ namespace Slice
     bool containedCompare(const ContainedPtr& lhs, const ContainedPtr& rhs);
     bool containedEqual(const ContainedPtr& lhs, const ContainedPtr& rhs);
 
-    using TypeList = std::list<TypePtr>;
     using StringList = std::list<std::string>;
+    using MetadataList = std::list<MetadataPtr>;
+    using TypeList = std::list<TypePtr>;
     using ContainedList = std::list<ContainedPtr>;
     using ModuleList = std::list<ModulePtr>;
     using ClassList = std::list<ClassDefPtr>;
@@ -159,13 +162,48 @@ namespace Slice
     };
 
     // ----------------------------------------------------------------------
+    // GrammarBase
+    // ----------------------------------------------------------------------
+
+    class GrammarBase
+    {
+    public:
+        virtual ~GrammarBase() = default;
+    };
+
+    // ----------------------------------------------------------------------
+    // Metadata
+    // ----------------------------------------------------------------------
+
+    class Metadata final : public virtual GrammarBase
+    {
+    public:
+        Metadata(const std::string& rawMetadata, const UnitPtr& unit);
+        std::string_view directive() const;
+        std::string_view arguments() const;
+
+        std::string_view file() const;
+        int line() const;
+
+    private:
+        /// Parses a metadata string into a pair of (directive, arguments) strings.
+        static std::pair<std::string, std::string> parseRawMetadata(const std::string& rawMetadata);
+
+        std::string _directive;
+        std::string _arguments;
+
+        std::string _file;
+        int _line;
+    };
+
+    // ----------------------------------------------------------------------
     // DefinitionContext
     // ----------------------------------------------------------------------
 
     class DefinitionContext final
     {
     public:
-        DefinitionContext(int includeLevel, const StringList& metadata);
+        DefinitionContext(int includeLevel, const MetadataList& metadata);
 
         std::string filename() const;
         int includeLevel() const;
@@ -174,10 +212,10 @@ namespace Slice
         void setFilename(const std::string& filename);
         void setSeenDefinition();
 
-        bool hasMetadata(const std::string& directive) const;
-        void setMetadata(const StringList& metadata);
-        std::optional<std::string> findMetadata(const std::string& prefix) const;
-        StringList getMetadata() const;
+        MetadataList getMetadata() const;
+        void setMetadata(MetadataList metadata);
+        bool hasMetadata(std::string_view directive) const;
+        std::optional<std::string> getMetadataArgs(std::string_view directive) const;
 
         /// Emits a warning unless it should be filtered out by a [["suppress-warning"]].
         void warning(WarningCategory category, const std::string& file, int line, const std::string& message) const;
@@ -187,7 +225,7 @@ namespace Slice
         void initSuppressedWarnings();
 
         int _includeLevel;
-        StringList _metadata;
+        MetadataList _metadata;
         std::string _filename;
         bool _seenDefinition;
         std::set<WarningCategory> _suppressedWarnings;
@@ -232,16 +270,6 @@ namespace Slice
         std::map<std::string, StringList> _exceptions;
     };
     using CommentPtr = std::shared_ptr<Comment>;
-
-    // ----------------------------------------------------------------------
-    // GrammarBase
-    // ----------------------------------------------------------------------
-
-    class GrammarBase
-    {
-    public:
-        virtual ~GrammarBase() = default;
-    };
 
     // ----------------------------------------------------------------------
     // SyntaxTreeBase
@@ -342,12 +370,12 @@ namespace Slice
 
         int includeLevel() const;
 
-        bool hasMetadata(const std::string& directive) const;
-        std::optional<std::string> findMetadata(const std::string& prefix) const;
-        StringList getMetadata() const;
-        void setMetadata(const StringList& metadata);
+        MetadataList getMetadata() const;
+        void setMetadata(MetadataList metadata);
+        bool hasMetadata(std::string_view directive) const;
+        std::optional<std::string> getMetadataArgs(std::string_view directive) const;
 
-        static std::optional<FormatType> parseFormatMetadata(const StringList& metadata);
+        std::optional<FormatType> parseFormatMetadata() const;
 
         /// Returns true if this item is deprecated, due to the presence of 'deprecated' metadata.
         /// @return True if this item has 'deprecated' metadata on it, false otherwise.
@@ -370,7 +398,7 @@ namespace Slice
         int _line;
         std::string _comment;
         int _includeLevel;
-        std::list<std::string> _metadata;
+        MetadataList _metadata;
     };
 
     // ----------------------------------------------------------------------
@@ -392,20 +420,20 @@ namespace Slice
         SequencePtr createSequence(
             const std::string& name,
             const TypePtr& type,
-            const StringList& metadata,
+            MetadataList metadata,
             NodeType nodeType = Real);
         DictionaryPtr createDictionary(
             const std::string& name,
             const TypePtr& keyType,
-            const StringList& keyMetadata,
+            MetadataList keyMetadata,
             const TypePtr& valueType,
-            const StringList& valueMetadata,
+            MetadataList valueMetadata,
             NodeType nodeType = Real);
         EnumPtr createEnum(const std::string& name, NodeType nodeType = Real);
         ConstPtr createConst(
             const std::string name,
             const TypePtr& constType,
-            const StringList& metadata,
+            MetadataList metadata,
             const SyntaxTreeBasePtr& valueType,
             const std::string& value,
             NodeType nodeType = Real);
@@ -541,7 +569,7 @@ namespace Slice
         DataMemberList classDataMembers() const;
         DataMemberList allClassDataMembers() const;
         bool canBeCyclic() const;
-        bool inheritsMetadata(const std::string& metadata) const;
+        bool inheritsMetadata(string_view directive) const;
         bool hasBaseDataMembers() const;
         void visit(ParserVisitor* visitor) final;
         int compactId() const;
@@ -675,7 +703,7 @@ namespace Slice
         OperationList operations() const;
         OperationList allOperations() const;
         bool hasOperations() const;
-        bool inheritsMetadata(const std::string& metadata) const;
+        bool inheritsMetadata(string_view directive) const;
         std::string kindOf() const final;
         void visit(ParserVisitor* visitor) final;
 
@@ -716,7 +744,7 @@ namespace Slice
         ExceptionList allBases() const;
         bool isBaseOf(const ExceptionPtr& otherException) const;
         bool usesClasses() const;
-        bool inheritsMetadata(const std::string& metadata) const;
+        bool inheritsMetadata(string_view metadata) const;
         bool hasBaseDataMembers() const;
         std::string kindOf() const final;
         void visit(ParserVisitor* visitor) final;
@@ -761,9 +789,9 @@ namespace Slice
             const ContainerPtr& container,
             const std::string& name,
             const TypePtr& type,
-            const StringList& typeMetadata);
+            MetadataList typeMetadata);
         TypePtr type() const;
-        StringList typeMetadata() const;
+        MetadataList typeMetadata() const;
         bool usesClasses() const final;
         size_t minWireSize() const final;
         std::string getOptionalFormat() const final;
@@ -773,7 +801,7 @@ namespace Slice
 
     private:
         TypePtr _type;
-        StringList _typeMetadata;
+        MetadataList _typeMetadata;
     };
 
     // ----------------------------------------------------------------------
@@ -787,13 +815,13 @@ namespace Slice
             const ContainerPtr& container,
             const std::string& name,
             const TypePtr& keyType,
-            const StringList& keyMetadata,
+            MetadataList keyMetadata,
             const TypePtr& valueType,
-            const StringList& valueMetadata);
+            MetadataList valueMetadata);
         TypePtr keyType() const;
         TypePtr valueType() const;
-        StringList keyMetadata() const;
-        StringList valueMetadata() const;
+        MetadataList keyMetadata() const;
+        MetadataList valueMetadata() const;
         bool usesClasses() const final;
         size_t minWireSize() const final;
         std::string getOptionalFormat() const final;
@@ -806,8 +834,8 @@ namespace Slice
     private:
         TypePtr _keyType;
         TypePtr _valueType;
-        StringList _keyMetadata;
-        StringList _valueMetadata;
+        MetadataList _keyMetadata;
+        MetadataList _valueMetadata;
     };
 
     // ----------------------------------------------------------------------
@@ -866,11 +894,11 @@ namespace Slice
             const ContainerPtr& container,
             const std::string& name,
             const TypePtr& type,
-            const StringList& typeMetadata,
+            MetadataList typeMetadata,
             const SyntaxTreeBasePtr& valueType,
             const std::string& valueString);
         TypePtr type() const;
-        StringList typeMetadata() const;
+        MetadataList typeMetadata() const;
         SyntaxTreeBasePtr valueType() const;
         std::string value() const;
         std::string kindOf() const final;
@@ -878,7 +906,7 @@ namespace Slice
 
     private:
         TypePtr _type;
-        StringList _typeMetadata;
+        MetadataList _typeMetadata;
         SyntaxTreeBasePtr _valueType;
         std::string _value;
     };

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -176,10 +176,10 @@ namespace Slice
     // Metadata
     // ----------------------------------------------------------------------
 
-    class Metadata final : public virtual GrammarBase
+    class Metadata final : public GrammarBase
     {
     public:
-        Metadata(const std::string& rawMetadata, const std::string& file, int line);
+        Metadata(std::string rawMetadata, std::string file, int line);
         std::string_view directive() const;
         std::string_view arguments() const;
 
@@ -190,7 +190,7 @@ namespace Slice
 
     private:
         /// Parses a metadata string into a pair of (directive, arguments) strings.
-        static std::pair<std::string, std::string> parseRawMetadata(const std::string& rawMetadata);
+        static std::pair<std::string, std::string> parseRawMetadata(std::string rawMetadata);
 
         std::string _directive;
         std::string _arguments;
@@ -216,7 +216,7 @@ namespace Slice
     class DefinitionContext final
     {
     public:
-        DefinitionContext(int includeLevel, const MetadataList& metadata);
+        DefinitionContext(int includeLevel, MetadataList metadata);
 
         std::string filename() const;
         int includeLevel() const;
@@ -999,7 +999,7 @@ namespace Slice
         int setCurrentFile(const std::string& currentFile, int lineNumber);
         int currentIncludeLevel() const;
 
-        void addFileMetadata(const MetadataList& metadata);
+        void addFileMetadata(MetadataList metadata);
 
         void setSeenDefinition();
 

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -1041,7 +1041,7 @@ namespace Slice
         std::set<std::string> getTopLevelModules(const std::string& file) const;
 
     private:
-        Unit(bool all, const MetadataList& defaultFileMetadata);
+        Unit(bool all, MetadataList defaultFileMetadata);
 
         void pushDefinitionContext();
         void popDefinitionContext();

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -189,9 +189,6 @@ namespace Slice
         friend std::ostream& operator<<(std::ostream& out, const Metadata& metadata);
 
     private:
-        /// Parses a metadata string into a pair of (directive, arguments) strings.
-        static std::pair<std::string, std::string> parseRawMetadata(std::string rawMetadata);
-
         std::string _directive;
         std::string _arguments;
 

--- a/cpp/src/Slice/Scanner.cpp
+++ b/cpp/src/Slice/Scanner.cpp
@@ -343,7 +343,7 @@
 #if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 
 /* C99 says to define __STDC_LIMIT_MACROS before including stdint.h,
- * if you want the limit (max/min) macros for int types.
+ * if you want the limit (max/min) macros for int types. 
  */
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS 1
@@ -356,12 +356,11 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
-typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
 typedef int flex_int32_t;
-typedef unsigned char flex_uint8_t;
+typedef unsigned char flex_uint8_t; 
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
 
@@ -481,7 +480,7 @@ typedef size_t yy_size_t;
 #endif
 
 /* %if-not-reentrant */
-extern yy_size_t yyleng;
+extern int yyleng;
 /* %endif */
 
 /* %if-c-only */
@@ -493,10 +492,10 @@ extern FILE *yyin, *yyout;
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     #define YY_LESS_LINENO(n)
     #define YY_LINENO_REWIND_TO(ptr)
-
+    
 /* Return all but the first "n" matched characters back to the input stream. */
 #define yyless(n) \
 	do \
@@ -534,7 +533,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -615,8 +614,8 @@ static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 /* %not-for-header */
 /* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
-static yy_size_t yy_n_chars;		/* number of characters read into yy_ch_buf */
-yy_size_t yyleng;
+static int yy_n_chars;		/* number of characters read into yy_ch_buf */
+int yyleng;
 
 /* Points to current character in buffer. */
 static char *yy_c_buf_p = NULL;
@@ -646,7 +645,7 @@ static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
 
 YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
 YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, yy_size_t len  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
 
 /* %endif */
 
@@ -715,7 +714,7 @@ static void yynoreturn yy_fatal_error ( const char* msg  );
 	(yytext_ptr) = yy_bp; \
 /* %% [2.0] code to fiddle yytext and yyleng for yymore() goes here \ */\
 	(yytext_ptr) -= (yy_more_len); \
-	yyleng = (yy_size_t) (yy_cp - (yytext_ptr)); \
+	yyleng = (int) (yy_cp - (yytext_ptr)); \
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 /* %% [3.0] code to copy yytext_ptr to yytext[] goes here, if %array \ */\
@@ -1171,7 +1170,7 @@ namespace
 #define YY_USER_ACTION preAction();
 #define YY_FATAL_ERROR(msg) fatalError(msg);
 
-#line 1174 "src/Slice/Scanner.cpp"
+#line 1173 "src/Slice/Scanner.cpp"
 #line 59 "src/Slice/Scanner.l"
   /* Changes the default prefix of 'yy' to 'slice_' for functions and variables in the generated code. */
   /* Instructs flex to not suppress any warnings when generating the scanner. */
@@ -1197,7 +1196,7 @@ namespace
 
   /* The scanner also has a built in 'INITIAL' start-condition state, which is the state the scanner is initialized in.
    * We use it solely to check for and consume any BOMs at the start of files. See Bug 3140. */
-#line 1200 "src/Slice/Scanner.cpp"
+#line 1199 "src/Slice/Scanner.cpp"
 
 #define INITIAL 0
 #define C_COMMENT 1
@@ -1258,7 +1257,7 @@ extern int yywrap ( void );
 
 /* %not-for-header */
 #ifndef YY_NO_UNPUT
-
+    
 #endif
 /* %ok-for-header */
 
@@ -1290,13 +1289,13 @@ static int input ( void );
         static int yy_start_stack_ptr = 0;
         static int yy_start_stack_depth = 0;
         static int *yy_start_stack = NULL;
-
+    
     static void yy_push_state ( int _new_state );
-
+    
     static void yy_pop_state ( void );
-
+    
     static int yy_top_state ( void );
-
+    
 /* %endif */
 
 /* Amount of stuff to slurp up with each read. */
@@ -1330,7 +1329,7 @@ static int input ( void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		yy_size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -1437,11 +1436,11 @@ YY_DECL
 	yy_state_type yy_current_state;
 	char *yy_cp, *yy_bp;
 	int yy_act;
-
+    
         YYSTYPE * yylval;
-
+    
         YYLTYPE * yylloc;
-
+    
     yylval = yylval_param;
 
     yylloc = yylloc_param;
@@ -1487,7 +1486,7 @@ YY_DECL
 
   /* ========== Literals ========== */
   /* Matches the start of a double-quoted string literal. */
-#line 1490 "src/Slice/Scanner.cpp"
+#line 1489 "src/Slice/Scanner.cpp"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1810,11 +1809,11 @@ YY_RULE_SETUP
     ftp->v = strtod(literal.c_str(), 0);
     if ((ftp->v == HUGE_VAL || ftp->v == -HUGE_VAL) && errno == ERANGE)
     {
-        currentUnit->error("floating-point constant `" + string(yytext) + "' too large (overflow)");
+        currentUnit->error("floating-point constant `" + string{yytext} + "' too large (overflow)");
     }
     else if (ftp->v == 0 && errno == ERANGE)
     {
-        currentUnit->error("floating-point constant `" + string(yytext) + "' too small (underflow)");
+        currentUnit->error("floating-point constant `" + string{yytext} + "' too small (underflow)");
     }
     return ICE_FLOATING_POINT_LITERAL;
 }
@@ -2118,7 +2117,7 @@ YY_RULE_SETUP
 #line 528 "src/Slice/Scanner.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 2121 "src/Slice/Scanner.cpp"
+#line 2120 "src/Slice/Scanner.cpp"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(SLICE):
 case YY_STATE_EOF(METADATA):
@@ -2324,7 +2323,7 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -2338,7 +2337,7 @@ static int yy_get_next_buffer (void)
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -2396,7 +2395,7 @@ static int yy_get_next_buffer (void)
 
 	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		yy_size_t new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
+		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
 		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
 			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
@@ -2425,7 +2424,7 @@ static int yy_get_next_buffer (void)
 {
 	yy_state_type yy_current_state;
 	char *yy_cp;
-
+    
 /* %% [15.0] code to get the start state into yy_current_state goes here */
 	yy_current_state = (yy_start);
 	yy_current_state += YY_AT_BOL();
@@ -2503,7 +2502,7 @@ static int yy_get_next_buffer (void)
 /* %endif */
 {
 	int c;
-
+    
 	*(yy_c_buf_p) = (yy_hold_char);
 
 	if ( *(yy_c_buf_p) == YY_END_OF_BUFFER_CHAR )
@@ -2518,7 +2517,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
+			int offset = (int) ((yy_c_buf_p) - (yytext_ptr));
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -2575,7 +2574,7 @@ static int yy_get_next_buffer (void)
 
 /** Immediately switch to a different input stream.
  * @param input_file A readable stream.
- *
+ * 
  * @note This function does not reset the start condition to @c INITIAL .
  */
 /* %if-c-only */
@@ -2584,7 +2583,7 @@ static int yy_get_next_buffer (void)
 /* %if-c++-only */
 /* %endif */
 {
-
+    
 	if ( ! YY_CURRENT_BUFFER ){
         yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
@@ -2600,7 +2599,7 @@ static int yy_get_next_buffer (void)
 
 /** Switch to a different input buffer.
  * @param new_buffer The new input buffer.
- *
+ * 
  */
 /* %if-c-only */
     void yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
@@ -2608,7 +2607,7 @@ static int yy_get_next_buffer (void)
 /* %if-c++-only */
 /* %endif */
 {
-
+    
 	/* TODO. We should be able to replace this entire function body
 	 * with
 	 *		yypop_buffer_state();
@@ -2656,7 +2655,7 @@ static void yy_load_buffer_state  (void)
 /** Allocate and initialize an input buffer state.
  * @param file A readable stream.
  * @param size The character buffer size in bytes. When in doubt, use @c YY_BUF_SIZE.
- *
+ * 
  * @return the allocated buffer state.
  */
 /* %if-c-only */
@@ -2666,7 +2665,7 @@ static void yy_load_buffer_state  (void)
 /* %endif */
 {
 	YY_BUFFER_STATE b;
-
+    
 	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
@@ -2692,7 +2691,7 @@ static void yy_load_buffer_state  (void)
 
 /** Destroy the buffer.
  * @param b a buffer created with yy_create_buffer()
- *
+ * 
  */
 /* %if-c-only */
     void yy_delete_buffer (YY_BUFFER_STATE  b )
@@ -2700,7 +2699,7 @@ static void yy_load_buffer_state  (void)
 /* %if-c++-only */
 /* %endif */
 {
-
+    
 	if ( ! b )
 		return;
 
@@ -2725,7 +2724,7 @@ static void yy_load_buffer_state  (void)
 
 {
 	int oerrno = errno;
-
+    
 	yy_flush_buffer( b );
 
 /* %if-c-only */
@@ -2747,7 +2746,7 @@ static void yy_load_buffer_state  (void)
 /* %if-c-only */
 
         b->yy_is_interactive = 0;
-
+    
 /* %endif */
 /* %if-c++-only */
 /* %endif */
@@ -2756,7 +2755,7 @@ static void yy_load_buffer_state  (void)
 
 /** Discard all buffered characters. On the next scan, YY_INPUT will be called.
  * @param b the buffer state to be flushed, usually @c YY_CURRENT_BUFFER.
- *
+ * 
  */
 /* %if-c-only */
     void yy_flush_buffer (YY_BUFFER_STATE  b )
@@ -2790,7 +2789,7 @@ static void yy_load_buffer_state  (void)
  *  the current state. This function will allocate the stack
  *  if necessary.
  *  @param new_buffer The new state.
- *
+ *  
  */
 /* %if-c-only */
 void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
@@ -2826,7 +2825,7 @@ void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 /* %if-c-or-c++ */
 /** Removes and deletes the top of the stack, if present.
  *  The next element becomes the new top.
- *
+ *  
  */
 /* %if-c-only */
 void yypop_buffer_state (void)
@@ -2860,7 +2859,7 @@ static void yyensure_buffer_stack (void)
 /* %endif */
 {
 	yy_size_t num_to_alloc;
-
+    
 	if (!(yy_buffer_stack)) {
 
 		/* First allocation is just for 2 elements, since we don't know if this
@@ -2972,7 +2971,7 @@ static void yynoreturn yy_fatal_error (const char* msg )
 	do \
 		{ \
 		/* Undo effects of setting up yytext. */ \
-        yy_size_t yyless_macro_arg = (n); \
+        int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
 		yytext[yyleng] = (yy_hold_char); \
 		(yy_c_buf_p) = yytext + yyless_macro_arg; \
@@ -2989,7 +2988,7 @@ static void yynoreturn yy_fatal_error (const char* msg )
 /* %endif */
 
 /** Get the current token.
- *
+ * 
  */
 
 /* %if-reentrant */
@@ -3040,7 +3039,7 @@ static int yy_init_globals (void)
 /* yylex_destroy is for both reentrant and non-reentrant scanners. */
 int yylex_destroy  (void)
 {
-
+    
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
 		yy_delete_buffer( YY_CURRENT_BUFFER  );
@@ -3073,7 +3072,7 @@ int yylex_destroy  (void)
 #ifndef yytext_ptr
 static void yy_flex_strncpy (char* s1, const char * s2, int n )
 {
-
+		
 	int i;
 	for ( i = 0; i < n; ++i )
 		s1[i] = s2[i];
@@ -3098,7 +3097,7 @@ void *yyalloc (yy_size_t  size )
 
 void *yyrealloc  (void * ptr, yy_size_t  size )
 {
-
+		
 	/* The cast to (char *) in the following accommodates both
 	 * implementations that use char* generic pointers, and those
 	 * that use void* generic pointers.  It works with the latter

--- a/cpp/src/Slice/Scanner.l
+++ b/cpp/src/Slice/Scanner.l
@@ -304,11 +304,11 @@ floating_literal    (({fractional_constant}{exponent_part}?)|((\+|-)?{dec}+{expo
     ftp->v = strtod(literal.c_str(), 0);
     if ((ftp->v == HUGE_VAL || ftp->v == -HUGE_VAL) && errno == ERANGE)
     {
-        currentUnit->error("floating-point constant `" + string(yytext) + "' too large (overflow)");
+        currentUnit->error("floating-point constant `" + string{yytext} + "' too large (overflow)");
     }
     else if (ftp->v == 0 && errno == ERANGE)
     {
-        currentUnit->error("floating-point constant `" + string(yytext) + "' too small (underflow)");
+        currentUnit->error("floating-point constant `" + string{yytext} + "' too small (underflow)");
     }
     return ICE_FLOATING_POINT_LITERAL;
 }

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -566,7 +566,7 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
 
     for (const auto& metadata : p->getMetadata())
     {
-        if (metadata->directive() == "cd:generic")
+        if (metadata->directive() == "cs:generic")
         {
             string_view type = metadata->arguments();
             if ((type == "LinkedList" || type == "Queue" || type == "Stack") && p->type()->isClassType())

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -100,12 +100,10 @@ namespace
 
         assert(m);
 
-        static const string prefix = "cs:namespace:";
-
-        if (auto meta = m->findMetadata(prefix))
+        if (auto metadata = m->getMetadataArgs("cs:namespace"))
         {
             hasCSharpNamespaceAttribute = true;
-            return meta->substr(prefix.size()) + "." + csharpNamespace;
+            return *metadata + "." + csharpNamespace;
         }
         else
         {
@@ -566,14 +564,11 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
 
     out << nl << "typealias " << p->name() << " = ";
 
-    StringList metadata = p->getMetadata();
-    const string csGenericPrefix = "cs:generic:";
-    for (StringList::iterator q = metadata.begin(); q != metadata.end(); ++q)
+    for (const auto& metadata : p->getMetadata())
     {
-        string& s = *q;
-        if (s.find(csGenericPrefix) == 0)
+        if (metadata->directive() == "cd:generic")
         {
-            string type = s.substr(csGenericPrefix.size());
+            string_view type = metadata->arguments();
             if ((type == "LinkedList" || type == "Queue" || type == "Stack") && p->type()->isClassType())
             {
                 continue; // Ignored for objects
@@ -607,12 +602,9 @@ Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
 
     out << nl << "typealias " << p->name() << " = ";
 
-    StringList metadata = p->getMetadata();
-    const string csGenericPrefix = "cs:generic:SortedDictionary";
-    for (StringList::iterator q = metadata.begin(); q != metadata.end(); ++q)
+    for (const auto& metadata : p->getMetadata())
     {
-        string& s = *q;
-        if (s.find(csGenericPrefix) == 0)
+        if (metadata->directive() == "cs:generic" && metadata->arguments() == "SortedDictionary")
         {
             out << "[cs::type(\"[System.Collections.Generic.SortedDictionary<"
                 // TODO the generic arguments must be the IceRPC C# mapped types

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -956,13 +956,13 @@ Slice::findMetadata(const MetadataList& metadata, TypeContext typeCtx)
         {
             if (directive == "cpp:view-type")
             {
-                return string(meta->arguments());
+                return string{meta->arguments()};
             }
         }
 
         if (directive == "cpp:type")
         {
-            return string(meta->arguments());
+            return string{meta->arguments()};
         }
 
         if ((typeCtx & (TypeContext::MarshalParam | TypeContext::UnmarshalParamZeroCopy)) != TypeContext::None)

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -136,7 +136,12 @@ namespace
             for (const auto& meta : metadata)
             {
                 string_view directive = meta->directive();
-                if (directive == "cpp:view-type" || directive == "cpp:array")
+                string_view arguments = meta->arguments();
+                if (directive == "cpp:view-type" && !arguments.empty())
+                {
+                    return true;
+                }
+                if (directive == "cpp:array" && arguments.empty())
                 {
                     return true;
                 }
@@ -967,7 +972,7 @@ Slice::findMetadata(const MetadataList& metadata, TypeContext typeCtx)
                 return "%array";
             }
         }
-        else if (directive == "cpp:unscoped") // The 'else if' here seems dubious. Should probably just be 'if'.
+        else if (directive == "cpp:unscoped") // TODO: The 'else if' here seems dubious. Should probably just be 'if'.
         {
             return "%unscoped";
         }

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -971,7 +971,6 @@ Slice::findMetadata(const MetadataList& metadata, TypeContext typeCtx)
         {
             return "%unscoped";
         }
-
     }
     return "";
 }

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -31,7 +31,7 @@ namespace Slice
         const TypePtr&,
         bool,
         const std::string& = "",
-        const StringList& = StringList(),
+        const MetadataList& = MetadataList(),
         TypeContext = TypeContext::None);
 
     // TODO: find a better name.
@@ -40,7 +40,7 @@ namespace Slice
         const TypePtr&,
         bool,
         const std::string& = "",
-        const StringList& = StringList(),
+        const MetadataList& = MetadataList(),
         TypeContext = TypeContext::None);
 
     // TODO: find a better name.
@@ -49,7 +49,7 @@ namespace Slice
         const TypePtr&,
         bool,
         const std::string& = "",
-        const StringList& = StringList(),
+        const MetadataList& = MetadataList(),
         TypeContext = TypeContext::None);
 
     std::string operationModeToString(Operation::Mode);
@@ -78,7 +78,7 @@ namespace Slice
 
     void writeIceTuple(::IceInternal::Output&, const DataMemberList&, TypeContext);
 
-    std::string findMetadata(const StringList&, TypeContext = TypeContext::None);
+    std::string findMetadata(const MetadataList&, TypeContext = TypeContext::None);
     bool inWstringModule(const SequencePtr&);
 }
 

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1119,7 +1119,7 @@ Slice::Gen::MetadataVisitor::validate(
             ostringstream ostr;
             ostr << "ignoring invalid metadata '" << *meta << "'";
             dc->warning(InvalidMetadata, file, line, ostr.str());
-            meta.remove(meta);
+            metadata.remove(meta);
             continue;
         }
 

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -785,7 +785,7 @@ Slice::Gen::generate(const UnitPtr& p)
                 else
                 {
                     ostringstream ostr;
-                    ostr << "ignoring invalid file metadata `" << metadata << "'";
+                    ostr << "ignoring invalid file metadata '" << *metadata << "'";
                     dc->warning(InvalidMetadata, file, -1, ostr.str());
                     fileMetadata.remove(metadata);
                 }
@@ -799,7 +799,7 @@ Slice::Gen::generate(const UnitPtr& p)
                 else
                 {
                     ostringstream ostr;
-                    ostr << "ignoring invalid file metadata `" << metadata << "'";
+                    ostr << "ignoring invalid file metadata '" << *metadata << "'";
                     dc->warning(InvalidMetadata, file, -1, ostr.str());
                     fileMetadata.remove(metadata);
                 }
@@ -926,7 +926,7 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
                 static const string cppHeaderExtPrefix = "cpp:header-ext";
                 static const string cppSourceExtPrefix = "cpp:source-ext";
                 static const string cppDllExportPrefix = "cpp:dll-export";
-                static const string cppDoxygenIncludePrefix = "cpp:doxygen:include";
+                static const string cppDoxygenIncludePrefix = "cpp:doxygen";
 
                 if (directive == cppNoDefaultInclude || directive == cppNoStream)
                 {
@@ -945,7 +945,7 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
                     if (seenHeaderExtension)
                     {
                         ostringstream ostr;
-                        ostr << "ignoring invalid file metadata '" << s << "': directive can appear only once per file";
+                        ostr << "ignoring invalid file metadata '" << *s << "': directive can appear only once per file";
                         dc->warning(InvalidMetadata, file, -1, ostr.str());
                         fileMetadata.remove(s);
                     }
@@ -957,7 +957,7 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
                     if (seenSourceExtension)
                     {
                         ostringstream ostr;
-                        ostr << "ignoring invalid file metadata '" << s << "': directive can appear only once per file";
+                        ostr << "ignoring invalid file metadata '" << *s << "': directive can appear only once per file";
                         dc->warning(InvalidMetadata, file, -1, ostr.str());
                         fileMetadata.remove(s);
                     }
@@ -969,20 +969,20 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
                     if (seenDllExport)
                     {
                         ostringstream ostr;
-                        ostr << "ignoring invalid file metadata '" << s << "': directive can appear only once per file";
+                        ostr << "ignoring invalid file metadata '" << *s << "': directive can appear only once per file";
                         dc->warning(InvalidMetadata, file, -1, ostr.str());
                         fileMetadata.remove(s);
                     }
                     seenDllExport = true;
                     continue;
                 }
-                else if (directive == cppDoxygenIncludePrefix && !arguments.empty())
+                else if (directive == cppDoxygenIncludePrefix && arguments.find("include:") == 0)
                 {
                     continue;
                 }
 
                 ostringstream ostr;
-                ostr << "ignoring invalid file metadata '" << s << "'";
+                ostr << "ignoring invalid file metadata '" << *s << "'";
                 dc->warning(InvalidMetadata, file, -1, ostr.str());
                 fileMetadata.remove(s);
             }
@@ -1048,7 +1048,7 @@ Slice::Gen::MetadataVisitor::visitOperation(const OperationPtr& p)
             if (directive == "cpp:type" || directive == "cpp:view-type" || directive == "cpp:array")
             {
                 ostringstream ostr;
-                ostr << "ignoring invalid metadata '" << s << "' for operation with void return type";
+                ostr << "ignoring invalid metadata '" << *s << "' for operation with void return type";
                 dc->warning(InvalidMetadata, p->file(), p->line(), ostr.str());
                 metadata.remove(s);
             }
@@ -1123,7 +1123,7 @@ Slice::Gen::MetadataVisitor::validate(
         if (directive.find("cpp11:") == 0 || directive.find("cpp98:") == 0)
         {
             ostringstream ostr;
-            ostr << "ignoring invalid metadata '" << meta << "'";
+            ostr << "ignoring invalid metadata '" << *meta << "'";
             dc->warning(InvalidMetadata, file, line, ostr.str());
             newMetadata.remove(meta);
             continue;
@@ -1183,7 +1183,7 @@ Slice::Gen::MetadataVisitor::validate(
         }
 
         ostringstream ostr;
-        ostr << "ignoring invalid metadata '" << meta << "'";
+        ostr << "ignoring invalid metadata '" << *meta << "'";
         dc->warning(InvalidMetadata, file, line, ostr.str());
         newMetadata.remove(meta);
     }

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -917,7 +917,7 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
             string_view directive = s->directive();
             string_view arguments = s->arguments();
 
-            if (directive.starts_with("cpp:"))
+            if (directive.find("cpp:") == 0)
             {
                 static const string cppIncludePrefix = "cpp:include";
                 static const string cppNoDefaultInclude = "cpp:no-default-include";
@@ -1120,7 +1120,7 @@ Slice::Gen::MetadataVisitor::validate(
 
         // Issue friendly warning for cpp11 and cpp98 metadata what were removed as Slice does not issue warnings
         // for unknown "top-level" metadata.
-        if (directive.starts_with("cpp11:") || directive.starts_with("cpp98:"))
+        if (directive.find("cpp11:") == 0 || directive.find("cpp98:") == 0)
         {
             ostringstream ostr;
             ostr << "ignoring invalid metadata '" << meta << "'";
@@ -1129,7 +1129,7 @@ Slice::Gen::MetadataVisitor::validate(
             continue;
         }
 
-        if (!directive.starts_with("cpp:"))
+        if (directive.find("cpp:") != 0)
         {
             continue;
         }

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -805,7 +805,7 @@ Slice::Gen::generate(const UnitPtr& p)
                 }
             }
         }
-        dc->setMetadata(fileMetadata);
+        dc->setMetadata(std::move(fileMetadata));
     }
 
     if (!dc->hasMetadata("cpp:no-default-include"))
@@ -990,7 +990,7 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
                 fileMetadata.remove(s);
             }
         }
-        dc->setMetadata(fileMetadata);
+        dc->setMetadata(std::move(fileMetadata));
     }
 
     return true;
@@ -999,39 +999,34 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
 bool
 Slice::Gen::MetadataVisitor::visitModuleStart(const ModulePtr& p)
 {
-    MetadataList metadata = validate(p, p->getMetadata(), p->file(), p->line());
-    p->setMetadata(metadata);
+    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
     return true;
 }
 
 void
 Slice::Gen::MetadataVisitor::visitClassDecl(const ClassDeclPtr& p)
 {
-    MetadataList metadata = validate(p, p->getMetadata(), p->file(), p->line());
-    p->setMetadata(metadata);
+    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
 }
 
 bool
 Slice::Gen::MetadataVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
-    MetadataList metadata = validate(p, p->getMetadata(), p->file(), p->line());
-    p->setMetadata(metadata);
+    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
     return true;
 }
 
 bool
 Slice::Gen::MetadataVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
-    MetadataList metadata = validate(p, p->getMetadata(), p->file(), p->line());
-    p->setMetadata(metadata);
+    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
     return true;
 }
 
 bool
 Slice::Gen::MetadataVisitor::visitStructStart(const StructPtr& p)
 {
-    MetadataList metadata = validate(p, p->getMetadata(), p->file(), p->line());
-    p->setMetadata(metadata);
+    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
     return true;
 }
 
@@ -1056,7 +1051,7 @@ Slice::Gen::MetadataVisitor::visitOperation(const OperationPtr& p)
                 metadata.remove(s);
             }
         }
-        p->setMetadata(metadata);
+        p->setMetadata(std::move(metadata));
     }
     else
     {
@@ -1072,36 +1067,31 @@ Slice::Gen::MetadataVisitor::visitOperation(const OperationPtr& p)
 void
 Slice::Gen::MetadataVisitor::visitDataMember(const DataMemberPtr& p)
 {
-    MetadataList metadata = validate(p->type(), p->getMetadata(), p->file(), p->line());
-    p->setMetadata(metadata);
+    p->setMetadata(validate(p->type(), p->getMetadata(), p->file(), p->line()));
 }
 
 void
 Slice::Gen::MetadataVisitor::visitSequence(const SequencePtr& p)
 {
-    MetadataList metadata = validate(p, p->getMetadata(), p->file(), p->line());
-    p->setMetadata(metadata);
+    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
 }
 
 void
 Slice::Gen::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
 {
-    MetadataList metadata = validate(p, p->getMetadata(), p->file(), p->line());
-    p->setMetadata(metadata);
+    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
 }
 
 void
 Slice::Gen::MetadataVisitor::visitEnum(const EnumPtr& p)
 {
-    MetadataList metadata = validate(p, p->getMetadata(), p->file(), p->line());
-    p->setMetadata(metadata);
+    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
 }
 
 void
 Slice::Gen::MetadataVisitor::visitConst(const ConstPtr& p)
 {
-    MetadataList metadata = validate(p, p->getMetadata(), p->file(), p->line());
-    p->setMetadata(metadata);
+    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
 }
 
 MetadataList

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1120,6 +1120,7 @@ Slice::Gen::MetadataVisitor::validate(
     for (const auto& meta : metadata)
     {
         string_view directive = meta->directive();
+        string_view arguments = meta->arguments();
 
         // Issue friendly warning for cpp11 and cpp98 metadata what were removed as Slice does not issue warnings
         // for unknown "top-level" metadata.
@@ -1137,12 +1138,11 @@ Slice::Gen::MetadataVisitor::validate(
             continue;
         }
 
-        if (operation && directive == "cpp:const")
+        if (operation && directive == "cpp:const" && arguments.empty())
         {
             continue;
         }
 
-        string_view arguments = meta->arguments();
         if (directive == "cpp:type" && (arguments == "wstring" || arguments == "string"))
         {
             BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(cont);
@@ -1159,27 +1159,34 @@ Slice::Gen::MetadataVisitor::validate(
         }
         if (dynamic_pointer_cast<Sequence>(cont))
         {
-            if (directive == "cpp:type" || directive == "cpp:view-type" || directive == "cpp:array")
+            if ((directive == "cpp:type" || directive == "cpp:view-type") && !arguments.empty())
+            {
+                continue;
+            }
+            if (directive == "cpp:array" && arguments.empty())
             {
                 continue;
             }
         }
-        if (dynamic_pointer_cast<Dictionary>(cont) && (directive == "cpp:type" || directive == "cpp:view-type"))
+        if (dynamic_pointer_cast<Dictionary>(cont))
+        {
+            if ((directive == "cpp:type" || directive == "cpp:view-type") && !arguments.empty())
+            {
+                continue;
+            }
+        }
+        if (dynamic_pointer_cast<Exception>(cont) && directive == "cpp:ice_print" && arguments.empty())
         {
             continue;
         }
-        if (dynamic_pointer_cast<Exception>(cont) && directive == "cpp:ice_print")
-        {
-            continue;
-        }
-        if (dynamic_pointer_cast<Enum>(cont) && directive == "cpp:unscoped")
+        if (dynamic_pointer_cast<Enum>(cont) && directive == "cpp:unscoped" && arguments.empty())
         {
             continue;
         }
 
         {
             ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(cont);
-            if (cl && directive == "cpp:type")
+            if (cl && directive == "cpp:type" && !arguments.empty())
             {
                 continue;
             }

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1120,7 +1120,7 @@ Slice::Gen::MetadataVisitor::validate(
 
         // Issue friendly warning for cpp11 and cpp98 metadata what were removed as Slice does not issue warnings
         // for unknown "top-level" metadata.
-        if (directive.find("cpp11:") == 0 || directive.find("cpp98:") == 0)
+        if (directive.find("cpp11") == 0 || directive.find("cpp98") == 0)
         {
             ostringstream ostr;
             ostr << "ignoring invalid metadata '" << *meta << "'";

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -945,7 +945,8 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
                     if (seenHeaderExtension)
                     {
                         ostringstream ostr;
-                        ostr << "ignoring invalid file metadata '" << *s << "': directive can appear only once per file";
+                        ostr << "ignoring invalid file metadata '" << *s
+                             << "': directive can appear only once per file";
                         dc->warning(InvalidMetadata, file, -1, ostr.str());
                         fileMetadata.remove(s);
                     }
@@ -957,7 +958,8 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
                     if (seenSourceExtension)
                     {
                         ostringstream ostr;
-                        ostr << "ignoring invalid file metadata '" << *s << "': directive can appear only once per file";
+                        ostr << "ignoring invalid file metadata '" << *s
+                             << "': directive can appear only once per file";
                         dc->warning(InvalidMetadata, file, -1, ostr.str());
                         fileMetadata.remove(s);
                     }
@@ -969,7 +971,8 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
                     if (seenDllExport)
                     {
                         ostringstream ostr;
-                        ostr << "ignoring invalid file metadata '" << *s << "': directive can appear only once per file";
+                        ostr << "ignoring invalid file metadata '" << *s
+                             << "': directive can appear only once per file";
                         dc->warning(InvalidMetadata, file, -1, ostr.str());
                         fileMetadata.remove(s);
                     }

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1097,7 +1097,7 @@ Slice::Gen::MetadataVisitor::visitConst(const ConstPtr& p)
 MetadataList
 Slice::Gen::MetadataVisitor::validate(
     const SyntaxTreeBasePtr& cont,
-    const MetadataList& metadata,
+    MetadataList metadata,
     const string& file,
     int line,
     bool operation)
@@ -1106,9 +1106,9 @@ Slice::Gen::MetadataVisitor::validate(
     const DefinitionContextPtr dc = ut->findDefinitionContext(file);
     assert(dc);
 
-    MetadataList newMetadata = metadata;
-    for (const auto& meta : metadata)
+    for (MetadataList::const_iterator q = metadata.begin(); q != metadata.end();)
     {
+        MetadataPtr meta = *q++;
         string_view directive = meta->directive();
         string_view arguments = meta->arguments();
 
@@ -1119,7 +1119,7 @@ Slice::Gen::MetadataVisitor::validate(
             ostringstream ostr;
             ostr << "ignoring invalid metadata '" << *meta << "'";
             dc->warning(InvalidMetadata, file, line, ostr.str());
-            newMetadata.remove(meta);
+            meta.remove(meta);
             continue;
         }
 
@@ -1185,9 +1185,9 @@ Slice::Gen::MetadataVisitor::validate(
         ostringstream ostr;
         ostr << "ignoring invalid metadata '" << *meta << "'";
         dc->warning(InvalidMetadata, file, line, ostr.str());
-        newMetadata.remove(meta);
+        metadata.remove(meta);
     }
-    return newMetadata;
+    return metadata;
 }
 
 TypeContext

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -94,7 +94,7 @@ namespace
         const SyntaxTreeBasePtr& valueType,
         const string& value,
         TypeContext typeContext,
-        const StringList& metadata,
+        const MetadataList& metadata,
         const string& scope)
     {
         ConstPtr constant = dynamic_pointer_cast<Const>(valueType);
@@ -414,12 +414,13 @@ namespace
             UnitPtr unt = p->container()->unit();
             string file = p->file();
             assert(!file.empty());
-            static const string prefix = "cpp:doxygen:include:";
             DefinitionContextPtr dc = unt->findDefinitionContext(file);
             assert(dc);
-            if (auto meta = dc->findMetadata(prefix))
+
+            // TODO: why do we ignore all instances of this metadata except the first?
+            if (auto headerFile = dc->getMetadataArgs("cpp:doxygen:include"))
             {
-                out << nl << " * \\headerfile " << meta->substr(prefix.size());
+                out << nl << " * \\headerfile " << *headerFile;
             }
         }
 
@@ -675,10 +676,9 @@ Slice::Gen::generate(const UnitPtr& p)
     //
     if (_dllExport.empty())
     {
-        static const string dllExportPrefix = "cpp:dll-export:";
-        if (auto meta = dc->findMetadata(dllExportPrefix))
+        if (auto dllExport = dc->getMetadataArgs("cpp:dll-export"))
         {
-            _dllExport = meta->substr(dllExportPrefix.size());
+            _dllExport = *dllExport;
         }
     }
 
@@ -767,19 +767,20 @@ Slice::Gen::generate(const UnitPtr& p)
         }
     }
 
-    // Emit #include statements for any cpp:include metadata directives in the top-level Slice file.
+    // Emit #include statements for any 'cpp:include' metadata directives in the top-level Slice file.
     {
-        StringList fileMetadata = dc->getMetadata();
-        for (StringList::const_iterator q = fileMetadata.begin(); q != fileMetadata.end();)
+        MetadataList fileMetadata = dc->getMetadata();
+        for (MetadataList::const_iterator q = fileMetadata.begin(); q != fileMetadata.end();)
         {
-            string metadata = *q++;
-            static const string includePrefix = "cpp:include:";
-            static const string sourceIncludePrefix = "cpp:source-include:";
-            if (metadata.find(includePrefix) == 0)
+            MetadataPtr metadata = *q++;
+            string_view directive = metadata->directive();
+            string_view arguments = metadata->arguments();
+
+            if (directive == "cpp:include")
             {
-                if (metadata.size() > includePrefix.size())
+                if (!arguments.empty())
                 {
-                    H << nl << "#include <" << metadata.substr(includePrefix.size()) << ">";
+                    H << nl << "#include <" << arguments << ">";
                 }
                 else
                 {
@@ -789,11 +790,11 @@ Slice::Gen::generate(const UnitPtr& p)
                     fileMetadata.remove(metadata);
                 }
             }
-            else if (metadata.find(sourceIncludePrefix) == 0)
+            else if (directive == "cpp:source-include")
             {
-                if (metadata.size() > sourceIncludePrefix.size())
+                if (!arguments.empty())
                 {
-                    C << nl << "#include <" << metadata.substr(sourceIncludePrefix.size()) << ">";
+                    C << nl << "#include <" << arguments << ">";
                 }
                 else
                 {
@@ -900,89 +901,88 @@ Slice::Gen::validateMetadata(const UnitPtr& u)
 bool
 Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
 {
-    static const string prefix = "cpp:";
-
-    //
     // Validate file metadata in the top-level file and all included files.
-    //
     for (const string& file : unit->allFiles())
     {
         DefinitionContextPtr dc = unit->findDefinitionContext(file);
-        StringList fileMetadata = dc->getMetadata();
+        MetadataList fileMetadata = dc->getMetadata();
         assert(dc);
-        int headerExtension = 0;
-        int sourceExtension = 0;
-        int dllExport = 0;
-        for (StringList::const_iterator r = fileMetadata.begin(); r != fileMetadata.end();)
+        bool seenHeaderExtension = false;
+        bool seenSourceExtension = false;
+        bool seenDllExport = false;
+
+        for (MetadataList::const_iterator r = fileMetadata.begin(); r != fileMetadata.end();)
         {
-            string s = *r++;
-            if (s.find(prefix) == 0)
+            MetadataPtr s = *r++;
+            string_view directive = s->directive();
+            string_view arguments = s->arguments();
+
+            if (directive.starts_with("cpp:"))
             {
-                static const string cppIncludePrefix = "cpp:include:";
+                static const string cppIncludePrefix = "cpp:include";
                 static const string cppNoDefaultInclude = "cpp:no-default-include";
                 static const string cppNoStream = "cpp:no-stream";
                 static const string cppSourceIncludePrefix = "cpp:source-include";
-                static const string cppHeaderExtPrefix = "cpp:header-ext:";
-                static const string cppSourceExtPrefix = "cpp:source-ext:";
-                static const string cppDllExportPrefix = "cpp:dll-export:";
-                static const string cppDoxygenIncludePrefix = "cpp:doxygen:include:";
+                static const string cppHeaderExtPrefix = "cpp:header-ext";
+                static const string cppSourceExtPrefix = "cpp:source-ext";
+                static const string cppDllExportPrefix = "cpp:dll-export";
+                static const string cppDoxygenIncludePrefix = "cpp:doxygen:include";
 
-                if (s == cppNoDefaultInclude || s == cppNoStream)
+                if (directive == cppNoDefaultInclude || directive == cppNoStream)
                 {
                     continue;
                 }
-                else if (s.find(cppIncludePrefix) == 0 && s.size() > cppIncludePrefix.size())
+                else if (directive == cppIncludePrefix && !arguments.empty())
                 {
                     continue;
                 }
-                else if (s.find(cppSourceIncludePrefix) == 0 && s.size() > cppSourceIncludePrefix.size())
+                else if (directive == cppSourceIncludePrefix && !arguments.empty())
                 {
                     continue;
                 }
-                else if (s.find(cppHeaderExtPrefix) == 0 && s.size() > cppHeaderExtPrefix.size())
+                else if (directive == cppHeaderExtPrefix && !arguments.empty())
                 {
-                    headerExtension++;
-                    if (headerExtension > 1)
+                    if (seenHeaderExtension)
                     {
                         ostringstream ostr;
-                        ostr << "ignoring invalid file metadata `" << s << "': directive can appear only once per file";
+                        ostr << "ignoring invalid file metadata '" << s << "': directive can appear only once per file";
                         dc->warning(InvalidMetadata, file, -1, ostr.str());
                         fileMetadata.remove(s);
                     }
+                    seenHeaderExtension = true;
                     continue;
                 }
-                else if (s.find(cppSourceExtPrefix) == 0 && s.size() > cppSourceExtPrefix.size())
+                else if (directive == cppSourceExtPrefix && !arguments.empty())
                 {
-                    sourceExtension++;
-                    if (sourceExtension > 1)
+                    if (seenSourceExtension)
                     {
                         ostringstream ostr;
-                        ostr << "ignoring invalid file metadata `" << s << "': directive can appear only once per file";
+                        ostr << "ignoring invalid file metadata '" << s << "': directive can appear only once per file";
                         dc->warning(InvalidMetadata, file, -1, ostr.str());
                         fileMetadata.remove(s);
                     }
+                    seenSourceExtension = true;
                     continue;
                 }
-                else if (s.find(cppDllExportPrefix) == 0 && s.size() > cppDllExportPrefix.size())
+                else if (directive == cppDllExportPrefix && !arguments.empty())
                 {
-                    dllExport++;
-                    if (dllExport > 1)
+                    if (seenDllExport)
                     {
                         ostringstream ostr;
-                        ostr << "ignoring invalid file metadata `" << s << "': directive can appear only once per file";
+                        ostr << "ignoring invalid file metadata '" << s << "': directive can appear only once per file";
                         dc->warning(InvalidMetadata, file, -1, ostr.str());
-
                         fileMetadata.remove(s);
                     }
+                    seenDllExport = true;
                     continue;
                 }
-                else if (s.find(cppDoxygenIncludePrefix) == 0 && s.size() > cppDoxygenIncludePrefix.size())
+                else if (directive == cppDoxygenIncludePrefix && !arguments.empty())
                 {
                     continue;
                 }
 
                 ostringstream ostr;
-                ostr << "ignoring invalid file metadata `" << s << "'";
+                ostr << "ignoring invalid file metadata '" << s << "'";
                 dc->warning(InvalidMetadata, file, -1, ostr.str());
                 fileMetadata.remove(s);
             }
@@ -996,7 +996,7 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
 bool
 Slice::Gen::MetadataVisitor::visitModuleStart(const ModulePtr& p)
 {
-    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    MetadataList metadata = validate(p, p->getMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
     return true;
 }
@@ -1004,14 +1004,14 @@ Slice::Gen::MetadataVisitor::visitModuleStart(const ModulePtr& p)
 void
 Slice::Gen::MetadataVisitor::visitClassDecl(const ClassDeclPtr& p)
 {
-    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    MetadataList metadata = validate(p, p->getMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
 }
 
 bool
 Slice::Gen::MetadataVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
-    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    MetadataList metadata = validate(p, p->getMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
     return true;
 }
@@ -1019,7 +1019,7 @@ Slice::Gen::MetadataVisitor::visitClassDefStart(const ClassDefPtr& p)
 bool
 Slice::Gen::MetadataVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
-    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    MetadataList metadata = validate(p, p->getMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
     return true;
 }
@@ -1027,7 +1027,7 @@ Slice::Gen::MetadataVisitor::visitExceptionStart(const ExceptionPtr& p)
 bool
 Slice::Gen::MetadataVisitor::visitStructStart(const StructPtr& p)
 {
-    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    MetadataList metadata = validate(p, p->getMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
     return true;
 }
@@ -1040,17 +1040,16 @@ Slice::Gen::MetadataVisitor::visitOperation(const OperationPtr& p)
     {
         const DefinitionContextPtr dc = p->unit()->findDefinitionContext(p->file());
         assert(dc);
-        StringList metadata = p->getMetadata();
-        for (StringList::const_iterator q = metadata.begin(); q != metadata.end();)
+        MetadataList metadata = p->getMetadata();
+        for (MetadataList::const_iterator q = metadata.begin(); q != metadata.end();)
         {
-            string s = *q++;
-            if (s.find("cpp:type:") == 0 || s.find("cpp:view-type:") == 0 || s == "cpp:array")
+            MetadataPtr s = *q++;
+            string_view directive = s->directive();
+            if (directive == "cpp:type" || directive == "cpp:view-type" || directive == "cpp:array")
             {
-                dc->warning(
-                    InvalidMetadata,
-                    p->file(),
-                    p->line(),
-                    "ignoring invalid metadata `" + s + "' for operation with void return type");
+                ostringstream ostr;
+                ostr << "ignoring invalid metadata '" << s << "' for operation with void return type";
+                dc->warning(InvalidMetadata, p->file(), p->line(), ostr.str());
                 metadata.remove(s);
             }
         }
@@ -1070,75 +1069,78 @@ Slice::Gen::MetadataVisitor::visitOperation(const OperationPtr& p)
 void
 Slice::Gen::MetadataVisitor::visitDataMember(const DataMemberPtr& p)
 {
-    StringList metadata = validate(p->type(), p->getMetadata(), p->file(), p->line());
+    MetadataList metadata = validate(p->type(), p->getMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
 }
 
 void
 Slice::Gen::MetadataVisitor::visitSequence(const SequencePtr& p)
 {
-    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    MetadataList metadata = validate(p, p->getMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
 }
 
 void
 Slice::Gen::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
 {
-    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    MetadataList metadata = validate(p, p->getMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
 }
 
 void
 Slice::Gen::MetadataVisitor::visitEnum(const EnumPtr& p)
 {
-    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    MetadataList metadata = validate(p, p->getMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
 }
 
 void
 Slice::Gen::MetadataVisitor::visitConst(const ConstPtr& p)
 {
-    StringList metadata = validate(p, p->getMetadata(), p->file(), p->line());
+    MetadataList metadata = validate(p, p->getMetadata(), p->file(), p->line());
     p->setMetadata(metadata);
 }
 
-StringList
+MetadataList
 Slice::Gen::MetadataVisitor::validate(
     const SyntaxTreeBasePtr& cont,
-    const StringList& metadata,
+    const MetadataList& metadata,
     const string& file,
     int line,
     bool operation)
 {
-    static const string cppPrefix = "cpp:";
-
     const UnitPtr ut = cont->unit();
     const DefinitionContextPtr dc = ut->findDefinitionContext(file);
     assert(dc);
-    StringList newMetadata = metadata;
-    for (const string& s : metadata)
+
+    MetadataList newMetadata = metadata;
+    for (const auto& meta : metadata)
     {
+        string_view directive = meta->directive();
+
         // Issue friendly warning for cpp11 and cpp98 metadata what were removed as Slice does not issue warnings
         // for unknown "top-level" metadata.
-        if (s.find("cpp11:") == 0 || s.find("cpp98:") == 0)
+        if (directive.starts_with("cpp11:") || directive.starts_with("cpp98:"))
         {
-            dc->warning(InvalidMetadata, file, line, "ignoring invalid metadata `" + s + "'");
-            newMetadata.remove(s);
+            ostringstream ostr;
+            ostr << "ignoring invalid metadata '" << meta << "'";
+            dc->warning(InvalidMetadata, file, line, ostr.str());
+            newMetadata.remove(meta);
             continue;
         }
 
-        if (s.find(cppPrefix) != 0)
-        {
-            continue;
-        }
-
-        if (operation && s == "cpp:const")
+        if (!directive.starts_with("cpp:"))
         {
             continue;
         }
 
-        string ss = s.substr(cppPrefix.size());
-        if (ss == "type:wstring" || ss == "type:string")
+        if (operation && directive == "cpp:const")
+        {
+            continue;
+        }
+
+        string_view arguments = meta->arguments();
+        if (directive == "cpp:type" && (arguments == "wstring" || arguments == "string"))
         {
             BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(cont);
             ModulePtr module = dynamic_pointer_cast<Module>(cont);
@@ -1154,34 +1156,36 @@ Slice::Gen::MetadataVisitor::validate(
         }
         if (dynamic_pointer_cast<Sequence>(cont))
         {
-            if (ss.find("type:") == 0 || ss.find("view-type:") == 0 || ss == "array")
+            if (directive == "cpp:type" || directive == "cpp:view-type" || directive == "cpp:array")
             {
                 continue;
             }
         }
-        if (dynamic_pointer_cast<Dictionary>(cont) && (ss.find("type:") == 0 || ss.find("view-type:") == 0))
+        if (dynamic_pointer_cast<Dictionary>(cont) && (directive == "cpp:type" || directive == "cpp:view-type"))
         {
             continue;
         }
-        if (dynamic_pointer_cast<Exception>(cont) && ss == "ice_print")
+        if (dynamic_pointer_cast<Exception>(cont) && directive == "cpp:ice_print")
         {
             continue;
         }
-        if (dynamic_pointer_cast<Enum>(cont) && ss == "unscoped")
+        if (dynamic_pointer_cast<Enum>(cont) && directive == "cpp:unscoped")
         {
             continue;
         }
 
         {
             ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(cont);
-            if (cl && ss.find("type:") == 0)
+            if (cl && directive == "cpp:type")
             {
                 continue;
             }
         }
 
-        dc->warning(InvalidMetadata, file, line, "ignoring invalid metadata `" + s + "'");
-        newMetadata.remove(s);
+        ostringstream ostr;
+        ostr << "ignoring invalid metadata '" << meta << "'";
+        dc->warning(InvalidMetadata, file, line, ostr.str());
+        newMetadata.remove(meta);
     }
     return newMetadata;
 }
@@ -1190,14 +1194,16 @@ TypeContext
 Slice::Gen::setUseWstring(ContainedPtr p, list<TypeContext>& hist, TypeContext typeCtx)
 {
     hist.push_back(typeCtx);
-    StringList metadata = p->getMetadata();
-    if (find(metadata.begin(), metadata.end(), "cpp:type:wstring") != metadata.end())
+    if (auto argument = p->getMetadataArgs("cpp:type"))
     {
-        typeCtx = TypeContext::UseWstring;
-    }
-    else if (find(metadata.begin(), metadata.end(), "cpp:type:string") != metadata.end())
-    {
-        typeCtx = TypeContext::None;
+        if (argument == "wstring")
+        {
+            typeCtx = TypeContext::UseWstring;
+        }
+        else if (argument == "string")
+        {
+            typeCtx = TypeContext::None;
+        }
     }
     return typeCtx;
 }
@@ -1213,27 +1219,17 @@ Slice::Gen::resetUseWstring(list<TypeContext>& hist)
 string
 Slice::Gen::getHeaderExt(const string& file, const UnitPtr& ut)
 {
-    static const string headerExtPrefix = "cpp:header-ext:";
     DefinitionContextPtr dc = ut->findDefinitionContext(file);
     assert(dc);
-    if (auto meta = dc->findMetadata(headerExtPrefix))
-    {
-        return meta->substr(headerExtPrefix.size());
-    }
-    return "";
+    return dc->getMetadataArgs("cpp:header-ext").value_or("");
 }
 
 string
 Slice::Gen::getSourceExt(const string& file, const UnitPtr& ut)
 {
-    static const string sourceExtPrefix = "cpp:source-ext:";
     DefinitionContextPtr dc = ut->findDefinitionContext(file);
     assert(dc);
-    if (auto meta = dc->findMetadata(sourceExtPrefix))
-    {
-        return meta->substr(sourceExtPrefix.size());
-    }
-    return "";
+    return dc->getMetadataArgs("cpp:source-ext").value_or("");
 }
 
 Slice::Gen::ForwardDeclVisitor::ForwardDeclVisitor(Output& h) : H(h), _useWstring(TypeContext::None) {}
@@ -1338,7 +1334,7 @@ Slice::Gen::ForwardDeclVisitor::visitSequence(const SequencePtr& p)
     string scope = fixKwd(p->scope());
     TypePtr type = p->type();
     TypeContext typeCtx = _useWstring;
-    StringList metadata = p->getMetadata();
+    MetadataList metadata = p->getMetadata();
 
     string seqType = findMetadata(metadata, _useWstring);
     writeDocSummary(H, p);
@@ -1658,7 +1654,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     for (const auto& q : paramList)
     {
         string paramName = fixKwd(q->name());
-        StringList metadata = q->getMetadata();
+        MetadataList metadata = q->getMetadata();
 
         if (q->isOutParam())
         {
@@ -2223,8 +2219,7 @@ Slice::Gen::DataDefVisitor::visitExceptionStart(const ExceptionPtr& p)
         H << sp;
     }
 
-    StringList metadata = p->getMetadata();
-    if (find(metadata.begin(), metadata.end(), "cpp:ice_print") != metadata.end())
+    if (p->hasMetadata("cpp:ice_print"))
     {
         H << nl << "/**";
         H << nl << " * Outputs a custom description of this exception to a stream.";

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -218,7 +218,7 @@ namespace Slice
             void visitConst(const ConstPtr&) final;
 
         private:
-            MetadataList validate(const SyntaxTreeBasePtr&, const MetadataList&, const std::string&, int, bool = false);
+            MetadataList validate(const SyntaxTreeBasePtr&, MetadataList, const std::string&, int, bool = false);
         };
 
         static void validateMetadata(const UnitPtr&);

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -218,7 +218,7 @@ namespace Slice
             void visitConst(const ConstPtr&) final;
 
         private:
-            StringList validate(const SyntaxTreeBasePtr&, const StringList&, const std::string&, int, bool = false);
+            MetadataList validate(const SyntaxTreeBasePtr&, const MetadataList&, const std::string&, int, bool = false);
         };
 
         static void validateMetadata(const UnitPtr&);

--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -209,14 +209,9 @@ compile(const vector<string>& argv)
             UnitPtr u = Unit::createUnit(false);
             int parseStatus = u->parse(*i, cppHandle, debug);
 
-            string ext = headerExtension;
-            static const string headerExtPrefix = "cpp:header-ext:";
             DefinitionContextPtr dc = u->findDefinitionContext(u->topLevelFile());
             assert(dc);
-            if (auto meta = dc->findMetadata(headerExtPrefix))
-            {
-                ext = meta->substr(headerExtPrefix.size());
-            }
+            string ext = dc->getMetadataArgs("cpp:header-ext").value_or("");
 
             u->destroy();
 

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1769,7 +1769,7 @@ Slice::CsGenerator::writeOptionalSequenceMarshalUnmarshalCode(
     const string typeS = typeToString(type, scope);
     const string seqS = typeToString(seq, scope);
 
-    const bool isArray = !seq->hasMetadata("cs:generic:");
+    const bool isArray = !seq->hasMetadata("cs:generic");
     const string length = isArray ? param + ".Length" : param + ".Count";
 
     BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -106,7 +106,7 @@ Slice::CsGenerator::getNamespace(const ContainedPtr& cont)
 
     return scope;
 }
-
+// getNamespace(seq) + "." + seq->name() + "Helper", scope
 string
 Slice::CsGenerator::getUnqualified(const string& type, const string& scope, bool builtin)
 {
@@ -1127,7 +1127,7 @@ Slice::CsGenerator::writeSequenceMarshalUnmarshalCode(
     assert(cont);
     if (useHelper)
     {
-        string helperName = getUnqualified(getNamespace(seq) + "." + seq->name() + "Helper", scope);
+        string helperName = getUnqualified(seq, scope, "", "Helper");
         if (marshal)
         {
             out << nl << helperName << ".write(" << stream << ", " << param << ");";

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1987,7 +1987,7 @@ Slice::CsGenerator::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
             }
             newFileMetadata.push_back(metadata);
         }
-        dc->setMetadata(newFileMetadata);
+        dc->setMetadata(std::move(newFileMetadata));
     }
     return true;
 }
@@ -2179,5 +2179,5 @@ Slice::CsGenerator::MetadataVisitor::validate(const ContainedPtr& cont)
         newLocalMetadata.push_back(metadata);
     }
 
-    cont->setMetadata(newLocalMetadata);
+    cont->setMetadata(std::move(newLocalMetadata));
 }

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -106,7 +106,7 @@ Slice::CsGenerator::getNamespace(const ContainedPtr& cont)
 
     return scope;
 }
-// getNamespace(seq) + "." + seq->name() + "Helper", scope
+
 string
 Slice::CsGenerator::getUnqualified(const string& type, const string& scope, bool builtin)
 {
@@ -1978,7 +1978,7 @@ Slice::CsGenerator::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
         for (const auto& metadata : dc->getMetadata())
         {
             string_view directive = metadata->directive();
-            if (directive.starts_with("cs:") && directive != "cs:attribute")
+            if (directive.find("cs:") == 0 && directive != "cs:attribute")
             {
                 dc->warning(InvalidMetadata, file, -1, "ignoring invalid file metadata '" + string(directive) + "'");
                 continue;
@@ -2085,7 +2085,7 @@ Slice::CsGenerator::MetadataVisitor::validate(const ContainedPtr& cont)
         string_view directive = metadata->directive();
         string_view arguments = metadata->arguments();
 
-        if (directive.starts_with("cs:"))
+        if (directive.find("cs:") == 0)
         {
             SequencePtr seq = dynamic_pointer_cast<Sequence>(cont);
             if (seq)

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1947,12 +1947,12 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     _out << nl << "public " << (classMapping ? "sealed partial record class" : "partial record struct") << ' ' << name;
 
     // Check for cs:implements metadata.
-    list<string_view> baseNames;
+    list<string> baseNames;
     for (const auto& metadata : p->getMetadata())
     {
         if (metadata->directive() == "cs:implements")
         {
-            baseNames.push_back(metadata->arguments());
+            baseNames.push_back(string(metadata->arguments()));
         }
     }
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1657,7 +1657,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     string ns = getNamespace(p);
     InterfaceList bases = p->bases();
 
-    list<string_view> baseNames;
+    list<string> baseNames;
 
     _out << sp;
     emitAttributes(p);
@@ -1680,7 +1680,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     {
         if (metadata->directive() == "cs:implements")
         {
-            baseNames.push_back(metadata->arguments());
+            baseNames.push_back(string(metadata->arguments()));
         }
     }
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1680,7 +1680,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     {
         if (metadata->directive() == "cs:implements")
         {
-            baseNames.push_back(string(metadata->arguments()));
+            baseNames.push_back(string{metadata->arguments()});
         }
     }
 
@@ -1952,7 +1952,7 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     {
         if (metadata->directive() == "cs:implements")
         {
-            baseNames.push_back(string(metadata->arguments()));
+            baseNames.push_back(string{metadata->arguments()});
         }
     }
 

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -1004,7 +1004,7 @@ Slice::JavaVisitor::writeUnmarshalProxyResults(Output& out, const string& packag
         bool optional;
         TypePtr type;
         int tag;
-        StringList metadata;
+        MetadataList metadata;
         if (ret)
         {
             type = ret;
@@ -1102,7 +1102,7 @@ Slice::JavaVisitor::writeMarshalServantResults(
         OptionalMode mode;
         TypePtr type;
         int tag;
-        StringList metadata;
+        MetadataList metadata;
         if (op->returnType())
         {
             type = op->returnType();
@@ -1343,18 +1343,11 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
     out << nl << "return \"" << p->scoped() << "\";";
     out << eb;
 
-    //
     // Dispatch methods. We only generate methods for operations
     // defined in this InterfaceDef, because we reuse existing methods
     // for inherited operations.
-    //
-    for (OperationList::const_iterator r = ops.begin(); r != ops.end(); ++r)
+    for (const auto& op : ops)
     {
-        OperationPtr op = *r;
-        StringList opMetadata = op->getMetadata();
-
-        CommentPtr dc = op->parseComment(false);
-
         string opName = op->name();
         out << sp;
 

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -2318,7 +2318,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     {
         if (metadata->directive() == "java:implements")
         {
-            implements.push_back(string(metadata->arguments()));
+            implements.push_back(string{metadata->arguments()});
         }
     }
 
@@ -2933,7 +2933,7 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     {
         if (metadata->directive() == "java:implements")
         {
-            implements.push_back(string(metadata->arguments()));
+            implements.push_back(string{metadata->arguments()});
         }
     }
 

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -2312,17 +2312,13 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     Output& out = output();
 
-    //
-    // Check for java:implements metadata.
-    //
-    const StringList metadata = p->getMetadata();
-    static const string prefix = "java:implements:";
+    // Check for 'java:implements' metadata.
     StringList implements;
-    for (StringList::const_iterator q = metadata.begin(); q != metadata.end(); ++q)
+    for (const auto& metadata : p->getMetadata())
     {
-        if (q->find(prefix) == 0)
+        if (metadata->directive() == "java:implements")
         {
-            implements.push_back(q->substr(prefix.size()));
+            implements.push_back(string(metadata->arguments()));
         }
     }
 
@@ -2931,17 +2927,13 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
 
     Output& out = output();
 
-    //
-    // Check for java:implements metadata.
-    //
-    const StringList metadata = p->getMetadata();
-    static const string prefix = "java:implements:";
+    // Check for 'java:implements' metadata.
     StringList implements;
-    for (StringList::const_iterator q = metadata.begin(); q != metadata.end(); ++q)
+    for (const auto& metadata : p->getMetadata())
     {
-        if (q->find(prefix) == 0)
+        if (metadata->directive() == "java:implements")
         {
-            implements.push_back(q->substr(prefix.size()));
+            implements.push_back(string(metadata->arguments()));
         }
     }
 
@@ -3252,13 +3244,13 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
     const ContainedPtr contained = dynamic_pointer_cast<Contained>(container);
 
     const string name = fixKwd(p->name());
-    const StringList metadata = p->getMetadata();
-    const bool getSet = p->hasMetadata(_getSetMetadata) || contained->hasMetadata(_getSetMetadata);
+    const bool getSet = p->hasMetadata("java:getset") || contained->hasMetadata("java:getset");
     const bool optional = p->optional();
     const TypePtr type = p->type();
     const BuiltinPtr b = dynamic_pointer_cast<Builtin>(type);
     const bool classType = type->isClassType();
 
+    const MetadataList metadata = p->getMetadata();
     const string s = typeToString(type, TypeModeMember, getPackage(contained), metadata, true, false);
 
     Output& out = output();
@@ -3272,10 +3264,8 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
         out << nl << "@Deprecated";
     }
 
-    //
     // Access visibility for class data members can be controlled by metadata.
     // If none is specified, the default is public.
-    //
     if (cls && (p->hasMetadata("protected") || contained->hasMetadata("protected")))
     {
         out << nl << "protected " << s << ' ' << name << ';';
@@ -3489,7 +3479,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
             if (!hasTypeMetadata(seq, metadata))
             {
                 string elem =
-                    typeToString(seq->type(), TypeModeMember, getPackage(contained), StringList(), true, false);
+                    typeToString(seq->type(), TypeModeMember, getPackage(contained), MetadataList(), true, false);
 
                 //
                 // Indexed getter.
@@ -3776,7 +3766,7 @@ Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
     bool suppressUnchecked = false;
 
     string instanceType, formalType;
-    bool customType = getSequenceTypes(p, "", StringList(), instanceType, formalType);
+    bool customType = getSequenceTypes(p, "", MetadataList(), instanceType, formalType);
 
     if (!customType)
     {
@@ -3869,16 +3859,13 @@ Slice::Gen::HelperVisitor::visitSequence(const SequencePtr& p)
         }
         else
         {
-            //
             // The sequence is an instance of java.util.List<E>, where E is a fixed-size type.
             // If the element type is bool or byte, we do NOT write an extra size.
-            //
             const size_t sz = p->type()->minWireSize();
             if (sz > 1)
             {
-                string metadata;
                 out << nl << "final int optSize = v == null ? 0 : ";
-                if (findMetadata("java:buffer", p->getMetadata(), metadata))
+                if (p->hasMetadata("java:buffer"))
                 {
                     out << "v.remaining() / " << sz << ";";
                 }
@@ -3942,8 +3929,7 @@ Slice::Gen::HelperVisitor::visitDictionary(const DictionaryPtr& p)
     string absolute = getUnqualified(p);
     string helper = getUnqualified(p, "", "", "Helper");
     string package = getPackage(p);
-    StringList metadata = p->getMetadata();
-    string formalType = typeToString(p, TypeModeIn, package, StringList(), true);
+    string formalType = typeToString(p, TypeModeIn, package, MetadataList(), true);
 
     open(helper, p->file());
     Output& out = output();

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -437,6 +437,7 @@ namespace
                     //
                     dc->warning(InvalidMetadata, file, line, "ignoring invalid metadata `" + *i + "'");
                 }
+                // TODO: the delegate metadata is only for local interfaces, we should remove this check.
                 else if (i->find("delegate") == 0)
                 {
                     dc->warning(InvalidMetadata, file, line, "ignoring invalid metadata `" + *i + "'");

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -101,7 +101,7 @@ namespace
                         else
                         {
                             ostringstream msg;
-                            msg << "ignoring invalid file metadata '" << metadata << "'";
+                            msg << "ignoring invalid file metadata '" << *metadata << "'";
                             dc->warning(InvalidMetadata, file, -1,  msg.str());
                             fileMetadata.remove(metadata);
                         }
@@ -173,7 +173,7 @@ namespace
                     if (m->directive() == "java:type")
                     {
                         ostringstream msg;
-                        msg << "ignoring invalid metadata '" << m << "' for operation with void return type";
+                        msg << "ignoring invalid metadata '" << *m << "' for operation with void return type";
                         dc->warning(InvalidMetadata, m->file(), m->line(), msg.str());
                         metadata.remove(m);
                         continue;
@@ -226,7 +226,7 @@ namespace
                     if (!builtin || builtin->kind() != Builtin::KindByte)
                     {
                         ostringstream msg;
-                        msg << "ignoring invalid metadata '" << m << "': this metadata can only be used with a byte sequence";
+                        msg << "ignoring invalid metadata '" << *m << "': this metadata can only be used with a byte sequence";
                         dc->warning(InvalidMetadata, file, line, msg.str());
                         continue;
                     }
@@ -242,7 +242,7 @@ namespace
                                      builtin->kind() != Builtin::KindFloat && builtin->kind() != Builtin::KindDouble))
                     {
                         ostringstream msg;
-                        msg << "ignoring invalid metadata '" << m << "': this metadata can not be used with this type";
+                        msg << "ignoring invalid metadata '" << *m << "': this metadata can not be used with this type";
                         dc->warning(InvalidMetadata, file, line, msg.str());
                         continue;
                     }
@@ -352,7 +352,7 @@ namespace
                     }
 
                     ostringstream msg;
-                    msg << "ignoring invalid metadata '" << m << "'";
+                    msg << "ignoring invalid metadata '" << *m << "'";
                     dc->warning(InvalidMetadata, m->file(), m->line(), msg.str());
                 }
                 else
@@ -392,7 +392,9 @@ namespace
                         assert(b);
                         str = b->typeId();
                     }
-                    dc->warning(InvalidMetadata, file, line, "invalid metadata for " + str);
+                    ostringstream msg;
+                    msg << "ignoring invalid metadata '" << *m << "' for " << str;
+                    dc->warning(InvalidMetadata, file, line, msg.str());
                 }
                 else if (directive == "java:buffer")
                 {
@@ -411,14 +413,14 @@ namespace
                     }
 
                     ostringstream msg;
-                    msg << "ignoring invalid metadata '" << m << "'";
+                    msg << "ignoring invalid metadata '" << *m << "'";
                     dc->warning(InvalidMetadata, file, line, msg.str());
                 }
                 else if (directive == "java:serializable")
                 {
                     // Only valid in sequence definition which is checked in visitSequence
                     ostringstream msg;
-                    msg << "ignoring invalid metadata '" << m << "'";
+                    msg << "ignoring invalid metadata '" << *m << "'";
                     dc->warning(InvalidMetadata, file, line, msg.str());
                 }
                 else if (directive == "java:implements")
@@ -430,7 +432,7 @@ namespace
                     else
                     {
                         ostringstream msg;
-                        msg << "ignoring invalid metadata '" << m << "'";
+                        msg << "ignoring invalid metadata '" << *m << "'";
                         dc->warning(InvalidMetadata, file, line, msg.str());
                     }
                 }
@@ -444,7 +446,7 @@ namespace
                     else
                     {
                         ostringstream msg;
-                        msg << "ignoring invalid metadata '" << m << "'";
+                        msg << "ignoring invalid metadata '" << *m << "'";
                         dc->warning(InvalidMetadata, file, line, msg.str());
                     }
                 }

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -107,7 +107,7 @@ namespace
                         }
                     }
                 }
-                dc->setMetadata(fileMetadata);
+                dc->setMetadata(std::move(fileMetadata));
             }
             return true;
         }
@@ -117,7 +117,7 @@ namespace
             MetadataList metadata = getMetadata(p);
             metadata = validateType(p, metadata, p->file(), p->line());
             metadata = validateGetSet(p, metadata);
-            p->setMetadata(metadata);
+            p->setMetadata(std::move(metadata));
             return true;
         }
 
@@ -126,7 +126,7 @@ namespace
             MetadataList metadata = getMetadata(p);
             metadata = validateType(p, metadata, p->file(), p->line());
             metadata = validateGetSet(p, metadata);
-            p->setMetadata(metadata);
+            p->setMetadata(std::move(metadata));
         }
 
         bool visitClassDefStart(const ClassDefPtr& p) final
@@ -134,7 +134,7 @@ namespace
             MetadataList metadata = getMetadata(p);
             metadata = validateType(p, metadata, p->file(), p->line());
             metadata = validateGetSet(p, metadata);
-            p->setMetadata(metadata);
+            p->setMetadata(std::move(metadata));
             return true;
         }
 
@@ -143,7 +143,7 @@ namespace
             MetadataList metadata = getMetadata(p);
             metadata = validateType(p, metadata, p->file(), p->line());
             metadata = validateGetSet(p, metadata);
-            p->setMetadata(metadata);
+            p->setMetadata(std::move(metadata));
             return true;
         }
 
@@ -152,7 +152,7 @@ namespace
             MetadataList metadata = getMetadata(p);
             metadata = validateType(p, metadata, p->file(), p->line());
             metadata = validateGetSet(p, metadata);
-            p->setMetadata(metadata);
+            p->setMetadata(std::move(metadata));
             return true;
         }
 
@@ -185,14 +185,14 @@ namespace
                 metadata = validateType(returnType, metadata, p->file(), p->line());
                 metadata = validateGetSet(p, metadata);
             }
-            p->setMetadata(metadata);
+            p->setMetadata(std::move(metadata));
 
             for (const auto& param : p->parameters())
             {
                 metadata = getMetadata(param);
                 metadata = validateType(param->type(), metadata, param->file(), param->line());
                 metadata = validateGetSet(param, metadata);
-                param->setMetadata(metadata);
+                param->setMetadata(std::move(metadata));
             }
         }
 
@@ -201,7 +201,7 @@ namespace
             MetadataList metadata = getMetadata(p);
             metadata = validateType(p->type(), metadata, p->file(), p->line());
             metadata = validateGetSet(p, metadata);
-            p->setMetadata(metadata);
+            p->setMetadata(std::move(metadata));
         }
 
         void visitSequence(const SequencePtr& p) final
@@ -254,7 +254,7 @@ namespace
             metadata = validateType(p, metadata, file, line);
             metadata = validateGetSet(p, metadata);
             newMetadata.insert(newMetadata.begin(), metadata.begin(), metadata.end());
-            p->setMetadata(newMetadata);
+            p->setMetadata(std::move(newMetadata));
         }
 
         void visitDictionary(const DictionaryPtr& p) final
@@ -262,7 +262,7 @@ namespace
             MetadataList metadata = getMetadata(p);
             metadata = validateType(p, metadata, p->file(), p->line());
             metadata = validateGetSet(p, metadata);
-            p->setMetadata(metadata);
+            p->setMetadata(std::move(metadata));
         }
 
         void visitEnum(const EnumPtr& p) final
@@ -270,7 +270,7 @@ namespace
             MetadataList metadata = getMetadata(p);
             metadata = validateType(p, metadata, p->file(), p->line());
             metadata = validateGetSet(p, metadata);
-            p->setMetadata(metadata);
+            p->setMetadata(std::move(metadata));
         }
 
         void visitConst(const ConstPtr& p) final
@@ -278,7 +278,7 @@ namespace
             MetadataList metadata = getMetadata(p);
             metadata = validateType(p, metadata, p->file(), p->line());
             metadata = validateGetSet(p, metadata);
-            p->setMetadata(metadata);
+            p->setMetadata(std::move(metadata));
         }
 
         bool shouldVisitIncludedDefinitions() const final { return true; }
@@ -2283,12 +2283,12 @@ Slice::JavaGenerator::getTypeMetadata(const MetadataList& metadata, string& inst
             string::size_type pos = arguments.find(':');
             if (pos != string::npos)
             {
-                instanceType = string(arguments.substr(0, pos));
-                formalType = string(arguments.substr(pos + 1));
+                instanceType = string{arguments.substr(0, pos)};
+                formalType = string{arguments.substr(pos + 1)};
             }
             else
             {
-                instanceType = string(arguments);
+                instanceType = string{arguments};
                 formalType.clear();
             }
             return true;

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -874,7 +874,7 @@ Slice::JavaGenerator::getPackagePrefix(const ContainedPtr& cont) const
 
     // The 'java:package' metadata can be defined as file metadata or applied to a top-level module.
     // We check for the metadata at the top-level module first and then fall back to the global scope.
-    if (auto metadataArgs = cont->getMetadataArgs("java:package"))
+    if (auto metadataArgs = m->getMetadataArgs("java:package"))
     {
         return *metadataArgs;
     }
@@ -2302,7 +2302,7 @@ Slice::JavaGenerator::hasTypeMetadata(const TypePtr& type, const MetadataList& l
     ContainedPtr cont = dynamic_pointer_cast<Contained>(type);
     if (cont)
     {
-        if (hasMetadata("java:type:", localMetadata))
+        if (hasMetadata("java:type", localMetadata))
         {
             return true;
         }

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -102,7 +102,7 @@ namespace
                         {
                             ostringstream msg;
                             msg << "ignoring invalid file metadata '" << *metadata << "'";
-                            dc->warning(InvalidMetadata, file, -1,  msg.str());
+                            dc->warning(InvalidMetadata, file, -1, msg.str());
                             fileMetadata.remove(metadata);
                         }
                     }
@@ -226,7 +226,8 @@ namespace
                     if (!builtin || builtin->kind() != Builtin::KindByte)
                     {
                         ostringstream msg;
-                        msg << "ignoring invalid metadata '" << *m << "': this metadata can only be used with a byte sequence";
+                        msg << "ignoring invalid metadata '" << *m
+                            << "': this metadata can only be used with a byte sequence";
                         dc->warning(InvalidMetadata, file, line, msg.str());
                         continue;
                     }
@@ -365,7 +366,8 @@ namespace
             return result;
         }
 
-        MetadataList validateType(const SyntaxTreeBasePtr& p, const MetadataList& metadata, const string& file, int line)
+        MetadataList
+        validateType(const SyntaxTreeBasePtr& p, const MetadataList& metadata, const string& file, int line)
         {
             const UnitPtr unt = p->unit();
             const DefinitionContextPtr dc = unt->findDefinitionContext(file);

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -239,7 +239,8 @@ namespace Slice
         // The functions return true if a custom type was defined and false to indicate
         // the default mapping was used.
         //
-        bool getDictionaryTypes(const DictionaryPtr&, const std::string&, const MetadataList&, std::string&, std::string&)
+        bool
+        getDictionaryTypes(const DictionaryPtr&, const std::string&, const MetadataList&, std::string&, std::string&)
             const;
         bool
         getSequenceTypes(const SequencePtr&, const std::string&, const MetadataList&, std::string&, std::string&) const;

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -142,7 +142,7 @@ namespace Slice
             const TypePtr&,
             TypeMode,
             const std::string& = std::string(),
-            const StringList& = StringList(),
+            const MetadataList& = MetadataList(),
             bool = true,
             bool = false) const;
 
@@ -155,7 +155,7 @@ namespace Slice
             const TypePtr&,
             TypeMode,
             const std::string& = std::string(),
-            const StringList& = StringList(),
+            const MetadataList& = MetadataList(),
             bool = true) const;
 
         //
@@ -184,7 +184,7 @@ namespace Slice
             bool,
             int&,
             const std::string& = "",
-            const StringList& = StringList(),
+            const MetadataList& = MetadataList(),
             const std::string& = "");
 
         //
@@ -199,7 +199,7 @@ namespace Slice
             int&,
             bool,
             const std::string& = "",
-            const StringList& = StringList());
+            const MetadataList& = MetadataList());
 
         //
         // Generate code to marshal or unmarshal a sequence type.
@@ -213,40 +213,38 @@ namespace Slice
             int&,
             bool,
             const std::string& = "",
-            const StringList& = StringList());
+            const MetadataList& = MetadataList());
 
         //
-        // Search metadata for an entry with the given prefix and return the entire string.
+        // Returns true if the metadata has an entry with the given directive, and false otherwise.
         //
-        static bool findMetadata(const std::string&, const StringList&, std::string&);
+        static bool hasMetadata(const std::string&, const MetadataList&);
 
         //
         // Get custom type metadata. If metadata is found, the abstract and
         // concrete types are extracted and the function returns true. If an
         // abstract type is not specified, it is set to an empty string.
         //
-        static bool getTypeMetadata(const StringList&, std::string&, std::string&);
+        static bool getTypeMetadata(const MetadataList&, std::string&, std::string&);
 
         //
         // Determine whether a custom type is defined. The function checks the
         // metadata of the type's original definition, as well as any optional
         // metadata that typically represents a data member or parameter.
         //
-        static bool hasTypeMetadata(const TypePtr&, const StringList& = StringList());
+        static bool hasTypeMetadata(const TypePtr&, const MetadataList& = MetadataList());
 
         //
         // Obtain the concrete and abstract types for a dictionary or sequence type.
         // The functions return true if a custom type was defined and false to indicate
         // the default mapping was used.
         //
-        bool getDictionaryTypes(const DictionaryPtr&, const std::string&, const StringList&, std::string&, std::string&)
+        bool getDictionaryTypes(const DictionaryPtr&, const std::string&, const MetadataList&, std::string&, std::string&)
             const;
         bool
-        getSequenceTypes(const SequencePtr&, const std::string&, const StringList&, std::string&, std::string&) const;
+        getSequenceTypes(const SequencePtr&, const std::string&, const MetadataList&, std::string&, std::string&) const;
 
         JavaOutput* createOutput();
-
-        static const std::string _getSetMetadata;
 
     private:
         std::string _dir;

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -1990,12 +1990,7 @@ namespace
 {
     string getDefinedIn(const ContainedPtr& p)
     {
-        const string prefix = "js:defined-in:";
-        if (auto meta = p->findMetadata(prefix))
-        {
-            return meta->substr(prefix.size());
-        }
-        return "";
+        return p->getMetadataArgs("js:defined-in").value_or("");
     }
 }
 
@@ -2061,7 +2056,7 @@ Slice::Gen::TypeScriptImportVisitor::visitUnitStart(const UnitPtr& unit)
     // Iterate all the included files and generate an import statement for each top-level module in the included file.
     for (const auto& included : includes)
     {
-        // The JavaScript module corresponding to the "js:module:" metadata in the included file.
+        // The JavaScript module corresponding to the `js:module` metadata in the included file.
         string jsImportedModule = getJavaScriptModule(unit->findDefinitionContext(included));
 
         if (_module != jsImportedModule)

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -940,7 +940,7 @@ Slice::Gen::ImportVisitor::writeImports(const UnitPtr& p)
     {
         set<string> sliceTopLevelModules = p->getTopLevelModules(included);
 
-        // The JavaScript module corresponding to the "js:module:" metadata in the included file.
+        // The JavaScript module corresponding to the 'js:module' metadata in the included file.
         string jsImportedModule = getJavaScriptModule(p->findDefinitionContext(included));
 
         if (jsModule == jsImportedModule || jsImportedModule.empty())
@@ -2048,7 +2048,7 @@ Slice::Gen::TypeScriptImportVisitor::visitUnitStart(const UnitPtr& unit)
     // Iterate all the included files and generate an import statement for each top-level module in the included file.
     for (const auto& included : includes)
     {
-        // The JavaScript module corresponding to the `js:module` metadata in the included file.
+        // The JavaScript module corresponding to the 'js:module' metadata in the included file.
         string jsImportedModule = getJavaScriptModule(unit->findDefinitionContext(included));
 
         if (_module != jsImportedModule)

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -1986,21 +1986,13 @@ Slice::Gen::TypesVisitor::encodeTypeForOperation(const TypePtr& type)
 
 Slice::Gen::TypeScriptImportVisitor::TypeScriptImportVisitor(IceInternal::Output& out) : JsVisitor(out) {}
 
-namespace
-{
-    string getDefinedIn(const ContainedPtr& p)
-    {
-        return p->getMetadataArgs("js:defined-in").value_or("");
-    }
-}
-
 void
 Slice::Gen::TypeScriptImportVisitor::addImport(const ContainedPtr& definition)
 {
     string jsImportedModule = getJavaScriptModule(definition->definitionContext());
     if (jsImportedModule.empty())
     {
-        string definedIn = getDefinedIn(definition);
+        string definedIn = definition->getMetadataArgs("js:defined-in").value_or("");
         if (!definedIn.empty())
         {
             _importedTypes[definition->scoped()] = "__module_" + pathToModule(definedIn) + ".";

--- a/cpp/src/slice2js/JsUtil.cpp
+++ b/cpp/src/slice2js/JsUtil.cpp
@@ -142,11 +142,9 @@ Slice::getJavaScriptModuleForType(const TypePtr& type)
 string
 Slice::getJavaScriptModule(const DefinitionContextPtr& dc)
 {
-    // Check if the file contains the js:module file metadata.-
+    // Check if the file contains the `js:module` file metadata.
     assert(dc);
-    const string prefix = "js:module:";
-    const optional<string> value = dc->findMetadata(prefix);
-    return value.has_value() ? (*value).substr(prefix.size()) : "";
+    return dc->getMetadataArgs("js:module").value_or("");
 }
 
 //

--- a/cpp/src/slice2js/JsUtil.cpp
+++ b/cpp/src/slice2js/JsUtil.cpp
@@ -142,7 +142,7 @@ Slice::getJavaScriptModuleForType(const TypePtr& type)
 string
 Slice::getJavaScriptModule(const DefinitionContextPtr& dc)
 {
-    // Check if the file contains the `js:module` file metadata.
+    // Check if the file contains the 'js:module' file metadata.
     assert(dc);
     return dc->getMetadataArgs("js:module").value_or("");
 }

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2966,7 +2966,7 @@ Slice::Python::MetadataVisitor::visitModuleStart(const ModulePtr& p)
         }
     }
 
-    p->setMetadata(metadata);
+    p->setMetadata(std::move(metadata));
     return true;
 }
 
@@ -3150,5 +3150,5 @@ Slice::Python::MetadataVisitor::reject(const ContainedPtr& cont)
             localMetadata.remove(s);
         }
     }
-    cont->setMetadata(localMetadata);
+    cont->setMetadata(std::move(localMetadata));
 }

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1841,7 +1841,7 @@ Slice::Python::CodeVisitor::writeMetadata(const MetadataList& metadata)
     for (const auto& meta : metadata)
     {
         string_view directive = meta->directive();
-        if (directive.starts_with("python:"))
+        if (directive.find("python:") == 0)
         {
             if (i > 0)
             {
@@ -2922,7 +2922,7 @@ Slice::Python::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
             string_view directive = meta->directive();
             string_view arguments = meta->arguments();
 
-            if (directive.starts_with("python:"))
+            if (directive.find("python:") == 0)
             {
                 if (directive == "python:package" && !arguments.empty())
                 {
@@ -2953,7 +2953,7 @@ Slice::Python::MetadataVisitor::visitModuleStart(const ModulePtr& p)
         MetadataPtr meta = *r++;
         string_view directive = meta->directive();
 
-        if (directive.starts_with("python:"))
+        if (directive.find("python:") == 0)
         {
             // Must be a top-level module.
             if (dynamic_pointer_cast<Unit>(p->container()) && directive == "python:package")
@@ -3071,12 +3071,11 @@ Slice::Python::MetadataVisitor::validateSequence(
     MetadataList newMetadata = metadata;
     for (MetadataList::const_iterator p = newMetadata.begin(); p != newMetadata.end();)
     {
-        string prefix = "python:";
         MetadataPtr s = *p++;
         string_view directive = s->directive();
         string_view arguments = s->arguments();
 
-        if (directive.starts_with(prefix))
+        if (directive.find(prefix) == 0)
         {
             SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
             if (seq)
@@ -3144,7 +3143,7 @@ Slice::Python::MetadataVisitor::reject(const ContainedPtr& cont)
     {
         MetadataPtr s = *p++;
         string_view directive = s->directive();
-        if (directive.starts_with("python:"))
+        if (directive.find("python:") == 0)
         {
             string msg = "ignoring invalid metadata '" + string(directive) + "'";
             dc->warning(InvalidMetadata, cont->file(), cont->line(), msg);

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1847,8 +1847,7 @@ Slice::Python::CodeVisitor::writeMetadata(const MetadataList& metadata)
             {
                 _out << ", ";
             }
-            // TODO are we really intentionally writing the _entire_ metadata here? And not just the arguments?
-            _out << "'" << directive << ":" << meta->arguments() << "'";
+            _out << "'" << *meta << "'";
             ++i;
         }
     }

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2932,7 +2932,7 @@ Slice::Python::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
                 }
 
                 ostringstream msg;
-                msg << "ignoring invalid file metadata '" << *meta << "'"
+                msg << "ignoring invalid file metadata '" << *meta << "'";
                 dc->warning(InvalidMetadata, file, -1, msg.str());
                 fileMetadata.remove(meta);
             }

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2960,7 +2960,7 @@ Slice::Python::MetadataVisitor::visitModuleStart(const ModulePtr& p)
                 continue;
             }
 
-            string msg =  "ignoring invalid file metadata '" + string(directive) + "'";
+            string msg = "ignoring invalid file metadata '" + string(directive) + "'";
             p->definitionContext()->warning(InvalidMetadata, p->file(), -1, msg);
             metadata.remove(meta);
         }
@@ -3079,7 +3079,6 @@ Slice::Python::MetadataVisitor::validateSequence(
             SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
             if (seq)
             {
-                // TODO This implementation seems strange, but I preserved the current behavior.
                 if (directive == "python:seq")
                 {
                     if (arguments == "tuple" || arguments == "list" || arguments == "default")
@@ -3089,12 +3088,12 @@ Slice::Python::MetadataVisitor::validateSequence(
                 }
                 else if (directive.size() > prefix.size())
                 {
-                    string_view subDirective = directive.substr(prefix.size());
-                    if (subDirective == "tuple" || subDirective == "list" || subDirective == "default")
+                    string_view argument = directive.substr(prefix.size());
+                    if (argument == "tuple" || argument == "list" || argument == "default")
                     {
                         continue;
                     }
-                    else if (subDirective == "array.array" || subDirective == "numpy.ndarray" || subDirective == "memoryview")
+                    else if (argument == "array.array" || argument == "numpy.ndarray" || argument == "memoryview")
                     {
                         // The memoryview sequence metadata is only valid for integral builtin
                         // types excluding strings.

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -25,13 +25,7 @@ namespace
     {
         DefinitionContextPtr dc = p->findDefinitionContext(p->topLevelFile());
         assert(dc);
-
-        static const string classResolverPrefix = "swift:class-resolver-prefix:";
-        if (auto meta = dc->findMetadata(classResolverPrefix))
-        {
-            return meta->substr(classResolverPrefix.size());
-        }
-        return "";
+        return dc->getMetadataArgs("swift:class-resolver-prefix").value_or("");
     }
 }
 
@@ -1020,7 +1014,7 @@ Gen::TypesVisitor::visitConst(const ConstPtr& p)
 
     writeDocSummary(out, p);
     out << nl << "public let " << name << ": " << typeToString(type, p) << " = ";
-    writeConstantValue(out, type, p->valueType(), p->value(), p->getMetadata(), swiftModule);
+    writeConstantValue(out, type, p->valueType(), p->value(), swiftModule);
     out << nl;
 }
 

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -614,7 +614,7 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     }
     else
     {
-        out << "[" << typeToString(p->type(), p, p->getMetadata(), false) << "]";
+        out << "[" << typeToString(p->type(), p, false) << "]";
     }
 
     if (builtin && builtin->kind() <= Builtin::KindString)
@@ -758,8 +758,8 @@ Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     const string swiftModule = getSwiftModule(getTopLevelModule(dynamic_pointer_cast<Contained>(p)));
     const string name = getRelativeTypeString(p, swiftModule);
 
-    const string keyType = typeToString(p->keyType(), p, p->keyMetadata(), false);
-    const string valueType = typeToString(p->valueType(), p, p->valueMetadata(), false);
+    const string keyType = typeToString(p->keyType(), p, false);
+    const string valueType = typeToString(p->valueType(), p, false);
     out << sp;
     writeDocSummary(out, p);
     out << nl << "public typealias " << fixIdent(name) << " = [" << keyType << ": " << valueType << "]";

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -1462,7 +1462,7 @@ Gen::ObjectVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     {
         if (metadata->directive() == "swift:inherits")
         {
-            baseNames.push_back(string(metadata->arguments()));
+            baseNames.push_back(string{metadata->arguments()});
         }
     }
 

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -1457,16 +1457,12 @@ Gen::ObjectVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         baseNames.push_back(fixIdent(getRelativeTypeString(*i, swiftModule)));
     }
 
-    //
-    // Check for swift:inherits metadata.
-    //
-    const StringList metadata = p->getMetadata();
-    static const string prefix = "swift:inherits:";
-    for (StringList::const_iterator q = metadata.begin(); q != metadata.end(); ++q)
+    // Check for 'swift:inherits' metadata.
+    for (const auto& metadata : p->getMetadata())
     {
-        if (q->find(prefix) == 0)
+        if (metadata->directive() == "swift:inherits")
         {
-            baseNames.push_back(q->substr(prefix.size()));
+            baseNames.push_back(string(metadata->arguments()));
         }
     }
 

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -1067,11 +1067,7 @@ SwiftGenerator::writeConstantValue(
 }
 
 string
-SwiftGenerator::typeToString(
-    const TypePtr& type,
-    const ContainedPtr& toplevel,
-    const MetadataList& metadata,
-    bool optional)
+SwiftGenerator::typeToString(const TypePtr& type, const ContainedPtr& toplevel, bool optional)
 {
     static const char* builtinTable[] = {
         "Swift.UInt8",
@@ -1323,7 +1319,7 @@ SwiftGenerator::writeMemberwiseInitializer(
         for (DataMemberList::const_iterator i = allMembers.begin(); i != allMembers.end(); ++i)
         {
             DataMemberPtr m = *i;
-            out << (fixIdent(m->name()) + ": " + typeToString(m->type(), p, m->getMetadata(), m->optional()));
+            out << (fixIdent(m->name()) + ": " + typeToString(m->type(), p, m->optional()));
         }
         out << epar;
         out << sb;
@@ -1365,7 +1361,7 @@ SwiftGenerator::writeMembers(
         const string defaultValue = member->defaultValue();
 
         const string memberName = fixIdent(member->name());
-        string memberType = typeToString(type, p, member->getMetadata(), member->optional());
+        string memberType = typeToString(type, p, member->optional());
 
         //
         // If the member type is equal to the member name, create a local type alias
@@ -1757,7 +1753,7 @@ SwiftGenerator::operationReturnType(const OperationPtr& op)
         {
             os << paramLabel("returnValue", outParams) << ": ";
         }
-        os << typeToString(returnType, op, op->getMetadata(), op->returnIsOptional());
+        os << typeToString(returnType, op, op->returnIsOptional());
     }
 
     for (ParamDeclList::const_iterator q = outParams.begin(); q != outParams.end(); ++q)
@@ -1772,7 +1768,7 @@ SwiftGenerator::operationReturnType(const OperationPtr& op)
             os << (*q)->name() << ": ";
         }
 
-        os << typeToString((*q)->type(), *q, (*q)->getMetadata(), (*q)->optional());
+        os << typeToString((*q)->type(), *q, (*q)->optional());
     }
 
     if (returnIsTuple)
@@ -1860,7 +1856,7 @@ SwiftGenerator::operationInParamsDeclaration(const OperationPtr& op)
                 os << ", ";
             }
 
-            os << typeToString((*q)->type(), *q, (*q)->getMetadata(), (*q)->optional());
+            os << typeToString((*q)->type(), *q, (*q)->optional());
         }
         if (isTuple)
         {
@@ -1881,7 +1877,7 @@ SwiftGenerator::getAllInParams(const OperationPtr& op)
         ParamInfo info;
         info.name = (*p)->name();
         info.type = (*p)->type();
-        info.typeStr = typeToString(info.type, op, (*p)->getMetadata(), (*p)->optional());
+        info.typeStr = typeToString(info.type, op, (*p)->optional());
         info.optional = (*p)->optional();
         info.tag = (*p)->tag();
         info.param = *p;
@@ -1928,7 +1924,7 @@ SwiftGenerator::getAllOutParams(const OperationPtr& op)
         ParamInfo info;
         info.name = (*p)->name();
         info.type = (*p)->type();
-        info.typeStr = typeToString(info.type, op, (*p)->getMetadata(), (*p)->optional());
+        info.typeStr = typeToString(info.type, op, (*p)->optional());
         info.optional = (*p)->optional();
         info.tag = (*p)->tag();
         info.param = *p;
@@ -1940,7 +1936,7 @@ SwiftGenerator::getAllOutParams(const OperationPtr& op)
         ParamInfo info;
         info.name = paramLabel("returnValue", params);
         info.type = op->returnType();
-        info.typeStr = typeToString(info.type, op, op->getMetadata(), op->returnIsOptional());
+        info.typeStr = typeToString(info.type, op, op->returnIsOptional());
         info.optional = op->returnIsOptional();
         info.tag = op->returnTag();
         l.push_back(info);
@@ -2444,7 +2440,7 @@ SwiftGenerator::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
 
     for (const auto& metadata : p->keyMetadata())
     {
-        if (metadata->directive().starts_with(prefix))
+        if (metadata->directive().find(prefix) == 0)
         {
             string msg = "ignoring invalid metadata '" + string(metadata->directive()) + "' for dictionary key type";
             dc->warning(InvalidMetadata, p->file(), p->line(), msg);
@@ -2453,7 +2449,7 @@ SwiftGenerator::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
 
     for (const auto& metadata : p->valueMetadata())
     {
-        if (metadata->directive().starts_with(prefix))
+        if (metadata->directive().find(prefix) == 0)
         {
             string msg = "ignoring invalid metadata '" + string(metadata->directive()) + "' for dictionary value type";
             dc->warning(InvalidMetadata, p->file(), p->line(), msg);
@@ -2492,7 +2488,7 @@ SwiftGenerator::MetadataVisitor::validate(
         MetadataPtr meta = *p++;
         string_view directive = meta->directive();
 
-        if (!directive.starts_with("swift:"))
+        if (directive.find("swift:") != 0)
         {
             continue;
         }

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -2515,7 +2515,7 @@ SwiftGenerator::MetadataVisitor::validate(
 
         ostringstream msg;
         msg << "ignoring invalid metadata '" << *meta << "'";
-        dc->warning(InvalidMetadata, file, line, msg);
+        dc->warning(InvalidMetadata, file, line, msg.str());
         newMetadata.remove(meta);
         continue;
     }

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -2506,7 +2506,7 @@ SwiftGenerator::MetadataVisitor::validate(
         if ((dynamic_pointer_cast<ClassDef>(cont) || dynamic_pointer_cast<InterfaceDef>(cont) ||
              dynamic_pointer_cast<Enum>(cont) || dynamic_pointer_cast<Exception>(cont) ||
              dynamic_pointer_cast<Operation>(cont)) &&
-             directive == "swift:attribute")
+            directive == "swift:attribute")
         {
             continue;
         }

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -2442,8 +2442,9 @@ SwiftGenerator::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
     {
         if (metadata->directive().find(prefix) == 0)
         {
-            string msg = "ignoring invalid metadata '" + string(metadata->directive()) + "' for dictionary key type";
-            dc->warning(InvalidMetadata, p->file(), p->line(), msg);
+            ostringstream msg;
+            msg << "ignoring invalid metadata '" << *metadata << "' for dictionary key type";
+            dc->warning(InvalidMetadata, p->file(), p->line(), msg.str());
         }
     }
 
@@ -2451,8 +2452,9 @@ SwiftGenerator::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
     {
         if (metadata->directive().find(prefix) == 0)
         {
-            string msg = "ignoring invalid metadata '" + string(metadata->directive()) + "' for dictionary value type";
-            dc->warning(InvalidMetadata, p->file(), p->line(), msg);
+            ostringstream msg;
+            msg << "ignoring invalid metadata '" << *metadata << "' for dictionary value type";
+            dc->warning(InvalidMetadata, p->file(), p->line(), msg.str());
         }
     }
 
@@ -2487,31 +2489,33 @@ SwiftGenerator::MetadataVisitor::validate(
     {
         MetadataPtr meta = *p++;
         string_view directive = meta->directive();
+        string_view arguments = meta->arguments();
 
         if (directive.find("swift:") != 0)
         {
             continue;
         }
 
-        if (dynamic_pointer_cast<Module>(cont) && directive == "swift:module")
+        if (dynamic_pointer_cast<Module>(cont) && directive == "swift:module" && !arguments.empty())
         {
             continue;
         }
 
-        if (dynamic_pointer_cast<InterfaceDef>(cont) && directive == "swift:inherits")
+        if (dynamic_pointer_cast<InterfaceDef>(cont) && directive == "swift:inherits" && !arguments.empty())
         {
             continue;
         }
 
         if ((dynamic_pointer_cast<ClassDef>(cont) || dynamic_pointer_cast<InterfaceDef>(cont) ||
-             dynamic_pointer_cast<Enum>(cont) || dynamic_pointer_cast<Exception>(cont) ||
-             dynamic_pointer_cast<Operation>(cont)) &&
-            directive == "swift:attribute")
+             dynamic_pointer_cast<Enum>(cont) || dynamic_pointer_cast<Exception>(cont)) &&
+            directive == "swift:attribute" && !arguments.empty())
         {
             continue;
         }
 
-        dc->warning(InvalidMetadata, file, line, "ignoring invalid metadata '" + string(directive) + "'");
+        ostringstream msg;
+        msg << "ignoring invalid metadata '" << *meta << "'";
+        dc->warning(InvalidMetadata, file, line, msg);
         newMetadata.remove(meta);
         continue;
     }

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -88,7 +88,11 @@ namespace Slice
         ParamInfoList getAllOutParams(const OperationPtr&);
         void getOutParams(const OperationPtr&, ParamInfoList&, ParamInfoList&);
 
-        std::string typeToString(const TypePtr&, const ContainedPtr&, const StringList& = StringList(), bool = false);
+        std::string typeToString(
+            const TypePtr&,
+            const ContainedPtr&,
+            const MetadataList& = MetadataList(),
+            bool = false);
 
         std::string getUnqualified(const std::string&, const std::string&);
         std::string modeToString(Operation::Mode);
@@ -109,7 +113,6 @@ namespace Slice
             const TypePtr&,
             const SyntaxTreeBasePtr&,
             const std::string&,
-            const StringList&,
             const std::string&,
             bool optional = false);
         void writeDefaultInitializer(IceInternal::Output&, bool, bool);
@@ -138,7 +141,7 @@ namespace Slice
         void writeUnmarshalInParams(::IceInternal::Output&, const OperationPtr&);
         void writeUnmarshalOutParams(::IceInternal::Output&, const OperationPtr&);
         void writeUnmarshalUserException(::IceInternal::Output& out, const OperationPtr&);
-        void writeSwiftAttributes(::IceInternal::Output&, const StringList&);
+        void writeSwiftAttributes(::IceInternal::Output&, const MetadataList&);
         void writeProxyOperation(::IceInternal::Output&, const OperationPtr&);
         void writeDispatchOperation(::IceInternal::Output&, const OperationPtr&);
 
@@ -160,7 +163,7 @@ namespace Slice
             bool shouldVisitIncludedDefinitions() const final { return true; }
 
         private:
-            StringList validate(const SyntaxTreeBasePtr&, const StringList&, const std::string&, int);
+            MetadataList validate(const SyntaxTreeBasePtr&, const MetadataList&, const std::string&, int);
 
             typedef std::map<std::string, std::string> ModuleMap;
             typedef std::map<std::string, ModuleMap> ModulePrefix;

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -88,11 +88,7 @@ namespace Slice
         ParamInfoList getAllOutParams(const OperationPtr&);
         void getOutParams(const OperationPtr&, ParamInfoList&, ParamInfoList&);
 
-        std::string typeToString(
-            const TypePtr&,
-            const ContainedPtr&,
-            const MetadataList& = MetadataList(),
-            bool = false);
+        std::string typeToString(const TypePtr&, const ContainedPtr&, bool = false);
 
         std::string getUnqualified(const std::string&, const std::string&);
         std::string modeToString(Operation::Mode);

--- a/cpp/test/Slice/errorDetection/WarningInvalidMetadata.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidMetadata.err
@@ -1,21 +1,21 @@
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata `cpp:header-ext:hh': directive can appear only once per file
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata `cpp:source-ext:cc': directive can appear only once per file
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata `cpp:dll-export:Test': directive can appear only once per file
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata `cpp:header-ext'
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata `cpp:header-ext:'
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata `cpp:source-ext'
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata `cpp:source-ext:'
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata `cpp:dll-export'
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata `cpp:dll-export:'
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata `cpp:include'
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata `cpp:include:'
-WarningInvalidMetadata.ice:35: warning: ignoring invalid metadata `cpp:type:std::list<::std::string>' for operation with void return type
-WarningInvalidMetadata.ice:38: warning: ignoring invalid metadata `cpp:array' for operation with void return type
-WarningInvalidMetadata.ice:40: warning: ignoring invalid metadata `cpp:type:my_string'
-WarningInvalidMetadata.ice:42: warning: ignoring invalid metadata `cpp:view-type:my_string'
-WarningInvalidMetadata.ice:47: warning: ignoring invalid metadata `cpp:const'
-WarningInvalidMetadata.ice:47: warning: ignoring invalid metadata `cpp:ice_print'
-WarningInvalidMetadata.ice:53: warning: ignoring invalid metadata `cpp:virtual'
-WarningInvalidMetadata.ice:58: warning: ignoring invalid metadata `cpp:bad'
-WarningInvalidMetadata.ice:63: warning: ignoring invalid metadata `cpp98:foo'
-WarningInvalidMetadata.ice:63: warning: ignoring invalid metadata `cpp11:bar'
+WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:header-ext:hh': directive can appear only once per file
+WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:source-ext:cc': directive can appear only once per file
+WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:dll-export:Test': directive can appear only once per file
+WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:header-ext'
+WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:header-ext:'
+WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:source-ext'
+WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:source-ext:'
+WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:dll-export'
+WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:dll-export:'
+WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:include'
+WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:include:'
+WarningInvalidMetadata.ice:35: warning: ignoring invalid metadata 'cpp:type:std::list<::std::string>' for operation with void return type
+WarningInvalidMetadata.ice:38: warning: ignoring invalid metadata 'cpp:array' for operation with void return type
+WarningInvalidMetadata.ice:40: warning: ignoring invalid metadata 'cpp:type:my_string'
+WarningInvalidMetadata.ice:42: warning: ignoring invalid metadata 'cpp:view-type:my_string'
+WarningInvalidMetadata.ice:47: warning: ignoring invalid metadata 'cpp:const'
+WarningInvalidMetadata.ice:47: warning: ignoring invalid metadata 'cpp:ice_print'
+WarningInvalidMetadata.ice:53: warning: ignoring invalid metadata 'cpp:virtual'
+WarningInvalidMetadata.ice:58: warning: ignoring invalid metadata 'cpp:bad'
+WarningInvalidMetadata.ice:63: warning: ignoring invalid metadata 'cpp98:foo'
+WarningInvalidMetadata.ice:63: warning: ignoring invalid metadata 'cpp11:bar'

--- a/cpp/test/Slice/errorDetection/WarningInvalidMetadata.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidMetadata.err
@@ -2,13 +2,13 @@ WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:header-
 WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:source-ext:cc': directive can appear only once per file
 WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:dll-export:Test': directive can appear only once per file
 WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:header-ext'
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:header-ext:'
+WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:header-ext'
 WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:source-ext'
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:source-ext:'
+WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:source-ext'
 WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:dll-export'
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:dll-export:'
+WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:dll-export'
 WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:include'
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:include:'
+WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:include'
 WarningInvalidMetadata.ice:35: warning: ignoring invalid metadata 'cpp:type:std::list<::std::string>' for operation with void return type
 WarningInvalidMetadata.ice:38: warning: ignoring invalid metadata 'cpp:array' for operation with void return type
 WarningInvalidMetadata.ice:40: warning: ignoring invalid metadata 'cpp:type:my_string'


### PR DESCRIPTION
This PR improves the infrastructure and API around metadata.

The main change is that metadata is no longer stored directly as a string.
Now it has its own `Metadata` grammar type, which stores a pre-parsed version of the metadata.
Having the metadata pre-parsed into `directive[:arguments]` lets us offer a better API over it.

----

The first file in this PR (`Grammar.cpp`) is the generated parser. You don't need to review it.