### PR TITLE
Treat multicast address like loopback address wrt computation of default PublishedEndpoints

### DIFF
--- a/cpp/src/Ice/EndpointI.h
+++ b/cpp/src/Ice/EndpointI.h
@@ -116,8 +116,8 @@ namespace IceInternal
         // Used only for server endpoints.
         virtual std::vector<EndpointIPtr> expandHost() const = 0;
 
-        // Returns true when the most underlying endpoint is an IP endpoint with a loopback address.
-        virtual bool isLoopback() const = 0;
+        // Returns true when the most underlying endpoint is an IP endpoint with a loopback or multicast address.
+        virtual bool isLoopbackOrMulticast() const = 0;
 
         // Returns a new endpoint with the specified host; returns this when this operation is not applicable.
         virtual std::shared_ptr<EndpointI> withPublishedHost(std::string host) const = 0;

--- a/cpp/src/Ice/IPEndpointI.cpp
+++ b/cpp/src/Ice/IPEndpointI.cpp
@@ -137,9 +137,9 @@ IceInternal::IPEndpointI::expandHost() const
 }
 
 bool
-IceInternal::IPEndpointI::isLoopback() const
+IceInternal::IPEndpointI::isLoopbackOrMulticast() const
 {
-    return _host.empty() ? false : isLoopbackAddress(_host);
+    return _host.empty() ? false : isLoopbackOrMulticastAddress(_host);
 }
 
 shared_ptr<EndpointI>

--- a/cpp/src/Ice/IPEndpointI.h
+++ b/cpp/src/Ice/IPEndpointI.h
@@ -49,7 +49,7 @@ namespace IceInternal
             std::function<void(std::vector<ConnectorPtr>)>,
             std::function<void(std::exception_ptr)>) const override;
         std::vector<EndpointIPtr> expandHost() const override;
-        bool isLoopback() const override;
+        bool isLoopbackOrMulticast() const override;
         std::shared_ptr<EndpointI> withPublishedHost(std::string host) const override;
         bool equivalent(const EndpointIPtr&) const override;
         std::size_t hash() const noexcept override;

--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -2145,7 +2145,7 @@ IceInternal::isIpAddress(const string& name)
 }
 
 bool
-IceInternal::isLoopbackAddress(const string& name)
+IceInternal::isLoopbackOrMulticastAddress(const string& name)
 {
     if (name.empty())
     {
@@ -2158,12 +2158,12 @@ IceInternal::isLoopbackAddress(const string& name)
         if (inet_pton(AF_INET, name.c_str(), &addr) > 0)
         {
             // It's an IPv4 address
-            return addr.s_addr == htonl(INADDR_LOOPBACK);
+            return addr.s_addr == htonl(INADDR_LOOPBACK) || IN_MULTICAST(ntohl(addr.s_addr));
         }
         else if (inet_pton(AF_INET6, name.c_str(), &addr6) > 0)
         {
             // It's an IPv6 address
-            return IN6_IS_ADDR_LOOPBACK(&addr6);
+            return IN6_IS_ADDR_LOOPBACK(&addr6) || IN6_IS_ADDR_MULTICAST(&addr6);
         }
         return false;
     }

--- a/cpp/src/Ice/Network.h
+++ b/cpp/src/Ice/Network.h
@@ -260,7 +260,7 @@ namespace IceInternal
 #endif
 
     ICE_API bool isIpAddress(const std::string&);
-    ICE_API bool isLoopbackAddress(const std::string&);
+    ICE_API bool isLoopbackOrMulticastAddress(const std::string&);
 
     ICE_API std::string getHostName();
 }

--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -1190,13 +1190,13 @@ ObjectAdapterI::computePublishedEndpoints()
                 endpoints.push_back(factory->endpoint());
             }
 
-            // Remove all loopback endpoints
+            // Remove all loopback/multicast endpoints
             vector<EndpointIPtr> endpointsNoLoopback;
             copy_if(
                 endpoints.begin(),
                 endpoints.end(),
                 back_inserter(endpointsNoLoopback),
-                [](const EndpointIPtr& endpoint) { return !endpoint->isLoopback(); });
+                [](const EndpointIPtr& endpoint) { return !endpoint->isLoopbackOrMulticast(); });
 
             // Retrieve published host
             string publishedHost = _communicator->getProperties()->getProperty(_name + ".PublishedHost");
@@ -1205,14 +1205,14 @@ ObjectAdapterI::computePublishedEndpoints()
             {
                 endpoints = std::move(endpointsNoLoopback);
 
-                // For non-loopback endpoints, we use the fully qualified name of the local host as default for
-                // publishedHost.
+                // For non-loopback/multicast endpoints, we use the fully qualified name of the local host as default
+                // for publishedHost.
                 if (publishedHost.empty())
                 {
                     publishedHost = getHostName(); // fully qualified name of local host
                 }
             }
-            // else keep endpoints as-is; they are all loopback.
+            // else keep endpoints as-is; they are all loopback or multicast
 
             if (!publishedHost.empty())
             {
@@ -1232,7 +1232,7 @@ ObjectAdapterI::computePublishedEndpoints()
                 }
                 endpoints = std::move(newEndpoints);
             }
-            // else keep the loopback-only endpoints as-is (with IP addresses)
+            // else keep the loopback/multicast endpoints as-is (with IP addresses)
         }
     }
 

--- a/cpp/src/Ice/OpaqueEndpointI.cpp
+++ b/cpp/src/Ice/OpaqueEndpointI.cpp
@@ -169,7 +169,7 @@ IceInternal::OpaqueEndpointI::expandHost() const
 }
 
 bool
-IceInternal::OpaqueEndpointI::isLoopback() const
+IceInternal::OpaqueEndpointI::isLoopbackOrMulticast() const
 {
     return false;
 }

--- a/cpp/src/Ice/OpaqueEndpointI.h
+++ b/cpp/src/Ice/OpaqueEndpointI.h
@@ -41,7 +41,7 @@ namespace IceInternal
         AcceptorPtr
         acceptor(const std::string&, const std::optional<Ice::SSL::ServerAuthenticationOptions>&) const final;
         std::vector<EndpointIPtr> expandHost() const final;
-        bool isLoopback() const final;
+        bool isLoopbackOrMulticast() const final;
         std::shared_ptr<EndpointI> withPublishedHost(std::string host) const final;
         bool equivalent(const EndpointIPtr&) const final;
         std::size_t hash() const noexcept final;

--- a/cpp/src/Ice/SSL/SSLEndpointI.cpp
+++ b/cpp/src/Ice/SSL/SSLEndpointI.cpp
@@ -254,9 +254,9 @@ Ice::SSL::EndpointI::expandHost() const
 }
 
 bool
-Ice::SSL::EndpointI::isLoopback() const
+Ice::SSL::EndpointI::isLoopbackOrMulticast() const
 {
-    return _delegate->isLoopback();
+    return _delegate->isLoopbackOrMulticast();
 }
 
 shared_ptr<IceInternal::EndpointI>

--- a/cpp/src/Ice/SSL/SSLEndpointI.h
+++ b/cpp/src/Ice/SSL/SSLEndpointI.h
@@ -43,7 +43,7 @@ namespace Ice::SSL
         IceInternal::AcceptorPtr
         acceptor(const std::string&, const std::optional<Ice::SSL::ServerAuthenticationOptions>&) const final;
         std::vector<IceInternal::EndpointIPtr> expandHost() const final;
-        bool isLoopback() const final;
+        bool isLoopbackOrMulticast() const final;
         std::shared_ptr<IceInternal::EndpointI> withPublishedHost(std::string host) const final;
         bool equivalent(const IceInternal::EndpointIPtr&) const final;
         std::size_t hash() const noexcept final;

--- a/cpp/src/Ice/WSEndpoint.cpp
+++ b/cpp/src/Ice/WSEndpoint.cpp
@@ -275,9 +275,9 @@ IceInternal::WSEndpoint::expandHost() const
 }
 
 bool
-IceInternal::WSEndpoint::isLoopback() const
+IceInternal::WSEndpoint::isLoopbackOrMulticast() const
 {
-    return _delegate->isLoopback();
+    return _delegate->isLoopbackOrMulticast();
 }
 
 shared_ptr<EndpointI>

--- a/cpp/src/Ice/WSEndpoint.h
+++ b/cpp/src/Ice/WSEndpoint.h
@@ -47,7 +47,7 @@ namespace IceInternal
         AcceptorPtr
         acceptor(const std::string&, const std::optional<Ice::SSL::ServerAuthenticationOptions>&) const final;
         std::vector<EndpointIPtr> expandHost() const final;
-        bool isLoopback() const final;
+        bool isLoopbackOrMulticast() const final;
         std::shared_ptr<EndpointI> withPublishedHost(std::string host) const final;
         bool equivalent(const EndpointIPtr&) const final;
         std::size_t hash() const noexcept final;

--- a/cpp/src/Ice/ios/iAPEndpointI.h
+++ b/cpp/src/Ice/ios/iAPEndpointI.h
@@ -55,7 +55,7 @@ namespace IceObjC
         IceInternal::AcceptorPtr
         acceptor(const std::string&, const std::optional<Ice::SSL::ServerAuthenticationOptions>&) const final;
         std::vector<IceInternal::EndpointIPtr> expandHost() const final;
-        bool isLoopback() const final;
+        bool isLoopbackOrMulticast() const final;
         std::shared_ptr<EndpointI> withPublishedHost(std::string host) const final;
         bool equivalent(const IceInternal::EndpointIPtr&) const final;
 

--- a/cpp/src/Ice/ios/iAPEndpointI.mm
+++ b/cpp/src/Ice/ios/iAPEndpointI.mm
@@ -309,7 +309,7 @@ IceObjC::iAPEndpointI::expandHost() const
 }
 
 bool
-IceObjC::iAPEndpointI::isLoopback() const
+IceObjC::iAPEndpointI::isLoopbackOrMulticast() const
 {
     return false;
 }

--- a/cpp/src/IceBT/EndpointI.cpp
+++ b/cpp/src/IceBT/EndpointI.cpp
@@ -198,7 +198,7 @@ IceBT::EndpointI::expandHost() const
 }
 
 bool
-IceBT::EndpointI::isLoopback() const
+IceBT::EndpointI::isLoopbackOrMulticast() const
 {
     return false;
 }

--- a/cpp/src/IceBT/EndpointI.h
+++ b/cpp/src/IceBT/EndpointI.h
@@ -48,7 +48,7 @@ namespace IceBT
         IceInternal::AcceptorPtr
         acceptor(const std::string&, const std::optional<Ice::SSL::ServerAuthenticationOptions>&) const final;
         std::vector<IceInternal::EndpointIPtr> expandHost() const final;
-        bool isLoopback() const final;
+        bool isLoopbackOrMulticast() const final;
         std::shared_ptr<IceInternal::EndpointI> withPublishedHost(std::string host) const final;
         bool equivalent(const IceInternal::EndpointIPtr&) const final;
 

--- a/cpp/test/Ice/background/EndpointI.cpp
+++ b/cpp/test/Ice/background/EndpointI.cpp
@@ -200,9 +200,9 @@ EndpointI::expandHost() const
 }
 
 bool
-EndpointI::isLoopback() const
+EndpointI::isLoopbackOrMulticast() const
 {
-    return _endpoint->isLoopback();
+    return _endpoint->isLoopbackOrMulticast();
 }
 
 shared_ptr<IceInternal::EndpointI>

--- a/cpp/test/Ice/background/EndpointI.h
+++ b/cpp/test/Ice/background/EndpointI.h
@@ -35,7 +35,7 @@ public:
     IceInternal::AcceptorPtr
     acceptor(const std::string&, const std::optional<Ice::SSL::ServerAuthenticationOptions>&) const final;
     std::vector<IceInternal::EndpointIPtr> expandHost() const final;
-    bool isLoopback() const final;
+    bool isLoopbackOrMulticast() const final;
     std::shared_ptr<IceInternal::EndpointI> withPublishedHost(std::string host) const final;
     bool equivalent(const IceInternal::EndpointIPtr&) const final;
 

--- a/csharp/src/Ice/Internal/EndpointI.cs
+++ b/csharp/src/Ice/Internal/EndpointI.cs
@@ -133,8 +133,8 @@ public abstract class EndpointI : Ice.Endpoint, IComparable<EndpointI>
     // Used only for server endpoints.
     public abstract List<EndpointI> expandHost();
 
-    // Returns true when the most underlying endpoint is an IP endpoint with a loopback address.
-    public abstract bool isLoopback();
+    // Returns true when the most underlying endpoint is an IP endpoint with a loopback or multicast address.
+    public abstract bool isLoopbackOrMulticast();
 
     // Returns a new endpoint with the specified host; returns this when this operation is not applicable.
     public abstract EndpointI withPublishedHost(string host);

--- a/csharp/src/Ice/Internal/IPEndpointI.cs
+++ b/csharp/src/Ice/Internal/IPEndpointI.cs
@@ -128,8 +128,18 @@ public abstract class IPEndpointI : EndpointI
 
     // Empty host_ means the endpoint is a wildcard address. This method must be called only on an endpoint with an
     // empty host or an IP address.
-    public override bool isLoopback() =>
-        host_.Length > 0 && IPAddress.IsLoopback(IPAddress.Parse(host_));
+    public override bool isLoopbackOrMulticast()
+    {
+        if (host_.Length > 0)
+        {
+            var ipEndPoint = IPEndPoint.Parse(host_);
+            return IPAddress.IsLoopback(ipEndPoint.Address) || Network.isMulticast(ipEndPoint);
+        }
+        else
+        {
+            return false;
+        }
+    }
 
     public override EndpointI withPublishedHost(string host) => createEndpoint(host, port_, connectionId_);
 

--- a/csharp/src/Ice/Internal/OpaqueEndpointI.cs
+++ b/csharp/src/Ice/Internal/OpaqueEndpointI.cs
@@ -213,7 +213,7 @@ internal sealed class OpaqueEndpointI : EndpointI
 
     public override List<EndpointI> expandHost() => [this];
 
-    public override bool isLoopback() => false;
+    public override bool isLoopbackOrMulticast() => false;
 
     public override EndpointI withPublishedHost(string host) => this;
 

--- a/csharp/src/Ice/Internal/WSEndpoint.cs
+++ b/csharp/src/Ice/Internal/WSEndpoint.cs
@@ -217,7 +217,7 @@ internal sealed class WSEndpoint : EndpointI
     public override List<EndpointI> expandHost() =>
         _delegate.expandHost().Select(e => endpoint(e) as EndpointI).ToList();
 
-    public override bool isLoopback() => _delegate.isLoopback();
+    public override bool isLoopbackOrMulticast() => _delegate.isLoopbackOrMulticast();
 
     public override EndpointI withPublishedHost(string host) => endpoint(_delegate.withPublishedHost(host));
 

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -1326,8 +1326,8 @@ public sealed class ObjectAdapter
                 // endpoints.
                 endpoints = _incomingConnectionFactories.Select(f => f.endpoint());
 
-                // Remove all loopback endpoints.
-                IEnumerable<EndpointI> endpointsNoLoopback = endpoints.Where(e => !e.isLoopback());
+                // Remove all loopback/multicast endpoints.
+                IEnumerable<EndpointI> endpointsNoLoopback = endpoints.Where(e => !e.isLoopbackOrMulticast());
 
                 // Retrieve published host
                 string publishedHost = _instance.initializationData().properties!.getProperty($"{_name}.PublishedHost");
@@ -1336,8 +1336,8 @@ public sealed class ObjectAdapter
                 {
                     endpoints = endpointsNoLoopback;
 
-                    // For non-loopback endpoints, we use the fully qualified name of the local host as default for
-                    // publishedHost.
+                    // For non-loopback & non-multicast endpoints, we use the fully qualified name of the local host as
+                    // default for publishedHost.
                     if (publishedHost.Length == 0)
                     {
                         publishedHost = Dns.GetHostEntry("").HostName; // fully qualified name of local host
@@ -1349,7 +1349,7 @@ public sealed class ObjectAdapter
                     // Replace the host in all endpoints by publishedHost (when applicable).
                     endpoints = endpoints.Select(e => e.withPublishedHost(publishedHost)).Distinct();
                 }
-                // else keep the loopback-only endpoints as-is (with IP addresses)
+                // else keep the loopback-only/multicast endpoints as-is (with IP addresses)
             }
         }
 

--- a/csharp/src/Ice/SSL/EndpointI.cs
+++ b/csharp/src/Ice/SSL/EndpointI.cs
@@ -155,7 +155,7 @@ internal sealed class EndpointI : Ice.Internal.EndpointI
     public override List<Internal.EndpointI> expandHost() =>
         _delegate.expandHost().Select(e => endpoint(e) as Internal.EndpointI).ToList();
 
-    public override bool isLoopback() => _delegate.isLoopback();
+    public override bool isLoopbackOrMulticast() => _delegate.isLoopbackOrMulticast();
 
     public override EndpointI withPublishedHost(string host) => endpoint(_delegate.withPublishedHost(host));
 

--- a/csharp/test/Ice/background/EndpointI.cs
+++ b/csharp/test/Ice/background/EndpointI.cs
@@ -176,7 +176,7 @@ internal class EndpointI : Ice.Internal.EndpointI
     public override List<Ice.Internal.EndpointI> expandHost() =>
         _endpoint.expandHost().Select(e => new EndpointI(e) as Ice.Internal.EndpointI).ToList();
 
-    public override bool isLoopback() => _endpoint.isLoopback();
+    public override bool isLoopbackOrMulticast() => _endpoint.isLoopbackOrMulticast();
 
     public override EndpointI withPublishedHost(string host) => endpoint(_endpoint.withPublishedHost(host));
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointI.java
@@ -116,8 +116,9 @@ public abstract class EndpointI implements Endpoint, Comparable<EndpointI> {
     // Used only for server endpoints.
     public abstract java.util.List<EndpointI> expandHost();
 
-    // Returns true when the most underlying endpoint is an IP endpoint with a loopback address.
-    public abstract boolean isLoopback();
+    // Returns true when the most underlying endpoint is an IP endpoint with a loopback or multicast
+    // address.
+    public abstract boolean isLoopbackOrMulticast();
 
     // Returns a new endpoint with the specified host; returns this when this operation is not
     // applicable.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IPEndpointI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IPEndpointI.java
@@ -115,11 +115,16 @@ abstract class IPEndpointI extends EndpointI {
     }
 
     @Override
-    public boolean isLoopback() {
-        try {
-            return !_host.isEmpty() && java.net.InetAddress.getByName(_host).isLoopbackAddress();
-        } catch (java.net.UnknownHostException ex) {
+    public boolean isLoopbackOrMulticast() {
+        if (_host.isEmpty()) {
             return false;
+        } else {
+            try {
+                var address = java.net.InetAddress.getByName(_host);
+                return address.isLoopbackAddress() || address.isMulticastAddress();
+            } catch (java.net.UnknownHostException ex) {
+                return false;
+            }
         }
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
@@ -1398,9 +1398,9 @@ public final class ObjectAdapter {
                                 .map(IncomingConnectionFactory::endpoint)
                                 .toList();
 
-                // Remove all loopback endpoints.
+                // Remove all loopback/multicast endpoints.
                 var endpointsNoLoopback =
-                        endpointsList.stream().filter(e -> !e.isLoopback()).toList();
+                        endpointsList.stream().filter(e -> !e.isLoopbackOrMulticast()).toList();
 
                 // Retrieve published host.
                 String publishedHost =
@@ -1416,8 +1416,8 @@ public final class ObjectAdapter {
                 } else {
                     endpoints = endpointsNoLoopback.stream();
 
-                    // For non-loopback endpoints, we use the fully qualified name of the local host
-                    // as default for publishedHost.
+                    // For non-loopback/multicast endpoints, we use the fully qualified name of the
+                    // local host as default for publishedHost.
                     if (publishedHost.isEmpty()) {
                         try {
                             publishedHost = InetAddress.getLocalHost().getHostName();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OpaqueEndpointI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OpaqueEndpointI.java
@@ -186,7 +186,7 @@ final class OpaqueEndpointI extends EndpointI {
     }
 
     @Override
-    public boolean isLoopback() {
+    public boolean isLoopbackOrMulticast() {
         return false;
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/EndpointI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/EndpointI.java
@@ -169,8 +169,8 @@ final class EndpointI extends com.zeroc.Ice.EndpointI {
     }
 
     @Override
-    public boolean isLoopback() {
-        return _delegate.isLoopback();
+    public boolean isLoopbackOrMulticast() {
+        return _delegate.isLoopbackOrMulticast();
     }
 
     @Override

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSEndpoint.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSEndpoint.java
@@ -179,8 +179,8 @@ final class WSEndpoint extends EndpointI {
     }
 
     @Override
-    public boolean isLoopback() {
-        return _delegate.isLoopback();
+    public boolean isLoopbackOrMulticast() {
+        return _delegate.isLoopbackOrMulticast();
     }
 
     @Override

--- a/java/src/com.zeroc.icebt/src/main/java/com/zeroc/IceBT/EndpointI.java
+++ b/java/src/com.zeroc.icebt/src/main/java/com/zeroc/IceBT/EndpointI.java
@@ -161,7 +161,7 @@ final class EndpointI extends com.zeroc.Ice.EndpointI {
     }
 
     @Override
-    public boolean isLoopback() {
+    public boolean isLoopbackOrMulticast() {
         return false;
     }
 

--- a/java/test/src/main/java/test/Ice/background/EndpointI.java
+++ b/java/test/src/main/java/test/Ice/background/EndpointI.java
@@ -154,8 +154,8 @@ final class EndpointI extends com.zeroc.Ice.EndpointI {
     }
 
     @Override
-    public boolean isLoopback() {
-        return _endpoint.isLoopback();
+    public boolean isLoopbackOrMulticast() {
+        return _endpoint.isLoopbackOrMulticast();
     }
 
     @Override


### PR DESCRIPTION
This PR updates the default PublishedEndpoints algorithm to treat multicast addresses like loopback addresses, i.e.:

- if an OA is listening only on loopback or multicast addresses, all these addresses are kept as-is in the default PublishedEndpoints
- if an OA is listening on anything else, the loopback/multicast addresses are dropped, and the PublishedEndpoints use the PublishedHost.

The typical use-case for multicast addresses is naturally a single multicast address. And in this case, the PublishedEndpoints is just this address as-is (+port, interface etc.). We don't want to replace this multicast address by the PublishedHost like we do prior to this PR.
