### PR TITLE
Remove ConnectTimeout override for binding test

### DIFF
--- a/cpp/test/Ice/binding/Client.cpp
+++ b/cpp/test/Ice/binding/Client.cpp
@@ -14,10 +14,7 @@ public:
 void
 Client::run(int argc, char** argv)
 {
-    Ice::PropertiesPtr properties = createTestProperties(argc, argv);
-    // Speed-up connection establishment failure on Windows.
-    properties->setProperty("Ice.Connection.Client.ConnectTimeout", "1");
-    Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
+    Ice::CommunicatorHolder communicator = initialize(argc, argv);
     void allTests(Test::TestHelper*);
     allTests(this);
 }

--- a/matlab/test/Ice/binding/Client.m
+++ b/matlab/test/Ice/binding/Client.m
@@ -7,9 +7,7 @@ function client(args)
     end
 
     helper = TestHelper();
-    properties = helper.createTestProperties(args);
-    properties.setProperty('Ice.Connection.Client.ConnectTimeout', '1'); % speed up testing on Windows
-    communicator = helper.initialize(properties);
+    communicator = helper.initialize(args);
     cleanup = onCleanup(@() communicator.destroy());
     AllTests.allTests(helper);
 


### PR DESCRIPTION
This PR should fix the test failures on Windows introduced by #3612.