### PR TITLE
Add Support for `swift:identifier` Metadata

### DIFF
--- a/cpp/src/IceStorm/Election.ice
+++ b/cpp/src/IceStorm/Election.ice
@@ -36,24 +36,21 @@ module IceStormElection
         /// Initialize the observer.
         /// @param llu The last log update seen by the master.
         /// @param content The topic content.
-        /// @throws ObserverInconsistencyException Raised if an
-        /// inconsistency was detected.
+        /// @throws ObserverInconsistencyException Raised if an inconsistency was detected.
         void init(LogUpdate llu, TopicContentSeq content)
             throws ObserverInconsistencyException;
 
         /// Create the topic with the given name.
         /// @param llu The log update token.
         /// @param name The topic name.
-        /// @throws ObserverInconsistencyException Raised if an
-        /// inconsistency was detected.
+        /// @throws ObserverInconsistencyException Raised if an inconsistency was detected.
         void createTopic(LogUpdate llu, string name)
             throws ObserverInconsistencyException;
 
         /// Destroy the topic with the given name.
         /// @param llu The log update token.
         /// @param name The topic name.
-        /// @throws ObserverInconsistencyException Raised if an
-        /// inconsistency was detected.
+        /// @throws ObserverInconsistencyException Raised if an inconsistency was detected.
         void destroyTopic(LogUpdate llu, string name)
             throws ObserverInconsistencyException;
 
@@ -61,8 +58,7 @@ module IceStormElection
         /// @param llu The log update token.
         /// @param topic The topic name to which to add the subscriber.
         /// @param record The subscriber information.
-        /// @throws ObserverInconsistencyException Raised if an
-        /// inconsistency was detected.
+        /// @throws ObserverInconsistencyException Raised if an inconsistency was detected.
         void addSubscriber(LogUpdate llu, string topic, IceStorm::SubscriberRecord record)
             throws ObserverInconsistencyException;
 

--- a/cpp/src/IceStorm/Election.ice
+++ b/cpp/src/IceStorm/Election.ice
@@ -37,7 +37,8 @@ module IceStormElection
         /// @param llu The last log update seen by the master.
         /// @param content The topic content.
         /// @throws ObserverInconsistencyException Raised if an
-        /// inconsisency was detected.
+        /// inconsistency was detected.
+        ["swift:identifier:initialize"]
         void init(LogUpdate llu, TopicContentSeq content)
             throws ObserverInconsistencyException;
 
@@ -45,7 +46,7 @@ module IceStormElection
         /// @param llu The log update token.
         /// @param name The topic name.
         /// @throws ObserverInconsistencyException Raised if an
-        /// inconsisency was detected.
+        /// inconsistency was detected.
         void createTopic(LogUpdate llu, string name)
             throws ObserverInconsistencyException;
 
@@ -53,7 +54,7 @@ module IceStormElection
         /// @param llu The log update token.
         /// @param name The topic name.
         /// @throws ObserverInconsistencyException Raised if an
-        /// inconsisency was detected.
+        /// inconsistency was detected.
         void destroyTopic(LogUpdate llu, string name)
             throws ObserverInconsistencyException;
 
@@ -62,7 +63,7 @@ module IceStormElection
         /// @param topic The topic name to which to add the subscriber.
         /// @param record The subscriber information.
         /// @throws ObserverInconsistencyException Raised if an
-        /// inconsisency was detected.
+        /// inconsistency was detected.
         void addSubscriber(LogUpdate llu, string topic, IceStorm::SubscriberRecord record)
             throws ObserverInconsistencyException;
 
@@ -70,7 +71,7 @@ module IceStormElection
         /// @param llu The log update token.
         /// @param name The topic name.
         /// @param subscribers The identities of the subscribers to remove.
-        /// @throws ObserverInconsistencyException Raised if an inconsisency was detected.
+        /// @throws ObserverInconsistencyException Raised if an inconsistency was detected.
         void removeSubscriber(LogUpdate llu, string topic, Ice::IdentitySeq subscribers)
             throws ObserverInconsistencyException;
     }

--- a/cpp/src/IceStorm/Election.ice
+++ b/cpp/src/IceStorm/Election.ice
@@ -38,7 +38,6 @@ module IceStormElection
         /// @param content The topic content.
         /// @throws ObserverInconsistencyException Raised if an
         /// inconsistency was detected.
-        ["swift:identifier:initialize"]
         void init(LogUpdate llu, TopicContentSeq content)
             throws ObserverInconsistencyException;
 

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -243,8 +243,8 @@ Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     out << sp;
     out << nl << "@_documentation(visibility: internal)";
-    out << nl << "public class " << removeEscaping(name) << "_TypeResolver: "
-        << getUnqualified("Ice.ValueTypeResolver", swiftModule);
+    out << nl << "public class " << removeEscaping(name)
+        << "_TypeResolver: " << getUnqualified("Ice.ValueTypeResolver", swiftModule);
     out << sb;
     out << nl << "public override func type() -> " << getUnqualified("Ice.Value.Type", swiftModule);
     out << sb;
@@ -405,8 +405,8 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 
     out << sp;
     out << nl << "@_documentation(visibility: internal)";
-    out << nl << "public class " << removeEscaping(name) << "_TypeResolver: "
-        << getUnqualified("Ice.UserExceptionTypeResolver", swiftModule);
+    out << nl << "public class " << removeEscaping(name)
+        << "_TypeResolver: " << getUnqualified("Ice.UserExceptionTypeResolver", swiftModule);
     out << sb;
     out << nl << "public override func type() -> " << getUnqualified("Ice.UserException.Type", swiftModule);
     out << sb;
@@ -464,8 +464,8 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     out << sp;
     out << nl << "open override func _iceWriteImpl(to ostr: " << getUnqualified("Ice.OutputStream", swiftModule) << ")";
     out << sb;
-    out << nl << "ostr.startSlice(typeId: " << name << ".ice_staticId(), compactId: -1, last: "
-        << (!base ? "true" : "false") << ")";
+    out << nl << "ostr.startSlice(typeId: " << name
+        << ".ice_staticId(), compactId: -1, last: " << (!base ? "true" : "false") << ")";
     for (const auto& member : members)
     {
         if (!member->optional())

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -1268,7 +1268,7 @@ Gen::ServantVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     const string servant = getRelativeTypeString(p, swiftModule);
     const string unescapedName = removeEscaping(servant);
     const string disp = unescapedName + "Disp";
-    const string traits = unescapedName + "Traits");
+    const string traits = unescapedName + "Traits";
 
     //
     // Disp struct

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -333,12 +333,12 @@ Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     {
         if (!member->optional())
         {
-            writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->name(), false);
+            writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->mappedName(), false);
         }
     }
     for (const auto& member : optionalMembers)
     {
-        writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->name(), false, member->tag());
+        writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->mappedName(), false, member->tag());
     }
     out << nl << "try istr.endSlice()";
     if (base)
@@ -357,12 +357,12 @@ Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
         TypePtr type = member->type();
         if (!member->optional())
         {
-            writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->name(), true);
+            writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->mappedName(), true);
         }
     }
     for (const auto& member : optionalMembers)
     {
-        writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->name(), true, member->tag());
+        writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->mappedName(), true, member->tag());
     }
     out << nl << "ostr.endSlice()";
     if (base)
@@ -470,13 +470,13 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     {
         if (!member->optional())
         {
-            writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->name(), true);
+            writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->mappedName(), true);
         }
     }
 
     for (const auto& member : optionalMembers)
     {
-        writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->name(), true, member->tag());
+        writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->mappedName(), true, member->tag());
     }
     out << nl << "ostr.endSlice()";
     if (base)
@@ -494,13 +494,13 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     {
         if (!member->optional())
         {
-            writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->name(), false);
+            writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->mappedName(), false);
         }
     }
 
     for (const auto& member : optionalMembers)
     {
-        writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->name(), false, member->tag());
+        writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->mappedName(), false, member->tag());
     }
 
     out << nl << "try istr.endSlice()";

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -243,20 +243,18 @@ Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     out << sp;
     out << nl << "@_documentation(visibility: internal)";
-    out << nl << "public class " << name << "_TypeResolver: " << getUnqualified("Ice.ValueTypeResolver", swiftModule);
+    out << nl << "public class " << removeEscaping(name) << "_TypeResolver: "
+        << getUnqualified("Ice.ValueTypeResolver", swiftModule);
     out << sb;
     out << nl << "public override func type() -> " << getUnqualified("Ice.Value.Type", swiftModule);
     out << sb;
-    out << nl << "return " << fixIdent(name) << ".self";
+    out << nl << "return " << name << ".self";
     out << eb;
     out << eb;
 
     if (p->compactId() >= 0)
     {
-        //
-        // For each Value class using a compact id we generate an extension
-        // method in TypeIdResolver.
-        //
+        // For each Value class using a compact id we generate an extension method in TypeIdResolver.
         out << sp;
         out << nl << "public extension " << getUnqualified("Ice.TypeIdResolver", swiftModule);
         out << sb;
@@ -267,9 +265,7 @@ Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
         out << eb;
     }
 
-    //
-    // For each Value class we generate an extension method in ClassResolver
-    //
+    // For each Value class we generate an extension method in ClassResolver.
     ostringstream factory;
     factory << prefix;
     vector<string> parts = splitScopedName(p->scoped());
@@ -288,17 +284,17 @@ Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     out << nl << "@objc static func " << factory.str() << "() -> "
         << getUnqualified("Ice.ValueTypeResolver", swiftModule);
     out << sb;
-    out << nl << "return " << name << "_TypeResolver()";
+    out << nl << "return " << removeEscaping(name) << "_TypeResolver()";
     out << eb;
     out << eb;
 
     out << sp;
     writeDocSummary(out, p);
     writeSwiftAttributes(out, p->getMetadata());
-    out << nl << "open class " << fixIdent(name) << ": ";
+    out << nl << "open class " << name << ": ";
     if (base)
     {
-        out << fixIdent(getRelativeTypeString(base, swiftModule));
+        out << getRelativeTypeString(base, swiftModule);
     }
     else
     {
@@ -337,12 +333,12 @@ Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     {
         if (!member->optional())
         {
-            writeMarshalUnmarshalCode(out, member->type(), p, "self." + fixIdent(member->name()), false);
+            writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->name(), false);
         }
     }
     for (const auto& member : optionalMembers)
     {
-        writeMarshalUnmarshalCode(out, member->type(), p, "self." + fixIdent(member->name()), false, member->tag());
+        writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->name(), false, member->tag());
     }
     out << nl << "try istr.endSlice()";
     if (base)
@@ -354,19 +350,19 @@ Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     out << sp;
     out << nl << "open override func _iceWriteImpl(to ostr: " << getUnqualified("Ice.OutputStream", swiftModule) << ")";
     out << sb;
-    out << nl << "ostr.startSlice(typeId: " << fixIdent(name) << ".ice_staticId(), compactId: " << p->compactId()
+    out << nl << "ostr.startSlice(typeId: " << name << ".ice_staticId(), compactId: " << p->compactId()
         << ", last: " << (!base ? "true" : "false") << ")";
     for (const auto& member : members)
     {
         TypePtr type = member->type();
         if (!member->optional())
         {
-            writeMarshalUnmarshalCode(out, member->type(), p, "self." + fixIdent(member->name()), true);
+            writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->name(), true);
         }
     }
     for (const auto& member : optionalMembers)
     {
-        writeMarshalUnmarshalCode(out, member->type(), p, "self." + fixIdent(member->name()), true, member->tag());
+        writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->name(), true, member->tag());
     }
     out << nl << "ostr.endSlice()";
     if (base)
@@ -394,9 +390,7 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 
     const string prefix = getClassResolverPrefix(p->unit());
 
-    //
-    // For each UserException class we generate an extension in ClassResolver
-    //
+    // For each UserException class we generate an extension in ClassResolver.
     ostringstream factory;
     factory << prefix;
     vector<string> parts = splitScopedName(p->scoped());
@@ -411,12 +405,12 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 
     out << sp;
     out << nl << "@_documentation(visibility: internal)";
-    out << nl << "public class " << name
-        << "_TypeResolver: " << getUnqualified("Ice.UserExceptionTypeResolver", swiftModule);
+    out << nl << "public class " << removeEscaping(name) << "_TypeResolver: "
+        << getUnqualified("Ice.UserExceptionTypeResolver", swiftModule);
     out << sb;
     out << nl << "public override func type() -> " << getUnqualified("Ice.UserException.Type", swiftModule);
     out << sb;
-    out << nl << "return " << fixIdent(name) << ".self";
+    out << nl << "return " << name << ".self";
     out << eb;
     out << eb;
 
@@ -426,17 +420,17 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     out << nl << "@objc static func " << factory.str() << "() -> "
         << getUnqualified("Ice.UserExceptionTypeResolver", swiftModule);
     out << sb;
-    out << nl << "return " << name << "_TypeResolver()";
+    out << nl << "return " << removeEscaping(name) << "_TypeResolver()";
     out << eb;
     out << eb;
 
     out << sp;
     writeDocSummary(out, p);
     writeSwiftAttributes(out, p->getMetadata());
-    out << nl << "open class " << fixIdent(name) << ": ";
+    out << nl << "open class " << name << ": ";
     if (base)
     {
-        out << fixIdent(getRelativeTypeString(base, swiftModule));
+        out << getRelativeTypeString(base, swiftModule);
     }
     else
     {
@@ -470,19 +464,19 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     out << sp;
     out << nl << "open override func _iceWriteImpl(to ostr: " << getUnqualified("Ice.OutputStream", swiftModule) << ")";
     out << sb;
-    out << nl << "ostr.startSlice(typeId: " << fixIdent(name)
-        << ".ice_staticId(), compactId: -1, last: " << (!base ? "true" : "false") << ")";
+    out << nl << "ostr.startSlice(typeId: " << name << ".ice_staticId(), compactId: -1, last: "
+        << (!base ? "true" : "false") << ")";
     for (const auto& member : members)
     {
         if (!member->optional())
         {
-            writeMarshalUnmarshalCode(out, member->type(), p, "self." + fixIdent(member->name()), true);
+            writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->name(), true);
         }
     }
 
     for (const auto& member : optionalMembers)
     {
-        writeMarshalUnmarshalCode(out, member->type(), p, "self." + fixIdent(member->name()), true, member->tag());
+        writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->name(), true, member->tag());
     }
     out << nl << "ostr.endSlice()";
     if (base)
@@ -500,13 +494,13 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     {
         if (!member->optional())
         {
-            writeMarshalUnmarshalCode(out, member->type(), p, "self." + fixIdent(member->name()), false);
+            writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->name(), false);
         }
     }
 
     for (const auto& member : optionalMembers)
     {
-        writeMarshalUnmarshalCode(out, member->type(), p, "self." + fixIdent(member->name()), false, member->tag());
+        writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->name(), false, member->tag());
     }
 
     out << nl << "try istr.endSlice()";
@@ -532,7 +526,8 @@ bool
 Gen::TypesVisitor::visitStructStart(const StructPtr& p)
 {
     const string swiftModule = getSwiftModule(getTopLevelModule(p));
-    const string name = fixIdent(getRelativeTypeString(p, swiftModule));
+    const string name = getRelativeTypeString(p, swiftModule);
+    const string docName = removeEscaping(name);
     bool isLegalKeyType = Dictionary::isLegalKeyType(p);
     const DataMemberList members = p->dataMembers();
     const string optionalFormat = getOptionalFormat(p);
@@ -557,12 +552,12 @@ Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     out << eb;
 
     out << sp;
-    out << nl << "/// An `Ice.InputStream` extension to read `" << name << "` structured values from the stream.";
+    out << nl << "/// An `Ice.InputStream` extension to read `" << docName << "` structured values from the stream.";
     out << nl << "public extension " << getUnqualified("Ice.InputStream", swiftModule);
     out << sb;
 
     out << sp;
-    out << nl << "/// Read a `" << name << "` structured value from the stream.";
+    out << nl << "/// Read a `" << docName << "` structured value from the stream.";
     out << nl << "///";
     out << nl << "/// - Returns: The structured value read from the stream.";
     out << nl << "func read() throws -> " << name;
@@ -570,13 +565,13 @@ Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     out << nl << (usesClasses ? "let" : "var") << " v = " << name << "()";
     for (const auto& member : members)
     {
-        writeMarshalUnmarshalCode(out, member->type(), p, "v." + fixIdent(member->name()), false);
+        writeMarshalUnmarshalCode(out, member->type(), p, "v." + member->mappedName(), false);
     }
     out << nl << "return v";
     out << eb;
 
     out << sp;
-    out << nl << "/// Read an optional `" << name << "?` structured value from the stream.";
+    out << nl << "/// Read an optional `" << docName << "?` structured value from the stream.";
     out << nl << "///";
     out << nl << "/// - Parameter tag: The numeric tag associated with the value.";
     out << nl << "///";
@@ -601,22 +596,22 @@ Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     out << eb;
 
     out << sp;
-    out << nl << "/// An `Ice.OutputStream` extension to write `" << name << "` structured values from the stream.";
+    out << nl << "/// An `Ice.OutputStream` extension to write `" << docName << "` structured values from the stream.";
     out << nl << "public extension " << getUnqualified("Ice.OutputStream", swiftModule);
     out << sb;
 
-    out << nl << "/// Write a `" << name << "` structured value to the stream.";
+    out << nl << "/// Write a `" << docName << "` structured value to the stream.";
     out << nl << "///";
     out << nl << "/// - Parameter v: The value to write to the stream.";
     out << nl << "func write(_ v: " << name << ")" << sb;
     for (const auto& member : members)
     {
-        writeMarshalUnmarshalCode(out, member->type(), p, "v." + fixIdent(member->name()), true);
+        writeMarshalUnmarshalCode(out, member->type(), p, "v." + member->mappedName(), true);
     }
     out << eb;
 
     out << sp;
-    out << nl << "/// Write an optional `" << name << "?` structured value to the stream.";
+    out << nl << "/// Write an optional `" << docName << "?` structured value to the stream.";
     out << nl << "///";
     out << nl << "/// - Parameter tag: The numeric tag associated with the value.";
     out << nl << "/// - Parameter value: The value to write to the stream.";
@@ -649,13 +644,14 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
 {
     const string swiftModule = getSwiftModule(getTopLevelModule(p));
     const string name = getRelativeTypeString(p, swiftModule);
+    const string unescapedName = removeEscaping(name);
 
     const TypePtr type = p->type();
-    BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(p->type());
+    BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
 
     out << sp;
     writeDocSummary(out, p);
-    out << nl << "public typealias " << fixIdent(name) << " = ";
+    out << nl << "public typealias " << name << " = ";
 
     if (builtin && builtin->kind() == Builtin::KindByte)
     {
@@ -663,7 +659,7 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     }
     else
     {
-        out << "[" << typeToString(p->type(), p, false) << "]";
+        out << "[" << typeToString(type, p, false) << "]";
     }
 
     if (builtin && builtin->kind() <= Builtin::KindString)
@@ -677,23 +673,23 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     const string optionalFormat = getOptionalFormat(p);
 
     out << sp;
-    out << nl << "/// Helper class to read and write `" << fixIdent(name) << "` sequence values from";
+    out << nl << "/// Helper class to read and write `" << unescapedName << "` sequence values from";
     out << nl << "/// `Ice.InputStream` and `Ice.OutputStream`.";
-    out << nl << "public struct " << name << "Helper";
+    out << nl << "public struct " << unescapedName << "Helper";
     out << sb;
 
-    out << nl << "/// Read a `" << fixIdent(name) << "` sequence from the stream.";
+    out << nl << "/// Read a `" << unescapedName << "` sequence from the stream.";
     out << nl << "///";
     out << nl << "/// - Parameter istr: The stream to read from.";
     out << nl << "///";
     out << nl << "/// - Returns: The sequence read from the stream.";
-    out << nl << "public static func read(from istr: " << istr << ") throws -> " << fixIdent(name);
+    out << nl << "public static func read(from istr: " << istr << ") throws -> " << name;
     out << sb;
     out << nl << "let sz = try istr.readAndCheckSeqSize(minSize: " << p->type()->minWireSize() << ")";
 
     if (type->isClassType())
     {
-        out << nl << "var v = " << fixIdent(name) << "(repeating: nil, count: sz)";
+        out << nl << "var v = " << name << "(repeating: nil, count: sz)";
         out << nl << "for i in 0 ..< sz";
         out << sb;
         out << nl << "try Swift.withUnsafeMutablePointer(to: &v[i])";
@@ -705,7 +701,7 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     }
     else
     {
-        out << nl << "var v = " << fixIdent(name) << "()";
+        out << nl << "var v = " << name << "()";
         out << nl << "v.reserveCapacity(sz)";
         out << nl << "for _ in 0 ..< sz";
         out << sb;
@@ -718,14 +714,13 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     out << eb;
 
     out << sp;
-    out << nl << "/// Read an optional `" << fixIdent(name) << "?` sequence from the stream.";
+    out << nl << "/// Read an optional `" << unescapedName << "?` sequence from the stream.";
     out << nl << "///";
     out << nl << "/// - Parameter istr: The stream to read from.";
     out << nl << "/// - Parameter tag: The numeric tag associated with the value.";
     out << nl << "///";
     out << nl << "/// - Returns: The sequence read from the stream.";
-    out << nl << "public static func read(from istr: " << istr << ", tag: Swift.Int32) throws -> " << fixIdent(name)
-        << "?";
+    out << nl << "public static func read(from istr: " << istr << ", tag: Swift.Int32) throws -> " << name << "?";
     out << sb;
     out << nl << "guard try istr.readOptional(tag: tag, expectedFormat: " << optionalFormat << ") else";
     out << sb;
@@ -743,11 +738,11 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     out << eb;
 
     out << sp;
-    out << nl << "/// Write a `" << fixIdent(name) << "` sequence to the stream.";
+    out << nl << "/// Write a `" << unescapedName << "` sequence to the stream.";
     out << nl << "///";
     out << nl << "/// - Parameter ostr: The stream to write to.";
     out << nl << "/// - Parameter value: The sequence value to write to the stream.";
-    out << nl << "public static func write(to ostr: " << ostr << ", value v: " << fixIdent(name) << ")";
+    out << nl << "public static func write(to ostr: " << ostr << ", value v: " << name << ")";
     out << sb;
     out << nl << "ostr.write(size: v.count)";
     out << nl << "for item in v";
@@ -757,14 +752,13 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     out << eb;
 
     out << sp;
-    out << nl << "/// Write an optional `" << fixIdent(name) << "?` sequence to the stream.";
+    out << nl << "/// Write an optional `" << unescapedName << "?` sequence to the stream.";
     out << nl << "///";
     out << nl << "/// - Parameters:";
     out << nl << "///   - ostr: The stream to write to.";
     out << nl << "///   - tag: The numeric tag associated with the value.";
     out << nl << "///   - value: The sequence value to write to the stream.";
-    out << nl << "public static func write(to ostr: " << ostr << ",  tag: Swift.Int32, value v: " << fixIdent(name)
-        << "?)";
+    out << nl << "public static func write(to ostr: " << ostr << ",  tag: Swift.Int32, value v: " << name << "?)";
     out << sb;
     out << nl << "guard let val = v else";
     out << sb;
@@ -804,12 +798,14 @@ Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
 {
     const string swiftModule = getSwiftModule(getTopLevelModule(p));
     const string name = getRelativeTypeString(p, swiftModule);
+    const string unescapedName = removeEscaping(name);
 
     const string keyType = typeToString(p->keyType(), p, false);
     const string valueType = typeToString(p->valueType(), p, false);
+
     out << sp;
     writeDocSummary(out, p);
-    out << nl << "public typealias " << fixIdent(name) << " = [" << keyType << ": " << valueType << "]";
+    out << nl << "public typealias " << name << " = [" << keyType << ": " << valueType << "]";
 
     const string ostr = getUnqualified("Ice.OutputStream", swiftModule);
     const string istr = getUnqualified("Ice.InputStream", swiftModule);
@@ -819,20 +815,20 @@ Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     const size_t minWireSize = p->keyType()->minWireSize() + p->valueType()->minWireSize();
 
     out << sp;
-    out << nl << "/// Helper class to read and write `" << fixIdent(name) << "` dictionary values from";
+    out << nl << "/// Helper class to read and write `" << unescapedName << "` dictionary values from";
     out << nl << "/// `Ice.InputStream` and `Ice.OutputStream`.";
-    out << nl << "public struct " << name << "Helper";
+    out << nl << "public struct " << unescapedName << "Helper";
     out << sb;
 
-    out << nl << "/// Read a `" << fixIdent(name) << "` dictionary from the stream.";
+    out << nl << "/// Read a `" << unescapedName << "` dictionary from the stream.";
     out << nl << "///";
     out << nl << "/// - Parameter istr: The stream to read from.";
     out << nl << "///";
     out << nl << "/// - Returns: The dictionary read from the stream.";
-    out << nl << "public static func read(from istr: " << istr << ") throws -> " << fixIdent(name);
+    out << nl << "public static func read(from istr: " << istr << ") throws -> " << name;
     out << sb;
     out << nl << "let sz = try Swift.Int(istr.readSize())";
-    out << nl << "var v = " << fixIdent(name) << "()";
+    out << nl << "var v = " << name << "()";
     if (p->valueType()->isClassType())
     {
         out << nl << "let e = " << getUnqualified("Ice.DictEntryArray", swiftModule) << "<" << keyType << ", "
@@ -874,14 +870,13 @@ Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     out << eb;
 
     out << sp;
-    out << nl << "/// Read an optional `" << fixIdent(name) << "?` dictionary from the stream.";
+    out << nl << "/// Read an optional `" << unescapedName << "?` dictionary from the stream.";
     out << nl << "///";
     out << nl << "/// - Parameter istr: The stream to read from.";
     out << nl << "/// - Parameter tag: The numeric tag associated with the value.";
     out << nl << "///";
     out << nl << "/// - Returns: The dictionary read from the stream.";
-    out << nl << "public static func read(from istr: " << istr << ", tag: Swift.Int32) throws -> " << fixIdent(name)
-        << "?";
+    out << nl << "public static func read(from istr: " << istr << ", tag: Swift.Int32) throws -> " << name << "?";
     out << sb;
     out << nl << "guard try istr.readOptional(tag: tag, expectedFormat: " << optionalFormat << ") else";
     out << sb;
@@ -899,11 +894,11 @@ Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     out << eb;
 
     out << sp;
-    out << nl << "/// Write a `" << fixIdent(name) << "` dictionary to the stream.";
+    out << nl << "/// Write a `" << unescapedName << "` dictionary to the stream.";
     out << nl << "///";
     out << nl << "/// - Parameter ostr: The stream to write to.";
     out << nl << "/// - Parameter value: The dictionary value to write to the stream.";
-    out << nl << "public static func write(to ostr: " << ostr << ", value v: " << fixIdent(name) << ")";
+    out << nl << "public static func write(to ostr: " << ostr << ", value v: " << name << ")";
     out << sb;
     out << nl << "ostr.write(size: v.count)";
     out << nl << "for (key, value) in v";
@@ -914,14 +909,13 @@ Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     out << eb;
 
     out << sp;
-    out << nl << "/// Write an optional `" << fixIdent(name) << "?` dictionary to the stream.";
+    out << nl << "/// Write an optional `" << unescapedName << "?` dictionary to the stream.";
     out << nl << "///";
     out << nl << "/// - Parameters:";
     out << nl << "///   - ostr: The stream to write to.";
     out << nl << "///   - tag: The numeric tag associated with the value.";
     out << nl << "///   - value: The dictionary value to write to the stream.";
-    out << nl << "public static func write(to ostr: " << ostr << ", tag: Swift.Int32, value v: " << fixIdent(name)
-        << "?)";
+    out << nl << "public static func write(to ostr: " << ostr << ", tag: Swift.Int32, value v: " << name << "?)";
     out << sb;
     out << nl << "guard let val = v else";
     out << sb;
@@ -952,7 +946,8 @@ void
 Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 {
     const string swiftModule = getSwiftModule(getTopLevelModule(p));
-    const string name = fixIdent(getRelativeTypeString(p, swiftModule));
+    const string name = getRelativeTypeString(p, swiftModule);
+    const string docName = removeEscaping(name);
     const EnumeratorList enumerators = p->enumerators();
     const string enumType = p->maxValue() <= 0xFF ? "Swift.UInt8" : "Swift.Int32";
     const string optionalFormat = getOptionalFormat(p);
@@ -966,18 +961,18 @@ Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     for (const auto& enumerator : enumerators)
     {
         writeDocSummary(out, enumerator);
-        out << nl << "case " << fixIdent(enumerator->name()) << " = " << enumerator->value();
+        out << nl << "case " << enumerator->mappedName() << " = " << enumerator->value();
     }
 
     out << nl << "public init()";
     out << sb;
-    out << nl << "self = ." << fixIdent((*enumerators.begin())->name());
+    out << nl << "self = ." << (*enumerators.begin())->mappedName();
     out << eb;
 
     out << eb;
 
     out << sp;
-    out << nl << "/// An `Ice.InputStream` extension to read `" << name << "` enumerated values from the stream.";
+    out << nl << "/// An `Ice.InputStream` extension to read `" << docName << "` enumerated values from the stream.";
     out << nl << "public extension " << getUnqualified("Ice.InputStream", swiftModule);
     out << sb;
 
@@ -1013,7 +1008,7 @@ Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     out << eb;
 
     out << sp;
-    out << nl << "/// An `Ice.OutputStream` extension to write `" << name << "` enumerated values to the stream.";
+    out << nl << "/// An `Ice.OutputStream` extension to write `" << docName << "` enumerated values to the stream.";
     out << nl << "public extension " << getUnqualified("Ice.OutputStream", swiftModule);
     out << sb;
 
@@ -1046,12 +1041,11 @@ Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 void
 Gen::TypesVisitor::visitConst(const ConstPtr& p)
 {
-    const string name = fixIdent(p->name());
     const TypePtr type = p->type();
     const string swiftModule = getSwiftModule(getTopLevelModule(p));
 
     writeDocSummary(out, p);
-    out << nl << "public let " << name << ": " << typeToString(type, p) << " = ";
+    out << nl << "public let " << p->mappedName() << ": " << typeToString(type, p) << " = ";
     writeConstantValue(out, type, p->valueType(), p->value(), swiftModule);
     out << nl;
 }
@@ -1062,10 +1056,10 @@ Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     InterfaceList bases = p->bases();
 
     const string swiftModule = getSwiftModule(getTopLevelModule(p));
-    const string name = getRelativeTypeString(p, swiftModule);
-    const string traits = name + "Traits";
-    const string prx = name + "Prx";
-    const string prxI = name + "PrxI";
+    const string unescapedName = removeEscaping(getRelativeTypeString(p, swiftModule));
+    const string traits = unescapedName + "Traits";
+    const string prx = unescapedName + "Prx";
+    const string prxI = unescapedName + "PrxI";
 
     // SliceTraits struct
     StringList allIds = p->ids();
@@ -1083,7 +1077,7 @@ Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     ids << "]";
 
     out << sp;
-    out << nl << "/// Traits for Slice interface `" << name << "`.";
+    out << nl << "/// Traits for Slice interface '" << p->name() << "'.";
     out << nl << "public struct " << traits << ": " << getUnqualified("Ice.SliceTraits", swiftModule);
     out << sb;
     out << nl << "public static let staticIds = " << ids.str();
@@ -1102,7 +1096,7 @@ Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     {
         for (auto i = bases.begin(); i != bases.end();)
         {
-            out << " " << getRelativeTypeString(*i, swiftModule) << "Prx";
+            out << " " << removeEscaping(getRelativeTypeString(*i, swiftModule)) << "Prx";
             if (++i != bases.end())
             {
                 out << ",";
@@ -1270,16 +1264,18 @@ bool
 Gen::ServantVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     const string swiftModule = getSwiftModule(getTopLevelModule(p));
-    const string disp = fixIdent(getRelativeTypeString(p, swiftModule) + "Disp");
-    const string traits = fixIdent(getRelativeTypeString(p, swiftModule) + "Traits");
-    const string servant = fixIdent(getRelativeTypeString(p, swiftModule));
+
+    const string servant = getRelativeTypeString(p, swiftModule);
+    const string unescapedName = removeEscaping(servant);
+    const string disp = unescapedName + "Disp";
+    const string traits = unescapedName + "Traits");
 
     //
     // Disp struct
     //
     out << sp;
     out << sp;
-    out << nl << "/// Dispatcher for `" << servant << "` servants.";
+    out << nl << "/// Dispatcher for `" << unescapedName << "` servants.";
     out << nl << "public struct " << disp << ": Ice.Dispatcher";
     out << sb;
     out << nl << "public let servant: " << servant;
@@ -1295,17 +1291,17 @@ Gen::ServantVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     const OperationList allOps = p->allOperations();
 
-    StringList allOpNames;
+    list<pair<string, string>> allOpNames;
     transform(
         allOps.begin(),
         allOps.end(),
         back_inserter(allOpNames),
-        [](const ContainedPtr& it) { return it->name(); });
+        [](const ContainedPtr& it) { return std::make_pair(it->name(), it->mappedName()); });
 
-    allOpNames.emplace_back("ice_id");
-    allOpNames.emplace_back("ice_ids");
-    allOpNames.emplace_back("ice_isA");
-    allOpNames.emplace_back("ice_ping");
+    allOpNames.emplace_back("ice_id", "ice_id");
+    allOpNames.emplace_back("ice_ids", "ice_ids");
+    allOpNames.emplace_back("ice_isA", "ice_isA");
+    allOpNames.emplace_back("ice_ping", "ice_ping");
 
     out << sp;
     out << nl;
@@ -1315,18 +1311,19 @@ Gen::ServantVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     out << "switch request.current.operation";
     out << sb;
     out.dec(); // to align case with switch
-    for (const auto& opName : allOpNames)
+    for (const auto& [sliceName, mappedName] : allOpNames)
     {
-        out << nl << "case \"" << opName << "\":";
+        const string mappedDispatchName = "_iceD_" + removeEscaping(mappedName);
+        out << nl << "case \"" << sliceName << "\":";
         out.inc();
-        if (opName == "ice_id" || opName == "ice_ids" || opName == "ice_isA" || opName == "ice_ping")
+        if (sliceName == "ice_id" || sliceName == "ice_ids" || sliceName == "ice_isA" || sliceName == "ice_ping")
         {
-            out << nl << "try await (servant as? Ice.Object ?? " << disp << ".defaultObject)._iceD_" << opName
+            out << nl << "try await (servant as? Ice.Object ?? " << disp << ".defaultObject)." << mappedDispatchName
                 << "(request)";
         }
         else
         {
-            out << nl << "try await servant._iceD_" << opName << "(request)";
+            out << nl << "try await servant." << mappedDispatchName << "(request)";
         }
 
         out.dec();
@@ -1347,7 +1344,7 @@ Gen::ServantVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     StringList baseNames;
     for (const auto& base : bases)
     {
-        baseNames.push_back(fixIdent(getRelativeTypeString(base, swiftModule)));
+        baseNames.push_back(getRelativeTypeString(base, swiftModule));
     }
 
     out << sp;
@@ -1385,12 +1382,12 @@ Gen::ServantVisitor::visitOperation(const OperationPtr& op)
 
     out << sp;
     writeOpDocSummary(out, op, true);
-    out << nl << "func " << fixIdent(op->name());
+    out << nl << "func " << op->mappedName();
     out << spar;
     for (const auto& param : op->inParameters())
     {
         const string typeString = typeToString(param->type(), op, param->optional());
-        out << param->name() + ": " + typeString;
+        out << param->mappedName() + ": " + typeString;
     }
     out << ("current: " + getUnqualified("Ice.Current", swiftModule));
     out << epar;
@@ -1408,11 +1405,10 @@ bool
 Gen::ServantExtVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     const string swiftModule = getSwiftModule(getTopLevelModule(p));
-    const string name = getRelativeTypeString(p, swiftModule);
 
     out << sp;
     writeServantDocSummary(out, p, swiftModule);
-    out << nl << "extension " << fixIdent(name);
+    out << nl << "extension " << getRelativeTypeString(p, swiftModule);
 
     out << sb;
     return true;

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -266,6 +266,7 @@ Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     }
 
     // For each Value class we generate an extension method in ClassResolver.
+    // This function name is based off of the Slice type ID, not the mapped name.
     ostringstream factory;
     factory << prefix;
     vector<string> parts = splitScopedName(p->scoped());
@@ -391,6 +392,7 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     const string prefix = getClassResolverPrefix(p->unit());
 
     // For each UserException class we generate an extension in ClassResolver.
+    // This function name is based off of the Slice type ID, not the mapped name.
     ostringstream factory;
     factory << prefix;
     vector<string> parts = splitScopedName(p->scoped());

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -507,6 +507,25 @@ SwiftGenerator::validateMetadata(const UnitPtr& u)
     };
     knownMetadata.emplace("swift:class-resolver-prefix", classResolverPrefixInfo);
 
+    // "swift:identifier"
+    MetadataInfo identifierInfo = {
+        .validOn =
+            {typeid(InterfaceDecl),
+             typeid(Operation),
+             typeid(ClassDecl),
+             typeid(Slice::Exception),
+             typeid(Struct),
+             typeid(Sequence),
+             typeid(Dictionary),
+             typeid(Enum),
+             typeid(Enumerator),
+             typeid(Const),
+             typeid(Parameter),
+             typeid(DataMember)},
+        .acceptedArgumentKind = MetadataArgumentKind::SingleArgument,
+    };
+    knownMetadata.emplace("swift:identifier", std::move(identifierInfo));
+
     // "swift:module"
     MetadataInfo moduleInfo = {
         .validOn = {typeid(Module)},

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -1636,8 +1636,10 @@ SwiftGenerator::writeDispatchOperation(::IceInternal::Output& out, const Operati
     out << spar;
     for (const auto& param : inParams)
     {
-        const string paramName = param->mappedName();
-        out << (paramName + ": iceP_" + removeEscaping(paramName));
+        // The swift compiler reports an error if you escape an argument label when calling a function.
+        // So we always need to remove escaping here.
+        const string paramName = removeEscaping(param->mappedName());
+        out << (paramName + ": iceP_" + paramName);
     }
     out << "current: request.current";
     out << epar;

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -1369,8 +1369,9 @@ SwiftGenerator::writeMarshalAsyncOutParams(::IceInternal::Output& out, const Ope
     out << nl << "let " << operationReturnDeclaration(op) << " = value";
     for (const auto& param : op->sortedReturnAndOutParameters("returnValue"))
     {
-        const string paramName = "iceP_" + removeEscaping(param->mappedName());
-        writeMarshalUnmarshalCode(out, param->type(), op, paramName, true, param->tag());
+        // 'isOutParam' fails for return types, and for return types, we don't want the 'mappedName'.
+        const string paramName = (param->isOutParam() ? param->mappedName() : param->name());
+        writeMarshalUnmarshalCode(out, param->type(), op, "iceP_" + removeEscaping(paramName), true, param->tag());
     }
     if (op->returnsClasses())
     {
@@ -1397,7 +1398,8 @@ SwiftGenerator::writeUnmarshalOutParams(::IceInternal::Output& out, const Operat
     {
         const TypePtr paramType = param->type();
         const string typeString = typeToString(paramType, op, param->optional());
-        const string paramName = "iceP_" + removeEscaping(param->mappedName());
+        // 'isOutParam' fails for return types, and for return types, we don't want the 'mappedName'.
+        const string paramName = "iceP_" + removeEscaping((param->isOutParam() ? param->mappedName() : param->name()));
         string paramString;
         if (paramType->isClassType())
         {

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -394,8 +394,7 @@ SwiftGenerator::writeProxyDocSummary(IceInternal::Output& out, const InterfaceDe
         return;
     }
 
-    const string name = getRelativeTypeString(p, swiftModule);
-    const string prx = removeEscaping(std::move(name)) + "Prx";
+    const string prx = removeEscaping(getRelativeTypeString(p, swiftModule)) + "Prx";
 
     StringList docOverview = doc->overview();
     if (docOverview.empty())

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -54,6 +54,9 @@ namespace Slice
 
         std::string typeToString(const TypePtr&, const ContainedPtr&, bool = false);
 
+        /// Removes any Swift escaping from the provided identifier (any leading or trailing backticks will be removed).
+        static std::string removeEscaping(std::string ident);
+
         std::string getUnqualified(const std::string&, const std::string&);
         std::string modeToString(Operation::Mode);
         std::string getOptionalFormat(const TypePtr&);

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -17,8 +17,6 @@ namespace Slice
     std::string getSwiftModule(const ModulePtr&);
     ModulePtr getTopLevelModule(const ContainedPtr&);
 
-    std::string fixIdent(const std::string&);
-
     class SwiftGenerator
     {
     public:

--- a/scripts/Controller.ice
+++ b/scripts/Controller.ice
@@ -8,6 +8,7 @@ sequence<string> StringSeq;
 
 class Config
 {
+    ["swift:identifier:transportProtocol"]
     optional(1) string protocol;
     optional(2) bool mx;
     optional(3) bool serialize;
@@ -19,6 +20,7 @@ class Config
 
 class OptionOverrides
 {
+    ["swift:identifier:transportProtocol"]
     optional(1) StringSeq protocol;
     optional(2) BoolSeq mx;
     optional(3) BoolSeq serialize;
@@ -59,7 +61,7 @@ interface Controller
 
     StringSeq getTestSuites(string mapping);
 
-    string getHost(string protocol, bool ipv6);
+    string getHost(["swift:identifier:transportProtocol"] string protocol, bool ipv6);
 }
 
 exception ProcessFailedException
@@ -83,7 +85,7 @@ interface ProcessController
     Process* start(string testsuite, string exe, StringSeq args)
         throws ProcessFailedException;
 
-    string getHost(string protocol, bool ipv6);
+    string getHost(["swift:identifier:transportProtocol"] string protocol, bool ipv6);
 }
 
 interface BrowserProcessController extends ProcessController

--- a/slice/Glacier2/Session.ice
+++ b/slice/Glacier2/Session.ice
@@ -54,6 +54,7 @@ module Glacier2
 
         /// Returns a sequence of strings describing the constraints in this set.
         /// @return The sequence of strings for this set.
+        ["swift:identifier:`get`"]
         idempotent Ice::StringSeq get();
     }
 
@@ -74,6 +75,7 @@ module Glacier2
 
         /// Returns a sequence of identities describing the constraints in this set.
         /// @return The sequence of Ice identities for this set.
+        ["swift:identifier:`get`"]
         idempotent Ice::IdentitySeq get();
     }
 

--- a/slice/Ice/RemoteLogger.ice
+++ b/slice/Ice/RemoteLogger.ice
@@ -64,6 +64,7 @@ module Ice
         /// init is called by attachRemoteLogger when a RemoteLogger proxy is attached.
         /// @param prefix The prefix of the associated local Logger.
         /// @param logMessages Old log messages generated before "now".
+        ["swift:identifier:initialize"]
         void init(string prefix, LogMessageSeq logMessages);
 
         /// Log a LogMessage. Note that log may be called by LoggerAdmin before init.

--- a/swift/test/Ice/admin/AllTests.swift
+++ b/swift/test/Ice/admin/AllTests.swift
@@ -16,7 +16,7 @@ class RemoteLoggerI: Ice.RemoteLogger {
         _helper = helper
     }
 
-    func `init`(prefix: String, logMessages: [Ice.LogMessage], current _: Ice.Current) async throws {
+    func initialize(prefix: String, logMessages: [Ice.LogMessage], current _: Ice.Current) async throws {
         withLock(&_lock) {
             _prefix = prefix
             _initMessages += logMessages

--- a/swift/test/Slice/escape/Clash.ice
+++ b/swift/test/Slice/escape/Clash.ice
@@ -37,7 +37,6 @@ class Cls
     string istr;
     string ostr;
     string inS;
-    string in;
     string proxy;
 }
 

--- a/swift/test/Slice/escape/Client.swift
+++ b/swift/test/Slice/escape/Client.swift
@@ -4,7 +4,7 @@ import Ice
 import TestCommon
 
 class BreakI: `break` {
-    func `case`(catch _: Int32, current _: Current) async throws -> Int32 {
+    func `case`(class _: Int32, current _: Current) async throws -> Int32 {
         return 0
     }
 }
@@ -12,7 +12,7 @@ class BreakI: `break` {
 class DoI: `do` {
     func `public`(current _: Current) async throws {}
 
-    func `case`(catch _: Int32, current _: Current) async throws -> Int32 {
+    func `case`(class _: Int32, current _: Current) async throws -> Int32 {
         return 0
     }
 

--- a/swift/test/Slice/escape/Client.swift
+++ b/swift/test/Slice/escape/Client.swift
@@ -9,15 +9,26 @@ class BreakI: `break` {
     }
 }
 
-class FuncI: `func` {
-    func `public`(current _: Current) async throws {}
-}
-
 class DoI: `do` {
     func `public`(current _: Current) async throws {}
 
     func `case`(catch _: Int32, current _: Current) async throws -> Int32 {
         return 0
+    }
+
+    func goto(
+        `if`: `continue`,
+        d: `guard`,
+        `private`: `switch`?,
+        mutable: doPrx?,
+        foo: breakPrx?,
+        not: `switch`?,
+        or: Swift.Int64,
+        current: Ice.Current
+    ) async throws -> `guard` {
+        var g = `guard`()
+        g.default = 79
+        return g
     }
 }
 
@@ -31,8 +42,7 @@ public class Client: TestHelperI {
             key: "TestAdapter.Endpoints", value: getTestEndpoint(num: 0))
         let adapter = try communicator.createObjectAdapter("TestAdapter")
         try adapter.add(servant: breakDisp(BreakI()), id: Ice.stringToIdentity("test"))
-        try adapter.add(servant: funcDisp(FuncI()), id: Ice.stringToIdentity("test1"))
-        try adapter.add(servant: doDisp(DoI()), id: Ice.stringToIdentity("test2"))
+        try adapter.add(servant: doDisp(DoI()), id: Ice.stringToIdentity("test1"))
         try adapter.activate()
 
         let out = getWriter()
@@ -43,38 +53,29 @@ public class Client: TestHelperI {
         out.writeLine("ok")
 
         out.write("testing types... ")
-        let e: `continue` = .let
+        let e: `continue` = .myFirstEnumerator
 
         var g = `guard`()
         g.default = 0
 
-        var d = `defer`()
-        d.else = "else"
-
         let c = `switch`()
-        c.if = 0
-        c.export = nil
-        c.volatile = 0
-        try test(c.if == 0)
+        c.`remappedExport` = nil
+        c.remappedVolatile = 0
+        try test(c.remappedVolatile == 0)
 
         let ss = `fileprivate`(repeating: g, count: 1)
         let dd: `for` = ["g": g]
         try test(dd.count == ss.count)
 
         do {
-            if e == .let {
+            if e == .myFirstEnumerator {
                 throw `return`(Int32: 0)
             }
         } catch {
             // Expected
         }
 
-        try test(`is` == 0)
-        try test(`throw` == 0)
         try test(`typealias` == 0)
-        try test(`internal` == 0)
-        try test(`while` == 0)
-        try test(`import` == 0)
 
         out.writeLine("ok")
     }

--- a/swift/test/Slice/escape/Key.ice
+++ b/swift/test/Slice/escape/Key.ice
@@ -20,7 +20,7 @@ module and
     interface break
     {
         ["amd"] ["swift:identifier:`case`"] void case(
-            ["swift:identifier:`catch`"] int catch,
+            ["swift:identifier:`class`"] int \class,
             out ["swift:identifier:`try`"] int try
         );
     }

--- a/swift/test/Slice/escape/Key.ice
+++ b/swift/test/Slice/escape/Key.ice
@@ -2,71 +2,73 @@
 
 module and
 {
+    ["swift:identifier:`continue`"]
+    enum continue
+    {
+        ["swift:identifier:myFirstEnumerator"] let,
+        ["swift:identifier:mySecondEnumerator"] var
+    }
 
-enum continue
-{
-    let,
-    var
-}
+    ["swift:identifier:`guard`"]
+    struct guard
+    {
+        ["swift:identifier:`default`"]
+        int default;
+    }
 
-struct guard
-{
-    int default;
-}
+    ["swift:identifier:`break`"]
+    interface break
+    {
+        ["amd"] ["swift:identifier:`case`"] void case(
+            ["swift:identifier:`catch`"] int catch,
+            out ["swift:identifier:`try`"] int try
+        );
+    }
 
-struct defer
-{
-    string else;
-}
+    ["swift:identifier:`switch`"]
+    class switch
+    {
+        ["swift:identifier:`remappedExport`"] break* export;
+        ["swift:identifier:remappedVolatile"] int volatile;
+    }
 
-interface break
-{
-    ["amd"] void case(int catch, out int try);
-}
+    ["swift:identifier:`return`"]
+    exception return
+    {
+        // It should be fine to use built-in types as identifiers.
+        int Int32;
+    }
 
-interface func
-{
-    void public();
-}
+    ["swift:identifier:`as`"]
+    exception as extends return
+    {
+        ["swift:identifier:`switch`"]
+        int switch;
+    }
 
-class switch
-{
-    int if;
-    func* export;
-    int volatile;
-}
+    ["swift:identifier:`do`"]
+    interface do extends break
+    {
+        ["swift:identifier:`public`"]
+        void public();
 
-interface do extends func, break
-{
-}
+        guard goto(
+            ["swift:identifier:`if`"] continue if,
+            guard d,
+            ["swift:identifier:`private`"] switch private,
+            do* mutable,
+            ["swift:identifier:foo"] break* namespace,
+            switch not,
+            long or
+        ) throws return, as;
+    }
 
-sequence<guard> fileprivate;
+    ["swift:identifier:`fileprivate`"]
+    sequence<guard> fileprivate;
 
-dictionary<string,guard> for;
+    ["swift:identifier:`for`"]
+    dictionary<string, guard> for;
 
-exception return
-{
-    int Int32;
-}
-
-exception as extends return
-{
-    int static; int switch;
-}
-
-interface friend
-{
-    guard goto(continue if, guard d, defer inline, switch private, do* mutable, break* namespace,
-               func* new, switch not, do* operator, int or, int protected, int public, int register)
-        throws return, as;
-}
-
-const int is = 0;
-const int self = 0;
-const int throw = 0;
-const int typealias = 0;
-const int internal = 0;
-const int while = 0;
-const int import = 0;
-
+    ["swift:identifier:`typealias`"]
+    const int typealias = 0;
 }

--- a/swift/test/ios/TestDriverApp/ControllerI.swift
+++ b/swift/test/ios/TestDriverApp/ControllerI.swift
@@ -79,7 +79,7 @@ class ProcessControllerI: CommonProcessController {
     }
 
     func getHost(
-        protocol _: String,
+        transportProtocol _: String,
         ipv6: Bool,
         current _: Ice.Current
     ) throws -> String {


### PR DESCRIPTION
This PR adds support for `swift:identifier`, just like we did in the other languages so far.
However, there are some caveats to Swift.

1) Most languages will happily tolerate 'over-escaping'. But there are some contexts in which the Swift compiler will error out if you use escaping. Mostly around argument labels, and how you call functions. In these contexts we always need to remove escaping.

2) The preferred way to escape identifiers in Swift is to wrap it in backticks: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/lexicalstructure/#Identifiers. However, this causes problems in the places where we want to add prefixes like `iceP_` or suffixes like `Prx`. We love adding prefixes and suffixes, so there's lots of places where we need to strip escaping from for this to work.

3) Swift does not want escaped identifiers in doc-comments, in fact, in doc-comments, wrapping something in backticks doesn't escape it, but instead tries to generate a doc-link. So, whenever we're writing a name into a doc-comment, we also need to be stripping escaping off the identifier.

So, I added a `removeEscaping` method which checks for and removes this escaping when necessary.
And we have to call it in lots of places.