### PR TITLE
Fix Metadata Warning Locations

### DIFF
--- a/cpp/src/Slice/Scanner.cpp
+++ b/cpp/src/Slice/Scanner.cpp
@@ -1721,7 +1721,7 @@ case 16:
 YY_RULE_SETUP
 #line 233 "src/Slice/Scanner.l"
 {
-    currentUnit->warning(All, "unknown escape sequence in string literal: `" + string(yytext) + "'");
+    currentUnit->warning(All, "unknown escape sequence in string literal: '" + string{yytext} + "'");
 
     StringTokPtr str = dynamic_pointer_cast<StringTok>(*yylval);
     // Escape the entire sequence.

--- a/cpp/src/Slice/Scanner.l
+++ b/cpp/src/Slice/Scanner.l
@@ -230,7 +230,7 @@ floating_literal    (({fractional_constant}{exponent_part}?)|((\+|-)?{dec}+{expo
   /* Matches an unknown escape value. This rule has a lower priority than all the other escape rules because
    * it only matches 2 characters (the lowest any match), and it's beneath the others. */
 <STRING_LITERAL>"\\". {
-    currentUnit->warning(All, "unknown escape sequence in string literal: `" + string(yytext) + "'");
+    currentUnit->warning(All, "unknown escape sequence in string literal: '" + string{yytext} + "'");
 
     StringTokPtr str = dynamic_pointer_cast<StringTok>(*yylval);
     // Escape the entire sequence.

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -786,7 +786,7 @@ Slice::Gen::generate(const UnitPtr& p)
                 {
                     ostringstream ostr;
                     ostr << "ignoring invalid file metadata '" << *metadata << "'";
-                    dc->warning(InvalidMetadata, file, -1, ostr.str());
+                    dc->warning(InvalidMetadata, metadata->file(), metadata->line(), ostr.str());
                     fileMetadata.remove(metadata);
                 }
             }
@@ -800,7 +800,7 @@ Slice::Gen::generate(const UnitPtr& p)
                 {
                     ostringstream ostr;
                     ostr << "ignoring invalid file metadata '" << *metadata << "'";
-                    dc->warning(InvalidMetadata, file, -1, ostr.str());
+                    dc->warning(InvalidMetadata, metadata->file(), metadata->line(), ostr.str());
                     fileMetadata.remove(metadata);
                 }
             }
@@ -947,7 +947,7 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
                         ostringstream ostr;
                         ostr << "ignoring invalid file metadata '" << *s
                              << "': directive can appear only once per file";
-                        dc->warning(InvalidMetadata, file, -1, ostr.str());
+                        dc->warning(InvalidMetadata, s->file(), s->line(), ostr.str());
                         fileMetadata.remove(s);
                     }
                     seenHeaderExtension = true;
@@ -960,7 +960,7 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
                         ostringstream ostr;
                         ostr << "ignoring invalid file metadata '" << *s
                              << "': directive can appear only once per file";
-                        dc->warning(InvalidMetadata, file, -1, ostr.str());
+                        dc->warning(InvalidMetadata, s->file(), s->line(), ostr.str());
                         fileMetadata.remove(s);
                     }
                     seenSourceExtension = true;
@@ -973,7 +973,7 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
                         ostringstream ostr;
                         ostr << "ignoring invalid file metadata '" << *s
                              << "': directive can appear only once per file";
-                        dc->warning(InvalidMetadata, file, -1, ostr.str());
+                        dc->warning(InvalidMetadata, s->file(), s->line(), ostr.str());
                         fileMetadata.remove(s);
                     }
                     seenDllExport = true;
@@ -986,7 +986,7 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
 
                 ostringstream ostr;
                 ostr << "ignoring invalid file metadata '" << *s << "'";
-                dc->warning(InvalidMetadata, file, -1, ostr.str());
+                dc->warning(InvalidMetadata, s->file(), s->line(), ostr.str());
                 fileMetadata.remove(s);
             }
         }
@@ -999,34 +999,34 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
 bool
 Slice::Gen::MetadataVisitor::visitModuleStart(const ModulePtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getMetadata(), p->file()));
     return true;
 }
 
 void
 Slice::Gen::MetadataVisitor::visitClassDecl(const ClassDeclPtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getMetadata(), p->file()));
 }
 
 bool
 Slice::Gen::MetadataVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getMetadata(), p->file()));
     return true;
 }
 
 bool
 Slice::Gen::MetadataVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getMetadata(), p->file()));
     return true;
 }
 
 bool
 Slice::Gen::MetadataVisitor::visitStructStart(const StructPtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getMetadata(), p->file()));
     return true;
 }
 
@@ -1047,7 +1047,7 @@ Slice::Gen::MetadataVisitor::visitOperation(const OperationPtr& p)
             {
                 ostringstream ostr;
                 ostr << "ignoring invalid metadata '" << *s << "' for operation with void return type";
-                dc->warning(InvalidMetadata, p->file(), p->line(), ostr.str());
+                dc->warning(InvalidMetadata, s->file(), s->line(), ostr.str());
                 metadata.remove(s);
             }
         }
@@ -1055,43 +1055,43 @@ Slice::Gen::MetadataVisitor::visitOperation(const OperationPtr& p)
     }
     else
     {
-        p->setMetadata(validate(returnType, p->getMetadata(), p->file(), p->line(), true));
+        p->setMetadata(validate(returnType, p->getMetadata(), p->file(), true));
     }
 
     for (const auto& param : p->parameters())
     {
-        param->setMetadata(validate(param->type(), param->getMetadata(), p->file(), param->line(), true));
+        param->setMetadata(validate(param->type(), param->getMetadata(), p->file(), true));
     }
 }
 
 void
 Slice::Gen::MetadataVisitor::visitDataMember(const DataMemberPtr& p)
 {
-    p->setMetadata(validate(p->type(), p->getMetadata(), p->file(), p->line()));
+    p->setMetadata(validate(p->type(), p->getMetadata(), p->file()));
 }
 
 void
 Slice::Gen::MetadataVisitor::visitSequence(const SequencePtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getMetadata(), p->file()));
 }
 
 void
 Slice::Gen::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getMetadata(), p->file()));
 }
 
 void
 Slice::Gen::MetadataVisitor::visitEnum(const EnumPtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getMetadata(), p->file()));
 }
 
 void
 Slice::Gen::MetadataVisitor::visitConst(const ConstPtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file(), p->line()));
+    p->setMetadata(validate(p, p->getMetadata(), p->file()));
 }
 
 MetadataList
@@ -1099,7 +1099,6 @@ Slice::Gen::MetadataVisitor::validate(
     const SyntaxTreeBasePtr& cont,
     MetadataList metadata,
     const string& file,
-    int line,
     bool operation)
 {
     const UnitPtr ut = cont->unit();
@@ -1118,7 +1117,7 @@ Slice::Gen::MetadataVisitor::validate(
         {
             ostringstream ostr;
             ostr << "ignoring invalid metadata '" << *meta << "'";
-            dc->warning(InvalidMetadata, file, line, ostr.str());
+            dc->warning(InvalidMetadata, meta->file(), meta->line(), ostr.str());
             metadata.remove(meta);
             continue;
         }
@@ -1184,7 +1183,7 @@ Slice::Gen::MetadataVisitor::validate(
 
         ostringstream ostr;
         ostr << "ignoring invalid metadata '" << *meta << "'";
-        dc->warning(InvalidMetadata, file, line, ostr.str());
+        dc->warning(InvalidMetadata, meta->file(), meta->line(), ostr.str());
         metadata.remove(meta);
     }
     return metadata;

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -218,7 +218,7 @@ namespace Slice
             void visitConst(const ConstPtr&) final;
 
         private:
-            MetadataList validate(const SyntaxTreeBasePtr&, MetadataList, const std::string&, int, bool = false);
+            MetadataList validate(const SyntaxTreeBasePtr&, MetadataList, const std::string&, bool = false);
         };
 
         static void validateMetadata(const UnitPtr&);

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -225,7 +225,7 @@ namespace Slice
                 const SyntaxTreeBasePtr& cont,
                 MetadataList metadata,
                 const std::string& file,
-                bool operation);
+                bool operation = false);
         };
 
         static void validateMetadata(const UnitPtr&);

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -218,7 +218,14 @@ namespace Slice
             void visitConst(const ConstPtr&) final;
 
         private:
-            MetadataList validate(const SyntaxTreeBasePtr&, MetadataList, const std::string&, bool = false);
+            /// Validates any 'cpp' specific metadata that's been applied to `cont`.
+            /// Additional metadata to validate can also be passed in with the `metadata` field.
+            /// For example, type metadata applied to a sequence where it's being used instead of just defined.
+            MetadataList validate(
+                const SyntaxTreeBasePtr& cont,
+                MetadataList metadata,
+                const std::string& file,
+                bool operation);
         };
 
         static void validateMetadata(const UnitPtr&);

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1982,7 +1982,7 @@ Slice::CsGenerator::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
             {
                 ostringstream msg;
                 msg << "ignoring invalid file metadata '" << *metadata << "'";
-                dc->warning(InvalidMetadata, file, -1, msg.str());
+                dc->warning(InvalidMetadata, metadata->file(), metadata->line(), msg.str());
                 continue;
             }
             newFileMetadata.push_back(metadata);
@@ -2173,7 +2173,7 @@ Slice::CsGenerator::MetadataVisitor::validate(const ContainedPtr& cont)
 
             ostringstream msg;
             msg << "ignoring invalid metadata '" << *metadata << "'";
-            dc->warning(InvalidMetadata, cont->file(), cont->line(), msg.str());
+            dc->warning(InvalidMetadata, metadata->file(), metadata->line(), msg.str());
             continue;
         }
         newLocalMetadata.push_back(metadata);

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -102,7 +102,7 @@ namespace
                         {
                             ostringstream msg;
                             msg << "ignoring invalid file metadata '" << *metadata << "'";
-                            dc->warning(InvalidMetadata, file, -1, msg.str());
+                            dc->warning(InvalidMetadata, metadata->file(), metadata->line(), msg.str());
                             fileMetadata.remove(metadata);
                         }
                     }
@@ -115,7 +115,7 @@ namespace
         bool visitModuleStart(const ModulePtr& p) final
         {
             MetadataList metadata = getMetadata(p);
-            metadata = validateType(p, metadata, p->file(), p->line());
+            metadata = validateType(p, metadata, p->file());
             metadata = validateGetSet(p, metadata);
             p->setMetadata(std::move(metadata));
             return true;
@@ -124,7 +124,7 @@ namespace
         void visitClassDecl(const ClassDeclPtr& p) final
         {
             MetadataList metadata = getMetadata(p);
-            metadata = validateType(p, metadata, p->file(), p->line());
+            metadata = validateType(p, metadata, p->file());
             metadata = validateGetSet(p, metadata);
             p->setMetadata(std::move(metadata));
         }
@@ -132,7 +132,7 @@ namespace
         bool visitClassDefStart(const ClassDefPtr& p) final
         {
             MetadataList metadata = getMetadata(p);
-            metadata = validateType(p, metadata, p->file(), p->line());
+            metadata = validateType(p, metadata, p->file());
             metadata = validateGetSet(p, metadata);
             p->setMetadata(std::move(metadata));
             return true;
@@ -141,7 +141,7 @@ namespace
         bool visitExceptionStart(const ExceptionPtr& p) final
         {
             MetadataList metadata = getMetadata(p);
-            metadata = validateType(p, metadata, p->file(), p->line());
+            metadata = validateType(p, metadata, p->file());
             metadata = validateGetSet(p, metadata);
             p->setMetadata(std::move(metadata));
             return true;
@@ -150,7 +150,7 @@ namespace
         bool visitStructStart(const StructPtr& p) final
         {
             MetadataList metadata = getMetadata(p);
-            metadata = validateType(p, metadata, p->file(), p->line());
+            metadata = validateType(p, metadata, p->file());
             metadata = validateGetSet(p, metadata);
             p->setMetadata(std::move(metadata));
             return true;
@@ -182,7 +182,7 @@ namespace
             }
             else
             {
-                metadata = validateType(returnType, metadata, p->file(), p->line());
+                metadata = validateType(returnType, metadata, p->file());
                 metadata = validateGetSet(p, metadata);
             }
             p->setMetadata(std::move(metadata));
@@ -190,7 +190,7 @@ namespace
             for (const auto& param : p->parameters())
             {
                 metadata = getMetadata(param);
-                metadata = validateType(param->type(), metadata, param->file(), param->line());
+                metadata = validateType(param->type(), metadata, param->file());
                 metadata = validateGetSet(param, metadata);
                 param->setMetadata(std::move(metadata));
             }
@@ -199,7 +199,7 @@ namespace
         void visitDataMember(const DataMemberPtr& p) final
         {
             MetadataList metadata = getMetadata(p);
-            metadata = validateType(p->type(), metadata, p->file(), p->line());
+            metadata = validateType(p->type(), metadata, p->file());
             metadata = validateGetSet(p, metadata);
             p->setMetadata(std::move(metadata));
         }
@@ -210,7 +210,6 @@ namespace
             MetadataList newMetadata;
 
             const string file = p->file();
-            int line = p->line();
             const UnitPtr unt = p->unit();
             const DefinitionContextPtr dc = unt->findDefinitionContext(file);
 
@@ -228,7 +227,7 @@ namespace
                         ostringstream msg;
                         msg << "ignoring invalid metadata '" << *m
                             << "': this metadata can only be used with a byte sequence";
-                        dc->warning(InvalidMetadata, file, line, msg.str());
+                        dc->warning(InvalidMetadata, m->file(), m->line(), msg.str());
                         continue;
                     }
                     newMetadata.push_back(m);
@@ -244,14 +243,14 @@ namespace
                     {
                         ostringstream msg;
                         msg << "ignoring invalid metadata '" << *m << "': this metadata can not be used with this type";
-                        dc->warning(InvalidMetadata, file, line, msg.str());
+                        dc->warning(InvalidMetadata, m->file(), m->line(), msg.str());
                         continue;
                     }
                     newMetadata.push_back(m);
                 }
             }
 
-            metadata = validateType(p, metadata, file, line);
+            metadata = validateType(p, metadata, file);
             metadata = validateGetSet(p, metadata);
             newMetadata.insert(newMetadata.begin(), metadata.begin(), metadata.end());
             p->setMetadata(std::move(newMetadata));
@@ -260,7 +259,7 @@ namespace
         void visitDictionary(const DictionaryPtr& p) final
         {
             MetadataList metadata = getMetadata(p);
-            metadata = validateType(p, metadata, p->file(), p->line());
+            metadata = validateType(p, metadata, p->file());
             metadata = validateGetSet(p, metadata);
             p->setMetadata(std::move(metadata));
         }
@@ -268,7 +267,7 @@ namespace
         void visitEnum(const EnumPtr& p) final
         {
             MetadataList metadata = getMetadata(p);
-            metadata = validateType(p, metadata, p->file(), p->line());
+            metadata = validateType(p, metadata, p->file());
             metadata = validateGetSet(p, metadata);
             p->setMetadata(std::move(metadata));
         }
@@ -276,7 +275,7 @@ namespace
         void visitConst(const ConstPtr& p) final
         {
             MetadataList metadata = getMetadata(p);
-            metadata = validateType(p, metadata, p->file(), p->line());
+            metadata = validateType(p, metadata, p->file());
             metadata = validateGetSet(p, metadata);
             p->setMetadata(std::move(metadata));
         }
@@ -367,7 +366,7 @@ namespace
         }
 
         MetadataList
-        validateType(const SyntaxTreeBasePtr& p, const MetadataList& metadata, const string& file, int line)
+        validateType(const SyntaxTreeBasePtr& p, const MetadataList& metadata, const string& file)
         {
             const UnitPtr unt = p->unit();
             const DefinitionContextPtr dc = unt->findDefinitionContext(file);
@@ -396,7 +395,7 @@ namespace
                     }
                     ostringstream msg;
                     msg << "ignoring invalid metadata '" << *m << "' for " << str;
-                    dc->warning(InvalidMetadata, file, line, msg.str());
+                    dc->warning(InvalidMetadata, m->file(), m->line(), msg.str());
                 }
                 else if (directive == "java:buffer")
                 {
@@ -416,14 +415,14 @@ namespace
 
                     ostringstream msg;
                     msg << "ignoring invalid metadata '" << *m << "'";
-                    dc->warning(InvalidMetadata, file, line, msg.str());
+                    dc->warning(InvalidMetadata, m->file(), m->line(), msg.str());
                 }
                 else if (directive == "java:serializable")
                 {
                     // Only valid in sequence definition which is checked in visitSequence
                     ostringstream msg;
                     msg << "ignoring invalid metadata '" << *m << "'";
-                    dc->warning(InvalidMetadata, file, line, msg.str());
+                    dc->warning(InvalidMetadata, m->file(), m->line(), msg.str());
                 }
                 else if (directive == "java:implements")
                 {
@@ -435,7 +434,7 @@ namespace
                     {
                         ostringstream msg;
                         msg << "ignoring invalid metadata '" << *m << "'";
-                        dc->warning(InvalidMetadata, file, line, msg.str());
+                        dc->warning(InvalidMetadata, m->file(), m->line(), msg.str());
                     }
                 }
                 else if (directive == "java:package")
@@ -449,7 +448,7 @@ namespace
                     {
                         ostringstream msg;
                         msg << "ignoring invalid metadata '" << *m << "'";
-                        dc->warning(InvalidMetadata, file, line, msg.str());
+                        dc->warning(InvalidMetadata, m->file(), m->line(), msg.str());
                     }
                 }
                 else

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -365,8 +365,7 @@ namespace
             return result;
         }
 
-        MetadataList
-        validateType(const SyntaxTreeBasePtr& p, const MetadataList& metadata, const string& file)
+        MetadataList validateType(const SyntaxTreeBasePtr& p, const MetadataList& metadata, const string& file)
         {
             const UnitPtr unt = p->unit();
             const DefinitionContextPtr dc = unt->findDefinitionContext(file);

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -3056,7 +3056,8 @@ Slice::Python::MetadataVisitor::visitConst(const ConstPtr& p)
 }
 
 MetadataList
-Slice::Python::MetadataVisitor::validateSequence(const ContainedPtr& cont, const TypePtr& type) {
+Slice::Python::MetadataVisitor::validateSequence(const ContainedPtr& cont, const TypePtr& type)
+{
     const UnitPtr ut = type->unit();
     const DefinitionContextPtr dc = ut->findDefinitionContext(cont->file());
     assert(dc);

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -151,7 +151,7 @@ namespace Slice
 
         private:
             /// Validates sequence metadata.
-            MetadataList validateSequence(const string&, int, const TypePtr&, const MetadataList&);
+            MetadataList validateSequence(const ContainedPtr&, const TypePtr&);
 
             /// Checks a definition that doesn't currently support Python metadata.
             void reject(const ContainedPtr&);
@@ -2933,7 +2933,7 @@ Slice::Python::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
 
                 ostringstream msg;
                 msg << "ignoring invalid file metadata '" << *meta << "'";
-                dc->warning(InvalidMetadata, file, -1, msg.str());
+                dc->warning(InvalidMetadata, meta->file(), meta->line(), msg.str());
                 fileMetadata.remove(meta);
             }
         }
@@ -2961,7 +2961,7 @@ Slice::Python::MetadataVisitor::visitModuleStart(const ModulePtr& p)
 
             ostringstream msg;
             msg << "ignoring invalid file metadata '" << *meta << "'";
-            p->definitionContext()->warning(InvalidMetadata, p->file(), -1, msg.str());
+            p->definitionContext()->warning(InvalidMetadata, meta->file(), meta->line(), msg.str());
             metadata.remove(meta);
         }
     }
@@ -3016,25 +3016,25 @@ Slice::Python::MetadataVisitor::visitOperation(const OperationPtr& p)
     TypePtr ret = p->returnType();
     if (ret)
     {
-        validateSequence(p->file(), p->line(), ret, p->getMetadata());
+        validateSequence(p, ret);
     }
 
     for (const auto& param : p->parameters())
     {
-        validateSequence(p->file(), param->line(), param->type(), param->getMetadata());
+        validateSequence(param, param->type());
     }
 }
 
 void
 Slice::Python::MetadataVisitor::visitDataMember(const DataMemberPtr& p)
 {
-    validateSequence(p->file(), p->line(), p->type(), p->getMetadata());
+    validateSequence(p, p->type());
 }
 
 void
 Slice::Python::MetadataVisitor::visitSequence(const SequencePtr& p)
 {
-    p->setMetadata(validateSequence(p->file(), p->line(), p, p->getMetadata()));
+    p->setMetadata(validateSequence(p, p));
 }
 
 void
@@ -3056,18 +3056,13 @@ Slice::Python::MetadataVisitor::visitConst(const ConstPtr& p)
 }
 
 MetadataList
-Slice::Python::MetadataVisitor::validateSequence(
-    const string& file,
-    int line,
-    const TypePtr& type,
-    const MetadataList& metadata)
-{
+Slice::Python::MetadataVisitor::validateSequence(const ContainedPtr& cont, const TypePtr& type) {
     const UnitPtr ut = type->unit();
-    const DefinitionContextPtr dc = ut->findDefinitionContext(file);
+    const DefinitionContextPtr dc = ut->findDefinitionContext(cont->file());
     assert(dc);
 
     static const string prefix = "python:";
-    MetadataList newMetadata = metadata;
+    MetadataList newMetadata = cont->getMetadata();
     for (MetadataList::const_iterator p = newMetadata.begin(); p != newMetadata.end();)
     {
         MetadataPtr s = *p++;
@@ -3123,7 +3118,7 @@ Slice::Python::MetadataVisitor::validateSequence(
             }
             ostringstream msg;
             msg << "ignoring invalid metadata '" << *s << "'";
-            dc->warning(InvalidMetadata, file, line, msg.str());
+            dc->warning(InvalidMetadata, s->file(), s->line(), msg.str());
             newMetadata.remove(s);
         }
     }
@@ -3146,7 +3141,7 @@ Slice::Python::MetadataVisitor::reject(const ContainedPtr& cont)
         {
             ostringstream msg;
             msg << "ignoring invalid metadata '" << *s << "'";
-            dc->warning(InvalidMetadata, cont->file(), cont->line(), msg.str());
+            dc->warning(InvalidMetadata, s->file(), s->line(), msg.str());
             localMetadata.remove(s);
         }
     }

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -2474,7 +2474,8 @@ SwiftGenerator::MetadataVisitor::visitConst(const ConstPtr& p)
 }
 
 MetadataList
-SwiftGenerator::MetadataVisitor::validate(const SyntaxTreeBasePtr& p, const ContainedPtr& cont) {
+SwiftGenerator::MetadataVisitor::validate(const SyntaxTreeBasePtr& p, const ContainedPtr& cont)
+{
     MetadataList newMetadata = cont->getMetadata();
     const UnitPtr ut = p->unit();
     const DefinitionContextPtr dc = ut->findDefinitionContext(cont->file());

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -159,7 +159,7 @@ namespace Slice
             bool shouldVisitIncludedDefinitions() const final { return true; }
 
         private:
-            MetadataList validate(const SyntaxTreeBasePtr&, const MetadataList&, const std::string&, int);
+            MetadataList validate(const SyntaxTreeBasePtr&, const ContainedPtr&);
 
             typedef std::map<std::string, std::string> ModuleMap;
             typedef std::map<std::string, ModuleMap> ModulePrefix;

--- a/cpp/test/Slice/errorDetection/ConstDef.err
+++ b/cpp/test/Slice/errorDetection/ConstDef.err
@@ -22,7 +22,7 @@ ConstDef.ice:118: initializer `256' for constant `b4' out of range for type byte
 ConstDef.ice:130: initializer `32767' for constant `c5' out of range for type byte
 ConstDef.ice:131: initializer `2147483647' for constant `c6' out of range for type short
 ConstDef.ice:132: initializer `9223372036854775807' for constant `c7' out of range for type int
-ConstDef.ice:143: warning: unknown escape sequence in string literal: `\g'
+ConstDef.ice:143: warning: unknown escape sequence in string literal: '\g'
 ConstDef.ice:144: unknown escape sequence in string literal: `\u000N'
 ConstDef.ice:145: unknown escape sequence in string literal: `\U0000000K'
 ConstDef.ice:146: octal escape sequence out of range: `\455'

--- a/cpp/test/Slice/errorDetection/WarningInvalidMetadata.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidMetadata.err
@@ -1,21 +1,21 @@
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:header-ext:hh': directive can appear only once per file
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:source-ext:cc': directive can appear only once per file
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:dll-export:Test': directive can appear only once per file
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:header-ext'
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:header-ext'
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:source-ext'
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:source-ext'
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:dll-export'
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:dll-export'
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:include'
-WarningInvalidMetadata.ice: warning: ignoring invalid file metadata 'cpp:include'
-WarningInvalidMetadata.ice:35: warning: ignoring invalid metadata 'cpp:type:std::list<::std::string>' for operation with void return type
-WarningInvalidMetadata.ice:38: warning: ignoring invalid metadata 'cpp:array' for operation with void return type
+WarningInvalidMetadata.ice:6: warning: ignoring invalid file metadata 'cpp:header-ext:hh': directive can appear only once per file
+WarningInvalidMetadata.ice:9: warning: ignoring invalid file metadata 'cpp:source-ext:cc': directive can appear only once per file
+WarningInvalidMetadata.ice:12: warning: ignoring invalid file metadata 'cpp:dll-export:Test': directive can appear only once per file
+WarningInvalidMetadata.ice:14: warning: ignoring invalid file metadata 'cpp:header-ext'
+WarningInvalidMetadata.ice:15: warning: ignoring invalid file metadata 'cpp:header-ext'
+WarningInvalidMetadata.ice:17: warning: ignoring invalid file metadata 'cpp:source-ext'
+WarningInvalidMetadata.ice:18: warning: ignoring invalid file metadata 'cpp:source-ext'
+WarningInvalidMetadata.ice:20: warning: ignoring invalid file metadata 'cpp:dll-export'
+WarningInvalidMetadata.ice:21: warning: ignoring invalid file metadata 'cpp:dll-export'
+WarningInvalidMetadata.ice:23: warning: ignoring invalid file metadata 'cpp:include'
+WarningInvalidMetadata.ice:24: warning: ignoring invalid file metadata 'cpp:include'
+WarningInvalidMetadata.ice:34: warning: ignoring invalid metadata 'cpp:type:std::list<::std::string>' for operation with void return type
+WarningInvalidMetadata.ice:37: warning: ignoring invalid metadata 'cpp:array' for operation with void return type
 WarningInvalidMetadata.ice:40: warning: ignoring invalid metadata 'cpp:type:my_string'
 WarningInvalidMetadata.ice:42: warning: ignoring invalid metadata 'cpp:view-type:my_string'
-WarningInvalidMetadata.ice:47: warning: ignoring invalid metadata 'cpp:const'
-WarningInvalidMetadata.ice:47: warning: ignoring invalid metadata 'cpp:ice_print'
-WarningInvalidMetadata.ice:53: warning: ignoring invalid metadata 'cpp:virtual'
-WarningInvalidMetadata.ice:58: warning: ignoring invalid metadata 'cpp:bad'
-WarningInvalidMetadata.ice:63: warning: ignoring invalid metadata 'cpp98:foo'
-WarningInvalidMetadata.ice:63: warning: ignoring invalid metadata 'cpp11:bar'
+WarningInvalidMetadata.ice:45: warning: ignoring invalid metadata 'cpp:const'
+WarningInvalidMetadata.ice:45: warning: ignoring invalid metadata 'cpp:ice_print'
+WarningInvalidMetadata.ice:51: warning: ignoring invalid metadata 'cpp:virtual'
+WarningInvalidMetadata.ice:56: warning: ignoring invalid metadata 'cpp:bad'
+WarningInvalidMetadata.ice:61: warning: ignoring invalid metadata 'cpp98:foo'
+WarningInvalidMetadata.ice:61: warning: ignoring invalid metadata 'cpp11:bar'


### PR DESCRIPTION
This PR fixes #2021.

Before my refactoring of metadata, we didn't store the metadata's location. So when reporting warnings, we either had to omit location information (by passing `-1`) of guess that it was the same line as some other Slice definition.

Now, we use the metadata's location properly.
You can see this in the test that had to be fixed at the bottom of this PR.