### PR TITLE
Run Swift format from linux runner

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install SwiftLints
+      - name: Install Ruff
         run: pip install ruff
 
       - name: Run Ruff

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,15 +15,17 @@ on:
 jobs:
   swift-format:
     name: Swift Format & Lint
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install swift-format
-        run: brew install swift-format
+
+      - uses: swift-actions/setup-swift@v2
+
       - name: swift-format Format
         working-directory: swift
-        run: swift-format . --recursive --configuration .swift-format.json
+        run: swift format . --recursive --configuration .swift-format.json
+
       - name: swift-format Lint
         working-directory: swift
-        run: swift-format lint . --recursive --strict --configuration .swift-format.json
+        run: swift format lint . --recursive --strict --configuration .swift-format.json


### PR DESCRIPTION
This PR moves the Swift format/lint action to use a linux runner. Also since Swift 6 the swift-format tool is bundled with the swift compiler. 