### PR TITLE
Fix Broken Links in C++ and XML Stripping Order

### DIFF
--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -271,8 +271,8 @@ namespace
             }
             if (auto enumTarget = dynamic_pointer_cast<Enum>(target))
             {
-                // If a link to an enum isn't qualified (ie. we're the source and target are in the same module),
-                // we have to place a '#' character in front, to explicitly tell Doxygen it's in the current scope.
+                // If a link to an enum isn't qualified (ie. the source and target are in the same module),
+                // we have to place a '#' character in front, so Doxygen looks in the current scope.
                 string link = getUnqualified(enumTarget->mappedScoped(), source->mappedScope());
                 if (link.find("::") == string::npos)
                 {

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -256,17 +256,34 @@ namespace
     /// Returns a doxygen formatted link to the provided Slice identifier.
     string cppLinkFormatter(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target)
     {
-        string result = "{@link ";
         if (target)
         {
-            if (auto dataMemberTarget = dynamic_pointer_cast<DataMember>(target))
+            if (dynamic_pointer_cast<DataMember>(target) || dynamic_pointer_cast<Enumerator>(target))
             {
-                // Links to fields must always be qualified in the form 'container#field'.
-                ContainedPtr parent = dynamic_pointer_cast<Contained>(dataMemberTarget->container());
+                ContainedPtr memberTarget = dynamic_pointer_cast<Contained>(target);
+
+                // Links to fields/enumerators must always be qualified in the form 'container#member'.
+                ContainedPtr parent = dynamic_pointer_cast<Contained>(memberTarget->container());
                 assert(parent);
 
                 string parentName = getUnqualified(parent->mappedScoped(), source->mappedScope());
-                return parentName + "#" + dataMemberTarget->mappedName();
+                return parentName + "#" + memberTarget->mappedName();
+            }
+            if (auto enumTarget = dynamic_pointer_cast<Enum>(target))
+            {
+                // If a link to an enum isn't qualified (ie. we're the source and target are in the same module),
+                // we have to place a '#' character in front, to explicitly tell Doxygen it's in the current scope.
+                string link = getUnqualified(enumTarget->mappedScoped(), source->mappedScope());
+                if (link.find("::") == string::npos)
+                {
+                    link.insert(0, "#");
+                }
+                return link;
+            }
+            if (auto interfaceTarget = dynamic_pointer_cast<InterfaceDecl>(target))
+            {
+                // Links to Slice interfaces should always point to the generated proxy type, not the servant type.
+                return getUnqualified(interfaceTarget->mappedScoped() + "Prx", source->mappedScope());
             }
             if (auto operationTarget = dynamic_pointer_cast<Operation>(target))
             {
@@ -277,7 +294,7 @@ namespace
                 InterfaceDefPtr parent = operationTarget->interface();
                 bool amd = (parent->hasMetadata("amd") || operationTarget->hasMetadata("amd"));
 
-                string parentName = getUnqualified(parent->mappedScoped(), source->mappedScope());
+                string parentName = getUnqualified(parent->mappedScoped() + "Prx", source->mappedScope());
                 string opName = operationTarget->mappedName() + (amd ? "Async" : "");
                 return parentName + "::" + opName;
             }
@@ -292,9 +309,8 @@ namespace
         }
         else
         {
-            result += rawLink;
+            return "{@link " + rawLink + "}";
         }
-        return result + "}";
     }
 
     void writeDocLines(Output& out, const StringList& lines, bool commentFirst, const string& space = " ")


### PR DESCRIPTION
The code for parsing doc-comments has a bool to XML tags out of the comment's text.
The issue is we were doing this _after_ we fixed all the `@link`s, which in C# are mapped to XML tags.

Now the order has been swapped. We do any stripping at the very beginning of parsing, then afterwards massage the `@link`s.

----

It also fixes a few bugs in how C++ generated links. I reviewed the generated Doxygen, and 
1) Enums and Enumerators were just broken. They require special handling with Doxygen.
![image](https://github.com/user-attachments/assets/a1264456-3d05-496a-ae60-ec08d1e90c2c)
Before these types were black, indicating they weren't proper links.

2) When `@link`ing to an interface/operation type, we should always point to the proxy version, not the generated servant types.
![image](https://github.com/user-attachments/assets/d49d5ecb-b6fe-4df4-b86c-c940a9f91d22)
Before we linked to the non-Prx type.


----

All of these issues were caught by @bernardnormier while improving the C# link generation.
