### PR TITLE
Remove workaround in slice2cs

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -604,21 +604,7 @@ Slice::CsGenerator::writeOptionalMarshalUnmarshalCode(
                 }
                 else
                 {
-                    //
-                    // BUGFIX: with .NET Core reading the byte optional directly in the
-                    // result struct can fails unexpectedly with optimized builds.
-                    //
-                    if (param.find('.') != string::npos)
-                    {
-                        out << sb;
-                        out << nl << "var tmp = " << stream << ".readByte(" << tag << ");";
-                        out << nl << param << " = tmp;";
-                        out << eb;
-                    }
-                    else
-                    {
-                        out << nl << param << " = " << stream << ".readByte(" << tag << ");";
-                    }
+                    out << nl << param << " = " << stream << ".readByte(" << tag << ");";
                 }
                 break;
             }
@@ -630,21 +616,7 @@ Slice::CsGenerator::writeOptionalMarshalUnmarshalCode(
                 }
                 else
                 {
-                    //
-                    // BUGFIX: with .NET Core reading the bool optional directly in the
-                    // result struct fails unexpectedly with optimized builds.
-                    //
-                    if (param.find('.') != string::npos)
-                    {
-                        out << sb;
-                        out << nl << "var tmp = " << stream << ".readBool(" << tag << ");";
-                        out << nl << param << " = tmp;";
-                        out << eb;
-                    }
-                    else
-                    {
-                        out << nl << param << " = " << stream << ".readBool(" << tag << ");";
-                    }
+                    out << nl << param << " = " << stream << ".readBool(" << tag << ");";
                 }
                 break;
             }


### PR DESCRIPTION
Removes workaround in `slice2cs`:

https://github.com/zeroc-ice/ice/blob/66cab0953f9d6bda930dae24ca34887a97d9273e/cpp/src/slice2cs/CsUtil.cpp#L608-L609

We now require .NET 8 and this is likely no longer an issue. I was unable to reproduce a crash locally. I don't think we should keep fixes like this around "just in case".

We'll see how CI feels about it.