### PR TITLE
Add clang-tidy config and tidy-up generated code

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,6 +13,7 @@ WarningsAsErrors:  ''
 HeaderFilterRegex: ''
 UseColor: true
 FormatStyle: 'file'
+ExtraArgs: ['-std=c++17']
 CheckOptions:
   - { key: modernize-use-nullptr.NullMacros, value: 'NULL' }
   # std::exception_ptr is a cheap to copy, pointer-like type; we pass it by value all the time.

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,12 +9,12 @@ Checks:
   performance-*,
   -performance-avoid-endl
 '
-WarningsAsErrors:  ''
+# WarningsAsErrors: '*'
 HeaderFilterRegex: ''
 UseColor: true
 FormatStyle: 'file'
 ExtraArgs: ['-std=c++17']
 CheckOptions:
-  - { key: modernize-use-nullptr.NullMacros, value: 'NULL' }
+  modernize-use-nullptr.NullMacros: 'NULL'
   # std::exception_ptr is a cheap to copy, pointer-like type; we pass it by value all the time.
-  - { key: performance-unnecessary-value-param.AllowedTypes, value: 'std::exception_ptr' }
+  performance-unnecessary-value-param.AllowedTypes: 'exception_ptr$;'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,19 @@
+Checks:
+'-*,
+  clang-analyzer-*,
+  -clang-diagnostic-shadow-uncaptured-local,
+  cert-*,
+  modernize-*,
+  -modernize-avoid-c-arrays,
+  -modernize-use-trailing-return-type,
+  performance-*,
+  -performance-avoid-endl
+'
+WarningsAsErrors:  ''
+HeaderFilterRegex: ''
+UseColor: true
+FormatStyle: 'file'
+CheckOptions:
+  - { key: modernize-use-nullptr.NullMacros, value: 'NULL' }
+  # std::exception_ptr is a cheap to copy, pointer-like type; we pass it by value all the time.
+  - { key: performance-unnecessary-value-param.AllowedTypes, value: 'std::exception_ptr' }

--- a/cpp/include/Ice/FactoryTable.h
+++ b/cpp/include/Ice/FactoryTable.h
@@ -78,7 +78,7 @@ namespace IceInternal
     class ICE_API CompactIdInit
     {
     public:
-        CompactIdInit(std::string_view, int) noexcept;
+        CompactIdInit(const char* typeId, int compactId) noexcept;
         ~CompactIdInit();
 
     private:

--- a/cpp/src/Ice/FactoryTable.cpp
+++ b/cpp/src/Ice/FactoryTable.cpp
@@ -190,7 +190,7 @@ IceInternal::FactoryTableInit::~FactoryTableInit()
     }
 }
 
-IceInternal::CompactIdInit::CompactIdInit(string_view typeId, int compactId) noexcept : _compactId(compactId)
+IceInternal::CompactIdInit::CompactIdInit(const char* typeId, int compactId) noexcept : _compactId(compactId)
 {
     assert(_compactId >= 0);
     factoryTable->addTypeId(_compactId, typeId);

--- a/cpp/test/Ice/custom/CustomBuffer.h
+++ b/cpp/test/Ice/custom/CustomBuffer.h
@@ -17,7 +17,7 @@ namespace Test
     template<typename T> class CustomBuffer
     {
     public:
-        CustomBuffer() : _buf(0), _count(0) {}
+        CustomBuffer() : _buf(nullptr), _count(0) {}
 
         CustomBuffer(const CustomBuffer& o) : _buf(0), _count(o._count)
         {
@@ -31,9 +31,15 @@ namespace Test
             }
         }
 
+        CustomBuffer(CustomBuffer&& o) : _buf(o._buf), _count(o._count)
+        {
+            o._buf = nullptr;
+            o._count = 0;
+        }
+
         ~CustomBuffer()
         {
-            if (_buf != 0)
+            if (_buf)
             {
                 delete[] _buf;
             }
@@ -50,6 +56,19 @@ namespace Test
                     _buf[i] = o._buf[i];
                 }
             }
+            return *this;
+        }
+
+        CustomBuffer& operator=(CustomBuffer&& o)
+        {
+            if (_buf)
+            {
+                delete[] _buf;
+            }
+            _buf = o._buf;
+            _count = o._count;
+            o._buf = nullptr;
+            o._count = 0;
             return *this;
         }
 

--- a/cpp/test/Ice/custom/CustomBuffer.h
+++ b/cpp/test/Ice/custom/CustomBuffer.h
@@ -37,13 +37,7 @@ namespace Test
             o._count = 0;
         }
 
-        ~CustomBuffer()
-        {
-            if (_buf)
-            {
-                delete[] _buf;
-            }
-        }
+        ~CustomBuffer() { delete[] _buf; }
 
         CustomBuffer& operator=(const CustomBuffer& o)
         {
@@ -61,10 +55,7 @@ namespace Test
 
         CustomBuffer& operator=(CustomBuffer&& o)
         {
-            if (_buf)
-            {
-                delete[] _buf;
-            }
+            delete[] _buf;
             _buf = o._buf;
             _count = o._count;
             o._buf = nullptr;

--- a/cpp/test/Ice/custom/MyByteSeq.cpp
+++ b/cpp/test/Ice/custom/MyByteSeq.cpp
@@ -27,8 +27,14 @@ MyByteSeq::MyByteSeq(const MyByteSeq& seq)
     }
     else
     {
-        _data = 0;
+        _data = nullptr;
     }
+}
+
+MyByteSeq::MyByteSeq(MyByteSeq&& seq) noexcept : _size(seq._size), _data(seq._data)
+{
+    seq._size = 0;
+    seq._data = nullptr;
 }
 
 MyByteSeq::~MyByteSeq() { delete[] _data; }
@@ -62,7 +68,7 @@ MyByteSeq::end() const
     return _data + _size;
 }
 
-void
+MyByteSeq&
 MyByteSeq::operator=(const MyByteSeq& rhs)
 {
     delete[] _data;
@@ -74,6 +80,21 @@ MyByteSeq::operator=(const MyByteSeq& rhs)
         _data = new std::byte[_size];
         memcpy(_data, rhs._data, _size);
     }
+    return *this;
+}
+
+MyByteSeq&
+MyByteSeq::operator=(MyByteSeq&& rhs)
+{
+    delete[] _data;
+    _data = nullptr;
+
+    _size = rhs._size;
+    _data = rhs._data;
+
+    rhs._size = 0;
+    rhs._data = nullptr;
+    return *this;
 }
 
 bool

--- a/cpp/test/Ice/custom/MyByteSeq.h
+++ b/cpp/test/Ice/custom/MyByteSeq.h
@@ -19,13 +19,17 @@ public:
     MyByteSeq();
     MyByteSeq(size_t);
     MyByteSeq(const MyByteSeq&);
+    MyByteSeq(MyByteSeq&&) noexcept;
     ~MyByteSeq();
 
     size_t size() const;
     void swap(MyByteSeq&);
     const_iterator begin() const;
     const_iterator end() const;
-    void operator=(const MyByteSeq&);
+
+    MyByteSeq& operator=(const MyByteSeq&);
+    MyByteSeq& operator=(MyByteSeq&&);
+
     bool operator==(const MyByteSeq&) const;
 
 private:


### PR DESCRIPTION
This PR adds a clang-tidy config file (.clang-tidy, from ice-demos), and fixes lints in the generated code.

You can run clang-tidy over all the generated code on macos as follows:
```zsh
xcrun run-clang-tidy **/generated/**/*.cpp -j12 -quiet 
```