### PR TITLE
Implement Ice.Trace.Dispatch in C#

### DIFF
--- a/config/PropertyNames.xml
+++ b/config/PropertyNames.xml
@@ -156,6 +156,7 @@
         <property name="Warn.Datagrams" languages="cpp,csharp,java" default="0" />
         <property name="Warn.Dispatch" languages="all" default="1" />
         <property name="Warn.Endpoints" languages="all" default="1" />
+        <property name="Warn.Executor" languages="cpp,csharp,java" default="1" />
         <property name="Warn.UnusedProperties" languages="all" default="0" />
         <property name="CacheMessageBuffers" languages="csharp,java" default="2" />
     </section>

--- a/config/PropertyNames.xml
+++ b/config/PropertyNames.xml
@@ -136,6 +136,7 @@
         <property name="ToStringMode" languages="all" default="Unicode" />
         <property name="Trace.Admin.Properties" languages="cpp,csharp,java" default="0" />
         <property name="Trace.Admin.Logger" languages="cpp,csharp,java" default="0" />
+        <property name="Trace.Dispatch" languages="all" default="0" />
         <property name="Trace.Locator" languages="all" default="0" />
         <property name="Trace.Network" languages="all" default="0" />
         <property name="Trace.Protocol" languages="all" default="0" />

--- a/cpp/src/Ice/PropertyNames.cpp
+++ b/cpp/src/Ice/PropertyNames.cpp
@@ -173,6 +173,7 @@ const Property IcePropsData[] =
     Property{"ToStringMode", "Unicode", false, false, nullptr},
     Property{"Trace.Admin.Properties", "0", false, false, nullptr},
     Property{"Trace.Admin.Logger", "0", false, false, nullptr},
+    Property{"Trace.Dispatch", "0", false, false, nullptr},
     Property{"Trace.Locator", "0", false, false, nullptr},
     Property{"Trace.Network", "0", false, false, nullptr},
     Property{"Trace.Protocol", "0", false, false, nullptr},
@@ -201,7 +202,7 @@ const PropertyArray PropertyNames::IceProps
     .prefixOnly=false,
     .isOptIn=false,
     .properties=IcePropsData,
-    .length=83
+    .length=84
 };
 
 const Property IceMXPropsData[] =

--- a/cpp/src/Ice/PropertyNames.cpp
+++ b/cpp/src/Ice/PropertyNames.cpp
@@ -193,6 +193,7 @@ const Property IcePropsData[] =
     Property{"Warn.Datagrams", "0", false, false, nullptr},
     Property{"Warn.Dispatch", "1", false, false, nullptr},
     Property{"Warn.Endpoints", "1", false, false, nullptr},
+    Property{"Warn.Executor", "1", false, false, nullptr},
     Property{"Warn.UnusedProperties", "0", false, false, nullptr}
 };
 
@@ -202,7 +203,7 @@ const PropertyArray PropertyNames::IceProps
     .prefixOnly=false,
     .isOptIn=false,
     .properties=IcePropsData,
-    .length=84
+    .length=85
 };
 
 const Property IceMXPropsData[] =

--- a/csharp/src/Ice/Internal/PropertiesAdminI.cs
+++ b/csharp/src/Ice/Internal/PropertiesAdminI.cs
@@ -166,32 +166,14 @@ internal sealed class PropertiesAdminI : Ice.PropertiesAdminDisp_, Ice.NativePro
                 // Copy callbacks to allow callbacks to update callbacks
                 foreach (var callback in new List<Ice.PropertiesAdminUpdateCallback>(_deprecatedUpdateCallbacks))
                 {
-                    try
-                    {
-                        callback.updated(changes);
-                    }
-                    catch (System.Exception ex)
-                    {
-                        if (_properties.getIcePropertyAsInt("Ice.Warn.Dispatch") > 1)
-                        {
-                            _logger.warning("properties admin update callback raised unexpected exception:\n" + ex);
-                        }
-                    }
+                    // The callback should not throw any exception.
+                    callback.updated(changes);
                 }
                 // Copy callbacks to allow callbacks to update callbacks
                 foreach (var callback in new List<System.Action<Dictionary<string, string>>>(_updateCallbacks))
                 {
-                    try
-                    {
-                        callback(changes);
-                    }
-                    catch (System.Exception ex)
-                    {
-                        if (_properties.getIcePropertyAsInt("Ice.Warn.Dispatch") > 1)
-                        {
-                            _logger.warning("properties admin update callback raised unexpected exception:\n" + ex);
-                        }
-                    }
+                    // The callback should not throw any exception.
+                    callback(changes);
                 }
             }
         }

--- a/csharp/src/Ice/Internal/PropertyNames.cs
+++ b/csharp/src/Ice/Internal/PropertyNames.cs
@@ -158,6 +158,7 @@ internal sealed class PropertyNames
             new(pattern: @"Warn.Datagrams", usesRegex: false, defaultValue: "0", deprecated: false, propertyArray: null),
             new(pattern: @"Warn.Dispatch", usesRegex: false, defaultValue: "1", deprecated: false, propertyArray: null),
             new(pattern: @"Warn.Endpoints", usesRegex: false, defaultValue: "1", deprecated: false, propertyArray: null),
+            new(pattern: @"Warn.Executor", usesRegex: false, defaultValue: "1", deprecated: false, propertyArray: null),
             new(pattern: @"Warn.UnusedProperties", usesRegex: false, defaultValue: "0", deprecated: false, propertyArray: null),
             new(pattern: @"CacheMessageBuffers", usesRegex: false, defaultValue: "2", deprecated: false, propertyArray: null)
         ]);

--- a/csharp/src/Ice/Internal/PropertyNames.cs
+++ b/csharp/src/Ice/Internal/PropertyNames.cs
@@ -141,6 +141,7 @@ internal sealed class PropertyNames
             new(pattern: @"ToStringMode", usesRegex: false, defaultValue: "Unicode", deprecated: false, propertyArray: null),
             new(pattern: @"Trace.Admin.Properties", usesRegex: false, defaultValue: "0", deprecated: false, propertyArray: null),
             new(pattern: @"Trace.Admin.Logger", usesRegex: false, defaultValue: "0", deprecated: false, propertyArray: null),
+            new(pattern: @"Trace.Dispatch", usesRegex: false, defaultValue: "0", deprecated: false, propertyArray: null),
             new(pattern: @"Trace.Locator", usesRegex: false, defaultValue: "0", deprecated: false, propertyArray: null),
             new(pattern: @"Trace.Network", usesRegex: false, defaultValue: "0", deprecated: false, propertyArray: null),
             new(pattern: @"Trace.Protocol", usesRegex: false, defaultValue: "0", deprecated: false, propertyArray: null),

--- a/csharp/src/Ice/Internal/ThreadPool.cs
+++ b/csharp/src/Ice/Internal/ThreadPool.cs
@@ -333,9 +333,9 @@ public sealed class ThreadPool : System.Threading.Tasks.TaskScheduler
             }
             catch (System.Exception ex)
             {
-                if (_instance.initializationData().properties.getIcePropertyAsInt("Ice.Warn.Dispatch") > 0)
+                if (_instance.initializationData().properties.getIcePropertyAsInt("Ice.Warn.Executor") > 0)
                 {
-                    _instance.initializationData().logger.warning("dispatch exception:\n" + ex);
+                    _instance.initializationData().logger.warning($"executor exception:\n{ex}");
                 }
             }
         }

--- a/csharp/src/Ice/Internal/TraceLevels.cs
+++ b/csharp/src/Ice/Internal/TraceLevels.cs
@@ -6,6 +6,7 @@ public sealed class TraceLevels
 {
     internal TraceLevels(Ice.Properties properties)
     {
+        dispatchCat = "Dispatch";
         networkCat = "Network";
         protocolCat = "Protocol";
         retryCat = "Retry";
@@ -15,6 +16,7 @@ public sealed class TraceLevels
 
         string keyBase = "Ice.Trace.";
 
+        dispatch = properties.getIcePropertyAsInt(keyBase + dispatchCat);
         network = properties.getIcePropertyAsInt(keyBase + networkCat);
         protocol = properties.getIcePropertyAsInt(keyBase + protocolCat);
         retry = properties.getIcePropertyAsInt(keyBase + retryCat);
@@ -23,6 +25,8 @@ public sealed class TraceLevels
         threadPool = properties.getIcePropertyAsInt(keyBase + threadPoolCat);
     }
 
+    public readonly int dispatch;
+    public readonly string dispatchCat;
     public readonly int network;
     public readonly string networkCat;
     public readonly int protocol;

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -1007,9 +1007,16 @@ public sealed class ObjectAdapter
         if (_instance.initializationData().logger is Logger logger)
         {
             int warningLevel = _instance.initializationData().properties!.getIcePropertyAsInt("Ice.Warn.Dispatch");
-            if (warningLevel > 0)
+            if (_instance.traceLevels().dispatch > 0 || warningLevel > 0)
             {
-                use(next => new LoggerMiddleware(next, logger, warningLevel, _instance.toStringMode()));
+                use(next =>
+                    new LoggerMiddleware(
+                        next,
+                        logger,
+                        _instance.traceLevels().dispatch,
+                        _instance.traceLevels().dispatchCat,
+                        warningLevel,
+                        _instance.toStringMode()));
             }
         }
         if (_instance.initializationData().observer is CommunicatorObserver observer)

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PropertyNames.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PropertyNames.java
@@ -162,6 +162,7 @@ final class PropertyNames
             new Property("Warn.Datagrams", false, "0", false, null),
             new Property("Warn.Dispatch", false, "1", false, null),
             new Property("Warn.Endpoints", false, "1", false, null),
+            new Property("Warn.Executor", false, "1", false, null),
             new Property("Warn.UnusedProperties", false, "0", false, null),
             new Property("CacheMessageBuffers", false, "2", false, null)
         });

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PropertyNames.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PropertyNames.java
@@ -144,6 +144,7 @@ final class PropertyNames
             new Property("ToStringMode", false, "Unicode", false, null),
             new Property("Trace.Admin.Properties", false, "0", false, null),
             new Property("Trace.Admin.Logger", false, "0", false, null),
+            new Property("Trace.Dispatch", false, "0", false, null),
             new Property("Trace.Locator", false, "0", false, null),
             new Property("Trace.Network", false, "0", false, null),
             new Property("Trace.Protocol", false, "0", false, null),

--- a/js/src/Ice/PropertyNames.js
+++ b/js/src/Ice/PropertyNames.js
@@ -68,6 +68,7 @@ PropertyNames.IceProps.properties = [
     new Property("Override.Secure", false, "", false, null),
     new Property("RetryIntervals", false, "0", false, null),
     new Property("ToStringMode", false, "Unicode", false, null),
+    new Property("Trace.Dispatch", false, "0", false, null),
     new Property("Trace.Locator", false, "0", false, null),
     new Property("Trace.Network", false, "0", false, null),
     new Property("Trace.Protocol", false, "0", false, null),


### PR DESCRIPTION
This PR implements Ice.Trace.Dispatch in C#.

Sample logging:
```
-- 2/5/2025 16:42:49:853 Server: Dispatch: dispatch of greet to greeter over ::ffff:127.0.0.1:4061<->::ffff:127.0.0.1:65145 returned a response with reply status Ok
```

```
-! 2/5/2025 16:45:58:497 Server: warning: failed to dispatch greet to greeter over ::ffff:127.0.0.1:4061<->::ffff:127.0.0.1:65310:
   Ice.ObjectNotExistException: Dispatch failed with ObjectNotExistException.
      at Ice.Internal.ServantManager.dispatchAsync(IncomingRequest request) in /Users/bernard/builds/ice/csharp/src/Ice/Internal/ServantManager.cs:line 75
      at Ice.Internal.LoggerMiddleware.dispatchAsync(IncomingRequest request) in /Users/bernard/builds/ice/csharp/src/Ice/Internal/LoggerMiddleware.cs:line 24
```

The message for dispatch exceptions is now different and shorter.

See #3498.

This PR also add a new property, Ice.Warn.Executor (default = 1), which prints warning when the user-installed executor throws exceptions.