### PR TITLE
Replace localhost by 127.0.0.1 in generated server endpoints

### DIFF
--- a/cpp/src/IceGrid/Client.cpp
+++ b/cpp/src/IceGrid/Client.cpp
@@ -79,7 +79,7 @@ main(int argc, char* argv[])
         Ice::CtrlCHandler ctrlCHandler;
         // Initialize IceGrid properties with a Properties object with the correct property prefix enabled.
         auto defaultProps = make_shared<Ice::Properties>(vector<string>{"IceGridAdmin"});
-        defaultProps->setProperty("IceGridAdmin.Server.Endpoints", "tcp -h localhost");
+        defaultProps->setProperty("IceGridAdmin.Server.Endpoints", "tcp -h 127.0.0.1");
 
         // Turn-off inactivity timeout for outgoing connections.
         defaultProps->setProperty("Ice.Connection.Client.InactivityTimeout", "0");

--- a/cpp/src/IceGrid/NodeCache.cpp
+++ b/cpp/src/IceGrid/NodeCache.cpp
@@ -771,7 +771,7 @@ NodeEntry::getInternalServerDescriptor(const ServerInfo& info) const
         }
         else
         {
-            props.push_back(createProperty("Ice.Admin.Endpoints", "tcp -h localhost"));
+            props.push_back(createProperty("Ice.Admin.Endpoints", "tcp -h 127.0.0.1"));
             server->processRegistered = true;
         }
     }


### PR DESCRIPTION
This PR updates the Endpoints properties generated by IceGrid to no longer use the DNS name localhost.