### PR TITLE
Retry after receive the disconnected request

### DIFF
--- a/cpp/src/DataStorm/NodeI.cpp
+++ b/cpp/src/DataStorm/NodeI.cpp
@@ -546,22 +546,6 @@ NodeI::getNodeWithExistingConnection(
         connection = nodeSession->getConnection();
     }
 
-    // Otherwise, check if the node already has a session established and use the connection from the session.
-    {
-        lock_guard<mutex> lock(_mutex);
-        auto p = _subscribers.find(node->ice_getIdentity());
-        if (p != _subscribers.end())
-        {
-            connection = p->second->getConnection();
-        }
-
-        auto q = _publishers.find(node->ice_getIdentity());
-        if (q != _publishers.end())
-        {
-            connection = q->second->getConnection();
-        }
-    }
-
     // Make sure the connection is still valid.
     if (connection)
     {

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -615,8 +615,8 @@ SessionI::disconnected(const ConnectionPtr& connection, exception_ptr ex)
     }
     else if (!_session)
     {
-        // Ignore if the session is already disconnected.
-        return false;
+        // A recovery attempt was in progress and failed. Return true to let the caller retry.
+        return true;
     }
 
     if (_traceLevels->session > 0)


### PR DESCRIPTION
This PR fix DataStorm session to not ignore disconnected requests if the session is in the disconnected state. Receiving a disconnected request on a disconnected session might indicate that a recovery attempt was in progress and failed.

There is also a fix to avoid reusing connection from publisher and subscriber sessions.
