### PR TITLE
Make InputStream resize internal

### DIFF
--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -78,26 +78,26 @@ namespace Ice
         /**
          * Constructs a stream using the given communicator and encoding version.
          * @param communicator The communicator to use for unmarshaling tasks.
-         * @param version The encoding version used to encode the data to be unmarshaled.
+         * @param encoding The encoding version used to encode the data to be unmarshaled.
          * @param bytes The encoded data.
          */
-        InputStream(const CommunicatorPtr& communicator, EncodingVersion version, const std::vector<std::byte>& bytes);
+        InputStream(const CommunicatorPtr& communicator, EncodingVersion encoding, const std::vector<std::byte>& bytes);
 
         /**
          * Constructs a stream using the given communicator and encoding version.
          * @param communicator The communicator to use for unmarshaling tasks.
-         * @param version The encoding version used to encode the data to be unmarshaled.
+         * @param encoding The encoding version used to encode the data to be unmarshaled.
          * @param bytes The encoded data.
          */
         InputStream(
             const CommunicatorPtr& communicator,
-            EncodingVersion version,
+            EncodingVersion encoding,
             std::pair<const std::byte*, const std::byte*> bytes);
 
         /// \cond INTERNAL
 
-        // Constructs a stream with an empty buffer and the 1.0 encoding.
-        explicit InputStream(IceInternal::Instance* instance);
+        // Constructs a stream with an empty buffer.
+        explicit InputStream(IceInternal::Instance* instance, EncodingVersion encoding);
 
         // Constructs a stream with the specified encoding and buffer.
         InputStream(IceInternal::Instance* instance, EncodingVersion encoding, IceInternal::Buffer& buf, bool adopt);
@@ -165,7 +165,6 @@ namespace Ice
 
         /// \cond INTERNAL
         void resetEncapsulation();
-        /// \endcond
 
         /**
          * Resizes the stream to a new size.
@@ -177,6 +176,7 @@ namespace Ice
             b.resize(sz);
             i = b.end();
         }
+        // \endcond
 
         /**
          * Marks the start of a class instance.

--- a/cpp/src/Ice/CollocatedRequestHandler.cpp
+++ b/cpp/src/Ice/CollocatedRequestHandler.cpp
@@ -160,7 +160,7 @@ CollocatedRequestHandler::invokeAsyncRequest(OutgoingAsyncBase* outAsync, int ba
 
     if (!synchronous || !_response || _reference->getInvocationTimeout() > 0ms)
     {
-        auto stream = make_shared<InputStream>(_reference->getInstance().get());
+        auto stream = make_shared<InputStream>(_reference->getInstance().get(), currentProtocolEncoding);
         is.swap(*stream);
 
         // Don't invoke from the user thread if async or invocation timeout is set
@@ -176,7 +176,7 @@ CollocatedRequestHandler::invokeAsyncRequest(OutgoingAsyncBase* outAsync, int ba
     }
     else if (_hasExecutor)
     {
-        auto stream = make_shared<InputStream>(_reference->getInstance().get());
+        auto stream = make_shared<InputStream>(_reference->getInstance().get(), currentProtocolEncoding);
         is.swap(*stream);
 
         _adapter->getThreadPool()->executeFromThisThread(

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -1160,7 +1160,7 @@ Ice::ConnectionI::message(ThreadPoolCurrent& current)
     function<void(ConnectionIPtr)> connectionStartCompleted;
     vector<OutgoingMessage> sentCBs;
     function<bool(InputStream&)> messageUpcall;
-    InputStream messageStream{_instance.get()};
+    InputStream messageStream{_instance.get(), currentProtocolEncoding};
 
     ThreadPoolMessage<ConnectionI> msg(current, *this);
     {
@@ -1462,7 +1462,7 @@ Ice::ConnectionI::message(ThreadPoolCurrent& current)
     }
     else
     {
-        auto stream = make_shared<InputStream>(_instance.get());
+        auto stream = make_shared<InputStream>(_instance.get(), currentProtocolEncoding);
         stream->swap(messageStream);
 
         auto self = shared_from_this();
@@ -1917,7 +1917,7 @@ Ice::ConnectionI::ConnectionI(
       _asyncRequestsHint(_asyncRequests.end()),
       _messageSizeMax(connector ? _instance->messageSizeMax() : adapter->messageSizeMax()),
       _batchRequestQueue(new BatchRequestQueue(instance, endpoint->datagram())),
-      _readStream(instance.get()),
+      _readStream{instance.get(), currentProtocolEncoding},
       _readHeader(false),
       _upcallCount(0),
       _maxDispatches(options.maxDispatches),
@@ -3187,7 +3187,7 @@ Ice::ConnectionI::parseMessage(int32_t& upcallCount, function<bool(InputStream&)
         if (compress == 2)
         {
 #ifdef ICE_HAS_BZIP2
-            InputStream ustream{_instance.get()};
+            InputStream ustream{_instance.get(), currentProtocolEncoding};
             doUncompress(stream, ustream);
             stream.b.swap(ustream.b);
 #else

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -75,7 +75,10 @@ IceInternal::Ex::throwMarshalException(const char* file, int line, string reason
     throw Ice::MarshalException{file, line, std::move(reason)};
 }
 
-Ice::InputStream::InputStream(Instance* instance) : InputStream{instance, currentProtocolEncoding, Buffer{}} {}
+Ice::InputStream::InputStream(Instance* instance, EncodingVersion encoding)
+    : InputStream{instance, std::move(encoding), Buffer{}}
+{
+}
 
 Ice::InputStream::InputStream(const CommunicatorPtr& communicator, const vector<byte>& v)
     : InputStream{

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -970,29 +970,11 @@ Ice::InputStream::readConverted(string& v, int sz)
     try
     {
         bool converted = false;
-
-        //
-        // NOTE: When using an _instance, we get a const& on the string reference to
-        // not have to increment unecessarily its reference count.
-        //
-
-        if (_instance)
+        const StringConverterPtr& stringConverter = _instance->getStringConverter();
+        if (stringConverter)
         {
-            const StringConverterPtr& stringConverter = _instance->getStringConverter();
-            if (stringConverter)
-            {
-                stringConverter->fromUTF8(i, i + sz, v);
-                converted = true;
-            }
-        }
-        else
-        {
-            StringConverterPtr stringConverter = getProcessStringConverter();
-            if (stringConverter)
-            {
-                stringConverter->fromUTF8(i, i + sz, v);
-                converted = true;
-            }
+            stringConverter->fromUTF8(i, i + sz, v);
+            converted = true;
         }
 
         return converted;
@@ -1034,17 +1016,8 @@ Ice::InputStream::read(wstring& v)
 
         try
         {
-            if (_instance)
-            {
-                const WstringConverterPtr& wstringConverter = _instance->getWstringConverter();
-                wstringConverter->fromUTF8(i, i + sz, v);
-            }
-            else
-            {
-                WstringConverterPtr wstringConverter = getProcessWstringConverter();
-                wstringConverter->fromUTF8(i, i + sz, v);
-            }
-
+            const WstringConverterPtr& wstringConverter = _instance->getWstringConverter();
+            wstringConverter->fromUTF8(i, i + sz, v);
             i += sz;
         }
         catch (const IllegalConversionException& ex)
@@ -1094,11 +1067,6 @@ Ice::InputStream::InputStream(Instance* instance, EncodingVersion encoding, Buff
 ReferencePtr
 Ice::InputStream::readReference()
 {
-    if (!_instance)
-    {
-        throw MarshalException(__FILE__, __LINE__, "cannot unmarshal a proxy without a communicator");
-    }
-
     Identity ident;
     read(ident);
     if (ident.name.empty())

--- a/cpp/src/Ice/OutgoingAsync.cpp
+++ b/cpp/src/Ice/OutgoingAsync.cpp
@@ -204,7 +204,7 @@ OutgoingAsyncBase::OutgoingAsyncBase(const InstancePtr& instance)
       _doneInSent(false),
       _state(0),
       _os(instance.get(), currentProtocolEncoding),
-      _is{instance.get()}
+      _is{instance.get(), currentProtocolEncoding}
 {
 }
 

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1389,7 +1389,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
         _nextRequestId = 1;
         _messageSizeMax = connector is null ? adapter.messageSizeMax() : instance.messageSizeMax();
         _batchRequestQueue = new BatchRequestQueue(instance, _endpoint.datagram());
-        _readStream = new InputStream(instance);
+        _readStream = new InputStream(instance, Util.currentProtocolEncoding);
         _readHeader = false;
         _readStreamPos = -1;
         _writeStream = new OutputStream(); // temporary stream
@@ -2232,7 +2232,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
     {
         Debug.Assert(_state > StateNotValidated && _state < StateClosed);
 
-        info.stream = new InputStream(_instance);
+        info.stream = new InputStream(_instance, Util.currentProtocolEncoding);
         _readStream.swap(info.stream);
         _readStream.resize(Protocol.headerSize);
         _readStream.pos(0);

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1389,7 +1389,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
         _nextRequestId = 1;
         _messageSizeMax = connector is null ? adapter.messageSizeMax() : instance.messageSizeMax();
         _batchRequestQueue = new BatchRequestQueue(instance, _endpoint.datagram());
-        _readStream = new InputStream(instance, Util.currentProtocolEncoding);
+        _readStream = new InputStream(instance);
         _readHeader = false;
         _readStreamPos = -1;
         _writeStream = new OutputStream(); // temporary stream
@@ -2232,7 +2232,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
     {
         Debug.Assert(_state > StateNotValidated && _state < StateClosed);
 
-        info.stream = new InputStream(_instance, Util.currentProtocolEncoding);
+        info.stream = new InputStream(_instance);
         _readStream.swap(info.stream);
         _readStream.resize(Protocol.headerSize);
         _readStream.pos(0);

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -5,7 +5,6 @@
 using Ice.Internal;
 using System.Diagnostics;
 using System.Globalization;
-using System.Text;
 using Protocol = Ice.Internal.Protocol;
 
 namespace Ice;

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -5,6 +5,7 @@
 using Ice.Internal;
 using System.Diagnostics;
 using System.Globalization;
+using System.Text;
 using Protocol = Ice.Internal.Protocol;
 
 namespace Ice;
@@ -48,10 +49,12 @@ public sealed class InputStream
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="InputStream" /> class with an empty buffer and the 1.0 encoding.
+    /// Initializes a new instance of the <see cref="InputStream" /> class with an empty buffer.
+    /// <param name="instance">The communicator instance.</param>
+    /// <param name="encoding">The desired encoding version.</param>
     /// </summary>
-    internal InputStream(Instance instance)
-        : this(instance, Util.currentProtocolEncoding, new Internal.Buffer())
+    internal InputStream(Instance instance, EncodingVersion encoding)
+        : this(instance, encoding, new Internal.Buffer())
     {
     }
 
@@ -146,7 +149,7 @@ public sealed class InputStream
     /// Resizes the stream to a new size.
     /// </summary>
     /// <param name="sz">The new size.</param>
-    public void resize(int sz)
+    internal void resize(int sz)
     {
         _buf.resize(sz, true);
         _buf.b.position(sz);

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -20,7 +20,7 @@ public delegate void UserExceptionFactory(string id);
 /// <summary>
 /// Interface for input streams used to extract Slice types from a sequence of bytes.
 /// </summary>
-public class InputStream
+public sealed class InputStream
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="InputStream" /> class. This constructor uses the communicator's
@@ -48,10 +48,10 @@ public class InputStream
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="InputStream" /> class with an empty buffer.
+    /// Initializes a new instance of the <see cref="InputStream" /> class with an empty buffer and the 1.0 encoding.
     /// </summary>
-    internal InputStream(Instance instance, EncodingVersion encoding)
-        : this(instance, encoding, new Internal.Buffer())
+    internal InputStream(Instance instance)
+        : this(instance, Util.currentProtocolEncoding, new Internal.Buffer())
     {
     }
 
@@ -113,9 +113,6 @@ public class InputStream
     public void swap(InputStream other)
     {
         Debug.Assert(_instance == other._instance);
-        // _valueFactoryManager and _classGraphDepthMax come from _instance.
-        Debug.Assert(_valueFactoryManager == other._valueFactoryManager);
-        Debug.Assert(_classGraphDepthMax == other._classGraphDepthMax);
 
         Internal.Buffer tmpBuf = other._buf;
         other._buf = _buf;
@@ -125,14 +122,6 @@ public class InputStream
         other._encoding = _encoding;
         _encoding = tmpEncoding;
 
-        //
-        // Swap is never called for InputStreams that have encapsulations being read. However,
-        // encapsulations might still be set in case un-marshaling failed. We just
-        // reset the encapsulations if there are still some set.
-        //
-        resetEncapsulation();
-        other.resetEncapsulation();
-
         int tmpStartSeq = other._startSeq;
         other._startSeq = _startSeq;
         _startSeq = tmpStartSeq;
@@ -140,6 +129,12 @@ public class InputStream
         int tmpMinSeqSize = other._minSeqSize;
         other._minSeqSize = _minSeqSize;
         _minSeqSize = tmpMinSeqSize;
+
+        // Swap is never called for InputStreams that have encapsulations being read. However,
+        // encapsulations might still be set in case un-marshaling failed. We just
+        // reset the encapsulations if there are still some set.
+        resetEncapsulation();
+        other.resetEncapsulation();
     }
 
     private void resetEncapsulation()

--- a/csharp/src/Ice/Internal/OutgoingAsync.cs
+++ b/csharp/src/Ice/Internal/OutgoingAsync.cs
@@ -243,7 +243,7 @@ public abstract class OutgoingAsyncBase
         _alreadySent = false;
         state_ = 0;
         os_ = os ?? new OutputStream(Ice.Util.currentProtocolEncoding, instance.defaultsAndOverrides().defaultFormat);
-        is_ = iss ?? new Ice.InputStream(instance);
+        is_ = iss ?? new Ice.InputStream(instance, Ice.Util.currentProtocolEncoding);
         _completionCallback = completionCallback;
         if (_completionCallback != null)
         {

--- a/csharp/src/Ice/Internal/OutgoingAsync.cs
+++ b/csharp/src/Ice/Internal/OutgoingAsync.cs
@@ -243,7 +243,7 @@ public abstract class OutgoingAsyncBase
         _alreadySent = false;
         state_ = 0;
         os_ = os ?? new OutputStream(Ice.Util.currentProtocolEncoding, instance.defaultsAndOverrides().defaultFormat);
-        is_ = iss ?? new Ice.InputStream(instance, Ice.Util.currentProtocolEncoding);
+        is_ = iss ?? new Ice.InputStream(instance);
         _completionCallback = completionCallback;
         if (_completionCallback != null)
         {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -790,7 +790,11 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                 //
                 assert (info.stream == current.stream);
                 InputStream stream = info.stream;
-                info.stream = new InputStream(_instance);
+                info.stream =
+                        new InputStream(
+                                _instance,
+                                Protocol.currentProtocolEncoding,
+                                _instance.cacheMessageBuffers() > 1);
                 info.stream.swap(stream);
             }
             final StartCallback finalStartCB = startCB;
@@ -1273,7 +1277,11 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         _nextRequestId = 1;
         _messageSizeMax = connector == null ? adapter.messageSizeMax() : instance.messageSizeMax();
         _batchRequestQueue = new BatchRequestQueue(instance, _endpoint.datagram());
-        _readStream = new InputStream(instance);
+        _readStream =
+                new InputStream(
+                        instance,
+                        Protocol.currentProtocolEncoding,
+                        instance.cacheMessageBuffers() > 1);
         _readHeader = false;
         _readStreamPos = -1;
         _writeStream = new OutputStream(); // temporary stream

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -60,10 +60,10 @@ public final class InputStream {
         this(communicator.getInstance(), encoding, new Buffer(buf));
     }
 
-    /** Constructs an InputStream with an empty buffer and the 1.0 encoding. */
-    InputStream(Instance instance) {
+    /** Constructs an InputStream with an empty buffer. */
+    InputStream(Instance instance, EncodingVersion encoding, boolean direct) {
         // Create an empty non-direct buffer.
-        this(instance, Protocol.currentProtocolEncoding, new Buffer(false));
+        this(instance, encoding, new Buffer(direct));
     }
 
     InputStream(Instance instance, EncodingVersion encoding, Buffer buf, boolean adopt) {
@@ -155,12 +155,12 @@ public final class InputStream {
      *
      * @param sz The new size.
      */
-    public void resize(int sz) {
+    void resize(int sz) {
         _buf.resize(sz, true);
         _buf.position(sz);
     }
 
-    public Buffer getBuffer() {
+    Buffer getBuffer() {
         return _buf;
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingAsync.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingAsync.java
@@ -218,7 +218,11 @@ public class OutgoingAsync<T> extends ProxyOutgoingAsyncBase<T> {
 
         // _is can already be initialized if the invocation is retried
         if (_is == null) {
-            _is = new InputStream(_instance);
+            _is =
+                    new InputStream(
+                            _instance,
+                            Protocol.currentProtocolEncoding,
+                            _instance.cacheMessageBuffers() > 1);
         }
         _is.swap(is);
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyIceInvoke.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyIceInvoke.java
@@ -118,7 +118,11 @@ class ProxyIceInvoke extends ProxyOutgoingAsyncBase<Object.Ice_invokeResult> {
 
         // _is can already be initialized if the invocation is retried
         if (_is == null) {
-            _is = new InputStream(_instance);
+            _is =
+                    new InputStream(
+                            _instance,
+                            Protocol.currentProtocolEncoding,
+                            _instance.cacheMessageBuffers() > 1);
         }
         _is.swap(is);
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ThreadPoolCurrent.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ThreadPoolCurrent.java
@@ -8,7 +8,11 @@ final class ThreadPoolCurrent {
     ThreadPoolCurrent(
             Instance instance, ThreadPool threadPool, ThreadPool.EventHandlerThread thread) {
         operation = SocketOperation.None;
-        stream = new InputStream(instance);
+        stream =
+                new InputStream(
+                        instance,
+                        Protocol.currentProtocolEncoding,
+                        instance.cacheMessageBuffers() > 1);
 
         _threadPool = threadPool;
         _thread = thread;


### PR DESCRIPTION
With the public API for InputStream, you create an InputStream over a (non-empty) buffer and then decode its contents.

InputStream also provides an internal API with a different usage model: you start with an empty buffer and fill this buffer little by little, by resizing this buffer.

This PR makes the InputStream resize API and a few updates related to this usage.