### PR TITLE
Ensure ifr_name buffer is null terminated

### DIFF
--- a/cpp/src/Ice/Network.cpp
+++ b/cpp/src/Ice/Network.cpp
@@ -611,7 +611,8 @@ namespace
         throw Ice::SocketException(__FILE__, __LINE__, WSAEINVAL);
 #else
         ifreq if_address;
-        strncpy(if_address.ifr_name, name.c_str(), IFNAMSIZ);
+        strncpy(if_address.ifr_name, name.c_str(), IFNAMSIZ - 1);
+        if_address.ifr_name[IFNAMSIZ - 1] = '\0';
 
         SOCKET fd = createSocketImpl(false, AF_INET);
         int rc = ioctl(fd, SIOCGIFADDR, &if_address);


### PR DESCRIPTION
Catch this when trying to build with GCC 9.4

```
at src/Ice/Network.cpp:618:16:
/usr/include/aarch64-linux-gnu/bits/string_fortified.h:106:34: error: 'char* __builtin_strncpy(char*, const char*, long unsigned int)' specified bound 16 equals destination size [-Werror=stringop-truncation]
```