### PR TITLE
Workflow cache fixes

### DIFF
--- a/.github/actions/setup-cache/action.yml
+++ b/.github/actions/setup-cache/action.yml
@@ -17,9 +17,8 @@ runs:
       with:
         # create-symlink: true
         append-timestamp: false
-        key: ${{ inputs.prefix }}-${{ runner.os }}-${{ github.sha }}-
+        key: ${{ inputs.prefix }}-${{ runner.os }}-${{ github.sha }}
         restore-keys: |
-          ${{ inputs.prefix }}-${{ runner.os }}-${{ github.sha }}-
           ${{ inputs.prefix }}-${{ runner.os }}-
       if: runner.os == 'macOS' || runner.os == 'Linux'
 

--- a/.github/actions/setup-cache/action.yml
+++ b/.github/actions/setup-cache/action.yml
@@ -1,0 +1,47 @@
+name: Setup Cache
+
+inputs:
+  prefix:
+    description: "Cache key prefix"
+    type: string
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    #
+    # Cache
+    #
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        # create-symlink: true
+        append-timestamp: false
+        key: ${{ inputs.prefix }}-${{ runner.os }}-${{ github.sha }}-
+        restore-keys: |
+          ${{ inputs.prefix }}-${{ runner.os }}-${{ github.sha }}-
+          ${{ inputs.prefix }}-${{ runner.os }}-
+      if: runner.os == 'macOS' || runner.os == 'Linux'
+
+    - name: Configure ccache path
+      run: |
+        echo "/usr/lib/ccache" >> $GITHUB_PATH
+        echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
+        echo "/opt/homebrew/opt/ccache/libexec" >> $GITHUB_PATH
+      shell: bash
+      if: runner.os == 'macOS' || runner.os == 'Linux'
+
+  # - name: Setup Windows Cache
+  #   uses: actions/cache@v4
+  #   with:
+  #     path: |
+  #       **/bin/x64
+  #       **/lib/x64
+  #       **/msbuild/**/x64
+  #       **/include/generated
+
+  #     key: ci-${{ runner.os }}-${{ matrix.config }}-${{ github.sha }}
+  #     restore-keys: |
+  #       ci-${{ runner.os }}-${{ matrix.config }}-
+  #       ci-${{ runner.os }}-
+  #   if: inputs.cache && runner.os == 'Windows'

--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -9,14 +9,6 @@ inputs:
     options:
       - true
       - false
-  use_ccache:
-    description: "Indicates whether to install and configure ccache"
-    type: choice
-    required: true
-    default: "true"
-    options:
-      - true
-      - false
 
 runs:
   using: "composite"
@@ -144,40 +136,3 @@ runs:
         sdkmanager emulator
         sdkmanager --update
       if: matrix.config == 'android'
-
-    #
-    # Cache
-    #
-    - name: Setup ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        # create-symlink: true
-        append-timestamp: false
-        key: ci-${{ runner.os }}-${{ matrix.config }}-${{ github.sha }}
-        restore-keys: |
-          ci-${{ runner.os }}-${{ matrix.config }}-
-          ci-${{ runner.os }}-
-      if: inputs.use_ccache == 'true' && (runner.os == 'macOS' || runner.os == 'Linux')
-
-    - name: Configure ccache path
-      run: |
-        echo "/usr/lib/ccache" >> $GITHUB_PATH
-        echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
-        echo "/opt/homebrew/opt/ccache/libexec" >> $GITHUB_PATH
-      shell: bash
-      if: inputs.use_ccache == 'true' && (runner.os == 'macOS' || runner.os == 'Linux')
-
-    # - name: Setup Windows Cache
-    #   uses: actions/cache@v4
-    #   with:
-    #     path: |
-    #       **/bin/x64
-    #       **/lib/x64
-    #       **/msbuild/**/x64
-    #       **/include/generated
-
-    #     key: ci-${{ runner.os }}-${{ matrix.config }}-${{ github.sha }}
-    #     restore-keys: |
-    #       ci-${{ runner.os }}-${{ matrix.config }}-
-    #       ci-${{ runner.os }}-
-    #   if: inputs.cache && runner.os == 'Windows'

--- a/.github/workflows/build-brew-packages.yml
+++ b/.github/workflows/build-brew-packages.yml
@@ -40,9 +40,14 @@ jobs:
       - name: Setup Dependencies
         uses: ./.github/actions/setup-dependencies
 
+      - name: Setup Cache
+        uses: ./.github/actions/setup-cache
+        with:
+          prefix: build-brew-packages
+
       - name: Tap Nightly Repository
         env:
-            NIGHTLY_URL: "https://download.zeroc.com/nexus/repository/nightly/homebrew-nightly.git"
+          NIGHTLY_URL: "https://download.zeroc.com/nexus/repository/nightly/homebrew-nightly.git"
         run: |
           if git ls-remote $NIGHTLY_URL; then
             brew tap zeroc-ice/nightly $NIGHTLY_URL

--- a/.github/workflows/build-gem-packages.yml
+++ b/.github/workflows/build-gem-packages.yml
@@ -40,6 +40,11 @@ jobs:
       - name: Setup Dependencies
         uses: ./.github/actions/setup-dependencies
 
+      - name: Setup Cache
+        uses: ./.github/actions/setup-cache
+        with:
+          prefix: build-gem-packages
+
       - name: Install Build Dependencies
         run: gem install rake
 
@@ -60,13 +65,13 @@ jobs:
 
       - name: Publish GEM Packages
         run: |
-           curl -u "${REPOSITORY_USERNAME}:${REPOSITORY_PASSWORD}" \
-             --upload-file ruby/zeroc-ice-*.gem \
-             --output /dev/null \
-             --silent \
-             --fail \
-             --show-error \
-             ${{ inputs.repository_url }} || { echo "Upload zeroc-ice-*.gem failed"; exit 1; }
+          curl -u "${REPOSITORY_USERNAME}:${REPOSITORY_PASSWORD}" \
+            --upload-file ruby/zeroc-ice-*.gem \
+            --output /dev/null \
+            --silent \
+            --fail \
+            --show-error \
+            ${{ inputs.repository_url }} || { echo "Upload zeroc-ice-*.gem failed"; exit 1; }
         if: inputs.repository_url != ''
         env:
           REPOSITORY_USERNAME: ${{ inputs.repository_username }}

--- a/.github/workflows/build-matlab-packages.yml
+++ b/.github/workflows/build-matlab-packages.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           use_matlab: true
 
+      - name: Setup Cache
+        uses: ./.github/actions/setup-cache
+        with:
+          prefix: build-matlab-packages
+
       - name: Build Linux MATLAB ToolBox
         run: |
           make -C cpp srcs

--- a/.github/workflows/build-pip-packages.yml
+++ b/.github/workflows/build-pip-packages.yml
@@ -47,6 +47,11 @@ jobs:
       - name: Setup Dependencies
         uses: ./.github/actions/setup-dependencies
 
+      - name: Setup Cache
+        uses: ./.github/actions/setup-cache
+        with:
+          prefix: build-pip-packages
+
       - name: Install Build Dependencies
         run: |
           python3 -m pip install --upgrade pip

--- a/.github/workflows/build-swift-package.yml
+++ b/.github/workflows/build-swift-package.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Setup Dependencies
         uses: ./.github/actions/setup-dependencies
 
+      - name: Setup Cache
+        uses: ./.github/actions/setup-cache
+        with:
+          prefix: build-swift-packages
+
       - name: Create ice-swift repository
         run: |
           cd packaging/swift

--- a/.github/workflows/build-xcframework-packages.yml
+++ b/.github/workflows/build-xcframework-packages.yml
@@ -41,6 +41,11 @@ jobs:
       - name: Setup Dependencies
         uses: ./.github/actions/setup-dependencies
 
+      - name: Setup Cache
+        uses: ./.github/actions/setup-cache
+        with:
+          prefix: build-xcframework-packages
+
       - name: Build XCFramework Packages
         run: make OPTIMIZE=yes PLATFORMS="all" CONFIGS="static" srcs
         working-directory: cpp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,11 @@ jobs:
         with:
           use_matlab: ${{ matrix.config == 'matlab' }}
 
+      - name: Setup Cache
+        uses: ./.github/actions/setup-cache
+        with:
+          prefix: ci-${{ matrix.config }}
+
       # See https://learn.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps
       - name: Enable Windows crash dumps
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,8 +14,6 @@ jobs:
 
       - name: Setup Dependencies
         uses: ./.github/actions/setup-dependencies
-        with:
-          use_ccache: false
 
       - name: Generate C++ Coverage
         working-directory: ./cpp
@@ -61,8 +59,6 @@ jobs:
 
       - name: Setup Dependencies
         uses: ./.github/actions/setup-dependencies
-        with:
-          use_ccache: false
 
       - name: Build
         run: |
@@ -103,8 +99,6 @@ jobs:
 
       - name: Setup Dependencies
         uses: ./.github/actions/setup-dependencies
-        with:
-          use_ccache: false
 
       - name: Generate Java Coverage
         working-directory: ./java

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -39,6 +39,11 @@ jobs:
       - name: Setup Ice Build Dependencies
         uses: ./.github/actions/setup-dependencies
 
+      - name: Setup Cache
+        uses: ./.github/actions/setup-cache
+        with:
+          prefix: clang-tidy
+
       - name: Install clang-tidy
         run: |
           # This LLVM script will add the relevant LLVM PPA: https://apt.llvm.org/

--- a/.github/workflows/ice2slice.yml
+++ b/.github/workflows/ice2slice.yml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Setup Dependencies
         uses: ./.github/actions/setup-dependencies
-        with:
-          use_ccache: false
 
       - name: Build ice2slice
         working-directory: ./cpp

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Setup Dependencies
         uses: ./.github/actions/setup-dependencies
+        with:
+          use_matlab: true
 
       - name: Build MATLAB on Ubuntu
         uses: ./.github/actions/build

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Setup Dependencies
         uses: ./.github/actions/setup-dependencies
-        with:
-          use_matlab: true
 
       - name: Build MATLAB on Ubuntu
         uses: ./.github/actions/build


### PR DESCRIPTION
This PR changes our setup for ccache build caching in our workflows.

Previously we always used a `ci-` prefix and used `${{ matrix.confg}}`.  This only really worked for CI and/or jobs that used a matrix with a config key. This is leading to thrashing the `ci--` key when there's no `matrix.conifg`.

This was leading to lots of errors in non-ci builds:
<img width="1316" alt="Screenshot 2025-03-07 at 12 14 51 PM" src="https://github.com/user-attachments/assets/2a28c230-7a9a-409d-989d-888f660fa226" />

This update moves the cache action out of `setup-dependencies` and into a new `setup-cache` action. 

This action requires a prefix. 

I did not add this action to windows only workflows, or workflows that only compiled a tiny amount of c++, such as the compilers. 