### PR TITLE
Fix Bugs in How 'slice2swift' Handled 'misc' Comment Components

### DIFF
--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -657,7 +657,7 @@ SwiftGenerator::writeDocSummary(IceInternal::Output& out, const ContainedPtr& p)
 
     if (!doc.misc.empty())
     {
-        out << "///" << nl;
+        out << nl << "///";
         writeDocLines(out, doc.misc);
     }
 
@@ -789,8 +789,8 @@ SwiftGenerator::writeOpDocSummary(IceInternal::Output& out, const OperationPtr& 
 
     if (!doc.misc.empty())
     {
-        out << nl;
-        writeDocLines(out, doc.misc, false);
+        out << nl << "///";
+        writeDocLines(out, doc.misc);
     }
 }
 
@@ -838,7 +838,8 @@ SwiftGenerator::writeProxyDocSummary(IceInternal::Output& out, const InterfaceDe
 
     if (!doc.misc.empty())
     {
-        writeDocLines(out, doc.misc, false);
+        out << nl << "///";
+        writeDocLines(out, doc.misc);
     }
 }
 
@@ -878,7 +879,8 @@ SwiftGenerator::writeServantDocSummary(IceInternal::Output& out, const Interface
 
     if (!doc.misc.empty())
     {
-        writeDocLines(out, doc.misc, false);
+        out << nl << "///";
+        writeDocLines(out, doc.misc);
     }
 }
 
@@ -907,6 +909,7 @@ SwiftGenerator::writeMemberDoc(IceInternal::Output& out, const DataMemberPtr& p)
 
     if (!doc.misc.empty())
     {
+        out << nl << "///";
         writeDocLines(out, doc.misc);
     }
 

--- a/swift/test/Slice/escape/Key.ice
+++ b/swift/test/Slice/escape/Key.ice
@@ -10,8 +10,12 @@ enum continue
     var
 }
 
+/// The guard struct.
+/// @see defer
 struct guard
 {
+    /// A default
+    /// @foo Test
     int default;
 }
 
@@ -20,8 +24,15 @@ struct defer
     string else;
 }
 
+/// The break interface.
+/// @foo Test
 interface break
 {
+    /// The case operation.
+    /// @foo Test1
+    /// @param catch A catch
+    /// @param try A try
+    /// @bar Test2
     ["amd"] void case(int catch, out int try);
 }
 


### PR DESCRIPTION
This PR fixes #2088 (Adding `@remarks` to a doc comment caused `slice2swift` to generate uncompilable code).

That being said, I think #2088 is also a strange issue to open, since Slice has no support for `@remarks` comment tags.
All unrecognized tags (including `@remarks`) are put in a special `misc` field, the contents of which are just pasted on to the end of generated comments, because we don't know what else to do with them.