### PR TITLE
Fix Instabilities and Unnecessary Sorting in the Generated Code

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -3087,7 +3087,7 @@ Slice::InterfaceDef::allOperations() const
             if (find_if(
                     result.begin(),
                     result.end(),
-                    [scoped = q->scoped()](const auto& other) { return other->scoped() == scoped; }) == result.end())
+                    [name = q->name()](const auto& other) { return other->name() == name; }) == result.end())
             {
                 result.push_back(q);
             }
@@ -3099,7 +3099,7 @@ Slice::InterfaceDef::allOperations() const
         if (find_if(
                 result.begin(),
                 result.end(),
-                [scoped = q->scoped()](const auto& other) { return other->scoped() == scoped; }) == result.end())
+                [name = q->name()](const auto& other) { return other->name() == name; }) == result.end())
         {
             result.push_back(q);
         }

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -3583,7 +3583,6 @@ Slice::Exception::createDataMember(
     checkIdentifier(name); // Don't return here -- we create the data member anyway.
 
     // Check whether any bases have defined a member with the same name already.
-    ExceptionList bl = allBases();
     for (const auto& q : allBases())
     {
         ContainedList contents;

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -3053,7 +3053,6 @@ Slice::InterfaceDef::allBases() const
 {
     InterfaceList result = _bases;
     result.sort(containedCompare);
-    result.unique(containedEqual);
     for (const auto& p : _bases)
     {
         result.merge(p->allBases(), containedCompare);

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -561,8 +561,6 @@ Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         }
 
         ExceptionList throws = op->throws();
-        throws.sort();
-        throws.unique();
         if (throws.size() == 1)
         {
             out << " throws " << getUnqualified(throws.front(), scope);

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -2651,7 +2651,6 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         allOpNames.push_back("ice_isA");
         allOpNames.push_back("ice_ping");
         allOpNames.sort();
-        allOpNames.unique();
 
         H << sp;
         H << nl << "/// \\cond INTERNAL";

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -216,15 +216,10 @@ namespace
         }
         else
         {
-            throws.sort();
-            throws.unique();
-
-            //
             // Arrange exceptions into most-derived to least-derived order. If we don't
             // do this, a base exception handler can appear before a derived exception
             // handler, causing compiler warnings and resulting in the base exception
             // being marshaled instead of the derived exception.
-            //
             throws.sort(Slice::DerivedToBaseCompare());
 
             C << "[](const " << getUnqualified("::Ice::UserException&", scope) << " ex)";
@@ -233,9 +228,8 @@ namespace
             C << sb;
             C << nl << "ex.ice_throw();";
             C << eb;
-            //
+
             // Generate a catch block for each legal user exception.
-            //
             for (const auto& ex : throws)
             {
                 C << nl << "catch(const " << getUnqualified(fixKwd(ex->scoped()), scope) << "&)";

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -325,9 +325,9 @@ Slice::CsVisitor::writeInheritedOperations(const InterfaceDefPtr& p)
             // It's possible to get the same operation name through diamond inheritance.
             // But we only want one 'copy' of each operation in our list, to avoid generating duplicate methods.
             if (find_if(
-                allBaseOps.begin(),
-                allBaseOps.end(),
-                [name = baseOp->name()](const auto& other) { return other->name() == name; }) == allBaseOps.end())
+                    allBaseOps.begin(),
+                    allBaseOps.end(),
+                    [name = baseOp->name()](const auto& other) { return other->name() == name; }) == allBaseOps.end())
             {
                 allBaseOps.push_back(baseOp);
             }

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -317,25 +317,20 @@ Slice::CsVisitor::writeUnmarshalDataMember(
 void
 Slice::CsVisitor::writeInheritedOperations(const InterfaceDefPtr& p)
 {
-    InterfaceList bases = p->bases();
-    if (!bases.empty())
+    OperationList allBaseOps;
+    for (const auto& base : p->bases())
     {
-        OperationList allOps;
-        for (InterfaceList::const_iterator q = bases.begin(); q != bases.end(); ++q)
-        {
-            OperationList tmp = (*q)->allOperations();
-            allOps.splice(allOps.end(), tmp);
-        }
-        allOps.sort();
-        allOps.unique();
-        for (OperationList::const_iterator i = allOps.begin(); i != allOps.end(); ++i)
-        {
-            string retS;
-            vector<string> params, args;
-            string ns = getNamespace(p);
-            string name = getDispatchParams(*i, retS, params, args, ns);
-            _out << sp << nl << "public abstract " << retS << " " << name << spar << params << epar << ';';
-        }
+        OperationList tmp = base->allOperations();
+        allBaseOps.splice(allBaseOps.end(), tmp);
+    }
+
+    for (const auto& op : allBaseOps)
+    {
+        string retS;
+        vector<string> params, args;
+        string ns = getNamespace(p);
+        string name = getDispatchParams(op, retS, params, args, ns);
+        _out << sp << nl << "public abstract " << retS << " " << name << spar << params << epar << ';';
     }
 }
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -3177,24 +3177,7 @@ Slice::Gen::DispatcherVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << fixId(name);
 
     _out << sb;
-
-    OperationList allOps = p->operations();
-    for (const auto& base : bases)
-    {
-        for (const auto& baseOp : base->allOperations())
-        {
-            // It's possible to get the same operation name through diamond inheritance.
-            // But we only want one 'copy' of each operation in our list, to avoid generating duplicate methods.
-            if (find_if(
-                    allOps.begin(),
-                    allOps.end(),
-                    [name = baseOp->name()](const auto& other) { return other->name() == name; }) == allOps.end())
-            {
-                allOps.push_back(baseOp);
-            }
-        }
-    }
-    for (const auto& op : allOps)
+    for (const auto& op : p->allOperations())
     {
         string retS;
         vector<string> params, args;

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -27,7 +27,6 @@ namespace Slice
         void writeMarshalDataMember(const DataMemberPtr&, const std::string&, const std::string&, bool = false);
         void writeUnmarshalDataMember(const DataMemberPtr&, const std::string&, const std::string&, bool = false);
 
-        void writeInheritedOperations(const InterfaceDefPtr&);
         void writeMarshaling(const ClassDefPtr&);
 
         static std::vector<std::string> getParams(const OperationPtr&, const std::string&);

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -1302,8 +1302,6 @@ Slice::JavaVisitor::writeDispatch(Output& out, const InterfaceDefPtr& p)
         const bool amd = p->hasMetadata("amd") || op->hasMetadata("amd");
 
         ExceptionList throws = op->throws();
-        throws.sort();
-        throws.unique();
 
         out << sp;
         writeServantDocComment(out, op, package, dc, amd);
@@ -4209,16 +4207,11 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     }
     const vector<string> args = getInArgs(p);
 
-    ExceptionList throws = p->throws();
-    throws.sort();
-    throws.unique();
-
-    //
     // Arrange exceptions into most-derived to least-derived order. If we don't
     // do this, a base exception handler can appear before a derived exception
     // handler, causing compiler warnings and resulting in the base exception
     // being marshaled instead of the derived exception.
-    //
+    ExceptionList throws = p->throws();
     throws.sort(Slice::DerivedToBaseCompare());
 
     const string contextParamName = getEscapedParamName(p, "context");

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -3954,8 +3954,6 @@ Slice::Gen::ProxyVisitor::ProxyVisitor(const string& dir) : JavaVisitor(dir) {}
 bool
 Slice::Gen::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
-    const OperationList ops = p->allOperations();
-
     string name = p->name();
     InterfaceList bases = p->bases();
     string package = getPackage(p);

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -1456,13 +1456,14 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             }
             _out << ",";
 
-            //
             // User exceptions.
-            //
+            // Arrange exceptions into most-derived to least-derived order. If we don't
+            // do this, a base exception handler can appear before a derived exception
+            // handler, causing compiler warnings and resulting in the base exception
+            // being marshaled instead of the derived exception.
             ExceptionList throws = op->throws();
-            throws.sort();
-            throws.unique();
             throws.sort(Slice::DerivedToBaseCompare());
+
             if (throws.empty())
             {
                 _out << " ";

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -2036,7 +2036,6 @@ Slice::Gen::TypeScriptImportVisitor::visitInterfaceDefStart(const InterfaceDefPt
     }
 
     // Add imports required for operation parameters and return types.
-    const OperationList operationList = p->allOperations();
     for (const auto& op : p->allOperations())
     {
         auto ret = dynamic_pointer_cast<Contained>(op->returnType());

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -2198,16 +2198,12 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         for (OperationList::const_iterator q = ops.begin(); q != ops.end(); ++q)
         {
             OperationPtr op = *q;
-            ExceptionList exceptions = op->throws();
-            exceptions.sort();
-            exceptions.unique();
 
-            //
             // Arrange exceptions into most-derived to least-derived order. If we don't
             // do this, a base exception handler can appear before a derived exception
             // handler, causing compiler warnings and resulting in the base exception
             // being marshaled instead of the derived exception.
-            //
+            ExceptionList exceptions = op->throws();
             exceptions.sort(Slice::DerivedToBaseCompare());
 
             if (!exceptions.empty())

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -1713,7 +1713,6 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     const string scoped = p->scoped();
     const string abs = getAbsolute(p);
     InterfaceList bases = p->bases();
-    const OperationList allOps = p->allOperations();
 
     //
     // Generate proxy class.

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -558,6 +558,7 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                 _out << "null";
             }
             _out << ", ";
+
             ExceptionList exceptions = (*oli)->throws();
             if (!exceptions.empty())
             {

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -1479,7 +1479,6 @@ Gen::ObjectVisitor::visitOperation(const OperationPtr& op)
     const string opName = fixIdent(op->name());
     const ParamInfoList allInParams = getAllInParams(op);
     const ParamInfoList allOutParams = getAllOutParams(op);
-    const ExceptionList allExceptions = op->throws();
 
     out << sp;
     writeOpDocSummary(out, op, true);

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -1391,8 +1391,6 @@ Gen::ObjectVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     allOpNames.push_back("ice_ids");
     allOpNames.push_back("ice_isA");
     allOpNames.push_back("ice_ping");
-    allOpNames.sort();
-    allOpNames.unique();
 
     out << sp;
     out << nl;

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -1820,9 +1820,13 @@ void
 SwiftGenerator::writeUnmarshalUserException(::IceInternal::Output& out, const OperationPtr& op)
 {
     const string swiftModule = getSwiftModule(getTopLevelModule(dynamic_pointer_cast<Contained>(op)));
+
+    // Arrange exceptions into most-derived to least-derived order. If we don't
+    // do this, a base exception handler can appear before a derived exception
+    // handler, causing compiler warnings and resulting in the base exception
+    // being marshaled instead of the derived exception.
     ExceptionList throws = op->throws();
-    throws.sort();
-    throws.unique();
+    throws.sort(Slice::DerivedToBaseCompare());
 
     out << "{ ex in";
     out.inc();


### PR DESCRIPTION
This PR fixes #3313 and #3205.

All of the instabilities were caused by places where we were calling `sort` on `list`s of `shared_ptr`s, which meant we were sorting things by unstable memory addresses.
Thankfully, all of the sorting we were trying to do in those places was unnecessary and removed.

The two types of sorting which is removed by this PR:
- We used to sort the exception specifications of operation, so it'd be safe to call `unique` to remove duplicates.
  But this is useless. The Slice compiler already disallows the same exception to appear twice in an exception specification.
- We used to sort out operations by name, so it'd be safe to call `unique` to remove duplicates.
  But again, the Slice compiler issues errors if there's any conflicts, even from inherited names (including diamonds).

One exception:
We still sort our operations by name in C++ because we use a binary search over operation names to perform dispatch.
So we require the names to be alphabetized. We re-use the same list for generating the actual operations and the dispatch, and I just left it alone. It's fine.