### PR TITLE
Do not disable warn connections in Ice/timeout test

### DIFF
--- a/cpp/test/Ice/timeout/Client.cpp
+++ b/cpp/test/Ice/timeout/Client.cpp
@@ -29,11 +29,6 @@ Client::run(int argc, char** argv)
     properties->setProperty("Ice.Connection.Client.CloseTimeout", "1");
 
     //
-    // This test kills connections, so we don't want warnings.
-    //
-    properties->setProperty("Ice.Warn.Connections", "0");
-
-    //
     // Limit the send buffer size, this test relies on the socket
     // send() blocking after sending a given amount of data.
     //

--- a/cpp/test/Ice/timeout/Server.cpp
+++ b/cpp/test/Ice/timeout/Server.cpp
@@ -19,19 +19,6 @@ Server::run(int argc, char** argv)
 {
     Ice::PropertiesPtr properties = createTestProperties(argc, argv);
 
-#if TARGET_OS_IPHONE != 0
-    //
-    // COMPILERFIX: Disable connect timeout introduced for
-    // workaround to iOS device hangs when using SSL
-    //
-    // properties->setProperty("Ice.Override.ConnectTimeout", "");
-#endif
-
-    //
-    // This test kills connections, so we don't want warnings.
-    //
-    properties->setProperty("Ice.Warn.Connections", "0");
-
     //
     // The client sends large messages to cause the transport
     // buffers to fill up.

--- a/csharp/test/Ice/timeout/Client.cs
+++ b/csharp/test/Ice/timeout/Client.cs
@@ -16,11 +16,6 @@ namespace Ice.timeout
             properties.setProperty("Ice.Connection.Client.ConnectTimeout", "1");
             properties.setProperty("Ice.Connection.Client.CloseTimeout", "1");
 
-            //
-            // This test kills connections, so we don't want warnings.
-            //
-            properties.setProperty("Ice.Warn.Connections", "0");
-
             using var communicator = initialize(properties);
             await AllTests.allTests(this);
         }

--- a/csharp/test/Ice/timeout/Server.cs
+++ b/csharp/test/Ice/timeout/Server.cs
@@ -7,10 +7,6 @@ namespace Ice.timeout
         public override void run(string[] args)
         {
             var properties = createTestProperties(ref args);
-            //
-            // This test kills connections, so we don't want warnings.
-            //
-            properties.setProperty("Ice.Warn.Connections", "0");
 
             using (var communicator = initialize(properties))
             {

--- a/java/test/src/main/java/test/Ice/timeout/Client.java
+++ b/java/test/src/main/java/test/Ice/timeout/Client.java
@@ -18,11 +18,6 @@ public class Client extends test.TestHelper {
         properties.setProperty("Ice.Connection.Client.ConnectTimeout", "1");
         properties.setProperty("Ice.Connection.Client.CloseTimeout", "1");
 
-        //
-        // This test kills connections, so we don't want warnings.
-        //
-        properties.setProperty("Ice.Warn.Connections", "0");
-
         try (com.zeroc.Ice.Communicator communicator = initialize(properties)) {
             AllTests.allTests(this);
         }

--- a/java/test/src/main/java/test/Ice/timeout/Server.java
+++ b/java/test/src/main/java/test/Ice/timeout/Server.java
@@ -8,10 +8,6 @@ public class Server extends test.TestHelper {
     public void run(String[] args) {
         com.zeroc.Ice.Properties properties = createTestProperties(args);
         properties.setProperty("Ice.Package.Test", "test.Ice.timeout");
-        //
-        // This test kills connections, so we don't want warnings.
-        //
-        properties.setProperty("Ice.Warn.Connections", "0");
 
         try (com.zeroc.Ice.Communicator communicator = initialize(properties)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));

--- a/js/test/Ice/timeout/Client.ts
+++ b/js/test/Ice/timeout/Client.ts
@@ -128,11 +128,6 @@ export class Client extends TestHelper {
             properties.setProperty("Ice.Connection.Client.ConnectTimeout", "1");
             properties.setProperty("Ice.Connection.Client.CloseTimeout", "1");
 
-            //
-            // We don't want connection warnings because of the timeout
-            //
-            properties.setProperty("Ice.Warn.Connections", "0");
-
             [communicator] = this.initialize(properties);
             await this.allTests();
         } finally {

--- a/matlab/test/Ice/timeout/Client.m
+++ b/matlab/test/Ice/timeout/Client.m
@@ -17,11 +17,6 @@ function client(args)
     properties.setProperty('Ice.RetryIntervals', '-1');
 
     %
-    % This test kills connections, so we don't want warnings.
-    %
-    properties.setProperty('Ice.Warn.Connections', '0');
-
-    %
     % Limit the send buffer size, this test relies on the socket
     % send() blocking after sending a given amount of data.
     %

--- a/php/test/Ice/timeout/Client.php
+++ b/php/test/Ice/timeout/Client.php
@@ -99,11 +99,6 @@ class Client extends TestHelper
             $properties->setProperty("Ice.RetryIntervals", "-1");
 
             //
-            // This test kills connections, so we don't want warnings.
-            //
-            $properties->setProperty("Ice.Warn.Connections", "0");
-
-            //
             // Limit the send buffer size, this test relies on the socket
             // send() blocking after sending a given amount of data.
             //

--- a/python/test/Ice/timeout/Client.py
+++ b/python/test/Ice/timeout/Client.py
@@ -23,11 +23,6 @@ class Client(TestHelper):
         properties.setProperty("Ice.RetryIntervals", "-1")
 
         #
-        # This test kills connections, so we don't want warnings.
-        #
-        properties.setProperty("Ice.Warn.Connections", "0")
-
-        #
         # Limit the send buffer size, this test relies on the socket
         # send() blocking after sending a given amount of data.
         #

--- a/python/test/Ice/timeout/Server.py
+++ b/python/test/Ice/timeout/Server.py
@@ -55,7 +55,6 @@ class ControllerI(Test.Controller):
 class Server(TestHelper):
     def run(self, args):
         properties = self.createTestProperties(args)
-        properties.setProperty("Ice.Warn.Connections", "0")
 
         #
         # The client sends large messages to cause the transport

--- a/ruby/test/Ice/timeout/Client.rb
+++ b/ruby/test/Ice/timeout/Client.rb
@@ -21,11 +21,6 @@ class Client < ::TestHelper
         properties.setProperty('Ice.RetryIntervals', '-1')
 
         #
-        # This test kills connections, so we don't want warnings.
-        #
-        properties.setProperty('Ice.Warn.Connections', '0')
-
-        #
         # Limit the send buffer size, this test relies on the socket
         # send() blocking after sending a given amount of data.
         #

--- a/swift/test/Ice/timeout/Server.swift
+++ b/swift/test/Ice/timeout/Server.swift
@@ -8,11 +8,6 @@ class Server: TestHelperI {
         let properties = try createTestProperties(args)
 
         //
-        // This test kills connections, so we don't want warnings.
-        //
-        properties.setProperty(key: "Ice.Warn.Connections", value: "0")
-
-        //
         // The client sends large messages to cause the transport
         // buffers to fill up.
         //


### PR DESCRIPTION
This PR removes the disabling of connection warnings in Ice/timeout test. If there is a test failure like in #3048 the exceptions can be relevant to find the issue.