### PR TITLE
Add Support for `java:identifier` Metadata

### DIFF
--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -3883,7 +3883,12 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     out << eb;
     close();
 
-    open(("_" + getUnqualified(p) + "PrxI"), p->file());
+    // Add a '_' prefix to the file name. We want this '_' to come after any package scopes.
+    string absolute = getUnqualified(p) + "PrxI";
+    auto scopePos = absolute.rfind('.');
+    scopePos = (scopePos == string::npos ? 0 : scopePos + 1);
+    absolute.insert(scopePos, 1, '_');
+    open(absolute, p->file());
 
     Output& outi = output();
 

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -1963,11 +1963,17 @@ Slice::JavaVisitor::writeProxyDocComment(
     //
     if (!async)
     {
-        map<string, StringList> exDocs = dc->exceptions();
-        for (const auto& exDoc : exDocs)
+        for (const auto& [name, lines] : dc->exceptions())
         {
-            out << nl << " * @throws " << fixKwd(exDoc.first) << ' ';
-            writeDocCommentLines(out, exDoc.second);
+            string scopedName = name;
+            // Try to locate the exception's definition using the name given in the comment.
+            ExceptionPtr ex = p->container()->lookupException(name, false);
+            if (ex)
+            {
+                scopedName = ex->mappedScoped(".").substr(1);
+            }
+            out << nl << " * @throws " << scopedName << ' ';
+            writeDocCommentLines(out, lines);
         }
     }
 
@@ -2099,11 +2105,17 @@ Slice::JavaVisitor::writeServantDocComment(Output& out, const OperationPtr& p, c
         out << nl << " * @return A completion stage that the servant will complete when the invocation completes.";
     }
 
-    map<string, StringList> exDocs = dc->exceptions();
-    for (const auto& exDoc : exDocs)
+    for (const auto& [name, lines] : dc->exceptions())
     {
-        out << nl << " * @throws " << fixKwd(exDoc.first) << ' ';
-        writeDocCommentLines(out, exDoc.second);
+        string scopedName = name;
+        // Try to locate the exception's definition using the name given in the comment.
+        ExceptionPtr ex = p->container()->lookupException(name, false);
+        if (ex)
+        {
+            scopedName = ex->mappedScoped(".").substr(1);
+        }
+        out << nl << " * @throws " << scopedName << ' ';
+        writeDocCommentLines(out, lines);
     }
 
     if (!dc->seeAlso().empty())

--- a/cpp/src/slice2java/Gen.h
+++ b/cpp/src/slice2java/Gen.h
@@ -49,7 +49,6 @@ namespace Slice
         //
         // Compose the argument lists for an operation.
         //
-        std::vector<std::string> getArgs(const OperationPtr&);
         std::vector<std::string> getInArgs(const OperationPtr&, bool = false);
 
         void writeMarshalProxyParams(IceInternal::Output&, const std::string&, const OperationPtr&, bool);
@@ -117,7 +116,7 @@ namespace Slice
     class Gen final
     {
     public:
-        Gen(const std::string&, std::string, const std::vector<std::string>&, std::string);
+        Gen(std::string, const std::vector<std::string>&, std::string);
         Gen(const Gen&) = delete;
         ~Gen();
 

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -1766,6 +1766,25 @@ Slice::JavaGenerator::validateMetadata(const UnitPtr& u)
     };
     knownMetadata.emplace("java:getset", std::move(getsetInfo));
 
+    // "java:identifier"
+    MetadataInfo identifierInfo = {
+        .validOn =
+            {typeid(InterfaceDecl),
+             typeid(Operation),
+             typeid(ClassDecl),
+             typeid(Slice::Exception),
+             typeid(Struct),
+             typeid(Sequence),
+             typeid(Dictionary),
+             typeid(Enum),
+             typeid(Enumerator),
+             typeid(Const),
+             typeid(Parameter),
+             typeid(DataMember)},
+        .acceptedArgumentKind = MetadataArgumentKind::SingleArgument,
+    };
+    knownMetadata.emplace("java:identifier", std::move(identifierInfo));
+
     // "java:package"
     MetadataInfo packageInfo = {
         .validOn = {typeid(Unit), typeid(Module)},

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -1719,8 +1719,6 @@ Slice::JavaGenerator::validateMetadata(const UnitPtr& u)
         .validOn =
             {typeid(InterfaceDecl),
              typeid(Operation),
-             typeid(ClassDecl),
-             typeid(Slice::Exception),
              typeid(Struct),
              typeid(Sequence),
              typeid(Dictionary),

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -53,30 +53,6 @@ namespace
             return builtinBufferTable[builtin->kind()];
         }
     }
-
-    string lookupKwd(const string& name)
-    {
-        //
-        // Keyword list. *Must* be kept in alphabetical order. Note that checkedCast and uncheckedCast
-        // are not Java keywords, but are in this list to prevent illegal code being generated if
-        // someone defines Slice operations with that name.
-        //
-        // NOTE: Any changes made to this list must also be made in BasicStream.java.
-        //
-        static const string keywordList[] = {
-            "abstract", "assert",      "boolean",    "break",     "byte",       "case",         "catch",
-            "char",     "checkedCast", "class",      "clone",     "const",      "continue",     "default",
-            "do",       "double",      "else",       "enum",      "equals",     "extends",      "false",
-            "final",    "finalize",    "finally",    "float",     "for",        "getClass",     "goto",
-            "hashCode", "if",          "implements", "import",    "instanceof", "int",          "interface",
-            "long",     "native",      "new",        "notify",    "notifyAll",  "null",         "package",
-            "permits",  "private",     "protected",  "public",    "record",     "return",       "sealed",
-            "short",    "static",      "strictfp",   "super",     "switch",     "synchronized", "this",
-            "throw",    "throws",      "toString",   "transient", "true",       "try",          "uncheckedCast",
-            "var",      "void",        "volatile",   "wait",      "when",       "while",        "yield"};
-        bool found = binary_search(&keywordList[0], &keywordList[sizeof(keywordList) / sizeof(*keywordList)], name);
-        return found ? "_" + name : name;
-    }
 }
 
 string
@@ -341,34 +317,6 @@ Slice::JavaGenerator::output() const
 {
     assert(_out != nullptr);
     return *_out;
-}
-
-//
-// If the passed name is a scoped name, return the identical scoped name,
-// but with all components that are Java keywords replaced by
-// their "_"-prefixed version; otherwise, if the passed name is
-// not scoped, but a Java keyword, return the "_"-prefixed name;
-// otherwise, return the name unchanged.
-//
-string
-Slice::JavaGenerator::fixKwd(const string& name)
-{
-    if (name.empty())
-    {
-        return name;
-    }
-    if (name[0] != ':')
-    {
-        return lookupKwd(name);
-    }
-    vector<string> ids = splitScopedName(name);
-    transform(ids.begin(), ids.end(), ids.begin(), [](const string& id) -> string { return lookupKwd(id); });
-    stringstream result;
-    for (const auto& id : ids)
-    {
-        result << "::" + id;
-    }
-    return result.str();
 }
 
 string

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -88,12 +88,6 @@ namespace Slice
         [[nodiscard]] ::IceInternal::Output& output() const;
 
         //
-        // Convert a Slice scoped name into a Java name.
-        //
-        [[nodiscard]] static std::string
-        convertScopedName(const std::string&, const std::string& = std::string(), const std::string& = std::string());
-
-        //
         // Returns the package prefix of a Contained entity.
         //
         [[nodiscard]] static std::string getPackagePrefix(const ContainedPtr&);
@@ -114,11 +108,7 @@ namespace Slice
         // package argument matches the entity's package name, then the
         // package is removed from the result.
         //
-        [[nodiscard]] static std::string getUnqualified(
-            const ContainedPtr&,
-            const std::string& = std::string(),
-            const std::string& = std::string(),
-            const std::string& = std::string());
+        [[nodiscard]] static std::string getUnqualified(const ContainedPtr&, const std::string& = std::string());
 
         //
         // Return the method call necessary to obtain the static type ID for an object type.

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -73,10 +73,6 @@ namespace Slice
 
         void close();
 
-        // Check a symbol against any of the Java keywords.
-        // If a match is found, return the symbol with a leading underscore.
-        static std::string fixKwd(const std::string&);
-
         JavaGenerator(std::string);
 
         //

--- a/cpp/src/slice2java/Main.cpp
+++ b/cpp/src/slice2java/Main.cpp
@@ -264,7 +264,7 @@ compile(const vector<string>& argv)
                 {
                     try
                     {
-                        Gen gen(argv[0], icecpp->getBaseName(), includePaths, output);
+                        Gen gen(icecpp->getBaseName(), includePaths, output);
                         gen.generate(p);
                     }
                     catch (const Slice::FileException& ex)

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
@@ -707,6 +707,7 @@ public final class Util {
         return System.getProperty("java.vm.name").startsWith("Dalvik");
     }
 
+    // TODOAUSTIN
     private static String fixKwd(String name) {
         //
         // Keyword list. *Must* be kept in alphabetical order. Note that checkedCast and

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
@@ -528,7 +528,7 @@ public final class Util {
             if (buf.length() > 0) {
                 buf.append('.');
             }
-            buf.append(fixKwd(s));
+            buf.append(s);
         }
 
         return buf.toString();
@@ -705,84 +705,6 @@ public final class Util {
      */
     public static boolean isAndroid() {
         return System.getProperty("java.vm.name").startsWith("Dalvik");
-    }
-
-    // TODOAUSTIN
-    private static String fixKwd(String name) {
-        //
-        // Keyword list. *Must* be kept in alphabetical order. Note that checkedCast and
-        // uncheckedCast
-        // are not Java keywords, but are in this list to prevent illegal code being generated if
-        // someone defines Slice operations with that name.
-        //
-        final String[] keywordList = {
-            "abstract",
-            "assert",
-            "boolean",
-            "break",
-            "byte",
-            "case",
-            "catch",
-            "char",
-            "checkedCast",
-            "class",
-            "clone",
-            "const",
-            "continue",
-            "default",
-            "do",
-            "double",
-            "else",
-            "enum",
-            "equals",
-            "extends",
-            "false",
-            "final",
-            "finalize",
-            "finally",
-            "float",
-            "for",
-            "getClass",
-            "goto",
-            "hashCode",
-            "if",
-            "implements",
-            "import",
-            "instanceof",
-            "int",
-            "interface",
-            "long",
-            "native",
-            "new",
-            "notify",
-            "notifyAll",
-            "null",
-            "package",
-            "private",
-            "protected",
-            "public",
-            "return",
-            "short",
-            "static",
-            "strictfp",
-            "super",
-            "switch",
-            "synchronized",
-            "this",
-            "throw",
-            "throws",
-            "toString",
-            "transient",
-            "true",
-            "try",
-            "uncheckedCast",
-            "void",
-            "volatile",
-            "wait",
-            "while"
-        };
-        boolean found = java.util.Arrays.binarySearch(keywordList, name) >= 0;
-        return found ? "_" + name : name;
     }
 
     private static byte stringToMajor(String str) {

--- a/java/test/src/main/java/test/Ice/adapterDeactivation/AllTests.java
+++ b/java/test/src/main/java/test/Ice/adapterDeactivation/AllTests.java
@@ -67,7 +67,7 @@ public class AllTests {
         out.print("creating/activating/deactivating object adapter in one operation... ");
         out.flush();
         obj._transient();
-        obj.transientAsync().join();
+        obj._transientAsync().join();
         out.println("ok");
 
         {

--- a/java/test/src/main/java/test/Ice/adapterDeactivation/Test.ice
+++ b/java/test/src/main/java/test/Ice/adapterDeactivation/Test.ice
@@ -8,6 +8,7 @@ module Test
 
 interface TestIntf
 {
+    ["java:identifier:_transient"]
     void transient();
 
     void deactivate();

--- a/java/test/src/main/java/test/Ice/packagemd/AllTests.java
+++ b/java/test/src/main/java/test/Ice/packagemd/AllTests.java
@@ -7,7 +7,7 @@ import test.Ice.packagemd.Test1.C1;
 import test.Ice.packagemd.Test1.C2;
 import test.Ice.packagemd.Test1.E1;
 import test.Ice.packagemd.Test1.E2;
-import test.Ice.packagemd.Test1._notify;
+import test.Ice.packagemd.Test1.notify;
 
 import java.io.PrintWriter;
 
@@ -58,7 +58,7 @@ public class AllTests {
             try {
                 initial.throwTest1Notify();
                 test(false);
-            } catch (_notify ex) {
+            } catch (notify ex) {
                 // Expected
             }
             out.println("ok");

--- a/java/test/src/main/java/test/Ice/packagemd/InitialI.java
+++ b/java/test/src/main/java/test/Ice/packagemd/InitialI.java
@@ -7,7 +7,7 @@ import test.Ice.packagemd.Test1.C1;
 import test.Ice.packagemd.Test1.C2;
 import test.Ice.packagemd.Test1.E1;
 import test.Ice.packagemd.Test1.E2;
-import test.Ice.packagemd.Test1._notify;
+import test.Ice.packagemd.Test1.notify;
 
 public final class InitialI implements Initial {
     public com.zeroc.Ice.Value getTest1C2AsObject(com.zeroc.Ice.Current current) {
@@ -35,8 +35,8 @@ public final class InitialI implements Initial {
     }
 
     @Override
-    public void throwTest1Notify(com.zeroc.Ice.Current current) throws _notify {
-        throw new _notify();
+    public void throwTest1Notify(com.zeroc.Ice.Current current) throws notify {
+        throw new notify();
     }
 
     public com.zeroc.Ice.Value getTest2C2AsObject(com.zeroc.Ice.Current current) {

--- a/java/test/src/main/java/test/Ice/packagemd/NoPackage.ice
+++ b/java/test/src/main/java/test/Ice/packagemd/NoPackage.ice
@@ -25,7 +25,8 @@ exception E2 extends E1
     long l;
 }
 
-exception notify /* Test keyword escape. */
+["java:identifier:_notify"]
+exception notify
 {
     int i;
 }

--- a/java/test/src/main/java/test/Ice/packagemd/NoPackage.ice
+++ b/java/test/src/main/java/test/Ice/packagemd/NoPackage.ice
@@ -25,7 +25,6 @@ exception E2 extends E1
     long l;
 }
 
-["java:identifier:_notify"]
 exception notify
 {
     int i;

--- a/java/test/src/main/java/test/Ice/servantLocator/AMDTestI.java
+++ b/java/test/src/main/java/test/Ice/servantLocator/AMDTestI.java
@@ -55,8 +55,8 @@ public final class AMDTestI implements TestIntf {
 
     @Override
     public CompletionStage<String> impossibleExceptionAsync(
-            boolean _throw, com.zeroc.Ice.Current current) {
-        if (_throw) {
+            boolean shouldThrow, com.zeroc.Ice.Current current) {
+        if (shouldThrow) {
             CompletableFuture<String> f = new CompletableFuture<>();
             f.completeExceptionally(new TestImpossibleException());
             return f;
@@ -71,8 +71,8 @@ public final class AMDTestI implements TestIntf {
 
     @Override
     public CompletionStage<String> intfUserExceptionAsync(
-            boolean _throw, com.zeroc.Ice.Current current) {
-        if (_throw) {
+            boolean shouldThrow, com.zeroc.Ice.Current current) {
+        if (shouldThrow) {
             CompletableFuture<String> f = new CompletableFuture<>();
             f.completeExceptionally(new TestIntfUserException());
             return f;

--- a/java/test/src/main/java/test/Ice/servantLocator/Test.ice
+++ b/java/test/src/main/java/test/Ice/servantLocator/Test.ice
@@ -26,8 +26,9 @@ interface TestIntf
 
     void unknownExceptionWithServantException();
 
-    string impossibleException(bool throw) throws TestImpossibleException;
-    string intfUserException(bool throw) throws TestIntfUserException, TestImpossibleException;
+    // TODO rename the throw variable in all language mappings before adding more 'xxx:identifier'.
+    string impossibleException(["java:identifier:shouldThrow"] bool throw) throws TestImpossibleException;
+    string intfUserException(["java:identifier:shouldThrow"] bool throw) throws TestIntfUserException, TestImpossibleException;
 
     void asyncResponse() throws TestIntfUserException, TestImpossibleException;
     void asyncException() throws TestIntfUserException, TestImpossibleException;

--- a/java/test/src/main/java/test/Ice/servantLocator/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/servantLocator/TestAMD.ice
@@ -26,8 +26,9 @@ exception TestImpossibleException
 
     void unknownExceptionWithServantException();
 
-    string impossibleException(bool throw) throws TestImpossibleException;
-    string intfUserException(bool throw) throws TestIntfUserException, TestImpossibleException;
+    // TODO rename the throw variable in all language mappings before adding more 'xxx:identifier'.
+    string impossibleException(["java:identifier:shouldThrow"] bool throw) throws TestImpossibleException;
+    string intfUserException(["java:identifier:shouldThrow"] bool throw) throws TestIntfUserException, TestImpossibleException;
 
     void asyncResponse() throws TestIntfUserException, TestImpossibleException;
     void asyncException() throws TestIntfUserException, TestImpossibleException;

--- a/java/test/src/main/java/test/Ice/servantLocator/TestI.java
+++ b/java/test/src/main/java/test/Ice/servantLocator/TestI.java
@@ -35,9 +35,9 @@ public final class TestI implements TestIntf {
     }
 
     @Override
-    public String impossibleException(boolean _throw, com.zeroc.Ice.Current current)
+    public String impossibleException(boolean shouldThrow, com.zeroc.Ice.Current current)
             throws TestImpossibleException {
-        if (_throw) {
+        if (shouldThrow) {
             throw new TestImpossibleException();
         }
 
@@ -49,9 +49,9 @@ public final class TestI implements TestIntf {
     }
 
     @Override
-    public String intfUserException(boolean _throw, com.zeroc.Ice.Current current)
+    public String intfUserException(boolean shouldThrow, com.zeroc.Ice.Current current)
             throws TestIntfUserException, TestImpossibleException {
-        if (_throw) {
+        if (shouldThrow) {
             throw new TestIntfUserException();
         }
 

--- a/java/test/src/main/java/test/Slice/escape/Clash.ice
+++ b/java/test/src/main/java/test/Slice/escape/Clash.ice
@@ -51,7 +51,7 @@ struct St
     short istr;
     int ostr;
     int rhs;
-    string hashCode; // TODOAUSTIN this might not work here...
+    string hashCode;
 }
 
 exception Ex

--- a/java/test/src/main/java/test/Slice/escape/Clash.ice
+++ b/java/test/src/main/java/test/Slice/escape/Clash.ice
@@ -43,7 +43,6 @@ class Cls
     string proxy;
     int obj;
     int getCookie;
-    string clone;
 }
 
 struct St
@@ -52,8 +51,7 @@ struct St
     short istr;
     int ostr;
     int rhs;
-    string hashCode;
-    int clone;
+    string hashCode; // TODOAUSTIN this might not work here...
 }
 
 exception Ex

--- a/java/test/src/main/java/test/Slice/escape/Client.java
+++ b/java/test/src/main/java/test/Slice/escape/Client.java
@@ -8,12 +8,12 @@ import test.Slice.escape.java_abstract._catch;
 import test.Slice.escape.java_abstract._catchPrx;
 import test.Slice.escape.java_abstract._default;
 import test.Slice.escape.java_abstract._defaultPrx;
-import test.Slice.escape.java_abstract._else;
 import test.Slice.escape.java_abstract._finalize;
 import test.Slice.escape.java_abstract._finalizePrx;
-import test.Slice.escape.java_abstract._hashCode;
-import test.Slice.escape.java_abstract._import;
+import test.Slice.escape.java_abstract.clone;
+import test.Slice.escape.java_abstract.hashCode;
 import test.Slice.escape.java_abstract.java_synchronized;
+import test.Slice.escape.java_abstract.notify;
 
 public class Client extends test.TestHelper {
     public static class _catchI implements _catch {
@@ -36,8 +36,8 @@ public class Client extends test.TestHelper {
         }
     }
 
-    public static class _elseI extends _else {
-        public _elseI() {}
+    public static class notifyI extends notify {
+        public notifyI() {}
     }
 
     public static class finalizeServantI implements _finalize {
@@ -54,12 +54,12 @@ public class Client extends test.TestHelper {
         @Override
         public _assert _notify(
                 _break java_notifyAll,
-                _else java_null,
+                notify java_null,
                 _finalizePrx java_package,
                 _defaultPrx java_return,
                 int java_super,
                 com.zeroc.Ice.Current current)
-                throws _hashCode, _import {
+                throws hashCode, clone {
             return null;
         }
     }
@@ -77,7 +77,7 @@ public class Client extends test.TestHelper {
         _defaultPrx d = null;
         d._do();
         _default d1 = new _defaultI();
-        _else e1 = new _elseI();
+        notify e1 = new notifyI();
         e1.foo = 0;
         e1._equals = null;
 
@@ -85,9 +85,9 @@ public class Client extends test.TestHelper {
         f.myCheckedCast(0);
         f._do();
 
-        _hashCode i = new _hashCode();
+        hashCode i = new hashCode();
         i.bar = 0;
-        _import j = new _import();
+        clone j = new clone();
         j.bar = 0;
         j.java_native = "native";
         _finalize k = new finalizeServantI();

--- a/java/test/src/main/java/test/Slice/escape/Client.java
+++ b/java/test/src/main/java/test/Slice/escape/Client.java
@@ -2,34 +2,33 @@
 
 package test.Slice.escape;
 
-import test.Slice.escape._abstract._assert;
-import test.Slice.escape._abstract._break;
-import test.Slice.escape._abstract._catch;
-import test.Slice.escape._abstract._default;
-import test.Slice.escape._abstract._else;
-import test.Slice.escape._abstract._finalize;
-import test.Slice.escape._abstract._hashCode;
-import test.Slice.escape._abstract._import;
-import test.Slice.escape._abstract._new;
-import test.Slice.escape._abstract._switch;
-import test.Slice.escape._abstract.catchPrx;
-import test.Slice.escape._abstract.defaultPrx;
-import test.Slice.escape._abstract.finalizePrx;
+import test.Slice.escape.java_abstract._assert;
+import test.Slice.escape.java_abstract._break;
+import test.Slice.escape.java_abstract._catch;
+import test.Slice.escape.java_abstract._catchPrx;
+import test.Slice.escape.java_abstract._default;
+import test.Slice.escape.java_abstract._defaultPrx;
+import test.Slice.escape.java_abstract._else;
+import test.Slice.escape.java_abstract._finalize;
+import test.Slice.escape.java_abstract._finalizePrx;
+import test.Slice.escape.java_abstract._hashCode;
+import test.Slice.escape.java_abstract._import;
+import test.Slice.escape.java_abstract.java_synchronized;
 
 public class Client extends test.TestHelper {
-    public static class catchI implements _catch {
-        public catchI() {}
+    public static class _catchI implements _catch {
+        public _catchI() {}
 
         @Override
-        public java.util.concurrent.CompletionStage<Integer> checkedCastAsync(
-                int _clone, com.zeroc.Ice.Current current) {
+        public java.util.concurrent.CompletionStage<Integer> myCheckedCastAsync(
+                int java_clone, com.zeroc.Ice.Current current) {
             int _continue = 0;
             return java.util.concurrent.CompletableFuture.completedFuture(_continue);
         }
     }
 
-    public static class defaultI implements _default {
-        public defaultI() {}
+    public static class _defaultI implements _default {
+        public _defaultI() {}
 
         @Override
         public void _do(com.zeroc.Ice.Current current) {
@@ -37,77 +36,68 @@ public class Client extends test.TestHelper {
         }
     }
 
-    public static class elseI extends _else {
-        public elseI() {}
-    }
-
-    public static class newI implements _new {
-        public newI() {}
-
-        @Override
-        public _assert _notify(
-                _break _notifyAll,
-                _else _null,
-                finalizePrx _package,
-                catchPrx _public,
-                defaultPrx _return,
-                int _static,
-                int _strictfp,
-                int _super,
-                com.zeroc.Ice.Current current)
-                throws _hashCode, _import {
-            return null;
-        }
+    public static class _elseI extends _else {
+        public _elseI() {}
     }
 
     public static class finalizeServantI implements _finalize {
         @Override
-        public java.util.concurrent.CompletionStage<Integer> checkedCastAsync(
-                int _clone, com.zeroc.Ice.Current current) {
+        public java.util.concurrent.CompletionStage<Integer> myCheckedCastAsync(
+                int java_clone, com.zeroc.Ice.Current current) {
             int _continue = 0;
             return java.util.concurrent.CompletableFuture.completedFuture(_continue);
         }
 
         @Override
         public void _do(com.zeroc.Ice.Current current) {}
+
+        @Override
+        public _assert _notify(
+                _break java_notifyAll,
+                _else java_null,
+                _finalizePrx java_package,
+                _defaultPrx java_return,
+                int java_super,
+                com.zeroc.Ice.Current current)
+                throws _hashCode, _import {
+            return null;
+        }
     }
 
     // This section of the test is present to ensure that the C++ types are named correctly.
     // It is not expected to run.
     @SuppressWarnings({"unused", "null"})
     private static void testtypes() {
-        _assert v = _assert._boolean;
+        _assert v = _assert.java_boolean;
         _break b = new _break();
-        b._case = 0;
-        catchPrx c = null;
-        c._checkedCast(0);
-        _catch c1 = new catchI();
-        defaultPrx d = null;
+        b.java_case = 0;
+        _catchPrx c = null;
+        c._myCheckedCast(0);
+        _catch c1 = new _catchI();
+        _defaultPrx d = null;
         d._do();
-        _default d1 = new defaultI();
-        _else e1 = new elseI();
-        e1._if = 0;
+        _default d1 = new _defaultI();
+        _else e1 = new _elseI();
+        e1.foo = 0;
         e1._equals = null;
-        e1._final = 0;
 
-        finalizePrx f = null;
-        f._checkedCast(0);
+        _finalizePrx f = null;
+        f._myCheckedCast(0);
         f._do();
 
         _hashCode i = new _hashCode();
-        i._if = 0;
+        i.bar = 0;
         _import j = new _import();
-        j._if = 0;
-        j._instanceof = 1;
-        j._native = 2;
-        _new k = new newI();
-        assert _switch.value == 0;
+        j.bar = 0;
+        j.java_native = 2;
+        _finalize k = new finalizeServantI();
+        assert java_synchronized.value == 0;
     }
 
     public void run(String[] args) {
         // In this test, we need at least two threads in the client side thread pool for nested AMI.
         com.zeroc.Ice.Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package._abstract", "test.Slice.escape");
+        properties.setProperty("Ice.Package.java_abstract", "test.Slice.escape");
         properties.setProperty("Ice.ThreadPool.Client.Size", "2");
         properties.setProperty("Ice.ThreadPool.Client.SizeWarn", "0");
         properties.setProperty("TestAdapter.Endpoints", "default");
@@ -117,13 +107,13 @@ public class Client extends test.TestHelper {
         properties.setProperty("Ice.MessageSizeMax", "100");
         try (com.zeroc.Ice.Communicator communicator = initialize(properties)) {
             com.zeroc.Ice.ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new defaultI(), com.zeroc.Ice.Util.stringToIdentity("test"));
+            adapter.add(new _defaultI(), com.zeroc.Ice.Util.stringToIdentity("test"));
             adapter.activate();
 
             System.out.print("Testing operation name... ");
             System.out.flush();
-            defaultPrx p =
-                    defaultPrx.uncheckedCast(
+            _defaultPrx p =
+                    _defaultPrx.uncheckedCast(
                             adapter.createProxy(com.zeroc.Ice.Util.stringToIdentity("test")));
             p._do();
             System.out.println("ok");

--- a/java/test/src/main/java/test/Slice/escape/Client.java
+++ b/java/test/src/main/java/test/Slice/escape/Client.java
@@ -72,7 +72,7 @@ public class Client extends test.TestHelper {
         _break b = new _break();
         b.java_case = 0;
         _catchPrx c = null;
-        c._myCheckedCast(0);
+        c.myCheckedCast(0);
         _catch c1 = new _catchI();
         _defaultPrx d = null;
         d._do();
@@ -82,14 +82,14 @@ public class Client extends test.TestHelper {
         e1._equals = null;
 
         _finalizePrx f = null;
-        f._myCheckedCast(0);
+        f.myCheckedCast(0);
         f._do();
 
         _hashCode i = new _hashCode();
         i.bar = 0;
         _import j = new _import();
         j.bar = 0;
-        j.java_native = 2;
+        j.java_native = "native";
         _finalize k = new finalizeServantI();
         assert java_synchronized.value == 0;
     }

--- a/java/test/src/main/java/test/Slice/escape/Key.ice
+++ b/java/test/src/main/java/test/Slice/escape/Key.ice
@@ -4,71 +4,74 @@
 
 [["java:package:test.Slice.escape"]]
 
-module abstract
+// TODO: figure out a better way to map module names.
+module java_abstract
 {
 
+["java:identifier:_assert"]
 enum assert
 {
-    boolean
+    ["java:identifier:java_boolean"] boolean
 }
 
+["java:identifier:_break"]
 struct break
 {
-    int case;
+    ["java:identifier:java_case"] int case;
 }
 
+["java:identifier:_catch"]
 interface catch
 {
-    ["amd"] void checkedCast(int clone, out int continue);
+    ["java:identifier:myCheckedCast"]
+    ["amd"] void checkedCast(
+        ["java:identifier:java_clone"] int clone,
+        out ["java:identifier:java_continue"] int continue
+    );
 }
 
+["java:identifier:_default"]
 interface default
 {
+    ["java:identifier:_do"]
     void do();
 }
 
+["java:identifier:_else"]
 class else
 {
-    int if;
-    default* equals;
-    int final;
+    ["java:identifier:foo"] int if;
+    ["java:identifier:_equals"] default* equals;
 }
 
-interface finalize extends default, catch
-{
-}
-sequence<assert> for;
-dictionary<string, assert> goto;
-
+["java:identifier:_hashCode"]
 exception hashCode
 {
-    int if;
+    ["java:identifier:bar"] int if;
 }
 
+["java:identifier:_import"]
 exception import extends hashCode
 {
-    int instanceof;
-    int native;
+    ["java:identifier:java_native"] string native;
 }
 
-interface new
+["java:identifier:_finalize"]
+interface finalize extends default, catch
 {
-    assert notify(break notifyAll, else null, finalize* package, catch* public,
-                default* return, int static, int strictfp, int super)
-        throws hashCode, import;
+    ["java:identifier:_notify"]
+    assert notify(
+        ["java:identifier:java_notifyAll"] break notifyAll,
+        ["java:identifier:java_null"] else null,
+        ["java:identifier:java_package"] finalize* package,
+        ["java:identifier:java_return"] default* return,
+        ["java:identifier:java_super"] int super
+    ) throws hashCode, import;
 }
 
-const int switch = 0;
-const int synchronized = 0;
-const int this = 0;
-const int throw = 0;
-const int toString = 0;
-const int try = 0;
-const int uncheckedCast = 0;
-const int volatile = 0;
-const int wait = 0;
-const int while = 0;
-const int finally = 0;
-const int getClass = 0;
+["java:identifier:java_for"] sequence<assert> for;
+["java:identifier:java_goto"] dictionary<string, assert> goto;
+
+["java:identifier:java_synchronized"] const int synchronized = 0;
 
 }

--- a/java/test/src/main/java/test/Slice/escape/Key.ice
+++ b/java/test/src/main/java/test/Slice/escape/Key.ice
@@ -37,21 +37,18 @@ interface default
     void do();
 }
 
-["java:identifier:_else"]
-class else
+class notify
 {
     ["java:identifier:foo"] int if;
     ["java:identifier:_equals"] default* equals;
 }
 
-["java:identifier:_hashCode"]
 exception hashCode
 {
     ["java:identifier:bar"] int if;
 }
 
-["java:identifier:_import"]
-exception import extends hashCode
+exception clone extends hashCode
 {
     ["java:identifier:java_native"] string native;
 }
@@ -62,11 +59,11 @@ interface finalize extends default, catch
     ["java:identifier:_notify"]
     assert notify(
         ["java:identifier:java_notifyAll"] break notifyAll,
-        ["java:identifier:java_null"] else null,
+        ["java:identifier:java_null"] notify null,
         ["java:identifier:java_package"] finalize* package,
         ["java:identifier:java_return"] default* return,
         ["java:identifier:java_super"] int super
-    ) throws hashCode, import;
+    ) throws hashCode, clone;
 }
 
 ["java:identifier:java_for"] sequence<assert> for;


### PR DESCRIPTION
This PR adds support for `java:identifier`, just as I've already done for C++ and C#.
It cannot be applied to modules for the same reason we haven't added it in C++ and C# yet.

But, a difference in Java is that `java:identifier` cannot be applied to classes or exceptions do to how the Java activator works.
It expects a tight coupling between a class's typeID and Java class name. `java:identifier` completely decouples these.

And since I've removed the auto-escaping logic, any users with classes or exceptions that collide with Java keywords will be unable to upgrade past 3.7. I expect this is a very rare occurrence though. See #3534 for further discussion.