### PR TITLE
Upgrade DataStorm to use a Default OA for OutgoingConnections

### DIFF
--- a/cpp/include/Ice/Communicator.h
+++ b/cpp/include/Ice/Communicator.h
@@ -210,7 +210,7 @@ namespace Ice
          * @return The object adapter associated by default with new outgoing connections.
          * @see Connection::getAdapter
          */
-        [[nodiscard]] ObjectAdapterPtr getDefaultObjectAdapter() const noexcept;
+        [[nodiscard]] ObjectAdapterPtr getDefaultObjectAdapter() const;
 
         /**
          * Sets the object adapter that will be associated with new outgoing connections created by this
@@ -218,7 +218,7 @@ namespace Ice
          * @param adapter The object adapter to associate with new outgoing connections.
          * @see Connection::setAdapter
          */
-        void setDefaultObjectAdapter(ObjectAdapterPtr adapter) noexcept;
+        void setDefaultObjectAdapter(ObjectAdapterPtr adapter);
 
         /**
          * Get the implicit context associated with this communicator.

--- a/cpp/src/DataStorm/Instance.cpp
+++ b/cpp/src/DataStorm/Instance.cpp
@@ -19,6 +19,12 @@ using namespace Ice;
 Instance::Instance(CommunicatorPtr communicator, function<void(function<void()> call)> customExecutor)
     : _communicator(std::move(communicator))
 {
+    if (_communicator->getDefaultObjectAdapter() != nullptr)
+    {
+        throw invalid_argument(
+            "communicator used to initialize a DataStorm node must not have a default object adapter");
+    }
+
     PropertiesPtr properties = _communicator->getProperties();
 
     if (properties->getIcePropertyAsInt("DataStorm.Node.Server.Enabled") > 0)
@@ -46,6 +52,7 @@ Instance::Instance(CommunicatorPtr communicator, function<void(function<void()> 
     {
         _adapter = _communicator->createObjectAdapter("");
     }
+    _communicator->setDefaultObjectAdapter(_adapter);
 
     if (properties->getIcePropertyAsInt("DataStorm.Node.Multicast.Enabled") > 0)
     {
@@ -179,6 +186,7 @@ Instance::destroy(bool ownsCommunicator)
         timer->destroy();
     }
 
+    _communicator->setDefaultObjectAdapter(nullptr);
     if (ownsCommunicator)
     {
         _communicator->destroy();

--- a/cpp/src/DataStorm/Instance.cpp
+++ b/cpp/src/DataStorm/Instance.cpp
@@ -19,7 +19,7 @@ using namespace Ice;
 Instance::Instance(CommunicatorPtr communicator, function<void(function<void()> call)> customExecutor)
     : _communicator(std::move(communicator))
 {
-    if (_communicator->getDefaultObjectAdapter() != nullptr)
+    if (_communicator->getDefaultObjectAdapter())
     {
         throw invalid_argument(
             "communicator used to initialize a DataStorm node must not have a default object adapter");

--- a/cpp/src/Ice/Communicator.cpp
+++ b/cpp/src/Ice/Communicator.cpp
@@ -157,13 +157,13 @@ Ice::Communicator::createObjectAdapterWithRouter(string name, RouterPrx router)
 }
 
 ObjectAdapterPtr
-Ice::Communicator::getDefaultObjectAdapter() const noexcept
+Ice::Communicator::getDefaultObjectAdapter() const
 {
     return _instance->outgoingConnectionFactory()->getDefaultObjectAdapter();
 }
 
 void
-Ice::Communicator::setDefaultObjectAdapter(ObjectAdapterPtr adapter) noexcept
+Ice::Communicator::setDefaultObjectAdapter(ObjectAdapterPtr adapter)
 {
     return _instance->outgoingConnectionFactory()->setDefaultObjectAdapter(std::move(adapter));
 }

--- a/cpp/test/DataStorm/api/Writer.cpp
+++ b/cpp/test/DataStorm/api/Writer.cpp
@@ -36,8 +36,8 @@ void ::Writer::run(int argc, char* argv[])
             // Communicators shared with DataStorm must have a property set that can use the "DataStorm" opt-in prefix.
             Ice::InitializationData initData;
             initData.properties = make_shared<Ice::Properties>(vector<string>{"DataStorm"});
-            Ice::CommunicatorHolder communicatorHolder(Ice::initialize(initData));
-            Node n2(communicatorHolder.communicator());
+            Ice::CommunicatorHolder communicatorHolder{Ice::initialize(initData)};
+            Node n2{communicatorHolder.communicator()};
         }
 
         Ice::InitializationData initData;

--- a/cpp/test/DataStorm/api/Writer.cpp
+++ b/cpp/test/DataStorm/api/Writer.cpp
@@ -36,8 +36,8 @@ void ::Writer::run(int argc, char* argv[])
             // Communicators shared with DataStorm must have a property set that can use the "DataStorm" opt-in prefix.
             Ice::InitializationData initData;
             initData.properties = make_shared<Ice::Properties>(vector<string>{"DataStorm"});
-            Node n2(Ice::initialize(initData));
-            n2.getCommunicator()->destroy();
+            Ice::CommunicatorHolder communicatorHolder(Ice::initialize(initData));
+            Node n2(communicatorHolder.communicator());
         }
 
         Ice::InitializationData initData;

--- a/cpp/test/DataStorm/config/Writer.cpp
+++ b/cpp/test/DataStorm/config/Writer.cpp
@@ -329,7 +329,8 @@ void ::Writer::run(int argc, char* argv[])
             Node node1(holder.communicator());
             Topic<string, int> topic1(node1, "sendTimeTopic");
             auto singleKeyWriter = makeSingleKeyWriter(topic1, "elem");
-            w.push_back(WriterHolder{std::move(holder), std::move(node1), std::move(topic1), std::move(singleKeyWriter)});
+            w.push_back(
+                WriterHolder{std::move(holder), std::move(node1), std::move(topic1), std::move(singleKeyWriter)});
         }
 
         int i = 0;

--- a/cpp/test/DataStorm/config/Writer.cpp
+++ b/cpp/test/DataStorm/config/Writer.cpp
@@ -308,16 +308,16 @@ void ::Writer::run(int argc, char* argv[])
     }
     cout << "ok" << endl;
 
-    struct WriterHolder
-    {
-        Ice::CommunicatorHolder communicator;
-        Node node;
-        Topic<string, int> topic;
-        SingleKeyWriter<string, int> writer;
-    };
-
     cout << "testing send time discard policy... " << flush;
     {
+        struct WriterHolder
+        {
+            Ice::CommunicatorHolder communicator;
+            Node node;
+            Topic<string, int> topic;
+            SingleKeyWriter<string, int> writer;
+        };
+
         writers.update(false); // Not ready
         vector<WriterHolder> w;
         size_t writerCount = 10;
@@ -329,7 +329,7 @@ void ::Writer::run(int argc, char* argv[])
             Node node1(holder.communicator());
             Topic<string, int> topic1(node1, "sendTimeTopic");
             auto singleKeyWriter = makeSingleKeyWriter(topic1, "elem");
-            w.emplace_back(std::move(holder), std::move(node1), std::move(topic1), std::move(singleKeyWriter));
+            w.push_back(WriterHolder{std::move(holder), std::move(node1), std::move(topic1), std::move(singleKeyWriter)});
         }
 
         int i = 0;


### PR DESCRIPTION
This PR upgrades DataStorm implementation to use setDefaultObjectAdapter to set a default object adapter for outgoing connections. See #3337