### PR TITLE
Disable stack trace collection on Windows/ws for the cpp/Ice/timeout test

### DIFF
--- a/cpp/test/Ice/timeout/Server.cpp
+++ b/cpp/test/Ice/timeout/Server.cpp
@@ -28,7 +28,7 @@ Server::run(int argc, char** argv)
 #ifdef _WIN32
     // Turn off stack traces on Windows with ws(s): they slow down the logging so much that this test can fail.
     // See #3048.
-    if (properties->getIceProperty("Ice.Default.Protocol").find("ws") == 0)
+    if (getTestProtocol(properties).find("ws") == 0)
     {
         properties->setProperty("Ice.PrintStackTraces", "0");
     }

--- a/cpp/test/Ice/timeout/Server.cpp
+++ b/cpp/test/Ice/timeout/Server.cpp
@@ -26,8 +26,8 @@ Server::run(int argc, char** argv)
     properties->setProperty("Ice.TCP.RcvSize", "50000");
 
 #ifdef _WIN32
-    // Turn off stack traces on Windows with ws(s): they slow down the logging so much that this test can fail.
-    // See #3048.
+    // Turn off stack trace collection and printing on Windows with ws(s): they slow down the logging so much that this
+    // test can fail. See #3048.
     if (getTestProtocol(properties).find("ws") == 0)
     {
         properties->setProperty("Ice.PrintStackTraces", "0");

--- a/cpp/test/Ice/timeout/Server.cpp
+++ b/cpp/test/Ice/timeout/Server.cpp
@@ -19,17 +19,20 @@ Server::run(int argc, char** argv)
 {
     Ice::PropertiesPtr properties = createTestProperties(argc, argv);
 
-    //
-    // The client sends large messages to cause the transport
-    // buffers to fill up.
-    //
+    // The client sends large messages to cause the transport buffers to fill up.
     properties->setProperty("Ice.MessageSizeMax", "20000");
 
-    //
-    // Limit the recv buffer size, this test relies on the socket
-    // send() blocking after sending a given amount of data.
-    //
+    // Limit the recv buffer size, this test relies on the socket send() blocking after sending a given amount of data.
     properties->setProperty("Ice.TCP.RcvSize", "50000");
+
+#ifdef _WIN32
+    // Turn off stack traces on Windows with ws(s): they slow down the logging so much that this test can fail.
+    // See #3048.
+    if (properties->getIceProperty("Ice.Default.Protocol").find("ws") == 0)
+    {
+        properties->setProperty("Ice.PrintStackTraces", "0");
+    }
+#endif
 
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
 


### PR DESCRIPTION
Fixes #3048.