### PR TITLE
Add connection info to Protocol tracing in C#

### DIFF
--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1843,7 +1843,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                     _writeStream.writeByte(Protocol.validateConnectionMsg);
                     _writeStream.writeByte(0); // Compression status (always zero for validate connection).
                     _writeStream.writeInt(Protocol.headerSize); // Message size.
-                    TraceUtil.traceSend(_writeStream, _instance, _logger, _traceLevels);
+                    TraceUtil.traceSend(_writeStream, _instance, this, _logger, _traceLevels);
                     _writeStream.prepareWrite();
                 }
 
@@ -1932,7 +1932,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                 {
                     throw new MarshalException($"Received ValidateConnection message with unexpected size {size}.");
                 }
-                TraceUtil.traceRecv(_readStream, _logger, _traceLevels);
+                TraceUtil.traceRecv(_readStream, this, _logger, _traceLevels);
             }
         }
 
@@ -2047,7 +2047,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                 message.stream.prepareWrite();
                 message.prepared = true;
 
-                TraceUtil.traceSend(stream, _instance, _logger, _traceLevels);
+                TraceUtil.traceSend(stream, _instance, this, _logger, _traceLevels);
 
                 //
                 // Send the message.
@@ -2118,7 +2118,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
         message.stream.prepareWrite();
         message.prepared = true;
 
-        TraceUtil.traceSend(stream, _instance, _logger, _traceLevels);
+        TraceUtil.traceSend(stream, _instance, this, _logger, _traceLevels);
 
         // Send the message without blocking.
         if (_observer is not null)
@@ -2252,7 +2252,8 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                 }
                 else
                 {
-                    throw new FeatureNotSupportedException("Cannot decompress compressed message: BZip2 library is not loaded.");
+                    throw new FeatureNotSupportedException(
+                        "Cannot decompress compressed message: BZip2 library is not loaded.");
                 }
             }
             info.stream.pos(Protocol.headerSize);
@@ -2261,7 +2262,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
             {
                 case Protocol.closeConnectionMsg:
                 {
-                    TraceUtil.traceRecv(info.stream, _logger, _traceLevels);
+                    TraceUtil.traceRecv(info.stream, this, _logger, _traceLevels);
                     if (_endpoint.datagram())
                     {
                         if (_warn)
@@ -2294,12 +2295,13 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                         TraceUtil.trace(
                             "received request during closing\n(ignored by server, client will retry)",
                             info.stream,
+                            this,
                             _logger,
                             _traceLevels);
                     }
                     else
                     {
-                        TraceUtil.traceRecv(info.stream, _logger, _traceLevels);
+                        TraceUtil.traceRecv(info.stream, this, _logger, _traceLevels);
                         info.requestId = info.stream.readInt();
                         info.requestCount = 1;
                         info.adapter = _adapter;
@@ -2318,12 +2320,13 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                         TraceUtil.trace(
                             "received batch request during closing\n(ignored by server, client will retry)",
                             info.stream,
+                            this,
                             _logger,
                             _traceLevels);
                     }
                     else
                     {
-                        TraceUtil.traceRecv(info.stream, _logger, _traceLevels);
+                        TraceUtil.traceRecv(info.stream, this, _logger, _traceLevels);
                         int requestCount = info.stream.readInt();
                         if (requestCount < 0)
                         {
@@ -2341,7 +2344,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
 
                 case Protocol.replyMsg:
                 {
-                    TraceUtil.traceRecv(info.stream, _logger, _traceLevels);
+                    TraceUtil.traceRecv(info.stream, this, _logger, _traceLevels);
                     info.requestId = info.stream.readInt();
                     if (_asyncRequests.TryGetValue(info.requestId, out info.outAsync))
                     {
@@ -2377,7 +2380,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
 
                 case Protocol.validateConnectionMsg:
                 {
-                    TraceUtil.traceRecv(info.stream, _logger, _traceLevels);
+                    TraceUtil.traceRecv(info.stream, this, _logger, _traceLevels);
                     break;
                 }
 
@@ -2386,6 +2389,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                     TraceUtil.trace(
                         "received unknown message\n(invalid, closing connection)",
                         info.stream,
+                        this,
                         _logger,
                         _traceLevels);
 

--- a/csharp/src/Ice/Internal/CollocatedRequestHandler.cs
+++ b/csharp/src/Ice/Internal/CollocatedRequestHandler.cs
@@ -163,7 +163,7 @@ public class CollocatedRequestHandler : RequestHandler
             {
                 fillInValue(os, Protocol.headerSize, requestCount);
             }
-            TraceUtil.traceSend(os, _reference.getInstance(), _logger, _traceLevels);
+            TraceUtil.traceSend(os, _reference.getInstance(), connection: null, _logger, _traceLevels);
         }
 
         Ice.InputStream iss = new Ice.InputStream(_reference.getInstance(), os.getEncoding(), os.getBuffer(), false);
@@ -264,7 +264,7 @@ public class CollocatedRequestHandler : RequestHandler
 
                 if (_traceLevels.protocol >= 1)
                 {
-                    TraceUtil.traceRecv(inputStream, _logger, _traceLevels);
+                    TraceUtil.traceRecv(inputStream, connection: null, _logger, _traceLevels);
                 }
 
                 if (_asyncRequests.TryGetValue(requestId, out outAsync))


### PR DESCRIPTION
This PR adds connection info to protocol tracing in C#.

Without this information, it's hard to understand the protocol tracing unless you have a single connection or you turn on network tracing at level 2 or higher and somehow correlate the network and protocol traces.

Since the protocol traces include the request ID, the connection is necessarily known. I didn't add any tracing for colloc.

If this PR is approved, I'll port this change to the other language mappings.

Typical server:
```
-- 11/4/2024 17:50:44:977 server: Protocol: received request 
   message type = 0 (request)
   compression status = 0 (not compressed; do not compress response, if any)
   message size = 56
   request id = 2
   identity = test
   facet = 
   operation = opByteSOnewayCallCount
   mode = 0 (normal)
   context = 
   encoding = 1.1
   transport = tcp
   local address = 127.0.0.1:12010
   remote address = 127.0.0.1:51425
-- 11/4/2024 17:50:44:977 server: Protocol: sending reply 
   message type = 2 (reply)
   compression status = 0 (not compressed; do not compress response, if any)
   message size = 29
   request id = 2
   reply status = 0 (ok)
   encoding = 1.1
   transport = tcp
   local address = 127.0.0.1:12010
   remote address = 127.0.0.1:51425
-- 11/4/2024 17:50:44:988 server: Protocol: received batch request 
   message type = 1 (batch request)
   compression status = 0 (not compressed; do not compress response, if any)
   message size = 42
   number of requests = 1
   request #0:
   identity = test
   facet = 
   operation = ice_ping
   mode = 2 (idempotent)
   context = 
   encoding = 1.1
   transport = tcp
   local address = 127.0.0.1:12010
   remote address = 127.0.0.1:51425
```

Typical client:
```
-- 11/4/2024 17:50:44:989 client: Protocol: received validate connection 
   message type = 3 (validate connection)
   compression status = 0 (not compressed; do not compress response, if any)
   message size = 14
   transport = tcp
   local address = 127.0.0.1:51426
   remote address = 127.0.0.1:12010
-- 11/4/2024 17:50:44:989 client: Protocol: sending batch request 
   message type = 1 (batch request)
   compression status = 0 (not compressed; do not compress response, if any)
   message size = 45
   number of requests = 1
   request #0:
   identity = invalid
   facet = 
   operation = ice_ping
   mode = 2 (idempotent)
   context = 
   encoding = 1.1
   transport = tcp
   local address = 127.0.0.1:51426
   remote address = 127.0.0.1:12010
```