### PR TITLE
Fix DataStorm clang-tidy lints

### DIFF
--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -1360,20 +1360,23 @@ namespace DataStorm
         std::function<void(std::vector<Key>)> init,
         std::function<void(CallbackReason, Key)> update) noexcept
     {
-        _impl->onConnectedKeys(init ? [init](const std::vector<std::shared_ptr<DataStormI::Key>>& connectedKeys)
-    {
-        std::vector<Key> keys;
-        keys.reserve(connectedKeys.size());
-        for(const auto& k : connectedKeys)
-        {
-            keys.push_back(std::static_pointer_cast<DataStormI::KeyT<Key>>(k)->get());
-        }
-        init(std::move(keys));
-    } : std::function<void(std::vector<std::shared_ptr<DataStormI::Key>>)>(),
-    update ? [update](CallbackReason action, std::shared_ptr<DataStormI::Key> key)
-    {
-        update(action, std::static_pointer_cast<DataStormI::KeyT<Key>>(key)->get());
-    } : std::function<void(CallbackReason, std::shared_ptr<DataStormI::Key>)>());
+        _impl->onConnectedKeys(
+            init ?
+            [init = std::move(init)](const std::vector<std::shared_ptr<DataStormI::Key>>& connectedKeys)
+            {
+                std::vector<Key> keys;
+                keys.reserve(connectedKeys.size());
+                for(const auto& k : connectedKeys)
+                {
+                    keys.push_back(std::static_pointer_cast<DataStormI::KeyT<Key>>(k)->get());
+                }
+                init(std::move(keys));
+            } : std::function<void(std::vector<std::shared_ptr<DataStormI::Key>>)>{},
+            update ?
+            [update = std::move(update)](CallbackReason action, const std::shared_ptr<DataStormI::Key>& key)
+            {
+                update(action, std::static_pointer_cast<DataStormI::KeyT<Key>>(key)->get());
+            } : std::function<void(CallbackReason, std::shared_ptr<DataStormI::Key>)>{});
     }
 
     template<typename Key, typename Value, typename UpdateTag>
@@ -1390,20 +1393,23 @@ namespace DataStorm
         std::function<void(Sample<Key, Value, UpdateTag>)> update) noexcept
     {
         auto communicator = _impl->getCommunicator();
-        _impl->onSamples(init ? [communicator, init](const std::vector<std::shared_ptr<DataStormI::Sample>>& samplesI)
-    {
-        std::vector<Sample<Key, Value, UpdateTag>> samples;
-        samples.reserve(samplesI.size());
-        for(const auto& s : samplesI)
-        {
-            samples.emplace_back(s);
-        }
-        init(std::move(samples));
-    } : std::function<void(const std::vector<std::shared_ptr<DataStormI::Sample>>&)>(),
-    update ? [communicator, update](const std::shared_ptr<DataStormI::Sample>& sampleI)
-    {
-        update(sampleI);
-    } : std::function<void(const std::shared_ptr<DataStormI::Sample>&)>());
+        _impl->onSamples(
+            init ?
+            [communicator, init = std::move(init)](const std::vector<std::shared_ptr<DataStormI::Sample>>& samplesI)
+            {
+                std::vector<Sample<Key, Value, UpdateTag>> samples;
+                samples.reserve(samplesI.size());
+                for(const auto& s : samplesI)
+                {
+                    samples.emplace_back(s);
+                }
+                init(std::move(samples));
+            } : std::function<void(const std::vector<std::shared_ptr<DataStormI::Sample>>&)>(),
+            update ?
+            [communicator, update = std::move(update)](const std::shared_ptr<DataStormI::Sample>& sampleI)
+            {
+                update(sampleI);
+            } : std::function<void(const std::shared_ptr<DataStormI::Sample>&)>{});
     }
 
     template<typename Key, typename Value, typename UpdateTag>
@@ -1629,20 +1635,23 @@ namespace DataStorm
         std::function<void(std::vector<Key>)> init,
         std::function<void(CallbackReason, Key)> update) noexcept
     {
-        _impl->onConnectedKeys(init ? [init](const std::vector<std::shared_ptr<DataStormI::Key>>& connectedKeys)
-    {
-        std::vector<Key> keys;
-        keys.reserve(connectedKeys.size());
-        for(const auto& k : connectedKeys)
-        {
-            keys.push_back(std::static_pointer_cast<DataStormI::KeyT<Key>>(k)->get());
-        }
-        init(std::move(keys));
-    } : std::function<void(std::vector<std::shared_ptr<DataStormI::Key>>)>(),
-    update ? [update](CallbackReason action, std::shared_ptr<DataStormI::Key> key)
-    {
-        update(action, std::static_pointer_cast<DataStormI::KeyT<Key>>(key)->get());
-    } : std::function<void(CallbackReason, std::shared_ptr<DataStormI::Key>)>());
+        _impl->onConnectedKeys(
+            init ?
+            [init = std::move(init)](const std::vector<std::shared_ptr<DataStormI::Key>>& connectedKeys)
+            {
+                std::vector<Key> keys;
+                keys.reserve(connectedKeys.size());
+                for(const auto& k : connectedKeys)
+                {
+                    keys.push_back(std::static_pointer_cast<DataStormI::KeyT<Key>>(k)->get());
+                }
+                init(std::move(keys));
+            } : std::function<void(std::vector<std::shared_ptr<DataStormI::Key>>)>{},
+            update ?
+            [update = std::move(update)](CallbackReason action, const std::shared_ptr<DataStormI::Key>& key)
+            {
+                update(action, std::static_pointer_cast<DataStormI::KeyT<Key>>(key)->get());
+            } : std::function<void(CallbackReason, std::shared_ptr<DataStormI::Key>)>{});
     }
 
     template<typename Key, typename Value, typename UpdateTag>
@@ -1820,13 +1829,13 @@ namespace DataStorm
     /** @private */
     template<typename T, typename V, typename Enabler = void> struct RegexFilter
     {
-        template<typename F> static void add(F) {}
+        template<typename F> static void add(const F&) {}
     };
 
     /** @private */
     template<typename T, typename V> struct RegexFilter<T, V, std::enable_if_t<DataStormI::is_streamable<V>::value>>
     {
-        template<typename F> static void add(F factory)
+        template<typename F> static void add(const F& factory)
         {
             factory->set("_regex", makeRegexFilter<T>()); // Only set the _regex filter if the value is streamable
         }
@@ -1943,21 +1952,23 @@ namespace DataStorm
     {
         std::lock_guard<std::mutex> lock(_mutex);
         auto tagI = _tagFactory->create(std::move(tag));
-        auto updaterImpl = updater ? [updater](const std::shared_ptr<DataStormI::Sample>& previous,
+        auto updaterImpl =
+            updater ?
+            [updater = std::move(updater)](const std::shared_ptr<DataStormI::Sample>& previous,
                                            const std::shared_ptr<DataStormI::Sample>& next,
                                            const Ice::CommunicatorPtr& communicator)
-    {
-        Value value;
-        if (previous)
-        {
-            value = Cloner<Value>::clone(
-                std::static_pointer_cast<DataStormI::SampleT<Key, Value, UpdateTag>>(previous)->getValue());
-        }
-        updater(value, Decoder<UpdateValue>::decode(communicator, next->getEncodedValue()));
-        std::static_pointer_cast<DataStormI::SampleT<Key, Value, UpdateTag>>(next)->setValue(std::move(value));
-    } : std::function<void(const std::shared_ptr<DataStormI::Sample>&,
-                           const std::shared_ptr<DataStormI::Sample>&,
-                           const Ice::CommunicatorPtr&)>();
+            {
+                Value value;
+                if (previous)
+                {
+                    value = Cloner<Value>::clone(
+                        std::static_pointer_cast<DataStormI::SampleT<Key, Value, UpdateTag>>(previous)->getValue());
+                }
+                updater(value, Decoder<UpdateValue>::decode(communicator, next->getEncodedValue()));
+                std::static_pointer_cast<DataStormI::SampleT<Key, Value, UpdateTag>>(next)->setValue(std::move(value));
+            } : std::function<void(const std::shared_ptr<DataStormI::Sample>&,
+                                const std::shared_ptr<DataStormI::Sample>&,
+                                const Ice::CommunicatorPtr&)>{};
 
         if (_reader && !_writer)
         {
@@ -1985,7 +1996,7 @@ namespace DataStorm
         std::function<std::function<bool(const Key&)>(const Criteria&)> factory) noexcept
     {
         std::lock_guard<std::mutex> lock(_mutex);
-        _keyFilterFactories->set(std::move(name), factory);
+        _keyFilterFactories->set(std::move(name), std::move(factory));
     }
 
     template<typename Key, typename Value, typename UpdateTag>
@@ -1995,7 +2006,7 @@ namespace DataStorm
         std::function<std::function<bool(const Sample<Key, Value, UpdateTag>&)>(const Criteria&)> factory) noexcept
     {
         std::lock_guard<std::mutex> lock(_mutex);
-        _sampleFilterFactories->set(std::move(name), factory);
+        _sampleFilterFactories->set(std::move(name), std::move(factory));
     }
 
     template<typename Key, typename Value, typename UpdateTag>

--- a/cpp/include/DataStorm/InternalT.h
+++ b/cpp/include/DataStorm/InternalT.h
@@ -170,6 +170,7 @@ namespace DataStormI
         {
             std::lock_guard<std::mutex> lock(_mutex);
             std::vector<std::shared_ptr<typename V::BaseClassType>> seq;
+            seq.reserve(values.size());
             for (auto& v : values)
             {
                 seq.push_back(createImpl(std::move(v)));
@@ -319,7 +320,7 @@ namespace DataStormI
             const std::shared_ptr<DataStormI::Tag>& tag,
             Ice::ByteSeq value,
             std::int64_t timestamp)
-            : Sample(std::move(session), std::move(origin), id, event, key, tag, value, timestamp),
+            : Sample(std::move(session), std::move(origin), id, event, key, tag, std::move(value), timestamp),
               _hasValue(false)
         {
         }
@@ -498,7 +499,7 @@ namespace DataStormI
             {
             }
 
-            [[nodiscard]] std::shared_ptr<Filter> create(Criteria criteria)
+            [[nodiscard]] std::shared_ptr<Filter> create(const Criteria& criteria)
             {
                 return std::static_pointer_cast<FilterT<Criteria, ValueT>>(
                     filterFactory.create(criteria, name, lambda(criteria)));

--- a/cpp/test/DataStorm/api/Writer.cpp
+++ b/cpp/test/DataStorm/api/Writer.cpp
@@ -49,7 +49,7 @@ void ::Writer::run(int argc, char* argv[])
             Node n23(c2);
         }
         {
-            const Ice::CommunicatorPtr c3 = c;
+            const Ice::CommunicatorPtr& c3 = c;
             Node n24(c3);
         }
         {
@@ -77,7 +77,7 @@ void ::Writer::run(int argc, char* argv[])
             test(n6.isShutdown());
             n6.waitForShutdown();
 
-            auto testException = [](function<void()> fn)
+            auto testException = [](const function<void()>& fn)
             {
                 try
                 {
@@ -149,7 +149,7 @@ void ::Writer::run(int argc, char* argv[])
         tc1.setWriterDefaultConfig(WriterConfig());
         t2.setReaderDefaultConfig(ReaderConfig());
 
-        tc1.setUpdater<string>("test", [](string&, string) {});
+        tc1.setUpdater<string>("test", [](string&, const string&) {});
     }
     cout << "ok" << endl;
 
@@ -173,7 +173,7 @@ void ::Writer::run(int argc, char* argv[])
             {
             }
             [[maybe_unused]] auto all = writer.getAll();
-            writer.onConnectedKeys([](vector<string>) {}, [](CallbackReason, string) {});
+            writer.onConnectedKeys([](const vector<string>&) {}, [](CallbackReason, const string&) {});
         };
 
         auto skw = makeSingleKeyWriter(topic, "key");
@@ -230,8 +230,8 @@ void ::Writer::run(int argc, char* argv[])
             [[maybe_unused]] auto allUnread = reader.getAllUnread();
             reader.waitForUnread(0);
             [[maybe_unused]] bool hasUnread = reader.hasUnread();
-            reader.onConnectedKeys([](vector<string>) {}, [](CallbackReason, string) {});
-            reader.onSamples([](vector<Sample<string, string>>) {}, [](Sample<string, string>) {});
+            reader.onConnectedKeys([](const vector<string>&) {}, [](CallbackReason, const string&) {});
+            reader.onSamples([](const vector<Sample<string, string>>&) {}, [](const Sample<string, string>&) {});
         };
 
         auto skr = makeSingleKeyReader(topic, "key");

--- a/cpp/test/DataStorm/callbacks/Reader.cpp
+++ b/cpp/test/DataStorm/callbacks/Reader.cpp
@@ -26,7 +26,7 @@ void ::Reader::run(int argc, char* argv[])
     {
         if (strcmp(argv[i], "--with-executor") == 0)
         {
-            customExecutor = [](function<void()> cb) { cb(); };
+            customExecutor = [](const function<void()>& cb) { cb(); };
         }
     }
     Node node(argc, argv, nullopt, customExecutor);
@@ -99,8 +99,8 @@ void ::Reader::run(int argc, char* argv[])
             auto reader = makeSingleKeyReader(topic, "elem3", "", config);
             promise<bool> p1, p2, p3;
             reader.onConnectedKeys(
-                [&p1](vector<string> keys) { p1.set_value(keys.empty()); },
-                [&p2, &p3](CallbackReason action, string key)
+                [&p1](const vector<string>& keys) { p1.set_value(keys.empty()); },
+                [&p2, &p3](CallbackReason action, const string& key)
                 {
                     if (action == CallbackReason::Connect)
                     {
@@ -123,7 +123,7 @@ void ::Reader::run(int argc, char* argv[])
             promise<bool> p1, p2;
             reader.onConnectedKeys(
                 [&p1](vector<string> keys) { p1.set_value(!keys.empty() && keys[0] == "elem4"); },
-                [&p2](CallbackReason action, string key)
+                [&p2](CallbackReason action, const string& key)
                 {
                     if (action == CallbackReason::Connect)
                     {
@@ -152,8 +152,8 @@ void ::Reader::run(int argc, char* argv[])
             auto reader = makeFilteredKeyReader(topic, Filter<string>("_regex", "elem3"), "", config);
             promise<bool> p1, p2, p3;
             reader.onConnectedKeys(
-                [&p1](vector<string> keys) { p1.set_value(keys.empty()); },
-                [&p2, &p3](CallbackReason action, string key)
+                [&p1](const vector<string>& keys) { p1.set_value(keys.empty()); },
+                [&p2, &p3](CallbackReason action, const string& key)
                 {
                     if (action == CallbackReason::Connect)
                     {
@@ -176,7 +176,7 @@ void ::Reader::run(int argc, char* argv[])
             promise<bool> p1, p2;
             reader.onConnectedKeys(
                 [&p1](vector<string> keys) { p1.set_value(!keys.empty() && keys[0] == "elem4"); },
-                [&p2](CallbackReason action, string key)
+                [&p2](CallbackReason action, const string& key)
                 {
                     if (action == CallbackReason::Connect)
                     {
@@ -206,8 +206,8 @@ void ::Reader::run(int argc, char* argv[])
             auto reader = makeAnyKeyReader(topic, "", config);
             promise<bool> p1, p2, p3;
             reader.onConnectedKeys(
-                [&p1](vector<string> keys) { p1.set_value(keys.empty()); },
-                [&p2, &p3](CallbackReason action, string key)
+                [&p1](const vector<string>& keys) { p1.set_value(keys.empty()); },
+                [&p2, &p3](CallbackReason action, const string& key)
                 {
                     if (action == CallbackReason::Connect)
                     {
@@ -242,8 +242,8 @@ void ::Reader::run(int argc, char* argv[])
             auto reader = makeSingleKeyReader(topic, "elem3", "", config);
             promise<bool> p1, p2, p3;
             reader.onConnectedWriters(
-                [&p1](vector<string> writers) { p1.set_value(writers.empty()); },
-                [&p2, &p3](CallbackReason action, string writer)
+                [&p1](const vector<string>& writers) { p1.set_value(writers.empty()); },
+                [&p2, &p3](CallbackReason action, const string& writer)
                 {
                     if (action == CallbackReason::Connect)
                     {
@@ -268,7 +268,7 @@ void ::Reader::run(int argc, char* argv[])
             promise<bool> p1, p2;
             reader.onConnectedWriters(
                 [&p1](vector<string> writers) { p1.set_value(!writers.empty() && writers[0] == "writer2"); },
-                [&p2](CallbackReason action, string writer)
+                [&p2](CallbackReason action, const string& writer)
                 {
                     if (action == CallbackReason::Connect)
                     {
@@ -299,8 +299,8 @@ void ::Reader::run(int argc, char* argv[])
             auto reader = makeFilteredKeyReader(topic, Filter<string>("_regex", "elem3"), "", config);
             promise<bool> p1, p2, p3;
             reader.onConnectedWriters(
-                [&p1](vector<string> writers) { p1.set_value(writers.empty()); },
-                [&p2, &p3](CallbackReason action, string writer)
+                [&p1](const vector<string>& writers) { p1.set_value(writers.empty()); },
+                [&p2, &p3](CallbackReason action, const string& writer)
                 {
                     if (action == CallbackReason::Connect)
                     {
@@ -323,7 +323,7 @@ void ::Reader::run(int argc, char* argv[])
             promise<bool> p1, p2;
             reader.onConnectedWriters(
                 [&p1](vector<string> writers) { p1.set_value(!writers.empty() && writers[0] == "writer2"); },
-                [&p2](CallbackReason action, string writer)
+                [&p2](CallbackReason action, const string& writer)
                 {
                     if (action == CallbackReason::Connect)
                     {
@@ -353,8 +353,8 @@ void ::Reader::run(int argc, char* argv[])
             auto reader = makeAnyKeyReader(topic, "", config);
             promise<bool> p1, p2, p3;
             reader.onConnectedWriters(
-                [&p1](vector<string> writers) { p1.set_value(writers.empty()); },
-                [&p2, &p3](CallbackReason action, string writer)
+                [&p1](const vector<string>& writers) { p1.set_value(writers.empty()); },
+                [&p2, &p3](CallbackReason action, const string& writer)
                 {
                     if (action == CallbackReason::Connect)
                     {

--- a/cpp/test/DataStorm/callbacks/Writer.cpp
+++ b/cpp/test/DataStorm/callbacks/Writer.cpp
@@ -26,7 +26,7 @@ void ::Writer::run(int argc, char* argv[])
     {
         if (strcmp(argv[i], "--with-executor") == 0)
         {
-            customExecutor = [](function<void()> cb) { cb(); };
+            customExecutor = [](const function<void()>& cb) { cb(); };
         }
     }
     Node node(argc, argv, nullopt, customExecutor);
@@ -73,8 +73,8 @@ void ::Writer::run(int argc, char* argv[])
                 auto writer = makeSingleKeyWriter(topic, "elem1", "", config);
                 promise<bool> p1, p2, p3;
                 writer.onConnectedKeys(
-                    [&p1](vector<string> keys) { p1.set_value(keys.empty()); },
-                    [&p2, &p3](CallbackReason action, string key)
+                    [&p1](const vector<string>& keys) { p1.set_value(keys.empty()); },
+                    [&p2, &p3](CallbackReason action, const string& key)
                     {
                         if (action == CallbackReason::Connect)
                         {
@@ -97,7 +97,7 @@ void ::Writer::run(int argc, char* argv[])
                 promise<bool> p1, p2;
                 writer.onConnectedKeys(
                     [&p1](vector<string> keys) { p1.set_value(!keys.empty() && keys[0] == "elem2"); },
-                    [&p2](CallbackReason action, string key)
+                    [&p2](CallbackReason action, const string& key)
                     {
                         if (action == CallbackReason::Connect)
                         {
@@ -129,8 +129,8 @@ void ::Writer::run(int argc, char* argv[])
             auto writer = makeAnyKeyWriter(topic, "", config);
             promise<bool> p1, p2, p3;
             writer.onConnectedKeys(
-                [&p1](vector<string> keys) { p1.set_value(keys.empty()); },
-                [&p2, &p3](CallbackReason action, string key)
+                [&p1](const vector<string>& keys) { p1.set_value(keys.empty()); },
+                [&p2, &p3](CallbackReason action, const string& key)
                 {
                     if (action == CallbackReason::Connect)
                     {
@@ -168,8 +168,8 @@ void ::Writer::run(int argc, char* argv[])
                 auto writer = makeSingleKeyWriter(topic, "elem1", "", config);
                 promise<bool> p1, p2, p3;
                 writer.onConnectedReaders(
-                    [&p1](vector<string> readers) { p1.set_value(readers.empty()); },
-                    [&p2, &p3](CallbackReason action, string reader)
+                    [&p1](const vector<string>& readers) { p1.set_value(readers.empty()); },
+                    [&p2, &p3](CallbackReason action, const string& reader)
                     {
                         if (action == CallbackReason::Connect)
                         {
@@ -194,7 +194,7 @@ void ::Writer::run(int argc, char* argv[])
                 promise<bool> p1, p2;
                 writer.onConnectedReaders(
                     [&p1](vector<string> readers) { p1.set_value(!readers.empty() && readers[0] == "reader2"); },
-                    [&p2](CallbackReason action, string reader)
+                    [&p2](CallbackReason action, const string& reader)
                     {
                         if (action == CallbackReason::Connect)
                         {
@@ -226,8 +226,8 @@ void ::Writer::run(int argc, char* argv[])
             auto writer = makeAnyKeyWriter(topic, "", config);
             promise<bool> p1, p2, p3;
             writer.onConnectedReaders(
-                [&p1](vector<string> readers) { p1.set_value(readers.empty()); },
-                [&p2, &p3](CallbackReason action, string reader)
+                [&p1](const vector<string>& readers) { p1.set_value(readers.empty()); },
+                [&p2, &p3](CallbackReason action, const string& reader)
                 {
                     if (action == CallbackReason::Connect)
                     {

--- a/cpp/test/DataStorm/config/Reader.cpp
+++ b/cpp/test/DataStorm/config/Reader.cpp
@@ -145,7 +145,7 @@ void ::Reader::run(int argc, char* argv[])
 
     // Writer clearHistory
     {
-        topic.setUpdater<string>("concat", [](string& value, string update) { value += update; });
+        topic.setUpdater<string>("concat", [](string& value, const string& update) { value += update; });
         ReaderConfig config;
         config.clearHistory = ClearHistoryPolicy::Never;
 

--- a/cpp/test/DataStorm/config/Writer.cpp
+++ b/cpp/test/DataStorm/config/Writer.cpp
@@ -149,7 +149,7 @@ void ::Writer::run(int argc, char* argv[])
 
     cout << "testing writer clearHistory... " << flush;
     {
-        topic.setUpdater<string>("concat", [](string& value, string update) { value += update; });
+        topic.setUpdater<string>("concat", [](string& value, const string& update) { value += update; });
 
         {
             writers.update(false); // Not ready

--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -110,8 +110,10 @@ void ::Reader::run(int argc, char* argv[])
     {
         Topic<string, shared_ptr<Test::Base>> topic(node, "baseclass2");
 
-        auto testSample =
-            [](typename decltype(topic)::ReaderType& reader, SampleEvent event, const string& key, const string& value = "")
+        auto testSample = [](typename decltype(topic)::ReaderType& reader,
+                             SampleEvent event,
+                             const string& key,
+                             const string& value = "")
         {
             reader.waitForWriters(1);
             test(reader.hasWriters());
@@ -319,8 +321,10 @@ void ::Reader::run(int argc, char* argv[])
         Topic<string, string> topic(node, "filtered reader key/value filter");
 
         {
-            auto testSample =
-                [](typename decltype(topic)::ReaderType& reader, SampleEvent event, const string& key, const string& value = "")
+            auto testSample = [](typename decltype(topic)::ReaderType& reader,
+                                 SampleEvent event,
+                                 const string& key,
+                                 const string& value = "")
             {
                 reader.waitForUnread(1);
                 auto sample = reader.getNextUnread();
@@ -355,8 +359,10 @@ void ::Reader::run(int argc, char* argv[])
             testSample(reader13, SampleEvent::Remove, "elem1");
         }
         {
-            auto testSample =
-                [](typename decltype(topic)::ReaderType& reader, SampleEvent event, const string& key, const string& value = "")
+            auto testSample = [](typename decltype(topic)::ReaderType& reader,
+                                 SampleEvent event,
+                                 const string& key,
+                                 const string& value = "")
             {
                 reader.waitForUnread(1);
                 auto sample = reader.getNextUnread();
@@ -379,8 +385,10 @@ void ::Reader::run(int argc, char* argv[])
             testSample(reader2, SampleEvent::Update, "elem2", "value4");
         }
         {
-            auto testSample =
-                [](typename decltype(topic)::ReaderType& reader, SampleEvent event, const string& key, const string& value = "")
+            auto testSample = [](typename decltype(topic)::ReaderType& reader,
+                                 SampleEvent event,
+                                 const string& key,
+                                 const string& value = "")
             {
                 reader.waitForUnread(1);
                 auto sample = reader.getNextUnread();

--- a/cpp/test/DataStorm/events/Reader.cpp
+++ b/cpp/test/DataStorm/events/Reader.cpp
@@ -31,7 +31,7 @@ void ::Reader::run(int argc, char* argv[])
             reader.waitForWriters(1);
             test(reader.hasWriters());
 
-            auto testSample = [&reader](SampleEvent event, string key, string value = "")
+            auto testSample = [&reader](SampleEvent event, const string& key, const string& value = "")
             {
                 reader.waitForUnread(1);
                 auto sample = reader.getNextUnread();
@@ -66,7 +66,7 @@ void ::Reader::run(int argc, char* argv[])
         reader.waitForWriters(1);
         test(reader.hasWriters());
 
-        auto testSample = [&reader](SampleEvent event, Test::StructValue value = Test::StructValue())
+        auto testSample = [&reader](SampleEvent event, const Test::StructValue& value = Test::StructValue())
         {
             reader.waitForUnread(1);
             auto sample = reader.getNextUnread();
@@ -90,7 +90,7 @@ void ::Reader::run(int argc, char* argv[])
         reader.waitForWriters(1);
         test(reader.hasWriters());
 
-        auto testSample = [&reader](SampleEvent event, string value = "")
+        auto testSample = [&reader](SampleEvent event, const string& value = "")
         {
             reader.waitForUnread(1);
             auto sample = reader.getNextUnread();
@@ -111,7 +111,7 @@ void ::Reader::run(int argc, char* argv[])
         Topic<string, shared_ptr<Test::Base>> topic(node, "baseclass2");
 
         auto testSample =
-            [](typename decltype(topic)::ReaderType& reader, SampleEvent event, string key, string value = "")
+            [](typename decltype(topic)::ReaderType& reader, SampleEvent event, const string& key, const string& value = "")
         {
             reader.waitForWriters(1);
             test(reader.hasWriters());
@@ -228,7 +228,7 @@ void ::Reader::run(int argc, char* argv[])
             reader.waitForWriters(1);
             test(reader.hasWriters());
 
-            auto testSample = [&reader](SampleEvent event, string key, string value = "")
+            auto testSample = [&reader](SampleEvent event, const string& key, const string& value = "")
             {
                 reader.waitForUnread(1);
                 auto sample = reader.getNextUnread();
@@ -265,7 +265,7 @@ void ::Reader::run(int argc, char* argv[])
         reader.waitForWriters(1);
         test(reader.hasWriters());
 
-        auto testSample = [&reader](SampleEvent event, string key, string value = "")
+        auto testSample = [&reader](SampleEvent event, const string& key, const string& value = "")
         {
             reader.waitForUnread(1);
             auto sample = reader.getNextUnread();
@@ -294,7 +294,7 @@ void ::Reader::run(int argc, char* argv[])
         reader.waitForWriters(1);
         test(reader.hasWriters());
 
-        auto testSample = [&reader](SampleEvent event, string key, string value = "")
+        auto testSample = [&reader](SampleEvent event, const string& key, const string& value = "")
         {
             reader.waitForUnread(1);
             auto sample = reader.getNextUnread();
@@ -320,7 +320,7 @@ void ::Reader::run(int argc, char* argv[])
 
         {
             auto testSample =
-                [](typename decltype(topic)::ReaderType& reader, SampleEvent event, string key, string value = "")
+                [](typename decltype(topic)::ReaderType& reader, SampleEvent event, const string& key, const string& value = "")
             {
                 reader.waitForUnread(1);
                 auto sample = reader.getNextUnread();
@@ -356,7 +356,7 @@ void ::Reader::run(int argc, char* argv[])
         }
         {
             auto testSample =
-                [](typename decltype(topic)::ReaderType& reader, SampleEvent event, string key, string value = "")
+                [](typename decltype(topic)::ReaderType& reader, SampleEvent event, const string& key, const string& value = "")
             {
                 reader.waitForUnread(1);
                 auto sample = reader.getNextUnread();
@@ -380,7 +380,7 @@ void ::Reader::run(int argc, char* argv[])
         }
         {
             auto testSample =
-                [](typename decltype(topic)::ReaderType& reader, SampleEvent event, string key, string value = "")
+                [](typename decltype(topic)::ReaderType& reader, SampleEvent event, const string& key, const string& value = "")
             {
                 reader.waitForUnread(1);
                 auto sample = reader.getNextUnread();

--- a/cpp/test/DataStorm/events/Writer.cpp
+++ b/cpp/test/DataStorm/events/Writer.cpp
@@ -344,7 +344,7 @@ void ::Writer::run(int argc, char* argv[])
             {
                 return [prefix](const Sample<string, string>& sample)
                 {
-                    auto value = sample.getValue();
+                    const auto& value = sample.getValue();
                     return value.size() >= prefix.size() && value.compare(0, prefix.size(), prefix) == 0;
                 };
             });

--- a/cpp/test/DataStorm/types/Reader.cpp
+++ b/cpp/test/DataStorm/types/Reader.cpp
@@ -29,14 +29,14 @@ namespace
         red,
     };
 
-    template<typename T> bool compare(T v1, T v2) { return v1 == v2; }
+    template<typename T> bool compare(const T& v1, const T& v2) { return v1 == v2; }
 
     template<typename T> bool compare(const shared_ptr<T>& v1, const shared_ptr<T>& v2)
     {
         return v1->ice_tuple() == v2->ice_tuple();
     }
 
-    template<typename T, typename A, typename U> void testReader(T topic, A add, U update)
+    template<typename T, typename A, typename U> void testReader(T topic, const A& add, const U& update)
     {
         topic.setReaderDefaultConfig(ReaderConfig(-1, std::nullopt, ClearHistoryPolicy::Never));
         map<typename decltype(topic)::KeyType, typename decltype(topic)::ReaderType> readers;

--- a/cpp/test/DataStorm/types/Writer.cpp
+++ b/cpp/test/DataStorm/types/Writer.cpp
@@ -18,13 +18,13 @@ public:
 
 namespace
 {
-
     enum class color : unsigned char
     {
         blue,
         red,
     };
 
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     template<typename T, typename A, typename U> void testWriter(T topic, A add, U update)
     {
         topic.setWriterDefaultConfig(WriterConfig(-1, std::nullopt, ClearHistoryPolicy::Never));
@@ -49,7 +49,6 @@ namespace
             writers.at(p.first).waitForNoReaders();
         }
     };
-
 }
 
 namespace DataStorm


### PR DESCRIPTION
This PR fixes DataStorm clang-tidy lints in the DataStorm headers and tests.