### PR TITLE
Fix more clang-tidy lints (C++)

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,13 +1,3 @@
-# C++ code generated from Slice files
-cpp/include/generated/**/*.h
-cpp/src/**/generated/**/*.cpp
-cpp/test/**/generated/**/*.h
-cpp/test/**/generated/**/*.cpp
-cpp/src/**/msbuild/**/*.h
-cpp/src/**/msbuild/**/*.cpp
-cpp/test/**/msbuild/**/*.h
-cpp/test/**/msbuild/**/*.cpp
-
 # C++ code generated from the Bison/Flex parsers
 cpp/src/Slice/Grammar.h
 cpp/src/Slice/Grammar.cpp

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,7 @@ Checks:
   -modernize-use-trailing-return-type,
   -modernize-concat-nested-namespaces,
   -modernize-use-default-member-init,
+  -modernize-macro-to-enum,
   performance-*,
   -performance-avoid-endl,
   -performance-enum-size,

--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -1360,7 +1360,7 @@ namespace DataStorm
         std::function<void(std::vector<Key>)> init,
         std::function<void(CallbackReason, Key)> update) noexcept
     {
-        _impl->onConnectedKeys(init ? [init](std::vector<std::shared_ptr<DataStormI::Key>> connectedKeys)
+        _impl->onConnectedKeys(init ? [init](const std::vector<std::shared_ptr<DataStormI::Key>>& connectedKeys)
     {
         std::vector<Key> keys;
         keys.reserve(connectedKeys.size());
@@ -1381,7 +1381,7 @@ namespace DataStorm
         std::function<void(std::vector<std::string>)> init,
         std::function<void(CallbackReason, std::string)> update) noexcept
     {
-        _impl->onConnectedElements(init, update);
+        _impl->onConnectedElements(std::move(init), std::move(update));
     }
 
     template<typename Key, typename Value, typename UpdateTag>
@@ -1629,7 +1629,7 @@ namespace DataStorm
         std::function<void(std::vector<Key>)> init,
         std::function<void(CallbackReason, Key)> update) noexcept
     {
-        _impl->onConnectedKeys(init ? [init](std::vector<std::shared_ptr<DataStormI::Key>> connectedKeys)
+        _impl->onConnectedKeys(init ? [init](const std::vector<std::shared_ptr<DataStormI::Key>>& connectedKeys)
     {
         std::vector<Key> keys;
         keys.reserve(connectedKeys.size());
@@ -1650,7 +1650,7 @@ namespace DataStorm
         std::function<void(std::vector<std::string>)> init,
         std::function<void(CallbackReason, std::string)> update) noexcept
     {
-        _impl->onConnectedElements(init, update);
+        _impl->onConnectedElements(std::move(init), std::move(update));
     }
 
     template<typename Key, typename Value, typename UpdateTag>

--- a/cpp/include/DataStorm/Node.h
+++ b/cpp/include/DataStorm/Node.h
@@ -68,7 +68,7 @@ namespace DataStorm
             char* argv[],
             std::optional<std::string_view> configFile = std::nullopt,
             std::function<void(std::function<void()> call)> customExecutor = nullptr)
-            : Node(argc, const_cast<const char**>(argv), configFile, customExecutor)
+            : Node(argc, const_cast<const char**>(argv), configFile, std::move(customExecutor))
         {
         }
 

--- a/cpp/include/Ice/Config.h
+++ b/cpp/include/Ice/Config.h
@@ -36,11 +36,9 @@
 #endif
 
 // The Ice version.
-// NOLINTBEGIN(modernize-macro-to-enum)
 #define ICE_STRING_VERSION "3.8.0-alpha.0" // "A.B.C", with A=major, B=minor, C=patch
 #define ICE_INT_VERSION 30850              // AABBCC, with AA=major, BB=minor, CC=patch
 #define ICE_SO_VERSION "38a0"              // "ABC", with A=major, B=minor, C=patch
-// NOLINTEND(modernize-macro-to-enum)
 
 #if !defined(ICE_BUILDING_ICE) && defined(ICE_API_EXPORTS)
 #    define ICE_BUILDING_ICE

--- a/cpp/include/Ice/ProxyFunctions.h
+++ b/cpp/include/Ice/ProxyFunctions.h
@@ -23,7 +23,7 @@ namespace Ice
      * @throw MarshalException If the proxy is null.
      * */
     template<typename Prx, std::enable_if_t<std::is_base_of_v<ObjectPrx, Prx>, bool> = true>
-    void checkNotNull(std::optional<Prx> prx, const char* file, int line, const Current& current)
+    void checkNotNull(const std::optional<Prx>& prx, const char* file, int line, const Current& current)
     {
         if (!prx)
         {

--- a/cpp/include/Ice/Timer.h
+++ b/cpp/include/Ice/Timer.h
@@ -131,7 +131,7 @@ namespace IceInternal
 
         // Schedule a task for repeated execution with the given delay between each execution.
         template<class Rep, class Period>
-        void scheduleRepeated(TimerTaskPtr task, const std::chrono::duration<Rep, Period>& delay)
+        void scheduleRepeated(const TimerTaskPtr& task, const std::chrono::duration<Rep, Period>& delay)
         {
             std::lock_guard lock(_mutex);
             if (_destroyed)

--- a/cpp/src/DataStorm/Node.cpp
+++ b/cpp/src/DataStorm/Node.cpp
@@ -98,7 +98,7 @@ Node::Node(CommunicatorPtr communicator, function<void(function<void()> call)> c
 }
 
 Node::Node(
-    CommunicatorPtr communicator,
+    CommunicatorPtr communicator, // NOLINT(performance-unnecessary-value-param)
     std::function<void(std::function<void()> call)> customExecutor,
     bool ownsCommunicator)
     : _ownsCommunicator(ownsCommunicator)

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1211,7 +1211,7 @@ void
 SessionI::runWithTopics(
     const std::string& name,
     vector<shared_ptr<TopicI>>& retained,
-    function<void(const shared_ptr<TopicI>&)> callback)
+    const function<void(const shared_ptr<TopicI>&)>& callback)
 {
     auto topics = getTopics(name);
     for (const auto& topic : topics)
@@ -1229,7 +1229,7 @@ SessionI::runWithTopics(
 }
 
 void
-SessionI::runWithTopics(int64_t topicId, function<void(TopicI*, TopicSubscriber&)> callback)
+SessionI::runWithTopics(int64_t topicId, const function<void(TopicI*, TopicSubscriber&)>& callback)
 {
     auto t = _topics.find(topicId);
     if (t != _topics.end())
@@ -1249,7 +1249,7 @@ SessionI::runWithTopics(int64_t topicId, function<void(TopicI*, TopicSubscriber&
 }
 
 void
-SessionI::runWithTopic(int64_t topicId, TopicI* topic, function<void(TopicSubscriber&)> callback)
+SessionI::runWithTopic(int64_t topicId, TopicI* topic, const function<void(TopicSubscriber&)>& callback)
 {
     auto t = _topics.find(topicId);
     if (t != _topics.end())

--- a/cpp/src/DataStorm/SessionI.h
+++ b/cpp/src/DataStorm/SessionI.h
@@ -367,14 +367,14 @@ namespace DataStormI
         void runWithTopics(
             const std::string& name,
             std::vector<std::shared_ptr<TopicI>>& retained,
-            std::function<void(const std::shared_ptr<TopicI>&)> callback);
+            const std::function<void(const std::shared_ptr<TopicI>&)>& callback);
 
         /// Runs the provided callback function for each subscriber of the specified topic.
         /// The callback is executed with the topic's mutex locked.
         ///
         /// @param topicId The ID of the topic to process.
         /// @param callback The callback function to execute for each subscriber.
-        void runWithTopics(std::int64_t topicId, std::function<void(TopicI*, TopicSubscriber&)> callback);
+        void runWithTopics(std::int64_t topicId, const std::function<void(TopicI*, TopicSubscriber&)>& callback);
 
         /// Runs the provided callback function for the specified topic, if it is among the subscribers for the given
         /// topic ID.
@@ -383,7 +383,7 @@ namespace DataStormI
         /// @param topicId The ID of the topic to process.
         /// @param topic The topic to process.
         /// @param callback The callback function to execute for the subscriber.
-        void runWithTopic(std::int64_t topicId, TopicI* topic, std::function<void(TopicSubscriber&)> callback);
+        void runWithTopic(std::int64_t topicId, TopicI* topic, const std::function<void(TopicSubscriber&)>& callback);
 
         /// Returns the topics that match the specified name.
         ///

--- a/cpp/src/DataStorm/TopicFactoryI.cpp
+++ b/cpp/src/DataStorm/TopicFactoryI.cpp
@@ -191,7 +191,7 @@ TopicFactoryI::getTopicWriters(const string& name) const
 void
 TopicFactoryI::createPublisherSession(
     const string& topic,
-    DataStormContract::NodePrx publisher,
+    const DataStormContract::NodePrx& publisher,
     const ConnectionPtr& connection)
 {
     auto readers = getTopicReaders(topic);
@@ -206,7 +206,7 @@ TopicFactoryI::createPublisherSession(
 void
 TopicFactoryI::createSubscriberSession(
     const string& topic,
-    DataStormContract::NodePrx subscriber,
+    const DataStormContract::NodePrx& subscriber,
     const ConnectionPtr& connection)
 {
     auto writers = getTopicWriters(topic);

--- a/cpp/src/DataStorm/TopicFactoryI.h
+++ b/cpp/src/DataStorm/TopicFactoryI.h
@@ -42,8 +42,8 @@ namespace DataStormI
         std::vector<std::shared_ptr<TopicI>> getTopicReaders(const std::string&) const;
         std::vector<std::shared_ptr<TopicI>> getTopicWriters(const std::string&) const;
 
-        void createSubscriberSession(const std::string&, DataStormContract::NodePrx, const Ice::ConnectionPtr&);
-        void createPublisherSession(const std::string&, DataStormContract::NodePrx, const Ice::ConnectionPtr&);
+        void createSubscriberSession(const std::string&, const DataStormContract::NodePrx&, const Ice::ConnectionPtr&);
+        void createPublisherSession(const std::string&, const DataStormContract::NodePrx&, const Ice::ConnectionPtr&);
 
         [[nodiscard]] DataStormContract::TopicInfoSeq getTopicReaders() const;
         [[nodiscard]] DataStormContract::TopicInfoSeq getTopicWriters() const;

--- a/cpp/src/Glacier2/Blobject.cpp
+++ b/cpp/src/Glacier2/Blobject.cpp
@@ -35,7 +35,7 @@ Glacier2::Blobject::invoke(
     ObjectPrx& proxy,
     pair<const byte*, const byte*> inParams,
     function<void(bool, pair<const byte*, const byte*>)> response,
-    function<void(exception_ptr)> exception,
+    function<void(exception_ptr)> exception, // NOLINT(performance-unnecessary-value-param)
     const Current& current)
 {
     //
@@ -169,6 +169,7 @@ Glacier2::Blobject::invoke(
             amiSent = [amdResponse = std::move(response)](bool) { amdResponse(true, {nullptr, nullptr}); };
         }
 
+        // We can't move exception because we use it in the catch block below.
         if (_forwardContext)
         {
             if (_context.size() > 0)

--- a/cpp/src/Glacier2/Blobject.h
+++ b/cpp/src/Glacier2/Blobject.h
@@ -12,7 +12,6 @@ namespace Glacier2
     {
     public:
         Blobject(std::shared_ptr<Instance>, Ice::ConnectionPtr, Ice::Context);
-        void invokeException(std::exception_ptr, std::function<void(std::exception_ptr)>&&);
 
     protected:
         void invoke(

--- a/cpp/src/Glacier2/RoutingTable.cpp
+++ b/cpp/src/Glacier2/RoutingTable.cpp
@@ -38,7 +38,9 @@ Glacier2::RoutingTable::updateObserver(
 }
 
 ObjectProxySeq
-Glacier2::RoutingTable::add(const ObjectProxySeq& unfiltered, const Current& current)
+Glacier2::RoutingTable::add(
+    ObjectProxySeq unfiltered, // NOLINT(performance-unnecessary-value-param)
+    const Current& current)
 {
     lock_guard<mutex> lock(_mutex);
 

--- a/cpp/src/Glacier2/RoutingTable.h
+++ b/cpp/src/Glacier2/RoutingTable.h
@@ -26,7 +26,7 @@ namespace Glacier2
             const Ice::ConnectionPtr&);
 
         // Returns evicted proxies.
-        Ice::ObjectProxySeq add(const Ice::ObjectProxySeq&, const Ice::Current&);
+        Ice::ObjectProxySeq add(Ice::ObjectProxySeq, const Ice::Current&);
         std::optional<Ice::ObjectPrx> get(const Ice::Identity&); // Returns nullopt if no proxy can be found.
 
     private:

--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -127,7 +127,7 @@ namespace Glacier2
             _sessionRouter->_verifier->checkPermissionsAsync(
                 _user,
                 _password,
-                [self](bool ok, string reason) { self->checkPermissionsResponse(ok, reason); },
+                [self](bool ok, const string& reason) { self->checkPermissionsResponse(ok, reason); },
                 [self](exception_ptr e) { self->checkPermissionsException(e); },
                 nullptr,
                 ctx);
@@ -160,7 +160,7 @@ namespace Glacier2
                 ctx);
         }
 
-        void finished(const optional<SessionPrx>& session) final { _response(session); }
+        void finished(optional<SessionPrx> session) final { _response(std::move(session)); }
 
         void finished(exception_ptr ex) final { _exception(ex); }
 
@@ -260,7 +260,7 @@ namespace Glacier2
                 ctx);
         }
 
-        void finished(const optional<SessionPrx>& session) final { _response(session); }
+        void finished(optional<SessionPrx> session) final { _response(std::move(session)); }
 
         void finished(exception_ptr ex) final { _exception(ex); }
 
@@ -400,7 +400,7 @@ CreateSession::createException(exception_ptr ex)
 }
 
 void
-CreateSession::sessionCreated(const optional<SessionPrx>& session)
+CreateSession::sessionCreated(optional<SessionPrx> session)
 {
     //
     // Create the session router object.
@@ -440,7 +440,7 @@ CreateSession::sessionCreated(const optional<SessionPrx>& session)
     try
     {
         _sessionRouter->finishCreateSession(_current.con, router);
-        finished(session);
+        finished(std::move(session));
     }
     catch (const Ice::Exception&)
     {

--- a/cpp/src/Glacier2/SessionRouterI.h
+++ b/cpp/src/Glacier2/SessionRouterI.h
@@ -30,7 +30,7 @@ namespace Glacier2
         void authorized(bool);
         void unexpectedAuthorizeException(std::exception_ptr);
 
-        void sessionCreated(const std::optional<SessionPrx>&);
+        void sessionCreated(std::optional<SessionPrx>);
         void unexpectedCreateSessionException(std::exception_ptr);
 
         void exception(std::exception_ptr);
@@ -40,7 +40,7 @@ namespace Glacier2
         virtual void authorize() = 0;
         virtual void createSession() = 0;
         virtual std::shared_ptr<FilterManager> createFilterManager() = 0;
-        virtual void finished(const std::optional<SessionPrx>&) = 0;
+        virtual void finished(std::optional<SessionPrx>) = 0;
         virtual void finished(std::exception_ptr) = 0;
 
     protected:

--- a/cpp/src/Glacier2CryptPermissionsVerifier/CryptPermissionsVerifierI.cpp
+++ b/cpp/src/Glacier2CryptPermissionsVerifier/CryptPermissionsVerifierI.cpp
@@ -342,6 +342,8 @@ namespace
             CFRelease(error);
             return false;
         }
+        assert(decoder.get());
+
         data.reset(CFDataCreateWithBytesNoCopy(
             kCFAllocatorDefault,
             reinterpret_cast<const uint8_t*>(checksum.c_str()),

--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -20,7 +20,6 @@ using namespace std;
 using namespace Ice;
 using namespace IceInternal;
 
-// NOLINTBEGIN(modernize-macro-to-enum)
 //
 // WebSocket opcodes
 //
@@ -46,8 +45,6 @@ using namespace IceInternal;
 #define CLOSURE_NORMAL 1000
 #define CLOSURE_SHUTDOWN 1001
 #define CLOSURE_PROTOCOL_ERROR 1002
-
-// NOLINTEND(modernize-macro-to-enum)
 
 namespace
 {

--- a/cpp/src/IceBox/ServiceManagerI.cpp
+++ b/cpp/src/IceBox/ServiceManagerI.cpp
@@ -272,7 +272,7 @@ IceBox::ServiceManagerI::addObserver(optional<ServiceObserverPrx> observer, cons
 }
 
 void
-IceBox::ServiceManagerI::addObserver(ServiceObserverPrx observer)
+IceBox::ServiceManagerI::addObserver(ServiceObserverPrx observer) // NOLINT(performance-unnecessary-value-param)
 {
     // Duplicate registrations are ignored
 
@@ -524,7 +524,7 @@ IceBox::ServiceManagerI::start(const string& service, const string& entryPoint, 
     {
         ostringstream os;
         os << "ServiceManager: unable to load entry point '" << entryPoint << "'";
-        const string msg = library.getErrorMessage();
+        const string& msg = library.getErrorMessage();
         if (!msg.empty())
         {
             os << ": " + msg;

--- a/cpp/src/IceBridge/IceBridge.cpp
+++ b/cpp/src/IceBridge/IceBridge.cpp
@@ -195,10 +195,10 @@ BridgeConnection::outgoingSuccess(ConnectionPtr outgoing)
     //
     // Flush any queued dispatches
     //
-    for (const auto& p : _queue)
+    for (auto& dispatch : _queue)
     {
-        auto inParams = make_pair(p.inParams.data(), p.inParams.data() + p.inParams.size());
-        send(_outgoing, inParams, std::move(p.response), std::move(p.error), p.current);
+        auto inParams = make_pair(dispatch.inParams.data(), dispatch.inParams.data() + dispatch.inParams.size());
+        send(_outgoing, inParams, std::move(dispatch.response), std::move(dispatch.error), dispatch.current);
     }
     _queue.clear();
 }
@@ -316,7 +316,7 @@ BridgeConnection::send(
     const ConnectionPtr& dest,
     pair<const byte*, const byte*> inParams,
     function<void(bool, pair<const byte*, const byte*>)> response,
-    function<void(exception_ptr)> error,
+    function<void(exception_ptr)> error, // NOLINT(performance-unnecessary-value-param)
     const Current& current)
 {
     try

--- a/cpp/src/IceDB/IceDB.h
+++ b/cpp/src/IceDB/IceDB.h
@@ -261,12 +261,12 @@ namespace IceDB
     public:
         void close();
 
+        CursorBase(const CursorBase&) = delete;
+        CursorBase& operator=(const CursorBase&) = delete;
+
     protected:
         CursorBase(MDB_dbi dbi, const Txn& txn);
         ~CursorBase();
-
-        CursorBase(const CursorBase&) = delete;
-        CursorBase& operator=(const CursorBase&) = delete;
 
         bool get(MDB_val*, MDB_val*, MDB_cursor_op);
         bool find(MDB_val*);

--- a/cpp/src/IceLocatorDiscovery/PluginI.cpp
+++ b/cpp/src/IceLocatorDiscovery/PluginI.cpp
@@ -490,6 +490,7 @@ LocatorI::getLocators(const string& instanceName, const chrono::milliseconds& wa
     //
     lock_guard lock(_mutex);
     vector<Ice::LocatorPrx> locators;
+    locators.reserve(_locators.size());
     for (const auto& [_, locator] : _locators)
     {
         locators.push_back(locator);

--- a/cpp/src/IceStorm/Admin.cpp
+++ b/cpp/src/IceStorm/Admin.cpp
@@ -38,7 +38,7 @@ main(int argc, char* argv[])
         id.properties->setProperty("Ice.Warn.Endpoints", "0");
 
         Ice::CommunicatorHolder ich(argc, argv, id);
-        auto communicator = ich.communicator();
+        const auto& communicator = ich.communicator();
 
         ctrlCHandler.setCallback([communicator](int) { communicator->destroy(); });
 

--- a/cpp/src/IceStorm/IceStormDB.cpp
+++ b/cpp/src/IceStorm/IceStormDB.cpp
@@ -125,7 +125,7 @@ run(const shared_ptr<Ice::Communicator>& communicator, const Ice::StringSeq& arg
     }
 
     string mapSizeStr = opts.optArg("mapsize");
-    size_t mapSize = IceDB::getMapSize(static_cast<int>(strtol(mapSizeStr.c_str(), nullptr, 10)));
+    size_t mapSize = IceDB::getMapSize(stoi(mapSizeStr));
 
     try
     {

--- a/cpp/src/IceStorm/IceStormDB.cpp
+++ b/cpp/src/IceStorm/IceStormDB.cpp
@@ -125,7 +125,7 @@ run(const shared_ptr<Ice::Communicator>& communicator, const Ice::StringSeq& arg
     }
 
     string mapSizeStr = opts.optArg("mapsize");
-    size_t mapSize = IceDB::getMapSize(atoi(mapSizeStr.c_str()));
+    size_t mapSize = IceDB::getMapSize(static_cast<int>(strtol(mapSizeStr.c_str(), nullptr, 10)));
 
     try
     {

--- a/cpp/src/IceStorm/NodeI.cpp
+++ b/cpp/src/IceStorm/NodeI.cpp
@@ -72,7 +72,7 @@ GroupNodeInfo::operator==(const GroupNodeInfo& rhs) const
 
 namespace
 {
-    static chrono::seconds getTimeout(const shared_ptr<Instance> instance, const string& key, int def)
+    static chrono::seconds getTimeout(const shared_ptr<Instance>& instance, const string& key, int def)
     {
         auto properties = instance->communicator()->getProperties();
         auto traceLevels = instance->traceLevels();
@@ -1204,7 +1204,7 @@ NodeI::setState(NodeState s)
             Ice::Trace out(_traceLevels->logger, _traceLevels->electionCat);
             out << "node " << _id << ": transition from " << stateToString(_state) << " to " << stateToString(s);
         }
-        _state = std::move(s);
+        _state = s;
         if (_state == NodeState::NodeStateNormal)
         {
             _condVar.notify_all();

--- a/cpp/src/IceStorm/Parser.cpp
+++ b/cpp/src/IceStorm/Parser.cpp
@@ -146,7 +146,7 @@ Parser::link(const list<string>& args)
 
         auto fromTopic = findTopic(*p++);
         auto toTopic = findTopic(*p++);
-        auto cost = p != args.end() ? atoi(p->c_str()) : 0;
+        auto cost = p != args.end() ? static_cast<int32_t>(strtol(p->c_str(), nullptr, 10)) : 0;
 
         fromTopic->link(toTopic, cost);
     }
@@ -419,8 +419,8 @@ Parser::getInput(char* buf, size_t& result, size_t maxSize)
                 }
                 else
                 {
-                    strcpy(buf, line);
-                    strcat(buf, "\n");
+                    strncpy(buf, line, result - 1);
+                    strncat(buf, "\n", 1);
                     free(line);
                 }
             }
@@ -464,7 +464,7 @@ Parser::getInput(char* buf, size_t& result, size_t maxSize)
             }
             else
             {
-                strcpy(buf, line.c_str());
+                strncpy(buf, line.c_str(), result);
             }
 #if defined(__APPLE__) || defined(__linux__)
         }

--- a/cpp/src/IceStorm/Parser.cpp
+++ b/cpp/src/IceStorm/Parser.cpp
@@ -419,8 +419,10 @@ Parser::getInput(char* buf, size_t& result, size_t maxSize)
                 }
                 else
                 {
-                    strncpy(buf, line, result - 1);
-                    strncat(buf, "\n", 1);
+                    // NOLINTBEGIN(clang-analyzer-security.insecureAPI.strcpy)
+                    strcpy(buf, line);
+                    strcat(buf, "\n");
+                    // NOLINTEND(clang-analyzer-security.insecureAPI.strcpy)
                     free(line);
                 }
             }
@@ -464,7 +466,7 @@ Parser::getInput(char* buf, size_t& result, size_t maxSize)
             }
             else
             {
-                strncpy(buf, line.c_str(), result);
+                strcpy(buf, line.c_str()); // NOLINT(clang-analyzer-security.insecureAPI.strcpy)
             }
 #if defined(__APPLE__) || defined(__linux__)
         }

--- a/cpp/src/IceStorm/Parser.cpp
+++ b/cpp/src/IceStorm/Parser.cpp
@@ -146,7 +146,7 @@ Parser::link(const list<string>& args)
 
         auto fromTopic = findTopic(*p++);
         auto toTopic = findTopic(*p++);
-        auto cost = p != args.end() ? static_cast<int32_t>(strtol(p->c_str(), nullptr, 10)) : 0;
+        int32_t cost = p != args.end() ? stoi(*p) : 0;
 
         fromTopic->link(toTopic, cost);
     }

--- a/cpp/src/IceStorm/Service.cpp
+++ b/cpp/src/IceStorm/Service.cpp
@@ -248,7 +248,7 @@ ServiceI::start(const string& serviceName, const CommunicatorPtr& communicator, 
                     throw IceBox::FailureException(__FILE__, __LINE__, "IceGrid deployment is incorrect");
                 }
 
-                int nodeid = atoi(adapterId.substr(start, end - start).c_str());
+                int nodeid = static_cast<int>(strtol(adapterId.substr(start, end - start).c_str(), nullptr, 10));
                 Ice::Identity ident;
                 ident.category = instanceName;
                 ident.name = "node" + to_string(nodeid);

--- a/cpp/src/IceStorm/Service.cpp
+++ b/cpp/src/IceStorm/Service.cpp
@@ -248,7 +248,7 @@ ServiceI::start(const string& serviceName, const CommunicatorPtr& communicator, 
                     throw IceBox::FailureException(__FILE__, __LINE__, "IceGrid deployment is incorrect");
                 }
 
-                int nodeid = static_cast<int>(strtol(adapterId.substr(start, end - start).c_str(), nullptr, 10));
+                int nodeid = stoi(adapterId.substr(start, end - start));
                 Ice::Identity ident;
                 ident.category = instanceName;
                 ident.name = "node" + to_string(nodeid);

--- a/cpp/src/IceStorm/Subscriber.cpp
+++ b/cpp/src/IceStorm/Subscriber.cpp
@@ -394,7 +394,7 @@ Subscriber::create(const shared_ptr<Instance>& instance, const SubscriberRecord&
             auto p = rec.theQoS.find("retryCount");
             if (p != rec.theQoS.end())
             {
-                retryCount = static_cast<int>(strtol(p->second.c_str(), nullptr, 10));
+                retryCount = stoi(p->second);
             }
 
             string reliability;

--- a/cpp/src/IceStorm/Subscriber.cpp
+++ b/cpp/src/IceStorm/Subscriber.cpp
@@ -278,7 +278,7 @@ SubscriberTwoway::flush()
                 e.op,
                 e.mode,
                 e.data,
-                [self](bool, vector<byte>) { self->completed(); },
+                [self](bool, const vector<byte>&) { self->completed(); },
                 [self](exception_ptr ex) { self->error(true, ex); },
                 nullptr,
                 e.context);
@@ -394,7 +394,7 @@ Subscriber::create(const shared_ptr<Instance>& instance, const SubscriberRecord&
             auto p = rec.theQoS.find("retryCount");
             if (p != rec.theQoS.end())
             {
-                retryCount = atoi(p->second.c_str());
+                retryCount = static_cast<int>(strtol(p->second.c_str(), nullptr, 10));
             }
 
             string reliability;
@@ -505,7 +505,7 @@ Subscriber::record() const
 }
 
 bool
-Subscriber::queue(bool forwarded, const EventDataSeq& events)
+Subscriber::queue(bool forwarded, EventDataSeq events)
 {
     lock_guard lock(_mutex);
 
@@ -535,7 +535,7 @@ Subscriber::queue(bool forwarded, const EventDataSeq& events)
 
         case SubscriberStateOnline:
         {
-            for (const auto& event : events)
+            for (auto& event : events)
             {
                 if (static_cast<int>(_events.size()) == _instance->sendQueueSizeMax())
                 {
@@ -549,7 +549,7 @@ Subscriber::queue(bool forwarded, const EventDataSeq& events)
                         _events.pop_front();
                     }
                 }
-                _events.push_back(event);
+                _events.push_back(std::move(event));
             }
 
             if (_observer)

--- a/cpp/src/IceStorm/Subscriber.h
+++ b/cpp/src/IceStorm/Subscriber.h
@@ -35,7 +35,7 @@ namespace IceStorm
         [[nodiscard]] IceStorm::SubscriberRecord record() const;   // Get the subscriber record.
 
         // Returns false if the subscriber should be reaped.
-        bool queue(bool, const EventDataSeq&);
+        bool queue(bool, EventDataSeq);
         bool reap();
         void resetIfReaped();
         [[nodiscard]] bool errored() const;

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -73,7 +73,7 @@ namespace
         void forward(EventDataSeq v, const Ice::Current&) override
         {
             // The publish call does a cached read.
-            _impl->publish(true, std::move(v));
+            _impl->publish(true, v);
         }
 
     private:
@@ -173,7 +173,7 @@ namespace
                 else
                 {
                     FinishUpdateHelper unlock(_instance->node());
-                    _impl->unsubscribe(std::move(*subscriber));
+                    _impl->unsubscribe(*subscriber);
                 }
                 break;
             }
@@ -239,7 +239,7 @@ namespace
                 {
                     try
                     {
-                        master->unlink(std::move(topic));
+                        master->unlink(topic);
                     }
                     catch (const Ice::ConnectFailedException&)
                     {
@@ -333,7 +333,7 @@ namespace
 
 shared_ptr<TopicImpl>
 TopicImpl::create(
-    shared_ptr<PersistentInstance> instance,
+    const shared_ptr<PersistentInstance>& instance,
     const string& name,
     const Ice::Identity& id,
     const SubscriberRecordSeq& subscribers)

--- a/cpp/src/IceStorm/TopicI.h
+++ b/cpp/src/IceStorm/TopicI.h
@@ -21,7 +21,7 @@ namespace IceStorm
     {
     public:
         static std::shared_ptr<TopicImpl> create(
-            std::shared_ptr<PersistentInstance>,
+            const std::shared_ptr<PersistentInstance>&,
             const std::string&,
             const Ice::Identity&,
             const SubscriberRecordSeq&);

--- a/cpp/src/IceStorm/TopicManagerI.cpp
+++ b/cpp/src/IceStorm/TopicManagerI.cpp
@@ -68,7 +68,7 @@ namespace
         {
             // Use cached reads.
             CachedReadHelper unlock(_instance->node(), __FILE__, __LINE__);
-            return _impl->retrieve(std::move(id));
+            return _impl->retrieve(id);
         }
 
         TopicDict retrieveAll(const Ice::Current&) final
@@ -111,7 +111,7 @@ namespace
             {
                 node->checkObserverInit(llu.generation);
             }
-            _impl->observerInit(std::move(llu), std::move(content));
+            _impl->observerInit(llu, content);
         }
 
         void createTopic(LogUpdate llu, string name, const Ice::Current&) final
@@ -119,7 +119,7 @@ namespace
             try
             {
                 ObserverUpdateHelper unlock(_instance->node(), llu.generation, __FILE__, __LINE__);
-                _impl->observerCreateTopic(llu, std::move(name));
+                _impl->observerCreateTopic(llu, name);
             }
             catch (const ObserverInconsistencyException& e)
             {
@@ -135,7 +135,7 @@ namespace
             try
             {
                 ObserverUpdateHelper unlock(_instance->node(), llu.generation, __FILE__, __LINE__);
-                _impl->observerDestroyTopic(llu, std::move(name));
+                _impl->observerDestroyTopic(llu, name);
             }
             catch (const ObserverInconsistencyException& e)
             {
@@ -151,7 +151,7 @@ namespace
             try
             {
                 ObserverUpdateHelper unlock(_instance->node(), llu.generation, __FILE__, __LINE__);
-                _impl->observerAddSubscriber(llu, std::move(name), std::move(rec));
+                _impl->observerAddSubscriber(llu, name, rec);
             }
             catch (const ObserverInconsistencyException& e)
             {
@@ -167,7 +167,7 @@ namespace
             try
             {
                 ObserverUpdateHelper unlock(_instance->node(), llu.generation, __FILE__, __LINE__);
-                _impl->observerRemoveSubscriber(llu, std::move(name), std::move(id));
+                _impl->observerRemoveSubscriber(llu, name, id);
             }
             catch (const ObserverInconsistencyException& e)
             {

--- a/cpp/src/IceStorm/TopicManagerI.cpp
+++ b/cpp/src/IceStorm/TopicManagerI.cpp
@@ -273,7 +273,7 @@ TopicManagerImpl::TopicManagerImpl(shared_ptr<PersistentInstance> instance)
 }
 
 TopicPrx
-TopicManagerImpl::create(const string& name)
+TopicManagerImpl::create(string name) // NOLINT(performance-unnecessary-value-param)
 {
     lock_guard lock(_mutex);
 

--- a/cpp/src/IceStorm/TopicManagerI.h
+++ b/cpp/src/IceStorm/TopicManagerI.h
@@ -25,7 +25,7 @@ namespace IceStorm
         static std::shared_ptr<TopicManagerImpl> create(const std::shared_ptr<PersistentInstance>&);
 
         // TopicManager methods.
-        TopicPrx create(const std::string&);
+        TopicPrx create(std::string);
         TopicPrx retrieve(const std::string&);
         TopicDict retrieveAll();
 

--- a/cpp/src/IceStorm/TransientTopicI.cpp
+++ b/cpp/src/IceStorm/TransientTopicI.cpp
@@ -52,7 +52,7 @@ namespace
     public:
         TransientTopicLinkI(shared_ptr<TransientTopicImpl> impl) : _impl(std::move(impl)) {}
 
-        void forward(EventDataSeq v, const Ice::Current&) override { _impl->publish(true, std::move(v)); }
+        void forward(EventDataSeq v, const Ice::Current&) override { _impl->publish(true, v); }
 
     private:
         const shared_ptr<TransientTopicImpl> _impl;

--- a/cpp/src/IceStorm/Util.cpp
+++ b/cpp/src/IceStorm/Util.cpp
@@ -83,7 +83,9 @@ IceStormElection::LogUpdate
 IceStormInternal::getIncrementedLLU(const IceDB::ReadWriteTxn& txn, LLUMap& lluMap)
 {
     IceStormElection::LogUpdate llu;
-    lluMap.get(txn, lluDbKey, llu);
+    [[maybe_unused]] bool ok = lluMap.get(txn, lluDbKey, llu);
+    assert(ok);
+
     llu.iteration++;
     lluMap.put(txn, lluDbKey, llu);
     return llu;

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -700,6 +700,10 @@ Slice::Gen::generate(const UnitPtr& p)
     printHeader(C);
     printGeneratedHeader(C, _base + ".ice");
 
+    // Reformatting moves NOLINT comments which is undesirable.
+    H << "\n";
+    H << "// clang-format off\n";
+
     string s = _base + "." + _headerExtension;
     if (_include.size())
     {


### PR DESCRIPTION
This PR fixes clang-tidy lints in Glacier2, IceBox, IceBridge, IceStorm and DataStorm.