### PR TITLE
Add Communicator::waitForShutdownAsync in C++

### DIFF
--- a/cpp/include/Ice/Communicator.h
+++ b/cpp/include/Ice/Communicator.h
@@ -67,7 +67,7 @@ namespace Ice
 
         /// Waits until the communicator is shut down.
         /// @param completed The callback to call when the shutdown is complete. This callback must not throw any
-        /// exception and it must not destroy the communicator.
+        /// exception.
         /// @remarks If you call this function on a communicator that has already been shut down, the callback is called
         /// immediately by the current thread.
         /// @see #shutdown

--- a/cpp/include/Ice/Communicator.h
+++ b/cpp/include/Ice/Communicator.h
@@ -65,6 +65,14 @@ namespace Ice
          */
         void waitForShutdown() noexcept;
 
+        /// Waits until the communicator is shut down.
+        /// @param completed The callback to call when the shutdown is complete. This callback must not throw any
+        /// exception and it must not destroy the communicator.
+        /// @remarks If you call this function on a communicator that has already been shut down, the callback is called
+        /// immediately by the current thread.
+        /// @see #shutdown
+        void waitForShutdownAsync(std::function<void()> completed) noexcept;
+
         /**
          * Check whether communicator has been shut down.
          * @return True if the communicator has been shut down; false otherwise.

--- a/cpp/src/Ice/Communicator.cpp
+++ b/cpp/src/Ice/Communicator.cpp
@@ -71,6 +71,27 @@ Ice::Communicator::waitForShutdown() noexcept
     }
 }
 
+void
+Ice::Communicator::waitForShutdownAsync(function<void()> completed) noexcept
+{
+    if (completed)
+    {
+        ObjectAdapterFactoryPtr factory;
+        try
+        {
+            factory = _instance->objectAdapterFactory();
+        }
+        catch (const Ice::CommunicatorDestroyedException&)
+        {
+            completed();
+            return;
+        }
+
+        factory->waitForShutdownAsync(std::move(completed));
+    }
+    // we tolerate null callbacks, they do nothing
+}
+
 bool
 Ice::Communicator::isShutdown() const noexcept
 {

--- a/cpp/src/Ice/ObjectAdapterFactory.cpp
+++ b/cpp/src/Ice/ObjectAdapterFactory.cpp
@@ -93,7 +93,7 @@ IceInternal::ObjectAdapterFactory::waitForShutdownAsync(function<void()> complet
                                                         self->waitForShutdown();
                                                         vector<function<void()>> callbacks;
                                                         {
-                                                            lock_guard lock(self->_mutex);
+                                                            lock_guard lg(self->_mutex);
                                                             callbacks = std::move(self->_shutdownCompletedCallbacks);
                                                         }
 

--- a/cpp/src/Ice/ObjectAdapterFactory.h
+++ b/cpp/src/Ice/ObjectAdapterFactory.h
@@ -42,7 +42,6 @@ namespace IceInternal
         std::set<std::string> _adapterNamesInUse;
         std::list<std::shared_ptr<Ice::ObjectAdapterI>> _adapters;
         std::vector<std::function<void()>> _shutdownCompletedCallbacks;
-        std::thread _shutdownCompletedThread;
         bool _shutdownCompleted = false;
 
         mutable std::recursive_mutex _mutex;

--- a/cpp/src/Ice/ObjectAdapterFactory.h
+++ b/cpp/src/Ice/ObjectAdapterFactory.h
@@ -42,6 +42,7 @@ namespace IceInternal
         std::set<std::string> _adapterNamesInUse;
         std::list<std::shared_ptr<Ice::ObjectAdapterI>> _adapters;
         std::vector<std::function<void()>> _shutdownCompletedCallbacks;
+        std::thread _shutdownCompletedThread;
         bool _shutdownCompleted = false;
 
         mutable std::recursive_mutex _mutex;

--- a/cpp/src/Ice/ObjectAdapterFactory.h
+++ b/cpp/src/Ice/ObjectAdapterFactory.h
@@ -14,10 +14,11 @@ namespace IceInternal
     class ObjectAdapterFactory : public std::enable_shared_from_this<ObjectAdapterFactory>
     {
     public:
-        void shutdown();
-        void waitForShutdown();
-        [[nodiscard]] bool isShutdown() const;
-        void destroy();
+        void shutdown() noexcept;
+        void waitForShutdown() noexcept;
+        void waitForShutdownAsync(std::function<void()> completed) noexcept;
+        [[nodiscard]] bool isShutdown() const noexcept;
+        void destroy() noexcept;
 
         void updateObservers(void (Ice::ObjectAdapterI::*)());
 
@@ -40,6 +41,10 @@ namespace IceInternal
         Ice::CommunicatorPtr _communicator;
         std::set<std::string> _adapterNamesInUse;
         std::list<std::shared_ptr<Ice::ObjectAdapterI>> _adapters;
+        std::vector<std::function<void()>> _shutdownCompletedCallbacks;
+        std::thread _shutdownCompletedThread;
+        bool _shutdownCompleted = false;
+
         mutable std::recursive_mutex _mutex;
         std::condition_variable_any _conditionVariable;
     };

--- a/cpp/test/Ice/ami/Server.cpp
+++ b/cpp/test/Ice/ami/Server.cpp
@@ -4,6 +4,8 @@
 #include "TestHelper.h"
 #include "TestI.h"
 
+#include <future>
+
 using namespace std;
 
 class Server : public Test::TestHelper
@@ -47,7 +49,9 @@ Server::run(int argc, char** argv)
 
     serverReady();
 
-    communicator->waitForShutdown();
+    promise<void> shutdownCompleted;
+    communicator->waitForShutdownAsync([&shutdownCompleted]() { shutdownCompleted.set_value(); });
+    shutdownCompleted.get_future().wait();
 }
 
 DEFINE_TEST(Server)

--- a/swift/src/Ice/CommunicatorI.swift
+++ b/swift/src/Ice/CommunicatorI.swift
@@ -41,10 +41,11 @@ class CommunicatorI: LocalObject<ICECommunicator>, Communicator {
     }
 
     func shutdownCompleted() async {
-        await Task {
-            // It would be nicer to wait asynchronously but doing so requires significant refactoring of the C++ code.
-            waitForShutdown()
-        }.value
+        return await withCheckedContinuation { continuation in
+            handle.waitForShutdownAsync {
+                continuation.resume()
+            }
+        }
     }
 
     func isShutdown() -> Bool {

--- a/swift/src/IceImpl/Communicator.mm
+++ b/swift/src/IceImpl/Communicator.mm
@@ -36,6 +36,18 @@
     self.communicator->waitForShutdown();
 }
 
+- (void)waitForShutdownAsync:(void (^)())completed
+{
+    self.communicator->waitForShutdownAsync(
+        [completed]()
+        {
+            @autoreleasepool
+            {
+                completed();
+            }
+        });
+}
+
 - (bool)isShutdown
 {
     return self.communicator->isShutdown();

--- a/swift/src/IceImpl/include/Communicator.h
+++ b/swift/src/IceImpl/include/Communicator.h
@@ -14,6 +14,7 @@ ICEIMPL_API @interface ICECommunicator : ICELocalObject
 - (void)destroy;
 - (void)shutdown;
 - (void)waitForShutdown;
+- (void)waitForShutdownAsync:(void (^)(void))completed NS_SWIFT_NAME(waitForShutdownAsync(_:));
 - (bool)isShutdown;
 - (nullable id)stringToProxy:(NSString*)str error:(NSError**)error NS_SWIFT_NAME(stringToProxy(str:));
 ;

--- a/swift/test/Ice/ami/Server.swift
+++ b/swift/test/Ice/ami/Server.swift
@@ -52,6 +52,6 @@ class Server: TestHelperI {
             id: Ice.stringToIdentity("testController"))
         try adapter2.activate()
         serverReady()
-        communicator.waitForShutdown()
+        await communicator.shutdownCompleted()
     }
 }


### PR DESCRIPTION
This PR adds Communicator::waitForShutdownAsync in C++ and uses this function to implement Communicator.shutdownCompleted() in Swift.