### PR TITLE
Fix JavaScript connection scheduling of heartbeats

### DIFF
--- a/js/src/Ice/IdleTimeoutTransceiverDecorator.js
+++ b/js/src/Ice/IdleTimeoutTransceiverDecorator.js
@@ -41,9 +41,9 @@ export class IdleTimeoutTransceiverDecorator {
         this._decoratee.destroy();
     }
 
-    write(buffer, bufferFullyWritten) {
+    write(buffer) {
         this.cancelWriteTimer();
-        const completed = this._decoratee.write(buffer, bufferFullyWritten);
+        const completed = this._decoratee.write(buffer);
         if (completed) {
             // write completed
             this.rescheduleWriteTimer();

--- a/js/src/Ice/TcpEndpointI.js
+++ b/js/src/Ice/TcpEndpointI.js
@@ -112,10 +112,8 @@ export class TcpEndpointI extends IPEndpointI {
     }
 
     connectable() {
-        //
         // TCP endpoints are not connectable when running in a browser, SSL isn't currently supported.
-        //
-        return typeof TcpTransceiver !== null && !this.secure();
+        return TcpTransceiver !== null && !this.secure();
     }
 
     connect() {

--- a/js/src/Ice/TcpTransceiver.js
+++ b/js/src/Ice/TcpTransceiver.js
@@ -145,15 +145,13 @@ if (typeof net.createConnection === "function") {
          * Write the given byte buffer to the socket. The buffer is written using multiple socket write calls.
          *
          * @param byteBuffer the byte buffer to write.
-         * @param bufferFullyWritten a callback that is called when the buffer has been fully written.
-         * @returns Whether or not the write completed synchronously.
+         * @returns Whether or not the write operation completed synchronously.
          **/
-        write(byteBuffer, bufferFullyWritten) {
+        write(byteBuffer) {
             if (this._exception) {
                 throw this._exception;
             }
 
-            DEV: console.assert(bufferFullyWritten);
             let packetSize = byteBuffer.remaining;
             DEV: console.assert(packetSize > 0);
 
@@ -163,10 +161,6 @@ if (typeof net.createConnection === "function") {
 
             while (packetSize > 0) {
                 const slice = byteBuffer.b.slice(byteBuffer.position, byteBuffer.position + packetSize);
-
-                if (packetSize === byteBuffer.remaining) {
-                    bufferFullyWritten();
-                }
                 let sync = true;
                 sync = this._fd.write(Buffer.from(slice), null, () => {
                     if (!sync) {

--- a/js/src/Ice/WSTransceiver.js
+++ b/js/src/Ice/WSTransceiver.js
@@ -138,17 +138,15 @@ if (typeof WebSocket !== "undefined") {
          * Write the given byte buffer to the web socket. The buffer is written using multiple web socket send calls.
          *
          * @param byteBuffer the byte buffer to write.
-         * @param bufferFullyWritten a callback that is called when the buffer has been fully written.
          * @returns Whether or not the write completed synchronously.
          **/
-        write(byteBuffer, bufferFullyWritten) {
+        write(byteBuffer) {
             if (this._exception) {
                 throw this._exception;
             } else if (byteBuffer.remaining === 0) {
                 return true;
             }
             DEV: console.assert(this._fd);
-            DEV: console.assert(bufferFullyWritten);
 
             const cb = () => {
                 if (this._fd) {
@@ -157,7 +155,7 @@ if (typeof WebSocket !== "undefined") {
                             ? this._maxSendPacketSize
                             : byteBuffer.remaining;
                     if (this._fd.bufferedAmount + packetSize <= this._maxSendPacketSize) {
-                        this._bytesWrittenCallback(0, 0);
+                        this._bytesWrittenCallback();
                     } else {
                         Timer.setTimeout(cb, this.writeReadyTimeout());
                     }
@@ -179,9 +177,7 @@ if (typeof WebSocket !== "undefined") {
                 }
                 this._writeReadyTimeout = 0;
                 const slice = byteBuffer.b.slice(byteBuffer.position, byteBuffer.position + packetSize);
-                if (packetSize === byteBuffer.remaining) {
-                    bufferFullyWritten();
-                }
+
                 this._fd.send(slice);
                 byteBuffer.position += packetSize;
 


### PR DESCRIPTION
This PR fixes JavaScript connection to ensure hearbeats are scheduled even if the write completes asynchronously.

It also reworks how the connection checks if the transceiver write call consumed the completed buffer. There is no need for a callback or separate parameter as the transceiver advances the buffer and the call can check if there is any remaining data.