### PR TITLE
Apply clang-tidy fixes to cpp (nullptr, using, override)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,7 +12,7 @@ Checks:
 '
 WarningsAsErrors:  '*'
 HeaderFilterRegex: '.*'
-ExcludeHeaderFilterRegex: 'include/.*'
+ExcludeHeaderFilterRegex: 'include/lmdb.h|Grammar.h'
 UseColor: true
 FormatStyle: 'file'
 ExtraArgs: ['-std=c++20']

--- a/cpp/include/Ice/FactoryTable.h
+++ b/cpp/include/Ice/FactoryTable.h
@@ -41,16 +41,16 @@ namespace IceInternal
     private:
         mutable std::mutex _mutex;
 
-        typedef std::pair<Ice::UserExceptionFactory, int> EFPair;
-        typedef std::map<std::string, EFPair, std::less<>> EFTable;
+        using EFPair = std::pair<Ice::UserExceptionFactory, int>;
+        using EFTable = std::map<std::string, EFPair, std::less<>>;
         EFTable _eft;
 
-        typedef std::pair<Ice::ValueFactory, int> VFPair;
-        typedef std::map<std::string, VFPair, std::less<>> VFTable;
+        using VFPair = std::pair<Ice::ValueFactory, int>;
+        using VFTable = std::map<std::string, VFPair, std::less<>>;
         VFTable _vft;
 
-        typedef std::pair<std::string, int> TypeIdPair;
-        typedef std::map<int, TypeIdPair> TypeIdTable;
+        using TypeIdPair = std::pair<std::string, int>;
+        using TypeIdTable = std::map<int, TypeIdPair>;
         TypeIdTable _typeIdTable;
     };
 

--- a/cpp/include/Ice/IconvStringConverter.h
+++ b/cpp/include/Ice/IconvStringConverter.h
@@ -112,7 +112,7 @@ namespace IceInternal
         //
         // Reset cd
         //
-        [[maybe_unused]] size_t rs = iconv(cd, 0, 0, 0, 0);
+        [[maybe_unused]] size_t rs = iconv(cd, nullptr, nullptr, nullptr, nullptr);
 
         char* inbuf = reinterpret_cast<char*>(const_cast<charT*>(sourceStart));
         size_t inbytesleft = static_cast<size_t>(sourceEnd - sourceStart) * sizeof(charT);
@@ -150,7 +150,7 @@ namespace IceInternal
         //
         // Reset cd
         //
-        [[maybe_unused]] size_t rs = iconv(cd, 0, 0, 0, 0);
+        [[maybe_unused]] size_t rs = iconv(cd, nullptr, nullptr, nullptr, nullptr);
         assert(rs == 0);
         char* inbuf = reinterpret_cast<char*>(const_cast<std::byte*>(sourceStart));
         assert(sourceEnd > sourceStart);

--- a/cpp/include/Ice/Initialize.h
+++ b/cpp/include/Ice/Initialize.h
@@ -248,10 +248,10 @@ namespace Ice
         ThreadHookPlugin(const CommunicatorPtr& communicator, std::function<void()> start, std::function<void()> stop);
 
         /** Not used. */
-        virtual void initialize();
+        void initialize() override;
 
         /** Not used. */
-        virtual void destroy();
+        void destroy() override;
     };
 
     /**
@@ -546,8 +546,9 @@ namespace Ice
      * @param args Additional arguments included in the plug-in's configuration.
      * @return The new plug-in object. Returning nil will cause the run time to raise PluginInitializationException.
      */
-    typedef Ice::Plugin* (
-        *PluginFactory)(const Ice::CommunicatorPtr& communicator, const std::string& name, const Ice::StringSeq& args);
+    using PluginFactory = Ice::Plugin* (*)(const Ice::CommunicatorPtr& communicator,
+                                           const std::string& name,
+                                           const Ice::StringSeq& args);
 
     /**
      * Manually registers a plug-in factory function.

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -52,7 +52,7 @@ namespace Ice
     class ICE_API InputStream final : public IceInternal::Buffer
     {
     public:
-        typedef size_t size_type;
+        using size_type = size_t;
 
         /**
          * Signature for a patch function, used to receive an unmarshaled value.
@@ -852,8 +852,8 @@ namespace Ice
             void addPatchEntry(std::int32_t, const PatchFunc&, void*);
             void unmarshal(std::int32_t, const ValuePtr&);
 
-            typedef std::map<std::int32_t, ValuePtr> IndexToPtrMap;
-            typedef std::map<std::int32_t, std::string> TypeIdMap;
+            using IndexToPtrMap = std::map<std::int32_t, ValuePtr>;
+            using TypeIdMap = std::map<std::int32_t, std::string>;
 
             struct PatchEntry
             {
@@ -861,8 +861,8 @@ namespace Ice
                 void* patchAddr;
                 size_t classGraphDepth;
             };
-            typedef std::vector<PatchEntry> PatchList;
-            typedef std::map<std::int32_t, PatchList> PatchMap;
+            using PatchList = std::vector<PatchEntry>;
+            using PatchMap = std::map<std::int32_t, PatchList>;
 
             InputStream* _stream;
             Encaps* _encaps;
@@ -894,16 +894,16 @@ namespace Ice
             {
             }
 
-            virtual void read(PatchFunc, void*);
-            virtual void throwException(UserExceptionFactory);
+            void read(PatchFunc, void*) override;
+            void throwException(UserExceptionFactory) override;
 
-            virtual void startInstance(SliceType);
-            virtual SlicedDataPtr endInstance();
-            virtual const std::string& startSlice();
-            virtual void endSlice();
-            virtual void skipSlice();
+            void startInstance(SliceType) override;
+            SlicedDataPtr endInstance() override;
+            const std::string& startSlice() override;
+            void endSlice() override;
+            void skipSlice() override;
 
-            virtual void readPendingValues();
+            void readPendingValues() override;
 
         private:
             void readInstance();
@@ -926,22 +926,22 @@ namespace Ice
                 size_t classGraphDepthMax,
                 const Ice::ValueFactoryManagerPtr& f)
                 : EncapsDecoder(stream, encaps, classGraphDepthMax, f),
-                  _preAllocatedInstanceData(0),
-                  _current(0),
+                  _preAllocatedInstanceData(nullptr),
+                  _current(nullptr),
                   _valueIdIndex(1)
             {
             }
 
-            virtual void read(PatchFunc, void*);
-            virtual void throwException(UserExceptionFactory);
+            void read(PatchFunc, void*) override;
+            void throwException(UserExceptionFactory) override;
 
-            virtual void startInstance(SliceType);
-            virtual SlicedDataPtr endInstance();
-            virtual const std::string& startSlice();
-            virtual void endSlice();
-            virtual void skipSlice();
+            void startInstance(SliceType) override;
+            SlicedDataPtr endInstance() override;
+            const std::string& startSlice() override;
+            void endSlice() override;
+            void skipSlice() override;
 
-            virtual bool readOptional(std::int32_t, OptionalFormat);
+            bool readOptional(std::int32_t, OptionalFormat) override;
 
         private:
             std::int32_t readInstance(std::int32_t, const PatchFunc&, void*);
@@ -953,14 +953,14 @@ namespace Ice
                 PatchFunc patchFunc;
                 void* patchAddr;
             };
-            typedef std::vector<IndirectPatchEntry> IndirectPatchList;
+            using IndirectPatchList = std::vector<IndirectPatchEntry>;
 
-            typedef std::vector<std::int32_t> IndexList;
-            typedef std::vector<IndexList> IndexListList;
+            using IndexList = std::vector<std::int32_t>;
+            using IndexListList = std::vector<IndexList>;
 
             struct InstanceData
             {
-                InstanceData(InstanceData* p) : previous(p), next(0)
+                InstanceData(InstanceData* p) : previous(p), next(nullptr)
                 {
                     if (previous)
                     {
@@ -1015,7 +1015,7 @@ namespace Ice
         class Encaps
         {
         public:
-            Encaps() : start(0), decoder(0), previous(0)
+            Encaps() : start(0), decoder(nullptr), previous(nullptr)
             {
                 // Inlined for performance reasons.
             }
@@ -1032,9 +1032,9 @@ namespace Ice
             {
                 // Inlined for performance reasons.
                 delete decoder;
-                decoder = 0;
+                decoder = nullptr;
 
-                previous = 0;
+                previous = nullptr;
             }
 
             Container::size_type start;

--- a/cpp/include/Ice/LoggerUtil.h
+++ b/cpp/include/Ice/LoggerUtil.h
@@ -47,7 +47,7 @@ namespace Ice
         static char testex(Ice::Exception*);
         static long testex(...);
 
-        static const bool value = sizeof(testex(static_cast<T*>(0))) == sizeof(char);
+        static const bool value = sizeof(testex(static_cast<T*>(nullptr))) == sizeof(char);
     };
 
     template<typename T, bool = false> struct LoggerOutputInserter
@@ -115,13 +115,13 @@ namespace Ice
     };
 
     /** Flushes output to Logger::print. */
-    typedef LoggerOutput<Logger, LoggerPtr, &Logger::print> Print;
+    using Print = LoggerOutput<Logger, LoggerPtr, &Logger::print>;
 
     /** Flushes output to Logger::warning. */
-    typedef LoggerOutput<Logger, LoggerPtr, &Logger::warning> Warning;
+    using Warning = LoggerOutput<Logger, LoggerPtr, &Logger::warning>;
 
     /** Flushes output to Logger::error. */
-    typedef LoggerOutput<Logger, LoggerPtr, &Logger::error> Error;
+    using Error = LoggerOutput<Logger, LoggerPtr, &Logger::error>;
 
     /**
      * Flushes output to Logger::trace.
@@ -155,10 +155,10 @@ namespace Ice
         LoggerPlugin(const CommunicatorPtr& communicator, const LoggerPtr& logger);
 
         /** This method is a no-op. */
-        virtual void initialize();
+        void initialize() override;
 
         /** This method is a no-op. */
-        virtual void destroy();
+        void destroy() override;
     };
 }
 

--- a/cpp/include/Ice/MetricsAdminI.h
+++ b/cpp/include/Ice/MetricsAdminI.h
@@ -107,7 +107,7 @@ namespace IceInternal
         using TPtr = std::shared_ptr<MetricsType>;
         using MetricsMapTPtr = std::shared_ptr<MetricsMapT>;
 
-        typedef IceMX::MetricsMap MetricsType::* SubMapMember;
+        using SubMapMember = IceMX::MetricsMap MetricsType::*;
 
         class EntryT;
         using EntryTPtr = std::shared_ptr<EntryT>;
@@ -160,7 +160,7 @@ namespace IceInternal
                     }
                     if (p == _subMaps.end())
                     {
-                        return 0;
+                        return nullptr;
                     }
                     m = p->second.first;
                 }
@@ -265,7 +265,7 @@ namespace IceInternal
             return std::static_pointer_cast<MetricsMapT>(MetricsMapI::shared_from_this());
         }
 
-        virtual void destroy()
+        void destroy() override
         {
             std::lock_guard lock(_mutex);
             _destroyed = true;
@@ -273,7 +273,7 @@ namespace IceInternal
             _detachedQueue.clear(); // Break cyclic reference counts
         }
 
-        virtual IceMX::MetricsMap getMetrics() const
+        IceMX::MetricsMap getMetrics() const override
         {
             IceMX::MetricsMap objects;
 
@@ -286,7 +286,7 @@ namespace IceInternal
             return objects;
         }
 
-        virtual IceMX::MetricsFailuresSeq getFailures()
+        IceMX::MetricsFailuresSeq getFailures() override
         {
             IceMX::MetricsFailuresSeq failures;
 
@@ -303,7 +303,7 @@ namespace IceInternal
             return failures;
         }
 
-        virtual IceMX::MetricsFailures getFailures(const std::string& id)
+        IceMX::MetricsFailures getFailures(const std::string& id) override
         {
             std::lock_guard lock(_mutex);
             typename std::map<std::string, EntryTPtr>::const_iterator p = _objects.find(id);
@@ -324,7 +324,7 @@ namespace IceInternal
                     p->second.second->clone()->shared_from_this(),
                     p->second.first);
             }
-            return std::pair<MetricsMapIPtr, SubMapMember>(MetricsMapIPtr(nullptr), static_cast<SubMapMember>(0));
+            return std::pair<MetricsMapIPtr, SubMapMember>(MetricsMapIPtr(nullptr), static_cast<SubMapMember>(nullptr));
         }
 
         EntryTPtr getMatching(const IceMX::MetricsHelperT<T>& helper, const EntryTPtr& previous = EntryTPtr())
@@ -412,7 +412,7 @@ namespace IceInternal
         }
 
     private:
-        virtual MetricsMapIPtr clone() const { return std::make_shared<MetricsMapT<MetricsType>>(*this); }
+        MetricsMapIPtr clone() const override { return std::make_shared<MetricsMapT<MetricsType>>(*this); }
 
         void detached(EntryTPtr entry)
         {
@@ -482,7 +482,7 @@ namespace IceInternal
     public:
         MetricsMapFactoryT(IceMX::Updater* updater) : MetricsMapFactory(updater) {}
 
-        virtual MetricsMapIPtr create(const std::string& mapPrefix, const Ice::PropertiesPtr& properties)
+        MetricsMapIPtr create(const std::string& mapPrefix, const Ice::PropertiesPtr& properties) override
         {
             return std::make_shared<MetricsMapT<MetricsType>>(mapPrefix, properties, _subMaps);
         }
@@ -531,7 +531,7 @@ namespace IceInternal
     {
     public:
         MetricsAdminI(const Ice::PropertiesPtr&, const Ice::LoggerPtr&);
-        ~MetricsAdminI();
+        ~MetricsAdminI() override;
 
         void destroy();
 
@@ -580,15 +580,15 @@ namespace IceInternal
 
         void unregisterMap(const std::string&);
 
-        virtual Ice::StringSeq getMetricsViewNames(Ice::StringSeq&, const Ice::Current&);
+        Ice::StringSeq getMetricsViewNames(Ice::StringSeq&, const Ice::Current&) override;
 
         void updated(const Ice::PropertyDict&);
 
-        virtual void enableMetricsView(std::string, const Ice::Current&);
-        virtual void disableMetricsView(std::string, const Ice::Current&);
-        virtual IceMX::MetricsView getMetricsView(std::string, std::int64_t&, const Ice::Current&);
-        virtual IceMX::MetricsFailuresSeq getMapMetricsFailures(std::string, std::string, const Ice::Current&);
-        virtual IceMX::MetricsFailures getMetricsFailures(std::string, std::string, std::string, const Ice::Current&);
+        void enableMetricsView(std::string, const Ice::Current&) override;
+        void disableMetricsView(std::string, const Ice::Current&) override;
+        IceMX::MetricsView getMetricsView(std::string, std::int64_t&, const Ice::Current&) override;
+        IceMX::MetricsFailuresSeq getMapMetricsFailures(std::string, std::string, const Ice::Current&) override;
+        IceMX::MetricsFailures getMetricsFailures(std::string, std::string, std::string, const Ice::Current&) override;
         std::vector<MetricsMapIPtr> getMaps(const std::string&) const;
 
         const Ice::LoggerPtr& getLogger() const;

--- a/cpp/include/Ice/MetricsObserverI.h
+++ b/cpp/include/Ice/MetricsObserverI.h
@@ -78,7 +78,7 @@ namespace IceMX
             };
 
         public:
-            AttributeResolverT() : _default(0) {}
+            AttributeResolverT() : _default(nullptr) {}
 
             ~AttributeResolverT()
             {
@@ -158,7 +158,7 @@ namespace IceMX
             public:
                 HelperMemberResolver(const std::string& name, Y Helper::* member) : Resolver(name), _member(member) {}
 
-                virtual std::string operator()(const Helper* r) const { return toString(r->*_member); }
+                std::string operator()(const Helper* r) const override { return toString(r->*_member); }
 
             private:
                 Y Helper::* _member;
@@ -173,7 +173,7 @@ namespace IceMX
                 {
                 }
 
-                virtual std::string operator()(const Helper* r) const { return toString((r->*_memberFn)()); }
+                std::string operator()(const Helper* r) const override { return toString((r->*_memberFn)()); }
 
             private:
                 Y (Helper::*_memberFn)() const;
@@ -189,7 +189,7 @@ namespace IceMX
                 {
                 }
 
-                virtual std::string operator()(const Helper* r) const
+                std::string operator()(const Helper* r) const override
                 {
                     O o = (r->*_getFn)();
                     I* v = dynamicCast<I>(IceInternal::ReferenceWrapper<O>::get(o));
@@ -218,7 +218,7 @@ namespace IceMX
                 {
                 }
 
-                virtual std::string operator()(const Helper* r) const
+                std::string operator()(const Helper* r) const override
                 {
                     O o = (r->*_getFn)();
                     I* v = dynamicCast<I>(IceInternal::ReferenceWrapper<O>::get(o));
@@ -249,7 +249,7 @@ namespace IceMX
                         return i;
                     }
                 }
-                return 0;
+                return nullptr;
             }
 
             template<typename I> static I* dynamicCast(Ice::ConnectionInfo* v)
@@ -262,7 +262,7 @@ namespace IceMX
                         return i;
                     }
                 }
-                return 0;
+                return nullptr;
             }
 
             template<typename I> static std::string toString(const I& v)
@@ -305,7 +305,7 @@ namespace IceMX
     public:
         UpdaterT(const std::shared_ptr<T>& updater, void (T::*fn)()) : _updater(updater), _fn(fn) {}
 
-        virtual void update() { (_updater.get()->*_fn)(); }
+        void update() override { (_updater.get()->*_fn)(); }
 
     private:
         const std::shared_ptr<T> _updater;
@@ -327,13 +327,13 @@ namespace IceMX
     template<typename T> class ObserverT : public virtual Ice::Instrumentation::Observer
     {
     public:
-        typedef T MetricsType;
-        typedef typename IceInternal::MetricsMapT<MetricsType>::EntryTPtr EntryPtrType;
-        typedef std::vector<EntryPtrType> EntrySeqType;
+        using MetricsType = T;
+        using EntryPtrType = typename IceInternal::MetricsMapT<MetricsType>::EntryTPtr;
+        using EntrySeqType = std::vector<EntryPtrType>;
 
         ObserverT() : _previousDelay(0) {}
 
-        virtual void attach()
+        void attach() override
         {
             if (!_watch.isStarted())
             {
@@ -341,7 +341,7 @@ namespace IceMX
             }
         }
 
-        virtual void detach()
+        void detach() override
         {
             std::chrono::microseconds lifetime = _previousDelay + _watch.stop();
             for (typename EntrySeqType::const_iterator p = _objects.begin(); p != _objects.end(); ++p)
@@ -350,7 +350,7 @@ namespace IceMX
             }
         }
 
-        virtual void failed(const std::string& exceptionName)
+        void failed(const std::string& exceptionName) override
         {
             for (typename EntrySeqType::const_iterator p = _objects.begin(); p != _objects.end(); ++p)
             {
@@ -366,11 +366,11 @@ namespace IceMX
             }
         }
 
-        void init(const MetricsHelperT<MetricsType>& /*helper*/, EntrySeqType& objects, ObserverT* previous = 0)
+        void init(const MetricsHelperT<MetricsType>& /*helper*/, EntrySeqType& objects, ObserverT* previous = nullptr)
         {
             _objects.swap(objects);
 
-            if (previous == 0)
+            if (previous == nullptr)
             {
                 return;
             }
@@ -529,7 +529,7 @@ namespace IceMX
 
         bool isEnabled() const { return _enabled != 0; }
 
-        virtual void update()
+        void update() override
         {
             UpdaterPtr updater;
             {
@@ -565,7 +565,7 @@ namespace IceMX
         void destroy()
         {
             std::lock_guard lock(_mutex);
-            _metrics = 0;
+            _metrics = nullptr;
             _maps.clear();
         }
 
@@ -578,7 +578,7 @@ namespace IceMX
         std::mutex _mutex;
     };
 
-    typedef ObserverT<Metrics> ObserverI;
+    using ObserverI = ObserverT<Metrics>;
     /// \endcond
 }
 

--- a/cpp/include/Ice/ObserverHelper.h
+++ b/cpp/include/Ice/ObserverHelper.h
@@ -67,7 +67,7 @@ namespace IceInternal
             if (_observer)
             {
                 _observer->detach();
-                _observer = 0;
+                _observer = nullptr;
             }
         }
 

--- a/cpp/include/Ice/OutgoingAsync.h
+++ b/cpp/include/Ice/OutgoingAsync.h
@@ -150,7 +150,7 @@ namespace IceInternal
         virtual AsyncStatus invokeRemote(const Ice::ConnectionIPtr&, bool, bool) = 0;
         virtual AsyncStatus invokeCollocated(CollocatedRequestHandler*) = 0;
 
-        virtual bool exception(std::exception_ptr);
+        bool exception(std::exception_ptr) override;
 
         void retryException();
         void retry();
@@ -163,14 +163,14 @@ namespace IceInternal
 
     protected:
         ProxyOutgoingAsyncBase(Ice::ObjectPrx);
-        ~ProxyOutgoingAsyncBase();
+        ~ProxyOutgoingAsyncBase() override;
 
         void invokeImpl(bool);
         bool sentImpl(bool);
         bool exceptionImpl(std::exception_ptr);
         bool responseImpl(bool, bool);
 
-        virtual void runTimerTask();
+        void runTimerTask() override;
 
         const Ice::ObjectPrx _proxy;
         RequestHandlerPtr _handler;
@@ -196,11 +196,11 @@ namespace IceInternal
 
         void prepare(std::string_view operation, Ice::OperationMode mode, const Ice::Context& context);
 
-        virtual bool sent();
-        virtual bool response();
+        bool sent() override;
+        bool response() override;
 
-        virtual AsyncStatus invokeRemote(const Ice::ConnectionIPtr&, bool, bool);
-        virtual AsyncStatus invokeCollocated(CollocatedRequestHandler*);
+        AsyncStatus invokeRemote(const Ice::ConnectionIPtr&, bool, bool) override;
+        AsyncStatus invokeCollocated(CollocatedRequestHandler*) override;
 
         void abort(std::exception_ptr);
         void invoke(std::string_view);

--- a/cpp/include/Ice/OutputStream.h
+++ b/cpp/include/Ice/OutputStream.h
@@ -35,7 +35,7 @@ namespace Ice
     class ICE_API OutputStream : public IceInternal::Buffer
     {
     public:
-        typedef size_t size_type;
+        using size_type = size_t;
 
         /**
          * Constructs an OutputStream.
@@ -804,7 +804,7 @@ namespace Ice
             ExceptionSlice
         };
 
-        typedef std::vector<ValuePtr> ValueList;
+        using ValueList = std::vector<ValuePtr>;
 
         class ICE_API EncapsEncoder
         {
@@ -834,8 +834,8 @@ namespace Ice
             OutputStream* _stream;
             Encaps* _encaps;
 
-            typedef std::map<ValuePtr, std::int32_t> PtrToIndexMap;
-            typedef std::map<std::string, std::int32_t, std::less<>> TypeIdMap;
+            using PtrToIndexMap = std::map<ValuePtr, std::int32_t>;
+            using TypeIdMap = std::map<std::string, std::int32_t, std::less<>>;
 
             // Encapsulation attributes for value marshaling.
             PtrToIndexMap _marshaledMap;
@@ -856,15 +856,15 @@ namespace Ice
             {
             }
 
-            virtual void write(const ValuePtr&);
-            virtual void write(const UserException&);
+            void write(const ValuePtr&) override;
+            void write(const UserException&) override;
 
-            virtual void startInstance(SliceType, const SlicedDataPtr&);
-            virtual void endInstance();
-            virtual void startSlice(std::string_view, int, bool);
-            virtual void endSlice();
+            void startInstance(SliceType, const SlicedDataPtr&) override;
+            void endInstance() override;
+            void startSlice(std::string_view, int, bool) override;
+            void endSlice() override;
 
-            virtual void writePendingValues();
+            void writePendingValues() override;
 
         private:
             std::int32_t registerValue(const ValuePtr&);
@@ -885,21 +885,21 @@ namespace Ice
         public:
             EncapsEncoder11(OutputStream* stream, Encaps* encaps)
                 : EncapsEncoder(stream, encaps),
-                  _preAllocatedInstanceData(0),
-                  _current(0),
+                  _preAllocatedInstanceData(nullptr),
+                  _current(nullptr),
                   _valueIdIndex(1)
             {
             }
 
-            virtual void write(const ValuePtr&);
-            virtual void write(const UserException&);
+            void write(const ValuePtr&) override;
+            void write(const UserException&) override;
 
-            virtual void startInstance(SliceType, const SlicedDataPtr&);
-            virtual void endInstance();
-            virtual void startSlice(std::string_view, int, bool);
-            virtual void endSlice();
+            void startInstance(SliceType, const SlicedDataPtr&) override;
+            void endInstance() override;
+            void startSlice(std::string_view, int, bool) override;
+            void endSlice() override;
 
-            virtual bool writeOptional(std::int32_t, OptionalFormat);
+            bool writeOptional(std::int32_t, OptionalFormat) override;
 
         private:
             void writeSlicedData(const SlicedDataPtr&);
@@ -907,7 +907,7 @@ namespace Ice
 
             struct InstanceData
             {
-                InstanceData(InstanceData* p) : previous(p), next(0)
+                InstanceData(InstanceData* p) : previous(p), next(nullptr)
                 {
                     if (previous)
                     {
@@ -946,7 +946,7 @@ namespace Ice
         class Encaps
         {
         public:
-            Encaps() : format(FormatType::CompactFormat), encoder(0), previous(0)
+            Encaps() : format(FormatType::CompactFormat), encoder(nullptr), previous(nullptr)
             {
                 // Inlined for performance reasons.
             }
@@ -963,9 +963,9 @@ namespace Ice
             {
                 // Inlined for performance reasons.
                 delete encoder;
-                encoder = 0;
+                encoder = nullptr;
 
-                previous = 0;
+                previous = nullptr;
             }
 
             Container::size_type start;

--- a/cpp/include/Ice/Service.h
+++ b/cpp/include/Ice/Service.h
@@ -295,27 +295,27 @@ namespace Ice
         /**
          * Logger utility class for a system error.
          */
-        typedef LoggerOutput<Service, Service*, &Service::syserror> ServiceSysError;
+        using ServiceSysError = LoggerOutput<Service, Service*, &Service::syserror>;
 
         /**
          * Logger utility class for an error.
          */
-        typedef LoggerOutput<Service, Service*, &Service::error> ServiceError;
+        using ServiceError = LoggerOutput<Service, Service*, &Service::error>;
 
         /**
          * Logger utility class for a warning.
          */
-        typedef LoggerOutput<Service, Service*, &Service::warning> ServiceWarning;
+        using ServiceWarning = LoggerOutput<Service, Service*, &Service::warning>;
 
         /**
          * Logger utility class for a trace message.
          */
-        typedef LoggerOutput<Service, Service*, &Service::trace> ServiceTrace;
+        using ServiceTrace = LoggerOutput<Service, Service*, &Service::trace>;
 
         /**
          * Logger utility class for a literal message.
          */
-        typedef LoggerOutput<Service, Service*, &Service::print> ServicePrint;
+        using ServicePrint = LoggerOutput<Service, Service*, &Service::print>;
 
     private:
         Ice::LoggerPtr _logger;

--- a/cpp/include/Ice/StreamHelpers.h
+++ b/cpp/include/Ice/StreamHelpers.h
@@ -313,7 +313,7 @@ namespace Ice
      */
     template<typename T, StreamHelperCategory st, bool fixedLength> struct StreamOptionalHelper
     {
-        typedef StreamableTraits<T> Traits;
+        using Traits = StreamableTraits<T>;
 
         // If this optionalFormat fails to compile, you must either define your specialization
         // for GetOptionalFormat (in which case the optional data will be marshaled/unmarshaled
@@ -452,7 +452,7 @@ namespace Ice
      */
     template<typename T> struct StreamOptionalHelper<T, StreamHelperCategorySequence, false>
     {
-        typedef typename T::value_type E;
+        using E = typename T::value_type;
         static const int size = StreamableTraits<E>::minWireSize;
         static const bool fixedLength = StreamableTraits<E>::fixedLength;
 
@@ -479,7 +479,7 @@ namespace Ice
      */
     template<typename T> struct StreamOptionalHelper<std::pair<const T*, const T*>, StreamHelperCategorySequence, false>
     {
-        typedef std::pair<const T*, const T*> P;
+        using P = std::pair<const T*, const T*>;
         static const int size = StreamableTraits<T>::minWireSize;
         static const bool fixedLength = StreamableTraits<T>::fixedLength;
 
@@ -507,8 +507,8 @@ namespace Ice
      */
     template<typename T> struct StreamOptionalHelper<T, StreamHelperCategoryDictionary, false>
     {
-        typedef typename T::key_type K;
-        typedef typename T::mapped_type V;
+        using K = typename T::key_type;
+        using V = typename T::mapped_type;
 
         static const int size = StreamableTraits<K>::minWireSize + StreamableTraits<V>::minWireSize;
         static const bool fixedLength = StreamableTraits<K>::fixedLength && StreamableTraits<V>::fixedLength;

--- a/cpp/src/Glacier2/InstrumentationI.cpp
+++ b/cpp/src/Glacier2/InstrumentationI.cpp
@@ -178,5 +178,5 @@ RouterObserverI::getSessionObserver(
             error << "unexpected exception trying to obtain observer:\n" << ex;
         }
     }
-    return 0;
+    return nullptr;
 }

--- a/cpp/src/Glacier2/ProxyVerifier.cpp
+++ b/cpp/src/Glacier2/ProxyVerifier.cpp
@@ -522,7 +522,7 @@ namespace Glacier2
             {
                 consoleErr << rule->toString() << " ";
             }
-            if (_portMatcher != 0)
+            if (_portMatcher != nullptr)
             {
                 consoleErr << "):port(" << _portMatcher->toString() << " ";
             }
@@ -573,7 +573,7 @@ namespace Glacier2
 
             while (!propertyInput.eof() && propertyInput.good())
             {
-                MatchesNumber* portMatch = 0;
+                MatchesNumber* portMatch = nullptr;
                 vector<AddressMatcher*> currentRuleSet;
 
                 string parameter;

--- a/cpp/src/Glacier2/RouterI.cpp
+++ b/cpp/src/Glacier2/RouterI.cpp
@@ -116,7 +116,7 @@ string
 Glacier2::RouterI::getCategoryForClient(const Current&) const
 {
     assert(false); // Must not be called in this router implementation.
-    return 0;
+    return nullptr;
 }
 
 void

--- a/cpp/src/Glacier2CryptPermissionsVerifier/CryptPermissionsVerifierI.cpp
+++ b/cpp/src/Glacier2CryptPermissionsVerifier/CryptPermissionsVerifierI.cpp
@@ -494,7 +494,7 @@ extern "C"
         {
             Error out(communicator->getLogger());
             out << "Plugin " << name << ": too many arguments";
-            return 0;
+            return nullptr;
         }
 
         return new CryptPermissionsVerifierPlugin(communicator);

--- a/cpp/src/Ice/ArgVector.cpp
+++ b/cpp/src/Ice/ArgVector.cpp
@@ -33,7 +33,7 @@ IceInternal::ArgVector&
 IceInternal::ArgVector::operator=(const ArgVector& rhs)
 {
     delete[] argv;
-    argv = 0;
+    argv = nullptr;
     _args = rhs._args;
     setupArgcArgv();
     return *this;
@@ -45,7 +45,7 @@ void
 IceInternal::ArgVector::setupArgcArgv()
 {
     argc = static_cast<int>(_args.size());
-    if ((argv = new char*[static_cast<size_t>(argc + 1)]) == 0)
+    if ((argv = new char*[static_cast<size_t>(argc + 1)]) == nullptr)
     {
         throw ::std::bad_alloc();
     }
@@ -53,5 +53,5 @@ IceInternal::ArgVector::setupArgcArgv()
     {
         argv[i] = const_cast<char*>(_args[i].c_str());
     }
-    argv[argc] = 0;
+    argv[argc] = nullptr;
 }

--- a/cpp/src/Ice/BatchRequestQueue.cpp
+++ b/cpp/src/Ice/BatchRequestQueue.cpp
@@ -31,7 +31,7 @@ namespace
 
         int getSize() const final { return _size; }
 
-        string_view getOperation() const { return _operation; }
+        string_view getOperation() const override { return _operation; }
 
         const Ice::ObjectPrx& getProxy() const final { return _proxy; }
 

--- a/cpp/src/Ice/Buffer.cpp
+++ b/cpp/src/Ice/Buffer.cpp
@@ -33,7 +33,7 @@ IceInternal::Buffer::Container::Container(const vector<value_type>& v) noexcept 
 {
     if (v.empty())
     {
-        _buf = 0;
+        _buf = nullptr;
         _size = 0;
         _capacity = 0;
         _owned = true;
@@ -57,7 +57,7 @@ IceInternal::Buffer::Container::Container(Container& other, bool adopt) noexcept
         _shrinkCounter = other._shrinkCounter;
         _owned = other._owned;
 
-        other._buf = 0;
+        other._buf = nullptr;
         other._size = 0;
         other._capacity = 0;
         other._shrinkCounter = 0;

--- a/cpp/src/Ice/CommunicatorFlushBatchAsync.cpp
+++ b/cpp/src/Ice/CommunicatorFlushBatchAsync.cpp
@@ -44,14 +44,14 @@ CommunicatorFlushBatchAsync::flushConnection(const ConnectionIPtr& con, Ice::Com
         {
         }
 
-        virtual bool sent()
+        bool sent() override
         {
             _childObserver.detach();
             _outAsync->check(false);
             return false;
         }
 
-        virtual bool exception(std::exception_ptr ex)
+        bool exception(std::exception_ptr ex) override
         {
             _childObserver.failed(getExceptionId(ex));
             _childObserver.detach();
@@ -59,7 +59,7 @@ CommunicatorFlushBatchAsync::flushConnection(const ConnectionIPtr& con, Ice::Com
             return false;
         }
 
-        virtual InvocationObserver& getObserver() { return _parentObserver; }
+        InvocationObserver& getObserver() override { return _parentObserver; }
 
         bool handleSent(bool, bool) noexcept final { return false; }
 

--- a/cpp/src/Ice/CommunicatorFlushBatchAsync.h
+++ b/cpp/src/Ice/CommunicatorFlushBatchAsync.h
@@ -17,7 +17,7 @@ namespace IceInternal
     class CommunicatorFlushBatchAsync : public OutgoingAsyncBase
     {
     public:
-        virtual ~CommunicatorFlushBatchAsync();
+        ~CommunicatorFlushBatchAsync() override;
 
         CommunicatorFlushBatchAsync(const InstancePtr&);
 

--- a/cpp/src/Ice/ConnectionFactory.cpp
+++ b/cpp/src/Ice/ConnectionFactory.cpp
@@ -78,7 +78,7 @@ namespace
         {
         }
 
-        void runTimerTask()
+        void runTimerTask() override
         {
             try
             {
@@ -384,7 +384,7 @@ IceInternal::OutgoingConnectionFactory::findConnection(const vector<EndpointIPtr
             return connection;
         }
     }
-    return 0;
+    return nullptr;
 }
 
 ConnectionIPtr
@@ -416,7 +416,7 @@ IceInternal::OutgoingConnectionFactory::findConnection(const vector<ConnectorInf
         }
     }
 
-    return 0;
+    return nullptr;
 }
 
 void
@@ -1526,7 +1526,7 @@ IceInternal::IncomingConnectionFactory::getNativeInfo()
     }
     else
     {
-        return 0;
+        return nullptr;
     }
 }
 

--- a/cpp/src/Ice/ConnectionFactory.h
+++ b/cpp/src/Ice/ConnectionFactory.h
@@ -199,18 +199,18 @@ namespace IceInternal
         virtual bool finishAsync(SocketOperation);
 #endif
 
-        virtual void message(ThreadPoolCurrent&);
-        virtual void finished(ThreadPoolCurrent&, bool);
+        void message(ThreadPoolCurrent&) override;
+        void finished(ThreadPoolCurrent&, bool) override;
 #if TARGET_OS_IPHONE != 0
         void finish();
 #endif
-        virtual std::string toString() const;
-        virtual NativeInfoPtr getNativeInfo();
+        std::string toString() const override;
+        NativeInfoPtr getNativeInfo() override;
 
         virtual void connectionStartCompleted(const Ice::ConnectionIPtr&);
         virtual void connectionStartFailed(const Ice::ConnectionIPtr&, std::exception_ptr);
         void initialize();
-        ~IncomingConnectionFactory();
+        ~IncomingConnectionFactory() override;
 
         std::shared_ptr<IncomingConnectionFactory> shared_from_this()
         {

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -212,19 +212,19 @@ Ice::ConnectionI::Observer::startRead(const Buffer& buf)
         assert(!buf.b.empty());
         _observer->receivedBytes(static_cast<int>(buf.i - _readStreamPos));
     }
-    _readStreamPos = buf.b.empty() ? 0 : buf.i;
+    _readStreamPos = buf.b.empty() ? nullptr : buf.i;
 }
 
 void
 Ice::ConnectionI::Observer::finishRead(const Buffer& buf)
 {
-    if (_readStreamPos == 0)
+    if (_readStreamPos == nullptr)
     {
         return;
     }
     assert(buf.i >= _readStreamPos);
     _observer->receivedBytes(static_cast<int>(buf.i - _readStreamPos));
-    _readStreamPos = 0;
+    _readStreamPos = nullptr;
 }
 
 void
@@ -235,13 +235,13 @@ Ice::ConnectionI::Observer::startWrite(const Buffer& buf)
         assert(!buf.b.empty());
         _observer->sentBytes(static_cast<int>(buf.i - _writeStreamPos));
     }
-    _writeStreamPos = buf.b.empty() ? 0 : buf.i;
+    _writeStreamPos = buf.b.empty() ? nullptr : buf.i;
 }
 
 void
 Ice::ConnectionI::Observer::finishWrite(const Buffer& buf)
 {
-    if (_writeStreamPos == 0)
+    if (_writeStreamPos == nullptr)
     {
         return;
     }
@@ -249,7 +249,7 @@ Ice::ConnectionI::Observer::finishWrite(const Buffer& buf)
     {
         _observer->sentBytes(static_cast<int>(buf.i - _writeStreamPos));
     }
-    _writeStreamPos = 0;
+    _writeStreamPos = nullptr;
 }
 
 void
@@ -258,8 +258,8 @@ Ice::ConnectionI::Observer::attach(const Ice::Instrumentation::ConnectionObserve
     ObserverHelperT<Ice::Instrumentation::ConnectionObserver>::attach(observer);
     if (!observer)
     {
-        _writeStreamPos = 0;
-        _readStreamPos = 0;
+        _writeStreamPos = nullptr;
+        _readStreamPos = nullptr;
     }
 }
 
@@ -351,7 +351,7 @@ Ice::ConnectionI::OutgoingMessage::completed(std::exception_ptr ex)
     {
         delete stream;
     }
-    stream = 0;
+    stream = nullptr;
 }
 
 void
@@ -1880,7 +1880,7 @@ Ice::ConnectionI::setBufferSize(int32_t rcvSize, int32_t sndSize)
         rethrow_exception(_exception);
     }
     _transceiver->setBufferSize(rcvSize, sndSize);
-    _info = 0; // Invalidate the cached connection info
+    _info = nullptr; // Invalidate the cached connection info
 }
 
 void
@@ -2211,7 +2211,7 @@ Ice::ConnectionI::setState(State state)
             case StateFinished:
             {
                 assert(_state == StateClosed);
-                _communicator = 0;
+                _communicator = nullptr;
                 break;
             }
         }
@@ -2887,14 +2887,14 @@ Ice::ConnectionI::sendMessage(OutgoingMessage& message)
     assert(_state >= StateActive);
     assert(_state < StateClosed);
 
-    message.stream->i = 0; // Reset the message stream iterator before starting sending the message.
+    message.stream->i = nullptr; // Reset the message stream iterator before starting sending the message.
 
     // Some messages are queued for sending. Just adds the message to the send queue and tell the caller that the
     // message was queued.
     if (!_sendStreams.empty())
     {
         _sendStreams.push_back(message);
-        _sendStreams.back().adopt(0);
+        _sendStreams.back().adopt(nullptr);
         return AsyncStatusQueued;
     }
 
@@ -2989,7 +2989,7 @@ Ice::ConnectionI::sendMessage(OutgoingMessage& message)
         }
 
         _sendStreams.push_back(message);
-        _sendStreams.back().adopt(0); // Adopt the stream.
+        _sendStreams.back().adopt(nullptr); // Adopt the stream.
 #ifdef ICE_HAS_BZIP2
     }
 #endif

--- a/cpp/src/Ice/CtrlCHandler.cpp
+++ b/cpp/src/Ice/CtrlCHandler.cpp
@@ -23,7 +23,7 @@ namespace
 {
     CtrlCHandlerCallback _callback = nullptr;
 
-    const CtrlCHandler* _handler = 0;
+    const CtrlCHandler* _handler = nullptr;
 
     mutex globalMutex;
 }
@@ -128,7 +128,7 @@ extern "C"
                 lock_guard lock(globalMutex);
                 if (!_handler) // The handler is destroyed.
                 {
-                    return 0;
+                    return nullptr;
                 }
                 callback = _callback;
             }
@@ -138,7 +138,7 @@ extern "C"
                 callback(signal);
             }
         }
-        return 0;
+        return nullptr;
     }
 }
 
@@ -150,7 +150,7 @@ namespace
 CtrlCHandler::CtrlCHandler(CtrlCHandlerCallback callback)
 {
     unique_lock lock(globalMutex);
-    bool handler = _handler != 0;
+    bool handler = _handler != nullptr;
 
     if (handler)
     {
@@ -174,11 +174,11 @@ CtrlCHandler::CtrlCHandler(CtrlCHandlerCallback callback)
         sigaddset(&ctrlCLikeSignals, SIGTERM);
 
 #    ifndef NDEBUG
-        int rc = pthread_sigmask(SIG_BLOCK, &ctrlCLikeSignals, 0);
+        int rc = pthread_sigmask(SIG_BLOCK, &ctrlCLikeSignals, nullptr);
         assert(rc == 0);
 
         // Joinable thread
-        rc = pthread_create(&_tid, 0, sigwaitThread, 0);
+        rc = pthread_create(&_tid, nullptr, sigwaitThread, nullptr);
         assert(rc == 0);
 #    else
         pthread_sigmask(SIG_BLOCK, &ctrlCLikeSignals, 0);
@@ -196,14 +196,14 @@ CtrlCHandler::~CtrlCHandler()
     //
     {
         lock_guard lock(globalMutex);
-        _handler = 0;
+        _handler = nullptr;
         _callback = nullptr;
     }
 
     //
     // Signal the sigwaitThread and join it.
     //
-    void* status = 0;
+    void* status = nullptr;
 #    ifndef NDEBUG
     int rc = pthread_kill(_tid, SIGTERM);
     assert(rc == 0);

--- a/cpp/src/Ice/DynamicLibrary.cpp
+++ b/cpp/src/Ice/DynamicLibrary.cpp
@@ -17,7 +17,7 @@ using namespace Ice;
 using namespace IceInternal;
 using namespace std;
 
-IceInternal::DynamicLibrary::DynamicLibrary() : _hnd(0) {}
+IceInternal::DynamicLibrary::DynamicLibrary() : _hnd(nullptr) {}
 
 IceInternal::DynamicLibrary::~DynamicLibrary()
 {
@@ -59,7 +59,7 @@ IceInternal::DynamicLibrary::loadEntryPoint(const string& entryPoint, bool useIc
     if (colon == string::npos || colon == entryPoint.size() - 1)
     {
         _err = "invalid entry point format `" + entryPoint + "'";
-        return 0;
+        return nullptr;
     }
 
     string libSpec = entryPoint.substr(0, colon);
@@ -104,7 +104,7 @@ IceInternal::DynamicLibrary::loadEntryPoint(const string& entryPoint, bool useIc
         if (comma == libSpec.size() - 1)
         {
             _err = "invalid entry point format `" + entryPoint + "'";
-            return 0;
+            return nullptr;
         }
         libName = libSpec.substr(0, comma);
         version = libSpec.substr(comma + 1);
@@ -153,7 +153,7 @@ IceInternal::DynamicLibrary::loadEntryPoint(const string& entryPoint, bool useIc
             if (!load(lib + ".bundle"))
             {
                 _err = errMsg + "; " + _err;
-                return 0;
+                return nullptr;
             }
         }
         _err = "";
@@ -181,7 +181,7 @@ IceInternal::DynamicLibrary::load(const string& lib)
     int flags = RTLD_NOW | RTLD_GLOBAL;
     _hnd = dlopen(lib.c_str(), flags);
 #endif
-    if (_hnd == 0)
+    if (_hnd == nullptr)
     {
         //
         // Remember the most recent error in _err.
@@ -197,20 +197,20 @@ IceInternal::DynamicLibrary::load(const string& lib)
 #endif
     }
 
-    return _hnd != 0;
+    return _hnd != nullptr;
 }
 
 IceInternal::DynamicLibrary::symbol_type
 IceInternal::DynamicLibrary::getSymbol(const string& name)
 {
-    assert(_hnd != 0);
+    assert(_hnd != nullptr);
 #ifdef _WIN32
     symbol_type result = GetProcAddress(_hnd, name.c_str());
 #else
     symbol_type result = dlsym(_hnd, name.c_str());
 #endif
 
-    if (result == 0)
+    if (result == nullptr)
     {
         //
         // Remember the most recent error in _err.

--- a/cpp/src/Ice/DynamicLibrary.h
+++ b/cpp/src/Ice/DynamicLibrary.h
@@ -27,7 +27,7 @@ namespace IceInternal
 #ifdef _WIN32
         typedef FARPROC symbol_type;
 #else
-        using symbol_type = void *;
+        using symbol_type = void*;
 #endif
 
         //

--- a/cpp/src/Ice/DynamicLibrary.h
+++ b/cpp/src/Ice/DynamicLibrary.h
@@ -27,7 +27,7 @@ namespace IceInternal
 #ifdef _WIN32
         typedef FARPROC symbol_type;
 #else
-        typedef void* symbol_type;
+        using symbol_type = void *;
 #endif
 
         //

--- a/cpp/src/Ice/EndpointFactory.h
+++ b/cpp/src/Ice/EndpointFactory.h
@@ -43,13 +43,13 @@ namespace IceInternal
     public:
         EndpointFactoryWithUnderlying(const ProtocolInstancePtr&, std::int16_t);
 
-        virtual void initialize();
-        virtual std::int16_t type() const;
-        virtual std::string protocol() const;
-        virtual EndpointIPtr create(std::vector<std::string>&, bool) const;
-        virtual EndpointIPtr read(Ice::InputStream*) const;
+        void initialize() override;
+        std::int16_t type() const override;
+        std::string protocol() const override;
+        EndpointIPtr create(std::vector<std::string>&, bool) const override;
+        EndpointIPtr read(Ice::InputStream*) const override;
 
-        virtual EndpointFactoryPtr clone(const ProtocolInstancePtr&) const;
+        EndpointFactoryPtr clone(const ProtocolInstancePtr&) const override;
 
         virtual EndpointFactoryPtr cloneWithUnderlying(const ProtocolInstancePtr&, std::int16_t) const = 0;
 
@@ -73,13 +73,13 @@ namespace IceInternal
     public:
         UnderlyingEndpointFactory(const ProtocolInstancePtr&, std::int16_t, std::int16_t);
 
-        virtual void initialize();
-        virtual std::int16_t type() const;
-        virtual std::string protocol() const;
-        virtual EndpointIPtr create(std::vector<std::string>&, bool) const;
-        virtual EndpointIPtr read(Ice::InputStream*) const;
+        void initialize() override;
+        std::int16_t type() const override;
+        std::string protocol() const override;
+        EndpointIPtr create(std::vector<std::string>&, bool) const override;
+        EndpointIPtr read(Ice::InputStream*) const override;
 
-        virtual EndpointFactoryPtr clone(const ProtocolInstancePtr&) const;
+        EndpointFactoryPtr clone(const ProtocolInstancePtr&) const override;
 
     private:
         const ProtocolInstancePtr _instance;
@@ -93,8 +93,8 @@ namespace IceInternal
     public:
         EndpointFactoryPlugin(const Ice::CommunicatorPtr&, const EndpointFactoryPtr&);
 
-        virtual void initialize();
-        virtual void destroy();
+        void initialize() override;
+        void destroy() override;
     };
 }
 

--- a/cpp/src/Ice/EndpointI.h
+++ b/cpp/src/Ice/EndpointI.h
@@ -135,7 +135,7 @@ namespace IceInternal
         //
         virtual std::string options() const = 0;
 
-        virtual std::string toString() const noexcept;
+        std::string toString() const noexcept override;
         void initWithOptions(std::vector<std::string>&);
 
     protected:

--- a/cpp/src/Ice/Exception.cpp
+++ b/cpp/src/Ice/Exception.cpp
@@ -118,7 +118,7 @@ namespace
 
     struct FrameInfo
     {
-        FrameInfo(int i, uintptr_t p) : index(i), pc(p), fallback(0), setByErrorCb(false) {}
+        FrameInfo(int i, uintptr_t p) : index(i), pc(p), fallback(nullptr), setByErrorCb(false) {}
 
         int index;
         uintptr_t pc;
@@ -348,7 +348,7 @@ namespace
         vector<void*>::const_iterator p = stackFrames.begin();
         int frameIndex = 0;
         int offset = 0;
-        char** backtraceStrings = 0;
+        char** backtraceStrings = nullptr;
 
 #    if defined(ICE_LIBBACKTRACE) && defined(ICE_BACKTRACE)
         bool backtraceStringsInitialized = false;
@@ -389,7 +389,7 @@ namespace
 #        endif
             }
 #    else // not using libbacktrace:
-            printFrame(&frameInfo, frameInfo.pc, 0, 0, 0);
+            printFrame(&frameInfo, frameInfo.pc, nullptr, 0, nullptr);
 #    endif
             if (!retry)
             {

--- a/cpp/src/Ice/FileUtil.h
+++ b/cpp/src/Ice/FileUtil.h
@@ -69,7 +69,7 @@ namespace IceInternal
 
 #else
 
-    typedef struct stat structstat;
+    using structstat = struct stat;
 #    define O_BINARY 0
 
 #endif

--- a/cpp/src/Ice/HttpParser.cpp
+++ b/cpp/src/Ice/HttpParser.cpp
@@ -75,14 +75,14 @@ IceInternal::HttpParser::isCompleteMessage(const byte* begin, const byte* end) c
         }
     }
 
-    return 0;
+    return nullptr;
 }
 
 bool
 IceInternal::HttpParser::parse(const byte* begin, const byte* end)
 {
     const byte* p = begin;
-    const byte* start = 0;
+    const byte* start = nullptr;
     const string::value_type CR = '\r';
     const string::value_type LF = '\n';
 

--- a/cpp/src/Ice/HttpParser.h
+++ b/cpp/src/Ice/HttpParser.h
@@ -16,7 +16,7 @@ namespace IceInternal
 {
     std::vector<unsigned char> calcSHA1(const std::vector<unsigned char>&);
 
-    typedef std::map<std::string, std::pair<std::string, std::string>> HeaderFields;
+    using HeaderFields = std::map<std::string, std::pair<std::string, std::string>>;
 
     class WebSocketException
     {

--- a/cpp/src/Ice/IPEndpointI.cpp
+++ b/cpp/src/Ice/IPEndpointI.cpp
@@ -456,7 +456,7 @@ IceInternal::EndpointHostResolver::resolve(
             vector<Address> addrs = getAddresses(host, port, _protocol, selType, _preferIPv6, false);
             if (!addrs.empty())
             {
-                response(endpoint->connectors(addrs, 0));
+                response(endpoint->connectors(addrs, nullptr));
                 return;
             }
         }
@@ -544,7 +544,7 @@ IceInternal::EndpointHostResolver::run()
             if (r.observer)
             {
                 r.observer->detach();
-                r.observer = 0;
+                r.observer = nullptr;
             }
 
             r.response(r.endpoint->connectors(addresses, networkProxy));

--- a/cpp/src/Ice/Initialize.cpp
+++ b/cpp/src/Ice/Initialize.cpp
@@ -91,7 +91,7 @@ Ice::stringSeqToArgs(const StringSeq& args, int& argc, const char* argv[])
     //
     if (argv && argcOrig != argc)
     {
-        argv[argc] = 0;
+        argv[argc] = nullptr;
     }
 }
 
@@ -262,7 +262,7 @@ Ice::initialize(const InitializationData& initData)
 
     CommunicatorPtr communicator = Communicator::create(initData);
     int argc = 0;
-    const char* argv[] = {0};
+    const char* argv[] = {nullptr};
     communicator->finishSetup(argc, argv);
     return communicator;
 }

--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -80,7 +80,7 @@ namespace
 {
     mutex staticMutex;
     bool oneOffDone = false;
-    std::list<IceInternal::Instance*>* instanceList = 0;
+    std::list<IceInternal::Instance*>* instanceList = nullptr;
 
 #ifndef _WIN32
     struct sigaction oldAction;
@@ -93,7 +93,7 @@ namespace
     //
     size_t instanceCount()
     {
-        if (instanceList == 0)
+        if (instanceList == nullptr)
         {
             return 0;
         }
@@ -168,7 +168,7 @@ namespace
                 }
 
                 delete instanceList;
-                instanceList = 0;
+                instanceList = nullptr;
             }
         }
     };
@@ -188,8 +188,8 @@ namespace IceInternal // Required because ObserverUpdaterI is a friend of Instan
     public:
         ObserverUpdaterI(const InstancePtr&);
 
-        virtual void updateConnectionObservers();
-        virtual void updateThreadObservers();
+        void updateConnectionObservers() override;
+        void updateThreadObservers() override;
 
     private:
         const InstancePtr _instance;
@@ -751,7 +751,7 @@ IceInternal::Instance::addAdminFacet(ObjectPtr servant, string facet)
         throw CommunicatorDestroyedException(__FILE__, __LINE__);
     }
 
-    if (_adminAdapter == 0 || (!_adminFacetFilter.empty() && _adminFacetFilter.find(facet) == _adminFacetFilter.end()))
+    if (_adminAdapter == nullptr || (!_adminFacetFilter.empty() && _adminFacetFilter.find(facet) == _adminFacetFilter.end()))
     {
         if (_adminFacets.insert(FacetMap::value_type(facet, servant)).second == false)
         {
@@ -776,7 +776,7 @@ IceInternal::Instance::removeAdminFacet(string_view facet)
 
     ObjectPtr result;
 
-    if (_adminAdapter == 0 || (!_adminFacetFilter.empty() && _adminFacetFilter.find(facet) == _adminFacetFilter.end()))
+    if (_adminAdapter == nullptr || (!_adminFacetFilter.empty() && _adminFacetFilter.find(facet) == _adminFacetFilter.end()))
     {
         FacetMap::iterator p = _adminFacets.find(facet);
         if (p == _adminFacets.end())
@@ -959,7 +959,7 @@ IceInternal::Instance::initialize(const Ice::CommunicatorPtr& communicator)
                 if (stdOutFilename != "")
                 {
                     FILE* file = IceInternal::freopen(stdOutFilename, "a", stdout);
-                    if (file == 0)
+                    if (file == nullptr)
                     {
                         throw FileException(__FILE__, __LINE__, stdOutFilename);
                     }
@@ -968,7 +968,7 @@ IceInternal::Instance::initialize(const Ice::CommunicatorPtr& communicator)
                 if (stdErrFilename != "")
                 {
                     FILE* file = IceInternal::freopen(stdErrFilename, "a", stderr);
-                    if (file == 0)
+                    if (file == nullptr)
                     {
                         throw FileException(__FILE__, __LINE__, stdErrFilename);
                     }
@@ -1319,7 +1319,7 @@ IceInternal::Instance::~Instance()
     assert(!_pluginManager);
 
     lock_guard lock(staticMutex);
-    if (instanceList != 0)
+    if (instanceList != nullptr)
     {
         instanceList->remove(this);
     }
@@ -1330,7 +1330,7 @@ IceInternal::Instance::~Instance()
 #endif
 
 #ifndef _WIN32
-        sigaction(SIGPIPE, &oldAction, 0);
+        sigaction(SIGPIPE, &oldAction, nullptr);
 
         if (!identForOpenlog.empty())
         {
@@ -1617,7 +1617,7 @@ IceInternal::Instance::destroy()
         {
             observer->destroy(); // Break cyclic reference counts. Don't clear _observer, it's immutable.
         }
-        _initData.observer->setObserverUpdater(0); // Break cyclic reference count.
+        _initData.observer->setObserverUpdater(nullptr); // Break cyclic reference count.
     }
 
 #if defined(ICE_USE_SCHANNEL)

--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -751,7 +751,8 @@ IceInternal::Instance::addAdminFacet(ObjectPtr servant, string facet)
         throw CommunicatorDestroyedException(__FILE__, __LINE__);
     }
 
-    if (_adminAdapter == nullptr || (!_adminFacetFilter.empty() && _adminFacetFilter.find(facet) == _adminFacetFilter.end()))
+    if (_adminAdapter == nullptr ||
+        (!_adminFacetFilter.empty() && _adminFacetFilter.find(facet) == _adminFacetFilter.end()))
     {
         if (_adminFacets.insert(FacetMap::value_type(facet, servant)).second == false)
         {
@@ -776,7 +777,8 @@ IceInternal::Instance::removeAdminFacet(string_view facet)
 
     ObjectPtr result;
 
-    if (_adminAdapter == nullptr || (!_adminFacetFilter.empty() && _adminFacetFilter.find(facet) == _adminFacetFilter.end()))
+    if (_adminAdapter == nullptr ||
+        (!_adminFacetFilter.empty() && _adminFacetFilter.find(facet) == _adminFacetFilter.end()))
     {
         FacetMap::iterator p = _adminFacets.find(facet);
         if (p == _adminFacets.end())

--- a/cpp/src/Ice/InstrumentationI.cpp
+++ b/cpp/src/Ice/InstrumentationI.cpp
@@ -25,7 +25,7 @@ namespace
         switch (s)
         {
             case ThreadState::ThreadStateIdle:
-                return 0;
+                return nullptr;
             case ThreadState::ThreadStateInUseForIO:
                 return &ThreadMetrics::inUseForIO;
             case ThreadState::ThreadStateInUseForUser:
@@ -34,7 +34,7 @@ namespace
                 return &ThreadMetrics::inUseForOther;
             default:
                 assert(false);
-                return 0;
+                return nullptr;
         }
     }
 
@@ -94,7 +94,7 @@ namespace
         {
         }
 
-        virtual string operator()(const string& attribute) const { return attributes(this, attribute); }
+        string operator()(const string& attribute) const override { return attributes(this, attribute); }
 
         const string& getId() const
         {
@@ -203,9 +203,9 @@ namespace
 
         DispatchHelper(const Current& current, int size) : _current(current), _size(size) {}
 
-        virtual string operator()(const string& attribute) const { return attributes(this, attribute); }
+        string operator()(const string& attribute) const override { return attributes(this, attribute); }
 
-        virtual void initMetrics(const DispatchMetricsPtr& v) const { v->size += _size; }
+        void initMetrics(const DispatchMetricsPtr& v) const override { v->size += _size; }
 
         string resolve(const string& attribute) const
         {
@@ -245,7 +245,7 @@ namespace
             {
                 return _current.con->getInfo();
             }
-            return 0;
+            return nullptr;
         }
 
         EndpointPtr getEndpoint() const
@@ -254,7 +254,7 @@ namespace
             {
                 return _current.con->getEndpoint();
             }
-            return 0;
+            return nullptr;
         }
 
         const ConnectionPtr& getConnection() const { return _current.con; }
@@ -322,7 +322,7 @@ namespace
             throw invalid_argument(attribute);
         }
 
-        virtual string operator()(const string& attribute) const { return attributes(this, attribute); }
+        string operator()(const string& attribute) const override { return attributes(this, attribute); }
 
         string getMode() const
         {
@@ -435,9 +435,9 @@ namespace
         {
         }
 
-        virtual string operator()(const string& attribute) const { return attributes(this, attribute); }
+        string operator()(const string& attribute) const override { return attributes(this, attribute); }
 
-        virtual void initMetrics(const RemoteMetricsPtr& v) const { v->size += _size; }
+        void initMetrics(const RemoteMetricsPtr& v) const override { v->size += _size; }
 
         const string& getId() const
         {
@@ -518,9 +518,9 @@ namespace
         {
         }
 
-        virtual string operator()(const string& attribute) const { return attributes(this, attribute); }
+        string operator()(const string& attribute) const override { return attributes(this, attribute); }
 
-        virtual void initMetrics(const CollocatedMetricsPtr& v) const { v->size += _size; }
+        void initMetrics(const CollocatedMetricsPtr& v) const override { v->size += _size; }
 
         const string& getId() const { return _id; }
 
@@ -561,9 +561,9 @@ namespace
         {
         }
 
-        virtual string operator()(const string& attribute) const { return attributes(this, attribute); }
+        string operator()(const string& attribute) const override { return attributes(this, attribute); }
 
-        virtual void initMetrics(const ThreadMetricsPtr& v) const
+        void initMetrics(const ThreadMetricsPtr& v) const override
         {
             if (_state != ThreadState::ThreadStateIdle)
             {
@@ -598,7 +598,7 @@ namespace
 
         EndpointHelper(const EndpointPtr& endpt) : _endpoint(endpt) {}
 
-        virtual string operator()(const string& attribute) const { return attributes(this, attribute); }
+        string operator()(const string& attribute) const override { return attributes(this, attribute); }
 
         const EndpointInfoPtr& getEndpointInfo() const
         {

--- a/cpp/src/Ice/InstrumentationI.h
+++ b/cpp/src/Ice/InstrumentationI.h
@@ -15,9 +15,9 @@ namespace IceInternal
     template<typename T, typename O> class ObserverWithDelegateT : public IceMX::ObserverT<T>, public virtual O
     {
     public:
-        typedef O ObserverType;
-        typedef typename std::shared_ptr<O> ObserverPtrType;
-        virtual void attach()
+        using ObserverType = O;
+        using ObserverPtrType = typename std::shared_ptr<O>;
+        void attach() override
         {
             IceMX::ObserverT<T>::attach();
             if (_delegate)
@@ -26,7 +26,7 @@ namespace IceInternal
             }
         }
 
-        virtual void detach()
+        void detach() override
         {
             IceMX::ObserverT<T>::detach();
             if (_delegate)
@@ -35,7 +35,7 @@ namespace IceInternal
             }
         }
 
-        virtual void failed(const std::string& exceptionName)
+        void failed(const std::string& exceptionName) override
         {
             IceMX::ObserverT<T>::failed(exceptionName);
             if (_delegate)
@@ -140,83 +140,83 @@ namespace IceInternal
         : public ObserverWithDelegateT<IceMX::ConnectionMetrics, Ice::Instrumentation::ConnectionObserver>
     {
     public:
-        virtual void sentBytes(std::int32_t);
-        virtual void receivedBytes(std::int32_t);
+        void sentBytes(std::int32_t) override;
+        void receivedBytes(std::int32_t) override;
     };
 
     class ThreadObserverI : public ObserverWithDelegateT<IceMX::ThreadMetrics, Ice::Instrumentation::ThreadObserver>
     {
     public:
-        virtual void stateChanged(Ice::Instrumentation::ThreadState, Ice::Instrumentation::ThreadState);
+        void stateChanged(Ice::Instrumentation::ThreadState, Ice::Instrumentation::ThreadState) override;
     };
 
     class DispatchObserverI
         : public ObserverWithDelegateT<IceMX::DispatchMetrics, Ice::Instrumentation::DispatchObserver>
     {
     public:
-        virtual void userException();
+        void userException() override;
 
-        virtual void reply(std::int32_t);
+        void reply(std::int32_t) override;
     };
 
     class RemoteObserverI : public ObserverWithDelegateT<IceMX::RemoteMetrics, Ice::Instrumentation::RemoteObserver>
     {
     public:
-        virtual void reply(std::int32_t);
+        void reply(std::int32_t) override;
     };
 
     class CollocatedObserverI
         : public ObserverWithDelegateT<IceMX::CollocatedMetrics, Ice::Instrumentation::CollocatedObserver>
     {
     public:
-        virtual void reply(std::int32_t);
+        void reply(std::int32_t) override;
     };
 
     class InvocationObserverI
         : public ObserverWithDelegateT<IceMX::InvocationMetrics, Ice::Instrumentation::InvocationObserver>
     {
     public:
-        virtual void retried();
+        void retried() override;
 
-        virtual void userException();
+        void userException() override;
 
-        virtual Ice::Instrumentation::RemoteObserverPtr
-        getRemoteObserver(const Ice::ConnectionInfoPtr&, const Ice::EndpointPtr&, std::int32_t, std::int32_t);
+        Ice::Instrumentation::RemoteObserverPtr
+        getRemoteObserver(const Ice::ConnectionInfoPtr&, const Ice::EndpointPtr&, std::int32_t, std::int32_t) override;
 
-        virtual Ice::Instrumentation::CollocatedObserverPtr
-        getCollocatedObserver(const Ice::ObjectAdapterPtr&, std::int32_t, std::int32_t);
+        Ice::Instrumentation::CollocatedObserverPtr
+        getCollocatedObserver(const Ice::ObjectAdapterPtr&, std::int32_t, std::int32_t) override;
     };
 
-    typedef ObserverWithDelegateT<IceMX::Metrics, Ice::Instrumentation::Observer> ObserverI;
+    using ObserverI = ObserverWithDelegateT<IceMX::Metrics, Ice::Instrumentation::Observer>;
 
     class ICE_API CommunicatorObserverI : public Ice::Instrumentation::CommunicatorObserver
     {
     public:
         CommunicatorObserverI(const Ice::InitializationData&);
 
-        virtual void setObserverUpdater(const Ice::Instrumentation::ObserverUpdaterPtr&);
+        void setObserverUpdater(const Ice::Instrumentation::ObserverUpdaterPtr&) override;
 
-        virtual Ice::Instrumentation::ObserverPtr
-        getConnectionEstablishmentObserver(const Ice::EndpointPtr&, const std::string&);
+        Ice::Instrumentation::ObserverPtr
+        getConnectionEstablishmentObserver(const Ice::EndpointPtr&, const std::string&) override;
 
-        virtual Ice::Instrumentation::ObserverPtr getEndpointLookupObserver(const Ice::EndpointPtr&);
+        Ice::Instrumentation::ObserverPtr getEndpointLookupObserver(const Ice::EndpointPtr&) override;
 
-        virtual Ice::Instrumentation::ConnectionObserverPtr getConnectionObserver(
+        Ice::Instrumentation::ConnectionObserverPtr getConnectionObserver(
             const Ice::ConnectionInfoPtr&,
             const Ice::EndpointPtr&,
             Ice::Instrumentation::ConnectionState,
-            const Ice::Instrumentation::ConnectionObserverPtr&);
+            const Ice::Instrumentation::ConnectionObserverPtr&) override;
 
-        virtual Ice::Instrumentation::ThreadObserverPtr getThreadObserver(
+        Ice::Instrumentation::ThreadObserverPtr getThreadObserver(
             const std::string&,
             const std::string&,
             Ice::Instrumentation::ThreadState,
-            const Ice::Instrumentation::ThreadObserverPtr&);
+            const Ice::Instrumentation::ThreadObserverPtr&) override;
 
-        virtual Ice::Instrumentation::InvocationObserverPtr
-        getInvocationObserver(const std::optional<Ice::ObjectPrx>&, std::string_view, const Ice::Context&);
+        Ice::Instrumentation::InvocationObserverPtr
+        getInvocationObserver(const std::optional<Ice::ObjectPrx>&, std::string_view, const Ice::Context&) override;
 
-        virtual Ice::Instrumentation::DispatchObserverPtr getDispatchObserver(const Ice::Current&, std::int32_t);
+        Ice::Instrumentation::DispatchObserverPtr getDispatchObserver(const Ice::Current&, std::int32_t) override;
 
         const IceInternal::MetricsAdminIPtr& getFacet() const;
 

--- a/cpp/src/Ice/LocatorInfo.cpp
+++ b/cpp/src/Ice/LocatorInfo.cpp
@@ -32,7 +32,7 @@ namespace
             assert(ref->isWellKnown());
         }
 
-        virtual void send()
+        void send() override
         {
             try
             {
@@ -58,7 +58,7 @@ namespace
             assert(ref->isIndirect() && !ref->isWellKnown());
         }
 
-        virtual void send()
+        void send() override
         {
             try
             {
@@ -260,7 +260,7 @@ IceInternal::LocatorTable::removeObjectReference(const Identity& id)
     auto p = _objectMap.find(id);
     if (p == _objectMap.end())
     {
-        return 0;
+        return nullptr;
     }
 
     ReferencePtr ref = p->second.second;
@@ -522,7 +522,7 @@ IceInternal::LocatorInfo::getEndpoints(
         {
             if (_background && !endpoints.empty())
             {
-                getAdapterRequest(ref)->addCallback(ref, wellKnownRef, ttl, 0);
+                getAdapterRequest(ref)->addCallback(ref, wellKnownRef, ttl, nullptr);
             }
             else
             {
@@ -538,11 +538,11 @@ IceInternal::LocatorInfo::getEndpoints(
         {
             if (_background && r)
             {
-                getObjectRequest(ref)->addCallback(ref, 0, ttl, 0);
+                getObjectRequest(ref)->addCallback(ref, nullptr, ttl, nullptr);
             }
             else
             {
-                getObjectRequest(ref)->addCallback(ref, 0, ttl, callback);
+                getObjectRequest(ref)->addCallback(ref, nullptr, ttl, callback);
                 return;
             }
         }

--- a/cpp/src/Ice/LocatorInfo.h
+++ b/cpp/src/Ice/LocatorInfo.h
@@ -135,7 +135,7 @@ namespace IceInternal
 
         void getEndpoints(const ReferencePtr& ref, std::chrono::milliseconds ttl, const GetEndpointsCallbackPtr& cb)
         {
-            getEndpoints(ref, 0, ttl, cb);
+            getEndpoints(ref, nullptr, ttl, cb);
         }
         void getEndpoints(
             const ReferencePtr&,

--- a/cpp/src/Ice/LoggerAdminI.cpp
+++ b/cpp/src/Ice/LoggerAdminI.cpp
@@ -28,12 +28,12 @@ namespace
     public:
         LoggerAdminI(const PropertiesPtr&);
 
-        virtual void
-        attachRemoteLogger(optional<RemoteLoggerPrx>, LogMessageTypeSeq, StringSeq, int32_t, const Current&);
+        void
+        attachRemoteLogger(optional<RemoteLoggerPrx>, LogMessageTypeSeq, StringSeq, int32_t, const Current&) override;
 
-        virtual bool detachRemoteLogger(optional<RemoteLoggerPrx>, const Current&);
+        bool detachRemoteLogger(optional<RemoteLoggerPrx>, const Current&) override;
 
-        virtual LogMessageSeq getLog(LogMessageTypeSeq, StringSeq, int32_t, string&, const Current&);
+        LogMessageSeq getLog(LogMessageTypeSeq, StringSeq, int32_t, string&, const Current&) override;
 
         void destroy();
 
@@ -77,7 +77,7 @@ namespace
             const set<string> traceCategories;
         };
 
-        typedef map<RemoteLoggerPrx, Filters, ObjectIdentityCompare> RemoteLoggerMap;
+        using RemoteLoggerMap = map<RemoteLoggerPrx, Filters, ObjectIdentityCompare>;
 
         struct GetRemoteLoggerMapKey
         {
@@ -113,7 +113,7 @@ namespace
         std::string getPrefix() final;
         LoggerPtr cloneWithPrefix(std::string) final;
 
-        ObjectPtr getFacet() const;
+        ObjectPtr getFacet() const override;
         void destroy() final;
 
         const LoggerPtr& getLocalLogger() const { return _localLogger; }
@@ -422,7 +422,7 @@ namespace
             {
                 _destroyed = true;
                 sendLogCommunicator = _sendLogCommunicator;
-                _sendLogCommunicator = 0;
+                _sendLogCommunicator = nullptr;
             }
         }
 

--- a/cpp/src/Ice/LoggerI.h
+++ b/cpp/src/Ice/LoggerI.h
@@ -16,7 +16,7 @@ namespace Ice
     {
     public:
         LoggerI(std::string prefix, std::string file, bool convert = true, std::size_t sizeMax = 0);
-        ~LoggerI();
+        ~LoggerI() override;
 
         void print(const std::string&) final;
         void trace(const std::string& category, const std::string& message) final;

--- a/cpp/src/Ice/LoggerUtil.cpp
+++ b/cpp/src/Ice/LoggerUtil.cpp
@@ -54,12 +54,12 @@ Ice::Trace::flush()
 
 Ice::LoggerPlugin::LoggerPlugin(const CommunicatorPtr& communicator, const LoggerPtr& logger)
 {
-    if (communicator == 0)
+    if (communicator == nullptr)
     {
         throw PluginInitializationException(__FILE__, __LINE__, "communicator cannot be null");
     }
 
-    if (logger == 0)
+    if (logger == nullptr)
     {
         throw PluginInitializationException(__FILE__, __LINE__, "logger cannot be null");
     }

--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -203,7 +203,7 @@ namespace
 
         struct ifaddrs* curr = ifap;
         set<string> interfaces;
-        while (curr != 0)
+        while (curr != nullptr)
         {
             if (curr->ifa_addr && (includeLoopback || !(curr->ifa_flags & IFF_LOOPBACK)))
             {
@@ -494,7 +494,7 @@ namespace
             if (::getifaddrs(&ifap) != SOCKET_ERROR)
             {
                 struct ifaddrs* curr = ifap;
-                while (curr != 0)
+                while (curr != nullptr)
                 {
                     if (curr->ifa_addr && curr->ifa_addr->sa_family == AF_INET6)
                     {
@@ -797,7 +797,7 @@ IceInternal::getAddresses(
     Address addr;
     memset(&addr.saStorage, 0, sizeof(sockaddr_storage));
 
-    struct addrinfo* info = 0;
+    struct addrinfo* info = nullptr;
     int retry = 5;
 
     struct addrinfo hints = {};
@@ -822,8 +822,8 @@ IceInternal::getAddresses(
     int rs = 0;
     do
     {
-        rs = getaddrinfo(host.c_str(), 0, &hints, &info);
-    } while (info == 0 && rs == EAI_AGAIN && --retry >= 0);
+        rs = getaddrinfo(host.c_str(), nullptr, &hints, &info);
+    } while (info == nullptr && rs == EAI_AGAIN && --retry >= 0);
 
     // In theory, getaddrinfo should only return EAI_NONAME if
     // AI_NUMERICHOST is specified and the host name is not a IP
@@ -1284,7 +1284,7 @@ IceInternal::inetAddrToString(const Address& ss)
         static_cast<socklen_t>(size),
         namebuf,
         static_cast<socklen_t>(sizeof(namebuf)),
-        0,
+        nullptr,
         0,
         NI_NUMERICHOST);
     return string(namebuf);
@@ -1912,7 +1912,7 @@ IceInternal::doAccept(SOCKET fd)
 #endif
 
 repeatAccept:
-    if ((ret = ::accept(fd, 0, 0)) == INVALID_SOCKET)
+    if ((ret = ::accept(fd, nullptr, nullptr)) == INVALID_SOCKET)
     {
         if (acceptInterrupted())
         {

--- a/cpp/src/Ice/ObjectAdapterFactory.cpp
+++ b/cpp/src/Ice/ObjectAdapterFactory.cpp
@@ -72,7 +72,7 @@ IceInternal::ObjectAdapterFactory::isShutdown() const
 {
     lock_guard lock(_mutex);
 
-    return _instance == 0;
+    return _instance == nullptr;
 }
 
 void

--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -1156,7 +1156,7 @@ Ice::ObjectAdapterI::parseEndpoints(string_view endpts, bool oaEndpoints) const
 
         string_view s = endpts.substr(beg, end - beg);
         EndpointIPtr endp = _instance->endpointFactoryManager()->create(s, oaEndpoints);
-        if (endp == 0)
+        if (endp == nullptr)
         {
             throw ParseException(__FILE__, __LINE__, "invalid object adapter endpoint '" + string{s} + "'");
         }

--- a/cpp/src/Ice/ObjectAdapterI.h
+++ b/cpp/src/Ice/ObjectAdapterI.h
@@ -44,7 +44,7 @@ namespace Ice
         void activate() final;
         void hold() final;
         void waitForHold() final;
-        void deactivate() noexcept;
+        void deactivate() noexcept override;
         void waitForDeactivate() noexcept final;
         bool isDeactivated() const noexcept final;
         void destroy() noexcept final;
@@ -76,10 +76,10 @@ namespace Ice
         ObjectPrx _createIndirectProxy(Identity) const final;
 
         void setLocator(std::optional<LocatorPrx>) final;
-        std::optional<LocatorPrx> getLocator() const noexcept;
-        EndpointSeq getEndpoints() const noexcept;
+        std::optional<LocatorPrx> getLocator() const noexcept override;
+        EndpointSeq getEndpoints() const noexcept override;
 
-        EndpointSeq getPublishedEndpoints() const noexcept;
+        EndpointSeq getPublishedEndpoints() const noexcept override;
         void setPublishedEndpoints(EndpointSeq) final;
 
         bool isLocal(const IceInternal::ReferencePtr&) const;
@@ -103,7 +103,7 @@ namespace Ice
             std::string name,
             bool,
             std::optional<SSL::ServerAuthenticationOptions>);
-        virtual ~ObjectAdapterI();
+        ~ObjectAdapterI() override;
 
         const std::optional<SSL::ServerAuthenticationOptions>& serverAuthenticationOptions() const noexcept
         {

--- a/cpp/src/Ice/Options.h
+++ b/cpp/src/Ice/Options.h
@@ -53,7 +53,7 @@ namespace IceInternal
         void
         addOpt(const std::string&, const std::string& = "", ArgType = NoArg, std::string = "", RepeatType = NoRepeat);
 
-        typedef std::vector<std::string> StringVector;
+        using StringVector = std::vector<std::string>;
 
         static StringVector split(const std::string&);
         StringVector parse(const StringVector&);
@@ -84,10 +84,10 @@ namespace IceInternal
         };
         using OVecPtr = std::shared_ptr<OptionValueVector>;
 
-        typedef std::map<std::string, ODPtr> ValidOpts;      // Valid options and their details.
-        typedef std::map<std::string, OValPtr> Opts;         // Value of non-repeating options.
-        typedef std::map<std::string, OVecPtr> ROpts;        // Value of repeating options.
-        typedef std::map<std::string, std::string> Synonyms; // Map from short to long option and vice versa.
+        using ValidOpts = std::map<std::string, ODPtr>;      // Valid options and their details.
+        using Opts = std::map<std::string, OValPtr>;         // Value of non-repeating options.
+        using ROpts = std::map<std::string, OVecPtr>;        // Value of repeating options.
+        using Synonyms = std::map<std::string, std::string>; // Map from short to long option and vice versa.
 
         void addValidOpt(const std::string&, const std::string&, ArgType, const std::string&, RepeatType);
         ValidOpts::iterator checkOpt(const std::string&, LengthType);

--- a/cpp/src/Ice/OutgoingAsync.cpp
+++ b/cpp/src/Ice/OutgoingAsync.cpp
@@ -218,7 +218,7 @@ OutgoingAsyncBase::sentImpl(bool done)
     {
         _doneInSent = true;
         _childObserver.detach();
-        _cancellationHandler = 0;
+        _cancellationHandler = nullptr;
     }
 
     bool invoke = handleSent(done, alreadySent);
@@ -239,7 +239,7 @@ OutgoingAsyncBase::exceptionImpl(std::exception_ptr ex)
         _childObserver.failed(getExceptionId(ex));
         _childObserver.detach();
     }
-    _cancellationHandler = 0;
+    _cancellationHandler = nullptr;
     _observer.failed(getExceptionId(ex));
 
     bool invoke = handleException(ex);
@@ -259,7 +259,7 @@ OutgoingAsyncBase::responseImpl(bool ok, bool invoke)
         _state |= OK;
     }
 
-    _cancellationHandler = 0;
+    _cancellationHandler = nullptr;
 
     try
     {
@@ -824,7 +824,7 @@ OutgoingAsync::prepare(string_view operation, OperationMode mode, const Context&
     //
     if (ref->getFacet().empty())
     {
-        _os.write(static_cast<string*>(0), static_cast<string*>(0));
+        _os.write(static_cast<string*>(nullptr), static_cast<string*>(nullptr));
     }
     else
     {

--- a/cpp/src/Ice/OutputUtil.h
+++ b/cpp/src/Ice/OutputUtil.h
@@ -86,7 +86,7 @@ namespace IceInternal
         Output(std::ostream&, bool = true, bool = false);
         Output(const char*, bool = true, bool = false);
 
-        virtual void print(const std::string&); // Print a string.
+        void print(const std::string&) override; // Print a string.
 
         void sb(); // Start a block.
         void eb(); // End a block.

--- a/cpp/src/Ice/PluginManagerI.cpp
+++ b/cpp/src/Ice/PluginManagerI.cpp
@@ -207,7 +207,7 @@ Ice::PluginManagerI::destroy() noexcept
             }
         }
 
-        _communicator = 0;
+        _communicator = nullptr;
     }
 
     _plugins.clear();
@@ -349,7 +349,7 @@ Ice::PluginManagerI::loadPlugin(const string& name, const string& pluginSpec, St
         cmdArgs = properties->parseCommandLineOptions(name, cmdArgs);
     }
 
-    PluginFactory factory = 0;
+    PluginFactory factory = nullptr;
 
     //
     // Always check the static plugin factory table first, it takes
@@ -374,7 +374,7 @@ Ice::PluginManagerI::loadPlugin(const string& name, const string& pluginSpec, St
         assert(!entryPoint.empty());
         DynamicLibrary library;
         DynamicLibrary::symbol_type sym = library.loadEntryPoint(entryPoint);
-        if (sym == 0)
+        if (sym == nullptr)
         {
             ostringstream os;
             string msg = library.getErrorMessage();

--- a/cpp/src/Ice/PluginManagerI.h
+++ b/cpp/src/Ice/PluginManagerI.h
@@ -15,7 +15,7 @@
 
 namespace Ice
 {
-    typedef Ice::Plugin* (*PluginFactory)(const Ice::CommunicatorPtr&, const std::string&, const Ice::StringSeq&);
+    using PluginFactory = Ice::Plugin *(*)(const Ice::CommunicatorPtr &, const std::string &, const Ice::StringSeq &);
 
     class PluginManagerI final : public PluginManager
     {
@@ -46,7 +46,7 @@ namespace Ice
             std::string name;
             PluginPtr plugin;
         };
-        typedef std::vector<PluginInfo> PluginInfoList;
+        using PluginInfoList = std::vector<PluginInfo>;
 
         CommunicatorPtr _communicator;
         PluginInfoList _plugins;

--- a/cpp/src/Ice/PluginManagerI.h
+++ b/cpp/src/Ice/PluginManagerI.h
@@ -15,7 +15,7 @@
 
 namespace Ice
 {
-    using PluginFactory = Ice::Plugin *(*)(const Ice::CommunicatorPtr &, const std::string &, const Ice::StringSeq &);
+    using PluginFactory = Ice::Plugin* (*)(const Ice::CommunicatorPtr&, const std::string&, const Ice::StringSeq&);
 
     class PluginManagerI final : public PluginManager
     {

--- a/cpp/src/Ice/Properties.cpp
+++ b/cpp/src/Ice/Properties.cpp
@@ -129,7 +129,7 @@ Ice::Properties::Properties(StringSeq& args, const PropertiesPtr& defaults)
             {
                 s += "=1";
             }
-            if (auto optionPair = parseLine(s.substr(2), 0))
+            if (auto optionPair = parseLine(s.substr(2), nullptr))
             {
                 auto [key, value] = *optionPair;
                 setProperty(key, value);
@@ -597,7 +597,7 @@ Ice::Properties::parseOptions(string_view prefix, const StringSeq& options)
                 opt += "=1";
             }
 
-            if (auto optionPair = parseLine(opt.substr(2), 0))
+            if (auto optionPair = parseLine(opt.substr(2), nullptr))
             {
                 matched.insert_or_assign(std::move(optionPair->first), std::move(optionPair->second));
             }

--- a/cpp/src/Ice/ProxyAsync.cpp
+++ b/cpp/src/Ice/ProxyAsync.cpp
@@ -39,8 +39,8 @@ namespace IceInternal
     public:
         ProxyFlushBatchAsync(Ice::ObjectPrx);
 
-        virtual AsyncStatus invokeRemote(const Ice::ConnectionIPtr&, bool, bool);
-        virtual AsyncStatus invokeCollocated(CollocatedRequestHandler*);
+        AsyncStatus invokeRemote(const Ice::ConnectionIPtr&, bool, bool) override;
+        AsyncStatus invokeCollocated(CollocatedRequestHandler*) override;
 
         void invoke(string_view operation);
 
@@ -56,8 +56,8 @@ namespace IceInternal
     public:
         ProxyGetConnection(Ice::ObjectPrx);
 
-        virtual AsyncStatus invokeRemote(const Ice::ConnectionIPtr&, bool, bool);
-        virtual AsyncStatus invokeCollocated(CollocatedRequestHandler*);
+        AsyncStatus invokeRemote(const Ice::ConnectionIPtr&, bool, bool) override;
+        AsyncStatus invokeCollocated(CollocatedRequestHandler*) override;
 
         virtual Ice::ConnectionPtr getConnection() const;
 

--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -142,7 +142,7 @@ IceInternal::Reference::streamWrite(OutputStream* s) const
     //
     if (_facet.empty())
     {
-        s->write(static_cast<string*>(0), static_cast<string*>(0));
+        s->write(static_cast<string*>(nullptr), static_cast<string*>(nullptr));
     }
     else
     {

--- a/cpp/src/Ice/RetryQueue.h
+++ b/cpp/src/Ice/RetryQueue.h
@@ -25,9 +25,9 @@ namespace IceInternal
     public:
         RetryTask(const InstancePtr&, const RetryQueuePtr&, const ProxyOutgoingAsyncBasePtr&);
 
-        virtual void runTimerTask();
+        void runTimerTask() override;
 
-        virtual void asyncRequestCanceled(const OutgoingAsyncBasePtr&, std::exception_ptr);
+        void asyncRequestCanceled(const OutgoingAsyncBasePtr&, std::exception_ptr) override;
 
         void destroy();
 

--- a/cpp/src/Ice/RouterInfo.cpp
+++ b/cpp/src/Ice/RouterInfo.cpp
@@ -93,7 +93,7 @@ IceInternal::RouterInfo::destroy()
     lock_guard lock(_mutex);
 
     _clientEndpoints.clear();
-    _adapter = 0;
+    _adapter = nullptr;
     _identities.clear();
 }
 

--- a/cpp/src/Ice/SSL/SSLAcceptorI.h
+++ b/cpp/src/Ice/SSL/SSLAcceptorI.h
@@ -25,7 +25,7 @@ namespace Ice::SSL
             const IceInternal::AcceptorPtr&,
             const std::string&,
             const std::optional<Ice::SSL::ServerAuthenticationOptions>&);
-        ~AcceptorI();
+        ~AcceptorI() override;
         IceInternal::NativeInfoPtr getNativeInfo() final;
 #if defined(ICE_USE_IOCP)
         IceInternal::AsyncInfo* getAsyncInfo(IceInternal::SocketOperation) final;

--- a/cpp/src/Ice/SSL/SSLConnectorI.h
+++ b/cpp/src/Ice/SSL/SSLConnectorI.h
@@ -19,7 +19,7 @@ namespace Ice::SSL
     {
     public:
         ConnectorI(const InstancePtr&, const IceInternal::ConnectorPtr&, const std::string&);
-        ~ConnectorI();
+        ~ConnectorI() override;
         IceInternal::TransceiverPtr connect() final;
 
         std::int16_t type() const final;

--- a/cpp/src/Ice/SSL/SSLUtil.cpp
+++ b/cpp/src/Ice/SSL/SSLUtil.cpp
@@ -68,7 +68,7 @@ Ice::SSL::parseBytes(const string& arg, vector<unsigned char>& buffer)
     // Convert the bytes.
     for (size_t i = 0, length = v.size(); i + 2 <= length;)
     {
-        buffer.push_back(static_cast<unsigned char>(strtol(v.substr(i, 2).c_str(), 0, 16)));
+        buffer.push_back(static_cast<unsigned char>(strtol(v.substr(i, 2).c_str(), nullptr, 16)));
         i += 2;
     }
     return true;

--- a/cpp/src/Ice/SSL/SecureTransportEngine.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportEngine.cpp
@@ -602,7 +602,7 @@ SecureTransport::SSLEngine::initialize()
         else if (properties->getIcePropertyAsInt("IceSSL.UsePlatformCAs") <= 0)
         {
             // Setup an empty list of Root CAs to not use the system root CAs.
-            _certificateAuthorities.reset(CFArrayCreate(0, 0, 0, 0));
+            _certificateAuthorities.reset(CFArrayCreate(nullptr, nullptr, 0, nullptr));
         }
     }
     catch (const CertificateReadException& ce)

--- a/cpp/src/Ice/SSL/SecureTransportTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportTransceiverI.cpp
@@ -343,7 +343,7 @@ Ice::SSL::SecureTransport::TransceiverI::write(IceInternal::Buffer& buf)
     while (buf.i != buf.b.end())
     {
         size_t processed = 0;
-        OSStatus err = _buffered ? SSLWrite(_ssl.get(), 0, 0, &processed)
+        OSStatus err = _buffered ? SSLWrite(_ssl.get(), nullptr, 0, &processed)
                                  : SSLWrite(_ssl.get(), reinterpret_cast<const void*>(buf.i), packetSize, &processed);
 
         if (err)

--- a/cpp/src/Ice/SSL/SecureTransportUtil.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportUtil.cpp
@@ -360,8 +360,11 @@ namespace
         if (err == noErr)
         {
             const char* pass = keychainPassword.empty() ? nullptr : keychainPassword.c_str();
-            if ((err =
-                     SecKeychainUnlock(keychain.get(), static_cast<UInt32>(keychainPassword.size()), pass, pass != nullptr)))
+            if ((err = SecKeychainUnlock(
+                     keychain.get(),
+                     static_cast<UInt32>(keychainPassword.size()),
+                     pass,
+                     pass != nullptr)))
             {
                 throw InitializationException(
                     __FILE__,

--- a/cpp/src/Ice/Selector.cpp
+++ b/cpp/src/Ice/Selector.cpp
@@ -209,7 +209,7 @@ Selector::Selector(const InstancePtr& instance) : _instance(instance), _interrup
 
     struct kevent ev;
     EV_SET(&ev, _fdIntrRead, EVFILT_READ, EV_ADD, 0, 0, 0);
-    int rs = kevent(_queueFd, &ev, 1, 0, 0, 0);
+    int rs = kevent(_queueFd, &ev, 1, nullptr, 0, nullptr);
     if (rs < 0)
     {
         Ice::Error out(_instance->initializationData().logger);

--- a/cpp/src/Ice/ServantManager.cpp
+++ b/cpp/src/Ice/ServantManager.cpp
@@ -209,7 +209,7 @@ IceInternal::ServantManager::findServant(const Identity& ident, const string_vie
             d = _defaultServantMap.find("");
             if (d == _defaultServantMap.end())
             {
-                return 0;
+                return nullptr;
             }
             else
             {
@@ -236,7 +236,7 @@ IceInternal::ServantManager::findDefaultServant(const string_view category) cons
     DefaultServantMap::const_iterator p = _defaultServantMap.find(category);
     if (p == _defaultServantMap.end())
     {
-        return 0;
+        return nullptr;
     }
     else
     {
@@ -390,7 +390,7 @@ IceInternal::ServantManager::findServantLocator(const string_view category) cons
     }
     else
     {
-        return 0;
+        return nullptr;
     }
 }
 
@@ -440,7 +440,7 @@ IceInternal::ServantManager::destroy()
         locatorMap.swap(_locatorMap);
         _locatorMapHint = _locatorMap.end();
 
-        _instance = 0;
+        _instance = nullptr;
     }
 
     for (auto p = locatorMap.begin(); p != locatorMap.end(); ++p)

--- a/cpp/src/Ice/ServantManager.h
+++ b/cpp/src/Ice/ServantManager.h
@@ -26,7 +26,7 @@ namespace IceInternal
     {
     public:
         ServantManager(InstancePtr, std::string);
-        ~ServantManager();
+        ~ServantManager() override;
         void addServant(Ice::ObjectPtr, Ice::Identity, std::string);
         void addDefaultServant(Ice::ObjectPtr, std::string);
         Ice::ObjectPtr removeServant(const Ice::Identity&, std::string_view);

--- a/cpp/src/Ice/Service.cpp
+++ b/cpp/src/Ice/Service.cpp
@@ -25,8 +25,8 @@ using namespace std;
 using namespace Ice;
 using namespace IceInternal;
 
-Ice::Service* Ice::Service::_instance = 0;
-static CtrlCHandler* _ctrlCHandler = 0;
+Ice::Service* Ice::Service::_instance = nullptr;
+static CtrlCHandler* _ctrlCHandler = nullptr;
 
 //
 // Callback for CtrlCHandler.
@@ -35,7 +35,7 @@ static void
 ctrlCHandlerCallback(int sig)
 {
     Ice::Service* service = Ice::Service::instance();
-    assert(service != 0);
+    assert(service != nullptr);
     service->handleInterrupt(sig);
 }
 
@@ -415,7 +415,7 @@ namespace
 
 Ice::Service::Service()
 {
-    assert(_instance == 0);
+    assert(_instance == nullptr);
     _nohup = true;
     _service = false;
     _instance = this;
@@ -427,7 +427,7 @@ Ice::Service::Service()
 
 Ice::Service::~Service()
 {
-    _instance = 0;
+    _instance = nullptr;
     delete _ctrlCHandler;
 }
 
@@ -994,7 +994,7 @@ Ice::Service::enableInterrupt()
 void
 Ice::Service::disableInterrupt()
 {
-    _ctrlCHandler->setCallback(0);
+    _ctrlCHandler->setCallback(nullptr);
 }
 
 #ifdef _WIN32

--- a/cpp/src/Ice/StreamSocket.h
+++ b/cpp/src/Ice/StreamSocket.h
@@ -18,7 +18,7 @@ namespace IceInternal
     public:
         StreamSocket(const ProtocolInstancePtr&, const NetworkProxyPtr&, const Address&, const Address&);
         StreamSocket(const ProtocolInstancePtr&, SOCKET);
-        virtual ~StreamSocket();
+        ~StreamSocket() override;
 
         SocketOperation connect(Buffer&, Buffer&);
         bool isConnected();

--- a/cpp/src/Ice/StringConverter.cpp
+++ b/cpp/src/Ice/StringConverter.cpp
@@ -36,12 +36,12 @@ namespace
 
     template<> struct SelectCodeCvt<2>
     {
-        typedef std::codecvt_utf8_utf16<wchar_t> Type;
+        using Type = std::codecvt_utf8_utf16<wchar_t>;
     };
 
     template<> struct SelectCodeCvt<4>
     {
-        typedef std::codecvt_utf8<wchar_t> Type;
+        using Type = std::codecvt_utf8<wchar_t>;
     };
 
     class UnicodeWstringConverter final : public WstringConverter
@@ -63,9 +63,9 @@ namespace
                 return buffer.getMoreBytes(1, nullptr);
             }
 
-            char* targetStart = 0;
-            char* targetEnd = 0;
-            char* targetNext = 0;
+            char* targetStart = nullptr;
+            char* targetEnd = nullptr;
+            char* targetNext = nullptr;
 
             mbstate_t state = mbstate_t(); // must be initialized!
             const wchar_t* sourceNext = sourceStart;
@@ -169,7 +169,7 @@ namespace
         }
 
     private:
-        typedef SelectCodeCvt<sizeof(wchar_t)>::Type CodeCvt;
+        using CodeCvt = SelectCodeCvt<sizeof(wchar_t)>::Type;
         const CodeCvt _codecvt;
     };
 
@@ -355,8 +355,8 @@ Ice::UTF8ToNative(string_view str, const Ice::StringConverterPtr& converter)
     return tmp;
 }
 
-typedef char16_t Char16T;
-typedef char32_t Char32T;
+using Char16T = char16_t;
+using Char32T = char32_t;
 
 vector<unsigned short>
 IceInternal::toUTF16(const vector<uint8_t>& source)
@@ -366,7 +366,7 @@ IceInternal::toUTF16(const vector<uint8_t>& source)
     {
         assert(sizeof(Char16T) == sizeof(unsigned short));
 
-        typedef wstring_convert<codecvt_utf8_utf16<Char16T>, Char16T> Convert;
+        using Convert = wstring_convert<codecvt_utf8_utf16<Char16T>, Char16T>;
 
         Convert convert;
 
@@ -396,7 +396,7 @@ IceInternal::toUTF32(const vector<uint8_t>& source)
     {
         assert(sizeof(Char32T) == sizeof(unsigned int));
 
-        typedef wstring_convert<codecvt_utf8<Char32T>, Char32T> Convert;
+        using Convert = wstring_convert<codecvt_utf8<Char32T>, Char32T>;
         Convert convert;
 
         try
@@ -425,7 +425,7 @@ IceInternal::fromUTF32(const vector<unsigned int>& source)
     {
         assert(sizeof(Char32T) == sizeof(unsigned int));
 
-        typedef wstring_convert<codecvt_utf8<Char32T>, Char32T> Convert;
+        using Convert = wstring_convert<codecvt_utf8<Char32T>, Char32T>;
         Convert convert;
 
         try

--- a/cpp/src/Ice/SysLoggerI.h
+++ b/cpp/src/Ice/SysLoggerI.h
@@ -17,7 +17,7 @@ namespace Ice
     public:
         SysLoggerI(std::string prefix, std::string_view facilityString);
         SysLoggerI(std::string prefix, int facility);
-        ~SysLoggerI();
+        ~SysLoggerI() override;
 
         void print(const std::string&) final;
         void trace(const std::string&, const std::string&) final;

--- a/cpp/src/Ice/TcpAcceptor.h
+++ b/cpp/src/Ice/TcpAcceptor.h
@@ -18,7 +18,7 @@ namespace IceInternal
     {
     public:
         TcpAcceptor(const TcpEndpointIPtr&, const ProtocolInstancePtr&, const std::string&, int);
-        ~TcpAcceptor();
+        ~TcpAcceptor() override;
         NativeInfoPtr getNativeInfo() final;
 #if defined(ICE_USE_IOCP)
         AsyncInfo* getAsyncInfo(SocketOperation) final;

--- a/cpp/src/Ice/TcpConnector.h
+++ b/cpp/src/Ice/TcpConnector.h
@@ -22,7 +22,7 @@ namespace IceInternal
             const Address&,
             std::int32_t,
             const std::string&);
-        ~TcpConnector();
+        ~TcpConnector() override;
         TransceiverPtr connect() final;
 
         std::int16_t type() const final;

--- a/cpp/src/Ice/TcpEndpointI.h
+++ b/cpp/src/Ice/TcpEndpointI.h
@@ -71,7 +71,7 @@ namespace IceInternal
     {
     public:
         TcpEndpointFactory(const ProtocolInstancePtr&);
-        ~TcpEndpointFactory();
+        ~TcpEndpointFactory() override;
 
         std::int16_t type() const final;
         std::string protocol() const final;

--- a/cpp/src/Ice/ThreadPool.cpp
+++ b/cpp/src/Ice/ThreadPool.cpp
@@ -136,7 +136,7 @@ IceInternal::ThreadPoolWorkQueue::toString() const
 NativeInfoPtr
 IceInternal::ThreadPoolWorkQueue::getNativeInfo()
 {
-    return 0;
+    return nullptr;
 }
 
 ThreadPoolPtr
@@ -606,7 +606,7 @@ IceInternal::ThreadPool::run(const EventHandlerThreadPtr& thread)
             }
             else
             {
-                current._handler = 0;
+                current._handler = nullptr;
             }
 
             if (!current._handler)
@@ -1110,7 +1110,7 @@ IceInternal::ThreadPool::EventHandlerThread::run()
         }
     }
 
-    _pool = 0; // Break cyclic dependency.
+    _pool = nullptr; // Break cyclic dependency.
 }
 
 void

--- a/cpp/src/Ice/ThreadPool.h
+++ b/cpp/src/Ice/ThreadPool.h
@@ -177,10 +177,10 @@ namespace IceInternal
         bool finishAsync(SocketOperation);
 #endif
 
-        virtual void message(ThreadPoolCurrent&);
-        virtual void finished(ThreadPoolCurrent&, bool);
-        virtual std::string toString() const;
-        virtual NativeInfoPtr getNativeInfo();
+        void message(ThreadPoolCurrent&) override;
+        void finished(ThreadPoolCurrent&, bool) override;
+        std::string toString() const override;
+        NativeInfoPtr getNativeInfo() override;
 
     private:
         ThreadPool& _threadPool;

--- a/cpp/src/Ice/UdpConnector.h
+++ b/cpp/src/Ice/UdpConnector.h
@@ -23,7 +23,7 @@ namespace IceInternal
             int,
             const std::string&);
 
-        ~UdpConnector();
+        ~UdpConnector() override;
         TransceiverPtr connect() final;
 
         std::int16_t type() const final;

--- a/cpp/src/Ice/UdpEndpointI.cpp
+++ b/cpp/src/Ice/UdpEndpointI.cpp
@@ -164,7 +164,7 @@ IceInternal::UdpEndpointI::transceiver() const
 AcceptorPtr
 IceInternal::UdpEndpointI::acceptor(const string&, const optional<Ice::SSL::ServerAuthenticationOptions>&) const
 {
-    return 0;
+    return nullptr;
 }
 
 UdpEndpointIPtr

--- a/cpp/src/Ice/UdpEndpointI.h
+++ b/cpp/src/Ice/UdpEndpointI.h
@@ -77,7 +77,7 @@ namespace IceInternal
     {
     public:
         UdpEndpointFactory(const ProtocolInstancePtr&);
-        ~UdpEndpointFactory();
+        ~UdpEndpointFactory() override;
 
         std::int16_t type() const final;
         std::string protocol() const final;

--- a/cpp/src/Ice/WSAcceptor.h
+++ b/cpp/src/Ice/WSAcceptor.h
@@ -19,7 +19,7 @@ namespace IceInternal
     {
     public:
         WSAcceptor(const WSEndpointPtr&, const ProtocolInstancePtr&, const AcceptorPtr&);
-        ~WSAcceptor();
+        ~WSAcceptor() override;
         NativeInfoPtr getNativeInfo() final;
 #if defined(ICE_USE_IOCP)
         AsyncInfo* getAsyncInfo(SocketOperation) final;

--- a/cpp/src/Ice/WSConnector.h
+++ b/cpp/src/Ice/WSConnector.h
@@ -18,7 +18,7 @@ namespace IceInternal
     {
     public:
         WSConnector(const ProtocolInstancePtr&, const ConnectorPtr&, const std::string&, const std::string&);
-        ~WSConnector();
+        ~WSConnector() override;
         TransceiverPtr connect() final;
 
         std::int16_t type() const final;

--- a/cpp/src/Ice/WSEndpoint.cpp
+++ b/cpp/src/Ice/WSEndpoint.cpp
@@ -23,8 +23,8 @@ namespace
     {
     public:
         WSEndpointFactoryPlugin(const CommunicatorPtr&);
-        virtual void initialize();
-        virtual void destroy();
+        void initialize() override;
+        void destroy() override;
     };
 
     IPEndpointInfoPtr getIPEndpointInfo(const EndpointInfoPtr& info)
@@ -200,7 +200,7 @@ IceInternal::WSEndpoint::secure() const
 TransceiverPtr
 IceInternal::WSEndpoint::transceiver() const
 {
-    return 0;
+    return nullptr;
 }
 
 void

--- a/cpp/src/Ice/WSEndpoint.h
+++ b/cpp/src/Ice/WSEndpoint.h
@@ -59,7 +59,7 @@ namespace IceInternal
         bool operator<(const Ice::Endpoint&) const final;
 
     protected:
-        bool checkOption(const std::string&, const std::string&, const std::string&);
+        bool checkOption(const std::string&, const std::string&, const std::string&) override;
 
     private:
         //

--- a/cpp/src/IceBox/IceBoxService.cpp
+++ b/cpp/src/IceBox/IceBoxService.cpp
@@ -93,7 +93,7 @@ IceBox::IceBoxService::stop()
     if (_serviceManager)
     {
         _serviceManager->stop();
-        _serviceManager = 0;
+        _serviceManager = nullptr;
     }
     return true;
 }

--- a/cpp/src/IceBox/ServiceManagerI.cpp
+++ b/cpp/src/IceBox/ServiceManagerI.cpp
@@ -16,7 +16,7 @@ using namespace IceInternal;
 using namespace IceBox;
 using namespace std;
 
-using ServiceFactory = IceBox::Service *(*)(const CommunicatorPtr &);
+using ServiceFactory = IceBox::Service* (*)(const CommunicatorPtr&);
 
 namespace
 {

--- a/cpp/src/IceBox/ServiceManagerI.cpp
+++ b/cpp/src/IceBox/ServiceManagerI.cpp
@@ -16,7 +16,7 @@ using namespace IceInternal;
 using namespace IceBox;
 using namespace std;
 
-typedef IceBox::Service* (*ServiceFactory)(const CommunicatorPtr&);
+using ServiceFactory = IceBox::Service *(*)(const CommunicatorPtr &);
 
 namespace
 {
@@ -146,7 +146,7 @@ IceBox::ServiceManagerI::startService(string name, const Current&)
     bool started = false;
     try
     {
-        info.service->start(name, info.communicator == 0 ? _sharedCommunicator : info.communicator, info.args);
+        info.service->start(name, info.communicator == nullptr ? _sharedCommunicator : info.communicator, info.args);
         started = true;
     }
     catch (const Exception& ex)
@@ -523,7 +523,7 @@ IceBox::ServiceManagerI::start(const string& service, const string& entryPoint, 
     //
     IceInternal::DynamicLibrary library;
     IceInternal::DynamicLibrary::symbol_type sym = library.loadEntryPoint(entryPoint, false);
-    if (sym == 0)
+    if (sym == nullptr)
     {
         ostringstream os;
         os << "ServiceManager: unable to load entry point `" << entryPoint << "'";
@@ -798,7 +798,7 @@ IceBox::ServiceManagerI::stopAll()
             removeAdminFacets("IceBox.Service." + info.name + ".");
 
             info.communicator->destroy();
-            info.communicator = 0;
+            info.communicator = nullptr;
         }
     }
 
@@ -807,7 +807,7 @@ IceBox::ServiceManagerI::stopAll()
         removeAdminFacets("IceBox.SharedCommunicator.");
 
         _sharedCommunicator->destroy();
-        _sharedCommunicator = 0;
+        _sharedCommunicator = nullptr;
     }
 
     _services.clear();

--- a/cpp/src/IceDB/IceDB.cpp
+++ b/cpp/src/IceDB/IceDB.cpp
@@ -136,10 +136,10 @@ Env::~Env() { close(); }
 void
 Env::close()
 {
-    if (_menv != 0)
+    if (_menv != nullptr)
     {
         mdb_env_close(_menv);
-        _menv = 0;
+        _menv = nullptr;
     }
 }
 
@@ -149,9 +149,9 @@ Env::menv() const
     return _menv;
 }
 
-Txn::Txn(const Env& env, unsigned int flags) : _mtxn(0), _readOnly(flags == MDB_RDONLY)
+Txn::Txn(const Env& env, unsigned int flags) : _mtxn(nullptr), _readOnly(flags == MDB_RDONLY)
 {
-    const int rc = mdb_txn_begin(env.menv(), 0, flags, &_mtxn);
+    const int rc = mdb_txn_begin(env.menv(), nullptr, flags, &_mtxn);
     if (rc != MDB_SUCCESS)
     {
         throw LMDBException(__FILE__, __LINE__, rc);
@@ -164,7 +164,7 @@ void
 Txn::commit()
 {
     const int rc = mdb_txn_commit(_mtxn);
-    _mtxn = 0;
+    _mtxn = nullptr;
     if (rc != MDB_SUCCESS)
     {
         throw LMDBException(__FILE__, __LINE__, rc);
@@ -174,10 +174,10 @@ Txn::commit()
 void
 Txn::rollback()
 {
-    if (_mtxn != 0)
+    if (_mtxn != nullptr)
     {
         mdb_txn_abort(_mtxn);
-        _mtxn = 0;
+        _mtxn = nullptr;
     }
 }
 
@@ -202,7 +202,7 @@ DbiBase::DbiBase(const Txn& txn, const std::string& name, unsigned int flags, MD
     {
         throw LMDBException(__FILE__, __LINE__, rc);
     }
-    if (cmp != 0)
+    if (cmp != nullptr)
     {
         rc = mdb_set_compare(txn.mtxn(), _mdbi, cmp);
         if (rc != MDB_SUCCESS)
@@ -295,10 +295,10 @@ CursorBase::~CursorBase()
 void
 CursorBase::close()
 {
-    if (_mcursor != 0)
+    if (_mcursor != nullptr)
     {
         mdb_cursor_close(_mcursor);
-        _mcursor = 0;
+        _mcursor = nullptr;
     }
 }
 

--- a/cpp/src/IceDB/IceDB.h
+++ b/cpp/src/IceDB/IceDB.h
@@ -167,7 +167,7 @@ namespace IceDB
     template<typename K, typename D, typename C, typename H> class Dbi : public DbiBase
     {
     public:
-        Dbi(const Txn& txn, const std::string& name, const C& ctx, unsigned int flags = 0, MDB_cmp_func* cmp = 0)
+        Dbi(const Txn& txn, const std::string& name, const C& ctx, unsigned int flags = 0, MDB_cmp_func* cmp = nullptr)
             : DbiBase(txn, name, flags, cmp),
               _marshalingContext(ctx)
         {
@@ -247,7 +247,7 @@ namespace IceDB
             MDB_val mkey = {maxKeySize, kbuf};
             if (Codec<K, C, H>::write(key, mkey))
             {
-                return DbiBase::del(txn, &mkey, 0);
+                return DbiBase::del(txn, &mkey, nullptr);
             }
             else
             {

--- a/cpp/src/IceDiscovery/LocatorI.h
+++ b/cpp/src/IceDiscovery/LocatorI.h
@@ -29,7 +29,7 @@ namespace IceDiscovery
             std::optional<Ice::ObjectPrx>,
             std::function<void()>,
             std::function<void(std::exception_ptr)>,
-            const Ice::Current&);
+            const Ice::Current&) override;
 
         void setServerProcessProxyAsync(
             std::string,
@@ -67,7 +67,7 @@ namespace IceDiscovery
             std::string,
             std::function<void(const std::optional<Ice::ObjectPrx>&)>,
             std::function<void(std::exception_ptr)>,
-            const Ice::Current&) const;
+            const Ice::Current&) const override;
 
         std::optional<Ice::LocatorRegistryPrx> getRegistry(const Ice::Current&) const final;
 

--- a/cpp/src/IceDiscovery/LookupI.h
+++ b/cpp/src/IceDiscovery/LookupI.h
@@ -69,12 +69,8 @@ namespace IceDiscovery
         std::vector<CB> _callbacks;
     };
 
-    typedef std::
-        pair<std::function<void(const std::optional<Ice::ObjectPrx>&)>, std::function<void(std::exception_ptr)>>
-            ObjectCB;
-    typedef std::
-        pair<std::function<void(const std::optional<Ice::ObjectPrx>&)>, std::function<void(std::exception_ptr)>>
-            AdapterCB;
+    using ObjectCB = std::pair<std::function<void (const std::optional<Ice::ObjectPrx> &)>, std::function<void (std::exception_ptr)>>;
+    using AdapterCB = std::pair<std::function<void (const std::optional<Ice::ObjectPrx> &)>, std::function<void (std::exception_ptr)>>;
 
     class ObjectRequest : public RequestT<Ice::Identity, ObjectCB>, public std::enable_shared_from_this<ObjectRequest>
     {
@@ -84,8 +80,8 @@ namespace IceDiscovery
         void response(const Ice::ObjectPrx&);
 
     private:
-        virtual void invokeWithLookup(const std::string&, const LookupPrx&, const LookupReplyPrx&);
-        virtual void runTimerTask();
+        void invokeWithLookup(const std::string&, const LookupPrx&, const LookupReplyPrx&) override;
+        void runTimerTask() override;
     };
     using ObjectRequestPtr = std::shared_ptr<ObjectRequest>;
 

--- a/cpp/src/IceDiscovery/LookupI.h
+++ b/cpp/src/IceDiscovery/LookupI.h
@@ -69,8 +69,10 @@ namespace IceDiscovery
         std::vector<CB> _callbacks;
     };
 
-    using ObjectCB = std::pair<std::function<void (const std::optional<Ice::ObjectPrx> &)>, std::function<void (std::exception_ptr)>>;
-    using AdapterCB = std::pair<std::function<void (const std::optional<Ice::ObjectPrx> &)>, std::function<void (std::exception_ptr)>>;
+    using ObjectCB =
+        std::pair<std::function<void(const std::optional<Ice::ObjectPrx>&)>, std::function<void(std::exception_ptr)>>;
+    using AdapterCB =
+        std::pair<std::function<void(const std::optional<Ice::ObjectPrx>&)>, std::function<void(std::exception_ptr)>>;
 
     class ObjectRequest : public RequestT<Ice::Identity, ObjectCB>, public std::enable_shared_from_this<ObjectRequest>
     {

--- a/cpp/src/IceDiscovery/PluginI.h
+++ b/cpp/src/IceDiscovery/PluginI.h
@@ -15,8 +15,8 @@ namespace IceDiscovery
     public:
         PluginI(const Ice::CommunicatorPtr&);
 
-        virtual void initialize();
-        virtual void destroy();
+        void initialize() override;
+        void destroy() override;
 
     private:
         const Ice::CommunicatorPtr _communicator;

--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -646,7 +646,7 @@ Activator::activate(
     {
         throw SyscallException{__FILE__, __LINE__, "getpwuid_r failed", err};
     }
-    else if (pw == 0)
+    else if (pw == nullptr)
     {
         ostringstream os;
         os << uid;
@@ -722,7 +722,7 @@ Activator::activate(
         sigaddset(&sigs, SIGHUP);
         sigaddset(&sigs, SIGINT);
         sigaddset(&sigs, SIGTERM);
-        sigprocmask(SIG_UNBLOCK, &sigs, 0);
+        sigprocmask(SIG_UNBLOCK, &sigs, nullptr);
 
         //
         // Change the uid/gid under which the process will run.
@@ -1279,7 +1279,7 @@ Activator::terminationListener()
         }
 
     repeatSelect:
-        int ret = ::select(maxFd + 1, &fdSet, 0, 0, 0);
+        int ret = ::select(maxFd + 1, &fdSet, nullptr, nullptr, nullptr);
         assert(ret != 0);
 
         if (ret == -1)

--- a/cpp/src/IceGrid/AdapterCache.cpp
+++ b/cpp/src/IceGrid/AdapterCache.cpp
@@ -54,7 +54,7 @@ namespace IceGrid
             return true;
         }
 
-        void synchronized()
+        void synchronized() override
         {
             shared_ptr<SynchronizationCallback> callback;
             {
@@ -82,7 +82,7 @@ namespace IceGrid
             }
         }
 
-        void synchronized(exception_ptr ex)
+        void synchronized(exception_ptr ex) override
         {
             shared_ptr<SynchronizationCallback> callback;
             {
@@ -104,7 +104,7 @@ namespace IceGrid
                 }
 
                 callback = _callback;
-                _callback = 0;
+                _callback = nullptr;
             }
 
             if (callback)

--- a/cpp/src/IceGrid/AdapterCache.h
+++ b/cpp/src/IceGrid/AdapterCache.h
@@ -162,8 +162,8 @@ namespace IceGrid
         void removeReplicaGroup(const std::string&);
 
     protected:
-        virtual std::shared_ptr<AdapterEntry> addImpl(const std::string&, const std::shared_ptr<AdapterEntry>&);
-        virtual void removeImpl(const std::string&);
+        std::shared_ptr<AdapterEntry> addImpl(const std::string&, const std::shared_ptr<AdapterEntry>&) override;
+        void removeImpl(const std::string&) override;
 
     private:
         const Ice::CommunicatorPtr _communicator;

--- a/cpp/src/IceGrid/Allocatable.cpp
+++ b/cpp/src/IceGrid/Allocatable.cpp
@@ -208,7 +208,7 @@ Allocatable::release(const shared_ptr<SessionI>& session, bool fromRelease)
 
         if (--_count == 0)
         {
-            _session = 0;
+            _session = nullptr;
 
             released(session);
 
@@ -269,8 +269,8 @@ Allocatable::release(const shared_ptr<SessionI>& session, bool fromRelease)
                                 lock_guard lock(_mutex);
                                 assert(_count);
 
-                                allocatable = 0;
-                                request = 0;
+                                allocatable = nullptr;
+                                request = nullptr;
 
                                 //
                                 // Check if there's other requests from the session

--- a/cpp/src/IceGrid/Allocatable.h
+++ b/cpp/src/IceGrid/Allocatable.h
@@ -20,7 +20,7 @@ namespace IceGrid
     class AllocationRequest : public IceInternal::TimerTask, public std::enable_shared_from_this<AllocationRequest>
     {
     public:
-        virtual ~AllocationRequest() = default;
+        ~AllocationRequest() override = default;
 
         virtual void allocated(const std::shared_ptr<Allocatable>&, const std::shared_ptr<SessionI>&) = 0;
         virtual void canceled(std::exception_ptr) = 0;

--- a/cpp/src/IceGrid/Database.cpp
+++ b/cpp/src/IceGrid/Database.cpp
@@ -2430,7 +2430,7 @@ Database::checkUpdate(
                 try
                 {
                     auto info = p->second;
-                    info.descriptor = 0; // Clear the descriptor to indicate removal.
+                    info.descriptor = nullptr; // Clear the descriptor to indicate removal.
                     auto result = _serverCache.get(p->first)->checkUpdate(info, true);
                     if (result)
                     {

--- a/cpp/src/IceGrid/DescriptorBuilder.h
+++ b/cpp/src/IceGrid/DescriptorBuilder.h
@@ -94,7 +94,7 @@ namespace IceGrid
         void setLoadBalancing(const XmlAttributesHelper&);
         void setReplicaGroupDescription(const std::string&);
         void addObject(const XmlAttributesHelper&);
-        virtual void addVariable(const XmlAttributesHelper&);
+        void addVariable(const XmlAttributesHelper&) override;
 
         virtual NodeDescriptorBuilder* createNode(const XmlAttributesHelper&);
         virtual TemplateDescriptorBuilder* createServerTemplate(const XmlAttributesHelper&);
@@ -143,7 +143,7 @@ namespace IceGrid
         virtual ServerInstanceDescriptorBuilder* createServerInstance(const XmlAttributesHelper&);
         virtual PropertySetDescriptorBuilder* createPropertySet(const XmlAttributesHelper&) const;
 
-        void addVariable(const XmlAttributesHelper&);
+        void addVariable(const XmlAttributesHelper&) override;
         void addServer(const std::shared_ptr<ServerDescriptor>&);
         void addServerInstance(const ServerInstanceDescriptor&);
         void addPropertySet(const std::string&, const PropertySetDescriptor&);
@@ -253,12 +253,12 @@ namespace IceGrid
 
         void init(const std::shared_ptr<IceBoxDescriptor>&, const XmlAttributesHelper&);
 
-        virtual ServiceDescriptorBuilder* createService(const XmlAttributesHelper&);
-        virtual ServiceInstanceDescriptorBuilder* createServiceInstance(const XmlAttributesHelper&);
+        ServiceDescriptorBuilder* createService(const XmlAttributesHelper&) override;
+        ServiceInstanceDescriptorBuilder* createServiceInstance(const XmlAttributesHelper&) override;
 
-        virtual void addAdapter(const XmlAttributesHelper&);
-        virtual void addServiceInstance(const ServiceInstanceDescriptor&);
-        virtual void addService(const std::shared_ptr<ServiceDescriptor>&);
+        void addAdapter(const XmlAttributesHelper&) override;
+        void addServiceInstance(const ServiceInstanceDescriptor&) override;
+        void addService(const std::shared_ptr<ServiceDescriptor>&) override;
 
     private:
         std::shared_ptr<IceBoxDescriptor> _descriptor;

--- a/cpp/src/IceGrid/DescriptorHelper.cpp
+++ b/cpp/src/IceGrid/DescriptorHelper.cpp
@@ -473,7 +473,7 @@ Resolver::Resolver(const Resolver& resolve, const map<string, string>& values, b
 }
 
 Resolver::Resolver(const shared_ptr<InternalNodeInfo>& info, const shared_ptr<Ice::Communicator>& com)
-    : _application(0),
+    : _application(nullptr),
       _communicator(com),
       _escape(true),
       _enableWarning(false),
@@ -1849,7 +1849,7 @@ ServerInstanceHelper::ServerInstanceHelper(
     bool instantiate)
     : _def(desc)
 {
-    init(0, resolve, instantiate);
+    init(nullptr, resolve, instantiate);
 }
 
 ServerInstanceHelper::ServerInstanceHelper(

--- a/cpp/src/IceGrid/DescriptorHelper.h
+++ b/cpp/src/IceGrid/DescriptorHelper.h
@@ -275,7 +275,7 @@ namespace IceGrid
         NodeDescriptor _instance;
         bool _instantiated;
 
-        typedef std::map<std::string, ServerInstanceHelper> ServerInstanceHelperDict;
+        using ServerInstanceHelperDict = std::map<std::string, ServerInstanceHelper>;
         ServerInstanceHelperDict _serverInstances;
         ServerInstanceHelperDict _servers;
     };

--- a/cpp/src/IceGrid/LocatorI.h
+++ b/cpp/src/IceGrid/LocatorI.h
@@ -18,7 +18,7 @@ namespace IceGrid
     class WellKnownObjectsManager;
 
     struct LocatorAdapterInfo;
-    typedef std::vector<LocatorAdapterInfo> LocatorAdapterInfoSeq;
+    using LocatorAdapterInfoSeq = std::vector<LocatorAdapterInfo>;
 
     class LocatorI : public Locator, public std::enable_shared_from_this<LocatorI>
     {

--- a/cpp/src/IceGrid/NodeSessionManager.h
+++ b/cpp/src/IceGrid/NodeSessionManager.h
@@ -61,7 +61,7 @@ namespace IceGrid
 
         void syncServers(const NodeSessionPrx&);
 
-        bool isDestroyed()
+        bool isDestroyed() override
         {
             std::lock_guard<std::mutex> lock(_mutex);
             return _destroyed;

--- a/cpp/src/IceGrid/Parser.cpp
+++ b/cpp/src/IceGrid/Parser.cpp
@@ -161,7 +161,7 @@ namespace
          "                          identities match the expression EXPR. A trailing\n"
          "                          wildcard is supported in EXPR, for example\n"
          "                          \"object list Ice*\".\n"},
-        {0, 0, 0}};
+        {nullptr, nullptr, nullptr}};
 
     int loggerCallbackCount = 0;
 
@@ -2584,7 +2584,7 @@ Parser::parse(FILE* file, bool debug)
         status = EXIT_FAILURE;
     }
 
-    parser = 0;
+    parser = nullptr;
     return status;
 }
 
@@ -2599,7 +2599,7 @@ Parser::parse(const std::string& commands, bool debug)
     _errors = 0;
     _commands = commands;
     assert(!_commands.empty());
-    yyin = 0;
+    yyin = nullptr;
 
     _continue = false;
 
@@ -2609,7 +2609,7 @@ Parser::parse(const std::string& commands, bool debug)
         status = EXIT_FAILURE;
     }
 
-    parser = 0;
+    parser = nullptr;
     return status;
 }
 

--- a/cpp/src/IceGrid/RegistryAdminRouter.cpp
+++ b/cpp/src/IceGrid/RegistryAdminRouter.cpp
@@ -30,7 +30,7 @@ namespace
         {
         }
 
-        void synchronized()
+        void synchronized() override
         {
             //
             // Retry to forward the call.
@@ -42,7 +42,7 @@ namespace
                 _current);
         }
 
-        void synchronized(exception_ptr)
+        void synchronized(exception_ptr) override
         {
             _exception(make_exception_ptr(Ice::ObjectNotExistException{__FILE__, __LINE__}));
         }

--- a/cpp/src/IceGrid/RegistryI.h
+++ b/cpp/src/IceGrid/RegistryI.h
@@ -36,7 +36,7 @@ namespace IceGrid
             bool,
             const std::string&,
             const std::string&);
-        virtual ~RegistryI() = default;
+        ~RegistryI() override = default;
 
         bool start();
         bool startImpl();

--- a/cpp/src/IceGrid/ReplicaSessionManager.h
+++ b/cpp/src/IceGrid/ReplicaSessionManager.h
@@ -67,7 +67,7 @@ namespace IceGrid
     private:
         friend class Thread;
 
-        bool isDestroyed()
+        bool isDestroyed() override
         {
             std::lock_guard<std::mutex> lock(_mutex);
             return !_communicator;

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -38,13 +38,13 @@ namespace IceGrid
     {
         vector<vector<uint8_t>> namelist;
         DIR* d;
-        if ((d = opendir(path.c_str())) == 0)
+        if ((d = opendir(path.c_str())) == nullptr)
         {
             throw runtime_error("cannot read directory `" + path + "':\n" + IceInternal::lastErrorToString());
         }
 
         struct dirent* entry;
-        while ((entry = readdir(d)) != 0)
+        while ((entry = readdir(d)) != nullptr)
         {
             size_t index = namelist.size();
             namelist.resize(index + 1);
@@ -1120,7 +1120,7 @@ ServerI::load(
             // waiting to be loaded, we wait for the loading to complete before replying.
             //
             _load->addCallback(response, exception);
-            return 0;
+            return nullptr;
         }
         else if (response)
         {
@@ -2387,7 +2387,7 @@ ServerI::checkAndUpdateUser(const shared_ptr<InternalServerDescriptor>& desc, bo
         {
             throw Ice::SyscallException{__FILE__, __LINE__, "getpwnam_r failed", err};
         }
-        else if (pw == 0)
+        else if (pw == nullptr)
         {
             throw runtime_error("unknown user account `" + user + "'");
         }

--- a/cpp/src/IceGrid/SessionI.h
+++ b/cpp/src/IceGrid/SessionI.h
@@ -22,7 +22,7 @@ namespace IceGrid
     class BaseSessionI : public virtual Ice::Object, public std::enable_shared_from_this<BaseSessionI>
     {
     public:
-        virtual ~BaseSessionI() = default;
+        ~BaseSessionI() override = default;
 
         // Return value is never used. Just returns nullopt when the session is destroyed.
         std::optional<std::chrono::steady_clock::time_point> timestamp() const noexcept;

--- a/cpp/src/IceGrid/SessionServantManager.h
+++ b/cpp/src/IceGrid/SessionServantManager.h
@@ -29,9 +29,9 @@ namespace IceGrid
             const Ice::ObjectPtr&,
             const std::shared_ptr<AdminCallbackRouter>&);
 
-        Ice::ObjectPtr locate(const Ice::Current&, std::shared_ptr<void>&);
-        void finished(const Ice::Current&, const Ice::ObjectPtr&, const std::shared_ptr<void>&);
-        void deactivate(std::string_view);
+        Ice::ObjectPtr locate(const Ice::Current&, std::shared_ptr<void>&) override;
+        void finished(const Ice::Current&, const Ice::ObjectPtr&, const std::shared_ptr<void>&) override;
+        void deactivate(std::string_view) override;
 
         Ice::ObjectPrx addSession(const Ice::ObjectPtr&, const Ice::ConnectionPtr&, const std::string&);
         void setSessionControl(const Ice::ObjectPtr&, const Glacier2::SessionControlPrx&, const Ice::IdentitySeq&);

--- a/cpp/src/IceGrid/Util.cpp
+++ b/cpp/src/IceGrid/Util.cpp
@@ -431,7 +431,7 @@ IceGrid::readDirectory(const string& pa)
 #else
 
     struct dirent** namelist;
-    int n = scandir(path.c_str(), &namelist, 0, alphasort);
+    int n = scandir(path.c_str(), &namelist, nullptr, alphasort);
 
     if (n < 0)
     {

--- a/cpp/src/IceStorm/InstrumentationI.cpp
+++ b/cpp/src/IceStorm/InstrumentationI.cpp
@@ -34,7 +34,7 @@ namespace
 
         TopicHelper(const string& service, const string& name) : _service(service), _name(name) {}
 
-        virtual string operator()(const string& attribute) const { return attributes(this, attribute); }
+        string operator()(const string& attribute) const override { return attributes(this, attribute); }
 
         const string& getService() const { return _service; }
 

--- a/cpp/src/IceStorm/NodeI.cpp
+++ b/cpp/src/IceStorm/NodeI.cpp
@@ -19,7 +19,7 @@ namespace
 
     public:
         CheckTask(shared_ptr<NodeI> node) : _node(std::move(node)) {}
-        virtual void runTimerTask() { _node->check(); }
+        void runTimerTask() override { _node->check(); }
     };
 
     class MergeTask : public IceInternal::TimerTask
@@ -29,7 +29,7 @@ namespace
 
     public:
         MergeTask(shared_ptr<NodeI> node, const set<int>& s) : _node(std::move(node)), _s(s) {}
-        virtual void runTimerTask() { _node->merge(_s); }
+        void runTimerTask() override { _node->merge(_s); }
     };
 
     class MergeContinueTask : public IceInternal::TimerTask
@@ -38,7 +38,7 @@ namespace
 
     public:
         MergeContinueTask(shared_ptr<NodeI> node) : _node(std::move(node)) {}
-        virtual void runTimerTask() { _node->mergeContinue(); }
+        void runTimerTask() override { _node->mergeContinue(); }
     };
 
     class TimeoutTask : public IceInternal::TimerTask
@@ -47,7 +47,7 @@ namespace
 
     public:
         TimeoutTask(shared_ptr<NodeI> node) : _node(std::move(node)) {}
-        virtual void runTimerTask() { _node->timeout(); }
+        void runTimerTask() override { _node->timeout(); }
     };
 }
 
@@ -216,7 +216,7 @@ NodeI::check()
                 // Clear _checkTask -- recovery() will reset the
                 // timer.
                 assert(_checkTask);
-                _checkTask = 0;
+                _checkTask = nullptr;
                 recovery();
                 return;
             }
@@ -262,7 +262,7 @@ NodeI::check()
     if (_destroy || _state == NodeState::NodeStateElection || _state == NodeState::NodeStateReorganization ||
         _coord != _id)
     {
-        _checkTask = 0;
+        _checkTask = nullptr;
         return;
     }
 
@@ -276,7 +276,7 @@ NodeI::check()
     }
 
     // _checkTask == 0 means that the check isn't scheduled.
-    _checkTask = 0;
+    _checkTask = nullptr;
 
     if (_traceLevels->election > 0)
     {
@@ -358,7 +358,7 @@ NodeI::merge(const set<int>& coordinatorSet)
     {
         unique_lock<recursive_mutex> lock(_mutex);
 
-        _mergeTask = 0;
+        _mergeTask = nullptr;
 
         // If the node is currently in an election, or reorganizing
         // then we're done.
@@ -447,7 +447,7 @@ NodeI::merge(const set<int>& coordinatorSet)
         }
 
         // Schedule the mergeContinueTask.
-        assert(_mergeContinueTask == 0);
+        assert(_mergeContinueTask == nullptr);
         _mergeContinueTask = make_shared<MergeContinueTask>(shared_from_this());
 
         // At this point we may have already accepted all of the
@@ -479,7 +479,7 @@ NodeI::mergeContinue()
         tmpSet = set<GroupNodeInfo>(_up);
 
         assert(_mergeContinueTask);
-        _mergeContinueTask = 0;
+        _mergeContinueTask = nullptr;
 
         // The node is now reorganizing.
         assert(_state == NodeState::NodeStateElection);
@@ -1002,12 +1002,12 @@ NodeI::recovery(int64_t generation)
     if (_mergeTask)
     {
         _timer->cancel(_mergeTask);
-        _mergeTask = 0;
+        _mergeTask = nullptr;
     }
     if (_timeoutTask)
     {
         _timer->cancel(_timeoutTask);
-        _timeoutTask = 0;
+        _timeoutTask = nullptr;
     }
     if (!_checkTask)
     {
@@ -1033,19 +1033,19 @@ NodeI::destroy()
     if (_checkTask)
     {
         _timer->cancel(_checkTask);
-        _checkTask = 0;
+        _checkTask = nullptr;
     }
 
     if (_timeoutTask)
     {
         _timer->cancel(_timeoutTask);
-        _timeoutTask = 0;
+        _timeoutTask = nullptr;
     }
 
     if (_mergeTask)
     {
         _timer->cancel(_mergeTask);
-        _mergeTask = 0;
+        _mergeTask = nullptr;
     }
 }
 

--- a/cpp/src/IceStorm/Parser.cpp
+++ b/cpp/src/IceStorm/Parser.cpp
@@ -546,7 +546,7 @@ Parser::parse(FILE* file, bool debug)
         status = EXIT_FAILURE;
     }
 
-    parser = 0;
+    parser = nullptr;
     return status;
 }
 
@@ -561,7 +561,7 @@ Parser::parse(const std::string& commands, bool debug)
     _errors = 0;
     _commands = commands;
     assert(!_commands.empty());
-    yyin = 0;
+    yyin = nullptr;
 
     _continue = false;
 
@@ -571,7 +571,7 @@ Parser::parse(const std::string& commands, bool debug)
         status = EXIT_FAILURE;
     }
 
-    parser = 0;
+    parser = nullptr;
     return status;
 }
 

--- a/cpp/src/IceStorm/Service.cpp
+++ b/cpp/src/IceStorm/Service.cpp
@@ -122,7 +122,7 @@ ServiceI::start(const string& serviceName, const CommunicatorPtr& communicator, 
         }
         catch (const Ice::Exception& ex)
         {
-            _instance = 0;
+            _instance = nullptr;
 
             LoggerOutputBase s;
             s << "exception while starting IceStorm service " << serviceName << ":\n";
@@ -146,7 +146,7 @@ ServiceI::start(const string& serviceName, const CommunicatorPtr& communicator, 
         }
         catch (const Ice::Exception& ex)
         {
-            _instance = 0;
+            _instance = nullptr;
 
             LoggerOutputBase s;
             s << "exception while starting IceStorm service " << serviceName << ":\n";

--- a/cpp/src/IceStorm/Subscriber.cpp
+++ b/cpp/src/IceStorm/Subscriber.cpp
@@ -858,7 +858,7 @@ Subscriber::Subscriber(
             _rec.theQoS,
             _rec.theTopic,
             toSubscriberState(_state),
-            0));
+            nullptr));
     }
 }
 

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -723,7 +723,7 @@ TopicImpl::shutdown()
 {
     lock_guard lock(_subscribersMutex);
 
-    _servant = 0;
+    _servant = nullptr;
 
     // Shutdown each subscriber. This waits for the event queues to drain.
     for (const auto& subscriber : _subscribers)
@@ -1217,7 +1217,7 @@ TopicImpl::destroyInternal(const LogUpdate& origLLU, bool master)
 
     _instance->topicAdapter()->remove(_id);
 
-    _servant = 0;
+    _servant = nullptr;
 
     return llu;
 }

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -4687,7 +4687,7 @@ Slice::Unit::setCurrentFile(const std::string& currentFile, int lineNumber)
     else
     {
         DefinitionContextPtr dc = currentDefinitionContext();
-        if (dc != 0 && !dc->filename().empty() && dc->filename() != currentFile)
+        if (dc != nullptr && !dc->filename().empty() && dc->filename() != currentFile)
         {
             type = Pop;
         }
@@ -4953,7 +4953,7 @@ Slice::Unit::parse(const string& filename, FILE* file, bool debugMode)
         popDefinitionContext();
     }
 
-    Slice::currentUnit = 0;
+    Slice::currentUnit = nullptr;
     return status;
 }
 

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -455,7 +455,7 @@ namespace Slice
         std::string thisScope() const;
         void visit(ParserVisitor* visitor) override;
 
-        bool checkIntroduced(const std::string& scopedName, ContainedPtr namedThing = 0);
+        bool checkIntroduced(const std::string& scopedName, ContainedPtr namedThing = nullptr);
 
         /// Returns true if this container is the global scope (i.e. it's of type `Unit`), and false otherwise.
         /// If false, we emit an error message. So this function should only be called for types which cannot appear at
@@ -611,8 +611,8 @@ namespace Slice
 
         InterfaceDefPtr _definition;
 
-        typedef std::list<InterfaceList> GraphPartitionList;
-        typedef std::list<StringList> StringPartitionList;
+        using GraphPartitionList = std::list<InterfaceList>;
+        using StringPartitionList = std::list<StringList>;
 
         static bool isInList(const GraphPartitionList& gpl, const InterfaceDefPtr& interfaceDef);
 

--- a/cpp/src/Slice/Preprocessor.cpp
+++ b/cpp/src/Slice/Preprocessor.cpp
@@ -53,7 +53,7 @@ Slice::Preprocessor::Preprocessor(const string& path, const string& fileName, co
       _fileName(fullPath(fileName)),
       _shortFileName(fileName),
       _args(args),
-      _cppHandle(0)
+      _cppHandle(nullptr)
 {
 }
 
@@ -159,7 +159,7 @@ Slice::Preprocessor::preprocess(bool keepComments, const string& languageArg)
 {
     if (!checkInputFile())
     {
-        return 0;
+        return nullptr;
     }
 
     //
@@ -233,7 +233,7 @@ Slice::Preprocessor::preprocess(bool keepComments, const string& languageArg)
         //
         // If that fails try to open file in current directory.
         //
-        if (_cppHandle == 0)
+        if (_cppHandle == nullptr)
         {
 #ifdef _WIN32
             _cppFile = "slice-" + Ice::generateUUID();
@@ -243,7 +243,7 @@ Slice::Preprocessor::preprocess(bool keepComments, const string& languageArg)
             _cppHandle = IceInternal::fopen(_cppFile, "w+");
         }
 
-        if (_cppHandle != 0)
+        if (_cppHandle != nullptr)
         {
             if (buf)
             {
@@ -719,10 +719,10 @@ Slice::Preprocessor::printMakefileDependencies(
 bool
 Slice::Preprocessor::close()
 {
-    if (_cppHandle != 0)
+    if (_cppHandle != nullptr)
     {
         int status = fclose(_cppHandle);
-        _cppHandle = 0;
+        _cppHandle = nullptr;
 
         if (_cppFile.size() != 0)
         {

--- a/cpp/src/Slice/SliceUtil.cpp
+++ b/cpp/src/Slice/SliceUtil.cpp
@@ -248,7 +248,7 @@ Slice::emitRaw(const char* message)
 vector<string>
 Slice::filterMcppWarnings(const string& message)
 {
-    static const char* messages[] = {"Converted [CR+LF] to [LF]", "no newline, supplemented newline", 0};
+    static const char* messages[] = {"Converted [CR+LF] to [LF]", "no newline, supplemented newline", nullptr};
 
     constexpr string_view warningPrefix = "warning:";
     constexpr string_view fromPrefix = "from";
@@ -270,7 +270,7 @@ Slice::filterMcppWarnings(const string& message)
 
         if (i->find(warningPrefix) != string::npos)
         {
-            for (int j = 0; messages[j] != 0; ++j)
+            for (int j = 0; messages[j] != nullptr; ++j)
             {
                 if (i->find(messages[j]) != string::npos)
                 {

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -22,7 +22,7 @@ namespace
         ParameterPtr param; // nullptr == return value
     };
 
-    typedef std::list<ParamInfo> ParamInfoList;
+    using ParamInfoList = std::list<ParamInfo>;
 
     ParamInfoList getAllInParams(const OperationPtr& op)
     {

--- a/cpp/src/ice2slice/Main.cpp
+++ b/cpp/src/ice2slice/Main.cpp
@@ -154,7 +154,7 @@ compile(const vector<string>& argv)
         PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
         FILE* cppHandle = icecpp->preprocess(true, "-D__ICE2SLICE__");
 
-        if (cppHandle == 0)
+        if (cppHandle == nullptr)
         {
             return EXIT_FAILURE;
         }

--- a/cpp/src/icegriddb/IceGridDB.cpp
+++ b/cpp/src/icegriddb/IceGridDB.cpp
@@ -26,7 +26,7 @@ namespace
         ServerDescriptorI(const string& serverVersion) : _serverVersion(serverVersion) {}
 
     protected:
-        virtual void ice_postUnmarshal() { iceVersion = _serverVersion; }
+        void ice_postUnmarshal() override { iceVersion = _serverVersion; }
 
     private:
         string _serverVersion;
@@ -38,7 +38,7 @@ namespace
         IceBoxDescriptorI(const string& serverVersion) : _serverVersion(serverVersion) {}
 
     protected:
-        virtual void ice_postUnmarshal() { iceVersion = _serverVersion; }
+        void ice_postUnmarshal() override { iceVersion = _serverVersion; }
 
     private:
         string _serverVersion;

--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -201,7 +201,7 @@ compile(const vector<string>& argv)
             PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
             FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2CPP__");
 
-            if (cppHandle == 0)
+            if (cppHandle == nullptr)
             {
                 return EXIT_FAILURE;
             }
@@ -240,7 +240,7 @@ compile(const vector<string>& argv)
             PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
             FILE* cppHandle = icecpp->preprocess(true, "-D__SLICE2CPP__");
 
-            if (cppHandle == 0)
+            if (cppHandle == nullptr)
             {
                 return EXIT_FAILURE;
             }

--- a/cpp/src/slice2cs/DotNetNames.cpp
+++ b/cpp/src/slice2cs/DotNetNames.cpp
@@ -19,12 +19,12 @@ namespace Slice
         };
 
         static const char* ObjectNames[] =
-            {"Equals", "Finalize", "GetHashCode", "GetType", "MemberwiseClone", "ReferenceEquals", "ToString", 0};
-        static const Node* ObjectParents[] = {0};
+            {"Equals", "Finalize", "GetHashCode", "GetType", "MemberwiseClone", "ReferenceEquals", "ToString", nullptr};
+        static const Node* ObjectParents[] = {nullptr};
         static const Node ObjectNode = {ObjectNames, &ObjectParents[0]};
 
-        static const char* ICloneableNames[] = {"Clone", 0};
-        static const Node* ICloneableParents[] = {&ObjectNode, 0};
+        static const char* ICloneableNames[] = {"Clone", nullptr};
+        static const Node* ICloneableParents[] = {&ObjectNode, nullptr};
         static const Node ICloneableNode = {ICloneableNames, &ICloneableParents[0]};
 
         static const char* ExceptionNames[] = {
@@ -38,8 +38,8 @@ namespace Slice
             "Source",
             "StackTrace",
             "TargetSite",
-            0};
-        static const Node* ExceptionParents[] = {&ObjectNode, 0};
+            nullptr};
+        static const Node* ExceptionParents[] = {&ObjectNode, nullptr};
         static const Node ExceptionNode = {ExceptionNames, &ExceptionParents[0]};
 
         //

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2535,7 +2535,7 @@ Slice::Gen::DispatchAdapterVisitor::visitOperation(const OperationPtr& op)
 
             _out << nl << typeS << ' ' << param << (pli->type()->isClassType() ? " = null;" : ";");
         }
-        writeMarshalUnmarshalParams(inParams, 0, false, ns);
+        writeMarshalUnmarshalParams(inParams, nullptr, false, ns);
         if (op->sendsClasses())
         {
             _out << nl << "istr.readPendingValues();";
@@ -2892,7 +2892,7 @@ Slice::Gen::HelperVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             _out << ",";
             _out << nl << "write: (Ice.OutputStream ostr) =>";
             _out << sb;
-            writeMarshalUnmarshalParams(inParams, 0, true, ns);
+            writeMarshalUnmarshalParams(inParams, nullptr, true, ns);
             if (op->sendsClasses())
             {
                 _out << nl << "ostr.writePendingValues();";

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -13,7 +13,7 @@ namespace Slice
     {
     public:
         CsVisitor(::IceInternal::Output&);
-        virtual ~CsVisitor();
+        ~CsVisitor() override;
 
     protected:
         void writeMarshalUnmarshalParams(

--- a/cpp/src/slice2cs/Main.cpp
+++ b/cpp/src/slice2cs/Main.cpp
@@ -178,7 +178,7 @@ compile(const vector<string>& argv)
             PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
             FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2CS__");
 
-            if (cppHandle == 0)
+            if (cppHandle == nullptr)
             {
                 return EXIT_FAILURE;
             }
@@ -211,7 +211,7 @@ compile(const vector<string>& argv)
             PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
             FILE* cppHandle = icecpp->preprocess(true, "-D__SLICE2CS__");
 
-            if (cppHandle == 0)
+            if (cppHandle == nullptr)
             {
                 return EXIT_FAILURE;
             }

--- a/cpp/src/slice2java/Gen.h
+++ b/cpp/src/slice2java/Gen.h
@@ -13,7 +13,7 @@ namespace Slice
     class JavaVisitor : public JavaGenerator, public ParserVisitor
     {
     public:
-        virtual ~JavaVisitor();
+        ~JavaVisitor() override;
 
     protected:
         JavaVisitor(const std::string&);
@@ -56,7 +56,7 @@ namespace Slice
         // Generate a throws clause containing only checked exceptions.
         // op is provided only when we want to check for the java:UserException metadata
         //
-        void writeThrowsClause(const std::string&, const ExceptionList&, const OperationPtr& op = 0);
+        void writeThrowsClause(const std::string&, const ExceptionList&, const OperationPtr& op = nullptr);
         //
         // Marshal/unmarshal a data member.
         //

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -691,23 +691,23 @@ Slice::JavaOutput::printHeader()
     print("//\n");
 }
 
-Slice::JavaGenerator::JavaGenerator(const string& dir) : _dir(dir), _out(0) {}
+Slice::JavaGenerator::JavaGenerator(const string& dir) : _dir(dir), _out(nullptr) {}
 
 Slice::JavaGenerator::~JavaGenerator()
 {
     // If open throws an exception other generators could be left open
     // during the stack unwind.
-    if (_out != 0)
+    if (_out != nullptr)
     {
         close();
     }
-    assert(_out == 0);
+    assert(_out == nullptr);
 }
 
 void
 Slice::JavaGenerator::open(const string& absolute, const string& file)
 {
-    assert(_out == 0);
+    assert(_out == nullptr);
 
     JavaOutput* out = createOutput();
     try
@@ -725,16 +725,16 @@ Slice::JavaGenerator::open(const string& absolute, const string& file)
 void
 Slice::JavaGenerator::close()
 {
-    assert(_out != 0);
+    assert(_out != nullptr);
     *_out << nl;
     delete _out;
-    _out = 0;
+    _out = nullptr;
 }
 
 Output&
 Slice::JavaGenerator::output() const
 {
-    assert(_out != 0);
+    assert(_out != nullptr);
     return *_out;
 }
 

--- a/cpp/src/slice2java/Main.cpp
+++ b/cpp/src/slice2java/Main.cpp
@@ -187,7 +187,7 @@ compile(const vector<string>& argv)
             PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
             FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2JAVA__");
 
-            if (cppHandle == 0)
+            if (cppHandle == nullptr)
             {
                 return EXIT_FAILURE;
             }
@@ -222,7 +222,7 @@ compile(const vector<string>& argv)
             PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
             FILE* cppHandle = icecpp->preprocess(true, "-D__SLICE2JAVA__");
 
-            if (cppHandle == 0)
+            if (cppHandle == nullptr)
             {
                 FileTracker::instance()->error();
                 status = EXIT_FAILURE;

--- a/cpp/src/slice2js/Gen.h
+++ b/cpp/src/slice2js/Gen.h
@@ -16,7 +16,7 @@ namespace Slice
             ::IceInternal::Output&,
             const std::vector<std::pair<std::string, std::string>>& imports =
                 std::vector<std::pair<std::string, std::string>>());
-        virtual ~JsVisitor();
+        ~JsVisitor() override;
 
         std::vector<std::pair<std::string, std::string>> imports() const;
 
@@ -44,7 +44,7 @@ namespace Slice
 
         Gen(const std::string&, const std::vector<std::string>&, const std::string&, bool, std::ostream&);
 
-        ~Gen();
+        ~Gen() override;
 
         void generate(const UnitPtr&);
 

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -1309,7 +1309,7 @@ private:
         bool inherited;
         DataMemberPtr dataMember;
     };
-    typedef list<MemberInfo> MemberInfoList;
+    using MemberInfoList = list<MemberInfo>;
 
     //
     // Convert an operation mode into a string.
@@ -1328,7 +1328,7 @@ private:
         int pos;            // Only used for out params
         ParameterPtr param; // 0 == return value
     };
-    typedef list<ParamInfo> ParamInfoList;
+    using ParamInfoList = list<ParamInfo>;
 
     ParamInfoList getAllInParams(const OperationPtr&);
     void getInParams(const OperationPtr&, ParamInfoList&, ParamInfoList&);
@@ -4166,7 +4166,7 @@ compile(const vector<string>& argv)
             PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
             FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2MATLAB__");
 
-            if (cppHandle == 0)
+            if (cppHandle == nullptr)
             {
                 return EXIT_FAILURE;
             }
@@ -4201,7 +4201,7 @@ compile(const vector<string>& argv)
             PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
             FILE* cppHandle = icecpp->preprocess(true, "-D__SLICE2MATLAB__");
 
-            if (cppHandle == 0)
+            if (cppHandle == nullptr)
             {
                 return EXIT_FAILURE;
             }

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -95,7 +95,7 @@ private:
         bool inherited;
         DataMemberPtr dataMember;
     };
-    typedef list<MemberInfo> MemberInfoList;
+    using MemberInfoList = list<MemberInfo>;
 
     // Write a member assignment statement for a constructor.
     void writeAssign(const MemberInfo&);
@@ -1454,7 +1454,7 @@ compile(const vector<string>& argv)
             PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
             FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2PHP__");
 
-            if (cppHandle == 0)
+            if (cppHandle == nullptr)
             {
                 return EXIT_FAILURE;
             }
@@ -1487,7 +1487,7 @@ compile(const vector<string>& argv)
             PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
             FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2PHP__");
 
-            if (cppHandle == 0)
+            if (cppHandle == nullptr)
             {
                 return EXIT_FAILURE;
             }

--- a/cpp/src/slice2py/Python.cpp
+++ b/cpp/src/slice2py/Python.cpp
@@ -558,7 +558,7 @@ Slice::Python::compile(const vector<string>& argv)
             PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
             FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2PY__");
 
-            if (cppHandle == 0)
+            if (cppHandle == nullptr)
             {
                 return EXIT_FAILURE;
             }
@@ -592,7 +592,7 @@ Slice::Python::compile(const vector<string>& argv)
             PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
             FILE* cppHandle = icecpp->preprocess(true, "-D__SLICE2PY__");
 
-            if (cppHandle == 0)
+            if (cppHandle == nullptr)
             {
                 return EXIT_FAILURE;
             }

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -246,7 +246,7 @@ namespace Slice
                 bool inherited;
                 DataMemberPtr dataMember;
             };
-            typedef list<MemberInfo> MemberInfoList;
+            using MemberInfoList = list<MemberInfo>;
 
             //
             // Write a member assignment statement for a constructor.
@@ -272,7 +272,7 @@ namespace Slice
             void writeDocstring(const string&, const DataMemberList&);
             void writeDocstring(const string&, const EnumeratorList&);
 
-            typedef map<string, string> StringMap;
+            using StringMap = map<string, string>;
             struct OpDocComment
             {
                 vector<string> description;

--- a/cpp/src/slice2rb/Ruby.cpp
+++ b/cpp/src/slice2rb/Ruby.cpp
@@ -167,7 +167,7 @@ Slice::Ruby::compile(const vector<string>& argv)
             PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
             FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2RB__");
 
-            if (cppHandle == 0)
+            if (cppHandle == nullptr)
             {
                 return EXIT_FAILURE;
             }
@@ -200,7 +200,7 @@ Slice::Ruby::compile(const vector<string>& argv)
             PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
             FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2RB__");
 
-            if (cppHandle == 0)
+            if (cppHandle == nullptr)
             {
                 return EXIT_FAILURE;
             }

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -95,7 +95,7 @@ namespace Slice
                 bool inherited = false;
                 DataMemberPtr dataMember;
             };
-            typedef list<MemberInfo> MemberInfoList;
+            using MemberInfoList = list<MemberInfo>;
 
             //
             // Write constructor parameters with default values.

--- a/cpp/src/slice2swift/Main.cpp
+++ b/cpp/src/slice2swift/Main.cpp
@@ -181,7 +181,7 @@ compile(const vector<string>& argv)
             PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
             FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2SWIFT__");
 
-            if (cppHandle == 0)
+            if (cppHandle == nullptr)
             {
                 return EXIT_FAILURE;
             }
@@ -214,7 +214,7 @@ compile(const vector<string>& argv)
             PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
             FILE* cppHandle = icecpp->preprocess(true, "-D__SLICE2SWIFT__");
 
-            if (cppHandle == 0)
+            if (cppHandle == nullptr)
             {
                 return EXIT_FAILURE;
             }

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -8,7 +8,7 @@
 #include "../Ice/OutputUtil.h"
 #include "../Slice/Parser.h"
 
-typedef std::list<std::pair<std::string, std::string>> StringPairList;
+using StringPairList = std::list<std::pair<std::string, std::string>>;
 
 namespace Slice
 {
@@ -32,7 +32,7 @@ namespace Slice
         ParameterPtr param; // 0 == return value
     };
 
-    typedef std::list<ParamInfo> ParamInfoList;
+    using ParamInfoList = std::list<ParamInfo>;
 
     class SwiftGenerator
     {
@@ -143,8 +143,8 @@ namespace Slice
         private:
             MetadataList validate(const SyntaxTreeBasePtr&, const ContainedPtr&);
 
-            typedef std::map<std::string, std::string> ModuleMap;
-            typedef std::map<std::string, ModuleMap> ModulePrefix;
+            using ModuleMap = std::map<std::string, std::string>;
+            using ModulePrefix = std::map<std::string, ModuleMap>;
 
             //
             // Each Slice unit has to map all top-level modules to a single Swift module

--- a/cpp/test/Common/TestHelper.cpp
+++ b/cpp/test/Common/TestHelper.cpp
@@ -15,7 +15,7 @@ using namespace Test;
 namespace
 {
 #if (!defined(__APPLE__) || TARGET_OS_IPHONE == 0)
-    Test::TestHelper* instance = 0;
+    Test::TestHelper* instance = nullptr;
 
     void shutdownOnInterruptCallback(int)
     {
@@ -128,10 +128,10 @@ StreamHelper::sputc(char c)
 #endif
 
 Test::TestHelper::TestHelper(bool registerPlugins)
-    : _controllerHelper(0)
+    : _controllerHelper(nullptr)
 #if !defined(__APPLE__) || TARGET_OS_IPHONE == 0
       ,
-      _ctrlCHandler(0)
+      _ctrlCHandler(nullptr)
 #endif
 {
 #if !defined(__APPLE__) || TARGET_OS_IPHONE == 0
@@ -167,7 +167,7 @@ Test::TestHelper::~TestHelper()
     if (_ctrlCHandler)
     {
         delete _ctrlCHandler;
-        _ctrlCHandler = 0;
+        _ctrlCHandler = nullptr;
     }
 #endif
 }
@@ -349,7 +349,7 @@ void
 Test::TestHelper::shutdownOnInterrupt()
 {
     assert(!_ctrlCHandler);
-    if (_ctrlCHandler == 0)
+    if (_ctrlCHandler == nullptr)
     {
         _ctrlCHandler = new Ice::CtrlCHandler();
     }

--- a/cpp/test/DataStorm/api/Writer.cpp
+++ b/cpp/test/DataStorm/api/Writer.cpp
@@ -16,7 +16,7 @@ class Writer : public Test::TestHelper
 public:
     Writer() : Test::TestHelper(false) {}
 
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void ::Writer::run(int argc, char* argv[])

--- a/cpp/test/DataStorm/callbacks/Reader.cpp
+++ b/cpp/test/DataStorm/callbacks/Reader.cpp
@@ -18,7 +18,7 @@ class Reader : public Test::TestHelper
 public:
     Reader() : Test::TestHelper(false) {}
 
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void ::Reader::run(int argc, char* argv[])

--- a/cpp/test/DataStorm/callbacks/Writer.cpp
+++ b/cpp/test/DataStorm/callbacks/Writer.cpp
@@ -18,7 +18,7 @@ class Writer : public Test::TestHelper
 public:
     Writer() : Test::TestHelper(false) {}
 
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void ::Writer::run(int argc, char* argv[])

--- a/cpp/test/DataStorm/config/Reader.cpp
+++ b/cpp/test/DataStorm/config/Reader.cpp
@@ -13,7 +13,7 @@ class Reader : public Test::TestHelper
 public:
     Reader() : Test::TestHelper(false) {}
 
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void ::Reader::run(int argc, char* argv[])

--- a/cpp/test/DataStorm/config/Writer.cpp
+++ b/cpp/test/DataStorm/config/Writer.cpp
@@ -15,7 +15,7 @@ class Writer : public Test::TestHelper
 public:
     Writer() : Test::TestHelper(false) {}
 
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void ::Writer::run(int argc, char* argv[])

--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -14,7 +14,7 @@ class Reader : public Test::TestHelper
 public:
     Reader() : Test::TestHelper(false) {}
 
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void ::Reader::run(int argc, char* argv[])

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -14,7 +14,7 @@ class Writer : public Test::TestHelper
 public:
     Writer() : Test::TestHelper(false) {}
 
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void ::Writer::run(int argc, char* argv[])

--- a/cpp/test/DataStorm/partial/Reader.cpp
+++ b/cpp/test/DataStorm/partial/Reader.cpp
@@ -15,7 +15,7 @@ class Reader : public Test::TestHelper
 public:
     Reader() : Test::TestHelper(false) {}
 
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void ::Reader::run(int argc, char* argv[])

--- a/cpp/test/DataStorm/partial/Writer.cpp
+++ b/cpp/test/DataStorm/partial/Writer.cpp
@@ -18,7 +18,7 @@ class Writer : public Test::TestHelper
 public:
     Writer() : Test::TestHelper(false) {}
 
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void ::Writer::run(int argc, char* argv[])

--- a/cpp/test/DataStorm/reliability/Reader.cpp
+++ b/cpp/test/DataStorm/reliability/Reader.cpp
@@ -15,7 +15,7 @@ class Reader : public Test::TestHelper
 public:
     Reader() : Test::TestHelper(false) {}
 
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void ::Reader::run(int argc, char* argv[])

--- a/cpp/test/DataStorm/reliability/Writer.cpp
+++ b/cpp/test/DataStorm/reliability/Writer.cpp
@@ -13,7 +13,7 @@ class Writer : public Test::TestHelper
 public:
     Writer() : Test::TestHelper(false) {}
 
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void ::Writer::run(int argc, char* argv[])

--- a/cpp/test/DataStorm/types/Reader.cpp
+++ b/cpp/test/DataStorm/types/Reader.cpp
@@ -21,7 +21,7 @@ class Reader : public Test::TestHelper
 public:
     Reader() : Test::TestHelper(false) {}
 
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 namespace

--- a/cpp/test/Ice/adapterDeactivation/Client.cpp
+++ b/cpp/test/Ice/adapterDeactivation/Client.cpp
@@ -15,7 +15,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/adapterDeactivation/Collocated.cpp
+++ b/cpp/test/Ice/adapterDeactivation/Collocated.cpp
@@ -13,7 +13,7 @@ using namespace Test;
 class Collocated : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/adapterDeactivation/Server.cpp
+++ b/cpp/test/Ice/adapterDeactivation/Server.cpp
@@ -11,7 +11,7 @@ using namespace Ice;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/adapterDeactivation/TestI.h
+++ b/cpp/test/Ice/adapterDeactivation/TestI.h
@@ -10,8 +10,8 @@
 class TestI : public Test::TestIntf
 {
 public:
-    virtual void transient(const Ice::Current&);
-    virtual void deactivate(const Ice::Current&);
+    void transient(const Ice::Current&) override;
+    void deactivate(const Ice::Current&) override;
 };
 
 class Cookie

--- a/cpp/test/Ice/admin/AllTests.cpp
+++ b/cpp/test/Ice/admin/AllTests.cpp
@@ -243,7 +243,7 @@ allTests(Test::TestHelper* helper)
         Identity id = stringToIdentity("test-admin");
         try
         {
-            com->createAdmin(0, id);
+            com->createAdmin(nullptr, id);
             test(false);
         }
         catch (const InitializationException&)

--- a/cpp/test/Ice/admin/Client.cpp
+++ b/cpp/test/Ice/admin/Client.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/admin/Server.cpp
+++ b/cpp/test/Ice/admin/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -22,7 +22,7 @@ namespace
     public:
         PingReplyI() : _received(false) {}
 
-        virtual void reply(const Current&) { _received = true; }
+        void reply(const Current&) override { _received = true; }
 
         bool checkReceived() { return _received; }
 

--- a/cpp/test/Ice/ami/Client.cpp
+++ b/cpp/test/Ice/ami/Client.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/ami/Collocated.cpp
+++ b/cpp/test/Ice/ami/Collocated.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Collocated : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/ami/Server.cpp
+++ b/cpp/test/Ice/ami/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/background/Acceptor.h
+++ b/cpp/test/Ice/background/Acceptor.h
@@ -12,18 +12,18 @@ class Acceptor : public IceInternal::Acceptor
 {
 public:
     Acceptor(const EndpointIPtr&, const IceInternal::AcceptorPtr&);
-    virtual IceInternal::NativeInfoPtr getNativeInfo();
+    IceInternal::NativeInfoPtr getNativeInfo() override;
 
-    virtual void close();
-    virtual IceInternal::EndpointIPtr listen();
+    void close() override;
+    IceInternal::EndpointIPtr listen() override;
 #ifdef ICE_USE_IOCP
     virtual void startAccept();
     virtual void finishAccept();
 #endif
-    virtual IceInternal::TransceiverPtr accept();
-    virtual std::string protocol() const;
-    virtual std::string toString() const;
-    virtual std::string toDetailedString() const;
+    IceInternal::TransceiverPtr accept() override;
+    std::string protocol() const override;
+    std::string toString() const override;
+    std::string toDetailedString() const override;
 
     IceInternal::AcceptorPtr delegate() const { return _acceptor; }
 

--- a/cpp/test/Ice/background/AllTests.cpp
+++ b/cpp/test/Ice/background/AllTests.cpp
@@ -297,11 +297,11 @@ connectTests(const ConfigurationPtr& configuration, const BackgroundPrx& backgro
 
         if (i == 0 || i == 2)
         {
-            configuration->connectorsException(0);
+            configuration->connectorsException(nullptr);
         }
         else
         {
-            configuration->connectException(0);
+            configuration->connectException(nullptr);
         }
     }
 
@@ -326,7 +326,7 @@ connectTests(const ConfigurationPtr& configuration, const BackgroundPrx& backgro
             make_exception_ptr(Ice::SocketException{__FILE__, __LINE__, socketErrorMessage}));
         background->ice_getCachedConnection()->abort();
         this_thread::sleep_for(chrono::milliseconds(10));
-        configuration->connectException(0);
+        configuration->connectException(nullptr);
         try
         {
             background->ice_ping();
@@ -400,12 +400,12 @@ initializeTests(
 
         if (i == 0 || i == 2)
         {
-            configuration->initializeException(0);
+            configuration->initializeException(nullptr);
         }
         else
         {
             configuration->initializeSocketOperation(IceInternal::SocketOperationNone);
-            configuration->initializeException(0);
+            configuration->initializeException(nullptr);
         }
     }
 
@@ -511,7 +511,7 @@ initializeTests(
             make_exception_ptr(Ice::SocketException{__FILE__, __LINE__, socketErrorMessage}));
         background->ice_getCachedConnection()->abort();
         this_thread::sleep_for(chrono::milliseconds(10));
-        configuration->initializeException(0);
+        configuration->initializeException(nullptr);
         try
         {
             background->ice_ping();
@@ -606,7 +606,7 @@ validationTests(
     }
     catch (const Ice::SocketException&)
     {
-        configuration->readException(0);
+        configuration->readException(nullptr);
     }
     catch (const Ice::LocalException& ex)
     {
@@ -627,7 +627,7 @@ validationTests(
             [&sent](bool value) { sent.set_value(value); });
         test(sent.get_future().wait_for(chrono::milliseconds(0)) != future_status::ready);
         completed.get_future().get();
-        configuration->readException(0);
+        configuration->readException(nullptr);
     }
 
     if (background->ice_getCommunicator()->getProperties()->getIceProperty("Ice.Default.Protocol") != "test-ssl" &&
@@ -658,7 +658,7 @@ validationTests(
         }
         catch (const Ice::SocketException&)
         {
-            configuration->readException(0);
+            configuration->readException(nullptr);
             configuration->readReady(true);
         }
         catch (const Ice::LocalException& ex)
@@ -691,7 +691,7 @@ validationTests(
                     }
                 });
             completed.get_future().get();
-            configuration->readException(0);
+            configuration->readException(nullptr);
             configuration->readReady(true);
         }
     }
@@ -881,7 +881,7 @@ readWriteTests(
         }
         catch (const Ice::SocketException&)
         {
-            configuration->writeException(0);
+            configuration->writeException(nullptr);
         }
 
         background->ice_ping();
@@ -908,7 +908,7 @@ readWriteTests(
             [&sent](bool value) { sent.set_value(value); });
         test(sent.get_future().wait_for(chrono::milliseconds(0)) != future_status::ready);
         completed.get_future().get();
-        configuration->writeException(0);
+        configuration->writeException(nullptr);
     }
 
     try
@@ -920,7 +920,7 @@ readWriteTests(
     }
     catch (const Ice::SocketException&)
     {
-        configuration->readException(0);
+        configuration->readException(nullptr);
     }
 
     background->ice_ping();
@@ -947,7 +947,7 @@ readWriteTests(
             });
         completed.get_future().get();
     }
-    configuration->readException(0);
+    configuration->readException(nullptr);
     configuration->readReady(true);
 
 #if defined(ICE_USE_IOCP) || defined(ICE_USE_CFSTREAM)
@@ -992,7 +992,7 @@ readWriteTests(
         catch (const Ice::SocketException&)
         {
             configuration->writeReady(true);
-            configuration->writeException(0);
+            configuration->writeException(nullptr);
         }
 
         for (int i = 0; i < 2; ++i)
@@ -1026,7 +1026,7 @@ readWriteTests(
             test(sent.get_future().wait_for(chrono::milliseconds(0)) != future_status::ready);
             completed.get_future().get();
             configuration->writeReady(true);
-            configuration->writeException(0);
+            configuration->writeException(nullptr);
         }
 
         try
@@ -1040,7 +1040,7 @@ readWriteTests(
         }
         catch (const Ice::SocketException&)
         {
-            configuration->readException(0);
+            configuration->readException(nullptr);
             configuration->readReady(true);
         }
 
@@ -1069,7 +1069,7 @@ readWriteTests(
                 });
             completed.get_future().get();
             configuration->readReady(true);
-            configuration->readException(0);
+            configuration->readException(nullptr);
         }
 
         {
@@ -1099,7 +1099,7 @@ readWriteTests(
             completed.get_future().get();
             configuration->writeReady(true);
             configuration->readReady(true);
-            configuration->readException(0);
+            configuration->readException(nullptr);
         }
 #if defined(ICE_USE_IOCP) || defined(ICE_USE_CFSTREAM)
     }
@@ -1284,7 +1284,7 @@ readWriteTests(
         catch (const Ice::LocalException&)
         {
         }
-        configuration->writeException(0);
+        configuration->writeException(nullptr);
 
         this_thread::sleep_for(chrono::milliseconds(10));
 

--- a/cpp/test/Ice/background/Client.cpp
+++ b/cpp/test/Ice/background/Client.cpp
@@ -22,7 +22,7 @@ extern "C"
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/background/Connector.h
+++ b/cpp/test/Ice/background/Connector.h
@@ -11,13 +11,13 @@
 class Connector : public IceInternal::Connector
 {
 public:
-    IceInternal::TransceiverPtr connect();
+    IceInternal::TransceiverPtr connect() override;
 
-    std::int16_t type() const;
-    std::string toString() const;
+    std::int16_t type() const override;
+    std::string toString() const override;
 
-    virtual bool operator==(const IceInternal::Connector&) const;
-    virtual bool operator<(const IceInternal::Connector&) const;
+    bool operator==(const IceInternal::Connector&) const override;
+    bool operator<(const IceInternal::Connector&) const override;
 
     Connector(const IceInternal::ConnectorPtr& connector);
 

--- a/cpp/test/Ice/background/EndpointI.cpp
+++ b/cpp/test/Ice/background/EndpointI.cpp
@@ -131,7 +131,7 @@ EndpointI::transceiver() const
     }
     else
     {
-        return 0;
+        return nullptr;
     }
 }
 

--- a/cpp/test/Ice/background/Server.cpp
+++ b/cpp/test/Ice/background/Server.cpp
@@ -49,7 +49,7 @@ public:
         response(current.adapter->createDirectProxy(id));
     }
 
-    optional<LocatorRegistryPrx> getRegistry(const Current&) const { return nullopt; }
+    optional<LocatorRegistryPrx> getRegistry(const Current&) const override { return nullopt; }
 
     LocatorI(const BackgroundControllerIPtr& controller) : _controller(controller) {}
 
@@ -60,7 +60,7 @@ private:
 class RouterI final : public Router
 {
 public:
-    optional<ObjectPrx> getClientProxy(optional<bool>& hasRoutingTable, const Current& current) const
+    optional<ObjectPrx> getClientProxy(optional<bool>& hasRoutingTable, const Current& current) const override
     {
         hasRoutingTable = true;
         _controller->checkCallPause(current);
@@ -84,7 +84,7 @@ private:
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/background/Transceiver.h
+++ b/cpp/test/Ice/background/Transceiver.h
@@ -16,7 +16,7 @@ public:
     IceInternal::NativeInfoPtr getNativeInfo() final;
 
     IceInternal::SocketOperation closing(bool, std::exception_ptr) final;
-    void close();
+    void close() override;
     IceInternal::SocketOperation write(IceInternal::Buffer&) final;
     IceInternal::SocketOperation read(IceInternal::Buffer&) final;
 #ifdef ICE_USE_IOCP

--- a/cpp/test/Ice/binding/Client.cpp
+++ b/cpp/test/Ice/binding/Client.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/binding/Server.cpp
+++ b/cpp/test/Ice/binding/Server.cpp
@@ -29,7 +29,7 @@ namespace
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/custom/Client.cpp
+++ b/cpp/test/Ice/custom/Client.cpp
@@ -12,7 +12,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/custom/Collocated.cpp
+++ b/cpp/test/Ice/custom/Collocated.cpp
@@ -13,7 +13,7 @@ using namespace std;
 class Collocated : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/custom/MyByteSeq.cpp
+++ b/cpp/test/Ice/custom/MyByteSeq.cpp
@@ -7,9 +7,9 @@
 
 using namespace std;
 
-MyByteSeq::MyByteSeq() : _size(0), _data(0) {}
+MyByteSeq::MyByteSeq() : _size(0), _data(nullptr) {}
 
-MyByteSeq::MyByteSeq(size_t size) : _size(size), _data(0)
+MyByteSeq::MyByteSeq(size_t size) : _size(size), _data(nullptr)
 {
     if (_size != 0)
     {
@@ -72,7 +72,7 @@ MyByteSeq&
 MyByteSeq::operator=(const MyByteSeq& rhs)
 {
     delete[] _data;
-    _data = 0;
+    _data = nullptr;
 
     _size = rhs._size;
     if (_size != 0)

--- a/cpp/test/Ice/custom/Server.cpp
+++ b/cpp/test/Ice/custom/Server.cpp
@@ -13,7 +13,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/custom/ServerAMD.cpp
+++ b/cpp/test/Ice/custom/ServerAMD.cpp
@@ -13,7 +13,7 @@ using namespace std;
 class ServerAMD : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/custom/StringConverterI.cpp
+++ b/cpp/test/Ice/custom/StringConverterI.cpp
@@ -11,7 +11,7 @@ byte*
 Test::StringConverterI::toUTF8(const char* sourceStart, const char* sourceEnd, UTF8Buffer& buffer) const
 {
     size_t size = static_cast<size_t>(sourceEnd - sourceStart);
-    byte* targetStart = buffer.getMoreBytes(size, 0);
+    byte* targetStart = buffer.getMoreBytes(size, nullptr);
     byte* targetEnd = targetStart + size;
 
     for (size_t i = 0; i < size; ++i)
@@ -40,7 +40,7 @@ Test::WstringConverterI::toUTF8(const wchar_t* sourceStart, const wchar_t* sourc
     string s = wstringToString(ws);
 
     size_t size = s.size();
-    byte* targetStart = buffer.getMoreBytes(size, 0);
+    byte* targetStart = buffer.getMoreBytes(size, nullptr);
     byte* targetEnd = targetStart + size;
 
     for (size_t i = 0; i < size; ++i)

--- a/cpp/test/Ice/custom/TestI.h
+++ b/cpp/test/Ice/custom/TestI.h
@@ -89,11 +89,11 @@ public:
         Test::CustomMap<std::string, std::int32_t>&,
         const Ice::Current&) final;
 
-    Test::ShortBuffer opShortBuffer(Test::ShortBuffer, Test::ShortBuffer&, const Ice::Current&);
+    Test::ShortBuffer opShortBuffer(Test::ShortBuffer, Test::ShortBuffer&, const Ice::Current&) override;
 
-    Test::CustomBuffer<bool> opBoolBuffer(Test::CustomBuffer<bool>, Test::CustomBuffer<bool>&, const Ice::Current&);
+    Test::CustomBuffer<bool> opBoolBuffer(Test::CustomBuffer<bool>, Test::CustomBuffer<bool>&, const Ice::Current&) override;
 
-    Test::BufferStruct opBufferStruct(Test::BufferStruct, const Ice::Current&);
+    Test::BufferStruct opBufferStruct(Test::BufferStruct, const Ice::Current&) override;
 
     void shutdown(const Ice::Current&) final;
 };

--- a/cpp/test/Ice/custom/TestI.h
+++ b/cpp/test/Ice/custom/TestI.h
@@ -91,7 +91,8 @@ public:
 
     Test::ShortBuffer opShortBuffer(Test::ShortBuffer, Test::ShortBuffer&, const Ice::Current&) override;
 
-    Test::CustomBuffer<bool> opBoolBuffer(Test::CustomBuffer<bool>, Test::CustomBuffer<bool>&, const Ice::Current&) override;
+    Test::CustomBuffer<bool>
+    opBoolBuffer(Test::CustomBuffer<bool>, Test::CustomBuffer<bool>&, const Ice::Current&) override;
 
     Test::BufferStruct opBufferStruct(Test::BufferStruct, const Ice::Current&) override;
 

--- a/cpp/test/Ice/custom/WstringI.h
+++ b/cpp/test/Ice/custom/WstringI.h
@@ -12,11 +12,11 @@ namespace Test1
     class WstringClassI : public virtual WstringClass
     {
     public:
-        virtual std::wstring opString(std::wstring, std::wstring&, const Ice::Current&);
+        std::wstring opString(std::wstring, std::wstring&, const Ice::Current&) override;
 
-        virtual ::Test1::WstringStruct opStruct(::Test1::WstringStruct, ::Test1::WstringStruct&, const Ice::Current&);
+        ::Test1::WstringStruct opStruct(::Test1::WstringStruct, ::Test1::WstringStruct&, const Ice::Current&) override;
 
-        virtual void throwExcept(std::wstring, const Ice::Current&);
+        void throwExcept(std::wstring, const Ice::Current&) override;
     };
 }
 
@@ -25,11 +25,11 @@ namespace Test2
     class WstringClassI : public virtual WstringClass
     {
     public:
-        virtual std::wstring opString(std::wstring, std::wstring&, const Ice::Current&);
+        std::wstring opString(std::wstring, std::wstring&, const Ice::Current&) override;
 
-        virtual ::Test2::WstringStruct opStruct(::Test2::WstringStruct, ::Test2::WstringStruct&, const Ice::Current&);
+        ::Test2::WstringStruct opStruct(::Test2::WstringStruct, ::Test2::WstringStruct&, const Ice::Current&) override;
 
-        virtual void throwExcept(std::wstring, const Ice::Current&);
+        void throwExcept(std::wstring, const Ice::Current&) override;
     };
 }
 

--- a/cpp/test/Ice/defaultServant/AllTests.cpp
+++ b/cpp/test/Ice/defaultServant/AllTests.cpp
@@ -32,7 +32,7 @@ allTests(Test::TestHelper* helper)
     test(r == servant);
 
     r = oa->findDefaultServant("bar");
-    test(r == 0);
+    test(r == nullptr);
 
     Ice::Identity identity;
     identity.category = "foo";
@@ -139,7 +139,7 @@ allTests(Test::TestHelper* helper)
     oa->addDefaultServant(servant, "");
 
     r = oa->findDefaultServant("bar");
-    test(r == 0);
+    test(r == nullptr);
 
     r = oa->findDefaultServant("");
     test(r == servant);

--- a/cpp/test/Ice/defaultServant/Client.cpp
+++ b/cpp/test/Ice/defaultServant/Client.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/defaultValue/Client.cpp
+++ b/cpp/test/Ice/defaultValue/Client.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/echo/Server.cpp
+++ b/cpp/test/Ice/echo/Server.cpp
@@ -14,13 +14,13 @@ class EchoI : public Test::Echo
 public:
     EchoI(const BlobjectIPtr& blob) : _blob(blob) {}
 
-    virtual void setConnection(const Ice::Current& current) { _blob->setConnection(current.con); }
+    void setConnection(const Ice::Current& current) override { _blob->setConnection(current.con); }
 
-    virtual void startBatch(const Ice::Current&) { _blob->startBatch(); }
+    void startBatch(const Ice::Current&) override { _blob->startBatch(); }
 
-    virtual void flushBatch(const Ice::Current&) { _blob->flushBatch(); }
+    void flushBatch(const Ice::Current&) override { _blob->flushBatch(); }
 
-    virtual void shutdown(const Ice::Current& current) { current.adapter->getCommunicator()->shutdown(); }
+    void shutdown(const Ice::Current& current) override { current.adapter->getCommunicator()->shutdown(); }
 
 private:
     BlobjectIPtr _blob;
@@ -29,7 +29,7 @@ private:
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/enums/Client.cpp
+++ b/cpp/test/Ice/enums/Client.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/enums/Server.cpp
+++ b/cpp/test/Ice/enums/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/exceptions/Client.cpp
+++ b/cpp/test/Ice/exceptions/Client.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/exceptions/Collocated.cpp
+++ b/cpp/test/Ice/exceptions/Collocated.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Collocated : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/exceptions/Server.cpp
+++ b/cpp/test/Ice/exceptions/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/exceptions/ServerAMD.cpp
+++ b/cpp/test/Ice/exceptions/ServerAMD.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class ServerAMD : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/exceptions/TestAMDI.h
+++ b/cpp/test/Ice/exceptions/TestAMDI.h
@@ -14,89 +14,89 @@ class ThrowerI : public Test::Thrower
 public:
     ThrowerI();
 
-    virtual void shutdownAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void shutdownAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void supportsUndeclaredExceptionsAsync(
+    void supportsUndeclaredExceptionsAsync(
         std::function<void(bool)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void supportsAssertExceptionAsync(
+    void supportsAssertExceptionAsync(
         std::function<void(bool)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void
-    throwAasAAsync(int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    throwAasAAsync(int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void
-    throwAorDasAorDAsync(int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    throwAorDasAorDAsync(int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void
-    throwBasAAsync(int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    throwBasAAsync(int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void
-    throwCasAAsync(int, int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    throwCasAAsync(int, int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void
-    throwBasBAsync(int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    throwBasBAsync(int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void
-    throwCasBAsync(int, int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    throwCasBAsync(int, int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void
-    throwCasCAsync(int, int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    throwCasCAsync(int, int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void
-    throwModAAsync(int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    throwModAAsync(int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void
-    throwUndeclaredAAsync(int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    throwUndeclaredAAsync(int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void throwUndeclaredBAsync(
+    void throwUndeclaredBAsync(
         int,
         int,
         std::function<void()>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void throwUndeclaredCAsync(
+    void throwUndeclaredCAsync(
         int,
         int,
         int,
         std::function<void()>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void
-    throwLocalExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    throwLocalExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void
-    throwNonIceExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    throwNonIceExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void
-    throwAssertExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    throwAssertExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void throwMemoryLimitExceptionAsync(
+    void throwMemoryLimitExceptionAsync(
         Ice::ByteSeq,
         std::function<void(const Ice::ByteSeq&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void throwLocalExceptionIdempotentAsync(
+    void throwLocalExceptionIdempotentAsync(
         std::function<void()>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void
-    throwAfterResponseAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    throwAfterResponseAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void
-    throwAfterExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    throwAfterExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void throwEAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void throwEAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void throwFAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void throwFAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 };
 
 #endif

--- a/cpp/test/Ice/exceptions/TestAMDI.h
+++ b/cpp/test/Ice/exceptions/TestAMDI.h
@@ -29,36 +29,36 @@ public:
     void
     throwAasAAsync(int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    void
-    throwAorDasAorDAsync(int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
+    void throwAorDasAorDAsync(int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
+        override;
+
+    void throwBasAAsync(int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
+        override;
 
     void
-    throwBasAAsync(int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
+    throwCasAAsync(int, int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
+        override;
+
+    void throwBasBAsync(int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
+        override;
 
     void
-    throwCasAAsync(int, int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
+    throwCasBAsync(int, int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
+        override;
 
     void
-    throwBasBAsync(int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
+    throwCasCAsync(int, int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
+        override;
+
+    void throwModAAsync(int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
+        override;
+
+    void throwUndeclaredAAsync(int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
+        override;
 
     void
-    throwCasBAsync(int, int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
-
-    void
-    throwCasCAsync(int, int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
-
-    void
-    throwModAAsync(int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
-
-    void
-    throwUndeclaredAAsync(int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
-
-    void throwUndeclaredBAsync(
-        int,
-        int,
-        std::function<void()>,
-        std::function<void(std::exception_ptr)>,
-        const Ice::Current&) override;
+    throwUndeclaredBAsync(int, int, std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
+        override;
 
     void throwUndeclaredCAsync(
         int,
@@ -68,14 +68,14 @@ public:
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) override;
 
-    void
-    throwLocalExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
+    void throwLocalExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
+        override;
 
-    void
-    throwNonIceExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
+    void throwNonIceExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
+        override;
 
-    void
-    throwAssertExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
+    void throwAssertExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
+        override;
 
     void throwMemoryLimitExceptionAsync(
         Ice::ByteSeq,
@@ -88,11 +88,11 @@ public:
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) override;
 
-    void
-    throwAfterResponseAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
+    void throwAfterResponseAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
+        override;
 
-    void
-    throwAfterExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
+    void throwAfterExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
+        override;
 
     void throwEAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 

--- a/cpp/test/Ice/exceptions/TestI.h
+++ b/cpp/test/Ice/exceptions/TestI.h
@@ -14,32 +14,32 @@ class ThrowerI : public Test::Thrower
 public:
     ThrowerI();
 
-    virtual void shutdown(const Ice::Current&);
-    virtual bool supportsUndeclaredExceptions(const Ice::Current&);
-    virtual bool supportsAssertException(const Ice::Current&);
+    void shutdown(const Ice::Current&) override;
+    bool supportsUndeclaredExceptions(const Ice::Current&) override;
+    bool supportsAssertException(const Ice::Current&) override;
 
-    virtual void throwAasA(std::int32_t, const Ice::Current&);
-    virtual void throwAorDasAorD(std::int32_t, const Ice::Current&);
-    virtual void throwBasA(std::int32_t, std::int32_t, const Ice::Current&);
-    virtual void throwCasA(std::int32_t, std::int32_t, std::int32_t, const Ice::Current&);
-    virtual void throwBasB(std::int32_t, std::int32_t, const Ice::Current&);
-    virtual void throwCasB(std::int32_t, std::int32_t, std::int32_t, const Ice::Current&);
-    virtual void throwCasC(std::int32_t, std::int32_t, std::int32_t, const Ice::Current&);
+    void throwAasA(std::int32_t, const Ice::Current&) override;
+    void throwAorDasAorD(std::int32_t, const Ice::Current&) override;
+    void throwBasA(std::int32_t, std::int32_t, const Ice::Current&) override;
+    void throwCasA(std::int32_t, std::int32_t, std::int32_t, const Ice::Current&) override;
+    void throwBasB(std::int32_t, std::int32_t, const Ice::Current&) override;
+    void throwCasB(std::int32_t, std::int32_t, std::int32_t, const Ice::Current&) override;
+    void throwCasC(std::int32_t, std::int32_t, std::int32_t, const Ice::Current&) override;
 
-    virtual void throwModA(std::int32_t, std::int32_t, const Ice::Current&);
+    void throwModA(std::int32_t, std::int32_t, const Ice::Current&) override;
 
-    virtual void throwUndeclaredA(std::int32_t, const Ice::Current&);
-    virtual void throwUndeclaredB(std::int32_t, std::int32_t, const Ice::Current&);
-    virtual void throwUndeclaredC(std::int32_t, std::int32_t, std::int32_t, const Ice::Current&);
-    virtual void throwLocalException(const Ice::Current&);
-    virtual void throwNonIceException(const Ice::Current&);
-    virtual void throwAssertException(const Ice::Current&);
-    virtual Ice::ByteSeq throwMemoryLimitException(Ice::ByteSeq, const Ice::Current&);
+    void throwUndeclaredA(std::int32_t, const Ice::Current&) override;
+    void throwUndeclaredB(std::int32_t, std::int32_t, const Ice::Current&) override;
+    void throwUndeclaredC(std::int32_t, std::int32_t, std::int32_t, const Ice::Current&) override;
+    void throwLocalException(const Ice::Current&) override;
+    void throwNonIceException(const Ice::Current&) override;
+    void throwAssertException(const Ice::Current&) override;
+    Ice::ByteSeq throwMemoryLimitException(Ice::ByteSeq, const Ice::Current&) override;
 
-    virtual void throwLocalExceptionIdempotent(const Ice::Current&);
+    void throwLocalExceptionIdempotent(const Ice::Current&) override;
 
-    virtual void throwAfterResponse(const Ice::Current&);
-    virtual void throwAfterException(const Ice::Current&);
+    void throwAfterResponse(const Ice::Current&) override;
+    void throwAfterException(const Ice::Current&) override;
 };
 
 #endif

--- a/cpp/test/Ice/executor/Client.cpp
+++ b/cpp/test/Ice/executor/Client.cpp
@@ -12,7 +12,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/executor/Collocated.cpp
+++ b/cpp/test/Ice/executor/Collocated.cpp
@@ -12,7 +12,7 @@ using namespace std;
 class Collocated : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/executor/Server.cpp
+++ b/cpp/test/Ice/executor/Server.cpp
@@ -12,7 +12,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/executor/TestI.h
+++ b/cpp/test/Ice/executor/TestI.h
@@ -14,17 +14,17 @@ using TestIntfControllerIPtr = std::shared_ptr<TestIntfControllerI>;
 class TestIntfI : public virtual Test::TestIntf
 {
 public:
-    virtual void op(const Ice::Current&);
-    virtual void sleep(std::int32_t, const Ice::Current&);
-    virtual void opWithPayload(Ice::ByteSeq, const Ice::Current&);
-    virtual void shutdown(const Ice::Current&);
+    void op(const Ice::Current&) override;
+    void sleep(std::int32_t, const Ice::Current&) override;
+    void opWithPayload(Ice::ByteSeq, const Ice::Current&) override;
+    void shutdown(const Ice::Current&) override;
 };
 
 class TestIntfControllerI : public Test::TestIntfController
 {
 public:
-    virtual void holdAdapter(const Ice::Current&);
-    virtual void resumeAdapter(const Ice::Current&);
+    void holdAdapter(const Ice::Current&) override;
+    void resumeAdapter(const Ice::Current&) override;
 
     TestIntfControllerI(const Ice::ObjectAdapterPtr&);
 

--- a/cpp/test/Ice/facets/Client.cpp
+++ b/cpp/test/Ice/facets/Client.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/facets/Collocated.cpp
+++ b/cpp/test/Ice/facets/Collocated.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Collocated : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/facets/Server.cpp
+++ b/cpp/test/Ice/facets/Server.cpp
@@ -9,7 +9,7 @@
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/facets/TestI.h
+++ b/cpp/test/Ice/facets/TestI.h
@@ -10,50 +10,50 @@
 class AI : public virtual Test::A
 {
 public:
-    virtual std::string callA(const Ice::Current&);
+    std::string callA(const Ice::Current&) override;
 };
 
 class BI : public virtual Test::B, public virtual AI
 {
 public:
-    virtual std::string callB(const Ice::Current&);
+    std::string callB(const Ice::Current&) override;
 };
 
 class CI : public virtual Test::C, public virtual AI
 {
 public:
-    virtual std::string callC(const Ice::Current&);
+    std::string callC(const Ice::Current&) override;
 };
 
 class DI : public virtual Test::D, public virtual BI, public virtual CI
 {
 public:
-    virtual std::string callD(const Ice::Current&);
+    std::string callD(const Ice::Current&) override;
 };
 
 class EI : public virtual Test::E
 {
 public:
-    virtual std::string callE(const Ice::Current&);
+    std::string callE(const Ice::Current&) override;
 };
 
 class FI : public virtual Test::F, public virtual EI
 {
 public:
-    virtual std::string callF(const Ice::Current&);
+    std::string callF(const Ice::Current&) override;
 };
 
 class GI : public virtual Test::G
 {
 public:
-    virtual void shutdown(const Ice::Current&);
-    virtual std::string callG(const Ice::Current&);
+    void shutdown(const Ice::Current&) override;
+    std::string callG(const Ice::Current&) override;
 };
 
 class HI : public virtual Test::H, public virtual GI
 {
 public:
-    virtual std::string callH(const Ice::Current&);
+    std::string callH(const Ice::Current&) override;
 };
 
 #endif

--- a/cpp/test/Ice/faultTolerance/Client.cpp
+++ b/cpp/test/Ice/faultTolerance/Client.cpp
@@ -13,7 +13,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/faultTolerance/Server.cpp
+++ b/cpp/test/Ice/faultTolerance/Server.cpp
@@ -13,7 +13,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/hash/Client.cpp
+++ b/cpp/test/Ice/hash/Client.cpp
@@ -17,7 +17,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/hold/Client.cpp
+++ b/cpp/test/Ice/hold/Client.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/hold/Server.cpp
+++ b/cpp/test/Ice/hold/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/idleTimeout/Client.cpp
+++ b/cpp/test/Ice/idleTimeout/Client.cpp
@@ -10,7 +10,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/idleTimeout/Server.cpp
+++ b/cpp/test/Ice/idleTimeout/Server.cpp
@@ -10,7 +10,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/inactivityTimeout/Client.cpp
+++ b/cpp/test/Ice/inactivityTimeout/Client.cpp
@@ -10,7 +10,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/inactivityTimeout/Server.cpp
+++ b/cpp/test/Ice/inactivityTimeout/Server.cpp
@@ -10,7 +10,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/info/Client.cpp
+++ b/cpp/test/Ice/info/Client.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/info/Server.cpp
+++ b/cpp/test/Ice/info/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/inheritance/Client.cpp
+++ b/cpp/test/Ice/inheritance/Client.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/inheritance/Collocated.cpp
+++ b/cpp/test/Ice/inheritance/Collocated.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Collocated : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/inheritance/Server.cpp
+++ b/cpp/test/Ice/inheritance/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/invoke/Client.cpp
+++ b/cpp/test/Ice/invoke/Client.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/invoke/Server.cpp
+++ b/cpp/test/Ice/invoke/Server.cpp
@@ -51,7 +51,7 @@ private:
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/library/AllTests.cpp
+++ b/cpp/test/Ice/library/AllTests.cpp
@@ -15,7 +15,7 @@ ICE_DECLSPEC_IMPORT void consume(const Ice::ObjectPtr&, const Ice::ObjectPrx&);
 class TestI : public Test::MyInterface
 {
 public:
-    void op(bool, const Ice::Current&);
+    void op(bool, const Ice::Current&) override;
 };
 
 void

--- a/cpp/test/Ice/library/Client.cpp
+++ b/cpp/test/Ice/library/Client.cpp
@@ -16,7 +16,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/location/AllTests.cpp
+++ b/cpp/test/Ice/location/AllTests.cpp
@@ -18,7 +18,7 @@ using namespace Ice;
 class HelloI : public virtual Hello
 {
 public:
-    virtual void sayHello(const Ice::Current&)
+    void sayHello(const Ice::Current&) override
     {
         // Do nothing, this is just a dummy servant.
     }

--- a/cpp/test/Ice/location/Client.cpp
+++ b/cpp/test/Ice/location/Client.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/location/Server.cpp
+++ b/cpp/test/Ice/location/Server.cpp
@@ -12,7 +12,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/logger/Client1.cpp
+++ b/cpp/test/Ice/logger/Client1.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Client1 : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/logger/Client2.cpp
+++ b/cpp/test/Ice/logger/Client2.cpp
@@ -15,7 +15,7 @@ using namespace std;
 class Client2 : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/logger/Client3.cpp
+++ b/cpp/test/Ice/logger/Client3.cpp
@@ -14,7 +14,7 @@ using namespace std;
 class Client3 : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/logger/Client4.cpp
+++ b/cpp/test/Ice/logger/Client4.cpp
@@ -15,7 +15,7 @@ using namespace std;
 class Client4 : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/logger/Client5.cpp
+++ b/cpp/test/Ice/logger/Client5.cpp
@@ -35,7 +35,7 @@ const string message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 class Client5 : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/maxConnections/Client.cpp
+++ b/cpp/test/Ice/maxConnections/Client.cpp
@@ -10,7 +10,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/maxConnections/Server.cpp
+++ b/cpp/test/Ice/maxConnections/Server.cpp
@@ -10,7 +10,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/maxDispatches/Client.cpp
+++ b/cpp/test/Ice/maxDispatches/Client.cpp
@@ -10,7 +10,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/maxDispatches/Server.cpp
+++ b/cpp/test/Ice/maxDispatches/Server.cpp
@@ -10,7 +10,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/metrics/Client.cpp
+++ b/cpp/test/Ice/metrics/Client.cpp
@@ -13,7 +13,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/metrics/Collocated.cpp
+++ b/cpp/test/Ice/metrics/Collocated.cpp
@@ -13,7 +13,7 @@ using namespace Test;
 class Collocated : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/metrics/Server.cpp
+++ b/cpp/test/Ice/metrics/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/metrics/ServerAMD.cpp
+++ b/cpp/test/Ice/metrics/ServerAMD.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class ServerAMD : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/middleware/Client.cpp
+++ b/cpp/test/Ice/middleware/Client.cpp
@@ -9,7 +9,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/networkProxy/Client.cpp
+++ b/cpp/test/Ice/networkProxy/Client.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/networkProxy/Server.cpp
+++ b/cpp/test/Ice/networkProxy/Server.cpp
@@ -13,14 +13,14 @@ namespace
     class TestI : public Test::TestIntf
     {
     public:
-        virtual void shutdown(const Ice::Current& current) { current.adapter->getCommunicator()->shutdown(); }
+        void shutdown(const Ice::Current& current) override { current.adapter->getCommunicator()->shutdown(); }
     };
 }
 
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/objects/Client.cpp
+++ b/cpp/test/Ice/objects/Client.cpp
@@ -29,7 +29,7 @@ makeFactory()
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/objects/Collocated.cpp
+++ b/cpp/test/Ice/objects/Collocated.cpp
@@ -19,7 +19,7 @@ makeFactory()
 class Collocated : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/objects/Server.cpp
+++ b/cpp/test/Ice/objects/Server.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/objects/TestI.cpp
+++ b/cpp/test/Ice/objects/TestI.cpp
@@ -72,9 +72,9 @@ InitialI::InitialI(const ObjectAdapterPtr& adapter)
       _e(new EI),
       _f(new FI(_e))
 {
-    _b1->theA = _b2; // Cyclic reference to another B
-    _b1->theB = _b1; // Self reference.
-    _b1->theC = nullptr;   // Null reference.
+    _b1->theA = _b2;     // Cyclic reference to another B
+    _b1->theB = _b1;     // Self reference.
+    _b1->theC = nullptr; // Null reference.
 
     _b2->theA = _b2; // Self reference, using base.
     _b2->theB = _b1; // Cyclic reference to another B
@@ -82,9 +82,9 @@ InitialI::InitialI(const ObjectAdapterPtr& adapter)
 
     _c->theB = _b2; // Cyclic reference to a B.
 
-    _d->theA = _b1; // Reference to a B.
-    _d->theB = _b2; // Reference to a B.
-    _d->theC = nullptr;   // Reference to a C.
+    _d->theA = _b1;     // Reference to a B.
+    _d->theB = _b2;     // Reference to a B.
+    _d->theC = nullptr; // Reference to a C.
 
     _b1->postUnmarshalInvoked = false;
     _b2->postUnmarshalInvoked = false;

--- a/cpp/test/Ice/objects/TestI.cpp
+++ b/cpp/test/Ice/objects/TestI.cpp
@@ -74,7 +74,7 @@ InitialI::InitialI(const ObjectAdapterPtr& adapter)
 {
     _b1->theA = _b2; // Cyclic reference to another B
     _b1->theB = _b1; // Self reference.
-    _b1->theC = 0;   // Null reference.
+    _b1->theC = nullptr;   // Null reference.
 
     _b2->theA = _b2; // Self reference, using base.
     _b2->theB = _b1; // Cyclic reference to another B
@@ -84,7 +84,7 @@ InitialI::InitialI(const ObjectAdapterPtr& adapter)
 
     _d->theA = _b1; // Reference to a B.
     _d->theB = _b2; // Reference to a B.
-    _d->theC = 0;   // Reference to a C.
+    _d->theC = nullptr;   // Reference to a C.
 
     _b1->postUnmarshalInvoked = false;
     _b2->postUnmarshalInvoked = false;

--- a/cpp/test/Ice/objects/TestI.h
+++ b/cpp/test/Ice/objects/TestI.h
@@ -52,7 +52,7 @@ class InitialI final : public Test::Initial
 {
 public:
     InitialI(const Ice::ObjectAdapterPtr&);
-    ~InitialI();
+    ~InitialI() override;
 
     void shutdown(const Ice::Current&) final;
     Test::BPtr getB1(const Ice::Current&) final;
@@ -130,7 +130,7 @@ public:
 class F2I : public Test::F2
 {
 public:
-    void op(const Ice::Current&) {}
+    void op(const Ice::Current&) override {}
 };
 
 #endif

--- a/cpp/test/Ice/operations/Client.cpp
+++ b/cpp/test/Ice/operations/Client.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/operations/Collocated.cpp
+++ b/cpp/test/Ice/operations/Collocated.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Collocated : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/operations/Server.cpp
+++ b/cpp/test/Ice/operations/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/operations/ServerAMD.cpp
+++ b/cpp/test/Ice/operations/ServerAMD.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class ServerAMD : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/optional/AllTests.cpp
+++ b/cpp/test/Ice/optional/AllTests.cpp
@@ -29,9 +29,9 @@ namespace
 class TestObjectReader : public Ice::Value
 {
 public:
-    virtual void _iceWrite(Ice::OutputStream*) const {}
+    void _iceWrite(Ice::OutputStream*) const override {}
 
-    virtual void _iceRead(Ice::InputStream* in)
+    void _iceRead(Ice::InputStream* in) override
     {
         in->startValue();
         in->startSlice();
@@ -40,7 +40,7 @@ public:
     }
 
 protected:
-    virtual Ice::ValuePtr _iceCloneImpl() const
+    Ice::ValuePtr _iceCloneImpl() const override
     {
         assert(0); // not used
         return nullptr;
@@ -50,9 +50,9 @@ protected:
 class BObjectReader : public Ice::Value
 {
 public:
-    virtual void _iceWrite(Ice::OutputStream*) const {}
+    void _iceWrite(Ice::OutputStream*) const override {}
 
-    virtual void _iceRead(Ice::InputStream* in)
+    void _iceRead(Ice::InputStream* in) override
     {
         in->startValue();
         // ::Test::B
@@ -68,7 +68,7 @@ public:
     }
 
 protected:
-    virtual Ice::ValuePtr _iceCloneImpl() const
+    Ice::ValuePtr _iceCloneImpl() const override
     {
         assert(0); // not used
         return nullptr;
@@ -78,9 +78,9 @@ protected:
 class CObjectReader : public Ice::Value
 {
 public:
-    virtual void _iceWrite(Ice::OutputStream*) const {}
+    void _iceWrite(Ice::OutputStream*) const override {}
 
-    virtual void _iceRead(Ice::InputStream* in)
+    void _iceRead(Ice::InputStream* in) override
     {
         in->startValue();
         // ::Test::C
@@ -99,7 +99,7 @@ public:
     }
 
 protected:
-    virtual Ice::ValuePtr _iceCloneImpl() const
+    Ice::ValuePtr _iceCloneImpl() const override
     {
         assert(0); // not used
         return nullptr;
@@ -109,7 +109,7 @@ protected:
 class DObjectWriter : public Ice::Value
 {
 public:
-    virtual void _iceWrite(Ice::OutputStream* out) const
+    void _iceWrite(Ice::OutputStream* out) const override
     {
         out->startValue(nullptr);
         // ::Test::D
@@ -139,10 +139,10 @@ public:
         out->endValue();
     }
 
-    virtual void _iceRead(Ice::InputStream*) {}
+    void _iceRead(Ice::InputStream*) override {}
 
 protected:
-    virtual Ice::ValuePtr _iceCloneImpl() const
+    Ice::ValuePtr _iceCloneImpl() const override
     {
         assert(0); // not used
         return nullptr;
@@ -152,9 +152,9 @@ protected:
 class DObjectReader : public Ice::Value
 {
 public:
-    virtual void _iceWrite(Ice::OutputStream*) const {}
+    void _iceWrite(Ice::OutputStream*) const override {}
 
-    virtual void _iceRead(Ice::InputStream* in)
+    void _iceRead(Ice::InputStream* in) override
     {
         in->startValue();
         // ::Test::D
@@ -184,7 +184,7 @@ public:
     void check() { test(a->mc == 18); }
 
 protected:
-    virtual Ice::ValuePtr _iceCloneImpl() const
+    Ice::ValuePtr _iceCloneImpl() const override
     {
         assert(0); // not used
         return nullptr;
@@ -197,9 +197,9 @@ private:
 class FObjectReader : public Ice::Value
 {
 public:
-    virtual void _iceWrite(Ice::OutputStream*) const {}
+    void _iceWrite(Ice::OutputStream*) const override {}
 
-    virtual void _iceRead(Ice::InputStream* in)
+    void _iceRead(Ice::InputStream* in) override
     {
         _f = make_shared<F>();
         in->startValue();
@@ -216,7 +216,7 @@ public:
     FPtr getF() { return _f; }
 
 protected:
-    virtual Ice::ValuePtr _iceCloneImpl() const
+    Ice::ValuePtr _iceCloneImpl() const override
     {
         assert(0); // not used
         return nullptr;
@@ -237,7 +237,7 @@ public:
     {
         if (!_enabled)
         {
-            return 0;
+            return nullptr;
         }
 
         if (typeId == "::Test::OneOptional")
@@ -265,7 +265,7 @@ public:
             return make_shared<FObjectReader>();
         }
 
-        return 0;
+        return nullptr;
     }
 
     void setEnabled(bool enabled) { _enabled = enabled; }

--- a/cpp/test/Ice/optional/Client.cpp
+++ b/cpp/test/Ice/optional/Client.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/optional/Server.cpp
+++ b/cpp/test/Ice/optional/Server.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/optional/ServerAMD.cpp
+++ b/cpp/test/Ice/optional/ServerAMD.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class ServerAMD : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/optional/TestI.h
+++ b/cpp/test/Ice/optional/TestI.h
@@ -12,140 +12,140 @@ class InitialI : public Test::Initial
 public:
     InitialI();
 
-    virtual void shutdown(const Ice::Current&);
-    virtual PingPongMarshaledResult pingPong(Ice::ValuePtr, const Ice::Current&);
+    void shutdown(const Ice::Current&) override;
+    PingPongMarshaledResult pingPong(Ice::ValuePtr, const Ice::Current&) override;
 
-    virtual void opOptionalException(std::optional<std::int32_t>, std::optional<std::string>, const Ice::Current&);
+    void opOptionalException(std::optional<std::int32_t>, std::optional<std::string>, const Ice::Current&) override;
 
-    virtual void opDerivedException(std::optional<std::int32_t>, std::optional<std::string>, const Ice::Current&);
+    void opDerivedException(std::optional<std::int32_t>, std::optional<std::string>, const Ice::Current&) override;
 
-    virtual void opRequiredException(std::optional<std::int32_t>, std::optional<std::string>, const Ice::Current&);
+    void opRequiredException(std::optional<std::int32_t>, std::optional<std::string>, const Ice::Current&) override;
 
-    virtual std::optional<std::uint8_t>
-    opByte(std::optional<std::uint8_t>, std::optional<std::uint8_t>&, const Ice::Current&);
+    std::optional<std::uint8_t>
+    opByte(std::optional<std::uint8_t>, std::optional<std::uint8_t>&, const Ice::Current&) override;
 
-    virtual std::optional<bool> opBool(std::optional<bool>, std::optional<bool>&, const Ice::Current&);
+    std::optional<bool> opBool(std::optional<bool>, std::optional<bool>&, const Ice::Current&) override;
 
-    virtual std::optional<std::int16_t>
-    opShort(std::optional<std::int16_t>, std::optional<std::int16_t>&, const Ice::Current&);
+    std::optional<std::int16_t>
+    opShort(std::optional<std::int16_t>, std::optional<std::int16_t>&, const Ice::Current&) override;
 
-    virtual std::optional<std::int32_t>
-    opInt(std::optional<std::int32_t>, std::optional<std::int32_t>&, const Ice::Current&);
+    std::optional<std::int32_t>
+    opInt(std::optional<std::int32_t>, std::optional<std::int32_t>&, const Ice::Current&) override;
 
-    virtual std::optional<std::int64_t>
-    opLong(std::optional<std::int64_t>, std::optional<std::int64_t>&, const Ice::Current&);
+    std::optional<std::int64_t>
+    opLong(std::optional<std::int64_t>, std::optional<std::int64_t>&, const Ice::Current&) override;
 
-    virtual std::optional<float> opFloat(std::optional<float>, std::optional<float>&, const Ice::Current&);
+    std::optional<float> opFloat(std::optional<float>, std::optional<float>&, const Ice::Current&) override;
 
-    virtual std::optional<double> opDouble(std::optional<double>, std::optional<double>&, const Ice::Current&);
+    std::optional<double> opDouble(std::optional<double>, std::optional<double>&, const Ice::Current&) override;
 
-    virtual std::optional<std::string>
-    opString(std::optional<std::string>, std::optional<std::string>&, const Ice::Current&);
+    std::optional<std::string>
+    opString(std::optional<std::string>, std::optional<std::string>&, const Ice::Current&) override;
 
-    virtual std::optional<Test::MyEnum>
-    opMyEnum(std::optional<Test::MyEnum>, std::optional<Test::MyEnum>&, const Ice::Current&);
+    std::optional<Test::MyEnum>
+    opMyEnum(std::optional<Test::MyEnum>, std::optional<Test::MyEnum>&, const Ice::Current&) override;
 
-    virtual std::optional<Test::SmallStruct>
-    opSmallStruct(std::optional<Test::SmallStruct>, std::optional<Test::SmallStruct>&, const Ice::Current&);
+    std::optional<Test::SmallStruct>
+    opSmallStruct(std::optional<Test::SmallStruct>, std::optional<Test::SmallStruct>&, const Ice::Current&) override;
 
-    virtual std::optional<Test::FixedStruct>
-    opFixedStruct(std::optional<Test::FixedStruct>, std::optional<Test::FixedStruct>&, const Ice::Current&);
+    std::optional<Test::FixedStruct>
+    opFixedStruct(std::optional<Test::FixedStruct>, std::optional<Test::FixedStruct>&, const Ice::Current&) override;
 
-    virtual std::optional<Test::VarStruct>
-    opVarStruct(std::optional<Test::VarStruct>, std::optional<Test::VarStruct>&, const Ice::Current&);
+    std::optional<Test::VarStruct>
+    opVarStruct(std::optional<Test::VarStruct>, std::optional<Test::VarStruct>&, const Ice::Current&) override;
 
-    virtual std::optional<Test::MyInterfacePrx>
-    opMyInterfaceProxy(std::optional<Test::MyInterfacePrx>, std::optional<Test::MyInterfacePrx>&, const Ice::Current&);
+    std::optional<Test::MyInterfacePrx>
+    opMyInterfaceProxy(std::optional<Test::MyInterfacePrx>, std::optional<Test::MyInterfacePrx>&, const Ice::Current&) override;
 
-    virtual Test::OneOptionalPtr opOneOptional(Test::OneOptionalPtr, Test::OneOptionalPtr&, const Ice::Current&);
+    Test::OneOptionalPtr opOneOptional(Test::OneOptionalPtr, Test::OneOptionalPtr&, const Ice::Current&) override;
 
-    virtual std::optional<::Test::ByteSeq> opByteSeq(
+    std::optional<::Test::ByteSeq> opByteSeq(
         std::optional<std::pair<const std::byte*, const std::byte*>>,
         std::optional<::Test::ByteSeq>&,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual std::optional<::Test::BoolSeq>
-    opBoolSeq(std::optional<std::pair<const bool*, const bool*>>, std::optional<::Test::BoolSeq>&, const Ice::Current&);
+    std::optional<::Test::BoolSeq>
+    opBoolSeq(std::optional<std::pair<const bool*, const bool*>>, std::optional<::Test::BoolSeq>&, const Ice::Current&) override;
 
-    virtual std::optional<::Test::ShortSeq> opShortSeq(
+    std::optional<::Test::ShortSeq> opShortSeq(
         std::optional<std::pair<const std::int16_t*, const std::int16_t*>>,
         std::optional<::Test::ShortSeq>&,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual std::optional<::Test::IntSeq> opIntSeq(
+    std::optional<::Test::IntSeq> opIntSeq(
         std::optional<std::pair<const std::int32_t*, const std::int32_t*>>,
         std::optional<::Test::IntSeq>&,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual std::optional<::Test::LongSeq> opLongSeq(
+    std::optional<::Test::LongSeq> opLongSeq(
         std::optional<std::pair<const std::int64_t*, const std::int64_t*>>,
         std::optional<::Test::LongSeq>&,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual std::optional<::Test::FloatSeq> opFloatSeq(
+    std::optional<::Test::FloatSeq> opFloatSeq(
         std::optional<std::pair<const float*, const float*>>,
         std::optional<::Test::FloatSeq>&,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual std::optional<::Test::DoubleSeq> opDoubleSeq(
+    std::optional<::Test::DoubleSeq> opDoubleSeq(
         std::optional<std::pair<const double*, const double*>>,
         std::optional<::Test::DoubleSeq>&,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual std::optional<::Test::StringSeq>
-    opStringSeq(std::optional<::Test::StringSeq>, std::optional<::Test::StringSeq>&, const Ice::Current&);
+    std::optional<::Test::StringSeq>
+    opStringSeq(std::optional<::Test::StringSeq>, std::optional<::Test::StringSeq>&, const Ice::Current&) override;
 
-    virtual std::optional<::Test::SmallStructSeq> opSmallStructSeq(
+    std::optional<::Test::SmallStructSeq> opSmallStructSeq(
         std::optional<std::pair<const ::Test::SmallStruct*, const ::Test::SmallStruct*>>,
         std::optional<::Test::SmallStructSeq>&,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual std::optional<::Test::SmallStructList> opSmallStructList(
+    std::optional<::Test::SmallStructList> opSmallStructList(
         std::optional<std::pair<const ::Test::SmallStruct*, const ::Test::SmallStruct*>>,
         std::optional<::Test::SmallStructList>&,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual std::optional<::Test::FixedStructSeq> opFixedStructSeq(
+    std::optional<::Test::FixedStructSeq> opFixedStructSeq(
         std::optional<std::pair<const ::Test::FixedStruct*, const ::Test::FixedStruct*>>,
         std::optional<::Test::FixedStructSeq>&,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual std::optional<::Test::FixedStructList> opFixedStructList(
+    std::optional<::Test::FixedStructList> opFixedStructList(
         std::optional<std::pair<const ::Test::FixedStruct*, const ::Test::FixedStruct*>>,
         std::optional<::Test::FixedStructList>&,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual std::optional<::Test::VarStructSeq>
-    opVarStructSeq(std::optional<::Test::VarStructSeq>, std::optional<::Test::VarStructSeq>&, const Ice::Current&);
+    std::optional<::Test::VarStructSeq>
+    opVarStructSeq(std::optional<::Test::VarStructSeq>, std::optional<::Test::VarStructSeq>&, const Ice::Current&) override;
 
-    virtual std::optional<::Test::Serializable>
-    opSerializable(std::optional<::Test::Serializable>, std::optional<::Test::Serializable>&, const Ice::Current&);
+    std::optional<::Test::Serializable>
+    opSerializable(std::optional<::Test::Serializable>, std::optional<::Test::Serializable>&, const Ice::Current&) override;
 
-    virtual std::optional<::Test::IntIntDict>
-    opIntIntDict(std::optional<::Test::IntIntDict>, std::optional<::Test::IntIntDict>&, const Ice::Current&);
+    std::optional<::Test::IntIntDict>
+    opIntIntDict(std::optional<::Test::IntIntDict>, std::optional<::Test::IntIntDict>&, const Ice::Current&) override;
 
-    virtual std::optional<::Test::StringIntDict>
-    opStringIntDict(std::optional<::Test::StringIntDict>, std::optional<::Test::StringIntDict>&, const Ice::Current&);
+    std::optional<::Test::StringIntDict>
+    opStringIntDict(std::optional<::Test::StringIntDict>, std::optional<::Test::StringIntDict>&, const Ice::Current&) override;
 
-    virtual void opClassAndUnknownOptional(Test::APtr, const Ice::Current&);
+    void opClassAndUnknownOptional(Test::APtr, const Ice::Current&) override;
 
-    virtual ::Test::GPtr opG(::Test::GPtr g, const Ice::Current&);
+    ::Test::GPtr opG(::Test::GPtr g, const Ice::Current&) override;
 
-    virtual void opVoid(const Ice::Current&);
+    void opVoid(const Ice::Current&) override;
 
-    virtual OpMStruct1MarshaledResult opMStruct1(const Ice::Current&);
+    OpMStruct1MarshaledResult opMStruct1(const Ice::Current&) override;
 
-    virtual OpMStruct2MarshaledResult opMStruct2(std::optional<Test::SmallStruct>, const Ice::Current&);
+    OpMStruct2MarshaledResult opMStruct2(std::optional<Test::SmallStruct>, const Ice::Current&) override;
 
-    virtual OpMSeq1MarshaledResult opMSeq1(const Ice::Current&);
+    OpMSeq1MarshaledResult opMSeq1(const Ice::Current&) override;
 
-    virtual OpMSeq2MarshaledResult opMSeq2(std::optional<Test::StringSeq>, const Ice::Current&);
+    OpMSeq2MarshaledResult opMSeq2(std::optional<Test::StringSeq>, const Ice::Current&) override;
 
-    virtual OpMDict1MarshaledResult opMDict1(const Ice::Current&);
+    OpMDict1MarshaledResult opMDict1(const Ice::Current&) override;
 
-    virtual OpMDict2MarshaledResult opMDict2(std::optional<Test::StringIntDict>, const Ice::Current&);
+    OpMDict2MarshaledResult opMDict2(std::optional<Test::StringIntDict>, const Ice::Current&) override;
 
-    virtual bool supportsJavaSerializable(const Ice::Current&);
+    bool supportsJavaSerializable(const Ice::Current&) override;
 };
 
 #endif

--- a/cpp/test/Ice/optional/TestI.h
+++ b/cpp/test/Ice/optional/TestI.h
@@ -54,8 +54,10 @@ public:
     std::optional<Test::VarStruct>
     opVarStruct(std::optional<Test::VarStruct>, std::optional<Test::VarStruct>&, const Ice::Current&) override;
 
-    std::optional<Test::MyInterfacePrx>
-    opMyInterfaceProxy(std::optional<Test::MyInterfacePrx>, std::optional<Test::MyInterfacePrx>&, const Ice::Current&) override;
+    std::optional<Test::MyInterfacePrx> opMyInterfaceProxy(
+        std::optional<Test::MyInterfacePrx>,
+        std::optional<Test::MyInterfacePrx>&,
+        const Ice::Current&) override;
 
     Test::OneOptionalPtr opOneOptional(Test::OneOptionalPtr, Test::OneOptionalPtr&, const Ice::Current&) override;
 
@@ -64,8 +66,10 @@ public:
         std::optional<::Test::ByteSeq>&,
         const Ice::Current&) override;
 
-    std::optional<::Test::BoolSeq>
-    opBoolSeq(std::optional<std::pair<const bool*, const bool*>>, std::optional<::Test::BoolSeq>&, const Ice::Current&) override;
+    std::optional<::Test::BoolSeq> opBoolSeq(
+        std::optional<std::pair<const bool*, const bool*>>,
+        std::optional<::Test::BoolSeq>&,
+        const Ice::Current&) override;
 
     std::optional<::Test::ShortSeq> opShortSeq(
         std::optional<std::pair<const std::int16_t*, const std::int16_t*>>,
@@ -115,17 +119,23 @@ public:
         std::optional<::Test::FixedStructList>&,
         const Ice::Current&) override;
 
-    std::optional<::Test::VarStructSeq>
-    opVarStructSeq(std::optional<::Test::VarStructSeq>, std::optional<::Test::VarStructSeq>&, const Ice::Current&) override;
+    std::optional<::Test::VarStructSeq> opVarStructSeq(
+        std::optional<::Test::VarStructSeq>,
+        std::optional<::Test::VarStructSeq>&,
+        const Ice::Current&) override;
 
-    std::optional<::Test::Serializable>
-    opSerializable(std::optional<::Test::Serializable>, std::optional<::Test::Serializable>&, const Ice::Current&) override;
+    std::optional<::Test::Serializable> opSerializable(
+        std::optional<::Test::Serializable>,
+        std::optional<::Test::Serializable>&,
+        const Ice::Current&) override;
 
     std::optional<::Test::IntIntDict>
     opIntIntDict(std::optional<::Test::IntIntDict>, std::optional<::Test::IntIntDict>&, const Ice::Current&) override;
 
-    std::optional<::Test::StringIntDict>
-    opStringIntDict(std::optional<::Test::StringIntDict>, std::optional<::Test::StringIntDict>&, const Ice::Current&) override;
+    std::optional<::Test::StringIntDict> opStringIntDict(
+        std::optional<::Test::StringIntDict>,
+        std::optional<::Test::StringIntDict>&,
+        const Ice::Current&) override;
 
     void opClassAndUnknownOptional(Test::APtr, const Ice::Current&) override;
 

--- a/cpp/test/Ice/plugin/Client.cpp
+++ b/cpp/test/Ice/plugin/Client.cpp
@@ -20,11 +20,11 @@ namespace
 
         bool isDestroyed() const { return _destroyed; }
 
-        void initialize() { _initialized = true; }
+        void initialize() override { _initialized = true; }
 
-        void destroy() { _destroyed = true; }
+        void destroy() override { _destroyed = true; }
 
-        ~MyPlugin()
+        ~MyPlugin() override
         {
             test(!_initialized || _destroyed); // If initialized, we must be destroyed too.
         }
@@ -47,7 +47,7 @@ extern "C"
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/plugin/Plugin.cpp
+++ b/cpp/test/Ice/plugin/Plugin.cpp
@@ -19,11 +19,11 @@ namespace
         {
         }
 
-        void initialize() { _initialized = true; }
+        void initialize() override { _initialized = true; }
 
-        void destroy() { _destroyed = true; }
+        void destroy() override { _destroyed = true; }
 
-        ~Plugin()
+        ~Plugin() override
         {
             test(_initialized);
             test(_destroyed);
@@ -40,7 +40,7 @@ namespace
     {
     public:
         CustomPluginException() noexcept {}
-        virtual const char* what() const noexcept { return "CustomPluginException"; }
+        const char* what() const noexcept override { return "CustomPluginException"; }
     };
 
     class PluginInitializeFail : public Ice::Plugin
@@ -48,9 +48,9 @@ namespace
     public:
         PluginInitializeFail(const Ice::CommunicatorPtr& communicator) : _communicator(communicator) {}
 
-        void initialize() { throw CustomPluginException(); }
+        void initialize() override { throw CustomPluginException(); }
 
-        void destroy() { test(false); }
+        void destroy() override { test(false); }
 
     private:
         const Ice::CommunicatorPtr _communicator;
@@ -85,18 +85,18 @@ namespace
     public:
         PluginOne(const Ice::CommunicatorPtr& communicator) : BasePlugin(communicator) {}
 
-        void initialize()
+        void initialize() override
         {
             _other = dynamic_pointer_cast<BasePlugin>(_communicator->getPluginManager()->getPlugin("PluginTwo"));
             test(!_other->isInitialized());
             _initialized = true;
         }
 
-        void destroy()
+        void destroy() override
         {
             _destroyed = true;
             test(_other->isDestroyed());
-            _other = 0;
+            _other = nullptr;
         }
     };
 
@@ -105,18 +105,18 @@ namespace
     public:
         PluginTwo(const Ice::CommunicatorPtr& communicator) : BasePlugin(communicator) {}
 
-        void initialize()
+        void initialize() override
         {
             _initialized = true;
             _other = dynamic_pointer_cast<BasePlugin>(_communicator->getPluginManager()->getPlugin("PluginOne"));
             test(_other->isInitialized());
         }
 
-        void destroy()
+        void destroy() override
         {
             _destroyed = true;
             test(!_other->isDestroyed());
-            _other = 0;
+            _other = nullptr;
         }
     };
 
@@ -125,18 +125,18 @@ namespace
     public:
         PluginThree(const Ice::CommunicatorPtr& communicator) : BasePlugin(communicator) {}
 
-        void initialize()
+        void initialize() override
         {
             _initialized = true;
             _other = dynamic_pointer_cast<BasePlugin>(_communicator->getPluginManager()->getPlugin("PluginTwo"));
             test(_other->isInitialized());
         }
 
-        void destroy()
+        void destroy() override
         {
             _destroyed = true;
             test(!_other->isDestroyed());
-            _other = 0;
+            _other = nullptr;
         }
     };
 
@@ -171,7 +171,7 @@ namespace
     public:
         PluginOneFail(const Ice::CommunicatorPtr& communicator) : BasePluginFail(communicator) {}
 
-        void initialize()
+        void initialize() override
         {
             _two = dynamic_pointer_cast<BasePluginFail>(_communicator->getPluginManager()->getPlugin("PluginTwoFail"));
             test(!_two->isInitialized());
@@ -181,7 +181,7 @@ namespace
             _initialized = true;
         }
 
-        void destroy()
+        void destroy() override
         {
             test(_two->isDestroyed());
             //
@@ -189,11 +189,11 @@ namespace
             //
             test(!_three->isDestroyed());
             _destroyed = true;
-            _two = 0;
-            _three = 0;
+            _two = nullptr;
+            _three = nullptr;
         }
 
-        ~PluginOneFail()
+        ~PluginOneFail() override
         {
             test(_initialized);
             test(_destroyed);
@@ -205,7 +205,7 @@ namespace
     public:
         PluginTwoFail(const Ice::CommunicatorPtr& communicator) : BasePluginFail(communicator) {}
 
-        void initialize()
+        void initialize() override
         {
             _initialized = true;
             _one = dynamic_pointer_cast<BasePluginFail>(_communicator->getPluginManager()->getPlugin("PluginOneFail"));
@@ -215,15 +215,15 @@ namespace
             test(!_three->isInitialized());
         }
 
-        void destroy()
+        void destroy() override
         {
             _destroyed = true;
             test(!_one->isDestroyed());
-            _one = 0;
-            _three = 0;
+            _one = nullptr;
+            _three = nullptr;
         }
 
-        ~PluginTwoFail()
+        ~PluginTwoFail() override
         {
             test(_initialized);
             test(_destroyed);
@@ -235,11 +235,11 @@ namespace
     public:
         PluginThreeFail(const Ice::CommunicatorPtr& communicator) : BasePluginFail(communicator) {}
 
-        void initialize() { throw CustomPluginException(); }
+        void initialize() override { throw CustomPluginException(); }
 
-        void destroy() { test(false); }
+        void destroy() override { test(false); }
 
-        ~PluginThreeFail()
+        ~PluginThreeFail() override
         {
             test(!_initialized);
             test(!_destroyed);

--- a/cpp/test/Ice/properties/Client.cpp
+++ b/cpp/test/Ice/properties/Client.cpp
@@ -13,7 +13,7 @@ string configPath;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/proxy/Client.cpp
+++ b/cpp/test/Ice/proxy/Client.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/proxy/Collocated.cpp
+++ b/cpp/test/Ice/proxy/Collocated.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Collocated : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/proxy/Server.cpp
+++ b/cpp/test/Ice/proxy/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/proxy/ServerAMD.cpp
+++ b/cpp/test/Ice/proxy/ServerAMD.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class ServerAMD : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/proxy/TestAMDI.h
+++ b/cpp/test/Ice/proxy/TestAMDI.h
@@ -12,20 +12,20 @@ class MyDerivedClassI : public Test::MyDerivedClass
 public:
     MyDerivedClassI();
 
-    virtual void echoAsync(
+    void echoAsync(
         std::optional<Ice::ObjectPrx>,
         std::function<void(const std::optional<Ice::ObjectPrx>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void shutdownAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void shutdownAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void getContextAsync(
+    void getContextAsync(
         std::function<void(const Ice::Context&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual bool ice_isA(std::string, const Ice::Current&) const;
+    bool ice_isA(std::string, const Ice::Current&) const override;
 
 private:
     mutable Ice::Context _ctx;

--- a/cpp/test/Ice/retry/Client.cpp
+++ b/cpp/test/Ice/retry/Client.cpp
@@ -13,7 +13,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/retry/Collocated.cpp
+++ b/cpp/test/Ice/retry/Collocated.cpp
@@ -22,7 +22,7 @@ setupObjectAdapter(const Ice::CommunicatorPtr& communicator)
 class Collocated : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/retry/Server.cpp
+++ b/cpp/test/Ice/retry/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/retry/TestI.h
+++ b/cpp/test/Ice/retry/TestI.h
@@ -12,11 +12,11 @@ class RetryI : public Test::Retry
 public:
     RetryI();
 
-    virtual void op(bool, const Ice::Current&);
-    virtual int opIdempotent(int, const Ice::Current&);
-    virtual void opNotIdempotent(const Ice::Current&);
-    virtual void sleep(int, const Ice::Current&);
-    virtual void shutdown(const Ice::Current&);
+    void op(bool, const Ice::Current&) override;
+    int opIdempotent(int, const Ice::Current&) override;
+    void opNotIdempotent(const Ice::Current&) override;
+    void sleep(int, const Ice::Current&) override;
+    void shutdown(const Ice::Current&) override;
 
 private:
     int _counter;

--- a/cpp/test/Ice/scope/Client.cpp
+++ b/cpp/test/Ice/scope/Client.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/scope/Server.cpp
+++ b/cpp/test/Ice/scope/Server.cpp
@@ -11,87 +11,87 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 class I1 : public Test::I
 {
 public:
-    virtual Test::S opS(Test::S, Test::S&, const Ice::Current&);
-    virtual Test::SSeq opSSeq(Test::SSeq, Test::SSeq&, const Ice::Current&);
-    virtual Test::SMap opSMap(Test::SMap, Test::SMap&, const Ice::Current&);
+    Test::S opS(Test::S, Test::S&, const Ice::Current&) override;
+    Test::SSeq opSSeq(Test::SSeq, Test::SSeq&, const Ice::Current&) override;
+    Test::SMap opSMap(Test::SMap, Test::SMap&, const Ice::Current&) override;
 
-    virtual Test::CPtr opC(Test::CPtr, Test::CPtr&, const Ice::Current&);
-    virtual Test::CSeq opCSeq(Test::CSeq, Test::CSeq&, const Ice::Current&);
-    virtual Test::CMap opCMap(Test::CMap, Test::CMap&, const Ice::Current&);
+    Test::CPtr opC(Test::CPtr, Test::CPtr&, const Ice::Current&) override;
+    Test::CSeq opCSeq(Test::CSeq, Test::CSeq&, const Ice::Current&) override;
+    Test::CMap opCMap(Test::CMap, Test::CMap&, const Ice::Current&) override;
 
-    virtual Test::E1 opE1(Test::E1, const Ice::Current&);
-    virtual Test::S1 opS1(Test::S1, const Ice::Current&);
-    virtual Test::C1Ptr opC1(Test::C1Ptr, const Ice::Current&);
+    Test::E1 opE1(Test::E1, const Ice::Current&) override;
+    Test::S1 opS1(Test::S1, const Ice::Current&) override;
+    Test::C1Ptr opC1(Test::C1Ptr, const Ice::Current&) override;
 
-    virtual void shutdown(const Ice::Current&);
+    void shutdown(const Ice::Current&) override;
 };
 
 class I2 : public Test::Inner::Inner2::I
 {
 public:
-    virtual Test::Inner::Inner2::S opS(Test::Inner::Inner2::S, Test::Inner::Inner2::S&, const Ice::Current&);
+    Test::Inner::Inner2::S opS(Test::Inner::Inner2::S, Test::Inner::Inner2::S&, const Ice::Current&) override;
 
-    virtual Test::Inner::Inner2::SSeq
-    opSSeq(Test::Inner::Inner2::SSeq, Test::Inner::Inner2::SSeq&, const Ice::Current&);
+    Test::Inner::Inner2::SSeq
+    opSSeq(Test::Inner::Inner2::SSeq, Test::Inner::Inner2::SSeq&, const Ice::Current&) override;
 
-    virtual Test::Inner::Inner2::SMap
-    opSMap(Test::Inner::Inner2::SMap, Test::Inner::Inner2::SMap&, const Ice::Current&);
+    Test::Inner::Inner2::SMap
+    opSMap(Test::Inner::Inner2::SMap, Test::Inner::Inner2::SMap&, const Ice::Current&) override;
 
-    virtual Test::Inner::Inner2::CPtr opC(Test::Inner::Inner2::CPtr, Test::Inner::Inner2::CPtr&, const Ice::Current&);
+    Test::Inner::Inner2::CPtr opC(Test::Inner::Inner2::CPtr, Test::Inner::Inner2::CPtr&, const Ice::Current&) override;
 
-    virtual Test::Inner::Inner2::CSeq
-    opCSeq(Test::Inner::Inner2::CSeq, Test::Inner::Inner2::CSeq&, const Ice::Current&);
+    Test::Inner::Inner2::CSeq
+    opCSeq(Test::Inner::Inner2::CSeq, Test::Inner::Inner2::CSeq&, const Ice::Current&) override;
 
-    virtual Test::Inner::Inner2::CMap
-    opCMap(Test::Inner::Inner2::CMap, Test::Inner::Inner2::CMap&, const Ice::Current&);
+    Test::Inner::Inner2::CMap
+    opCMap(Test::Inner::Inner2::CMap, Test::Inner::Inner2::CMap&, const Ice::Current&) override;
 
-    virtual void shutdown(const Ice::Current&);
+    void shutdown(const Ice::Current&) override;
 };
 
 class I3 : public Test::Inner::I
 {
 public:
-    virtual Test::Inner::Inner2::S opS(Test::Inner::Inner2::S, Test::Inner::Inner2::S&, const Ice::Current&);
+    Test::Inner::Inner2::S opS(Test::Inner::Inner2::S, Test::Inner::Inner2::S&, const Ice::Current&) override;
 
-    virtual Test::Inner::Inner2::SSeq
-    opSSeq(Test::Inner::Inner2::SSeq, Test::Inner::Inner2::SSeq&, const Ice::Current&);
+    Test::Inner::Inner2::SSeq
+    opSSeq(Test::Inner::Inner2::SSeq, Test::Inner::Inner2::SSeq&, const Ice::Current&) override;
 
-    virtual Test::Inner::Inner2::SMap
-    opSMap(Test::Inner::Inner2::SMap, Test::Inner::Inner2::SMap&, const Ice::Current&);
+    Test::Inner::Inner2::SMap
+    opSMap(Test::Inner::Inner2::SMap, Test::Inner::Inner2::SMap&, const Ice::Current&) override;
 
-    virtual Test::Inner::Inner2::CPtr opC(Test::Inner::Inner2::CPtr, Test::Inner::Inner2::CPtr&, const Ice::Current&);
+    Test::Inner::Inner2::CPtr opC(Test::Inner::Inner2::CPtr, Test::Inner::Inner2::CPtr&, const Ice::Current&) override;
 
-    virtual Test::Inner::Inner2::CSeq
-    opCSeq(Test::Inner::Inner2::CSeq, Test::Inner::Inner2::CSeq&, const Ice::Current&);
+    Test::Inner::Inner2::CSeq
+    opCSeq(Test::Inner::Inner2::CSeq, Test::Inner::Inner2::CSeq&, const Ice::Current&) override;
 
-    virtual Test::Inner::Inner2::CMap
-    opCMap(Test::Inner::Inner2::CMap, Test::Inner::Inner2::CMap&, const Ice::Current&);
+    Test::Inner::Inner2::CMap
+    opCMap(Test::Inner::Inner2::CMap, Test::Inner::Inner2::CMap&, const Ice::Current&) override;
 
-    virtual void shutdown(const Ice::Current&);
+    void shutdown(const Ice::Current&) override;
 };
 
 class I4 : public Inner::Test::Inner2::I
 {
 public:
-    virtual Test::S opS(Test::S, Test::S&, const Ice::Current&);
+    Test::S opS(Test::S, Test::S&, const Ice::Current&) override;
 
-    virtual Test::SSeq opSSeq(Test::SSeq, Test::SSeq&, const Ice::Current&);
+    Test::SSeq opSSeq(Test::SSeq, Test::SSeq&, const Ice::Current&) override;
 
-    virtual Test::SMap opSMap(Test::SMap, Test::SMap&, const Ice::Current&);
+    Test::SMap opSMap(Test::SMap, Test::SMap&, const Ice::Current&) override;
 
-    virtual Test::CPtr opC(Test::CPtr, Test::CPtr&, const Ice::Current&);
+    Test::CPtr opC(Test::CPtr, Test::CPtr&, const Ice::Current&) override;
 
-    virtual Test::CSeq opCSeq(Test::CSeq, Test::CSeq&, const Ice::Current&);
+    Test::CSeq opCSeq(Test::CSeq, Test::CSeq&, const Ice::Current&) override;
 
-    virtual Test::CMap opCMap(Test::CMap, Test::CMap&, const Ice::Current&);
+    Test::CMap opCMap(Test::CMap, Test::CMap&, const Ice::Current&) override;
 
-    virtual void shutdown(const Ice::Current&);
+    void shutdown(const Ice::Current&) override;
 };
 
 //

--- a/cpp/test/Ice/servantLocator/Client.cpp
+++ b/cpp/test/Ice/servantLocator/Client.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/servantLocator/Collocated.cpp
+++ b/cpp/test/Ice/servantLocator/Collocated.cpp
@@ -35,7 +35,7 @@ protected:
 class TestActivationI : public Test::TestActivation
 {
 public:
-    void activateServantLocator(bool activate, const Ice::Current& current)
+    void activateServantLocator(bool activate, const Ice::Current& current) override
     {
         if (activate)
         {
@@ -55,7 +55,7 @@ public:
 class Collocated : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/servantLocator/ServantLocatorI.cpp
+++ b/cpp/test/Ice/servantLocator/ServantLocatorI.cpp
@@ -28,12 +28,12 @@ ServantLocatorI::locate(const Ice::Current& current, shared_ptr<void>& cookie)
 
     if (current.id.name == "unknown")
     {
-        return 0;
+        return nullptr;
     }
 
     if (current.id.name == "invalidReturnValue" || current.id.name == "invalidReturnType")
     {
-        return 0;
+        return nullptr;
     }
 
     test(current.id.name == "locate" || current.id.name == "finished");

--- a/cpp/test/Ice/servantLocator/Server.cpp
+++ b/cpp/test/Ice/servantLocator/Server.cpp
@@ -34,7 +34,7 @@ protected:
 class TestActivationI : public Test::TestActivation
 {
 public:
-    void activateServantLocator(bool activate, const Ice::Current& current)
+    void activateServantLocator(bool activate, const Ice::Current& current) override
     {
         if (activate)
         {
@@ -54,7 +54,7 @@ public:
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/servantLocator/ServerAMD.cpp
+++ b/cpp/test/Ice/servantLocator/ServerAMD.cpp
@@ -34,7 +34,7 @@ protected:
 class TestActivationI : public Test::TestActivation
 {
 public:
-    void activateServantLocator(bool activate, const Ice::Current& current)
+    void activateServantLocator(bool activate, const Ice::Current& current) override
     {
         if (activate)
         {
@@ -54,7 +54,7 @@ public:
 class ServerAMD : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/servantLocator/TestAMDI.h
+++ b/cpp/test/Ice/servantLocator/TestAMDI.h
@@ -10,14 +10,16 @@
 class TestAMDI : public Test::TestIntf
 {
 public:
-    void
-    requestFailedExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
+    void requestFailedExceptionAsync(
+        std::function<void()>,
+        std::function<void(std::exception_ptr)>,
+        const Ice::Current&) override;
 
-    void
-    unknownUserExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
+    void unknownUserExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
+        override;
 
-    void
-    unknownLocalExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
+    void unknownLocalExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
+        override;
 
     void
     unknownExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
@@ -28,9 +30,11 @@ public:
     void
     localExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    void stdExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
+    void
+    stdExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    void cppExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
+    void
+    cppExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
     void unknownExceptionWithServantExceptionAsync(
         std::function<void()>,

--- a/cpp/test/Ice/servantLocator/TestAMDI.h
+++ b/cpp/test/Ice/servantLocator/TestAMDI.h
@@ -10,52 +10,52 @@
 class TestAMDI : public Test::TestIntf
 {
 public:
-    virtual void
-    requestFailedExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    requestFailedExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void
-    unknownUserExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    unknownUserExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void
-    unknownLocalExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    unknownLocalExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void
-    unknownExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    unknownExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void
-    userExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    userExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void
-    localExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    localExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void stdExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void stdExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void cppExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void cppExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void unknownExceptionWithServantExceptionAsync(
+    void unknownExceptionWithServantExceptionAsync(
         std::function<void()>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void impossibleExceptionAsync(
+    void impossibleExceptionAsync(
         bool,
         std::function<void(std::string_view)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void intfUserExceptionAsync(
+    void intfUserExceptionAsync(
         bool,
         std::function<void(std::string_view)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void
-    asyncResponseAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    asyncResponseAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void
-    asyncExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    asyncExceptionAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void shutdownAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void shutdownAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 };
 
 class Cookie

--- a/cpp/test/Ice/servantLocator/TestI.h
+++ b/cpp/test/Ice/servantLocator/TestI.h
@@ -10,24 +10,24 @@
 class TestI : public Test::TestIntf
 {
 public:
-    virtual void requestFailedException(const Ice::Current&);
-    virtual void unknownUserException(const Ice::Current&);
-    virtual void unknownLocalException(const Ice::Current&);
-    virtual void unknownException(const Ice::Current&);
-    virtual void userException(const Ice::Current&);
-    virtual void localException(const Ice::Current&);
-    virtual void stdException(const Ice::Current&);
-    virtual void cppException(const Ice::Current&);
+    void requestFailedException(const Ice::Current&) override;
+    void unknownUserException(const Ice::Current&) override;
+    void unknownLocalException(const Ice::Current&) override;
+    void unknownException(const Ice::Current&) override;
+    void userException(const Ice::Current&) override;
+    void localException(const Ice::Current&) override;
+    void stdException(const Ice::Current&) override;
+    void cppException(const Ice::Current&) override;
 
-    virtual void unknownExceptionWithServantException(const Ice::Current&);
+    void unknownExceptionWithServantException(const Ice::Current&) override;
 
-    virtual std::string impossibleException(bool, const Ice::Current&);
-    virtual std::string intfUserException(bool, const Ice::Current&);
+    std::string impossibleException(bool, const Ice::Current&) override;
+    std::string intfUserException(bool, const Ice::Current&) override;
 
-    virtual void asyncResponse(const Ice::Current&);
-    virtual void asyncException(const Ice::Current&);
+    void asyncResponse(const Ice::Current&) override;
+    void asyncException(const Ice::Current&) override;
 
-    virtual void shutdown(const Ice::Current&);
+    void shutdown(const Ice::Current&) override;
 };
 
 class Cookie

--- a/cpp/test/Ice/services/AllTests.cpp
+++ b/cpp/test/Ice/services/AllTests.cpp
@@ -17,7 +17,7 @@ namespace
     class ClockI : public Clock
     {
     public:
-        virtual void tick(string time, const Ice::Current&) { cout << time << endl; }
+        void tick(string time, const Ice::Current&) override { cout << time << endl; }
     };
 }
 

--- a/cpp/test/Ice/services/Client.cpp
+++ b/cpp/test/Ice/services/Client.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/slicing/exceptions/Client.cpp
+++ b/cpp/test/Ice/slicing/exceptions/Client.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/slicing/exceptions/Server.cpp
+++ b/cpp/test/Ice/slicing/exceptions/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/slicing/exceptions/ServerAMD.cpp
+++ b/cpp/test/Ice/slicing/exceptions/ServerAMD.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class ServerAMD : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/slicing/objects/AllTests.cpp
+++ b/cpp/test/Ice/slicing/objects/AllTests.cpp
@@ -342,17 +342,17 @@ namespace
         {
             test(p1);
             test(p1->sb == "D2.sb (p1 1)");
-            test(p1->pb == 0);
+            test(p1->pb == nullptr);
             test(string{p1->ice_id()} == "::Test::B");
 
             test(p2);
             test(p2->sb == "D2.sb (p2 1)");
-            test(p2->pb == 0);
+            test(p2->pb == nullptr);
             test(string{p2->ice_id()} == "::Test::B");
 
             test(ret);
             test(ret->sb == "D1.sb (p2 2)");
-            test(ret->pb == 0);
+            test(ret->pb == nullptr);
             test(string{ret->ice_id()} == "::Test::D1");
             called();
 
@@ -365,12 +365,12 @@ namespace
         {
             test(b);
             test(b->sb == "D4.sb (1)");
-            test(b->pb == 0);
+            test(b->pb == nullptr);
             test(string{b->ice_id()} == "::Test::B");
 
             test(ret);
             test(ret->sb == "B.sb (2)");
-            test(ret->pb == 0);
+            test(ret->pb == nullptr);
             test(string{ret->ice_id()} == "::Test::B");
             called();
 
@@ -1581,17 +1581,17 @@ allTests(Test::TestHelper* helper)
 
             test(p1);
             test(p1->sb == "D2.sb (p1 1)");
-            test(p1->pb == 0);
+            test(p1->pb == nullptr);
             test(string{p1->ice_id()} == "::Test::B");
 
             test(p2);
             test(p2->sb == "D2.sb (p2 1)");
-            test(p2->pb == 0);
+            test(p2->pb == nullptr);
             test(string{p2->ice_id()} == "::Test::B");
 
             test(ret);
             test(ret->sb == "D1.sb (p2 2)");
-            test(ret->pb == 0);
+            test(ret->pb == nullptr);
             test(string{ret->ice_id()} == "::Test::D1");
 
             breakCycles(ret);
@@ -1617,17 +1617,17 @@ allTests(Test::TestHelper* helper)
 
             test(p1);
             test(p1->sb == "D2.sb (p1 1)");
-            test(p1->pb == 0);
+            test(p1->pb == nullptr);
             test(string{p1->ice_id()} == "::Test::B");
 
             test(p2);
             test(p2->sb == "D2.sb (p2 1)");
-            test(p2->pb == 0);
+            test(p2->pb == nullptr);
             test(string{p2->ice_id()} == "::Test::B");
 
             test(ret);
             test(ret->sb == "D1.sb (p2 2)");
-            test(ret->pb == 0);
+            test(ret->pb == nullptr);
             test(string{ret->ice_id()} == "::Test::D1");
 
             breakCycles(ret);
@@ -1650,12 +1650,12 @@ allTests(Test::TestHelper* helper)
 
             test(b);
             test(b->sb == "D4.sb (1)");
-            test(b->pb == 0);
+            test(b->pb == nullptr);
             test(string{b->ice_id()} == "::Test::B");
 
             test(ret);
             test(ret->sb == "B.sb (2)");
-            test(ret->pb == 0);
+            test(ret->pb == nullptr);
             test(string{ret->ice_id()} == "::Test::B");
 
             breakCycles(ret);
@@ -2139,7 +2139,7 @@ allTests(Test::TestHelper* helper)
                 std::ostringstream s;
                 s << "D1." << i * 20;
                 test(b->sb == s.str());
-                test(b->pb == (i == 0 ? BPtr(0) : r.find((i - 1) * 20)->second));
+                test(b->pb == (i == 0 ? BPtr(nullptr) : r.find((i - 1) * 20)->second));
                 D1Ptr d1 = dynamic_pointer_cast<D1>(b);
                 test(d1);
                 test(d1->sd1 == s.str());
@@ -2202,7 +2202,7 @@ allTests(Test::TestHelper* helper)
                 std::ostringstream s;
                 s << "D1." << i * 20;
                 test(b->sb == s.str());
-                test(b->pb == (i == 0 ? BPtr(0) : r.find((i - 1) * 20)->second));
+                test(b->pb == (i == 0 ? BPtr(nullptr) : r.find((i - 1) * 20)->second));
                 D1Ptr d1 = dynamic_pointer_cast<D1>(b);
                 test(d1);
                 test(d1->sd1 == s.str());
@@ -2561,7 +2561,7 @@ allTests(Test::TestHelper* helper)
         {
             PCDerived2Ptr p2 = std::make_shared<PCDerived2>();
             p2->pi = i;
-            p2->pbs.push_back(0); // Nil reference. This slice should not have an indirection table.
+            p2->pbs.push_back(nullptr); // Nil reference. This slice should not have an indirection table.
             p2->pcd2 = i;
             pcd->pbs.push_back(p2);
         }
@@ -2763,7 +2763,7 @@ allTests(Test::TestHelper* helper)
         {
             PCDerived2Ptr p2 = std::make_shared<PCDerived2>();
             p2->pi = i;
-            p2->pbs.push_back(0); // Nil reference. This slice should not have an indirection table.
+            p2->pbs.push_back(nullptr); // Nil reference. This slice should not have an indirection table.
             p2->pcd2 = i;
             pcd->pbs.push_back(p2);
         }

--- a/cpp/test/Ice/slicing/objects/Client.cpp
+++ b/cpp/test/Ice/slicing/objects/Client.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/slicing/objects/Server.cpp
+++ b/cpp/test/Ice/slicing/objects/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/slicing/objects/ServerAMD.cpp
+++ b/cpp/test/Ice/slicing/objects/ServerAMD.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class ServerAMD : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/slicing/objects/TestAMDI.cpp
+++ b/cpp/test/Ice/slicing/objects/TestAMDI.cpp
@@ -373,7 +373,7 @@ TestI::dictionaryTestAsync(
         s << "D1." << i * 20;
         auto d1 = make_shared<D1>();
         d1->sb = s.str();
-        d1->pb = (i == 0 ? BPtr(0) : r.find((i - 1) * 20)->second);
+        d1->pb = (i == 0 ? BPtr(nullptr) : r.find((i - 1) * 20)->second);
         d1->sd1 = s.str();
         d1->pd1 = d1;
         r[i * 20] = d1;

--- a/cpp/test/Ice/slicing/objects/TestAMDI.h
+++ b/cpp/test/Ice/slicing/objects/TestAMDI.h
@@ -11,188 +11,188 @@ class TestI : public virtual ::Test::TestIntf
 {
 public:
     TestI();
-    virtual void SBaseAsObjectAsync(
+    void SBaseAsObjectAsync(
         std::function<void(const Ice::ValuePtr&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void SBaseAsSBaseAsync(
+    void SBaseAsSBaseAsync(
         std::function<void(const std::shared_ptr<Test::SBase>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void SBSKnownDerivedAsSBaseAsync(
+    void SBSKnownDerivedAsSBaseAsync(
         std::function<void(const std::shared_ptr<Test::SBase>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void SBSKnownDerivedAsSBSKnownDerivedAsync(
+    void SBSKnownDerivedAsSBSKnownDerivedAsync(
         std::function<void(const std::shared_ptr<Test::SBSKnownDerived>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void SBSUnknownDerivedAsSBaseAsync(
+    void SBSUnknownDerivedAsSBaseAsync(
         std::function<void(const std::shared_ptr<Test::SBase>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void SBSUnknownDerivedAsSBaseCompactAsync(
+    void SBSUnknownDerivedAsSBaseCompactAsync(
         std::function<void(const std::shared_ptr<Test::SBase>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void SUnknownAsObjectAsync(
+    void SUnknownAsObjectAsync(
         std::function<void(const Ice::ValuePtr&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void checkSUnknownAsync(
+    void checkSUnknownAsync(
         Ice::ValuePtr,
         std::function<void()>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void oneElementCycleAsync(
+    void oneElementCycleAsync(
         std::function<void(const std::shared_ptr<Test::B>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void twoElementCycleAsync(
+    void twoElementCycleAsync(
         std::function<void(const std::shared_ptr<Test::B>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void D1AsBAsync(
+    void D1AsBAsync(
         std::function<void(const std::shared_ptr<Test::B>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void D1AsD1Async(
+    void D1AsD1Async(
         std::function<void(const std::shared_ptr<Test::D1>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void D2AsBAsync(
+    void D2AsBAsync(
         std::function<void(const std::shared_ptr<Test::B>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void paramTest1Async(
+    void paramTest1Async(
         std::function<void(const std::shared_ptr<Test::B>&, const std::shared_ptr<Test::B>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void paramTest2Async(
+    void paramTest2Async(
         std::function<void(const std::shared_ptr<Test::B>&, const std::shared_ptr<Test::B>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void paramTest3Async(
+    void paramTest3Async(
         std::function<
             void(const std::shared_ptr<Test::B>&, const std::shared_ptr<Test::B>&, const std::shared_ptr<Test::B>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void paramTest4Async(
+    void paramTest4Async(
         std::function<void(const std::shared_ptr<Test::B>&, const std::shared_ptr<Test::B>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void returnTest1Async(
+    void returnTest1Async(
         std::function<
             void(const std::shared_ptr<Test::B>&, const std::shared_ptr<Test::B>&, const std::shared_ptr<Test::B>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void returnTest2Async(
+    void returnTest2Async(
         std::function<
             void(const std::shared_ptr<Test::B>&, const std::shared_ptr<Test::B>&, const std::shared_ptr<Test::B>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void returnTest3Async(
+    void returnTest3Async(
         std::shared_ptr<::Test::B>,
         std::shared_ptr<::Test::B>,
         std::function<void(const std::shared_ptr<Test::B>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void sequenceTestAsync(
+    void sequenceTestAsync(
         std::shared_ptr<::Test::SS1>,
         std::shared_ptr<::Test::SS2>,
         std::function<void(const ::Test::SS3&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void dictionaryTestAsync(
+    void dictionaryTestAsync(
         Test::BDict,
         std::function<void(const ::Test::BDict&, const ::Test::BDict&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void exchangePBaseAsync(
+    void exchangePBaseAsync(
         std::shared_ptr<::Test::PBase>,
         std::function<void(const std::shared_ptr<::Test::PBase>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void PBSUnknownAsPreservedAsync(
+    void PBSUnknownAsPreservedAsync(
         std::function<void(const std::shared_ptr<::Test::Preserved>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void checkPBSUnknownAsync(
+    void checkPBSUnknownAsync(
         std::shared_ptr<::Test::Preserved>,
         std::function<void()>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void PBSUnknownAsPreservedWithGraphAsync(
+    void PBSUnknownAsPreservedWithGraphAsync(
         std::function<void(const std::shared_ptr<::Test::Preserved>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void checkPBSUnknownWithGraphAsync(
+    void checkPBSUnknownWithGraphAsync(
         std::shared_ptr<::Test::Preserved>,
         std::function<void()>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void PBSUnknown2AsPreservedWithGraphAsync(
+    void PBSUnknown2AsPreservedWithGraphAsync(
         std::function<void(const std::shared_ptr<::Test::Preserved>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void checkPBSUnknown2WithGraphAsync(
+    void checkPBSUnknown2WithGraphAsync(
         std::shared_ptr<::Test::Preserved>,
         std::function<void()>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void exchangePNodeAsync(
+    void exchangePNodeAsync(
         std::shared_ptr<::Test::PNode>,
         std::function<void(const std::shared_ptr<::Test::PNode>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void
-    throwBaseAsBaseAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    throwBaseAsBaseAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void
-    throwDerivedAsBaseAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    throwDerivedAsBaseAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void
-    throwDerivedAsDerivedAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    throwDerivedAsDerivedAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void
-    throwUnknownDerivedAsBaseAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void
+    throwUnknownDerivedAsBaseAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    virtual void useForwardAsync(
+    void useForwardAsync(
         std::function<void(const std::shared_ptr<::Test::Forward>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
+        const Ice::Current&) override;
 
-    virtual void shutdownAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&);
+    void shutdownAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 };
 
 #endif

--- a/cpp/test/Ice/slicing/objects/TestAMDI.h
+++ b/cpp/test/Ice/slicing/objects/TestAMDI.h
@@ -178,14 +178,16 @@ public:
     void
     throwBaseAsBaseAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
 
-    void
-    throwDerivedAsBaseAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
+    void throwDerivedAsBaseAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
+        override;
 
-    void
-    throwDerivedAsDerivedAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
+    void throwDerivedAsDerivedAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
+        override;
 
-    void
-    throwUnknownDerivedAsBaseAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
+    void throwUnknownDerivedAsBaseAsync(
+        std::function<void()>,
+        std::function<void(std::exception_ptr)>,
+        const Ice::Current&) override;
 
     void useForwardAsync(
         std::function<void(const std::shared_ptr<::Test::Forward>&)>,

--- a/cpp/test/Ice/slicing/objects/TestI.cpp
+++ b/cpp/test/Ice/slicing/objects/TestI.cpp
@@ -327,28 +327,28 @@ TestI::paramTest3(BPtr& p1, BPtr& p2, const ::Ice::Current&)
 {
     D2Ptr d2 = make_shared<D2>();
     d2->sb = "D2.sb (p1 1)";
-    d2->pb = 0;
+    d2->pb = nullptr;
     d2->sd2 = "D2.sd2 (p1 1)";
     p1 = d2;
 
     D1Ptr d1 = make_shared<D1>();
     d1->sb = "D1.sb (p1 2)";
-    d1->pb = 0;
+    d1->pb = nullptr;
     d1->sd1 = "D1.sd2 (p1 2)";
-    d1->pd1 = 0;
+    d1->pd1 = nullptr;
     d2->pd2 = d1;
 
     D2Ptr d4 = make_shared<D2>();
     d4->sb = "D2.sb (p2 1)";
-    d4->pb = 0;
+    d4->pb = nullptr;
     d4->sd2 = "D2.sd2 (p2 1)";
     p2 = d4;
 
     D1Ptr d3 = make_shared<D1>();
     d3->sb = "D1.sb (p2 2)";
-    d3->pb = 0;
+    d3->pb = nullptr;
     d3->sd1 = "D1.sd2 (p2 2)";
-    d3->pd1 = 0;
+    d3->pd1 = nullptr;
     d4->pd2 = d3;
 
     _values.push_back(d1);
@@ -364,7 +364,7 @@ TestI::paramTest4(BPtr& p1, const ::Ice::Current&)
 {
     D4Ptr d4 = make_shared<D4>();
     d4->sb = "D4.sb (1)";
-    d4->pb = 0;
+    d4->pb = nullptr;
     d4->p1 = make_shared<B>();
     d4->p1->sb = "B.sb (1)";
     d4->p2 = make_shared<B>();
@@ -432,7 +432,7 @@ TestI::dictionaryTest(BDict bin, BDict& bout, const ::Ice::Current&)
         s << "D1." << i * 20;
         D1Ptr d1 = make_shared<D1>();
         d1->sb = s.str();
-        d1->pb = (i == 0 ? BPtr(0) : r.find((i - 1) * 20)->second);
+        d1->pb = (i == 0 ? BPtr(nullptr) : r.find((i - 1) * 20)->second);
         d1->sd1 = s.str();
         d1->pd1 = d1;
         _values.push_back(d1);
@@ -455,7 +455,7 @@ TestI::PBSUnknownAsPreserved(const Ice::Current& current)
     r->pi = 5;
     r->ps = "preserved";
     r->psu = "unknown";
-    r->graph = 0;
+    r->graph = nullptr;
     if (current.encoding != Ice::Encoding_1_0)
     {
         //
@@ -503,7 +503,7 @@ TestI::PBSUnknownAsPreservedWithGraphAsync(
     r->graph->next->next = make_shared<PNode>();
     r->graph->next->next->next = r->graph;
     response(r);
-    r->graph->next->next->next = 0; // Break the cycle.
+    r->graph->next->next->next = nullptr; // Break the cycle.
 }
 
 void
@@ -525,7 +525,7 @@ TestI::checkPBSUnknownWithGraph(Test::PreservedPtr p, const Ice::Current& curren
         test(pu->graph != pu->graph->next);
         test(pu->graph->next != pu->graph->next->next);
         test(pu->graph->next->next->next == pu->graph);
-        pu->graph->next->next->next = 0; // Break the cycle.
+        pu->graph->next->next->next = nullptr; // Break the cycle.
     }
 }
 
@@ -540,7 +540,7 @@ TestI::PBSUnknown2AsPreservedWithGraphAsync(
     r->ps = "preserved";
     r->pb = r;
     response(r);
-    r->pb = 0; // Break the cycle.
+    r->pb = nullptr; // Break the cycle.
 }
 
 void
@@ -559,7 +559,7 @@ TestI::checkPBSUnknown2WithGraph(Test::PreservedPtr p, const Ice::Current& curre
         test(pu->pi == 5);
         test(pu->ps == "preserved");
         test(pu->pb == pu);
-        pu->pb = 0; // Break the cycle.
+        pu->pb = nullptr; // Break the cycle.
     }
 }
 

--- a/cpp/test/Ice/slicing/objects/TestI.h
+++ b/cpp/test/Ice/slicing/objects/TestI.h
@@ -11,67 +11,67 @@ class TestI : public virtual Test::TestIntf
 {
 public:
     TestI();
-    ~TestI();
+    ~TestI() override;
 
-    virtual Ice::ValuePtr SBaseAsObject(const Ice::Current&);
-    virtual ::Test::SBasePtr SBaseAsSBase(const Ice::Current&);
-    virtual ::Test::SBasePtr SBSKnownDerivedAsSBase(const Ice::Current&);
-    virtual ::Test::SBSKnownDerivedPtr SBSKnownDerivedAsSBSKnownDerived(const Ice::Current&);
+    Ice::ValuePtr SBaseAsObject(const Ice::Current&) override;
+    ::Test::SBasePtr SBaseAsSBase(const Ice::Current&) override;
+    ::Test::SBasePtr SBSKnownDerivedAsSBase(const Ice::Current&) override;
+    ::Test::SBSKnownDerivedPtr SBSKnownDerivedAsSBSKnownDerived(const Ice::Current&) override;
 
-    virtual ::Test::SBasePtr SBSUnknownDerivedAsSBase(const Ice::Current&);
+    ::Test::SBasePtr SBSUnknownDerivedAsSBase(const Ice::Current&) override;
 
-    virtual ::Test::SBasePtr SBSUnknownDerivedAsSBaseCompact(const Ice::Current&);
+    ::Test::SBasePtr SBSUnknownDerivedAsSBaseCompact(const Ice::Current&) override;
 
-    virtual Ice::ValuePtr SUnknownAsObject(const Ice::Current&);
-    virtual void checkSUnknown(Ice::ValuePtr object, const Ice::Current&);
+    Ice::ValuePtr SUnknownAsObject(const Ice::Current&) override;
+    void checkSUnknown(Ice::ValuePtr object, const Ice::Current&) override;
 
-    virtual ::Test::BPtr oneElementCycle(const Ice::Current&);
-    virtual ::Test::BPtr twoElementCycle(const Ice::Current&);
+    ::Test::BPtr oneElementCycle(const Ice::Current&) override;
+    ::Test::BPtr twoElementCycle(const Ice::Current&) override;
 
-    virtual ::Test::BPtr D1AsB(const Ice::Current&);
-    virtual ::Test::D1Ptr D1AsD1(const Ice::Current&);
-    virtual ::Test::BPtr D2AsB(const Ice::Current&);
+    ::Test::BPtr D1AsB(const Ice::Current&) override;
+    ::Test::D1Ptr D1AsD1(const Ice::Current&) override;
+    ::Test::BPtr D2AsB(const Ice::Current&) override;
 
-    virtual void paramTest1(::Test::BPtr&, ::Test::BPtr&, const Ice::Current&);
-    virtual void paramTest2(::Test::BPtr&, ::Test::BPtr&, const Ice::Current&);
-    virtual ::Test::BPtr paramTest3(::Test::BPtr&, ::Test::BPtr&, const Ice::Current&);
-    virtual ::Test::BPtr paramTest4(::Test::BPtr&, const Ice::Current&);
+    void paramTest1(::Test::BPtr&, ::Test::BPtr&, const Ice::Current&) override;
+    void paramTest2(::Test::BPtr&, ::Test::BPtr&, const Ice::Current&) override;
+    ::Test::BPtr paramTest3(::Test::BPtr&, ::Test::BPtr&, const Ice::Current&) override;
+    ::Test::BPtr paramTest4(::Test::BPtr&, const Ice::Current&) override;
 
-    virtual ::Test::BPtr returnTest1(::Test::BPtr&, ::Test::BPtr&, const Ice::Current&);
-    virtual ::Test::BPtr returnTest2(::Test::BPtr&, ::Test::BPtr&, const Ice::Current&);
-    virtual ::Test::BPtr returnTest3(::Test::BPtr, ::Test::BPtr, const Ice::Current&);
+    ::Test::BPtr returnTest1(::Test::BPtr&, ::Test::BPtr&, const Ice::Current&) override;
+    ::Test::BPtr returnTest2(::Test::BPtr&, ::Test::BPtr&, const Ice::Current&) override;
+    ::Test::BPtr returnTest3(::Test::BPtr, ::Test::BPtr, const Ice::Current&) override;
 
-    virtual ::Test::SS3 sequenceTest(::Test::SS1Ptr, ::Test::SS2Ptr, const Ice::Current&);
+    ::Test::SS3 sequenceTest(::Test::SS1Ptr, ::Test::SS2Ptr, const Ice::Current&) override;
 
-    virtual ::Test::BDict dictionaryTest(::Test::BDict, ::Test::BDict&, const Ice::Current&);
+    ::Test::BDict dictionaryTest(::Test::BDict, ::Test::BDict&, const Ice::Current&) override;
 
-    virtual ::Test::PBasePtr exchangePBase(::Test::PBasePtr, const Ice::Current&);
+    ::Test::PBasePtr exchangePBase(::Test::PBasePtr, const Ice::Current&) override;
 
-    virtual ::Test::PreservedPtr PBSUnknownAsPreserved(const Ice::Current&);
-    virtual void checkPBSUnknown(::Test::PreservedPtr, const Ice::Current&);
+    ::Test::PreservedPtr PBSUnknownAsPreserved(const Ice::Current&) override;
+    void checkPBSUnknown(::Test::PreservedPtr, const Ice::Current&) override;
 
-    virtual void PBSUnknownAsPreservedWithGraphAsync(
+    void PBSUnknownAsPreservedWithGraphAsync(
         std::function<void(const std::shared_ptr<Test::Preserved>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
-    virtual void checkPBSUnknownWithGraph(::Test::PreservedPtr, const Ice::Current&);
+        const Ice::Current&) override;
+    void checkPBSUnknownWithGraph(::Test::PreservedPtr, const Ice::Current&) override;
 
-    virtual void PBSUnknown2AsPreservedWithGraphAsync(
+    void PBSUnknown2AsPreservedWithGraphAsync(
         std::function<void(const std::shared_ptr<Test::Preserved>&)>,
         std::function<void(std::exception_ptr)>,
-        const Ice::Current&);
-    virtual void checkPBSUnknown2WithGraph(::Test::PreservedPtr, const Ice::Current&);
+        const Ice::Current&) override;
+    void checkPBSUnknown2WithGraph(::Test::PreservedPtr, const Ice::Current&) override;
 
-    virtual ::Test::PNodePtr exchangePNode(::Test::PNodePtr, const Ice::Current&);
+    ::Test::PNodePtr exchangePNode(::Test::PNodePtr, const Ice::Current&) override;
 
-    virtual void throwBaseAsBase(const Ice::Current&);
-    virtual void throwDerivedAsBase(const Ice::Current&);
-    virtual void throwDerivedAsDerived(const Ice::Current&);
-    virtual void throwUnknownDerivedAsBase(const Ice::Current&);
+    void throwBaseAsBase(const Ice::Current&) override;
+    void throwDerivedAsBase(const Ice::Current&) override;
+    void throwDerivedAsDerived(const Ice::Current&) override;
+    void throwUnknownDerivedAsBase(const Ice::Current&) override;
 
-    virtual void useForward(::Test::ForwardPtr&, const Ice::Current&);
+    void useForward(::Test::ForwardPtr&, const Ice::Current&) override;
 
-    virtual void shutdown(const Ice::Current&);
+    void shutdown(const Ice::Current&) override;
 
 private:
     std::vector<Ice::ValuePtr> _values;

--- a/cpp/test/Ice/span/Client.cpp
+++ b/cpp/test/Ice/span/Client.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/span/Collocated.cpp
+++ b/cpp/test/Ice/span/Collocated.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Collocated : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/span/Server.cpp
+++ b/cpp/test/Ice/span/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/span/ServerAMD.cpp
+++ b/cpp/test/Ice/span/ServerAMD.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class ServerAMD : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/stream/Client.cpp
+++ b/cpp/test/Ice/stream/Client.cpp
@@ -24,13 +24,13 @@ public:
         called = false;
     }
 
-    virtual void _iceWrite(Ice::OutputStream* out) const
+    void _iceWrite(Ice::OutputStream* out) const override
     {
         obj->_iceWrite(out);
         const_cast<TestObjectWriter*>(this)->called = true;
     }
 
-    virtual void _iceRead(Ice::InputStream*) { assert(false); }
+    void _iceRead(Ice::InputStream*) override { assert(false); }
 
     MyClassPtr obj;
     bool called;
@@ -41,9 +41,9 @@ class TestObjectReader : public Ice::Value
 public:
     TestObjectReader() { called = false; }
 
-    virtual void _iceWrite(Ice::OutputStream*) const { assert(false); }
+    void _iceWrite(Ice::OutputStream*) const override { assert(false); }
 
-    virtual void _iceRead(Ice::InputStream* in)
+    void _iceRead(Ice::InputStream* in) override
     {
         obj = std::make_shared<MyClass>();
         obj->_iceRead(in);
@@ -1086,7 +1086,7 @@ allTests(Test::TestHelper* helper)
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/stringConverter/Client.cpp
+++ b/cpp/test/Ice/stringConverter/Client.cpp
@@ -24,7 +24,7 @@ static bool useIconv = true;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void
@@ -43,7 +43,7 @@ Client::run(int argc, char** argv)
     // (we just used the codeset for as default internal code for
     // stringConverter below)
     //
-    useLocale = (setlocale(LC_ALL, "fr_FR.ISO8859-15") != 0 || setlocale(LC_ALL, "fr_FR.iso885915@euro") != 0);
+    useLocale = (setlocale(LC_ALL, "fr_FR.ISO8859-15") != nullptr || setlocale(LC_ALL, "fr_FR.iso885915@euro") != nullptr);
 #endif
 
     if (useIconv)

--- a/cpp/test/Ice/stringConverter/Client.cpp
+++ b/cpp/test/Ice/stringConverter/Client.cpp
@@ -43,7 +43,8 @@ Client::run(int argc, char** argv)
     // (we just used the codeset for as default internal code for
     // stringConverter below)
     //
-    useLocale = (setlocale(LC_ALL, "fr_FR.ISO8859-15") != nullptr || setlocale(LC_ALL, "fr_FR.iso885915@euro") != nullptr);
+    useLocale =
+        (setlocale(LC_ALL, "fr_FR.ISO8859-15") != nullptr || setlocale(LC_ALL, "fr_FR.iso885915@euro") != nullptr);
 #endif
 
     if (useIconv)

--- a/cpp/test/Ice/stringConverter/Server.cpp
+++ b/cpp/test/Ice/stringConverter/Server.cpp
@@ -14,23 +14,23 @@ using namespace std;
 class MyObjectI : public Test::MyObject
 {
 public:
-    virtual wstring widen(string msg, const Ice::Current&)
+    wstring widen(string msg, const Ice::Current&) override
     {
         return stringToWstring(msg, Ice::getProcessStringConverter(), Ice::getProcessWstringConverter());
     }
 
-    virtual string narrow(wstring wmsg, const Ice::Current&)
+    string narrow(wstring wmsg, const Ice::Current&) override
     {
         return wstringToString(wmsg, Ice::getProcessStringConverter(), Ice::getProcessWstringConverter());
     }
 
-    virtual void shutdown(const Ice::Current& current) { current.adapter->getCommunicator()->shutdown(); }
+    void shutdown(const Ice::Current& current) override { current.adapter->getCommunicator()->shutdown(); }
 };
 
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/timeout/Client.cpp
+++ b/cpp/test/Ice/timeout/Client.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/timeout/Server.cpp
+++ b/cpp/test/Ice/timeout/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/udp/Client.cpp
+++ b/cpp/test/Ice/udp/Client.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Ice/udp/Server.cpp
+++ b/cpp/test/Ice/udp/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/IceBox/admin/Client.cpp
+++ b/cpp/test/IceBox/admin/Client.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/IceBox/admin/Service.cpp
+++ b/cpp/test/IceBox/admin/Service.cpp
@@ -13,11 +13,11 @@ class ServiceI : public ::IceBox::Service
 {
 public:
     ServiceI(const CommunicatorPtr&);
-    virtual ~ServiceI();
+    ~ServiceI() override;
 
-    virtual void start(const string&, const CommunicatorPtr&, const StringSeq&);
+    void start(const string&, const CommunicatorPtr&, const StringSeq&) override;
 
-    virtual void stop();
+    void stop() override;
 };
 
 extern "C"

--- a/cpp/test/IceBox/admin/TestI.h
+++ b/cpp/test/IceBox/admin/TestI.h
@@ -12,7 +12,7 @@ class TestFacetI : public virtual ::Test::TestFacet
 public:
     TestFacetI();
 
-    virtual Ice::PropertyDict getChanges(const Ice::Current&);
+    Ice::PropertyDict getChanges(const Ice::Current&) override;
 
     virtual void updated(const Ice::PropertyDict&);
 

--- a/cpp/test/IceBox/configuration/Client.cpp
+++ b/cpp/test/IceBox/configuration/Client.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/IceBox/configuration/Service.cpp
+++ b/cpp/test/IceBox/configuration/Service.cpp
@@ -13,11 +13,11 @@ class ServiceI : public ::IceBox::Service
 {
 public:
     ServiceI();
-    virtual ~ServiceI();
+    ~ServiceI() override;
 
-    virtual void start(const string&, const CommunicatorPtr&, const StringSeq&);
+    void start(const string&, const CommunicatorPtr&, const StringSeq&) override;
 
-    virtual void stop();
+    void stop() override;
 };
 
 extern "C"

--- a/cpp/test/IceBox/configuration/TestI.h
+++ b/cpp/test/IceBox/configuration/TestI.h
@@ -12,8 +12,8 @@ class TestI : public ::Test::TestIntf
 public:
     TestI(const Ice::StringSeq&);
 
-    virtual std::string getProperty(std::string, const Ice::Current&);
-    virtual Ice::StringSeq getArgs(const Ice::Current&);
+    std::string getProperty(std::string, const Ice::Current&) override;
+    Ice::StringSeq getArgs(const Ice::Current&) override;
 
 private:
     const Ice::StringSeq _args;

--- a/cpp/test/IceDiscovery/simple/Client.cpp
+++ b/cpp/test/IceDiscovery/simple/Client.cpp
@@ -13,7 +13,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/IceDiscovery/simple/Server.cpp
+++ b/cpp/test/IceDiscovery/simple/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/IceDiscovery/simple/TestI.h
+++ b/cpp/test/IceDiscovery/simple/TestI.h
@@ -10,19 +10,19 @@
 class TestIntfI : public Test::TestIntf
 {
 public:
-    virtual std::string getAdapterId(const Ice::Current&);
+    std::string getAdapterId(const Ice::Current&) override;
 };
 
 class ControllerI : public Test::Controller
 {
 public:
-    virtual void activateObjectAdapter(std::string, std::string, std::string, const Ice::Current&);
-    virtual void deactivateObjectAdapter(std::string, const Ice::Current&);
+    void activateObjectAdapter(std::string, std::string, std::string, const Ice::Current&) override;
+    void deactivateObjectAdapter(std::string, const Ice::Current&) override;
 
-    virtual void addObject(std::string, std::string, const Ice::Current&);
-    virtual void removeObject(std::string, std::string, const Ice::Current&);
+    void addObject(std::string, std::string, const Ice::Current&) override;
+    void removeObject(std::string, std::string, const Ice::Current&) override;
 
-    virtual void shutdown(const Ice::Current&);
+    void shutdown(const Ice::Current&) override;
 
 private:
     std::map<std::string, Ice::ObjectAdapterPtr> _adapters;

--- a/cpp/test/IceGrid/activation/Client.cpp
+++ b/cpp/test/IceGrid/activation/Client.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/IceGrid/activation/Server.cpp
+++ b/cpp/test/IceGrid/activation/Server.cpp
@@ -14,7 +14,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 class TestActivationFailure : public std::runtime_error

--- a/cpp/test/IceGrid/activation/TestI.h
+++ b/cpp/test/IceGrid/activation/TestI.h
@@ -12,8 +12,8 @@ class TestI final : public Test::TestIntf
 public:
     TestI();
 
-    virtual void fail(const Ice::Current&);
-    virtual void shutdown(const Ice::Current&);
+    void fail(const Ice::Current&) override;
+    void shutdown(const Ice::Current&) override;
 
     bool isFailed() const;
 

--- a/cpp/test/IceGrid/admin/Server.cpp
+++ b/cpp/test/IceGrid/admin/Server.cpp
@@ -10,7 +10,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/IceGrid/allocation/Client.cpp
+++ b/cpp/test/IceGrid/allocation/Client.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/IceGrid/deployer/Client.cpp
+++ b/cpp/test/IceGrid/deployer/Client.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/IceGrid/deployer/Server.cpp
+++ b/cpp/test/IceGrid/deployer/Server.cpp
@@ -13,7 +13,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void
@@ -23,7 +23,7 @@ Server::run(int argc, char** argv)
     // Test if MY_ENV_VARIABLE is set.
     //
     char* value = getenv("MY_ENV_VARIABLE");
-    test(value != 0 && string(value) == "12");
+    test(value != nullptr && string(value) == "12");
 
     ifstream in("envs");
     if (!in)
@@ -54,16 +54,16 @@ Server::run(int argc, char** argv)
 
 #else
     char* value2 = getenv("MY_ENV_UNICODE_VARIABLE");
-    test(value2 != 0 && string(value2) == unicodeVar);
+    test(value2 != nullptr && string(value2) == unicodeVar);
 
     char* value3 = getenv(varname1.c_str());
-    test(value3 != 0 && string(value3) == "1");
+    test(value3 != nullptr && string(value3) == "1");
 
     char* value4 = getenv(varname2.c_str());
-    test(value4 != 0 && string(value4) == "2");
+    test(value4 != nullptr && string(value4) == "2");
 
     char* value5 = getenv("MY_UNIX_COMPOSED_VARIABLE");
-    test(value5 != 0 && string(value5) == "BAR;12");
+    test(value5 != nullptr && string(value5) == "BAR;12");
 #endif
 
     Ice::CommunicatorHolder communicator = initialize(argc, argv);

--- a/cpp/test/IceGrid/deployer/Service.cpp
+++ b/cpp/test/IceGrid/deployer/Service.cpp
@@ -13,11 +13,11 @@ class ServiceI : public ::IceBox::Service
 {
 public:
     ServiceI();
-    virtual ~ServiceI();
+    ~ServiceI() override;
 
-    virtual void start(const string&, const CommunicatorPtr&, const StringSeq&);
+    void start(const string&, const CommunicatorPtr&, const StringSeq&) override;
 
-    virtual void stop();
+    void stop() override;
 };
 
 extern "C"

--- a/cpp/test/IceGrid/deployer/TestI.h
+++ b/cpp/test/IceGrid/deployer/TestI.h
@@ -12,8 +12,8 @@ class TestI : public ::Test::TestIntf
 public:
     TestI(const Ice::PropertiesPtr&);
 
-    virtual void shutdown(const Ice::Current&);
-    virtual std::string getProperty(std::string, const Ice::Current&);
+    void shutdown(const Ice::Current&) override;
+    std::string getProperty(std::string, const Ice::Current&) override;
 
 private:
     Ice::PropertiesPtr _properties;

--- a/cpp/test/IceGrid/noRestartUpdate/Server.cpp
+++ b/cpp/test/IceGrid/noRestartUpdate/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server final : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/IceGrid/replicaGroup/Client.cpp
+++ b/cpp/test/IceGrid/replicaGroup/Client.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/IceGrid/replicaGroup/Server.cpp
+++ b/cpp/test/IceGrid/replicaGroup/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/IceGrid/replicaGroup/TestI.h
+++ b/cpp/test/IceGrid/replicaGroup/TestI.h
@@ -12,8 +12,8 @@ class TestI : public ::Test::TestIntf
 public:
     TestI(const Ice::PropertiesPtr&);
 
-    virtual std::string getReplicaId(const Ice::Current&);
-    virtual std::string getReplicaIdAndShutdown(const Ice::Current&);
+    std::string getReplicaId(const Ice::Current&) override;
+    std::string getReplicaIdAndShutdown(const Ice::Current&) override;
 
 private:
     Ice::PropertiesPtr _properties;

--- a/cpp/test/IceGrid/simple/Client.cpp
+++ b/cpp/test/IceGrid/simple/Client.cpp
@@ -12,7 +12,7 @@ using namespace Test;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/IceGrid/simple/Server.cpp
+++ b/cpp/test/IceGrid/simple/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/IceGrid/simple/TestI.h
+++ b/cpp/test/IceGrid/simple/TestI.h
@@ -12,7 +12,7 @@ class TestI : public ::Test::TestIntf
 public:
     TestI();
 
-    virtual void shutdown(const Ice::Current&);
+    void shutdown(const Ice::Current&) override;
 };
 
 #endif

--- a/cpp/test/IceGrid/update/Client.cpp
+++ b/cpp/test/IceGrid/update/Client.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/IceGrid/update/Server.cpp
+++ b/cpp/test/IceGrid/update/Server.cpp
@@ -11,7 +11,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/IceGrid/update/TestI.h
+++ b/cpp/test/IceGrid/update/TestI.h
@@ -12,8 +12,8 @@ class TestI : public ::Test::TestIntf
 public:
     TestI(const Ice::PropertiesPtr&);
 
-    virtual void shutdown(const Ice::Current&);
-    virtual std::string getProperty(std::string, const Ice::Current&);
+    void shutdown(const Ice::Current&) override;
+    std::string getProperty(std::string, const Ice::Current&) override;
 
 private:
     Ice::PropertiesPtr _properties;

--- a/cpp/test/IceSSL/configuration/AllTests.cpp
+++ b/cpp/test/IceSSL/configuration/AllTests.cpp
@@ -813,7 +813,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
 
     cout << "testing certificate chains... " << flush;
     {
-        const char* certificates[] = {"/s_rsa_cai2.p12", 0};
+        const char* certificates[] = {"/s_rsa_cai2.p12", nullptr};
         ImportCerts import(defaultDir, certificates);
 
         InitializationData initData;
@@ -2012,7 +2012,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             "SUBJECTKEYID:'0C 8A 4F 53 BE DF C8 1B 70 05 AD 39 AA EE 30 C6 F3 BE FD 79'",
             "SERIAL:02",
             "SERIAL:02 LABEL:Client",
-            0};
+            nullptr};
 
         const char* serverFindCertProperties[] = {
 #    if !defined(__APPLE__) || TARGET_OS_IPHONE == 0
@@ -2023,7 +2023,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             "SUBJECTKEYID:'A2 DD 5E A5 52 06 0B 9D 64 89 DC E1 01 B0 7E 46 F5 60 A5 D7'",
             "SERIAL:01",
             "SERIAL:01 LABEL:Server",
-            0};
+            nullptr};
 
         const char* failFindCertProperties[] = {
             "nolabel",
@@ -2037,12 +2037,12 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             "SUBJECTKEYID:'a6 42 aa 17 04 41 86 56 67 e4 04 64 59 34 30 c7 4c 6b ef ff'",
             "SERIAL:04",
             "SERIAL:04 LABEL:Client",
-            0};
+            nullptr};
 
-        const char* certificates[] = {"/s_rsa_ca1.p12", "/c_rsa_ca1.p12", 0};
+        const char* certificates[] = {"/s_rsa_ca1.p12", "/c_rsa_ca1.p12", nullptr};
         ImportCerts import(defaultDir, certificates);
 
-        for (int i = 0; clientFindCertProperties[i] != 0; i++)
+        for (int i = 0; clientFindCertProperties[i] != nullptr; i++)
         {
             InitializationData initData;
             initData.properties = createClientProps(defaultProps, p12);
@@ -2086,7 +2086,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             comm->destroy();
         }
 
-        for (int i = 0; failFindCertProperties[i] != 0; i++)
+        for (int i = 0; failFindCertProperties[i] != nullptr; i++)
         {
             InitializationData initData;
             initData.properties = createClientProps(defaultProps, p12);
@@ -2315,7 +2315,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
         comm->destroy();
 
         // Test with s_rsa_cai4 only the intermediate CA cert is revoked
-        const char* certificates[] = {"/s_rsa_cai4.p12", 0};
+        const char* certificates[] = {"/s_rsa_cai4.p12", nullptr};
         ImportCerts import(defaultDir, certificates);
         initData.properties = createClientProps(defaultProps, p12, "", "cacert4");
         initData.properties->setProperty("IceSSL.RevocationCheck", "2");

--- a/cpp/test/IceSSL/configuration/Client.cpp
+++ b/cpp/test/IceSSL/configuration/Client.cpp
@@ -15,7 +15,7 @@ class Client : public Test::TestHelper
 public:
     Client() : Test::TestHelper(false) {}
 
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/IceSSL/configuration/Server.cpp
+++ b/cpp/test/IceSSL/configuration/Server.cpp
@@ -13,7 +13,7 @@ using namespace std;
 class Server : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/IceSSL/configuration/TestI.h
+++ b/cpp/test/IceSSL/configuration/TestI.h
@@ -12,8 +12,8 @@ class ServerI : public Test::Server
 public:
     ServerI(const Ice::CommunicatorPtr&);
 
-    virtual void noCert(const Ice::Current&);
-    virtual void checkCert(std::string, std::string, const Ice::Current&);
+    void noCert(const Ice::Current&) override;
+    void checkCert(std::string, std::string, const Ice::Current&) override;
 
     void destroy();
 
@@ -27,9 +27,9 @@ class ServerFactoryI : public Test::ServerFactory
 public:
     ServerFactoryI(const std::string&);
 
-    virtual std::optional<Test::ServerPrx> createServer(Test::Properties, const Ice::Current&);
-    virtual void destroyServer(std::optional<Test::ServerPrx>, const Ice::Current&);
-    virtual void shutdown(const Ice::Current&);
+    std::optional<Test::ServerPrx> createServer(Test::Properties, const Ice::Current&) override;
+    void destroyServer(std::optional<Test::ServerPrx>, const Ice::Current&) override;
+    void shutdown(const Ice::Current&) override;
 
 private:
     std::string _defaultDir;

--- a/cpp/test/IceStorm/federation/Publisher.cpp
+++ b/cpp/test/IceStorm/federation/Publisher.cpp
@@ -15,7 +15,7 @@ using namespace Test;
 class Publisher final : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/IceUtil/ctrlCHandler/Client.cpp
+++ b/cpp/test/IceUtil/ctrlCHandler/Client.cpp
@@ -20,7 +20,7 @@ callback(int signal)
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/IceUtil/sha1/Client.cpp
+++ b/cpp/test/IceUtil/sha1/Client.cpp
@@ -71,7 +71,7 @@ namespace
 class Client : public Test::TestHelper
 {
 public:
-    virtual void run(int argc, char* argv[]);
+    void run(int argc, char* argv[]) override;
 };
 
 void

--- a/cpp/test/IceUtil/timer/Client.cpp
+++ b/cpp/test/IceUtil/timer/Client.cpp
@@ -36,7 +36,7 @@ public:
 
     TestTask(const chrono::milliseconds& scheduledTime) : _scheduledTime(scheduledTime), _count(0) {}
 
-    virtual void runTimerTask()
+    void runTimerTask() override
     {
         lock_guard lock(_mutex);
         ++_count;
@@ -98,7 +98,7 @@ class DestroyTask : public TimerTask
 public:
     DestroyTask(const IceInternal::TimerPtr& timer) : _timer(timer), _run(false) {}
 
-    virtual void runTimerTask()
+    void runTimerTask() override
     {
         lock_guard lock(_mutex);
         try
@@ -137,7 +137,7 @@ using DestroyTaskPtr = std::shared_ptr<DestroyTask>;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int argc, char* argv[]);
+    void run(int argc, char* argv[]) override;
 };
 
 void

--- a/cpp/test/IceUtil/uuid/Client.cpp
+++ b/cpp/test/IceUtil/uuid/Client.cpp
@@ -28,7 +28,7 @@ usage(const char* myName)
 template<typename T, typename GenerateFunc> class InsertThread
 {
 public:
-    typedef set<T> ItemSet;
+    using ItemSet = set<T>;
 
     InsertThread(int threadId, ItemSet& itemSet, GenerateFunc func, long howMany, bool verbose)
         : _threadId(threadId),
@@ -151,7 +151,7 @@ runTest(int threadCount, GenerateFunc func, long howMany, bool verbose, string n
 class Client : public Test::TestHelper
 {
 public:
-    virtual void run(int argc, char* argv[]);
+    void run(int argc, char* argv[]) override;
 };
 
 void

--- a/cpp/test/Slice/deprecated/Client.cpp
+++ b/cpp/test/Slice/deprecated/Client.cpp
@@ -37,7 +37,7 @@ allTests(const Ice::CommunicatorPtr& communicator)
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Slice/escape/Client.cpp
+++ b/cpp/test/Slice/escape/Client.cpp
@@ -12,8 +12,8 @@ using namespace std;
 class breakI : public _cpp_and::_cpp_break
 {
 public:
-    virtual void
-    caseAsync(::int32_t, function<void(int)> response, function<void(exception_ptr)>, const ::Ice::Current&)
+    void
+    caseAsync(::int32_t, function<void(int)> response, function<void(exception_ptr)>, const ::Ice::Current&) override
     {
         response(0);
     }
@@ -23,9 +23,9 @@ class charI : public _cpp_and::_cpp_char
 {
 public:
 #ifndef NDEBUG
-    virtual void _cpp_explicit(const ::Ice::Current& current)
+    void _cpp_explicit(const ::Ice::Current& current) override
 #else
-    virtual void _cpp_explicit(const ::Ice::Current&)
+    virtual void _cpp_explicit(const ::Ice::Current&) override
 #endif
     {
         assert(current.operation == "explicit");
@@ -41,12 +41,12 @@ public:
 class doI : public _cpp_and::_cpp_do
 {
 public:
-    virtual void
-    caseAsync(int, ::std::function<void(int)>, ::std::function<void(::std::exception_ptr)>, const ::Ice::Current&)
+    void
+    caseAsync(int, ::std::function<void(int)>, ::std::function<void(::std::exception_ptr)>, const ::Ice::Current&) override
     {
     }
 
-    virtual void _cpp_explicit(const ::Ice::Current&) {}
+    void _cpp_explicit(const ::Ice::Current&) override {}
 
     virtual void foo(const _cpp_and::charPrx&, int32_t&, const ::Ice::Current&) {}
 };
@@ -138,7 +138,7 @@ testtypes(const Ice::CommunicatorPtr& communicator)
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Slice/escape/Client.cpp
+++ b/cpp/test/Slice/escape/Client.cpp
@@ -41,8 +41,8 @@ public:
 class doI : public _cpp_and::_cpp_do
 {
 public:
-    void
-    caseAsync(int, ::std::function<void(int)>, ::std::function<void(::std::exception_ptr)>, const ::Ice::Current&) override
+    void caseAsync(int, ::std::function<void(int)>, ::std::function<void(::std::exception_ptr)>, const ::Ice::Current&)
+        override
     {
     }
 

--- a/cpp/test/Slice/macros/Client.cpp
+++ b/cpp/test/Slice/macros/Client.cpp
@@ -12,7 +12,7 @@ using namespace std;
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void

--- a/cpp/test/Slice/structure/Client.cpp
+++ b/cpp/test/Slice/structure/Client.cpp
@@ -42,7 +42,7 @@ allTests(const Ice::CommunicatorPtr& communicator)
 class Client : public Test::TestHelper
 {
 public:
-    void run(int, char**);
+    void run(int, char**) override;
 };
 
 void


### PR DESCRIPTION
This PR applies modernize-use-override, moderninze-use-nullptr and modernize-use-using to cpp/*