### PR TITLE
Update DataStorm strings

### DIFF
--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -618,7 +618,7 @@ namespace DataStorm
          */
         template<typename Criteria>
         void setKeyFilter(
-            const std::string& name,
+            std::string name,
             std::function<std::function<bool(const Key&)>(const Criteria&)> factory) noexcept;
 
         /**
@@ -630,7 +630,7 @@ namespace DataStorm
          */
         template<typename Criteria>
         void setSampleFilter(
-            const std::string& name,
+            std::string name,
             std::function<std::function<bool(const SampleType&)>(const Criteria&)> factory) noexcept;
 
     private:
@@ -1829,6 +1829,7 @@ namespace DataStorm
     template<typename Value>
     std::function<std::function<bool(const Value&)>(const std::string&)> makeRegexFilter() noexcept
     {
+        // std::regex_match accepts a const string&.
         return [](const std::string& criteria)
         {
             std::regex expr(criteria);
@@ -2017,21 +2018,21 @@ namespace DataStorm
     template<typename Key, typename Value, typename UpdateTag>
     template<typename Criteria>
     void Topic<Key, Value, UpdateTag>::setKeyFilter(
-        const std::string& name,
+        std::string name,
         std::function<std::function<bool(const Key&)>(const Criteria&)> factory) noexcept
     {
         std::lock_guard<std::mutex> lock(_mutex);
-        _keyFilterFactories->set(name, factory);
+        _keyFilterFactories->set(std::move(name), factory);
     }
 
     template<typename Key, typename Value, typename UpdateTag>
     template<typename Criteria>
     void Topic<Key, Value, UpdateTag>::setSampleFilter(
-        const std::string& name,
+        std::string name,
         std::function<std::function<bool(const Sample<Key, Value, UpdateTag>&)>(const Criteria&)> factory) noexcept
     {
         std::lock_guard<std::mutex> lock(_mutex);
-        _sampleFilterFactories->set(name, factory);
+        _sampleFilterFactories->set(std::move(name), factory);
     }
 
     template<typename Key, typename Value, typename UpdateTag>

--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -673,8 +673,8 @@ namespace DataStorm
          * @param criteria The criteria
          */
         template<typename TT>
-        Filter(std::string name, TT&& criteria) noexcept :
-            name(std::move(name)), criteria(std::forward<TT>(criteria))
+        Filter(std::string name, TT&& criteria) noexcept : name(std::move(name)),
+                                                           criteria(std::forward<TT>(criteria))
         {
         }
 
@@ -1453,7 +1453,8 @@ namespace DataStorm
         const Key& key,
         std::string name,
         const ReaderConfig& config)
-        : Reader<Key, Value, UpdateTag>(topic.getReader()->create({topic._keyFactory->create(key)}, std::move(name), config))
+        : Reader<Key, Value, UpdateTag>(
+              topic.getReader()->create({topic._keyFactory->create(key)}, std::move(name), config))
     {
     }
 
@@ -1494,7 +1495,8 @@ namespace DataStorm
         const std::vector<Key>& keys,
         std::string name,
         const ReaderConfig& config)
-        : Reader<Key, Value, UpdateTag>(topic.getReader()->create(topic._keyFactory->create(keys), std::move(name), config))
+        : Reader<Key, Value, UpdateTag>(
+              topic.getReader()->create(topic._keyFactory->create(keys), std::move(name), config))
     {
     }
 
@@ -1698,7 +1700,8 @@ namespace DataStorm
         const Key& key,
         std::string name,
         const WriterConfig& config) noexcept
-        : Writer<Key, Value, UpdateTag>(topic.getWriter()->create({topic._keyFactory->create(key)}, std::move(name), config)),
+        : Writer<Key, Value, UpdateTag>(
+              topic.getWriter()->create({topic._keyFactory->create(key)}, std::move(name), config)),
           _tagFactory(topic._tagFactory)
     {
     }
@@ -1762,7 +1765,8 @@ namespace DataStorm
         const std::vector<Key>& keys,
         std::string name,
         const WriterConfig& config) noexcept
-        : Writer<Key, Value, UpdateTag>(topic.getWriter()->create(topic._keyFactory->create(keys), std::move(name), config)),
+        : Writer<Key, Value, UpdateTag>(
+              topic.getWriter()->create(topic._keyFactory->create(keys), std::move(name), config)),
           _keyFactory(topic._keyFactory),
           _tagFactory(topic._tagFactory)
     {

--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -510,7 +510,7 @@ namespace DataStorm
          * @param node The node.
          * @param name The name of the topic.
          */
-        Topic(const Node& node, const std::string& name) noexcept;
+        Topic(const Node& node, std::string name) noexcept;
 
         /**
          * Construct a new Topic by taking ownership of the given topic.
@@ -673,8 +673,8 @@ namespace DataStorm
          * @param criteria The criteria
          */
         template<typename TT>
-        Filter(const std::string& name, TT&& criteria) noexcept : name(name),
-                                                                  criteria(std::forward<TT>(criteria))
+        Filter(std::string name, TT&& criteria) noexcept :
+            name(std::move(name)), criteria(std::forward<TT>(criteria))
         {
         }
 
@@ -706,7 +706,7 @@ namespace DataStorm
         SingleKeyReader(
             const Topic<Key, Value, UpdateTag>& topic,
             const Key& key,
-            const std::string& name = std::string(),
+            std::string name = std::string(),
             const ReaderConfig& config = ReaderConfig());
 
         /**
@@ -725,7 +725,7 @@ namespace DataStorm
             const Topic<Key, Value, UpdateTag>& topic,
             const Key& key,
             const Filter<SampleFilterCriteria>& sampleFilter,
-            const std::string& name = std::string(),
+            std::string name = std::string(),
             const ReaderConfig& config = ReaderConfig());
 
         /**
@@ -765,7 +765,7 @@ namespace DataStorm
         MultiKeyReader(
             const Topic<Key, Value, UpdateTag>& topic,
             const std::vector<Key>& keys,
-            const std::string& name = std::string(),
+            std::string name = std::string(),
             const ReaderConfig& config = ReaderConfig());
 
         /**
@@ -785,7 +785,7 @@ namespace DataStorm
             const Topic<Key, Value, UpdateTag>& topic,
             const std::vector<Key>& keys,
             const Filter<SampleFilterCriteria>& sampleFilter,
-            const std::string& name = std::string(),
+            std::string name = std::string(),
             const ReaderConfig& config = ReaderConfig());
 
         /**
@@ -816,10 +816,10 @@ namespace DataStorm
     SingleKeyReader<K, V, UT> makeSingleKeyReader(
         const Topic<K, V, UT>& topic,
         const typename Topic<K, V, UT>::KeyType& key,
-        const std::string& name = std::string(),
+        std::string name = std::string(),
         const ReaderConfig& config = ReaderConfig())
     {
-        return SingleKeyReader<K, V, UT>(topic, key, name, config);
+        return SingleKeyReader<K, V, UT>(topic, key, std::move(name), config);
     }
 
     /**
@@ -837,10 +837,10 @@ namespace DataStorm
         const Topic<K, V, UT>& topic,
         const typename Topic<K, V, UT>::KeyType& key,
         const Filter<SFC>& sampleFilter,
-        const std::string& name = std::string(),
+        std::string name = std::string(),
         const ReaderConfig& config = ReaderConfig())
     {
-        return SingleKeyReader<K, V, UT>(topic, key, sampleFilter, name, config);
+        return SingleKeyReader<K, V, UT>(topic, key, sampleFilter, std::move(name), config);
     }
 
     /**
@@ -858,10 +858,10 @@ namespace DataStorm
     MultiKeyReader<K, V, UT> makeMultiKeyReader(
         const Topic<K, V, UT>& topic,
         const std::vector<typename Topic<K, V, UT>::KeyType>& keys,
-        const std::string& name = std::string(),
+        std::string name = std::string(),
         const ReaderConfig& config = ReaderConfig())
     {
-        return MultiKeyReader<K, V, UT>(topic, keys, name, config);
+        return MultiKeyReader<K, V, UT>(topic, keys, std::move(name), config);
     }
 
     /**
@@ -881,10 +881,10 @@ namespace DataStorm
         const Topic<K, V, UT>& topic,
         const std::vector<typename Topic<K, V, UT>::KeyType>& keys,
         const Filter<SFC>& sampleFilter,
-        const std::string& name = std::string(),
+        std::string name = std::string(),
         const ReaderConfig& config = ReaderConfig())
     {
-        return MultiKeyReader<K, V, UT>(topic, keys, sampleFilter, name, config);
+        return MultiKeyReader<K, V, UT>(topic, keys, sampleFilter, std::move(name), config);
     }
 
     /**
@@ -900,10 +900,10 @@ namespace DataStorm
     template<typename K, typename V, typename UT>
     MultiKeyReader<K, V, UT> makeAnyKeyReader(
         const Topic<K, V, UT>& topic,
-        const std::string& name = std::string(),
+        std::string name = std::string(),
         const ReaderConfig& config = ReaderConfig())
     {
-        return MultiKeyReader<K, V, UT>(topic, {}, name, config);
+        return MultiKeyReader<K, V, UT>(topic, {}, std::move(name), config);
     }
 
     /**
@@ -921,10 +921,10 @@ namespace DataStorm
     MultiKeyReader<K, V, UT> makeAnyKeyReader(
         const Topic<K, V, UT>& topic,
         const Filter<SFC>& sampleFilter,
-        const std::string& name = std::string(),
+        std::string name = std::string(),
         const ReaderConfig& config = ReaderConfig())
     {
-        return MultiKeyReader<K, V, UT>(topic, {}, sampleFilter, name, config);
+        return MultiKeyReader<K, V, UT>(topic, {}, sampleFilter, std::move(name), config);
     }
 
     /**
@@ -952,7 +952,7 @@ namespace DataStorm
         FilteredKeyReader(
             const Topic<Key, Value, UpdateTag>& topic,
             const Filter<KeyFilterCriteria>& keyFilter,
-            const std::string& name = std::string(),
+            std::string name = std::string(),
             const ReaderConfig& config = ReaderConfig());
 
         /**
@@ -973,7 +973,7 @@ namespace DataStorm
             const Topic<Key, Value, UpdateTag>& topic,
             const Filter<KeyFilterCriteria>& keyFilter,
             const Filter<SampleFilterCriteria>& sampleFilter,
-            const std::string& name = std::string(),
+            std::string name = std::string(),
             const ReaderConfig& config = ReaderConfig());
 
         /**
@@ -1004,10 +1004,10 @@ namespace DataStorm
     FilteredKeyReader<K, V, UT> makeFilteredKeyReader(
         const Topic<K, V, UT>& topic,
         const Filter<KFC>& filter,
-        const std::string& name = std::string(),
+        std::string name = std::string(),
         const ReaderConfig& config = ReaderConfig())
     {
-        return FilteredKeyReader<K, V, UT>(topic, filter, name, config);
+        return FilteredKeyReader<K, V, UT>(topic, filter, std::move(name), config);
     }
 
     /**
@@ -1025,10 +1025,10 @@ namespace DataStorm
         const Topic<K, V, UT>& topic,
         const Filter<KFC>& keyFilter,
         const Filter<SFC>& sampleFilter,
-        const std::string& name = std::string(),
+        std::string name = std::string(),
         const ReaderConfig& config = ReaderConfig())
     {
-        return FilteredKeyReader<K, V, UT>(topic, keyFilter, sampleFilter, name, config);
+        return FilteredKeyReader<K, V, UT>(topic, keyFilter, sampleFilter, std::move(name), config);
     }
 
     /**
@@ -1052,7 +1052,7 @@ namespace DataStorm
         SingleKeyWriter(
             const Topic<Key, Value, UpdateTag>& topic,
             const Key& key,
-            const std::string& name = std::string(),
+            std::string name = std::string(),
             const WriterConfig& config = WriterConfig()) noexcept;
 
         /**
@@ -1128,7 +1128,7 @@ namespace DataStorm
         MultiKeyWriter(
             const Topic<Key, Value, UpdateTag>& topic,
             const std::vector<Key>& keys,
-            const std::string& name = std::string(),
+            std::string name = std::string(),
             const WriterConfig& config = WriterConfig()) noexcept;
 
         /**
@@ -1198,10 +1198,10 @@ namespace DataStorm
     SingleKeyWriter<K, V, UT> makeSingleKeyWriter(
         const Topic<K, V, UT>& topic,
         const typename Topic<K, V, UT>::KeyType& key,
-        const std::string& name = std::string(),
+        std::string name = std::string(),
         const WriterConfig& config = WriterConfig()) noexcept
     {
-        return SingleKeyWriter<K, V, UT>(topic, key, name, config);
+        return SingleKeyWriter<K, V, UT>(topic, key, std::move(name), config);
     }
 
     /**
@@ -1217,10 +1217,10 @@ namespace DataStorm
     MultiKeyWriter<K, V, UT> makeMultiKeyWriter(
         const Topic<K, V, UT>& topic,
         const std::vector<typename Topic<K, V, UT>::KeyType>& keys,
-        const std::string& name = std::string(),
+        std::string name = std::string(),
         const WriterConfig& config = WriterConfig()) noexcept
     {
-        return MultiKeyWriter<K, V, UT>(topic, keys, name, config);
+        return MultiKeyWriter<K, V, UT>(topic, keys, std::move(name), config);
     }
 
     /**
@@ -1234,10 +1234,10 @@ namespace DataStorm
     template<typename K, typename V, typename UT>
     MultiKeyWriter<K, V, UT> makeAnyKeyWriter(
         const Topic<K, V, UT>& topic,
-        const std::string& name = std::string(),
+        std::string name = std::string(),
         const WriterConfig& config = WriterConfig()) noexcept
     {
-        return MultiKeyWriter<K, V, UT>(topic, {}, name, config);
+        return MultiKeyWriter<K, V, UT>(topic, {}, std::move(name), config);
     }
 
 }
@@ -1451,9 +1451,9 @@ namespace DataStorm
     SingleKeyReader<Key, Value, UpdateTag>::SingleKeyReader(
         const Topic<Key, Value, UpdateTag>& topic,
         const Key& key,
-        const std::string& name,
+        std::string name,
         const ReaderConfig& config)
-        : Reader<Key, Value, UpdateTag>(topic.getReader()->create({topic._keyFactory->create(key)}, name, config))
+        : Reader<Key, Value, UpdateTag>(topic.getReader()->create({topic._keyFactory->create(key)}, std::move(name), config))
     {
     }
 
@@ -1463,11 +1463,11 @@ namespace DataStorm
         const Topic<Key, Value, UpdateTag>& topic,
         const Key& key,
         const Filter<SFC>& sampleFilter,
-        const std::string& name,
+        std::string name,
         const ReaderConfig& config)
         : Reader<Key, Value, UpdateTag>(topic.getReader()->create(
               {topic._keyFactory->create(key)},
-              name,
+              std::move(name),
               config,
               sampleFilter.name,
               DataStormI::EncoderT<SFC>::encode(topic.getCommunicator(), sampleFilter.criteria)))
@@ -1492,9 +1492,9 @@ namespace DataStorm
     MultiKeyReader<Key, Value, UpdateTag>::MultiKeyReader(
         const Topic<Key, Value, UpdateTag>& topic,
         const std::vector<Key>& keys,
-        const std::string& name,
+        std::string name,
         const ReaderConfig& config)
-        : Reader<Key, Value, UpdateTag>(topic.getReader()->create(topic._keyFactory->create(keys), name, config))
+        : Reader<Key, Value, UpdateTag>(topic.getReader()->create(topic._keyFactory->create(keys), std::move(name), config))
     {
     }
 
@@ -1504,11 +1504,11 @@ namespace DataStorm
         const Topic<Key, Value, UpdateTag>& topic,
         const std::vector<Key>& keys,
         const Filter<SFC>& sampleFilter,
-        const std::string& name,
+        std::string name,
         const ReaderConfig& config)
         : Reader<Key, Value, UpdateTag>(topic.getReader()->create(
               topic._keyFactory->create(keys),
-              name,
+              std::move(name),
               config,
               sampleFilter.name,
               Encoder<SFC>::encode(topic.getCommunicator(), sampleFilter.criteria)))
@@ -1534,11 +1534,11 @@ namespace DataStorm
     FilteredKeyReader<Key, Value, UpdateTag>::FilteredKeyReader(
         const Topic<Key, Value, UpdateTag>& topic,
         const Filter<KFC>& filter,
-        const std::string& name,
+        std::string name,
         const ReaderConfig& config)
         : Reader<Key, Value, UpdateTag>(topic.getReader()->createFiltered(
               topic._keyFilterFactories->create(filter.name, filter.criteria),
-              name,
+              std::move(name),
               config))
     {
     }
@@ -1549,11 +1549,11 @@ namespace DataStorm
         const Topic<Key, Value, UpdateTag>& topic,
         const Filter<KFC>& keyFilter,
         const Filter<SFC>& sampleFilter,
-        const std::string& name,
+        std::string name,
         const ReaderConfig& config)
         : Reader<Key, Value, UpdateTag>(topic.getReader()->createFiltered(
               topic._keyFilterFactories->create(keyFilter.name, keyFilter.criteria),
-              name,
+              std::move(name),
               config,
               sampleFilter.name,
               Encoder<SFC>::encode(topic.getCommunicator(), sampleFilter.criteria)))
@@ -1696,9 +1696,9 @@ namespace DataStorm
     SingleKeyWriter<Key, Value, UpdateTag>::SingleKeyWriter(
         const Topic<Key, Value, UpdateTag>& topic,
         const Key& key,
-        const std::string& name,
+        std::string name,
         const WriterConfig& config) noexcept
-        : Writer<Key, Value, UpdateTag>(topic.getWriter()->create({topic._keyFactory->create(key)}, name, config)),
+        : Writer<Key, Value, UpdateTag>(topic.getWriter()->create({topic._keyFactory->create(key)}, std::move(name), config)),
           _tagFactory(topic._tagFactory)
     {
     }
@@ -1760,9 +1760,9 @@ namespace DataStorm
     MultiKeyWriter<Key, Value, UpdateTag>::MultiKeyWriter(
         const Topic<Key, Value, UpdateTag>& topic,
         const std::vector<Key>& keys,
-        const std::string& name,
+        std::string name,
         const WriterConfig& config) noexcept
-        : Writer<Key, Value, UpdateTag>(topic.getWriter()->create(topic._keyFactory->create(keys), name, config)),
+        : Writer<Key, Value, UpdateTag>(topic.getWriter()->create(topic._keyFactory->create(keys), std::move(name), config)),
           _keyFactory(topic._keyFactory),
           _tagFactory(topic._tagFactory)
     {
@@ -1873,8 +1873,8 @@ namespace DataStorm
     // Topic template implementation
     //
     template<typename Key, typename Value, typename UpdateTag>
-    Topic<Key, Value, UpdateTag>::Topic(const Node& node, const std::string& name) noexcept
-        : _name(name),
+    Topic<Key, Value, UpdateTag>::Topic(const Node& node, std::string name) noexcept
+        : _name(std::move(name)),
           _topicFactory(node._factory),
           _keyFactory(DataStormI::KeyFactoryT<Key>::createFactory()),
           _tagFactory(DataStormI::TagFactoryT<UpdateTag>::createFactory()),

--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -1833,7 +1833,7 @@ namespace DataStorm
     template<typename Value>
     std::function<std::function<bool(const Value&)>(const std::string&)> makeRegexFilter() noexcept
     {
-        // std::regex_match accepts a const string&.
+        // std::regex's constructor accepts a const string&; it does not accept a string_view.
         return [](const std::string& criteria)
         {
             std::regex expr(criteria);

--- a/cpp/include/DataStorm/InternalI.h
+++ b/cpp/include/DataStorm/InternalI.h
@@ -71,16 +71,16 @@ namespace DataStormI
     {
     public:
         Sample(
-            const std::string& session,
-            const std::string& origin,
+            std::string session,
+            std::string origin,
             std::int64_t id,
             DataStorm::SampleEvent event,
             const std::shared_ptr<Key>& key,
             const std::shared_ptr<Tag>& tag,
             Ice::ByteSeq value,
             std::int64_t timestamp)
-            : session(session),
-              origin(origin),
+            : session(std::move(session)),
+              origin(std::move(origin)),
               id(id),
               event(event),
               key(key),
@@ -119,8 +119,8 @@ namespace DataStormI
         virtual ~SampleFactory() = default;
 
         virtual std::shared_ptr<Sample> create(
-            const std::string&,
-            const std::string&,
+            std::string,
+            std::string,
             std::int64_t,
             DataStorm::SampleEvent,
             const std::shared_ptr<Key>&,
@@ -229,14 +229,14 @@ namespace DataStormI
             const std::shared_ptr<Filter>&,
             std::string,
             DataStorm::ReaderConfig,
-            const std::string& = std::string(),
+            std::string = std::string(),
             Ice::ByteSeq = {}) = 0;
 
         virtual std::shared_ptr<DataReader> create(
             const std::vector<std::shared_ptr<Key>>&,
             std::string,
             DataStorm::ReaderConfig,
-            const std::string& = std::string(),
+            std::string = std::string(),
             Ice::ByteSeq = {}) = 0;
 
         virtual void setDefaultConfig(DataStorm::ReaderConfig) = 0;

--- a/cpp/include/DataStorm/InternalI.h
+++ b/cpp/include/DataStorm/InternalI.h
@@ -227,14 +227,14 @@ namespace DataStormI
     public:
         virtual std::shared_ptr<DataReader> createFiltered(
             const std::shared_ptr<Filter>&,
-            const std::string&,
+            std::string,
             DataStorm::ReaderConfig,
             const std::string& = std::string(),
             Ice::ByteSeq = {}) = 0;
 
         virtual std::shared_ptr<DataReader> create(
             const std::vector<std::shared_ptr<Key>>&,
-            const std::string&,
+            std::string,
             DataStorm::ReaderConfig,
             const std::string& = std::string(),
             Ice::ByteSeq = {}) = 0;
@@ -248,7 +248,7 @@ namespace DataStormI
     {
     public:
         virtual std::shared_ptr<DataWriter>
-        create(const std::vector<std::shared_ptr<Key>>&, const std::string&, DataStorm::WriterConfig) = 0;
+        create(const std::vector<std::shared_ptr<Key>>&, std::string, DataStorm::WriterConfig) = 0;
 
         virtual void setDefaultConfig(DataStorm::WriterConfig) = 0;
         virtual bool hasReaders() const = 0;

--- a/cpp/include/DataStorm/InternalI.h
+++ b/cpp/include/DataStorm/InternalI.h
@@ -261,20 +261,20 @@ namespace DataStormI
         virtual ~TopicFactory() = default;
 
         virtual std::shared_ptr<TopicReader> createTopicReader(
-            const std::string&,
-            const std::shared_ptr<KeyFactory>&,
-            const std::shared_ptr<TagFactory>&,
-            const std::shared_ptr<SampleFactory>&,
-            const std::shared_ptr<FilterManager>&,
-            const std::shared_ptr<FilterManager>&) = 0;
+            std::string,
+            std::shared_ptr<KeyFactory>,
+            std::shared_ptr<TagFactory>,
+            std::shared_ptr<SampleFactory>,
+            std::shared_ptr<FilterManager>,
+            std::shared_ptr<FilterManager>) = 0;
 
         virtual std::shared_ptr<TopicWriter> createTopicWriter(
-            const std::string&,
-            const std::shared_ptr<KeyFactory>&,
-            const std::shared_ptr<TagFactory>&,
-            const std::shared_ptr<SampleFactory>&,
-            const std::shared_ptr<FilterManager>&,
-            const std::shared_ptr<FilterManager>&) = 0;
+            std::string,
+            std::shared_ptr<KeyFactory>,
+            std::shared_ptr<TagFactory>,
+            std::shared_ptr<SampleFactory>,
+            std::shared_ptr<FilterManager>,
+            std::shared_ptr<FilterManager>) = 0;
 
         virtual Ice::CommunicatorPtr getCommunicator() const = 0;
     };

--- a/cpp/include/DataStorm/InternalT.h
+++ b/cpp/include/DataStorm/InternalT.h
@@ -491,8 +491,8 @@ namespace DataStormI
 
         template<typename Criteria> struct FactoryT : Factory
         {
-            FactoryT(const std::string& name, std::function<std::function<bool(const Value&)>(const Criteria&)> lambda)
-                : name(name),
+            FactoryT(std::string name, std::function<std::function<bool(const Value&)>(const Criteria&)> lambda)
+                : name(std::move(name)),
                   lambda(std::move(lambda))
             {
             }

--- a/cpp/include/DataStorm/InternalT.h
+++ b/cpp/include/DataStorm/InternalT.h
@@ -416,8 +416,15 @@ namespace DataStormI
             Ice::ByteSeq value,
             std::int64_t timestamp)
         {
-            return std::make_shared<
-                SampleT<Key, Value, UpdateTag>>(std::move(session), std::move(origin), id, type, key, tag, std::move(value), timestamp);
+            return std::make_shared<SampleT<Key, Value, UpdateTag>>(
+                std::move(session),
+                std::move(origin),
+                id,
+                type,
+                key,
+                tag,
+                std::move(value),
+                timestamp);
         }
     };
 

--- a/cpp/include/DataStorm/InternalT.h
+++ b/cpp/include/DataStorm/InternalT.h
@@ -571,7 +571,7 @@ namespace DataStormI
         {
             if (lambda)
             {
-                auto factory = make_unique<FactoryT<Criteria>>(name, std::move(lambda));
+                auto factory = std::make_unique<FactoryT<Criteria>>(name, std::move(lambda));
                 _factories.emplace(std::move(name), std::move(factory));
             }
             else

--- a/cpp/include/DataStorm/InternalT.h
+++ b/cpp/include/DataStorm/InternalT.h
@@ -311,15 +311,15 @@ namespace DataStormI
     {
     public:
         SampleT(
-            const std::string& session,
-            const std::string& origin,
+            std::string session,
+            std::string origin,
             std::int64_t id,
             DataStorm::SampleEvent event,
             const std::shared_ptr<DataStormI::Key>& key,
             const std::shared_ptr<DataStormI::Tag>& tag,
             Ice::ByteSeq value,
             std::int64_t timestamp)
-            : Sample(session, origin, id, event, key, tag, value, timestamp),
+            : Sample(std::move(session), std::move(origin), id, event, key, tag, value, timestamp),
               _hasValue(false)
         {
         }
@@ -407,8 +407,8 @@ namespace DataStormI
     {
     public:
         virtual std::shared_ptr<Sample> create(
-            const std::string& session,
-            const std::string& origin,
+            std::string session,
+            std::string origin,
             std::int64_t id,
             DataStorm::SampleEvent type,
             const std::shared_ptr<DataStormI::Key>& key,
@@ -417,7 +417,7 @@ namespace DataStormI
             std::int64_t timestamp)
         {
             return std::make_shared<
-                SampleT<Key, Value, UpdateTag>>(session, origin, id, type, key, tag, std::move(value), timestamp);
+                SampleT<Key, Value, UpdateTag>>(std::move(session), std::move(origin), id, type, key, tag, std::move(value), timestamp);
         }
     };
 
@@ -560,11 +560,12 @@ namespace DataStormI
         }
 
         template<typename Criteria>
-        void set(const std::string& name, std::function<std::function<bool(const Value&)>(const Criteria&)> lambda)
+        void set(std::string name, std::function<std::function<bool(const Value&)>(const Criteria&)> lambda)
         {
             if (lambda)
             {
-                _factories[name] = std::unique_ptr<Factory>(new FactoryT<Criteria>(name, std::move(lambda)));
+                auto factory = make_unique<FactoryT<Criteria>>(name, std::move(lambda));
+                _factories.emplace(std::move(name), std::move(factory));
             }
             else
             {

--- a/cpp/include/DataStorm/Node.h
+++ b/cpp/include/DataStorm/Node.h
@@ -193,7 +193,7 @@ namespace DataStorm
          * @return The connection associated with the given session
          * @see DataStorm::Sample::ElementId DataStorm::Sample::getSession
          */
-        Ice::ConnectionPtr getSessionConnection(const std::string& ident) const noexcept;
+        Ice::ConnectionPtr getSessionConnection(std::string_view ident) const noexcept;
 
     private:
         Node(

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -645,7 +645,7 @@ DataReaderI::DataReaderI(
     TopicReaderI* topic,
     string name,
     int64_t id,
-    const string& sampleFilterName,
+    string sampleFilterName,
     Ice::ByteSeq sampleFilterCriteria,
     const DataStorm::ReaderConfig& config)
     : DataElementI(topic, std::move(name), id, config),
@@ -654,7 +654,7 @@ DataReaderI::DataReaderI(
 {
     if (!sampleFilterName.empty())
     {
-        _config->sampleFilter = FilterInfo{sampleFilterName, std::move(sampleFilterCriteria)};
+        _config->sampleFilter = FilterInfo{std::move(sampleFilterName), std::move(sampleFilterCriteria)};
     }
 }
 
@@ -1046,10 +1046,10 @@ KeyDataReaderI::KeyDataReaderI(
     string name,
     int64_t id,
     const vector<shared_ptr<Key>>& keys,
-    const string& sampleFilterName,
+    string sampleFilterName,
     const Ice::ByteSeq sampleFilterCriteria,
     const DataStorm::ReaderConfig& config)
-    : DataReaderI(topic, std::move(name), id, sampleFilterName, sampleFilterCriteria, config),
+    : DataReaderI(topic, std::move(name), id, std::move(sampleFilterName), sampleFilterCriteria, config),
       _keys(keys)
 {
     if (_traceLevels->data > 0)
@@ -1328,10 +1328,10 @@ FilteredDataReaderI::FilteredDataReaderI(
     string name,
     int64_t id,
     const shared_ptr<Filter>& filter,
-    const string& sampleFilterName,
+    string sampleFilterName,
     Ice::ByteSeq sampleFilterCriteria,
     const DataStorm::ReaderConfig& config)
-    : DataReaderI(topic, std::move(name), id, sampleFilterName, sampleFilterCriteria, config),
+    : DataReaderI(topic, std::move(name), id, std::move(sampleFilterName), std::move(sampleFilterCriteria), config),
       _filter(filter)
 {
     if (_traceLevels->data > 0)

--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -45,9 +45,9 @@ namespace
     }
 }
 
-DataElementI::DataElementI(TopicI* parent, const string& name, int64_t id, const DataStorm::Config& config)
+DataElementI::DataElementI(TopicI* parent, string name, int64_t id, const DataStorm::Config& config)
     : _traceLevels(parent->getInstance()->getTraceLevels()),
-      _name(name),
+      _name(std::move(name)),
       _id(id),
       _config(make_shared<ElementConfig>()),
       _executor(parent->getInstance()->getCallbackExecutor()),
@@ -63,9 +63,9 @@ DataElementI::DataElementI(TopicI* parent, const string& name, int64_t id, const
 {
     _config->sampleCount = config.sampleCount;
     _config->sampleLifetime = config.sampleLifetime;
-    if (!name.empty())
+    if (!_name.empty())
     {
-        _config->name = name;
+        _config->name = _name;
     }
     if (config.clearHistory)
     {
@@ -643,12 +643,12 @@ DataElementI::forward(const Ice::ByteSeq& inParams, const Ice::Current& current)
 
 DataReaderI::DataReaderI(
     TopicReaderI* topic,
-    const string& name,
+    string name,
     int64_t id,
     const string& sampleFilterName,
     Ice::ByteSeq sampleFilterCriteria,
     const DataStorm::ReaderConfig& config)
-    : DataElementI(topic, name, id, config),
+    : DataElementI(topic, std::move(name), id, config),
       _parent(topic),
       _discardPolicy(config.discardPolicy ? *config.discardPolicy : DataStorm::DiscardPolicy::None)
 {
@@ -979,8 +979,8 @@ DataReaderI::addConnectedKey(const shared_ptr<Key>& key, const shared_ptr<Subscr
     }
 }
 
-DataWriterI::DataWriterI(TopicWriterI* topic, const string& name, int64_t id, const DataStorm::WriterConfig& config)
-    : DataElementI(topic, name, id, config),
+DataWriterI::DataWriterI(TopicWriterI* topic, string name, int64_t id, const DataStorm::WriterConfig& config)
+    : DataElementI(topic, std::move(name), id, config),
       _parent(topic),
       _subscribers{Ice::uncheckedCast<DataStormContract::SubscriberSessionPrx>(_forwarder)}
 {
@@ -1043,13 +1043,13 @@ DataWriterI::publish(const shared_ptr<Key>& key, const shared_ptr<Sample>& sampl
 
 KeyDataReaderI::KeyDataReaderI(
     TopicReaderI* topic,
-    const string& name,
+    string name,
     int64_t id,
     const vector<shared_ptr<Key>>& keys,
     const string& sampleFilterName,
     const Ice::ByteSeq sampleFilterCriteria,
     const DataStorm::ReaderConfig& config)
-    : DataReaderI(topic, name, id, sampleFilterName, sampleFilterCriteria, config),
+    : DataReaderI(topic, std::move(name), id, sampleFilterName, sampleFilterCriteria, config),
       _keys(keys)
 {
     if (_traceLevels->data > 0)
@@ -1131,11 +1131,11 @@ KeyDataReaderI::matchKey(const shared_ptr<Key>& key) const
 
 KeyDataWriterI::KeyDataWriterI(
     TopicWriterI* topic,
-    const string& name,
+    string name,
     int64_t id,
     const vector<shared_ptr<Key>>& keys,
     const DataStorm::WriterConfig& config)
-    : DataWriterI(topic, name, id, config),
+    : DataWriterI(topic, std::move(name), id, config),
       _keys(keys)
 {
     if (_traceLevels->data > 0)
@@ -1325,13 +1325,13 @@ KeyDataWriterI::forward(const Ice::ByteSeq& inParams, const Ice::Current& curren
 
 FilteredDataReaderI::FilteredDataReaderI(
     TopicReaderI* topic,
-    const string& name,
+    string name,
     int64_t id,
     const shared_ptr<Filter>& filter,
     const string& sampleFilterName,
     Ice::ByteSeq sampleFilterCriteria,
     const DataStorm::ReaderConfig& config)
-    : DataReaderI(topic, name, id, sampleFilterName, sampleFilterCriteria, config),
+    : DataReaderI(topic, std::move(name), id, sampleFilterName, sampleFilterCriteria, config),
       _filter(filter)
 {
     if (_traceLevels->data > 0)

--- a/cpp/src/DataStorm/DataElementI.h
+++ b/cpp/src/DataStorm/DataElementI.h
@@ -34,12 +34,12 @@ namespace DataStormI
                 std::int64_t id,
                 const std::shared_ptr<Filter>& filter,
                 const std::shared_ptr<Filter>& sampleFilter,
-                const std::string& name,
+                std::string name,
                 int priority)
                 : id(id),
                   filter(filter),
                   sampleFilter(sampleFilter),
-                  name(name),
+                  name(std::move(name)),
                   priority(priority)
             {
             }
@@ -133,7 +133,7 @@ namespace DataStormI
         };
 
     public:
-        DataElementI(TopicI*, const std::string&, std::int64_t, const DataStorm::Config&);
+        DataElementI(TopicI*, std::string, std::int64_t, const DataStorm::Config&);
         virtual ~DataElementI();
 
         virtual void destroy() override;
@@ -281,7 +281,7 @@ namespace DataStormI
     public:
         DataReaderI(
             TopicReaderI*,
-            const std::string&,
+            std::string,
             std::int64_t,
             const std::string&,
             Ice::ByteSeq,
@@ -330,7 +330,7 @@ namespace DataStormI
     class DataWriterI : public DataElementI, public DataWriter
     {
     public:
-        DataWriterI(TopicWriterI*, const std::string&, std::int64_t, const DataStorm::WriterConfig&);
+        DataWriterI(TopicWriterI*, std::string, std::int64_t, const DataStorm::WriterConfig&);
 
         virtual void publish(const std::shared_ptr<Key>&, const std::shared_ptr<Sample>&) override;
 
@@ -348,7 +348,7 @@ namespace DataStormI
     public:
         KeyDataReaderI(
             TopicReaderI*,
-            const std::string&,
+            std::string,
             std::int64_t,
             const std::vector<std::shared_ptr<Key>>&,
             const std::string&,
@@ -373,7 +373,7 @@ namespace DataStormI
     public:
         KeyDataWriterI(
             TopicWriterI*,
-            const std::string&,
+            std::string,
             std::int64_t,
             const std::vector<std::shared_ptr<Key>>&,
             const DataStorm::WriterConfig&);
@@ -406,7 +406,7 @@ namespace DataStormI
     public:
         FilteredDataReaderI(
             TopicReaderI*,
-            const std::string&,
+            std::string,
             std::int64_t,
             const std::shared_ptr<Filter>&,
             const std::string&,

--- a/cpp/src/DataStorm/DataElementI.h
+++ b/cpp/src/DataStorm/DataElementI.h
@@ -283,7 +283,7 @@ namespace DataStormI
             TopicReaderI*,
             std::string,
             std::int64_t,
-            const std::string&,
+            std::string,
             Ice::ByteSeq,
             const DataStorm::ReaderConfig&);
 
@@ -351,7 +351,7 @@ namespace DataStormI
             std::string,
             std::int64_t,
             const std::vector<std::shared_ptr<Key>>&,
-            const std::string&,
+            std::string,
             Ice::ByteSeq,
             const DataStorm::ReaderConfig&);
 
@@ -409,7 +409,7 @@ namespace DataStormI
             std::string,
             std::int64_t,
             const std::shared_ptr<Filter>&,
-            const std::string&,
+            std::string,
             Ice::ByteSeq,
             const DataStorm::ReaderConfig&);
 

--- a/cpp/src/DataStorm/Node.cpp
+++ b/cpp/src/DataStorm/Node.cpp
@@ -169,7 +169,7 @@ Node::getCommunicator() const noexcept
 }
 
 Ice::ConnectionPtr
-Node::getSessionConnection(const string& ident) const noexcept
+Node::getSessionConnection(string_view ident) const noexcept
 {
     return _instance ? _instance->getNode()->getSessionConnection(ident) : nullptr;
 }

--- a/cpp/src/DataStorm/NodeI.cpp
+++ b/cpp/src/DataStorm/NodeI.cpp
@@ -388,7 +388,7 @@ NodeI::removePublisherSession(NodePrx node, const shared_ptr<PublisherSessionI>&
 }
 
 Ice::ConnectionPtr
-NodeI::getSessionConnection(const string& id) const
+NodeI::getSessionConnection(string_view id) const
 {
     auto session = getSession(Ice::stringToIdentity(id));
     if (session)

--- a/cpp/src/DataStorm/NodeI.h
+++ b/cpp/src/DataStorm/NodeI.h
@@ -62,7 +62,7 @@ namespace DataStormI
             const std::shared_ptr<PublisherSessionI>&,
             std::exception_ptr);
 
-        Ice::ConnectionPtr getSessionConnection(const std::string&) const;
+        Ice::ConnectionPtr getSessionConnection(std::string_view) const;
 
         std::shared_ptr<SessionI> getSession(const Ice::Identity&) const;
 

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -48,8 +48,8 @@ namespace DataStormI
         class ElementSubscribers
         {
         public:
-            ElementSubscribers(const std::string& name, int priority)
-                : name(name),
+            ElementSubscribers(std::string name, int priority)
+                : name(std::move(name)),
                   priority(priority),
                   _sessionInstanceId(0)
             {
@@ -124,12 +124,12 @@ namespace DataStormI
         public:
             TopicSubscriber(int sessionInstanceId) : sessionInstanceId(sessionInstanceId) {}
 
-            ElementSubscribers* add(std::int64_t id, const std::string& name, int priority)
+            ElementSubscribers* add(std::int64_t id, std::string name, int priority)
             {
                 auto p = _elements.find(id);
                 if (p == _elements.end())
                 {
-                    p = _elements.emplace(id, ElementSubscribers(name, priority)).first;
+                    p = _elements.emplace(id, ElementSubscribers(std::move(name), priority)).first;
                 }
                 return &p->second;
             }

--- a/cpp/src/DataStorm/TopicFactoryI.cpp
+++ b/cpp/src/DataStorm/TopicFactoryI.cpp
@@ -22,12 +22,12 @@ TopicFactoryI::TopicFactoryI(const shared_ptr<Instance>& instance)
 
 shared_ptr<TopicReader>
 TopicFactoryI::createTopicReader(
-    const string& name,
-    const shared_ptr<KeyFactory>& keyFactory,
-    const shared_ptr<TagFactory>& tagFactory,
-    const shared_ptr<SampleFactory>& sampleFactory,
-    const shared_ptr<FilterManager>& keyFilterFactories,
-    const shared_ptr<FilterManager>& sampleFilterFactories)
+    string name,
+    shared_ptr<KeyFactory> keyFactory,
+    shared_ptr<TagFactory> tagFactory,
+    shared_ptr<SampleFactory> sampleFactory,
+    shared_ptr<FilterManager> keyFilterFactories,
+    shared_ptr<FilterManager> sampleFilterFactories)
 {
     shared_ptr<TopicReaderI> reader;
     bool hasWriters;
@@ -35,12 +35,12 @@ TopicFactoryI::createTopicReader(
         lock_guard<mutex> lock(_mutex);
         reader = make_shared<TopicReaderI>(
             shared_from_this(),
-            keyFactory,
-            tagFactory,
-            sampleFactory,
-            keyFilterFactories,
-            sampleFilterFactories,
-            name,
+            std::move(keyFactory),
+            std::move(tagFactory),
+            std::move(sampleFactory),
+            std::move(keyFilterFactories),
+            std::move(sampleFilterFactories),
+            name, // we keep using name below
             _nextReaderId++);
         _readers[name].push_back(reader);
         if (_traceLevels->topic > 0)
@@ -79,12 +79,12 @@ TopicFactoryI::createTopicReader(
 
 shared_ptr<TopicWriter>
 TopicFactoryI::createTopicWriter(
-    const string& name,
-    const shared_ptr<KeyFactory>& keyFactory,
-    const shared_ptr<TagFactory>& tagFactory,
-    const shared_ptr<SampleFactory>& sampleFactory,
-    const shared_ptr<FilterManager>& keyFilterFactories,
-    const shared_ptr<FilterManager>& sampleFilterFactories)
+    string name,
+    shared_ptr<KeyFactory> keyFactory,
+    shared_ptr<TagFactory> tagFactory,
+    shared_ptr<SampleFactory> sampleFactory,
+    shared_ptr<FilterManager> keyFilterFactories,
+    shared_ptr<FilterManager> sampleFilterFactories)
 {
     shared_ptr<TopicWriterI> writer;
     bool hasReaders;
@@ -92,12 +92,12 @@ TopicFactoryI::createTopicWriter(
         lock_guard<mutex> lock(_mutex);
         writer = make_shared<TopicWriterI>(
             shared_from_this(),
-            keyFactory,
-            tagFactory,
-            sampleFactory,
-            keyFilterFactories,
-            sampleFilterFactories,
-            name,
+            std::move(keyFactory),
+            std::move(tagFactory),
+            std::move(sampleFactory),
+            std::move(keyFilterFactories),
+            std::move(sampleFilterFactories),
+            name, // we keep using name below
             _nextWriterId++);
         _writers[name].push_back(writer);
         if (_traceLevels->topic > 0)

--- a/cpp/src/DataStorm/TopicFactoryI.h
+++ b/cpp/src/DataStorm/TopicFactoryI.h
@@ -15,28 +15,28 @@ namespace DataStormI
 
     class TopicI;
 
-    class TopicFactoryI : public TopicFactory, public std::enable_shared_from_this<TopicFactoryI>
+    class TopicFactoryI final : public TopicFactory, public std::enable_shared_from_this<TopicFactoryI>
     {
     public:
         TopicFactoryI(const std::shared_ptr<Instance>&);
 
-        virtual std::shared_ptr<TopicReader> createTopicReader(
-            const std::string&,
-            const std::shared_ptr<KeyFactory>&,
-            const std::shared_ptr<TagFactory>&,
-            const std::shared_ptr<SampleFactory>&,
-            const std::shared_ptr<FilterManager>&,
-            const std::shared_ptr<FilterManager>&) override;
+        std::shared_ptr<TopicReader> createTopicReader(
+            std::string,
+            std::shared_ptr<KeyFactory>,
+            std::shared_ptr<TagFactory>,
+            std::shared_ptr<SampleFactory>,
+            std::shared_ptr<FilterManager>,
+            std::shared_ptr<FilterManager>) final;
 
-        virtual std::shared_ptr<TopicWriter> createTopicWriter(
-            const std::string&,
-            const std::shared_ptr<KeyFactory>&,
-            const std::shared_ptr<TagFactory>&,
-            const std::shared_ptr<SampleFactory>&,
-            const std::shared_ptr<FilterManager>&,
-            const std::shared_ptr<FilterManager>&) override;
+        std::shared_ptr<TopicWriter> createTopicWriter(
+            std::string,
+            std::shared_ptr<KeyFactory>,
+            std::shared_ptr<TagFactory>,
+            std::shared_ptr<SampleFactory>,
+            std::shared_ptr<FilterManager>,
+            std::shared_ptr<FilterManager>) final;
 
-        virtual Ice::CommunicatorPtr getCommunicator() const override;
+        Ice::CommunicatorPtr getCommunicator() const final;
 
         void removeTopicReader(const std::string&, const std::shared_ptr<TopicI>&);
         void removeTopicWriter(const std::string&, const std::shared_ptr<TopicI>&);

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -865,7 +865,15 @@ TopicReaderI::TopicReaderI(
     shared_ptr<FilterManager> sampleFilterFactories,
     string name,
     int64_t id)
-    : TopicI(std::move(factory), std::move(keyFactory), std::move(tagFactory), std::move(sampleFactory), std::move(keyFilterFactories), std::move(sampleFilterFactories), std::move(name), id)
+    : TopicI(
+          std::move(factory),
+          std::move(keyFactory),
+          std::move(tagFactory),
+          std::move(sampleFactory),
+          std::move(keyFilterFactories),
+          std::move(sampleFilterFactories),
+          std::move(name),
+          id)
 {
     _defaultConfig = {-1, 0, DataStorm::ClearHistoryPolicy::OnAll, DataStorm::DiscardPolicy::None};
     _defaultConfig = mergeConfigs(parseConfig("DataStorm.Topic"));
@@ -1000,7 +1008,15 @@ TopicWriterI::TopicWriterI(
     shared_ptr<FilterManager> sampleFilterFactories,
     string name,
     int64_t id)
-    : TopicI(std::move(factory), std::move(keyFactory), std::move(tagFactory), std::move(sampleFactory), std::move(keyFilterFactories), std::move(sampleFilterFactories), std::move(name), id)
+    : TopicI(
+          std::move(factory),
+          std::move(keyFactory),
+          std::move(tagFactory),
+          std::move(sampleFactory),
+          std::move(keyFilterFactories),
+          std::move(sampleFilterFactories),
+          std::move(name),
+          id)
 {
     _defaultConfig = {-1, 0, DataStorm::ClearHistoryPolicy::OnAll};
     _defaultConfig = mergeConfigs(parseConfig("DataStorm.Topic"));

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -60,22 +60,22 @@ namespace
 }
 
 TopicI::TopicI(
-    const weak_ptr<TopicFactoryI>& factory,
-    const shared_ptr<KeyFactory>& keyFactory,
-    const shared_ptr<TagFactory>& tagFactory,
-    const shared_ptr<SampleFactory>& sampleFactory,
-    const shared_ptr<FilterManager>& keyFilterFactories,
-    const shared_ptr<FilterManager>& sampleFilterFactories,
-    const string& name,
+    weak_ptr<TopicFactoryI> factory,
+    shared_ptr<KeyFactory> keyFactory,
+    shared_ptr<TagFactory> tagFactory,
+    shared_ptr<SampleFactory> sampleFactory,
+    shared_ptr<FilterManager> keyFilterFactories,
+    shared_ptr<FilterManager> sampleFilterFactories,
+    string name,
     int64_t id)
-    : _factory(factory),
-      _keyFactory(keyFactory),
-      _tagFactory(tagFactory),
+    : _factory(std::move(factory)),
+      _keyFactory(std::move(keyFactory)),
+      _tagFactory(std::move(tagFactory)),
       _sampleFactory(std::move(sampleFactory)),
-      _keyFilterFactories(keyFilterFactories),
-      _sampleFilterFactories(sampleFilterFactories),
-      _name(name),
-      _instance(factory.lock()->getInstance()),
+      _keyFilterFactories(std::move(keyFilterFactories)),
+      _sampleFilterFactories(std::move(sampleFilterFactories)),
+      _name(std::move(name)),
+      _instance(_factory.lock()->getInstance()),
       _traceLevels(_instance->getTraceLevels()),
       _id(id),
       _forwarder{_instance->getCollocatedForwarder()->add<SessionPrx>(
@@ -857,15 +857,15 @@ TopicI::parseConfigImpl(const Ice::PropertyDict& properties, const string& prefi
 }
 
 TopicReaderI::TopicReaderI(
-    const shared_ptr<TopicFactoryI>& factory,
-    const shared_ptr<KeyFactory>& keyFactory,
-    const shared_ptr<TagFactory>& tagFactory,
-    const shared_ptr<SampleFactory>& sampleFactory,
-    const shared_ptr<FilterManager>& keyFilterFactories,
-    const shared_ptr<FilterManager>& sampleFilterFactories,
-    const string& name,
+    shared_ptr<TopicFactoryI> factory,
+    shared_ptr<KeyFactory> keyFactory,
+    shared_ptr<TagFactory> tagFactory,
+    shared_ptr<SampleFactory> sampleFactory,
+    shared_ptr<FilterManager> keyFilterFactories,
+    shared_ptr<FilterManager> sampleFilterFactories,
+    string name,
     int64_t id)
-    : TopicI(factory, keyFactory, tagFactory, sampleFactory, keyFilterFactories, sampleFilterFactories, name, id)
+    : TopicI(std::move(factory), std::move(keyFactory), std::move(tagFactory), std::move(sampleFactory), std::move(keyFilterFactories), std::move(sampleFilterFactories), std::move(name), id)
 {
     _defaultConfig = {-1, 0, DataStorm::ClearHistoryPolicy::OnAll, DataStorm::DiscardPolicy::None};
     _defaultConfig = mergeConfigs(parseConfig("DataStorm.Topic"));
@@ -992,15 +992,15 @@ TopicReaderI::mergeConfigs(DataStorm::ReaderConfig config) const
 }
 
 TopicWriterI::TopicWriterI(
-    const shared_ptr<TopicFactoryI>& factory,
-    const shared_ptr<KeyFactory>& keyFactory,
-    const shared_ptr<TagFactory>& tagFactory,
-    const shared_ptr<SampleFactory>& sampleFactory,
-    const shared_ptr<FilterManager>& keyFilterFactories,
-    const shared_ptr<FilterManager>& sampleFilterFactories,
-    const string& name,
+    shared_ptr<TopicFactoryI> factory,
+    shared_ptr<KeyFactory> keyFactory,
+    shared_ptr<TagFactory> tagFactory,
+    shared_ptr<SampleFactory> sampleFactory,
+    shared_ptr<FilterManager> keyFilterFactories,
+    shared_ptr<FilterManager> sampleFilterFactories,
+    string name,
     int64_t id)
-    : TopicI(factory, keyFactory, tagFactory, sampleFactory, keyFilterFactories, sampleFilterFactories, name, id)
+    : TopicI(std::move(factory), std::move(keyFactory), std::move(tagFactory), std::move(sampleFactory), std::move(keyFilterFactories), std::move(sampleFilterFactories), std::move(name), id)
 {
     _defaultConfig = {-1, 0, DataStorm::ClearHistoryPolicy::OnAll};
     _defaultConfig = mergeConfigs(parseConfig("DataStorm.Topic"));

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -874,7 +874,7 @@ TopicReaderI::TopicReaderI(
 shared_ptr<DataReader>
 TopicReaderI::createFiltered(
     const shared_ptr<Filter>& filter,
-    const string& name,
+    string name,
     DataStorm::ReaderConfig config,
     const string& sampleFilterName,
     Ice::ByteSeq sampleFilterCriteria)
@@ -882,7 +882,7 @@ TopicReaderI::createFiltered(
     lock_guard<mutex> lock(_mutex);
     auto element = make_shared<FilteredDataReaderI>(
         this,
-        name,
+        std::move(name),
         ++_nextFilteredId,
         filter,
         sampleFilterName,
@@ -895,7 +895,7 @@ TopicReaderI::createFiltered(
 shared_ptr<DataReader>
 TopicReaderI::create(
     const vector<shared_ptr<Key>>& keys,
-    const string& name,
+    string name,
     DataStorm::ReaderConfig config,
     const string& sampleFilterName,
     Ice::ByteSeq sampleFilterCriteria)
@@ -903,7 +903,7 @@ TopicReaderI::create(
     lock_guard<mutex> lock(_mutex);
     auto element = make_shared<KeyDataReaderI>(
         this,
-        name,
+        std::move(name),
         ++_nextId,
         keys,
         sampleFilterName,
@@ -1007,10 +1007,10 @@ TopicWriterI::TopicWriterI(
 }
 
 shared_ptr<DataWriter>
-TopicWriterI::create(const vector<shared_ptr<Key>>& keys, const string& name, DataStorm::WriterConfig config)
+TopicWriterI::create(const vector<shared_ptr<Key>>& keys, string name, DataStorm::WriterConfig config)
 {
     lock_guard<mutex> lock(_mutex);
-    auto element = make_shared<KeyDataWriterI>(this, name, ++_nextId, keys, mergeConfigs(std::move(config)));
+    auto element = make_shared<KeyDataWriterI>(this, std::move(name), ++_nextId, keys, mergeConfigs(std::move(config)));
     add(element, keys);
     return element;
 }

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -876,7 +876,7 @@ TopicReaderI::createFiltered(
     const shared_ptr<Filter>& filter,
     string name,
     DataStorm::ReaderConfig config,
-    const string& sampleFilterName,
+    string sampleFilterName,
     Ice::ByteSeq sampleFilterCriteria)
 {
     lock_guard<mutex> lock(_mutex);
@@ -885,7 +885,7 @@ TopicReaderI::createFiltered(
         std::move(name),
         ++_nextFilteredId,
         filter,
-        sampleFilterName,
+        std::move(sampleFilterName),
         std::move(sampleFilterCriteria),
         mergeConfigs(std::move(config)));
     addFiltered(element, filter);
@@ -897,7 +897,7 @@ TopicReaderI::create(
     const vector<shared_ptr<Key>>& keys,
     string name,
     DataStorm::ReaderConfig config,
-    const string& sampleFilterName,
+    string sampleFilterName,
     Ice::ByteSeq sampleFilterCriteria)
 {
     lock_guard<mutex> lock(_mutex);
@@ -906,7 +906,7 @@ TopicReaderI::create(
         std::move(name),
         ++_nextId,
         keys,
-        sampleFilterName,
+        std::move(sampleFilterName),
         std::move(sampleFilterCriteria),
         mergeConfigs(std::move(config)));
     add(element, keys);

--- a/cpp/src/DataStorm/TopicI.h
+++ b/cpp/src/DataStorm/TopicI.h
@@ -167,14 +167,14 @@ namespace DataStormI
 
         std::shared_ptr<DataReader> createFiltered(
             const std::shared_ptr<Filter>&,
-            const std::string&,
+            std::string,
             DataStorm::ReaderConfig,
             const std::string&,
             Ice::ByteSeq) final;
 
         std::shared_ptr<DataReader> create(
             const std::vector<std::shared_ptr<Key>>&,
-            const std::string&,
+            std::string,
             DataStorm::ReaderConfig,
             const std::string&,
             Ice::ByteSeq) final;
@@ -205,7 +205,7 @@ namespace DataStormI
             std::int64_t);
 
         std::shared_ptr<DataWriter>
-        create(const std::vector<std::shared_ptr<Key>>&, const std::string&, DataStorm::WriterConfig) final;
+        create(const std::vector<std::shared_ptr<Key>>&, std::string, DataStorm::WriterConfig) final;
 
         void setDefaultConfig(DataStorm::WriterConfig) final;
         void waitForReaders(int) const final;

--- a/cpp/src/DataStorm/TopicI.h
+++ b/cpp/src/DataStorm/TopicI.h
@@ -169,14 +169,14 @@ namespace DataStormI
             const std::shared_ptr<Filter>&,
             std::string,
             DataStorm::ReaderConfig,
-            const std::string&,
+            std::string,
             Ice::ByteSeq) final;
 
         std::shared_ptr<DataReader> create(
             const std::vector<std::shared_ptr<Key>>&,
             std::string,
             DataStorm::ReaderConfig,
-            const std::string&,
+            std::string,
             Ice::ByteSeq) final;
 
         void setDefaultConfig(DataStorm::ReaderConfig) final;

--- a/cpp/src/DataStorm/TopicI.h
+++ b/cpp/src/DataStorm/TopicI.h
@@ -165,12 +165,9 @@ namespace DataStormI
             std::string,
             std::int64_t);
 
-        std::shared_ptr<DataReader> createFiltered(
-            const std::shared_ptr<Filter>&,
-            std::string,
-            DataStorm::ReaderConfig,
-            std::string,
-            Ice::ByteSeq) final;
+        std::shared_ptr<DataReader>
+        createFiltered(const std::shared_ptr<Filter>&, std::string, DataStorm::ReaderConfig, std::string, Ice::ByteSeq)
+            final;
 
         std::shared_ptr<DataReader> create(
             const std::vector<std::shared_ptr<Key>>&,

--- a/cpp/src/DataStorm/TopicI.h
+++ b/cpp/src/DataStorm/TopicI.h
@@ -11,20 +11,12 @@
 #include "ForwarderManager.h"
 #include "Instance.h"
 
-#if defined(__clang__)
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
-#elif defined(__GNUC__)
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wshadow"
-#endif
-
 namespace DataStormI
 {
     class SessionI;
     class TopicFactoryI;
 
-    class TopicI : virtual public Topic, public std::enable_shared_from_this<TopicI>
+    class TopicI : public virtual Topic, public std::enable_shared_from_this<TopicI>
     {
         struct ListenerKey
         {
@@ -35,7 +27,7 @@ namespace DataStormI
 
         struct Listener
         {
-            Listener(DataStormContract::SessionPrx proxy) : proxy(std::move(proxy)) {}
+            Listener(DataStormContract::SessionPrx sessionPrx) : proxy(std::move(sessionPrx)) {}
 
             std::set<std::int64_t> topics;
             DataStormContract::SessionPrx proxy;
@@ -43,19 +35,19 @@ namespace DataStormI
 
     public:
         TopicI(
-            const std::weak_ptr<TopicFactoryI>&,
-            const std::shared_ptr<KeyFactory>&,
-            const std::shared_ptr<TagFactory>&,
-            const std::shared_ptr<SampleFactory>&,
-            const std::shared_ptr<FilterManager>&,
-            const std::shared_ptr<FilterManager>&,
-            const std::string&,
+            std::weak_ptr<TopicFactoryI>,
+            std::shared_ptr<KeyFactory>,
+            std::shared_ptr<TagFactory>,
+            std::shared_ptr<SampleFactory>,
+            std::shared_ptr<FilterManager>,
+            std::shared_ptr<FilterManager>,
+            std::string,
             std::int64_t);
 
-        virtual ~TopicI();
+        ~TopicI() override;
 
-        virtual std::string getName() const override;
-        virtual void destroy() override;
+        std::string getName() const override;
+        void destroy() override;
 
         void shutdown();
 
@@ -84,11 +76,11 @@ namespace DataStormI
             const std::chrono::time_point<std::chrono::system_clock>&,
             Ice::LongSeq&);
 
-        virtual void setUpdater(const std::shared_ptr<Tag>&, Updater) override;
+        void setUpdater(const std::shared_ptr<Tag>&, Updater) override;
         const Updater& getUpdater(const std::shared_ptr<Tag>&) const;
 
-        virtual void setUpdaters(std::map<std::shared_ptr<Tag>, Updater>) override;
-        virtual std::map<std::shared_ptr<Tag>, Updater> getUpdaters() const override;
+        void setUpdaters(std::map<std::shared_ptr<Tag>, Updater>) override;
+        std::map<std::shared_ptr<Tag>, Updater> getUpdaters() const override;
 
         bool isDestroyed() const { return _destroyed; }
 
@@ -160,36 +152,37 @@ namespace DataStormI
         std::int64_t _nextSampleId;
     };
 
-    class TopicReaderI : public TopicReader, public TopicI
+    class TopicReaderI final : public TopicReader, public TopicI
     {
     public:
         TopicReaderI(
-            const std::shared_ptr<TopicFactoryI>&,
-            const std::shared_ptr<KeyFactory>&,
-            const std::shared_ptr<TagFactory>&,
-            const std::shared_ptr<SampleFactory>&,
-            const std::shared_ptr<FilterManager>&,
-            const std::shared_ptr<FilterManager>&,
-            const std::string&,
+            std::shared_ptr<TopicFactoryI>,
+            std::shared_ptr<KeyFactory>,
+            std::shared_ptr<TagFactory>,
+            std::shared_ptr<SampleFactory>,
+            std::shared_ptr<FilterManager>,
+            std::shared_ptr<FilterManager>,
+            std::string,
             std::int64_t);
 
-        virtual std::shared_ptr<DataReader> createFiltered(
+        std::shared_ptr<DataReader> createFiltered(
             const std::shared_ptr<Filter>&,
             const std::string&,
             DataStorm::ReaderConfig,
             const std::string&,
-            Ice::ByteSeq) override;
-        virtual std::shared_ptr<DataReader> create(
+            Ice::ByteSeq) final;
+
+        std::shared_ptr<DataReader> create(
             const std::vector<std::shared_ptr<Key>>&,
             const std::string&,
             DataStorm::ReaderConfig,
             const std::string&,
-            Ice::ByteSeq) override;
+            Ice::ByteSeq) final;
 
-        virtual void setDefaultConfig(DataStorm::ReaderConfig) override;
-        virtual void waitForWriters(int) const override;
-        virtual bool hasWriters() const override;
-        virtual void destroy() override;
+        void setDefaultConfig(DataStorm::ReaderConfig) final;
+        void waitForWriters(int) const final;
+        bool hasWriters() const final;
+        void destroy() final;
 
     private:
         DataStorm::ReaderConfig parseConfig(const std::string&) const;
@@ -198,26 +191,26 @@ namespace DataStormI
         DataStorm::ReaderConfig _defaultConfig;
     };
 
-    class TopicWriterI : public TopicWriter, public TopicI
+    class TopicWriterI final : public TopicWriter, public TopicI
     {
     public:
         TopicWriterI(
-            const std::shared_ptr<TopicFactoryI>&,
-            const std::shared_ptr<KeyFactory>&,
-            const std::shared_ptr<TagFactory>&,
-            const std::shared_ptr<SampleFactory>&,
-            const std::shared_ptr<FilterManager>&,
-            const std::shared_ptr<FilterManager>&,
-            const std::string&,
+            std::shared_ptr<TopicFactoryI>,
+            std::shared_ptr<KeyFactory>,
+            std::shared_ptr<TagFactory>,
+            std::shared_ptr<SampleFactory>,
+            std::shared_ptr<FilterManager>,
+            std::shared_ptr<FilterManager>,
+            std::string,
             std::int64_t);
 
-        virtual std::shared_ptr<DataWriter>
-        create(const std::vector<std::shared_ptr<Key>>&, const std::string&, DataStorm::WriterConfig) override;
+        std::shared_ptr<DataWriter>
+        create(const std::vector<std::shared_ptr<Key>>&, const std::string&, DataStorm::WriterConfig) final;
 
-        virtual void setDefaultConfig(DataStorm::WriterConfig) override;
-        virtual void waitForReaders(int) const override;
-        virtual bool hasReaders() const override;
-        virtual void destroy() override;
+        void setDefaultConfig(DataStorm::WriterConfig) final;
+        void waitForReaders(int) const final;
+        bool hasReaders() const final;
+        void destroy() final;
 
     private:
         DataStorm::WriterConfig parseConfig(const std::string&) const;
@@ -226,11 +219,5 @@ namespace DataStormI
         DataStorm::WriterConfig _defaultConfig;
     };
 }
-
-#if defined(__clang__)
-#    pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#    pragma GCC diagnostic pop
-#endif
 
 #endif


### PR DESCRIPTION
This PR updates the DataStorm to use `string` (copies) instead of `const string&` where appropriate.