### PR TITLE
Add Support for `python:identifier` Metadata.

### DIFF
--- a/cpp/src/Ice/FileUtil.cpp
+++ b/cpp/src/Ice/FileUtil.cpp
@@ -405,7 +405,7 @@ IceInternal::FileLock::FileLock(const std::string& path) : _path(path)
 
     struct ::flock lock;
     lock.l_type = F_WRLCK;    // Write lock
-    lock.l_whence = SEEK_SET; // beginning of file
+    lock.l_whence = SEEK_SET; // Beginning of file
     lock.l_start = 0;
     lock.l_len = 0;
 

--- a/cpp/src/Ice/FileUtil.cpp
+++ b/cpp/src/Ice/FileUtil.cpp
@@ -405,7 +405,7 @@ IceInternal::FileLock::FileLock(const std::string& path) : _path(path)
 
     struct ::flock lock;
     lock.l_type = F_WRLCK;    // Write lock
-    lock.l_whence = SEEK_SET; // Begining of file
+    lock.l_whence = SEEK_SET; // beginning of file
     lock.l_start = 0;
     lock.l_len = 0;
 
@@ -427,7 +427,7 @@ IceInternal::FileLock::FileLock(const std::string& path) : _path(path)
     //
 
     //
-    // Now that we have acquire an excluxive write lock,
+    // Now that we have acquire an exclusive write lock,
     // write the process pid there.
     //
     ostringstream os;

--- a/cpp/src/IceGrid/DescriptorBuilder.cpp
+++ b/cpp/src/IceGrid/DescriptorBuilder.cpp
@@ -592,7 +592,7 @@ void
 CommunicatorDescriptorBuilder::finish()
 {
     //
-    // Add the hidden properties at the begining of the communicator
+    // Add the hidden properties at the beginning of the communicator
     // properties. These properties are not added directly to the
     // property set because it's not allowed to define properties
     // before references to property sets.

--- a/cpp/src/IceGrid/FileCache.cpp
+++ b/cpp/src/IceGrid/FileCache.cpp
@@ -59,13 +59,13 @@ FileCache::getOffsetFromEnd(const string& file, int originalCount)
         }
         else
         {
-            is.seekg(0, ios::beg); // We've reach the begining of the file.
+            is.seekg(0, ios::beg); // We've reach the beginning of the file.
         }
 
         //
         // Read the block and count the number of lines in the block
         // If we found the "first last N lines", we start throwing out
-        // the lines read at the begining of the file.
+        // the lines read at the beginning of the file.
         //
         int count = originalCount - totalCount; // Number of lines left to find.
         while (is.good() && is.tellg() <= streamoff(lastBlockOffset))
@@ -88,7 +88,7 @@ FileCache::getOffsetFromEnd(const string& file, int originalCount)
 
         if (lastBlockOffset - blockSize < streamoff(0))
         {
-            break; // We're done if the block started at the begining of the file.
+            break; // We're done if the block started at the beginning of the file.
         }
         else if (totalCount < originalCount)
         {

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2398,6 +2398,25 @@ Slice::Python::validateMetadata(const UnitPtr& unit)
     knownMetadata.emplace("python:array.array", arrayTypeInfo);
     knownMetadata.emplace("python:numpy.ndarray", std::move(arrayTypeInfo));
 
+    // "python:identifier"
+    MetadataInfo identifierInfo = {
+        .validOn =
+            {typeid(InterfaceDecl),
+             typeid(Operation),
+             typeid(ClassDecl),
+             typeid(Slice::Exception),
+             typeid(Struct),
+             typeid(Sequence),
+             typeid(Dictionary),
+             typeid(Enum),
+             typeid(Enumerator),
+             typeid(Const),
+             typeid(Parameter),
+             typeid(DataMember)},
+        .acceptedArgumentKind = MetadataArgumentKind::SingleArgument,
+    };
+    knownMetadata.emplace("python:identifier", std::move(identifierInfo));
+
     // "python:memoryview"
     MetadataInfo memoryViewInfo = {
         .validOn = {typeid(Sequence)},

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -572,8 +572,8 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     _out.dec();
 
-    _out << sp << nl << type << " = IcePy.defineValue('" << scoped << "', " << valueName << ", "
-         << p->compactId() << ", ";
+    _out << sp << nl << type << " = IcePy.defineValue('" << scoped << "', " << valueName << ", " << p->compactId()
+         << ", ";
     writeMetadata(p->getMetadata());
     _out << ", False, ";
     if (!base)
@@ -936,8 +936,8 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
         const string sliceName = operation->name();
 
-        _out << nl << className << "._op_" << sliceName << " = IcePy.Operation('" << sliceName << "', '" << operation->mappedName() << "', "
-             << getOperationMode(operation->mode()) << ", "
+        _out << nl << className << "._op_" << sliceName << " = IcePy.Operation('" << sliceName << "', '"
+             << operation->mappedName() << "', " << getOperationMode(operation->mode()) << ", "
              << ((p->hasMetadata("amd") || operation->hasMetadata("amd")) ? "True" : "False") << ", " << format << ", ";
         writeMetadata(operation->getMetadata());
         _out << ", (";

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -411,7 +411,7 @@ Slice::Python::CodeVisitor::visitClassDecl(const ClassDeclPtr& p)
     {
         writeModuleHasDefinitionCheck(_out, p, p->mappedName());
         _out.inc();
-        _out << nl << getTypeReference(p) << " = IcePy.declareValue('" << scoped << "')";
+        _out << nl << getMetaTypeReference(p) << " = IcePy.declareValue('" << scoped << "')";
         _out.dec();
         _classHistory.insert(scoped); // Avoid redundant declarations.
     }
@@ -426,7 +426,7 @@ Slice::Python::CodeVisitor::visitInterfaceDecl(const InterfaceDeclPtr& p)
     {
         writeModuleHasDefinitionCheck(_out, p, p->mappedName());
         _out.inc();
-        _out << nl << getTypeReference(p) << "Prx" << " = IcePy.declareProxy('" << scoped << "')";
+        _out << nl << getMetaTypeReference(p) << "Prx" << " = IcePy.declareProxy('" << scoped << "')";
         _out.dec();
         _classHistory.insert(scoped); // Avoid redundant declarations.
     }
@@ -461,7 +461,7 @@ Slice::Python::CodeVisitor::writeOperations(const InterfaceDefPtr& p)
             _out << nl << "Returns";
             _out << nl << "  An object containing the marshaled result.";
             _out << nl << tripleQuotes;
-            _out << nl << "return IcePy.MarshaledResult(result, " << getModuleReference(p) << "._op_" << sliceName
+            _out << nl << "return IcePy.MarshaledResult(result, " << getTypeReference(p) << "._op_" << sliceName
                  << ", current.adapter.getCommunicator()._getImpl(), current.encoding)";
             _out.dec();
         }
@@ -492,14 +492,14 @@ bool
 Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
     const string scoped = p->scoped();
-    const string type = getTypeReference(p);
+    const string type = getMetaTypeReference(p);
     const string valueName = p->mappedName();
     const ClassDefPtr base = p->base();
     const DataMemberList members = p->dataMembers();
 
     writeModuleHasDefinitionCheck(_out, p, valueName);
     _out.inc();
-    _out << nl << getModuleReference(p) << " = None";
+    _out << nl << getTypeReference(p) << " = None";
     _out << nl << "class " << valueName << '(';
     if (!base)
     {
@@ -507,7 +507,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     }
     else
     {
-        _out << getModuleReference(base);
+        _out << getTypeReference(base);
     }
     _out << "):";
 
@@ -530,7 +530,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     {
         if (base)
         {
-            _out << nl << getModuleReference(base) << ".__init__(self";
+            _out << nl << getTypeReference(base) << ".__init__(self";
             for (const auto& member : base->allDataMembers())
             {
                 _out << ", " << member->mappedName();
@@ -582,7 +582,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     }
     else
     {
-        _out << getTypeReference(base);
+        _out << getMetaTypeReference(base);
     }
     _out << ", (";
     //
@@ -637,7 +637,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     string scoped = p->scoped();
     string className = p->mappedName();
-    string classAbs = getModuleReference(p);
+    string classAbs = getTypeReference(p);
     string prxName = className + "Prx";
     string prxAbs = classAbs + "Prx";
     InterfaceList bases = p->bases();
@@ -654,7 +654,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         for (const auto& base : bases)
         {
             InterfaceDefPtr d = base;
-            baseClasses.push_back(getModuleReference(base) + "Prx");
+            baseClasses.push_back(getTypeReference(base) + "Prx");
         }
 
         if (baseClasses.empty())
@@ -811,7 +811,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     _out.dec(); // end prx class
 
-    _out << nl << getTypeReference(p) << "Prx" << " = IcePy.defineProxy('" << scoped << "', " << prxName << ")";
+    _out << nl << getMetaTypeReference(p) << "Prx" << " = IcePy.defineProxy('" << scoped << "', " << prxName << ")";
 
     registerName(prxName);
 
@@ -823,7 +823,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         for (const auto& base : bases)
         {
             InterfaceDefPtr d = base;
-            baseClasses.push_back(getModuleReference(base));
+            baseClasses.push_back(getTypeReference(base));
         }
 
         if (baseClasses.empty())
@@ -890,7 +890,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     //
     _out << sp << nl << "def __str__(self):";
     _out.inc();
-    _out << nl << "return IcePy.stringify(self, " << getTypeReference(p) << "Disp" << ")";
+    _out << nl << "return IcePy.stringify(self, " << getMetaTypeReference(p) << "Disp" << ")";
     _out.dec();
     _out << sp << nl << "__repr__ = __str__";
 
@@ -1010,7 +1010,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             {
                 _out << ", ";
             }
-            _out << getTypeReference(*u);
+            _out << getMetaTypeReference(*u);
         }
         if (exceptions.size() == 1)
         {
@@ -1045,11 +1045,11 @@ Slice::Python::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
 
     writeModuleHasDefinitionCheck(_out, p, name);
     _out.inc();
-    _out << nl << getModuleReference(p) << " = None";
+    _out << nl << getTypeReference(p) << " = None";
     _out << nl << "class " << name << '(';
     if (base)
     {
-        baseName = getModuleReference(base);
+        baseName = getTypeReference(base);
         _out << baseName;
     }
     else
@@ -1109,7 +1109,7 @@ Slice::Python::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     //
     // Emit the type information.
     //
-    string type = getTypeReference(p);
+    string type = getMetaTypeReference(p);
     _out << sp << nl << type << " = IcePy.defineException('" << scoped << "', " << name << ", ";
     writeMetadata(p->getMetadata());
     _out << ", ";
@@ -1119,7 +1119,7 @@ Slice::Python::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     }
     else
     {
-        _out << getTypeReference(base);
+        _out << getMetaTypeReference(base);
     }
     _out << ", (";
     if (members.size() > 1)
@@ -1170,7 +1170,7 @@ bool
 Slice::Python::CodeVisitor::visitStructStart(const StructPtr& p)
 {
     const string scoped = p->scoped();
-    const string abs = getModuleReference(p);
+    const string abs = getTypeReference(p);
     const string name = p->mappedName();
     const DataMemberList members = p->dataMembers();
 
@@ -1378,7 +1378,7 @@ Slice::Python::CodeVisitor::visitStructStart(const StructPtr& p)
     //
     _out << sp << nl << "def __str__(self):";
     _out.inc();
-    _out << nl << "return IcePy.stringify(self, " << getTypeReference(p) << ")";
+    _out << nl << "return IcePy.stringify(self, " << getMetaTypeReference(p) << ")";
     _out.dec();
     _out << sp << nl << "__repr__ = __str__";
 
@@ -1387,7 +1387,7 @@ Slice::Python::CodeVisitor::visitStructStart(const StructPtr& p)
     //
     // Emit the type information.
     //
-    _out << sp << nl << getTypeReference(p) << " = IcePy.defineStruct('" << scoped << "', " << name << ", ";
+    _out << sp << nl << getMetaTypeReference(p) << " = IcePy.defineStruct('" << scoped << "', " << name << ", ";
     writeMetadata(p->getMetadata());
     _out << ", (";
     //
@@ -1438,7 +1438,7 @@ Slice::Python::CodeVisitor::visitSequence(const SequencePtr& p)
     // Emit the type information.
     writeModuleHasDefinitionCheck(_out, p, "_t_" + p->mappedName());
     _out.inc();
-    _out << nl << getTypeReference(p) << " = IcePy.defineSequence('" << p->scoped() << "', ";
+    _out << nl << getMetaTypeReference(p) << " = IcePy.defineSequence('" << p->scoped() << "', ";
     writeMetadata(p->getMetadata());
     _out << ", ";
     writeType(p->type());
@@ -1452,7 +1452,7 @@ Slice::Python::CodeVisitor::visitDictionary(const DictionaryPtr& p)
     // Emit the type information.
     writeModuleHasDefinitionCheck(_out, p, "_t_" + p->mappedName());
     _out.inc();
-    _out << nl << getTypeReference(p) << " = IcePy.defineDictionary('" << p->scoped() << "', ";
+    _out << nl << getMetaTypeReference(p) << " = IcePy.defineDictionary('" << p->scoped() << "', ";
     writeMetadata(p->getMetadata());
     _out << ", ";
     writeType(p->keyType());
@@ -1471,7 +1471,7 @@ Slice::Python::CodeVisitor::visitEnum(const EnumPtr& p)
 
     writeModuleHasDefinitionCheck(_out, p, name);
     _out.inc();
-    _out << nl << getModuleReference(p) << " = None";
+    _out << nl << getTypeReference(p) << " = None";
     _out << nl << "class " << name << "(Ice.EnumBase):";
     _out.inc();
 
@@ -1514,7 +1514,7 @@ Slice::Python::CodeVisitor::visitEnum(const EnumPtr& p)
     //
     // Emit the type information.
     //
-    _out << sp << nl << getTypeReference(p) << " = IcePy.defineEnum('" << scoped << "', " << name << ", ";
+    _out << sp << nl << getMetaTypeReference(p) << " = IcePy.defineEnum('" << scoped << "', " << name << ", ";
     writeMetadata(p->getMetadata());
     _out << ", " << name << "._enumerators)";
 
@@ -1526,7 +1526,7 @@ Slice::Python::CodeVisitor::visitEnum(const EnumPtr& p)
 void
 Slice::Python::CodeVisitor::visitConst(const ConstPtr& p)
 {
-    _out << sp << nl << getModuleReference(p) << " = ";
+    _out << sp << nl << getTypeReference(p) << " = ";
     writeConstantValue(p->type(), p->valueType(), p->value());
 }
 
@@ -1604,13 +1604,13 @@ Slice::Python::CodeVisitor::writeType(const TypePtr& p)
     InterfaceDeclPtr prx = dynamic_pointer_cast<InterfaceDecl>(p);
     if (prx)
     {
-        _out << getTypeReference(prx) + "Prx";
+        _out << getMetaTypeReference(prx) + "Prx";
         return;
     }
 
     ContainedPtr cont = dynamic_pointer_cast<Contained>(p);
     assert(cont);
-    _out << getTypeReference(cont);
+    _out << getMetaTypeReference(cont);
 }
 
 void
@@ -1660,7 +1660,7 @@ Slice::Python::CodeVisitor::writeInitializer(const DataMemberPtr& m)
     EnumPtr en = dynamic_pointer_cast<Enum>(p);
     if (en)
     {
-        _out << getModuleReference(en->enumerators().front());
+        _out << getTypeReference(en->enumerators().front());
         return;
     }
 
@@ -1742,7 +1742,7 @@ Slice::Python::CodeVisitor::writeAssign(const DataMemberPtr& member)
     if (st && !member->optional())
     {
         _out << nl << "self." << memberName << " = " << memberName << " if " << memberName << " is not None else "
-             << getModuleReference(st) << "()";
+             << getTypeReference(st) << "()";
     }
     else
     {
@@ -1759,7 +1759,7 @@ Slice::Python::CodeVisitor::writeConstantValue(
     ConstPtr constant = dynamic_pointer_cast<Const>(valueType);
     if (constant)
     {
-        _out << getModuleReference(constant);
+        _out << getTypeReference(constant);
     }
     else
     {
@@ -1802,7 +1802,7 @@ Slice::Python::CodeVisitor::writeConstantValue(
         {
             EnumeratorPtr lte = dynamic_pointer_cast<Enumerator>(valueType);
             assert(lte);
-            _out << getModuleReference(lte);
+            _out << getTypeReference(lte);
         }
         else
         {
@@ -2236,7 +2236,6 @@ Slice::Python::getImportFileName(const string& file, const UnitPtr& ut, const ve
         //
         // The metadata is present, so the generated file was placed in the specified directory.
         //
-        // TODOAUSTIN This can be simplifies probably
         vector<string> names;
         IceInternal::splitString(pkgdir, "/", names);
         assert(!names.empty());
@@ -2341,15 +2340,15 @@ Slice::Python::getAbsolute(const ContainedPtr& p)
 }
 
 string
-Slice::Python::getModuleReference(const ContainedPtr& p)
+Slice::Python::getTypeReference(const ContainedPtr& p)
 {
     return "_M_" + getAbsolute(p);
 }
 
 string
-Slice::Python::getTypeReference(const ContainedPtr& p)
+Slice::Python::getMetaTypeReference(const ContainedPtr& p)
 {
-    string absoluteName = getModuleReference(p);
+    string absoluteName = getTypeReference(p);
 
     // Append a "_t_" in front of the last name segment.
     auto pos = absoluteName.rfind('.');

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -205,11 +205,6 @@ namespace Slice::Python
         void writeOperations(const InterfaceDefPtr&);
 
         //
-        // Return a Python symbol for the given parser element.
-        //
-        string getSymbol(const ContainedPtr&, const string& = "", const string& = "");
-
-        //
         // Emit Python code to assign the given symbol in the current module.
         //
         void registerName(const string&);
@@ -433,7 +428,7 @@ Slice::Python::CodeVisitor::visitClassDecl(const ClassDeclPtr& p)
     {
         _out << sp << nl << "if " << getDictLookup(p) << ':';
         _out.inc();
-        _out << nl << "_M_" << getAbsolute(p, "_t_") << " = IcePy.declareValue('" << scoped << "')";
+        _out << nl << getAbsoluteType(p) << " = IcePy.declareValue('" << scoped << "')";
         _out.dec();
         _classHistory.insert(scoped); // Avoid redundant declarations.
     }
@@ -450,7 +445,7 @@ Slice::Python::CodeVisitor::visitInterfaceDecl(const InterfaceDeclPtr& p)
     {
         _out << sp << nl << "if " << getDictLookup(p) << ':';
         _out.inc();
-        _out << nl << "_M_" << getAbsolute(p, "_t_", "Prx") << " = IcePy.declareProxy('" << scoped << "')";
+        _out << nl << getAbsoluteType(p) << "Prx" << " = IcePy.declareProxy('" << scoped << "')";
         _out.dec();
         _classHistory.insert(scoped); // Avoid redundant declarations.
     }
@@ -487,7 +482,7 @@ Slice::Python::CodeVisitor::writeOperations(const InterfaceDefPtr& p)
             _out << nl << "Returns";
             _out << nl << "  An object containing the marshaled result.";
             _out << nl << tripleQuotes;
-            _out << nl << "return IcePy.MarshaledResult(result, _M_" << getAbsolute(p) << "._op_" << fixedOpName
+            _out << nl << "return IcePy.MarshaledResult(result, " << getExplicitAbsolute(p) << "._op_" << fixedOpName
                  << ", current.adapter.getCommunicator()._getImpl(), current.encoding)";
             _out.dec();
         }
@@ -518,7 +513,7 @@ bool
 Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
     const string scoped = p->scoped();
-    const string type = getAbsolute(p, "_t_");
+    const string type = getAbsoluteType(p);
     const string valueName = fixIdent(p->name());
     const ClassDefPtr base = p->base();
     const DataMemberList members = p->dataMembers();
@@ -526,7 +521,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     _out << sp << nl << "if " << getDictLookup(p) << ':';
     _out.inc();
-    _out << nl << "_M_" << getAbsolute(p) << " = None";
+    _out << nl << getExplicitAbsolute(p) << " = None";
     _out << nl << "class " << valueName << '(';
     if (!base)
     {
@@ -534,7 +529,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     }
     else
     {
-        _out << getSymbol(base);
+        _out << getExplicitAbsolute(base);
     }
     _out << "):";
 
@@ -557,7 +552,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     {
         if (base)
         {
-            _out << nl << getSymbol(base) << ".__init__(self";
+            _out << nl << getExplicitAbsolute(base) << ".__init__(self";
             for (const auto& member : baseMembers)
             {
                 _out << ", " << fixIdent(member->name());
@@ -593,13 +588,13 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     //
     _out << sp << nl << "def __str__(self):";
     _out.inc();
-    _out << nl << "return IcePy.stringify(self, _M_" << type << ")";
+    _out << nl << "return IcePy.stringify(self, " << type << ")";
     _out.dec();
     _out << sp << nl << "__repr__ = __str__";
 
     _out.dec();
 
-    _out << sp << nl << "_M_" << type << " = IcePy.defineValue('" << scoped << "', " << valueName << ", "
+    _out << sp << nl << type << " = IcePy.defineValue('" << scoped << "', " << valueName << ", "
          << p->compactId() << ", ";
     writeMetadata(p->getMetadata());
     _out << ", False, ";
@@ -609,7 +604,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     }
     else
     {
-        _out << "_M_" << getAbsolute(base, "_t_");
+        _out << getAbsoluteType(base);
     }
     _out << ", (";
     //
@@ -650,7 +645,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
         _out << nl;
     }
     _out << "))";
-    _out << nl << valueName << "._ice_type = _M_" << type;
+    _out << nl << valueName << "._ice_type = " << type;
 
     registerName(valueName);
 
@@ -663,20 +658,17 @@ bool
 Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     string scoped = p->scoped();
-    string classType = getAbsolute(p, "_t_", "Disp");
-    string abs = getAbsolute(p);
     string className = fixIdent(p->name());
-    string classAbs = getAbsolute(p);
-    string prxAbs = getAbsolute(p, "", "Prx");
+    string classAbs = getExplicitAbsolute(p);
+    string prxAbs = getExplicitAbsolute(p) + "Prx";
     string prxName = fixIdent(p->name() + "Prx");
-    string prxType = getAbsolute(p, "_t_", "Prx");
     InterfaceList bases = p->bases();
 
     _out << sp << nl << "if " << getDictLookup(p, "", "Prx") << ':';
     _out.inc();
 
     // Define the proxy class
-    _out << nl << "_M_" << prxAbs << " = None";
+    _out << nl << prxAbs << " = None";
     _out << nl << "class " << prxName << '(';
 
     {
@@ -684,7 +676,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         for (const auto& base : bases)
         {
             InterfaceDefPtr d = base;
-            baseClasses.push_back(getSymbol(base, "", "Prx"));
+            baseClasses.push_back(getExplicitAbsolute(base) + "Prx");
         }
 
         if (baseClasses.empty())
@@ -788,7 +780,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         _out << ", " << contextParamName << "=None):";
         _out.inc();
         writeDocstring(operation, DocSync);
-        _out << nl << "return _M_" << classAbs << "._op_" << operation->name() << ".invoke(self, ((" << inParams;
+        _out << nl << "return " << classAbs << "._op_" << operation->name() << ".invoke(self, ((" << inParams;
         if (!inParams.empty() && inParams.find(',') == string::npos)
         {
             _out << ", ";
@@ -808,7 +800,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         _out << ", " << contextParamName << "=None):";
         _out.inc();
         writeDocstring(operation, DocAsync);
-        _out << nl << "return _M_" << classAbs << "._op_" << operation->name() << ".invokeAsync(self, ((" << inParams;
+        _out << nl << "return " << classAbs << "._op_" << operation->name() << ".invokeAsync(self, ((" << inParams;
         if (!inParams.empty() && inParams.find(',') == string::npos)
         {
             _out << ", ";
@@ -820,13 +812,13 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << sp << nl << "@staticmethod";
     _out << nl << "def checkedCast(proxy, facetOrContext=None, context=None):";
     _out.inc();
-    _out << nl << "return _M_" << prxAbs << ".ice_checkedCast(proxy, '" << scoped << "', facetOrContext, context)";
+    _out << nl << "return " << prxAbs << ".ice_checkedCast(proxy, '" << scoped << "', facetOrContext, context)";
     _out.dec();
 
     _out << sp << nl << "@staticmethod";
     _out << nl << "def uncheckedCast(proxy, facet=None):";
     _out.inc();
-    _out << nl << "return _M_" << prxAbs << ".ice_uncheckedCast(proxy, facet)";
+    _out << nl << "return " << prxAbs << ".ice_uncheckedCast(proxy, facet)";
     _out.dec();
 
     //
@@ -840,19 +832,19 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     _out.dec(); // end prx class
 
-    _out << nl << "_M_" << prxType << " = IcePy.defineProxy('" << scoped << "', " << prxName << ")";
+    _out << nl << getAbsoluteType(p) << "Prx" << " = IcePy.defineProxy('" << scoped << "', " << prxName << ")";
 
     registerName(prxName);
 
     // Define the servant class
-    _out << sp << nl << "_M_" << classAbs << " = None";
+    _out << sp << nl << classAbs << " = None";
     _out << nl << "class " << className << '(';
     {
         vector<string> baseClasses;
         for (const auto& base : bases)
         {
             InterfaceDefPtr d = base;
-            baseClasses.push_back(getSymbol(base, "", ""));
+            baseClasses.push_back(getExplicitAbsolute(base));
         }
 
         if (baseClasses.empty())
@@ -919,7 +911,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     //
     _out << sp << nl << "def __str__(self):";
     _out.inc();
-    _out << nl << "return IcePy.stringify(self, _M_" << classType << ")";
+    _out << nl << "return IcePy.stringify(self, " << getAbsoluteType(p) << "Disp" << ")";
     _out.dec();
     _out << sp << nl << "__repr__ = __str__";
 
@@ -1037,7 +1029,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             {
                 _out << ", ";
             }
-            _out << "_M_" << getAbsolute(*u, "_t_");
+            _out << getAbsoluteType(*u);
         }
         if (exceptions.size() == 1)
         {
@@ -1063,7 +1055,6 @@ bool
 Slice::Python::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
     const string scoped = p->scoped();
-    const string abs = getAbsolute(p);
     const string name = fixIdent(p->name());
 
     const ExceptionPtr base = p->base();
@@ -1074,12 +1065,11 @@ Slice::Python::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
 
     _out << sp << nl << "if " << getDictLookup(p) << ':';
     _out.inc();
-    _out << nl << "_M_" << abs << " = None";
+    _out << nl << getExplicitAbsolute(p) << " = None";
     _out << nl << "class " << name << '(';
     if (base)
     {
-        baseName = getSymbol(base);
-        _out << baseName;
+        _out << getExplicitAbsolute(base);
     }
     else
     {
@@ -1138,8 +1128,8 @@ Slice::Python::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     //
     // Emit the type information.
     //
-    string type = getAbsolute(p, "_t_");
-    _out << sp << nl << "_M_" << type << " = IcePy.defineException('" << scoped << "', " << name << ", ";
+    string type = getAbsoluteType(p);
+    _out << sp << nl << type << " = IcePy.defineException('" << scoped << "', " << name << ", ";
     writeMetadata(p->getMetadata());
     _out << ", ";
     if (!base)
@@ -1148,7 +1138,7 @@ Slice::Python::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     }
     else
     {
-        _out << "_M_" << getAbsolute(base, "_t_");
+        _out << getAbsoluteType(base);
     }
     _out << ", (";
     if (members.size() > 1)
@@ -1186,7 +1176,7 @@ Slice::Python::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
         _out << nl;
     }
     _out << "))";
-    _out << nl << name << "._ice_type = _M_" << type;
+    _out << nl << name << "._ice_type = " << type;
 
     registerName(name);
 
@@ -1199,13 +1189,13 @@ bool
 Slice::Python::CodeVisitor::visitStructStart(const StructPtr& p)
 {
     const string scoped = p->scoped();
-    const string abs = getAbsolute(p);
+    const string abs = getExplicitAbsolute(p);
     const string name = fixIdent(p->name());
     const DataMemberList members = p->dataMembers();
 
     _out << sp << nl << "if " << getDictLookup(p) << ':';
     _out.inc();
-    _out << nl << "_M_" << abs << " = None";
+    _out << nl << abs << " = None";
     _out << nl << "class " << name << "(object):";
     _out.inc();
 
@@ -1248,7 +1238,7 @@ Slice::Python::CodeVisitor::visitStructStart(const StructPtr& p)
         _out.inc();
         _out << nl << "return 1";
         _out.dec();
-        _out << nl << "elif not isinstance(other, _M_" << abs << "):";
+        _out << nl << "elif not isinstance(other, " << abs << "):";
         _out.inc();
         _out << nl << "return NotImplemented";
         _out.dec();
@@ -1374,7 +1364,7 @@ Slice::Python::CodeVisitor::visitStructStart(const StructPtr& p)
         _out.inc();
         _out << nl << "return False";
         _out.dec();
-        _out << nl << "elif not isinstance(other, _M_" << abs << "):";
+        _out << nl << "elif not isinstance(other, " << abs << "):";
         _out.inc();
         _out << nl << "return NotImplemented";
         _out.dec();
@@ -1407,7 +1397,7 @@ Slice::Python::CodeVisitor::visitStructStart(const StructPtr& p)
     //
     _out << sp << nl << "def __str__(self):";
     _out.inc();
-    _out << nl << "return IcePy.stringify(self, _M_" << getAbsolute(p, "_t_") << ")";
+    _out << nl << "return IcePy.stringify(self, " << getAbsoluteType(p) << ")";
     _out.dec();
     _out << sp << nl << "__repr__ = __str__";
 
@@ -1416,7 +1406,7 @@ Slice::Python::CodeVisitor::visitStructStart(const StructPtr& p)
     //
     // Emit the type information.
     //
-    _out << sp << nl << "_M_" << getAbsolute(p, "_t_") << " = IcePy.defineStruct('" << scoped << "', " << name << ", ";
+    _out << sp << nl << getAbsoluteType(p) << " = IcePy.defineStruct('" << scoped << "', " << name << ", ";
     writeMetadata(p->getMetadata());
     _out << ", (";
     //
@@ -1468,7 +1458,7 @@ Slice::Python::CodeVisitor::visitSequence(const SequencePtr& p)
     string scoped = p->scoped();
     _out << sp << nl << "if " << getDictLookup(p, "_t_") << ':';
     _out.inc();
-    _out << nl << "_M_" << getAbsolute(p, "_t_") << " = IcePy.defineSequence('" << scoped << "', ";
+    _out << nl << getAbsoluteType(p) << " = IcePy.defineSequence('" << scoped << "', ";
     writeMetadata(p->getMetadata());
     _out << ", ";
     writeType(p->type());
@@ -1483,7 +1473,7 @@ Slice::Python::CodeVisitor::visitDictionary(const DictionaryPtr& p)
     string scoped = p->scoped();
     _out << sp << nl << "if " << getDictLookup(p, "_t_") << ':';
     _out.inc();
-    _out << nl << "_M_" << getAbsolute(p, "_t_") << " = IcePy.defineDictionary('" << scoped << "', ";
+    _out << nl << getAbsoluteType(p) << " = IcePy.defineDictionary('" << scoped << "', ";
     writeMetadata(p->getMetadata());
     _out << ", ";
     writeType(p->keyType());
@@ -1497,13 +1487,12 @@ void
 Slice::Python::CodeVisitor::visitEnum(const EnumPtr& p)
 {
     string scoped = p->scoped();
-    string abs = getAbsolute(p);
     string name = fixIdent(p->name());
     EnumeratorList enumerators = p->enumerators();
 
     _out << sp << nl << "if " << getDictLookup(p) << ':';
     _out.inc();
-    _out << nl << "_M_" << abs << " = None";
+    _out << nl << getExplicitAbsolute(p) << " = None";
     _out << nl << "class " << name << "(Ice.EnumBase):";
     _out.inc();
 
@@ -1548,7 +1537,7 @@ Slice::Python::CodeVisitor::visitEnum(const EnumPtr& p)
     //
     // Emit the type information.
     //
-    _out << sp << nl << "_M_" << getAbsolute(p, "_t_") << " = IcePy.defineEnum('" << scoped << "', " << name << ", ";
+    _out << sp << nl << getAbsoluteType(p) << " = IcePy.defineEnum('" << scoped << "', " << name << ", ";
     writeMetadata(p->getMetadata());
     _out << ", " << name << "._enumerators)";
 
@@ -1563,17 +1552,8 @@ Slice::Python::CodeVisitor::visitConst(const ConstPtr& p)
     Slice::TypePtr type = p->type();
     string name = fixIdent(p->name());
 
-    _out << sp << nl << "_M_" << getAbsolute(p) << " = ";
+    _out << sp << nl << getExplicitAbsolute(p) << " = ";
     writeConstantValue(type, p->valueType(), p->value());
-}
-
-string
-Slice::Python::CodeVisitor::getSymbol(const ContainedPtr& p, const string& prefix, const string& suffix)
-{
-    //
-    // An explicit reference to another type must always be prefixed with "_M_".
-    //
-    return "_M_" + getAbsolute(p, prefix, suffix);
 }
 
 void
@@ -1650,13 +1630,13 @@ Slice::Python::CodeVisitor::writeType(const TypePtr& p)
     InterfaceDeclPtr prx = dynamic_pointer_cast<InterfaceDecl>(p);
     if (prx)
     {
-        _out << "_M_" << getAbsolute(prx, "_t_", "Prx");
+        _out << getAbsoluteType(prx) + "Prx");
         return;
     }
 
     ContainedPtr cont = dynamic_pointer_cast<Contained>(p);
     assert(cont);
-    _out << "_M_" << getAbsolute(cont, "_t_");
+    _out << getAbsoluteType(cont);
 }
 
 void
@@ -1707,7 +1687,7 @@ Slice::Python::CodeVisitor::writeInitializer(const DataMemberPtr& m)
     if (en)
     {
         string firstEnumerator = en->enumerators().front()->name();
-        _out << getSymbol(en) << "." << fixIdent(firstEnumerator);
+        _out << getExplicitAbsolute(en) << "." << fixIdent(firstEnumerator);
         return;
     }
 
@@ -1789,7 +1769,7 @@ Slice::Python::CodeVisitor::writeAssign(const DataMemberPtr& member)
     if (st && !member->optional())
     {
         _out << nl << "self." << memberName << " = " << memberName << " if " << memberName << " is not None else "
-             << getSymbol(st) << "()";
+             << getExplicitAbsolute(st) << "()";
     }
     else
     {
@@ -1806,7 +1786,7 @@ Slice::Python::CodeVisitor::writeConstantValue(
     ConstPtr constant = dynamic_pointer_cast<Const>(valueType);
     if (constant)
     {
-        _out << "_M_" << getAbsolute(constant);
+        _out << getExplicitAbsolute(constant);
     }
     else
     {
@@ -1849,7 +1829,7 @@ Slice::Python::CodeVisitor::writeConstantValue(
         {
             EnumeratorPtr lte = dynamic_pointer_cast<Enumerator>(valueType);
             assert(lte);
-            _out << getSymbol(lte);
+            _out << getExplicitAbsolute(lte);
         }
         else
         {
@@ -2410,24 +2390,37 @@ Slice::Python::getPackageMetadata(const ContainedPtr& cont)
 }
 
 string
-Slice::Python::getAbsolute(const ContainedPtr& cont, const string& suffix, const string& nameSuffix)
+Slice::Python::getAbsolute(const ContainedPtr& p)
 {
-    string scope = cont->mappedScope(".").substr(1);
+    string scope = p->mappedScope(".").substr(1);
 
-    string package = getPackageMetadata(cont);
+    string package = getPackageMetadata(p);
     if (!package.empty())
     {
-        if (!scope.empty())
-        {
-            scope = package + "." + scope;
-        }
-        else
-        {
-            scope = package + ".";
-        }
+        scope = package + "." + scope;
     }
 
-    return scope + suffix + fixIdent(cont->name() + nameSuffix);
+    return scope + fixIdent(p->name());
+}
+
+string
+Slice::Python::getExplicitAbsolute(const ContainedPtr& p)
+{
+    return "_M_" + getAbsolute(p);
+}
+
+string
+Slice::Python::getAbsoluteType(const ContainedPtr& p)
+{
+    string absoluteName = getExplicitAbsolute(p);
+
+    // Append a "_t_" in front of the last name segment.
+    auto pos = absoluteName.rfind('.');
+    pos = (pos == string::npos ? 0 : pos + 1);
+    absoluteName.insert(pos, "_t_");
+
+
+    return absoluteName;
 }
 
 void

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1069,7 +1069,8 @@ Slice::Python::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     _out << nl << "class " << name << '(';
     if (base)
     {
-        _out << getExplicitAbsolute(base);
+        baseName = getExplicitAbsolute(base);
+        _out << baseName;
     }
     else
     {
@@ -2418,7 +2419,6 @@ Slice::Python::getAbsoluteType(const ContainedPtr& p)
     auto pos = absoluteName.rfind('.');
     pos = (pos == string::npos ? 0 : pos + 1);
     absoluteName.insert(pos, "_t_");
-
 
     return absoluteName;
 }

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1630,7 +1630,7 @@ Slice::Python::CodeVisitor::writeType(const TypePtr& p)
     InterfaceDeclPtr prx = dynamic_pointer_cast<InterfaceDecl>(p);
     if (prx)
     {
-        _out << getAbsoluteType(prx) + "Prx");
+        _out << getAbsoluteType(prx) + "Prx";
         return;
     }
 

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -955,7 +955,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             format = "None";
         }
 
-        _out << nl << className << "._op_" << operation->name() << " = IcePy.Operation('" << operation->name() << "', "
+        _out << nl << className << "._op_" << operation->name() << " = IcePy.Operation('" << operation->name() << "', '" << fixIdent(operation->name()) << "', "
              << getOperationMode(operation->mode()) << ", "
              << ((p->hasMetadata("amd") || operation->hasMetadata("amd")) ? "True" : "False") << ", " << format << ", ";
         writeMetadata(operation->getMetadata());

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -82,13 +82,13 @@ namespace
         ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
         if (cl)
         {
-            return Slice::Python::scopedToName(cl->scoped());
+            return cl->mappedScoped(".").substr(1);
         }
 
         StructPtr st = dynamic_pointer_cast<Struct>(type);
         if (st)
         {
-            return Slice::Python::scopedToName(st->scoped());
+            return st->mappedScoped(".").substr(1);
         }
 
         InterfaceDeclPtr proxy = dynamic_pointer_cast<InterfaceDecl>(type);
@@ -96,7 +96,7 @@ namespace
         {
             ostringstream os;
             os << "(";
-            os << Slice::Python::scopedToName(proxy->scoped() + "Prx");
+            os << proxy->mappedScoped(".").substr(1) + "Prx";
             os << " or None)";
             return os.str();
         }
@@ -104,7 +104,7 @@ namespace
         EnumPtr en = dynamic_pointer_cast<Enum>(type);
         if (en)
         {
-            return Slice::Python::scopedToName(en->scoped());
+            return en->mappedScoped(".").substr(1);
         }
 
         SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
@@ -291,7 +291,7 @@ lookupKwd(const string& name)
 static string
 getDictLookup(const ContainedPtr& cont, const string& suffix = "", const string& prefix = "")
 {
-    string scope = Slice::Python::scopedToName(cont->scope());
+    string scope = cont->mappedScope(".").substr(1);
     assert(!scope.empty());
 
     string package = Slice::Python::getPackageMetadata(cont);
@@ -2354,24 +2354,6 @@ Slice::Python::generate(const UnitPtr& unit, bool all, const vector<string>& inc
 }
 
 string
-Slice::Python::scopedToName(const string& scoped)
-{
-    string result = fixIdent(scoped);
-    if (result.find("::") == 0)
-    {
-        result.erase(0, 2);
-    }
-
-    string::size_type pos;
-    while ((pos = result.find("::")) != string::npos)
-    {
-        result.replace(pos, 2, ".");
-    }
-
-    return result;
-}
-
-string
 Slice::Python::fixIdent(const string& ident)
 {
     if (ident[0] != ':')
@@ -2430,7 +2412,7 @@ Slice::Python::getPackageMetadata(const ContainedPtr& cont)
 string
 Slice::Python::getAbsolute(const ContainedPtr& cont, const string& suffix, const string& nameSuffix)
 {
-    string scope = scopedToName(cont->scope());
+    string scope = cont->mappedScope(".").substr(1);
 
     string package = getPackageMetadata(cont);
     if (!package.empty())

--- a/cpp/src/slice2py/PythonUtil.h
+++ b/cpp/src/slice2py/PythonUtil.h
@@ -26,12 +26,12 @@ namespace Slice::Python
 
     /// Get the fully-qualified name of the given definition, including any package defined via metadata,
     /// but "_M_" is prepended to the first name segment, indicating that this is a an explicit reference.
-    std::string getExplicitAbsolute(const Slice::ContainedPtr& p);
+    std::string getModuleReference(const Slice::ContainedPtr& p);
 
     /// Get the fully-qualified name of the given definition, including any package defined via metadata,
     /// but "_M_" is prepended to the first name segment, and "_t_" is prepended to the final name segment,
     /// indicating that this is a an explicit reference to a type.
-    std::string getAbsoluteType(const Slice::ContainedPtr& p);
+    std::string getTypeReference(const Slice::ContainedPtr& p);
 
     /// Emit a comment header.
     void printHeader(IceInternal::Output&);

--- a/cpp/src/slice2py/PythonUtil.h
+++ b/cpp/src/slice2py/PythonUtil.h
@@ -26,12 +26,12 @@ namespace Slice::Python
 
     /// Get the fully-qualified name of the given definition, including any package defined via metadata,
     /// but "_M_" is prepended to the first name segment, indicating that this is a an explicit reference.
-    std::string getModuleReference(const Slice::ContainedPtr& p);
+    std::string getTypeReference(const Slice::ContainedPtr& p);
 
     /// Get the fully-qualified name of the given definition, including any package defined via metadata,
     /// but "_M_" is prepended to the first name segment, and "_t_" is prepended to the final name segment,
     /// indicating that this is a an explicit reference to a type.
-    std::string getTypeReference(const Slice::ContainedPtr& p);
+    std::string getMetaTypeReference(const Slice::ContainedPtr& p);
 
     /// Emit a comment header.
     void printHeader(IceInternal::Output&);

--- a/cpp/src/slice2py/PythonUtil.h
+++ b/cpp/src/slice2py/PythonUtil.h
@@ -18,10 +18,6 @@ namespace Slice::Python
     /// Generate Python code for a translation unit.
     void generate(const Slice::UnitPtr&, bool, const std::vector<std::string>&, IceInternal::Output&);
 
-    /// Check the given identifier against Python's list of reserved words. If it matches
-    /// a reserved word, then an escaped version is returned with a leading underscore.
-    std::string fixIdent(const std::string&);
-
     /// Return the package specified by metadata for the given definition, or an empty string if no metadata was found.
     std::string getPackageMetadata(const Slice::ContainedPtr&);
 

--- a/cpp/src/slice2py/PythonUtil.h
+++ b/cpp/src/slice2py/PythonUtil.h
@@ -8,50 +8,36 @@
 
 namespace Slice::Python
 {
-    //
-    // Get the package directory from metadata (if any).
-    //
+    /// Get the package directory from metadata (if any).
     std::string getPackageDirectory(const std::string&, const Slice::UnitPtr&);
 
-    //
-    // Determine the name of a Python source file for use in an import statement.
-    // The return value does not include the .py extension.
-    //
+    /// Determine the name of a Python source file for use in an import statement.
+    /// The return value does not include the .py extension.
     std::string getImportFileName(const std::string&, const Slice::UnitPtr&, const std::vector<std::string>&);
 
-    //
-    // Generate Python code for a translation unit.
-    //
+    /// Generate Python code for a translation unit.
     void generate(const Slice::UnitPtr&, bool, const std::vector<std::string>&, IceInternal::Output&);
 
-    //
-    // Convert a scoped name into a Python name.
-    //
-    std::string scopedToName(const std::string&);
-
-    //
-    // Check the given identifier against Python's list of reserved words. If it matches
-    // a reserved word, then an escaped version is returned with a leading underscore.
-    //
+    /// Check the given identifier against Python's list of reserved words. If it matches
+    /// a reserved word, then an escaped version is returned with a leading underscore.
     std::string fixIdent(const std::string&);
 
-    //
-    // Return the package specified by metadata for the given definition,
-    // or an empty string if no metadata was found.
-    //
+    /// Return the package specified by metadata for the given definition, or an empty string if no metadata was found.
     std::string getPackageMetadata(const Slice::ContainedPtr&);
 
-    //
-    // Get the fully-qualified name of the given definition, including any
-    // package defined via metadata. If a suffix is provided, it is
-    // prepended to the definition's unqualified name. If the nameSuffix
-    // is provided, it is appended to the containers name.
-    //
-    std::string getAbsolute(const Slice::ContainedPtr&, const std::string& = "", const std::string& = "");
+    /// Get the fully-qualified name of the given definition, including any package defined via metadata.
+    std::string getAbsolute(const Slice::ContainedPtr& p);
 
-    //
-    // Emit a comment header.
-    //
+    /// Get the fully-qualified name of the given definition, including any package defined via metadata,
+    /// but "_M_" is prepended to the first name segment, indicating that this is a an explicit reference.
+    std::string getExplicitAbsolute(const Slice::ContainedPtr& p);
+
+    /// Get the fully-qualified name of the given definition, including any package defined via metadata,
+    /// but "_M_" is prepended to the first name segment, and "_t_" is prepended to the final name segment,
+    /// indicating that this is a an explicit reference to a type.
+    std::string getAbsoluteType(const Slice::ContainedPtr& p);
+
+    /// Emit a comment header.
     void printHeader(IceInternal::Output&);
 
     int compile(const std::vector<std::string>&);

--- a/cpp/test/Ice/operations/ServerAMD.cpp
+++ b/cpp/test/Ice/operations/ServerAMD.cpp
@@ -19,7 +19,7 @@ ServerAMD::run(int argc, char** argv)
     //
     // Its possible to have batch oneway requests dispatched after
     // the adapter is deactivated due to thread scheduling so we
-    // supress this warning.
+    // suppress this warning.
     //
     properties->setProperty("Ice.Warn.Dispatch", "0");
 

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -338,7 +338,7 @@ extern "C" int
 operationInit(OperationObject* self, PyObject* args, PyObject* /*kwds*/)
 {
     char* sliceName;
-    char mappedName;
+    char* mappedName;
     PyObject* modeType = lookupType("Ice.OperationMode");
     assert(modeType);
     PyObject* mode;

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -44,7 +44,17 @@ namespace IcePy
     class Operation
     {
     public:
-        Operation(const char*, const char*, PyObject*, int, PyObject*, PyObject*, PyObject*, PyObject*, PyObject*, PyObject*);
+        Operation(
+            const char*,
+            const char*,
+            PyObject*,
+            int,
+            PyObject*,
+            PyObject*,
+            PyObject*,
+            PyObject*,
+            PyObject*,
+            PyObject*);
 
         void marshalResult(Ice::OutputStream&, PyObject*);
 
@@ -371,8 +381,17 @@ operationInit(OperationObject* self, PyObject* args, PyObject* /*kwds*/)
         return -1;
     }
 
-    self->op = new OperationPtr(
-        make_shared<Operation>(sliceName, mappedName, mode, amd, format, metadata, inParams, outParams, returnType, exceptions));
+    self->op = new OperationPtr(make_shared<Operation>(
+        sliceName,
+        mappedName,
+        mode,
+        amd,
+        format,
+        metadata,
+        inParams,
+        outParams,
+        returnType,
+        exceptions));
     return 0;
 }
 
@@ -713,7 +732,6 @@ IcePy::Operation::Operation(
     // amd
     //
     amd = amdFlag ? true : false;
-    
 
     //
     // format
@@ -1583,8 +1601,12 @@ IcePy::SyncTypedInvocation::invoke(PyObject* args, PyObject* /* kwds */)
 
         {
             AllowThreads allowThreads; // Release Python's global interpreter lock during remote invocations.
-            status =
-                _prx->ice_invoke(_op->sliceName, _op->mode, params, result, pyctx == Py_None ? Ice::noExplicitContext : ctx);
+            status = _prx->ice_invoke(
+                _op->sliceName,
+                _op->mode,
+                params,
+                result,
+                pyctx == Py_None ? Ice::noExplicitContext : ctx);
         }
 
         //

--- a/python/modules/IcePy/Util.cpp
+++ b/python/modules/IcePy/Util.cpp
@@ -632,7 +632,7 @@ namespace
         // This function should only ever be called on a specific list of well-known local exceptions.
         string result = typeId;
         assert(result.find("::Ice::") == 0);
-        result.replace(0, 7, "Ice.")
+        result.replace(0, 7, "Ice.");
         assert(result.find(':') == string::npos); // Assert that there weren't any intermediate scopes.
 
         PyObject* type = IcePy::lookupType(result);

--- a/python/modules/IcePy/Util.cpp
+++ b/python/modules/IcePy/Util.cpp
@@ -628,7 +628,19 @@ namespace
     PyObject*
     createPythonException(const char* typeId, std::array<PyObject*, N> args, bool fallbackToLocalException = false)
     {
-        PyObject* type = IcePy::lookupType(scopedToName(typeId));
+        // Convert the exception's typeId to it's mapped Python type.
+        string result = fixIdent(typeId);
+        if (result.find("::") == 0)
+        {
+            result.erase(0, 2);
+        }
+        string::size_type pos;
+        while ((pos = result.find("::")) != string::npos)
+        {
+            result.replace(pos, 2, ".");
+        }
+
+        PyObject* type = IcePy::lookupType(result);
         if (!type)
         {
             if (fallbackToLocalException)

--- a/python/modules/IcePy/Util.cpp
+++ b/python/modules/IcePy/Util.cpp
@@ -629,7 +629,7 @@ namespace
     createPythonException(const char* typeId, std::array<PyObject*, N> args, bool fallbackToLocalException = false)
     {
         // Convert the exception's typeId to its mapped Python type by replacing "::Ice::" with "Ice.".
-        // This function should only ever be called on a specific list of well-known local exceptions.
+        // This function should only ever be called on a specific list of Ice local exceptions.
         string result = typeId;
         assert(result.find("::Ice::") == 0);
         result.replace(0, 7, "Ice.");

--- a/python/modules/IcePy/Util.cpp
+++ b/python/modules/IcePy/Util.cpp
@@ -628,17 +628,12 @@ namespace
     PyObject*
     createPythonException(const char* typeId, std::array<PyObject*, N> args, bool fallbackToLocalException = false)
     {
-        // Convert the exception's typeId to it's mapped Python type.
-        string result = fixIdent(typeId);
-        if (result.find("::") == 0)
-        {
-            result.erase(0, 2);
-        }
-        string::size_type pos;
-        while ((pos = result.find("::")) != string::npos)
-        {
-            result.replace(pos, 2, ".");
-        }
+        // Convert the exception's typeId to its mapped Python type by replacing "::Ice::" with "Ice.".
+        // This function should only ever be called on a specific list of well-known local exceptions.
+        string result = typeId;
+        assert(result.find("::Ice::") == 0);
+        result.replace(0, 7, "Ice.")
+        assert(result.find(':') == string::npos); // Assert that there weren't any intermediate scopes.
 
         PyObject* type = IcePy::lookupType(result);
         if (!type)

--- a/python/python/Ice/Object.py
+++ b/python/python/Ice/Object.py
@@ -83,6 +83,7 @@ class Object(object):
 
 Object._op_ice_isA = IcePy.Operation(
     "ice_isA",
+    "ice_isA",
     Ice.OperationMode.Idempotent,
     False,
     None,
@@ -93,6 +94,7 @@ Object._op_ice_isA = IcePy.Operation(
     (),
 )
 Object._op_ice_ping = IcePy.Operation(
+    "ice_ping",
     "ice_ping",
     Ice.OperationMode.Idempotent,
     False,
@@ -105,6 +107,7 @@ Object._op_ice_ping = IcePy.Operation(
 )
 Object._op_ice_ids = IcePy.Operation(
     "ice_ids",
+    "ice_ids",
     Ice.OperationMode.Idempotent,
     False,
     None,
@@ -115,6 +118,7 @@ Object._op_ice_ids = IcePy.Operation(
     (),
 )
 Object._op_ice_id = IcePy.Operation(
+    "ice_id",
     "ice_id",
     Ice.OperationMode.Idempotent,
     False,

--- a/python/test/Ice/blobject/Server.py
+++ b/python/test/Ice/blobject/Server.py
@@ -30,7 +30,7 @@ class Server(TestHelper):
         properties = self.createTestProperties(args)
         #
         # Its possible to have batch oneway requests dispatched after the
-        # adapter is deactivated due to thread scheduling so we supress
+        # adapter is deactivated due to thread scheduling so we suppress
         # this warning.
         #
         properties.setProperty("Ice.Warn.Dispatch", "0")

--- a/python/test/Ice/operations/Server.py
+++ b/python/test/Ice/operations/Server.py
@@ -14,7 +14,7 @@ class Server(TestHelper):
         properties = self.createTestProperties(args)
         #
         # Its possible to have batch oneway requests dispatched after the
-        # adapter is deactivated due to thread scheduling so we supress
+        # adapter is deactivated due to thread scheduling so we suppress
         # this warning.
         #
         properties.setProperty("Ice.Warn.Dispatch", "0")

--- a/python/test/Ice/operations/ServerAMD.py
+++ b/python/test/Ice/operations/ServerAMD.py
@@ -20,7 +20,7 @@ class ServerAMD(TestHelper):
         properties = self.createTestProperties(args)
         #
         # Its possible to have batch oneway requests dispatched after the
-        # adapter is deactivated due to thread scheduling so we supress
+        # adapter is deactivated due to thread scheduling so we suppress
         # this warning.
         #
         properties.setProperty("Ice.Warn.Dispatch", "0")

--- a/python/test/Ice/packagemd/AllTests.py
+++ b/python/test/Ice/packagemd/AllTests.py
@@ -33,12 +33,6 @@ def allTests(helper, communicator):
     except Test1.E2:
         # Expected
         pass
-    try:
-        initial.throwTest1Def()
-        test(False)
-    except Test1._def:
-        # Expected
-        pass
     print("ok")
 
     sys.stdout.write("testing types with package... ")

--- a/python/test/Ice/packagemd/NoPackage.ice
+++ b/python/test/Ice/packagemd/NoPackage.ice
@@ -23,9 +23,4 @@ exception E2 extends E1
 {
     long l;
 }
-
-exception def /* Test keyword escape. */
-{
-    int i;
-}
 }

--- a/python/test/Ice/packagemd/Server.py
+++ b/python/test/Ice/packagemd/Server.py
@@ -28,9 +28,6 @@ class InitialI(Test.Initial):
     def throwTest1E2AsE2(self, current):
         raise Test1.E2()
 
-    def throwTest1Def(self, current):
-        raise Test1._def()
-
     def getTest2C2AsObject(self, current):
         return testpkg.Test2.C2()
 

--- a/python/test/Ice/packagemd/Test.ice
+++ b/python/test/Ice/packagemd/Test.ice
@@ -14,7 +14,6 @@ interface Initial
     Test1::C2 getTest1C2AsC2();
     void throwTest1E2AsE1() throws Test1::E1;
     void throwTest1E2AsE2() throws Test1::E2;
-    void throwTest1Def() throws Test1::def;
 
     Test2::C1 getTest2C2AsC1();
     Test2::C2 getTest2C2AsC2();

--- a/python/test/Slice/escape/Clash.ice
+++ b/python/test/Slice/escape/Clash.ice
@@ -10,7 +10,7 @@ interface Intf
     void response();
     void upCast();
     void typeId();
-    void del();
+    ["python:identifier:_del"] void del();
     void cookie();
     void sync();
     void inS();
@@ -31,14 +31,14 @@ class Cls
     short response;
     string upCast;
     int typeId;
-    short del;
+    ["python:identifier:_del"] short del;
     optional(1) short cookie;
     string ex;
     int result;
     string istr;
     string ostr;
     string inS;
-    string in;
+    ["python:identifier:_in"] string in;
     string proxy;
 }
 

--- a/python/test/Slice/escape/Client.py
+++ b/python/test/Slice/escape/Client.py
@@ -37,18 +37,18 @@ def testtypes():
     _a = escapedAnd._assert._break
     b = escapedAnd._continue
     b._def = 0
-    _c = escapedAnd.delPrx.uncheckedCast(None)
-    assert "_elif" in dir(escapedAnd.delPrx)
+    _c = escapedAnd._delPrx.uncheckedCast(None)
+    assert "_elif" in dir(escapedAnd._delPrx)
     _c1 = delI()
-    _d = escapedAnd.execPrx.uncheckedCast(None)
-    assert "_finally" in dir(escapedAnd.execPrx)
+    _d = escapedAnd._execPrx.uncheckedCast(None)
+    assert "_finally" in dir(escapedAnd._execPrx)
     _d1 = execI()
 
     _e1 = escapedAnd._for()
-    _f = escapedAnd.ifPrx.uncheckedCast(None)
+    _f = escapedAnd._ifPrx.uncheckedCast(None)
 
-    assert "_finally" in dir(escapedAnd.ifPrx)
-    assert "_elif" in dir(escapedAnd.ifPrx)
+    assert "_finally" in dir(escapedAnd._ifPrx)
+    assert "_elif" in dir(escapedAnd._ifPrx)
     _f1 = ifI()
     g = escapedAnd._is()
     g.bar = 0
@@ -65,7 +65,7 @@ class Client(TestHelper):
         properties = self.createTestProperties(args)
         #
         # Its possible to have batch oneway requests dispatched after the
-        # adapter is deactivated due to thread scheduling so we supress
+        # adapter is deactivated due to thread scheduling so we suppress
         # this warning.
         #
         properties.setProperty("Ice.Warn.Dispatch", "0")
@@ -77,7 +77,7 @@ class Client(TestHelper):
 
             sys.stdout.write("Testing operation name... ")
             sys.stdout.flush()
-            p = escapedAnd.execPrx.uncheckedCast(
+            p = escapedAnd._execPrx.uncheckedCast(
                 adapter.createProxy(Ice.stringToIdentity("test"))
             )
             p._finally()

--- a/python/test/Slice/escape/Client.py
+++ b/python/test/Slice/escape/Client.py
@@ -7,31 +7,26 @@ from TestHelper import TestHelper
 TestHelper.loadSlice("Key.ice Clash.ice")
 import sys
 import Ice
-import _and
+import escapedAnd
 
 
-class delI(_and._del):
+class delI(escapedAnd._del):
     def _elifAsync(self, _else, current):
         pass
 
 
-class execI(_and._exec):
+class execI(escapedAnd._exec):
     def _finally(self, current):
         assert current.operation == "finally"
 
 
-class ifI(_and._if):
+class ifI(escapedAnd._if):
     def _elifAsync(self, _else, current):
         pass
 
     def _finally(self, current):
         pass
 
-    def foo(self, _from, current):
-        pass
-
-
-class printI(_and._print):
     def _raise(self, _else, _return, _while, _yield, _or, _global):
         pass
 
@@ -39,31 +34,29 @@ class printI(_and._print):
 def testtypes():
     sys.stdout.write("Testing generated type names... ")
     sys.stdout.flush()
-    _a = _and._assert._break
-    b = _and._continue
+    _a = escapedAnd._assert._break
+    b = escapedAnd._continue
     b._def = 0
-    _c = _and.delPrx.uncheckedCast(None)
-    assert "_elif" in dir(_and.delPrx)
+    _c = escapedAnd.delPrx.uncheckedCast(None)
+    assert "_elif" in dir(escapedAnd.delPrx)
     _c1 = delI()
-    _d = _and.execPrx.uncheckedCast(None)
-    assert "_finally" in dir(_and.execPrx)
+    _d = escapedAnd.execPrx.uncheckedCast(None)
+    assert "_finally" in dir(escapedAnd.execPrx)
     _d1 = execI()
 
-    _e1 = _and._for()
-    _f = _and.ifPrx.uncheckedCast(None)
+    _e1 = escapedAnd._for()
+    _f = escapedAnd.ifPrx.uncheckedCast(None)
 
-    assert "_finally" in dir(_and.ifPrx)
-    assert "_elif" in dir(_and.ifPrx)
+    assert "_finally" in dir(escapedAnd.ifPrx)
+    assert "_elif" in dir(escapedAnd.ifPrx)
     _f1 = ifI()
-    g = _and._is()
-    g._lamba = 0
-    h = _and._not()
-    h._lamba = 0
-    h._or = 1
+    g = escapedAnd._is()
+    g.bar = 0
+    h = escapedAnd._not()
+    h.bar = 0
     h._pass = 2
-    _i = printI()
-    _j = _and._lambda
-    _en = _and.EnumNone._None
+    _j = escapedAnd._lambda
+    _en = escapedAnd.EnumNone._None
     print("ok")
 
 
@@ -84,7 +77,7 @@ class Client(TestHelper):
 
             sys.stdout.write("Testing operation name... ")
             sys.stdout.flush()
-            p = _and.execPrx.uncheckedCast(
+            p = escapedAnd.execPrx.uncheckedCast(
                 adapter.createProxy(Ice.stringToIdentity("test"))
             )
             p._finally()

--- a/python/test/Slice/escape/Key.ice
+++ b/python/test/Slice/escape/Key.ice
@@ -33,7 +33,7 @@ module escapedAnd
         void finally();
     }
 
-    ["python:identifier:_foo"]
+    ["python:identifier:_for"]
     class for
     {
         int foo;

--- a/python/test/Slice/escape/Key.ice
+++ b/python/test/Slice/escape/Key.ice
@@ -1,61 +1,83 @@
 // Copyright (c) ZeroC, Inc.
 
-module and
+// TODO find a better solution for remapping modules.
+module escapedAnd
 {
+    ["python:identifier:_assert"]
     enum assert
     {
+        ["python:identifier:_break"]
         break
     }
 
+    ["python:identifier:_continue"]
     struct continue
     {
+        ["python:identifier:_def"]
         int def;
     }
 
+    ["python:identifier:_del"]
     interface del
     {
-        ["amd"] void elif(int else, out int except);
+        ["amd"] ["python:identifier:_elif"] void elif(
+            ["python:identifier:_else"] int else,
+            out ["python:identifier:_except"] int except
+        );
     }
 
+    ["python:identifier:_exec"]
     interface exec
     {
+        ["python:identifier:_finally"]
         void finally();
     }
 
+    ["python:identifier:_foo"]
     class for
     {
-        int lambda;
-        exec* from;
-        int global;
+        int foo;
+        ["python:identifier:_from"] exec* from;
     }
 
-    interface if extends exec, del
-    {
-    }
-
-    sequence<assert> import;
-    dictionary<string,assert> in;
-
+    ["python:identifier:_is"]
     exception is
     {
-        int lambda;
+        int bar;
     }
 
+    ["python:identifier:_not"]
     exception not extends is
     {
-        int or;
-        int pass;
+        ["python:identifier:_pass"] int pass;
     }
 
-    interface print
+    ["python:identifier:_if"]
+    interface if extends exec, del
     {
-        assert raise(continue else, for return, del* while, exec* yield, if* or, int global) throws is;
+        ["python:identifier:_raise"]
+        assert raise(
+            ["python:identifier:_else"] continue else,
+            ["python:identifier:_return"] for return,
+            ["python:identifier:_while"] del* while,
+            ["python:identifier:_yield"] exec* yield,
+            ["python:identifier:_or"] if* or,
+            ["python:identifier:_global"] int global
+        ) throws is;
     }
 
+    ["python:identifier:_import"]
+    sequence<assert> import;
+
+    ["python:identifier:_in"]
+    dictionary<string,assert> in;
+
+    ["python:identifier:_lambda"]
     const int lambda = 0;
 
     enum EnumNone
     {
+        ["python:identifier:_None"]
         None
     }
 }

--- a/slice/IceGrid/Admin.ice
+++ b/slice/IceGrid/Admin.ice
@@ -825,8 +825,8 @@ module IceGrid
         /// @param id The server id.
         /// @param path The path of the log file. A log file can be opened only if it's declared in the server or
         /// service deployment descriptor.
-        /// @param count Specifies where to start reading the file. If negative, the file is read from the begining. If
-        /// 0 or positive, the file is read from the last <code>count</code> lines.
+        /// @param count Specifies where to start reading the file. If negative, the file is read from the beginning.
+        /// If 0 or positive, the file is read from the last <code>count</code> lines.
         /// @return An iterator to read the file. The returned proxy is never null.
         /// @throws FileNotAvailableException Raised if the file can't be read.
         /// @throws ServerNotExistException Raised if the server doesn't exist.
@@ -837,8 +837,8 @@ module IceGrid
 
         /// Open the given server stderr file for reading. The file can be read with the returned file iterator.
         /// @param id The server id.
-        /// @param count Specifies where to start reading the file. If negative, the file is read from the begining. If
-        /// 0 or positive, the file is read from the last <code>count</code> lines.
+        /// @param count Specifies where to start reading the file. If negative, the file is read from the beginning.
+        /// If 0 or positive, the file is read from the last <code>count</code> lines.
         /// @return An iterator to read the file. The returned proxy is never null.
         /// @throws FileNotAvailableException Raised if the file can't be read.
         /// @throws ServerNotExistException Raised if the server doesn't exist.
@@ -849,7 +849,7 @@ module IceGrid
 
         /// Open the given server stdout file for reading. The file can be read with the returned file iterator.
         /// @param id The server id.
-        /// @param count Specifies where to start reading the file. If negative, the file is read from the begining.
+        /// @param count Specifies where to start reading the file. If negative, the file is read from the beginning.
         /// If 0 or positive, the file is read from the last <code>count</code> lines.
         /// @return An iterator to read the file. The returned proxy is never null.
         /// @throws FileNotAvailableException Raised if the file can't be read.
@@ -861,8 +861,8 @@ module IceGrid
 
         /// Open the given node stderr file for reading. The file can be read with the returned file iterator.
         /// @param name The node name.
-        /// @param count Specifies where to start reading the file. If negative, the file is read from the begining. If
-        /// 0 or positive, the file is read from the last <code>count</code> lines.
+        /// @param count Specifies where to start reading the file. If negative, the file is read from the beginning.
+        /// If 0 or positive, the file is read from the last <code>count</code> lines.
         /// @return An iterator to read the file. The returned proxy is never null.
         /// @throws FileNotAvailableException Raised if the file can't be read.
         /// @throws NodeNotExistException Raised if the node doesn't exist.
@@ -872,8 +872,8 @@ module IceGrid
 
         /// Open the given node stdout file for reading. The file can be read with the returned file iterator.
         /// @param name The node name.
-        /// @param count Specifies where to start reading the file. If negative, the file is read from the begining. If
-        /// 0 or positive, the file is read from the last <code>count</code> lines.
+        /// @param count Specifies where to start reading the file. If negative, the file is read from the beginning.
+        /// If 0 or positive, the file is read from the last <code>count</code> lines.
         /// @return An iterator to read the file. The returned proxy is never null.
         /// @throws FileNotAvailableException Raised if the file can't be read.
         /// @throws NodeNotExistException Raised if the node doesn't exist.
@@ -883,8 +883,8 @@ module IceGrid
 
         /// Open the given registry stderr file for reading. The file can be read with the returned file iterator.
         /// @param name The registry name.
-        /// @param count Specifies where to start reading the file. If negative, the file is read from the begining. If
-        /// 0 or positive, the file is read from the last <code>count</code> lines.
+        /// @param count Specifies where to start reading the file. If negative, the file is read from the beginning.
+        /// If 0 or positive, the file is read from the last <code>count</code> lines.
         /// @return An iterator to read the file. The returned proxy is never null.
         /// @throws FileNotAvailableException Raised if the file can't be read.
         /// @throws RegistryNotExistException Raised if the registry doesn't exist.
@@ -894,8 +894,8 @@ module IceGrid
 
         /// Open the given registry stdout file for reading. The file can be read with the returned file iterator.
         /// @param name The registry name.
-        /// @param count Specifies where to start reading the file. If negative, the file is read from the begining. If
-        /// 0 or positive, the file is read from the last <code>count</code> lines.
+        /// @param count Specifies where to start reading the file. If negative, the file is read from the beginning.
+        /// If 0 or positive, the file is read from the last <code>count</code> lines.
         /// @return An iterator to read the file. The returned proxy is never null.
         /// @throws FileNotAvailableException Raised if the file can't be read.
         /// @throws RegistryNotExistException Raised if the registry doesn't exist.

--- a/swift/test/Ice/operations/Server.swift
+++ b/swift/test/Ice/operations/Server.swift
@@ -9,7 +9,7 @@ class Server: TestHelperI {
         //
         // Its possible to have batch oneway requests dispatched
         // after the adapter is deactivated due to thread
-        // scheduling so we supress this warning.
+        // scheduling so we suppress this warning.
         //
         properties.setProperty(key: "Ice.Warn.Dispatch", value: "0")
         //


### PR DESCRIPTION
This PR adds support for `python:identifier` to `slice2py`.

Some of the code in the `IcePy` module assuming it could convert between `current.operation` and the mapped operation name. With `xxx:identifier` these two names are completely decoupled, so I had to modify `IcePy` to take both the slice name and the mapped name in it's API.

There was also a section of code that was converting an exception's type-id into it's Python type.
This also no-longer works, but it was only being used for local exceptions, with known type-ids.
So I was able to refactor this away.