### PR TITLE
Fail earlier on ConnectTimeout for multi-home endpoint

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingConnectionFactory.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingConnectionFactory.java
@@ -825,15 +825,16 @@ final class OutgoingConnectionFactory {
             }
 
             _factory.handleConnectionException(ex, _hasMore || _iter.hasNext());
-            if (ex instanceof CommunicatorDestroyedException) // No need to continue.
-            {
-                _factory.finishGetConnection(_connectors, ex, this);
-            } else if (_iter.hasNext()) // Try the next connector.
-            {
-                return true;
-            } else {
-                _factory.finishGetConnection(_connectors, ex, this);
+
+            // We stop on ConnectTimeoutException to fail reasonably fast when the endpoint has many
+            // connectors (IP addresses).
+            if (_iter.hasNext()
+                    && !(ex instanceof CommunicatorDestroyedException
+                            || ex instanceof ConnectTimeoutException)) {
+                return true; // keep going
             }
+
+            _factory.finishGetConnection(_connectors, ex, this);
             return false;
         }
 

--- a/js/src/Ice/OutgoingConnectionFactory.js
+++ b/js/src/Ice/OutgoingConnectionFactory.js
@@ -623,8 +623,10 @@ class ConnectCallback {
 
         // We stop on ConnectTimeoutException to fail reasonably fast when the endpoint has many connectors
         // (IP addresses).
-        if (this._index < this._endpoints.length &&
-            !(ex instanceof CommunicatorDestroyedException || ex instanceof ConnectTimeoutException)) {
+        if (
+            this._index < this._endpoints.length &&
+            !(ex instanceof CommunicatorDestroyedException || ex instanceof ConnectTimeoutException)
+        ) {
             return true; // keep going
         }
 

--- a/js/src/Ice/OutgoingConnectionFactory.js
+++ b/js/src/Ice/OutgoingConnectionFactory.js
@@ -5,6 +5,7 @@ import { HashMap } from "./HashMap.js";
 import { Promise } from "./Promise.js";
 import { LocalException } from "./LocalException.js";
 import { CommunicatorDestroyedException } from "./LocalExceptions.js";
+import { ConnectTimeoutException } from "./LocalExceptions.js";
 
 //
 // Only for use by Instance.
@@ -618,20 +619,16 @@ class ConnectCallback {
     }
 
     connectionStartFailedImpl(ex) {
-        if (ex instanceof LocalException) {
-            this._factory.handleConnectionException(ex, this._hasMore || this._index < this._endpoints.length);
-            if (ex instanceof CommunicatorDestroyedException) {
-                // No need to continue.
-                this._factory.finishGetConnectionEx(this._endpoints, ex, this);
-            } else if (this._index < this._endpoints.length) {
-                // Try the next endpoint.
-                return true;
-            } else {
-                this._factory.finishGetConnectionEx(this._endpoints, ex, this);
-            }
-        } else {
-            this._factory.finishGetConnectionEx(this._endpoints, ex, this);
+        this._factory.handleConnectionException(ex, this._hasMore || this._index < this._endpoints.length);
+
+        // We stop on ConnectTimeoutException to fail reasonably fast when the endpoint has many connectors
+        // (IP addresses).
+        if (this._index < this._endpoints.length &&
+            !(ex instanceof CommunicatorDestroyedException || ex instanceof ConnectTimeoutException)) {
+            return true; // keep going
         }
+
+        this._factory.finishGetConnectionEx(this._endpoints, ex, this);
         return false;
     }
 }


### PR DESCRIPTION
This PR updates the OutgoingConnectionFactory logic to stop further "connector" connection attempt when an attempt fails with ConnectTimeoutException.

This speeds up connect failure for multi-home endpoints.