### PR TITLE
Add static C++ ci testing on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           - os: ubuntu-24.04
             config: "static"
             build_flags: "CONFIGS=static"
-            test_flags: "--config=static --filter=Ice/"
+            test_flags: "--config=static --filter=Ice/ --filter=IceDiscovery/"
             working_directory: "cpp"
 
           # # Xcode SDK builds

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,13 @@ jobs:
             test_flags: "--platform=x64 --config=Debug"
             msbuild_project: "msbuild/ice.proj"
 
+          # Static builds
+          - os: ubuntu-24.04
+            config: "static"
+            build_flags: "CONFIGS=static"
+            test_flags: "--config=static"
+            working_directory: "cpp"
+
           # # Xcode SDK builds
           # # TODO - Should we also test the debug config here as well?
           # - macos-15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           - os: ubuntu-24.04
             config: "static"
             build_flags: "CONFIGS=static"
-            test_flags: "--config=static"
+            test_flags: "--config=static --filter=Ice/"
             working_directory: "cpp"
 
           # # Xcode SDK builds


### PR DESCRIPTION
This PR adds ci testing for C++ static libs on Linux. We only run the `Ice/*` tests as the `CONFIGS=static` build does not include the service executables. Is there anything relevant that's missing here?

I didn't add macOS/Windows since we're already low on the number of these runners.