### PR TITLE
Report Unknown Doc-Comment Tags in Slice

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -321,12 +321,6 @@ Slice::Comment::overview() const
 }
 
 StringList
-Slice::Comment::misc() const
-{
-    return _misc;
-}
-
-StringList
 Slice::Comment::seeAlso() const
 {
     return _seeAlso;
@@ -777,95 +771,99 @@ Slice::Contained::parseComment(function<string(string, string)> linkFormatter, b
 
     enum State
     {
-        StateMisc,
+        StateUnknown,
         StateParam,
         StateThrows,
+        StateSee,
         StateReturn,
         StateDeprecated
     };
-    State state = StateMisc;
+    State state = StateUnknown;
     string name;
     const string ws = " \t";
     const string paramTag = "@param";
     const string throwsTag = "@throws";
     const string exceptionTag = "@exception";
+    const string seeTag = "@see";
     const string returnTag = "@return";
     const string deprecatedTag = "@deprecated";
-    const string seeTag = "@see";
     for (; i != lines.end(); ++i)
     {
         const string l = IceInternal::trim(*i);
-        string line;
-        if (parseCommentLine(l, paramTag, true, name, line))
+        string lineText;
+        if (parseCommentLine(l, paramTag, true, name, lineText))
         {
-            if (!line.empty())
+            if (!lineText.empty())
             {
                 state = StateParam;
                 StringList sl;
-                sl.push_back(line); // The first line of the description.
+                sl.push_back(lineText); // The first line of the description.
                 comment->_parameters[name] = sl;
             }
         }
-        else if (parseCommentLine(l, throwsTag, true, name, line))
+        else if (parseCommentLine(l, throwsTag, true, name, lineText))
         {
-            if (!line.empty())
+            if (!lineText.empty())
             {
                 state = StateThrows;
                 StringList sl;
-                sl.push_back(line); // The first line of the description.
+                sl.push_back(lineText); // The first line of the description.
                 comment->_exceptions[name] = sl;
             }
         }
-        else if (parseCommentLine(l, exceptionTag, true, name, line))
+        else if (parseCommentLine(l, exceptionTag, true, name, lineText))
         {
-            if (!line.empty())
+            if (!lineText.empty())
             {
                 state = StateThrows;
                 StringList sl;
-                sl.push_back(line); // The first line of the description.
+                sl.push_back(lineText); // The first line of the description.
                 comment->_exceptions[name] = sl;
             }
         }
-        else if (parseCommentLine(l, seeTag, false, name, line))
+        else if (parseCommentLine(l, seeTag, false, name, lineText))
         {
-            if (!line.empty())
+            if (!lineText.empty())
             {
-                state = StateMisc; // Reset the state; `@see` cannot span multiple lines.
-                comment->_seeAlso.push_back(line);
+                state = StateSee;
+                comment->_seeAlso.push_back(lineText);
             }
         }
-        else if (parseCommentLine(l, returnTag, false, name, line))
+        else if (parseCommentLine(l, returnTag, false, name, lineText))
         {
-            if (!line.empty())
+            if (!lineText.empty())
             {
                 state = StateReturn;
-                comment->_returns.push_back(line); // The first line of the description.
+                comment->_returns.push_back(lineText); // The first line of the description.
             }
         }
-        else if (parseCommentLine(l, deprecatedTag, false, name, line))
+        else if (parseCommentLine(l, deprecatedTag, false, name, lineText))
         {
             comment->_isDeprecated = true;
-            if (!line.empty())
+            if (!lineText.empty())
             {
                 state = StateDeprecated;
-                comment->_deprecated.push_back(line); // The first line of the description.
+                comment->_deprecated.push_back(lineText); // The first line of the description.
             }
         }
         else if (!l.empty())
         {
             if (l[0] == '@')
             {
-                //
-                // Treat all other tags as miscellaneous comments.
-                //
-                state = StateMisc;
+                // We've encountered an unknown doc tag.
+                auto unknownTag = l.substr(0, l.find_first_not_of(" \t:"));
+                string msg = "encountered unknown doc tag '" + unknownTag + "' in comment";
+                unit()->warning(file(), line(), InvalidComment, msg);
+                state = StateUnknown;
+                continue;
             }
 
             switch (state)
             {
-                case StateMisc:
+                case StateUnknown:
                 {
-                    comment->_misc.push_back(l);
+                    // Getting here means we've hit an unknown tag that spanned multiple lines.
+                    // We immediately break - ignoring and discarding the line.
                     break;
                 }
                 case StateParam:
@@ -892,6 +890,14 @@ Slice::Contained::parseComment(function<string(string, string)> linkFormatter, b
                     comment->_exceptions[name] = sl;
                     break;
                 }
+                case StateSee:
+                {
+                    // This isn't allowed - '@see' tags cannot span multiple lines.
+                    // We issue a warning, then discard the line.
+                    string msg = "'@see' comment tags cannot span multiple lines and can only be of the form: '@see identifier'";
+                    unit()->warning(file(), line(), InvalidComment, msg);
+                    break;
+                }
                 case StateReturn:
                 {
                     comment->_returns.push_back(l);
@@ -908,7 +914,6 @@ Slice::Contained::parseComment(function<string(string, string)> linkFormatter, b
 
     trimLines(comment->_overview);
     trimLines(comment->_deprecated);
-    trimLines(comment->_misc);
     trimLines(comment->_returns);
 
     return comment;

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -287,6 +287,10 @@ Slice::DefinitionContext::initSuppressedWarnings()
                 {
                     _suppressedWarnings.insert(InvalidMetadata);
                 }
+                else if (s == "invalid-comment")
+                {
+                    _suppressedWarnings.insert(InvalidComment);
+                }
                 else
                 {
                     ostringstream os;

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -851,7 +851,7 @@ Slice::Contained::parseComment(function<string(string, string)> linkFormatter, b
             if (l[0] == '@')
             {
                 // We've encountered an unknown doc tag.
-                auto unknownTag = l.substr(0, l.find_first_not_of(" \t:"));
+                auto unknownTag = l.substr(0, l.find_first_of(" \t:"));
                 string msg = "encountered unknown doc tag '" + unknownTag + "' in comment";
                 unit()->warning(file(), line(), InvalidComment, msg);
                 state = StateUnknown;

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -856,7 +856,7 @@ Slice::Contained::parseComment(function<string(string, string)> linkFormatter, b
             {
                 // We've encountered an unknown doc tag.
                 auto unknownTag = l.substr(0, l.find_first_of(" \t:"));
-                string msg = "encountered unknown doc tag '" + unknownTag + "' in comment";
+                string msg = "ignoring unknown doc tag '" + unknownTag + "' in comment";
                 unit()->warning(file(), line(), InvalidComment, msg);
                 state = StateUnknown;
                 continue;
@@ -896,8 +896,8 @@ Slice::Contained::parseComment(function<string(string, string)> linkFormatter, b
                 }
                 case StateSee:
                 {
-                    // This isn't allowed - '@see' tags cannot span multiple lines.
-                    // We issue a warning, then discard the line.
+                    // This isn't allowed - '@see' tags cannot span multiple lines. We've already kept the original
+                    // line by this point, but we ignore any lines that follow it (until hitting another '@' tag).
                     string msg = "'@see' comment tags cannot span multiple lines and can only be of the form: '@see identifier'";
                     unit()->warning(file(), line(), InvalidComment, msg);
                     break;

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -898,7 +898,7 @@ Slice::Contained::parseComment(function<string(string, string)> linkFormatter, b
                 {
                     // This isn't allowed - '@see' tags cannot span multiple lines. We've already kept the original
                     // line by this point, but we ignore any lines that follow it (until hitting another '@' tag).
-                    string msg = "'@see' comment tags cannot span multiple lines and can only be of the form: '@see identifier'";
+                    string msg = "'@see' tags cannot span multiple lines and must be of the form: '@see identifier'";
                     unit()->warning(file(), line(), InvalidComment, msg);
                     break;
                 }

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -38,7 +38,8 @@ namespace Slice
     {
         All,
         Deprecated,
-        InvalidMetadata
+        InvalidMetadata,
+        InvalidComment
     };
 
     class GrammarBase;
@@ -252,9 +253,7 @@ namespace Slice
 
         /// Contains all introductory lines up to the first tag.
         StringList overview() const;
-        /// Contains unrecognized tags.
-        StringList misc() const;
-        /// Targets of @see tags.
+        /// Targets of '@see' tags.
         StringList seeAlso() const;
 
         /// Description of an operation's return value.
@@ -270,7 +269,6 @@ namespace Slice
         bool _isDeprecated;
         StringList _deprecated;
         StringList _overview;
-        StringList _misc;
         StringList _seeAlso;
 
         StringList _returns;

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -398,11 +398,6 @@ namespace
             writeDocLines(out, doc->overview(), true);
         }
 
-        if (!doc->misc().empty())
-        {
-            writeDocLines(out, doc->misc(), true);
-        }
-
         if (!doc->seeAlso().empty())
         {
             writeSeeAlso(out, doc->seeAlso());
@@ -539,12 +534,6 @@ namespace
         if (showExceptions)
         {
             writeOpDocExceptions(out, op, doc);
-        }
-
-        const auto& misc = doc->misc();
-        if (!misc.empty())
-        {
-            writeDocLines(out, misc, true);
         }
 
         const auto& seeAlso = doc->seeAlso();

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -1860,12 +1860,6 @@ Slice::JavaVisitor::writeDocComment(Output& out, const UnitPtr& unt, const Comme
         writeDocCommentLines(out, dc->overview());
     }
 
-    if (!dc->misc().empty())
-    {
-        out << nl << " * ";
-        writeDocCommentLines(out, dc->misc());
-    }
-
     if (!dc->seeAlso().empty())
     {
         out << nl << " *";
@@ -2005,12 +1999,6 @@ Slice::JavaVisitor::writeProxyDocComment(
             out << nl << " * @throws " << fixKwd(i->first) << ' ';
             writeDocCommentLines(out, i->second);
         }
-    }
-
-    if (!dc->misc().empty())
-    {
-        out << nl << " * ";
-        writeDocCommentLines(out, dc->misc());
     }
 
     if (!dc->seeAlso().empty())
@@ -2170,12 +2158,6 @@ Slice::JavaVisitor::writeServantDocComment(
             out << nl << " * @throws " << fixKwd(i->first) << ' ';
             writeDocCommentLines(out, i->second);
         }
-    }
-
-    if (!dc->misc().empty())
-    {
-        out << nl << " * ";
-        writeDocCommentLines(out, dc->misc());
     }
 
     if (!dc->seeAlso().empty())

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -495,11 +495,6 @@ Slice::JsVisitor::writeDocCommentFor(const ContainedPtr& p, bool includeDeprecat
             writeDocLines(_out, comment->overview(), true);
         }
 
-        if (!comment->misc().empty())
-        {
-            writeDocLines(_out, comment->misc(), true);
-        }
-
         if (!comment->seeAlso().empty())
         {
             writeSeeAlso(_out, comment->seeAlso());
@@ -2503,11 +2498,6 @@ Slice::Gen::TypeScriptVisitor::writeOpDocSummary(
     if (comment)
     {
         writeOpDocExceptions(out, op, comment);
-
-        if (!comment->misc().empty())
-        {
-            writeDocLines(out, comment->misc(), true);
-        }
 
         if (!comment->seeAlso().empty())
         {

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -970,13 +970,6 @@ namespace
             }
         }
 
-        StringList docMisc = doc->misc();
-        if (!docMisc.empty())
-        {
-            out << nl << "%";
-            writeDocLines(out, docMisc, true);
-        }
-
         StringList docSeeAlso = doc->seeAlso();
         if (!docSeeAlso.empty())
         {
@@ -1138,13 +1131,6 @@ namespace
             }
         }
 
-        StringList docMisc = doc->misc();
-        if (!docMisc.empty())
-        {
-            out << nl << "%";
-            writeDocLines(out, docMisc, true);
-        }
-
         StringList docSeeAlso = doc->seeAlso();
         if (!docSeeAlso.empty())
         {
@@ -1224,13 +1210,6 @@ namespace
         out << nl << "%   checkedCast - Contacts the remote server to verify that the object implements this type.";
         out << nl << "%   uncheckedCast - Downcasts the given proxy to this type without contacting the remote server.";
 
-        StringList docMisc = doc->misc();
-        if (!docMisc.empty())
-        {
-            out << nl << "%";
-            writeDocLines(out, docMisc, true);
-        }
-
         StringList docSeeAlso = doc->seeAlso();
         if (!docSeeAlso.empty())
         {
@@ -1263,7 +1242,6 @@ namespace
         }
 
         StringList docOverview = doc->overview();
-        StringList docMisc = doc->misc();
         StringList docSeeAlso = doc->seeAlso();
         StringList docDeprecated = doc->deprecated();
         bool docIsDeprecated = doc->isDeprecated();
@@ -1285,12 +1263,6 @@ namespace
         {
             out << " - ";
             writeDocLines(out, docOverview, false);
-        }
-
-        if (!docMisc.empty())
-        {
-            out << nl << "%";
-            writeDocLines(out, docMisc, true);
         }
 
         if (!docSeeAlso.empty())

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -361,17 +361,6 @@ SwiftGenerator::writeDocSummary(IceInternal::Output& out, const ContainedPtr& p)
         hasStarted = true;
     }
 
-    StringList docMisc = doc->misc();
-    if (!docMisc.empty())
-    {
-        if (hasStarted)
-        {
-            out << nl << "///";
-        }
-        hasStarted = true;
-        writeDocLines(out, docMisc);
-    }
-
     if (doc->isDeprecated())
     {
         if (hasStarted)
@@ -532,13 +521,6 @@ SwiftGenerator::writeOpDocSummary(IceInternal::Output& out, const OperationPtr& 
             }
         }
     }
-
-    StringList docMisc = doc->misc();
-    if (!docMisc.empty())
-    {
-        out << nl;
-        writeDocLines(out, docMisc, false);
-    }
 }
 
 void
@@ -596,12 +578,6 @@ SwiftGenerator::writeProxyDocSummary(IceInternal::Output& out, const InterfaceDe
             }
         }
     }
-
-    StringList docMisc = doc->misc();
-    if (!docMisc.empty())
-    {
-        writeDocLines(out, docMisc, false);
-    }
 }
 
 void
@@ -644,12 +620,6 @@ SwiftGenerator::writeServantDocSummary(IceInternal::Output& out, const Interface
                 }
             }
         }
-    }
-
-    StringList docMisc = doc->misc();
-    if (!docMisc.empty())
-    {
-        writeDocLines(out, docMisc, false);
     }
 }
 

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.err
@@ -1,3 +1,3 @@
 WarningInvalidComment.ice:10: warning: ignoring unknown doc tag '@remarks' in comment
-WarningInvalidComment.ice:10: warning: '@see' comment tags cannot span multiple lines and can only be of the form: '@see identifier'
+WarningInvalidComment.ice:10: warning: '@see' tags cannot span multiple lines and must be of the form: '@see identifier'"
 WarningInvalidComment.ice:10: warning: ignoring unknown doc tag '@bad' in comment

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.err
@@ -1,3 +1,3 @@
-WarningInvalidComment.ice:10: warning: encountered unknown doc tag '@remarks' in comment
+WarningInvalidComment.ice:10: warning: ignoring unknown doc tag '@remarks' in comment
 WarningInvalidComment.ice:10: warning: '@see' comment tags cannot span multiple lines and can only be of the form: '@see identifier'
-WarningInvalidComment.ice:10: warning: encountered unknown doc tag '@bad' in comment
+WarningInvalidComment.ice:10: warning: ignoring unknown doc tag '@bad' in comment

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.err
@@ -1,3 +1,3 @@
 WarningInvalidComment.ice:10: warning: ignoring unknown doc tag '@remarks' in comment
-WarningInvalidComment.ice:10: warning: '@see' tags cannot span multiple lines and must be of the form: '@see identifier'"
+WarningInvalidComment.ice:10: warning: '@see' tags cannot span multiple lines and must be of the form: '@see identifier'
 WarningInvalidComment.ice:10: warning: ignoring unknown doc tag '@bad' in comment

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.err
@@ -1,0 +1,3 @@
+WarningInvalidComment.ice:10: warning: encountered unknown doc tag '@bad' in comment
+WarningInvalidComment.ice:10: warning: '@see' comment tags cannot span multiple lines and can only be of the form: '@see identifier'
+WarningInvalidComment.ice:10: warning: encountered unknown doc tag '@foo' in comment

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.err
@@ -1,3 +1,3 @@
-WarningInvalidComment.ice:10: warning: encountered unknown doc tag '@bad' in comment
+WarningInvalidComment.ice:10: warning: encountered unknown doc tag '@remarks' in comment
 WarningInvalidComment.ice:10: warning: '@see' comment tags cannot span multiple lines and can only be of the form: '@see identifier'
-WarningInvalidComment.ice:10: warning: encountered unknown doc tag '@foo' in comment
+WarningInvalidComment.ice:10: warning: encountered unknown doc tag '@bad' in comment

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.ice
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.ice
@@ -2,10 +2,10 @@
 module Test
 {
     /// This is a test overview.
-    /// @bad: This is an unknown comment tag which spans 1 line.
+    /// @remarks: This is an unknown comment tag which spans 1 line.
     /// @see: CommentDummy
     ///       But then we write a 2nd line, which isn't allowed for 'see' tags.
-    /// @foo: Another unknown comment tag, but this will span 2 lines.
+    /// @bad: Another unknown comment tag, but this will span 2 lines.
     ///       This 2nd line should be ignored, but won't trigger another error.
     class CommentDummy {}
 }

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.ice
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.ice
@@ -1,0 +1,11 @@
+
+module Test
+{
+    /// This is a test overview.
+    /// @bad: This is an unknown comment tag which spans 1 line.
+    /// @see: CommentDummy
+    ///       But then we write a 2nd line, which isn't allowed for 'see' tags.
+    /// @foo: Another unknown comment tag, but this will span 2 lines.
+    ///       This 2nd line should be ignored, but won't trigger another error.
+    class CommentDummy {}
+}


### PR DESCRIPTION
This PR fixes #2088.
Now, the Slice parser rejects unknown doc-comment tags (including `@remarks`), making it's situation impossible to hit.

It also adds a check which rejects multi-line `@see` tags, since these are disallowed and `@see` should always be of the form: `@see IDENTIFIER` and nothing else.

When the parser encounters either of these cases, we discard (ignore) the offending line, and issue a _warning_ for it.
I think that the predominant philosophy in compilers is that: "a badly formatted comment should never break your build".
Since, on a logical level, compilers _should be_ ignoring all comments in your source file.

Since we currently have no validation of comments, I also added a new "InvalidComment" diagnostic category, which this PR uses.