### PR TITLE
`Unit` Cycle Fixes & Cleanup `SyntaxTreeBase`

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -11,11 +11,6 @@
 #include <iterator>
 #include <limits>
 
-// TODO: fix this warning once we no longer support VS2013 and earlier
-#if defined(_MSC_VER)
-#    pragma warning(disable : 4589) // Constructor of abstract class 'Slice::Type' ignores initializer...
-#endif
-
 using namespace std;
 using namespace Slice;
 

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -722,6 +722,13 @@ Slice::Type::usesClasses() const
 // Builtin
 // ----------------------------------------------------------------------
 
+void
+Slice::Builtin::destroy()
+{
+    _unit = nullptr;
+}
+
+
 UnitPtr
 Slice::Builtin::unit()
 {
@@ -873,6 +880,12 @@ Slice::Builtin::Builtin(const UnitPtr& unit, Kind kind) : _unit(unit), _kind(kin
 // ----------------------------------------------------------------------
 // Contained
 // ----------------------------------------------------------------------
+
+void
+Slice::Contained::destroy()
+{
+    _unit = nullptr;
+}
 
 ContainerPtr
 Slice::Contained::container() const
@@ -2352,6 +2365,13 @@ Slice::Module::visit(ParserVisitor* visitor)
     }
 }
 
+void
+Slice::Module::destroy()
+{
+    Container::destroy();
+    Contained::destroy();
+}
+
 Slice::Module::Module(const ContainerPtr& container, const string& name) : Contained(container, name) {}
 
 // ----------------------------------------------------------------------
@@ -2428,6 +2448,7 @@ Slice::ClassDef::destroy()
     _declaration = nullptr;
     _base = nullptr;
     Container::destroy();
+    Contained::destroy();
 }
 
 DataMemberPtr
@@ -2896,6 +2917,7 @@ Slice::InterfaceDef::destroy()
     _declaration = nullptr;
     _bases.clear();
     Container::destroy();
+    Contained::destroy();
 }
 
 OperationPtr
@@ -3484,6 +3506,13 @@ Slice::Operation::visit(ParserVisitor* visitor)
     visitor->visitOperation(dynamic_pointer_cast<Operation>(shared_from_this()));
 }
 
+void
+Slice::Operation::destroy()
+{
+    Container::destroy();
+    Contained::destroy();
+}
+
 Slice::Operation::Operation(
     const ContainerPtr& container,
     const string& name,
@@ -3508,6 +3537,7 @@ Slice::Exception::destroy()
 {
     _base = nullptr;
     Container::destroy();
+    Contained::destroy();
 }
 
 DataMemberPtr
@@ -3890,6 +3920,13 @@ Slice::Struct::visit(ParserVisitor* visitor)
     }
 }
 
+void
+Slice::Struct::destroy()
+{
+    Container::destroy();
+    Contained::destroy();
+}
+
 Slice::Struct::Struct(const ContainerPtr& container, const string& name)
     : Contained(container, name),
       Constructed(container, name)
@@ -4234,6 +4271,13 @@ void
 Slice::Enum::visit(ParserVisitor* visitor)
 {
     visitor->visitEnum(dynamic_pointer_cast<Enum>(shared_from_this()));
+}
+
+void
+Slice::Enum::destroy()
+{
+    Container::destroy();
+    Contained::destroy();
 }
 
 Slice::Enum::Enum(const ContainerPtr& container, const string& name)

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1674,7 +1674,7 @@ Slice::Container::lookupType(const string& identifier)
         return {unit()->createBuiltin(*kind)};
     }
 
-    // Not a builtin type, try to look up a constructed type.
+    // Not a builtin type, try to look up a user-defined type.
     return lookupTypeNoBuiltin(identifier, true);
 }
 
@@ -2365,12 +2365,6 @@ Slice::Module::destroy()
 Slice::Module::Module(const ContainerPtr& container, const string& name) : Contained(container, name) {}
 
 // ----------------------------------------------------------------------
-// Constructed
-// ----------------------------------------------------------------------
-
-Slice::Constructed::Constructed(const ContainerPtr& container, const string& name) : Contained(container, name) {}
-
-// ----------------------------------------------------------------------
 // ClassDecl
 // ----------------------------------------------------------------------
 
@@ -2423,11 +2417,7 @@ Slice::ClassDecl::visit(ParserVisitor* visitor)
     visitor->visitClassDecl(shared_from_this());
 }
 
-Slice::ClassDecl::ClassDecl(const ContainerPtr& container, const string& name)
-    : Contained(container, name),
-      Constructed(container, name)
-{
-}
+Slice::ClassDecl::ClassDecl(const ContainerPtr& container, const string& name) : Contained(container, name) {}
 
 // ----------------------------------------------------------------------
 // ClassDef
@@ -2768,11 +2758,7 @@ Slice::InterfaceDecl::checkBasesAreLegal(const string& name, const InterfaceList
     }
 }
 
-Slice::InterfaceDecl::InterfaceDecl(const ContainerPtr& container, const string& name)
-    : Contained(container, name),
-      Constructed(container, name)
-{
-}
+Slice::InterfaceDecl::InterfaceDecl(const ContainerPtr& container, const string& name) : Contained(container, name) {}
 
 // Return true if the interface definition `idp` is on one of the interface lists in `gpl`, false otherwise.
 bool
@@ -3919,11 +3905,7 @@ Slice::Struct::destroy()
     Contained::destroy();
 }
 
-Slice::Struct::Struct(const ContainerPtr& container, const string& name)
-    : Contained(container, name),
-      Constructed(container, name)
-{
-}
+Slice::Struct::Struct(const ContainerPtr& container, const string& name) : Contained(container, name) {}
 
 // ----------------------------------------------------------------------
 // Sequence
@@ -3985,7 +3967,6 @@ Slice::Sequence::visit(ParserVisitor* visitor)
 
 Slice::Sequence::Sequence(const ContainerPtr& container, const string& name, TypePtr type, MetadataList typeMetadata)
     : Contained(container, name),
-      Constructed(container, name),
       _type(std::move(type)),
       _typeMetadata(std::move(typeMetadata))
 {
@@ -4127,7 +4108,6 @@ Slice::Dictionary::Dictionary(
     TypePtr valueType,
     MetadataList valueMetadata)
     : Contained(container, name),
-      Constructed(container, name),
       _keyType(std::move(keyType)),
       _valueType(std::move(valueType)),
       _keyMetadata(std::move(keyMetadata)),
@@ -4274,7 +4254,6 @@ Slice::Enum::destroy()
 
 Slice::Enum::Enum(const ContainerPtr& container, const string& name)
     : Contained(container, name),
-      Constructed(container, name),
       _minValue(numeric_limits<int32_t>::max())
 {
 }

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -4894,7 +4894,7 @@ Slice::Unit::destroy()
     {
         builtin.second->destroy();
     }
-    Container::destroy();
+    destroyContents();
 
     _contentMap.clear();
     _builtins.clear();

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -865,7 +865,7 @@ Slice::Builtin::kindFromString(string_view str)
     return nullopt;
 }
 
-Slice::Builtin::Builtin(const UnitPtr& unit, Kind kind) : _unit(unit), _kind(kind) {}
+Slice::Builtin::Builtin(const UnitPtr& unit, Kind kind) : _kind(kind), _unit(unit) {}
 
 // ----------------------------------------------------------------------
 // Contained

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1083,7 +1083,7 @@ Slice::Contained::Contained(const ContainerPtr& container, string name)
 // ----------------------------------------------------------------------
 
 void
-Slice::Container::destroy()
+Slice::Container::destroyContents()
 {
     for (const auto& i : _contents)
     {
@@ -2358,7 +2358,7 @@ Slice::Module::visit(ParserVisitor* visitor)
 void
 Slice::Module::destroy()
 {
-    Container::destroy();
+    destroyContents();
     Contained::destroy();
 }
 
@@ -2438,7 +2438,7 @@ Slice::ClassDef::destroy()
 {
     _declaration = nullptr;
     _base = nullptr;
-    Container::destroy();
+    destroyContents();
     Contained::destroy();
 }
 
@@ -2908,7 +2908,7 @@ Slice::InterfaceDef::destroy()
 {
     _declaration = nullptr;
     _bases.clear();
-    Container::destroy();
+    destroyContents();
     Contained::destroy();
 }
 
@@ -3501,7 +3501,7 @@ Slice::Operation::visit(ParserVisitor* visitor)
 void
 Slice::Operation::destroy()
 {
-    Container::destroy();
+    destroyContents();
     Contained::destroy();
 }
 
@@ -3528,7 +3528,7 @@ void
 Slice::Exception::destroy()
 {
     _base = nullptr;
-    Container::destroy();
+    destroyContents();
     Contained::destroy();
 }
 
@@ -3915,7 +3915,7 @@ Slice::Struct::visit(ParserVisitor* visitor)
 void
 Slice::Struct::destroy()
 {
-    Container::destroy();
+    destroyContents();
     Contained::destroy();
 }
 
@@ -4268,7 +4268,7 @@ Slice::Enum::visit(ParserVisitor* visitor)
 void
 Slice::Enum::destroy()
 {
-    Container::destroy();
+    destroyContents();
     Contained::destroy();
 }
 

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -860,7 +860,7 @@ Slice::Builtin::kindFromString(string_view str)
     return nullopt;
 }
 
-Slice::Builtin::Builtin(const UnitPtr& unit, Kind kind) : _kind(kind), _unit(unit) {}
+Slice::Builtin::Builtin(UnitPtr unit, Kind kind) : _kind(kind), _unit(std::move(unit)) {}
 
 // ----------------------------------------------------------------------
 // Contained

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -717,7 +717,7 @@ Slice::Builtin::destroy()
 }
 
 UnitPtr
-Slice::Builtin::unit()
+Slice::Builtin::unit() const
 {
     return _unit;
 }
@@ -962,7 +962,7 @@ Slice::Contained::definitionContext() const
 }
 
 UnitPtr
-Slice::Contained::unit()
+Slice::Contained::unit() const
 {
     return _container->unit();
 }
@@ -4899,9 +4899,10 @@ Slice::Unit::visit(ParserVisitor* visitor)
 }
 
 UnitPtr
-Slice::Unit::unit()
+Slice::Unit::unit() const
 {
-    return dynamic_pointer_cast<Unit>(shared_from_this());
+    ContainerPtr self = const_cast<Unit*>(this)->shared_from_this();
+    return dynamic_pointer_cast<Unit>(self);
 }
 
 BuiltinPtr

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -2378,6 +2378,7 @@ void
 Slice::ClassDecl::destroy()
 {
     _definition = nullptr;
+    Contained::destroy();
 }
 
 ClassDefPtr
@@ -2691,6 +2692,7 @@ void
 Slice::InterfaceDecl::destroy()
 {
     _definition = nullptr;
+    Contained::destroy();
 }
 
 InterfaceDefPtr
@@ -4909,9 +4911,14 @@ Slice::Unit::parse(const string& filename, FILE* file, bool debugMode)
 void
 Slice::Unit::destroy()
 {
+    for (auto& builtin : _builtins)
+    {
+        builtin.second->destroy();
+    }
+    Container::destroy();
+
     _contentMap.clear();
     _builtins.clear();
-    Container::destroy();
 }
 
 void

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1098,13 +1098,13 @@ Slice::Container::destroy()
 ModulePtr
 Slice::Container::createModule(const string& name)
 {
-    ContainedList matches = _unit->findContents(thisScope() + name);
+    ContainedList matches = unit()->findContents(thisScope() + name);
     matches.sort(containedCompare); // Modules can occur many times...
     matches.unique(containedEqual); // ... but we only want one instance of each.
 
     if (thisScope() == "::")
     {
-        _unit->addTopLevelModule(_unit->currentFile(), name);
+        unit()->addTopLevelModule(unit()->currentFile(), name);
     }
 
     for (const auto& p : matches)
@@ -1118,7 +1118,7 @@ Slice::Container::createModule(const string& name)
                 ostringstream os;
                 os << "module '" << name << "' is capitalized inconsistently with its previous name: '"
                    << module->name() << "'";
-                _unit->error(os.str());
+                unit()->error(os.str());
                 return nullptr;
             }
         }
@@ -1126,7 +1126,7 @@ Slice::Container::createModule(const string& name)
         {
             ostringstream os;
             os << "redefinition of " << matches.front()->kindOf() << " '" << matches.front()->name() << "' as module";
-            _unit->error(os.str());
+            unit()->error(os.str());
             return nullptr;
         }
         else
@@ -1134,7 +1134,7 @@ Slice::Container::createModule(const string& name)
             ostringstream os;
             os << "module '" << name << "' differs only in capitalization from " << matches.front()->kindOf()
                << " name '" << matches.front()->name() << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
             return nullptr;
         }
     }
@@ -1145,7 +1145,7 @@ Slice::Container::createModule(const string& name)
     }
 
     ModulePtr q = make_shared<Module>(shared_from_this(), name);
-    _unit->addContent(q);
+    unit()->addContent(q);
     _contents.push_back(q);
     return q;
 }
@@ -1153,7 +1153,7 @@ Slice::Container::createModule(const string& name)
 ClassDefPtr
 Slice::Container::createClassDef(const string& name, int id, const ClassDefPtr& base)
 {
-    ContainedList matches = _unit->findContents(thisScope() + name);
+    ContainedList matches = unit()->findContents(thisScope() + name);
     for (const auto& p : matches)
     {
         ClassDeclPtr decl = dynamic_pointer_cast<ClassDecl>(p);
@@ -1171,13 +1171,13 @@ Slice::Container::createClassDef(const string& name, int id, const ClassDefPtr& 
                 ostringstream os;
                 os << "class definition '" << name << "' is capitalized inconsistently with its previous name: '"
                    << def->name() << "'";
-                _unit->error(os.str());
+                unit()->error(os.str());
             }
             else
             {
                 ostringstream os;
                 os << "redefinition of class '" << name << "'";
-                _unit->error(os.str());
+                unit()->error(os.str());
             }
         }
         else if (differsOnlyInCase)
@@ -1185,13 +1185,13 @@ Slice::Container::createClassDef(const string& name, int id, const ClassDefPtr& 
             ostringstream os;
             os << "class definition '" << name << "' differs only in capitalization from " << matches.front()->kindOf()
                << " name '" << matches.front()->name() << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         else
         {
             ostringstream os;
             os << "class '" << name << "' was previously defined as " << prependA(matches.front()->kindOf());
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         return nullptr;
     }
@@ -1214,7 +1214,7 @@ Slice::Container::createClassDef(const string& name, int id, const ClassDefPtr& 
         dynamic_pointer_cast<ClassDecl>(q)->_definition = def;
     }
 
-    _unit->addContent(def);
+    unit()->addContent(def);
     _contents.push_back(def);
     return def;
 }
@@ -1222,7 +1222,7 @@ Slice::Container::createClassDef(const string& name, int id, const ClassDefPtr& 
 ClassDeclPtr
 Slice::Container::createClassDecl(const string& name)
 {
-    ContainedList matches = _unit->findContents(thisScope() + name);
+    ContainedList matches = unit()->findContents(thisScope() + name);
     for (const auto& p : matches)
     {
         ClassDefPtr clDef = dynamic_pointer_cast<ClassDef>(p);
@@ -1243,13 +1243,13 @@ Slice::Container::createClassDecl(const string& name)
             ostringstream os;
             os << "class declaration '" << name << "' differs only in capitalization from " << matches.front()->kindOf()
                << " name '" << matches.front()->name() << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         else
         {
             ostringstream os;
             os << "class '" << name << "' was previously defined as " << prependA(matches.front()->kindOf());
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         return nullptr;
     }
@@ -1277,7 +1277,7 @@ Slice::Container::createClassDecl(const string& name)
     }
 
     ClassDeclPtr decl = make_shared<ClassDecl>(shared_from_this(), name);
-    _unit->addContent(decl);
+    unit()->addContent(decl);
     _contents.push_back(decl);
     return decl;
 }
@@ -1285,7 +1285,7 @@ Slice::Container::createClassDecl(const string& name)
 InterfaceDefPtr
 Slice::Container::createInterfaceDef(const string& name, const InterfaceList& bases)
 {
-    ContainedList matches = _unit->findContents(thisScope() + name);
+    ContainedList matches = unit()->findContents(thisScope() + name);
     for (const auto& p : matches)
     {
         InterfaceDeclPtr decl = dynamic_pointer_cast<InterfaceDecl>(p);
@@ -1303,13 +1303,13 @@ Slice::Container::createInterfaceDef(const string& name, const InterfaceList& ba
                 ostringstream os;
                 os << "interface definition '" << name << "' is capitalized inconsistently with its previous name: '"
                    << def->name() + "'";
-                _unit->error(os.str());
+                unit()->error(os.str());
             }
             else
             {
                 ostringstream os;
                 os << "redefinition of interface '" << name << "'";
-                _unit->error(os.str());
+                unit()->error(os.str());
             }
         }
         else if (differsOnlyInCase)
@@ -1317,13 +1317,13 @@ Slice::Container::createInterfaceDef(const string& name, const InterfaceList& ba
             ostringstream os;
             os << "interface definition '" << name << "' differs only in capitalization from "
                << matches.front()->kindOf() << " name '" << matches.front()->name() << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         else
         {
             ostringstream os;
             os << "interface '" << name << "' was previously defined as " << prependA(matches.front()->kindOf());
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         return nullptr;
     }
@@ -1333,7 +1333,7 @@ Slice::Container::createInterfaceDef(const string& name, const InterfaceList& ba
         return nullptr;
     }
 
-    InterfaceDecl::checkBasesAreLegal(name, bases, _unit);
+    InterfaceDecl::checkBasesAreLegal(name, bases, unit());
 
     // Implicitly create an interface declaration for each interface definition.
     // This way the code generator can rely on always having an interface declaration available for lookup.
@@ -1348,7 +1348,7 @@ Slice::Container::createInterfaceDef(const string& name, const InterfaceList& ba
         dynamic_pointer_cast<InterfaceDecl>(q)->_definition = def;
     }
 
-    _unit->addContent(def);
+    unit()->addContent(def);
     _contents.push_back(def);
     return def;
 }
@@ -1356,7 +1356,7 @@ Slice::Container::createInterfaceDef(const string& name, const InterfaceList& ba
 InterfaceDeclPtr
 Slice::Container::createInterfaceDecl(const string& name)
 {
-    ContainedList matches = _unit->findContents(thisScope() + name);
+    ContainedList matches = unit()->findContents(thisScope() + name);
     for (const auto& p : matches)
     {
         InterfaceDefPtr interfaceDef = dynamic_pointer_cast<InterfaceDef>(p);
@@ -1377,13 +1377,13 @@ Slice::Container::createInterfaceDecl(const string& name)
             ostringstream os;
             os << "interface declaration '" << name << "' differs only in capitalization from "
                << matches.front()->kindOf() << " name '" << matches.front()->name() << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         else
         {
             ostringstream os;
             os << "interface '" << name << "' was previously defined as " << prependA(matches.front()->kindOf());
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         return nullptr;
     }
@@ -1408,7 +1408,7 @@ Slice::Container::createInterfaceDecl(const string& name)
     }
 
     InterfaceDeclPtr decl = make_shared<InterfaceDecl>(shared_from_this(), name);
-    _unit->addContent(decl);
+    unit()->addContent(decl);
     _contents.push_back(decl);
     return decl;
 }
@@ -1416,21 +1416,21 @@ Slice::Container::createInterfaceDecl(const string& name)
 ExceptionPtr
 Slice::Container::createException(const string& name, const ExceptionPtr& base, NodeType nodeType)
 {
-    ContainedList matches = _unit->findContents(thisScope() + name);
+    ContainedList matches = unit()->findContents(thisScope() + name);
     if (!matches.empty())
     {
         if (matches.front()->name() == name)
         {
             ostringstream os;
             os << "redefinition of " << matches.front()->kindOf() << " '" << name << "' as exception";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         else
         {
             ostringstream os;
             os << "exception '" << name << "' differs only in capitalization from " << matches.front()->kindOf() << " '"
                << matches.front()->name() << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         return nullptr;
     }
@@ -1443,7 +1443,7 @@ Slice::Container::createException(const string& name, const ExceptionPtr& base, 
     }
 
     ExceptionPtr p = make_shared<Exception>(shared_from_this(), name, base);
-    _unit->addContent(p);
+    unit()->addContent(p);
     _contents.push_back(p);
     return p;
 }
@@ -1451,21 +1451,21 @@ Slice::Container::createException(const string& name, const ExceptionPtr& base, 
 StructPtr
 Slice::Container::createStruct(const string& name, NodeType nodeType)
 {
-    ContainedList matches = _unit->findContents(thisScope() + name);
+    ContainedList matches = unit()->findContents(thisScope() + name);
     if (!matches.empty())
     {
         if (matches.front()->name() == name)
         {
             ostringstream os;
             os << "redefinition of " << matches.front()->kindOf() << " '" << name << "' as struct";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         else
         {
             ostringstream os;
             os << "struct '" << name << "' differs only in capitalization from " << matches.front()->kindOf() << " '"
                << matches.front()->name() << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         return nullptr;
     }
@@ -1478,7 +1478,7 @@ Slice::Container::createStruct(const string& name, NodeType nodeType)
     }
 
     StructPtr p = make_shared<Struct>(shared_from_this(), name);
-    _unit->addContent(p);
+    unit()->addContent(p);
     _contents.push_back(p);
     return p;
 }
@@ -1486,21 +1486,21 @@ Slice::Container::createStruct(const string& name, NodeType nodeType)
 SequencePtr
 Slice::Container::createSequence(const string& name, const TypePtr& type, MetadataList metadata, NodeType nodeType)
 {
-    ContainedList matches = _unit->findContents(thisScope() + name);
+    ContainedList matches = unit()->findContents(thisScope() + name);
     if (!matches.empty())
     {
         if (matches.front()->name() == name)
         {
             ostringstream os;
             os << "redefinition of " << matches.front()->kindOf() << " '" << name << "' as sequence";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         else
         {
             ostringstream os;
             os << "sequence '" << name << "' differs only in capitalization from " << matches.front()->kindOf() << " '"
                << matches.front()->name() << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         return nullptr;
     }
@@ -1513,7 +1513,7 @@ Slice::Container::createSequence(const string& name, const TypePtr& type, Metada
     }
 
     SequencePtr p = make_shared<Sequence>(shared_from_this(), name, type, std::move(metadata));
-    _unit->addContent(p);
+    unit()->addContent(p);
     _contents.push_back(p);
     return p;
 }
@@ -1527,21 +1527,21 @@ Slice::Container::createDictionary(
     MetadataList valueMetadata,
     NodeType nodeType)
 {
-    ContainedList matches = _unit->findContents(thisScope() + name);
+    ContainedList matches = unit()->findContents(thisScope() + name);
     if (!matches.empty())
     {
         if (matches.front()->name() == name)
         {
             ostringstream os;
             os << "redefinition of " << matches.front()->kindOf() << " '" << name << "' as dictionary";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         else
         {
             ostringstream os;
             os << "dictionary '" << name << "' differs only in capitalization from " << matches.front()->kindOf()
                << " '" << matches.front()->name() << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         return nullptr;
     }
@@ -1556,7 +1556,7 @@ Slice::Container::createDictionary(
         {
             ostringstream os;
             os << "dictionary '" << name << "' uses an illegal key type";
-            _unit->error(os.str());
+            unit()->error(os.str());
             return nullptr;
         }
     }
@@ -1568,7 +1568,7 @@ Slice::Container::createDictionary(
         std::move(keyMetadata),
         valueType,
         std::move(valueMetadata));
-    _unit->addContent(p);
+    unit()->addContent(p);
     _contents.push_back(p);
     return p;
 }
@@ -1576,21 +1576,21 @@ Slice::Container::createDictionary(
 EnumPtr
 Slice::Container::createEnum(const string& name, NodeType nodeType)
 {
-    ContainedList matches = _unit->findContents(thisScope() + name);
+    ContainedList matches = unit()->findContents(thisScope() + name);
     if (!matches.empty())
     {
         if (matches.front()->name() == name)
         {
             ostringstream os;
             os << "redefinition of " << matches.front()->kindOf() << " '" << name << "' as enumeration";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         else
         {
             ostringstream os;
             os << "enumeration '" << name << "' differs only in capitalization from " << matches.front()->kindOf()
                << " '" << matches.front()->name() << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         return nullptr;
     }
@@ -1603,7 +1603,7 @@ Slice::Container::createEnum(const string& name, NodeType nodeType)
     }
 
     EnumPtr p = make_shared<Enum>(shared_from_this(), name);
-    _unit->addContent(p);
+    unit()->addContent(p);
     _contents.push_back(p);
     return p;
 }
@@ -1617,21 +1617,21 @@ Slice::Container::createConst(
     const string& valueString,
     NodeType nodeType)
 {
-    ContainedList matches = _unit->findContents(thisScope() + name);
+    ContainedList matches = unit()->findContents(thisScope() + name);
     if (!matches.empty())
     {
         if (matches.front()->name() == name)
         {
             ostringstream os;
             os << "redefinition of " << matches.front()->kindOf() << " '" << name << "' as constant";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         else
         {
             ostringstream os;
             os << "constant '" << name << "' differs only in capitalization from " << matches.front()->kindOf() << " '"
                << matches.front()->name() << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         return nullptr;
     }
@@ -1653,7 +1653,7 @@ Slice::Container::createConst(
 
     ConstPtr p =
         make_shared<Const>(shared_from_this(), name, type, std::move(metadata), resolvedValueType, valueString);
-    _unit->addContent(p);
+    unit()->addContent(p);
     _contents.push_back(p);
     return p;
 }
@@ -1673,7 +1673,7 @@ Slice::Container::lookupType(const string& identifier)
     auto kind = Builtin::kindFromString(sc);
     if (kind)
     {
-        return {_unit->createBuiltin(*kind)};
+        return {unit()->createBuiltin(*kind)};
     }
 
     // Not a builtin type, try to look up a constructed type.
@@ -1694,14 +1694,14 @@ Slice::Container::lookupTypeNoBuiltin(const string& identifier, bool emitErrors,
     // Absolute scoped name?
     if (sc.size() >= 2 && sc[0] == ':')
     {
-        return _unit->lookupTypeNoBuiltin(sc.substr(2), emitErrors);
+        return unit()->lookupTypeNoBuiltin(sc.substr(2), emitErrors);
     }
 
     TypeList results;
     bool typeError = false;
     vector<string> errors;
 
-    ContainedList matches = _unit->findContents(thisScope() + sc);
+    ContainedList matches = unit()->findContents(thisScope() + sc);
     for (const auto& p : matches)
     {
         if (dynamic_pointer_cast<InterfaceDef>(p) || dynamic_pointer_cast<ClassDef>(p))
@@ -1724,7 +1724,7 @@ Slice::Container::lookupTypeNoBuiltin(const string& identifier, bool emitErrors,
             {
                 ostringstream os;
                 os << "'" << sc << "' is an exception, which cannot be used as a type";
-                _unit->error(os.str());
+                unit()->error(os.str());
             }
             return {};
         }
@@ -1757,7 +1757,7 @@ Slice::Container::lookupTypeNoBuiltin(const string& identifier, bool emitErrors,
             {
                 ostringstream os;
                 os << "'" << sc << "' is not defined";
-                _unit->error(os.str());
+                unit()->error(os.str());
             }
             return {};
         }
@@ -1768,7 +1768,7 @@ Slice::Container::lookupTypeNoBuiltin(const string& identifier, bool emitErrors,
     {
         for (const auto& error : errors)
         {
-            _unit->error(error);
+            unit()->error(error);
         }
     }
     return results;
@@ -1788,10 +1788,10 @@ Slice::Container::lookupContained(const string& identifier, bool emitErrors)
     // Absolute scoped name?
     if (sc.size() >= 2 && sc[0] == ':')
     {
-        return _unit->lookupContained(sc.substr(2), emitErrors);
+        return unit()->lookupContained(sc.substr(2), emitErrors);
     }
 
-    ContainedList matches = _unit->findContents(thisScope() + sc);
+    ContainedList matches = unit()->findContents(thisScope() + sc);
     ContainedList results;
     for (const auto& p : matches)
     {
@@ -1807,7 +1807,7 @@ Slice::Container::lookupContained(const string& identifier, bool emitErrors)
             ostringstream os;
             os << p->kindOf() << " name '" << identifier << "' is capitalized inconsistently with its previous name: '"
                << p->scoped() << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
     }
 
@@ -1820,7 +1820,7 @@ Slice::Container::lookupContained(const string& identifier, bool emitErrors)
             {
                 ostringstream os;
                 os << "'" << sc << "' is not defined";
-                _unit->error(os.str());
+                unit()->error(os.str());
             }
             return {};
         }
@@ -1851,7 +1851,7 @@ Slice::Container::lookupException(const string& identifier, bool emitErrors)
             {
                 ostringstream os;
                 os << "'" << identifier << "' is not an exception";
-                _unit->error(os.str());
+                unit()->error(os.str());
             }
             return nullptr;
         }
@@ -2088,7 +2088,7 @@ Slice::Container::checkIntroduced(const string& scopedName, ContainedPtr namedTh
                 return true;
             }
 
-            _unit->error("'" + firstComponent + "' has changed meaning");
+            unit()->error("'" + firstComponent + "' has changed meaning");
 
             return false;
         }
@@ -2103,7 +2103,7 @@ Slice::Container::checkForGlobalDefinition(const char* definitionKindPlural)
     {
         ostringstream os;
         os << definitionKindPlural << " can only be defined within a module";
-        _unit->error(os.str());
+        unit()->error(os.str());
         return false;
     }
     return true;
@@ -2138,14 +2138,14 @@ Slice::Container::validateConstant(
             {
                 ostringstream os;
                 os << "constant '" << name << "' has illegal type: '" << b->kindAsString() << "'";
-                _unit->error(os.str());
+                unit()->error(os.str());
             }
             else
             {
                 ostringstream os;
                 os << "default value not allowed for data member '" << name << "' of type '" << b->kindAsString()
                    << "'";
-                _unit->error(os.str());
+                unit()->error(os.str());
             }
             return false;
         }
@@ -2156,13 +2156,13 @@ Slice::Container::validateConstant(
         {
             ostringstream os;
             os << "constant '" << name << "' has illegal type";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         else
         {
             ostringstream os;
             os << "default value not allowed for data member '" << name << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         return false;
     }
@@ -2202,7 +2202,7 @@ Slice::Container::validateConstant(
                 ostringstream os;
                 os << "initializer of type '" << lt->kindAsString() << "' is incompatible with the type '"
                    << b->kindAsString() << "' of " << desc << " '" << name << "'";
-                _unit->error(os.str());
+                unit()->error(os.str());
                 return false;
             }
         }
@@ -2211,7 +2211,7 @@ Slice::Container::validateConstant(
             ostringstream os;
             os << "type of initializer is incompatible with the type '" << b->kindAsString() << "' of " << desc << " '"
                << name << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
             return false;
         }
 
@@ -2225,7 +2225,7 @@ Slice::Container::validateConstant(
                     ostringstream os;
                     os << "initializer '" << valueString << "' for " << desc << " '" << name
                        << "' out of range for type byte";
-                    _unit->error(os.str());
+                    unit()->error(os.str());
                     return false;
                 }
                 break;
@@ -2238,7 +2238,7 @@ Slice::Container::validateConstant(
                     ostringstream os;
                     os << "initializer '" << valueString << "' for " << desc << " '" << name
                        << "' out of range for type short";
-                    _unit->error(os.str());
+                    unit()->error(os.str());
                     return false;
                 }
                 break;
@@ -2251,7 +2251,7 @@ Slice::Container::validateConstant(
                     ostringstream os;
                     os << "initializer '" << valueString << "' for " + desc << " '" << name
                        << "' out of range for type int";
-                    _unit->error(os.str());
+                    unit()->error(os.str());
                     return false;
                 }
                 break;
@@ -2273,7 +2273,7 @@ Slice::Container::validateConstant(
             {
                 ostringstream os;
                 os << "type of initializer is incompatible with the type of " << desc << " '" << name << "'";
-                _unit->error(os.str());
+                unit()->error(os.str());
                 return false;
             }
         }
@@ -2287,7 +2287,7 @@ Slice::Container::validateConstant(
                 {
                     ostringstream os;
                     os << "type of initializer is incompatible with the type of " << desc << " '" << name << "'";
-                    _unit->error(os.str());
+                    unit()->error(os.str());
                     return false;
                 }
                 EnumeratorList elist = e->enumerators();
@@ -2295,7 +2295,7 @@ Slice::Container::validateConstant(
                 {
                     ostringstream os;
                     os << "enumerator '" << valueString << "' is not defined in enumeration '" << e->scoped() << "'";
-                    _unit->error(os.str());
+                    unit()->error(os.str());
                     return false;
                 }
             }
@@ -2315,7 +2315,7 @@ Slice::Container::validateConstant(
                 {
                     ostringstream os;
                     os << "'" << valueString << "' does not designate an enumerator of '" << e->scoped() << "'";
-                    _unit->error(os.str());
+                    unit()->error(os.str());
                     return false;
                 }
 
@@ -2328,7 +2328,7 @@ Slice::Container::validateConstant(
                 {
                     ostringstream os;
                     os << "type of initializer is incompatible with the type of " << desc << " '" << name << "'";
-                    _unit->error(os.str());
+                    unit()->error(os.str());
                     return false;
                 }
             }
@@ -2459,7 +2459,7 @@ Slice::ClassDef::createDataMember(
     const SyntaxTreeBasePtr& defaultValueType,
     const string& defaultValueString)
 {
-    ContainedList matches = _unit->findContents(thisScope() + name);
+    ContainedList matches = unit()->findContents(thisScope() + name);
     if (!matches.empty())
     {
         if (matches.front()->name() != name)
@@ -2467,14 +2467,14 @@ Slice::ClassDef::createDataMember(
             ostringstream os;
             os << "data member '" << name << "' differs only in capitalization from " << matches.front()->kindOf()
                << " '" << matches.front()->name() << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         else
         {
             ostringstream os;
             os << "redefinition of " << matches.front()->kindOf() << " '" << name << "' as data member '" << name
                << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
             return nullptr;
         }
     }
@@ -2492,7 +2492,7 @@ Slice::ClassDef::createDataMember(
             {
                 ostringstream os;
                 os << "data member '" << name << "' is already defined as a data member in a base class";
-                _unit->error(os.str());
+                unit()->error(os.str());
                 return nullptr;
             }
 
@@ -2503,7 +2503,7 @@ Slice::ClassDef::createDataMember(
                 ostringstream os;
                 os << "data member '" << name << "' differs only in capitalization from data member '"
                    << dataMember->name() << "', which is defined in a base class";
-                _unit->error(os.str());
+                unit()->error(os.str());
             }
         }
     }
@@ -2531,14 +2531,14 @@ Slice::ClassDef::createDataMember(
             {
                 ostringstream os;
                 os << "tag for optional data member '" << name << "' is already in use";
-                _unit->error(os.str());
+                unit()->error(os.str());
                 break;
             }
         }
     }
 
     DataMemberPtr member = make_shared<DataMember>(shared_from_this(), name, type, isOptional, tag, dlt, dv);
-    _unit->addContent(member);
+    unit()->addContent(member);
     _contents.push_back(member);
     return member;
 }
@@ -2931,7 +2931,7 @@ Slice::InterfaceDef::createOperation(
     int tag,
     Operation::Mode mode)
 {
-    ContainedList matches = _unit->findContents(thisScope() + name);
+    ContainedList matches = unit()->findContents(thisScope() + name);
     if (!matches.empty())
     {
         if (matches.front()->name() != name)
@@ -2939,12 +2939,12 @@ Slice::InterfaceDef::createOperation(
             ostringstream os;
             os << "operation '" << name << "' differs only in capitalization from " << matches.front()->kindOf() << " '"
                << matches.front()->name() << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         ostringstream os;
         os << "redefinition of " << matches.front()->kindOf() << " '" << matches.front()->name() << "' as operation '"
            << name << "'";
-        _unit->error(os.str());
+        unit()->error(os.str());
         return nullptr;
     }
 
@@ -2953,7 +2953,7 @@ Slice::InterfaceDef::createOperation(
     {
         ostringstream os;
         os << "interface name '" << name << "' cannot be used as operation name";
-        _unit->error(os.str());
+        unit()->error(os.str());
         return nullptr;
     }
 
@@ -2964,7 +2964,7 @@ Slice::InterfaceDef::createOperation(
         ostringstream os;
         os << "operation '" << name << "' differs only in capitalization from enclosing interface name '"
            << this->name() << "'";
-        _unit->error(os.str());
+        unit()->error(os.str());
         return nullptr;
     }
 
@@ -2989,7 +2989,7 @@ Slice::InterfaceDef::createOperation(
     }
 
     OperationPtr op = make_shared<Operation>(shared_from_this(), name, returnType, isOptional, tag, mode);
-    _unit->addContent(op);
+    unit()->addContent(op);
     _contents.push_back(op);
     return op;
 }
@@ -3005,7 +3005,7 @@ Slice::InterfaceDef::checkBaseOperationNames(const string& name, const vector<st
         {
             ostringstream os;
             os << "operation '" << name << "' is already defined as an operation in a base interface";
-            _unit->error(os.str());
+            unit()->error(os.str());
             return false;
         }
 
@@ -3016,7 +3016,7 @@ Slice::InterfaceDef::checkBaseOperationNames(const string& name, const vector<st
             ostringstream os;
             os << "operation '" << name << "' differs only in capitalization from operation"
                << " '" << baseName << "', which is defined in a base interface";
-            _unit->error(os.str());
+            unit()->error(os.str());
             return false;
         }
     }
@@ -3211,7 +3211,7 @@ Slice::Operation::hasMarshaledResult() const
 ParameterPtr
 Slice::Operation::createParameter(const string& name, const TypePtr& type, bool isOutParam, bool isOptional, int tag)
 {
-    ContainedList matches = _unit->findContents(thisScope() + name);
+    ContainedList matches = unit()->findContents(thisScope() + name);
     if (!matches.empty())
     {
         if (matches.front()->name() != name)
@@ -3219,13 +3219,13 @@ Slice::Operation::createParameter(const string& name, const TypePtr& type, bool 
             ostringstream os;
             os << "parameter '" << name << "' differs only in capitalization from parameter '"
                << matches.front()->name() << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         else
         {
             ostringstream os;
             os << "redefinition of parameter '" << name << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
             return nullptr;
         }
     }
@@ -3243,7 +3243,7 @@ Slice::Operation::createParameter(const string& name, const TypePtr& type, bool 
         {
             ostringstream os;
             os << "'" << name << "': in parameters cannot follow out parameters";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
     }
 
@@ -3254,7 +3254,7 @@ Slice::Operation::createParameter(const string& name, const TypePtr& type, bool 
         os << "tag for optional parameter '" << name << "' is already in use";
         if (_returnIsOptional && tag == _returnTag)
         {
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         else
         {
@@ -3262,7 +3262,7 @@ Slice::Operation::createParameter(const string& name, const TypePtr& type, bool 
             {
                 if (p->optional() && p->tag() == tag)
                 {
-                    _unit->error(os.str());
+                    unit()->error(os.str());
                     break;
                 }
             }
@@ -3270,7 +3270,7 @@ Slice::Operation::createParameter(const string& name, const TypePtr& type, bool 
     }
 
     ParameterPtr p = make_shared<Parameter>(shared_from_this(), name, type, isOutParam, isOptional, tag);
-    _unit->addContent(p);
+    unit()->addContent(p);
     _contents.push_back(p);
     return p;
 }
@@ -3400,7 +3400,7 @@ Slice::Operation::setExceptionList(const ExceptionList& exceptions)
         {
             os << ", '" << (*i)->name() << "'";
         }
-        _unit->error(os.str());
+        unit()->error(os.str());
     }
 }
 
@@ -3548,7 +3548,7 @@ Slice::Exception::createDataMember(
     const SyntaxTreeBasePtr& defaultValueType,
     const string& defaultValueString)
 {
-    ContainedList matches = _unit->findContents(thisScope() + name);
+    ContainedList matches = unit()->findContents(thisScope() + name);
     if (!matches.empty())
     {
         if (matches.front()->name() != name)
@@ -3556,13 +3556,13 @@ Slice::Exception::createDataMember(
             ostringstream os;
             os << "exception member '" << name << "' differs only in capitalization from exception member '"
                << matches.front()->name() << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         else
         {
             ostringstream os;
             os << "redefinition of exception member '" << name << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
             return nullptr;
         }
     }
@@ -3578,7 +3578,7 @@ Slice::Exception::createDataMember(
             {
                 ostringstream os;
                 os << "exception member '" << name << "' is already defined in a base exception";
-                _unit->error(os.str());
+                unit()->error(os.str());
                 return nullptr;
             }
 
@@ -3589,7 +3589,7 @@ Slice::Exception::createDataMember(
                 ostringstream os;
                 os << "exception member '" << name << "' differs only in capitalization from exception member '"
                    << member->name() << "', which is defined in a base exception";
-                _unit->error(os.str());
+                unit()->error(os.str());
             }
         }
     }
@@ -3617,14 +3617,14 @@ Slice::Exception::createDataMember(
             {
                 ostringstream os;
                 os << "tag for optional data member '" << name << "' is already in use";
-                _unit->error(os.str());
+                unit()->error(os.str());
                 break;
             }
         }
     }
 
     DataMemberPtr p = make_shared<DataMember>(shared_from_this(), name, type, isOptional, tag, dlt, dv);
-    _unit->addContent(p);
+    unit()->addContent(p);
     _contents.push_back(p);
     return p;
 }
@@ -3776,7 +3776,7 @@ Slice::Struct::createDataMember(
     const SyntaxTreeBasePtr& defaultValueType,
     const string& defaultValueString)
 {
-    ContainedList matches = _unit->findContents(thisScope() + name);
+    ContainedList matches = unit()->findContents(thisScope() + name);
     if (!matches.empty())
     {
         if (matches.front()->name() != name)
@@ -3784,13 +3784,13 @@ Slice::Struct::createDataMember(
             ostringstream os;
             os << "member '" << name << "' differs only in capitalization from member '" << matches.front()->name()
                << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         else
         {
             ostringstream os;
             os << "redefinition of struct member '" << name << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
             return nullptr;
         }
     }
@@ -3802,7 +3802,7 @@ Slice::Struct::createDataMember(
     {
         ostringstream os;
         os << "struct '" << this->name() << "' cannot contain itself";
-        _unit->error(os.str());
+        unit()->error(os.str());
         return nullptr;
     }
 
@@ -3821,7 +3821,7 @@ Slice::Struct::createDataMember(
     }
 
     DataMemberPtr p = make_shared<DataMember>(shared_from_this(), name, type, isOptional, tag, dlt, dv);
-    _unit->addContent(p);
+    unit()->addContent(p);
     _contents.push_back(p);
     return p;
 }
@@ -4158,7 +4158,7 @@ EnumeratorPtr
 Slice::Enum::createEnumerator(const string& name, optional<int> explicitValue)
 {
     // Validate the enumerator's name.
-    ContainedList matches = _unit->findContents(thisScope() + name);
+    ContainedList matches = unit()->findContents(thisScope() + name);
     if (!matches.empty())
     {
         EnumeratorPtr p = dynamic_pointer_cast<Enumerator>(matches.front());
@@ -4166,13 +4166,13 @@ Slice::Enum::createEnumerator(const string& name, optional<int> explicitValue)
         {
             ostringstream os;
             os << "redefinition of enumerator '" << name << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         else
         {
             ostringstream os;
             os << "enumerator '" << name << "' differs only in capitalization from '" << matches.front()->name() << "'";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
     }
     checkIdentifier(name); // Ignore return value.
@@ -4191,7 +4191,7 @@ Slice::Enum::createEnumerator(const string& name, optional<int> explicitValue)
         {
             ostringstream os;
             os << "value for enumerator '" << name << "' is out of range";
-            _unit->error(os.str());
+            unit()->error(os.str());
         }
         // If the enumerator was not assigned an explicit value,
         // we automatically assign it one more than the previous enumerator.
@@ -4218,7 +4218,7 @@ Slice::Enum::createEnumerator(const string& name, optional<int> explicitValue)
             {
                 ostringstream os;
                 os << "enumerator '" << name << "' has the same value as enumerator '" << r->name() << "'";
-                _unit->error(os.str());
+                unit()->error(os.str());
             }
         }
     }
@@ -4226,7 +4226,7 @@ Slice::Enum::createEnumerator(const string& name, optional<int> explicitValue)
     // Create the enumerator.
     ContainerPtr cont = shared_from_this();
     EnumeratorPtr p = make_shared<Enumerator>(cont, name, nextValue, explicitValue.has_value());
-    _unit->addContent(p);
+    unit()->addContent(p);
     _contents.push_back(p);
     _lastValue = nextValue;
     return p;

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -698,12 +698,6 @@ Slice::DocComment::exceptions() const
 // ----------------------------------------------------------------------
 
 void
-Slice::SyntaxTreeBase::destroy()
-{
-    //TODOAUSTIN _unit = nullptr;
-}
-
-void
 Slice::SyntaxTreeBase::visit(ParserVisitor* /*visitor*/)
 {
 }
@@ -1094,7 +1088,6 @@ Slice::Container::destroy()
     }
     _contents.clear();
     _introducedMap.clear();
-    SyntaxTreeBase::destroy();
 }
 
 ModulePtr
@@ -2375,7 +2368,6 @@ void
 Slice::ClassDecl::destroy()
 {
     _definition = nullptr;
-    SyntaxTreeBase::destroy();
 }
 
 ClassDefPtr
@@ -2688,7 +2680,6 @@ void
 Slice::InterfaceDecl::destroy()
 {
     _definition = nullptr;
-    SyntaxTreeBase::destroy();
 }
 
 InterfaceDefPtr
@@ -4119,12 +4110,6 @@ Slice::Dictionary::Dictionary(
 // Enum
 // ----------------------------------------------------------------------
 
-void
-Slice::Enum::destroy()
-{
-    SyntaxTreeBase::destroy();
-}
-
 EnumeratorPtr
 Slice::Enum::createEnumerator(const string& name, optional<int> explicitValue)
 {
@@ -4950,9 +4935,7 @@ Slice::Unit::getTopLevelModules(const string& file) const
 }
 
 Slice::Unit::Unit(string languageName, bool all, MetadataList defaultFileMetadata)
-    : SyntaxTreeBase(nullptr),
-      Container(nullptr),
-      _languageName(std::move(languageName)),
+    : _languageName(std::move(languageName)),
       _all(all),
       _defaultFileMetadata(std::move(defaultFileMetadata))
 {

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -719,7 +719,6 @@ Slice::Builtin::destroy()
     _unit = nullptr;
 }
 
-
 UnitPtr
 Slice::Builtin::unit()
 {

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -704,7 +704,7 @@ Slice::SyntaxTreeBase::destroy()
 }
 
 UnitPtr
-Slice::SyntaxTreeBase::unit() const
+Slice::SyntaxTreeBase::unit()
 {
     return _unit;
 }
@@ -1859,12 +1859,6 @@ Slice::Container::lookupException(const string& identifier, bool emitErrors)
     }
     assert(exceptions.size() == 1);
     return exceptions.front();
-}
-
-UnitPtr
-Slice::Container::unit() const
-{
-    return SyntaxTreeBase::unit();
 }
 
 ModuleList

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1995,7 +1995,7 @@ Slice::Container::thisScope() const
 }
 
 void
-Slice::Container::visit(ParserVisitor* visitor)
+Slice::Container::visitContents(ParserVisitor* visitor)
 {
     for (const auto& p : _contents)
     {
@@ -2351,7 +2351,7 @@ Slice::Module::visit(ParserVisitor* visitor)
     auto self = dynamic_pointer_cast<Module>(shared_from_this());
     if (visitor->visitModuleStart(self))
     {
-        Container::visit(visitor);
+        visitContents(visitor);
         visitor->visitModuleEnd(self);
     }
 }
@@ -2644,7 +2644,7 @@ Slice::ClassDef::visit(ParserVisitor* visitor)
     auto self = dynamic_pointer_cast<ClassDef>(shared_from_this());
     if (visitor->visitClassDefStart(self))
     {
-        Container::visit(visitor);
+        visitContents(visitor);
         visitor->visitClassDefEnd(self);
     }
 }
@@ -3094,7 +3094,7 @@ Slice::InterfaceDef::visit(ParserVisitor* visitor)
     auto self = dynamic_pointer_cast<InterfaceDef>(shared_from_this());
     if (visitor->visitInterfaceDefStart(self))
     {
-        Container::visit(visitor);
+        visitContents(visitor);
         visitor->visitInterfaceDefEnd(self);
     }
 }
@@ -3742,7 +3742,7 @@ Slice::Exception::visit(ParserVisitor* visitor)
     auto self = dynamic_pointer_cast<Exception>(shared_from_this());
     if (visitor->visitExceptionStart(self))
     {
-        Container::visit(visitor);
+        visitContents(visitor);
         visitor->visitExceptionEnd(self);
     }
 }
@@ -3906,7 +3906,7 @@ Slice::Struct::visit(ParserVisitor* visitor)
     auto self = dynamic_pointer_cast<Struct>(shared_from_this());
     if (visitor->visitStructStart(self))
     {
-        Container::visit(visitor);
+        visitContents(visitor);
         visitor->visitStructEnd(self);
     }
 }
@@ -4921,7 +4921,7 @@ Slice::Unit::visit(ParserVisitor* visitor)
     auto self = dynamic_pointer_cast<Unit>(shared_from_this());
     if (visitor->visitUnitStart(self))
     {
-        Container::visit(visitor);
+        visitContents(visitor);
         visitor->visitUnitEnd(self);
     }
 }

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -694,15 +694,6 @@ Slice::DocComment::exceptions() const
 }
 
 // ----------------------------------------------------------------------
-// SyntaxTreeBase
-// ----------------------------------------------------------------------
-
-void
-Slice::SyntaxTreeBase::visit(ParserVisitor* /*visitor*/)
-{
-}
-
-// ----------------------------------------------------------------------
 // Type
 // ----------------------------------------------------------------------
 
@@ -4313,6 +4304,12 @@ int
 Slice::Enumerator::value() const
 {
     return _value;
+}
+
+void
+Slice::Enumerator::visit(ParserVisitor*)
+{
+    // TODO we should probably visit enumerators, even if only for validation purposes.
 }
 
 Slice::Enumerator::Enumerator(const ContainerPtr& container, const string& name, int value, bool hasExplicitValue)

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -868,14 +868,6 @@ Slice::Builtin::Builtin(UnitPtr unit, Kind kind) : _kind(kind), _unit(std::move(
 // Contained
 // ----------------------------------------------------------------------
 
-void
-Slice::Contained::destroy()
-{
-    // We keep a pointer to the Unit that this element lives within.
-    // And that Unit transitively has a pointer to this element since through its `contents`.
-    _unit = nullptr;
-}
-
 ContainerPtr
 Slice::Contained::container() const
 {
@@ -908,7 +900,7 @@ Slice::Contained::scope() const
 string
 Slice::Contained::mappedName() const
 {
-    const string languageName = _unit->languageName();
+    const string languageName = unit()->languageName();
     assert(!languageName.empty());
 
     // First check if any 'xxx:identifier' has been applied to this element.
@@ -972,7 +964,7 @@ Slice::Contained::definitionContext() const
 UnitPtr
 Slice::Contained::unit()
 {
-    return _unit;
+    return _container->unit();
 }
 
 MetadataList
@@ -1066,15 +1058,14 @@ Slice::Contained::getDeprecationReason() const
 
 Slice::Contained::Contained(const ContainerPtr& container, string name)
     : _container(container),
-      _name(std::move(name)),
-      _unit(container->unit())
+      _name(std::move(name))
 {
-    assert(_unit);
-    _file = _unit->currentFile();
-    _line = _unit->currentLine();
-    _docComment = _unit->currentDocComment();
-    _includeLevel = _unit->currentIncludeLevel();
-    _definitionContext = _unit->currentDefinitionContext();
+    UnitPtr unit = container->unit();
+    _file = unit->currentFile();
+    _line = unit->currentLine();
+    _docComment = unit->currentDocComment();
+    _includeLevel = unit->currentIncludeLevel();
+    _definitionContext = unit->currentDefinitionContext();
 }
 
 // ----------------------------------------------------------------------
@@ -2361,7 +2352,6 @@ void
 Slice::Module::destroy()
 {
     destroyContents();
-    Contained::destroy();
 }
 
 Slice::Module::Module(const ContainerPtr& container, const string& name) : Contained(container, name) {}
@@ -2374,7 +2364,6 @@ void
 Slice::ClassDecl::destroy()
 {
     _definition = nullptr;
-    Contained::destroy();
 }
 
 ClassDefPtr
@@ -2431,7 +2420,6 @@ Slice::ClassDef::destroy()
     _declaration = nullptr;
     _base = nullptr;
     destroyContents();
-    Contained::destroy();
 }
 
 DataMemberPtr
@@ -2684,7 +2672,6 @@ void
 Slice::InterfaceDecl::destroy()
 {
     _definition = nullptr;
-    Contained::destroy();
 }
 
 InterfaceDefPtr
@@ -2897,7 +2884,6 @@ Slice::InterfaceDef::destroy()
     _declaration = nullptr;
     _bases.clear();
     destroyContents();
-    Contained::destroy();
 }
 
 OperationPtr
@@ -3490,7 +3476,6 @@ void
 Slice::Operation::destroy()
 {
     destroyContents();
-    Contained::destroy();
 }
 
 Slice::Operation::Operation(
@@ -3517,7 +3502,6 @@ Slice::Exception::destroy()
 {
     _base = nullptr;
     destroyContents();
-    Contained::destroy();
 }
 
 DataMemberPtr
@@ -3904,7 +3888,6 @@ void
 Slice::Struct::destroy()
 {
     destroyContents();
-    Contained::destroy();
 }
 
 Slice::Struct::Struct(const ContainerPtr& container, const string& name) : Contained(container, name) {}
@@ -4251,7 +4234,6 @@ void
 Slice::Enum::destroy()
 {
     destroyContents();
-    Contained::destroy();
 }
 
 Slice::Enum::Enum(const ContainerPtr& container, const string& name)

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -1056,9 +1056,7 @@ Slice::Contained::getDeprecationReason() const
     return (reasonMessage.empty()) ? nullopt : optional{reasonMessage};
 }
 
-Slice::Contained::Contained(const ContainerPtr& container, string name)
-    : _container(container),
-      _name(std::move(name))
+Slice::Contained::Contained(const ContainerPtr& container, string name) : _container(container), _name(std::move(name))
 {
     UnitPtr unit = container->unit();
     _file = unit->currentFile();

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -310,7 +310,6 @@ namespace Slice
     class SyntaxTreeBase : public GrammarBase
     {
     public:
-        virtual void destroy() {};
         [[nodiscard]] virtual UnitPtr unit() = 0;
     };
 
@@ -351,7 +350,7 @@ namespace Slice
         };
 
         Builtin(const UnitPtr& unit, Kind kind);
-        void destroy() final;
+        void destroy();
         [[nodiscard]] UnitPtr unit() final;
 
         [[nodiscard]] bool isClassType() const final;
@@ -382,7 +381,7 @@ namespace Slice
     class Contained : public virtual SyntaxTreeBase
     {
     public:
-        void destroy() override;
+        virtual void destroy();
         [[nodiscard]] ContainerPtr container() const;
 
         /// Returns the Slice identifier of this element.
@@ -452,7 +451,7 @@ namespace Slice
     class Container : public virtual SyntaxTreeBase, public std::enable_shared_from_this<Container>
     {
     public:
-        void destroy() override;
+        void destroyContents();
         ModulePtr createModule(const std::string& name);
         [[nodiscard]] ClassDefPtr createClassDef(const std::string& name, int id, const ClassDefPtr& base);
         [[nodiscard]] ClassDeclPtr createClassDecl(const std::string& name);
@@ -1073,7 +1072,7 @@ namespace Slice
 
         int parse(const std::string& filename, FILE* file, bool debugMode);
 
-        void destroy() final;
+        void destroy();
         void visit(ParserVisitor* visitor);
         [[nodiscard]] UnitPtr unit() final;
 

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -379,7 +379,7 @@ namespace Slice
     class Contained : public virtual SyntaxTreeBase
     {
     public:
-        virtual void destroy();
+        virtual void destroy() {};
         [[nodiscard]] ContainerPtr container() const;
 
         /// Returns the Slice identifier of this element.
@@ -437,9 +437,6 @@ namespace Slice
         int _includeLevel;
         DefinitionContextPtr _definitionContext;
         MetadataList _metadata;
-
-    private:
-        UnitPtr _unit;
     };
 
     // ----------------------------------------------------------------------

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -311,7 +311,7 @@ namespace Slice
     {
     public:
         virtual void destroy() {};
-        virtual void visit(ParserVisitor* visitor);
+        virtual void visit(ParserVisitor* visitor) = 0;
         [[nodiscard]] virtual UnitPtr unit() = 0;
     };
 
@@ -924,6 +924,8 @@ namespace Slice
 
         [[nodiscard]] bool hasExplicitValue() const;
         [[nodiscard]] int value() const;
+
+        void visit(ParserVisitor* visitor) final;
 
     private:
         bool _hasExplicitValue;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -900,7 +900,7 @@ namespace Slice
     // Enumerator
     // ----------------------------------------------------------------------
 
-    class Enumerator final : public virtual Contained
+    class Enumerator final : public Contained
     {
     public:
         Enumerator(const ContainerPtr& container, const std::string& name, int value, bool hasExplicitValue);
@@ -921,7 +921,7 @@ namespace Slice
     // Const
     // ----------------------------------------------------------------------
 
-    class Const final : public virtual Contained, public std::enable_shared_from_this<Const>
+    class Const final : public Contained, public std::enable_shared_from_this<Const>
     {
     public:
         Const(
@@ -950,7 +950,7 @@ namespace Slice
     // Parameter
     // ----------------------------------------------------------------------
 
-    class Parameter final : public virtual Contained, public std::enable_shared_from_this<Parameter>
+    class Parameter final : public Contained, public std::enable_shared_from_this<Parameter>
     {
     public:
         Parameter(
@@ -978,7 +978,7 @@ namespace Slice
     // DataMember
     // ----------------------------------------------------------------------
 
-    class DataMember final : public virtual Contained, public std::enable_shared_from_this<DataMember>
+    class DataMember final : public Contained, public std::enable_shared_from_this<DataMember>
     {
     public:
         DataMember(

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -352,6 +352,7 @@ namespace Slice
         };
 
         Builtin(const UnitPtr& unit, Kind kind);
+        void destroy() final;
         [[nodiscard]] UnitPtr unit() final;
 
         [[nodiscard]] bool isClassType() const final;
@@ -372,7 +373,7 @@ namespace Slice
 
     private:
         const Kind _kind;
-        const UnitPtr _unit;
+        UnitPtr _unit;
     };
 
     // ----------------------------------------------------------------------
@@ -382,6 +383,7 @@ namespace Slice
     class Contained : public virtual SyntaxTreeBase
     {
     public:
+        void destroy() override;
         [[nodiscard]] ContainerPtr container() const;
 
         /// Returns the Slice identifier of this element.
@@ -440,7 +442,7 @@ namespace Slice
         MetadataList _metadata;
 
     private:
-        const UnitPtr _unit;
+        UnitPtr _unit;
     };
 
     // ----------------------------------------------------------------------
@@ -539,6 +541,7 @@ namespace Slice
         Module(const ContainerPtr& container, const std::string& name);
         [[nodiscard]] std::string kindOf() const final;
         void visit(ParserVisitor* visitor) final;
+        void destroy() final;
     };
 
     // ----------------------------------------------------------------------
@@ -705,6 +708,7 @@ namespace Slice
         [[nodiscard]] std::optional<FormatType> format() const;
         [[nodiscard]] std::string kindOf() const final;
         void visit(ParserVisitor* visitor) final;
+        void destroy() final;
 
     private:
         TypePtr _returnType;
@@ -819,6 +823,7 @@ namespace Slice
         [[nodiscard]] bool isVariableLength() const final;
         [[nodiscard]] std::string kindOf() const final;
         void visit(ParserVisitor* visitor) final;
+        void destroy() final;
     };
 
     // ----------------------------------------------------------------------
@@ -897,6 +902,7 @@ namespace Slice
         [[nodiscard]] bool isVariableLength() const final;
         [[nodiscard]] std::string kindOf() const final;
         void visit(ParserVisitor* visitor) final;
+        void destroy() final;
 
     private:
         bool _hasExplicitValues{false};

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -308,7 +308,7 @@ namespace Slice
     class SyntaxTreeBase : public GrammarBase
     {
     public:
-        [[nodiscard]] virtual UnitPtr unit() = 0;
+        [[nodiscard]] virtual UnitPtr unit() const = 0;
     };
 
     // ----------------------------------------------------------------------
@@ -349,7 +349,7 @@ namespace Slice
 
         Builtin(UnitPtr unit, Kind kind);
         void destroy();
-        [[nodiscard]] UnitPtr unit() final;
+        [[nodiscard]] UnitPtr unit() const final;
 
         [[nodiscard]] bool isClassType() const final;
         [[nodiscard]] size_t minWireSize() const final;
@@ -404,7 +404,7 @@ namespace Slice
 
         [[nodiscard]] int includeLevel() const;
         [[nodiscard]] DefinitionContextPtr definitionContext() const;
-        [[nodiscard]] UnitPtr unit() final;
+        [[nodiscard]] UnitPtr unit() const final;
 
         [[nodiscard]] virtual MetadataList getMetadata() const;
         virtual void setMetadata(MetadataList metadata);
@@ -1057,7 +1057,7 @@ namespace Slice
 
         void destroy();
         void visit(ParserVisitor* visitor);
-        [[nodiscard]] UnitPtr unit() final;
+        [[nodiscard]] UnitPtr unit() const final;
 
         // Not const, as builtins are created on the fly. (Lazy initialization.)
         BuiltinPtr createBuiltin(Builtin::Kind kind);

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -1021,6 +1021,7 @@ namespace Slice
     public:
         static UnitPtr
         createUnit(std::string languageName, bool all, const StringList& defaultFileMetadata = StringList());
+        Unit(std::string languageName, bool all, MetadataList defaultFileMetadata);
 
         [[nodiscard]] std::string languageName() const;
 
@@ -1075,8 +1076,6 @@ namespace Slice
         [[nodiscard]] std::set<std::string> getTopLevelModules(const std::string& file) const;
 
     private:
-        Unit(std::string languageName, bool all, MetadataList defaultFileMetadata);
-
         void pushDefinitionContext();
         void popDefinitionContext();
 

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -310,7 +310,7 @@ namespace Slice
     class SyntaxTreeBase : public GrammarBase
     {
     public:
-        virtual void destroy();
+        virtual void destroy() {};
         virtual void visit(ParserVisitor* visitor);
         [[nodiscard]] virtual UnitPtr unit() = 0;
     };
@@ -322,7 +322,6 @@ namespace Slice
     class Type : public virtual SyntaxTreeBase
     {
     public:
-        Type(const UnitPtr& unit);
         [[nodiscard]] virtual bool isClassType() const;
         [[nodiscard]] virtual bool usesClasses() const;
         [[nodiscard]] virtual size_t minWireSize() const = 0;
@@ -451,7 +450,6 @@ namespace Slice
     class Container : public virtual SyntaxTreeBase, public std::enable_shared_from_this<Container>
     {
     public:
-        Container(const UnitPtr& unit);
         void destroy() override;
         ModulePtr createModule(const std::string& name);
         [[nodiscard]] ClassDefPtr createClassDef(const std::string& name, int id, const ClassDefPtr& base);
@@ -890,7 +888,6 @@ namespace Slice
     {
     public:
         Enum(const ContainerPtr& container, const std::string& name);
-        void destroy() final;
         EnumeratorPtr createEnumerator(const std::string& name, std::optional<int> explicitValue);
         [[nodiscard]] bool hasExplicitValues() const;
         [[nodiscard]] int minValue() const;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -50,7 +50,6 @@ namespace Slice
     class Contained;
     class Container;
     class Module;
-    class Constructed;
     class ClassDecl;
     class ClassDef;
     class InterfaceDecl;
@@ -75,7 +74,6 @@ namespace Slice
     using ContainedPtr = std::shared_ptr<Contained>;
     using ContainerPtr = std::shared_ptr<Container>;
     using ModulePtr = std::shared_ptr<Module>;
-    using ConstructedPtr = std::shared_ptr<Constructed>;
     using ClassDeclPtr = std::shared_ptr<ClassDecl>;
     using ClassDefPtr = std::shared_ptr<ClassDef>;
     using InterfaceDeclPtr = std::shared_ptr<InterfaceDecl>;
@@ -544,20 +542,10 @@ namespace Slice
     };
 
     // ----------------------------------------------------------------------
-    // Constructed
-    // ----------------------------------------------------------------------
-
-    class Constructed : public virtual Type, public virtual Contained
-    {
-    public:
-        Constructed(const ContainerPtr& container, const std::string& name);
-    };
-
-    // ----------------------------------------------------------------------
     // ClassDecl
     // ----------------------------------------------------------------------
 
-    class ClassDecl final : public virtual Constructed, public std::enable_shared_from_this<ClassDecl>
+    class ClassDecl final : public virtual Contained, public virtual Type, public std::enable_shared_from_this<ClassDecl>
     {
     public:
         ClassDecl(const ContainerPtr& container, const std::string& name);
@@ -584,7 +572,7 @@ namespace Slice
     // Note: For the purpose of this parser, a class definition is not
     // considered to be a type, but a class declaration is. And each class
     // definition has at least one class declaration (but not vice versa),
-    // so if you need the class as a "constructed type", use the
+    // so if you need the class as a "type", use the
     // declaration() operation to navigate to the class declaration.
     //
     class ClassDef final : public virtual Container, public virtual Contained
@@ -629,7 +617,7 @@ namespace Slice
     // InterfaceDecl
     // ----------------------------------------------------------------------
 
-    class InterfaceDecl final : public virtual Constructed, public std::enable_shared_from_this<InterfaceDecl>
+    class InterfaceDecl final : public virtual Contained, public virtual Type, public std::enable_shared_from_this<InterfaceDecl>
     {
     public:
         InterfaceDecl(const ContainerPtr& container, const std::string& name);
@@ -725,7 +713,7 @@ namespace Slice
     // Note: For the purpose of this parser, an interface definition is not
     // considered to be a type, but an interface declaration is. And each interface
     // definition has at least one interface declaration (but not vice versa),
-    // so if you need the interface as a "constructed type", use the
+    // so if you need the interface as a "type", use the
     // declaration() function to navigate to the interface declaration.
     //
     class InterfaceDef final : public virtual Container, public virtual Contained
@@ -770,8 +758,6 @@ namespace Slice
     // ----------------------------------------------------------------------
     // Exception
     // ----------------------------------------------------------------------
-
-    // No inheritance from Constructed, as this is not a Type
     class Exception final : public virtual Container, public virtual Contained
     {
     public:
@@ -803,7 +789,7 @@ namespace Slice
     // Struct
     // ----------------------------------------------------------------------
 
-    class Struct final : public virtual Container, public virtual Constructed
+    class Struct final : public virtual Container, public virtual Contained, public virtual Type
     {
     public:
         Struct(const ContainerPtr& container, const std::string& name);
@@ -829,7 +815,7 @@ namespace Slice
     // Sequence
     // ----------------------------------------------------------------------
 
-    class Sequence final : public virtual Constructed, public std::enable_shared_from_this<Sequence>
+    class Sequence final : public virtual Contained, public virtual Type, public std::enable_shared_from_this<Sequence>
     {
     public:
         Sequence(const ContainerPtr& container, const std::string& name, TypePtr type, MetadataList typeMetadata);
@@ -852,7 +838,7 @@ namespace Slice
     // Dictionary
     // ----------------------------------------------------------------------
 
-    class Dictionary final : public virtual Constructed, public std::enable_shared_from_this<Dictionary>
+    class Dictionary final : public virtual Contained, public virtual Type, public std::enable_shared_from_this<Dictionary>
     {
     public:
         Dictionary(
@@ -888,7 +874,7 @@ namespace Slice
     // Enum
     // ----------------------------------------------------------------------
 
-    class Enum final : public virtual Container, public virtual Constructed
+    class Enum final : public virtual Container, public virtual Contained, public virtual Type
     {
     public:
         Enum(const ContainerPtr& container, const std::string& name);

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -329,7 +329,7 @@ namespace Slice
     // Builtin
     // ----------------------------------------------------------------------
 
-    class Builtin final : public virtual Type
+    class Builtin final : public Type
     {
     public:
         enum Kind
@@ -1009,7 +1009,7 @@ namespace Slice
     // Unit
     // ----------------------------------------------------------------------
 
-    class Unit final : public virtual Container
+    class Unit final : public Container
     {
     public:
         static UnitPtr

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -347,7 +347,7 @@ namespace Slice
             KindValue
         };
 
-        Builtin(const UnitPtr& unit, Kind kind);
+        Builtin(UnitPtr unit, Kind kind);
         void destroy();
         [[nodiscard]] UnitPtr unit() final;
 

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -532,7 +532,7 @@ namespace Slice
     // Module
     // ----------------------------------------------------------------------
 
-    class Module final : public virtual Container, public virtual Contained
+    class Module final : public Container, public Contained
     {
     public:
         Module(const ContainerPtr& container, const std::string& name);
@@ -545,7 +545,7 @@ namespace Slice
     // ClassDecl
     // ----------------------------------------------------------------------
 
-    class ClassDecl final : public virtual Contained, public virtual Type, public std::enable_shared_from_this<ClassDecl>
+    class ClassDecl final : public Contained, public Type, public std::enable_shared_from_this<ClassDecl>
     {
     public:
         ClassDecl(const ContainerPtr& container, const std::string& name);
@@ -575,7 +575,7 @@ namespace Slice
     // so if you need the class as a "type", use the
     // declaration() operation to navigate to the class declaration.
     //
-    class ClassDef final : public virtual Container, public virtual Contained
+    class ClassDef final : public Container, public Contained
     {
     public:
         ClassDef(const ContainerPtr& container, const std::string& name, int id, ClassDefPtr base);
@@ -617,7 +617,7 @@ namespace Slice
     // InterfaceDecl
     // ----------------------------------------------------------------------
 
-    class InterfaceDecl final : public virtual Contained, public virtual Type, public std::enable_shared_from_this<InterfaceDecl>
+    class InterfaceDecl final : public Contained, public Type, public std::enable_shared_from_this<InterfaceDecl>
     {
     public:
         InterfaceDecl(const ContainerPtr& container, const std::string& name);
@@ -656,7 +656,7 @@ namespace Slice
     // Operation
     // ----------------------------------------------------------------------
 
-    class Operation final : public virtual Contained, public virtual Container
+    class Operation final : public Container, public Contained
     {
     public:
         //
@@ -716,7 +716,7 @@ namespace Slice
     // so if you need the interface as a "type", use the
     // declaration() function to navigate to the interface declaration.
     //
-    class InterfaceDef final : public virtual Container, public virtual Contained
+    class InterfaceDef final : public Container, public Contained
     {
     public:
         InterfaceDef(const ContainerPtr& container, const std::string& name, InterfaceList bases);
@@ -758,7 +758,7 @@ namespace Slice
     // ----------------------------------------------------------------------
     // Exception
     // ----------------------------------------------------------------------
-    class Exception final : public virtual Container, public virtual Contained
+    class Exception final : public Container, public Contained
     {
     public:
         Exception(const ContainerPtr& container, const std::string& name, ExceptionPtr base);
@@ -789,7 +789,7 @@ namespace Slice
     // Struct
     // ----------------------------------------------------------------------
 
-    class Struct final : public virtual Container, public virtual Contained, public virtual Type
+    class Struct final : public Container, public Contained, public Type
     {
     public:
         Struct(const ContainerPtr& container, const std::string& name);
@@ -815,7 +815,7 @@ namespace Slice
     // Sequence
     // ----------------------------------------------------------------------
 
-    class Sequence final : public virtual Contained, public virtual Type, public std::enable_shared_from_this<Sequence>
+    class Sequence final : public Contained, public Type, public std::enable_shared_from_this<Sequence>
     {
     public:
         Sequence(const ContainerPtr& container, const std::string& name, TypePtr type, MetadataList typeMetadata);
@@ -838,7 +838,7 @@ namespace Slice
     // Dictionary
     // ----------------------------------------------------------------------
 
-    class Dictionary final : public virtual Contained, public virtual Type, public std::enable_shared_from_this<Dictionary>
+    class Dictionary final : public Contained, public Type, public std::enable_shared_from_this<Dictionary>
     {
     public:
         Dictionary(
@@ -874,7 +874,7 @@ namespace Slice
     // Enum
     // ----------------------------------------------------------------------
 
-    class Enum final : public virtual Container, public virtual Contained, public virtual Type
+    class Enum final : public Container, public Contained, public Type
     {
     public:
         Enum(const ContainerPtr& container, const std::string& name);

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -312,7 +312,7 @@ namespace Slice
     public:
         SyntaxTreeBase(UnitPtr unit);
         virtual void destroy();
-        [[nodiscard]] UnitPtr unit() const;
+        [[nodiscard]] UnitPtr unit();
         virtual void visit(ParserVisitor* visitor);
 
     protected:
@@ -481,7 +481,6 @@ namespace Slice
         lookupTypeNoBuiltin(const std::string& identifier, bool emitErrors, bool ignoreUndefined = false);
         [[nodiscard]] ContainedList lookupContained(const std::string& identifier, bool emitErrors);
         [[nodiscard]] ExceptionPtr lookupException(const std::string& identifier, bool emitErrors);
-        [[nodiscard]] UnitPtr unit() const;
         [[nodiscard]] ModuleList modules() const;
         [[nodiscard]] InterfaceList interfaces() const;
         [[nodiscard]] EnumList enums() const;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -379,7 +379,7 @@ namespace Slice
     class Contained : public virtual SyntaxTreeBase
     {
     public:
-        virtual void destroy() {};
+        virtual void destroy() {}
         [[nodiscard]] ContainerPtr container() const;
 
         /// Returns the Slice identifier of this element.

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -311,7 +311,6 @@ namespace Slice
     {
     public:
         virtual void destroy() {};
-        virtual void visit(ParserVisitor* visitor) = 0;
         [[nodiscard]] virtual UnitPtr unit() = 0;
     };
 
@@ -427,6 +426,7 @@ namespace Slice
         /// @return The message provided to the 'deprecated' metadata, if present.
         [[nodiscard]] std::optional<std::string> getDeprecationReason() const;
 
+        virtual void visit(ParserVisitor* visitor) = 0;
         [[nodiscard]] virtual std::string kindOf() const = 0;
 
     protected:
@@ -489,7 +489,7 @@ namespace Slice
         [[nodiscard]] EnumeratorList enumerators() const;
         [[nodiscard]] EnumeratorList enumerators(const std::string& identifier) const;
         [[nodiscard]] ContainedList contents() const;
-        void visit(ParserVisitor* visitor) override;
+        void visitContents(ParserVisitor* visitor);
 
         bool checkIntroduced(const std::string& scopedName, ContainedPtr namedThing = nullptr);
 
@@ -1074,7 +1074,7 @@ namespace Slice
         int parse(const std::string& filename, FILE* file, bool debugMode);
 
         void destroy() final;
-        void visit(ParserVisitor* visitor) final;
+        void visit(ParserVisitor* visitor);
         [[nodiscard]] UnitPtr unit() final;
 
         // Not const, as builtins are created on the fly. (Lazy initialization.)

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -310,13 +310,9 @@ namespace Slice
     class SyntaxTreeBase : public GrammarBase
     {
     public:
-        SyntaxTreeBase(UnitPtr unit);
         virtual void destroy();
-        [[nodiscard]] UnitPtr unit();
         virtual void visit(ParserVisitor* visitor);
-
-    protected:
-        UnitPtr _unit;
+        [[nodiscard]] virtual UnitPtr unit() = 0;
     };
 
     // ----------------------------------------------------------------------
@@ -357,6 +353,7 @@ namespace Slice
         };
 
         Builtin(const UnitPtr& unit, Kind kind);
+        [[nodiscard]] UnitPtr unit() final;
 
         [[nodiscard]] bool isClassType() const final;
         [[nodiscard]] size_t minWireSize() const final;
@@ -376,6 +373,7 @@ namespace Slice
 
     private:
         const Kind _kind;
+        const UnitPtr _unit;
     };
 
     // ----------------------------------------------------------------------
@@ -409,6 +407,7 @@ namespace Slice
 
         [[nodiscard]] int includeLevel() const;
         [[nodiscard]] DefinitionContextPtr definitionContext() const;
+        [[nodiscard]] UnitPtr unit() final;
 
         [[nodiscard]] virtual MetadataList getMetadata() const;
         virtual void setMetadata(MetadataList metadata);
@@ -440,6 +439,9 @@ namespace Slice
         int _includeLevel;
         DefinitionContextPtr _definitionContext;
         MetadataList _metadata;
+
+    private:
+        const UnitPtr _unit;
     };
 
     // ----------------------------------------------------------------------
@@ -1067,6 +1069,7 @@ namespace Slice
 
         void destroy() final;
         void visit(ParserVisitor* visitor) final;
+        [[nodiscard]] UnitPtr unit() final;
 
         // Not const, as builtins are created on the fly. (Lazy initialization.)
         BuiltinPtr createBuiltin(Builtin::Kind kind);

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -734,9 +734,9 @@ Slice::Gen::TypesVisitor::visitConst(const ConstPtr& p)
     }
     else
     {
-        auto constructed = dynamic_pointer_cast<Constructed>(p->type());
-        assert(constructed);
-        typeString = constructed->scoped();
+        auto contained = dynamic_pointer_cast<Contained>(p->type());
+        assert(contained);
+        typeString = contained->scoped();
     }
 
     Output& out = getOutput(p);

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -423,10 +423,9 @@ namespace
         if (dynamic_pointer_cast<ClassDef>(p) || dynamic_pointer_cast<ClassDecl>(p) ||
             dynamic_pointer_cast<Struct>(p) || dynamic_pointer_cast<Slice::Exception>(p))
         {
-            UnitPtr unt = p->container()->unit();
             string file = p->file();
             assert(!file.empty());
-            DefinitionContextPtr dc = unt->findDefinitionContext(file);
+            DefinitionContextPtr dc = p->unit()->findDefinitionContext(file);
             assert(dc);
 
             // TODO: why do we ignore all instances of this metadata except the first?

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -551,7 +551,7 @@ Slice::CsGenerator::writeMarshalUnmarshalCode(
         return;
     }
 
-    assert(dynamic_pointer_cast<Constructed>(type));
+    assert(dynamic_pointer_cast<Contained>(type));
     string helperName;
     DictionaryPtr d = dynamic_pointer_cast<Dictionary>(type);
     if (d)

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -1133,9 +1133,8 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(
         return;
     }
 
-    ConstructedPtr constructed = dynamic_pointer_cast<Constructed>(type);
+    assert(dynamic_pointer_cast<Contained>(type));
     StructPtr st = dynamic_pointer_cast<Struct>(type);
-    assert(constructed);
     if (marshal)
     {
         if (optionalParam)

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -297,7 +297,7 @@ CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     //
     //   ('MemberName', MemberType, Optional, Tag)
     //
-    // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a constructed type.
+    // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a user-defined type.
     if (!members.empty())
     {
         _out << "array(";
@@ -635,7 +635,7 @@ CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     //
     //   ('MemberName', MemberType, Optional, Tag)
     //
-    // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a constructed type.
+    // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a user-defined type.
     if (!members.empty())
     {
         _out << "array(";
@@ -739,7 +739,7 @@ CodeVisitor::visitStructStart(const StructPtr& p)
     //
     //   ('MemberName', MemberType)
     //
-    // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a constructed type.
+    // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a user-defined type.
     for (auto r = memberList.begin(); r != memberList.end(); ++r)
     {
         if (r != memberList.begin())

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -667,7 +667,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     //
     //   ('MemberName', MemberMetadata, MemberType, Optional, Tag)
     //
-    // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a constructed type.
+    // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a user-defined type.
     //
     if (members.size() > 1)
     {
@@ -1215,7 +1215,7 @@ Slice::Python::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     //
     //   ('MemberName', MemberMetadata, MemberType, Optional, Tag)
     //
-    // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a constructed type.
+    // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a user-defined type.
     //
     for (auto dmli = members.begin(); dmli != members.end(); ++dmli)
     {
@@ -1485,7 +1485,7 @@ Slice::Python::CodeVisitor::visitStructStart(const StructPtr& p)
     //
     //   ('MemberName', MemberMetadata, MemberType)
     //
-    // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a constructed type.
+    // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a user-defined type.
     //
     if (memberList.size() > 1)
     {

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -367,7 +367,7 @@ Slice::Ruby::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     //
     //   ['MemberName', MemberType, Optional, Tag]
     //
-    // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a constructed type.
+    // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a user-defined type.
     //
     _out << "[";
     if (members.size() > 1)
@@ -696,7 +696,7 @@ Slice::Ruby::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     //
     //   ['MemberName', MemberType, Optional, Tag]
     //
-    // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a constructed type.
+    // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a user-defined type.
     //
     for (auto dmli = members.begin(); dmli != members.end(); ++dmli)
     {
@@ -832,7 +832,7 @@ Slice::Ruby::CodeVisitor::visitStructStart(const StructPtr& p)
     //
     //   ['MemberName', MemberType]
     //
-    // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a constructed type.
+    // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a user-defined type.
     //
     if (memberList.size() > 1)
     {


### PR DESCRIPTION
The classes we use to represent Slice definitions in the parser rely heavily on inheritance. The base of all these types is `SyntaxTreeBase`. This PR's focus is on moving stuff out of `SyntaxTreeBase` and into more appropriate places,
further up the inheritance tree.

Specifically:
- `SyntaxTreeBase` has a default implementation of `visit` which is no-op. This is bad.
  It means that you can call `Builtin::visit`. But what does it even mean to visit a built in type?
  This `visit` function was moved up to `Contained`, which represents a Slice definition.
  These are the only sensible things to visit.
  Also, `visit` is now pure virtual. Every type should (and does) implement it's own visit logic.

- `SyntaxTreeBase` also holds a `UnitPtr` field. This was removed.
  We had to jump through hoops to get this to work for `Unit`, since this means it holds a `shared_ptr` to itself... Also, it made us unable to provide a default constructor for `SyntaxTreeBase`.
  So. This field was removed and replaced with a pure virtual `unit()` function.
  `Contained` holds a `UnitPtr` field, and returns it in it's implementation.
  Whereas `Unit` implements this function with `shared_from_this`.

- By slimming down `SyntaxTreeBase` in these ways, I was able to completely eliminate it's constructor, along with the constructors for `Type` and `Container`.

----

A result of this is that #3358 is fixed.