### PR TITLE
Bring back SliceChecksumDict

### DIFF
--- a/slice/Ice/PropertyDict.ice
+++ b/slice/Ice/PropertyDict.ice
@@ -23,6 +23,6 @@ module Ice
 {
     /// A simple collection of properties, represented as a dictionary of key/value pairs. Both key and value are
     /// strings.
-    /// @see Properties#getPropertiesForPrefix
+    /// @see PropertiesAdmin#getPropertiesForPrefix
     dictionary<string, string> PropertyDict;
 }

--- a/slice/Ice/SliceChecksumDict.ice
+++ b/slice/Ice/SliceChecksumDict.ice
@@ -1,0 +1,25 @@
+//
+// Copyright (c) ZeroC, Inc. All rights reserved.
+//
+
+#pragma once
+
+[["cpp:dll-export:ICE_API"]]
+[["cpp:doxygen:include:Ice/Ice.h"]]
+[["cpp:header-ext:h"]]
+
+[["js:module:ice"]]
+
+[["python:pkgdir:Ice"]]
+
+[["java:package:com.zeroc"]]
+
+module Ice
+{
+
+    /// mapping from type IDs to Slice checksums. The dictionary allows verification at run time that client and server
+    /// use matching Slice definitions. Ice 3.8 no longer generate Slice checksums but we keep the dictionary definition for
+    /// backward compatibility.
+    dictionary<string, string> SliceChecksumDict;
+
+}

--- a/slice/Ice/SliceChecksumDict.ice
+++ b/slice/Ice/SliceChecksumDict.ice
@@ -17,7 +17,7 @@
 module Ice
 {
     /// Mapping from type IDs to Slice checksums. The dictionary allows verification at run time that client and server
-    /// use matching Slice definitions. Ice 3.8 no longer generate Slice checksums but we keep the dictionary definition
+    /// use matching Slice definitions. Ice 3.8 no longer generates Slice checksums but we keep the dictionary definition
     /// for backward compatibility.
     dictionary<string, string> SliceChecksumDict;
 }

--- a/slice/Ice/SliceChecksumDict.ice
+++ b/slice/Ice/SliceChecksumDict.ice
@@ -16,10 +16,8 @@
 
 module Ice
 {
-
-    /// mapping from type IDs to Slice checksums. The dictionary allows verification at run time that client and server
-    /// use matching Slice definitions. Ice 3.8 no longer generate Slice checksums but we keep the dictionary definition for
-    /// backward compatibility.
+    /// Mapping from type IDs to Slice checksums. The dictionary allows verification at run time that client and server
+    /// use matching Slice definitions. Ice 3.8 no longer generate Slice checksums but we keep the dictionary definition
+    /// for backward compatibility.
     dictionary<string, string> SliceChecksumDict;
-
 }


### PR DESCRIPTION
Fix #1824

We also remove all IcePatch2 definitions, but I think is better to leave them out. If you want to interact with an Ice 3.7 IcePatch2 server you can use the definitions from 3.7.

We also remove this non local dictionary https://github.com/zeroc-ice/ice/blob/234b98676be05280b8843871f3af9ee5a666fcf6/slice/Ice/Connection.ice#L501

But it was probably an oversight that it was not marked as local, as it was only used by local types.