### PR TITLE
Stop printing -t 60000 for tcp, ssl (...) endpoints

### DIFF
--- a/cpp/src/Ice/TcpEndpointI.cpp
+++ b/cpp/src/Ice/TcpEndpointI.cpp
@@ -31,6 +31,11 @@ extern "C"
     }
 }
 
+namespace
+{
+    const int32_t defaultTimeout = 60000; // 60,000 ms.
+}
+
 IceInternal::TcpEndpointI::TcpEndpointI(
     const ProtocolInstancePtr& instance,
     const string& host,
@@ -47,8 +52,8 @@ IceInternal::TcpEndpointI::TcpEndpointI(
 
 IceInternal::TcpEndpointI::TcpEndpointI(const ProtocolInstancePtr& instance)
     : IPEndpointI(instance),
-      // The default timeout for TCP endpoints is 60,000 milliseconds. This timeout is not used in Ice 3.8 and greater.
-      _timeout(60000),
+      // This timeout is not used in Ice 3.8 and greater.
+      _timeout(defaultTimeout),
       _compress(false)
 {
 }
@@ -186,13 +191,17 @@ IceInternal::TcpEndpointI::options() const
     ostringstream s;
     s << IPEndpointI::options();
 
-    if (_timeout == -1)
+    // -t is totally ignored by Ice as of Ice 3.8. To avoid confusion, we don't output it when set to the default value.
+    if (_timeout != defaultTimeout)
     {
-        s << " -t infinite";
-    }
-    else
-    {
-        s << " -t " << to_string(_timeout);
+        if (_timeout == -1)
+        {
+            s << " -t infinite";
+        }
+        else
+        {
+            s << " -t " << to_string(_timeout);
+        }
     }
 
     if (_compress)

--- a/cpp/src/Ice/ios/StreamEndpointI.cpp
+++ b/cpp/src/Ice/ios/StreamEndpointI.cpp
@@ -35,6 +35,11 @@ extern "C"
     }
 }
 
+namespace
+{
+    const int32_t defaultTimeout = 60000; // 60,000 ms.
+}
+
 #    if TARGET_IPHONE_SIMULATOR == 0
 namespace
 {
@@ -128,7 +133,7 @@ IceObjC::StreamEndpointI::StreamEndpointI(
 IceObjC::StreamEndpointI::StreamEndpointI(const InstancePtr& instance)
     : IceInternal::IPEndpointI(instance),
       _streamInstance(instance),
-      _timeout(60000), // the default timeout is 60,000 milliseconds
+      _timeout(defaultTimeout),
       _compress(false)
 {
 }
@@ -298,13 +303,16 @@ IceObjC::StreamEndpointI::options() const
 
     s << IPEndpointI::options();
 
-    if (_timeout == -1)
+    if (_timeout != defaultTimeout)
     {
-        s << " -t infinite";
-    }
-    else
-    {
-        s << " -t " << to_string(_timeout);
+        if (_timeout == -1)
+        {
+            s << " -t infinite";
+        }
+        else
+        {
+            s << " -t " << to_string(_timeout);
+        }
     }
 
     if (_compress)

--- a/cpp/src/IceBT/EndpointI.cpp
+++ b/cpp/src/IceBT/EndpointI.cpp
@@ -19,6 +19,11 @@ using namespace std;
 using namespace Ice;
 using namespace IceBT;
 
+namespace
+{
+    const int32_t defaultTimeout = 60000; // 60,000 ms.
+}
+
 // Implement virtual destructors out of line to avoid weak vtables.
 IceBT::ConnectionInfo::~ConnectionInfo() = default;
 IceBT::EndpointInfo::~EndpointInfo() = default;
@@ -46,7 +51,7 @@ IceBT::EndpointI::EndpointI(
 IceBT::EndpointI::EndpointI(InstancePtr instance)
     : _instance(std::move(instance)),
       _channel(0),
-      _timeout(60000), // the default timeout is 60,000 ms
+      _timeout(defaultTimeout),
       _compress(false)
 {
 }
@@ -397,14 +402,17 @@ IceBT::EndpointI::options() const
         s << " -c " << to_string(_channel);
     }
 
-    if (_timeout == -1)
+    if (_timeout != defaultTimeout)
     {
-        s << " -t infinite";
-    }
-    else
-    {
-        // Use to_string for locale independent formatting.
-        s << " -t " << to_string(_timeout);
+        if (_timeout == -1)
+        {
+            s << " -t infinite";
+        }
+        else
+        {
+            // Use to_string for locale independent formatting.
+            s << " -t " << to_string(_timeout);
+        }
     }
 
     if (_compress)

--- a/cpp/test/Ice/metrics/AllTests.cpp
+++ b/cpp/test/Ice/metrics/AllTests.cpp
@@ -685,7 +685,7 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
             update.get(),
             "ConnectionEstablishment",
             "endpoint",
-            endpoint + " -t 60000",
+            endpoint,
             c);
 
         testAttribute(clientMetrics, clientProps, update.get(), "ConnectionEstablishment", "endpointType", type, c);
@@ -884,7 +884,7 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
     testAttribute(serverMetrics, serverProps, update.get(), "Dispatch", "id", "metrics [op]", op);
     if (!collocated)
     {
-        testAttribute(serverMetrics, serverProps, update.get(), "Dispatch", "endpoint", endpoint + " -t 60000", op);
+        testAttribute(serverMetrics, serverProps, update.get(), "Dispatch", "endpoint", endpoint, op);
         // testAttribute(serverMetrics, serverProps, update.get(), "Dispatch", "connection", "", op);
 
         testAttribute(serverMetrics, serverProps, update.get(), "Dispatch", "endpointType", type, op);
@@ -1231,7 +1231,7 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         update.get(),
         "Invocation",
         "proxy",
-        "metrics -t -e 1.1:" + endpoint + " -t 60000",
+        "metrics -t -e 1.1:" + endpoint,
         op);
     testAttribute(clientMetrics, clientProps, update.get(), "Invocation", "context.entry1", "test", op);
     testAttribute(clientMetrics, clientProps, update.get(), "Invocation", "context.entry2", "", op);

--- a/cpp/test/Ice/metrics/AllTests.cpp
+++ b/cpp/test/Ice/metrics/AllTests.cpp
@@ -679,14 +679,7 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
         Connect c(metrics);
         testAttribute(clientMetrics, clientProps, update.get(), "ConnectionEstablishment", "parent", "Communicator", c);
         testAttribute(clientMetrics, clientProps, update.get(), "ConnectionEstablishment", "id", hostAndPort, c);
-        testAttribute(
-            clientMetrics,
-            clientProps,
-            update.get(),
-            "ConnectionEstablishment",
-            "endpoint",
-            endpoint,
-            c);
+        testAttribute(clientMetrics, clientProps, update.get(), "ConnectionEstablishment", "endpoint", endpoint, c);
 
         testAttribute(clientMetrics, clientProps, update.get(), "ConnectionEstablishment", "endpointType", type, c);
         testAttribute(
@@ -1225,14 +1218,7 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
     testAttribute(clientMetrics, clientProps, update.get(), "Invocation", "facet", "", op);
     testAttribute(clientMetrics, clientProps, update.get(), "Invocation", "encoding", "1.1", op);
     testAttribute(clientMetrics, clientProps, update.get(), "Invocation", "mode", "twoway", op);
-    testAttribute(
-        clientMetrics,
-        clientProps,
-        update.get(),
-        "Invocation",
-        "proxy",
-        "metrics -t -e 1.1:" + endpoint,
-        op);
+    testAttribute(clientMetrics, clientProps, update.get(), "Invocation", "proxy", "metrics -t -e 1.1:" + endpoint, op);
     testAttribute(clientMetrics, clientProps, update.get(), "Invocation", "context.entry1", "test", op);
     testAttribute(clientMetrics, clientProps, update.get(), "Invocation", "context.entry2", "", op);
     testAttribute(clientMetrics, clientProps, update.get(), "Invocation", "context.entry3", "", op);

--- a/cpp/test/Slice/print/AllTests.cpp
+++ b/cpp/test/Slice/print/AllTests.cpp
@@ -187,8 +187,8 @@ testProxy(const Ice::CommunicatorPtr& communicator)
     ProxyStruct proxyStruct{object, nullopt, printer};
     testPrint(
         proxyStruct,
-        "Test::ProxyStruct{object = obj -t -e 1.1:tcp -h localhost -p 4061 -t 60000, nullPrinter = , printer = printer "
-        "-t -e 1.1:tcp -h localhost -p 10000 -t 60000}");
+        "Test::ProxyStruct{object = obj -t -e 1.1:tcp -h localhost -p 4061, nullPrinter = , printer = printer "
+        "-t -e 1.1:tcp -h localhost -p 10000}");
 
     cout << "ok" << endl;
 }

--- a/csharp/src/Ice/Internal/TcpEndpointI.cs
+++ b/csharp/src/Ice/Internal/TcpEndpointI.cs
@@ -9,6 +9,8 @@ namespace Ice.Internal;
 
 internal sealed class TcpEndpointI : IPEndpointI
 {
+    private const int defaultTimeout = 60_000; // 60,000 milliseconds (1 minute)
+
     public TcpEndpointI(
         ProtocolInstance instance,
         string ho,
@@ -26,9 +28,8 @@ internal sealed class TcpEndpointI : IPEndpointI
     public TcpEndpointI(ProtocolInstance instance)
         : base(instance)
     {
-        // The default timeout for TCP endpoints is 60,000 milliseconds (1 minute).
         // This timeout is not used in Ice 3.8 or greater.
-        _timeout = 60_000;
+        _timeout = defaultTimeout;
         _compress = false;
     }
 
@@ -130,13 +131,16 @@ internal sealed class TcpEndpointI : IPEndpointI
         //
         string s = base.options();
 
-        if (_timeout == -1)
+        if (_timeout != defaultTimeout)
         {
-            s += " -t infinite";
-        }
-        else
-        {
-            s += " -t " + _timeout;
+            if (_timeout == -1)
+            {
+                s += " -t infinite";
+            }
+            else
+            {
+                s += " -t " + _timeout;
+            }
         }
 
         if (_compress)

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -461,8 +461,6 @@ public class AllTests : Test.AllTests
         string endpoint = $"{protocol} -h {host} -p {port}";
         string forwardingEndpoint = $"{protocol} -h {host} -p {helper.getTestPort(1)}";
 
-        const string defaultTimeout = "60000";
-
         MetricsPrx metrics = MetricsPrxHelper.checkedCast(communicator.stringToProxy("metrics:" + endpoint));
         bool collocated = metrics.ice_getConnection() == null;
         var output = helper.getWriter();
@@ -742,14 +740,14 @@ public class AllTests : Test.AllTests
             await testAttributeAsync(clientMetrics, clientProps, update, "ConnectionEstablishment", "parent", "Communicator", c, output);
             await testAttributeAsync(clientMetrics, clientProps, update, "ConnectionEstablishment", "id", hostAndPort, c, output);
             await testAttributeAsync(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpoint",
-                          endpoint + " -t " + defaultTimeout, c, output);
+                          endpoint, c, output);
 
             await testAttributeAsync(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointType", type, c, output);
             await testAttributeAsync(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointIsDatagram", "False",
                           c, output);
             await testAttributeAsync(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointIsSecure", isSecure,
                           c, output);
-            await testAttributeAsync(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointTimeout", defaultTimeout, c, output);
+            await testAttributeAsync(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointTimeout", "60000", c, output);
             await testAttributeAsync(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointCompress", "False",
                           c, output);
             await testAttributeAsync(clientMetrics, clientProps, update, "ConnectionEstablishment", "endpointHost", host, c, output);
@@ -909,8 +907,7 @@ public class AllTests : Test.AllTests
 
         if (!collocated)
         {
-            await testAttributeAsync(serverMetrics, serverProps, update, "Dispatch", "endpoint",
-                          endpoint + " -t 60000", op, output);
+            await testAttributeAsync(serverMetrics, serverProps, update, "Dispatch", "endpoint", endpoint, op, output);
             // await testAttributeAsync(serverMetrics, serverProps, update, "Dispatch", "connection", "", op);
 
             await testAttributeAsync(serverMetrics, serverProps, update, "Dispatch", "endpointType", type, op, output);
@@ -1121,7 +1118,7 @@ public class AllTests : Test.AllTests
         await testAttributeAsync(clientMetrics, clientProps, update, "Invocation", "encoding", "1.1", op, output);
         await testAttributeAsync(clientMetrics, clientProps, update, "Invocation", "mode", "twoway", op, output);
         await testAttributeAsync(clientMetrics, clientProps, update, "Invocation", "proxy",
-                      "metrics -t -e 1.1:" + endpoint + " -t " + defaultTimeout, op, output);
+                      "metrics -t -e 1.1:" + endpoint, op, output);
 
         await testAttributeAsync(clientMetrics, clientProps, update, "Invocation", "context.entry1", "test", op, output);
         await testAttributeAsync(clientMetrics, clientProps, update, "Invocation", "context.entry2", "", op, output);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpEndpointI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpEndpointI.java
@@ -5,6 +5,8 @@ package com.zeroc.Ice;
 import com.zeroc.Ice.SSL.SSLEngineFactory;
 
 final class TcpEndpointI extends IPEndpointI {
+    private static final int defaultTimeout = 60_000; // 60,000 milliseconds (1 minute)
+
     public TcpEndpointI(
             ProtocolInstance instance,
             String ho,
@@ -20,9 +22,8 @@ final class TcpEndpointI extends IPEndpointI {
 
     public TcpEndpointI(ProtocolInstance instance) {
         super(instance);
-        // The default timeout is 60,000 milliseconds (1 minute). It's not used in Ice 3.8 or
-        // greater.
-        _timeout = 60_000;
+        // The timeout is not used in Ice 3.8 or greater.
+        _timeout = defaultTimeout;
         _compress = false;
     }
 
@@ -143,10 +144,12 @@ final class TcpEndpointI extends IPEndpointI {
         //
         String s = super.options();
 
-        if (_timeout == -1) {
-            s += " -t infinite";
-        } else {
-            s += " -t " + _timeout;
+        if (_timeout != defaultTimeout) {
+            if (_timeout == -1) {
+                s += " -t infinite";
+            } else {
+                s += " -t " + _timeout;
+            }
         }
 
         if (_compress) {

--- a/java/src/com.zeroc.icebt/src/main/java/com/zeroc/IceBT/EndpointI.java
+++ b/java/src/com.zeroc.icebt/src/main/java/com/zeroc/IceBT/EndpointI.java
@@ -18,6 +18,8 @@ import java.util.Collections;
 import java.util.UUID;
 
 final class EndpointI extends com.zeroc.Ice.EndpointI {
+    private static final int defaultTimeout = 60_000; // 60,000 milliseconds (1 minute)
+
     public EndpointI(
             Instance instance,
             String addr,
@@ -43,9 +45,8 @@ final class EndpointI extends com.zeroc.Ice.EndpointI {
         _uuid = "";
         _name = "";
         _channel = 0;
-        // The default timeout is 60,000 milliseconds (1 minute). It's not used in Ice 3.8 or
-        // greater.
-        _timeout = 60_000;
+        // This timeout is not used in Ice 3.8 or greater.
+        _timeout = defaultTimeout;
         _connectionId = "";
         _compress = false;
     }
@@ -219,10 +220,12 @@ final class EndpointI extends com.zeroc.Ice.EndpointI {
             s += " -c " + _channel;
         }
 
-        if (_timeout == -1) {
-            s += " -t infinite";
-        } else {
-            s += " -t " + _timeout;
+        if (_timeout != defaultTimeout) {
+            if (_timeout == -1) {
+                s += " -t infinite";
+            } else {
+                s += " -t " + _timeout;
+            }
         }
 
         if (_compress) {

--- a/java/test/src/main/java/test/Ice/metrics/AllTests.java
+++ b/java/test/src/main/java/test/Ice/metrics/AllTests.java
@@ -678,7 +678,7 @@ public class AllTests {
                     clientProps,
                     "ConnectionEstablishment",
                     "endpoint",
-                    endpoint + " -t 60000",
+                    endpoint,
                     c,
                     out);
 
@@ -916,14 +916,7 @@ public class AllTests {
         testAttribute(serverMetrics, serverProps, "Dispatch", "parent", "TestAdapter", op, out);
         testAttribute(serverMetrics, serverProps, "Dispatch", "id", "metrics [op]", op, out);
         if (!collocated) {
-            testAttribute(
-                    serverMetrics,
-                    serverProps,
-                    "Dispatch",
-                    "endpoint",
-                    endpoint + " -t 60000",
-                    op,
-                    out);
+            testAttribute(serverMetrics, serverProps, "Dispatch", "endpoint", endpoint, op, out);
             // testAttribute(serverMetrics, serverProps, "Dispatch", "connection", "", op);
 
             testAttribute(serverMetrics, serverProps, "Dispatch", "endpointType", type, op, out);
@@ -1182,7 +1175,7 @@ public class AllTests {
                 clientProps,
                 "Invocation",
                 "proxy",
-                "metrics -t -e 1.1:" + endpoint + " -t 60000",
+                "metrics -t -e 1.1:" + endpoint,
                 op,
                 out);
 

--- a/js/src/Ice/TcpEndpointI.js
+++ b/js/src/Ice/TcpEndpointI.js
@@ -8,11 +8,13 @@ import { IPEndpointI } from "./IPEndpointI.js";
 import { EndpointInfo as SSLEndpointInfo } from "./SSL/EndpointInfo.js";
 import { TcpTransceiver } from "./TcpTransceiver.js";
 
+const defaultTimeout = 60000; // 60,000 milliseconds (1 minute)
+
 export class TcpEndpointI extends IPEndpointI {
     constructor(instance, host, port, sourceAddress, timeout, connectionId, compress) {
         super(instance, host, port, sourceAddress, connectionId);
-        // The default timeout is 60,000 milliseconds (1 minute). It's not used in Ice 3.8 or greater.
-        this._timeout = timeout === undefined ? (instance ? 60000 : undefined) : timeout;
+        // The timeout is not used in Ice 3.8 or greater.
+        this._timeout = timeout === undefined ? (instance ? defaultTimeout : undefined) : timeout;
         this._compress = compress === undefined ? false : compress;
     }
 
@@ -143,10 +145,15 @@ export class TcpEndpointI extends IPEndpointI {
         // format of proxyToString() before changing this and related code.
         //
         let s = super.options();
-        if (this._timeout == -1) {
-            s += " -t infinite";
-        } else {
-            s += " -t " + this._timeout;
+
+        // We don't print the timeout when it's the default; this timeout is purely for backwards compatibility and
+        // has no effect with Ice 3.8 or greater.
+        if (this._timeout != defaultTimeout) {
+            if (this._timeout == -1) {
+                s += " -t infinite";
+            } else {
+                s += " -t " + this._timeout;
+            }
         }
 
         if (this._compress) {


### PR DESCRIPTION
This PR updates the printing of tcp/ssl/bt (...) endpoints to no longer include "-t 60000".

As a reminder: this timeout no longer has any effect in Ice 3.8 and is only kept for backwards compatibility with Ice 3.7. If you use Ice 3.8, you should never see it - and including "-t 60000" in all proxy strings is confusing.