### PR TITLE
DataStorm session recovery fixes

### DIFF
--- a/cpp/src/DataStorm/NodeI.cpp
+++ b/cpp/src/DataStorm/NodeI.cpp
@@ -150,6 +150,8 @@ NodeI::createSession(
     checkNotNull(subscriber, __FILE__, __LINE__, current);
     checkNotNull(subscriberSession, __FILE__, __LINE__, current);
 
+    bool isWellKnown = subscriber->ice_getEndpoints().empty() && subscriber->ice_getAdapterId().empty();
+
     auto instance = _instance.lock();
     assert(instance);
 
@@ -182,16 +184,22 @@ NodeI::createSession(
         {
             return; // Shutting down.
         }
-        else if (session->checkSession())
-        {
-            return; // Already connected.
-        }
 
         s->ice_getConnectionAsync(
             [=, self = shared_from_this()](const auto& connection) mutable
             {
                 if (session->checkSession())
                 {
+                    if (isWellKnown && current.con && session->getConnection() != current.con)
+                    {
+                        // If the peer is using a well-known proxy and requests a session using a different connection,
+                        // assume the current session connection is being closed and reconnect using the new connection.
+                        //
+                        // Otherwise, once the current connection is actually closed, we won't be able to reconnect.
+                        session->disconnect();
+                        session->reconnect(*subscriber, current.con);
+                    }
+                    // else is already connected.
                     return;
                 }
 
@@ -302,6 +310,8 @@ NodeI::createPublisherSession(
     auto instance = _instance.lock();
     assert(instance);
 
+    bool isWellKnown = publisher->ice_getEndpoints().empty() && publisher->ice_getAdapterId().empty();
+
     try
     {
         auto p = getNodeWithExistingConnection(instance, publisher, publisherConnection);
@@ -316,7 +326,17 @@ NodeI::createPublisherSession(
             }
             else if (session->checkSession())
             {
-                return; // Already connected.
+                if (isWellKnown && publisherConnection && session->getConnection() != publisherConnection)
+                {
+                    // If the peer is using a well-known proxy and requests a session using a different connection,
+                    // assume the current session connection is being closed and reconnect using the new connection.
+                    //
+                    // Otherwise, once the current connection is actually closed, we won't be able to reconnect.
+                    session->disconnect();
+                    session->reconnect(publisher, publisherConnection);
+                }
+                // else is already connected.
+                return;
             }
         }
 

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -743,7 +743,7 @@ SessionI::retry(NodePrx node, exception_ptr exception)
         }
 
         _retryTask = make_shared<IceInternal::InlineTimerTask>([node = std::move(node), self = shared_from_this()]
-                                                               { self->reconnect(node); });
+                                                               { self->reconnect(node, nullptr); });
         _instance->scheduleTimerTask(_retryTask, delay);
     }
     return true;
@@ -938,6 +938,40 @@ SessionI::disconnect(int64_t topicId, TopicI* topic)
     {
         _topics.erase(topicId);
     }
+}
+
+void
+SessionI::disconnect()
+{
+    lock_guard<mutex> lock(_mutex);
+    if (_destroyed)
+    {
+        // Ignore already destroyed.
+        return;
+    }
+    else if (!_session)
+    {
+        // Ignore if the session is already disconnected.
+        return;
+    }
+
+    if (_traceLevels->session > 0)
+    {
+        Trace out(_traceLevels->logger, _traceLevels->sessionCat);
+        out << _id << ": session '" << _session->ice_getIdentity() << "' disconnected:\n";
+        out << (_connection ? _connection->toString() : "<no connection>") << "\n";
+    }
+
+    // Detach all topics from the session.
+    auto self = shared_from_this();
+    for (const auto& [topicId, _] : _topics)
+    {
+        runWithTopics(topicId, [topicId, self](TopicI* topic, TopicSubscriber&) { topic->detach(topicId, self); });
+    }
+
+    _session = nullopt;
+    _connection = nullptr;
+    _retryCount = 0;
 }
 
 void
@@ -1352,14 +1386,14 @@ SubscriberSessionI::s(int64_t topicId, int64_t elementId, DataSample dataSample,
 }
 
 void
-SubscriberSessionI::reconnect(NodePrx node)
+SubscriberSessionI::reconnect(NodePrx node, const Ice::ConnectionPtr& connection)
 {
     if (_traceLevels->session > 0)
     {
         Trace out(_traceLevels->logger, _traceLevels->sessionCat);
         out << _id << ": trying to reconnect session with '" << node->ice_toString() << "'";
     }
-    _parent->createPublisherSession(node, nullptr, dynamic_pointer_cast<SubscriberSessionI>(shared_from_this()));
+    _parent->createPublisherSession(node, connection, dynamic_pointer_cast<SubscriberSessionI>(shared_from_this()));
 }
 
 void
@@ -1384,14 +1418,14 @@ PublisherSessionI::getTopics(const string& name) const
 }
 
 void
-PublisherSessionI::reconnect(NodePrx node)
+PublisherSessionI::reconnect(NodePrx node, const ConnectionPtr& connection)
 {
     if (_traceLevels->session > 0)
     {
         Trace out(_traceLevels->logger, _traceLevels->sessionCat);
         out << _id << ": trying to reconnect session with '" << node->ice_toString() << "'";
     }
-    _parent->createSubscriberSession(node, nullptr, dynamic_pointer_cast<PublisherSessionI>(shared_from_this()));
+    _parent->createSubscriberSession(node, connection, dynamic_pointer_cast<PublisherSessionI>(shared_from_this()));
 }
 
 void

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -307,6 +307,7 @@ namespace DataStormI
         void subscribe(std::int64_t, TopicI*);
         void unsubscribe(std::int64_t, TopicI*);
         void disconnect(std::int64_t, TopicI*);
+        void disconnect();
 
         void subscribeToKey(
             std::int64_t topicId,
@@ -349,6 +350,12 @@ namespace DataStormI
             const std::shared_ptr<Key>&,
             const std::shared_ptr<DataElementI>&);
 
+        /// Attempts to reconnect the session with the specified node.
+        ///
+        /// @param node The node to reconnect to.
+        /// @param connection The connection to the node or nullptr if a new connection should be established.
+        virtual void reconnect(DataStormContract::NodePrx node, const Ice::ConnectionPtr& connection) = 0;
+
     protected:
         /// Runs the provided callback function for each topic with the specified name.
         /// The callback is executed with the topic's mutex locked.
@@ -390,10 +397,6 @@ namespace DataStormI
         /// @return A vector containing the topics that match the specified name.
         virtual std::vector<std::shared_ptr<TopicI>> getTopics(const std::string& name) const = 0;
 
-        /// Attempts to reconnect the session with the specified node.
-        ///
-        /// @param node The node to reconnect to.
-        virtual void reconnect(DataStormContract::NodePrx node) = 0;
         virtual void remove() = 0;
 
         const std::shared_ptr<Instance> _instance;
@@ -449,10 +452,10 @@ namespace DataStormI
             DataStormContract::SessionPrx);
 
         void s(std::int64_t, std::int64_t, DataStormContract::DataSample, const Ice::Current&) final;
+        void reconnect(DataStormContract::NodePrx, const Ice::ConnectionPtr&) final;
 
     private:
         [[nodiscard]] std::vector<std::shared_ptr<TopicI>> getTopics(const std::string&) const final;
-        void reconnect(DataStormContract::NodePrx) final;
         void remove() final;
     };
 
@@ -464,10 +467,10 @@ namespace DataStormI
             std::shared_ptr<NodeI>,
             DataStormContract::NodePrx,
             DataStormContract::SessionPrx);
+        void reconnect(DataStormContract::NodePrx, const Ice::ConnectionPtr&) final;
 
     private:
         [[nodiscard]] std::vector<std::shared_ptr<TopicI>> getTopics(const std::string&) const final;
-        void reconnect(DataStormContract::NodePrx) final;
         void remove() final;
     };
 }


### PR DESCRIPTION
This PR updates the session recovery mechanism to handle scenarios where a peer’s recovery attempt arrives before the connection closure is detected, and the peer is using a well-known proxy. In such cases, if the incoming recovery attempt is ignored because the session is assumed to still be active on the other end, the peer will later be unable to reconnect. There is no alternative way to reach the remote peer other than through the new incoming connection provided by this recovery attempt.