### PR TITLE
Fix Generation of `serialVersionUID` Default Values

### DIFF
--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -131,7 +131,8 @@ Slice::computeDefaultSerialVersionUID(const ContainedPtr& p)
     os << ";";
     for (const auto& member : members)
     {
-        const string typeString = JavaGenerator::typeToString(member->type(), TypeModeMember, "", member->getMetadata());
+        const MetadataList metadata = member->getMetadata();
+        const string typeString = JavaGenerator::typeToString(member->type(), TypeModeMember, "", metadata);
         os << member->name() << ":" << typeString << ",";
     }
 

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -123,22 +123,17 @@ Slice::computeDefaultSerialVersionUID(const ContainedPtr& p)
 
     // Actually compute the `SerialVersionUID` value.
     ostringstream os;
-    os << "Name: " << name;
+    os << name << ":";
     if (baseName)
     {
-        os << " Base: [" << *baseName << "]";
+        os << *baseName;
     }
-    os << " Members: [";
-    for (DataMemberList::const_iterator i = members.begin(); i != members.end();)
+    os << ";";
+    for (const auto& member : members)
     {
-        os << (*i)->name() << ":" << (*i)->type();
-        i++;
-        if (i != members.end())
-        {
-            os << ", ";
-        }
+        const string typeString = JavaGenerator::typeToString(member->type(), TypeModeMember, "", member->getMetadata());
+        os << member->name() << ":" << typeString << ",";
     }
-    os << "]";
 
     // We use a custom hash instead of relying on `std::hash` to ensure cross-platform consistency.
     const string data = os.str();
@@ -381,7 +376,7 @@ Slice::JavaGenerator::fixKwd(const string& name)
 }
 
 string
-Slice::JavaGenerator::convertScopedName(const string& scoped, const string& prefix, const string& suffix) const
+Slice::JavaGenerator::convertScopedName(const string& scoped, const string& prefix, const string& suffix)
 {
     string result;
     string::size_type start = 0;
@@ -430,7 +425,7 @@ Slice::JavaGenerator::convertScopedName(const string& scoped, const string& pref
 }
 
 string
-Slice::JavaGenerator::getPackagePrefix(const ContainedPtr& cont) const
+Slice::JavaGenerator::getPackagePrefix(const ContainedPtr& cont)
 {
     //
     // Traverse to the top-level module.
@@ -467,7 +462,7 @@ Slice::JavaGenerator::getPackagePrefix(const ContainedPtr& cont) const
 }
 
 string
-Slice::JavaGenerator::getPackage(const ContainedPtr& cont) const
+Slice::JavaGenerator::getPackage(const ContainedPtr& cont)
 {
     string scope = convertScopedName(cont->scope());
     string prefix = getPackagePrefix(cont);
@@ -487,7 +482,7 @@ Slice::JavaGenerator::getPackage(const ContainedPtr& cont) const
 }
 
 string
-Slice::JavaGenerator::getUnqualified(const std::string& type, const std::string& package) const
+Slice::JavaGenerator::getUnqualified(const std::string& type, const std::string& package)
 {
     if (type.find(".") != string::npos && type.find(package) == 0 && type.find(".", package.size() + 1) == string::npos)
     {
@@ -501,7 +496,7 @@ Slice::JavaGenerator::getUnqualified(
     const ContainedPtr& cont,
     const string& package,
     const string& prefix,
-    const string& suffix) const
+    const string& suffix)
 {
     string name = cont->name();
     if (prefix == "" && suffix == "")
@@ -524,7 +519,7 @@ Slice::JavaGenerator::getUnqualified(
 }
 
 string
-Slice::JavaGenerator::getStaticId(const TypePtr& type, const string& package) const
+Slice::JavaGenerator::getStaticId(const TypePtr& type, const string& package)
 {
     BuiltinPtr b = dynamic_pointer_cast<Builtin>(type);
     ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
@@ -558,7 +553,7 @@ Slice::JavaGenerator::typeToString(
     const string& package,
     const MetadataList& metadata,
     bool formal,
-    bool optional) const
+    bool optional)
 {
     static const char* builtinTable[] = {
         "byte",
@@ -686,7 +681,7 @@ Slice::JavaGenerator::typeToObjectString(
     TypeMode mode,
     const string& package,
     const MetadataList& metadata,
-    bool formal) const
+    bool formal)
 {
     static const char* builtinTable[] = {
         "java.lang.Byte",
@@ -1824,7 +1819,7 @@ Slice::JavaGenerator::getDictionaryTypes(
     const string& package,
     const MetadataList& metadata,
     string& instanceType,
-    string& formalType) const
+    string& formalType)
 {
     //
     // Get the types of the key and value.
@@ -1860,7 +1855,7 @@ Slice::JavaGenerator::getSequenceTypes(
     const string& package,
     const MetadataList& metadata,
     string& instanceType,
-    string& formalType) const
+    string& formalType)
 {
     if (auto meta = seq->getMetadataArgs("java:serializable"))
     {

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -92,10 +92,8 @@ namespace Slice
         //
         // Convert a Slice scoped name into a Java name.
         //
-        [[nodiscard]] static std::string convertScopedName(
-            const std::string&,
-            const std::string& = std::string(),
-            const std::string& = std::string());
+        [[nodiscard]] static std::string
+        convertScopedName(const std::string&, const std::string& = std::string(), const std::string& = std::string());
 
         //
         // Returns the package prefix of a Contained entity.

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -10,6 +10,16 @@
 
 namespace Slice
 {
+    // Get the Java name for a type.
+    // If an optional scope is provided, the scope will be removed from the result if possible.
+    enum TypeMode
+    {
+        TypeModeIn,
+        TypeModeOut,
+        TypeModeMember,
+        TypeModeReturn
+    };
+
     //
     // These functions should only be called for classes, exceptions, and structs.
     // Enums automatically implement Serializable (Java just serializes the enumerator's identifier),
@@ -69,7 +79,6 @@ namespace Slice
         // If a match is found, return the symbol with a leading underscore.
         static std::string fixKwd(const std::string&);
 
-    protected:
         JavaGenerator(const std::string&);
 
         //
@@ -83,78 +92,67 @@ namespace Slice
         //
         // Convert a Slice scoped name into a Java name.
         //
-        [[nodiscard]] std::string convertScopedName(
+        [[nodiscard]] static std::string convertScopedName(
             const std::string&,
             const std::string& = std::string(),
-            const std::string& = std::string()) const;
+            const std::string& = std::string());
 
         //
         // Returns the package prefix of a Contained entity.
         //
-        [[nodiscard]] std::string getPackagePrefix(const ContainedPtr&) const;
+        [[nodiscard]] static std::string getPackagePrefix(const ContainedPtr&);
 
         //
         // Returns the Java package of a Contained entity.
         //
-        [[nodiscard]] std::string getPackage(const ContainedPtr&) const;
+        [[nodiscard]] static std::string getPackage(const ContainedPtr&);
 
         //
         // Returns the Java type without a package if the package
         // matches the current package
         //
-        [[nodiscard]] std::string getUnqualified(const std::string&, const std::string&) const;
+        [[nodiscard]] static std::string getUnqualified(const std::string&, const std::string&);
 
         //
         // Returns the Java name for a Contained entity. If the optional
         // package argument matches the entity's package name, then the
         // package is removed from the result.
         //
-        [[nodiscard]] std::string getUnqualified(
+        [[nodiscard]] static std::string getUnqualified(
             const ContainedPtr&,
             const std::string& = std::string(),
             const std::string& = std::string(),
-            const std::string& = std::string()) const;
+            const std::string& = std::string());
 
         //
         // Return the method call necessary to obtain the static type ID for an object type.
         //
-        [[nodiscard]] std::string getStaticId(const TypePtr&, const std::string&) const;
+        [[nodiscard]] static std::string getStaticId(const TypePtr&, const std::string&);
 
         //
         // Returns the optional type corresponding to the given Slice type.
         //
-        std::string getOptionalFormat(const TypePtr&);
+        [[nodiscard]] static std::string getOptionalFormat(const TypePtr&);
 
-        //
-        // Get the Java name for a type. If an optional scope is provided,
-        // the scope will be removed from the result if possible.
-        //
-        enum TypeMode
-        {
-            TypeModeIn,
-            TypeModeOut,
-            TypeModeMember,
-            TypeModeReturn
-        };
-        [[nodiscard]] std::string typeToString(
+        [[nodiscard]] static std::string typeToString(
             const TypePtr&,
             TypeMode,
             const std::string& = std::string(),
             const MetadataList& = MetadataList(),
             bool = true,
-            bool = false) const;
+            bool = false);
 
         //
         // Get the Java object name for a type. For primitive types, this returns the
         // Java class type (e.g., Integer). For all other types, this function delegates
         // to typeToString.
         //
-        [[nodiscard]] std::string typeToObjectString(
+        [[nodiscard]] static std::string typeToObjectString(
             const TypePtr&,
             TypeMode,
             const std::string& = std::string(),
             const MetadataList& = MetadataList(),
-            bool = true) const;
+            bool = true);
 
         //
         // Generate code to marshal or unmarshal a type.
@@ -237,11 +235,10 @@ namespace Slice
         // The functions return true if a custom type was defined and false to indicate
         // the default mapping was used.
         //
-        bool
-        getDictionaryTypes(const DictionaryPtr&, const std::string&, const MetadataList&, std::string&, std::string&)
-            const;
-        bool
-        getSequenceTypes(const SequencePtr&, const std::string&, const MetadataList&, std::string&, std::string&) const;
+        static bool
+        getDictionaryTypes(const DictionaryPtr&, const std::string&, const MetadataList&, std::string&, std::string&);
+        static bool
+        getSequenceTypes(const SequencePtr&, const std::string&, const MetadataList&, std::string&, std::string&);
 
         JavaOutput* createOutput();
 


### PR DESCRIPTION
This PR fixes #3312 and #3316, both of which deal with how we generate the `serialVersionUID` field in java.
All of the 'real' changes are at the top of the first file.

But, I had to switch alot of functions defined on `JavaGenerator` from being `const` methods to `static` functions.
Since the function for computing `serialVersionUID` lives outside this `JavaGenerator` class, this change was necessary for it to be able to call `typeToString`. And changing `typeToString` to `static` had some viral effects.