### PR TITLE
Python Metadata Validation

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -891,6 +891,12 @@ Slice::Contained::container() const
     return _container;
 }
 
+bool
+Slice::Contained::isTopLevel() const
+{
+    return dynamic_pointer_cast<Unit>(container()) != nullptr;
+}
+
 string
 Slice::Contained::name() const
 {

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -96,6 +96,7 @@ namespace Slice
 // ----------------------------------------------------------------------
 // Metadata
 // ----------------------------------------------------------------------
+
 Slice::Metadata::Metadata(string rawMetadata, string file, int line)
 {
     _file = std::move(file);

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -386,6 +386,7 @@ namespace Slice
     {
     public:
         [[nodiscard]] ContainerPtr container() const;
+        [[nodiscard]] bool isTopLevel() const;
 
         /// Returns the Slice identifier of this element.
         [[nodiscard]] std::string name() const;

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -87,12 +87,12 @@ namespace
                 }
             }
 
-            ContainerPtr c = p->container();
-            p = dynamic_pointer_cast<Contained>(c); // This cast fails for Unit.
-            if (!p)
+            if (p->isTopLevel())
             {
                 break;
             }
+            p = dynamic_pointer_cast<Contained>(p->container());
+            assert(p);
         }
 
         assert(m);

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -3255,11 +3255,9 @@ Slice::Gen::StreamVisitor::visitModuleStart(const ModulePtr& m)
         return false;
     }
 
-    if (dynamic_pointer_cast<Unit>(m->container()))
+    if (m->isTopLevel())
     {
-        //
         // Only emit this for the top-level module.
-        //
         H << sp;
         H << nl << "/// \\cond STREAM";
         H << nl << "namespace Ice" << nl << '{';
@@ -3271,11 +3269,9 @@ Slice::Gen::StreamVisitor::visitModuleStart(const ModulePtr& m)
 void
 Slice::Gen::StreamVisitor::visitModuleEnd(const ModulePtr& m)
 {
-    if (dynamic_pointer_cast<Unit>(m->container()))
+    if (m->isTopLevel())
     {
-        //
         // Only emit this for the top-level module.
-        //
         H.dec();
         H << nl << '}';
         H << nl << "/// \\endcond";

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -36,12 +36,12 @@ Slice::CsGenerator::getNamespacePrefix(const ContainedPtr& cont)
             m = dynamic_pointer_cast<Module>(p);
         }
 
-        ContainerPtr c = p->container();
-        p = dynamic_pointer_cast<Contained>(c); // This cast fails for Unit.
-        if (!p)
+        if (p->isTopLevel())
         {
             break;
         }
+        p = dynamic_pointer_cast<Contained>(p->container());
+        assert(p);
     }
 
     assert(m);
@@ -1849,7 +1849,7 @@ Slice::CsGenerator::validateMetadata(const UnitPtr& u)
         {
             // 'cs:namespace' can only be applied to top-level modules
             // Top-level modules are contained by the 'Unit'. Non-top-level modules are contained in 'Module's.
-            if (auto mod = dynamic_pointer_cast<Module>(p); mod && !dynamic_pointer_cast<Unit>(mod->container()))
+            if (auto mod = dynamic_pointer_cast<Module>(p); mod && !mod->isTopLevel())
             {
                 return "the 'cs:namespace' metadata can only be applied to top-level modules";
             }

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -753,7 +753,7 @@ Slice::CsVisitor::writeParameterDocComments(const DocComment& comment, const Par
 void
 Slice::CsVisitor::moduleStart(const ModulePtr& p)
 {
-    if (!dynamic_pointer_cast<Contained>(p->container()))
+    if (p->isTopLevel())
     {
         string ns = getNamespacePrefix(p);
         if (!ns.empty())
@@ -768,7 +768,7 @@ Slice::CsVisitor::moduleStart(const ModulePtr& p)
 void
 Slice::CsVisitor::moduleEnd(const ModulePtr& p)
 {
-    if (!dynamic_pointer_cast<Contained>(p->container()))
+    if (p->isTopLevel())
     {
         if (!getNamespacePrefix(p).empty())
         {

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -2241,7 +2241,7 @@ bool
 Slice::Gen::TypesVisitor::visitModuleStart(const ModulePtr& p)
 {
     string prefix = getPackagePrefix(p);
-    if (!prefix.empty() && dynamic_pointer_cast<Unit>(p->container())) // generate Marker class for top-level modules
+    if (!prefix.empty() && p->isTopLevel()) // generate Marker class for top-level modules
     {
         string markerClass = prefix + "." + fixKwd(p->name()) + "._Marker";
         open(markerClass, p->file());

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -435,12 +435,12 @@ Slice::JavaGenerator::getPackagePrefix(const ContainedPtr& cont)
             m = dynamic_pointer_cast<Module>(p);
         }
 
-        ContainerPtr c = p->container();
-        p = dynamic_pointer_cast<Contained>(c); // This cast fails for Unit.
-        if (!p)
+        if (p->isTopLevel())
         {
             break;
         }
+        p = dynamic_pointer_cast<Contained>(p->container());
+        assert(p);
     }
 
     assert(m);
@@ -1840,7 +1840,7 @@ Slice::JavaGenerator::validateMetadata(const UnitPtr& u)
         {
             // If 'java:package' is applied to a module, it must be a top-level module.
             // // Top-level modules are contained by the 'Unit'. Non-top-level modules are contained in 'Module's.
-            if (auto mod = dynamic_pointer_cast<Module>(p); mod && !dynamic_pointer_cast<Unit>(mod->container()))
+            if (auto mod = dynamic_pointer_cast<Module>(p); mod && !mod->isTopLevel())
             {
                 return "the 'java:package' metadata can only be applied at the file level or to top-level modules";
             }

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -1041,10 +1041,9 @@ Slice::Gen::ExportsVisitor::visitModuleStart(const ModulePtr& p)
     const string scoped = getLocalScope(p->scoped());
     if (_exportedModules.insert(scoped).second)
     {
-        const bool topLevel = dynamic_pointer_cast<Unit>(p->container()) != nullptr;
         _out << sp;
         _out << nl;
-        if (topLevel)
+        if (p->isTopLevel())
         {
             if (_importedModules.find(scoped) == _importedModules.end())
             {

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2539,19 +2539,19 @@ void
 Slice::Python::validateMetadata(const UnitPtr& unit)
 {
     auto pythonArrayTypeValidationFunc = [](const MetadataPtr& m, const SyntaxTreeBasePtr& p) -> optional<string>
+    {
+        if (auto sequence = dynamic_pointer_cast<Sequence>(p))
         {
-            if (auto sequence = dynamic_pointer_cast<Sequence>(p))
+            BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(sequence->type());
+            if (!builtin || !(builtin->isNumericType() || builtin->kind() == Builtin::KindBool))
             {
-                BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(sequence->type());
-                if (!builtin || !(builtin->isNumericType() || builtin->kind() == Builtin::KindBool))
-                {
-                    return "the '" + m->directive() +
-                           "' metadata can only be applied to sequences of bools, bytes, shorts, ints, longs, floats, "
-                           "or doubles";
-                }
+                return "the '" + m->directive() +
+                       "' metadata can only be applied to sequences of bools, bytes, shorts, ints, longs, floats, "
+                       "or doubles";
             }
-            return nullopt;
-        };
+        }
+        return nullopt;
+    };
 
     map<string, MetadataInfo> knownMetadata;
 

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 #include "PythonUtil.h"
+#include "../Slice/MetadataValidation.h"
 #include "../Slice/Util.h"
 #include "Ice/StringUtil.h"
 
@@ -153,30 +154,6 @@ namespace
 
 namespace Slice::Python
 {
-    class MetadataVisitor final : public ParserVisitor
-    {
-    public:
-        bool visitUnitStart(const UnitPtr&) final;
-        bool visitModuleStart(const ModulePtr&) final;
-        void visitClassDecl(const ClassDeclPtr&) final;
-        void visitInterfaceDecl(const InterfaceDeclPtr&) final;
-        bool visitExceptionStart(const ExceptionPtr&) final;
-        bool visitStructStart(const StructPtr&) final;
-        void visitOperation(const OperationPtr&) final;
-        void visitDataMember(const DataMemberPtr&) final;
-        void visitSequence(const SequencePtr&) final;
-        void visitDictionary(const DictionaryPtr&) final;
-        void visitEnum(const EnumPtr&) final;
-        void visitConst(const ConstPtr&) final;
-
-    private:
-        /// Validates sequence metadata.
-        MetadataList validateSequence(const ContainedPtr&, const TypePtr&);
-
-        /// Checks a definition that doesn't currently support Python metadata.
-        void reject(const ContainedPtr&);
-    };
-
     //
     // ModuleVisitor finds all of the Slice modules whose include level is greater
     // than 0 and emits a statement of the following form:
@@ -2426,8 +2403,7 @@ Slice::Python::getImportFileName(const string& file, const UnitPtr& ut, const ve
 void
 Slice::Python::generate(const UnitPtr& un, bool all, const vector<string>& includePaths, Output& out)
 {
-    Slice::Python::MetadataVisitor visitor;
-    un->visit(&visitor);
+    validateMetadata(un);
 
     out << nl << "import Ice";
     out << nl << "import IcePy";
@@ -2563,223 +2539,96 @@ Slice::Python::printHeader(IceInternal::Output& out)
     out << "#\n";
 }
 
-bool
-Slice::Python::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
+void
+Slice::Python::validateMetadata(const UnitPtr& u)
 {
-    // Validate file metadata in the top-level file and all included files.
-    for (const auto& file : unit->allFiles())
-    {
-        DefinitionContextPtr dc = unit->findDefinitionContext(file);
-        MetadataList fileMetadata = dc->getMetadata();
-        for (auto r = fileMetadata.begin(); r != fileMetadata.end();)
+    map<string, MetadataInfo> knownMetadata;
+
+    // "python:pkgdir"
+    MetadataInfo pkgdirInfo = {
+        .validOn = {typeid(Unit)},
+        .acceptedArgumentKind = MetadataArgumentKind::RequiredTextArgument,
+    };
+    knownMetadata.emplace("python:pkgdir", std::move(pkgdirInfo));
+
+    // "python:package"
+    MetadataInfo packageInfo = {
+        .validOn = {typeid(Module), typeid(Unit)},
+        .acceptedArgumentKind = MetadataArgumentKind::SingleArgument,
+        .extraValidation = [](const MetadataPtr&, const SyntaxTreeBasePtr& p) -> optional<string>
         {
-            MetadataPtr meta = *r++;
-            string_view directive = meta->directive();
-            string_view arguments = meta->arguments();
-
-            if (directive.find("python:") == 0)
+            // If 'python:package' is applied to a module, it must be a top-level module.
+            // // Top-level modules are contained by the 'Unit'. Non-top-level modules are contained in 'Module's.
+            if (auto mod = dynamic_pointer_cast<Module>(p); mod && !dynamic_pointer_cast<Unit>(mod->container()))
             {
-                if (directive == "python:package" && !arguments.empty())
-                {
-                    continue;
-                }
-                if (directive == "python:pkgdir" && !arguments.empty())
-                {
-                    continue;
-                }
-
-                ostringstream msg;
-                msg << "ignoring invalid file metadata '" << *meta << "'";
-                unit->warning(meta->file(), meta->line(), InvalidMetadata, msg.str());
-                fileMetadata.remove(meta);
+                return "the 'python:package' metadata can only be applied at the file level or to top-level modules";
             }
-        }
-        dc->setMetadata(fileMetadata);
-    }
-    return true;
-}
+            return nullopt;
+        },
+    };
+    knownMetadata.emplace("python:package", std::move(packageInfo));
 
-bool
-Slice::Python::MetadataVisitor::visitModuleStart(const ModulePtr& p)
-{
-    MetadataList metadata = p->getMetadata();
-    for (auto r = metadata.begin(); r != metadata.end();)
-    {
-        MetadataPtr meta = *r++;
-        string_view directive = meta->directive();
+    // "python:seq"
+    // We support 3 arguments to this metadata: "default", "list", and "tuple".
+    // We also allow users to omit the "seq" in the middle, ie. "python:seq:list" and "python:list" are equivalent.
+    MetadataInfo seqInfo = {
+        .validOn = {typeid(Sequence)},
+        .acceptedArgumentKind = MetadataArgumentKind::SingleArgument,
+        .validArgumentValues = {{"default", "list", "tuple"}},
+        .acceptedContext = MetadataApplicationContext::DefinitionsAndTypeReferences,
+    };
+    MetadataInfo unqualifiedSeqInfo = {
+        .validOn = {typeid(Sequence)},
+        .acceptedArgumentKind = MetadataArgumentKind::NoArguments,
+        .acceptedContext = MetadataApplicationContext::DefinitionsAndTypeReferences,
+    };
+    knownMetadata.emplace("python:seq", std::move(seqInfo));
+    knownMetadata.emplace("python:default", unqualifiedSeqInfo);
+    knownMetadata.emplace("python:list", unqualifiedSeqInfo);
+    knownMetadata.emplace("python:tuple", std::move(unqualifiedSeqInfo));
 
-        if (directive.find("python:") == 0)
+    // "python:<array-type>"
+    MetadataInfo arrayTypeInfo = {
+        .validOn = {typeid(Sequence)},
+        .acceptedArgumentKind = MetadataArgumentKind::NoArguments,
+        .acceptedContext = MetadataApplicationContext::DefinitionsAndTypeReferences,
+        .extraValidation = [](const MetadataPtr& m, const SyntaxTreeBasePtr& p) -> optional<string>
         {
-            // Must be a top-level module.
-            if (dynamic_pointer_cast<Unit>(p->container()) && directive == "python:package")
+            if (auto sequence = dynamic_pointer_cast<Sequence>(p))
             {
-                continue;
-            }
-
-            ostringstream msg;
-            msg << "ignoring invalid file metadata '" << *meta << "'";
-            p->unit()->warning(meta->file(), meta->line(), InvalidMetadata, msg.str());
-            metadata.remove(meta);
-        }
-    }
-
-    p->setMetadata(std::move(metadata));
-    return true;
-}
-
-void
-Slice::Python::MetadataVisitor::visitClassDecl(const ClassDeclPtr& p)
-{
-    reject(p);
-}
-
-void
-Slice::Python::MetadataVisitor::visitInterfaceDecl(const InterfaceDeclPtr& p)
-{
-    reject(p);
-}
-
-bool
-Slice::Python::MetadataVisitor::visitExceptionStart(const ExceptionPtr& p)
-{
-    reject(p);
-    return true;
-}
-
-bool
-Slice::Python::MetadataVisitor::visitStructStart(const StructPtr& p)
-{
-    reject(p);
-    return true;
-}
-
-void
-Slice::Python::MetadataVisitor::visitOperation(const OperationPtr& p)
-{
-    TypePtr ret = p->returnType();
-    if (ret)
-    {
-        validateSequence(p, ret);
-    }
-
-    for (const auto& param : p->parameters())
-    {
-        validateSequence(param, param->type());
-    }
-}
-
-void
-Slice::Python::MetadataVisitor::visitDataMember(const DataMemberPtr& p)
-{
-    validateSequence(p, p->type());
-}
-
-void
-Slice::Python::MetadataVisitor::visitSequence(const SequencePtr& p)
-{
-    p->setMetadata(validateSequence(p, p));
-}
-
-void
-Slice::Python::MetadataVisitor::visitDictionary(const DictionaryPtr& p)
-{
-    reject(p);
-}
-
-void
-Slice::Python::MetadataVisitor::visitEnum(const EnumPtr& p)
-{
-    reject(p);
-}
-
-void
-Slice::Python::MetadataVisitor::visitConst(const ConstPtr& p)
-{
-    reject(p);
-}
-
-MetadataList
-Slice::Python::MetadataVisitor::validateSequence(const ContainedPtr& cont, const TypePtr& type)
-{
-    static const string prefix = "python:";
-    MetadataList newMetadata = cont->getMetadata();
-    for (auto p = newMetadata.begin(); p != newMetadata.end();)
-    {
-        MetadataPtr s = *p++;
-        string_view directive = s->directive();
-        string_view arguments = s->arguments();
-
-        if (directive.find(prefix) == 0)
-        {
-            SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
-            if (seq)
-            {
-                if (directive == "python:seq")
+                BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(sequence->type());
+                if (!builtin || !(builtin->isNumericType() || builtin->kind() == Builtin::KindBool))
                 {
-                    if (arguments == "tuple" || arguments == "list" || arguments == "default")
-                    {
-                        continue;
-                    }
-                }
-                else if (directive.size() > prefix.size())
-                {
-                    string_view subArg = directive.substr(prefix.size());
-                    if (subArg == "tuple" || subArg == "list" || subArg == "default")
-                    {
-                        continue;
-                    }
-                    else if (subArg == "array.array" || subArg == "numpy.ndarray" || subArg.find("memoryview") == 0)
-                    {
-                        // The memoryview sequence metadata is only valid for integral builtin
-                        // types excluding strings.
-                        BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(seq->type());
-                        if (builtin)
-                        {
-                            switch (builtin->kind())
-                            {
-                                case Builtin::KindBool:
-                                case Builtin::KindByte:
-                                case Builtin::KindShort:
-                                case Builtin::KindInt:
-                                case Builtin::KindLong:
-                                case Builtin::KindFloat:
-                                case Builtin::KindDouble:
-                                {
-                                    continue;
-                                }
-                                default:
-                                {
-                                    break;
-                                }
-                            }
-                        }
-                    }
+                    return "the '" + m->directive() + "' metadata can only be applied to sequences of bools, bytes, shorts, ints, longs, floats, or doubles";
                 }
             }
-            ostringstream msg;
-            msg << "ignoring invalid metadata '" << *s << "'";
-            type->unit()->warning(s->file(), s->line(), InvalidMetadata, msg.str());
-            newMetadata.remove(s);
-        }
-    }
-    return newMetadata;
-}
+            return nullopt;
+        },
+    };
+    knownMetadata.emplace("python:array.array", arrayTypeInfo);
+    knownMetadata.emplace("python:numpy.ndarray", std::move(arrayTypeInfo));
 
-void
-Slice::Python::MetadataVisitor::reject(const ContainedPtr& cont)
-{
-    MetadataList localMetadata = cont->getMetadata();
-
-    for (auto p = localMetadata.begin(); p != localMetadata.end();)
-    {
-        MetadataPtr s = *p++;
-        if (s->directive().find("python:") == 0)
+    // "python:memoryview"
+    MetadataInfo memoryViewInfo = {
+        .validOn = {typeid(Sequence)},
+        .acceptedArgumentKind = MetadataArgumentKind::RequiredTextArgument,
+        .acceptedContext = MetadataApplicationContext::DefinitionsAndTypeReferences,
+        // TODO: is this restriction correct? Or can memory-view apply to any sequence types?
+        .extraValidation = [](const MetadataPtr& m, const SyntaxTreeBasePtr& p) -> optional<string>
         {
-            ostringstream msg;
-            msg << "ignoring invalid metadata '" << *s << "'";
-            cont->unit()->warning(s->file(), s->line(), InvalidMetadata, msg.str());
-            localMetadata.remove(s);
-        }
-    }
-    cont->setMetadata(std::move(localMetadata));
+            if (auto sequence = dynamic_pointer_cast<Sequence>(p))
+            {
+                BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(sequence->type());
+                if (!builtin || !(builtin->isNumericType() || builtin->kind() == Builtin::KindBool))
+                {
+                    return "the '" + m->directive() + "' metadata can only be applied to sequences of bools, bytes, shorts, ints, longs, floats, or doubles";
+                }
+            }
+            return nullopt;
+        },
+    };
+    knownMetadata.emplace("python:memoryview", std::move(memoryViewInfo));
+
+    // Pass this information off to the parser's metadata validation logic.
+    Slice::validateMetadata(u, "python", knownMetadata);
 }

--- a/cpp/src/slice2py/PythonUtil.h
+++ b/cpp/src/slice2py/PythonUtil.h
@@ -55,6 +55,8 @@ namespace Slice::Python
     void printHeader(IceInternal::Output&);
 
     int compile(const std::vector<std::string>&);
+
+    static void validateMetadata(const UnitPtr&);
 }
 
 #endif

--- a/cpp/src/slice2py/PythonUtil.h
+++ b/cpp/src/slice2py/PythonUtil.h
@@ -56,7 +56,7 @@ namespace Slice::Python
 
     int compile(const std::vector<std::string>&);
 
-    static void validateMetadata(const UnitPtr&);
+    void validateMetadata(const UnitPtr&);
 }
 
 #endif

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -202,7 +202,7 @@ Slice::Ruby::CodeVisitor::visitModuleStart(const ModulePtr& p)
 {
     _out << sp << nl << "module ";
     // Ensure that Slice top-level modules are defined as top level modules in Ruby
-    if (dynamic_pointer_cast<Unit>(p->container()))
+    if (p->isTopLevel())
     {
         _out << "::";
     }

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -102,10 +102,8 @@ Gen::ImportVisitor::ImportVisitor(IceInternal::Output& o) : out(o) {}
 bool
 Gen::ImportVisitor::visitModuleStart(const ModulePtr& p)
 {
-    //
     // Always import Ice module first if not building Ice
-    //
-    if (dynamic_pointer_cast<Unit>(p->container()) && _imports.empty())
+    if (p->isTopLevel() && _imports.empty())
     {
         string swiftModule = getSwiftModule(p);
         if (swiftModule != "Ice")

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -249,12 +249,12 @@ Slice::getTopLevelModule(const ContainedPtr& cont)
             m = dynamic_pointer_cast<Module>(p);
         }
 
-        ContainerPtr c = p->container();
-        p = dynamic_pointer_cast<Contained>(c); // This cast fails for Unit.
-        if (!p)
+        if (p->isTopLevel())
         {
             break;
         }
+        p = dynamic_pointer_cast<Contained>(p->container());
+        assert(p);
     }
     return m;
 }
@@ -1268,7 +1268,7 @@ SwiftGenerator::writeMarshalUnmarshalCode(
 bool
 SwiftGenerator::MetadataVisitor::visitModuleStart(const ModulePtr& p)
 {
-    if (dynamic_pointer_cast<Unit>(p->container()))
+    if (p->isTopLevel())
     {
         // top-level module
         const UnitPtr unit = p->unit();

--- a/python/modules/IcePy/msbuild/icepy.vcxproj
+++ b/python/modules/IcePy/msbuild/icepy.vcxproj
@@ -23,6 +23,7 @@
     <ClCompile Include="..\..\..\..\cpp\src\slice2py\PythonUtil.cpp" />
     <ClCompile Include="..\..\..\..\cpp\src\Slice\FileTracker.cpp" />
     <ClCompile Include="..\..\..\..\cpp\src\Slice\Grammar.cpp" />
+    <ClCompile Include="..\..\..\..\cpp\src\Slice\MetadataValidation.cpp" />
     <ClCompile Include="..\..\..\..\cpp\src\Slice\Parser.cpp" />
     <ClCompile Include="..\..\..\..\cpp\src\Slice\Preprocessor.cpp" />
     <ClCompile Include="..\..\..\..\cpp\src\Slice\Scanner.cpp" />

--- a/python/modules/IcePy/msbuild/icepy.vcxproj.filters
+++ b/python/modules/IcePy/msbuild/icepy.vcxproj.filters
@@ -78,6 +78,9 @@
     <ClCompile Include="..\..\..\..\cpp\src\Slice\Grammar.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\cpp\src\Slice\MetadataValidation.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\cpp\src\Slice\Parser.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/python/test/Ice/custom/Test.ice
+++ b/python/test/Ice/custom/Test.ice
@@ -96,11 +96,11 @@ module Test
         DoubleSeq1 opDoubleSeq(DoubleSeq1 v1, out DoubleSeq2 v2);
 
         ["python:memoryview:Custom.myBogusArrayNotExistsFactory"] BoolSeq1 opBogusArrayNotExistsFactory();
-        ["python:memoryview:Custom.myBogusArrayThrowFactory"]BoolSeq1 opBogusArrayThrowFactory();
-        ["python:memoryview:Custom.myBogusArrayType"]BoolSeq1 opBogusArrayType();
-        ["python:memoryview:Custom.myBogusArrayNoneFactory"]BoolSeq1 opBogusArrayNoneFactory();
-        ["python:memoryview:Custom.myBogusArraySignatureFactory"]BoolSeq1 opBogusArraySignatureFactory();
-        ["python:memoryview:Custom.myNoCallableFactory"]BoolSeq1 opBogusArrayNoCallableFactory();
+        ["python:memoryview:Custom.myBogusArrayThrowFactory"] BoolSeq1 opBogusArrayThrowFactory();
+        ["python:memoryview:Custom.myBogusArrayType"] BoolSeq1 opBogusArrayType();
+        ["python:memoryview:Custom.myBogusArrayNoneFactory"] BoolSeq1 opBogusArrayNoneFactory();
+        ["python:memoryview:Custom.myBogusArraySignatureFactory"] BoolSeq1 opBogusArraySignatureFactory();
+        ["python:memoryview:Custom.myNoCallableFactory"] BoolSeq1 opBogusArrayNoCallableFactory();
 
         D opD(D d);
 


### PR DESCRIPTION
This PR switches `slice2py` to use the 'new' metadata validator (I added 3 months ago).

The implementation, old validation, and docs disagree about these metadata, so insight would be appreciated:
`python:array.array`, `python:numpy.ndarray`, and `python:memoryview:X`

----

The docs state that `array.array` and `numpy.ndarray` are only valid on: `integral builtin types excluding strings`. But:
1) "strings" are not an "integral" type... So I don't see why we mention this 'exclusion' at all.
2) It says for "integral" types... but we have tests using this metadata with seqs of `bool`, `float`, and `double`.

So... I'm guessing that the documentation is just wrong. And it should say:
`... are valid on sequences of numeric built-in types and bools`

----

For `python:memoryview:X`.
The docs list no restriction on what this can be applied to.
But, the old validation for `memoryview` re-used the logic for `array` and `ndarray`, restricting what it can be applied to.

Is this correct; that `memoryview` can only go on sequences of built-in numeric types and bools?
Or did we incorrectly re-use logic, and in reality, this metadata can be used with any sequence type?