### PR TITLE
Rework printTarget to show non-IP transport

### DIFF
--- a/cpp/src/Ice/LoggerMiddleware.cpp
+++ b/cpp/src/Ice/LoggerMiddleware.cpp
@@ -145,8 +145,8 @@ LoggerMiddleware::printTarget(LoggerOutputBase& out, const Current& current) con
 
         if (auto ipConnInfo = dynamic_pointer_cast<IPConnectionInfo>(connInfo))
         {
-            out << ipConnInfo->localAddress << ':' << ipConnInfo->localPort << "<->"
-                << ipConnInfo->remoteAddress << ':' << ipConnInfo->remotePort;
+            out << ipConnInfo->localAddress << ':' << ipConnInfo->localPort << "<->" << ipConnInfo->remoteAddress << ':'
+                << ipConnInfo->remotePort;
         }
         else
         {

--- a/cpp/src/Ice/LoggerMiddleware.cpp
+++ b/cpp/src/Ice/LoggerMiddleware.cpp
@@ -133,18 +133,29 @@ LoggerMiddleware::printTarget(LoggerOutputBase& out, const Current& current) con
     {
         out << " -f " << escapeString(current.facet, "", _toStringMode);
     }
+    out << " over ";
 
     if (current.con)
     {
-        for (ConnectionInfoPtr connInfo = current.con->getInfo(); connInfo; connInfo = connInfo->underlying)
+        ConnectionInfoPtr connInfo = current.con->getInfo();
+        while (connInfo->underlying)
         {
-            auto ipConnInfo = dynamic_pointer_cast<IPConnectionInfo>(connInfo);
-            if (ipConnInfo)
-            {
-                out << " over " << ipConnInfo->localAddress << ':' << ipConnInfo->localPort << "<->"
-                    << ipConnInfo->remoteAddress << ':' << ipConnInfo->remotePort;
-                break;
-            }
+            connInfo = connInfo->underlying;
         }
+
+        if (auto ipConnInfo = dynamic_pointer_cast<IPConnectionInfo>(connInfo))
+        {
+            out << ipConnInfo->localAddress << ':' << ipConnInfo->localPort << "<->"
+                << ipConnInfo->remoteAddress << ':' << ipConnInfo->remotePort;
+        }
+        else
+        {
+            // Connection::toString returns a multiline string, so we just use type() here for bt and similar.
+            out << current.con->type();
+        }
+    }
+    else
+    {
+        out << "colloc";
     }
 }

--- a/csharp/src/Ice/Internal/LoggerMiddleware.cs
+++ b/csharp/src/Ice/Internal/LoggerMiddleware.cs
@@ -122,29 +122,35 @@ internal sealed class LoggerMiddleware : Object
             sb.Append(Ice.UtilInternal.StringUtil.escapeString(current.facet, "", _toStringMode));
         }
 
+        sb.Append(" over ");
+
         if (current.con is not null)
         {
-            try
+            ConnectionInfo connInfo = current.con.getInfo();
+            while (connInfo.underlying is not null)
             {
-                for (ConnectionInfo? p = current.con.getInfo(); p is not null; p = p.underlying)
-                {
-                    if (p is IPConnectionInfo ipInfo)
-                    {
-                        sb.Append(" over ");
-                        sb.Append(ipInfo.localAddress);
-                        sb.Append(':');
-                        sb.Append(ipInfo.localPort);
-                        sb.Append("<->");
-                        sb.Append(ipInfo.remoteAddress);
-                        sb.Append(':');
-                        sb.Append(ipInfo.remotePort);
-                        break;
-                    }
-                }
+                connInfo = connInfo.underlying;
             }
-            catch (LocalException)
+
+            if (connInfo is IPConnectionInfo ipConnInfo)
             {
+                sb.Append(ipConnInfo.localAddress);
+                sb.Append(':');
+                sb.Append(ipConnInfo.localPort);
+                sb.Append("<->");
+                sb.Append(ipConnInfo.remoteAddress);
+                sb.Append(':');
+                sb.Append(ipConnInfo.remotePort);
             }
+            else
+            {
+                // Connection.ToString() returns a multiline string, so we just use type here for bt and similar.
+                sb.Append(current.con.type());
+            }
+        }
+        else
+        {
+            sb.Append("colloc");
         }
     }
 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerMiddleware.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerMiddleware.java
@@ -119,23 +119,27 @@ final class LoggerMiddleware implements com.zeroc.Ice.Object {
             out.print(" -f ");
             out.print(StringUtil.escapeString(current.facet, "", _toStringMode));
         }
+        out.print(" over ");
+
         if (current.con != null) {
-            try {
-                for (ConnectionInfo connInfo = current.con.getInfo();
-                        connInfo != null;
-                        connInfo = connInfo.underlying) {
-                    if (connInfo instanceof IPConnectionInfo ipConnInfo) {
-                        out.print(" over ");
-                        out.print(ipConnInfo.localAddress);
-                        out.print(":" + ipConnInfo.localPort);
-                        out.print("<->");
-                        out.print(ipConnInfo.remoteAddress);
-                        out.print(":" + ipConnInfo.remotePort);
-                    }
-                }
-            } catch (LocalException exc) {
-                // Ignore.
+            ConnectionInfo connInfo = current.con.getInfo();
+            while (connInfo.underlying != null) {
+                connInfo = connInfo.underlying;
             }
+
+            if (connInfo instanceof IPConnectionInfo ipConnInfo) {
+                out.print(ipConnInfo.localAddress);
+                out.print(":" + ipConnInfo.localPort);
+                out.print("<->");
+                out.print(ipConnInfo.remoteAddress);
+                out.print(":" + ipConnInfo.remotePort);
+            } else {
+                // Connection.toString() returns a multiline string, so we just use type() here
+                // for bt and similar.
+                out.print(current.con.type());
+            }
+        } else {
+            out.print("colloc");
         }
     }
 }


### PR DESCRIPTION
This PR updates the LoggerMiddleware printTarget to show the transport (or colloc) for non-IP connections.