### PR TITLE
Add CMake support files 

### DIFF
--- a/.devcontainer/rhel9/Dockerfile
+++ b/.devcontainer/rhel9/Dockerfile
@@ -1,0 +1,30 @@
+FROM registry.access.redhat.com/ubi9
+
+RUN dnf install -y https://zeroc.com/download/ice/3.7/el9/ice-repo-3.7.el9.noarch.rpm && \
+    dnf clean all
+
+# Install required build tools and dependencies
+RUN dnf install --setopt=multilib_policy=all -y \
+    sudo \
+    rpmdevtools \
+    make \
+    curl-minimal \
+    git \
+    gcc-c++ \
+    glibc-devel \
+    libstdc++-devel \
+    redhat-rpm-config \
+    glibc-static \
+    libstdc++-static && \
+    dnf clean all
+
+# Create a non-root user and set permissions
+RUN useradd -ms /bin/bash vscode \
+    && mkdir -p /home/vscode \
+    && chown -R vscode:vscode /home/vscode \
+    && echo "vscode ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/vscode
+
+USER vscode
+WORKDIR /home/vscode
+
+ENV LANG=en_US.UTF-8

--- a/.devcontainer/rhel9/Dockerfile
+++ b/.devcontainer/rhel9/Dockerfile
@@ -4,9 +4,8 @@ RUN dnf install -y https://zeroc.com/download/ice/3.7/el9/ice-repo-3.7.el9.noarc
     dnf clean all
 
 # Install required build tools and dependencies
-RUN dnf install --setopt=multilib_policy=all -y \
+RUN dnf install -y \
     sudo \
-    rpmdevtools \
     make \
     curl-minimal \
     git \
@@ -15,8 +14,15 @@ RUN dnf install --setopt=multilib_policy=all -y \
     libstdc++-devel \
     redhat-rpm-config \
     glibc-static \
-    libstdc++-static && \
-    dnf clean all
+    libstdc++-static \
+    mcpp-devel \
+    bzip2-devel \
+    openssl-devel \
+    expat-devel \
+    libedit-devel \
+    readline-devel \
+    lmdb-devel \
+    && dnf clean all
 
 # Create a non-root user and set permissions
 RUN useradd -ms /bin/bash vscode \

--- a/.devcontainer/rhel9/devcontainer.json
+++ b/.devcontainer/rhel9/devcontainer.json
@@ -1,0 +1,26 @@
+{
+    // Use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "name": "RHEL 9",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "runArgs": [
+        // "--cpuset-cpus=0-1", // Limit CPU usage
+        // "--shm-size=4gb" // Limit memory usage
+    ],
+    // Configure tool-specific properties
+    "customizations": {
+        "vscode": {
+            /* spell-checker:disable */
+            "extensions": [
+                "davidson.vscode-markdownlint",
+                "editorconfig.editorconfig",
+                "ms-azuretools.vscode-docker",
+                "streetsidesoftware.code-spell-checker",
+                "zerocinc.slice",
+                "ms-vscode.cpptools-extension-pack"
+            ]
+            /* spell-checker:enable */
+        }
+    }
+}

--- a/config/Make.project.rules
+++ b/config/Make.project.rules
@@ -182,7 +182,6 @@ $3/%.h $2/%.$($6_targetext): $1/%.ice $($6_path) | $3
 	$(Q)$($6_path) $(strip $5) $(SLICEFLAGS) --depend $$< | sed 's|\(.*:\)|$3/$$*.h $2/$$*.$($6_targetext):|' > $2/$$*.ice.d
 	$(Q)$($6_path) $(strip $5) $(SLICEFLAGS) --output-dir $2 $$<
 	$(if $(filter-out $2,$3),$(Q)$(MV) $2/$$*.h $3/)
-
 endef
 
 #

--- a/config/Make.rules.Darwin
+++ b/config/Make.rules.Darwin
@@ -9,6 +9,7 @@ macosx_cppflags                 = -mmacosx-version-min=14.00
 macosx_ldflags                  = $(macosx_cppflags) \
                                   $(if $(filter yes, $(allow-undefined-symbols)),-undefined dynamic_lookup,)
 macosx_targetdir                = $(if $(filter %/build,$5),/macosx)
+macosx_cmakedir				 	= /cmake
 
 iphoneos_ar                     = libtool
 iphoneos_cc                     = xcrun -sdk iphoneos clang

--- a/config/Make.rules.Darwin
+++ b/config/Make.rules.Darwin
@@ -9,7 +9,7 @@ macosx_cppflags                 = -mmacosx-version-min=14.00
 macosx_ldflags                  = $(macosx_cppflags) \
                                   $(if $(filter yes, $(allow-undefined-symbols)),-undefined dynamic_lookup,)
 macosx_targetdir                = $(if $(filter %/build,$5),/macosx)
-macosx_cmakedir				 	= /cmake
+macosx_cmakedir                 = /cmake
 
 iphoneos_ar                     = libtool
 iphoneos_cc                     = xcrun -sdk iphoneos clang

--- a/config/Make.rules.Linux
+++ b/config/Make.rules.Linux
@@ -112,7 +112,7 @@ $(build-platform)_cppflags      := $(call opt-cppflags,$(build-platform))
 $(build-platform)_ldflags       := $(call opt-ldflags,$(build-platform))
 $(build-platform)_targetdir     = $(if $(filter %/build,$5),/$(build-platform),$(if $(filter-out $($1_target),program),$(lib-suffix)))
 $(build-platform)_installdir    = $(if $(and $(filter-out $($1_target),program),$(if $5,$(filter-out %$(lib-suffix),$5),true)),$(lib-suffix))
-$(build-platform)_cmakedir      = $(lib-suffix)/cmake
+$(build-platform)_cmakedir      = /cmake
 
 endif
 

--- a/config/Make.rules.Linux
+++ b/config/Make.rules.Linux
@@ -39,11 +39,13 @@ x64_cppflags            := $(call opt-cppflags,x86_64) -m64 -march=x86-64-v2
 x64_ldflags             := $(call opt-ldflags,x86_64) -m64
 x64_targetdir           = $(if $(filter %/build,$5),/x64,$(if $(filter-out $($1_target),program),64))
 x64_installdir          = $(if $(and $(filter-out $($1_target),program),$(if $5,$(filter-out %64,$5),true)),64)
+x64_cmakedir            = 64/cmake
 
 x86_cppflags            := $(call opt-cppflags,i386) -m32 -march=x86-64-v2
 x86_ldflags             := $(call opt-ldflags,i386) -m32
 x86_targetdir           = $(if $(filter %/build,$5),/x86)
 x86_targetname          = $(if $(is-bin-program),32)
+x86_cmakedir            = 32/cmake
 
 # No Slice translators for x86
 x86_excludes            = slice2%
@@ -76,6 +78,7 @@ $1_libtool      = $$($1_gnu_type)-$(AR)
 $1_targetdir    = /$$($1_multiarch)
 $1_objdir       = /$$($1_multiarch)
 $1_installdir   = $$(if $$(and $(is-bin-program),$(usr_dir_install)),,/$$($1_multiarch))
+$1_cmakedir     = $$($1_multiarch)/cmake
 
 #
 # Disable ABI compatibility warnings for armhf using -Wno-psabi
@@ -109,10 +112,9 @@ $(build-platform)_cppflags      := $(call opt-cppflags,$(build-platform))
 $(build-platform)_ldflags       := $(call opt-ldflags,$(build-platform))
 $(build-platform)_targetdir     = $(if $(filter %/build,$5),/$(build-platform),$(if $(filter-out $($1_target),program),$(lib-suffix)))
 $(build-platform)_installdir    = $(if $(and $(filter-out $($1_target),program),$(if $5,$(filter-out %$(lib-suffix),$5),true)),$(lib-suffix))
+$(build-platform)_cmakedir      = $(lib-suffix)/cmake
 
 endif
-
-$(build-platform)_cmakedir      = $($(build-platform)_installdir)/cmake
 
 rpath-link-ldflag       = -Wl,-rpath-link,$1
 make-rpath-link-ldflags = $(foreach d,$(filter-out $2,$(call get-all-deps,$1)),$(call rpath-link-ldflag,$($d_targetdir)))

--- a/config/Make.rules.Linux
+++ b/config/Make.rules.Linux
@@ -78,7 +78,7 @@ $1_libtool      = $$($1_gnu_type)-$(AR)
 $1_targetdir    = /$$($1_multiarch)
 $1_objdir       = /$$($1_multiarch)
 $1_installdir   = $$(if $$(and $(is-bin-program),$(usr_dir_install)),,/$$($1_multiarch))
-$1_cmakedir     = $$($1_multiarch)/cmake
+$1_cmakedir     = /$$($1_multiarch)/cmake
 
 #
 # Disable ABI compatibility warnings for armhf using -Wno-psabi

--- a/config/Make.rules.Linux
+++ b/config/Make.rules.Linux
@@ -39,7 +39,7 @@ x64_cppflags            := $(call opt-cppflags,x86_64) -m64 -march=x86-64-v2
 x64_ldflags             := $(call opt-ldflags,x86_64) -m64
 x64_targetdir           = $(if $(filter %/build,$5),/x64,$(if $(filter-out $($1_target),program),64))
 x64_installdir          = $(if $(and $(filter-out $($1_target),program),$(if $5,$(filter-out %64,$5),true)),64)
-x64_cmakedir            = 64/cmake
+x64_cmakedir            = /cmake
 
 x86_cppflags            := $(call opt-cppflags,i386) -m32 -march=x86-64-v2
 x86_ldflags             := $(call opt-ldflags,i386) -m32

--- a/config/Make.rules.Linux
+++ b/config/Make.rules.Linux
@@ -112,6 +112,8 @@ $(build-platform)_installdir    = $(if $(and $(filter-out $($1_target),program),
 
 endif
 
+$(build-platform)_cmakedir      = $($(build-platform)_installdir)/cmake
+
 rpath-link-ldflag       = -Wl,-rpath-link,$1
 make-rpath-link-ldflags = $(foreach d,$(filter-out $2,$(call get-all-deps,$1)),$(call rpath-link-ldflag,$($d_targetdir)))
 

--- a/config/Make.rules.Linux
+++ b/config/Make.rules.Linux
@@ -45,7 +45,7 @@ x86_cppflags            := $(call opt-cppflags,i386) -m32 -march=x86-64-v2
 x86_ldflags             := $(call opt-ldflags,i386) -m32
 x86_targetdir           = $(if $(filter %/build,$5),/x86)
 x86_targetname          = $(if $(is-bin-program),32)
-x86_cmakedir            = 32/cmake
+x86_cmakedir            = /cmake
 
 # No Slice translators for x86
 x86_excludes            = slice2%

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -55,5 +55,5 @@ install:: | $(DESTDIR)$(install_configdir)
 install:: install-cmake
 
 $(eval $(call install-data-files,$(wildcard $(lang_srcdir)/config/*.cmake),$(lang_srcdir)/config,\
-	$(DESTDIR)$(install_libdir)$($(build-platform)_cmakedir)/Ice-$(version),\
+	$(install_libdir)$($(build-platform)_cmakedir)/Ice-$(version),\
     install-cmake,"Installing CMake files"))

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -54,6 +54,6 @@ install:: | $(DESTDIR)$(install_configdir)
 
 install:: install-cmake
 
-$(eval $(call install-data-files,$(wildcard $(lang_srcdir)/config/*.cmake),$(lang_srcdir)/config,\
-	$(install_libdir)$($(build-platform)_cmakedir)/Ice-$(version),\
-    install-cmake,"Installing CMake files"))
+install_cmakedir = $(install_libdir)$($(build-platform)_cmakedir)/Ice-$(version)
+$(eval $(call install-data-files,$(wildcard $(lang_srcdir)/config/*.cmake),$(lang_srcdir)/config,$(install_cmakedir),\
+	install-cmake,"Installing CMake files"))

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -52,6 +52,8 @@ all:: srcs tests doxygen_examples
 install:: | $(DESTDIR)$(install_configdir)
 	$(Q)$(call install-data,templates.xml,$(lang_srcdir)/config,$(install_configdir))
 
-install:: | $(DESTDIR)$(install_configdir)
-	$(Q)$(MKDIR) -p $(DESTDIR)$(libdir)/cmake/Ice
-	$(Q)$(call install-data,IceConfig.cmake IceTargets.cmake slic2cpp.cmake,$(lang_srcdir)/config,$(DESTDIR)$(libdir)/cmake/Ice)
+install:: install-cmake
+
+$(eval $(call install-data-files,$(wildcard $(lang_srcdir)/config/*.cmake),$(lang_srcdir)/config,\
+	$(DESTDIR)$(install_libdir)$($(build-platform)_cmakedir)/Ice-$(version),\
+    install-cmake,"Installing CMake files"))

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -54,6 +54,8 @@ install:: | $(DESTDIR)$(install_configdir)
 
 install:: install-cmake
 
-install_cmakedir = $(install_libdir)$($(build-platform)_cmakedir)/Ice-$(version)
+# We use a variable here to avoid splitting the call onto multiple lines. Splitting before the install directory
+# causes any indentation to be included in the directory name, which is incorrect.
+install_cmakedir = $(install_libdir)$($(build-platform)_cmakedir)/Ice-$(mmversion)
 $(eval $(call install-data-files,$(wildcard $(lang_srcdir)/config/*.cmake),$(lang_srcdir)/config,$(install_cmakedir),\
 	install-cmake,"Installing CMake files"))

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -51,3 +51,7 @@ all:: srcs tests doxygen_examples
 
 install:: | $(DESTDIR)$(install_configdir)
 	$(Q)$(call install-data,templates.xml,$(lang_srcdir)/config,$(install_configdir))
+
+install:: | $(DESTDIR)$(install_configdir)
+	$(Q)$(MKDIR) -p $(DESTDIR)$(libdir)/cmake/Ice
+	$(Q)$(call install-data,IceConfig.cmake IceTargets.cmake slic2cpp.cmake,$(lang_srcdir)/config,$(DESTDIR)$(libdir)/cmake/Ice)

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -54,8 +54,12 @@ install:: | $(DESTDIR)$(install_configdir)
 
 install:: install-cmake
 
-# We use a variable here to avoid splitting the call onto multiple lines. Splitting before the install directory
-# causes any indentation to be included in the directory name, which is incorrect.
-install_cmakedir = $(install_libdir)$($(build-platform)_cmakedir)/Ice-$(mmversion)
-$(eval $(call install-data-files,$(wildcard $(lang_srcdir)/config/*.cmake),$(lang_srcdir)/config,$(install_cmakedir),\
-	install-cmake,"Installing CMake files"))
+# Install CMake files for a platform
+# $(call install-cmake-files,$1=platform)
+define install-cmake-files
+$(eval $(call install-data-files,$(wildcard $(lang_srcdir)/config/*.cmake),$(lang_srcdir)/config,$(install_libdir)$$($(1)_cmakedir)/Ice-$(mmversion),\
+	install-cmake-$(1),"Installing CMake files for $(1)"))
+install-cmake:: install-cmake-$(1)
+endef
+
+$(foreach p,$(platforms),$(eval $(call install-cmake-files,$p)))

--- a/cpp/config/IceConfig.cmake
+++ b/cpp/config/IceConfig.cmake
@@ -2,11 +2,16 @@
 
 if(WIN32)
     # On Windows Ice ships was a NuGet package, so we need to find the package prefix directory.
-    # This config file is located at <ice_nuget_package>/build/native/lib/cmake/ice/IceConfig.cmake
-    get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../../../" ABSOLUTE)
+    # This config file is located at <ice_nuget_package>/cmake/IceConfig.cmake
+    get_filename_component(Ice_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)
 else()
-    # This file is located at <ice_install_prefix>/lib/cmake/Ice/IceConfig.cmake
-    get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
+    # This file is located at either:
+    # -  <ice_install_prefix>/<lib>/cmake/Ice/IceConfig.cmake
+    # -  <ice_install_prefix>/<lib>/<arch>/cmake/Ice/IceConfig.cmake
+    get_filename_component(Ice_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
+    if(DEFINED CMAKE_LIBRARY_ARCHITECTURE)
+        get_filename_component(Ice_PREFIX "${Ice_PREFIX}/.." ABSOLUTE)
+    endif()
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/IceTargets.cmake")

--- a/cpp/config/IceConfig.cmake
+++ b/cpp/config/IceConfig.cmake
@@ -1,0 +1,13 @@
+# Copyright (c) ZeroC, Inc.
+
+if(WIN32)
+    # On Windows Ice ships was a NuGet package, so we need to find the package prefix directory.
+    # This config file is located at <ice_nuget_package>/build/native/lib/cmake/ice/IceConfig.cmake
+    get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../../../" ABSOLUTE)
+else()
+    # This file is located at <ice_install_prefix>/lib/cmake/Ice/IceConfig.cmake
+    get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/IceTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/slice2cpp.cmake")

--- a/cpp/config/IceConfig.cmake
+++ b/cpp/config/IceConfig.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) ZeroC, Inc.
 
 if(WIN32)
-    # On Windows Ice ships was a NuGet package, so we need to find the package prefix directory.
+    # On Windows Ice ships as a NuGet package, so we need to find the package prefix directory.
     # This config file is located at <ice_nuget_package>/cmake/IceConfig.cmake
     get_filename_component(Ice_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)
 else()

--- a/cpp/config/IceTargets.cmake
+++ b/cpp/config/IceTargets.cmake
@@ -1,0 +1,158 @@
+# Copyright (c) ZeroC, Inc.
+
+if(WIN32 AND NOT DEFINED Ice_WIN32_PLATFORM)
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(Ice_WIN32_PLATFORM "x64" CACHE PATH "Use x64 Ice library")
+  else()
+    set(Ice_WIN32_PLATFORM "Win32" CACHE PATH "Use Win32 Ice library")
+  endif()
+endif()
+
+find_path(Ice_INCLUDE_DIR NAMES Ice/Ice.h
+  HINTS ${PACKAGE_PREFIX_DIR} ${PACKAGE_PREFIX_DIR}/build/native
+  PATH_SUFFIXES include DOC "Directory containing Ice header files"
+  NO_DEFAULT_PATH
+  REQUIRED)
+
+# Read Ice version variables from Ice/Config.h
+if(NOT DEFINED Ice_VERSION)
+  file(STRINGS "${Ice_INCLUDE_DIR}/Ice/Config.h" _ice_config_h_content REGEX "#define ICE_([A-Z]+)_VERSION ")
+
+  if("${_ice_config_h_content}" MATCHES "#define ICE_STRING_VERSION \"([^\"]+)\"")
+    set(Ice_VERSION "${CMAKE_MATCH_1}" CACHE STRING "Ice version")
+  endif()
+
+  if("${_ice_config_h_content}" MATCHES "#define ICE_SO_VERSION \"([^\"]+)\"")
+    set(Ice_SO_VERSION "${CMAKE_MATCH_1}" CACHE STRING "Ice SO version")
+  endif()
+  unset(_ice_config_h_content)
+endif()
+
+find_program(Ice_SLICE2CPP_EXECUTABLE slice2cpp
+  HINTS ${PACKAGE_PREFIX_DIR}
+  PATH_SUFFIXES bin tools
+  DOC "Path to the slice2cpp compiler"
+  NO_DEFAULT_PATH
+  REQUIRED
+)
+
+# Add an imported target for slice2cpp
+add_executable(Ice::slice2cpp IMPORTED)
+set_target_properties(Ice::slice2cpp PROPERTIES
+  IMPORTED_LOCATION "${Ice_SLICE2CPP_EXECUTABLE}"
+)
+
+find_path(Ice_SLICE_DIR
+  NAMES Ice/Identity.ice
+  HINTS ${PACKAGE_PREFIX_DIR}
+  PATH_SUFFIXES slice share/ice/slice
+  DOC "Path to the Ice Slice files directory"
+  NO_DEFAULT_PATH
+  REQUIRED)
+
+# Adds an Ice:<component> target with the specified link libraries
+function(add_ice_target component link_libraries)
+  add_library(Ice::${component} SHARED IMPORTED)
+  set_target_properties(Ice::${component} PROPERTIES
+    INTERFACE_COMPILE_FEATURES "cxx_std_17"
+    INTERFACE_INCLUDE_DIRECTORIES "${Ice_INCLUDE_DIR}"
+    INTERFACE_LINK_LIBRARIES "${link_libraries}"
+  )
+
+  if(WIN32)
+    if(Ice_${component}_LIBRARY_RELEASE)
+      set_target_properties(Ice::${component} PROPERTIES
+        IMPORTED_CONFIGURATIONS RELEASE
+        IMPORTED_IMPLIB_RELEASE "${Ice_${component}_IMPLIB_RELEASE}"
+        IMPORTED_LOCATION_RELEASE "${Ice_${component}_LIBRARY_RELEASE}"
+      )
+    endif()
+
+    if(Ice_${component}_LIBRARY_DEBUG)
+      set_target_properties(Ice::${component} PROPERTIES
+        IMPORTED_CONFIGURATIONS DEBUG
+        IMPORTED_IMPLIB_DEBUG "${Ice_${component}_IMPLIB_DEBUG}"
+        IMPORTED_LOCATION_DEBUG "${Ice_${component}_LIBRARY_DEBUG}"
+      )
+    endif()
+
+  else()
+    if(Ice_${component}_LIBRARY)
+      set_target_properties(Ice::${component} PROPERTIES
+        IMPORTED_LOCATION "${Ice_${component}_LIBRARY}"
+      )
+    endif()
+  endif()
+
+endfunction()
+
+function(add_ice_library component link_libraries)
+
+  if(WIN32)
+    # Find Release and Debug libraries on Windows
+    find_library(Ice_${component}_IMPLIB_RELEASE
+      NAMES ${component}${Ice_SO_VERSION}
+      HINTS "${PACKAGE_PREFIX_DIR}/build/native/lib/${Ice_WIN32_PLATFORM}/Release"
+      NO_DEFAULT_PATH
+    )
+
+    message(STATUS "Ice_${component}_IMPLIB_RELEASE: ${Ice_${component}_IMPLIB_RELEASE}")
+    message(STATUS "${PACKAGE_PREFIX_DIR}/build/native/lib/${Ice_WIN32_PLATFORM}/Release")
+
+    find_library(Ice_${component}_IMPLIB_DEBUG
+      NAMES ${component}d ${component}${Ice_SO_VERSION}d
+      HINTS "${PACKAGE_PREFIX_DIR}/build/native/lib/${Ice_WIN32_PLATFORM}/Debug"
+      NO_DEFAULT_PATH
+    )
+
+    find_file(Ice_${component}_LIBRARY_RELEASE
+      NAMES ${component}${Ice_SO_VERSION}.dll
+      HINTS "${PACKAGE_PREFIX_DIR}/build/native/bin/${Ice_WIN32_PLATFORM}/Release"
+      NO_DEFAULT_PATH
+    )
+
+    find_file(Ice_${component}_LIBRARY_DEBUG
+      NAMES ${component}${Ice_SO_VERSION}d.dll
+      HINTS "${PACKAGE_PREFIX_DIR}/build/native/bin/${Ice_WIN32_PLATFORM}/Debug"
+      NO_DEFAULT_PATH
+    )
+  else()
+    # Linux and macOS only have one library configuration
+    find_library(
+      Ice_${component}_LIBRARY_RELEASE
+      NAMES ${component}
+      HINTS "${PACKAGE_PREFIX_DIR}/lib"
+      PATH_SUFFIXES "${CMAKE_LIBRARY_ARCHITECTURE}"
+      NO_DEFAULT_PATH
+    )
+  endif()
+
+  # Select the appropriate library configuration based on platform and build type
+  include(SelectLibraryConfigurations)
+  select_library_configurations(Ice_${component})
+
+  if(Ice_${component}_LIBRARY)
+    # Set the Ice_<component>_FOUND variable to TRUE so that find_package_handle_standard_args
+    # will consider the component found
+    set(Ice_${component}_FOUND TRUE PARENT_SCOPE)
+    add_ice_target(${component} "${link_libraries}")
+  endif()
+
+endfunction()
+
+include(CMakeFindDependencyMacro)
+find_package(Threads REQUIRED QUIET)
+
+add_ice_library(Ice Threads::Threads)
+add_ice_library(DataStorm Ice::Ice)
+add_ice_library(Glacier2 Ice::Ice)
+add_ice_library(IceBox Ice::Ice)
+add_ice_library(IceDiscovery Ice::Ice)
+add_ice_library(IceGrid Ice::Ice Ice::Glacier2)
+add_ice_library(IceLocatorDiscovery Ice::Ice)
+add_ice_library(IceStorm Ice::Ice)
+add_ice_library(IceBT Ice::Ice)
+
+include(FindPackageHandleStandardArgs)
+set(${CMAKE_FIND_PACKAGE_NAME}_CONFIG "${CMAKE_CURRENT_LIST_FILE}")
+find_package_handle_standard_args(Ice HANDLE_COMPONENTS CONFIG_MODE)

--- a/cpp/config/IceTargets.cmake
+++ b/cpp/config/IceTargets.cmake
@@ -2,8 +2,6 @@
 
 cmake_policy(PUSH)
 
-cmake_minimum_required(VERSION 3.13)
-
 if(WIN32 AND NOT DEFINED Ice_WIN32_PLATFORM)
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     set(Ice_WIN32_PLATFORM "x64" CACHE PATH "Use x64 Ice library")

--- a/cpp/config/IceTargets.cmake
+++ b/cpp/config/IceTargets.cmake
@@ -1,5 +1,9 @@
 # Copyright (c) ZeroC, Inc.
 
+cmake_policy(PUSH)
+
+cmake_minimum_required(VERSION 3.13)
+
 if(WIN32 AND NOT DEFINED Ice_WIN32_PLATFORM)
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     set(Ice_WIN32_PLATFORM "x64" CACHE PATH "Use x64 Ice library")
@@ -153,3 +157,5 @@ add_ice_library(IceBT Ice::Ice)
 include(FindPackageHandleStandardArgs)
 set(${CMAKE_FIND_PACKAGE_NAME}_CONFIG "${CMAKE_CURRENT_LIST_FILE}")
 find_package_handle_standard_args(Ice HANDLE_COMPONENTS CONFIG_MODE)
+
+cmake_policy(POP)

--- a/cpp/config/IceTargets.cmake
+++ b/cpp/config/IceTargets.cmake
@@ -9,7 +9,7 @@ if(WIN32 AND NOT DEFINED Ice_WIN32_PLATFORM)
 endif()
 
 find_path(Ice_INCLUDE_DIR NAMES Ice/Ice.h
-  HINTS ${PACKAGE_PREFIX_DIR} ${PACKAGE_PREFIX_DIR}/build/native
+  HINTS ${Ice_PREFIX} ${Ice_PREFIX}/build/native
   PATH_SUFFIXES include DOC "Directory containing Ice header files"
   NO_DEFAULT_PATH
   REQUIRED)
@@ -29,7 +29,7 @@ if(NOT DEFINED Ice_VERSION)
 endif()
 
 find_program(Ice_SLICE2CPP_EXECUTABLE slice2cpp
-  HINTS ${PACKAGE_PREFIX_DIR}
+  HINTS ${Ice_PREFIX}
   PATH_SUFFIXES bin tools
   DOC "Path to the slice2cpp compiler"
   NO_DEFAULT_PATH
@@ -44,7 +44,7 @@ set_target_properties(Ice::slice2cpp PROPERTIES
 
 find_path(Ice_SLICE_DIR
   NAMES Ice/Identity.ice
-  HINTS ${PACKAGE_PREFIX_DIR}
+  HINTS ${Ice_PREFIX}
   PATH_SUFFIXES slice share/ice/slice
   DOC "Path to the Ice Slice files directory"
   NO_DEFAULT_PATH
@@ -92,28 +92,25 @@ function(add_ice_library component link_libraries)
     # Find Release and Debug libraries on Windows
     find_library(Ice_${component}_IMPLIB_RELEASE
       NAMES ${component}${Ice_SO_VERSION}
-      HINTS "${PACKAGE_PREFIX_DIR}/build/native/lib/${Ice_WIN32_PLATFORM}/Release"
+      HINTS "${Ice_PREFIX}/build/native/lib/${Ice_WIN32_PLATFORM}/Release"
       NO_DEFAULT_PATH
     )
 
-    message(STATUS "Ice_${component}_IMPLIB_RELEASE: ${Ice_${component}_IMPLIB_RELEASE}")
-    message(STATUS "${PACKAGE_PREFIX_DIR}/build/native/lib/${Ice_WIN32_PLATFORM}/Release")
-
     find_library(Ice_${component}_IMPLIB_DEBUG
       NAMES ${component}d ${component}${Ice_SO_VERSION}d
-      HINTS "${PACKAGE_PREFIX_DIR}/build/native/lib/${Ice_WIN32_PLATFORM}/Debug"
+      HINTS "${Ice_PREFIX}/build/native/lib/${Ice_WIN32_PLATFORM}/Debug"
       NO_DEFAULT_PATH
     )
 
     find_file(Ice_${component}_LIBRARY_RELEASE
       NAMES ${component}${Ice_SO_VERSION}.dll
-      HINTS "${PACKAGE_PREFIX_DIR}/build/native/bin/${Ice_WIN32_PLATFORM}/Release"
+      HINTS "${Ice_PREFIX}/build/native/bin/${Ice_WIN32_PLATFORM}/Release"
       NO_DEFAULT_PATH
     )
 
     find_file(Ice_${component}_LIBRARY_DEBUG
       NAMES ${component}${Ice_SO_VERSION}d.dll
-      HINTS "${PACKAGE_PREFIX_DIR}/build/native/bin/${Ice_WIN32_PLATFORM}/Debug"
+      HINTS "${Ice_PREFIX}/build/native/bin/${Ice_WIN32_PLATFORM}/Debug"
       NO_DEFAULT_PATH
     )
   else()
@@ -121,7 +118,7 @@ function(add_ice_library component link_libraries)
     find_library(
       Ice_${component}_LIBRARY_RELEASE
       NAMES ${component}
-      HINTS "${PACKAGE_PREFIX_DIR}/lib"
+      HINTS "${Ice_PREFIX}/lib"
       PATH_SUFFIXES "${CMAKE_LIBRARY_ARCHITECTURE}"
       NO_DEFAULT_PATH
     )

--- a/cpp/config/slice2cpp.cmake
+++ b/cpp/config/slice2cpp.cmake
@@ -1,0 +1,46 @@
+# Copyright (c) ZeroC, Inc.
+
+# Function to generate C++ source files from Slice (.ice) files for a target using slice2cpp
+# The target must have the Slice files in its sources
+# The generated files are added to the target sources
+# Usage:
+# add_executable(a_target source1.cpp source2.ice source3.ice)
+# slice2cpp_generate(a_target)
+function(slice2cpp_generate target)
+
+  # Get the list of source files for the target
+  get_target_property(sources ${target} SOURCES)
+
+  # Get the output directory for the generated files
+  set(output_dir ${CMAKE_CURRENT_BINARY_DIR}/generated/${target})
+  file(RELATIVE_PATH output_dir_relative ${CMAKE_CURRENT_LIST_DIR} ${output_dir})
+
+  # Create a directory to store the generated files
+  make_directory(${output_dir})
+
+  # Add the generated headers files to the target include directories
+  target_include_directories(${target} PRIVATE ${output_dir})
+
+  # Process each Slice (.ice) file in the source list
+  # 1. Run the slice2cpp command to generate the header and source files
+  # 2. Add the generated files to the target sources
+  foreach(file IN LISTS sources)
+    if(file MATCHES "\\.ice$")
+
+      get_filename_component(slice_file_name ${file} NAME_WE)
+      get_filename_component(slice_file_path ${file} ABSOLUTE)
+
+      set(output_files ${output_dir}/${slice_file_name}.h ${output_dir}/${slice_file_name}.cpp)
+
+      add_custom_command(
+        OUTPUT ${output_files}
+        COMMAND $<TARGET_FILE:Ice::slice2cpp> -I${Ice_SLICE_DIR} ${slice_file_path} --output-dir ${output_dir}
+        DEPENDS ${slice_file_path}
+        COMMENT "Compiling Slice ${file} -> ${output_dir_relative}/${slice_file_name}.cpp ${output_dir_relative}/${slice_file_name}.h"
+      )
+
+      target_sources(${target} PRIVATE ${output_files})
+
+    endif()
+  endforeach()
+endfunction()

--- a/cpp/msbuild/ice.nuget.targets
+++ b/cpp/msbuild/ice.nuget.targets
@@ -43,6 +43,11 @@
                          $(IceSrcRootDir)..\slice\IceLocatorDiscovery\*.ice"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <!-- CMake support files -->
+        <CMakeFiles Include="$(IceSrcRootDir)config\*.cmake" />
+    </ItemGroup>
+
     <!-- Copy required files to the package specific directories -->
     <Target Name="NugetPack">
         <Copy Condition="'$(DefaultBuild)' == '$(Platform)|$(Configuration)'"
@@ -56,6 +61,6 @@
 
         <Copy SourceFiles="@(Executables)" DestinationFolder="$(PackageDirectory)\build\native\bin\$(Platform)\$(Configuration)" />
         <Copy SourceFiles="@(Libraries)" DestinationFolder="$(PackageDirectory)\build\native\bin\$(Platform)\$(Configuration)" />
-        <Copy SourceFiles="@(ImportLibraries)" DestinationFolder="$(PackageDirectory)\build\native\lib\$(Platform)\$(Configuration)" />
+        <Copy SourceFiles="@(CMakeFiles)" DestinationFolder="$(PackageDirectory)\build\native\lib\cmake\Ice" />
     </Target>
 </Project>

--- a/cpp/msbuild/ice.nuget.targets
+++ b/cpp/msbuild/ice.nuget.targets
@@ -61,6 +61,6 @@
 
         <Copy SourceFiles="@(Executables)" DestinationFolder="$(PackageDirectory)\build\native\bin\$(Platform)\$(Configuration)" />
         <Copy SourceFiles="@(Libraries)" DestinationFolder="$(PackageDirectory)\build\native\bin\$(Platform)\$(Configuration)" />
-        <Copy SourceFiles="@(CMakeFiles)" DestinationFolder="$(PackageDirectory)\build\native\lib\cmake\Ice" />
+        <Copy SourceFiles="@(CMakeFiles)" DestinationFolder="$(PackageDirectory)\cmake" />
     </Target>
 </Project>

--- a/cpp/msbuild/ice.nuget.targets
+++ b/cpp/msbuild/ice.nuget.targets
@@ -61,6 +61,7 @@
 
         <Copy SourceFiles="@(Executables)" DestinationFolder="$(PackageDirectory)\build\native\bin\$(Platform)\$(Configuration)" />
         <Copy SourceFiles="@(Libraries)" DestinationFolder="$(PackageDirectory)\build\native\bin\$(Platform)\$(Configuration)" />
+        <Copy SourceFiles="@(ImportLibraries)" DestinationFolder="$(PackageDirectory)\build\native\lib\$(Platform)\$(Configuration)" />
         <Copy SourceFiles="@(CMakeFiles)" DestinationFolder="$(PackageDirectory)\cmake" />
     </Target>
 </Project>

--- a/packaging/dpkg/debian/libzeroc-ice-dev.install
+++ b/packaging/dpkg/debian/libzeroc-ice-dev.install
@@ -1,4 +1,4 @@
 usr/include/*
 usr/lib/*/*.so
 usr/lib/*/*.a
-usr/lib/*/cmake/Ice/*.cmake
+usr/lib/*/cmake/*/*.cmake

--- a/packaging/dpkg/debian/libzeroc-ice-dev.install
+++ b/packaging/dpkg/debian/libzeroc-ice-dev.install
@@ -1,3 +1,4 @@
 usr/include/*
 usr/lib/*/*.so
 usr/lib/*/*.a
+usr/lib/cmake/Ice/*.cmake

--- a/packaging/dpkg/debian/libzeroc-ice-dev.install
+++ b/packaging/dpkg/debian/libzeroc-ice-dev.install
@@ -1,4 +1,4 @@
 usr/include/*
 usr/lib/*/*.so
 usr/lib/*/*.a
-usr/lib/cmake/Ice/*.cmake
+usr/lib/*/cmake/Ice/*.cmake

--- a/packaging/rpm/ice.spec
+++ b/packaging/rpm/ice.spec
@@ -496,7 +496,7 @@ rm -rf %{buildroot}%{_datadir}/ice
 %ifarch %{_host_cpu}
 %{_libdir}/libGlacier2CryptPermissionsVerifier.so.*
 %endif
-%{_libdir}/cmake/Ice/*.cmake
+%{_libdir}/cmake/*/*.cmake
 %post -n lib%{?nameprefix}ice3.8-c++ -p /sbin/ldconfig
 %postun -n lib%{?nameprefix}ice3.8-c++
 /sbin/ldconfig

--- a/packaging/rpm/ice.spec
+++ b/packaging/rpm/ice.spec
@@ -496,6 +496,7 @@ rm -rf %{buildroot}%{_datadir}/ice
 %ifarch %{_host_cpu}
 %{_libdir}/libGlacier2CryptPermissionsVerifier.so.*
 %endif
+%{_libdir}/cmake/Ice/*.cmake
 %post -n lib%{?nameprefix}ice3.8-c++ -p /sbin/ldconfig
 %postun -n lib%{?nameprefix}ice3.8-c++
 /sbin/ldconfig


### PR DESCRIPTION
This PR adds CMake support files that we will ship in our packaging.

We install the CMake files to the following locations:

- **NuGet**: `<nuget_package>/cmake/`
- **macOS**: `<install_prefix>/lib/cmake/Ice-<version>`
- **Debian**: `<install_prefix>/lib/<arch>/cmake/Ice-<version>`
- **RedHat**: ` <install_prefix>/<lib>/cmake/Ice-<version>` 