### PR TITLE
Update Ice/ami to make sure connection close doesn't throw

### DIFF
--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -1118,7 +1118,7 @@ allTests(TestHelper* helper, bool collocated)
                 {
                     done = true;
                     p->ice_ping();
-                    vector<future<void>> results;
+                    vector<future<void>> futures;
                     for (int i = 0; i < maxQueue; ++i)
                     {
                         auto s = make_shared<promise<void>>();
@@ -1126,10 +1126,17 @@ allTests(TestHelper* helper, bool collocated)
                             seq,
                             [s]() { s->set_value(); },
                             [s](exception_ptr ex) { s->set_exception(ex); });
-                        results.push_back(s->get_future());
+                        futures.push_back(s->get_future());
                     }
                     atomic_flag sent = ATOMIC_FLAG_INIT;
-                    p->closeConnectionAsync(nullptr, nullptr, [&sent](bool) { sent.test_and_set(); });
+
+                    auto closePromise = make_shared<promise<void>>();
+                    p->closeConnectionAsync(
+                        [closePromise] { closePromise->set_value(); },
+                        [closePromise](exception_ptr ex) { closePromise->set_exception(ex); },
+                        [&sent](bool) { sent.test_and_set(); });
+                    futures.push_back(closePromise->get_future());
+
                     if (!sent.test_and_set())
                     {
                         for (int i = 0; i < maxQueue; i++)
@@ -1141,7 +1148,7 @@ allTests(TestHelper* helper, bool collocated)
                                 [s]() { s->set_value(); },
                                 [s](exception_ptr ex) { s->set_exception(ex); },
                                 [&sent2](bool) { sent2.test_and_set(); });
-                            results.push_back(s->get_future());
+                            futures.push_back(s->get_future());
                             if (sent2.test_and_set())
                             {
                                 done = false;
@@ -1156,11 +1163,11 @@ allTests(TestHelper* helper, bool collocated)
                         done = false;
                     }
 
-                    for (vector<future<void>>::iterator r = results.begin(); r != results.end(); ++r)
+                    for (auto& f : futures)
                     {
                         try
                         {
-                            r->get();
+                            f.get();
                         }
                         catch (const Ice::LocalException& ex)
                         {

--- a/cpp/test/Ice/ami/TestI.cpp
+++ b/cpp/test/Ice/ami/TestI.cpp
@@ -97,7 +97,20 @@ TestIntfI::waitForBatch(int32_t count, const Ice::Current&)
 void
 TestIntfI::closeConnection(const Ice::Current& current)
 {
-    current.con->close(nullptr, nullptr);
+    current.con->close(
+        nullptr,
+        [](exception_ptr ex)
+        {
+            try
+            {
+                rethrow_exception(ex);
+            }
+            catch (const std::exception& e)
+            {
+                cerr << "Connection::close failed with: " << e.what() << endl;
+                test(false);
+            }
+        });
 }
 
 void

--- a/csharp/test/Ice/ami/TestI.cs
+++ b/csharp/test/Ice/ami/TestI.cs
@@ -73,7 +73,20 @@ namespace Ice
             public override void closeConnection(Ice.Current current)
             {
                 // We can't wait for the connection to close - it would self-deadlock. So we just initiate the closure.
-                _ = current.con.closeAsync();
+                _ = closeAsync();
+
+                async Task closeAsync()
+                {
+                    try
+                    {
+                        await current.con.closeAsync();
+                    }
+                    catch (System.Exception ex)
+                    {
+                        Console.WriteLine($"Connection close failed: {ex}");
+                        test(false);
+                    }
+                }
             }
 
             public override void abortConnection(Ice.Current current)

--- a/java/test/src/main/java/test/Ice/ami/TestI.java
+++ b/java/test/src/main/java/test/Ice/ami/TestI.java
@@ -128,9 +128,17 @@ public class TestI implements TestIntf {
     @Override
     public void closeConnection(com.zeroc.Ice.Current current) {
         // We can't wait for the connection to be closed - this would cause a self dead-lock.
-        // So instead we just initiate the closure by running `close` in a separate thread.
-        var closureThread = new Thread(() -> current.con.close());
-        closureThread.start();
+        // So instead we just initiate the closure in the background.
+        CompletableFuture.runAsync(
+                () -> {
+                    try {
+                        current.con.close();
+                    } catch (Exception e) {
+                        // make sure the closure is graceful
+                        System.err.println("********** Connection.close failed: " + e);
+                        test(false);
+                    }
+                });
     }
 
     @Override

--- a/python/test/Ice/ami/TestI.py
+++ b/python/test/Ice/ami/TestI.py
@@ -45,6 +45,7 @@ class TestIntfI(Test.TestIntf):
             return result
 
     def closeConnection(self, current):
+        # TODO: make sure close is graceful once API is fixed
         current.con.close(False)
 
     def abortConnection(self, current):

--- a/swift/test/Ice/ami/AllTests.swift
+++ b/swift/test/Ice/ami/AllTests.swift
@@ -312,6 +312,8 @@ func allTests(_ helper: TestHelper, collocated: Bool = false) async throws {
 
                     maxQueue *= 2
                 }
+
+                try await p.ice_getCachedConnection()!.close()
             }
         }
 

--- a/swift/test/Ice/ami/TestI.swift
+++ b/swift/test/Ice/ami/TestI.swift
@@ -150,7 +150,13 @@ class TestI: TestIntf {
     }
 
     func closeConnection(current: Current) async throws {
-        Task { try await current.con!.close() }
+        Task {
+            do {
+                try await current.con!.close()
+            } catch {
+                fatalError("Connection.close failed: \(error)")
+            }
+        }
     }
 
     func abortConnection(current: Current) async throws {


### PR DESCRIPTION
Prior to this PR, the Ice/ami largely ignored the completion of calls to Connection.close.