### PR TITLE
Fix Missing Extension with `--depend` and `errorDetection` Path Checking

### DIFF
--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -209,7 +209,7 @@ compile(const vector<string>& argv)
 
             DefinitionContextPtr dc = u->findDefinitionContext(u->topLevelFile());
             assert(dc);
-            string ext = dc->getMetadataArgs("cpp:header-ext").value_or("");
+            string ext = dc->getMetadataArgs("cpp:header-ext").value_or(headerExtension);
 
             u->destroy();
 

--- a/cpp/test/Slice/errorDetection/test.py
+++ b/cpp/test/Slice/errorDetection/test.py
@@ -48,8 +48,8 @@ class SliceErrorDetectionTestCase(ClientTestCase):
                     regex2 = re.compile("^.*(?=" + os.path.basename(file) + ")")
                     i = 0
                     while i < len(lines1):
-                        line1 = regex2.sub("", lines1[i]).strip()
-                        line2 = regex2.sub("", lines2[i]).strip()
+                        line1 = regex2.sub("", lines1[i]).strip() # Actual output from slice2cpp
+                        line2 = lines2[i].strip()                 # Expected output from .err file
                         if line1 != line2:
                             raise RuntimeError(
                                 'failed! (line1 = "{0}", line2 = "{1}"'.format(


### PR DESCRIPTION
This PR fixes two issues:

1) #3642 points out that by default `--depend` is generating output with empty file extensions. This is a bug IMO.
The `--depend` code only checks for `header-ext` metadata, and falls-back to `""` is none is present.
It should be falling back to `headerExtension` like the generated code (which checks for any CLI options, and falls-back to `.h`).

2) Fixes #3643. The `errorDetection` test no longer tolerates paths in the `.err`.