### PR TITLE
Centralize comment parsing

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -754,9 +754,7 @@ namespace
     }
 }
 
-CommentPtr
-Slice::Contained::parseComment(function<string(string)> linkFormatter, bool stripMarkup)
-    const
+CommentPtr Slice::Contained::parseComment(function<string(string)> linkFormatter, bool stripMarkup) const
 {
     CommentPtr comment = make_shared<Comment>();
 

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -8,7 +8,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cstring>
-#include <functional>
 #include <iterator>
 #include <limits>
 
@@ -757,10 +756,8 @@ namespace
 }
 
 CommentPtr
-Slice::Contained::parseComment(
-    function<string(string)> linkFormatter,
-    bool includeDeprecatedMetadata,
-    bool stripMarkup) const
+Slice::Contained::parseComment(function<string(string)> linkFormatter, bool includeDeprecatedMetadata, bool stripMarkup)
+    const
 {
     CommentPtr comment = make_shared<Comment>();
 

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -677,16 +677,12 @@ namespace
                 comment.erase(pos, endpos - pos + 1);
 
                 // Split the link into 'class' and 'member' components (links are of the form 'class#member').
-                string memberComponent;
+                string memberComponent = "";
                 string::size_type hashPos = ident.find('#');
                 if (hashPos != string::npos)
                 {
                     memberComponent = ident.substr(hashPos + 1);
                     ident.erase(hashPos);
-                }
-                else
-                {
-                    memberComponent = "";
                 }
 
                 // In it's place, insert the correctly formatted link.

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -697,21 +697,16 @@ namespace
             pos = comment.find(link, pos);
         }
 
+        // Split the comment into separate lines, and removing any trailing whitespace and lines from it.
         StringList result;
-
         pos = 0;
         string::size_type nextPos;
         while ((nextPos = comment.find_first_of('\n', pos)) != string::npos)
         {
-            result.push_back(IceInternal::trim(string(comment, pos, nextPos - pos)));
+            result.push_back(IceInternal::trim(comment.substr(pos, nextPos - pos)));
             pos = nextPos + 1;
         }
-        string lastLine = IceInternal::trim(string(comment, pos));
-        if (!lastLine.empty())
-        {
-            result.push_back(lastLine);
-        }
-
+        result.push_back(IceInternal::trim(comment.substr(pos)));
         trimLines(result);
 
         return result;

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -641,12 +641,11 @@ namespace
     StringList splitComment(string_view c, function<string(string)> linkFormatter, bool stripMarkup)
     {
         string comment = string{c};
-        string::size_type pos;
+        string::size_type pos = 0;
 
         if (stripMarkup)
         {
             // Strip HTML markup.
-            pos = 0;
             do
             {
                 pos = comment.find('<', pos);
@@ -756,20 +755,10 @@ namespace
 }
 
 CommentPtr
-Slice::Contained::parseComment(function<string(string)> linkFormatter, bool includeDeprecatedMetadata, bool stripMarkup)
+Slice::Contained::parseComment(function<string(string)> linkFormatter, bool stripMarkup)
     const
 {
     CommentPtr comment = make_shared<Comment>();
-
-    // Check for deprecated metadata and add it to the comment if necessary.
-    if (includeDeprecatedMetadata)
-    {
-        comment->_isDeprecated = isDeprecated();
-        if (auto reason = getDeprecationReason())
-        {
-            comment->_deprecated.push_back(IceInternal::trim(*reason));
-        }
-    }
 
     // Split the comment's raw text up into lines.
     StringList lines = splitComment(_comment, linkFormatter, stripMarkup);

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -754,7 +754,8 @@ namespace
     }
 }
 
-CommentPtr Slice::Contained::parseComment(function<string(string)> linkFormatter, bool stripMarkup) const
+CommentPtr
+Slice::Contained::parseComment(function<string(string)> linkFormatter, bool stripMarkup) const
 {
     CommentPtr comment = make_shared<Comment>();
 

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -376,10 +376,7 @@ namespace Slice
         int line() const;
 
         std::string comment() const;
-        CommentPtr parseComment(
-            std::function<std::string(std::string)> linkFormatter,
-            bool includeDeprecatedMetadata = false,
-            bool stripMarkup = false) const;
+        CommentPtr parseComment(std::function<std::string(std::string)> linkFormatter, bool stripMarkup = false) const;
 
         int includeLevel() const;
 

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -375,8 +375,10 @@ namespace Slice
         int line() const;
 
         std::string comment() const;
-        CommentPtr parseComment(bool stripMarkup) const;
-        CommentPtr parseComment(const std::string& text, bool stripMarkup) const;
+        CommentPtr parseComment(
+            std::function<std::string(std::string)> linkFormatter,
+            bool includeDeprecatedMetadata = false,
+            bool stripMarkup = false) const;
 
         int includeLevel() const;
 

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstdint>
+#include <functional>
 #include <list>
 #include <map>
 #include <memory>

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -376,7 +376,9 @@ namespace Slice
         int line() const;
 
         std::string comment() const;
-        CommentPtr parseComment(std::function<std::string(std::string)> linkFormatter, bool stripMarkup = false) const;
+        CommentPtr parseComment(
+            std::function<std::string(std::string, std::string)> linkFormatter,
+            bool stripMarkup = false) const;
 
         int includeLevel() const;
 

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -4,6 +4,7 @@
 
 #include "Gen.h"
 
+#include <algorithm>
 #include <cassert>
 
 using namespace std;

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -275,7 +275,7 @@ namespace
     string slice2LinkFormatter(string identifier)
     {
         // Replace links of the form `{@link Type#member}` with `{@link Type.member}`.
-        replace(identifier.begin(), identifier.end(), '#', '.');
+        std::replace(identifier.begin(), identifier.end(), '#', '.');
         return "{@link " + identifier + "}";
     }
 

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -272,9 +272,16 @@ namespace
         return os.str();
     }
 
+    string slice2LinkFormatter(string identifier)
+    {
+        // Replace links of the form `{@link Type#member}` with `{@link Type.member}`.
+        replace(identifier.begin(), identifier.end(), '#', '.');
+        return "{@link " + identifier + "}";
+    }
+
     void writeComment(const ContainedPtr& contained, Output& out)
     {
-        CommentPtr comment = contained->parseComment(true);
+        CommentPtr comment = contained->parseComment(slice2LinkFormatter, false, true);
         if (!comment)
         {
             return;

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -282,7 +282,7 @@ namespace
 
     void writeComment(const ContainedPtr& contained, Output& out)
     {
-        CommentPtr comment = contained->parseComment(slice2LinkFormatter, false, true);
+        CommentPtr comment = contained->parseComment(slice2LinkFormatter, true);
         if (!comment)
         {
             return;

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -273,11 +273,23 @@ namespace
         return os.str();
     }
 
-    string slice2LinkFormatter(string identifier)
+    string slice2LinkFormatter(string identifier, string memberComponent)
     {
         // Replace links of the form `{@link Type#member}` with `{@link Type.member}`.
-        std::replace(identifier.begin(), identifier.end(), '#', '.');
-        return "{@link " + identifier + "}";
+        string result = "{@link ";
+        if (memberComponent.empty())
+        {
+            result += identifier;
+        }
+        else if (identifier.empty())
+        {
+            result += memberComponent;
+        }
+        else
+        {
+            result += identifier + "." + memberComponent;
+        }
+        return result += "}";
     }
 
     void writeComment(const ContainedPtr& contained, Output& out)

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cstring>
-#include <functional>
 
 #ifndef _WIN32
 #    include <fcntl.h>

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -273,6 +273,12 @@ namespace
         return r;
     }
 
+    /// Returns a doxygen formatted link to the provided Slice identifier.
+    string cppLinkFormatter(string identifier)
+    {
+        return "{@link " + fixKwd(identifier) + "}";
+    }
+
     void writeDocLines(Output& out, const StringList& lines, bool commentFirst, const string& space = " ")
     {
         auto l = lines.cbegin();
@@ -374,7 +380,7 @@ namespace
             return;
         }
 
-        CommentPtr doc = p->parseComment(false);
+        CommentPtr doc = p->parseComment(cppLinkFormatter);
 
         out << nl << "/**";
 
@@ -1689,7 +1695,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
 
     const string deprecatedSymbol = getDeprecatedSymbol(p);
 
-    CommentPtr comment = p->parseComment(false);
+    CommentPtr comment = p->parseComment(cppLinkFormatter);
     const string contextDoc = "@param " + contextParam + " The Context map to send with the invocation.";
     const string futureDoc = "The future object for the invocation.";
 
@@ -2115,7 +2121,7 @@ Slice::Gen::DataDefVisitor::visitExceptionStart(const ExceptionPtr& p)
             typeToString(dataMember->type(), dataMember->optional(), scope, dataMember->getMetadata(), _useWstring);
         allParamDecls.push_back(typeName + " " + fixKwd(dataMember->name()));
 
-        CommentPtr comment = dataMember->parseComment(false);
+        CommentPtr comment = dataMember->parseComment(cppLinkFormatter);
         if (comment)
         {
             allComments[dataMember->name()] = comment;
@@ -2592,14 +2598,12 @@ Slice::Gen::DataDefVisitor::emitOneShotConstructor(const ClassDefPtr& p)
             string typeName =
                 typeToString(dataMember->type(), dataMember->optional(), scope, dataMember->getMetadata(), _useWstring);
             allParamDecls.push_back(typeName + " " + fixKwd(dataMember->name()));
-            CommentPtr comment = dataMember->parseComment(false);
+            CommentPtr comment = dataMember->parseComment(cppLinkFormatter);
             if (comment)
             {
                 allComments[dataMember->name()] = comment;
             }
         }
-
-        CommentPtr comment = p->parseComment(false);
 
         H << sp;
         H << nl << "/**";
@@ -2950,7 +2954,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
     const string currentTypeDecl = "const " + getUnqualified("::Ice::Current&", interfaceScope);
     const string currentDecl = currentTypeDecl + " " + currentParam;
 
-    CommentPtr comment = p->parseComment(false);
+    CommentPtr comment = p->parseComment(cppLinkFormatter);
 
     if (ret)
     {

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -274,7 +274,19 @@ namespace
     }
 
     /// Returns a doxygen formatted link to the provided Slice identifier.
-    string cppLinkFormatter(string identifier) { return "{@link " + fixKwd(identifier) + "}"; }
+    string cppLinkFormatter(string identifier, string memberComponent)
+    {
+        string result = "{@link ";
+        if (!identifier.empty())
+        {
+            result += fixKwd(identifier);
+        }
+        if (!memberComponent.empty())
+        {
+            result += "#" + fixKwd(memberComponent);
+        }
+        return result + "}";
+    }
 
     void writeDocLines(Output& out, const StringList& lines, bool commentFirst, const string& space = " ")
     {

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -274,10 +274,7 @@ namespace
     }
 
     /// Returns a doxygen formatted link to the provided Slice identifier.
-    string cppLinkFormatter(string identifier)
-    {
-        return "{@link " + fixKwd(identifier) + "}";
-    }
+    string cppLinkFormatter(string identifier) { return "{@link " + fixKwd(identifier) + "}"; }
 
     void writeDocLines(Output& out, const StringList& lines, bool commentFirst, const string& space = " ")
     {

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -2130,8 +2130,7 @@ Slice::Gen::DataDefVisitor::visitExceptionStart(const ExceptionPtr& p)
             typeToString(dataMember->type(), dataMember->optional(), scope, dataMember->getMetadata(), _useWstring);
         allParamDecls.push_back(typeName + " " + fixKwd(dataMember->name()));
 
-        CommentPtr comment = dataMember->parseComment(cppLinkFormatter);
-        if (comment)
+        if (CommentPtr comment = dataMember->parseComment(cppLinkFormatter))
         {
             allComments[dataMember->name()] = comment;
         }
@@ -2607,8 +2606,7 @@ Slice::Gen::DataDefVisitor::emitOneShotConstructor(const ClassDefPtr& p)
             string typeName =
                 typeToString(dataMember->type(), dataMember->optional(), scope, dataMember->getMetadata(), _useWstring);
             allParamDecls.push_back(typeName + " " + fixKwd(dataMember->name()));
-            CommentPtr comment = dataMember->parseComment(cppLinkFormatter);
-            if (comment)
+            if (CommentPtr comment = dataMember->parseComment(cppLinkFormatter))
             {
                 allComments[dataMember->name()] = comment;
             }

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -100,8 +100,19 @@ namespace
     }
 
     /// Returns a javadoc formatted link to the provided Slice identifier.
-    string javaLinkFormatter(string identifier) { return "{@link " + Slice::JavaGenerator::fixKwd(identifier) + "}"; }
-
+    string javaLinkFormatter(string identifier, string memberComponent)
+    {
+        string result = "{@link ";
+        if (!identifier.empty())
+        {
+            result += Slice::JavaGenerator::fixKwd(identifier);
+        }
+        if (!memberComponent.empty())
+        {
+            result += "#" + Slice::JavaGenerator::fixKwd(memberComponent);
+        }
+        return result + "}";
+    }
 }
 
 Slice::JavaVisitor::JavaVisitor(const string& dir) : JavaGenerator(dir) {}

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -98,6 +98,13 @@ namespace
 
         return "java.util.Optional.ofNullable";
     }
+
+    /// Returns a javadoc formatted link to the provided Slice identifier.
+    string javaLinkFormatter(string identifier)
+    {
+        return "{@link " + Slice::JavaGenerator::fixKwd(identifier) + "}";
+    }
+
 }
 
 Slice::JavaVisitor::JavaVisitor(const string& dir) : JavaGenerator(dir) {}
@@ -1280,7 +1287,7 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
 
     for (const auto& op : ops)
     {
-        CommentPtr dc = op->parseComment(false);
+        CommentPtr dc = op->parseComment(javaLinkFormatter);
         vector<string> params = getParams(op, package);
         const string currentParam = "com.zeroc.Ice.Current " + getEscapedParamName(op, "current");
 
@@ -1348,6 +1355,11 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
     // for inherited operations.
     for (const auto& op : ops)
     {
+        OperationPtr op = *r;
+        StringList opMetadata = op->getMetadata();
+
+        CommentPtr dc = op->parseComment(javaLinkFormatter);
+
         string opName = op->name();
         out << sp;
 
@@ -1751,28 +1763,6 @@ Slice::JavaVisitor::writeDataMemberInitializers(Output& out, const DataMemberLis
             }
         }
     }
-}
-
-StringList
-Slice::JavaVisitor::splitComment(const ContainedPtr& p)
-{
-    StringList result;
-
-    string comment = p->comment();
-    string::size_type pos = 0;
-    string::size_type nextPos;
-    while ((nextPos = comment.find_first_of('\n', pos)) != string::npos)
-    {
-        result.push_back(string(comment, pos, nextPos - pos));
-        pos = nextPos + 1;
-    }
-    string lastLine = string(comment, pos);
-    if (lastLine.find_first_not_of(" \t\n\r") != string::npos)
-    {
-        result.push_back(lastLine);
-    }
-
-    return result;
 }
 
 void
@@ -2322,7 +2312,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
         }
     }
 
-    CommentPtr dc = p->parseComment(false);
+    CommentPtr dc = p->parseComment(javaLinkFormatter);
 
     //
     // Slice interfaces map to Java interfaces.
@@ -2560,7 +2550,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     open(absolute, p->file());
 
     Output& out = output();
-    CommentPtr dc = p->parseComment(false);
+    CommentPtr dc = p->parseComment(javaLinkFormatter);
 
     bool hasOptionals = false;
     for (const auto& op : p->allOperations())
@@ -2632,7 +2622,7 @@ Slice::Gen::TypesVisitor::visitOperation(const OperationPtr& p)
 
     Output& out = output();
 
-    CommentPtr dc = p->parseComment(false);
+    CommentPtr dc = p->parseComment(javaLinkFormatter);
 
     //
     // Generate the "Result" type needed by operations that return multiple values.
@@ -2673,7 +2663,7 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 
     out << sp;
 
-    CommentPtr dc = p->parseComment(false);
+    CommentPtr dc = p->parseComment(javaLinkFormatter);
     writeDocComment(out, p->unit(), dc);
     if (dc && dc->isDeprecated())
     {
@@ -2939,7 +2929,7 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
 
     out << sp;
 
-    CommentPtr dc = p->parseComment(false);
+    CommentPtr dc = p->parseComment(javaLinkFormatter);
     writeDocComment(out, p->unit(), dc);
     if (dc && dc->isDeprecated())
     {
@@ -3257,7 +3247,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
 
     out << sp;
 
-    CommentPtr dc = p->parseComment(false);
+    CommentPtr dc = p->parseComment(javaLinkFormatter);
     writeDocComment(out, p->unit(), dc);
     if (dc && dc->isDeprecated())
     {
@@ -3539,7 +3529,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 
     out << sp;
 
-    CommentPtr dc = p->parseComment(false);
+    CommentPtr dc = p->parseComment(javaLinkFormatter);
     writeDocComment(out, p->unit(), dc);
     if (dc && dc->isDeprecated())
     {
@@ -3555,7 +3545,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
         {
             out << ',';
         }
-        CommentPtr edc = (*en)->parseComment(false);
+        CommentPtr edc = (*en)->parseComment(javaLinkFormatter);
         writeDocComment(out, p->unit(), edc);
         if (edc && edc->isDeprecated())
         {
@@ -3678,7 +3668,7 @@ Slice::Gen::TypesVisitor::visitConst(const ConstPtr& p)
 
     out << sp;
 
-    CommentPtr dc = p->parseComment(false);
+    CommentPtr dc = p->parseComment(javaLinkFormatter);
     writeDocComment(out, p->unit(), dc);
     if (dc && dc->isDeprecated())
     {
@@ -4029,7 +4019,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     open(absolute, p->file());
 
     Output& out = output();
-    CommentPtr dc = p->parseComment(false);
+    CommentPtr dc = p->parseComment(javaLinkFormatter);
 
     //
     // Generate a Java interface as the user-visible type
@@ -4069,7 +4059,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 {
     Output& out = output();
 
-    CommentPtr dc = p->parseComment(false);
+    CommentPtr dc = p->parseComment(javaLinkFormatter);
 
     const string package = getPackage(p);
     const string contextParam = "java.util.Map<String, String> context";
@@ -4289,7 +4279,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     const string contextParam = "java.util.Map<String, String> " + contextParamName;
     const string noExplicitContextArg = "com.zeroc.Ice.ObjectPrx.noExplicitContext";
 
-    CommentPtr dc = p->parseComment(false);
+    CommentPtr dc = p->parseComment(javaLinkFormatter);
 
     //
     // Synchronous methods with required parameters.

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -100,10 +100,7 @@ namespace
     }
 
     /// Returns a javadoc formatted link to the provided Slice identifier.
-    string javaLinkFormatter(string identifier)
-    {
-        return "{@link " + Slice::JavaGenerator::fixKwd(identifier) + "}";
-    }
+    string javaLinkFormatter(string identifier) { return "{@link " + Slice::JavaGenerator::fixKwd(identifier) + "}"; }
 
 }
 
@@ -1355,7 +1352,6 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
     // for inherited operations.
     for (const auto& op : ops)
     {
-        OperationPtr op = *r;
         string opName = op->name();
         out << sp;
 

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -1356,10 +1356,6 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
     for (const auto& op : ops)
     {
         OperationPtr op = *r;
-        StringList opMetadata = op->getMetadata();
-
-        CommentPtr dc = op->parseComment(javaLinkFormatter);
-
         string opName = op->name();
         out << sp;
 

--- a/cpp/src/slice2java/Gen.h
+++ b/cpp/src/slice2java/Gen.h
@@ -93,7 +93,6 @@ namespace Slice
         //
         // Handle doc comments.
         //
-        static StringList splitComment(const ContainedPtr&);
         void writeHiddenDocComment(::IceInternal::Output&);
         void writeDocCommentLines(::IceInternal::Output&, const StringList&);
         void writeDocCommentLines(::IceInternal::Output&, const std::string&);

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -780,7 +780,7 @@ Slice::JavaGenerator::output() const
 // otherwise, return the name unchanged.
 //
 string
-Slice::JavaGenerator::fixKwd(const string& name) const
+Slice::JavaGenerator::fixKwd(const string& name)
 {
     if (name.empty())
     {

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -65,6 +65,12 @@ namespace Slice
 
         void close();
 
+        //
+        // Check a symbol against any of the Java keywords. If a
+        // match is found, return the symbol with a leading underscore.
+        //
+        static std::string fixKwd(const std::string&);
+
     protected:
         JavaGenerator(const std::string&);
 
@@ -75,12 +81,6 @@ namespace Slice
         void open(const std::string&, const std::string&);
 
         ::IceInternal::Output& output() const;
-
-        //
-        // Check a symbol against any of the Java keywords. If a
-        // match is found, return the symbol with a leading underscore.
-        //
-        std::string fixKwd(const std::string&) const;
 
         //
         // Convert a Slice scoped name into a Java name.

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -65,10 +65,8 @@ namespace Slice
 
         void close();
 
-        //
-        // Check a symbol against any of the Java keywords. If a
-        // match is found, return the symbol with a leading underscore.
-        //
+        // Check a symbol against any of the Java keywords.
+        // If a match is found, return the symbol with a leading underscore.
         static std::string fixKwd(const std::string&);
 
     protected:

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -22,36 +22,15 @@ using namespace IceInternal;
 
 namespace
 {
-    CommentPtr parseComment(const ContainedPtr& p)
+    /// Returns a JsDoc formatted link to the provided Slice identifier.
+    string jsLinkFormatter(string identifier)
     {
-        // JavaScript TypeDoc doc processor doesn't accept # at the beginning of a link
-        // so we need to remove it.
-        string text = p->comment();
-        const string linkBegin = "{@link ";
-        const string linkEnd = "}";
-
-        string::size_type pos = text.find(linkBegin);
-        while (pos != string::npos)
+        // JavaScript TypeDoc doc processor doesn't accept # at the beginning of a link so we need to remove it.
+        if (identifier.find("#") == 0)
         {
-            string::size_type endPos = text.find(linkEnd, pos);
-            if (endPos == string::npos)
-            {
-                // Invalid link, ignore it
-                break;
-            }
-
-            string link = text.substr(pos + linkBegin.size(), endPos - pos - linkBegin.size());
-            if (link.find("#") == 0)
-            {
-                link = link.substr(1);
-            }
-            const string replacement = "{@link " + link + "}";
-
-            text.replace(pos, endPos - pos + linkEnd.size(), replacement);
-            pos = text.find(linkBegin, pos + replacement.size());
+            identifier.erase(0, 1);
         }
-
-        return p->parseComment(text, false);
+        return "{@link " + Slice::JsGenerator::fixId(identifier) + "}";
     }
 
     // Convert a path to a module name, e.g., "../foo/bar/baz.ice" -> "__foo_bar_baz"
@@ -238,7 +217,7 @@ namespace
             return;
         }
 
-        CommentPtr doc = parseComment(p);
+        CommentPtr doc = p->parseComment(jsLinkFormatter);
 
         out << nl << "/**";
 
@@ -510,47 +489,43 @@ Slice::JsVisitor::writeConstantValue(
     return os.str();
 }
 
-StringList
-Slice::JsVisitor::splitComment(const ContainedPtr& p)
+void
+Slice::JsVisitor::writeDocCommentFor(const ContainedPtr& p, bool includeDeprecated)
 {
-    StringList result;
+    StringList lines;
 
-    string comment = p->comment();
-    string::size_type pos = 0;
-    string::size_type nextPos;
-    string line;
-    while ((nextPos = comment.find_first_of('\n', pos)) != string::npos)
     {
-        line = string(comment, pos, nextPos - pos);
+        string comment = p->comment();
+        string::size_type pos = 0;
+        string::size_type nextPos;
+        string line;
+        while ((nextPos = comment.find_first_of('\n', pos)) != string::npos)
+        {
+            line = string(comment, pos, nextPos - pos);
+            pos = line.find_first_not_of(" \t");
+            if (pos != string::npos)
+            {
+                line = line.substr(pos);
+            }
+            lines.push_back(line);
+            pos = nextPos + 1;
+        }
+
+        line = string(comment, pos);
         pos = line.find_first_not_of(" \t");
         if (pos != string::npos)
         {
             line = line.substr(pos);
         }
-        result.push_back(line);
-        pos = nextPos + 1;
+
+        if (line.find_first_not_of(" \t\n\r") != string::npos)
+        {
+            lines.push_back(line);
+        }
     }
 
-    line = string(comment, pos);
-    pos = line.find_first_not_of(" \t");
-    if (pos != string::npos)
-    {
-        line = line.substr(pos);
-    }
-
-    if (line.find_first_not_of(" \t\n\r") != string::npos)
-    {
-        result.push_back(line);
-    }
-
-    return result;
-}
-
-void
-Slice::JsVisitor::writeDocCommentFor(const ContainedPtr& p, bool includeDeprecated)
-{
-    StringList lines = splitComment(p);
-    CommentPtr dc = p->parseComment(false);
+    // TODO this whole function seems bogus. Why do we manually split the lines and also call `parseComment`?
+    CommentPtr dc = p->parseComment(jsLinkFormatter);
 
     if (lines.empty())
     {
@@ -2456,7 +2431,7 @@ Slice::Gen::TypeScriptVisitor::visitClassDefStart(const ClassDefPtr& p)
     _out << nl << " * One-shot constructor to initialize all data members.";
     for (const auto& dataMember : allDataMembers)
     {
-        CommentPtr comment = parseComment(dataMember);
+        CommentPtr comment = dataMember->parseComment(jsLinkFormatter);
         if (comment)
         {
             _out << nl << " * @param " << fixId(dataMember->name()) << " " << getDocSentence(comment->overview());
@@ -2651,7 +2626,7 @@ Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         }
 
         const string contextParam = escapeParam(paramList, "context");
-        CommentPtr comment = parseComment(op);
+        CommentPtr comment = op->parseComment(jsLinkFormatter);
         const string contextDoc = "@param " + contextParam + " The Context map to send with the invocation.";
         const string asyncDoc = "The asynchronous result object for the invocation.";
 
@@ -2755,7 +2730,7 @@ Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         }
 
         const string currentParam = escapeParam(inParams, "current");
-        CommentPtr comment = parseComment(op);
+        CommentPtr comment = op->parseComment(jsLinkFormatter);
         const string currentDoc = "@param " + currentParam + " The Current object for the invocation.";
         const string resultDoc = "The result or a promise like object that will "
                                  "be resolved with the result of the invocation.";
@@ -2842,7 +2817,7 @@ Slice::Gen::TypeScriptVisitor::visitExceptionStart(const ExceptionPtr& p)
         _out << nl << " * One-shot constructor to initialize all data members.";
         for (const auto& dataMember : allDataMembers)
         {
-            CommentPtr comment = dataMember->parseComment(false);
+            CommentPtr comment = dataMember->parseComment(jsLinkFormatter);
             if (comment)
             {
                 _out << nl << " * @param " << fixId(dataMember->name()) << " " << getDocSentence(comment->overview());

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -2440,8 +2440,7 @@ Slice::Gen::TypeScriptVisitor::visitClassDefStart(const ClassDefPtr& p)
     _out << nl << " * One-shot constructor to initialize all data members.";
     for (const auto& dataMember : allDataMembers)
     {
-        CommentPtr comment = dataMember->parseComment(jsLinkFormatter);
-        if (comment)
+        if (CommentPtr comment = dataMember->parseComment(jsLinkFormatter))
         {
             _out << nl << " * @param " << fixId(dataMember->name()) << " " << getDocSentence(comment->overview());
         }
@@ -2826,8 +2825,7 @@ Slice::Gen::TypeScriptVisitor::visitExceptionStart(const ExceptionPtr& p)
         _out << nl << " * One-shot constructor to initialize all data members.";
         for (const auto& dataMember : allDataMembers)
         {
-            CommentPtr comment = dataMember->parseComment(jsLinkFormatter);
-            if (comment)
+            if (CommentPtr comment = dataMember->parseComment(jsLinkFormatter))
             {
                 _out << nl << " * @param " << fixId(dataMember->name()) << " " << getDocSentence(comment->overview());
             }

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -23,14 +23,23 @@ using namespace IceInternal;
 namespace
 {
     /// Returns a JsDoc formatted link to the provided Slice identifier.
-    string jsLinkFormatter(string identifier)
+    string jsLinkFormatter(string identifier, string memberComponent)
     {
-        // JavaScript TypeDoc doc processor doesn't accept # at the beginning of a link so we need to remove it.
-        if (identifier.find("#") == 0)
+        string result = "{@link ";
+        if (!identifier.empty())
         {
-            identifier.erase(0, 1);
+            result += Slice::JsGenerator::fixId(identifier);
+            if (!memberComponent.empty())
+            {
+                result += "#" + Slice::JsGenerator::fixId(memberComponent);
+            }
         }
-        return "{@link " + Slice::JsGenerator::fixId(identifier) + "}";
+        else
+        {
+            // JavaScript TypeDoc doc processor doesn't accept # at the beginning of a link.
+            result += Slice::JsGenerator::fixId(memberComponent);
+        }
+        return result + "}";
     }
 
     // Convert a path to a module name, e.g., "../foo/bar/baz.ice" -> "__foo_bar_baz"

--- a/cpp/src/slice2js/Gen.h
+++ b/cpp/src/slice2js/Gen.h
@@ -30,7 +30,6 @@ namespace Slice
         std::string
         writeConstantValue(const std::string&, const TypePtr&, const SyntaxTreeBasePtr&, const std::string&);
 
-        static StringList splitComment(const ContainedPtr&);
         void writeDocCommentFor(const ContainedPtr& p, bool includeDeprecated = true);
 
         ::IceInternal::Output& _out;

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -872,7 +872,7 @@ namespace
 
     void writeDocSummary(IceInternal::Output& out, const ContainedPtr& p)
     {
-        CommentPtr doc = p->parseComment(matlabLinkFormatter, true, true);
+        CommentPtr doc = p->parseComment(matlabLinkFormatter, true);
         if (!doc)
         {
             return;
@@ -902,7 +902,7 @@ namespace
                 for (const auto& enumerator : enumerators)
                 {
                     out << nl << "%   " << fixEnumerator(enumerator->name());
-                    CommentPtr enumeratorDoc = enumerator->parseComment(matlabLinkFormatter, true, true);
+                    CommentPtr enumeratorDoc = enumerator->parseComment(matlabLinkFormatter, true);
                     if (enumeratorDoc)
                     {
                         StringList enumeratorOverview = enumeratorDoc->overview();
@@ -925,7 +925,7 @@ namespace
                 for (const auto& member : members)
                 {
                     out << nl << "%   " << fixIdent(member->name());
-                    CommentPtr memberDoc = member->parseComment(matlabLinkFormatter, true, true);
+                    CommentPtr memberDoc = member->parseComment(matlabLinkFormatter, true);
                     if (memberDoc)
                     {
                         StringList memberOverview = memberDoc->overview();
@@ -948,7 +948,7 @@ namespace
                 for (const auto& member : members)
                 {
                     out << nl << "%   " << fixExceptionMember(member->name());
-                    CommentPtr memberDoc = member->parseComment(matlabLinkFormatter, true, true);
+                    CommentPtr memberDoc = member->parseComment(matlabLinkFormatter, true);
                     if (memberDoc)
                     {
                         StringList memberOverview = memberDoc->overview();
@@ -971,7 +971,7 @@ namespace
                 for (const auto& member : members)
                 {
                     out << nl << "%   " << fixIdent(member->name());
-                    CommentPtr memberDoc = member->parseComment(matlabLinkFormatter, true, true);
+                    CommentPtr memberDoc = member->parseComment(matlabLinkFormatter, true);
                     if (memberDoc)
                     {
                         StringList memberOverview = memberDoc->overview();
@@ -1017,7 +1017,7 @@ namespace
 
     void writeOpDocSummary(IceInternal::Output& out, const OperationPtr& p, bool async)
     {
-        CommentPtr doc = p->parseComment(matlabLinkFormatter, true, true);
+        CommentPtr doc = p->parseComment(matlabLinkFormatter, true);
         if (!doc)
         {
             return;
@@ -1185,7 +1185,7 @@ namespace
 
     void writeProxyDocSummary(IceInternal::Output& out, const InterfaceDefPtr& p)
     {
-        CommentPtr doc = p->parseComment(matlabLinkFormatter, true, true);
+        CommentPtr doc = p->parseComment(matlabLinkFormatter, true);
         if (!doc)
         {
             return;
@@ -1213,7 +1213,7 @@ namespace
             for (OperationList::const_iterator q = ops.begin(); q != ops.end(); ++q)
             {
                 OperationPtr op = *q;
-                CommentPtr opdoc = op->parseComment(matlabLinkFormatter, true, true);
+                CommentPtr opdoc = op->parseComment(matlabLinkFormatter, true);
                 out << nl << "%   " << fixOp(op->name());
                 if (opdoc)
                 {
@@ -1271,7 +1271,7 @@ namespace
 
     void writeMemberDoc(IceInternal::Output& out, const DataMemberPtr& p)
     {
-        CommentPtr doc = p->parseComment(matlabLinkFormatter, true, true);
+        CommentPtr doc = p->parseComment(matlabLinkFormatter, true);
         if (!doc)
         {
             return;

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -913,8 +913,7 @@ namespace
                 for (const auto& member : members)
                 {
                     out << nl << "%   " << fixIdent(member->name());
-                    CommentPtr memberDoc = member->parseComment(matlabLinkFormatter, true);
-                    if (memberDoc)
+                    if (CommentPtr memberDoc = member->parseComment(matlabLinkFormatter, true))
                     {
                         StringList memberOverview = memberDoc->overview();
                         if (!memberOverview.empty())
@@ -936,8 +935,7 @@ namespace
                 for (const auto& member : members)
                 {
                     out << nl << "%   " << fixExceptionMember(member->name());
-                    CommentPtr memberDoc = member->parseComment(matlabLinkFormatter, true);
-                    if (memberDoc)
+                    if (CommentPtr memberDoc = member->parseComment(matlabLinkFormatter, true))
                     {
                         StringList memberOverview = memberDoc->overview();
                         if (!memberOverview.empty())
@@ -959,8 +957,7 @@ namespace
                 for (const auto& member : members)
                 {
                     out << nl << "%   " << fixIdent(member->name());
-                    CommentPtr memberDoc = member->parseComment(matlabLinkFormatter, true);
-                    if (memberDoc)
+                    if (CommentPtr memberDoc = member->parseComment(matlabLinkFormatter, true))
                     {
                         StringList memberOverview = memberDoc->overview();
                         if (!memberOverview.empty())

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -720,31 +720,19 @@ namespace
     }
 
     /// Returns a MATLAB formatted link to the provided Slice identifier.
-    string matlabLinkFormatter(string identifier)
+    string matlabLinkFormatter(string identifier, string memberComponent)
     {
-        string::size_type hashPos = identifier.find("#");
-        if (hashPos != string::npos)
+        if (memberComponent.empty())
         {
-            string rest = identifier.substr(hashPos + 1);
-            identifier.erase(hashPos);
-            if (!identifier.empty())
-            {
-                identifier = fixIdent(identifier);
-                if (!rest.empty())
-                {
-                    identifier += "." + fixIdent(rest);
-                }
-                return identifier;
-            }
-            else
-            {
-                assert(!rest.empty());
-                return fixIdent(rest);
-            }
+            return fixIdent(identifier);
+        }
+        else if (identifier.empty())
+        {
+            return fixIdent(memberComponent);
         }
         else
         {
-            return fixIdent(identifier);
+            return fixIdent(identifier) + "." + fixIdent(memberComponent);
         }
     }
 

--- a/cpp/src/slice2php/PHPUtil.cpp
+++ b/cpp/src/slice2php/PHPUtil.cpp
@@ -5,7 +5,6 @@
 #include "PHPUtil.h"
 #include "../Slice/Util.h"
 #include <algorithm>
-#include <functional>
 #include <vector>
 
 using namespace std;

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -920,13 +920,7 @@ Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 
     for (const auto& enumerator : enumerators)
     {
-        StringList sl = splitComment(enumerator->comment());
-        out << nl << "/// " << fixIdent(enumerator->name());
-        if (!sl.empty())
-        {
-            out << " ";
-            writeDocLines(out, sl, false);
-        }
+        writeDocSummary(out, enumerator);
         out << nl << "case " << fixIdent(enumerator->name()) << " = " << enumerator->value();
     }
 

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -154,6 +154,34 @@ namespace
             return "nil";
         }
     }
+
+    string swiftLinkFormatter(string identifier)
+    {
+        string::size_type hashPos = identifier.find('#');
+        if (hashPos != string::npos)
+        {
+            string rest = identifier.substr(hashPos + 1);
+            identifier.erase(hashPos);
+            if (!identifier.empty())
+            {
+                identifier = fixIdent(identifier);
+                if (!rest.empty())
+                {
+                    identifier += "." + fixIdent(rest);
+                }
+                return identifier;
+            }
+            else
+            {
+                assert(!rest.empty());
+                return fixIdent(rest);
+            }
+        }
+        else
+        {
+            return fixIdent(identifier);
+        }
+    }
 }
 
 // Check the given identifier against Swift's list of reserved words. If it matches
@@ -252,321 +280,6 @@ Slice::getTopLevelModule(const TypePtr& type)
 }
 
 void
-SwiftGenerator::trimLines(StringList& l)
-{
-    //
-    // Remove empty trailing lines.
-    //
-    while (!l.empty() && l.back().empty())
-    {
-        l.pop_back();
-    }
-}
-
-StringList
-SwiftGenerator::splitComment(const string& c)
-{
-    string comment = c;
-
-    //
-    // TODO: this comment is suspicious. Does this apply to Swift docs as well?
-    // Strip HTML markup and javadoc links -- MATLAB doesn't display them.
-    //
-    string::size_type pos = 0;
-    do
-    {
-        pos = comment.find('<', pos);
-        if (pos != string::npos)
-        {
-            string::size_type endpos = comment.find('>', pos);
-            if (endpos == string::npos)
-            {
-                break;
-            }
-            comment.erase(pos, endpos - pos + 1);
-        }
-    } while (pos != string::npos);
-
-    const string link = "{@link";
-    pos = 0;
-    do
-    {
-        pos = comment.find(link, pos);
-        if (pos != string::npos)
-        {
-            comment.erase(pos, link.size() + 1); // Erase trailing white space too.
-            string::size_type endpos = comment.find('}', pos);
-            if (endpos != string::npos)
-            {
-                string ident = comment.substr(pos, endpos - pos);
-                comment.erase(pos, endpos - pos + 1);
-
-                //
-                // Check for links of the form {@link Type#member}.
-                //
-                string::size_type hash = ident.find('#');
-                string rest;
-                if (hash != string::npos)
-                {
-                    rest = ident.substr(hash + 1);
-                    ident = ident.substr(0, hash);
-                    if (!ident.empty())
-                    {
-                        ident = fixIdent(ident);
-                        if (!rest.empty())
-                        {
-                            ident += "." + fixIdent(rest);
-                        }
-                    }
-                    else if (!rest.empty())
-                    {
-                        ident = fixIdent(rest);
-                    }
-                }
-                else
-                {
-                    ident = fixIdent(ident);
-                }
-
-                comment.insert(pos, ident);
-            }
-        }
-    } while (pos != string::npos);
-
-    StringList result;
-
-    pos = 0;
-    string::size_type nextPos;
-    while ((nextPos = comment.find_first_of('\n', pos)) != string::npos)
-    {
-        result.push_back(IceInternal::trim(string(comment, pos, nextPos - pos)));
-        pos = nextPos + 1;
-    }
-    string lastLine = IceInternal::trim(string(comment, pos));
-    if (!lastLine.empty())
-    {
-        result.push_back(lastLine);
-    }
-
-    trimLines(result);
-
-    return result;
-}
-
-bool
-SwiftGenerator::parseCommentLine(const string& l, const string& tag, bool namedTag, string& name, string& doc)
-{
-    doc.clear();
-
-    if (l.find(tag) == 0)
-    {
-        const string ws = " \t";
-
-        if (namedTag)
-        {
-            string::size_type n = l.find_first_not_of(ws, tag.size());
-            if (n == string::npos)
-            {
-                return false; // Malformed line, ignore it.
-            }
-            string::size_type end = l.find_first_of(ws, n);
-            if (end == string::npos)
-            {
-                return false; // Malformed line, ignore it.
-            }
-            name = l.substr(n, end - n);
-            n = l.find_first_not_of(ws, end);
-            if (n != string::npos)
-            {
-                doc = l.substr(n);
-            }
-        }
-        else
-        {
-            name.clear();
-
-            string::size_type n = l.find_first_not_of(ws, tag.size());
-            if (n == string::npos)
-            {
-                return false; // Malformed line, ignore it.
-            }
-            doc = l.substr(n);
-        }
-
-        return true;
-    }
-
-    return false;
-}
-
-DocElements
-SwiftGenerator::parseComment(const ContainedPtr& p)
-{
-    DocElements doc;
-
-    doc.deprecated = p->isDeprecated();
-
-    // First check metadata for a deprecated tag.
-    if (auto reason = p->getDeprecationReason())
-    {
-        doc.deprecateReason.push_back(IceInternal::trim(*reason));
-    }
-
-    //
-    // Split up the comment into lines.
-    //
-    StringList lines = splitComment(p->comment());
-
-    StringList::const_iterator i;
-    for (i = lines.begin(); i != lines.end(); ++i)
-    {
-        const string l = *i;
-        if (l[0] == '@')
-        {
-            break;
-        }
-        doc.overview.push_back(l);
-    }
-
-    enum State
-    {
-        StateMisc,
-        StateParam,
-        StateThrows,
-        StateReturn,
-        StateDeprecated
-    };
-    State state = StateMisc;
-    string name;
-    const string ws = " \t";
-    const string paramTag = "@param";
-    const string throwsTag = "@throws";
-    const string exceptionTag = "@exception";
-    const string returnTag = "@return";
-    const string deprecatedTag = "@deprecated";
-    const string seeTag = "@see";
-    for (; i != lines.end(); ++i)
-    {
-        const string l = IceInternal::trim(*i);
-        string line;
-        if (parseCommentLine(l, paramTag, true, name, line))
-        {
-            if (!line.empty())
-            {
-                state = StateParam;
-                StringList sl;
-                sl.push_back(line); // The first line of the description.
-                doc.params[name] = sl;
-            }
-        }
-        else if (parseCommentLine(l, throwsTag, true, name, line))
-        {
-            if (!line.empty())
-            {
-                state = StateThrows;
-                StringList sl;
-                sl.push_back(line); // The first line of the description.
-                doc.exceptions[name] = sl;
-            }
-        }
-        else if (parseCommentLine(l, exceptionTag, true, name, line))
-        {
-            if (!line.empty())
-            {
-                state = StateThrows;
-                StringList sl;
-                sl.push_back(line); // The first line of the description.
-                doc.exceptions[name] = sl;
-            }
-        }
-        else if (parseCommentLine(l, seeTag, false, name, line))
-        {
-            if (!line.empty())
-            {
-                doc.seeAlso.push_back(line);
-            }
-        }
-        else if (parseCommentLine(l, returnTag, false, name, line))
-        {
-            if (!line.empty())
-            {
-                state = StateReturn;
-                doc.returns.push_back(line); // The first line of the description.
-            }
-        }
-        else if (parseCommentLine(l, deprecatedTag, false, name, line))
-        {
-            doc.deprecated = true;
-            if (!line.empty())
-            {
-                state = StateDeprecated;
-                doc.deprecateReason.push_back(line); // The first line of the description.
-            }
-        }
-        else if (!l.empty())
-        {
-            if (l[0] == '@')
-            {
-                //
-                // Treat all other tags as miscellaneous comments.
-                //
-                state = StateMisc;
-            }
-
-            switch (state)
-            {
-                case StateMisc:
-                {
-                    doc.misc.push_back(l);
-                    break;
-                }
-                case StateParam:
-                {
-                    assert(!name.empty());
-                    StringList sl;
-                    if (doc.params.find(name) != doc.params.end())
-                    {
-                        sl = doc.params[name];
-                    }
-                    sl.push_back(l);
-                    doc.params[name] = sl;
-                    break;
-                }
-                case StateThrows:
-                {
-                    assert(!name.empty());
-                    StringList sl;
-                    if (doc.exceptions.find(name) != doc.exceptions.end())
-                    {
-                        sl = doc.exceptions[name];
-                    }
-                    sl.push_back(l);
-                    doc.exceptions[name] = sl;
-                    break;
-                }
-                case StateReturn:
-                {
-                    doc.returns.push_back(l);
-                    break;
-                }
-                case StateDeprecated:
-                {
-                    doc.deprecateReason.push_back(l);
-                    break;
-                }
-            }
-        }
-    }
-
-    trimLines(doc.overview);
-    trimLines(doc.deprecateReason);
-    trimLines(doc.misc);
-    trimLines(doc.returns);
-
-    return doc;
-}
-
-void
 SwiftGenerator::writeDocLines(IceInternal::Output& out, const StringList& lines, bool commentFirst, const string& space)
 {
     StringList l = lines;
@@ -643,31 +356,33 @@ SwiftGenerator::writeDocSentence(IceInternal::Output& out, const StringList& lin
 void
 SwiftGenerator::writeDocSummary(IceInternal::Output& out, const ContainedPtr& p)
 {
-    DocElements doc = parseComment(p);
-
-    string n = fixIdent(p->name());
-
-    //
-    // No leading newline.
-    //
-    if (!doc.overview.empty())
+    CommentPtr doc = p->parseComment(swiftLinkFormatter, true, true);
+    if (!doc)
     {
-        writeDocLines(out, doc.overview);
+        return;
     }
 
-    if (!doc.misc.empty())
+    StringList docOverview = doc->overview();
+    if (!docOverview.empty())
     {
-        out << "///" << nl;
-        writeDocLines(out, doc.misc);
+        writeDocLines(out, docOverview);
     }
 
-    if (doc.deprecated)
+    StringList docMisc = doc->misc();
+    if (!docMisc.empty())
+    {
+        out << nl << "///";
+        writeDocLines(out, docMisc);
+    }
+
+    if (doc->isDeprecated())
     {
         out << nl << "///";
         out << nl << "/// ## Deprecated";
-        if (!doc.deprecateReason.empty())
+        StringList docDeprecated = doc->deprecated();
+        if (!docDeprecated.empty())
         {
-            writeDocLines(out, doc.deprecateReason);
+            writeDocLines(out, docDeprecated);
         }
     }
 }
@@ -675,30 +390,38 @@ SwiftGenerator::writeDocSummary(IceInternal::Output& out, const ContainedPtr& p)
 void
 SwiftGenerator::writeOpDocSummary(IceInternal::Output& out, const OperationPtr& p, bool dispatch)
 {
-    DocElements doc = parseComment(p);
-    if (!doc.overview.empty())
+    CommentPtr doc = p->parseComment(swiftLinkFormatter, true, true);
+    if (!doc)
     {
-        writeDocLines(out, doc.overview);
+        return;
     }
 
-    if (doc.deprecated)
+    StringList docOverview = doc->overview();
+    if (!docOverview.empty())
+    {
+        writeDocLines(out, docOverview);
+    }
+
+    if (doc->isDeprecated())
     {
         out << nl << "///";
         out << nl << "///  ## Deprecated";
-        if (!doc.deprecateReason.empty())
+        StringList docDeprecated = doc->deprecated();
+        if (!docDeprecated.empty())
         {
-            writeDocLines(out, doc.deprecateReason);
+            writeDocLines(out, docDeprecated);
         }
     }
 
     const ParamInfoList allInParams = getAllInParams(p);
+    auto docParameters = doc->parameters();
     for (ParamInfoList::const_iterator q = allInParams.begin(); q != allInParams.end(); ++q)
     {
         out << nl << "///";
         out << nl << "/// - parameter " << (!dispatch && allInParams.size() == 1 ? "_" : q->name) << ": `" << q->typeStr
             << "`";
-        map<string, StringList>::const_iterator r = doc.params.find(q->name);
-        if (r != doc.params.end() && !r->second.empty())
+        map<string, StringList>::const_iterator r = docParameters.find(q->name);
+        if (r != docParameters.end() && !r->second.empty())
         {
             out << " ";
             writeDocLines(out, r->second, false);
@@ -723,16 +446,17 @@ SwiftGenerator::writeOpDocSummary(IceInternal::Output& out, const OperationPtr& 
         out << nl << "/// - returns: `" << ret.typeStr << "`";
         if (p->returnType())
         {
-            if (!doc.returns.empty())
+            StringList docReturns = doc->returns();
+            if (!docReturns.empty())
             {
                 out << " - ";
-                writeDocLines(out, doc.returns, false);
+                writeDocLines(out, docReturns, false);
             }
         }
         else
         {
-            map<string, StringList>::const_iterator r = doc.params.find(ret.name);
-            if (r != doc.params.end() && !r->second.empty())
+            map<string, StringList>::const_iterator r = docParameters.find(ret.name);
+            if (r != docParameters.end() && !r->second.empty())
             {
                 out << " - ";
                 writeDocLines(out, r->second, false);
@@ -748,10 +472,11 @@ SwiftGenerator::writeOpDocSummary(IceInternal::Output& out, const OperationPtr& 
             ParamInfo ret = allOutParams.back();
             out << nl << "///";
             out << nl << "///   - " << ret.name << ": `" << ret.typeStr << "`";
-            if (!doc.returns.empty())
+            StringList docReturns = doc->returns();
+            if (!docReturns.empty())
             {
                 out << " - ";
-                writeDocLines(out, doc.returns, false);
+                writeDocLines(out, docReturns, false);
             }
         }
 
@@ -761,8 +486,8 @@ SwiftGenerator::writeOpDocSummary(IceInternal::Output& out, const OperationPtr& 
             {
                 out << nl << "///";
                 out << nl << "///   - " << q->name << ": `" << q->typeStr << "`";
-                map<string, StringList>::const_iterator r = doc.params.find(q->name);
-                if (r != doc.params.end() && !r->second.empty())
+                map<string, StringList>::const_iterator r = docParameters.find(q->name);
+                if (r != docParameters.end() && !r->second.empty())
                 {
                     out << " - ";
                     writeDocLines(out, r->second, false);
@@ -771,44 +496,51 @@ SwiftGenerator::writeOpDocSummary(IceInternal::Output& out, const OperationPtr& 
         }
     }
 
-    if (!doc.exceptions.empty())
+    auto docExceptions = doc->exceptions();
+    if (!docExceptions.empty())
     {
         out << nl << "///";
         out << nl << "/// - throws:";
-        for (map<string, StringList>::const_iterator q = doc.exceptions.begin(); q != doc.exceptions.end(); ++q)
+        for (const auto& docException : docExceptions)
         {
             out << nl << "///";
-            out << nl << "///   - " << q->first;
-            if (!q->second.empty())
+            out << nl << "///   - " << docException.first;
+            if (!docException.second.empty())
             {
                 out << " - ";
-                writeDocLines(out, q->second, false, "     ");
+                writeDocLines(out, docException.second, false, "     ");
             }
         }
     }
 
-    if (!doc.misc.empty())
+    StringList docMisc = doc->misc();
+    if (!docMisc.empty())
     {
         out << nl;
-        writeDocLines(out, doc.misc, false);
+        writeDocLines(out, docMisc, false);
     }
 }
 
 void
 SwiftGenerator::writeProxyDocSummary(IceInternal::Output& out, const InterfaceDefPtr& p, const string& swiftModule)
 {
-    DocElements doc = parseComment(p);
+    CommentPtr doc = p->parseComment(swiftLinkFormatter, true, true);
+    if (!doc)
+    {
+        return;
+    }
 
     const string name = getRelativeTypeString(p, swiftModule);
     const string prx = name + "Prx";
 
-    if (doc.overview.empty())
+    StringList docOverview = doc->overview();
+    if (docOverview.empty())
     {
         out << nl << "/// " << prx << " overview.";
     }
     else
     {
-        writeDocLines(out, doc.overview);
+        writeDocLines(out, docOverview);
     }
 
     const OperationList ops = p->operations();
@@ -819,43 +551,59 @@ SwiftGenerator::writeProxyDocSummary(IceInternal::Output& out, const InterfaceDe
         for (OperationList::const_iterator q = ops.begin(); q != ops.end(); ++q)
         {
             OperationPtr op = *q;
-            DocElements opdoc = parseComment(op);
+            CommentPtr opdoc = op->parseComment(swiftLinkFormatter, true, true);
             out << nl << "///";
-            out << nl << "///  - " << fixIdent(op->name()) << ": ";
-            if (!opdoc.overview.empty())
+            out << nl << "///  - " << fixIdent(op->name());
+            if (opdoc)
             {
-                writeDocSentence(out, opdoc.overview);
+                out << ": ";
+                StringList opdocOverview = opdoc->overview();
+                if (!opdocOverview.empty())
+                {
+                    writeDocSentence(out, opdocOverview);
+                }
             }
 
             out << nl << "///";
-            out << nl << "///  - " << op->name() << "Async: ";
-            if (!opdoc.overview.empty())
+            out << nl << "///  - " << op->name() << "Async";
+            if (opdoc)
             {
-                writeDocSentence(out, opdoc.overview);
+                out << ": ";
+                StringList opdocOverview = opdoc->overview();
+                if (!opdocOverview.empty())
+                {
+                    writeDocSentence(out, opdocOverview);
+                }
             }
         }
     }
 
-    if (!doc.misc.empty())
+    StringList docMisc = doc->misc();
+    if (!docMisc.empty())
     {
-        writeDocLines(out, doc.misc, false);
+        writeDocLines(out, docMisc, false);
     }
 }
 
 void
 SwiftGenerator::writeServantDocSummary(IceInternal::Output& out, const InterfaceDefPtr& p, const string& swiftModule)
 {
-    DocElements doc = parseComment(p);
+    CommentPtr doc = p->parseComment(swiftLinkFormatter, true, true);
+    if (!doc)
+    {
+        return;
+    }
 
     const string name = getRelativeTypeString(p, swiftModule);
 
-    if (doc.overview.empty())
+    StringList docOverview = doc->overview();
+    if (docOverview.empty())
     {
         out << nl << "/// " << name << " overview.";
     }
     else
     {
-        writeDocLines(out, doc.overview);
+        writeDocLines(out, docOverview);
     }
 
     const OperationList ops = p->operations();
@@ -866,56 +614,64 @@ SwiftGenerator::writeServantDocSummary(IceInternal::Output& out, const Interface
         for (OperationList::const_iterator q = ops.begin(); q != ops.end(); ++q)
         {
             OperationPtr op = *q;
-            DocElements opdoc = parseComment(op);
+            CommentPtr opdoc = op->parseComment(swiftLinkFormatter, true, true);
             out << nl << "///";
-            out << nl << "///  - " << fixIdent(op->name()) << ": ";
-            if (!opdoc.overview.empty())
+            out << nl << "///  - " << fixIdent(op->name());
+            if (opdoc)
             {
-                writeDocSentence(out, opdoc.overview);
+                out << ": ";
+                StringList opdocOverview = opdoc->overview();
+                if (!opdocOverview.empty())
+                {
+                    writeDocSentence(out, opdocOverview);
+                }
             }
         }
     }
 
-    if (!doc.misc.empty())
+    StringList docMisc = doc->misc();
+    if (!docMisc.empty())
     {
-        writeDocLines(out, doc.misc, false);
+        writeDocLines(out, docMisc, false);
     }
 }
 
 void
 SwiftGenerator::writeMemberDoc(IceInternal::Output& out, const DataMemberPtr& p)
 {
-    DocElements doc = parseComment(p);
-
-    //
-    // Skip if there are no doc comments.
-    //
-    if (doc.overview.empty() && doc.misc.empty() && doc.seeAlso.empty() && doc.deprecateReason.empty() &&
-        !doc.deprecated)
+    CommentPtr doc = p->parseComment(swiftLinkFormatter, true, true);
+    if (!doc)
     {
         return;
     }
 
-    if (doc.overview.empty())
+    // Skip if there are no doc comments.
+    StringList docOverview = doc->overview();
+    StringList docMisc = doc->misc();
+    StringList docSeeAlso = doc->seeAlso(); // TODO we check seeAlso, but don't write any of in the generated comment?
+    StringList docDeprecated = doc->deprecated();
+    bool docIsDeprecated = doc->isDeprecated();
+
+    if (docOverview.empty())
     {
         out << nl << "/// " << fixIdent(p->name());
     }
     else
     {
-        writeDocLines(out, doc.overview);
+        writeDocLines(out, docOverview);
     }
 
-    if (!doc.misc.empty())
+    if (!docMisc.empty())
     {
-        writeDocLines(out, doc.misc);
+        writeDocLines(out, docMisc);
     }
 
-    if (doc.deprecated)
+    if (docIsDeprecated)
     {
         out << nl << "/// ##Deprecated";
-        if (!doc.deprecateReason.empty())
+        if (!docDeprecated.empty())
         {
-            writeDocLines(out, doc.deprecateReason);
+            writeDocLines(out, docDeprecated);
         }
     }
 }

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -154,31 +154,19 @@ namespace
         }
     }
 
-    string swiftLinkFormatter(string identifier)
+    string swiftLinkFormatter(string identifier, string memberComponent)
     {
-        string::size_type hashPos = identifier.find('#');
-        if (hashPos != string::npos)
+        if (memberComponent.empty())
         {
-            string rest = identifier.substr(hashPos + 1);
-            identifier.erase(hashPos);
-            if (!identifier.empty())
-            {
-                identifier = fixIdent(identifier);
-                if (!rest.empty())
-                {
-                    identifier += "." + fixIdent(rest);
-                }
-                return identifier;
-            }
-            else
-            {
-                assert(!rest.empty());
-                return fixIdent(rest);
-            }
+            return fixIdent(identifier);
+        }
+        else if (identifier.empty())
+        {
+            return fixIdent(memberComponent);
         }
         else
         {
-            return fixIdent(identifier);
+            return fixIdent(identifier) + "." + fixIdent(memberComponent);
         }
     }
 }

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -355,7 +355,7 @@ SwiftGenerator::writeDocSentence(IceInternal::Output& out, const StringList& lin
 void
 SwiftGenerator::writeDocSummary(IceInternal::Output& out, const ContainedPtr& p)
 {
-    CommentPtr doc = p->parseComment(swiftLinkFormatter, true, true);
+    CommentPtr doc = p->parseComment(swiftLinkFormatter, true);
     if (!doc)
     {
         return;
@@ -389,7 +389,7 @@ SwiftGenerator::writeDocSummary(IceInternal::Output& out, const ContainedPtr& p)
 void
 SwiftGenerator::writeOpDocSummary(IceInternal::Output& out, const OperationPtr& p, bool dispatch)
 {
-    CommentPtr doc = p->parseComment(swiftLinkFormatter, true, true);
+    CommentPtr doc = p->parseComment(swiftLinkFormatter, true);
     if (!doc)
     {
         return;
@@ -523,7 +523,7 @@ SwiftGenerator::writeOpDocSummary(IceInternal::Output& out, const OperationPtr& 
 void
 SwiftGenerator::writeProxyDocSummary(IceInternal::Output& out, const InterfaceDefPtr& p, const string& swiftModule)
 {
-    CommentPtr doc = p->parseComment(swiftLinkFormatter, true, true);
+    CommentPtr doc = p->parseComment(swiftLinkFormatter, true);
     if (!doc)
     {
         return;
@@ -550,7 +550,7 @@ SwiftGenerator::writeProxyDocSummary(IceInternal::Output& out, const InterfaceDe
         for (OperationList::const_iterator q = ops.begin(); q != ops.end(); ++q)
         {
             OperationPtr op = *q;
-            CommentPtr opdoc = op->parseComment(swiftLinkFormatter, true, true);
+            CommentPtr opdoc = op->parseComment(swiftLinkFormatter, true);
             out << nl << "///";
             out << nl << "///  - " << fixIdent(op->name());
             if (opdoc)
@@ -587,7 +587,7 @@ SwiftGenerator::writeProxyDocSummary(IceInternal::Output& out, const InterfaceDe
 void
 SwiftGenerator::writeServantDocSummary(IceInternal::Output& out, const InterfaceDefPtr& p, const string& swiftModule)
 {
-    CommentPtr doc = p->parseComment(swiftLinkFormatter, true, true);
+    CommentPtr doc = p->parseComment(swiftLinkFormatter, true);
     if (!doc)
     {
         return;
@@ -613,7 +613,7 @@ SwiftGenerator::writeServantDocSummary(IceInternal::Output& out, const Interface
         for (OperationList::const_iterator q = ops.begin(); q != ops.end(); ++q)
         {
             OperationPtr op = *q;
-            CommentPtr opdoc = op->parseComment(swiftLinkFormatter, true, true);
+            CommentPtr opdoc = op->parseComment(swiftLinkFormatter, true);
             out << nl << "///";
             out << nl << "///  - " << fixIdent(op->name());
             if (opdoc)
@@ -638,7 +638,7 @@ SwiftGenerator::writeServantDocSummary(IceInternal::Output& out, const Interface
 void
 SwiftGenerator::writeMemberDoc(IceInternal::Output& out, const DataMemberPtr& p)
 {
-    CommentPtr doc = p->parseComment(swiftLinkFormatter, true, true);
+    CommentPtr doc = p->parseComment(swiftLinkFormatter, true);
     if (!doc)
     {
         return;

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -11,7 +11,6 @@
 #include "SwiftUtil.h"
 
 #include <cassert>
-#include <functional>
 
 using namespace std;
 using namespace Slice;

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -34,18 +34,6 @@ namespace Slice
 
     typedef std::list<ParamInfo> ParamInfoList;
 
-    struct DocElements
-    {
-        StringList overview;
-        bool deprecated;
-        StringList deprecateReason;
-        StringList misc;
-        StringList seeAlso;
-        StringList returns;
-        std::map<std::string, StringList> params;
-        std::map<std::string, StringList> exceptions;
-    };
-
     class SwiftGenerator
     {
     public:
@@ -58,10 +46,6 @@ namespace Slice
         static void validateMetadata(const UnitPtr&);
 
     protected:
-        void trimLines(StringList&);
-        StringList splitComment(const std::string&);
-        bool parseCommentLine(const std::string&, const std::string&, bool, std::string&, std::string&);
-        DocElements parseComment(const ContainedPtr&);
         void writeDocLines(
             IceInternal::Output&,
             const StringList&,


### PR DESCRIPTION
This PR removes a bunch of duplicate code we have for parsing comments. Most from `slice2matlab` and `slice2swift`.
Originally I was just going to fix this in Swift (see #2631), but I just went ahead and ripped it all out at once.
While I was at it, I also accidentally found/fixed some small bugs in our doc comment generation along the way.

----

Currently we have code for parsing Slice doc comments scattered around the various compilers, much of it nearly identical.
Sometimes we even invent a new type for holding the comment data `DocElement`; a near duplicate of `Comment`.

The main reason for this duplication was that every language had it's own formatting for doc-links.
My 'fix' for this is that now you can pass in an `std::function` to `parseComment` which is used to handle language-specific link formatting.