### PR TITLE
Fix bugs in idle timeout logic (C#)

### DIFF
--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1941,6 +1941,9 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                     throw new MarshalException($"Received ValidateConnection message with unexpected size {size}.");
                 }
                 TraceUtil.traceRecv(_readStream, this, _logger, _traceLevels);
+
+                // Client connection starts sending heartbeats once it's received the ValidateConnection message.
+                _idleTimeoutTransceiver?.scheduleHeartbeat();
             }
         }
 


### PR DESCRIPTION
This PR fixes two small bugs in the idle timeout logic (in C# - will port to other languages in a follow-up PR).
