### PR TITLE
Swift testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,8 @@ jobs:
           - os: macos-15
             config: "ios"
             build_flags: "PLATFORMS='macosx iphonesimulator' CONFIGS='static shared' LANGUAGES='cpp swift'"
-            # Remove rfilter swift/Ice/operations once #3286 is fixed
-            # swift/Ice/udp doesn't work on CI
-            test_flags: "--languages='cpp,swift' --platform=iphonesimulator --controller-app --rfilter=swift/Ice/operations --rfilter=swift/Ice/udp"
+            # TODO swift/Ice/udp doesn't work on CI
+            test_flags: "--languages='cpp,swift' --platform=iphonesimulator --controller-app --rfilter=swift/Ice/udp"
             build_cpp_and_python: true
 
           # Static builds

--- a/cpp/src/Ice/CollocatedRequestHandler.cpp
+++ b/cpp/src/Ice/CollocatedRequestHandler.cpp
@@ -134,8 +134,7 @@ CollocatedRequestHandler::invokeAsyncRequest(OutgoingAsyncBase* outAsync, int ba
 
         outAsync->attachCollocatedObserver(_adapter, requestId);
 
-        // Adopt the OutgoingAsync output stream buffer, to ensure it's not deleted before the request is dispatched.
-        InputStream is{_reference->getInstance().get(), os->getEncoding(), *os, true};
+        InputStream is{_reference->getInstance().get(), os->getEncoding(), *os, false};
 
         if (batchRequestCount > 0)
         {

--- a/cpp/src/Ice/CollocatedRequestHandler.cpp
+++ b/cpp/src/Ice/CollocatedRequestHandler.cpp
@@ -134,7 +134,8 @@ CollocatedRequestHandler::invokeAsyncRequest(OutgoingAsyncBase* outAsync, int ba
 
         outAsync->attachCollocatedObserver(_adapter, requestId);
 
-        InputStream is{_reference->getInstance().get(), os->getEncoding(), *os, false};
+        // Adopt the OutgoingAsync output stream buffer, to ensure it's not deleted before the request is dispatched.
+        InputStream is{_reference->getInstance().get(), os->getEncoding(), *os, true};
 
         if (batchRequestCount > 0)
         {

--- a/swift/src/IceImpl/DispatchAdapter.mm
+++ b/swift/src/IceImpl/DispatchAdapter.mm
@@ -17,16 +17,15 @@ CppDispatcher::dispatch(Ice::IncomingRequest& request, std::function<void(Ice::O
     std::function<void()> cleanup;
 
     // The Swift side can asynchronously unmarshal the request, so we need to either move or copy the encapsulation
-    // data to ensure it remains alive until Swift completes unmarshaling. The data should then be freed once the
-    // dispatch finishes.
+    // data to ensure it remains alive until Swift completes unmarshaling.
     //
     // For a batch request with multiple requests remaining in the input stream, we need to copy the encapsulation data
     // because moving it isn't an option—subsequent requests still depend on the input stream.
     //
     // For collocated requests, we also need to copy the encapsulation data because the input stream doesn't own
     // the memory. The memory is owned by the output stream used for the invocation, which might be freed before the
-    // input stream is unmarshaled. Additionally, we can't take ownership of the output stream because it is still needed
-    // in case of a retry.
+    // input stream is unmarshaled. Additionally, we can't take ownership of the output stream because it is still
+    // needed in case of a retry.
     //
     // If neither of these conditions applies, the input stream can be safely moved to the heap for processing.
     if (request.requestCount() > 1 || request.current().con == nullptr)

--- a/swift/src/IceImpl/DispatchAdapter.mm
+++ b/swift/src/IceImpl/DispatchAdapter.mm
@@ -17,18 +17,19 @@ CppDispatcher::dispatch(Ice::IncomingRequest& request, std::function<void(Ice::O
     std::function<void()> cleanup;
 
     // The Swift side can asynchronously unmarshal the request, so we need to either move or copy the encapsulation
-    // data to ensure it remains alive until Swift completes unmarshaling. It should then be freed once the dispatch
-    // finishes.
+    // data to ensure it remains alive until Swift completes unmarshaling. The data should then be freed once the
+    // dispatch finishes.
     //
     // For a batch request with multiple requests remaining in the input stream, we need to copy the encapsulation data
     // because moving it isn't an option—subsequent requests still depend on the input stream.
     //
-    // For oneway collocated requests, we also need to copy the encapsulation data because the input stream doesn't own
-    // the memory—it is owned by the output stream used for the invocation. This output stream might be freed before
-    // the input stream is unmarshaled.
+    // For collocated requests, we also need to copy the encapsulation data because the input stream doesn't own
+    // the memory. The memory is owned by the output stream used for the invocation, which might be freed before the
+    // input stream is unmarshaled. Additionally, we can't take ownership of the output stream because it is still needed
+    // in case of a retry.
     //
-    // If neither of these conditions applies, the input stream can be safely moved to the heap.
-    if (request.requestCount() > 1 || (request.current().con == nullptr && request.current().requestId == 0))
+    // If neither of these conditions applies, the input stream can be safely moved to the heap for processing.
+    if (request.requestCount() > 1 || request.current().con == nullptr)
     {
         Ice::InputStream& inputStream = request.inputStream();
         inputStream.readEncapsulation(inEncaps, sz);

--- a/swift/src/IceImpl/DispatchAdapter.mm
+++ b/swift/src/IceImpl/DispatchAdapter.mm
@@ -16,15 +16,23 @@ CppDispatcher::dispatch(Ice::IncomingRequest& request, std::function<void(Ice::O
     const std::byte* inEncaps;
     std::function<void()> cleanup;
 
-    // An InputSteam can contain one or more requests when we're processing a batch request. In the case when there
-    // is more than one request in the the batch we need to copy the encapsulation from the InputStream to a
-    // heap allocated vector as the remainder of the memory is needed for subsequent requests.
-    if (request.requestCount() > 1)
+    // The Swift side can asynchronously unmarshal the request, so we need to either move or copy the encapsulation
+    // data to ensure it remains alive until Swift completes unmarshaling. It should then be freed once the dispatch
+    // finishes.
+    //
+    // For a batch request with multiple requests remaining in the input stream, we need to copy the encapsulation data
+    // because moving it isn't an option—subsequent requests still depend on the input stream.
+    //
+    // For oneway collocated requests, we also need to copy the encapsulation data because the input stream doesn't own
+    // the memory—it is owned by the output stream used for the invocation. This output stream might be freed before
+    // the input stream is unmarshaled.
+    //
+    // If neither of these conditions applies, the input stream can be safely moved to the heap.
+    if (request.requestCount() > 1 || (request.current().con == nullptr && request.current().requestId == 0))
     {
         Ice::InputStream& inputStream = request.inputStream();
         inputStream.readEncapsulation(inEncaps, sz);
 
-        // Copy the contents to a heap allocated vector.
         auto encapsulation = new std::vector<std::byte>(inEncaps, inEncaps + sz);
         inEncaps = encapsulation->data();
 
@@ -32,15 +40,12 @@ CppDispatcher::dispatch(Ice::IncomingRequest& request, std::function<void(Ice::O
     }
     else
     {
-        // In the case of a twoway request we can just take the memory as its no longer needed after this request.
-        // Move the request's InputStream into a new heap allocated InputStream.
-        // When dispatch completes, the new InputStream will be deleted.
         auto dispatchInputStream = new Ice::InputStream(std::move(request.inputStream()));
 
         cleanup = [dispatchInputStream] { delete dispatchInputStream; };
 
         dispatchInputStream->readEncapsulation(inEncaps, sz);
-    };
+    }
 
     ICEOutgoingResponse outgoingResponse =
         ^(uint8_t replyStatus, NSString* exceptionId, NSString* exceptionDetails, const void* message, long count) {


### PR DESCRIPTION
This PR updates the C++ collocated request handler to adopt the output stream buffer, when creating the InputStream for dispatch.

As show in #3286 the unmarshalling can happen asynchronously in which case the OutputStream that owned the memory can be removed before than the request is dispatched.

-- EDIT -- 

The original fix didn't work well because OutputStream can be user after the first dispatch if the operation is retried.

The actual fix is to always copy the incoming encaps for collocated dispatch.
