### PR TITLE
Add support for Ruby 3.4

### DIFF
--- a/ruby/config/Make.rules
+++ b/ruby/config/Make.rules
@@ -26,7 +26,8 @@ ifneq ($(wildcard $(ruby_config_dir)/ruby/config.h),)
 endif
 
 ifeq ($(os),Linux)
-   cppflags   := $(filter-out -Wredundant-decls -Wshadow,$(cppflags))
+   cppflags			:= $(filter-out -Wredundant-decls -Wshadow,$(cppflags))
+   ruby_cppflags 	+= $(ruby_cppflags) -Wno-missing-field-initializers
 endif
 
 # Ruby linker flags

--- a/ruby/src/IceRuby/Communicator.cpp
+++ b/ruby/src/IceRuby/Communicator.cpp
@@ -53,10 +53,7 @@ static const rb_data_type_t IceRuby_CommunicatorType = {
         {
             .dmark = IceRuby_Communicator_mark,
             .dfree = IceRuby_Communicator_free,
-            .dsize = nullptr,
         },
-    .data = nullptr,
-    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
 namespace

--- a/ruby/src/IceRuby/Communicator.cpp
+++ b/ruby/src/IceRuby/Communicator.cpp
@@ -54,6 +54,7 @@ static const rb_data_type_t IceRuby_CommunicatorType = {
             .dmark = IceRuby_Communicator_mark,
             .dfree = IceRuby_Communicator_free,
         },
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
 namespace

--- a/ruby/src/IceRuby/Communicator.cpp
+++ b/ruby/src/IceRuby/Communicator.cpp
@@ -43,8 +43,7 @@ IceRuby_Communicator_mark(void* p)
 extern "C" void
 IceRuby_Communicator_free(void* p)
 {
-    auto communicator = static_cast<Ice::CommunicatorPtr*>(p);
-    delete communicator;
+    delete static_cast<Ice::CommunicatorPtr*>(p);
 }
 
 static const rb_data_type_t IceRuby_CommunicatorType = {

--- a/ruby/src/IceRuby/Communicator.cpp
+++ b/ruby/src/IceRuby/Communicator.cpp
@@ -25,12 +25,12 @@ using CommunicatorMap = map<Ice::CommunicatorPtr, VALUE>;
 static CommunicatorMap _communicatorMap;
 
 extern "C" void
-IceRuby_Communicator_mark(Ice::CommunicatorPtr* p)
+IceRuby_Communicator_mark(void* p)
 {
-    assert(p);
+    auto communicator = static_cast<Ice::CommunicatorPtr*>(p);
     try
     {
-        auto vfm = dynamic_pointer_cast<ValueFactoryManager>((*p)->getValueFactoryManager());
+        auto vfm = dynamic_pointer_cast<ValueFactoryManager>((*communicator)->getValueFactoryManager());
         assert(vfm);
         vfm->markSelf();
     }
@@ -41,11 +41,23 @@ IceRuby_Communicator_mark(Ice::CommunicatorPtr* p)
 }
 
 extern "C" void
-IceRuby_Communicator_free(Ice::CommunicatorPtr* p)
+IceRuby_Communicator_free(void* p)
 {
-    assert(p);
-    delete p;
+    auto communicator = static_cast<Ice::CommunicatorPtr*>(p);
+    delete communicator;
 }
+
+static const rb_data_type_t IceRuby_CommunicatorType = {
+    .wrap_struct_name = "Ice::Communicator",
+    .function =
+        {
+            .dmark = IceRuby_Communicator_mark,
+            .dfree = IceRuby_Communicator_free,
+            .dsize = nullptr,
+        },
+    .data = nullptr,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
 
 namespace
 {
@@ -260,10 +272,9 @@ IceRuby_initialize(int argc, VALUE* argv, VALUE /*self*/)
         }
         delete[] av;
 
-        VALUE result = Data_Wrap_Struct(
+        VALUE result = TypedData_Wrap_Struct(
             _communicatorClass,
-            IceRuby_Communicator_mark,
-            IceRuby_Communicator_free,
+            &IceRuby_CommunicatorType,
             new Ice::CommunicatorPtr(communicator));
 
         CommunicatorMap::iterator p = _communicatorMap.find(communicator);

--- a/ruby/src/IceRuby/Connection.cpp
+++ b/ruby/src/IceRuby/Connection.cpp
@@ -21,19 +21,28 @@ static VALUE _udpConnectionInfoClass;
 static VALUE _wsConnectionInfoClass;
 static VALUE _sslConnectionInfoClass;
 
-// Connection
-
 extern "C" void
-IceRuby_Connection_free(Ice::ConnectionPtr* p)
+IceRuby_Connection_free(void* p)
 {
-    assert(p);
-    delete p;
+    delete static_cast<Ice::ConnectionPtr*>(p);
 }
+
+static const rb_data_type_t IceRuby_ConnectionType = {
+    .wrap_struct_name = "Ice::Connection",
+    .function =
+        {
+            .dmark = nullptr,
+            .dfree = IceRuby_Connection_free,
+            .dsize = nullptr,
+        },
+    .data = nullptr,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
 
 VALUE
 IceRuby::createConnection(const Ice::ConnectionPtr& p)
 {
-    return Data_Wrap_Struct(_connectionClass, 0, IceRuby_Connection_free, new Ice::ConnectionPtr(p));
+    return TypedData_Wrap_Struct(_connectionClass, &IceRuby_ConnectionType, new Ice::ConnectionPtr(p));
 }
 
 extern "C" VALUE
@@ -197,11 +206,22 @@ IceRuby_Connection_equals(VALUE self, VALUE other)
 // ConnectionInfo
 
 extern "C" void
-IceRuby_ConnectionInfo_free(Ice::ConnectionInfoPtr* p)
+IceRuby_ConnectionInfo_free(void* p)
 {
-    assert(p);
-    delete p;
+    delete static_cast<Ice::ConnectionInfoPtr*>(p);
 }
+
+static const rb_data_type_t IceRuby_ConnectionInfoType = {
+    .wrap_struct_name = "Ice::ConnectionInfo",
+    .function =
+        {
+            .dmark = nullptr,
+            .dfree = IceRuby_ConnectionInfo_free,
+            .dsize = nullptr,
+        },
+    .data = nullptr,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
 
 VALUE
 IceRuby::createConnectionInfo(const Ice::ConnectionInfoPtr& p)
@@ -214,7 +234,8 @@ IceRuby::createConnectionInfo(const Ice::ConnectionInfoPtr& p)
     VALUE info;
     if (dynamic_pointer_cast<Ice::WSConnectionInfo>(p))
     {
-        info = Data_Wrap_Struct(_wsConnectionInfoClass, 0, IceRuby_ConnectionInfo_free, new Ice::ConnectionInfoPtr(p));
+        info =
+            TypedData_Wrap_Struct(_wsConnectionInfoClass, &IceRuby_ConnectionInfoType, new Ice::ConnectionInfoPtr(p));
 
         Ice::WSConnectionInfoPtr ws = dynamic_pointer_cast<Ice::WSConnectionInfo>(p);
         volatile VALUE result = callRuby(rb_hash_new);
@@ -228,7 +249,8 @@ IceRuby::createConnectionInfo(const Ice::ConnectionInfoPtr& p)
     }
     else if (dynamic_pointer_cast<Ice::TCPConnectionInfo>(p))
     {
-        info = Data_Wrap_Struct(_tcpConnectionInfoClass, 0, IceRuby_ConnectionInfo_free, new Ice::ConnectionInfoPtr(p));
+        info =
+            TypedData_Wrap_Struct(_tcpConnectionInfoClass, &IceRuby_ConnectionInfoType, new Ice::ConnectionInfoPtr(p));
 
         Ice::TCPConnectionInfoPtr tcp = dynamic_pointer_cast<Ice::TCPConnectionInfo>(p);
         rb_ivar_set(info, rb_intern("@rcvSize"), INT2FIX(tcp->rcvSize));
@@ -236,7 +258,8 @@ IceRuby::createConnectionInfo(const Ice::ConnectionInfoPtr& p)
     }
     else if (dynamic_pointer_cast<Ice::UDPConnectionInfo>(p))
     {
-        info = Data_Wrap_Struct(_udpConnectionInfoClass, 0, IceRuby_ConnectionInfo_free, new Ice::ConnectionInfoPtr(p));
+        info =
+            TypedData_Wrap_Struct(_udpConnectionInfoClass, &IceRuby_ConnectionInfoType, new Ice::ConnectionInfoPtr(p));
 
         Ice::UDPConnectionInfoPtr udp = dynamic_pointer_cast<Ice::UDPConnectionInfo>(p);
         rb_ivar_set(info, rb_intern("@mcastAddress"), createString(udp->mcastAddress));
@@ -246,7 +269,8 @@ IceRuby::createConnectionInfo(const Ice::ConnectionInfoPtr& p)
     }
     else if (dynamic_pointer_cast<Ice::SSL::ConnectionInfo>(p))
     {
-        info = Data_Wrap_Struct(_sslConnectionInfoClass, 0, IceRuby_ConnectionInfo_free, new Ice::ConnectionInfoPtr(p));
+        info =
+            TypedData_Wrap_Struct(_sslConnectionInfoClass, &IceRuby_ConnectionInfoType, new Ice::ConnectionInfoPtr(p));
 
         Ice::SSL::ConnectionInfoPtr ssl = dynamic_pointer_cast<Ice::SSL::ConnectionInfo>(p);
         string encoded;
@@ -258,11 +282,12 @@ IceRuby::createConnectionInfo(const Ice::ConnectionInfoPtr& p)
     }
     else if (dynamic_pointer_cast<Ice::IPConnectionInfo>(p))
     {
-        info = Data_Wrap_Struct(_ipConnectionInfoClass, 0, IceRuby_ConnectionInfo_free, new Ice::ConnectionInfoPtr(p));
+        info =
+            TypedData_Wrap_Struct(_ipConnectionInfoClass, &IceRuby_ConnectionInfoType, new Ice::ConnectionInfoPtr(p));
     }
     else
     {
-        info = Data_Wrap_Struct(_connectionInfoClass, 0, IceRuby_ConnectionInfo_free, new Ice::ConnectionInfoPtr(p));
+        info = TypedData_Wrap_Struct(_connectionInfoClass, &IceRuby_ConnectionInfoType, new Ice::ConnectionInfoPtr(p));
     }
 
     if (dynamic_pointer_cast<Ice::IPConnectionInfo>(p))

--- a/ruby/src/IceRuby/Connection.cpp
+++ b/ruby/src/IceRuby/Connection.cpp
@@ -31,12 +31,8 @@ static const rb_data_type_t IceRuby_ConnectionType = {
     .wrap_struct_name = "Ice::Connection",
     .function =
         {
-            .dmark = nullptr,
             .dfree = IceRuby_Connection_free,
-            .dsize = nullptr,
         },
-    .data = nullptr,
-    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
 VALUE
@@ -215,12 +211,8 @@ static const rb_data_type_t IceRuby_ConnectionInfoType = {
     .wrap_struct_name = "Ice::ConnectionInfo",
     .function =
         {
-            .dmark = nullptr,
             .dfree = IceRuby_ConnectionInfo_free,
-            .dsize = nullptr,
         },
-    .data = nullptr,
-    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
 VALUE

--- a/ruby/src/IceRuby/Connection.cpp
+++ b/ruby/src/IceRuby/Connection.cpp
@@ -33,6 +33,8 @@ static const rb_data_type_t IceRuby_ConnectionType = {
         {
             .dfree = IceRuby_Connection_free,
         },
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+
 };
 
 VALUE
@@ -213,6 +215,8 @@ static const rb_data_type_t IceRuby_ConnectionInfoType = {
         {
             .dfree = IceRuby_ConnectionInfo_free,
         },
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+
 };
 
 VALUE

--- a/ruby/src/IceRuby/Connection.cpp
+++ b/ruby/src/IceRuby/Connection.cpp
@@ -34,7 +34,6 @@ static const rb_data_type_t IceRuby_ConnectionType = {
             .dfree = IceRuby_Connection_free,
         },
     .flags = RUBY_TYPED_FREE_IMMEDIATELY,
-
 };
 
 VALUE
@@ -216,7 +215,6 @@ static const rb_data_type_t IceRuby_ConnectionInfoType = {
             .dfree = IceRuby_ConnectionInfo_free,
         },
     .flags = RUBY_TYPED_FREE_IMMEDIATELY,
-
 };
 
 VALUE

--- a/ruby/src/IceRuby/Endpoint.cpp
+++ b/ruby/src/IceRuby/Endpoint.cpp
@@ -42,7 +42,7 @@ static const rb_data_type_t IceRuby_EndpointType = {
 VALUE
 IceRuby::createEndpoint(const Ice::EndpointPtr& p)
 {
-    return TypedData_Wrap_Struct(_endpointClass, &IceRuby_EndpointType, new Ice::EndpointPtr(p));
+    return TypedData_Wrap_Struct(_endpointClass, &IceRuby_Endpoint, new Ice::EndpointPtr(p));
 }
 
 extern "C" VALUE

--- a/ruby/src/IceRuby/Endpoint.cpp
+++ b/ruby/src/IceRuby/Endpoint.cpp
@@ -42,7 +42,7 @@ static const rb_data_type_t IceRuby_EndpointType = {
 VALUE
 IceRuby::createEndpoint(const Ice::EndpointPtr& p)
 {
-    return TypedData_Wrap_Struct(_endpointClass, &IceRuby_Endpoint, new Ice::EndpointPtr(p));
+    return TypedData_Wrap_Struct(_endpointClass, &IceRuby_EndpointType, new Ice::EndpointPtr(p));
 }
 
 extern "C" VALUE

--- a/ruby/src/IceRuby/Endpoint.cpp
+++ b/ruby/src/IceRuby/Endpoint.cpp
@@ -22,16 +22,27 @@ static VALUE _sslEndpointInfoClass;
 // Endpoint
 
 extern "C" void
-IceRuby_Endpoint_free(Ice::EndpointPtr* p)
+IceRuby_Endpoint_free(void* p)
 {
-    assert(p);
-    delete p;
+    delete static_cast<Ice::EndpointPtr*>(p);
 }
+
+static const rb_data_type_t IceRuby_EndpointType = {
+    .wrap_struct_name = "Ice::Endpoint",
+    .function =
+        {
+            .dmark = nullptr,
+            .dfree = IceRuby_Endpoint_free,
+            .dsize = nullptr,
+        },
+    .data = nullptr,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
 
 VALUE
 IceRuby::createEndpoint(const Ice::EndpointPtr& p)
 {
-    return Data_Wrap_Struct(_endpointClass, 0, IceRuby_Endpoint_free, new Ice::EndpointPtr(p));
+    return TypedData_Wrap_Struct(_endpointClass, &IceRuby_EndpointType, new Ice::EndpointPtr(p));
 }
 
 extern "C" VALUE
@@ -105,11 +116,22 @@ IceRuby_Endpoint_equals(VALUE self, VALUE other)
 // EndpointInfo
 
 extern "C" void
-IceRuby_EndpointInfo_free(Ice::EndpointPtr* p)
+IceRuby_EndpointInfo_free(void* p)
 {
-    assert(p);
-    delete p;
+    delete static_cast<Ice::EndpointInfoPtr*>(p);
 }
+
+static const rb_data_type_t IceRuby_EndpointInfoType = {
+    .wrap_struct_name = "Ice::EndpointInfo",
+    .function =
+        {
+            .dmark = nullptr,
+            .dfree = IceRuby_EndpointInfo_free,
+            .dsize = nullptr,
+        },
+    .data = nullptr,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
 
 VALUE
 IceRuby::createEndpointInfo(const Ice::EndpointInfoPtr& p)
@@ -122,18 +144,18 @@ IceRuby::createEndpointInfo(const Ice::EndpointInfoPtr& p)
     VALUE info;
     if (dynamic_pointer_cast<Ice::WSEndpointInfo>(p))
     {
-        info = Data_Wrap_Struct(_wsEndpointInfoClass, 0, IceRuby_EndpointInfo_free, new Ice::EndpointInfoPtr(p));
+        info = TypedData_Wrap_Struct(_wsEndpointInfoClass, &IceRuby_EndpointInfoType, new Ice::EndpointInfoPtr(p));
 
         Ice::WSEndpointInfoPtr ws = dynamic_pointer_cast<Ice::WSEndpointInfo>(p);
         rb_ivar_set(info, rb_intern("@resource"), createString(ws->resource));
     }
     else if (dynamic_pointer_cast<Ice::TCPEndpointInfo>(p))
     {
-        info = Data_Wrap_Struct(_tcpEndpointInfoClass, 0, IceRuby_EndpointInfo_free, new Ice::EndpointInfoPtr(p));
+        info = TypedData_Wrap_Struct(_tcpEndpointInfoClass, &IceRuby_EndpointInfoType, new Ice::EndpointInfoPtr(p));
     }
     else if (dynamic_pointer_cast<Ice::UDPEndpointInfo>(p))
     {
-        info = Data_Wrap_Struct(_udpEndpointInfoClass, 0, IceRuby_EndpointInfo_free, new Ice::EndpointInfoPtr(p));
+        info = TypedData_Wrap_Struct(_udpEndpointInfoClass, &IceRuby_EndpointInfoType, new Ice::EndpointInfoPtr(p));
 
         Ice::UDPEndpointInfoPtr udp = dynamic_pointer_cast<Ice::UDPEndpointInfo>(p);
         rb_ivar_set(info, rb_intern("@mcastInterface"), createString(udp->mcastInterface));
@@ -141,7 +163,7 @@ IceRuby::createEndpointInfo(const Ice::EndpointInfoPtr& p)
     }
     else if (dynamic_pointer_cast<Ice::OpaqueEndpointInfo>(p))
     {
-        info = Data_Wrap_Struct(_opaqueEndpointInfoClass, 0, IceRuby_EndpointInfo_free, new Ice::EndpointInfoPtr(p));
+        info = TypedData_Wrap_Struct(_opaqueEndpointInfoClass, &IceRuby_EndpointInfoType, new Ice::EndpointInfoPtr(p));
 
         Ice::OpaqueEndpointInfoPtr opaque = dynamic_pointer_cast<Ice::OpaqueEndpointInfo>(p);
         auto b = opaque->rawBytes;
@@ -151,15 +173,15 @@ IceRuby::createEndpointInfo(const Ice::EndpointInfoPtr& p)
     }
     else if (dynamic_pointer_cast<Ice::SSL::EndpointInfo>(p))
     {
-        info = Data_Wrap_Struct(_sslEndpointInfoClass, 0, IceRuby_EndpointInfo_free, new Ice::EndpointInfoPtr(p));
+        info = TypedData_Wrap_Struct(_sslEndpointInfoClass, &IceRuby_EndpointInfoType, new Ice::EndpointInfoPtr(p));
     }
     else if (dynamic_pointer_cast<Ice::IPEndpointInfo>(p))
     {
-        info = Data_Wrap_Struct(_ipEndpointInfoClass, 0, IceRuby_EndpointInfo_free, new Ice::EndpointInfoPtr(p));
+        info = TypedData_Wrap_Struct(_ipEndpointInfoClass, &IceRuby_EndpointInfoType, new Ice::EndpointInfoPtr(p));
     }
     else
     {
-        info = Data_Wrap_Struct(_endpointInfoClass, 0, IceRuby_EndpointInfo_free, new Ice::EndpointInfoPtr(p));
+        info = TypedData_Wrap_Struct(_endpointInfoClass, &IceRuby_EndpointInfoType, new Ice::EndpointInfoPtr(p));
     }
 
     if (dynamic_pointer_cast<Ice::IPEndpointInfo>(p))

--- a/ruby/src/IceRuby/Endpoint.cpp
+++ b/ruby/src/IceRuby/Endpoint.cpp
@@ -31,12 +31,8 @@ static const rb_data_type_t IceRuby_EndpointType = {
     .wrap_struct_name = "Ice::Endpoint",
     .function =
         {
-            .dmark = nullptr,
             .dfree = IceRuby_Endpoint_free,
-            .dsize = nullptr,
         },
-    .data = nullptr,
-    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
 VALUE
@@ -125,9 +121,7 @@ static const rb_data_type_t IceRuby_EndpointInfoType = {
     .wrap_struct_name = "Ice::EndpointInfo",
     .function =
         {
-            .dmark = nullptr,
             .dfree = IceRuby_EndpointInfo_free,
-            .dsize = nullptr,
         },
     .data = nullptr,
     .flags = RUBY_TYPED_FREE_IMMEDIATELY,

--- a/ruby/src/IceRuby/Endpoint.cpp
+++ b/ruby/src/IceRuby/Endpoint.cpp
@@ -33,6 +33,8 @@ static const rb_data_type_t IceRuby_EndpointType = {
         {
             .dfree = IceRuby_Endpoint_free,
         },
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+
 };
 
 VALUE
@@ -123,8 +125,8 @@ static const rb_data_type_t IceRuby_EndpointInfoType = {
         {
             .dfree = IceRuby_EndpointInfo_free,
         },
-    .data = nullptr,
     .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+
 };
 
 VALUE

--- a/ruby/src/IceRuby/Endpoint.cpp
+++ b/ruby/src/IceRuby/Endpoint.cpp
@@ -34,7 +34,6 @@ static const rb_data_type_t IceRuby_EndpointType = {
             .dfree = IceRuby_Endpoint_free,
         },
     .flags = RUBY_TYPED_FREE_IMMEDIATELY,
-
 };
 
 VALUE
@@ -126,7 +125,6 @@ static const rb_data_type_t IceRuby_EndpointInfoType = {
             .dfree = IceRuby_EndpointInfo_free,
         },
     .flags = RUBY_TYPED_FREE_IMMEDIATELY,
-
 };
 
 VALUE

--- a/ruby/src/IceRuby/ImplicitContext.cpp
+++ b/ruby/src/IceRuby/ImplicitContext.cpp
@@ -26,7 +26,6 @@ static const rb_data_type_t IceRuby_ImplicitContextType = {
 
         },
     .flags = RUBY_TYPED_FREE_IMMEDIATELY,
-
 };
 
 extern "C" VALUE

--- a/ruby/src/IceRuby/ImplicitContext.cpp
+++ b/ruby/src/IceRuby/ImplicitContext.cpp
@@ -25,8 +25,8 @@ static const rb_data_type_t IceRuby_ImplicitContextType = {
             .dfree = IceRuby_ImplicitContext_free,
 
         },
-    .data = nullptr,
     .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+
 };
 
 extern "C" VALUE

--- a/ruby/src/IceRuby/ImplicitContext.cpp
+++ b/ruby/src/IceRuby/ImplicitContext.cpp
@@ -22,9 +22,8 @@ static const rb_data_type_t IceRuby_ImplicitContextType = {
     .wrap_struct_name = "Ice::ImplicitContext",
     .function =
         {
-            .dmark = nullptr,
             .dfree = IceRuby_ImplicitContext_free,
-            .dsize = nullptr,
+
         },
     .data = nullptr,
     .flags = RUBY_TYPED_FREE_IMMEDIATELY,

--- a/ruby/src/IceRuby/ImplicitContext.cpp
+++ b/ruby/src/IceRuby/ImplicitContext.cpp
@@ -23,7 +23,6 @@ static const rb_data_type_t IceRuby_ImplicitContextType = {
     .function =
         {
             .dfree = IceRuby_ImplicitContext_free,
-
         },
     .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };

--- a/ruby/src/IceRuby/ImplicitContext.cpp
+++ b/ruby/src/IceRuby/ImplicitContext.cpp
@@ -13,11 +13,22 @@ using namespace IceRuby;
 static VALUE _implicitContextClass;
 
 extern "C" void
-IceRuby_ImplicitContext_free(Ice::ImplicitContextPtr* p)
+IceRuby_ImplicitContext_free(void* p)
 {
-    assert(p);
-    delete p;
+    delete static_cast<Ice::ImplicitContextPtr*>(p);
 }
+
+static const rb_data_type_t IceRuby_ImplicitContextType = {
+    .wrap_struct_name = "Ice::ImplicitContext",
+    .function =
+        {
+            .dmark = nullptr,
+            .dfree = IceRuby_ImplicitContext_free,
+            .dsize = nullptr,
+        },
+    .data = nullptr,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
 
 extern "C" VALUE
 IceRuby_ImplicitContext_getContext(VALUE self)
@@ -133,5 +144,5 @@ IceRuby::getImplicitContext(VALUE v)
 VALUE
 IceRuby::createImplicitContext(const Ice::ImplicitContextPtr& p)
 {
-    return Data_Wrap_Struct(_implicitContextClass, 0, IceRuby_ImplicitContext_free, new Ice::ImplicitContextPtr(p));
+    return TypedData_Wrap_Struct(_implicitContextClass, &IceRuby_ImplicitContextType, new Ice::ImplicitContextPtr(p));
 }

--- a/ruby/src/IceRuby/Logger.cpp
+++ b/ruby/src/IceRuby/Logger.cpp
@@ -21,11 +21,8 @@ static const rb_data_type_t IceRuby_LoggerType = {
     .wrap_struct_name = "Ice::Logger",
     .function =
         {
-            .dmark = nullptr,
             .dfree = IceRuby_Logger_free,
-            .dsize = nullptr,
         },
-    .data = nullptr,
     .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
 

--- a/ruby/src/IceRuby/Logger.cpp
+++ b/ruby/src/IceRuby/Logger.cpp
@@ -12,16 +12,27 @@ using namespace IceRuby;
 static VALUE _loggerClass;
 
 extern "C" void
-IceRuby_Logger_free(Ice::LoggerPtr* p)
+IceRuby_Logger_free(void* p)
 {
-    assert(p);
-    delete p;
+    delete static_cast<Ice::LoggerPtr*>(p);
 }
+
+static const rb_data_type_t IceRuby_LoggerType = {
+    .wrap_struct_name = "Ice::Logger",
+    .function =
+        {
+            .dmark = nullptr,
+            .dfree = IceRuby_Logger_free,
+            .dsize = nullptr,
+        },
+    .data = nullptr,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
 
 VALUE
 IceRuby::createLogger(const Ice::LoggerPtr& p)
 {
-    return Data_Wrap_Struct(_loggerClass, 0, IceRuby_Logger_free, new Ice::LoggerPtr(p));
+    return TypedData_Wrap_Struct(_loggerClass, &IceRuby_LoggerType, new Ice::LoggerPtr(p));
 }
 
 extern "C" VALUE

--- a/ruby/src/IceRuby/Logger.cpp
+++ b/ruby/src/IceRuby/Logger.cpp
@@ -24,7 +24,6 @@ static const rb_data_type_t IceRuby_LoggerType = {
             .dfree = IceRuby_Logger_free,
         },
     .flags = RUBY_TYPED_FREE_IMMEDIATELY,
-
 };
 
 VALUE

--- a/ruby/src/IceRuby/Logger.cpp
+++ b/ruby/src/IceRuby/Logger.cpp
@@ -24,6 +24,7 @@ static const rb_data_type_t IceRuby_LoggerType = {
             .dfree = IceRuby_Logger_free,
         },
     .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+
 };
 
 VALUE

--- a/ruby/src/IceRuby/Operation.cpp
+++ b/ruby/src/IceRuby/Operation.cpp
@@ -83,7 +83,6 @@ static const rb_data_type_t IceRuby_OperationType = {
             .dfree = IceRuby_Operation_free,
         },
     .flags = RUBY_TYPED_FREE_IMMEDIATELY,
-
 };
 
 extern "C" VALUE

--- a/ruby/src/IceRuby/Operation.cpp
+++ b/ruby/src/IceRuby/Operation.cpp
@@ -71,10 +71,22 @@ namespace IceRuby
 }
 
 extern "C" void
-IceRuby_Operation_free(OperationPtr* p)
+IceRuby_Operation_free(void* p)
 {
-    delete p;
+    delete static_cast<OperationPtr*>(p);
 }
+
+static const rb_data_type_t IceRuby_OperationType = {
+    .wrap_struct_name = "Ice::Operation",
+    .function =
+        {
+            .dmark = nullptr,
+            .dfree = IceRuby_Operation_free,
+            .dsize = nullptr,
+        },
+    .data = nullptr,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
 
 extern "C" VALUE
 IceRuby_defineOperation(
@@ -90,7 +102,7 @@ IceRuby_defineOperation(
     ICE_RUBY_TRY
     {
         OperationIPtr op = make_shared<OperationI>(name, mode, format, inParams, outParams, returnType, exceptions);
-        return Data_Wrap_Struct(_operationClass, 0, IceRuby_Operation_free, new OperationPtr(op));
+        return TypedData_Wrap_Struct(_operationClass, &IceRuby_OperationType, new OperationPtr(op));
     }
     ICE_RUBY_CATCH
     return Qnil;

--- a/ruby/src/IceRuby/Operation.cpp
+++ b/ruby/src/IceRuby/Operation.cpp
@@ -80,10 +80,10 @@ static const rb_data_type_t IceRuby_OperationType = {
     .wrap_struct_name = "Ice::Operation",
     .function =
         {
-            .dmark = nullptr,
             .dfree = IceRuby_Operation_free,
-            .dsize = nullptr,
         },
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+
 };
 
 extern "C" VALUE

--- a/ruby/src/IceRuby/Operation.cpp
+++ b/ruby/src/IceRuby/Operation.cpp
@@ -84,8 +84,6 @@ static const rb_data_type_t IceRuby_OperationType = {
             .dfree = IceRuby_Operation_free,
             .dsize = nullptr,
         },
-    .data = nullptr,
-    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
 extern "C" VALUE

--- a/ruby/src/IceRuby/Properties.cpp
+++ b/ruby/src/IceRuby/Properties.cpp
@@ -22,9 +22,10 @@ static const rb_data_type_t IceRuby_PropertiesType = {
     .wrap_struct_name = "Ice::Properties",
     .function =
         {
-            .dmark = nullptr,
             .dfree = IceRuby_Properties_free,
         },
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+
 };
 
 extern "C" VALUE

--- a/ruby/src/IceRuby/Properties.cpp
+++ b/ruby/src/IceRuby/Properties.cpp
@@ -13,11 +13,22 @@ using namespace IceRuby;
 static VALUE _propertiesClass;
 
 extern "C" void
-IceRuby_Properties_free(Ice::PropertiesPtr* p)
+IceRuby_Properties_free(void* p)
 {
-    assert(p);
-    delete p;
+    delete static_cast<Ice::PropertiesPtr*>(p);
 }
+
+static const rb_data_type_t IceRuby_PropertiesType = {
+    .wrap_struct_name = "Ice::Properties",
+    .function =
+        {
+            .dmark = nullptr,
+            .dfree = IceRuby_Properties_free,
+            .dsize = nullptr,
+        },
+    .data = nullptr,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
 
 extern "C" VALUE
 IceRuby_createProperties(int argc, VALUE* argv, VALUE /*self*/)
@@ -411,5 +422,5 @@ IceRuby::getProperties(VALUE v)
 VALUE
 IceRuby::createProperties(const Ice::PropertiesPtr& p)
 {
-    return Data_Wrap_Struct(_propertiesClass, 0, IceRuby_Properties_free, new Ice::PropertiesPtr(p));
+    return TypedData_Wrap_Struct(_propertiesClass, &IceRuby_PropertiesType, new Ice::PropertiesPtr(p));
 }

--- a/ruby/src/IceRuby/Properties.cpp
+++ b/ruby/src/IceRuby/Properties.cpp
@@ -25,7 +25,6 @@ static const rb_data_type_t IceRuby_PropertiesType = {
             .dfree = IceRuby_Properties_free,
         },
     .flags = RUBY_TYPED_FREE_IMMEDIATELY,
-
 };
 
 extern "C" VALUE

--- a/ruby/src/IceRuby/Properties.cpp
+++ b/ruby/src/IceRuby/Properties.cpp
@@ -24,10 +24,7 @@ static const rb_data_type_t IceRuby_PropertiesType = {
         {
             .dmark = nullptr,
             .dfree = IceRuby_Properties_free,
-            .dsize = nullptr,
         },
-    .data = nullptr,
-    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
 extern "C" VALUE

--- a/ruby/src/IceRuby/Proxy.cpp
+++ b/ruby/src/IceRuby/Proxy.cpp
@@ -45,8 +45,6 @@ static const rb_data_type_t IceRuby_ObjectPrxType = {
             .dfree = IceRuby_ObjectPrx_free,
             .dsize = nullptr,
         },
-    .data = nullptr,
-    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
 // If a context was provided set it to ::Ice::noExplicitContext.

--- a/ruby/src/IceRuby/Proxy.cpp
+++ b/ruby/src/IceRuby/Proxy.cpp
@@ -45,7 +45,6 @@ static const rb_data_type_t IceRuby_ObjectPrxType = {
             .dfree = IceRuby_ObjectPrx_free,
         },
     .flags = RUBY_TYPED_FREE_IMMEDIATELY,
-
 };
 
 // If a context was provided set it to ::Ice::noExplicitContext.

--- a/ruby/src/IceRuby/Proxy.cpp
+++ b/ruby/src/IceRuby/Proxy.cpp
@@ -22,21 +22,32 @@ static VALUE _proxyClass;
 // ObjectPrx
 
 extern "C" void
-IceRuby_ObjectPrx_mark(Ice::ObjectPrx* p)
+IceRuby_ObjectPrx_mark(void* p)
 {
     // We need to mark the communicator associated with this proxy.
-    assert(p);
-    volatile VALUE communicator = lookupCommunicator((*p)->ice_getCommunicator());
+    auto proxy = static_cast<Ice::ObjectPrx*>(p);
+    volatile VALUE communicator = lookupCommunicator((*proxy)->ice_getCommunicator());
     assert(!NIL_P(communicator));
     rb_gc_mark(communicator);
 }
 
 extern "C" void
-IceRuby_ObjectPrx_free(Ice::ObjectPrx* p)
+IceRuby_ObjectPrx_free(void* p)
 {
-    assert(p);
-    delete p;
+    delete static_cast<Ice::ObjectPrx*>(p);
 }
+
+static const rb_data_type_t IceRuby_ObjectPrxType = {
+    .wrap_struct_name = "Ice::ObjectPrx",
+    .function =
+        {
+            .dmark = IceRuby_ObjectPrx_mark,
+            .dfree = IceRuby_ObjectPrx_free,
+            .dsize = nullptr,
+        },
+    .data = nullptr,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
 
 // If a context was provided set it to ::Ice::noExplicitContext.
 static void
@@ -1246,10 +1257,9 @@ VALUE
 IceRuby::createProxy(Ice::ObjectPrx p, VALUE cls)
 {
     // If cls is nil then the proxy has the base type Ice::ObjectPrx.
-    return Data_Wrap_Struct(
+    return TypedData_Wrap_Struct(
         NIL_P(cls) ? _proxyClass : cls,
-        IceRuby_ObjectPrx_mark,
-        IceRuby_ObjectPrx_free,
+        &IceRuby_ObjectPrxType,
         new Ice::ObjectPrx(std::move(p)));
 }
 

--- a/ruby/src/IceRuby/Proxy.cpp
+++ b/ruby/src/IceRuby/Proxy.cpp
@@ -43,8 +43,9 @@ static const rb_data_type_t IceRuby_ObjectPrxType = {
         {
             .dmark = IceRuby_ObjectPrx_mark,
             .dfree = IceRuby_ObjectPrx_free,
-            .dsize = nullptr,
         },
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+
 };
 
 // If a context was provided set it to ::Ice::noExplicitContext.

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -3109,15 +3109,24 @@ IceRuby::getType(VALUE obj)
 }
 
 extern "C" void
-IceRuby_TypeInfo_free(TypeInfoPtr* p)
+IceRuby_TypeInfo_free(void* p)
 {
-    delete p;
+    delete static_cast<TypeInfoPtr*>(p);
 }
+
+static const rb_data_type_t IceRuby_TypeInfoType = {
+    .wrap_struct_name = "Ice::TypeInfo",
+    .function =
+        {
+            .dfree = IceRuby_TypeInfo_free,
+        },
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
 
 VALUE
 IceRuby::createType(const TypeInfoPtr& info)
 {
-    return Data_Wrap_Struct(_typeInfoClass, 0, IceRuby_TypeInfo_free, new TypeInfoPtr(info));
+    return TypedData_Wrap_Struct(_typeInfoClass, &IceRuby_TypeInfoType, new TypeInfoPtr(info));
 }
 
 IceRuby::ExceptionInfoPtr
@@ -3130,13 +3139,22 @@ IceRuby::getException(VALUE obj)
 }
 
 extern "C" void
-IceRuby_ExceptionInfo_free(ExceptionInfoPtr* p)
+IceRuby_ExceptionInfo_free(void* p)
 {
-    delete p;
+    delete static_cast<ExceptionInfoPtr*>(p);
 }
+
+static const rb_data_type_t IceRuby_ExceptionInfoType = {
+    .wrap_struct_name = "Ice::ExceptionInfo",
+    .function =
+        {
+            .dfree = IceRuby_ExceptionInfo_free,
+        },
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
 
 VALUE
 IceRuby::createException(const ExceptionInfoPtr& info)
 {
-    return Data_Wrap_Struct(_exceptionInfoClass, 0, IceRuby_ExceptionInfo_free, new ExceptionInfoPtr(info));
+    return TypedData_Wrap_Struct(_exceptionInfoClass, &IceRuby_ExceptionInfoType, new ExceptionInfoPtr(info));
 }

--- a/ruby/src/IceRuby/ValueFactoryManager.cpp
+++ b/ruby/src/IceRuby/ValueFactoryManager.cpp
@@ -51,6 +51,7 @@ static const rb_data_type_t IceRuby_ValueFactoryManagerType = {
     .wrap_struct_name = "Ice::ValueFactoryManager",
     .function =
         {
+            .dmark = IceRuby_ValueFactoryManager_mark,
             .dfree = IceRuby_ValueFactoryManager_free,
         },
     .flags = RUBY_TYPED_FREE_IMMEDIATELY,

--- a/ruby/src/IceRuby/ValueFactoryManager.cpp
+++ b/ruby/src/IceRuby/ValueFactoryManager.cpp
@@ -51,12 +51,8 @@ static const rb_data_type_t IceRuby_ValueFactoryManagerType = {
     .wrap_struct_name = "Ice::ValueFactoryManager",
     .function =
         {
-            .dmark = nullptr,
             .dfree = IceRuby_ValueFactoryManager_free,
-            .dsize = nullptr,
         },
-    .data = nullptr,
-    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
 /* static */ ValueFactoryManagerPtr

--- a/ruby/src/IceRuby/ValueFactoryManager.cpp
+++ b/ruby/src/IceRuby/ValueFactoryManager.cpp
@@ -53,6 +53,8 @@ static const rb_data_type_t IceRuby_ValueFactoryManagerType = {
         {
             .dfree = IceRuby_ValueFactoryManager_free,
         },
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+
 };
 
 /* static */ ValueFactoryManagerPtr

--- a/ruby/src/IceRuby/ValueFactoryManager.cpp
+++ b/ruby/src/IceRuby/ValueFactoryManager.cpp
@@ -54,7 +54,6 @@ static const rb_data_type_t IceRuby_ValueFactoryManagerType = {
             .dfree = IceRuby_ValueFactoryManager_free,
         },
     .flags = RUBY_TYPED_FREE_IMMEDIATELY,
-
 };
 
 /* static */ ValueFactoryManagerPtr

--- a/ruby/src/IceRuby/ValueFactoryManager.cpp
+++ b/ruby/src/IceRuby/ValueFactoryManager.cpp
@@ -35,18 +35,29 @@ namespace
 }
 
 extern "C" void
-IceRuby_ValueFactoryManager_mark(ValueFactoryManagerPtr* p)
+IceRuby_ValueFactoryManager_mark(void* p)
 {
-    assert(p);
-    (*p)->mark();
+    auto manager = static_cast<ValueFactoryManagerPtr*>(p);
+    (*manager)->mark();
 }
 
 extern "C" void
-IceRuby_ValueFactoryManager_free(ValueFactoryManagerPtr* p)
+IceRuby_ValueFactoryManager_free(void* p)
 {
-    assert(p);
-    delete p;
+    delete static_cast<ValueFactoryManagerPtr*>(p);
 }
+
+static const rb_data_type_t IceRuby_ValueFactoryManagerType = {
+    .wrap_struct_name = "Ice::ValueFactoryManager",
+    .function =
+        {
+            .dmark = nullptr,
+            .dfree = IceRuby_ValueFactoryManager_free,
+            .dsize = nullptr,
+        },
+    .data = nullptr,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
 
 /* static */ ValueFactoryManagerPtr
 IceRuby::ValueFactoryManager::ValueFactoryManager::create()
@@ -57,10 +68,9 @@ IceRuby::ValueFactoryManager::ValueFactoryManager::create()
     //
     // Create a Ruby wrapper around this object. Note that this is a cyclic reference.
     //
-    vfm->_self = Data_Wrap_Struct(
+    vfm->_self = TypedData_Wrap_Struct(
         _valueFactoryManagerClass,
-        IceRuby_ValueFactoryManager_mark,
-        IceRuby_ValueFactoryManager_free,
+        &IceRuby_ValueFactoryManagerType,
         new ValueFactoryManagerPtr(vfm));
 
     return vfm;


### PR DESCRIPTION
This PR adds support for Ruby 3.4. The build was failing as `Data_Wrap_Struct` is now deprecated and should be replaced by `TypedData_Wrap_Struct` (which has been around for a while). 

Fixes #3311