### PR TITLE
Use docfx from dotnet tools

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
     branches: ["main"]
 
 jobs:
-  ci:
+  api-reference:
     runs-on: macos-15
     steps:
       - name: Checkout repository
@@ -30,7 +30,7 @@ jobs:
           brew install doxygen --formula || true
 
       - name: Install docfx for C# API reference
-        run: brew install docfx
+        run: dotnet tool install -g docfx
 
       - name: Build C++
         working-directory: ./cpp


### PR DESCRIPTION
The C# docfx generation is currently not generating any HTML. There is a warning about templates being missing. I was able to reproduce locally when using the docfx installed with brew.

```
2024-11-01T09:50:42.4028480Z [38;5;11mwarning: No template bundles were found, no template will be applied to the documents. 1) Check your docfx.json 2) the templates subfolder exists inside your application folder or your docfx.json directory.[0m
2024-11-01T09:50:47.3596100Z [38;5;15mBuilding 572 file(s) in ManagedReferenceDocumentProcessor(BuildManagedReferenceDocument=>SplitClassPageToMemberLevel=>ValidateManagedReferenceDocumentMetadata=>ApplyOverwriteDocumentForMref=>FillReferenceInformation)...[0m
2024-11-01T09:50:47.3598460Z [38;5;15mBuilding 1 file(s) in ConceptualDocumentProcessor(BuildConceptualDocument=>ValidateConceptualDocumentMetadata)...[0m
2024-11-01T09:50:47.3599510Z [38;5;15mBuilding 2 file(s) in ResourceDocumentProcessor(ValidateResourceMetadata)...[0m
2024-11-01T09:50:47.3600680Z [38;5;15mBuilding 2 file(s) in TocDocumentProcessor(BuildTocDocument)...[0m
2024-11-01T09:50:50.3404030Z [38;5;15mApplying templates to 577 model(s)...[0m
2024-11-01T09:50:50.3407110Z [38;5;11mwarning: UnknownContentTypeForTemplate: There is no template processing document type(s): Conceptual,ManagedReference,Toc[0m
2024-11-01T09:50:50.9088260Z [38;5;15mXRef map exported.[0m
```

Things seems to work as expected when using docfx installed with `dotnet tool install docfx -g`