### PR TITLE
Move `definitionContext` up from `SyntaxTreeBase` to `Contained`

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -709,24 +709,12 @@ Slice::SyntaxTreeBase::unit() const
     return _unit;
 }
 
-DefinitionContextPtr
-Slice::SyntaxTreeBase::definitionContext() const
-{
-    return _definitionContext;
-}
-
 void
 Slice::SyntaxTreeBase::visit(ParserVisitor* /*visitor*/)
 {
 }
 
-Slice::SyntaxTreeBase::SyntaxTreeBase(UnitPtr unit) : _unit(std::move(unit))
-{
-    if (_unit)
-    {
-        _definitionContext = _unit->currentDefinitionContext();
-    }
-}
+Slice::SyntaxTreeBase::SyntaxTreeBase(UnitPtr unit) : _unit(std::move(unit)) {}
 
 // ----------------------------------------------------------------------
 // Type
@@ -890,11 +878,7 @@ Slice::Builtin::kindFromString(string_view str)
     return nullopt;
 }
 
-Slice::Builtin::Builtin(const UnitPtr& unit, Kind kind) : SyntaxTreeBase(unit), Type(unit), _kind(kind)
-{
-    // Builtin types do not have a definition context.
-    _definitionContext = nullptr;
-}
+Slice::Builtin::Builtin(const UnitPtr& unit, Kind kind) : SyntaxTreeBase(unit), Type(unit), _kind(kind) {}
 
 // ----------------------------------------------------------------------
 // Contained
@@ -985,6 +969,12 @@ int
 Slice::Contained::includeLevel() const
 {
     return _includeLevel;
+}
+
+DefinitionContextPtr
+Slice::Contained::definitionContext() const
+{
+    return _definitionContext;
 }
 
 MetadataList
@@ -1086,6 +1076,7 @@ Slice::Contained::Contained(const ContainerPtr& container, string name)
     _line = _unit->currentLine();
     _docComment = _unit->currentDocComment();
     _includeLevel = _unit->currentIncludeLevel();
+    _definitionContext = _unit->currentDefinitionContext();
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -313,12 +313,10 @@ namespace Slice
         SyntaxTreeBase(UnitPtr unit);
         virtual void destroy();
         [[nodiscard]] UnitPtr unit() const;
-        [[nodiscard]] DefinitionContextPtr definitionContext() const; // May be nil
         virtual void visit(ParserVisitor* visitor);
 
     protected:
         UnitPtr _unit;
-        DefinitionContextPtr _definitionContext;
     };
 
     // ----------------------------------------------------------------------
@@ -410,6 +408,7 @@ namespace Slice
         [[nodiscard]] std::string docComment() const;
 
         [[nodiscard]] int includeLevel() const;
+        [[nodiscard]] DefinitionContextPtr definitionContext() const;
 
         [[nodiscard]] virtual MetadataList getMetadata() const;
         virtual void setMetadata(MetadataList metadata);
@@ -439,6 +438,7 @@ namespace Slice
         int _line;
         std::string _docComment;
         int _includeLevel;
+        DefinitionContextPtr _definitionContext;
         MetadataList _metadata;
     };
 


### PR DESCRIPTION
`DefinitionContext` provides information about the file-scope a Slice definition is contained in.
It's mostly for checking file-metadata, but there's other niche things we do with it.

Right now it's defined on `SyntaxTreeBase`, but this is the wrong place to put it.
This includes types like `Unit` and `Builtin`. Calling `definitionContext` on these always gives `nullptr`, because they aren't "Slice definitions".

So, this PR moves this method down the inheritance tree and onto `Contained`, which is what we would consider a "Slice definition".

----

This PR is a step towards #3358.