### PR TITLE
Fix Swift race condition

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -3,6 +3,7 @@
     "language": "en",
     "words": [
         "apos",
+        "autoreleasepool",
         "Blobject",
         "cacerts",
         "datagram",

--- a/swift/src/IceImpl/DispatchAdapter.mm
+++ b/swift/src/IceImpl/DispatchAdapter.mm
@@ -61,7 +61,7 @@ CppDispatcher::dispatch(Ice::IncomingRequest& request, std::function<void(Ice::O
     ICEObjectAdapter* adapter = [ICEObjectAdapter getHandle:current.adapter];
     ICEConnection* con = [ICEConnection getHandle:current.con];
 
-    // Both are null or both are non-null
+    // Both are null (colloc) or both are non-null (non-colloc).
     assert((current.con && con) || (!current.con && !con));
 
     @autoreleasepool

--- a/swift/src/IceImpl/DispatchAdapter.mm
+++ b/swift/src/IceImpl/DispatchAdapter.mm
@@ -6,8 +6,6 @@
 #import "include/LocalExceptionFactory.h"
 #import "include/ObjectAdapter.h"
 
-#include <iostream>
-
 void
 CppDispatcher::dispatch(Ice::IncomingRequest& request, std::function<void(Ice::OutgoingResponse)> sendResponse)
 {
@@ -62,6 +60,9 @@ CppDispatcher::dispatch(Ice::IncomingRequest& request, std::function<void(Ice::O
 
     ICEObjectAdapter* adapter = [ICEObjectAdapter getHandle:current.adapter];
     ICEConnection* con = [ICEConnection getHandle:current.con];
+
+    // Both are null or both are non-null
+    assert((current.con && con) || (!current.con && !con));
 
     @autoreleasepool
     {

--- a/swift/src/IceImpl/LocalObject.mm
+++ b/swift/src/IceImpl/LocalObject.mm
@@ -75,7 +75,7 @@ namespace
 
         // When the last reference on this object is released, p->second is nil and we remove the stale entry from the
         // cache.
-        if(p->second == nil)
+        if (p->second == nil)
         {
             cachedObjects->erase(p);
         }

--- a/swift/src/IceImpl/LocalObject.mm
+++ b/swift/src/IceImpl/LocalObject.mm
@@ -3,9 +3,6 @@
 
 #import "include/LocalObject.h"
 
-#include <iostream>
-using namespace std;
-
 namespace
 {
     // We "leak" this map to avoid the destructor being called when the application is terminated.


### PR DESCRIPTION
There was a race condition that could occur if one thread was trying to access the cached object while another thread was trying to deallocate said object.

Fixes #3031