### PR TITLE
Use the 'New' Metadata Validator for `slice2swift`

### DIFF
--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -73,6 +73,7 @@ void
 Gen::generate(const UnitPtr& p)
 {
     SwiftGenerator::validateMetadata(p);
+    SwiftGenerator::validateSwiftModuleMappings(p);
 
     ImportVisitor importVisitor(_out);
     p->visit(&importVisitor);

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -619,6 +619,69 @@ SwiftGenerator::validateMetadata(const UnitPtr& u)
     u->visit(&visitor);
 }
 
+void
+SwiftGenerator::validateSwiftModuleMappings(const UnitPtr& unit)
+{
+    using ModuleMap = std::map<std::string, std::string>;
+    // Each Slice unit has to map all top-level modules to a single Swift module
+    ModuleMap mappedModules;
+    // With a given Swift module a Slice module has to map to a single prefix
+    std::map<std::string, ModuleMap> mappedModulePrefixes;
+
+    // Any modules that are directly contained on the unit are (by definition) top-level modules.
+    // And since there is only one unit per compilation, this must be all the top-level modules.
+    for (const auto& module : unit->modules())
+    {
+        string swiftPrefix;
+        string swiftModule = getSwiftModule(module, swiftPrefix);
+
+        const string filename = module->definitionContext()->filename();
+        auto current = mappedModules.find(filename);
+
+        if (current == mappedModules.end())
+        {
+            mappedModules[filename] = swiftModule;
+        }
+        else if (current->second != swiftModule)
+        {
+            ostringstream os;
+            os << "invalid module mapping:\n Slice module '" << module->scoped() << "' should map to Swift module '"
+               << current->second << "'" << endl;
+            unit->error(module->file(), module->line(), os.str());
+        }
+
+        auto prefixes = mappedModulePrefixes.find(swiftModule);
+        if (prefixes == mappedModulePrefixes.end())
+        {
+            ModuleMap mappings;
+            mappings[module->name()] = swiftPrefix;
+            mappedModulePrefixes[swiftModule] = mappings;
+        }
+        else
+        {
+            current = prefixes->second.find(module->name());
+            if (current == prefixes->second.end())
+            {
+                prefixes->second[module->name()] = swiftPrefix;
+            }
+            else if (current->second != swiftPrefix)
+            {
+                ostringstream os;
+                os << "invalid module prefix:\n Slice module '" << module->scoped() << "' is already using";
+                if (current->second.empty())
+                {
+                    os << " no prefix " << endl;
+                }
+                else
+                {
+                    os << " a different Swift module prefix '" << current->second << "'" << endl;
+                }
+                unit->error(module->file(), module->line(), os.str());
+            }
+        }
+    }
+}
+
 string
 SwiftGenerator::getRelativeTypeString(const ContainedPtr& contained, const string& currentModule)
 {
@@ -1263,71 +1326,6 @@ SwiftGenerator::writeMarshalUnmarshalCode(
         }
         return;
     }
-}
-
-bool
-SwiftGenerator::MetadataVisitor::visitUnitStart(const UnitPtr& unit)
-{
-    using ModuleMap = std::map<std::string, std::string>;
-    // Each Slice unit has to map all top-level modules to a single Swift module
-    ModuleMap mappedModules;
-    // With a given Swift module a Slice module has to map to a single prefix
-    std::map<std::string, ModuleMap> mappedModulePrefixes;
-
-    // Any modules that are directly contained on the unit are (by definition) top-level modules.
-    // And since there is only one unit per compilation, this must be all the top-level modules.
-    for (const auto& module : unit->modules())
-    {
-        string swiftPrefix;
-        string swiftModule = getSwiftModule(module, swiftPrefix);
-
-        const string filename = module->definitionContext()->filename();
-        auto current = mappedModules.find(filename);
-
-        if (current == mappedModules.end())
-        {
-            mappedModules[filename] = swiftModule;
-        }
-        else if (current->second != swiftModule)
-        {
-            ostringstream os;
-            os << "invalid module mapping:\n Slice module '" << module->scoped() << "' should map to Swift module '"
-               << current->second << "'" << endl;
-            unit->error(module->file(), module->line(), os.str());
-        }
-
-        auto prefixes = mappedModulePrefixes.find(swiftModule);
-        if (prefixes == mappedModulePrefixes.end())
-        {
-            ModuleMap mappings;
-            mappings[module->name()] = swiftPrefix;
-            mappedModulePrefixes[swiftModule] = mappings;
-        }
-        else
-        {
-            current = prefixes->second.find(module->name());
-            if (current == prefixes->second.end())
-            {
-                prefixes->second[module->name()] = swiftPrefix;
-            }
-            else if (current->second != swiftPrefix)
-            {
-                ostringstream os;
-                os << "invalid module prefix:\n Slice module '" << module->scoped() << "' is already using";
-                if (current->second.empty())
-                {
-                    os << " no prefix " << endl;
-                }
-                else
-                {
-                    os << " a different Swift module prefix '" << current->second << "'" << endl;
-                }
-                unit->error(module->file(), module->line(), os.str());
-            }
-        }
-    }
-
-    return true;
 }
 
 bool

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -2,8 +2,8 @@
 //
 
 #include "SwiftUtil.h"
-#include "../Slice/MetadataValidation.h"
 #include "../Ice/OutputUtil.h"
+#include "../Slice/MetadataValidation.h"
 #include "../Slice/Util.h"
 
 #include <algorithm>

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -42,6 +42,10 @@ namespace Slice
 
         static void validateMetadata(const UnitPtr&);
 
+        // Swift only allows 1 package per file, so this function checks that if there are multiple top-level-modules
+        // within a single Slice file, that they all map to the same Swift package.
+        static void validateSwiftModuleMappings(const UnitPtr&);
+
     protected:
         void writeDocLines(
             IceInternal::Output&,
@@ -124,7 +128,6 @@ namespace Slice
         class MetadataVisitor final : public ParserVisitor
         {
         public:
-            bool visitUnitStart(const UnitPtr&) final;
             bool visitModuleStart(const ModulePtr&) final;
             bool visitClassDefStart(const ClassDefPtr&) final;
             bool visitInterfaceDefStart(const InterfaceDefPtr&) final;

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -123,27 +123,6 @@ namespace Slice
         void writeSwiftAttributes(::IceInternal::Output&, const MetadataList&);
         void writeProxyOperation(::IceInternal::Output&, const OperationPtr&);
         void writeDispatchOperation(::IceInternal::Output&, const OperationPtr&);
-
-    private:
-        class MetadataVisitor final : public ParserVisitor
-        {
-        public:
-            bool visitModuleStart(const ModulePtr&) final;
-            bool visitClassDefStart(const ClassDefPtr&) final;
-            bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
-            void visitOperation(const OperationPtr&) final;
-            bool visitExceptionStart(const ExceptionPtr&) final;
-            bool visitStructStart(const StructPtr&) final;
-            void visitSequence(const SequencePtr&) final;
-            void visitDictionary(const DictionaryPtr&) final;
-            void visitEnum(const EnumPtr&) final;
-            void visitConst(const ConstPtr&) final;
-
-            [[nodiscard]] bool shouldVisitIncludedDefinitions() const final { return true; }
-
-        private:
-            MetadataList validate(const SyntaxTreeBasePtr&, const ContainedPtr&);
-        };
     };
 }
 


### PR DESCRIPTION
This PR switches `slice2swift` to use the new metadata validator built into `libSlice`.
It is the last language to be switched, and after this PR is merged, I will finally consider issue #117 fixed.