### PR TITLE
Remove encoding declaration comments from Ruby and Python

### DIFF
--- a/cpp/src/slice2py/Python.cpp
+++ b/cpp/src/slice2py/Python.cpp
@@ -702,11 +702,6 @@ Slice::Python::compile(const vector<string>& argv)
                             }
                             FileTracker::instance()->addFile(path);
 
-                            //
-                            // Emit a Python magic comment to set the file encoding.
-                            // It must be the first or second line.
-                            //
-                            out << "# -*- coding: utf-8 -*-\n";
                             printHeader(out);
                             printGeneratedHeader(out, base + ".ice", "#");
 

--- a/cpp/src/slice2rb/Ruby.cpp
+++ b/cpp/src/slice2rb/Ruby.cpp
@@ -259,10 +259,7 @@ Slice::Ruby::compile(const vector<string>& argv)
                             throw FileException(__FILE__, __LINE__, oss.str());
                         }
                         FileTracker::instance()->addFile(file);
-                        //
-                        // Ruby magic comment to set the file encoding, it must be first or second line
-                        //
-                        out << "# encoding: utf-8\n";
+
                         printHeader(out);
                         printGeneratedHeader(out, base + ".ice", "#");
 

--- a/cpp/test/Glacier2/attack/test.py
+++ b/cpp/test/Glacier2/attack/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 from Glacier2Util import Glacier2TestSuite

--- a/cpp/test/Glacier2/dynamicFiltering/test.py
+++ b/cpp/test/Glacier2/dynamicFiltering/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 #

--- a/cpp/test/Glacier2/hashpassword/test.py
+++ b/cpp/test/Glacier2/hashpassword/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 import os

--- a/cpp/test/Glacier2/sessionControl/test.py
+++ b/cpp/test/Glacier2/sessionControl/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 #

--- a/cpp/test/Glacier2/ssl/test.py
+++ b/cpp/test/Glacier2/ssl/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 from Glacier2Util import Glacier2Router, Glacier2TestSuite

--- a/cpp/test/Glacier2/staticFiltering/test.py
+++ b/cpp/test/Glacier2/staticFiltering/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 import os

--- a/cpp/test/Ice/logger/test.py
+++ b/cpp/test/Ice/logger/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 import glob

--- a/cpp/test/IceBridge/simple/test.py
+++ b/cpp/test/IceBridge/simple/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 from IceBridgeUtil import IceBridge

--- a/cpp/test/IceGrid/activation/test.py
+++ b/cpp/test/IceGrid/activation/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 import os
 import re

--- a/cpp/test/IceGrid/admin/test.py
+++ b/cpp/test/IceGrid/admin/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 

--- a/cpp/test/IceGrid/allocation/test.py
+++ b/cpp/test/IceGrid/allocation/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 import os

--- a/cpp/test/IceGrid/deployer/test.py
+++ b/cpp/test/IceGrid/deployer/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 

--- a/cpp/test/IceGrid/fileLock/test.py
+++ b/cpp/test/IceGrid/fileLock/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 

--- a/cpp/test/IceGrid/noRestartUpdate/test.py
+++ b/cpp/test/IceGrid/noRestartUpdate/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 

--- a/cpp/test/IceGrid/replicaGroup/test.py
+++ b/cpp/test/IceGrid/replicaGroup/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 import os

--- a/cpp/test/IceGrid/replication/test.py
+++ b/cpp/test/IceGrid/replication/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 

--- a/cpp/test/IceGrid/session/test.py
+++ b/cpp/test/IceGrid/session/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 

--- a/cpp/test/IceGrid/update/test.py
+++ b/cpp/test/IceGrid/update/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 

--- a/cpp/test/IceStorm/federation/test.py
+++ b/cpp/test/IceStorm/federation/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 

--- a/cpp/test/IceStorm/federation2/test.py
+++ b/cpp/test/IceStorm/federation2/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 #

--- a/cpp/test/IceStorm/persistent/test.py
+++ b/cpp/test/IceStorm/persistent/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 from IceStormUtil import IceStorm, IceStormAdmin, IceStormProcess

--- a/cpp/test/IceStorm/rep1/test.py
+++ b/cpp/test/IceStorm/rep1/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 #

--- a/cpp/test/IceStorm/repgrid/test.py
+++ b/cpp/test/IceStorm/repgrid/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 # Use the IceGridServer for the client because the client is an IceStorm subscriber and needs to be able

--- a/cpp/test/IceStorm/repstress/test.py
+++ b/cpp/test/IceStorm/repstress/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 #

--- a/cpp/test/IceStorm/single/test.py
+++ b/cpp/test/IceStorm/single/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 #

--- a/cpp/test/IceStorm/stress/test.py
+++ b/cpp/test/IceStorm/stress/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 #

--- a/cpp/test/IceUtil/unicode/test.py
+++ b/cpp/test/IceUtil/unicode/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 from Util import ClientTestCase, SimpleClient, TestSuite

--- a/cpp/test/Slice/errorDetection/test.py
+++ b/cpp/test/Slice/errorDetection/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 import glob

--- a/cpp/test/Slice/headers/test.py
+++ b/cpp/test/Slice/headers/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 import os

--- a/cpp/test/Slice/unicodePaths/test.py
+++ b/cpp/test/Slice/unicodePaths/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 import os

--- a/python/modules/IcePy/Slice.cpp
+++ b/python/modules/IcePy/Slice.cpp
@@ -142,11 +142,6 @@ IcePy_loadSlice(PyObject* /*self*/, PyObject* args)
         IceInternal::Output out(codeStream);
         out.setUseTab(false);
 
-        //
-        // Emit a Python magic comment to set the file encoding.
-        // It must be the first or second line.
-        //
-        out << "# -*- coding: utf-8 -*-\n";
         generate(u, all, includePaths, out);
         u->destroy();
 

--- a/python/test/Ice/blobject/test.py
+++ b/python/test/Ice/blobject/test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 # This test doesn't support running with IceSSL, the Router object in the client process uses

--- a/python/test/Ice/properties/Client.py
+++ b/python/test/Ice/properties/Client.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 import sys

--- a/scripts/tests/Glacier2/application.py
+++ b/scripts/tests/Glacier2/application.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 from Glacier2Util import Glacier2TestSuite

--- a/scripts/tests/Glacier2/router.py
+++ b/scripts/tests/Glacier2/router.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 from Glacier2Util import Glacier2Router, Glacier2TestSuite

--- a/scripts/tests/Glacier2/sessionHelper.py
+++ b/scripts/tests/Glacier2/sessionHelper.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 from Glacier2Util import Glacier2TestSuite

--- a/scripts/tests/Ice/adapterDeactivation.py
+++ b/scripts/tests/Ice/adapterDeactivation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 from Util import CSharpMapping, Darwin, TestSuite, platform, Mapping

--- a/scripts/tests/Ice/admin.py
+++ b/scripts/tests/Ice/admin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 from Util import TestSuite

--- a/scripts/tests/Ice/ami.py
+++ b/scripts/tests/Ice/ami.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 # Enable some tracing to allow investigating test failures

--- a/scripts/tests/Ice/hold.py
+++ b/scripts/tests/Ice/hold.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 from Util import ClientServerTestCase, Server, TestSuite

--- a/scripts/tests/Ice/info.py
+++ b/scripts/tests/Ice/info.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 from Util import TestSuite

--- a/scripts/tests/Ice/interrupt.py
+++ b/scripts/tests/Ice/interrupt.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 from Util import TestSuite

--- a/scripts/tests/Ice/location.py
+++ b/scripts/tests/Ice/location.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 # Enable some tracing to allow investigating test failures

--- a/scripts/tests/Ice/metrics.py
+++ b/scripts/tests/Ice/metrics.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 from Util import (

--- a/scripts/tests/Ice/operations.py
+++ b/scripts/tests/Ice/operations.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 # Enable some tracing to allow investigating test failures

--- a/scripts/tests/Ice/properties.py
+++ b/scripts/tests/Ice/properties.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 from Util import Client, ClientTestCase, MatlabMapping, PhpMapping, TestSuite

--- a/scripts/tests/Ice/retry.py
+++ b/scripts/tests/Ice/retry.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 # Enable some tracing to allow investigating test failures

--- a/scripts/tests/Ice/timeout.py
+++ b/scripts/tests/Ice/timeout.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 # Enable some tracing to allow investigating test failures

--- a/scripts/tests/IceBox/admin.py
+++ b/scripts/tests/IceBox/admin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 from IceBoxUtil import IceBox, IceBoxAdmin

--- a/scripts/tests/IceBox/configuration.py
+++ b/scripts/tests/IceBox/configuration.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 from IceBoxUtil import IceBox

--- a/scripts/tests/IceDiscovery/simple.py
+++ b/scripts/tests/IceDiscovery/simple.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 import re

--- a/scripts/tests/IceGrid/simple.py
+++ b/scripts/tests/IceGrid/simple.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 import os

--- a/scripts/tests/IceSSL/configuration.py
+++ b/scripts/tests/IceSSL/configuration.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 import os

--- a/scripts/tests/IceSSL/revocationutil.py
+++ b/scripts/tests/IceSSL/revocationutil.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) ZeroC, Inc.
 
 from cryptography.hazmat.primitives import hashes, serialization


### PR DESCRIPTION
I've removed (both from generated and source code) the encoding comments from Ruby and Python.

In Python: 
```diff
-# -*- coding: utf-8 -*-
```

The utf-8 encoding is the default in Python 3 and we no longer support Python 2.

In Ruby:
```diff
-# encoding: utf-8
```

Ditto, it's recommend not to use this as it's the default. See https://docs.rubocop.org/rubocop/cops_style.html#styleencoding.

Oddly enough, we never used this in our Ruby source code, just the generated Ruby code.



