### PR TITLE
Reenable IceGrid/replication test in Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,9 +110,7 @@ jobs:
         timeout-minutes: 30
         with:
           working_directory: ${{ matrix.working_directory || '.' }}
-          # See:
-          # - https://github.com/zeroc-ice/ice/issues/1653 IceGrid/replication
-          flags: "--rfilter=IceGrid/replication ${{ matrix.test_flags }}"
+          flags: ${{ matrix.test_flags }}
         # Don't test matlab on Windows (see setup-dependencies/action.yml)
         if: matrix.config != 'matlab' || runner.os != 'Windows'
 

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -370,9 +370,15 @@ Ice::ConnectionI::startAsync(
 
         if (!initialize() || !validate())
         {
-            if (_connectTimeout > chrono::seconds::zero())
+            if (_connectTimeout == chrono::seconds::zero())
             {
-                _timer->schedule(make_shared<ConnectTimerTask>(shared_from_this()), _connectTimeout);
+                // We interpret a connection timeout of 0s as meaning "fail very quickly". This is particularly useful
+                // on Windows where connection establishment takes a long time to fail.
+                _timer->schedule(make_shared<ConnectTimerTask>(shared_from_this()), 300ms);
+            }
+            else if (_connectTimeout > chrono::seconds::zero())
+            {
+               _timer->schedule(make_shared<ConnectTimerTask>(shared_from_this()), _connectTimeout);
             }
 
             if (connectionStartCompleted && connectionStartFailed)

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -370,13 +370,7 @@ Ice::ConnectionI::startAsync(
 
         if (!initialize() || !validate())
         {
-            if (_connectTimeout == chrono::seconds::zero())
-            {
-                // We interpret a connection timeout of 0s as meaning "fail very quickly". This is particularly useful
-                // on Windows where connection establishment takes a long time to fail.
-                _timer->schedule(make_shared<ConnectTimerTask>(shared_from_this()), 300ms);
-            }
-            else if (_connectTimeout > chrono::seconds::zero())
+            if (_connectTimeout > chrono::seconds::zero())
             {
                 _timer->schedule(make_shared<ConnectTimerTask>(shared_from_this()), _connectTimeout);
             }

--- a/cpp/src/IceGrid/NodeSessionI.cpp
+++ b/cpp/src/IceGrid/NodeSessionI.cpp
@@ -181,10 +181,9 @@ NodeSessionI::waitForApplicationUpdateAsync(
 }
 
 void
-NodeSessionI::destroy(const Ice::Current& current)
+NodeSessionI::destroy(const Ice::Current&)
 {
-    // If the adapter is not set, it means this session is destroyed by the reaper.
-    destroyImpl(false, current.adapter == nullptr);
+    destroyImpl(false);
 }
 
 optional<chrono::steady_clock::time_point>
@@ -201,7 +200,7 @@ NodeSessionI::timestamp() const noexcept
 void
 NodeSessionI::shutdown()
 {
-    destroyImpl(true, true);
+    destroyImpl(true);
 }
 
 const NodePrx&
@@ -237,7 +236,7 @@ NodeSessionI::isDestroyed() const
 }
 
 void
-NodeSessionI::destroyImpl(bool shutdown, bool byReaper)
+NodeSessionI::destroyImpl(bool shutdown)
 {
     {
         lock_guard lock(_mutex);
@@ -255,14 +254,6 @@ NodeSessionI::destroyImpl(bool shutdown, bool byReaper)
         if (shutdown)
         {
             out << " because the registry is shutting down";
-        }
-        else if (byReaper)
-        {
-            out << " because the node did not send a keepAlive in a timely manner";
-        }
-        else
-        {
-            out << " because the node requested it";
         }
     }
 

--- a/cpp/src/IceGrid/NodeSessionI.h
+++ b/cpp/src/IceGrid/NodeSessionI.h
@@ -57,7 +57,7 @@ namespace IceGrid
             NodeSessionPrx,
             const LoadInfo&);
 
-        void destroyImpl(bool shutdown, bool byReaper);
+        void destroyImpl(bool shutdown);
 
         const std::shared_ptr<Database> _database;
         const std::shared_ptr<TraceLevels> _traceLevels;

--- a/cpp/src/IceGrid/NodeSessionI.h
+++ b/cpp/src/IceGrid/NodeSessionI.h
@@ -57,7 +57,7 @@ namespace IceGrid
             NodeSessionPrx,
             const LoadInfo&);
 
-        void destroyImpl(bool);
+        void destroyImpl(bool shutdown, bool byReaper);
 
         const std::shared_ptr<Database> _database;
         const std::shared_ptr<TraceLevels> _traceLevels;

--- a/cpp/test/IceGrid/replication/Client.cpp
+++ b/cpp/test/IceGrid/replication/Client.cpp
@@ -19,6 +19,11 @@ Client::run(int argc, char** argv)
 {
     auto properties = createTestProperties(argc, argv);
     properties->setProperty("Ice.Warn.Connections", "0");
+
+    // The test connects only to localhost and we want connection establishment to fail quickly when the server is not
+    // running, especially on Windows.
+    properties->setProperty("Ice.Connection.Client.ConnectTimeout", "0"); // equivalent to 300ms
+
     Ice::CommunicatorHolder communicatorHolder = initialize(argc, argv, properties);
     communicatorHolder->getProperties()->parseCommandLineOptions("", Ice::argsToStringSeq(argc, argv));
     void allTests(Test::TestHelper*);

--- a/cpp/test/IceGrid/replication/Client.cpp
+++ b/cpp/test/IceGrid/replication/Client.cpp
@@ -22,7 +22,7 @@ Client::run(int argc, char** argv)
 
     // The test connects only to localhost and we want connection establishment to fail quickly when the server is not
     // running, especially on Windows.
-    properties->setProperty("Ice.Connection.Client.ConnectTimeout", "0"); // equivalent to 300ms
+    properties->setProperty("Ice.Connection.Client.ConnectTimeout", "1");
 
     Ice::CommunicatorHolder communicatorHolder = initialize(argc, argv, properties);
     communicatorHolder->getProperties()->parseCommandLineOptions("", Ice::argsToStringSeq(argc, argv));

--- a/cpp/test/IceGrid/replication/application.xml
+++ b/cpp/test/IceGrid/replication/application.xml
@@ -14,9 +14,9 @@
         <property name="IceGrid.Node.Data" value="${server.data}"/>
         <property name="IceGrid.Node.PropertiesOverride" value="${properties-override} Ice.PrintProcessId=0 Ice.PrintAdapterReady=0"/>
         <property name="Ice.Default.Locator" value="RepTestIceGrid/Locator:default -p 12050:default -p 12051:default -p 12052"/>
-        <property name="IceGrid.Node.Trace.Replica" value="1"/>
+        <property name="IceGrid.Node.Trace.Replica" value="3"/>
         <property name="IceGrid.Node.Trace.Adapter" value="1"/>
-        <property name="Ice.Trace.Network" value="0"/>
+        <property name="Ice.Trace.Network" value="1"/>
         <property name="Ice.Warn.Connections" value="0"/>
         <property name="Ice.Admin.Enabled" value="0"/>
         <property name="Ice.Connection.Client.ConnectTimeout" value="0"/>
@@ -50,7 +50,7 @@
         <property name="IceGrid.Registry.Trace.Replica" value="1"/>
         <property name="IceGrid.Registry.Trace.Locator" value="2"/>
         <property name="IceGrid.Registry.Trace.Node" value="2"/>
-        <property name="Ice.Trace.Network" value="0"/>
+        <property name="Ice.Trace.Network" value="1"/>
         <property name="Ice.Warn.Connections" value="0"/>
         <property name="IceGrid.Registry.Trace.Locator" value="0"/>
         <property name="IceGrid.Registry.UserAccounts" value="${test.dir}/useraccounts.txt"/>

--- a/cpp/test/IceGrid/replication/application.xml
+++ b/cpp/test/IceGrid/replication/application.xml
@@ -19,7 +19,7 @@
         <property name="Ice.Trace.Network" value="0"/>
         <property name="Ice.Warn.Connections" value="0"/>
         <property name="Ice.Admin.Enabled" value="0"/>
-        <property name="Ice.Connection.Client.ConnectTimeout" value="1"/>
+        <property name="Ice.Connection.Client.ConnectTimeout" value="0"/>
         <property name="Ice.Default.EncodingVersion" value="${encoding}"/>
         <property name="Ice.StdErr" value="${server.data}/trace.log"/>
       </server>
@@ -55,7 +55,7 @@
         <property name="IceGrid.Registry.Trace.Locator" value="0"/>
         <property name="IceGrid.Registry.UserAccounts" value="${test.dir}/useraccounts.txt"/>
         <property name="Ice.Admin.Enabled" value="0"/>
-        <property name="Ice.Connection.Client.ConnectTimeout" value="1"/>
+        <property name="Ice.Connection.Client.ConnectTimeout" value="0"/>
         <property name="Ice.Default.EncodingVersion" value="${encoding}"/>
         <property name="Ice.StdErr" value="${server.data}/trace.log"/>
       </server>

--- a/cpp/test/IceGrid/replication/application.xml
+++ b/cpp/test/IceGrid/replication/application.xml
@@ -17,7 +17,6 @@
         <property name="IceGrid.Node.Trace.Replica" value="3"/>
         <property name="IceGrid.Node.Trace.Adapter" value="1"/>
         <property name="Ice.Trace.Network" value="1"/>
-        <property name="Ice.Trace.Protocol" value="1"/>
         <property name="Ice.Warn.Connections" value="0"/>
         <property name="Ice.Admin.Enabled" value="0"/>
         <property name="Ice.Connection.Client.ConnectTimeout" value="1"/>

--- a/cpp/test/IceGrid/replication/application.xml
+++ b/cpp/test/IceGrid/replication/application.xml
@@ -20,7 +20,7 @@
         <property name="Ice.Trace.Protocol" value="1"/>
         <property name="Ice.Warn.Connections" value="0"/>
         <property name="Ice.Admin.Enabled" value="0"/>
-        <property name="Ice.Connection.Client.ConnectTimeout" value="0"/>
+        <property name="Ice.Connection.Client.ConnectTimeout" value="1"/>
         <property name="Ice.Default.EncodingVersion" value="${encoding}"/>
         <property name="Ice.StdErr" value="${server.data}/trace.log"/>
       </server>
@@ -56,7 +56,7 @@
         <property name="IceGrid.Registry.Trace.Locator" value="0"/>
         <property name="IceGrid.Registry.UserAccounts" value="${test.dir}/useraccounts.txt"/>
         <property name="Ice.Admin.Enabled" value="0"/>
-        <property name="Ice.Connection.Client.ConnectTimeout" value="0"/>
+        <property name="Ice.Connection.Client.ConnectTimeout" value="1"/>
         <property name="Ice.Default.EncodingVersion" value="${encoding}"/>
         <property name="Ice.StdErr" value="${server.data}/trace.log"/>
       </server>

--- a/cpp/test/IceGrid/replication/application.xml
+++ b/cpp/test/IceGrid/replication/application.xml
@@ -17,6 +17,7 @@
         <property name="IceGrid.Node.Trace.Replica" value="3"/>
         <property name="IceGrid.Node.Trace.Adapter" value="1"/>
         <property name="Ice.Trace.Network" value="1"/>
+        <property name="Ice.Trace.Protocol" value="1"/>
         <property name="Ice.Warn.Connections" value="0"/>
         <property name="Ice.Admin.Enabled" value="0"/>
         <property name="Ice.Connection.Client.ConnectTimeout" value="0"/>


### PR DESCRIPTION
This PR reenables the IceGrid replication test in CI (Windows), and increases tracing for this test.

In an earlier version of this PR, I sped it up on Windows by reducing the ConnectTimeout to 300ms, but this caused CI to fail on Windows.

### Initial description (no longer accurate):
This PR speeds up the IceGrid/replication test on Windows, from ~3 min 40s to ~ 1 min 30 s on my Windows workstation (all debug/x64 build). 1 min 30s is similar to the time on the 3.7 branch.

The issue with this test on Windows is it makes many "ConnectionRefused" connection attempts and they take a long time on Windows.

The solution relies on a reinterpretation of the ConnectTimeout values:

- before this PR: <= 0 means infinite, > 0 means connect timeout in seconds
- with this PR: < 0 means infinite, 0 means "fail quickly" (300 ms timeout), and > 0 means connect timeout in seconds

If approved, I will:
 - apply the same change to ConnectTimeout in all languages
 - make "0" an invalid value for all other Connection timeouts (currently it means infinite, just like any negative value)
