### PR TITLE
Fix to correctly set NuGet PackageVersion

### DIFF
--- a/.github/workflows/build-dotnet-packages.yml
+++ b/.github/workflows/build-dotnet-packages.yml
@@ -88,10 +88,8 @@ jobs:
         run: nuget restore cpp/msbuild/ice.sln
 
       - name: Pack .NET Packages
-        run: dotnet msbuild csharp\msbuild\ice.proj /t:Pack /p:Configuration=Release
+        run: dotnet msbuild csharp\msbuild\ice.proj /t:Pack /p:Configuration=Release /p:IcePackageVersion="${{ inputs.ice_version }}"
         env:
-          Version: ${{ inputs.ice_version || '' }}
-          PackageVersion: ${{ inputs.ice_version || '' }}
           SLICE2CS_STAGING_PATH: "${{ github.workspace }}\\tools"
 
       - name: Upload NuGet Packages

--- a/config/ice.version.props
+++ b/config/ice.version.props
@@ -2,10 +2,10 @@
 <!-- Copyright (c) ZeroC, Inc. -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <IceVersion>3.8a0</IceVersion>
-    <IceIntVersion>30850</IceIntVersion>
-    <IceVersionMM>3.8</IceVersionMM>
-    <IceSoVersion>38a0</IceSoVersion>
-    <IcePackageVersion>3.8.0-alpha0</IcePackageVersion>
+    <IceVersion Condition="'$(IceVersion)' == ''">3.8a0</IceVersion>
+    <IceIntVersion Condition="'$(IceIntVersion)' == ''">30850</IceIntVersion>
+    <IceVersionMM Condition="'$(IceVersionMM)' == ''">3.8</IceVersionMM>
+    <IceSoVersion Condition="'$(IceSoVersion)' == ''">38a0</IceSoVersion>
+    <IcePackageVersion Condition="'$(IcePackageVersion)' == ''">3.8.0-alpha0</IcePackageVersion>
   </PropertyGroup>
 </Project>

--- a/cpp/msbuild/ice.proj
+++ b/cpp/msbuild/ice.proj
@@ -10,7 +10,9 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <PackageVersion Condition="'$(PackageVersion)' == ''">$(IcePackageVersion)</PackageVersion>
+        <!-- The version for all NuGet packages built with this distribution. -->
+        <!-- Defaults to IcePackageVersion, which is set in ice.version.props imported above. -->
+        <PackageVersion>$(IcePackageVersion)</PackageVersion>
         <VCTargetsPath Condition="'$(VCTargetsPath)' == ''">C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0</VCTargetsPath>
         <IceTestSolution>ice.test.sln</IceTestSolution>
         <IceDoxygenExamplesSolution>ice.doxygen.examples.sln</IceDoxygenExamplesSolution>

--- a/csharp/msbuild/ice.common.props
+++ b/csharp/msbuild/ice.common.props
@@ -22,9 +22,6 @@
     <StyleCopAnalyzersVersion>1.2.0-beta.556</StyleCopAnalyzersVersion>
   </PropertyGroup>
 
-  <!-- Import Ice version settings -->
-  <Import Project="$(MSBuildThisFileDirectory)..\..\config\ice.version.props"/>
-
 <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DebugType>portable</DebugType>
     <Optimize>false</Optimize>

--- a/csharp/msbuild/ice.proj
+++ b/csharp/msbuild/ice.proj
@@ -73,7 +73,6 @@
     </Target>
 
     <Target Name="Build" DependsOnTargets="NuGetRestore">
-        <Message Text="Building Ice @(SolutionFile.Properties)" Importance="High" />
         <MSBuild Projects="@(ToolsSolution)" Properties="%(Properties)" />
         <MSBuild Projects="@(SolutionFile)" Properties="%(Properties)"/>
     </Target>
@@ -104,11 +103,5 @@
         <RemoveDir Directories="$(NuGetGlobalPackages)\%(DistPackage.Identity)\$(PackageVersion)"
             Condition="Exists('$(NuGetGlobalPackages)\%(DistPackage.Identity)\$(PackageVersion)')"/>
         <Exec Command="dotnet nuget push %(DistPackage.ProjectDir)/bin/$(Configuration)/%(DistPackage.Identity).$(PackageVersion).nupkg --source $(NuGetGlobalPackages)" />
-    </Target>
-
-    <Target Name="DistInfo">
-        <Message Text="Solution: %(SolutionFile.Identity) %(SolutionFile.Properties)" Importance="High" />
-        <Message Text="PackageVersion: $(PackageVersion)" Importance="High" />
-        <Message Text="IcePackageVersion: $(IcePackageVersion)" Importance="High" />
     </Target>
 </Project>

--- a/csharp/msbuild/ice.proj
+++ b/csharp/msbuild/ice.proj
@@ -4,7 +4,9 @@
         <Configuration>Release</Configuration>
     </PropertyGroup>
     <PropertyGroup>
-        <PackageVersion Condition="'$(PackageVersion)' == ''">$(IcePackageVersion)</PackageVersion>
+        <!-- The version for all NuGet packages built with this distribution. -->
+        <!-- Defaults to IcePackageVersion, which is set in ice.version.props imported above. -->
+        <PackageVersion>$(IcePackageVersion)</PackageVersion>
         <CppPlatform Condition="'$(Platform)' == 'x64'">x64</CppPlatform>
         <CppPlatform Condition="'$(Platform)' == 'x86' or '$(Platform)' == 'Win32'">Win32</CppPlatform>
     </PropertyGroup>
@@ -49,21 +51,18 @@
         <!-- Tools projects -->
         <ToolsSolution Include="$(MSBuildThisFileDirectory)..\..\tools\ZeroC.Ice.Slice.Tools.CSharp\ZeroC.Ice.Slice.Tools.CSharp.sln">
             <Properties>Configuration=$(Configuration);Platform=Any CPU</Properties>
-            <Properties Condition="'$(Version)' != ''">%(Properties);Version=$(Version)</Properties>
             <Properties Condition="'$(PackageVersion)' != ''">%(Properties);PackageVersion=$(PackageVersion)</Properties>
         </ToolsSolution>
 
         <!-- .NET Solution files -->
         <SolutionFile Include="ice.sln">
           <Properties>Configuration=$(Configuration);Platform=Any CPU;CppPlatform=$(CppPlatform)</Properties>
-          <Properties Condition="'$(Version)' != ''">%(Properties);Version=$(Version)</Properties>
           <Properties Condition="'$(PackageVersion)' != ''">%(Properties);PackageVersion=$(PackageVersion)</Properties>
         </SolutionFile>
 
         <!-- .NET projects to build with dist target -->
         <DistSolutionFile Include="ice.dist.sln">
           <Properties>Configuration=$(Configuration);Platform=Any CPU;CppPlatform=$(CppPlatform)</Properties>
-          <Properties Condition="'$(Version)' != ''">%(Properties);Version=$(Version)</Properties>
           <Properties Condition="'$(PackageVersion)' != ''">%(Properties);PackageVersion=$(PackageVersion)</Properties>
         </DistSolutionFile>
     </ItemGroup>
@@ -74,6 +73,7 @@
     </Target>
 
     <Target Name="Build" DependsOnTargets="NuGetRestore">
+        <Message Text="Building Ice @(SolutionFile.Properties)" Importance="High" />
         <MSBuild Projects="@(ToolsSolution)" Properties="%(Properties)" />
         <MSBuild Projects="@(SolutionFile)" Properties="%(Properties)"/>
     </Target>
@@ -88,8 +88,8 @@
     </Target>
 
     <Target Name="Pack" DependsOnTargets="BuildDist">
-        <Exec Command="dotnet pack @(ToolsSolution) /p:Platform=&quot;Any CPU&quot;" />
-        <Exec Command="dotnet pack @(DistSolutionFile) /p:Platform=&quot;Any CPU&quot;" />
+        <Exec Command="dotnet pack @(ToolsSolution) /p:PackageVersion=$(PackageVersion);Platform=&quot;Any CPU&quot;" />
+        <Exec Command="dotnet pack @(DistSolutionFile) /p:PackageVersion=$(PackageVersion);Platform=&quot;Any CPU&quot;" />
     </Target>
 
     <Target Name="Publish" DependsOnTargets="Pack">
@@ -104,5 +104,11 @@
         <RemoveDir Directories="$(NuGetGlobalPackages)\%(DistPackage.Identity)\$(PackageVersion)"
             Condition="Exists('$(NuGetGlobalPackages)\%(DistPackage.Identity)\$(PackageVersion)')"/>
         <Exec Command="dotnet nuget push %(DistPackage.ProjectDir)/bin/$(Configuration)/%(DistPackage.Identity).$(PackageVersion).nupkg --source $(NuGetGlobalPackages)" />
+    </Target>
+
+    <Target Name="DistInfo">
+        <Message Text="Solution: %(SolutionFile.Identity) %(SolutionFile.Properties)" Importance="High" />
+        <Message Text="PackageVersion: $(PackageVersion)" Importance="High" />
+        <Message Text="IcePackageVersion: $(IcePackageVersion)" Importance="High" />
     </Target>
 </Project>

--- a/csharp/src/Directory.Build.props
+++ b/csharp/src/Directory.Build.props
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$(MSBuildThisFileDirectory)..\..\config\ice.version.props" />
     <PropertyGroup>
+        <!-- The version for all NuGet packages built with this distribution. -->
+        <!-- Defaults to IcePackageVersion, which is set in ice.version.props imported above. -->
+        <PackageVersion>$(IcePackageVersion)</PackageVersion>
         <!-- Include PDB in the built .nupkg -->
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
         <!-- TODO: move to common.props and fix analyzer warnings in tests -->

--- a/tools/ZeroC.Ice.Slice.Tools.CSharp/ZeroC.Ice.Slice.Tools.CSharp.csproj
+++ b/tools/ZeroC.Ice.Slice.Tools.CSharp/ZeroC.Ice.Slice.Tools.CSharp.csproj
@@ -7,6 +7,10 @@
       <LangVersion>10.0</LangVersion>
 
       <!-- Packaging properties -->
+
+      <!-- The version for the NuGet package. -->
+      <!-- Defaults to IcePackageVersion, which is set in ice.version.props imported above. -->
+      <PackageVersion>$(IcePackageVersion)</PackageVersion>
       <Description>Provides tools to generate C# code from Slice definitions; includes support for MSBuild projects.</Description>
       <DevelopmentDependency>true</DevelopmentDependency>
       <PackageType>Dependency</PackageType>

--- a/tools/ZeroC.Ice.Slice.Tools.CSharp/ZeroC.Ice.Slice.Tools.CSharp.targets
+++ b/tools/ZeroC.Ice.Slice.Tools.CSharp/ZeroC.Ice.Slice.Tools.CSharp.targets
@@ -65,11 +65,8 @@
     <Target Name="SliceCompile" BeforeTargets="CoreCompile"
             Condition="@(SliceCompile) != ''">
 
-        <Error Text="Ice Installation invalid or not detected. Invalid IceHome setting `$(IceHome)'"
-               Condition="!Exists('$(IceHome)')" />
-
-        <Error Text="Ice Installation invalid or not detected. Invalid IceToolsPath setting `$(IceToolsPath)'"
-               Condition="!Exists('$(IceToolsPath)')" />
+        <Error Text="IceToolsPath is set to a non-existing directory: `$(IceToolsPath)'. Did you forget to build the slice2cs compiler?"
+           Condition="!Exists('$(IceToolsPath)')" />
 
         <MakeDir Directories="%(SliceCompile.OutputDir)"/>
 

--- a/tools/ZeroC.Ice.Slice.Tools.Cpp/ZeroC.Ice.Slice.Tools.Cpp.csproj
+++ b/tools/ZeroC.Ice.Slice.Tools.Cpp/ZeroC.Ice.Slice.Tools.Cpp.csproj
@@ -7,6 +7,10 @@
       <LangVersion>10.0</LangVersion>
 
       <!-- Packaging properties -->
+
+      <!-- The version for the NuGet package. -->
+      <!-- Defaults to IcePackageVersion, which is set in ice.version.props imported above. -->
+      <PackageVersion>$(IcePackageVersion)</PackageVersion>
       <Description>Provides tools to generate C# code from Slice definitions; includes support for MSBuild projects.</Description>
       <DevelopmentDependency>true</DevelopmentDependency>
       <PackageType>Dependency</PackageType>

--- a/tools/ZeroC.Ice.Slice.Tools.Cpp/ZeroC.Ice.Slice.Tools.Cpp.targets
+++ b/tools/ZeroC.Ice.Slice.Tools.Cpp/ZeroC.Ice.Slice.Tools.Cpp.targets
@@ -50,11 +50,8 @@
     <Target Name="SliceCompile" BeforeTargets="CLCompile"
             Condition="@(SliceCompile) != ''">
 
-        <Error Text="Ice Installation invalid or not detected. Invalid IceHome setting `$(IceHome)'"
-               Condition="!Exists('$(IceHome)')" />
-
-        <Error Text="Ice Installation invalid or not detected. Invalid IceToolsPath setting `$(IceToolsPath)'"
-               Condition="!Exists('$(IceToolsPath)')" />
+        <Error Text="IceToolsPath is set to a non-existing directory: `$(IceToolsPath)'. Did you forget to build the slice2cpp compiler?"
+           Condition="!Exists('$(IceToolsPath)')" />
 
         <!--
             Create the output directories


### PR DESCRIPTION
This PR fixes the PackageVersion settings. The setting was not correctly pass to the pack targets and they were using default 1.0.0 version for .NET project system. Which resulted in an error with `/t:Publish` not finding the packages with the expected version `3.8.0-alpha0`