### PR TITLE
Restrict cs:attribute to fewer constructs

### DIFF
--- a/CHANGELOG-3.8.md
+++ b/CHANGELOG-3.8.md
@@ -258,6 +258,8 @@ other CPUs.
 invocation made from an Ice thread pool thread executes in a .NET thread pool thread; previously, this continuation
 was executed in a thread managed by the same Ice thread pool unless you specified `.ConfigureAwait(false)`.
 
+- The `cs:attribute` Slice metadata is now limited to enum, enumerators, fields and constants.
+
 ## Objective-C Changes
 
 - The Objective-C mapping was removed.

--- a/CHANGELOG-3.8.md
+++ b/CHANGELOG-3.8.md
@@ -258,7 +258,7 @@ other CPUs.
 invocation made from an Ice thread pool thread executes in a .NET thread pool thread; previously, this continuation
 was executed in a thread managed by the same Ice thread pool unless you specified `.ConfigureAwait(false)`.
 
-- The `cs:attribute` Slice metadata is now limited to enum, enumerators, fields, and constants.
+- The `cs:attribute` Slice metadata is now limited to enums, enumerators, fields, and constants.
 
 ## Objective-C Changes
 

--- a/CHANGELOG-3.8.md
+++ b/CHANGELOG-3.8.md
@@ -258,7 +258,7 @@ other CPUs.
 invocation made from an Ice thread pool thread executes in a .NET thread pool thread; previously, this continuation
 was executed in a thread managed by the same Ice thread pool unless you specified `.ConfigureAwait(false)`.
 
-- The `cs:attribute` Slice metadata is now limited to enum, enumerators, fields and constants.
+- The `cs:attribute` Slice metadata is now limited to enum, enumerators, fields, and constants.
 
 ## Objective-C Changes
 

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1733,11 +1733,7 @@ Slice::CsGenerator::validateMetadata(const UnitPtr& u)
 
     // "cs:attribute"
     MetadataInfo attributeInfo = {
-        .validOn =
-            {typeid(Enum),
-             typeid(Enumerator),
-             typeid(Const),
-             typeid(DataMember)},
+        .validOn = {typeid(Enum), typeid(Enumerator), typeid(Const), typeid(DataMember)},
         .acceptedArgumentKind = MetadataArgumentKind::RequiredTextArgument,
         .mustBeUnique = false,
     };

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1734,17 +1734,9 @@ Slice::CsGenerator::validateMetadata(const UnitPtr& u)
     // "cs:attribute"
     MetadataInfo attributeInfo = {
         .validOn =
-            {typeid(Unit),
-             typeid(Module),
-             typeid(InterfaceDecl),
-             typeid(ClassDecl),
-             typeid(Operation),
-             typeid(Slice::Exception),
-             typeid(Struct),
-             typeid(Enum),
+            {typeid(Enum),
              typeid(Enumerator),
              typeid(Const),
-             typeid(Parameter),
              typeid(DataMember)},
         .acceptedArgumentKind = MetadataArgumentKind::RequiredTextArgument,
         .mustBeUnique = false,

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -640,10 +640,9 @@ Slice::CsVisitor::getDispatchParams(
 void
 Slice::CsVisitor::emitAttributes(const ContainedPtr& p)
 {
-    assert(dynamic_pointer_cast<Enum>(p->container()) ||
-        dynamic_pointer_cast<Enumerator>(p->container()) ||
-        dynamic_pointer_cast<DataMember>(p->container()) ||
-        dynamic_pointer_cast<Const>(p->container()));
+    assert(
+        dynamic_pointer_cast<Enum>(p->container()) || dynamic_pointer_cast<Enumerator>(p->container()) ||
+        dynamic_pointer_cast<DataMember>(p->container()) || dynamic_pointer_cast<Const>(p->container()));
 
     for (const auto& metadata : p->getMetadata())
     {

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -641,8 +641,8 @@ void
 Slice::CsVisitor::emitAttributes(const ContainedPtr& p)
 {
     assert(
-        dynamic_pointer_cast<Enum>(p->container()) || dynamic_pointer_cast<Enumerator>(p->container()) ||
-        dynamic_pointer_cast<DataMember>(p->container()) || dynamic_pointer_cast<Const>(p->container()));
+        dynamic_pointer_cast<Enum>(p) || dynamic_pointer_cast<Enumerator>(p) || dynamic_pointer_cast<DataMember>(p) ||
+        dynamic_pointer_cast<Const>(p));
 
     for (const auto& metadata : p->getMetadata())
     {

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -505,20 +505,6 @@ Slice::CsVisitor::writeMarshaling(const ClassDefPtr& p)
     _out << eb;
 }
 
-string
-Slice::CsVisitor::getParamAttributes(const ParameterPtr& p)
-{
-    ostringstream ostr;
-    for (const auto& metadata : p->getMetadata())
-    {
-        if (metadata->directive() == "cs:attribute")
-        {
-            ostr << "[" << metadata->arguments() << "] ";
-        }
-    }
-    return ostr.str();
-}
-
 vector<string>
 Slice::CsVisitor::getParams(const OperationPtr& op, const string& ns)
 {
@@ -527,10 +513,10 @@ Slice::CsVisitor::getParams(const OperationPtr& op, const string& ns)
     InterfaceDefPtr interface = op->interface();
     for (const auto& q : paramList)
     {
-        string param = getParamAttributes(q);
+        string param;
         if (q->isOutParam())
         {
-            param += "out ";
+            param = "out ";
         }
         param += typeToString(q->type(), ns, q->optional()) + " " + q->mappedName();
         params.push_back(param);
@@ -545,7 +531,7 @@ Slice::CsVisitor::getInParams(const OperationPtr& op, const string& ns, bool int
     for (const auto& q : op->inParameters())
     {
         string param = (internal ? ("iceP_" + removeEscapePrefix(q->mappedName())) : q->mappedName());
-        params.push_back(getParamAttributes(q) + typeToString(q->type(), ns, q->optional()) + " " + param);
+        params.push_back(typeToString(q->type(), ns, q->optional()) + " " + param);
     }
     return params;
 }
@@ -565,10 +551,10 @@ Slice::CsVisitor::getOutParams(const OperationPtr& op, const string& ns, bool re
 
     for (const auto& q : op->outParameters())
     {
-        string s = getParamAttributes(q);
+        string s;
         if (outKeyword)
         {
-            s += "out ";
+            s = "out ";
         }
         s += typeToString(q->type(), ns, q->optional()) + ' ' + q->mappedName();
         params.push_back(s);
@@ -654,6 +640,11 @@ Slice::CsVisitor::getDispatchParams(
 void
 Slice::CsVisitor::emitAttributes(const ContainedPtr& p)
 {
+    assert(dynamic_pointer_cast<Enum>(p->container()) ||
+        dynamic_pointer_cast<Enumerator>(p->container()) ||
+        dynamic_pointer_cast<DataMember>(p->container()) ||
+        dynamic_pointer_cast<Const>(p->container()));
+
     for (const auto& metadata : p->getMetadata())
     {
         if (metadata->directive() == "cs:attribute")
@@ -931,35 +922,11 @@ Slice::Gen::printHeader()
 Slice::Gen::TypesVisitor::TypesVisitor(IceInternal::Output& out) : CsVisitor(out) {}
 
 bool
-Slice::Gen::TypesVisitor::visitUnitStart(const UnitPtr& unit)
-{
-    DefinitionContextPtr dc = unit->findDefinitionContext(unit->topLevelFile());
-    assert(dc);
-
-    bool sep = false;
-    for (const auto& metadata : dc->getMetadata())
-    {
-        if (metadata->directive() == "cs:attribute")
-        {
-            if (!sep)
-            {
-                _out << sp;
-                sep = true;
-            }
-            _out << nl << '[' << metadata->arguments() << ']';
-        }
-    }
-    return true;
-}
-
-bool
 Slice::Gen::TypesVisitor::visitModuleStart(const ModulePtr& p)
 {
     moduleStart(p);
     _out << sp;
-    emitAttributes(p);
     _out << nl << "namespace " << p->mappedName();
-
     _out << sb;
 
     return true;
@@ -980,8 +947,6 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     _out << sp;
     writeDocComment(p, "class");
-    emitAttributes(p);
-
     _out << nl << "[Ice.SliceTypeId(\"" << p->scoped() << "\")]";
     if (p->compactId() >= 0)
     {
@@ -1266,7 +1231,6 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     _out << sp;
     writeDocComment(p, "exception class");
     emitObsoleteAttribute(p, _out);
-    emitAttributes(p);
     _out << nl << "[Ice.SliceTypeId(\"" << p->scoped() << "\")]";
     _out << nl << "public partial class " << p->mappedName() << " : ";
     if (base)
@@ -1462,7 +1426,6 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
 
     writeDocComment(p, mappedType);
     emitObsoleteAttribute(p, _out);
-    emitAttributes(p);
     _out << nl << "public " << (classMapping ? "sealed " : "") << "partial " << mappedType << ' ' << name;
     _out << sb;
     return true;
@@ -1581,6 +1544,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
         }
 
         writeDocComment(enumerator, "");
+        emitObsoleteAttribute(enumerator, _out);
         emitAttributes(enumerator);
         _out << nl << enumerator->mappedName();
         if (hasExplicitValues)
@@ -1639,10 +1603,9 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
 
     _out << sp;
 
-    emitObsoleteAttribute(p, _out);
-
     string type = typeToString(p->type(), ns, p->optional());
 
+    emitObsoleteAttribute(p, _out);
     emitAttributes(p);
     _out << nl << "public" << ' ' << type << ' ' << p->mappedName();
 
@@ -2283,8 +2246,6 @@ Slice::Gen::ServantVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     string ns = getNamespace(p);
 
     _out << sp;
-    emitAttributes(p);
-
     ostringstream notes;
     notes << "Your servant class implements this interface by deriving from <see cref=\"" << p->mappedName()
           << "Disp_\" /> or from the Disp_ class for a derived interface.";
@@ -2377,7 +2338,6 @@ Slice::Gen::ServantVisitor::visitOperation(const OperationPtr& op)
 
     writeOpDocComment(op, {"<param name=\"" + args.back() + "\">The Current object for the dispatch.</param>"}, amd);
 
-    emitAttributes(op);
     emitObsoleteAttribute(op, _out);
     _out << nl << retS << " " << opName << spar << params << epar << ";";
 

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -39,7 +39,7 @@ namespace Slice
             std::vector<std::string>&,
             const std::string&);
 
-        // Generates a C# attribute from the cs:attribute metadata.
+        /// Generates C# attributes from any 'cs:attribute' metadata.
         void emitAttributes(const ContainedPtr&);
 
         void emitNonBrowsableAttribute();

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -39,10 +39,10 @@ namespace Slice
             std::vector<std::string>&,
             const std::string&);
 
+        // Generates a C# attribute from the cs:attribute metadata.
         void emitAttributes(const ContainedPtr&);
-        void emitNonBrowsableAttribute();
 
-        static std::string getParamAttributes(const ParameterPtr&);
+        void emitNonBrowsableAttribute();
 
         void writeConstantValue(const TypePtr&, const SyntaxTreeBasePtr&, const std::string&);
 
@@ -85,8 +85,6 @@ namespace Slice
         {
         public:
             TypesVisitor(IceInternal::Output&);
-
-            bool visitUnitStart(const UnitPtr&) final;
 
             bool visitModuleStart(const ModulePtr&) final;
             void visitModuleEnd(const ModulePtr&) final;

--- a/csharp/src/Ice/Internal/OutgoingAsync.cs
+++ b/csharp/src/Ice/Internal/OutgoingAsync.cs
@@ -651,7 +651,7 @@ public abstract class ProxyOutgoingAsyncBase : OutgoingAsyncBase, TimerTask
         // If the request didn't get sent or if it's non-mutating or idempotent it can
         // also always be retried if the retry count isn't reached.
         bool shouldRetry = ex is LocalException && (!_sent ||
-            mode_ == OperationMode.Nonmutating || mode_ == OperationMode.Idempotent ||
+            mode_ is not OperationMode.Normal ||
             ex is CloseConnectionException ||
             ex is ObjectNotExistException);
 

--- a/csharp/src/Ice/Internal/TraceUtil.cs
+++ b/csharp/src/Ice/Internal/TraceUtil.cs
@@ -174,33 +174,7 @@ internal sealed class TraceUtil
         try
         {
             byte mode = str.readByte();
-            s.Write("\nmode = " + (int)mode + ' ');
-            switch ((Ice.OperationMode)mode)
-            {
-                case Ice.OperationMode.Normal:
-                {
-                    s.Write("(normal)");
-                    break;
-                }
-
-                case Ice.OperationMode.Nonmutating:
-                {
-                    s.Write("(nonmutating)");
-                    break;
-                }
-
-                case Ice.OperationMode.Idempotent:
-                {
-                    s.Write("(idempotent)");
-                    break;
-                }
-
-                default:
-                {
-                    s.Write("(unknown)");
-                    break;
-                }
-            }
+            s.Write("\nmode = " + ((OperationMode)mode).ToString());
 
             int sz = str.readSize();
             s.Write("\ncontext = ");

--- a/csharp/src/Ice/Object.cs
+++ b/csharp/src/Ice/Object.cs
@@ -125,6 +125,22 @@ public abstract class ObjectImpl : Object
     /// <returns>The return value is always ::Ice::Object.</returns>
     public static string ice_staticId() => "::Ice::Object";
 
+    public static void iceCheckMode(OperationMode expected, OperationMode received)
+    {
+        Debug.Assert(expected is OperationMode.Normal or OperationMode.Idempotent); // We never expect Nonmutating
+        if (expected != received)
+        {
+            if (expected is OperationMode.Idempotent && received is not OperationMode.Normal)
+            {
+                // Fine: typically an old client still using the deprecated nonmutating keyword/mode.
+            }
+            else
+            {
+                throw new MarshalException($"unexpected operation mode: expected = {expected} received = {received}");
+            }
+        }
+    }
+
     /// <inheritdoc />
     public virtual string ice_id(Current current) => ice_staticId();
 
@@ -137,41 +153,6 @@ public abstract class ObjectImpl : Object
             "ice_ping" => Object.iceD_ice_pingAsync(this, request),
             _ => throw new OperationNotExistException()
         };
-
-    private static string operationModeToString(OperationMode mode)
-    {
-        if (mode == OperationMode.Normal)
-        {
-            return "::Ice::Normal";
-        }
-        if (mode == OperationMode.Nonmutating)
-        {
-            return "::Ice::Nonmutating";
-        }
-
-        if (mode == OperationMode.Idempotent)
-        {
-            return "::Ice::Idempotent";
-        }
-
-        return "???";
-    }
-
-    public static void iceCheckMode(OperationMode expected, OperationMode received)
-    {
-        Debug.Assert(expected != OperationMode.Nonmutating); // We never expect Nonmutating
-        if (expected != received)
-        {
-            if (expected == OperationMode.Idempotent && received == OperationMode.Nonmutating)
-            {
-                // Fine: typically an old client still using the deprecated nonmutating keyword
-            }
-            else
-            {
-                throw new MarshalException($"unexpected operation mode: expected = {operationModeToString(expected)} received = {operationModeToString(received)}");
-            }
-        }
-    }
 }
 
 /// <summary>


### PR DESCRIPTION
This PR restricts cs:attribute to enums, enumerators, fields and constants.

Fixes #3662.