### PR TITLE
Disallow setAdapter on server connections

### DIFF
--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -996,6 +996,11 @@ Ice::ConnectionI::connector() const
 void
 Ice::ConnectionI::setAdapter(const ObjectAdapterPtr& adapter)
 {
+    if (!_connector) // server connection
+    {
+        throw std::logic_error{"setAdapter can only be called on a client connection"};
+    }
+
     if (adapter)
     {
         // Go through the adapter to set the adapter on this connection

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -519,6 +519,11 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
 
     public void setAdapter(ObjectAdapter adapter)
     {
+        if (_connector is null) // server connection
+        {
+            throw new InvalidOperationException("setAdapter can only be called on a client connection");
+        }
+
         if (adapter is not null)
         {
             // Go through the adapter to set the adapter and servant manager on this connection

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -465,6 +465,11 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
     @Override
     public void setAdapter(ObjectAdapter adapter) {
+        if (_connector == null) { // server connection
+            throw new UnsupportedOperationException(
+                    "setAdapter can only be called on a client connection");
+        }
+
         if (adapter != null) {
             // Go through the adapter to set the adapter on this connection to ensure the
             // object adapter is still active and to ensure proper locking order.


### PR DESCRIPTION
This PR disallows calling setAdapter on a server connection in all languages (C++, C# and Java).
