### PR TITLE
Remove Extra String Constructors that aren't Necessary Anymore

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -240,7 +240,7 @@ Slice::DefinitionContext::getMetadataArgs(string_view directive) const
     {
         if (p->directive() == directive)
         {
-            return string{p->arguments()};
+            return p->arguments();
         }
     }
     return nullopt;
@@ -974,7 +974,7 @@ Slice::Contained::getMetadataArgs(string_view directive) const
     {
         if (p->directive() == directive)
         {
-            return string{p->arguments()};
+            return p->arguments();
         }
     }
     return nullopt;

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -956,13 +956,13 @@ Slice::findMetadata(const MetadataList& metadata, TypeContext typeCtx)
         {
             if (directive == "cpp:view-type")
             {
-                return string{meta->arguments()};
+                return meta->arguments();
             }
         }
 
         if (directive == "cpp:type")
         {
-            return string{meta->arguments()};
+            return meta->arguments();
         }
 
         if ((typeCtx & (TypeContext::MarshalParam | TypeContext::UnmarshalParamZeroCopy)) != TypeContext::None)

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1680,7 +1680,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     {
         if (metadata->directive() == "cs:implements")
         {
-            baseNames.push_back(string{metadata->arguments()});
+            baseNames.push_back(metadata->arguments());
         }
     }
 
@@ -1952,7 +1952,7 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     {
         if (metadata->directive() == "cs:implements")
         {
-            baseNames.push_back(string{metadata->arguments()});
+            baseNames.push_back(metadata->arguments());
         }
     }
 

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -2318,7 +2318,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     {
         if (metadata->directive() == "java:implements")
         {
-            implements.push_back(string{metadata->arguments()});
+            implements.push_back(metadata->arguments());
         }
     }
 
@@ -2933,7 +2933,7 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     {
         if (metadata->directive() == "java:implements")
         {
-            implements.push_back(string{metadata->arguments()});
+            implements.push_back(metadata->arguments());
         }
     }
 

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -2277,16 +2277,16 @@ Slice::JavaGenerator::getTypeMetadata(const MetadataList& metadata, string& inst
     {
         if (m->directive() == "java:type")
         {
-            string_view arguments = m->arguments();
+            string arguments = m->arguments();
             string::size_type pos = arguments.find(':');
             if (pos != string::npos)
             {
-                instanceType = string{arguments.substr(0, pos)};
-                formalType = string{arguments.substr(pos + 1)};
+                instanceType = arguments.substr(0, pos);
+                formalType = arguments.substr(pos + 1);
             }
             else
             {
-                instanceType = string{arguments};
+                instanceType = arguments;
                 formalType.clear();
             }
             return true;

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -1462,7 +1462,7 @@ Gen::ObjectVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     {
         if (metadata->directive() == "swift:inherits")
         {
-            baseNames.push_back(string{metadata->arguments()});
+            baseNames.push_back(metadata->arguments());
         }
     }
 


### PR DESCRIPTION
This is my follow up to #3026, which removes some extra `string` constructors that aren't necessary anymore.