### PR TITLE
Fix C++17 build with MSVC

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,7 @@ Checks:
   -modernize-avoid-c-arrays,
   -modernize-use-trailing-return-type,
   -modernize-macro-to-enum,
+  -modernize-use-designated-initializers,
   performance-*,
   -performance-avoid-endl,
   -performance-enum-size,

--- a/cpp/include/DataStorm/InternalT.h
+++ b/cpp/include/DataStorm/InternalT.h
@@ -154,10 +154,7 @@ namespace DataStormI
     public:
         AbstractFactoryT() = default;
 
-        void init()
-        {
-            _deleter = Deleter{std::enable_shared_from_this<AbstractFactoryT<K, V>>::shared_from_this()};
-        }
+        void init() { _deleter = Deleter{std::enable_shared_from_this<AbstractFactoryT<K, V>>::shared_from_this()}; }
 
         template<typename F, typename... Args>
         [[nodiscard]] std::shared_ptr<typename V::BaseClassType> create(F&& value, Args&&... args)

--- a/cpp/include/DataStorm/InternalT.h
+++ b/cpp/include/DataStorm/InternalT.h
@@ -156,7 +156,7 @@ namespace DataStormI
 
         void init()
         {
-            _deleter = Deleter{._factory = std::enable_shared_from_this<AbstractFactoryT<K, V>>::shared_from_this()};
+            _deleter = Deleter{std::enable_shared_from_this<AbstractFactoryT<K, V>>::shared_from_this()};
         }
 
         template<typename F, typename... Args>

--- a/cpp/include/Ice/StreamHelpers.h
+++ b/cpp/include/Ice/StreamHelpers.h
@@ -12,7 +12,7 @@
 
 #if defined(_MSC_VER)
 // With MSVC, __has_include(<span>) evaluates to 1 in c++17 mode and the <span> header then issues a warning. This
-// is a permissible but impractical behavior. As a result, we include <span> only in c++20 mode.
+// is a permissible but impractical behavior. As a result, we include <span> only for c++20 or higher.
 #    if _MSVC_LANG >= 202002L
 #        include <span>
 #    endif

--- a/cpp/include/Ice/StreamHelpers.h
+++ b/cpp/include/Ice/StreamHelpers.h
@@ -10,7 +10,11 @@
 #include <iterator>
 #include <ostream>
 
-#if __has_include(<span>)
+#if defined(_MSC_VER) // workaround for MSVC bug
+#    if _MSVC_LANG >= 202002L
+#        include <span>
+#    endif
+#elif __has_include(<span>)
 #    include <span>
 #endif
 

--- a/cpp/include/Ice/StreamHelpers.h
+++ b/cpp/include/Ice/StreamHelpers.h
@@ -11,8 +11,8 @@
 #include <ostream>
 
 #if defined(_MSC_VER)
-// With MSVC, __has_include(<span>) evaluates to 1 in c++17 mode and the <span> header then issues a warning. This
-// is a permissible but impractical behavior. As a result, we include <span> only for c++20 or higher.
+// With MSVC, __has_include(<span>) evaluates to 1 in c++17 mode and the <span> header then issues a warning that can't
+// be disabled. This is a permissible but impractical behavior. See https://github.com/microsoft/STL/issues/4010.
 #    if _MSVC_LANG >= 202002L
 #        include <span>
 #    endif

--- a/cpp/include/Ice/StreamHelpers.h
+++ b/cpp/include/Ice/StreamHelpers.h
@@ -10,7 +10,9 @@
 #include <iterator>
 #include <ostream>
 
-#if defined(_MSC_VER) // workaround for MSVC bug
+#if defined(_MSC_VER)
+// With MSVC, __has_include(<span>) evaluates to 1 in c++17 mode and the <span> header then issues a warning. This
+// is a permissible but impractical behavior. As a result, we include <span> only in c++20 mode.
 #    if _MSVC_LANG >= 202002L
 #        include <span>
 #    endif

--- a/cpp/include/Ice/VersionFunctions.h
+++ b/cpp/include/Ice/VersionFunctions.h
@@ -11,13 +11,13 @@
 namespace Ice
 {
     /** Identifies protocol version 1.0. */
-    constexpr ProtocolVersion Protocol_1_0{.major = 1, .minor = 0};
+    constexpr ProtocolVersion Protocol_1_0{1, 0};
 
     /** Identifies encoding version 1.0. */
-    constexpr EncodingVersion Encoding_1_0{.major = 1, .minor = 0};
+    constexpr EncodingVersion Encoding_1_0{1, 0};
 
     /** Identifies encoding version 1.1. */
-    constexpr EncodingVersion Encoding_1_1{.major = 1, .minor = 1};
+    constexpr EncodingVersion Encoding_1_1{1, 1};
 
     /** Identifies the latest protocol version. */
     constexpr ProtocolVersion currentProtocol{Protocol_1_0};


### PR DESCRIPTION
This PR updates the Ice C++ headers to support building applications (e.g. the demos) in C++17 mode.

Fixes #3476.

Note: the Ice C++ source builds still use C++20 and the source code uses designated initializers (a C++20 feature that appears to work with GCC in C++17 mode). That's fine - we just Ice C++ users to be able to use C++17 mode for their applications.