### PR TITLE
Swift build fixes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,28 +41,28 @@ let package = Package(
             name: "Ice",
             dependencies: ["IceImpl"],
             path: "swift/src/Ice",
-            resources: [.process("slice-plugin.json")],
+            exclude: ["slice-plugin.json"],
             plugins: [.plugin(name: "CompileSlice")]
         ),
         .target(
             name: "Glacier2",
             dependencies: ["Ice"],
             path: "swift/src/Glacier2",
-            resources: [.process("slice-plugin.json")],
+            exclude: ["slice-plugin.json"],
             plugins: [.plugin(name: "CompileSlice")]
         ),
         .target(
             name: "IceGrid",
             dependencies: ["Ice", "Glacier2"],
             path: "swift/src/IceGrid",
-            resources: [.process("slice-plugin.json")],
+            exclude: ["slice-plugin.json"],
             plugins: [.plugin(name: "CompileSlice")]
         ),
         .target(
             name: "IceStorm",
             dependencies: ["Ice"],
             path: "swift/src/IceStorm",
-            resources: [.process("slice-plugin.json")],
+            exclude: ["slice-plugin.json"],
             plugins: [.plugin(name: "CompileSlice")]
         ),
         .target(

--- a/swift/README.md
+++ b/swift/README.md
@@ -44,6 +44,7 @@ list:
 ```swift
 .target(
     name: "MyTarget",
+    ...,
     plugins: [
         .plugin(name: "CompileSlice", package: "ice"),
     ]
@@ -69,8 +70,13 @@ Example `slice-plugin.json`:
 ```
 
 > [!NOTE]
-> The `slice-plugin.json` file must be included as part of the target's source files and cannot be excluded.
+> The `slice-plugin.json` file is discovered automatically by the plugin. It must be located in the target's source
+> directory.
+>
 > Only one `slice-plugin.json` file is allowed per target.
+>
+> To avoid warnings regarding unhandled files, the `slice-plugin.json` file and corresponding Slice files (if included
+> in the target source directory) should be explicitly declared as resources or excluded from the target.
 
 ## Sample Code
 

--- a/swift/src/CompileSlicePlugin/CompileSlicePlugin.swift
+++ b/swift/src/CompileSlicePlugin/CompileSlicePlugin.swift
@@ -56,7 +56,7 @@ struct CompileSlicePlugin: BuildToolPlugin {
         let fm = FileManager.default
 
         // Search for the configuration file. If this plugin was loaded, the configuration file must be present, or
-        // its considered an error.
+        // it's considered an error.
         let configFilePath = try fm.contentsOfDirectory(atPath: target.directory.string).first { path in
             path == Self.configFileName
         }.map { target.directory.appending($0).string }

--- a/swift/test/Package.swift
+++ b/swift/test/Package.swift
@@ -90,32 +90,31 @@ let testTargets = testDirectories.map { (testPath, testConfig) in
         .product(name: "IceGrid", package: "ice"),
         .product(name: "IceStorm", package: "ice"),
     ]
+
     var plugins: [Target.PluginUsage] = []
-
-    var sources = testConfig.sources
-
     var excludes = [String]()
 
-    if testConfig.sliceFiles.count > 0 {
-        plugins += [.plugin(name: "CompileSlice", package: "ice")]
-        excludes += testConfig.sliceFiles + ["slice-plugin.json"]
+    if !testConfig.sliceFiles.isEmpty {
+        plugins.append(.plugin(name: "CompileSlice", package: "ice"))
+        excludes.append(contentsOf: testConfig.sliceFiles + ["slice-plugin.json"])
     }
 
-    let name = testPathToTargetName("\(testPath)")
+    let name = testPathToTargetName(testPath)
+    var sources = testConfig.sources
 
     if testConfig.collocated {
-        sources += ["Collocated.swift"]
+        sources.append("Collocated.swift")
     }
 
     return Target.target(
-            name: name,
-            dependencies: dependencies,
-            path: testPath,
-            exclude: excludes,
-            sources: sources,
-            resources: testConfig.resources,
-            plugins: plugins
-        )
+        name: name,
+        dependencies: dependencies,
+        path: testPath,
+        exclude: excludes,
+        sources: sources,
+        resources: testConfig.resources,
+        plugins: plugins
+    )
 }
 
 let testDriverDependencies = testTargets.map { Target.Dependency(stringLiteral: $0.name) }


### PR DESCRIPTION
This PR makes changes the Swift build system so that the compile slice plugin now searches the target source directory for the `slice-plugin.json` file. This way it no longer needs to be passed in as resource file (unless you want to for another reason).  You generally only want to add resources when you intend to access them in code.

It also fixes the Swift tests to ignore the Swift Slice files.