### PR TITLE
Add collocated = true to tracing for collocated calls

### DIFF
--- a/cpp/src/Ice/TraceUtil.cpp
+++ b/cpp/src/Ice/TraceUtil.cpp
@@ -380,6 +380,10 @@ printMessage(ostream& s, InputStream& stream, const ConnectionI* connection)
         }
         s << connection->toString();
     }
+    else
+    {
+        s << "\ncollocated = true";
+    }
 
     return type;
 }

--- a/csharp/src/Ice/Internal/TraceUtil.cs
+++ b/csharp/src/Ice/Internal/TraceUtil.cs
@@ -415,6 +415,10 @@ internal sealed class TraceUtil
             }
             s.Write(connection.ToString());
         }
+        else
+        {
+            s.Write("\ncollocated = true");
+        }
 
         return type;
     }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TraceUtil.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TraceUtil.java
@@ -347,6 +347,8 @@ final class TraceUtil {
                 s.write("connection ID = " + connectionId + "\n");
             }
             s.write(connection.toString());
+        } else {
+            s.write("\ncollocated = true");
         }
 
         return type;


### PR DESCRIPTION
Fixes #3266 in C++, C# and Java (JS doesn't support colloc).