### PR TITLE
Test collocated invocations with normalized IPv6 addresses

### DIFF
--- a/cpp/test/Ice/operations/Collocated.cpp
+++ b/cpp/test/Ice/operations/Collocated.cpp
@@ -4,6 +4,8 @@
 #include "TestHelper.h"
 #include "TestI.h"
 
+#include <iostream>
+
 using namespace std;
 
 class Collocated : public Test::TestHelper
@@ -12,22 +14,47 @@ public:
     void run(int, char**) override;
 };
 
+namespace
+{
+
+    void testCollocatedIPv6Invocation()
+    {
+        cout << "testing collocated invocation with normalized IPv6 address... " << flush;
+        Ice::CommunicatorHolder communicator = Ice::initialize();
+        communicator->getProperties()->setProperty("TestAdapter.Endpoints", "tcp -h \"0:0:0:0:0:0:0:1\" -p 10000");
+        Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
+        adapter->add(std::make_shared<MyDerivedClassI>(), Ice::stringToIdentity("test"));
+
+        auto prx = Ice::ObjectPrx(communicator.communicator(), "test:tcp -h \"::1\" -p 10000");
+        prx = prx->ice_invocationTimeout(10ms);
+        prx->ice_ping();
+
+        prx = Ice::ObjectPrx(communicator.communicator(), "test:tcp -h \"0:0:0:0:0:0:0:1\" -p 10000");
+        prx = prx->ice_invocationTimeout(10ms);
+        prx->ice_ping();
+        cout << "ok" << endl;
+    }
+}
+
 void
 Collocated::run(int argc, char** argv)
 {
     Ice::PropertiesPtr properties = createTestProperties(argc, argv);
     properties->setProperty("Ice.BatchAutoFlushSize", "100");
-    Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
-    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
-    communicator->getProperties()->setProperty("TestAdapter.AdapterId", "test");
-    Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
-    Ice::ObjectPrx prx = adapter->add(std::make_shared<MyDerivedClassI>(), Ice::stringToIdentity("test"));
-    // adapter->activate(); // Don't activate OA to ensure collocation is used.
+    {
+        Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
+        communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
+        communicator->getProperties()->setProperty("TestAdapter.AdapterId", "test");
+        Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
+        Ice::ObjectPrx prx = adapter->add(std::make_shared<MyDerivedClassI>(), Ice::stringToIdentity("test"));
+        // adapter->activate(); // Don't activate OA to ensure collocation is used.
 
-    test(!prx->ice_getConnection());
+        test(!prx->ice_getConnection());
 
-    Test::MyClassPrx allTests(Test::TestHelper*);
-    allTests(this);
+        Test::MyClassPrx allTests(Test::TestHelper*);
+        allTests(this);
+    }
+    testCollocatedIPv6Invocation();
 }
 
 DEFINE_TEST(Collocated)

--- a/cpp/test/Ice/operations/Collocated.cpp
+++ b/cpp/test/Ice/operations/Collocated.cpp
@@ -16,7 +16,6 @@ public:
 
 namespace
 {
-
     void testCollocatedIPv6Invocation()
     {
         cout << "testing collocated invocation with normalized IPv6 address... " << flush;

--- a/cpp/test/Ice/operations/Collocated.cpp
+++ b/cpp/test/Ice/operations/Collocated.cpp
@@ -16,20 +16,25 @@ public:
 
 namespace
 {
-    void testCollocatedIPv6Invocation()
+    void testCollocatedIPv6Invocation(Test::TestHelper* helper)
     {
+        int port = helper->getTestPort(1);
+
+        string endpoint1 = "tcp -h \"::1\" -p " + to_string(port);
+        string endpoint2 = "tcp -h \"0:0:0:0:0:0:0:1\" -p " + to_string(port);
+
         cout << "testing collocated invocation with normalized IPv6 address... " << flush;
         Ice::CommunicatorHolder communicator = Ice::initialize();
-        communicator->getProperties()->setProperty("TestAdapter.Endpoints", "tcp -h \"0:0:0:0:0:0:0:1\" -p 10000");
+        communicator->getProperties()->setProperty("TestAdapter.Endpoints", endpoint1);
         Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
         adapter->add(std::make_shared<MyDerivedClassI>(), Ice::stringToIdentity("test"));
         // Don't activate OA to ensure collocation is used.
 
-        auto prx = Ice::ObjectPrx{communicator.communicator(), "test:tcp -h \"::1\" -p 10000"};
+        auto prx = Ice::ObjectPrx{communicator.communicator(), "test:" + endpoint1};
         prx = prx->ice_invocationTimeout(10ms);
         prx->ice_ping();
 
-        prx = Ice::ObjectPrx{communicator.communicator(), "test:tcp -h \"0:0:0:0:0:0:0:1\" -p 10000"};
+        prx = Ice::ObjectPrx{communicator.communicator(), "test:" + endpoint2};
         prx = prx->ice_invocationTimeout(10ms);
         prx->ice_ping();
         cout << "ok" << endl;
@@ -52,7 +57,7 @@ Collocated::run(int argc, char** argv)
     Test::MyClassPrx allTests(Test::TestHelper*);
     allTests(this);
 
-    testCollocatedIPv6Invocation();
+    testCollocatedIPv6Invocation(this);
 }
 
 DEFINE_TEST(Collocated)

--- a/csharp/test/Ice/operations/Collocated.cs
+++ b/csharp/test/Ice/operations/Collocated.cs
@@ -28,23 +28,25 @@ namespace Ice
 
                 await AllTests.allTests(this);
 
-                testCollocatedIPv6Invocation(this.getWriter());
+                testCollocatedIPv6Invocation(this);
             }
 
-            private static void testCollocatedIPv6Invocation(TextWriter output)
+            private static void testCollocatedIPv6Invocation(TestHelper helper)
             {
+                TextWriter output = helper.getWriter();
+                int port = helper.getTestPort(1);
                 output.Write("testing collocated invocation with normalized IPv6 address... ");
                 output.Flush();
                 using var communicator = Ice.Util.initialize();
-                communicator.getProperties().setProperty("TestAdapter.Endpoints", "tcp -h \"0:0:0:0:0:0:0:1\" -p 10000");
+                communicator.getProperties().setProperty("TestAdapter.Endpoints", $"tcp -h \"0:0:0:0:0:0:0:1\" -p {port}");
                 var adapter = communicator.createObjectAdapter("TestAdapter");
                 adapter.add(new MyDerivedClassI(), Ice.Util.stringToIdentity("test"));
 
-                var prx = Ice.ObjectPrxHelper.createProxy(communicator, "test:tcp -h \"::1\" -p 10000");
+                var prx = Ice.ObjectPrxHelper.createProxy(communicator, $"test:tcp -h \"::1\" -p {port}");
                 prx = prx.ice_invocationTimeout(TimeSpan.FromMilliseconds(10));
                 prx.ice_ping();
 
-                prx = Ice.ObjectPrxHelper.createProxy(communicator, "test:tcp -h \"0:0:0:0:0:0:0:1\" -p 10000");
+                prx = Ice.ObjectPrxHelper.createProxy(communicator, $"test:tcp -h \"0:0:0:0:0:0:0:1\" -p {port}");
                 prx = prx.ice_invocationTimeout(TimeSpan.FromMilliseconds(10));
                 prx.ice_ping();
                 output.WriteLine();

--- a/csharp/test/Ice/operations/Collocated.cs
+++ b/csharp/test/Ice/operations/Collocated.cs
@@ -16,7 +16,6 @@ namespace Ice
                 initData.properties.setProperty("Ice.ThreadPool.Client.SizeWarn", "0");
                 initData.properties.setProperty("Ice.BatchAutoFlushSize", "100");
                 using var communicator = initialize(initData);
-                communicator.getProperties().setProperty("TestAdapter.AdapterId", "test");
                 communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
                 ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
                 ObjectPrx prx = adapter.add(new MyDerivedClassI(), Ice.Util.stringToIdentity("test"));

--- a/java/test/src/main/java/test/Ice/operations/Collocated.java
+++ b/java/test/src/main/java/test/Ice/operations/Collocated.java
@@ -30,25 +30,27 @@ public class Collocated extends test.TestHelper {
                 throw new RuntimeException();
             }
             AllTests.allTests(this);
-            testCollocatedIPv6Invocation(this.getWriter());
+            testCollocatedIPv6Invocation(this);
         }
     }
 
-    private static void testCollocatedIPv6Invocation(PrintWriter output) {
+    private static void testCollocatedIPv6Invocation(test.TestHelper helper) {
+        int port = helper.getTestPort(1);
+        PrintWriter output = helper.getWriter();
         output.print("testing collocated invocation with normalized IPv6 address... ");
         output.flush();
         try (var communicator = com.zeroc.Ice.Util.initialize()) {
             communicator
                     .getProperties()
-                    .setProperty("TestAdapter.Endpoints", "tcp -h \"0:0:0:0:0:0:0:1\" -p 10000");
+                    .setProperty("TestAdapter.Endpoints", "tcp -h \"0:0:0:0:0:0:0:1\" -p " + port);
             var adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new MyDerivedClassI(), com.zeroc.Ice.Util.stringToIdentity("test"));
 
-            var prx = ObjectPrx.createProxy(communicator, "test:tcp -h \"::1\" -p 10000");
+            var prx = ObjectPrx.createProxy(communicator, "test:tcp -h \"::1\" -p " + port);
             prx = prx.ice_invocationTimeout(10);
             prx.ice_ping();
 
-            prx = ObjectPrx.createProxy(communicator, "test:tcp -h \"0:0:0:0:0:0:0:1\" -p 10000");
+            prx = ObjectPrx.createProxy(communicator, "test:tcp -h \"0:0:0:0:0:0:0:1\" -p " + port);
             prx = prx.ice_invocationTimeout(10);
             prx.ice_ping();
             output.println();

--- a/java/test/src/main/java/test/Ice/operations/Collocated.java
+++ b/java/test/src/main/java/test/Ice/operations/Collocated.java
@@ -2,7 +2,10 @@
 
 package test.Ice.operations;
 
+import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.Util;
+
+import java.io.PrintWriter;
 
 public class Collocated extends test.TestHelper {
     public void run(String[] args) {
@@ -27,6 +30,28 @@ public class Collocated extends test.TestHelper {
                 throw new RuntimeException();
             }
             AllTests.allTests(this);
+            testCollocatedIPv6Invocation(this.getWriter());
+        }
+    }
+
+    private static void testCollocatedIPv6Invocation(PrintWriter output) {
+        output.print("testing collocated invocation with normalized IPv6 address... ");
+        output.flush();
+        try (var communicator = com.zeroc.Ice.Util.initialize()) {
+            communicator
+                    .getProperties()
+                    .setProperty("TestAdapter.Endpoints", "tcp -h \"0:0:0:0:0:0:0:1\" -p 10000");
+            var adapter = communicator.createObjectAdapter("TestAdapter");
+            adapter.add(new MyDerivedClassI(), com.zeroc.Ice.Util.stringToIdentity("test"));
+
+            var prx = ObjectPrx.createProxy(communicator, "test:tcp -h \"::1\" -p 10000");
+            prx = prx.ice_invocationTimeout(10);
+            prx.ice_ping();
+
+            prx = ObjectPrx.createProxy(communicator, "test:tcp -h \"0:0:0:0:0:0:0:1\" -p 10000");
+            prx = prx.ice_invocationTimeout(10);
+            prx.ice_ping();
+            output.println();
         }
     }
 }


### PR DESCRIPTION
This PR adds a test to ensure that collocated invocation works with proxies containing IPv6 endpoints. See #3154
