### PR TITLE
Fix weak vtables warnings

### DIFF
--- a/config/Make.rules.Darwin
+++ b/config/Make.rules.Darwin
@@ -48,10 +48,9 @@ cppflags        = -fvisibility=hidden -Wall -Wextra -Wshadow -Wshadow-all -Wredu
                   $(if $(filter yes,$(OPTIMIZE)),-O2 -DNDEBUG,-g) \
                   -std=c++20
 
-# TODO review this setting
-ifeq ($(MAXWARN),yes)
-    cppflags	+=  -Wweak-vtables
-endif
+# When we export an API from a shared library, we check for weak vtables. This flag also works for static
+# libraries/exes, but is not necessary.
+api_exports_cppflags = -Wweak-vtables
 
 # We compile static and shared with the same flags so we want their .o to share directories.
 static_objdir   = obj

--- a/cpp/include/DataStorm/InternalI.h
+++ b/cpp/include/DataStorm/InternalI.h
@@ -14,6 +14,7 @@
 #if defined(__clang__)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
+#    pragma clang diagnostic ignored "-Wweak-vtables"
 #elif defined(__GNUC__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wshadow"

--- a/cpp/include/Ice/BatchRequest.h
+++ b/cpp/include/Ice/BatchRequest.h
@@ -3,6 +3,8 @@
 #ifndef ICE_BATCH_REQUEST_H
 #define ICE_BATCH_REQUEST_H
 
+#include "Config.h"
+
 #include <string_view>
 
 namespace Ice
@@ -13,10 +15,10 @@ namespace Ice
      * Represents an invocation on a proxy configured for batch-oneway or batch-datagram.
      * \headerfile Ice/Ice.h
      */
-    class BatchRequest
+    class ICE_API BatchRequest
     {
     public:
-        virtual ~BatchRequest() = default;
+        virtual ~BatchRequest();
 
         /**
          * Queues the request for an eventual flush.

--- a/cpp/include/Ice/Connection.h
+++ b/cpp/include/Ice/Connection.h
@@ -63,7 +63,7 @@ namespace Ice
     class ICE_API Connection
     {
     public:
-        virtual ~Connection() = 0;
+        virtual ~Connection();
 
         /**
          * Aborts this connection.
@@ -264,6 +264,8 @@ namespace Ice
     public:
         IPConnectionInfo(const IPConnectionInfo&) = delete;
         IPConnectionInfo& operator=(const IPConnectionInfo&) = delete;
+
+        ~IPConnectionInfo() override;
 
         /**
          * The local address.

--- a/cpp/include/Ice/Endpoint.h
+++ b/cpp/include/Ice/Endpoint.h
@@ -112,6 +112,8 @@ namespace Ice
         IPEndpointInfo(const IPEndpointInfo&) = delete;
         IPEndpointInfo& operator=(const IPEndpointInfo&) = delete;
 
+        ~IPEndpointInfo() override;
+
         /**
          * The host or address configured with the endpoint.
          */

--- a/cpp/include/Ice/Instrumentation.h
+++ b/cpp/include/Ice/Instrumentation.h
@@ -12,6 +12,11 @@
 #include <memory>
 #include <optional>
 
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
+
 namespace Ice
 {
     struct Current;
@@ -371,5 +376,9 @@ namespace Ice::Instrumentation
         virtual void setObserverUpdater(const ObserverUpdaterPtr& updater) = 0;
     };
 }
+
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#endif
 
 #endif

--- a/cpp/include/Ice/Logger.h
+++ b/cpp/include/Ice/Logger.h
@@ -3,6 +3,8 @@
 #ifndef ICE_LOGGER_H
 #define ICE_LOGGER_H
 
+#include "Config.h"
+
 #include <memory>
 #include <string>
 
@@ -15,10 +17,10 @@ namespace Ice
      * The Ice message logger. Applications can provide their own logger by implementing this interface and installing
      * it in a communicator. \headerfile Ice/Ice.h
      */
-    class Logger
+    class ICE_API Logger
     {
     public:
-        virtual ~Logger() = default;
+        virtual ~Logger();
 
         // We use const std::string& and not std::string_view for the log messages because implementations commonly
         // send the message to C APIs that require null-terminated strings.

--- a/cpp/include/Ice/MarshaledResult.h
+++ b/cpp/include/Ice/MarshaledResult.h
@@ -20,7 +20,7 @@ namespace Ice
         MarshaledResult(const MarshaledResult&) = delete;
         MarshaledResult(MarshaledResult&&) = default;
 
-        virtual ~MarshaledResult() = default;
+        virtual ~MarshaledResult();
 
         MarshaledResult& operator=(const MarshaledResult&) = delete;
         MarshaledResult& operator=(MarshaledResult&&) = default;

--- a/cpp/include/Ice/MetricsObserverI.h
+++ b/cpp/include/Ice/MetricsObserverI.h
@@ -14,6 +14,11 @@
 #include <sstream>
 #include <stdexcept>
 
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
+
 namespace IceInternal
 {
     class StopWatch
@@ -576,5 +581,9 @@ namespace IceMX
     using ObserverI = ObserverT<Metrics>;
     /// \endcond
 }
+
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#endif
 
 #endif

--- a/cpp/include/Ice/NativePropertiesAdmin.h
+++ b/cpp/include/Ice/NativePropertiesAdmin.h
@@ -19,7 +19,7 @@ namespace Ice
     class ICE_API NativePropertiesAdmin
     {
     public:
-        virtual ~NativePropertiesAdmin() = 0;
+        virtual ~NativePropertiesAdmin();
 
         /**
          * Register an update callback that will be invoked when property updates occur.

--- a/cpp/include/Ice/ObjectAdapter.h
+++ b/cpp/include/Ice/ObjectAdapter.h
@@ -26,10 +26,10 @@ namespace Ice
      * @see ServantLocator
      * \headerfile Ice/Ice.h
      */
-    class ObjectAdapter
+    class ICE_API ObjectAdapter
     {
     public:
-        virtual ~ObjectAdapter() = default;
+        virtual ~ObjectAdapter();
 
         /**
          * Get the name of this object adapter.

--- a/cpp/include/Ice/OutgoingAsync.h
+++ b/cpp/include/Ice/OutgoingAsync.h
@@ -23,6 +23,7 @@
 #    pragma clang diagnostic push
 // See #2747
 #    pragma clang diagnostic ignored "-Wshadow-uncaptured-local"
+#    pragma clang diagnostic ignored "-Wweak-vtables"
 #endif
 
 namespace IceInternal

--- a/cpp/include/Ice/Plugin.h
+++ b/cpp/include/Ice/Plugin.h
@@ -15,10 +15,10 @@ namespace Ice
      * invokes {@link Plugin#initialize} on each one.
      * \headerfile Ice/Ice.h
      */
-    class Plugin
+    class ICE_API Plugin
     {
     public:
-        virtual ~Plugin() = default;
+        virtual ~Plugin();
 
         /**
          * Perform any necessary initialization steps.
@@ -36,10 +36,10 @@ namespace Ice
      * Each communicator has a plug-in manager to administer the set of plug-ins.
      * \headerfile Ice/Ice.h
      */
-    class PluginManager
+    class ICE_API PluginManager
     {
     public:
-        virtual ~PluginManager() = default;
+        virtual ~PluginManager();
 
         /**
          * Initialize the configured plug-ins. The communicator automatically initializes the plug-ins by default, but

--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -301,7 +301,7 @@ namespace Ice
 
         ObjectPrx(const Ice::CommunicatorPtr& communicator, std::string_view proxyString);
 
-        virtual ~ObjectPrx() = default;
+        virtual ~ObjectPrx();
 
         ObjectPrx& operator=(const ObjectPrx& rhs) noexcept = default;
         ObjectPrx& operator=(ObjectPrx&& rhs) noexcept = default;

--- a/cpp/include/Ice/ServantLocator.h
+++ b/cpp/include/Ice/ServantLocator.h
@@ -15,10 +15,10 @@ namespace Ice
      * @see ObjectAdapter#findServantLocator
      * \headerfile Ice/Ice.h
      */
-    class ServantLocator
+    class ICE_API ServantLocator
     {
     public:
-        virtual ~ServantLocator() = default;
+        virtual ~ServantLocator();
 
         /**
          * Called before a request is dispatched if a servant cannot be found in the object adapter's active servant

--- a/cpp/include/Ice/Timer.h
+++ b/cpp/include/Ice/Timer.h
@@ -30,6 +30,11 @@ namespace IceInternal
     };
     using TimerTaskPtr = std::shared_ptr<TimerTask>;
 
+#ifdef __clang__
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
+
     // Adapts a function<void()> to a TimerTask.
     class InlineTimerTask final : public TimerTask
     {
@@ -41,6 +46,10 @@ namespace IceInternal
     private:
         std::function<void()> _function;
     };
+
+#ifdef __clang__
+#    pragma clang diagnostic pop
+#endif
 
     // The timer class is used to schedule tasks for one-time execution or repeated execution. Tasks are executed by a
     // dedicated timer thread sequentially.

--- a/cpp/include/Ice/ValueFactory.h
+++ b/cpp/include/Ice/ValueFactory.h
@@ -32,7 +32,7 @@ namespace Ice
     class ICE_API ValueFactoryManager
     {
     public:
-        virtual ~ValueFactoryManager() = 0;
+        virtual ~ValueFactoryManager();
 
         /**
          * Adds a value factory. Attempting to add a factory with a type ID for which a factory is already registered

--- a/cpp/include/IceBox/Service.h
+++ b/cpp/include/IceBox/Service.h
@@ -32,10 +32,10 @@ namespace IceBox
      * An application service managed by a {@link ServiceManager}.
      * \headerfile IceBox/IceBox.h
      */
-    class Service
+    class ICEBOX_API Service
     {
     public:
-        virtual ~Service() = default;
+        virtual ~Service();
 
         /**
          * Start the service. The given communicator is created by the {@link ServiceManager} for use by the service.

--- a/cpp/src/DataStorm/Makefile.mk
+++ b/cpp/src/DataStorm/Makefile.mk
@@ -6,7 +6,7 @@ $(project)_generated_includedir := $(project)/generated/DataStorm
 
 DataStorm_sliceflags    := --include-dir DataStorm
 DataStorm_targetdir     := $(libdir)
-DataStorm_cppflags      := -DDATASTORM_API_EXPORTS
+DataStorm_cppflags      := -DDATASTORM_API_EXPORTS $(api_exports_cppflags)
 DataStorm_dependencies  := Ice
 
 projects += $(project)

--- a/cpp/src/Glacier2CryptPermissionsVerifier/Makefile.mk
+++ b/cpp/src/Glacier2CryptPermissionsVerifier/Makefile.mk
@@ -4,7 +4,7 @@ $(project)_libraries                            += Glacier2CryptPermissionsVerif
 
 Glacier2CryptPermissionsVerifier_targetdir        := $(libdir)
 Glacier2CryptPermissionsVerifier_dependencies     := Glacier2 Ice
-Glacier2CryptPermissionsVerifier_cppflags         := -DCRYPT_PERMISSIONS_VERIFIER_API_EXPORTS
+Glacier2CryptPermissionsVerifier_cppflags         := -DCRYPT_PERMISSIONS_VERIFIER_API_EXPORTS $(api_exports_cppflags)
 Glacier2CryptPermissionsVerifier_devinstall       := no
 
 projects += $(project)

--- a/cpp/src/Glacier2Lib/Makefile.mk
+++ b/cpp/src/Glacier2Lib/Makefile.mk
@@ -4,7 +4,7 @@ $(project)_libraries    := Glacier2
 
 Glacier2_targetdir              := $(libdir)
 Glacier2_dependencies           := Ice
-Glacier2_cppflags               := -DGLACIER2_API_EXPORTS
+Glacier2_cppflags               := $(api_exports_cppflags)
 Glacier2_sliceflags             := --include-dir Glacier2
 
 projects += $(project)

--- a/cpp/src/Ice/Acceptor.h
+++ b/cpp/src/Ice/Acceptor.h
@@ -8,6 +8,11 @@
 #include "Network.h"
 #include "TransceiverF.h"
 
+#ifdef __clang__
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
+
 namespace IceInternal
 {
     class Acceptor
@@ -28,5 +33,9 @@ namespace IceInternal
         [[nodiscard]] virtual std::string toDetailedString() const = 0;
     };
 }
+
+#ifdef __clang__
+#    pragma clang diagnostic pop
+#endif
 
 #endif

--- a/cpp/src/Ice/BatchRequestQueue.cpp
+++ b/cpp/src/Ice/BatchRequestQueue.cpp
@@ -41,6 +41,8 @@ namespace
     };
 }
 
+BatchRequest::~BatchRequest() = default; // avoid weak vtable
+
 BatchRequestQueue::BatchRequestQueue(const InstancePtr& instance, bool datagram)
     : _interceptor(instance->initializationData().batchRequestInterceptor),
       _batchStream(instance.get(), Ice::currentProtocolEncoding),

--- a/cpp/src/Ice/Connection.cpp
+++ b/cpp/src/Ice/Connection.cpp
@@ -7,12 +7,13 @@ using namespace std;
 
 // Implement virtual destructors out of line to avoid weak vtables.
 Ice::ConnectionInfo::~ConnectionInfo() = default;
+Ice::IPConnectionInfo::~IPConnectionInfo() = default;
 Ice::TCPConnectionInfo::~TCPConnectionInfo() = default;
 Ice::UDPConnectionInfo::~UDPConnectionInfo() = default;
 Ice::WSConnectionInfo::~WSConnectionInfo() = default;
 Ice::IAPConnectionInfo::~IAPConnectionInfo() = default;
 
-Ice::Connection::~Connection() = default;
+Ice::Connection::~Connection() = default; // avoid weak vtable
 
 void
 Ice::Connection::flushBatchRequests(CompressBatch compress)

--- a/cpp/src/Ice/Connector.h
+++ b/cpp/src/Ice/Connector.h
@@ -9,6 +9,11 @@
 #include <cstdint>
 #include <string>
 
+#ifdef __clang__
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
+
 namespace IceInternal
 {
     class Connector
@@ -25,5 +30,9 @@ namespace IceInternal
         virtual bool operator<(const Connector&) const = 0;
     };
 }
+
+#ifdef __clang__
+#    pragma clang diagnostic pop
+#endif
 
 #endif

--- a/cpp/src/Ice/EndpointI.cpp
+++ b/cpp/src/Ice/EndpointI.cpp
@@ -29,14 +29,11 @@ Ice::EndpointInfo::secure() const noexcept
     return underlying ? underlying->secure() : false;
 }
 
+Ice::IPEndpointInfo::~IPEndpointInfo() = default;
 Ice::TCPEndpointInfo::~TCPEndpointInfo() = default;
-
 Ice::UDPEndpointInfo::~UDPEndpointInfo() = default;
-
 Ice::WSEndpointInfo::~WSEndpointInfo() = default;
-
 Ice::IAPEndpointInfo::~IAPEndpointInfo() = default;
-
 Ice::OpaqueEndpointInfo::~OpaqueEndpointInfo() = default;
 
 void

--- a/cpp/src/Ice/LocatorInfo.cpp
+++ b/cpp/src/Ice/LocatorInfo.cpp
@@ -396,6 +396,8 @@ IceInternal::LocatorInfo::Request::addCallback(
     }
 }
 
+IceInternal::LocatorInfo::GetEndpointsCallback::~GetEndpointsCallback() = default; // avoid weak vtable
+
 IceInternal::LocatorInfo::Request::Request(LocatorInfoPtr locatorInfo, ReferencePtr ref)
     : _locatorInfo(std::move(locatorInfo)),
       _reference(std::move(ref)),
@@ -403,6 +405,8 @@ IceInternal::LocatorInfo::Request::Request(LocatorInfoPtr locatorInfo, Reference
       _response(false)
 {
 }
+
+IceInternal::LocatorInfo::Request::~Request() = default; // avoid weak vtable
 
 void
 IceInternal::LocatorInfo::Request::response(const optional<ObjectPrx>& proxy)

--- a/cpp/src/Ice/LocatorInfo.h
+++ b/cpp/src/Ice/LocatorInfo.h
@@ -69,6 +69,7 @@ namespace IceInternal
         class GetEndpointsCallback
         {
         public:
+            virtual ~GetEndpointsCallback();
             virtual void setEndpoints(const std::vector<EndpointIPtr>&, bool) = 0;
             virtual void setException(std::exception_ptr) = 0;
         };
@@ -103,6 +104,7 @@ namespace IceInternal
 
         protected:
             Request(LocatorInfoPtr, ReferencePtr);
+            virtual ~Request();
 
             virtual void send() = 0;
 

--- a/cpp/src/Ice/LoggerAdminI.cpp
+++ b/cpp/src/Ice/LoggerAdminI.cpp
@@ -750,12 +750,10 @@ namespace
     }
 }
 
-//
-// createLoggerAdminLogger
-//
-
 namespace IceInternal
 {
+    LoggerAdminLogger::~LoggerAdminLogger() = default; // avoid weak vtable
+
     LoggerAdminLoggerPtr createLoggerAdminLogger(const PropertiesPtr& props, const LoggerPtr& localLogger)
     {
         return make_shared<LoggerAdminLoggerI>(props, localLogger);

--- a/cpp/src/Ice/LoggerAdminI.h
+++ b/cpp/src/Ice/LoggerAdminI.h
@@ -17,6 +17,8 @@ namespace IceInternal
     class LoggerAdminLogger : public Ice::Logger
     {
     public:
+        virtual ~LoggerAdminLogger();
+
         //
         // Return the associated Admin facet
         //

--- a/cpp/src/Ice/LoggerI.cpp
+++ b/cpp/src/Ice/LoggerI.cpp
@@ -23,6 +23,8 @@ namespace
     const chrono::minutes retryTimeout = chrono::minutes(5); // NOLINT(cert-err58-cpp)
 }
 
+Ice::Logger::~Logger() = default; // avoid weak vtable
+
 Ice::LoggerI::LoggerI(string prefix, string file, bool convert, size_t sizeMax)
     : _prefix(std::move(prefix)),
       _convert(convert),

--- a/cpp/src/Ice/Makefile.mk
+++ b/cpp/src/Ice/Makefile.mk
@@ -3,7 +3,7 @@
 $(project)_libraries    = Ice
 
 Ice_targetdir           := $(libdir)
-Ice_cppflags            = -DICE_API_EXPORTS $(IceUtil_cppflags)
+Ice_cppflags            = -DICE_API_EXPORTS $(api_exports_cppflags) $(IceUtil_cppflags)
 
 Ice_sliceflags          := --include-dir Ice
 Ice_libs                := bz2

--- a/cpp/src/Ice/MarshaledResult.cpp
+++ b/cpp/src/Ice/MarshaledResult.cpp
@@ -16,3 +16,5 @@ MarshaledResult::MarshaledResult(const Current& current)
     _ostr.write(current.requestId);
     _ostr.write(replyOK);
 }
+
+MarshaledResult::~MarshaledResult() = default; // avoid weak vtable

--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -47,6 +47,8 @@ namespace
     inline EndpointIPtr toEndpointI(const EndpointPtr& endp) { return dynamic_pointer_cast<EndpointI>(endp); }
 }
 
+Ice::ObjectAdapter::~ObjectAdapter() = default; // avoid weak vtable
+
 string
 Ice::ObjectAdapterI::getName() const noexcept
 {

--- a/cpp/src/Ice/PluginManagerI.cpp
+++ b/cpp/src/Ice/PluginManagerI.cpp
@@ -15,6 +15,9 @@ using namespace IceInternal;
 
 const char* const Ice::PluginManagerI::_kindOfObject = "plugin";
 
+Ice::Plugin::~Plugin() = default;               // avoid weak vtable
+Ice::PluginManager::~PluginManager() = default; // avoid weak vtable
+
 namespace
 {
     map<string, PluginFactory>* factories = nullptr;

--- a/cpp/src/Ice/Proxy.cpp
+++ b/cpp/src/Ice/Proxy.cpp
@@ -53,6 +53,8 @@ Ice::ObjectPrx::ObjectPrx(ReferencePtr&& ref)
 {
 }
 
+Ice::ObjectPrx::~ObjectPrx() = default; // avoid weak vtable
+
 void
 Ice::ObjectPrx::_checkTwowayOnly(string_view name) const
 {

--- a/cpp/src/Ice/ProxyAsync.cpp
+++ b/cpp/src/Ice/ProxyAsync.cpp
@@ -15,6 +15,10 @@ using namespace std;
 using namespace Ice;
 using namespace IceInternal;
 
+#if defined(__clang__)
+#    pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
+
 namespace IceInternal
 {
     inline std::pair<const byte*, const byte*> makePair(const Ice::ByteSeq& seq)

--- a/cpp/src/Ice/RequestHandler.cpp
+++ b/cpp/src/Ice/RequestHandler.cpp
@@ -17,8 +17,12 @@ RetryException::get() const
     return _ex;
 }
 
+CancellationHandler::~CancellationHandler() = default; // avoid weak vtable
+
 RequestHandler::RequestHandler(const ReferencePtr& reference)
     : _reference(reference),
       _response(reference->getMode() == Reference::ModeTwoway)
 {
 }
+
+RequestHandler::~RequestHandler() = default; // avoid weak vtable

--- a/cpp/src/Ice/RequestHandler.h
+++ b/cpp/src/Ice/RequestHandler.h
@@ -29,6 +29,8 @@ namespace IceInternal
     class CancellationHandler
     {
     public:
+        virtual ~CancellationHandler();
+
         virtual void asyncRequestCanceled(const OutgoingAsyncBasePtr&, std::exception_ptr) = 0;
     };
 
@@ -36,6 +38,7 @@ namespace IceInternal
     {
     public:
         RequestHandler(const ReferencePtr&);
+        ~RequestHandler() override;
 
         virtual AsyncStatus sendAsyncRequest(const ProxyOutgoingAsyncBasePtr&) = 0;
 

--- a/cpp/src/Ice/SSL/SSLInstance.cpp
+++ b/cpp/src/Ice/SSL/SSLInstance.cpp
@@ -13,6 +13,8 @@ Ice::SSL::Instance::Instance(const SSLEnginePtr& engine, int16_t type, const str
 {
 }
 
+Ice::SSL::Instance::~Instance() = default; // avoid weak vtable
+
 SSLEnginePtr
 Ice::SSL::Instance::engine() const
 {

--- a/cpp/src/Ice/SSL/SSLInstance.h
+++ b/cpp/src/Ice/SSL/SSLInstance.h
@@ -13,6 +13,7 @@ namespace Ice::SSL
     {
     public:
         Instance(const SSLEnginePtr&, std::int16_t, const std::string&);
+        ~Instance() final;
 
         [[nodiscard]] SSLEnginePtr engine() const;
 

--- a/cpp/src/Ice/ServantManager.cpp
+++ b/cpp/src/Ice/ServantManager.cpp
@@ -12,6 +12,8 @@ using namespace std;
 using namespace Ice;
 using namespace IceInternal;
 
+Ice::ServantLocator::~ServantLocator() = default; // avoid weak vtable
+
 void
 IceInternal::ServantManager::addServant(ObjectPtr object, Identity ident, string facet)
 {

--- a/cpp/src/IceBT/Makefile.mk
+++ b/cpp/src/IceBT/Makefile.mk
@@ -8,7 +8,7 @@ $(project)_libraries    := IceBT
 
 IceBT_targetdir         := $(libdir)
 IceBT_dependencies      := Ice
-IceBT_cppflags          := -DICEBT_API_EXPORTS $(shell pkg-config --cflags dbus-1)
+IceBT_cppflags          := -DICEBT_API_EXPORTS $(api_exports_cppflags) $(shell pkg-config --cflags dbus-1)
 
 projects += $(project)
 endif

--- a/cpp/src/IceBox/Makefile.mk
+++ b/cpp/src/IceBox/Makefile.mk
@@ -4,6 +4,7 @@ $(project)_libraries    := IceBox
 $(project)_programs     := icebox iceboxadmin
 $(project)_dependencies := Ice
 $(project)_sliceflags   := --include-dir IceBox
+$(project)_cppflags     := $(api_exports_cppflags)
 
 IceBox_targetdir        := $(libdir)
 IceBox_sources          := $(slicedir)/IceBox/ServiceManager.ice $(currentdir)/Service.cpp

--- a/cpp/src/IceBox/Service.cpp
+++ b/cpp/src/IceBox/Service.cpp
@@ -9,3 +9,5 @@ IceBox::FailureException::ice_id() const noexcept
 {
     return "::IceBox::FailureException";
 }
+
+IceBox::Service::~Service() = default; // avoid weak vtable

--- a/cpp/src/IceDB/Makefile.mk
+++ b/cpp/src/IceDB/Makefile.mk
@@ -5,7 +5,7 @@ $(project)_libraries    = IceDB
 IceDB_targetdir         := $(libdir)
 IceDB_dependencies      := Ice
 IceDB_libs              := lmdb
-IceDB_cppflags          := -DICE_DB_API_EXPORTS
+IceDB_cppflags          := -DICE_DB_API_EXPORTS $(api_exports_cppflags)
 IceDB_devinstall        := no
 
 projects += $(project)

--- a/cpp/src/IceDiscovery/Makefile.mk
+++ b/cpp/src/IceDiscovery/Makefile.mk
@@ -4,6 +4,6 @@ $(project)_libraries := IceDiscovery
 
 IceDiscovery_targetdir                  := $(libdir)
 IceDiscovery_dependencies               := Ice
-IceDiscovery_cppflags                   := -DICE_DISCOVERY_API_EXPORTS
+IceDiscovery_cppflags                   := -DICE_DISCOVERY_API_EXPORTS $(api_exports_cppflags)
 
 projects += $(project)

--- a/cpp/src/IceGrid/Makefile.mk
+++ b/cpp/src/IceGrid/Makefile.mk
@@ -64,7 +64,7 @@ $(project)_programs             = icegridnode icegridregistry icegridadmin
 $(project)_dependencies         := IceGrid Glacier2 Ice
 $(project)_targetdir            := $(bindir)
 
-# This is not necessary for the icegridadmin sources. However, we want to build all objects with the same flags to
+# lmdb is not necessary for the icegridadmin sources. However, we want to build all objects with the same flags to
 # reuse common object files in the different programs.
 $(project)_cppflags             := $(if $(lmdb_includedir),-I$(lmdb_includedir))
 

--- a/cpp/src/IceGridLib/Makefile.mk
+++ b/cpp/src/IceGridLib/Makefile.mk
@@ -5,5 +5,6 @@ $(project)_libraries    := IceGrid
 IceGrid_targetdir       := $(libdir)
 IceGrid_dependencies    := Glacier2 Ice
 IceGrid_sliceflags      := --include-dir IceGrid
+IceGrid_cppflags        := -DICEGRID_API_EXPORTS $(api_exports_cppflags)
 
 projects += $(project)

--- a/cpp/src/IceGridLib/PluginFacadeI.cpp
+++ b/cpp/src/IceGridLib/PluginFacadeI.cpp
@@ -16,8 +16,7 @@ namespace
 namespace IceGrid
 {
     ICEGRID_API void setRegistryPluginFacade(const RegistryPluginFacadePtr&);
-
-};
+}
 
 RegistryPluginFacadePtr
 IceGrid::getRegistryPluginFacade()

--- a/cpp/src/IceLocatorDiscovery/Makefile.mk
+++ b/cpp/src/IceLocatorDiscovery/Makefile.mk
@@ -4,6 +4,6 @@ $(project)_libraries := IceLocatorDiscovery
 
 IceLocatorDiscovery_targetdir                   := $(libdir)
 IceLocatorDiscovery_dependencies                := Ice
-IceLocatorDiscovery_cppflags                    := -DICE_LOCATOR_DISCOVERY_API_EXPORTS
+IceLocatorDiscovery_cppflags                    := -DICE_LOCATOR_DISCOVERY_API_EXPORTS $(api_exports_cppflags)
 
 projects += $(project)

--- a/cpp/src/IceLocatorDiscovery/Plugin.h
+++ b/cpp/src/IceLocatorDiscovery/Plugin.h
@@ -31,6 +31,8 @@ namespace IceLocatorDiscovery
     class ICE_LOCATOR_DISCOVERY_API Plugin : public Ice::Plugin
     {
     public:
+        ~Plugin() override;
+
         [[nodiscard]] virtual std::vector<Ice::LocatorPrx>
         getLocators(const std::string&, const std::chrono::milliseconds&) const = 0;
     };

--- a/cpp/src/IceLocatorDiscovery/PluginI.cpp
+++ b/cpp/src/IceLocatorDiscovery/PluginI.cpp
@@ -180,6 +180,8 @@ namespace Ice
     }
 }
 
+Plugin::~Plugin() = default;
+
 PluginI::PluginI(Ice::CommunicatorPtr communicator) : _communicator(std::move(communicator)) {}
 
 void

--- a/cpp/src/IceStorm/Instrumentation.h
+++ b/cpp/src/IceStorm/Instrumentation.h
@@ -6,6 +6,11 @@
 #include "Ice/Ice.h"
 #include "IceStorm/IceStorm.h"
 
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
+
 namespace IceStorm::Instrumentation
 {
     enum class SubscriberState : std::uint8_t
@@ -134,5 +139,9 @@ namespace IceStorm::Instrumentation
     using ObserverUpdaterPtr = std::shared_ptr<ObserverUpdater>;
     using TopicManagerObserverPtr = std::shared_ptr<TopicManagerObserver>;
 }
+
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#endif
 
 #endif

--- a/cpp/src/IceStorm/Makefile.mk
+++ b/cpp/src/IceStorm/Makefile.mk
@@ -4,9 +4,13 @@ $(project)_libraries            := IceStormService
 $(project)_programs             := icestormadmin icestormdb
 $(project)_dependencies         := IceStorm Ice Glacier2
 
+# lmdb is not necessary for the icestormadmin sources. However, we want to build all objects with the same flags to
+# reuse common object files in the different programs.
+# we also include api_exports_cppflags because we "export" IceStormService to IceGrid.
+$(project)_cppflags             := $(if $(lmdb_includedir),-I$(lmdb_includedir)) $(api_exports_cppflags)
+
 IceStormService_targetdir       := $(libdir)
 IceStormService_dependencies    := IceGrid IceBox IceDB
-IceStormService_cppflags        := $(if $(lmdb_includedir),-I$(lmdb_includedir))
 IceStormService_devinstall      := no
 IceStormService_sources         := $(addprefix $(currentdir)/,Instance.cpp \
                                                              InstrumentationI.cpp \
@@ -39,7 +43,6 @@ icestormadmin_sources           := $(addprefix $(currentdir)/,Admin.cpp \
 
 icestormdb_targetdir            := $(bindir)
 icestormdb_dependencies         := IceDB
-icestormdb_cppflags             := $(if $(lmdb_includedir),-I$(lmdb_includedir))
 icestormdb_sources              := $(addprefix $(currentdir)/,IceStormDB.cpp SubscriberRecord.ice DBTypes.ice LLURecord.ice)
 
 projects += $(project)

--- a/cpp/src/IceStorm/Replica.h
+++ b/cpp/src/IceStorm/Replica.h
@@ -8,6 +8,11 @@
 
 #include <set>
 
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
+
 namespace IceStormElection
 {
     struct GroupNodeInfo
@@ -34,4 +39,8 @@ namespace IceStormElection
     };
 }
 
-#endif // RELICA_H
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#endif
+
+#endif

--- a/cpp/src/IceStorm/Service.cpp
+++ b/cpp/src/IceStorm/Service.cpp
@@ -72,6 +72,8 @@ extern "C"
     ICESTORM_SERVICE_API ::IceBox::Service* createIceStorm(const CommunicatorPtr&) { return new ServiceI; }
 }
 
+IceStormInternal::Service::~Service() = default;
+
 shared_ptr<IceStormInternal::Service>
 IceStormInternal::Service::create(
     const CommunicatorPtr& communicator,

--- a/cpp/src/IceStorm/Service.h
+++ b/cpp/src/IceStorm/Service.h
@@ -22,17 +22,19 @@
 // This API is internal to Ice, and should not be used by external applications.
 namespace IceStormInternal
 {
-    class Service : public IceBox::Service
+    class ICESTORM_SERVICE_API Service : public IceBox::Service
     {
     public:
-        ICESTORM_SERVICE_API static std::shared_ptr<Service> create(
+        ~Service() override;
+
+        static std::shared_ptr<Service> create(
             const Ice::CommunicatorPtr&,
             const Ice::ObjectAdapterPtr&,
             const Ice::ObjectAdapterPtr&,
             const std::string&,
             const Ice::Identity&);
 
-        [[nodiscard]] ICESTORM_SERVICE_API virtual IceStorm::TopicManagerPrx getTopicManager() const = 0;
+        [[nodiscard]] virtual IceStorm::TopicManagerPrx getTopicManager() const = 0;
     };
 }
 

--- a/cpp/src/IceStorm/Subscriber.h
+++ b/cpp/src/IceStorm/Subscriber.h
@@ -10,6 +10,11 @@
 
 #include <condition_variable>
 
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
+
 namespace IceStorm
 {
     class Instance;
@@ -96,5 +101,9 @@ namespace IceStorm
     bool operator!=(const IceStorm::Subscriber&, const IceStorm::Subscriber&);
     bool operator<(const IceStorm::Subscriber&, const IceStorm::Subscriber&);
 }
+
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#endif
 
 #endif // SUBSCRIBER_H

--- a/cpp/src/IceStormLib/Makefile.mk
+++ b/cpp/src/IceStormLib/Makefile.mk
@@ -5,5 +5,6 @@ $(project)_libraries    := IceStorm
 IceStorm_targetdir      := $(libdir)
 IceStorm_dependencies   := Ice
 IceStorm_sliceflags     := --include-dir IceStorm
+IceStorm_cppflags       := $(api_exports_cppflags)
 
 projects += $(project)

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1463,6 +1463,12 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     H << sp;
     H << nl << prx << "(const ::Ice::CommunicatorPtr& communicator, std::string_view proxyString)";
     H << " : ::Ice::ObjectPrx(communicator, proxyString) {} // NOLINT(modernize-use-equals-default)";
+
+    H << sp;
+    H << nl << "~" << prx << "() override;";
+    C << sp;
+    C << nl << scopedPrx.substr(2) << "::~" << prx << "() = default;"; // avoid weak table
+
     H << sp;
     H << nl << prx << "& operator=(const " << prx << "& rhs) noexcept";
     H << sb;

--- a/cpp/test/Common/Makefile.mk
+++ b/cpp/test/Common/Makefile.mk
@@ -10,6 +10,6 @@ $(project)_caninstall   := no
 #
 TestCommon[shared]_targetdir    := $(call mappingdir,$(currentdir),lib)
 TestCommon_dependencies         := Ice
-TestCommon_cppflags             := -DTEST_API_EXPORTS -I$(includedir) -Itest/include
+TestCommon_cppflags             := -DTEST_API_EXPORTS $(api_exports_cppflags) -I$(includedir) -Itest/include
 
 projects += $(project)


### PR DESCRIPTION
With clang, a class without any out-of-line virtual function has a "weak vtable", meaning clang stores this vtable in all translation units.

I believe this is an issue only with shared libraries, where having 2 vtables for the same class in different objects (say exe and shared library) leads to `dynamic_cast` and `catch(const exception&)` failures at runtime.

This PR addresses this issue by turning on `-Wweak-vtables` and fixing many weak vtables warnings in shared libraries.

The usual fix is to define the virtual destructor out of line:
```cpp
MyClass::~MyClass() = default;
```

It's only meaningful when MyClass is exported (= part of the public API, or the semi-public API that plugins can use). And putting a virtual function out of line doesn't work with template classes.

Fixes #3409.