### PR TITLE
Ensure that NodeJS fails on unhandled errors

### DIFF
--- a/js/test/Common/run.js
+++ b/js/test/Common/run.js
@@ -18,6 +18,16 @@ class ControllerHelper {
 
 (async function () {
     try {
+        process.on("unhandledRejection", (reason, promise) => {
+            console.error("Unhandled Rejection at:", promise, "reason:", reason);
+            process.exit(1);
+        });
+
+        process.on("uncaughtException", err => {
+            console.error("Uncaught Exception:", err);
+            process.exit(1);
+        });
+
         const path = process.argv[2];
         const name = process.argv[3];
         const module = await import(path);


### PR DESCRIPTION
This is a minor fix to the NodeJS test runner to ensure we fail on uncaught exceptions and unhandled promise rejections.