### PR TITLE
Add workflow to build and publish nightly releases

### DIFF
--- a/.github/actions/build-deb-package/action.yml
+++ b/.github/actions/build-deb-package/action.yml
@@ -1,32 +1,37 @@
 name: "Build DEB Package"
 description: "Builds a DEB package using a Docker image"
+
 inputs:
   ice_version:
     description: "The Ice version to build"
-    required: true
+    required: false
+  repository_url:
+    description: "The URL of the DEB repository to publish to"
+    required: false
+  repository_suffix:
+    description: "The suffix to append to the repository URL"
+    required: false
   deb_build_options:
     description: "DEB_BUILD_OPTIONS for the build"
     required: false
-    default: ""
   deb_build_profiles:
     description: "DEB_BUILD_PROFILES for the build"
     required: false
-    default: ""
-  os:
-    description: "The target OS (e.g., ubuntu-24.04, ubuntu-24.04-arm)"
+  distribution:
+    description: "The target distribution: (e.g., ubuntu-24.04, debian-12)"
     required: true
-  dockerfile_path:
-    description: "Path to the Dockerfile"
+  arch:
+    description: "The target build architecture: (e.g., x86_64, aarch64)"
     required: true
 
 runs:
   using: "composite"
   steps:
     - name: Build Docker Image
-      run: docker build --pull -f ${{ inputs.dockerfile_path }} -t ice-deb-package-builder .
+      run: docker build --pull -f "ice/packaging/dpkg/docker/${{ inputs.distribution }}/Dockerfile" -t ice-deb-package-builder "$GITHUB_WORKSPACE/ice"
       shell: bash
 
-    - name: Run Package Build with Mounted Source
+    - name: Build DEB Packages
       run: |
         docker run --rm \
           -v "$GITHUB_WORKSPACE:/workspace" \
@@ -39,7 +44,7 @@ runs:
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: deb-packages-${{ inputs.os }}
+        name: deb-packages-${{ inputs.distribution }}-${{ inputs.arch }}
         path: |
           *.deb
           *.ddeb
@@ -48,3 +53,14 @@ runs:
           *.tar.gz
           *.changes
           *.buildinfo
+
+    - name: Publish DEB Packages
+      run: |
+        docker run --rm \
+          -v "$GITHUB_WORKSPACE:/workspace" \
+          -e REPOSITORY_URL="${{ inputs.repository_url }}/${{ inputs.distribution }}${{ inputs.repository_suffix }}/" \
+          -e REPOSITORY_USERNAME="$REPOSITORY_USERNAME" \
+          -e REPOSITORY_PASSWORD="$REPOSITORY_PASSWORD" \
+          ice-deb-package-builder /workspace/ice/packaging/dpkg/publish-packages.sh
+      shell: bash
+      if: inputs.repository_url != ''

--- a/.github/actions/build-rpm-package/action.yml
+++ b/.github/actions/build-rpm-package/action.yml
@@ -4,35 +4,43 @@ inputs:
   ice_version:
     description: "The Ice version to build"
     required: true
-  os:
-    description: "The target OS (e.g., rhel9, rhel9-arm64, rhel9-x86)"
+  distribution:
+    description: "The target distribution: (e.g., rhel9)"
     required: true
-  target_arch:
-    description: "The target build architecture uses as a parameter for rpmbuild --target"
-    required: true
-  dockerfile_path:
-    description: "Path to the Dockerfile"
+  arch:
+    description: "The target build architecture used as a parameter for rpmbuild --target"
     required: true
 
 runs:
   using: "composite"
   steps:
     - name: Build Docker Image
-      run: docker build --pull -f ${{ inputs.dockerfile_path }} -t ice-rpm-package-builder "$GITHUB_WORKSPACE/ice"
+      run: docker build --pull -f ice/packaging/rpm/docker/${{ inputs.distribution }}/Dockerfile -t ice-rpm-package-builder "$GITHUB_WORKSPACE/ice"
       shell: bash
 
-    - name: Run Package Build with Mounted Source
+    - name: Build RPM Packages
       run: |
         docker run --rm \
           -v "$GITHUB_WORKSPACE:/workspace" \
           -e ICE_VERSION="${{ inputs.ice_version }}" \
-          -e TARGET_ARCH="${{ inputs.target_arch }}" \
+          -e TARGET_ARCH="${{ inputs.arch }}" \
           ice-rpm-package-builder /workspace/ice/packaging/rpm/build-package.sh
       shell: bash
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: rpm-packages-${{ inputs.os }}
+        name: rpm-packages-${{ inputs.distribution }}-${{ inputs.arch }}
         path: |
           *.rpm
+
+    - name: Publish RPM Packages
+      run: |
+        docker run --rm \
+          -v "$GITHUB_WORKSPACE:/workspace" \
+          -e REPOSITORY_URL="${{ inputs.repository_url }}/${{ inputs.distribution }}${{ inputs.repository_suffix }}/" \
+          -e REPOSITORY_USERNAME="$REPOSITORY_USERNAME" \
+          -e REPOSITORY_PASSWORD="$REPOSITORY_PASSWORD" \
+          ice-rpm-package-builder /workspace/ice/packaging/rpm/publish-packages.sh
+      shell: bash
+      if: inputs.repository_url != ''

--- a/.github/workflows/build-deb-packages.yml
+++ b/.github/workflows/build-deb-packages.yml
@@ -5,37 +5,59 @@ on:
     inputs:
       ice_version:
         description: "The Ice version to build"
-        required: true
-        default: "3.8.0~alpha0"
+        required: false
       deb_build_options:
         description: "DEB_BUILD_OPTIONS for the build"
         required: false
         default: "nocheck parallel=4"
+      repository_url:
+        description: "The URL of the Nexus repository to publish to"
+        required: false
+        type: string
+      repository_suffix:
+        description: "The suffix to append to the repository URL"
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      ice_version:
+        required: false
+        type: string
+      deb_build_options:
+        type: string
+        required: false
+      repository_url:
+        required: false
+        type: string
+      repository_suffix:
+        required: false
+        type: string
+    secrets:
+      REPOSITORY_USERNAME:
+        required: false
+      REPOSITORY_PASSWORD:
+        required: false
 
 jobs:
   build:
-    name: "Build for ${{ matrix.os }}"
-    runs-on: ${{ matrix.runner }}
+    name: "Build for ${{ matrix.distribution }}-${{ matrix.arch }}"
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     strategy:
       matrix:
         include:
-          - os: ubuntu-24.04
-            runner: ubuntu-24.04
-            dockerfile_path: ice/packaging/dpkg/docker/ubuntu-24.04/Dockerfile
+          - distribution: ubuntu-24.04
+            arch: x86_64
 
-          - os: ubuntu-24.04-arm64
-            runner: ubuntu-24.04-arm
-            dockerfile_path: ice/packaging/dpkg/docker/ubuntu-24.04/Dockerfile
+          - distribution: ubuntu-24.04
+            arch: aarch64
 
-          - os: debian-12
-            runner: ubuntu-24.04
-            dockerfile_path: ice/packaging/dpkg/docker/debian-12/Dockerfile
-            build_profiles: "no-python312"
+          - distribution: debian-12
+            arch: x86_64
+            deb_build_profiles: "no-python312"
 
-          - os: debian12-arm64
-            runner: ubuntu-24.04-arm
-            dockerfile_path: ice/packaging/dpkg/docker/debian-12/Dockerfile
-            build_profiles: "no-python312"
+          - os: debian12
+            arch: aarch64
+            deb_build_profiles: "no-python312"
 
     steps:
       - name: Check out repository
@@ -46,7 +68,13 @@ jobs:
       - name: Call Build Debian Package Action
         uses: ./ice/.github/actions/build-deb-package
         with:
-          ice_version: ${{ inputs.ice_version }}
-          deb_build_options: ${{ inputs.deb_build_options }}
-          os: ${{ matrix.os }}
-          dockerfile_path: ${{ matrix.dockerfile_path }}
+          ice_version: ${{ inputs.ice_version || ''}}
+          deb_build_options: ${{ inputs.deb_build_options || '' }}
+          deb_build_profiles: ${{ matrix.deb_build_profiles || '' }}
+          distribution: ${{ matrix.distribution }}
+          arch: ${{ matrix.arch }}
+          repository_url: ${{ inputs.repository_url || ''}}
+          repository_suffix: ${{ inputs.repository_suffix || '' }}
+        env:
+          REPOSITORY_USERNAME: ${{ secrets.REPOSITORY_USERNAME }}
+          REPOSITORY_PASSWORD: ${{ secrets.REPOSITORY_PASSWORD }}

--- a/.github/workflows/build-dotnet-packages.yml
+++ b/.github/workflows/build-dotnet-packages.yml
@@ -2,7 +2,25 @@ name: "Build .NET Packages"
 
 on:
   workflow_call:
+    inputs:
+      ice_version:
+        required: false
+        type: string
+      source_url:
+        required: false
+        type: string
+    secrets:
+      NUGET_API_KEY:
+        required: false
   workflow_dispatch:
+    inputs:
+      ice_version:
+        description: "The Ice version to build"
+        required: false
+      source_url:
+        description: "The URL of the NuGet repository to publish to"
+        required: false
+        type: string
 
 jobs:
   build-slice-compilers:
@@ -41,6 +59,7 @@ jobs:
         with:
           name: slice2cs-${{ matrix.target }}
           path: ${{ matrix.artifact-path }}
+
   pack-dotnet:
     runs-on: windows-latest
     needs: build-slice-compilers
@@ -57,7 +76,7 @@ jobs:
       - name: Copy slice2cs binaries to staging path
         run: |
           @("macos-arm64", "linux-x64", "linux-arm64", "windows-x64") | ForEach-Object { New-Item -ItemType Directory -Path $env:GITHUB_WORKSPACE\tools -Name $_ }
-          Copy-Item "slice2cs-macos-arm64\slice2cs" -Destination "$env:GITHUB_WORKSPACE\tools\macos-x64"
+          Copy-Item "slice2cs-macos-arm64\slice2cs" -Destination "$env:GITHUB_WORKSPACE\tools\macos-arm64"
           Copy-Item "slice2cs-linux-x64\slice2cs" -Destination "$env:GITHUB_WORKSPACE\tools\linux-x64"
           Copy-Item "slice2cs-linux-arm64\slice2cs" -Destination "$env:GITHUB_WORKSPACE\tools\linux-arm64"
           Copy-Item "slice2cs-windows-x64\slice2cs.exe" -Destination "$env:GITHUB_WORKSPACE\tools\windows-x64"
@@ -72,6 +91,8 @@ jobs:
 
       - name: Pack .NET Packages
         run: dotnet msbuild csharp/msbuild/ice.proj /t:Pack /p:Configuration=Release /p:Platform=x64
+        env:
+          VERSION: ${{ inputs.ice_version || '' }}
 
       - name: Upload NuGet Packages
         uses: actions/upload-artifact@v4
@@ -80,3 +101,8 @@ jobs:
           path: |
             csharp/msbuild/zeroc.ice.net/*.nupkg
             csharp/msbuild/zeroc.ice.net/*.snupkg
+
+      - name: Publish NuGet Packages
+        run: |
+          dotnet nuget push csharp/msbuild/zeroc.ice.net/*.nupkg --source ${{ inputs.source_url }} --api-key ${{ secrets.NUGET_API_KEY }}
+        if: inputs.source_url != ''

--- a/.github/workflows/build-gem-packages.yml
+++ b/.github/workflows/build-gem-packages.yml
@@ -1,11 +1,31 @@
 name: "Build GEM Packages"
 
 on:
-  workflow_call: # Allows calling from other workflows
-  workflow_dispatch: # Allows manual triggering
+  workflow_call:
+    inputs:
+      ice_version:
+        required: true
+        type: string
+      repository_url:
+        required: true
+        type: string
+    secrets:
+      REPOSITORY_USERNAME:
+        required: false
+      REPOSITORY_PASSWORD:
+        required: false
+  workflow_dispatch:
+    inputs:
+      ice_version:
+        description: "The Ice version to build"
+        required: false
+      repository_url:
+        description: "The URL of the GEM repository to publish to"
+        required: false
+        type: string
 
 jobs:
-  build-python-packages:
+  build-gem-packages:
     runs-on: ubuntu-24.04
 
     steps:
@@ -18,6 +38,11 @@ jobs:
       - name: Install Build Dependencies
         run: gem install rake
 
+      - name: Update GEM Version
+        working-directory: ruby
+        run: sed -i "s/spec.version.*/spec.version = '${{ inputs.ice_version }}'/" ice.gemspec
+        if: inputs.ice_version != ''
+
       - name: Build GEM Package
         working-directory: ruby
         run: rake
@@ -27,3 +52,9 @@ jobs:
         with:
           name: gem-packages
           path: ruby/*.gem
+
+      - name: Publish GEM Packages
+        run: |
+           curl -u "${REPOSITORY_USERNAME}:${REPOSITORY_PASSWORD}" \
+             --upload-file "ruby/*.gem" ${{ inputs.repository_url }}
+        if: inputs.repository_url != ''

--- a/.github/workflows/build-matlab-packages.yml
+++ b/.github/workflows/build-matlab-packages.yml
@@ -1,12 +1,11 @@
 name: "Build MATLAB Packages"
 
 on:
-  workflow_call: # Allows calling from other workflows
-  workflow_dispatch: # Allows manual triggering
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
-  build-python-packages:
-
+  build-matlab-packages:
     strategy:
       matrix:
         include:
@@ -24,13 +23,13 @@ jobs:
         with:
           use_matlab: true
 
-      - name: Build MATLAB ToolBox
+      - name: Build Linux MATLAB ToolBox
         run: |
           make -C cpp srcs
           make -C matlab toolbox
         if: runner.os == 'Linux'
 
-      - name: Build MATLAB ToolBox
+      - name: Build Windows MATLAB ToolBox
         run: MSBuild /p:Configuration=Release /p:Platform=x64 /t:Package matlab\msbuild\ice.proj
         if: runner.os == 'Windows'
 

--- a/.github/workflows/build-maven-packages.yml
+++ b/.github/workflows/build-maven-packages.yml
@@ -1,0 +1,63 @@
+name: "Build Maven Packages"
+
+on:
+  workflow_call:
+    inputs:
+      ice_version:
+        required: false
+        type: string
+      repository_url:
+        required: false
+        type: string
+    secrets:
+      MAVEN_USERNAME:
+        required: false
+      MAVEN_PASSWORD:
+        required: false
+  workflow_dispatch:
+    inputs:
+      ice_version:
+        description: "The Ice version to build"
+        required: false
+      repository_url:
+        description: "The URL of the Maven repository to publish to"
+        required: false
+        type: string
+
+jobs:
+  build-slice-compilers:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Dependencies
+        uses: ./.github/actions/setup-dependencies
+
+      - name: Build Slice Compiler
+        run: make slice2java
+        working-directory: cpp
+
+      - name: Update Ice Version
+        run: |
+          sed -i "s/^iceVersion = .*/iceVersion = ${{ inputs.ice_version }}/" java/gradle.properties
+        if: inputs.ice_version != ''
+
+      - name: Build Java Packages
+        run: ./gradlew dist
+        working-directory: java
+
+      - name: Upload Java Packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: java-packages
+          path: java/lib/*
+
+      - name: Publish Maven Packages
+        run: ./gradlew publish
+        env:
+          MAVEN_REPOSITORY: ${{ inputs.repository_url }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+        if: inputs.repository_url != ''

--- a/.github/workflows/build-msi-package.yml
+++ b/.github/workflows/build-msi-package.yml
@@ -5,31 +5,31 @@ on:
   workflow_dispatch:
 
 jobs:
-    build-msi-package:
-      runs-on: windows-latest
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v4
+  build-msi-package:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-        - name: Setup Dependencies
-          uses: ./.github/actions/setup-dependencies
+      - name: Setup Dependencies
+        uses: ./.github/actions/setup-dependencies
 
-        - name: Build C++ NuGet Packages
-          run: msbuild /m ice.proj /t:Pack /p:BuildAllConfigurations=yes
-          working-directory: cpp/msbuild
+      - name: Build C++ NuGet Packages
+        run: msbuild /m ice.proj /t:Pack /p:BuildAllConfigurations=yes
+        working-directory: cpp/msbuild
 
-        - name: Build IceGrid GUI
-          run: ./gradlew.bat dist -PcppPlatform=x64 -PcppConfiguration=Release
-          working-directory: java
+      - name: Build IceGrid GUI
+        run: ./gradlew.bat dist -PcppPlatform=x64 -PcppConfiguration=Release
+        working-directory: java
 
-        - name: Build MSI
-          run: dotnet build -c Release -p x64
-          working-directory: packaging/msi
+      - name: Build MSI
+        run: dotnet build -c Release -p:Platform=x64
+        working-directory: packaging/msi
 
-        - name: Upload NuGet Packages
-          uses: actions/upload-artifact@v4
-          with:
-            name: windows-msi-and-nuget-packages
-            path: |
-              cpp/msbuild/**/zeroc.ice.*.nupkg
-              packaging/msi/bin/x64/Release/*.msi
+      - name: Upload NuGet Packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-msi-and-nuget-packages
+          path: |
+            cpp/msbuild/**/zeroc.ice.*.nupkg
+            packaging/msi/bin/x64/Release/*.msi

--- a/.github/workflows/build-nightly-release-workflow.yml
+++ b/.github/workflows/build-nightly-release-workflow.yml
@@ -1,0 +1,138 @@
+name: Build Nightly Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_number:
+        description: "Build number for nightly releases"
+        required: false
+        default: "1"
+      repository_url:
+        description: "URL of the repository to publish to"
+        required: false
+        default: "https://download.zeroc.com/nexus/"
+
+jobs:
+  set-version:
+    runs-on: ubuntu-latest
+    outputs:
+      deb_version: ${{ steps.set-vars.outputs.deb_version }}
+      gem_version: ${{ steps.set-vars.outputs.gem_version }}
+      npm_version: ${{ steps.set-vars.outputs.npm_version }}
+      maven_version: ${{ steps.set-vars.outputs.maven_version }}
+      nuget_version: ${{ steps.set-vars.outputs.nuget_version }}
+      pypi_version: ${{ steps.set-vars.outputs.pypi_version }}
+      rpm_version: ${{ steps.set-vars.outputs.rpm_version }}
+    steps:
+      - name: Set version variables
+        id: set-vars
+        run: |
+          DATE=$(date +%Y%m%d)
+          BUILD=${{ github.event.inputs.build_number }}
+          VERSION=3.8.0
+
+          # Set version variables for nightly packages according to the platform conventions:
+          # - DEB: 3.8.0-0.nightlyYYYYMMDD.BUILD
+          echo "deb_version=${VERSION}-0.nightly${DATE}.${BUILD}" >> $GITHUB_OUTPUT
+          # - GEM: 3.8.0.pre.YYYYMMDD.BUILD
+          echo "gem_version=${VERSION}.pre.${DATE}.${BUILD}" >> $GITHUB_OUTPUT
+          # - MAVEN: 3.8.0-nightly-YYYYMMDD.BUILD-SNAPSHOT
+          echo "maven_version=${VERSION}-nightly-${DATE}.${BUILD}-SNAPSHOT" >> $GITHUB_OUTPUT
+          # - NPM: 3.8.0-nightly.YYYYMMDD.BUILD
+          echo "npm_version=${VERSION}-nightly.${DATE}.${BUILD}" >> $GITHUB_OUTPUT
+          # - NuGet: 3.8.0-nightly.YYYYMMDD.BUILD
+          echo "nuget_version=${VERSION}-nightly.${DATE}.${BUILD}" >> $GITHUB_OUTPUT
+          # - PyPI: 3.8.0.devYYYYMMDD.BUILD
+          echo "pypi_version=${VERSION}.dev${DATE}.${BUILD}" >> $GITHUB_OUTPUT
+          # - RPM: 3.8.0-0.nightlyYYYYMMDD.BUILD
+          echo "rpm_version=${VERSION}-0.nightly${DATE}.${BUILD}" >> $GITHUB_OUTPUT
+
+  build-deb-packages:
+    name: Build DEB Packages
+    uses: ./.github/workflows/build-deb-packages.yml
+    needs: set-version
+    with:
+      ice_version: ${{ needs.set-version.outputs.deb_version }}
+      deb_build_options: "nocheck parallel=4"
+      repository_url: ${{ inputs.repository_url }}
+      repository_suffix: "-nightly"
+    secrets:
+      REPOSITORY_USERNAME: secrets.NEXUS_NIGHTLY_USERNAME
+      REPOSITORY_PASSWORD: secrets.NEXUS_NIGHTLY_PASSWORD
+
+  build-dotnet-packages:
+    name: Build .NET Packages
+    uses: ./.github/workflows/build-dotnet-packages.yml
+    needs: set-version
+    with:
+      ice_version: ${{ needs.set-version.outputs.nuget_version }}
+      source_url: "${{ inputs.repository_url }}/nuget-nightly/"
+    secrets:
+      NUGET_API_KEY: secrets.NEXUS_NIGHTLY_NUGET_API_KEY
+
+  build-gem-packages:
+    name: Build GEM Packages
+    uses: ./.github/workflows/build-gem-packages.yml
+    needs: set-version
+    with:
+      ice_version: ${{ needs.set-version.outputs.gem_version }}
+      repository_url: "${{ inputs.repository_url }}/rubygems-nightly/gems/"
+    secrets:
+      REPOSITORY_USERNAME: secrets.NEXUS_NIGHTLY_USERNAME
+      REPOSITORY_PASSWORD: secrets.NEXUS_NIGHTLY_PASSWORD
+
+  build-matlab-packages:
+    name: Build MATLAB Packages
+    uses: ./.github/workflows/build-matlab-packages.yml
+
+  build-maven-packages:
+    name: Build Maven Packages
+    uses: ./.github/workflows/build-maven-packages.yml
+    needs: set-version
+    with:
+      ice_version: ${{ needs.set-version.outputs.maven_version }}
+      repository_url: "${{ inputs.repository_url }}/maven-nightly/"
+    secrets:
+      MAVEN_USERNAME: secrets.NEXUS_NIGHTLY_USERNAME
+      MAVEN_PASSWORD: secrets.NEXUS_NIGHTLY_PASSWORD
+
+  build-msi-package:
+    name: Build MSI Package
+    uses: ./.github/workflows/build-msi-package.yml
+
+  build-npm-packages:
+    name: Build NPM Packages
+    uses: ./.github/workflows/build-npm-packages.yml
+    needs: set-version
+    with:
+      ice_version: ${{ needs.set-version.outputs.npm_version }}
+      registry_url: "${{ inputs.repository_url }}/npm-nightly/"
+    secrets:
+      NPM_AUTH_TOKEN: secrets.NEXUS_NIGHTLY_NPM_AUTH_TOKEN
+
+  build-pip-packages:
+    name: Build PIP Packages
+    uses: ./.github/workflows/build-pip-packages.yml
+    needs: set-version
+    with:
+      ice_version: ${{ needs.set-version.outputs.pypi_version }}
+      repository_url: "${{ inputs.repository_url }}/pypi-nightly/"
+    secrets:
+      PYPI_USERNAME: secrets.NEXUS_NIGHTLY_USERNAME
+      PYPI_PASSWORD: secrets.NEXUS_NIGHTLY_PASSWORD
+
+  build-rpm-packages:
+    name: Build RPM Packages
+    uses: ./.github/workflows/build-rpm-packages.yml
+    needs: set-version
+    with:
+      ice_version: ${{ needs.set-version.outputs.rpm_version }}
+      repository_url: ${{ inputs.repository_url }}
+      repository_suffix: "-nightly"
+    secrets:
+      REPOSITORY_USERNAME: secrets.NEXUS_NIGHTLY_USERNAME
+      REPOSITORY_PASSWORD: secrets.NEXUS_NIGHTLY_PASSWORD
+
+  build-xcframework-packages:
+    name: Build XCFramework Packages
+    uses: ./.github/workflows/build-xcframework-packages.yml

--- a/.github/workflows/build-npm-packages.yml
+++ b/.github/workflows/build-npm-packages.yml
@@ -2,7 +2,25 @@ name: "Build NPM Packages"
 
 on:
   workflow_call:
+    inputs:
+      ice_version:
+        required: false
+        type: string
+      registry_url:
+        required: false
+        type: string
+    secrets:
+      NPM_AUTH_TOKEN:
+        required: false
   workflow_dispatch:
+    inputs:
+      ice_version:
+        description: "The Ice version to build"
+        required: false
+      registry_url:
+        description: "The URL of the NPM registry to publish to"
+        required: false
+        type: string
 
 jobs:
   build-slice-compilers:
@@ -85,6 +103,11 @@ jobs:
         run: make
         working-directory: ice/js
 
+      - name: Update Version
+        run: |
+          sed -i 's/"version":.*/"version": "${{ inputs.ice_version }}"/' package.json
+        if: inputs.ice_version != ''
+
       - name: Pack npm
         run: npm pack
         working-directory: ice/js
@@ -94,3 +117,12 @@ jobs:
         with:
           name: js-npm-packages
           path: ice/js/*.tgz
+
+      - name: Publish NPM Packages
+        run: |
+          echo "//${{ inputs.registry_url }}/:_auth=\${NPM_AUTH_TOKEN}" > ~/.npmrc
+          echo "always-auth=true" >> ~/.npmrc
+          npm publish ice/js/*.tgz --registry ${{ inputs.registry_url }}
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        if: inputs.registry_url != ''

--- a/.github/workflows/build-pip-packages.yml
+++ b/.github/workflows/build-pip-packages.yml
@@ -1,12 +1,31 @@
 name: "Build PIP Packages"
 
 on:
-  workflow_call: # Allows calling from other workflows
-  workflow_dispatch: # Allows manual triggering
+  workflow_call:
+    inputs:
+      ice_version:
+        required: false
+        type: string
+      repository_url:
+        required: false
+        type: string
+    secrets:
+      PYPI_USERNAME:
+        required: false
+      PYPI_PASSWORD:
+        required: false
+  workflow_dispatch:
+    inputs:
+      ice_version:
+        description: "The Ice version to build"
+        required: false
+      repository_url:
+        description: "The URL of the PYPI registry to publish to"
+        required: false
+        type: string
 
 jobs:
   build-python-packages:
-
     strategy:
       matrix:
         include:
@@ -27,6 +46,11 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install build
 
+      - name: Update PYPI Version
+        working-directory: python
+        run: sed -i 's/version = .*/version = "${{ inputs.ice_version }}"/' pyproject.toml
+        if: inputs.ice_version != ''
+
       - name: Build PIP Package
         working-directory: python
         run: python3 -m build
@@ -38,3 +62,26 @@ jobs:
           path: |
             python/dist/zeroc_ice-*.whl
             python/dist/zeroc_ice-*.tar.gz
+
+  publish-python-packages:
+    runs-on: ubuntu-latest
+    needs: build-python-packages
+
+    steps:
+      - name: Download All Compiler Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Publish PIP Package
+        run: mkdir -p ${{ github.workspace }}/dist
+          cp -r artifacts/pip-packages-windows-latest/*.whl ${{ github.workspace }}/dist
+          cp -r artifacts/pip-packages-macos-latest/*.whl ${{ github.workspace }}/dist
+          cp -r artifacts/pip-packages-macos-latest/*.tar.gz ${{ github.workspace }}/dist
+
+          python3 -m pip install twine --user
+          python3 -m twine upload --repository_url ${{ inputs.repository_url }} python/dist/*
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        if: inputs.repository_url != ''

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -5,30 +5,47 @@ on:
     inputs:
       ice_version:
         description: "The Ice version to build"
-        required: true
-        default: "3.8.0~alpha0"
+        required: false
+      repository_url:
+        description: "The URL of the Nexus repository to publish to"
+        required: false
+        type: string
+      repository_suffix:
+        description: "The suffix to append to the repository URL"
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      ice_version:
+        required: false
+        type: string
+      repository_url:
+        required: false
+        type: string
+      repository_suffix:
+        required: false
+        type: string
+    secrets:
+      REPOSITORY_USERNAME:
+        required: false
+      REPOSITORY_PASSWORD:
+        required: false
 
 jobs:
   build:
-    name: "Build for ${{ matrix.os }}"
-    runs-on: ${{ matrix.runner }}
+    name: "Build for ${{ matrix.distribution }}-${{ matrix.arch }}"
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     strategy:
       matrix:
         include:
-          - os: rhel9
-            runner: ubuntu-24.04
-            target_arch: x86_64
-            dockerfile_path: ice/packaging/rpm/docker/rhel9/Dockerfile
+          - distribution: rhel9
+            arch: x86_64
 
-          - os: rhel9-i686
-            runner: ubuntu-24.04
-            target_arch: i686
-            dockerfile_path: ice/packaging/rpm/docker/rhel9/Dockerfile
+          - distribution: rhel9
+            arch: i686
 
-          - os: rhel9-arm64
-            runner: ubuntu-24.04-arm
-            target_arch: aarch64
-            dockerfile_path: ice/packaging/rpm/docker/rhel9/Dockerfile
+          - distribution: rhel9
+            arch: aarch64
 
     steps:
       - name: Check out repository
@@ -39,7 +56,11 @@ jobs:
       - name: Call Build RPM Package Action
         uses: ./ice/.github/actions/build-rpm-package
         with:
-          ice_version: ${{ inputs.ice_version }}
-          os: ${{ matrix.os }}
-          dockerfile_path: ${{ matrix.dockerfile_path }}
-          target_arch: ${{ matrix.target_arch }}
+          ice_version: ${{ inputs.ice_version || '' }}
+          distribution: ${{ matrix.distribution }}
+          arch: ${{ matrix.arch }}
+          repository_url: ${{ inputs.repository_url || ''}}
+          repository_suffix: ${{ inputs.repository_suffix || '' }}
+        env:
+          REPOSITORY_USERNAME: ${{ secrets.REPOSITORY_USERNAME }}
+          REPOSITORY_PASSWORD: ${{ secrets.REPOSITORY_PASSWORD }}

--- a/.github/workflows/build-xcframework-packages.yml
+++ b/.github/workflows/build-xcframework-packages.yml
@@ -1,8 +1,8 @@
 name: "Build XCFramework Packages"
 
 on:
-  workflow_call: # Allows calling from other workflows
-  workflow_dispatch: # Allows manual triggering
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   build-xcfranework-packages:

--- a/java/gradle/maven-publish.publishing.gradle
+++ b/java/gradle/maven-publish.publishing.gradle
@@ -7,16 +7,16 @@ tasks.withType(GenerateMavenPom.class) {
     destination = file(project.ext.pomName)
 }
 
-ext.mavenRepo = rootProject.hasProperty('mavenRepo')?project.mavenRepo:System.getenv('MAVEN_REPO')?:''
-ext.mavenUser = rootProject.hasProperty('mavenUser')?project.mavenUser:System.getenv('MAVEN_USER')?:''
+ext.mavenRepository = rootProject.hasProperty('mavenRepository')?project.mavenRepo:System.getenv('MAVEN_REPOSITORY')?:''
+ext.mavenUsername = rootProject.hasProperty('mavenUsername')?project.mavenUser:System.getenv('MAVEN_USERNAME')?:''
 ext.mavenPassword = rootProject.hasProperty('mavenPassword')?project.mavenPassword:System.getenv('MAVEN_PASSWORD')?:''
 
 publishing {
     repositories {
         maven {
-            url = mavenRepo
+            url = mavenRepository
             credentials {
-                username mavenUser
+                username mavenUsername
                 password mavenPassword
             }
         }

--- a/packaging/dpkg/build-package.sh
+++ b/packaging/dpkg/build-package.sh
@@ -1,22 +1,31 @@
 #!/bin/bash
 set -eux  # Exit on error, print commands
 
-# Ensure ICE_VERSION is set
-if [ -z "$ICE_VERSION" ]; then
-    echo "Error: ICE_VERSION is not set!"
-    exit 1
+# Create build directory and copy Debian packaging files
+mkdir -p /workspace/build
+cp -rfv /workspace/ice/packaging/dpkg/debian /workspace/build
+
+# If ICE_VERSION is set, update the changelog entry to the given version. Otherwise use ICE_VERSION from the changelog.
+if [[ -n "${ICE_VERSION:-}" ]]; then
+    echo "Updating UNRELEASED changelog entry to: ${ICE_VERSION}"
+    dch --changelog /workspace/build/debian/changelog --newversion "$ICE_VERSION" \
+        --force-bad-version --distribution UNRELEASED \
+        "Ice Nightly build $ICE_VERSION"
+else
+    ICE_VERSION=$(dpkg-parsechangelog --file /workspace/build/debian/changelog --show-field Version)
 fi
 
-# Generate the upstream tarball
+# Generate a tarball of the current repository state for the given ICE_VERSION
 echo "Creating tarball for ICE_VERSION=$ICE_VERSION"
-tar -czf /workspace/zeroc-ice_${ICE_VERSION}.orig.tar.gz --exclude=.git -C /workspace/ice .
+cd /workspace/ice
+git archive --format=tar.gz -o /workspace/zeroc-ice_${ICE_VERSION}.orig.tar.gz HEAD
 
-# Create build directory and unpack
-mkdir -p /workspace/build
+# Unpack the source tarball
 cd /workspace/build
 tar xzf ../zeroc-ice_${ICE_VERSION}.orig.tar.gz
 
-# Copy Debian packaging files and build
-cp -rfv /workspace/ice/packaging/dpkg/debian .
+# Build the source package (-S generates .dsc and .tar.gz files)
 dpkg-buildpackage -S
+
+# Build the binary packages (-b creates .deb files, -uc -us skips signing)
 dpkg-buildpackage -b -uc -us

--- a/packaging/dpkg/debian/changelog
+++ b/packaging/dpkg/debian/changelog
@@ -1,4 +1,4 @@
-zeroc-ice (3.8.0~alpha0-1) unstable; urgency=medium
+zeroc-ice (3.8.0~alpha0-1) UNRELEASED; urgency=medium
 
   * Ice 3.8 alpha0 pre-release
 

--- a/packaging/dpkg/docker/debian-12/Dockerfile
+++ b/packaging/dpkg/docker/debian-12/Dockerfile
@@ -6,6 +6,6 @@ RUN apt-get update && apt-get install -y \
     libbluetooth-dev libbz2-dev libdbus-1-dev libedit-dev libexpat1-dev liblmdb-dev \
     libmcpp-dev libssl-dev libsystemd-dev \
     dh-exec dh-php dh-python locales-all php-all-dev python3-setuptools \
-    build-essential \
+    build-essential git devscripts curl \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean

--- a/packaging/dpkg/docker/ubuntu-24.04/Dockerfile
+++ b/packaging/dpkg/docker/ubuntu-24.04/Dockerfile
@@ -6,6 +6,6 @@ RUN apt-get update && apt-get install -y \
     libbluetooth-dev libbz2-dev libdbus-1-dev libedit-dev libexpat1-dev liblmdb-dev \
     libmcpp-dev libssl-dev libsystemd-dev \
     dh-exec dh-php dh-python locales-all php-all-dev python3-setuptools \
-    build-essential \
+    build-essential git devscripts curl \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean

--- a/packaging/dpkg/publish-packages.sh
+++ b/packaging/dpkg/publish-packages.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eu
+
+# Ensure the repository url is set
+if [ -z "${REPOSITORY_URL}" ]; then
+    echo "Error: REPOSITORY_URL must be set as environment variable."
+    exit 1
+fi
+
+# Iterate over all .deb and .ddeb files in the current directory and subdirectories
+find . -type f \( -name "*.deb" -o -name "*.ddeb" \) | while read -r file; do
+    echo "Uploading $file to Nexus..."
+    curl -u "${REPOSITORY_USERNAME}:${REPOSITORY_PASSWORD}" \
+         -H "Content-Type: multipart/form-data" \
+         --data-binary "$file" \
+         "${REPOSITORY_URL}"
+    echo "Successfully uploaded: $file"
+done

--- a/packaging/rpm/build-package.sh
+++ b/packaging/rpm/build-package.sh
@@ -13,6 +13,12 @@ ICE_SPEC_DEST="$RPM_BUILD_ROOT/SPECS/ice.spec"
 
 cp "$ICE_SPEC_SRC" "$ICE_SPEC_DEST"
 
+# If ICE_VERSION is set, update the version in the spec file to the given version. Otherwise use ICE_VERSION from the
+# spec file.
+if [[ -n "${ICE_VERSION:-}" ]]; then
+    sed -i "s/^Version:.*/Version: $ICE_VERSION/" "$ICE_SPEC_DEST"
+fi
+
 # Validate TARGET_ARCH
 VALID_ARCHS=("x86_64" "i686" "aarch64")
 if [[ -z "${TARGET_ARCH:-}" || ! " ${VALID_ARCHS[@]} " =~ " ${TARGET_ARCH} " ]]; then

--- a/packaging/rpm/docker/rhel9/Dockerfile
+++ b/packaging/rpm/docker/rhel9/Dockerfile
@@ -8,6 +8,7 @@ RUN dnf install -y https://zeroc.com/download/ice/3.7/el9/ice-repo-3.7.el9.noarc
 RUN dnf install --setopt=multilib_policy=all -y \
     rpmdevtools \
     make \
+    curl \
     git \
     gcc-c++ \
     glibc-devel \

--- a/packaging/rpm/publish-packages.sh
+++ b/packaging/rpm/publish-packages.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eu
+
+# Ensure the repository url is set
+if [ -z "${REPOSITORY_URL}" ]; then
+    echo "Error: REPOSITORY_URL must be set as environment variable."
+    exit 1
+fi
+
+# Iterate over all .rpm files in the current directory and subdirectories
+find . -type f -name "*.rpm" | while read -r file; do
+    echo "Uploading $file to Nexus..."
+    curl -u "${REPOSITORY_USERNAME}:${REPOSITORY_PASSWORD}" \
+         -H "Content-Type: multipart/form-data" \
+         --data-binary "@$file" \
+         "${REPOSITORY_URL}"
+    echo "Successfully uploaded: $file"
+done


### PR DESCRIPTION
This PR adds a new workflow **"Build Nightly Release"** that allows the creation and publication of nightly packages to [https://download.zeroc.com/nexus/](https://download.zeroc.com/nexus/).

It might need additional fixes, but we will see once we try it with CI.

The **MSI, XCFrameworks, and MATLAB Toolboxes** are not published to any repositories as they do not use one. However, it would be good to upload the files somewhere other than to the Action artifacts.

We should also consider creating a **nightly release page** where we can show the instructions for each package/repository.