### PR TITLE
Remove supportsAMD from Ice/ami test

### DIFF
--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -1075,7 +1075,7 @@ allTests(TestHelper* helper, bool collocated)
         }
         cout << "ok" << endl;
 
-        if (p->ice_getConnection() && protocol != "bt" && p->supportsAMD())
+        if (p->ice_getConnection() && protocol != "bt")
         {
             cout << "testing connection close... " << flush;
             {

--- a/cpp/test/Ice/ami/Test.ice
+++ b/cpp/test/Ice/ami/Test.ice
@@ -1,6 +1,4 @@
-//
-// Copyright (c) ZeroC, Inc. All rights reserved.
-//
+// Copyright (c) ZeroC, Inc.
 
 #pragma once
 
@@ -9,59 +7,54 @@
 
 module Test
 {
+    exception TestIntfException
+    {
+    }
 
-exception TestIntfException
-{
-}
+    interface PingReply
+    {
+        void reply();
+    }
 
-interface PingReply
-{
-    void reply();
-}
+    interface TestIntf
+    {
+        void op();
+        void opWithPayload(Ice::ByteSeq seq);
+        int opWithResult();
+        void opWithUE()
+            throws TestIntfException;
+        int opWithResultAndUE()
+            throws TestIntfException;
+        void opBatch();
 
-interface TestIntf
-{
-    void op();
-    void opWithPayload(Ice::ByteSeq seq);
-    int opWithResult();
-    void opWithUE()
-        throws TestIntfException;
-    int opWithResultAndUE()
-        throws TestIntfException;
-    void opBatch();
+        void opWithArgs(out int one, out int two, out int three, out int four, out int five, out int six, out int seven,
+                        out int eight, out int nine, out int ten, out int eleven);
+        int opBatchCount();
+        bool waitForBatch(int count);
+        void closeConnection();
+        void abortConnection();
+        void sleep(int ms);
+        ["amd"] void startDispatch();
+        void finishDispatch();
+        void shutdown();
 
-    void opWithArgs(out int one, out int two, out int three, out int four, out int five, out int six, out int seven,
-                    out int eight, out int nine, out int ten, out int eleven);
-    int opBatchCount();
-    bool waitForBatch(int count);
-    void closeConnection();
-    void abortConnection();
-    void sleep(int ms);
-    ["amd"] void startDispatch();
-    void finishDispatch();
-    void shutdown();
+        bool supportsFunctionalTests();
+        bool supportsBackPressureTests();
 
-    bool supportsAMD();
-    bool supportsFunctionalTests();
-    bool supportsBackPressureTests();
+        ["amd"] void pingBiDir(PingReply* reply);
+    }
 
-    ["amd"] void pingBiDir(PingReply* reply);
-}
+    interface TestIntfController
+    {
+        void holdAdapter();
+        void resumeAdapter();
+    }
 
-interface TestIntfController
-{
-    void holdAdapter();
-    void resumeAdapter();
-}
-
-module Outer::Inner
-{
-
-interface TestIntf
-{
-    int op(int i, out int j);
-}
-
-}
-
+    module Outer::Inner
+    {
+        interface TestIntf
+        {
+            int op(int i, out int j);
+        }
+    }
 }

--- a/cpp/test/Ice/ami/TestI.cpp
+++ b/cpp/test/Ice/ami/TestI.cpp
@@ -161,12 +161,6 @@ TestIntfI::shutdown(const Ice::Current& current)
 }
 
 bool
-TestIntfI::supportsAMD(const Ice::Current&)
-{
-    return true;
-}
-
-bool
 TestIntfI::supportsFunctionalTests(const Ice::Current&)
 {
     return false;

--- a/cpp/test/Ice/ami/TestI.h
+++ b/cpp/test/Ice/ami/TestI.h
@@ -44,7 +44,6 @@ public:
     void finishDispatch(const Ice::Current&) final;
     void shutdown(const Ice::Current&) final;
 
-    bool supportsAMD(const Ice::Current&) final;
     bool supportsFunctionalTests(const Ice::Current&) final;
     bool supportsBackPressureTests(const Ice::Current&) final;
 

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -690,7 +690,7 @@ namespace Ice
                     output.WriteLine("ok");
                 }
 
-                if (p.ice_getConnection() != null && p.supportsAMD())
+                if (p.ice_getConnection() != null)
                 {
                     output.Write("testing connection close... ");
                     output.Flush();

--- a/csharp/test/Ice/ami/Test.ice
+++ b/csharp/test/Ice/ami/Test.ice
@@ -1,6 +1,4 @@
-//
-// Copyright (c) ZeroC, Inc. All rights reserved.
-//
+// Copyright (c) ZeroC, Inc.
 
 #pragma once
 
@@ -10,60 +8,55 @@
 ["cs:namespace:Ice.ami"]
 module Test
 {
+    exception TestIntfException
+    {
+    }
 
-exception TestIntfException
-{
-}
+    interface PingReply
+    {
+        void reply();
+    }
 
-interface PingReply
-{
-    void reply();
-}
+    interface TestIntf
+    {
+        void op();
+        void opWithPayload(Ice::ByteSeq seq);
+        int opWithResult();
+        void opWithUE()
+            throws TestIntfException;
+        void opBatch();
+        int opBatchCount();
+        bool waitForBatch(int count);
 
-interface TestIntf
-{
-    void op();
-    void opWithPayload(Ice::ByteSeq seq);
-    int opWithResult();
-    void opWithUE()
-        throws TestIntfException;
-    void opBatch();
-    int opBatchCount();
-    bool waitForBatch(int count);
+        void closeConnection();
+        void abortConnection();
+        void sleep(int ms);
+        ["amd"] void startDispatch();
+        void finishDispatch();
+        void shutdown();
 
-    void closeConnection();
-    void abortConnection();
-    void sleep(int ms);
-    ["amd"] void startDispatch();
-    void finishDispatch();
-    void shutdown();
+        bool supportsFunctionalTests();
+        bool supportsBackPressureTests();
 
-    bool supportsAMD();
-    bool supportsFunctionalTests();
-    bool supportsBackPressureTests();
+        ["amd"] void opAsyncDispatch();
+        ["amd"] int opWithResultAsyncDispatch();
+        ["amd"] void opWithUEAsyncDispatch()
+            throws TestIntfException;
 
-    ["amd"] void opAsyncDispatch();
-    ["amd"] int opWithResultAsyncDispatch();
-    ["amd"] void opWithUEAsyncDispatch()
-        throws TestIntfException;
+        ["amd"] void pingBiDir(PingReply* reply);
+    }
 
-    ["amd"] void pingBiDir(PingReply* reply);
-}
+    interface TestIntfController
+    {
+        void holdAdapter();
+        void resumeAdapter();
+    }
 
-interface TestIntfController
-{
-    void holdAdapter();
-    void resumeAdapter();
-}
-
-module Outer::Inner
-{
-
-interface TestIntf
-{
-    int op(int i, out int j);
-}
-
-}
-
+    module Outer::Inner
+    {
+        interface TestIntf
+        {
+            int op(int i, out int j);
+        }
+    }
 }

--- a/csharp/test/Ice/ami/TestI.cs
+++ b/csharp/test/Ice/ami/TestI.cs
@@ -110,12 +110,6 @@ namespace Ice
             }
 
             public override bool
-            supportsAMD(Ice.Current current)
-            {
-                return true;
-            }
-
-            public override bool
             supportsFunctionalTests(Ice.Current current)
             {
                 return false;

--- a/java/test/src/main/java/test/Ice/ami/AllTests.java
+++ b/java/test/src/main/java/test/Ice/ami/AllTests.java
@@ -907,7 +907,7 @@ public class AllTests {
         }
         out.println("ok");
 
-        if (p.ice_getConnection() != null && p.supportsAMD() && !bluetooth) {
+        if (p.ice_getConnection() != null && !bluetooth) {
             out.print("testing connection close... ");
             out.flush();
             {

--- a/java/test/src/main/java/test/Ice/ami/Test.ice
+++ b/java/test/src/main/java/test/Ice/ami/Test.ice
@@ -1,6 +1,4 @@
-//
-// Copyright (c) ZeroC, Inc. All rights reserved.
-//
+// Copyright (c) ZeroC, Inc.
 
 #pragma once
 
@@ -10,62 +8,57 @@
 [["java:package:test.Ice.ami"]]
 module Test
 {
+    exception TestIntfException
+    {
+    }
 
-exception TestIntfException
-{
-}
+    interface PingReply
+    {
+        void reply();
+    }
 
-interface PingReply
-{
-    void reply();
-}
+    interface TestIntf
+    {
+        void op();
+        void opWithPayload(Ice::ByteSeq seq);
+        int opWithResult();
+        void opWithUE()
+            throws TestIntfException;
+        void opBatch();
+        int opBatchCount();
+        bool waitForBatch(int count);
+        void closeConnection();
+        void abortConnection();
+        void sleep(int ms);
+        ["amd"] void startDispatch();
+        void finishDispatch();
+        void shutdown();
 
-interface TestIntf
-{
-    void op();
-    void opWithPayload(Ice::ByteSeq seq);
-    int opWithResult();
-    void opWithUE()
-        throws TestIntfException;
-    void opBatch();
-    int opBatchCount();
-    bool waitForBatch(int count);
-    void closeConnection();
-    void abortConnection();
-    void sleep(int ms);
-    ["amd"] void startDispatch();
-    void finishDispatch();
-    void shutdown();
+        bool supportsFunctionalTests();
+        bool supportsBackPressureTests();
 
-    bool supportsAMD();
-    bool supportsFunctionalTests();
-    bool supportsBackPressureTests();
+        bool opBool(bool b);
+        byte opByte(byte b);
+        short opShort(short s);
+        int opInt(int i);
+        long opLong(long l);
+        float opFloat(float f);
+        double opDouble(double d);
 
-    bool opBool(bool b);
-    byte opByte(byte b);
-    short opShort(short s);
-    int opInt(int i);
-    long opLong(long l);
-    float opFloat(float f);
-    double opDouble(double d);
+        ["amd"] void pingBiDir(PingReply* reply);
+    }
 
-    ["amd"] void pingBiDir(PingReply* reply);
-}
+    interface TestIntfController
+    {
+        void holdAdapter();
+        void resumeAdapter();
+    }
 
-interface TestIntfController
-{
-    void holdAdapter();
-    void resumeAdapter();
-}
-
-module Outer::Inner
-{
-
-interface TestIntf
-{
-    int op(int i, out int j);
-}
-
-}
-
+    module Outer::Inner
+    {
+        interface TestIntf
+        {
+            int op(int i, out int j);
+        }
+    }
 }

--- a/java/test/src/main/java/test/Ice/ami/TestI.java
+++ b/java/test/src/main/java/test/Ice/ami/TestI.java
@@ -52,11 +52,6 @@ public class TestI implements TestIntf {
     }
 
     @Override
-    public boolean supportsAMD(com.zeroc.Ice.Current current) {
-        return true;
-    }
-
-    @Override
     public boolean supportsFunctionalTests(com.zeroc.Ice.Current current) {
         return true;
     }

--- a/js/test/Ice/ami/Test.ice
+++ b/js/test/Ice/ami/Test.ice
@@ -1,6 +1,4 @@
-//
-// Copyright (c) ZeroC, Inc. All rights reserved.
-//
+// Copyright (c) ZeroC, Inc.
 
 #pragma once
 
@@ -9,43 +7,40 @@
 
 module Test
 {
+    exception TestIntfException
+    {
+    }
 
-exception TestIntfException
-{
-}
+    interface PingReply
+    {
+        void reply();
+    }
 
-interface PingReply
-{
-    void reply();
-}
+    interface TestIntf
+    {
+        void op();
+        void opWithPayload(Ice::ByteSeq seq);
+        int opWithResult();
+        void opWithUE()
+            throws TestIntfException;
+        void opBatch();
+        int opBatchCount();
+        bool waitForBatch(int count);
+        void closeConnection();
+        void abortConnection();
+        void sleep(int ms);
+        ["amd"] void startDispatch();
+        void finishDispatch();
+        void shutdown();
 
-interface TestIntf
-{
-    void op();
-    void opWithPayload(Ice::ByteSeq seq);
-    int opWithResult();
-    void opWithUE()
-        throws TestIntfException;
-    void opBatch();
-    int opBatchCount();
-    bool waitForBatch(int count);
-    void closeConnection();
-    void abortConnection();
-    void sleep(int ms);
-    ["amd"] void startDispatch();
-    void finishDispatch();
-    void shutdown();
+        bool supportsFunctionalTests();
 
-    bool supportsAMD();
-    bool supportsFunctionalTests();
+        void pingBiDir(PingReply* reply);
+    }
 
-    void pingBiDir(PingReply* reply);
-}
-
-interface TestIntfController
-{
-    void holdAdapter();
-    void resumeAdapter();
-}
-
+    interface TestIntfController
+    {
+        void holdAdapter();
+        void resumeAdapter();
+    }
 }

--- a/matlab/test/Ice/ami/AllTests.m
+++ b/matlab/test/Ice/ami/AllTests.m
@@ -155,7 +155,7 @@ classdef AllTests
 
             fprintf('ok\n');
 
-            if ~isempty(p.ice_getConnection()) && p.supportsAMD()
+            if ~isempty(p.ice_getConnection())
                 fprintf('testing connection close... ');
 
                 %

--- a/matlab/test/Ice/ami/Test.ice
+++ b/matlab/test/Ice/ami/Test.ice
@@ -1,6 +1,4 @@
-//
-// Copyright (c) ZeroC, Inc. All rights reserved.
-//
+// Copyright (c) ZeroC, Inc.
 
 #pragma once
 
@@ -9,60 +7,55 @@
 
 module Test
 {
+    exception TestIntfException
+    {
+    }
 
-exception TestIntfException
-{
-}
+    interface PingReply
+    {
+        void reply();
+    }
 
-interface PingReply
-{
-    void reply();
-}
+    interface TestIntf
+    {
+        void op();
+        void opWithPayload(Ice::ByteSeq seq);
+        int opWithResult();
+        void opWithUE()
+            throws TestIntfException;
+        void opBatch();
+        int opBatchCount();
+        bool waitForBatch(int count);
+        void closeConnection();
+        void abortConnection();
+        void sleep(int ms);
+        ["amd"] void startDispatch();
+        void finishDispatch();
+        void shutdown();
 
-interface TestIntf
-{
-    void op();
-    void opWithPayload(Ice::ByteSeq seq);
-    int opWithResult();
-    void opWithUE()
-        throws TestIntfException;
-    void opBatch();
-    int opBatchCount();
-    bool waitForBatch(int count);
-    void closeConnection();
-    void abortConnection();
-    void sleep(int ms);
-    ["amd"] void startDispatch();
-    void finishDispatch();
-    void shutdown();
+        bool supportsFunctionalTests();
+        bool opBool(bool b);
+        byte opByte(byte b);
+        short opShort(short s);
+        int opInt(int i);
+        long opLong(long l);
+        float opFloat(float f);
+        double opDouble(double d);
 
-    bool supportsAMD();
-    bool supportsFunctionalTests();
-    bool opBool(bool b);
-    byte opByte(byte b);
-    short opShort(short s);
-    int opInt(int i);
-    long opLong(long l);
-    float opFloat(float f);
-    double opDouble(double d);
+        void pingBiDir(PingReply* reply);
+    }
 
-    void pingBiDir(PingReply* reply);
-}
+    interface TestIntfController
+    {
+        void holdAdapter();
+        void resumeAdapter();
+    }
 
-interface TestIntfController
-{
-    void holdAdapter();
-    void resumeAdapter();
-}
-
-module Outer::Inner
-{
-
-interface TestIntf
-{
-    int op(int i, out int j);
-}
-
-}
-
+    module Outer::Inner
+    {
+        interface TestIntf
+        {
+            int op(int i, out int j);
+        }
+    }
 }

--- a/python/test/Ice/ami/AllTests.py
+++ b/python/test/Ice/ami/AllTests.py
@@ -419,7 +419,7 @@ class Thrower(CallbackBase):
 def allTests(helper, communicator, collocated):
     p = Test.TestIntfPrx(communicator, f"test:{helper.getTestEndpoint(num=0)}")
 
-    if p.ice_getConnection() and p.supportsAMD():
+    if p.ice_getConnection():
         sys.stdout.write("testing close connection... ")
         sys.stdout.flush()
 

--- a/python/test/Ice/ami/Test.ice
+++ b/python/test/Ice/ami/Test.ice
@@ -1,6 +1,4 @@
-//
-// Copyright (c) ZeroC, Inc. All rights reserved.
-//
+// Copyright (c) ZeroC, Inc.
 
 #pragma once
 
@@ -9,54 +7,49 @@
 
 module Test
 {
+    exception TestIntfException
+    {
+    }
 
-exception TestIntfException
-{
-}
+    interface PingReply
+    {
+        void reply();
+    }
 
-interface PingReply
-{
-    void reply();
-}
+    interface TestIntf
+    {
+        void op();
+        void opWithPayload(Ice::ByteSeq seq);
+        int opWithResult();
+        void opWithUE()
+            throws TestIntfException;
+        void opBatch();
+        int opBatchCount();
+        bool waitForBatch(int count);
+        void closeConnection();
+        void abortConnection();
+        void sleep(int ms);
+        ["amd"] void startDispatch();
+        void finishDispatch();
+        void shutdown();
 
-interface TestIntf
-{
-    void op();
-    void opWithPayload(Ice::ByteSeq seq);
-    int opWithResult();
-    void opWithUE()
-        throws TestIntfException;
-    void opBatch();
-    int opBatchCount();
-    bool waitForBatch(int count);
-    void closeConnection();
-    void abortConnection();
-    void sleep(int ms);
-    ["amd"] void startDispatch();
-    void finishDispatch();
-    void shutdown();
+        bool supportsFunctionalTests();
+        bool supportsBackPressureTests();
 
-    bool supportsAMD();
-    bool supportsFunctionalTests();
-    bool supportsBackPressureTests();
+        ["amd"] void pingBiDir(PingReply* reply);
+    }
 
-    ["amd"] void pingBiDir(PingReply* reply);
-}
+    interface TestIntfController
+    {
+        void holdAdapter();
+        void resumeAdapter();
+    }
 
-interface TestIntfController
-{
-    void holdAdapter();
-    void resumeAdapter();
-}
-
-module Outer::Inner
-{
-
-interface TestIntf
-{
-    int op(int i, out int j);
-}
-
-}
-
+    module Outer::Inner
+    {
+        interface TestIntf
+        {
+            int op(int i, out int j);
+        }
+    }
 }

--- a/python/test/Ice/ami/TestI.py
+++ b/python/test/Ice/ami/TestI.py
@@ -84,9 +84,6 @@ class TestIntfI(Test.TestIntf):
                 self._pending = None
             current.adapter.getCommunicator().shutdown()
 
-    def supportsAMD(self, current):
-        return True
-
     def supportsFunctionalTests(self, current):
         return False
 

--- a/swift/test/Ice/ami/AllTests.swift
+++ b/swift/test/Ice/ami/AllTests.swift
@@ -250,7 +250,7 @@ func allTests(_ helper: TestHelper, collocated: Bool = false) async throws {
         output.writeLine("ok")
     }
 
-    if try await p.ice_getConnection() != nil, try await p.supportsAMD() {
+    if try await p.ice_getConnection() != nil {
         output.write("testing connection close... ")
         do {
             //

--- a/swift/test/Ice/ami/Test.ice
+++ b/swift/test/Ice/ami/Test.ice
@@ -1,4 +1,5 @@
 // Copyright (c) ZeroC, Inc.
+
 #pragma once
 
 #include "Ice/BuiltinSequences.ice"
@@ -6,59 +7,54 @@
 
 module Test
 {
+    exception TestIntfException
+    {
+    }
 
-exception TestIntfException
-{
-}
+    interface PingReply
+    {
+        void reply();
+    }
 
-interface PingReply
-{
-    void reply();
-}
+    interface TestIntf
+    {
+        void op();
+        void opWithPayload(Ice::ByteSeq seq);
+        int opWithResult();
+        void opWithUE()
+            throws TestIntfException;
+        int opWithResultAndUE()
+            throws TestIntfException;
+        void opBatch();
 
-interface TestIntf
-{
-    void op();
-    void opWithPayload(Ice::ByteSeq seq);
-    int opWithResult();
-    void opWithUE()
-        throws TestIntfException;
-    int opWithResultAndUE()
-        throws TestIntfException;
-    void opBatch();
+        void opWithArgs(out int one, out int two, out int three, out int four, out int five, out int six, out int seven,
+                        out int eight, out int nine, out int ten, out int eleven);
+        int opBatchCount();
+        bool waitForBatch(int count);
+        void closeConnection();
+        void abortConnection();
+        void sleep(int ms);
+        ["amd"] void startDispatch();
+        void finishDispatch();
+        void shutdown();
 
-    void opWithArgs(out int one, out int two, out int three, out int four, out int five, out int six, out int seven,
-                    out int eight, out int nine, out int ten, out int eleven);
-    int opBatchCount();
-    bool waitForBatch(int count);
-    void closeConnection();
-    void abortConnection();
-    void sleep(int ms);
-    ["amd"] void startDispatch();
-    void finishDispatch();
-    void shutdown();
+        bool supportsFunctionalTests();
+        bool supportsBackPressureTests();
 
-    bool supportsAMD();
-    bool supportsFunctionalTests();
-    bool supportsBackPressureTests();
+        void pingBiDir(PingReply* reply);
+    }
 
-    void pingBiDir(PingReply* reply);
-}
+    interface TestIntfController
+    {
+        void holdAdapter();
+        void resumeAdapter();
+    }
 
-interface TestIntfController
-{
-    void holdAdapter();
-    void resumeAdapter();
-}
-
-module Outer::Inner
-{
-
-interface TestIntf
-{
-    int op(int i, out int j);
-}
-
-}
-
+    module Outer::Inner
+    {
+        interface TestIntf
+        {
+            int op(int i, out int j);
+        }
+    }
 }

--- a/swift/test/Ice/ami/TestI.swift
+++ b/swift/test/Ice/ami/TestI.swift
@@ -170,10 +170,6 @@ class TestI: TestIntf {
         current.adapter.getCommunicator().shutdown()
     }
 
-    func supportsAMD(current _: Current) async throws -> Bool {
-        return true
-    }
-
     func supportsFunctionalTests(current _: Current) async throws -> Bool {
         return false
     }


### PR DESCRIPTION
This is a cleanup of the Ice/ami Test.ice file + removal of the supportsAMD operation. All implementations were returning true.