### PR TITLE
Update dev container to use temurin JDK 17

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,16 +10,7 @@ RUN set -eux \
     && sudo apt update \
     && sudo apt-get install -y php-dev python3 python3-dev python3-passlib ruby-full gdb \
     && sudo apt-get install -y libbluetooth-dev libbz2-dev libdbus-1-dev libedit-dev libexpat1-dev liblmdb-dev libmcpp-dev libssl-dev libsystemd-dev \
-    && sudo rm -rf /var/lib/apt/lists/* \
-    && sudo apt-get clean
-
-# See https://adoptium.net/installation/linux/
-RUN set -eux \
-    && sudo apt-get install -y wget apt-transport-https gpg \
-    && wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/adoptium.gpg > /dev/null \
-    && echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | sudo tee /etc/apt/sources.list.d/adoptium.list \
-    && sudo apt update \
-    && sudo apt-get install -y temurin-17-jdk \
+    && sudo apt-get install -y openjdk-17-jdk \
     && sudo rm -rf /var/lib/apt/lists/* \
     && sudo apt-get clean
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,5 +24,3 @@ RUN set -eux \
 ENV DOTNET_ROOT=/home/vscode/.dotnet
 ENV PATH=$DOTNET_ROOT:$PATH
 ENV LANG=en_US.UTF-8
-ENV JAVA_HOME=/usr/java/jdk-17
-ENV PATH=$JAVA_HOME/bin:$PATH

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,23 +13,15 @@ RUN set -eux \
     && sudo rm -rf /var/lib/apt/lists/* \
     && sudo apt-get clean
 
-# Borrowed from https://github.com/oracle/docker-images/blob/main/OracleJava/17/Dockerfile
-ARG JAVA_URL=https://download.oracle.com/java/17/latest
-ARG JAVA_HOME=/usr/java/jdk-17
-
-RUN set -eux; \
-    ARCH="$(uname -m)" && \
-    # Java uses just x64 in the name of the tarball
-    if [ "$ARCH" = "x86_64" ]; \
-    then ARCH="x64"; \
-    fi && \
-    JAVA_PKG="$JAVA_URL"/jdk-17_linux-"${ARCH}"_bin.tar.gz ; \
-    JAVA_SHA256="$(curl "$JAVA_PKG".sha256)" ; \
-    curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
-    echo "$JAVA_SHA256" */tmp/jdk.tgz | sha256sum -c; \
-    sudo mkdir -p "$JAVA_HOME"; \
-    sudo tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1; \
-    rm /tmp/jdk.tgz;
+# See https://adoptium.net/installation/linux/
+RUN set -eux \
+    && sudo apt-get install -y wget apt-transport-https gpg \
+    && wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/adoptium.gpg > /dev/null \
+    && echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | sudo tee /etc/apt/sources.list.d/adoptium.list \
+    && sudo apt update \
+    && sudo apt-get install -y temurin-17-jdk \
+    && sudo rm -rf /var/lib/apt/lists/* \
+    && sudo apt-get clean
 
 # Install .NET 8.0
 RUN set -eux \


### PR DESCRIPTION
Oracle JDK 17 is no longer available under no fee-term-and-conditions so it now requires users to download the binary first

Fixes #3068