### PR TITLE
Simplify 'swift:module' Prefix Check

### DIFF
--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -124,6 +124,7 @@ namespace Slice
         class MetadataVisitor final : public ParserVisitor
         {
         public:
+            bool visitUnitStart(const UnitPtr&) final;
             bool visitModuleStart(const ModulePtr&) final;
             bool visitClassDefStart(const ClassDefPtr&) final;
             bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
@@ -139,21 +140,6 @@ namespace Slice
 
         private:
             MetadataList validate(const SyntaxTreeBasePtr&, const ContainedPtr&);
-
-            using ModuleMap = std::map<std::string, std::string>;
-            using ModulePrefix = std::map<std::string, ModuleMap>;
-
-            //
-            // Each Slice unit has to map all top-level modules to a single Swift module
-            //
-            ModuleMap _modules;
-
-            //
-            // With a given Swift module a Slice module has to map to a single prefix
-            //
-            ModulePrefix _prefixes;
-
-            static const std::string _msg;
         };
     };
 }


### PR DESCRIPTION
`slice2swift` has a special check for the `swift:module` metadata to ensure it's used consistently.

Right now, we maintain a pair of maps in a field, and each `visitModule` uses these fields.
But, since this check only cares about top-level modules, we could instead just do this in a single function:
```
visitUnit() {
    // declare the 2 maps here.
    for (module : unit->modules()) { ... }
}
```
And IMO a stand-alone, self-contained function is nicer than fields which are checked and updated by multiple calls.