### PR TITLE
Fix missing-field-initializer warning with GCC

### DIFF
--- a/cpp/doxygen/examples/Ice/Makefile.mk
+++ b/cpp/doxygen/examples/Ice/Makefile.mk
@@ -12,7 +12,6 @@ IceExamples_ldflags       += -framework Security -framework CoreFoundation
 else
 IceExamples_extra_sources += $(filter-out doxygen/examples/Ice/SSL/SecureTransport%.cpp doxygen/examples/Ice/SSL/Schannel%.cpp, $(wildcard doxygen/examples/Ice/SSL/*.cpp))
 IceExamples_ldflags       += -lssl -lcrypto
-IceExamples_cppflags      += -Wno-missing-field-initializers
 endif
 
 projects += $(project)

--- a/cpp/include/Ice/Initialize.h
+++ b/cpp/include/Ice/Initialize.h
@@ -261,17 +261,17 @@ namespace Ice
         /**
          * The properties for the communicator.
          */
-        PropertiesPtr properties;
+        PropertiesPtr properties{};
 
         /**
          * The logger for the communicator.
          */
-        LoggerPtr logger;
+        LoggerPtr logger{};
 
         /**
          * The communicator observer used by the Ice run-time.
          */
-        Instrumentation::CommunicatorObserverPtr observer;
+        Instrumentation::CommunicatorObserverPtr observer{};
 
 #if defined(__clang__)
 #    pragma clang diagnostic push
@@ -281,12 +281,12 @@ namespace Ice
         /**
          * Called whenever the communicator starts a new thread.
          */
-        std::function<void()> threadStart;
+        std::function<void()> threadStart{};
 
         /**
          * Called whenever a thread created by the communicator is about to be destroyed.
          */
-        std::function<void()> threadStop;
+        std::function<void()> threadStop{};
 
         /**
          * You can control which thread receives operation dispatches and async invocation
@@ -300,7 +300,7 @@ namespace Ice
          * @param call Represents the function to execute. The execute must eventually execute this function.
          * @param con The connection associated with this call, or null if no connection is associated with it.
          */
-        std::function<void(std::function<void()> call, const Ice::ConnectionPtr& con)> executor;
+        std::function<void(std::function<void()> call, const Ice::ConnectionPtr& con)> executor{};
 
         /**
          * Applications that make use of compact type IDs to conserve space
@@ -312,7 +312,7 @@ namespace Ice
          * @return The fully-scoped type ID such as "::Module::Class", or an empty string if
          * the compact ID is unknown.
          */
-        std::function<std::string(int id)> compactIdResolver;
+        std::function<std::string(int id)> compactIdResolver{};
 
         /**
          * The batch request interceptor, which is called by the Ice run time to enqueue a batch request.
@@ -320,7 +320,7 @@ namespace Ice
          * @param count The number of requests currently in the queue.
          * @param size The number of bytes consumed by the requests currently in the queue.
          */
-        std::function<void(const Ice::BatchRequest& req, int count, int size)> batchRequestInterceptor;
+        std::function<void(const Ice::BatchRequest& req, int count, int size)> batchRequestInterceptor{};
 
 #if defined(__clang__)
 #    pragma clang diagnostic pop
@@ -329,7 +329,7 @@ namespace Ice
         /**
          * The value factory manager.
          */
-        ValueFactoryManagerPtr valueFactoryManager;
+        ValueFactoryManagerPtr valueFactoryManager{};
 
         /**
          * The authentication options for %SSL client connections. When set, the %SSL transport ignores all IceSSL
@@ -342,7 +342,7 @@ namespace Ice
          * @see SSL::SecureTransportClientAuthenticationOptions
          * @see SSL::SchannelClientAuthenticationOptions
          */
-        std::optional<SSL::ClientAuthenticationOptions> clientAuthenticationOptions;
+        std::optional<SSL::ClientAuthenticationOptions> clientAuthenticationOptions{};
     };
 
     /**

--- a/cpp/include/Ice/SSL/ClientAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ClientAuthenticationOptions.h
@@ -240,7 +240,7 @@ namespace Ice::SSL
          *
          * [SSL_CTX_new]: https://www.openssl.org/docs/manmaster/man3/SSL_CTX_new.html
          */
-        std::function<SSL_CTX*(const std::string& host)> clientSSLContextSelectionCallback;
+        std::function<SSL_CTX*(const std::string& host)> clientSSLContextSelectionCallback{};
 
         /**
          * A callback invoked before initiating a new %SSL handshake, providing an opportunity to customize the %SSL
@@ -256,7 +256,7 @@ namespace Ice::SSL
          *
          * [SSL_new]: https://www.openssl.org/docs/manmaster/man3/SSL_new.html
          */
-        std::function<void(::SSL* ssl, const std::string& host)> sslNewSessionCallback;
+        std::function<void(::SSL* ssl, const std::string& host)> sslNewSessionCallback{};
 
         /**
          * A callback for validating the server certificate chain. If the verification callback returns false,
@@ -282,7 +282,7 @@ namespace Ice::SSL
          * @see SSL::SchannelConnectionInfo
          */
         std::function<bool(bool verified, X509_STORE_CTX* ctx, const ConnectionInfoPtr& info)>
-            serverCertificateValidationCallback;
+            serverCertificateValidationCallback{};
     };
 
     /// \cond INTERNAL

--- a/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
@@ -255,7 +255,7 @@ namespace Ice::SSL
          *
          * [SSL_CTX_new]: https://www.openssl.org/docs/manmaster/man3/SSL_CTX_new.html
          */
-        std::function<SSL_CTX*(const std::string& adapterName)> serverSSLContextSelectionCallback;
+        std::function<SSL_CTX*(const std::string& adapterName)> serverSSLContextSelectionCallback{};
 
         /**
          * A callback invoked before initiating a new %SSL handshake, providing an opportunity to customize the %SSL
@@ -271,7 +271,7 @@ namespace Ice::SSL
          *
          * [SSL_new]: https://www.openssl.org/docs/manmaster/man3/SSL_new.html
          */
-        std::function<void(::SSL* ssl, const std::string& adapterName)> sslNewSessionCallback;
+        std::function<void(::SSL* ssl, const std::string& adapterName)> sslNewSessionCallback{};
 
         /**
          * A callback for validating the client certificate chain. If the verification callback returns false,
@@ -297,7 +297,7 @@ namespace Ice::SSL
          * @see SSL::SchannelConnectionInfo
          */
         std::function<bool(bool verified, X509_STORE_CTX* ctx, const ConnectionInfoPtr& info)>
-            clientCertificateValidationCallback;
+            clientCertificateValidationCallback{};
     };
 
     /// \cond INTERNAL

--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -33,10 +33,6 @@
 #    include <ifaddrs.h>
 #endif
 
-#if defined(__GNUC__) && (__GNUC__ < 5)
-#    pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#endif
-
 using namespace std;
 using namespace Ice;
 using namespace IceInternal;

--- a/cpp/test/IceSSL/configuration/OpenSSLTests.cpp
+++ b/cpp/test/IceSSL/configuration/OpenSSLTests.cpp
@@ -19,11 +19,6 @@ using namespace Test;
 
 #ifdef ICE_USE_OPENSSL
 
-#    if defined(__GNUC__)
-#        pragma GCC diagnostic push
-#        pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#    endif
-
 const string password = "password"; // NOLINT(cert-err58-cpp)
 
 extern "C"
@@ -835,9 +830,5 @@ allAuthenticationOptionsTests(Test::TestHelper* helper, const string& testDir)
 
     serverHotCertificateReload(helper, testDir);
 }
-
-#    if defined(__GNUC__)
-#        pragma GCC diagnostic pop
-#    endif
 
 #endif

--- a/cpp/test/IceSSL/configuration/SecureTransportTests.cpp
+++ b/cpp/test/IceSSL/configuration/SecureTransportTests.cpp
@@ -18,8 +18,6 @@ using namespace Test;
 
 #ifdef ICE_USE_SECURE_TRANSPORT
 
-#    pragma clang diagnostic ignored "-Wmissing-field-initializers"
-
 atomic<int> nextKeyChain = 1000;
 
 string


### PR DESCRIPTION
Removed all `pragma GCC diagnostic ignored "-Wmissing-field-initializers"` and fixed the code instead.