### PR TITLE
Add Publish target for C# builds and upgrade NuGet packages

### DIFF
--- a/csharp/BUILDING.md
+++ b/csharp/BUILDING.md
@@ -1,8 +1,7 @@
 # Building Ice for .NET
 
-This page describes how to build Ice for .NET from source and package the
-resulting binaries. As an alternative, you can download and install the
-[zeroc.ice.net][1] NuGet package.
+This page describes how to build Ice for .NET from source and package the resulting binaries. As an alternative, you
+can download and install the [zeroc.ice.net][1] NuGet package.
 
 * [Building on Windows](#building-on-windows)
   * [Windows Build Requirements](#windows-build-requirements)
@@ -45,12 +44,6 @@ msbuild msbuild\ice.proj
 
 Upon completion, the Ice assemblies for .NET 8.0 are placed in the `lib\net8.0` folder.
 
-You can skip the build of the test suite with the `BuildDist` target:
-
-```shell
-msbuild msbuild\ice.proj /t:BuildDist
-```
-
 #### Authenticode Signatures
 
 You can sign the Ice binaries with Authenticode by setting the following
@@ -84,44 +77,40 @@ dotnet msbuild msbuild/ice.proj
 
 Upon completion, the Ice assemblies are placed in the `lib/net8.0` directory.
 
-You can skip the build of the test suite with the `BuildDist` target:
-
-```shell
-dotnet msbuild msbuild/ice.proj /t:BuildDist
-```
-
 ## Running the Tests
 
-Python is required to run the test suite. Additionally, the Glacier2 tests
-require the Python module `passlib`, which you can install with the command:
+Python is required to run the test suite. Additionally, the Glacier2 tests require the Python module `passlib`, which
+you can install with the command:
 
 ```shell
 pip install passlib
 ```
 
-To run the tests, open a command window and change to the top-level directory.
-At the command prompt, execute:
+To run the tests, open a command window and change to the top-level directory. At the command prompt, execute:
 
 ```shell
 python allTests.py
 ```
 
-If everything worked out, you should see lots of `ok` messages. In case of a
-failure, the tests abort with `failed`.
+If everything worked out, you should see lots of `ok` messages. In case of a failure, the tests abort with `failed`.
 
 ## NuGet Package
 
 ### Creating NuGet Packages on Windows
 
-To create a NuGet package, open a Visual Studio command prompt and run the
-following command:
+To create a NuGet package, open a Visual Studio command prompt and run the following command:
 
 ```shell
 msbuild msbuild\ice.proj /t:NuGetPack
 ```
 
-This creates the `zeroc.ice.net` Nuget package in the `msbuild\zeroc.ice.net`
-directory.
+This creates the `zeroc.ice.net` Nuget package in the `msbuild\zeroc.ice.net` directory.
+
+You can publish the package to your local `global-packages` source with the following command:
+
+```shell
+msbuild msbuild\ice.proj /t:Publish
+```
 
 ### Creating NuGet Packages on Linux or macOS
 
@@ -131,8 +120,13 @@ To create a NuGet package, open a command prompt and run the following command:
 dotnet msbuild msbuild/ice.proj /t:NuGetPack
 ```
 
-This creates the `zeroc.ice.net` Nuget package in the `msbuild/zeroc.ice.net`
-directory.
+This creates the `zeroc.ice.net` Nuget package in the `msbuild/zeroc.ice.net` directory.
+
+You can publish the package to your local `global-packages` source with the following command:
+
+```shell
+dotnet msbuild msbuild\ice.proj /t:Publish
+```
 
 [1]: https://zeroc.com/downloads/ice
 [2]: https://dotnet.microsoft.com/en-us/download/dotnet/8.0

--- a/csharp/msbuild/ice.proj
+++ b/csharp/msbuild/ice.proj
@@ -58,8 +58,6 @@
                  Properties="%(Properties)"/>
     </Target>
 
-    <Target Name="BuildDist" DependsOnTargets="Build"></Target>
-
     <Target Name="Clean">
         <MSBuild Projects="@(SolutionFile)"
                  BuildInParallel="true"
@@ -120,4 +118,18 @@
     </Target>
 
     <Target Name="NuGetPack" DependsOnTargets="WindowsNuGetPack;UnixNuGetPack" />
+
+    <Target Name="Publish" DependsOnTargets="NuGetPack">
+        <Exec Command="dotnet nuget locals --list global-packages" ConsoleToMSBuild="true" EchoOff="yes">
+            <Output TaskParameter="ConsoleOutput" PropertyName="NuGetGlobalPackages" />
+        </Exec>
+        <PropertyGroup>
+            <NuGetGlobalPackages>$(NuGetGlobalPackages.TrimStart('info : '))</NuGetGlobalPackages>
+            <NuGetGlobalPackages>$(NuGetGlobalPackages.TrimStart('global-packages: '))</NuGetGlobalPackages>
+        </PropertyGroup>
+
+        <RemoveDir Directories="$(NuGetGlobalPackages)\zeroc.ice.net\$(IceJSONVersion)"
+            Condition="Exists('$(NuGetGlobalPackages)\zeroc.ice.net\$(IceJSONVersion)')"/>
+        <Exec Command="dotnet nuget push $(MSBuildThisFileDirectory)zeroc.ice.net\zeroc.ice.net.$(IceJSONVersion).nupkg --source $(NuGetGlobalPackages)" />
+    </Target>
 </Project>

--- a/csharp/msbuild/ice.proj
+++ b/csharp/msbuild/ice.proj
@@ -58,6 +58,8 @@
                  Properties="%(Properties)"/>
     </Target>
 
+    <Target Name="BuildDist" DependsOnTargets="Build"></Target>
+
     <Target Name="Clean">
         <MSBuild Projects="@(SolutionFile)"
                  BuildInParallel="true"

--- a/csharp/msbuild/icebuilder.csharp.props
+++ b/csharp/msbuild/icebuilder.csharp.props
@@ -35,8 +35,4 @@
     <PropertyGroup Condition="Exists('$(IceHome)\cpp\bin\Win32\Debug\slice2cs.exe')  And '$(IceToolsPath)' == ''">
         <IceToolsPath>$(IceHome)\cpp\bin\Win32\Debug</IceToolsPath>
     </PropertyGroup>
-
-    <PropertyGroup>
-        <IceAssembliesDir>$(IceHome)\csharp\lib\net45</IceAssembliesDir>
-    </PropertyGroup>
 </Project>

--- a/csharp/msbuild/zeroc.ice.net.csproj
+++ b/csharp/msbuild/zeroc.ice.net.csproj
@@ -32,19 +32,19 @@
             <Pack>true</Pack>
         </Content>
 
-        <Content Include="..\lib\net6.0\*.dll">
-            <Pack>true</Pack>
-            <PackagePath>lib\net6.0</PackagePath>
-        </Content>
-
         <Content Include="..\lib\net8.0\*.dll">
             <Pack>true</Pack>
             <PackagePath>lib\net8.0</PackagePath>
         </Content>
 
-        <Content Include="..\bin\$(AppTargetFramework)\publish\*" Exclude="..\bin\$(AppTargetFramework)\publish\iceboxnet">
+        <Content Include="..\bin\net8.0\publish\*" Exclude="..\bin\net8.0\publish\iceboxnet">
             <Pack>true</Pack>
-            <PackagePath>tools\$(AppTargetFramework)</PackagePath>
+            <PackagePath>tools\net8.0</PackagePath>
+        </Content>
+
+         <Content Include="..\..\cpp\bin\slice2cs">
+            <Pack>true</Pack>
+            <PackagePath>tools\</PackagePath>
         </Content>
 
         <Content Include="..\..\slice\**\*.ice"

--- a/csharp/msbuild/zeroc.ice.net.props
+++ b/csharp/msbuild/zeroc.ice.net.props
@@ -8,33 +8,6 @@
         <IceSoVersion>38</IceSoVersion>
         <IceHome>$(MSBuildThisFileDirectory)..</IceHome>
         <IceAssembliesDir>$(IceHome)\lib</IceAssembliesDir>
+        <IceToolsPath>$(IceHome)\tools</IceToolsPath>
     </PropertyGroup>
-
-    <Choose>
-        <When Condition="'$(IceToolsPath)' == ''">
-            <Choose>
-                <When Condition="'$(OS)' == 'Windows_NT'">
-                    <PropertyGroup>
-                        <IceToolsPath>$(IceHome)\tools</IceToolsPath>
-                    </PropertyGroup>
-                </When>
-                <When Condition="Exists('/usr/bin/slice2cs')">
-                    <PropertyGroup>
-                        <IceToolsPath>/usr/bin</IceToolsPath>
-                    </PropertyGroup>
-                </When>
-                <When Condition="Exists('/usr/local/bin/slice2cs')">
-                    <PropertyGroup>
-                        <IceToolsPath>/usr/local/bin</IceToolsPath>
-                    </PropertyGroup>
-                </When>
-                <!-- For Homebrew on macOS with Apple Silicon   -->
-                <When Condition="Exists('/opt/homebrew/bin/slice2cs')">
-                    <PropertyGroup>
-                        <IceToolsPath>/opt/homebrew/bin</IceToolsPath>
-                    </PropertyGroup>
-                </When>
-            </Choose>
-        </When>
-    </Choose>
 </Project>


### PR DESCRIPTION
This PR upgrades C# NuGet packages to include slice2cs compiler in all builds. The PR also adds a new MSBuild target `Publish` to publish the NuGet package to the local `global-packages` source. 

The BUILDING.md has been updated to reflect this changes.