### PR TITLE
Add command-line property ordering testing

### DIFF
--- a/cpp/include/Ice/Properties.h
+++ b/cpp/include/Ice/Properties.h
@@ -207,7 +207,7 @@ namespace Ice
 
         /**
          * Parse a sequence of options into a map of key value pairs starting with a prefix. The options are expected to
-         * be of the form <code><em>key</em>=<em>value</em></code>.
+         * be of the form <code--<em>key</em>=<em>value</em></code>.
          * @param prefix The prefix to match.
          * @param options The options to parse.
          * @return A pair containing a map of matched key value pairs and a sequence of unmatched options.

--- a/cpp/include/Ice/Properties.h
+++ b/cpp/include/Ice/Properties.h
@@ -207,7 +207,7 @@ namespace Ice
 
         /**
          * Parse a sequence of options into a map of key value pairs starting with a prefix. The options are expected to
-         * be of the form <code--<em>key</em>=<em>value</em></code>.
+         * be of the form <code>--<em>key</em>=<em>value</em></code>.
          * @param prefix The prefix to match.
          * @param options The options to parse.
          * @return A pair containing a map of matched key value pairs and a sequence of unmatched options.

--- a/cpp/src/Ice/Properties.cpp
+++ b/cpp/src/Ice/Properties.cpp
@@ -599,7 +599,7 @@ Ice::Properties::parseOptions(string_view prefix, const StringSeq& options)
 
             if (auto optionPair = parseLine(opt.substr(2), 0))
             {
-                matched.insert_or_assign(optionPair->first, optionPair->second);
+                matched.insert_or_assign(std::move(optionPair->first), std::move(optionPair->second));
             }
         }
         else

--- a/cpp/src/Ice/Properties.cpp
+++ b/cpp/src/Ice/Properties.cpp
@@ -587,6 +587,7 @@ Ice::Properties::parseOptions(string_view prefix, const StringSeq& options)
     pfx = "--" + pfx;
 
     StringSeq unmatched;
+
     for (auto opt : options)
     {
         if (opt.find(pfx) == 0)
@@ -598,7 +599,7 @@ Ice::Properties::parseOptions(string_view prefix, const StringSeq& options)
 
             if (auto optionPair = parseLine(opt.substr(2), 0))
             {
-                matched.insert(*optionPair);
+                matched.insert_or_assign(optionPair->first, optionPair->second);
             }
         }
         else

--- a/cpp/test/Ice/properties/Client.cpp
+++ b/cpp/test/Ice/properties/Client.cpp
@@ -169,7 +169,7 @@ Client::run(int, char**)
         Ice::CommunicatorHolder communicator = Ice::initialize();
         Ice::PropertiesPtr properties = communicator->getProperties();
 
-        cout << "testing that creating an object adapter with unknown properties throws an exception..." << flush;
+        cout << "testing that creating an object adapter with unknown properties throws an exception... " << flush;
         properties->setProperty("FooOA.Endpoints", "tcp -h 127.0.0.1");
         properties->setProperty("FooOA.UnknownProperty", "bar");
         try
@@ -182,7 +182,7 @@ Client::run(int, char**)
         }
         cout << "ok" << endl;
 
-        cout << "testing that creating a proxy with unknown properties throws an exception..." << flush;
+        cout << "testing that creating a proxy with unknown properties throws an exception... " << flush;
         properties->setProperty("FooProxy", "test:tcp -h 127.0.0.1 -p 10000");
         properties->setProperty("FooProxy.UnknownProperty", "bar");
         try
@@ -195,7 +195,7 @@ Client::run(int, char**)
         }
         cout << "ok" << endl;
 
-        cout << "testing that setting a property in an opt-in prefix that is not configured throws an exception..."
+        cout << "testing that setting a property in an opt-in prefix that is not configured throws an exception... "
              << flush;
         try
         {
@@ -205,6 +205,14 @@ Client::run(int, char**)
         catch (const Ice::PropertyException&)
         {
         }
+        cout << "ok" << endl;
+    }
+
+    {
+        cout << "testing that passing a property multiple times on the command line uses the last value... " << flush;
+        Ice::StringSeq props{"--Ice.MessageSizeMax=10", "--Ice.MessageSizeMax=20"};
+        Ice::PropertiesPtr properties = Ice::createProperties(props, nullptr);
+        test(properties->getProperty("Ice.MessageSizeMax") == "20");
         cout << "ok" << endl;
     }
 }

--- a/csharp/src/Ice/Properties.cs
+++ b/csharp/src/Ice/Properties.cs
@@ -37,6 +37,10 @@ public sealed class Properties
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Properties" /> class with a list of opt-in prefixes.
+    /// </summary>
+    /// <param name="optInPrefixes">A list of opt-in prefixes to allow in the property set.</param>
     public Properties(List<string> optInPrefixes) => _optInPrefixes = optInPrefixes;
 
     /// <summary>

--- a/csharp/test/Ice/properties/Client.cs
+++ b/csharp/test/Ice/properties/Client.cs
@@ -78,7 +78,7 @@ public class Client : Test.TestHelper
         }
 
         {
-            Console.Out.Write("testing ice properties with set default values...");
+            Console.Out.Write("testing ice properties with set default values... ");
             Console.Out.Flush();
             Ice.Properties properties = new Ice.Properties();
             string toStringMode = properties.getIceProperty("Ice.ToStringMode");
@@ -92,7 +92,7 @@ public class Client : Test.TestHelper
         }
 
         {
-            Console.Out.Write("testing ice properties with unset default values...");
+            Console.Out.Write("testing ice properties with unset default values... ");
             Console.Out.Flush();
             Ice.Properties properties = new Ice.Properties();
             string stringValue = properties.getIceProperty("Ice.Admin.Router");
@@ -105,7 +105,7 @@ public class Client : Test.TestHelper
         }
 
         {
-            Console.Out.Write("testing that getting an unknown ice property throws an exception...");
+            Console.Out.Write("testing that getting an unknown ice property throws an exception... ");
             Console.Out.Flush();
             Ice.Properties properties = new Ice.Properties();
             try
@@ -120,7 +120,7 @@ public class Client : Test.TestHelper
         }
 
         {
-            Console.Out.Write("testing that setting an unknown ice property throws an exception...");
+            Console.Out.Write("testing that setting an unknown ice property throws an exception... ");
             Console.Out.Flush();
             Ice.Properties properties = new Ice.Properties();
             try
@@ -138,7 +138,7 @@ public class Client : Test.TestHelper
             using Ice.Communicator communicator = Ice.Util.initialize();
             Ice.Properties properties = communicator.getProperties();
 
-            Console.Out.Write("testing that creating an object adapter with unknown properties throws an exception...");
+            Console.Out.Write("testing that creating an object adapter with unknown properties throws an exception... ");
             properties.setProperty("FooOA.Endpoints", "tcp -h 127.0.0.1");
             properties.setProperty("FooOA.UnknownProperty", "bar");
             try
@@ -151,7 +151,7 @@ public class Client : Test.TestHelper
             }
             Console.Out.WriteLine("ok");
 
-            Console.Out.Write("testing that creating a proxy with unknown properties throws an exception...");
+            Console.Out.Write("testing that creating a proxy with unknown properties throws an exception... ");
             properties.setProperty("FooProxy", "test:tcp -h 127.0.0.1 -p 10000");
             properties.setProperty("FooProxy.UnknownProperty", "bar");
             try
@@ -165,7 +165,7 @@ public class Client : Test.TestHelper
 
             Console.Out.WriteLine("ok");
 
-            Console.Out.Write("testing that setting a property in an opt-in prefix that is not configured throws an exception...");
+            Console.Out.Write("testing that setting a property in an opt-in prefix that is not configured throws an exception... ");
             Console.Out.Flush();
             try
             {
@@ -175,6 +175,15 @@ public class Client : Test.TestHelper
             catch (Ice.PropertyException)
             {
             }
+            Console.Out.WriteLine("ok");
+        }
+
+        {
+            Console.Out.Write("testing that passing a property multiple times on the command line uses the last value... ");
+            Console.Out.Flush();
+            string[] commandLineArgs = ["--Ice.MessageSizeMax=10", "--Ice.MessageSizeMax=20"];
+            var properties = new Ice.Properties(ref commandLineArgs);
+            test(properties.getIceProperty("Ice.MessageSizeMax") == "20");
             Console.Out.WriteLine("ok");
         }
     }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
@@ -29,6 +29,11 @@ public final class Properties {
     /** Creates a new empty property set. */
     public Properties() {}
 
+    /**
+     * Creates a property set initialized with a list of opt-in prefixes.
+     *
+     * @param optInPrefixes A list of prefixes that are opt-in.
+     */
     public Properties(java.util.List<String> optInPrefixes) {
         _optInPrefixes.addAll(optInPrefixes);
     }

--- a/java/test/src/main/java/test/Ice/properties/Client.java
+++ b/java/test/src/main/java/test/Ice/properties/Client.java
@@ -174,6 +174,17 @@ public class Client extends test.TestHelper {
                 System.out.println("ok");
             }
         }
+
+        {
+            System.out.print(
+                    "testing that passing a property multiple times on the command line uses the"
+                            + " last value... ");
+            System.out.flush();
+            String[] commandLineArgs = {"--Ice.MessageSizeMax=10", "--Ice.MessageSizeMax=20"};
+            Properties properties = new Properties(commandLineArgs);
+            test(properties.getIceProperty("Ice.MessageSizeMax").equals("20"));
+            System.out.println("ok");
+        }
     }
 
     private static final String configPath = "./config/\u4E2D\u56FD_client.config";

--- a/js/test/Ice/properties/Client.ts
+++ b/js/test/Ice/properties/Client.ts
@@ -147,6 +147,13 @@ export class Client extends TestHelper {
 
             communicator.shutdown();
         }
+
+        {
+            out.write("testing that passing a property multiple times on the command line uses the last value... ");
+            const properties = Ice.createProperties(["--Ice.MessageSizeMax=10", "--Ice.MessageSizeMax=20"]);
+            test(properties.getIceProperty("Ice.MessageSizeMax") == "20");
+            out.writeLine("ok");
+        }
     }
 
     async run(args: string[]) {


### PR DESCRIPTION
The C++ behavior was broken. The test of the languages were fine.

Fixes #3111
