### PR TITLE
Remove remaining Ice.Override.ConnectTimeout

### DIFF
--- a/cpp/test/Ice/timeout/Server.cpp
+++ b/cpp/test/Ice/timeout/Server.cpp
@@ -19,14 +19,6 @@ Server::run(int argc, char** argv)
 {
     Ice::PropertiesPtr properties = createTestProperties(argc, argv);
 
-#if TARGET_OS_IPHONE != 0
-    //
-    // COMPILERFIX: Disable connect timeout introduced for
-    // workaround to iOS device hangs when using SSL
-    //
-    // properties->setProperty("Ice.Override.ConnectTimeout", "");
-#endif
-
     //
     // This test kills connections, so we don't want warnings.
     //

--- a/java/test/android/controller/src/main/java/com/zeroc/testcontroller/ControllerApp.java
+++ b/java/test/android/controller/src/main/java/com/zeroc/testcontroller/ControllerApp.java
@@ -197,7 +197,6 @@ public class ControllerApp extends Application
             initData.properties.setProperty("Ice.ThreadPool.Server.SizeMax", "10");
             initData.properties.setProperty("ControllerAdapter.Endpoints", "tcp");
             initData.properties.setProperty("ControllerAdapter.AdapterId", java.util.UUID.randomUUID().toString());
-            initData.properties.setProperty("Ice.Override.ConnectTimeout", "1000");
             if(!isEmulator())
             {
                 if(bluetooth)

--- a/java/test/src/main/java/test/Ice/binding/AllTests.java
+++ b/java/test/src/main/java/test/Ice/binding/AllTests.java
@@ -75,10 +75,6 @@ public class AllTests {
                 // Usually the actual type of this exception is ConnectionRefusedException,
                 // but not always. See bug 3179.
                 //
-            } catch (com.zeroc.Ice.ConnectTimeoutException ex) {
-                //
-                // On Windows, we set Ice.Override.ConnectTimeout to speed up testing.
-                //
             }
         }
         out.println("ok");
@@ -409,10 +405,6 @@ public class AllTests {
                 // Usually the actual type of this exception is ConnectionRefusedException,
                 // but not always. See bug 3179.
                 //
-            } catch (com.zeroc.Ice.ConnectTimeoutException ex) {
-                //
-                // On Windows, we set Ice.Override.ConnectTimeout to speed up testing.
-                //
             }
 
             Endpoint[] endpoints = test.ice_getEndpoints();
@@ -466,10 +458,6 @@ public class AllTests {
                 //
                 // Usually the actual type of this exception is ConnectionRefusedException,
                 // but not always. See bug 3179.
-                //
-            } catch (com.zeroc.Ice.ConnectTimeoutException ex) {
-                //
-                // On Windows, we set Ice.Override.ConnectTimeout to speed up testing.
                 //
             }
         }
@@ -585,10 +573,6 @@ public class AllTests {
                 // Usually the actual type of this exception is ConnectionRefusedException,
                 // but not always. See bug 3179.
                 //
-            } catch (com.zeroc.Ice.ConnectTimeoutException ex) {
-                //
-                // On Windows, we set Ice.Override.ConnectTimeout to speed up testing.
-                //
             }
 
             Endpoint[] endpoints = test.ice_getEndpoints();
@@ -655,10 +639,6 @@ public class AllTests {
                 //
                 // Usually the actual type of this exception is ConnectionRefusedException,
                 // but not always. See bug 3179.
-                //
-            } catch (com.zeroc.Ice.ConnectTimeoutException ex) {
-                //
-                // On Windows, we set Ice.Override.ConnectTimeout to speed up testing.
                 //
             }
 
@@ -752,10 +732,6 @@ public class AllTests {
                     //
                     // Usually the actual type of this exception is ConnectionRefusedException,
                     // but not always. See bug 3179.
-                    //
-                } catch (com.zeroc.Ice.ConnectTimeoutException ex) {
-                    //
-                    // On Windows, we set Ice.Override.ConnectTimeout to speed up testing.
                     //
                 }
 

--- a/js/test/Common/ControllerI.js
+++ b/js/test/Common/ControllerI.js
@@ -154,7 +154,6 @@ export async function runController(clientOutput, serverOutput, scripts) {
     const initData = new Ice.InitializationData();
     initData.logger = new Logger(out);
     initData.properties = Ice.createProperties();
-    initData.properties.setProperty("Ice.Override.ConnectTimeout", "1000");
 
     async function registerProcessController(adapter, registry, processController) {
         try {

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -883,21 +883,6 @@ class Mapping(object):
                     props["IceMX.Metrics.Parent.GroupBy"] = "parent"
                     props["IceMX.Metrics.All.GroupBy"] = "none"
 
-                #
-                # Speed up Windows testing. We override the connect timeout for some tests which are
-                # establishing connections to inactive ports. It takes around 1s for such connection
-                # establishment to fail on Windows.
-                #
-                # if isinstance(platform, Windows):
-                #     if current.testsuite.getId().startswith("IceGrid") or \
-                #         current.testsuite.getId() in ["Ice/binding",
-                #                                       "Ice/location",
-                #                                       "Ice/background",
-                #                                       "Ice/faultTolerance",
-                #                                       "Ice/services",
-                #                                       "IceDiscovery/simple"]:
-                #         props["Ice.Override.ConnectTimeout"] = "400"
-
                 # Additional properties specified on the command line with --cprops or --sprops
                 additionalProps = []
                 if self.cprops and isinstance(process, Client):


### PR DESCRIPTION
This property no longer exists but we still reference it in a few places.