### PR TITLE
Suppress doc generation for Disp_ never implemented by the user (C#)

### DIFF
--- a/csharp/docfx/docfx.json
+++ b/csharp/docfx/docfx.json
@@ -6,7 +6,9 @@
           "files": ["src/*/*.csproj"],
           "exclude": [
             "src/Ice/Internal/**",
-            "src/Ice/UtilInternal/**"
+            "src/Ice/UtilInternal/**",
+            "src/IceDiscovery/**",
+            "src/IceLocatorDiscovery/**"
           ],
           "src": "../"
         }

--- a/slice/Glacier2/Router.ice
+++ b/slice/Glacier2/Router.ice
@@ -31,6 +31,7 @@ module Glacier2
     }
 
     /// The Glacier2 specialization of the <code>Ice::Router</code> interface.
+    ["cs:attribute:System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)"]
     interface Router extends Ice::Router
     {
         /// This category must be used in the identities of all of the client's callback objects. This is necessary in

--- a/slice/Glacier2/Session.ice
+++ b/slice/Glacier2/Session.ice
@@ -41,6 +41,7 @@ module Glacier2
     /// {@link Session}.
     /// @see Session
     /// @see SessionControl
+    ["cs:attribute:System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)"]
     interface StringSet
     {
         /// Add a sequence of strings to this set of constraints. Order is not preserved and duplicates are implicitly
@@ -61,6 +62,7 @@ module Glacier2
     /// An object for managing the set of object identity constraints on a {@link Session}.
     /// @see Session
     /// @see SessionControl
+    ["cs:attribute:System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)"]
     interface IdentitySet
     {
         /// Add a sequence of Ice identities to this set of constraints. Order is not preserved and duplicates are
@@ -81,6 +83,7 @@ module Glacier2
 
     /// An administrative session control object, which is tied to the lifecycle of a {@link Session}.
     /// @see Session
+    ["cs:attribute:System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)"]
     interface SessionControl
     {
         /// Access the object that manages the allowable categories for object identities for this session.

--- a/slice/Ice/Metrics.ice
+++ b/slice/Ice/Metrics.ice
@@ -72,6 +72,7 @@ module IceMX
 
     /// The metrics administrative facet interface. This interface allows remote administrative clients to access
     /// metrics of an application that enabled the Ice administrative facility and configured some metrics views.
+    ["cs:attribute:System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)"]
     interface MetricsAdmin
     {
         /// Get the names of enabled and disabled metrics.

--- a/slice/Ice/Process.ice
+++ b/slice/Ice/Process.ice
@@ -18,9 +18,10 @@ module Ice
     /// <p class="Note">A servant implementing this interface is a potential target for denial-of-service attacks,
     /// therefore proper security precautions should be taken. For example, the servant can use a UUID to make its
     /// identity harder to guess, and be registered in an object adapter with a secured endpoint.
+    ["cs:attribute:System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)"]
     interface Process
     {
-        /// Initiate a graceful shut-down.
+        /// Initiate a graceful shutdown.
         /// @see Communicator#shutdown
         void shutdown();
 

--- a/slice/Ice/PropertiesAdmin.ice
+++ b/slice/Ice/PropertiesAdmin.ice
@@ -17,6 +17,7 @@
 module Ice
 {
     /// The PropertiesAdmin interface provides remote access to the properties of a communicator.
+    ["cs:attribute:System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)"]
     interface PropertiesAdmin
     {
         /// Get a property by key. If the property is not set, an empty string is returned.

--- a/slice/Ice/RemoteLogger.ice
+++ b/slice/Ice/RemoteLogger.ice
@@ -83,6 +83,7 @@ module Ice
 
     /// The interface of the admin object that allows an Ice application the attach its
     /// {@link RemoteLogger} to the {@link RemoteLogger} of this admin object's Ice communicator.
+    ["cs:attribute:System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)"]
     interface LoggerAdmin
     {
         /// Attaches a RemoteLogger object to the local logger. attachRemoteLogger calls init on the provided

--- a/slice/IceBox/ServiceManager.ice
+++ b/slice/IceBox/ServiceManager.ice
@@ -49,6 +49,7 @@ module IceBox
 
     /// Administers a set of IceBox Service instances.
     /// @see Service
+    ["cs:attribute:System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)"]
     interface ServiceManager
     {
         /// Start an individual service.

--- a/slice/IceGrid/Admin.ice
+++ b/slice/IceGrid/Admin.ice
@@ -211,6 +211,7 @@ module IceGrid
 
     /// The IceGrid administrative interface. <p class="Warning">Allowing access to this interface is a security risk!
     /// Please see the IceGrid documentation for further information.
+    ["cs:attribute:System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)"]
     interface Admin
     {
         /// Add an application to IceGrid.
@@ -757,6 +758,7 @@ module IceGrid
     /// sessions are created either via the {@link Registry} object or via the registry admin
     /// <code>SessionManager</code> object.
     /// @see Registry
+    ["cs:attribute:System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)"]
     interface AdminSession extends Glacier2::Session
     {
         /// Keep the session alive.

--- a/slice/IceGrid/FileParser.ice
+++ b/slice/IceGrid/FileParser.ice
@@ -26,6 +26,7 @@ module IceGrid
 
     /// <code>icegridadmin</code> provides a {@link FileParser} object to transform XML files into
     /// {@link ApplicationDescriptor} objects.
+    ["cs:attribute:System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)"]
     interface FileParser
     {
         /// Parse a file.

--- a/slice/IceGrid/Registry.ice
+++ b/slice/IceGrid/Registry.ice
@@ -38,6 +38,7 @@ module IceGrid
 
     /// The IceGrid query interface. This interface is accessible to Ice clients who wish to look up well-known
     /// objects.
+    ["cs:attribute:System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)"]
     interface Query
     {
         /// Find a well-known object by identity.
@@ -76,6 +77,7 @@ module IceGrid
     /// The IceGrid registry allows clients create sessions directly with the registry.
     /// @see Session
     /// @see AdminSession
+    ["cs:attribute:System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)"]
     interface Registry
     {
         /// Create a client session.
@@ -121,6 +123,7 @@ module IceGrid
     /// registry.
     /// @see Query
     /// @see Registry
+    ["cs:attribute:System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)"]
     interface Locator extends Ice::Locator
     {
         /// Get the proxy of the registry object hosted by this IceGrid registry.

--- a/slice/IceGrid/Session.ice
+++ b/slice/IceGrid/Session.ice
@@ -23,6 +23,7 @@ module IceGrid
     /// A session object is used by IceGrid clients to allocate and release objects. Client sessions are created either
     /// via the {@link Registry} object or via the registry client <code>SessionManager</code> object.
     /// @see Registry
+    ["cs:attribute:System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)"]
     interface Session extends Glacier2::Session
     {
         /// Keep the session alive.

--- a/slice/IceStorm/IceStorm.ice
+++ b/slice/IceStorm/IceStorm.ice
@@ -80,6 +80,7 @@ exception BadQoS
 
 /// Publishers publish information on a particular topic. A topic logically represents a type.
 /// @see TopicManager
+["cs:attribute:System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)"]
 interface Topic
 {
     /// Get the name of this topic.
@@ -158,6 +159,7 @@ exception NoSuchTopic
 
 /// A topic manager manages topics, and subscribers to topics.
 /// @see Topic
+["cs:attribute:System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)"]
 interface TopicManager
 {
     /// Create a new topic. The topic name must be unique.
@@ -179,6 +181,7 @@ interface TopicManager
 
 /// This interface is advertised by the IceStorm service through the Ice object with the identity 'IceStorm/Finder'.
 /// This allows clients to retrieve the topic manager with just the endpoint information of the IceStorm service.
+["cs:attribute:System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)"]
 interface Finder
 {
     /// Get the topic manager proxy. The proxy might point to several replicas.


### PR DESCRIPTION
This PR suppresses doc generation for Disp_ classes that the user should never implement. For example, IceGrid::Admin.

Including these classes in the API reference is naturally confusing.