### PR TITLE
Simplified the Parser's Logic for Splitting up Raw Metadata

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -105,7 +105,7 @@ Slice::Metadata::Metadata(string rawMetadata, string file, int line) : GrammarBa
     {
         // Check if the metadata starts with a language prefix.
         // NOTE: It is important that this list is kept in alphabetical order!
-        static const string languages[] = {"cpp", "cs", "java", "js", "matlab", "php", "python", "ruby", "swift"};
+        constexpr string_view languages[] = {"cpp", "cs", "java", "js", "matlab", "php", "python", "ruby", "swift"};
         string prefix = rawMetadata.substr(0, firstColonPos);
         bool hasLangPrefix = binary_search(&languages[0], &languages[sizeof(languages) / sizeof(*languages)], prefix);
         if (hasLangPrefix)


### PR DESCRIPTION
This PR implements #3150.

Currently, if a directive contains no colons, we know it's parser-metadata, (`["protected"]`)
and if it contains 2 colons, we just assume it's language specific metadata. (`["cpp:header-ext:hh"]`)
If there is only 1 colon, then we use a more complex check which will inspect whether the first piece is a known language prefix.

For _valid_ metadata, this is all correct.
But a downside of this approach is that for something like `foo:bar:baz`, we'll assume that `foo` is a language, and since it's a language that `slice2xxx` won't ever recognize, it will be silently skipped. This is suboptimal, since this is nonsense metadata.

----

This PR keeps the same logic for directives with no colons, but eliminated this assumption about 2 colons meaning a language.
Now, if there are _any_ colons in a piece of metadata, we will always check if it starts with a valid language.
And only if it does start with a valid language will it be treated as language metadata. If it doesn't, it is treated as parser metadata.

(Note that this works well with the metadata validator PR I also have open, which will then reject `foo:bar:baz` as invalid parser metadata).