### PR TITLE
Remove checkForDeactivation in getLocator

### DIFF
--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -327,13 +327,13 @@ Ice::ObjectAdapterI::destroy() noexcept
         //
         // Remove object references (some of them cyclic).
         //
-        _instance = 0;
-        _threadPool = 0;
-        _routerInfo = 0;
+        _instance = nullptr;
+        _threadPool = nullptr;
+        _routerInfo = nullptr;
         _publishedEndpoints.clear();
-        _locatorInfo = 0;
-        _reference = 0;
-        _objectAdapterFactory = 0;
+        _locatorInfo = nullptr;
+        _reference = nullptr;
+        _objectAdapterFactory = nullptr;
 
         _state = StateDestroyed;
         _conditionVariable.notify_all();
@@ -582,7 +582,6 @@ optional<LocatorPrx>
 Ice::ObjectAdapterI::getLocator() const noexcept
 {
     lock_guard lock(_mutex);
-    checkForDeactivation();
     return _locatorInfo ? optional<LocatorPrx>(_locatorInfo->getLocator()) : nullopt;
 }
 

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -765,7 +765,6 @@ public sealed class ObjectAdapter
     {
         lock (_mutex)
         {
-            checkForDeactivation();
             return _locatorInfo?.getLocator();
         }
     }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
@@ -863,7 +863,6 @@ public final class ObjectAdapter {
      * @see #setLocator
      */
     public synchronized LocatorPrx getLocator() {
-        checkForDeactivation();
         if (_locatorInfo == null) {
             return null;
         } else {

--- a/python/modules/IcePy/ObjectAdapter.cpp
+++ b/python/modules/IcePy/ObjectAdapter.cpp
@@ -1393,16 +1393,7 @@ extern "C" PyObject*
 adapterGetLocator(ObjectAdapterObject* self, PyObject* /*args*/)
 {
     assert(self->adapter);
-    optional<Ice::LocatorPrx> locator;
-    try
-    {
-        locator = (*self->adapter)->getLocator();
-    }
-    catch (...)
-    {
-        setPythonException(current_exception());
-        return nullptr;
-    }
+    optional<Ice::LocatorPrx> locator = (*self->adapter)->getLocator();
 
     if (!locator)
     {


### PR DESCRIPTION
getLocator in noexcept in C++ but was checking for deactivation. Fixed other languages for consistency.

This is partial fix for #3016.