### PR TITLE
Remove AMD check in Ruby

### DIFF
--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -516,7 +516,7 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     //
     // Define each operation. The arguments to __defineOperation are:
     //
-    // 'opName', Mode, IsAmd, FormatType, [InParams], [OutParams], ReturnParam, [Exceptions]
+    // 'opName', Mode, FormatType, [InParams], [OutParams], ReturnParam, [Exceptions]
     //
     // where InParams and OutParams are arrays of type descriptions, and Exceptions
     // is an array of exception types.
@@ -582,8 +582,7 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                 _out << "::Ice::OperationMode::Idempotent";
                 break;
         }
-        _out << ", " << ((p->hasMetadata("amd") || op->hasMetadata("amd")) ? "true" : "false") << ", " << format
-             << ", [";
+        _out << ", " << format << ", [";
         for (t = params.begin(), count = 0; t != params.end(); ++t)
         {
             if (!(*t)->isOutParam())

--- a/ruby/src/IceRuby/Operation.cpp
+++ b/ruby/src/IceRuby/Operation.cpp
@@ -89,8 +89,7 @@ IceRuby_defineOperation(
 {
     ICE_RUBY_TRY
     {
-        OperationIPtr op =
-            make_shared<OperationI>(name, mode, format, inParams, outParams, returnType, exceptions);
+        OperationIPtr op = make_shared<OperationI>(name, mode, format, inParams, outParams, returnType, exceptions);
         return Data_Wrap_Struct(_operationClass, 0, IceRuby_Operation_free, new OperationPtr(op));
     }
     ICE_RUBY_CATCH

--- a/ruby/src/IceRuby/Operation.cpp
+++ b/ruby/src/IceRuby/Operation.cpp
@@ -40,7 +40,7 @@ namespace IceRuby
     class OperationI final : public Operation
     {
     public:
-        OperationI(VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE);
+        OperationI(VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE);
 
         VALUE invoke(const Ice::ObjectPrx&, VALUE, VALUE) final;
         void deprecate(const string&) final;
@@ -48,7 +48,6 @@ namespace IceRuby
     private:
         string _name;
         Ice::OperationMode _mode;
-        bool _amd;
         std::optional<Ice::FormatType> _format;
         ParamInfoList _inParams;
         ParamInfoList _optionalInParams;
@@ -56,7 +55,6 @@ namespace IceRuby
         ParamInfoList _optionalOutParams;
         ParamInfoPtr _returnType;
         ExceptionInfoList _exceptions;
-        string _dispatchName;
         bool _sendsClasses;
         bool _returnsClasses;
         string _deprecateMessage;
@@ -83,7 +81,6 @@ IceRuby_defineOperation(
     VALUE /*self*/,
     VALUE name,
     VALUE mode,
-    VALUE amd,
     VALUE format,
     VALUE inParams,
     VALUE outParams,
@@ -93,7 +90,7 @@ IceRuby_defineOperation(
     ICE_RUBY_TRY
     {
         OperationIPtr op =
-            make_shared<OperationI>(name, mode, amd, format, inParams, outParams, returnType, exceptions);
+            make_shared<OperationI>(name, mode, format, inParams, outParams, returnType, exceptions);
         return Data_Wrap_Struct(_operationClass, 0, IceRuby_Operation_free, new OperationPtr(op));
     }
     ICE_RUBY_CATCH
@@ -151,7 +148,6 @@ IceRuby::ParamInfo::unmarshaled(VALUE val, VALUE target, void* closure)
 IceRuby::OperationI::OperationI(
     VALUE name,
     VALUE mode,
-    VALUE amd,
     VALUE format,
     VALUE inParams,
     VALUE outParams,
@@ -159,15 +155,6 @@ IceRuby::OperationI::OperationI(
     VALUE exceptions)
 {
     _name = getString(name);
-    _amd = amd == Qtrue;
-    if (_amd)
-    {
-        _dispatchName = fixIdent(_name, IdentNormal) + "_async";
-    }
-    else
-    {
-        _dispatchName = fixIdent(_name, IdentNormal);
-    }
 
     //
     // mode
@@ -611,7 +598,7 @@ IceRuby::OperationI::checkTwowayOnly(const Ice::ObjectPrx& proxy) const
 bool
 IceRuby::initOperation(VALUE iceModule)
 {
-    rb_define_module_function(iceModule, "__defineOperation", CAST_METHOD(IceRuby_defineOperation), 8);
+    rb_define_module_function(iceModule, "__defineOperation", CAST_METHOD(IceRuby_defineOperation), 7);
 
     //
     // Define a class to represent an operation.


### PR DESCRIPTION
Ruby is client-side only and as a result does not support AMD. Unclear why we had this code in the first place.

It was mentioned here: https://github.com/zeroc-ice/ice/pull/2840#discussion_r1785205585

but I can't find the issue that was created from this comment.