### PR TITLE
Js at most once semantics fixes

### DIFF
--- a/js/src/Ice/ConnectionI.js
+++ b/js/src/Ice/ConnectionI.js
@@ -1176,8 +1176,7 @@ export class ConnectionI {
                 let message = this._sendStreams.shift();
                 this._writeStream.swap(message.stream);
                 message.sent();
-                if (message.receivedReply)
-                {
+                if (message.receivedReply) {
                     completed ??= [];
                     completed.push(message);
                 }
@@ -1348,8 +1347,7 @@ export class ConnectionI {
                     TraceUtil.traceRecv(info.stream, this, this._logger, this._traceLevels);
                     info.requestId = info.stream.readInt();
                     info.outAsync = this._asyncRequests.get(info.requestId);
-                    if (info.outAsync !== undefined)
-                    {
+                    if (info.outAsync !== undefined) {
                         this._asyncRequests.delete(info.requestId);
 
                         // If we receive a reply for a request that hasn’t been marked as sent, we mark the request as
@@ -1365,7 +1363,11 @@ export class ConnectionI {
                             ++this._upcallCount;
                         }
 
-                        if (this._closed !== undefined && this._state < StateClosing && this._asyncRequests.size === 0) {
+                        if (
+                            this._closed !== undefined &&
+                            this._state < StateClosing &&
+                            this._asyncRequests.size === 0
+                        ) {
                             this.doApplicationClose();
                         }
                     } else {

--- a/js/src/Ice/Debug.js
+++ b/js/src/Ice/Debug.js
@@ -5,7 +5,7 @@
 export class Debug {
     static assert(condition, message) {
         if (!condition) {
-            console.trace("Assertion failed: " + message);
+            console.trace(message === undefined ? "Assertion failed" : `Assertion failed: ${message}`);
             if (typeof process !== "undefined") {
                 process.exit(1);
             }

--- a/js/src/Ice/IdleTimeoutTransceiverDecorator.js
+++ b/js/src/Ice/IdleTimeoutTransceiverDecorator.js
@@ -44,9 +44,9 @@ export class IdleTimeoutTransceiverDecorator {
         this._decoratee.close();
     }
 
-    write(buf) {
+    write(buffer, bufferFullyWritten) {
         this.cancelWriteTimer();
-        const completed = this._decoratee.write(buf);
+        const completed = this._decoratee.write(buffer, bufferFullyWritten);
         if (completed) {
             // write completed
             this.rescheduleWriteTimer();


### PR DESCRIPTION
This PR lay on top of #3097 it includes fixes to ensure that JavaScript marks requests as sent before the socket writes the last packet.

Currently JavaScript only marks requests as sent in `sendNextMessage` implementation, which can be called  from the socket async callbacks. In this case when called from the async callbacks it can be processed before other events, and can result in breaking at most once semantics.

This is somehow similar to the fix for #3072

It also includes a few fixes for Ice/ami tests mostly to ensure we await all promises.
