### PR TITLE
Add C++ coverage report workflow  

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,56 @@
+name: Generate API Coverage
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["coverage-ci"]
+
+jobs:
+  generate-coverage-report:
+    runs-on: macos-15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Dependencies
+        uses: ./.github/actions/setup-dependencies
+        with:
+          use_ccache: false
+
+      - name: Generate C++ Coverage
+        working-directory: ./cpp
+        run: ../scripts/generate-code-coverage.sh
+
+      - name: Generate C++ Coverage Reports
+        working-directory: ./cpp
+        run: |
+          for binary in bin/*; do
+            ../scripts/generate-code-coverage-reports.sh "$binary"
+          done
+
+          for library in lib/*; do
+            if [[ $library =~ lib/lib[a-zA-Z0-9]+\.dylib ]]; then
+              ../scripts/generate-code-coverage-reports.sh "$library"
+            fi
+          done
+
+      # This will perform a full sync of the documentation to S3 every time the workflow is run since
+      # the timestamps will always be different. Using --size-only is not sufficient since the
+      # documentation may be updated without changing the size of the files. S3 does not offer a hash based sync.
+      #
+      # Additionally, we do not cache the doxygen output since it does not remove files old files.
+      - name: Sync Documentation to S3
+        working-directory: ./cpp/coverage/html
+        run: |
+          for coverage_dir in *; do
+              if [[ -d $coverage_dir ]]; then
+                  aws s3 sync $coverage_dir s3://${AWS_S3_CODE_BUCKET}/ice/cpp/main/coverage/$(basename $coverage_dir) --delete
+              fi
+          done
+
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_S3_CODE_BUCKET: ${{ secrets.AWS_S3_CODE_BUCKET }}
+          AWS_DEFAULT_REGION: us-east-1
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,12 +25,12 @@ jobs:
         working-directory: ./cpp
         run: |
           for binary in bin/*; do
-            ../scripts/generate-code-coverage-reports.sh "$binary"
+            ../scripts/generate-code-coverage.sh "$binary"
           done
 
           for library in lib/*; do
             if [[ $library =~ lib/lib[a-zA-Z0-9]+\.dylib ]]; then
-              ../scripts/generate-code-coverage-reports.sh "$library"
+              ../scripts/generate-code-coverage.sh "$library"
             fi
           done
 
@@ -53,4 +53,4 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_CODE_BUCKET: ${{ secrets.AWS_S3_CODE_BUCKET }}
           AWS_DEFAULT_REGION: us-east-1
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+      # if: github.ref == 'refs/heads/main'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,8 +35,6 @@ jobs:
       # This will perform a full sync of the documentation to S3 every time the workflow is run since
       # the timestamps will always be different. Using --size-only is not sufficient since the
       # documentation may be updated without changing the size of the files. S3 does not offer a hash based sync.
-      #
-      # Additionally, we do not cache the doxygen output since it does not remove files old files.
       - name: Sync Documentation to S3
         working-directory: ./cpp/coverage/html
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,8 +2,6 @@ name: Generate API Coverage
 
 on:
   workflow_dispatch:
-  push:
-    branches: ["coverage-ci"]
 
 jobs:
   generate-coverage-report:
@@ -53,4 +51,4 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_CODE_BUCKET: ${{ secrets.AWS_S3_CODE_BUCKET }}
           AWS_DEFAULT_REGION: us-east-1
-      # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'

--- a/scripts/generate-code-coverage.sh
+++ b/scripts/generate-code-coverage.sh
@@ -58,16 +58,12 @@ if [ -e default.profdata ]; then
     echo "Remove default.profdata to rebuild code coverage"
 else
     echo "Building with code coverage..."
-    if [ -z "$MAKEFLAGS" ]; then
-        ncpu=$(sysctl -n hw.ncpu)
-        export MAKEFLAGS="-j$ncpu"
-    fi
-
+    ncpu=$(sysctl -n hw.ncpu)
     make clean
-    make
+    make "-j$ncpu"
 
     echo "Running tests..."
-    python3 allTests.py --all --workers=8
+    python3 allTests.py --all --workers="$ncpu"
 
     echo "Merge coverage data..."
     ${CLI_TOOLS}/llvm-profdata merge -o default.profdata coverage/*.profraw


### PR DESCRIPTION
This PR adds a new workflow to generate C++ coverage reports and upload them to S3. This workflow is ran on demand to avoid consuming yet another macOS runner.