### PR TITLE
Add connection info to Protocol tracing

### DIFF
--- a/cpp/src/Ice/CollocatedRequestHandler.cpp
+++ b/cpp/src/Ice/CollocatedRequestHandler.cpp
@@ -133,7 +133,7 @@ CollocatedRequestHandler::invokeAsyncRequest(OutgoingAsyncBase* outAsync, int ba
         {
             fillInValue(os, headerSize, batchRequestCount);
         }
-        traceSend(*os, _reference->getInstance(), _logger, _traceLevels);
+        traceSend(*os, _reference->getInstance(), nullptr, _logger, _traceLevels);
     }
 
     outAsync->attachCollocatedObserver(_adapter, requestId);
@@ -337,7 +337,7 @@ CollocatedRequestHandler::sendResponse(OutgoingResponse response)
 
                 if (_traceLevels->protocol >= 1)
                 {
-                    traceRecv(is, _logger, _traceLevels);
+                    traceRecv(is, nullptr, _logger, _traceLevels);
                 }
 
                 map<int, OutgoingAsyncBasePtr>::iterator q = _asyncRequests.find(response.current().requestId);

--- a/cpp/src/Ice/TraceUtil.cpp
+++ b/cpp/src/Ice/TraceUtil.cpp
@@ -374,6 +374,9 @@ printMessage(ostream& s, InputStream& stream, const ConnectionI* connection)
     if (connection)
     {
         s << "\ntransport = " << connection->type() << '\n';
+
+        // We can't get connectionInfo here: it results in a self-deadlock since this code is often executed with the
+        // non-recursive connection mutex locked.
         const string& connectionId = connection->endpoint()->connectionId();
         if (!connectionId.empty())
         {

--- a/cpp/src/Ice/TraceUtil.cpp
+++ b/cpp/src/Ice/TraceUtil.cpp
@@ -3,6 +3,8 @@
 //
 
 #include "TraceUtil.h"
+#include "ConnectionI.h"
+#include "EndpointI.h"
 #include "Ice/InputStream.h"
 #include "Ice/Logger.h"
 #include "Ice/Object.h"
@@ -332,7 +334,7 @@ printReply(ostream& s, InputStream& stream)
 }
 
 static uint8_t
-printMessage(ostream& s, InputStream& stream)
+printMessage(ostream& s, InputStream& stream, const ConnectionI* connection)
 {
     uint8_t type = printHeader(s, stream);
 
@@ -369,6 +371,17 @@ printMessage(ostream& s, InputStream& stream)
         }
     }
 
+    if (connection)
+    {
+        s << "\ntransport = " << connection->type() << '\n';
+        const string& connectionId = connection->endpoint()->connectionId();
+        if (!connectionId.empty())
+        {
+            s << "connection ID = " << connectionId << '\n';
+        }
+        s << connection->toString();
+    }
+
     return type;
 }
 
@@ -397,6 +410,7 @@ void
 IceInternal::traceSend(
     const OutputStream& str,
     const InstancePtr& instance,
+    const ConnectionI* connection,
     const LoggerPtr& logger,
     const TraceLevelsPtr& tl)
 {
@@ -407,14 +421,18 @@ IceInternal::traceSend(
         is.i = is.b.begin();
 
         ostringstream s;
-        uint8_t type = printMessage(s, is);
+        uint8_t type = printMessage(s, is, connection);
 
         logger->trace(tl->protocolCat, "sending " + getMessageTypeAsString(type) + " " + s.str());
     }
 }
 
 void
-IceInternal::traceRecv(const InputStream& str, const LoggerPtr& logger, const TraceLevelsPtr& tl)
+IceInternal::traceRecv(
+    const InputStream& str,
+    const ConnectionI* connection,
+    const LoggerPtr& logger,
+    const TraceLevelsPtr& tl)
 {
     if (tl->protocol >= 1)
     {
@@ -423,7 +441,7 @@ IceInternal::traceRecv(const InputStream& str, const LoggerPtr& logger, const Tr
         stream.i = stream.b.begin();
 
         ostringstream s;
-        uint8_t type = printMessage(s, stream);
+        uint8_t type = printMessage(s, stream, connection);
 
         logger->trace(tl->protocolCat, "received " + getMessageTypeAsString(type) + " " + s.str());
         stream.i = p;
@@ -431,7 +449,12 @@ IceInternal::traceRecv(const InputStream& str, const LoggerPtr& logger, const Tr
 }
 
 void
-IceInternal::trace(const char* heading, const InputStream& str, const LoggerPtr& logger, const TraceLevelsPtr& tl)
+IceInternal::trace(
+    const char* heading,
+    const InputStream& str,
+    const ConnectionI* connection,
+    const LoggerPtr& logger,
+    const TraceLevelsPtr& tl)
 {
     if (tl->protocol >= 1)
     {
@@ -441,7 +464,7 @@ IceInternal::trace(const char* heading, const InputStream& str, const LoggerPtr&
 
         ostringstream s;
         s << heading;
-        printMessage(s, stream);
+        printMessage(s, stream, connection);
 
         logger->trace(tl->protocolCat, s.str());
         stream.i = p;

--- a/cpp/src/Ice/TraceUtil.h
+++ b/cpp/src/Ice/TraceUtil.h
@@ -13,15 +13,30 @@ namespace Ice
 {
     class OutputStream;
     class InputStream;
+    class ConnectionI;
 }
 
 namespace IceInternal
 {
     class Instance;
 
-    void traceSend(const Ice::OutputStream&, const InstancePtr& instance, const Ice::LoggerPtr&, const TraceLevelsPtr&);
-    void traceRecv(const Ice::InputStream&, const Ice::LoggerPtr&, const TraceLevelsPtr&);
-    void trace(const char*, const Ice::InputStream&, const Ice::LoggerPtr&, const TraceLevelsPtr&);
+    void traceSend(
+        const Ice::OutputStream&,
+        const InstancePtr& instance,
+        const Ice::ConnectionI* connection,
+        const Ice::LoggerPtr&,
+        const TraceLevelsPtr&);
+    void traceRecv(
+        const Ice::InputStream&,
+        const Ice::ConnectionI* connection,
+        const Ice::LoggerPtr&,
+        const TraceLevelsPtr&);
+    void trace(
+        const char*,
+        const Ice::InputStream&,
+        const Ice::ConnectionI* connection,
+        const Ice::LoggerPtr&,
+        const TraceLevelsPtr&);
     void traceSlicing(const char*, std::string_view, const char*, const Ice::LoggerPtr&);
 }
 

--- a/csharp/src/Ice/Internal/TraceUtil.cs
+++ b/csharp/src/Ice/Internal/TraceUtil.cs
@@ -411,11 +411,11 @@ internal sealed class TraceUtil
 
         if (connection is not null)
         {
-            var connectionInfo = connection.getInfo();
             s.Write("\ntransport = " + connection.type() + "\n");
-            if (connectionInfo.connectionId.Length > 0)
+            string connectionId = connection.endpoint().connectionId();
+            if (connectionId.Length > 0)
             {
-                s.Write("connection id = " + connectionInfo.connectionId + "\n");
+                s.Write("connection ID = " + connectionId + "\n");
             }
             s.Write(connection.ToString());
         }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CollocatedRequestHandler.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CollocatedRequestHandler.java
@@ -158,7 +158,7 @@ final class CollocatedRequestHandler implements RequestHandler {
             } else if (requestCount > 0) {
                 fillInValue(os, Protocol.headerSize, requestCount);
             }
-            TraceUtil.traceSend(os, _reference.getInstance(), _logger, _traceLevels);
+            TraceUtil.traceSend(os, _reference.getInstance(), null, _logger, _traceLevels);
         }
 
         var is = new InputStream(_reference.getInstance(), os.getEncoding(), os.getBuffer(), false);
@@ -256,7 +256,7 @@ final class CollocatedRequestHandler implements RequestHandler {
                 inputStream.pos(Protocol.replyHdr.length + 4);
 
                 if (_traceLevels.protocol >= 1) {
-                    TraceUtil.traceRecv(inputStream, _logger, _traceLevels);
+                    TraceUtil.traceRecv(inputStream, null, _logger, _traceLevels);
                 }
 
                 outAsync = _asyncRequests.remove(requestId);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -1656,7 +1656,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                     // (always zero for
                     // validate connection).
                     _writeStream.writeInt(Protocol.headerSize); // Message size.
-                    TraceUtil.traceSend(_writeStream, _instance, _logger, _traceLevels);
+                    TraceUtil.traceSend(_writeStream, _instance, this, _logger, _traceLevels);
                     _writeStream.prepareWrite();
                 }
 
@@ -1741,7 +1741,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                                     + size
                                     + ".");
                 }
-                TraceUtil.traceRecv(_readStream, _logger, _traceLevels);
+                TraceUtil.traceRecv(_readStream, this, _logger, _traceLevels);
             }
         }
 
@@ -1847,7 +1847,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                 message.stream.prepareWrite();
                 message.prepared = true;
 
-                TraceUtil.traceSend(stream, _instance, _logger, _traceLevels);
+                TraceUtil.traceSend(stream, _instance, this, _logger, _traceLevels);
 
                 //
                 // Send the message.
@@ -1911,7 +1911,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         message.stream.prepareWrite();
         message.prepared = true;
         int op;
-        TraceUtil.traceSend(stream, _instance, _logger, _traceLevels);
+        TraceUtil.traceSend(stream, _instance, this, _logger, _traceLevels);
 
         // Send the message without blocking.
         if (_observer != null) {
@@ -2052,7 +2052,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
             switch (messageType) {
                 case Protocol.closeConnectionMsg:
                     {
-                        TraceUtil.traceRecv(info.stream, _logger, _traceLevels);
+                        TraceUtil.traceRecv(info.stream, this, _logger, _traceLevels);
                         if (_endpoint.datagram()) {
                             if (_warn) {
                                 _logger.warning(
@@ -2081,10 +2081,11 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                             TraceUtil.trace(
                                     "received request during closing\n(ignored by server, client will retry)",
                                     info.stream,
+                                    this,
                                     _logger,
                                     _traceLevels);
                         } else {
-                            TraceUtil.traceRecv(info.stream, _logger, _traceLevels);
+                            TraceUtil.traceRecv(info.stream, this, _logger, _traceLevels);
                             info.requestId = info.stream.readInt();
                             info.requestCount = 1;
                             info.adapter = _adapter;
@@ -2102,10 +2103,11 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                             TraceUtil.trace(
                                     "received batch request during closing\n(ignored by server, client will retry)",
                                     info.stream,
+                                    this,
                                     _logger,
                                     _traceLevels);
                         } else {
-                            TraceUtil.traceRecv(info.stream, _logger, _traceLevels);
+                            TraceUtil.traceRecv(info.stream, this, _logger, _traceLevels);
                             info.requestCount = info.stream.readInt();
                             if (info.requestCount < 0) {
                                 info.requestCount = 0;
@@ -2125,7 +2127,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
                 case Protocol.replyMsg:
                     {
-                        TraceUtil.traceRecv(info.stream, _logger, _traceLevels);
+                        TraceUtil.traceRecv(info.stream, this, _logger, _traceLevels);
                         info.requestId = info.stream.readInt();
 
                         var outAsync = _asyncRequests.remove(info.requestId);
@@ -2141,7 +2143,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
                 case Protocol.validateConnectionMsg:
                     {
-                        TraceUtil.traceRecv(info.stream, _logger, _traceLevels);
+                        TraceUtil.traceRecv(info.stream, this, _logger, _traceLevels);
                         break;
                     }
 
@@ -2150,6 +2152,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                         TraceUtil.trace(
                                 "received unknown message\n(invalid, closing connection)",
                                 info.stream,
+                                this,
                                 _logger,
                                 _traceLevels);
                         throw new ProtocolException(

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TraceUtil.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TraceUtil.java
@@ -6,14 +6,18 @@ package com.zeroc.Ice;
 
 final class TraceUtil {
     public static void traceSend(
-            OutputStream str, Instance instance, Logger logger, TraceLevels tl) {
+            OutputStream str,
+            Instance instance,
+            ConnectionI connection,
+            Logger logger,
+            TraceLevels tl) {
         if (tl.protocol >= 1) {
             int p = str.pos();
             var is = new InputStream(instance, str.getEncoding(), str.getBuffer(), false);
             is.pos(0);
 
             java.io.StringWriter s = new java.io.StringWriter();
-            byte type = printMessage(s, is);
+            byte type = printMessage(s, is, connection);
 
             logger.trace(
                     tl.protocolCat, "sending " + getMessageTypeAsString(type) + " " + s.toString());
@@ -22,13 +26,14 @@ final class TraceUtil {
         }
     }
 
-    public static void traceRecv(InputStream str, Logger logger, TraceLevels tl) {
+    public static void traceRecv(
+            InputStream str, ConnectionI connection, Logger logger, TraceLevels tl) {
         if (tl.protocol >= 1) {
             int p = str.pos();
             str.pos(0);
 
             java.io.StringWriter s = new java.io.StringWriter();
-            byte type = printMessage(s, str);
+            byte type = printMessage(s, str, connection);
 
             logger.trace(
                     tl.protocolCat,
@@ -38,14 +43,19 @@ final class TraceUtil {
         }
     }
 
-    public static void trace(String heading, InputStream str, Logger logger, TraceLevels tl) {
+    public static void trace(
+            String heading,
+            InputStream str,
+            ConnectionI connection,
+            Logger logger,
+            TraceLevels tl) {
         if (tl.protocol >= 1) {
             int p = str.pos();
             str.pos(0);
 
             java.io.StringWriter s = new java.io.StringWriter();
             s.write(heading);
-            printMessage(s, str);
+            printMessage(s, str, connection);
 
             logger.trace(tl.protocolCat, s.toString());
             str.pos(p);
@@ -297,7 +307,8 @@ final class TraceUtil {
         }
     }
 
-    private static byte printMessage(java.io.StringWriter s, InputStream str) {
+    private static byte printMessage(
+            java.io.StringWriter s, InputStream str, ConnectionI connection) {
         byte type = printHeader(s, str);
 
         switch (type) {
@@ -330,6 +341,15 @@ final class TraceUtil {
                 {
                     break;
                 }
+        }
+
+        if (connection != null) {
+            s.write("\ntransport = " + connection.type() + "\n");
+            String connectionId = connection.endpoint().connectionId();
+            if (!connectionId.isEmpty()) {
+                s.write("connection ID = " + connectionId + "\n");
+            }
+            s.write(connection.toString());
         }
 
         return type;

--- a/js/src/Ice/ConnectionI.js
+++ b/js/src/Ice/ConnectionI.js
@@ -1153,7 +1153,7 @@ export class ConnectionI {
         if (this._readStream.readInt() !== Protocol.headerSize) {
             throw new MarshalException(`Received ValidateConnection message with unexpected size ${size}.`);
         }
-        TraceUtil.traceRecv(this._readStream, this._logger, this._traceLevels);
+        TraceUtil.traceRecv(this._readStream, this, this._logger, this._traceLevels);
 
         this._writeStream.resize(0);
         this._writeStream.pos = 0;
@@ -1220,7 +1220,7 @@ export class ConnectionI {
                 stream.prepareWrite();
                 message.prepared = true;
 
-                TraceUtil.traceSend(stream, this._logger, this._traceLevels);
+                TraceUtil.traceSend(stream, this, this._logger, this._traceLevels);
 
                 this._writeStream.swap(message.stream);
 
@@ -1266,7 +1266,7 @@ export class ConnectionI {
         stream.prepareWrite();
         message.prepared = true;
 
-        TraceUtil.traceSend(stream, this._logger, this._traceLevels);
+        TraceUtil.traceSend(stream, this, this._logger, this._traceLevels);
 
         if (this.write(stream.buffer)) {
             //
@@ -1309,7 +1309,7 @@ export class ConnectionI {
 
             switch (messageType) {
                 case Protocol.closeConnectionMsg: {
-                    TraceUtil.traceRecv(info.stream, this._logger, this._traceLevels);
+                    TraceUtil.traceRecv(info.stream, this, this._logger, this._traceLevels);
                     // We transition directly to StateClosed, not StateClosingPending.
                     this.setState(StateClosed, new CloseConnectionException());
                     break;
@@ -1320,11 +1320,12 @@ export class ConnectionI {
                         TraceUtil.traceIn(
                             "received request during closing\n" + "(ignored by server, client will retry)",
                             info.stream,
+                            this,
                             this._logger,
                             this._traceLevels,
                         );
                     } else {
-                        TraceUtil.traceRecv(info.stream, this._logger, this._traceLevels);
+                        TraceUtil.traceRecv(info.stream, this, this._logger, this._traceLevels);
                         info.requestId = info.stream.readInt();
                         info.requestCount = 1;
                         info.adapter = this._adapter;
@@ -1341,11 +1342,12 @@ export class ConnectionI {
                         TraceUtil.traceIn(
                             "received batch request during closing\n" + "(ignored by server, client will retry)",
                             info.stream,
+                            this,
                             this._logger,
                             this._traceLevels,
                         );
                     } else {
-                        TraceUtil.traceRecv(info.stream, this._logger, this._traceLevels);
+                        TraceUtil.traceRecv(info.stream, this, this._logger, this._traceLevels);
                         const requestCount = info.stream.readInt();
                         if (info.requestCount < 0) {
                             throw new MarshalException(`Received batch request with ${requestCount} batches.`);
@@ -1361,7 +1363,7 @@ export class ConnectionI {
                 }
 
                 case Protocol.replyMsg: {
-                    TraceUtil.traceRecv(info.stream, this._logger, this._traceLevels);
+                    TraceUtil.traceRecv(info.stream, this, this._logger, this._traceLevels);
                     info.requestId = info.stream.readInt();
                     info.outAsync = this._asyncRequests.get(info.requestId);
                     if (info.outAsync) {
@@ -1378,7 +1380,7 @@ export class ConnectionI {
                 }
 
                 case Protocol.validateConnectionMsg: {
-                    TraceUtil.traceRecv(info.stream, this._logger, this._traceLevels);
+                    TraceUtil.traceRecv(info.stream, this, this._logger, this._traceLevels);
                     break;
                 }
 
@@ -1386,6 +1388,7 @@ export class ConnectionI {
                     TraceUtil.traceIn(
                         "received unknown message\n(invalid, closing connection)",
                         info.stream,
+                        this,
                         this._logger,
                         this._traceLevels,
                     );


### PR DESCRIPTION
in C++, Java and JavaScript.

C# was fixed by #3062.

Fixes #856.