### PR TITLE
Add ice2slice warnings when const values appears in .ice file

### DIFF
--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -663,7 +663,8 @@ Slice::Gen::TypesVisitor::visitConst(const ConstPtr& p)
     out << nl << "// ice2slice could not convert:";
     out << nl << "// const " << p->type()->typeId() << " " << p->name() << " = " << p->value();
 
-    p->unit()->warning(p->file(), p->line(), WarningCategory::All, "ice2slice could not convert constant: " + p->name());
+    p->unit()
+        ->warning(p->file(), p->line(), WarningCategory::All, "ice2slice could not convert constant: " + p->name());
 }
 
 void

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -344,63 +344,63 @@ Gen::Gen(const std::string& fileBase) : _fileBase(fileBase) {}
 void
 Gen::generate(const UnitPtr& p)
 {
-    OutputVisitor outputVisitor;
-    p->visit(&outputVisitor);
+    OutputModulesVisitor outputModulesVisitor;
+    p->visit(&outputModulesVisitor);
 
-    TypesVisitor typesVisitor(_fileBase, outputVisitor.modules());
+    TypesVisitor typesVisitor(_fileBase, outputModulesVisitor.modules());
     p->visit(&typesVisitor);
 
     typesVisitor.newLine(); // Ensure all files end with a newline
 }
 
 bool
-Gen::OutputVisitor::visitClassDefStart(const ClassDefPtr& p)
+Gen::OutputModulesVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
     _modules.insert(p->scope());
     return false;
 }
 
 bool
-Gen::OutputVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
+Gen::OutputModulesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     _modules.insert(p->scope());
     return false;
 }
 
 bool
-Gen::OutputVisitor::visitExceptionStart(const ExceptionPtr& p)
+Gen::OutputModulesVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
     _modules.insert(p->scope());
     return false;
 }
 
 bool
-Gen::OutputVisitor::visitStructStart(const StructPtr& p)
+Gen::OutputModulesVisitor::visitStructStart(const StructPtr& p)
 {
     _modules.insert(p->scope());
     return false;
 }
 
 void
-Gen::OutputVisitor::visitSequence(const SequencePtr& p)
+Gen::OutputModulesVisitor::visitSequence(const SequencePtr& p)
 {
     _modules.insert(p->scope());
 }
 
 void
-Gen::OutputVisitor::visitDictionary(const DictionaryPtr& p)
+Gen::OutputModulesVisitor::visitDictionary(const DictionaryPtr& p)
 {
     _modules.insert(p->scope());
 }
 
 void
-Gen::OutputVisitor::visitEnum(const EnumPtr& p)
+Gen::OutputModulesVisitor::visitEnum(const EnumPtr& p)
 {
     _modules.insert(p->scope());
 }
 
 set<string>
-Gen::OutputVisitor::modules() const
+Gen::OutputModulesVisitor::modules() const
 {
     return _modules;
 }

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -5,7 +5,6 @@
 #include "Gen.h"
 #include "../Slice/Util.h"
 
-#include <algorithm>
 #include <cassert>
 
 using namespace std;
@@ -350,6 +349,8 @@ Gen::generate(const UnitPtr& p)
 
     TypesVisitor typesVisitor(_fileBase, outputVisitor.modules());
     p->visit(&typesVisitor);
+
+    typesVisitor.newLine(); // Ensure all files end with a newline
 }
 
 bool
@@ -417,6 +418,7 @@ Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     const string scope = p->scope();
     Output& out = getOutput(p);
 
+    out << sp;
     writeComment(p, out);
 
     out << nl << "class " << p->name();
@@ -431,7 +433,6 @@ Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     out.dec();
     out << nl << "}";
-    out << nl;
     return false;
 }
 
@@ -442,6 +443,7 @@ Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     const string scope = p->scope();
     Output& out = getOutput(p);
 
+    out << sp;
     writeComment(p, out);
     out << nl << "interface " << p->name();
     if (bases.size() > 0)
@@ -518,11 +520,10 @@ Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     }
     out.dec();
     out << nl << "}";
-    out << sp;
 
+    out << sp;
     out << nl << "[cs::type(\"" << typeToCsString(p->declaration(), false) << "\")]";
     out << nl << "custom " << p->name() << "Proxy";
-    out << nl;
     return false;
 }
 
@@ -531,6 +532,8 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
     const string scope = p->scope();
     Output& out = getOutput(p);
+
+    out << sp;
     writeComment(p, out);
     out << nl << "exception " << p->name();
     if (ExceptionPtr base = p->base())
@@ -544,7 +547,6 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 
     out.dec();
     out << nl << "}";
-    out << nl;
     return false;
 }
 
@@ -553,6 +555,8 @@ Gen::TypesVisitor::visitStructStart(const StructPtr& p)
 {
     const string scope = p->scope();
     Output& out = getOutput(p);
+
+    out << sp;
     writeComment(p, out);
     out << nl << "compact struct " << p->name() << " {";
     out.inc();
@@ -561,7 +565,6 @@ Gen::TypesVisitor::visitStructStart(const StructPtr& p)
 
     out.dec();
     out << nl << "}";
-    out << nl;
     return false;
 }
 
@@ -571,6 +574,7 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     const string scope = p->scope();
     Output& out = getOutput(p);
 
+    out << sp;
     writeComment(p, out);
     out << nl << "typealias " << p->name() << " = ";
 
@@ -601,7 +605,6 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
         }
     }
     out << " Sequence<" << typeToString(p->type(), p->scope(), false) << ">";
-    out << nl;
 }
 
 void
@@ -610,6 +613,7 @@ Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     const string scope = p->scope();
     Output& out = getOutput(p);
 
+    out << sp;
     writeComment(p, out);
     out << nl << "typealias " << p->name() << " = ";
 
@@ -626,7 +630,6 @@ Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     }
     out << " Dictionary<" << typeToString(p->keyType(), p->scope(), false) << ", "
         << typeToString(p->valueType(), p->scope(), false) << ">";
-    out << nl;
 }
 
 void
@@ -635,6 +638,7 @@ Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     const string scope = p->scope();
     Output& out = getOutput(p);
 
+    out << sp;
     writeComment(p, out);
     out << nl << "enum " << p->name() << " {";
     out.inc();
@@ -649,7 +653,26 @@ Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     }
     out.dec();
     out << nl << "}";
-    out << nl;
+}
+
+void
+Slice::Gen::TypesVisitor::visitConst(const ConstPtr& p)
+{
+    Output& out = getOutput(p);
+    out << sp;
+    out << nl << "// ice2slice could not convert:";
+    out << nl << "// const " << p->name() << " = " << p->value();
+
+    p->unit()->warning(p->file(), p->line(), WarningCategory::All, "ice2slice could not convert constant: " + p->name());
+}
+
+void
+Slice::Gen::TypesVisitor::newLine()
+{
+    for (const auto& [_, output] : _outputs)
+    {
+        *output << nl;
+    }
 }
 
 // Get the output stream where to write the mapped Slice construct, creating a new output stream if necessary. The
@@ -687,7 +710,6 @@ Gen::TypesVisitor::getOutput(const ContainedPtr& contained)
         string moduleName = scope.substr(2).substr(0, scope.size() - 4);
 
         *out << nl << "module " << moduleName;
-        *out << nl;
         auto inserted = _outputs.emplace(scope, std::move(out));
         return *(inserted.first->second);
     }

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -349,8 +349,6 @@ Gen::generate(const UnitPtr& p)
 
     TypesVisitor typesVisitor(_fileBase, outputModulesVisitor.modules());
     p->visit(&typesVisitor);
-
-    typesVisitor.newLine(); // Ensure all files end with a newline
 }
 
 bool
@@ -409,6 +407,16 @@ Gen::TypesVisitor::TypesVisitor(const std::string& fileBase, const std::set<std:
     : _fileBase(fileBase),
       _modules(modules)
 {
+}
+
+void
+Gen::TypesVisitor::visitUnitEnd(const UnitPtr&)
+{
+    // Append a newline to each generated file to ensure it ends properly.
+    for (const auto& [_, output] : _outputs)
+    {
+        *output << nl;
+    }
 }
 
 bool
@@ -665,15 +673,6 @@ Slice::Gen::TypesVisitor::visitConst(const ConstPtr& p)
 
     p->unit()
         ->warning(p->file(), p->line(), WarningCategory::All, "ice2slice could not convert constant: " + p->name());
-}
-
-void
-Slice::Gen::TypesVisitor::newLine()
-{
-    for (const auto& [_, output] : _outputs)
-    {
-        *output << nl;
-    }
 }
 
 // Get the output stream where to write the mapped Slice construct, creating a new output stream if necessary. The

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -661,7 +661,7 @@ Slice::Gen::TypesVisitor::visitConst(const ConstPtr& p)
     Output& out = getOutput(p);
     out << sp;
     out << nl << "// ice2slice could not convert:";
-    out << nl << "// const " << p->name() << " = " << p->value();
+    out << nl << "// const " << p->type()->typeId() << " " << p->name() << " = " << p->value();
 
     p->unit()->warning(p->file(), p->line(), WarningCategory::All, "ice2slice could not convert constant: " + p->name());
 }

--- a/cpp/src/ice2slice/Gen.h
+++ b/cpp/src/ice2slice/Gen.h
@@ -22,8 +22,8 @@ namespace Slice
     private:
         std::string _fileBase;
 
-        /// The OutputModulesVisitor class gathers a list of modules requiring the generation of output `.slice` files. Each
-        /// `.ice` file may correspond to multiple `.slice` files, with one for each module that contains Slice
+        /// The OutputModulesVisitor class gathers a list of modules requiring the generation of output `.slice` files.
+        /// Each `.ice` file may correspond to multiple `.slice` files, with one for each module that contains Slice
         /// definitions.
         class OutputModulesVisitor final : public ParserVisitor
         {

--- a/cpp/src/ice2slice/Gen.h
+++ b/cpp/src/ice2slice/Gen.h
@@ -22,7 +22,10 @@ namespace Slice
     private:
         std::string _fileBase;
 
-        class OutputVisitor final : public ParserVisitor
+        /// The OutputModulesVisitor class gathers a list of modules requiring the generation of output `.slice` files. Each
+        /// `.ice` file may correspond to multiple `.slice` files, with one for each module that contains Slice
+        /// definitions.
+        class OutputModulesVisitor final : public ParserVisitor
         {
         public:
             bool visitClassDefStart(const ClassDefPtr&) final;
@@ -33,16 +36,28 @@ namespace Slice
             void visitDictionary(const DictionaryPtr&) final;
             void visitEnum(const EnumPtr&) final;
 
+            /// After visiting all definitions, return the list of scopes corresponding to modules for which we need
+            /// to generate an output `.slice`.
+            /// @return The list of modules for which we need to generate an output `.slice`.
             std::set<std::string> modules() const;
 
         private:
             std::set<std::string> _modules;
         };
 
+        /// The TypesVisitor class converts Slice definitions in `.ice` files to corresponding Slice definitions in
+        /// `.slice` files.
+        ///
+        /// If the `.ice` file contains a single module, the output is a single `.slice` file with the same base name,
+        /// replacing the `.ice` extension with `.slice`.
+        ///
+        /// If the `.ice` file contains multiple modules, it generates a `.slice` file for each module. Each file uses
+        /// the base name of the `.ice` file, appending the module scope with "::" replaced by "_" and the `.slice`
+        /// extension.
         class TypesVisitor final : public ParserVisitor
         {
         public:
-            TypesVisitor(const std::string&, const std::set<std::string>&);
+            TypesVisitor(const std::string& fileBase, const std::set<std::string>& modules);
 
             bool visitClassDefStart(const ClassDefPtr&) final;
             bool visitInterfaceDefStart(const InterfaceDefPtr&) final;

--- a/cpp/src/ice2slice/Gen.h
+++ b/cpp/src/ice2slice/Gen.h
@@ -59,6 +59,7 @@ namespace Slice
         public:
             TypesVisitor(const std::string& fileBase, const std::set<std::string>& modules);
 
+            void visitUnitEnd(const UnitPtr&) final;
             bool visitClassDefStart(const ClassDefPtr&) final;
             bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
             bool visitExceptionStart(const ExceptionPtr&) final;
@@ -67,8 +68,6 @@ namespace Slice
             void visitDictionary(const DictionaryPtr&) final;
             void visitEnum(const EnumPtr&) final;
             void visitConst(const ConstPtr&) final;
-
-            void newLine(); // Ensure all files end with a newline
 
         private:
             IceInternal::Output& getOutput(const ContainedPtr&);

--- a/cpp/src/ice2slice/Gen.h
+++ b/cpp/src/ice2slice/Gen.h
@@ -22,16 +22,16 @@ namespace Slice
     private:
         std::string _fileBase;
 
-        class OutputVisitor : public ParserVisitor
+        class OutputVisitor final : public ParserVisitor
         {
         public:
-            virtual bool visitClassDefStart(const ClassDefPtr&);
-            virtual bool visitInterfaceDefStart(const InterfaceDefPtr&);
-            virtual bool visitExceptionStart(const ExceptionPtr&);
-            virtual bool visitStructStart(const StructPtr&);
-            virtual void visitSequence(const SequencePtr&);
-            virtual void visitDictionary(const DictionaryPtr&);
-            virtual void visitEnum(const EnumPtr&);
+            bool visitClassDefStart(const ClassDefPtr&) final;
+            bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
+            bool visitExceptionStart(const ExceptionPtr&) final;
+            bool visitStructStart(const StructPtr&) final;
+            void visitSequence(const SequencePtr&)final;
+            void visitDictionary(const DictionaryPtr&) final;
+            void visitEnum(const EnumPtr&) final;
 
             std::set<std::string> modules() const;
 
@@ -39,18 +39,21 @@ namespace Slice
             std::set<std::string> _modules;
         };
 
-        class TypesVisitor : public ParserVisitor
+        class TypesVisitor final : public ParserVisitor
         {
         public:
             TypesVisitor(const std::string&, const std::set<std::string>&);
 
-            virtual bool visitClassDefStart(const ClassDefPtr&);
-            virtual bool visitInterfaceDefStart(const InterfaceDefPtr&);
-            virtual bool visitExceptionStart(const ExceptionPtr&);
-            virtual bool visitStructStart(const StructPtr&);
-            virtual void visitSequence(const SequencePtr&);
-            virtual void visitDictionary(const DictionaryPtr&);
-            virtual void visitEnum(const EnumPtr&);
+            bool visitClassDefStart(const ClassDefPtr&) final;
+            bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
+            bool visitExceptionStart(const ExceptionPtr&) final;
+            bool visitStructStart(const StructPtr&) final;
+            void visitSequence(const SequencePtr&) final;
+            void visitDictionary(const DictionaryPtr&) final;
+            void visitEnum(const EnumPtr&) final;
+            void visitConst(const ConstPtr&) final;
+
+            void newLine(); // Ensure all files end with a newline
 
         private:
             IceInternal::Output& getOutput(const ContainedPtr&);

--- a/cpp/src/ice2slice/Gen.h
+++ b/cpp/src/ice2slice/Gen.h
@@ -29,7 +29,7 @@ namespace Slice
             bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
             bool visitExceptionStart(const ExceptionPtr&) final;
             bool visitStructStart(const StructPtr&) final;
-            void visitSequence(const SequencePtr&)final;
+            void visitSequence(const SequencePtr&) final;
             void visitDictionary(const DictionaryPtr&) final;
             void visitEnum(const EnumPtr&) final;
 


### PR DESCRIPTION
This PR enhances ice2slice to emit a warning when a const definition appears in a .ice file, indicating that it cannot be converted into a Slice construct in the generated .slice file.

Additionally, it cleans up the newlines between constructs for improved readability.

See comments in #1809 