### PR TITLE
Do not use QueueExecutor for Android - Fix #3300

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -917,13 +917,8 @@ public final class Instance implements java.util.function.Function<String, Class
                 }
             }
 
-            //
-            // If Ice.ThreadInterruptSafe is set or we're running on Android all
-            // IO is done on the background thread. For Android we use the queue
-            // executor as Android doesn't allow any network invocations on the main
-            // thread even if the call is non-blocking.
-            //
-            if (properties.getIcePropertyAsInt("Ice.ThreadInterruptSafe") > 0 || Util.isAndroid()) {
+            // If Ice.ThreadInterruptSafe is set all IO is done on the background thread.
+            if (properties.getIcePropertyAsInt("Ice.ThreadInterruptSafe") > 0) {
                 _queueExecutor =
                         new QueueExecutor(
                                 properties, Util.createThreadName(properties, "Ice.BackgroundIO"));


### PR DESCRIPTION
Ice no longer uses a QueueExecutor on Android, as it was working around the restriction on making IO calls from the main thread. Android explicitly prohibits IO operations on the main thread, which QueueExecutor was bypassing.

Additionally, QueueExecutor was prone to deadlocks because all IO operations were executed on a single thread (see #3300 for details).

The Android test suite creates a Controller object. When the controller receives a runTestCase request, it creates a TestCase object, which can be used to start the server and client applications. These applications run in separate threads within the same process.

This setup means we are not testing whether async operations are safe to call from the main thread.