### PR TITLE
Throw OperationInterruptedException only when catching an InterruptedException (Java)

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CommunicatorFlushBatch.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CommunicatorFlushBatch.java
@@ -100,14 +100,10 @@ class CommunicatorFlushBatch extends InvocationFuture<Void> {
     }
 
     public void waitForResponse() {
-        if (Thread.interrupted()) {
-            throw new OperationInterruptedException();
-        }
-
         try {
             get();
         } catch (InterruptedException ex) {
-            throw new OperationInterruptedException();
+            throw new OperationInterruptedException(ex);
         } catch (java.util.concurrent.ExecutionException ee) {
             try {
                 throw ee.getCause().fillInStackTrace();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -133,10 +133,6 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
     @Override
     public void close() {
-        if (Thread.interrupted()) {
-            throw new OperationInterruptedException();
-        }
-
         synchronized (this) {
             if (_state < StateClosing) {
                 if (_asyncRequests.isEmpty()) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointHostResolver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointHostResolver.java
@@ -117,14 +117,15 @@ class EndpointHostResolver {
     }
 
     synchronized void destroy() {
-        assert (!_destroyed);
-        _destroyed = true;
+        if (!_destroyed) {
+            _destroyed = true;
 
-        //
-        // Shutdown the executor. No new tasks will be accepted.
-        // Existing tasks will execute.
-        //
-        _executor.shutdown();
+            //
+            // Shutdown the executor. No new tasks will be accepted.
+            // Existing tasks will execute.
+            //
+            _executor.shutdown();
+        }
     }
 
     void joinWithThread() throws InterruptedException {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IncomingConnectionFactory.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IncomingConnectionFactory.java
@@ -411,7 +411,7 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
             if (ex instanceof LocalException) {
                 throw (LocalException) ex;
             } else if (ex instanceof InterruptedException) {
-                throw new OperationInterruptedException();
+                throw new OperationInterruptedException(ex);
             } else {
                 throw new SyscallException(ex);
             }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -317,10 +317,6 @@ public final class Instance implements java.util.function.Function<String, Class
     }
 
     public synchronized ObjectPrx createAdmin(ObjectAdapter adminAdapter, Identity adminIdentity) {
-        if (Thread.interrupted()) {
-            throw new OperationInterruptedException();
-        }
-
         boolean createAdapter = (adminAdapter == null);
 
         synchronized (this) {
@@ -378,10 +374,6 @@ public final class Instance implements java.util.function.Function<String, Class
     }
 
     public ObjectPrx getAdmin() {
-        if (Thread.interrupted()) {
-            throw new OperationInterruptedException();
-        }
-
         ObjectAdapter adminAdapter;
         Identity adminIdentity;
 
@@ -1096,10 +1088,6 @@ public final class Instance implements java.util.function.Function<String, Class
     // Only for use by com.zeroc.Ice.Communicator
     //
     void destroy(boolean interruptible) {
-        if (interruptible && Thread.interrupted()) {
-            throw new OperationInterruptedException();
-        }
-
         synchronized (this) {
             //
             // If destroy is in progress, wait for it to be done. This
@@ -1111,7 +1099,7 @@ public final class Instance implements java.util.function.Function<String, Class
                     wait();
                 } catch (InterruptedException ex) {
                     if (interruptible) {
-                        throw new OperationInterruptedException();
+                        throw new OperationInterruptedException(ex);
                     }
                 }
             }
@@ -1195,7 +1183,7 @@ public final class Instance implements java.util.function.Function<String, Class
                 }
             } catch (InterruptedException ex) {
                 if (interruptible) {
-                    throw new OperationInterruptedException();
+                    throw new OperationInterruptedException(ex);
                 }
             }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminLoggerI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminLoggerI.java
@@ -68,7 +68,7 @@ final class LoggerAdminLoggerI implements LoggerAdminLogger, Runnable {
                 synchronized (this) {
                     _sendLogThread = thread;
                 }
-                throw new OperationInterruptedException();
+                throw new OperationInterruptedException(e);
             }
         }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
@@ -182,10 +182,6 @@ public final class ObjectAdapter {
      * @see Communicator#waitForShutdown
      */
     public void waitForHold() {
-        if (Thread.interrupted()) {
-            throw new OperationInterruptedException();
-        }
-
         List<IncomingConnectionFactory> incomingConnectionFactories;
         synchronized (this) {
             checkForDeactivation();
@@ -216,10 +212,6 @@ public final class ObjectAdapter {
      * @see Communicator#shutdown
      */
     public void deactivate() {
-        if (Thread.interrupted()) {
-            throw new OperationInterruptedException();
-        }
-
         synchronized (this) {
             // Wait for activation or a previous deactivation to complete.
             // This is necessary to avoid out of order locator updates.
@@ -270,10 +262,6 @@ public final class ObjectAdapter {
      * @see Communicator#waitForShutdown
      */
     public void waitForDeactivate() {
-        if (Thread.interrupted()) {
-            throw new OperationInterruptedException();
-        }
-
         try {
             List<IncomingConnectionFactory> incomingConnectionFactories;
             synchronized (this) {
@@ -300,7 +288,7 @@ public final class ObjectAdapter {
                 f.waitUntilFinished();
             }
         } catch (InterruptedException e) {
-            throw new OperationInterruptedException();
+            throw new OperationInterruptedException(e);
         }
     }
 
@@ -325,10 +313,6 @@ public final class ObjectAdapter {
      * @see Communicator#destroy
      */
     public void destroy() {
-        if (Thread.interrupted()) {
-            throw new OperationInterruptedException();
-        }
-
         //
         // Deactivate and wait for completion.
         //
@@ -381,7 +365,7 @@ public final class ObjectAdapter {
             try {
                 _threadPool.joinWithAllThreads();
             } catch (InterruptedException e) {
-                throw new OperationInterruptedException();
+                throw new OperationInterruptedException(e);
             }
         }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapterFactory.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapterFactory.java
@@ -38,7 +38,7 @@ final class ObjectAdapterFactory {
                 try {
                     wait();
                 } catch (InterruptedException ex) {
-                    throw new OperationInterruptedException();
+                    throw new OperationInterruptedException(ex);
                 }
             }
 
@@ -101,10 +101,6 @@ final class ObjectAdapterFactory {
 
     public ObjectAdapter createObjectAdapter(
             String name, RouterPrx router, SSLEngineFactory sslEngineFactory) {
-        if (Thread.interrupted()) {
-            throw new OperationInterruptedException();
-        }
-
         synchronized (this) {
             if (_instance == null) {
                 throw new CommunicatorDestroyedException();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OperationInterruptedException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OperationInterruptedException.java
@@ -4,10 +4,6 @@ package com.zeroc.Ice;
 
 /** This exception indicates a request was interrupted. */
 public final class OperationInterruptedException extends LocalException {
-    public OperationInterruptedException() {
-        super(null);
-    }
-
     public OperationInterruptedException(Throwable cause) {
         super(null, cause);
     }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingAsync.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingAsync.java
@@ -95,10 +95,6 @@ public class OutgoingAsync<T> extends ProxyOutgoingAsyncBase<T> {
     }
 
     public T waitForResponseOrUserEx() throws UserException {
-        if (Thread.interrupted()) {
-            throw new OperationInterruptedException();
-        }
-
         try {
             return get();
         } catch (InterruptedException ex) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingAsyncBase.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingAsyncBase.java
@@ -50,10 +50,6 @@ abstract class OutgoingAsyncBase<T> extends InvocationFuture<T> {
     }
 
     public T waitForResponse() {
-        if (Thread.interrupted()) {
-            throw new OperationInterruptedException();
-        }
-
         try {
             return get();
         } catch (InterruptedException ex) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingConnectionFactory.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingConnectionFactory.java
@@ -68,7 +68,7 @@ final class OutgoingConnectionFactory {
                 try {
                     wait();
                 } catch (InterruptedException ex) {
-                    throw new OperationInterruptedException();
+                    throw new OperationInterruptedException(ex);
                 }
             }
 
@@ -95,7 +95,7 @@ final class OutgoingConnectionFactory {
                             c.abort();
                         }
                     }
-                    throw new OperationInterruptedException();
+                    throw new OperationInterruptedException(e);
                 }
             }
         }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ThreadPool.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ThreadPool.java
@@ -201,7 +201,7 @@ final class ThreadPool implements java.util.concurrent.Executor {
             try {
                 joinWithAllThreads();
             } catch (InterruptedException e) {
-                throw new OperationInterruptedException();
+                throw new OperationInterruptedException(e);
             }
             throw ex;
         }

--- a/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
+++ b/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
@@ -203,7 +203,7 @@ class PluginI implements Plugin {
                     }
                 }
             } catch (InterruptedException ex) {
-                throw new com.zeroc.Ice.OperationInterruptedException();
+                throw new com.zeroc.Ice.OperationInterruptedException(ex);
             }
 
             // Return found locators

--- a/java/test/src/main/java/test/Ice/interrupt/AllTests.java
+++ b/java/test/src/main/java/test/Ice/interrupt/AllTests.java
@@ -134,7 +134,7 @@ public class AllTests {
                     Thread.currentThread().interrupt();
                     InvocationFuture<Void> f = Util.getInvocationFuture(r);
                     f.waitForSent();
-                    test(false);
+                    test(Thread.interrupted());
                 } catch (com.zeroc.Ice.OperationInterruptedException ex) {
                     // Expected
                 }


### PR DESCRIPTION
This PR updates the Java code to remove this pattern:
```java
if (Thread.interrupted()) {
    throw new OperationInterruptedException();
}
```

This pattern is not correct. It would comparable to adding:
```cs
cancellationToken.ThrowIfCancellationRequested();
```
at the beginning of all C# methods that accept a cancellation token.