### PR TITLE
DataStorm: Fixes for Session Establishment and Reconnection

### DIFF
--- a/cpp/src/DataStorm/Contract.ice
+++ b/cpp/src/DataStorm/Contract.ice
@@ -403,14 +403,28 @@ module DataStormContract
         /// @see Lookup::announceTopicReader
         void initiateCreateSession(Node* publisher);
 
-        /// Initiate the creation of a subscriber session with a node, after the target node has announced a topic
-        /// writer for which this node has a corresponding topic reader, or after the node has called
-        /// Node::initiateCreateSession.
+        /// Initiates the creation of a subscriber session with a node. The subscriber node sends this request to a
+        /// publisher node in one of the following scenarios:
         ///
-        /// @param subscriber The subscriber node initiating the session. The proxy is never null.
-        /// @param session The subscriber session being created. The proxy is never null.
-        /// @param fromRelay Indicates if the session is being created from a relay node.
-        void createSession(Node* subscriber, SubscriberSession* session, bool fromRelay);
+        /// - The subscriber has received a topic writer announcement from the publisher and has a matching topic
+        /// reader.
+        /// - The publisher node has previously send a initiateCreateSession request.
+        ///
+        /// The publisher node dispatching this request would send a confirmCreateSession request to the subscriber node
+        /// to continue session establishment. If an active session already exists with the subscriber node, the
+        /// request is ignored.
+        ///
+        /// @param subscriber The subscriber node initiating the session. This proxy is never null.
+        /// @param session The subscriber session being created. This proxy is never null.
+        /// @param fromRelay Indicates whether the session is being created from a relay node.
+        /// @param subscriberIsHostedOnRelay Specifies if the relay is hosting a forwarder for the subscriber. If the
+        /// subscriber has endpoints or an adapter ID, the relay does not host a forwarder, and the publisher is
+        /// expected to send requests directly to the subscriber node instead of going through a forwarder.
+        void createSession(
+            Node* subscriber,
+            SubscriberSession* session,
+            bool fromRelay,
+            optional(1) bool subscriberIsHostedOnRelay);
 
         /// Confirm the creation of a publisher session with a node.
         ///

--- a/cpp/src/DataStorm/Contract.ice
+++ b/cpp/src/DataStorm/Contract.ice
@@ -410,21 +410,17 @@ module DataStormContract
         /// reader.
         /// - The publisher node has previously sent a initiateCreateSession request.
         ///
-        /// The publisher node dispatching this request would send a confirmCreateSession request to the subscriber node
+        /// The publisher node dispatching this request then sends a confirmCreateSession request to the subscriber node
         /// to continue session establishment. If an active session already exists with the subscriber node, the
         /// request is ignored.
         ///
         /// @param subscriber The subscriber node initiating the session. This proxy is never null.
         /// @param session The subscriber session being created. This proxy is never null.
         /// @param fromRelay Indicates whether the session is being created from a relay node.
-        /// @param subscriberIsHostedOnRelay Specifies if the relay is hosting a forwarder for the subscriber. If the
-        /// subscriber has endpoints or an adapter ID, the relay does not host a forwarder, and the publisher is
-        /// expected to send requests directly to the subscriber node instead of going through a forwarder.
         void createSession(
             Node* subscriber,
             SubscriberSession* session,
-            bool fromRelay,
-            optional(1) bool subscriberIsHostedOnRelay);
+            bool fromRelay);
 
         /// Confirm the creation of a publisher session with a node.
         ///

--- a/cpp/src/DataStorm/Contract.ice
+++ b/cpp/src/DataStorm/Contract.ice
@@ -417,10 +417,7 @@ module DataStormContract
         /// @param subscriber The subscriber node initiating the session. This proxy is never null.
         /// @param session The subscriber session being created. This proxy is never null.
         /// @param fromRelay Indicates whether the session is being created from a relay node.
-        void createSession(
-            Node* subscriber,
-            SubscriberSession* session,
-            bool fromRelay);
+        void createSession(Node* subscriber, SubscriberSession* session, bool fromRelay);
 
         /// Confirm the creation of a publisher session with a node.
         ///

--- a/cpp/src/DataStorm/Contract.ice
+++ b/cpp/src/DataStorm/Contract.ice
@@ -408,7 +408,7 @@ module DataStormContract
         ///
         /// - The subscriber has received a topic writer announcement from the publisher and has a matching topic
         /// reader.
-        /// - The publisher node has previously send a initiateCreateSession request.
+        /// - The publisher node has previously sent a initiateCreateSession request.
         ///
         /// The publisher node dispatching this request would send a confirmCreateSession request to the subscriber node
         /// to continue session establishment. If an active session already exists with the subscriber node, the

--- a/cpp/src/DataStorm/NodeI.cpp
+++ b/cpp/src/DataStorm/NodeI.cpp
@@ -252,12 +252,14 @@ NodeI::confirmCreateSession(
         return;
     }
 
-    // If publisher session is hosted on a relay, current.con is the connection to that relay. Otherwise this is a
-    // connection to the publisher node.
+    // If the publisher session is hosted on a relay, current.con represents the connection to the relay.
+    // Otherwise, it represents the connection to the publisher node. In both cases, a fixed proxy is used
+    // to ensure the session is no longer used once the connection is closed.
     if (current.con)
     {
         publisherSession = publisherSession->ice_fixed(current.con);
     }
+    // else collocated call.
 
     auto instance = _instance.lock();
     assert(instance);
@@ -341,7 +343,7 @@ NodeI::createPublisherSession(
             {
                 if (session->checkSession())
                 {
-                    return;
+                    return; // Already connected.
                 }
 
                 if (connection)

--- a/cpp/src/DataStorm/NodeI.cpp
+++ b/cpp/src/DataStorm/NodeI.cpp
@@ -145,7 +145,6 @@ NodeI::createSession(
     optional<NodePrx> subscriber,
     optional<SubscriberSessionPrx> subscriberSession,
     bool fromRelay,
-    optional<bool> subscriberIsHostedOnRelay,
     const Current& current)
 {
     checkNotNull(subscriber, __FILE__, __LINE__, current);
@@ -158,7 +157,7 @@ NodeI::createSession(
     try
     {
         NodePrx s = *subscriber;
-        if (fromRelay && !subscriberIsHostedOnRelay.value_or(false))
+        if (fromRelay && subscriberSession->ice_getIdentity().category == "s")
         {
             // If the request originates from a relay and the relay does not host a forwarder for the subscriber node,
             // check if there is an existing connection to the subscriber node and reuse it if available. Otherwise,
@@ -361,7 +360,6 @@ NodeI::createPublisherSession(
                     p->createSessionAsync(
                         self->_proxy,
                         uncheckedCast<SubscriberSessionPrx>(session->getProxy()),
-                        false,
                         false,
                         nullptr,
                         [=](exception_ptr ex) { self->removeSubscriberSession(publisher, session, ex); });

--- a/cpp/src/DataStorm/NodeI.h
+++ b/cpp/src/DataStorm/NodeI.h
@@ -35,6 +35,7 @@ namespace DataStormI
             std::optional<DataStormContract::NodePrx>,
             std::optional<DataStormContract::SubscriberSessionPrx>,
             bool,
+            std::optional<bool>,
             const Ice::Current&) final;
 
         void confirmCreateSession(

--- a/cpp/src/DataStorm/NodeI.h
+++ b/cpp/src/DataStorm/NodeI.h
@@ -35,7 +35,6 @@ namespace DataStormI
             std::optional<DataStormContract::NodePrx>,
             std::optional<DataStormContract::SubscriberSessionPrx>,
             bool,
-            std::optional<bool>,
             const Ice::Current&) final;
 
         void confirmCreateSession(

--- a/cpp/src/DataStorm/NodeSessionI.cpp
+++ b/cpp/src/DataStorm/NodeSessionI.cpp
@@ -57,19 +57,34 @@ namespace
             optional<NodePrx> subscriber,
             optional<SubscriberSessionPrx> subscriberSession,
             bool /* fromRelay */,
+            optional<bool> /*subscriberIsHostedOnRelay*/,
             const Current& current) final
         {
             checkNotNull(subscriber, __FILE__, __LINE__, current);
             checkNotNull(subscriberSession, __FILE__, __LINE__, current);
 
+            bool subscriberIsHostedOnRelay =
+                (subscriber->ice_getEndpoints().empty() && subscriber->ice_getAdapterId().empty());
+
             if (auto nodeSession = _nodeSession.lock())
             {
                 try
                 {
-                    updateNodeAndSessionProxy(*subscriber, subscriberSession, current);
-                    nodeSession->addSession(*subscriberSession);
+                    optional<SubscriberSessionPrx> subscriberSessionForwarder = subscriberSession;
+                    updateNodeAndSessionProxy(*subscriber, subscriberSessionForwarder, current);
+
+                    // Keep track of the subscriber session with the NodeSession, the NodeSession will use this proxy
+                    // to inform the subscriber of the disconnection if the target publisher is disconnected.
+                    nodeSession->addSession(
+                        subscriberIsHostedOnRelay ? subscriberSession->ice_fixed(current.con) : *subscriberSession);
+
                     // Forward the call to the target Node object, don't need to wait for the result.
-                    _node->createSessionAsync(subscriber, subscriberSession, true, nullptr);
+                    _node->createSessionAsync(
+                        subscriber,
+                        subscriberSessionForwarder,
+                        true,
+                        subscriberIsHostedOnRelay,
+                        nullptr);
                 }
                 catch (const CommunicatorDestroyedException&)
                 {
@@ -87,12 +102,19 @@ namespace
 
             if (auto nodeSession = _nodeSession.lock())
             {
+                bool publisherIsHostedOnRelay =
+                    (publisher->ice_getEndpoints().empty() && publisher->ice_getAdapterId().empty());
                 try
                 {
-                    updateNodeAndSessionProxy(*publisher, publisherSession, current);
-                    nodeSession->addSession(*publisherSession);
-                    // Forward the call to the target Node object, don't need to wait for the result.
-                    _node->confirmCreateSessionAsync(publisher, publisherSession, nullptr);
+                    optional<PublisherSessionPrx> publisherSessionForwarder = publisherSession;
+                    updateNodeAndSessionProxy(*publisher, publisherSessionForwarder, current);
+
+                    // Keep track of the publisher session with the NodeSession, the NodeSession will use this proxy
+                    // to inform the publisher of the disconnection if the target subscriber is disconnected.
+                    nodeSession->addSession(
+                        publisherIsHostedOnRelay ? publisherSession->ice_fixed(current.con) : *publisherSession);
+                    // Forward the request to the target subscriber.
+                    _node->confirmCreateSessionAsync(publisher, publisherSessionForwarder, nullptr);
                 }
                 catch (const CommunicatorDestroyedException&)
                 {
@@ -101,8 +123,17 @@ namespace
         }
 
     private:
-        // This helper method is used to replace the Node and Session proxies with forwarders when the calling Node
-        // doesn't have a public endpoint.
+        /// This helper method is used to replace the Node and Session proxy parameters with forwarder proxies.
+        ///
+        /// Before forwarding a request to the target Node, this method is called and creates the required forwarders
+        /// to ensure that the target can call back to the source node and session objects using the provided proxy.
+        ///
+        /// @tparam T The type of the session being updated.
+        /// @param node The proxy for the Node, which may be replaced with a forwarder if the Node lacks a public
+        /// endpoint.
+        /// @param session The optional session proxy, which may be replaced with a forwarder if the Node lacks a public
+        /// endpoint.
+        /// @param current A reference to the current object of the request.
         template<typename T> void updateNodeAndSessionProxy(NodePrx& node, optional<T>& session, const Current& current)
         {
             if (node->ice_getEndpoints().empty() && node->ice_getAdapterId().empty())

--- a/cpp/src/DataStorm/NodeSessionI.cpp
+++ b/cpp/src/DataStorm/NodeSessionI.cpp
@@ -57,7 +57,6 @@ namespace
             optional<NodePrx> subscriber,
             optional<SubscriberSessionPrx> subscriberSession,
             bool /* fromRelay */,
-            optional<bool> /*subscriberIsHostedOnRelay*/,
             const Current& current) final
         {
             checkNotNull(subscriber, __FILE__, __LINE__, current);
@@ -79,12 +78,7 @@ namespace
                         subscriberIsHostedOnRelay ? subscriberSession->ice_fixed(current.con) : *subscriberSession);
 
                     // Forward the call to the target Node object, don't need to wait for the result.
-                    _node->createSessionAsync(
-                        subscriber,
-                        subscriberSessionForwarder,
-                        true,
-                        subscriberIsHostedOnRelay,
-                        nullptr);
+                    _node->createSessionAsync(subscriber, subscriberSessionForwarder, true, nullptr);
                 }
                 catch (const CommunicatorDestroyedException&)
                 {

--- a/cpp/src/DataStorm/NodeSessionI.h
+++ b/cpp/src/DataStorm/NodeSessionI.h
@@ -41,6 +41,7 @@ namespace DataStormI
 
     private:
         const std::shared_ptr<Instance> _instance;
+
         // A proxy to the target node, representing the node that created the session.
         DataStormContract::NodePrx _node;
 
@@ -48,6 +49,7 @@ namespace DataStormI
         const Ice::ConnectionPtr _connection;
 
         std::mutex _mutex;
+
         // A proxy to the target node.
         //
         // - If the target node has a public endpoint or an adapter ID, this proxy is identical to the `_node` proxy.
@@ -62,6 +64,8 @@ namespace DataStormI
 
         // A map containing all publisher and subscriber sessions established with the session's target node via a
         // node forwarder.
+        //
+        // The key is the session identity, and the value is the session proxy.
         std::map<Ice::Identity, DataStormContract::SessionPrx> _sessions;
     };
 }

--- a/cpp/src/DataStorm/NodeSessionManager.cpp
+++ b/cpp/src/DataStorm/NodeSessionManager.cpp
@@ -86,14 +86,16 @@ NodeSessionManager::init()
 }
 
 shared_ptr<NodeSessionI>
-NodeSessionManager::createOrGet(NodePrx node, const ConnectionPtr& connection, bool forwardAnnouncements)
+NodeSessionManager::createOrGet(NodePrx node, const ConnectionPtr& newConnection, bool forwardAnnouncements)
 {
     unique_lock<mutex> lock(_mutex);
 
     auto p = _sessions.find(node->ice_getIdentity());
     if (p != _sessions.end())
     {
-        if (p->second->getConnection() != connection)
+        // If called with a newConnection we destroy the node session before creating a new one that uses the new
+        // connection
+        if (p->second->getConnection() != newConnection)
         {
             p->second->destroy();
             _sessions.erase(p);
@@ -107,21 +109,21 @@ NodeSessionManager::createOrGet(NodePrx node, const ConnectionPtr& connection, b
     auto instance = _instance.lock();
     assert(instance);
 
-    if (!connection->getAdapter())
+    if (!newConnection->getAdapter())
     {
-        connection->setAdapter(instance->getObjectAdapter());
+        newConnection->setAdapter(instance->getObjectAdapter());
     }
 
-    auto session = make_shared<NodeSessionI>(instance, node, connection, forwardAnnouncements);
+    auto session = make_shared<NodeSessionI>(instance, node, newConnection, forwardAnnouncements);
     session->init();
     _sessions.emplace(node->ice_getIdentity(), session);
 
     // Register a callback with the connection manager to destroy the session when the connection is closed.
     instance->getConnectionManager()->add(
-        connection,
+        newConnection,
         make_shared<NodePrx>(node),
-        [self = shared_from_this(), node = std::move(node)](const ConnectionPtr&, exception_ptr) mutable
-        { self->destroySession(node); });
+        [self = shared_from_this(), node = std::move(node)](const ConnectionPtr& connection, exception_ptr) mutable
+        { self->destroySession(connection, node); });
 
     return session;
 }
@@ -444,11 +446,13 @@ NodeSessionManager::disconnected(const LookupPrx& lookup)
 }
 
 void
-NodeSessionManager::destroySession(const NodePrx& node)
+NodeSessionManager::destroySession(const ConnectionPtr& connection, const NodePrx& node)
 {
     unique_lock<mutex> lock(_mutex);
+    // If the session is still using the connection destroy it, otherwise the node has already
+    // replace its NodeSession and it is using a new connection.
     auto p = _sessions.find(node->ice_getIdentity());
-    if (p != _sessions.end())
+    if (p != _sessions.end() && p->second->getConnection() == connection)
     {
         p->second->destroy();
         _sessions.erase(p);

--- a/cpp/src/DataStorm/NodeSessionManager.cpp
+++ b/cpp/src/DataStorm/NodeSessionManager.cpp
@@ -449,8 +449,8 @@ void
 NodeSessionManager::destroySession(const ConnectionPtr& connection, const NodePrx& node)
 {
     unique_lock<mutex> lock(_mutex);
-    // If the session is still using the connection destroy it, otherwise the node has already
-    // replace its NodeSession and it is using a new connection.
+    // Destroy the connection if the session is still using it, otherwise the node has already
+    // replaced its NodeSession and it is using a new connection.
     auto p = _sessions.find(node->ice_getIdentity());
     if (p != _sessions.end() && p->second->getConnection() == connection)
     {

--- a/cpp/src/DataStorm/NodeSessionManager.cpp
+++ b/cpp/src/DataStorm/NodeSessionManager.cpp
@@ -93,7 +93,7 @@ NodeSessionManager::createOrGet(NodePrx node, const ConnectionPtr& newConnection
     auto p = _sessions.find(node->ice_getIdentity());
     if (p != _sessions.end())
     {
-        // If called with a newConnection we destroy the node session before creating a new one that uses the new
+        // If called with a new connection we destroy the node session before creating a new one that uses the new
         // connection
         if (p->second->getConnection() != newConnection)
         {

--- a/cpp/src/DataStorm/NodeSessionManager.h
+++ b/cpp/src/DataStorm/NodeSessionManager.h
@@ -49,7 +49,7 @@ namespace DataStormI
         void disconnected(const DataStormContract::NodePrx&, const DataStormContract::LookupPrx&);
         void disconnected(const DataStormContract::LookupPrx&);
 
-        void destroySession(const DataStormContract::NodePrx&);
+        void destroySession(const Ice::ConnectionPtr&, const DataStormContract::NodePrx&);
 
         std::weak_ptr<Instance> _instance;
         const std::shared_ptr<TraceLevels> _traceLevels;
@@ -60,7 +60,7 @@ namespace DataStormI
 
         int _retryCount{0};
 
-        // A map containing the `NodeSessionI` servants for all nodes that have an active session with this node.
+        // A map containing the NodeSessionI servants for all nodes that have an active session with this node.
         // The map is indexed by the identity of the nodes.
         std::map<Ice::Identity, std::shared_ptr<NodeSessionI>> _sessions;
 

--- a/cpp/test/DataStorm/reliability/Reader.cpp
+++ b/cpp/test/DataStorm/reliability/Reader.cpp
@@ -107,6 +107,7 @@ void ::Reader::run(int argc, char* argv[])
 
         // Let the writer know the connection was closed again, and that it can proceed with the second batch of
         // samples.
+        writerB.waitForReaders();
         writerB.update(0);
 
         for (int i = 0; i < 100; ++i)

--- a/cpp/test/DataStorm/reliability/test.py
+++ b/cpp/test/DataStorm/reliability/test.py
@@ -12,32 +12,44 @@ traceProps = {
     "Ice.Trace.Protocol" : 1,
 }
 
+# Disable client and server idle timeout below to avoid a test to recover after the connection is closed by the idle timeout.
+# This ensure that test hangs if the session goes into an invalid state, and is not silently recover after the idle timeout
+# closes the connection.
+
 # A client connected to the default server
 clientProps = {
     "DataStorm.Node.Multicast.Enabled": 0,
     "DataStorm.Node.Server.Enabled": 0,
-    "DataStorm.Node.ConnectTo": "tcp -p {port1}"
+    "DataStorm.Node.ConnectTo": "tcp -p {port1}",
+    "Ice.Connection.Server.IdleTimeout": 0,
+    "Ice.Connection.Client.IdleTimeout": 0,
 }
 
 # A client connected to the second server
 client2Props = {
     "DataStorm.Node.Multicast.Enabled": 0,
     "DataStorm.Node.Server.Enabled": 0,
-    "DataStorm.Node.ConnectTo": "tcp -p {port2}"
+    "DataStorm.Node.ConnectTo": "tcp -p {port2}",
+    "Ice.Connection.Server.IdleTimeout": 0,
+    "Ice.Connection.Client.IdleTimeout": 0,
 }
 
 # The default server, not connected to any other server.
 serverProps = {
     "DataStorm.Node.Multicast.Enabled": 0,
     "DataStorm.Node.Server.Endpoints": "tcp -p {port1}",
-    "DataStorm.Node.ConnectTo": ""
+    "DataStorm.Node.ConnectTo": "",
+    "Ice.Connection.Server.IdleTimeout": 0,
+    "Ice.Connection.Client.IdleTimeout": 0,
 }
 
 # A second server connected to the first server
 server2Props = {
     "DataStorm.Node.Multicast.Enabled": 0,
     "DataStorm.Node.Server.Endpoints": "tcp -p {port2}",
-    "DataStorm.Node.ConnectTo": "tcp -p {port1}"
+    "DataStorm.Node.ConnectTo": "tcp -p {port1}",
+    "Ice.Connection.Server.IdleTimeout": 0,
+    "Ice.Connection.Client.IdleTimeout": 0,
 }
 
 # A server without a fixed endpoint, connected to the first server.
@@ -45,6 +57,8 @@ serverAnyProps = {
     "DataStorm.Node.Multicast.Enabled": 0,
     "DataStorm.Node.Server.Endpoints": "tcp",
     "DataStorm.Node.ConnectTo": "tcp -p {port1}",
+    "Ice.Connection.Server.IdleTimeout": 0,
+    "Ice.Connection.Client.IdleTimeout": 0,
 }
 
 props = [
@@ -70,8 +84,8 @@ testcases = []
 for (name, readerProps, writerProps, nodeProps, node2Props, reversedStart) in props:
     if reversedStart:
         name += " (reversed start order)"
-    c = Writer(props=writerProps) if not reversedStart else Reader(props=readerProps)
-    s = Reader(props=readerProps) if not reversedStart else Writer(props=writerProps)
+    c = Reader(props=writerProps) if reversedStart else Writer(props=readerProps)
+    s = Writer(props=readerProps) if reversedStart else Reader(props=writerProps)
     if node2Props:
         nodes = [Node(desc="node1", props=nodeProps), Node(desc="node2", props=node2Props)]
         testcases.append(NodeTestCase(name=name, client=c, server=s, nodes=nodes, traceProps=traceProps))


### PR DESCRIPTION
This commit addresses two issues in the session establishment and reconnection process:

- **Session Reconnection Failure**

A bug prevented proper recovery from connection failures. Specifically, when a publisher session sent the `confirmCreateSession` request via a forwarder using a new connection (different from the one used to receive the `createSession` request), the `NodeForwarder` dispatching the request was unaware of the subscriber session. If the publisher’s connection to the forwarder was closed before the subscriber sent any additional messages, the forwarder could not notify the subscriber of the publisher’s disconnection.

As a result, if the publisher attempted to reconnect, the subscriber would ignore the request, thinking the session was still active.

- **Incorrect Use of Forwarding Proxies for Disconnect Requests**

Disconnect requests from the forwarder were sent using a forwarding proxy, which could cause unexpected behavior, such as requests being dispatched in the wrong order by the target node. Forwarding proxies are meant to be used by nodes connected to the forwarder, not by the forwarder itself.

This caused issues where `confirmCreateSession` was sent before `disconnected`, even if the forwarder invoked them in the correct reverse order. This happened because `disconnected` went through the forwarder, while `confirmCreateSession` was sent directly.


Replaces #3310 fixes #3309 