### PR TITLE
Remove usage of deprecated E_STRICT in PHP tests

### DIFF
--- a/php/test/Ice/binding/Client.php
+++ b/php/test/Ice/binding/Client.php
@@ -3,8 +3,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-error_reporting(E_ALL | E_STRICT);
-
 require_once('Test.php');
 
 function createTestIntfPrx($adapters)

--- a/php/test/TestHelper.php
+++ b/php/test/TestHelper.php
@@ -3,7 +3,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 if(!extension_loaded("ice"))
 {


### PR DESCRIPTION
 Fix #3381