### PR TITLE
Fix bogus timestamp format on Windows

### DIFF
--- a/cpp/src/Ice/TimeUtil.cpp
+++ b/cpp/src/Ice/TimeUtil.cpp
@@ -15,19 +15,23 @@ IceInternal::timePointToString(const chrono::system_clock::time_point& timePoint
     time_t time = static_cast<time_t>(chrono::duration_cast<chrono::seconds>(timePoint.time_since_epoch()).count());
     struct tm tr;
 #ifdef _MSC_VER
-    auto p = localtime_s(&tr, &time);
-#else
-    auto p = localtime_r(&time, &tr);
-#endif
+    // localtime_s in Microsoft CRT is incompatible with the C standard as it returns errno_t instead of struct tm*
+    errno_t p = localtime_s(&tr, &time);
     if (p)
-    {
-        char buf[32];
-        return strftime(buf, sizeof(buf), format.c_str(), &tr) == 0 ? std::string{} : std::string{buf};
-    }
-    else
     {
         return std::string{};
     }
+#else
+    // the standard localtime_r returns a null pointer on error.
+    struct tm* p = localtime_r(&time, &tr);
+    if (!p)
+    {
+        return std::string{};
+    }
+#endif
+
+    char buf[32];
+    return strftime(buf, sizeof(buf), format.c_str(), &tr) == 0 ? std::string{} : std::string{buf};
 }
 
 string
@@ -36,6 +40,7 @@ IceInternal::timePointToDateTimeString(const chrono::system_clock::time_point& t
     const string format = "%x %H:%M:%S";
     ostringstream os;
     os << timePointToString(timePoint, format);
+    os << '.';
     os.fill('0');
     os.width(3);
     auto usec = chrono::duration_cast<chrono::microseconds>(timePoint.time_since_epoch());


### PR DESCRIPTION
Fix #3363