### PR TITLE
Java comment standardization

### DIFF
--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Node.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Node.java
@@ -393,8 +393,7 @@ class Node extends TreeNode implements PropertySetParent {
         java.util.List<Server> servers;
     }
 
-    // Try to rebuild this node; returns a backup object if rollback is later necessary
-    // We don't rebuild the property sets since they don't depend on the variables.
+    // Try to rebuild this node; returns a backup object if rollback is later necessary We don't rebuild the property sets since they don't depend on the variables.
     Backup rebuild(java.util.List<Editable> editables) throws UpdateFailedException {
         Root root = getRoot();
         Backup backup = new Backup();

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Node.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Node.java
@@ -393,7 +393,8 @@ class Node extends TreeNode implements PropertySetParent {
         java.util.List<Server> servers;
     }
 
-    // Try to rebuild this node; returns a backup object if rollback is later necessary We don't rebuild the property sets since they don't depend on the variables.
+    // Try to rebuild this node; returns a backup object if rollback is later necessary We don't
+    // rebuild the property sets since they don't depend on the variables.
     Backup rebuild(java.util.List<Editable> editables) throws UpdateFailedException {
         Root root = getRoot();
         Backup backup = new Backup();

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PlainServer.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PlainServer.java
@@ -28,7 +28,8 @@ class PlainServer extends Communicator implements Server {
     }
 
     public static void shallowRestore(ServerDescriptor from, ServerDescriptor into) {
-        // When editing a server or server template, if we update properties, we replace the entire field
+        // When editing a server or server template, if we update properties, we replace the entire
+        // field
         into.propertySet = from.propertySet;
         into.description = from.description;
         into.id = from.id;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PlainServer.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PlainServer.java
@@ -28,8 +28,7 @@ class PlainServer extends Communicator implements Server {
     }
 
     public static void shallowRestore(ServerDescriptor from, ServerDescriptor into) {
-        // When editing a server or server template, if we update properties, we replace the entire
-        // field
+        // When editing a server or server template, if we update properties, we replace the entire field
         into.propertySet = from.propertySet;
         into.description = from.description;
         into.id = from.id;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PropertiesField.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PropertiesField.java
@@ -74,7 +74,8 @@ public class PropertiesField extends JTable {
         _hiddenProperties.clear();
 
         if (adapters != null) {
-            // Note that we don't substitute *on purpose*, i.e. the names or values must match before substitution.
+            // Note that we don't substitute *on purpose*, i.e. the names or values must match
+            // before substitution.
             for (AdapterDescriptor p : adapters) {
                 hiddenPropertyNames.add(p.name + ".Endpoints");
                 hiddenPropertyNames.add(p.name + ".PublishedEndpoints");

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PropertiesField.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PropertiesField.java
@@ -74,8 +74,7 @@ public class PropertiesField extends JTable {
         _hiddenProperties.clear();
 
         if (adapters != null) {
-            // Note that we don't substitute *on purpose*, i.e. the names or values
-            // must match before substitution.
+            // Note that we don't substitute *on purpose*, i.e. the names or values must match before substitution.
             for (AdapterDescriptor p : adapters) {
                 hiddenPropertyNames.add(p.name + ".Endpoints");
                 hiddenPropertyNames.add(p.name + ".PublishedEndpoints");

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Root.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Root.java
@@ -436,7 +436,8 @@ public class Root extends ListTreeNode {
                                             });
                                     asyncRelease = true;
 
-                                    // If the update fails, we know we can't get other updates since we have exclusive write access
+                                    // If the update fails, we know we can't get other updates since
+                                    // we have exclusive write access
                                     _skipUpdates++;
                                 } else {
                                     final String prefix =
@@ -556,7 +557,9 @@ public class Root extends ListTreeNode {
                                                             () -> {
                                                                 commit();
                                                                 if (!_live) {
-                                                                    // Make this tab live or close it if there is one already open
+                                                                    // Make this tab live or close
+                                                                    // it if there is one already
+                                                                    // open
                                                                     ApplicationPane app =
                                                                             _coordinator
                                                                                     .getLiveApplication(
@@ -1180,7 +1183,8 @@ public class Root extends ListTreeNode {
     }
 
     boolean pasteIceBox(IceBoxDescriptor ibd) {
-        // During paste, check that all service instances refer to existing services, and remove any extra template parameters
+        // During paste, check that all service instances refer to existing services, and remove any
+        // extra template parameters
         for (ServiceInstanceDescriptor p : ibd.services) {
             if (p.template.length() > 0) {
                 TemplateDescriptor td = findServiceTemplateDescriptor(p.template);

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Root.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Root.java
@@ -436,8 +436,7 @@ public class Root extends ListTreeNode {
                                             });
                                     asyncRelease = true;
 
-                                    // If the update fails, we know we can't get other updates
-                                    // since we have exclusive write access
+                                    // If the update fails, we know we can't get other updates since we have exclusive write access
                                     _skipUpdates++;
                                 } else {
                                     final String prefix =
@@ -557,9 +556,7 @@ public class Root extends ListTreeNode {
                                                             () -> {
                                                                 commit();
                                                                 if (!_live) {
-                                                                    // Make this tab live or close
-                                                                    // it if there is one already
-                                                                    // open
+                                                                    // Make this tab live or close it if there is one already open
                                                                     ApplicationPane app =
                                                                             _coordinator
                                                                                     .getLiveApplication(
@@ -1183,8 +1180,7 @@ public class Root extends ListTreeNode {
     }
 
     boolean pasteIceBox(IceBoxDescriptor ibd) {
-        // During paste, check that all service instances refer to existing services,
-        // and remove any extra template parameters
+        // During paste, check that all service instances refer to existing services, and remove any extra template parameters
         for (ServiceInstanceDescriptor p : ibd.services) {
             if (p.template.length() > 0) {
                 TemplateDescriptor td = findServiceTemplateDescriptor(p.template);
@@ -1254,8 +1250,7 @@ public class Root extends ListTreeNode {
 
     private boolean _discardMe = false;
 
-    // True when any update was applied to this application
-    // (including children)
+    // True when any update was applied to this application (including children)
     private boolean _updated = false;
 
     // Updates saved when _updated == false and

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Coordinator.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Coordinator.java
@@ -48,9 +48,7 @@ import javax.swing.filechooser.FileFilter;
 import javax.swing.text.JTextComponent;
 
 //
-// This class coordinates the communications between the various objects
-// that make up the IceGrid GUI.
-// It also provides both the menu bar and tool bar.
+// This class coordinates the communications between the various objects that make up the IceGrid GUI. It also provides both the menu bar and tool bar.
 //
 public class Coordinator {
     public interface IGraphView {
@@ -1235,15 +1233,9 @@ public class Coordinator {
         }
 
         // This class acts as a decorator around an existing trust manager, enabling it to intercept
-        // and
-        // react to
-        // certificate exceptions thrown due to invalid certificates. In such cases, rather than
-        // terminating the
+        // and react to certificate exceptions thrown due to invalid certificates. In such cases, rather than terminating the
         // connection, this class presents the user with an interactive dialog, allowing them to
-        // manually decide
-        // whether to trust the certificate. If the user rejects the certificate, the original
-        // exception
-        // is rethrown.
+        // manually decide whether to trust the certificate. If the user rejects the certificate, the original exception is rethrown.
         final class TrustManagerI implements javax.net.ssl.X509TrustManager {
             TrustManagerI(
                     KeyStore trustedServerKeyStore, javax.net.ssl.X509TrustManager decoratee) {
@@ -1275,11 +1267,9 @@ public class Coordinator {
                     //
                     // Compare the server certificate with a previous accepted certificate if
                     // any, the transient certificate is reset by Coordinator.login, and is only
-                    // useful in case the connection is retry, because a timeout or ACM closed
-                    // it while the certificate verifier was waiting for the user decision.
+                    // useful in case the connection is retry, because a timeout or ACM closed it while the certificate verifier was waiting for the user decision.
                     //
-                    // This avoids to show the dialog again if the user already granted the cert for
-                    // this login operation.
+                    // This avoids to show the dialog again if the user already granted the cert for this login operation.
                     //
                     if (_transientCert != null && _transientCert.equals(serverCertificate)) {
                         return;
@@ -1406,8 +1396,7 @@ public class Coordinator {
                 while (aliases.hasMoreElements()) {
                     if (trustedCaKeyStore.entryInstanceOf(
                             aliases.nextElement(), TrustedCertificateEntry.class)) {
-                        // Only initialize the trust managers if there is at least one trusted
-                        // certificate.
+                        // Only initialize the trust managers if there is at least one trusted certificate.
                         trustManagerFactory.init(trustedCaKeyStore);
                         trustManagers = trustManagerFactory.getTrustManagers();
                         break;
@@ -1463,10 +1452,7 @@ public class Coordinator {
             }
 
             if (trustManagers == null || trustManagers.length == 0) {
-                // The trust managers array would be empty if the trusted CA KeyStore is empty. In
-                // this
-                // case, we
-                // install a trust manager that rejects all peer certificates.
+                // The trust managers array would be empty if the trusted CA KeyStore is empty. In this case, we install a trust manager that rejects all peer certificates.
                 trustManagers =
                         new javax.net.ssl.TrustManager[] {
                             new javax.net.ssl.X509TrustManager() {
@@ -1860,15 +1846,9 @@ public class Coordinator {
                                     }
 
                                     //
-                                    // If the registry to use is the locator local registry, we
-                                    // install a default
-                                    // router
-                                    // to ensure we'll use a single connection regardless of the
+                                    // If the registry to use is the locator local registry, we install a default router to ensure we'll use a single connection regardless of the
                                     // endpoints returned in
-                                    // the
-                                    // proxies of the various session/admin methods (useful if used
-                                    // over a ssh
-                                    // tunnel).
+                                    // the proxies of the various session/admin methods (useful if used over a ssh tunnel).
                                     //
                                     if (cb.getRegistry()
                                             .ice_getIdentity()
@@ -3388,8 +3368,7 @@ public class Coordinator {
     //
     private void trace(String category, String message) {
         //
-        // It would be nicer to use the communicator's logger,
-        // but accessing _communicator is not thread-safe.
+        // It would be nicer to use the communicator's logger, but accessing _communicator is not thread-safe.
         //
         _initData.logger.trace(category, message);
     }
@@ -3481,8 +3460,7 @@ public class Coordinator {
     private MainPane _mainPane;
 
     //
-    // Keep tracks of serial number when viewing/editing application definitions
-    // (not used for displaying live deployment)
+    // Keep tracks of serial number when viewing/editing application definitions (not used for displaying live deployment)
     //
     private int _latestSerial = -1;
     private int _writeSerial = -1;
@@ -3543,8 +3521,7 @@ public class Coordinator {
     private ActionWrapper _moveDown;
 
     //
-    // Two sets of actions because the popup's target and the menu/toolbar's target
-    // can be different.
+    // Two sets of actions because the popup's target and the menu/toolbar's target can be different.
     //
     private LiveActions _liveActionsForMenu = new LiveActions();
     private LiveActions _liveActionsForPopup = new LiveActions();

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Coordinator.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Coordinator.java
@@ -48,7 +48,8 @@ import javax.swing.filechooser.FileFilter;
 import javax.swing.text.JTextComponent;
 
 //
-// This class coordinates the communications between the various objects that make up the IceGrid GUI. It also provides both the menu bar and tool bar.
+// This class coordinates the communications between the various objects that make up the IceGrid
+// GUI. It also provides both the menu bar and tool bar.
 //
 public class Coordinator {
     public interface IGraphView {
@@ -1233,9 +1234,11 @@ public class Coordinator {
         }
 
         // This class acts as a decorator around an existing trust manager, enabling it to intercept
-        // and react to certificate exceptions thrown due to invalid certificates. In such cases, rather than terminating the
+        // and react to certificate exceptions thrown due to invalid certificates. In such cases,
+        // rather than terminating the
         // connection, this class presents the user with an interactive dialog, allowing them to
-        // manually decide whether to trust the certificate. If the user rejects the certificate, the original exception is rethrown.
+        // manually decide whether to trust the certificate. If the user rejects the certificate,
+        // the original exception is rethrown.
         final class TrustManagerI implements javax.net.ssl.X509TrustManager {
             TrustManagerI(
                     KeyStore trustedServerKeyStore, javax.net.ssl.X509TrustManager decoratee) {
@@ -1267,9 +1270,11 @@ public class Coordinator {
                     //
                     // Compare the server certificate with a previous accepted certificate if
                     // any, the transient certificate is reset by Coordinator.login, and is only
-                    // useful in case the connection is retry, because a timeout or ACM closed it while the certificate verifier was waiting for the user decision.
+                    // useful in case the connection is retry, because a timeout or ACM closed it
+                    // while the certificate verifier was waiting for the user decision.
                     //
-                    // This avoids to show the dialog again if the user already granted the cert for this login operation.
+                    // This avoids to show the dialog again if the user already granted the cert for
+                    // this login operation.
                     //
                     if (_transientCert != null && _transientCert.equals(serverCertificate)) {
                         return;
@@ -1396,7 +1401,8 @@ public class Coordinator {
                 while (aliases.hasMoreElements()) {
                     if (trustedCaKeyStore.entryInstanceOf(
                             aliases.nextElement(), TrustedCertificateEntry.class)) {
-                        // Only initialize the trust managers if there is at least one trusted certificate.
+                        // Only initialize the trust managers if there is at least one trusted
+                        // certificate.
                         trustManagerFactory.init(trustedCaKeyStore);
                         trustManagers = trustManagerFactory.getTrustManagers();
                         break;
@@ -1452,7 +1458,8 @@ public class Coordinator {
             }
 
             if (trustManagers == null || trustManagers.length == 0) {
-                // The trust managers array would be empty if the trusted CA KeyStore is empty. In this case, we install a trust manager that rejects all peer certificates.
+                // The trust managers array would be empty if the trusted CA KeyStore is empty. In
+                // this case, we install a trust manager that rejects all peer certificates.
                 trustManagers =
                         new javax.net.ssl.TrustManager[] {
                             new javax.net.ssl.X509TrustManager() {
@@ -1846,9 +1853,12 @@ public class Coordinator {
                                     }
 
                                     //
-                                    // If the registry to use is the locator local registry, we install a default router to ensure we'll use a single connection regardless of the
+                                    // If the registry to use is the locator local registry, we
+                                    // install a default router to ensure we'll use a single
+                                    // connection regardless of the
                                     // endpoints returned in
-                                    // the proxies of the various session/admin methods (useful if used over a ssh tunnel).
+                                    // the proxies of the various session/admin methods (useful if
+                                    // used over a ssh tunnel).
                                     //
                                     if (cb.getRegistry()
                                             .ice_getIdentity()
@@ -3368,7 +3378,8 @@ public class Coordinator {
     //
     private void trace(String category, String message) {
         //
-        // It would be nicer to use the communicator's logger, but accessing _communicator is not thread-safe.
+        // It would be nicer to use the communicator's logger, but accessing _communicator is not
+        // thread-safe.
         //
         _initData.logger.trace(category, message);
     }
@@ -3460,7 +3471,8 @@ public class Coordinator {
     private MainPane _mainPane;
 
     //
-    // Keep tracks of serial number when viewing/editing application definitions (not used for displaying live deployment)
+    // Keep tracks of serial number when viewing/editing application definitions (not used for
+    // displaying live deployment)
     //
     private int _latestSerial = -1;
     private int _writeSerial = -1;
@@ -3521,7 +3533,8 @@ public class Coordinator {
     private ActionWrapper _moveDown;
 
     //
-    // Two sets of actions because the popup's target and the menu/toolbar's target can be different.
+    // Two sets of actions because the popup's target and the menu/toolbar's target can be
+    // different.
     //
     private LiveActions _liveActionsForMenu = new LiveActions();
     private LiveActions _liveActionsForPopup = new LiveActions();

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/GraphView.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/GraphView.java
@@ -206,8 +206,7 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
                                         _maxRefreshPeriod,
                                         1);
 
-                        // SpinnerNumberModel to set the maximum number of samples to keep in X
-                        // axis.
+                        // SpinnerNumberModel to set the maximum number of samples to keep in X axis.
                         final SpinnerNumberModel samples =
                                 new SpinnerNumberModel(_samples, _minSamples, _maxSamples, 1);
 
@@ -339,9 +338,7 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
                                             if (seriesClass != null) {
                                                 _styles.remove(seriesClass);
                                             }
-                                            // Don't remove the XYChart.Series object here, to avoid
-                                            // the series style classes getting reassigned by
-                                            // JavaFX.
+                                            // Don't remove the XYChart.Series object here, to avoid the series style classes getting reassigned by JavaFX.
                                             //
                                             // TODO: _chart.getData().remove(row.series);
                                             try {
@@ -642,8 +639,7 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
 
                                 columns.put(j.getField().getFieldName(), row);
                                 j.getField().setContext(GraphView.this);
-                                // When a line is clicked we select the corresponding row in the
-                                // legend table.
+                                // When a line is clicked we select the corresponding row in the legend table.
                                 javafx.scene.Node n =
                                         _chart.lookup(".chart-series-line." + styleClass);
                                 if (n != null) {
@@ -703,8 +699,7 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
         // Reset the cell field necessary to avoid bogus calculations.
         row.cell.resetField();
 
-        // We need also a new click handler so click works in all segments
-        // of the line.
+        // We need also a new click handler so click works in all segments of the line.
         //
         // When a line is clicked we select the corresponding row in the legend table.
         javafx.scene.Node n = _chart.lookup(".chart-series-line." + styleClass);
@@ -749,9 +744,7 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
                             metricsSeq = data.get(i.getKey());
                         }
 
-                        // Iterate over all configured values, if there isn't data for one
-                        // configured
-                        // field we need to add a gap.
+                        // Iterate over all configured values, if there isn't data for one configured field we need to add a gap.
                         for (Map.Entry<String, Map<String, MetricsRow>> j :
                                 i.getValue().entrySet()) {
                             com.zeroc.Ice.IceMX.Metrics metrics = null;
@@ -766,19 +759,14 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
                             }
                             for (Map.Entry<String, MetricsRow> k : j.getValue().entrySet()) {
                                 MetricsRow row = k.getValue();
-                                // If there isn't a metrics object we disable the row and add a
-                                // dummy value.
+                                // If there isn't a metrics object we disable the row and add a dummy value.
                                 if (metrics == null) {
-                                    // If the row isn't disabled we add a new series to represent
-                                    // the gap
-                                    // and mark the row as disabled.
+                                    // If the row isn't disabled we add a new series to represent the gap and mark the row as disabled.
                                     if (!row.disabled) {
                                         row.series.push(new XYChart.Series<Number, Number>());
                                         row.disabled = true;
                                     }
-                                    // This dummy value is added to represent gap sizes, but isn't
-                                    // displayed
-                                    // as the series isn't added to the graph.
+                                    // This dummy value is added to represent gap sizes, but isn't displayed as the series isn't added to the graph.
                                     row.series
                                             .peek()
                                             .getData()
@@ -791,10 +779,7 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
                                         }
 
                                         Number value = row.cell.getValue(metrics, timestamp);
-                                        // The cell returns null to indicate the value must be
-                                        // skipped,
-                                        // this is usually because it needs two values to calculate
-                                        // the average.
+                                        // The cell returns null to indicate the value must be skipped, this is usually because it needs two values to calculate the average.
                                         if (value == null) {
                                             continue;
                                         }
@@ -810,9 +795,7 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
                                     }
                                 }
 
-                                // Remove the vertices from the beginning of the series that
-                                // exceeded
-                                // the maximum number of samples.
+                                // Remove the vertices from the beginning of the series that exceeded the maximum number of samples.
                                 adjustSize(row);
                             }
                         }
@@ -1157,8 +1140,7 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
                     row.cell.setScaleFactor(((Double) value).doubleValue());
                 } else if (_columnNames[columnIndex].equals("Color")) {
                     Color color = (Color) value;
-                    // Convert color to the CSS representation used by JavaFX style.
-                    // example: #ff00aa
+                    // Convert color to the CSS representation used by JavaFX style. example: #ff00aa
                     row.color =
                             "#"
                                     + String.format("%02X", color.getRed())

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/GraphView.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/GraphView.java
@@ -206,7 +206,8 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
                                         _maxRefreshPeriod,
                                         1);
 
-                        // SpinnerNumberModel to set the maximum number of samples to keep in X axis.
+                        // SpinnerNumberModel to set the maximum number of samples to keep in X
+                        // axis.
                         final SpinnerNumberModel samples =
                                 new SpinnerNumberModel(_samples, _minSamples, _maxSamples, 1);
 
@@ -338,7 +339,9 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
                                             if (seriesClass != null) {
                                                 _styles.remove(seriesClass);
                                             }
-                                            // Don't remove the XYChart.Series object here, to avoid the series style classes getting reassigned by JavaFX.
+                                            // Don't remove the XYChart.Series object here, to avoid
+                                            // the series style classes getting reassigned by
+                                            // JavaFX.
                                             //
                                             // TODO: _chart.getData().remove(row.series);
                                             try {
@@ -639,7 +642,8 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
 
                                 columns.put(j.getField().getFieldName(), row);
                                 j.getField().setContext(GraphView.this);
-                                // When a line is clicked we select the corresponding row in the legend table.
+                                // When a line is clicked we select the corresponding row in the
+                                // legend table.
                                 javafx.scene.Node n =
                                         _chart.lookup(".chart-series-line." + styleClass);
                                 if (n != null) {
@@ -744,7 +748,8 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
                             metricsSeq = data.get(i.getKey());
                         }
 
-                        // Iterate over all configured values, if there isn't data for one configured field we need to add a gap.
+                        // Iterate over all configured values, if there isn't data for one
+                        // configured field we need to add a gap.
                         for (Map.Entry<String, Map<String, MetricsRow>> j :
                                 i.getValue().entrySet()) {
                             com.zeroc.Ice.IceMX.Metrics metrics = null;
@@ -759,14 +764,17 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
                             }
                             for (Map.Entry<String, MetricsRow> k : j.getValue().entrySet()) {
                                 MetricsRow row = k.getValue();
-                                // If there isn't a metrics object we disable the row and add a dummy value.
+                                // If there isn't a metrics object we disable the row and add a
+                                // dummy value.
                                 if (metrics == null) {
-                                    // If the row isn't disabled we add a new series to represent the gap and mark the row as disabled.
+                                    // If the row isn't disabled we add a new series to represent
+                                    // the gap and mark the row as disabled.
                                     if (!row.disabled) {
                                         row.series.push(new XYChart.Series<Number, Number>());
                                         row.disabled = true;
                                     }
-                                    // This dummy value is added to represent gap sizes, but isn't displayed as the series isn't added to the graph.
+                                    // This dummy value is added to represent gap sizes, but isn't
+                                    // displayed as the series isn't added to the graph.
                                     row.series
                                             .peek()
                                             .getData()
@@ -779,7 +787,9 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
                                         }
 
                                         Number value = row.cell.getValue(metrics, timestamp);
-                                        // The cell returns null to indicate the value must be skipped, this is usually because it needs two values to calculate the average.
+                                        // The cell returns null to indicate the value must be
+                                        // skipped, this is usually because it needs two values to
+                                        // calculate the average.
                                         if (value == null) {
                                             continue;
                                         }
@@ -795,7 +805,8 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
                                     }
                                 }
 
-                                // Remove the vertices from the beginning of the series that exceeded the maximum number of samples.
+                                // Remove the vertices from the beginning of the series that
+                                // exceeded the maximum number of samples.
                                 adjustSize(row);
                             }
                         }
@@ -1140,7 +1151,8 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
                     row.cell.setScaleFactor(((Double) value).doubleValue());
                 } else if (_columnNames[columnIndex].equals("Color")) {
                     Color color = (Color) value;
-                    // Convert color to the CSS representation used by JavaFX style. example: #ff00aa
+                    // Convert color to the CSS representation used by JavaFX style. example:
+                    // #ff00aa
                     row.color =
                             "#"
                                     + String.format("%02X", color.getRed())

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/GraphView.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/GraphView.java
@@ -1151,8 +1151,8 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
                     row.cell.setScaleFactor(((Double) value).doubleValue());
                 } else if (_columnNames[columnIndex].equals("Color")) {
                     Color color = (Color) value;
-                    // Convert color to the CSS representation used by JavaFX style. example:
-                    // #ff00aa
+                    // Convert color to the CSS representation used by JavaFX style.
+                    // example: #ff00aa
                     row.color =
                             "#"
                                     + String.format("%02X", color.getRed())

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/MetricsView.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/MetricsView.java
@@ -83,7 +83,9 @@ class MetricsView extends TreeNode {
                                                                     .getTree()
                                                                     .getLastSelectedPathComponent()
                                                             == MetricsView.this) {
-                                                        // If the metrics view is selected when enabled success, we must start the refresh thread to pull updates.
+                                                        // If the metrics view is selected when
+                                                        // enabled success, we must start the
+                                                        // refresh thread to pull updates.
                                                         MetricsViewEditor.startRefresh(
                                                                 MetricsView.this);
                                                     }
@@ -134,7 +136,8 @@ class MetricsView extends TreeNode {
                                                                     .getTree()
                                                                     .getLastSelectedPathComponent()
                                                             == MetricsView.this) {
-                                                        // If the metrics view is selected when disabled success, we stop the refresh.
+                                                        // If the metrics view is selected when
+                                                        // disabled success, we stop the refresh.
                                                         MetricsViewEditor.stopRefresh();
                                                     }
                                                 });

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/MetricsView.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/MetricsView.java
@@ -83,10 +83,7 @@ class MetricsView extends TreeNode {
                                                                     .getTree()
                                                                     .getLastSelectedPathComponent()
                                                             == MetricsView.this) {
-                                                        // If the metrics view is selected when
-                                                        // enabled success,
-                                                        // we must start the refresh thread to pull
-                                                        // updates.
+                                                        // If the metrics view is selected when enabled success, we must start the refresh thread to pull updates.
                                                         MetricsViewEditor.startRefresh(
                                                                 MetricsView.this);
                                                     }
@@ -137,8 +134,7 @@ class MetricsView extends TreeNode {
                                                                     .getTree()
                                                                     .getLastSelectedPathComponent()
                                                             == MetricsView.this) {
-                                                        // If the metrics view is selected when
-                                                        // disabled success, we stop the refresh.
+                                                        // If the metrics view is selected when disabled success, we stop the refresh.
                                                         MetricsViewEditor.stopRefresh();
                                                     }
                                                 });

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/MetricsViewEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/MetricsViewEditor.java
@@ -1254,7 +1254,8 @@ public class MetricsViewEditor extends Editor implements MetricsFieldContext {
             _deltas.put(m.id, d2);
 
             if (d1 == null) {
-                // Return null indicate the graph to ignore this measurement. We need two measurement to calculate the delta increments.
+                // Return null indicate the graph to ignore this measurement. We need two
+                // measurement to calculate the delta increments.
                 return null;
             }
 

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/MetricsViewEditor.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/MetricsViewEditor.java
@@ -1254,9 +1254,7 @@ public class MetricsViewEditor extends Editor implements MetricsFieldContext {
             _deltas.put(m.id, d2);
 
             if (d1 == null) {
-                // Return null indicate the graph to ignore this measurement. We need two
-                // measurement to calculate
-                // the delta increments.
+                // Return null indicate the graph to ignore this measurement. We need two measurement to calculate the delta increments.
                 return null;
             }
 

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Server.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Server.java
@@ -658,13 +658,16 @@ public class Server extends Communicator {
                     }
 
                     if (_serviceObserver != null) {
-                        // Add observer to service manager using AMI call Note that duplicate registrations are ignored
+                        // Add observer to service manager using AMI call Note that duplicate
+                        // registrations are ignored
 
                         com.zeroc.IceBox.ServiceManagerPrx serviceManager = getServiceManager();
 
                         if (serviceManager != null) {
                             try {
-                                // Ignore failures to register the service observers. Failures can occur if there's an incompatibility between IceGrid nodes & registries (it's the case for instance between 3.5 and 3.7).
+                                // Ignore failures to register the service observers. Failures can
+                                // occur if there's an incompatibility between IceGrid nodes &
+                                // registries (it's the case for instance between 3.5 and 3.7).
                                 serviceManager.addObserverAsync(_serviceObserver);
                             } catch (com.zeroc.Ice.LocalException ex) {
                                 // Ignore

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Server.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Server.java
@@ -658,18 +658,13 @@ public class Server extends Communicator {
                     }
 
                     if (_serviceObserver != null) {
-                        // Add observer to service manager using AMI call
-                        // Note that duplicate registrations are ignored
+                        // Add observer to service manager using AMI call Note that duplicate registrations are ignored
 
                         com.zeroc.IceBox.ServiceManagerPrx serviceManager = getServiceManager();
 
                         if (serviceManager != null) {
                             try {
-                                // Ignore failures to register the service observers. Failures can
-                                // occur if
-                                // there's an incompatibility between IceGrid nodes & registries
-                                // (it's the
-                                // case for instance between 3.5 and 3.7).
+                                // Ignore failures to register the service observers. Failures can occur if there's an incompatibility between IceGrid nodes & registries (it's the case for instance between 3.5 and 3.7).
                                 serviceManager.addObserverAsync(_serviceObserver);
                             } catch (com.zeroc.Ice.LocalException ex) {
                                 // Ignore

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SessionKeeper.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SessionKeeper.java
@@ -4460,7 +4460,8 @@ public class SessionKeeper {
                 private JCheckBox _storeKeyPassword;
             }
 
-            // If there isn't a store password or the certificate requires a password and the password isn't provided, we show the login dialog.
+            // If there isn't a store password or the certificate requires a password and the
+            // password isn't provided, we show the login dialog.
             if ((info.getPassword() == null || info.getPassword().length == 0)
                     || (info.getUseX509Certificate()
                             && checkCertificateRequirePassword(info.getAlias())
@@ -4600,7 +4601,8 @@ public class SessionKeeper {
                 private JCheckBox _storeKeyPassword;
             }
 
-            // If the certificate requires a password and the password isn't provided, we show the login dialog.
+            // If the certificate requires a password and the password isn't provided, we show the
+            // login dialog.
             if ((info.getKeyPassword() == null || info.getKeyPassword().length == 0)
                     && checkCertificateRequirePassword(info.getAlias())) {
                 _authDialog = new X509CertificateAuthDialog();

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SessionKeeper.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SessionKeeper.java
@@ -4460,8 +4460,7 @@ public class SessionKeeper {
                 private JCheckBox _storeKeyPassword;
             }
 
-            // If there isn't a store password or the certificate requires a password
-            // and the password isn't provided, we show the login dialog.
+            // If there isn't a store password or the certificate requires a password and the password isn't provided, we show the login dialog.
             if ((info.getPassword() == null || info.getPassword().length == 0)
                     || (info.getUseX509Certificate()
                             && checkCertificateRequirePassword(info.getAlias())
@@ -4601,8 +4600,7 @@ public class SessionKeeper {
                 private JCheckBox _storeKeyPassword;
             }
 
-            // If the certificate requires a password and the password isn't provided, we
-            // show the login dialog.
+            // If the certificate requires a password and the password isn't provided, we show the login dialog.
             if ((info.getKeyPassword() == null || info.getKeyPassword().length == 0)
                     && checkCertificateRequirePassword(info.getAlias())) {
                 _authDialog = new X509CertificateAuthDialog();

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/TreeNodeBase.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/TreeNodeBase.java
@@ -11,7 +11,8 @@ import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreeCellRenderer;
 import javax.swing.tree.TreePath;
 
-// This class behaves like a leaf; derived class that represent non-leaf nodes must override various methods.
+// This class behaves like a leaf; derived class that represent non-leaf nodes must override various
+// methods.
 public class TreeNodeBase implements javax.swing.tree.TreeNode, TreeCellRenderer {
     public Coordinator getCoordinator() {
         return _parent.getCoordinator();

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/TreeNodeBase.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/TreeNodeBase.java
@@ -11,8 +11,7 @@ import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreeCellRenderer;
 import javax.swing.tree.TreePath;
 
-// This class behaves like a leaf; derived class that represent non-leaf nodes must
-// override various methods.
+// This class behaves like a leaf; derived class that represent non-leaf nodes must override various methods.
 public class TreeNodeBase implements javax.swing.tree.TreeNode, TreeCellRenderer {
     public Coordinator getCoordinator() {
         return _parent.getCoordinator();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/BZip2.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/BZip2.java
@@ -153,7 +153,8 @@ public class BZip2 {
 
     public static synchronized boolean supported() {
         //
-        // Use lazy initialization when determining whether support for bzip2 compression is available.
+        // Use lazy initialization when determining whether support for bzip2 compression is
+        // available.
         //
         if (!_checked) {
             _checked = true;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/BZip2.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/BZip2.java
@@ -50,8 +50,7 @@ public class BZip2 {
         }
 
         //
-        // Don't bother if the compressed data is larger than the
-        // uncompressed data.
+        // Don't bother if the compressed data is larger than the uncompressed data.
         //
         if (compressedLen >= uncompressedLen) {
             return null;
@@ -154,8 +153,7 @@ public class BZip2 {
 
     public static synchronized boolean supported() {
         //
-        // Use lazy initialization when determining whether support for bzip2 compression is
-        // available.
+        // Use lazy initialization when determining whether support for bzip2 compression is available.
         //
         if (!_checked) {
             _checked = true;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Base64.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Base64.java
@@ -3,8 +3,7 @@
 package com.zeroc.Ice;
 
 // We would prefer to use java.util.Base64 but unfortunately that class isn't supported in Android
-// until
-// Android O, so we are using our own implementation.
+// until Android O, so we are using our own implementation.
 final class Base64 {
     public static String encode(byte[] plainSeq) {
         if (plainSeq == null || plainSeq.length == 0) {
@@ -94,8 +93,7 @@ final class Base64 {
             return null;
         }
 
-        // Note: This is how we were previously computing the size of the return
-        //       sequence. The method below is more efficient (and correct).
+        // Note: This is how we were previously computing the size of the return sequence. The method below is more efficient (and correct).
         // size_t lines = str.size() / 78;
         // size_t totalBytes = (lines * 76) + (((str.size() - (lines * 78)) * 3) / 4);
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Base64.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Base64.java
@@ -93,7 +93,8 @@ final class Base64 {
             return null;
         }
 
-        // Note: This is how we were previously computing the size of the return sequence. The method below is more efficient (and correct).
+        // Note: This is how we were previously computing the size of the return sequence. The
+        // method below is more efficient (and correct).
         // size_t lines = str.size() / 78;
         // size_t totalBytes = (lines * 76) + (((str.size() - (lines * 78)) * 3) / 4);
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/BatchRequestQueue.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/BatchRequestQueue.java
@@ -73,7 +73,8 @@ class BatchRequestQueue {
 
     public void finishBatchRequest(OutputStream os, ObjectPrx proxy, String operation) {
         //
-        // No need for synchronization, no other threads are supposed to modify the queue since we set _batchStreamInUse to true.
+        // No need for synchronization, no other threads are supposed to modify the queue since we
+        // set _batchStreamInUse to true.
         //
         assert (_batchStreamInUse);
         _batchStream.swap(os);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/BatchRequestQueue.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/BatchRequestQueue.java
@@ -73,8 +73,7 @@ class BatchRequestQueue {
 
     public void finishBatchRequest(OutputStream os, ObjectPrx proxy, String operation) {
         //
-        // No need for synchronization, no other threads are supposed
-        // to modify the queue since we set _batchStreamInUse to true.
+        // No need for synchronization, no other threads are supposed to modify the queue since we set _batchStreamInUse to true.
         //
         assert (_batchStreamInUse);
         _batchStream.swap(os);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Buffer.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Buffer.java
@@ -118,9 +118,7 @@ public class Buffer {
 
     //
     // Call expand(n) to add room for n additional bytes. Note that expand()
-    // examines the current position of the buffer first; we don't want to
-    // expand the buffer if the caller is writing to a location that is
-    // already in the buffer.
+    // examines the current position of the buffer first; we don't want to expand the buffer if the caller is writing to a location that is already in the buffer.
     //
     public void expand(int n) {
         final int sz = (b == _emptyBuffer) ? n : b.position() + n;
@@ -150,10 +148,7 @@ public class Buffer {
     public void reset() {
         if (_size > 0 && _size * 2 < _capacity) {
             //
-            // If the current buffer size is smaller than the
-            // buffer capacity, we shrink the buffer memory to the
-            // current size. This is to avoid holding on to too much
-            // memory if it's not needed anymore.
+            // If the current buffer size is smaller than the buffer capacity, we shrink the buffer memory to the current size. This is to avoid holding on to too much memory if it's not needed anymore.
             //
             if (++_shrinkCounter > 2) {
                 reserve(_size);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Buffer.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Buffer.java
@@ -118,7 +118,8 @@ public class Buffer {
 
     //
     // Call expand(n) to add room for n additional bytes. Note that expand()
-    // examines the current position of the buffer first; we don't want to expand the buffer if the caller is writing to a location that is already in the buffer.
+    // examines the current position of the buffer first; we don't want to expand the buffer if the
+    // caller is writing to a location that is already in the buffer.
     //
     public void expand(int n) {
         final int sz = (b == _emptyBuffer) ? n : b.position() + n;
@@ -148,7 +149,9 @@ public class Buffer {
     public void reset() {
         if (_size > 0 && _size * 2 < _capacity) {
             //
-            // If the current buffer size is smaller than the buffer capacity, we shrink the buffer memory to the current size. This is to avoid holding on to too much memory if it's not needed anymore.
+            // If the current buffer size is smaller than the buffer capacity, we shrink the buffer
+            // memory to the current size. This is to avoid holding on to too much memory if it's
+            // not needed anymore.
             //
             if (++_shrinkCounter > 2) {
                 reserve(_size);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CollocatedRequestHandler.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CollocatedRequestHandler.java
@@ -82,8 +82,7 @@ final class CollocatedRequestHandler implements RequestHandler {
 
     int invokeAsyncRequest(OutgoingAsyncBase outAsync, int batchRequestNum, boolean sync) {
         //
-        // Increase the direct count to prevent the thread pool from being destroyed before
-        // dispatchAll is called. This will also throw if the object adapter has been deactivated.
+        // Increase the direct count to prevent the thread pool from being destroyed before dispatchAll is called. This will also throw if the object adapter has been deactivated.
         //
         _adapter.incDirectCount();
 
@@ -135,9 +134,7 @@ final class CollocatedRequestHandler implements RequestHandler {
             }
 
             //
-            // This must be called within the synchronization to
-            // ensure completed(ex) can't be called concurrently if
-            // the request is canceled.
+            // This must be called within the synchronization to ensure completed(ex) can't be called concurrently if the request is canceled.
             //
             if (!outAsync.sent()) {
                 return true;
@@ -176,10 +173,7 @@ final class CollocatedRequestHandler implements RequestHandler {
         try {
             while (dispatchCount > 0) {
                 //
-                // Increase the direct count for the dispatch. We increase it again here for
-                // each dispatch. It's important for the direct count to be > 0 until the last
-                // collocated request response is sent to make sure the thread pool isn't
-                // destroyed before.
+                // Increase the direct count for the dispatch. We increase it again here for each dispatch. It's important for the direct count to be > 0 until the last collocated request response is sent to make sure the thread pool isn't destroyed before.
                 //
                 try {
                     _adapter.incDirectCount();
@@ -217,9 +211,7 @@ final class CollocatedRequestHandler implements RequestHandler {
         } catch (LocalException ex) {
             dispatchException(ex, requestId, false); // Fatal dispatch exception
         } catch (RuntimeException | Error ex) {
-            // A runtime exception or an error was thrown outside of servant code (i.e., by Ice
-            // code).
-            // Note that this code does NOT send a response to the client.
+            // A runtime exception or an error was thrown outside of servant code (i.e., by Ice code). Note that this code does NOT send a response to the client.
             var uex = new UnknownException(ex);
             var sw = new java.io.StringWriter();
             var pw = new java.io.PrintWriter(sw);
@@ -265,9 +257,7 @@ final class CollocatedRequestHandler implements RequestHandler {
 
             if (outAsync != null) {
                 //
-                // If called from an AMD dispatch, invoke asynchronously
-                // the completion callback since this might be called from
-                // the user code.
+                // If called from an AMD dispatch, invoke asynchronously the completion callback since this might be called from the user code.
                 //
                 if (amd) {
                     outAsync.invokeCompletedAsync();
@@ -299,9 +289,7 @@ final class CollocatedRequestHandler implements RequestHandler {
 
         if (outAsync != null) {
             //
-            // If called from an AMD dispatch, invoke asynchronously
-            // the completion callback since this might be called from
-            // the user code.
+            // If called from an AMD dispatch, invoke asynchronously the completion callback since this might be called from the user code.
             //
             if (amd) {
                 outAsync.invokeCompletedAsync();
@@ -324,8 +312,7 @@ final class CollocatedRequestHandler implements RequestHandler {
 
     private int _requestId;
 
-    // A map of outstanding requests that can be canceled. A request
-    // can be canceled if it has an invocation timeout, or we support
+    // A map of outstanding requests that can be canceled. A request can be canceled if it has an invocation timeout, or we support
     // interrupts.
     private final java.util.Map<OutgoingAsyncBase, Integer> _sendAsyncRequests =
             new java.util.HashMap<>();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CollocatedRequestHandler.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CollocatedRequestHandler.java
@@ -82,7 +82,8 @@ final class CollocatedRequestHandler implements RequestHandler {
 
     int invokeAsyncRequest(OutgoingAsyncBase outAsync, int batchRequestNum, boolean sync) {
         //
-        // Increase the direct count to prevent the thread pool from being destroyed before dispatchAll is called. This will also throw if the object adapter has been deactivated.
+        // Increase the direct count to prevent the thread pool from being destroyed before
+        // dispatchAll is called. This will also throw if the object adapter has been deactivated.
         //
         _adapter.incDirectCount();
 
@@ -134,7 +135,8 @@ final class CollocatedRequestHandler implements RequestHandler {
             }
 
             //
-            // This must be called within the synchronization to ensure completed(ex) can't be called concurrently if the request is canceled.
+            // This must be called within the synchronization to ensure completed(ex) can't be
+            // called concurrently if the request is canceled.
             //
             if (!outAsync.sent()) {
                 return true;
@@ -173,7 +175,9 @@ final class CollocatedRequestHandler implements RequestHandler {
         try {
             while (dispatchCount > 0) {
                 //
-                // Increase the direct count for the dispatch. We increase it again here for each dispatch. It's important for the direct count to be > 0 until the last collocated request response is sent to make sure the thread pool isn't destroyed before.
+                // Increase the direct count for the dispatch. We increase it again here for each
+                // dispatch. It's important for the direct count to be > 0 until the last collocated
+                // request response is sent to make sure the thread pool isn't destroyed before.
                 //
                 try {
                     _adapter.incDirectCount();
@@ -211,7 +215,8 @@ final class CollocatedRequestHandler implements RequestHandler {
         } catch (LocalException ex) {
             dispatchException(ex, requestId, false); // Fatal dispatch exception
         } catch (RuntimeException | Error ex) {
-            // A runtime exception or an error was thrown outside of servant code (i.e., by Ice code). Note that this code does NOT send a response to the client.
+            // A runtime exception or an error was thrown outside of servant code (i.e., by Ice
+            // code). Note that this code does NOT send a response to the client.
             var uex = new UnknownException(ex);
             var sw = new java.io.StringWriter();
             var pw = new java.io.PrintWriter(sw);
@@ -257,7 +262,8 @@ final class CollocatedRequestHandler implements RequestHandler {
 
             if (outAsync != null) {
                 //
-                // If called from an AMD dispatch, invoke asynchronously the completion callback since this might be called from the user code.
+                // If called from an AMD dispatch, invoke asynchronously the completion callback
+                // since this might be called from the user code.
                 //
                 if (amd) {
                     outAsync.invokeCompletedAsync();
@@ -289,7 +295,8 @@ final class CollocatedRequestHandler implements RequestHandler {
 
         if (outAsync != null) {
             //
-            // If called from an AMD dispatch, invoke asynchronously the completion callback since this might be called from the user code.
+            // If called from an AMD dispatch, invoke asynchronously the completion callback since
+            // this might be called from the user code.
             //
             if (amd) {
                 outAsync.invokeCompletedAsync();
@@ -312,7 +319,8 @@ final class CollocatedRequestHandler implements RequestHandler {
 
     private int _requestId;
 
-    // A map of outstanding requests that can be canceled. A request can be canceled if it has an invocation timeout, or we support
+    // A map of outstanding requests that can be canceled. A request can be canceled if it has an
+    // invocation timeout, or we support
     // interrupts.
     private final java.util.Map<OutgoingAsyncBase, Integer> _sendAsyncRequests =
             new java.util.HashMap<>();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
@@ -547,8 +547,7 @@ public final class Communicator implements AutoCloseable {
      */
 
     //
-    // Certain initialization tasks need to be completed after the
-    // constructor.
+    // Certain initialization tasks need to be completed after the constructor.
     //
     void finishSetup(String[] args, java.util.List<String> rArgs) {
         try {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectRequestHandler.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectRequestHandler.java
@@ -48,11 +48,7 @@ final class ConnectRequestHandler
     @Override
     public synchronized ConnectionI getConnection() {
         //
-        // First check for the connection, it's important otherwise the user could first get a
-        // connection
-        // and then the exception if he tries to obtain the proxy cached connection multiple times
-        // (the
-        // exception can be set after the connection is set if the flush of pending requests fails).
+        // First check for the connection, it's important otherwise the user could first get a connection and then the exception if he tries to obtain the proxy cached connection multiple times (the exception can be set after the connection is set if the flush of pending requests fails).
         //
         if (_connection != null) {
             return _connection;
@@ -75,8 +71,7 @@ final class ConnectRequestHandler
         }
 
         //
-        // If this proxy is for a non-local object, and we are using a router, then
-        // add this proxy to the router info object.
+        // If this proxy is for a non-local object, and we are using a router, then add this proxy to the router info object.
         //
         RouterInfo ri = _reference.getRouterInfo();
         if (ri != null && !ri.addProxy(_reference, this)) {
@@ -116,8 +111,7 @@ final class ConnectRequestHandler
     @Override
     public void addedProxy() {
         //
-        // The proxy was added to the router info, we're now ready to send the
-        // queued requests.
+        // The proxy was added to the router info, we're now ready to send the queued requests.
         //
         flushRequests();
     }
@@ -137,8 +131,7 @@ final class ConnectRequestHandler
             return true;
         } else {
             //
-            // This is similar to a mutex lock in that the flag is
-            // only true for a short period of time.
+            // This is similar to a mutex lock in that the flag is only true for a short period of time.
             //
             boolean interrupted = false;
             while (_flushing) {
@@ -158,9 +151,7 @@ final class ConnectRequestHandler
             if (_exception != null) {
                 if (_connection != null) {
                     //
-                    // Only throw if the connection didn't get established. If
-                    // it died after being established, we allow the caller to
-                    // retry the connection establishment by not throwing here
+                    // Only throw if the connection didn't get established. If it died after being established, we allow the caller to retry the connection establishment by not throwing here
                     // (the connection will throw RetryException).
                     //
                     return true;
@@ -177,9 +168,7 @@ final class ConnectRequestHandler
             assert (_connection != null && !_initialized);
 
             //
-            // We set the _flushing flag to true to prevent any additional queuing. Callers
-            // might block for a little while as the queued requests are being sent but this
-            // shouldn't be an issue as the request sends are non-blocking.
+            // We set the _flushing flag to true to prevent any additional queuing. Callers might block for a little while as the queued requests are being sent but this shouldn't be an issue as the request sends are non-blocking.
             //
             _flushing = true;
         }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectRequestHandler.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectRequestHandler.java
@@ -48,7 +48,10 @@ final class ConnectRequestHandler
     @Override
     public synchronized ConnectionI getConnection() {
         //
-        // First check for the connection, it's important otherwise the user could first get a connection and then the exception if he tries to obtain the proxy cached connection multiple times (the exception can be set after the connection is set if the flush of pending requests fails).
+        // First check for the connection, it's important otherwise the user could first get a
+        // connection and then the exception if he tries to obtain the proxy cached connection
+        // multiple times (the exception can be set after the connection is set if the flush of
+        // pending requests fails).
         //
         if (_connection != null) {
             return _connection;
@@ -71,7 +74,8 @@ final class ConnectRequestHandler
         }
 
         //
-        // If this proxy is for a non-local object, and we are using a router, then add this proxy to the router info object.
+        // If this proxy is for a non-local object, and we are using a router, then add this proxy
+        // to the router info object.
         //
         RouterInfo ri = _reference.getRouterInfo();
         if (ri != null && !ri.addProxy(_reference, this)) {
@@ -131,7 +135,8 @@ final class ConnectRequestHandler
             return true;
         } else {
             //
-            // This is similar to a mutex lock in that the flag is only true for a short period of time.
+            // This is similar to a mutex lock in that the flag is only true for a short period of
+            // time.
             //
             boolean interrupted = false;
             while (_flushing) {
@@ -151,7 +156,9 @@ final class ConnectRequestHandler
             if (_exception != null) {
                 if (_connection != null) {
                     //
-                    // Only throw if the connection didn't get established. If it died after being established, we allow the caller to retry the connection establishment by not throwing here
+                    // Only throw if the connection didn't get established. If it died after being
+                    // established, we allow the caller to retry the connection establishment by not
+                    // throwing here
                     // (the connection will throw RetryException).
                     //
                     return true;
@@ -168,7 +175,9 @@ final class ConnectRequestHandler
             assert (_connection != null && !_initialized);
 
             //
-            // We set the _flushing flag to true to prevent any additional queuing. Callers might block for a little while as the queued requests are being sent but this shouldn't be an issue as the request sends are non-blocking.
+            // We set the _flushing flag to true to prevent any additional queuing. Callers might
+            // block for a little while as the queued requests are being sent but this shouldn't be
+            // an issue as the request sends are non-blocking.
             //
             _flushing = true;
         }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -189,7 +189,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
     public synchronized void waitUntilFinished() throws InterruptedException {
         //
-        // We wait indefinitely until the connection is finished and all outstanding requests are completed. Otherwise we couldn't
+        // We wait indefinitely until the connection is finished and all outstanding requests are
+        // completed. Otherwise we couldn't
         // guarantee that there are no outstanding calls when deactivate()
         // is called on the servant locators.
         //
@@ -235,7 +236,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
         if (_exception != null) {
             //
-            // If the connection is closed before we even have a chance to send our request, we always try to send the request again.
+            // If the connection is closed before we even have a chance to send our request, we
+            // always try to send the request again.
             //
             throw new RetryException((LocalException) _exception.fillInStackTrace());
         }
@@ -249,7 +251,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         _transceiver.checkSendSize(os.getBuffer());
 
         //
-        // Notify the request that it's cancelable with this connection. This will throw if the request is canceled.
+        // Notify the request that it's cancelable with this connection. This will throw if the
+        // request is canceled.
         //
         out.cancelable(this);
 
@@ -358,7 +361,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                     setState(StateClosed, ex);
                 } else {
                     //
-                    // If the request is being sent, don't remove it from the send streams, it will be removed once the sending is finished.
+                    // If the request is being sent, don't remove it from the send streams, it will
+                    // be removed once the sending is finished.
                     //
                     // Note that since we swapped the message stream to _writeStream
                     // it's fine if the OutgoingAsync output stream is released (and
@@ -420,7 +424,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         }
 
         if (adapter != null) {
-            // Go through the adapter to set the adapter on this connection to ensure the object adapter is still active and to ensure proper locking order.
+            // Go through the adapter to set the adapter on this connection to ensure the object
+            // adapter is still active and to ensure proper locking order.
             adapter.setAdapterOnConnection(this);
         } else {
             synchronized (this) {
@@ -432,7 +437,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         }
 
         //
-        // We never change the thread pool with which we were initially registered, even if we add or remove an object adapter.
+        // We never change the thread pool with which we were initially registered, even if we add
+        // or remove an object adapter.
         //
     }
 
@@ -487,7 +493,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                 int writeOp = SocketOperation.None;
                 int readOp = SocketOperation.None;
 
-                // If writes are ready, write the data from the connection's write buffer (_writeStream)
+                // If writes are ready, write the data from the connection's write buffer
+                // (_writeStream)
                 if ((current.operation & SocketOperation.Write) != 0) {
                     final Buffer buf = _writeStream.getBuffer();
                     if (_observer != null) {
@@ -502,7 +509,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                 // If reads are ready, read the data into the connection's read buffer
                 // (_readStream). The data is read until:
                 // - the full message is read (the transport read returns SocketOperationNone)
-                // and the read buffer is fully filled - the read operation on the transport can't continue without blocking
+                // and the read buffer is fully filled - the read operation on the transport can't
+                // continue without blocking
                 if ((current.operation & SocketOperation.Read) != 0) {
                     while (true) {
                         final Buffer buf = _readStream.getBuffer();
@@ -520,7 +528,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                             observerFinishRead(buf);
                         }
 
-                        // If read header is true, we're reading a new Ice protocol message and we need to read the message header.
+                        // If read header is true, we're reading a new Ice protocol message and we
+                        // need to read the message header.
                         if (_readHeader) {
                             // The next read will read the remainder of the message.
                             _readHeader = false;
@@ -538,7 +547,9 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                             //
                             _validated = true;
 
-                            // Full header should be read because the size of _readStream is always headerSize (14) when reading a new message (see the code that sets _readHeader = true).
+                            // Full header should be read because the size of _readStream is always
+                            // headerSize (14) when reading a new message (see the code that sets
+                            // _readHeader = true).
                             int pos = _readStream.pos();
                             if (pos < Protocol.headerSize) {
                                 //
@@ -605,7 +616,9 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                     }
                 }
 
-                // readOp and writeOp are set to the operations that the transport read or write calls from above returned. They indicate which operations will need to be monitored by the thread pool's selector when this method returns.
+                // readOp and writeOp are set to the operations that the transport read or write
+                // calls from above returned. They indicate which operations will need to be
+                // monitored by the thread pool's selector when this method returns.
                 int newOp = readOp | writeOp;
 
                 // Operations that are ready. For example, if message was called with
@@ -614,7 +627,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                 int readyOp = current.operation & ~newOp;
 
                 if (_state <= StateNotValidated) {
-                    // If the connection is still not validated and there's still data to read or write, continue waiting for data to read or write.
+                    // If the connection is still not validated and there's still data to read or
+                    // write, continue waiting for data to read or write.
                     if (newOp != 0) {
                         _threadPool.update(this, current.operation, newOp);
                         return;
@@ -630,10 +644,12 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                         return;
                     }
 
-                    // The connection is validated and doesn't need additional data to be read or written. So unregister it from the thread pool's selector.
+                    // The connection is validated and doesn't need additional data to be read or
+                    // written. So unregister it from the thread pool's selector.
                     _threadPool.unregister(this, current.operation);
 
-                    // The connection starts in the holding state. It will be activated by the connection factory.
+                    // The connection starts in the holding state. It will be activated by the
+                    // connection factory.
                     setState(StateHolding);
                     if (_startCallback != null) {
                         startCB = _startCallback;
@@ -646,14 +662,16 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                     assert (_state <= StateClosingPending);
 
                     //
-                    // We parse messages first, if we receive a close connection message we won't send more messages.
+                    // We parse messages first, if we receive a close connection message we won't
+                    // send more messages.
                     //
                     if ((readyOp & SocketOperation.Read) != 0) {
                         // Optimization: use the thread's stream.
                         info = new MessageInfo(current.stream);
 
                         // At this point, the protocol message is fully read and can therefore be
-                        // decoded by parseMessage. parseMessage returns the operation to wait for readiness next.
+                        // decoded by parseMessage. parseMessage returns the operation to wait for
+                        // readiness next.
                         newOp |= parseMessage(info);
                         upcallCount += info.upcallCount;
                     }
@@ -670,7 +688,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                         }
                     }
 
-                    // If the connection is not closed yet, we update the thread pool selector to wait for readiness of read, write or both operations.
+                    // If the connection is not closed yet, we update the thread pool selector to
+                    // wait for readiness of read, write or both operations.
                     if (_state < StateClosed) {
                         _threadPool.update(this, current.operation, newOp);
                     }
@@ -682,7 +701,9 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
                 _upcallCount += upcallCount;
 
-                // There's something to dispatch so we mark IO as completed to elect a new leader thread and let IO be performed on this new leader thread while this thread continues with dispatching the up-calls.
+                // There's something to dispatch so we mark IO as completed to elect a new leader
+                // thread and let IO be performed on this new leader thread while this thread
+                // continues with dispatching the up-calls.
                 current.ioCompleted();
             } catch (DatagramLimitException ex) // Expected.
             {
@@ -718,7 +739,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         } else {
             if (info != null) {
                 //
-                // Create a new stream for the dispatch instead of using the thread pool's thread stream.
+                // Create a new stream for the dispatch instead of using the thread pool's thread
+                // stream.
                 //
                 assert (info.stream == current.stream);
                 InputStream stream = info.stream;
@@ -766,7 +788,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
         if (info != null) {
             //
-            // Asynchronous replies must be handled outside the thread synchronization, so that nested calls are possible.
+            // Asynchronous replies must be handled outside the thread synchronization, so that
+            // nested calls are possible.
             //
             if (info.outAsync != null) {
                 info.outAsync.invokeCompleted();
@@ -774,7 +797,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
             }
 
             //
-            // Method invocation (or multiple invocations for batch messages) must be done outside the thread synchronization, so that nested calls are possible.
+            // Method invocation (or multiple invocations for batch messages) must be done outside
+            // the thread synchronization, so that nested calls are possible.
             //
             if (info.requestCount > 0) {
                 dispatchAll(
@@ -785,7 +809,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                         info.adapter);
 
                 //
-                // Don't increase dispatchedCount, the dispatch count is decreased when the incoming reply is sent.
+                // Don't increase dispatchedCount, the dispatch count is decreased when the incoming
+                // reply is sent.
                 //
             }
         }
@@ -800,7 +825,9 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                 _upcallCount -= dispatchedCount;
                 if (_upcallCount == 0) {
                     //
-                    // Only initiate shutdown if not already done. It might have already been done if the sent callback or AMI callback was dispatched when the connection was already in the closing state.
+                    // Only initiate shutdown if not already done. It might have already been done
+                    // if the sent callback or AMI callback was dispatched when the connection was
+                    // already in the closing state.
                     //
                     if (_state == StateClosing) {
                         try {
@@ -839,7 +866,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
         //
         // If there are no callbacks to call, we don't call ioCompleted() since
-        // we're not going to call code that will potentially block (this avoids promoting a new leader and unnecessary thread creation, especially if this is called on shutdown).
+        // we're not going to call code that will potentially block (this avoids promoting a new
+        // leader and unnecessary thread creation, especially if this is called on shutdown).
         //
         if (_startCallback == null
                 && _sendStreams.isEmpty()
@@ -928,7 +956,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         if (!_sendStreams.isEmpty()) {
             if (!_writeStream.isEmpty()) {
                 //
-                // Return the stream to the outgoing call. This is important for retriable AMI calls which are not marshaled again.
+                // Return the stream to the outgoing call. This is important for retriable AMI calls
+                // which are not marshaled again.
                 //
                 OutgoingMessage message = _sendStreams.getFirst();
                 _writeStream.swap(message.stream);
@@ -1078,7 +1107,9 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                     && _readHeader // we're not waiting for the remainder of an incoming message
                     && _sendStreams.size() <= 1 // there is at most one pending outgoing message
             ) {
-                // We may become inactive while the peer is back-pressuring us. In this case, we only schedule the inactivity timer if there is no pending outgoing message or the pending outgoing message is a heartbeat.
+                // We may become inactive while the peer is back-pressuring us. In this case, we
+                // only schedule the inactivity timer if there is no pending outgoing message or the
+                // pending outgoing message is a heartbeat.
 
                 // The stream of the first _sendStreams message is in _writeStream.
                 if (_sendStreams.isEmpty()
@@ -1087,8 +1118,14 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                 }
             }
 
-            // We send a heartbeat to the peer to generate a "write" on the connection. This write in turns creates a read on the peer, and resets the peer's idle check timer. When _sendStream is not empty, there is already an outstanding write, so we don't need to send a heartbeat. It's possible the first message of _sendStreams was already sent but not yet removed from _sendStreams: it means the last write occurred very recently, which is good enough with respect to the idle check.
-            // As a result of this optimization, the only possible heartbeat in _sendStreams is the first _sendStreams message.
+            // We send a heartbeat to the peer to generate a "write" on the connection. This write
+            // in turns creates a read on the peer, and resets the peer's idle check timer. When
+            // _sendStream is not empty, there is already an outstanding write, so we don't need to
+            // send a heartbeat. It's possible the first message of _sendStreams was already sent
+            // but not yet removed from _sendStreams: it means the last write occurred very
+            // recently, which is good enough with respect to the idle check.
+            // As a result of this optimization, the only possible heartbeat in _sendStreams is the
+            // first _sendStreams message.
             if (_sendStreams.isEmpty()) {
                 OutputStream os = new OutputStream(Protocol.currentProtocolEncoding);
                 os.writeBlob(Protocol.magic);
@@ -1259,7 +1296,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
         //
         // We must set the new state before we notify requests of any
-        // exceptions. Otherwise new requests may retry on a connection that is not yet marked as closed or closing.
+        // exceptions. Otherwise new requests may retry on a connection that is not yet marked as
+        // closed or closing.
         //
         setState(state);
     }
@@ -1319,7 +1357,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                                 _idleTimeoutTransceiver.enableIdleCheck();
                             }
                         }
-                        // else don't resume reading since we're at or over the _maxDispatches limit.
+                        // else don't resume reading since we're at or over the _maxDispatches
+                        // limit.
                         break;
                     }
 
@@ -1338,7 +1377,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                                 _idleTimeoutTransceiver.disableIdleCheck();
                             }
                         }
-                        // else reads are already disabled because the _maxDispatches limit is reached or exceeded.
+                        // else reads are already disabled because the _maxDispatches limit is
+                        // reached or exceeded.
                         break;
                     }
 
@@ -1363,7 +1403,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                         _batchRequestQueue.destroy(_exception);
 
                         //
-                        // Don't need to close now for connections so only close the transceiver if the selector request it.
+                        // Don't need to close now for connections so only close the transceiver if
+                        // the selector request it.
                         //
                         if (_threadPool.finish(this, false)) {
                             _transceiver.close();
@@ -1636,10 +1677,12 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
      */
     private int sendNextMessage(java.util.List<OutgoingMessage> callbacks) {
         if (_sendStreams.isEmpty()) {
-            // This can occur if no message was being written and the socket write operation was registered with the thread pool (a transceiver read method can request writing data).
+            // This can occur if no message was being written and the socket write operation was
+            // registered with the thread pool (a transceiver read method can request writing data).
             return SocketOperation.None;
         } else if (_state == StateClosingPending && _writeStream.pos() == 0) {
-            // Message wasn't sent, empty the _writeStream, we're not going to send more data because the connection is being closed.
+            // Message wasn't sent, empty the _writeStream, we're not going to send more data
+            // because the connection is being closed.
             OutgoingMessage message = _sendStreams.getFirst();
             _writeStream.swap(message.stream);
             return SocketOperation.None;
@@ -1651,7 +1694,9 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         try {
             while (true) {
                 //
-                // The message that was being sent is sent. We can swap back the write stream buffer to the outgoing message (required for retry) and queue its sent callback (if any).
+                // The message that was being sent is sent. We can swap back the write stream buffer
+                // to the outgoing message (required for retry) and queue its sent callback (if
+                // any).
                 //
                 OutgoingMessage message = _sendStreams.getFirst();
                 _writeStream.swap(message.stream);
@@ -1735,7 +1780,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         assert _state >= StateActive;
         assert _state < StateClosed;
 
-        // Some messages are queued for sending. Just adds the message to the send queue and tell the caller that the message was queued.
+        // Some messages are queued for sending. Just adds the message to the send queue and tell
+        // the caller that the message was queued.
         if (!_sendStreams.isEmpty()) {
             _sendStreams.addLast(message);
             return AsyncStatus.Queued;
@@ -1771,9 +1817,12 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
             return status;
         }
 
-        // The message couldn't be sent right away so we add it to the send stream queue (which is empty) and swap its stream with `_writeStream`. The socket operation returned by the transceiver write is registered with the thread
+        // The message couldn't be sent right away so we add it to the send stream queue (which is
+        // empty) and swap its stream with `_writeStream`. The socket operation returned by the
+        // transceiver write is registered with the thread
         // pool. At this point the message() method will take care of sending the whole
-        // message (held by _writeStream) when the transceiver is ready to write more of the message buffer.
+        // message (held by _writeStream) when the transceiver is ready to write more of the message
+        // buffer.
 
         _writeStream.swap(message.stream);
         _sendStreams.addLast(message);
@@ -1785,7 +1834,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         boolean compressionSupported = false;
         if (compress) {
             //
-            // Don't check whether compression support is available unless the proxy is configured for compression.
+            // Don't check whether compression support is available unless the proxy is configured
+            // for compression.
             //
             compressionSupported = BZip2.supported();
         }
@@ -2026,13 +2076,15 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
             byte compress,
             ObjectAdapter adapter) {
 
-        // Note: In contrast to other private or protected methods, this method must be called *without* the mutex locked.
+        // Note: In contrast to other private or protected methods, this method must be called
+        // *without* the mutex locked.
 
         Object dispatcher = adapter != null ? adapter.dispatchPipeline() : null;
 
         try {
             while (requestCount > 0) {
-                // adapter can be null here, however we never pass a null current.adapter to the application code.
+                // adapter can be null here, however we never pass a null current.adapter to the
+                // application code.
                 var request = new IncomingRequest(requestId, this, adapter, stream);
                 final boolean isTwoWay = !_endpoint.datagram() && requestId != 0;
 
@@ -2073,7 +2125,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         } catch (LocalException ex) {
             dispatchException(ex, requestCount);
         } catch (RuntimeException | Error ex) {
-            // A runtime exception or an error was thrown outside of servant code (i.e., by Ice code). Note that this code does NOT send a response to the client.
+            // A runtime exception or an error was thrown outside of servant code (i.e., by Ice
+            // code). Note that this code does NOT send a response to the client.
             var uex = new UnknownException(ex);
             var sw = new java.io.StringWriter();
             var pw = new java.io.PrintWriter(sw);
@@ -2110,7 +2163,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                         if (_state == StateActive
                                 && _maxDispatches > 0
                                 && _dispatchCount == _maxDispatches) {
-                            // Resume reading if the connection is active and the dispatch count is about to be less than _maxDispatches.
+                            // Resume reading if the connection is active and the dispatch count is
+                            // about to be less than _maxDispatches.
                             _threadPool.update(this, SocketOperation.None, SocketOperation.Read);
                             if (_idleTimeoutTransceiver != null) {
                                 _idleTimeoutTransceiver.enableIdleCheck();
@@ -2137,7 +2191,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
     private void dispatchException(LocalException ex, int requestCount) {
         boolean finished = false;
         synchronized (this) {
-            // Fatal exception while dispatching a request. Since sendResponse isn't called in case of a fatal exception we decrement _upcallCount here.
+            // Fatal exception while dispatching a request. Since sendResponse isn't called in case
+            // of a fatal exception we decrement _upcallCount here.
 
             setState(StateClosed, ex);
 
@@ -2277,7 +2332,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
     private synchronized void closeTimedOut() {
         if (_state < StateClosed) {
-            // We don't use setState(state, exception) because we want to overwrite the exception set by a graceful closure.
+            // We don't use setState(state, exception) because we want to overwrite the exception
+            // set by a graceful closure.
             _exception = new CloseTimeoutException();
             setState(StateClosed);
         }
@@ -2430,24 +2486,31 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
     private InputStream _readStream;
 
     // When _readHeader is true, the next bytes we'll read are the header of a new
-    // message. When false, we're reading next the remainder of a message that was already partially received.
+    // message. When false, we're reading next the remainder of a message that was already partially
+    // received.
     private boolean _readHeader;
 
-    // Contains the message which is being sent. The write stream buffer is empty if no message is being sent.
+    // Contains the message which is being sent. The write stream buffer is empty if no message is
+    // being sent.
     private OutputStream _writeStream;
 
     private com.zeroc.Ice.Instrumentation.ConnectionObserver _observer;
     private int _readStreamPos;
     private int _writeStreamPos;
 
-    // The upcall count keeps track of the number of dispatches, AMI (response) continuations, sent callbacks and connection establishment callbacks that have been started (or are about to be started) by a thread of the thread pool associated with this connection, and have not completed yet. All these operations except the connection establishment callbacks execute application code or code generated from Slice definitions.
+    // The upcall count keeps track of the number of dispatches, AMI (response) continuations, sent
+    // callbacks and connection establishment callbacks that have been started (or are about to be
+    // started) by a thread of the thread pool associated with this connection, and have not
+    // completed yet. All these operations except the connection establishment callbacks execute
+    // application code or code generated from Slice definitions.
     private int _upcallCount;
 
     // The number of outstanding dispatches. Maintained only while state is
     // StateActive or StateHolding.
     private int _dispatchCount;
 
-    // When we dispatch _maxDispatches concurrent requests, we stop reading the connection to back-pressure the peer. _maxDispatches <= 0 means no limit.
+    // When we dispatch _maxDispatches concurrent requests, we stop reading the connection to
+    // back-pressure the peer. _maxDispatches <= 0 means no limit.
     private final int _maxDispatches;
 
     private int _state; // The current state.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -21,8 +21,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
     public void start(StartCallback callback) {
         try {
             synchronized (this) {
-                // The connection might already be closed if the communicator
-                // was destroyed.
+                // The connection might already be closed if the communicator was destroyed.
                 if (_state >= StateClosed) {
                     assert (_exception != null);
                     throw (LocalException) _exception.fillInStackTrace();
@@ -54,8 +53,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
     public void startAndWait() throws InterruptedException {
         try {
             synchronized (this) {
-                // The connection might already be closed if the communicator
-                // was destroyed.
+                // The connection might already be closed if the communicator was destroyed.
                 if (_state >= StateClosed) {
                     assert (_exception != null);
                     throw (LocalException) _exception.fillInStackTrace();
@@ -191,8 +189,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
     public synchronized void waitUntilFinished() throws InterruptedException {
         //
-        // We wait indefinitely until the connection is finished and all
-        // outstanding requests are completed. Otherwise we couldn't
+        // We wait indefinitely until the connection is finished and all outstanding requests are completed. Otherwise we couldn't
         // guarantee that there are no outstanding calls when deactivate()
         // is called on the servant locators.
         //
@@ -238,9 +235,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
         if (_exception != null) {
             //
-            // If the connection is closed before we even have a chance
-            // to send our request, we always try to send the request
-            // again.
+            // If the connection is closed before we even have a chance to send our request, we always try to send the request again.
             //
             throw new RetryException((LocalException) _exception.fillInStackTrace());
         }
@@ -249,14 +244,12 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         assert (_state < StateClosing);
 
         //
-        // Ensure the message isn't bigger than what we can send with the
-        // transport.
+        // Ensure the message isn't bigger than what we can send with the transport.
         //
         _transceiver.checkSendSize(os.getBuffer());
 
         //
-        // Notify the request that it's cancelable with this connection.
-        // This will throw if the request is canceled.
+        // Notify the request that it's cancelable with this connection. This will throw if the request is canceled.
         //
         out.cancelable(this);
 
@@ -365,8 +358,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                     setState(StateClosed, ex);
                 } else {
                     //
-                    // If the request is being sent, don't remove it from the send
-                    // streams, it will be removed once the sending is finished.
+                    // If the request is being sent, don't remove it from the send streams, it will be removed once the sending is finished.
                     //
                     // Note that since we swapped the message stream to _writeStream
                     // it's fine if the OutgoingAsync output stream is released (and
@@ -428,8 +420,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         }
 
         if (adapter != null) {
-            // Go through the adapter to set the adapter on this connection to ensure the
-            // object adapter is still active and to ensure proper locking order.
+            // Go through the adapter to set the adapter on this connection to ensure the object adapter is still active and to ensure proper locking order.
             adapter.setAdapterOnConnection(this);
         } else {
             synchronized (this) {
@@ -441,9 +432,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         }
 
         //
-        // We never change the thread pool with which we were
-        // initially registered, even if we add or remove an object
-        // adapter.
+        // We never change the thread pool with which we were initially registered, even if we add or remove an object adapter.
         //
     }
 
@@ -461,8 +450,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
     @Override
     public ObjectPrx createProxy(Identity ident) {
         //
-        // Create a reference and return a reverse proxy for this
-        // reference.
+        // Create a reference and return a reverse proxy for this reference.
         //
         var ref = _instance.referenceFactory().create(ident, this);
         return (ref == null) ? null : new com.zeroc.Ice._ObjectPrxI(ref);
@@ -499,8 +487,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                 int writeOp = SocketOperation.None;
                 int readOp = SocketOperation.None;
 
-                // If writes are ready, write the data from the connection's write buffer
-                // (_writeStream)
+                // If writes are ready, write the data from the connection's write buffer (_writeStream)
                 if ((current.operation & SocketOperation.Write) != 0) {
                     final Buffer buf = _writeStream.getBuffer();
                     if (_observer != null) {
@@ -515,8 +502,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                 // If reads are ready, read the data into the connection's read buffer
                 // (_readStream). The data is read until:
                 // - the full message is read (the transport read returns SocketOperationNone)
-                // and the read buffer is fully filled
-                // - the read operation on the transport can't continue without blocking
+                // and the read buffer is fully filled - the read operation on the transport can't continue without blocking
                 if ((current.operation & SocketOperation.Read) != 0) {
                     while (true) {
                         final Buffer buf = _readStream.getBuffer();
@@ -534,9 +520,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                             observerFinishRead(buf);
                         }
 
-                        // If read header is true, we're reading a new Ice protocol message and we
-                        // need
-                        // to read the message header.
+                        // If read header is true, we're reading a new Ice protocol message and we need to read the message header.
                         if (_readHeader) {
                             // The next read will read the remainder of the message.
                             _readHeader = false;
@@ -554,9 +538,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                             //
                             _validated = true;
 
-                            // Full header should be read because the size of _readStream is always
-                            // headerSize (14) when reading a new message (see the code that sets
-                            // _readHeader = true).
+                            // Full header should be read because the size of _readStream is always headerSize (14) when reading a new message (see the code that sets _readHeader = true).
                             int pos = _readStream.pos();
                             if (pos < Protocol.headerSize) {
                                 //
@@ -623,9 +605,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                     }
                 }
 
-                // readOp and writeOp are set to the operations that the transport read or write
-                // calls from above returned. They indicate which operations will need to be
-                // monitored by the thread pool's selector when this method returns.
+                // readOp and writeOp are set to the operations that the transport read or write calls from above returned. They indicate which operations will need to be monitored by the thread pool's selector when this method returns.
                 int newOp = readOp | writeOp;
 
                 // Operations that are ready. For example, if message was called with
@@ -634,8 +614,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                 int readyOp = current.operation & ~newOp;
 
                 if (_state <= StateNotValidated) {
-                    // If the connection is still not validated and there's still data to read or
-                    // write, continue waiting for data to read or write.
+                    // If the connection is still not validated and there's still data to read or write, continue waiting for data to read or write.
                     if (newOp != 0) {
                         _threadPool.update(this, current.operation, newOp);
                         return;
@@ -651,12 +630,10 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                         return;
                     }
 
-                    // The connection is validated and doesn't need additional data to be read or
-                    // written. So unregister it from the thread pool's selector.
+                    // The connection is validated and doesn't need additional data to be read or written. So unregister it from the thread pool's selector.
                     _threadPool.unregister(this, current.operation);
 
-                    // The connection starts in the holding state. It will be activated by the
-                    // connection factory.
+                    // The connection starts in the holding state. It will be activated by the connection factory.
                     setState(StateHolding);
                     if (_startCallback != null) {
                         startCB = _startCallback;
@@ -669,16 +646,14 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                     assert (_state <= StateClosingPending);
 
                     //
-                    // We parse messages first, if we receive a close
-                    // connection message we won't send more messages.
+                    // We parse messages first, if we receive a close connection message we won't send more messages.
                     //
                     if ((readyOp & SocketOperation.Read) != 0) {
                         // Optimization: use the thread's stream.
                         info = new MessageInfo(current.stream);
 
                         // At this point, the protocol message is fully read and can therefore be
-                        // decoded by parseMessage. parseMessage returns the operation to wait for
-                        // readiness next.
+                        // decoded by parseMessage. parseMessage returns the operation to wait for readiness next.
                         newOp |= parseMessage(info);
                         upcallCount += info.upcallCount;
                     }
@@ -695,9 +670,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                         }
                     }
 
-                    // If the connection is not closed yet, we update the thread pool selector to
-                    // wait
-                    // for readiness of read, write or both operations.
+                    // If the connection is not closed yet, we update the thread pool selector to wait for readiness of read, write or both operations.
                     if (_state < StateClosed) {
                         _threadPool.update(this, current.operation, newOp);
                     }
@@ -709,9 +682,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
                 _upcallCount += upcallCount;
 
-                // There's something to dispatch so we mark IO as completed to elect a new
-                // leader thread and let IO be performed on this new leader thread while
-                // this thread continues with dispatching the up-calls.
+                // There's something to dispatch so we mark IO as completed to elect a new leader thread and let IO be performed on this new leader thread while this thread continues with dispatching the up-calls.
                 current.ioCompleted();
             } catch (DatagramLimitException ex) // Expected.
             {
@@ -747,8 +718,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         } else {
             if (info != null) {
                 //
-                // Create a new stream for the dispatch instead of using the
-                // thread pool's thread stream.
+                // Create a new stream for the dispatch instead of using the thread pool's thread stream.
                 //
                 assert (info.stream == current.stream);
                 InputStream stream = info.stream;
@@ -777,8 +747,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         int dispatchedCount = 0;
 
         //
-        // Notify the factory that the connection establishment and
-        // validation has completed.
+        // Notify the factory that the connection establishment and validation has completed.
         //
         if (startCB != null) {
             startCB.connectionStartCompleted(this);
@@ -797,8 +766,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
         if (info != null) {
             //
-            // Asynchronous replies must be handled outside the thread
-            // synchronization, so that nested calls are possible.
+            // Asynchronous replies must be handled outside the thread synchronization, so that nested calls are possible.
             //
             if (info.outAsync != null) {
                 info.outAsync.invokeCompleted();
@@ -806,9 +774,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
             }
 
             //
-            // Method invocation (or multiple invocations for batch messages)
-            // must be done outside the thread synchronization, so that nested
-            // calls are possible.
+            // Method invocation (or multiple invocations for batch messages) must be done outside the thread synchronization, so that nested calls are possible.
             //
             if (info.requestCount > 0) {
                 dispatchAll(
@@ -819,8 +785,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                         info.adapter);
 
                 //
-                // Don't increase dispatchedCount, the dispatch count is
-                // decreased when the incoming reply is sent.
+                // Don't increase dispatchedCount, the dispatch count is decreased when the incoming reply is sent.
                 //
             }
         }
@@ -835,10 +800,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                 _upcallCount -= dispatchedCount;
                 if (_upcallCount == 0) {
                     //
-                    // Only initiate shutdown if not already done. It might
-                    // have already been done if the sent callback or AMI
-                    // callback was dispatched when the connection was already
-                    // in the closing state.
+                    // Only initiate shutdown if not already done. It might have already been done if the sent callback or AMI callback was dispatched when the connection was already in the closing state.
                     //
                     if (_state == StateClosing) {
                         try {
@@ -877,9 +839,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
         //
         // If there are no callbacks to call, we don't call ioCompleted() since
-        // we're not going to call code that will potentially block (this avoids
-        // promoting a new leader and unnecessary thread creation, especially if
-        // this is called on shutdown).
+        // we're not going to call code that will potentially block (this avoids promoting a new leader and unnecessary thread creation, especially if this is called on shutdown).
         //
         if (_startCallback == null
                 && _sendStreams.isEmpty()
@@ -968,8 +928,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         if (!_sendStreams.isEmpty()) {
             if (!_writeStream.isEmpty()) {
                 //
-                // Return the stream to the outgoing call. This is important for
-                // retriable AMI calls which are not marshaled again.
+                // Return the stream to the outgoing call. This is important for retriable AMI calls which are not marshaled again.
                 //
                 OutgoingMessage message = _sendStreams.getFirst();
                 _writeStream.swap(message.stream);
@@ -1011,8 +970,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
         //
         // This must be done last as this will cause waitUntilFinished() to
-        // return (and communicator objects such as the timer might be destroyed
-        // too).
+        // return (and communicator objects such as the timer might be destroyed too).
         //
         boolean finished = false;
         synchronized (this) {
@@ -1120,9 +1078,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                     && _readHeader // we're not waiting for the remainder of an incoming message
                     && _sendStreams.size() <= 1 // there is at most one pending outgoing message
             ) {
-                // We may become inactive while the peer is back-pressuring us. In this case, we
-                // only schedule the inactivity timer if there is no pending outgoing message or
-                // the pending outgoing message is a heartbeat.
+                // We may become inactive while the peer is back-pressuring us. In this case, we only schedule the inactivity timer if there is no pending outgoing message or the pending outgoing message is a heartbeat.
 
                 // The stream of the first _sendStreams message is in _writeStream.
                 if (_sendStreams.isEmpty()
@@ -1131,14 +1087,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                 }
             }
 
-            // We send a heartbeat to the peer to generate a "write" on the connection. This
-            // write in turns creates a read on the peer, and resets the peer's idle check timer.
-            // When _sendStream is not empty, there is already an outstanding write, so we don't
-            // need to send a heartbeat. It's possible the first message of _sendStreams was
-            // already sent but not yet removed from _sendStreams: it means the last write
-            // occurred very recently, which is good enough with respect to the idle check.
-            // As a result of this optimization, the only possible heartbeat in _sendStreams
-            // is the first _sendStreams message.
+            // We send a heartbeat to the peer to generate a "write" on the connection. This write in turns creates a read on the peer, and resets the peer's idle check timer. When _sendStream is not empty, there is already an outstanding write, so we don't need to send a heartbeat. It's possible the first message of _sendStreams was already sent but not yet removed from _sendStreams: it means the last write occurred very recently, which is good enough with respect to the idle check.
+            // As a result of this optimization, the only possible heartbeat in _sendStreams is the first _sendStreams message.
             if (_sendStreams.isEmpty()) {
                 OutputStream os = new OutputStream(Protocol.currentProtocolEncoding);
                 os.writeBlob(Protocol.magic);
@@ -1309,8 +1259,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
         //
         // We must set the new state before we notify requests of any
-        // exceptions. Otherwise new requests may retry on a
-        // connection that is not yet marked as closed or closing.
+        // exceptions. Otherwise new requests may retry on a connection that is not yet marked as closed or closing.
         //
         setState(state);
     }
@@ -1370,16 +1319,14 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                                 _idleTimeoutTransceiver.enableIdleCheck();
                             }
                         }
-                        // else don't resume reading since we're at or over the _maxDispatches
-                        // limit.
+                        // else don't resume reading since we're at or over the _maxDispatches limit.
                         break;
                     }
 
                 case StateHolding:
                     {
                         //
-                        // Can only switch from active or not validated to
-                        // holding.
+                        // Can only switch from active or not validated to holding.
                         //
                         if (_state != StateActive && _state != StateNotValidated) {
                             return;
@@ -1391,9 +1338,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                                 _idleTimeoutTransceiver.disableIdleCheck();
                             }
                         }
-                        // else reads are already disabled because the _maxDispatches limit is
-                        // reached or
-                        // exceeded.
+                        // else reads are already disabled because the _maxDispatches limit is reached or exceeded.
                         break;
                     }
 
@@ -1418,8 +1363,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                         _batchRequestQueue.destroy(_exception);
 
                         //
-                        // Don't need to close now for connections so only close the transceiver
-                        // if the selector request it.
+                        // Don't need to close now for connections so only close the transceiver if the selector request it.
                         //
                         if (_threadPool.finish(this, false)) {
                             _transceiver.close();
@@ -1530,8 +1474,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         }
 
         //
-        // Update the connection description once the transceiver is
-        // initialized.
+        // Update the connection description once the transceiver is initialized.
         //
         _desc = _transceiver.toString();
         _initialized = true;
@@ -1553,8 +1496,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                     Protocol.currentProtocolEncoding.ice_writeMembers(_writeStream);
                     _writeStream.writeByte(Protocol.validateConnectionMsg);
                     _writeStream.writeByte((byte) 0); // Compression status
-                    // (always zero for
-                    // validate connection).
+                    // (always zero for validate connection).
                     _writeStream.writeInt(Protocol.headerSize); // Message size.
                     TraceUtil.traceSend(_writeStream, _instance, this, _logger, _traceLevels);
                     _writeStream.prepareWrite();
@@ -1694,13 +1636,10 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
      */
     private int sendNextMessage(java.util.List<OutgoingMessage> callbacks) {
         if (_sendStreams.isEmpty()) {
-            // This can occur if no message was being written and the socket write operation
-            // was registered with the thread pool (a transceiver read method can request
-            // writing data).
+            // This can occur if no message was being written and the socket write operation was registered with the thread pool (a transceiver read method can request writing data).
             return SocketOperation.None;
         } else if (_state == StateClosingPending && _writeStream.pos() == 0) {
-            // Message wasn't sent, empty the _writeStream, we're not going to send more
-            // data because the connection is being closed.
+            // Message wasn't sent, empty the _writeStream, we're not going to send more data because the connection is being closed.
             OutgoingMessage message = _sendStreams.getFirst();
             _writeStream.swap(message.stream);
             return SocketOperation.None;
@@ -1712,9 +1651,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         try {
             while (true) {
                 //
-                // The message that was being sent is sent. We can swap back the write
-                // stream buffer to the outgoing message (required for retry) and queue its
-                // sent callback (if any).
+                // The message that was being sent is sent. We can swap back the write stream buffer to the outgoing message (required for retry) and queue its sent callback (if any).
                 //
                 OutgoingMessage message = _sendStreams.getFirst();
                 _writeStream.swap(message.stream);
@@ -1731,8 +1668,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                 }
 
                 //
-                // If we are in the closed state or if the close is
-                // pending, don't continue sending.
+                // If we are in the closed state or if the close is pending, don't continue sending.
                 //
                 // This can occur if parseMessage (called before
                 // sendNextMessage by message()) closes the connection.
@@ -1799,9 +1735,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         assert _state >= StateActive;
         assert _state < StateClosed;
 
-        // Some messages are queued for sending. Just adds the message to the send queue
-        // and
-        // tell the caller that the message was queued.
+        // Some messages are queued for sending. Just adds the message to the send queue and tell the caller that the message was queued.
         if (!_sendStreams.isEmpty()) {
             _sendStreams.addLast(message);
             return AsyncStatus.Queued;
@@ -1837,12 +1771,9 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
             return status;
         }
 
-        // The message couldn't be sent right away so we add it to the send stream
-        // queue (which is empty) and swap its stream with `_writeStream`. The socket
-        // operation returned by the transceiver write is registered with the thread
+        // The message couldn't be sent right away so we add it to the send stream queue (which is empty) and swap its stream with `_writeStream`. The socket operation returned by the transceiver write is registered with the thread
         // pool. At this point the message() method will take care of sending the whole
-        // message (held by _writeStream) when the transceiver is ready to write more
-        // of the message buffer.
+        // message (held by _writeStream) when the transceiver is ready to write more of the message buffer.
 
         _writeStream.swap(message.stream);
         _sendStreams.addLast(message);
@@ -1854,8 +1785,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         boolean compressionSupported = false;
         if (compress) {
             //
-            // Don't check whether compression support is available unless the
-            // proxy is configured for compression.
+            // Don't check whether compression support is available unless the proxy is configured for compression.
             //
             compressionSupported = BZip2.supported();
         }
@@ -2096,18 +2026,13 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
             byte compress,
             ObjectAdapter adapter) {
 
-        // Note: In contrast to other private or protected methods, this method must be
-        // called
-        // *without*
-        // the mutex locked.
+        // Note: In contrast to other private or protected methods, this method must be called *without* the mutex locked.
 
         Object dispatcher = adapter != null ? adapter.dispatchPipeline() : null;
 
         try {
             while (requestCount > 0) {
-                // adapter can be null here, however we never pass a null current.adapter to the
-                // application
-                // code.
+                // adapter can be null here, however we never pass a null current.adapter to the application code.
                 var request = new IncomingRequest(requestId, this, adapter, stream);
                 final boolean isTwoWay = !_endpoint.datagram() && requestId != 0;
 
@@ -2148,10 +2073,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         } catch (LocalException ex) {
             dispatchException(ex, requestCount);
         } catch (RuntimeException | Error ex) {
-            // A runtime exception or an error was thrown outside of servant code (i.e., by
-            // Ice
-            // code).
-            // Note that this code does NOT send a response to the client.
+            // A runtime exception or an error was thrown outside of servant code (i.e., by Ice code). Note that this code does NOT send a response to the client.
             var uex = new UnknownException(ex);
             var sw = new java.io.StringWriter();
             var pw = new java.io.PrintWriter(sw);
@@ -2188,9 +2110,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                         if (_state == StateActive
                                 && _maxDispatches > 0
                                 && _dispatchCount == _maxDispatches) {
-                            // Resume reading if the connection is active and the dispatch count is
-                            // about to be
-                            // less than _maxDispatches.
+                            // Resume reading if the connection is active and the dispatch count is about to be less than _maxDispatches.
                             _threadPool.update(this, SocketOperation.None, SocketOperation.Read);
                             if (_idleTimeoutTransceiver != null) {
                                 _idleTimeoutTransceiver.enableIdleCheck();
@@ -2217,8 +2137,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
     private void dispatchException(LocalException ex, int requestCount) {
         boolean finished = false;
         synchronized (this) {
-            // Fatal exception while dispatching a request. Since sendResponse isn't
-            // called in case of a fatal exception we decrement _upcallCount here.
+            // Fatal exception while dispatching a request. Since sendResponse isn't called in case of a fatal exception we decrement _upcallCount here.
 
             setState(StateClosed, ex);
 
@@ -2358,10 +2277,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
     private synchronized void closeTimedOut() {
         if (_state < StateClosed) {
-            // We don't use setState(state, exception) because we want to overwrite the
-            // exception
-            // set by a
-            // graceful closure.
+            // We don't use setState(state, exception) because we want to overwrite the exception set by a graceful closure.
             _exception = new CloseTimeoutException();
             setState(StateClosed);
         }
@@ -2414,8 +2330,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         }
     }
 
-    // Only public so that tests can initiate a closure without blocking on it to
-    // complete.
+    // Only public so that tests can initiate a closure without blocking on it to complete.
     public synchronized void doApplicationClose() {
         assert (_state < StateClosing);
         setState(
@@ -2509,48 +2424,30 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
     private java.util.LinkedList<OutgoingMessage> _sendStreams = new java.util.LinkedList<>();
 
-    // Contains the message which is being received. If the connection is waiting to
-    // receive a
+    // Contains the message which is being received. If the connection is waiting to receive a
     // message (_readHeader == true), its size is Protocol.headerSize. Otherwise,
-    // its size is
-    // the message size specified in the received message header.
+    // its size is the message size specified in the received message header.
     private InputStream _readStream;
 
     // When _readHeader is true, the next bytes we'll read are the header of a new
-    // message. When
-    // false, we're reading
-    // next the remainder of a message that was already partially received.
+    // message. When false, we're reading next the remainder of a message that was already partially received.
     private boolean _readHeader;
 
-    // Contains the message which is being sent. The write stream buffer is empty if
-    // no message
-    // is being sent.
+    // Contains the message which is being sent. The write stream buffer is empty if no message is being sent.
     private OutputStream _writeStream;
 
     private com.zeroc.Ice.Instrumentation.ConnectionObserver _observer;
     private int _readStreamPos;
     private int _writeStreamPos;
 
-    // The upcall count keeps track of the number of dispatches, AMI (response)
-    // continuations,
-    // sent callbacks and connection establishment callbacks that have been started
-    // (or are about
-    // to be started) by a thread of the thread pool associated with this
-    // connection, and have
-    // not completed yet. All these operations except the connection establishment
-    // callbacks
-    // execute application code or code generated from Slice definitions.
+    // The upcall count keeps track of the number of dispatches, AMI (response) continuations, sent callbacks and connection establishment callbacks that have been started (or are about to be started) by a thread of the thread pool associated with this connection, and have not completed yet. All these operations except the connection establishment callbacks execute application code or code generated from Slice definitions.
     private int _upcallCount;
 
     // The number of outstanding dispatches. Maintained only while state is
-    // StateActive or
-    // StateHolding.
+    // StateActive or StateHolding.
     private int _dispatchCount;
 
-    // When we dispatch _maxDispatches concurrent requests, we stop reading the
-    // connection to
-    // back-pressure the peer.
-    // _maxDispatches <= 0 means no limit.
+    // When we dispatch _maxDispatches concurrent requests, we stop reading the connection to back-pressure the peer. _maxDispatches <= 0 means no limit.
     private final int _maxDispatches;
 
     private int _state; // The current state.
@@ -2559,8 +2456,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
     private boolean _validated = false;
 
     // When true, the application called close and Connection must close the
-    // connection when it
-    // receives the reply for the last outstanding invocation.
+    // connection when it receives the reply for the last outstanding invocation.
     private boolean _closeRequested;
 
     private ProtocolVersion _readProtocol = new ProtocolVersion();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Current.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Current.java
@@ -188,7 +188,8 @@ public final class Current implements Cloneable {
         OutputStream ostr;
 
         if (requestId != 0) {
-            // The default class format doesn't matter since we always encode user exceptions in Sliced format.;
+            // The default class format doesn't matter since we always encode user exceptions in
+            // Sliced format.;
             ostr =
                     new OutputStream(
                             Protocol.currentProtocolEncoding, FormatType.SlicedFormat, false);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Current.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Current.java
@@ -62,8 +62,7 @@ public final class Current implements Cloneable {
             int requestId,
             EncodingVersion encoding) {
         // We may occasionally construct a Current with a null adapter, however we never
-        // return such
-        // a current to the application code.
+        // return such a current to the application code.
         Objects.requireNonNull(id);
         Objects.requireNonNull(facet);
         Objects.requireNonNull(operation);
@@ -189,9 +188,7 @@ public final class Current implements Cloneable {
         OutputStream ostr;
 
         if (requestId != 0) {
-            // The default class format doesn't matter since we always encode user
-            // exceptions in
-            // Sliced format.;
+            // The default class format doesn't matter since we always encode user exceptions in Sliced format.;
             ostr =
                     new OutputStream(
                             Protocol.currentProtocolEncoding, FormatType.SlicedFormat, false);
@@ -267,8 +264,7 @@ public final class Current implements Cloneable {
                 // and we don't use the dispatchExceptionMessage.
             } else {
                 // If the exception is a DispatchException, we keep its message as-is; otherwise, we
-                // create a custom
-                // message. This message doesn't include the stack trace.
+                // create a custom message. This message doesn't include the stack trace.
                 if (dispatchExceptionMessage == null) {
                     dispatchExceptionMessage = "Dispatch failed with " + exc.toString();
                 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointHostResolver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointHostResolver.java
@@ -34,7 +34,9 @@ class EndpointHostResolver {
             final IPEndpointI endpoint,
             final EndpointI_connectors callback) {
         //
-        // TODO: Optimize to avoid the lookup if the given host is a textual IPv4 or IPv6 address. This requires implementing parsing of IPv4/IPv6 addresses (Java does not provide such methods).
+        // TODO: Optimize to avoid the lookup if the given host is a textual IPv4 or IPv6 address.
+        // This requires implementing parsing of IPv4/IPv6 addresses (Java does not provide such
+        // methods).
         //
 
         assert (!_destroyed);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointHostResolver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointHostResolver.java
@@ -34,9 +34,7 @@ class EndpointHostResolver {
             final IPEndpointI endpoint,
             final EndpointI_connectors callback) {
         //
-        // TODO: Optimize to avoid the lookup if the given host is a textual IPv4 or IPv6
-        // address. This requires implementing parsing of IPv4/IPv6 addresses (Java does
-        // not provide such methods).
+        // TODO: Optimize to avoid the lookup if the given host is a textual IPv4 or IPv6 address. This requires implementing parsing of IPv4/IPv6 addresses (Java does not provide such methods).
         //
 
         assert (!_destroyed);
@@ -117,8 +115,7 @@ class EndpointHostResolver {
             _destroyed = true;
 
             //
-            // Shutdown the executor. No new tasks will be accepted.
-            // Existing tasks will execute.
+            // Shutdown the executor. No new tasks will be accepted. Existing tasks will execute.
             //
             _executor.shutdown();
         }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointI.java
@@ -22,8 +22,7 @@ public abstract class EndpointI implements Endpoint, Comparable<EndpointI> {
         //
         // WARNING: Certain features, such as proxy validation in Glacier2,
         // depend on the format of proxy strings. Changes to toString() and
-        // methods called to generate parts of the reference string could break
-        // these features. Please review for all features that depend on the
+        // methods called to generate parts of the reference string could break these features. Please review for all features that depend on the
         // format of proxyToString() before changing this and related code.
         //
         return protocol() + options();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointI.java
@@ -22,7 +22,8 @@ public abstract class EndpointI implements Endpoint, Comparable<EndpointI> {
         //
         // WARNING: Certain features, such as proxy validation in Glacier2,
         // depend on the format of proxy strings. Changes to toString() and
-        // methods called to generate parts of the reference string could break these features. Please review for all features that depend on the
+        // methods called to generate parts of the reference string could break these features.
+        // Please review for all features that depend on the
         // format of proxyToString() before changing this and related code.
         //
         return protocol() + options();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ErrorObserverMiddleware.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ErrorObserverMiddleware.java
@@ -41,16 +41,20 @@ public final class ErrorObserverMiddleware implements Object {
                                 } else if (exception
                                                 instanceof CompletionException completionException
                                         && completionException.getCause() instanceof Error error) {
-                                    // This can occur when the closure of a parent completion stage throws an error.
+                                    // This can occur when the closure of a parent completion stage
+                                    // throws an error.
                                     _errorObserver.accept(error);
                                 }
 
                                 if (exception instanceof RuntimeException runtimeException) {
-                                    // Rethrow as-is. Note that Java does not wrap CompletionException in CompletionException.
+                                    // Rethrow as-is. Note that Java does not wrap
+                                    // CompletionException in CompletionException.
                                     throw runtimeException;
                                 }
 
-                                // exception is a Throwable that is not an Error or a RuntimeException. We can't throw it so we marshal this exception into a response.
+                                // exception is a Throwable that is not an Error or a
+                                // RuntimeException. We can't throw it so we marshal this exception
+                                // into a response.
                                 return request.current.createOutgoingResponse(exception);
                             });
         } catch (Error error) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ErrorObserverMiddleware.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ErrorObserverMiddleware.java
@@ -41,20 +41,16 @@ public final class ErrorObserverMiddleware implements Object {
                                 } else if (exception
                                                 instanceof CompletionException completionException
                                         && completionException.getCause() instanceof Error error) {
-                                    // This can occur when the closure of a parent completion stage
-                                    // throws an error.
+                                    // This can occur when the closure of a parent completion stage throws an error.
                                     _errorObserver.accept(error);
                                 }
 
                                 if (exception instanceof RuntimeException runtimeException) {
-                                    // Rethrow as-is. Note that Java does not wrap
-                                    // CompletionException in CompletionException.
+                                    // Rethrow as-is. Note that Java does not wrap CompletionException in CompletionException.
                                     throw runtimeException;
                                 }
 
-                                // exception is a Throwable that is not an Error or a
-                                // RuntimeException. We can't
-                                // throw it so we marshal this exception into a response.
+                                // exception is a Throwable that is not an Error or a RuntimeException. We can't throw it so we marshal this exception into a response.
                                 return request.current.createOutgoingResponse(exception);
                             });
         } catch (Error error) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/FixedReference.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/FixedReference.java
@@ -197,8 +197,7 @@ public class FixedReference extends Reference {
         }
 
         //
-        // If a secure connection is requested or secure overrides is set,
-        // check if the connection is secure.
+        // If a secure connection is requested or secure overrides is set, check if the connection is secure.
         //
         boolean secure;
         DefaultsAndOverrides defaultsAndOverrides = getInstance().defaultsAndOverrides();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/FixedReference.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/FixedReference.java
@@ -197,7 +197,8 @@ public class FixedReference extends Reference {
         }
 
         //
-        // If a secure connection is requested or secure overrides is set, check if the connection is secure.
+        // If a secure connection is requested or secure overrides is set, check if the connection
+        // is secure.
         //
         boolean secure;
         DefaultsAndOverrides defaultsAndOverrides = getInstance().defaultsAndOverrides();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IPEndpointI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IPEndpointI.java
@@ -137,8 +137,7 @@ abstract class IPEndpointI extends EndpointI {
         //
         // WARNING: Certain features, such as proxy validation in Glacier2,
         // depend on the format of proxy strings. Changes to toString() and
-        // methods called to generate parts of the reference string could break
-        // these features. Please review for all features that depend on the
+        // methods called to generate parts of the reference string could break these features. Please review for all features that depend on the
         // format of proxyToString() before changing this and related code.
         //
         String s = "";

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IPEndpointI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IPEndpointI.java
@@ -137,7 +137,8 @@ abstract class IPEndpointI extends EndpointI {
         //
         // WARNING: Certain features, such as proxy validation in Glacier2,
         // depend on the format of proxy strings. Changes to toString() and
-        // methods called to generate parts of the reference string could break these features. Please review for all features that depend on the
+        // methods called to generate parts of the reference string could break these features.
+        // Please review for all features that depend on the
         // format of proxyToString() before changing this and related code.
         //
         String s = "";

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IdleTimeoutTransceiverDecorator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IdleTimeoutTransceiverDecorator.java
@@ -68,7 +68,8 @@ final class IdleTimeoutTransceiverDecorator implements Transceiver {
     @Override
     public int read(Buffer buf) {
         if (_idleCheckEnabled) {
-            // We don't want the idle check to run while we're reading, so we reschedule it before reading.
+            // We don't want the idle check to run while we're reading, so we reschedule it before
+            // reading.
             rescheduleReadTimer();
         }
         return _decoratee.read(buf);
@@ -137,7 +138,8 @@ final class IdleTimeoutTransceiverDecorator implements Transceiver {
     }
 
     void scheduleHeartbeat() {
-        // Reschedule because the connection establishment may have already written to the connection and scheduled a heartbeat.
+        // Reschedule because the connection establishment may have already written to the
+        // connection and scheduled a heartbeat.
         rescheduleWriteTimer();
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IdleTimeoutTransceiverDecorator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IdleTimeoutTransceiverDecorator.java
@@ -7,8 +7,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 // Decorates Transceiver to send heartbeats and optionally detect when no byte is received/read for
-// a while.
-// This decorator must not be applied on UDP connections.
+// a while. This decorator must not be applied on UDP connections.
 final class IdleTimeoutTransceiverDecorator implements Transceiver {
     private final Transceiver _decoratee;
     private final int _idleTimeout;
@@ -69,8 +68,7 @@ final class IdleTimeoutTransceiverDecorator implements Transceiver {
     @Override
     public int read(Buffer buf) {
         if (_idleCheckEnabled) {
-            // We don't want the idle check to run while we're reading, so we reschedule it before
-            // reading.
+            // We don't want the idle check to run while we're reading, so we reschedule it before reading.
             rescheduleReadTimer();
         }
         return _decoratee.read(buf);
@@ -139,8 +137,7 @@ final class IdleTimeoutTransceiverDecorator implements Transceiver {
     }
 
     void scheduleHeartbeat() {
-        // Reschedule because the connection establishment may have already written to the
-        // connection and scheduled a heartbeat.
+        // Reschedule because the connection establishment may have already written to the connection and scheduled a heartbeat.
         rescheduleWriteTimer();
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IncomingConnectionFactory.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IncomingConnectionFactory.java
@@ -53,7 +53,8 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
             }
 
             //
-            // We want to wait until all connections are in holding state outside the thread synchronization.
+            // We want to wait until all connections are in holding state outside the thread
+            // synchronization.
             //
             connections = new java.util.LinkedList<>(_connections);
         }
@@ -71,7 +72,8 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
 
         synchronized (this) {
             //
-            // First we wait until the factory is destroyed. If we are using an acceptor, we also wait for it to be closed.
+            // First we wait until the factory is destroyed. If we are using an acceptor, we also
+            // wait for it to be closed.
             //
             while (_state != StateFinished) {
                 wait();
@@ -83,7 +85,8 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
             _adapter = null;
 
             //
-            // We want to wait until all connections are finished outside the thread synchronization.
+            // We want to wait until all connections are finished outside the thread
+            // synchronization.
             //
             connections = new java.util.LinkedList<>(_connections);
         }
@@ -268,7 +271,8 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
             }
 
             //
-            // If the acceptor hasn't been explicitly stopped (which is the case if the acceptor got closed because of an unexpected error), try to restart the acceptor in 1 second.
+            // If the acceptor hasn't been explicitly stopped (which is the case if the acceptor got
+            // closed because of an unexpected error), try to restart the acceptor in 1 second.
             //
             _instance
                     .timer()
@@ -311,7 +315,8 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
     @Override
     public synchronized void connectionStartCompleted(ConnectionI connection) {
         //
-        // Initially, connections are in the holding state. If the factory is active we activate the connection.
+        // Initially, connections are in the holding state. If the factory is active we activate the
+        // connection.
         //
         if (_state == StateActive) {
             connection.activate();
@@ -490,7 +495,10 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
                 {
                     if (_acceptorStarted) {
                         //
-                        // If possible, close the acceptor now to prevent new connections from being accepted while we are deactivating. This is especially useful if there are no more threads in the thread pool available to dispatch the finish() call.
+                        // If possible, close the acceptor now to prevent new connections from being
+                        // accepted while we are deactivating. This is especially useful if there
+                        // are no more threads in the thread pool available to dispatch the finish()
+                        // call.
                         //
                         _acceptorStarted = false;
                         if (_adapter.getThreadPool().finish(this, true)) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IncomingConnectionFactory.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IncomingConnectionFactory.java
@@ -46,16 +46,14 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
 
         synchronized (this) {
             //
-            // First we wait until the connection factory itself is in holding
-            // state.
+            // First we wait until the connection factory itself is in holding state.
             //
             while (_state < StateHolding) {
                 wait();
             }
 
             //
-            // We want to wait until all connections are in holding state
-            // outside the thread synchronization.
+            // We want to wait until all connections are in holding state outside the thread synchronization.
             //
             connections = new java.util.LinkedList<>(_connections);
         }
@@ -73,8 +71,7 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
 
         synchronized (this) {
             //
-            // First we wait until the factory is destroyed. If we are using
-            // an acceptor, we also wait for it to be closed.
+            // First we wait until the factory is destroyed. If we are using an acceptor, we also wait for it to be closed.
             //
             while (_state != StateFinished) {
                 wait();
@@ -86,8 +83,7 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
             _adapter = null;
 
             //
-            // We want to wait until all connections are finished outside the
-            // thread synchronization.
+            // We want to wait until all connections are finished outside the thread synchronization.
             //
             connections = new java.util.LinkedList<>(_connections);
         }
@@ -272,9 +268,7 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
             }
 
             //
-            // If the acceptor hasn't been explicitly stopped (which is the case if the acceptor got
-            // closed
-            // because of an unexpected error), try to restart the acceptor in 1 second.
+            // If the acceptor hasn't been explicitly stopped (which is the case if the acceptor got closed because of an unexpected error), try to restart the acceptor in 1 second.
             //
             _instance
                     .timer()
@@ -317,8 +311,7 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
     @Override
     public synchronized void connectionStartCompleted(ConnectionI connection) {
         //
-        // Initially, connections are in the holding state. If the factory is active
-        // we activate the connection.
+        // Initially, connections are in the holding state. If the factory is active we activate the connection.
         //
         if (_state == StateActive) {
             connection.activate();
@@ -497,10 +490,7 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
                 {
                     if (_acceptorStarted) {
                         //
-                        // If possible, close the acceptor now to prevent new connections from
-                        // being accepted while we are deactivating. This is especially useful
-                        // if there are no more threads in the thread pool available to dispatch
-                        // the finish() call.
+                        // If possible, close the acceptor now to prevent new connections from being accepted while we are deactivating. This is especially useful if there are no more threads in the thread pool available to dispatch the finish() call.
                         //
                         _acceptorStarted = false;
                         if (_adapter.getThreadPool().finish(this, true)) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -137,7 +137,9 @@ public final class InputStream {
         other._minSeqSize = _minSeqSize;
         _minSeqSize = tmpMinSeqSize;
 
-        // Swap is never called for streams that have encapsulations being read. However, encapsulations might still be set in case unmarshaling failed. We just reset the encapsulations if there are still some set.
+        // Swap is never called for streams that have encapsulations being read. However,
+        // encapsulations might still be set in case unmarshaling failed. We just reset the
+        // encapsulations if there are still some set.
         resetEncapsulation();
         other.resetEncapsulation();
     }
@@ -289,7 +291,8 @@ public final class InputStream {
             }
         } else {
             //
-            // Skip the optional content of the encapsulation if we are expecting an empty encapsulation.
+            // Skip the optional content of the encapsulation if we are expecting an empty
+            // encapsulation.
             //
             _buf.position(_buf.b.position() + sz - 6);
         }
@@ -403,9 +406,11 @@ public final class InputStream {
                 ? _encapsStack.encoding_1_0
                 : _encoding.equals(Util.Encoding_1_0)) {
             //
-            // If using the 1.0 encoding and no instances were read, we still read an empty sequence of pending instances if requested (i.e.: if this is called).
+            // If using the 1.0 encoding and no instances were read, we still read an empty sequence
+            // of pending instances if requested (i.e.: if this is called).
             //
-            // This is required by the 1.0 encoding, even if no instances are written we do marshal an empty sequence if marshaled data types use classes.
+            // This is required by the 1.0 encoding, even if no instances are written we do marshal
+            // an empty sequence if marshaled data types use classes.
             //
             skipSize();
         }
@@ -450,11 +455,17 @@ public final class InputStream {
         // The _startSeq variable points to the start of the sequence for which
         // we expect to read at least _minSeqSize bytes from the stream.
         //
-        // If not initialized or if we already read more data than _minSeqSize, we reset _startSeq and _minSeqSize for this sequence (possibly a top-level sequence or enclosed sequence it doesn't really matter).
+        // If not initialized or if we already read more data than _minSeqSize, we reset _startSeq
+        // and _minSeqSize for this sequence (possibly a top-level sequence or enclosed sequence it
+        // doesn't really matter).
         //
-        // Otherwise, we are reading an enclosed sequence and we have to bump _minSeqSize by the minimum size that this sequence will require on the stream.
+        // Otherwise, we are reading an enclosed sequence and we have to bump _minSeqSize by the
+        // minimum size that this sequence will require on the stream.
         //
-        // The goal of this check is to ensure that when we start un-marshaling a new sequence, we check the minimal size of this new sequence against the estimated remaining buffer size. This estimation is based on the minimum size of the enclosing sequences, it's _minSeqSize.
+        // The goal of this check is to ensure that when we start un-marshaling a new sequence, we
+        // check the minimal size of this new sequence against the estimated remaining buffer size.
+        // This estimation is based on the minimum size of the enclosing sequences, it's
+        // _minSeqSize.
         //
         if (_startSeq == -1 || _buf.b.position() > (_startSeq + _minSeqSize)) {
             _startSeq = _buf.b.position();
@@ -464,7 +475,9 @@ public final class InputStream {
         }
 
         //
-        // If there isn't enough data to read on the stream for the sequence (and possibly enclosed sequences), something is wrong with the marshaled data: it's claiming having more data that what is possible to read.
+        // If there isn't enough data to read on the stream for the sequence (and possibly enclosed
+        // sequences), something is wrong with the marshaled data: it's claiming having more data
+        // that what is possible to read.
         //
         if (_startSeq + _minSeqSize > _buf.size()) {
             throw new MarshalException(END_OF_BUFFER_MESSAGE);
@@ -1137,7 +1150,8 @@ public final class InputStream {
                         // conversion.
                         //
                         // TODO: If the string contains garbage bytes
-                        // that won't correctly decode as UTF, the behavior of this constructor is undefined. It would be better to explicitly decode using
+                        // that won't correctly decode as UTF, the behavior of this constructor is
+                        // undefined. It would be better to explicitly decode using
                         // java.nio.charset.CharsetDecoder and to
                         // throw MarshalException if the string won't
                         // decode.
@@ -1650,7 +1664,8 @@ public final class InputStream {
             assert (index > 0);
 
             //
-            // Check if we have already unmarshaled the instance. If that's the case, just invoke the callback and we're done.
+            // Check if we have already unmarshaled the instance. If that's the case, just invoke
+            // the callback and we're done.
             //
             Value obj = _unmarshaledMap.get(index);
             if (obj != null) {
@@ -1664,12 +1679,14 @@ public final class InputStream {
             }
 
             //
-            // Add patch entry if the instance isn't unmarshaled yet, the callback will be called when the instance is unmarshaled.
+            // Add patch entry if the instance isn't unmarshaled yet, the callback will be called
+            // when the instance is unmarshaled.
             //
             java.util.LinkedList<PatchEntry> l = _patchMap.get(index);
             if (l == null) {
                 //
-                // We have no outstanding instances to be patched for this index, so make a new entry in the patch map.
+                // We have no outstanding instances to be patched for this index, so make a new
+                // entry in the patch map.
                 //
                 l = new java.util.LinkedList<>();
                 _patchMap.put(index, l);
@@ -1683,7 +1700,8 @@ public final class InputStream {
 
         protected void unmarshal(int index, Value v) {
             //
-            // Add the instance to the map of unmarshaled instances, this must be done before reading the instances (for circular references).
+            // Add the instance to the map of unmarshaled instances, this must be done before
+            // reading the instances (for circular references).
             //
             _unmarshaledMap.put(index, v);
 
@@ -1708,7 +1726,8 @@ public final class InputStream {
                     }
 
                     //
-                    // Clear out the patch map for that index -- there is nothing left to patch for that index for the time being.
+                    // Clear out the patch map for that index -- there is nothing left to patch for
+                    // that index for the time being.
                     //
                     _patchMap.remove(index);
                 }
@@ -1724,7 +1743,9 @@ public final class InputStream {
                 _valueList.add(v);
 
                 if (_patchMap == null || _patchMap.isEmpty()) {
-                    // Iterate over the instance list and invoke ice_postUnmarshal on each instance. We must do this after all instances have been unmarshaled in order to ensure that any instance data members have been properly patched.
+                    // Iterate over the instance list and invoke ice_postUnmarshal on each instance.
+                    // We must do this after all instances have been unmarshaled in order to ensure
+                    // that any instance data members have been properly patched.
                     for (Value p : _valueList) {
                         p.ice_postUnmarshal();
                     }
@@ -1786,7 +1807,8 @@ public final class InputStream {
             // User exception with the 1.0 encoding start with a boolean flag
             // that indicates whether or not the exception has classes.
             //
-            // This allows reading the pending instances even if some part of the exception was sliced.
+            // This allows reading the pending instances even if some part of the exception was
+            // sliced.
             //
             boolean usesClasses = _stream.readBool();
 
@@ -1837,7 +1859,8 @@ public final class InputStream {
                     startSlice();
                 } catch (MarshalException ex) {
                     //
-                    // An oversight in the 1.0 encoding means there is no marker to indicate the last slice of an exception. As a result, we just try to read the
+                    // An oversight in the 1.0 encoding means there is no marker to indicate the
+                    // last slice of an exception. As a result, we just try to read the
                     // next type ID, which raises MarshalException when the input buffer underflows.
                     throw new MarshalException("unknown exception type '" + mostDerivedId + "'");
                 }
@@ -1881,7 +1904,8 @@ public final class InputStream {
 
             //
             // For class instances, first read the type ID boolean which indicates
-            // whether or not the type ID is encoded as a string or as an index. For exceptions, the type ID is always encoded as a string.
+            // whether or not the type ID is encoded as a string or as an index. For exceptions, the
+            // type ID is always encoded as a string.
             //
             if (_sliceType
                     == SliceType.ValueSlice) // For exceptions, the type ID is always encoded as a
@@ -1923,7 +1947,8 @@ public final class InputStream {
 
             if (_patchMap != null && !_patchMap.isEmpty()) {
                 //
-                // If any entries remain in the patch map, the sender has sent an index for an object, but failed to supply the object.
+                // If any entries remain in the patch map, the sender has sent an index for an
+                // object, but failed to supply the object.
                 //
                 throw new MarshalException("index for class received, but no instance");
             }
@@ -1971,7 +1996,8 @@ public final class InputStream {
             }
 
             //
-            // Compute the biggest class graph depth of this object. To compute this, we get the class graph depth of each ancestor from the patch map and keep the biggest one.
+            // Compute the biggest class graph depth of this object. To compute this, we get the
+            // class graph depth of each ancestor from the patch map and keep the biggest one.
             //
             _classGraphDepth = 0;
             var l = _patchMap != null ? _patchMap.get(index) : null;
@@ -2024,7 +2050,8 @@ public final class InputStream {
             } else if (_current != null
                     && (_current.sliceFlags & Protocol.FLAG_HAS_INDIRECTION_TABLE) != 0) {
                 //
-                // When reading a class instance within a slice and there's an indirect instance table, always read an indirect reference
+                // When reading a class instance within a slice and there's an indirect instance
+                // table, always read an indirect reference
                 // that points to an instance from the indirect instance table
                 // marshaled at the end of the Slice.
                 //
@@ -2132,7 +2159,8 @@ public final class InputStream {
             _current.sliceFlags = _stream.readByte();
 
             //
-            // Read the type ID, for value slices the type ID is encoded as a string or as an index, for exceptions it's always encoded as a string.
+            // Read the type ID, for value slices the type ID is encoded as a string or as an index,
+            // for exceptions it's always encoded as a string.
             //
             if (_current.sliceType == SliceType.ValueSlice) {
                 if ((_current.sliceFlags & Protocol.FLAG_HAS_TYPE_ID_COMPACT)
@@ -2195,7 +2223,8 @@ public final class InputStream {
                 }
 
                 //
-                // Sanity checks. If there are optional members, it's possible that not all instance references were read if they are from unknown optional data members.
+                // Sanity checks. If there are optional members, it's possible that not all instance
+                // references were read if they are from unknown optional data members.
                 //
                 if (indirectionTable.length == 0) {
                     throw new MarshalException("empty indirection table");
@@ -2243,7 +2272,8 @@ public final class InputStream {
             }
 
             //
-            // Preserve this slice if unmarshaling a value in Slice format. Exception slices are not preserved.
+            // Preserve this slice if unmarshaling a value in Slice format. Exception slices are not
+            // preserved.
             //
             if (_current.sliceType == SliceType.ValueSlice) {
                 boolean hasOptionalMembers =
@@ -2254,7 +2284,8 @@ public final class InputStream {
                 int dataEnd = end;
                 if (hasOptionalMembers) {
                     //
-                    // Don't include the optional member end marker. It will be re-written by endSlice when the sliced data is re-written.
+                    // Don't include the optional member end marker. It will be re-written by
+                    // endSlice when the sliced data is re-written.
                     //
                     --dataEnd;
                 }
@@ -2284,7 +2315,8 @@ public final class InputStream {
             }
 
             //
-            // Read the indirect instance table. We read the instances or their IDs if the instance is a reference to an already unmarshaled instance.
+            // Read the indirect instance table. We read the instances or their IDs if the instance
+            // is a reference to an already unmarshaled instance.
             //
             if ((_current.sliceFlags & Protocol.FLAG_HAS_INDIRECTION_TABLE) != 0) {
                 int[] indirectionTable = new int[_stream.readAndCheckSeqSize(1)];
@@ -2320,7 +2352,8 @@ public final class InputStream {
             push(SliceType.ValueSlice);
 
             //
-            // Get the instance ID before we start reading slices. If some slices are skipped, the indirect instance table is still read and might read other instances.
+            // Get the instance ID before we start reading slices. If some slices are skipped, the
+            // indirect instance table is still read and might read other instances.
             //
             index = ++_valueIdIndex;
 
@@ -2361,7 +2394,8 @@ public final class InputStream {
                     }
 
                     //
-                    // If we haven't already cached a class for the compact ID, then try to translate the
+                    // If we haven't already cached a class for the compact ID, then try to
+                    // translate the
                     // compact ID into a type ID.
                     //
                     if (v == null) {
@@ -2396,7 +2430,9 @@ public final class InputStream {
                 //
                 if ((_current.sliceFlags & Protocol.FLAG_IS_LAST_SLICE) != 0) {
                     //
-                    // Provide a factory with an opportunity to supply the instance. We pass the "::Ice::Object" ID to indicate that this is the last chance to preserve the instance.
+                    // Provide a factory with an opportunity to supply the instance. We pass the
+                    // "::Ice::Object" ID to indicate that this is the last chance to preserve the
+                    // instance.
                     //
                     v = newInstance(Value.ice_staticId());
                     if (v == null) {
@@ -2422,7 +2458,8 @@ public final class InputStream {
 
             if (_current == null && _patchMap != null && !_patchMap.isEmpty()) {
                 //
-                // If any entries remain in the patch map, the sender has sent an index for an instance, but failed to supply the instance.
+                // If any entries remain in the patch map, the sender has sent an index for an
+                // instance, but failed to supply the instance.
                 //
                 throw new MarshalException("index for class received, but no instance");
             }
@@ -2447,7 +2484,8 @@ public final class InputStream {
             for (int n = 0; n < _current.slices.size(); ++n) {
                 //
                 // We use the "instances" list in SliceInfo to hold references
-                // to the target instances. Note that the instances might not have been read yet in the case of a circular reference to an enclosing instance.
+                // to the target instances. Note that the instances might not have been read yet in
+                // the case of a circular reference to an enclosing instance.
                 //
                 final int[] table = _current.indirectionTables.get(n);
                 SliceInfo info = _current.slices.get(n);
@@ -2530,7 +2568,8 @@ public final class InputStream {
     }
 
     //
-    // The encoding version to use when there's no encapsulation to read from. This is for example used to read message headers.
+    // The encoding version to use when there's no encapsulation to read from. This is for example
+    // used to read message headers.
     //
     private EncodingVersion _encoding;
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -137,9 +137,7 @@ public final class InputStream {
         other._minSeqSize = _minSeqSize;
         _minSeqSize = tmpMinSeqSize;
 
-        // Swap is never called for streams that have encapsulations being read. However,
-        // encapsulations might still be set in case unmarshaling failed. We just
-        // reset the encapsulations if there are still some set.
+        // Swap is never called for streams that have encapsulations being read. However, encapsulations might still be set in case unmarshaling failed. We just reset the encapsulations if there are still some set.
         resetEncapsulation();
         other.resetEncapsulation();
     }
@@ -291,8 +289,7 @@ public final class InputStream {
             }
         } else {
             //
-            // Skip the optional content of the encapsulation if we are expecting an
-            // empty encapsulation.
+            // Skip the optional content of the encapsulation if we are expecting an empty encapsulation.
             //
             _buf.position(_buf.b.position() + sz - 6);
         }
@@ -406,13 +403,9 @@ public final class InputStream {
                 ? _encapsStack.encoding_1_0
                 : _encoding.equals(Util.Encoding_1_0)) {
             //
-            // If using the 1.0 encoding and no instances were read, we
-            // still read an empty sequence of pending instances if
-            // requested (i.e.: if this is called).
+            // If using the 1.0 encoding and no instances were read, we still read an empty sequence of pending instances if requested (i.e.: if this is called).
             //
-            // This is required by the 1.0 encoding, even if no instances
-            // are written we do marshal an empty sequence if marshaled
-            // data types use classes.
+            // This is required by the 1.0 encoding, even if no instances are written we do marshal an empty sequence if marshaled data types use classes.
             //
             skipSize();
         }
@@ -457,18 +450,11 @@ public final class InputStream {
         // The _startSeq variable points to the start of the sequence for which
         // we expect to read at least _minSeqSize bytes from the stream.
         //
-        // If not initialized or if we already read more data than _minSeqSize,
-        // we reset _startSeq and _minSeqSize for this sequence (possibly a
-        // top-level sequence or enclosed sequence it doesn't really matter).
+        // If not initialized or if we already read more data than _minSeqSize, we reset _startSeq and _minSeqSize for this sequence (possibly a top-level sequence or enclosed sequence it doesn't really matter).
         //
-        // Otherwise, we are reading an enclosed sequence and we have to bump
-        // _minSeqSize by the minimum size that this sequence will require on
-        // the stream.
+        // Otherwise, we are reading an enclosed sequence and we have to bump _minSeqSize by the minimum size that this sequence will require on the stream.
         //
-        // The goal of this check is to ensure that when we start un-marshaling
-        // a new sequence, we check the minimal size of this new sequence against
-        // the estimated remaining buffer size. This estimation is based on
-        // the minimum size of the enclosing sequences, it's _minSeqSize.
+        // The goal of this check is to ensure that when we start un-marshaling a new sequence, we check the minimal size of this new sequence against the estimated remaining buffer size. This estimation is based on the minimum size of the enclosing sequences, it's _minSeqSize.
         //
         if (_startSeq == -1 || _buf.b.position() > (_startSeq + _minSeqSize)) {
             _startSeq = _buf.b.position();
@@ -478,9 +464,7 @@ public final class InputStream {
         }
 
         //
-        // If there isn't enough data to read on the stream for the sequence (and
-        // possibly enclosed sequences), something is wrong with the marshaled
-        // data: it's claiming having more data that what is possible to read.
+        // If there isn't enough data to read on the stream for the sequence (and possibly enclosed sequences), something is wrong with the marshaled data: it's claiming having more data that what is possible to read.
         //
         if (_startSeq + _minSeqSize > _buf.size()) {
             throw new MarshalException(END_OF_BUFFER_MESSAGE);
@@ -1131,8 +1115,7 @@ public final class InputStream {
 
             try {
                 //
-                // We reuse the _stringBytes array to avoid creating
-                // excessive garbage.
+                // We reuse the _stringBytes array to avoid creating excessive garbage.
                 //
                 if (_stringBytes == null || len > _stringBytes.length) {
                     _stringBytes = new byte[len];
@@ -1154,10 +1137,7 @@ public final class InputStream {
                         // conversion.
                         //
                         // TODO: If the string contains garbage bytes
-                        // that won't correctly decode as UTF, the
-                        // behavior of this constructor is
-                        // undefined. It would be better to explicitly
-                        // decode using
+                        // that won't correctly decode as UTF, the behavior of this constructor is undefined. It would be better to explicitly decode using
                         // java.nio.charset.CharsetDecoder and to
                         // throw MarshalException if the string won't
                         // decode.
@@ -1638,8 +1618,7 @@ public final class InputStream {
             }
 
             //
-            // If that fails, invoke the default factory if one has been
-            // registered.
+            // If that fails, invoke the default factory if one has been registered.
             //
             if (v == null) {
                 userFactory = _valueFactoryManager.find("");
@@ -1671,8 +1650,7 @@ public final class InputStream {
             assert (index > 0);
 
             //
-            // Check if we have already unmarshaled the instance. If that's the case,
-            // just invoke the callback and we're done.
+            // Check if we have already unmarshaled the instance. If that's the case, just invoke the callback and we're done.
             //
             Value obj = _unmarshaledMap.get(index);
             if (obj != null) {
@@ -1686,15 +1664,12 @@ public final class InputStream {
             }
 
             //
-            // Add patch entry if the instance isn't unmarshaled yet,
-            // the callback will be called when the instance is
-            // unmarshaled.
+            // Add patch entry if the instance isn't unmarshaled yet, the callback will be called when the instance is unmarshaled.
             //
             java.util.LinkedList<PatchEntry> l = _patchMap.get(index);
             if (l == null) {
                 //
-                // We have no outstanding instances to be patched for this
-                // index, so make a new entry in the patch map.
+                // We have no outstanding instances to be patched for this index, so make a new entry in the patch map.
                 //
                 l = new java.util.LinkedList<>();
                 _patchMap.put(index, l);
@@ -1708,8 +1683,7 @@ public final class InputStream {
 
         protected void unmarshal(int index, Value v) {
             //
-            // Add the instance to the map of unmarshaled instances, this must
-            // be done before reading the instances (for circular references).
+            // Add the instance to the map of unmarshaled instances, this must be done before reading the instances (for circular references).
             //
             _unmarshaledMap.put(index, v);
 
@@ -1734,8 +1708,7 @@ public final class InputStream {
                     }
 
                     //
-                    // Clear out the patch map for that index -- there is nothing left
-                    // to patch for that index for the time being.
+                    // Clear out the patch map for that index -- there is nothing left to patch for that index for the time being.
                     //
                     _patchMap.remove(index);
                 }
@@ -1751,10 +1724,7 @@ public final class InputStream {
                 _valueList.add(v);
 
                 if (_patchMap == null || _patchMap.isEmpty()) {
-                    // Iterate over the instance list and invoke ice_postUnmarshal on
-                    // each instance. We must do this after all instances have been
-                    // unmarshaled in order to ensure that any instance data members
-                    // have been properly patched.
+                    // Iterate over the instance list and invoke ice_postUnmarshal on each instance. We must do this after all instances have been unmarshaled in order to ensure that any instance data members have been properly patched.
                     for (Value p : _valueList) {
                         p.ice_postUnmarshal();
                     }
@@ -1816,8 +1786,7 @@ public final class InputStream {
             // User exception with the 1.0 encoding start with a boolean flag
             // that indicates whether or not the exception has classes.
             //
-            // This allows reading the pending instances even if some part of
-            // the exception was sliced.
+            // This allows reading the pending instances even if some part of the exception was sliced.
             //
             boolean usesClasses = _stream.readBool();
 
@@ -1868,8 +1837,7 @@ public final class InputStream {
                     startSlice();
                 } catch (MarshalException ex) {
                     //
-                    // An oversight in the 1.0 encoding means there is no marker to indicate
-                    // the last slice of an exception. As a result, we just try to read the
+                    // An oversight in the 1.0 encoding means there is no marker to indicate the last slice of an exception. As a result, we just try to read the
                     // next type ID, which raises MarshalException when the input buffer underflows.
                     throw new MarshalException("unknown exception type '" + mostDerivedId + "'");
                 }
@@ -1913,9 +1881,7 @@ public final class InputStream {
 
             //
             // For class instances, first read the type ID boolean which indicates
-            // whether or not the type ID is encoded as a string or as an
-            // index. For exceptions, the type ID is always encoded as a
-            // string.
+            // whether or not the type ID is encoded as a string or as an index. For exceptions, the type ID is always encoded as a string.
             //
             if (_sliceType
                     == SliceType.ValueSlice) // For exceptions, the type ID is always encoded as a
@@ -1957,10 +1923,7 @@ public final class InputStream {
 
             if (_patchMap != null && !_patchMap.isEmpty()) {
                 //
-                // If any entries remain in the patch map, the sender has sent an index for an
-                // object, but
-                // failed
-                // to supply the object.
+                // If any entries remain in the patch map, the sender has sent an index for an object, but failed to supply the object.
                 //
                 throw new MarshalException("index for class received, but no instance");
             }
@@ -1984,8 +1947,7 @@ public final class InputStream {
             Value v = null;
             while (true) {
                 //
-                // For the 1.0 encoding, the type ID for the base Object class
-                // marks the last slice.
+                // For the 1.0 encoding, the type ID for the base Object class marks the last slice.
                 //
                 if (_typeId.equals(Value.ice_staticId())) {
                     throw new MarshalException(
@@ -2009,9 +1971,7 @@ public final class InputStream {
             }
 
             //
-            // Compute the biggest class graph depth of this object. To compute this,
-            // we get the class graph depth of each ancestor from the patch map and
-            // keep the biggest one.
+            // Compute the biggest class graph depth of this object. To compute this, we get the class graph depth of each ancestor from the patch map and keep the biggest one.
             //
             _classGraphDepth = 0;
             var l = _patchMap != null ? _patchMap.get(index) : null;
@@ -2064,8 +2024,7 @@ public final class InputStream {
             } else if (_current != null
                     && (_current.sliceFlags & Protocol.FLAG_HAS_INDIRECTION_TABLE) != 0) {
                 //
-                // When reading a class instance within a slice and there's an
-                // indirect instance table, always read an indirect reference
+                // When reading a class instance within a slice and there's an indirect instance table, always read an indirect reference
                 // that points to an instance from the indirect instance table
                 // marshaled at the end of the Slice.
                 //
@@ -2173,9 +2132,7 @@ public final class InputStream {
             _current.sliceFlags = _stream.readByte();
 
             //
-            // Read the type ID, for value slices the type ID is encoded as a
-            // string or as an index, for exceptions it's always encoded as a
-            // string.
+            // Read the type ID, for value slices the type ID is encoded as a string or as an index, for exceptions it's always encoded as a string.
             //
             if (_current.sliceType == SliceType.ValueSlice) {
                 if ((_current.sliceFlags & Protocol.FLAG_HAS_TYPE_ID_COMPACT)
@@ -2238,9 +2195,7 @@ public final class InputStream {
                 }
 
                 //
-                // Sanity checks. If there are optional members, it's possible
-                // that not all instance references were read if they are from
-                // unknown optional data members.
+                // Sanity checks. If there are optional members, it's possible that not all instance references were read if they are from unknown optional data members.
                 //
                 if (indirectionTable.length == 0) {
                     throw new MarshalException("empty indirection table");
@@ -2288,8 +2243,7 @@ public final class InputStream {
             }
 
             //
-            // Preserve this slice if unmarshaling a value in Slice format. Exception slices are not
-            // preserved.
+            // Preserve this slice if unmarshaling a value in Slice format. Exception slices are not preserved.
             //
             if (_current.sliceType == SliceType.ValueSlice) {
                 boolean hasOptionalMembers =
@@ -2300,8 +2254,7 @@ public final class InputStream {
                 int dataEnd = end;
                 if (hasOptionalMembers) {
                     //
-                    // Don't include the optional member end marker. It will be re-written by
-                    // endSlice when the sliced data is re-written.
+                    // Don't include the optional member end marker. It will be re-written by endSlice when the sliced data is re-written.
                     //
                     --dataEnd;
                 }
@@ -2331,9 +2284,7 @@ public final class InputStream {
             }
 
             //
-            // Read the indirect instance table. We read the instances or their
-            // IDs if the instance is a reference to an already unmarshaled
-            // instance.
+            // Read the indirect instance table. We read the instances or their IDs if the instance is a reference to an already unmarshaled instance.
             //
             if ((_current.sliceFlags & Protocol.FLAG_HAS_INDIRECTION_TABLE) != 0) {
                 int[] indirectionTable = new int[_stream.readAndCheckSeqSize(1)];
@@ -2369,9 +2320,7 @@ public final class InputStream {
             push(SliceType.ValueSlice);
 
             //
-            // Get the instance ID before we start reading slices. If some
-            // slices are skipped, the indirect instance table is still read and
-            // might read other instances.
+            // Get the instance ID before we start reading slices. If some slices are skipped, the indirect instance table is still read and might read other instances.
             //
             index = ++_valueIdIndex;
 
@@ -2412,8 +2361,7 @@ public final class InputStream {
                     }
 
                     //
-                    // If we haven't already cached a class for the compact ID, then try to
-                    // translate the
+                    // If we haven't already cached a class for the compact ID, then try to translate the
                     // compact ID into a type ID.
                     //
                     if (v == null) {
@@ -2448,9 +2396,7 @@ public final class InputStream {
                 //
                 if ((_current.sliceFlags & Protocol.FLAG_IS_LAST_SLICE) != 0) {
                     //
-                    // Provide a factory with an opportunity to supply the instance.
-                    // We pass the "::Ice::Object" ID to indicate that this is the
-                    // last chance to preserve the instance.
+                    // Provide a factory with an opportunity to supply the instance. We pass the "::Ice::Object" ID to indicate that this is the last chance to preserve the instance.
                     //
                     v = newInstance(Value.ice_staticId());
                     if (v == null) {
@@ -2476,10 +2422,7 @@ public final class InputStream {
 
             if (_current == null && _patchMap != null && !_patchMap.isEmpty()) {
                 //
-                // If any entries remain in the patch map, the sender has sent an index for an
-                // instance, but
-                // failed
-                // to supply the instance.
+                // If any entries remain in the patch map, the sender has sent an index for an instance, but failed to supply the instance.
                 //
                 throw new MarshalException("index for class received, but no instance");
             }
@@ -2498,16 +2441,13 @@ public final class InputStream {
             }
 
             //
-            // The _indirectionTables member holds the indirection table for each slice
-            // in _slices.
+            // The _indirectionTables member holds the indirection table for each slice in _slices.
             //
             assert (_current.slices.size() == _current.indirectionTables.size());
             for (int n = 0; n < _current.slices.size(); ++n) {
                 //
                 // We use the "instances" list in SliceInfo to hold references
-                // to the target instances. Note that the instances might not have
-                // been read yet in the case of a circular reference to an
-                // enclosing instance.
+                // to the target instances. Note that the instances might not have been read yet in the case of a circular reference to an enclosing instance.
                 //
                 final int[] table = _current.indirectionTables.get(n);
                 SliceInfo info = _current.slices.get(n);
@@ -2590,8 +2530,7 @@ public final class InputStream {
     }
 
     //
-    // The encoding version to use when there's no encapsulation to
-    // read from. This is for example used to read message headers.
+    // The encoding version to use when there's no encapsulation to read from. This is for example used to read message headers.
     //
     private EncodingVersion _encoding;
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -131,8 +131,7 @@ public final class Instance implements java.util.function.Function<String, Class
 
     public InitializationData initializationData() {
         //
-        // No check for destruction. It must be possible to access the
-        // initialization data after destruction.
+        // No check for destruction. It must be possible to access the initialization data after destruction.
         //
         // No mutex lock, immutable.
         //
@@ -546,14 +545,9 @@ public final class Instance implements java.util.function.Function<String, Class
         //
         // 1. Convert the Slice type ID into a classname (e.g., ::M::X becomes M.X).
         // 2. Check if the application has defined any package prefixes for the top-level module
-        // (e.g.:
-        // "M").
-        //    Attempt to resolve the <package-prefix>+<class-name> in order trying each defined
-        // package
-        //    prefix.
+        // (e.g.: "M").    Attempt to resolve the <package-prefix>+<class-name> in order trying each defined package    prefix.
         // 3. If the above step fails, it checks the value of Default.Package property. If found,
-        //    prepend its value to the classname. Otherwise, attempt to use the
-        //    classname directly.
+        //    prepend its value to the classname. Otherwise, attempt to use the    classname directly.
         //
         String fullyQualifiedClassName;
 
@@ -687,8 +681,7 @@ public final class Instance implements java.util.function.Function<String, Class
 
                     if (!stdOut.isEmpty()) {
                         //
-                        // We need to close the existing stdout for JVM thread dump to go
-                        // to the new file
+                        // We need to close the existing stdout for JVM thread dump to go to the new file
                         //
                         System.out.close();
 
@@ -1035,8 +1028,7 @@ public final class Instance implements java.util.function.Function<String, Class
         _clientThreadPool = new ThreadPool(this, "Ice.ThreadPool.Client", 0);
 
         //
-        // The default router/locator may have been set during the loading of plugins.
-        // Therefore we make sure it is not already set before checking the property.
+        // The default router/locator may have been set during the loading of plugins. Therefore we make sure it is not already set before checking the property.
         //
         if (_referenceFactory.getDefaultRouter() == null) {
             RouterPrx router =
@@ -1110,8 +1102,7 @@ public final class Instance implements java.util.function.Function<String, Class
 
         try {
             //
-            // Shutdown and destroy all the incoming and outgoing Ice
-            // connections and wait for the connections to be finished.
+            // Shutdown and destroy all the incoming and outgoing Ice connections and wait for the connections to be finished.
             //
             if (_objectAdapterFactory != null) {
                 _objectAdapterFactory.shutdown();
@@ -1143,9 +1134,7 @@ public final class Instance implements java.util.function.Function<String, Class
             }
 
             //
-            // Now, destroy the thread pools. This must be done *only* after
-            // all the connections are finished (the connections destruction
-            // can require invoking callbacks with the thread pools).
+            // Now, destroy the thread pools. This must be done *only* after all the connections are finished (the connections destruction can require invoking callbacks with the thread pools).
             //
             if (_serverThreadPool != null) {
                 _serverThreadPool.destroy();
@@ -1187,8 +1176,7 @@ public final class Instance implements java.util.function.Function<String, Class
 
             //
             // NOTE: at this point destroy() can't be interrupted
-            // anymore. The calls below are therefore guaranteed to be
-            // called once.
+            // anymore. The calls below are therefore guaranteed to be called once.
             //
             if (_routerManager != null) {
                 _routerManager.destroy();
@@ -1412,8 +1400,7 @@ public final class Instance implements java.util.function.Function<String, Class
             ProcessPrx process = ProcessPrx.uncheckedCast(admin.ice_facet("Process"));
             try {
                 //
-                // Note that as soon as the process proxy is registered, the communicator might be
-                // shutdown by a remote client and admin facets might start receiving calls.
+                // Note that as soon as the process proxy is registered, the communicator might be shutdown by a remote client and admin facets might start receiving calls.
                 //
                 locator.getRegistry().setServerProcessProxy(serverId, process);
             } catch (ServerNotFoundException ex) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -131,7 +131,8 @@ public final class Instance implements java.util.function.Function<String, Class
 
     public InitializationData initializationData() {
         //
-        // No check for destruction. It must be possible to access the initialization data after destruction.
+        // No check for destruction. It must be possible to access the initialization data after
+        // destruction.
         //
         // No mutex lock, immutable.
         //
@@ -545,9 +546,11 @@ public final class Instance implements java.util.function.Function<String, Class
         //
         // 1. Convert the Slice type ID into a classname (e.g., ::M::X becomes M.X).
         // 2. Check if the application has defined any package prefixes for the top-level module
-        // (e.g.: "M").    Attempt to resolve the <package-prefix>+<class-name> in order trying each defined package    prefix.
+        // (e.g.: "M").    Attempt to resolve the <package-prefix>+<class-name> in order trying each
+        // defined package    prefix.
         // 3. If the above step fails, it checks the value of Default.Package property. If found,
-        //    prepend its value to the classname. Otherwise, attempt to use the    classname directly.
+        //    prepend its value to the classname. Otherwise, attempt to use the    classname
+        // directly.
         //
         String fullyQualifiedClassName;
 
@@ -681,7 +684,8 @@ public final class Instance implements java.util.function.Function<String, Class
 
                     if (!stdOut.isEmpty()) {
                         //
-                        // We need to close the existing stdout for JVM thread dump to go to the new file
+                        // We need to close the existing stdout for JVM thread dump to go to the new
+                        // file
                         //
                         System.out.close();
 
@@ -1028,7 +1032,8 @@ public final class Instance implements java.util.function.Function<String, Class
         _clientThreadPool = new ThreadPool(this, "Ice.ThreadPool.Client", 0);
 
         //
-        // The default router/locator may have been set during the loading of plugins. Therefore we make sure it is not already set before checking the property.
+        // The default router/locator may have been set during the loading of plugins. Therefore we
+        // make sure it is not already set before checking the property.
         //
         if (_referenceFactory.getDefaultRouter() == null) {
             RouterPrx router =
@@ -1102,7 +1107,8 @@ public final class Instance implements java.util.function.Function<String, Class
 
         try {
             //
-            // Shutdown and destroy all the incoming and outgoing Ice connections and wait for the connections to be finished.
+            // Shutdown and destroy all the incoming and outgoing Ice connections and wait for the
+            // connections to be finished.
             //
             if (_objectAdapterFactory != null) {
                 _objectAdapterFactory.shutdown();
@@ -1134,7 +1140,9 @@ public final class Instance implements java.util.function.Function<String, Class
             }
 
             //
-            // Now, destroy the thread pools. This must be done *only* after all the connections are finished (the connections destruction can require invoking callbacks with the thread pools).
+            // Now, destroy the thread pools. This must be done *only* after all the connections are
+            // finished (the connections destruction can require invoking callbacks with the thread
+            // pools).
             //
             if (_serverThreadPool != null) {
                 _serverThreadPool.destroy();
@@ -1400,7 +1408,8 @@ public final class Instance implements java.util.function.Function<String, Class
             ProcessPrx process = ProcessPrx.uncheckedCast(admin.ice_facet("Process"));
             try {
                 //
-                // Note that as soon as the process proxy is registered, the communicator might be shutdown by a remote client and admin facets might start receiving calls.
+                // Note that as soon as the process proxy is registered, the communicator might be
+                // shutdown by a remote client and admin facets might start receiving calls.
                 //
                 locator.getRegistry().setServerProcessProxy(serverId, process);
             } catch (ServerNotFoundException ex) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InvocationFuture.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InvocationFuture.java
@@ -311,7 +311,9 @@ public abstract class InvocationFuture<T> extends CompletableFuture<T> {
                 _doneInSent = true;
 
                 //
-                // For oneway requests after the data has been sent the buffers can be reused unless this is a collocated invocation. For collocated invocations the buffer won't be reused because it has already
+                // For oneway requests after the data has been sent the buffers can be reused unless
+                // this is a collocated invocation. For collocated invocations the buffer won't be
+                // reused because it has already
                 // been marked as cached in invokeCollocated.
                 //
                 cacheMessageBuffers();
@@ -392,7 +394,9 @@ public abstract class InvocationFuture<T> extends CompletableFuture<T> {
 
     public final void invokeSentAsync() {
         //
-        // This is called when it's not safe to call the sent callback synchronously from this thread. Instead the future is completed asynchronously from a client in the client thread pool.
+        // This is called when it's not safe to call the sent callback synchronously from this
+        // thread. Instead the future is completed asynchronously from a client in the client thread
+        // pool.
         //
         dispatch(() -> invokeSent());
     }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InvocationFuture.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InvocationFuture.java
@@ -262,8 +262,7 @@ public abstract class InvocationFuture<T> extends CompletableFuture<T> {
     public final void invokeCompletedAsync() {
         //
         // CommunicatorDestroyedException is the only exception that can propagate directly from
-        // this
-        // method.
+        // this method.
         //
         _instance
                 .clientThreadPool()
@@ -312,10 +311,7 @@ public abstract class InvocationFuture<T> extends CompletableFuture<T> {
                 _doneInSent = true;
 
                 //
-                // For oneway requests after the data has been sent
-                // the buffers can be reused unless this is a
-                // collocated invocation. For collocated invocations
-                // the buffer won't be reused because it has already
+                // For oneway requests after the data has been sent the buffers can be reused unless this is a collocated invocation. For collocated invocations the buffer won't be reused because it has already
                 // been marked as cached in invokeCollocated.
                 //
                 cacheMessageBuffers();
@@ -396,9 +392,7 @@ public abstract class InvocationFuture<T> extends CompletableFuture<T> {
 
     public final void invokeSentAsync() {
         //
-        // This is called when it's not safe to call the sent callback
-        // synchronously from this thread. Instead the future is completed
-        // asynchronously from a client in the client thread pool.
+        // This is called when it's not safe to call the sent callback synchronously from this thread. Instead the future is completed asynchronously from a client in the client thread pool.
         //
         dispatch(() -> invokeSent());
     }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LocatorInfo.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LocatorInfo.java
@@ -19,7 +19,8 @@ final class LocatorInfo {
                 if (_ref.isWellKnown()
                         && !Protocol.isSupported(_ref.getEncoding(), r.getEncoding())) {
                     //
-                    // If a well-known proxy and the returned proxy encoding isn't supported, we're done: there's
+                    // If a well-known proxy and the returned proxy encoding isn't supported, we're
+                    // done: there's
                     // no compatible endpoint we can use.
                     //
                 } else if (!r.isIndirect()) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LocatorInfo.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LocatorInfo.java
@@ -19,8 +19,7 @@ final class LocatorInfo {
                 if (_ref.isWellKnown()
                         && !Protocol.isSupported(_ref.getEncoding(), r.getEncoding())) {
                     //
-                    // If a well-known proxy and the returned proxy
-                    // encoding isn't supported, we're done: there's
+                    // If a well-known proxy and the returned proxy encoding isn't supported, we're done: there's
                     // no compatible endpoint we can use.
                     //
                 } else if (!r.isIndirect()) {
@@ -578,8 +577,7 @@ final class LocatorInfo {
                 // Cache the well-known object reference.
                 _table.addObjectReference(ref.getIdentity(), ((_ObjectPrxI) proxy)._getReference());
             } else if (notRegistered) {
-                // If the well-known object isn't registered anymore, remove it from
-                // the cache.
+                // If the well-known object isn't registered anymore, remove it from the cache.
                 _table.removeObjectReference(ref.getIdentity());
             }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LocatorManager.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LocatorManager.java
@@ -60,7 +60,8 @@ final class LocatorManager {
     }
 
     //
-    // Returns locator info for a given locator. Automatically creates the locator info if it doesn't exist yet.
+    // Returns locator info for a given locator. Automatically creates the locator info if it
+    // doesn't exist yet.
     //
     public LocatorInfo get(LocatorPrx loc) {
         if (loc == null) {
@@ -80,7 +81,8 @@ final class LocatorManager {
             LocatorInfo info = _table.get(locator);
             if (info == null) {
                 //
-                // Rely on locator identity for the adapter table. We want to have only one table per locator (not one per locator proxy).
+                // Rely on locator identity for the adapter table. We want to have only one table
+                // per locator (not one per locator proxy).
                 //
                 LocatorTable table = _locatorTables.get(_lookupKey.set(locator));
                 if (table == null) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LocatorManager.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LocatorManager.java
@@ -60,8 +60,7 @@ final class LocatorManager {
     }
 
     //
-    // Returns locator info for a given locator. Automatically creates
-    // the locator info if it doesn't exist yet.
+    // Returns locator info for a given locator. Automatically creates the locator info if it doesn't exist yet.
     //
     public LocatorInfo get(LocatorPrx loc) {
         if (loc == null) {
@@ -81,9 +80,7 @@ final class LocatorManager {
             LocatorInfo info = _table.get(locator);
             if (info == null) {
                 //
-                // Rely on locator identity for the adapter table. We want to
-                // have only one table per locator (not one per locator
-                // proxy).
+                // Rely on locator identity for the adapter table. We want to have only one table per locator (not one per locator proxy).
                 //
                 LocatorTable table = _locatorTables.get(_lookupKey.set(locator));
                 if (table == null) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminI.java
@@ -166,9 +166,7 @@ final class LoggerAdminI implements LoggerAdmin {
         }
 
         //
-        // Destroy outside lock to avoid deadlock when there are outstanding two-way log calls sent
-        // to
-        // remote loggers
+        // Destroy outside lock to avoid deadlock when there are outstanding two-way log calls sent to remote loggers
         //
         if (sendLogCommunicator != null) {
             sendLogCommunicator.destroy();
@@ -288,8 +286,7 @@ final class LoggerAdminI implements LoggerAdmin {
         assert (!logMessages.isEmpty() && messageMax != 0);
 
         //
-        // Filter only if one of the 3 filters is set; messageMax < 0 means "give me all"
-        // that match the other filters, if any.
+        // Filter only if one of the 3 filters is set; messageMax < 0 means "give me all" that match the other filters, if any.
         //
         if (!messageTypes.isEmpty() || !traceCategories.isEmpty() || messageMax > 0) {
             int count = 0;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminI.java
@@ -166,7 +166,8 @@ final class LoggerAdminI implements LoggerAdmin {
         }
 
         //
-        // Destroy outside lock to avoid deadlock when there are outstanding two-way log calls sent to remote loggers
+        // Destroy outside lock to avoid deadlock when there are outstanding two-way log calls sent
+        // to remote loggers
         //
         if (sendLogCommunicator != null) {
             sendLogCommunicator.destroy();
@@ -286,7 +287,8 @@ final class LoggerAdminI implements LoggerAdmin {
         assert (!logMessages.isEmpty() && messageMax != 0);
 
         //
-        // Filter only if one of the 3 filters is set; messageMax < 0 means "give me all" that match the other filters, if any.
+        // Filter only if one of the 3 filters is set; messageMax < 0 means "give me all" that match
+        // the other filters, if any.
         //
         if (!messageTypes.isEmpty() || !traceCategories.isEmpty() || messageMax > 0) {
             int count = 0;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminLoggerI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminLoggerI.java
@@ -113,8 +113,7 @@ final class LoggerAdminLoggerI implements LoggerAdminLogger, Runnable {
                                     (Void v, Throwable ex) -> {
                                         if (ex != null) {
                                             if (ex instanceof CommunicatorDestroyedException) {
-                                                // Expected if there are outstanding calls during
-                                                // communicator destruction.
+                                                // Expected if there are outstanding calls during communicator destruction.
                                             } else if (ex instanceof LocalException) {
                                                 _loggerAdmin.deadRemoteLogger(
                                                         p,

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminLoggerI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminLoggerI.java
@@ -113,7 +113,8 @@ final class LoggerAdminLoggerI implements LoggerAdminLogger, Runnable {
                                     (Void v, Throwable ex) -> {
                                         if (ex != null) {
                                             if (ex instanceof CommunicatorDestroyedException) {
-                                                // Expected if there are outstanding calls during communicator destruction.
+                                                // Expected if there are outstanding calls during
+                                                // communicator destruction.
                                             } else if (ex instanceof LocalException) {
                                                 _loggerAdmin.deadRemoteLogger(
                                                         p,

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Network.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Network.java
@@ -49,7 +49,8 @@ public final class Network {
     public static boolean connectionRefused(java.net.ConnectException ex) {
         //
         // The JDK raises a generic ConnectException when the server
-        // actively refuses a connection. Unfortunately, our only choice is to search the exception message for distinguishing phrases.
+        // actively refuses a connection. Unfortunately, our only choice is to search the exception
+        // message for distinguishing phrases.
         //
 
         String msg = ex.getMessage();
@@ -328,7 +329,9 @@ public final class Network {
 
         if (System.getProperty("os.name").equals("Linux")) {
             //
-            // Prevent self connect (self connect happens on Linux when a client tries to connect to a server which was just deactivated if the client socket re-uses the same ephemeral port as the server).
+            // Prevent self connect (self connect happens on Linux when a client tries to connect to
+            // a server which was just deactivated if the client socket re-uses the same ephemeral
+            // port as the server).
             //
             if (addr.equals(fd.socket().getLocalSocketAddress())) {
                 closeSocketNoThrow(fd);
@@ -340,7 +343,8 @@ public final class Network {
 
     public static void doFinishConnect(java.nio.channels.SocketChannel fd) {
         //
-        // Note: we don't close the socket if there's an exception. It's the responsibility of the caller to do so.
+        // Note: we don't close the socket if there's an exception. It's the responsibility of the
+        // caller to do so.
         //
 
         try {
@@ -350,7 +354,9 @@ public final class Network {
 
             if (System.getProperty("os.name").equals("Linux")) {
                 //
-                // Prevent self connect (self connect happens on Linux when a client tries to connect to a server which was just deactivated if the client socket re-uses the same ephemeral port as the server).
+                // Prevent self connect (self connect happens on Linux when a client tries to
+                // connect to a server which was just deactivated if the client socket re-uses the
+                // same ephemeral port as the server).
                 //
                 java.net.SocketAddress addr = fd.socket().getRemoteSocketAddress();
                 if (addr != null && addr.equals(fd.socket().getLocalSocketAddress())) {
@@ -647,7 +653,8 @@ public final class Network {
     public static void setTcpBufSize(
             java.nio.channels.SocketChannel socket, ProtocolInstance instance) {
         //
-        // By default, on Windows we use a 128KB buffer size. On Unix platforms, we use the system defaults.
+        // By default, on Windows we use a 128KB buffer size. On Unix platforms, we use the system
+        // defaults.
         //
         int dfltBufSize = 0;
         if (System.getProperty("os.name").startsWith("Windows")) {
@@ -669,12 +676,14 @@ public final class Network {
             ProtocolInstance instance) {
         if (rcvSize > 0) {
             //
-            // Try to set the buffer size. The kernel will silently adjust the size to an acceptable value. Then read the size back to get the size that was actually set.
+            // Try to set the buffer size. The kernel will silently adjust the size to an acceptable
+            // value. Then read the size back to get the size that was actually set.
             //
             setRecvBufferSize(socket, rcvSize);
             int size = getRecvBufferSize(socket);
             if (size < rcvSize) {
-                // Warn if the size that was set is less than the requested size and we have not already warned.
+                // Warn if the size that was set is less than the requested size and we have not
+                // already warned.
                 BufSizeWarnInfo winfo = instance.getBufSizeWarn(TCPEndpointType.value);
                 if (!winfo.rcvWarn || rcvSize != winfo.rcvSize) {
                     instance.logger()
@@ -690,12 +699,14 @@ public final class Network {
 
         if (sndSize > 0) {
             //
-            // Try to set the buffer size. The kernel will silently adjust the size to an acceptable value. Then read the size back to get the size that was actually set.
+            // Try to set the buffer size. The kernel will silently adjust the size to an acceptable
+            // value. Then read the size back to get the size that was actually set.
             //
             setSendBufferSize(socket, sndSize);
             int size = getSendBufferSize(socket);
             if (size < sndSize) {
-                // Warn if the size that was set is less than the requested size and we have not already warned.
+                // Warn if the size that was set is less than the requested size and we have not
+                // already warned.
                 BufSizeWarnInfo winfo = instance.getBufSizeWarn(TCPEndpointType.value);
                 if (!winfo.sndWarn || sndSize != winfo.sndSize) {
                     instance.logger()
@@ -713,7 +724,8 @@ public final class Network {
     public static void setTcpBufSize(
             java.nio.channels.ServerSocketChannel socket, ProtocolInstance instance) {
         //
-        // By default, on Windows we use a 128KB buffer size. On Unix platforms, we use the system defaults.
+        // By default, on Windows we use a 128KB buffer size. On Unix platforms, we use the system
+        // defaults.
         //
         int dfltBufSize = 0;
         if (System.getProperty("os.name").startsWith("Windows")) {
@@ -727,12 +739,14 @@ public final class Network {
                 instance.properties().getPropertyAsIntWithDefault("Ice.TCP.RcvSize", dfltBufSize);
         if (sizeRequested > 0) {
             //
-            // Try to set the buffer size. The kernel will silently adjust the size to an acceptable value. Then read the size back to get the size that was actually set.
+            // Try to set the buffer size. The kernel will silently adjust the size to an acceptable
+            // value. Then read the size back to get the size that was actually set.
             //
             setRecvBufferSize(socket, sizeRequested);
             int size = getRecvBufferSize(socket);
             if (size < sizeRequested) {
-                // Warn if the size that was set is less than the requested size and we have not already warned.
+                // Warn if the size that was set is less than the requested size and we have not
+                // already warned.
                 BufSizeWarnInfo winfo = instance.getBufSizeWarn(TCPEndpointType.value);
                 if (!winfo.rcvWarn || sizeRequested != winfo.rcvSize) {
                     instance.logger()
@@ -874,7 +888,8 @@ public final class Network {
         StringBuffer s = new StringBuffer();
 
         //
-        // In early Android releases, sockets don't correctly report their address and port information.
+        // In early Android releases, sockets don't correctly report their address and port
+        // information.
         //
 
         if (addr == null || addr.isAnyLocalAddress()) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Network.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Network.java
@@ -49,9 +49,7 @@ public final class Network {
     public static boolean connectionRefused(java.net.ConnectException ex) {
         //
         // The JDK raises a generic ConnectException when the server
-        // actively refuses a connection. Unfortunately, our only
-        // choice is to search the exception message for
-        // distinguishing phrases.
+        // actively refuses a connection. Unfortunately, our only choice is to search the exception message for distinguishing phrases.
         //
 
         String msg = ex.getMessage();
@@ -115,8 +113,7 @@ public final class Network {
             // It's not possible to set TCP_NODELAY or KEEP_ALIVE on a server socket in Java
             //
             // java.net.Socket socket = fd.socket();
-            // socket.setTcpNoDelay(true);
-            // socket.setKeepAlive(true);
+            // socket.setTcpNoDelay(true); socket.setKeepAlive(true);
             return fd;
         } catch (java.io.IOException ex) {
             throw new SocketException(ex);
@@ -331,9 +328,7 @@ public final class Network {
 
         if (System.getProperty("os.name").equals("Linux")) {
             //
-            // Prevent self connect (self connect happens on Linux when a client tries to connect to
-            // a server which was just deactivated if the client socket re-uses the same ephemeral
-            // port as the server).
+            // Prevent self connect (self connect happens on Linux when a client tries to connect to a server which was just deactivated if the client socket re-uses the same ephemeral port as the server).
             //
             if (addr.equals(fd.socket().getLocalSocketAddress())) {
                 closeSocketNoThrow(fd);
@@ -345,8 +340,7 @@ public final class Network {
 
     public static void doFinishConnect(java.nio.channels.SocketChannel fd) {
         //
-        // Note: we don't close the socket if there's an exception. It's the responsibility
-        // of the caller to do so.
+        // Note: we don't close the socket if there's an exception. It's the responsibility of the caller to do so.
         //
 
         try {
@@ -356,11 +350,7 @@ public final class Network {
 
             if (System.getProperty("os.name").equals("Linux")) {
                 //
-                // Prevent self connect (self connect happens on Linux when a client tries to
-                // connect to
-                // a server which was just deactivated if the client socket re-uses the same
-                // ephemeral
-                // port as the server).
+                // Prevent self connect (self connect happens on Linux when a client tries to connect to a server which was just deactivated if the client socket re-uses the same ephemeral port as the server).
                 //
                 java.net.SocketAddress addr = fd.socket().getRemoteSocketAddress();
                 if (addr != null && addr.equals(fd.socket().getLocalSocketAddress())) {
@@ -657,8 +647,7 @@ public final class Network {
     public static void setTcpBufSize(
             java.nio.channels.SocketChannel socket, ProtocolInstance instance) {
         //
-        // By default, on Windows we use a 128KB buffer size. On Unix
-        // platforms, we use the system defaults.
+        // By default, on Windows we use a 128KB buffer size. On Unix platforms, we use the system defaults.
         //
         int dfltBufSize = 0;
         if (System.getProperty("os.name").startsWith("Windows")) {
@@ -680,15 +669,12 @@ public final class Network {
             ProtocolInstance instance) {
         if (rcvSize > 0) {
             //
-            // Try to set the buffer size. The kernel will silently adjust
-            // the size to an acceptable value. Then read the size back to
-            // get the size that was actually set.
+            // Try to set the buffer size. The kernel will silently adjust the size to an acceptable value. Then read the size back to get the size that was actually set.
             //
             setRecvBufferSize(socket, rcvSize);
             int size = getRecvBufferSize(socket);
             if (size < rcvSize) {
-                // Warn if the size that was set is less than the requested size and
-                // we have not already warned.
+                // Warn if the size that was set is less than the requested size and we have not already warned.
                 BufSizeWarnInfo winfo = instance.getBufSizeWarn(TCPEndpointType.value);
                 if (!winfo.rcvWarn || rcvSize != winfo.rcvSize) {
                     instance.logger()
@@ -704,15 +690,12 @@ public final class Network {
 
         if (sndSize > 0) {
             //
-            // Try to set the buffer size. The kernel will silently adjust
-            // the size to an acceptable value. Then read the size back to
-            // get the size that was actually set.
+            // Try to set the buffer size. The kernel will silently adjust the size to an acceptable value. Then read the size back to get the size that was actually set.
             //
             setSendBufferSize(socket, sndSize);
             int size = getSendBufferSize(socket);
             if (size < sndSize) {
-                // Warn if the size that was set is less than the requested size and
-                // we have not already warned.
+                // Warn if the size that was set is less than the requested size and we have not already warned.
                 BufSizeWarnInfo winfo = instance.getBufSizeWarn(TCPEndpointType.value);
                 if (!winfo.sndWarn || sndSize != winfo.sndSize) {
                     instance.logger()
@@ -730,8 +713,7 @@ public final class Network {
     public static void setTcpBufSize(
             java.nio.channels.ServerSocketChannel socket, ProtocolInstance instance) {
         //
-        // By default, on Windows we use a 128KB buffer size. On Unix
-        // platforms, we use the system defaults.
+        // By default, on Windows we use a 128KB buffer size. On Unix platforms, we use the system defaults.
         //
         int dfltBufSize = 0;
         if (System.getProperty("os.name").startsWith("Windows")) {
@@ -745,15 +727,12 @@ public final class Network {
                 instance.properties().getPropertyAsIntWithDefault("Ice.TCP.RcvSize", dfltBufSize);
         if (sizeRequested > 0) {
             //
-            // Try to set the buffer size. The kernel will silently adjust
-            // the size to an acceptable value. Then read the size back to
-            // get the size that was actually set.
+            // Try to set the buffer size. The kernel will silently adjust the size to an acceptable value. Then read the size back to get the size that was actually set.
             //
             setRecvBufferSize(socket, sizeRequested);
             int size = getRecvBufferSize(socket);
             if (size < sizeRequested) {
-                // Warn if the size that was set is less than the requested size and
-                // we have not already warned.
+                // Warn if the size that was set is less than the requested size and we have not already warned.
                 BufSizeWarnInfo winfo = instance.getBufSizeWarn(TCPEndpointType.value);
                 if (!winfo.rcvWarn || sizeRequested != winfo.rcvSize) {
                     instance.logger()
@@ -895,8 +874,7 @@ public final class Network {
         StringBuffer s = new StringBuffer();
 
         //
-        // In early Android releases, sockets don't correctly report their address and
-        // port information.
+        // In early Android releases, sockets don't correctly report their address and port information.
         //
 
         if (addr == null || addr.isAnyLocalAddress()) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapterFactory.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapterFactory.java
@@ -113,8 +113,7 @@ final class ObjectAdapterFactory {
         }
 
         //
-        // Must be called outside the synchronization since initialize can make client invocations
-        // on the router if it's set.
+        // Must be called outside the synchronization since initialize can make client invocations on the router if it's set.
         //
         ObjectAdapter adapter = null;
         try {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapterFactory.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapterFactory.java
@@ -113,7 +113,8 @@ final class ObjectAdapterFactory {
         }
 
         //
-        // Must be called outside the synchronization since initialize can make client invocations on the router if it's set.
+        // Must be called outside the synchronization since initialize can make client invocations
+        // on the router if it's set.
         //
         ObjectAdapter adapter = null;
         try {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObserverMiddleware.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObserverMiddleware.java
@@ -31,9 +31,7 @@ final class ObserverMiddleware implements Object {
                                 (response, exception) -> {
                                     if (exception != null) {
                                         // We need to marshal the exception into the response
-                                        // immediately to observe
-                                        // the response size.
-                                        // TODO: should we really marshal/handle errors here?
+                                        // immediately to observe the response size. TODO: should we really marshal/handle errors here?
                                         response =
                                                 request.current.createOutgoingResponse(exception);
                                     }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObserverMiddleware.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObserverMiddleware.java
@@ -31,7 +31,8 @@ final class ObserverMiddleware implements Object {
                                 (response, exception) -> {
                                     if (exception != null) {
                                         // We need to marshal the exception into the response
-                                        // immediately to observe the response size. TODO: should we really marshal/handle errors here?
+                                        // immediately to observe the response size. TODO: should we
+                                        // really marshal/handle errors here?
                                         response =
                                                 request.current.createOutgoingResponse(exception);
                                     }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Options.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Options.java
@@ -31,13 +31,19 @@ public final class Options {
                         switch (c) {
                             case '\\':
                                 {
-                                    // Ignore a backslash at the end of the string, and strip backslash-newline pairs.
+                                    // Ignore a backslash at the end of the string, and strip
+                                    // backslash-newline pairs.
                                     //
                                     // If a backslash comes before a space, single quote, double
-                                    // quote, or dollar sign we drop the backslash, but still write the the space, quote, or dollar sign. This is necessary to allow quotes to be escaped. Dropping the backslash preceding a space deviates from bash quoting rules, but is necessary so we don't drop backslashes from Windows path names.
+                                    // quote, or dollar sign we drop the backslash, but still write
+                                    // the the space, quote, or dollar sign. This is necessary to
+                                    // allow quotes to be escaped. Dropping the backslash preceding
+                                    // a space deviates from bash quoting rules, but is necessary so
+                                    // we don't drop backslashes from Windows path names.
                                     if (i < line.length() - 1 && line.charAt(++i) != '\n') {
                                         char nextChar = line.charAt(i);
-                                        // TODO: comment says we should be checking single quotes here, but we aren't?
+                                        // TODO: comment says we should be checking single quotes
+                                        // here, but we aren't?
                                         if (nextChar != ' '
                                                 && nextChar != '$'
                                                 && nextChar != '\\'
@@ -61,7 +67,8 @@ public final class Options {
                             case '$':
                                 {
                                     if (i < line.length() - 1 && line.charAt(i + 1) == '\'') {
-                                        // Bash uses $'<text>' to allow ANSI escape sequences within <text>.
+                                        // Bash uses $'<text>' to allow ANSI escape sequences within
+                                        // <text>.
                                         state = ANSIQuoteState;
                                         ++i;
                                     } else {
@@ -254,9 +261,12 @@ public final class Options {
                                                                     (Character.toUpperCase(c)
                                                                             - '@'));
                                                 } else {
-                                                    // Bash does not define what should happen if a \c is not followed by a recognized control
+                                                    // Bash does not define what should happen if a
+                                                    // \c is not followed by a recognized control
                                                     // character.
-                                                    // We simply treat this case like other unrecognized escape sequences, that is, we preserve the escape sequence unchanged.
+                                                    // We simply treat this case like other
+                                                    // unrecognized escape sequences, that is, we
+                                                    // preserve the escape sequence unchanged.
                                                     arg.append('\\');
                                                     arg.append('c');
                                                     arg.append(c);
@@ -264,8 +274,10 @@ public final class Options {
                                                 break;
                                             }
 
-                                        // If inside an ANSI-quoted string, a backslash isn't followed by
-                                        // one of the recognized characters, both the backslash and the character are preserved.
+                                        // If inside an ANSI-quoted string, a backslash isn't
+                                        // followed by
+                                        // one of the recognized characters, both the backslash and
+                                        // the character are preserved.
                                         default:
                                             {
                                                 arg.append('\\');

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Options.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Options.java
@@ -31,22 +31,13 @@ public final class Options {
                         switch (c) {
                             case '\\':
                                 {
-                                    // Ignore a backslash at the end of the string, and strip
-                                    // backslash-newline pairs.
+                                    // Ignore a backslash at the end of the string, and strip backslash-newline pairs.
                                     //
                                     // If a backslash comes before a space, single quote, double
-                                    // quote, or dollar sign
-                                    // we drop the backslash, but still write the the space, quote,
-                                    // or dollar sign.
-                                    // This is necessary to allow quotes to be escaped. Dropping the
-                                    // backslash
-                                    // preceding a space deviates from bash quoting rules, but is
-                                    // necessary so we
-                                    // don't drop backslashes from Windows path names.
+                                    // quote, or dollar sign we drop the backslash, but still write the the space, quote, or dollar sign. This is necessary to allow quotes to be escaped. Dropping the backslash preceding a space deviates from bash quoting rules, but is necessary so we don't drop backslashes from Windows path names.
                                     if (i < line.length() - 1 && line.charAt(++i) != '\n') {
                                         char nextChar = line.charAt(i);
-                                        // TODO: comment says we should be checking single quotes
-                                        // here, but we aren't?
+                                        // TODO: comment says we should be checking single quotes here, but we aren't?
                                         if (nextChar != ' '
                                                 && nextChar != '$'
                                                 && nextChar != '\\'
@@ -70,8 +61,7 @@ public final class Options {
                             case '$':
                                 {
                                     if (i < line.length() - 1 && line.charAt(i + 1) == '\'') {
-                                        // Bash uses $'<text>' to allow ANSI escape sequences within
-                                        // <text>.
+                                        // Bash uses $'<text>' to allow ANSI escape sequences within <text>.
                                         state = ANSIQuoteState;
                                         ++i;
                                     } else {
@@ -264,15 +254,9 @@ public final class Options {
                                                                     (Character.toUpperCase(c)
                                                                             - '@'));
                                                 } else {
-                                                    // Bash does not define what should happen if a
-                                                    // \c
-                                                    // is not followed by a recognized control
+                                                    // Bash does not define what should happen if a \c is not followed by a recognized control
                                                     // character.
-                                                    // We simply treat this case like other
-                                                    // unrecognized
-                                                    // escape sequences, that is, we preserve the
-                                                    // escape
-                                                    // sequence unchanged.
+                                                    // We simply treat this case like other unrecognized escape sequences, that is, we preserve the escape sequence unchanged.
                                                     arg.append('\\');
                                                     arg.append('c');
                                                     arg.append(c);
@@ -280,11 +264,8 @@ public final class Options {
                                                 break;
                                             }
 
-                                        // If inside an ANSI-quoted string, a backslash isn't
-                                        // followed by
-                                        // one of the recognized characters, both the backslash
-                                        // and the
-                                        // character are preserved.
+                                        // If inside an ANSI-quoted string, a backslash isn't followed by
+                                        // one of the recognized characters, both the backslash and the character are preserved.
                                         default:
                                             {
                                                 arg.append('\\');

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingAsync.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingAsync.java
@@ -126,8 +126,7 @@ public class OutgoingAsync<T> extends ProxyOutgoingAsyncBase<T> {
 
     @Override
     public int invokeCollocated(CollocatedRequestHandler handler) {
-        // The stream cannot be cached if the proxy is not a twoway or there is an invocation
-        // timeout set.
+        // The stream cannot be cached if the proxy is not a twoway or there is an invocation timeout set.
         if (!_proxy.ice_isTwoway()
                 || _proxy._getReference().getInvocationTimeout().compareTo(Duration.ZERO) > 0) {
             // Disable caching by marking the streams as cached!
@@ -204,8 +203,7 @@ public class OutgoingAsync<T> extends ProxyOutgoingAsyncBase<T> {
     public final boolean completed(InputStream is) {
         //
         // NOTE: this method is called from ConnectionI.parseMessage
-        // with the connection locked. Therefore, it must not invoke
-        // any user callbacks.
+        // with the connection locked. Therefore, it must not invoke any user callbacks.
         //
 
         // _is can already be initialized if the invocation is retried

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingAsync.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingAsync.java
@@ -126,7 +126,8 @@ public class OutgoingAsync<T> extends ProxyOutgoingAsyncBase<T> {
 
     @Override
     public int invokeCollocated(CollocatedRequestHandler handler) {
-        // The stream cannot be cached if the proxy is not a twoway or there is an invocation timeout set.
+        // The stream cannot be cached if the proxy is not a twoway or there is an invocation
+        // timeout set.
         if (!_proxy.ice_isTwoway()
                 || _proxy._getReference().getInvocationTimeout().compareTo(Duration.ZERO) > 0) {
             // Disable caching by marking the streams as cached!

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingAsyncBase.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingAsyncBase.java
@@ -4,8 +4,7 @@ package com.zeroc.Ice;
 
 //
 // Base class for handling asynchronous invocations. This class is
-// responsible for the handling of the output stream and the child
-// invocation observer.
+// responsible for the handling of the output stream and the child invocation observer.
 //
 abstract class OutgoingAsyncBase<T> extends InvocationFuture<T> {
     public boolean sent() {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingConnectionFactory.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingConnectionFactory.java
@@ -57,7 +57,9 @@ final class OutgoingConnectionFactory {
         java.util.Map<Connector, java.util.List<ConnectionI>> connections = null;
         synchronized (this) {
             //
-            // First we wait until the factory is destroyed. We also wait until there are no pending connections anymore. Only then we can be sure the _connections contains all connections.
+            // First we wait until the factory is destroyed. We also wait until there are no pending
+            // connections anymore. Only then we can be sure the _connections contains all
+            // connections.
             //
             while (!_destroyed || !_pending.isEmpty() || _pendingConnectCount > 0) {
                 try {
@@ -68,7 +70,8 @@ final class OutgoingConnectionFactory {
             }
 
             //
-            // We want to wait until all connections are finished outside the thread synchronization.
+            // We want to wait until all connections are finished outside the thread
+            // synchronization.
             //
             connections = new java.util.HashMap<>(_connections);
         }
@@ -145,9 +148,11 @@ final class OutgoingConnectionFactory {
                 //
                 // The Connection object does not take the compression flag of
                 // endpoints into account, but instead gets the information
-                // about whether messages should be compressed or not from other sources. In order to allow connection sharing for
+                // about whether messages should be compressed or not from other sources. In order
+                // to allow connection sharing for
                 // endpoints that differ in the value of the compression flag
-                // only, we always set the compression flag to false here in this connection factory. We also clear the timeout as it is
+                // only, we always set the compression flag to false here in this connection
+                // factory. We also clear the timeout as it is
                 // no longer used for Ice 3.8.
                 //
                 endpoint = endpoint.compress(false).timeout(-1);
@@ -343,7 +348,8 @@ final class OutgoingConnectionFactory {
 
             if (addToPending(cb, connectors)) {
                 // A connection to one of our endpoints is pending. The callback will be notified
-                // once the connection is established. Returning null indicates that the connection is still pending.
+                // once the connection is established. Returning null indicates that the connection
+                // is still pending.
                 return null;
             }
         }
@@ -501,7 +507,9 @@ final class OutgoingConnectionFactory {
         }
 
         //
-        // If there's no pending connection for the given connectors, we're responsible for its establishment. We add empty pending lists, other callbacks to the same connectors will be queued.
+        // If there's no pending connection for the given connectors, we're responsible for its
+        // establishment. We add empty pending lists, other callbacks to the same connectors will be
+        // queued.
         //
         for (ConnectorInfo p : connectors) {
             if (!_pending.containsKey(p.connector)) {
@@ -699,7 +707,9 @@ final class OutgoingConnectionFactory {
         private void getConnectors() {
             try {
                 //
-                // Notify the factory that there's an async connect pending. This is necessary to prevent the outgoing connection factory to be destroyed before all the pending asynchronous connects are finished.
+                // Notify the factory that there's an async connect pending. This is necessary to
+                // prevent the outgoing connection factory to be destroyed before all the pending
+                // asynchronous connects are finished.
                 //
                 _factory.incPendingConnectCount();
             } catch (LocalException ex) {
@@ -730,7 +740,8 @@ final class OutgoingConnectionFactory {
                 if (connection == null) {
                     //
                     // A null return value from getConnection indicates that the connection
-                    // is being established and that everything has been done to ensure that the callback will be notified when the connection establishment is done.
+                    // is being established and that everything has been done to ensure that the
+                    // callback will be notified when the connection establishment is done.
                     //
                     return;
                 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingConnectionFactory.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingConnectionFactory.java
@@ -57,10 +57,7 @@ final class OutgoingConnectionFactory {
         java.util.Map<Connector, java.util.List<ConnectionI>> connections = null;
         synchronized (this) {
             //
-            // First we wait until the factory is destroyed. We also
-            // wait until there are no pending connections
-            // anymore. Only then we can be sure the _connections
-            // contains all connections.
+            // First we wait until the factory is destroyed. We also wait until there are no pending connections anymore. Only then we can be sure the _connections contains all connections.
             //
             while (!_destroyed || !_pending.isEmpty() || _pendingConnectCount > 0) {
                 try {
@@ -71,8 +68,7 @@ final class OutgoingConnectionFactory {
             }
 
             //
-            // We want to wait until all connections are finished outside the
-            // thread synchronization.
+            // We want to wait until all connections are finished outside the thread synchronization.
             //
             connections = new java.util.HashMap<>(_connections);
         }
@@ -143,18 +139,15 @@ final class OutgoingConnectionFactory {
             //
             // Search for connections to the router's client proxy
             // endpoints, and update the object adapter for such
-            // connections, so that callbacks from the router can be
-            // received over such connections.
+            // connections, so that callbacks from the router can be received over such connections.
             //
             for (EndpointI endpoint : endpoints) {
                 //
                 // The Connection object does not take the compression flag of
                 // endpoints into account, but instead gets the information
-                // about whether messages should be compressed or not from
-                // other sources. In order to allow connection sharing for
+                // about whether messages should be compressed or not from other sources. In order to allow connection sharing for
                 // endpoints that differ in the value of the compression flag
-                // only, we always set the compression flag to false here in
-                // this connection factory. We also clear the timeout as it is
+                // only, we always set the compression flag to false here in this connection factory. We also clear the timeout as it is
                 // no longer used for Ice 3.8.
                 //
                 endpoint = endpoint.compress(false).timeout(-1);
@@ -350,15 +343,13 @@ final class OutgoingConnectionFactory {
 
             if (addToPending(cb, connectors)) {
                 // A connection to one of our endpoints is pending. The callback will be notified
-                // once the connection
-                // is established. Returning null indicates that the connection is still pending.
+                // once the connection is established. Returning null indicates that the connection is still pending.
                 return null;
             }
         }
 
         // No connection is pending. Call nextConnector to initiate connection establishment. Return
-        // null to indicate
-        // that the connection is still pending.
+        // null to indicate that the connection is still pending.
         cb.nextConnector();
         return null;
     }
@@ -510,9 +501,7 @@ final class OutgoingConnectionFactory {
         }
 
         //
-        // If there's no pending connection for the given connectors, we're
-        // responsible for its establishment. We add empty pending lists,
-        // other callbacks to the same connectors will be queued.
+        // If there's no pending connection for the given connectors, we're responsible for its establishment. We add empty pending lists, other callbacks to the same connectors will be queued.
         //
         for (ConnectorInfo p : connectors) {
             if (!_pending.containsKey(p.connector)) {
@@ -710,9 +699,7 @@ final class OutgoingConnectionFactory {
         private void getConnectors() {
             try {
                 //
-                // Notify the factory that there's an async connect pending. This is necessary
-                // to prevent the outgoing connection factory to be destroyed before all the
-                // pending asynchronous connects are finished.
+                // Notify the factory that there's an async connect pending. This is necessary to prevent the outgoing connection factory to be destroyed before all the pending asynchronous connects are finished.
                 //
                 _factory.incPendingConnectCount();
             } catch (LocalException ex) {
@@ -736,17 +723,14 @@ final class OutgoingConnectionFactory {
         private void getConnection() {
             try {
                 //
-                // If all the connectors have been created, we ask the factory to get a
-                // connection.
+                // If all the connectors have been created, we ask the factory to get a connection.
                 //
                 Holder<Boolean> compress = new Holder<>();
                 ConnectionI connection = _factory.getConnection(_connectors, this, compress);
                 if (connection == null) {
                     //
                     // A null return value from getConnection indicates that the connection
-                    // is being established and that everything has been done to ensure that
-                    // the callback will be notified when the connection establishment is
-                    // done.
+                    // is being established and that everything has been done to ensure that the callback will be notified when the connection establishment is done.
                     //
                     return;
                 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutputStream.java
@@ -47,11 +47,7 @@ public final class OutputStream {
      * @param direct Indicates whether to use a direct buffer.
      */
     public OutputStream(EncodingVersion encoding, FormatType format, boolean direct) {
-        // The 1.0 encoding doesn't use the class format type, but we still have to set
-        // it in case
-        // the stream reads an 1.1 encapsulation, in which case it would use the format
-        // type set
-        // in the stream.
+        // The 1.0 encoding doesn't use the class format type, but we still have to set it in case the stream reads an 1.1 encapsulation, in which case it would use the format type set in the stream.
         _buf = new Buffer(direct);
         _encoding = encoding;
         _format = format;
@@ -127,10 +123,7 @@ public final class OutputStream {
         _encoding = tmpEncoding;
 
         //
-        // Swap is never called for streams that have encapsulations being written.
-        // However,
-        // encapsulations might still be set in case marshaling failed. We just
-        // reset the encapsulations if there are still some set.
+        // Swap is never called for streams that have encapsulations being written. However, encapsulations might still be set in case marshaling failed. We just reset the encapsulations if there are still some set.
         //
         resetEncapsulation();
         other.resetEncapsulation();
@@ -201,9 +194,7 @@ public final class OutputStream {
     /** Writes the start of an encapsulation to the stream. */
     public void startEncapsulation() {
         //
-        // If no encoding version is specified, use the current write
-        // encapsulation encoding version if there's a current write
-        // encapsulation, otherwise, use the stream encoding version.
+        // If no encoding version is specified, use the current write encapsulation encoding version if there's a current write encapsulation, otherwise, use the stream encoding version.
         //
 
         if (_encapsStack != null) {
@@ -320,13 +311,9 @@ public final class OutputStream {
                 ? _encapsStack.encoding_1_0
                 : _encoding.equals(Util.Encoding_1_0)) {
             //
-            // If using the 1.0 encoding and no instances were written, we
-            // still write an empty sequence for pending instances if
-            // requested (i.e.: if this is called).
+            // If using the 1.0 encoding and no instances were written, we still write an empty sequence for pending instances if requested (i.e.: if this is called).
             //
-            // This is required by the 1.0 encoding, even if no instances
-            // are written we do marshal an empty sequence if marshaled
-            // data types use classes.
+            // This is required by the 1.0 encoding, even if no instances are written we do marshal an empty sequence if marshaled data types use classes.
             //
             writeSize(0);
         }
@@ -1491,12 +1478,9 @@ public final class OutputStream {
         @Override
         void writeException(UserException v) {
             //
-            // User exception with the 1.0 encoding start with a boolean
-            // flag that indicates whether or not the exception uses
-            // classes.
+            // User exception with the 1.0 encoding start with a boolean flag that indicates whether or not the exception uses classes.
             //
-            // This allows reading the pending instances even if some part of
-            // the exception was sliced.
+            // This allows reading the pending instances even if some part of the exception was sliced.
             //
             boolean usesClasses = v._usesClasses();
             _stream.writeBool(usesClasses);
@@ -1528,8 +1512,7 @@ public final class OutputStream {
         void startSlice(String typeId, int compactId, boolean last) {
             //
             // For instance slices, encode a boolean to indicate how the type ID
-            // is encoded and the type ID either as a string or index. For
-            // exception slices, always encode the type ID as a string.
+            // is encoded and the type ID either as a string or index. For exception slices, always encode the type ID as a string.
             //
             if (_sliceType == SliceType.ValueSlice) {
                 int index = registerTypeId(typeId);
@@ -1562,8 +1545,7 @@ public final class OutputStream {
         void writePendingValues() {
             while (!_toBeMarshaledMap.isEmpty()) {
                 //
-                // Consider the to be marshaled instances as marshaled now,
-                // this is necessary to avoid adding again the "to be
+                // Consider the to be marshaled instances as marshaled now, this is necessary to avoid adding again the "to be
                 // marshaled instances" into _toBeMarshaledMap while writing
                 // instances.
                 //
@@ -1574,9 +1556,7 @@ public final class OutputStream {
                 _stream.writeSize(savedMap.size());
                 for (java.util.Map.Entry<Value, Integer> p : savedMap.entrySet()) {
                     //
-                    // Ask the instance to marshal itself. Any new class
-                    // instances that are triggered by the classes marshaled
-                    // are added to toBeMarshaledMap.
+                    // Ask the instance to marshal itself. Any new class instances that are triggered by the classes marshaled are added to toBeMarshaledMap.
                     //
                     _stream.writeInt(p.getValue().intValue());
 
@@ -1645,11 +1625,7 @@ public final class OutputStream {
                 }
 
                 //
-                // If writing an instance within a slice and using the sliced
-                // format, write an index from the instance indirection
-                // table. The indirect instance table is encoded at the end of
-                // each slice and is always read (even if the Slice is
-                // unknown).
+                // If writing an instance within a slice and using the sliced format, write an index from the instance indirection table. The indirect instance table is encoded at the end of each slice and is always read (even if the Slice is unknown).
                 //
                 Integer index = _current.indirectionMap.get(v);
                 if (index == null) {
@@ -1711,14 +1687,11 @@ public final class OutputStream {
             _stream.writeByte((byte) 0); // Placeholder for the slice flags
 
             //
-            // For instance slices, encode the flag and the type ID either as a
-            // string or index. For exception slices, always encode the type
-            // ID a string.
+            // For instance slices, encode the flag and the type ID either as a string or index. For exception slices, always encode the type ID a string.
             //
             if (_current.sliceType == SliceType.ValueSlice) {
                 //
-                // Encode the type ID (only in the first slice for the compact
-                // encoding).
+                // Encode the type ID (only in the first slice for the compact encoding).
                 //
                 if (_encaps.format == FormatType.SlicedFormat || _current.firstSlice) {
                     if (compactId >= 0) {
@@ -1750,9 +1723,7 @@ public final class OutputStream {
         @Override
         void endSlice() {
             //
-            // Write the optional member end marker if some optional members
-            // were encoded. Note that the optional members are encoded before
-            // the indirection table and are included in the slice size.
+            // Write the optional member end marker if some optional members were encoded. Note that the optional members are encoded before the indirection table and are included in the slice size.
             //
             if ((_current.sliceFlags & Protocol.FLAG_HAS_OPTIONAL_MEMBERS) != 0) {
                 _stream.writeByte((byte) Protocol.OPTIONAL_END_MARKER);
@@ -1920,10 +1891,7 @@ public final class OutputStream {
     }
 
     //
-    // The encoding version to use when there's no encapsulation to
-    // read from or write to. This is for example used to read message
-    // headers or when the user is using the streaming API with no
-    // encapsulation.
+    // The encoding version to use when there's no encapsulation to read from or write to. This is for example used to read message headers or when the user is using the streaming API with no encapsulation.
     //
     private EncodingVersion _encoding;
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutputStream.java
@@ -47,7 +47,9 @@ public final class OutputStream {
      * @param direct Indicates whether to use a direct buffer.
      */
     public OutputStream(EncodingVersion encoding, FormatType format, boolean direct) {
-        // The 1.0 encoding doesn't use the class format type, but we still have to set it in case the stream reads an 1.1 encapsulation, in which case it would use the format type set in the stream.
+        // The 1.0 encoding doesn't use the class format type, but we still have to set it in case
+        // the stream reads an 1.1 encapsulation, in which case it would use the format type set in
+        // the stream.
         _buf = new Buffer(direct);
         _encoding = encoding;
         _format = format;
@@ -123,7 +125,9 @@ public final class OutputStream {
         _encoding = tmpEncoding;
 
         //
-        // Swap is never called for streams that have encapsulations being written. However, encapsulations might still be set in case marshaling failed. We just reset the encapsulations if there are still some set.
+        // Swap is never called for streams that have encapsulations being written. However,
+        // encapsulations might still be set in case marshaling failed. We just reset the
+        // encapsulations if there are still some set.
         //
         resetEncapsulation();
         other.resetEncapsulation();
@@ -194,7 +198,8 @@ public final class OutputStream {
     /** Writes the start of an encapsulation to the stream. */
     public void startEncapsulation() {
         //
-        // If no encoding version is specified, use the current write encapsulation encoding version if there's a current write encapsulation, otherwise, use the stream encoding version.
+        // If no encoding version is specified, use the current write encapsulation encoding version
+        // if there's a current write encapsulation, otherwise, use the stream encoding version.
         //
 
         if (_encapsStack != null) {
@@ -311,9 +316,11 @@ public final class OutputStream {
                 ? _encapsStack.encoding_1_0
                 : _encoding.equals(Util.Encoding_1_0)) {
             //
-            // If using the 1.0 encoding and no instances were written, we still write an empty sequence for pending instances if requested (i.e.: if this is called).
+            // If using the 1.0 encoding and no instances were written, we still write an empty
+            // sequence for pending instances if requested (i.e.: if this is called).
             //
-            // This is required by the 1.0 encoding, even if no instances are written we do marshal an empty sequence if marshaled data types use classes.
+            // This is required by the 1.0 encoding, even if no instances are written we do marshal
+            // an empty sequence if marshaled data types use classes.
             //
             writeSize(0);
         }
@@ -1478,9 +1485,11 @@ public final class OutputStream {
         @Override
         void writeException(UserException v) {
             //
-            // User exception with the 1.0 encoding start with a boolean flag that indicates whether or not the exception uses classes.
+            // User exception with the 1.0 encoding start with a boolean flag that indicates whether
+            // or not the exception uses classes.
             //
-            // This allows reading the pending instances even if some part of the exception was sliced.
+            // This allows reading the pending instances even if some part of the exception was
+            // sliced.
             //
             boolean usesClasses = v._usesClasses();
             _stream.writeBool(usesClasses);
@@ -1512,7 +1521,8 @@ public final class OutputStream {
         void startSlice(String typeId, int compactId, boolean last) {
             //
             // For instance slices, encode a boolean to indicate how the type ID
-            // is encoded and the type ID either as a string or index. For exception slices, always encode the type ID as a string.
+            // is encoded and the type ID either as a string or index. For exception slices, always
+            // encode the type ID as a string.
             //
             if (_sliceType == SliceType.ValueSlice) {
                 int index = registerTypeId(typeId);
@@ -1545,7 +1555,8 @@ public final class OutputStream {
         void writePendingValues() {
             while (!_toBeMarshaledMap.isEmpty()) {
                 //
-                // Consider the to be marshaled instances as marshaled now, this is necessary to avoid adding again the "to be
+                // Consider the to be marshaled instances as marshaled now, this is necessary to
+                // avoid adding again the "to be
                 // marshaled instances" into _toBeMarshaledMap while writing
                 // instances.
                 //
@@ -1556,7 +1567,8 @@ public final class OutputStream {
                 _stream.writeSize(savedMap.size());
                 for (java.util.Map.Entry<Value, Integer> p : savedMap.entrySet()) {
                     //
-                    // Ask the instance to marshal itself. Any new class instances that are triggered by the classes marshaled are added to toBeMarshaledMap.
+                    // Ask the instance to marshal itself. Any new class instances that are
+                    // triggered by the classes marshaled are added to toBeMarshaledMap.
                     //
                     _stream.writeInt(p.getValue().intValue());
 
@@ -1625,7 +1637,9 @@ public final class OutputStream {
                 }
 
                 //
-                // If writing an instance within a slice and using the sliced format, write an index from the instance indirection table. The indirect instance table is encoded at the end of each slice and is always read (even if the Slice is unknown).
+                // If writing an instance within a slice and using the sliced format, write an index
+                // from the instance indirection table. The indirect instance table is encoded at
+                // the end of each slice and is always read (even if the Slice is unknown).
                 //
                 Integer index = _current.indirectionMap.get(v);
                 if (index == null) {
@@ -1687,7 +1701,8 @@ public final class OutputStream {
             _stream.writeByte((byte) 0); // Placeholder for the slice flags
 
             //
-            // For instance slices, encode the flag and the type ID either as a string or index. For exception slices, always encode the type ID a string.
+            // For instance slices, encode the flag and the type ID either as a string or index. For
+            // exception slices, always encode the type ID a string.
             //
             if (_current.sliceType == SliceType.ValueSlice) {
                 //
@@ -1723,7 +1738,9 @@ public final class OutputStream {
         @Override
         void endSlice() {
             //
-            // Write the optional member end marker if some optional members were encoded. Note that the optional members are encoded before the indirection table and are included in the slice size.
+            // Write the optional member end marker if some optional members were encoded. Note that
+            // the optional members are encoded before the indirection table and are included in the
+            // slice size.
             //
             if ((_current.sliceFlags & Protocol.FLAG_HAS_OPTIONAL_MEMBERS) != 0) {
                 _stream.writeByte((byte) Protocol.OPTIONAL_END_MARKER);
@@ -1891,7 +1908,9 @@ public final class OutputStream {
     }
 
     //
-    // The encoding version to use when there's no encapsulation to read from or write to. This is for example used to read message headers or when the user is using the streaming API with no encapsulation.
+    // The encoding version to use when there's no encapsulation to read from or write to. This is
+    // for example used to read message headers or when the user is using the streaming API with no
+    // encapsulation.
     //
     private EncodingVersion _encoding;
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutputStreamWrapper.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutputStreamWrapper.java
@@ -108,7 +108,9 @@ class OutputStreamWrapper extends java.io.OutputStream {
 
     @Override
     public void flush() throws IOException {
-        // This does nothing because we do not know the final size of a writable stream until it is closed, and we cannot write to the stream until we know whether the final size is < 255 or not.
+        // This does nothing because we do not know the final size of a writable stream until it is
+        // closed, and we cannot write to the stream until we know whether the final size is < 255
+        // or not.
     }
 
     @Override

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutputStreamWrapper.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutputStreamWrapper.java
@@ -108,9 +108,7 @@ class OutputStreamWrapper extends java.io.OutputStream {
 
     @Override
     public void flush() throws IOException {
-        // This does nothing because we do not know the final size of a writable stream until it is
-        // closed,
-        // and we cannot write to the stream until we know whether the final size is < 255 or not.
+        // This does nothing because we do not know the final size of a writable stream until it is closed, and we cannot write to the stream until we know whether the final size is < 255 or not.
     }
 
     @Override

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
@@ -366,7 +366,8 @@ public final class Properties {
             throw new InitializationException("Attempt to set property with empty key");
         }
 
-        // Check if the property is in an Ice property prefix. If so, check that it's a valid property.
+        // Check if the property is in an Ice property prefix. If so, check that it's a valid
+        // property.
         PropertyArray propertyArray = findIcePropertyArray(key);
         if (propertyArray != null) {
             if (propertyArray.isOptIn()
@@ -806,7 +807,9 @@ public final class Properties {
     static Property findProperty(String key, PropertyArray propertyArray) {
         for (Property prop : propertyArray.properties()) {
             String pattern = prop.pattern();
-            // If the key is an exact match, return the property unless it has a property class which is prefix only. If the key is a regex match, return the property. A property cannot have a property class and use regex.
+            // If the key is an exact match, return the property unless it has a property class
+            // which is prefix only. If the key is a regex match, return the property. A property
+            // cannot have a property class and use regex.
             if (key.equals(pattern)) {
                 if (prop.propertyArray() != null && prop.propertyArray().prefixOnly()) {
                     return null;
@@ -827,7 +830,8 @@ public final class Properties {
                         && key.startsWith(pattern)
                         && key.charAt(pattern.length()) == '.') {
                     String substring = key.substring(pattern.length() + 1);
-                    // Check if the suffix is a valid property. If so, return it. If it's not, continue searching the current property array.
+                    // Check if the suffix is a valid property. If so, return it. If it's not,
+                    // continue searching the current property array.
                     Property foundProp = findProperty(substring, prop.propertyArray());
                     if (foundProp != null) {
                         return foundProp;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
@@ -822,7 +822,7 @@ public final class Properties {
             // If the property has a property class, check if the key is a prefix of the property.
             if (prop.propertyArray() != null) {
                 // Check if the key is a prefix of the property.
-                //  The key must be:
+                // The key must be:
                 //  - shorter than the property pattern
                 //  - the property pattern must start with the key
                 // - the pattern character after the key must be a dot

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
@@ -366,8 +366,7 @@ public final class Properties {
             throw new InitializationException("Attempt to set property with empty key");
         }
 
-        // Check if the property is in an Ice property prefix. If so, check that it's a valid
-        // property.
+        // Check if the property is in an Ice property prefix. If so, check that it's a valid property.
         PropertyArray propertyArray = findIcePropertyArray(key);
         if (propertyArray != null) {
             if (propertyArray.isOptIn()
@@ -807,10 +806,7 @@ public final class Properties {
     static Property findProperty(String key, PropertyArray propertyArray) {
         for (Property prop : propertyArray.properties()) {
             String pattern = prop.pattern();
-            // If the key is an exact match, return the property unless it has a property class
-            // which is prefix only.
-            // If the key is a regex match, return the property. A property cannot have a property
-            // class and use regex.
+            // If the key is an exact match, return the property unless it has a property class which is prefix only. If the key is a regex match, return the property. A property cannot have a property class and use regex.
             if (key.equals(pattern)) {
                 if (prop.propertyArray() != null && prop.propertyArray().prefixOnly()) {
                     return null;
@@ -823,17 +819,15 @@ public final class Properties {
             // If the property has a property class, check if the key is a prefix of the property.
             if (prop.propertyArray() != null) {
                 // Check if the key is a prefix of the property.
-                // The key must be:
-                // - shorter than the property pattern
-                // - the property pattern must start with the key
+                //  The key must be:
+                //  - shorter than the property pattern
+                //  - the property pattern must start with the key
                 // - the pattern character after the key must be a dot
                 if (key.length() > pattern.length()
                         && key.startsWith(pattern)
                         && key.charAt(pattern.length()) == '.') {
                     String substring = key.substring(pattern.length() + 1);
-                    // Check if the suffix is a valid property. If so, return it. If it's not,
-                    // continue searching
-                    // the current property array.
+                    // Check if the suffix is a valid property. If so, return it. If it's not, continue searching the current property array.
                     Property foundProp = findProperty(substring, prop.propertyArray());
                     if (foundProp != null) {
                         return foundProp;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyIceInvoke.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyIceInvoke.java
@@ -62,9 +62,7 @@ class ProxyIceInvoke extends ProxyOutgoingAsyncBase<Object.Ice_invokeResult> {
 
     @Override
     public int invokeCollocated(CollocatedRequestHandler handler) {
-        // The stream cannot be cached if the proxy is not a twoway or there is an invocation
-        // timeout
-        // set.
+        // The stream cannot be cached if the proxy is not a twoway or there is an invocation timeout set.
         if (!_proxy.ice_isTwoway()
                 || _proxy._getReference().getInvocationTimeout().compareTo(Duration.ZERO) > 0) {
             // Disable caching by marking the streams as cached!

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyIceInvoke.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyIceInvoke.java
@@ -62,7 +62,8 @@ class ProxyIceInvoke extends ProxyOutgoingAsyncBase<Object.Ice_invokeResult> {
 
     @Override
     public int invokeCollocated(CollocatedRequestHandler handler) {
-        // The stream cannot be cached if the proxy is not a twoway or there is an invocation timeout set.
+        // The stream cannot be cached if the proxy is not a twoway or there is an invocation
+        // timeout set.
         if (!_proxy.ice_isTwoway()
                 || _proxy._getReference().getInvocationTimeout().compareTo(Duration.ZERO) > 0) {
             // Disable caching by marking the streams as cached!

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RouterInfo.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RouterInfo.java
@@ -160,7 +160,8 @@ final class RouterInfo {
 
     private synchronized void addAndEvictProxies(Identity identity, ObjectPrx[] evictedProxies) {
         //
-        // Check if the proxy hasn't already been evicted by a concurrent addProxies call. If it's the case, don't add it to our local map.
+        // Check if the proxy hasn't already been evicted by a concurrent addProxies call. If it's
+        // the case, don't add it to our local map.
         //
         int index = _evictedIdentities.indexOf(identity);
         if (index >= 0) {
@@ -178,7 +179,8 @@ final class RouterInfo {
         for (ObjectPrx p : evictedProxies) {
             if (!_identities.remove(p.ice_getIdentity())) {
                 //
-                // It's possible for the proxy to not have been added yet in the local map if two threads concurrently call addProxies.
+                // It's possible for the proxy to not have been added yet in the local map if two
+                // threads concurrently call addProxies.
                 //
                 _evictedIdentities.add(p.ice_getIdentity());
             }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RouterInfo.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RouterInfo.java
@@ -160,17 +160,14 @@ final class RouterInfo {
 
     private synchronized void addAndEvictProxies(Identity identity, ObjectPrx[] evictedProxies) {
         //
-        // Check if the proxy hasn't already been evicted by a
-        // concurrent addProxies call. If it's the case, don't
-        // add it to our local map.
+        // Check if the proxy hasn't already been evicted by a concurrent addProxies call. If it's the case, don't add it to our local map.
         //
         int index = _evictedIdentities.indexOf(identity);
         if (index >= 0) {
             _evictedIdentities.remove(index);
         } else {
             //
-            // If we successfully added the proxy to the router,
-            // we add it to our local map.
+            // If we successfully added the proxy to the router, we add it to our local map.
             //
             _identities.add(identity);
         }
@@ -181,9 +178,7 @@ final class RouterInfo {
         for (ObjectPrx p : evictedProxies) {
             if (!_identities.remove(p.ice_getIdentity())) {
                 //
-                // It's possible for the proxy to not have been
-                // added yet in the local map if two threads
-                // concurrently call addProxies.
+                // It's possible for the proxy to not have been added yet in the local map if two threads concurrently call addProxies.
                 //
                 _evictedIdentities.add(p.ice_getIdentity());
             }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RouterManager.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RouterManager.java
@@ -13,8 +13,7 @@ final class RouterManager {
     }
 
     //
-    // Returns router info for a given router. Automatically creates
-    // the router info if it doesn't exist yet.
+    // Returns router info for a given router. Automatically creates the router info if it doesn't exist yet.
     //
     public RouterInfo get(RouterPrx router) {
         if (router == null) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RouterManager.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RouterManager.java
@@ -13,7 +13,8 @@ final class RouterManager {
     }
 
     //
-    // Returns router info for a given router. Automatically creates the router info if it doesn't exist yet.
+    // Returns router info for a given router. Automatically creates the router info if it doesn't
+    // exist yet.
     //
     public RouterInfo get(RouterPrx router) {
         if (router == null) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RunnableThreadPoolWorkItem.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RunnableThreadPoolWorkItem.java
@@ -3,10 +3,7 @@
 package com.zeroc.Ice;
 
 //
-// A helper class for thread pool work items that only need to call user
-// callbacks. If an executor is installed with the communicator, the
-// thread pool work item is executed with the executor, otherwise it's
-// executed by a thread pool thread (after promoting a follower thread).
+// A helper class for thread pool work items that only need to call user callbacks. If an executor is installed with the communicator, the thread pool work item is executed with the executor, otherwise it's executed by a thread pool thread (after promoting a follower thread).
 //
 abstract class RunnableThreadPoolWorkItem implements ThreadPoolWorkItem, Runnable {
     public RunnableThreadPoolWorkItem() {}

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RunnableThreadPoolWorkItem.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RunnableThreadPoolWorkItem.java
@@ -3,7 +3,9 @@
 package com.zeroc.Ice;
 
 //
-// A helper class for thread pool work items that only need to call user callbacks. If an executor is installed with the communicator, the thread pool work item is executed with the executor, otherwise it's executed by a thread pool thread (after promoting a follower thread).
+// A helper class for thread pool work items that only need to call user callbacks. If an executor
+// is installed with the communicator, the thread pool work item is executed with the executor,
+// otherwise it's executed by a thread pool thread (after promoting a follower thread).
 //
 abstract class RunnableThreadPoolWorkItem implements ThreadPoolWorkItem, Runnable {
     public RunnableThreadPoolWorkItem() {}

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
@@ -27,34 +27,27 @@ public class SSLEngine {
         com.zeroc.Ice.Properties properties = communicator().getProperties();
 
         //
-        // CheckCertName determines whether we compare the name in a peer's
-        // certificate against its hostname.
+        // CheckCertName determines whether we compare the name in a peer's certificate against its hostname.
         //
         _checkCertName = properties.getIcePropertyAsInt("IceSSL.CheckCertName") > 0;
 
         //
-        // CheckCertName > 1 enables SNI, the SNI extension applies to client
-        // connections,
-        // indicating the hostname to the server (must be DNS hostname, not an IP
-        // address).
+        // CheckCertName > 1 enables SNI, the SNI extension applies to client connections, indicating the hostname to the server (must be DNS hostname, not an IP address).
         //
         _serverNameIndication = properties.getIcePropertyAsInt("IceSSL.CheckCertName") > 1;
 
         //
-        // VerifyPeer determines whether certificate validation failures abort a
-        // connection.
+        // VerifyPeer determines whether certificate validation failures abort a connection.
         //
         _verifyPeer = properties.getIcePropertyAsInt("IceSSL.VerifyPeer");
 
         //
-        // If the user doesn't supply an SSLContext, we need to create one based
-        // on property settings.
+        // If the user doesn't supply an SSLContext, we need to create one based on property settings.
         //
         if (_context == null) {
             try {
                 //
-                // Check for a default directory. We look in this directory for
-                // files mentioned in the configuration.
+                // Check for a default directory. We look in this directory for files mentioned in the configuration.
                 //
                 _defaultDir = properties.getIceProperty("IceSSL.DefaultDir");
 
@@ -74,9 +67,7 @@ public class SSLEngine {
                 String keystorePassword = properties.getIceProperty("IceSSL.KeystorePassword");
 
                 //
-                // The default keystore type is usually "JKS", but the legal values are
-                // determined
-                // by the JVM implementation. Other possibilities include "PKCS12" and "BKS".
+                // The default keystore type is usually "JKS", but the legal values are determined by the JVM implementation. Other possibilities include "PKCS12" and "BKS".
                 //
                 final String defaultType = java.security.KeyStore.getDefaultType();
                 final String keystoreType =
@@ -99,9 +90,7 @@ public class SSLEngine {
                 String truststorePassword = properties.getIceProperty("IceSSL.TruststorePassword");
 
                 //
-                // The default truststore type is usually "JKS", but the legal values are
-                // determined
-                // by the JVM implementation. Other possibilities include "PKCS12" and "BKS".
+                // The default truststore type is usually "JKS", but the legal values are determined by the JVM implementation. Other possibilities include "PKCS12" and "BKS".
                 //
                 final String truststoreType =
                         properties.getPropertyWithDefault("IceSSL.TruststoreType", defaultType);
@@ -213,8 +202,7 @@ public class SSLEngine {
                 java.security.KeyStore ts = null;
                 if (_truststoreStream != null || !truststorePath.isEmpty()) {
                     //
-                    // If the trust store and the key store are the same input
-                    // stream or file, don't create another key store.
+                    // If the trust store and the key store are the same input stream or file, don't create another key store.
                     //
                     if ((_truststoreStream != null && _truststoreStream == _keystoreStream)
                             || (!truststorePath.isEmpty() && truststorePath.equals(keystorePath))) {
@@ -268,11 +256,7 @@ public class SSLEngine {
                 }
 
                 //
-                // Collect the trust managers. Use IceSSL.Truststore if
-                // specified, otherwise use the Java root CAs if
-                // Ice.Use.PlatformCAs is enabled. If none of these are enabled,
-                // use the keystore or a dummy trust manager which rejects any
-                // certificate.
+                // Collect the trust managers. Use IceSSL.Truststore if specified, otherwise use the Java root CAs if Ice.Use.PlatformCAs is enabled. If none of these are enabled, use the keystore or a dummy trust manager which rejects any certificate.
                 //
                 javax.net.ssl.TrustManager[] trustManagers = null;
                 {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
@@ -27,12 +27,14 @@ public class SSLEngine {
         com.zeroc.Ice.Properties properties = communicator().getProperties();
 
         //
-        // CheckCertName determines whether we compare the name in a peer's certificate against its hostname.
+        // CheckCertName determines whether we compare the name in a peer's certificate against its
+        // hostname.
         //
         _checkCertName = properties.getIcePropertyAsInt("IceSSL.CheckCertName") > 0;
 
         //
-        // CheckCertName > 1 enables SNI, the SNI extension applies to client connections, indicating the hostname to the server (must be DNS hostname, not an IP address).
+        // CheckCertName > 1 enables SNI, the SNI extension applies to client connections,
+        // indicating the hostname to the server (must be DNS hostname, not an IP address).
         //
         _serverNameIndication = properties.getIcePropertyAsInt("IceSSL.CheckCertName") > 1;
 
@@ -42,12 +44,14 @@ public class SSLEngine {
         _verifyPeer = properties.getIcePropertyAsInt("IceSSL.VerifyPeer");
 
         //
-        // If the user doesn't supply an SSLContext, we need to create one based on property settings.
+        // If the user doesn't supply an SSLContext, we need to create one based on property
+        // settings.
         //
         if (_context == null) {
             try {
                 //
-                // Check for a default directory. We look in this directory for files mentioned in the configuration.
+                // Check for a default directory. We look in this directory for files mentioned in
+                // the configuration.
                 //
                 _defaultDir = properties.getIceProperty("IceSSL.DefaultDir");
 
@@ -67,7 +71,8 @@ public class SSLEngine {
                 String keystorePassword = properties.getIceProperty("IceSSL.KeystorePassword");
 
                 //
-                // The default keystore type is usually "JKS", but the legal values are determined by the JVM implementation. Other possibilities include "PKCS12" and "BKS".
+                // The default keystore type is usually "JKS", but the legal values are determined
+                // by the JVM implementation. Other possibilities include "PKCS12" and "BKS".
                 //
                 final String defaultType = java.security.KeyStore.getDefaultType();
                 final String keystoreType =
@@ -90,7 +95,8 @@ public class SSLEngine {
                 String truststorePassword = properties.getIceProperty("IceSSL.TruststorePassword");
 
                 //
-                // The default truststore type is usually "JKS", but the legal values are determined by the JVM implementation. Other possibilities include "PKCS12" and "BKS".
+                // The default truststore type is usually "JKS", but the legal values are determined
+                // by the JVM implementation. Other possibilities include "PKCS12" and "BKS".
                 //
                 final String truststoreType =
                         properties.getPropertyWithDefault("IceSSL.TruststoreType", defaultType);
@@ -202,7 +208,8 @@ public class SSLEngine {
                 java.security.KeyStore ts = null;
                 if (_truststoreStream != null || !truststorePath.isEmpty()) {
                     //
-                    // If the trust store and the key store are the same input stream or file, don't create another key store.
+                    // If the trust store and the key store are the same input stream or file, don't
+                    // create another key store.
                     //
                     if ((_truststoreStream != null && _truststoreStream == _keystoreStream)
                             || (!truststorePath.isEmpty() && truststorePath.equals(keystorePath))) {
@@ -256,7 +263,9 @@ public class SSLEngine {
                 }
 
                 //
-                // Collect the trust managers. Use IceSSL.Truststore if specified, otherwise use the Java root CAs if Ice.Use.PlatformCAs is enabled. If none of these are enabled, use the keystore or a dummy trust manager which rejects any certificate.
+                // Collect the trust managers. Use IceSSL.Truststore if specified, otherwise use the
+                // Java root CAs if Ice.Use.PlatformCAs is enabled. If none of these are enabled,
+                // use the keystore or a dummy trust manager which rejects any certificate.
                 //
                 javax.net.ssl.TrustManager[] trustManagers = null;
                 {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ServantManager.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ServantManager.java
@@ -42,9 +42,7 @@ final class ServantManager implements Object {
                 skipEncapsulation = false;
             } finally {
                 if (skipEncapsulation) {
-                    // Skip the encapsulation on exception. This allows the next batch requests in
-                    // the same
-                    // InputStream to proceed.
+                    // Skip the encapsulation on exception. This allows the next batch requests in the same InputStream to proceed.
                     request.inputStream.skipEncapsulation();
                 }
             }
@@ -55,8 +53,7 @@ final class ServantManager implements Object {
             try {
                 response = servant.dispatch(request);
             } catch (UserException | RuntimeException | Error exception) {
-                // We catch Error because ServantLocator guarantees finished gets called no matter
-                // what.
+                // We catch Error because ServantLocator guarantees finished gets called no matter what.
                 locator.finished(current, servant, cookie);
                 throw exception; // unless finished above throws another exception
             }
@@ -72,8 +69,7 @@ final class ServantManager implements Object {
                             ex = finishedEx;
                         }
                         if (ex != null) {
-                            // We only marshal errors and runtime exceptions (including
-                            // CompletionException) at a higher level.
+                            // We only marshal errors and runtime exceptions (including CompletionException) at a higher level.
                             if (ex instanceof Error errorEx) {
                                 throw errorEx;
                             }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ServantManager.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ServantManager.java
@@ -42,7 +42,8 @@ final class ServantManager implements Object {
                 skipEncapsulation = false;
             } finally {
                 if (skipEncapsulation) {
-                    // Skip the encapsulation on exception. This allows the next batch requests in the same InputStream to proceed.
+                    // Skip the encapsulation on exception. This allows the next batch requests in
+                    // the same InputStream to proceed.
                     request.inputStream.skipEncapsulation();
                 }
             }
@@ -53,7 +54,8 @@ final class ServantManager implements Object {
             try {
                 response = servant.dispatch(request);
             } catch (UserException | RuntimeException | Error exception) {
-                // We catch Error because ServantLocator guarantees finished gets called no matter what.
+                // We catch Error because ServantLocator guarantees finished gets called no matter
+                // what.
                 locator.finished(current, servant, cookie);
                 throw exception; // unless finished above throws another exception
             }
@@ -69,7 +71,8 @@ final class ServantManager implements Object {
                             ex = finishedEx;
                         }
                         if (ex != null) {
-                            // We only marshal errors and runtime exceptions (including CompletionException) at a higher level.
+                            // We only marshal errors and runtime exceptions (including
+                            // CompletionException) at a higher level.
                             if (ex instanceof Error errorEx) {
                                 throw errorEx;
                             }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/StreamSocket.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/StreamSocket.java
@@ -211,7 +211,8 @@ class StreamSocket {
 
         if (System.getProperty("os.name").startsWith("Windows")) {
             //
-            // On Windows, limiting the buffer size is important to prevent poor throughput performances when sending large amount of data. See Microsoft KB article KB823764.
+            // On Windows, limiting the buffer size is important to prevent poor throughput
+            // performances when sending large amount of data. See Microsoft KB article KB823764.
             //
             _maxSendPacketSize = java.lang.Math.max(512, Network.getSendBufferSize(_fd) / 2);
         } else {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/StreamSocket.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/StreamSocket.java
@@ -211,9 +211,7 @@ class StreamSocket {
 
         if (System.getProperty("os.name").startsWith("Windows")) {
             //
-            // On Windows, limiting the buffer size is important to prevent
-            // poor throughput performances when sending large amount of
-            // data. See Microsoft KB article KB823764.
+            // On Windows, limiting the buffer size is important to prevent poor throughput performances when sending large amount of data. See Microsoft KB article KB823764.
             //
             _maxSendPacketSize = java.lang.Math.max(512, Network.getSendBufferSize(_fd) / 2);
         } else {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpTransceiver.java
@@ -21,8 +21,7 @@ final class TcpTransceiver implements Transceiver {
 
     @Override
     public int closing(boolean initiator, LocalException ex) {
-        // If we are initiating the connection closure, wait for the peer
-        // to close the TCP/IP connection. Otherwise, close immediately.
+        // If we are initiating the connection closure, wait for the peer to close the TCP/IP connection. Otherwise, close immediately.
         return initiator ? SocketOperation.Read : SocketOperation.None;
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpTransceiver.java
@@ -21,7 +21,8 @@ final class TcpTransceiver implements Transceiver {
 
     @Override
     public int closing(boolean initiator, LocalException ex) {
-        // If we are initiating the connection closure, wait for the peer to close the TCP/IP connection. Otherwise, close immediately.
+        // If we are initiating the connection closure, wait for the peer to close the TCP/IP
+        // connection. Otherwise, close immediately.
         return initiator ? SocketOperation.Read : SocketOperation.None;
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ThreadPool.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ThreadPool.java
@@ -38,8 +38,7 @@ final class ThreadPool implements java.util.concurrent.Executor {
 
         @Override
         public void execute(ThreadPoolCurrent current) {
-            // No call to ioCompleted, this shouldn't block (and we don't want to cause
-            // a new thread to be started).
+            // No call to ioCompleted, this shouldn't block (and we don't want to cause a new thread to be started).
             try {
                 _thread.join();
             } catch (InterruptedException e) {
@@ -83,9 +82,7 @@ final class ThreadPool implements java.util.concurrent.Executor {
         int nProcessors = Runtime.getRuntime().availableProcessors();
 
         //
-        // We use just one thread as the default. This is the fastest
-        // possible setting, still allows one level of nesting, and
-        // doesn't require to make the servants thread safe.
+        // We use just one thread as the default. This is the fastest possible setting, still allows one level of nesting, and doesn't require to make the servants thread safe.
         //
         int size = properties.getPropertyAsIntWithDefault(_prefix + ".Size", 1);
         if (size < 1) {
@@ -313,9 +310,7 @@ final class ThreadPool implements java.util.concurrent.Executor {
     public void joinWithAllThreads() throws InterruptedException {
         //
         // _threads is immutable after destroy() has been called,
-        // therefore no synchronization is needed. (Synchronization
-        // wouldn't be possible here anyway, because otherwise the
-        // other threads would never terminate.)
+        // therefore no synchronization is needed. (Synchronization wouldn't be possible here anyway, because otherwise the other threads would never terminate.)
         //
         for (EventHandlerThread thread : _threads) {
             thread.join();
@@ -423,10 +418,7 @@ final class ThreadPool implements java.util.concurrent.Executor {
 
                 if (current._handler == null) {
                     //
-                    // If there are no more ready handlers and there are still threads busy
-                    // performing
-                    // IO, we give up leadership and promote another follower (which will perform
-                    // the
+                    // If there are no more ready handlers and there are still threads busy performing IO, we give up leadership and promote another follower (which will perform the
                     // select() only once all the IOs are completed). Otherwise, if there's no more
                     // threads peforming IOs, it's time to do another select().
                     //
@@ -440,8 +432,7 @@ final class ThreadPool implements java.util.concurrent.Executor {
                     }
                 } else if (_sizeMax > 1) {
                     //
-                    // Increment the IO thread count and if there's still threads available
-                    // to perform IO and more handlers ready, we promote a follower.
+                    // Increment the IO thread count and if there's still threads available to perform IO and more handlers ready, we promote a follower.
                     //
                     ++_inUseIO;
                     if (_nextHandler.hasNext() && _inUseIO < _sizeIO) {
@@ -540,9 +531,7 @@ final class ThreadPool implements java.util.concurrent.Executor {
         current._thread.setState(ThreadState.ThreadStateIdle);
 
         //
-        // It's important to clear the handler before waiting to make sure that
-        // resources for the handler are released now if it's finished. We also
-        // clear the per-thread stream.
+        // It's important to clear the handler before waiting to make sure that resources for the handler are released now if it's finished. We also clear the per-thread stream.
         //
         current._handler = null;
         current.stream.reset();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ThreadPool.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ThreadPool.java
@@ -38,7 +38,8 @@ final class ThreadPool implements java.util.concurrent.Executor {
 
         @Override
         public void execute(ThreadPoolCurrent current) {
-            // No call to ioCompleted, this shouldn't block (and we don't want to cause a new thread to be started).
+            // No call to ioCompleted, this shouldn't block (and we don't want to cause a new thread
+            // to be started).
             try {
                 _thread.join();
             } catch (InterruptedException e) {
@@ -82,7 +83,8 @@ final class ThreadPool implements java.util.concurrent.Executor {
         int nProcessors = Runtime.getRuntime().availableProcessors();
 
         //
-        // We use just one thread as the default. This is the fastest possible setting, still allows one level of nesting, and doesn't require to make the servants thread safe.
+        // We use just one thread as the default. This is the fastest possible setting, still allows
+        // one level of nesting, and doesn't require to make the servants thread safe.
         //
         int size = properties.getPropertyAsIntWithDefault(_prefix + ".Size", 1);
         if (size < 1) {
@@ -310,7 +312,8 @@ final class ThreadPool implements java.util.concurrent.Executor {
     public void joinWithAllThreads() throws InterruptedException {
         //
         // _threads is immutable after destroy() has been called,
-        // therefore no synchronization is needed. (Synchronization wouldn't be possible here anyway, because otherwise the other threads would never terminate.)
+        // therefore no synchronization is needed. (Synchronization wouldn't be possible here
+        // anyway, because otherwise the other threads would never terminate.)
         //
         for (EventHandlerThread thread : _threads) {
             thread.join();
@@ -418,7 +421,9 @@ final class ThreadPool implements java.util.concurrent.Executor {
 
                 if (current._handler == null) {
                     //
-                    // If there are no more ready handlers and there are still threads busy performing IO, we give up leadership and promote another follower (which will perform the
+                    // If there are no more ready handlers and there are still threads busy
+                    // performing IO, we give up leadership and promote another follower (which will
+                    // perform the
                     // select() only once all the IOs are completed). Otherwise, if there's no more
                     // threads peforming IOs, it's time to do another select().
                     //
@@ -432,7 +437,8 @@ final class ThreadPool implements java.util.concurrent.Executor {
                     }
                 } else if (_sizeMax > 1) {
                     //
-                    // Increment the IO thread count and if there's still threads available to perform IO and more handlers ready, we promote a follower.
+                    // Increment the IO thread count and if there's still threads available to
+                    // perform IO and more handlers ready, we promote a follower.
                     //
                     ++_inUseIO;
                     if (_nextHandler.hasNext() && _inUseIO < _sizeIO) {
@@ -531,7 +537,8 @@ final class ThreadPool implements java.util.concurrent.Executor {
         current._thread.setState(ThreadState.ThreadStateIdle);
 
         //
-        // It's important to clear the handler before waiting to make sure that resources for the handler are released now if it's finished. We also clear the per-thread stream.
+        // It's important to clear the handler before waiting to make sure that resources for the
+        // handler are released now if it's finished. We also clear the per-thread stream.
         //
         current._handler = null;
         current.stream.reset();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpMulticastClientTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpMulticastClientTransceiver.java
@@ -165,8 +165,7 @@ final class UdpMulticastClientTransceiver implements Transceiver {
     @Override
     public synchronized void checkSendSize(Buffer buf) {
         //
-        // The maximum packetSize is either the maximum allowable UDP packet size, or
-        // the UDP send buffer size (whichever is smaller).
+        // The maximum packetSize is either the maximum allowable UDP packet size, or the UDP send buffer size (whichever is smaller).
         //
         final int packetSize = java.lang.Math.min(_maxPacketSize, _size - _udpOverhead);
         if (packetSize < buf.size()) {
@@ -278,16 +277,13 @@ final class UdpMulticastClientTransceiver implements Transceiver {
 
         try {
             //
-            // Try to set the buffer size. The kernel will silently adjust the size to an acceptable
-            // value.
-            // Then read the size back to get the size that was actually set.
+            // Try to set the buffer size. The kernel will silently adjust the size to an acceptable value. Then read the size back to get the size that was actually set.
             //
             _socket.setSendBufferSize(_newSize);
             _size = _socket.getSendBufferSize();
 
             //
-            // Warn if the size that was set is less than the requested size and we have not already
-            // warned.
+            // Warn if the size that was set is less than the requested size and we have not already warned.
             //
             if (_size < _newSize) {
                 BufSizeWarnInfo winfo = _instance.getBufSizeWarn(UDPEndpointType.value);
@@ -333,8 +329,7 @@ final class UdpMulticastClientTransceiver implements Transceiver {
 
                 synchronized (this) {
                     //
-                    // Wait until the socket is closed, an exception occurs, or we have something to
-                    // write.
+                    // Wait until the socket is closed, an exception occurs, or we have something to write.
                     //
                     while (_socket != null && _exception == null && _buffers.isEmpty()) {
                         try {
@@ -369,8 +364,7 @@ final class UdpMulticastClientTransceiver implements Transceiver {
                         offset = buf.b.arrayOffset();
                     } else {
                         //
-                        // If the buffer doesn't have a backing array, we'll have to make a copy of
-                        // the data.
+                        // If the buffer doesn't have a backing array, we'll have to make a copy of the data.
                         //
                         arr = new byte[buf.b.limit()];
                         offset = 0;
@@ -402,10 +396,7 @@ final class UdpMulticastClientTransceiver implements Transceiver {
     private int _newSize;
 
     //
-    // The maximum IP datagram size is 65535. Subtract 20 bytes for the IP header and 8 bytes for
-    // the
-    // UDP header
-    // to get the maximum payload.
+    // The maximum IP datagram size is 65535. Subtract 20 bytes for the IP header and 8 bytes for the UDP header to get the maximum payload.
     //
     private static final int _udpOverhead = 20 + 8;
     private static final int _maxPacketSize = 65535 - _udpOverhead;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpMulticastClientTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpMulticastClientTransceiver.java
@@ -165,7 +165,8 @@ final class UdpMulticastClientTransceiver implements Transceiver {
     @Override
     public synchronized void checkSendSize(Buffer buf) {
         //
-        // The maximum packetSize is either the maximum allowable UDP packet size, or the UDP send buffer size (whichever is smaller).
+        // The maximum packetSize is either the maximum allowable UDP packet size, or the UDP send
+        // buffer size (whichever is smaller).
         //
         final int packetSize = java.lang.Math.min(_maxPacketSize, _size - _udpOverhead);
         if (packetSize < buf.size()) {
@@ -277,13 +278,15 @@ final class UdpMulticastClientTransceiver implements Transceiver {
 
         try {
             //
-            // Try to set the buffer size. The kernel will silently adjust the size to an acceptable value. Then read the size back to get the size that was actually set.
+            // Try to set the buffer size. The kernel will silently adjust the size to an acceptable
+            // value. Then read the size back to get the size that was actually set.
             //
             _socket.setSendBufferSize(_newSize);
             _size = _socket.getSendBufferSize();
 
             //
-            // Warn if the size that was set is less than the requested size and we have not already warned.
+            // Warn if the size that was set is less than the requested size and we have not already
+            // warned.
             //
             if (_size < _newSize) {
                 BufSizeWarnInfo winfo = _instance.getBufSizeWarn(UDPEndpointType.value);
@@ -329,7 +332,8 @@ final class UdpMulticastClientTransceiver implements Transceiver {
 
                 synchronized (this) {
                     //
-                    // Wait until the socket is closed, an exception occurs, or we have something to write.
+                    // Wait until the socket is closed, an exception occurs, or we have something to
+                    // write.
                     //
                     while (_socket != null && _exception == null && _buffers.isEmpty()) {
                         try {
@@ -364,7 +368,8 @@ final class UdpMulticastClientTransceiver implements Transceiver {
                         offset = buf.b.arrayOffset();
                     } else {
                         //
-                        // If the buffer doesn't have a backing array, we'll have to make a copy of the data.
+                        // If the buffer doesn't have a backing array, we'll have to make a copy of
+                        // the data.
                         //
                         arr = new byte[buf.b.limit()];
                         offset = 0;
@@ -396,7 +401,8 @@ final class UdpMulticastClientTransceiver implements Transceiver {
     private int _newSize;
 
     //
-    // The maximum IP datagram size is 65535. Subtract 20 bytes for the IP header and 8 bytes for the UDP header to get the maximum payload.
+    // The maximum IP datagram size is 65535. Subtract 20 bytes for the IP header and 8 bytes for
+    // the UDP header to get the maximum payload.
     //
     private static final int _udpOverhead = 20 + 8;
     private static final int _maxPacketSize = 65535 - _udpOverhead;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpMulticastServerTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpMulticastServerTransceiver.java
@@ -114,7 +114,8 @@ final class UdpMulticastServerTransceiver implements Transceiver {
             }
 
             //
-            // The read thread will temporarily stop reading if we exceed our threshold. Wake it up if we've transitioned below the limit.
+            // The read thread will temporarily stop reading if we exceed our threshold. Wake it up
+            // if we've transitioned below the limit.
             //
             if (_buffers.size() == _threshold - 1) {
                 notifyAll();
@@ -287,13 +288,15 @@ final class UdpMulticastServerTransceiver implements Transceiver {
 
         try {
             //
-            // Try to set the buffer size. The kernel will silently adjust the size to an acceptable value. Then read the size back to get the size that was actually set.
+            // Try to set the buffer size. The kernel will silently adjust the size to an acceptable
+            // value. Then read the size back to get the size that was actually set.
             //
             _socket.setReceiveBufferSize(_newSize);
             _size = _socket.getReceiveBufferSize();
 
             //
-            // Warn if the size that was set is less than the requested size and we have not already warned.
+            // Warn if the size that was set is less than the requested size and we have not already
+            // warned.
             //
             if (_size < _newSize) {
                 BufSizeWarnInfo winfo = _instance.getBufSizeWarn(UDPEndpointType.value);
@@ -338,7 +341,8 @@ final class UdpMulticastServerTransceiver implements Transceiver {
 
                 synchronized (this) {
                     //
-                    // If we've read too much data, wait until the application consumes some before we read again.
+                    // If we've read too much data, wait until the application consumes some before
+                    // we read again.
                     //
                     while (_socket != null && _exception == null && _buffers.size() >= _threshold) {
                         try {
@@ -425,7 +429,8 @@ final class UdpMulticastServerTransceiver implements Transceiver {
     private static final int _udpOverhead = 20 + 8;
 
     //
-    // The maximum number of packets that we'll queue before the read thread temporarily stops reading.
+    // The maximum number of packets that we'll queue before the read thread temporarily stops
+    // reading.
     //
     private static final int _threshold = 10;
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpMulticastServerTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpMulticastServerTransceiver.java
@@ -114,9 +114,7 @@ final class UdpMulticastServerTransceiver implements Transceiver {
             }
 
             //
-            // The read thread will temporarily stop reading if we exceed our threshold. Wake it up
-            // if
-            // we've transitioned below the limit.
+            // The read thread will temporarily stop reading if we exceed our threshold. Wake it up if we've transitioned below the limit.
             //
             if (_buffers.size() == _threshold - 1) {
                 notifyAll();
@@ -289,16 +287,13 @@ final class UdpMulticastServerTransceiver implements Transceiver {
 
         try {
             //
-            // Try to set the buffer size. The kernel will silently adjust the size to an acceptable
-            // value.
-            // Then read the size back to get the size that was actually set.
+            // Try to set the buffer size. The kernel will silently adjust the size to an acceptable value. Then read the size back to get the size that was actually set.
             //
             _socket.setReceiveBufferSize(_newSize);
             _size = _socket.getReceiveBufferSize();
 
             //
-            // Warn if the size that was set is less than the requested size and we have not already
-            // warned.
+            // Warn if the size that was set is less than the requested size and we have not already warned.
             //
             if (_size < _newSize) {
                 BufSizeWarnInfo winfo = _instance.getBufSizeWarn(UDPEndpointType.value);
@@ -343,9 +338,7 @@ final class UdpMulticastServerTransceiver implements Transceiver {
 
                 synchronized (this) {
                     //
-                    // If we've read too much data, wait until the application consumes some before
-                    // we read
-                    // again.
+                    // If we've read too much data, wait until the application consumes some before we read again.
                     //
                     while (_socket != null && _exception == null && _buffers.size() >= _threshold) {
                         try {
@@ -401,16 +394,14 @@ final class UdpMulticastServerTransceiver implements Transceiver {
             exception(new SocketException(ex));
             //
             // Mark as ready for reading so that the Ice run time will invoke read() and we can
-            // report the
-            // exception.
+            // report the exception.
             //
             _readyCallback.ready(SocketOperation.Read, true);
         } catch (LocalException ex) {
             exception(ex);
             //
             // Mark as ready for reading so that the Ice run time will invoke read() and we can
-            // report the
-            // exception.
+            // report the exception.
             //
             _readyCallback.ready(SocketOperation.Read, true);
         }
@@ -434,8 +425,7 @@ final class UdpMulticastServerTransceiver implements Transceiver {
     private static final int _udpOverhead = 20 + 8;
 
     //
-    // The maximum number of packets that we'll queue before the read thread temporarily stops
-    // reading.
+    // The maximum number of packets that we'll queue before the read thread temporarily stops reading.
     //
     private static final int _threshold = 10;
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpTransceiver.java
@@ -46,7 +46,10 @@ final class UdpTransceiver implements Transceiver {
             _mcastAddr = _addr;
             if (System.getProperty("os.name").startsWith("Windows")) {
                 //
-                // Windows does not allow binding to the mcast address itself so we bind to INADDR_ANY (0.0.0.0) instead. As a result, bi-directional connection won't work because the source address won't be the multicast address and the client will therefore reject the datagram.
+                // Windows does not allow binding to the mcast address itself so we bind to
+                // INADDR_ANY (0.0.0.0) instead. As a result, bi-directional connection won't work
+                // because the source address won't be the multicast address and the client will
+                // therefore reject the datagram.
                 //
                 int protocolSupport = Network.getProtocolSupport(_mcastAddr);
                 _addr =
@@ -62,9 +65,13 @@ final class UdpTransceiver implements Transceiver {
         } else {
             if (!System.getProperty("os.name").startsWith("Windows")) {
                 //
-                // Enable SO_REUSEADDR on Unix platforms to allow re-using the socket even if it's in the TIME_WAIT state. On Windows, this doesn't appear to be necessary and enabling SO_REUSEADDR would actually not be a good thing since it allows a second process to bind to an address even it's already bound by another process.
+                // Enable SO_REUSEADDR on Unix platforms to allow re-using the socket even if it's
+                // in the TIME_WAIT state. On Windows, this doesn't appear to be necessary and
+                // enabling SO_REUSEADDR would actually not be a good thing since it allows a second
+                // process to bind to an address even it's already bound by another process.
                 //
-                // TODO: using SO_EXCLUSIVEADDRUSE on Windows would probably be better but it's only supported by recent
+                // TODO: using SO_EXCLUSIVEADDRUSE on Windows would probably be better but it's only
+                // supported by recent
                 // Windows versions (XP SP2, Windows Server 2003).
                 //
                 Network.setReuseAddress(_fd, true);
@@ -270,7 +277,8 @@ final class UdpTransceiver implements Transceiver {
     @Override
     public synchronized void checkSendSize(Buffer buf) {
         //
-        // The maximum packetSize is either the maximum allowable UDP packet size, or the UDP send buffer size (which ever is smaller).
+        // The maximum packetSize is either the maximum allowable UDP packet size, or the UDP send
+        // buffer size (which ever is smaller).
         //
         final int packetSize = java.lang.Math.min(_maxPacketSize, _sndSize - _udpOverhead);
         if (packetSize < buf.size()) {
@@ -403,7 +411,8 @@ final class UdpTransceiver implements Transceiver {
 
             if (sizeRequested != dfltSize) {
                 //
-                // Try to set the buffer size. The kernel will silently adjust the size to an acceptable value. Then read the size back to get the size that was actually set.
+                // Try to set the buffer size. The kernel will silently adjust the size to an
+                // acceptable value. Then read the size back to get the size that was actually set.
                 //
                 int sizeSet;
                 if (i == 0) {
@@ -417,7 +426,8 @@ final class UdpTransceiver implements Transceiver {
                 }
 
                 //
-                // Warn if the size that was set is less than the requested size and we have not already warned
+                // Warn if the size that was set is less than the requested size and we have not
+                // already warned
                 //
                 if (sizeSet < sizeRequested) {
                     BufSizeWarnInfo winfo = _instance.getBufSizeWarn(UDPEndpointType.value);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpTransceiver.java
@@ -46,11 +46,7 @@ final class UdpTransceiver implements Transceiver {
             _mcastAddr = _addr;
             if (System.getProperty("os.name").startsWith("Windows")) {
                 //
-                // Windows does not allow binding to the mcast address itself
-                // so we bind to INADDR_ANY (0.0.0.0) instead. As a result,
-                // bi-directional connection won't work because the source
-                // address won't be the multicast address and the client will
-                // therefore reject the datagram.
+                // Windows does not allow binding to the mcast address itself so we bind to INADDR_ANY (0.0.0.0) instead. As a result, bi-directional connection won't work because the source address won't be the multicast address and the client will therefore reject the datagram.
                 //
                 int protocolSupport = Network.getProtocolSupport(_mcastAddr);
                 _addr =
@@ -66,16 +62,9 @@ final class UdpTransceiver implements Transceiver {
         } else {
             if (!System.getProperty("os.name").startsWith("Windows")) {
                 //
-                // Enable SO_REUSEADDR on Unix platforms to allow
-                // re-using the socket even if it's in the TIME_WAIT
-                // state. On Windows, this doesn't appear to be
-                // necessary and enabling SO_REUSEADDR would actually
-                // not be a good thing since it allows a second
-                // process to bind to an address even it's already
-                // bound by another process.
+                // Enable SO_REUSEADDR on Unix platforms to allow re-using the socket even if it's in the TIME_WAIT state. On Windows, this doesn't appear to be necessary and enabling SO_REUSEADDR would actually not be a good thing since it allows a second process to bind to an address even it's already bound by another process.
                 //
-                // TODO: using SO_EXCLUSIVEADDRUSE on Windows would
-                // probably be better but it's only supported by recent
+                // TODO: using SO_EXCLUSIVEADDRUSE on Windows would probably be better but it's only supported by recent
                 // Windows versions (XP SP2, Windows Server 2003).
                 //
                 Network.setReuseAddress(_fd, true);
@@ -281,8 +270,7 @@ final class UdpTransceiver implements Transceiver {
     @Override
     public synchronized void checkSendSize(Buffer buf) {
         //
-        // The maximum packetSize is either the maximum allowable UDP packet size, or
-        // the UDP send buffer size (which ever is smaller).
+        // The maximum packetSize is either the maximum allowable UDP packet size, or the UDP send buffer size (which ever is smaller).
         //
         final int packetSize = java.lang.Math.min(_maxPacketSize, _sndSize - _udpOverhead);
         if (packetSize < buf.size()) {
@@ -415,9 +403,7 @@ final class UdpTransceiver implements Transceiver {
 
             if (sizeRequested != dfltSize) {
                 //
-                // Try to set the buffer size. The kernel will silently adjust
-                // the size to an acceptable value. Then read the size back to
-                // get the size that was actually set.
+                // Try to set the buffer size. The kernel will silently adjust the size to an acceptable value. Then read the size back to get the size that was actually set.
                 //
                 int sizeSet;
                 if (i == 0) {
@@ -431,8 +417,7 @@ final class UdpTransceiver implements Transceiver {
                 }
 
                 //
-                // Warn if the size that was set is less than the requested size
-                // and we have not already warned
+                // Warn if the size that was set is less than the requested size and we have not already warned
                 //
                 if (sizeSet < sizeRequested) {
                     BufSizeWarnInfo winfo = _instance.getBufSizeWarn(UDPEndpointType.value);
@@ -488,9 +473,7 @@ final class UdpTransceiver implements Transceiver {
 
     //
     // The maximum IP datagram size is 65535. Subtract 20 bytes for the IP header and 8 bytes for
-    // the
-    // UDP header
-    // to get the maximum payload.
+    // the UDP header to get the maximum payload.
     //
     private static final int _udpOverhead = 20 + 8;
     private static final int _maxPacketSize = 65535 - _udpOverhead;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UserException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UserException.java
@@ -168,10 +168,7 @@ public abstract class UserException extends java.lang.Exception {
                 writeFields(name, obj, c.getSuperclass(), objectTable, out);
 
                 //
-                // Write the declared fields of the given class. We prefer to use the declared
-                // fields because it includes protected fields that may have been defined using
-                // the Slice "protected" metadata. However, if a security manager prevents us
-                // from obtaining the declared fields, we will fall back to using the public ones.
+                // Write the declared fields of the given class. We prefer to use the declared fields because it includes protected fields that may have been defined using the Slice "protected" metadata. However, if a security manager prevents us from obtaining the declared fields, we will fall back to using the public ones.
                 //
                 java.lang.reflect.Field[] fields = null;
                 try {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UserException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UserException.java
@@ -168,7 +168,10 @@ public abstract class UserException extends java.lang.Exception {
                 writeFields(name, obj, c.getSuperclass(), objectTable, out);
 
                 //
-                // Write the declared fields of the given class. We prefer to use the declared fields because it includes protected fields that may have been defined using the Slice "protected" metadata. However, if a security manager prevents us from obtaining the declared fields, we will fall back to using the public ones.
+                // Write the declared fields of the given class. We prefer to use the declared
+                // fields because it includes protected fields that may have been defined using the
+                // Slice "protected" metadata. However, if a security manager prevents us from
+                // obtaining the declared fields, we will fall back to using the public ones.
                 //
                 java.lang.reflect.Field[] fields = null;
                 try {

--- a/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/Server.java
+++ b/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/Server.java
@@ -20,9 +20,7 @@ public final class Server {
 
             synchronized (_doneMutex) {
                 // Wait on the server to finish shutting down before exiting the ShutdownHook. This
-                // ensures
-                // that all IceBox services have had a chance to shutdown cleanly before the JVM
-                // terminates.
+                // ensures that all IceBox services have had a chance to shutdown cleanly before the JVM terminates.
                 while (!_done) {
                     try {
                         _doneMutex.wait();

--- a/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/Server.java
+++ b/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/Server.java
@@ -20,7 +20,8 @@ public final class Server {
 
             synchronized (_doneMutex) {
                 // Wait on the server to finish shutting down before exiting the ShutdownHook. This
-                // ensures that all IceBox services have had a chance to shutdown cleanly before the JVM terminates.
+                // ensures that all IceBox services have had a chance to shutdown cleanly before the
+                // JVM terminates.
                 while (!_done) {
                     try {
                         _doneMutex.wait();

--- a/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/ServiceManagerI.java
+++ b/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/ServiceManagerI.java
@@ -40,7 +40,8 @@ public class ServiceManagerI implements ServiceManager {
             throws AlreadyStartedException, NoSuchServiceException {
         ServiceInfo info = null;
         synchronized (this) {
-            // Search would be more efficient if services were contained in a map, but order is required for shutdown.
+            // Search would be more efficient if services were contained in a map, but order is
+            // required for shutdown.
             for (ServiceInfo p : _services) {
                 if (p.name.equals(name)) {
                     if (p.status == StatusStarted) {
@@ -101,7 +102,8 @@ public class ServiceManagerI implements ServiceManager {
             throws AlreadyStoppedException, NoSuchServiceException {
         ServiceInfo info = null;
         synchronized (this) {
-            // Search would be more efficient if services were contained in a map, but order is required for shutdown.
+            // Search would be more efficient if services were contained in a map, but order is
+            // required for shutdown.
             for (ServiceInfo p : _services) {
                 if (p.name.equals(name)) {
                     if (p.status == StatusStopped) {
@@ -200,7 +202,8 @@ public class ServiceManagerI implements ServiceManager {
             //
             // IceBox.Service.Foo=[jar-or-dir:]Package.Foo [args]
             //
-            // We parse the service properties specified in IceBox.LoadOrder first, then the ones from remaining services.
+            // We parse the service properties specified in IceBox.LoadOrder first, then the ones
+            // from remaining services.
             final String prefix = "IceBox.Service.";
             java.util.Map<String, String> services = properties.getPropertiesForPrefix(prefix);
 
@@ -229,7 +232,9 @@ public class ServiceManagerI implements ServiceManager {
                 servicesInfo.add(new StartServiceInfo(name, value, _argv));
             }
 
-            // Check if some services are using the shared communicator in which case we create the shared communicator now with a property set that is the union of all the service properties (from services that use the shared communicator).
+            // Check if some services are using the shared communicator in which case we create the
+            // shared communicator now with a property set that is the union of all the service
+            // properties (from services that use the shared communicator).
             if (properties.getPropertiesForPrefix("IceBox.UseSharedCommunicator.").size() > 0) {
                 com.zeroc.Ice.InitializationData initData = new com.zeroc.Ice.InitializationData();
                 initData.properties = createServiceProperties("SharedCommunicator");
@@ -240,13 +245,15 @@ public class ServiceManagerI implements ServiceManager {
                         continue;
                     }
 
-                    // Load the service properties using the shared communicator properties as the default properties.
+                    // Load the service properties using the shared communicator properties as the
+                    // default properties.
                     java.util.List<String> remainingArgs = new java.util.ArrayList<>();
                     Properties serviceProps =
                             new Properties(service.args, initData.properties, remainingArgs);
                     service.args = remainingArgs.toArray(new String[remainingArgs.size()]);
 
-                    // Remove properties from the shared property set that a service explicitly clears.
+                    // Remove properties from the shared property set that a service explicitly
+                    // clears.
                     java.util.Map<String, String> allProps =
                             initData.properties.getPropertiesForPrefix("");
                     for (String key : allProps.keySet()) {
@@ -273,7 +280,9 @@ public class ServiceManagerI implements ServiceManager {
                 _sharedCommunicator = Util.initialize(initData);
 
                 if (addFacets) {
-                    // Add all facets created on shared communicator to the IceBox communicator but renamed <prefix>.<facet-name>, except for the Process facet which is never added.
+                    // Add all facets created on shared communicator to the IceBox communicator but
+                    // renamed <prefix>.<facet-name>, except for the Process facet which is never
+                    // added.
                     for (java.util.Map.Entry<String, com.zeroc.Ice.Object> p :
                             _sharedCommunicator.findAllAdminFacets().entrySet()) {
                         if (!p.getKey().equals("Process")) {
@@ -295,7 +304,8 @@ public class ServiceManagerI implements ServiceManager {
             // is "ready".
             // This is done by defining the property IceBox.PrintServicesReady=bundleName
             //
-            // bundleName is whatever you choose to call this set of services. It will be echoed back as "bundleName ready".
+            // bundleName is whatever you choose to call this set of services. It will be echoed
+            // back as "bundleName ready".
             //
             // This must be done after start() has been invoked on the services.
             String bundleName = properties.getIceProperty("IceBox.PrintServicesReady");
@@ -356,7 +366,8 @@ public class ServiceManagerI implements ServiceManager {
                 }
                 classDir = URLEncoder.encode(classDir, "UTF-8");
 
-                // Reuse an existing class loader if we have already loaded a plug-in with the same value for classDir, otherwise create a new one.
+                // Reuse an existing class loader if we have already loaded a plug-in with the same
+                // value for classDir, otherwise create a new one.
                 ClassLoader cl = null;
 
                 if (_classLoaders == null) {
@@ -399,7 +410,9 @@ public class ServiceManagerI implements ServiceManager {
         info.args = args;
 
         // If IceBox.UseSharedCommunicator.<name> is defined, create a
-        // communicator for the service. The communicator inherits from the shared communicator properties. If it's not defined, add the service properties to the shared communicator property set.
+        // communicator for the service. The communicator inherits from the shared communicator
+        // properties. If it's not defined, add the service properties to the shared communicator
+        // property set.
         com.zeroc.Ice.Communicator communicator;
         if (_communicator
                         .getProperties()
@@ -415,7 +428,8 @@ public class ServiceManagerI implements ServiceManager {
                 initData.properties = createServiceProperties(service);
                 String[] serviceArgs = info.args;
                 if (serviceArgs.length > 0) {
-                    // Create the service properties with the given service arguments. This should read the service config file if it's specified with --Ice.Config.
+                    // Create the service properties with the given service arguments. This should
+                    // read the service config file if it's specified with --Ice.Config.
                     java.util.List<String> remainingArgs = new java.util.ArrayList<>();
                     initData.properties =
                             new Properties(serviceArgs, initData.properties, remainingArgs);
@@ -426,7 +440,8 @@ public class ServiceManagerI implements ServiceManager {
                     serviceArgs = initData.properties.parseCommandLineOptions(service, serviceArgs);
                 }
 
-                // Clone the logger to assign a new prefix. If one of the built-in loggers is configured don't set any logger.
+                // Clone the logger to assign a new prefix. If one of the built-in loggers is
+                // configured don't set any logger.
                 if (initData.properties.getIceProperty("Ice.LogFile").isEmpty()
                         && (initData.properties.getIcePropertyAsInt("Ice.UseSyslog") <= 0
                                 || System.getProperty("os.name").startsWith("Windows"))) {
@@ -444,7 +459,8 @@ public class ServiceManagerI implements ServiceManager {
                 String serviceFacetNamePrefix = "IceBox.Service." + service + ".";
                 boolean addFacets = configureAdmin(initData.properties, serviceFacetNamePrefix);
 
-                // Remaining command line options are passed to the communicator. This is necessary for Ice plug-in properties (e.g.: Ice.SSL).
+                // Remaining command line options are passed to the communicator. This is necessary
+                // for Ice plug-in properties (e.g.: Ice.SSL).
                 java.util.List<String> remainingArgs = new java.util.ArrayList<>();
                 info.communicator = Util.initialize(serviceArgs, initData, remainingArgs);
                 info.args = remainingArgs.toArray(new String[remainingArgs.size()]);
@@ -655,7 +671,8 @@ public class ServiceManagerI implements ServiceManager {
     private void observerRemoved(ServiceObserverPrx observer, RuntimeException ex) {
         if (_traceServiceObserver >= 1) {
             // CommunicatorDestroyedException may occur during shutdown. The observer notification
-            // has been sent, but the communicator was destroyed before the reply was received. We do not log a message for this exception.
+            // has been sent, but the communicator was destroyed before the reply was received. We
+            // do not log a message for this exception.
             if (!(ex instanceof com.zeroc.Ice.CommunicatorDestroyedException)) {
                 _logger.trace(
                         "IceBox.ServiceObserver",
@@ -805,7 +822,8 @@ public class ServiceManagerI implements ServiceManager {
             communicator.shutdown();
             communicator.waitForShutdown();
         } catch (com.zeroc.Ice.CommunicatorDestroyedException e) {
-            // Ignore, the service might have already destroyed the communicator for its own reasons.
+            // Ignore, the service might have already destroyed the communicator for its own
+            // reasons.
         } catch (Exception e) {
             java.io.StringWriter sw = new java.io.StringWriter();
             java.io.PrintWriter pw = new java.io.PrintWriter(sw);

--- a/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/ServiceManagerI.java
+++ b/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/ServiceManagerI.java
@@ -713,7 +713,8 @@ public class ServiceManagerI implements ServiceManager {
 
             // We support the following formats:
             //
-            // <class-name> [args] <jar-file>:<class-name> [args]
+            // <class-name> [args]
+            // <jar-file>:<class-name> [args]
             // <class-dir>:<class-name> [args]
             // "<path with spaces>":<class-name> [args]
             // "<path with spaces>:<class-name>" [args]

--- a/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/ServiceManagerI.java
+++ b/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/ServiceManagerI.java
@@ -40,8 +40,7 @@ public class ServiceManagerI implements ServiceManager {
             throws AlreadyStartedException, NoSuchServiceException {
         ServiceInfo info = null;
         synchronized (this) {
-            // Search would be more efficient if services were contained in a map,
-            // but order is required for shutdown.
+            // Search would be more efficient if services were contained in a map, but order is required for shutdown.
             for (ServiceInfo p : _services) {
                 if (p.name.equals(name)) {
                     if (p.status == StatusStarted) {
@@ -102,8 +101,7 @@ public class ServiceManagerI implements ServiceManager {
             throws AlreadyStoppedException, NoSuchServiceException {
         ServiceInfo info = null;
         synchronized (this) {
-            // Search would be more efficient if services were contained in a map,
-            // but order is required for shutdown.
+            // Search would be more efficient if services were contained in a map, but order is required for shutdown.
             for (ServiceInfo p : _services) {
                 if (p.name.equals(name)) {
                     if (p.status == StatusStopped) {
@@ -202,8 +200,7 @@ public class ServiceManagerI implements ServiceManager {
             //
             // IceBox.Service.Foo=[jar-or-dir:]Package.Foo [args]
             //
-            // We parse the service properties specified in IceBox.LoadOrder
-            // first, then the ones from remaining services.
+            // We parse the service properties specified in IceBox.LoadOrder first, then the ones from remaining services.
             final String prefix = "IceBox.Service.";
             java.util.Map<String, String> services = properties.getPropertiesForPrefix(prefix);
 
@@ -232,10 +229,7 @@ public class ServiceManagerI implements ServiceManager {
                 servicesInfo.add(new StartServiceInfo(name, value, _argv));
             }
 
-            // Check if some services are using the shared communicator in which
-            // case we create the shared communicator now with a property set that
-            // is the union of all the service properties (from services that use
-            // the shared communicator).
+            // Check if some services are using the shared communicator in which case we create the shared communicator now with a property set that is the union of all the service properties (from services that use the shared communicator).
             if (properties.getPropertiesForPrefix("IceBox.UseSharedCommunicator.").size() > 0) {
                 com.zeroc.Ice.InitializationData initData = new com.zeroc.Ice.InitializationData();
                 initData.properties = createServiceProperties("SharedCommunicator");
@@ -246,15 +240,13 @@ public class ServiceManagerI implements ServiceManager {
                         continue;
                     }
 
-                    // Load the service properties using the shared communicator properties as the
-                    // default properties.
+                    // Load the service properties using the shared communicator properties as the default properties.
                     java.util.List<String> remainingArgs = new java.util.ArrayList<>();
                     Properties serviceProps =
                             new Properties(service.args, initData.properties, remainingArgs);
                     service.args = remainingArgs.toArray(new String[remainingArgs.size()]);
 
-                    // Remove properties from the shared property set that a service explicitly
-                    // clears.
+                    // Remove properties from the shared property set that a service explicitly clears.
                     java.util.Map<String, String> allProps =
                             initData.properties.getPropertiesForPrefix("");
                     for (String key : allProps.keySet()) {
@@ -281,9 +273,7 @@ public class ServiceManagerI implements ServiceManager {
                 _sharedCommunicator = Util.initialize(initData);
 
                 if (addFacets) {
-                    // Add all facets created on shared communicator to the IceBox communicator
-                    // but renamed <prefix>.<facet-name>, except for the Process facet which is
-                    // never added.
+                    // Add all facets created on shared communicator to the IceBox communicator but renamed <prefix>.<facet-name>, except for the Process facet which is never added.
                     for (java.util.Map.Entry<String, com.zeroc.Ice.Object> p :
                             _sharedCommunicator.findAllAdminFacets().entrySet()) {
                         if (!p.getKey().equals("Process")) {
@@ -305,8 +295,7 @@ public class ServiceManagerI implements ServiceManager {
             // is "ready".
             // This is done by defining the property IceBox.PrintServicesReady=bundleName
             //
-            // bundleName is whatever you choose to call this set of services.
-            // It will be echoed back as "bundleName ready".
+            // bundleName is whatever you choose to call this set of services. It will be echoed back as "bundleName ready".
             //
             // This must be done after start() has been invoked on the services.
             String bundleName = properties.getIceProperty("IceBox.PrintServicesReady");
@@ -367,8 +356,7 @@ public class ServiceManagerI implements ServiceManager {
                 }
                 classDir = URLEncoder.encode(classDir, "UTF-8");
 
-                // Reuse an existing class loader if we have already loaded a plug-in with
-                // the same value for classDir, otherwise create a new one.
+                // Reuse an existing class loader if we have already loaded a plug-in with the same value for classDir, otherwise create a new one.
                 ClassLoader cl = null;
 
                 if (_classLoaders == null) {
@@ -411,10 +399,7 @@ public class ServiceManagerI implements ServiceManager {
         info.args = args;
 
         // If IceBox.UseSharedCommunicator.<name> is defined, create a
-        // communicator for the service. The communicator inherits
-        // from the shared communicator properties. If it's not
-        // defined, add the service properties to the shared
-        // communicator property set.
+        // communicator for the service. The communicator inherits from the shared communicator properties. If it's not defined, add the service properties to the shared communicator property set.
         com.zeroc.Ice.Communicator communicator;
         if (_communicator
                         .getProperties()
@@ -430,8 +415,7 @@ public class ServiceManagerI implements ServiceManager {
                 initData.properties = createServiceProperties(service);
                 String[] serviceArgs = info.args;
                 if (serviceArgs.length > 0) {
-                    // Create the service properties with the given service arguments. This should
-                    // read the service config file if it's specified with --Ice.Config.
+                    // Create the service properties with the given service arguments. This should read the service config file if it's specified with --Ice.Config.
                     java.util.List<String> remainingArgs = new java.util.ArrayList<>();
                     initData.properties =
                             new Properties(serviceArgs, initData.properties, remainingArgs);
@@ -442,9 +426,7 @@ public class ServiceManagerI implements ServiceManager {
                     serviceArgs = initData.properties.parseCommandLineOptions(service, serviceArgs);
                 }
 
-                // Clone the logger to assign a new prefix. If one of the built-in loggers is
-                // configured
-                // don't set any logger.
+                // Clone the logger to assign a new prefix. If one of the built-in loggers is configured don't set any logger.
                 if (initData.properties.getIceProperty("Ice.LogFile").isEmpty()
                         && (initData.properties.getIcePropertyAsInt("Ice.UseSyslog") <= 0
                                 || System.getProperty("os.name").startsWith("Windows"))) {
@@ -462,8 +444,7 @@ public class ServiceManagerI implements ServiceManager {
                 String serviceFacetNamePrefix = "IceBox.Service." + service + ".";
                 boolean addFacets = configureAdmin(initData.properties, serviceFacetNamePrefix);
 
-                // Remaining command line options are passed to the communicator. This is
-                // necessary for Ice plug-in properties (e.g.: Ice.SSL).
+                // Remaining command line options are passed to the communicator. This is necessary for Ice plug-in properties (e.g.: Ice.SSL).
                 java.util.List<String> remainingArgs = new java.util.ArrayList<>();
                 info.communicator = Util.initialize(serviceArgs, initData, remainingArgs);
                 info.args = remainingArgs.toArray(new String[remainingArgs.size()]);
@@ -472,8 +453,7 @@ public class ServiceManagerI implements ServiceManager {
                 if (addFacets) {
                     // Add all facets created on the service communicator to the IceBox communicator
                     // but renamed IceBox.Service.<service>.<facet-name>, except for the Process
-                    // facet
-                    // which is never added
+                    // facet which is never added
                     for (java.util.Map.Entry<String, com.zeroc.Ice.Object> p :
                             communicator.findAllAdminFacets().entrySet()) {
                         if (!p.getKey().equals("Process")) {
@@ -675,10 +655,7 @@ public class ServiceManagerI implements ServiceManager {
     private void observerRemoved(ServiceObserverPrx observer, RuntimeException ex) {
         if (_traceServiceObserver >= 1) {
             // CommunicatorDestroyedException may occur during shutdown. The observer notification
-            // has
-            // been sent, but the communicator was destroyed before the reply was received. We do
-            // not
-            // log a message for this exception.
+            // has been sent, but the communicator was destroyed before the reply was received. We do not log a message for this exception.
             if (!(ex instanceof com.zeroc.Ice.CommunicatorDestroyedException)) {
                 _logger.trace(
                         "IceBox.ServiceObserver",
@@ -719,8 +696,7 @@ public class ServiceManagerI implements ServiceManager {
 
             // We support the following formats:
             //
-            // <class-name> [args]
-            // <jar-file>:<class-name> [args]
+            // <class-name> [args] <jar-file>:<class-name> [args]
             // <class-dir>:<class-name> [args]
             // "<path with spaces>":<class-name> [args]
             // "<path with spaces>:<class-name>" [args]
@@ -829,8 +805,7 @@ public class ServiceManagerI implements ServiceManager {
             communicator.shutdown();
             communicator.waitForShutdown();
         } catch (com.zeroc.Ice.CommunicatorDestroyedException e) {
-            // Ignore, the service might have already destroyed the communicator for its own
-            // reasons.
+            // Ignore, the service might have already destroyed the communicator for its own reasons.
         } catch (Exception e) {
             java.io.StringWriter sw = new java.io.StringWriter();
             java.io.PrintWriter pw = new java.io.PrintWriter(sw);

--- a/java/src/com.zeroc.icebt/src/main/java/com/zeroc/IceBT/TransceiverI.java
+++ b/java/src/com.zeroc.icebt/src/main/java/com/zeroc/IceBT/TransceiverI.java
@@ -49,8 +49,7 @@ final class TransceiverI implements Transceiver {
 
     @Override
     public int closing(boolean initiator, LocalException ex) {
-        // If we are initiating the connection closure, wait for the peer
-        // to close the connection. Otherwise, close immediately.
+        // If we are initiating the connection closure, wait for the peer to close the connection. Otherwise, close immediately.
         return initiator ? SocketOperation.Read : SocketOperation.None;
     }
 
@@ -372,8 +371,7 @@ final class TransceiverI implements Transceiver {
 
             while (true) {
                 synchronized (this) {
-                    // If we've read too much data, wait until the application consumes some before
-                    // we read again.
+                    // If we've read too much data, wait until the application consumes some before we read again.
                     while (_state == StateConnected
                             && _exception == null
                             && _readBuffer.b.position() > _rcvSize) {

--- a/java/src/com.zeroc.icebt/src/main/java/com/zeroc/IceBT/TransceiverI.java
+++ b/java/src/com.zeroc.icebt/src/main/java/com/zeroc/IceBT/TransceiverI.java
@@ -49,7 +49,8 @@ final class TransceiverI implements Transceiver {
 
     @Override
     public int closing(boolean initiator, LocalException ex) {
-        // If we are initiating the connection closure, wait for the peer to close the connection. Otherwise, close immediately.
+        // If we are initiating the connection closure, wait for the peer to close the connection.
+        // Otherwise, close immediately.
         return initiator ? SocketOperation.Read : SocketOperation.None;
     }
 
@@ -371,7 +372,8 @@ final class TransceiverI implements Transceiver {
 
             while (true) {
                 synchronized (this) {
-                    // If we've read too much data, wait until the application consumes some before we read again.
+                    // If we've read too much data, wait until the application consumes some before
+                    // we read again.
                     while (_state == StateConnected
                             && _exception == null
                             && _readBuffer.b.position() > _rcvSize) {

--- a/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
+++ b/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
@@ -235,9 +235,7 @@ class PluginI implements Plugin {
                 return;
             }
 
-            // If we already have a locator assigned, ensure the given locator has the same
-            // identity,
-            // otherwise ignore it.
+            // If we already have a locator assigned, ensure the given locator has the same identity, otherwise ignore it.
             if (!_pendingRequests.isEmpty()
                     && _locator != null
                     && !locator.ice_getIdentity()
@@ -401,8 +399,7 @@ class PluginI implements Plugin {
 
         synchronized void exception(Throwable ex) {
             if (++_failureCount == _lookups.size() && _pending) {
-                // All the lookup calls failed, cancel the timer and propagate the error to the
-                // requests.
+                // All the lookup calls failed, cancel the timer and propagate the error to the requests.
                 _future.cancel(false);
                 _future = null;
                 _pendingRetryCount = 0;

--- a/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
+++ b/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
@@ -235,7 +235,8 @@ class PluginI implements Plugin {
                 return;
             }
 
-            // If we already have a locator assigned, ensure the given locator has the same identity, otherwise ignore it.
+            // If we already have a locator assigned, ensure the given locator has the same
+            // identity, otherwise ignore it.
             if (!_pendingRequests.isEmpty()
                     && _locator != null
                     && !locator.ice_getIdentity()
@@ -399,7 +400,8 @@ class PluginI implements Plugin {
 
         synchronized void exception(Throwable ex) {
             if (++_failureCount == _lookups.size() && _pending) {
-                // All the lookup calls failed, cancel the timer and propagate the error to the requests.
+                // All the lookup calls failed, cancel the timer and propagate the error to the
+                // requests.
                 _future.cancel(false);
                 _future = null;
                 _pendingRetryCount = 0;

--- a/java/test/src/main/java/test/Glacier2/router/Client.java
+++ b/java/test/src/main/java/test/Glacier2/router/Client.java
@@ -321,8 +321,7 @@ public class Client extends test.TestHelper {
                   base.ice_ping();
                   test(false);
                   }
-                  // If we use the glacier router, the exact exception reason gets
-                  // lost.
+                  // If we use the glacier router, the exact exception reason gets lost.
                   catch(com.zeroc.Ice.UnknownLocalException ex)
                   {
                   System.out.println("ok");

--- a/java/test/src/main/java/test/Ice/adapterDeactivation/AllTests.java
+++ b/java/test/src/main/java/test/Ice/adapterDeactivation/AllTests.java
@@ -54,7 +54,8 @@ public class AllTests {
             }
             adapter.destroy();
             //
-            // Use a different port than the first adapter to avoid an "address already in use" error.
+            // Use a different port than the first adapter to avoid an "address already in use"
+            // error.
             //
             adapter =
                     communicator.createObjectAdapterWithEndpoints(

--- a/java/test/src/main/java/test/Ice/adapterDeactivation/AllTests.java
+++ b/java/test/src/main/java/test/Ice/adapterDeactivation/AllTests.java
@@ -54,8 +54,7 @@ public class AllTests {
             }
             adapter.destroy();
             //
-            // Use a different port than the first adapter to avoid an "address already in use"
-            // error.
+            // Use a different port than the first adapter to avoid an "address already in use" error.
             //
             adapter =
                     communicator.createObjectAdapterWithEndpoints(

--- a/java/test/src/main/java/test/Ice/admin/RemoteCommunicatorI.java
+++ b/java/test/src/main/java/test/Ice/admin/RemoteCommunicatorI.java
@@ -48,7 +48,8 @@ public class RemoteCommunicatorI
     @Override
     public void waitForShutdown(com.zeroc.Ice.Current current) {
         //
-        // Note that we are executing in a thread of the *main* communicator, not the one that is being shut down.
+        // Note that we are executing in a thread of the *main* communicator, not the one that is
+        // being shut down.
         //
         _communicator.waitForShutdown();
     }

--- a/java/test/src/main/java/test/Ice/admin/RemoteCommunicatorI.java
+++ b/java/test/src/main/java/test/Ice/admin/RemoteCommunicatorI.java
@@ -48,8 +48,7 @@ public class RemoteCommunicatorI
     @Override
     public void waitForShutdown(com.zeroc.Ice.Current current) {
         //
-        // Note that we are executing in a thread of the *main* communicator,
-        // not the one that is being shut down.
+        // Note that we are executing in a thread of the *main* communicator, not the one that is being shut down.
         //
         _communicator.waitForShutdown();
     }

--- a/java/test/src/main/java/test/Ice/ami/AllTests.java
+++ b/java/test/src/main/java/test/Ice/ami/AllTests.java
@@ -650,9 +650,7 @@ public class AllTests {
                     //
                     // Exception - 2 connections - 1 failure.
                     //
-                    // All connections should be flushed even if there are failures on some
-                    // connections.
-                    // Exceptions should not be reported.
+                    // All connections should be flushed even if there are failures on some connections. Exceptions should not be reported.
                     //
                     final SentCallback cb = new SentCallback();
                     test(p.opBatchCount() == 0);
@@ -926,8 +924,7 @@ public class AllTests {
             out.print("testing connection close... ");
             out.flush();
             {
-                // Local case: begin a request, close the connection gracefully, and make sure it
-                // waits for the request to complete.
+                // Local case: begin a request, close the connection gracefully, and make sure it waits for the request to complete.
                 com.zeroc.Ice.Connection con = p.ice_getConnection();
                 Callback cb = new Callback();
                 con.setCloseCallback(c -> cb.called());
@@ -946,10 +943,7 @@ public class AllTests {
                 //
                 byte[] seq = new byte[1024 * 10];
 
-                // Send multiple opWithPayload, followed by a close and followed by multiple
-                // opWithPayload.
-                // The goal is to make sure that none of the opWithPayload fail even if the server
-                // closes the connection gracefully in between.
+                // Send multiple opWithPayload, followed by a close and followed by multiple opWithPayload. The goal is to make sure that none of the opWithPayload fail even if the server closes the connection gracefully in between.
                 int maxQueue = 2;
                 boolean done = false;
                 while (!done && maxQueue < 50) {
@@ -990,9 +984,7 @@ public class AllTests {
             out.flush();
             {
                 //
-                // Local case: start an operation and then close the connection forcefully on the
-                // client
-                // side. There will be no retry and we expect the invocation to fail with
+                // Local case: start an operation and then close the connection forcefully on the client side. There will be no retry and we expect the invocation to fail with
                 // ConnectionAbortedException.
                 //
                 p.ice_ping();
@@ -1016,11 +1008,9 @@ public class AllTests {
                 p.finishDispatch();
 
                 //
-                // Remote case: the server closes the connection forcefully. This causes the request
-                // to fail
+                // Remote case: the server closes the connection forcefully. This causes the request to fail
                 // with a ConnectionLostException. Since the close() operation is not idempotent,
-                // the client
-                // will not retry.
+                // the client will not retry.
                 //
                 try {
                     p.abortConnection();
@@ -1103,8 +1093,7 @@ public class AllTests {
                 CompletableFuture<Void> sleep3Future = p.sleepAsync(1000);
                 TestIntfPrx onewayProxy = p.ice_oneway();
 
-                // Sending should block because the TCP send/receive buffer
-                // size on the server is set to 50KB.
+                // Sending should block because the TCP send/receive buffer size on the server is set to 50KB.
                 CompletableFuture<Void> future =
                         onewayProxy.opWithPayloadAsync(new byte[768 * 1024]);
                 boolean timeout = false;

--- a/java/test/src/main/java/test/Ice/ami/AllTests.java
+++ b/java/test/src/main/java/test/Ice/ami/AllTests.java
@@ -650,7 +650,8 @@ public class AllTests {
                     //
                     // Exception - 2 connections - 1 failure.
                     //
-                    // All connections should be flushed even if there are failures on some connections. Exceptions should not be reported.
+                    // All connections should be flushed even if there are failures on some
+                    // connections. Exceptions should not be reported.
                     //
                     final SentCallback cb = new SentCallback();
                     test(p.opBatchCount() == 0);
@@ -924,7 +925,8 @@ public class AllTests {
             out.print("testing connection close... ");
             out.flush();
             {
-                // Local case: begin a request, close the connection gracefully, and make sure it waits for the request to complete.
+                // Local case: begin a request, close the connection gracefully, and make sure it
+                // waits for the request to complete.
                 com.zeroc.Ice.Connection con = p.ice_getConnection();
                 Callback cb = new Callback();
                 con.setCloseCallback(c -> cb.called());
@@ -943,7 +945,9 @@ public class AllTests {
                 //
                 byte[] seq = new byte[1024 * 10];
 
-                // Send multiple opWithPayload, followed by a close and followed by multiple opWithPayload. The goal is to make sure that none of the opWithPayload fail even if the server closes the connection gracefully in between.
+                // Send multiple opWithPayload, followed by a close and followed by multiple
+                // opWithPayload. The goal is to make sure that none of the opWithPayload fail even
+                // if the server closes the connection gracefully in between.
                 int maxQueue = 2;
                 boolean done = false;
                 while (!done && maxQueue < 50) {
@@ -984,7 +988,8 @@ public class AllTests {
             out.flush();
             {
                 //
-                // Local case: start an operation and then close the connection forcefully on the client side. There will be no retry and we expect the invocation to fail with
+                // Local case: start an operation and then close the connection forcefully on the
+                // client side. There will be no retry and we expect the invocation to fail with
                 // ConnectionAbortedException.
                 //
                 p.ice_ping();
@@ -1008,7 +1013,8 @@ public class AllTests {
                 p.finishDispatch();
 
                 //
-                // Remote case: the server closes the connection forcefully. This causes the request to fail
+                // Remote case: the server closes the connection forcefully. This causes the request
+                // to fail
                 // with a ConnectionLostException. Since the close() operation is not idempotent,
                 // the client will not retry.
                 //
@@ -1093,7 +1099,8 @@ public class AllTests {
                 CompletableFuture<Void> sleep3Future = p.sleepAsync(1000);
                 TestIntfPrx onewayProxy = p.ice_oneway();
 
-                // Sending should block because the TCP send/receive buffer size on the server is set to 50KB.
+                // Sending should block because the TCP send/receive buffer size on the server is
+                // set to 50KB.
                 CompletableFuture<Void> future =
                         onewayProxy.opWithPayloadAsync(new byte[768 * 1024]);
                 boolean timeout = false;

--- a/java/test/src/main/java/test/Ice/ami/TestI.java
+++ b/java/test/src/main/java/test/Ice/ami/TestI.java
@@ -125,7 +125,8 @@ public class TestI implements TestIntf {
 
     @Override
     public void closeConnection(com.zeroc.Ice.Current current) {
-        // We can't wait for the connection to be closed - this would cause a self dead-lock. So instead we just initiate the closure in the background.
+        // We can't wait for the connection to be closed - this would cause a self dead-lock. So
+        // instead we just initiate the closure in the background.
         CompletableFuture.runAsync(
                 () -> {
                     try {
@@ -154,7 +155,8 @@ public class TestI implements TestIntf {
     @Override
     public synchronized CompletionStage<Void> startDispatchAsync(com.zeroc.Ice.Current current) {
         if (_shutdown) {
-            // Ignore, this can occur with the forceful connection close test, shutdown can be dispatch before start dispatch.
+            // Ignore, this can occur with the forceful connection close test, shutdown can be
+            // dispatch before start dispatch.
             CompletableFuture<Void> v = new CompletableFuture<>();
             v.complete(null);
             return v;

--- a/java/test/src/main/java/test/Ice/ami/TestI.java
+++ b/java/test/src/main/java/test/Ice/ami/TestI.java
@@ -125,8 +125,7 @@ public class TestI implements TestIntf {
 
     @Override
     public void closeConnection(com.zeroc.Ice.Current current) {
-        // We can't wait for the connection to be closed - this would cause a self dead-lock.
-        // So instead we just initiate the closure in the background.
+        // We can't wait for the connection to be closed - this would cause a self dead-lock. So instead we just initiate the closure in the background.
         CompletableFuture.runAsync(
                 () -> {
                     try {
@@ -155,8 +154,7 @@ public class TestI implements TestIntf {
     @Override
     public synchronized CompletionStage<Void> startDispatchAsync(com.zeroc.Ice.Current current) {
         if (_shutdown) {
-            // Ignore, this can occur with the forceful connection close test, shutdown can be
-            // dispatch before start dispatch.
+            // Ignore, this can occur with the forceful connection close test, shutdown can be dispatch before start dispatch.
             CompletableFuture<Void> v = new CompletableFuture<>();
             v.complete(null);
             return v;

--- a/java/test/src/main/java/test/Ice/background/AllTests.java
+++ b/java/test/src/main/java/test/Ice/background/AllTests.java
@@ -869,8 +869,7 @@ public class AllTests {
             configuration.readException(new com.zeroc.Ice.SocketException());
             r = background.opAsync();
             InvocationFuture<Void> f = Util.getInvocationFuture(r);
-            // The read exception might propagate before the message send is seen as completed on
-            // IOCP.
+            // The read exception might propagate before the message send is seen as completed on IOCP.
             f.waitForSent();
             try {
                 r.join();

--- a/java/test/src/main/java/test/Ice/background/AllTests.java
+++ b/java/test/src/main/java/test/Ice/background/AllTests.java
@@ -869,7 +869,8 @@ public class AllTests {
             configuration.readException(new com.zeroc.Ice.SocketException());
             r = background.opAsync();
             InvocationFuture<Void> f = Util.getInvocationFuture(r);
-            // The read exception might propagate before the message send is seen as completed on IOCP.
+            // The read exception might propagate before the message send is seen as completed on
+            // IOCP.
             f.waitForSent();
             try {
                 r.join();

--- a/java/test/src/main/java/test/Ice/background/Client.java
+++ b/java/test/src/main/java/test/Ice/background/Client.java
@@ -19,8 +19,7 @@ public class Client extends test.TestHelper {
         properties.setProperty("Ice.Warn.Connections", "0");
 
         //
-        // This test relies on filling the TCP send/recv buffer, so
-        // we rely on a fixed value for these buffers.
+        // This test relies on filling the TCP send/recv buffer, so we rely on a fixed value for these buffers.
         //
         properties.setProperty("Ice.TCP.SndSize", "50000");
 

--- a/java/test/src/main/java/test/Ice/background/Client.java
+++ b/java/test/src/main/java/test/Ice/background/Client.java
@@ -19,7 +19,8 @@ public class Client extends test.TestHelper {
         properties.setProperty("Ice.Warn.Connections", "0");
 
         //
-        // This test relies on filling the TCP send/recv buffer, so we rely on a fixed value for these buffers.
+        // This test relies on filling the TCP send/recv buffer, so we rely on a fixed value for
+        // these buffers.
         //
         properties.setProperty("Ice.TCP.SndSize", "50000");
 

--- a/java/test/src/main/java/test/Ice/background/Server.java
+++ b/java/test/src/main/java/test/Ice/background/Server.java
@@ -74,8 +74,7 @@ public class Server extends test.TestHelper {
         properties.setProperty("Ice.Warn.Connections", "0");
         properties.setProperty("Ice.MessageSizeMax", "50000");
 
-        // This test relies on filling the TCP send/recv buffer, so
-        // we rely on a fixed value for these buffers.
+        // This test relies on filling the TCP send/recv buffer, so we rely on a fixed value for these buffers.
         properties.setProperty("Ice.TCP.RcvSize", "50000");
 
         //

--- a/java/test/src/main/java/test/Ice/background/Server.java
+++ b/java/test/src/main/java/test/Ice/background/Server.java
@@ -74,7 +74,8 @@ public class Server extends test.TestHelper {
         properties.setProperty("Ice.Warn.Connections", "0");
         properties.setProperty("Ice.MessageSizeMax", "50000");
 
-        // This test relies on filling the TCP send/recv buffer, so we rely on a fixed value for these buffers.
+        // This test relies on filling the TCP send/recv buffer, so we rely on a fixed value for
+        // these buffers.
         properties.setProperty("Ice.TCP.RcvSize", "50000");
 
         //

--- a/java/test/src/main/java/test/Ice/binding/AllTests.java
+++ b/java/test/src/main/java/test/Ice/binding/AllTests.java
@@ -110,8 +110,7 @@ public class AllTests {
             }
 
             //
-            // Ensure that the proxy correctly caches the connection (we
-            // always send the request over the same connection.)
+            // Ensure that the proxy correctly caches the connection (we always send the request over the same connection.)
             //
             {
                 for (RemoteObjectAdapterPrx p : adapters) {
@@ -132,8 +131,7 @@ public class AllTests {
             }
 
             //
-            // Deactivate an adapter and ensure that we can still
-            // establish the connection to the remaining adapters.
+            // Deactivate an adapter and ensure that we can still establish the connection to the remaining adapters.
             //
             rcom.deactivateObjectAdapter(adapters.get(0));
             names.add("Adapter12");
@@ -155,8 +153,7 @@ public class AllTests {
             }
 
             //
-            // Deactivate an adapter and ensure that we can still
-            // establish the connection to the remaining adapter.
+            // Deactivate an adapter and ensure that we can still establish the connection to the remaining adapter.
             //
             rcom.deactivateObjectAdapter(adapters.get(2));
             TestIntfPrx test = createTestIntfPrx(adapters);
@@ -274,8 +271,7 @@ public class AllTests {
             }
 
             //
-            // Ensure that the proxy correctly caches the connection (we
-            // always send the request over the same connection.)
+            // Ensure that the proxy correctly caches the connection (we always send the request over the same connection.)
             //
             {
                 for (RemoteObjectAdapterPrx p : adapters) {
@@ -296,8 +292,7 @@ public class AllTests {
             }
 
             //
-            // Deactivate an adapter and ensure that we can still
-            // establish the connection to the remaining adapters.
+            // Deactivate an adapter and ensure that we can still establish the connection to the remaining adapters.
             //
             rcom.deactivateObjectAdapter(adapters.get(0));
             names.add("AdapterAMI12");
@@ -319,8 +314,7 @@ public class AllTests {
             }
 
             //
-            // Deactivate an adapter and ensure that we can still
-            // establish the connection to the remaining adapter.
+            // Deactivate an adapter and ensure that we can still establish the connection to the remaining adapter.
             //
             rcom.deactivateObjectAdapter(adapters.get(2));
             TestIntfPrx test = createTestIntfPrx(adapters);
@@ -831,11 +825,9 @@ public class AllTests {
                             } catch (com.zeroc.Ice.ObjectNotExistException ex) {
                                 // Expected, no object registered.
                             } catch (com.zeroc.Ice.DNSException ex) {
-                                // Expected if no IPv4 or IPv6 address is
-                                // associated to localhost or if trying to connect
+                                // Expected if no IPv4 or IPv6 address is associated to localhost or if trying to connect
                                 // to an any endpoint with the wrong IP version,
-                                // e.g.: resolving an IPv4 address when only IPv6
-                                // is enabled fails with a DNS exception.
+                                // e.g.: resolving an IPv4 address when only IPv6 is enabled fails with a DNS exception.
                             } catch (com.zeroc.Ice.SocketException ex) {
                                 test(
                                         (p == ipv4 && q == ipv6)

--- a/java/test/src/main/java/test/Ice/binding/AllTests.java
+++ b/java/test/src/main/java/test/Ice/binding/AllTests.java
@@ -110,7 +110,8 @@ public class AllTests {
             }
 
             //
-            // Ensure that the proxy correctly caches the connection (we always send the request over the same connection.)
+            // Ensure that the proxy correctly caches the connection (we always send the request
+            // over the same connection.)
             //
             {
                 for (RemoteObjectAdapterPrx p : adapters) {
@@ -131,7 +132,8 @@ public class AllTests {
             }
 
             //
-            // Deactivate an adapter and ensure that we can still establish the connection to the remaining adapters.
+            // Deactivate an adapter and ensure that we can still establish the connection to the
+            // remaining adapters.
             //
             rcom.deactivateObjectAdapter(adapters.get(0));
             names.add("Adapter12");
@@ -153,7 +155,8 @@ public class AllTests {
             }
 
             //
-            // Deactivate an adapter and ensure that we can still establish the connection to the remaining adapter.
+            // Deactivate an adapter and ensure that we can still establish the connection to the
+            // remaining adapter.
             //
             rcom.deactivateObjectAdapter(adapters.get(2));
             TestIntfPrx test = createTestIntfPrx(adapters);
@@ -271,7 +274,8 @@ public class AllTests {
             }
 
             //
-            // Ensure that the proxy correctly caches the connection (we always send the request over the same connection.)
+            // Ensure that the proxy correctly caches the connection (we always send the request
+            // over the same connection.)
             //
             {
                 for (RemoteObjectAdapterPrx p : adapters) {
@@ -292,7 +296,8 @@ public class AllTests {
             }
 
             //
-            // Deactivate an adapter and ensure that we can still establish the connection to the remaining adapters.
+            // Deactivate an adapter and ensure that we can still establish the connection to the
+            // remaining adapters.
             //
             rcom.deactivateObjectAdapter(adapters.get(0));
             names.add("AdapterAMI12");
@@ -314,7 +319,8 @@ public class AllTests {
             }
 
             //
-            // Deactivate an adapter and ensure that we can still establish the connection to the remaining adapter.
+            // Deactivate an adapter and ensure that we can still establish the connection to the
+            // remaining adapter.
             //
             rcom.deactivateObjectAdapter(adapters.get(2));
             TestIntfPrx test = createTestIntfPrx(adapters);
@@ -825,9 +831,11 @@ public class AllTests {
                             } catch (com.zeroc.Ice.ObjectNotExistException ex) {
                                 // Expected, no object registered.
                             } catch (com.zeroc.Ice.DNSException ex) {
-                                // Expected if no IPv4 or IPv6 address is associated to localhost or if trying to connect
+                                // Expected if no IPv4 or IPv6 address is associated to localhost or
+                                // if trying to connect
                                 // to an any endpoint with the wrong IP version,
-                                // e.g.: resolving an IPv4 address when only IPv6 is enabled fails with a DNS exception.
+                                // e.g.: resolving an IPv4 address when only IPv6 is enabled fails
+                                // with a DNS exception.
                             } catch (com.zeroc.Ice.SocketException ex) {
                                 test(
                                         (p == ipv4 && q == ipv6)

--- a/java/test/src/main/java/test/Ice/custom/AllTests.java
+++ b/java/test/src/main/java/test/Ice/custom/AllTests.java
@@ -60,8 +60,7 @@ public class AllTests {
             }
 
             //
-            // Invoke each operation and verify that the returned sequences have the same
-            // structure as the original.
+            // Invoke each operation and verify that the returned sequences have the same structure as the original.
             //
             TestIntf.OpASeqResult seqR = t.opASeq(seq);
             test(seqR.returnValue.length == seq.length);

--- a/java/test/src/main/java/test/Ice/custom/AllTests.java
+++ b/java/test/src/main/java/test/Ice/custom/AllTests.java
@@ -60,7 +60,8 @@ public class AllTests {
             }
 
             //
-            // Invoke each operation and verify that the returned sequences have the same structure as the original.
+            // Invoke each operation and verify that the returned sequences have the same structure
+            // as the original.
             //
             TestIntf.OpASeqResult seqR = t.opASeq(seq);
             test(seqR.returnValue.length == seq.length);

--- a/java/test/src/main/java/test/Ice/exceptions/AMDThrowerI.java
+++ b/java/test/src/main/java/test/Ice/exceptions/AMDThrowerI.java
@@ -144,7 +144,7 @@ public final class AMDThrowerI implements Thrower {
         ex.cMem = c;
         throw ex;
         // r.completeExceptionally(ex);
-        //  return r;
+        // return r;
     }
 
     @Override

--- a/java/test/src/main/java/test/Ice/exceptions/AMDThrowerI.java
+++ b/java/test/src/main/java/test/Ice/exceptions/AMDThrowerI.java
@@ -144,7 +144,7 @@ public final class AMDThrowerI implements Thrower {
         ex.cMem = c;
         throw ex;
         // r.completeExceptionally(ex);
-        // return r;
+        //  return r;
     }
 
     @Override
@@ -191,18 +191,14 @@ public final class AMDThrowerI implements Thrower {
 
     @Override
     public CompletionStage<Void> throwAfterResponseAsync(com.zeroc.Ice.Current current) {
-        // The Java 8 mapping doesn't support completing a request and continuing to use the
-        // dispatch
-        // thread.
+        // The Java 8 mapping doesn't support completing a request and continuing to use the dispatch thread.
 
         return CompletableFuture.completedFuture((Void) null);
     }
 
     @Override
     public CompletionStage<Void> throwAfterExceptionAsync(com.zeroc.Ice.Current current) throws A {
-        // The Java 8 mapping doesn't support completing a request and continuing to use the
-        // dispatch
-        // thread.
+        // The Java 8 mapping doesn't support completing a request and continuing to use the dispatch thread.
 
         CompletableFuture<Void> r = new CompletableFuture<>();
         r.completeExceptionally(new A());

--- a/java/test/src/main/java/test/Ice/exceptions/AMDThrowerI.java
+++ b/java/test/src/main/java/test/Ice/exceptions/AMDThrowerI.java
@@ -191,14 +191,16 @@ public final class AMDThrowerI implements Thrower {
 
     @Override
     public CompletionStage<Void> throwAfterResponseAsync(com.zeroc.Ice.Current current) {
-        // The Java 8 mapping doesn't support completing a request and continuing to use the dispatch thread.
+        // The Java 8 mapping doesn't support completing a request and continuing to use the
+        // dispatch thread.
 
         return CompletableFuture.completedFuture((Void) null);
     }
 
     @Override
     public CompletionStage<Void> throwAfterExceptionAsync(com.zeroc.Ice.Current current) throws A {
-        // The Java 8 mapping doesn't support completing a request and continuing to use the dispatch thread.
+        // The Java 8 mapping doesn't support completing a request and continuing to use the
+        // dispatch thread.
 
         CompletableFuture<Void> r = new CompletableFuture<>();
         r.completeExceptionally(new A());

--- a/java/test/src/main/java/test/Ice/executor/AllTests.java
+++ b/java/test/src/main/java/test/Ice/executor/AllTests.java
@@ -208,7 +208,8 @@ public class AllTests {
                 cb.check();
             }
 
-            // Hold adapter to make sure the invocations don't complete synchronously Also disable collocation optimization on p
+            // Hold adapter to make sure the invocations don't complete synchronously Also disable
+            // collocation optimization on p
             //
             testController.holdAdapter();
             p = p.ice_collocationOptimized(false);

--- a/java/test/src/main/java/test/Ice/executor/AllTests.java
+++ b/java/test/src/main/java/test/Ice/executor/AllTests.java
@@ -208,8 +208,8 @@ public class AllTests {
                 cb.check();
             }
 
-            // Hold adapter to make sure the invocations don't complete synchronously Also disable
-            // collocation optimization on p
+            // Hold adapter to make sure the invocations don't complete synchronously. Also disable
+            // collocation optimization on p.
             //
             testController.holdAdapter();
             p = p.ice_collocationOptimized(false);

--- a/java/test/src/main/java/test/Ice/executor/AllTests.java
+++ b/java/test/src/main/java/test/Ice/executor/AllTests.java
@@ -208,8 +208,7 @@ public class AllTests {
                 cb.check();
             }
 
-            // Hold adapter to make sure the invocations don't complete synchronously
-            // Also disable collocation optimization on p
+            // Hold adapter to make sure the invocations don't complete synchronously Also disable collocation optimization on p
             //
             testController.holdAdapter();
             p = p.ice_collocationOptimized(false);

--- a/java/test/src/main/java/test/Ice/hold/HoldI.java
+++ b/java/test/src/main/java/test/Ice/hold/HoldI.java
@@ -50,7 +50,8 @@ public final class HoldI implements Hold {
 
                             current.adapter.activate();
                         } catch (com.zeroc.Ice.LocalException ex) {
-                            // This shouldn't occur. The test ensures all the waitForHold timers are finished before shutting down the communicator.
+                            // This shouldn't occur. The test ensures all the waitForHold timers are
+                            // finished before shutting down the communicator.
                             test(false);
                         }
                     }

--- a/java/test/src/main/java/test/Ice/hold/HoldI.java
+++ b/java/test/src/main/java/test/Ice/hold/HoldI.java
@@ -50,9 +50,7 @@ public final class HoldI implements Hold {
 
                             current.adapter.activate();
                         } catch (com.zeroc.Ice.LocalException ex) {
-                            // This shouldn't occur. The test ensures all the
-                            // waitForHold timers are finished before shutting down the
-                            // communicator.
+                            // This shouldn't occur. The test ensures all the waitForHold timers are finished before shutting down the communicator.
                             test(false);
                         }
                     }

--- a/java/test/src/main/java/test/Ice/idleTimeout/AllTests.java
+++ b/java/test/src/main/java/test/Ice/idleTimeout/AllTests.java
@@ -36,7 +36,11 @@ public class AllTests {
         p.shutdown();
     }
 
-    // The client and server have the same idle timeout (1s) and both side enable the idle check (the default). We verify that the server's idle check does not abort the connection as long as this connection receives heartbeats, even when the heartbeats are not read off the connection in a timely manner. To verify this situation, we use an OA with a MaxDispatches = 1 to back-pressure the connection.
+    // The client and server have the same idle timeout (1s) and both side enable the idle check
+    // (the default). We verify that the server's idle check does not abort the connection as long
+    // as this connection receives heartbeats, even when the heartbeats are not read off the
+    // connection in a timely manner. To verify this situation, we use an OA with a MaxDispatches =
+    // 1 to back-pressure the connection.
     private static void testIdleCheckDoesNotAbortBackPressuredConnection(
             TestIntfPrx p, PrintWriter output) {
         output.write("testing that the idle check does not abort a back-pressured connection... ");
@@ -77,7 +81,8 @@ public class AllTests {
             var connection = p.ice_getConnection();
             test(connection != null);
 
-            // The idle check on the server side aborts the connection because it doesn't get a heartbeat in a timely fashion.
+            // The idle check on the server side aborts the connection because it doesn't get a
+            // heartbeat in a timely fashion.
             try {
                 p.sleep(2000); // the implementation in the server sleeps for 2,000ms
                 test(false); // we expect the server to abort the connection after about 1 second.
@@ -88,7 +93,8 @@ public class AllTests {
         output.println("ok");
     }
 
-    // Verifies the behavior with the idle check enabled or disabled when the client and the server have mismatched idle timeouts (here: 3s on the server side and 1s on the client side).
+    // Verifies the behavior with the idle check enabled or disabled when the client and the server
+    // have mismatched idle timeouts (here: 3s on the server side and 1s on the client side).
     private static void testEnableDisableIdleCheck(
             TestHelper helper,
             boolean enabled,

--- a/java/test/src/main/java/test/Ice/idleTimeout/AllTests.java
+++ b/java/test/src/main/java/test/Ice/idleTimeout/AllTests.java
@@ -36,14 +36,7 @@ public class AllTests {
         p.shutdown();
     }
 
-    // The client and server have the same idle timeout (1s) and both side enable the idle check
-    // (the
-    // default). We verify that the server's idle check does not abort the connection as long as
-    // this
-    // connection receives heartbeats, even when the heartbeats are not read off the connection in a
-    // timely manner.
-    // To verify this situation, we use an OA with a MaxDispatches = 1 to back-pressure the
-    // connection.
+    // The client and server have the same idle timeout (1s) and both side enable the idle check (the default). We verify that the server's idle check does not abort the connection as long as this connection receives heartbeats, even when the heartbeats are not read off the connection in a timely manner. To verify this situation, we use an OA with a MaxDispatches = 1 to back-pressure the connection.
     private static void testIdleCheckDoesNotAbortBackPressuredConnection(
             TestIntfPrx p, PrintWriter output) {
         output.write("testing that the idle check does not abort a back-pressured connection... ");
@@ -84,9 +77,7 @@ public class AllTests {
             var connection = p.ice_getConnection();
             test(connection != null);
 
-            // The idle check on the server side aborts the connection because it doesn't get a
-            // heartbeat
-            // in a timely fashion.
+            // The idle check on the server side aborts the connection because it doesn't get a heartbeat in a timely fashion.
             try {
                 p.sleep(2000); // the implementation in the server sleeps for 2,000ms
                 test(false); // we expect the server to abort the connection after about 1 second.
@@ -97,8 +88,7 @@ public class AllTests {
         output.println("ok");
     }
 
-    // Verifies the behavior with the idle check enabled or disabled when the client and the server
-    // have mismatched idle timeouts (here: 3s on the server side and 1s on the client side).
+    // Verifies the behavior with the idle check enabled or disabled when the client and the server have mismatched idle timeouts (here: 3s on the server side and 1s on the client side).
     private static void testEnableDisableIdleCheck(
             TestHelper helper,
             boolean enabled,

--- a/java/test/src/main/java/test/Ice/inactivityTimeout/AllTests.java
+++ b/java/test/src/main/java/test/Ice/inactivityTimeout/AllTests.java
@@ -37,7 +37,8 @@ public class AllTests {
         Connection connection = p.ice_getConnection();
         test(connection != null);
 
-        // The inactivity timeout is 3s on the client side and 5s on the server side. 4 seconds tests the client side.
+        // The inactivity timeout is 3s on the client side and 5s on the server side. 4 seconds
+        // tests the client side.
         try {
             Thread.sleep(4000);
         } catch (InterruptedException ex) {
@@ -67,7 +68,8 @@ public class AllTests {
             Connection connection = p.ice_getConnection();
             test(connection != null);
 
-            // The inactivity timeout is 5s on the client side and 3s on the server side. 4 seconds tests the server side.
+            // The inactivity timeout is 5s on the client side and 3s on the server side. 4 seconds
+            // tests the server side.
             try {
                 Thread.sleep(4000);
             } catch (InterruptedException ex) {
@@ -96,7 +98,8 @@ public class AllTests {
         Connection connection = p.ice_getConnection();
         test(connection != null);
 
-        // The inactivity timeout is 3s on the client side and 5s on the server side; 4 seconds tests only the client-side.
+        // The inactivity timeout is 3s on the client side and 5s on the server side; 4 seconds
+        // tests only the client-side.
         p.sleep(4000); // two-way blocks for 4 seconds; one-way is non-blocking
         if (oneway) {
             try {
@@ -108,7 +111,8 @@ public class AllTests {
         Connection connection2 = p.ice_getConnection();
 
         if (oneway) {
-            // With a oneway invocation, the inactivity timeout on the client side shut down the first connection.
+            // With a oneway invocation, the inactivity timeout on the client side shut down the
+            // first connection.
             test(connection2 != connection);
         } else {
             // With a two-way invocation, the inactivity timeout should not shutdown any connection.

--- a/java/test/src/main/java/test/Ice/inactivityTimeout/AllTests.java
+++ b/java/test/src/main/java/test/Ice/inactivityTimeout/AllTests.java
@@ -37,9 +37,7 @@ public class AllTests {
         Connection connection = p.ice_getConnection();
         test(connection != null);
 
-        // The inactivity timeout is 3s on the client side and 5s on the server side. 4 seconds
-        // tests
-        // the client side.
+        // The inactivity timeout is 3s on the client side and 5s on the server side. 4 seconds tests the client side.
         try {
             Thread.sleep(4000);
         } catch (InterruptedException ex) {
@@ -69,9 +67,7 @@ public class AllTests {
             Connection connection = p.ice_getConnection();
             test(connection != null);
 
-            // The inactivity timeout is 5s on the client side and 3s on the server side. 4 seconds
-            // tests
-            // the server side.
+            // The inactivity timeout is 5s on the client side and 3s on the server side. 4 seconds tests the server side.
             try {
                 Thread.sleep(4000);
             } catch (InterruptedException ex) {
@@ -100,9 +96,7 @@ public class AllTests {
         Connection connection = p.ice_getConnection();
         test(connection != null);
 
-        // The inactivity timeout is 3s on the client side and 5s on the server side; 4 seconds
-        // tests
-        // only the client-side.
+        // The inactivity timeout is 3s on the client side and 5s on the server side; 4 seconds tests only the client-side.
         p.sleep(4000); // two-way blocks for 4 seconds; one-way is non-blocking
         if (oneway) {
             try {
@@ -114,9 +108,7 @@ public class AllTests {
         Connection connection2 = p.ice_getConnection();
 
         if (oneway) {
-            // With a oneway invocation, the inactivity timeout on the client side shut down the
-            // first
-            // connection.
+            // With a oneway invocation, the inactivity timeout on the client side shut down the first connection.
             test(connection2 != connection);
         } else {
             // With a two-way invocation, the inactivity timeout should not shutdown any connection.

--- a/java/test/src/main/java/test/Ice/inactivityTimeout/Client.java
+++ b/java/test/src/main/java/test/Ice/inactivityTimeout/Client.java
@@ -8,9 +8,7 @@ public class Client extends test.TestHelper {
         var properties = createTestProperties(args);
         properties.setProperty("Ice.Package.Test", "test.Ice.inactivityTimeout");
 
-        // We configure a low idle timeout to make sure we send heartbeats frequently. It's the
-        // sending
-        // of the heartbeats that schedules the inactivity timer task.
+        // We configure a low idle timeout to make sure we send heartbeats frequently. It's the sending of the heartbeats that schedules the inactivity timer task.
         properties.setProperty("Ice.Connection.Client.IdleTimeout", "1");
         properties.setProperty("Ice.Connection.Client.InactivityTimeout", "3");
 

--- a/java/test/src/main/java/test/Ice/inactivityTimeout/Client.java
+++ b/java/test/src/main/java/test/Ice/inactivityTimeout/Client.java
@@ -8,7 +8,8 @@ public class Client extends test.TestHelper {
         var properties = createTestProperties(args);
         properties.setProperty("Ice.Package.Test", "test.Ice.inactivityTimeout");
 
-        // We configure a low idle timeout to make sure we send heartbeats frequently. It's the sending of the heartbeats that schedules the inactivity timer task.
+        // We configure a low idle timeout to make sure we send heartbeats frequently. It's the
+        // sending of the heartbeats that schedules the inactivity timer task.
         properties.setProperty("Ice.Connection.Client.IdleTimeout", "1");
         properties.setProperty("Ice.Connection.Client.InactivityTimeout", "3");
 

--- a/java/test/src/main/java/test/Ice/inactivityTimeout/Server.java
+++ b/java/test/src/main/java/test/Ice/inactivityTimeout/Server.java
@@ -8,9 +8,7 @@ public class Server extends test.TestHelper {
     public void run(String[] args) {
         var properties = createTestProperties(args);
         properties.setProperty("Ice.Package.Test", "test.Ice.inactivityTimeout");
-        // We configure a low idle timeout to make sure we send heartbeats frequently. It's the
-        // sending
-        // of the heartbeats that schedules the inactivity timer.
+        // We configure a low idle timeout to make sure we send heartbeats frequently. It's the sending of the heartbeats that schedules the inactivity timer.
         properties.setProperty("Ice.Connection.Server.IdleTimeout", "1");
         properties.setProperty("TestAdapter.Connection.InactivityTimeout", "5");
         properties.setProperty("TestAdapter3s.Connection.InactivityTimeout", "3");

--- a/java/test/src/main/java/test/Ice/inactivityTimeout/Server.java
+++ b/java/test/src/main/java/test/Ice/inactivityTimeout/Server.java
@@ -8,7 +8,8 @@ public class Server extends test.TestHelper {
     public void run(String[] args) {
         var properties = createTestProperties(args);
         properties.setProperty("Ice.Package.Test", "test.Ice.inactivityTimeout");
-        // We configure a low idle timeout to make sure we send heartbeats frequently. It's the sending of the heartbeats that schedules the inactivity timer.
+        // We configure a low idle timeout to make sure we send heartbeats frequently. It's the
+        // sending of the heartbeats that schedules the inactivity timer.
         properties.setProperty("Ice.Connection.Server.IdleTimeout", "1");
         properties.setProperty("TestAdapter.Connection.InactivityTimeout", "5");
         properties.setProperty("TestAdapter3s.Connection.InactivityTimeout", "3");

--- a/java/test/src/main/java/test/Ice/interrupt/AllTests.java
+++ b/java/test/src/main/java/test/Ice/interrupt/AllTests.java
@@ -211,8 +211,7 @@ public class AllTests {
                     r.get();
                     //
                     // get() won't raise InterruptedException if connection establishment has
-                    // already
-                    // completed.
+                    // already completed.
                     //
                     // test(false);
                     mainThread.interrupted();

--- a/java/test/src/main/java/test/Ice/interrupt/Client.java
+++ b/java/test/src/main/java/test/Ice/interrupt/Client.java
@@ -7,8 +7,7 @@ public class Client extends test.TestHelper {
         com.zeroc.Ice.Properties properties = createTestProperties(args);
         properties.setProperty("Ice.Package.Test", "test.Ice.interrupt");
         //
-        // We need to send messages large enough to cause the transport
-        // buffers to fill up.
+        // We need to send messages large enough to cause the transport buffers to fill up.
         //
         properties.setProperty("Ice.MessageSizeMax", "20000");
         //

--- a/java/test/src/main/java/test/Ice/interrupt/Collocated.java
+++ b/java/test/src/main/java/test/Ice/interrupt/Collocated.java
@@ -7,8 +7,7 @@ public class Collocated extends test.TestHelper {
         com.zeroc.Ice.Properties properties = createTestProperties(args);
         properties.setProperty("Ice.Package.Test", "test.Ice.interrupt");
         //
-        // We need to send messages large enough to cause the transport
-        // buffers to fill up.
+        // We need to send messages large enough to cause the transport buffers to fill up.
         //
         properties.setProperty("Ice.MessageSizeMax", "20000");
         //

--- a/java/test/src/main/java/test/Ice/location/AllTests.java
+++ b/java/test/src/main/java/test/Ice/location/AllTests.java
@@ -69,8 +69,7 @@ public class AllTests {
                         == 0);
 
         //
-        // We also test ice_router/ice_getRouter (perhaps we should add a
-        // test/Ice/router test?)
+        // We also test ice_router/ice_getRouter (perhaps we should add a test/Ice/router test?)
         //
         test(base.ice_getRouter() == null);
         var anotherRouter = com.zeroc.Ice.RouterPrx.createProxy(communicator, "anotherRouter");
@@ -470,10 +469,7 @@ public class AllTests {
                 test(count == locator.getRequestCount());
                 Thread.sleep(1200);
 
-                // The following request should trigger the background updates but still use the
-                // cached
-                // endpoints
-                // and therefore succeed.
+                // The following request should trigger the background updates but still use the cached endpoints and therefore succeed.
                 ic.stringToProxy("test@TestAdapter5")
                         .ice_locatorCacheTimeout(1)
                         .ice_ping(); // 1s timeout.

--- a/java/test/src/main/java/test/Ice/location/AllTests.java
+++ b/java/test/src/main/java/test/Ice/location/AllTests.java
@@ -469,7 +469,8 @@ public class AllTests {
                 test(count == locator.getRequestCount());
                 Thread.sleep(1200);
 
-                // The following request should trigger the background updates but still use the cached endpoints and therefore succeed.
+                // The following request should trigger the background updates but still use the
+                // cached endpoints and therefore succeed.
                 ic.stringToProxy("test@TestAdapter5")
                         .ice_locatorCacheTimeout(1)
                         .ice_ping(); // 1s timeout.

--- a/java/test/src/main/java/test/Ice/location/ServerLocator.java
+++ b/java/test/src/main/java/test/Ice/location/ServerLocator.java
@@ -27,7 +27,8 @@ public class ServerLocator implements TestLocator {
             return CompletableFuture.completedFuture(_registry.getAdapter("TestAdapter"));
         }
 
-        // We add a small delay to make sure locator request queuing gets tested when running the test on a fast machine
+        // We add a small delay to make sure locator request queuing gets tested when running the
+        // test on a fast machine
         try {
             Thread.sleep(1);
         } catch (InterruptedException ex) {
@@ -40,7 +41,8 @@ public class ServerLocator implements TestLocator {
             com.zeroc.Ice.Identity id, com.zeroc.Ice.Current current)
             throws com.zeroc.Ice.ObjectNotFoundException {
         ++_requestCount;
-        // We add a small delay to make sure locator request queuing gets tested when running the test on a fast machine
+        // We add a small delay to make sure locator request queuing gets tested when running the
+        // test on a fast machine
         try {
             Thread.sleep(1);
         } catch (InterruptedException ex) {

--- a/java/test/src/main/java/test/Ice/location/ServerLocator.java
+++ b/java/test/src/main/java/test/Ice/location/ServerLocator.java
@@ -27,8 +27,7 @@ public class ServerLocator implements TestLocator {
             return CompletableFuture.completedFuture(_registry.getAdapter("TestAdapter"));
         }
 
-        // We add a small delay to make sure locator request queuing gets tested when
-        // running the test on a fast machine
+        // We add a small delay to make sure locator request queuing gets tested when running the test on a fast machine
         try {
             Thread.sleep(1);
         } catch (InterruptedException ex) {
@@ -41,8 +40,7 @@ public class ServerLocator implements TestLocator {
             com.zeroc.Ice.Identity id, com.zeroc.Ice.Current current)
             throws com.zeroc.Ice.ObjectNotFoundException {
         ++_requestCount;
-        // We add a small delay to make sure locator request queuing gets tested when
-        // running the test on a fast machine
+        // We add a small delay to make sure locator request queuing gets tested when running the test on a fast machine
         try {
             Thread.sleep(1);
         } catch (InterruptedException ex) {

--- a/java/test/src/main/java/test/Ice/location/ServerManagerI.java
+++ b/java/test/src/main/java/test/Ice/location/ServerManagerI.java
@@ -75,10 +75,7 @@ public class ServerManagerI implements ServerManager {
                     throw ex;
                 }
 
-                // Retry, if OA creation fails with EADDRINUSE (this can occur when running with JS
-                // web
-                // browser clients if the driver uses ports in the same range as this test,
-                // ICE-8148)
+                // Retry, if OA creation fails with EADDRINUSE (this can occur when running with JS web browser clients if the driver uses ports in the same range as this test, ICE-8148)
                 if (adapter != null) {
                     adapter.destroy();
                 }

--- a/java/test/src/main/java/test/Ice/location/ServerManagerI.java
+++ b/java/test/src/main/java/test/Ice/location/ServerManagerI.java
@@ -75,7 +75,9 @@ public class ServerManagerI implements ServerManager {
                     throw ex;
                 }
 
-                // Retry, if OA creation fails with EADDRINUSE (this can occur when running with JS web browser clients if the driver uses ports in the same range as this test, ICE-8148)
+                // Retry, if OA creation fails with EADDRINUSE (this can occur when running with JS
+                // web browser clients if the driver uses ports in the same range as this test,
+                // ICE-8148)
                 if (adapter != null) {
                     adapter.destroy();
                 }

--- a/java/test/src/main/java/test/Ice/metrics/AllTests.java
+++ b/java/test/src/main/java/test/Ice/metrics/AllTests.java
@@ -31,13 +31,7 @@ public class AllTests {
             s = (ConnectionMetrics) r.returnValue.get("Connection")[0];
             int nRetry = 30;
             while (s.sentBytes != expected && nRetry-- > 0) {
-                // On some platforms, it's necessary to wait a little before obtaining the server
-                // metrics
-                // to get an accurate sentBytes metric. The sentBytes metric is updated before the
-                // response
-                // to the operation is sent and getMetricsView can be dispatched before the metric
-                // is really
-                // updated.
+                // On some platforms, it's necessary to wait a little before obtaining the server metrics to get an accurate sentBytes metric. The sentBytes metric is updated before the response to the operation is sent and getMetricsView can be dispatched before the metric is really updated.
                 try {
                     Thread.sleep(100);
                 } catch (InterruptedException ex) {
@@ -536,12 +530,7 @@ public class AllTests {
             map = toMap(serverMetrics.getMetricsView("View").returnValue.get("Connection"));
             test(map.get("holding").current == 1);
 
-            // Calling `close` on a Connection blocks the calling thread until the closure is
-            // complete.
-            // At which point the connection is in the `Closed` state. So to test the `Closing`
-            // state,
-            // we directly call `doApplicationClose` to _initiate_ a closure, without having to
-            // wait.
+            // Calling `close` on a Connection blocks the calling thread until the closure is complete. At which point the connection is in the `Closed` state. So to test the `Closing` state, we directly call `doApplicationClose` to _initiate_ a closure, without having to wait.
             ((com.zeroc.Ice.ConnectionI) metrics.ice_getConnection()).doApplicationClose();
 
             map = toMap(clientMetrics.getMetricsView("View").returnValue.get("Connection"));

--- a/java/test/src/main/java/test/Ice/metrics/AllTests.java
+++ b/java/test/src/main/java/test/Ice/metrics/AllTests.java
@@ -31,7 +31,10 @@ public class AllTests {
             s = (ConnectionMetrics) r.returnValue.get("Connection")[0];
             int nRetry = 30;
             while (s.sentBytes != expected && nRetry-- > 0) {
-                // On some platforms, it's necessary to wait a little before obtaining the server metrics to get an accurate sentBytes metric. The sentBytes metric is updated before the response to the operation is sent and getMetricsView can be dispatched before the metric is really updated.
+                // On some platforms, it's necessary to wait a little before obtaining the server
+                // metrics to get an accurate sentBytes metric. The sentBytes metric is updated
+                // before the response to the operation is sent and getMetricsView can be dispatched
+                // before the metric is really updated.
                 try {
                     Thread.sleep(100);
                 } catch (InterruptedException ex) {
@@ -530,7 +533,10 @@ public class AllTests {
             map = toMap(serverMetrics.getMetricsView("View").returnValue.get("Connection"));
             test(map.get("holding").current == 1);
 
-            // Calling `close` on a Connection blocks the calling thread until the closure is complete. At which point the connection is in the `Closed` state. So to test the `Closing` state, we directly call `doApplicationClose` to _initiate_ a closure, without having to wait.
+            // Calling `close` on a Connection blocks the calling thread until the closure is
+            // complete. At which point the connection is in the `Closed` state. So to test the
+            // `Closing` state, we directly call `doApplicationClose` to _initiate_ a closure,
+            // without having to wait.
             ((com.zeroc.Ice.ConnectionI) metrics.ice_getConnection()).doApplicationClose();
 
             map = toMap(clientMetrics.getMetricsView("View").returnValue.get("Connection"));

--- a/java/test/src/main/java/test/Ice/retry/AllTests.java
+++ b/java/test/src/main/java/test/Ice/retry/AllTests.java
@@ -162,7 +162,8 @@ public class AllTests {
             test(retry1.opIdempotent(4) == 4);
             instrumentation.testInvocationCount(1);
             instrumentation.testFailureCount(0);
-            // It succeeded after 3 retry because of the failed opIdempotent on the fixed proxy above
+            // It succeeded after 3 retry because of the failed opIdempotent on the fixed proxy
+            // above
             instrumentation.testRetryCount(3);
             out.println("ok");
         }

--- a/java/test/src/main/java/test/Ice/retry/AllTests.java
+++ b/java/test/src/main/java/test/Ice/retry/AllTests.java
@@ -162,8 +162,7 @@ public class AllTests {
             test(retry1.opIdempotent(4) == 4);
             instrumentation.testInvocationCount(1);
             instrumentation.testFailureCount(0);
-            // It succeeded after 3 retry because of the failed opIdempotent on the fixed proxy
-            // above
+            // It succeeded after 3 retry because of the failed opIdempotent on the fixed proxy above
             instrumentation.testRetryCount(3);
             out.println("ok");
         }

--- a/java/test/src/main/java/test/Ice/seqMapping/TwowaysAMI.java
+++ b/java/test/src/main/java/test/Ice/seqMapping/TwowaysAMI.java
@@ -52,9 +52,7 @@ class TwowaysAMI {
                                                     instanceof
                                                     com.zeroc.Ice
                                                             .OperationNotExistException); // OK,
-                                    // talking
-                                    // to
-                                    // non-Java server.
+                                    // talking to non-Java server.
                                 } else {
                                     test(result.o == null);
                                     test(result.returnValue == null);
@@ -78,9 +76,7 @@ class TwowaysAMI {
                                                     instanceof
                                                     com.zeroc.Ice
                                                             .OperationNotExistException); // OK,
-                                    // talking
-                                    // to
-                                    // non-Java server.
+                                    // talking to non-Java server.
                                 } else {
                                     test(result.o.i == 99);
                                     test(result.returnValue.i == 99);
@@ -113,9 +109,7 @@ class TwowaysAMI {
                                                     instanceof
                                                     com.zeroc.Ice
                                                             .OperationNotExistException); // OK,
-                                    // talking
-                                    // to
-                                    // non-Java server.
+                                    // talking to non-Java server.
                                 } else {
                                     test(result.o.d1 == 1.0);
                                     test(result.o.d2 == 2.0);

--- a/java/test/src/main/java/test/Ice/servantLocator/AMDServantLocatorI.java
+++ b/java/test/src/main/java/test/Ice/servantLocator/AMDServantLocatorI.java
@@ -110,7 +110,8 @@ public final class AMDServantLocatorI implements ServantLocator {
             throw new UnknownException("reason");
         }
         //
-        // User exceptions are checked exceptions in Java, so it's not possible to throw it from the servant locator.
+        // User exceptions are checked exceptions in Java, so it's not possible to throw it from the
+        // servant locator.
         //
         //      else if(current.operation.equals("userException"))
         //      {

--- a/java/test/src/main/java/test/Ice/servantLocator/AMDServantLocatorI.java
+++ b/java/test/src/main/java/test/Ice/servantLocator/AMDServantLocatorI.java
@@ -110,8 +110,7 @@ public final class AMDServantLocatorI implements ServantLocator {
             throw new UnknownException("reason");
         }
         //
-        // User exceptions are checked exceptions in Java, so it's not
-        // possible to throw it from the servant locator.
+        // User exceptions are checked exceptions in Java, so it's not possible to throw it from the servant locator.
         //
         //      else if(current.operation.equals("userException"))
         //      {

--- a/java/test/src/main/java/test/Ice/servantLocator/ServantLocatorI.java
+++ b/java/test/src/main/java/test/Ice/servantLocator/ServantLocatorI.java
@@ -110,7 +110,8 @@ public final class ServantLocatorI implements ServantLocator {
             throw new UnknownException("reason");
         }
         //
-        // User exceptions are checked exceptions in Java, so it's not possible to throw it from the servant locator.
+        // User exceptions are checked exceptions in Java, so it's not possible to throw it from the
+        // servant locator.
         //
         //      else if(current.operation.equals("userException"))
         //      {

--- a/java/test/src/main/java/test/Ice/servantLocator/ServantLocatorI.java
+++ b/java/test/src/main/java/test/Ice/servantLocator/ServantLocatorI.java
@@ -110,8 +110,7 @@ public final class ServantLocatorI implements ServantLocator {
             throw new UnknownException("reason");
         }
         //
-        // User exceptions are checked exceptions in Java, so it's not
-        // possible to throw it from the servant locator.
+        // User exceptions are checked exceptions in Java, so it's not possible to throw it from the servant locator.
         //
         //      else if(current.operation.equals("userException"))
         //      {

--- a/java/test/src/main/java/test/Ice/slicing/objects/AllTests.java
+++ b/java/test/src/main/java/test/Ice/slicing/objects/AllTests.java
@@ -249,8 +249,7 @@ public class AllTests {
         } else {
             try {
                 //
-                // This test fails when using the compact format because the instance cannot
-                // be sliced to a known type.
+                // This test fails when using the compact format because the instance cannot be sliced to a known type.
                 //
                 test.SBSUnknownDerivedAsSBaseCompact();
                 test(false);
@@ -294,8 +293,7 @@ public class AllTests {
             cb.check();
         } else {
             //
-            // This test fails when using the compact format because the instance cannot
-            // be sliced to a known type.
+            // This test fails when using the compact format because the instance cannot be sliced to a known type.
             //
             Callback cb = new Callback();
             test.SBSUnknownDerivedAsSBaseCompactAsync()
@@ -1866,9 +1864,7 @@ public class AllTests {
 
         try {
             //
-            // Obtain an object with preserved slices and send it back to the server.
-            // The preserved slices should be excluded for the 1.0 encoding, otherwise
-            // they should be included.
+            // Obtain an object with preserved slices and send it back to the server. The preserved slices should be excluded for the 1.0 encoding, otherwise they should be included.
             //
             Preserved p = test.PBSUnknownAsPreserved();
             test.checkPBSUnknown(p);
@@ -2097,9 +2093,7 @@ public class AllTests {
 
         try {
             //
-            // Obtain an object with preserved slices and send it back to the server.
-            // The preserved slices should be excluded for the 1.0 encoding, otherwise
-            // they should be included.
+            // Obtain an object with preserved slices and send it back to the server. The preserved slices should be excluded for the 1.0 encoding, otherwise they should be included.
             //
             Preserved p = test.PBSUnknownAsPreserved();
             test.checkPBSUnknown(p);
@@ -2150,9 +2144,7 @@ public class AllTests {
             }
 
             //
-            // Obtain a preserved object from the server where the most-derived
-            // type is unknown. A data member in the preserved slice refers to the
-            // outer object, so the chain of references looks like this:
+            // Obtain a preserved object from the server where the most-derived type is unknown. A data member in the preserved slice refers to the outer object, so the chain of references looks like this:
             //
             // outer.slicedData.outer
             //
@@ -2165,11 +2157,7 @@ public class AllTests {
             }
 
             //
-            // Throw a preserved exception where the most-derived type is unknown.
-            // The preserved exception slice contains a class data member. This
-            // object is also preserved, and its most-derived type is also unknown.
-            // The preserved slice of the object contains a class data member that
-            // refers to itself.
+            // Throw a preserved exception where the most-derived type is unknown. The preserved exception slice contains a class data member. This object is also preserved, and its most-derived type is also unknown. The preserved slice of the object contains a class data member that refers to itself.
             //
             // The chain of references looks like this:
             //

--- a/java/test/src/main/java/test/Ice/slicing/objects/AllTests.java
+++ b/java/test/src/main/java/test/Ice/slicing/objects/AllTests.java
@@ -249,7 +249,8 @@ public class AllTests {
         } else {
             try {
                 //
-                // This test fails when using the compact format because the instance cannot be sliced to a known type.
+                // This test fails when using the compact format because the instance cannot be
+                // sliced to a known type.
                 //
                 test.SBSUnknownDerivedAsSBaseCompact();
                 test(false);
@@ -293,7 +294,8 @@ public class AllTests {
             cb.check();
         } else {
             //
-            // This test fails when using the compact format because the instance cannot be sliced to a known type.
+            // This test fails when using the compact format because the instance cannot be sliced
+            // to a known type.
             //
             Callback cb = new Callback();
             test.SBSUnknownDerivedAsSBaseCompactAsync()
@@ -1864,7 +1866,8 @@ public class AllTests {
 
         try {
             //
-            // Obtain an object with preserved slices and send it back to the server. The preserved slices should be excluded for the 1.0 encoding, otherwise they should be included.
+            // Obtain an object with preserved slices and send it back to the server. The preserved
+            // slices should be excluded for the 1.0 encoding, otherwise they should be included.
             //
             Preserved p = test.PBSUnknownAsPreserved();
             test.checkPBSUnknown(p);
@@ -2093,7 +2096,8 @@ public class AllTests {
 
         try {
             //
-            // Obtain an object with preserved slices and send it back to the server. The preserved slices should be excluded for the 1.0 encoding, otherwise they should be included.
+            // Obtain an object with preserved slices and send it back to the server. The preserved
+            // slices should be excluded for the 1.0 encoding, otherwise they should be included.
             //
             Preserved p = test.PBSUnknownAsPreserved();
             test.checkPBSUnknown(p);
@@ -2144,7 +2148,9 @@ public class AllTests {
             }
 
             //
-            // Obtain a preserved object from the server where the most-derived type is unknown. A data member in the preserved slice refers to the outer object, so the chain of references looks like this:
+            // Obtain a preserved object from the server where the most-derived type is unknown. A
+            // data member in the preserved slice refers to the outer object, so the chain of
+            // references looks like this:
             //
             // outer.slicedData.outer
             //
@@ -2157,7 +2163,10 @@ public class AllTests {
             }
 
             //
-            // Throw a preserved exception where the most-derived type is unknown. The preserved exception slice contains a class data member. This object is also preserved, and its most-derived type is also unknown. The preserved slice of the object contains a class data member that refers to itself.
+            // Throw a preserved exception where the most-derived type is unknown. The preserved
+            // exception slice contains a class data member. This object is also preserved, and its
+            // most-derived type is also unknown. The preserved slice of the object contains a class
+            // data member that refers to itself.
             //
             // The chain of references looks like this:
             //

--- a/java/test/src/main/java/test/Ice/timeout/AllTests.java
+++ b/java/test/src/main/java/test/Ice/timeout/AllTests.java
@@ -42,9 +42,7 @@ public class AllTests {
         try {
             allTestsWithController(helper, controller);
         } catch (Exception ex) {
-            // Ensure the adapter is not in the holding state when an unexpected exception occurs to
-            // prevent the test
-            // from hanging on exit in case a connection which disables timeouts is still opened.
+            // Ensure the adapter is not in the holding state when an unexpected exception occurs to prevent the test from hanging on exit in case a connection which disables timeouts is still opened.
             controller.resumeAdapter();
             throw ex;
         }
@@ -151,14 +149,9 @@ public class AllTests {
         out.print("testing close timeout... ");
         out.flush();
         {
-            // This test wants to call some local methods while our connection is in the `Closing`
-            // state, before it eventually transitions to the `Closed` state due to hitting the
-            // close timeout.
+            // This test wants to call some local methods while our connection is in the `Closing` state, before it eventually transitions to the `Closed` state due to hitting the close timeout.
             //
-            // However, in Java `close` blocks until the connection is closed. So, in order to
-            // access the `Closing` state, we initiate the close in a separate thread, wait 50ms to
-            // let the thread start the closure process, and hope that we're in the `Closing` state
-            // by then.
+            // However, in Java `close` blocks until the connection is closed. So, in order to access the `Closing` state, we initiate the close in a separate thread, wait 50ms to let the thread start the closure process, and hope that we're in the `Closing` state by then.
 
             // Get the connection, and put the OA in the `Hold` state.
             var connection = connect(timeout);

--- a/java/test/src/main/java/test/Ice/timeout/AllTests.java
+++ b/java/test/src/main/java/test/Ice/timeout/AllTests.java
@@ -42,7 +42,9 @@ public class AllTests {
         try {
             allTestsWithController(helper, controller);
         } catch (Exception ex) {
-            // Ensure the adapter is not in the holding state when an unexpected exception occurs to prevent the test from hanging on exit in case a connection which disables timeouts is still opened.
+            // Ensure the adapter is not in the holding state when an unexpected exception occurs to
+            // prevent the test from hanging on exit in case a connection which disables timeouts is
+            // still opened.
             controller.resumeAdapter();
             throw ex;
         }
@@ -149,9 +151,14 @@ public class AllTests {
         out.print("testing close timeout... ");
         out.flush();
         {
-            // This test wants to call some local methods while our connection is in the `Closing` state, before it eventually transitions to the `Closed` state due to hitting the close timeout.
+            // This test wants to call some local methods while our connection is in the `Closing`
+            // state, before it eventually transitions to the `Closed` state due to hitting the
+            // close timeout.
             //
-            // However, in Java `close` blocks until the connection is closed. So, in order to access the `Closing` state, we initiate the close in a separate thread, wait 50ms to let the thread start the closure process, and hope that we're in the `Closing` state by then.
+            // However, in Java `close` blocks until the connection is closed. So, in order to
+            // access the `Closing` state, we initiate the close in a separate thread, wait 50ms to
+            // let the thread start the closure process, and hope that we're in the `Closing` state
+            // by then.
 
             // Get the connection, and put the OA in the `Hold` state.
             var connection = connect(timeout);

--- a/java/test/src/main/java/test/Ice/udp/AllTests.java
+++ b/java/test/src/main/java/test/Ice/udp/AllTests.java
@@ -72,8 +72,7 @@ public class AllTests {
                 break; // Success
             }
 
-            // If the 3 datagrams were not received within the 2 seconds, we try again to
-            // receive 3 new datagrams using a new object. We give up after 5 retries.
+            // If the 3 datagrams were not received within the 2 seconds, we try again to receive 3 new datagrams using a new object. We give up after 5 retries.
             replyI = new PingReplyI();
             reply = PingReplyPrx.uncheckedCast(adapter.addWithUUID(replyI)).ice_datagram();
         }
@@ -81,8 +80,7 @@ public class AllTests {
 
         if (communicator.getProperties().getIcePropertyAsInt("Ice.Override.Compress") == 0) {
             //
-            // Only run this test if compression is disabled, the test expects fixed message size
-            // to be sent over the wire.
+            // Only run this test if compression is disabled, the test expects fixed message size to be sent over the wire.
             //
             byte[] seq = null;
             try {
@@ -104,8 +102,7 @@ public class AllTests {
                 replyI.reset();
                 obj.sendByteSeq(seq, reply);
                 //
-                // We don't expect a reply because the server's value for Ice.UDP.RcvSize is too
-                // small.
+                // We don't expect a reply because the server's value for Ice.UDP.RcvSize is too small.
                 //
                 test(!replyI.waitReply(1, 500));
             } catch (com.zeroc.Ice.LocalException ex) {
@@ -143,9 +140,7 @@ public class AllTests {
             TestIntfPrx objMcast = TestIntfPrx.uncheckedCast(base);
 
             //
-            // On Android, the test suite driver only starts one server instance. Otherwise, we
-            // expect
-            // there to be five servers and we expect a response from all of them.
+            // On Android, the test suite driver only starts one server instance. Otherwise, we expect there to be five servers and we expect a response from all of them.
             //
             final int numServers = helper.isAndroid() ? 1 : 5;
 
@@ -156,9 +151,7 @@ public class AllTests {
                     objMcast.ping(reply);
                 } catch (com.zeroc.Ice.SocketException ex) {
                     if (communicator.getProperties().getIceProperty("Ice.IPv6").equals("1")) {
-                        // Multicast IPv6 not supported on the platform. This occurs for example on
-                        // macOS Big
-                        // Sur
+                        // Multicast IPv6 not supported on the platform. This occurs for example on macOS Big Sur
                         out.print("(not supported) ");
                         ret = true;
                         break;

--- a/java/test/src/main/java/test/Ice/udp/AllTests.java
+++ b/java/test/src/main/java/test/Ice/udp/AllTests.java
@@ -72,7 +72,8 @@ public class AllTests {
                 break; // Success
             }
 
-            // If the 3 datagrams were not received within the 2 seconds, we try again to receive 3 new datagrams using a new object. We give up after 5 retries.
+            // If the 3 datagrams were not received within the 2 seconds, we try again to receive 3
+            // new datagrams using a new object. We give up after 5 retries.
             replyI = new PingReplyI();
             reply = PingReplyPrx.uncheckedCast(adapter.addWithUUID(replyI)).ice_datagram();
         }
@@ -80,7 +81,8 @@ public class AllTests {
 
         if (communicator.getProperties().getIcePropertyAsInt("Ice.Override.Compress") == 0) {
             //
-            // Only run this test if compression is disabled, the test expects fixed message size to be sent over the wire.
+            // Only run this test if compression is disabled, the test expects fixed message size to
+            // be sent over the wire.
             //
             byte[] seq = null;
             try {
@@ -102,7 +104,8 @@ public class AllTests {
                 replyI.reset();
                 obj.sendByteSeq(seq, reply);
                 //
-                // We don't expect a reply because the server's value for Ice.UDP.RcvSize is too small.
+                // We don't expect a reply because the server's value for Ice.UDP.RcvSize is too
+                // small.
                 //
                 test(!replyI.waitReply(1, 500));
             } catch (com.zeroc.Ice.LocalException ex) {
@@ -140,7 +143,8 @@ public class AllTests {
             TestIntfPrx objMcast = TestIntfPrx.uncheckedCast(base);
 
             //
-            // On Android, the test suite driver only starts one server instance. Otherwise, we expect there to be five servers and we expect a response from all of them.
+            // On Android, the test suite driver only starts one server instance. Otherwise, we
+            // expect there to be five servers and we expect a response from all of them.
             //
             final int numServers = helper.isAndroid() ? 1 : 5;
 
@@ -151,7 +155,8 @@ public class AllTests {
                     objMcast.ping(reply);
                 } catch (com.zeroc.Ice.SocketException ex) {
                     if (communicator.getProperties().getIceProperty("Ice.IPv6").equals("1")) {
-                        // Multicast IPv6 not supported on the platform. This occurs for example on macOS Big Sur
+                        // Multicast IPv6 not supported on the platform. This occurs for example on
+                        // macOS Big Sur
                         out.print("(not supported) ");
                         ret = true;
                         break;

--- a/java/test/src/main/java/test/Ice/udp/TestIntfI.java
+++ b/java/test/src/main/java/test/Ice/udp/TestIntfI.java
@@ -27,8 +27,7 @@ public final class TestIntfI implements TestIntf {
     public void pingBiDir(com.zeroc.Ice.Identity id, com.zeroc.Ice.Current current) {
         try {
             //
-            // Ensure sending too much data doesn't cause the UDP connection
-            // to be closed.
+            // Ensure sending too much data doesn't cause the UDP connection to be closed.
             //
             try {
                 byte[] seq = new byte[32 * 1024];

--- a/java/test/src/main/java/test/IceGrid/simple/AllTests.java
+++ b/java/test/src/main/java/test/IceGrid/simple/AllTests.java
@@ -71,8 +71,7 @@ public class AllTests {
                 test(false);
             }
 
-            // Ensure the IceGrid discovery locator can discover the
-            // registries and make sure locator requests are forwarded.
+            // Ensure the IceGrid discovery locator can discover the registries and make sure locator requests are forwarded.
             com.zeroc.Ice.InitializationData initData = new com.zeroc.Ice.InitializationData();
             initData.properties = communicator.getProperties()._clone();
             initData.properties.setProperty("Ice.Default.Locator", "");
@@ -106,8 +105,7 @@ public class AllTests {
             adapter.deactivate();
             comm.destroy();
 
-            // Now, ensure that the IceGrid discovery locator correctly handles failure to find a
-            // locator.
+            // Now, ensure that the IceGrid discovery locator correctly handles failure to find a locator.
             initData.properties.setProperty("IceLocatorDiscovery.InstanceName", "unknown");
             initData.properties.setProperty("IceLocatorDiscovery.RetryCount", "1");
             initData.properties.setProperty("IceLocatorDiscovery.Timeout", "100");

--- a/java/test/src/main/java/test/IceGrid/simple/AllTests.java
+++ b/java/test/src/main/java/test/IceGrid/simple/AllTests.java
@@ -71,7 +71,8 @@ public class AllTests {
                 test(false);
             }
 
-            // Ensure the IceGrid discovery locator can discover the registries and make sure locator requests are forwarded.
+            // Ensure the IceGrid discovery locator can discover the registries and make sure
+            // locator requests are forwarded.
             com.zeroc.Ice.InitializationData initData = new com.zeroc.Ice.InitializationData();
             initData.properties = communicator.getProperties()._clone();
             initData.properties.setProperty("Ice.Default.Locator", "");
@@ -105,7 +106,8 @@ public class AllTests {
             adapter.deactivate();
             comm.destroy();
 
-            // Now, ensure that the IceGrid discovery locator correctly handles failure to find a locator.
+            // Now, ensure that the IceGrid discovery locator correctly handles failure to find a
+            // locator.
             initData.properties.setProperty("IceLocatorDiscovery.InstanceName", "unknown");
             initData.properties.setProperty("IceLocatorDiscovery.RetryCount", "1");
             initData.properties.setProperty("IceLocatorDiscovery.Timeout", "100");

--- a/java/test/src/main/java/test/IceGrid/simple/Server.java
+++ b/java/test/src/main/java/test/IceGrid/simple/Server.java
@@ -6,8 +6,7 @@ public class Server extends test.TestHelper {
     public void run(String[] args) {
         com.zeroc.Ice.Properties properties = createTestProperties(args);
 
-        // It's possible to have batch oneway requests dispatched after the adapter is
-        // deactivated due to thread scheduling so we suppress this warning.
+        // It's possible to have batch oneway requests dispatched after the adapter is deactivated due to thread scheduling so we suppress this warning.
         properties.setProperty("Ice.Warn.Dispatch", "0");
         properties.setProperty("Ice.Package.Test", "test.IceGrid.simple");
         try (com.zeroc.Ice.Communicator communicator = initialize(args)) {

--- a/java/test/src/main/java/test/IceGrid/simple/Server.java
+++ b/java/test/src/main/java/test/IceGrid/simple/Server.java
@@ -6,7 +6,8 @@ public class Server extends test.TestHelper {
     public void run(String[] args) {
         com.zeroc.Ice.Properties properties = createTestProperties(args);
 
-        // It's possible to have batch oneway requests dispatched after the adapter is deactivated due to thread scheduling so we suppress this warning.
+        // It's possible to have batch oneway requests dispatched after the adapter is deactivated
+        // due to thread scheduling so we suppress this warning.
         properties.setProperty("Ice.Warn.Dispatch", "0");
         properties.setProperty("Ice.Package.Test", "test.IceGrid.simple");
         try (com.zeroc.Ice.Communicator communicator = initialize(args)) {

--- a/java/test/src/main/java/test/IceSSL/configuration/AllTests.java
+++ b/java/test/src/main/java/test/IceSSL/configuration/AllTests.java
@@ -168,7 +168,8 @@ public class AllTests {
 
             // Test Ice.SSL.VerifyPeer=1. Client has a certificate.
             //
-            // Provide "cacert1" to the client to verify the server certificate (without this the client connection wouldn't be able to provide the certificate chain).
+            // Provide "cacert1" to the client to verify the server certificate (without this the
+            // client connection wouldn't be able to provide the certificate chain).
             initData = createClientProps(defaultProperties, "c_rsa_ca1", "cacert1");
             comm = Util.initialize(args, initData);
             fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
@@ -264,7 +265,8 @@ public class AllTests {
             fact.destroyServer(server);
             comm.destroy();
 
-            // This should succeed because the self signed certificate used by the server is trusted.
+            // This should succeed because the self signed certificate used by the server is
+            // trusted.
             initData = createClientProps(defaultProperties, "", "cacert2");
             initData.properties.setProperty("IceSSL.VerifyPeer", "1");
             comm = Util.initialize(args, initData);
@@ -282,7 +284,8 @@ public class AllTests {
             fact.destroyServer(server);
             comm.destroy();
 
-            // This should fail because the self signed certificate used by the server is not trusted.
+            // This should fail because the self signed certificate used by the server is not
+            // trusted.
             initData = createClientProps(defaultProperties);
             initData.properties.setProperty("IceSSL.VerifyPeer", "1");
             comm = Util.initialize(args, initData);
@@ -367,7 +370,8 @@ public class AllTests {
                     comm.destroy();
                 }
 
-                // Target host matches the certificate Common Name and the certificate does not include a DNS altName
+                // Target host matches the certificate Common Name and the certificate does not
+                // include a DNS altName
                 {
                     initData = createClientProps(defaultProperties, "c_rsa_ca1", "cacert1");
                     initData.properties.setProperty("IceSSL.CheckCertName", "1");
@@ -387,7 +391,8 @@ public class AllTests {
                     comm.destroy();
                 }
 
-                // Target host does not match the certificate Common Name and the certificate does not include a DNS altName
+                // Target host does not match the certificate Common Name and the certificate does
+                // not include a DNS altName
                 {
                     initData = createClientProps(defaultProperties, "c_rsa_ca1", "cacert1");
                     initData.properties.setProperty("IceSSL.CheckCertName", "1");
@@ -407,7 +412,8 @@ public class AllTests {
                     comm.destroy();
                 }
 
-                // Target host matches the certificate Common Name and the certificate has a DNS altName that does not matches the target host
+                // Target host matches the certificate Common Name and the certificate has a DNS
+                // altName that does not matches the target host
                 {
                     initData = createClientProps(defaultProperties, "c_rsa_ca1", "cacert1");
                     initData.properties.setProperty("IceSSL.CheckCertName", "1");
@@ -469,7 +475,8 @@ public class AllTests {
                     comm.destroy();
                 }
 
-                // Target host is an IP address that matches the CN and the certificate doesn't include an IP altName
+                // Target host is an IP address that matches the CN and the certificate doesn't
+                // include an IP altName
                 {
                     initData = createClientProps(defaultProperties, "c_rsa_ca1", "cacert1");
                     initData.properties.setProperty("IceSSL.CheckCertName", "1");
@@ -489,7 +496,8 @@ public class AllTests {
                     comm.destroy();
                 }
 
-                // Target host does not match the certificate DNS altName, connection should succeed because Ice.SSL.CheckCertName is set to 0.
+                // Target host does not match the certificate DNS altName, connection should succeed
+                // because Ice.SSL.CheckCertName is set to 0.
                 {
                     initData = createClientProps(defaultProperties, "c_rsa_ca1", "cacert1");
                     initData.properties.setProperty("IceSSL.CheckCertName", "0");

--- a/java/test/src/main/java/test/IceSSL/configuration/AllTests.java
+++ b/java/test/src/main/java/test/IceSSL/configuration/AllTests.java
@@ -168,9 +168,7 @@ public class AllTests {
 
             // Test Ice.SSL.VerifyPeer=1. Client has a certificate.
             //
-            // Provide "cacert1" to the client to verify the server
-            // certificate (without this the client connection wouldn't be
-            // able to provide the certificate chain).
+            // Provide "cacert1" to the client to verify the server certificate (without this the client connection wouldn't be able to provide the certificate chain).
             initData = createClientProps(defaultProperties, "c_rsa_ca1", "cacert1");
             comm = Util.initialize(args, initData);
             fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
@@ -266,8 +264,7 @@ public class AllTests {
             fact.destroyServer(server);
             comm.destroy();
 
-            // This should succeed because the self signed certificate used by the server is
-            // trusted.
+            // This should succeed because the self signed certificate used by the server is trusted.
             initData = createClientProps(defaultProperties, "", "cacert2");
             initData.properties.setProperty("IceSSL.VerifyPeer", "1");
             comm = Util.initialize(args, initData);
@@ -285,8 +282,7 @@ public class AllTests {
             fact.destroyServer(server);
             comm.destroy();
 
-            // This should fail because the self signed certificate used by the server is not
-            // trusted.
+            // This should fail because the self signed certificate used by the server is not trusted.
             initData = createClientProps(defaultProperties);
             initData.properties.setProperty("IceSSL.VerifyPeer", "1");
             comm = Util.initialize(args, initData);
@@ -371,8 +367,7 @@ public class AllTests {
                     comm.destroy();
                 }
 
-                // Target host matches the certificate Common Name and the certificate does not
-                // include a DNS altName
+                // Target host matches the certificate Common Name and the certificate does not include a DNS altName
                 {
                     initData = createClientProps(defaultProperties, "c_rsa_ca1", "cacert1");
                     initData.properties.setProperty("IceSSL.CheckCertName", "1");
@@ -392,9 +387,7 @@ public class AllTests {
                     comm.destroy();
                 }
 
-                // Target host does not match the certificate Common Name and the certificate does
-                // not
-                // include a DNS altName
+                // Target host does not match the certificate Common Name and the certificate does not include a DNS altName
                 {
                     initData = createClientProps(defaultProperties, "c_rsa_ca1", "cacert1");
                     initData.properties.setProperty("IceSSL.CheckCertName", "1");
@@ -414,8 +407,7 @@ public class AllTests {
                     comm.destroy();
                 }
 
-                // Target host matches the certificate Common Name and the certificate has
-                // a DNS altName that does not matches the target host
+                // Target host matches the certificate Common Name and the certificate has a DNS altName that does not matches the target host
                 {
                     initData = createClientProps(defaultProperties, "c_rsa_ca1", "cacert1");
                     initData.properties.setProperty("IceSSL.CheckCertName", "1");
@@ -477,8 +469,7 @@ public class AllTests {
                     comm.destroy();
                 }
 
-                // Target host is an IP address that matches the CN and the certificate doesn't
-                // include an IP altName
+                // Target host is an IP address that matches the CN and the certificate doesn't include an IP altName
                 {
                     initData = createClientProps(defaultProperties, "c_rsa_ca1", "cacert1");
                     initData.properties.setProperty("IceSSL.CheckCertName", "1");
@@ -498,8 +489,7 @@ public class AllTests {
                     comm.destroy();
                 }
 
-                // Target host does not match the certificate DNS altName, connection should succeed
-                // because Ice.SSL.CheckCertName is set to 0.
+                // Target host does not match the certificate DNS altName, connection should succeed because Ice.SSL.CheckCertName is set to 0.
                 {
                     initData = createClientProps(defaultProperties, "c_rsa_ca1", "cacert1");
                     initData.properties.setProperty("IceSSL.CheckCertName", "0");

--- a/java/test/src/main/java/test/Slice/escape/Client.java
+++ b/java/test/src/main/java/test/Slice/escape/Client.java
@@ -64,8 +64,7 @@ public class Client extends test.TestHelper {
         }
     }
 
-    // This section of the test is present to ensure that the C++ types are named correctly.
-    // It is not expected to run.
+    // This section of the test is present to ensure that the C++ types are named correctly. It is not expected to run.
     @SuppressWarnings({"unused", "null"})
     private static void testtypes() {
         _assert v = _assert.escaped_boolean;

--- a/java/test/src/main/java/test/Slice/escape/Client.java
+++ b/java/test/src/main/java/test/Slice/escape/Client.java
@@ -64,7 +64,8 @@ public class Client extends test.TestHelper {
         }
     }
 
-    // This section of the test is present to ensure that the C++ types are named correctly. It is not expected to run.
+    // This section of the test is present to ensure that the C++ types are named correctly. It is
+    // not expected to run.
     @SuppressWarnings({"unused", "null"})
     private static void testtypes() {
         _assert v = _assert.escaped_boolean;


### PR DESCRIPTION
Squishes up all the comments and then expands them back out again using Spotless's formatting rules to do away with the strangely formatted comment blocks. Line breaks are now standardized to occur if a word would go over Spotless's character limit.

Fixes #2758.