### PR TITLE
Add CtrlCHandler helper class (Swift)

### DIFF
--- a/cpp/include/Ice/CtrlCHandler.h
+++ b/cpp/include/Ice/CtrlCHandler.h
@@ -37,7 +37,7 @@ namespace Ice
 
         /// Unregisters the callback function.
         /// On Linux and macOS, this destructor joins and terminates the thread created by the constructor but does not
-        /// "unmask" SIGHUP, SIGINT and SIGTERM. As a result, these signals are ignored after this destructor completes.
+        /// unmask SIGHUP, SIGINT and SIGTERM. As a result, these signals are ignored after this destructor completes.
         /// On Windows, this destructor unregisters the SetConsoleCtrlHandler handler routine, and as a result a
         /// Ctrl+C or similar signal will terminate the application after this destructor completes.
         ~CtrlCHandler();

--- a/cpp/include/Ice/CtrlCHandler.h
+++ b/cpp/include/Ice/CtrlCHandler.h
@@ -15,25 +15,31 @@ namespace Ice
     /// \headerfile Ice/Ice.h
     using CtrlCHandlerCallback = std::function<void(int sig)>;
 
-    /// Provides a portable way to handle Ctrl-C and Ctrl-C like signals. On Linux and macOS, the CtrlCHandler handles
-    /// SIGHUP, SIGINT and SIGTERM. On Windows, it is essentially a wrapper for SetConsoleCtrlHandler.
+    /// Provides a portable way to handle Ctrl+C and Ctrl+C like signals. On Linux and macOS, the CtrlCHandler handles
+    /// SIGHUP, SIGINT and SIGTERM. On Windows, it is a wrapper for SetConsoleCtrlHandler.
     /// \headerfile Ice/Ice.h
     class ICE_API CtrlCHandler
     {
     public:
-        /// Constructs a CtrlCHandler.
+        /// Constructs a CtrlCHandler with a null callback, meaning the callback does nothing.
+        /// @see #CtrlCHandler(CtrlCHandlerCallback)
+        CtrlCHandler();
+
+        /// Constructs a CtrlCHandler. Only one instance of this class can exist in a program at any point in time.
         /// On Linux and macOS, this constructor masks the SIGHUP, SIGINT and SIGTERM signals and then creates a thread
         /// that waits for these signals using sigwait. On Windows, this constructor calls SetConsoleCtrlCHandler to
         /// register a handler routine that calls the supplied callback function.
-        /// Only a single CtrlCHandler object can exist in a process at a give time.
-        /// @param cb The callback function to invoke when a signal is received. The default (nullptr) means do nothing.
-        explicit CtrlCHandler(CtrlCHandlerCallback cb = nullptr);
+        /// @param cb The callback function to invoke when a signal is received.
+        explicit CtrlCHandler(CtrlCHandlerCallback cb);
+
+        CtrlCHandler(const CtrlCHandler&) = delete;
+        CtrlCHandler& operator=(const CtrlCHandler&) = delete;
 
         /// Unregisters the callback function.
         /// On Linux and macOS, this destructor joins and terminates the thread created by the constructor but does not
         /// "unmask" SIGHUP, SIGINT and SIGTERM. As a result, these signals are ignored after this destructor completes.
         /// On Windows, this destructor unregisters the SetConsoleCtrlHandler handler routine, and as a result a
-        /// Ctrl-C or similar signal will terminate the application after this destructor completes.
+        /// Ctrl+C or similar signal will terminate the application after this destructor completes.
         ~CtrlCHandler();
 
         /// Replaces the signal callback.

--- a/cpp/src/Ice/CtrlCHandler.cpp
+++ b/cpp/src/Ice/CtrlCHandler.cpp
@@ -5,15 +5,13 @@
 
 #ifdef _WIN32
 #    include <windows.h>
+#else
+#    include <csignal>
 #endif
 
 #include <cassert>
 #include <future>
 #include <mutex>
-
-#ifndef _WIN32
-#    include <csignal>
-#endif
 
 using namespace Ice;
 using namespace std;
@@ -45,6 +43,27 @@ CtrlCHandler::getCallback() const
     return _callback;
 }
 
+int
+CtrlCHandler::wait()
+{
+    promise<int> promise;
+
+    CtrlCHandlerCallback oldCallback = setCallback(
+        [&promise, this](int sig)
+        {
+            setCallback(nullptr); // ignore further signals
+            promise.set_value(sig);
+        });
+
+    if (oldCallback)
+    {
+        setCallback(oldCallback);
+        throw Ice::LocalException{__FILE__, __LINE__, "do not call wait on a CtrlCHandler with a registered callback"};
+    }
+
+    return promise.get_future().get();
+}
+
 #ifdef _WIN32
 
 static BOOL WINAPI
@@ -69,9 +88,9 @@ handlerRoutine(DWORD dwCtrlType)
 CtrlCHandler::CtrlCHandler(CtrlCHandlerCallback callback)
 {
     unique_lock lock(globalMutex);
-    bool handler = _handler != nullptr;
+    const bool handlerAlive = _handler != nullptr;
 
-    if (handler)
+    if (handlerAlive)
     {
         throw Ice::LocalException{__FILE__, __LINE__, "another CtrlCHandler was already created"};
     }
@@ -88,11 +107,9 @@ CtrlCHandler::CtrlCHandler(CtrlCHandlerCallback callback)
 CtrlCHandler::~CtrlCHandler()
 {
     SetConsoleCtrlHandler(handlerRoutine, FALSE);
-    {
-        lock_guard lock(globalMutex);
-        _handler = 0;
-        _callback = nullptr;
-    }
+    lock_guard lock(globalMutex);
+    _handler = nullptr;
+    _callback = nullptr;
 }
 
 #else
@@ -107,19 +124,15 @@ extern "C"
         sigaddset(&ctrlCLikeSignals, SIGINT);
         sigaddset(&ctrlCLikeSignals, SIGTERM);
 
-        //
-        // Run until the handler is destroyed (_handler == 0)
-        //
+        // Run until the handler is destroyed (!_handler)
         for (;;)
         {
             int signal = 0;
             int rc = sigwait(&ctrlCLikeSignals, &signal);
             if (rc == EINTR)
             {
-                //
-                // Some sigwait() implementations incorrectly return EINTR
-                // when interrupted by an unblocked caught signal
-                //
+                // Some sigwait() implementations incorrectly return EINTR when interrupted by an unblocked caught
+                // signal.
                 continue;
             }
             assert(rc == 0);
@@ -151,9 +164,9 @@ namespace
 CtrlCHandler::CtrlCHandler(CtrlCHandlerCallback callback)
 {
     unique_lock lock(globalMutex);
-    bool handler = _handler != nullptr;
+    const bool handlerAlive = _handler != nullptr;
 
-    if (handler)
+    if (handlerAlive)
     {
         throw Ice::LocalException{__FILE__, __LINE__, "another CtrlCHandler was already created"};
     }
@@ -164,9 +177,8 @@ CtrlCHandler::CtrlCHandler(CtrlCHandlerCallback callback)
 
         lock.unlock();
 
-        // We block these CTRL+C like signals in the main thread,
-        // and by default all other threads will inherit this signal
-        // mask.
+        // We block these CTRL+C like signals in the main thread, and by default all other threads will inherit this
+        // signal mask.
 
         sigset_t ctrlCLikeSignals;
         sigemptyset(&ctrlCLikeSignals);
@@ -185,18 +197,14 @@ CtrlCHandler::CtrlCHandler(CtrlCHandlerCallback callback)
 
 CtrlCHandler::~CtrlCHandler()
 {
-    //
     // Clear the handler, the sigwaitThread will exit if _handler is null
-    //
     {
         lock_guard lock(globalMutex);
         _handler = nullptr;
         _callback = nullptr;
     }
 
-    //
     // Signal the sigwaitThread and join it.
-    //
     void* status = nullptr;
     [[maybe_unused]] int rc = pthread_kill(_tid, SIGTERM); // NOLINT(cert-pos44-c)
     assert(rc == 0);
@@ -205,24 +213,3 @@ CtrlCHandler::~CtrlCHandler()
 }
 
 #endif
-
-int
-CtrlCHandler::wait()
-{
-    promise<int> promise;
-
-    CtrlCHandlerCallback oldCallback = setCallback(
-        [&promise, this](int sig)
-        {
-            setCallback(nullptr); // ignore further signals
-            promise.set_value(sig);
-        });
-
-    if (oldCallback)
-    {
-        setCallback(oldCallback);
-        throw Ice::LocalException{__FILE__, __LINE__, "do not call wait on a CtrlCHandler with a registered callback"};
-    }
-
-    return promise.get_future().get();
-}

--- a/cpp/src/Ice/CtrlCHandler.cpp
+++ b/cpp/src/Ice/CtrlCHandler.cpp
@@ -27,6 +27,8 @@ namespace
     mutex globalMutex;
 }
 
+CtrlCHandler::CtrlCHandler() : CtrlCHandler(nullptr) {}
+
 CtrlCHandlerCallback
 CtrlCHandler::setCallback(CtrlCHandlerCallback callback)
 {

--- a/cpp/src/Ice/CtrlCHandler.cpp
+++ b/cpp/src/Ice/CtrlCHandler.cpp
@@ -88,9 +88,7 @@ handlerRoutine(DWORD dwCtrlType)
 CtrlCHandler::CtrlCHandler(CtrlCHandlerCallback callback)
 {
     unique_lock lock(globalMutex);
-    const bool handlerAlive = _handler != nullptr;
-
-    if (handlerAlive)
+    if (_handler)
     {
         throw Ice::LocalException{__FILE__, __LINE__, "another CtrlCHandler was already created"};
     }
@@ -164,9 +162,7 @@ namespace
 CtrlCHandler::CtrlCHandler(CtrlCHandlerCallback callback)
 {
     unique_lock lock(globalMutex);
-    const bool handlerAlive = _handler != nullptr;
-
-    if (handlerAlive)
+    if (_handler)
     {
         throw Ice::LocalException{__FILE__, __LINE__, "another CtrlCHandler was already created"};
     }

--- a/swift/src/Ice/CtrlCHandler.swift
+++ b/swift/src/Ice/CtrlCHandler.swift
@@ -1,13 +1,19 @@
 // Copyright (c) ZeroC, Inc.
 
-import Foundation
 import IceImpl
 
+/// A utility class that help applications handle Ctrl+C and similar signals.
 public final class CtrlCHandler {
     private let handle = ICECtrlCHandler()
 
+    /// Creates a CtrlCHandler. Only one instance of this class can exist in a program at any point in time.
+    /// This instance must be created because starting any thread.
+    public init() {}
+
+    /// Waits until a Ctrl+C or similar signal is received by this handler.
+    /// - Returns: The signal number received.
     public func receiveSignal() async -> Int32 {
-        await withCheckedContinuation { continuation in
+        return await withCheckedContinuation { continuation in
             self.handle.receiveSignal { signal in
                 continuation.resume(returning: signal)
             }

--- a/swift/src/Ice/CtrlCHandler.swift
+++ b/swift/src/Ice/CtrlCHandler.swift
@@ -10,11 +10,11 @@ public final class CtrlCHandler {
     /// This instance must be created before starting any thread.
     public init() {}
 
-    /// Waits until a Ctrl+C or similar signal is received by this handler.
-    /// - Returns: The signal number received.
-    public func receiveSignal() async -> Int32 {
+    /// Waits until this handler catches a Ctrl+C or similar signal.
+    /// - Returns: The signal number.
+    public func catchSignal() async -> Int32 {
         return await withCheckedContinuation { continuation in
-            self.handle.receiveSignal { signal in
+            self.handle.catchSignal { signal in
                 continuation.resume(returning: signal)
             }
         }

--- a/swift/src/Ice/CtrlCHandler.swift
+++ b/swift/src/Ice/CtrlCHandler.swift
@@ -2,7 +2,7 @@
 
 import IceImpl
 
-/// A utility class that help applications handle Ctrl+C (SIGINT) and similar signals (SIGHUP and SIGTERM).
+/// Helps applications handle Ctrl+C (SIGINT) and similar signals (SIGHUP and SIGTERM).
 public final class CtrlCHandler {
     private let handle = ICECtrlCHandler()
 

--- a/swift/src/Ice/CtrlCHandler.swift
+++ b/swift/src/Ice/CtrlCHandler.swift
@@ -2,23 +2,22 @@
 
 import IceImpl
 
-#if os(macOS)
-    /// Helps applications handle Ctrl+C (SIGINT) and similar signals (SIGHUP and SIGTERM). Only available on macOS.
-    public final class CtrlCHandler {
-        private let handle = ICECtrlCHandler()
+/// Helps applications handle Ctrl+C (SIGINT) and similar signals (SIGHUP and SIGTERM). Only available on macOS.
+@available(macOS 14, *)
+public final class CtrlCHandler {
+    private let handle = ICECtrlCHandler()
 
-        /// Creates a CtrlCHandler. Only one instance of this class can exist in a program at any point in time.
-        /// This instance must be created before starting any thread.
-        public init() {}
+    /// Creates a CtrlCHandler. Only one instance of this class can exist in a program at any point in time.
+    /// This instance must be created before starting any thread.
+    public init() {}
 
-        /// Waits until this handler catches a Ctrl+C or similar signal.
-        /// - Returns: The signal number.
-        public func catchSignal() async -> Int32 {
-            return await withCheckedContinuation { continuation in
-                self.handle.catchSignal { signal in
-                    continuation.resume(returning: signal)
-                }
+    /// Waits until this handler catches a Ctrl+C or similar signal.
+    /// - Returns: The signal number.
+    public func catchSignal() async -> Int32 {
+        return await withCheckedContinuation { continuation in
+            self.handle.catchSignal { signal in
+                continuation.resume(returning: signal)
             }
         }
     }
-#endif
+}

--- a/swift/src/Ice/CtrlCHandler.swift
+++ b/swift/src/Ice/CtrlCHandler.swift
@@ -1,0 +1,16 @@
+// Copyright (c) ZeroC, Inc.
+
+import Foundation
+import IceImpl
+
+public final class CtrlCHandler {
+    private let handle = ICECtrlCHandler()
+
+    public func receiveSignal() async -> Int32 {
+        await withCheckedContinuation { continuation in
+            self.handle.receiveSignal { signal in
+                continuation.resume(returning: signal)
+            }
+        }
+    }
+}

--- a/swift/src/Ice/CtrlCHandler.swift
+++ b/swift/src/Ice/CtrlCHandler.swift
@@ -7,7 +7,7 @@ public final class CtrlCHandler {
     private let handle = ICECtrlCHandler()
 
     /// Creates a CtrlCHandler. Only one instance of this class can exist in a program at any point in time.
-    /// This instance must be created because starting any thread.
+    /// This instance must be created before starting any thread.
     public init() {}
 
     /// Waits until a Ctrl+C or similar signal is received by this handler.

--- a/swift/src/Ice/CtrlCHandler.swift
+++ b/swift/src/Ice/CtrlCHandler.swift
@@ -2,21 +2,23 @@
 
 import IceImpl
 
-/// Helps applications handle Ctrl+C (SIGINT) and similar signals (SIGHUP and SIGTERM).
-public final class CtrlCHandler {
-    private let handle = ICECtrlCHandler()
+#if os(macOS)
+    /// Helps applications handle Ctrl+C (SIGINT) and similar signals (SIGHUP and SIGTERM). Only available on macOS.
+    public final class CtrlCHandler {
+        private let handle = ICECtrlCHandler()
 
-    /// Creates a CtrlCHandler. Only one instance of this class can exist in a program at any point in time.
-    /// This instance must be created before starting any thread.
-    public init() {}
+        /// Creates a CtrlCHandler. Only one instance of this class can exist in a program at any point in time.
+        /// This instance must be created before starting any thread.
+        public init() {}
 
-    /// Waits until this handler catches a Ctrl+C or similar signal.
-    /// - Returns: The signal number.
-    public func catchSignal() async -> Int32 {
-        return await withCheckedContinuation { continuation in
-            self.handle.catchSignal { signal in
-                continuation.resume(returning: signal)
+        /// Waits until this handler catches a Ctrl+C or similar signal.
+        /// - Returns: The signal number.
+        public func catchSignal() async -> Int32 {
+            return await withCheckedContinuation { continuation in
+                self.handle.catchSignal { signal in
+                    continuation.resume(returning: signal)
+                }
             }
         }
     }
-}
+#endif

--- a/swift/src/Ice/CtrlCHandler.swift
+++ b/swift/src/Ice/CtrlCHandler.swift
@@ -2,7 +2,7 @@
 
 import IceImpl
 
-/// A utility class that help applications handle Ctrl+C and similar signals.
+/// A utility class that help applications handle Ctrl+C (SIGINT) and similar signals (SIGHUP and SIGTERM).
 public final class CtrlCHandler {
     private let handle = ICECtrlCHandler()
 

--- a/swift/src/IceImpl/CtlCHandler.mm
+++ b/swift/src/IceImpl/CtlCHandler.mm
@@ -4,7 +4,7 @@
 
 @implementation ICECtrlCHandler
 
-- (void)receiveSignal:(void (^)(int))callback
+- (void)catchSignal:(void (^)(int))callback
 {
     [[maybe_unused]] Ice::CtrlCHandlerCallback previousCallback = self->cppObject.setCallback(
         [callback, self](int signal)

--- a/swift/src/IceImpl/CtlCHandler.mm
+++ b/swift/src/IceImpl/CtlCHandler.mm
@@ -28,4 +28,11 @@
     assert(previousCallback == nullptr);
 }
 @end
+#else
+@implementation ICECtrlCHandler
+- (void)catchSignal:(void (^)(int))callback
+{
+    fatalError(@"ICECtrlCHandler is not implemented on this platform");
+}
+@end
 #endif

--- a/swift/src/IceImpl/CtlCHandler.mm
+++ b/swift/src/IceImpl/CtlCHandler.mm
@@ -1,0 +1,22 @@
+// Copyright (c) ZeroC, Inc.
+
+#import "include/CtrlCHandler.h"
+
+@implementation ICECtrlCHandler
+
+- (void)receiveSignal:(void(^)(int))callback
+{
+    self.cppObject.setCallback(
+        [callback, self](int signal)
+        {
+            // We need an autorelease pool in case the callback creates auto release objects.
+            @autoreleasepool
+            {
+                callback(signal);
+            }
+
+            // Then remove callback
+            self.cppObject.setCallback(nullptr);
+        });
+}
+@end

--- a/swift/src/IceImpl/CtlCHandler.mm
+++ b/swift/src/IceImpl/CtlCHandler.mm
@@ -4,10 +4,13 @@
 
 #if TARGET_OS_OSX != 0
 @implementation ICECtrlCHandler
-
+{
+@private
+    Ice::CtrlCHandler _cppObject;
+}
 - (void)catchSignal:(void (^)(int))callback
 {
-    [[maybe_unused]] Ice::CtrlCHandlerCallback previousCallback = self->cppObject.setCallback(
+    [[maybe_unused]] Ice::CtrlCHandlerCallback previousCallback = self->_cppObject.setCallback(
         [callback, self](int signal)
         {
             // This callback executes in the C++ CtrlCHandler thread.
@@ -19,7 +22,7 @@
             }
 
             // Then remove callback
-            self->cppObject.setCallback(nullptr);
+            self->_cppObject.setCallback(nullptr);
         });
 
     assert(previousCallback == nullptr);

--- a/swift/src/IceImpl/CtlCHandler.mm
+++ b/swift/src/IceImpl/CtlCHandler.mm
@@ -32,7 +32,7 @@
 @implementation ICECtrlCHandler
 - (void)catchSignal:(void (^)(int))callback
 {
-    fatalError(@"ICECtrlCHandler is not implemented on this platform");
+    assert(false); // CtrlCHandler is not implemented on this platform
 }
 @end
 #endif

--- a/swift/src/IceImpl/CtlCHandler.mm
+++ b/swift/src/IceImpl/CtlCHandler.mm
@@ -2,6 +2,7 @@
 
 #import "include/CtrlCHandler.h"
 
+#if TARGET_OS_OSX != 0
 @implementation ICECtrlCHandler
 
 - (void)catchSignal:(void (^)(int))callback
@@ -24,3 +25,4 @@
     assert(previousCallback == nullptr);
 }
 @end
+#endif

--- a/swift/src/IceImpl/CtlCHandler.mm
+++ b/swift/src/IceImpl/CtlCHandler.mm
@@ -4,19 +4,23 @@
 
 @implementation ICECtrlCHandler
 
-- (void)receiveSignal:(void(^)(int))callback
+- (void)receiveSignal:(void (^)(int))callback
 {
-    self.cppObject.setCallback(
+    [[maybe_unused]] Ice::CtrlCHandlerCallback previousCallback = self->cppObject.setCallback(
         [callback, self](int signal)
         {
-            // We need an autorelease pool in case the callback creates auto release objects.
+            // This callback executes in the C++ CtrlCHandler thread.
+
+            // We need an autorelease pool in case the callback creates autorelease objects.
             @autoreleasepool
             {
                 callback(signal);
             }
 
             // Then remove callback
-            self.cppObject.setCallback(nullptr);
+            self->cppObject.setCallback(nullptr);
         });
+
+    assert(previousCallback == nullptr);
 }
 @end

--- a/swift/src/IceImpl/include/CtrlCHandler.h
+++ b/swift/src/IceImpl/include/CtrlCHandler.h
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // The implementation of Ice.CtrlCHandler, which wraps the C++ class Ice::CtrlCHandler.
 ICEIMPL_API @interface ICECtrlCHandler : NSObject
-- (void)receiveSignal:(void (^)(int))callback;
+- (void)catchSignal:(void (^)(int))callback;
 @end
 
 #ifdef __cplusplus

--- a/swift/src/IceImpl/include/CtrlCHandler.h
+++ b/swift/src/IceImpl/include/CtrlCHandler.h
@@ -1,0 +1,19 @@
+// Copyright (c) ZeroC, Inc.
+
+#import "Config.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+ICEIMPL_API @interface ICECtrlCHandler : NSObject
+- (void)receiveSignal:(void(^)(int))callback;
+@end
+
+#ifdef __cplusplus
+
+@interface ICECtrlCHandler ()
+@property(nonatomic, readonly) Ice::CtrlCHandler cppObject;
+@end
+
+#endif
+
+NS_ASSUME_NONNULL_END

--- a/swift/src/IceImpl/include/CtrlCHandler.h
+++ b/swift/src/IceImpl/include/CtrlCHandler.h
@@ -2,23 +2,11 @@
 
 #import "Config.h"
 
-#if TARGET_OS_OSX != 0
 NS_ASSUME_NONNULL_BEGIN
 
-// The implementation of Ice.CtrlCHandler, which wraps the C++ class Ice::CtrlCHandler.
+// The implementation of Ice.CtrlCHandler, which wraps the C++ class Ice::CtrlCHandler (macOS only).
 ICEIMPL_API @interface ICECtrlCHandler : NSObject
 - (void)catchSignal:(void (^)(int))callback;
 @end
 
-#    ifdef __cplusplus
-
-@interface ICECtrlCHandler ()
-{
-    Ice::CtrlCHandler cppObject;
-}
-@end
-
-#    endif
-
 NS_ASSUME_NONNULL_END
-#endif

--- a/swift/src/IceImpl/include/CtrlCHandler.h
+++ b/swift/src/IceImpl/include/CtrlCHandler.h
@@ -4,14 +4,17 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+// The implementation of Ice.CtrlCHandler, which wraps the C++ class Ice::CtrlCHandler.
 ICEIMPL_API @interface ICECtrlCHandler : NSObject
-- (void)receiveSignal:(void(^)(int))callback;
+- (void)receiveSignal:(void (^)(int))callback;
 @end
 
 #ifdef __cplusplus
 
 @interface ICECtrlCHandler ()
-@property(nonatomic, readonly) Ice::CtrlCHandler cppObject;
+{
+    Ice::CtrlCHandler cppObject;
+}
 @end
 
 #endif

--- a/swift/src/IceImpl/include/CtrlCHandler.h
+++ b/swift/src/IceImpl/include/CtrlCHandler.h
@@ -2,6 +2,7 @@
 
 #import "Config.h"
 
+#if TARGET_OS_OSX != 0
 NS_ASSUME_NONNULL_BEGIN
 
 // The implementation of Ice.CtrlCHandler, which wraps the C++ class Ice::CtrlCHandler.
@@ -9,7 +10,7 @@ ICEIMPL_API @interface ICECtrlCHandler : NSObject
 - (void)catchSignal:(void (^)(int))callback;
 @end
 
-#ifdef __cplusplus
+#    ifdef __cplusplus
 
 @interface ICECtrlCHandler ()
 {
@@ -17,6 +18,7 @@ ICEIMPL_API @interface ICECtrlCHandler : NSObject
 }
 @end
 
-#endif
+#    endif
 
 NS_ASSUME_NONNULL_END
+#endif


### PR DESCRIPTION
This PR adds the CtrlCHandler helper class to Swift.

It's a thin wrapper over the Ice::CtrlCHandler class provided by Ice C++. It's main consumer is our Swift demos for macOS.