### PR TITLE
Simplified how Metadata is Stored on Types Which Support Forward Declaration

### DIFF
--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -1791,7 +1791,7 @@ yyreduce:
     auto contained = dynamic_pointer_cast<Contained>(yyvsp[0]);
     if (contained && !metadata->v.empty())
     {
-        contained->setMetadata(std::move(metadata->v));
+        contained->appendMetadata(std::move(metadata->v));
     }
 }
 #line 1798 "src/Slice/Grammar.cpp"
@@ -2670,7 +2670,7 @@ yyreduce:
     auto contained = dynamic_pointer_cast<Contained>(yyvsp[-2]);
     if (contained && !metadata->v.empty())
     {
-        contained->setMetadata(std::move(metadata->v));
+        contained->appendMetadata(std::move(metadata->v));
     }
 }
 #line 2677 "src/Slice/Grammar.cpp"
@@ -3221,7 +3221,7 @@ yyreduce:
     auto contained = dynamic_pointer_cast<Contained>(yyvsp[-2]);
     if (contained && !metadata->v.empty())
     {
-        contained->setMetadata(std::move(metadata->v));
+        contained->appendMetadata(std::move(metadata->v));
     }
 }
 #line 3228 "src/Slice/Grammar.cpp"
@@ -3435,7 +3435,7 @@ yyreduce:
     auto enumerator = dynamic_pointer_cast<Enumerator>(yyvsp[-2]);
     if (enumerator && !metadata->v.empty())
     {
-        enumerator->setMetadata(std::move(metadata->v));
+        enumerator->appendMetadata(std::move(metadata->v));
     }
     auto enumeratorList = dynamic_pointer_cast<EnumeratorListTok>(yyvsp[0]);
     enumeratorList->v.push_front(enumerator);
@@ -3451,7 +3451,7 @@ yyreduce:
     auto enumerator = dynamic_pointer_cast<Enumerator>(yyvsp[0]);
     if (enumerator && !metadata->v.empty())
     {
-        enumerator->setMetadata(std::move(metadata->v));
+        enumerator->appendMetadata(std::move(metadata->v));
     }
     auto enumeratorList = make_shared<EnumeratorListTok>();
     enumeratorList->v.push_front(enumerator);
@@ -3599,7 +3599,7 @@ yyreduce:
         auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-1]);
         if (!metadata->v.empty())
         {
-            pd->setMetadata(std::move(metadata->v));
+            pd->appendMetadata(std::move(metadata->v));
         }
     }
 }
@@ -3619,7 +3619,7 @@ yyreduce:
         auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-1]);
         if (!metadata->v.empty())
         {
-            pd->setMetadata(std::move(metadata->v));
+            pd->appendMetadata(std::move(metadata->v));
         }
     }
 }

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -234,7 +234,7 @@ definitions
     auto contained = dynamic_pointer_cast<Contained>($3);
     if (contained && !metadata->v.empty())
     {
-        contained->setMetadata(std::move(metadata->v));
+        contained->appendMetadata(std::move(metadata->v));
     }
 }
 | %empty
@@ -989,7 +989,7 @@ data_members
     auto contained = dynamic_pointer_cast<Contained>($2);
     if (contained && !metadata->v.empty())
     {
-        contained->setMetadata(std::move(metadata->v));
+        contained->appendMetadata(std::move(metadata->v));
     }
 }
 | error ';' data_members
@@ -1470,7 +1470,7 @@ operations
     auto contained = dynamic_pointer_cast<Contained>($2);
     if (contained && !metadata->v.empty())
     {
-        contained->setMetadata(std::move(metadata->v));
+        contained->appendMetadata(std::move(metadata->v));
     }
 }
 | error ';' operations
@@ -1648,7 +1648,7 @@ enumerator_list
     auto enumerator = dynamic_pointer_cast<Enumerator>($2);
     if (enumerator && !metadata->v.empty())
     {
-        enumerator->setMetadata(std::move(metadata->v));
+        enumerator->appendMetadata(std::move(metadata->v));
     }
     auto enumeratorList = dynamic_pointer_cast<EnumeratorListTok>($4);
     enumeratorList->v.push_front(enumerator);
@@ -1660,7 +1660,7 @@ enumerator_list
     auto enumerator = dynamic_pointer_cast<Enumerator>($2);
     if (enumerator && !metadata->v.empty())
     {
-        enumerator->setMetadata(std::move(metadata->v));
+        enumerator->appendMetadata(std::move(metadata->v));
     }
     auto enumeratorList = make_shared<EnumeratorListTok>();
     enumeratorList->v.push_front(enumerator);
@@ -1788,7 +1788,7 @@ parameters
         auto metadata = dynamic_pointer_cast<MetadataListTok>($2);
         if (!metadata->v.empty())
         {
-            pd->setMetadata(std::move(metadata->v));
+            pd->appendMetadata(std::move(metadata->v));
         }
     }
 }
@@ -1804,7 +1804,7 @@ parameters
         auto metadata = dynamic_pointer_cast<MetadataListTok>($4);
         if (!metadata->v.empty())
         {
-            pd->setMetadata(std::move(metadata->v));
+            pd->appendMetadata(std::move(metadata->v));
         }
     }
 }

--- a/cpp/src/Slice/MetadataValidation.h
+++ b/cpp/src/Slice/MetadataValidation.h
@@ -64,6 +64,9 @@ namespace Slice
         /// If this list is empty we don't perform any automatic checking of whether this metadata is validly applied.
         /// Usually, this is because determining validity isn't as straightforward as matching against a list,
         /// and requires a more complex approach, which is achieved through providing an `extraValidation` function.
+        ///
+        /// Note that `ClassDef` and `InterfaceDef` should never appear in this list, since class & interface metadata
+        /// is always stored on the corresponding `ClassDecl` and `InterfaceDecl` types, which should be used instead.
         std::list<std::reference_wrapper<const std::type_info>> validOn;
 
         /// Specifies how many, and what kinds of arguments, this metadata accepts.

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -217,7 +217,7 @@ Slice::DefinitionContext::setMetadata(MetadataList metadata)
 void
 Slice::DefinitionContext::appendMetadata(MetadataList metadata)
 {
-    _metadata.splice(_metadata.end(), metadata);
+    _metadata.splice(_metadata.end(), std::move(metadata));
     initSuppressedWarnings();
 }
 
@@ -975,7 +975,7 @@ Slice::Contained::setMetadata(MetadataList metadata)
 void
 Slice::Contained::appendMetadata(MetadataList metadata)
 {
-    _metadata.splice(_metadata.end(), metadata);
+    _metadata.splice(_metadata.end(), std::move(metadata));
 }
 
 bool
@@ -4757,7 +4757,7 @@ Slice::Unit::addFileMetadata(MetadataList metadata)
     }
     else
     {
-        dc->appendMetadata(metadata);
+        dc->appendMetadata(std::move(metadata));
     }
 }
 

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -214,10 +214,17 @@ Slice::DefinitionContext::setMetadata(MetadataList metadata)
     initSuppressedWarnings();
 }
 
+void
+Slice::DefinitionContext::appendMetadata(MetadataList metadata)
+{
+    _metadata.splice(_metadata.end(), metadata);
+    initSuppressedWarnings();
+}
+
 bool
 Slice::DefinitionContext::hasMetadata(string_view directive) const
 {
-    for (const auto& p : _metadata)
+    for (const auto& p : getMetadata())
     {
         if (p->directive() == directive)
         {
@@ -230,7 +237,7 @@ Slice::DefinitionContext::hasMetadata(string_view directive) const
 optional<string>
 Slice::DefinitionContext::getMetadataArgs(string_view directive) const
 {
-    for (const auto& p : _metadata)
+    for (const auto& p : getMetadata())
     {
         if (p->directive() == directive)
         {
@@ -251,7 +258,7 @@ void
 Slice::DefinitionContext::initSuppressedWarnings()
 {
     _suppressedWarnings.clear();
-    for (const auto& metadata : _metadata)
+    for (const auto& metadata : getMetadata())
     {
         if (metadata->directive() != "suppress-warning")
         {
@@ -965,10 +972,16 @@ Slice::Contained::setMetadata(MetadataList metadata)
     _metadata = metadata;
 }
 
+void
+Slice::Contained::appendMetadata(MetadataList metadata)
+{
+    _metadata.splice(_metadata.end(), metadata);
+}
+
 bool
 Slice::Contained::hasMetadata(string_view directive) const
 {
-    for (const auto& p : _metadata)
+    for (const auto& p : getMetadata())
     {
         if (p->directive() == directive)
         {
@@ -981,7 +994,7 @@ Slice::Contained::hasMetadata(string_view directive) const
 optional<string>
 Slice::Contained::getMetadataArgs(string_view directive) const
 {
-    for (const auto& p : _metadata)
+    for (const auto& p : getMetadata())
     {
         if (p->directive() == directive)
         {
@@ -1023,16 +1036,17 @@ Slice::Contained::isDeprecated() const
 optional<string>
 Slice::Contained::getDeprecationReason() const
 {
+    string reasonMessage;
     if (auto reason = getMetadataArgs("deprecate"))
     {
-        return *reason;
+        reasonMessage = *reason;
     }
     if (auto reason = getMetadataArgs("deprecated"))
     {
-        return *reason;
+        reasonMessage = *reason;
     }
 
-    return nullopt;
+    return (reasonMessage.empty()) ? nullopt : optional{reasonMessage};
 }
 
 Slice::Contained::Contained(const ContainerPtr& container, const string& name)
@@ -1178,23 +1192,15 @@ Slice::Container::createClassDef(const string& name, int id, const ClassDefPtr& 
     }
 
     ClassDefPtr def = make_shared<ClassDef>(shared_from_this(), name, id, base);
-    _unit->addContent(def);
-    _contents.push_back(def);
 
-    for (const auto& q : matches)
-    {
-        ClassDeclPtr decl = dynamic_pointer_cast<ClassDecl>(q);
-        decl->_definition = def;
-    }
-
-    //
-    // Implicitly create a class declaration for each class
-    // definition. This way the code generator can rely on always
-    // having a class declaration available for lookup.
-    //
+    // Implicitly create a class declaration for each class definition.
+    // This way the code generator can rely on always having a class declaration available for lookup.
     ClassDeclPtr decl = createClassDecl(name);
     def->_declaration = decl;
+    decl->_definition = def;
 
+    _unit->addContent(def);
+    _contents.push_back(def);
     return def;
 }
 
@@ -1330,23 +1336,15 @@ Slice::Container::createInterfaceDef(const string& name, const InterfaceList& ba
     InterfaceDecl::checkBasesAreLegal(name, bases, _unit);
 
     InterfaceDefPtr def = make_shared<InterfaceDef>(shared_from_this(), name, bases);
-    _unit->addContent(def);
-    _contents.push_back(def);
 
-    for (const auto& q : matches)
-    {
-        InterfaceDeclPtr decl = dynamic_pointer_cast<InterfaceDecl>(q);
-        decl->_definition = def;
-    }
-
-    //
-    // Implicitly create an interface declaration for each interface
-    // definition. This way the code generator can rely on always
-    // having an interface declaration available for lookup.
-    //
+    // Implicitly create an interface declaration for each interface definition.
+    // This way the code generator can rely on always having an interface declaration available for lookup.
     InterfaceDeclPtr decl = createInterfaceDecl(name);
     def->_declaration = decl;
+    decl->_definition = def;
 
+    _unit->addContent(def);
+    _contents.push_back(def);
     return def;
 }
 
@@ -2695,6 +2693,24 @@ Slice::ClassDef::compactId() const
     return _compactId;
 }
 
+MetadataList
+Slice::ClassDef::getMetadata() const
+{
+    return _declaration->getMetadata();
+}
+
+void
+Slice::ClassDef::setMetadata(MetadataList metadata)
+{
+    _declaration->setMetadata(std::move(metadata));
+}
+
+void
+Slice::ClassDef::appendMetadata(MetadataList metadata)
+{
+    _declaration->appendMetadata(std::move(metadata));
+}
+
 Slice::ClassDef::ClassDef(const ContainerPtr& container, const string& name, int id, const ClassDefPtr& base)
     : SyntaxTreeBase(container->unit()),
       Container(container->unit()),
@@ -3114,6 +3130,24 @@ Slice::InterfaceDef::ids() const
     ids.sort();
     ids.unique();
     return ids;
+}
+
+MetadataList
+Slice::InterfaceDef::getMetadata() const
+{
+    return _declaration->getMetadata();
+}
+
+void
+Slice::InterfaceDef::setMetadata(MetadataList metadata)
+{
+    _declaration->setMetadata(std::move(metadata));
+}
+
+void
+Slice::InterfaceDef::appendMetadata(MetadataList metadata)
+{
+    _declaration->appendMetadata(std::move(metadata));
 }
 
 Slice::InterfaceDef::InterfaceDef(const ContainerPtr& container, const string& name, const InterfaceList& bases)
@@ -4713,10 +4747,7 @@ Slice::Unit::addFileMetadata(MetadataList metadata)
     }
     else
     {
-        // Append the file metadata to any existing metadata (e.g., default file metadata).
-        MetadataList l = dc->getMetadata();
-        move(metadata.begin(), metadata.end(), back_inserter(l));
-        dc->setMetadata(l);
+        dc->appendMetadata(metadata);
     }
 }
 

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1192,15 +1192,20 @@ Slice::Container::createClassDef(const string& name, int id, const ClassDefPtr& 
     }
 
     ClassDefPtr def = make_shared<ClassDef>(shared_from_this(), name, id, base);
+    _unit->addContent(def);
+    _contents.push_back(def);
+
+    for (const auto& q : matches)
+    {
+        ClassDeclPtr decl = dynamic_pointer_cast<ClassDecl>(q);
+        decl->_definition = def;
+    }
 
     // Implicitly create a class declaration for each class definition.
     // This way the code generator can rely on always having a class declaration available for lookup.
     ClassDeclPtr decl = createClassDecl(name);
     def->_declaration = decl;
-    decl->_definition = def;
 
-    _unit->addContent(def);
-    _contents.push_back(def);
     return def;
 }
 
@@ -1336,15 +1341,20 @@ Slice::Container::createInterfaceDef(const string& name, const InterfaceList& ba
     InterfaceDecl::checkBasesAreLegal(name, bases, _unit);
 
     InterfaceDefPtr def = make_shared<InterfaceDef>(shared_from_this(), name, bases);
+    _unit->addContent(def);
+    _contents.push_back(def);
+
+    for (const auto& q : matches)
+    {
+        InterfaceDeclPtr decl = dynamic_pointer_cast<InterfaceDecl>(q);
+        decl->_definition = def;
+    }
 
     // Implicitly create an interface declaration for each interface definition.
     // This way the code generator can rely on always having an interface declaration available for lookup.
     InterfaceDeclPtr decl = createInterfaceDecl(name);
     def->_declaration = decl;
-    decl->_definition = def;
 
-    _unit->addContent(def);
-    _contents.push_back(def);
     return def;
 }
 

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -225,6 +225,7 @@ namespace Slice
 
         MetadataList getMetadata() const;
         void setMetadata(MetadataList metadata);
+        void appendMetadata(MetadataList metadata);
         bool hasMetadata(std::string_view directive) const;
         std::optional<std::string> getMetadataArgs(std::string_view directive) const;
 
@@ -375,8 +376,9 @@ namespace Slice
 
         int includeLevel() const;
 
-        MetadataList getMetadata() const;
-        void setMetadata(MetadataList metadata);
+        virtual MetadataList getMetadata() const;
+        virtual void setMetadata(MetadataList metadata);
+        virtual void appendMetadata(MetadataList metadata);
         bool hasMetadata(std::string_view directive) const;
         std::optional<std::string> getMetadataArgs(std::string_view directive) const;
 
@@ -572,6 +574,12 @@ namespace Slice
         int compactId() const;
         std::string kindOf() const final;
 
+        // Class metadata is always stored on the underlying decl type, not the definition.
+        // So we override these `xMetadata` functions to forward to `_declarations->xMetadata()` instead.
+        MetadataList getMetadata() const final;
+        void setMetadata(MetadataList metadata) final;
+        void appendMetadata(MetadataList metadata) final;
+
     private:
         friend class Container;
 
@@ -704,6 +712,12 @@ namespace Slice
 
         // Returns the type IDs of all the interfaces in the inheritance tree, in alphabetical order.
         StringList ids() const;
+
+        // Interface metadata is always stored on the underlying decl type, not the definition.
+        // So we override these `xMetadata` functions to forward to `_declarations->xMetadata()` instead.
+        MetadataList getMetadata() const final;
+        void setMetadata(MetadataList metadata) final;
+        void appendMetadata(MetadataList metadata) final;
 
     private:
         friend class Container;

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -976,8 +976,8 @@ Slice::Gen::validateMetadata(const UnitPtr& u)
     typeInfo.extraValidation = [](const MetadataPtr& meta, const SyntaxTreeBasePtr& p) -> optional<string>
     {
         // 'cpp:type' can be placed on containers, but only if it is the 'string' flavor of the metadata.
-        if (dynamic_pointer_cast<Module>(p) || dynamic_pointer_cast<InterfaceDef>(p) ||
-            dynamic_pointer_cast<ClassDef>(p) || dynamic_pointer_cast<Struct>(p) ||
+        if (dynamic_pointer_cast<Module>(p) || dynamic_pointer_cast<InterfaceDecl>(p) ||
+            dynamic_pointer_cast<ClassDecl>(p) || dynamic_pointer_cast<Struct>(p) ||
             dynamic_pointer_cast<Slice::Exception>(p))
         {
             const string& argument = meta->arguments();

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1914,13 +1914,6 @@ Slice::CsGenerator::MetadataVisitor::visitClassDecl(const ClassDeclPtr& p)
 }
 
 bool
-Slice::CsGenerator::MetadataVisitor::visitClassDefStart(const ClassDefPtr& p)
-{
-    validate(p);
-    return true;
-}
-
-bool
 Slice::CsGenerator::MetadataVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
     validate(p);
@@ -2024,7 +2017,7 @@ Slice::CsGenerator::MetadataVisitor::validate(const ContainedPtr& cont)
                     continue;
                 }
             }
-            else if (dynamic_pointer_cast<ClassDef>(cont) || dynamic_pointer_cast<Exception>(cont))
+            else if (dynamic_pointer_cast<ClassDecl>(cont) || dynamic_pointer_cast<Exception>(cont))
             {
                 if (directive == "cs:property" && arguments.empty())
                 {
@@ -2032,7 +2025,7 @@ Slice::CsGenerator::MetadataVisitor::validate(const ContainedPtr& cont)
                     continue;
                 }
             }
-            else if (dynamic_pointer_cast<InterfaceDef>(cont))
+            else if (dynamic_pointer_cast<InterfaceDecl>(cont))
             {
                 if (directive == "cs:implements" && !arguments.empty())
                 {
@@ -2056,7 +2049,7 @@ Slice::CsGenerator::MetadataVisitor::validate(const ContainedPtr& cont)
                 DataMemberPtr dataMember = dynamic_pointer_cast<DataMember>(cont);
                 StructPtr st = dynamic_pointer_cast<Struct>(dataMember->container());
                 ExceptionPtr ex = dynamic_pointer_cast<Exception>(dataMember->container());
-                ClassDefPtr cl = dynamic_pointer_cast<ClassDef>(dataMember->container());
+                ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(dataMember->container());
                 static const string csTypePrefix = "cs:type:";
                 // TODO Seems like this validation only got half written?...
             }

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -119,7 +119,6 @@ namespace Slice
             bool visitUnitStart(const UnitPtr&) final;
             bool visitModuleStart(const ModulePtr&) final;
             void visitClassDecl(const ClassDeclPtr&) final;
-            bool visitClassDefStart(const ClassDefPtr&) final;
             bool visitExceptionStart(const ExceptionPtr&) final;
             bool visitStructStart(const StructPtr&) final;
             void visitOperation(const OperationPtr&) final;

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -129,15 +129,6 @@ namespace
             p->setMetadata(std::move(metadata));
         }
 
-        bool visitClassDefStart(const ClassDefPtr& p) final
-        {
-            MetadataList metadata = getMetadata(p);
-            metadata = validateType(p, metadata);
-            metadata = validateGetSet(p, metadata);
-            p->setMetadata(std::move(metadata));
-            return true;
-        }
-
         bool visitExceptionStart(const ExceptionPtr& p) final
         {
             MetadataList metadata = getMetadata(p);
@@ -407,7 +398,7 @@ namespace
                 }
                 else if (directive == "java:implements")
                 {
-                    if (dynamic_pointer_cast<ClassDef>(p) || dynamic_pointer_cast<Struct>(p))
+                    if (dynamic_pointer_cast<ClassDecl>(p) || dynamic_pointer_cast<Struct>(p))
                     {
                         newMetadata.push_back(m);
                     }
@@ -447,7 +438,7 @@ namespace
             {
                 // The "getset" metadata can only be specified on a class, struct, exception or data member.
                 if (m->directive() == "java:getset" &&
-                    (!dynamic_pointer_cast<ClassDef>(p) && !dynamic_pointer_cast<Struct>(p) &&
+                    (!dynamic_pointer_cast<ClassDecl>(p) && !dynamic_pointer_cast<Struct>(p) &&
                      !dynamic_pointer_cast<Slice::Exception>(p) && !dynamic_pointer_cast<DataMember>(p)))
                 {
                     p->unit()->warning(m->file(), m->line(), InvalidMetadata, "invalid metadata for " + p->kindOf());

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -137,9 +137,7 @@ namespace Slice
             bool visitUnitStart(const UnitPtr&) final;
             bool visitModuleStart(const ModulePtr&) final;
             void visitClassDecl(const ClassDeclPtr&) final;
-            bool visitClassDefStart(const ClassDefPtr&) final;
             void visitInterfaceDecl(const InterfaceDeclPtr&) final;
-            bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
             bool visitExceptionStart(const ExceptionPtr&) final;
             bool visitStructStart(const StructPtr&) final;
             void visitOperation(const OperationPtr&) final;
@@ -2975,24 +2973,10 @@ Slice::Python::MetadataVisitor::visitClassDecl(const ClassDeclPtr& p)
     reject(p);
 }
 
-bool
-Slice::Python::MetadataVisitor::visitClassDefStart(const ClassDefPtr& p)
-{
-    reject(p);
-    return true;
-}
-
 void
 Slice::Python::MetadataVisitor::visitInterfaceDecl(const InterfaceDeclPtr& p)
 {
     reject(p);
-}
-
-bool
-Slice::Python::MetadataVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
-{
-    reject(p);
-    return true;
 }
 
 bool

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -2118,12 +2118,12 @@ SwiftGenerator::MetadataVisitor::validate(const SyntaxTreeBasePtr& p, const Cont
             continue;
         }
 
-        if (dynamic_pointer_cast<InterfaceDef>(p) && directive == "swift:inherits" && !arguments.empty())
+        if (dynamic_pointer_cast<InterfaceDecl>(p) && directive == "swift:inherits" && !arguments.empty())
         {
             continue;
         }
 
-        if ((dynamic_pointer_cast<ClassDef>(p) || dynamic_pointer_cast<InterfaceDef>(p) ||
+        if ((dynamic_pointer_cast<ClassDecl>(p) || dynamic_pointer_cast<InterfaceDecl>(p) ||
              dynamic_pointer_cast<Enum>(p) || dynamic_pointer_cast<Exception>(p)) &&
             directive == "swift:attribute" && !arguments.empty())
         {

--- a/cpp/test/Slice/errorDetection/InterfaceMismatch.err
+++ b/cpp/test/Slice/errorDetection/InterfaceMismatch.err
@@ -1,6 +1,6 @@
 InterfaceMismatch.ice:9: class `Foo1' was previously declared as an interface
 InterfaceMismatch.ice:10: class `Foo1' was previously declared as an interface
-InterfaceMismatch.ice:13: class `Foo2' was previously defined as an interface
+InterfaceMismatch.ice:13: class `Foo2' was previously declared as an interface
 InterfaceMismatch.ice:16: interface `Foo3' was previously declared as a class
 InterfaceMismatch.ice:17: interface `Foo3' was previously declared as a class
-InterfaceMismatch.ice:20: interface `Foo4' was previously defined as a class
+InterfaceMismatch.ice:20: interface `Foo4' was previously declared as a class

--- a/cpp/test/Slice/errorDetection/InterfaceMismatch.err
+++ b/cpp/test/Slice/errorDetection/InterfaceMismatch.err
@@ -1,6 +1,6 @@
 InterfaceMismatch.ice:9: class `Foo1' was previously declared as an interface
 InterfaceMismatch.ice:10: class `Foo1' was previously declared as an interface
-InterfaceMismatch.ice:13: class `Foo2' was previously declared as an interface
+InterfaceMismatch.ice:13: class `Foo2' was previously defined as an interface
 InterfaceMismatch.ice:16: interface `Foo3' was previously declared as a class
 InterfaceMismatch.ice:17: interface `Foo3' was previously declared as a class
-InterfaceMismatch.ice:20: interface `Foo4' was previously declared as a class
+InterfaceMismatch.ice:20: interface `Foo4' was previously defined as a class

--- a/cpp/test/Slice/errorDetection/WarningInvalidMetadata.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidMetadata.err
@@ -22,7 +22,7 @@ WarningInvalidMetadata.ice:31: warning: the 'cpp:no-default-include' metadata do
 WarningInvalidMetadata.ice:34: warning: 'amd' metadata cannot be specified as file metadata
 WarningInvalidMetadata.ice:40: warning: the 'cpp:header-ext' metadata only accepts one argument but a list was provided
 WarningInvalidMetadata.ice:40: warning: 'cpp:header-ext' metadata cannot be applied to sequences
-WarningInvalidMetadata.ice:44: warning: ignoring duplicate metadata: 'deprecated' has already been applied in this context
+WarningInvalidMetadata.ice:44: warning: ignoring duplicate metadata: 'deprecated:do not use this' does not match previously applied metadata of 'deprecated'
 WarningInvalidMetadata.ice:48: warning: ignoring unknown metadata: 'unknown'
 WarningInvalidMetadata.ice:48: warning: ignoring unknown metadata: 'cpp:unknown'
 WarningInvalidMetadata.ice:48: warning: ignoring unknown metadata: 'bad:unknown'
@@ -43,3 +43,5 @@ WarningInvalidMetadata.ice:90: warning: ignoring unknown metadata: 'bad'
 WarningInvalidMetadata.ice:90: warning: ignoring unknown metadata: 'cpp:nope'
 WarningInvalidMetadata.ice:95: warning: ignoring unknown metadata: 'cpp98:foo'
 WarningInvalidMetadata.ice:95: warning: ignoring unknown metadata: 'cpp11:bar'
+WarningInvalidMetadata.ice:106: warning: ignoring duplicate metadata: 'deprecated:goodbye' does not match previously applied metadata of 'deprecated:hello'
+WarningInvalidMetadata.ice:111: warning: ignoring duplicate metadata: 'deprecated' does not match previously applied metadata of 'deprecated:hello'

--- a/cpp/test/Slice/errorDetection/WarningInvalidMetadata.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidMetadata.err
@@ -22,13 +22,13 @@ WarningInvalidMetadata.ice:31: warning: the 'cpp:no-default-include' metadata do
 WarningInvalidMetadata.ice:34: warning: 'amd' metadata cannot be specified as file metadata
 WarningInvalidMetadata.ice:40: warning: the 'cpp:header-ext' metadata only accepts one argument but a list was provided
 WarningInvalidMetadata.ice:40: warning: 'cpp:header-ext' metadata cannot be applied to sequences
-WarningInvalidMetadata.ice:44: warning: ignoring duplicate metadata: 'deprecated:do not use this' does not match previously applied metadata of 'deprecated'
 WarningInvalidMetadata.ice:48: warning: ignoring unknown metadata: 'unknown'
 WarningInvalidMetadata.ice:48: warning: ignoring unknown metadata: 'cpp:unknown'
 WarningInvalidMetadata.ice:48: warning: ignoring unknown metadata: 'bad:unknown'
 WarningInvalidMetadata.ice:56: warning: the 'protected' metadata does not take any arguments
 WarningInvalidMetadata.ice:56: warning: the 'cpp:array' metadata does not take any arguments
 WarningInvalidMetadata.ice:56: warning: 'cpp:array' metadata can only be applied to operation parameters and return types
+WarningInvalidMetadata.ice:44: warning: ignoring duplicate metadata: 'deprecated:do not use this' does not match previously applied metadata of 'deprecated'
 WarningInvalidMetadata.ice:62: warning: 'cpp:type' metadata cannot be applied to operations with void return type
 WarningInvalidMetadata.ice:65: warning: 'cpp:array' metadata cannot be applied to operations with void return type
 WarningInvalidMetadata.ice:68: warning: invalid argument 'my_string' supplied to 'cpp:type' metadata in this context

--- a/cpp/test/Slice/errorDetection/WarningInvalidMetadata.ice
+++ b/cpp/test/Slice/errorDetection/WarningInvalidMetadata.ice
@@ -97,4 +97,18 @@ class P
 {
 }
 
+// Metadata is shared between forward declarations and definitions.
+// We allow duplicate metadata, but require that that metadata must be identical.
+
+["java:nonsense", "deprecated:hello", "protected"]
+class K;
+
+["java:nonsense", "deprecated:goodbye", "protected"]
+class K
+{
+}
+
+["java:nonsense", "deprecated", "protected"]
+class K;
+
 }


### PR DESCRIPTION
The main focus of this PR is #3216 (cleaning up how metadata is stored)
but it also fixes #3039 (which was specifically about how `deprecated` is handled between `Decl` and `Def`).

----

1) **Added a new `appendMetadata` function.**
So now we have `setMetadata` which overwrites existing metadata with a new list (_used by the validator where we want to throw away bad metadata_) and `appendMetadata` which just appends metadata to a Slice entity without touching any that's already present (_used by the parser to add metadata to entities_).
This fixes the problem where forward-declarations were constantly overwriting their own metadata.

2) **All class/interface metadata is now stored exclusively on the `Decl` types, and never the `Def` types.**
Previously, both of them had their own distinct lists of metadata. Note that the `Def` types still support the same API for metadata, but these functions just forward to the 'underlying' `Decl` type. This way the code-gen never has to worry about whether it should be using `Decl` or `Def`, both will work just fine.

I also removed all of the `visitClassDef`/`visitInterfaceDef` metadata validation functions.
It is sufficient to only visit the `Decl` types now.