### PR TITLE
Remove `...Info` Structs & Minor `OutputUtil` Cleanup

### DIFF
--- a/cpp/src/Ice/OutputUtil.cpp
+++ b/cpp/src/Ice/OutputUtil.cpp
@@ -15,8 +15,6 @@ namespace IceInternal
     EndBlock eb;
     StartPar spar;
     EndPar epar;
-    StartAbrk sabrk;
-    EndAbrk eabrk;
     Separator sp;
 }
 
@@ -303,18 +301,18 @@ IceInternal::Output::eb()
 }
 
 void
-IceInternal::Output::spar(char c)
+IceInternal::Output::spar(string_view s)
 {
     _emptyBlock = false;
-    _out << c;
+    _out << s;
     _par = 0;
 }
 
 void
-IceInternal::Output::epar(char c)
+IceInternal::Output::epar(string_view s)
 {
     _par = -1;
-    _out << c;
+    _out << s;
 }
 
 Output&

--- a/cpp/src/Ice/OutputUtil.h
+++ b/cpp/src/Ice/OutputUtil.h
@@ -89,8 +89,8 @@ namespace IceInternal
         void sb(); // Start a block.
         void eb(); // End a block.
 
-        void spar(char = '('); // Start a paramater list.
-        void epar(char = ')'); // End a paramater list.
+        void spar(std::string_view s = "("); // Start a paramater list.
+        void epar(std::string_view s = ")"); // End a paramater list.
 
     private:
         std::string _blockStart;
@@ -163,24 +163,6 @@ namespace IceInternal
     template<> inline Output& operator<<(Output& o, const EndPar&)
     {
         o.epar();
-        return o;
-    }
-
-    class ICE_API StartAbrk{};
-    extern ICE_API StartAbrk sabrk;
-
-    template<> inline Output& operator<<(Output& o, const StartAbrk&)
-    {
-        o.spar('<');
-        return o;
-    }
-
-    class ICE_API EndAbrk{};
-    extern ICE_API EndAbrk eabrk;
-
-    template<> inline Output& operator<<(Output& o, const EndAbrk&)
-    {
-        o.epar('>');
         return o;
     }
 

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -3318,45 +3318,51 @@ Slice::Operation::outParameters() const
 }
 
 ParameterList
-Slice::Operation::sortedReturnAndOutParameters(const string& returnsName)
+Slice::Operation::returnAndOutParameters(const string& returnsName)
 {
-    bool shouldEscapeReturnsName = false;
+    ParameterList outParams = outParameters();
 
-    // First sort each parameter into either 'required' or 'optional'.
-    ParameterList required, optional;
-    for (const auto& param : outParameters())
-    {
-        if (param->optional())
-        {
-            optional.push_back(param);
-        }
-        else
-        {
-            required.push_back(param);
-        }
-
-        if (param->mappedName() == returnsName)
-        {
-            shouldEscapeReturnsName = true;
-        }
-    }
-
-    // Next, create a dummy parameter for the return type, if it's non-void.
+    // Check if this operation has a non-void return type.
     if (_returnType)
     {
+        // Then check if any of the out parameter's mapped names collide with the return name.
+        bool shouldEscapeReturnsName = false;
+        for (const auto& param : outParams)
+        {
+            if (param->mappedName() == returnsName)
+            {
+                shouldEscapeReturnsName = true;
+            }
+        }
+
+        // Create the dummy return-value parameter.
         const string fixedName = returnsName + (shouldEscapeReturnsName ? "_" : "");
         ParameterPtr returnParam =
             make_shared<Parameter>(shared_from_this(), fixedName, _returnType, false, _returnIsOptional, _returnTag);
         returnParam->setMetadata(getMetadata());
 
-        // And add it to the appropiate list.
-        if (_returnIsOptional)
+        outParams.push_back(returnParam);
+    }
+}
+
+ParameterList
+Slice::Operation::sortedReturnAndOutParameters(const string& returnsName)
+{
+    // We get the return and out parameters, and filter out any optional parameters into a separate 'optional' list.
+    ParameterList required = returnAndOutParameters(returnsName);
+    ParameterList optional;
+
+    // First sort each parameter into either 'required' or 'optional'.
+    for (auto i = required.begin(); i != required.end();)
+    {
+        if ((*i)->optional())
         {
-            optional.push_back(returnParam);
+            optional.push_back(*i);
+            i = required.erase(i);
         }
         else
         {
-            required.push_back(returnParam);
+            ++i;
         }
     }
 

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -3343,6 +3343,8 @@ Slice::Operation::returnAndOutParameters(const string& returnsName)
 
         outParams.push_back(returnParam);
     }
+
+    return outParams;
 }
 
 ParameterList

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -692,7 +692,7 @@ namespace Slice
         //
         // Creating this temporary Parameter doesn't introduce cycles, since nothing from the AST points to it,
         // even if it points back into the AST. So it will be destroyed when the returned list goes out of scope.
-        [[nodiscard]] ParameterList returnAndOutParameters(const string& returnsName);
+        [[nodiscard]] ParameterList returnAndOutParameters(const std::string& returnsName);
         /// Returns this operation's out parameters and return type sorted in this order: '(required..., optional...)'.
         /// If the this operation's return type is non-void and non-optional, it is at the end of the 'required' list.
         /// Otherwise, required parameters are kept in definition order and optional parameters are sorted by tag.

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -686,8 +686,15 @@ namespace Slice
         [[nodiscard]] ParameterList sortedInParameters() const;
         /// Returns a list of all this operation's out-parameters (all parameters marked with 'out').
         [[nodiscard]] ParameterList outParameters() const;
-        /// Returns this operation's return type and out parameters sorted in this order: '(required..., optional...)'.
-        /// If the this operation's return type is non-void and non-optional, it is at the end of this list.
+        /// Returns this operation's out parameters and return type (if the operation is non-void), in that order.
+        ///
+        /// @param returnsName The name that should be returned by `returnValueParam->name()`.
+        //
+        // Creating this temporary Parameter doesn't introduce cycles, since nothing from the AST points to it,
+        // even if it points back into the AST. So it will be destroyed when the returned list goes out of scope.
+        [[nodiscard]] ParameterList returnAndOutParameters(const string& returnsName);
+        /// Returns this operation's out parameters and return type sorted in this order: '(required..., optional...)'.
+        /// If the this operation's return type is non-void and non-optional, it is at the end of the 'required' list.
         /// Otherwise, required parameters are kept in definition order and optional parameters are sorted by tag.
         ///
         /// For convenience, non-void return types are represented by a dummy `Parameter` in this list.

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -477,25 +477,24 @@ Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         out << op->name();
 
         // Write the operation's parameters.
-        out << "(";
         out << spar;
         for (const auto& param : op->inParameters())
         {
             out << paramToString(param, scope);
         }
         out << epar;
-        out << ")";
 
         // Write the operation's return type.
         const ParameterList returnAndOutParams = op->returnAndOutParameters("returnValue");
         if (returnAndOutParams.size() > 1)
         {
-            out << " -> (" << spar;
+            out << " -> "
+            out << spar;
             for (const auto& param : returnAndOutParams)
             {
                 out << paramToString(param, scope);
             }
-            out << epar << ")";
+            out << epar;
         }
         else if (returnAndOutParams.size() > 0)
         {

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -572,12 +572,13 @@ namespace
             {
                 ostringstream os;
                 Output out(os);
-                out << "std::tuple" << sabrk;
+                out << "std::tuple";
+                out.spar("<");
                 for (const auto& element : elements)
                 {
                     out << element;
                 }
-                out << eabrk;
+                out.epar(">");
                 return os.str();
             }
         }
@@ -2797,12 +2798,12 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     // These type IDs are sorted alphabetically.
     C << nl << "static const std::vector<std::string> allTypeIds = ";
-    C.spar('{');
+    C.spar("{");
     for (const auto& typeId : p->ids())
     {
         C << '"' + typeId + '"';
     }
-    C.epar('}');
+    C.epar("}");
     C << ";";
 
     C << nl << "return allTypeIds;";
@@ -2857,12 +2858,12 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 
         C << sp;
         C << nl << "static constexpr std::array<std::string_view, " << allOpNames.size() << "> allOperations";
-        C.spar('{');
+        C.spar("{");
         for (const auto& opNames : allOpNames)
         {
             C << '"' + opNames.first + '"';
         }
-        C.epar('}');
+        C.epar("}");
         C << ";";
 
         C << sp;

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -1734,12 +1734,12 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         out << nl << "function ";
         if (returnsMultipleValues)
         {
-            out.spar('[');
+            out.spar("[");
             for (const auto& param : returnAndOutParameters)
             {
                 out << fixIdent(param->name());
             }
-            out.epar(']');
+            out.epar("]");
             out << " = ";
         }
         else if (returnsAnyValues)

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -1734,14 +1734,13 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         out << nl << "function ";
         if (returnsMultipleValues)
         {
-            out << "[";
-            out << spar;
+            out.spar('[');
             for (const auto& param : returnAndOutParameters)
             {
                 out << fixIdent(param->name());
             }
-            out << epar;
-            out << "] = ";
+            out.epar(']');
+            out << " = ";
         }
         else if (returnsAnyValues)
         {

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -1698,7 +1698,7 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             returnAndOutParameters.splice(
                 returnAndOutParameters.begin(),
                 returnAndOutParameters,
-                returnAndOutParameters.end());
+                std::prev(returnAndOutParameters.end()));
         }
 
         const bool twowayOnly = op->returnsData();

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -110,7 +110,6 @@ private:
     string getOperationMode(Slice::Operation::Mode);
 
     void collectClassMembers(const ClassDefPtr&, MemberInfoList&, bool);
-    void collectExceptionMembers(const ExceptionPtr&, MemberInfoList&, bool);
 
     Output& _out;
     set<string> _classHistory;
@@ -1177,27 +1176,6 @@ CodeVisitor::collectClassMembers(const ClassDefPtr& p, MemberInfoList& allMember
     if (base)
     {
         collectClassMembers(base, allMembers, true);
-    }
-
-    DataMemberList members = p->dataMembers();
-
-    for (const auto& member : members)
-    {
-        MemberInfo m;
-        m.fixedName = fixIdent(member->name());
-        m.inherited = inherited;
-        m.dataMember = member;
-        allMembers.push_back(m);
-    }
-}
-
-void
-CodeVisitor::collectExceptionMembers(const ExceptionPtr& p, MemberInfoList& allMembers, bool inherited)
-{
-    ExceptionPtr base = p->base();
-    if (base)
-    {
-        collectExceptionMembers(base, allMembers, true);
     }
 
     DataMemberList members = p->dataMembers();

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1068,7 +1068,7 @@ Slice::Python::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     const string name = fixIdent(p->name());
 
     const ExceptionPtr base = p->base();
-    const string baseName;
+    string baseName;
 
     const DataMemberList members = p->dataMembers();
     const DataMemberList baseMembers = (base ? base->allDataMembers() : DataMemberList{});

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -764,12 +764,12 @@ Slice::Ruby::CodeVisitor::visitStructStart(const StructPtr& p)
     if (!members.empty())
     {
         _out << sp << nl << "attr_accessor ";
-        _out.spar('');
+        _out.spar(0);
         for (const auto& member : members)
         {
             _out << (":" + fixIdent(member->name(), IdentNormal));
         }
-        _out.epar('');
+        _out.epar(0);
     }
 
     _out.dec();

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -100,7 +100,6 @@ namespace Slice::Ruby
         void writeConstructorParams(const MemberInfoList&);
 
         void collectClassMembers(const ClassDefPtr&, MemberInfoList&, bool);
-        void collectExceptionMembers(const ExceptionPtr&, MemberInfoList&, bool);
 
         void outputElementSp();
 
@@ -1260,28 +1259,6 @@ Slice::Ruby::CodeVisitor::collectClassMembers(const ClassDefPtr& p, MemberInfoLi
     if (base)
     {
         collectClassMembers(base, allMembers, true);
-    }
-
-    DataMemberList members = p->dataMembers();
-
-    for (const auto& member : members)
-    {
-        MemberInfo m;
-        m.lowerName = fixIdent(member->name(), IdentToLower);
-        m.fixedName = fixIdent(member->name(), IdentNormal);
-        m.inherited = inherited;
-        m.dataMember = member;
-        allMembers.push_back(m);
-    }
-}
-
-void
-Slice::Ruby::CodeVisitor::collectExceptionMembers(const ExceptionPtr& p, MemberInfoList& allMembers, bool inherited)
-{
-    ExceptionPtr base = p->base();
-    if (base)
-    {
-        collectExceptionMembers(base, allMembers, true);
     }
 
     DataMemberList members = p->dataMembers();

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -764,12 +764,12 @@ Slice::Ruby::CodeVisitor::visitStructStart(const StructPtr& p)
     if (!members.empty())
     {
         _out << sp << nl << "attr_accessor ";
-        _out.spar(0);
+        _out.spar("");
         for (const auto& member : members)
         {
             _out << (":" + fixIdent(member->name(), IdentNormal));
         }
-        _out.epar(0);
+        _out.epar("");
     }
 
     _out.dec();

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -764,12 +764,12 @@ Slice::Ruby::CodeVisitor::visitStructStart(const StructPtr& p)
     if (!members.empty())
     {
         _out << sp << nl << "attr_accessor ";
-        _out << spar;
+        _out.spar('');
         for (const auto& member : members)
         {
             _out << (":" + fixIdent(member->name(), IdentNormal));
         }
-        _out << epar;
+        _out.epar('');
     }
 
     _out.dec();

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -94,10 +94,8 @@ namespace Slice::Ruby
         };
         using MemberInfoList = list<MemberInfo>;
 
-        //
-        // Write constructor parameters with default values.
-        //
-        void writeConstructorParams(const MemberInfoList&);
+        /// Write constructor parameters with default values.
+        void writeConstructorParams(const DataMemberList&);
 
         void collectClassMembers(const ClassDefPtr&, MemberInfoList&, bool);
 
@@ -290,7 +288,7 @@ Slice::Ruby::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     if (!allMembers.empty())
     {
         _out << sp << nl << "def initialize(";
-        writeConstructorParams(allMembers);
+        writeConstructorParams(p->allDataMembers());
         _out << ')';
         _out.inc();
 
@@ -749,7 +747,7 @@ Slice::Ruby::CodeVisitor::visitStructStart(const StructPtr& p)
     if (!memberList.empty())
     {
         _out << nl << "def initialize(";
-        writeConstructorParams(memberList);
+        writeConstructorParams(p->dataMembers());
         _out << ")";
         _out.inc();
         for (const auto& r : memberList)
@@ -1226,17 +1224,18 @@ Slice::Ruby::CodeVisitor::writeConstantValue(
 }
 
 void
-Slice::Ruby::CodeVisitor::writeConstructorParams(const MemberInfoList& members)
+Slice::Ruby::CodeVisitor::writeConstructorParams(const DataMemberList& members)
 {
-    for (auto p = members.begin(); p != members.end(); ++p)
+    bool isFirst = true;
+    for (const auto& member : members)
     {
-        if (p != members.begin())
+        if (!isFirst)
         {
             _out << ", ";
         }
-        _out << p->lowerName << "=";
+        isFirst = false;
 
-        const DataMemberPtr member = p->dataMember;
+        _out << fixIdent(member->name(), IdentToLower) << "=";
         if (member->defaultValue())
         {
             writeConstantValue(member->type(), member->defaultValueType(), *member->defaultValue());


### PR DESCRIPTION
In some of the Slice compilers, we have a form of 'domain separation' between the parser and the code-gen.
Instead of working directly with `DataMember` or `Parameter` (parser types), we convert them into `MemberInfo` and `ParamInfo` structs.

I think the use case for these intermediate types is weak now that the parser API has been vastly improved, and logic has been centralized on the parser types. So, I removed all of these `...Info` structs and the APIs that produced/consumed them.