### PR TITLE
Use .NET 9.x form Linux ARM64 tests

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -17,14 +17,6 @@ inputs:
     options:
       - true
       - false
-  dotnet_version:
-    description: "The .NET version to install"
-    type: choice
-    required: false
-    default: "8.x"
-    options:
-      - 8.x
-      - 9.x
 
 runs:
   using: "composite"
@@ -53,7 +45,15 @@ runs:
     - name: Setup .NET 8
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: ${{ inputs.dotnet_version }}
+        dotnet-version: 8.x
+      if: matrix.os != 'ubuntu-24.04-arm'
+
+    # Use .NET 9.x on Ubuntu ARM see https://github.com/dotnet/runtime/issues/104123
+    - name: Setup .NET 9
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.x
+      if: matrix.os == 'ubuntu-24.04-arm'
 
     - name: Install testing dependencies from pip
       run: python3 -m pip install passlib cryptography numpy

--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -17,6 +17,14 @@ inputs:
     options:
       - true
       - false
+  dotnet_version:
+    description: "The .NET version to install"
+    type: choice
+    required: false
+    default: "8.x"
+    options:
+      - 8.x
+      - 9.x
 
 runs:
   using: "composite"

--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -53,7 +53,7 @@ runs:
     - name: Setup .NET 8
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.x
+        dotnet-version: ${{ inputs.dotnet_version }}
 
     - name: Install testing dependencies from pip
       run: python3 -m pip install passlib cryptography numpy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
             config: "release"
           - os: ubuntu-24.04-arm
             config: "release"
-            dotnet_version: "9.x" # Use .NET 9.x on ARM https://github.com/dotnet/runtime/issues/104123
             test_flags: "--rfilter=java/Ice/udp" # Remove rfilter once https://github.com/zeroc-ice/ice/issues/3389 is fixed
           - os: windows-2022
             config: "release"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
             config: "release"
           - os: ubuntu-24.04-arm
             config: "release"
+            dotnet_version: "9.x" # Use .NET 9.x on ARM https://github.com/dotnet/runtime/issues/104123
             test_flags: "--rfilter=java/Ice/udp" # Remove rfilter once https://github.com/zeroc-ice/ice/issues/3389 is fixed
           - os: windows-2022
             config: "release"


### PR DESCRIPTION
Switch ARM Linux tests to .NET 9 to see if it is more stable.