### PR TITLE
Remove -fno-var-tracking-assignments from some tests (Linux, release)

### DIFF
--- a/cpp/test/Ice/custom/Makefile.mk
+++ b/cpp/test/Ice/custom/Makefile.mk
@@ -28,11 +28,4 @@ $(project)_serveramd_sources       = ServerAMD.cpp \
 # TODO: should be turn on ICE_UNALIGNED only on some platforms?
 $(project)_cppflags        := -I$(project) -DICE_UNALIGNED
 
-#
-# Disable var tracking assignments for Linux with this test
-#
-ifneq ($(linux_id),)
-    $(project)_cppflags += $(if $(filter yes,$(OPTIMIZE)),-fno-var-tracking-assignments)
-endif
-
 tests += $(project)

--- a/cpp/test/Ice/operations/Makefile.mk
+++ b/cpp/test/Ice/operations/Makefile.mk
@@ -10,15 +10,4 @@ $(project)_client_sources  = Test.ice \
                           BatchOneways.cpp \
                           BatchOnewaysAMI.cpp
 
-ifeq ($(xlc_compiler),yes)
-    $(project)_cppflags += -qsuppress="1540-0895"
-endif
-
-#
-# Disable var tracking assignments for Linux with this test
-#
-ifneq ($(linux_id),)
-    $(project)_cppflags += $(if $(filter yes,$(OPTIMIZE)),-fno-var-tracking-assignments)
-endif
-
 tests += $(project)

--- a/cpp/test/Ice/optional/Makefile.mk
+++ b/cpp/test/Ice/optional/Makefile.mk
@@ -1,11 +1,4 @@
 # For the include <CustomMap.h> in the generated code.
 $(project)_cppflags        := -I$(project)
 
-#
-# Disable var tracking assignments for Linux with this test
-#
-ifneq ($(linux_id),)
-    $(project)_cppflags += $(if $(filter yes,$(OPTIMIZE)),-fno-var-tracking-assignments)
-endif
-
 tests += $(project)

--- a/cpp/test/Ice/proxy/Makefile.mk
+++ b/cpp/test/Ice/proxy/Makefile.mk
@@ -1,7 +1,0 @@
-#
-# Disable var tracking assignments for Linux with this test
-#
-ifneq ($(linux_id),)
-    $(project)_cppflags += $(if $(filter yes,$(OPTIMIZE)),-fno-var-tracking-assignments)
-endif
-tests += $(project)

--- a/cpp/test/Ice/slicing/exceptions/Makefile.mk
+++ b/cpp/test/Ice/slicing/exceptions/Makefile.mk
@@ -4,8 +4,4 @@ $(project)_client_sources          = $(test-client-sources)
 $(project)_server_sources          = $(test-server-sources) ServerPrivate.ice
 $(project)_serveramd_sources       = $(test-serveramd-sources) ServerPrivateAMD.ice
 
-ifneq ($(linux_id),)
-    $(project)_cppflags += $(if $(filter yes,$(OPTIMIZE)),-fno-var-tracking-assignments)
-endif
-
 tests += $(project)

--- a/cpp/test/IceSSL/configuration/Makefile.mk
+++ b/cpp/test/IceSSL/configuration/Makefile.mk
@@ -12,8 +12,6 @@ endif
 ifeq ($(os),Linux)
     $(project)_client_sources += OpenSSLTests.cpp
     $(project)_client_ldflags = -lssl -lcrypto
-    # Disable var tracking assignments for Linux with this test
-    $(project)_cppflags += $(if $(filter yes,$(OPTIMIZE)),-fno-var-tracking-assignments)
 endif
 
 tests += $(project)


### PR DESCRIPTION
It's not clear if we still need it.