### PR TITLE
Minor Comment Fixes

### DIFF
--- a/cpp/include/Ice/IncomingRequest.h
+++ b/cpp/include/Ice/IncomingRequest.h
@@ -15,7 +15,7 @@ namespace Ice
     class InputStream;
 
     /**
-     * Represent a request received by a connection. It's the argument to the dispatch function on Object.
+     * Represents a request received by a connection. It's the argument to the dispatch function on Object.
      * @remarks IncomingRequest is neither copyable nor movable. It can be used only on the dispatch thread.
      * @see Object::dispatch
      * \headerfile Ice/Ice.h

--- a/cpp/include/Ice/OutgoingResponse.h
+++ b/cpp/include/Ice/OutgoingResponse.h
@@ -14,7 +14,7 @@
 namespace Ice
 {
     /**
-     * Represent the status of a response.
+     * Represents the status of a response.
      * \headerfile Ice/Ice.h
      */
     enum class ReplyStatus : std::uint8_t
@@ -30,7 +30,7 @@ namespace Ice
     };
 
     /**
-     * Represent the response to an incoming request. It's the argument to the sendResponse callback accepted by
+     * Represents the response to an incoming request. It's the argument to the sendResponse callback accepted by
      * Object::dispatch.
      * @remarks OutgoingResponse is movable but not copyable. sendResponse wrappers must move the response to the next
      * callback.

--- a/cpp/test/Slice/errorDetection/ConstDef.ice
+++ b/cpp/test/Slice/errorDetection/ConstDef.ice
@@ -125,7 +125,7 @@ const string nullstring4 = "a\U00000000"; // OK
 const byte c1 = l1;             // OK
 const short c2 = l1;            // OK
 const int c3 = l1;              // OK
-const long c4  = l1;            // OK
+const long c4 = l1;             // OK
 
 const byte c5 = s2;             // overflow
 const short c6 = i2;            // overflow

--- a/slice/Ice/EndpointTypes.ice
+++ b/slice/Ice/EndpointTypes.ice
@@ -32,7 +32,7 @@ module Ice
     /// Uniquely identifies TCP-based WebSocket endpoints.
     const short WSEndpointType = 4;
 
-    ///  Uniquely identifies SSL-based WebSocket endpoints.
+    /// Uniquely identifies SSL-based WebSocket endpoints.
     const short WSSEndpointType = 5;
 
     /// Uniquely identifies Bluetooth endpoints.

--- a/slice/Ice/Locator.ice
+++ b/slice/Ice/Locator.ice
@@ -22,7 +22,7 @@ module Ice
 {
     interface Process;
 
-    ///  This exception is raised if an adapter cannot be found.
+    /// This exception is raised if an adapter cannot be found.
     exception AdapterNotFoundException
     {
     }
@@ -113,7 +113,7 @@ module Ice
     }
 
     /// This interface should be implemented by services implementing the <code>Ice::Locator interface</code>. It should
-    /// be advertised through an Ice object with the identity <code>`Ice/LocatorFinder'</code>. This allows clients to
+    /// be advertised through an Ice object with the identity <code>'Ice/LocatorFinder'</code>. This allows clients to
     /// retrieve the locator proxy with just the endpoint information of the service.
     interface LocatorFinder
     {

--- a/slice/Ice/Router.ice
+++ b/slice/Ice/Router.ice
@@ -42,7 +42,7 @@ module Ice
     }
 
     /// This interface should be implemented by services implementing the Ice::Router interface. It should be advertised
-    /// through an Ice object with the identity `Ice/RouterFinder'. This allows clients to retrieve the router proxy
+    /// through an Ice object with the identity 'Ice/RouterFinder'. This allows clients to retrieve the router proxy
     /// with just the endpoint information of the service.
     interface RouterFinder
     {

--- a/slice/IceGrid/Admin.ice
+++ b/slice/IceGrid/Admin.ice
@@ -846,7 +846,7 @@ module IceGrid
         /// If 0 or positive, the file is read from the last <code>count</code> lines.
         /// @return An iterator to read the file. The returned proxy is never null.
         /// @throws FileNotAvailableException Raised if the file can't be read.
-        ///  @throws ServerNotExistException Raised if the server doesn't exist.
+        /// @throws ServerNotExistException Raised if the server doesn't exist.
         /// @throws NodeUnreachableException Raised if the node could not be reached.
         /// @throws DeploymentException Raised if the server couldn't be deployed on the node.
         FileIterator* openServerStdOut(string id, int count)

--- a/slice/IceLocatorDiscovery/IceLocatorDiscovery.ice
+++ b/slice/IceLocatorDiscovery/IceLocatorDiscovery.ice
@@ -30,7 +30,7 @@ module IceLocatorDiscovery
 
     /// The Ice lookup interface is implemented by Ice locator implementations and can be used by clients to find
     /// available Ice locators on the network.
-    /// Ice locator implementations provide a well-known `Ice/LocatorLookup' object accessible through UDP multicast.
+    /// Ice locator implementations provide a well-known 'Ice/LocatorLookup' object accessible through UDP multicast.
     /// Clients typically make a multicast findLocator request to find the locator proxy.
     /// @see LookupReply
     interface Lookup

--- a/slice/IceStorm/IceStorm.ice
+++ b/slice/IceStorm/IceStorm.ice
@@ -27,7 +27,7 @@ module IceStorm
 
 interface Topic;
 
-///  Information on the topic links.
+/// Information on the topic links.
 struct LinkInfo
 {
     /// The linked topic. It is never null.
@@ -61,7 +61,7 @@ exception NoSuchLink
     string name;
 }
 
-///  This exception indicates that an attempt was made to subscribe a proxy for which a subscription already exists.
+/// This exception indicates that an attempt was made to subscribe a proxy for which a subscription already exists.
 exception AlreadySubscribed
 {
 }
@@ -80,7 +80,7 @@ exception BadQoS
     string reason;
 }
 
-/// Publishers publish information on a particular topic. A topic logically represents a type. A
+/// Publishers publish information on a particular topic. A topic logically represents a type.
 /// @see TopicManager
 interface Topic
 {
@@ -101,7 +101,7 @@ interface Topic
     /// @return A proxy to publish data on this topic.
     ["cpp:const"] idempotent Object* getNonReplicatedPublisher();
 
-    /// Subscribe with the given <code>qos</code> to this topic.  A per-subscriber publisher object is returned.
+    /// Subscribe with the given <code>qos</code> to this topic. A per-subscriber publisher object is returned.
     /// @param theQoS The quality of service parameters for this subscription.
     /// @param subscriber The subscriber's proxy. This proxy is never null.
     /// @return The per-subscriber publisher object. The returned object is never null.
@@ -179,7 +179,7 @@ interface TopicManager
     idempotent TopicDict retrieveAll();
 }
 
-/// This interface is advertised by the IceStorm service through the Ice object with the identity `IceStorm/Finder'.
+/// This interface is advertised by the IceStorm service through the Ice object with the identity 'IceStorm/Finder'.
 /// This allows clients to retrieve the topic manager with just the endpoint information of the IceStorm service.
 interface Finder
 {


### PR DESCRIPTION
The main point of this PR was to fix our usage of asymmetric quotations like `` `hello' `` in our Slice files.
These seem to confuse Doxygen, which thinks that they are un-closed code-blocks.
I wrote more about this on my blog, but these need to be removed before we can switch to triple-slash style doc-comments.

While reviewing the generated code, I also stumbled across a couple of things that I fixed in this PR too.
- Sometimes we'd accidentally add an extra space in between things
- Sometimes we'd forget to conjugate the word `Represent`