### PR TITLE
Apply modernize pass by value

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,15 @@
 Checks:
 '-*,
-  modernize-pass-by-value,
+  clang-analyzer-*,
+  -clang-diagnostic-shadow-uncaptured-local,
+  -clang-analyzer-optin.core.EnumCastOutOfRange,
+  cert-*,
+  modernize-*,
+  -modernize-avoid-c-arrays,
+  -modernize-use-trailing-return-type,
+  -modernize-concat-nested-namespaces,
+  performance-*,
+  -performance-avoid-endl
 '
 WarningsAsErrors:  '*'
 HeaderFilterRegex: '.*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,15 +1,6 @@
 Checks:
 '-*,
-  clang-analyzer-*,
-  -clang-diagnostic-shadow-uncaptured-local,
-  -clang-analyzer-optin.core.EnumCastOutOfRange,
-  cert-*,
-  modernize-*,
-  -modernize-avoid-c-arrays,
-  -modernize-use-trailing-return-type,
-  -modernize-concat-nested-namespaces,
-  performance-*,
-  -performance-avoid-endl
+  modernize-pass-by-value,
 '
 WarningsAsErrors:  '*'
 HeaderFilterRegex: '.*'

--- a/cpp/include/Ice/Buffer.h
+++ b/cpp/include/Ice/Buffer.h
@@ -9,6 +9,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <utility>
 #include <vector>
 
 namespace IceInternal

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -21,7 +21,6 @@
 #include <map>
 #include <string>
 #include <string_view>
-#include <utility>
 
 namespace IceInternal::Ex
 {

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -836,11 +836,7 @@ namespace Ice
             virtual void readPendingValues() {}
 
         protected:
-            EncapsDecoder(
-                InputStream* stream,
-                Encaps* encaps,
-                size_t classGraphDepthMax,
-                Ice::ValueFactoryManagerPtr  f)
+            EncapsDecoder(InputStream* stream, Encaps* encaps, size_t classGraphDepthMax, Ice::ValueFactoryManagerPtr f)
                 : _stream(stream),
                   _encaps(encaps),
                   _classGraphDepthMax(classGraphDepthMax),

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -21,6 +21,7 @@
 #include <map>
 #include <string>
 #include <string_view>
+#include <utility>
 
 namespace IceInternal::Ex
 {
@@ -839,12 +840,12 @@ namespace Ice
                 InputStream* stream,
                 Encaps* encaps,
                 size_t classGraphDepthMax,
-                const Ice::ValueFactoryManagerPtr& f)
+                Ice::ValueFactoryManagerPtr  f)
                 : _stream(stream),
                   _encaps(encaps),
                   _classGraphDepthMax(classGraphDepthMax),
                   _classGraphDepth(0),
-                  _valueFactoryManager(f),
+                  _valueFactoryManager(std::move(f)),
                   _typeIdIndex(0)
             {
             }

--- a/cpp/include/Ice/LoggerUtil.h
+++ b/cpp/include/Ice/LoggerUtil.h
@@ -95,7 +95,7 @@ namespace Ice
     template<class L, class LPtr, void (L::*output)(const std::string&)> class LoggerOutput : public LoggerOutputBase
     {
     public:
-        inline LoggerOutput(LPtr  lptr) : _logger(std::move(lptr)) {}
+        inline LoggerOutput(LPtr lptr) : _logger(std::move(lptr)) {}
 
         inline ~LoggerOutput() { flush(); }
 

--- a/cpp/include/Ice/LoggerUtil.h
+++ b/cpp/include/Ice/LoggerUtil.h
@@ -13,6 +13,7 @@
 #include "Proxy.h"
 
 #include <sstream>
+#include <utility>
 
 namespace Ice
 {
@@ -94,7 +95,7 @@ namespace Ice
     template<class L, class LPtr, void (L::*output)(const std::string&)> class LoggerOutput : public LoggerOutputBase
     {
     public:
-        inline LoggerOutput(const LPtr& lptr) : _logger(lptr) {}
+        inline LoggerOutput(LPtr  lptr) : _logger(std::move(lptr)) {}
 
         inline ~LoggerOutput() { flush(); }
 

--- a/cpp/include/Ice/MetricsAdminI.h
+++ b/cpp/include/Ice/MetricsAdminI.h
@@ -14,7 +14,6 @@
 #include <list>
 #include <mutex>
 #include <regex>
-#include <utility>
 
 namespace IceMX
 {

--- a/cpp/include/Ice/MetricsAdminI.h
+++ b/cpp/include/Ice/MetricsAdminI.h
@@ -14,6 +14,7 @@
 #include <list>
 #include <mutex>
 #include <regex>
+#include <utility>
 
 namespace IceMX
 {
@@ -35,7 +36,7 @@ namespace IceInternal
         class ICE_API RegExp
         {
         public:
-            RegExp(const std::string&, const std::string&);
+            RegExp(std::string, const std::string&);
 
             template<typename T> bool match(const IceMX::MetricsHelperT<T>& helper, bool reject)
             {
@@ -115,9 +116,9 @@ namespace IceInternal
         class EntryT : public std::enable_shared_from_this<EntryT>
         {
         public:
-            EntryT(MetricsMapTPtr map, const TPtr& object, const typename std::list<EntryTPtr>::iterator& p)
-                : _map(map),
-                  _object(object),
+            EntryT(MetricsMapTPtr map, TPtr object, const typename std::list<EntryTPtr>::iterator& p)
+                : _map(std::move(map)),
+                  _object(std::move(object)),
                   _detachedPos(p)
             {
             }
@@ -505,7 +506,7 @@ namespace IceInternal
     class MetricsViewI
     {
     public:
-        MetricsViewI(const std::string&);
+        MetricsViewI(std::string);
 
         void destroy();
 
@@ -533,7 +534,7 @@ namespace IceInternal
     class ICE_API MetricsAdminI : public IceMX::MetricsAdmin
     {
     public:
-        MetricsAdminI(const Ice::PropertiesPtr&, const Ice::LoggerPtr&);
+        MetricsAdminI(Ice::PropertiesPtr, Ice::LoggerPtr);
         ~MetricsAdminI() override;
 
         void destroy();

--- a/cpp/include/Ice/MetricsObserverI.h
+++ b/cpp/include/Ice/MetricsObserverI.h
@@ -15,7 +15,6 @@
 #include <cassert>
 #include <sstream>
 #include <stdexcept>
-#include <utility>
 
 namespace IceInternal
 {

--- a/cpp/include/Ice/MetricsObserverI.h
+++ b/cpp/include/Ice/MetricsObserverI.h
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <sstream>
 #include <stdexcept>
+#include <utility>
 
 namespace IceInternal
 {
@@ -67,7 +68,7 @@ namespace IceMX
             class Resolver
             {
             public:
-                Resolver(const std::string& name) : _name(name) {}
+                Resolver(std::string  name) : _name(std::move(name)) {}
 
                 virtual ~Resolver() {}
 
@@ -440,8 +441,8 @@ namespace IceMX
         using MetricsType = typename ObserverImplType::MetricsType;
         using MetricsMapSeqType = std::vector<std::shared_ptr<IceInternal::MetricsMapT<MetricsType>>>;
 
-        ObserverFactoryT(const IceInternal::MetricsAdminIPtr& metrics, const std::string& name)
-            : _metrics(metrics),
+        ObserverFactoryT(IceInternal::MetricsAdminIPtr  metrics, const std::string& name)
+            : _metrics(std::move(metrics)),
               _name(name),
               _enabled(0)
         {

--- a/cpp/include/Ice/MetricsObserverI.h
+++ b/cpp/include/Ice/MetricsObserverI.h
@@ -68,7 +68,7 @@ namespace IceMX
             class Resolver
             {
             public:
-                Resolver(std::string  name) : _name(std::move(name)) {}
+                Resolver(std::string name) : _name(std::move(name)) {}
 
                 virtual ~Resolver() {}
 
@@ -441,7 +441,7 @@ namespace IceMX
         using MetricsType = typename ObserverImplType::MetricsType;
         using MetricsMapSeqType = std::vector<std::shared_ptr<IceInternal::MetricsMapT<MetricsType>>>;
 
-        ObserverFactoryT(IceInternal::MetricsAdminIPtr  metrics, const std::string& name)
+        ObserverFactoryT(IceInternal::MetricsAdminIPtr metrics, const std::string& name)
             : _metrics(std::move(metrics)),
               _name(name),
               _enabled(0)

--- a/cpp/src/DataStorm/NodeI.h
+++ b/cpp/src/DataStorm/NodeI.h
@@ -8,7 +8,6 @@
 #include "DataStorm/Contract.h"
 #include "DataStorm/InternalI.h"
 #include "ForwarderManager.h"
-
 #include "Ice/Ice.h"
 
 #include <set>

--- a/cpp/src/Glacier2/Blobject.cpp
+++ b/cpp/src/Glacier2/Blobject.cpp
@@ -3,8 +3,10 @@
 //
 
 #include "Blobject.h"
+
 #include "Instrumentation.h"
 #include "SessionRouterI.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -19,7 +21,7 @@ namespace
     constexpr string_view clientTraceRequest = "Glacier2.Client.Trace.Request";
 }
 
-Glacier2::Blobject::Blobject(shared_ptr<Instance> instance, ConnectionPtr reverseConnection, const Context& context)
+Glacier2::Blobject::Blobject(shared_ptr<Instance> instance, ConnectionPtr reverseConnection, Context context)
     : _instance(std::move(instance)),
       _reverseConnection(std::move(reverseConnection)),
       _forwardContext(
@@ -28,7 +30,7 @@ Glacier2::Blobject::Blobject(shared_ptr<Instance> instance, ConnectionPtr revers
       _requestTraceLevel(
           _reverseConnection ? _instance->properties()->getIcePropertyAsInt(serverTraceRequest)
                              : _instance->properties()->getIcePropertyAsInt(clientTraceRequest)),
-      _context(context)
+      _context(std::move(context))
 {
 }
 

--- a/cpp/src/Glacier2/Blobject.cpp
+++ b/cpp/src/Glacier2/Blobject.cpp
@@ -3,10 +3,8 @@
 //
 
 #include "Blobject.h"
-
 #include "Instrumentation.h"
 #include "SessionRouterI.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Glacier2/Blobject.h
+++ b/cpp/src/Glacier2/Blobject.h
@@ -13,7 +13,7 @@ namespace Glacier2
     class Blobject : public Ice::BlobjectArrayAsync, public std::enable_shared_from_this<Blobject>
     {
     public:
-        Blobject(std::shared_ptr<Instance>, Ice::ConnectionPtr, const Ice::Context&);
+        Blobject(std::shared_ptr<Instance>, Ice::ConnectionPtr, Ice::Context);
         void invokeException(std::exception_ptr, std::function<void(std::exception_ptr)>&&);
 
     protected:

--- a/cpp/src/Glacier2/ClientBlobject.cpp
+++ b/cpp/src/Glacier2/ClientBlobject.cpp
@@ -2,9 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-#include "../Ice/CheckIdentity.h"
-
 #include "ClientBlobject.h"
+#include "../Ice/CheckIdentity.h"
 #include "FilterManager.h"
 #include "FilterT.h"
 #include "RoutingTable.h"

--- a/cpp/src/Glacier2/FilterT.h
+++ b/cpp/src/Glacier2/FilterT.h
@@ -5,7 +5,6 @@
 #define FILTER_I_H
 
 #include "Glacier2/Session.h"
-
 #include "Ice/Identity.h"
 
 #include <list>

--- a/cpp/src/Glacier2/Instance.h
+++ b/cpp/src/Glacier2/Instance.h
@@ -8,7 +8,6 @@
 #include "Ice/CommunicatorF.h"
 #include "Ice/ObjectAdapterF.h"
 #include "Ice/PropertiesF.h"
-
 #include "Instrumentation.h"
 #include "ProxyVerifier.h"
 #include "SessionRouterI.h"

--- a/cpp/src/Glacier2/InstrumentationI.cpp
+++ b/cpp/src/Glacier2/InstrumentationI.cpp
@@ -3,7 +3,9 @@
 //
 
 #include "InstrumentationI.h"
+
 #include "../Ice/InstrumentationI.h"
+#include <utility>
 
 #include "Ice/Communicator.h"
 #include "Ice/LocalExceptions.h"
@@ -146,9 +148,9 @@ SessionObserverI::routingTableSize(int delta)
     forEach(add(&SessionMetrics::routingTableSize, delta));
 }
 
-RouterObserverI::RouterObserverI(shared_ptr<IceInternal::MetricsAdminI> metrics, const string& instanceName)
+RouterObserverI::RouterObserverI(shared_ptr<IceInternal::MetricsAdminI> metrics, string instanceName)
     : _metrics(std::move(metrics)),
-      _instanceName(instanceName),
+      _instanceName(std::move(instanceName)),
       _sessions(_metrics, "Session")
 {
 }

--- a/cpp/src/Glacier2/InstrumentationI.cpp
+++ b/cpp/src/Glacier2/InstrumentationI.cpp
@@ -3,10 +3,7 @@
 //
 
 #include "InstrumentationI.h"
-
 #include "../Ice/InstrumentationI.h"
-#include <utility>
-
 #include "Ice/Communicator.h"
 #include "Ice/LocalExceptions.h"
 #include "Ice/LoggerUtil.h"

--- a/cpp/src/Glacier2/InstrumentationI.h
+++ b/cpp/src/Glacier2/InstrumentationI.h
@@ -5,9 +5,8 @@
 #ifndef INSTRUMENTATION_I_H
 #define INSTRUMENTATION_I_H
 
-#include "Ice/MetricsObserverI.h"
-
 #include "Glacier2/Metrics.h"
+#include "Ice/MetricsObserverI.h"
 #include "Instrumentation.h"
 
 namespace Glacier2

--- a/cpp/src/Glacier2/InstrumentationI.h
+++ b/cpp/src/Glacier2/InstrumentationI.h
@@ -25,7 +25,7 @@ namespace Glacier2
     class RouterObserverI final : public Glacier2::Instrumentation::RouterObserver
     {
     public:
-        RouterObserverI(std::shared_ptr<IceInternal::MetricsAdminI>, const std::string&);
+        RouterObserverI(std::shared_ptr<IceInternal::MetricsAdminI>, std::string);
 
         void setObserverUpdater(const std::shared_ptr<Glacier2::Instrumentation::ObserverUpdater>&) override;
 

--- a/cpp/src/Glacier2/RouterI.cpp
+++ b/cpp/src/Glacier2/RouterI.cpp
@@ -8,7 +8,6 @@
 #include "RoutingTable.h"
 
 #include <random>
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Glacier2/RouterI.cpp
+++ b/cpp/src/Glacier2/RouterI.cpp
@@ -8,6 +8,7 @@
 #include "RoutingTable.h"
 
 #include <random>
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -16,18 +17,18 @@ using namespace Glacier2;
 Glacier2::RouterI::RouterI(
     shared_ptr<Instance> instance,
     ConnectionPtr connection,
-    const string& userId,
+    string userId,
     optional<SessionPrx> session,
-    const Identity& controlId,
+    Identity controlId,
     shared_ptr<FilterManager> filters,
     const Context& context)
     : _instance(std::move(instance)),
       _routingTable(make_shared<RoutingTable>(_instance->communicator(), _instance->proxyVerifier())),
       _clientBlobject(make_shared<ClientBlobject>(_instance, std::move(filters), context, _routingTable)),
       _connection(std::move(connection)),
-      _userId(userId),
+      _userId(std::move(userId)),
       _session(std::move(session)),
-      _controlId(controlId),
+      _controlId(std::move(controlId)),
       _context(context)
 {
     if (_instance->serverObjectAdapter())

--- a/cpp/src/Glacier2/RouterI.h
+++ b/cpp/src/Glacier2/RouterI.h
@@ -22,9 +22,9 @@ namespace Glacier2
         RouterI(
             std::shared_ptr<Instance>,
             Ice::ConnectionPtr,
-            const std::string&,
+            std::string,
             std::optional<SessionPrx>,
-            const Ice::Identity&,
+            Ice::Identity,
             std::shared_ptr<FilterManager>,
             const Ice::Context&);
 

--- a/cpp/src/Glacier2/RoutingTable.h
+++ b/cpp/src/Glacier2/RoutingTable.h
@@ -7,7 +7,6 @@
 
 #include "Ice/Ice.h"
 #include "Ice/ObserverHelper.h"
-
 #include "Instrumentation.h"
 #include "ProxyVerifier.h"
 

--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -10,8 +10,6 @@
 #include "Ice/Ice.h"
 #include "RouterI.h"
 
-#include <utility>
-
 using namespace std;
 using namespace Ice;
 using namespace Glacier2;

--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -10,6 +10,8 @@
 #include "Ice/Ice.h"
 #include "RouterI.h"
 
+#include <utility>
+
 using namespace std;
 using namespace Ice;
 using namespace Glacier2;
@@ -80,13 +82,13 @@ namespace Glacier2
             function<void(const optional<SessionPrx>&)> response,
             function<void(exception_ptr)> exception,
             const string& user,
-            const string& password,
+            string password,
             const Ice::Current& current,
             const shared_ptr<SessionRouterI>& sessionRouter)
             : CreateSession(sessionRouter, user, current),
               _response(std::move(response)),
               _exception(std::move(exception)),
-              _password(password)
+              _password(std::move(password))
         {
         }
 
@@ -179,13 +181,13 @@ namespace Glacier2
             function<void(const optional<SessionPrx>& returnValue)> response,
             function<void(exception_ptr)> exception,
             const string& user,
-            const SSLInfo& sslInfo,
+            SSLInfo sslInfo,
             const Ice::Current& current,
             const shared_ptr<SessionRouterI>& sessionRouter)
             : CreateSession(sessionRouter, user, current),
               _response(std::move(response)),
               _exception(std::move(exception)),
-              _sslInfo(sslInfo)
+              _sslInfo(std::move(sslInfo))
         {
         }
 
@@ -273,10 +275,10 @@ namespace Glacier2
     };
 }
 
-CreateSession::CreateSession(shared_ptr<SessionRouterI> sessionRouter, const string& user, const Ice::Current& current)
+CreateSession::CreateSession(shared_ptr<SessionRouterI> sessionRouter, string user, const Ice::Current& current)
     : _instance(sessionRouter->_instance),
       _sessionRouter(std::move(sessionRouter)),
-      _user(user),
+      _user(std::move(user)),
       _current(current)
 {
     // Clear reserved contexts potentially set by client

--- a/cpp/src/Glacier2/SessionRouterI.h
+++ b/cpp/src/Glacier2/SessionRouterI.h
@@ -25,7 +25,7 @@ namespace Glacier2
     class CreateSession : public std::enable_shared_from_this<CreateSession>
     {
     public:
-        CreateSession(std::shared_ptr<SessionRouterI>, const std::string&, const Ice::Current&);
+        CreateSession(std::shared_ptr<SessionRouterI>, std::string, const Ice::Current&);
 
         void create();
         void addPendingCallback(std::shared_ptr<CreateSession>);

--- a/cpp/src/Glacier2/SessionRouterI.h
+++ b/cpp/src/Glacier2/SessionRouterI.h
@@ -5,10 +5,9 @@
 #ifndef GLACIER2_SESSION_ROUTER_I_H
 #define GLACIER2_SESSION_ROUTER_I_H
 
-#include "Ice/Ice.h"
-
 #include "Glacier2/PermissionsVerifier.h"
 #include "Glacier2/Router.h"
+#include "Ice/Ice.h"
 #include "Instrumentation.h"
 
 #include <set>

--- a/cpp/src/Glacier2CryptPermissionsVerifier/CryptPermissionsVerifierI.cpp
+++ b/cpp/src/Glacier2CryptPermissionsVerifier/CryptPermissionsVerifierI.cpp
@@ -2,10 +2,9 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+#include "../Ice/FileUtil.h"
 #include "Glacier2/PermissionsVerifier.h"
 #include "Ice/Ice.h"
-
-#include "../Ice/FileUtil.h"
 #include "Ice/StringUtil.h"
 
 #include <fstream>

--- a/cpp/src/Ice/CommunicatorFlushBatchAsync.cpp
+++ b/cpp/src/Ice/CommunicatorFlushBatchAsync.cpp
@@ -3,11 +3,13 @@
 //
 
 #include "CommunicatorFlushBatchAsync.h"
+
 #include "BatchRequestQueue.h"
 #include "ConnectionFactory.h"
 #include "ConnectionI.h"
 #include "Instance.h"
 #include "ObjectAdapterFactory.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -34,12 +36,9 @@ CommunicatorFlushBatchAsync::flushConnection(const ConnectionIPtr& con, Ice::Com
     class FlushBatch final : public OutgoingAsyncBase
     {
     public:
-        FlushBatch(
-            const CommunicatorFlushBatchAsyncPtr& outAsync,
-            const InstancePtr& instance,
-            InvocationObserver& observer)
+        FlushBatch(CommunicatorFlushBatchAsyncPtr outAsync, const InstancePtr& instance, InvocationObserver& observer)
             : OutgoingAsyncBase(instance),
-              _outAsync(outAsync),
+              _outAsync(std::move(outAsync)),
               _parentObserver(observer)
         {
         }

--- a/cpp/src/Ice/CommunicatorFlushBatchAsync.cpp
+++ b/cpp/src/Ice/CommunicatorFlushBatchAsync.cpp
@@ -3,13 +3,11 @@
 //
 
 #include "CommunicatorFlushBatchAsync.h"
-
 #include "BatchRequestQueue.h"
 #include "ConnectionFactory.h"
 #include "ConnectionI.h"
 #include "Instance.h"
 #include "ObjectAdapterFactory.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/ConnectionFactory.cpp
+++ b/cpp/src/Ice/ConnectionFactory.cpp
@@ -24,6 +24,7 @@
 
 #include <chrono>
 #include <iterator>
+#include <utility>
 
 #if TARGET_OS_IPHONE != 0
 namespace IceInternal
@@ -72,9 +73,9 @@ namespace
     class StartAcceptor : public TimerTask, public std::enable_shared_from_this<StartAcceptor>
     {
     public:
-        StartAcceptor(const IncomingConnectionFactoryPtr& factory, const InstancePtr& instance)
-            : _factory(factory),
-              _instance(instance)
+        StartAcceptor(IncomingConnectionFactoryPtr factory, InstancePtr instance)
+            : _factory(std::move(factory)),
+              _instance(std::move(instance))
         {
         }
 
@@ -319,9 +320,9 @@ IceInternal::OutgoingConnectionFactory::removeConnection(const ConnectionIPtr& c
 }
 
 IceInternal::OutgoingConnectionFactory::OutgoingConnectionFactory(
-    const CommunicatorPtr& communicator,
+    CommunicatorPtr communicator,
     const InstancePtr& instance)
-    : _communicator(communicator),
+    : _communicator(std::move(communicator)),
       _instance(instance),
       _connectionOptions(instance->clientConnectionOptions()),
       _destroyed(false),
@@ -792,15 +793,15 @@ IceInternal::OutgoingConnectionFactory::handleConnectionException(exception_ptr 
 }
 
 IceInternal::OutgoingConnectionFactory::ConnectCallback::ConnectCallback(
-    const InstancePtr& instance,
-    const OutgoingConnectionFactoryPtr& factory,
+    InstancePtr instance,
+    OutgoingConnectionFactoryPtr factory,
     const vector<EndpointIPtr>& endpoints,
     bool hasMore,
     std::function<void(Ice::ConnectionIPtr, bool)> createConnectionResponse,
     std::function<void(std::exception_ptr)> createConnectionException,
     Ice::EndpointSelectionType selType)
-    : _instance(instance),
-      _factory(factory),
+    : _instance(std::move(instance)),
+      _factory(std::move(factory)),
       _endpoints(endpoints),
       _hasMore(hasMore),
       _createConnectionResponse(std::move(createConnectionResponse)),

--- a/cpp/src/Ice/ConnectionFactory.cpp
+++ b/cpp/src/Ice/ConnectionFactory.cpp
@@ -24,7 +24,6 @@
 
 #include <chrono>
 #include <iterator>
-#include <utility>
 
 #if TARGET_OS_IPHONE != 0
 namespace IceInternal

--- a/cpp/src/Ice/ConnectionFactory.h
+++ b/cpp/src/Ice/ConnectionFactory.h
@@ -25,7 +25,6 @@
 #include <list>
 #include <mutex>
 #include <set>
-#include <utility>
 
 namespace Ice
 {

--- a/cpp/src/Ice/ConnectionFactory.h
+++ b/cpp/src/Ice/ConnectionFactory.h
@@ -66,14 +66,14 @@ namespace IceInternal
         void setDefaultObjectAdapter(Ice::ObjectAdapterPtr adapter) noexcept;
         [[nodiscard]] Ice::ObjectAdapterPtr getDefaultObjectAdapter() const noexcept;
 
-        OutgoingConnectionFactory(const Ice::CommunicatorPtr&, const InstancePtr&);
+        OutgoingConnectionFactory(Ice::CommunicatorPtr, const InstancePtr&);
         ~OutgoingConnectionFactory();
         friend class Instance;
 
     private:
         struct ConnectorInfo
         {
-            ConnectorInfo(ConnectorPtr  c, EndpointIPtr  e) : connector(std::move(c)), endpoint(std::move(e)) {}
+            ConnectorInfo(ConnectorPtr c, EndpointIPtr e) : connector(std::move(c)), endpoint(std::move(e)) {}
 
             bool operator==(const ConnectorInfo& other) const;
 
@@ -85,8 +85,8 @@ namespace IceInternal
         {
         public:
             ConnectCallback(
-                const InstancePtr&,
-                const OutgoingConnectionFactoryPtr&,
+                InstancePtr,
+                OutgoingConnectionFactoryPtr,
                 const std::vector<EndpointIPtr>&,
                 bool,
                 std::function<void(Ice::ConnectionIPtr, bool)>,

--- a/cpp/src/Ice/ConnectionFactory.h
+++ b/cpp/src/Ice/ConnectionFactory.h
@@ -25,6 +25,7 @@
 #include <list>
 #include <mutex>
 #include <set>
+#include <utility>
 
 namespace Ice
 {
@@ -72,7 +73,7 @@ namespace IceInternal
     private:
         struct ConnectorInfo
         {
-            ConnectorInfo(const ConnectorPtr& c, const EndpointIPtr& e) : connector(c), endpoint(e) {}
+            ConnectorInfo(ConnectorPtr  c, EndpointIPtr  e) : connector(std::move(c)), endpoint(std::move(e)) {}
 
             bool operator==(const ConnectorInfo& other) const;
 

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -26,7 +26,6 @@
 
 #include <iomanip>
 #include <stdexcept>
-#include <utility>
 
 #ifdef ICE_HAS_BZIP2
 #    include <bzlib.h>

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -26,6 +26,7 @@
 
 #include <iomanip>
 #include <stdexcept>
+#include <utility>
 
 #ifdef ICE_HAS_BZIP2
 #    include <bzlib.h>
@@ -95,7 +96,7 @@ namespace
     class ConnectionFlushBatchAsync : public OutgoingAsyncBase
     {
     public:
-        ConnectionFlushBatchAsync(const Ice::ConnectionIPtr&, const InstancePtr&);
+        ConnectionFlushBatchAsync(Ice::ConnectionIPtr, const InstancePtr&);
 
         [[nodiscard]] virtual Ice::ConnectionPtr getConnection() const;
 
@@ -128,9 +129,9 @@ namespace
     }
 }
 
-ConnectionFlushBatchAsync::ConnectionFlushBatchAsync(const ConnectionIPtr& connection, const InstancePtr& instance)
+ConnectionFlushBatchAsync::ConnectionFlushBatchAsync(ConnectionIPtr connection, const InstancePtr& instance)
     : OutgoingAsyncBase(instance),
-      _connection(connection)
+      _connection(std::move(connection))
 {
 }
 
@@ -1891,7 +1892,7 @@ Ice::ConnectionI::exception(std::exception_ptr ex)
 }
 
 Ice::ConnectionI::ConnectionI(
-    const CommunicatorPtr& communicator,
+    CommunicatorPtr communicator,
     const InstancePtr& instance,
     const TransceiverPtr& transceiver,
     const ConnectorPtr& connector,
@@ -1899,7 +1900,7 @@ Ice::ConnectionI::ConnectionI(
     const shared_ptr<ObjectAdapterI>& adapter,
     std::function<void(const ConnectionIPtr&)> removeFromFactory,
     const ConnectionOptions& options) noexcept
-    : _communicator(communicator),
+    : _communicator(std::move(communicator)),
       _instance(instance),
       _transceiver(transceiver),
       _idleTimeoutTransceiver(dynamic_pointer_cast<IdleTimeoutTransceiverDecorator>(transceiver)),

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -32,6 +32,7 @@
 #include <deque>
 #include <list>
 #include <mutex>
+#include <utility>
 
 #ifndef ICE_HAS_BZIP2
 #    define ICE_HAS_BZIP2
@@ -97,9 +98,9 @@ namespace Ice
                 assert(stream->b.ownsMemory());
             }
 
-            OutgoingMessage(const IceInternal::OutgoingAsyncBasePtr& o, Ice::OutputStream* str, bool comp, int rid)
+            OutgoingMessage(IceInternal::OutgoingAsyncBasePtr  o, Ice::OutputStream* str, bool comp, int rid)
                 : stream(str),
-                  outAsync(o),
+                  outAsync(std::move(o)),
                   compress(comp),
                   requestId(rid),
                   adopted(false)

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -32,7 +32,6 @@
 #include <deque>
 #include <list>
 #include <mutex>
-#include <utility>
 
 #ifndef ICE_HAS_BZIP2
 #    define ICE_HAS_BZIP2

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -98,7 +98,7 @@ namespace Ice
                 assert(stream->b.ownsMemory());
             }
 
-            OutgoingMessage(IceInternal::OutgoingAsyncBasePtr  o, Ice::OutputStream* str, bool comp, int rid)
+            OutgoingMessage(IceInternal::OutgoingAsyncBasePtr o, Ice::OutputStream* str, bool comp, int rid)
                 : stream(str),
                   outAsync(std::move(o)),
                   compress(comp),
@@ -244,7 +244,7 @@ namespace Ice
 
     private:
         ConnectionI(
-            const Ice::CommunicatorPtr&,
+            Ice::CommunicatorPtr,
             const IceInternal::InstancePtr&,
             const IceInternal::TransceiverPtr&,
             const IceInternal::ConnectorPtr&,

--- a/cpp/src/Ice/EndpointFactory.cpp
+++ b/cpp/src/Ice/EndpointFactory.cpp
@@ -3,9 +3,11 @@
 //
 
 #include "EndpointFactory.h"
+
 #include "EndpointFactoryManager.h"
 #include "Instance.h"
 #include "ProtocolInstance.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -39,10 +41,8 @@ IceInternal::EndpointFactoryPlugin::destroy()
 {
 }
 
-IceInternal::EndpointFactoryWithUnderlying::EndpointFactoryWithUnderlying(
-    const ProtocolInstancePtr& instance,
-    int16_t type)
-    : _instance(instance),
+IceInternal::EndpointFactoryWithUnderlying::EndpointFactoryWithUnderlying(ProtocolInstancePtr instance, int16_t type)
+    : _instance(std::move(instance)),
       _type(type)
 {
 }
@@ -101,10 +101,10 @@ IceInternal::EndpointFactoryWithUnderlying::clone(const ProtocolInstancePtr& ins
 }
 
 IceInternal::UnderlyingEndpointFactory::UnderlyingEndpointFactory(
-    const ProtocolInstancePtr& instance,
+    ProtocolInstancePtr instance,
     int16_t type,
     int16_t underlying)
-    : _instance(instance),
+    : _instance(std::move(instance)),
       _type(type),
       _underlying(underlying)
 {

--- a/cpp/src/Ice/EndpointFactory.cpp
+++ b/cpp/src/Ice/EndpointFactory.cpp
@@ -3,11 +3,9 @@
 //
 
 #include "EndpointFactory.h"
-
 #include "EndpointFactoryManager.h"
 #include "Instance.h"
 #include "ProtocolInstance.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/EndpointFactory.h
+++ b/cpp/src/Ice/EndpointFactory.h
@@ -41,7 +41,7 @@ namespace IceInternal
     class ICE_API EndpointFactoryWithUnderlying : public EndpointFactory
     {
     public:
-        EndpointFactoryWithUnderlying(const ProtocolInstancePtr&, std::int16_t);
+        EndpointFactoryWithUnderlying(ProtocolInstancePtr, std::int16_t);
 
         void initialize() override;
         [[nodiscard]] std::int16_t type() const override;
@@ -72,7 +72,7 @@ namespace IceInternal
     class ICE_API UnderlyingEndpointFactory : public EndpointFactory
     {
     public:
-        UnderlyingEndpointFactory(const ProtocolInstancePtr&, std::int16_t, std::int16_t);
+        UnderlyingEndpointFactory(ProtocolInstancePtr, std::int16_t, std::int16_t);
 
         void initialize() override;
         [[nodiscard]] std::int16_t type() const override;

--- a/cpp/src/Ice/EndpointFactoryManager.cpp
+++ b/cpp/src/Ice/EndpointFactoryManager.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "EndpointFactoryManager.h"
+
 #include "DefaultsAndOverrides.h"
 #include "Ice/Endpoint.h"
 #include "Ice/InputStream.h"
@@ -12,12 +13,13 @@
 #include "Ice/StringUtil.h"
 #include "Instance.h"
 #include "OpaqueEndpointI.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
 using namespace IceInternal;
 
-IceInternal::EndpointFactoryManager::EndpointFactoryManager(const InstancePtr& instance) : _instance(instance) {}
+IceInternal::EndpointFactoryManager::EndpointFactoryManager(InstancePtr instance) : _instance(std::move(instance)) {}
 
 void
 IceInternal::EndpointFactoryManager::initialize() const

--- a/cpp/src/Ice/EndpointFactoryManager.cpp
+++ b/cpp/src/Ice/EndpointFactoryManager.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "EndpointFactoryManager.h"
-
 #include "DefaultsAndOverrides.h"
 #include "Ice/Endpoint.h"
 #include "Ice/InputStream.h"
@@ -13,7 +12,6 @@
 #include "Ice/StringUtil.h"
 #include "Instance.h"
 #include "OpaqueEndpointI.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/EndpointFactoryManager.h
+++ b/cpp/src/Ice/EndpointFactoryManager.h
@@ -25,7 +25,7 @@ namespace IceInternal
     class EndpointFactoryManager
     {
     public:
-        EndpointFactoryManager(const InstancePtr&);
+        EndpointFactoryManager(InstancePtr);
         void initialize() const;
         void add(const EndpointFactoryPtr&);
         [[nodiscard]] EndpointFactoryPtr get(std::int16_t) const;

--- a/cpp/src/Ice/FixedRequestHandler.cpp
+++ b/cpp/src/Ice/FixedRequestHandler.cpp
@@ -3,22 +3,21 @@
 //
 
 #include "FixedRequestHandler.h"
+
 #include "ConnectionI.h"
 #include "Ice/OutgoingAsync.h"
 #include "Ice/Proxy.h"
 #include "Reference.h"
 #include "RouterInfo.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
 using namespace IceInternal;
 
-FixedRequestHandler::FixedRequestHandler(
-    const ReferencePtr& reference,
-    const Ice::ConnectionIPtr& connection,
-    bool compress)
+FixedRequestHandler::FixedRequestHandler(const ReferencePtr& reference, Ice::ConnectionIPtr connection, bool compress)
     : RequestHandler(reference),
-      _connection(connection),
+      _connection(std::move(connection)),
       _compress(compress)
 {
 }

--- a/cpp/src/Ice/FixedRequestHandler.cpp
+++ b/cpp/src/Ice/FixedRequestHandler.cpp
@@ -3,13 +3,11 @@
 //
 
 #include "FixedRequestHandler.h"
-
 #include "ConnectionI.h"
 #include "Ice/OutgoingAsync.h"
 #include "Ice/Proxy.h"
 #include "Reference.h"
 #include "RouterInfo.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/FixedRequestHandler.h
+++ b/cpp/src/Ice/FixedRequestHandler.h
@@ -14,7 +14,7 @@ namespace IceInternal
     class FixedRequestHandler final : public RequestHandler
     {
     public:
-        FixedRequestHandler(const ReferencePtr&, const Ice::ConnectionIPtr&, bool);
+        FixedRequestHandler(const ReferencePtr&, Ice::ConnectionIPtr, bool);
 
         AsyncStatus sendAsyncRequest(const ProxyOutgoingAsyncBasePtr&) final;
 

--- a/cpp/src/Ice/HttpParser.cpp
+++ b/cpp/src/Ice/HttpParser.cpp
@@ -8,6 +8,7 @@
 #include "Ice/StringUtil.h"
 
 #include <cassert>
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -24,7 +25,7 @@ namespace
     }
 }
 
-IceInternal::WebSocketException::WebSocketException(const string& r) : reason(r) {}
+IceInternal::WebSocketException::WebSocketException(string r) : reason(std::move(r)) {}
 
 IceInternal::HttpParser::HttpParser()
     : _type(TypeUnknown),

--- a/cpp/src/Ice/HttpParser.cpp
+++ b/cpp/src/Ice/HttpParser.cpp
@@ -8,7 +8,6 @@
 #include "Ice/StringUtil.h"
 
 #include <cassert>
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/HttpParser.h
+++ b/cpp/src/Ice/HttpParser.h
@@ -21,7 +21,7 @@ namespace IceInternal
     class WebSocketException
     {
     public:
-        WebSocketException(const std::string&);
+        WebSocketException(std::string);
 
         std::string reason;
     };

--- a/cpp/src/Ice/IPEndpointI.cpp
+++ b/cpp/src/Ice/IPEndpointI.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "IPEndpointI.h"
-
 #include "HashUtil.h"
 #include "Ice/InputStream.h"
 #include "Ice/LocalExceptions.h"
@@ -12,7 +11,6 @@
 #include "Instance.h"
 #include "NetworkProxy.h"
 #include "ProtocolInstance.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/IPEndpointI.cpp
+++ b/cpp/src/Ice/IPEndpointI.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "IPEndpointI.h"
+
 #include "HashUtil.h"
 #include "Ice/InputStream.h"
 #include "Ice/LocalExceptions.h"
@@ -11,6 +12,7 @@
 #include "Instance.h"
 #include "NetworkProxy.h"
 #include "ProtocolInstance.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -403,23 +405,23 @@ IceInternal::IPEndpointI::checkOption(const string& option, const string& argume
 }
 
 IceInternal::IPEndpointI::IPEndpointI(
-    const ProtocolInstancePtr& instance,
-    const string& host,
+    ProtocolInstancePtr instance,
+    string host,
     int port,
     const Address& sourceAddr,
-    const string& connectionId)
-    : _instance(instance),
-      _host(host),
+    string connectionId)
+    : _instance(std::move(instance)),
+      _host(std::move(host)),
       _port(port),
       _sourceAddr(sourceAddr),
-      _connectionId(connectionId)
+      _connectionId(std::move(connectionId))
 {
 }
 
-IceInternal::IPEndpointI::IPEndpointI(const ProtocolInstancePtr& instance) : _instance(instance), _port(0) {}
+IceInternal::IPEndpointI::IPEndpointI(ProtocolInstancePtr instance) : _instance(std::move(instance)), _port(0) {}
 
-IceInternal::IPEndpointI::IPEndpointI(const ProtocolInstancePtr& instance, InputStream* s)
-    : _instance(instance),
+IceInternal::IPEndpointI::IPEndpointI(ProtocolInstancePtr instance, InputStream* s)
+    : _instance(std::move(instance)),
       _port(0)
 {
     s->read(const_cast<string&>(_host), false);

--- a/cpp/src/Ice/IPEndpointI.h
+++ b/cpp/src/Ice/IPEndpointI.h
@@ -57,9 +57,9 @@ namespace IceInternal
         [[nodiscard]] virtual ConnectorPtr createConnector(const Address& address, const NetworkProxyPtr&) const = 0;
         [[nodiscard]] virtual IPEndpointIPtr createEndpoint(const std::string&, int, const std::string&) const = 0;
 
-        IPEndpointI(const ProtocolInstancePtr&, const std::string&, int, const Address&, const std::string&);
-        IPEndpointI(const ProtocolInstancePtr&);
-        IPEndpointI(const ProtocolInstancePtr&, Ice::InputStream*);
+        IPEndpointI(ProtocolInstancePtr, std::string, int, const Address&, std::string);
+        IPEndpointI(ProtocolInstancePtr);
+        IPEndpointI(ProtocolInstancePtr, Ice::InputStream*);
 
         const ProtocolInstancePtr _instance;
         const std::string _host;

--- a/cpp/src/Ice/IdleTimeoutTransceiverDecorator.h
+++ b/cpp/src/Ice/IdleTimeoutTransceiverDecorator.h
@@ -10,6 +10,7 @@
 #include "Transceiver.h"
 
 #include <cassert>
+#include <utility>
 
 namespace IceInternal
 {
@@ -19,12 +20,12 @@ namespace IceInternal
     {
     public:
         IdleTimeoutTransceiverDecorator(
-            const TransceiverPtr& decoratee,
+            TransceiverPtr decoratee,
             const std::chrono::seconds& idleTimeout,
-            const IceInternal::TimerPtr& timer)
-            : _decoratee(decoratee),
+            IceInternal::TimerPtr timer)
+            : _decoratee(std::move(decoratee)),
               _idleTimeout(idleTimeout),
-              _timer(timer)
+              _timer(std::move(timer))
         {
             assert(_decoratee->protocol() != "udp");
         }

--- a/cpp/src/Ice/IdleTimeoutTransceiverDecorator.h
+++ b/cpp/src/Ice/IdleTimeoutTransceiverDecorator.h
@@ -10,7 +10,6 @@
 #include "Transceiver.h"
 
 #include <cassert>
-#include <utility>
 
 namespace IceInternal
 {

--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -45,7 +45,6 @@
 #include <list>
 #include <mutex>
 #include <stdio.h>
-#include <utility>
 
 #if defined(_WIN32)
 #    include "SSL/SchannelEngine.h"

--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -44,6 +44,7 @@
 
 #include <list>
 #include <mutex>
+#include <utility>
 #include <stdio.h>
 
 #if defined(_WIN32)
@@ -186,7 +187,7 @@ namespace IceInternal // Required because ObserverUpdaterI is a friend of Instan
     class ObserverUpdaterI : public Ice::Instrumentation::ObserverUpdater
     {
     public:
-        ObserverUpdaterI(const InstancePtr&);
+        ObserverUpdaterI(InstancePtr );
 
         void updateConnectionObservers() override;
         void updateThreadObservers() override;
@@ -271,7 +272,7 @@ ThreadObserverTimer::runTimerTask(const TimerTaskPtr& task)
     }
 }
 
-IceInternal::ObserverUpdaterI::ObserverUpdaterI(const InstancePtr& instance) : _instance(instance) {}
+IceInternal::ObserverUpdaterI::ObserverUpdaterI(InstancePtr  instance) : _instance(std::move(instance)) {}
 
 void
 IceInternal::ObserverUpdaterI::updateConnectionObservers()
@@ -911,9 +912,9 @@ IceInternal::Instance::create(const Ice::CommunicatorPtr& communicator, const Ic
     return instance;
 }
 
-IceInternal::Instance::Instance(const InitializationData& initData)
+IceInternal::Instance::Instance(InitializationData  initData)
     : _state(StateActive),
-      _initData(initData),
+      _initData(std::move(initData)),
       _messageSizeMax(0),
       _batchAutoFlushSize(0),
       _classGraphDepthMax(0),
@@ -1858,7 +1859,7 @@ IceInternal::Instance::setRcvBufSizeWarn(int16_t type, int size)
     _setBufSizeWarn[type] = info;
 }
 
-IceInternal::ProcessI::ProcessI(const CommunicatorPtr& communicator) : _communicator(communicator) {}
+IceInternal::ProcessI::ProcessI(CommunicatorPtr  communicator) : _communicator(std::move(communicator)) {}
 
 void
 IceInternal::ProcessI::shutdown(const Current&)

--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -44,8 +44,8 @@
 
 #include <list>
 #include <mutex>
-#include <utility>
 #include <stdio.h>
+#include <utility>
 
 #if defined(_WIN32)
 #    include "SSL/SchannelEngine.h"
@@ -187,7 +187,7 @@ namespace IceInternal // Required because ObserverUpdaterI is a friend of Instan
     class ObserverUpdaterI : public Ice::Instrumentation::ObserverUpdater
     {
     public:
-        ObserverUpdaterI(InstancePtr );
+        ObserverUpdaterI(InstancePtr);
 
         void updateConnectionObservers() override;
         void updateThreadObservers() override;
@@ -272,7 +272,7 @@ ThreadObserverTimer::runTimerTask(const TimerTaskPtr& task)
     }
 }
 
-IceInternal::ObserverUpdaterI::ObserverUpdaterI(InstancePtr  instance) : _instance(std::move(instance)) {}
+IceInternal::ObserverUpdaterI::ObserverUpdaterI(InstancePtr instance) : _instance(std::move(instance)) {}
 
 void
 IceInternal::ObserverUpdaterI::updateConnectionObservers()
@@ -912,7 +912,7 @@ IceInternal::Instance::create(const Ice::CommunicatorPtr& communicator, const Ic
     return instance;
 }
 
-IceInternal::Instance::Instance(InitializationData  initData)
+IceInternal::Instance::Instance(InitializationData initData)
     : _state(StateActive),
       _initData(std::move(initData)),
       _messageSizeMax(0),
@@ -1859,7 +1859,7 @@ IceInternal::Instance::setRcvBufSizeWarn(int16_t type, int size)
     _setBufSizeWarn[type] = info;
 }
 
-IceInternal::ProcessI::ProcessI(CommunicatorPtr  communicator) : _communicator(std::move(communicator)) {}
+IceInternal::ProcessI::ProcessI(CommunicatorPtr communicator) : _communicator(std::move(communicator)) {}
 
 void
 IceInternal::ProcessI::shutdown(const Current&)

--- a/cpp/src/Ice/Instance.h
+++ b/cpp/src/Ice/Instance.h
@@ -123,7 +123,7 @@ namespace IceInternal
         [[nodiscard]] Ice::SSL::SSLEnginePtr sslEngine() const { return _sslEngine; }
 
     private:
-        Instance(Ice::InitializationData );
+        Instance(Ice::InitializationData);
         void initialize(const Ice::CommunicatorPtr&);
         void finishSetup(int&, const char*[], const Ice::CommunicatorPtr&);
         void destroy();
@@ -204,7 +204,7 @@ namespace IceInternal
     class ProcessI final : public Ice::Process
     {
     public:
-        ProcessI(Ice::CommunicatorPtr );
+        ProcessI(Ice::CommunicatorPtr);
 
         void shutdown(const Ice::Current&) final;
         void writeMessage(std::string message, std::int32_t fd, const Ice::Current&) final;

--- a/cpp/src/Ice/Instance.h
+++ b/cpp/src/Ice/Instance.h
@@ -123,7 +123,7 @@ namespace IceInternal
         [[nodiscard]] Ice::SSL::SSLEnginePtr sslEngine() const { return _sslEngine; }
 
     private:
-        Instance(const Ice::InitializationData&);
+        Instance(Ice::InitializationData );
         void initialize(const Ice::CommunicatorPtr&);
         void finishSetup(int&, const char*[], const Ice::CommunicatorPtr&);
         void destroy();
@@ -204,7 +204,7 @@ namespace IceInternal
     class ProcessI final : public Ice::Process
     {
     public:
-        ProcessI(const Ice::CommunicatorPtr&);
+        ProcessI(Ice::CommunicatorPtr );
 
         void shutdown(const Ice::Current&) final;
         void writeMessage(std::string message, std::int32_t fd, const Ice::Current&) final;

--- a/cpp/src/Ice/InstrumentationI.cpp
+++ b/cpp/src/Ice/InstrumentationI.cpp
@@ -4,8 +4,6 @@
 
 #include "InstrumentationI.h"
 
-#include <utility>
-
 #include "Ice/Communicator.h"
 #include "Ice/Connection.h"
 #include "Ice/Endpoint.h"

--- a/cpp/src/Ice/InstrumentationI.cpp
+++ b/cpp/src/Ice/InstrumentationI.cpp
@@ -4,6 +4,8 @@
 
 #include "InstrumentationI.h"
 
+#include <utility>
+
 #include "Ice/Communicator.h"
 #include "Ice/Connection.h"
 #include "Ice/Endpoint.h"
@@ -557,9 +559,9 @@ namespace
         };
         static Attributes attributes;
 
-        ThreadHelper(const string& parent, const string& id, ThreadState state)
-            : _parent(parent),
-              _id(id),
+        ThreadHelper(string parent, string id, ThreadState state)
+            : _parent(std::move(parent)),
+              _id(std::move(id)),
               _state(state)
         {
         }
@@ -597,9 +599,9 @@ namespace
         };
         static Attributes attributes;
 
-        EndpointHelper(const EndpointPtr& endpt, const string& id) : _endpoint(endpt), _id(id) {}
+        EndpointHelper(EndpointPtr endpt, string id) : _endpoint(std::move(endpt)), _id(std::move(id)) {}
 
-        EndpointHelper(const EndpointPtr& endpt) : _endpoint(endpt) {}
+        EndpointHelper(EndpointPtr endpt) : _endpoint(std::move(endpt)) {}
 
         string operator()(const string& attribute) const override { return attributes(this, attribute); }
 

--- a/cpp/src/Ice/LocatorInfo.cpp
+++ b/cpp/src/Ice/LocatorInfo.cpp
@@ -16,7 +16,6 @@
 #include "TraceLevels.h"
 
 #include <iterator>
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/LocatorInfo.cpp
+++ b/cpp/src/Ice/LocatorInfo.cpp
@@ -16,6 +16,7 @@
 #include "TraceLevels.h"
 
 #include <iterator>
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -347,12 +348,12 @@ IceInternal::LocatorInfo::RequestCallback::exception(const LocatorInfoPtr& locat
 }
 
 IceInternal::LocatorInfo::RequestCallback::RequestCallback(
-    const ReferencePtr& ref,
+    ReferencePtr ref,
     chrono::milliseconds ttl,
-    const GetEndpointsCallbackPtr& cb)
-    : _reference(ref),
+    GetEndpointsCallbackPtr cb)
+    : _reference(std::move(ref)),
       _ttl(ttl),
-      _callback(cb)
+      _callback(std::move(cb))
 {
 }
 
@@ -394,9 +395,9 @@ IceInternal::LocatorInfo::Request::addCallback(
     }
 }
 
-IceInternal::LocatorInfo::Request::Request(const LocatorInfoPtr& locatorInfo, const ReferencePtr& ref)
-    : _locatorInfo(locatorInfo),
-      _reference(ref),
+IceInternal::LocatorInfo::Request::Request(LocatorInfoPtr locatorInfo, ReferencePtr ref)
+    : _locatorInfo(std::move(locatorInfo)),
+      _reference(std::move(ref)),
       _sent(false),
       _response(false)
 {
@@ -444,9 +445,9 @@ IceInternal::LocatorInfo::Request::exception(std::exception_ptr ex)
     }
 }
 
-IceInternal::LocatorInfo::LocatorInfo(const LocatorPrx& locator, const LocatorTablePtr& table, bool background)
-    : _locator(locator),
-      _table(table),
+IceInternal::LocatorInfo::LocatorInfo(LocatorPrx locator, LocatorTablePtr table, bool background)
+    : _locator(std::move(locator)),
+      _table(std::move(table)),
       _background(background)
 {
     assert(_table);

--- a/cpp/src/Ice/LocatorInfo.h
+++ b/cpp/src/Ice/LocatorInfo.h
@@ -79,7 +79,7 @@ namespace IceInternal
         class RequestCallback final
         {
         public:
-            RequestCallback(const ReferencePtr&, std::chrono::milliseconds, const GetEndpointsCallbackPtr&);
+            RequestCallback(ReferencePtr, std::chrono::milliseconds, GetEndpointsCallbackPtr);
 
             void response(const LocatorInfoPtr&, const std::optional<Ice::ObjectPrx>&);
             void exception(const LocatorInfoPtr&, std::exception_ptr);
@@ -104,7 +104,7 @@ namespace IceInternal
             void exception(std::exception_ptr);
 
         protected:
-            Request(const LocatorInfoPtr&, const ReferencePtr&);
+            Request(LocatorInfoPtr, ReferencePtr);
 
             virtual void send() = 0;
 
@@ -122,7 +122,7 @@ namespace IceInternal
         };
         using RequestPtr = std::shared_ptr<Request>;
 
-        LocatorInfo(const Ice::LocatorPrx&, const LocatorTablePtr&, bool);
+        LocatorInfo(Ice::LocatorPrx, LocatorTablePtr, bool);
 
         void destroy();
 

--- a/cpp/src/Ice/LoggerAdminI.cpp
+++ b/cpp/src/Ice/LoggerAdminI.cpp
@@ -15,6 +15,7 @@
 
 #include <deque>
 #include <set>
+#include <utility>
 
 using namespace Ice;
 using namespace std;
@@ -93,7 +94,7 @@ namespace
     class Job
     {
     public:
-        Job(const vector<RemoteLoggerPrx>& r, const LogMessage& l) : remoteLoggers(r), logMessage(l) {}
+        Job(const vector<RemoteLoggerPrx>& r, LogMessage l) : remoteLoggers(r), logMessage(std::move(l)) {}
 
         const vector<RemoteLoggerPrx> remoteLoggers;
         const LogMessage logMessage;

--- a/cpp/src/Ice/LoggerAdminI.cpp
+++ b/cpp/src/Ice/LoggerAdminI.cpp
@@ -15,7 +15,6 @@
 
 #include <deque>
 #include <set>
-#include <utility>
 
 using namespace Ice;
 using namespace std;

--- a/cpp/src/Ice/MetricsAdminI.cpp
+++ b/cpp/src/Ice/MetricsAdminI.cpp
@@ -3,19 +3,16 @@
 //
 
 #include "Ice/MetricsAdminI.h"
-
 #include "Ice/Communicator.h"
 #include "Ice/Logger.h"
 #include "Ice/LoggerUtil.h"
 #include "Ice/Properties.h"
+#include "Ice/StringUtil.h"
 #include "Instance.h"
 #include "InstrumentationI.h"
 
-#include "Ice/StringUtil.h"
-
 #include <chrono>
 #include <stdexcept>
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/MetricsAdminI.cpp
+++ b/cpp/src/Ice/MetricsAdminI.cpp
@@ -15,6 +15,7 @@
 
 #include <chrono>
 #include <stdexcept>
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -86,7 +87,7 @@ namespace
     }
 }
 
-MetricsMapI::RegExp::RegExp(const string& attribute, const string& regexp) : _attribute(attribute)
+MetricsMapI::RegExp::RegExp(string attribute, const string& regexp) : _attribute(std::move(attribute))
 {
     _regex = regex(regexp, std::regex_constants::extended | std::regex_constants::nosubs);
 }
@@ -185,7 +186,7 @@ MetricsMapFactory::update()
     _updater->update();
 }
 
-MetricsViewI::MetricsViewI(const string& name) : _name(name) {}
+MetricsViewI::MetricsViewI(string name) : _name(std::move(name)) {}
 
 void
 MetricsViewI::destroy()
@@ -338,9 +339,9 @@ MetricsViewI::getMap(const string& mapName) const
     return nullptr;
 }
 
-MetricsAdminI::MetricsAdminI(const PropertiesPtr& properties, const LoggerPtr& logger)
-    : _logger(logger),
-      _properties(properties)
+MetricsAdminI::MetricsAdminI(PropertiesPtr properties, LoggerPtr logger)
+    : _logger(std::move(logger)),
+      _properties(std::move(properties))
 {
     updateViews();
 }

--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "Network.h"
-#include "DisableWarnings.h"
 #include "Ice/Buffer.h"
 #include "Ice/LocalExceptions.h"
 #include "Ice/LoggerUtil.h" // For setTcpBufSize
@@ -13,6 +12,8 @@
 #include "NetworkProxy.h"
 #include "ProtocolInstance.h" // For setTcpBufSize
 #include "Random.h"
+
+#include "DisableWarnings.h"
 
 #include <cassert>
 #include <functional>

--- a/cpp/src/Ice/Network.h
+++ b/cpp/src/Ice/Network.h
@@ -6,7 +6,6 @@
 #define ICE_NETWORK_H
 
 #include "Ice/Config.h"
-
 #include "Ice/EndpointSelectionType.h"
 #include "Ice/EndpointTypes.h"
 #include "Ice/Logger.h"      // For setTcpBufSize

--- a/cpp/src/Ice/ObjectAdapterFactory.cpp
+++ b/cpp/src/Ice/ObjectAdapterFactory.cpp
@@ -3,13 +3,11 @@
 //
 
 #include "ObjectAdapterFactory.h"
-
 #include "Ice/LocalExceptions.h"
 #include "Ice/Object.h"
 #include "Ice/Router.h"
 #include "Ice/UUID.h"
 #include "ObjectAdapterI.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/ObjectAdapterFactory.cpp
+++ b/cpp/src/Ice/ObjectAdapterFactory.cpp
@@ -3,11 +3,13 @@
 //
 
 #include "ObjectAdapterFactory.h"
+
 #include "Ice/LocalExceptions.h"
 #include "Ice/Object.h"
 #include "Ice/Router.h"
 #include "Ice/UUID.h"
 #include "ObjectAdapterI.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -267,11 +269,9 @@ IceInternal::ObjectAdapterFactory::flushAsyncBatchRequests(
     }
 }
 
-IceInternal::ObjectAdapterFactory::ObjectAdapterFactory(
-    const InstancePtr& instance,
-    const CommunicatorPtr& communicator)
-    : _instance(instance),
-      _communicator(communicator)
+IceInternal::ObjectAdapterFactory::ObjectAdapterFactory(InstancePtr instance, CommunicatorPtr communicator)
+    : _instance(std::move(instance)),
+      _communicator(std::move(communicator))
 {
 }
 

--- a/cpp/src/Ice/ObjectAdapterFactory.h
+++ b/cpp/src/Ice/ObjectAdapterFactory.h
@@ -32,7 +32,7 @@ namespace IceInternal
         void removeObjectAdapter(const Ice::ObjectAdapterPtr&);
         void flushAsyncBatchRequests(const CommunicatorFlushBatchAsyncPtr&, Ice::CompressBatch) const;
 
-        ObjectAdapterFactory(const InstancePtr&, const Ice::CommunicatorPtr&);
+        ObjectAdapterFactory(InstancePtr, Ice::CommunicatorPtr);
         virtual ~ObjectAdapterFactory();
 
     private:

--- a/cpp/src/Ice/PluginManagerI.cpp
+++ b/cpp/src/Ice/PluginManagerI.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "PluginManagerI.h"
-
 #include "DynamicLibrary.h"
 #include "Ice/Communicator.h"
 #include "Ice/LocalExceptions.h"
@@ -11,7 +10,6 @@
 #include "Ice/Properties.h"
 #include "Instance.h"
 #include "Options.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/PluginManagerI.cpp
+++ b/cpp/src/Ice/PluginManagerI.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "PluginManagerI.h"
+
 #include "DynamicLibrary.h"
 #include "Ice/Communicator.h"
 #include "Ice/LocalExceptions.h"
@@ -10,6 +11,7 @@
 #include "Ice/Properties.h"
 #include "Instance.h"
 #include "Options.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -213,8 +215,8 @@ Ice::PluginManagerI::destroy() noexcept
     _plugins.clear();
 }
 
-Ice::PluginManagerI::PluginManagerI(const CommunicatorPtr& communicator)
-    : _communicator(communicator),
+Ice::PluginManagerI::PluginManagerI(CommunicatorPtr communicator)
+    : _communicator(std::move(communicator)),
       _initialized(false)
 {
 }

--- a/cpp/src/Ice/PluginManagerI.h
+++ b/cpp/src/Ice/PluginManagerI.h
@@ -30,7 +30,7 @@ namespace Ice
         void destroy() noexcept final;
 
         // Constructs the plugin manager (internal).
-        PluginManagerI(const CommunicatorPtr&);
+        PluginManagerI(CommunicatorPtr);
 
         // Loads all the plugins (internal).
         // Returns true when one or more libraries may have been loaded dynamically; returns false when definitely no

--- a/cpp/src/Ice/ProtocolInstance.cpp
+++ b/cpp/src/Ice/ProtocolInstance.cpp
@@ -8,7 +8,9 @@
 #include "IPEndpointI.h"
 #include "Ice/Initialize.h"
 #include "Instance.h"
+
 #include "TraceLevels.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -19,31 +21,23 @@ IceInternal::ProtocolInstance::~ProtocolInstance()
     // Out of line to avoid weak vtable
 }
 
-IceInternal::ProtocolInstance::ProtocolInstance(
-    const CommunicatorPtr& com,
-    int16_t type,
-    const string& protocol,
-    bool secure)
+IceInternal::ProtocolInstance::ProtocolInstance(const CommunicatorPtr& com, int16_t type, string protocol, bool secure)
     : _instance(getInstance(com)),
       _traceLevel(_instance.lock()->traceLevels()->network),
       _traceCategory(_instance.lock()->traceLevels()->networkCat),
       _properties(_instance.lock()->initializationData().properties),
-      _protocol(protocol),
+      _protocol(std::move(protocol)),
       _type(type),
       _secure(secure)
 {
 }
 
-IceInternal::ProtocolInstance::ProtocolInstance(
-    const InstancePtr& instance,
-    int16_t type,
-    const string& protocol,
-    bool secure)
+IceInternal::ProtocolInstance::ProtocolInstance(const InstancePtr& instance, int16_t type, string protocol, bool secure)
     : _instance(instance),
       _traceLevel(instance->traceLevels()->network),
       _traceCategory(instance->traceLevels()->networkCat),
       _properties(instance->initializationData().properties),
-      _protocol(protocol),
+      _protocol(std::move(protocol)),
       _type(type),
       _secure(secure)
 {

--- a/cpp/src/Ice/ProtocolInstance.cpp
+++ b/cpp/src/Ice/ProtocolInstance.cpp
@@ -8,9 +8,7 @@
 #include "IPEndpointI.h"
 #include "Ice/Initialize.h"
 #include "Instance.h"
-
 #include "TraceLevels.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/ProtocolInstance.h
+++ b/cpp/src/Ice/ProtocolInstance.h
@@ -23,7 +23,7 @@ namespace IceInternal
     public:
         virtual ~ProtocolInstance();
 
-        ProtocolInstance(const Ice::CommunicatorPtr&, std::int16_t, const std::string&, bool);
+        ProtocolInstance(const Ice::CommunicatorPtr&, std::int16_t, std::string, bool);
 
         [[nodiscard]] int traceLevel() const { return _traceLevel; }
 
@@ -60,7 +60,7 @@ namespace IceInternal
             std::function<void(std::exception_ptr)>) const;
 
     protected:
-        ProtocolInstance(const InstancePtr&, std::int16_t, const std::string&, bool);
+        ProtocolInstance(const InstancePtr&, std::int16_t, std::string, bool);
         friend class Instance;
         // Use a weak pointer to avoid circular references. The communicator owns the endpoint factory, which in
         // turn own this protocol instance.

--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -29,6 +29,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -1439,10 +1440,10 @@ IceInternal::RoutableReference::getConnectionNoRouterInfoAsync(
         void setException(std::exception_ptr ex) final { _exception(ex); }
 
         Callback(
-            const RoutableReferencePtr& reference,
+            RoutableReferencePtr reference,
             function<void(ConnectionIPtr, bool)> response,
             function<void(std::exception_ptr)> exception)
-            : _reference(reference),
+            : _reference(std::move(reference)),
               _response(std::move(response)),
               _exception(std::move(exception))
         {

--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -29,7 +29,6 @@
 
 #include <algorithm>
 #include <functional>
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/RetryQueue.cpp
+++ b/cpp/src/Ice/RetryQueue.cpp
@@ -10,18 +10,16 @@
 #include "TraceLevels.h"
 
 #include <stdexcept>
+#include <utility>
 
 using namespace std;
 using namespace Ice;
 using namespace IceInternal;
 
-IceInternal::RetryTask::RetryTask(
-    const InstancePtr& instance,
-    const RetryQueuePtr& queue,
-    const ProxyOutgoingAsyncBasePtr& outAsync)
-    : _instance(instance),
-      _queue(queue),
-      _outAsync(outAsync)
+IceInternal::RetryTask::RetryTask(InstancePtr instance, RetryQueuePtr queue, ProxyOutgoingAsyncBasePtr outAsync)
+    : _instance(std::move(instance)),
+      _queue(std::move(queue)),
+      _outAsync(std::move(outAsync))
 {
 }
 
@@ -76,7 +74,7 @@ IceInternal::RetryTask::destroy()
     }
 }
 
-IceInternal::RetryQueue::RetryQueue(const InstancePtr& instance) : _instance(instance) {}
+IceInternal::RetryQueue::RetryQueue(InstancePtr instance) : _instance(std::move(instance)) {}
 
 void
 IceInternal::RetryQueue::add(const ProxyOutgoingAsyncBasePtr& out, int interval)

--- a/cpp/src/Ice/RetryQueue.cpp
+++ b/cpp/src/Ice/RetryQueue.cpp
@@ -10,7 +10,6 @@
 #include "TraceLevels.h"
 
 #include <stdexcept>
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/RetryQueue.h
+++ b/cpp/src/Ice/RetryQueue.h
@@ -23,7 +23,7 @@ namespace IceInternal
     class RetryTask : public TimerTask, public CancellationHandler, public std::enable_shared_from_this<RetryTask>
     {
     public:
-        RetryTask(const InstancePtr&, const RetryQueuePtr&, const ProxyOutgoingAsyncBasePtr&);
+        RetryTask(InstancePtr, RetryQueuePtr, ProxyOutgoingAsyncBasePtr);
 
         void runTimerTask() override;
 
@@ -41,7 +41,7 @@ namespace IceInternal
     class RetryQueue : public std::enable_shared_from_this<RetryQueue>
     {
     public:
-        RetryQueue(const InstancePtr&);
+        RetryQueue(InstancePtr);
 
         void add(const ProxyOutgoingAsyncBasePtr&, int);
         void destroy();

--- a/cpp/src/Ice/RouterInfo.cpp
+++ b/cpp/src/Ice/RouterInfo.cpp
@@ -10,7 +10,6 @@
 #include "Reference.h"
 
 #include <cassert>
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/RouterInfo.cpp
+++ b/cpp/src/Ice/RouterInfo.cpp
@@ -10,6 +10,7 @@
 #include "Reference.h"
 
 #include <cassert>
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -85,7 +86,7 @@ IceInternal::RouterManager::erase(const RouterPrx& router)
     }
 }
 
-IceInternal::RouterInfo::RouterInfo(const RouterPrx& router) : _router(router), _hasRoutingTable(false) {}
+IceInternal::RouterInfo::RouterInfo(RouterPrx router) : _router(std::move(router)), _hasRoutingTable(false) {}
 
 void
 IceInternal::RouterInfo::destroy()

--- a/cpp/src/Ice/RouterInfo.h
+++ b/cpp/src/Ice/RouterInfo.h
@@ -48,7 +48,7 @@ namespace IceInternal
     class RouterInfo final : public std::enable_shared_from_this<RouterInfo>
     {
     public:
-        RouterInfo(const Ice::RouterPrx&);
+        RouterInfo(Ice::RouterPrx);
 
         void destroy();
 

--- a/cpp/src/Ice/SSL/DistinguishedName.h
+++ b/cpp/src/Ice/SSL/DistinguishedName.h
@@ -9,7 +9,6 @@
 
 #include <list>
 #include <string>
-#include <utility>
 
 namespace Ice::SSL
 {

--- a/cpp/src/Ice/SSL/RFC2253.cpp
+++ b/cpp/src/Ice/SSL/RFC2253.cpp
@@ -9,7 +9,6 @@
 
 #include <cassert>
 #include <string>
-#include <utility>
 
 using namespace std;
 using namespace Ice::SSL;

--- a/cpp/src/Ice/SSL/SSLAcceptorI.cpp
+++ b/cpp/src/Ice/SSL/SSLAcceptorI.cpp
@@ -3,13 +3,11 @@
 //
 
 #include "SSLAcceptorI.h"
-
 #include "Ice/LocalExceptions.h"
 #include "SSLEndpointI.h"
 #include "SSLEngine.h"
 #include "SSLInstance.h"
 #include "SSLUtil.h"
-#include <utility>
 
 #if defined(_WIN32)
 #    include "SchannelEngine.h"

--- a/cpp/src/Ice/SSL/SSLAcceptorI.cpp
+++ b/cpp/src/Ice/SSL/SSLAcceptorI.cpp
@@ -3,11 +3,13 @@
 //
 
 #include "SSLAcceptorI.h"
+
 #include "Ice/LocalExceptions.h"
 #include "SSLEndpointI.h"
 #include "SSLEngine.h"
 #include "SSLInstance.h"
 #include "SSLUtil.h"
+#include <utility>
 
 #if defined(_WIN32)
 #    include "SchannelEngine.h"
@@ -112,15 +114,15 @@ Ice::SSL::AcceptorI::toDetailedString() const
 }
 
 Ice::SSL::AcceptorI::AcceptorI(
-    const EndpointIPtr& endpoint,
-    const InstancePtr& instance,
-    const IceInternal::AcceptorPtr& del,
-    const string& adapterName,
+    EndpointIPtr endpoint,
+    InstancePtr instance,
+    IceInternal::AcceptorPtr del,
+    string adapterName,
     const optional<Ice::SSL::ServerAuthenticationOptions>& serverAuthenticationOptions)
-    : _endpoint(endpoint),
-      _instance(instance),
-      _delegate(del),
-      _adapterName(adapterName),
+    : _endpoint(std::move(endpoint)),
+      _instance(std::move(instance)),
+      _delegate(std::move(del)),
+      _adapterName(std::move(adapterName)),
       _serverAuthenticationOptions(serverAuthenticationOptions)
 {
 }

--- a/cpp/src/Ice/SSL/SSLAcceptorI.h
+++ b/cpp/src/Ice/SSL/SSLAcceptorI.h
@@ -20,10 +20,10 @@ namespace Ice::SSL
     {
     public:
         AcceptorI(
-            const EndpointIPtr&,
-            const InstancePtr&,
-            const IceInternal::AcceptorPtr&,
-            const std::string&,
+            EndpointIPtr,
+            InstancePtr,
+            IceInternal::AcceptorPtr,
+            std::string,
             const std::optional<Ice::SSL::ServerAuthenticationOptions>&);
         ~AcceptorI() override;
         IceInternal::NativeInfoPtr getNativeInfo() final;

--- a/cpp/src/Ice/SSL/SSLConnectorI.cpp
+++ b/cpp/src/Ice/SSL/SSLConnectorI.cpp
@@ -3,10 +3,6 @@
 //
 
 #include "SSLConnectorI.h"
-
-#include "SSLInstance.h"
-#include <utility>
-
 #include "../NetworkProxy.h"
 #include "../StreamSocket.h"
 #include "Ice/Communicator.h"
@@ -15,6 +11,7 @@
 #include "Ice/SSL/ClientAuthenticationOptions.h"
 #include "SSLEndpointI.h"
 #include "SSLEngine.h"
+#include "SSLInstance.h"
 #include "SSLUtil.h"
 
 #if defined(ICE_USE_SCHANNEL)

--- a/cpp/src/Ice/SSL/SSLConnectorI.cpp
+++ b/cpp/src/Ice/SSL/SSLConnectorI.cpp
@@ -3,7 +3,9 @@
 //
 
 #include "SSLConnectorI.h"
+
 #include "SSLInstance.h"
+#include <utility>
 
 #include "../NetworkProxy.h"
 #include "../StreamSocket.h"
@@ -92,10 +94,10 @@ Ice::SSL::ConnectorI::operator<(const IceInternal::Connector& r) const
     return Ice::targetLess(_delegate, p->_delegate);
 }
 
-Ice::SSL::ConnectorI::ConnectorI(const InstancePtr& instance, const IceInternal::ConnectorPtr& del, const string& h)
-    : _instance(instance),
-      _delegate(del),
-      _host(h)
+Ice::SSL::ConnectorI::ConnectorI(InstancePtr instance, IceInternal::ConnectorPtr del, string h)
+    : _instance(std::move(instance)),
+      _delegate(std::move(del)),
+      _host(std::move(h))
 {
 }
 

--- a/cpp/src/Ice/SSL/SSLConnectorI.h
+++ b/cpp/src/Ice/SSL/SSLConnectorI.h
@@ -18,7 +18,7 @@ namespace Ice::SSL
     class ConnectorI final : public IceInternal::Connector
     {
     public:
-        ConnectorI(const InstancePtr&, const IceInternal::ConnectorPtr&, const std::string&);
+        ConnectorI(InstancePtr, IceInternal::ConnectorPtr, std::string);
         ~ConnectorI() override;
         IceInternal::TransceiverPtr connect() final;
 

--- a/cpp/src/Ice/SSL/SSLConnectorI.h
+++ b/cpp/src/Ice/SSL/SSLConnectorI.h
@@ -8,7 +8,6 @@
 #include "../Connector.h"
 #include "../Network.h"
 #include "../TransceiverF.h"
-
 #include "SSLInstanceF.h"
 
 namespace Ice::SSL

--- a/cpp/src/Ice/SSL/SSLEndpointI.cpp
+++ b/cpp/src/Ice/SSL/SSLEndpointI.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "SSLEndpointI.h"
-
 #include "../DefaultsAndOverrides.h"
 #include "../EndpointFactoryManager.h"
 #include "../HashUtil.h"
@@ -15,7 +14,6 @@
 #include "SSLAcceptorI.h"
 #include "SSLConnectorI.h"
 #include "SSLInstance.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/SSL/SSLEndpointI.cpp
+++ b/cpp/src/Ice/SSL/SSLEndpointI.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "SSLEndpointI.h"
+
 #include "../DefaultsAndOverrides.h"
 #include "../EndpointFactoryManager.h"
 #include "../HashUtil.h"
@@ -14,6 +15,7 @@
 #include "SSLAcceptorI.h"
 #include "SSLConnectorI.h"
 #include "SSLInstance.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -81,9 +83,9 @@ Ice::SSL::EndpointInfo::~EndpointInfo()
     // out of line to avoid weak vtable
 }
 
-Ice::SSL::EndpointI::EndpointI(const InstancePtr& instance, const IceInternal::EndpointIPtr& del)
-    : _instance(instance),
-      _delegate(del)
+Ice::SSL::EndpointI::EndpointI(InstancePtr instance, IceInternal::EndpointIPtr del)
+    : _instance(std::move(instance)),
+      _delegate(std::move(del))
 {
 }
 

--- a/cpp/src/Ice/SSL/SSLEndpointI.h
+++ b/cpp/src/Ice/SSL/SSLEndpointI.h
@@ -18,7 +18,7 @@ namespace Ice::SSL
     class EndpointI final : public IceInternal::EndpointI, public std::enable_shared_from_this<EndpointI>
     {
     public:
-        EndpointI(const InstancePtr&, const IceInternal::EndpointIPtr&);
+        EndpointI(InstancePtr, IceInternal::EndpointIPtr);
 
         void streamWriteImpl(Ice::OutputStream*) const final;
 

--- a/cpp/src/Ice/SSL/SSLUtil.h
+++ b/cpp/src/Ice/SSL/SSLUtil.h
@@ -10,7 +10,6 @@
 
 #include <optional>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace Ice::SSL

--- a/cpp/src/Ice/SSL/SecureTransportTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportTransceiverI.cpp
@@ -11,6 +11,7 @@
 #include "SecureTransportUtil.h"
 
 #include <sstream>
+#include <utility>
 
 // Disable deprecation warnings from SecureTransport APIs
 #include "../DisableWarnings.h"
@@ -535,15 +536,15 @@ Ice::SSL::SecureTransport::TransceiverI::setBufferSize(int rcvSize, int sndSize)
 
 Ice::SSL::SecureTransport::TransceiverI::TransceiverI(
     const Ice::SSL::InstancePtr& instance,
-    const IceInternal::TransceiverPtr& delegate,
-    const string& adapterName,
+    IceInternal::TransceiverPtr delegate,
+    string adapterName,
     const ServerAuthenticationOptions& serverAuthenticationOptions)
     : _instance(instance),
       _engine(dynamic_pointer_cast<Ice::SSL::SecureTransport::SSLEngine>(instance->engine())),
       _host(""),
-      _adapterName(adapterName),
+      _adapterName(std::move(adapterName)),
       _incoming(true),
-      _delegate(delegate),
+      _delegate(std::move(delegate)),
       _connected(false),
       _buffered(0),
       _sslNewSessionCallback(serverAuthenticationOptions.sslNewSessionCallback),
@@ -557,15 +558,15 @@ Ice::SSL::SecureTransport::TransceiverI::TransceiverI(
 
 Ice::SSL::SecureTransport::TransceiverI::TransceiverI(
     const Ice::SSL::InstancePtr& instance,
-    const IceInternal::TransceiverPtr& delegate,
-    const string& host,
+    IceInternal::TransceiverPtr delegate,
+    string host,
     const ClientAuthenticationOptions& clientAuthenticationOptions)
     : _instance(instance),
       _engine(dynamic_pointer_cast<Ice::SSL::SecureTransport::SSLEngine>(instance->engine())),
-      _host(host),
+      _host(std::move(host)),
       _adapterName(""),
       _incoming(false),
-      _delegate(delegate),
+      _delegate(std::move(delegate)),
       _connected(false),
       _buffered(0),
       _sslNewSessionCallback(clientAuthenticationOptions.sslNewSessionCallback),

--- a/cpp/src/Ice/SSL/SecureTransportTransceiverI.h
+++ b/cpp/src/Ice/SSL/SecureTransportTransceiverI.h
@@ -27,13 +27,13 @@ namespace Ice::SSL::SecureTransport
     public:
         TransceiverI(
             const InstancePtr&,
-            const IceInternal::TransceiverPtr&,
-            const std::string&,
+            IceInternal::TransceiverPtr,
+            std::string,
             const Ice::SSL::ServerAuthenticationOptions&);
         TransceiverI(
             const InstancePtr&,
-            const IceInternal::TransceiverPtr&,
-            const std::string&,
+            IceInternal::TransceiverPtr,
+            std::string,
             const Ice::SSL::ClientAuthenticationOptions&);
         ~TransceiverI();
 

--- a/cpp/src/Ice/SSL/TrustManager.cpp
+++ b/cpp/src/Ice/SSL/TrustManager.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "TrustManager.h"
+
 #include "../Instance.h"
 #include "../Network.h"
 #include "Ice/Communicator.h"
@@ -13,11 +14,12 @@
 #include "Ice/SSL/ConnectionInfo.h"
 #include "RFC2253.h"
 #include "SSLUtil.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice::SSL;
 
-TrustManager::TrustManager(const IceInternal::InstancePtr& instance) : _instance(instance)
+TrustManager::TrustManager(IceInternal::InstancePtr instance) : _instance(std::move(instance))
 {
     Ice::PropertiesPtr properties = _instance->initializationData().properties;
     _traceLevel = properties->getIcePropertyAsInt("IceSSL.Trace.Security");

--- a/cpp/src/Ice/SSL/TrustManager.cpp
+++ b/cpp/src/Ice/SSL/TrustManager.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "TrustManager.h"
-
 #include "../Instance.h"
 #include "../Network.h"
 #include "Ice/Communicator.h"
@@ -14,7 +13,6 @@
 #include "Ice/SSL/ConnectionInfo.h"
 #include "RFC2253.h"
 #include "SSLUtil.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice::SSL;

--- a/cpp/src/Ice/SSL/TrustManager.h
+++ b/cpp/src/Ice/SSL/TrustManager.h
@@ -19,7 +19,7 @@ namespace Ice::SSL
     class TrustManager
     {
     public:
-        TrustManager(const IceInternal::InstancePtr&);
+        TrustManager(IceInternal::InstancePtr);
 
         [[nodiscard]] bool verify(const ConnectionInfoPtr&) const;
 

--- a/cpp/src/Ice/Selector.cpp
+++ b/cpp/src/Ice/Selector.cpp
@@ -15,7 +15,6 @@
 
 #include <chrono>
 #include <thread>
-#include <utility>
 
 using namespace std;
 using namespace IceInternal;

--- a/cpp/src/Ice/Selector.cpp
+++ b/cpp/src/Ice/Selector.cpp
@@ -15,6 +15,7 @@
 
 #include <chrono>
 #include <thread>
+#include <utility>
 
 using namespace std;
 using namespace IceInternal;
@@ -174,7 +175,7 @@ Selector::completed(EventHandler* handler, SocketOperation op)
 
 #elif defined(ICE_USE_KQUEUE) || defined(ICE_USE_EPOLL) || defined(ICE_USE_POLL)
 
-Selector::Selector(const InstancePtr& instance) : _instance(instance), _interrupted(false)
+Selector::Selector(InstancePtr instance) : _instance(std::move(instance)), _interrupted(false)
 {
     SOCKET fds[2];
     createPipe(fds);

--- a/cpp/src/Ice/Selector.h
+++ b/cpp/src/Ice/Selector.h
@@ -79,7 +79,7 @@ namespace IceInternal
     class Selector final
     {
     public:
-        Selector(const InstancePtr&);
+        Selector(InstancePtr);
 
         void destroy();
 

--- a/cpp/src/Ice/Selector.h
+++ b/cpp/src/Ice/Selector.h
@@ -5,10 +5,9 @@
 #ifndef ICE_SELECTOR_H
 #define ICE_SELECTOR_H
 
-#include "Ice/StringUtil.h"
-
 #include "EventHandlerF.h"
 #include "Ice/InstanceF.h"
+#include "Ice/StringUtil.h"
 #include "Network.h"
 #include "UniqueRef.h"
 

--- a/cpp/src/Ice/SharedContext.h
+++ b/cpp/src/Ice/SharedContext.h
@@ -8,7 +8,6 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <utility>
 
 namespace Ice
 {

--- a/cpp/src/Ice/SharedContext.h
+++ b/cpp/src/Ice/SharedContext.h
@@ -22,7 +22,7 @@ namespace IceInternal
     public:
         SharedContext() {}
 
-        SharedContext(Ice::Context  val) : _val(std::move(val)) {}
+        SharedContext(Ice::Context val) : _val(std::move(val)) {}
 
         inline const Ice::Context& getValue() { return _val; }
 

--- a/cpp/src/Ice/SharedContext.h
+++ b/cpp/src/Ice/SharedContext.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 
 namespace Ice
 {
@@ -21,7 +22,7 @@ namespace IceInternal
     public:
         SharedContext() {}
 
-        SharedContext(const Ice::Context& val) : _val(val) {}
+        SharedContext(Ice::Context  val) : _val(std::move(val)) {}
 
         inline const Ice::Context& getValue() { return _val; }
 

--- a/cpp/src/Ice/StreamSocket.cpp
+++ b/cpp/src/Ice/StreamSocket.cpp
@@ -3,18 +3,20 @@
 //
 
 #include "StreamSocket.h"
+
 #include "NetworkProxy.h"
 #include "ProtocolInstance.h"
+#include <utility>
 
 using namespace IceInternal;
 
 StreamSocket::StreamSocket(
-    const ProtocolInstancePtr& instance,
+    ProtocolInstancePtr instance,
     const NetworkProxyPtr& proxy,
     const Address& addr,
     const Address& sourceAddr)
     : NativeInfo(createSocket(false, proxy ? proxy->getAddress() : addr)),
-      _instance(instance),
+      _instance(std::move(instance)),
       _proxy(proxy),
       _addr(addr),
       _sourceAddr(sourceAddr),
@@ -43,9 +45,9 @@ StreamSocket::StreamSocket(
     }
 }
 
-StreamSocket::StreamSocket(const ProtocolInstancePtr& instance, SOCKET fd)
+StreamSocket::StreamSocket(ProtocolInstancePtr instance, SOCKET fd)
     : NativeInfo(fd),
-      _instance(instance),
+      _instance(std::move(instance)),
       _addr(),
       _sourceAddr(),
       _state(StateConnected)

--- a/cpp/src/Ice/StreamSocket.cpp
+++ b/cpp/src/Ice/StreamSocket.cpp
@@ -3,10 +3,8 @@
 //
 
 #include "StreamSocket.h"
-
 #include "NetworkProxy.h"
 #include "ProtocolInstance.h"
-#include <utility>
 
 using namespace IceInternal;
 

--- a/cpp/src/Ice/StreamSocket.h
+++ b/cpp/src/Ice/StreamSocket.h
@@ -16,8 +16,8 @@ namespace IceInternal
     class ICE_API StreamSocket : public NativeInfo
     {
     public:
-        StreamSocket(const ProtocolInstancePtr&, const NetworkProxyPtr&, const Address&, const Address&);
-        StreamSocket(const ProtocolInstancePtr&, SOCKET);
+        StreamSocket(ProtocolInstancePtr, const NetworkProxyPtr&, const Address&, const Address&);
+        StreamSocket(ProtocolInstancePtr, SOCKET);
         ~StreamSocket() override;
 
         SocketOperation connect(Buffer&, Buffer&);

--- a/cpp/src/Ice/TcpAcceptor.cpp
+++ b/cpp/src/Ice/TcpAcceptor.cpp
@@ -13,8 +13,10 @@
 #    include "ProtocolInstance.h"
 #    include "StreamSocket.h"
 #    include "TcpAcceptor.h"
+
 #    include "TcpEndpointI.h"
 #    include "TcpTransceiver.h"
+#    include <utility>
 
 #    if defined(ICE_USE_IOCP)
 #        include <Mswsock.h>
@@ -178,11 +180,11 @@ IceInternal::TcpAcceptor::effectivePort() const
 }
 
 IceInternal::TcpAcceptor::TcpAcceptor(
-    const TcpEndpointIPtr& endpoint,
+    TcpEndpointIPtr endpoint,
     const ProtocolInstancePtr& instance,
     const string& host,
     int port)
-    : _endpoint(endpoint),
+    : _endpoint(std::move(endpoint)),
       _instance(instance),
       _addr(getAddressForServer(host, port, _instance->protocolSupport(), instance->preferIPv6(), true))
 #    ifdef ICE_USE_IOCP

--- a/cpp/src/Ice/TcpAcceptor.h
+++ b/cpp/src/Ice/TcpAcceptor.h
@@ -17,7 +17,7 @@ namespace IceInternal
     class TcpAcceptor final : public Acceptor, public NativeInfo, public std::enable_shared_from_this<TcpAcceptor>
     {
     public:
-        TcpAcceptor(const TcpEndpointIPtr&, const ProtocolInstancePtr&, const std::string&, int);
+        TcpAcceptor(TcpEndpointIPtr, const ProtocolInstancePtr&, const std::string&, int);
         ~TcpAcceptor() override;
         NativeInfoPtr getNativeInfo() final;
 #if defined(ICE_USE_IOCP)

--- a/cpp/src/Ice/TcpConnector.cpp
+++ b/cpp/src/Ice/TcpConnector.cpp
@@ -12,8 +12,10 @@
 #    include "ProtocolInstance.h"
 #    include "StreamSocket.h"
 #    include "TcpConnector.h"
+
 #    include "TcpEndpointI.h"
 #    include "TcpTransceiver.h"
+#    include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -109,18 +111,18 @@ IceInternal::TcpConnector::operator<(const Connector& r) const
 }
 
 IceInternal::TcpConnector::TcpConnector(
-    const ProtocolInstancePtr& instance,
+    ProtocolInstancePtr instance,
     const Address& addr,
-    const NetworkProxyPtr& proxy,
+    NetworkProxyPtr proxy,
     const Address& sourceAddr,
     int32_t timeout,
-    const string& connectionId)
-    : _instance(instance),
+    string connectionId)
+    : _instance(std::move(instance)),
       _addr(addr),
-      _proxy(proxy),
+      _proxy(std::move(proxy)),
       _sourceAddr(sourceAddr),
       _timeout(timeout),
-      _connectionId(connectionId)
+      _connectionId(std::move(connectionId))
 {
 }
 

--- a/cpp/src/Ice/TcpConnector.h
+++ b/cpp/src/Ice/TcpConnector.h
@@ -15,13 +15,7 @@ namespace IceInternal
     class TcpConnector final : public Connector
     {
     public:
-        TcpConnector(
-            const ProtocolInstancePtr&,
-            const Address&,
-            const NetworkProxyPtr&,
-            const Address&,
-            std::int32_t,
-            const std::string&);
+        TcpConnector(ProtocolInstancePtr, const Address&, NetworkProxyPtr, const Address&, std::int32_t, std::string);
         ~TcpConnector() override;
         TransceiverPtr connect() final;
 

--- a/cpp/src/Ice/TcpEndpointI.cpp
+++ b/cpp/src/Ice/TcpEndpointI.cpp
@@ -15,7 +15,9 @@
 #    include "TcpAcceptor.h"
 #    include "TcpConnector.h"
 #    include "TcpEndpointI.h"
+
 #    include "TcpTransceiver.h"
+#    include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -353,7 +355,7 @@ IceInternal::TcpEndpointI::createEndpoint(const string& host, int port, const st
     return make_shared<TcpEndpointI>(_instance, host, port, _sourceAddr, _timeout, connectionId, _compress);
 }
 
-IceInternal::TcpEndpointFactory::TcpEndpointFactory(const ProtocolInstancePtr& instance) : _instance(instance) {}
+IceInternal::TcpEndpointFactory::TcpEndpointFactory(ProtocolInstancePtr instance) : _instance(std::move(instance)) {}
 
 IceInternal::TcpEndpointFactory::~TcpEndpointFactory() {}
 

--- a/cpp/src/Ice/TcpEndpointI.h
+++ b/cpp/src/Ice/TcpEndpointI.h
@@ -70,7 +70,7 @@ namespace IceInternal
     class TcpEndpointFactory final : public EndpointFactory
     {
     public:
-        TcpEndpointFactory(const ProtocolInstancePtr&);
+        TcpEndpointFactory(ProtocolInstancePtr);
         ~TcpEndpointFactory() override;
 
         [[nodiscard]] std::int16_t type() const final;

--- a/cpp/src/Ice/TcpTransceiver.cpp
+++ b/cpp/src/Ice/TcpTransceiver.cpp
@@ -13,6 +13,8 @@
 #    include "ProtocolInstance.h"
 #    include "TcpTransceiver.h"
 
+#    include <utility>
+
 using namespace std;
 using namespace Ice;
 using namespace IceInternal;
@@ -137,9 +139,9 @@ IceInternal::TcpTransceiver::setBufferSize(int rcvSize, int sndSize)
     _stream->setBufferSize(rcvSize, sndSize);
 }
 
-IceInternal::TcpTransceiver::TcpTransceiver(const ProtocolInstancePtr& instance, const StreamSocketPtr& stream)
-    : _instance(instance),
-      _stream(stream)
+IceInternal::TcpTransceiver::TcpTransceiver(ProtocolInstancePtr instance, StreamSocketPtr stream)
+    : _instance(std::move(instance)),
+      _stream(std::move(stream))
 {
 }
 

--- a/cpp/src/Ice/TcpTransceiver.h
+++ b/cpp/src/Ice/TcpTransceiver.h
@@ -18,7 +18,7 @@ namespace IceInternal
     class TcpTransceiver final : public Transceiver
     {
     public:
-        TcpTransceiver(const ProtocolInstancePtr&, const StreamSocketPtr&);
+        TcpTransceiver(ProtocolInstancePtr, StreamSocketPtr);
         ~TcpTransceiver();
         NativeInfoPtr getNativeInfo() final;
 

--- a/cpp/src/Ice/ThreadPool.cpp
+++ b/cpp/src/Ice/ThreadPool.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "ThreadPool.h"
-
 #include "EventHandler.h"
 #include "Ice/LocalExceptions.h"
 #include "Ice/LoggerUtil.h"
@@ -13,7 +12,6 @@
 #include "ObjectAdapterFactory.h"
 #include "PropertyUtil.h"
 #include "TraceLevels.h"
-#include <utility>
 
 #if defined(__FreeBSD__)
 #    include <sys/sysctl.h>

--- a/cpp/src/Ice/ThreadPool.h
+++ b/cpp/src/Ice/ThreadPool.h
@@ -32,7 +32,7 @@ namespace IceInternal
         class EventHandlerThread final : public std::enable_shared_from_this<EventHandlerThread>
         {
         public:
-            EventHandlerThread(const ThreadPoolPtr&, const std::string&);
+            EventHandlerThread(ThreadPoolPtr, std::string);
             void start();
             void run();
             void join();
@@ -78,7 +78,7 @@ namespace IceInternal
         [[nodiscard]] std::string prefix() const;
 
     private:
-        ThreadPool(const InstancePtr&, const std::string&, int);
+        ThreadPool(const InstancePtr&, std::string, int);
         void initialize();
 
         void run(const EventHandlerThreadPtr&);
@@ -136,7 +136,7 @@ namespace IceInternal
     class ThreadPoolCurrent
     {
     public:
-        ThreadPoolCurrent(const ThreadPoolPtr&, const ThreadPool::EventHandlerThreadPtr&);
+        ThreadPoolCurrent(const ThreadPoolPtr&, ThreadPool::EventHandlerThreadPtr);
 
         SocketOperation operation;
 

--- a/cpp/src/Ice/UdpConnector.cpp
+++ b/cpp/src/Ice/UdpConnector.cpp
@@ -3,10 +3,12 @@
 //
 
 #include "UdpConnector.h"
+
 #include "Ice/LocalExceptions.h"
 #include "ProtocolInstance.h"
 #include "UdpEndpointI.h"
 #include "UdpTransceiver.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -115,18 +117,18 @@ IceInternal::UdpConnector::operator<(const Connector& r) const
 }
 
 IceInternal::UdpConnector::UdpConnector(
-    const ProtocolInstancePtr& instance,
+    ProtocolInstancePtr instance,
     const Address& addr,
     const Address& sourceAddr,
-    const string& mcastInterface,
+    string mcastInterface,
     int mcastTtl,
-    const std::string& connectionId)
-    : _instance(instance),
+    std::string connectionId)
+    : _instance(std::move(instance)),
       _addr(addr),
       _sourceAddr(sourceAddr),
-      _mcastInterface(mcastInterface),
+      _mcastInterface(std::move(mcastInterface)),
       _mcastTtl(mcastTtl),
-      _connectionId(connectionId)
+      _connectionId(std::move(connectionId))
 {
 }
 

--- a/cpp/src/Ice/UdpConnector.cpp
+++ b/cpp/src/Ice/UdpConnector.cpp
@@ -3,12 +3,10 @@
 //
 
 #include "UdpConnector.h"
-
 #include "Ice/LocalExceptions.h"
 #include "ProtocolInstance.h"
 #include "UdpEndpointI.h"
 #include "UdpTransceiver.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/UdpConnector.h
+++ b/cpp/src/Ice/UdpConnector.h
@@ -15,13 +15,7 @@ namespace IceInternal
     class UdpConnector final : public Connector
     {
     public:
-        UdpConnector(
-            const ProtocolInstancePtr&,
-            const Address&,
-            const Address&,
-            const std::string&,
-            int,
-            const std::string&);
+        UdpConnector(ProtocolInstancePtr, const Address&, const Address&, std::string, int, std::string);
 
         ~UdpConnector() override;
         TransceiverPtr connect() final;

--- a/cpp/src/Ice/UdpEndpointI.cpp
+++ b/cpp/src/Ice/UdpEndpointI.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "UdpEndpointI.h"
-
 #include "HashUtil.h"
 #include "Ice/InputStream.h"
 #include "Ice/LocalExceptions.h"
@@ -13,7 +12,6 @@
 #include "ProtocolInstance.h"
 #include "UdpConnector.h"
 #include "UdpTransceiver.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/UdpEndpointI.cpp
+++ b/cpp/src/Ice/UdpEndpointI.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "UdpEndpointI.h"
+
 #include "HashUtil.h"
 #include "Ice/InputStream.h"
 #include "Ice/LocalExceptions.h"
@@ -12,6 +13,7 @@
 #include "ProtocolInstance.h"
 #include "UdpConnector.h"
 #include "UdpTransceiver.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -40,13 +42,13 @@ IceInternal::UdpEndpointI::UdpEndpointI(
     const string& host,
     int32_t port,
     const Address& sourceAddr,
-    const string& mcastInterface,
+    string mcastInterface,
     int32_t mttl,
     const string& connectionId,
     bool compress)
     : IPEndpointI(instance, host, port, sourceAddr, connectionId),
       _mcastTtl(mttl),
-      _mcastInterface(mcastInterface),
+      _mcastInterface(std::move(mcastInterface)),
       _compress(compress)
 {
 }
@@ -435,7 +437,7 @@ IceInternal::UdpEndpointI::createEndpoint(const string& host, int port, const st
         UdpEndpointI>(_instance, host, port, _sourceAddr, _mcastInterface, _mcastTtl, connectionId, _compress);
 }
 
-IceInternal::UdpEndpointFactory::UdpEndpointFactory(const ProtocolInstancePtr& instance) : _instance(instance) {}
+IceInternal::UdpEndpointFactory::UdpEndpointFactory(ProtocolInstancePtr instance) : _instance(std::move(instance)) {}
 
 IceInternal::UdpEndpointFactory::~UdpEndpointFactory() {}
 

--- a/cpp/src/Ice/UdpEndpointI.h
+++ b/cpp/src/Ice/UdpEndpointI.h
@@ -23,7 +23,7 @@ namespace IceInternal
             const std::string&,
             std::int32_t,
             const Address&,
-            const std::string&,
+            std::string,
             std::int32_t,
             const std::string&,
             bool);
@@ -76,7 +76,7 @@ namespace IceInternal
     class UdpEndpointFactory final : public EndpointFactory
     {
     public:
-        UdpEndpointFactory(const ProtocolInstancePtr&);
+        UdpEndpointFactory(ProtocolInstancePtr);
         ~UdpEndpointFactory() override;
 
         [[nodiscard]] std::int16_t type() const final;

--- a/cpp/src/Ice/UdpTransceiver.cpp
+++ b/cpp/src/Ice/UdpTransceiver.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "UdpTransceiver.h"
-
 #include "Ice/Buffer.h"
 #include "Ice/Connection.h"
 #include "Ice/LocalExceptions.h"
@@ -12,7 +11,6 @@
 #include "Ice/StringUtil.h"
 #include "ProtocolInstance.h"
 #include "UdpEndpointI.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/UdpTransceiver.cpp
+++ b/cpp/src/Ice/UdpTransceiver.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "UdpTransceiver.h"
+
 #include "Ice/Buffer.h"
 #include "Ice/Connection.h"
 #include "Ice/LocalExceptions.h"
@@ -11,6 +12,7 @@
 #include "Ice/StringUtil.h"
 #include "ProtocolInstance.h"
 #include "UdpEndpointI.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -601,12 +603,12 @@ IceInternal::UdpTransceiver::effectivePort() const
 }
 
 IceInternal::UdpTransceiver::UdpTransceiver(
-    const ProtocolInstancePtr& instance,
+    ProtocolInstancePtr instance,
     const Address& addr,
     const Address& sourceAddr,
     const string& mcastInterface,
     int mcastTtl)
-    : _instance(instance),
+    : _instance(std::move(instance)),
       _incoming(false),
       _bound(false),
       _addr(addr),
@@ -664,17 +666,17 @@ IceInternal::UdpTransceiver::UdpTransceiver(
 }
 
 IceInternal::UdpTransceiver::UdpTransceiver(
-    const UdpEndpointIPtr& endpoint,
+    UdpEndpointIPtr endpoint,
     const ProtocolInstancePtr& instance,
     const string& host,
     int port,
-    const string& mcastInterface)
-    : _endpoint(endpoint),
+    string mcastInterface)
+    : _endpoint(std::move(endpoint)),
       _instance(instance),
       _incoming(true),
       _bound(false),
       _addr(getAddressForServer(host, port, instance->protocolSupport(), instance->preferIPv6(), true)),
-      _mcastInterface(mcastInterface),
+      _mcastInterface(std::move(mcastInterface)),
 #ifdef _WIN32
       _port(port),
 #endif

--- a/cpp/src/Ice/UdpTransceiver.h
+++ b/cpp/src/Ice/UdpTransceiver.h
@@ -26,8 +26,8 @@ namespace IceInternal
         };
 
     public:
-        UdpTransceiver(const ProtocolInstancePtr&, const Address&, const Address&, const std::string&, int);
-        UdpTransceiver(const UdpEndpointIPtr&, const ProtocolInstancePtr&, const std::string&, int, const std::string&);
+        UdpTransceiver(ProtocolInstancePtr, const Address&, const Address&, const std::string&, int);
+        UdpTransceiver(UdpEndpointIPtr, const ProtocolInstancePtr&, const std::string&, int, std::string);
 
         ~UdpTransceiver() final;
 

--- a/cpp/src/Ice/WSAcceptor.cpp
+++ b/cpp/src/Ice/WSAcceptor.cpp
@@ -3,10 +3,8 @@
 //
 
 #include "WSAcceptor.h"
-
 #include "WSEndpoint.h"
 #include "WSTransceiver.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/WSAcceptor.cpp
+++ b/cpp/src/Ice/WSAcceptor.cpp
@@ -3,8 +3,10 @@
 //
 
 #include "WSAcceptor.h"
+
 #include "WSEndpoint.h"
 #include "WSTransceiver.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -79,13 +81,10 @@ IceInternal::WSAcceptor::toDetailedString() const
     return _delegate->toDetailedString();
 }
 
-IceInternal::WSAcceptor::WSAcceptor(
-    const WSEndpointPtr& endpoint,
-    const ProtocolInstancePtr& instance,
-    const AcceptorPtr& del)
-    : _endpoint(endpoint),
-      _instance(instance),
-      _delegate(del)
+IceInternal::WSAcceptor::WSAcceptor(WSEndpointPtr endpoint, ProtocolInstancePtr instance, AcceptorPtr del)
+    : _endpoint(std::move(endpoint)),
+      _instance(std::move(instance)),
+      _delegate(std::move(del))
 {
 }
 

--- a/cpp/src/Ice/WSAcceptor.h
+++ b/cpp/src/Ice/WSAcceptor.h
@@ -18,7 +18,7 @@ namespace IceInternal
     class WSAcceptor final : public Acceptor, public NativeInfo
     {
     public:
-        WSAcceptor(const WSEndpointPtr&, const ProtocolInstancePtr&, const AcceptorPtr&);
+        WSAcceptor(WSEndpointPtr, ProtocolInstancePtr, AcceptorPtr);
         ~WSAcceptor() override;
         NativeInfoPtr getNativeInfo() final;
 #if defined(ICE_USE_IOCP)

--- a/cpp/src/Ice/WSConnector.cpp
+++ b/cpp/src/Ice/WSConnector.cpp
@@ -3,9 +3,11 @@
 //
 
 #include "WSConnector.h"
+
 #include "HttpParser.h"
 #include "WSEndpoint.h"
 #include "WSTransceiver.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -77,15 +79,11 @@ IceInternal::WSConnector::operator<(const Connector& r) const
     return Ice::targetLess(_delegate, p->_delegate);
 }
 
-IceInternal::WSConnector::WSConnector(
-    const ProtocolInstancePtr& instance,
-    const ConnectorPtr& del,
-    const string& host,
-    const string& resource)
-    : _instance(instance),
-      _delegate(del),
-      _host(host),
-      _resource(resource)
+IceInternal::WSConnector::WSConnector(ProtocolInstancePtr instance, ConnectorPtr del, string host, string resource)
+    : _instance(std::move(instance)),
+      _delegate(std::move(del)),
+      _host(std::move(host)),
+      _resource(std::move(resource))
 {
 }
 

--- a/cpp/src/Ice/WSConnector.cpp
+++ b/cpp/src/Ice/WSConnector.cpp
@@ -3,11 +3,9 @@
 //
 
 #include "WSConnector.h"
-
 #include "HttpParser.h"
 #include "WSEndpoint.h"
 #include "WSTransceiver.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/WSConnector.h
+++ b/cpp/src/Ice/WSConnector.h
@@ -17,7 +17,7 @@ namespace IceInternal
     class WSConnector final : public Connector
     {
     public:
-        WSConnector(const ProtocolInstancePtr&, const ConnectorPtr&, const std::string&, const std::string&);
+        WSConnector(ProtocolInstancePtr, ConnectorPtr, std::string, std::string);
         ~WSConnector() override;
         TransceiverPtr connect() final;
 

--- a/cpp/src/Ice/WSEndpoint.cpp
+++ b/cpp/src/Ice/WSEndpoint.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "WSEndpoint.h"
-
 #include "EndpointFactoryManager.h"
 #include "HashUtil.h"
 #include "IPEndpointI.h"
@@ -13,7 +12,6 @@
 #include "Ice/OutputStream.h"
 #include "WSAcceptor.h"
 #include "WSConnector.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/WSEndpoint.cpp
+++ b/cpp/src/Ice/WSEndpoint.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "WSEndpoint.h"
+
 #include "EndpointFactoryManager.h"
 #include "HashUtil.h"
 #include "IPEndpointI.h"
@@ -12,6 +13,7 @@
 #include "Ice/OutputStream.h"
 #include "WSAcceptor.h"
 #include "WSConnector.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -77,16 +79,16 @@ WSEndpointFactoryPlugin::destroy()
 {
 }
 
-IceInternal::WSEndpoint::WSEndpoint(const ProtocolInstancePtr& instance, const EndpointIPtr& del, const string& res)
-    : _instance(instance),
-      _delegate(del),
-      _resource(res)
+IceInternal::WSEndpoint::WSEndpoint(ProtocolInstancePtr instance, EndpointIPtr del, string res)
+    : _instance(std::move(instance)),
+      _delegate(std::move(del)),
+      _resource(std::move(res))
 {
 }
 
-IceInternal::WSEndpoint::WSEndpoint(const ProtocolInstancePtr& inst, const EndpointIPtr& del, vector<string>& args)
-    : _instance(inst),
-      _delegate(del)
+IceInternal::WSEndpoint::WSEndpoint(ProtocolInstancePtr inst, EndpointIPtr del, vector<string>& args)
+    : _instance(std::move(inst)),
+      _delegate(std::move(del))
 {
     initWithOptions(args);
 
@@ -96,9 +98,9 @@ IceInternal::WSEndpoint::WSEndpoint(const ProtocolInstancePtr& inst, const Endpo
     }
 }
 
-IceInternal::WSEndpoint::WSEndpoint(const ProtocolInstancePtr& instance, const EndpointIPtr& del, InputStream* s)
-    : _instance(instance),
-      _delegate(del)
+IceInternal::WSEndpoint::WSEndpoint(ProtocolInstancePtr instance, EndpointIPtr del, InputStream* s)
+    : _instance(std::move(instance)),
+      _delegate(std::move(del))
 {
     s->read(const_cast<string&>(_resource), false);
 }

--- a/cpp/src/Ice/WSEndpoint.h
+++ b/cpp/src/Ice/WSEndpoint.h
@@ -20,9 +20,9 @@ namespace IceInternal
     class WSEndpoint final : public EndpointI, public std::enable_shared_from_this<WSEndpoint>
     {
     public:
-        WSEndpoint(const ProtocolInstancePtr&, const EndpointIPtr&, const std::string&);
-        WSEndpoint(const ProtocolInstancePtr&, const EndpointIPtr&, std::vector<std::string>&);
-        WSEndpoint(const ProtocolInstancePtr&, const EndpointIPtr&, Ice::InputStream*);
+        WSEndpoint(ProtocolInstancePtr, EndpointIPtr, std::string);
+        WSEndpoint(ProtocolInstancePtr, EndpointIPtr, std::vector<std::string>&);
+        WSEndpoint(ProtocolInstancePtr, EndpointIPtr, Ice::InputStream*);
 
         void streamWriteImpl(Ice::OutputStream*) const final;
 

--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -19,6 +19,7 @@
 
 #include <climits>
 #include <stdint.h>
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -816,14 +817,14 @@ IceInternal::WSTransceiver::setBufferSize(int rcvSize, int sndSize)
 }
 
 IceInternal::WSTransceiver::WSTransceiver(
-    const ProtocolInstancePtr& instance,
-    const TransceiverPtr& del,
-    const string& host,
-    const string& resource)
-    : _instance(instance),
-      _delegate(del),
-      _host(host),
-      _resource(resource),
+    ProtocolInstancePtr instance,
+    TransceiverPtr del,
+    string host,
+    string resource)
+    : _instance(std::move(instance)),
+      _delegate(std::move(del)),
+      _host(std::move(host)),
+      _resource(std::move(resource)),
       _incoming(false),
       _state(StateInitializeDelegate),
       _parser(make_shared<HttpParser>()),
@@ -849,9 +850,9 @@ IceInternal::WSTransceiver::WSTransceiver(
     //
 }
 
-IceInternal::WSTransceiver::WSTransceiver(const ProtocolInstancePtr& instance, const TransceiverPtr& del)
-    : _instance(instance),
-      _delegate(del),
+IceInternal::WSTransceiver::WSTransceiver(ProtocolInstancePtr instance, TransceiverPtr del)
+    : _instance(std::move(instance)),
+      _delegate(std::move(del)),
       _incoming(true),
       _state(StateInitializeDelegate),
       _parser(make_shared<HttpParser>()),

--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -19,7 +19,6 @@
 
 #include <climits>
 #include <stdint.h>
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/Ice/WSTransceiver.h
+++ b/cpp/src/Ice/WSTransceiver.h
@@ -6,11 +6,10 @@
 #define ICE_WS_TRANSCEIVER_I_H
 
 #include "HttpParser.h"
-#include "ProtocolInstance.h"
-
 #include "Ice/Buffer.h"
 #include "Ice/Logger.h"
 #include "Network.h"
+#include "ProtocolInstance.h"
 #include "Transceiver.h"
 
 namespace IceInternal

--- a/cpp/src/Ice/WSTransceiver.h
+++ b/cpp/src/Ice/WSTransceiver.h
@@ -21,8 +21,8 @@ namespace IceInternal
     class WSTransceiver final : public Transceiver
     {
     public:
-        WSTransceiver(const ProtocolInstancePtr&, const TransceiverPtr&, const std::string&, const std::string&);
-        WSTransceiver(const ProtocolInstancePtr&, const TransceiverPtr&);
+        WSTransceiver(ProtocolInstancePtr, TransceiverPtr, std::string, std::string);
+        WSTransceiver(ProtocolInstancePtr, TransceiverPtr);
         ~WSTransceiver();
 
         NativeInfoPtr getNativeInfo() final;

--- a/cpp/src/IceBT/AcceptorI.cpp
+++ b/cpp/src/IceBT/AcceptorI.cpp
@@ -3,18 +3,17 @@
 //
 
 #include "AcceptorI.h"
-#include "EndpointI.h"
-#include "Engine.h"
-#include "Instance.h"
-#include "TransceiverI.h"
-#include "Util.h"
-
 #include "../Ice/Network.h"
 #include "../Ice/StreamSocket.h"
+#include "EndpointI.h"
+#include "Engine.h"
 #include "Ice/Communicator.h"
 #include "Ice/LocalExceptions.h"
 #include "Ice/Properties.h"
 #include "Ice/StringUtil.h"
+#include "Instance.h"
+#include "TransceiverI.h"
+#include "Util.h"
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/IceBT/ConnectorI.cpp
+++ b/cpp/src/IceBT/ConnectorI.cpp
@@ -3,10 +3,9 @@
 //
 
 #include "ConnectorI.h"
+#include "Ice/LocalExceptions.h"
 #include "Instance.h"
 #include "TransceiverI.h"
-
-#include "Ice/LocalExceptions.h"
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/IceBT/ConnectorI.h
+++ b/cpp/src/IceBT/ConnectorI.h
@@ -5,12 +5,11 @@
 #ifndef ICE_BT_CONNECTOR_I_H
 #define ICE_BT_CONNECTOR_I_H
 
+#include "../Ice/Connector.h"
+#include "../Ice/TransceiverF.h"
 #include "Config.h"
 #include "Engine.h"
 #include "InstanceF.h"
-
-#include "../Ice/Connector.h"
-#include "../Ice/TransceiverF.h"
 
 namespace IceBT
 {

--- a/cpp/src/IceBT/StreamSocket.cpp
+++ b/cpp/src/IceBT/StreamSocket.cpp
@@ -3,12 +3,11 @@
 //
 
 #include "StreamSocket.h"
+#include "Ice/LoggerUtil.h"
+#include "Ice/Properties.h"
 #include "IceBT/EndpointInfo.h"
 #include "Instance.h"
 #include "Util.h"
-
-#include "Ice/LoggerUtil.h"
-#include "Ice/Properties.h"
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/IceBT/StreamSocket.h
+++ b/cpp/src/IceBT/StreamSocket.h
@@ -5,11 +5,10 @@
 #ifndef ICE_BT_STREAM_SOCKET_H
 #define ICE_BT_STREAM_SOCKET_H
 
-#include "Config.h"
-#include "InstanceF.h"
-
 #include "../Ice/Network.h"
+#include "Config.h"
 #include "Ice/Buffer.h"
+#include "InstanceF.h"
 
 namespace IceBT
 {

--- a/cpp/src/IceBT/TransceiverI.cpp
+++ b/cpp/src/IceBT/TransceiverI.cpp
@@ -4,12 +4,11 @@
 
 #include "TransceiverI.h"
 #include "Engine.h"
+#include "Ice/Connection.h"
+#include "Ice/LocalExceptions.h"
 #include "IceBT/ConnectionInfo.h"
 #include "Instance.h"
 #include "Util.h"
-
-#include "Ice/Connection.h"
-#include "Ice/LocalExceptions.h"
 
 #include "../Ice/DisableWarnings.h"
 

--- a/cpp/src/IceBT/TransceiverI.h
+++ b/cpp/src/IceBT/TransceiverI.h
@@ -5,11 +5,10 @@
 #ifndef ICE_BT_TRANSCEIVER_H
 #define ICE_BT_TRANSCEIVER_H
 
+#include "../Ice/Transceiver.h"
 #include "Engine.h"
 #include "InstanceF.h"
 #include "StreamSocket.h"
-
-#include "../Ice/Transceiver.h"
 
 namespace IceBT
 {

--- a/cpp/src/IceBT/Util.cpp
+++ b/cpp/src/IceBT/Util.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "Util.h"
-
 #include "../Ice/Network.h"
 #include "Ice/LocalExceptions.h"
 #include "Ice/StringUtil.h"

--- a/cpp/src/IceBT/Util.h
+++ b/cpp/src/IceBT/Util.h
@@ -5,10 +5,9 @@
 #ifndef ICE_BT_UTIL_H
 #define ICE_BT_UTIL_H
 
+#include "../Ice/Network.h"
 #include "Config.h"
 #include "IceBT/Types.h"
-
-#include "../Ice/Network.h"
 
 namespace IceBT
 {

--- a/cpp/src/IceBox/ServiceManagerI.cpp
+++ b/cpp/src/IceBox/ServiceManagerI.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "ServiceManagerI.h"
+
 #include "../Ice/ConsoleUtil.h"
 #include "../Ice/DynamicLibrary.h"
 #include "../Ice/Instance.h"
@@ -10,6 +11,7 @@
 #include "Ice/Ice.h"
 #include "Ice/Initialize.h"
 #include "Ice/StringUtil.h"
+#include <utility>
 
 using namespace Ice;
 using namespace IceInternal;
@@ -77,7 +79,7 @@ namespace
 }
 
 IceBox::ServiceManagerI::ServiceManagerI(CommunicatorPtr communicator, int& argc, char* argv[])
-    : _communicator(communicator),
+    : _communicator(std::move(communicator)),
       _adminEnabled(false),
       _pendingStatusChanges(false),
       _traceServiceObserver(0)

--- a/cpp/src/IceBox/ServiceManagerI.cpp
+++ b/cpp/src/IceBox/ServiceManagerI.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "ServiceManagerI.h"
-
 #include "../Ice/ConsoleUtil.h"
 #include "../Ice/DynamicLibrary.h"
 #include "../Ice/Instance.h"
@@ -11,7 +10,6 @@
 #include "Ice/Ice.h"
 #include "Ice/Initialize.h"
 #include "Ice/StringUtil.h"
-#include <utility>
 
 using namespace Ice;
 using namespace IceInternal;

--- a/cpp/src/IceBridge/IceBridge.cpp
+++ b/cpp/src/IceBridge/IceBridge.cpp
@@ -10,7 +10,6 @@
 #include "Ice/UUID.h"
 
 #include <iostream>
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/IceBridge/IceBridge.cpp
+++ b/cpp/src/IceBridge/IceBridge.cpp
@@ -10,6 +10,7 @@
 #include "Ice/UUID.h"
 
 #include <iostream>
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -30,11 +31,11 @@ namespace
             pair<const byte*, const byte*> p,
             function<void(bool, pair<const byte*, const byte*>)>&& r,
             function<void(exception_ptr)>&& e,
-            const Current& c)
+            Current c)
             : inParams(p.first, p.second),
               response(std::move(r)),
               error(std::move(e)),
-              current(c)
+              current(std::move(c))
         {
         }
 

--- a/cpp/src/IceDB/IceDB.h
+++ b/cpp/src/IceDB/IceDB.h
@@ -13,12 +13,6 @@
 
 #include <lmdb.h>
 
-#include <utility>
-
-#include <utility>
-
-#include <utility>
-
 #ifndef ICE_DB_API
 #    if defined(ICE_DB_API_EXPORTS)
 #        define ICE_DB_API ICE_DECLSPEC_EXPORT
@@ -175,7 +169,7 @@ namespace IceDB
     public:
         Dbi(const Txn& txn, const std::string& name, C ctx, unsigned int flags = 0, MDB_cmp_func* cmp = nullptr)
             : DbiBase(txn, name, flags, cmp),
-              _marshalingContext(std::move(std::move(std::move(ctx))))
+              _marshalingContext(std::move(ctx))
         {
         }
 

--- a/cpp/src/IceDB/IceDB.h
+++ b/cpp/src/IceDB/IceDB.h
@@ -13,6 +13,12 @@
 
 #include <lmdb.h>
 
+#include <utility>
+
+#include <utility>
+
+#include <utility>
+
 #ifndef ICE_DB_API
 #    if defined(ICE_DB_API_EXPORTS)
 #        define ICE_DB_API ICE_DECLSPEC_EXPORT
@@ -167,9 +173,9 @@ namespace IceDB
     template<typename K, typename D, typename C, typename H> class Dbi : public DbiBase
     {
     public:
-        Dbi(const Txn& txn, const std::string& name, const C& ctx, unsigned int flags = 0, MDB_cmp_func* cmp = nullptr)
+        Dbi(const Txn& txn, const std::string& name, C ctx, unsigned int flags = 0, MDB_cmp_func* cmp = nullptr)
             : DbiBase(txn, name, flags, cmp),
-              _marshalingContext(ctx)
+              _marshalingContext(std::move(std::move(std::move(ctx))))
         {
         }
 

--- a/cpp/src/IceDiscovery/LocatorI.cpp
+++ b/cpp/src/IceDiscovery/LocatorI.cpp
@@ -3,16 +3,13 @@
 //
 
 #include "LocatorI.h"
-#include "LookupI.h"
-
+#include "../Ice/Random.h"
 #include "Ice/Communicator.h"
 #include "Ice/LocalExceptions.h"
 #include "Ice/ObjectAdapter.h"
-
-#include "../Ice/Random.h"
+#include "LookupI.h"
 
 #include <iterator>
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/IceDiscovery/LocatorI.cpp
+++ b/cpp/src/IceDiscovery/LocatorI.cpp
@@ -12,6 +12,7 @@
 #include "../Ice/Random.h"
 
 #include <iterator>
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -185,7 +186,9 @@ LocatorRegistryI::findAdapter(const string& adapterId, bool& isReplicaGroup) con
     return nullopt;
 }
 
-LocatorI::LocatorI(const LookupIPtr& lookup, const LocatorRegistryPrx& registry) : _lookup(lookup), _registry(registry)
+LocatorI::LocatorI(LookupIPtr lookup, LocatorRegistryPrx registry)
+    : _lookup(std::move(lookup)),
+      _registry(std::move(registry))
 {
 }
 

--- a/cpp/src/IceDiscovery/LocatorI.h
+++ b/cpp/src/IceDiscovery/LocatorI.h
@@ -55,7 +55,7 @@ namespace IceDiscovery
     class LocatorI final : public Ice::Locator
     {
     public:
-        LocatorI(const LookupIPtr&, const Ice::LocatorRegistryPrx&);
+        LocatorI(LookupIPtr, Ice::LocatorRegistryPrx);
 
         void findObjectByIdAsync(
             Ice::Identity,

--- a/cpp/src/IceDiscovery/LookupI.cpp
+++ b/cpp/src/IceDiscovery/LookupI.cpp
@@ -12,13 +12,14 @@
 
 #include "LookupI.h"
 #include <iterator>
+#include <utility>
 
 using namespace std;
 using namespace Ice;
 using namespace IceDiscovery;
 
-IceDiscovery::Request::Request(const LookupIPtr& lookup, int retryCount)
-    : _lookup(lookup),
+IceDiscovery::Request::Request(LookupIPtr lookup, int retryCount)
+    : _lookup(std::move(lookup)),
       _requestId(Ice::generateUUID()),
       _retryCount(retryCount),
       _lookupCount(0),
@@ -169,8 +170,8 @@ ObjectRequest::runTimerTask()
     _lookup->objectRequestTimedOut(shared_from_this());
 }
 
-LookupI::LookupI(const LocatorRegistryIPtr& registry, const LookupPrx& lookup, const Ice::PropertiesPtr& properties)
-    : _registry(registry),
+LookupI::LookupI(LocatorRegistryIPtr registry, const LookupPrx& lookup, const Ice::PropertiesPtr& properties)
+    : _registry(std::move(registry)),
       _lookup(lookup),
       _timeout(chrono::milliseconds(properties->getIcePropertyAsInt("IceDiscovery.Timeout"))),
       _retryCount(properties->getIcePropertyAsInt("IceDiscovery.RetryCount")),
@@ -482,7 +483,7 @@ LookupI::objectRequestException(const ObjectRequestPtr& request, exception_ptr e
     }
 }
 
-LookupReplyI::LookupReplyI(const LookupIPtr& lookup) : _lookup(lookup) {}
+LookupReplyI::LookupReplyI(LookupIPtr lookup) : _lookup(std::move(lookup)) {}
 
 void
 LookupReplyI::foundObjectById(Identity id, optional<ObjectPrx> proxy, const Current& current)

--- a/cpp/src/IceDiscovery/LookupI.cpp
+++ b/cpp/src/IceDiscovery/LookupI.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+#include "LookupI.h"
 #include "Ice/Communicator.h"
 #include "Ice/Connection.h"
 #include "Ice/Initialize.h"
@@ -10,9 +11,7 @@
 #include "Ice/ObjectAdapter.h"
 #include "Ice/UUID.h"
 
-#include "LookupI.h"
 #include <iterator>
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/IceDiscovery/LookupI.h
+++ b/cpp/src/IceDiscovery/LookupI.h
@@ -14,6 +14,7 @@
 
 #include <chrono>
 #include <set>
+#include <utility>
 
 namespace IceDiscovery
 {
@@ -22,7 +23,7 @@ namespace IceDiscovery
     class Request : public IceInternal::TimerTask
     {
     public:
-        Request(const LookupIPtr&, int);
+        Request(LookupIPtr, int);
 
         virtual bool retry();
         void invoke(const std::string&, const std::vector<std::pair<LookupPrx, LookupReplyPrx>>&);
@@ -45,7 +46,7 @@ namespace IceDiscovery
     template<class T, class CB> class RequestT : public Request
     {
     public:
-        RequestT(const LookupIPtr& lookup, T id, int retryCount) : Request(lookup, retryCount), _id(id) {}
+        RequestT(const LookupIPtr& lookup, T id, int retryCount) : Request(lookup, retryCount), _id(std::move(id)) {}
 
         [[nodiscard]] T getId() const { return _id; }
 
@@ -116,7 +117,7 @@ namespace IceDiscovery
     class LookupI final : public Lookup, public std::enable_shared_from_this<LookupI>
     {
     public:
-        LookupI(const LocatorRegistryIPtr&, const LookupPrx&, const Ice::PropertiesPtr&);
+        LookupI(LocatorRegistryIPtr, const LookupPrx&, const Ice::PropertiesPtr&);
 
         void destroy();
 
@@ -159,7 +160,7 @@ namespace IceDiscovery
     class LookupReplyI final : public LookupReply
     {
     public:
-        LookupReplyI(const LookupIPtr&);
+        LookupReplyI(LookupIPtr);
 
         void foundObjectById(Ice::Identity, std::optional<Ice::ObjectPrx>, const Ice::Current&) final;
         void foundAdapterById(std::string, std::optional<Ice::ObjectPrx>, bool, const Ice::Current&) final;

--- a/cpp/src/IceDiscovery/LookupI.h
+++ b/cpp/src/IceDiscovery/LookupI.h
@@ -5,16 +5,14 @@
 #ifndef LOOKUPI_H
 #define LOOKUPI_H
 
-#include "IceDiscovery.h"
-#include "LocatorI.h"
-
 #include "Ice/Comparable.h"
 #include "Ice/Properties.h"
 #include "Ice/Timer.h"
+#include "IceDiscovery.h"
+#include "LocatorI.h"
 
 #include <chrono>
 #include <set>
-#include <utility>
 
 namespace IceDiscovery
 {

--- a/cpp/src/IceDiscovery/PluginI.cpp
+++ b/cpp/src/IceDiscovery/PluginI.cpp
@@ -9,6 +9,8 @@
 #include "LookupI.h"
 #include "PluginI.h"
 
+#include <utility>
+
 using namespace std;
 using namespace IceDiscovery;
 
@@ -40,7 +42,7 @@ namespace Ice
     }
 }
 
-PluginI::PluginI(const Ice::CommunicatorPtr& communicator) : _communicator(communicator) {}
+PluginI::PluginI(Ice::CommunicatorPtr communicator) : _communicator(std::move(communicator)) {}
 
 void
 PluginI::initialize()

--- a/cpp/src/IceDiscovery/PluginI.cpp
+++ b/cpp/src/IceDiscovery/PluginI.cpp
@@ -2,14 +2,11 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+#include "PluginI.h"
 #include "../Ice/Network.h" // For getInterfacesForMulticast
 #include "Ice/Ice.h"
-
 #include "LocatorI.h"
 #include "LookupI.h"
-#include "PluginI.h"
-
-#include <utility>
 
 using namespace std;
 using namespace IceDiscovery;

--- a/cpp/src/IceDiscovery/PluginI.h
+++ b/cpp/src/IceDiscovery/PluginI.h
@@ -13,7 +13,7 @@ namespace IceDiscovery
     class PluginI : public Ice::Plugin
     {
     public:
-        PluginI(const Ice::CommunicatorPtr&);
+        PluginI(Ice::CommunicatorPtr);
 
         void initialize() override;
         void destroy() override;

--- a/cpp/src/IceGrid/AdapterCache.cpp
+++ b/cpp/src/IceGrid/AdapterCache.cpp
@@ -13,7 +13,6 @@
 #include "SessionI.h"
 
 #include <functional>
-#include <utility>
 
 #include "SynchronizationException.h"
 

--- a/cpp/src/IceGrid/AdapterCache.cpp
+++ b/cpp/src/IceGrid/AdapterCache.cpp
@@ -13,6 +13,7 @@
 #include "SessionI.h"
 
 #include <functional>
+#include <utility>
 
 #include "SynchronizationException.h"
 
@@ -319,10 +320,10 @@ AdapterCache::removeImpl(const string& id)
     Cache<string, AdapterEntry>::removeImpl(id);
 }
 
-AdapterEntry::AdapterEntry(AdapterCache& cache, const string& id, const string& application)
+AdapterEntry::AdapterEntry(AdapterCache& cache, string id, string application)
     : _cache(cache),
-      _id(id),
-      _application(application)
+      _id(std::move(id)),
+      _application(std::move(application))
 {
 }
 
@@ -348,11 +349,11 @@ ServerAdapterEntry::ServerAdapterEntry(
     AdapterCache& cache,
     const string& id,
     const string& application,
-    const string& replicaGroupId,
+    string replicaGroupId,
     int priority,
     const shared_ptr<ServerEntry>& server)
     : AdapterEntry(cache, id, application),
-      _replicaGroupId(replicaGroupId),
+      _replicaGroupId(std::move(replicaGroupId)),
       _priority(priority),
       _server(server)
 {

--- a/cpp/src/IceGrid/AdapterCache.h
+++ b/cpp/src/IceGrid/AdapterCache.h
@@ -45,7 +45,7 @@ namespace IceGrid
     class AdapterEntry
     {
     public:
-        AdapterEntry(AdapterCache&, const std::string&, const std::string&);
+        AdapterEntry(AdapterCache&, std::string, std::string);
 
         virtual bool addSyncCallback(const std::shared_ptr<SynchronizationCallback>&, const std::set<std::string>&) = 0;
 
@@ -79,7 +79,7 @@ namespace IceGrid
             AdapterCache&,
             const std::string&,
             const std::string&,
-            const std::string&,
+            std::string,
             int,
             const std::shared_ptr<ServerEntry>&);
 

--- a/cpp/src/IceGrid/AdminI.cpp
+++ b/cpp/src/IceGrid/AdminI.cpp
@@ -2,22 +2,19 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-#include "Ice/UUID.h"
-
-#include "../Ice/TraceUtil.h"
-#include "Ice/Ice.h"
-#include "Ice/LoggerUtil.h"
-
 #include "AdminI.h"
+#include "../Ice/TraceUtil.h"
 #include "AdminSessionI.h"
 #include "Database.h"
 #include "DescriptorHelper.h"
 #include "DescriptorParser.h"
+#include "Ice/Ice.h"
+#include "Ice/LoggerUtil.h"
+#include "Ice/UUID.h"
 #include "NodeSessionI.h"
 #include "RegistryI.h"
-#include "Util.h"
-
 #include "SynchronizationException.h"
+#include "Util.h"
 
 using namespace std;
 using namespace std::chrono;

--- a/cpp/src/IceGrid/AdminSessionI.cpp
+++ b/cpp/src/IceGrid/AdminSessionI.cpp
@@ -3,14 +3,12 @@
 //
 
 #include "AdminSessionI.h"
-
 #include "../Ice/SSL/SSLUtil.h"
 #include "AdminI.h"
 #include "Database.h"
 #include "Ice/Ice.h"
 #include "RegistryI.h"
 #include "SynchronizationException.h"
-#include <utility>
 
 using namespace std;
 using namespace IceGrid;

--- a/cpp/src/IceGrid/AdminSessionI.cpp
+++ b/cpp/src/IceGrid/AdminSessionI.cpp
@@ -3,12 +3,14 @@
 //
 
 #include "AdminSessionI.h"
+
 #include "../Ice/SSL/SSLUtil.h"
 #include "AdminI.h"
 #include "Database.h"
 #include "Ice/Ice.h"
 #include "RegistryI.h"
 #include "SynchronizationException.h"
+#include <utility>
 
 using namespace std;
 using namespace IceGrid;
@@ -48,12 +50,12 @@ namespace
 FileIteratorI::FileIteratorI(
     shared_ptr<AdminSessionI> session,
     FileReaderPrx reader,
-    const string& filename,
+    string filename,
     int64_t offset,
     int messageSizeMax)
     : _session(std::move(session)),
       _reader(std::move(reader)),
-      _filename(filename),
+      _filename(std::move(filename)),
       _offset(offset),
       _messageSizeMax(messageSizeMax - 256) // Room for the header
 {

--- a/cpp/src/IceGrid/AdminSessionI.h
+++ b/cpp/src/IceGrid/AdminSessionI.h
@@ -130,7 +130,7 @@ namespace IceGrid
     class FileIteratorI final : public FileIterator
     {
     public:
-        FileIteratorI(std::shared_ptr<AdminSessionI>, FileReaderPrx, const std::string&, std::int64_t, int);
+        FileIteratorI(std::shared_ptr<AdminSessionI>, FileReaderPrx, std::string, std::int64_t, int);
 
         bool read(int, Ice::StringSeq&, const Ice::Current&) final;
         void destroy(const Ice::Current&) final;

--- a/cpp/src/IceGrid/Allocatable.h
+++ b/cpp/src/IceGrid/Allocatable.h
@@ -6,7 +6,6 @@
 #define ICEGRID_ALLOCATABLE_H
 
 #include "Ice/Timer.h"
-
 #include "IceGrid/Session.h"
 
 #include <list>

--- a/cpp/src/IceGrid/AllocatableObjectCache.cpp
+++ b/cpp/src/IceGrid/AllocatableObjectCache.cpp
@@ -10,7 +10,6 @@
 #include "Ice/LoggerUtil.h"
 #include "ServerCache.h"
 #include "SessionI.h"
-#include <utility>
 
 using namespace std;
 using namespace IceGrid;

--- a/cpp/src/IceGrid/AllocatableObjectCache.cpp
+++ b/cpp/src/IceGrid/AllocatableObjectCache.cpp
@@ -3,12 +3,14 @@
 //
 
 #include "AllocatableObjectCache.h"
+
 #include "../Ice/Random.h"
 #include "Ice/Communicator.h"
 #include "Ice/LocalExceptions.h"
 #include "Ice/LoggerUtil.h"
 #include "ServerCache.h"
 #include "SessionI.h"
+#include <utility>
 
 using namespace std;
 using namespace IceGrid;
@@ -252,11 +254,11 @@ AllocatableObjectCache::canTryAllocate(const shared_ptr<AllocatableObjectEntry>&
 
 AllocatableObjectEntry::AllocatableObjectEntry(
     AllocatableObjectCache& cache,
-    const ObjectInfo& info,
+    ObjectInfo info,
     const shared_ptr<ServerEntry>& parent)
     : Allocatable(true, parent),
       _cache(cache),
-      _info(info),
+      _info(std::move(info)),
       _server(parent),
       _destroyed(false)
 {

--- a/cpp/src/IceGrid/AllocatableObjectCache.h
+++ b/cpp/src/IceGrid/AllocatableObjectCache.h
@@ -18,7 +18,7 @@ namespace IceGrid
     class AllocatableObjectEntry : public Allocatable
     {
     public:
-        AllocatableObjectEntry(AllocatableObjectCache&, const ObjectInfo&, const std::shared_ptr<ServerEntry>&);
+        AllocatableObjectEntry(AllocatableObjectCache&, ObjectInfo, const std::shared_ptr<ServerEntry>&);
         [[nodiscard]] Ice::ObjectPrx getProxy() const;
         [[nodiscard]] std::string getType() const;
 

--- a/cpp/src/IceGrid/Database.cpp
+++ b/cpp/src/IceGrid/Database.cpp
@@ -19,7 +19,6 @@
 #include <algorithm>
 #include <functional>
 #include <iterator>
-#include <utility>
 
 using namespace std;
 using namespace IceGrid;

--- a/cpp/src/IceGrid/Database.cpp
+++ b/cpp/src/IceGrid/Database.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <functional>
 #include <iterator>
+#include <utility>
 
 using namespace std;
 using namespace IceGrid;
@@ -196,14 +197,14 @@ Database::create(
 Database::Database(
     const Ice::ObjectAdapterPtr& registryAdapter,
     IceStorm::TopicManagerPrx topicManager,
-    const string& instanceName,
+    string instanceName,
     const shared_ptr<TraceLevels>& traceLevels,
     const RegistryInfo& info,
     bool readonly)
     : _communicator(registryAdapter->getCommunicator()),
       _internalAdapter(registryAdapter),
       _topicManager(std::move(topicManager)),
-      _instanceName(instanceName),
+      _instanceName(std::move(instanceName)),
       _traceLevels(traceLevels),
       _master(info.name == "Master"),
       _readonly(readonly || !_master),

--- a/cpp/src/IceGrid/Database.h
+++ b/cpp/src/IceGrid/Database.h
@@ -5,6 +5,8 @@
 #ifndef ICEGRID_DATABASE_H
 #define ICEGRID_DATABASE_H
 
+#include <utility>
+
 #include "../Ice/FileUtil.h"
 #include "AdapterCache.h"
 #include "AllocatableObjectCache.h"
@@ -170,7 +172,7 @@ namespace IceGrid
         Database(
             const Ice::ObjectAdapterPtr&,
             IceStorm::TopicManagerPrx,
-            const std::string&,
+            std::string,
             const std::shared_ptr<TraceLevels>&,
             const RegistryInfo&,
             bool);
@@ -276,9 +278,9 @@ namespace IceGrid
             std::vector<std::pair<std::function<void()>, std::function<void(std::exception_ptr)>>> cbs;
             bool updated;
 
-            UpdateInfo(const std::string& n, const std::string& u, int r)
-                : name(n),
-                  uuid(u),
+            UpdateInfo(std::string n, std::string u, int r)
+                : name(std::move(n)),
+                  uuid(std::move(u)),
                   revision(r),
                   updated(false)
             {

--- a/cpp/src/IceGrid/Database.h
+++ b/cpp/src/IceGrid/Database.h
@@ -5,8 +5,6 @@
 #ifndef ICEGRID_DATABASE_H
 #define ICEGRID_DATABASE_H
 
-#include <utility>
-
 #include "../Ice/FileUtil.h"
 #include "AdapterCache.h"
 #include "AllocatableObjectCache.h"

--- a/cpp/src/IceGrid/DescriptorBuilder.cpp
+++ b/cpp/src/IceGrid/DescriptorBuilder.cpp
@@ -10,18 +10,15 @@
 #include "Util.h"
 
 #include <stdexcept>
+#include <utility>
 
 using namespace std;
 using namespace IceGrid;
 
-XmlAttributesHelper::XmlAttributesHelper(
-    const XMLAttributes& attrs,
-    const Ice::LoggerPtr& logger,
-    const string& filename,
-    int line)
+XmlAttributesHelper::XmlAttributesHelper(const XMLAttributes& attrs, Ice::LoggerPtr logger, string filename, int line)
     : _attributes(attrs),
-      _logger(logger),
-      _filename(filename),
+      _logger(std::move(logger)),
+      _filename(std::move(filename)),
       _line(line)
 {
 }
@@ -228,11 +225,11 @@ ApplicationDescriptorBuilder::ApplicationDescriptorBuilder(
 
 ApplicationDescriptorBuilder::ApplicationDescriptorBuilder(
     const shared_ptr<Ice::Communicator>& communicator,
-    const ApplicationDescriptor& app,
+    ApplicationDescriptor app,
     const XmlAttributesHelper& attrs,
     const map<string, string>& overrides)
     : _communicator(communicator),
-      _descriptor(app),
+      _descriptor(std::move(app)),
       _overrides(overrides)
 {
     _descriptor.name = attrs("name");
@@ -444,10 +441,10 @@ ServerInstanceDescriptorBuilder::addPropertySet(const string& service, const Pro
 
 NodeDescriptorBuilder::NodeDescriptorBuilder(
     ApplicationDescriptorBuilder& app,
-    const NodeDescriptor& desc,
+    NodeDescriptor desc,
     const XmlAttributesHelper& attrs)
     : _application(app),
-      _descriptor(desc)
+      _descriptor(std::move(desc))
 {
     _name = attrs("name");
     _descriptor.loadFactor = attrs("load-factor", "");

--- a/cpp/src/IceGrid/DescriptorBuilder.cpp
+++ b/cpp/src/IceGrid/DescriptorBuilder.cpp
@@ -10,7 +10,6 @@
 #include "Util.h"
 
 #include <stdexcept>
-#include <utility>
 
 using namespace std;
 using namespace IceGrid;

--- a/cpp/src/IceGrid/DescriptorBuilder.h
+++ b/cpp/src/IceGrid/DescriptorBuilder.h
@@ -15,7 +15,7 @@ namespace IceGrid
     class XmlAttributesHelper
     {
     public:
-        XmlAttributesHelper(const XMLAttributes&, const Ice::LoggerPtr&, const std::string&, int);
+        XmlAttributesHelper(const XMLAttributes&, Ice::LoggerPtr, std::string, int);
 
         void checkUnknownAttributes();
         bool contains(const std::string&) const;          // NOLINT:modernize-use-nodiscard
@@ -80,7 +80,7 @@ namespace IceGrid
             const std::map<std::string, std::string>&);
         ApplicationDescriptorBuilder(
             const Ice::CommunicatorPtr&,
-            const ApplicationDescriptor&,
+            ApplicationDescriptor,
             const XmlAttributesHelper&,
             const std::map<std::string, std::string>&);
 
@@ -135,7 +135,7 @@ namespace IceGrid
     {
     public:
         NodeDescriptorBuilder(ApplicationDescriptorBuilder&, const XmlAttributesHelper&);
-        NodeDescriptorBuilder(ApplicationDescriptorBuilder&, const NodeDescriptor&, const XmlAttributesHelper&);
+        NodeDescriptorBuilder(ApplicationDescriptorBuilder&, NodeDescriptor, const XmlAttributesHelper&);
 
         virtual ServerDescriptorBuilder* createServer(const XmlAttributesHelper&);
         virtual ServerDescriptorBuilder* createIceBox(const XmlAttributesHelper&);

--- a/cpp/src/IceGrid/DescriptorHelper.cpp
+++ b/cpp/src/IceGrid/DescriptorHelper.cpp
@@ -9,6 +9,7 @@
 
 #include <iterator>
 #include <stdexcept>
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -1725,7 +1726,7 @@ InstanceHelper::instantiateParams(
     return params;
 }
 
-ServiceInstanceHelper::ServiceInstanceHelper(const ServiceInstanceDescriptor& desc, bool ignoreProps) : _def(desc)
+ServiceInstanceHelper::ServiceInstanceHelper(ServiceInstanceDescriptor desc, bool ignoreProps) : _def(std::move(desc))
 {
     //
     // If the service instance is not a template instance, its
@@ -1843,11 +1844,8 @@ ServiceInstanceHelper::print(const shared_ptr<Ice::Communicator>& communicator, 
     }
 }
 
-ServerInstanceHelper::ServerInstanceHelper(
-    const ServerInstanceDescriptor& desc,
-    const Resolver& resolve,
-    bool instantiate)
-    : _def(desc)
+ServerInstanceHelper::ServerInstanceHelper(ServerInstanceDescriptor desc, const Resolver& resolve, bool instantiate)
+    : _def(std::move(desc))
 {
     init(nullptr, resolve, instantiate);
 }
@@ -2012,13 +2010,9 @@ ServerInstanceHelper::getReplicaGroups(set<string>& replicaGroups) const
     _serverInstance->getReplicaGroups(replicaGroups);
 }
 
-NodeHelper::NodeHelper(
-    const string& name,
-    const NodeDescriptor& descriptor,
-    const Resolver& appResolve,
-    bool instantiate)
-    : _name(name),
-      _def(descriptor),
+NodeHelper::NodeHelper(string name, NodeDescriptor descriptor, const Resolver& appResolve, bool instantiate)
+    : _name(std::move(name)),
+      _def(std::move(descriptor)),
       _instantiated(instantiate)
 {
     if (_name.empty())
@@ -2488,11 +2482,11 @@ NodeHelper::printDiff(Output& out, const NodeHelper& helper) const
 
 ApplicationHelper::ApplicationHelper(
     const shared_ptr<Ice::Communicator>& communicator,
-    const ApplicationDescriptor& appDesc,
+    ApplicationDescriptor appDesc,
     bool enableWarning,
     bool instantiate)
     : _communicator(communicator),
-      _def(appDesc)
+      _def(std::move(appDesc))
 {
     if (_def.name.empty())
     {

--- a/cpp/src/IceGrid/DescriptorHelper.cpp
+++ b/cpp/src/IceGrid/DescriptorHelper.cpp
@@ -9,7 +9,6 @@
 
 #include <iterator>
 #include <stdexcept>
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/IceGrid/DescriptorHelper.h
+++ b/cpp/src/IceGrid/DescriptorHelper.h
@@ -170,7 +170,7 @@ namespace IceGrid
     class ServiceInstanceHelper final : public InstanceHelper
     {
     public:
-        ServiceInstanceHelper(const ServiceInstanceDescriptor&, bool);
+        ServiceInstanceHelper(ServiceInstanceDescriptor, bool);
 
         bool operator==(const ServiceInstanceHelper&) const;
         bool operator!=(const ServiceInstanceHelper&) const;
@@ -219,7 +219,7 @@ namespace IceGrid
     class ServerInstanceHelper final : public InstanceHelper
     {
     public:
-        ServerInstanceHelper(const ServerInstanceDescriptor&, const Resolver&, bool);
+        ServerInstanceHelper(ServerInstanceDescriptor, const Resolver&, bool);
         ServerInstanceHelper(const std::shared_ptr<ServerDescriptor>&, const Resolver&, bool);
 
         bool operator==(const ServerInstanceHelper&) const;
@@ -249,7 +249,7 @@ namespace IceGrid
     class NodeHelper final
     {
     public:
-        NodeHelper(const std::string&, const NodeDescriptor&, const Resolver&, bool);
+        NodeHelper(std::string, NodeDescriptor, const Resolver&, bool);
 
         bool operator==(const NodeHelper&) const;
         bool operator!=(const NodeHelper&) const;
@@ -283,7 +283,7 @@ namespace IceGrid
     class ApplicationHelper final
     {
     public:
-        ApplicationHelper(const Ice::CommunicatorPtr&, const ApplicationDescriptor&, bool = false, bool = true);
+        ApplicationHelper(const Ice::CommunicatorPtr&, ApplicationDescriptor, bool = false, bool = true);
 
         [[nodiscard]] ApplicationUpdateDescriptor diff(const ApplicationHelper&) const;
         [[nodiscard]] ApplicationDescriptor update(const ApplicationUpdateDescriptor&) const;

--- a/cpp/src/IceGrid/DescriptorParser.cpp
+++ b/cpp/src/IceGrid/DescriptorParser.cpp
@@ -11,7 +11,6 @@
 
 #include <fstream>
 #include <stack>
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/IceGrid/DescriptorParser.cpp
+++ b/cpp/src/IceGrid/DescriptorParser.cpp
@@ -11,6 +11,7 @@
 
 #include <fstream>
 #include <stack>
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -21,7 +22,7 @@ namespace
     class DescriptorHandler final : public XMLHandler
     {
     public:
-        DescriptorHandler(const string&, const shared_ptr<Ice::Communicator>&);
+        DescriptorHandler(string, const shared_ptr<Ice::Communicator>&);
 
         void setAdmin(IceGrid::AdminPrx);
         void setVariables(const map<string, string>&, const vector<string>&);
@@ -67,9 +68,9 @@ namespace
         bool _inReplicaGroup;
     };
 
-    DescriptorHandler::DescriptorHandler(const string& filename, const shared_ptr<Ice::Communicator>& communicator)
+    DescriptorHandler::DescriptorHandler(string filename, const shared_ptr<Ice::Communicator>& communicator)
         : _communicator(communicator),
-          _filename(filename),
+          _filename(std::move(filename)),
           _isCurrentTargetDeployable(true),
           _currentCommunicator(nullptr),
           _isTopLevel(true),

--- a/cpp/src/IceGrid/FileCache.cpp
+++ b/cpp/src/IceGrid/FileCache.cpp
@@ -2,12 +2,10 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+#include "FileCache.h"
+#include "../Ice/FileUtil.h"
 #include "Ice/Communicator.h"
 #include "Ice/Properties.h"
-
-#include "../Ice/FileUtil.h"
-
-#include "FileCache.h"
 #include "IceGrid/Exception.h"
 
 #include <deque>

--- a/cpp/src/IceGrid/InternalRegistryI.cpp
+++ b/cpp/src/IceGrid/InternalRegistryI.cpp
@@ -2,14 +2,12 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-#include "../Ice/DisableWarnings.h"
-
+#include "InternalRegistryI.h"
 #include "../Ice/SSL/RFC2253.h"
 #include "../Ice/SSL/SSLUtil.h"
 #include "Database.h"
 #include "FileCache.h"
 #include "Ice/Ice.h"
-#include "InternalRegistryI.h"
 #include "NodeSessionI.h"
 #include "ReapThread.h"
 #include "RegistryI.h"
@@ -17,6 +15,8 @@
 #include "ReplicaSessionManager.h"
 #include "Topics.h"
 #include "WellKnownObjectsManager.h"
+
+#include "../Ice/DisableWarnings.h"
 
 using namespace std;
 using namespace IceGrid;

--- a/cpp/src/IceGrid/LocatorI.cpp
+++ b/cpp/src/IceGrid/LocatorI.cpp
@@ -3,14 +3,12 @@
 //
 
 #include "LocatorI.h"
-
 #include "../Ice/Protocol.h"
 #include "Database.h"
 #include "Ice/Ice.h"
 #include "SessionI.h"
 #include "Util.h"
 #include "WellKnownObjectsManager.h"
-#include <utility>
 
 #include "SynchronizationException.h"
 

--- a/cpp/src/IceGrid/LocatorI.cpp
+++ b/cpp/src/IceGrid/LocatorI.cpp
@@ -3,12 +3,14 @@
 //
 
 #include "LocatorI.h"
+
 #include "../Ice/Protocol.h"
 #include "Database.h"
 #include "Ice/Ice.h"
 #include "SessionI.h"
 #include "Util.h"
 #include "WellKnownObjectsManager.h"
+#include <utility>
 
 #include "SynchronizationException.h"
 
@@ -25,11 +27,11 @@ namespace
             function<void(const optional<Ice::ObjectPrx>&)> response,
             const shared_ptr<LocatorI>& locator,
             const Ice::EncodingVersion& encoding,
-            const LocatorAdapterInfo& adapter)
+            LocatorAdapterInfo adapter)
             : _response(std::move(response)),
               _locator(locator),
               _encoding(encoding),
-              _adapter(adapter),
+              _adapter(std::move(adapter)),
               _traceLevels(locator->getTraceLevels())
         {
             assert(_adapter.proxy);
@@ -83,16 +85,16 @@ namespace
         ReplicaGroupRequest(
             function<void(const optional<Ice::ObjectPrx>&)> response,
             const shared_ptr<LocatorI>& locator,
-            const string& id,
+            string id,
             const Ice::EncodingVersion& encoding,
-            const LocatorAdapterInfoSeq& adapters,
+            LocatorAdapterInfoSeq adapters,
             int count,
             optional<Ice::ObjectPrx> firstProxy)
             : _response(std::move(response)),
               _locator(locator),
-              _id(id),
+              _id(std::move(id)),
               _encoding(encoding),
-              _adapters(adapters),
+              _adapters(std::move(adapters)),
               _traceLevels(locator->getTraceLevels()),
               _count(static_cast<unsigned int>(count)),
               _lastAdapter(_adapters.begin())
@@ -299,19 +301,19 @@ namespace
             function<void(exception_ptr)> exception,
             const shared_ptr<LocatorI>& locator,
             const shared_ptr<Database> database,
-            const string& id,
+            string id,
             const Ice::Current& current,
-            const LocatorAdapterInfoSeq& adapters,
+            LocatorAdapterInfoSeq adapters,
             int count)
             : _response(std::move(response)),
               _exception(std::move(exception)),
               _locator(locator),
               _database(database),
-              _id(id),
+              _id(std::move(id)),
               _encoding(current.encoding),
               _connection(current.con),
               _context(current.ctx),
-              _adapters(adapters),
+              _adapters(std::move(adapters)),
               _traceLevels(locator->getTraceLevels()),
               _count(count),
               _waitForActivation(false)
@@ -610,13 +612,13 @@ namespace
             const shared_ptr<LocatorI>& locator,
             function<void(const optional<Ice::ObjectPrx>&)> response,
             function<void(exception_ptr)> exception,
-            const string& id,
-            const Ice::Current& current)
+            string id,
+            Ice::Current current)
             : _locator(locator),
               _response(std::move(response)),
               _exception(std::move(exception)),
-              _id(id),
-              _current(current)
+              _id(std::move(id)),
+              _current(std::move(current))
         {
         }
 

--- a/cpp/src/IceGrid/LocatorRegistryI.cpp
+++ b/cpp/src/IceGrid/LocatorRegistryI.cpp
@@ -3,10 +3,12 @@
 //
 
 #include "LocatorRegistryI.h"
+
 #include "Database.h"
 #include "Ice/Ice.h"
 #include "ReplicaSessionManager.h"
 #include "Util.h"
+#include <utility>
 
 #include "SynchronizationException.h"
 
@@ -77,14 +79,14 @@ namespace IceGrid
             const shared_ptr<LocatorRegistryI>& registry,
             function<void()> response,
             function<void(exception_ptr)> exception,
-            const string& adapterId,
-            const string& replicaGroupId,
+            string adapterId,
+            string replicaGroupId,
             optional<Ice::ObjectPrx> proxy)
             : _registry(registry),
               _response(std::move(response)),
               _exception(std::move(exception)),
-              _adapterId(adapterId),
-              _replicaGroupId(replicaGroupId),
+              _adapterId(std::move(adapterId)),
+              _replicaGroupId(std::move(replicaGroupId)),
               _proxy(std::move(proxy))
         {
         }
@@ -119,12 +121,12 @@ namespace IceGrid
             const shared_ptr<LocatorRegistryI>& registry,
             const function<void()> response,
             const function<void(exception_ptr)> exception,
-            const string& id,
+            string id,
             Ice::ProcessPrx proxy)
             : _registry(registry),
               _response(std::move(response)),
               _exception(std::move(exception)),
-              _id(id),
+              _id(std::move(id)),
               _proxy(std::move(proxy))
         {
         }

--- a/cpp/src/IceGrid/LocatorRegistryI.cpp
+++ b/cpp/src/IceGrid/LocatorRegistryI.cpp
@@ -3,12 +3,10 @@
 //
 
 #include "LocatorRegistryI.h"
-
 #include "Database.h"
 #include "Ice/Ice.h"
 #include "ReplicaSessionManager.h"
 #include "Util.h"
-#include <utility>
 
 #include "SynchronizationException.h"
 

--- a/cpp/src/IceGrid/NodeCache.cpp
+++ b/cpp/src/IceGrid/NodeCache.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "NodeCache.h"
+
 #include "DescriptorHelper.h"
 #include "Ice/Communicator.h"
 #include "Ice/LoggerUtil.h"
@@ -11,6 +12,7 @@
 #include "ReplicaCache.h"
 #include "ServerCache.h"
 #include "SessionI.h"
+#include <utility>
 
 using namespace std;
 using namespace IceGrid;
@@ -37,12 +39,9 @@ namespace
     }
 }
 
-NodeCache::NodeCache(
-    const shared_ptr<Ice::Communicator>& communicator,
-    ReplicaCache& replicaCache,
-    const string& replicaName)
+NodeCache::NodeCache(const shared_ptr<Ice::Communicator>& communicator, ReplicaCache& replicaCache, string replicaName)
     : _communicator(communicator),
-      _replicaName(replicaName),
+      _replicaName(std::move(replicaName)),
       _replicaCache(replicaCache)
 {
 }
@@ -91,9 +90,9 @@ NodeCache::get(const string& name, bool create) const
     return entry;
 }
 
-NodeEntry::NodeEntry(NodeCache& cache, const std::string& name)
+NodeEntry::NodeEntry(NodeCache& cache, std::string name)
     : _cache(cache),
-      _name(name),
+      _name(std::move(name)),
       _registering(false),
       _selfRemovingRefCount(0)
 {

--- a/cpp/src/IceGrid/NodeCache.cpp
+++ b/cpp/src/IceGrid/NodeCache.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "NodeCache.h"
-
 #include "DescriptorHelper.h"
 #include "Ice/Communicator.h"
 #include "Ice/LoggerUtil.h"
@@ -12,7 +11,6 @@
 #include "ReplicaCache.h"
 #include "ServerCache.h"
 #include "SessionI.h"
-#include <utility>
 
 using namespace std;
 using namespace IceGrid;

--- a/cpp/src/IceGrid/NodeCache.h
+++ b/cpp/src/IceGrid/NodeCache.h
@@ -21,7 +21,7 @@ namespace IceGrid
     class NodeEntry final
     {
     public:
-        NodeEntry(NodeCache&, const std::string&);
+        NodeEntry(NodeCache&, std::string);
 
         void addDescriptor(const std::string&, const NodeDescriptor&);
         void removeDescriptor(const std::string&);
@@ -90,7 +90,7 @@ namespace IceGrid
     public:
         using ValueType = NodeEntry*;
 
-        NodeCache(const Ice::CommunicatorPtr&, ReplicaCache&, const std::string&);
+        NodeCache(const Ice::CommunicatorPtr&, ReplicaCache&, std::string);
 
         [[nodiscard]] std::shared_ptr<NodeEntry> get(const std::string&, bool = false) const;
 

--- a/cpp/src/IceGrid/NodeI.cpp
+++ b/cpp/src/IceGrid/NodeI.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "NodeI.h"
+
 #include "../Ice/FileUtil.h"
 #include "Activator.h"
 #include "Ice/Ice.h"
@@ -12,6 +13,7 @@
 #include "ServerI.h"
 #include "TraceLevels.h"
 #include "Util.h"
+#include <utility>
 
 using namespace std;
 using namespace IceGrid;
@@ -48,24 +50,24 @@ NodeI::NodeI(
     const Ice::ObjectAdapterPtr& adapter,
     NodeSessionManager& sessions,
     const shared_ptr<Activator>& activator,
-    const IceInternal::TimerPtr& timer,
+    IceInternal::TimerPtr timer,
     const shared_ptr<TraceLevels>& traceLevels,
     NodePrx proxy,
-    const string& name,
+    string name,
     const optional<UserAccountMapperPrx>& mapper,
-    const string& instanceName)
+    string instanceName)
     : _communicator(adapter->getCommunicator()),
       _adapter(adapter),
       _sessions(sessions),
       _activator(activator),
-      _timer(timer),
+      _timer(std::move(timer)),
       _traceLevels(traceLevels),
-      _name(name),
+      _name(std::move(name)),
       _proxy(std::move(proxy)),
       _redirectErrToOut(false),
       _allowEndpointsOverride(false),
       _waitTime(0),
-      _instanceName(instanceName),
+      _instanceName(std::move(instanceName)),
       _userAccountMapper(mapper),
       _platform("IceGrid.Node", _communicator, _traceLevels),
       _fileCache(make_shared<FileCache>(_communicator)),

--- a/cpp/src/IceGrid/NodeI.cpp
+++ b/cpp/src/IceGrid/NodeI.cpp
@@ -13,7 +13,6 @@
 #include "ServerI.h"
 #include "TraceLevels.h"
 #include "Util.h"
-#include <utility>
 
 using namespace std;
 using namespace IceGrid;

--- a/cpp/src/IceGrid/NodeI.h
+++ b/cpp/src/IceGrid/NodeI.h
@@ -44,12 +44,12 @@ namespace IceGrid
             const Ice::ObjectAdapterPtr&,
             NodeSessionManager&,
             const std::shared_ptr<Activator>&,
-            const IceInternal::TimerPtr&,
+            IceInternal::TimerPtr,
             const std::shared_ptr<TraceLevels>&,
             NodePrx,
-            const std::string&,
+            std::string,
             const std::optional<UserAccountMapperPrx>&,
-            const std::string&);
+            std::string);
 
         void loadServerAsync(
             std::shared_ptr<InternalServerDescriptor>,

--- a/cpp/src/IceGrid/ObjectCache.cpp
+++ b/cpp/src/IceGrid/ObjectCache.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "ObjectCache.h"
+
 #include "../Ice/Random.h"
 #include "Ice/Communicator.h"
 #include "Ice/LocalExceptions.h"
@@ -10,6 +11,7 @@
 #include "NodeSessionI.h"
 #include "ServerCache.h"
 #include "SessionI.h"
+#include <utility>
 
 using namespace std;
 using namespace IceGrid;
@@ -160,10 +162,10 @@ ObjectCache::getAllByType(const string& type)
     return infos;
 }
 
-ObjectEntry::ObjectEntry(const ObjectInfo& info, const string& application, const string& server)
-    : _info(info),
-      _application(application),
-      _server(server)
+ObjectEntry::ObjectEntry(ObjectInfo info, string application, string server)
+    : _info(std::move(info)),
+      _application(std::move(application)),
+      _server(std::move(server))
 {
 }
 

--- a/cpp/src/IceGrid/ObjectCache.cpp
+++ b/cpp/src/IceGrid/ObjectCache.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "ObjectCache.h"
-
 #include "../Ice/Random.h"
 #include "Ice/Communicator.h"
 #include "Ice/LocalExceptions.h"
@@ -11,7 +10,6 @@
 #include "NodeSessionI.h"
 #include "ServerCache.h"
 #include "SessionI.h"
-#include <utility>
 
 using namespace std;
 using namespace IceGrid;

--- a/cpp/src/IceGrid/ObjectCache.h
+++ b/cpp/src/IceGrid/ObjectCache.h
@@ -16,7 +16,7 @@ namespace IceGrid
     class ObjectEntry
     {
     public:
-        ObjectEntry(const ObjectInfo&, const std::string&, const std::string&);
+        ObjectEntry(ObjectInfo, std::string, std::string);
         [[nodiscard]] Ice::ObjectPrx getProxy() const;
         [[nodiscard]] std::string getType() const;
         [[nodiscard]] std::string getApplication() const;

--- a/cpp/src/IceGrid/Parser.cpp
+++ b/cpp/src/IceGrid/Parser.cpp
@@ -4,7 +4,6 @@
 
 #include "Parser.h"
 #include "../Ice/ConsoleUtil.h"
-#include "../Ice/DisableWarnings.h"
 #include "../Ice/Options.h"
 #include "../Ice/TimeUtil.h"
 #include "DescriptorHelper.h"
@@ -13,6 +12,8 @@
 #include "IceBox/IceBox.h"
 #include "Util.h"
 #include "XMLParser.h"
+
+#include "../Ice/DisableWarnings.h"
 
 #if defined(__APPLE__) || defined(__linux__)
 #    include <editline/readline.h>

--- a/cpp/src/IceGrid/PlatformInfo.cpp
+++ b/cpp/src/IceGrid/PlatformInfo.cpp
@@ -2,15 +2,13 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+#include "PlatformInfo.h"
 #include "../Ice/FileUtil.h"
-#include "Ice/StringUtil.h"
-
 #include "Ice/Communicator.h"
 #include "Ice/LocalExceptions.h"
 #include "Ice/LoggerUtil.h"
 #include "Ice/Properties.h"
-
-#include "PlatformInfo.h"
+#include "Ice/StringUtil.h"
 #include "TraceLevels.h"
 
 #include <climits>

--- a/cpp/src/IceGrid/QueryI.cpp
+++ b/cpp/src/IceGrid/QueryI.cpp
@@ -3,15 +3,17 @@
 //
 
 #include "QueryI.h"
+
 #include "Database.h"
 #include "Internal.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
 using namespace IceGrid;
 
-QueryI::QueryI(const CommunicatorPtr& communicator, const shared_ptr<Database>& database)
-    : _communicator(communicator),
+QueryI::QueryI(CommunicatorPtr communicator, const shared_ptr<Database>& database)
+    : _communicator(std::move(communicator)),
       _database(database)
 {
 }

--- a/cpp/src/IceGrid/QueryI.cpp
+++ b/cpp/src/IceGrid/QueryI.cpp
@@ -3,10 +3,8 @@
 //
 
 #include "QueryI.h"
-
 #include "Database.h"
 #include "Internal.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/src/IceGrid/QueryI.h
+++ b/cpp/src/IceGrid/QueryI.h
@@ -15,7 +15,7 @@ namespace IceGrid
     class QueryI final : public Query
     {
     public:
-        QueryI(const Ice::CommunicatorPtr&, const std::shared_ptr<Database>&);
+        QueryI(Ice::CommunicatorPtr, const std::shared_ptr<Database>&);
 
         [[nodiscard]] std::optional<Ice::ObjectPrx> findObjectById(Ice::Identity, const Ice::Current&) const override;
 

--- a/cpp/src/IceGrid/ReapThread.h
+++ b/cpp/src/IceGrid/ReapThread.h
@@ -9,7 +9,6 @@
 
 #include <list>
 #include <set>
-#include <utility>
 
 namespace IceGrid
 {

--- a/cpp/src/IceGrid/ReapThread.h
+++ b/cpp/src/IceGrid/ReapThread.h
@@ -9,6 +9,7 @@
 
 #include <list>
 #include <set>
+#include <utility>
 
 namespace IceGrid
 {
@@ -27,8 +28,8 @@ namespace IceGrid
     template<class T> class SessionReapable final : public Reapable
     {
     public:
-        SessionReapable(const Ice::LoggerPtr& logger, const std::shared_ptr<T>& session)
-            : _logger(logger),
+        SessionReapable(Ice::LoggerPtr logger, const std::shared_ptr<T>& session)
+            : _logger(std::move(logger)),
               _session(session)
         {
         }

--- a/cpp/src/IceGrid/RegistryAdminRouter.cpp
+++ b/cpp/src/IceGrid/RegistryAdminRouter.cpp
@@ -3,9 +3,7 @@
 //
 
 #include "RegistryAdminRouter.h"
-
 #include "Ice/Ice.h"
-#include <utility>
 
 #include "SynchronizationException.h"
 

--- a/cpp/src/IceGrid/RegistryAdminRouter.cpp
+++ b/cpp/src/IceGrid/RegistryAdminRouter.cpp
@@ -3,7 +3,9 @@
 //
 
 #include "RegistryAdminRouter.h"
+
 #include "Ice/Ice.h"
+#include <utility>
 
 #include "SynchronizationException.h"
 
@@ -21,12 +23,12 @@ namespace
             pair<const byte*, const byte*> inParams,
             function<void(bool, pair<const byte*, const byte*>)> response,
             function<void(exception_ptr)> exception,
-            const Current& current)
+            Current current)
             : _adminRouter(adminRouter),
               _response(std::move(response)),
               _exception(std::move(exception)),
               _inParams(inParams.first, inParams.second),
-              _current(current)
+              _current(std::move(current))
         {
         }
 
@@ -106,9 +108,9 @@ RegistryServerAdminRouter::ice_invokeAsync(
     invokeOnTarget(target->ice_facet(current.facet), inParams, std::move(response), std::move(exception), current);
 }
 
-RegistryNodeAdminRouter::RegistryNodeAdminRouter(const string& collocNodeName, const shared_ptr<Database>& database)
+RegistryNodeAdminRouter::RegistryNodeAdminRouter(string collocNodeName, const shared_ptr<Database>& database)
     : AdminRouter(database->getTraceLevels()),
-      _collocNodeName(collocNodeName),
+      _collocNodeName(std::move(collocNodeName)),
       _database(database)
 {
 }
@@ -155,9 +157,9 @@ RegistryNodeAdminRouter::ice_invokeAsync(
     invokeOnTarget(target->ice_facet(current.facet), inParams, std::move(response), std::move(exception), current);
 }
 
-RegistryReplicaAdminRouter::RegistryReplicaAdminRouter(const string& name, const shared_ptr<Database>& database)
+RegistryReplicaAdminRouter::RegistryReplicaAdminRouter(string name, const shared_ptr<Database>& database)
     : AdminRouter(database->getTraceLevels()),
-      _name(name),
+      _name(std::move(name)),
       _database(database)
 {
 }

--- a/cpp/src/IceGrid/RegistryAdminRouter.h
+++ b/cpp/src/IceGrid/RegistryAdminRouter.h
@@ -29,7 +29,7 @@ namespace IceGrid
     class RegistryNodeAdminRouter final : public AdminRouter
     {
     public:
-        RegistryNodeAdminRouter(const std::string&, const std::shared_ptr<Database>&);
+        RegistryNodeAdminRouter(std::string, const std::shared_ptr<Database>&);
 
         void ice_invokeAsync(
             std::pair<const std::byte*, const std::byte*>,
@@ -45,7 +45,7 @@ namespace IceGrid
     class RegistryReplicaAdminRouter final : public AdminRouter
     {
     public:
-        RegistryReplicaAdminRouter(const std::string&, const std::shared_ptr<Database>&);
+        RegistryReplicaAdminRouter(std::string, const std::shared_ptr<Database>&);
 
         void ice_invokeAsync(
             std::pair<const std::byte*, const std::byte*>,

--- a/cpp/src/IceGrid/RegistryI.cpp
+++ b/cpp/src/IceGrid/RegistryI.cpp
@@ -32,6 +32,7 @@
 #include "RegistryAdminRouter.h"
 
 #include <fstream>
+#include <utility>
 
 #include <sys/types.h>
 
@@ -45,10 +46,10 @@ namespace
     {
     public:
         LookupI(
-            const string& instanceName,
+            string instanceName,
             const shared_ptr<WellKnownObjectsManager>& wellKnownObjects,
             const shared_ptr<TraceLevels>& traceLevels)
-            : _instanceName(instanceName),
+            : _instanceName(std::move(instanceName)),
               _wellKnownObjects(wellKnownObjects),
               _traceLevels(traceLevels)
         {
@@ -142,14 +143,14 @@ RegistryI::RegistryI(
     const shared_ptr<TraceLevels>& traceLevels,
     bool nowarn,
     bool readonly,
-    const string& initFromReplica,
-    const string& collocatedNodeName)
+    string initFromReplica,
+    string collocatedNodeName)
     : _communicator(communicator),
       _traceLevels(traceLevels),
       _nowarn(nowarn),
       _readonly(readonly),
-      _initFromReplica(initFromReplica),
-      _collocatedNodeName(collocatedNodeName),
+      _initFromReplica(std::move(initFromReplica)),
+      _collocatedNodeName(std::move(collocatedNodeName)),
       _platform("IceGrid.Registry", communicator, traceLevels)
 {
 }

--- a/cpp/src/IceGrid/RegistryI.cpp
+++ b/cpp/src/IceGrid/RegistryI.cpp
@@ -24,15 +24,13 @@
 #include "LocatorRegistryI.h"
 #include "QueryI.h"
 #include "ReapThread.h"
+#include "RegistryAdminRouter.h"
 #include "SessionI.h"
 #include "SessionServantManager.h"
 #include "TraceLevels.h"
 #include "WellKnownObjectsManager.h"
 
-#include "RegistryAdminRouter.h"
-
 #include <fstream>
-#include <utility>
 
 #include <sys/types.h>
 

--- a/cpp/src/IceGrid/RegistryI.h
+++ b/cpp/src/IceGrid/RegistryI.h
@@ -34,8 +34,8 @@ namespace IceGrid
             const std::shared_ptr<TraceLevels>&,
             bool,
             bool,
-            const std::string&,
-            const std::string&);
+            std::string,
+            std::string);
         ~RegistryI() override = default;
 
         bool start();

--- a/cpp/src/IceGrid/ReplicaCache.cpp
+++ b/cpp/src/IceGrid/ReplicaCache.cpp
@@ -3,13 +3,11 @@
 //
 
 #include "ReplicaCache.h"
-
 #include "Ice/Communicator.h"
 #include "Ice/LocalExceptions.h"
 #include "Ice/LoggerUtil.h"
 #include "ReplicaSessionI.h"
 #include "Topics.h"
-#include <utility>
 
 using namespace std;
 using namespace IceGrid;

--- a/cpp/src/IceGrid/ReplicaCache.cpp
+++ b/cpp/src/IceGrid/ReplicaCache.cpp
@@ -3,11 +3,13 @@
 //
 
 #include "ReplicaCache.h"
+
 #include "Ice/Communicator.h"
 #include "Ice/LocalExceptions.h"
 #include "Ice/LoggerUtil.h"
 #include "ReplicaSessionI.h"
 #include "Topics.h"
+#include <utility>
 
 using namespace std;
 using namespace IceGrid;
@@ -275,8 +277,8 @@ ReplicaCache::getInternalRegistry() const
     return *_self;
 }
 
-ReplicaEntry::ReplicaEntry(const std::string& name, const shared_ptr<ReplicaSessionI>& session)
-    : _name(name),
+ReplicaEntry::ReplicaEntry(std::string name, const shared_ptr<ReplicaSessionI>& session)
+    : _name(std::move(name)),
       _session(session)
 {
 }

--- a/cpp/src/IceGrid/ReplicaCache.h
+++ b/cpp/src/IceGrid/ReplicaCache.h
@@ -17,7 +17,7 @@ namespace IceGrid
     class ReplicaEntry final
     {
     public:
-        ReplicaEntry(const std::string&, const std::shared_ptr<ReplicaSessionI>&);
+        ReplicaEntry(std::string, const std::shared_ptr<ReplicaSessionI>&);
 
         [[nodiscard]] bool canRemove() const { return true; }
         [[nodiscard]] const std::shared_ptr<ReplicaSessionI>& getSession() const;

--- a/cpp/src/IceGrid/ServerAdapterI.cpp
+++ b/cpp/src/IceGrid/ServerAdapterI.cpp
@@ -3,10 +3,12 @@
 //
 
 #include "ServerAdapterI.h"
+
 #include "Ice/Ice.h"
 #include "NodeI.h"
 #include "ServerI.h"
 #include "TraceLevels.h"
+#include <utility>
 
 using namespace std;
 using namespace IceGrid;
@@ -14,14 +16,14 @@ using namespace IceGrid;
 ServerAdapterI::ServerAdapterI(
     const shared_ptr<NodeI>& node,
     ServerI* server,
-    const string& serverName,
+    string serverName,
     AdapterPrx proxy,
-    const string& id,
+    string id,
     bool enabled)
     : _node(node),
       _this(std::move(proxy)),
-      _serverId(serverName),
-      _id(id),
+      _serverId(std::move(serverName)),
+      _id(std::move(id)),
       _server(server),
       _enabled(enabled)
 {

--- a/cpp/src/IceGrid/ServerAdapterI.cpp
+++ b/cpp/src/IceGrid/ServerAdapterI.cpp
@@ -3,12 +3,10 @@
 //
 
 #include "ServerAdapterI.h"
-
 #include "Ice/Ice.h"
 #include "NodeI.h"
 #include "ServerI.h"
 #include "TraceLevels.h"
-#include <utility>
 
 using namespace std;
 using namespace IceGrid;

--- a/cpp/src/IceGrid/ServerAdapterI.h
+++ b/cpp/src/IceGrid/ServerAdapterI.h
@@ -15,13 +15,7 @@ namespace IceGrid
     class ServerAdapterI : public Adapter
     {
     public:
-        ServerAdapterI(
-            const std::shared_ptr<NodeI>&,
-            ServerI*,
-            const std::string&,
-            AdapterPrx,
-            const std::string&,
-            bool);
+        ServerAdapterI(const std::shared_ptr<NodeI>&, ServerI*, std::string, AdapterPrx, std::string, bool);
         ~ServerAdapterI() override;
 
         void activateAsync(

--- a/cpp/src/IceGrid/ServerCache.cpp
+++ b/cpp/src/IceGrid/ServerCache.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "ServerCache.h"
+
 #include "../Ice/DisableWarnings.h"
 #include "AdapterCache.h"
 #include "AllocatableObjectCache.h"
@@ -14,20 +15,16 @@
 #include "ObjectCache.h"
 #include "SessionI.h"
 #include "Topics.h"
+#include <utility>
 
 #include "SynchronizationException.h"
 
 using namespace std;
 using namespace IceGrid;
 
-CheckUpdateResult::CheckUpdateResult(
-    const string& server,
-    const string& node,
-    bool noRestart,
-    bool remove,
-    future<bool>&& result)
-    : _server(server),
-      _node(node),
+CheckUpdateResult::CheckUpdateResult(string server, string node, bool noRestart, bool remove, future<bool>&& result)
+    : _server(std::move(server)),
+      _node(std::move(node)),
       _remove(remove),
       _noRestart(noRestart),
       _result(std::move(result))
@@ -72,13 +69,13 @@ CheckUpdateResult::getResult()
 
 ServerCache::ServerCache(
     const shared_ptr<Ice::Communicator>& communicator,
-    const string& instanceName,
+    string instanceName,
     NodeCache& nodeCache,
     AdapterCache& adapterCache,
     ObjectCache& objectCache,
     AllocatableObjectCache& allocatableObjectCache)
     : _communicator(communicator),
-      _instanceName(instanceName),
+      _instanceName(std::move(instanceName)),
       _nodeCache(nodeCache),
       _adapterCache(adapterCache),
       _objectCache(objectCache),
@@ -322,10 +319,10 @@ ServerCache::removeCommunicator(
     }
 }
 
-ServerEntry::ServerEntry(ServerCache& cache, const string& id)
+ServerEntry::ServerEntry(ServerCache& cache, string id)
     : Allocatable(false, nullptr),
       _cache(cache),
-      _id(id),
+      _id(std::move(id)),
       _activationTimeout(-1),
       _deactivationTimeout(-1),
       _synchronizing(false),

--- a/cpp/src/IceGrid/ServerCache.cpp
+++ b/cpp/src/IceGrid/ServerCache.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "ServerCache.h"
-
 #include "../Ice/DisableWarnings.h"
 #include "AdapterCache.h"
 #include "AllocatableObjectCache.h"
@@ -15,7 +14,6 @@
 #include "ObjectCache.h"
 #include "SessionI.h"
 #include "Topics.h"
-#include <utility>
 
 #include "SynchronizationException.h"
 

--- a/cpp/src/IceGrid/ServerCache.h
+++ b/cpp/src/IceGrid/ServerCache.h
@@ -25,7 +25,7 @@ namespace IceGrid
     class CheckUpdateResult final
     {
     public:
-        CheckUpdateResult(const std::string&, const std::string&, bool, bool, std::future<bool>&&);
+        CheckUpdateResult(std::string, std::string, bool, bool, std::future<bool>&&);
 
         bool getResult();
 
@@ -42,7 +42,7 @@ namespace IceGrid
     class ServerEntry final : public Allocatable
     {
     public:
-        ServerEntry(ServerCache&, const std::string&);
+        ServerEntry(ServerCache&, std::string);
 
         void sync();
         void waitForSync(std::chrono::seconds);
@@ -122,7 +122,7 @@ namespace IceGrid
     public:
         ServerCache(
             const Ice::CommunicatorPtr&,
-            const std::string&,
+            std::string,
             NodeCache&,
             AdapterCache&,
             ObjectCache&,

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -16,6 +16,7 @@
 
 #include <fstream>
 #include <sys/types.h>
+#include <utility>
 
 #ifdef _WIN32
 #    include <direct.h>
@@ -381,10 +382,10 @@ ServerCommand::ServerCommand(const shared_ptr<ServerI>& server) : _server(server
 
 TimedServerCommand::TimedServerCommand(
     const shared_ptr<ServerI>& server,
-    const IceInternal::TimerPtr& timer,
+    IceInternal::TimerPtr timer,
     chrono::seconds timeout)
     : ServerCommand(server),
-      _timer(timer),
+      _timer(std::move(timer)),
       _timeout(timeout)
 {
 }

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -16,7 +16,6 @@
 
 #include <fstream>
 #include <sys/types.h>
-#include <utility>
 
 #ifdef _WIN32
 #    include <direct.h>

--- a/cpp/src/IceGrid/ServerI.h
+++ b/cpp/src/IceGrid/ServerI.h
@@ -190,7 +190,7 @@ namespace IceGrid
     class TimedServerCommand : public ServerCommand, public std::enable_shared_from_this<TimedServerCommand>
     {
     public:
-        TimedServerCommand(const std::shared_ptr<ServerI>&, const IceInternal::TimerPtr&, std::chrono::seconds);
+        TimedServerCommand(const std::shared_ptr<ServerI>&, IceInternal::TimerPtr, std::chrono::seconds);
         virtual void timeout() = 0;
 
         void startTimer();

--- a/cpp/src/IceGrid/SessionI.cpp
+++ b/cpp/src/IceGrid/SessionI.cpp
@@ -3,14 +3,12 @@
 //
 
 #include "SessionI.h"
-
 #include "../Ice/SSL/SSLUtil.h"
 #include "Database.h"
 #include "Ice/Ice.h"
 #include "IceGrid/Admin.h"
 #include "LocatorI.h"
 #include "QueryI.h"
-#include <utility>
 
 using namespace std;
 using namespace IceGrid;

--- a/cpp/src/IceGrid/SessionI.cpp
+++ b/cpp/src/IceGrid/SessionI.cpp
@@ -3,12 +3,14 @@
 //
 
 #include "SessionI.h"
+
 #include "../Ice/SSL/SSLUtil.h"
 #include "Database.h"
 #include "Ice/Ice.h"
 #include "IceGrid/Admin.h"
 #include "LocatorI.h"
 #include "QueryI.h"
+#include <utility>
 
 using namespace std;
 using namespace IceGrid;
@@ -48,9 +50,9 @@ namespace IceGrid
     };
 }
 
-BaseSessionI::BaseSessionI(const string& id, const string& prefix, const shared_ptr<Database>& database)
-    : _id(id),
-      _prefix(prefix),
+BaseSessionI::BaseSessionI(string id, string prefix, const shared_ptr<Database>& database)
+    : _id(std::move(id)),
+      _prefix(std::move(prefix)),
       _traceLevels(database->getTraceLevels()),
       _database(database),
       _destroyed(false)
@@ -110,9 +112,9 @@ BaseSessionI::getGlacier2AdapterIdSet()
     return _servantManager->getGlacier2AdapterIdSet(shared_from_this());
 }
 
-SessionI::SessionI(const string& id, const shared_ptr<Database>& database, const IceInternal::TimerPtr& timer)
+SessionI::SessionI(const string& id, const shared_ptr<Database>& database, IceInternal::TimerPtr timer)
     : BaseSessionI(id, "client", database),
-      _timer(timer),
+      _timer(std::move(timer)),
       _allocationTimeout(-1)
 {
 }
@@ -260,11 +262,11 @@ SessionI::destroyImpl(bool shutdown)
 ClientSessionFactory::ClientSessionFactory(
     const shared_ptr<SessionServantManager>& servantManager,
     const shared_ptr<Database>& database,
-    const IceInternal::TimerPtr& timer,
+    IceInternal::TimerPtr timer,
     const shared_ptr<ReapThread>& reaper)
     : _servantManager(servantManager),
       _database(database),
-      _timer(timer),
+      _timer(std::move(timer)),
       _reaper(reaper),
       _filters(false)
 {

--- a/cpp/src/IceGrid/SessionI.h
+++ b/cpp/src/IceGrid/SessionI.h
@@ -35,7 +35,7 @@ namespace IceGrid
         virtual void destroyImpl(bool);
 
     protected:
-        BaseSessionI(const std::string&, const std::string&, const std::shared_ptr<Database>&);
+        BaseSessionI(std::string, std::string, const std::shared_ptr<Database>&);
 
         const std::string _id;
         const std::string _prefix;
@@ -54,7 +54,7 @@ namespace IceGrid
     class SessionI final : public BaseSessionI, public Session
     {
     public:
-        SessionI(const std::string&, const std::shared_ptr<Database>&, const IceInternal::TimerPtr&);
+        SessionI(const std::string&, const std::shared_ptr<Database>&, IceInternal::TimerPtr);
 
         Ice::ObjectPrx _register(const std::shared_ptr<SessionServantManager>&, const Ice::ConnectionPtr&);
 
@@ -96,7 +96,7 @@ namespace IceGrid
         ClientSessionFactory(
             const std::shared_ptr<SessionServantManager>&,
             const std::shared_ptr<Database>&,
-            const IceInternal::TimerPtr&,
+            IceInternal::TimerPtr,
             const std::shared_ptr<ReapThread>&);
 
         Glacier2::SessionPrx createGlacier2Session(

--- a/cpp/src/IceGrid/SessionManager.h
+++ b/cpp/src/IceGrid/SessionManager.h
@@ -5,11 +5,8 @@
 #ifndef ICEGRID_SESSION_MANAGER_H
 #define ICEGRID_SESSION_MANAGER_H
 
-#include <utility>
-
 #include "Ice/Logger.h"
 #include "Ice/LoggerUtil.h"
-
 #include "IceGrid/Registry.h"
 #include "Internal.h"
 #include "Util.h"

--- a/cpp/src/IceGrid/SessionManager.h
+++ b/cpp/src/IceGrid/SessionManager.h
@@ -5,6 +5,8 @@
 #ifndef ICEGRID_SESSION_MANAGER_H
 #define ICEGRID_SESSION_MANAGER_H
 
+#include <utility>
+
 #include "Ice/Logger.h"
 #include "Ice/LoggerUtil.h"
 
@@ -33,9 +35,9 @@ namespace IceGrid
         };
 
     public:
-        SessionKeepAliveThread(std::optional<InternalRegistryPrx> registry, const Ice::LoggerPtr& logger)
+        SessionKeepAliveThread(std::optional<InternalRegistryPrx> registry, Ice::LoggerPtr logger)
             : _registry(std::move(registry)),
-              _logger(logger),
+              _logger(std::move(logger)),
               _state(InProgress),
               _nextAction(None),
               _thread([this] { run(); })

--- a/cpp/src/IceGrid/SessionServantManager.cpp
+++ b/cpp/src/IceGrid/SessionServantManager.cpp
@@ -7,7 +7,6 @@
 #include "Ice/ObjectAdapter.h"
 #include "Ice/UUID.h"
 #include <iterator>
-#include <utility>
 
 using namespace std;
 using namespace IceGrid;

--- a/cpp/src/IceGrid/SessionServantManager.cpp
+++ b/cpp/src/IceGrid/SessionServantManager.cpp
@@ -7,30 +7,31 @@
 #include "Ice/ObjectAdapter.h"
 #include "Ice/UUID.h"
 #include <iterator>
+#include <utility>
 
 using namespace std;
 using namespace IceGrid;
 
 SessionServantManager::SessionServantManager(
-    const Ice::ObjectAdapterPtr& adapter,
-    const string& instanceName,
+    Ice::ObjectAdapterPtr adapter,
+    string instanceName,
     bool checkConnection,
-    const string& serverAdminCategory,
-    const Ice::ObjectPtr& serverAdminRouter,
-    const string& nodeAdminCategory,
-    const Ice::ObjectPtr& nodeAdminRouter,
-    const string& replicaAdminCategory,
-    const Ice::ObjectPtr& replicaAdminRouter,
+    string serverAdminCategory,
+    Ice::ObjectPtr serverAdminRouter,
+    string nodeAdminCategory,
+    Ice::ObjectPtr nodeAdminRouter,
+    string replicaAdminCategory,
+    Ice::ObjectPtr replicaAdminRouter,
     const shared_ptr<AdminCallbackRouter>& adminCallbackRouter)
-    : _adapter(adapter),
-      _instanceName(instanceName),
+    : _adapter(std::move(adapter)),
+      _instanceName(std::move(instanceName)),
       _checkConnection(checkConnection),
-      _serverAdminCategory(serverAdminCategory),
-      _serverAdminRouter(serverAdminRouter),
-      _nodeAdminCategory(nodeAdminCategory),
-      _nodeAdminRouter(nodeAdminRouter),
-      _replicaAdminCategory(replicaAdminCategory),
-      _replicaAdminRouter(replicaAdminRouter),
+      _serverAdminCategory(std::move(serverAdminCategory)),
+      _serverAdminRouter(std::move(serverAdminRouter)),
+      _nodeAdminCategory(std::move(nodeAdminCategory)),
+      _nodeAdminRouter(std::move(nodeAdminRouter)),
+      _replicaAdminCategory(std::move(replicaAdminCategory)),
+      _replicaAdminRouter(std::move(replicaAdminRouter)),
       _adminCallbackRouter(adminCallbackRouter)
 {
 }

--- a/cpp/src/IceGrid/SessionServantManager.h
+++ b/cpp/src/IceGrid/SessionServantManager.h
@@ -6,12 +6,10 @@
 #define ICEGRID_SESSIONSERVANTLOCATOR_H
 
 #include "AdminCallbackRouter.h"
+#include "Glacier2/Session.h"
 #include "Ice/ServantLocator.h"
 
-#include "Glacier2/Session.h"
-
 #include <set>
-#include <utility>
 
 namespace IceGrid
 {

--- a/cpp/src/IceGrid/SessionServantManager.h
+++ b/cpp/src/IceGrid/SessionServantManager.h
@@ -11,6 +11,7 @@
 #include "Glacier2/Session.h"
 
 #include <set>
+#include <utility>
 
 namespace IceGrid
 {
@@ -18,15 +19,15 @@ namespace IceGrid
     {
     public:
         SessionServantManager(
-            const Ice::ObjectAdapterPtr&,
-            const std::string&,
+            Ice::ObjectAdapterPtr,
+            std::string,
             bool,
-            const std::string&,
-            const Ice::ObjectPtr&,
-            const std::string&,
-            const Ice::ObjectPtr&,
-            const std::string&,
-            const Ice::ObjectPtr&,
+            std::string,
+            Ice::ObjectPtr,
+            std::string,
+            Ice::ObjectPtr,
+            std::string,
+            Ice::ObjectPtr,
             const std::shared_ptr<AdminCallbackRouter>&);
 
         Ice::ObjectPtr locate(const Ice::Current&, std::shared_ptr<void>&) override;
@@ -49,10 +50,10 @@ namespace IceGrid
 
         struct ServantInfo
         {
-            ServantInfo(const Ice::ObjectPtr& s, const Ice::ConnectionPtr& con, const Ice::ObjectPtr& ss)
-                : servant(s),
-                  connection(con),
-                  session(ss)
+            ServantInfo(Ice::ObjectPtr s, Ice::ConnectionPtr con, Ice::ObjectPtr ss)
+                : servant(std::move(s)),
+                  connection(std::move(con)),
+                  session(std::move(ss))
             {
             }
 
@@ -63,7 +64,7 @@ namespace IceGrid
 
         struct SessionInfo
         {
-            SessionInfo(const Ice::ConnectionPtr& c, const std::string& cat) : connection(c), category(cat) {}
+            SessionInfo(Ice::ConnectionPtr c, std::string cat) : connection(std::move(c)), category(std::move(cat)) {}
 
             const Ice::ConnectionPtr connection;
             const std::string category;

--- a/cpp/src/IceLocatorDiscovery/PluginI.cpp
+++ b/cpp/src/IceLocatorDiscovery/PluginI.cpp
@@ -5,12 +5,10 @@
 #include "../Ice/Network.h" // For getInterfacesForMulticast
 #include "Ice/Ice.h"
 #include "Ice/LoggerUtil.h"
-
 #include "IceLocatorDiscovery.h"
 #include "Plugin.h"
 
 #include <thread>
-#include <utility>
 
 using namespace std;
 using namespace IceLocatorDiscovery;

--- a/cpp/src/IceLocatorDiscovery/PluginI.cpp
+++ b/cpp/src/IceLocatorDiscovery/PluginI.cpp
@@ -10,6 +10,7 @@
 #include "Plugin.h"
 
 #include <thread>
+#include <utility>
 
 using namespace std;
 using namespace IceLocatorDiscovery;
@@ -22,16 +23,16 @@ namespace
     public:
         Request(
             LocatorI* locator,
-            const string& operation,
+            string operation,
             Ice::OperationMode mode,
             pair<const byte*, const byte*> inParams,
-            const Ice::Context& ctx,
+            Ice::Context ctx,
             function<void(bool, pair<const byte*, const byte*>)> responseCallback,
             function<void(exception_ptr)> exceptionCallback)
             : _locator(locator),
-              _operation(operation),
+              _operation(std::move(operation)),
               _mode(mode),
-              _context(ctx),
+              _context(std::move(ctx)),
               _inParams(inParams.first, inParams.second),
               _responseCallback(std::move(responseCallback)),
               _exceptionCallback(std::move(exceptionCallback))
@@ -61,7 +62,7 @@ namespace
                            public std::enable_shared_from_this<LocatorI>
     {
     public:
-        LocatorI(const LookupPrx&, const Ice::PropertiesPtr&, const string&, const Ice::LocatorPrx&);
+        LocatorI(const LookupPrx&, const Ice::PropertiesPtr&, string, Ice::LocatorPrx);
         void setLookupReply(const LookupReplyPrx&);
 
         void ice_invokeAsync(
@@ -108,7 +109,7 @@ namespace
     class LookupReplyI final : public LookupReply
     {
     public:
-        LookupReplyI(const LocatorIPtr& locator) : _locator(locator) {}
+        LookupReplyI(LocatorIPtr locator) : _locator(std::move(locator)) {}
 
         void foundLocator(optional<Ice::LocatorPrx>, const Ice::Current&) final;
 
@@ -146,7 +147,7 @@ namespace
     class PluginI final : public Plugin
     {
     public:
-        PluginI(const Ice::CommunicatorPtr&);
+        PluginI(Ice::CommunicatorPtr);
 
         void initialize() final;
         void destroy() final;
@@ -183,7 +184,7 @@ namespace Ice
     }
 }
 
-PluginI::PluginI(const Ice::CommunicatorPtr& communicator) : _communicator(communicator) {}
+PluginI::PluginI(Ice::CommunicatorPtr communicator) : _communicator(std::move(communicator)) {}
 
 void
 PluginI::initialize()
@@ -376,18 +377,18 @@ Request::exception(std::exception_ptr ex)
 LocatorI::LocatorI(
     const LookupPrx& lookup,
     const Ice::PropertiesPtr& p,
-    const string& instanceName,
-    const Ice::LocatorPrx& voidLocator)
+    string instanceName,
+    Ice::LocatorPrx voidLocator)
     : _lookup(lookup),
       _timeout(chrono::milliseconds(p->getIcePropertyAsInt("IceLocatorDiscovery.Timeout"))),
       _retryCount(p->getIcePropertyAsInt("IceLocatorDiscovery.RetryCount")),
       _retryDelay(chrono::milliseconds(p->getIcePropertyAsInt("IceLocatorDiscovery.RetryDelay"))),
       _timer(IceInternal::getInstanceTimer(lookup->ice_getCommunicator())),
       _traceLevel(p->getIcePropertyAsInt("IceLocatorDiscovery.Trace.Lookup")),
-      _instanceName(instanceName),
+      _instanceName(std::move(instanceName)),
       _warned(false),
       _locator(lookup->ice_getCommunicator()->getDefaultLocator()),
-      _voidLocator(voidLocator),
+      _voidLocator(std::move(voidLocator)),
       _pending(false),
       _pendingRetryCount(0),
       _failureCount(0),

--- a/cpp/src/IceStorm/Instance.cpp
+++ b/cpp/src/IceStorm/Instance.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "Instance.h"
-
 #include "../Ice/InstrumentationI.h"
 #include "../Ice/TraceUtil.h"
 #include "Ice/Communicator.h"
@@ -13,7 +12,6 @@
 #include "NodeI.h"
 #include "Observers.h"
 #include "TraceLevels.h"
-#include <utility>
 
 using namespace std;
 using namespace IceStorm;

--- a/cpp/src/IceStorm/Instance.cpp
+++ b/cpp/src/IceStorm/Instance.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "Instance.h"
+
 #include "../Ice/InstrumentationI.h"
 #include "../Ice/TraceUtil.h"
 #include "Ice/Communicator.h"
@@ -12,6 +13,7 @@
 #include "NodeI.h"
 #include "Observers.h"
 #include "TraceLevels.h"
+#include <utility>
 
 using namespace std;
 using namespace IceStorm;
@@ -53,14 +55,14 @@ TopicReaper::consumeReapedTopics()
 }
 
 Instance::Instance(
-    const string& instanceName,
+    string instanceName,
     const string& serviceName,
     shared_ptr<Ice::Communicator> communicator,
     Ice::ObjectAdapterPtr publishAdapter,
     Ice::ObjectAdapterPtr topicAdapter,
     Ice::ObjectAdapterPtr nodeAdapter,
     optional<NodePrx> nodeProxy)
-    : _instanceName(instanceName),
+    : _instanceName(std::move(instanceName)),
       _serviceName(serviceName),
       _communicator(std::move(communicator)),
       _publishAdapter(std::move(publishAdapter)),

--- a/cpp/src/IceStorm/Instance.h
+++ b/cpp/src/IceStorm/Instance.h
@@ -44,7 +44,7 @@ namespace IceStorm
         };
 
         Instance(
-            const std::string&,
+            std::string,
             const std::string&,
             Ice::CommunicatorPtr,
             Ice::ObjectAdapterPtr,

--- a/cpp/src/IceStorm/Parser.cpp
+++ b/cpp/src/IceStorm/Parser.cpp
@@ -4,11 +4,12 @@
 
 #include "Parser.h"
 #include "../Ice/ConsoleUtil.h"
-#include "../Ice/DisableWarnings.h"
 #include "Ice/Ice.h"
 #include "IceStormInternal.h"
+
+#include "../Ice/DisableWarnings.h"
+
 #include <algorithm>
-#include <utility>
 
 #if defined(__APPLE__) || defined(__linux__)
 #    include <editline/readline.h>

--- a/cpp/src/IceStorm/Parser.cpp
+++ b/cpp/src/IceStorm/Parser.cpp
@@ -8,6 +8,7 @@
 #include "Ice/Ice.h"
 #include "IceStormInternal.h"
 #include <algorithm>
+#include <utility>
 
 #if defined(__APPLE__) || defined(__linux__)
 #    include <editline/readline.h>
@@ -40,7 +41,7 @@ namespace
     class UnknownManagerException : public std::exception
     {
     public:
-        explicit UnknownManagerException(const std::string& name) : _name(name) {}
+        explicit UnknownManagerException(std::string name) : _name(std::move(name)) {}
 
         [[nodiscard]] const char* what() const noexcept override { return _name.c_str(); }
 

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -12,6 +12,7 @@
 #include "Util.h"
 
 #include <algorithm>
+#include <utility>
 
 using namespace std;
 using namespace IceStorm;
@@ -380,12 +381,12 @@ TopicImpl::create(
 
 TopicImpl::TopicImpl(
     shared_ptr<PersistentInstance> instance,
-    const string& name,
-    const Ice::Identity& id,
+    string name,
+    Ice::Identity id,
     const SubscriberRecordSeq& subscribers)
     : _instance(std::move(instance)),
-      _name(name),
-      _id(id),
+      _name(std::move(name)),
+      _id(std::move(id)),
       _destroyed(false),
       _lluMap(_instance->lluMap()),
       _subscriberMap(_instance->subscriberMap())

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -12,7 +12,6 @@
 #include "Util.h"
 
 #include <algorithm>
-#include <utility>
 
 using namespace std;
 using namespace IceStorm;

--- a/cpp/src/IceStorm/TopicI.h
+++ b/cpp/src/IceStorm/TopicI.h
@@ -63,11 +63,7 @@ namespace IceStorm
         void updateSubscriberObservers();
 
     private:
-        TopicImpl(
-            std::shared_ptr<PersistentInstance>,
-            const std::string&,
-            const Ice::Identity&,
-            const SubscriberRecordSeq&);
+        TopicImpl(std::shared_ptr<PersistentInstance>, std::string, Ice::Identity, const SubscriberRecordSeq&);
 
         IceStormElection::LogUpdate destroyInternal(const IceStormElection::LogUpdate&, bool);
         void removeSubscribers(const Ice::IdentitySeq&);

--- a/cpp/src/IceStorm/TransientTopicI.cpp
+++ b/cpp/src/IceStorm/TransientTopicI.cpp
@@ -11,7 +11,6 @@
 
 #include <algorithm>
 #include <list>
-#include <utility>
 
 using namespace IceStorm;
 using namespace std;

--- a/cpp/src/IceStorm/TransientTopicI.cpp
+++ b/cpp/src/IceStorm/TransientTopicI.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <list>
+#include <utility>
 
 using namespace IceStorm;
 using namespace std;
@@ -101,10 +102,10 @@ TransientTopicImpl::create(const shared_ptr<Instance>& instance, const std::stri
     return topicImpl;
 }
 
-TransientTopicImpl::TransientTopicImpl(shared_ptr<Instance> instance, const std::string& name, const Ice::Identity& id)
+TransientTopicImpl::TransientTopicImpl(shared_ptr<Instance> instance, std::string name, Ice::Identity id)
     : _instance(std::move(instance)),
-      _name(name),
-      _id(id),
+      _name(std::move(name)),
+      _id(std::move(id)),
       _destroyed(false)
 {
 }

--- a/cpp/src/IceStorm/TransientTopicI.h
+++ b/cpp/src/IceStorm/TransientTopicI.h
@@ -41,7 +41,7 @@ namespace IceStorm
         void shutdown();
 
     private:
-        TransientTopicImpl(std::shared_ptr<Instance>, const std::string&, const Ice::Identity&);
+        TransientTopicImpl(std::shared_ptr<Instance>, std::string, Ice::Identity);
 
         //
         // Immutable members.

--- a/cpp/src/Slice/GrammarUtil.h
+++ b/cpp/src/Slice/GrammarUtil.h
@@ -7,6 +7,7 @@
 #include "Util.h"
 #include <cassert>
 #include <memory>
+#include <utility>
 
 #if defined(__clang__)
 #    pragma clang diagnostic push
@@ -33,7 +34,7 @@ namespace Slice
 
     struct TypeStringTok final : public GrammarBase
     {
-        TypeStringTok(TypePtr type, std::string name) : type(type), name(name) {}
+        TypeStringTok(TypePtr type, std::string name) : type(std::move(type)), name(std::move(name)) {}
         TypePtr type;
         std::string name;
     };
@@ -79,7 +80,11 @@ namespace Slice
     struct ConstDefTok final : public GrammarBase
     {
         ConstDefTok() {}
-        ConstDefTok(SyntaxTreeBasePtr value, std::string stringValue) : v(value), valueAsString(stringValue) {}
+        ConstDefTok(SyntaxTreeBasePtr value, std::string stringValue)
+            : v(std::move(value)),
+              valueAsString(std::move(stringValue))
+        {
+        }
 
         SyntaxTreeBasePtr v;
         std::string valueAsString;

--- a/cpp/src/Slice/GrammarUtil.h
+++ b/cpp/src/Slice/GrammarUtil.h
@@ -7,7 +7,6 @@
 #include "Util.h"
 #include <cassert>
 #include <memory>
-#include <utility>
 
 #if defined(__clang__)
 #    pragma clang diagnostic push

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -285,7 +285,7 @@ namespace Slice
     class SyntaxTreeBase : public GrammarBase
     {
     public:
-        SyntaxTreeBase(const UnitPtr& unit);
+        SyntaxTreeBase(UnitPtr unit);
         virtual void destroy();
         [[nodiscard]] UnitPtr unit() const;
         [[nodiscard]] DefinitionContextPtr definitionContext() const; // May be nil
@@ -397,7 +397,7 @@ namespace Slice
         [[nodiscard]] virtual std::string kindOf() const = 0;
 
     protected:
-        Contained(const ContainerPtr& container, const std::string& name);
+        Contained(const ContainerPtr& container, std::string name);
 
         ContainerPtr _container;
         std::string _name;
@@ -553,7 +553,7 @@ namespace Slice
     class ClassDef final : public virtual Container, public virtual Contained
     {
     public:
-        ClassDef(const ContainerPtr& container, const std::string& name, int id, const ClassDefPtr& base);
+        ClassDef(const ContainerPtr& container, const std::string& name, int id, ClassDefPtr base);
         void destroy() final;
         DataMemberPtr createDataMember(
             const std::string& name,
@@ -645,7 +645,7 @@ namespace Slice
             Idempotent = 2
         };
 
-        Operation(const ContainerPtr&, const std::string&, const TypePtr&, bool, int, Mode);
+        Operation(const ContainerPtr&, const std::string&, TypePtr, bool, int, Mode);
         [[nodiscard]] InterfaceDefPtr interface() const;
         [[nodiscard]] TypePtr returnType() const;
         [[nodiscard]] bool returnIsOptional() const;
@@ -694,7 +694,7 @@ namespace Slice
     class InterfaceDef final : public virtual Container, public virtual Contained
     {
     public:
-        InterfaceDef(const ContainerPtr& container, const std::string& name, const InterfaceList& bases);
+        InterfaceDef(const ContainerPtr& container, const std::string& name, InterfaceList bases);
         void destroy() final;
         OperationPtr createOperation(
             const std::string& name,
@@ -738,7 +738,7 @@ namespace Slice
     class Exception final : public virtual Container, public virtual Contained
     {
     public:
-        Exception(const ContainerPtr& container, const std::string& name, const ExceptionPtr& base);
+        Exception(const ContainerPtr& container, const std::string& name, ExceptionPtr base);
         void destroy() final;
         DataMemberPtr createDataMember(
             const std::string& name,
@@ -795,11 +795,7 @@ namespace Slice
     class Sequence final : public virtual Constructed, public std::enable_shared_from_this<Sequence>
     {
     public:
-        Sequence(
-            const ContainerPtr& container,
-            const std::string& name,
-            const TypePtr& type,
-            MetadataList typeMetadata);
+        Sequence(const ContainerPtr& container, const std::string& name, TypePtr type, MetadataList typeMetadata);
         [[nodiscard]] TypePtr type() const;
         [[nodiscard]] MetadataList typeMetadata() const;
         void setTypeMetadata(MetadataList metadata);
@@ -825,9 +821,9 @@ namespace Slice
         Dictionary(
             const ContainerPtr& container,
             const std::string& name,
-            const TypePtr& keyType,
+            TypePtr keyType,
             MetadataList keyMetadata,
-            const TypePtr& valueType,
+            TypePtr valueType,
             MetadataList valueMetadata);
         [[nodiscard]] TypePtr keyType() const;
         [[nodiscard]] TypePtr valueType() const;
@@ -906,10 +902,10 @@ namespace Slice
         Const(
             const ContainerPtr& container,
             const std::string& name,
-            const TypePtr& type,
+            TypePtr type,
             MetadataList typeMetadata,
-            const SyntaxTreeBasePtr& valueType,
-            const std::string& valueString);
+            SyntaxTreeBasePtr valueType,
+            std::string valueString);
         [[nodiscard]] TypePtr type() const;
         [[nodiscard]] MetadataList typeMetadata() const;
         void setTypeMetadata(MetadataList metadata);
@@ -935,7 +931,7 @@ namespace Slice
         Parameter(
             const ContainerPtr& container,
             const std::string& name,
-            const TypePtr& type,
+            TypePtr type,
             bool isOutParam,
             bool isOptional,
             int tag);
@@ -963,11 +959,11 @@ namespace Slice
         DataMember(
             const ContainerPtr& container,
             const std::string& name,
-            const TypePtr& type,
+            TypePtr type,
             bool isOptional,
             int tag,
-            const SyntaxTreeBasePtr& defaultValueType,
-            const std::string& defaultValueString);
+            SyntaxTreeBasePtr defaultValueType,
+            std::string defaultValueString);
         [[nodiscard]] TypePtr type() const;
         [[nodiscard]] bool optional() const;
         [[nodiscard]] int tag() const;

--- a/cpp/src/Slice/Preprocessor.cpp
+++ b/cpp/src/Slice/Preprocessor.cpp
@@ -14,6 +14,7 @@
 #include <iterator>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <utility>
 #include <vector>
 
 #ifndef _WIN32
@@ -48,8 +49,8 @@ Slice::Preprocessor::create(const string& path, const string& fileName, const ve
     return make_shared<Preprocessor>(path, fileName, args);
 }
 
-Slice::Preprocessor::Preprocessor(const string& path, const string& fileName, const vector<string>& args)
-    : _path(path),
+Slice::Preprocessor::Preprocessor(string path, const string& fileName, const vector<string>& args)
+    : _path(std::move(path)),
       _fileName(fullPath(fileName)),
       _shortFileName(fileName),
       _args(args),

--- a/cpp/src/Slice/Preprocessor.cpp
+++ b/cpp/src/Slice/Preprocessor.cpp
@@ -14,7 +14,6 @@
 #include <iterator>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <utility>
 #include <vector>
 
 #ifndef _WIN32

--- a/cpp/src/Slice/Preprocessor.h
+++ b/cpp/src/Slice/Preprocessor.h
@@ -18,7 +18,7 @@ namespace Slice
         static PreprocessorPtr
         create(const std::string& path, const std::string& fileName, const std::vector<std::string>& args);
 
-        Preprocessor(const std::string& path, const std::string& fileName, const std::vector<std::string>& args);
+        Preprocessor(std::string path, const std::string& fileName, const std::vector<std::string>& args);
         ~Preprocessor();
 
         FILE* preprocess(bool keepComments, const std::string& languageArg = "");

--- a/cpp/src/Slice/StringLiteralUtil.cpp
+++ b/cpp/src/Slice/StringLiteralUtil.cpp
@@ -7,6 +7,7 @@
 #include <cassert>
 #include <iomanip>
 #include <ostream>
+#include <utility>
 
 using namespace std;
 using namespace Slice;
@@ -18,7 +19,7 @@ namespace
     class StringLiteralGenerator final
     {
     public:
-        StringLiteralGenerator(const string&, const string&, EscapeMode, unsigned char);
+        StringLiteralGenerator(string, const string&, EscapeMode, unsigned char);
 
         string escapeASCIIChar(char);
         string escapeCodePoint(unsigned int);
@@ -45,11 +46,11 @@ namespace
     };
 
     StringLiteralGenerator::StringLiteralGenerator(
-        const string& nonPrintableEscaped,
+        string nonPrintableEscaped,
         const string& printableEscaped,
         EscapeMode escapeMode,
         unsigned char cutOff)
-        : _nonPrintableEscaped(nonPrintableEscaped),
+        : _nonPrintableEscaped(std::move(nonPrintableEscaped)),
           _printableEscaped(printableEscaped + "\\"),
           _escapeMode(escapeMode),
           _cutOff(cutOff),

--- a/cpp/src/Slice/StringLiteralUtil.cpp
+++ b/cpp/src/Slice/StringLiteralUtil.cpp
@@ -7,7 +7,6 @@
 #include <cassert>
 #include <iomanip>
 #include <ostream>
-#include <utility>
 
 using namespace std;
 using namespace Slice;

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -6,7 +6,6 @@
 #include "../Slice/Util.h"
 
 #include <cassert>
-#include <utility>
 
 using namespace std;
 using namespace Slice;

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -6,6 +6,7 @@
 #include "../Slice/Util.h"
 
 #include <cassert>
+#include <utility>
 
 using namespace std;
 using namespace Slice;
@@ -402,7 +403,7 @@ namespace
     }
 }
 
-Gen::Gen(const std::string& fileBase) : _fileBase(fileBase) {}
+Gen::Gen(std::string fileBase) : _fileBase(std::move(fileBase)) {}
 
 void
 Gen::generate(const UnitPtr& p)
@@ -466,8 +467,8 @@ Gen::OutputModulesVisitor::modules() const
     return _modules;
 }
 
-Gen::TypesVisitor::TypesVisitor(const std::string& fileBase, const std::set<std::string>& modules)
-    : _fileBase(fileBase),
+Gen::TypesVisitor::TypesVisitor(std::string fileBase, const std::set<std::string>& modules)
+    : _fileBase(std::move(fileBase)),
       _modules(modules)
 {
 }

--- a/cpp/src/ice2slice/Gen.h
+++ b/cpp/src/ice2slice/Gen.h
@@ -15,7 +15,7 @@ namespace Slice
     class Gen
     {
     public:
-        Gen(const std::string&);
+        Gen(std::string);
 
         void generate(const UnitPtr&);
 
@@ -57,7 +57,7 @@ namespace Slice
         class TypesVisitor final : public ParserVisitor
         {
         public:
-            TypesVisitor(const std::string& fileBase, const std::set<std::string>& modules);
+            TypesVisitor(std::string fileBase, const std::set<std::string>& modules);
 
             void visitUnitEnd(const UnitPtr&) final;
             bool visitClassDefStart(const ClassDefPtr&) final;

--- a/cpp/src/icegriddb/IceGridDB.cpp
+++ b/cpp/src/icegriddb/IceGridDB.cpp
@@ -14,6 +14,7 @@
 
 #include <fstream>
 #include <iterator>
+#include <utility>
 
 using namespace std;
 using namespace IceInternal;
@@ -23,7 +24,7 @@ namespace
     class ServerDescriptorI : public IceGrid::ServerDescriptor
     {
     public:
-        ServerDescriptorI(const string& serverVersion) : _serverVersion(serverVersion) {}
+        ServerDescriptorI(string serverVersion) : _serverVersion(std::move(serverVersion)) {}
 
     protected:
         void ice_postUnmarshal() override { iceVersion = _serverVersion; }
@@ -35,7 +36,7 @@ namespace
     class IceBoxDescriptorI : public IceGrid::IceBoxDescriptor
     {
     public:
-        IceBoxDescriptorI(const string& serverVersion) : _serverVersion(serverVersion) {}
+        IceBoxDescriptorI(string serverVersion) : _serverVersion(std::move(serverVersion)) {}
 
     protected:
         void ice_postUnmarshal() override { iceVersion = _serverVersion; }

--- a/cpp/src/icegriddb/IceGridDB.cpp
+++ b/cpp/src/icegriddb/IceGridDB.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "../Ice/ConsoleUtil.h"
-#include "../Ice/DisableWarnings.h"
 #include "../Ice/FileUtil.h"
 #include "../Ice/Options.h"
 #include "../IceDB/IceDB.h"
@@ -12,9 +11,10 @@
 #include "Ice/StringUtil.h"
 #include "IceGrid/Admin.h"
 
+#include "../Ice/DisableWarnings.h"
+
 #include <fstream>
 #include <iterator>
-#include <utility>
 
 using namespace std;
 using namespace IceInternal;

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -14,6 +14,7 @@
 #include <cassert>
 #include <limits>
 #include <string.h>
+#include <utility>
 
 using namespace std;
 using namespace Slice;
@@ -587,22 +588,22 @@ namespace
 }
 
 Slice::Gen::Gen(
-    const string& base,
-    const string& headerExtension,
-    const string& sourceExtension,
+    string base,
+    string headerExtension,
+    string sourceExtension,
     const vector<string>& extraHeaders,
-    const string& include,
+    string include,
     const vector<string>& includePaths,
-    const string& dllExport,
-    const string& dir)
-    : _base(base),
-      _headerExtension(headerExtension),
-      _sourceExtension(sourceExtension),
+    string dllExport,
+    string dir)
+    : _base(std::move(base)),
+      _headerExtension(std::move(headerExtension)),
+      _sourceExtension(std::move(sourceExtension)),
       _extraHeaders(extraHeaders),
-      _include(include),
+      _include(std::move(include)),
       _includePaths(includePaths),
-      _dllExport(dllExport),
-      _dir(dir)
+      _dllExport(std::move(dllExport)),
+      _dir(std::move(dir))
 {
     for (vector<string>::iterator p = _includePaths.begin(); p != _includePaths.end(); ++p)
     {
@@ -1264,10 +1265,10 @@ Slice::Gen::DefaultFactoryVisitor::visitExceptionStart(const ExceptionPtr& p)
     return false;
 }
 
-Slice::Gen::ProxyVisitor::ProxyVisitor(Output& h, Output& c, const string& dllExport)
+Slice::Gen::ProxyVisitor::ProxyVisitor(Output& h, Output& c, string dllExport)
     : H(h),
       C(c),
-      _dllExport(dllExport),
+      _dllExport(std::move(dllExport)),
       _useWstring(TypeContext::None)
 {
 }
@@ -2473,13 +2474,10 @@ Slice::Gen::DataDefVisitor::emitDataMember(const DataMemberPtr& p)
     H << ";";
 }
 
-Slice::Gen::InterfaceVisitor::InterfaceVisitor(
-    ::IceInternal::Output& h,
-    ::IceInternal::Output& c,
-    const string& dllExport)
+Slice::Gen::InterfaceVisitor::InterfaceVisitor(::IceInternal::Output& h, ::IceInternal::Output& c, string dllExport)
     : H(h),
       C(c),
-      _dllExport(dllExport),
+      _dllExport(std::move(dllExport)),
       _useWstring(TypeContext::None)
 {
 }

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -14,7 +14,6 @@
 #include <cassert>
 #include <limits>
 #include <string.h>
-#include <utility>
 
 using namespace std;
 using namespace Slice;

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -14,14 +14,14 @@ namespace Slice
     class Gen final
     {
     public:
-        Gen(const std::string&,
-            const std::string&,
-            const std::string&,
+        Gen(std::string,
+            std::string,
+            std::string,
             const std::vector<std::string>&,
-            const std::string&,
+            std::string,
             const std::vector<std::string>&,
-            const std::string&,
-            const std::string&);
+            std::string,
+            std::string);
         ~Gen();
 
         Gen(const Gen&) = delete;
@@ -105,7 +105,7 @@ namespace Slice
         class ProxyVisitor final : public ParserVisitor
         {
         public:
-            ProxyVisitor(::IceInternal::Output&, ::IceInternal::Output&, const std::string&);
+            ProxyVisitor(::IceInternal::Output&, ::IceInternal::Output&, std::string);
             ProxyVisitor(const ProxyVisitor&) = delete;
 
             bool visitModuleStart(const ModulePtr&) final;
@@ -164,7 +164,7 @@ namespace Slice
         class InterfaceVisitor final : public ParserVisitor
         {
         public:
-            InterfaceVisitor(::IceInternal::Output&, ::IceInternal::Output&, const std::string&);
+            InterfaceVisitor(::IceInternal::Output&, ::IceInternal::Output&, std::string);
             InterfaceVisitor(const InterfaceVisitor&) = delete;
 
             bool visitModuleStart(const ModulePtr&) final;

--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -4,12 +4,11 @@
 
 #include "../Ice/ConsoleUtil.h"
 #include "../Ice/Options.h"
-#include "Ice/CtrlCHandler.h"
-
 #include "../Slice/FileTracker.h"
 #include "../Slice/Preprocessor.h"
 #include "../Slice/Util.h"
 #include "Gen.h"
+#include "Ice/CtrlCHandler.h"
 
 #include <algorithm>
 #include <cassert>

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -10,7 +10,6 @@
 #include <algorithm>
 #include <cassert>
 #include <limits>
-#include <utility>
 
 using namespace std;
 using namespace Slice;

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <cassert>
 #include <limits>
+#include <utility>
 
 using namespace std;
 using namespace Slice;
@@ -2217,10 +2218,10 @@ Slice::JavaVisitor::writeSeeAlso(Output& out, const UnitPtr& unt, const string& 
     }
 }
 
-Slice::Gen::Gen(const string& /*name*/, const string& base, const vector<string>& includePaths, const string& dir)
-    : _base(base),
+Slice::Gen::Gen(const string& /*name*/, string base, const vector<string>& includePaths, string dir)
+    : _base(std::move(base)),
       _includePaths(includePaths),
-      _dir(dir)
+      _dir(std::move(dir))
 {
 }
 

--- a/cpp/src/slice2java/Gen.h
+++ b/cpp/src/slice2java/Gen.h
@@ -118,7 +118,7 @@ namespace Slice
     class Gen final
     {
     public:
-        Gen(const std::string&, const std::string&, const std::vector<std::string>&, const std::string&);
+        Gen(const std::string&, std::string, const std::vector<std::string>&, std::string);
         Gen(const Gen&) = delete;
         ~Gen();
 

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -13,6 +13,7 @@
 #include <cassert>
 #include <string.h>
 #include <sys/types.h>
+#include <utility>
 
 #ifdef _WIN32
 #    include <direct.h>
@@ -301,7 +302,7 @@ Slice::JavaOutput::printHeader()
     print("//\n");
 }
 
-Slice::JavaGenerator::JavaGenerator(const string& dir) : _dir(dir), _out(nullptr) {}
+Slice::JavaGenerator::JavaGenerator(string dir) : _dir(std::move(dir)), _out(nullptr) {}
 
 Slice::JavaGenerator::~JavaGenerator()
 {

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -13,7 +13,6 @@
 #include <cassert>
 #include <string.h>
 #include <sys/types.h>
-#include <utility>
 
 #ifdef _WIN32
 #    include <direct.h>

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -79,7 +79,7 @@ namespace Slice
         // If a match is found, return the symbol with a leading underscore.
         static std::string fixKwd(const std::string&);
 
-        JavaGenerator(const std::string&);
+        JavaGenerator(std::string);
 
         //
         // Given the fully-scoped Java class name, create any intermediate

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -15,7 +15,6 @@
 #include <cassert>
 #include <iostream>
 #include <iterator>
-#include <utility>
 
 using namespace std;
 using namespace Slice;

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <iostream>
 #include <iterator>
+#include <utility>
 
 using namespace std;
 using namespace Slice;
@@ -679,7 +680,7 @@ Slice::Gen::ImportVisitor::ImportVisitor(IceInternal::Output& out, vector<string
       _seenObjectSeq(false),
       _seenObjectDict(false),
       _seenObjectProxyDict(false),
-      _includePaths(includePaths)
+      _includePaths(std::move(includePaths))
 {
     for (vector<string>::iterator p = _includePaths.begin(); p != _includePaths.end(); ++p)
     {
@@ -1035,7 +1036,7 @@ Slice::Gen::ImportVisitor::writeImports(const UnitPtr& p)
 
 Slice::Gen::ExportsVisitor::ExportsVisitor(::IceInternal::Output& out, std::set<std::string> importedModules)
     : JsVisitor(out),
-      _importedModules(importedModules)
+      _importedModules(std::move(importedModules))
 {
 }
 

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -20,7 +20,6 @@
 #include <cstring>
 #include <iterator>
 #include <mutex>
-#include <utility>
 
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -20,6 +20,7 @@
 #include <cstring>
 #include <iterator>
 #include <mutex>
+#include <utility>
 
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -1292,7 +1293,7 @@ namespace
 class CodeVisitor final : public ParserVisitor
 {
 public:
-    CodeVisitor(const string&);
+    CodeVisitor(string);
 
     bool visitClassDefStart(const ClassDefPtr&) final;
     bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
@@ -1353,7 +1354,7 @@ private:
 //
 // CodeVisitor implementation.
 //
-CodeVisitor::CodeVisitor(const string& dir) : _dir(dir) {}
+CodeVisitor::CodeVisitor(string dir) : _dir(std::move(dir)) {}
 
 bool
 CodeVisitor::visitClassDefStart(const ClassDefPtr& p)

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -3,12 +3,10 @@
 //
 //
 
-#include "../Ice/OutputUtil.h"
-#include "Ice/StringUtil.h"
-
-#include "../Slice/Util.h"
-
 #include "SwiftUtil.h"
+#include "../Ice/OutputUtil.h"
+#include "../Slice/Util.h"
+#include "Ice/StringUtil.h"
 
 #include <cassert>
 

--- a/cpp/test/Glacier2/dynamicFiltering/TestControllerI.h
+++ b/cpp/test/Glacier2/dynamicFiltering/TestControllerI.h
@@ -8,7 +8,6 @@
 #include "Glacier2/Session.h"
 #include "Test.h"
 #include <string>
-#include <utility>
 #include <vector>
 
 struct SessionTuple

--- a/cpp/test/Glacier2/dynamicFiltering/TestControllerI.h
+++ b/cpp/test/Glacier2/dynamicFiltering/TestControllerI.h
@@ -8,6 +8,7 @@
 #include "Glacier2/Session.h"
 #include "Test.h"
 #include <string>
+#include <utility>
 #include <vector>
 
 struct SessionTuple
@@ -38,7 +39,7 @@ struct TestCase
     std::string proxy;
     bool expectedResult;
 
-    TestCase(const std::string& s, const bool b) : proxy(s), expectedResult(b) {}
+    TestCase(std::string s, const bool b) : proxy(std::move(s)), expectedResult(b) {}
 };
 
 struct TestConfiguration

--- a/cpp/test/Glacier2/staticFiltering/Server.cpp
+++ b/cpp/test/Glacier2/staticFiltering/Server.cpp
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+#include <utility>
+
 #include "BackendI.h"
 #include "Ice/Ice.h"
 #include "TestHelper.h"
@@ -53,9 +55,9 @@ public:
 class ServerLocatorI final : public Locator
 {
 public:
-    ServerLocatorI(shared_ptr<Backend> backend, const ObjectAdapterPtr& adapter)
+    ServerLocatorI(shared_ptr<Backend> backend, ObjectAdapterPtr adapter)
         : _backend(std::move(backend)),
-          _adapter(adapter),
+          _adapter(std::move(adapter)),
           _registryPrx(_adapter->add<LocatorRegistryPrx>(
               make_shared<ServerLocatorRegistry>(),
               Ice::stringToIdentity("registry")))

--- a/cpp/test/Glacier2/staticFiltering/Server.cpp
+++ b/cpp/test/Glacier2/staticFiltering/Server.cpp
@@ -2,8 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-#include <utility>
-
 #include "BackendI.h"
 #include "Ice/Ice.h"
 #include "TestHelper.h"

--- a/cpp/test/Ice/admin/TestI.cpp
+++ b/cpp/test/Ice/admin/TestI.cpp
@@ -3,7 +3,9 @@
 //
 
 #include "TestI.h"
+
 #include "Ice/Ice.h"
+#include <utility>
 
 using namespace Ice;
 using namespace Test;
@@ -32,8 +34,8 @@ namespace
     };
 }
 
-RemoteCommunicatorI::RemoteCommunicatorI(const CommunicatorPtr& communicator)
-    : _communicator(communicator),
+RemoteCommunicatorI::RemoteCommunicatorI(CommunicatorPtr communicator)
+    : _communicator(std::move(communicator)),
       _removeCallback(nullptr)
 {
 }

--- a/cpp/test/Ice/admin/TestI.cpp
+++ b/cpp/test/Ice/admin/TestI.cpp
@@ -3,9 +3,7 @@
 //
 
 #include "TestI.h"
-
 #include "Ice/Ice.h"
-#include <utility>
 
 using namespace Ice;
 using namespace Test;

--- a/cpp/test/Ice/admin/TestI.h
+++ b/cpp/test/Ice/admin/TestI.h
@@ -12,7 +12,7 @@
 class RemoteCommunicatorI final : public Test::RemoteCommunicator
 {
 public:
-    RemoteCommunicatorI(const Ice::CommunicatorPtr&);
+    RemoteCommunicatorI(Ice::CommunicatorPtr);
 
     std::optional<Ice::ObjectPrx> getAdmin(const Ice::Current&) final;
     Ice::PropertyDict getChanges(const Ice::Current&) final;

--- a/cpp/test/Ice/ami/TestI.cpp
+++ b/cpp/test/Ice/ami/TestI.cpp
@@ -3,9 +3,7 @@
 //
 
 #include "TestI.h"
-
 #include "Ice/Ice.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/test/Ice/ami/TestI.cpp
+++ b/cpp/test/Ice/ami/TestI.cpp
@@ -3,7 +3,9 @@
 //
 
 #include "TestI.h"
+
 #include "Ice/Ice.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -239,7 +241,7 @@ TestIntfControllerI::resumeAdapter(const Ice::Current&)
     _adapter->activate();
 }
 
-TestIntfControllerI::TestIntfControllerI(const Ice::ObjectAdapterPtr& adapter) : _adapter(adapter) {}
+TestIntfControllerI::TestIntfControllerI(Ice::ObjectAdapterPtr adapter) : _adapter(std::move(adapter)) {}
 
 int32_t
 TestIntfII::op(int32_t i, int32_t& j, const Ice::Current&)

--- a/cpp/test/Ice/ami/TestI.h
+++ b/cpp/test/Ice/ami/TestI.h
@@ -67,7 +67,7 @@ public:
     void holdAdapter(const Ice::Current&) final;
     void resumeAdapter(const Ice::Current&) final;
 
-    TestIntfControllerI(const Ice::ObjectAdapterPtr&);
+    TestIntfControllerI(Ice::ObjectAdapterPtr);
 
 private:
     Ice::ObjectAdapterPtr _adapter;

--- a/cpp/test/Ice/background/Acceptor.cpp
+++ b/cpp/test/Ice/background/Acceptor.cpp
@@ -7,10 +7,8 @@
 #endif
 
 #include "Acceptor.h"
-
 #include "EndpointI.h"
 #include "Transceiver.h"
-#include <utility>
 
 using namespace std;
 

--- a/cpp/test/Ice/background/Acceptor.cpp
+++ b/cpp/test/Ice/background/Acceptor.cpp
@@ -7,8 +7,10 @@
 #endif
 
 #include "Acceptor.h"
+
 #include "EndpointI.h"
 #include "Transceiver.h"
+#include <utility>
 
 using namespace std;
 
@@ -69,8 +71,8 @@ Acceptor::toDetailedString() const
     return _acceptor->toDetailedString();
 }
 
-Acceptor::Acceptor(const EndpointIPtr& endpoint, const IceInternal::AcceptorPtr& acceptor)
-    : _endpoint(endpoint),
-      _acceptor(acceptor)
+Acceptor::Acceptor(EndpointIPtr endpoint, IceInternal::AcceptorPtr acceptor)
+    : _endpoint(std::move(endpoint)),
+      _acceptor(std::move(acceptor))
 {
 }

--- a/cpp/test/Ice/background/Acceptor.h
+++ b/cpp/test/Ice/background/Acceptor.h
@@ -11,7 +11,7 @@
 class Acceptor : public IceInternal::Acceptor
 {
 public:
-    Acceptor(const EndpointIPtr&, const IceInternal::AcceptorPtr&);
+    Acceptor(EndpointIPtr, IceInternal::AcceptorPtr);
     IceInternal::NativeInfoPtr getNativeInfo() override;
 
     void close() override;

--- a/cpp/test/Ice/background/Connector.cpp
+++ b/cpp/test/Ice/background/Connector.cpp
@@ -7,10 +7,8 @@
 #endif
 
 #include "Connector.h"
-
 #include "EndpointI.h"
 #include "Transceiver.h"
-#include <utility>
 
 using namespace std;
 

--- a/cpp/test/Ice/background/Connector.cpp
+++ b/cpp/test/Ice/background/Connector.cpp
@@ -7,8 +7,10 @@
 #endif
 
 #include "Connector.h"
+
 #include "EndpointI.h"
 #include "Transceiver.h"
+#include <utility>
 
 using namespace std;
 
@@ -55,8 +57,8 @@ Connector::operator<(const IceInternal::Connector& r) const
     return *_connector < *p->_connector;
 }
 
-Connector::Connector(const IceInternal::ConnectorPtr& connector)
-    : _connector(connector),
+Connector::Connector(IceInternal::ConnectorPtr connector)
+    : _connector(std::move(connector)),
       _configuration(Configuration::getInstance())
 {
 }

--- a/cpp/test/Ice/background/Connector.h
+++ b/cpp/test/Ice/background/Connector.h
@@ -19,7 +19,7 @@ public:
     bool operator==(const IceInternal::Connector&) const override;
     bool operator<(const IceInternal::Connector&) const override;
 
-    Connector(const IceInternal::ConnectorPtr& connector);
+    Connector(IceInternal::ConnectorPtr connector);
 
 private:
     const IceInternal::ConnectorPtr _connector;

--- a/cpp/test/Ice/background/EndpointFactory.cpp
+++ b/cpp/test/Ice/background/EndpointFactory.cpp
@@ -6,12 +6,9 @@
 #    define TEST_API_EXPORTS
 #endif
 
-#include "Ice/EndpointFactoryManager.h"
-
 #include "EndpointFactory.h"
-
 #include "EndpointI.h"
-#include <utility>
+#include "Ice/EndpointFactoryManager.h"
 
 using namespace std;
 

--- a/cpp/test/Ice/background/EndpointFactory.cpp
+++ b/cpp/test/Ice/background/EndpointFactory.cpp
@@ -9,11 +9,13 @@
 #include "Ice/EndpointFactoryManager.h"
 
 #include "EndpointFactory.h"
+
 #include "EndpointI.h"
+#include <utility>
 
 using namespace std;
 
-EndpointFactory::EndpointFactory(const IceInternal::EndpointFactoryPtr& factory) : _factory(factory) {}
+EndpointFactory::EndpointFactory(IceInternal::EndpointFactoryPtr factory) : _factory(std::move(factory)) {}
 
 int16_t
 EndpointFactory::type() const

--- a/cpp/test/Ice/background/EndpointFactory.h
+++ b/cpp/test/Ice/background/EndpointFactory.h
@@ -10,7 +10,7 @@
 class EndpointFactory final : public IceInternal::EndpointFactory, public std::enable_shared_from_this<EndpointFactory>
 {
 public:
-    EndpointFactory(const IceInternal::EndpointFactoryPtr&);
+    EndpointFactory(IceInternal::EndpointFactoryPtr);
 
     [[nodiscard]] std::int16_t type() const final;
     [[nodiscard]] std::string protocol() const final;

--- a/cpp/test/Ice/background/EndpointI.cpp
+++ b/cpp/test/Ice/background/EndpointI.cpp
@@ -7,9 +7,11 @@
 #endif
 
 #include "EndpointI.h"
+
 #include "Acceptor.h"
 #include "Connector.h"
 #include "Transceiver.h"
+#include <utility>
 
 #ifdef _MSC_VER
 // For 'Ice::Object::ice_getHash': was declared deprecated
@@ -24,8 +26,8 @@ using namespace std;
 
 int16_t EndpointI::TYPE_BASE = 100;
 
-EndpointI::EndpointI(const IceInternal::EndpointIPtr& endpoint)
-    : _endpoint(endpoint),
+EndpointI::EndpointI(IceInternal::EndpointIPtr endpoint)
+    : _endpoint(std::move(endpoint)),
       _configuration(Configuration::getInstance())
 {
 }

--- a/cpp/test/Ice/background/EndpointI.cpp
+++ b/cpp/test/Ice/background/EndpointI.cpp
@@ -11,7 +11,6 @@
 #include "Acceptor.h"
 #include "Connector.h"
 #include "Transceiver.h"
-#include <utility>
 
 #ifdef _MSC_VER
 // For 'Ice::Object::ice_getHash': was declared deprecated

--- a/cpp/test/Ice/background/EndpointI.h
+++ b/cpp/test/Ice/background/EndpointI.h
@@ -18,7 +18,7 @@ class EndpointI final : public IceInternal::EndpointI, public std::enable_shared
 public:
     static std::int16_t TYPE_BASE;
 
-    EndpointI(const IceInternal::EndpointIPtr&);
+    EndpointI(IceInternal::EndpointIPtr);
 
     // From EndpointI
     void streamWriteImpl(Ice::OutputStream*) const final;

--- a/cpp/test/Ice/background/PluginI.cpp
+++ b/cpp/test/Ice/background/PluginI.cpp
@@ -13,12 +13,14 @@
 #include "EndpointFactory.h"
 #include "PluginI.h"
 
+#include <utility>
+
 using namespace std;
 
 class TestPluginI final : public PluginI
 {
 public:
-    TestPluginI(const Ice::CommunicatorPtr&);
+    TestPluginI(Ice::CommunicatorPtr);
 
     void initialize() final;
     void destroy() final;
@@ -41,8 +43,8 @@ extern "C"
     }
 }
 
-TestPluginI::TestPluginI(const Ice::CommunicatorPtr& communicator)
-    : _communicator(communicator),
+TestPluginI::TestPluginI(Ice::CommunicatorPtr communicator)
+    : _communicator(std::move(communicator)),
       _configuration(make_shared<Configuration>())
 {
     _configuration->init();

--- a/cpp/test/Ice/background/PluginI.cpp
+++ b/cpp/test/Ice/background/PluginI.cpp
@@ -6,14 +6,11 @@
 #    define TEST_API_EXPORTS
 #endif
 
+#include "PluginI.h"
+#include "EndpointFactory.h"
 #include "Ice/EndpointFactoryManager.h"
 #include "Ice/Initialize.h"
 #include "Ice/ProtocolPluginFacade.h"
-
-#include "EndpointFactory.h"
-#include "PluginI.h"
-
-#include <utility>
 
 using namespace std;
 

--- a/cpp/test/Ice/background/Server.cpp
+++ b/cpp/test/Ice/background/Server.cpp
@@ -2,8 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-#include <utility>
-
 #include "Configuration.h"
 #include "Ice/Ice.h"
 #include "PluginI.h"

--- a/cpp/test/Ice/background/Server.cpp
+++ b/cpp/test/Ice/background/Server.cpp
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+#include <utility>
+
 #include "Configuration.h"
 #include "Ice/Ice.h"
 #include "PluginI.h"
@@ -51,7 +53,7 @@ public:
 
     [[nodiscard]] optional<LocatorRegistryPrx> getRegistry(const Current&) const override { return nullopt; }
 
-    LocatorI(const BackgroundControllerIPtr& controller) : _controller(controller) {}
+    LocatorI(BackgroundControllerIPtr controller) : _controller(std::move(controller)) {}
 
 private:
     BackgroundControllerIPtr _controller;

--- a/cpp/test/Ice/background/TestI.cpp
+++ b/cpp/test/Ice/background/TestI.cpp
@@ -3,7 +3,9 @@
 //
 
 #include "TestI.h"
+
 #include "Ice/Ice.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -26,7 +28,7 @@ BackgroundI::shutdown(const Current& current)
     current.adapter->getCommunicator()->shutdown();
 }
 
-BackgroundI::BackgroundI(const BackgroundControllerIPtr& controller) : _controller(controller) {}
+BackgroundI::BackgroundI(BackgroundControllerIPtr controller) : _controller(std::move(controller)) {}
 
 void
 BackgroundControllerI::pauseCall(string opName, const Current&)
@@ -107,8 +109,8 @@ BackgroundControllerI::buffered(bool enable, const Current&)
     _configuration->buffered(enable);
 }
 
-BackgroundControllerI::BackgroundControllerI(const ObjectAdapterPtr& adapter, const ConfigurationPtr& configuration)
-    : _adapter(adapter),
-      _configuration(configuration)
+BackgroundControllerI::BackgroundControllerI(ObjectAdapterPtr adapter, ConfigurationPtr configuration)
+    : _adapter(std::move(adapter)),
+      _configuration(std::move(configuration))
 {
 }

--- a/cpp/test/Ice/background/TestI.cpp
+++ b/cpp/test/Ice/background/TestI.cpp
@@ -4,9 +4,6 @@
 
 #include "TestI.h"
 
-#include "Ice/Ice.h"
-#include <utility>
-
 using namespace std;
 using namespace Ice;
 

--- a/cpp/test/Ice/background/TestI.h
+++ b/cpp/test/Ice/background/TestI.h
@@ -16,7 +16,7 @@ using BackgroundControllerIPtr = std::shared_ptr<BackgroundControllerI>;
 class BackgroundI final : public Test::Background
 {
 public:
-    BackgroundI(const BackgroundControllerIPtr&);
+    BackgroundI(BackgroundControllerIPtr);
 
     void op(const Ice::Current&) final;
     void opWithPayload(Ice::ByteSeq, const Ice::Current&) final;
@@ -29,7 +29,7 @@ private:
 class BackgroundControllerI final : public Test::BackgroundController
 {
 public:
-    BackgroundControllerI(const Ice::ObjectAdapterPtr&, const ConfigurationPtr&);
+    BackgroundControllerI(Ice::ObjectAdapterPtr, ConfigurationPtr);
 
     void pauseCall(std::string, const Ice::Current&) final;
     void resumeCall(std::string, const Ice::Current&) final;

--- a/cpp/test/Ice/background/Transceiver.cpp
+++ b/cpp/test/Ice/background/Transceiver.cpp
@@ -8,6 +8,8 @@
 
 #include "Transceiver.h"
 
+#include <utility>
+
 using namespace std;
 
 IceInternal::NativeInfoPtr
@@ -251,8 +253,8 @@ Transceiver::setBufferSize(int rcvSize, int sndSize)
 //
 // Only for use by Connector, Acceptor
 //
-Transceiver::Transceiver(const IceInternal::TransceiverPtr& transceiver)
-    : _transceiver(transceiver),
+Transceiver::Transceiver(IceInternal::TransceiverPtr transceiver)
+    : _transceiver(std::move(transceiver)),
       _configuration(Configuration::getInstance()),
       _initialized(false),
       _buffered(_configuration->buffered())

--- a/cpp/test/Ice/background/Transceiver.cpp
+++ b/cpp/test/Ice/background/Transceiver.cpp
@@ -8,8 +8,6 @@
 
 #include "Transceiver.h"
 
-#include <utility>
-
 using namespace std;
 
 IceInternal::NativeInfoPtr

--- a/cpp/test/Ice/background/Transceiver.h
+++ b/cpp/test/Ice/background/Transceiver.h
@@ -12,7 +12,7 @@
 class Transceiver final : public IceInternal::Transceiver
 {
 public:
-    Transceiver(const IceInternal::TransceiverPtr&);
+    Transceiver(IceInternal::TransceiverPtr);
     IceInternal::NativeInfoPtr getNativeInfo() final;
 
     IceInternal::SocketOperation closing(bool, std::exception_ptr) final;

--- a/cpp/test/Ice/binding/TestI.cpp
+++ b/cpp/test/Ice/binding/TestI.cpp
@@ -3,10 +3,7 @@
 //
 
 #include "TestI.h"
-
-#include "Ice/Ice.h"
 #include "TestHelper.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/test/Ice/binding/TestI.cpp
+++ b/cpp/test/Ice/binding/TestI.cpp
@@ -3,8 +3,10 @@
 //
 
 #include "TestI.h"
+
 #include "Ice/Ice.h"
 #include "TestHelper.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -56,8 +58,8 @@ RemoteCommunicatorI::shutdown(const Current& current)
     current.adapter->getCommunicator()->shutdown();
 }
 
-RemoteObjectAdapterI::RemoteObjectAdapterI(const ObjectAdapterPtr& adapter)
-    : _adapter(adapter),
+RemoteObjectAdapterI::RemoteObjectAdapterI(ObjectAdapterPtr adapter)
+    : _adapter(std::move(adapter)),
       _testIntf(_adapter->add<TestIntfPrx>(make_shared<TestI>(), stringToIdentity("test")))
 {
     _adapter->activate();

--- a/cpp/test/Ice/binding/TestI.h
+++ b/cpp/test/Ice/binding/TestI.h
@@ -25,7 +25,7 @@ private:
 class RemoteObjectAdapterI final : public Test::RemoteObjectAdapter
 {
 public:
-    RemoteObjectAdapterI(const Ice::ObjectAdapterPtr&);
+    RemoteObjectAdapterI(Ice::ObjectAdapterPtr);
 
     std::optional<Test::TestIntfPrx> getTestIntf(const Ice::Current&) final;
     void deactivate(const Ice::Current&) final;

--- a/cpp/test/Ice/echo/Server.cpp
+++ b/cpp/test/Ice/echo/Server.cpp
@@ -5,14 +5,16 @@
 #include "BlobjectI.h"
 #include "Ice/Ice.h"
 #include "Test.h"
+
 #include "TestHelper.h"
+#include <utility>
 
 using namespace std;
 
 class EchoI : public Test::Echo
 {
 public:
-    EchoI(const BlobjectIPtr& blob) : _blob(blob) {}
+    EchoI(BlobjectIPtr blob) : _blob(std::move(blob)) {}
 
     void setConnection(const Ice::Current& current) override { _blob->setConnection(current.con); }
 

--- a/cpp/test/Ice/echo/Server.cpp
+++ b/cpp/test/Ice/echo/Server.cpp
@@ -7,7 +7,6 @@
 #include "Test.h"
 
 #include "TestHelper.h"
-#include <utility>
 
 using namespace std;
 

--- a/cpp/test/Ice/executor/TestI.cpp
+++ b/cpp/test/Ice/executor/TestI.cpp
@@ -9,6 +9,7 @@
 
 #include <chrono>
 #include <thread>
+#include <utility>
 
 using namespace std;
 
@@ -51,4 +52,4 @@ TestIntfControllerI::resumeAdapter(const Ice::Current&)
     _adapter->activate();
 }
 
-TestIntfControllerI::TestIntfControllerI(const Ice::ObjectAdapterPtr& adapter) : _adapter(adapter) {}
+TestIntfControllerI::TestIntfControllerI(Ice::ObjectAdapterPtr adapter) : _adapter(std::move(adapter)) {}

--- a/cpp/test/Ice/executor/TestI.cpp
+++ b/cpp/test/Ice/executor/TestI.cpp
@@ -9,7 +9,6 @@
 
 #include <chrono>
 #include <thread>
-#include <utility>
 
 using namespace std;
 

--- a/cpp/test/Ice/executor/TestI.h
+++ b/cpp/test/Ice/executor/TestI.h
@@ -26,7 +26,7 @@ public:
     void holdAdapter(const Ice::Current&) override;
     void resumeAdapter(const Ice::Current&) override;
 
-    TestIntfControllerI(const Ice::ObjectAdapterPtr&);
+    TestIntfControllerI(Ice::ObjectAdapterPtr);
 
 private:
     Ice::ObjectAdapterPtr _adapter;

--- a/cpp/test/Ice/hold/TestI.cpp
+++ b/cpp/test/Ice/hold/TestI.cpp
@@ -10,10 +10,11 @@
 #include <iostream>
 #include <stdexcept>
 #include <thread>
+#include <utility>
 
 using namespace std;
 
-HoldI::HoldI(const Ice::ObjectAdapterPtr& adapter) : _last(0), _adapter(adapter) {}
+HoldI::HoldI(Ice::ObjectAdapterPtr adapter) : _last(0), _adapter(std::move(adapter)) {}
 
 void
 HoldI::putOnHoldAsync(int32_t delay, function<void()> response, function<void(std::exception_ptr)>, const Ice::Current&)

--- a/cpp/test/Ice/hold/TestI.cpp
+++ b/cpp/test/Ice/hold/TestI.cpp
@@ -10,7 +10,6 @@
 #include <iostream>
 #include <stdexcept>
 #include <thread>
-#include <utility>
 
 using namespace std;
 

--- a/cpp/test/Ice/hold/TestI.h
+++ b/cpp/test/Ice/hold/TestI.h
@@ -10,7 +10,7 @@
 class HoldI final : public Test::Hold
 {
 public:
-    HoldI(const Ice::ObjectAdapterPtr&);
+    HoldI(Ice::ObjectAdapterPtr);
 
     void putOnHoldAsync(
         std::int32_t delay,

--- a/cpp/test/Ice/location/ServerLocator.cpp
+++ b/cpp/test/Ice/location/ServerLocator.cpp
@@ -9,6 +9,7 @@
 
 #include <chrono>
 #include <thread>
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -102,8 +103,8 @@ ServerLocatorRegistry::addObject(const optional<ObjectPrx>& object)
     _objects[object->ice_getIdentity()] = object;
 }
 
-ServerLocator::ServerLocator(const ServerLocatorRegistryPtr& registry, const optional<LocatorRegistryPrx>& registryPrx)
-    : _registry(registry),
+ServerLocator::ServerLocator(ServerLocatorRegistryPtr registry, const optional<LocatorRegistryPrx>& registryPrx)
+    : _registry(std::move(registry)),
       _registryPrx(registryPrx),
       _requestCount(0)
 {

--- a/cpp/test/Ice/location/ServerLocator.cpp
+++ b/cpp/test/Ice/location/ServerLocator.cpp
@@ -9,7 +9,6 @@
 
 #include <chrono>
 #include <thread>
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/test/Ice/location/ServerLocator.h
+++ b/cpp/test/Ice/location/ServerLocator.h
@@ -53,7 +53,7 @@ using ServerLocatorRegistryPtr = std::shared_ptr<ServerLocatorRegistry>;
 class ServerLocator final : public Test::TestLocator
 {
 public:
-    ServerLocator(const ::ServerLocatorRegistryPtr&, const std::optional<Ice::LocatorRegistryPrx>&);
+    ServerLocator(::ServerLocatorRegistryPtr, const std::optional<Ice::LocatorRegistryPrx>&);
 
     void findObjectByIdAsync(
         Ice::Identity,

--- a/cpp/test/Ice/location/TestI.cpp
+++ b/cpp/test/Ice/location/TestI.cpp
@@ -3,11 +3,8 @@
 //
 
 #include "TestI.h"
-
-#include "Ice/Ice.h"
 #include "Ice/Locator.h"
 #include "TestHelper.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/test/Ice/location/TestI.cpp
+++ b/cpp/test/Ice/location/TestI.cpp
@@ -3,17 +3,19 @@
 //
 
 #include "TestI.h"
+
 #include "Ice/Ice.h"
 #include "Ice/Locator.h"
 #include "TestHelper.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
 using namespace Test;
 
-ServerManagerI::ServerManagerI(const ServerLocatorRegistryPtr& registry, const InitializationData& initData)
-    : _registry(registry),
-      _initData(initData),
+ServerManagerI::ServerManagerI(ServerLocatorRegistryPtr registry, InitializationData initData)
+    : _registry(std::move(registry)),
+      _initData(std::move(initData)),
       _nextPort(1)
 {
     _initData.properties->setProperty("TestAdapter.AdapterId", "TestAdapter");
@@ -109,13 +111,10 @@ ServerManagerI::shutdown(const Current& current)
     current.adapter->getCommunicator()->shutdown();
 }
 
-TestI::TestI(
-    const ObjectAdapterPtr& adapter,
-    const ObjectAdapterPtr& adapter2,
-    const ServerLocatorRegistryPtr& registry)
-    : _adapter1(adapter),
-      _adapter2(adapter2),
-      _registry(registry)
+TestI::TestI(ObjectAdapterPtr adapter, ObjectAdapterPtr adapter2, ServerLocatorRegistryPtr registry)
+    : _adapter1(std::move(adapter)),
+      _adapter2(std::move(adapter2)),
+      _registry(std::move(registry))
 {
     _registry->addObject(_adapter1->add(make_shared<HelloI>(), stringToIdentity("hello")));
 }

--- a/cpp/test/Ice/location/TestI.h
+++ b/cpp/test/Ice/location/TestI.h
@@ -13,7 +13,7 @@
 class ServerManagerI final : public Test::ServerManager
 {
 public:
-    ServerManagerI(const ServerLocatorRegistryPtr&, const Ice::InitializationData&);
+    ServerManagerI(ServerLocatorRegistryPtr, Ice::InitializationData);
 
     void startServer(const Ice::Current&) final;
     void shutdown(const Ice::Current&) final;
@@ -34,7 +34,7 @@ public:
 class TestI final : public Test::TestIntf
 {
 public:
-    TestI(const Ice::ObjectAdapterPtr&, const Ice::ObjectAdapterPtr&, const ServerLocatorRegistryPtr&);
+    TestI(Ice::ObjectAdapterPtr, Ice::ObjectAdapterPtr, ServerLocatorRegistryPtr);
 
     void shutdown(const Ice::Current&) final;
     std::optional<Test::HelloPrx> getHello(const Ice::Current&) final;

--- a/cpp/test/Ice/metrics/AllTests.cpp
+++ b/cpp/test/Ice/metrics/AllTests.cpp
@@ -8,7 +8,6 @@
 #include "TestHelper.h"
 
 #include <thread>
-#include <utility>
 
 using namespace std;
 using namespace Test;

--- a/cpp/test/Ice/metrics/AllTests.cpp
+++ b/cpp/test/Ice/metrics/AllTests.cpp
@@ -8,6 +8,7 @@
 #include "TestHelper.h"
 
 #include <thread>
+#include <utility>
 
 using namespace std;
 using namespace Test;
@@ -93,7 +94,7 @@ namespace
     class UpdateCallbackI
     {
     public:
-        UpdateCallbackI(const Ice::PropertiesAdminPrx& serverProps) : _updated(false), _serverProps(serverProps) {}
+        UpdateCallbackI(Ice::PropertiesAdminPrx serverProps) : _updated(false), _serverProps(std::move(serverProps)) {}
 
         void waitForUpdate()
         {
@@ -227,7 +228,7 @@ namespace
 
     struct Connect
     {
-        Connect(const Ice::ObjectPrx& proxyP) : proxy(proxyP) {}
+        Connect(Ice::ObjectPrx proxyP) : proxy(std::move(proxyP)) {}
 
         void operator()() const
         {
@@ -253,7 +254,7 @@ namespace
 
     struct InvokeOp
     {
-        InvokeOp(const Test::MetricsPrx& proxyP) : proxy(proxyP) {}
+        InvokeOp(Test::MetricsPrx proxyP) : proxy(std::move(proxyP)) {}
 
         void operator()() const
         {

--- a/cpp/test/Ice/metrics/TestAMDI.cpp
+++ b/cpp/test/Ice/metrics/TestAMDI.cpp
@@ -3,7 +3,9 @@
 //
 
 #include "TestAMDI.h"
+
 #include "Ice/Ice.h"
+#include <utility>
 
 using namespace std;
 
@@ -76,7 +78,7 @@ MetricsI::shutdown(const Ice::Current& current)
     current.adapter->getCommunicator()->shutdown();
 }
 
-ControllerI::ControllerI(const Ice::ObjectAdapterPtr& adapter) : _adapter(adapter) {}
+ControllerI::ControllerI(Ice::ObjectAdapterPtr adapter) : _adapter(std::move(adapter)) {}
 
 void
 ControllerI::hold(const Ice::Current&)

--- a/cpp/test/Ice/metrics/TestAMDI.cpp
+++ b/cpp/test/Ice/metrics/TestAMDI.cpp
@@ -3,9 +3,7 @@
 //
 
 #include "TestAMDI.h"
-
 #include "Ice/Ice.h"
-#include <utility>
 
 using namespace std;
 

--- a/cpp/test/Ice/metrics/TestAMDI.h
+++ b/cpp/test/Ice/metrics/TestAMDI.h
@@ -41,7 +41,7 @@ public:
 class ControllerI final : public Test::Controller
 {
 public:
-    ControllerI(const Ice::ObjectAdapterPtr&);
+    ControllerI(Ice::ObjectAdapterPtr);
 
     void hold(const Ice::Current&) final;
 

--- a/cpp/test/Ice/metrics/TestI.cpp
+++ b/cpp/test/Ice/metrics/TestI.cpp
@@ -3,9 +3,7 @@
 //
 
 #include "TestI.h"
-
 #include "Ice/Ice.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/test/Ice/metrics/TestI.cpp
+++ b/cpp/test/Ice/metrics/TestI.cpp
@@ -3,7 +3,9 @@
 //
 
 #include "TestI.h"
+
 #include "Ice/Ice.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -61,7 +63,7 @@ MetricsI::shutdown(const Current& current)
     current.adapter->getCommunicator()->shutdown();
 }
 
-ControllerI::ControllerI(const ObjectAdapterPtr& adapter) : _adapter(adapter) {}
+ControllerI::ControllerI(ObjectAdapterPtr adapter) : _adapter(std::move(adapter)) {}
 
 void
 ControllerI::hold(const Current&)

--- a/cpp/test/Ice/metrics/TestI.h
+++ b/cpp/test/Ice/metrics/TestI.h
@@ -31,7 +31,7 @@ class MetricsI final : public Test::Metrics
 class ControllerI final : public Test::Controller
 {
 public:
-    ControllerI(const Ice::ObjectAdapterPtr&);
+    ControllerI(Ice::ObjectAdapterPtr);
 
     void hold(const Ice::Current&) final;
 

--- a/cpp/test/Ice/objects/TestI.cpp
+++ b/cpp/test/Ice/objects/TestI.cpp
@@ -3,7 +3,9 @@
 //
 
 #include "TestI.h"
+
 #include "Ice/Ice.h"
+#include <utility>
 
 using namespace Test;
 using namespace std;
@@ -63,8 +65,8 @@ FI::checkValues()
     return e1 && e1 == e2;
 }
 
-InitialI::InitialI(const ObjectAdapterPtr& adapter)
-    : _adapter(adapter),
+InitialI::InitialI(ObjectAdapterPtr adapter)
+    : _adapter(std::move(adapter)),
       _b1(new BI),
       _b2(new BI),
       _c(new CI),

--- a/cpp/test/Ice/objects/TestI.cpp
+++ b/cpp/test/Ice/objects/TestI.cpp
@@ -4,9 +4,6 @@
 
 #include "TestI.h"
 
-#include "Ice/Ice.h"
-#include <utility>
-
 using namespace Test;
 using namespace std;
 using namespace Ice;

--- a/cpp/test/Ice/objects/TestI.h
+++ b/cpp/test/Ice/objects/TestI.h
@@ -51,7 +51,7 @@ using FIPtr = std::shared_ptr<FI>;
 class InitialI final : public Test::Initial
 {
 public:
-    InitialI(const Ice::ObjectAdapterPtr&);
+    InitialI(Ice::ObjectAdapterPtr);
     ~InitialI() override;
 
     void shutdown(const Ice::Current&) final;

--- a/cpp/test/Ice/operations/Twoways.cpp
+++ b/cpp/test/Ice/operations/Twoways.cpp
@@ -6,6 +6,7 @@
 #include "Test.h"
 #include "TestHelper.h"
 #include <limits>
+#include <utility>
 
 //
 // Visual C++ defines min and max as macros
@@ -32,7 +33,7 @@ namespace
     class PerThreadContextInvokeThread final
     {
     public:
-        PerThreadContextInvokeThread(const Test::MyClassPrx& proxy) : _proxy(proxy) {}
+        PerThreadContextInvokeThread(Test::MyClassPrx proxy) : _proxy(std::move(proxy)) {}
 
         void run()
         {

--- a/cpp/test/Ice/operations/TwowaysAMI.cpp
+++ b/cpp/test/Ice/operations/TwowaysAMI.cpp
@@ -4,7 +4,9 @@
 
 #include "Ice/Ice.h"
 #include "Test.h"
+
 #include "TestHelper.h"
+#include <utility>
 
 //
 // Work-around for GCC warning bug
@@ -61,7 +63,7 @@ namespace
     public:
         Callback() {}
 
-        Callback(const CommunicatorPtr& communicator) : _communicator(communicator) {}
+        Callback(CommunicatorPtr communicator) : _communicator(std::move(communicator)) {}
 
         void ping() { called(); }
 

--- a/cpp/test/Ice/plugin/Plugin.cpp
+++ b/cpp/test/Ice/plugin/Plugin.cpp
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+#include <utility>
+
 #include "Ice/Ice.h"
 #include "TestHelper.h"
 
@@ -12,8 +14,8 @@ namespace
     class Plugin : public Ice::Plugin
     {
     public:
-        Plugin(const Ice::CommunicatorPtr& communicator)
-            : _communicator(communicator),
+        Plugin(Ice::CommunicatorPtr communicator)
+            : _communicator(std::move(communicator)),
               _initialized(false),
               _destroyed(false)
         {
@@ -46,7 +48,7 @@ namespace
     class PluginInitializeFail : public Ice::Plugin
     {
     public:
-        PluginInitializeFail(const Ice::CommunicatorPtr& communicator) : _communicator(communicator) {}
+        PluginInitializeFail(Ice::CommunicatorPtr communicator) : _communicator(std::move(communicator)) {}
 
         void initialize() override { throw CustomPluginException(); }
 
@@ -62,8 +64,8 @@ namespace
     class BasePlugin : public Ice::Plugin
     {
     public:
-        BasePlugin(const Ice::CommunicatorPtr& communicator)
-            : _communicator(communicator),
+        BasePlugin(Ice::CommunicatorPtr communicator)
+            : _communicator(std::move(communicator)),
               _initialized(false),
               _destroyed(false)
         {
@@ -146,8 +148,8 @@ namespace
     class BasePluginFail : public Ice::Plugin
     {
     public:
-        BasePluginFail(const Ice::CommunicatorPtr& communicator)
-            : _communicator(communicator),
+        BasePluginFail(Ice::CommunicatorPtr communicator)
+            : _communicator(std::move(communicator)),
               _initialized(false),
               _destroyed(false)
         {

--- a/cpp/test/Ice/plugin/Plugin.cpp
+++ b/cpp/test/Ice/plugin/Plugin.cpp
@@ -2,8 +2,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-#include <utility>
-
 #include "Ice/Ice.h"
 #include "TestHelper.h"
 

--- a/cpp/test/Ice/retry/TestI.cpp
+++ b/cpp/test/Ice/retry/TestI.cpp
@@ -2,9 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-#include "Ice/Ice.h"
-
 #include "TestI.h"
+#include "Ice/Ice.h"
 
 #include <thread>
 using namespace std;

--- a/cpp/test/Ice/servantLocator/ServantLocatorI.cpp
+++ b/cpp/test/Ice/servantLocator/ServantLocatorI.cpp
@@ -11,12 +11,15 @@
 #include "TestHelper.h"
 
 #include <stdexcept>
+#include <utility>
 
 using namespace std;
 using namespace Ice;
 using namespace Test;
 
-ServantLocatorI::ServantLocatorI(const string& category) : _category(category), _deactivated(false), _requestId(-1) {}
+ServantLocatorI::ServantLocatorI(string category) : _category(std::move(category)), _deactivated(false), _requestId(-1)
+{
+}
 
 ServantLocatorI::~ServantLocatorI() { test(_deactivated); }
 

--- a/cpp/test/Ice/servantLocator/ServantLocatorI.cpp
+++ b/cpp/test/Ice/servantLocator/ServantLocatorI.cpp
@@ -11,7 +11,6 @@
 #include "TestHelper.h"
 
 #include <stdexcept>
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/test/Ice/servantLocator/ServantLocatorI.h
+++ b/cpp/test/Ice/servantLocator/ServantLocatorI.h
@@ -12,7 +12,7 @@ namespace Test
     class ServantLocatorI : public Ice::ServantLocator
     {
     public:
-        ServantLocatorI(const std::string&);
+        ServantLocatorI(std::string);
         ~ServantLocatorI() override;
         Ice::ObjectPtr locate(const Ice::Current&, std::shared_ptr<void>&) override;
         void finished(const Ice::Current&, const Ice::ObjectPtr&, const std::shared_ptr<void>&) override;

--- a/cpp/test/Ice/stringConverter/Client.cpp
+++ b/cpp/test/Ice/stringConverter/Client.cpp
@@ -2,12 +2,12 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+#include "../../../src/Ice/Endian.h"
 #include "Ice/Ice.h"
 #include "Ice/IconvStringConverter.h"
 #include "Test.h"
 #include "TestHelper.h"
 
-#include "../../../src/Ice/Endian.h"
 #include <iostream>
 #include <locale.h>
 

--- a/cpp/test/Ice/timeout/TestI.cpp
+++ b/cpp/test/Ice/timeout/TestI.cpp
@@ -7,7 +7,6 @@
 
 #include <chrono>
 #include <thread>
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/test/Ice/timeout/TestI.cpp
+++ b/cpp/test/Ice/timeout/TestI.cpp
@@ -7,6 +7,7 @@
 
 #include <chrono>
 #include <thread>
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -27,7 +28,7 @@ TimeoutI::sleep(int32_t to, const Ice::Current&)
     this_thread::sleep_for(chrono::milliseconds(to));
 }
 
-ControllerI::ControllerI(const Ice::ObjectAdapterPtr& adapter) : _adapter(adapter) {}
+ControllerI::ControllerI(Ice::ObjectAdapterPtr adapter) : _adapter(std::move(adapter)) {}
 
 void
 ControllerI::holdAdapter(int32_t to, const Ice::Current&)

--- a/cpp/test/Ice/timeout/TestI.h
+++ b/cpp/test/Ice/timeout/TestI.h
@@ -18,7 +18,7 @@ public:
 class ControllerI final : public Test::Controller
 {
 public:
-    ControllerI(const Ice::ObjectAdapterPtr&);
+    ControllerI(Ice::ObjectAdapterPtr);
 
     void holdAdapter(std::int32_t, const Ice::Current&) final;
     void resumeAdapter(const Ice::Current&) final;

--- a/cpp/test/IceBox/configuration/TestI.cpp
+++ b/cpp/test/IceBox/configuration/TestI.cpp
@@ -3,11 +3,13 @@
 //
 
 #include "TestI.h"
+
 #include "Ice/Ice.h"
+#include <utility>
 
 using namespace Test;
 
-TestI::TestI(const Ice::StringSeq& args) : _args(args) {}
+TestI::TestI(Ice::StringSeq args) : _args(std::move(args)) {}
 
 std::string
 TestI::getProperty(std::string name, const Ice::Current& current)

--- a/cpp/test/IceBox/configuration/TestI.cpp
+++ b/cpp/test/IceBox/configuration/TestI.cpp
@@ -4,9 +4,6 @@
 
 #include "TestI.h"
 
-#include "Ice/Ice.h"
-#include <utility>
-
 using namespace Test;
 
 TestI::TestI(Ice::StringSeq args) : _args(std::move(args)) {}

--- a/cpp/test/IceBox/configuration/TestI.h
+++ b/cpp/test/IceBox/configuration/TestI.h
@@ -10,7 +10,7 @@
 class TestI : public ::Test::TestIntf
 {
 public:
-    TestI(const Ice::StringSeq&);
+    TestI(Ice::StringSeq);
 
     std::string getProperty(std::string, const Ice::Current&) override;
     Ice::StringSeq getArgs(const Ice::Current&) override;

--- a/cpp/test/IceGrid/deployer/Server.cpp
+++ b/cpp/test/IceGrid/deployer/Server.cpp
@@ -2,11 +2,12 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-#include "../../src/Ice/DisableWarnings.h"
 #include "Ice/Ice.h"
 #include "TestHelper.h"
 #include "TestI.h"
 #include <fstream>
+
+#include "../../src/Ice/DisableWarnings.h"
 
 using namespace std;
 

--- a/cpp/test/IceGrid/deployer/TestI.cpp
+++ b/cpp/test/IceGrid/deployer/TestI.cpp
@@ -3,9 +3,11 @@
 //
 
 #include "TestI.h"
-#include "Ice/Ice.h"
 
-TestI::TestI(const Ice::PropertiesPtr& properties) : _properties(properties) {}
+#include "Ice/Ice.h"
+#include <utility>
+
+TestI::TestI(Ice::PropertiesPtr properties) : _properties(std::move(properties)) {}
 
 void
 TestI::shutdown(const Ice::Current& current)

--- a/cpp/test/IceGrid/deployer/TestI.cpp
+++ b/cpp/test/IceGrid/deployer/TestI.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "TestI.h"
-
 #include "Ice/Ice.h"
 #include <utility>
 

--- a/cpp/test/IceGrid/deployer/TestI.h
+++ b/cpp/test/IceGrid/deployer/TestI.h
@@ -10,7 +10,7 @@
 class TestI : public ::Test::TestIntf
 {
 public:
-    TestI(const Ice::PropertiesPtr&);
+    TestI(Ice::PropertiesPtr);
 
     void shutdown(const Ice::Current&) override;
     std::string getProperty(std::string, const Ice::Current&) override;

--- a/cpp/test/IceGrid/replicaGroup/RegistryPlugin.cpp
+++ b/cpp/test/IceGrid/replicaGroup/RegistryPlugin.cpp
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+#include <utility>
+
 #include "Ice/Ice.h"
 #include "IceGrid/IceGrid.h"
 
@@ -120,9 +122,9 @@ namespace
     class ExcludeReplicaGroupFilterI final : public IceGrid::ReplicaGroupFilter
     {
     public:
-        ExcludeReplicaGroupFilterI(const shared_ptr<RegistryPluginFacade>& facade, const string& exclude)
+        ExcludeReplicaGroupFilterI(const shared_ptr<RegistryPluginFacade>& facade, string exclude)
             : _facade(facade),
-              _exclude(exclude)
+              _exclude(std::move(exclude))
         {
         }
 

--- a/cpp/test/IceGrid/replicaGroup/RegistryPlugin.cpp
+++ b/cpp/test/IceGrid/replicaGroup/RegistryPlugin.cpp
@@ -2,11 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-#include <utility>
-
 #include "Ice/Ice.h"
 #include "IceGrid/IceGrid.h"
-
 #include "TestHelper.h"
 
 using namespace std;

--- a/cpp/test/IceGrid/replicaGroup/TestI.cpp
+++ b/cpp/test/IceGrid/replicaGroup/TestI.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "TestI.h"
-
 #include "Ice/Ice.h"
 #include <utility>
 

--- a/cpp/test/IceGrid/replicaGroup/TestI.cpp
+++ b/cpp/test/IceGrid/replicaGroup/TestI.cpp
@@ -3,9 +3,11 @@
 //
 
 #include "TestI.h"
-#include "Ice/Ice.h"
 
-TestI::TestI(const Ice::PropertiesPtr& properties) : _properties(properties) {}
+#include "Ice/Ice.h"
+#include <utility>
+
+TestI::TestI(Ice::PropertiesPtr properties) : _properties(std::move(properties)) {}
 
 std::string
 TestI::getReplicaId(const Ice::Current& current)

--- a/cpp/test/IceGrid/replicaGroup/TestI.h
+++ b/cpp/test/IceGrid/replicaGroup/TestI.h
@@ -10,7 +10,7 @@
 class TestI : public ::Test::TestIntf
 {
 public:
-    TestI(const Ice::PropertiesPtr&);
+    TestI(Ice::PropertiesPtr);
 
     std::string getReplicaId(const Ice::Current&) override;
     std::string getReplicaIdAndShutdown(const Ice::Current&) override;

--- a/cpp/test/IceGrid/update/TestI.cpp
+++ b/cpp/test/IceGrid/update/TestI.cpp
@@ -3,9 +3,11 @@
 //
 
 #include "TestI.h"
-#include "Ice/Ice.h"
 
-TestI::TestI(const Ice::PropertiesPtr& properties) : _properties(properties) {}
+#include "Ice/Ice.h"
+#include <utility>
+
+TestI::TestI(Ice::PropertiesPtr properties) : _properties(std::move(properties)) {}
 
 void
 TestI::shutdown(const Ice::Current& current)

--- a/cpp/test/IceGrid/update/TestI.cpp
+++ b/cpp/test/IceGrid/update/TestI.cpp
@@ -4,9 +4,6 @@
 
 #include "TestI.h"
 
-#include "Ice/Ice.h"
-#include <utility>
-
 TestI::TestI(Ice::PropertiesPtr properties) : _properties(std::move(properties)) {}
 
 void

--- a/cpp/test/IceGrid/update/TestI.h
+++ b/cpp/test/IceGrid/update/TestI.h
@@ -10,7 +10,7 @@
 class TestI : public ::Test::TestIntf
 {
 public:
-    TestI(const Ice::PropertiesPtr&);
+    TestI(Ice::PropertiesPtr);
 
     void shutdown(const Ice::Current&) override;
     std::string getProperty(std::string, const Ice::Current&) override;

--- a/cpp/test/IceSSL/configuration/TestI.cpp
+++ b/cpp/test/IceSSL/configuration/TestI.cpp
@@ -3,10 +3,8 @@
 //
 
 #include "TestI.h"
-
 #include "Ice/Ice.h"
 #include "TestHelper.h"
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/test/IceSSL/configuration/TestI.cpp
+++ b/cpp/test/IceSSL/configuration/TestI.cpp
@@ -3,13 +3,15 @@
 //
 
 #include "TestI.h"
+
 #include "Ice/Ice.h"
 #include "TestHelper.h"
+#include <utility>
 
 using namespace std;
 using namespace Ice;
 
-ServerI::ServerI(const CommunicatorPtr& communicator) : _communicator(communicator) {}
+ServerI::ServerI(CommunicatorPtr communicator) : _communicator(std::move(communicator)) {}
 
 void
 ServerI::noCert(const Ice::Current& c)
@@ -51,7 +53,7 @@ ServerI::destroy()
     _communicator->destroy();
 }
 
-ServerFactoryI::ServerFactoryI(const string& defaultDir) : _defaultDir(defaultDir) {}
+ServerFactoryI::ServerFactoryI(string defaultDir) : _defaultDir(std::move(defaultDir)) {}
 
 optional<Test::ServerPrx>
 ServerFactoryI::createServer(Test::Properties props, const Current&)

--- a/cpp/test/IceSSL/configuration/TestI.h
+++ b/cpp/test/IceSSL/configuration/TestI.h
@@ -10,7 +10,7 @@
 class ServerI : public Test::Server
 {
 public:
-    ServerI(const Ice::CommunicatorPtr&);
+    ServerI(Ice::CommunicatorPtr);
 
     void noCert(const Ice::Current&) override;
     void checkCert(std::string, std::string, const Ice::Current&) override;
@@ -25,7 +25,7 @@ using ServerIPtr = std::shared_ptr<ServerI>;
 class ServerFactoryI : public Test::ServerFactory
 {
 public:
-    ServerFactoryI(const std::string&);
+    ServerFactoryI(std::string);
 
     std::optional<Test::ServerPrx> createServer(Test::Properties, const Ice::Current&) override;
     void destroyServer(std::optional<Test::ServerPrx>, const Ice::Current&) override;

--- a/cpp/test/IceStorm/rep1/Subscriber.cpp
+++ b/cpp/test/IceStorm/rep1/Subscriber.cpp
@@ -9,7 +9,6 @@
 #include "TestHelper.h"
 
 #include <stdexcept>
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/test/IceStorm/rep1/Subscriber.cpp
+++ b/cpp/test/IceStorm/rep1/Subscriber.cpp
@@ -9,6 +9,7 @@
 #include "TestHelper.h"
 
 #include <stdexcept>
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -18,9 +19,9 @@ using namespace Test;
 class SingleI final : public Single
 {
 public:
-    SingleI(const CommunicatorPtr& communicator, const string& name, int max)
-        : _communicator(communicator),
-          _name(name),
+    SingleI(CommunicatorPtr communicator, string name, int max)
+        : _communicator(std::move(communicator)),
+          _name(std::move(name)),
           _max(max),
           _count(0),
           _last(0)

--- a/cpp/test/IceStorm/single/Subscriber.cpp
+++ b/cpp/test/IceStorm/single/Subscriber.cpp
@@ -8,6 +8,7 @@
 #include "TestHelper.h"
 
 #include <stdexcept>
+#include <utility>
 
 using namespace std;
 using namespace Ice;
@@ -17,7 +18,7 @@ using namespace Test;
 class SingleI final : public Single
 {
 public:
-    SingleI(const string& name) : _name(name), _count(0), _last(0) {}
+    SingleI(string name) : _name(std::move(name)), _count(0), _last(0) {}
 
     void event(int i, const Current& current) override
     {

--- a/cpp/test/IceStorm/single/Subscriber.cpp
+++ b/cpp/test/IceStorm/single/Subscriber.cpp
@@ -8,7 +8,6 @@
 #include "TestHelper.h"
 
 #include <stdexcept>
-#include <utility>
 
 using namespace std;
 using namespace Ice;

--- a/cpp/test/IceUtil/timer/Client.cpp
+++ b/cpp/test/IceUtil/timer/Client.cpp
@@ -9,7 +9,6 @@
 #include <chrono>
 #include <stdexcept>
 #include <thread>
-#include <utility>
 #include <vector>
 
 using namespace IceInternal;

--- a/cpp/test/IceUtil/timer/Client.cpp
+++ b/cpp/test/IceUtil/timer/Client.cpp
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <stdexcept>
 #include <thread>
+#include <utility>
 #include <vector>
 
 using namespace IceInternal;
@@ -96,7 +97,7 @@ using TestTaskPtr = std::shared_ptr<TestTask>;
 class DestroyTask : public TimerTask
 {
 public:
-    DestroyTask(const IceInternal::TimerPtr& timer) : _timer(timer), _run(false) {}
+    DestroyTask(IceInternal::TimerPtr timer) : _timer(std::move(timer)), _run(false) {}
 
     void runTimerTask() override
     {


### PR DESCRIPTION
Updates using clang-tidy -fix option.

Performance wide I believe there is no change since clang-tidy didn't update the calling sites to `std::move` the argument when possible.