### PR TITLE
Update udp connection info + test

### DIFF
--- a/cpp/src/Ice/UdpTransceiver.cpp
+++ b/cpp/src/Ice/UdpTransceiver.cpp
@@ -474,10 +474,6 @@ IceInternal::UdpTransceiver::toString() const
         Address localAddr;
         fdToLocalAddress(_fd, localAddr);
         s << "local address = " << addrToString(localAddr);
-        if (isAddressValid(_peerAddr))
-        {
-            s << "\nremote address = " << addrToString(_peerAddr);
-        }
     }
     else
     {
@@ -538,21 +534,16 @@ IceInternal::UdpTransceiver::getInfo(bool incoming, string adapterName, string c
             int localPort;
             addrToAddressAndPort(localAddr, localAddress, localPort);
 
-            string remoteAddress;
-            int remotePort = 0;
-            if (isAddressValid(_peerAddr))
-            {
-                addrToAddressAndPort(_peerAddr, remoteAddress, remotePort);
-            }
-
+            // Since this info is cached in the Connection object shared by all the clients, we don't store the
+            // remote address/port of the latest client in this info.
             return make_shared<UDPConnectionInfo>(
                 incoming,
                 std::move(adapterName),
                 std::move(connectionId),
                 std::move(localAddress),
                 localPort,
-                std::move(remoteAddress),
-                remotePort,
+                "", // remoteAddress
+                -1, // remotePort
                 std::move(mcastAddress),
                 mcastPort,
                 _rcvSize,

--- a/cpp/test/Ice/udp/AllTests.cpp
+++ b/cpp/test/Ice/udp/AllTests.cpp
@@ -168,6 +168,8 @@ allTests(Test::TestHelper* helper)
 #endif
 
     cout << "testing udp bi-dir connection... " << flush;
+    // This feature is only half-implemented. In particular, we maintain a single Connection object on the server side
+    // that gets updated each time we receive a new request.
     obj->ice_getConnection()->setAdapter(adapter);
     nRetry = 5;
     while (nRetry-- > 0)

--- a/csharp/src/Ice/Internal/UdpTransceiver.cs
+++ b/csharp/src/Ice/Internal/UdpTransceiver.cs
@@ -521,14 +521,17 @@ internal sealed class UdpTransceiver : Transceiver
             if (_state == StateNotConnected) // a server connection
             {
                 Debug.Assert(incoming);
+
+                // Since this info is cached in the Connection object shared by all the clients, we don't store the
+                // remote address/port of the latest client in this info.
                 return new UDPConnectionInfo(
                     incoming,
                     adapterName,
                     connectionId,
                     Network.endpointAddressToString(localEndpoint),
                     Network.endpointPort(localEndpoint),
-                    _peerAddr is not null ? Network.endpointAddressToString(_peerAddr) : "",
-                    _peerAddr is not null ? Network.endpointPort(_peerAddr) : -1,
+                    remoteAddress: "",
+                    remotePort: -1,
                     _mcastAddr is not null ? Network.endpointAddressToString(_mcastAddr) : "",
                     _mcastAddr is not null ? Network.endpointPort(_mcastAddr) : -1,
                     _rcvSize,

--- a/csharp/test/Ice/udp/AllTests.cs
+++ b/csharp/test/Ice/udp/AllTests.cs
@@ -199,6 +199,8 @@ public class AllTests : global::Test.AllTests
         Console.Out.WriteLine("ok");
 
         Console.Out.Write("testing udp bi-dir connection... ");
+        // This feature is only half-implemented. In particular, we maintain a single Connection object on the server
+        // side that gets updated each time we receive a new request.
         Console.Out.Flush();
         obj.ice_getConnection().setAdapter(adapter);
         nRetry = 5;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpTransceiver.java
@@ -198,9 +198,6 @@ final class UdpTransceiver implements Transceiver {
                     "local address = "
                             + Network.addrToString(
                                     (java.net.InetSocketAddress) socket.getLocalSocketAddress());
-            if (_peerAddr != null) {
-                s += "\nremote address = " + Network.addrToString(_peerAddr);
-            }
         } else {
             s = Network.fdToString(_fd);
         }
@@ -247,14 +244,17 @@ final class UdpTransceiver implements Transceiver {
 
             if (_state == StateNotConnected) {
                 assert _incoming;
+
+                // Since this info is cached in the Connection object shared by all the clients,
+                // we don't store the remote address/port of the latest client in this info.
                 return new UDPConnectionInfo(
                         incoming,
                         adapterName,
                         connectionId,
                         socket.getLocalAddress().getHostAddress(),
                         socket.getLocalPort(),
-                        _peerAddr != null ? _peerAddr.getAddress().getHostAddress() : "",
-                        _peerAddr != null ? _peerAddr.getPort() : -1,
+                        "", // remoteAddress
+                        -1, // remotePort
                         _mcastAddr != null ? _mcastAddr.getAddress().getHostAddress() : "",
                         _mcastAddr != null ? _mcastAddr.getPort() : -1,
                         rcvSize,

--- a/java/test/src/main/java/test/Ice/udp/AllTests.java
+++ b/java/test/src/main/java/test/Ice/udp/AllTests.java
@@ -179,6 +179,9 @@ public class AllTests {
             out.println("ok");
 
             out.print("testing udp bi-dir connection... ");
+            // This feature is only half-implemented. In particular, we maintain a single
+            // Connection object on the server side that gets updated each time we receive
+            // a new request.
             out.flush();
             obj.ice_getConnection().setAdapter(adapter);
             nRetry = 5;


### PR DESCRIPTION
This PR updates the connection info for UDP server connections to not include the remote/peer address and port, since this information is not what you'd expect (it's the address of the most recent client the first time you call getInfo).

This PR also adds comments to the UDP tests.

