### PR TITLE
Set TCP backlog default to 511, remove SOMAXCONN

### DIFF
--- a/config/PropertyNames.xml
+++ b/config/PropertyNames.xml
@@ -144,7 +144,7 @@
         <property name="Trace.ThreadPool" languages="cpp,csharp,java" default="0" />
         <property name="UDP.RcvSize" languages="cpp,csharp,java" />
         <property name="UDP.SndSize" languages="cpp,csharp,java" />
-        <property name="TCP.Backlog" languages="cpp,csharp,java" />
+        <property name="TCP.Backlog" languages="cpp,csharp,java" default="511" />
         <property name="TCP.RcvSize" languages="cpp,csharp,java" />
         <property name="TCP.SndSize" languages="cpp,csharp,java" />
         <property name="UseOSLog" languages="cpp" default="0" />

--- a/config/makeprops.py
+++ b/config/makeprops.py
@@ -453,7 +453,7 @@ final class PropertyNames
             location,
             "java",
             "src",
-            "Ice",
+            "com.zeroc.ice",
             "src",
             "main",
             "java",

--- a/cpp/src/Ice/PropertyNames.cpp
+++ b/cpp/src/Ice/PropertyNames.cpp
@@ -181,7 +181,7 @@ const Property IcePropsData[] =
     Property{"Trace.ThreadPool", "0", false, false, nullptr},
     Property{"UDP.RcvSize", "", false, false, nullptr},
     Property{"UDP.SndSize", "", false, false, nullptr},
-    Property{"TCP.Backlog", "", false, false, nullptr},
+    Property{"TCP.Backlog", "511", false, false, nullptr},
     Property{"TCP.RcvSize", "", false, false, nullptr},
     Property{"TCP.SndSize", "", false, false, nullptr},
     Property{"UseOSLog", "0", false, false, nullptr},

--- a/cpp/src/Ice/TcpAcceptor.cpp
+++ b/cpp/src/Ice/TcpAcceptor.cpp
@@ -20,13 +20,6 @@
 #        include <Mswsock.h>
 #    endif
 
-//
-// Use the system default for the listen() backlog or 511 if not defined.
-//
-#    ifndef SOMAXCONN
-#        define SOMAXCONN 511
-#    endif
-
 using namespace std;
 using namespace Ice;
 using namespace IceInternal;
@@ -198,7 +191,7 @@ IceInternal::TcpAcceptor::TcpAcceptor(
       _info(SocketOperationRead)
 #    endif
 {
-    _backlog = instance->properties()->getPropertyAsIntWithDefault("Ice.TCP.Backlog", SOMAXCONN);
+    _backlog = instance->properties()->getIcePropertyAsInt("Ice.TCP.Backlog");
     _fd = createServerSocket(false, _addr, instance->protocolSupport());
 
 #    ifdef ICE_USE_IOCP

--- a/cpp/src/Ice/ios/StreamAcceptor.cpp
+++ b/cpp/src/Ice/ios/StreamAcceptor.cpp
@@ -125,11 +125,7 @@ IceObjC::StreamAcceptor::StreamAcceptor(
       _instance(instance),
       _addr(getAddressForServer(host, port, instance->protocolSupport(), instance->preferIPv6(), true))
 {
-#    ifdef SOMAXCONN
-    _backlog = instance->properties()->getPropertyAsIntWithDefault("Ice.TCP.Backlog", SOMAXCONN);
-#    else
-    _backlog = instance->properties()->getPropertyAsIntWithDefault("Ice.TCP.Backlog", 511);
-#    endif
+    _backlog = instance->properties()->getIcePropertyAsInt("Ice.TCP.Backlog");
 
     try
     {

--- a/csharp/src/Ice/Internal/PropertyNames.cs
+++ b/csharp/src/Ice/Internal/PropertyNames.cs
@@ -149,7 +149,7 @@ internal sealed class PropertyNames
             new(pattern: @"Trace.ThreadPool", usesRegex: false, defaultValue: "0", deprecated: false, propertyArray: null),
             new(pattern: @"UDP.RcvSize", usesRegex: false, defaultValue: "", deprecated: false, propertyArray: null),
             new(pattern: @"UDP.SndSize", usesRegex: false, defaultValue: "", deprecated: false, propertyArray: null),
-            new(pattern: @"TCP.Backlog", usesRegex: false, defaultValue: "", deprecated: false, propertyArray: null),
+            new(pattern: @"TCP.Backlog", usesRegex: false, defaultValue: "511", deprecated: false, propertyArray: null),
             new(pattern: @"TCP.RcvSize", usesRegex: false, defaultValue: "", deprecated: false, propertyArray: null),
             new(pattern: @"TCP.SndSize", usesRegex: false, defaultValue: "", deprecated: false, propertyArray: null),
             new(pattern: @"Warn.AMICallback", usesRegex: false, defaultValue: "1", deprecated: false, propertyArray: null),

--- a/csharp/src/Ice/Internal/TcpAcceptor.cs
+++ b/csharp/src/Ice/Internal/TcpAcceptor.cs
@@ -122,7 +122,7 @@ internal class TcpAcceptor : Acceptor
     {
         _endpoint = endpoint;
         _instance = instance;
-        _backlog = instance.properties().getPropertyAsIntWithDefault("Ice.TCP.Backlog", 511);
+        _backlog = instance.properties().getIcePropertyAsInt("Ice.TCP.Backlog");
 
         try
         {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PropertyNames.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PropertyNames.java
@@ -152,7 +152,7 @@ final class PropertyNames
             new Property("Trace.ThreadPool", false, "0", false, null),
             new Property("UDP.RcvSize", false, "", false, null),
             new Property("UDP.SndSize", false, "", false, null),
-            new Property("TCP.Backlog", false, "", false, null),
+            new Property("TCP.Backlog", false, "511", false, null),
             new Property("TCP.RcvSize", false, "", false, null),
             new Property("TCP.SndSize", false, "", false, null),
             new Property("UseSyslog", false, "0", false, null),

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpAcceptor.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpAcceptor.java
@@ -72,7 +72,7 @@ class TcpAcceptor implements Acceptor {
     TcpAcceptor(TcpEndpointI endpoint, ProtocolInstance instance, String host, int port) {
         _endpoint = endpoint;
         _instance = instance;
-        _backlog = instance.properties().getPropertyAsIntWithDefault("Ice.TCP.Backlog", 511);
+        _backlog = instance.properties().getIcePropertyAsInt("Ice.TCP.Backlog");
 
         try {
             _fd = Network.createTcpServerSocket();


### PR DESCRIPTION
This PR sets the default TCP backlog to 511 everywhere.

It used to be SOMAXCONN in C++ when SOMAXCONN was set. See https://linux.die.net/man/2/listen.

