### PR TITLE
Add Communicator.waitForShutdownAsync to Python mapping

### DIFF
--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -494,6 +494,38 @@ communicatorWaitForShutdown(CommunicatorObject* self, PyObject* args)
 }
 
 extern "C" PyObject*
+communicatorWaitForShutdownAsync(CommunicatorObject* self, PyObject* /*args*/)
+{
+    assert(self->communicator);
+
+    PyObject* futureType = lookupType("Ice.Future");
+    assert(futureType);
+
+    PyObjectHandle emptyArgs{PyTuple_New(0)};
+    PyTypeObject* type = reinterpret_cast<PyTypeObject*>(futureType);
+    PyObjectHandle future{type->tp_new(type, emptyArgs.get(), nullptr)};
+    if (!future.get())
+    {
+        return nullptr;
+    }
+
+    // Call Ice.Future.__init__
+    type->tp_init(future.get(), emptyArgs.get(), nullptr);
+
+    (*self->communicator)
+        ->waitForShutdownAsync(
+            [futureHandle = PyObjectHandle(future)]()
+            {
+                AdoptThread adoptThread; // Ensure the current thread is able to call into Python.
+                PyObjectHandle discard{callMethod(futureHandle.get(), "set_result", Py_None)};
+            });
+
+    // Release the reference to the future object and let the caller take ownership. The
+    // callback keeps its own strong reference to the future.
+    return future.release();
+}
+
+extern "C" PyObject*
 communicatorIsShutdown(CommunicatorObject* self, PyObject* /*args*/)
 {
     assert(self->communicator);
@@ -1413,6 +1445,10 @@ static PyMethodDef CommunicatorMethods[] = {
      reinterpret_cast<PyCFunction>(communicatorWaitForShutdown),
      METH_VARARGS,
      PyDoc_STR("waitForShutdown() -> None")},
+    {"waitForShutdownAsync",
+     reinterpret_cast<PyCFunction>(communicatorWaitForShutdownAsync),
+     METH_VARARGS,
+     PyDoc_STR("waitForShutdownAsync() -> Ice.Future")},
     {"isShutdown",
      reinterpret_cast<PyCFunction>(communicatorIsShutdown),
      METH_NOARGS,

--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -494,7 +494,7 @@ communicatorWaitForShutdown(CommunicatorObject* self, PyObject* args)
 }
 
 extern "C" PyObject*
-communicatorWaitForShutdownAsync(CommunicatorObject* self, PyObject* /*args*/)
+communicatorShutdownCompleted(CommunicatorObject* self, PyObject* /*args*/)
 {
     assert(self->communicator);
 
@@ -1445,10 +1445,10 @@ static PyMethodDef CommunicatorMethods[] = {
      reinterpret_cast<PyCFunction>(communicatorWaitForShutdown),
      METH_VARARGS,
      PyDoc_STR("waitForShutdown() -> None")},
-    {"waitForShutdownAsync",
-     reinterpret_cast<PyCFunction>(communicatorWaitForShutdownAsync),
+    {"shutdownCompleted",
+     reinterpret_cast<PyCFunction>(communicatorShutdownCompleted),
      METH_VARARGS,
-     PyDoc_STR("waitForShutdownAsync() -> Ice.Future")},
+     PyDoc_STR("shutdownCompleted() -> Ice.Future")},
     {"isShutdown",
      reinterpret_cast<PyCFunction>(communicatorIsShutdown),
      METH_NOARGS,

--- a/python/python/Ice/Communicator.py
+++ b/python/python/Ice/Communicator.py
@@ -77,11 +77,18 @@ class Communicator:
         while not self._impl.waitForShutdown(500):
             pass
 
-    def waitForShutdownAsync(self):
+    def shutdownCompleted(self):
         """
-        returns a future that will be set when the communicator has been shut down.
+        Return a Future that is marked as done when the communicator's shutdown completes.
+
+        The returned Future always completes successfully.
+
+        Returns
+        -------
+        Ice.Future
+            A Future that is marked as done upon shutdown completion.
         """
-        return self._impl.waitForShutdownAsync()
+        return self._impl.shutdownCompleted()
 
     def isShutdown(self):
         """

--- a/python/python/Ice/Communicator.py
+++ b/python/python/Ice/Communicator.py
@@ -77,6 +77,12 @@ class Communicator:
         while not self._impl.waitForShutdown(500):
             pass
 
+    def waitForShutdownAsync(self):
+        """
+        returns a future that will be set when the communicator has been shut down.
+        """
+        return self._impl.waitForShutdownAsync()
+
     def isShutdown(self):
         """
         Check whether the communicator has been shut down.

--- a/python/test/Ice/asyncio/AllTests.py
+++ b/python/test/Ice/asyncio/AllTests.py
@@ -80,12 +80,12 @@ async def allTestsAsync(helper, communicator):
 
     await Ice.wrap_future(p.shutdownAsync())
 
-    sys.stdout.write("testing communicator waitForShutdownAsync... ")
+    sys.stdout.write("testing communicator shutdownCompleted... ")
     sys.stdout.flush()
 
     testCommunicator = Ice.initialize()
-    waitForShutdownFuture = Ice.wrap_future(testCommunicator.waitForShutdownAsync())
-    test(not waitForShutdownFuture.done())
+    shutdownCompletedFuture = Ice.wrap_future(testCommunicator.shutdownCompleted())
+    test(not shutdownCompletedFuture.done())
     test(not testCommunicator.isShutdown())
 
     # Call destroy() from a separate thread to avoid blocking the event loop
@@ -95,9 +95,9 @@ async def allTestsAsync(helper, communicator):
     destroy_thread = threading.Thread(target=destroy_communicator)
     destroy_thread.start()
 
-    await waitForShutdownFuture
+    await shutdownCompletedFuture
 
-    test(waitForShutdownFuture.done())
+    test(shutdownCompletedFuture.done())
     test(testCommunicator.isShutdown())
 
     destroy_thread.join()

--- a/python/test/Ice/asyncio/AllTests.py
+++ b/python/test/Ice/asyncio/AllTests.py
@@ -100,4 +100,6 @@ async def allTestsAsync(helper, communicator):
     test(waitForShutdownFuture.done())
     test(testCommunicator.isShutdown())
 
+    destroy_thread.join()
+
     print("ok")


### PR DESCRIPTION
This PR adds the waitForShutdownAsync to the Python mapping.