### PR TITLE
Remove cxxDescription from Swift LocalException

### DIFF
--- a/swift/src/Ice/LocalException.swift
+++ b/swift/src/Ice/LocalException.swift
@@ -8,22 +8,19 @@ public class LocalException: Exception, CustomStringConvertible {
     public let file: String
     /// The line number where this exception was thrown.
     public let line: Int32
-    /// The C++ exception description, when this exception is a C++ exception converted to Swift.
-    private let cxxDescription: String?
 
     /// A textual representation of this Ice exception.
-    public var description: String { cxxDescription ?? "\(file):\(line) \(ice_id()) \(message)" }
+    public var description: String { "\(file):\(line) \(ice_id()) \(message)" }
 
     /// Creates a LocalException.
     /// - Parameters:
     ///   - message: The exception message.
     ///   - file: The file where the exception was thrown.
     ///   - line: The line where the exception was thrown.
-    public init(_ message: String, file: String = #fileID, line: Int32 = #line) {
+    public required init(_ message: String, file: String = #fileID, line: Int32 = #line) {
         self.message = message
         self.file = file
         self.line = line
-        self.cxxDescription = nil
     }
 
     /// Gets the type ID of the class, for example "::Ice::CommunicatorDestroyedException".
@@ -31,18 +28,5 @@ public class LocalException: Exception, CustomStringConvertible {
     /// - Returns: The type ID of the class.
     public func ice_id() -> String {
         "::" + String(reflecting: type(of: self)).replacingOccurrences(of: ".", with: "::")
-    }
-
-    /// Creates a LocalException from an Ice C++ local exception.
-    /// - Parameters:
-    ///   - message: The exception message.
-    ///   - cxxDescription: The C++ exception description.
-    ///   - file: The file where the exception was thrown.
-    ///   - line: The line where the exception was thrown.
-    internal required init(message: String, cxxDescription: String, file: String, line: Int32) {
-        self.message = message
-        self.file = file
-        self.line = line
-        self.cxxDescription = cxxDescription
     }
 }

--- a/swift/src/Ice/LocalExceptionFactory.swift
+++ b/swift/src/Ice/LocalExceptionFactory.swift
@@ -18,8 +18,7 @@ class LocalExceptionFactory: ICELocalExceptionFactory {
     }
 
     static func registeredException(
-        _ typeId: String, kindOfObject: String, objectId: String, message: String,
-        file: String, line: Int32
+        _ typeId: String, kindOfObject: String, objectId: String, message: String, file: String, line: Int32
     ) -> Error {
         switch typeId {
         case "::Ice::AlreadyRegisteredException":
@@ -38,8 +37,7 @@ class LocalExceptionFactory: ICELocalExceptionFactory {
     }
 
     static func connectionClosedException(
-        _ typeId: String, closedByApplication: Bool, message: String,
-        file: String, line: Int32
+        _ typeId: String, closedByApplication: Bool, message: String, file: String, line: Int32
     ) -> Error {
         switch typeId {
         case "::Ice::ConnectionAbortedException":
@@ -57,22 +55,17 @@ class LocalExceptionFactory: ICELocalExceptionFactory {
         }
     }
 
-    static func localException(
-        _ typeId: String, message: String, file: String, line: Int32
-    )
-        -> Error
+    static func localException(_ typeId: String, message: String, file: String, line: Int32) -> Error
     {
         let className = typeId.dropFirst(2).replacingOccurrences(of: "::", with: ".")
         return if let localExceptionType = NSClassFromString(className) as? LocalException.Type {
             localExceptionType.init(message, file: file, line: line)
         } else {
-            CxxLocalException(
-                typeId: typeId, message: message, file: file, line: line)
+            CxxLocalException(typeId: typeId, message: message, file: file, line: line)
         }
     }
 
     static func cxxException(_ typeName: String, message: String) -> Error {
-        CxxLocalException(
-            typeId: typeName, message: message, file: "???", line: 0)
+        CxxLocalException(typeId: typeName, message: message, file: "???", line: 0)
     }
 }

--- a/swift/src/Ice/LocalExceptionFactory.swift
+++ b/swift/src/Ice/LocalExceptionFactory.swift
@@ -5,14 +5,13 @@ import IceImpl
 class LocalExceptionFactory: ICELocalExceptionFactory {
     static func requestFailedException(
         _ typeId: String, name: String, category: String, facet: String, operation: String,
-        message: String, cxxDescription: String, file: String, line: Int32
+        message: String, file: String, line: Int32
     ) -> Error {
         let className = typeId.dropFirst(2).replacingOccurrences(of: "::", with: ".")
         if let requestFailedExceptionType = NSClassFromString(className) as? RequestFailedException.Type {
             return requestFailedExceptionType.init(
                 id: Identity(name: name, category: category), facet: facet, operation: operation,
-                message: message,
-                cxxDescription: cxxDescription, file: file, line: line)
+                message: message, file: file, line: line)
         } else {
             fatalError("unexpected RequestFailedException type: \(typeId)")
         }
@@ -20,18 +19,17 @@ class LocalExceptionFactory: ICELocalExceptionFactory {
 
     static func registeredException(
         _ typeId: String, kindOfObject: String, objectId: String, message: String,
-        cxxDescription: String, file: String,
-        line: Int32
+        file: String, line: Int32
     ) -> Error {
         switch typeId {
         case "::Ice::AlreadyRegisteredException":
             AlreadyRegisteredException(
-                kindOfObject: kindOfObject, id: objectId, message: message, cxxDescription: cxxDescription,
+                kindOfObject: kindOfObject, id: objectId, message: message,
                 file: file,
                 line: line)
         case "::Ice::NotRegisteredException":
             NotRegisteredException(
-                kindOfObject: kindOfObject, id: objectId, message: message, cxxDescription: cxxDescription,
+                kindOfObject: kindOfObject, id: objectId, message: message,
                 file: file,
                 line: line)
         default:
@@ -40,18 +38,18 @@ class LocalExceptionFactory: ICELocalExceptionFactory {
     }
 
     static func connectionClosedException(
-        _ typeId: String, closedByApplication: Bool, message: String, cxxDescription: String,
+        _ typeId: String, closedByApplication: Bool, message: String,
         file: String, line: Int32
     ) -> Error {
         switch typeId {
         case "::Ice::ConnectionAbortedException":
             ConnectionAbortedException(
-                closedByApplication: closedByApplication, message: message, cxxDescription: cxxDescription,
+                closedByApplication: closedByApplication, message: message,
                 file: file,
                 line: line)
         case "::Ice::ConnectionClosedException":
             ConnectionClosedException(
-                closedByApplication: closedByApplication, message: message, cxxDescription: cxxDescription,
+                closedByApplication: closedByApplication, message: message,
                 file: file,
                 line: line)
         default:
@@ -60,23 +58,21 @@ class LocalExceptionFactory: ICELocalExceptionFactory {
     }
 
     static func localException(
-        _ typeId: String, message: String, cxxDescription: String, file: String, line: Int32
+        _ typeId: String, message: String, file: String, line: Int32
     )
         -> Error
     {
         let className = typeId.dropFirst(2).replacingOccurrences(of: "::", with: ".")
         return if let localExceptionType = NSClassFromString(className) as? LocalException.Type {
-            localExceptionType.init(
-                message: message, cxxDescription: cxxDescription, file: file, line: line)
+            localExceptionType.init(message, file: file, line: line)
         } else {
             CxxLocalException(
-                typeId: typeId, message: message, cxxDescription: cxxDescription, file: file, line: line)
+                typeId: typeId, message: message, file: file, line: line)
         }
     }
 
     static func cxxException(_ typeName: String, message: String) -> Error {
         CxxLocalException(
-            typeId: typeName, message: message, cxxDescription: "\(typeName) \(message)", file: "???",
-            line: 0)
+            typeId: typeName, message: message, file: "???", line: 0)
     }
 }

--- a/swift/src/Ice/LocalExceptionFactory.swift
+++ b/swift/src/Ice/LocalExceptionFactory.swift
@@ -55,8 +55,7 @@ class LocalExceptionFactory: ICELocalExceptionFactory {
         }
     }
 
-    static func localException(_ typeId: String, message: String, file: String, line: Int32) -> Error
-    {
+    static func localException(_ typeId: String, message: String, file: String, line: Int32) -> Error {
         let className = typeId.dropFirst(2).replacingOccurrences(of: "::", with: ".")
         return if let localExceptionType = NSClassFromString(className) as? LocalException.Type {
             localExceptionType.init(message, file: file, line: line)

--- a/swift/src/Ice/LocalExceptions.swift
+++ b/swift/src/Ice/LocalExceptions.swift
@@ -22,18 +22,17 @@ public class RequestFailedException: LocalException {
     ///   - facet: The facet of the target Ice object.
     ///   - operation: The operation name carried by the request.
     ///   - message: The exception message.
-    ///   - cxxDescription: The C++ exception description.
     ///   - file: The file where the exception was thrown.
     ///   - line: The line where the exception was thrown.
     internal required init(
-        id: Identity, facet: String, operation: String, message: String, cxxDescription: String,
+        id: Identity, facet: String, operation: String, message: String,
         file: String,
         line: Int32
     ) {
         self.id = id
         self.facet = facet
         self.operation = operation
-        super.init(message: message, cxxDescription: cxxDescription, file: file, line: line)
+        super.init(message, file: file, line: line)
     }
 
     internal init(
@@ -47,16 +46,11 @@ public class RequestFailedException: LocalException {
             line: line)
     }
 
-    override internal init(_ message: String, file: String, line: Int32) {
+    internal required init(_ message: String, file: String, line: Int32) {
         self.id = Identity()
         self.facet = ""
         self.operation = ""
         super.init(message, file: file, line: line)
-    }
-
-    // Don't use.
-    internal required init(message: String, cxxDescription: String, file: String, line: Int32) {
-        fatalError("RequestFailedException must be initialized with an id, facet, and operation")
     }
 
     internal class func makeMessage(typeName: String, id: Identity, facet: String, operation: String)
@@ -267,16 +261,16 @@ public final class AlreadyRegisteredException: LocalException {
 
     // Initializer for C++ exceptions
     internal init(
-        kindOfObject: String, id: String, message: String, cxxDescription: String, file: String,
+        kindOfObject: String, id: String, message: String, file: String,
         line: Int32
     ) {
         self.kindOfObject = kindOfObject
         self.id = id
-        super.init(message: message, cxxDescription: cxxDescription, file: file, line: line)
+        super.init(message, file: file, line: line)
     }
 
     // Don't use.
-    internal required init(message: String, cxxDescription: String, file: String, line: Int32) {
+    internal required init(_ message: String, file: String, line: Int32) {
         fatalError("AlreadyRegisteredException must be initialized with a kindOfObject and id")
     }
 }
@@ -294,14 +288,14 @@ public final class ConnectionAbortedException: LocalException {
     public let closedByApplication: Bool
 
     internal init(
-        closedByApplication: Bool, message: String, cxxDescription: String, file: String, line: Int32
+        closedByApplication: Bool, message: String, file: String, line: Int32
     ) {
         self.closedByApplication = closedByApplication
-        super.init(message: message, cxxDescription: cxxDescription, file: file, line: line)
+        super.init(message, file: file, line: line)
     }
 
     // Don't use.
-    internal required init(message: String, cxxDescription: String, file: String, line: Int32) {
+    internal required init(_ message: String, file: String, line: Int32) {
         fatalError("ConnectionAbortedException must be initialized with a closedByApplication flag")
     }
 }
@@ -313,14 +307,14 @@ public final class ConnectionClosedException: LocalException {
     public let closedByApplication: Bool
 
     internal init(
-        closedByApplication: Bool, message: String, cxxDescription: String, file: String, line: Int32
+        closedByApplication: Bool, message: String, file: String, line: Int32
     ) {
         self.closedByApplication = closedByApplication
-        super.init(message: message, cxxDescription: cxxDescription, file: file, line: line)
+        super.init(message, file: file, line: line)
     }
 
     // Don't use.
-    internal required init(message: String, cxxDescription: String, file: String, line: Int32) {
+    internal required init(_ message: String, file: String, line: Int32) {
         fatalError("ConnectionClosedException must be initialized with a closedByApplication flag")
     }
 }
@@ -331,13 +325,13 @@ internal final class CxxLocalException: LocalException {
 
     override public func ice_id() -> String { typeId }
 
-    internal init(typeId: String, message: String, cxxDescription: String, file: String, line: Int32) {
+    internal init(typeId: String, message: String, file: String, line: Int32) {
         self.typeId = typeId
-        super.init(message: message, cxxDescription: cxxDescription, file: file, line: line)
+        super.init(message, file: file, line: line)
     }
 
     // Don't use.
-    internal required init(message: String, cxxDescription: String, file: String, line: Int32) {
+    internal required init(_ message: String, file: String, line: Int32) {
         fatalError("CxxLocalException must be initialized with a typeId")
     }
 }
@@ -393,16 +387,16 @@ public final class NotRegisteredException: LocalException {
 
     // Initializer for C++ exceptions
     internal init(
-        kindOfObject: String, id: String, message: String, cxxDescription: String, file: String,
+        kindOfObject: String, id: String, message: String, file: String,
         line: Int32
     ) {
         self.kindOfObject = kindOfObject
         self.id = id
-        super.init(message: message, cxxDescription: cxxDescription, file: file, line: line)
+        super.init(message, file: file, line: line)
     }
 
     // Don't use.
-    internal required init(message: String, cxxDescription: String, file: String, line: Int32) {
+    internal required init(_ message: String, file: String, line: Int32) {
         fatalError("NotRegisteredException must be initialized with a kindOfObject and id")
     }
 }

--- a/swift/src/Ice/LocalExceptions.swift
+++ b/swift/src/Ice/LocalExceptions.swift
@@ -25,9 +25,7 @@ public class RequestFailedException: LocalException {
     ///   - file: The file where the exception was thrown.
     ///   - line: The line where the exception was thrown.
     internal required init(
-        id: Identity, facet: String, operation: String, message: String,
-        file: String,
-        line: Int32
+        id: Identity, facet: String, operation: String, message: String, file: String, line: Int32
     ) {
         self.id = id
         self.facet = facet
@@ -35,15 +33,12 @@ public class RequestFailedException: LocalException {
         super.init(message, file: file, line: line)
     }
 
-    internal init(
-        typeName: String, id: Identity, facet: String, operation: String, file: String, line: Int32
-    ) {
+    internal init(typeName: String, id: Identity, facet: String, operation: String, file: String, line: Int32) {
         self.id = id
         self.facet = facet
         self.operation = operation
         super.init(
-            Self.makeMessage(typeName: typeName, id: id, facet: facet, operation: operation), file: file,
-            line: line)
+            Self.makeMessage(typeName: typeName, id: id, facet: facet, operation: operation), file: file, line: line)
     }
 
     internal required init(_ message: String, file: String, line: Int32) {
@@ -53,9 +48,7 @@ public class RequestFailedException: LocalException {
         super.init(message, file: file, line: line)
     }
 
-    internal class func makeMessage(typeName: String, id: Identity, facet: String, operation: String)
-        -> String
-    {
+    internal class func makeMessage(typeName: String, id: Identity, facet: String, operation: String) -> String {
         "dispatch failed with \(typeName) { id = '\(identityToString(id: id))', facet = '\(facet)', operation = '\(operation)' }"
     }
 }
@@ -74,8 +67,7 @@ public final class ObjectNotExistException: RequestFailedException {
         id: Identity, facet: String, operation: String, file: String = #fileID, line: Int32 = #line
     ) {
         self.init(
-            typeName: "ObjectNotExistException", id: id, facet: facet, operation: operation, file: file,
-            line: line)
+            typeName: "ObjectNotExistException", id: id, facet: facet, operation: operation, file: file, line: line)
     }
 
     /// Creates an ObjectNotExistException. The request details (id, facet, operation) will be filled-in by the Ice
@@ -102,8 +94,7 @@ public final class FacetNotExistException: RequestFailedException {
         id: Identity, facet: String, operation: String, file: String = #fileID, line: Int32 = #line
     ) {
         self.init(
-            typeName: "FacetNotExistException", id: id, facet: facet, operation: operation, file: file,
-            line: line)
+            typeName: "FacetNotExistException", id: id, facet: facet, operation: operation, file: file, line: line)
     }
 
     /// Creates a FacetNotExistException. The request details (id, facet, operation) will be filled-in by the Ice
@@ -131,8 +122,7 @@ public final class OperationNotExistException: RequestFailedException {
         id: Identity, facet: String, operation: String, file: String = #fileID, line: Int32 = #line
     ) {
         self.init(
-            typeName: "OperationNotExistException", id: id, facet: facet, operation: operation,
-            file: file, line: line)
+            typeName: "OperationNotExistException", id: id, facet: facet, operation: operation, file: file, line: line)
     }
 
     /// Creates an OperationNotExistException. The request details (id, facet, operation) will be filled-in by the Ice
@@ -260,10 +250,7 @@ public final class AlreadyRegisteredException: LocalException {
     }
 
     // Initializer for C++ exceptions
-    internal init(
-        kindOfObject: String, id: String, message: String, file: String,
-        line: Int32
-    ) {
+    internal init(kindOfObject: String, id: String, message: String, file: String, line: Int32) {
         self.kindOfObject = kindOfObject
         self.id = id
         super.init(message, file: file, line: line)
@@ -287,9 +274,7 @@ public final class ConnectionAbortedException: LocalException {
     /// runtime.
     public let closedByApplication: Bool
 
-    internal init(
-        closedByApplication: Bool, message: String, file: String, line: Int32
-    ) {
+    internal init(closedByApplication: Bool, message: String, file: String, line: Int32) {
         self.closedByApplication = closedByApplication
         super.init(message, file: file, line: line)
     }
@@ -306,9 +291,7 @@ public final class ConnectionClosedException: LocalException {
     /// runtime.
     public let closedByApplication: Bool
 
-    internal init(
-        closedByApplication: Bool, message: String, file: String, line: Int32
-    ) {
+    internal init(closedByApplication: Bool, message: String, file: String, line: Int32) {
         self.closedByApplication = closedByApplication
         super.init(message, file: file, line: line)
     }
@@ -386,10 +369,7 @@ public final class NotRegisteredException: LocalException {
     }
 
     // Initializer for C++ exceptions
-    internal init(
-        kindOfObject: String, id: String, message: String, file: String,
-        line: Int32
-    ) {
+    internal init(kindOfObject: String, id: String, message: String, file: String, line: Int32) {
         self.kindOfObject = kindOfObject
         self.id = id
         super.init(message, file: file, line: line)

--- a/swift/src/IceImpl/Convert.mm
+++ b/swift/src/IceImpl/Convert.mm
@@ -4,7 +4,6 @@
 #import "include/LocalExceptionFactory.h"
 
 #include <cstdlib>
-#include <sstream>
 #include <typeinfo>
 
 NSError*

--- a/swift/src/IceImpl/Convert.mm
+++ b/swift/src/IceImpl/Convert.mm
@@ -7,16 +7,6 @@
 #include <sstream>
 #include <typeinfo>
 
-namespace
-{
-    inline std::string cxxDescription(const Ice::LocalException& e)
-    {
-        std::ostringstream os;
-        os << e;
-        return os.str();
-    }
-}
-
 NSError*
 convertException(std::exception_ptr exc)
 {
@@ -33,7 +23,6 @@ convertException(std::exception_ptr exc)
                                kindOfObject:toNSString(e.kindOfObject())
                                    objectId:toNSString(e.id())
                                     message:toNSString(e.what())
-                             cxxDescription:toNSString(cxxDescription(e))
                                        file:toNSString(e.ice_file())
                                        line:e.ice_line()];
     }
@@ -43,7 +32,6 @@ convertException(std::exception_ptr exc)
                                kindOfObject:toNSString(e.kindOfObject())
                                    objectId:toNSString(e.id())
                                     message:toNSString(e.what())
-                             cxxDescription:toNSString(cxxDescription(e))
                                        file:toNSString(e.ice_file())
                                        line:e.ice_line()];
     }
@@ -52,7 +40,6 @@ convertException(std::exception_ptr exc)
         return [factory connectionClosedException:toNSString(e.ice_id())
                               closedByApplication:e.closedByApplication()
                                           message:toNSString(e.what())
-                                   cxxDescription:toNSString(cxxDescription(e))
                                              file:toNSString(e.ice_file())
                                              line:e.ice_line()];
     }
@@ -61,7 +48,6 @@ convertException(std::exception_ptr exc)
         return [factory connectionClosedException:toNSString(e.ice_id())
                               closedByApplication:e.closedByApplication()
                                           message:toNSString(e.what())
-                                   cxxDescription:toNSString(cxxDescription(e))
                                              file:toNSString(e.ice_file())
                                              line:e.ice_line()];
     }
@@ -73,7 +59,6 @@ convertException(std::exception_ptr exc)
                                          facet:toNSString(e.facet())
                                      operation:toNSString(e.operation())
                                        message:toNSString(e.what())
-                                cxxDescription:toNSString(cxxDescription(e))
                                           file:toNSString(e.ice_file())
                                           line:e.ice_line()];
     }
@@ -81,7 +66,6 @@ convertException(std::exception_ptr exc)
     {
         return [factory localException:toNSString(e.ice_id())
                                message:toNSString(e.what())
-                        cxxDescription:toNSString(cxxDescription(e))
                                   file:toNSString(e.ice_file())
                                   line:e.ice_line()];
     }

--- a/swift/src/IceImpl/include/LocalExceptionFactory.h
+++ b/swift/src/IceImpl/include/LocalExceptionFactory.h
@@ -15,7 +15,6 @@ ICEIMPL_API @protocol ICELocalExceptionFactory
                              facet:(NSString*)facet
                          operation:(NSString*)operation
                            message:(NSString*)message
-                    cxxDescription:(NSString*)cxxDescription
                               file:(NSString*)file
                               line:(int32_t)line;
 
@@ -24,7 +23,6 @@ ICEIMPL_API @protocol ICELocalExceptionFactory
                    kindOfObject:(NSString*)kindOfObject
                        objectId:(NSString*)objectId
                         message:(NSString*)message
-                 cxxDescription:(NSString*)cxxDescription
                            file:(NSString*)file
                            line:(int32_t)line;
 
@@ -32,14 +30,12 @@ ICEIMPL_API @protocol ICELocalExceptionFactory
 + (NSError*)connectionClosedException:(NSString*)typeId
                   closedByApplication:(BOOL)closedByApplication
                               message:(NSString*)message
-                       cxxDescription:(NSString*)cxxDescription
                                  file:(NSString*)file
                                  line:(int32_t)line;
 
 // All other local exceptions.
 + (NSError*)localException:(NSString*)typeId
                    message:(NSString*)message
-            cxxDescription:(NSString*)cxxDescription
                       file:(NSString*)file
                       line:(int32_t)line;
 

--- a/swift/src/IceImpl/include/LocalExceptionFactory.h
+++ b/swift/src/IceImpl/include/LocalExceptionFactory.h
@@ -34,10 +34,7 @@ ICEIMPL_API @protocol ICELocalExceptionFactory
                                  line:(int32_t)line;
 
 // All other local exceptions.
-+ (NSError*)localException:(NSString*)typeId
-                   message:(NSString*)message
-                      file:(NSString*)file
-                      line:(int32_t)line;
++ (NSError*)localException:(NSString*)typeId message:(NSString*)message file:(NSString*)file line:(int32_t)line;
 
 // Other std::exception
 + (NSError*)cxxException:(NSString*)typeName message:(NSString*)message;


### PR DESCRIPTION
This PR removes the full C++ description (cxxDescription) from Swift local exceptions created from C++ local exceptions.

This cxxDescription included the C++ stack trace (when available) and was printed when the Swift local exception is printed.

Now, when a Swift local exception created from a C++ local exception is printed, we only get the C++ file, line, type ID and message, for example:

```
src/Ice/OutgoingAsync.cpp:945 ::Ice::OperationNotExistException dispatch failed with OperationNotExistException
identity: 'thrower'
facet: 
operation: noSuchOperation
```