### PR TITLE
Fix duplicate thread::join in IceGrid

### DIFF
--- a/cpp/src/IceGrid/NodeSessionManager.cpp
+++ b/cpp/src/IceGrid/NodeSessionManager.cpp
@@ -444,8 +444,6 @@ NodeSessionManager::addReplicaSession(InternalRegistryPrx replica)
 void
 NodeSessionManager::reapReplicas()
 {
-    // NodeSessionKeepAliveThread's destructor will join its thread on destruction
-    // Keep this vector do the destruction outside the lock
     vector<shared_ptr<NodeSessionKeepAliveThread>> reap;
     {
         lock_guard lock(_mutex);

--- a/cpp/src/IceGrid/SessionManager.h
+++ b/cpp/src/IceGrid/SessionManager.h
@@ -263,7 +263,18 @@ namespace IceGrid
             _condVar.notify_all();
         }
 
-        void join() { _thread.join(); }
+        void join()
+        {
+            std::thread thread;
+            {
+                std::lock_guard lock{_mutex};
+                thread = std::move(_thread);
+            }
+            if (thread.joinable())
+            {
+                thread.join();
+            }
+        }
 
         bool isDestroyed()
         {


### PR DESCRIPTION
See #3602.

A std::thread can only be joined once.