### PR TITLE
Update Swift enum casing

### DIFF
--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -826,12 +826,12 @@ SwiftGenerator::modeToString(Operation::Mode opMode)
     {
         case Operation::Normal:
         {
-            mode = ".Normal";
+            mode = ".normal";
             break;
         }
         case Operation::Idempotent:
         {
-            mode = ".Idempotent";
+            mode = ".idempotent";
             break;
         }
         default:

--- a/slice/Ice/OperationMode.ice
+++ b/slice/Ice/OperationMode.ice
@@ -27,18 +27,22 @@ module Ice
         /// Ordinary operations have <code>Normal</code> mode. These operations modify object state; invoking such an
         /// operation twice in a row has different semantics than invoking it once. The Ice run time guarantees that it
         /// will not violate at-most-once semantics for <code>Normal</code> operations.
+        ["swift:identifier:normal"]
         Normal,
 
         /// Operations that are <code>nonmutating</code> must not modify object state.
         /// The Ice run-time no longer makes a distinction between nonmutating operations and idempotent operations.
         /// Use the <code>idempotent</code> keyword instead.
-        ["deprecated:Use Idempotent instead."] Nonmutating,
+        ["deprecated:Use Idempotent instead."]
+        ["swift:identifier:nonMutating"]
+        Nonmutating,
 
         /// Operations that use the Slice <code>idempotent</code> keyword can modify object state, but invoking an
         /// operation twice in a row must result in the same object state as invoking it once. For example,
         /// <code>x = 1</code> is an idempotent statement, whereas <code>x += 1</code> is not. In addition, the Ice
         /// run time will attempt to transparently recover from certain run-time errors by re-issuing a failed request
         /// and propagate the failure to the application only if the second attempt fails.
+        ["swift:identifier:idempotent"]
         Idempotent
     }
 }

--- a/slice/Ice/OperationMode.ice
+++ b/slice/Ice/OperationMode.ice
@@ -34,7 +34,7 @@ module Ice
         /// The Ice run-time no longer makes a distinction between nonmutating operations and idempotent operations.
         /// Use the <code>idempotent</code> keyword instead.
         ["deprecated:Use Idempotent instead."]
-        ["swift:identifier:nonMutating"]
+        ["swift:identifier:nonmutating"]
         Nonmutating,
 
         /// Operations that use the Slice <code>idempotent</code> keyword can modify object state, but invoking an

--- a/slice/Ice/RemoteLogger.ice
+++ b/slice/Ice/RemoteLogger.ice
@@ -21,15 +21,19 @@ module Ice
     enum LogMessageType
     {
         /// The {@link RemoteLogger} received a print message.
+        ["swift:identifier:printMessage"]
         PrintMessage,
 
         /// The {@link RemoteLogger} received a trace message.
+        ["swift:identifier:traceMessage"]
         TraceMessage,
 
         /// The {@link RemoteLogger} received a warning message.
+        ["swift:identifier:warningMessage"]
         WarningMessage,
 
         /// The {@link RemoteLogger} received an error message.
+        ["swift:identifier:errorMessage"]
         ErrorMessage
     }
 

--- a/slice/IceGrid/Admin.ice
+++ b/slice/IceGrid/Admin.ice
@@ -27,25 +27,32 @@ module IceGrid
     enum ServerState
     {
         /// The server is not running.
+        ["swift:identifier:inactive"]
         Inactive,
 
         /// The server is being activated and will change to the active state when the registered server object adapters
         /// are activated or to the activation timed out state if the activation timeout expires.
+        ["swift:identifier:activating"]
         Activating,
 
         /// The activation timed out state indicates that the server activation timed out.
+        ["swift:identifier:activationTimedOut"]
         ActivationTimedOut,
 
         /// The server is running.
+        ["swift:identifier:active"]
         Active,
 
         /// The server is being deactivated.
+        ["swift:identifier:deactivating"]
         Deactivating,
 
         /// The server is being destroyed.
+        ["swift:identifier:destroying"]
         Destroying,
 
         /// The server is destroyed.
+        ["swift:identifier:destroyed"]
         Destroyed
     }
 

--- a/slice/IceGrid/Registry.ice
+++ b/slice/IceGrid/Registry.ice
@@ -24,12 +24,15 @@ module IceGrid
     enum LoadSample
     {
         /// Sample every minute.
+        ["swift:identifier:loadSample1"]
         LoadSample1,
 
         /// Sample every five minutes.
+        ["swift:identifier:loadSample5"]
         LoadSample5,
 
         /// Sample every fifteen minutes.
+        ["swift:identifier:loadSample15"]
         LoadSample15
     }
 

--- a/swift/src/Ice/Proxy.swift
+++ b/swift/src/Ice/Proxy.swift
@@ -397,7 +397,7 @@ extension ObjectPrx {
     ) async throws {
         return try await _impl._invoke(
             operation: "ice_ping",
-            mode: .Idempotent,
+            mode: .idempotent,
             context: context)
     }
 
@@ -413,7 +413,7 @@ extension ObjectPrx {
     ) async throws -> Bool {
         return try await _impl._invoke(
             operation: "ice_isA",
-            mode: .Idempotent,
+            mode: .idempotent,
             write: { ostr in
                 ostr.write(id)
             },
@@ -431,7 +431,7 @@ extension ObjectPrx {
     ) async throws -> String {
         return try await _impl._invoke(
             operation: "ice_id",
-            mode: .Idempotent,
+            mode: .idempotent,
             read: { istr in try istr.read() as String },
             context: context)
     }
@@ -446,7 +446,7 @@ extension ObjectPrx {
     ) async throws -> StringSeq {
         return try await _impl._invoke(
             operation: "ice_ids",
-            mode: .Idempotent,
+            mode: .idempotent,
             read: { istr in try istr.read() as StringSeq },
             context: context)
     }

--- a/swift/test/Ice/invoke/AllTests.swift
+++ b/swift/test/Ice/invoke/AllTests.swift
@@ -27,15 +27,15 @@ func allTests(_ helper: TestHelper) async throws -> MyClassPrx {
 
     output.write("testing ice_invoke... ")
     do {
-        try await test(oneway.ice_invoke(operation: "opOneway", mode: .Normal, inEncaps: Data()).ok)
+        try await test(oneway.ice_invoke(operation: "opOneway", mode: .normal, inEncaps: Data()).ok)
         try await test(
-            batchOneway.ice_invoke(operation: "opOneway", mode: .Normal, inEncaps: Data()).ok)
+            batchOneway.ice_invoke(operation: "opOneway", mode: .normal, inEncaps: Data()).ok)
         try await test(
-            batchOneway.ice_invoke(operation: "opOneway", mode: .Normal, inEncaps: Data()).ok)
+            batchOneway.ice_invoke(operation: "opOneway", mode: .normal, inEncaps: Data()).ok)
         try await test(
-            batchOneway.ice_invoke(operation: "opOneway", mode: .Normal, inEncaps: Data()).ok)
+            batchOneway.ice_invoke(operation: "opOneway", mode: .normal, inEncaps: Data()).ok)
         try await test(
-            batchOneway.ice_invoke(operation: "opOneway", mode: .Normal, inEncaps: Data()).ok)
+            batchOneway.ice_invoke(operation: "opOneway", mode: .normal, inEncaps: Data()).ok)
 
         try await batchOneway.ice_flushBatchRequests()
         let outS = Ice.OutputStream(communicator: communicator)
@@ -43,7 +43,7 @@ func allTests(_ helper: TestHelper) async throws -> MyClassPrx {
         outS.write(testString)
         outS.endEncapsulation()
         let inEncaps = outS.finished()
-        let result = try await cl.ice_invoke(operation: "opString", mode: .Normal, inEncaps: inEncaps)
+        let result = try await cl.ice_invoke(operation: "opString", mode: .normal, inEncaps: inEncaps)
         try test(result.ok)
         let inS = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
         _ = try inS.startEncapsulation()
@@ -61,7 +61,7 @@ func allTests(_ helper: TestHelper) async throws -> MyClassPrx {
             ctx["raise"] = ""
         }
         let result = try await cl.ice_invoke(
-            operation: "opException", mode: .Normal, inEncaps: Data(), context: ctx)
+            operation: "opException", mode: .normal, inEncaps: Data(), context: ctx)
         try test(!result.ok)
         let inS = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
         _ = try inS.startEncapsulation()

--- a/swift/test/Ice/operations/TestI.swift
+++ b/swift/test/Ice/operations/TestI.swift
@@ -22,7 +22,7 @@ class MyDerivedClassI: ObjectI<MyDerivedClassTraits>, MyDerivedClass {
     }
 
     func opVoid(current: Ice.Current) async throws {
-        try _helper.test(current.mode == .Normal)
+        try _helper.test(current.mode == .normal)
     }
 
     func opBool(p1: Bool, p2: Bool, current _: Ice.Current) async throws -> (
@@ -400,7 +400,7 @@ class MyDerivedClassI: ObjectI<MyDerivedClassTraits>, MyDerivedClass {
     }
 
     func opIdempotent(current: Ice.Current) async throws {
-        try _helper.test(current.mode == .Idempotent)
+        try _helper.test(current.mode == .idempotent)
     }
 
     func opDerived(current _: Ice.Current) async throws {}

--- a/swift/test/Ice/optional/AllTests.swift
+++ b/swift/test/Ice/optional/AllTests.swift
@@ -484,7 +484,7 @@ func allTests(_ helper: TestHelper) async throws -> InitialPrx {
         let inEncaps = ostr.finished()
         let result = try await initial.ice_invoke(
             operation: "pingPong",
-            mode: Ice.OperationMode.Normal,
+            mode: .normal,
             inEncaps: inEncaps)
         try test(result.ok)
 
@@ -505,7 +505,7 @@ func allTests(_ helper: TestHelper) async throws -> InitialPrx {
         let inEncaps = ostr.finished()
         let result = try await initial.ice_invoke(
             operation: "pingPong",
-            mode: .Normal,
+            mode: .normal,
             inEncaps: inEncaps)
         try test(result.ok)
         let istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
@@ -540,7 +540,7 @@ func allTests(_ helper: TestHelper) async throws -> InitialPrx {
         ostr.endEncapsulation()
         let inEncaps = ostr.finished()
         let result = try await initial.ice_invoke(
-            operation: "opVoid", mode: .Normal, inEncaps: inEncaps)
+            operation: "opVoid", mode: .normal, inEncaps: inEncaps)
         try test(result.ok)
     }
     output.writeLine("ok")
@@ -571,7 +571,7 @@ func allTests(_ helper: TestHelper) async throws -> InitialPrx {
         ostr.endEncapsulation()
         let inEncaps = ostr.finished()
         let result = try await initial.ice_invoke(
-            operation: "pingPong", mode: .Normal, inEncaps: inEncaps)
+            operation: "pingPong", mode: .normal, inEncaps: inEncaps)
         try test(result.ok)
         let istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
         _ = try istr.startEncapsulation()
@@ -609,7 +609,7 @@ func allTests(_ helper: TestHelper) async throws -> InitialPrx {
         ostr.endEncapsulation()
         let inEncaps = ostr.finished()
         let result = try await initial.ice_invoke(
-            operation: "pingPong", mode: .Normal, inEncaps: inEncaps)
+            operation: "pingPong", mode: .normal, inEncaps: inEncaps)
         try test(result.ok)
         let istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
         _ = try istr.startEncapsulation()
@@ -674,7 +674,7 @@ func allTests(_ helper: TestHelper) async throws -> InitialPrx {
             var inEncaps = ostr.finished()
             factory.setEnabled(enabled: true)
             var result = try await initial.ice_invoke(
-                operation: "pingPong", mode: .Normal, inEncaps: inEncaps)
+                operation: "pingPong", mode: .normal, inEncaps: inEncaps)
             try test(result.ok)
             var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
             _ = try istr.startEncapsulation()
@@ -692,7 +692,7 @@ func allTests(_ helper: TestHelper) async throws -> InitialPrx {
             ostr.endEncapsulation()
             inEncaps = ostr.finished()
             result = try await initial.ice_invoke(
-                operation: "pingPong", mode: .Normal, inEncaps: inEncaps)
+                operation: "pingPong", mode: .normal, inEncaps: inEncaps)
             try test(result.ok)
             istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
             _ = try istr.startEncapsulation()
@@ -718,7 +718,7 @@ func allTests(_ helper: TestHelper) async throws -> InitialPrx {
             let inEncaps = ostr.finished()
             let result = try await initial.ice_invoke(
                 operation: "opClassAndUnknownOptional",
-                mode: .Normal,
+                mode: .normal,
                 inEncaps: inEncaps)
             try test(result.ok)
 
@@ -908,7 +908,7 @@ func testByte(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.write(tag: 2, value: p1)
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
-    let result = try await initial.ice_invoke(operation: "opByte", mode: .Normal, inEncaps: inEncaps)
+    let result = try await initial.ice_invoke(operation: "opByte", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(istr.readOptional(tag: 1, expectedFormat: .F1))
@@ -956,7 +956,7 @@ func testBool(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.write(tag: 2, value: p1)
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
-    let result = try await initial.ice_invoke(operation: "opBool", mode: .Normal, inEncaps: inEncaps)
+    let result = try await initial.ice_invoke(operation: "opBool", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(istr.readOptional(tag: 1, expectedFormat: .F1))
@@ -1003,7 +1003,7 @@ func testShort(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.write(tag: 2, value: p1)
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
-    let result = try await initial.ice_invoke(operation: "opShort", mode: .Normal, inEncaps: inEncaps)
+    let result = try await initial.ice_invoke(operation: "opShort", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(istr.readOptional(tag: 1, expectedFormat: .F2))
@@ -1051,7 +1051,7 @@ func testInt32(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opInt", mode: Ice.OperationMode.Normal, inEncaps: inEncaps)
+        operation: "opInt", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(istr.readOptional(tag: 1, expectedFormat: .F4))
@@ -1098,7 +1098,7 @@ func testInt64(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.write(tag: 1, value: p1)
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
-    let result = try await initial.ice_invoke(operation: "opLong", mode: .Normal, inEncaps: inEncaps)
+    let result = try await initial.ice_invoke(operation: "opLong", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(istr.readOptional(tag: 2, expectedFormat: .F8))
@@ -1145,7 +1145,7 @@ func testFloat(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.write(tag: 2, value: p1)
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
-    let result = try await initial.ice_invoke(operation: "opFloat", mode: .Normal, inEncaps: inEncaps)
+    let result = try await initial.ice_invoke(operation: "opFloat", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(istr.readOptional(tag: 1, expectedFormat: .F4))
@@ -1192,7 +1192,7 @@ func testDouble(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opDouble", mode: .Normal, inEncaps: inEncaps)
+        operation: "opDouble", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(istr.readOptional(tag: 1, expectedFormat: .F8))
@@ -1240,7 +1240,7 @@ func testString(initial: InitialPrx, helper: TestHelper) async throws {
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
         operation: "opString",
-        mode: .Normal,
+        mode: .normal,
         inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
@@ -1289,7 +1289,7 @@ func testEnum(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opMyEnum", mode: .Normal, inEncaps: inEncaps)
+        operation: "opMyEnum", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(istr.readOptional(tag: 1, expectedFormat: .Size))
@@ -1336,7 +1336,7 @@ func testSmallStruct(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opSmallStruct", mode: .Normal, inEncaps: inEncaps)
+        operation: "opSmallStruct", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     var s: SmallStruct = try istr.read(tag: 1)!
@@ -1384,7 +1384,7 @@ func testFixedStruct(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opFixedStruct", mode: .Normal, inEncaps: inEncaps)
+        operation: "opFixedStruct", mode: .normal, inEncaps: inEncaps)
 
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
@@ -1436,7 +1436,7 @@ func testVarStruct(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opVarStruct", mode: .Normal, inEncaps: inEncaps)
+        operation: "opVarStruct", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     var v: VarStruct = try istr.read(tag: 1)!
@@ -1476,7 +1476,7 @@ func testOneOptional(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opOneOptional", mode: .Normal, inEncaps: inEncaps)
+        operation: "opOneOptional", mode: .normal, inEncaps: inEncaps)
     let istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     var v1: Ice.Value?
@@ -1517,7 +1517,7 @@ func testMyInterfacePrx(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opMyInterfaceProxy", mode: .Normal, inEncaps: inEncaps)
+        operation: "opMyInterfaceProxy", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     p2 = try istr.read(tag: 1, type: MyInterfacePrx.self)
@@ -1565,7 +1565,7 @@ func testByteSeq(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opByteSeq", mode: .Normal, inEncaps: inEncaps)
+        operation: "opByteSeq", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(istr.read(tag: 1) == p1)
@@ -1611,7 +1611,7 @@ func testBoolSeq(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opBoolSeq", mode: .Normal, inEncaps: inEncaps)
+        operation: "opBoolSeq", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(istr.read(tag: 1) == p1)
@@ -1657,7 +1657,7 @@ func testInt16Seq(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opShortSeq", mode: .Normal, inEncaps: inEncaps)
+        operation: "opShortSeq", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(istr.read(tag: 1) == p1)
@@ -1703,7 +1703,7 @@ func testInt32Seq(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opIntSeq", mode: .Normal, inEncaps: inEncaps)
+        operation: "opIntSeq", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(istr.read(tag: 1) == p1)
@@ -1749,7 +1749,7 @@ func testInt64Seq(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opLongSeq", mode: .Normal, inEncaps: inEncaps)
+        operation: "opLongSeq", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(istr.read(tag: 1) == p1)
@@ -1796,7 +1796,7 @@ func testFloatSeq(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opFloatSeq", mode: .Normal, inEncaps: inEncaps)
+        operation: "opFloatSeq", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(istr.read(tag: 1) == p1)
@@ -1842,7 +1842,7 @@ func testDoubleSeq(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opDoubleSeq", mode: .Normal, inEncaps: inEncaps)
+        operation: "opDoubleSeq", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(istr.read(tag: 1) == p1)
@@ -1888,7 +1888,7 @@ func testStringSeq(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opStringSeq", mode: .Normal, inEncaps: inEncaps)
+        operation: "opStringSeq", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(istr.read(tag: 1) == p1)
@@ -1935,7 +1935,7 @@ func testSmallStructSeq(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opSmallStructSeq", mode: .Normal, inEncaps: inEncaps)
+        operation: "opSmallStructSeq", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(SmallStructSeqHelper.read(from: istr, tag: 1) == p1)
@@ -1982,7 +1982,7 @@ func testFixedStructSeq(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opFixedStructSeq", mode: .Normal, inEncaps: inEncaps)
+        operation: "opFixedStructSeq", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(FixedStructSeqHelper.read(from: istr, tag: 1) == p1)
@@ -2028,7 +2028,7 @@ func testVarStructSeq(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opVarStructSeq", mode: .Normal, inEncaps: inEncaps)
+        operation: "opVarStructSeq", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(VarStructSeqHelper.read(from: istr, tag: 1) == p1)
@@ -2074,7 +2074,7 @@ func testInt32Int32Dict(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     let inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opIntIntDict", mode: .Normal, inEncaps: inEncaps)
+        operation: "opIntIntDict", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(IntIntDictHelper.read(from: istr, tag: 1) == p1)
@@ -2120,7 +2120,7 @@ func testStringInt32Dict(initial: InitialPrx, helper: TestHelper) async throws {
     ostr.endEncapsulation()
     var inEncaps = ostr.finished()
     let result = try await initial.ice_invoke(
-        operation: "opStringIntDict", mode: .Normal, inEncaps: inEncaps)
+        operation: "opStringIntDict", mode: .normal, inEncaps: inEncaps)
     var istr = Ice.InputStream(communicator: communicator, bytes: result.outEncaps)
     _ = try istr.startEncapsulation()
     try test(StringIntDictHelper.read(from: istr, tag: 1) == p1)

--- a/swift/test/Ice/proxy/AllTests.swift
+++ b/swift/test/Ice/proxy/AllTests.swift
@@ -744,7 +744,7 @@ public func allTests(_ helper: TestHelper) async throws -> MyClassPrx {
         inEncaps[5] = version.minor
 
         _ = try await cl.ice_invoke(
-            operation: "ice_ping", mode: Ice.OperationMode.Normal, inEncaps: inEncaps)
+            operation: "ice_ping", mode: .normal, inEncaps: inEncaps)
         try test(false)
     } catch let ex as Ice.UnknownLocalException {
         try test(
@@ -761,7 +761,7 @@ public func allTests(_ helper: TestHelper) async throws -> MyClassPrx {
         inEncaps[4] = version.major
         inEncaps[5] = version.minor
         _ = try await cl.ice_invoke(
-            operation: "ice_ping", mode: Ice.OperationMode.Normal, inEncaps: inEncaps)
+            operation: "ice_ping", mode: .normal, inEncaps: inEncaps)
         try test(false)
     } catch let ex as Ice.UnknownLocalException {
         try test(


### PR DESCRIPTION
This PR updates the Swift enums (for the public API, I didn't do the tests) to use the preferred Swift enum casing format.