### PR TITLE
Remove :: before std:: and Ice::

### DIFF
--- a/cpp/include/DataStorm/Types.h
+++ b/cpp/include/DataStorm/Types.h
@@ -262,8 +262,7 @@ namespace DataStorm
     /**
      * Cloner template specialization to clone shared Ice values using ice_clone.
      */
-    template<typename T>
-    struct Cloner<std::shared_ptr<T>, typename std::enable_if_t<std::is_base_of_v<::Ice::Value, T>>>
+    template<typename T> struct Cloner<std::shared_ptr<T>, typename std::enable_if_t<std::is_base_of_v<Ice::Value, T>>>
     {
         static std::shared_ptr<T> clone(const std::shared_ptr<T>& value) noexcept { return value->ice_clone(); }
     };

--- a/cpp/src/Ice/ArgVector.cpp
+++ b/cpp/src/Ice/ArgVector.cpp
@@ -15,7 +15,7 @@ IceInternal::ArgVector::ArgVector(int argcP, const char* const argvP[])
     setupArgcArgv();
 }
 
-IceInternal::ArgVector::ArgVector(const ::std::vector<::std::string>& vec)
+IceInternal::ArgVector::ArgVector(const std::vector<std::string>& vec)
 {
     _args = vec;
     setupArgcArgv();
@@ -48,7 +48,7 @@ IceInternal::ArgVector::setupArgcArgv()
     argc = static_cast<int>(_args.size());
     if ((argv = new char*[static_cast<size_t>(argc + 1)]) == nullptr)
     {
-        throw ::std::bad_alloc();
+        throw std::bad_alloc();
     }
     for (size_t i = 0; i < static_cast<size_t>(argc); i++)
     {

--- a/cpp/src/Ice/Communicator.cpp
+++ b/cpp/src/Ice/Communicator.cpp
@@ -239,7 +239,7 @@ Ice::Communicator::postToClientThreadPool(function<void()> call)
     _instance->clientThreadPool()->execute(std::move(call), nullptr);
 }
 
-::std::function<void()>
+std::function<void()>
 Ice::Communicator::flushBatchRequestsAsync(
     CompressBatch compress,
     function<void(exception_ptr)> ex,

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -757,8 +757,8 @@ Ice::ConnectionI::getBatchRequestQueue() const
 std::function<void()>
 Ice::ConnectionI::flushBatchRequestsAsync(
     CompressBatch compress,
-    ::std::function<void(::std::exception_ptr)> ex,
-    ::std::function<void(bool)> sent)
+    std::function<void(std::exception_ptr)> ex,
+    std::function<void(bool)> sent)
 {
     class ConnectionFlushBatchLambda : public ConnectionFlushBatchAsync, public LambdaInvoke
     {

--- a/cpp/src/Ice/ImplicitContext.cpp
+++ b/cpp/src/Ice/ImplicitContext.cpp
@@ -68,7 +68,7 @@ ImplicitContext::remove(string_view key)
 }
 
 void
-ImplicitContext::write(const Context& context, ::Ice::OutputStream* os) const
+ImplicitContext::write(const Context& context, Ice::OutputStream* os) const
 {
     unique_lock lock(_mutex);
     if (context.size() == 0)

--- a/cpp/src/Ice/MetricsAdminI.cpp
+++ b/cpp/src/Ice/MetricsAdminI.cpp
@@ -157,7 +157,7 @@ MetricsMapI::MetricsMapI(const MetricsMapI& map)
 {
 }
 
-const ::Ice::PropertyDict&
+const Ice::PropertyDict&
 MetricsMapI::getProperties() const
 {
     return _properties;
@@ -190,7 +190,7 @@ MetricsViewI::addOrUpdateMap(
     const PropertiesPtr& properties,
     const string& mapName,
     const MetricsMapFactoryPtr& factory,
-    const ::Ice::LoggerPtr& logger)
+    const Ice::LoggerPtr& logger)
 {
     const string viewPrefix = "IceMX.Metrics." + _name + ".";
     const string mapsPrefix = viewPrefix + "Map.";
@@ -253,7 +253,7 @@ MetricsViewI::addOrUpdateMap(
     }
     catch (const std::exception& ex)
     {
-        ::Ice::Warning warn(logger);
+        Ice::Warning warn(logger);
         warn << "unexpected exception while creating metrics map:\n" << ex;
     }
     return true;
@@ -577,7 +577,7 @@ MetricsAdminI::updated(const PropertyDict& props)
             }
             catch (const std::exception& ex)
             {
-                ::Ice::Warning warn(_logger);
+                Ice::Warning warn(_logger);
                 warn << "unexpected exception while updating metrics view configuration:\n" << ex.what();
             }
             return;

--- a/cpp/src/Ice/Object.cpp
+++ b/cpp/src/Ice/Object.cpp
@@ -21,7 +21,7 @@ Ice::Object::ice_isA(
     const Current& current) const
 {
     vector<string> allTypeIds = ice_ids(current); // sorted type IDs
-    return ::std::binary_search(allTypeIds.begin(), allTypeIds.end(), s);
+    return std::binary_search(allTypeIds.begin(), allTypeIds.end(), s);
 }
 
 void

--- a/cpp/src/Ice/Options.cpp
+++ b/cpp/src/Ice/Options.cpp
@@ -963,7 +963,7 @@ IceInternal::Options::checkOptHasArg(const string& opt) const
 }
 
 void
-IceInternal::Options::updateSynonyms(const ::std::string& shortOpt, const ::std::string& longOpt)
+IceInternal::Options::updateSynonyms(const std::string& shortOpt, const std::string& longOpt)
 {
     if (!shortOpt.empty() && !longOpt.empty())
     {
@@ -973,7 +973,7 @@ IceInternal::Options::updateSynonyms(const ::std::string& shortOpt, const ::std:
 }
 
 string
-IceInternal::Options::getSynonym(const ::std::string& optName) const
+IceInternal::Options::getSynonym(const std::string& optName) const
 {
     auto pos = _synonyms.find(optName);
     return pos != _synonyms.end() ? pos->second : string("");

--- a/cpp/src/Ice/Proxy.cpp
+++ b/cpp/src/Ice/Proxy.cpp
@@ -129,7 +129,7 @@ Ice::ObjectPrx::ice_isSecure() const noexcept
     return _reference->getSecure();
 }
 
-::Ice::EncodingVersion
+Ice::EncodingVersion
 Ice::ObjectPrx::ice_getEncodingVersion() const noexcept
 {
     return _reference->getEncoding();

--- a/cpp/src/Ice/ProxyAsync.cpp
+++ b/cpp/src/Ice/ProxyAsync.cpp
@@ -566,8 +566,8 @@ Ice::ObjectPrx::ice_invokeAsync(
     std::pair<const byte*, const byte*> inParams,
     const Ice::Context& context) const
 {
-    using Outgoing = IceInternal::InvokePromiseOutgoing<::std::tuple<bool, vector<byte>>>;
-    auto outAsync = ::std::make_shared<Outgoing>(*this, false);
+    using Outgoing = IceInternal::InvokePromiseOutgoing<std::tuple<bool, vector<byte>>>;
+    auto outAsync = std::make_shared<Outgoing>(*this, false);
     outAsync->invoke(operation, mode, inParams, context);
     return outAsync->getFuture();
 }
@@ -582,19 +582,19 @@ Ice::ObjectPrx::ice_invokeAsync(
     std::function<void(bool)> sent,
     const Ice::Context& context) const
 {
-    using Result = ::std::tuple<bool, ::std::pair<const ::byte*, const ::byte*>>;
+    using Result = std::tuple<bool, std::pair<const ::byte*, const ::byte*>>;
     using Outgoing = IceInternal::InvokeLambdaOutgoing<Result>;
 
-    ::std::function<void(Result&&)> r;
+    std::function<void(Result&&)> r;
     if (response)
     {
         r = [response = std::move(response)](Result&& result)
         {
-            auto [success, outParams] = ::std::move(result);
+            auto [success, outParams] = std::move(result);
             response(success, std::move(outParams));
         };
     }
-    auto outAsync = ::std::make_shared<Outgoing>(*this, std::move(r), std::move(ex), std::move(sent));
+    auto outAsync = std::make_shared<Outgoing>(*this, std::move(r), std::move(ex), std::move(sent));
     outAsync->invoke(operation, mode, inParams, context);
     return [outAsync]() { outAsync->cancel(); };
 }

--- a/cpp/src/IceGrid/AdminI.cpp
+++ b/cpp/src/IceGrid/AdminI.cpp
@@ -394,7 +394,7 @@ AdminI::getAllAdapterIds(const Current&) const
 }
 
 void
-AdminI::addObject(optional<Ice::ObjectPrx> proxy, const ::Ice::Current& current)
+AdminI::addObject(optional<Ice::ObjectPrx> proxy, const Ice::Current& current)
 {
     checkIsReadOnly();
 
@@ -416,7 +416,7 @@ AdminI::addObject(optional<Ice::ObjectPrx> proxy, const ::Ice::Current& current)
 }
 
 void
-AdminI::updateObject(optional<Ice::ObjectPrx> proxy, const ::Ice::Current&)
+AdminI::updateObject(optional<Ice::ObjectPrx> proxy, const Ice::Current&)
 {
     checkIsReadOnly();
 
@@ -436,7 +436,7 @@ AdminI::updateObject(optional<Ice::ObjectPrx> proxy, const ::Ice::Current&)
 }
 
 void
-AdminI::addObjectWithType(optional<Ice::ObjectPrx> proxy, string type, const ::Ice::Current&)
+AdminI::addObjectWithType(optional<Ice::ObjectPrx> proxy, string type, const Ice::Current&)
 {
     checkIsReadOnly();
 

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -819,7 +819,7 @@ ServerI::getProcess() const
 }
 
 void
-ServerI::setEnabled(bool enabled, const ::Ice::Current&)
+ServerI::setEnabled(bool enabled, const Ice::Current&)
 {
     bool activate = false;
     ServerAdapterDict adpts;
@@ -876,7 +876,7 @@ ServerI::setEnabled(bool enabled, const ::Ice::Current&)
 }
 
 bool
-ServerI::isEnabled(const ::Ice::Current&) const
+ServerI::isEnabled(const Ice::Current&) const
 {
     lock_guard lock(_mutex);
     checkDestroyed();

--- a/cpp/src/IceStorm/InstrumentationI.cpp
+++ b/cpp/src/IceStorm/InstrumentationI.cpp
@@ -147,7 +147,7 @@ namespace
                 {
                     _id = _proxy->ice_toString();
                 }
-                catch (const ::Ice::FixedProxyException&)
+                catch (const Ice::FixedProxyException&)
                 {
                     _id = _proxy->ice_getCommunicator()->identityToString(_proxy->ice_getIdentity());
                 }

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -50,12 +50,12 @@ namespace
 
         if (strType == "")
         {
-            strType = (typeCtx & TypeContext::UseWstring) != TypeContext::None ? "::std::wstring" : "::std::string";
+            strType = (typeCtx & TypeContext::UseWstring) != TypeContext::None ? "std::wstring" : "std::string";
         }
         else
         {
             assert(strType == "string" || strType == "wstring");
-            strType = "::std::" + strType;
+            strType = "std::" + strType;
         }
 
         if ((typeCtx & TypeContext::MarshalParam) != TypeContext::None)
@@ -88,7 +88,7 @@ namespace
                         seq->typeMetadata(),
                         typeCtx | (inWstringModule(seq) ? TypeContext::UseWstring : TypeContext::None));
                 }
-                return "::std::pair<const " + s + "*, const " + s + "*>";
+                return "std::pair<const " + s + "*, const " + s + "*>";
             }
             else
             {
@@ -219,7 +219,7 @@ namespace
                 {
                     auto index =
                         std::distance(params.begin(), std::find(params.begin(), params.end(), param)) + retOffset;
-                    out << "::std::get<" + std::to_string(index) + ">(v)";
+                    out << "std::get<" + std::to_string(index) + ">(v)";
                 }
                 else
                 {
@@ -230,7 +230,7 @@ namespace
             {
                 if (tuple)
                 {
-                    out << "::std::get<0>(v)";
+                    out << "std::get<0>(v)";
                 }
                 else
                 {
@@ -304,7 +304,7 @@ namespace
                     {
                         if (tuple)
                         {
-                            out << "::std::get<0>(v)";
+                            out << "std::get<0>(v)";
                         }
                         else
                         {
@@ -317,7 +317,7 @@ namespace
                     {
                         auto index =
                             std::distance(params.begin(), std::find(params.begin(), params.end(), param)) + retOffset;
-                        out << "::std::get<" + std::to_string(index) + ">(v)";
+                        out << "std::get<" + std::to_string(index) + ">(v)";
                     }
                     else
                     {
@@ -328,7 +328,7 @@ namespace
                 {
                     if (tuple)
                     {
-                        out << "::std::get<0>(v)";
+                        out << "std::get<0>(v)";
                     }
                     else
                     {
@@ -484,21 +484,21 @@ Slice::typeToString(
         }
         else
         {
-            return "::std::optional<" + typeToString(type, false, scope, metadata, typeCtx) + '>';
+            return "std::optional<" + typeToString(type, false, scope, metadata, typeCtx) + '>';
         }
     }
 
     static constexpr string_view builtinTable[] = {
-        "::std::uint8_t",
+        "std::uint8_t",
         "bool",
-        "::std::int16_t",
-        "::std::int32_t",
-        "::std::int64_t",
+        "std::int16_t",
+        "std::int32_t",
+        "std::int64_t",
         "float",
         "double",
         "****", // string or wstring, see below
         "Ice::ValuePtr",
-        "::std::optional<Ice::ObjectPrx>",
+        "std::optional<Ice::ObjectPrx>",
         "Ice::ValuePtr"};
 
     BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
@@ -536,7 +536,7 @@ Slice::typeToString(
     InterfaceDeclPtr proxy = dynamic_pointer_cast<InterfaceDecl>(type);
     if (proxy)
     {
-        return "::std::optional<" + getUnqualified(proxy->mappedScoped() + "Prx", scope) + ">";
+        return "std::optional<" + getUnqualified(proxy->mappedScoped() + "Prx", scope) + ">";
     }
 
     EnumPtr en = dynamic_pointer_cast<Enum>(type);
@@ -641,7 +641,7 @@ Slice::opFormatTypeToString(const OperationPtr& op)
     }
     else
     {
-        return "::std::nullopt";
+        return "std::nullopt";
     }
 }
 

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -250,7 +250,7 @@ namespace
         return s;
     }
 
-    string condMove(bool moveIt, const string& str) { return moveIt ? string("::std::move(") + str + ")" : str; }
+    string condMove(bool moveIt, const string& str) { return moveIt ? string("std::move(") + str + ")" : str; }
 
     /// Ensures that there is no collision between 'name' and any of the parameters in the provided 'params' list.
     /// If a collision exists, we return 'name' with an underscore appended to it. Otherwise we return 'name' as-is.
@@ -559,7 +559,7 @@ namespace
             {
                 ostringstream os;
                 Output out(os);
-                out << "::std::tuple" << sabrk;
+                out << "std::tuple" << sabrk;
                 for (const auto& element : elements)
                 {
                     out << element;
@@ -592,7 +592,7 @@ namespace
     {
         ostringstream os;
         Output out(os);
-        out << "::std::function<void" << spar << createOutgoingAsyncParams(p, "", typeContext) << epar << ">";
+        out << "std::function<void" << spar << createOutgoingAsyncParams(p, "", typeContext) << epar << ">";
         return os.str();
     }
 }
@@ -1116,7 +1116,7 @@ Slice::Gen::ForwardDeclVisitor::visitClassDecl(const ClassDeclPtr& p)
 {
     const string name = p->mappedName();
     H << nl << "class " << name << ';';
-    H << nl << "using " << name << "Ptr " << getDeprecatedAttribute(p) << "= ::std::shared_ptr<" << name << ">;" << sp;
+    H << nl << "using " << name << "Ptr " << getDeprecatedAttribute(p) << "= std::shared_ptr<" << name << ">;" << sp;
 }
 
 bool
@@ -1139,7 +1139,7 @@ Slice::Gen::ForwardDeclVisitor::visitEnum(const EnumPtr& p)
 
     writeDocSummary(H, p);
     H << nl << "enum class " << getDeprecatedAttribute(p) << mappedName;
-    H << " : ::std::" << (p->maxValue() <= numeric_limits<uint8_t>::max() ? "uint8_t" : "int32_t");
+    H << " : std::" << (p->maxValue() <= numeric_limits<uint8_t>::max() ? "uint8_t" : "int32_t");
 
     if (p->maxValue() > numeric_limits<uint8_t>::max() && p->maxValue() <= numeric_limits<int16_t>::max())
     {
@@ -1177,15 +1177,15 @@ Slice::Gen::ForwardDeclVisitor::visitEnum(const EnumPtr& p)
     }
     H << eb << ';';
 
-    H << nl << _dllExport << "::std::ostream& operator<<(::std::ostream&, " << mappedName << ");" << sp;
+    H << nl << _dllExport << "std::ostream& operator<<(std::ostream&, " << mappedName << ");" << sp;
 
     if (!p->hasMetadata("cpp:custom-print"))
     {
         // We generate the implementation unless custom-print tells us not to.
         // If the provided value corresponds to a named enumerator value, we print the corresponding name.
         // Otherwise, we print the underlying integer value.
-        C << sp << nl << "::std::ostream&";
-        C << nl << p->mappedScope().substr(2) << "operator<<(::std::ostream& os, " << mappedName << " value)";
+        C << sp << nl << "std::ostream&";
+        C << nl << p->mappedScope().substr(2) << "operator<<(std::ostream& os, " << mappedName << " value)";
         C << sb;
         C << nl << "switch (value)";
         C << sb;
@@ -1199,7 +1199,7 @@ Slice::Gen::ForwardDeclVisitor::visitEnum(const EnumPtr& p)
         }
         C << nl << "default:";
         C.inc();
-        C << nl << "return os << static_cast<::std::int32_t>(value);";
+        C << nl << "return os << static_cast<std::int32_t>(value);";
         C.dec();
         C << eb;
         C << eb;
@@ -1230,12 +1230,12 @@ Slice::Gen::ForwardDeclVisitor::visitSequence(const SequencePtr& p)
         auto builtin = dynamic_pointer_cast<Builtin>(type);
         if (builtin && builtin->kind() == Builtin::KindByte)
         {
-            H << "::std::vector<std::byte>;" << sp;
+            H << "std::vector<std::byte>;" << sp;
         }
         else
         {
             string s = typeToString(type, false, scope, p->typeMetadata(), typeCtx);
-            H << "::std::vector<" << s << ">;" << sp;
+            H << "std::vector<" << s << ">;" << sp;
         }
     }
 }
@@ -1261,7 +1261,7 @@ Slice::Gen::ForwardDeclVisitor::visitDictionary(const DictionaryPtr& p)
         string ks = typeToString(keyType, false, scope, p->keyMetadata(), typeCtx);
         string vs = typeToString(valueType, false, scope, p->valueMetadata(), typeCtx);
 
-        H << "::std::map<" << ks << ", " << vs << ">;" << sp;
+        H << "std::map<" << ks << ", " << vs << ">;" << sp;
     }
     else
     {
@@ -1660,11 +1660,11 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
         for (const auto& q : outParams)
         {
             C << nl << paramPrefix << q->mappedName() << " = ";
-            C << condMove(isMovable(q->type()), "::std::get<" + std::to_string(index++) + ">(result)") << ";";
+            C << condMove(isMovable(q->type()), "std::get<" + std::to_string(index++) + ">(result)") << ";";
         }
         if (ret)
         {
-            C << nl << "return " + condMove(isMovable(ret), "::std::get<0>(result)") + ";";
+            C << nl << "return " + condMove(isMovable(ret), "std::get<0>(result)") + ";";
         }
     }
     C << eb;
@@ -1690,11 +1690,11 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
             returns);
     }
 
-    H << nl << deprecatedAttribute << "[[nodiscard]] ::std::future<" << futureT << "> " << opName << "Async" << spar
+    H << nl << deprecatedAttribute << "[[nodiscard]] std::future<" << futureT << "> " << opName << "Async" << spar
       << inParamsDecl << contextDecl << epar << " const;";
 
     C << sp;
-    C << nl << "::std::future<" << futureTAbsolute << ">";
+    C << nl << "std::future<" << futureTAbsolute << ">";
     C << nl;
     C << prxScopedOpName << "Async" << spar << inParamsImplDecl << "const Ice::Context& context" << epar << " const";
 
@@ -1736,7 +1736,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     }
     H << nl;
     H << deprecatedAttribute;
-    H << "::std::function<void()> // NOLINT(modernize-use-nodiscard)";
+    H << "std::function<void()> // NOLINT(modernize-use-nodiscard)";
 
     // TODO: need "nl" version of spar/epar
     H << nl << opName << "Async" << spar;
@@ -1744,35 +1744,35 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
     H << inParamsDecl;
 
     H << lambdaResponse + " " + responseParam;
-    H << "::std::function<void(::std::exception_ptr)> " + exParam + " = nullptr";
-    H << "::std::function<void(bool)> " + sentParam + " = nullptr";
+    H << "std::function<void(std::exception_ptr)> " + exParam + " = nullptr";
+    H << "std::function<void(bool)> " + sentParam + " = nullptr";
     H << contextDecl << epar << " const;";
     H.restoreIndent();
 
     C << sp;
-    C << nl << "::std::function<void()>";
+    C << nl << "std::function<void()>";
     C << nl << prxScopedOpName << "Async" << spar;
     C.useCurrentPosAsIndent();
     C << inParamsImplDecl;
     C << lambdaResponse + " response";
-    C << "::std::function<void(::std::exception_ptr)> ex";
-    C << "::std::function<void(bool)> sent";
+    C << "std::function<void(std::exception_ptr)> ex";
+    C << "std::function<void(bool)> sent";
     C << "const Ice::Context& context" << epar << " const";
     C.restoreIndent();
 
     C << sb;
     if (lambdaOutParams.size() > 1)
     {
-        C << nl << "auto responseCb = [response = ::std::move(response)](" << lambdaT << "&& result) mutable";
+        C << nl << "auto responseCb = [response = std::move(response)](" << lambdaT << "&& result) mutable";
         C << sb;
-        C << nl << "::std::apply(::std::move(response), ::std::move(result));";
+        C << nl << "std::apply(std::move(response), std::move(result));";
         C << eb << ";";
     }
 
     C << nl << "return IceInternal::makeLambdaOutgoing<" << lambdaT << ">" << spar;
 
-    C << "::std::move(" + (lambdaOutParams.size() > 1 ? string("responseCb") : "response") + ")" << "::std::move(ex)"
-      << "::std::move(sent)"
+    C << "std::move(" + (lambdaOutParams.size() > 1 ? string("responseCb") : "response") + ")" << "std::move(ex)"
+      << "std::move(sent)"
       << "this";
     C << string("&" + getUnqualified(scopedPrxPrefix, interfaceScope.substr(2)) + lambdaImplPrefix + opName);
     C << inParamsImpl;
@@ -1832,7 +1832,7 @@ Slice::Gen::ProxyVisitor::emitOperationImpl(
     H << sp;
     H << nl << "/// \\cond INTERNAL";
     H << nl << "void " << opImplName << spar;
-    H << "const ::std::shared_ptr<IceInternal::OutgoingAsyncT<" + returnT + ">>&";
+    H << "const std::shared_ptr<IceInternal::OutgoingAsyncT<" + returnT + ">>&";
     H << inParamsS;
     H << "const Ice::Context&";
     H << epar << " const;";
@@ -1840,11 +1840,11 @@ Slice::Gen::ProxyVisitor::emitOperationImpl(
 
     C << sp;
     C << nl << "void" << nl << scopedPrxPrefix << opImplName << spar;
-    C << "const ::std::shared_ptr<IceInternal::OutgoingAsyncT<" + returnT + ">>& outAsync";
+    C << "const std::shared_ptr<IceInternal::OutgoingAsyncT<" + returnT + ">>& outAsync";
     C << inParamsImplDecl << "const Ice::Context& context";
     C << epar << " const";
     C << sb;
-    C << nl << "static constexpr ::std::string_view operationName = \"" << p->name() << "\";";
+    C << nl << "static constexpr std::string_view operationName = \"" << p->name() << "\";";
     C << sp;
     if (p->returnsData())
     {
@@ -1973,24 +1973,24 @@ Slice::Gen::DataDefVisitor::visitStructEnd(const StructPtr& p)
     H << sp;
     H << nl << "/// Outputs the name and value of each field of this instance to the stream.";
     H << nl << "/// @param os The output stream.";
-    H << nl << _dllExport << "void ice_printFields(::std::ostream& os) const;";
+    H << nl << _dllExport << "void ice_printFields(std::ostream& os) const;";
     H << eb << ';';
 
     const string scoped = p->mappedScoped();
 
     C << sp << nl << "void";
-    C << nl << scoped.substr(2) << "::ice_printFields(::std::ostream& os) const";
+    C << nl << scoped.substr(2) << "::ice_printFields(std::ostream& os) const";
     C << sb;
     printFields(p->dataMembers(), true);
     C << eb;
 
-    H << sp << nl << _dllExport << "::std::ostream& operator<<(::std::ostream&, const " << p->mappedName() << "&);";
+    H << sp << nl << _dllExport << "std::ostream& operator<<(std::ostream&, const " << p->mappedName() << "&);";
 
     if (!p->hasMetadata("cpp:custom-print"))
     {
         // We generate the implementation unless custom-print tells us not to.
-        C << sp << nl << "::std::ostream&";
-        C << nl << p->mappedScope().substr(2) << "operator<<(::std::ostream& os, const " << scoped << "& value)";
+        C << sp << nl << "std::ostream&";
+        C << nl << p->mappedScope().substr(2) << "operator<<(std::ostream& os, const " << scoped << "& value)";
         C << sb;
         C << sp << nl << "os << \"" << scoped.substr(2) << "{\";";
         C << nl << "value.ice_printFields(os);";
@@ -2335,7 +2335,7 @@ Slice::Gen::DataDefVisitor::visitClassDefStart(const ClassDefPtr& p)
     H << sp;
     H << nl << "/// Creates a shallow polymorphic copy of this instance.";
     H << nl << "/// @return The cloned value.";
-    H << nl << "[[nodiscard]] " << name << "Ptr ice_clone() const { return ::std::static_pointer_cast<" << name
+    H << nl << "[[nodiscard]] " << name << "Ptr ice_clone() const { return std::static_pointer_cast<" << name
       << ">(_iceCloneImpl()); }";
 
     return true;
@@ -2658,23 +2658,23 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     H << nl << "/// Obtains a list of the Slice type IDs representing the interfaces supported by this object.";
     H << nl << "/// @param current The Current object for the invocation.";
     H << nl << "/// @return A list of fully-scoped type IDs.";
-    H << nl << "[[nodiscard]] ::std::vector<::std::string> ice_ids(const Ice::Current& current) const override;";
+    H << nl << "[[nodiscard]] std::vector<std::string> ice_ids(const Ice::Current& current) const override;";
     H << sp;
     H << nl << "/// Obtains a Slice type ID representing the most-derived interface supported by this object.";
     H << nl << "/// @param current The Current object for the invocation.";
     H << nl << "/// @return A fully-scoped type ID.";
-    H << nl << "[[nodiscard]] ::std::string ice_id(const Ice::Current& current) const override;";
+    H << nl << "[[nodiscard]] std::string ice_id(const Ice::Current& current) const override;";
     H << sp;
     H << nl << "/// Obtains the Slice type ID corresponding to this interface.";
     H << nl << "/// @return A fully-scoped type ID.";
     H << nl << "static const char* ice_staticId() noexcept;";
 
     C << sp;
-    C << nl << "::std::vector<::std::string>" << nl << scoped.substr(2) << "::ice_ids(const Ice::Current&) const";
+    C << nl << "std::vector<std::string>" << nl << scoped.substr(2) << "::ice_ids(const Ice::Current&) const";
     C << sb;
 
     // These type IDs are sorted alphabetically.
-    C << nl << "static const ::std::vector<::std::string> allTypeIds = ";
+    C << nl << "static const std::vector<std::string> allTypeIds = ";
     C.spar('{');
     for (const auto& typeId : p->ids())
     {
@@ -2687,9 +2687,9 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     C << eb;
 
     C << sp;
-    C << nl << "::std::string" << nl << scoped.substr(2) << "::ice_id(const Ice::Current&) const";
+    C << nl << "std::string" << nl << scoped.substr(2) << "::ice_id(const Ice::Current&) const";
     C << sb;
-    C << nl << "return ::std::string{ice_staticId()};";
+    C << nl << "return std::string{ice_staticId()};";
     C << eb;
 
     C << sp;
@@ -2724,7 +2724,7 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         H << sp;
         H << nl << "/// \\cond INTERNAL";
         H << nl
-          << "void dispatch(Ice::IncomingRequest&, ::std::function<void(Ice::OutgoingResponse)>) "
+          << "void dispatch(Ice::IncomingRequest&, std::function<void(Ice::OutgoingResponse)>) "
              "override;";
         H << nl << "/// \\endcond";
 
@@ -2732,12 +2732,12 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         C << nl << "/// \\cond INTERNAL";
         C << nl << "void";
         C << nl << scoped.substr(2)
-          << "::dispatch(Ice::IncomingRequest& request, ::std::function<void(Ice::OutgoingResponse)> "
+          << "::dispatch(Ice::IncomingRequest& request, std::function<void(Ice::OutgoingResponse)> "
              "sendResponse)";
         C << sb;
 
         C << sp;
-        C << nl << "static constexpr ::std::array<::std::string_view, " << allOpNames.size() << "> allOperations";
+        C << nl << "static constexpr std::array<std::string_view, " << allOpNames.size() << "> allOperations";
         C.spar('{');
         for (const auto& opName : allOpNames)
         {
@@ -2748,11 +2748,11 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 
         C << sp;
         C << nl << "const Ice::Current& current = request.current();";
-        C << nl << "auto r = ::std::equal_range(allOperations.begin(), allOperations.end(), current.operation);";
+        C << nl << "auto r = std::equal_range(allOperations.begin(), allOperations.end(), current.operation);";
         C << nl << "if (r.first == r.second)";
         C << sb;
         C << nl
-          << "sendResponse(Ice::makeOutgoingResponse(::std::make_exception_ptr(Ice::OperationNotExistException{__"
+          << "sendResponse(Ice::makeOutgoingResponse(std::make_exception_ptr(Ice::OperationNotExistException{__"
              "FILE__, __LINE__}), current));";
         C << nl << "return;";
         C << eb;
@@ -2764,7 +2764,7 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         {
             C << nl << "case " << i++ << ':';
             C << sb;
-            C << nl << "_iceD_" << opName << "(request, ::std::move(sendResponse));";
+            C << nl << "_iceD_" << opName << "(request, std::move(sendResponse));";
             C << nl << "break;";
             C << eb;
         }
@@ -2772,7 +2772,7 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         C << sb;
         C << nl << "assert(false);";
         C << nl
-          << "sendResponse(Ice::makeOutgoingResponse(::std::make_exception_ptr(Ice::OperationNotExistException{__"
+          << "sendResponse(Ice::makeOutgoingResponse(std::make_exception_ptr(Ice::OperationNotExistException{__"
              "FILE__, __LINE__}), current));";
         C << eb;
         C << eb;
@@ -2782,7 +2782,7 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 
     H << eb << ';';
 
-    H << sp << nl << "using " << name << "Ptr = ::std::shared_ptr<" << name << ">;";
+    H << sp << nl << "using " << name << "Ptr = std::shared_ptr<" << name << ">;";
 
     _useWstring = resetUseWstring(_useWstringHist);
 }
@@ -2894,19 +2894,19 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
         if (p->hasMarshaledResult())
         {
             string resultName = marshaledResultStructName(name);
-            params.push_back("::std::function<void(" + resultName + ")> " + responsecbParam);
+            params.push_back("std::function<void(" + resultName + ")> " + responsecbParam);
             args.push_back(
                 "[responseHandler](" + resultName +
-                " marshaledResult) { responseHandler->sendResponse(::std::move(marshaledResult)); }");
+                " marshaledResult) { responseHandler->sendResponse(std::move(marshaledResult)); }");
         }
         else
         {
-            params.push_back("::std::function<void(" + joinString(responseParams, ", ") + ")> " + responsecbParam);
+            params.push_back("std::function<void(" + joinString(responseParams, ", ") + ")> " + responsecbParam);
             args.emplace_back(
-                ret || !outParams.empty() ? "::std::move(responseCb)"
+                ret || !outParams.empty() ? "std::move(responseCb)"
                                           : "[responseHandler] { responseHandler->sendEmptyResponse(); }");
         }
-        params.push_back("::std::function<void(::std::exception_ptr)> " + excbParam);
+        params.push_back("std::function<void(std::exception_ptr)> " + excbParam);
         args.emplace_back("[responseHandler](std::exception_ptr ex) { "
                           "responseHandler->sendException(ex); }");
         params.push_back(currentDecl);
@@ -2992,7 +2992,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
     }
     H << nl << noDiscard << "virtual " << retS << ' ' << opName << spar << params << epar << isConst << " = 0;";
     H << nl << "/// \\cond INTERNAL";
-    H << nl << "void _iceD_" << p->name() << "(Ice::IncomingRequest&, ::std::function<void(Ice::OutgoingResponse)>)"
+    H << nl << "void _iceD_" << p->name() << "(Ice::IncomingRequest&, std::function<void(Ice::OutgoingResponse)>)"
       << isConst << ';';
     H << nl << "/// \\endcond";
 
@@ -3001,7 +3001,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
     C << nl << "void";
     C << nl << scope.substr(2) << "_iceD_" << p->name() << "(";
     C.inc();
-    C << nl << "Ice::IncomingRequest& request," << nl << "::std::function<void(Ice::OutgoingResponse)> sendResponse)"
+    C << nl << "Ice::IncomingRequest& request," << nl << "std::function<void(Ice::OutgoingResponse)> sendResponse)"
       << isConst;
 
     if (!amd)
@@ -3088,7 +3088,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
     {
         C << nl
           << "auto responseHandler = "
-             "::std::make_shared<IceInternal::AsyncResponseHandler>(::std::move(sendResponse), request.current());";
+             "std::make_shared<IceInternal::AsyncResponseHandler>(std::move(sendResponse), request.current());";
         if (!p->hasMarshaledResult() && (ret || !outParams.empty()))
         {
             C << nl << "auto responseCb = [responseHandler]" << spar << responseParamsDecl << epar;
@@ -3118,7 +3118,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
         C << eb;
         C << nl << "catch (...)";
         C << sb;
-        C << nl << "responseHandler->sendException(::std::current_exception());";
+        C << nl << "responseHandler->sendException(std::current_exception());";
         C << eb;
     }
     C << eb;

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -271,7 +271,7 @@ Slice::Ruby::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     }
     else
     {
-        _out << " < ::Ice::Value";
+        _out << " < Ice::Value";
     }
     _out.inc();
 

--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -55,7 +55,7 @@ namespace
             }
             case ThrowType::StandardException:
             {
-                throw ::std::bad_alloc();
+                throw std::bad_alloc();
                 break;
             }
             case ThrowType::OtherException:

--- a/cpp/test/Ice/custom/Test.ice
+++ b/cpp/test/Ice/custom/Test.ice
@@ -16,17 +16,17 @@ sequence<BoolList> BoolListSeq;
 
 ["cpp:type:std::list<::Test::BoolSeq>"] sequence<BoolSeq> BoolSeqList;
 
-["cpp:type:std::list<::std::deque<bool>>"] sequence<["cpp:type:std::deque<bool>"] BoolSeq> BoolDequeList;
+["cpp:type:std::list<std::deque<bool>>"] sequence<["cpp:type:std::deque<bool>"] BoolSeq> BoolDequeList;
 
 sequence<byte> ByteSeq;
-["cpp:type:std::list<::std::byte>"] sequence<byte> ByteList;
+["cpp:type:std::list<std::byte>"] sequence<byte> ByteList;
 
 ["cpp:type:std::list<::Test::ByteList>"] sequence<ByteList> ByteListList;
 sequence<ByteList> ByteListSeq;
 ["cpp:type:std::list<::Test::ByteSeq>"] sequence<ByteSeq> ByteSeqList;
 
 sequence<string> StringSeq;
-["cpp:type:std::list<::std::string>"] sequence<string> StringList;
+["cpp:type:std::list<std::string>"] sequence<string> StringList;
 
 ["cpp:type:std::list<::Test::StringList>"] sequence<StringList> StringListList;
 sequence<StringList> StringListSeq;
@@ -48,7 +48,7 @@ struct Variable
 {
     string s;
     BoolList bl;
-    ["cpp:type:std::list<::std::string>"] StringSeq ss;
+    ["cpp:type:std::list<std::string>"] StringSeq ss;
 }
 
 sequence<Variable> VariableSeq;
@@ -76,7 +76,7 @@ sequence<EList> EListSeq;
 
 class C {}
 sequence<C> CSeq;
-["cpp:type:std::list<::std::shared_ptr<::Test::C>>"] sequence<C> CList;
+["cpp:type:std::list<std::shared_ptr<::Test::C>>"] sequence<C> CList;
 
 ["cpp:type:std::list<::Test::CList>"] sequence<CList> CListList;
 sequence<CList> CListSeq;
@@ -84,7 +84,7 @@ sequence<CList> CListSeq;
 
 interface D {}
 sequence<D*> DPrxSeq;
-["cpp:type:std::list<::std::optional<::Test::DPrx>>"] sequence<D*> DPrxList;
+["cpp:type:std::list<std::optional<::Test::DPrx>>"] sequence<D*> DPrxList;
 
 ["cpp:type:std::list<::Test::DPrxList>"] sequence<DPrxList> DPrxListList;
 sequence<DPrxList> DPrxListSeq;
@@ -93,7 +93,7 @@ sequence<DPrxList> DPrxListSeq;
 sequence<double> DoubleSeq;
 sequence<short> ShortSeq;
 
-["cpp:type:Test::CustomMap<::std::int32_t, std::string>"] dictionary<int, string> IntStringDict;
+["cpp:type:Test::CustomMap<std::int32_t, std::string>"] dictionary<int, string> IntStringDict;
 dictionary<long, long> LongLongDict;
 dictionary<string, int> StringIntDict;
 
@@ -103,12 +103,12 @@ class DictClass
 }
 
 ["cpp:type:Test::CustomBuffer<bool>"] sequence<bool> BoolBuffer;
-["cpp:type:Test::CustomBuffer<::std::int16_t>"] sequence<short> ShortBuffer;
-["cpp:type:Test::CustomBuffer<::std::int32_t>"] sequence<int> IntBuffer;
+["cpp:type:Test::CustomBuffer<std::int16_t>"] sequence<short> ShortBuffer;
+["cpp:type:Test::CustomBuffer<std::int32_t>"] sequence<int> IntBuffer;
 ["cpp:type:Test::CustomBuffer<int64_t>"] sequence<long> LongBuffer;
 ["cpp:type:Test::CustomBuffer<float>"] sequence<float> FloatBuffer;
 ["cpp:type:Test::CustomBuffer<double>"] sequence<double> DoubleBuffer;
-["cpp:type:Test::CustomBuffer<::std::byte>"] sequence<byte> ByteBuffer;
+["cpp:type:Test::CustomBuffer<std::byte>"] sequence<byte> ByteBuffer;
 struct BufferStruct
 {
     ByteBuffer byteBuf;
@@ -141,18 +141,18 @@ interface TestIntf
     ["cpp:array"] BoolDequeList opBoolDequeListArray(["cpp:array"] BoolDequeList inSeq,
                                                 out ["cpp:array"] BoolDequeList outSeq);
 
-    ["cpp:type:std::deque<::std::byte>"] ByteSeq
-    opByteSeq(["cpp:type:std::deque<::std::byte>"] ByteSeq inSeq,
-              out ["cpp:type:std::deque<::std::byte>"] ByteSeq outSeq);
+    ["cpp:type:std::deque<std::byte>"] ByteSeq
+    opByteSeq(["cpp:type:std::deque<std::byte>"] ByteSeq inSeq,
+              out ["cpp:type:std::deque<std::byte>"] ByteSeq outSeq);
 
     ByteList opByteList(ByteList inSeq, out ByteList outSeq);
 
     ["cpp:type:MyByteSeq"] ByteSeq
     opMyByteSeq(["cpp:type:MyByteSeq"] ByteSeq inSeq, out ["cpp:type:MyByteSeq"] ByteSeq outSeq);
 
-    ["cpp:type:std::deque<::std::string>"] StringSeq
-    opStringSeq(["cpp:type:std::deque<::std::string>"] StringSeq inSeq,
-                out ["cpp:type:std::deque<::std::string>"] StringSeq outSeq);
+    ["cpp:type:std::deque<std::string>"] StringSeq
+    opStringSeq(["cpp:type:std::deque<std::string>"] StringSeq inSeq,
+                out ["cpp:type:std::deque<std::string>"] StringSeq outSeq);
 
     StringList opStringList(StringList inSeq, out StringList outSeq);
 
@@ -179,15 +179,15 @@ interface TestIntf
 
     EList opEList(EList inSeq, out EList outSeq);
 
-    ["cpp:type:std::deque<::std::optional<::Test::DPrx>>"] DPrxSeq
-    opDPrxSeq(["cpp:type:std::deque<::std::optional<::Test::DPrx>>"] DPrxSeq inSeq,
-              out ["cpp:type:std::deque<::std::optional<::Test::DPrx>>"] DPrxSeq outSeq);
+    ["cpp:type:std::deque<std::optional<::Test::DPrx>>"] DPrxSeq
+    opDPrxSeq(["cpp:type:std::deque<std::optional<::Test::DPrx>>"] DPrxSeq inSeq,
+              out ["cpp:type:std::deque<std::optional<::Test::DPrx>>"] DPrxSeq outSeq);
 
     DPrxList opDPrxList(DPrxList inSeq, out DPrxList outSeq);
 
-    ["cpp:type:std::deque<::std::shared_ptr<Test::C>>"] CSeq
-    opCSeq(["cpp:type:std::deque<::std::shared_ptr<Test::C>>"] CSeq inSeq,
-           out ["cpp:type:std::deque<::std::shared_ptr<Test::C>>"] CSeq outSeq);
+    ["cpp:type:std::deque<std::shared_ptr<Test::C>>"] CSeq
+    opCSeq(["cpp:type:std::deque<std::shared_ptr<Test::C>>"] CSeq inSeq,
+           out ["cpp:type:std::deque<std::shared_ptr<Test::C>>"] CSeq outSeq);
 
     CList opCList(CList inSeq, out CList outSeq);
 
@@ -196,8 +196,8 @@ interface TestIntf
     IntStringDict opIntStringDict(IntStringDict idict, out IntStringDict odict);
 
     ["cpp:type:::Test::CustomMap< int64_t, int64_t>"] LongLongDict
-    opVarDict(["cpp:type:::Test::CustomMap<::std::string, std::int32_t>"] StringIntDict idict,
-              out ["cpp:type:::Test::CustomMap<::std::string, std::int32_t>"] StringIntDict odict);
+    opVarDict(["cpp:type:::Test::CustomMap<std::string, std::int32_t>"] StringIntDict idict,
+              out ["cpp:type:::Test::CustomMap<std::string, std::int32_t>"] StringIntDict odict);
 
     ShortBuffer opShortBuffer(ShortBuffer inS, out ShortBuffer outS);
 

--- a/cpp/test/Ice/custom/TestAMD.ice
+++ b/cpp/test/Ice/custom/TestAMD.ice
@@ -81,7 +81,7 @@ sequence<CList> CListSeq;
 
 interface D{}
 sequence<D*> DPrxSeq;
-["cpp:type:std::list<::std::optional<::Test::DPrx>>"] sequence<D*> DPrxList;
+["cpp:type:std::list<std::optional<::Test::DPrx>>"] sequence<D*> DPrxList;
 
 ["cpp:type:std::list<::Test::DPrxList>"] sequence<DPrxList> DPrxListList;
 sequence<DPrxList> DPrxListSeq;
@@ -172,9 +172,9 @@ struct BufferStruct
 
     EList opEList(EList inSeq, out EList outSeq);
 
-    ["cpp:type:std::deque<::std::optional<::Test::DPrx>>"] DPrxSeq
-    opDPrxSeq(["cpp:type:std::deque<::std::optional<::Test::DPrx>>"] DPrxSeq inSeq,
-              out ["cpp:type:std::deque<::std::optional<::Test::DPrx>>"] DPrxSeq outSeq);
+    ["cpp:type:std::deque<std::optional<::Test::DPrx>>"] DPrxSeq
+    opDPrxSeq(["cpp:type:std::deque<std::optional<::Test::DPrx>>"] DPrxSeq inSeq,
+              out ["cpp:type:std::deque<std::optional<::Test::DPrx>>"] DPrxSeq outSeq);
 
     DPrxList opDPrxList(DPrxList inSeq, out DPrxList outSeq);
 

--- a/cpp/test/Ice/custom/WstringI.cpp
+++ b/cpp/test/Ice/custom/WstringI.cpp
@@ -2,8 +2,8 @@
 
 #include "WstringI.h"
 
-::std::wstring
-Test1::WstringClassI::opString(::std::wstring s1, ::std::wstring& s2, const Ice::Current&)
+std::wstring
+Test1::WstringClassI::opString(std::wstring s1, std::wstring& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
@@ -17,15 +17,15 @@ Test1::WstringClassI::opStruct(::Test1::WstringStruct s1, ::Test1::WstringStruct
 }
 
 void
-Test1::WstringClassI::throwExcept(::std::wstring reason, const Ice::Current&)
+Test1::WstringClassI::throwExcept(std::wstring reason, const Ice::Current&)
 {
     Test1::WstringException ex;
     ex.reason = reason;
     throw ex;
 }
 
-::std::wstring
-Test2::WstringClassI::opString(::std::wstring s1, ::std::wstring& s2, const Ice::Current&)
+std::wstring
+Test2::WstringClassI::opString(std::wstring s1, std::wstring& s2, const Ice::Current&)
 {
     s2 = s1;
     return s1;
@@ -39,7 +39,7 @@ Test2::WstringClassI::opStruct(::Test2::WstringStruct s1, ::Test2::WstringStruct
 }
 
 void
-Test2::WstringClassI::throwExcept(::std::wstring reason, const Ice::Current&)
+Test2::WstringClassI::throwExcept(std::wstring reason, const Ice::Current&)
 {
     Test2::WstringException ex;
     ex.reason = reason;

--- a/cpp/test/Ice/operations/TestI.cpp
+++ b/cpp/test/Ice/operations/TestI.cpp
@@ -235,7 +235,7 @@ MyDerivedClassI::opStringSS(Test::StringSS p1, Test::StringSS p2, Test::StringSS
 }
 
 Test::StringSSS
-MyDerivedClassI::opStringSSS(Test::StringSSS p1, Test::StringSSS p2, Test::StringSSS& p3, const ::Ice::Current&)
+MyDerivedClassI::opStringSSS(Test::StringSSS p1, Test::StringSSS p2, Test::StringSSS& p3, const Ice::Current&)
 {
     p3 = p1;
     std::copy(p2.begin(), p2.end(), std::back_inserter(p3));

--- a/cpp/test/Ice/optional/TestAMDI.cpp
+++ b/cpp/test/Ice/optional/TestAMDI.cpp
@@ -18,8 +18,8 @@ InitialI::shutdownAsync(function<void()> response, function<void(exception_ptr)>
 
 void
 InitialI::pingPongAsync(
-    shared_ptr<::Ice::Value> obj,
-    function<void(const shared_ptr<::Ice::Value>&)> response,
+    shared_ptr<Ice::Value> obj,
+    function<void(const shared_ptr<Ice::Value>&)> response,
     function<void(exception_ptr)>,
     const Ice::Current&)
 {

--- a/cpp/test/Ice/plugin/Client.cpp
+++ b/cpp/test/Ice/plugin/Client.cpp
@@ -36,7 +36,7 @@ namespace
 
 extern "C"
 {
-    Ice::Plugin* createMyPlugin(const ::Ice::CommunicatorPtr&, const std::string&, const ::Ice::StringSeq&)
+    Ice::Plugin* createMyPlugin(const Ice::CommunicatorPtr&, const std::string&, const Ice::StringSeq&)
     {
         return new MyPlugin();
     }

--- a/cpp/test/Ice/plugin/Plugin.cpp
+++ b/cpp/test/Ice/plugin/Plugin.cpp
@@ -245,13 +245,13 @@ namespace
     };
 }
 
-extern "C" ICE_DECLSPEC_EXPORT ::Ice::Plugin*
+extern "C" ICE_DECLSPEC_EXPORT Ice::Plugin*
 createPlugin(const Ice::CommunicatorPtr& communicator, const string&, const Ice::StringSeq&)
 {
     return new Plugin(communicator);
 }
 
-extern "C" ICE_DECLSPEC_EXPORT ::Ice::Plugin*
+extern "C" ICE_DECLSPEC_EXPORT Ice::Plugin*
 createPluginWithArgs(const Ice::CommunicatorPtr& communicator, const string&, const Ice::StringSeq& args)
 {
     test(args.size() == 3);
@@ -261,43 +261,43 @@ createPluginWithArgs(const Ice::CommunicatorPtr& communicator, const string&, co
     return new Plugin(communicator);
 }
 
-extern "C" ICE_DECLSPEC_EXPORT ::Ice::Plugin*
+extern "C" ICE_DECLSPEC_EXPORT Ice::Plugin*
 createPluginInitializeFail(const Ice::CommunicatorPtr& communicator, const string&, const Ice::StringSeq&)
 {
     return new PluginInitializeFail(communicator);
 }
 
-extern "C" ICE_DECLSPEC_EXPORT ::Ice::Plugin*
+extern "C" ICE_DECLSPEC_EXPORT Ice::Plugin*
 createPluginOne(const Ice::CommunicatorPtr& communicator, const string&, const Ice::StringSeq&)
 {
     return new PluginOne(communicator);
 }
 
-extern "C" ICE_DECLSPEC_EXPORT ::Ice::Plugin*
+extern "C" ICE_DECLSPEC_EXPORT Ice::Plugin*
 createPluginTwo(const Ice::CommunicatorPtr& communicator, const string&, const Ice::StringSeq&)
 {
     return new PluginTwo(communicator);
 }
 
-extern "C" ICE_DECLSPEC_EXPORT ::Ice::Plugin*
+extern "C" ICE_DECLSPEC_EXPORT Ice::Plugin*
 createPluginThree(const Ice::CommunicatorPtr& communicator, const string&, const Ice::StringSeq&)
 {
     return new PluginThree(communicator);
 }
 
-extern "C" ICE_DECLSPEC_EXPORT ::Ice::Plugin*
+extern "C" ICE_DECLSPEC_EXPORT Ice::Plugin*
 createPluginOneFail(const Ice::CommunicatorPtr& communicator, const string&, const Ice::StringSeq&)
 {
     return new PluginOneFail(communicator);
 }
 
-extern "C" ICE_DECLSPEC_EXPORT ::Ice::Plugin*
+extern "C" ICE_DECLSPEC_EXPORT Ice::Plugin*
 createPluginTwoFail(const Ice::CommunicatorPtr& communicator, const string&, const Ice::StringSeq&)
 {
     return new PluginTwoFail(communicator);
 }
 
-extern "C" ICE_DECLSPEC_EXPORT ::Ice::Plugin*
+extern "C" ICE_DECLSPEC_EXPORT Ice::Plugin*
 createPluginThreeFail(const Ice::CommunicatorPtr& communicator, const string&, const Ice::StringSeq&)
 {
     return new PluginThreeFail(communicator);

--- a/cpp/test/Ice/retry/AllTests.cpp
+++ b/cpp/test/Ice/retry/AllTests.cpp
@@ -42,7 +42,7 @@ class CallbackSuccess : public CallbackBase
 public:
     void response() { called(); }
 
-    void exception(const ::Ice::Exception&) { test(false); }
+    void exception(const Ice::Exception&) { test(false); }
 };
 using CallbackSuccessPtr = shared_ptr<CallbackSuccess>;
 
@@ -51,7 +51,7 @@ class CallbackFail : public CallbackBase
 public:
     void response() { test(false); }
 
-    void exception(const ::Ice::Exception& ex)
+    void exception(const Ice::Exception& ex)
     {
         test(
             dynamic_cast<const Ice::ConnectionLostException*>(&ex) ||

--- a/cpp/test/Ice/slicing/exceptions/TestAMDI.cpp
+++ b/cpp/test/Ice/slicing/exceptions/TestAMDI.cpp
@@ -226,7 +226,7 @@ TestI::unknownMostDerived2AsBaseAsync(function<void()>, function<void(exception_
 }
 
 void
-TestI::shutdownAsync(function<void()> response, function<void(exception_ptr)>, const ::Ice::Current& current)
+TestI::shutdownAsync(function<void()> response, function<void(exception_ptr)>, const Ice::Current& current)
 {
     current.adapter->getCommunicator()->shutdown();
     response();

--- a/cpp/test/Ice/slicing/objects/AllTests.cpp
+++ b/cpp/test/Ice/slicing/objects/AllTests.cpp
@@ -151,7 +151,7 @@ namespace
     class Callback : public CallbackBase
     {
     public:
-        void response_SBaseAsObject(const ::Ice::ValuePtr& o)
+        void response_SBaseAsObject(const Ice::ValuePtr& o)
         {
             test(o);
             test(string{o->ice_id()} == "::Test::SBase");
@@ -389,7 +389,7 @@ namespace
             called();
         }
 
-        void exception_throwBaseAsBase(const ::Ice::Exception& ex)
+        void exception_throwBaseAsBase(const Ice::Exception& ex)
         {
             test(string{ex.ice_id()} == "::Test::BaseException");
             const auto& e = dynamic_cast<const BaseException&>(ex);
@@ -401,7 +401,7 @@ namespace
             breakCycles(e.pb);
         }
 
-        void exception_throwDerivedAsBase(const ::Ice::Exception& ex)
+        void exception_throwDerivedAsBase(const Ice::Exception& ex)
         {
             test(string{ex.ice_id()} == "::Test::DerivedException");
             const auto& e = dynamic_cast<const DerivedException&>(ex);
@@ -418,7 +418,7 @@ namespace
             called();
         }
 
-        void exception_throwDerivedAsDerived(const ::Ice::Exception& ex)
+        void exception_throwDerivedAsDerived(const Ice::Exception& ex)
         {
             test(string{ex.ice_id()} == "::Test::DerivedException");
             const auto& e = dynamic_cast<const DerivedException&>(ex);
@@ -435,7 +435,7 @@ namespace
             called();
         }
 
-        void exception_throwUnknownDerivedAsBase(const ::Ice::Exception& ex)
+        void exception_throwUnknownDerivedAsBase(const Ice::Exception& ex)
         {
             test(string{ex.ice_id()} == "::Test::BaseException");
             const auto& e = dynamic_cast<const BaseException&>(ex);
@@ -543,7 +543,7 @@ namespace
 
         void response() { test(false); }
 
-        void exception(const ::Ice::Exception& ex)
+        void exception(const Ice::Exception& ex)
         {
             if (!dynamic_cast<const Ice::OperationNotExistException*>(&ex))
             {
@@ -1986,7 +1986,7 @@ allTests(Test::TestHelper* helper)
             breakCycles(ss.c1);
             breakCycles(ss.c2);
         }
-        catch (const ::Ice::Exception&)
+        catch (const Ice::Exception&)
         {
             test(false);
         }
@@ -2087,7 +2087,7 @@ allTests(Test::TestHelper* helper)
             breakCycles(ss.c1);
             breakCycles(ss.c2);
         }
-        catch (const ::Ice::Exception&)
+        catch (const Ice::Exception&)
         {
             test(false);
         }
@@ -2148,7 +2148,7 @@ allTests(Test::TestHelper* helper)
             breakCycles(bout);
             breakCycles(r);
         }
-        catch (const ::Ice::Exception&)
+        catch (const Ice::Exception&)
         {
             test(false);
         }
@@ -2211,7 +2211,7 @@ allTests(Test::TestHelper* helper)
             breakCycles(bout);
             breakCycles(r);
         }
-        catch (const ::Ice::Exception&)
+        catch (const Ice::Exception&)
         {
             test(false);
         }

--- a/cpp/test/Ice/slicing/objects/TestAMDI.cpp
+++ b/cpp/test/Ice/slicing/objects/TestAMDI.cpp
@@ -13,7 +13,7 @@ void
 TestI::SBaseAsObjectAsync(
     function<void(const Ice::ValuePtr&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto sb = make_shared<SBase>();
     sb->sb = "SBase.sb";
@@ -24,7 +24,7 @@ void
 TestI::SBaseAsSBaseAsync(
     function<void(const shared_ptr<Test::SBase>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto sb = make_shared<SBase>();
     sb->sb = "SBase.sb";
@@ -35,7 +35,7 @@ void
 TestI::SBSKnownDerivedAsSBaseAsync(
     function<void(const shared_ptr<Test::SBase>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto sbskd = make_shared<SBSKnownDerived>();
     sbskd->sb = "SBSKnownDerived.sb";
@@ -47,7 +47,7 @@ void
 TestI::SBSKnownDerivedAsSBSKnownDerivedAsync(
     function<void(const shared_ptr<Test::SBSKnownDerived>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto sbskd = make_shared<SBSKnownDerived>();
     sbskd->sb = "SBSKnownDerived.sb";
@@ -59,7 +59,7 @@ void
 TestI::SBSUnknownDerivedAsSBaseAsync(
     function<void(const shared_ptr<Test::SBase>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto sbsud = make_shared<SBSUnknownDerived>();
     sbsud->sb = "SBSUnknownDerived.sb";
@@ -71,7 +71,7 @@ void
 TestI::SBSUnknownDerivedAsSBaseCompactAsync(
     function<void(const shared_ptr<Test::SBase>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto sbsud = make_shared<SBSUnknownDerived>();
     sbsud->sb = "SBSUnknownDerived.sb";
@@ -83,7 +83,7 @@ void
 TestI::SUnknownAsObjectAsync(
     function<void(const Ice::ValuePtr&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto su = make_shared<SUnknown>();
     su->su = "SUnknown.su";
@@ -96,7 +96,7 @@ TestI::checkSUnknownAsync(
     Ice::ValuePtr obj,
     function<void()> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current& current)
+    const Ice::Current& current)
 {
     auto su = dynamic_pointer_cast<SUnknown>(obj);
     if (current.encoding == Ice::Encoding_1_0)
@@ -115,7 +115,7 @@ void
 TestI::oneElementCycleAsync(
     function<void(const shared_ptr<Test::B>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto b = make_shared<B>();
     b->sb = "B1.sb";
@@ -127,7 +127,7 @@ void
 TestI::twoElementCycleAsync(
     function<void(const shared_ptr<Test::B>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto b1 = make_shared<B>();
     b1->sb = "B1.sb";
@@ -142,7 +142,7 @@ void
 TestI::D1AsBAsync(
     function<void(const shared_ptr<Test::B>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto d1 = make_shared<D1>();
     d1->sb = "D1.sb";
@@ -161,7 +161,7 @@ void
 TestI::D1AsD1Async(
     function<void(const shared_ptr<Test::D1>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto d1 = make_shared<D1>();
     d1->sb = "D1.sb";
@@ -180,7 +180,7 @@ void
 TestI::D2AsBAsync(
     function<void(const shared_ptr<Test::B>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto d2 = make_shared<D2>();
     d2->sb = "D2.sb";
@@ -199,7 +199,7 @@ void
 TestI::paramTest1Async(
     function<void(const shared_ptr<Test::B>&, const shared_ptr<Test::B>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto d1 = make_shared<D1>();
     d1->sb = "D1.sb";
@@ -218,7 +218,7 @@ void
 TestI::paramTest2Async(
     function<void(const shared_ptr<Test::B>&, const shared_ptr<Test::B>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto d1 = make_shared<D1>();
     d1->sb = "D1.sb";
@@ -237,7 +237,7 @@ void
 TestI::paramTest3Async(
     function<void(const shared_ptr<Test::B>&, const shared_ptr<Test::B>&, const shared_ptr<Test::B>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto d2 = make_shared<D2>();
     d2->sb = "D2.sb (p1 1)";
@@ -270,7 +270,7 @@ void
 TestI::paramTest4Async(
     function<void(const shared_ptr<Test::B>&, const shared_ptr<Test::B>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto d4 = make_shared<D4>();
     d4->sb = "D4.sb (1)";
@@ -286,7 +286,7 @@ void
 TestI::returnTest1Async(
     function<void(const shared_ptr<Test::B>&, const shared_ptr<Test::B>&, const shared_ptr<Test::B>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto d1 = make_shared<D1>();
     d1->sb = "D1.sb";
@@ -305,7 +305,7 @@ void
 TestI::returnTest2Async(
     function<void(const shared_ptr<Test::B>&, const shared_ptr<Test::B>&, const shared_ptr<Test::B>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto d1 = make_shared<D1>();
     d1->sb = "D1.sb";
@@ -326,7 +326,7 @@ TestI::returnTest3Async(
     shared_ptr<::Test::B>,
     function<void(const shared_ptr<Test::B>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     response(p1);
 }
@@ -337,7 +337,7 @@ TestI::sequenceTestAsync(
     shared_ptr<::Test::SS2> p2,
     function<void(const ::Test::SS3&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     SS3 ss;
     ss.c1 = std::move(p1);
@@ -350,7 +350,7 @@ TestI::dictionaryTestAsync(
     Test::BDict bin,
     function<void(const ::Test::BDict&, const ::Test::BDict&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     BDict bout;
     int i;
@@ -384,7 +384,7 @@ TestI::exchangePBaseAsync(
     shared_ptr<::Test::PBase> pb,
     function<void(const shared_ptr<::Test::PBase>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     response(pb);
 }
@@ -393,7 +393,7 @@ void
 TestI::PBSUnknownAsPreservedAsync(
     function<void(const shared_ptr<::Test::Preserved>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current& current)
+    const Ice::Current& current)
 {
     auto r = make_shared<PSUnknown>();
     r->pi = 5;
@@ -416,7 +416,7 @@ TestI::checkPBSUnknownAsync(
     shared_ptr<::Test::Preserved> p,
     function<void()> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current& current)
+    const Ice::Current& current)
 {
     auto pu = dynamic_pointer_cast<PSUnknown>(p);
     if (current.encoding == Ice::Encoding_1_0)
@@ -441,7 +441,7 @@ void
 TestI::PBSUnknownAsPreservedWithGraphAsync(
     function<void(const shared_ptr<::Test::Preserved>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto r = make_shared<PSUnknown>();
     r->pi = 5;
@@ -460,7 +460,7 @@ TestI::checkPBSUnknownWithGraphAsync(
     shared_ptr<::Test::Preserved> p,
     function<void()> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current& current)
+    const Ice::Current& current)
 {
     auto pu = dynamic_pointer_cast<PSUnknown>(p);
     if (current.encoding == Ice::Encoding_1_0)
@@ -487,7 +487,7 @@ void
 TestI::PBSUnknown2AsPreservedWithGraphAsync(
     function<void(const shared_ptr<::Test::Preserved>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto r = make_shared<PSUnknown2>();
     r->pi = 5;
@@ -502,7 +502,7 @@ TestI::checkPBSUnknown2WithGraphAsync(
     shared_ptr<::Test::Preserved> p,
     function<void()> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current& current)
+    const Ice::Current& current)
 {
     auto pu = dynamic_pointer_cast<PSUnknown2>(p);
     if (current.encoding == Ice::Encoding_1_0)
@@ -527,13 +527,13 @@ TestI::exchangePNodeAsync(
     shared_ptr<::Test::PNode> pn,
     function<void(const shared_ptr<::Test::PNode>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     response(pn);
 }
 
 void
-TestI::throwBaseAsBaseAsync(function<void()>, function<void(exception_ptr)> exception, const ::Ice::Current&)
+TestI::throwBaseAsBaseAsync(function<void()>, function<void(exception_ptr)> exception, const Ice::Current&)
 {
     try
     {
@@ -551,7 +551,7 @@ TestI::throwBaseAsBaseAsync(function<void()>, function<void(exception_ptr)> exce
 }
 
 void
-TestI::throwDerivedAsBaseAsync(function<void()>, function<void(exception_ptr)> exception, const ::Ice::Current&)
+TestI::throwDerivedAsBaseAsync(function<void()>, function<void(exception_ptr)> exception, const Ice::Current&)
 {
     try
     {
@@ -575,7 +575,7 @@ TestI::throwDerivedAsBaseAsync(function<void()>, function<void(exception_ptr)> e
 }
 
 void
-TestI::throwDerivedAsDerivedAsync(function<void()>, function<void(exception_ptr)> exception, const ::Ice::Current&)
+TestI::throwDerivedAsDerivedAsync(function<void()>, function<void(exception_ptr)> exception, const Ice::Current&)
 {
     try
     {
@@ -599,7 +599,7 @@ TestI::throwDerivedAsDerivedAsync(function<void()>, function<void(exception_ptr)
 }
 
 void
-TestI::throwUnknownDerivedAsBaseAsync(function<void()>, function<void(exception_ptr)> exception, const ::Ice::Current&)
+TestI::throwUnknownDerivedAsBaseAsync(function<void()>, function<void(exception_ptr)> exception, const Ice::Current&)
 {
     try
     {
@@ -626,7 +626,7 @@ void
 TestI::useForwardAsync(
     function<void(const shared_ptr<::Test::Forward>&)> response,
     function<void(exception_ptr)>,
-    const ::Ice::Current&)
+    const Ice::Current&)
 {
     auto f = make_shared<Forward>();
     f->h = make_shared<Hidden>();
@@ -635,7 +635,7 @@ TestI::useForwardAsync(
 }
 
 void
-TestI::shutdownAsync(function<void()> response, function<void(exception_ptr)>, const ::Ice::Current& current)
+TestI::shutdownAsync(function<void()> response, function<void(exception_ptr)>, const Ice::Current& current)
 {
     current.adapter->getCommunicator()->shutdown();
     response();

--- a/cpp/test/Ice/slicing/objects/TestI.cpp
+++ b/cpp/test/Ice/slicing/objects/TestI.cpp
@@ -143,7 +143,7 @@ TestI::~TestI()
 }
 
 Ice::ValuePtr
-TestI::SBaseAsObject(const ::Ice::Current&)
+TestI::SBaseAsObject(const Ice::Current&)
 {
     SBasePtr sb = make_shared<SBase>();
     sb->sb = "SBase.sb";
@@ -151,7 +151,7 @@ TestI::SBaseAsObject(const ::Ice::Current&)
 }
 
 SBasePtr
-TestI::SBaseAsSBase(const ::Ice::Current&)
+TestI::SBaseAsSBase(const Ice::Current&)
 {
     SBasePtr sb = make_shared<SBase>();
     sb->sb = "SBase.sb";
@@ -159,7 +159,7 @@ TestI::SBaseAsSBase(const ::Ice::Current&)
 }
 
 SBasePtr
-TestI::SBSKnownDerivedAsSBase(const ::Ice::Current&)
+TestI::SBSKnownDerivedAsSBase(const Ice::Current&)
 {
     SBSKnownDerivedPtr sbskd = make_shared<SBSKnownDerived>();
     sbskd->sb = "SBSKnownDerived.sb";
@@ -168,7 +168,7 @@ TestI::SBSKnownDerivedAsSBase(const ::Ice::Current&)
 }
 
 SBSKnownDerivedPtr
-TestI::SBSKnownDerivedAsSBSKnownDerived(const ::Ice::Current&)
+TestI::SBSKnownDerivedAsSBSKnownDerived(const Ice::Current&)
 {
     SBSKnownDerivedPtr sbskd = make_shared<SBSKnownDerived>();
     sbskd->sb = "SBSKnownDerived.sb";
@@ -177,7 +177,7 @@ TestI::SBSKnownDerivedAsSBSKnownDerived(const ::Ice::Current&)
 }
 
 SBasePtr
-TestI::SBSUnknownDerivedAsSBase(const ::Ice::Current&)
+TestI::SBSUnknownDerivedAsSBase(const Ice::Current&)
 {
     SBSUnknownDerivedPtr sbsud = make_shared<SBSUnknownDerived>();
     sbsud->sb = "SBSUnknownDerived.sb";
@@ -186,7 +186,7 @@ TestI::SBSUnknownDerivedAsSBase(const ::Ice::Current&)
 }
 
 SBasePtr
-TestI::SBSUnknownDerivedAsSBaseCompact(const ::Ice::Current&)
+TestI::SBSUnknownDerivedAsSBaseCompact(const Ice::Current&)
 {
     SBSUnknownDerivedPtr sbsud = make_shared<SBSUnknownDerived>();
     sbsud->sb = "SBSUnknownDerived.sb";
@@ -195,7 +195,7 @@ TestI::SBSUnknownDerivedAsSBaseCompact(const ::Ice::Current&)
 }
 
 Ice::ValuePtr
-TestI::SUnknownAsObject(const ::Ice::Current&)
+TestI::SUnknownAsObject(const Ice::Current&)
 {
     SUnknownPtr su = make_shared<SUnknown>();
     su->su = "SUnknown.su";
@@ -205,7 +205,7 @@ TestI::SUnknownAsObject(const ::Ice::Current&)
 }
 
 void
-TestI::checkSUnknown(Ice::ValuePtr obj, const ::Ice::Current& current)
+TestI::checkSUnknown(Ice::ValuePtr obj, const Ice::Current& current)
 {
     SUnknownPtr su = dynamic_pointer_cast<SUnknown>(obj);
     if (current.encoding == Ice::Encoding_1_0)
@@ -221,7 +221,7 @@ TestI::checkSUnknown(Ice::ValuePtr obj, const ::Ice::Current& current)
 }
 
 BPtr
-TestI::oneElementCycle(const ::Ice::Current&)
+TestI::oneElementCycle(const Ice::Current&)
 {
     BPtr b = make_shared<B>();
     b->sb = "B1.sb";
@@ -231,7 +231,7 @@ TestI::oneElementCycle(const ::Ice::Current&)
 }
 
 BPtr
-TestI::twoElementCycle(const ::Ice::Current&)
+TestI::twoElementCycle(const Ice::Current&)
 {
     BPtr b1 = make_shared<B>();
     b1->sb = "B1.sb";
@@ -244,7 +244,7 @@ TestI::twoElementCycle(const ::Ice::Current&)
 }
 
 BPtr
-TestI::D1AsB(const ::Ice::Current&)
+TestI::D1AsB(const Ice::Current&)
 {
     D1Ptr d1 = make_shared<D1>();
     d1->sb = "D1.sb";
@@ -261,7 +261,7 @@ TestI::D1AsB(const ::Ice::Current&)
 }
 
 D1Ptr
-TestI::D1AsD1(const ::Ice::Current&)
+TestI::D1AsD1(const Ice::Current&)
 {
     D1Ptr d1 = make_shared<D1>();
     d1->sb = "D1.sb";
@@ -278,7 +278,7 @@ TestI::D1AsD1(const ::Ice::Current&)
 }
 
 BPtr
-TestI::D2AsB(const ::Ice::Current&)
+TestI::D2AsB(const Ice::Current&)
 {
     D2Ptr d2 = make_shared<D2>();
     d2->sb = "D2.sb";
@@ -296,7 +296,7 @@ TestI::D2AsB(const ::Ice::Current&)
 }
 
 void
-TestI::paramTest1(BPtr& p1, BPtr& p2, const ::Ice::Current&)
+TestI::paramTest1(BPtr& p1, BPtr& p2, const Ice::Current&)
 {
     D1Ptr d1 = make_shared<D1>();
     d1->sb = "D1.sb";
@@ -314,14 +314,14 @@ TestI::paramTest1(BPtr& p1, BPtr& p2, const ::Ice::Current&)
 }
 
 void
-TestI::paramTest2(BPtr& p1, BPtr& p2, const ::Ice::Current&)
+TestI::paramTest2(BPtr& p1, BPtr& p2, const Ice::Current&)
 {
-    ::Ice::Current c;
+    Ice::Current c;
     paramTest1(p2, p1, c);
 }
 
 BPtr
-TestI::paramTest3(BPtr& p1, BPtr& p2, const ::Ice::Current&)
+TestI::paramTest3(BPtr& p1, BPtr& p2, const Ice::Current&)
 {
     D2Ptr d2 = make_shared<D2>();
     d2->sb = "D2.sb (p1 1)";
@@ -358,7 +358,7 @@ TestI::paramTest3(BPtr& p1, BPtr& p2, const ::Ice::Current&)
 }
 
 BPtr
-TestI::paramTest4(BPtr& p1, const ::Ice::Current&)
+TestI::paramTest4(BPtr& p1, const Ice::Current&)
 {
     D4Ptr d4 = make_shared<D4>();
     d4->sb = "D4.sb (1)";
@@ -373,23 +373,23 @@ TestI::paramTest4(BPtr& p1, const ::Ice::Current&)
 }
 
 BPtr
-TestI::returnTest1(BPtr& p1, BPtr& p2, const ::Ice::Current&)
+TestI::returnTest1(BPtr& p1, BPtr& p2, const Ice::Current&)
 {
-    ::Ice::Current c;
+    Ice::Current c;
     paramTest1(p1, p2, c);
     return p1;
 }
 
 BPtr
-TestI::returnTest2(BPtr& p1, BPtr& p2, const ::Ice::Current&)
+TestI::returnTest2(BPtr& p1, BPtr& p2, const Ice::Current&)
 {
-    ::Ice::Current c;
+    Ice::Current c;
     paramTest1(p2, p1, c);
     return p1;
 }
 
 BPtr
-TestI::returnTest3(BPtr p1, BPtr p2, const ::Ice::Current&)
+TestI::returnTest3(BPtr p1, BPtr p2, const Ice::Current&)
 {
     _values.push_back(p1);
     _values.push_back(p2);
@@ -397,7 +397,7 @@ TestI::returnTest3(BPtr p1, BPtr p2, const ::Ice::Current&)
 }
 
 SS3
-TestI::sequenceTest(SS1Ptr p1, SS2Ptr p2, const ::Ice::Current&)
+TestI::sequenceTest(SS1Ptr p1, SS2Ptr p2, const Ice::Current&)
 {
     SS3 ss;
     ss.c1 = p1;
@@ -408,7 +408,7 @@ TestI::sequenceTest(SS1Ptr p1, SS2Ptr p2, const ::Ice::Current&)
 }
 
 Test::BDict
-TestI::dictionaryTest(BDict bin, BDict& bout, const ::Ice::Current&)
+TestI::dictionaryTest(BDict bin, BDict& bout, const Ice::Current&)
 {
     int i;
     for (i = 0; i < 10; ++i)
@@ -569,7 +569,7 @@ TestI::exchangePNode(Test::PNodePtr pn, const Ice::Current&)
 }
 
 void
-TestI::throwBaseAsBase(const ::Ice::Current&)
+TestI::throwBaseAsBase(const Ice::Current&)
 {
     BaseException be;
     be.sbe = "sbe";
@@ -581,7 +581,7 @@ TestI::throwBaseAsBase(const ::Ice::Current&)
 }
 
 void
-TestI::throwDerivedAsBase(const ::Ice::Current&)
+TestI::throwDerivedAsBase(const Ice::Current&)
 {
     DerivedException de;
     de.sbe = "sbe";
@@ -600,7 +600,7 @@ TestI::throwDerivedAsBase(const ::Ice::Current&)
 }
 
 void
-TestI::throwDerivedAsDerived(const ::Ice::Current&)
+TestI::throwDerivedAsDerived(const Ice::Current&)
 {
     DerivedException de;
     de.sbe = "sbe";
@@ -619,7 +619,7 @@ TestI::throwDerivedAsDerived(const ::Ice::Current&)
 }
 
 void
-TestI::throwUnknownDerivedAsBase(const ::Ice::Current&)
+TestI::throwUnknownDerivedAsBase(const Ice::Current&)
 {
     D2Ptr d2 = make_shared<D2>();
     d2->sb = "sb d2";
@@ -636,7 +636,7 @@ TestI::throwUnknownDerivedAsBase(const ::Ice::Current&)
 }
 
 void
-TestI::useForward(ForwardPtr& f, const ::Ice::Current&)
+TestI::useForward(ForwardPtr& f, const Ice::Current&)
 {
     f = make_shared<Forward>();
     f->h = make_shared<Hidden>();
@@ -645,7 +645,7 @@ TestI::useForward(ForwardPtr& f, const ::Ice::Current&)
 }
 
 void
-TestI::shutdown(const ::Ice::Current& current)
+TestI::shutdown(const Ice::Current& current)
 {
     current.adapter->getCommunicator()->shutdown();
 }

--- a/cpp/test/Slice/errorDetection/WarningInvalidMetadata.ice
+++ b/cpp/test/Slice/errorDetection/WarningInvalidMetadata.ice
@@ -59,7 +59,7 @@ class Container
 
 interface I
 {
-    ["cpp:type:std::list<::std::string>"]
+    ["cpp:type:std::list<std::string>"]
     void op1();
 
     ["cpp:array"]

--- a/cpp/test/Slice/escape/Client.cpp
+++ b/cpp/test/Slice/escape/Client.cpp
@@ -10,8 +10,8 @@ using namespace std;
 class breakI : public cpp_and::_cpp_break
 {
 public:
-    void _cpp_caseAsync(::int32_t, function<void(int)> response, function<void(exception_ptr)>, const ::Ice::Current&)
-        override
+    void
+    _cpp_caseAsync(::int32_t, function<void(int)> response, function<void(exception_ptr)>, const Ice::Current&) override
     {
         response(0);
     }
@@ -25,21 +25,20 @@ public:
 class switchI : public cpp_and::_cpp_switch
 {
 public:
-    virtual void foo(optional<cpp_and::_cpp_breakPrx>, int32_t&, const ::Ice::Current&) {}
+    virtual void foo(optional<cpp_and::_cpp_breakPrx>, int32_t&, const Ice::Current&) {}
 };
 
 class doI : public cpp_and::_cpp_do
 {
 public:
     void
-    _cpp_caseAsync(int, ::std::function<void(int)>, ::std::function<void(::std::exception_ptr)>, const ::Ice::Current&)
-        override
+    _cpp_caseAsync(int, std::function<void(int)>, std::function<void(std::exception_ptr)>, const Ice::Current&) override
     {
     }
 
-    void _cpp_explicit(const ::Ice::Current&) override {}
+    void _cpp_explicit(const Ice::Current&) override {}
 
-    virtual void foo(const cpp_and::_cpp_breakPrx&, int32_t&, const ::Ice::Current&) {}
+    virtual void foo(const cpp_and::_cpp_breakPrx&, int32_t&, const Ice::Current&) {}
 };
 
 class friendI : public cpp_and::_cpp_friend
@@ -53,7 +52,7 @@ public:
         optional<cpp_and::_cpp_breakPrx>,
         cpp_and::_cpp_switchPtr,
         ::int32_t,
-        const ::Ice::Current&) override
+        const Ice::Current&) override
     {
         return {};
     }

--- a/php/src/Types.h
+++ b/php/src/Types.h
@@ -71,7 +71,7 @@ namespace IcePHP
         ReadObjectCallback(const ClassInfoPtr&, const UnmarshalCallbackPtr&, zval*, void*);
         ~ReadObjectCallback();
 
-        void invoke(const ::std::shared_ptr<Ice::Value>&);
+        void invoke(const std::shared_ptr<Ice::Value>&);
 
     private:
         ClassInfoPtr _info;

--- a/python/modules/IcePy/Types.h
+++ b/python/modules/IcePy/Types.h
@@ -74,7 +74,7 @@ namespace IcePy
         ReadValueCallback(const ValueInfoPtr&, const UnmarshalCallbackPtr&, PyObject*, void*);
         ~ReadValueCallback();
 
-        void invoke(const ::std::shared_ptr<Ice::Value>&);
+        void invoke(const std::shared_ptr<Ice::Value>&);
 
     private:
         ValueInfoPtr _info;

--- a/ruby/src/IceRuby/Types.h
+++ b/ruby/src/IceRuby/Types.h
@@ -76,7 +76,7 @@ namespace IceRuby
     public:
         ReadValueCallback(const ClassInfoPtr&, const UnmarshalCallbackPtr&, VALUE, void*);
 
-        void invoke(const ::std::shared_ptr<Ice::Value>&);
+        void invoke(const std::shared_ptr<Ice::Value>&);
 
     private:
         ClassInfoPtr _info;

--- a/ruby/src/IceRuby/Util.h
+++ b/ruby/src/IceRuby/Util.h
@@ -484,7 +484,7 @@ namespace IceRuby
 
 #define ICE_RUBY_CATCH                                                                                                 \
     catch (const ::IceRuby::RubyException& ex) { ICE_RUBY_RETHROW(ex.ex); }                                            \
-    catch (const ::std::bad_alloc& ex) { ICE_RUBY_RETHROW(rb_exc_new2(rb_eNoMemError, ex.what())); }                   \
+    catch (const std::bad_alloc& ex) { ICE_RUBY_RETHROW(rb_exc_new2(rb_eNoMemError, ex.what())); }                     \
     catch (...) { ICE_RUBY_RETHROW(convertException(current_exception())); }
 
 #endif

--- a/swift/src/IceImpl/Convert.h
+++ b/swift/src/IceImpl/Convert.h
@@ -35,7 +35,7 @@ toObjC(const std::string& s)
 inline void
 fromObjC(id object, std::string& s)
 {
-    s = object == [NSNull null] ? ::std::string() : [object UTF8String];
+    s = object == [NSNull null] ? std::string() : [object UTF8String];
 }
 
 NSObject* toObjC(const std::shared_ptr<Ice::Endpoint>& endpoint);


### PR DESCRIPTION
This PR removes :: in front of namespace std and namespace Ice (C++).