### PR TITLE
Fix incorrect duplicate check in IceGrid

### DIFF
--- a/cpp/src/IceGrid/WellKnownObjectsManager.cpp
+++ b/cpp/src/IceGrid/WellKnownObjectsManager.cpp
@@ -124,14 +124,18 @@ WellKnownObjectsManager::getWellKnownObjectReplicatedProxy(const Ice::Identity& 
     try
     {
         auto proxy = _database->getObjectProxy(id);
+
         Ice::EndpointSeq registryEndpoints = getEndpoints(endpt)->ice_getEndpoints();
 
         // Re-order the endpoints to return first the endpoint for this registry replica.
-        Ice::EndpointSeq endpoints = proxy->ice_getEndpoints();
         Ice::EndpointSeq newEndpoints = registryEndpoints;
-        for (const auto& endpoint : endpoints)
+        for (const auto& endpoint : proxy->ice_getEndpoints())
         {
-            if (find(registryEndpoints.begin(), registryEndpoints.end(), endpoint) == registryEndpoints.end())
+            // Avoid duplicates.
+            if (find_if(
+                    registryEndpoints.begin(),
+                    registryEndpoints.end(),
+                    [&endpoint](const Ice::EndpointPtr& p) { return *endpoint == *p; }) == registryEndpoints.end())
             {
                 newEndpoints.push_back(endpoint);
             }


### PR DESCRIPTION
When running an IceGrid demo, I noticed the locator registry proxy had duplicated endpoints, and I tracked it down to this bug in the IceGrid code.

It was introduced by the upgrade to C++11/17 from C++98 - IceGrid 3.7 is not affected.