### PR TITLE
Document Ice for Python future types

### DIFF
--- a/python/python/Ice/Future.py
+++ b/python/python/Ice/Future.py
@@ -18,7 +18,36 @@ class FutureBase(object):
 
 
 def wrap_future(future, *, loop=None):
-    """Wrap Ice.Future object into an asyncio.Future."""
+    """
+    Wrap an Ice.Future object into an asyncio.Future.
+
+    This function converts an Ice.Future into an asyncio.Future to allow integration of Ice's
+    asynchronous operations with Python's asyncio framework. If the provided future is already
+    an asyncio.Future, it is returned unchanged.
+
+    If the Ice.Future is already completed, the asyncio.Future is immediately resolved. Otherwise,
+    completion callbacks are registered to ensure that the asyncio.Future reflects the state of the
+    Ice.Future, including result propagation, exception handling, and cancellation.
+
+    Parameters
+    ----------
+    future : FutureBase or asyncio.Future
+        The Ice.Future object to wrap. If an asyncio.Future is passed, it is returned as-is.
+
+    loop : asyncio.AbstractEventLoop, optional
+        The event loop to associate with the asyncio.Future. If not provided, the current event loop
+        is used.
+
+    Returns
+    -------
+    asyncio.Future
+        A future that mirrors the state of the input Ice.Future.
+
+    Raises
+    ------
+    AssertionError
+        If `future` is not an instance of Ice.Future (or FutureBase).
+    """
     if isinstance(future, asyncio.Future):
         return future
 
@@ -57,6 +86,10 @@ def wrap_future(future, *, loop=None):
 
 
 class Future(FutureBase):
+    """
+    A Future object representing the result of an asynchronous operation.
+    """
+
     def __init__(self):
         self._result = None
         self._exception = None
@@ -65,6 +98,17 @@ class Future(FutureBase):
         self._state = Future.StateRunning
 
     def cancel(self):
+        """
+        Attempt to cancel the operation.
+
+        If the operation is already running or has completed, it cannot be cancelled, and the method returns False.
+        Otherwise, the operation is cancelled, and the method returns True.
+
+        Returns
+        -------
+        bool
+            True if the operation was cancelled, False otherwise.
+        """
         callbacks = []
         with self._condition:
             if self._state == Future.StateDone:
@@ -83,18 +127,57 @@ class Future(FutureBase):
         return True
 
     def cancelled(self):
+        """
+        Check if the future has been cancelled.
+
+        Returns
+        -------
+        bool
+            True if the future was cancelled using `cancel()`, otherwise False.
+        """
         with self._condition:
             return self._state == Future.StateCancelled
 
     def running(self):
+        """
+        Check if the future is still running.
+
+        Returns
+        -------
+        bool
+            True if the operation is currently executing and cannot be cancelled,
+            otherwise False.
+        """
         with self._condition:
             return self._state == Future.StateRunning
 
     def done(self):
+        """
+        Check if the future has completed or been cancelled.
+
+        Returns
+        -------
+        bool
+            True if the operation has completed (successfully or with an exception)
+            or has been cancelled, otherwise False.
+        """
         with self._condition:
             return self._state in [Future.StateCancelled, Future.StateDone]
 
     def add_done_callback(self, fn):
+        """
+        Attach a callback to be executed when the future completes.
+
+        The callback `fn` is called with the future as its only argument once the future completes or is cancelled.
+        Registered callbacks are executed in the order they were added.
+
+        If the future is already complete, `fn` is called immediately from the calling thread.
+
+        Parameters
+        ----------
+        fn : callable
+            The function to execute upon completion.
+        """
         with self._condition:
             if self._state == Future.StateRunning:
                 self._doneCallbacks.append(fn)
@@ -102,6 +185,36 @@ class Future(FutureBase):
         fn(self)
 
     def result(self, timeout=None):
+        """
+        Retrieve the result of the future.
+
+        If the operation has not completed, this method waits up to `timeout` seconds for it to finish. If the
+        timeout is reached, a `TimeoutException` is raised.
+
+        If the future was cancelled before completing, an `InvocationCanceledException` is raised.
+
+        If the operation raised an exception, this method raises the same exception.
+
+        Parameters
+        ----------
+        timeout : int or float, optional
+            Maximum time (in seconds) to wait for the result. If `None`, the method waits indefinitely until the
+            operation completes.
+
+        Returns
+        -------
+        object
+            The result of the operation.
+
+        Raises
+        ------
+        TimeoutException
+            If the operation has not completed within the specified timeout.
+        InvocationCanceledException
+            If the operation was cancelled before completing.
+        Exception
+            If the operation raised an exception.
+        """
         with self._condition:
             if not self._wait(timeout, lambda: self._state == Future.StateRunning):
                 raise TimeoutException()
@@ -114,6 +227,34 @@ class Future(FutureBase):
                 return self._result
 
     def exception(self, timeout=None):
+        """
+        Retrieve the exception raised by the operation.
+
+        If the operation has not completed, this method waits up to `timeout` seconds for it to finish. If the timeout
+        is reached, a `TimeoutException` is raised.
+
+        If the future was cancelled before completing, an `InvocationCanceledException` is raised.
+
+        If the operation completed successfully without raising an exception, `None` is returned.
+
+        Parameters
+        ----------
+        timeout : int or float, optional
+            Maximum time (in seconds) to wait for the exception. If `None`, the method waits indefinitely until the
+            operation completes.
+
+        Returns
+        -------
+        Exception or None
+            The exception raised by the operation, or `None` if the operation completed successfully.
+
+        Raises
+        ------
+        TimeoutException
+            If the operation has not completed within the specified timeout.
+        InvocationCanceledException
+            If the operation was cancelled before completing.
+        """
         with self._condition:
             if not self._wait(timeout, lambda: self._state == Future.StateRunning):
                 raise TimeoutException()
@@ -123,6 +264,19 @@ class Future(FutureBase):
                 return self._exception
 
     def set_result(self, result):
+        """
+        Set the result of the future and mark it as completed.
+
+        This method stores the provided `result` and transitions the future's state to "done". Any registered
+        callbacks are executed after the state update.
+
+        If the future is not in a running state, this method has no effect.
+
+        Parameters
+        ----------
+        result : object
+            The result value to store in the future.
+        """
         callbacks = []
         with self._condition:
             if self._state != Future.StateRunning:
@@ -136,6 +290,19 @@ class Future(FutureBase):
         self._callCallbacks(callbacks)
 
     def set_exception(self, ex):
+        """
+        Set an exception for the future and mark it as completed.
+
+        This method stores the provided exception `ex` and transitions the future's state to "done". Any registered
+        callbacks are executed after the state update.
+
+        If the future is not in a running state, this method has no effect.
+
+        Parameters
+        ----------
+        ex : Exception
+            The exception to store in the future.
+        """
         callbacks = []
         with self._condition:
             if self._state != Future.StateRunning:

--- a/python/test/Ice/ami/AllTests.py
+++ b/python/test/Ice/ami/AllTests.py
@@ -578,54 +578,6 @@ def allTestsFuture(helper, communicator, collocated):
 
     print("ok")
 
-    sys.stdout.write("testing done callback async... ")
-    sys.stdout.flush()
-
-    # Now repeat with add_done_callback_async
-    ctx = {}
-    cb = FutureDoneCallback()
-
-    p.ice_isAAsync(Test.TestIntf.ice_staticId()).add_done_callback_async(cb.isA)
-    cb.check()
-    p.ice_isAAsync(Test.TestIntf.ice_staticId(), ctx).add_done_callback_async(cb.isA)
-    cb.check()
-
-    p.ice_pingAsync().add_done_callback_async(cb.ping)
-    cb.check()
-    p.ice_pingAsync(ctx).add_done_callback_async(cb.ping)
-    cb.check()
-
-    p.ice_idAsync().add_done_callback_async(cb.id)
-    cb.check()
-    p.ice_idAsync(ctx).add_done_callback_async(cb.id)
-    cb.check()
-
-    p.ice_idsAsync().add_done_callback_async(cb.ids)
-    cb.check()
-    p.ice_idsAsync(ctx).add_done_callback_async(cb.ids)
-    cb.check()
-
-    if not collocated:
-        p.ice_getConnectionAsync().add_done_callback_async(cb.connection)
-        cb.check()
-
-    p.opAsync().add_done_callback_async(cb.op)
-    cb.check()
-    p.opAsync(ctx).add_done_callback_async(cb.op)
-    cb.check()
-
-    p.opWithResultAsync().add_done_callback_async(cb.opWithResult)
-    cb.check()
-    p.opWithResultAsync(ctx).add_done_callback_async(cb.opWithResult)
-    cb.check()
-
-    p.opWithUEAsync().add_done_callback_async(cb.opWithUE)
-    cb.check()
-    p.opWithUEAsync(ctx).add_done_callback_async(cb.opWithUE)
-    cb.check()
-
-    print("ok")
-
     if not collocated:
         sys.stdout.write("testing bi-dir... ")
         sys.stdout.flush()
@@ -741,21 +693,6 @@ def allTestsFuture(helper, communicator, collocated):
     p.opAsync().add_sent_callback(cb.sent)
     cb.check()
 
-    p.ice_isAAsync("").add_sent_callback_async(cb.sentAsync)
-    cb.check()
-
-    p.ice_pingAsync().add_sent_callback_async(cb.sentAsync)
-    cb.check()
-
-    p.ice_idAsync().add_sent_callback_async(cb.sentAsync)
-    cb.check()
-
-    p.ice_idsAsync().add_sent_callback_async(cb.sentAsync)
-    cb.check()
-
-    p.opAsync().add_sent_callback_async(cb.sentAsync)
-    cb.check()
-
     cbs = []
     b = [random.randint(0, 255) for x in range(0, 1024)]
     seq = bytes(b)
@@ -788,7 +725,6 @@ def allTestsFuture(helper, communicator, collocated):
     cb = FutureFlushCallback()
     f = b1.ice_flushBatchRequestsAsync()
     f.add_sent_callback(cb.sent)
-    f.add_sent_callback_async(cb.sentAsync)
     cb.check()
     test(f.is_sent())
     test(f.done())
@@ -1026,14 +962,10 @@ def allTestsFuture(helper, communicator, collocated):
     f2.result()
     test(f2.done())
 
-    test(f1.operation() == "op")
-    test(f2.operation() == "opWithPayload")
-
     #
     # Twoway
     #
     f = p.ice_pingAsync()
-    test(f.operation() == "ice_ping")
     f.result()
 
     #
@@ -1041,7 +973,6 @@ def allTestsFuture(helper, communicator, collocated):
     #
     p2 = p.ice_oneway()
     f = p2.ice_pingAsync()
-    test(f.operation() == "ice_ping")
 
     #
     # Batch request via proxy

--- a/python/test/Ice/executor/AllTests.py
+++ b/python/test/Ice/executor/AllTests.py
@@ -63,21 +63,21 @@ def allTests(helper, communicator):
 
     cb = Callback()
 
-    p.opAsync().add_done_callback_async(cb.response)
+    p.opAsync().add_done_callback(cb.response)
     cb.check()
 
     #
     # Expect NoEndpointException.
     #
     i = p.ice_adapterId("dummy")
-    i.opAsync().add_done_callback_async(cb.exception)
+    i.opAsync().add_done_callback(cb.exception)
     cb.check()
 
     #
     # Expect InvocationTimeoutException.
     #
     to = p.ice_invocationTimeout(10)
-    to.sleepAsync(500).add_done_callback_async(cb.exceptionEx)
+    to.sleepAsync(500).add_done_callback(cb.exceptionEx)
     cb.check()
 
     #


### PR DESCRIPTION
This PR include doc string comments for the Future types provided by Ice for Python.

We have some documentation for this classes in the Manual:

https://doc.zeroc.com/ice/3.7/language-mappings/python-mapping/client-side-slice-to-python-mapping/asynchronous-method-invocation-ami-in-python/ami-in-python-with-futures#id-.AMIinPythonwithFuturesv3.7-FutureClassesinPython

I also prune a few methods from Ice.InvocationFuture API witch I believe there is no good use case for:

- add_done_callback_async, add_sent_callback_async: If you don't want your callback to run on the current thread when completed deal with it in the callback, doesn't seems like a common use case.
- operation - Seems we bring this from our AsyncResult style mappings

Fix #3680