### PR TITLE
Preserve doc comments in converted sequences and dictionaries

### DIFF
--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -266,7 +266,7 @@ namespace
 
     string slice2LinkFormatter(string identifier, string memberComponent)
     {
-        // Replace links of the form `{@link Type#member}` with `{@link Type.member}`.
+        // Replace links of the form `{@link Type#member}` with `{@link Type::member}`.
         string result = "{@link ";
         if (memberComponent.empty())
         {
@@ -278,7 +278,7 @@ namespace
         }
         else
         {
-            result += identifier + "." + memberComponent;
+            result += identifier + "::" + memberComponent;
         }
         return result += "}";
     }
@@ -571,6 +571,7 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     const string scope = p->scope();
     Output& out = getOutput(p);
 
+    writeComment(p, out);
     out << nl << "typealias " << p->name() << " = ";
 
     for (const auto& metadata : p->getMetadata())
@@ -609,6 +610,7 @@ Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     const string scope = p->scope();
     Output& out = getOutput(p);
 
+    writeComment(p, out);
     out << nl << "typealias " << p->name() << " = ";
 
     for (const auto& metadata : p->getMetadata())


### PR DESCRIPTION
This PR upgrades ice2slice to preserve the doc comments for sequences and dictionaries.

Related to point 3 in #1809