### PR TITLE
Fix incorrect thread pool set by ConnectionI::create

### DIFF
--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -1986,13 +1986,15 @@ Ice::ConnectionI::create(
         decoratedTransceiver->decoratorInit(connection, options.enableIdleCheck);
     }
 
-    if (adapter)
+    if (connector) // client connection
     {
-        const_cast<ThreadPoolPtr&>(connection->_threadPool) = adapter->getThreadPool();
+        const_cast<ThreadPoolPtr&>(connection->_threadPool) = connection->_instance->clientThreadPool();
     }
     else
     {
-        const_cast<ThreadPoolPtr&>(connection->_threadPool) = connection->_instance->clientThreadPool();
+        // server connection
+        assert(adapter);
+        const_cast<ThreadPoolPtr&>(connection->_threadPool) = adapter->getThreadPool();
     }
     connection->_threadPool->initialize(connection);
     return connection;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -1235,9 +1235,10 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         _transceiver = transceiver;
 
         try {
-            if (adapter != null) {
+            if (connector == null) { // server connection
+                assert adapter != null;
                 _threadPool = adapter.getThreadPool();
-            } else {
+            } else { // client connection
                 _threadPool = _instance.clientThreadPool();
             }
             _threadPool.initialize(this);


### PR DESCRIPTION
Fixes #3346 in C++ and Java. C# was already correct. Other languages are not affected.