### PR TITLE
Add Support for `cs:attribute` on Enumerators

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1877,6 +1877,7 @@ Slice::CsGenerator::validateMetadata(const UnitPtr& u)
              typeid(Slice::Exception),
              typeid(Struct),
              typeid(Enum),
+             typeid(Enumerator),
              typeid(Const),
              typeid(Parameter),
              typeid(DataMember)},

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1529,6 +1529,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
             _out << ',';
         }
         writeDocComment(*en);
+        emitAttributes(*en);
         _out << nl << fixId((*en)->name());
         if (hasExplicitValues)
         {


### PR DESCRIPTION
This PR implements #3246.
The only item left to do for it was allowing `cs:attribute` on enumerators and generating the corresponding code.
Which this PR does!