### PR TITLE
Updates to rename "ice" to "@zeroc/ice" scoped package

### DIFF
--- a/cpp/src/slice2js/Gen.h
+++ b/cpp/src/slice2js/Gen.h
@@ -179,7 +179,7 @@ namespace Slice
 
             // The module name of the current unit.
             std::string _module;
-            // The import prefix for the "ice" module either empty string when building Ice or "__module_ice."
+            // The import prefix for the "ice" module either empty string when building Ice or "__module__zeroc_ice."
             std::string _iceImportPrefix;
             // A map of imported types to their module name.
             std::map<std::string, std::string> _importedTypes;

--- a/cpp/src/slice2js/JsUtil.cpp
+++ b/cpp/src/slice2js/JsUtil.cpp
@@ -116,17 +116,17 @@ string
 Slice::getJavaScriptModuleForType(const TypePtr& type)
 {
     static const char* builtinModuleTable[] = {
-        "",    // byte
-        "",    // bool
-        "",    // short
-        "",    // int
-        "ice", // long
-        "",    // float
-        "",    // double
-        "",    // string
-        "ice", // Ice.Value
-        "ice", // Ice.ObjectPrx
-        "ice"  // Ice.Object
+        "",           // byte
+        "",           // bool
+        "",           // short
+        "",           // int
+        "_zeroc_ice", // long
+        "",           // float
+        "",           // double
+        "",           // string
+        "_zeroc_ice", // Ice.Value
+        "_zeroc_ice", // Ice.ObjectPrx
+        "_zeroc_ice"  // Ice.Object
     };
 
     BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);

--- a/js/.gitignore
+++ b/js/.gitignore
@@ -38,3 +38,6 @@ bin/linux-arm64
 bin/linux-x64
 bin/macos-arm64
 bin/windows-x64
+
+# NPM package
+zeroc-ice-*.tgz

--- a/js/bin/slice2js
+++ b/js/bin/slice2js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+import { compile } from "../src/slice2js";
+
+try {
+    // Extract arguments for slice2js, skipping the first two:
+    // - argv[0]: The JavaScript interpreter (e.g., npx or node)
+    // - argv[1]: The script's file path
+    // - Remaining arguments are passed to slice2js via the compile method
+    const exitCode = await compile(process.argv.slice(2), { stdio: "inherit" });
+    process.exit(exitCode);
+} catch (err) {
+    console.error(`Error executing slice2js: ${err.message}`);
+    process.exit(1);
+}

--- a/js/gulpfile.js
+++ b/js/gulpfile.js
@@ -116,16 +116,16 @@ gulp.task("dist", gulp.parallel(libs.map(libName => libTask(libName, "generate")
 
 gulp.task("dist:clean", gulp.parallel(libs.map(libName => libTask(libName, "clean"))));
 
-gulp.task("ice:module:package", () => gulp.src(["package.json"]).pipe(gulp.dest("node_modules/ice")));
+gulp.task("ice:module:package", () => gulp.src(["package.json"]).pipe(gulp.dest("node_modules/@zeroc/ice")));
 
 gulp.task(
     "ice:module",
     gulp.series("ice:module:package", cb => {
-        pump([gulp.src([`${root}/src/**/*`]), gulp.dest(`${root}/node_modules/ice/src`)], cb);
+        pump([gulp.src([`${root}/src/**/*`]), gulp.dest(`${root}/node_modules/@zeroc/ice/src`)], cb);
     }),
 );
 
-gulp.task("ice:module:clean", () => deleteAsync("node_modules/ice"));
+gulp.task("ice:module:clean", () => deleteAsync("node_modules/@zeroc/ice"));
 
 const tests = [
     "test/Ice/adapterDeactivation",
@@ -204,12 +204,12 @@ gulp.task("ice:bundle", cb => {
     });
 });
 
-// A rollup resolver plugin to resolve "ice" module as an external file.
+// A rollup resolver plugin to resolve "@zeroc/ice" module as an external file.
 function IceResolver() {
     return {
         name: "ice-resolver",
         async resolveId(source) {
-            if (source == "ice") {
+            if (source == "@zeroc/ice") {
                 return { id: "/ice.js", external: "absolute" };
             }
             return null;

--- a/js/gulpfile.js
+++ b/js/gulpfile.js
@@ -271,7 +271,7 @@ for (const name of tests) {
                     target: "es2020",
                     module: "es2020",
                     noImplicitAny: true,
-                    moduleResolution: "node",
+                    moduleResolution: "bundler",
                 }),
                 gulp.dest(`${root}/${name}`),
             ],

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,13 +1,16 @@
 {
-    "name": "ice",
+    "name": "@zeroc/ice",
     "version": "3.8.0-alpha0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "ice",
+            "name": "@zeroc/ice",
             "version": "3.8.0-alpha0",
             "license": "GPL-2.0",
+            "bin": {
+                "slice2js": "bin/slice2js.js"
+            },
             "devDependencies": {
                 "@rollup/plugin-strip": "^3.0.4",
                 "@types/node": "^22.5.1",

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -9,7 +9,7 @@
             "version": "3.8.0-alpha0",
             "license": "GPL-2.0",
             "bin": {
-                "slice2js": "bin/slice2js.js"
+                "slice2js": "bin/slice2js"
             },
             "devDependencies": {
                 "@rollup/plugin-strip": "^3.0.4",

--- a/js/package.json
+++ b/js/package.json
@@ -18,7 +18,10 @@
     ],
     "type": "module",
     "exports": {
-        ".": "./src/index.js",
+        ".": {
+            "import": "./src/index.js",
+            "types": "./src/index.d.ts"
+        },
         "./slice2js": "./src/slice2js.js"
     },
     "bin": {

--- a/js/package.json
+++ b/js/package.json
@@ -19,12 +19,11 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./slice2js": "./bin/slice2js.js"
+        "./slice2js": "./src/slice2js.js"
     },
     "bin": {
-        "slice2js": "./bin/slice2js.js"
+        "slice2js": "./bin/slice2js"
     },
-    "types": "src/index.d.ts",
     "browserslist": "> 0.25%, not dead",
     "devDependencies": {
         "@rollup/plugin-strip": "^3.0.4",

--- a/js/src/Ice/ArrayUtil.d.ts
+++ b/js/src/Ice/ArrayUtil.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Utility functions for arrays.

--- a/js/src/Ice/AsyncResult.d.ts
+++ b/js/src/Ice/AsyncResult.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * The `AsyncResult` class encapsulates the state of an asynchronous invocation. It extends the {@link Promise}

--- a/js/src/Ice/Communicator.d.ts
+++ b/js/src/Ice/Communicator.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * The central object in Ice. One or more communicators can be instantiated for an Ice application.

--- a/js/src/Ice/Connection.d.ts
+++ b/js/src/Ice/Connection.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Callback invoked when the connection is closed. If additional information about the closure is needed,

--- a/js/src/Ice/Current.d.ts
+++ b/js/src/Ice/Current.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Provides information about an incoming request being dispatched.

--- a/js/src/Ice/Endpoint.d.ts
+++ b/js/src/Ice/Endpoint.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * The user-level interface to an endpoint.

--- a/js/src/Ice/EndpointSelectionType.d.ts
+++ b/js/src/Ice/EndpointSelectionType.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Determines the order in which the Ice runtime uses the endpoints in a proxy when establishing a connection.

--- a/js/src/Ice/EnumBase.d.ts
+++ b/js/src/Ice/EnumBase.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Base class for enumerated types.

--- a/js/src/Ice/Exception.d.ts
+++ b/js/src/Ice/Exception.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Base class for all Ice exceptions.

--- a/js/src/Ice/FormatType.d.ts
+++ b/js/src/Ice/FormatType.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          *  This enumeration describes the possible formats for classes.

--- a/js/src/Ice/HashMap.d.ts
+++ b/js/src/Ice/HashMap.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         type HashMapKey =
             | number

--- a/js/src/Ice/Holder.d.ts
+++ b/js/src/Ice/Holder.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * A holder for a value. This interface is used to emulate `out` parameters in JavaScript.

--- a/js/src/Ice/Identity.d.ts
+++ b/js/src/Ice/Identity.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Represents the identity of an Ice object. In a proxy, an empty {@link Identity#name} denotes a null proxy.

--- a/js/src/Ice/IdentityToString.d.ts
+++ b/js/src/Ice/IdentityToString.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Converts an object identity to a string.

--- a/js/src/Ice/ImplicitContext.d.ts
+++ b/js/src/Ice/ImplicitContext.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Interface to associate implicit contexts with communicators.

--- a/js/src/Ice/IncomingRequest.d.ts
+++ b/js/src/Ice/IncomingRequest.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Represents a request received by a connection. It's the argument to {@link Object.dispatch}.

--- a/js/src/Ice/Initialize.d.ts
+++ b/js/src/Ice/Initialize.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * A class that encapsulates data to initialize a communicator.

--- a/js/src/Ice/InputStream.d.ts
+++ b/js/src/Ice/InputStream.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * The InputStream class provides methods for decoding Slice encoded data from a stream of bytes.

--- a/js/src/Ice/LocalException.d.ts
+++ b/js/src/Ice/LocalException.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Base class for Ice run-time exceptions.

--- a/js/src/Ice/LocalExceptions.d.ts
+++ b/js/src/Ice/LocalExceptions.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * The base exception for the 3 NotExist exceptions.

--- a/js/src/Ice/Logger.d.ts
+++ b/js/src/Ice/Logger.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * The Ice message logger. Applications can provide their own logger by implementing this interface and installing it

--- a/js/src/Ice/Long.d.ts
+++ b/js/src/Ice/Long.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Represents a 64-bit signed integer.

--- a/js/src/Ice/MapUtil.d.ts
+++ b/js/src/Ice/MapUtil.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         class MapUtil {
             /**

--- a/js/src/Ice/Object.d.ts
+++ b/js/src/Ice/Object.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * The base class for servants.

--- a/js/src/Ice/ObjectAdapter.d.ts
+++ b/js/src/Ice/ObjectAdapter.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * The object adapter provides an up-call interface from the Ice run time to the implementation of Ice objects.

--- a/js/src/Ice/ObjectPrx.d.ts
+++ b/js/src/Ice/ObjectPrx.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * The base class for all object proxies.

--- a/js/src/Ice/OptionalFormat.d.ts
+++ b/js/src/Ice/OptionalFormat.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Optional format for encoding optional values.

--- a/js/src/Ice/OutgoingResponse.d.ts
+++ b/js/src/Ice/OutgoingResponse.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Represents the response to an incoming request. It's returned by {@link Object#dispatch}.

--- a/js/src/Ice/OutputStream.d.ts
+++ b/js/src/Ice/OutputStream.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * The OutputStream class provides methods for encoding data using Slice encoding into a stream of bytes.

--- a/js/src/Ice/Promise.d.ts
+++ b/js/src/Ice/Promise.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * The `Promise` class is a subclass of the global `Promise` class that adds the ability to resolve or reject the

--- a/js/src/Ice/Properties.d.ts
+++ b/js/src/Ice/Properties.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * A property set used to configure Ice applications. Properties are key/value pairs, with both keys and

--- a/js/src/Ice/Protocol.d.ts
+++ b/js/src/Ice/Protocol.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         const Encoding_1_0: EncodingVersion;
         const Encoding_1_1: EncodingVersion;

--- a/js/src/Ice/ReplyStatus.d.ts
+++ b/js/src/Ice/ReplyStatus.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Represents the status of a reply.

--- a/js/src/Ice/SSL/ConnectionInfo.d.ts
+++ b/js/src/Ice/SSL/ConnectionInfo.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         namespace SSL {
             /**

--- a/js/src/Ice/SSL/EndpointInfo.d.ts
+++ b/js/src/Ice/SSL/EndpointInfo.d.ts
@@ -1,4 +1,4 @@
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         namespace SSL {
             /**

--- a/js/src/Ice/ServantLocator.d.ts
+++ b/js/src/Ice/ServantLocator.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * A servant locator is called by an object adapter to locate a servant that is not found in its active servant map.

--- a/js/src/Ice/StreamHelpers.d.ts
+++ b/js/src/Ice/StreamHelpers.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         class ByteHelper {
             static validate(v: number): boolean;

--- a/js/src/Ice/StringToIdentity.d.ts
+++ b/js/src/Ice/StringToIdentity.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Converts a string to an object identity, throwing a {@link ParseException} if the string cannot be

--- a/js/src/Ice/ToStringMode.d.ts
+++ b/js/src/Ice/ToStringMode.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * The output mode for xxxToString method such as identityToString and proxyToString. The actual encoding format for

--- a/js/src/Ice/UUID.d.ts
+++ b/js/src/Ice/UUID.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Generates a universally unique identifier (UUID).

--- a/js/src/Ice/UnknownSlicedValue.d.ts
+++ b/js/src/Ice/UnknownSlicedValue.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Encapsulates the details of a slice with an unknown type.

--- a/js/src/Ice/UserException.d.ts
+++ b/js/src/Ice/UserException.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Base class for all Ice user exceptions.

--- a/js/src/Ice/Value.d.ts
+++ b/js/src/Ice/Value.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * The base class for instances of Slice classes.

--- a/js/src/Ice/ValueFactoryManager.d.ts
+++ b/js/src/Ice/ValueFactoryManager.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * Creates a new value for a given value type. The type should be the absolute Slice type ID. For example,

--- a/js/src/Ice/Version.d.ts
+++ b/js/src/Ice/Version.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-declare module "ice" {
+declare module "@zeroc/ice" {
     namespace Ice {
         /**
          * A version structure for the protocol version.

--- a/js/src/slice2js.js
+++ b/js/src/slice2js.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 // Copyright (c) ZeroC, Inc.
 
 import { spawn } from "child_process";
@@ -58,17 +56,6 @@ export async function compile(args = [], options = {}) {
         process.on("error", reject);
         process.on("exit", resolve);
     });
-}
-
-// If executed directly via `npx slice2js`
-if (import.meta.url === `file://${process.argv[1]}`) {
-    try {
-        const exitCode = await compile(process.argv.slice(2), { stdio: "inherit" });
-        process.exit(exitCode);
-    } catch (err) {
-        console.error(`Error executing slice2js: ${err.message}`);
-        process.exit(1);
-    }
 }
 
 // Options for configuring gulp-ice-builder to use this package

--- a/js/test/Common/ControllerHelper.js
+++ b/js/test/Common/ControllerHelper.js
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 
 export class ControllerHelper {
     constructor(exe, output) {

--- a/js/test/Common/ControllerI.js
+++ b/js/test/Common/ControllerI.js
@@ -2,7 +2,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Controller.js";
 import { ControllerHelper } from "./ControllerHelper.js";
 

--- a/js/test/Common/TestHelper.d.ts
+++ b/js/test/Common/TestHelper.d.ts
@@ -1,4 +1,4 @@
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import ControllerHelper from "./ControllerI";
 
 export class TestHelper {

--- a/js/test/Common/TestHelper.js
+++ b/js/test/Common/TestHelper.js
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 
 export class TestHelper {
     getTestEndpoint(...args) {

--- a/js/test/Glacier2/router/Client.ts
+++ b/js/test/Glacier2/router/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice, Glacier2 } from "ice";
+import { Ice, Glacier2 } from "@zeroc/ice";
 import { Test } from "./Callback.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/adapterDeactivation/Client.ts
+++ b/js/test/Ice/adapterDeactivation/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/ami/Client.ts
+++ b/js/test/Ice/ami/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/binding/Client.ts
+++ b/js/test/Ice/binding/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/defaultValue/Client.ts
+++ b/js/test/Ice/defaultValue/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/enums/Client.ts
+++ b/js/test/Ice/enums/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { TestHelper } from "../../Common/TestHelper.js";
 import { Test } from "./Test.js";
 

--- a/js/test/Ice/exceptions/AMDThrowerI.ts
+++ b/js/test/Ice/exceptions/AMDThrowerI.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/exceptions/Client.ts
+++ b/js/test/Ice/exceptions/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/exceptions/Server.ts
+++ b/js/test/Ice/exceptions/Server.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 import { ThrowerI } from "./ThrowerI.js";

--- a/js/test/Ice/exceptions/ServerAMD.ts
+++ b/js/test/Ice/exceptions/ServerAMD.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 import { AMDThrowerI } from "./AMDThrowerI.js";

--- a/js/test/Ice/exceptions/ThrowerI.ts
+++ b/js/test/Ice/exceptions/ThrowerI.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/facets/Client.ts
+++ b/js/test/Ice/facets/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/facets/Server.ts
+++ b/js/test/Ice/facets/Server.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 import { DI, FI, HI, EmptyI } from "./TestI.js";

--- a/js/test/Ice/facets/TestI.ts
+++ b/js/test/Ice/facets/TestI.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 
 export class DI extends Test.D {

--- a/js/test/Ice/idleTimeout/Client.ts
+++ b/js/test/Ice/idleTimeout/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/inactivityTimeout/Client.ts
+++ b/js/test/Ice/inactivityTimeout/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/info/Client.ts
+++ b/js/test/Ice/info/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/inheritance/Client.ts
+++ b/js/test/Ice/inheritance/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/inheritance/InitialI.ts
+++ b/js/test/Ice/inheritance/InitialI.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 
 export class IAI extends Test.MA.IA {

--- a/js/test/Ice/inheritance/Server.ts
+++ b/js/test/Ice/inheritance/Server.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 import { InitialI } from "./InitialI.js";

--- a/js/test/Ice/location/Client.ts
+++ b/js/test/Ice/location/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/middleware/Client.ts
+++ b/js/test/Ice/middleware/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { TestHelper } from "../../Common/TestHelper.js";
 import { Test } from "./Test.js";
 

--- a/js/test/Ice/middleware/Server.ts
+++ b/js/test/Ice/middleware/Server.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/number/Client.ts
+++ b/js/test/Ice/number/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { TestHelper } from "../../Common/TestHelper.js";
 
 const test = TestHelper.test;

--- a/js/test/Ice/objects/Client.ts
+++ b/js/test/Ice/objects/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test as Test_Test } from "./Test.js";
 import { Test as Test_Forward } from "./Forward.js";
 

--- a/js/test/Ice/objects/InitialI.ts
+++ b/js/test/Ice/objects/InitialI.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 
 import { Test } from "./Test.js";
 import { Test as Test_Forward } from "./Forward.js";

--- a/js/test/Ice/objects/Server.ts
+++ b/js/test/Ice/objects/Server.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test as Test_Test } from "./Test.js";
 import { Test as Test_Forward } from "./Forward.js";
 

--- a/js/test/Ice/operations/AMDMyDerivedClassI.ts
+++ b/js/test/Ice/operations/AMDMyDerivedClassI.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/operations/BatchOneways.ts
+++ b/js/test/Ice/operations/BatchOneways.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/operations/Client.ts
+++ b/js/test/Ice/operations/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/operations/MyDerivedClassI.ts
+++ b/js/test/Ice/operations/MyDerivedClassI.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/operations/Oneways.ts
+++ b/js/test/Ice/operations/Oneways.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/operations/Server.ts
+++ b/js/test/Ice/operations/Server.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 import { MyDerivedClassI } from "./MyDerivedClassI.js";

--- a/js/test/Ice/operations/ServerAMD.ts
+++ b/js/test/Ice/operations/ServerAMD.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 import { AMDMyDerivedClassI } from "./AMDMyDerivedClassI.js";

--- a/js/test/Ice/operations/Twoways.ts
+++ b/js/test/Ice/operations/Twoways.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/optional/AMDInitialI.ts
+++ b/js/test/Ice/optional/AMDInitialI.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 
 export class AMDInitialI extends Test.Initial {

--- a/js/test/Ice/optional/Client.ts
+++ b/js/test/Ice/optional/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/optional/InitialI.ts
+++ b/js/test/Ice/optional/InitialI.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 
 export class InitialI extends Test.Initial {

--- a/js/test/Ice/optional/Server.ts
+++ b/js/test/Ice/optional/Server.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 import { InitialI } from "./InitialI.js";

--- a/js/test/Ice/optional/ServerAMD.ts
+++ b/js/test/Ice/optional/ServerAMD.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 import { AMDInitialI } from "./AMDInitialI.js";

--- a/js/test/Ice/properties/Client.ts
+++ b/js/test/Ice/properties/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { TestHelper } from "../../Common/TestHelper.js";
 import * as fs from "fs";
 import * as path from "path";

--- a/js/test/Ice/proxy/Client.ts
+++ b/js/test/Ice/proxy/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/retry/Client.ts
+++ b/js/test/Ice/retry/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/scope/Client.ts
+++ b/js/test/Ice/scope/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test, Inner } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/servantLocator/Client.ts
+++ b/js/test/Ice/servantLocator/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/servantLocator/ServantLocatorI.ts
+++ b/js/test/Ice/servantLocator/ServantLocatorI.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 import { TestI } from "./TestI.js";

--- a/js/test/Ice/servantLocator/Server.ts
+++ b/js/test/Ice/servantLocator/Server.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 import { TestI } from "./TestI.js";

--- a/js/test/Ice/servantLocator/TestActivationI.ts
+++ b/js/test/Ice/servantLocator/TestActivationI.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { ServantLocatorI } from "./ServantLocatorI.js";
 

--- a/js/test/Ice/servantLocator/TestI.ts
+++ b/js/test/Ice/servantLocator/TestI.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 
 export class TestI extends Test.TestIntf {

--- a/js/test/Ice/slicing/exceptions/Client.ts
+++ b/js/test/Ice/slicing/exceptions/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../../Common/TestHelper.js";
 

--- a/js/test/Ice/slicing/objects/Client.ts
+++ b/js/test/Ice/slicing/objects/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../../Common/TestHelper.js";
 

--- a/js/test/Ice/stream/Client.ts
+++ b/js/test/Ice/stream/Client.ts
@@ -2,7 +2,7 @@
 
 /* eslint-env jquery */
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Ice/timeout/Client.ts
+++ b/js/test/Ice/timeout/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/js/test/Slice/escape/Client.ts
+++ b/js/test/Slice/escape/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { TestHelper } from "../../Common/TestHelper.js";
 import { _await } from "./Key.js";
 

--- a/js/test/Slice/macros/Client.ts
+++ b/js/test/Slice/macros/Client.ts
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-import { Ice } from "ice";
+import { Ice } from "@zeroc/ice";
 import { Test } from "./Test.js";
 import { TestHelper } from "../../Common/TestHelper.js";
 

--- a/slice/Glacier2/Metrics.ice
+++ b/slice/Glacier2/Metrics.ice
@@ -7,7 +7,7 @@
 [["cpp:header-ext:h"]]
 [["cpp:include:Glacier2/Config.h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:Glacier2"]]
 

--- a/slice/Glacier2/PermissionsVerifier.ice
+++ b/slice/Glacier2/PermissionsVerifier.ice
@@ -7,7 +7,7 @@
 [["cpp:header-ext:h"]]
 [["cpp:include:Glacier2/Config.h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:Glacier2"]]
 

--- a/slice/Glacier2/Router.ice
+++ b/slice/Glacier2/Router.ice
@@ -7,7 +7,7 @@
 [["cpp:header-ext:h"]]
 [["cpp:include:Glacier2/Config.h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:Glacier2"]]
 

--- a/slice/Glacier2/SSLInfo.ice
+++ b/slice/Glacier2/SSLInfo.ice
@@ -7,7 +7,7 @@
 [["cpp:header-ext:h"]]
 [["cpp:include:Glacier2/Config.h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:Glacier2"]]
 

--- a/slice/Glacier2/Session.ice
+++ b/slice/Glacier2/Session.ice
@@ -7,7 +7,7 @@
 [["cpp:header-ext:h"]]
 [["cpp:include:Glacier2/Config.h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:Glacier2"]]
 

--- a/slice/Ice/BuiltinSequences.ice
+++ b/slice/Ice/BuiltinSequences.ice
@@ -16,7 +16,7 @@
 [["cpp:include:string"]]
 [["cpp:include:vector"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:Ice"]]
 

--- a/slice/Ice/Context.ice
+++ b/slice/Ice/Context.ice
@@ -11,7 +11,7 @@
 [["cpp:include:map"]]
 [["cpp:include:string"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:Ice"]]
 

--- a/slice/Ice/EndpointTypes.ice
+++ b/slice/Ice/EndpointTypes.ice
@@ -10,7 +10,7 @@
 [["cpp:include:Ice/Config.h"]]
 [["cpp:include:cstdint"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:Ice"]]
 

--- a/slice/Ice/Identity.ice
+++ b/slice/Ice/Identity.ice
@@ -13,7 +13,7 @@
 [["cpp:include:string"]]
 [["cpp:include:vector"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:Ice"]]
 

--- a/slice/Ice/Locator.ice
+++ b/slice/Ice/Locator.ice
@@ -8,7 +8,7 @@
 
 [["cpp:source-include:Ice/Process.h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:Ice"]]
 

--- a/slice/Ice/Metrics.ice
+++ b/slice/Ice/Metrics.ice
@@ -6,7 +6,7 @@
 [["cpp:doxygen:include:Ice/Ice.h"]]
 [["cpp:header-ext:h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:Ice"]]
 

--- a/slice/Ice/OperationMode.ice
+++ b/slice/Ice/OperationMode.ice
@@ -10,7 +10,7 @@
 [["cpp:include:Ice/Config.h"]]
 [["cpp:include:Ice/StreamHelpers.h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:Ice"]]
 

--- a/slice/Ice/Process.ice
+++ b/slice/Ice/Process.ice
@@ -6,7 +6,7 @@
 [["cpp:doxygen:include:Ice/Ice.h"]]
 [["cpp:header-ext:h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:Ice"]]
 

--- a/slice/Ice/PropertiesAdmin.ice
+++ b/slice/Ice/PropertiesAdmin.ice
@@ -6,7 +6,7 @@
 [["cpp:doxygen:include:Ice/Ice.h"]]
 [["cpp:header-ext:h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:Ice"]]
 

--- a/slice/Ice/PropertyDict.ice
+++ b/slice/Ice/PropertyDict.ice
@@ -11,7 +11,7 @@
 [["cpp:include:map"]]
 [["cpp:include:string"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:Ice"]]
 

--- a/slice/Ice/RemoteLogger.ice
+++ b/slice/Ice/RemoteLogger.ice
@@ -7,7 +7,7 @@
 [["cpp:header-ext:h"]]
 [["cpp:include:list"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:Ice"]]
 

--- a/slice/Ice/Router.ice
+++ b/slice/Ice/Router.ice
@@ -6,7 +6,7 @@
 [["cpp:doxygen:include:Ice/Ice.h"]]
 [["cpp:header-ext:h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:Ice"]]
 

--- a/slice/Ice/SliceChecksumDict.ice
+++ b/slice/Ice/SliceChecksumDict.ice
@@ -6,7 +6,7 @@
 [["cpp:doxygen:include:Ice/Ice.h"]]
 [["cpp:header-ext:h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:Ice"]]
 

--- a/slice/Ice/Version.ice
+++ b/slice/Ice/Version.ice
@@ -13,7 +13,7 @@
 [["cpp:include:cstdint"]]
 [["cpp:include:ostream"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:Ice"]]
 

--- a/slice/IceBox/ServiceManager.ice
+++ b/slice/IceBox/ServiceManager.ice
@@ -7,7 +7,7 @@
 [["cpp:header-ext:h"]]
 [["cpp:include:IceBox/Config.h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:IceBox"]]
 

--- a/slice/IceDiscovery/IceDiscovery.ice
+++ b/slice/IceDiscovery/IceDiscovery.ice
@@ -5,7 +5,7 @@
 [["cpp:doxygen:include:IceDiscovery/IceDiscovery.h"]]
 [["cpp:header-ext:h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:IceDiscovery"]]
 

--- a/slice/IceGrid/Admin.ice
+++ b/slice/IceGrid/Admin.ice
@@ -7,7 +7,7 @@
 [["cpp:header-ext:h"]]
 [["cpp:include:IceGrid/Config.h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:IceGrid"]]
 

--- a/slice/IceGrid/Descriptor.ice
+++ b/slice/IceGrid/Descriptor.ice
@@ -6,7 +6,7 @@
 [["cpp:header-ext:h"]]
 [["cpp:include:IceGrid/Config.h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:IceGrid"]]
 

--- a/slice/IceGrid/Exception.ice
+++ b/slice/IceGrid/Exception.ice
@@ -6,7 +6,7 @@
 [["cpp:header-ext:h"]]
 [["cpp:include:IceGrid/Config.h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:IceGrid"]]
 

--- a/slice/IceGrid/FileParser.ice
+++ b/slice/IceGrid/FileParser.ice
@@ -7,7 +7,7 @@
 [["cpp:header-ext:h"]]
 [["cpp:include:IceGrid/Config.h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:IceGrid"]]
 

--- a/slice/IceGrid/Registry.ice
+++ b/slice/IceGrid/Registry.ice
@@ -7,7 +7,7 @@
 [["cpp:header-ext:h"]]
 [["cpp:include:IceGrid/Config.h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:IceGrid"]]
 

--- a/slice/IceGrid/Session.ice
+++ b/slice/IceGrid/Session.ice
@@ -7,7 +7,7 @@
 [["cpp:header-ext:h"]]
 [["cpp:include:IceGrid/Config.h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:IceGrid"]]
 

--- a/slice/IceGrid/UserAccountMapper.ice
+++ b/slice/IceGrid/UserAccountMapper.ice
@@ -7,7 +7,7 @@
 [["cpp:header-ext:h"]]
 [["cpp:include:IceGrid/Config.h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:IceGrid"]]
 

--- a/slice/IceLocatorDiscovery/IceLocatorDiscovery.ice
+++ b/slice/IceLocatorDiscovery/IceLocatorDiscovery.ice
@@ -5,7 +5,7 @@
 [["cpp:doxygen:include:IceLocatorDiscovery/IceLocatorDiscovery.h"]]
 [["cpp:header-ext:h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:IceLocatorDiscovery"]]
 

--- a/slice/IceStorm/IceStorm.ice
+++ b/slice/IceStorm/IceStorm.ice
@@ -7,7 +7,7 @@
 [["cpp:header-ext:h"]]
 [["cpp:include:IceStorm/Config.h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:IceStorm"]]
 

--- a/slice/IceStorm/Metrics.ice
+++ b/slice/IceStorm/Metrics.ice
@@ -7,7 +7,7 @@
 [["cpp:header-ext:h"]]
 [["cpp:include:IceStorm/Config.h"]]
 
-[["js:module:ice"]]
+[["js:module:@zeroc/ice"]]
 
 [["python:pkgdir:IceStorm"]]
 


### PR DESCRIPTION
This PR renames "ice" NPM module to "@zeroc/ice" scoped modules.

Using a scoped module has the advantage of identify the organization that published it in the NPM registry.

This is similar to NuGet reserved prefixes we have for `zeroc.` and `IceRpc.`.

npm also allow to configure per scope registries witch is very convenient for testing.

For uses upgrading from 3.7 it means using:

```
import { Ice } from "@zeroc/ice"
``` 

instead of 

```
import { Ice } from "ice";
```

Also update the package.json dependencies to use `@zeroc/ice` instead of `ice`.

The PR also fix slice2js to support scoped modules with `js:module` metadata, the previous version would include `@` and `/` in the import alias which are not valid characters for JavaScript variables.