### PR TITLE
Include slice2js in ice NPM package

### DIFF
--- a/js/.gitignore
+++ b/js/.gitignore
@@ -32,3 +32,7 @@ test/**/*I.js
 test/Ice/operations/BatchOneways.js
 test/Ice/operations/Oneways.js
 test/Ice/operations/Twoways.js
+
+# Files copied during packaging
+slice/
+bin/

--- a/js/BUILDING.md
+++ b/js/BUILDING.md
@@ -1,6 +1,6 @@
 # Ice for JavaScript Build Instructions
 
-This file describes how to build and install Ice for JavaScript from source code. If you prefer, you can also download 
+This file describes how to build and install Ice for JavaScript from source code. If you prefer, you can also download
 [binary distributions] for the supported platforms.
 
 <!-- TOC depthFrom:2 -->

--- a/js/BUILDING.md
+++ b/js/BUILDING.md
@@ -1,8 +1,7 @@
 # Ice for JavaScript Build Instructions
 
-This file describes how to build and install Ice for JavaScript from source
-code. If you prefer, you can also download [binary distributions] for the
-supported platforms.
+This file describes how to build and install Ice for JavaScript from source code. If you prefer, you can also download 
+[binary distributions] for the supported platforms.
 
 <!-- TOC depthFrom:2 -->
 
@@ -24,7 +23,7 @@ To build Ice for JavaScript you must have the following:
 
 - The `slice2js` compiler from Ice for C++. If you have not built Ice for C++ in this source distribution, refer to the
   [C++ build instructions](../cpp/BUILDING.md).
-- Node.js 20 or later
+- Node.js 23 or later
 
 ## Building the JavaScript libraries and NodeJS packages
 
@@ -41,16 +40,14 @@ npm install
 npm run build
 ```
 
-On Windows, you need to set the platform and configuration in order to locate
-`slice2js`. For example, if you have built C++ with the x64 Release
-configuration, you can use the following command to build JavaScript:
+On Windows, you need to set the platform and configuration in order to locate `slice2js`. For example, if you have
+built C++ with the x64 platform and the Release configuration, you can use the following command to build JavaScript:
 
 ```shell
 npm run build -- --cppPlatform x64 --cppConfiguration Release
 ```
 
-Alternatively you can use the `CPP_PLATFORM` and `CPP_CONFIGURATION` environment
-variables:
+Alternatively you can use the `CPP_PLATFORM` and `CPP_CONFIGURATION` environment variables:
 
 ```shell
 set CPP_PLATFORM=x64

--- a/js/BUILDING.md
+++ b/js/BUILDING.md
@@ -55,13 +55,10 @@ set CPP_CONFIGURATION=Debug
 npm run build
 ```
 
-Upon successful completion, the build generates libraries in the `lib`
-subdirectory, including compressed and minified versions.
-
 ## Running the JavaScript Tests
 
-Python is required to run the test suite. Additionally, the Glacier2 tests
-require the Python module `passlib`, which you can install with the command:
+Python is required to run the test suite. Additionally, the Glacier2 tests require the Python module `passlib`,
+which you can install with the command:
 
 ```shell
 pip install passlib

--- a/js/BUILDING.md
+++ b/js/BUILDING.md
@@ -23,7 +23,7 @@ To build Ice for JavaScript you must have the following:
 
 - The `slice2js` compiler from Ice for C++. If you have not built Ice for C++ in this source distribution, refer to the
   [C++ build instructions](../cpp/BUILDING.md).
-- Node.js 23 or later
+- Node.js 22 or later
 
 ## Building the JavaScript libraries and NodeJS packages
 

--- a/js/package.json
+++ b/js/package.json
@@ -14,7 +14,10 @@
         "rpc"
     ],
     "type": "module",
-    "main": "src/index.js",
+    "exports": {
+        ".": "./src/index.js",
+        "./slice2js": "./scripts/slice2js.js"
+    },
     "types": "src/index.d.ts",
     "browserslist": "> 0.25%, not dead",
     "devDependencies": {
@@ -35,9 +38,16 @@
         "vinyl": "^3.0.0",
         "vinyl-paths": "^5.0.0"
     },
+    "files": [
+        "src/",
+        "bin/",
+        "slice/",
+        "README.md"
+    ],
     "scripts": {
         "build": "gulp",
         "dist": "gulp dist",
-        "clean": "gulp clean"
+        "clean": "gulp clean",
+        "prepack": "node scripts/prepack.js"
     }
 }

--- a/js/scripts/prepack.js
+++ b/js/scripts/prepack.js
@@ -1,0 +1,73 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+let platformPrefix = '';
+let archPrefix = '';
+let slice2js = '';
+switch (os.platform()) {
+    case 'win32':
+        platformPrefix = 'windows';
+        archPrefix = 'x64';
+        slice2js = 'slice2js.exe';
+        break;
+    case 'darwin':
+        platformPrefix = 'macos';
+        archPrefix = 'arm64';
+        slice2js = 'slice2js';
+        break;
+    case 'linux':
+        platformPrefix = 'linux';
+        archPrefix = os.arch();
+        slice2js = 'slice2js';
+        break;
+    default:
+        console.error(`Unsupported platform: ${os.platform()}`);
+        process.exit(1);
+}
+
+const sourceDir = path.resolve(__dirname, '../../slice');
+const sliceDestDir = path.resolve(__dirname, '../slice');
+let binDestDir = path.resolve(__dirname, '../bin');
+
+function copyFolderSync(src, dest) {
+    if (fs.existsSync(dest)) {
+        fs.rmSync(dest, { recursive: true, force: true });
+    }
+
+    fs.mkdirSync(dest, { recursive: true });
+
+    fs.readdirSync(src).forEach((file) => {
+        const srcFile = path.join(src, file);
+        const destFile = path.join(dest, file);
+
+        if (fs.lstatSync(srcFile).isDirectory()) {
+            copyFolderSync(srcFile, destFile);
+        } else {
+            fs.copyFileSync(srcFile, destFile);
+        }
+    });
+}
+
+console.log(`Copying Slice files from ${sourceDir} to ${sliceDestDir}... `);
+copyFolderSync(sourceDir, sliceDestDir);
+console.log('Done.');
+
+const stagingPath = process.env.SLICE2JS_STAGING_PATH;
+if (stagingPath) {
+    console.log(`Copying Slice compilers from ${sourceDir} to ${binDestDir}...`);
+    copyFolderSync(sourceDir, binDestDir);
+    console.log('Done.');
+} else {
+    console.log(`Compiling Slice compiler from cpp build...`);
+    let binDir = path.resolve(__dirname, '../../cpp/bin');
+    if (os.platform() === 'win32') {
+        binDir = path.resolve(binDir, process.env.PLATFORM || "x64", process.env.CONFIGURATION || "Release");
+    }
+    fs.mkdirSync(path.join(binDestDir, `${platformPrefix}-${archPrefix}`), { recursive: true });
+    fs.copyFileSync(path.join(binDir, slice2js), path.join(binDestDir, `${platformPrefix}-${archPrefix}`, slice2js));
+}

--- a/js/scripts/prepack.js
+++ b/js/scripts/prepack.js
@@ -53,7 +53,7 @@ function copyFolderSync(src, dest) {
     });
 }
 
-console.log(`Copying Slice files from ${sourceDir} to ${sliceDestDir}... `);
+console.log(`Copying Slice files from ${sourceDir} to ${sliceDestDir}...`);
 copyFolderSync(sourceDir, sliceDestDir);
 console.log('Done.');
 

--- a/js/scripts/prepack.js
+++ b/js/scripts/prepack.js
@@ -1,38 +1,47 @@
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
-import { fileURLToPath } from 'url';
+// Copyright (c) ZeroC, Inc.
+
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-let platformPrefix = '';
-let archPrefix = '';
-let slice2js = '';
+let platformPrefix = "";
+let archPrefix = "";
+let slice2js = "";
+
 switch (os.platform()) {
-    case 'win32':
-        platformPrefix = 'windows';
-        archPrefix = 'x64';
-        slice2js = 'slice2js.exe';
+    case "win32":
+        platformPrefix = "windows";
+        archPrefix = "x64";
+        slice2js = "slice2js.exe";
         break;
-    case 'darwin':
-        platformPrefix = 'macos';
-        archPrefix = 'arm64';
-        slice2js = 'slice2js';
+    case "darwin":
+        platformPrefix = "macos";
+        archPrefix = "arm64";
+        slice2js = "slice2js";
         break;
-    case 'linux':
-        platformPrefix = 'linux';
+    case "linux":
+        platformPrefix = "linux";
         archPrefix = os.arch();
-        slice2js = 'slice2js';
+        slice2js = "slice2js";
         break;
     default:
         console.error(`Unsupported platform: ${os.platform()}`);
         process.exit(1);
 }
 
-const sourceDir = path.resolve(__dirname, '../../slice');
-const sliceDestDir = path.resolve(__dirname, '../slice');
-let binDestDir = path.resolve(__dirname, '../bin');
+const allSupportedPlatforms = ["windows-x64", "macos-arm64", "linux-x64", "linux-arm64"];
+
+const sliceSourceDir = path.resolve(__dirname, "../../slice");
+const sliceDestDir = path.resolve(__dirname, "../slice");
+let cppBinDir = path.resolve(__dirname, "../../cpp/bin");
+
+if (os.platform() === "win32") {
+    cppBinDir = path.resolve(cppBinDir, "x64", "Release");
+}
 
 function copyFolderSync(src, dest) {
     if (fs.existsSync(dest)) {
@@ -41,7 +50,7 @@ function copyFolderSync(src, dest) {
 
     fs.mkdirSync(dest, { recursive: true });
 
-    fs.readdirSync(src).forEach((file) => {
+    fs.readdirSync(src).forEach(file => {
         const srcFile = path.join(src, file);
         const destFile = path.join(dest, file);
 
@@ -53,21 +62,51 @@ function copyFolderSync(src, dest) {
     });
 }
 
-console.log(`Copying Slice files from ${sourceDir} to ${sliceDestDir}...`);
-copyFolderSync(sourceDir, sliceDestDir);
-console.log('Done.');
+// Ensure we are running from Ice source distribution
+if (!fs.existsSync(sliceSourceDir)) {
+    console.error("The pack command must be run from the Ice source distribution.");
+    console.error("See https://github.com/zeroc-ice/ice/blob/main/js/BUILDING.md");
+    process.exit(1);
+}
+
+console.log(`Copying Slice files from ${sliceSourceDir} to ${sliceDestDir}... `);
+copyFolderSync(sliceSourceDir, sliceDestDir);
+console.log("Done.");
 
 const stagingPath = process.env.SLICE2JS_STAGING_PATH;
+let binDestDir = path.resolve(__dirname, "../bin");
+
 if (stagingPath) {
-    console.log(`Copying Slice compilers from ${sourceDir} to ${binDestDir}...`);
-    copyFolderSync(sourceDir, binDestDir);
-    console.log('Done.');
-} else {
-    console.log(`Compiling Slice compiler from cpp build...`);
-    let binDir = path.resolve(__dirname, '../../cpp/bin');
-    if (os.platform() === 'win32') {
-        binDir = path.resolve(binDir, process.env.PLATFORM || "x64", process.env.CONFIGURATION || "Release");
+    // Check that all compilers are available in the staging path
+    for (const platform of allSupportedPlatforms) {
+        const compilerPath = path.join(
+            stagingPath,
+            platform,
+            platform.startsWith("windows") ? "slice2js.exe" : "slice2js",
+        );
+        if (!fs.existsSync(compilerPath)) {
+            console.error(`Missing compiler ${compilerPath} in the staging path ${stagingPath}`);
+            process.exit(1);
+        }
     }
+
+    console.log(`Copying Slice compilers from ${stagingPath} to ${binDestDir}...`);
+    copyFolderSync(stagingPath, binDestDir);
+    console.log("Done.");
+} else {
+    console.log(`Compiling Slice compiler from cpp build... `);
+    if (fs.existsSync(binDestDir)) {
+        fs.rmSync(binDestDir, { recursive: true, force: true });
+    }
+
+    const compilerPath = path.join(cppBinDir, slice2js);
+    if (!fs.existsSync(compilerPath)) {
+        console.error(`Missing compiler ${compilerPath} in the source distribution`);
+        console.error(`The slice2js compiler must be built before running the pack command.`);
+        process.exit(1);
+    }
+
     fs.mkdirSync(path.join(binDestDir, `${platformPrefix}-${archPrefix}`), { recursive: true });
-    fs.copyFileSync(path.join(binDir, slice2js), path.join(binDestDir, `${platformPrefix}-${archPrefix}`, slice2js));
+    fs.copyFileSync(compilerPath, path.join(binDestDir, `${platformPrefix}-${archPrefix}`, slice2js));
+    console.log("Done.");
 }

--- a/js/scripts/slice2js.js
+++ b/js/scripts/slice2js.js
@@ -1,0 +1,44 @@
+// Copyright (c) ZeroC, Inc.
+
+import { spawn } from 'child_process';
+import path from 'path';
+import os from 'os';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+let platformPrefix = '';
+let archPrefix = '';
+let exe = '';
+switch (os.platform()) {
+    case 'win32':
+        platformPrefix = 'windows';
+        archPrefix = 'x64';
+        exe = 'slice2js.exe';
+        break;
+    case 'darwin':
+        platformPrefix = 'macos';
+        archPrefix = 'arm64';
+        exe = 'slice2js';
+        break;
+    case 'linux':
+        platformPrefix = 'linux';
+        archPrefix = os.arch();
+        exe = 'slice2js';
+        break;
+    default:
+        console.error(`Unsupported platform: ${os.platform()}`);
+        process.exit(1);
+}
+
+const sliceDir = path.resolve(path.join(__dirname, '..', 'slice'));
+const binDir = path.resolve(path.join(__dirname, '..', 'bin', `${platformPrefix}-${archPrefix}`));
+const slice2js = path.resolve(path.join(binDir, exe));
+
+export function compile(args = [], options) {
+    let slice2jsArgs = args.slice();
+    slice2jsArgs.push(`-I${sliceDir}`);
+    return spawn(slice2js, slice2jsArgs, options);
+}
+
+export { sliceDir, slice2js };

--- a/js/scripts/slice2js.js
+++ b/js/scripts/slice2js.js
@@ -31,14 +31,14 @@ switch (os.platform()) {
         process.exit(1);
 }
 
-const sliceDir = path.resolve(path.join(__dirname, '..', 'slice'));
+const slicePath = path.resolve(path.join(__dirname, '..', 'slice'));
 const binDir = path.resolve(path.join(__dirname, '..', 'bin', `${platformPrefix}-${archPrefix}`));
 const slice2js = path.resolve(path.join(binDir, exe));
 
 export function compile(args = [], options) {
     let slice2jsArgs = args.slice();
-    slice2jsArgs.push(`-I${sliceDir}`);
+    slice2jsArgs.push(`-I${slicePath}`);
     return spawn(slice2js, slice2jsArgs, options);
 }
 
-export { sliceDir, slice2js };
+export { slicePath, slice2js };

--- a/js/scripts/slice2js.js
+++ b/js/scripts/slice2js.js
@@ -1,44 +1,74 @@
+#!/usr/bin/env node
+
 // Copyright (c) ZeroC, Inc.
 
-import { spawn } from 'child_process';
-import path from 'path';
-import os from 'os';
-import { fileURLToPath } from 'url';
+import { spawn } from "child_process";
+import path from "path";
+import os from "os";
+import { fileURLToPath } from "url";
+import fs from "fs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-let platformPrefix = '';
-let archPrefix = '';
-let exe = '';
+let platformPrefix = "";
+let archPrefix = os.arch();
+let exe = "";
+
 switch (os.platform()) {
-    case 'win32':
-        platformPrefix = 'windows';
-        archPrefix = 'x64';
-        exe = 'slice2js.exe';
+    case "win32":
+        platformPrefix = "windows";
+        archPrefix = "x64";
+        exe = "slice2js.exe";
         break;
-    case 'darwin':
-        platformPrefix = 'macos';
-        archPrefix = 'arm64';
-        exe = 'slice2js';
+    case "darwin":
+        platformPrefix = "macos";
+        archPrefix = "arm64";
+        exe = "slice2js";
         break;
-    case 'linux':
-        platformPrefix = 'linux';
-        archPrefix = os.arch();
-        exe = 'slice2js';
+    case "linux":
+        platformPrefix = "linux";
+        exe = "slice2js";
         break;
     default:
         console.error(`Unsupported platform: ${os.platform()}`);
         process.exit(1);
 }
 
-const slicePath = path.resolve(path.join(__dirname, '..', 'slice'));
-const binDir = path.resolve(path.join(__dirname, '..', 'bin', `${platformPrefix}-${archPrefix}`));
-const slice2js = path.resolve(path.join(binDir, exe));
+const slicePath = path.resolve(__dirname, "..", "slice");
+const binDir = path.resolve(__dirname, "..", "bin", `${platformPrefix}-${archPrefix}`);
+const slice2js = path.resolve(binDir, exe);
 
-export function compile(args = [], options) {
+/**
+ * Compile function for programmatic use.
+ * @param {string[]} args - Command-line arguments for slice2js.
+ * @param {object} options - Options passed to spawn.
+ * @returns {Promise<number>} Resolves with the exit code.
+ */
+export async function compile(args = [], options = {}) {
+    if (!fs.existsSync(slice2js)) {
+        throw new Error(`Missing slice2js executable at ${slice2js}`);
+    }
+
     let slice2jsArgs = args.slice();
     slice2jsArgs.push(`-I${slicePath}`);
-    return spawn(slice2js, slice2jsArgs, options);
+
+    return new Promise((resolve, reject) => {
+        const process = spawn(slice2js, slice2jsArgs, options);
+
+        process.on("error", reject);
+        process.on("exit", resolve);
+    });
+}
+
+// If executed directly via `npx slice2js`
+if (import.meta.url === `file://${process.argv[1]}`) {
+    try {
+        const exitCode = await compile(process.argv.slice(2), { stdio: "inherit" });
+        process.exit(exitCode);
+    } catch (err) {
+        console.error(`Error executing slice2js: ${err.message}`);
+        process.exit(1);
+    }
 }
 
 export { slicePath, slice2js };


### PR DESCRIPTION
This PR updates the NPM ice package to include the slice2js compiler.

It can include the slice2js from the current C++ build, or prebuilt compilers from `SLICE2JS_STAGING_PATH` environment variable.

For CI builds and release packages we will include the slice2js for all supported platforms.