### PR TITLE
More slice2cpp doc updates

### DIFF
--- a/cpp/doxygen/Doxyfile
+++ b/cpp/doxygen/Doxyfile
@@ -514,7 +514,7 @@ TIMESTAMP              = NO
 # normally produced when WARNINGS is set to YES.
 # The default value is: NO.
 
-EXTRACT_ALL            = YES
+EXTRACT_ALL            = NO
 
 # If the EXTRACT_PRIVATE tag is set to YES, all private members of a class will
 # be included in the documentation.
@@ -546,7 +546,7 @@ EXTRACT_STATIC         = NO
 # for Java sources.
 # The default value is: YES.
 
-EXTRACT_LOCAL_CLASSES  = YES
+EXTRACT_LOCAL_CLASSES  = NO
 
 # This flag is only useful for Objective-C code. If set to YES, local methods,
 # which are defined in the implementation section but not in the interface are
@@ -881,7 +881,7 @@ WARN_NO_PARAMDOC       = NO
 # will automatically be disabled.
 # The default value is: NO.
 
-WARN_IF_UNDOC_ENUM_VAL = NO
+WARN_IF_UNDOC_ENUM_VAL = YES
 
 # If the WARN_AS_ERROR tag is set to YES then doxygen will immediately stop when
 # a warning is encountered. If the WARN_AS_ERROR tag is set to FAIL_ON_WARNINGS

--- a/cpp/include/Ice/EndpointSelectionType.h
+++ b/cpp/include/Ice/EndpointSelectionType.h
@@ -9,6 +9,7 @@ namespace Ice
 {
     /**
      * Determines the order in which the Ice run time uses the endpoints in a proxy when establishing a connection.
+     * \headerfile Ice/Ice.h
      */
     enum class EndpointSelectionType : std::uint8_t
     {

--- a/cpp/include/Ice/MetricsAdminI.h
+++ b/cpp/include/Ice/MetricsAdminI.h
@@ -241,9 +241,10 @@ namespace IceInternal
                         continue; // This sub-map isn't configured.
                     }
                 }
-                _subMaps.insert(std::make_pair(
-                    p->first,
-                    std::make_pair(p->second.first, p->second.second->create(subMapPrefix, properties))));
+                _subMaps.insert(
+                    std::make_pair(
+                        p->first,
+                        std::make_pair(p->second.first, p->second.second->create(subMapPrefix, properties))));
             }
         }
 
@@ -386,9 +387,10 @@ namespace IceInternal
                 t->id = key;
 
                 p = _objects
-                        .insert(typename std::map<std::string, EntryTPtr>::value_type(
-                            key,
-                            std::make_shared<EntryT>(shared_from_this(), t, _detachedQueue.end())))
+                        .insert(
+                            typename std::map<std::string, EntryTPtr>::value_type(
+                                key,
+                                std::make_shared<EntryT>(shared_from_this(), t, _detachedQueue.end())))
                         .first;
             }
             p->second->attach(helper);

--- a/cpp/include/Ice/MetricsObserverI.h
+++ b/cpp/include/Ice/MetricsObserverI.h
@@ -113,32 +113,36 @@ namespace IceMX
 
             template<typename Y> void add(const std::string& name, Y Helper::* member)
             {
-                _attributes.insert(typename std::map<std::string, Resolver*>::value_type(
-                    name,
-                    new HelperMemberResolver<Y>(name, member)));
+                _attributes.insert(
+                    typename std::map<std::string, Resolver*>::value_type(
+                        name,
+                        new HelperMemberResolver<Y>(name, member)));
             }
 
             template<typename Y> void add(const std::string& name, Y (Helper::*memberFn)() const)
             {
-                _attributes.insert(typename std::map<std::string, Resolver*>::value_type(
-                    name,
-                    new HelperMemberFunctionResolver<Y>(name, memberFn)));
+                _attributes.insert(
+                    typename std::map<std::string, Resolver*>::value_type(
+                        name,
+                        new HelperMemberFunctionResolver<Y>(name, memberFn)));
             }
 
             template<typename I, typename O, typename Y>
             void add(const std::string& name, O (Helper::*getFn)() const, Y I::* member)
             {
-                _attributes.insert(typename std::map<std::string, Resolver*>::value_type(
-                    name,
-                    new MemberResolver<I, O, Y>(name, getFn, member)));
+                _attributes.insert(
+                    typename std::map<std::string, Resolver*>::value_type(
+                        name,
+                        new MemberResolver<I, O, Y>(name, getFn, member)));
             }
 
             template<typename I, typename O, typename Y>
             void add(const std::string& name, O (Helper::*getFn)() const, Y (I::*memberFn)() const)
             {
-                _attributes.insert(typename std::map<std::string, Resolver*>::value_type(
-                    name,
-                    new MemberFunctionResolver<I, O, Y>(name, getFn, memberFn)));
+                _attributes.insert(
+                    typename std::map<std::string, Resolver*>::value_type(
+                        name,
+                        new MemberFunctionResolver<I, O, Y>(name, getFn, memberFn)));
             }
 
             //
@@ -148,9 +152,10 @@ namespace IceMX
             template<typename I, typename O, typename Y>
             void add(const std::string& name, O (Helper::*getFn)() const, Y (I::*memberFn)() const noexcept)
             {
-                _attributes.insert(typename std::map<std::string, Resolver*>::value_type(
-                    name,
-                    new MemberFunctionResolver<I, O, Y>(name, getFn, memberFn)));
+                _attributes.insert(
+                    typename std::map<std::string, Resolver*>::value_type(
+                        name,
+                        new MemberFunctionResolver<I, O, Y>(name, getFn, memberFn)));
             }
 
         private:

--- a/cpp/include/Ice/StreamHelpers.h
+++ b/cpp/include/Ice/StreamHelpers.h
@@ -22,8 +22,6 @@
 
 namespace Ice
 {
-    /// \cond STREAM
-
     // StreamHelper templates used by streams to read, write and print data.
 
     /// Prints a value with a pass-by-value type (such as bool, int32, or enum) to the stream.
@@ -732,8 +730,6 @@ namespace Ice
     {
         static void read(InputStream* istr, EncodingVersion& v) { istr->readAll(v.major, v.minor); }
     };
-
-    /// \endcond
 }
 
 #endif

--- a/cpp/include/Ice/StreamableTraits.h
+++ b/cpp/include/Ice/StreamableTraits.h
@@ -13,8 +13,6 @@ namespace Ice
     class ObjectPrx;
     class UserException;
 
-    /// \cond STREAM
-
     /**
      * The stream helper category allows streams to select the desired StreamHelper for a given streamable object.
      */
@@ -100,12 +98,13 @@ namespace Ice
         static const bool value = IsContainer<T>::value && sizeof(test<T>(nullptr)) == sizeof(char);
     };
 
-    /**
-     * Base traits template. Types with no specialized trait use this trait.
-     * \headerfile Ice/Ice.h
-     */
+    /// Base traits template. Types with no specialized trait use this trait.
+    /// @tparam T The type.
+    /// @tparam Enabler The specialization enabler.
+    /// \headerfile Ice/Ice.h
     template<typename T, typename Enabler = void> struct StreamableTraits
     {
+        /// The category trait, used for selecting the appropriate StreamHelper.
         static const StreamHelperCategory helper = StreamHelperCategoryUnknown;
 
         //
@@ -128,9 +127,14 @@ namespace Ice
      */
     template<typename T> struct StreamableTraits<T, std::enable_if_t<IsMap<T>::value || IsContainer<T>::value>>
     {
+        /// @copydoc StreamableTraits::helper
         static const StreamHelperCategory helper =
             IsMap<T>::value ? StreamHelperCategoryDictionary : StreamHelperCategorySequence;
+
+        /// The minimum number of bytes needed to marshal this type.
         static const int minWireSize = 1;
+
+        /// Is this type always encoded on a fixed number of bytes?
         static const bool fixedLength = false;
     };
 
@@ -140,6 +144,7 @@ namespace Ice
      */
     template<typename T> struct StreamableTraits<T, std::enable_if_t<std::is_base_of_v<UserException, T>>>
     {
+        /// @copydoc StreamableTraits::helper
         static const StreamHelperCategory helper = StreamHelperCategoryUserException;
 
         //
@@ -154,8 +159,13 @@ namespace Ice
      */
     template<typename T> struct StreamableTraits<std::pair<T*, T*>>
     {
+        /// @copydoc StreamableTraits::helper
         static const StreamHelperCategory helper = StreamHelperCategorySequence;
+
+        /// The minimum number of bytes needed to marshal this type.
         static const int minWireSize = 1;
+
+        /// Is this type always encoded on a fixed number of bytes?
         static const bool fixedLength = false;
     };
 
@@ -166,8 +176,13 @@ namespace Ice
      */
     template<> struct StreamableTraits<bool>
     {
+        /// @copydoc StreamableTraits::helper
         static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
+
+        /// The minimum number of bytes needed to marshal this type.
         static const int minWireSize = 1;
+
+        /// Is this type always encoded on a fixed number of bytes?
         static const bool fixedLength = true;
     };
 
@@ -178,8 +193,11 @@ namespace Ice
      */
     template<> struct StreamableTraits<std::byte>
     {
+        /// @copydoc StreamableTraits::helper
         static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
         static const int minWireSize = 1;
+
+        /// Is this type always encoded on a fixed number of bytes?
         static const bool fixedLength = true;
     };
 
@@ -190,8 +208,13 @@ namespace Ice
      */
     template<> struct StreamableTraits<std::uint8_t>
     {
+        /// @copydoc StreamableTraits::helper
         static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
+
+        /// The minimum number of bytes needed to marshal this type.
         static const int minWireSize = 1;
+
+        /// Is this type always encoded on a fixed number of bytes?
         static const bool fixedLength = true;
     };
 
@@ -202,8 +225,13 @@ namespace Ice
      */
     template<> struct StreamableTraits<std::int16_t>
     {
+        /// @copydoc StreamableTraits::helper
         static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
+
+        /// The minimum number of bytes needed to marshal this type.
         static const int minWireSize = 2;
+
+        /// Is this type always encoded on a fixed number of bytes?
         static const bool fixedLength = true;
     };
 
@@ -214,8 +242,13 @@ namespace Ice
      */
     template<> struct StreamableTraits<std::int32_t>
     {
+        /// @copydoc StreamableTraits::helper
         static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
+
+        /// The minimum number of bytes needed to marshal this type.
         static const int minWireSize = 4;
+
+        /// Is this type always encoded on a fixed number of bytes?
         static const bool fixedLength = true;
     };
 
@@ -226,8 +259,13 @@ namespace Ice
      */
     template<> struct StreamableTraits<std::int64_t>
     {
+        /// @copydoc StreamableTraits::helper
         static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
+
+        /// The minimum number of bytes needed to marshal this type.
         static const int minWireSize = 8;
+
+        /// Is this type always encoded on a fixed number of bytes?
         static const bool fixedLength = true;
     };
 
@@ -238,8 +276,13 @@ namespace Ice
      */
     template<> struct StreamableTraits<float>
     {
+        /// @copydoc StreamableTraits::helper
         static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
+
+        /// The minimum number of bytes needed to marshal this type.
         static const int minWireSize = 4;
+
+        /// Is this type always encoded on a fixed number of bytes?
         static const bool fixedLength = true;
     };
 
@@ -250,8 +293,13 @@ namespace Ice
      */
     template<> struct StreamableTraits<double>
     {
+        /// @copydoc StreamableTraits::helper
         static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
+
+        /// The minimum number of bytes needed to marshal this type.
         static const int minWireSize = 8;
+
+        /// Is this type always encoded on a fixed number of bytes?
         static const bool fixedLength = true;
     };
 
@@ -262,8 +310,13 @@ namespace Ice
      */
     template<> struct StreamableTraits<std::string>
     {
+        /// @copydoc StreamableTraits::helper
         static const StreamHelperCategory helper = StreamHelperCategoryBuiltin;
+
+        /// The minimum number of bytes needed to marshal this type.
         static const int minWireSize = 1;
+
+        /// Is this type always encoded on a fixed number of bytes?
         static const bool fixedLength = false;
     };
 
@@ -274,8 +327,13 @@ namespace Ice
      */
     template<> struct StreamableTraits<std::string_view>
     {
+        /// @copydoc StreamableTraits::helper
         static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
+
+        /// The minimum number of bytes needed to marshal this type.
         static const int minWireSize = 1;
+
+        /// Is this type always encoded on a fixed number of bytes?
         static const bool fixedLength = false;
     };
 
@@ -286,7 +344,10 @@ namespace Ice
      */
     template<> struct StreamableTraits<std::wstring>
     {
+        /// @copydoc StreamableTraits::helper
         static const StreamHelperCategory helper = StreamHelperCategoryBuiltin;
+
+        /// The minimum number of bytes needed to marshal this type.
         static const int minWireSize = 1;
         static const bool fixedLength = false;
     };
@@ -298,8 +359,13 @@ namespace Ice
      */
     template<> struct StreamableTraits<std::wstring_view>
     {
+        /// @copydoc StreamableTraits::helper
         static const StreamHelperCategory helper = StreamHelperCategoryBuiltinValue;
+
+        /// The minimum number of bytes needed to marshal this type.
         static const int minWireSize = 1;
+
+        /// Is this type always encoded on a fixed number of bytes?
         static const bool fixedLength = false;
     };
 
@@ -309,8 +375,13 @@ namespace Ice
      */
     template<> struct StreamableTraits<std::vector<bool>>
     {
+        /// @copydoc StreamableTraits::helper
         static const StreamHelperCategory helper = StreamHelperCategoryBuiltin;
+
+        /// The minimum number of bytes needed to marshal this type.
         static const int minWireSize = 1;
+
+        /// Is this type always encoded on a fixed number of bytes?
         static const bool fixedLength = false;
     };
 
@@ -320,8 +391,13 @@ namespace Ice
      */
     template<typename T> struct StreamableTraits<std::optional<T>, std::enable_if_t<std::is_base_of_v<ObjectPrx, T>>>
     {
+        /// @copydoc StreamableTraits::helper
         static const StreamHelperCategory helper = StreamHelperCategoryProxy;
+
+        /// The minimum number of bytes needed to marshal this type.
         static const int minWireSize = 2;
+
+        /// Is this type always encoded on a fixed number of bytes?
         static const bool fixedLength = false;
     };
 
@@ -331,14 +407,18 @@ namespace Ice
      */
     template<typename T> struct StreamableTraits<std::shared_ptr<T>, std::enable_if_t<std::is_base_of_v<Value, T>>>
     {
+        /// @copydoc StreamableTraits::helper
         static const StreamHelperCategory helper = StreamHelperCategoryClass;
+
+        /// The minimum number of bytes needed to marshal this type.
         static const int minWireSize = 1;
+
+        /// Is this type always encoded on a fixed number of bytes?
         static const bool fixedLength = false;
     };
 
     template<typename T, StreamHelperCategory st> struct StreamHelper;
     template<typename T, StreamHelperCategory st, bool fixedLength> struct StreamOptionalHelper;
-    /// \endcond
 }
 
 #endif

--- a/cpp/include/Ice/UserException.h
+++ b/cpp/include/Ice/UserException.h
@@ -28,19 +28,23 @@ namespace Ice
         /// @param os The output stream.
         virtual void ice_printFields(std::ostream& os) const;
 
-        /// \cond STREAM
         // _write and _read are virtual for the Python, Ruby etc. mappings.
+
+        /// @private
         virtual void _write(OutputStream*) const;
+
+        /// @private
         virtual void _read(InputStream*);
 
+        /// @private
         [[nodiscard]] virtual bool _usesClasses() const;
-        /// \endcond
 
     protected:
-        /// \cond STREAM
+        /// @private
         virtual void _writeImpl(OutputStream*) const = 0;
+
+        /// @private
         virtual void _readImpl(InputStream*) = 0;
-        /// \endcond
     };
 }
 

--- a/cpp/include/Ice/Value.h
+++ b/cpp/include/Ice/Value.h
@@ -80,13 +80,11 @@ namespace Ice
         /// @param os The output stream.
         virtual void ice_printFields(std::ostream& os) const;
 
-        /// \cond STREAM
+        /// \cond INTERNAL
         virtual void _iceWrite(Ice::OutputStream*) const;
         virtual void _iceRead(Ice::InputStream*);
-        /// \endcond
 
     protected:
-        /// \cond INTERNAL
         Value(const Value&) = default; // for clone
 
         // Helper class that allows derived classes to clone "this" even though the copy constructor is protected.
@@ -97,9 +95,7 @@ namespace Ice
         };
 
         [[nodiscard]] virtual ValuePtr _iceCloneImpl() const;
-        /// \endcond
 
-        /// \cond STREAM
         virtual void _iceWriteImpl(Ice::OutputStream*) const {}
         virtual void _iceReadImpl(Ice::InputStream*) {}
         /// \endcond

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -731,9 +731,12 @@ Slice::writeStreamReader(Output& out, const StructPtr& p, const DataMemberList& 
 {
     string fullName = p->mappedScoped();
 
+    out << nl << "/// @private"; // No need to pollute the doc with all these specializations.
+    out << nl << "/// Specialization of StreamReader for " << fullName << ".";
     out << nl << "template<>";
     out << nl << "struct StreamReader<" << fullName << ">";
     out << sb;
+    out << nl << "/// Unmarshals a " << fullName << " from the input stream.";
     out << nl << "static void read(InputStream* istr, " << fullName << "& v)";
     out << sb;
 

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1540,6 +1540,12 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     H << nl << "/// @return The fully-scoped type ID.";
     H << nl << "static const char* ice_staticId() noexcept;";
 
+    C << sp;
+    C << nl << "const char*" << nl << scopedPrx.substr(2) << "::ice_staticId() noexcept";
+    C << sb;
+    C << nl << "return \"" << scopedName << "\";";
+    C << eb;
+
     if (!bases.empty())
     {
         // -Wextra wants to initialize all the virtual base classes _in the right order_, which is not practical, and
@@ -1554,15 +1560,25 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     }
 
     // We can't use "= default" for the copy/move ctor/assignment operator as it's not correct with virtual inheritance.
+
     H << sp;
+    H << nl << "/// Copy constructor. Constructs with a copy of the contents of other.";
+    H << nl << "/// @param other The proxy to copy from.";
     H << nl << prx << "(const " << prx << "& other) noexcept : Ice::ObjectPrx(other)";
     H << " {} // NOLINT(modernize-use-equals-default)";
+
     H << sp;
-    H << nl << prx << "(" << prx << "&& other) noexcept : Ice::ObjectPrx(std::move(other))";
-    H << " {} // NOLINT(modernize-use-equals-default)";
+    H << nl << "/// Move constructor. Constructs a proxy with the contents of other using move semantics.";
+    H << nl << "/// @param other The proxy to move from.";
+    H << nl << prx << "(" << prx << "&& other) noexcept : Ice::ObjectPrx(std::move(other))"
+      << " {} // NOLINT(modernize-use-equals-default)";
+
     H << sp;
-    H << nl << prx << "(const Ice::CommunicatorPtr& communicator, std::string_view proxyString)";
-    H << " : Ice::ObjectPrx(communicator, proxyString) {} // NOLINT(modernize-use-equals-default)";
+    H << nl << "/// Constructs a proxy from a communicator and a proxy string.";
+    H << nl << "/// @param communicator The communicator of the new proxy.";
+    H << nl << "/// @param proxyString The proxy string.";
+    H << nl << prx << "(const Ice::CommunicatorPtr& communicator, std::string_view proxyString)"
+      << " : Ice::ObjectPrx(communicator, proxyString) {} // NOLINT(modernize-use-equals-default)";
 
     H << sp;
     H << nl << "~" << prx << "() override;";
@@ -1570,6 +1586,8 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     C << nl << scopedPrx.substr(2) << "::~" << prx << "() = default;"; // avoid weak table
 
     H << sp;
+    H << nl << "/// Copy assignment operator. Replaces the contents of this proxy with a copy of the contents of rhs.";
+    H << nl << "/// @param rhs The proxy to copy from.";
     H << nl << prx << "& operator=(const " << prx << "& rhs) noexcept";
     H << sb;
     // The self-assignment check is to make clang-tidy happy.
@@ -1579,7 +1597,12 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     H << eb;
     H << nl << "return *this;";
     H << eb;
+
     H << sp;
+    H << nl
+      << "/// Move assignment operator. Replaces the contents of this proxy with the contents of rhs using move "
+         "semantics.";
+    H << nl << "/// @param rhs The proxy to move from.";
     H << nl << prx << "& operator=(" << prx << "&& rhs) noexcept";
     H << sb;
     // The self-assignment check is to make clang-tidy happy.
@@ -1590,17 +1613,19 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     H << nl << "return *this;";
     H << eb;
     H << sp;
-    H << nl << "/// \\cond INTERNAL";
+    H << nl << "/// @private";
     H << nl << "static " << prx << " _fromReference(IceInternal::ReferencePtr ref) { return " << prx
       << "(std::move(ref)); }";
     H.dec();
+
     H << sp << nl << "protected:";
     H.inc();
+    H << nl << "/// @private";
     H << nl << prx << "() = default;";
     H << sp;
+    H << nl << "/// @private";
     H << nl << "explicit " << prx << "(IceInternal::ReferencePtr&& ref) : Ice::ObjectPrx(std::move(ref))";
     H << sb << eb;
-    H << nl << "/// \\endcond";
 
     if (!bases.empty())
     {
@@ -1615,12 +1640,6 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     }
 
     H << eb << ';';
-
-    C << sp;
-    C << nl << "const char*" << nl << scopedPrx.substr(2) << "::ice_staticId() noexcept";
-    C << sb;
-    C << nl << "return \"" << scopedName << "\";";
-    C << eb;
 
     _useWstring = resetUseWstring(_useWstringHist);
 }
@@ -1933,13 +1952,12 @@ Slice::Gen::ProxyVisitor::emitOperationImpl(
     string returnT = createOutgoingAsyncTypeParam(outgoingAsyncParams);
 
     H << sp;
-    H << nl << "/// \\cond INTERNAL";
+    H << nl << "/// @private";
     H << nl << "void " << opImplName << spar;
     H << "const std::shared_ptr<IceInternal::OutgoingAsyncT<" + returnT + ">>&";
     H << inParamsS;
     H << "const Ice::Context&";
     H << epar << " const;";
-    H << nl << "/// \\endcond";
 
     C << sp;
     C << nl << "void" << nl << scopedPrxPrefix << opImplName << spar;
@@ -2312,18 +2330,15 @@ Slice::Gen::DataDefVisitor::visitExceptionStart(const ExceptionPtr& p)
     if (p->usesClasses() && !(base && base->usesClasses()))
     {
         H << sp;
-        H << nl << "/// \\cond STREAM";
+        H << nl << "/// @private";
         H << nl << _dllMemberExport << "[[nodiscard]] bool _usesClasses() const override;";
-        H << nl << "/// \\endcond";
 
         C << sp;
-        C << nl << "/// \\cond STREAM";
         C << nl << "bool";
         C << nl << scoped.substr(2) << "::_usesClasses() const";
         C << sb;
         C << nl << "return true;";
         C << eb;
-        C << nl << "/// \\endcond";
     }
 
     if (!dataMembers.empty())
@@ -2347,6 +2362,7 @@ Slice::Gen::DataDefVisitor::visitExceptionEnd(const ExceptionPtr& p)
     H << sp << nl << "protected:";
     H.inc();
 
+    H << nl << "/// @private";
     H << nl << _dllMemberExport << "void _writeImpl(Ice::OutputStream*) const override;";
     C << sp << nl << "void" << nl << scoped.substr(2) << "::_writeImpl(Ice::OutputStream* ostr) const";
     C << sb;
@@ -2363,7 +2379,9 @@ Slice::Gen::DataDefVisitor::visitExceptionEnd(const ExceptionPtr& p)
     }
     C << eb;
 
-    H << sp << nl << _dllMemberExport << "void _readImpl(Ice::InputStream*) override;";
+    H << sp;
+    H << nl << "/// @private";
+    H << nl << _dllMemberExport << "void _readImpl(Ice::InputStream*) override;";
     C << sp << nl << "void" << nl << scoped.substr(2) << "::_readImpl(Ice::InputStream* istr)";
     C << sb;
     C << nl << "istr->startSlice();";
@@ -2488,7 +2506,7 @@ Slice::Gen::DataDefVisitor::visitClassDefEnd(const ClassDefPtr& p)
     if (p->hasMetadata("cpp:custom-print"))
     {
         H << sp;
-        H << nl << "// Custom ice_print implemented by the application.";
+        H << nl << "/// Custom ice_print implemented by the application.";
         H << nl << "void ice_print(std::ostream& os) const override;";
     }
 
@@ -2509,8 +2527,13 @@ Slice::Gen::DataDefVisitor::visitClassDefEnd(const ClassDefPtr& p)
         C << eb;
     }
 
+    H << sp;
+    H << nl << "/// Copy constructor.";
     H << nl << name << "(const " << name << "&) = default;";
-    H << sp << nl << _dllMemberExport << "[[nodiscard]] Ice::ValuePtr _iceCloneImpl() const override;";
+
+    H << sp;
+    H << nl << "/// @private";
+    H << nl << _dllMemberExport << "[[nodiscard]] Ice::ValuePtr _iceCloneImpl() const override;";
     C << sp;
     C << nl << "Ice::ValuePtr" << nl << scoped.substr(2) << "::_iceCloneImpl() const";
     C << sb;
@@ -2518,6 +2541,7 @@ Slice::Gen::DataDefVisitor::visitClassDefEnd(const ClassDefPtr& p)
     C << eb;
 
     H << sp;
+    H << nl << "/// @private";
     H << nl << _dllMemberExport << "void _iceWriteImpl(Ice::OutputStream*) const override;";
     C << sp << nl << "void" << nl << scoped.substr(2) << "::_iceWriteImpl(Ice::OutputStream* ostr) const";
     C << sb;
@@ -2534,7 +2558,9 @@ Slice::Gen::DataDefVisitor::visitClassDefEnd(const ClassDefPtr& p)
     }
     C << eb;
 
-    H << sp << nl << _dllMemberExport << "void _iceReadImpl(Ice::InputStream*) override;";
+    H << sp;
+    H << nl << "/// @private";
+    H << nl << _dllMemberExport << "void _iceReadImpl(Ice::InputStream*) override;";
     C << sp << nl << "void" << nl << scoped.substr(2) << "::_iceReadImpl(Ice::InputStream* istr)";
     C << sb;
     C << nl << "istr->startSlice();";
@@ -2786,6 +2812,7 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     // In C++, a nested type cannot have the same name as the enclosing type
     if (name != "ProxyType")
     {
+        H << nl << "/// The associated proxy type.";
         H << nl << "using ProxyType = " << p->mappedName() << "Prx;";
     }
 
@@ -2858,10 +2885,14 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         allOpNames.emplace_back("ice_ping", "ice_ping");
         allOpNames.sort();
 
+        // The Ice:: qualification confuses doxygen, so we remove it when in the Ice module.
+        bool inIceModule = p->scope() == "::Ice::";
+        string_view incomingRequestType = inIceModule ? "IncomingRequest" : "Ice::IncomingRequest";
+        string_view outgoingResponseType = inIceModule ? "OutgoingResponse" : "Ice::OutgoingResponse";
+
         H << sp;
-        H << nl
-          << "void dispatch(Ice::IncomingRequest&, std::function<void(Ice::OutgoingResponse)>) "
-             "override;";
+        H << nl << "void dispatch(" << incomingRequestType << "& request, std::function<void(" << outgoingResponseType
+          << ")> sendResponse) override;";
 
         C << sp;
         C << nl << "void";
@@ -3125,13 +3156,12 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
         writeOpDocSummary(H, p, *comment, pt, true, GenerateDeprecated::No, StringList(), postParams, returns);
     }
     H << nl << noDiscard << "virtual " << retS << ' ' << opName << spar << params << epar << isConst << " = 0;";
-    H << sp << nl << "/// \\cond INTERNAL";
+    H << sp;
+    H << nl << "/// @private";
     H << nl << "void _iceD_" << p->mappedName() << "(Ice::IncomingRequest&, std::function<void(Ice::OutgoingResponse)>)"
       << isConst << ';';
-    H << nl << "/// \\endcond";
 
     C << sp;
-    C << nl << "/// \\cond INTERNAL";
     C << nl << "void";
     C << nl << scope.substr(2) << "_iceD_" << p->mappedName() << "(";
     C.inc();
@@ -3256,7 +3286,6 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
         C << eb;
     }
     C << eb;
-    C << nl << "/// \\endcond";
 }
 
 Slice::Gen::StreamVisitor::StreamVisitor(Output& h) : H(h) {}
@@ -3273,7 +3302,6 @@ Slice::Gen::StreamVisitor::visitModuleStart(const ModulePtr& m)
     {
         // Only emit this for the top-level module.
         H << sp;
-        H << nl << "/// \\cond STREAM";
         H << nl << "namespace Ice" << nl << '{';
         H.inc();
     }
@@ -3288,7 +3316,6 @@ Slice::Gen::StreamVisitor::visitModuleEnd(const ModulePtr& m)
         // Only emit this for the top-level module.
         H.dec();
         H << nl << '}';
-        H << nl << "/// \\endcond";
     }
 }
 
@@ -3304,11 +3331,18 @@ Slice::Gen::StreamVisitor::visitStructStart(const StructPtr& p)
         H << sp;
     }
 
+    H << nl << "/// @private"; // No need to pollute the doc with all these specializations.
+    H << nl << "/// Specialization of StreamableTraits for " << p->mappedScoped() << ".";
     H << nl << "template<>";
     H << nl << "struct StreamableTraits<" << p->mappedScoped() << ">";
     H << sb;
+    H << nl << "/// @copydoc StreamableTraits::helper";
     H << nl << "static const StreamHelperCategory helper = StreamHelperCategoryStruct;";
+    H << sp;
+    H << nl << "/// The minimum number of bytes needed to marshal this type.";
     H << nl << "static const int minWireSize = " << p->minWireSize() << ";";
+    H << sp;
+    H << nl << "/// Is this type always encoded on a fixed number of bytes?";
     H << nl << "static const bool fixedLength = " << (p->isVariableLength() ? "false" : "true") << ";";
     H << eb << ";" << nl;
 
@@ -3328,13 +3362,24 @@ Slice::Gen::StreamVisitor::visitEnum(const EnumPtr& p)
         H << sp;
     }
 
+    H << nl << "/// @private"; // No need to pollute the doc with all these specializations.
+    H << nl << "/// Specialization of StreamableTraits for " << p->mappedScoped() << ".";
     H << nl << "template<>";
     H << nl << "struct StreamableTraits<" << p->mappedScoped() << ">";
     H << sb;
+    H << nl << "/// @copydoc StreamableTraits::helper";
     H << nl << "static const StreamHelperCategory helper = StreamHelperCategoryEnum;";
+    H << sp;
+    H << nl << "/// The minimum value of this enum.";
     H << nl << "static const int minValue = " << p->minValue() << ";";
+    H << sp;
+    H << nl << "/// The maximum value of this enum.";
     H << nl << "static const int maxValue = " << p->maxValue() << ";";
+    H << sp;
+    H << nl << "/// The minimum number of bytes needed to marshal this type.";
     H << nl << "static const int minWireSize = " << p->minWireSize() << ";";
+    H << sp;
+    H << nl << "/// Is this type always encoded on a fixed number of bytes?";
     H << nl << "static const bool fixedLength = false;";
     H << eb << ";";
 }

--- a/slice/Ice/Version.ice
+++ b/slice/Ice/Version.ice
@@ -25,7 +25,10 @@ module Ice
     ["cpp:custom-print"]
     struct ProtocolVersion
     {
+        /// The major version of the Ice protocol.
         byte major;
+
+        /// The minor version of the Ice protocol.
         byte minor;
     }
 
@@ -33,7 +36,10 @@ module Ice
     ["cpp:custom-print"]
     struct EncodingVersion
     {
+        /// The major version of the Ice encoding.
         byte major;
+
+        /// The minor version of the Ice encoding.
         byte minor;
     }
 }


### PR DESCRIPTION
This PR continues with the slice2cpp doc updates.

The main change is to set EXTRACT_ALL to NO in the Doxyfile. This allows to detect undocumented constructs.

It also removes cond STREAM (everywhere) and cond INTERNAL (in the general code). 

`/// @private` is a better way to mark a class / function as "do not document even though it's public or protected".