### PR TITLE
Add BuildDist alias for Build in C# builds

### DIFF
--- a/csharp/msbuild/ice.proj
+++ b/csharp/msbuild/ice.proj
@@ -58,6 +58,8 @@
                  Properties="%(Properties)"/>
     </Target>
 
+    <Target Name="BuildDist" DependsOnTargets="Build"></Target>
+
     <Target Name="Clean">
         <MSBuild Projects="@(SolutionFile)"
                  BuildInParallel="true"


### PR DESCRIPTION
This PR adds back `BuildDist` target to C# builds. Before merging test and src solutions we have two separate targets:

- `Build` to build everything
- `BuildDist` to just build srcs

This adds back `BuildDist` as an alias for Build, which build the ice.sln solution. All language mappings provide a `BuildDist` target keeping it here as alias for `Build` simplifies CI jobs.