### PR TITLE
Refactor ConnectionInfo in C#

### DIFF
--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -138,48 +138,128 @@ namespace Ice
         /// <summary>
         /// The underlying connection information.
         /// </summary>
-        public ConnectionInfo? underlying;
+        public readonly ConnectionInfo? underlying;
 
         /// <summary>
         /// Whether the connection is an incoming connection (<c>true</c>) or an outgoing connection (<c>false</c>).
         /// </summary>
-        public bool incoming;
+        public readonly bool incoming;
 
         /// <summary>
         /// The name of the adapter associated with the connection.
         /// </summary>
-        public string adapterName = "";
+        public readonly string adapterName;
 
         /// <summary>
         /// The connection id.
         /// </summary>
-        public string connectionId = "";
+        public readonly string connectionId;
+
+        protected ConnectionInfo(ConnectionInfo underlying)
+        {
+            this.underlying = underlying;
+            incoming = underlying.incoming;
+            adapterName = underlying.adapterName;
+            connectionId = underlying.connectionId;
+        }
+
+        protected ConnectionInfo(bool incoming, string adapterName, string connectionId)
+        {
+            this.incoming = incoming;
+            this.adapterName = adapterName;
+            this.connectionId = connectionId;
+        }
     }
 
     public class IPConnectionInfo : ConnectionInfo
     {
-        public string localAddress = "";
-        public int localPort = -1;
-        public string remoteAddress = "";
-        public int remotePort = -1;
+        public readonly string localAddress;
+        public readonly int localPort;
+        public readonly string remoteAddress;
+        public readonly int remotePort;
+
+        protected IPConnectionInfo(
+            bool incoming,
+            string adapterName,
+            string connectionId,
+            string localAddress,
+            int localPort,
+            string remoteAddress,
+            int remotePort)
+            : base(incoming, adapterName, connectionId)
+        {
+            this.localAddress = localAddress;
+            this.localPort = localPort;
+            this.remoteAddress = remoteAddress;
+            this.remotePort = remotePort;
+        }
     }
 
     public sealed class TCPConnectionInfo : IPConnectionInfo
     {
-        public int rcvSize;
-        public int sndSize;
+        public readonly int rcvSize;
+        public readonly int sndSize;
+
+        internal TCPConnectionInfo(
+            bool incoming,
+            string adapterName,
+            string connectionId,
+            string localAddress,
+            int localPort,
+            string remoteAddress,
+            int remotePort,
+            int rcvSize,
+            int sndSize)
+            : base(incoming, adapterName, connectionId, localAddress, localPort, remoteAddress, remotePort)
+        {
+            this.rcvSize = rcvSize;
+            this.sndSize = sndSize;
+        }
+
+        internal TCPConnectionInfo(bool incoming, string adapterName, string connectionId)
+            : this(incoming, adapterName, connectionId, "", -1, "", -1, 0, 0)
+        {
+        }
     }
 
     public sealed class UDPConnectionInfo : IPConnectionInfo
     {
-        public string mcastAddress = "";
-        public int mcastPort = -1;
-        public int rcvSize;
-        public int sndSize;
+        public readonly string mcastAddress;
+        public readonly int mcastPort;
+        public readonly int rcvSize;
+        public readonly int sndSize;
+
+        internal UDPConnectionInfo(
+            bool incoming,
+            string adapterName,
+            string connectionId,
+            string localAddress,
+            int localPort,
+            string remoteAddress,
+            int remotePort,
+            string mcastAddress,
+            int mcastPort,
+            int rcvSize,
+            int sndSize)
+            : base(incoming, adapterName, connectionId, localAddress, localPort, remoteAddress, remotePort)
+        {
+            this.mcastAddress = mcastAddress;
+            this.mcastPort = mcastPort;
+            this.rcvSize = rcvSize;
+            this.sndSize = sndSize;
+        }
+
+        internal UDPConnectionInfo(bool incoming, string adapterName, string connectionId)
+            : this(incoming, adapterName, connectionId, "", -1, "", -1, "", -1, 0, 0)
+        {
+        }
     }
 
     public sealed class WSConnectionInfo : ConnectionInfo
     {
-        public Dictionary<string, string> headers = [];
+        public readonly Dictionary<string, string> headers;
+
+        internal WSConnectionInfo(ConnectionInfo underlying, Dictionary<string, string> headers)
+            : base(underlying) => this.headers = headers;
     }
 }

--- a/csharp/src/Ice/Connection.cs
+++ b/csharp/src/Ice/Connection.cs
@@ -217,7 +217,16 @@ namespace Ice
         }
 
         internal TCPConnectionInfo(bool incoming, string adapterName, string connectionId)
-            : this(incoming, adapterName, connectionId, "", -1, "", -1, 0, 0)
+            : this(
+                incoming,
+                adapterName,
+                connectionId,
+                localAddress: "",
+                localPort: -1,
+                remoteAddress: "",
+                remotePort: -1,
+                rcvSize: 0,
+                sndSize: 0)
         {
         }
     }
@@ -250,7 +259,18 @@ namespace Ice
         }
 
         internal UDPConnectionInfo(bool incoming, string adapterName, string connectionId)
-            : this(incoming, adapterName, connectionId, "", -1, "", -1, "", -1, 0, 0)
+            : this(
+                incoming,
+                adapterName,
+                connectionId,
+                localAddress: "",
+                localPort: -1,
+                remoteAddress: "",
+                remotePort: -1,
+                mcastAddress: "",
+                mcastPort: -1,
+                rcvSize: 0,
+                sndSize: 0)
         {
         }
     }

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -2667,7 +2667,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
             return _info;
         }
 
-        _info = _transceiver.getInfo(incoming: _connector is null, _endpoint.connectionId(), _adapter?.getName() ?? "");
+        _info = _transceiver.getInfo(incoming: _connector is null, _adapter?.getName() ?? "", _endpoint.connectionId());
         return _info;
     }
 

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -2660,25 +2660,14 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
 
     private ConnectionInfo initConnectionInfo()
     {
+        // Called with _mutex locked.
+
         if (_state > StateNotInitialized && _info is not null) // Update the connection info until it's initialized
         {
             return _info;
         }
 
-        try
-        {
-            _info = _transceiver.getInfo();
-        }
-        catch (LocalException)
-        {
-            _info = new ConnectionInfo();
-        }
-        for (ConnectionInfo info = _info; info is not null; info = info.underlying)
-        {
-            info.connectionId = _endpoint.connectionId();
-            info.adapterName = _adapter?.getName() ?? "";
-            info.incoming = _connector is null;
-        }
+        _info = _transceiver.getInfo(incoming: _connector is null, _endpoint.connectionId(), _adapter?.getName() ?? "");
         return _info;
     }
 

--- a/csharp/src/Ice/Internal/IdleTimeoutTransceiverDecorator.cs
+++ b/csharp/src/Ice/Internal/IdleTimeoutTransceiverDecorator.cs
@@ -58,8 +58,8 @@ internal sealed class IdleTimeoutTransceiverDecorator : Transceiver
     // We call write after finishWrite, so no need to do anything here.
     public void finishWrite(Buffer buf) => _decoratee.finishWrite(buf);
 
-    public ConnectionInfo getInfo(bool incoming, string connectionId, string adapterName) =>
-        _decoratee.getInfo(incoming, connectionId, adapterName);
+    public ConnectionInfo getInfo(bool incoming, string adapterName, string connectionId) =>
+        _decoratee.getInfo(incoming, adapterName, connectionId);
 
     public int initialize(Buffer readBuffer, Buffer writeBuffer, ref bool hasMoreData) =>
         _decoratee.initialize(readBuffer, writeBuffer, ref hasMoreData);

--- a/csharp/src/Ice/Internal/IdleTimeoutTransceiverDecorator.cs
+++ b/csharp/src/Ice/Internal/IdleTimeoutTransceiverDecorator.cs
@@ -58,7 +58,8 @@ internal sealed class IdleTimeoutTransceiverDecorator : Transceiver
     // We call write after finishWrite, so no need to do anything here.
     public void finishWrite(Buffer buf) => _decoratee.finishWrite(buf);
 
-    public ConnectionInfo getInfo() => _decoratee.getInfo();
+    public ConnectionInfo getInfo(bool incoming, string connectionId, string adapterName) =>
+        _decoratee.getInfo(incoming, connectionId, adapterName);
 
     public int initialize(Buffer readBuffer, Buffer writeBuffer, ref bool hasMoreData) =>
         _decoratee.initialize(readBuffer, writeBuffer, ref hasMoreData);

--- a/csharp/src/Ice/Internal/TcpTransceiver.cs
+++ b/csharp/src/Ice/Internal/TcpTransceiver.cs
@@ -76,7 +76,7 @@ internal sealed class TcpTransceiver : Transceiver
         return _instance.protocol();
     }
 
-    public ConnectionInfo getInfo(bool incoming, string connectionId, string adapterName)
+    public ConnectionInfo getInfo(bool incoming, string adapterName, string connectionId)
     {
         if (_stream.fd() is null)
         {

--- a/csharp/src/Ice/Internal/TcpTransceiver.cs
+++ b/csharp/src/Ice/Internal/TcpTransceiver.cs
@@ -76,21 +76,28 @@ internal sealed class TcpTransceiver : Transceiver
         return _instance.protocol();
     }
 
-    public Ice.ConnectionInfo getInfo()
+    public ConnectionInfo getInfo(bool incoming, string connectionId, string adapterName)
     {
-        Ice.TCPConnectionInfo info = new Ice.TCPConnectionInfo();
-        if (_stream.fd() != null)
+        if (_stream.fd() is null)
+        {
+            return new TCPConnectionInfo(incoming, adapterName, connectionId);
+        }
+        else
         {
             EndPoint localEndpoint = Network.getLocalAddress(_stream.fd());
-            info.localAddress = Network.endpointAddressToString(localEndpoint);
-            info.localPort = Network.endpointPort(localEndpoint);
             EndPoint remoteEndpoint = Network.getRemoteAddress(_stream.fd());
-            info.remoteAddress = Network.endpointAddressToString(remoteEndpoint);
-            info.remotePort = Network.endpointPort(remoteEndpoint);
-            info.rcvSize = Network.getRecvBufferSize(_stream.fd());
-            info.sndSize = Network.getSendBufferSize(_stream.fd());
+
+            return new TCPConnectionInfo(
+                incoming,
+                adapterName,
+                connectionId,
+                Network.endpointAddressToString(localEndpoint),
+                Network.endpointPort(localEndpoint),
+                Network.endpointAddressToString(remoteEndpoint),
+                Network.endpointPort(remoteEndpoint),
+                Network.getRecvBufferSize(_stream.fd()),
+                Network.getSendBufferSize(_stream.fd()));
         }
-        return info;
     }
 
     public void checkSendSize(Buffer buf)

--- a/csharp/src/Ice/Internal/Transceiver.cs
+++ b/csharp/src/Ice/Internal/Transceiver.cs
@@ -53,7 +53,7 @@ public interface Transceiver
 
     string toDetailedString();
 
-    ConnectionInfo getInfo(bool incoming, string connectionId, string adapterName);
+    ConnectionInfo getInfo(bool incoming, string adapterName, string connectionId);
 
     void checkSendSize(Buffer buf);
 

--- a/csharp/src/Ice/Internal/Transceiver.cs
+++ b/csharp/src/Ice/Internal/Transceiver.cs
@@ -53,7 +53,7 @@ public interface Transceiver
 
     string toDetailedString();
 
-    Ice.ConnectionInfo getInfo();
+    ConnectionInfo getInfo(bool incoming, string connectionId, string adapterName);
 
     void checkSendSize(Buffer buf);
 

--- a/csharp/src/Ice/Internal/UdpTransceiver.cs
+++ b/csharp/src/Ice/Internal/UdpTransceiver.cs
@@ -544,41 +544,49 @@ internal sealed class UdpTransceiver : Transceiver
         return _instance.protocol();
     }
 
-    public Ice.ConnectionInfo getInfo()
+    public ConnectionInfo getInfo(bool incoming, string connectionId, string adapterName)
     {
-        Ice.UDPConnectionInfo info = new Ice.UDPConnectionInfo();
-        if (_fd != null)
+        if (_fd is null)
+        {
+            return new UDPConnectionInfo(incoming, connectionId, adapterName);
+        }
+        else
         {
             EndPoint localEndpoint = Network.getLocalAddress(_fd);
-            info.localAddress = Network.endpointAddressToString(localEndpoint);
-            info.localPort = Network.endpointPort(localEndpoint);
-            if (_state == StateNotConnected)
+
+            if (_state == StateNotConnected) // TODO: eliminate all these states
             {
-                if (_peerAddr != null)
-                {
-                    info.remoteAddress = Network.endpointAddressToString(_peerAddr);
-                    info.remotePort = Network.endpointPort(_peerAddr);
-                }
+                return new UDPConnectionInfo(
+                    incoming,
+                    connectionId,
+                    adapterName,
+                    Network.endpointAddressToString(localEndpoint),
+                    Network.endpointPort(localEndpoint),
+                    _peerAddr is not null ? Network.endpointAddressToString(_peerAddr) : "",
+                    _peerAddr is not null ? Network.endpointPort(_peerAddr) : -1,
+                    _mcastAddr is not null ? Network.endpointAddressToString(_mcastAddr) : "",
+                    _mcastAddr is not null ? Network.endpointPort(_mcastAddr) : -1,
+                    _rcvSize,
+                    _sndSize);
             }
             else
             {
                 EndPoint remoteEndpoint = Network.getRemoteAddress(_fd);
-                if (remoteEndpoint != null)
-                {
-                    info.remoteAddress = Network.endpointAddressToString(remoteEndpoint);
-                    info.remotePort = Network.endpointPort(remoteEndpoint);
-                }
-            }
-            info.rcvSize = Network.getRecvBufferSize(_fd);
-            info.sndSize = Network.getSendBufferSize(_fd);
-        }
 
-        if (_mcastAddr != null)
-        {
-            info.mcastAddress = Network.endpointAddressToString(_mcastAddr);
-            info.mcastPort = Network.endpointPort(_mcastAddr);
+                return new UDPConnectionInfo(
+                    incoming,
+                    connectionId,
+                    adapterName,
+                    Network.endpointAddressToString(localEndpoint),
+                    Network.endpointPort(localEndpoint),
+                    remoteEndpoint is not null ? Network.endpointAddressToString(remoteEndpoint) : "",
+                    remoteEndpoint is not null ? Network.endpointPort(remoteEndpoint) : -1,
+                    _mcastAddr is not null ? Network.endpointAddressToString(_mcastAddr) : "",
+                    _mcastAddr is not null ? Network.endpointPort(_mcastAddr) : -1,
+                    _rcvSize,
+                    _sndSize);
+            }
         }
-        return info;
     }
 
     public void checkSendSize(Buffer buf)

--- a/csharp/src/Ice/Internal/UdpTransceiver.cs
+++ b/csharp/src/Ice/Internal/UdpTransceiver.cs
@@ -558,8 +558,8 @@ internal sealed class UdpTransceiver : Transceiver
             {
                 return new UDPConnectionInfo(
                     incoming,
-                    connectionId,
                     adapterName,
+                    connectionId,
                     Network.endpointAddressToString(localEndpoint),
                     Network.endpointPort(localEndpoint),
                     _peerAddr is not null ? Network.endpointAddressToString(_peerAddr) : "",
@@ -575,8 +575,8 @@ internal sealed class UdpTransceiver : Transceiver
 
                 return new UDPConnectionInfo(
                     incoming,
-                    connectionId,
                     adapterName,
+                    connectionId,
                     Network.endpointAddressToString(localEndpoint),
                     Network.endpointPort(localEndpoint),
                     remoteEndpoint is not null ? Network.endpointAddressToString(remoteEndpoint) : "",

--- a/csharp/src/Ice/Internal/UdpTransceiver.cs
+++ b/csharp/src/Ice/Internal/UdpTransceiver.cs
@@ -544,11 +544,11 @@ internal sealed class UdpTransceiver : Transceiver
         return _instance.protocol();
     }
 
-    public ConnectionInfo getInfo(bool incoming, string connectionId, string adapterName)
+    public ConnectionInfo getInfo(bool incoming, string adapterName, string connectionId)
     {
         if (_fd is null)
         {
-            return new UDPConnectionInfo(incoming, connectionId, adapterName);
+            return new UDPConnectionInfo(incoming, adapterName, connectionId);
         }
         else
         {

--- a/csharp/src/Ice/Internal/WSTransceiver.cs
+++ b/csharp/src/Ice/Internal/WSTransceiver.cs
@@ -655,8 +655,8 @@ internal sealed class WSTransceiver : Transceiver
         return _instance.protocol();
     }
 
-    public ConnectionInfo getInfo(bool incoming, string connectionId, string adapterName) =>
-        new WSConnectionInfo(_delegate.getInfo(incoming, connectionId, adapterName), _parser.getHeaders());
+    public ConnectionInfo getInfo(bool incoming, string adapterName, string connectionId) =>
+        new WSConnectionInfo(_delegate.getInfo(incoming, adapterName, connectionId), _parser.getHeaders());
 
     public void checkSendSize(Buffer buf)
     {

--- a/csharp/src/Ice/Internal/WSTransceiver.cs
+++ b/csharp/src/Ice/Internal/WSTransceiver.cs
@@ -655,13 +655,8 @@ internal sealed class WSTransceiver : Transceiver
         return _instance.protocol();
     }
 
-    public Ice.ConnectionInfo getInfo()
-    {
-        Ice.WSConnectionInfo info = new Ice.WSConnectionInfo();
-        info.headers = _parser.getHeaders();
-        info.underlying = _delegate.getInfo();
-        return info;
-    }
+    public ConnectionInfo getInfo(bool incoming, string connectionId, string adapterName) =>
+        new WSConnectionInfo(_delegate.getInfo(incoming, connectionId, adapterName), _parser.getHeaders());
 
     public void checkSendSize(Buffer buf)
     {

--- a/csharp/src/Ice/SSL/ConnectionInfo.cs
+++ b/csharp/src/Ice/SSL/ConnectionInfo.cs
@@ -8,7 +8,15 @@ namespace Ice.SSL;
 
 public sealed class ConnectionInfo : Ice.ConnectionInfo
 {
-    public string cipher = "";
-    public X509Certificate2[] certs = [];
-    public bool verified;
+    public readonly string cipher;
+    public readonly X509Certificate2[] certs;
+    public readonly bool verified;
+
+    internal ConnectionInfo(Ice.ConnectionInfo underlying, string cipher, X509Certificate2[] certs, bool verified)
+        : base(underlying)
+    {
+        this.cipher = cipher;
+        this.certs = certs;
+        this.verified = verified;
+    }
 }

--- a/csharp/src/Ice/SSL/TransceiverI.cs
+++ b/csharp/src/Ice/SSL/TransceiverI.cs
@@ -60,7 +60,7 @@ internal sealed class TransceiverI : Ice.Internal.Transceiver
         _authenticated = true;
 
         _cipher = _sslStream.CipherAlgorithm.ToString();
-        _instance.verifyPeer((ConnectionInfo)getInfo(_incoming, connectionId: "", _adapterName), ToString());
+        _instance.verifyPeer((ConnectionInfo)getInfo(_incoming, _adapterName, connectionId: ""), ToString());
 
         if (_instance.securityTraceLevel() >= 1)
         {
@@ -309,13 +309,13 @@ internal sealed class TransceiverI : Ice.Internal.Transceiver
 
     public string protocol() => _delegate.protocol();
 
-    public Ice.ConnectionInfo getInfo(bool incoming, string connectionId, string adapterName)
+    public Ice.ConnectionInfo getInfo(bool incoming, string adapterName, string connectionId)
     {
         Debug.Assert(incoming == _incoming);
         Debug.Assert(adapterName == _adapterName);
 
         return new Ice.SSL.ConnectionInfo(
-            _delegate.getInfo(incoming, connectionId, adapterName),
+            _delegate.getInfo(incoming, adapterName, connectionId),
             _cipher,
             _sslStream is SslStream sslStream && sslStream.RemoteCertificate is X509Certificate2 remoteCertificate ?
                 [remoteCertificate] : [],

--- a/csharp/test/Ice/background/Transceiver.cs
+++ b/csharp/test/Ice/background/Transceiver.cs
@@ -197,9 +197,9 @@ internal class Transceiver : Ice.Internal.Transceiver
         return "test-" + _transceiver.protocol();
     }
 
-    public Ice.ConnectionInfo getInfo()
+    public Ice.ConnectionInfo getInfo(bool incoming, string connectionId, string adapterName)
     {
-        return _transceiver.getInfo();
+        return _transceiver.getInfo(incoming, connectionId, adapterName);
     }
 
     public override string ToString()

--- a/csharp/test/Ice/background/Transceiver.cs
+++ b/csharp/test/Ice/background/Transceiver.cs
@@ -197,8 +197,8 @@ internal class Transceiver : Ice.Internal.Transceiver
         return "test-" + _transceiver.protocol();
     }
 
-    public Ice.ConnectionInfo getInfo(bool incoming, string connectionId, string adapterName) =>
-        _transceiver.getInfo(incoming, connectionId, adapterName);
+    public Ice.ConnectionInfo getInfo(bool incoming, string adapterName, string connectionId) =>
+        _transceiver.getInfo(incoming, adapterName, connectionId);
 
     public override string ToString()
     {

--- a/csharp/test/Ice/background/Transceiver.cs
+++ b/csharp/test/Ice/background/Transceiver.cs
@@ -197,10 +197,8 @@ internal class Transceiver : Ice.Internal.Transceiver
         return "test-" + _transceiver.protocol();
     }
 
-    public Ice.ConnectionInfo getInfo(bool incoming, string connectionId, string adapterName)
-    {
-        return _transceiver.getInfo(incoming, connectionId, adapterName);
-    }
+    public Ice.ConnectionInfo getInfo(bool incoming, string connectionId, string adapterName) =>
+        _transceiver.getInfo(incoming, connectionId, adapterName);
 
     public override string ToString()
     {


### PR DESCRIPTION
This is a companion PR for #3185 - it simplifies ConnectionInfo by switching to readonly fields + protected or internal constructors.