### PR TITLE
Fix for linking with libbacktrace only when available

### DIFF
--- a/config/Make.rules.Linux
+++ b/config/Make.rules.Linux
@@ -164,7 +164,14 @@ mkshlibname     = lib$(1).so
 # Clear the iconv ldflags, iconv is part of libc on Linux
 iconv_ldflags   :=
 
-IceUtil_system_libs                             = -lrt -lbacktrace
+ifneq ($(OPTIMIZE),yes)
+libbacktrace_fullpath := $(shell $(CXX) --print-file-name=libbacktrace.a)
+ifneq ($(libbacktrace_fullpath),libbacktrace.a)
+   libbacktrace = yes
+endif
+endif
+
+IceUtil_system_libs                             = -lrt $(if $(filter yes,$(libbacktrace)),-lbacktrace)
 Ice_system_libs                                 = -ldl -lssl -lcrypto $(IceUtil_system_libs)
 ifeq ($(shell pkg-config --exists libsystemd 2> /dev/null && echo yes),yes)
 Ice_system_libs                                 += $(shell pkg-config --libs libsystemd)


### PR DESCRIPTION
This was broken in 3.8 when I cleanup the build system. I incorrectly assume that `libbacktrace` was always available.