### PR TITLE
Added Slice Doc-Comment Validation for Operation Only Tags and `@see` Tags.

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -837,7 +837,7 @@ Slice::Contained::parseDocComment(function<string(string, string)> linkFormatter
             state = StateSee;
 
             // Remove any leading and trailing whitespace from the line.
-            // There's no concern of losing formatting for `@see` due to it's simplicity.
+            // There's no concern of losing formatting for `@see` due to its simplicity.
             lineText = IceInternal::trim(lineText);
             if (lineText.empty())
             {
@@ -846,7 +846,7 @@ Slice::Contained::parseDocComment(function<string(string, string)> linkFormatter
             else
             {
                 // '@see' tags aren't allowed to end with periods.
-                // They do not take sentences, and the trailing period will trip up some languages doc-comments.
+                // They do not take sentences, and the trailing period will trip up some language's doc-comments.
                 if (lineText.back() == '.')
                 {
                     string msg = "ignoring trailing '.' character in '" + seeTag + "' tag";

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.err
@@ -1,3 +1,9 @@
-WarningInvalidComment.ice:10: warning: ignoring unknown doc tag '@remarks' in comment
-WarningInvalidComment.ice:10: warning: '@see' tags cannot span multiple lines and must be of the form: '@see identifier'
-WarningInvalidComment.ice:10: warning: ignoring unknown doc tag '@bad' in comment
+WarningInvalidComment.ice:10: warning: the '@param' tag is only valid on operations
+WarningInvalidComment.ice:10: warning: the '@throws' tag is only valid on operations
+WarningInvalidComment.ice:10: warning: the '@exception' tag is only valid on operations
+WarningInvalidComment.ice:10: warning: the '@return' tag is only valid on operations
+WarningInvalidComment.ice:14: warning: missing link target after '@see' tag
+WarningInvalidComment.ice:16: warning: ignoring trailing '.' character in '@see' tag
+WarningInvalidComment.ice:25: warning: ignoring unknown doc tag '@remarks' in comment
+WarningInvalidComment.ice:25: warning: '@see' tags cannot span multiple lines and must be of the form: '@see identifier'
+WarningInvalidComment.ice:25: warning: ignoring unknown doc tag '@bad' in comment

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.ice
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.ice
@@ -1,6 +1,21 @@
 
 module Test
 {
+    /// Test that operation specific tags don't work on non-operations.
+    /// @param foo Not real.
+    /// @deprecated This one is fine.
+    /// @throws Exception never.
+    /// @exception Exception synonym for @throws.
+    /// @return Nothing because it's an enum.
+    enum NotAnOperation {
+        /// @see CommentDummy
+        Okay,
+        /// @see
+        MissingLinkTarget,
+        /// @see CommentDummy.
+        EndsWithInvalidPeriod,
+    }
+
     /// This is a test overview.
     /// @remarks: This is an unknown comment tag which spans 1 line.
     /// @see: CommentDummy


### PR DESCRIPTION
This PR further improves the validation of doc-comments.

1) It implements #1085 - which is about how ending `@see` with periods breaks things.
Now, if a user ends `@see` with a period, we issue a warning, and remove the trailing period.

2) We enforce that `@param`, `@exception`, `@throws`, and `@return` can only be placed on operations.
If they are placed on anything else, we issue a warning, and throw the tag away (along with it's contents).