### PR TITLE
ConnectionInfo fixes in C++ and C#

### DIFF
--- a/cpp/include/Ice/Connection.h
+++ b/cpp/include/Ice/Connection.h
@@ -231,7 +231,7 @@ namespace Ice
         const bool incoming;
 
         /**
-         * The name of the object adapter that created this incoming connection.
+         * The name of the adapter associated with the connection.
          */
         const std::string adapterName;
 

--- a/cpp/include/Ice/Connection.h
+++ b/cpp/include/Ice/Connection.h
@@ -231,7 +231,7 @@ namespace Ice
         const bool incoming;
 
         /**
-         * The name of the adapter associated with the connection.
+         * The name of the object adapter that created this incoming connection.
          */
         const std::string adapterName;
 

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -3493,17 +3493,19 @@ Ice::ConnectionI::dispatchAll(
 Ice::ConnectionInfoPtr
 Ice::ConnectionI::initConnectionInfo() const
 {
-    // Called with _mutex locked.
-
     if (_state > StateNotInitialized && _info) // Update the connection information until it's initialized
     {
         return _info;
     }
 
+    bool incoming = !_connector;
+
+    // _adapter is set for an incoming connection until "finished"
     _info = _transceiver->getInfo(
-        _connector == nullptr,
-        _adapter ? _adapter->getName() : string{},
+        incoming,
+        incoming && _adapter ? _adapter->getName() : string{},
         _endpoint->connectionId());
+
     return _info;
 }
 

--- a/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
@@ -601,7 +601,23 @@ Ice::ConnectionInfoPtr
 OpenSSL::TransceiverI::getInfo(bool incoming, string adapterName, string connectionId) const
 {
     assert(incoming == _incoming);
-    assert(adapterName == _adapterName);
+
+    if (incoming)
+    {
+        // adapterName can be empty during connection shutdown
+        if (adapterName.empty())
+        {
+            adapterName = _adapterName;
+        }
+        else
+        {
+            assert(adapterName == _adapterName);
+        }
+    }
+    else
+    {
+        assert(adapterName.empty());
+    }
 
     X509* peerCertificate = nullptr;
     if (_peerCertificate)

--- a/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
@@ -601,23 +601,8 @@ Ice::ConnectionInfoPtr
 OpenSSL::TransceiverI::getInfo(bool incoming, string adapterName, string connectionId) const
 {
     assert(incoming == _incoming);
-
-    if (incoming)
-    {
-        // adapterName can be empty during connection shutdown
-        if (adapterName.empty())
-        {
-            adapterName = _adapterName;
-        }
-        else
-        {
-            assert(adapterName == _adapterName);
-        }
-    }
-    else
-    {
-        assert(adapterName.empty());
-    }
+    // adapterName is the name of the object adapter currently associated with this connection, while _adapterName
+    // represents the name of the object adapter that created this connection (incoming only).
 
     X509* peerCertificate = nullptr;
     if (_peerCertificate)

--- a/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
@@ -933,7 +933,23 @@ Ice::ConnectionInfoPtr
 Schannel::TransceiverI::getInfo(bool incoming, string adapterName, string connectionId) const
 {
     assert(incoming == _incoming);
-    assert(adapterName == _adapterName);
+
+    if (incoming)
+    {
+        // adapterName can be empty during connection shutdown
+        if (adapterName.empty())
+        {
+            adapterName = _adapterName;
+        }
+        else
+        {
+            assert(adapterName == _adapterName);
+        }
+    }
+    else
+    {
+        assert(adapterName.empty());
+    }
 
     return make_shared<ConnectionInfo>(
         _delegate->getInfo(incoming, std::move(adapterName), std::move(connectionId)),

--- a/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
@@ -933,23 +933,8 @@ Ice::ConnectionInfoPtr
 Schannel::TransceiverI::getInfo(bool incoming, string adapterName, string connectionId) const
 {
     assert(incoming == _incoming);
-
-    if (incoming)
-    {
-        // adapterName can be empty during connection shutdown
-        if (adapterName.empty())
-        {
-            adapterName = _adapterName;
-        }
-        else
-        {
-            assert(adapterName == _adapterName);
-        }
-    }
-    else
-    {
-        assert(adapterName.empty());
-    }
+    // adapterName is the name of the object adapter currently associated with this connection, while _adapterName
+    // represents the name of the object adapter that created this connection (incoming only).
 
     return make_shared<ConnectionInfo>(
         _delegate->getInfo(incoming, std::move(adapterName), std::move(connectionId)),

--- a/cpp/src/Ice/SSL/SecureTransportTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportTransceiverI.cpp
@@ -506,23 +506,8 @@ Ice::ConnectionInfoPtr
 Ice::SSL::SecureTransport::TransceiverI::getInfo(bool incoming, string adapterName, string connectionId) const
 {
     assert(incoming == _incoming);
-
-    if (incoming)
-    {
-        // adapterName can be empty during connection shutdown
-        if (adapterName.empty())
-        {
-            adapterName = _adapterName;
-        }
-        else
-        {
-            assert(adapterName == _adapterName);
-        }
-    }
-    else
-    {
-        assert(adapterName.empty());
-    }
+    // adapterName is the name of the object adapter currently associated with this connection, while _adapterName
+    // represents the name of the object adapter that created this connection (incoming only).
 
     SecCertificateRef peerCertificate = nullptr;
 

--- a/cpp/src/Ice/SSL/SecureTransportTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportTransceiverI.cpp
@@ -506,7 +506,23 @@ Ice::ConnectionInfoPtr
 Ice::SSL::SecureTransport::TransceiverI::getInfo(bool incoming, string adapterName, string connectionId) const
 {
     assert(incoming == _incoming);
-    assert(adapterName == _adapterName);
+
+    if (incoming)
+    {
+        // adapterName can be empty during connection shutdown
+        if (adapterName.empty())
+        {
+            adapterName = _adapterName;
+        }
+        else
+        {
+            assert(adapterName == _adapterName);
+        }
+    }
+    else
+    {
+        assert(adapterName.empty());
+    }
 
     SecCertificateRef peerCertificate = nullptr;
 

--- a/cpp/src/Ice/Transceiver.h
+++ b/cpp/src/Ice/Transceiver.h
@@ -38,6 +38,12 @@ namespace IceInternal
         virtual std::string toString() const = 0;
         virtual std::string toDetailedString() const = 0;
 
+        /// @brief Creates a connection info object for this connection.
+        /// @param incoming true for an incoming connection, false for an outgoing connection.
+        /// @param adapterName The name of the object adapter that created this connection. It's empty when incoming is
+        /// false.
+        /// @param connectionId The connection ID of this connection.
+        /// @return The new connection info.
         virtual Ice::ConnectionInfoPtr
         getInfo(bool incoming, std::string adapterName, std::string connectionId) const = 0;
 

--- a/cpp/src/Ice/Transceiver.h
+++ b/cpp/src/Ice/Transceiver.h
@@ -40,8 +40,7 @@ namespace IceInternal
 
         /// @brief Creates a connection info object for this connection.
         /// @param incoming true for an incoming connection, false for an outgoing connection.
-        /// @param adapterName The name of the object adapter that created this connection. It's empty when incoming is
-        /// false.
+        /// @param adapterName The name of the object adapter currently associated with this connection.
         /// @param connectionId The connection ID of this connection.
         /// @return The new connection info.
         virtual Ice::ConnectionInfoPtr

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -572,6 +572,9 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
             }
             Debug.Assert(adapter is not null); // Called by ObjectAdapter::setAdapterOnConnection
             _adapter = adapter;
+
+            // Clear cached connection info (if any) as it's no longer accurate.
+            _info = null;
         }
     }
 
@@ -2667,14 +2670,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
             return _info;
         }
 
-        bool incoming = _connector is null;
-
-        // For incoming connections, the adapter is not null until "finished".
-        _info = _transceiver.getInfo(
-            incoming,
-            incoming ? _adapter?.getName() ?? "" : "",
-            _endpoint.connectionId());
-
+        _info = _transceiver.getInfo(incoming: _connector is null, _adapter?.getName() ?? "", _endpoint.connectionId());
         return _info;
     }
 

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -2667,7 +2667,14 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
             return _info;
         }
 
-        _info = _transceiver.getInfo(incoming: _connector is null, _adapter?.getName() ?? "", _endpoint.connectionId());
+        bool incoming = _connector is null;
+
+        // For incoming connections, the adapter is not null until "finished".
+        _info = _transceiver.getInfo(
+            incoming,
+            incoming ? _adapter?.getName() ?? "" : "",
+            _endpoint.connectionId());
+
         return _info;
     }
 

--- a/csharp/src/Ice/Internal/Transceiver.cs
+++ b/csharp/src/Ice/Internal/Transceiver.cs
@@ -56,8 +56,7 @@ public interface Transceiver
     /// <summary>Creates a connection info object for this connection.</summary>
     /// <param name="incoming"><see langword="true"/> for an incoming connection, <see langword="true"/> for an outgoing
     /// connection.</param>
-    /// <param name="adapterName">The name of the object adapter that created this connection. It's empty when
-    /// <paramref name="incoming"/> is <see langword="false"/>.</param>
+    /// <param name="adapterName">The name of the object adapter currently associated with this connection.</param>
     /// <param name="connectionId">The connection ID of this connection.</param>
     /// <returns>The new connection info.</returns>
     ConnectionInfo getInfo(bool incoming, string adapterName, string connectionId);

--- a/csharp/src/Ice/Internal/Transceiver.cs
+++ b/csharp/src/Ice/Internal/Transceiver.cs
@@ -53,6 +53,13 @@ public interface Transceiver
 
     string toDetailedString();
 
+    /// <summary>Creates a connection info object for this connection.</summary>
+    /// <param name="incoming"><see langword="true"/> for an incoming connection, <see langword="true"/> for an outgoing
+    /// connection.</param>
+    /// <param name="adapterName">The name of the object adapter that created this connection. It's empty when
+    /// <paramref name="incoming"/> is <see langword="false"/>.</param>
+    /// <param name="connectionId">The connection ID of this connection.</param>
+    /// <returns>The new connection info.</returns>
     ConnectionInfo getInfo(bool incoming, string adapterName, string connectionId);
 
     void checkSendSize(Buffer buf);

--- a/csharp/src/Ice/SSL/TransceiverI.cs
+++ b/csharp/src/Ice/SSL/TransceiverI.cs
@@ -312,7 +312,21 @@ internal sealed class TransceiverI : Ice.Internal.Transceiver
     public Ice.ConnectionInfo getInfo(bool incoming, string adapterName, string connectionId)
     {
         Debug.Assert(incoming == _incoming);
-        Debug.Assert(adapterName == _adapterName);
+        if (incoming)
+        {
+            if (adapterName.Length == 0) // cleared during shutdown
+            {
+                adapterName = _adapterName;
+            }
+            else
+            {
+                Debug.Assert(adapterName == _adapterName);
+            }
+        }
+        else
+        {
+            Debug.Assert(adapterName.Length == 0);
+        }
 
         return new Ice.SSL.ConnectionInfo(
             _delegate.getInfo(incoming, adapterName, connectionId),

--- a/csharp/src/Ice/SSL/TransceiverI.cs
+++ b/csharp/src/Ice/SSL/TransceiverI.cs
@@ -312,21 +312,8 @@ internal sealed class TransceiverI : Ice.Internal.Transceiver
     public Ice.ConnectionInfo getInfo(bool incoming, string adapterName, string connectionId)
     {
         Debug.Assert(incoming == _incoming);
-        if (incoming)
-        {
-            if (adapterName.Length == 0) // cleared during shutdown
-            {
-                adapterName = _adapterName;
-            }
-            else
-            {
-                Debug.Assert(adapterName == _adapterName);
-            }
-        }
-        else
-        {
-            Debug.Assert(adapterName.Length == 0);
-        }
+        // adapterName is the name of the object adapter currently associated with this connection, while _adapterName
+        // represents the name of the object adapter that created this connection (incoming only).
 
         return new Ice.SSL.ConnectionInfo(
             _delegate.getInfo(incoming, adapterName, connectionId),


### PR DESCRIPTION
The PR:
 - clarifies the internal Transceiver::getInfo operation
 - clears the cached connection info when a new adapter is set on a connection
