### PR TITLE
Add Support for `js:identifier` Metadata

### DIFF
--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -2219,16 +2219,16 @@ Slice::Gen::TypeScriptVisitor::visitUnitEnd(const UnitPtr&)
         if (value == "__global_")
         {
             // find the top level module for the type.
-            auto pos = key.find(".");
+            auto pos = key.find('.');
             assert(pos != string::npos);
 
             globalModules.insert(key.substr(0, pos));
         }
     }
 
-    for (const auto& mod : globalModules)
+    for (const auto& moduleName : globalModules)
     {
-        _out << nl << "import __global_" << mod << " = " << mod << ";";
+        _out << nl << "import __global_" << moduleName << " = " << moduleName << ";";
     }
 
     if (!_module.empty())

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -272,19 +272,13 @@ Slice::JsVisitor::imports() const
 }
 
 void
-Slice::JsVisitor::writeMarshalDataMembers(
-    const DataMemberList& dataMembers,
-    const DataMemberList& optionalMembers)
+Slice::JsVisitor::writeMarshalDataMembers(const DataMemberList& dataMembers, const DataMemberList& optionalMembers)
 {
     for (const auto& dataMember : dataMembers)
     {
         if (!dataMember->optional())
         {
-            writeMarshalUnmarshalCode(
-                _out,
-                dataMember->type(),
-                "this." + dataMember->mappedName(),
-                true);
+            writeMarshalUnmarshalCode(_out, dataMember->type(), "this." + dataMember->mappedName(), true);
         }
     }
 
@@ -300,19 +294,13 @@ Slice::JsVisitor::writeMarshalDataMembers(
 }
 
 void
-Slice::JsVisitor::writeUnmarshalDataMembers(
-    const DataMemberList& dataMembers,
-    const DataMemberList& optionalMembers)
+Slice::JsVisitor::writeUnmarshalDataMembers(const DataMemberList& dataMembers, const DataMemberList& optionalMembers)
 {
     for (const auto& dataMember : dataMembers)
     {
         if (!dataMember->optional())
         {
-            writeMarshalUnmarshalCode(
-                _out,
-                dataMember->type(),
-                "this." + dataMember->mappedName(),
-                false);
+            writeMarshalUnmarshalCode(_out, dataMember->type(), "this." + dataMember->mappedName(), false);
         }
     }
 
@@ -1238,8 +1226,8 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << sp;
     _out << nl << "Ice.defineOperations(";
     _out.inc();
-    _out << nl << serviceType << "," << nl << proxyType << "," << nl << flattenedIdsName << ","
-         << nl << "\"" << p->scoped() << "\"";
+    _out << nl << serviceType << "," << nl << proxyType << "," << nl << flattenedIdsName << "," << nl << "\""
+         << p->scoped() << "\"";
 
     const OperationList ops = p->operations();
     if (!ops.empty())
@@ -1513,10 +1501,8 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
         {
             if (dataMember->defaultValue())
             {
-                value = writeConstantValue(
-                    dataMember->type(),
-                    dataMember->defaultValueType(),
-                    *dataMember->defaultValue());
+                value =
+                    writeConstantValue(dataMember->type(), dataMember->defaultValueType(), *dataMember->defaultValue());
             }
             else
             {
@@ -1527,10 +1513,8 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
         {
             if (dataMember->defaultValue())
             {
-                value = writeConstantValue(
-                    dataMember->type(),
-                    dataMember->defaultValueType(),
-                    *dataMember->defaultValue());
+                value =
+                    writeConstantValue(dataMember->type(), dataMember->defaultValueType(), *dataMember->defaultValue());
             }
             else
             {
@@ -1622,10 +1606,8 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
         {
             if (dataMember->defaultValue())
             {
-                value = writeConstantValue(
-                    dataMember->type(),
-                    dataMember->defaultValueType(),
-                    *dataMember->defaultValue());
+                value =
+                    writeConstantValue(dataMember->type(), dataMember->defaultValueType(), *dataMember->defaultValue());
             }
             else
             {
@@ -1636,10 +1618,8 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
         {
             if (dataMember->defaultValue())
             {
-                value = writeConstantValue(
-                    dataMember->type(),
-                    dataMember->defaultValueType(),
-                    *dataMember->defaultValue());
+                value =
+                    writeConstantValue(dataMember->type(), dataMember->defaultValueType(), *dataMember->defaultValue());
             }
             else
             {
@@ -1711,8 +1691,8 @@ Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     bool fixed = !keyType->isVariableLength() && !valueType->isVariableLength();
 
     _out << sp;
-    _out << nl << "[" << scopedName << ", " << helperName << "] = Ice.defineDictionary("
-         << getHelper(keyType) << ", " << getHelper(valueType) << ", " << (fixed ? "true" : "false") << ", "
+    _out << nl << "[" << scopedName << ", " << helperName << "] = Ice.defineDictionary(" << getHelper(keyType) << ", "
+         << getHelper(valueType) << ", " << (fixed ? "true" : "false") << ", "
          << (keyUseEquals ? "Ice.HashMap.compareEquals" : "undefined");
 
     if (valueType->isClassType())

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -2883,6 +2883,25 @@ Slice::Gen::validateMetadata(const UnitPtr& u)
     };
     knownMetadata.emplace("js:defined-in", std::move(definedInInfo));
 
+    // "js:identifier"
+    MetadataInfo identifierInfo = {
+        .validOn =
+            {typeid(InterfaceDecl),
+             typeid(Operation),
+             typeid(ClassDecl),
+             typeid(Slice::Exception),
+             typeid(Struct),
+             typeid(Sequence),
+             typeid(Dictionary),
+             typeid(Enum),
+             typeid(Enumerator),
+             typeid(Const),
+             typeid(Parameter),
+             typeid(DataMember)},
+        .acceptedArgumentKind = MetadataArgumentKind::SingleArgument,
+    };
+    knownMetadata.emplace("js:identifier", std::move(identifierInfo));
+
     // Pass this information off to the parser's metadata validation logic.
     Slice::validateMetadata(u, "js", knownMetadata);
 }

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -1760,9 +1760,11 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 void
 Slice::Gen::TypesVisitor::visitConst(const ConstPtr& p)
 {
-    const string scopedName = p->mappedScoped(".").substr(1);
+    string scope = p->mappedScope(".").substr(1);
+    scope.pop_back(); // Remove the trailing '.' from the scope.
+
     _out << sp;
-    _out << nl << "Object.defineProperty(" << scopedName << "', {";
+    _out << nl << "Object.defineProperty(" << scope << ", '" << p->mappedName() << "', {";
     _out.inc();
     _out << nl << "enumerable: true,";
     _out << nl << "value: ";

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -33,14 +33,14 @@ namespace
             // JavaScript TypeDoc doc processor doesn't accept # at the beginning of a link.
             if (hashPos != 0)
             {
-                result += Slice::JsGenerator::fixId(rawLink.substr(0, hashPos));
+                result += rawLink.substr(0, hashPos);
                 result += "#";
             }
-            result += Slice::JsGenerator::fixId(rawLink.substr(hashPos + 1));
+            result += rawLink.substr(hashPos + 1);
         }
         else
         {
-            result += Slice::JsGenerator::fixId(rawLink);
+            result += rawLink;
         }
         return result + "}";
     }
@@ -117,16 +117,14 @@ namespace
 
     string escapeParam(const ParameterList& params, const string& name)
     {
-        string r = name;
         for (const auto& param : params)
         {
-            if (Slice::JsGenerator::fixId(param->name()) == name)
+            if (param->mappedName() == name)
             {
-                r = name + "_";
-                break;
+                return name + "_";
             }
         }
-        return r;
+        return name;
     }
 
     void writeDocLines(Output& out, const StringList& lines, bool commentFirst, const string& space = " ")
@@ -249,20 +247,16 @@ namespace
 
     void writeOpDocExceptions(Output& out, const OperationPtr& op, const DocComment& doc)
     {
-        for (const auto& p : doc.exceptions())
+        for (const auto& [name, lines] : doc.exceptions())
         {
-            //
             // Try to locate the exception's definition using the name given in the comment.
-            //
-            string name = p.first;
-            ExceptionPtr ex = op->container()->lookupException(name, false);
-            if (ex)
+            string mappedName = name;
+            if (ExceptionPtr ex = op->container()->lookupException(name, false))
             {
-                name = ex->scoped();
+                mappedName = ex->mappedScoped(".").substr(1);
             }
-            name = JsGenerator::fixId(name);
-            out << nl << " * @throws {@link " << name << "} ";
-            writeDocLines(out, p.second, false);
+            out << nl << " * @throws {@link " << mappedName << "} ";
+            writeDocLines(out, lines, false);
         }
     }
 }
@@ -280,12 +274,8 @@ Slice::JsVisitor::imports() const
 void
 Slice::JsVisitor::writeMarshalDataMembers(
     const DataMemberList& dataMembers,
-    const DataMemberList& optionalMembers,
-    const ContainedPtr& contained)
+    const DataMemberList& optionalMembers)
 {
-    bool isStruct = dynamic_pointer_cast<Struct>(contained) != nullptr;
-    bool isLegalKeyType = Dictionary::isLegalKeyType(dynamic_pointer_cast<Struct>(contained));
-
     for (const auto& dataMember : dataMembers)
     {
         if (!dataMember->optional())
@@ -293,7 +283,7 @@ Slice::JsVisitor::writeMarshalDataMembers(
             writeMarshalUnmarshalCode(
                 _out,
                 dataMember->type(),
-                "this." + fixDataMemberName(dataMember->name(), isStruct, isLegalKeyType),
+                "this." + dataMember->mappedName(),
                 true);
         }
     }
@@ -303,7 +293,7 @@ Slice::JsVisitor::writeMarshalDataMembers(
         writeOptionalMarshalUnmarshalCode(
             _out,
             optionalMember->type(),
-            "this." + fixDataMemberName(optionalMember->name(), isStruct, isLegalKeyType),
+            "this." + optionalMember->mappedName(),
             optionalMember->tag(),
             true);
     }
@@ -312,12 +302,8 @@ Slice::JsVisitor::writeMarshalDataMembers(
 void
 Slice::JsVisitor::writeUnmarshalDataMembers(
     const DataMemberList& dataMembers,
-    const DataMemberList& optionalMembers,
-    const ContainedPtr& contained)
+    const DataMemberList& optionalMembers)
 {
-    bool isStruct = dynamic_pointer_cast<Struct>(contained) != nullptr;
-    bool isLegalKeyType = Dictionary::isLegalKeyType(dynamic_pointer_cast<Struct>(contained));
-
     for (const auto& dataMember : dataMembers)
     {
         if (!dataMember->optional())
@@ -325,7 +311,7 @@ Slice::JsVisitor::writeUnmarshalDataMembers(
             writeMarshalUnmarshalCode(
                 _out,
                 dataMember->type(),
-                "this." + fixDataMemberName(dataMember->name(), isStruct, isLegalKeyType),
+                "this." + dataMember->mappedName(),
                 false);
         }
     }
@@ -335,27 +321,14 @@ Slice::JsVisitor::writeUnmarshalDataMembers(
         writeOptionalMarshalUnmarshalCode(
             _out,
             optionalMember->type(),
-            "this." + fixDataMemberName(optionalMember->name(), isStruct, isLegalKeyType),
+            "this." + optionalMember->mappedName(),
             optionalMember->tag(),
             false);
     }
 }
 
-void
-Slice::JsVisitor::writeInitDataMembers(const DataMemberList& dataMembers, const ContainedPtr& contained)
-{
-    bool isStruct = dynamic_pointer_cast<Struct>(contained) != nullptr;
-    bool isLegalKeyType = Dictionary::isLegalKeyType(dynamic_pointer_cast<Struct>(contained));
-
-    for (const auto& dataMember : dataMembers)
-    {
-        const string m = fixDataMemberName(dataMember->name(), isStruct, isLegalKeyType);
-        _out << nl << "this." << m << " = " << fixId(dataMember->name()) << ';';
-    }
-}
-
 string
-Slice::JsVisitor::getValue(const string& /*scope*/, const TypePtr& type)
+Slice::JsVisitor::getValue(const TypePtr& type)
 {
     assert(type);
 
@@ -402,7 +375,7 @@ Slice::JsVisitor::getValue(const string& /*scope*/, const TypePtr& type)
     EnumPtr en = dynamic_pointer_cast<Enum>(type);
     if (en)
     {
-        return fixId(en->scoped()) + '.' + fixId((*en->enumerators().begin())->name());
+        return (*en->enumerators().begin())->mappedScoped(".").substr(1);
     }
 
     StructPtr st = dynamic_pointer_cast<Struct>(type);
@@ -415,17 +388,13 @@ Slice::JsVisitor::getValue(const string& /*scope*/, const TypePtr& type)
 }
 
 string
-Slice::JsVisitor::writeConstantValue(
-    const string& /*scope*/,
-    const TypePtr& type,
-    const SyntaxTreeBasePtr& valueType,
-    const string& value)
+Slice::JsVisitor::writeConstantValue(const TypePtr& type, const SyntaxTreeBasePtr& valueType, const string& value)
 {
     ostringstream os;
     ConstPtr constant = dynamic_pointer_cast<Const>(valueType);
     if (constant)
     {
-        os << fixId(constant->scoped());
+        os << constant->mappedScoped(".").substr(1);
     }
     else
     {
@@ -446,7 +415,7 @@ Slice::JsVisitor::writeConstantValue(
         {
             EnumeratorPtr lte = dynamic_pointer_cast<Enumerator>(valueType);
             assert(lte);
-            os << fixId(ep->scoped()) << '.' << fixId(lte->name());
+            os << lte->mappedScoped(".").substr(1);
         }
         else
         {
@@ -1019,7 +988,7 @@ Slice::Gen::ExportsVisitor::visitModuleStart(const ModulePtr& p)
     //
     // Foo.Bar = Foo.Bar || {};
     //
-    const string scoped = getLocalScope(p->scoped());
+    const string scoped = p->mappedScoped(".").substr(1);
     if (_exportedModules.insert(scoped).second)
     {
         _out << sp;
@@ -1054,12 +1023,9 @@ Slice::Gen::TypesVisitor::TypesVisitor(IceInternal::Output& out) : JsVisitor(out
 bool
 Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
-    const string scope = p->scope();
-    const string scoped = p->scoped();
-    const string localScope = getLocalScope(scope);
-    const string name = fixId(p->name());
+    const string scopedName = p->mappedScoped(".").substr(1);
     ClassDefPtr base = p->base();
-    string baseRef = base ? fixId(base->scoped()) : "Ice.Value";
+    string baseRef = base ? base->mappedScoped(".").substr(1) : "Ice.Value";
 
     const DataMemberList dataMembers = p->dataMembers();
     const DataMemberList optionalMembers = p->orderedOptionalDataMembers();
@@ -1067,7 +1033,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     vector<string> allParamNames;
     for (const auto& member : p->allDataMembers())
     {
-        allParamNames.push_back(fixId(member->name()));
+        allParamNames.push_back(member->mappedName());
     }
 
     vector<string> baseParamNames;
@@ -1078,13 +1044,13 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
         baseDataMembers = base->allDataMembers();
         for (const auto& baseDataMember : baseDataMembers)
         {
-            baseParamNames.push_back(fixId(baseDataMember->name()));
+            baseParamNames.push_back(baseDataMember->mappedName());
         }
     }
 
     _out << sp;
     writeDocCommentFor(p);
-    _out << nl << localScope << '.' << name << " = class";
+    _out << nl << scopedName << " = class";
     _out << " extends " << baseRef;
 
     _out << sb;
@@ -1093,7 +1059,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
         _out << nl << "constructor" << spar;
         for (const auto& baseDataMember : baseDataMembers)
         {
-            _out << fixId(baseDataMember->name());
+            _out << baseDataMember->mappedName();
         }
 
         for (const auto& dataMember : dataMembers)
@@ -1104,7 +1070,6 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
                 if (dataMember->defaultValue())
                 {
                     value = writeConstantValue(
-                        scope,
                         dataMember->type(),
                         dataMember->defaultValueType(),
                         *dataMember->defaultValue());
@@ -1119,22 +1084,25 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
                 if (dataMember->defaultValue())
                 {
                     value = writeConstantValue(
-                        scope,
                         dataMember->type(),
                         dataMember->defaultValueType(),
                         *dataMember->defaultValue());
                 }
                 else
                 {
-                    value = getValue(scope, dataMember->type());
+                    value = getValue(dataMember->type());
                 }
             }
-            _out << (fixId(dataMember->name()) + (value.empty() ? value : (" = " + value)));
+            _out << (dataMember->mappedName() + (value.empty() ? value : (" = " + value)));
         }
 
         _out << epar << sb;
         _out << nl << "super" << spar << baseParamNames << epar << ';';
-        writeInitDataMembers(dataMembers, p);
+        for (const auto& member : dataMembers)
+        {
+            const string memberName = member->mappedName();
+            _out << nl << "this." << memberName << " = " << memberName << ';';
+        }
         _out << eb;
 
         if (p->compactId() != -1)
@@ -1151,13 +1119,13 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
             _out << sp;
             _out << nl << "_iceWriteMemberImpl(ostr)";
             _out << sb;
-            writeMarshalDataMembers(dataMembers, optionalMembers, p);
+            writeMarshalDataMembers(dataMembers, optionalMembers);
             _out << eb;
 
             _out << sp;
             _out << nl << "_iceReadMemberImpl(istr)";
             _out << sb;
-            writeUnmarshalDataMembers(dataMembers, optionalMembers, p);
+            writeUnmarshalDataMembers(dataMembers, optionalMembers);
             _out << eb;
         }
     }
@@ -1165,14 +1133,13 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     _out << sp;
 
-    _out << nl << "Ice.defineValue(" << localScope << "." << name << ", \"" << scoped << "\"";
+    _out << nl << "Ice.defineValue(" << scopedName << ", \"" << p->scoped() << "\"";
     if (p->compactId() >= 0)
     {
         _out << ", " << p->compactId();
     }
     _out << ");";
-    _out << nl << "Ice.TypeRegistry.declareValueType(\"" << localScope << '.' << name << "\", " << localScope << '.'
-         << name << ");";
+    _out << nl << "Ice.TypeRegistry.declareValueType(\"" << scopedName << "\", " << scopedName << ");";
 
     return false;
 }
@@ -1180,17 +1147,15 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 bool
 Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
-    const string scope = p->scope();
-    const string scoped = p->scoped();
-    const string localScope = getLocalScope(scope);
-    const string serviceType = localScope + '.' + fixId(p->name());
-    const string proxyType = localScope + '.' + p->name() + "Prx";
+    const string serviceType = p->mappedScoped(".").substr(1);
+    const string proxyType = serviceType + "Prx";
+    const string flattenedIdsName = "iceC_" + p->mappedScoped("_").substr(1) + "_ids";
 
     InterfaceList bases = p->bases();
     StringList ids = p->ids();
 
     _out << sp;
-    _out << nl << "const iceC_" << getLocalScope(scoped, "_") << "_ids = [";
+    _out << nl << "const " << flattenedIdsName << " = [";
     _out.inc();
 
     for (auto q = ids.begin(); q != ids.end(); ++q)
@@ -1224,7 +1189,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         for (auto q = bases.begin(); q != bases.end();)
         {
             InterfaceDefPtr base = *q;
-            _out << nl << getLocalScope(base->scope()) << "." << base->name();
+            _out << nl << base->mappedScoped(".").substr(1);
             if (++q != bases.end())
             {
                 _out << ",";
@@ -1256,7 +1221,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         {
             InterfaceDefPtr base = *q;
 
-            _out << nl << getLocalScope(base->scope()) << "." << base->name() << "Prx";
+            _out << nl << base->mappedScoped(".").substr(1) + "Prx";
             if (++q != bases.end())
             {
                 _out << ",";
@@ -1273,8 +1238,8 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << sp;
     _out << nl << "Ice.defineOperations(";
     _out.inc();
-    _out << nl << serviceType << "," << nl << proxyType << "," << nl << "iceC_" << getLocalScope(scoped, "_") << "_ids,"
-         << nl << "\"" << scoped << "\"";
+    _out << nl << serviceType << "," << nl << proxyType << "," << nl << flattenedIdsName << ","
+         << nl << "\"" << p->scoped() << "\"";
 
     const OperationList ops = p->operations();
     if (!ops.empty())
@@ -1289,7 +1254,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             }
 
             const OperationPtr& op = *q;
-            const string opName = fixId(op->name());
+            const string opName = op->mappedName();
             const ParameterList paramList = op->parameters();
             const TypePtr ret = op->returnType();
             ParameterList inParams, outParams;
@@ -1451,7 +1416,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                     {
                         _out << ',';
                     }
-                    _out << nl << fixId((*eli)->scoped());
+                    _out << nl << (*eli)->mappedScoped(".").substr(1);
                 }
                 _out.dec();
                 _out << nl << ']';
@@ -1482,19 +1447,13 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 void
 Slice::Gen::TypesVisitor::visitSequence(const SequencePtr& p)
 {
+    // Stream helpers for sequences are lazy initialized as the required types might not be available until later.
+    const string helperName = p->mappedScoped(".").substr(1) + "Helper";
     const TypePtr type = p->type();
-
-    //
-    // Stream helpers for sequences are lazy initialized as the required
-    // types might not be available until later.
-    //
-    const string scope = getLocalScope(p->scope());
-    const string name = fixId(p->name());
-    const string propertyName = name + "Helper";
     const bool fixed = !type->isVariableLength();
 
     _out << sp;
-    _out << nl << scope << "." << propertyName << " = Ice.StreamHelpers.generateSeqHelper(" << getHelper(type) << ", "
+    _out << nl << helperName << " = Ice.StreamHelpers.generateSeqHelper(" << getHelper(type) << ", "
          << (fixed ? "true" : "false");
     if (type->isClassType())
     {
@@ -1507,14 +1466,13 @@ Slice::Gen::TypesVisitor::visitSequence(const SequencePtr& p)
 bool
 Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
-    const string scope = p->scope();
-    const string localScope = getLocalScope(scope);
-    const string name = fixId(p->name());
+    const string scopedName = p->mappedScoped(".").substr(1);
     const ExceptionPtr base = p->base();
     string baseRef;
+
     if (base)
     {
-        baseRef = fixId(base->scoped());
+        baseRef = base->mappedScoped(".").substr(1);
     }
     else
     {
@@ -1524,34 +1482,28 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     const DataMemberList dataMembers = p->dataMembers();
     const DataMemberList optionalMembers = p->orderedOptionalDataMembers();
 
-    vector<string> allParamNames;
-    for (const auto& member : p->allDataMembers())
-    {
-        allParamNames.push_back(fixId(member->name()));
-    }
-
     vector<string> baseParamNames;
     DataMemberList baseDataMembers;
 
-    if (p->base())
+    if (base)
     {
-        baseDataMembers = p->base()->allDataMembers();
+        baseDataMembers = base->allDataMembers();
         for (const auto& baseDataMember : baseDataMembers)
         {
-            baseParamNames.push_back(fixId(baseDataMember->name()));
+            baseParamNames.push_back(baseDataMember->mappedName());
         }
     }
 
     _out << sp;
     writeDocCommentFor(p);
-    _out << nl << localScope << '.' << name << " = class extends " << baseRef;
+    _out << nl << scopedName << " = class extends " << baseRef;
     _out << sb;
 
     _out << nl << "constructor" << spar;
 
     for (const auto& baseDataMember : baseDataMembers)
     {
-        _out << fixId(baseDataMember->name());
+        _out << baseDataMember->mappedName();
     }
 
     for (const auto& dataMember : dataMembers)
@@ -1562,7 +1514,6 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
             if (dataMember->defaultValue())
             {
                 value = writeConstantValue(
-                    scope,
                     dataMember->type(),
                     dataMember->defaultValueType(),
                     *dataMember->defaultValue());
@@ -1577,23 +1528,26 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
             if (dataMember->defaultValue())
             {
                 value = writeConstantValue(
-                    scope,
                     dataMember->type(),
                     dataMember->defaultValueType(),
                     *dataMember->defaultValue());
             }
             else
             {
-                value = getValue(scope, dataMember->type());
+                value = getValue(dataMember->type());
             }
         }
-        _out << (fixId(dataMember->name()) + (value.empty() ? value : (" = " + value)));
+        _out << (dataMember->mappedName() + (value.empty() ? value : (" = " + value)));
     }
 
     _out << "_cause = \"\"" << epar;
     _out << sb;
     _out << nl << "super" << spar << baseParamNames << "_cause" << epar << ';';
-    writeInitDataMembers(dataMembers, p);
+    for (const auto& member : dataMembers)
+    {
+        const string memberName = member->mappedName();
+        _out << nl << "this." << memberName << " = " << memberName << ';';
+    }
     _out << eb;
 
     _out << sp;
@@ -1611,7 +1565,7 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     _out << sp;
     _out << nl << "_mostDerivedType()";
     _out << sb;
-    _out << nl << "return " << localScope << '.' << name << ";";
+    _out << nl << "return " << scopedName << ";";
     _out << eb;
 
     if (!dataMembers.empty())
@@ -1619,13 +1573,13 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
         _out << sp;
         _out << nl << "_writeMemberImpl(ostr)";
         _out << sb;
-        writeMarshalDataMembers(dataMembers, optionalMembers, p);
+        writeMarshalDataMembers(dataMembers, optionalMembers);
         _out << eb;
 
         _out << sp;
         _out << nl << "_readMemberImpl(istr)";
         _out << sb;
-        writeUnmarshalDataMembers(dataMembers, optionalMembers, p);
+        writeUnmarshalDataMembers(dataMembers, optionalMembers);
         _out << eb;
     }
 
@@ -1641,8 +1595,8 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     _out << eb << ";";
     _out << nl << "Ice.TypeRegistry.declareUserExceptionType(";
     _out.inc();
-    _out << nl << "\"" << localScope << '.' << name << "\",";
-    _out << nl << localScope << '.' << name << ");";
+    _out << nl << "\"" << scopedName << "\",";
+    _out << nl << scopedName << ");";
     _out.dec();
 
     return false;
@@ -1651,21 +1605,12 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 bool
 Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
 {
-    const string scope = p->scope();
-    const string localScope = getLocalScope(scope);
-    const string name = fixId(p->name());
-
+    const string scopedName = p->mappedScoped(".").substr(1);
     const DataMemberList dataMembers = p->dataMembers();
-
-    vector<string> paramNames;
-    for (const auto& dataMember : dataMembers)
-    {
-        paramNames.push_back(fixId(dataMember->name()));
-    }
 
     _out << sp;
     writeDocCommentFor(p);
-    _out << nl << localScope << '.' << name << " = class";
+    _out << nl << scopedName << " = class";
     _out << sb;
 
     _out << nl << "constructor" << spar;
@@ -1678,7 +1623,6 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
             if (dataMember->defaultValue())
             {
                 value = writeConstantValue(
-                    scope,
                     dataMember->type(),
                     dataMember->defaultValueType(),
                     *dataMember->defaultValue());
@@ -1693,34 +1637,37 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
             if (dataMember->defaultValue())
             {
                 value = writeConstantValue(
-                    scope,
                     dataMember->type(),
                     dataMember->defaultValueType(),
                     *dataMember->defaultValue());
             }
             else
             {
-                value = getValue(scope, dataMember->type());
+                value = getValue(dataMember->type());
             }
         }
-        _out << (fixId(dataMember->name()) + (value.empty() ? value : (" = " + value)));
+        _out << (dataMember->mappedName() + (value.empty() ? value : (" = " + value)));
     }
 
     _out << epar;
     _out << sb;
-    writeInitDataMembers(dataMembers, p);
+    for (const auto& member : dataMembers)
+    {
+        const string memberName = member->mappedName();
+        _out << nl << "this." << memberName << " = " << memberName << ';';
+    }
     _out << eb;
 
     _out << sp;
     _out << nl << "_write(ostr)";
     _out << sb;
-    writeMarshalDataMembers(dataMembers, DataMemberList(), p);
+    writeMarshalDataMembers(dataMembers, DataMemberList());
     _out << eb;
 
     _out << sp;
     _out << nl << "_read(istr)";
     _out << sb;
-    writeUnmarshalDataMembers(dataMembers, DataMemberList(), p);
+    writeUnmarshalDataMembers(dataMembers, DataMemberList());
     _out << eb;
 
     _out << sp;
@@ -1737,7 +1684,7 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     bool legalKeyType = Dictionary::isLegalKeyType(p);
 
     _out << sp;
-    _out << nl << "Ice.defineStruct(" << localScope << '.' << name << ", " << (legalKeyType ? "true" : "false") << ", "
+    _out << nl << "Ice.defineStruct(" << scopedName << ", " << (legalKeyType ? "true" : "false") << ", "
          << (p->isVariableLength() ? "true" : "false") << ");";
     return false;
 }
@@ -1748,10 +1695,8 @@ Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     const TypePtr keyType = p->keyType();
     const TypePtr valueType = p->valueType();
 
-    //
     // For some key types, we have to use an equals() method to compare keys
     // rather than the native comparison operators.
-    //
     bool keyUseEquals = false;
     BuiltinPtr b = dynamic_pointer_cast<Builtin>(keyType);
     if ((b && b->kind() == Builtin::KindLong) || dynamic_pointer_cast<Struct>(keyType))
@@ -1759,17 +1704,14 @@ Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
         keyUseEquals = true;
     }
 
-    //
     // Stream helpers for dictionaries of objects are lazy initialized
     // as the required object type might not be available until later.
-    //
-    const string scope = getLocalScope(p->scope());
-    const string name = fixId(p->name());
-    const string propertyName = name + "Helper";
+    const string scopedName = p->mappedScoped(".").substr(1);
+    const string helperName = scopedName + "Helper";
     bool fixed = !keyType->isVariableLength() && !valueType->isVariableLength();
 
     _out << sp;
-    _out << nl << "[" << scope << "." << name << ", " << scope << "." << propertyName << "] = Ice.defineDictionary("
+    _out << nl << "[" << scopedName << ", " << helperName << "] = Ice.defineDictionary("
          << getHelper(keyType) << ", " << getHelper(valueType) << ", " << (fixed ? "true" : "false") << ", "
          << (keyUseEquals ? "Ice.HashMap.compareEquals" : "undefined");
 
@@ -1783,13 +1725,10 @@ Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
 void
 Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 {
-    const string scope = p->scope();
-    const string localScope = getLocalScope(scope);
-    const string name = fixId(p->name());
-
+    const string scopedName = p->mappedScoped(".").substr(1);
     _out << sp;
     writeDocCommentFor(p);
-    _out << nl << localScope << '.' << name << " = Ice.defineEnum([";
+    _out << nl << scopedName << " = Ice.defineEnum([";
     _out.inc();
     _out << nl;
 
@@ -1808,7 +1747,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
                 _out << ", ";
             }
         }
-        _out << "['" << fixId((*en)->name()) << "', " << (*en)->value() << ']';
+        _out << "['" << (*en)->mappedName() << "', " << (*en)->value() << ']';
     }
     _out << "]);";
     _out.dec();
@@ -1821,16 +1760,13 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 void
 Slice::Gen::TypesVisitor::visitConst(const ConstPtr& p)
 {
-    const string scope = p->scope();
-    const string localScope = getLocalScope(scope);
-    const string name = fixId(p->name());
-
+    const string scopedName = p->mappedScoped(".").substr(1);
     _out << sp;
-    _out << nl << "Object.defineProperty(" << localScope << ", '" << name << "', {";
+    _out << nl << "Object.defineProperty(" << scopedName << "', {";
     _out.inc();
     _out << nl << "enumerable: true,";
     _out << nl << "value: ";
-    _out << writeConstantValue(scope, p->type(), p->valueType(), p->value());
+    _out << writeConstantValue(p->type(), p->valueType(), p->value());
     _out.dec();
     _out << nl << "});";
 }
@@ -1863,37 +1799,37 @@ Slice::Gen::TypesVisitor::encodeTypeForOperation(const TypePtr& type)
     InterfaceDeclPtr proxy = dynamic_pointer_cast<InterfaceDecl>(type);
     if (proxy)
     {
-        return "\"" + fixId(proxy->scoped() + "Prx") + "\"";
+        return "\"" + proxy->mappedScoped(".").substr(1) + "Prx" + "\"";
     }
 
     SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
     if (seq)
     {
-        return fixId(seq->scoped() + "Helper");
+        return seq->mappedScoped(".").substr(1) + "Helper";
     }
 
     DictionaryPtr d = dynamic_pointer_cast<Dictionary>(type);
     if (d)
     {
-        return fixId(d->scoped() + "Helper");
+        return d->mappedScoped(".").substr(1) + "Helper";
     }
 
     EnumPtr e = dynamic_pointer_cast<Enum>(type);
     if (e)
     {
-        return fixId(e->scoped()) + "._helper";
+        return e->mappedScoped(".").substr(1) + "._helper";
     }
 
     StructPtr st = dynamic_pointer_cast<Struct>(type);
     if (st)
     {
-        return fixId(st->scoped());
+        return st->mappedScoped(".").substr(1);
     }
 
     ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
     if (cl)
     {
-        return "\"" + fixId(cl->scoped()) + "\"";
+        return "\"" + cl->mappedScoped(".").substr(1) + "\"";
     }
 
     return "???";
@@ -1904,13 +1840,15 @@ Slice::Gen::TypeScriptImportVisitor::TypeScriptImportVisitor(IceInternal::Output
 void
 Slice::Gen::TypeScriptImportVisitor::addImport(const ContainedPtr& definition)
 {
+    const string definitionId = definition->mappedScoped(".").substr(1);
+
     string jsImportedModule = getJavaScriptModule(definition->definitionContext());
     if (jsImportedModule.empty())
     {
         string definedIn = definition->getMetadataArgs("js:defined-in").value_or("");
         if (!definedIn.empty())
         {
-            _importedTypes[definition->scoped()] = "__module_" + pathToModule(definedIn) + ".";
+            _importedTypes[definitionId] = "__module_" + pathToModule(definedIn) + ".";
             _importedModules.insert(removeExtension(definedIn) + ".js");
         }
         else
@@ -1919,7 +1857,7 @@ Slice::Gen::TypeScriptImportVisitor::addImport(const ContainedPtr& definition)
             if (filename == _filename)
             {
                 // For types defined in the same unit we use a __global_ prefix to refer to the global scope.
-                _importedTypes[definition->scoped()] = "__global_";
+                _importedTypes[definitionId] = "__global_";
             }
             else
             {
@@ -1934,19 +1872,19 @@ Slice::Gen::TypeScriptImportVisitor::addImport(const ContainedPtr& definition)
                     // Make the import relative to the current file.
                     f = "./" + f;
                 }
-                _importedTypes[definition->scoped()] = "__module_" + pathToModule(f) + ".";
+                _importedTypes[definitionId] = "__module_" + pathToModule(f) + ".";
                 _importedModules.insert(removeExtension(f) + ".js");
             }
         }
     }
     else if (_module != jsImportedModule)
     {
-        _importedTypes[definition->scoped()] = "__module_" + pathToModule(jsImportedModule) + ".";
+        _importedTypes[definitionId] = "__module_" + pathToModule(jsImportedModule) + ".";
     }
     else
     {
         // For types defined in the same module, we use a __global_ prefix, to refer to the global scope.
-        _importedTypes[definition->scoped()] = "__global_";
+        _importedTypes[definitionId] = "__global_";
     }
 }
 
@@ -2194,7 +2132,8 @@ Slice::Gen::TypeScriptVisitor::typeToTsString(const TypePtr& type, bool nullable
     ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
     if (cl)
     {
-        t = importPrefix(cl->scoped()) + fixId(cl->scoped());
+        const string scopedName = cl->mappedScoped(".").substr(1);
+        t = importPrefix(scopedName) + scopedName;
         if (nullable)
         {
             t += " | null";
@@ -2204,7 +2143,8 @@ Slice::Gen::TypeScriptVisitor::typeToTsString(const TypePtr& type, bool nullable
     InterfaceDeclPtr proxy = dynamic_pointer_cast<InterfaceDecl>(type);
     if (proxy)
     {
-        t = importPrefix(proxy->scoped()) + fixId(proxy->scoped() + "Prx");
+        const string scopedName = proxy->mappedScoped(".").substr(1);
+        t = importPrefix(scopedName) + scopedName + "Prx";
         if (nullable)
         {
             t += " | null";
@@ -2254,7 +2194,8 @@ Slice::Gen::TypeScriptVisitor::typeToTsString(const TypePtr& type, bool nullable
     ContainedPtr contained = dynamic_pointer_cast<Contained>(type);
     if (t.empty() && contained)
     {
-        t = importPrefix(contained->scoped()) + fixId(contained->scoped());
+        const string scopedName = contained->mappedScoped(".").substr(1);
+        t = importPrefix(scopedName) + scopedName;
     }
 
     // For optional parameters we use "?:" instead of Ice.Optional<T>
@@ -2296,16 +2237,16 @@ Slice::Gen::TypeScriptVisitor::visitUnitEnd(const UnitPtr&)
         if (value == "__global_")
         {
             // find the top level module for the type.
-            auto pos = key.find("::", 2);
+            auto pos = key.find(".");
             assert(pos != string::npos);
 
-            globalModules.insert(key.substr(2, pos - 2));
+            globalModules.insert(key.substr(0, pos - 1));
         }
     }
 
-    for (const auto& module : globalModules)
+    for (const auto& mod : globalModules)
     {
-        _out << nl << "import __global_" << fixId(module) << " = " << fixId(module) << ";";
+        _out << nl << "import __global_" << mod << " = " << mod << ";";
     }
 
     if (!_module.empty())
@@ -2317,15 +2258,14 @@ Slice::Gen::TypeScriptVisitor::visitUnitEnd(const UnitPtr&)
 bool
 Slice::Gen::TypeScriptVisitor::visitModuleStart(const ModulePtr& p)
 {
-    UnitPtr unit = dynamic_pointer_cast<Unit>(p->container());
-    if (unit && _module.empty())
+    if (p->isTopLevel() && _module.empty())
     {
         _out << sp;
-        _out << nl << "export namespace " << fixId(p->name()) << sb;
+        _out << nl << "export namespace " << p->mappedName() << sb;
     }
     else
     {
-        _out << nl << "namespace " << fixId(p->name()) << sb;
+        _out << nl << "namespace " << p->mappedName() << sb;
     }
     return true;
 }
@@ -2343,11 +2283,12 @@ Slice::Gen::TypeScriptVisitor::visitClassDefStart(const ClassDefPtr& p)
     const DataMemberList allDataMembers = p->allDataMembers();
     _out << sp;
     writeDocCommentFor(p);
-    _out << nl << "export class " << fixId(p->name()) << " extends ";
+    _out << nl << "export class " << p->mappedName() << " extends ";
     ClassDefPtr base = p->base();
     if (base)
     {
-        _out << importPrefix(base->scoped()) << fixId(base->scoped());
+        const string baseName = base->mappedScoped(".").substr(1);
+        _out << importPrefix(baseName) << baseName;
     }
     else
     {
@@ -2360,22 +2301,21 @@ Slice::Gen::TypeScriptVisitor::visitClassDefStart(const ClassDefPtr& p)
     {
         if (auto comment = DocComment::parseFrom(dataMember, jsLinkFormatter))
         {
-            _out << nl << " * @param " << fixId(dataMember->name()) << " " << getDocSentence(comment->overview());
+            _out << nl << " * @param " << dataMember->mappedName() << " " << getDocSentence(comment->overview());
         }
     }
     _out << nl << " */";
     _out << nl << "constructor" << spar;
     for (const auto& dataMember : allDataMembers)
     {
-        _out << (fixId(dataMember->name()) + "?: " + typeToTsString(dataMember->type()));
+        _out << (dataMember->mappedName() + "?: " + typeToTsString(dataMember->type()));
     }
     _out << epar << ";";
     for (const auto& dataMember : dataMembers)
     {
         _out << sp;
         writeDocCommentFor(dataMember);
-        _out << nl << fixDataMemberName(dataMember->name(), false, false) << ": "
-             << typeToTsString(dataMember->type(), true) << ";";
+        _out << nl << dataMember->mappedName() << ": " << typeToTsString(dataMember->type(), true) << ";";
     }
     _out << eb;
 
@@ -2423,7 +2363,7 @@ Slice::Gen::TypeScriptVisitor::writeOpDocSummary(Output& out, const OperationPtr
             auto q = paramDoc.find(param->name());
             if (q != paramDoc.end())
             {
-                out << nl << " * @param " << Slice::JsGenerator::fixId(q->first) << " ";
+                out << nl << " * @param " << param->mappedName() << " ";
                 writeDocLines(out, q->second, false);
             }
         }
@@ -2496,28 +2436,28 @@ Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     //
     // Define servant an proxy types
     //
-    const string prx = p->name() + "Prx";
+    const string prxName = p->mappedName() + "Prx";
     _out << sp;
     writeDocCommentFor(p);
-    _out << nl << "export class " << prx << " extends " << _iceImportPrefix << "Ice.ObjectPrx";
+    _out << nl << "export class " << prxName << " extends " << _iceImportPrefix << "Ice.ObjectPrx";
     _out << sb;
 
     _out << sp;
     _out << nl << "/**";
-    _out << nl << " * Constructs a new " << prx << " proxy.";
+    _out << nl << " * Constructs a new " << prxName << " proxy.";
     _out << nl << " * @param communicator - The communicator for the new proxy.";
     _out << nl << " * @param proxyString - The string representation of the proxy.";
-    _out << nl << " * @returns The new " << prx << " proxy.";
+    _out << nl << " * @returns The new " << prxName << " proxy.";
     _out << nl << " * @throws ParseException - Thrown if the proxyString is not a valid proxy string.";
     _out << nl << " */";
     _out << nl << "constructor(communicator: " << _iceImportPrefix << "Ice.Communicator, proxyString: string);";
 
     _out << sp;
     _out << nl << "/**";
-    _out << nl << " * Constructs a new " << prx << " proxy from an ObjectPrx. The new proxy is a clone of the";
+    _out << nl << " * Constructs a new " << prxName << " proxy from an ObjectPrx. The new proxy is a clone of the";
     _out << nl << " * provided proxy.";
     _out << nl << " * @param prx - The proxy to clone.";
-    _out << nl << " * @returns The new " << prx << " proxy.";
+    _out << nl << " * @returns The new " << prxName << " proxy.";
     _out << nl << " */";
     _out << nl << "constructor(prx: " << _iceImportPrefix << "Ice.ObjectPrx);";
 
@@ -2540,14 +2480,14 @@ Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
         _out << sp;
         writeOpDocSummary(_out, op, false);
-        _out << nl << fixId(op->name()) << spar;
+        _out << nl << op->mappedName() << spar;
         for (const auto& param : inParams)
         {
             // TypeScript doesn't allow optional parameters with '?' prefix before required parameters.
             const string optionalPrefix =
                 param->optional() && areRemainingParamsOptional(paramList, param->name()) ? "?" : "";
             _out
-                << (fixId(param->name()) + optionalPrefix + ": " +
+                << (param->mappedName() + optionalPrefix + ": " +
                     typeToTsString(param->type(), true, true, param->optional()));
         }
         _out << "context?: Map<string, string>";
@@ -2595,7 +2535,7 @@ Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << nl << " */";
     _out << nl << "static uncheckedCast(prx: " << _iceImportPrefix << "Ice.ObjectPrx"
          << ", "
-         << "facet?: string): " << fixId(p->name() + "Prx") << ";";
+         << "facet?: string): " << prxName << ";";
 
     _out << sp;
     _out << nl << "/**";
@@ -2610,12 +2550,12 @@ Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << nl << "static checkedCast(prx: " << _iceImportPrefix << "Ice.ObjectPrx"
          << ", "
          << "facet?: string, context?: Map<string, string>): " << _iceImportPrefix << "Ice.AsyncResult"
-         << "<" << fixId(p->name() + "Prx") << " | null>;";
+         << "<" << prxName << " | null>;";
     _out << eb;
 
     _out << sp;
     writeDocCommentFor(p, false);
-    _out << nl << "export abstract class " << fixId(p->name()) << " extends " << _iceImportPrefix << "Ice.Object";
+    _out << nl << "export abstract class " << p->mappedName() << " extends " << _iceImportPrefix << "Ice.Object";
     _out << sb;
     for (const auto& op : p->allOperations())
     {
@@ -2636,10 +2576,10 @@ Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
         _out << sp;
         writeOpDocSummary(_out, op, true);
-        _out << nl << "abstract " << fixId(op->name()) << spar;
+        _out << nl << "abstract " << op->mappedName() << spar;
         for (const auto& param : inParams)
         {
-            _out << (fixId(param->name()) + ": " + typeToTsString(param->type(), true, true, param->optional()));
+            _out << (param->mappedName() + ": " + typeToTsString(param->type(), true, true, param->optional()));
         }
         _out << ("current: " + _iceImportPrefix + "Ice.Current");
         _out << epar << ": ";
@@ -2689,7 +2629,6 @@ Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 bool
 Slice::Gen::TypeScriptVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
-    const string name = fixId(p->name());
     const DataMemberList dataMembers = p->dataMembers();
     const DataMemberList allDataMembers = p->allDataMembers();
 
@@ -2697,7 +2636,8 @@ Slice::Gen::TypeScriptVisitor::visitExceptionStart(const ExceptionPtr& p)
     string baseRef;
     if (base)
     {
-        baseRef = importPrefix(base->scoped()) + fixId(base->scoped());
+        const string baseName = base->mappedScoped(".").substr(1);
+        baseRef = importPrefix(baseName) + baseName;
     }
     else
     {
@@ -2706,7 +2646,7 @@ Slice::Gen::TypeScriptVisitor::visitExceptionStart(const ExceptionPtr& p)
 
     _out << sp;
     writeDocCommentFor(p);
-    _out << nl << "export class " << name << " extends " << baseRef << sb;
+    _out << nl << "export class " << p->mappedName() << " extends " << baseRef << sb;
     if (!allDataMembers.empty())
     {
         _out << nl << "/**";
@@ -2715,14 +2655,14 @@ Slice::Gen::TypeScriptVisitor::visitExceptionStart(const ExceptionPtr& p)
         {
             if (auto comment = DocComment::parseFrom(dataMember, jsLinkFormatter))
             {
-                _out << nl << " * @param " << fixId(dataMember->name()) << " " << getDocSentence(comment->overview());
+                _out << nl << " * @param " << dataMember->mappedName() << " " << getDocSentence(comment->overview());
             }
         }
         _out << nl << " */";
         _out << nl << "constructor" << spar;
         for (const auto& dataMember : allDataMembers)
         {
-            _out << (fixId(dataMember->name()) + "?: " + typeToTsString(dataMember->type()));
+            _out << (dataMember->mappedName() + "?: " + typeToTsString(dataMember->type()));
         }
         _out << epar << ";";
     }
@@ -2730,7 +2670,7 @@ Slice::Gen::TypeScriptVisitor::visitExceptionStart(const ExceptionPtr& p)
     for (const auto& dataMember : allDataMembers)
     {
         const string optionalModifier = dataMember->optional() ? "?" : "";
-        _out << nl << fixId(dataMember->name()) << optionalModifier << ": " << typeToTsString(dataMember->type(), true)
+        _out << nl << dataMember->mappedName() << optionalModifier << ": " << typeToTsString(dataMember->type(), true)
              << ";";
     }
     _out << eb;
@@ -2740,8 +2680,9 @@ Slice::Gen::TypeScriptVisitor::visitExceptionStart(const ExceptionPtr& p)
 bool
 Slice::Gen::TypeScriptVisitor::visitStructStart(const StructPtr& p)
 {
-    const string name = fixId(p->name());
+    const string name = p->mappedName();
     const DataMemberList dataMembers = p->dataMembers();
+
     _out << sp;
     writeDocCommentFor(p);
     _out << nl << "export class " << name << sb;
@@ -2749,7 +2690,7 @@ Slice::Gen::TypeScriptVisitor::visitStructStart(const StructPtr& p)
     for (const auto& dataMember : dataMembers)
     {
         // TODO why are all parameters optional?
-        _out << (fixDataMemberName(dataMember->name(), false, false) + "?: " + typeToTsString(dataMember->type()));
+        _out << (dataMember->mappedName() + "?: " + typeToTsString(dataMember->type()));
     }
     _out << epar << ";";
 
@@ -2770,11 +2711,8 @@ Slice::Gen::TypeScriptVisitor::visitStructStart(const StructPtr& p)
     _out << nl << " */";
     _out << nl << "equals(other: any): boolean;";
 
-    //
     // Only generate hashCode if this structure type is a legal dictionary key type.
-    //
-    bool isLegalKeyType = Dictionary::isLegalKeyType(p);
-    if (isLegalKeyType)
+    if (Dictionary::isLegalKeyType(p))
     {
         _out << sp;
         _out << nl << "/**";
@@ -2807,8 +2745,7 @@ Slice::Gen::TypeScriptVisitor::visitStructStart(const StructPtr& p)
     {
         _out << sp;
         writeDocCommentFor(dataMember);
-        _out << nl << fixDataMemberName(dataMember->name(), true, isLegalKeyType) << ":"
-             << typeToTsString(dataMember->type(), true) << ";";
+        _out << nl << dataMember->mappedName() << ":" << typeToTsString(dataMember->type(), true) << ";";
     }
 
     _out << eb;
@@ -2818,7 +2755,8 @@ Slice::Gen::TypeScriptVisitor::visitStructStart(const StructPtr& p)
 void
 Slice::Gen::TypeScriptVisitor::visitSequence(const SequencePtr& p)
 {
-    const string name = fixId(p->name());
+    const string name = p->mappedName();
+
     _out << sp;
     writeDocCommentFor(p);
     _out << nl << "export type " << name << " = " << typeToTsString(p) << ";";
@@ -2828,7 +2766,7 @@ Slice::Gen::TypeScriptVisitor::visitSequence(const SequencePtr& p)
     _out << nl << " * Helper class for encoding {@link " << name << "} into an OutputStream and";
     _out << nl << " * decoding {@link " << name << "} from an InputStream.";
     _out << nl << " */";
-    _out << nl << "export class " << fixId(p->name() + "Helper");
+    _out << nl << "export class " << name + "Helper";
     _out << sb;
 
     _out << nl << "/**";
@@ -2853,7 +2791,7 @@ Slice::Gen::TypeScriptVisitor::visitSequence(const SequencePtr& p)
 void
 Slice::Gen::TypeScriptVisitor::visitDictionary(const DictionaryPtr& p)
 {
-    const string name = fixId(p->name());
+    const string name = p->mappedName();
     _out << sp;
     writeDocCommentFor(p);
     string dictionaryType = typeToTsString(p);
@@ -2870,7 +2808,7 @@ Slice::Gen::TypeScriptVisitor::visitDictionary(const DictionaryPtr& p)
     _out << nl << " * Helper class for encoding {@link " << name << "} into an OutputStream and";
     _out << nl << " * decoding {@link " << name << "} from an InputStream.";
     _out << nl << " */";
-    _out << nl << "export class " << fixId(p->name() + "Helper");
+    _out << nl << "export class " << name + "Helper";
     _out << sb;
 
     _out << nl << "/**";
@@ -2895,15 +2833,17 @@ Slice::Gen::TypeScriptVisitor::visitDictionary(const DictionaryPtr& p)
 void
 Slice::Gen::TypeScriptVisitor::visitEnum(const EnumPtr& p)
 {
+    const string name = p->mappedName();
+
     _out << sp;
     writeDocCommentFor(p);
-    _out << nl << "export class " << fixId(p->name()) << " extends " << _iceImportPrefix << "Ice.EnumBase";
+    _out << nl << "export class " << name << " extends " << _iceImportPrefix << "Ice.EnumBase";
     _out << sb;
     for (const auto& enumerator : p->enumerators())
     {
         _out << sp;
         writeDocCommentFor(enumerator);
-        _out << nl << "static readonly " << fixId(enumerator->name()) << ": " << fixId(p->name()) << ";";
+        _out << nl << "static readonly " << enumerator->mappedName() << ": " << name << ";";
     }
     _out << nl;
     _out << nl << "/**";
@@ -2912,7 +2852,7 @@ Slice::Gen::TypeScriptVisitor::visitEnum(const EnumPtr& p)
     _out << nl << " * @param value The enumerator value.";
     _out << nl << " * @returns The enumerator for the given value.";
     _out << nl << " */";
-    _out << nl << "static valueOf(value: number): " << fixId(p->name()) << ";";
+    _out << nl << "static valueOf(value: number): " << name << ";";
     _out << eb;
 }
 
@@ -2921,7 +2861,7 @@ Slice::Gen::TypeScriptVisitor::visitConst(const ConstPtr& p)
 {
     _out << sp;
     writeDocCommentFor(p);
-    _out << nl << "export const " << fixId(p->name()) << ": " << typeToTsString(p->type()) << ";";
+    _out << nl << "export const " << p->mappedName() << ": " << typeToTsString(p->type()) << ";";
 }
 
 void

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -2242,7 +2242,7 @@ Slice::Gen::TypeScriptVisitor::visitUnitEnd(const UnitPtr&)
             auto pos = key.find(".");
             assert(pos != string::npos);
 
-            globalModules.insert(key.substr(0, pos - 1));
+            globalModules.insert(key.substr(0, pos));
         }
     }
 

--- a/cpp/src/slice2js/Gen.h
+++ b/cpp/src/slice2js/Gen.h
@@ -25,8 +25,7 @@ namespace Slice
 
         std::string getValue(const TypePtr&);
 
-        std::string
-        writeConstantValue(const TypePtr&, const SyntaxTreeBasePtr&, const std::string&);
+        std::string writeConstantValue(const TypePtr&, const SyntaxTreeBasePtr&, const std::string&);
 
         void writeDocCommentFor(const ContainedPtr& p, bool includeDeprecated = true);
 

--- a/cpp/src/slice2js/Gen.h
+++ b/cpp/src/slice2js/Gen.h
@@ -19,14 +19,14 @@ namespace Slice
         [[nodiscard]] std::vector<std::pair<std::string, std::string>> imports() const;
 
     protected:
-        void writeMarshalDataMembers(const DataMemberList&, const DataMemberList&, const ContainedPtr&);
-        void writeUnmarshalDataMembers(const DataMemberList&, const DataMemberList&, const ContainedPtr&);
-        void writeInitDataMembers(const DataMemberList&, const ContainedPtr&);
+        void writeMarshalDataMembers(const DataMemberList&, const DataMemberList&);
+        void writeUnmarshalDataMembers(const DataMemberList&, const DataMemberList&);
+        void writeInitDataMembers(const DataMemberList&);
 
-        std::string getValue(const std::string&, const TypePtr&);
+        std::string getValue(const TypePtr&);
 
         std::string
-        writeConstantValue(const std::string&, const TypePtr&, const SyntaxTreeBasePtr&, const std::string&);
+        writeConstantValue(const TypePtr&, const SyntaxTreeBasePtr&, const std::string&);
 
         void writeDocCommentFor(const ContainedPtr& p, bool includeDeprecated = true);
 

--- a/cpp/src/slice2js/JsUtil.h
+++ b/cpp/src/slice2js/JsUtil.h
@@ -20,14 +20,8 @@ namespace Slice
         virtual ~JsGenerator() = default;
 
         JsGenerator& operator=(const JsGenerator&) = delete;
-        static std::string fixDataMemberName(const std::string&, bool, bool);
-        static std::string fixId(const std::string&);
-
-        static std::string getUnqualified(const std::string&, const std::string&, const std::string&);
 
         static std::string typeToJsString(const TypePtr&, bool definition = false);
-
-        static std::string getLocalScope(const std::string&, const std::string& separator = ".");
 
         static std::string getHelper(const TypePtr&);
         //

--- a/js/test/Slice/escape/Clash.ice
+++ b/js/test/Slice/escape/Clash.ice
@@ -37,11 +37,11 @@ class Cls
     string istr;
     string ostr;
     string inS;
-    string in;
+    ["js:identifier:_in"] string in;
     string proxy;
     int obj;
     int getCookie;
-    string clone;
+    ["js:identifier:_clone"] string clone;
 }
 
 struct St
@@ -50,8 +50,8 @@ struct St
     short istr;
     int ostr;
     int rhs;
-    string hashCode;
-    int clone;
+    ["js:identifier:_hashCode"] string hashCode;
+    ["js:identifier:_clone"] int clone;
 }
 
 exception Ex

--- a/js/test/Slice/escape/Client.ts
+++ b/js/test/Slice/escape/Client.ts
@@ -23,7 +23,7 @@ export class Client extends TestHelper {
 
         out.write("testing proxies... ");
 
-        const casePrx = new escapedAwait.casePrx(communicator, `hello: ${this.getTestEndpoint()}`);
+        const casePrx = new escapedAwait._casePrx(communicator, `hello: ${this.getTestEndpoint()}`);
 
         try {
             await casePrx._catch(10);
@@ -32,7 +32,7 @@ export class Client extends TestHelper {
             test(ex instanceof Ice.LocalException);
         }
 
-        const typeofPrx = new escapedAwait.typeofPrx(communicator, `hello: ${this.getTestEndpoint()}`).ice_invocationTimeout(
+        const typeofPrx = new escapedAwait._typeofPrx(communicator, `hello: ${this.getTestEndpoint()}`).ice_invocationTimeout(
             100,
         );
 
@@ -56,12 +56,10 @@ export class Client extends TestHelper {
             escapedAwait.explicitPrx.uncheckedCast(communicator.stringToProxy("hello")),
             new Map<string, escapedAwait._break>(),
             "",
-            escapedAwait.explicitPrx.uncheckedCast(communicator.stringToProxy("hello")),
         );
 
         test(p._for._while === 100);
         test(p.goto === escapedAwait._var.base);
-        test(p._if instanceof escapedAwait.explicitPrx);
         test(p.internal instanceof Map);
         test(p._debugger === "");
         test(p._null instanceof escapedAwait.explicitPrx);

--- a/js/test/Slice/escape/Client.ts
+++ b/js/test/Slice/escape/Client.ts
@@ -2,7 +2,7 @@
 
 import { Ice } from "@zeroc/ice";
 import { TestHelper } from "../../Common/TestHelper.js";
-import { _await } from "./Key.js";
+import { escapedAwait } from "./Key.js";
 
 const test = TestHelper.test;
 
@@ -13,17 +13,17 @@ export class Client extends TestHelper {
 
         out.write("testing enums... ");
 
-        test(_await._var.base.value === 0);
+        test(escapedAwait._var.base.value === 0);
         out.writeLine("ok");
 
         out.write("testing structs... ");
-        const s = new _await._break(10);
+        const s = new escapedAwait._break(10);
         test(s._while == 10);
         out.writeLine("ok");
 
         out.write("testing proxies... ");
 
-        const casePrx = new _await.casePrx(communicator, `hello: ${this.getTestEndpoint()}`);
+        const casePrx = new escapedAwait.casePrx(communicator, `hello: ${this.getTestEndpoint()}`);
 
         try {
             await casePrx._catch(10);
@@ -32,7 +32,7 @@ export class Client extends TestHelper {
             test(ex instanceof Ice.LocalException);
         }
 
-        const typeofPrx = new _await.typeofPrx(communicator, `hello: ${this.getTestEndpoint()}`).ice_invocationTimeout(
+        const typeofPrx = new escapedAwait.typeofPrx(communicator, `hello: ${this.getTestEndpoint()}`).ice_invocationTimeout(
             100,
         );
 
@@ -46,26 +46,25 @@ export class Client extends TestHelper {
 
         out.write("testing classes... ");
 
-        const d = new _await._delete(10, null, 10);
-        test(d._if === 10);
+        const d = new escapedAwait._delete(null, 10);
         test(d._else === null);
         test(d._export === 10);
 
-        let p = new _await._package(
-            new _await._break(100),
-            _await._var.base,
-            _await.explicitPrx.uncheckedCast(communicator.stringToProxy("hello")),
-            new Map<string, _await._break>(),
+        let p = new escapedAwait._package(
+            new escapedAwait._break(100),
+            escapedAwait._var.base,
+            escapedAwait.explicitPrx.uncheckedCast(communicator.stringToProxy("hello")),
+            new Map<string, escapedAwait._break>(),
             "",
-            _await.explicitPrx.uncheckedCast(communicator.stringToProxy("hello")),
+            escapedAwait.explicitPrx.uncheckedCast(communicator.stringToProxy("hello")),
         );
 
         test(p._for._while === 100);
-        test(p.goto === _await._var.base);
-        test(p._if instanceof _await.explicitPrx);
+        test(p.goto === escapedAwait._var.base);
+        test(p._if instanceof escapedAwait.explicitPrx);
         test(p.internal instanceof Map);
         test(p._debugger === "");
-        test(p._null instanceof _await.explicitPrx);
+        test(p._null instanceof escapedAwait.explicitPrx);
         out.writeLine("ok");
     }
 

--- a/js/test/Slice/escape/Key.ice
+++ b/js/test/Slice/escape/Key.ice
@@ -78,17 +78,17 @@ module await
     {
         ["js:identifier:_in"]
         optional(1) break in(optional(2) var goto,
-                             ["js:identifier:_if"] out optional(3) explicit* if,
+                             ["js:identifier:_if"] optional(3) explicit* if,
                              optional(5) while internal,
                              out optional(7) string namespace,
-                             ["js:identifier:_null"] optional(8) explicit* null);
+                             out ["js:identifier:_null"] optional(8) explicit* null);
 
         ["amd"] ["js:identifier:_continue"]
         optional(1) break continue(optional(2) var goto,
-                                   ["js:identifier:_if"] out optional(3) explicit* if,
+                                   ["js:identifier:_if"] optional(3) explicit* if,
                                    optional(5) while internal,
                                    out optional(7) string namespace,
-                                   ["js:identifier:_null"] optional(8) explicit* null);
+                                   out ["js:identifier:_null"] optional(8) explicit* null);
     }
 
     ["js:identifier:_public"]

--- a/js/test/Slice/escape/Key.ice
+++ b/js/test/Slice/escape/Key.ice
@@ -27,7 +27,7 @@ module escapedAwait
     ["js:identifier:_typeof"]
     interface typeof
     {
-        ["js:identifier:_typeof"]
+        ["js:identifier:_default"]
         void default();
     }
 

--- a/js/test/Slice/escape/Key.ice
+++ b/js/test/Slice/escape/Key.ice
@@ -2,134 +2,113 @@
 
 #pragma once
 
+// TODO we need a better way to remap modules.
+["js:identifier:escapedAwait"]
 module await
 {
+    ["js:identifier:_var"]
+    enum var
+    {
+        base
+    }
 
-enum var
-{
-    base
+    ["js:identifier:_break"]
+    struct break
+    {
+        ["js:identifier:_while"] int while;
+        ["js:identifier:_constructor"] string constructor;
+    }
+
+    ["js:identifier:_case"]
+    interface case
+    {
+        ["amd"] ["js:identifier:_catch"] void catch(int checked, out ["js:identifier:_continue"] int continue);
+    }
+
+    ["js:identifier:_typeof"]
+    interface typeof
+    {
+        ["js:identifier:_typeof"]
+        void default();
+    }
+
+    ["js:identifier:_delete"]
+    class delete
+    {
+        ["js:identifier:_else"] case* else;
+        ["js:identifier:_export"] int export;
+        ["js:identifier:_clone"] string clone;
+    }
+
+    exception fixed
+    {
+        ["js:identifier:myFor"] int for;
+    }
+
+    exception foreach extends fixed
+    {
+        int goto;
+        ["js:identifier:_if"] int if;
+    }
+
+    interface explicit extends typeof, case
+    {
+        ["js:identifier:_in"] var in(
+            break internal,
+            ["js:identifier:_new"] typeof* new,
+            ["js:identifier:_null"] delete null,
+            int override
+        ) throws fixed, foreach;
+    }
+
+    ["js:identifier:_while"]
+    dictionary<string, break> while;
+
+    ["js:identifier:_package"]
+    class package
+    {
+        ["js:identifier:_for"] optional(1) break for;
+        optional(2) var goto;
+        ["js:identifier:_null"] optional(3) explicit* null;
+        optional(5) while internal;
+        ["js:identifier:_debugger"] optional(7) string debugger;
+    }
+
+    interface optionalParams
+    {
+        ["js:identifier:_in"]
+        optional(1) break in(optional(2) var goto,
+                             ["js:identifier:_if"] out optional(3) explicit* if,
+                             optional(5) while internal,
+                             out optional(7) string namespace,
+                             ["js:identifier:_null"] optional(8) explicit* null);
+
+        ["amd"] ["js:identifier:_continue"]
+        optional(1) break continue(optional(2) var goto,
+                                   ["js:identifier:_if"] out optional(3) explicit* if,
+                                   optional(5) while internal,
+                                   out optional(7) string namespace,
+                                   ["js:identifier:_null"] optional(8) explicit* null);
+    }
+
+    ["js:identifier:_public"]
+    const int public = 0;
+
+    // System as inner module.
+    module System
+    {
+        interface Test
+        {
+            void op();
+        }
+    }
 }
 
-struct break
-{
-    int while;
-    string clone;
-    string equals;
-    string hashCode;
-    string constructor;
-}
-
-interface case
-{
-    ["amd"] void catch(int checked, out int continue);
-}
-
-interface typeof
-{
-    void default();
-}
-
-class delete
-{
-    int if;
-    case* else;
-    int export;
-    string clone;
-    string equals;
-    string hashCode;
-    string constructor;
-}
-
-interface explicit extends typeof, case
-{
-}
-
-dictionary<string, break> while;
-
-class package
-{
-    optional(1) break for;
-    optional(2) var goto;
-    optional(3) explicit* if;
-    optional(5) while internal;
-    optional(7) string debugger;
-    optional(8) explicit* null;
-}
-
-interface optionalParams
-{
-    optional(1) break for(optional(2) var goto,
-                          optional(3) explicit* if,
-                          optional(5) while internal,
-                          optional(7) string namespace,
-                          optional(8) explicit* null);
-
-    ["amd"]
-    optional(1) break continue(optional(2) var goto,
-                               optional(3) explicit* if,
-                               optional(5) while internal,
-                               optional(7) string namespace,
-                               optional(8) explicit* null);
-
-    optional(1) break in(out optional(2) var goto,
-                         out optional(3) explicit* if,
-                         out optional(5) while internal,
-                         out optional(7) string namespace,
-                         out optional(8) explicit* null);
-
-    ["amd"]
-    optional(1) break foreach(out optional(2) var goto,
-                              out optional(3) explicit* if,
-                              out optional(5) while internal,
-                              out optional(7) string namespace,
-                              out optional(8) explicit* null);
-}
-
-exception fixed
-{
-    int for;
-}
-
-exception foreach extends fixed
-{
-    int goto;
-    int if;
-}
-
-interface implicit
-{
-    var in(break internal, delete is, explicit* lock, case* namespace, typeof* new, delete null,
-          explicit* operator, int override, int params, int private)
-        throws fixed, foreach;
-}
-
-const int protected = 0;
-const int public = 0;
-
-//
-// System as inner module.
-//
-module System
-{
-
-interface Test
-{
-    void op();
-}
-
-}
-
-}
-
-//
 // System as outer module.
-//
 module System
 {
-
-interface Test
-{
-    void op();
-}
-
+    interface Test
+    {
+        void op();
+    }
 }

--- a/js/test/Slice/escape/Key.ice
+++ b/js/test/Slice/escape/Key.ice
@@ -3,8 +3,7 @@
 #pragma once
 
 // TODO we need a better way to remap modules.
-["js:identifier:escapedAwait"]
-module await
+module escapedAwait
 {
     ["js:identifier:_var"]
     enum var


### PR DESCRIPTION
This PR adds support for `js:identifier` just like we did in all the other languages so far.
It fixes the `escape` test to use the new metadata, and also cleans up the `slice2js` compiler a little while I was in there.