### PR TITLE
Add Support for `matlab:identifier` Metadata

### DIFF
--- a/cpp/src/IceGrid/Internal.ice
+++ b/cpp/src/IceGrid/Internal.ice
@@ -154,7 +154,7 @@ module IceGrid
         ["amd"] void start()
             throws ServerStartException;
 
-        /// Stop the server. This methods returns only when the server is deactivated. If the server doesn't stop after a
+        /// Stop the server. This method returns only when the server is deactivated. If the server doesn't stop after a
         /// configurable amount of time, it will be killed.
         ["amd"] void stop()
             throws ServerStopException;

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -1032,7 +1032,7 @@ namespace
         knownMetadata.emplace("matlab:identifier", std::move(identifierInfo));
 
         // Pass this information off to the parser's metadata validation logic.
-        Slice::validateMetadata(unit, "matlab", knownMetadata);
+        Slice::validateMetadata(unit, "matlab", std::move(knownMetadata));
     }
 }
 

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -34,19 +34,6 @@ using namespace IceInternal;
 
 namespace
 {
-    string replace(const string& s, const string& patt, const string& val)
-    {
-        string r{s};
-        string::size_type pos = r.find(patt);
-        while (pos != string::npos)
-        {
-            r.replace(pos, patt.size(), val);
-            pos += val.size();
-            pos = r.find(patt, pos);
-        }
-        return r;
-    }
-
     void writeCopyright(IceInternal::Output& out, const string& file)
     {
         string f = file;

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -1023,6 +1023,31 @@ namespace
             out << nl << "% Deprecated";
         }
     }
+
+    void validateMetadata(const UnitPtr& unit)
+    {
+        map<string, MetadataInfo> knownMetadata;
+
+        // "matlab:identifier"
+        MetadataInfo identifierInfo = {
+            .validOn =
+                {typeid(InterfaceDecl),
+                typeid(Operation),
+                typeid(Struct),
+                typeid(Sequence),
+                typeid(Dictionary),
+                typeid(Enum),
+                typeid(Enumerator),
+                typeid(Const),
+                typeid(Parameter),
+                typeid(DataMember)},
+            .acceptedArgumentKind = MetadataArgumentKind::SingleArgument,
+        };
+        knownMetadata.emplace("matlab:identifier", std::move(identifierInfo));
+
+        // Pass this information off to the parser's metadata validation logic.
+        Slice::validateMetadata(unit, "matlab", knownMetadata);
+    }
 }
 
 //
@@ -3638,10 +3663,7 @@ compile(const vector<string>& argv)
 
                     try
                     {
-                        // 'slice2matlab' doesn't have any language-specific metadata, so we call `validateMetadata`
-                        // with an empty list.  This ensures that the validation still runs, and will reject any
-                        // 'matlab' metadata the user might think exists.
-                        Slice::validateMetadata(u, "matlab", {});
+                        validateMetadata(u);
 
                         CodeVisitor codeVisitor(output);
                         u->visit(&codeVisitor);

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -826,8 +826,7 @@ namespace
                     }
                     for (const auto& outParam : outParams)
                     {
-                        out << nl << "%   " << outParam->mappedName() << " (" << typeToString(outParam->type())
-                            << ")";
+                        out << nl << "%   " << outParam->mappedName() << " (" << typeToString(outParam->type()) << ")";
                         auto r = docParameters.find(outParam->name());
                         if (r != docParameters.end() && !r->second.empty())
                         {
@@ -1019,15 +1018,15 @@ namespace
         MetadataInfo identifierInfo = {
             .validOn =
                 {typeid(InterfaceDecl),
-                typeid(Operation),
-                typeid(Struct),
-                typeid(Sequence),
-                typeid(Dictionary),
-                typeid(Enum),
-                typeid(Enumerator),
-                typeid(Const),
-                typeid(Parameter),
-                typeid(DataMember)},
+                 typeid(Operation),
+                 typeid(Struct),
+                 typeid(Sequence),
+                 typeid(Dictionary),
+                 typeid(Enum),
+                 typeid(Enumerator),
+                 typeid(Const),
+                 typeid(Parameter),
+                 typeid(DataMember)},
             .acceptedArgumentKind = MetadataArgumentKind::SingleArgument,
         };
         knownMetadata.emplace("matlab:identifier", std::move(identifierInfo));
@@ -1274,13 +1273,7 @@ CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     }
     for (const auto& optionalMember : optionalMembers)
     {
-        marshal(
-            out,
-            "os",
-            "obj." + optionalMember->mappedName(),
-            optionalMember->type(),
-            true,
-            optionalMember->tag());
+        marshal(out, "os", "obj." + optionalMember->mappedName(), optionalMember->type(), true, optionalMember->tag());
     }
     out << nl << "os.endSlice();";
     if (base)
@@ -1894,7 +1887,8 @@ CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     }
     else
     {
-        out << nl << self << " = " << self << "@" << base->mappedScoped(".").substr(1) << spar << "errID" << "msg" << epar << ';';
+        out << nl << self << " = " << self << "@" << base->mappedScoped(".").substr(1) << spar << "errID" << "msg"
+            << epar << ';';
     }
     out.dec();
     out << nl << "end";

--- a/matlab/test/Slice/escape/AllTests.m
+++ b/matlab/test/Slice/escape/AllTests.m
@@ -7,37 +7,37 @@ classdef AllTests
 
             fprintf('testing enum... ');
 
-            members = enumeration('classdef_.break_.bitand');
-            for i = 0:int32(classdef_.break_.bitand.LAST) - 1
+            members = enumeration('escaped_classdef.bitand');
+            for i = 0:int32(escaped_classdef.bitand.LAST) - 1
                 % Every enumerator should be escaped and therefore have a trailing underscore.
                 name = char(members(i + 1));
                 assert(strcmp(name(length(name)), '_'));
                 % Ensure ice_getValue is generated correctly.
-                assert(members(i + 1) == classdef_.break_.bitand.ice_getValue(i));
+                assert(members(i + 1) == escaped_classdef.bitand.ice_getValue(i));
             end
 
             fprintf('ok\n');
 
             fprintf('testing struct... ');
 
-            s = classdef_.break_.bitor();
-            assert(s.case_ == classdef_.break_.bitand.catch_);
+            s = escaped_classdef.bitor();
+            assert(s.case_ == escaped_classdef.bitand.catch_);
             assert(s.continue_ == 1);
             assert(s.eq_ == 2);
             % Exercise the marshaling code.
             os = Ice.OutputStream(communicator.getEncoding());
-            classdef_.break_.bitor.ice_write(os, s);
+            escaped_classdef.bitor.ice_write(os, s);
             is = Ice.InputStream(communicator, os.getEncoding(), os.finished());
-            s2 = classdef_.break_.bitor.ice_read(is);
+            s2 = escaped_classdef.bitor.ice_read(is);
             assert(isequal(s, s2));
 
             fprintf('ok\n');
 
             fprintf('testing class... ');
 
-            c = classdef_.break_.logical();
-            assert(c.else_ == classdef_.break_.bitand.enumeration_);
-            assert(c.for_.case_ == classdef_.break_.bitand.catch_);
+            c = escaped_classdef.logical();
+            assert(c.else_ == escaped_classdef.bitand.break_);
+            assert(c.for_.case_ == escaped_classdef.bitand.catch_);
             assert(c.for_.continue_ == 1);
             assert(c.for_.eq_ == 2);
             assert(c.int64 == true);
@@ -47,7 +47,7 @@ classdef AllTests
             os.writePendingValues();
             is = Ice.InputStream(communicator, os.getEncoding(), os.finished());
             v = IceInternal.ValueHolder();
-            is.readValue(@v.set, 'classdef_.break_.logical');
+            is.readValue(@v.set, 'escaped_classdef.logical');
             is.readPendingValues();
             assert(v.value.else_ == c.else_);
             assert(v.value.for_.case_ == c.for_.case_);
@@ -55,9 +55,9 @@ classdef AllTests
             assert(v.value.for_.eq_ == c.for_.eq_);
             assert(v.value.int64 == c.int64);
 
-            d = classdef_.break_.xor();
-            assert(d.else_ == classdef_.break_.bitand.enumeration_);
-            assert(d.for_.case_ == classdef_.break_.bitand.catch_);
+            d = escaped_classdef.xor_();
+            assert(d.else_ == escaped_classdef.bitand.break_);
+            assert(d.for_.case_ == escaped_classdef.bitand.catch_);
             assert(d.for_.continue_ == 1);
             assert(d.for_.eq_ == 2);
             assert(d.int64 == true);
@@ -68,7 +68,7 @@ classdef AllTests
             os.writePendingValues();
             is = Ice.InputStream(communicator, os.getEncoding(), os.finished());
             v = IceInternal.ValueHolder();
-            is.readValue(@v.set, 'classdef_.break_.xor');
+            is.readValue(@v.set, 'escaped_classdef.xor_');
             is.readPendingValues();
             assert(v.value.else_ == d.else_);
             assert(v.value.for_.case_ == d.for_.case_);
@@ -77,43 +77,34 @@ classdef AllTests
             assert(v.value.int64 == d.int64);
             assert(v.value.return_ == d.return_);
 
-            p = classdef_.break_.properties_();
+            p = escaped_classdef.properties_();
             assert(p.while_ == 1);
-            assert(p.delete == 2);
             assert(p.if_ == 2);
             assert(isempty(p.spmd_));
             assert(isempty(p.otherwise_));
-            p.catch_ = d;
             % Exercise the marshaling code.
             os = Ice.OutputStream(communicator.getEncoding());
             os.writeValue(p);
             os.writePendingValues();
             is = Ice.InputStream(communicator, os.getEncoding(), os.finished());
             v = IceInternal.ValueHolder();
-            is.readValue(@v.set, 'classdef_.break_.properties_');
+            is.readValue(@v.set, 'escaped_classdef.properties_');
             is.readPendingValues();
             assert(v.value.while_ == p.while_);
-            assert(v.value.delete == p.delete);
             assert(v.value.if_ == p.if_);
 
             fprintf('ok\n');
 
             fprintf('testing exception... ');
 
-            e = classdef_.break_.persistent_();
+            e = escaped_classdef.persistent_();
             assert(isempty(e.identifier_));
             assert(isempty(e.message_));
-            assert(isempty(e.stack_));
-            assert(isempty(e.cause_));
-            assert(isempty(e.type_));
             assert(isempty(e.end_));
 
-            g = classdef_.break_.global_();
+            g = escaped_classdef.global_();
             assert(isempty(g.identifier_));
             assert(isempty(g.message_));
-            assert(isempty(g.stack_));
-            assert(isempty(g.cause_));
-            assert(isempty(g.type_));
             assert(isempty(g.end_));
             assert(isempty(g.enumeration_));
 
@@ -121,22 +112,18 @@ classdef AllTests
 
             fprintf('testing interface... ');
 
-            assert(exist('classdef_.break_.elseifPrx', 'class') ~= 0);
-            m = methods('classdef_.break_.elseifPrx');
-            assert(ismember('events_', m));
-            assert(ismember('eventsAsync', m));
-            assert(ismember('function_', m));
-            assert(ismember('functionAsync', m));
-            assert(ismember('delete_', m));
-            assert(ismember('deleteAsync', m));
-            assert(ismember('checkedCast_', m));
-            assert(ismember('checkedCastAsync', m));
+            assert(exist('escaped_classdef.MyInterfacePrx', 'class') ~= 0);
+            m = methods('escaped_classdef.MyInterfacePrx');
+            assert(ismember('foobar', m));
+            assert(ismember('foobarAsync', m));
+            assert(ismember('func', m));
+            assert(ismember('funcAsync', m));
 
             fprintf('ok\n');
 
             fprintf('testing constant... ');
 
-            assert(classdef_.break_.methods_.value == 1);
+            assert(escaped_classdef.methods_.value == 1);
 
             fprintf('ok\n');
         end

--- a/matlab/test/Slice/escape/AllTests.m
+++ b/matlab/test/Slice/escape/AllTests.m
@@ -7,28 +7,28 @@ classdef AllTests
 
             fprintf('testing enum... ');
 
-            members = enumeration('escaped_classdef.bitand');
-            for i = 0:int32(escaped_classdef.bitand.LAST) - 1
+            members = enumeration('escaped_classdef.persistent_');
+            for i = 0:int32(escaped_classdef.persistent_.LAST) - 1
                 % Every enumerator should be escaped and therefore have a trailing underscore.
                 name = char(members(i + 1));
                 assert(strcmp(name(length(name)), '_'));
                 % Ensure ice_getValue is generated correctly.
-                assert(members(i + 1) == escaped_classdef.bitand.ice_getValue(i));
+                assert(members(i + 1) == escaped_classdef.persistent_.ice_getValue(i));
             end
 
             fprintf('ok\n');
 
             fprintf('testing struct... ');
 
-            s = escaped_classdef.bitor();
-            assert(s.case_ == escaped_classdef.bitand.catch_);
+            s = escaped_classdef.global_();
+            assert(s.case_ == escaped_classdef.persistent_.catch_);
             assert(s.continue_ == 1);
             assert(s.eq_ == 2);
             % Exercise the marshaling code.
             os = Ice.OutputStream(communicator.getEncoding());
-            escaped_classdef.bitor.ice_write(os, s);
+            escaped_classdef.global_.ice_write(os, s);
             is = Ice.InputStream(communicator, os.getEncoding(), os.finished());
-            s2 = escaped_classdef.bitor.ice_read(is);
+            s2 = escaped_classdef.global_.ice_read(is);
             assert(isequal(s, s2));
 
             fprintf('ok\n');
@@ -36,8 +36,8 @@ classdef AllTests
             fprintf('testing class... ');
 
             c = escaped_classdef.logical();
-            assert(c.else_ == escaped_classdef.bitand.break_);
-            assert(c.for_.case_ == escaped_classdef.bitand.catch_);
+            assert(c.else_ == escaped_classdef.persistent_.break_);
+            assert(c.for_.case_ == escaped_classdef.persistent_.catch_);
             assert(c.for_.continue_ == 1);
             assert(c.for_.eq_ == 2);
             assert(c.int64 == true);
@@ -55,9 +55,9 @@ classdef AllTests
             assert(v.value.for_.eq_ == c.for_.eq_);
             assert(v.value.int64 == c.int64);
 
-            d = escaped_classdef.xor_();
-            assert(d.else_ == escaped_classdef.bitand.break_);
-            assert(d.for_.case_ == escaped_classdef.bitand.catch_);
+            d = escaped_classdef.xor();
+            assert(d.else_ == escaped_classdef.persistent_.break_);
+            assert(d.for_.case_ == escaped_classdef.persistent_.catch_);
             assert(d.for_.continue_ == 1);
             assert(d.for_.eq_ == 2);
             assert(d.int64 == true);
@@ -68,7 +68,7 @@ classdef AllTests
             os.writePendingValues();
             is = Ice.InputStream(communicator, os.getEncoding(), os.finished());
             v = IceInternal.ValueHolder();
-            is.readValue(@v.set, 'escaped_classdef.xor_');
+            is.readValue(@v.set, 'escaped_classdef.xor');
             is.readPendingValues();
             assert(v.value.else_ == d.else_);
             assert(v.value.for_.case_ == d.for_.case_);
@@ -77,7 +77,7 @@ classdef AllTests
             assert(v.value.int64 == d.int64);
             assert(v.value.return_ == d.return_);
 
-            p = escaped_classdef.properties_();
+            p = escaped_classdef.Derived();
             assert(p.while_ == 1);
             assert(p.if_ == 2);
             assert(isempty(p.spmd_));
@@ -88,7 +88,7 @@ classdef AllTests
             os.writePendingValues();
             is = Ice.InputStream(communicator, os.getEncoding(), os.finished());
             v = IceInternal.ValueHolder();
-            is.readValue(@v.set, 'escaped_classdef.properties_');
+            is.readValue(@v.set, 'escaped_classdef.Derived');
             is.readPendingValues();
             assert(v.value.while_ == p.while_);
             assert(v.value.if_ == p.if_);
@@ -97,12 +97,12 @@ classdef AllTests
 
             fprintf('testing exception... ');
 
-            e = escaped_classdef.persistent_();
+            e = escaped_classdef.bitand();
             assert(isempty(e.identifier_));
             assert(isempty(e.message_));
             assert(isempty(e.end_));
 
-            g = escaped_classdef.global_();
+            g = escaped_classdef.bitor();
             assert(isempty(g.identifier_));
             assert(isempty(g.message_));
             assert(isempty(g.end_));

--- a/matlab/test/Slice/escape/Test.ice
+++ b/matlab/test/Slice/escape/Test.ice
@@ -2,86 +2,77 @@
 
 #pragma once
 
-module classdef::break // Should be escaped
+// TODO come up with a better way to escape modules.
+module escaped_classdef
 {
-    enum bitand // Should not be escaped
+    enum bitand
     {
-        //
-        // All of the keywords.
-        //
-        break, case, catch, classdef, continue, else, elseif, end, enumeration, events, for, function, global,
-        if, methods, otherwise, parfor, persistent, properties, return, spmd, switch, try, while,
-        //
-        // Plus a few method names reserved for enumerators because the enumeration class derives from uint8
-        // or int32.
-        //
-        abs, and, char, eq, length, size, xor,
+        ["matlab:identifier:break_"] break,
+        ["matlab:identifier:catch_"] catch,
         LAST
     }
 
-    struct bitor // Should not be escaped
+    struct bitor
     {
-        bitand case = catch;
-        int continue = 1;
-        int eq = 2;
-        int ne = 3;
+        ["matlab:identifier:case_"] bitand case = catch;
+        ["matlab:identifier:continue_"] int continue = 1;
+        ["matlab:identifier:eq_"] int eq = 2;
     }
 
-    class logical // Should not be escaped
+    class logical
     {
-        bitand else = enumeration;
-        bitor for;
-        bool int64 = true; // Should not be escaped
+        ["matlab:identifier:else_"] bitand else = break;
+        ["matlab:identifier:for_"] bitor for;
+        bool int64 = true;
     }
 
-    class xor extends logical // Should not be escaped
+    ["matlab:identifier:xor_"]
+    class xor extends logical
     {
-        int return = 1;
+        ["matlab:identifier:return_"] int return = 1;
     }
 
-    sequence<bitor> parfor;
-    dictionary<int, bitor> switch;
+    ["matlab:identifier:parfor_"] sequence<bitor> parfor;
+    ["matlab:identifier:switch_"] dictionary<int, bitor> switch;
 
-    class try // Should be escaped
+    ["matlab:identifier:try_"]
+    class try
     {
-        int while = 1;
-        int delete = 2; // Should not be escaped
+        ["matlab:identifier:while_"] int while = 1;
     }
 
-    class properties extends try // Should be escaped
+    ["matlab:identifier:properties_"]
+    class properties extends try
     {
-        int if = 2;
-        xor catch;
-        parfor spmd;
-        switch otherwise;
+        ["matlab:identifier:if_"] int if = 2;
+        ["matlab:identifier:spmd_"] parfor spmd;
+        ["matlab:identifier:otherwise_"] switch otherwise;
     }
 
-    exception persistent // Should be escaped
+    ["matlab:identifier:persistent_"]
+    exception persistent
     {
-        //
-        // These symbols clash with members of MException and should be escaped.
-        //
-        string identifier = "1";
-        string message = "2";
-        string stack = "3";
-        string cause = "4";
-        string type = "5";
+        // These data members clash with members of MException.
+        ["matlab:identifier:identifier_"] string identifier = "1";
+        ["matlab:identifier:message_"] string message = "2";
 
-        logical end;
+        ["matlab:identifier:end_"] logical end;
     }
 
-    exception global extends persistent // Should be escaped
+    ["matlab:identifier:global_"]
+    exception global extends persistent
     {
+        ["matlab:identifier:enumeration_"]
         int enumeration = 1;
     }
 
-    interface elseif // elseifPrx should not be escaped
+    ["matlab:identifier:MyInterface"]
+    interface operations
     {
-        void events();
-        void function();
-        void delete();
-        void checkedCast();
+        ["matlab:identifier:foobar"] void events();
+        ["matlab:identifier:func"] void function();
     }
 
+    ["matlab:identifier:methods_"]
     const int methods = 1;
 }

--- a/matlab/test/Slice/escape/Test.ice
+++ b/matlab/test/Slice/escape/Test.ice
@@ -5,52 +5,50 @@
 // TODO come up with a better way to escape modules.
 module escaped_classdef
 {
-    enum bitand
+    ["matlab:identifier:persistent_"]
+    enum persistent
     {
         ["matlab:identifier:break_"] break,
         ["matlab:identifier:catch_"] catch,
         LAST
     }
 
-    struct bitor
+    ["matlab:identifier:global_"]
+    struct global
     {
-        ["matlab:identifier:case_"] bitand case = catch;
+        ["matlab:identifier:case_"] persistent case = catch;
         ["matlab:identifier:continue_"] int continue = 1;
         ["matlab:identifier:eq_"] int eq = 2;
     }
 
     class logical
     {
-        ["matlab:identifier:else_"] bitand else = break;
-        ["matlab:identifier:for_"] bitor for;
+        ["matlab:identifier:else_"] persistent else = break;
+        ["matlab:identifier:for_"] global for;
         bool int64 = true;
     }
 
-    ["matlab:identifier:xor_"]
     class xor extends logical
     {
         ["matlab:identifier:return_"] int return = 1;
     }
 
-    ["matlab:identifier:parfor_"] sequence<bitor> parfor;
-    ["matlab:identifier:switch_"] dictionary<int, bitor> switch;
+    ["matlab:identifier:parfor_"] sequence<global> parfor;
+    ["matlab:identifier:switch_"] dictionary<int, global> switch;
 
-    ["matlab:identifier:try_"]
-    class try
+    class Base
     {
         ["matlab:identifier:while_"] int while = 1;
     }
 
-    ["matlab:identifier:properties_"]
-    class properties extends try
+    class Derived extends Base
     {
         ["matlab:identifier:if_"] int if = 2;
         ["matlab:identifier:spmd_"] parfor spmd;
         ["matlab:identifier:otherwise_"] switch otherwise;
     }
 
-    ["matlab:identifier:persistent_"]
-    exception persistent
+    exception bitand
     {
         // These data members clash with members of MException.
         ["matlab:identifier:identifier_"] string identifier = "1";
@@ -59,8 +57,7 @@ module escaped_classdef
         ["matlab:identifier:end_"] logical end;
     }
 
-    ["matlab:identifier:global_"]
-    exception global extends persistent
+    exception bitor extends bitand
     {
         ["matlab:identifier:enumeration_"]
         int enumeration = 1;

--- a/slice/IceGrid/Descriptor.ice
+++ b/slice/IceGrid/Descriptor.ice
@@ -42,6 +42,7 @@ module IceGrid
         Ice::StringSeq references;
 
         /// The property set properties.
+        ["matlab:identifier:propertyDescriptors"]
         PropertyDescriptorSeq properties;
     }
 


### PR DESCRIPTION
This PR adds the very first MATLAB metadata: `matlab:identifier`. You already know what this does...

The only difference is we don't allow it on classes or exceptions, because the `ClassResolver` needs to be able to map from a type-ID to a MATLAB type... Note that we have the same issue and limitation with `java:identifier`.