### PR TITLE
Fix android IceSSL testing

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InitializationData.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InitializationData.java
@@ -76,4 +76,14 @@ public final class InitializationData implements Cloneable {
      * the SSLEngineFactory.
      */
     public SSLEngineFactory clientSSLEngineFactory;
+
+    /**
+     * A user-supplied function used to loads resources (e.g., key stores, trust stores) given a
+     * resource identifier or path. If this field is non-null, the provided function is used to load
+     * resources. Otherwise, the default loader (using the classpath and file system) is used.
+     *
+     * <p>If the function itself returns {@code null} when attempting to load a particular resource,
+     * this class will automatically fall back to the default resource loader.
+     */
+    public java.util.function.Function<String, java.io.InputStream> resourceLoader;
 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
@@ -553,7 +553,7 @@ public final class Properties {
         } else {
             java.io.PushbackInputStream is = null;
             try {
-                java.io.InputStream f = Util.openResource(getClass().getClassLoader(), file);
+                java.io.InputStream f = Util.openResource(null, getClass().getClassLoader(), file);
                 if (f == null) {
                     throw new FileException("failed to open '" + file + "'");
                 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
@@ -476,6 +476,11 @@ public class SSLEngine {
     }
 
     private java.io.InputStream openResource(String path) throws java.io.IOException {
+        java.io.InputStream stream;
+
+        com.zeroc.Ice.InitializationData initData =
+                _communicator.getInstance().initializationData();
+
         boolean isAbsolute = false;
         try {
             new java.net.URL(path);
@@ -485,8 +490,9 @@ public class SSLEngine {
             isAbsolute = f.isAbsolute();
         }
 
-        java.io.InputStream stream =
-                com.zeroc.Ice.Util.openResource(getClass().getClassLoader(), path);
+        stream =
+                com.zeroc.Ice.Util.openResource(
+                        initData.resourceLoader, getClass().getClassLoader(), path);
 
         //
         // If the first attempt fails and IceSSL.DefaultDir is defined and the original
@@ -497,6 +503,7 @@ public class SSLEngine {
         if (stream == null && !_defaultDir.isEmpty() && !isAbsolute) {
             stream =
                     com.zeroc.Ice.Util.openResource(
+                            initData.resourceLoader,
                             getClass().getClassLoader(),
                             _defaultDir + java.io.File.separator + path);
         }

--- a/java/test/android/controller/src/main/java/com/zeroc/testcontroller/ControllerActivity.java
+++ b/java/test/android/controller/src/main/java/com/zeroc/testcontroller/ControllerActivity.java
@@ -131,7 +131,7 @@ public class ControllerActivity extends ListActivity
 
         // Start the controller in a background thread. Starting the controller creates the ObjectAdapter which makes
         // IO calls. Android doesn't allow making IO calls from the main thread.
-        Executor executor = Executors.newSingleThreadExecutor();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
         executor.submit(() -> {
             try {
                 app.startController(this, bluetooth);

--- a/java/test/android/controller/src/main/java/com/zeroc/testcontroller/ControllerApp.java
+++ b/java/test/android/controller/src/main/java/com/zeroc/testcontroller/ControllerApp.java
@@ -281,21 +281,19 @@ public class ControllerApp extends Application {
             _args = args;
         }
 
-        public void communicatorInitialized(Communicator communicator) {
-            com.zeroc.Ice.Properties properties = communicator.getProperties();
-            if (properties
-                    .getIceProperty("Ice.Plugin.IceSSL")
-                    .equals("com.zeroc.IceSSL.PluginFactory")) {
-                com.zeroc.Ice.SSL.Plugin plugin =
-                        (com.zeroc.Ice.SSL.Plugin)
-                                communicator.getPluginManager().getPlugin("IceSSL");
-                String keystore = communicator.getProperties().getIceProperty("IceSSL.Keystore");
-                properties.setProperty("IceSSL.Keystore", "");
-                int resource = keystore.equals("client.bks") ? R.raw.client : R.raw.server;
-                java.io.InputStream certs = getResources().openRawResource(resource);
-                plugin.setKeystoreStream(certs);
-                plugin.setTruststoreStream(certs);
-                communicator.getPluginManager().initializePlugins();
+        public void communicatorInitialized(Communicator communicator) {}
+
+        public java.io.InputStream loadResource(String path) {
+            switch (path) {
+                case "server.bks" -> {
+                    return getResources().openRawResource(R.raw.server);
+                }
+                case "client.bks" -> {
+                    return getResources().openRawResource(R.raw.client);
+                }
+                default -> {
+                    return null;
+                }
             }
         }
 

--- a/java/test/src/main/java/test/Ice/inactivityTimeout/AllTests.java
+++ b/java/test/src/main/java/test/Ice/inactivityTimeout/AllTests.java
@@ -6,7 +6,6 @@ import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Connection;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.Properties;
-import com.zeroc.Ice.Util;
 
 import test.Ice.inactivityTimeout.Test.TestIntfPrx;
 
@@ -22,7 +21,7 @@ public class AllTests {
 
         testClientInactivityTimeout(p, helper.getWriter());
         testServerInactivityTimeout(
-                proxyString3s, communicator.getProperties(), helper.getWriter());
+                helper, proxyString3s, communicator.getProperties(), helper.getWriter());
         testWithOutstandingRequest(p, false, helper.getWriter());
         testWithOutstandingRequest(p, true, helper.getWriter());
 
@@ -53,7 +52,7 @@ public class AllTests {
     }
 
     private static void testServerInactivityTimeout(
-            String proxyString, Properties properties, PrintWriter output) {
+            test.TestHelper helper, String proxyString, Properties properties, PrintWriter output) {
         output.write(
                 "testing that the server side inactivity timeout shuts down the connection... ");
         output.flush();
@@ -63,7 +62,7 @@ public class AllTests {
         properties.setProperty("Ice.Connection.Client.InactivityTimeout", "5");
         var initData = new InitializationData();
         initData.properties = properties;
-        try (var communicator = Util.initialize(initData)) {
+        try (var communicator = helper.initialize(initData)) {
             TestIntfPrx p = TestIntfPrx.uncheckedCast(communicator.stringToProxy(proxyString));
 
             p.ice_ping();

--- a/java/test/src/main/java/test/Ice/timeout/AllTests.java
+++ b/java/test/src/main/java/test/Ice/timeout/AllTests.java
@@ -91,7 +91,7 @@ public class AllTests {
             properties.setProperty("Ice.Connection.Client.ConnectTimeout", "-1");
             var initData = new InitializationData();
             initData.properties = properties;
-            try (var communicator2 = com.zeroc.Ice.Util.initialize(initData)) {
+            try (var communicator2 = helper.initialize(initData)) {
                 TimeoutPrx to = TimeoutPrx.uncheckedCast(communicator2.stringToProxy(sref));
                 controller.holdAdapter(100);
                 try {

--- a/java/test/src/main/java/test/TestHelper.java
+++ b/java/test/src/main/java/test/TestHelper.java
@@ -16,6 +16,8 @@ public abstract class TestHelper {
     public interface ControllerHelper {
         void communicatorInitialized(Communicator c);
 
+        java.io.InputStream loadResource(String name);
+
         void serverReady();
     }
 
@@ -125,6 +127,15 @@ public abstract class TestHelper {
     public Communicator initialize(InitializationData initData) {
         if (_classLoader != null && initData.classLoader == null) {
             initData.classLoader = _classLoader;
+        }
+
+        if (isAndroid()) {
+            initData.resourceLoader =
+                    (String path) -> {
+                        return _controllerHelper != null
+                                ? _controllerHelper.loadResource(path)
+                                : null;
+                    };
         }
 
         Communicator communicator = Util.initialize(initData);

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -3780,7 +3780,6 @@ class JavaMapping(Mapping):
                 {
                     "IceSSL.KeystoreType": "BKS",
                     "IceSSL.TruststoreType": "BKS",
-                    "Ice.InitPlugins": "0",
                     "IceSSL.Keystore": "server.bks"
                     if isinstance(process, Server)
                     else "client.bks",


### PR DESCRIPTION
This PR fixes Android SSL testing, see #3288

With Ice 3.7, we relied on delaying IceSSL plug-in initialization and then manually setting the key store or trust store from the test controller helper in the communicator-initialized hook.

With Ice 3.8, this approach doesn't work because IceSSL is no longer a plug-in. It’s now a built-in transport, and its configuration must either be specified using IceSSL properties (as before) or when the communicator is created (client side) or the object adapter is created (server side).

Using the new native SSL APIs would require reviewing all object adapter creation in the test suite to correctly set the SSL configuration. For the client side, communicators are already created with a helper method, which simplifies things.

To keep it simpler, I added a new `resourceLoader` member to `InitializationData` that allows loading certificates using a custom loader; in this case, we want to load them from Android resources.

If we don’t want to take this approach of adding a new `resourceLoader`, an alternative would be to set the existing `classLoader` and wrap it with a decorator that re-implements `getResourceAsStream`.