### PR TITLE
Simplify printing of proxies in C#

### DIFF
--- a/csharp/src/Ice/Internal/Reference.cs
+++ b/csharp/src/Ice/Internal/Reference.cs
@@ -333,7 +333,7 @@ public abstract class Reference : IEquatable<Reference>
         {
             case Mode.ModeTwoway:
             {
-                s.Append(" -t");
+                // Don't print the default mode.
                 break;
             }
 
@@ -367,25 +367,20 @@ public abstract class Reference : IEquatable<Reference>
             s.Append(" -s");
         }
 
-        if (!_protocol.Equals(Ice.Util.Protocol_1_0))
+        if (_protocol != Ice.Util.Protocol_1_0)
         {
-            //
-            // We only print the protocol if it's not 1.0. It's fine as
-            // long as we don't add Ice.Default.ProtocolVersion, a
-            // stringified proxy will convert back to the same proxy with
-            // stringToProxy.
-            //
+            // We print the protocol unless it's 1.0.
             s.Append(" -p ");
             s.Append(Ice.Util.protocolVersionToString(_protocol));
         }
 
-        //
-        // Always print the encoding version to ensure a stringified proxy
-        // will convert back to a proxy with the same encoding with
-        // stringToProxy (and won't use Ice.Default.EncodingVersion).
-        //
-        s.Append(" -e ");
-        s.Append(Ice.Util.encodingVersionToString(_encoding));
+        // We print the encoding if it's not 1.1 or if Ice.Default.EncodingVersion is set to something other than 1.1.
+        if (_encoding != Ice.Util.Encoding_1_1 ||
+            _instance.defaultsAndOverrides().defaultEncoding != Ice.Util.Encoding_1_1)
+        {
+            s.Append(" -e ");
+            s.Append(Ice.Util.encodingVersionToString(_encoding));
+        }
 
         return s.ToString();
 

--- a/csharp/test/Ice/metrics/AllTests.cs
+++ b/csharp/test/Ice/metrics/AllTests.cs
@@ -1110,15 +1110,14 @@ public class AllTests : Test.AllTests
         }
 
         await testAttributeAsync(clientMetrics, clientProps, update, "Invocation", "parent", "Communicator", op, output);
-        await testAttributeAsync(clientMetrics, clientProps, update, "Invocation", "id", "metrics -t -e 1.1 [op]", op, output);
+        await testAttributeAsync(clientMetrics, clientProps, update, "Invocation", "id", "metrics [op]", op, output);
 
         await testAttributeAsync(clientMetrics, clientProps, update, "Invocation", "operation", "op", op, output);
         await testAttributeAsync(clientMetrics, clientProps, update, "Invocation", "identity", "metrics", op, output);
         await testAttributeAsync(clientMetrics, clientProps, update, "Invocation", "facet", "", op, output);
         await testAttributeAsync(clientMetrics, clientProps, update, "Invocation", "encoding", "1.1", op, output);
         await testAttributeAsync(clientMetrics, clientProps, update, "Invocation", "mode", "twoway", op, output);
-        await testAttributeAsync(clientMetrics, clientProps, update, "Invocation", "proxy",
-                      "metrics -t -e 1.1:" + endpoint, op, output);
+        await testAttributeAsync(clientMetrics, clientProps, update, "Invocation", "proxy", "metrics:" + endpoint, op, output);
 
         await testAttributeAsync(clientMetrics, clientProps, update, "Invocation", "context.entry1", "test", op, output);
         await testAttributeAsync(clientMetrics, clientProps, update, "Invocation", "context.entry2", "", op, output);

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -220,10 +220,10 @@ namespace Ice
                 test(b1.ice_getEncodingVersion().major == 6 && b1.ice_getEncodingVersion().minor == 5);
 
                 b1 = communicator.stringToProxy("test -p 1.0 -e 1.0");
-                test(b1.ToString() == "test -t -e 1.0");
+                test(b1.ToString() == "test -e 1.0");
 
                 b1 = communicator.stringToProxy("test -p 6.5 -e 1.0");
-                test(b1.ToString() == "test -t -p 6.5 -e 1.0");
+                test(b1.ToString() == "test -p 6.5 -e 1.0");
 
                 try
                 {
@@ -521,7 +521,7 @@ namespace Ice
                 Dictionary<string, string> proxyProps = communicator.proxyToProperty(b1, "Test");
                 test(proxyProps.Count == 21);
 
-                test(proxyProps["Test"] == "test -t -e 1.0");
+                test(proxyProps["Test"] == "test -e 1.0");
                 test(proxyProps["Test.CollocationOptimized"] == "1");
                 test(proxyProps["Test.ConnectionCached"] == "1");
                 test(proxyProps["Test.PreferSecure"] == "0");
@@ -529,8 +529,7 @@ namespace Ice
                 test(proxyProps["Test.LocatorCacheTimeout"] == "100");
                 test(proxyProps["Test.InvocationTimeout"] == "1234");
 
-                test(proxyProps["Test.Locator"].Equals(
-                         "locator -t -e " + Ice.Util.encodingVersionToString(Ice.Util.currentEncoding)));
+                test(proxyProps["Test.Locator"] == "locator");
                 // Locator collocation optimization is always disabled.
                 // test(proxyProps["Test.Locator.CollocationOptimized"] == "1");
                 test(proxyProps["Test.Locator.ConnectionCached"] == "0");
@@ -539,8 +538,7 @@ namespace Ice
                 test(proxyProps["Test.Locator.LocatorCacheTimeout"] == "300");
                 test(proxyProps["Test.Locator.InvocationTimeout"] == "1500");
 
-                test(proxyProps["Test.Locator.Router"].Equals(
-                         "router -t -e " + Ice.Util.encodingVersionToString(Ice.Util.currentEncoding)));
+                test(proxyProps["Test.Locator.Router"] == "router");
                 test(proxyProps["Test.Locator.Router.CollocationOptimized"] == "0");
                 test(proxyProps["Test.Locator.Router.ConnectionCached"] == "1");
                 test(proxyProps["Test.Locator.Router.PreferSecure"] == "1");
@@ -1003,23 +1001,23 @@ namespace Ice
                 // Legal TCP endpoint expressed as opaque endpoint
                 Ice.ObjectPrx p1 = communicator.stringToProxy("test -e 1.1:opaque -t 1 -e 1.0 -v CTEyNy4wLjAuMeouAAAQJwAAAA==");
                 string pstr = communicator.proxyToString(p1);
-                test(pstr == "test -t -e 1.1:tcp -h 127.0.0.1 -p 12010 -t 10000");
+                test(pstr == "test:tcp -h 127.0.0.1 -p 12010 -t 10000");
 
                 // Opaque endpoint encoded with 1.1 encoding.
                 Ice.ObjectPrx p2 = communicator.stringToProxy("test -e 1.1:opaque -e 1.1 -t 1 -v CTEyNy4wLjAuMeouAAAQJwAAAA==");
-                test(communicator.proxyToString(p2) == "test -t -e 1.1:tcp -h 127.0.0.1 -p 12010 -t 10000");
+                test(communicator.proxyToString(p2) == "test:tcp -h 127.0.0.1 -p 12010 -t 10000");
 
                 if (communicator.getProperties().getIcePropertyAsInt("Ice.IPv6") == 0)
                 {
                     // Two legal TCP endpoints expressed as opaque endpoints
                     p1 = communicator.stringToProxy("test -e 1.0:opaque -e 1.0 -t 1 -v CTEyNy4wLjAuMeouAAAQJwAAAA==:opaque -e 1.0 -t 1 -v CTEyNy4wLjAuMusuAAAQJwAAAA==");
                     pstr = communicator.proxyToString(p1);
-                    test(pstr == "test -t -e 1.0:tcp -h 127.0.0.1 -p 12010 -t 10000:tcp -h 127.0.0.2 -p 12011 -t 10000");
+                    test(pstr == "test -e 1.0:tcp -h 127.0.0.1 -p 12010 -t 10000:tcp -h 127.0.0.2 -p 12011 -t 10000");
 
                     // Test that an SSL endpoint and a nonsense endpoint get written back out as an opaque endpoint.
                     p1 = communicator.stringToProxy("test -e 1.0:opaque -e 1.0 -t 2 -v CTEyNy4wLjAuMREnAAD/////AA==:opaque -e 1.0 -t 99 -v abch");
                     pstr = communicator.proxyToString(p1);
-                    test(pstr == "test -t -e 1.0:ssl -h 127.0.0.1 -p 10001 -t infinite:opaque -t 99 -e 1.0 -v abch");
+                    test(pstr == "test -e 1.0:ssl -h 127.0.0.1 -p 10001 -t infinite:opaque -t 99 -e 1.0 -v abch");
                 }
 
                 output.WriteLine("ok");


### PR DESCRIPTION
This PR simplifies the printing of proxies in C#:  we no longer print "-t" (= two-way, the default), or "-e 1.1" unless Ice.Default.EncodingVersion is set to something other than 1.1.

If approved, I'll apply the same update to other languages.