### PR TITLE
FileLogger exception fixes

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/FileLoggerI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/FileLoggerI.java
@@ -9,13 +9,13 @@ final class FileLoggerI extends LoggerI {
         super(prefix);
 
         if (file.isEmpty()) {
-            throw new InitializationException("FileLogger: file name is empty");
+            throw new FileException("FileLogger: file name is empty");
         }
 
         try {
             _out = new java.io.FileOutputStream(new java.io.File(file), true);
         } catch (java.io.FileNotFoundException ex) {
-            throw new InitializationException("FileLogger: cannot open " + file);
+            throw new FileException("FileLogger: cannot open '" + file + "': file not found", ex);
         }
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -934,7 +934,7 @@ public final class Instance implements java.util.function.Function<String, Class
             } else {
                 _cacheMessageBuffers = properties.getIcePropertyAsInt("Ice.CacheMessageBuffers");
             }
-        } catch (LocalException ex) {
+        } catch (Exception ex) {
             destroy(false);
             throw ex;
         }


### PR DESCRIPTION
Updates FileLoggerI to throw `FileException` instead of `InitializationException` and improves the error message. 

We were already throwing `FileException` in `initialize` for file related things. I didn't add catch for SecurityException because it is a `RunTimeException`, however I did update initialize to catch Java `Exception` instead of just our `LocalException.

Closes #2892