### PR TITLE
Fix dynamic property warning in PHP slicing/objects test

### DIFF
--- a/php/test/Ice/slicing/objects/Client.php
+++ b/php/test/Ice/slicing/objects/Client.php
@@ -408,7 +408,10 @@ function allTests($helper)
         $d1->pb = null;
         $d1->pd1 = null;
         $b1->pb = null;
-        $p1->pd1 = null;
+        if($p1 instanceof Test\D3)
+        {
+            $p1->pd3 = null;
+        }
     }
     echo "ok\n";
 


### PR DESCRIPTION
Fix #3090