### PR TITLE
Remove bogus await call in JavaScript Instance.destroy

### DIFF
--- a/js/src/Ice/InstanceExtensions.js
+++ b/js/src/Ice/InstanceExtensions.js
@@ -339,7 +339,7 @@ Instance.prototype.destroy = async function () {
         }
 
         if (this._objectAdapterFactory !== null) {
-            await this._objectAdapterFactory.destroy();
+            this._objectAdapterFactory.destroy();
         }
 
         if (this._outgoingConnectionFactory !== null) {


### PR DESCRIPTION
ObjectAdapterFactory.destroy is no longer async in JavaScript.