### PR TITLE
Update Swift build to error on warning

### DIFF
--- a/swift/Makefile
+++ b/swift/Makefile
@@ -28,7 +28,7 @@ srcs::
 	$(Q)swift build $(SWIFT_BUILD_FLAGS)
 
 tests::
-	$(Q)swift build --package-path test $(SWIFT_BUILD_FLAGS)
+	$(Q)swift build -Xswiftc -warnings-as-errors --package-path test $(SWIFT_BUILD_FLAGS)
 
 install::
 	@echo nothing to install

--- a/swift/test/Ice/hold/TestI.swift
+++ b/swift/test/Ice/hold/TestI.swift
@@ -2,6 +2,7 @@
 
 import Dispatch
 import Foundation
+// @preconcurrency is needed as 'Ice.Current' does not conform to the 'Sendable' protocol
 @preconcurrency import Ice
 import TestCommon
 

--- a/swift/test/Ice/hold/TestI.swift
+++ b/swift/test/Ice/hold/TestI.swift
@@ -23,7 +23,7 @@ class HoldI: Hold, @unchecked Sendable {
             _adapter.hold()
             try _adapter.activate()
         } else {
-            _queue.asyncAfter(deadline: .now() + .milliseconds(Int(delay))) {  [self] in
+            _queue.asyncAfter(deadline: .now() + .milliseconds(Int(delay))) { [self] in
                 do {
                     _adapter.hold()
                     try _adapter.activate()

--- a/swift/test/Ice/hold/TestI.swift
+++ b/swift/test/Ice/hold/TestI.swift
@@ -2,10 +2,10 @@
 
 import Dispatch
 import Foundation
-import Ice
+@preconcurrency import Ice
 import TestCommon
 
-class HoldI: Hold {
+class HoldI: Hold, @unchecked Sendable {
     var _adapter: Ice.ObjectAdapter
     var _helper: TestHelper
     var _last: Int32 = 0
@@ -23,7 +23,7 @@ class HoldI: Hold {
             _adapter.hold()
             try _adapter.activate()
         } else {
-            _queue.asyncAfter(deadline: .now() + .milliseconds(Int(delay))) { [self] in
+            _queue.asyncAfter(deadline: .now() + .milliseconds(Int(delay))) {  [self] in
                 do {
                     _adapter.hold()
                     try _adapter.activate()


### PR DESCRIPTION
This PR updates the Swift build to error on warnings. I had to fix on test as a result. 