### PR TITLE
Upgrade DataStorm tests to use TestHelper class

### DIFF
--- a/cpp/test/DataStorm/api/Writer.cpp
+++ b/cpp/test/DataStorm/api/Writer.cpp
@@ -11,8 +11,15 @@ using namespace DataStorm;
 using namespace std;
 using namespace Test;
 
-int
-main(int argc, char* argv[])
+class Writer : public Test::TestHelper
+{
+public:
+    Writer() : Test::TestHelper(false) {}
+
+    void run(int, char**);
+};
+
+void ::Writer::run(int argc, char* argv[])
 {
     Node node(argc, argv);
 
@@ -325,6 +332,6 @@ main(int argc, char* argv[])
         os << skw.getLast().getEvent();
     }
     cout << "ok" << endl;
-
-    return 0;
 }
+
+DEFINE_TEST(::Writer)

--- a/cpp/test/DataStorm/callbacks/Reader.cpp
+++ b/cpp/test/DataStorm/callbacks/Reader.cpp
@@ -13,8 +13,15 @@ using namespace std;
 #    pragma GCC diagnostic ignored "-Wshadow"
 #endif
 
-int
-main(int argc, char* argv[])
+class Reader : public Test::TestHelper
+{
+public:
+    Reader() : Test::TestHelper(false) {}
+
+    void run(int, char**);
+};
+
+void ::Reader::run(int argc, char* argv[])
 {
     function<void(function<void()> call)> customExecutor = nullptr;
     for (int i = 1; i < argc; ++i)
@@ -369,5 +376,6 @@ main(int argc, char* argv[])
 
         readers.update(3);
     }
-    return 0;
 }
+
+DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/callbacks/Writer.cpp
+++ b/cpp/test/DataStorm/callbacks/Writer.cpp
@@ -13,8 +13,15 @@ using namespace std;
 #    pragma GCC diagnostic ignored "-Wshadow"
 #endif
 
-int
-main(int argc, char* argv[])
+class Writer : public Test::TestHelper
+{
+public:
+    Writer() : Test::TestHelper(false) {}
+
+    void run(int, char**);
+};
+
+void ::Writer::run(int argc, char* argv[])
 {
     function<void(function<void()> call)> customExecutor = nullptr;
     for (int i = 1; i < argc; ++i)
@@ -252,6 +259,6 @@ main(int argc, char* argv[])
         test(readers.getNextUnread().getValue() == 3);
     }
     cout << "ok" << endl;
-
-    return 0;
 }
+
+DEFINE_TEST(::Writer)

--- a/cpp/test/DataStorm/config/Reader.cpp
+++ b/cpp/test/DataStorm/config/Reader.cpp
@@ -8,8 +8,15 @@
 using namespace DataStorm;
 using namespace std;
 
-int
-main(int argc, char* argv[])
+class Reader : public Test::TestHelper
+{
+public:
+    Reader() : Test::TestHelper(false) {}
+
+    void run(int, char**);
+};
+
+void ::Reader::run(int argc, char* argv[])
 {
     Node node(argc, argv);
 
@@ -312,6 +319,6 @@ main(int argc, char* argv[])
         }
         readers.update(true); // Reader is done
     }
-
-    return 0;
 }
+
+DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/config/Writer.cpp
+++ b/cpp/test/DataStorm/config/Writer.cpp
@@ -10,8 +10,15 @@
 using namespace DataStorm;
 using namespace std;
 
-int
-main(int argc, char* argv[])
+class Writer : public Test::TestHelper
+{
+public:
+    Writer() : Test::TestHelper(false) {}
+
+    void run(int, char**);
+};
+
+void ::Writer::run(int argc, char* argv[])
 {
     Node node(argc, argv);
 
@@ -327,6 +334,6 @@ main(int argc, char* argv[])
             ; // Wait for reader to be done
     }
     cout << "ok" << endl;
-
-    return 0;
 }
+
+DEFINE_TEST(::Writer)

--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -9,8 +9,15 @@
 using namespace DataStorm;
 using namespace std;
 
-int
-main(int argc, char* argv[])
+class Reader : public Test::TestHelper
+{
+public:
+    Reader() : Test::TestHelper(false) {}
+
+    void run(int, char**);
+};
+
+void ::Reader::run(int argc, char* argv[])
 {
     Node node(argc, argv);
 
@@ -390,6 +397,6 @@ main(int argc, char* argv[])
             testSample(reader2, SampleEvent::Update, "elem3", "value");
         }
     }
-
-    return 0;
 }
+
+DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -9,8 +9,15 @@
 using namespace DataStorm;
 using namespace std;
 
-int
-main(int argc, char* argv[])
+class Writer : public Test::TestHelper
+{
+public:
+    Writer() : Test::TestHelper(false) {}
+
+    void run(int, char**);
+};
+
+void ::Writer::run(int argc, char* argv[])
 {
     Node node(argc, argv);
 
@@ -389,6 +396,6 @@ main(int argc, char* argv[])
         }
     }
     cout << "ok" << endl;
-
-    return 0;
 }
+
+DEFINE_TEST(::Writer)

--- a/cpp/test/DataStorm/partial/Reader.cpp
+++ b/cpp/test/DataStorm/partial/Reader.cpp
@@ -10,8 +10,15 @@ using namespace DataStorm;
 using namespace std;
 using namespace Test;
 
-int
-main(int argc, char* argv[])
+class Reader : public Test::TestHelper
+{
+public:
+    Reader() : Test::TestHelper(false) {}
+
+    void run(int, char**);
+};
+
+void ::Reader::run(int argc, char* argv[])
 {
     Node node(argc, argv);
 
@@ -64,6 +71,6 @@ main(int argc, char* argv[])
         test(sample.getEvent() == SampleEvent::PartialUpdate);
         test(sample.getValue().price == 18.0f);
     }
-
-    return 0;
 }
+
+DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/partial/Writer.cpp
+++ b/cpp/test/DataStorm/partial/Writer.cpp
@@ -13,8 +13,15 @@ using namespace DataStorm;
 using namespace std;
 using namespace Test;
 
-int
-main(int argc, char* argv[])
+class Writer : public Test::TestHelper
+{
+public:
+    Writer() : Test::TestHelper(false) {}
+
+    void run(int, char**);
+};
+
+void ::Writer::run(int argc, char* argv[])
 {
     Node node(argc, argv);
 
@@ -37,6 +44,6 @@ main(int argc, char* argv[])
         writer.waitForNoReaders();
     }
     cout << "ok" << endl;
-
-    return 0;
 }
+
+DEFINE_TEST(::Writer)

--- a/cpp/test/DataStorm/reliability/Reader.cpp
+++ b/cpp/test/DataStorm/reliability/Reader.cpp
@@ -10,8 +10,15 @@
 using namespace DataStorm;
 using namespace std;
 
-int
-main(int argc, char* argv[])
+class Reader : public Test::TestHelper
+{
+public:
+    Reader() : Test::TestHelper(false) {}
+
+    void run(int, char**);
+};
+
+void ::Reader::run(int argc, char* argv[])
 {
     Node node(argc, argv);
 
@@ -60,5 +67,6 @@ main(int argc, char* argv[])
         writer.update(0);
         writer.waitForNoReaders();
     }
-    return 0;
 }
+
+DEFINE_TEST(::Reader)

--- a/cpp/test/DataStorm/reliability/Writer.cpp
+++ b/cpp/test/DataStorm/reliability/Writer.cpp
@@ -10,8 +10,15 @@
 using namespace DataStorm;
 using namespace std;
 
-int
-main(int argc, char* argv[])
+class Writer : public Test::TestHelper
+{
+public:
+    Writer() : Test::TestHelper(false) {}
+
+    void run(int, char**);
+};
+
+void ::Writer::run(int argc, char* argv[])
 {
     Node node(argc, argv);
 
@@ -49,6 +56,6 @@ main(int argc, char* argv[])
         makeSingleKeyReader(topic, "barrier").getNextUnread();
     }
     cout << "ok" << endl;
-
-    return 0;
 }
+
+DEFINE_TEST(::Writer)

--- a/cpp/test/DataStorm/types/Reader.cpp
+++ b/cpp/test/DataStorm/types/Reader.cpp
@@ -16,6 +16,14 @@ using namespace DataStorm;
 using namespace std;
 using namespace Test;
 
+class Reader : public Test::TestHelper
+{
+public:
+    Reader() : Test::TestHelper(false) {}
+
+    void run(int, char**);
+};
+
 namespace
 {
 
@@ -74,8 +82,7 @@ namespace DataStorm
 
 }
 
-int
-main(int argc, char* argv[])
+void ::Reader::run(int argc, char* argv[])
 {
     Node node(argc, argv);
 
@@ -115,5 +122,6 @@ main(int argc, char* argv[])
         Topic<color, string>(node, "enumstring"),
         map<color, string>{{color::blue, "v1"}, {color::red, "v2"}},
         map<color, string>{{color::blue, "u1"}, {color::red, "u2"}});
-    return 0;
 }
+
+DEFINE_TEST(::Reader)


### PR DESCRIPTION
This PR upgrades the DataStorm tests to use the TestHelper class. For Windows this specially important to avoid tests hanging on an alert window.

See https://github.com/zeroc-ice/ice/blob/140192b1e381b971b92f12fb7b844a0a43f45869/cpp/test/Common/TestHelper.cpp#L151-L160