### PR TITLE
Remove wait/catchSignal from CtrlCHandler in C++ and Swift

### DIFF
--- a/cpp/include/Ice/CtrlCHandler.h
+++ b/cpp/include/Ice/CtrlCHandler.h
@@ -50,12 +50,6 @@ namespace Ice
         /// Obtains the current signal callback.
         /// @return The callback.
         [[nodiscard]] CtrlCHandlerCallback getCallback() const;
-
-        /// Waits until this handler catches a signal.
-        /// @return The signal number that was caught.
-        /// @remark This function installs a signal callback. It must not be called when a non-null callback is already
-        /// installed.
-        int wait();
     };
 }
 

--- a/cpp/src/Ice/CtrlCHandler.cpp
+++ b/cpp/src/Ice/CtrlCHandler.cpp
@@ -10,7 +10,6 @@
 #endif
 
 #include <cassert>
-#include <future>
 #include <mutex>
 
 using namespace Ice;
@@ -41,28 +40,6 @@ CtrlCHandler::getCallback() const
 {
     lock_guard lock(globalMutex);
     return _callback;
-}
-
-int
-CtrlCHandler::wait()
-{
-    promise<int> promise;
-
-    CtrlCHandlerCallback oldCallback = setCallback(
-        [&promise, this](int sig)
-        {
-            setCallback(nullptr); // ignore further signals
-            promise.set_value(sig);
-        });
-
-    if (oldCallback)
-    {
-        setCallback(oldCallback);
-        throw Ice::LocalException{__FILE__, __LINE__, "do not call wait on a CtrlCHandler with a registered callback"};
-    }
-
-    // NOLINTNEXTLINE(clang-analyzer-core.StackAddressEscape): callback clears itself before calling set_value.
-    return promise.get_future().get();
 }
 
 #ifdef _WIN32

--- a/swift/src/Ice/CtrlCHandler.swift
+++ b/swift/src/Ice/CtrlCHandler.swift
@@ -12,19 +12,9 @@ public final class CtrlCHandler {
     public init() {}
 
     /// Sets the signal callback. If there was a previous callback, it is replaced.
-    /// - Parameter callback: The callback to call when a signal is caught. Its parameter is the signal number.
-    public func setCallback(_ callback: @escaping (Int32) -> Void) {
+    /// - Parameter callback: The callback to call when a signal is caught; its parameter is the signal number.
+    /// When nil, the signal is ignored.
+    public func setCallback(_ callback: ((Int32) -> Void)?) {
         self.handle.setCallback(callback)
-    }
-
-    /// Waits until this handler catches a Ctrl+C or similar signal.
-    /// - Returns: The signal number.
-    public func catchSignal() async -> Int32 {
-        return await withCheckedContinuation { continuation in
-            let ok = self.handle.catchSignal { signal in
-                continuation.resume(returning: signal)
-            }
-            precondition(ok, "do not call catchSignal on a CtrlCHandler with a registered callback")
-        }
     }
 }

--- a/swift/src/IceImpl/CtlCHandler.mm
+++ b/swift/src/IceImpl/CtlCHandler.mm
@@ -8,47 +8,29 @@
 @private
     Ice::CtrlCHandler _cppObject;
 }
-- (BOOL)catchSignal:(void (^)(int))callback
-{
-    Ice::CtrlCHandlerCallback previousCallback = self->_cppObject.setCallback(
-        [callback, self](int signal)
-        {
-            // This callback executes in the C++ CtrlCHandler thread.
-
-            // We need an autorelease pool in case the callback creates autorelease objects.
-            @autoreleasepool
-            {
-                callback(signal);
-            }
-
-            // Then remove callback
-            self->_cppObject.setCallback(nullptr);
-        });
-
-    return previousCallback == nullptr;
-}
-
 - (void)setCallback:(void (^)(int))callback
 {
-    self->_cppObject.setCallback(
-        [callback, self](int signal)
-        {
-            // This callback executes in the C++ CtrlCHandler thread.
-
-            // We need an autorelease pool in case the callback creates autorelease objects.
-            @autoreleasepool
+    if (callback)
+    {
+        self->_cppObject.setCallback(
+            [callback, self](int signal)
             {
-                callback(signal);
-            }
-        });
+                // This callback executes in the C++ CtrlCHandler thread.
+                // We need an autorelease pool in case the callback creates autorelease objects.
+                @autoreleasepool
+                {
+                    callback(signal);
+                }
+            });
+    }
+    else
+    {
+        self->_cppObject.setCallback(nullptr);
+    }
 }
 @end
 #else
 @implementation ICECtrlCHandler
-- (BOOL)catchSignal:(void (^)(int))callback
-{
-    assert(false); // CtrlCHandler is not implemented on this platform
-}
 - (void)setCallback:(void (^)(int))callback
 {
     assert(false); // CtrlCHandler is not implemented on this platform

--- a/swift/src/IceImpl/include/CtrlCHandler.h
+++ b/swift/src/IceImpl/include/CtrlCHandler.h
@@ -2,12 +2,7 @@
 
 #import "Config.h"
 
-NS_ASSUME_NONNULL_BEGIN
-
 // The implementation of Ice.CtrlCHandler, which wraps the C++ class Ice::CtrlCHandler (macOS only).
 ICEIMPL_API @interface ICECtrlCHandler : NSObject
-- (BOOL)catchSignal:(void (^)(int))callback;
 - (void)setCallback:(void (^)(int))callback;
 @end
-
-NS_ASSUME_NONNULL_END


### PR DESCRIPTION
We no longer use these new APIs in the demos, so I removed them.