### PR TITLE
Allow swift:attribute metadata on structs

### DIFF
--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -2140,8 +2140,8 @@ SwiftGenerator::MetadataVisitor::validate(const SyntaxTreeBasePtr& p, const Cont
             continue;
         }
 
-        if ((dynamic_pointer_cast<ClassDecl>(p) || dynamic_pointer_cast<InterfaceDecl>(p) ||
-             dynamic_pointer_cast<Enum>(p) || dynamic_pointer_cast<Exception>(p)) &&
+        if ((dynamic_pointer_cast<ClassDecl>(p) || dynamic_pointer_cast<Struct>(p) || dynamic_pointer_cast<Enum>(p) ||
+             dynamic_pointer_cast<Exception>(p)) &&
             directive == "swift:attribute" && !arguments.empty())
         {
             continue;


### PR DESCRIPTION
Fixes #3259
