### PR TITLE
Fix ice_getConnectionAsync

### DIFF
--- a/cpp/src/Ice/OutgoingAsync.cpp
+++ b/cpp/src/Ice/OutgoingAsync.cpp
@@ -494,10 +494,8 @@ ProxyOutgoingAsyncBase::invokeImpl(bool userThread)
     }
     catch (const Exception&)
     {
-        //
-        // If called from the user thread we re-throw, the exception
-        // will be catch by the caller and abort(ex) will be called.
-        //
+        // If called from the user thread we re-throw, the exception will be caught by the caller and handler using
+        // abort.
         if (userThread)
         {
             throw;
@@ -1064,11 +1062,7 @@ OutgoingAsync::invoke(string_view operation)
         return;
     }
 
-    //
-    // NOTE: invokeImpl doesn't throw so this can be called from the
-    // try block with the catch block calling abort(ex) in case of an
-    // exception.
-    //
+    // invokeImpl can throw. The exception should be handled by calling abort (in the caller).
     invokeImpl(true); // userThread = true
 }
 

--- a/cpp/src/Ice/OutgoingAsync.cpp
+++ b/cpp/src/Ice/OutgoingAsync.cpp
@@ -494,7 +494,7 @@ ProxyOutgoingAsyncBase::invokeImpl(bool userThread)
     }
     catch (const Exception&)
     {
-        // If called from the user thread we re-throw, the exception will be caught by the caller and handler using
+        // If called from the user thread we re-throw, the exception will be caught by the caller and handled using
         // abort.
         if (userThread)
         {

--- a/cpp/src/Ice/ProxyAsync.cpp
+++ b/cpp/src/Ice/ProxyAsync.cpp
@@ -261,10 +261,18 @@ ProxyFlushBatchAsync::invoke(string_view operation)
             "cannot send request using protocol version " +
                 Ice::protocolVersionToString(_proxy._getReference()->getProtocol())};
     }
-    _observer.attach(_proxy, operation, noExplicitContext);
-    bool compress; // Ignore for proxy flushBatchRequests
-    _batchRequestNum = _proxy._getReference()->getBatchRequestQueue()->swap(&_os, compress);
-    invokeImpl(true); // userThread = true
+
+    try
+    {
+        _observer.attach(_proxy, operation, noExplicitContext);
+        bool compress; // Ignore for proxy flushBatchRequests
+        _batchRequestNum = _proxy._getReference()->getBatchRequestQueue()->swap(&_os, compress);
+        invokeImpl(true); // userThread = true
+    }
+    catch (const Exception&)
+    {
+        abort(current_exception());
+    }
 }
 
 ProxyGetConnection::ProxyGetConnection(ObjectPrx proxy) : ProxyOutgoingAsyncBase(std::move(proxy)) {}
@@ -299,8 +307,15 @@ ProxyGetConnection::getConnection() const
 void
 ProxyGetConnection::invoke(string_view operation)
 {
-    _observer.attach(_proxy, operation, noExplicitContext);
-    invokeImpl(true); // userThread = true
+    try
+    {
+        _observer.attach(_proxy, operation, noExplicitContext);
+        invokeImpl(true); // userThread = true
+    }
+    catch (const Exception&)
+    {
+        abort(current_exception());
+    }
 }
 
 bool

--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -445,6 +445,21 @@ allTests(TestHelper* helper, bool collocated)
         }
 
         {
+            promise<Ice::ConnectionPtr> promise;
+            indirect->ice_getConnectionAsync(
+                [&](Ice::ConnectionPtr connection) { promise.set_value(std::move(connection)); },
+                [&](exception_ptr ex) { promise.set_exception(ex); });
+            try
+            {
+                promise.get_future().get();
+                test(false);
+            }
+            catch (const NoEndpointException&)
+            {
+            }
+        }
+
+        {
             try
             {
                 promise<int> promise;

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -1583,14 +1583,7 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     private void iceI_ice_getConnection(OutgoingAsyncCompletionCallback completed, bool synchronous)
     {
         var outgoing = new ProxyGetConnection(this, completed);
-        try
-        {
-            outgoing.invoke(_ice_getConnection_name, synchronous);
-        }
-        catch (Ice.Exception ex)
-        {
-            outgoing.abort(ex);
-        }
+        outgoing.invoke(_ice_getConnection_name, synchronous);
     }
 
     /// <summary>
@@ -1632,14 +1625,7 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
     private void iceI_ice_flushBatchRequests(OutgoingAsyncCompletionCallback completed, bool synchronous)
     {
         var outgoing = new ProxyFlushBatchAsync(this, completed);
-        try
-        {
-            outgoing.invoke(_ice_flushBatchRequests_name, synchronous);
-        }
-        catch (Exception ex)
-        {
-            outgoing.abort(ex);
-        }
+        outgoing.invoke(_ice_flushBatchRequests_name, synchronous);
     }
 
     public System.Threading.Tasks.TaskScheduler ice_scheduler()

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -182,9 +182,20 @@ namespace Ice
                 {
                     Test.TestIntfPrx indirect = Test.TestIntfPrxHelper.uncheckedCast(p.ice_adapterId("dummy"));
 
+                    Task t = indirect.opAsync();
                     try
                     {
-                        await indirect.opAsync();
+                        await t;
+                        test(false);
+                    }
+                    catch (NoEndpointException)
+                    {
+                    }
+
+                    t = indirect.ice_getConnectionAsync();
+                    try
+                    {
+                        await t;
                         test(false);
                     }
                     catch (NoEndpointException)

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingAsync.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingAsync.java
@@ -73,9 +73,7 @@ public class OutgoingAsync<T> extends ProxyOutgoingAsyncBase<T> {
                         .finishBatchRequest(_os, _proxy, _operation);
                 finished(true, false);
             } else {
-                // NOTE: invokeImpl doesn't throw so this can be called from the
-                // try block with the catch block calling abort() in case of an
-                // exception.
+                // invokeImpl can throw; we handle this exception by calling abort
                 invokeImpl(true); // userThread = true
             }
         } catch (LocalException ex) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyFlushBatch.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyFlushBatch.java
@@ -44,7 +44,11 @@ class ProxyFlushBatch extends ProxyOutgoingAsyncBase<Void> {
     public void invoke() {
         Protocol.checkSupportedProtocol(
                 Protocol.getCompatibleProtocol(_proxy._getReference().getProtocol()));
-        invokeImpl(true); // userThread = true
+        try {
+            invokeImpl(true); // userThread = true
+        } catch (LocalException ex) {
+            abort(ex);
+        }
     }
 
     protected int _batchRequestNum;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyGetConnection.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyGetConnection.java
@@ -40,6 +40,10 @@ class ProxyGetConnection extends ProxyOutgoingAsyncBase<Connection> {
     }
 
     public void invoke() {
-        invokeImpl(true); // userThread = true
+        try {
+            invokeImpl(true); // userThread = true
+        } catch (LocalException ex) {
+            abort(ex);
+        }
     }
 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyIceInvoke.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyIceInvoke.java
@@ -31,11 +31,7 @@ class ProxyIceInvoke extends ProxyOutgoingAsyncBase<Object.Ice_invokeResult> {
                         .finishBatchRequest(_os, _proxy, _operation);
                 finished(true, false);
             } else {
-                //
-                // NOTE: invokeImpl doesn't throw so this can be called from the
-                // try block with the catch block calling abort() in case of an
-                // exception.
-                //
+                // invokeImpl can throw and we handle the exception with abort.
                 invokeImpl(true); // userThread = true
             }
         } catch (LocalException ex) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyOutgoingAsyncBase.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyOutgoingAsyncBase.java
@@ -248,10 +248,8 @@ abstract class ProxyOutgoingAsyncBase<T> extends OutgoingAsyncBase<T> {
                 }
             }
         } catch (LocalException ex) {
-            //
-            // If called from the user thread we re-throw, the exception
-            // will be catch by the caller and abort() will be called.
-            //
+            // If called from the user thread we re-throw: the exception
+            // will be caught by the caller and handled using abort().
             if (userThread) {
                 throw ex;
             } else if (finished(ex)) // No retries, we're done

--- a/java/test/src/main/java/test/Ice/ami/AllTests.java
+++ b/java/test/src/main/java/test/Ice/ami/AllTests.java
@@ -202,6 +202,12 @@ public class AllTests {
                                 test(ex != null && ex instanceof com.zeroc.Ice.NoEndpointException);
                             });
 
+            indirect.ice_getConnectionAsync()
+                    .whenComplete(
+                            (result, ex) -> {
+                                test(ex != null && ex instanceof com.zeroc.Ice.NoEndpointException);
+                            });
+
             //
             // Check that CommunicatorDestroyedException is raised directly.
             //

--- a/python/modules/IcePy/Proxy.cpp
+++ b/python/modules/IcePy/Proxy.cpp
@@ -17,7 +17,6 @@
 #include "Types.h"
 #include "Util.h"
 
-#include <iostream>
 #include <structmember.h>
 
 using namespace std;
@@ -1553,12 +1552,6 @@ proxyIceGetConnectionAsync(ProxyObject* self, PyObject* /*args*/, PyObject* /*kw
                      ->ice_getConnectionAsync(
                          [callback](const Ice::ConnectionPtr& connection) { callback->response(connection); },
                          [callback](exception_ptr ex) { callback->exception(ex); });
-    }
-    catch (const Ice::LocalException& lex)
-    {
-        cerr << "Caught std::exception: " << lex << endl;
-        setPythonException(current_exception());
-        return nullptr;
     }
     catch (...)
     {

--- a/python/modules/IcePy/Proxy.cpp
+++ b/python/modules/IcePy/Proxy.cpp
@@ -17,6 +17,7 @@
 #include "Types.h"
 #include "Util.h"
 
+#include <iostream>
 #include <structmember.h>
 
 using namespace std;
@@ -1552,6 +1553,12 @@ proxyIceGetConnectionAsync(ProxyObject* self, PyObject* /*args*/, PyObject* /*kw
                      ->ice_getConnectionAsync(
                          [callback](const Ice::ConnectionPtr& connection) { callback->response(connection); },
                          [callback](exception_ptr ex) { callback->exception(ex); });
+    }
+    catch (const Ice::LocalException& lex)
+    {
+        cerr << "Caught std::exception: " << lex << endl;
+        setPythonException(current_exception());
+        return nullptr;
     }
     catch (...)
     {

--- a/python/test/Ice/ami/AllTests.py
+++ b/python/test/Ice/ami/AllTests.py
@@ -700,10 +700,8 @@ def allTestsFuture(helper, communicator, collocated):
     cb.check()
 
     if not collocated:
-        try:
-            i.ice_getConnectionAsync()
-        except Ice.NoEndpointException:
-            pass
+        i.ice_getConnectionAsync().add_done_callback(cb.ex)
+        cb.check()
 
     i.opAsync().add_done_callback(cb.ex)
     cb.check()


### PR DESCRIPTION
This PR fixes ice_getConnectionAsync to no throw synchronously NoEndpointException and other local exceptions.

Fixes #1729.