### PR TITLE
Pass the native SecCertificate to Swift SSL ConnectionInfo

### DIFF
--- a/swift/src/Ice/ConnectionInfoFactory.swift
+++ b/swift/src/Ice/ConnectionInfoFactory.swift
@@ -58,25 +58,9 @@ class ConnectionInfoFactory: ICEConnectionInfoFactory {
         WSConnectionInfo(underlying: underlying as! ConnectionInfo, headers: headers)
     }
 
-    static func createSSLConnectionInfo(_ underlying: Any, peerCertificate: String) -> Any {
-        let beginPrefix = "-----BEGIN CERTIFICATE-----\n"
-        let endPrefix = "\n-----END CERTIFICATE-----\n"
-
-        var raw = peerCertificate
-        if raw.hasPrefix(beginPrefix) {
-            raw = String(raw.dropFirst(beginPrefix.count))
-            raw = String(raw.dropLast(endPrefix.count))
-        }
-
-        var decodedPeerCertificate: SecCertificate? = nil
-        if let data = NSData(base64Encoded: raw, options: .ignoreUnknownCharacters) {
-            if let cert = SecCertificateCreateWithData(kCFAllocatorDefault, data) {
-                decodedPeerCertificate = cert
-            }
-        }
-
+    static func createSSLConnectionInfo(_ underlying: Any, peerCertificate: SecCertificate) -> Any {
         return SSLConnectionInfo(
-            underlying: underlying as! ConnectionInfo, peerCertificate: decodedPeerCertificate)
+            underlying: underlying as! ConnectionInfo, peerCertificate: peerCertificate)
     }
 
     static func createIAPConnectionInfo(

--- a/swift/src/IceImpl/Connection.mm
+++ b/swift/src/IceImpl/Connection.mm
@@ -226,15 +226,7 @@ createConnectionInfo(std::shared_ptr<Ice::ConnectionInfo> infoPtr)
     auto sslInfo = std::dynamic_pointer_cast<Ice::SSL::ConnectionInfo>(infoPtr);
     if (sslInfo)
     {
-        std::string encoded;
-        // See https://github.com/zeroc-ice/ice/issues/3283
-#if TARGET_OS_IPHONE == 0
-        if (sslInfo->peerCertificate)
-        {
-            encoded = Ice::SSL::encodeCertificate(sslInfo->peerCertificate);
-        }
-#endif
-        return [factory createSSLConnectionInfo:underlying peerCertificate:toNSString(encoded)];
+        return [factory createSSLConnectionInfo:underlying peerCertificate:sslInfo->peerCertificate];
     }
 
     auto iapInfo = std::dynamic_pointer_cast<Ice::IAPConnectionInfo>(infoPtr);

--- a/swift/src/IceImpl/include/Connection.h
+++ b/swift/src/IceImpl/include/Connection.h
@@ -52,7 +52,7 @@ ICEIMPL_API @protocol ICEConnectionInfoFactory
 
 + (id)createWSConnectionInfo:(id)underlying headers:(NSDictionary<NSString*, NSString*>*)headers;
 
-+ (id)createSSLConnectionInfo:(id)underlying peerCertificate:(NSString*)peerCertificate;
++ (id)createSSLConnectionInfo:(id)underlying peerCertificate:(SecCertificateRef)peerCertificate;
 
 + (id)createIAPConnectionInfo:(BOOL)incoming
                   adapterName:(NSString*)adapterName


### PR DESCRIPTION
Fix #3283