### PR TITLE
Fix IceBox test scripts and config to wait until IceBox server is fully started

### DIFF
--- a/cpp/test/IceBox/admin/config.icebox
+++ b/cpp/test/IceBox/admin/config.icebox
@@ -3,3 +3,5 @@ Ice.Admin.Endpoints=default -p 9996 -h 127.0.0.1
 Ice.ProgramName=IceBox
 
 IceBox.Service.TestService=TestService:create --Ice.Config=config.service
+
+IceBox.PrintServicesReady=IceBox.ServiceManager

--- a/cpp/test/IceBox/configuration/config.icebox
+++ b/cpp/test/IceBox/configuration/config.icebox
@@ -11,3 +11,5 @@ IceBox.UseSharedCommunicator.Service4=1
 IceBox.Service.Service4=TestService:create --Ice.Config=config.service4 --Service3.Prop=2 --Ice.Trace.Slicing=3
 
 IceBox.LoadOrder=Service1 Service2 Service3 Service4
+
+IceBox.PrintServicesReady=IceBox.ServiceManager

--- a/cpp/test/IceBox/configuration/config.icebox2
+++ b/cpp/test/IceBox/configuration/config.icebox2
@@ -16,3 +16,5 @@ IceBox.UseSharedCommunicator.Service2=1
 IceBox.Service.Service2=TestService:create --Ice.Config=config.service2-2
 
 IceBox.LoadOrder=Service1 Service2
+
+IceBox.PrintServicesReady=IceBox.ServiceManager

--- a/csharp/test/IceBox/admin/config.icebox
+++ b/csharp/test/IceBox/admin/config.icebox
@@ -3,3 +3,5 @@ Ice.Admin.Endpoints=default -p 9996 -h 127.0.0.1
 Ice.ProgramName=IceBox
 
 IceBox.Service.TestService=msbuild/testservice/net8.0/testservice.dll:TestServiceI --Ice.Config=config.service
+
+IceBox.PrintServicesReady=IceBox.ServiceManager

--- a/csharp/test/IceBox/configuration/config.icebox
+++ b/csharp/test/IceBox/configuration/config.icebox
@@ -11,3 +11,5 @@ IceBox.UseSharedCommunicator.Service4=1
 IceBox.Service.Service4=msbuild/testservice/net8.0/testservice.dll:TestServiceI --Ice.Config=config.service4 --Service3.Prop=2 --Ice.Trace.Slicing=3
 
 IceBox.LoadOrder=Service1 Service2 Service3 Service4
+
+IceBox.PrintServicesReady=IceBox.ServiceManager

--- a/csharp/test/IceBox/configuration/config.icebox2
+++ b/csharp/test/IceBox/configuration/config.icebox2
@@ -14,3 +14,5 @@ IceBox.UseSharedCommunicator.Service2=1
 IceBox.Service.Service2=msbuild/testservice/net8.0/testservice.dll:TestServiceI --Ice.Config=config.service2-2
 
 IceBox.LoadOrder=Service1 Service2
+
+IceBox.PrintServicesReady=IceBox.ServiceManager

--- a/java/test/src/main/java/test/IceBox/admin/config.icebox
+++ b/java/test/src/main/java/test/IceBox/admin/config.icebox
@@ -3,3 +3,5 @@ Ice.Admin.Endpoints=default -p 9996 -h 127.0.0.1
 Ice.ProgramName=IceBox
 
 IceBox.Service.TestService=test.IceBox.admin.TestServiceI --Ice.Config=config.service
+
+IceBox.PrintServicesReady=IceBox.ServiceManager

--- a/java/test/src/main/java/test/IceBox/configuration/config.icebox
+++ b/java/test/src/main/java/test/IceBox/configuration/config.icebox
@@ -11,3 +11,5 @@ IceBox.UseSharedCommunicator.Service4=1
 IceBox.Service.Service4=test.IceBox.configuration.TestServiceI --Ice.Config=config.service4 --Service3.Prop=2 --Ice.Trace.Slicing=3
 
 IceBox.LoadOrder=Service1 Service2 Service3 Service4
+
+IceBox.PrintServicesReady=IceBox.ServiceManager

--- a/java/test/src/main/java/test/IceBox/configuration/config.icebox2
+++ b/java/test/src/main/java/test/IceBox/configuration/config.icebox2
@@ -14,3 +14,5 @@ IceBox.UseSharedCommunicator.Service2=1
 IceBox.Service.Service2=test.IceBox.configuration.TestServiceI --Ice.Config=config.service2-2
 
 IceBox.LoadOrder=Service1 Service2
+
+IceBox.PrintServicesReady=IceBox.ServiceManager

--- a/scripts/tests/IceBox/admin.py
+++ b/scripts/tests/IceBox/admin.py
@@ -24,8 +24,9 @@ class IceBoxAdminTestCase(ClientServerTestCase):
 TestSuite(
     __name__,
     [
-        ClientServerTestCase(server=IceBox("{testdir}/config.icebox")),
-        IceBoxAdminTestCase("iceboxadmin", server=IceBox("{testdir}/config.icebox")),
+        # readyCount=2 for Ice.Admin and the "bundleName" from IceBox.PrintServicesReady
+        ClientServerTestCase(server=IceBox("{testdir}/config.icebox", readyCount=2)),
+        IceBoxAdminTestCase("iceboxadmin", server=IceBox("{testdir}/config.icebox", readyCount=2)),
     ],
     libDirs=["testservice"],
     runOnMainThread=True,

--- a/scripts/tests/IceBox/configuration.py
+++ b/scripts/tests/IceBox/configuration.py
@@ -10,11 +10,12 @@ from Util import ClientServerTestCase, TestSuite
 TestSuite(
     __name__,
     [
+        # readyCount=2 for Ice.Admin and the "bundleName" from IceBox.PrintServicesReady
         ClientServerTestCase(
-            "client/server #1", server=IceBox("{testdir}/config.icebox")
+           "client/server #1", server=IceBox("{testdir}/config.icebox", readyCount=2)
         ),
         ClientServerTestCase(
-            "client/server #2", server=IceBox("{testdir}/config.icebox2")
+            "client/server #2", server=IceBox("{testdir}/config.icebox2", readyCount=2)
         ),
     ],
     libDirs=["testservice"],


### PR DESCRIPTION
It appears the client could run to completion while the IceBox server was still starting. This PR fixes this issue by setting/waiting for the little known IceBox.PrintServicesReady=bundleName property.

Fixes #3016.

