### PR TITLE
Refactor EndpointInfo in C#

### DIFF
--- a/csharp/src/Ice/Endpoint.cs
+++ b/csharp/src/Ice/Endpoint.cs
@@ -19,94 +19,170 @@ public interface Endpoint
 /// <summary>
 /// Base class providing access to the endpoint details.
 /// </summary>
-public abstract class EndpointInfo
+public class EndpointInfo
 {
     /// <summary>
-    /// The information of the underlying endpoint or null if there's no underlying endpoint.
+    /// Gets the information for the underlying endpoint, or null if there's no underlying endpoint.
     /// </summary>
-    public EndpointInfo? underlying;
+    public readonly EndpointInfo? underlying;
 
     /// <summary>
-    /// The timeout for the endpoint in milliseconds. -1 means no timeout.
+    /// Gets the timeout of the endpoint in milliseconds. -1 means no timeout.
     /// </summary>
-    public int timeout;
+    public readonly int timeout;
 
     /// <summary>
-    /// Specifies whether or not compression should be used if available when using this endpoint.
+    /// Gets a value indicating whether or not compression should be used if available when using this endpoint.
     /// </summary>
-    public bool compress;
+    public readonly bool compress;
 
-    /// <summary>Returns the type of the endpoint.</summary>
+    /// <summary>Gets a 16-bit integer that identifies the transport of this endpoint.</summary>
     /// <returns>The endpoint type.</returns>
-    public abstract short type();
+    /// <remarks>The type of an underlying endpoint is always the same as the type its enclosing endpoint.</remarks>
+    public virtual short type() => underlying?.type() ?? -1;
 
-    /// <summary>Returns true if this endpoint is a datagram endpoint.</summary>
-    /// <returns>True for a datagram endpoint.</returns>
-    public abstract bool datagram();
+    /// <summary>Checks if this endpoint's transport is a datagram transport such as UDP.</summary>
+    /// <returns>True for a datagram endpoint; otherwise, false.</returns>
+    public virtual bool datagram() => underlying?.datagram() ?? false;
 
-    /// <summary>Returns true if this endpoint is secure; otherwise false.</summary>
-    /// <returns>True if the endpoint is secure.</returns>
-    public abstract bool secure();
+    /// <summary>Checks if this endpoint's transport is secure.</summary>
+    /// <returns>True if the endpoint's transport is secure; otherwise, false.</returns>
+    /// <remarks>The value returned for an underlying endpoint is the same as the value returned for the enclosing
+    /// endpoint.</remarks>
+    public virtual bool secure() => underlying?.secure() ?? false;
+
+    protected EndpointInfo(EndpointInfo underlying)
+    {
+        this.underlying = underlying;
+        timeout = underlying.timeout;
+        compress = underlying.compress;
+    }
+
+    protected EndpointInfo(bool compress, int timeout)
+    {
+        this.compress = compress;
+        this.timeout = timeout;
+    }
 }
 
 /// <summary>
-/// Provides access to the address details of a IP endpoint.
+/// Provides access to the details of an IP endpoint.
 /// </summary>
-public abstract class IPEndpointInfo : EndpointInfo
+public class IPEndpointInfo : EndpointInfo
 {
     /// <summary>
-    /// The host or address configured with the endpoint.
+    /// Gets the host or address configured with the endpoint.
     /// </summary>
-    public string host = "";
+    public readonly string host;
 
     /// <summary>
-    /// The endpoint's port number.
+    /// Gets the endpoint's port number.
     /// </summary>
-    public int port;
+    public readonly int port;
 
     /// <summary>
-    /// The source IP address.
+    /// Gets the source IP address.
     /// </summary>
-    public string sourceAddress = "";
+    public readonly string sourceAddress;
+
+    protected IPEndpointInfo(bool compress, int timeout, string host, int port, string sourceAddress)
+        : base(compress, timeout)
+    {
+        this.host = host;
+        this.port = port;
+        this.sourceAddress = sourceAddress;
+    }
 }
 
-public abstract class TCPEndpointInfo : IPEndpointInfo
+public sealed class TCPEndpointInfo : IPEndpointInfo
 {
+    private readonly bool _secure;
+    private readonly short _type;
+
+    public override short type() => _type;
+
+    public override bool secure() => _secure;
+
+    internal TCPEndpointInfo(
+        bool compress,
+        int timeout,
+        string host,
+        int port,
+        string sourceAddress,
+        short type,
+        bool secure)
+        : base(compress, timeout, host, port, sourceAddress)
+    {
+        _type = type;
+        _secure = secure;
+    }
 }
 
 /// <summary>
-/// Provides access to a TCP endpoint information.
+/// Provides access to a UDP endpoint information.
 /// </summary>
-public abstract class UDPEndpointInfo : IPEndpointInfo
+public sealed class UDPEndpointInfo : IPEndpointInfo
 {
-    public string mcastInterface = "";
+    public readonly string mcastInterface;
 
-    public int mcastTtl;
+    public readonly int mcastTtl;
+
+    public override short type() => UDPEndpointType.value;
+
+    public override bool datagram() => true;
+
+    internal UDPEndpointInfo(
+        bool compress,
+        string host,
+        int port,
+        string sourceAddress,
+        string mcastInterface,
+        int mcastTtl)
+        : base(compress, timeout: -1, host, port, sourceAddress)
+    {
+        this.mcastInterface = mcastInterface;
+        this.mcastTtl = mcastTtl;
+    }
 }
 
 /// <summary>
 /// Provides access to a WebSocket endpoint information.
 /// </summary>
-public abstract class WSEndpointInfo : EndpointInfo
+public sealed class WSEndpointInfo : EndpointInfo
 {
     /// <summary>
-    /// The URI configured with the endpoint.
+    /// Gets the URI configured for this endpoint.
     /// </summary>
-    public string resource = "";
+    public readonly string resource;
+
+    internal WSEndpointInfo(EndpointInfo underlying, string resource)
+        : base(underlying) => this.resource = resource;
 }
 
 /// <summary>
 /// Provides access to the details of an opaque endpoint.
 /// </summary>
-public abstract class OpaqueEndpointInfo : EndpointInfo
+public sealed class OpaqueEndpointInfo : EndpointInfo
 {
     /// <summary>
-    /// The encoding version of the opaque endpoint (to decode or encode the rawBytes).
+    /// Gets the raw encoding (to decode the rawBytes).
     /// </summary>
-    public EncodingVersion rawEncoding;
+    public readonly EncodingVersion rawEncoding;
 
     /// <summary>
-    /// The raw encoding of the opaque endpoint.
+    /// Gets the raw bytes of the opaque endpoint.
     /// </summary>
-    public byte[] rawBytes = [];
+    public readonly byte[] rawBytes;
+
+    private readonly short _type;
+
+    public override short type() => _type;
+
+    internal OpaqueEndpointInfo(short type, EncodingVersion rawEncoding, byte[] rawBytes)
+        : base(compress: false, timeout: -1)
+    {
+        _type = type;
+        this.rawEncoding = rawEncoding;
+        this.rawBytes = rawBytes;
+    }
 }

--- a/csharp/src/Ice/Internal/IPEndpointI.cs
+++ b/csharp/src/Ice/Internal/IPEndpointI.cs
@@ -34,38 +34,6 @@ public abstract class IPEndpointI : EndpointI
         connectionId_ = "";
     }
 
-    private sealed class InfoI : Ice.IPEndpointInfo
-    {
-        public InfoI(IPEndpointI e)
-        {
-            _endpoint = e;
-        }
-
-        public override short type()
-        {
-            return _endpoint.type();
-        }
-
-        public override bool datagram()
-        {
-            return _endpoint.datagram();
-        }
-
-        public override bool secure()
-        {
-            return _endpoint.secure();
-        }
-
-        private IPEndpointI _endpoint;
-    }
-
-    public override Ice.EndpointInfo getInfo()
-    {
-        InfoI info = new InfoI(this);
-        fillEndpointInfo(info);
-        return info;
-    }
-
     public override short type()
     {
         return instance_.type();
@@ -268,13 +236,6 @@ public abstract class IPEndpointI : EndpointI
     {
         s.writeString(host_);
         s.writeInt(port_);
-    }
-
-    public virtual void fillEndpointInfo(Ice.IPEndpointInfo info)
-    {
-        info.host = host_;
-        info.port = port_;
-        info.sourceAddress = Network.endpointAddressToString(sourceAddr_);
     }
 
     public virtual void initWithOptions(List<string> args, bool oaEndpoint)

--- a/csharp/src/Ice/Internal/OpaqueEndpointI.cs
+++ b/csharp/src/Ice/Internal/OpaqueEndpointI.cs
@@ -59,40 +59,10 @@ internal sealed class OpaqueEndpointI : EndpointI
         return "opaque -t " + _type + " -e " + Ice.Util.encodingVersionToString(_rawEncoding) + " -v " + val;
     }
 
-    private sealed class InfoI : OpaqueEndpointInfo
-    {
-        public InfoI(short type, EncodingVersion rawEncoding, byte[] rawBytes)
-        {
-            _type = type;
-            this.rawEncoding = rawEncoding;
-            this.rawBytes = rawBytes;
-        }
-
-        public override short type()
-        {
-            return _type;
-        }
-
-        public override bool datagram()
-        {
-            return false;
-        }
-
-        public override bool secure()
-        {
-            return false;
-        }
-
-        private readonly short _type;
-    }
-
     //
     // Return the endpoint information.
     //
-    public override Ice.EndpointInfo getInfo()
-    {
-        return new InfoI(_type, _rawEncoding, _rawBytes);
-    }
+    public override EndpointInfo getInfo() => new OpaqueEndpointInfo(_type, _rawEncoding, _rawBytes);
 
     //
     // Return the endpoint type

--- a/csharp/src/Ice/Internal/TcpEndpointI.cs
+++ b/csharp/src/Ice/Internal/TcpEndpointI.cs
@@ -39,31 +39,6 @@ internal sealed class TcpEndpointI : IPEndpointI
         _compress = s.readBool();
     }
 
-    private sealed class InfoI : Ice.TCPEndpointInfo
-    {
-        public InfoI(IPEndpointI e)
-        {
-            _endpoint = e;
-        }
-
-        public override short type()
-        {
-            return _endpoint.type();
-        }
-
-        public override bool datagram()
-        {
-            return _endpoint.datagram();
-        }
-
-        public override bool secure()
-        {
-            return _endpoint.secure();
-        }
-
-        private IPEndpointI _endpoint;
-    }
-
     public override void streamWriteImpl(Ice.OutputStream s)
     {
         base.streamWriteImpl(s);
@@ -71,12 +46,8 @@ internal sealed class TcpEndpointI : IPEndpointI
         s.writeBool(_compress);
     }
 
-    public override Ice.EndpointInfo getInfo()
-    {
-        InfoI info = new InfoI(this);
-        fillEndpointInfo(info);
-        return info;
-    }
+    public override EndpointInfo getInfo() =>
+        new TCPEndpointInfo(_compress, _timeout, host_, port_, Network.endpointAddressToString(sourceAddr_), type(), secure());
 
     public override int timeout()
     {
@@ -204,13 +175,6 @@ internal sealed class TcpEndpointI : IPEndpointI
     }
 
     public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), _timeout, _compress);
-
-    public override void fillEndpointInfo(Ice.IPEndpointInfo info)
-    {
-        base.fillEndpointInfo(info);
-        info.timeout = _timeout;
-        info.compress = _compress;
-    }
 
     public override EndpointI toPublishedEndpoint(string publishedHost)
     {

--- a/csharp/src/Ice/Internal/UdpEndpointI.cs
+++ b/csharp/src/Ice/Internal/UdpEndpointI.cs
@@ -50,39 +50,21 @@ internal sealed class UdpEndpointI : IPEndpointI
         _compress = s.readBool();
     }
 
-    private sealed class InfoI : Ice.UDPEndpointInfo
-    {
-        public InfoI(UdpEndpointI e)
-        {
-            _endpoint = e;
-        }
-
-        public override short type()
-        {
-            return _endpoint.type();
-        }
-
-        public override bool datagram()
-        {
-            return _endpoint.datagram();
-        }
-
-        public override bool secure()
-        {
-            return _endpoint.secure();
-        }
-
-        private UdpEndpointI _endpoint;
-    }
-
     //
     // Return the endpoint information.
     //
-    public override Ice.EndpointInfo getInfo()
+    public override EndpointInfo getInfo()
     {
-        InfoI info = new InfoI(this);
-        fillEndpointInfo(info);
-        return info;
+        Debug.Assert(!secure());
+        Debug.Assert(type() == UDPEndpointType.value);
+
+        return new UDPEndpointInfo(
+            _compress,
+            host_,
+            port_,
+            Network.endpointAddressToString(sourceAddr_),
+            _mcastInterface,
+            _mcastTtl);
     }
 
     //
@@ -318,19 +300,6 @@ internal sealed class UdpEndpointI : IPEndpointI
     }
 
     public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), _mcastInterface, _mcastTtl, _connect, _compress);
-
-    public override void fillEndpointInfo(Ice.IPEndpointInfo info)
-    {
-        base.fillEndpointInfo(info);
-        if (info is Ice.UDPEndpointInfo)
-        {
-            Ice.UDPEndpointInfo udpInfo = (Ice.UDPEndpointInfo)info;
-            udpInfo.timeout = -1;
-            udpInfo.compress = _compress;
-            udpInfo.mcastInterface = _mcastInterface;
-            udpInfo.mcastTtl = _mcastTtl;
-        }
-    }
 
     public override EndpointI toPublishedEndpoint(string publishedHost) =>
         new UdpEndpointI(

--- a/csharp/src/Ice/Internal/WSEndpoint.cs
+++ b/csharp/src/Ice/Internal/WSEndpoint.cs
@@ -34,40 +34,7 @@ internal sealed class WSEndpoint : EndpointI
         _resource = s.readString();
     }
 
-    private sealed class InfoI : Ice.WSEndpointInfo
-    {
-        public InfoI(EndpointI e)
-        {
-            _endpoint = e;
-        }
-
-        public override short type()
-        {
-            return _endpoint.type();
-        }
-
-        public override bool datagram()
-        {
-            return _endpoint.datagram();
-        }
-
-        public override bool secure()
-        {
-            return _endpoint.secure();
-        }
-
-        private EndpointI _endpoint;
-    }
-
-    public override Ice.EndpointInfo getInfo()
-    {
-        Ice.WSEndpointInfo info = new InfoI(this);
-        info.underlying = _delegate.getInfo();
-        info.resource = _resource;
-        info.compress = info.underlying.compress;
-        info.timeout = info.underlying.timeout;
-        return info;
-    }
+    public override EndpointInfo getInfo() => new WSEndpointInfo(_delegate.getInfo(), _resource);
 
     public override short type()
     {

--- a/csharp/src/Ice/SSL/EndpointI.cs
+++ b/csharp/src/Ice/SSL/EndpointI.cs
@@ -14,27 +14,7 @@ internal sealed class EndpointI : Ice.Internal.EndpointI
 
     public override void streamWriteImpl(Ice.OutputStream os) => _delegate.streamWriteImpl(os);
 
-    private sealed class InfoI : EndpointInfo
-    {
-        public InfoI(EndpointI e) => _endpoint = e;
-
-        public override short type() => _endpoint.type();
-
-        public override bool datagram() => _endpoint.datagram();
-
-        public override bool secure() => _endpoint.secure();
-
-        private readonly EndpointI _endpoint;
-    }
-
-    public override Ice.EndpointInfo getInfo()
-    {
-        var info = new InfoI(this);
-        info.underlying = _delegate.getInfo();
-        info.compress = info.underlying.compress;
-        info.timeout = info.underlying.timeout;
-        return info;
-    }
+    public override Ice.EndpointInfo getInfo() => new EndpointInfo(_delegate.getInfo());
 
     public override short type() => _delegate.type();
 

--- a/csharp/src/Ice/SSL/EndpointInfo.cs
+++ b/csharp/src/Ice/SSL/EndpointInfo.cs
@@ -4,6 +4,10 @@
 
 namespace Ice.SSL;
 
-public abstract class EndpointInfo : Ice.EndpointInfo
+public sealed class EndpointInfo : Ice.EndpointInfo
 {
+    internal EndpointInfo(Ice.EndpointInfo underlying)
+        : base(underlying)
+    {
+    }
 }


### PR DESCRIPTION
This PR simplifies EndpointInfo in C#, in particular, make all the fields readonly.