### PR TITLE
Add PythonDispatcher to handle calls to servant dispatch methods

### DIFF
--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -2249,16 +2249,10 @@ Upcall::dispatchImpl(PyObject* servant, const string& dispatchName, PyObject* ar
         throw Ice::UnknownException{__FILE__, __LINE__, ostr.str()};
     }
 
-    // Get the dispatch function from Ice.PythonDispatcher module.
+    // Get the dispatch function from Ice.Dispatch module.
     // lookupType() returns a borrowed reference.
-    PyObject* dispatchMethod = lookupType("Ice.PythonDispatcher.dispatch");
-    if (!dispatchMethod)
-    {
-        ostringstream ostr;
-        ostr << "dispatch method not found for identity " << communicator->identityToString(current.id)
-             << " and operation '" << dispatchName << "'";
-        throw Ice::UnknownException{__FILE__, __LINE__, ostr.str()};
-    }
+    PyObject* dispatchMethod = lookupType("Ice.Dispatch.dispatch");
+    assert(dispatchMethod);
     Py_INCREF(dispatchMethod);
     // Ensure we release the reference when this method exist.
     PyObjectHandle dispatchMethodHandle{dispatchMethod};

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -1077,9 +1077,9 @@ namespace IcePy
     static PyTypeObject DispatchCallbackType = {
         /* The ob_type field must be initialized in the module init function
          * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.Dispatch", /* tp_name */
-        sizeof(DispatchCallbackObject),               /* tp_basicsize */
-        0,                                            /* tp_itemsize */
+        PyVarObject_HEAD_INIT(0, 0) "IcePy.DispatchCallback", /* tp_name */
+        sizeof(DispatchCallbackObject),                       /* tp_basicsize */
+        0,                                                    /* tp_itemsize */
         /* methods */
         reinterpret_cast<destructor>(dispatchCallbackDealloc), /* tp_dealloc */
         0,                                                     /* tp_print */
@@ -2249,17 +2249,19 @@ Upcall::dispatchImpl(PyObject* servant, const string& dispatchName, PyObject* ar
         throw Ice::UnknownException{__FILE__, __LINE__, ostr.str()};
     }
 
-    //
-    // Get the _iceDispatch method. The _iceDispatch method will invoke the servant method and pass it the arguments.
-    //
-    PyObjectHandle dispatchMethod{getAttr(servant, "_iceDispatch", false)};
-    if (!dispatchMethod.get())
+    // Get the dispatch function from Ice.PythonDispatcher module.
+    // lookupType() returns a borrowed reference.
+    PyObject* dispatchMethod = lookupType("Ice.PythonDispatcher.dispatch");
+    if (!dispatchMethod)
     {
         ostringstream ostr;
-        ostr << "_iceDispatch method not found for identity " << communicator->identityToString(current.id)
+        ostr << "dispatch method not found for identity " << communicator->identityToString(current.id)
              << " and operation '" << dispatchName << "'";
         throw Ice::UnknownException{__FILE__, __LINE__, ostr.str()};
     }
+    Py_INCREF(dispatchMethod);
+    // Ensure we release the reference when this method exist.
+    PyObjectHandle dispatchMethodHandle{dispatchMethod};
 
     PyObjectHandle dispatchArgs{PyTuple_New(3)};
     if (!dispatchArgs.get())
@@ -2279,9 +2281,9 @@ Upcall::dispatchImpl(PyObject* servant, const string& dispatchName, PyObject* ar
     PyTuple_SET_ITEM(dispatchArgs.get(), 2, args); // Steals a reference.
 
     //
-    // Ignore the return value of _iceDispatch -- it will use the dispatch callback.
+    // Ignore the return value of dispatch -- it will use the dispatch callback.
     //
-    PyObjectHandle ignored{PyObject_Call(dispatchMethod.get(), dispatchArgs.get(), 0)};
+    PyObjectHandle ignored{PyObject_Call(dispatchMethod, dispatchArgs.get(), 0)};
 
     //
     // Check for exceptions.

--- a/python/python/Ice/PythonDispatcher.py
+++ b/python/python/Ice/PythonDispatcher.py
@@ -38,7 +38,7 @@ def dispatch(cb, method, args):
     result = method(*args)
 
     # If the result is a coroutine and the communicator has a custom coroutine executor, execute the coroutine using
-    # the configured executor.
+    # the configured coroutine executor.
     if inspect.iscoroutine(result):
         assert (
             len(args) > 0

--- a/python/python/Ice/PythonDispatcher.py
+++ b/python/python/Ice/PythonDispatcher.py
@@ -1,0 +1,92 @@
+# Copyright (c) ZeroC, Inc.
+
+import inspect
+import sys
+
+def is_future(obj):
+    return callable(
+        getattr(obj, "add_done_callback", None)
+    )
+
+def dispatch(cb, method, args):
+    """
+    Dispatch a request to the given servant method.
+
+    This function is called by IcePy from an Ice server thread pool thread to dispatch a request to a servant method
+    with the given arguments. The method's result is then sent back to IcePy using the provided callback.
+
+    The method can return:
+    - A direct result, which is immediately sent back.
+    - A coroutine.
+    - A future.
+
+    If the result is a coroutine and the Ice communicator has a custom coroutine executor, the executor is used to
+    execute the coroutine, and the resulting future is used to wait for the dispatch completion.
+
+    Parameters
+    ----------
+    cb : IcePy.DispatchCallback
+        The callback used to return the result or report an exception to IcePy.
+    method : callable
+        The servant method to invoke. This method is bound to the servant instance and takes the request parameters as
+        arguments.
+    args : list
+        The request parameters.
+    """
+
+    # Invoke the servant method with the request parameters. Let exceptions propagate to the caller.
+    result = method(*args)
+
+    # If the result is a coroutine and the communicator has a custom coroutine executor, execute the coroutine using
+    # the configured executor.
+    if inspect.iscoroutine(result):
+        assert (
+            len(args) > 0
+        ), "args must have at least one element representing the dispatch current parameter"
+        current = args[-1]
+        coroutineExecutor = current.adapter.getCommunicator().getCoroutineExecutor()
+        if coroutineExecutor:
+            result = coroutineExecutor(result)
+            if not is_future(result):
+                raise TypeError("The coroutine executor must return a Future-like object")
+
+    # If the result is a future, attach a done callback to handle dispatch completion.
+    if is_future(result):
+        def handle_future_result(future):
+            try:
+                cb.response(future.result())
+            except Exception:
+                cb.exception(sys.exc_info()[1])
+
+        result.add_done_callback(handle_future_result)
+
+    # If the result is a coroutine and no custom coroutine executor is available, run the coroutine synchronously in
+    # the current thread using run_coroutine helper function.
+    elif inspect.iscoroutine(result):
+        run_coroutine(cb, result)
+
+    # Otherwise, return the result directly.
+    else:
+        cb.response(result)
+
+def run_coroutine(cb, coroutine, value=None, exception=None):
+    try:
+        if exception:
+            result = coroutine.throw(exception)
+        else:
+            result = coroutine.send(value)
+
+        if is_future(result):
+            def handle_future_result(future):
+                try:
+                    run_coroutine(cb, coroutine, value=future.result())
+                except BaseException:
+                    run_coroutine(cb, coroutine, exception=sys.exc_info()[1])
+
+            result.add_done_callback(handle_future_result)
+        else:
+            raise RuntimeError(f"unexpected value of type {type(result)} returned by coroutine.send()")
+    except StopIteration as ex:
+        cb.response(ex.value)
+    except BaseException:
+        cb.exception(sys.exc_info()[1])


### PR DESCRIPTION
This PR moves the logic from Python Object._iceDispatch implementation to PythonDispatcher.dispatch. It add some comments to clarify the implementation and cleanups things.