### PR TITLE
Cleanup virtual/override/final in DataStorm

### DIFF
--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -24,7 +24,6 @@
 
 namespace DataStorm
 {
-
     /**
      * A sample provides information about a data element update.
      *
@@ -2083,7 +2082,6 @@ namespace DataStorm
     {
         return _topicFactory->getCommunicator();
     }
-
 }
 
 #if defined(__clang__)

--- a/cpp/include/DataStorm/InternalI.h
+++ b/cpp/include/DataStorm/InternalI.h
@@ -152,7 +152,8 @@ namespace DataStormI
 
         virtual std::shared_ptr<Filter> get(const std::string&, std::int64_t) const = 0;
 
-        virtual std::shared_ptr<Filter> decode(const Ice::CommunicatorPtr&, const std::string&, const Ice::ByteSeq&) = 0;
+        virtual std::shared_ptr<Filter>
+        decode(const Ice::CommunicatorPtr&, const std::string&, const Ice::ByteSeq&) = 0;
     };
 
     class DataElement

--- a/cpp/include/DataStorm/InternalI.h
+++ b/cpp/include/DataStorm/InternalI.h
@@ -43,7 +43,7 @@ namespace DataStormI
         virtual std::int64_t getId() const = 0;
     };
 
-    class Key : public Filterable, virtual public Element
+    class Key : public Filterable, public virtual Element
     {
     };
 
@@ -55,7 +55,7 @@ namespace DataStormI
         virtual std::shared_ptr<Key> decode(const Ice::CommunicatorPtr&, const Ice::ByteSeq&) = 0;
     };
 
-    class Tag : virtual public Element
+    class Tag : public virtual Element
     {
     };
 
@@ -129,7 +129,7 @@ namespace DataStormI
             std::int64_t) = 0;
     };
 
-    class Filter : virtual public Element
+    class Filter : public virtual Element
     {
     public:
         virtual bool match(const std::shared_ptr<Filterable>&) const = 0;
@@ -152,8 +152,7 @@ namespace DataStormI
 
         virtual std::shared_ptr<Filter> get(const std::string&, std::int64_t) const = 0;
 
-        virtual std::shared_ptr<Filter>
-        decode(const Ice::CommunicatorPtr&, const std::string&, const Ice::ByteSeq&) = 0;
+        virtual std::shared_ptr<Filter> decode(const Ice::CommunicatorPtr&, const std::string&, const Ice::ByteSeq&) = 0;
     };
 
     class DataElement
@@ -176,7 +175,7 @@ namespace DataStormI
         virtual Ice::CommunicatorPtr getCommunicator() const = 0;
     };
 
-    class DataReader : virtual public DataElement
+    class DataReader : public virtual DataElement
     {
     public:
         virtual bool hasWriters() = 0;
@@ -193,7 +192,7 @@ namespace DataStormI
             std::function<void(const std::shared_ptr<Sample>&)>) = 0;
     };
 
-    class DataWriter : virtual public DataElement
+    class DataWriter : public virtual DataElement
     {
     public:
         virtual bool hasReaders() const = 0;
@@ -222,7 +221,7 @@ namespace DataStormI
         virtual void destroy() = 0;
     };
 
-    class TopicReader : virtual public Topic
+    class TopicReader : public virtual Topic
     {
     public:
         virtual std::shared_ptr<DataReader> createFiltered(
@@ -244,7 +243,7 @@ namespace DataStormI
         virtual void waitForWriters(int) const = 0;
     };
 
-    class TopicWriter : virtual public Topic
+    class TopicWriter : public virtual Topic
     {
     public:
         virtual std::shared_ptr<DataWriter>

--- a/cpp/include/DataStorm/InternalT.h
+++ b/cpp/include/DataStorm/InternalT.h
@@ -256,10 +256,7 @@ namespace DataStormI
     public:
         using AbstractFactoryT<K, KeyT<K>>::AbstractFactoryT;
 
-        std::shared_ptr<Key> get(std::int64_t id) const final
-        {
-            return AbstractFactoryT<K, KeyT<K>>::getImpl(id);
-        }
+        std::shared_ptr<Key> get(std::int64_t id) const final { return AbstractFactoryT<K, KeyT<K>>::getImpl(id); }
 
         std::shared_ptr<Key> decode(const Ice::CommunicatorPtr& communicator, const Ice::ByteSeq& data) final
         {
@@ -288,10 +285,7 @@ namespace DataStormI
     public:
         using AbstractFactoryT<T, TagT<T>>::AbstractFactoryT;
 
-        std::shared_ptr<Tag> get(std::int64_t id) const final
-        {
-            return AbstractFactoryT<T, TagT<T>>::getImpl(id);
-        }
+        std::shared_ptr<Tag> get(std::int64_t id) const final { return AbstractFactoryT<T, TagT<T>>::getImpl(id); }
 
         std::shared_ptr<Tag> decode(const Ice::CommunicatorPtr& communicator, const Ice::ByteSeq& data) final
         {

--- a/cpp/include/DataStorm/Node.h
+++ b/cpp/include/DataStorm/Node.h
@@ -19,10 +19,10 @@ namespace DataStorm
      *
      * @headerfile DataStorm/DataStorm.h
      */
-    class DATASTORM_API NodeShutdownException : public std::exception
+    class DATASTORM_API NodeShutdownException final : public std::exception
     {
     public:
-        virtual const char* what() const noexcept;
+        const char* what() const noexcept final;
     };
 
     /**

--- a/cpp/src/DataStorm/CallbackExecutor.h
+++ b/cpp/src/DataStorm/CallbackExecutor.h
@@ -16,7 +16,7 @@ namespace DataStormI
 {
     class DataElementI;
 
-    class CallbackExecutor
+    class CallbackExecutor final
     {
     public:
         CallbackExecutor(std::function<void(std::function<void()> call)> customExecutor);

--- a/cpp/src/DataStorm/ConnectionManager.h
+++ b/cpp/src/DataStorm/ConnectionManager.h
@@ -17,8 +17,8 @@ namespace DataStormI
     public:
         ConnectionManager(const std::shared_ptr<CallbackExecutor>&);
 
-        void add(
-            const Ice::ConnectionPtr&,
+        void
+        add(const Ice::ConnectionPtr&,
             std::shared_ptr<void>,
             std::function<void(const Ice::ConnectionPtr&, std::exception_ptr)>);
 

--- a/cpp/src/DataStorm/ConnectionManager.h
+++ b/cpp/src/DataStorm/ConnectionManager.h
@@ -12,13 +12,13 @@ namespace DataStormI
 {
     class CallbackExecutor;
 
-    class ConnectionManager : public std::enable_shared_from_this<ConnectionManager>
+    class ConnectionManager final : public std::enable_shared_from_this<ConnectionManager>
     {
     public:
         ConnectionManager(const std::shared_ptr<CallbackExecutor>&);
 
-        void
-        add(const Ice::ConnectionPtr&,
+        void add(
+            const Ice::ConnectionPtr&,
             std::shared_ptr<void>,
             std::function<void(const Ice::ConnectionPtr&, std::exception_ptr)>);
 

--- a/cpp/src/DataStorm/DataElementI.h
+++ b/cpp/src/DataStorm/DataElementI.h
@@ -25,7 +25,8 @@ namespace DataStormI
     class CallbackExecutor;
     class TraceLevels;
 
-    class DataElementI : virtual public DataElement, public std::enable_shared_from_this<DataElementI>
+    // Base class for DataReaderI and DataWriterI.
+    class DataElementI : public virtual DataElement, public std::enable_shared_from_this<DataElementI>
     {
     protected:
         struct Subscriber
@@ -134,9 +135,9 @@ namespace DataStormI
 
     public:
         DataElementI(TopicI*, std::string, std::int64_t, const DataStorm::Config&);
-        virtual ~DataElementI();
+        ~DataElementI() override;
 
-        virtual void destroy() override;
+        void destroy() override;
 
         void attach(
             std::int64_t,
@@ -201,12 +202,14 @@ namespace DataStormI
             const std::string&,
             bool);
 
-        virtual std::vector<std::shared_ptr<Key>> getConnectedKeys() const override;
-        virtual std::vector<std::string> getConnectedElements() const override;
-        virtual void onConnectedKeys(
+        std::vector<std::shared_ptr<Key>> getConnectedKeys() const override;
+        std::vector<std::string> getConnectedElements() const override;
+
+        void onConnectedKeys(
             std::function<void(std::vector<std::shared_ptr<Key>>)>,
             std::function<void(DataStorm::CallbackReason, std::shared_ptr<Key>)>) override;
-        virtual void onConnectedElements(
+
+        void onConnectedElements(
             std::function<void(std::vector<std::string>)>,
             std::function<void(DataStorm::CallbackReason, std::string)>) override;
 
@@ -217,6 +220,7 @@ namespace DataStormI
             int,
             const std::chrono::time_point<std::chrono::system_clock>&,
             bool);
+
         virtual DataStormContract::DataSamples getSamples(
             const std::shared_ptr<Key>&,
             const std::shared_ptr<Filter>&,
@@ -233,7 +237,8 @@ namespace DataStormI
             bool);
 
         virtual std::string toString() const = 0;
-        virtual Ice::CommunicatorPtr getCommunicator() const override;
+
+        Ice::CommunicatorPtr getCommunicator() const override;
 
         std::int64_t getId() const { return _id; }
 
@@ -287,21 +292,22 @@ namespace DataStormI
             Ice::ByteSeq,
             const DataStorm::ReaderConfig&);
 
-        virtual int getInstanceCount() const override;
+        int getInstanceCount() const override;
 
-        virtual std::vector<std::shared_ptr<Sample>> getAllUnread() override;
-        virtual void waitForUnread(unsigned int) const override;
-        virtual bool hasUnread() const override;
-        virtual std::shared_ptr<Sample> getNextUnread() override;
+        std::vector<std::shared_ptr<Sample>> getAllUnread() override;
+        void waitForUnread(unsigned int) const override;
+        bool hasUnread() const override;
+        std::shared_ptr<Sample> getNextUnread() override;
 
-        virtual void initSamples(
+        void initSamples(
             const std::vector<std::shared_ptr<Sample>>&,
             std::int64_t,
             std::int64_t,
             int,
             const std::chrono::time_point<std::chrono::system_clock>&,
             bool) override;
-        virtual void queue(
+
+        void queue(
             const std::shared_ptr<Sample>&,
             int,
             const std::shared_ptr<SessionI>&,
@@ -309,13 +315,13 @@ namespace DataStormI
             const std::chrono::time_point<std::chrono::system_clock>&,
             bool) override;
 
-        virtual void onSamples(
+        void onSamples(
             std::function<void(const std::vector<std::shared_ptr<Sample>>&)>,
             std::function<void(const std::shared_ptr<Sample>&)>) override;
 
     protected:
         virtual bool matchKey(const std::shared_ptr<Key>&) const = 0;
-        virtual bool addConnectedKey(const std::shared_ptr<Key>&, const std::shared_ptr<Subscriber>&) override;
+        bool addConnectedKey(const std::shared_ptr<Key>&, const std::shared_ptr<Subscriber>&) override;
 
         TopicReaderI* _parent;
 
@@ -332,7 +338,7 @@ namespace DataStormI
     public:
         DataWriterI(TopicWriterI*, std::string, std::int64_t, const DataStorm::WriterConfig&);
 
-        virtual void publish(const std::shared_ptr<Key>&, const std::shared_ptr<Sample>&) override;
+        void publish(const std::shared_ptr<Key>&, const std::shared_ptr<Sample>&) override;
 
     protected:
         virtual void send(const std::shared_ptr<Key>&, const std::shared_ptr<Sample>&) const = 0;
@@ -343,7 +349,7 @@ namespace DataStormI
         std::shared_ptr<Sample> _last;
     };
 
-    class KeyDataReaderI : public DataReaderI
+    class KeyDataReaderI final : public DataReaderI
     {
     public:
         KeyDataReaderI(
@@ -355,20 +361,20 @@ namespace DataStormI
             Ice::ByteSeq,
             const DataStorm::ReaderConfig&);
 
-        virtual void destroyImpl() override;
+        void destroyImpl() final;
 
-        virtual void waitForWriters(int) override;
-        virtual bool hasWriters() override;
+        void waitForWriters(int) final;
+        bool hasWriters() final;
 
-        virtual std::string toString() const override;
+        std::string toString() const final;
 
     private:
-        virtual bool matchKey(const std::shared_ptr<Key>&) const override;
+        bool matchKey(const std::shared_ptr<Key>&) const final;
 
         const std::vector<std::shared_ptr<Key>> _keys;
     };
 
-    class KeyDataWriterI : public DataWriterI
+    class KeyDataWriterI final : public DataWriterI
     {
     public:
         KeyDataWriterI(
@@ -378,30 +384,31 @@ namespace DataStormI
             const std::vector<std::shared_ptr<Key>>&,
             const DataStorm::WriterConfig&);
 
-        virtual void destroyImpl() override;
+        void destroyImpl() final;
 
-        virtual void waitForReaders(int) const override;
-        virtual bool hasReaders() const override;
+        void waitForReaders(int) const final;
+        bool hasReaders() const final;
 
-        virtual std::shared_ptr<Sample> getLast() const override;
-        virtual std::vector<std::shared_ptr<Sample>> getAll() const override;
+        std::shared_ptr<Sample> getLast() const final;
+        std::vector<std::shared_ptr<Sample>> getAll() const final;
 
-        virtual std::string toString() const override;
-        virtual DataStormContract::DataSamples getSamples(
+        std::string toString() const final;
+
+        DataStormContract::DataSamples getSamples(
             const std::shared_ptr<Key>&,
             const std::shared_ptr<Filter>&,
             const std::shared_ptr<DataStormContract::ElementConfig>&,
             std::int64_t,
-            const std::chrono::time_point<std::chrono::system_clock>&) override;
+            const std::chrono::time_point<std::chrono::system_clock>&) final;
 
     private:
-        virtual void send(const std::shared_ptr<Key>&, const std::shared_ptr<Sample>&) const override;
-        virtual void forward(const Ice::ByteSeq&, const Ice::Current&) const override;
+        void send(const std::shared_ptr<Key>&, const std::shared_ptr<Sample>&) const final;
+        void forward(const Ice::ByteSeq&, const Ice::Current&) const final;
 
         const std::vector<std::shared_ptr<Key>> _keys;
     };
 
-    class FilteredDataReaderI : public DataReaderI
+    class FilteredDataReaderI final : public DataReaderI
     {
     public:
         FilteredDataReaderI(
@@ -413,15 +420,15 @@ namespace DataStormI
             Ice::ByteSeq,
             const DataStorm::ReaderConfig&);
 
-        virtual void destroyImpl() override;
+        void destroyImpl() final;
 
-        virtual void waitForWriters(int) override;
-        virtual bool hasWriters() override;
+        void waitForWriters(int) final;
+        bool hasWriters() final;
 
-        virtual std::string toString() const override;
+        std::string toString() const final;
 
     private:
-        virtual bool matchKey(const std::shared_ptr<Key>&) const override;
+        bool matchKey(const std::shared_ptr<Key>&) const final;
 
         const std::shared_ptr<Filter> _filter;
     };

--- a/cpp/src/DataStorm/ForwarderManager.h
+++ b/cpp/src/DataStorm/ForwarderManager.h
@@ -13,7 +13,7 @@
 
 namespace DataStormI
 {
-    class ForwarderManager : public Ice::BlobjectAsync
+    class ForwarderManager final : public Ice::BlobjectAsync
     {
     public:
         using Response = std::function<void(bool, const Ice::ByteSeq&)>;
@@ -57,11 +57,11 @@ namespace DataStormI
         void destroy();
 
     private:
-        virtual void ice_invokeAsync(
+        void ice_invokeAsync(
             Ice::ByteSeq,
             std::function<void(bool, const Ice::ByteSeq&)>,
             std::function<void(std::exception_ptr)>,
-            const Ice::Current&);
+            const Ice::Current&) final;
 
         const Ice::ObjectAdapterPtr _adapter;
         const std::string _category;

--- a/cpp/src/DataStorm/Instance.h
+++ b/cpp/src/DataStorm/Instance.h
@@ -22,7 +22,7 @@ namespace DataStormI
     class NodeI;
     class CallbackExecutor;
 
-    class Instance : public std::enable_shared_from_this<Instance>
+    class Instance final : public std::enable_shared_from_this<Instance>
     {
     public:
         Instance(

--- a/cpp/src/DataStorm/NodeI.h
+++ b/cpp/src/DataStorm/NodeI.h
@@ -20,11 +20,11 @@ namespace DataStormI
     class PublisherSessionI;
     class SubscriberSessionI;
 
-    class NodeI final : virtual public DataStormContract::Node, public std::enable_shared_from_this<NodeI>
+    class NodeI final : public virtual DataStormContract::Node, public std::enable_shared_from_this<NodeI>
     {
     public:
         NodeI(const std::shared_ptr<Instance>&);
-        virtual ~NodeI();
+        ~NodeI() final;
 
         void init();
         void destroy(bool);

--- a/cpp/src/DataStorm/NodeSessionI.h
+++ b/cpp/src/DataStorm/NodeSessionI.h
@@ -13,7 +13,7 @@ namespace DataStormI
 {
     class TraceLevels;
 
-    class NodeSessionI : public std::enable_shared_from_this<NodeSessionI>
+    class NodeSessionI final : public std::enable_shared_from_this<NodeSessionI>
     {
     public:
         NodeSessionI(std::shared_ptr<Instance>, std::optional<DataStormContract::NodePrx>, Ice::ConnectionPtr, bool);

--- a/cpp/src/DataStorm/NodeSessionManager.h
+++ b/cpp/src/DataStorm/NodeSessionManager.h
@@ -17,7 +17,7 @@ namespace DataStormI
     class TraceLevels;
     class NodeI;
 
-    class NodeSessionManager : public std::enable_shared_from_this<NodeSessionManager>
+    class NodeSessionManager final : public std::enable_shared_from_this<NodeSessionManager>
     {
     public:
         NodeSessionManager(const std::shared_ptr<Instance>&, const std::shared_ptr<NodeI>&);

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -24,7 +24,7 @@ namespace DataStormI
     class Instance;
     class TraceLevels;
 
-    class SessionI : virtual public DataStormContract::Session, public std::enable_shared_from_this<SessionI>
+    class SessionI : public virtual DataStormContract::Session, public std::enable_shared_from_this<SessionI>
     {
     protected:
         struct ElementSubscriber
@@ -353,12 +353,12 @@ namespace DataStormI
     public:
         SubscriberSessionI(const std::shared_ptr<NodeI>&, DataStormContract::NodePrx, DataStormContract::SessionPrx);
 
-        virtual void s(std::int64_t, std::int64_t, DataStormContract::DataSample, const Ice::Current&) final;
+        void s(std::int64_t, std::int64_t, DataStormContract::DataSample, const Ice::Current&) final;
 
     private:
-        virtual std::vector<std::shared_ptr<TopicI>> getTopics(const std::string&) const final;
-        virtual void reconnect(DataStormContract::NodePrx) final;
-        virtual void remove() final;
+        std::vector<std::shared_ptr<TopicI>> getTopics(const std::string&) const final;
+        void reconnect(DataStormContract::NodePrx) final;
+        void remove() final;
     };
 
     class PublisherSessionI : public SessionI, public DataStormContract::PublisherSession

--- a/cpp/src/DataStorm/TopicI.cpp
+++ b/cpp/src/DataStorm/TopicI.cpp
@@ -36,25 +36,25 @@ namespace
     { next->setValue(previous); };
 
     // The always match filter always matches the value, it's used by the any key reader/writer.
-    class AlwaysMatchFilter : public Filter
+    class AlwaysMatchFilter final : public Filter
     {
     public:
-        virtual string toString() const { return "f1:alwaysmatch"; }
+        string toString() const final { return "f1:alwaysmatch"; }
 
-        virtual const string& getName() const
+        const string& getName() const final
         {
             static string alwaysmatch("alwaysmatch");
             return alwaysmatch;
         }
 
-        virtual Ice::ByteSeq encode(const Ice::CommunicatorPtr&) const { return {}; }
+        Ice::ByteSeq encode(const Ice::CommunicatorPtr&) const final { return {}; }
 
-        virtual int64_t getId() const
+        int64_t getId() const final
         {
             return 1; // 1 is reserved for the match all filter.
         }
 
-        virtual bool match(const shared_ptr<Filterable>&) const { return true; }
+        bool match(const shared_ptr<Filterable>&) const final { return true; }
     };
     const auto alwaysMatchFilter = make_shared<AlwaysMatchFilter>();
 }


### PR DESCRIPTION
Cleans up the DataStorm C++ code to use virtual/override/final correctly.