### PR TITLE
Simplify the API for Reporting Parser Warnings

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -247,7 +247,7 @@ Slice::DefinitionContext::getMetadataArgs(string_view directive) const
 }
 
 bool
-Slice::DefinitionContext::shouldSuppressWarning(WarningCategory category) const
+Slice::DefinitionContext::isSuppressed(WarningCategory category) const
 {
     return _suppressedWarnings.find(category) != _suppressedWarnings.end() ||
            _suppressedWarnings.find(All) != _suppressedWarnings.end();
@@ -4812,7 +4812,7 @@ Slice::Unit::warning(string_view file, int line, WarningCategory category, strin
     assert(dc);
 
     // Determine whether the warning should be ignored by checking for any 'suppress-warning' metadata in this context.
-    if (!dc->shouldSuppressWarning(category))
+    if (!dc->isSuppressed(category))
     {
         emitWarning(file, line, message);
     }

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -226,11 +226,9 @@ namespace Slice
         bool hasMetadata(std::string_view directive) const;
         std::optional<std::string> getMetadataArgs(std::string_view directive) const;
 
-        /// Emits a warning unless it should be filtered out by a [["suppress-warning"]].
-        void warning(WarningCategory category, const std::string& file, int line, const std::string& message) const;
+        bool shouldSuppressWarning(WarningCategory category) const;
 
     private:
-        bool shouldSuppressWarning(WarningCategory category) const;
         void initSuppressedWarnings();
 
         int _includeLevel;
@@ -999,16 +997,17 @@ namespace Slice
 
         void setSeenDefinition();
 
-        void error(const std::string& message);
-        void error(const std::string& file, int line, const std::string& message);
-        void warning(WarningCategory category, const std::string& message) const;
+        void error(std::string_view message);
+        void error(std::string_view file, int line, std::string_view message);
+        void warning(WarningCategory category, std::string_view message) const;
+        void warning(std::string_view file, int line, WarningCategory category, std::string_view message) const;
 
         ContainerPtr currentContainer() const;
         void pushContainer(const ContainerPtr& container);
         void popContainer();
 
         DefinitionContextPtr currentDefinitionContext() const;
-        DefinitionContextPtr findDefinitionContext(const std::string& file) const;
+        DefinitionContextPtr findDefinitionContext(std::string_view file) const;
 
         void addContent(const ContainedPtr& contained);
         ContainedList findContents(const std::string& scopedName) const;
@@ -1050,7 +1049,7 @@ namespace Slice
         std::stack<ContainerPtr> _containerStack;
         std::map<Builtin::Kind, BuiltinPtr> _builtins;
         std::map<std::string, ContainedList> _contentMap;
-        std::map<std::string, DefinitionContextPtr> _definitionContextMap;
+        std::map<std::string, DefinitionContextPtr, std::less<>> _definitionContextMap;
         std::map<int, std::string> _typeIds;
         std::map<std::string, std::set<std::string>> _fileTopLevelModules;
     };

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -226,7 +226,7 @@ namespace Slice
         bool hasMetadata(std::string_view directive) const;
         std::optional<std::string> getMetadataArgs(std::string_view directive) const;
 
-        bool shouldSuppressWarning(WarningCategory category) const;
+        bool isSuppressed(WarningCategory category) const;
 
     private:
         void initSuppressedWarnings();

--- a/cpp/src/Slice/SliceUtil.cpp
+++ b/cpp/src/Slice/SliceUtil.cpp
@@ -210,7 +210,7 @@ Slice::removeExtension(const string& path)
 }
 
 void
-Slice::emitError(const string& file, int line, const string& message)
+Slice::emitError(string_view file, int line, string_view message)
 {
     if (!file.empty())
     {
@@ -225,7 +225,7 @@ Slice::emitError(const string& file, int line, const string& message)
 }
 
 void
-Slice::emitWarning(const string& file, int line, const string& message)
+Slice::emitWarning(string_view file, int line, string_view message)
 {
     if (!file.empty())
     {

--- a/cpp/src/Slice/Util.h
+++ b/cpp/src/Slice/Util.h
@@ -11,8 +11,8 @@ namespace Slice
     std::string fullPath(const std::string& path);
     std::string changeInclude(const std::string& path, const std::vector<std::string>& includePaths);
     std::string removeExtension(const std::string& path);
-    void emitError(const std::string& file, int line, const std::string& message);
-    void emitWarning(const std::string& file, int line, const std::string& message);
+    void emitError(std::string_view file, int line, std::string_view message);
+    void emitWarning(std::string_view file, int line, std::string_view message);
     void emitRaw(const char* message);
     std::vector<std::string> filterMcppWarnings(const std::string& message);
     void

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -786,7 +786,7 @@ Slice::Gen::generate(const UnitPtr& p)
                 {
                     ostringstream ostr;
                     ostr << "ignoring invalid file metadata '" << *metadata << "'";
-                    dc->warning(InvalidMetadata, metadata->file(), metadata->line(), ostr.str());
+                    p->warning(metadata->file(), metadata->line(), InvalidMetadata, ostr.str());
                     fileMetadata.remove(metadata);
                 }
             }
@@ -800,7 +800,7 @@ Slice::Gen::generate(const UnitPtr& p)
                 {
                     ostringstream ostr;
                     ostr << "ignoring invalid file metadata '" << *metadata << "'";
-                    dc->warning(InvalidMetadata, metadata->file(), metadata->line(), ostr.str());
+                    p->warning(metadata->file(), metadata->line(), InvalidMetadata, ostr.str());
                     fileMetadata.remove(metadata);
                 }
             }
@@ -947,7 +947,7 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
                         ostringstream ostr;
                         ostr << "ignoring invalid file metadata '" << *s
                              << "': directive can appear only once per file";
-                        dc->warning(InvalidMetadata, s->file(), s->line(), ostr.str());
+                        unit->warning(s->file(), s->line(), InvalidMetadata, ostr.str());
                         fileMetadata.remove(s);
                     }
                     seenHeaderExtension = true;
@@ -960,7 +960,7 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
                         ostringstream ostr;
                         ostr << "ignoring invalid file metadata '" << *s
                              << "': directive can appear only once per file";
-                        dc->warning(InvalidMetadata, s->file(), s->line(), ostr.str());
+                        unit->warning(s->file(), s->line(), InvalidMetadata, ostr.str());
                         fileMetadata.remove(s);
                     }
                     seenSourceExtension = true;
@@ -973,7 +973,7 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
                         ostringstream ostr;
                         ostr << "ignoring invalid file metadata '" << *s
                              << "': directive can appear only once per file";
-                        dc->warning(InvalidMetadata, s->file(), s->line(), ostr.str());
+                        unit->warning(s->file(), s->line(), InvalidMetadata, ostr.str());
                         fileMetadata.remove(s);
                     }
                     seenDllExport = true;
@@ -986,7 +986,7 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
 
                 ostringstream ostr;
                 ostr << "ignoring invalid file metadata '" << *s << "'";
-                dc->warning(InvalidMetadata, s->file(), s->line(), ostr.str());
+                unit->warning(s->file(), s->line(), InvalidMetadata, ostr.str());
                 fileMetadata.remove(s);
             }
         }
@@ -999,34 +999,34 @@ Slice::Gen::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
 bool
 Slice::Gen::MetadataVisitor::visitModuleStart(const ModulePtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file()));
+    p->setMetadata(validate(p, p->getMetadata()));
     return true;
 }
 
 void
 Slice::Gen::MetadataVisitor::visitClassDecl(const ClassDeclPtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file()));
+    p->setMetadata(validate(p, p->getMetadata()));
 }
 
 bool
 Slice::Gen::MetadataVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file()));
+    p->setMetadata(validate(p, p->getMetadata()));
     return true;
 }
 
 bool
 Slice::Gen::MetadataVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file()));
+    p->setMetadata(validate(p, p->getMetadata()));
     return true;
 }
 
 bool
 Slice::Gen::MetadataVisitor::visitStructStart(const StructPtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file()));
+    p->setMetadata(validate(p, p->getMetadata()));
     return true;
 }
 
@@ -1036,8 +1036,6 @@ Slice::Gen::MetadataVisitor::visitOperation(const OperationPtr& p)
     TypePtr returnType = p->returnType();
     if (!returnType)
     {
-        const DefinitionContextPtr dc = p->unit()->findDefinitionContext(p->file());
-        assert(dc);
         MetadataList metadata = p->getMetadata();
         for (MetadataList::const_iterator q = metadata.begin(); q != metadata.end();)
         {
@@ -1047,7 +1045,7 @@ Slice::Gen::MetadataVisitor::visitOperation(const OperationPtr& p)
             {
                 ostringstream ostr;
                 ostr << "ignoring invalid metadata '" << *s << "' for operation with void return type";
-                dc->warning(InvalidMetadata, s->file(), s->line(), ostr.str());
+                p->unit()->warning(s->file(), s->line(), InvalidMetadata, ostr.str());
                 metadata.remove(s);
             }
         }
@@ -1055,56 +1053,51 @@ Slice::Gen::MetadataVisitor::visitOperation(const OperationPtr& p)
     }
     else
     {
-        p->setMetadata(validate(returnType, p->getMetadata(), p->file(), true));
+        p->setMetadata(validate(returnType, p->getMetadata(), true));
     }
 
     for (const auto& param : p->parameters())
     {
-        param->setMetadata(validate(param->type(), param->getMetadata(), p->file(), true));
+        param->setMetadata(validate(param->type(), param->getMetadata(), true));
     }
 }
 
 void
 Slice::Gen::MetadataVisitor::visitDataMember(const DataMemberPtr& p)
 {
-    p->setMetadata(validate(p->type(), p->getMetadata(), p->file()));
+    p->setMetadata(validate(p->type(), p->getMetadata()));
 }
 
 void
 Slice::Gen::MetadataVisitor::visitSequence(const SequencePtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file()));
+    p->setMetadata(validate(p, p->getMetadata()));
 }
 
 void
 Slice::Gen::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file()));
+    p->setMetadata(validate(p, p->getMetadata()));
 }
 
 void
 Slice::Gen::MetadataVisitor::visitEnum(const EnumPtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file()));
+    p->setMetadata(validate(p, p->getMetadata()));
 }
 
 void
 Slice::Gen::MetadataVisitor::visitConst(const ConstPtr& p)
 {
-    p->setMetadata(validate(p, p->getMetadata(), p->file()));
+    p->setMetadata(validate(p, p->getMetadata()));
 }
 
 MetadataList
 Slice::Gen::MetadataVisitor::validate(
     const SyntaxTreeBasePtr& cont,
     MetadataList metadata,
-    const string& file,
     bool operation)
 {
-    const UnitPtr ut = cont->unit();
-    const DefinitionContextPtr dc = ut->findDefinitionContext(file);
-    assert(dc);
-
     for (MetadataList::const_iterator q = metadata.begin(); q != metadata.end();)
     {
         MetadataPtr meta = *q++;
@@ -1117,7 +1110,7 @@ Slice::Gen::MetadataVisitor::validate(
         {
             ostringstream ostr;
             ostr << "ignoring invalid metadata '" << *meta << "'";
-            dc->warning(InvalidMetadata, meta->file(), meta->line(), ostr.str());
+            cont->unit()->warning(meta->file(), meta->line(), InvalidMetadata, ostr.str());
             metadata.remove(meta);
             continue;
         }
@@ -1183,7 +1176,7 @@ Slice::Gen::MetadataVisitor::validate(
 
         ostringstream ostr;
         ostr << "ignoring invalid metadata '" << *meta << "'";
-        dc->warning(InvalidMetadata, meta->file(), meta->line(), ostr.str());
+        cont->unit()->warning(meta->file(), meta->line(), InvalidMetadata, ostr.str());
         metadata.remove(meta);
     }
     return metadata;

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1093,10 +1093,7 @@ Slice::Gen::MetadataVisitor::visitConst(const ConstPtr& p)
 }
 
 MetadataList
-Slice::Gen::MetadataVisitor::validate(
-    const SyntaxTreeBasePtr& cont,
-    MetadataList metadata,
-    bool operation)
+Slice::Gen::MetadataVisitor::validate(const SyntaxTreeBasePtr& cont, MetadataList metadata, bool operation)
 {
     for (MetadataList::const_iterator q = metadata.begin(); q != metadata.end();)
     {

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -224,7 +224,6 @@ namespace Slice
             MetadataList validate(
                 const SyntaxTreeBasePtr& cont,
                 MetadataList metadata,
-                const std::string& file,
                 bool operation = false);
         };
 

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -221,10 +221,7 @@ namespace Slice
             /// Validates any 'cpp' specific metadata that's been applied to `cont`.
             /// Additional metadata to validate can also be passed in with the `metadata` field.
             /// For example, type metadata applied to a sequence where it's being used instead of just defined.
-            MetadataList validate(
-                const SyntaxTreeBasePtr& cont,
-                MetadataList metadata,
-                bool operation = false);
+            MetadataList validate(const SyntaxTreeBasePtr& cont, MetadataList metadata, bool operation = false);
         };
 
         static void validateMetadata(const UnitPtr&);

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1982,7 +1982,7 @@ Slice::CsGenerator::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
             {
                 ostringstream msg;
                 msg << "ignoring invalid file metadata '" << *metadata << "'";
-                dc->warning(InvalidMetadata, metadata->file(), metadata->line(), msg.str());
+                unit->warning(metadata->file(), metadata->line(), InvalidMetadata, msg.str());
                 continue;
             }
             newFileMetadata.push_back(metadata);
@@ -2075,10 +2075,6 @@ Slice::CsGenerator::MetadataVisitor::visitConst(const ConstPtr& p)
 void
 Slice::CsGenerator::MetadataVisitor::validate(const ContainedPtr& cont)
 {
-    const UnitPtr ut = cont->unit();
-    const DefinitionContextPtr dc = ut->findDefinitionContext(cont->file());
-    assert(dc);
-
     MetadataList newLocalMetadata;
     for (const auto& metadata : cont->getMetadata())
     {
@@ -2173,7 +2169,7 @@ Slice::CsGenerator::MetadataVisitor::validate(const ContainedPtr& cont)
 
             ostringstream msg;
             msg << "ignoring invalid metadata '" << *metadata << "'";
-            dc->warning(InvalidMetadata, metadata->file(), metadata->line(), msg.str());
+            cont->unit()->warning(metadata->file(), metadata->line(), InvalidMetadata, msg.str());
             continue;
         }
         newLocalMetadata.push_back(metadata);

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -818,10 +818,6 @@ CodeVisitor::visitDictionary(const DictionaryPtr& p)
 {
     TypePtr keyType = p->keyType();
     BuiltinPtr b = dynamic_pointer_cast<Builtin>(keyType);
-
-    const UnitPtr unit = p->unit();
-    const DefinitionContextPtr dc = unit->findDefinitionContext(p->file());
-    assert(dc);
     if (b)
     {
         switch (b->kind())
@@ -848,7 +844,7 @@ CodeVisitor::visitDictionary(const DictionaryPtr& p)
     {
         // TODO: using 'InvalidMetadata' as our warning category for an unsupported key type feels weird.
         // See https://github.com/zeroc-ice/ice/issues/254
-        dc->warning(InvalidMetadata, p->file(), p->line(), "dictionary key type not supported in PHP");
+        p->unit()->warning(p->file(), p->line(), InvalidMetadata, "dictionary key type not supported in PHP");
     }
 
     string type = getTypeVar(p);

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2912,7 +2912,6 @@ Slice::Python::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
     for (const auto& file : unit->allFiles())
     {
         DefinitionContextPtr dc = unit->findDefinitionContext(file);
-        assert(dc);
         MetadataList fileMetadata = dc->getMetadata();
         for (MetadataList::const_iterator r = fileMetadata.begin(); r != fileMetadata.end();)
         {
@@ -2933,7 +2932,7 @@ Slice::Python::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
 
                 ostringstream msg;
                 msg << "ignoring invalid file metadata '" << *meta << "'";
-                dc->warning(InvalidMetadata, meta->file(), meta->line(), msg.str());
+                unit->warning(meta->file(), meta->line(), InvalidMetadata, msg.str());
                 fileMetadata.remove(meta);
             }
         }
@@ -2961,7 +2960,7 @@ Slice::Python::MetadataVisitor::visitModuleStart(const ModulePtr& p)
 
             ostringstream msg;
             msg << "ignoring invalid file metadata '" << *meta << "'";
-            p->definitionContext()->warning(InvalidMetadata, meta->file(), meta->line(), msg.str());
+            p->unit()->warning(meta->file(), meta->line(), InvalidMetadata, msg.str());
             metadata.remove(meta);
         }
     }
@@ -3058,10 +3057,6 @@ Slice::Python::MetadataVisitor::visitConst(const ConstPtr& p)
 MetadataList
 Slice::Python::MetadataVisitor::validateSequence(const ContainedPtr& cont, const TypePtr& type)
 {
-    const UnitPtr ut = type->unit();
-    const DefinitionContextPtr dc = ut->findDefinitionContext(cont->file());
-    assert(dc);
-
     static const string prefix = "python:";
     MetadataList newMetadata = cont->getMetadata();
     for (MetadataList::const_iterator p = newMetadata.begin(); p != newMetadata.end();)
@@ -3119,7 +3114,7 @@ Slice::Python::MetadataVisitor::validateSequence(const ContainedPtr& cont, const
             }
             ostringstream msg;
             msg << "ignoring invalid metadata '" << *s << "'";
-            dc->warning(InvalidMetadata, s->file(), s->line(), msg.str());
+            type->unit()->warning(s->file(), s->line(), InvalidMetadata, msg.str());
             newMetadata.remove(s);
         }
     }
@@ -3131,10 +3126,6 @@ Slice::Python::MetadataVisitor::reject(const ContainedPtr& cont)
 {
     MetadataList localMetadata = cont->getMetadata();
 
-    const UnitPtr ut = cont->unit();
-    const DefinitionContextPtr dc = ut->findDefinitionContext(cont->file());
-    assert(dc);
-
     for (MetadataList::const_iterator p = localMetadata.begin(); p != localMetadata.end();)
     {
         MetadataPtr s = *p++;
@@ -3142,7 +3133,7 @@ Slice::Python::MetadataVisitor::reject(const ContainedPtr& cont)
         {
             ostringstream msg;
             msg << "ignoring invalid metadata '" << *s << "'";
-            dc->warning(InvalidMetadata, s->file(), s->line(), msg.str());
+            cont->unit()->warning(s->file(), s->line(), InvalidMetadata, msg.str());
             localMetadata.remove(s);
         }
     }

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -2428,8 +2428,6 @@ void
 SwiftGenerator::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
 {
     const string prefix = "swift:";
-    const DefinitionContextPtr dc = p->unit()->findDefinitionContext(p->file());
-    assert(dc);
 
     for (const auto& metadata : p->keyMetadata())
     {
@@ -2437,7 +2435,7 @@ SwiftGenerator::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
         {
             ostringstream msg;
             msg << "ignoring invalid metadata '" << *metadata << "' for dictionary key type";
-            dc->warning(InvalidMetadata, metadata->file(), metadata->line(), msg.str());
+            p->unit()->warning(metadata->file(), metadata->line(), InvalidMetadata, msg.str());
         }
     }
 
@@ -2447,7 +2445,7 @@ SwiftGenerator::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
         {
             ostringstream msg;
             msg << "ignoring invalid metadata '" << *metadata << "' for dictionary value type";
-            dc->warning(InvalidMetadata, metadata->file(), metadata->line(), msg.str());
+            p->unit()->warning(metadata->file(), metadata->line(), InvalidMetadata, msg.str());
         }
     }
 
@@ -2470,9 +2468,6 @@ MetadataList
 SwiftGenerator::MetadataVisitor::validate(const SyntaxTreeBasePtr& p, const ContainedPtr& cont)
 {
     MetadataList newMetadata = cont->getMetadata();
-    const UnitPtr ut = p->unit();
-    const DefinitionContextPtr dc = ut->findDefinitionContext(cont->file());
-    assert(dc);
 
     for (MetadataList::const_iterator m = newMetadata.begin(); m != newMetadata.end();)
     {
@@ -2504,7 +2499,7 @@ SwiftGenerator::MetadataVisitor::validate(const SyntaxTreeBasePtr& p, const Cont
 
         ostringstream msg;
         msg << "ignoring invalid metadata '" << *meta << "'";
-        dc->warning(InvalidMetadata, meta->file(), meta->line(), msg.str());
+        p->unit()->warning(meta->file(), meta->line(), InvalidMetadata, msg.str());
         newMetadata.remove(meta);
         continue;
     }


### PR DESCRIPTION
This PR simplifies how warnings are reported by the parser and compilers.
Previously we had 2 warnings: one on `Unit` (think: a compilation run) and one on `DefinitionContext` (think: a file).

This is already asymetric, but was also a pain since then we had to look up the context using a file name... which was doubly weird since we _already_ had to pass in a file name to `warning` anyways... and sometimes these could differ.

----

This PR simplifies all this.
Now, all diagnostic reporting is handled by `Unit`. There are 2 functions for `error` and 2 functions for `warning`.
One pair takes an explicit file name/line number, the other doesn't (and automatically uses the parser's current position).
