### PR TITLE
Normalize IPv6 used in Endpoint.equivalent

### DIFF
--- a/cpp/src/Ice/IPEndpointI.cpp
+++ b/cpp/src/Ice/IPEndpointI.cpp
@@ -116,7 +116,7 @@ IceInternal::IPEndpointI::equivalent(const EndpointIPtr& endpoint) const
     {
         return false;
     }
-    return ipEndpointI->type() == type() && ipEndpointI->_host == _host && ipEndpointI->_port == _port;
+    return ipEndpointI->type() == type() && ipEndpointI->_normalizedHost == _normalizedHost && ipEndpointI->_port == _port;
 }
 
 size_t
@@ -311,7 +311,8 @@ IceInternal::IPEndpointI::initWithOptions(vector<string>& args, bool oaEndpoint)
     {
         if (oaEndpoint)
         {
-            const_cast<string&>(_host) = string();
+            const_cast<string&>(_host) = string{};
+            const_cast<string&>(_normalizedHost) = string{};
         }
         else
         {
@@ -348,6 +349,7 @@ IceInternal::IPEndpointI::checkOption(const string& option, const string& argume
                 "no argument provided for -h option in endpoint '" + endpoint + "'");
         }
         const_cast<string&>(_host) = argument;
+        const_cast<string&>(_normalizedHost) = normalizeIPv6Address(_host);
     }
     else if (option == "-p")
     {
@@ -407,6 +409,7 @@ IceInternal::IPEndpointI::IPEndpointI(
     string connectionId)
     : _instance(std::move(instance)),
       _host(std::move(host)),
+      _normalizedHost(normalizeIPv6Address(_host)),
       _port(port),
       _sourceAddr(sourceAddr),
       _connectionId(std::move(connectionId))

--- a/cpp/src/Ice/IPEndpointI.cpp
+++ b/cpp/src/Ice/IPEndpointI.cpp
@@ -116,7 +116,8 @@ IceInternal::IPEndpointI::equivalent(const EndpointIPtr& endpoint) const
     {
         return false;
     }
-    return ipEndpointI->type() == type() && ipEndpointI->_normalizedHost == _normalizedHost && ipEndpointI->_port == _port;
+    return ipEndpointI->type() == type() && ipEndpointI->_normalizedHost == _normalizedHost &&
+           ipEndpointI->_port == _port;
 }
 
 size_t
@@ -424,6 +425,7 @@ IceInternal::IPEndpointI::IPEndpointI(ProtocolInstancePtr instance, InputStream*
       _port(0)
 {
     s->read(const_cast<string&>(_host), false);
+    const_cast<string&>(_normalizedHost) = normalizeIPv6Address(_host);
     s->read(const_cast<int32_t&>(_port));
 }
 

--- a/cpp/src/Ice/IPEndpointI.cpp
+++ b/cpp/src/Ice/IPEndpointI.cpp
@@ -306,6 +306,7 @@ IceInternal::IPEndpointI::initWithOptions(vector<string>& args, bool oaEndpoint)
     if (_host.empty())
     {
         const_cast<string&>(_host) = _instance->defaultHost();
+        const_cast<string&>(_normalizedHost) = normalizeIPv6Address(_host);
     }
     else if (_host == "*")
     {

--- a/cpp/src/Ice/IPEndpointI.h
+++ b/cpp/src/Ice/IPEndpointI.h
@@ -61,6 +61,7 @@ namespace IceInternal
 
         const ProtocolInstancePtr _instance;
         const std::string _host;
+        const std::string _normalizedHost;
         const int _port;
         const Address _sourceAddr;
         const std::string _connectionId;

--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -1610,6 +1610,26 @@ IceInternal::getNumericAddress(const std::string& address)
     }
 }
 
+string IceInternal::normalizeIPv6Address(string_view host)
+{
+    if (host.find(':') != string::npos)
+    {
+        struct in6_addr result;
+        if (inet_pton(AF_INET6, host.data(), &result) == 1)
+        {
+            // Normalize the address
+            char buf[INET6_ADDRSTRLEN];
+            if (inet_ntop(AF_INET6, &result, buf, sizeof(buf)) != nullptr)
+            {
+                return string{buf};
+            }
+            // else conversion to string failed, keep host as is
+        }
+        // else it's not a valid IPv6 address keep host as is
+    }
+    return string{host};
+}
+
 SyscallException::ErrorCode
 IceInternal::getSocketErrno()
 {

--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -1610,7 +1610,8 @@ IceInternal::getNumericAddress(const std::string& address)
     }
 }
 
-string IceInternal::normalizeIPv6Address(string_view host)
+string
+IceInternal::normalizeIPv6Address(string_view host)
 {
     if (host.find(':') != string::npos)
     {

--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -1611,12 +1611,12 @@ IceInternal::getNumericAddress(const std::string& address)
 }
 
 string
-IceInternal::normalizeIPv6Address(string_view host)
+IceInternal::normalizeIPv6Address(const string& host)
 {
     if (host.find(':') != string::npos)
     {
         struct in6_addr result;
-        if (inet_pton(AF_INET6, host.data(), &result) == 1)
+        if (inet_pton(AF_INET6, host.c_str(), &result) == 1)
         {
             // Normalize the address
             char buf[INET6_ADDRSTRLEN];
@@ -1628,7 +1628,7 @@ IceInternal::normalizeIPv6Address(string_view host)
         }
         // else it's not a valid IPv6 address keep host as is
     }
-    return string{host};
+    return host;
 }
 
 SyscallException::ErrorCode

--- a/cpp/src/Ice/Network.h
+++ b/cpp/src/Ice/Network.h
@@ -250,7 +250,7 @@ namespace IceInternal
     ICE_API Ice::SyscallException::ErrorCode getSocketErrno();
 
     ICE_API Address getNumericAddress(const std::string&);
-    ICE_API std::string normalizeIPv6Address(std::string_view);
+    ICE_API std::string normalizeIPv6Address(const std::string&);
 
 #if defined(ICE_USE_IOCP)
     ICE_API void doConnectAsync(SOCKET, const Address&, const Address&, AsyncInfo&);

--- a/cpp/src/Ice/Network.h
+++ b/cpp/src/Ice/Network.h
@@ -250,6 +250,7 @@ namespace IceInternal
     ICE_API Ice::SyscallException::ErrorCode getSocketErrno();
 
     ICE_API Address getNumericAddress(const std::string&);
+    ICE_API std::string normalizeIPv6Address(std::string_view);
 
 #if defined(ICE_USE_IOCP)
     ICE_API void doConnectAsync(SOCKET, const Address&, const Address&, AsyncInfo&);

--- a/csharp/src/Ice/Internal/IPEndpointI.cs
+++ b/csharp/src/Ice/Internal/IPEndpointI.cs
@@ -11,6 +11,7 @@ public abstract class IPEndpointI : EndpointI
     {
         instance_ = instance;
         host_ = host;
+        _normalizedHost = normalizeHost(host_);
         port_ = port;
         sourceAddr_ = sourceAddr;
         connectionId_ = connectionId;

--- a/csharp/src/Ice/Internal/IPEndpointI.cs
+++ b/csharp/src/Ice/Internal/IPEndpointI.cs
@@ -345,7 +345,7 @@ public abstract class IPEndpointI : EndpointI
                 // Ignore - don't normalize host.
             }
         }
-        return "";
+        return host;
     }
 
     protected abstract Connector createConnector(EndPoint addr, NetworkProxy proxy);

--- a/csharp/src/Ice/Internal/IPEndpointI.cs
+++ b/csharp/src/Ice/Internal/IPEndpointI.cs
@@ -20,6 +20,7 @@ public abstract class IPEndpointI : EndpointI
     {
         instance_ = instance;
         host_ = null;
+        _normalizedHost = null;
         port_ = 0;
         sourceAddr_ = null;
         connectionId_ = "";
@@ -29,6 +30,7 @@ public abstract class IPEndpointI : EndpointI
     {
         instance_ = instance;
         host_ = s.readString();
+        _normalizedHost = normalizeHost(host_);
         port_ = s.readInt();
         sourceAddr_ = null;
         connectionId_ = "";

--- a/csharp/src/Ice/Internal/IPEndpointI.cs
+++ b/csharp/src/Ice/Internal/IPEndpointI.cs
@@ -120,7 +120,7 @@ public abstract class IPEndpointI : EndpointI
         }
         IPEndpointI ipEndpointI = (IPEndpointI)endpoint;
         return ipEndpointI.type() == type() &&
-            ipEndpointI._normalizedHost.Equals(_normalizedHost, StringComparison.Ordinal) &&
+            ipEndpointI._normalizedHost == _normalizedHost &&
             ipEndpointI.port_ == port_;
     }
 


### PR DESCRIPTION
C# and C++, Java was already done see #3154.

I don't think we need to update JavaScript, 
- This fix is required for collocated calls which are not supported in JavaScript
- We don't do any IP address manipulation in JavaScript just pass the address directly into the WebSocket.
