### PR TITLE
Update ReplyStatus range

### DIFF
--- a/CHANGELOG-3.8.md
+++ b/CHANGELOG-3.8.md
@@ -132,7 +132,7 @@ registered with the Ice Locator (typically the IceGrid registry).
   - Removed the `refreshPublishedEndpoints` operation on `ObjectAdapter`.
 
 - The local exceptions that can be marshaled now have a common base class (`DispatchException`), and are no longer
-  limited to 6 exceptions. The reply status of a dispatch exception can have any value between 2 and 126. A dispatch
+  limited to 6 exceptions. The reply status of a dispatch exception can have any value between 2 and 255. A dispatch
   exception with reply status >= 5 is marshaled as its reply status (one byte) followed by its message (a Slice-encoded
   string).
 
@@ -146,7 +146,6 @@ classDiagram
         FacetNotExist
         OperationNotExist
         ...
-        ... = 126
     }
     LocalException <|-- DispatchException
     LocalException: +string message
@@ -195,7 +194,7 @@ classDiagram
   | StringConversionException           | MarshalException (base)    |          |
   | UnexpectedObjectException           | MarshalException (base)    |          |
   | UnknownMessageException             | ProtocolException (base)   |          |
-  | UnknownReplyStatusException         | MarshalException           | For reply status > 126 |
+  | UnknownReplyStatusException         | None: all values are now valid | |
   | UnmarshalOutOfBoundsException       | MarshalException (base)    |          |
   | UnsupportedEncodingException        | MarshalException           |          |
   | UnsupportedProtocolException        | MarshalException, FeatureNotSupportedException | |

--- a/cpp/src/Ice/OutgoingAsync.cpp
+++ b/cpp/src/Ice/OutgoingAsync.cpp
@@ -875,8 +875,10 @@ OutgoingAsync::response()
 
     try
     {
-        ReplyStatus replyStatus;
-        _is.read(replyStatus); // throws a MarshalException if received byte is out of range.
+        // We can't use the generated code to unmarshal a possibly unknown reply status enumerator.
+        uint8_t replyStatusByte;
+        _is.read(replyStatusByte);
+        ReplyStatus replyStatus{replyStatusByte};
 
         switch (replyStatus)
         {

--- a/cpp/src/Ice/OutgoingResponse.cpp
+++ b/cpp/src/Ice/OutgoingResponse.cpp
@@ -143,7 +143,8 @@ namespace
 
         if (current.requestId != 0 && replyStatus > ReplyStatus::OperationNotExist)
         {
-            ostr.write(replyStatus);
+            // We can't use the generated code to marshal a possibly unknown reply status.
+            ostr.write(static_cast<uint8_t>(replyStatus));
             ostr.write(dispatchExceptionMessage);
         }
 

--- a/cpp/src/Ice/TraceUtil.cpp
+++ b/cpp/src/Ice/TraceUtil.cpp
@@ -221,8 +221,10 @@ printReply(ostream& s, InputStream& stream)
     stream.read(requestId);
     s << "\nrequest id = " << requestId;
 
-    ReplyStatus replyStatus;
-    stream.read(replyStatus);
+    // We can't use the generated code to unmarshal a possibly unknown reply status enumerator.
+    uint8_t replyStatusByte;
+    stream.read(replyStatusByte);
+    ReplyStatus replyStatus{replyStatusByte};
 
     s << "\nreply status = " << replyStatus;
     switch (replyStatus)

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1481,18 +1481,20 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     emitAttributes(p);
     _out << nl << "public enum " << name;
     _out << sb;
-    for (auto en = enumerators.begin(); en != enumerators.end(); ++en)
+    for (const auto& enumerator : enumerators)
     {
-        if (en != enumerators.begin())
+        if (!isFirstElement(enumerator))
         {
             _out << ',';
+            _out << sp;
         }
-        writeDocComment(*en);
-        emitAttributes(*en);
-        _out << nl << (*en)->mappedName();
+
+        writeDocComment(enumerator);
+        emitAttributes(enumerator);
+        _out << nl << enumerator->mappedName();
         if (hasExplicitValues)
         {
-            _out << " = " << (*en)->value();
+            _out << " = " << enumerator->value();
         }
     }
     _out << eb;

--- a/cpp/test/Ice/exceptions/AllTests.cpp
+++ b/cpp/test/Ice/exceptions/AllTests.cpp
@@ -679,7 +679,7 @@ allTests(Test::TestHelper* helper)
 
     try
     {
-        thrower->throwDispatchException(Ice::ReplyStatus::OperationNotExist);
+        thrower->throwDispatchException(static_cast<uint8_t>(Ice::ReplyStatus::OperationNotExist));
         test(false);
     }
     catch (const Ice::OperationNotExistException&) // remapped as expected
@@ -688,7 +688,7 @@ allTests(Test::TestHelper* helper)
 
     try
     {
-        thrower->throwDispatchException(Ice::ReplyStatus::Unauthorized);
+        thrower->throwDispatchException(static_cast<uint8_t>(Ice::ReplyStatus::Unauthorized));
         test(false);
     }
     catch (const Ice::DispatchException& ex)
@@ -698,12 +698,12 @@ allTests(Test::TestHelper* helper)
 
     try
     {
-        thrower.throwDispatchException(Ice::ReplyStatus{111});
+        thrower.throwDispatchException(212);
         test(false);
     }
     catch (const Ice::DispatchException& ex)
     {
-        test(ex.replyStatus() == Ice::ReplyStatus{111});
+        test(ex.replyStatus() == Ice::ReplyStatus{212});
     }
     cout << "ok" << endl;
 
@@ -1115,7 +1115,7 @@ allTests(Test::TestHelper* helper)
 
     cout << "catching dispatch exception with new AMI mapping... " << endl;
     {
-        auto f = thrower->throwDispatchExceptionAsync(Ice::ReplyStatus::OperationNotExist);
+        auto f = thrower->throwDispatchExceptionAsync(static_cast<uint8_t>(Ice::ReplyStatus::OperationNotExist));
         try
         {
             f.get();
@@ -1127,7 +1127,7 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        auto f = thrower->throwDispatchExceptionAsync(Ice::ReplyStatus::Unauthorized);
+        auto f = thrower->throwDispatchExceptionAsync(static_cast<uint8_t>(Ice::ReplyStatus::Unauthorized));
         try
         {
             f.get();
@@ -1140,7 +1140,7 @@ allTests(Test::TestHelper* helper)
     }
 
     {
-        auto f = thrower->throwDispatchExceptionAsync(Ice::ReplyStatus{111});
+        auto f = thrower->throwDispatchExceptionAsync(212);
         try
         {
             f.get();
@@ -1148,7 +1148,7 @@ allTests(Test::TestHelper* helper)
         }
         catch (const Ice::DispatchException& ex)
         {
-            test(ex.replyStatus() == Ice::ReplyStatus{111});
+            test(ex.replyStatus() == Ice::ReplyStatus{212});
         }
     }
     cout << "ok" << endl;

--- a/cpp/test/Ice/exceptions/Test.ice
+++ b/cpp/test/Ice/exceptions/Test.ice
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "Ice/BuiltinSequences.ice"
-#include "Ice/ReplyStatus.ice"
 
 module Test
 {
@@ -72,7 +71,7 @@ module Test
 
         idempotent void throwLocalExceptionIdempotent();
 
-        void throwDispatchException(Ice::ReplyStatus replyStatus);
+        void throwDispatchException(byte replyStatus);
 
         void throwAfterResponse();
         void throwAfterException() throws A;

--- a/cpp/test/Ice/exceptions/TestAMD.ice
+++ b/cpp/test/Ice/exceptions/TestAMD.ice
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "Ice/BuiltinSequences.ice"
-#include "Ice/ReplyStatus.ice"
 
 module Test
 {
@@ -72,7 +71,7 @@ module Test
 
         idempotent void throwLocalExceptionIdempotent();
 
-        void throwDispatchException(Ice::ReplyStatus replyStatus);
+        void throwDispatchException(byte replyStatus);
 
         void throwAfterResponse();
         void throwAfterException() throws A;

--- a/cpp/test/Ice/exceptions/TestAMDI.cpp
+++ b/cpp/test/Ice/exceptions/TestAMDI.cpp
@@ -253,12 +253,12 @@ ThrowerI::throwLocalExceptionIdempotentAsync(function<void()>, function<void(exc
 
 void
 ThrowerI::throwDispatchExceptionAsync(
-    Ice::ReplyStatus replyStatus,
+    uint8_t replyStatus,
     function<void()>,
     function<void(exception_ptr)> error,
     const Ice::Current&)
 {
-    error(make_exception_ptr(Ice::DispatchException{__FILE__, __LINE__, replyStatus}));
+    error(make_exception_ptr(Ice::DispatchException{__FILE__, __LINE__, Ice::ReplyStatus{replyStatus}}));
 }
 
 void

--- a/cpp/test/Ice/exceptions/TestAMDI.h
+++ b/cpp/test/Ice/exceptions/TestAMDI.h
@@ -87,7 +87,7 @@ public:
         const Ice::Current&) override;
 
     void throwDispatchExceptionAsync(
-        Ice::ReplyStatus replyStatus,
+        std::uint8_t replyStatus,
         std::function<void()>,
         std::function<void(std::exception_ptr)>,
         const Ice::Current&) override;

--- a/cpp/test/Ice/exceptions/TestI.cpp
+++ b/cpp/test/Ice/exceptions/TestI.cpp
@@ -130,9 +130,9 @@ ThrowerI::throwLocalExceptionIdempotent(const Ice::Current&)
 }
 
 void
-ThrowerI::throwDispatchException(Ice::ReplyStatus replyStatus, const Ice::Current&)
+ThrowerI::throwDispatchException(uint8_t replyStatus, const Ice::Current&)
 {
-    throw Ice::DispatchException{__FILE__, __LINE__, replyStatus};
+    throw Ice::DispatchException{__FILE__, __LINE__, Ice::ReplyStatus{replyStatus}};
 }
 
 void

--- a/cpp/test/Ice/exceptions/TestI.h
+++ b/cpp/test/Ice/exceptions/TestI.h
@@ -36,7 +36,7 @@ public:
 
     void throwLocalExceptionIdempotent(const Ice::Current&) override;
 
-    void throwDispatchException(Ice::ReplyStatus replyStatus, const Ice::Current&) override;
+    void throwDispatchException(std::uint8_t replyStatus, const Ice::Current&) override;
 
     void throwAfterResponse(const Ice::Current&) override;
     void throwAfterException(const Ice::Current&) override;

--- a/csharp/src/Ice/CurrentExtensions.cs
+++ b/csharp/src/Ice/CurrentExtensions.cs
@@ -214,7 +214,9 @@ public static class CurrentExtensions
                 }
                 else
                 {
-                    ReplyStatusHelper.write(ostr, replyStatus);
+                    // We can't use ReplyStatusHelper to marshal a possibly unknown reply status value.
+                    ostr.writeByte((byte)replyStatus);
+
                     // If the exception is a DispatchException, we keep its message as-is; otherwise, we create a custom
                     // message. This message doesn't include the stack trace.
                     dispatchExceptionMessage ??= $"Dispatch failed with {exceptionId}: {exc.Message}";

--- a/csharp/src/Ice/Internal/OutgoingAsync.cs
+++ b/csharp/src/Ice/Internal/OutgoingAsync.cs
@@ -938,23 +938,17 @@ public class OutgoingAsync : ProxyOutgoingAsyncBase
 
         try
         {
-            // The generated code does not throw any exception, even if the byte we received is > 126.
-            ReplyStatus replyStatus = ReplyStatusHelper.read(is_);
+            // We can't (shouldn't) use the generated code to unmarshal a possibly unknown reply status.
+            var replyStatus = (ReplyStatus)is_.readByte();
 
             switch (replyStatus)
             {
                 case ReplyStatus.Ok:
-                {
                     break;
-                }
+
                 case ReplyStatus.UserException:
-                {
-                    if (observer_ != null)
-                    {
-                        observer_.userException();
-                    }
+                    observer_?.userException();
                     break;
-                }
 
                 case ReplyStatus.ObjectNotExist:
                 case ReplyStatus.FacetNotExist:

--- a/csharp/src/Ice/Internal/TraceUtil.cs
+++ b/csharp/src/Ice/Internal/TraceUtil.cs
@@ -136,7 +136,8 @@ internal sealed class TraceUtil
         int requestId = str.readInt();
         s.Write("\nrequest id = " + requestId);
 
-        ReplyStatus replyStatus = ReplyStatusHelper.read(str);
+        // We can't (shouldn't) use the generated code to unmarshal a possibly unknown reply status.
+        var replyStatus = (ReplyStatus)str.readByte();
         s.Write("\nreply status = ");
         s.Write(replyStatus);
 

--- a/csharp/test/Ice/exceptions/AllTests.cs
+++ b/csharp/test/Ice/exceptions/AllTests.cs
@@ -559,7 +559,7 @@ public class AllTests : global::Test.AllTests
 
         try
         {
-            thrower.throwDispatchException(ReplyStatus.OperationNotExist);
+            thrower.throwDispatchException((byte)ReplyStatus.OperationNotExist);
             test(false);
         }
         catch (OperationNotExistException) // remapped as expected
@@ -568,7 +568,7 @@ public class AllTests : global::Test.AllTests
 
         try
         {
-            thrower.throwDispatchException(ReplyStatus.Unauthorized);
+            thrower.throwDispatchException((byte)ReplyStatus.Unauthorized);
             test(false);
         }
         catch (DispatchException ex) when (ex.replyStatus == ReplyStatus.Unauthorized)
@@ -577,10 +577,10 @@ public class AllTests : global::Test.AllTests
 
         try
         {
-            thrower.throwDispatchException((ReplyStatus)111);
+            thrower.throwDispatchException(212);
             test(false);
         }
-        catch (DispatchException ex) when (ex.replyStatus == (ReplyStatus)111)
+        catch (DispatchException ex) when (ex.replyStatus == (ReplyStatus)212)
         {
         }
         output.WriteLine("ok");
@@ -960,7 +960,7 @@ public class AllTests : global::Test.AllTests
 
         try
         {
-            await thrower.throwDispatchExceptionAsync(ReplyStatus.OperationNotExist);
+            await thrower.throwDispatchExceptionAsync((byte)ReplyStatus.OperationNotExist);
             test(false);
         }
         catch (OperationNotExistException)
@@ -969,7 +969,7 @@ public class AllTests : global::Test.AllTests
 
         try
         {
-            await thrower.throwDispatchExceptionAsync(ReplyStatus.Unauthorized);
+            await thrower.throwDispatchExceptionAsync((byte)ReplyStatus.Unauthorized);
             test(false);
         }
         catch (DispatchException ex) when (ex.replyStatus == ReplyStatus.Unauthorized)
@@ -978,10 +978,10 @@ public class AllTests : global::Test.AllTests
 
         try
         {
-            await thrower.throwDispatchExceptionAsync((ReplyStatus)111);
+            await thrower.throwDispatchExceptionAsync(212);
             test(false);
         }
-        catch (DispatchException ex) when (ex.replyStatus == (ReplyStatus)111)
+        catch (DispatchException ex) when (ex.replyStatus == (ReplyStatus)212)
         {
         }
         output.WriteLine("ok");

--- a/csharp/test/Ice/exceptions/Test.ice
+++ b/csharp/test/Ice/exceptions/Test.ice
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "Ice/BuiltinSequences.ice"
-#include "Ice/ReplyStatus.ice"
 
 ["cs:namespace:Ice.exceptions"]
 module Test
@@ -57,7 +56,7 @@ module Test
 
         idempotent void throwLocalExceptionIdempotent();
 
-        void throwDispatchException(Ice::ReplyStatus replyStatus);
+        void throwDispatchException(byte replyStatus);
 
         void throwAfterResponse();
         void throwAfterException() throws A;

--- a/csharp/test/Ice/exceptions/TestAMD.ice
+++ b/csharp/test/Ice/exceptions/TestAMD.ice
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "Ice/BuiltinSequences.ice"
-#include "Ice/ReplyStatus.ice"
 
 ["cs:namespace:Ice.exceptions.AMD"]
 module Test
@@ -57,7 +56,7 @@ module Test
 
         idempotent void throwLocalExceptionIdempotent();
 
-        void throwDispatchException(Ice::ReplyStatus replyStatus);
+        void throwDispatchException(byte replyStatus);
 
         void throwAfterResponse();
         void throwAfterException() throws A;

--- a/csharp/test/Ice/exceptions/ThrowerAMDI.cs
+++ b/csharp/test/Ice/exceptions/ThrowerAMDI.cs
@@ -88,8 +88,8 @@ public class ThrowerI : Test.ThrowerDisp_
     public override Task
     throwLocalExceptionIdempotentAsync(Current current) => throw new TimeoutException();
 
-    public override Task throwDispatchExceptionAsync(ReplyStatus replyStatus, Current current) =>
-        throw new DispatchException(replyStatus);
+    public override Task throwDispatchExceptionAsync(byte replyStatus, Current current) =>
+        throw new DispatchException((ReplyStatus)replyStatus);
 
     // Only supported with callback based AMD API
     public override Task

--- a/csharp/test/Ice/exceptions/ThrowerI.cs
+++ b/csharp/test/Ice/exceptions/ThrowerI.cs
@@ -128,8 +128,8 @@ public sealed class ThrowerI : Test.ThrowerDisp_
         throw ex;
     }
 
-    public override void throwDispatchException(ReplyStatus replyStatus, Current current) =>
-        throw new DispatchException(replyStatus);
+    public override void throwDispatchException(byte replyStatus, Current current) =>
+        throw new DispatchException((ReplyStatus)replyStatus);
 
     public override void throwAfterResponse(Ice.Current current)
     {

--- a/slice/Ice/ReplyStatus.ice
+++ b/slice/Ice/ReplyStatus.ice
@@ -19,6 +19,8 @@
 module Ice
 {
     /// Represents the status of a reply.
+    /// A reply status can have any value in the range 0..255. Do not use this enum to marshal or unmarshal a reply
+    /// status unless you know its value corresponds to one of the enumerators defined below.
     enum ReplyStatus
     {
         /// The dispatch completed successfully.
@@ -52,10 +54,5 @@ module Ice
 
         /// The caller is not authorized to access the requested resource.
         Unauthorized,
-
-        // Work-around to get an "unchecked" enum in C++, C# and other languages.
-        // 126 is the maximum value encoded on a single byte with the Ice 1.0 encoding - the encoding used when
-        // marshaling reply headers.
-        MaxValue = 126
     }
 }


### PR DESCRIPTION
This PR updates the ReplyStatus range to be 0..255 instead of 0..126.

The 126 limit is (was) due to a constraint with the 1.0 encoding. It assumed we could marshal/unmarshal reply statuses using the generated code... but it is actually doable only in C++ and C#, where native enums are "unchecked". In Java, Swift, Python (...), native enums are checked and the generated code is unusable for unknown enumerators.

As of this PR:
 - we use the generated code only to marshal known reply status enumerators (in C++ and C# for now, eventually in all languages)
 - we don't use the generated code to unmarshal reply status (any byte is ok)
 - in C++ and C#, where the native ReplyStatus is unchecked, we use ReplyStatus to hold the reply status in DispatchException and OutgoingResponse. We won't be able to do that in other languages where the mapped enum is checked.
