### PR TITLE
Replace ':nodoc:' with a proper 'DocC' attribute.

### DIFF
--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -353,7 +353,7 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     }
 
     out << sp;
-    out << nl << "/// :nodoc:";
+    out << nl << "@_documentation(visibility: internal)";
     out << nl << "public class " << name
         << "_TypeResolver: " << getUnqualified("Ice.UserExceptionTypeResolver", swiftModule);
     out << sb;
@@ -1207,7 +1207,7 @@ Gen::ValueVisitor::visitClassDefStart(const ClassDefPtr& p)
     ClassDefPtr base = p->base();
 
     out << sp;
-    out << nl << "/// :nodoc:";
+    out << nl << "@_documentation(visibility: internal)";
     out << nl << "public class " << name << "_TypeResolver: " << getUnqualified("Ice.ValueTypeResolver", swiftModule);
     out << sb;
     out << nl << "public override func type() -> " << getUnqualified("Ice.Value.Type", swiftModule);


### PR DESCRIPTION
I checked the generated documentation site and this works correctly: the types it's applied to no longer show up at all in the reference.

The `:nodoc:` that we're using seems to be a holdover from the older "Jazz" documentation system that I guess we used to be using.