### PR TITLE
Additional WS connection tracing

### DIFF
--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -218,6 +218,12 @@ IceInternal::WSTransceiver::initialize(Buffer& readBuffer, Buffer& writeBuffer)
             }
             assert(_writeBuffer.i == _writeBuffer.b.end());
             _state = StateUpgradeResponsePending;
+
+            if (_instance->traceLevel() >= 1)
+            {
+                Trace out(_instance->logger(), _instance->traceCategory());
+                out << "sent " << protocol() << " connection HTTP upgrade request\n" << toString();
+            }
         }
 
         while (true)

--- a/csharp/src/Ice/Internal/WSTransceiver.cs
+++ b/csharp/src/Ice/Internal/WSTransceiver.cs
@@ -91,6 +91,13 @@ internal sealed class WSTransceiver : Transceiver
                 }
                 Debug.Assert(!_writeBuffer.b.hasRemaining());
                 _state = StateUpgradeResponsePending;
+
+                if (_instance.traceLevel() >= 1)
+                {
+                    _instance.logger().trace(
+                        _instance.traceCategory(),
+                        "sent " + protocol() + " connection HTTP upgrade request\n" + ToString());
+                }
             }
 
             while (true)

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSTransceiver.java
@@ -88,6 +88,17 @@ final class WSTransceiver implements Transceiver {
                 }
                 assert (!_writeBuffer.b.hasRemaining());
                 _state = StateUpgradeResponsePending;
+
+                if (_instance.traceLevel() >= 1) {
+                    _instance
+                            .logger()
+                            .trace(
+                                    _instance.traceCategory(),
+                                    "sent "
+                                            + protocol()
+                                            + " connection HTTP upgrade request\n"
+                                            + toString());
+                }
             }
 
             while (true) {


### PR DESCRIPTION
This PR adds more tracing to the WS transport (C++, C#, Java).

For example:
```
-- 11/04/24 16:50:18554 /Users/bernard/builds/ice/cpp/test/Ice/timeout/build/macosx/shared/client: Network: trying to establish ws connection to 127.0.0.1:12010
-- 11/04/24 16:50:18554 /Users/bernard/builds/ice/cpp/test/Ice/timeout/build/macosx/shared/client: Network: sent ws connection HTTP upgrade request
   local address = 127.0.0.1:50855
   remote address = 127.0.0.1:12010
-- 11/04/24 16:50:19555 /Users/bernard/builds/ice/cpp/test/Ice/timeout/build/macosx/shared/client: Network: failed to establish ws connection
   local address = 127.0.0.1:50855
   remote address = 127.0.0.1:12010
   connection establishment timed out
```

The "sent ws connection HTTP upgrade request" is new.

This could help understand #3048.
