### PR TITLE
Fix bug in logger middleware

### DIFF
--- a/cpp/src/Ice/LoggerMiddleware.cpp
+++ b/cpp/src/Ice/LoggerMiddleware.cpp
@@ -133,14 +133,23 @@ LoggerMiddleware::printTarget(LoggerOutputBase& out, const Current& current) con
     {
         out << " -f " << escapeString(current.facet, "", _toStringMode);
     }
+
     out << " over ";
 
     if (current.con)
     {
-        ConnectionInfoPtr connInfo = current.con->getInfo();
-        while (connInfo->underlying)
+        ConnectionInfoPtr connInfo = nullptr;
+        try
         {
-            connInfo = connInfo->underlying;
+            connInfo = current.con->getInfo();
+            while (connInfo->underlying)
+            {
+                connInfo = connInfo->underlying;
+            }
+        }
+        catch (...)
+        {
+            // Thrown by getInfo() when the connection is closed.
         }
 
         if (auto ipConnInfo = dynamic_pointer_cast<IPConnectionInfo>(connInfo))

--- a/csharp/src/Ice/Internal/LoggerMiddleware.cs
+++ b/csharp/src/Ice/Internal/LoggerMiddleware.cs
@@ -126,10 +126,18 @@ internal sealed class LoggerMiddleware : Object
 
         if (current.con is not null)
         {
-            ConnectionInfo connInfo = current.con.getInfo();
-            while (connInfo.underlying is not null)
+            ConnectionInfo? connInfo = null;
+            try
             {
-                connInfo = connInfo.underlying;
+                connInfo = current.con.getInfo();
+                while (connInfo.underlying is not null)
+                {
+                    connInfo = connInfo.underlying;
+                }
+            }
+            catch
+            {
+                // Thrown by getInfo() when the connection is closed.
             }
 
             if (connInfo is IPConnectionInfo ipConnInfo)

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerMiddleware.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerMiddleware.java
@@ -122,9 +122,14 @@ final class LoggerMiddleware implements com.zeroc.Ice.Object {
         out.print(" over ");
 
         if (current.con != null) {
-            ConnectionInfo connInfo = current.con.getInfo();
-            while (connInfo.underlying != null) {
-                connInfo = connInfo.underlying;
+            ConnectionInfo connInfo = null;
+            try {
+                connInfo = current.con.getInfo();
+                while (connInfo.underlying != null) {
+                    connInfo = connInfo.underlying;
+                }
+            } catch (Exception e) {
+                // Thrown by getInfo() when the connection is closed.
             }
 
             if (connInfo instanceof IPConnectionInfo ipConnInfo) {


### PR DESCRIPTION
This PR fixes a bug in the logger middleware introduced by #3507, #3512 and #3513: `Connection::getInfo` throws when the connection is closed.