### PR TITLE
Fix bug in the Swift Ice/ami test

### DIFF
--- a/swift/test/Ice/ami/AllTests.swift
+++ b/swift/test/Ice/ami/AllTests.swift
@@ -4,9 +4,6 @@ import Foundation
 import Ice
 import TestCommon
 
-// WORKAROUND: Disable optimization for this test. Otherwise we get a crash in
-// "testing batch requests with communicator"
-@_optimize(none)
 func allTests(_ helper: TestHelper, collocated: Bool = false) async throws {
     func test(_ value: Bool, file: String = #file, line: Int = #line) throws {
         try helper.test(value, file: file, line: line)


### PR DESCRIPTION
We were not resetting the publishers (batchSubject) count back to 0 so new subscribers were sometimes getting an old value when subscribing.

Closes #2718