### PR TITLE
Do not include ice2slice in C++ NuGet packages

### DIFF
--- a/cpp/msbuild/ice.nuget.targets
+++ b/cpp/msbuild/ice.nuget.targets
@@ -17,9 +17,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <!-- The Slice for C++, and Ice to Slice compilers are includes as Tools -->
+        <!-- The Slice to C++ compiler is included as a Tool -->
         <Tools Include="$(IceSrcRootDir)bin\$(Platform)\$(Configuration)\slice2cpp.exe" />
-        <Tools Include="$(IceSrcRootDir)bin\$(Platform)\$(Configuration)\ice2slice.exe" />
 
         <!-- The executables to exclude from the package bin directory -->
         <ExecutablesExclude Include="$(IceSrcRootDir)bin\$(Platform)\$(Configuration)\slice2*.exe" />

--- a/packaging/msi/Ice.wixproj
+++ b/packaging/msi/Ice.wixproj
@@ -30,7 +30,7 @@
   <ItemGroup>
     <Slices Include="$(PackageDir)slice\**\*.ice" />
 
-    <Tools Include="$(PackageDir)tools\ice2slice.exe" />
+    <Tools Include="$(MSBuildThisFileDirectory)..\..\cpp\bin\x64\Release\ice2slice.exe" />
     <Tools Include="$(MSBuildThisFileDirectory)..\..\cpp\bin\x64\Release\slice2java.exe" />
 
     <Libraries Include="$(PackageDir)build\native\bin\x64\Release\*.dll" />


### PR DESCRIPTION
The `ice2slice` is now just part of the MSI distribution and not included in the NuGet packages.