### PR TITLE
Cleanup 'addImport' and Surrounding Functions in `slice2swift`

### DIFF
--- a/cpp/src/slice2swift/Gen.h
+++ b/cpp/src/slice2swift/Gen.h
@@ -46,9 +46,8 @@ namespace Slice
             void writeImports();
 
         private:
-            void addImport(const TypePtr&, const ContainedPtr&);
-            void addImport(const ContainedPtr&, const ContainedPtr&);
-            void addImport(const std::string&);
+            void addImport(const SyntaxTreeBasePtr& p, const ContainedPtr& toplevel);
+            void addImport(const std::string& module);
 
             IceInternal::Output& out;
             std::vector<std::string> _imports;

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -18,7 +18,6 @@ namespace Slice
     std::string getSwiftModule(const ModulePtr&, std::string&);
     std::string getSwiftModule(const ModulePtr&);
     ModulePtr getTopLevelModule(const ContainedPtr&);
-    ModulePtr getTopLevelModule(const TypePtr&);
 
     std::string fixIdent(const std::string&);
 


### PR DESCRIPTION
In `slice2swift` we have two versions of `getTopLevelModule` and `addImport`.
One takes a `ContainedPtr` and one takes a `TypePtr`.

But, the versions which took `TypePtr` were weird and not really necessary.
They basically just converted the `TypePtr` into a `ContainedPtr` to call the other one.
But most of the places where it was called, the `Type` was already a `Contained`.

Anyways, I removed the `TypePtr` versions.
And because of this, alot of unnecessary `dynamic_pointer_cast`s.