### PR TITLE
Fix DataStorm filter initialization

### DIFF
--- a/cpp/include/DataStorm/InternalI.h
+++ b/cpp/include/DataStorm/InternalI.h
@@ -142,7 +142,6 @@ namespace DataStormI
         virtual ~FilterFactory() = default;
 
         virtual std::shared_ptr<Filter> get(std::int64_t) const = 0;
-        virtual std::shared_ptr<Filter> decode(const Ice::CommunicatorPtr&, const Ice::ByteSeq&) = 0;
     };
 
     class FilterManager


### PR DESCRIPTION
This PR fix #2926, and replaces #3277

- Removed the Filter init method.
- Updated the Filter constructor to accept the extra arguments previously passed through init.
