### PR TITLE
Fix colloc and IPv6

### DIFF
--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -3437,9 +3437,7 @@ class Driver:
         props = {}
         if isinstance(process, IceProcess):
             if not self.host:
-                props["Ice.Default.Host"] = (
-                    "0:0:0:0:0:0:0:1" if current.config.ipv6 else "127.0.0.1"
-                )
+                props["Ice.Default.Host"] = ("::1" if current.config.ipv6 else "127.0.0.1")
             else:
                 props["Ice.Default.Host"] = self.host
         return props


### PR DESCRIPTION
This PR fixes #3154 by:
 - changing the test scripts to use ::1 for colloc ipv6
 - normalizing IPv6 host in Java (in IPEndpointI)

For Java, I picked the "normalization" provided by https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/net/Inet6Address.html#getHostAddress(), which returns a "long form" of the IPv6 address. We call getHostAddress directly a number of times and this was the simplest normalization.

This is not a complete fix for #3154. We should also normalize IPv6 hosts in C++, C# and JS. In C++ and C#, system APIs appear to return the short form, which is why "::1" works with colloc. We should run at least one test with colloc + ipv6 (not in this PR).