### PR TITLE
Simplify C++ NuGet package props and targets

### DIFF
--- a/cpp/msbuild/ZeroC.Ice.Cpp.props
+++ b/cpp/msbuild/ZeroC.Ice.Cpp.props
@@ -1,13 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c) ZeroC, Inc. All rights reserved. -->
+<!-- Copyright (c) ZeroC, Inc. -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <IceVersion>3.8a0</IceVersion>
-        <IceIntVersion>30800</IceIntVersion>
-        <IceVersionMM>3.8</IceVersionMM>
-        <IceSoVersion>38a0</IceSoVersion>
-        <IceNugetPackageVersion>3.8.0-alpha0</IceNugetPackageVersion>
-    </PropertyGroup>
     <!-- Import Slice Tools props file -->
     <Import Project="$(MSBuildThisFileDirectory)..\ZeroC.Ice.Slice.Tools.Cpp.props" />
 </Project>

--- a/cpp/msbuild/ZeroC.Ice.Cpp.targets
+++ b/cpp/msbuild/ZeroC.Ice.Cpp.targets
@@ -1,39 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c) ZeroC, Inc. All rights reserved. -->
+<!-- Copyright (c) ZeroC, Inc. -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <!-- Use bin and lib directories that match the used platform toolset -->
     <PropertyGroup>
         <IceConfiguration Condition="'$(UseDebugLibraries)' == 'true'">Debug</IceConfiguration>
         <IceConfiguration Condition="'$(UseDebugLibraries)' != 'true'">Release</IceConfiguration>
+
+        <!-- Set the debugger environment PATH to include the package bin directory for the selected configuration. -->
         <LocalDebuggerEnvironment Condition="'$(LocalDebuggerEnvironment)' == ''">PATH=$(MSBuildThisFileDirectory)bin\$(Platform)\$(IceConfiguration)</LocalDebuggerEnvironment>
-        <IceDllDebugSuffix Condition="'$(IceConfiguration)' == 'Debug'">d</IceDllDebugSuffix>
-        <IceDLLSuffix>38a0$(IceDllDebugSuffix)</IceDLLSuffix>
     </PropertyGroup>
+
     <!-- Import Slice Tools targets file -->
     <Import Project="$(MSBuildThisFileDirectory)..\ZeroC.Ice.Slice.Tools.Cpp.targets" />
 
-    <ItemGroup>
-        <_Ice_DLLs Include="$(MSBuildThisFileDirectory)bin\$(Platform)\$(IceConfiguration)\*$(IceDLLSuffix).dll" Exclude="$(MSBuildThisFileDirectory)bin\$(Platform)\$(IceConfiguration)\icedb38*.dll"/>
-        <_Ice_DLLs Include="$(MSBuildThisFileDirectory)bin\$(Platform)\$(IceConfiguration)\libssl*.dll"/>
-        <_Ice_DLLs Include="$(MSBuildThisFileDirectory)bin\$(Platform)\$(IceConfiguration)\libcrypto*.dll"/>
-        <_Ice_DLLs Include="$(MSBuildThisFileDirectory)bin\$(Platform)\$(IceConfiguration)\bzip2*.dll"/>
-    </ItemGroup>
-
     <ItemDefinitionGroup>
         <ClCompile>
+            <!-- Add the package include directory to the compiler's include path. -->
             <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
         </ClCompile>
         <Link>
-            <AdditionalLibraryDirectories>$(MSBuildThisFileDirectory)lib\$(Platform)\Release;$(MSBuildThisFileDirectory)lib\$(Platform)\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+            <!-- Add the package library directories for both Debug and Release configurations -->
+            <!-- to the linker library path. -->
+            <AdditionalLibraryDirectories>$(MSBuildThisFileDirectory)lib\$(Platform)\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+            <AdditionalLibraryDirectories>$(MSBuildThisFileDirectory)lib\$(Platform)\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
         </Link>
     </ItemDefinitionGroup>
 
-    <Target Name="ValidateSliceCompilerVersion" BeforeTargets="CLCompile">
-        <Error Text="Detected invalid Ice version '$(IceVersion)' expected '3.8a0'" Condition="'$(IceVersion)' != '3.8a0'" />
-    </Target>
-
-    <Target Name="Ice_CopyDLLs" AfterTargets="Build" Condition="'$(Ice_CopyDLLs)' == 'Yes'">
-        <Copy SourceFiles="@(_Ice_DLLs)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true"/>
-    </Target>
 </Project>


### PR DESCRIPTION
This PR cleanups the props and target files ship with ZeroC.Ice.Cpp NuGet package.

Fix #3669 by removing this helper target.