### PR TITLE
Restored C-style Comments to 'Ice/operations' Test Constants

### DIFF
--- a/java/test/src/main/java/test/Ice/operations/Test.ice
+++ b/java/test/src/main/java/test/Ice/operations/Test.ice
@@ -323,9 +323,9 @@ const string ss0 = "\'\"\?\\\a\b\f\n\r\t\v\6";
 const string ss1 = "\u0027\u0022\u003f\u005c\u0007\u0008\u000c\u000a\u000d\u0009\u000b\u0006";
 const string ss2 = "\U00000027\U00000022\U0000003f\U0000005c\U00000007\U00000008\U0000000c\U0000000a\U0000000d\U00000009\U0000000b\U00000006";
 
-const string ss3 = "\\\\U\\u\\";
-const string ss4 = "\\\u0041\\";
-const string ss5 = "\\u0041\\";
+const string ss3 = "\\\\U\\u\\"; /* \\U\u\  */
+const string ss4 = "\\\u0041\\"; /* \A\     */
+const string ss5 = "\\u0041\\";  /* \u0041\ */
 
 //
 // Ĩ - Unicode Character 'LATIN CAPITAL LETTER I WITH TILDE' (U+0128)


### PR DESCRIPTION
This PR adds these comments back to the Java version of the test (every other language has them).
They were removed due to #1606, but it turns out that the whole thing was a red-herring.

This was actually just a super-early manifestation of the Slice scanner not distinguishing between `/* */`  and `/** */` comments.
Now that that's been fixed by #3193, it's now safe to add these comments back.