### PR TITLE
Modernize C++ Python extension code

### DIFF
--- a/python/modules/IcePy/BatchRequestInterceptor.cpp
+++ b/python/modules/IcePy/BatchRequestInterceptor.cpp
@@ -133,55 +133,22 @@ static PyMethodDef BatchRequestMethods[] = {
      METH_NOARGS,
      PyDoc_STR("getProxy() -> Ice.ObjectPrx")},
     {"enqueue", reinterpret_cast<PyCFunction>(batchRequestEnqueue), METH_NOARGS, PyDoc_STR("enqueue() -> None")},
-    {0, 0} /* sentinel */
+    {nullptr, nullptr} /* sentinel */
 };
 
 namespace IcePy
 {
+    // clang-format off
     PyTypeObject BatchRequestType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.BatchRequest", /* tp_name */
-        sizeof(BatchRequestObject),                       /* tp_basicsize */
-        0,                                                /* tp_itemsize */
-        /* methods */
-        reinterpret_cast<destructor>(batchRequestDealloc), /* tp_dealloc */
-        0,                                                 /* tp_print */
-        0,                                                 /* tp_getattr */
-        0,                                                 /* tp_setattr */
-        0,                                                 /* tp_reserved */
-        0,                                                 /* tp_repr */
-        0,                                                 /* tp_as_number */
-        0,                                                 /* tp_as_sequence */
-        0,                                                 /* tp_as_mapping */
-        0,                                                 /* tp_hash */
-        0,                                                 /* tp_call */
-        0,                                                 /* tp_str */
-        0,                                                 /* tp_getattro */
-        0,                                                 /* tp_setattro */
-        0,                                                 /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT,                                /* tp_flags */
-        0,                                                 /* tp_doc */
-        0,                                                 /* tp_traverse */
-        0,                                                 /* tp_clear */
-        0,                                                 /* tp_richcompare */
-        0,                                                 /* tp_weaklistoffset */
-        0,                                                 /* tp_iter */
-        0,                                                 /* tp_iternext */
-        BatchRequestMethods,                               /* tp_methods */
-        0,                                                 /* tp_members */
-        0,                                                 /* tp_getset */
-        0,                                                 /* tp_base */
-        0,                                                 /* tp_dict */
-        0,                                                 /* tp_descr_get */
-        0,                                                 /* tp_descr_set */
-        0,                                                 /* tp_dictoffset */
-        0,                                                 /* tp_init */
-        0,                                                 /* tp_alloc */
-        reinterpret_cast<newfunc>(batchRequestNew),        /* tp_new */
-        0,                                                 /* tp_free */
-        0,                                                 /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.BatchRequest",
+        .tp_basicsize = sizeof(BatchRequestObject),
+        .tp_dealloc = (destructor)batchRequestDealloc,
+        .tp_flags = Py_TPFLAGS_DEFAULT,
+        .tp_methods = BatchRequestMethods,
+        .tp_new = (newfunc)batchRequestNew,
     };
+    // clang-format on
 }
 
 bool
@@ -191,8 +158,8 @@ IcePy::initBatchRequest(PyObject* module)
     {
         return false;
     }
-    PyTypeObject* type = &BatchRequestType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "BatchRequest", reinterpret_cast<PyObject*>(type)) < 0)
+
+    if (PyModule_AddObject(module, "BatchRequest", reinterpret_cast<PyObject*>(&BatchRequestType)) < 0)
     {
         return false;
     }
@@ -218,16 +185,16 @@ IcePy::BatchRequestInterceptorWrapper::enqueue(const Ice::BatchRequest& request,
 {
     AdoptThread adoptThread; // Ensure the current thread is able to call into Python.
 
-    BatchRequestObject* obj = reinterpret_cast<BatchRequestObject*>(BatchRequestType.tp_alloc(&BatchRequestType, 0));
+    auto* obj = reinterpret_cast<BatchRequestObject*>(BatchRequestType.tp_alloc(&BatchRequestType, 0));
     if (!obj)
     {
         return;
     }
 
     obj->request = &request;
-    obj->size = 0;
-    obj->operation = 0;
-    obj->proxy = 0;
+    obj->size = nullptr;
+    obj->operation = nullptr;
+    obj->proxy = nullptr;
     PyObjectHandle tmp;
     if (PyCallable_Check(_interceptor.get()))
     {

--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -34,10 +34,10 @@ using namespace IcePy;
 #    pragma GCC diagnostic ignored "-Wcast-function-type"
 #endif
 
-static unsigned long _mainThreadId;
+static unsigned long mainThreadId;
 
 using CommunicatorMap = map<Ice::CommunicatorPtr, PyObject*>;
-static CommunicatorMap _communicatorMap;
+static CommunicatorMap communicatorMap;
 
 namespace IcePy
 {
@@ -56,13 +56,13 @@ extern "C" CommunicatorObject*
 communicatorNew(PyTypeObject* type, PyObject* /*args*/, PyObject* /*kwds*/)
 {
     assert(type && type->tp_alloc);
-    CommunicatorObject* self = reinterpret_cast<CommunicatorObject*>(type->tp_alloc(type, 0));
+    auto* self = reinterpret_cast<CommunicatorObject*>(type->tp_alloc(type, 0));
     if (!self)
     {
         return nullptr;
     }
-    self->communicator = 0;
-    self->wrapper = 0;
+    self->communicator = nullptr;
+    self->wrapper = nullptr;
     self->shutdownFuture = nullptr;
     self->shutdownException = nullptr;
     self->shutdown = false;
@@ -84,25 +84,25 @@ communicatorInit(CommunicatorObject* self, PyObject* args, PyObject* /*kwds*/)
     // Ice.initialize(args, configFile)
     //
 
-    PyObject* arg1 = 0;
-    PyObject* arg2 = 0;
+    PyObject* arg1{nullptr};
+    PyObject* arg2{nullptr};
     if (!PyArg_ParseTuple(args, "|OO", &arg1, &arg2))
     {
         return -1;
     }
 
-    PyObject* argList = 0;
-    PyObject* initData = 0;
-    PyObject* configFile = 0;
+    PyObject* argList{nullptr};
+    PyObject* initData{nullptr};
+    PyObject* configFile{nullptr};
 
     if (arg1 == Py_None)
     {
-        arg1 = 0;
+        arg1 = nullptr;
     }
 
     if (arg2 == Py_None)
     {
-        arg2 = 0;
+        arg2 = nullptr;
     }
 
     PyObject* initDataType = lookupType("Ice.InitializationData");
@@ -220,7 +220,7 @@ communicatorInit(CommunicatorObject* self, PyObject* args, PyObject* /*kwds*/)
             {
                 executorWrapper = make_shared<Executor>(executor.get());
                 data.executor = [executorWrapper](function<void()> call, const shared_ptr<Ice::Connection>& connection)
-                { executorWrapper->execute(call, connection); };
+                { executorWrapper->execute(std::move(call), connection); };
             }
 
             if (batchRequestInterceptor.get())
@@ -266,11 +266,11 @@ communicatorInit(CommunicatorObject* self, PyObject* args, PyObject* /*kwds*/)
     int argc = static_cast<int>(seq.size());
     char** argv = new char*[static_cast<size_t>(argc) + 1];
     int i = 0;
-    for (Ice::StringSeq::const_iterator s = seq.begin(); s != seq.end(); ++s, ++i)
+    for (const auto& s : seq)
     {
-        argv[i] = strdup(s->c_str());
+        argv[i++] = strdup(s.c_str());
     }
-    argv[argc] = 0;
+    argv[argc] = nullptr;
 
     data.compactIdResolver = resolveCompactId;
 
@@ -307,7 +307,7 @@ communicatorInit(CommunicatorObject* self, PyObject* args, PyObject* /*kwds*/)
     //
     if (argList)
     {
-        PyList_SetSlice(argList, 0, PyList_Size(argList), 0); // Clear the list.
+        PyList_SetSlice(argList, 0, PyList_Size(argList), nullptr); // Clear the list.
 
         for (i = 0; i < argc; ++i)
         {
@@ -323,7 +323,7 @@ communicatorInit(CommunicatorObject* self, PyObject* args, PyObject* /*kwds*/)
     delete[] argv;
 
     self->communicator = new Ice::CommunicatorPtr(communicator);
-    _communicatorMap.insert(CommunicatorMap::value_type(communicator, reinterpret_cast<PyObject*>(self)));
+    communicatorMap.insert(CommunicatorMap::value_type(communicator, reinterpret_cast<PyObject*>(self)));
 
     if (executorWrapper)
     {
@@ -339,13 +339,13 @@ communicatorDealloc(CommunicatorObject* self)
 {
     if (self->communicator)
     {
-        CommunicatorMap::iterator p = _communicatorMap.find(*self->communicator);
+        auto p = communicatorMap.find(*self->communicator);
         //
         // find() can fail if an error occurred during communicator initialization.
         //
-        if (p != _communicatorMap.end())
+        if (p != communicatorMap.end())
         {
-            _communicatorMap.erase(p);
+            communicatorMap.erase(p);
         }
     }
 
@@ -384,7 +384,7 @@ communicatorDestroy(CommunicatorObject* self, PyObject* /*args*/)
     // Break cyclic reference between this object and its Python wrapper.
     //
     Py_XDECREF(self->wrapper);
-    self->wrapper = 0;
+    self->wrapper = nullptr;
 
     if (PyErr_Occurred())
     {
@@ -439,7 +439,7 @@ communicatorWaitForShutdown(CommunicatorObject* self, PyObject* args)
     // Do not call waitForShutdown from the main thread, because it prevents
     // signals (such as keyboard interrupts) from being delivered to Python.
     //
-    if (PyThread_get_thread_ident() == _mainThreadId)
+    if (PyThread_get_thread_ident() == mainThreadId)
     {
         if (!self->shutdown)
         {
@@ -679,11 +679,11 @@ communicatorProxyToProperty(CommunicatorObject* self, PyObject* args)
     PyObjectHandle result{PyDict_New()};
     if (result.get())
     {
-        for (Ice::PropertyDict::iterator p = dict.begin(); p != dict.end(); ++p)
+        for (const auto& [key, value] : dict)
         {
-            PyObjectHandle key{createString(p->first)};
-            PyObjectHandle val{createString(p->second)};
-            if (!val.get() || PyDict_SetItem(result.get(), key.get(), val.get()) < 0)
+            PyObjectHandle pyKey{createString(key)};
+            PyObjectHandle pyValue{createString(value)};
+            if (!pyValue.get() || PyDict_SetItem(result.get(), pyKey.get(), pyValue.get()) < 0)
             {
                 return nullptr;
             }
@@ -736,7 +736,7 @@ communicatorFlushBatchRequests(CommunicatorObject* self, PyObject* args)
 
     PyObjectHandle v{getAttr(compressBatch, "_value", false)};
     assert(v.get());
-    Ice::CompressBatch cb = static_cast<Ice::CompressBatch>(PyLong_AsLong(v.get()));
+    auto cb = static_cast<Ice::CompressBatch>(PyLong_AsLong(v.get()));
 
     assert(self->communicator);
     try
@@ -765,7 +765,7 @@ communicatorFlushBatchRequestsAsync(CommunicatorObject* self, PyObject* args, Py
 
     PyObjectHandle v{getAttr(compressBatch, "_value", false)};
     assert(v.get());
-    Ice::CompressBatch compress = static_cast<Ice::CompressBatch>(PyLong_AsLong(v.get()));
+    auto compress = static_cast<Ice::CompressBatch>(PyLong_AsLong(v.get()));
 
     assert(self->communicator);
     const string op = "flushBatchRequests";
@@ -983,25 +983,25 @@ communicatorFindAllAdminFacets(CommunicatorObject* self, PyObject* /*args*/)
     PyTypeObject* objectType = reinterpret_cast<PyTypeObject*>(lookupType("Ice.Object"));
     PyObjectHandle plainObject{objectType->tp_alloc(objectType, 0)};
 
-    for (Ice::FacetMap::const_iterator p = facetMap.begin(); p != facetMap.end(); ++p)
+    for (const auto& [facet, servant] : facetMap)
     {
         PyObjectHandle obj = plainObject;
 
-        ServantWrapperPtr wrapper = dynamic_pointer_cast<ServantWrapper>(p->second);
+        ServantWrapperPtr wrapper = dynamic_pointer_cast<ServantWrapper>(servant);
         if (wrapper)
         {
             obj = wrapper->getObject();
         }
         else
         {
-            Ice::NativePropertiesAdminPtr props = dynamic_pointer_cast<Ice::NativePropertiesAdmin>(p->second);
+            Ice::NativePropertiesAdminPtr props = dynamic_pointer_cast<Ice::NativePropertiesAdmin>(servant);
             if (props)
             {
                 obj = createNativePropertiesAdmin(props);
             }
         }
 
-        if (PyDict_SetItemString(result.get(), const_cast<char*>(p->first.c_str()), obj.get()) < 0)
+        if (PyDict_SetItemString(result.get(), const_cast<char*>(facet.c_str()), obj.get()) < 0)
         {
             return nullptr;
         }
@@ -1137,7 +1137,7 @@ communicatorGetImplicitContext(CommunicatorObject* self, PyObject* /*args*/)
 {
     Ice::ImplicitContextPtr implicitContext = (*self->communicator)->getImplicitContext();
 
-    if (implicitContext == 0)
+    if (!implicitContext)
     {
         return Py_None;
     }
@@ -1563,61 +1563,28 @@ static PyMethodDef CommunicatorMethods[] = {
      METH_VARARGS,
      PyDoc_STR("internal function")},
     {"_getWrapper", reinterpret_cast<PyCFunction>(communicatorGetWrapper), METH_NOARGS, PyDoc_STR("internal function")},
-    {0, 0} /* sentinel */
+    {nullptr, nullptr} /* sentinel */
 };
 
 namespace IcePy
 {
+    // clang-format off
     PyTypeObject CommunicatorType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.Communicator", /* tp_name */
-        sizeof(CommunicatorObject),                       /* tp_basicsize */
-        0,                                                /* tp_itemsize */
-        /* methods */
-        reinterpret_cast<destructor>(communicatorDealloc), /* tp_dealloc */
-        0,                                                 /* tp_print */
-        0,                                                 /* tp_getattr */
-        0,                                                 /* tp_setattr */
-        0,                                                 /* tp_reserved */
-        0,                                                 /* tp_repr */
-        0,                                                 /* tp_as_number */
-        0,                                                 /* tp_as_sequence */
-        0,                                                 /* tp_as_mapping */
-        0,                                                 /* tp_hash */
-        0,                                                 /* tp_call */
-        0,                                                 /* tp_str */
-        0,                                                 /* tp_getattro */
-        0,                                                 /* tp_setattro */
-        0,                                                 /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT,                                /* tp_flags */
-        0,                                                 /* tp_doc */
-        0,                                                 /* tp_traverse */
-        0,                                                 /* tp_clear */
-        0,                                                 /* tp_richcompare */
-        0,                                                 /* tp_weaklistoffset */
-        0,                                                 /* tp_iter */
-        0,                                                 /* tp_iternext */
-        CommunicatorMethods,                               /* tp_methods */
-        0,                                                 /* tp_members */
-        0,                                                 /* tp_getset */
-        0,                                                 /* tp_base */
-        0,                                                 /* tp_dict */
-        0,                                                 /* tp_descr_get */
-        0,                                                 /* tp_descr_set */
-        0,                                                 /* tp_dictoffset */
-        reinterpret_cast<initproc>(communicatorInit),      /* tp_init */
-        0,                                                 /* tp_alloc */
-        reinterpret_cast<newfunc>(communicatorNew),        /* tp_new */
-        0,                                                 /* tp_free */
-        0,                                                 /* tp_is_gc */
-    };
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.Communicator",
+        .tp_basicsize = sizeof(CommunicatorObject),
+        .tp_dealloc = reinterpret_cast<destructor>(communicatorDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT,
+        .tp_methods = CommunicatorMethods,
+        .tp_init = reinterpret_cast<initproc>(communicatorInit),
+        .tp_new = reinterpret_cast<newfunc>(communicatorNew)};
+    // clang-format on
 }
 
 bool
 IcePy::initCommunicator(PyObject* module)
 {
-    _mainThreadId = PyThread_get_thread_ident();
+    mainThreadId = PyThread_get_thread_ident();
 
     if (PyType_Ready(&CommunicatorType) < 0)
     {
@@ -1636,21 +1603,21 @@ Ice::CommunicatorPtr
 IcePy::getCommunicator(PyObject* obj)
 {
     assert(PyObject_IsInstance(obj, reinterpret_cast<PyObject*>(&CommunicatorType)));
-    CommunicatorObject* cobj = reinterpret_cast<CommunicatorObject*>(obj);
+    auto* cobj = reinterpret_cast<CommunicatorObject*>(obj);
     return *cobj->communicator;
 }
 
 PyObject*
 IcePy::createCommunicator(const Ice::CommunicatorPtr& communicator)
 {
-    CommunicatorMap::iterator p = _communicatorMap.find(communicator);
-    if (p != _communicatorMap.end())
+    auto p = communicatorMap.find(communicator);
+    if (p != communicatorMap.end())
     {
         Py_INCREF(p->second);
         return p->second;
     }
 
-    CommunicatorObject* obj = communicatorNew(&CommunicatorType, 0, 0);
+    CommunicatorObject* obj = communicatorNew(&CommunicatorType, nullptr, nullptr);
     if (obj)
     {
         obj->communicator = new Ice::CommunicatorPtr(communicator);
@@ -1661,9 +1628,9 @@ IcePy::createCommunicator(const Ice::CommunicatorPtr& communicator)
 PyObject*
 IcePy::getCommunicatorWrapper(const Ice::CommunicatorPtr& communicator)
 {
-    CommunicatorMap::iterator p = _communicatorMap.find(communicator);
+    auto p = communicatorMap.find(communicator);
     assert(p != _communicatorMap.end());
-    CommunicatorObject* obj = reinterpret_cast<CommunicatorObject*>(p->second);
+    auto* obj = reinterpret_cast<CommunicatorObject*>(p->second);
     if (obj->wrapper)
     {
         Py_INCREF(obj->wrapper);
@@ -1682,8 +1649,8 @@ extern "C" PyObject*
 IcePy_identityToString(PyObject* /*self*/, PyObject* args)
 {
     PyObject* identityType = lookupType("Ice.Identity");
-    PyObject* obj;
-    PyObject* mode = 0;
+    PyObject* obj{nullptr};
+    PyObject* mode{nullptr};
     if (!PyArg_ParseTuple(args, "O!O", identityType, &obj, &mode))
     {
         return nullptr;

--- a/python/modules/IcePy/ConnectionInfo.cpp
+++ b/python/modules/IcePy/ConnectionInfo.cpp
@@ -168,329 +168,145 @@ sslConnectionInfoGetPeerCertificate(ConnectionInfoObject* self, PyObject* /*args
 static PyGetSetDef ConnectionInfoGetters[] = {
     {"underlying",
      reinterpret_cast<getter>(connectionInfoGetUnderlying),
-     0,
+     nullptr,
      PyDoc_STR("get underlying connection information"),
-     0},
+     nullptr},
     {"incoming",
      reinterpret_cast<getter>(connectionInfoGetIncoming),
-     0,
+     nullptr,
      PyDoc_STR("whether connection is incoming"),
-     0},
+     nullptr},
     {"adapterName",
      reinterpret_cast<getter>(connectionInfoGetAdapterName),
-     0,
+     nullptr,
      PyDoc_STR("adapter associated the connection"),
-     0},
-    {0, 0} /* sentinel */
+     nullptr},
+    {nullptr, nullptr} /* sentinel */
 };
 
 static PyGetSetDef IPConnectionInfoGetters[] = {
-    {"localAddress", reinterpret_cast<getter>(ipConnectionInfoGetLocalAddress), 0, PyDoc_STR("local address"), 0},
-    {"localPort", reinterpret_cast<getter>(ipConnectionInfoGetLocalPort), 0, PyDoc_STR("local port"), 0},
-    {"remoteAddress", reinterpret_cast<getter>(ipConnectionInfoGetRemoteAddress), 0, PyDoc_STR("remote address"), 0},
-    {"remotePort", reinterpret_cast<getter>(ipConnectionInfoGetRemotePort), 0, PyDoc_STR("remote port"), 0},
-    {0, 0} /* sentinel */
+    {"localAddress",
+     reinterpret_cast<getter>(ipConnectionInfoGetLocalAddress),
+     nullptr,
+     PyDoc_STR("local address"),
+     nullptr},
+    {"localPort", reinterpret_cast<getter>(ipConnectionInfoGetLocalPort), nullptr, PyDoc_STR("local port"), nullptr},
+    {"remoteAddress",
+     reinterpret_cast<getter>(ipConnectionInfoGetRemoteAddress),
+     nullptr,
+     PyDoc_STR("remote address"),
+     nullptr},
+    {"remotePort", reinterpret_cast<getter>(ipConnectionInfoGetRemotePort), nullptr, PyDoc_STR("remote port"), nullptr},
+    {nullptr, nullptr} /* sentinel */
 };
 
 static PyGetSetDef TCPConnectionInfoGetters[] = {
-    {"rcvSize", reinterpret_cast<getter>(tcpConnectionInfoGetRcvSize), 0, PyDoc_STR("receive buffer size"), 0},
-    {"sndSize", reinterpret_cast<getter>(tcpConnectionInfoGetSndSize), 0, PyDoc_STR("send buffer size"), 0},
-    {0, 0} /* sentinel */
+    {"rcvSize",
+     reinterpret_cast<getter>(tcpConnectionInfoGetRcvSize),
+     nullptr,
+     PyDoc_STR("receive buffer size"),
+     nullptr},
+    {"sndSize", reinterpret_cast<getter>(tcpConnectionInfoGetSndSize), nullptr, PyDoc_STR("send buffer size"), nullptr},
+    {nullptr, nullptr} /* sentinel */
 };
 
 static PyGetSetDef UDPConnectionInfoGetters[] = {
-    {"mcastAddress", reinterpret_cast<getter>(udpConnectionInfoGetMcastAddress), 0, PyDoc_STR("multicast address"), 0},
-    {"mcastPort", reinterpret_cast<getter>(udpConnectionInfoGetMcastPort), 0, PyDoc_STR("multicast port"), 0},
-    {"rcvSize", reinterpret_cast<getter>(udpConnectionInfoGetRcvSize), 0, PyDoc_STR("receive buffer size"), 0},
-    {"sndSize", reinterpret_cast<getter>(udpConnectionInfoGetSndSize), 0, PyDoc_STR("send buffer size"), 0},
-    {0, 0} /* sentinel */
+    {"mcastAddress",
+     reinterpret_cast<getter>(udpConnectionInfoGetMcastAddress),
+     nullptr,
+     PyDoc_STR("multicast address"),
+     nullptr},
+    {"mcastPort",
+     reinterpret_cast<getter>(udpConnectionInfoGetMcastPort),
+     nullptr,
+     PyDoc_STR("multicast port"),
+     nullptr},
+    {"rcvSize",
+     reinterpret_cast<getter>(udpConnectionInfoGetRcvSize),
+     nullptr,
+     PyDoc_STR("receive buffer size"),
+     nullptr},
+    {"sndSize", reinterpret_cast<getter>(udpConnectionInfoGetSndSize), nullptr, PyDoc_STR("send buffer size"), nullptr},
+    {nullptr, nullptr} /* sentinel */
 };
 
 static PyGetSetDef WSConnectionInfoGetters[] = {
-    {"headers", reinterpret_cast<getter>(wsConnectionInfoGetHeaders), 0, PyDoc_STR("request headers"), 0},
-    {0, 0} /* sentinel */
+    {"headers", reinterpret_cast<getter>(wsConnectionInfoGetHeaders), nullptr, PyDoc_STR("request headers"), nullptr},
+    {nullptr, nullptr} /* sentinel */
 };
 
 static PyGetSetDef SSLConnectionInfoGetters[] = {
     {"peerCertificate",
      reinterpret_cast<getter>(sslConnectionInfoGetPeerCertificate),
-     0,
+     nullptr,
      PyDoc_STR("peer certificate"),
-     0},
-    {0, 0} /* sentinel */
+     nullptr},
+    {nullptr, nullptr} /* sentinel */
 };
 
 namespace IcePy
 {
+    // clang-format off
     PyTypeObject ConnectionInfoType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.ConnectionInfo", /* tp_name */
-        sizeof(ConnectionInfoObject),                       /* tp_basicsize */
-        0,                                                  /* tp_itemsize */
-        /* methods */
-        (destructor)connectionInfoDealloc,        /* tp_dealloc */
-        0,                                        /* tp_print */
-        0,                                        /* tp_getattr */
-        0,                                        /* tp_setattr */
-        0,                                        /* tp_reserved */
-        0,                                        /* tp_repr */
-        0,                                        /* tp_as_number */
-        0,                                        /* tp_as_sequence */
-        0,                                        /* tp_as_mapping */
-        0,                                        /* tp_hash */
-        0,                                        /* tp_call */
-        0,                                        /* tp_str */
-        0,                                        /* tp_getattro */
-        0,                                        /* tp_setattro */
-        0,                                        /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
-        0,                                        /* tp_doc */
-        0,                                        /* tp_traverse */
-        0,                                        /* tp_clear */
-        0,                                        /* tp_richcompare */
-        0,                                        /* tp_weaklistoffset */
-        0,                                        /* tp_iter */
-        0,                                        /* tp_iternext */
-        0,                                        /* tp_methods */
-        0,                                        /* tp_members */
-        ConnectionInfoGetters,                    /* tp_getset */
-        0,                                        /* tp_base */
-        0,                                        /* tp_dict */
-        0,                                        /* tp_descr_get */
-        0,                                        /* tp_descr_set */
-        0,                                        /* tp_dictoffset */
-        0,                                        /* tp_init */
-        0,                                        /* tp_alloc */
-        (newfunc)connectionInfoNew,               /* tp_new */
-        0,                                        /* tp_free */
-        0,                                        /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.ConnectionInfo",
+        .tp_basicsize = sizeof(ConnectionInfoObject),
+        .tp_dealloc = reinterpret_cast<destructor>(connectionInfoDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+        .tp_getset = ConnectionInfoGetters,
+        .tp_new = reinterpret_cast<newfunc>(connectionInfoNew),
     };
 
     PyTypeObject IPConnectionInfoType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.IPConnectionInfo", /* tp_name */
-        sizeof(ConnectionInfoObject),                         /* tp_basicsize */
-        0,                                                    /* tp_itemsize */
-        /* methods */
-        (destructor)connectionInfoDealloc,        /* tp_dealloc */
-        0,                                        /* tp_print */
-        0,                                        /* tp_getattr */
-        0,                                        /* tp_setattr */
-        0,                                        /* tp_reserved */
-        0,                                        /* tp_repr */
-        0,                                        /* tp_as_number */
-        0,                                        /* tp_as_sequence */
-        0,                                        /* tp_as_mapping */
-        0,                                        /* tp_hash */
-        0,                                        /* tp_call */
-        0,                                        /* tp_str */
-        0,                                        /* tp_getattro */
-        0,                                        /* tp_setattro */
-        0,                                        /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
-        0,                                        /* tp_doc */
-        0,                                        /* tp_traverse */
-        0,                                        /* tp_clear */
-        0,                                        /* tp_richcompare */
-        0,                                        /* tp_weaklistoffset */
-        0,                                        /* tp_iter */
-        0,                                        /* tp_iternext */
-        0,                                        /* tp_methods */
-        0,                                        /* tp_members */
-        IPConnectionInfoGetters,                  /* tp_getset */
-        0,                                        /* tp_base */
-        0,                                        /* tp_dict */
-        0,                                        /* tp_descr_get */
-        0,                                        /* tp_descr_set */
-        0,                                        /* tp_dictoffset */
-        0,                                        /* tp_init */
-        0,                                        /* tp_alloc */
-        (newfunc)connectionInfoNew,               /* tp_new */
-        0,                                        /* tp_free */
-        0,                                        /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.IPConnectionInfo",
+        .tp_basicsize = sizeof(ConnectionInfoObject),
+        .tp_dealloc = reinterpret_cast<destructor>(connectionInfoDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+        .tp_getset = IPConnectionInfoGetters,
+        .tp_new = reinterpret_cast<newfunc>(connectionInfoNew),
     };
 
     PyTypeObject TCPConnectionInfoType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.TCPConnectionInfo", /* tp_name */
-        sizeof(ConnectionInfoObject),                          /* tp_basicsize */
-        0,                                                     /* tp_itemsize */
-        /* methods */
-        (destructor)connectionInfoDealloc,        /* tp_dealloc */
-        0,                                        /* tp_print */
-        0,                                        /* tp_getattr */
-        0,                                        /* tp_setattr */
-        0,                                        /* tp_reserved */
-        0,                                        /* tp_repr */
-        0,                                        /* tp_as_number */
-        0,                                        /* tp_as_sequence */
-        0,                                        /* tp_as_mapping */
-        0,                                        /* tp_hash */
-        0,                                        /* tp_call */
-        0,                                        /* tp_str */
-        0,                                        /* tp_getattro */
-        0,                                        /* tp_setattro */
-        0,                                        /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
-        0,                                        /* tp_doc */
-        0,                                        /* tp_traverse */
-        0,                                        /* tp_clear */
-        0,                                        /* tp_richcompare */
-        0,                                        /* tp_weaklistoffset */
-        0,                                        /* tp_iter */
-        0,                                        /* tp_iternext */
-        0,                                        /* tp_methods */
-        0,                                        /* tp_members */
-        TCPConnectionInfoGetters,                 /* tp_getset */
-        0,                                        /* tp_base */
-        0,                                        /* tp_dict */
-        0,                                        /* tp_descr_get */
-        0,                                        /* tp_descr_set */
-        0,                                        /* tp_dictoffset */
-        0,                                        /* tp_init */
-        0,                                        /* tp_alloc */
-        (newfunc)connectionInfoNew,               /* tp_new */
-        0,                                        /* tp_free */
-        0,                                        /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.TCPConnectionInfo",
+        .tp_basicsize = sizeof(ConnectionInfoObject),
+        .tp_dealloc = reinterpret_cast<destructor>(connectionInfoDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+        .tp_getset = TCPConnectionInfoGetters,
+        .tp_new = reinterpret_cast<newfunc>(connectionInfoNew),
     };
 
     PyTypeObject UDPConnectionInfoType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.UDPConnectionInfo", /* tp_name */
-        sizeof(ConnectionInfoObject),                          /* tp_basicsize */
-        0,                                                     /* tp_itemsize */
-        /* methods */
-        (destructor)connectionInfoDealloc,        /* tp_dealloc */
-        0,                                        /* tp_print */
-        0,                                        /* tp_getattr */
-        0,                                        /* tp_setattr */
-        0,                                        /* tp_reserved */
-        0,                                        /* tp_repr */
-        0,                                        /* tp_as_number */
-        0,                                        /* tp_as_sequence */
-        0,                                        /* tp_as_mapping */
-        0,                                        /* tp_hash */
-        0,                                        /* tp_call */
-        0,                                        /* tp_str */
-        0,                                        /* tp_getattro */
-        0,                                        /* tp_setattro */
-        0,                                        /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
-        0,                                        /* tp_doc */
-        0,                                        /* tp_traverse */
-        0,                                        /* tp_clear */
-        0,                                        /* tp_richcompare */
-        0,                                        /* tp_weaklistoffset */
-        0,                                        /* tp_iter */
-        0,                                        /* tp_iternext */
-        0,                                        /* tp_methods */
-        0,                                        /* tp_members */
-        UDPConnectionInfoGetters,                 /* tp_getset */
-        0,                                        /* tp_base */
-        0,                                        /* tp_dict */
-        0,                                        /* tp_descr_get */
-        0,                                        /* tp_descr_set */
-        0,                                        /* tp_dictoffset */
-        0,                                        /* tp_init */
-        0,                                        /* tp_alloc */
-        (newfunc)connectionInfoNew,               /* tp_new */
-        0,                                        /* tp_free */
-        0,                                        /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.UDPConnectionInfo",
+        .tp_basicsize = sizeof(ConnectionInfoObject),
+        .tp_dealloc = reinterpret_cast<destructor>(connectionInfoDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+        .tp_getset = UDPConnectionInfoGetters,
+        .tp_new = reinterpret_cast<newfunc>(connectionInfoNew),
     };
 
     PyTypeObject WSConnectionInfoType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.WSConnectionInfo", /* tp_name */
-        sizeof(ConnectionInfoObject),                         /* tp_basicsize */
-        0,                                                    /* tp_itemsize */
-        /* methods */
-        (destructor)connectionInfoDealloc,        /* tp_dealloc */
-        0,                                        /* tp_print */
-        0,                                        /* tp_getattr */
-        0,                                        /* tp_setattr */
-        0,                                        /* tp_reserved */
-        0,                                        /* tp_repr */
-        0,                                        /* tp_as_number */
-        0,                                        /* tp_as_sequence */
-        0,                                        /* tp_as_mapping */
-        0,                                        /* tp_hash */
-        0,                                        /* tp_call */
-        0,                                        /* tp_str */
-        0,                                        /* tp_getattro */
-        0,                                        /* tp_setattro */
-        0,                                        /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
-        0,                                        /* tp_doc */
-        0,                                        /* tp_traverse */
-        0,                                        /* tp_clear */
-        0,                                        /* tp_richcompare */
-        0,                                        /* tp_weaklistoffset */
-        0,                                        /* tp_iter */
-        0,                                        /* tp_iternext */
-        0,                                        /* tp_methods */
-        0,                                        /* tp_members */
-        WSConnectionInfoGetters,                  /* tp_getset */
-        0,                                        /* tp_base */
-        0,                                        /* tp_dict */
-        0,                                        /* tp_descr_get */
-        0,                                        /* tp_descr_set */
-        0,                                        /* tp_dictoffset */
-        0,                                        /* tp_init */
-        0,                                        /* tp_alloc */
-        (newfunc)connectionInfoNew,               /* tp_new */
-        0,                                        /* tp_free */
-        0,                                        /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.WSConnectionInfo",
+        .tp_basicsize = sizeof(ConnectionInfoObject),
+        .tp_dealloc = reinterpret_cast<destructor>(connectionInfoDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+        .tp_getset = WSConnectionInfoGetters,
+        .tp_new = reinterpret_cast<newfunc>(connectionInfoNew),
     };
 
-    PyTypeObject SSLConnectionInfoType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.SSLConnectionInfo", /* tp_name */
-        sizeof(ConnectionInfoObject),                          /* tp_basicsize */
-        0,                                                     /* tp_itemsize */
-        /* methods */
-        (destructor)connectionInfoDealloc,        /* tp_dealloc */
-        0,                                        /* tp_print */
-        0,                                        /* tp_getattr */
-        0,                                        /* tp_setattr */
-        0,                                        /* tp_reserved */
-        0,                                        /* tp_repr */
-        0,                                        /* tp_as_number */
-        0,                                        /* tp_as_sequence */
-        0,                                        /* tp_as_mapping */
-        0,                                        /* tp_hash */
-        0,                                        /* tp_call */
-        0,                                        /* tp_str */
-        0,                                        /* tp_getattro */
-        0,                                        /* tp_setattro */
-        0,                                        /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
-        0,                                        /* tp_doc */
-        0,                                        /* tp_traverse */
-        0,                                        /* tp_clear */
-        0,                                        /* tp_richcompare */
-        0,                                        /* tp_weaklistoffset */
-        0,                                        /* tp_iter */
-        0,                                        /* tp_iternext */
-        0,                                        /* tp_methods */
-        0,                                        /* tp_members */
-        SSLConnectionInfoGetters,                 /* tp_getset */
-        0,                                        /* tp_base */
-        0,                                        /* tp_dict */
-        0,                                        /* tp_descr_get */
-        0,                                        /* tp_descr_set */
-        0,                                        /* tp_dictoffset */
-        0,                                        /* tp_init */
-        0,                                        /* tp_alloc */
-        (newfunc)connectionInfoNew,               /* tp_new */
-        0,                                        /* tp_free */
-        0,                                        /* tp_is_gc */
+    static PyTypeObject SSLConnectionInfoType = {
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.SSLConnectionInfo",
+        .tp_basicsize = sizeof(ConnectionInfoObject),
+        .tp_dealloc = reinterpret_cast<destructor>(connectionInfoDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+        .tp_getset = SSLConnectionInfoGetters,
+        .tp_new = reinterpret_cast<newfunc>(connectionInfoNew),
     };
+    // clang-format on
 }
 
 bool
@@ -500,8 +316,8 @@ IcePy::initConnectionInfo(PyObject* module)
     {
         return false;
     }
-    PyTypeObject* type = &ConnectionInfoType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "ConnectionInfo", reinterpret_cast<PyObject*>(type)) < 0)
+
+    if (PyModule_AddObject(module, "ConnectionInfo", reinterpret_cast<PyObject*>(&ConnectionInfoType)) < 0)
     {
         return false;
     }
@@ -511,8 +327,8 @@ IcePy::initConnectionInfo(PyObject* module)
     {
         return false;
     }
-    type = &IPConnectionInfoType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "IPConnectionInfo", reinterpret_cast<PyObject*>(type)) < 0)
+
+    if (PyModule_AddObject(module, "IPConnectionInfo", reinterpret_cast<PyObject*>(&IPConnectionInfoType)) < 0)
     {
         return false;
     }
@@ -522,8 +338,8 @@ IcePy::initConnectionInfo(PyObject* module)
     {
         return false;
     }
-    type = &TCPConnectionInfoType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "TCPConnectionInfo", reinterpret_cast<PyObject*>(type)) < 0)
+
+    if (PyModule_AddObject(module, "TCPConnectionInfo", reinterpret_cast<PyObject*>(&TCPConnectionInfoType)) < 0)
     {
         return false;
     }
@@ -533,8 +349,8 @@ IcePy::initConnectionInfo(PyObject* module)
     {
         return false;
     }
-    type = &UDPConnectionInfoType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "UDPConnectionInfo", reinterpret_cast<PyObject*>(type)) < 0)
+
+    if (PyModule_AddObject(module, "UDPConnectionInfo", reinterpret_cast<PyObject*>(&UDPConnectionInfoType)) < 0)
     {
         return false;
     }
@@ -544,8 +360,8 @@ IcePy::initConnectionInfo(PyObject* module)
     {
         return false;
     }
-    type = &WSConnectionInfoType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "WSConnectionInfo", reinterpret_cast<PyObject*>(type)) < 0)
+
+    if (PyModule_AddObject(module, "WSConnectionInfo", reinterpret_cast<PyObject*>(&WSConnectionInfoType)) < 0)
     {
         return false;
     }
@@ -555,8 +371,8 @@ IcePy::initConnectionInfo(PyObject* module)
     {
         return false;
     }
-    type = &SSLConnectionInfoType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "SSLConnectionInfo", reinterpret_cast<PyObject*>(type)) < 0)
+
+    if (PyModule_AddObject(module, "SSLConnectionInfo", reinterpret_cast<PyObject*>(&SSLConnectionInfoType)) < 0)
     {
         return false;
     }
@@ -568,7 +384,7 @@ Ice::ConnectionInfoPtr
 IcePy::getConnectionInfo(PyObject* obj)
 {
     assert(PyObject_IsInstance(obj, reinterpret_cast<PyObject*>(&ConnectionInfoType)));
-    ConnectionInfoObject* eobj = reinterpret_cast<ConnectionInfoObject*>(obj);
+    auto* eobj = reinterpret_cast<ConnectionInfoObject*>(obj);
     return *eobj->connectionInfo;
 }
 
@@ -606,7 +422,7 @@ IcePy::createConnectionInfo(const Ice::ConnectionInfoPtr& connectionInfo)
         type = &ConnectionInfoType;
     }
 
-    ConnectionInfoObject* obj = reinterpret_cast<ConnectionInfoObject*>(type->tp_alloc(type, 0));
+    auto* obj = reinterpret_cast<ConnectionInfoObject*>(type->tp_alloc(type, 0));
     if (!obj)
     {
         return nullptr;

--- a/python/modules/IcePy/Current.cpp
+++ b/python/modules/IcePy/Current.cpp
@@ -12,11 +12,11 @@ using namespace IcePy;
 PyObject*
 IcePy::createCurrent(const Ice::Current& current)
 {
-    PyObject* currentType = lookupType("Ice.Current");
+    PyObject* currentType{lookupType("Ice.Current")};
 
     PyObjectHandle args{PyTuple_New(9)};
 
-    PyObject* adapter = wrapObjectAdapter(current.adapter);
+    PyObject* adapter{wrapObjectAdapter(current.adapter)};
     if (!adapter)
     {
         return nullptr;
@@ -25,7 +25,7 @@ IcePy::createCurrent(const Ice::Current& current)
 
     if (current.con)
     {
-        PyObject* connection = createConnection(current.con, current.adapter->getCommunicator());
+        PyObject* connection{createConnection(current.con, current.adapter->getCommunicator())};
         if (!connection)
         {
             return nullptr;
@@ -37,21 +37,21 @@ IcePy::createCurrent(const Ice::Current& current)
         PyTuple_SetItem(args.get(), 1, Py_None);
     }
 
-    PyObject* id = createIdentity(current.id);
+    PyObject* id{createIdentity(current.id)};
     if (!id)
     {
         return nullptr;
     }
     PyTuple_SetItem(args.get(), 2, id);
 
-    PyObject* facet = createString(current.facet);
+    PyObject* facet{createString(current.facet)};
     if (!facet)
     {
         return nullptr;
     }
     PyTuple_SetItem(args.get(), 3, facet);
 
-    PyObject* operation = createString(current.operation);
+    PyObject* operation{createString(current.operation)};
     if (!operation)
     {
         return nullptr;
@@ -60,7 +60,7 @@ IcePy::createCurrent(const Ice::Current& current)
 
     PyObject* operationModeType = lookupType("Ice.OperationMode");
     assert(operationModeType);
-    const char* enumerator = nullptr;
+    const char* enumerator{nullptr};
     switch (current.mode)
     {
         case Ice::OperationMode::Normal:
@@ -84,14 +84,14 @@ IcePy::createCurrent(const Ice::Current& current)
     }
     PyTuple_SetItem(args.get(), 6, ctx.release());
 
-    PyObject* requestId = PyLong_FromLong(current.requestId);
+    PyObject* requestId{PyLong_FromLong(current.requestId)};
     if (!requestId)
     {
         return nullptr;
     }
     PyTuple_SetItem(args.get(), 7, requestId);
 
-    PyObject* encoding = IcePy::createEncodingVersion(current.encoding);
+    PyObject* encoding{IcePy::createEncodingVersion(current.encoding)};
     if (!encoding)
     {
         return nullptr;

--- a/python/modules/IcePy/EndpointInfo.cpp
+++ b/python/modules/IcePy/EndpointInfo.cpp
@@ -36,16 +36,7 @@ extern "C" PyObject*
 endpointInfoType(EndpointInfoObject* self, PyObject* /*args*/)
 {
     assert(self->endpointInfo);
-    try
-    {
-        int16_t type = (*self->endpointInfo)->type();
-        return PyLong_FromLong(type);
-    }
-    catch (...)
-    {
-        setPythonException(current_exception());
-        return nullptr;
-    }
+    return PyLong_FromLong((*self->endpointInfo)->type());
 }
 
 //
@@ -55,19 +46,7 @@ extern "C" PyObject*
 endpointInfoDatagram(EndpointInfoObject* self, PyObject* /*args*/)
 {
     assert(self->endpointInfo);
-    PyObject* b;
-    try
-    {
-        b = (*self->endpointInfo)->datagram() ? Py_True : Py_False;
-    }
-    catch (...)
-    {
-        setPythonException(current_exception());
-        return nullptr;
-    }
-
-    Py_INCREF(b);
-    return b;
+    return (*self->endpointInfo)->datagram() ? Py_True : Py_False;
 }
 
 //
@@ -77,19 +56,7 @@ extern "C" PyObject*
 endpointInfoSecure(EndpointInfoObject* self, PyObject* /*args*/)
 {
     assert(self->endpointInfo);
-    PyObject* b;
-    try
-    {
-        b = (*self->endpointInfo)->secure() ? Py_True : Py_False;
-    }
-    catch (...)
-    {
-        setPythonException(current_exception());
-        return nullptr;
-    }
-
-    Py_INCREF(b);
-    return b;
+    return (*self->endpointInfo)->secure() ? Py_True : Py_False;
 }
 
 extern "C" PyObject*
@@ -180,368 +147,136 @@ static PyMethodDef EndpointInfoMethods[] = {
     {"type", reinterpret_cast<PyCFunction>(endpointInfoType), METH_NOARGS, PyDoc_STR("type() -> int")},
     {"datagram", reinterpret_cast<PyCFunction>(endpointInfoDatagram), METH_NOARGS, PyDoc_STR("datagram() -> bool")},
     {"secure", reinterpret_cast<PyCFunction>(endpointInfoSecure), METH_NOARGS, PyDoc_STR("secure() -> bool")},
-    {0, 0} /* sentinel */
+    {nullptr, nullptr} /* sentinel */
 };
 
 static PyGetSetDef EndpointInfoGetters[] = {
     {"underlying",
      reinterpret_cast<getter>(endpointInfoGetUnderlying),
-     0,
+     nullptr,
      PyDoc_STR("underling endpoint information"),
-     0},
-    {"timeout", reinterpret_cast<getter>(endpointInfoGetTimeout), 0, PyDoc_STR("timeout in milliseconds"), 0},
-    {"compress", reinterpret_cast<getter>(endpointInfoGetCompress), 0, PyDoc_STR("compression status"), 0},
-    {0, 0} /* sentinel */
+     nullptr},
+    {"timeout",
+     reinterpret_cast<getter>(endpointInfoGetTimeout),
+     nullptr,
+     PyDoc_STR("timeout in milliseconds"),
+     nullptr},
+    {"compress", reinterpret_cast<getter>(endpointInfoGetCompress), nullptr, PyDoc_STR("compression status"), nullptr},
+    {nullptr, nullptr} /* sentinel */
 };
 
 static PyGetSetDef IPEndpointInfoGetters[] = {
-    {"host", reinterpret_cast<getter>(ipEndpointInfoGetHost), 0, PyDoc_STR("host name or IP address"), 0},
-    {"port", reinterpret_cast<getter>(ipEndpointInfoGetPort), 0, PyDoc_STR("TCP port number"), 0},
-    {"sourceAddress", reinterpret_cast<getter>(ipEndpointInfoGetSourceAddress), 0, PyDoc_STR("source IP address"), 0},
-    {0, 0} /* sentinel */
+    {"host", reinterpret_cast<getter>(ipEndpointInfoGetHost), nullptr, PyDoc_STR("host name or IP address"), nullptr},
+    {"port", reinterpret_cast<getter>(ipEndpointInfoGetPort), nullptr, PyDoc_STR("TCP port number"), nullptr},
+    {"sourceAddress",
+     reinterpret_cast<getter>(ipEndpointInfoGetSourceAddress),
+     nullptr,
+     PyDoc_STR("source IP address"),
+     nullptr},
+    {nullptr, nullptr} /* sentinel */
 };
 
 static PyGetSetDef UDPEndpointInfoGetters[] = {
     {"mcastInterface",
      reinterpret_cast<getter>(udpEndpointInfoGetMcastInterface),
-     0,
+     nullptr,
      PyDoc_STR("multicast interface"),
-     0},
-    {"mcastTtl", reinterpret_cast<getter>(udpEndpointInfoGetMcastTtl), 0, PyDoc_STR("multicast time-to-live"), 0},
-    {0, 0} /* sentinel */
+     nullptr},
+    {"mcastTtl",
+     reinterpret_cast<getter>(udpEndpointInfoGetMcastTtl),
+     nullptr,
+     PyDoc_STR("multicast time-to-live"),
+     nullptr},
+    {nullptr, nullptr} /* sentinel */
 };
 
 static PyGetSetDef WSEndpointInfoGetters[] = {
-    {"resource", reinterpret_cast<getter>(wsEndpointInfoGetResource), 0, PyDoc_STR("resource"), 0},
-    {0, 0} /* sentinel */
+    {"resource", reinterpret_cast<getter>(wsEndpointInfoGetResource), nullptr, PyDoc_STR("resource"), nullptr},
+    {nullptr, nullptr} /* sentinel */
 };
 
 static PyGetSetDef OpaqueEndpointInfoGetters[] = {
-    {"rawBytes", reinterpret_cast<getter>(opaqueEndpointInfoGetRawBytes), 0, PyDoc_STR("raw encoding"), 0},
+    {"rawBytes", reinterpret_cast<getter>(opaqueEndpointInfoGetRawBytes), nullptr, PyDoc_STR("raw encoding"), nullptr},
     {"rawEncoding",
      reinterpret_cast<getter>(opaqueEndpointInfoGetRawEncoding),
-     0,
+     nullptr,
      PyDoc_STR("raw encoding version"),
-     0},
-    {0, 0} /* sentinel */
+     nullptr},
+    {nullptr, nullptr} /* sentinel */
 };
 
 namespace IcePy
 {
+    // clang-format off
     PyTypeObject EndpointInfoType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.EndpointInfo", /* tp_name */
-        sizeof(EndpointInfoObject),                       /* tp_basicsize */
-        0,                                                /* tp_itemsize */
-        /* methods */
-        reinterpret_cast<destructor>(endpointInfoDealloc), /* tp_dealloc */
-        0,                                                 /* tp_print */
-        0,                                                 /* tp_getattr */
-        0,                                                 /* tp_setattr */
-        0,                                                 /* tp_reserved */
-        0,                                                 /* tp_repr */
-        0,                                                 /* tp_as_number */
-        0,                                                 /* tp_as_sequence */
-        0,                                                 /* tp_as_mapping */
-        0,                                                 /* tp_hash */
-        0,                                                 /* tp_call */
-        0,                                                 /* tp_str */
-        0,                                                 /* tp_getattro */
-        0,                                                 /* tp_setattro */
-        0,                                                 /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,          /* tp_flags */
-        0,                                                 /* tp_doc */
-        0,                                                 /* tp_traverse */
-        0,                                                 /* tp_clear */
-        0,                                                 /* tp_richcompare */
-        0,                                                 /* tp_weaklistoffset */
-        0,                                                 /* tp_iter */
-        0,                                                 /* tp_iternext */
-        EndpointInfoMethods,                               /* tp_methods */
-        0,                                                 /* tp_members */
-        EndpointInfoGetters,                               /* tp_getset */
-        0,                                                 /* tp_base */
-        0,                                                 /* tp_dict */
-        0,                                                 /* tp_descr_get */
-        0,                                                 /* tp_descr_set */
-        0,                                                 /* tp_dictoffset */
-        0,                                                 /* tp_init */
-        0,                                                 /* tp_alloc */
-        reinterpret_cast<newfunc>(endpointInfoNew),        /* tp_new */
-        0,                                                 /* tp_free */
-        0,                                                 /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.EndpointInfo",
+        .tp_basicsize = sizeof(EndpointInfoObject),
+        .tp_dealloc = reinterpret_cast<destructor>(endpointInfoDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+        .tp_methods = EndpointInfoMethods,
+        .tp_getset = EndpointInfoGetters,
+        .tp_new = reinterpret_cast<newfunc>(endpointInfoNew),
     };
 
     PyTypeObject IPEndpointInfoType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.IPEndpointInfo", /* tp_name */
-        sizeof(EndpointInfoObject),                         /* tp_basicsize */
-        0,                                                  /* tp_itemsize */
-        /* methods */
-        reinterpret_cast<destructor>(endpointInfoDealloc), /* tp_dealloc */
-        0,                                                 /* tp_print */
-        0,                                                 /* tp_getattr */
-        0,                                                 /* tp_setattr */
-        0,                                                 /* tp_reserved */
-        0,                                                 /* tp_repr */
-        0,                                                 /* tp_as_number */
-        0,                                                 /* tp_as_sequence */
-        0,                                                 /* tp_as_mapping */
-        0,                                                 /* tp_hash */
-        0,                                                 /* tp_call */
-        0,                                                 /* tp_str */
-        0,                                                 /* tp_getattro */
-        0,                                                 /* tp_setattro */
-        0,                                                 /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,          /* tp_flags */
-        0,                                                 /* tp_doc */
-        0,                                                 /* tp_traverse */
-        0,                                                 /* tp_clear */
-        0,                                                 /* tp_richcompare */
-        0,                                                 /* tp_weaklistoffset */
-        0,                                                 /* tp_iter */
-        0,                                                 /* tp_iternext */
-        0,                                                 /* tp_methods */
-        0,                                                 /* tp_members */
-        IPEndpointInfoGetters,                             /* tp_getset */
-        0,                                                 /* tp_base */
-        0,                                                 /* tp_dict */
-        0,                                                 /* tp_descr_get */
-        0,                                                 /* tp_descr_set */
-        0,                                                 /* tp_dictoffset */
-        0,                                                 /* tp_init */
-        0,                                                 /* tp_alloc */
-        reinterpret_cast<newfunc>(endpointInfoNew),        /* tp_new */
-        0,                                                 /* tp_free */
-        0,                                                 /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.IPEndpointInfo",
+        .tp_basicsize = sizeof(EndpointInfoObject),
+        .tp_dealloc = reinterpret_cast<destructor>(endpointInfoDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+        .tp_getset = IPEndpointInfoGetters,
+        .tp_new = reinterpret_cast<newfunc>(endpointInfoNew),
     };
 
     PyTypeObject TCPEndpointInfoType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.TCPEndpointInfo", /* tp_name */
-        sizeof(EndpointInfoObject),                          /* tp_basicsize */
-        0,                                                   /* tp_itemsize */
-        /* methods */
-        reinterpret_cast<destructor>(endpointInfoDealloc), /* tp_dealloc */
-        0,                                                 /* tp_print */
-        0,                                                 /* tp_getattr */
-        0,                                                 /* tp_setattr */
-        0,                                                 /* tp_reserved */
-        0,                                                 /* tp_repr */
-        0,                                                 /* tp_as_number */
-        0,                                                 /* tp_as_sequence */
-        0,                                                 /* tp_as_mapping */
-        0,                                                 /* tp_hash */
-        0,                                                 /* tp_call */
-        0,                                                 /* tp_str */
-        0,                                                 /* tp_getattro */
-        0,                                                 /* tp_setattro */
-        0,                                                 /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,          /* tp_flags */
-        0,                                                 /* tp_doc */
-        0,                                                 /* tp_traverse */
-        0,                                                 /* tp_clear */
-        0,                                                 /* tp_richcompare */
-        0,                                                 /* tp_weaklistoffset */
-        0,                                                 /* tp_iter */
-        0,                                                 /* tp_iternext */
-        0,                                                 /* tp_methods */
-        0,                                                 /* tp_members */
-        0,                                                 /* tp_getset */
-        0,                                                 /* tp_base */
-        0,                                                 /* tp_dict */
-        0,                                                 /* tp_descr_get */
-        0,                                                 /* tp_descr_set */
-        0,                                                 /* tp_dictoffset */
-        0,                                                 /* tp_init */
-        0,                                                 /* tp_alloc */
-        reinterpret_cast<newfunc>(endpointInfoNew),        /* tp_new */
-        0,                                                 /* tp_free */
-        0,                                                 /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.TCPEndpointInfo",
+        .tp_basicsize = sizeof(EndpointInfoObject),
+        .tp_dealloc = reinterpret_cast<destructor>(endpointInfoDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+        .tp_new = reinterpret_cast<newfunc>(endpointInfoNew),
     };
 
     PyTypeObject UDPEndpointInfoType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.UDPEndpointInfo", /* tp_name */
-        sizeof(EndpointInfoObject),                          /* tp_basicsize */
-        0,                                                   /* tp_itemsize */
-        /* methods */
-        reinterpret_cast<destructor>(endpointInfoDealloc), /* tp_dealloc */
-        0,                                                 /* tp_print */
-        0,                                                 /* tp_getattr */
-        0,                                                 /* tp_setattr */
-        0,                                                 /* tp_reserved */
-        0,                                                 /* tp_repr */
-        0,                                                 /* tp_as_number */
-        0,                                                 /* tp_as_sequence */
-        0,                                                 /* tp_as_mapping */
-        0,                                                 /* tp_hash */
-        0,                                                 /* tp_call */
-        0,                                                 /* tp_str */
-        0,                                                 /* tp_getattro */
-        0,                                                 /* tp_setattro */
-        0,                                                 /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,          /* tp_flags */
-        0,                                                 /* tp_doc */
-        0,                                                 /* tp_traverse */
-        0,                                                 /* tp_clear */
-        0,                                                 /* tp_richcompare */
-        0,                                                 /* tp_weaklistoffset */
-        0,                                                 /* tp_iter */
-        0,                                                 /* tp_iternext */
-        0,                                                 /* tp_methods */
-        0,                                                 /* tp_members */
-        UDPEndpointInfoGetters,                            /* tp_getset */
-        0,                                                 /* tp_base */
-        0,                                                 /* tp_dict */
-        0,                                                 /* tp_descr_get */
-        0,                                                 /* tp_descr_set */
-        0,                                                 /* tp_dictoffset */
-        0,                                                 /* tp_init */
-        0,                                                 /* tp_alloc */
-        reinterpret_cast<newfunc>(endpointInfoNew),        /* tp_new */
-        0,                                                 /* tp_free */
-        0,                                                 /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.UDPEndpointInfo",
+        .tp_basicsize = sizeof(EndpointInfoObject),
+        .tp_dealloc = reinterpret_cast<destructor>(endpointInfoDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+        .tp_getset = UDPEndpointInfoGetters,
+        .tp_new = reinterpret_cast<newfunc>(endpointInfoNew),
     };
 
     PyTypeObject WSEndpointInfoType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.WSEndpointInfo", /* tp_name */
-        sizeof(EndpointInfoObject),                         /* tp_basicsize */
-        0,                                                  /* tp_itemsize */
-        /* methods */
-        reinterpret_cast<destructor>(endpointInfoDealloc), /* tp_dealloc */
-        0,                                                 /* tp_print */
-        0,                                                 /* tp_getattr */
-        0,                                                 /* tp_setattr */
-        0,                                                 /* tp_reserved */
-        0,                                                 /* tp_repr */
-        0,                                                 /* tp_as_number */
-        0,                                                 /* tp_as_sequence */
-        0,                                                 /* tp_as_mapping */
-        0,                                                 /* tp_hash */
-        0,                                                 /* tp_call */
-        0,                                                 /* tp_str */
-        0,                                                 /* tp_getattro */
-        0,                                                 /* tp_setattro */
-        0,                                                 /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,          /* tp_flags */
-        0,                                                 /* tp_doc */
-        0,                                                 /* tp_traverse */
-        0,                                                 /* tp_clear */
-        0,                                                 /* tp_richcompare */
-        0,                                                 /* tp_weaklistoffset */
-        0,                                                 /* tp_iter */
-        0,                                                 /* tp_iternext */
-        0,                                                 /* tp_methods */
-        0,                                                 /* tp_members */
-        WSEndpointInfoGetters,                             /* tp_getset */
-        0,                                                 /* tp_base */
-        0,                                                 /* tp_dict */
-        0,                                                 /* tp_descr_get */
-        0,                                                 /* tp_descr_set */
-        0,                                                 /* tp_dictoffset */
-        0,                                                 /* tp_init */
-        0,                                                 /* tp_alloc */
-        reinterpret_cast<newfunc>(endpointInfoNew),        /* tp_new */
-        0,                                                 /* tp_free */
-        0,                                                 /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.WSEndpointInfo",
+        .tp_basicsize = sizeof(EndpointInfoObject),
+        .tp_dealloc = reinterpret_cast<destructor>(endpointInfoDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+        .tp_getset = WSEndpointInfoGetters,
+        .tp_new = reinterpret_cast<newfunc>(endpointInfoNew),
     };
 
     PyTypeObject SSLEndpointInfoType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.SSLEndpointInfo", /* tp_name */
-        sizeof(EndpointInfoObject),                          /* tp_basicsize */
-        0,                                                   /* tp_itemsize */
-        /* methods */
-        reinterpret_cast<destructor>(endpointInfoDealloc), /* tp_dealloc */
-        0,                                                 /* tp_print */
-        0,                                                 /* tp_getattr */
-        0,                                                 /* tp_setattr */
-        0,                                                 /* tp_reserved */
-        0,                                                 /* tp_repr */
-        0,                                                 /* tp_as_number */
-        0,                                                 /* tp_as_sequence */
-        0,                                                 /* tp_as_mapping */
-        0,                                                 /* tp_hash */
-        0,                                                 /* tp_call */
-        0,                                                 /* tp_str */
-        0,                                                 /* tp_getattro */
-        0,                                                 /* tp_setattro */
-        0,                                                 /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,          /* tp_flags */
-        0,                                                 /* tp_doc */
-        0,                                                 /* tp_traverse */
-        0,                                                 /* tp_clear */
-        0,                                                 /* tp_richcompare */
-        0,                                                 /* tp_weaklistoffset */
-        0,                                                 /* tp_iter */
-        0,                                                 /* tp_iternext */
-        0,                                                 /* tp_methods */
-        0,                                                 /* tp_members */
-        0,                                                 /* tp_getset */
-        0,                                                 /* tp_base */
-        0,                                                 /* tp_dict */
-        0,                                                 /* tp_descr_get */
-        0,                                                 /* tp_descr_set */
-        0,                                                 /* tp_dictoffset */
-        0,                                                 /* tp_init */
-        0,                                                 /* tp_alloc */
-        reinterpret_cast<newfunc>(endpointInfoNew),        /* tp_new */
-        0,                                                 /* tp_free */
-        0,                                                 /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.SSLEndpointInfo",
+        .tp_basicsize = sizeof(EndpointInfoObject),
+        .tp_dealloc = reinterpret_cast<destructor>(endpointInfoDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+        .tp_new = reinterpret_cast<newfunc>(endpointInfoNew),
     };
 
     PyTypeObject OpaqueEndpointInfoType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.OpaqueEndpointInfo", /* tp_name */
-        sizeof(EndpointInfoObject),                             /* tp_basicsize */
-        0,                                                      /* tp_itemsize */
-        /* methods */
-        reinterpret_cast<destructor>(endpointInfoDealloc), /* tp_dealloc */
-        0,                                                 /* tp_print */
-        0,                                                 /* tp_getattr */
-        0,                                                 /* tp_setattr */
-        0,                                                 /* tp_reserved */
-        0,                                                 /* tp_repr */
-        0,                                                 /* tp_as_number */
-        0,                                                 /* tp_as_sequence */
-        0,                                                 /* tp_as_mapping */
-        0,                                                 /* tp_hash */
-        0,                                                 /* tp_call */
-        0,                                                 /* tp_str */
-        0,                                                 /* tp_getattro */
-        0,                                                 /* tp_setattro */
-        0,                                                 /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,          /* tp_flags */
-        0,                                                 /* tp_doc */
-        0,                                                 /* tp_traverse */
-        0,                                                 /* tp_clear */
-        0,                                                 /* tp_richcompare */
-        0,                                                 /* tp_weaklistoffset */
-        0,                                                 /* tp_iter */
-        0,                                                 /* tp_iternext */
-        0,                                                 /* tp_methods */
-        0,                                                 /* tp_members */
-        OpaqueEndpointInfoGetters,                         /* tp_getset */
-        0,                                                 /* tp_base */
-        0,                                                 /* tp_dict */
-        0,                                                 /* tp_descr_get */
-        0,                                                 /* tp_descr_set */
-        0,                                                 /* tp_dictoffset */
-        0,                                                 /* tp_init */
-        0,                                                 /* tp_alloc */
-        reinterpret_cast<newfunc>(endpointInfoNew),        /* tp_new */
-        0,                                                 /* tp_free */
-        0,                                                 /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.OpaqueEndpointInfo",
+        .tp_basicsize = sizeof(EndpointInfoObject),
+        .tp_dealloc = reinterpret_cast<destructor>(endpointInfoDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+        .tp_getset = OpaqueEndpointInfoGetters,
+        .tp_new = reinterpret_cast<newfunc>(endpointInfoNew),
     };
+    // clang-format on
 }
 
 bool
@@ -551,8 +286,8 @@ IcePy::initEndpointInfo(PyObject* module)
     {
         return false;
     }
-    PyTypeObject* type = &EndpointInfoType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "EndpointInfo", reinterpret_cast<PyObject*>(type)) < 0)
+
+    if (PyModule_AddObject(module, "EndpointInfo", reinterpret_cast<PyObject*>(&EndpointInfoType)) < 0)
     {
         return false;
     }
@@ -562,8 +297,8 @@ IcePy::initEndpointInfo(PyObject* module)
     {
         return false;
     }
-    type = &IPEndpointInfoType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "IPEndpointInfo", reinterpret_cast<PyObject*>(type)) < 0)
+
+    if (PyModule_AddObject(module, "IPEndpointInfo", reinterpret_cast<PyObject*>(&IPEndpointInfoType)) < 0)
     {
         return false;
     }
@@ -573,8 +308,8 @@ IcePy::initEndpointInfo(PyObject* module)
     {
         return false;
     }
-    type = &TCPEndpointInfoType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "TCPEndpointInfo", reinterpret_cast<PyObject*>(type)) < 0)
+
+    if (PyModule_AddObject(module, "TCPEndpointInfo", reinterpret_cast<PyObject*>(&TCPEndpointInfoType)) < 0)
     {
         return false;
     }
@@ -584,8 +319,8 @@ IcePy::initEndpointInfo(PyObject* module)
     {
         return false;
     }
-    type = &UDPEndpointInfoType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "UDPEndpointInfo", reinterpret_cast<PyObject*>(type)) < 0)
+
+    if (PyModule_AddObject(module, "UDPEndpointInfo", reinterpret_cast<PyObject*>(&UDPEndpointInfoType)) < 0)
     {
         return false;
     }
@@ -595,8 +330,8 @@ IcePy::initEndpointInfo(PyObject* module)
     {
         return false;
     }
-    type = &WSEndpointInfoType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "WSEndpointInfo", reinterpret_cast<PyObject*>(type)) < 0)
+
+    if (PyModule_AddObject(module, "WSEndpointInfo", reinterpret_cast<PyObject*>(&WSEndpointInfoType)) < 0)
     {
         return false;
     }
@@ -606,8 +341,8 @@ IcePy::initEndpointInfo(PyObject* module)
     {
         return false;
     }
-    type = &SSLEndpointInfoType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "SSLEndpointInfo", reinterpret_cast<PyObject*>(type)) < 0)
+
+    if (PyModule_AddObject(module, "SSLEndpointInfo", reinterpret_cast<PyObject*>(&SSLEndpointInfoType)) < 0)
     {
         return false;
     }
@@ -617,8 +352,8 @@ IcePy::initEndpointInfo(PyObject* module)
     {
         return false;
     }
-    type = &OpaqueEndpointInfoType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "OpaqueEndpointInfo", reinterpret_cast<PyObject*>(type)) < 0)
+
+    if (PyModule_AddObject(module, "OpaqueEndpointInfo", reinterpret_cast<PyObject*>(&OpaqueEndpointInfoType)) < 0)
     {
         return false;
     }
@@ -630,7 +365,7 @@ Ice::EndpointInfoPtr
 IcePy::getEndpointInfo(PyObject* obj)
 {
     assert(PyObject_IsInstance(obj, reinterpret_cast<PyObject*>(&EndpointInfoType)));
-    EndpointInfoObject* eobj = reinterpret_cast<EndpointInfoObject*>(obj);
+    auto* eobj = reinterpret_cast<EndpointInfoObject*>(obj);
     return *eobj->endpointInfo;
 }
 
@@ -672,7 +407,7 @@ IcePy::createEndpointInfo(const Ice::EndpointInfoPtr& endpointInfo)
         type = &EndpointInfoType;
     }
 
-    EndpointInfoObject* obj = reinterpret_cast<EndpointInfoObject*>(type->tp_alloc(type, 0));
+    auto* obj = reinterpret_cast<EndpointInfoObject*>(type->tp_alloc(type, 0));
     if (!obj)
     {
         return nullptr;

--- a/python/modules/IcePy/Executor.cpp
+++ b/python/modules/IcePy/Executor.cpp
@@ -31,7 +31,8 @@ executorCallInvoke(ExecutorCallObject* self, PyObject* /*args*/, PyObject* /*kwd
 {
     try
     {
-        AllowThreads allowThreads; // Release Python's global interpreter lock during blocking calls.
+        // Release Python's global interpreter lock during blocking calls.
+        AllowThreads allowThreads;
         (*self->call)();
     }
     catch (...)
@@ -45,50 +46,16 @@ executorCallInvoke(ExecutorCallObject* self, PyObject* /*args*/, PyObject* /*kwd
 
 namespace IcePy
 {
+    // clang-format off
     PyTypeObject ExecutorCallType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.ExecutorCall", /* tp_name */
-        sizeof(ExecutorCallObject),                       /* tp_basicsize */
-        0,                                                /* tp_itemsize */
-        /* methods */
-        reinterpret_cast<destructor>(executorCallDealloc), /* tp_dealloc */
-        0,                                                 /* tp_print */
-        0,                                                 /* tp_getattr */
-        0,                                                 /* tp_setattr */
-        0,                                                 /* tp_reserved */
-        0,                                                 /* tp_repr */
-        0,                                                 /* tp_as_number */
-        0,                                                 /* tp_as_sequence */
-        0,                                                 /* tp_as_mapping */
-        0,                                                 /* tp_hash */
-        reinterpret_cast<ternaryfunc>(executorCallInvoke), /* tp_call */
-        0,                                                 /* tp_str */
-        0,                                                 /* tp_getattro */
-        0,                                                 /* tp_setattro */
-        0,                                                 /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT,                                /* tp_flags */
-        0,                                                 /* tp_doc */
-        0,                                                 /* tp_traverse */
-        0,                                                 /* tp_clear */
-        0,                                                 /* tp_richcompare */
-        0,                                                 /* tp_weaklistoffset */
-        0,                                                 /* tp_iter */
-        0,                                                 /* tp_iternext */
-        0,                                                 /* tp_methods */
-        0,                                                 /* tp_members */
-        0,                                                 /* tp_getset */
-        0,                                                 /* tp_base */
-        0,                                                 /* tp_dict */
-        0,                                                 /* tp_descr_get */
-        0,                                                 /* tp_descr_set */
-        0,                                                 /* tp_dictoffset */
-        0,                                                 /* tp_init */
-        0,                                                 /* tp_alloc */
-        0,                                                 /* tp_new */
-        0,                                                 /* tp_free */
-        0,                                                 /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.ExecutorCall",
+        .tp_basicsize = sizeof(ExecutorCallObject),
+        .tp_dealloc = reinterpret_cast<destructor>(executorCallDealloc),
+        .tp_call = reinterpret_cast<ternaryfunc>(executorCallInvoke),
+        .tp_flags = Py_TPFLAGS_DEFAULT,
     };
+    // clang-format on
 }
 
 bool
@@ -98,8 +65,8 @@ IcePy::initExecutor(PyObject* module)
     {
         return false;
     }
-    PyTypeObject* type = &ExecutorCallType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "ExecutorCall", reinterpret_cast<PyObject*>(type)) < 0)
+
+    if (PyModule_AddObject(module, "ExecutorCall", reinterpret_cast<PyObject*>(&ExecutorCallType)) < 0)
     {
         return false;
     }

--- a/python/modules/IcePy/ImplicitContext.cpp
+++ b/python/modules/IcePy/ImplicitContext.cpp
@@ -22,12 +22,12 @@ namespace IcePy
 extern "C" ImplicitContextObject*
 implicitContextNew(PyTypeObject* type, PyObject* /*args*/, PyObject* /*kwds*/)
 {
-    ImplicitContextObject* self = reinterpret_cast<ImplicitContextObject*>(type->tp_alloc(type, 0));
+    auto* self = reinterpret_cast<ImplicitContextObject*>(type->tp_alloc(type, 0));
     if (!self)
     {
         return nullptr;
     }
-    self->implicitContext = 0;
+    self->implicitContext = nullptr;
     return self;
 }
 
@@ -41,11 +41,11 @@ implicitContextDealloc(ImplicitContextObject* self)
 extern "C" PyObject*
 implicitContextCompare(ImplicitContextObject* c1, PyObject* other, int op)
 {
-    bool result = false;
+    bool result{false};
 
     if (PyObject_TypeCheck(other, &ImplicitContextType))
     {
-        ImplicitContextObject* c2 = reinterpret_cast<ImplicitContextObject*>(other);
+        auto* c2 = reinterpret_cast<ImplicitContextObject*>(other);
 
         switch (op)
         {
@@ -143,18 +143,15 @@ implicitContextContainsKey(ImplicitContextObject* self, PyObject* args)
         return nullptr;
     }
 
-    bool containsKey;
     try
     {
-        containsKey = (*self->implicitContext)->containsKey(key);
+        return (*self->implicitContext)->containsKey(key) ? Py_True : Py_False;
     }
     catch (...)
     {
         setPythonException(current_exception());
         return nullptr;
     }
-
-    return containsKey ? Py_True : Py_False;
 }
 
 extern "C" PyObject*
@@ -263,55 +260,23 @@ static PyMethodDef ImplicitContextMethods[] = {
     {"get", reinterpret_cast<PyCFunction>(implicitContextGet), METH_VARARGS, PyDoc_STR("get(key) -> string")},
     {"put", reinterpret_cast<PyCFunction>(implicitContextPut), METH_VARARGS, PyDoc_STR("put(key, value) -> string")},
     {"remove", reinterpret_cast<PyCFunction>(implicitContextRemove), METH_VARARGS, PyDoc_STR("remove(key) -> string")},
-    {0, 0} /* sentinel */
+    {nullptr, nullptr} /* sentinel */
 };
 
 namespace IcePy
 {
+    // clang-format off
     PyTypeObject ImplicitContextType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.ImplicitContext", /* tp_name */
-        sizeof(ImplicitContextObject),                       /* tp_basicsize */
-        0,                                                   /* tp_itemsize */
-        /* methods */
-        reinterpret_cast<destructor>(implicitContextDealloc),  /* tp_dealloc */
-        0,                                                     /* tp_print */
-        0,                                                     /* tp_getattr */
-        0,                                                     /* tp_setattr */
-        0,                                                     /* tp_reserved */
-        0,                                                     /* tp_repr */
-        0,                                                     /* tp_as_number */
-        0,                                                     /* tp_as_sequence */
-        0,                                                     /* tp_as_mapping */
-        0,                                                     /* tp_hash */
-        0,                                                     /* tp_call */
-        0,                                                     /* tp_str */
-        0,                                                     /* tp_getattro */
-        0,                                                     /* tp_setattro */
-        0,                                                     /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT,                                    /* tp_flags */
-        0,                                                     /* tp_doc */
-        0,                                                     /* tp_traverse */
-        0,                                                     /* tp_clear */
-        reinterpret_cast<richcmpfunc>(implicitContextCompare), /* tp_richcompare */
-        0,                                                     /* tp_weaklistoffset */
-        0,                                                     /* tp_iter */
-        0,                                                     /* tp_iternext */
-        ImplicitContextMethods,                                /* tp_methods */
-        0,                                                     /* tp_members */
-        0,                                                     /* tp_getset */
-        0,                                                     /* tp_base */
-        0,                                                     /* tp_dict */
-        0,                                                     /* tp_descr_get */
-        0,                                                     /* tp_descr_set */
-        0,                                                     /* tp_dictoffset */
-        0,                                                     /* tp_init */
-        0,                                                     /* tp_alloc */
-        reinterpret_cast<newfunc>(implicitContextNew),         /* tp_new */
-        0,                                                     /* tp_free */
-        0,                                                     /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.ImplicitContext",
+        .tp_basicsize = sizeof(ImplicitContextObject),
+        .tp_dealloc = reinterpret_cast<destructor>(implicitContextDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT,
+        .tp_richcompare = reinterpret_cast<richcmpfunc>(implicitContextCompare),
+        .tp_methods = ImplicitContextMethods,
+        .tp_new = reinterpret_cast<newfunc>(implicitContextNew),
     };
+    // clang-format on
 }
 
 bool
@@ -321,8 +286,8 @@ IcePy::initImplicitContext(PyObject* module)
     {
         return false;
     }
-    PyTypeObject* type = &ImplicitContextType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "ImplicitContext", reinterpret_cast<PyObject*>(type)) < 0)
+
+    if (PyModule_AddObject(module, "ImplicitContext", reinterpret_cast<PyObject*>(&ImplicitContextType)) < 0)
     {
         return false;
     }
@@ -333,7 +298,7 @@ IcePy::initImplicitContext(PyObject* module)
 PyObject*
 IcePy::createImplicitContext(const Ice::ImplicitContextPtr& implicitContext)
 {
-    ImplicitContextObject* obj = implicitContextNew(&ImplicitContextType, 0, 0);
+    ImplicitContextObject* obj{implicitContextNew(&ImplicitContextType, nullptr, nullptr)};
     if (obj)
     {
         obj->implicitContext = new Ice::ImplicitContextPtr(implicitContext);

--- a/python/modules/IcePy/Init.cpp
+++ b/python/modules/IcePy/Init.cpp
@@ -110,7 +110,7 @@ static PyMethodDef methods[] = {
      PyDoc_STR("internal function")},
     {"loadSlice", reinterpret_cast<PyCFunction>(IcePy_loadSlice), METH_VARARGS, PyDoc_STR("loadSlice(cmd) -> None")},
     {"compile", reinterpret_cast<PyCFunction>(IcePy_compile), METH_VARARGS, PyDoc_STR("internal function")},
-    {0, 0} /* sentinel */
+    {nullptr, nullptr} /* sentinel */
 };
 
 static struct PyModuleDef iceModule = {
@@ -133,80 +133,18 @@ PyMODINIT_FUNC ICE_DECLSPEC_EXPORT
 #endif
 PyInit_IcePy(void)
 {
-    PyObject* module;
-
     Ice::registerIceDiscovery(false);
     Ice::registerIceLocatorDiscovery(false);
 
-    //
-    // Create the module.
-    //
-    module = PyModule_Create(&iceModule);
+    // Create the IcePy  module.
+    PyObject* module{PyModule_Create(&iceModule)};
 
-    //
-    // Install built-in Ice types.
-    //
-    if (!initProxy(module))
-    {
-        return nullptr;
-    }
-    if (!initTypes(module))
-    {
-        return nullptr;
-    }
-    if (!initProperties(module))
-    {
-        return nullptr;
-    }
-    if (!initPropertiesAdmin(module))
-    {
-        return nullptr;
-    }
-    if (!initExecutor(module))
-    {
-        return nullptr;
-    }
-    if (!initBatchRequest(module))
-    {
-        return nullptr;
-    }
-    if (!initCommunicator(module))
-    {
-        return nullptr;
-    }
-    if (!initObjectAdapter(module))
-    {
-        return nullptr;
-    }
-    if (!initOperation(module))
-    {
-        return nullptr;
-    }
-    if (!initLogger(module))
-    {
-        return nullptr;
-    }
-    if (!initConnection(module))
-    {
-        return nullptr;
-    }
-    if (!initConnectionInfo(module))
-    {
-        return nullptr;
-    }
-    if (!initImplicitContext(module))
-    {
-        return nullptr;
-    }
-    if (!initEndpoint(module))
-    {
-        return nullptr;
-    }
-    if (!initEndpointInfo(module))
-    {
-        return nullptr;
-    }
-    if (!initValueFactoryManager(module))
+    // Initialize the IcePy built-in types.
+    if (!initProxy(module) || !initTypes(module) || !initProperties(module) || !initPropertiesAdmin(module) ||
+        !initExecutor(module) || !initBatchRequest(module) || !initCommunicator(module) || !initObjectAdapter(module) ||
+        !initOperation(module) || !initLogger(module) || !initConnection(module) || !initConnectionInfo(module) ||
+        !initImplicitContext(module) || !initEndpoint(module) || !initEndpointInfo(module) ||
+        !initValueFactoryManager(module))
     {
         return nullptr;
     }

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 #include "Operation.h"
+
 #include "Communicator.h"
 #include "Connection.h"
 #include "Current.h"
@@ -29,7 +30,7 @@ namespace IcePy
     class ParamInfo : public UnmarshalCallback
     {
     public:
-        virtual void unmarshaled(PyObject*, PyObject*, void*);
+        void unmarshaled(PyObject*, PyObject*, void*) override;
 
         Ice::StringSeq metadata;
         TypeInfoPtr type;
@@ -90,7 +91,7 @@ namespace IcePy
     public:
         Invocation(const Ice::ObjectPrx&);
 
-        virtual PyObject* invoke(PyObject*, PyObject* = 0) = 0;
+        virtual PyObject* invoke(PyObject*, PyObject* = nullptr) = 0;
 
     protected:
         // Helpers for typed invocations.
@@ -120,9 +121,9 @@ namespace IcePy
     class SyncTypedInvocation final : public Invocation
     {
     public:
-        SyncTypedInvocation(const Ice::ObjectPrx&, const OperationPtr&);
+        SyncTypedInvocation(const Ice::ObjectPrx&, OperationPtr);
 
-        PyObject* invoke(PyObject*, PyObject* = 0) final;
+        PyObject* invoke(PyObject*, PyObject* = nullptr) final;
 
     private:
         OperationPtr _op;
@@ -131,10 +132,10 @@ namespace IcePy
     class AsyncInvocation : public Invocation
     {
     public:
-        AsyncInvocation(const Ice::ObjectPrx&, PyObject*, const string&);
+        AsyncInvocation(const Ice::ObjectPrx&, PyObject*, string);
         ~AsyncInvocation();
 
-        PyObject* invoke(PyObject*, PyObject* = 0) final;
+        PyObject* invoke(PyObject*, PyObject* = nullptr) final;
 
         void response(bool, pair<const byte*, const byte*>);
         void exception(std::exception_ptr);
@@ -147,13 +148,13 @@ namespace IcePy
         PyObject* _pyProxy;
         string _operation;
         bool _twoway;
-        bool _sent;
-        bool _sentSynchronously;
-        bool _done;
-        PyObject* _future;
-        bool _ok;
+        bool _sent{false};
+        bool _sentSynchronously{false};
+        bool _done{false};
+        PyObject* _future{nullptr};
+        bool _ok{false};
         vector<byte> _results;
-        PyObject* _exception;
+        PyObject* _exception{nullptr};
     };
     using AsyncInvocationPtr = shared_ptr<AsyncInvocation>;
 
@@ -175,7 +176,7 @@ namespace IcePy
     public:
         SyncBlobjectInvocation(const Ice::ObjectPrx&);
 
-        PyObject* invoke(PyObject*, PyObject* = 0) final;
+        PyObject* invoke(PyObject*, PyObject* = nullptr) final;
     };
 
     class AsyncBlobjectInvocation final : public AsyncInvocation,
@@ -210,10 +211,10 @@ namespace IcePy
     {
     public:
         TypedUpcall(
-            const OperationPtr&,
+            OperationPtr,
             function<void(bool, pair<const byte*, const byte*>)>,
             function<void(std::exception_ptr)>,
-            const Ice::CommunicatorPtr&);
+            Ice::CommunicatorPtr);
 
         void dispatch(PyObject*, pair<const byte*, const byte*>, const Ice::Current&) final;
         void response(PyObject*) final;
@@ -310,7 +311,7 @@ namespace
     OperationPtr getOperation(PyObject* p)
     {
         assert(PyObject_IsInstance(p, reinterpret_cast<PyObject*>(&OperationType)) == 1);
-        OperationObject* obj = reinterpret_cast<OperationObject*>(p);
+        auto* obj = reinterpret_cast<OperationObject*>(p);
         return *obj->op;
     }
 
@@ -320,12 +321,10 @@ namespace
 
         PyException ex; // Retrieve it before another Python API call clears it.
 
-        //
         // A callback that calls sys.exit() will raise the SystemExit exception.
-        // This is normally caught by the interpreter, causing it to exit.
-        // However, we have no way to pass this exception to the interpreter,
-        // so we act on it directly.
         //
+        // This is normally caught by the interpreter, causing it to exit. However, we have no way to pass this
+        // exception to the interpreter, so we act on it directly.
         ex.checkSystemExit();
 
         ex.raise();
@@ -335,12 +334,12 @@ namespace
 extern "C" OperationObject*
 operationNew(PyTypeObject* type, PyObject* /*args*/, PyObject* /*kwds*/)
 {
-    OperationObject* self = reinterpret_cast<OperationObject*>(type->tp_alloc(type, 0));
+    auto* self = reinterpret_cast<OperationObject*>(type->tp_alloc(type, 0));
     if (!self)
     {
         return nullptr;
     }
-    self->op = 0;
+    self->op = nullptr;
     return self;
 }
 
@@ -405,31 +404,31 @@ operationDealloc(OperationObject* self)
 extern "C" PyObject*
 operationInvoke(OperationObject* self, PyObject* args)
 {
-    PyObject* pyProxy;
-    PyObject* opArgs;
+    PyObject* pyProxy{nullptr};
+    PyObject* opArgs{nullptr};
     if (!PyArg_ParseTuple(args, "O!O!", &ProxyType, &pyProxy, &PyTuple_Type, &opArgs))
     {
         return nullptr;
     }
 
-    Ice::ObjectPrx prx = getProxy(pyProxy);
+    Ice::ObjectPrx prx{getProxy(pyProxy)};
     assert(self->op);
 
-    InvocationPtr i = make_shared<SyncTypedInvocation>(prx, *self->op);
+    auto i = make_shared<SyncTypedInvocation>(prx, *self->op);
     return i->invoke(opArgs);
 }
 
 extern "C" PyObject*
 operationInvokeAsync(OperationObject* self, PyObject* args)
 {
-    PyObject* proxy;
-    PyObject* opArgs;
+    PyObject* proxy{nullptr};
+    PyObject* opArgs{nullptr};
     if (!PyArg_ParseTuple(args, "O!O!", &ProxyType, &proxy, &PyTuple_Type, &opArgs))
     {
         return nullptr;
     }
 
-    Ice::ObjectPrx prx = getProxy(proxy);
+    Ice::ObjectPrx prx{getProxy(proxy)};
     InvocationPtr i = make_shared<AsyncTypedInvocation>(prx, proxy, *self->op);
     return i->invoke(opArgs);
 }
@@ -437,7 +436,7 @@ operationInvokeAsync(OperationObject* self, PyObject* args)
 extern "C" PyObject*
 operationDeprecate(OperationObject* self, PyObject* args)
 {
-    char* msg;
+    char* msg{nullptr};
     if (!PyArg_ParseTuple(args, "s", &msg))
     {
         return nullptr;
@@ -456,12 +455,12 @@ operationDeprecate(OperationObject* self, PyObject* args)
 extern "C" DispatchCallbackObject*
 dispatchCallbackNew(PyTypeObject* type, PyObject* /*args*/, PyObject* /*kwds*/)
 {
-    DispatchCallbackObject* self = reinterpret_cast<DispatchCallbackObject*>(type->tp_alloc(type, 0));
+    auto* self = reinterpret_cast<DispatchCallbackObject*>(type->tp_alloc(type, 0));
     if (!self)
     {
         return nullptr;
     }
-    self->upcall = 0;
+    self->upcall = nullptr;
     return self;
 }
 
@@ -475,7 +474,7 @@ dispatchCallbackDealloc(DispatchCallbackObject* self)
 extern "C" PyObject*
 dispatchCallbackResponse(DispatchCallbackObject* self, PyObject* args)
 {
-    PyObject* result = 0;
+    PyObject* result{nullptr};
     if (!PyArg_ParseTuple(args, "O", &result))
     {
         return nullptr;
@@ -500,7 +499,7 @@ dispatchCallbackResponse(DispatchCallbackObject* self, PyObject* args)
 extern "C" PyObject*
 dispatchCallbackException(DispatchCallbackObject* self, PyObject* args)
 {
-    PyObject* ex = 0;
+    PyObject* ex{nullptr};
     if (!PyArg_ParseTuple(args, "O", &ex))
     {
         return nullptr;
@@ -535,8 +534,8 @@ asyncInvocationContextNew(PyTypeObject* type, PyObject* /*args*/, PyObject* /*kw
     {
         return nullptr;
     }
-    self->cancel = 0;
-    self->communicator = 0;
+    self->cancel = nullptr;
+    self->communicator = nullptr;
     return self;
 }
 
@@ -566,7 +565,7 @@ asyncInvocationContextCancel(AsyncInvocationContextObject* self, PyObject* /*arg
 extern "C" PyObject*
 asyncInvocationContextCallLater(AsyncInvocationContextObject* self, PyObject* args)
 {
-    PyObject* callback;
+    PyObject* callback{nullptr};
     if (!PyArg_ParseTuple(args, "O", &callback))
     {
         return nullptr;
@@ -596,12 +595,12 @@ asyncInvocationContextCallLater(AsyncInvocationContextObject* self, PyObject* ar
 
             PyObjectHandle args{PyTuple_New(0)};
             assert(args.get());
-            PyObjectHandle tmp{PyObject_Call(_callback, args.get(), 0)};
+            PyObjectHandle tmp{PyObject_Call(_callback, args.get(), nullptr)};
             PyErr_Clear();
         }
 
     private:
-        PyObject* _callback;
+        PyObject* _callback{nullptr};
     };
 
     // CommunicatorDestroyedException is the only exception that can propagate directly from this method.
@@ -630,29 +629,29 @@ asyncInvocationContextCallLater(AsyncInvocationContextObject* self, PyObject* ar
 extern "C" MarshaledResultObject*
 marshaledResultNew(PyTypeObject* type, PyObject* /*args*/, PyObject* /*kwds*/)
 {
-    MarshaledResultObject* self = reinterpret_cast<MarshaledResultObject*>(type->tp_alloc(type, 0));
+    MarshaledResultObject* self{reinterpret_cast<MarshaledResultObject*>(type->tp_alloc(type, 0))};
     if (!self)
     {
         return nullptr;
     }
-    self->out = 0;
+    self->out = nullptr;
     return self;
 }
 
 extern "C" int
 marshaledResultInit(MarshaledResultObject* self, PyObject* args, PyObject* /*kwds*/)
 {
-    PyObject* versionType = IcePy::lookupType("Ice.EncodingVersion");
-    PyObject* result;
-    OperationObject* opObj;
-    PyObject* communicatorObj;
-    PyObject* encodingObj;
+    PyObject* versionType{IcePy::lookupType("Ice.EncodingVersion")};
+    PyObject* result{nullptr};
+    OperationObject* opObj{nullptr};
+    PyObject* communicatorObj{nullptr};
+    PyObject* encodingObj{nullptr};
     if (!PyArg_ParseTuple(args, "OOOO!", &result, &opObj, &communicatorObj, versionType, &encodingObj))
     {
         return -1;
     }
 
-    Ice::CommunicatorPtr communicator = getCommunicator(communicatorObj);
+    Ice::CommunicatorPtr communicator{getCommunicator(communicatorObj)};
     Ice::EncodingVersion encoding;
     if (!getEncodingVersion(encodingObj, encoding))
     {
@@ -661,7 +660,7 @@ marshaledResultInit(MarshaledResultObject* self, PyObject* args, PyObject* /*kwd
 
     self->out = new Ice::OutputStream(communicator);
 
-    OperationPtr op = *opObj->op;
+    OperationPtr op{*opObj->op};
     self->out->startEncapsulation(encoding, op->format);
 
     try
@@ -698,7 +697,7 @@ void
 IcePy::ParamInfo::unmarshaled(PyObject* val, PyObject* target, void* closure)
 {
     assert(PyTuple_Check(target));
-    Py_ssize_t i = reinterpret_cast<Py_ssize_t>(closure);
+    auto i = reinterpret_cast<Py_ssize_t>(closure);
     Py_XINCREF(val);
     PyTuple_SET_ITEM(target, i, val); // PyTuple_SET_ITEM steals a reference.
 }
@@ -827,7 +826,7 @@ Operation::marshalResult(Ice::OutputStream& os, PyObject* result)
     // returned in a tuple of the form (result, outParam1, ...).
     //
 
-    Py_ssize_t numResults = static_cast<Py_ssize_t>(outParams.size());
+    auto numResults = static_cast<Py_ssize_t>(outParams.size());
     if (returnType)
     {
         numResults++;
@@ -868,9 +867,8 @@ Operation::marshalResult(Ice::OutputStream& os, PyObject* result)
     //
     // Validate the results.
     //
-    for (p = outParams.begin(); p != outParams.end(); ++p)
+    for (const auto& info : outParams)
     {
-        ParamInfoPtr info = *p;
         PyObject* arg = PyTuple_GET_ITEM(t.get(), info->pos);
         if ((!info->optional || arg != Py_None) && !info->type->validate(arg))
         {
@@ -911,9 +909,8 @@ Operation::marshalResult(Ice::OutputStream& os, PyObject* result)
     //
     // Marshal the required out parameters.
     //
-    for (p = outParams.begin(); p != outParams.end(); ++p)
+    for (const auto& info : outParams)
     {
-        ParamInfoPtr info = *p;
         if (!info->optional)
         {
             PyObject* arg = PyTuple_GET_ITEM(t.get(), info->pos);
@@ -933,9 +930,8 @@ Operation::marshalResult(Ice::OutputStream& os, PyObject* result)
     //
     // Marshal the optional results.
     //
-    for (p = optionalOutParams.begin(); p != optionalOutParams.end(); ++p)
+    for (const auto& info : optionalOutParams)
     {
-        ParamInfoPtr info = *p;
         PyObject* arg = PyTuple_GET_ITEM(t.get(), info->pos);
         if (arg != Py_None && os.writeOptional(info->tag, info->type->optionalFormat()))
         {
@@ -968,7 +964,7 @@ IcePy::Operation::convertParams(PyObject* p, ParamInfoList& params, Py_ssize_t p
     int sz = static_cast<int>(PyTuple_GET_SIZE(p));
     for (Py_ssize_t i = 0; i < sz; ++i)
     {
-        PyObject* item = PyTuple_GET_ITEM(p, i);
+        PyObject* item{PyTuple_GET_ITEM(p, i)};
         ParamInfoPtr param = convertParam(item, i + posOffset);
         params.push_back(param);
         if (!param->optional && !usesClasses)
@@ -1025,7 +1021,7 @@ static PyMethodDef OperationMethods[] = {
     {"invoke", reinterpret_cast<PyCFunction>(operationInvoke), METH_VARARGS, PyDoc_STR("internal function")},
     {"invokeAsync", reinterpret_cast<PyCFunction>(operationInvokeAsync), METH_VARARGS, PyDoc_STR("internal function")},
     {"deprecate", reinterpret_cast<PyCFunction>(operationDeprecate), METH_VARARGS, PyDoc_STR("internal function")},
-    {0, 0} /* sentinel */
+    {nullptr, nullptr} /* sentinel */
 };
 
 static PyMethodDef DispatchCallbackMethods[] = {
@@ -1034,7 +1030,7 @@ static PyMethodDef DispatchCallbackMethods[] = {
      reinterpret_cast<PyCFunction>(dispatchCallbackException),
      METH_VARARGS,
      PyDoc_STR("internal function")},
-    {0, 0} /* sentinel */
+    {nullptr, nullptr} /* sentinel */
 };
 
 static PyMethodDef AsyncInvocationContextMethods[] = {
@@ -1046,190 +1042,53 @@ static PyMethodDef AsyncInvocationContextMethods[] = {
      reinterpret_cast<PyCFunction>(asyncInvocationContextCallLater),
      METH_VARARGS,
      PyDoc_STR("internal function")},
-    {0, 0} /* sentinel */
+    {nullptr, nullptr} /* sentinel */
 };
 
 namespace IcePy
 {
+    // clang-format off
     PyTypeObject OperationType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.Operation", /* tp_name */
-        sizeof(OperationObject),                       /* tp_basicsize */
-        0,                                             /* tp_itemsize */
-        /* methods */
-        reinterpret_cast<destructor>(operationDealloc), /* tp_dealloc */
-        0,                                              /* tp_print */
-        0,                                              /* tp_getattr */
-        0,                                              /* tp_setattr */
-        0,                                              /* tp_reserved */
-        0,                                              /* tp_repr */
-        0,                                              /* tp_as_number */
-        0,                                              /* tp_as_sequence */
-        0,                                              /* tp_as_mapping */
-        0,                                              /* tp_hash */
-        0,                                              /* tp_call */
-        0,                                              /* tp_str */
-        0,                                              /* tp_getattro */
-        0,                                              /* tp_setattro */
-        0,                                              /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT,                             /* tp_flags */
-        0,                                              /* tp_doc */
-        0,                                              /* tp_traverse */
-        0,                                              /* tp_clear */
-        0,                                              /* tp_richcompare */
-        0,                                              /* tp_weaklistoffset */
-        0,                                              /* tp_iter */
-        0,                                              /* tp_iternext */
-        OperationMethods,                               /* tp_methods */
-        0,                                              /* tp_members */
-        0,                                              /* tp_getset */
-        0,                                              /* tp_base */
-        0,                                              /* tp_dict */
-        0,                                              /* tp_descr_get */
-        0,                                              /* tp_descr_set */
-        0,                                              /* tp_dictoffset */
-        reinterpret_cast<initproc>(operationInit),      /* tp_init */
-        0,                                              /* tp_alloc */
-        reinterpret_cast<newfunc>(operationNew),        /* tp_new */
-        0,                                              /* tp_free */
-        0,                                              /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.Operation",
+        .tp_basicsize = sizeof(OperationObject),
+        .tp_dealloc = reinterpret_cast<destructor>(operationDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT,
+        .tp_methods = OperationMethods,
+        .tp_init = reinterpret_cast<initproc>(operationInit),
+        .tp_new = reinterpret_cast<newfunc>(operationNew),
     };
 
-    static PyTypeObject DispatchCallbackType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.DispatchCallback", /* tp_name */
-        sizeof(DispatchCallbackObject),                       /* tp_basicsize */
-        0,                                                    /* tp_itemsize */
-        /* methods */
-        reinterpret_cast<destructor>(dispatchCallbackDealloc), /* tp_dealloc */
-        0,                                                     /* tp_print */
-        0,                                                     /* tp_getattr */
-        0,                                                     /* tp_setattr */
-        0,                                                     /* tp_reserved */
-        0,                                                     /* tp_repr */
-        0,                                                     /* tp_as_number */
-        0,                                                     /* tp_as_sequence */
-        0,                                                     /* tp_as_mapping */
-        0,                                                     /* tp_hash */
-        0,                                                     /* tp_call */
-        0,                                                     /* tp_str */
-        0,                                                     /* tp_getattro */
-        0,                                                     /* tp_setattro */
-        0,                                                     /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT,                                    /* tp_flags */
-        0,                                                     /* tp_doc */
-        0,                                                     /* tp_traverse */
-        0,                                                     /* tp_clear */
-        0,                                                     /* tp_richcompare */
-        0,                                                     /* tp_weaklistoffset */
-        0,                                                     /* tp_iter */
-        0,                                                     /* tp_iternext */
-        DispatchCallbackMethods,                               /* tp_methods */
-        0,                                                     /* tp_members */
-        0,                                                     /* tp_getset */
-        0,                                                     /* tp_base */
-        0,                                                     /* tp_dict */
-        0,                                                     /* tp_descr_get */
-        0,                                                     /* tp_descr_set */
-        0,                                                     /* tp_dictoffset */
-        0,                                                     /* tp_init */
-        0,                                                     /* tp_alloc */
-        reinterpret_cast<newfunc>(dispatchCallbackNew),        /* tp_new */
-        0,                                                     /* tp_free */
-        0,                                                     /* tp_is_gc */
+    PyTypeObject DispatchCallbackType = {
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.DispatchCallback",
+        .tp_basicsize = sizeof(DispatchCallbackObject),
+        .tp_dealloc = reinterpret_cast<destructor>(dispatchCallbackDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT,
+        .tp_methods = DispatchCallbackMethods,
+        .tp_new = reinterpret_cast<newfunc>(dispatchCallbackNew),
     };
 
     PyTypeObject AsyncInvocationContextType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.AsyncInvocationContext", /* tp_name */
-        sizeof(AsyncInvocationContextObject),                       /* tp_basicsize */
-        0,                                                          /* tp_itemsize */
-        /* methods */
-        reinterpret_cast<destructor>(asyncInvocationContextDealloc), /* tp_dealloc */
-        0,                                                           /* tp_print */
-        0,                                                           /* tp_getattr */
-        0,                                                           /* tp_setattr */
-        0,                                                           /* tp_reserved */
-        0,                                                           /* tp_repr */
-        0,                                                           /* tp_as_number */
-        0,                                                           /* tp_as_sequence */
-        0,                                                           /* tp_as_mapping */
-        0,                                                           /* tp_hash */
-        0,                                                           /* tp_call */
-        0,                                                           /* tp_str */
-        0,                                                           /* tp_getattro */
-        0,                                                           /* tp_setattro */
-        0,                                                           /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT,                                          /* tp_flags */
-        0,                                                           /* tp_doc */
-        0,                                                           /* tp_traverse */
-        0,                                                           /* tp_clear */
-        0,                                                           /* tp_richcompare */
-        0,                                                           /* tp_weaklistoffset */
-        0,                                                           /* tp_iter */
-        0,                                                           /* tp_iternext */
-        AsyncInvocationContextMethods,                               /* tp_methods */
-        0,                                                           /* tp_members */
-        0,                                                           /* tp_getset */
-        0,                                                           /* tp_base */
-        0,                                                           /* tp_dict */
-        0,                                                           /* tp_descr_get */
-        0,                                                           /* tp_descr_set */
-        0,                                                           /* tp_dictoffset */
-        0,                                                           /* tp_init */
-        0,                                                           /* tp_alloc */
-        reinterpret_cast<newfunc>(asyncInvocationContextNew),        /* tp_new */
-        0,                                                           /* tp_free */
-        0,                                                           /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.AsyncInvocationContext",
+        .tp_basicsize = sizeof(AsyncInvocationContextObject),
+        .tp_dealloc = reinterpret_cast<destructor>(asyncInvocationContextDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT,
+        .tp_methods = AsyncInvocationContextMethods,
+        .tp_new = reinterpret_cast<newfunc>(asyncInvocationContextNew),
     };
 
     PyTypeObject MarshaledResultType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.MarshaledResult", /* tp_name */
-        sizeof(MarshaledResultObject),                       /* tp_basicsize */
-        0,                                                   /* tp_itemsize */
-        /* methods */
-        reinterpret_cast<destructor>(marshaledResultDealloc), /* tp_dealloc */
-        0,                                                    /* tp_print */
-        0,                                                    /* tp_getattr */
-        0,                                                    /* tp_setattr */
-        0,                                                    /* tp_reserved */
-        0,                                                    /* tp_repr */
-        0,                                                    /* tp_as_number */
-        0,                                                    /* tp_as_sequence */
-        0,                                                    /* tp_as_mapping */
-        0,                                                    /* tp_hash */
-        0,                                                    /* tp_call */
-        0,                                                    /* tp_str */
-        0,                                                    /* tp_getattro */
-        0,                                                    /* tp_setattro */
-        0,                                                    /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT,                                   /* tp_flags */
-        0,                                                    /* tp_doc */
-        0,                                                    /* tp_traverse */
-        0,                                                    /* tp_clear */
-        0,                                                    /* tp_richcompare */
-        0,                                                    /* tp_weaklistoffset */
-        0,                                                    /* tp_iter */
-        0,                                                    /* tp_iternext */
-        0,                                                    /* tp_methods */
-        0,                                                    /* tp_members */
-        0,                                                    /* tp_getset */
-        0,                                                    /* tp_base */
-        0,                                                    /* tp_dict */
-        0,                                                    /* tp_descr_get */
-        0,                                                    /* tp_descr_set */
-        0,                                                    /* tp_dictoffset */
-        reinterpret_cast<initproc>(marshaledResultInit),      /* tp_init */
-        0,                                                    /* tp_alloc */
-        reinterpret_cast<newfunc>(marshaledResultNew),        /* tp_new */
-        0,                                                    /* tp_free */
-        0,                                                    /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0) /* object header */
+        .tp_name = "IcePy.MarshaledResult",
+        .tp_basicsize = sizeof(MarshaledResultObject),
+        .tp_dealloc = reinterpret_cast<destructor>(marshaledResultDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT,
+        .tp_init = reinterpret_cast<initproc>(marshaledResultInit),
+        .tp_new = reinterpret_cast<newfunc>(marshaledResultNew),
     };
+    // clang-format on
 }
 
 bool
@@ -1239,8 +1098,8 @@ IcePy::initOperation(PyObject* module)
     {
         return false;
     }
-    PyTypeObject* opType = &OperationType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "Operation", reinterpret_cast<PyObject*>(opType)) < 0)
+
+    if (PyModule_AddObject(module, "Operation", reinterpret_cast<PyObject*>(&OperationType)) < 0)
     {
         return false;
     }
@@ -1249,8 +1108,8 @@ IcePy::initOperation(PyObject* module)
     {
         return false;
     }
-    PyTypeObject* dispatchType = &DispatchCallbackType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "DispatchCallback", reinterpret_cast<PyObject*>(dispatchType)) < 0)
+
+    if (PyModule_AddObject(module, "DispatchCallback", reinterpret_cast<PyObject*>(&DispatchCallbackType)) < 0)
     {
         return false;
     }
@@ -1259,8 +1118,9 @@ IcePy::initOperation(PyObject* module)
     {
         return false;
     }
-    PyTypeObject* arType = &AsyncInvocationContextType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "AsyncInvocationContext", reinterpret_cast<PyObject*>(arType)) < 0)
+
+    if (PyModule_AddObject(module, "AsyncInvocationContext", reinterpret_cast<PyObject*>(&AsyncInvocationContextType)) <
+        0)
     {
         return false;
     }
@@ -1269,8 +1129,8 @@ IcePy::initOperation(PyObject* module)
     {
         return false;
     }
-    PyTypeObject* mrType = &MarshaledResultType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "MarshaledResult", reinterpret_cast<PyObject*>(mrType)) < 0)
+
+    if (PyModule_AddObject(module, "MarshaledResult", reinterpret_cast<PyObject*>(&MarshaledResultType)) < 0)
     {
         return false;
     }
@@ -1292,13 +1152,13 @@ IcePy::Invocation::prepareRequest(
     pair<const byte*, const byte*>& params)
 {
     assert(PyTuple_Check(args));
-    params.first = params.second = static_cast<const byte*>(0);
+    params.first = params.second = static_cast<const byte*>(nullptr);
 
     //
     // Validate the number of arguments.
     //
-    Py_ssize_t argc = PyTuple_GET_SIZE(args);
-    Py_ssize_t paramCount = static_cast<Py_ssize_t>(op->inParams.size());
+    Py_ssize_t argc{PyTuple_GET_SIZE(args)};
+    Py_ssize_t paramCount{static_cast<Py_ssize_t>(op->inParams.size())};
     if (argc != paramCount)
     {
         string opName = op->mappedName;
@@ -1320,14 +1180,11 @@ IcePy::Invocation::prepareRequest(
             os->startEncapsulation(_prx->ice_getEncodingVersion(), op->format);
 
             ObjectMap objectMap;
-            ParamInfoList::iterator p;
-
             //
             // Validate the supplied arguments.
             //
-            for (p = op->inParams.begin(); p != op->inParams.end(); ++p)
+            for (const auto& info : op->inParams)
             {
-                ParamInfoPtr info = *p;
                 PyObject* arg = PyTuple_GET_ITEM(args, info->pos);
                 if ((!info->optional || arg != Py_None) && !info->type->validate(arg))
                 {
@@ -1395,7 +1252,7 @@ IcePy::Invocation::prepareRequest(
 PyObject*
 IcePy::Invocation::unmarshalResults(const OperationPtr& op, pair<const byte*, const byte*> bytes)
 {
-    Py_ssize_t numResults = static_cast<Py_ssize_t>(op->outParams.size());
+    Py_ssize_t numResults{static_cast<Py_ssize_t>(op->outParams.size())};
     if (op->returnType)
     {
         numResults++;
@@ -1416,14 +1273,11 @@ IcePy::Invocation::unmarshalResults(const OperationPtr& op, pair<const byte*, co
 
         is.startEncapsulation();
 
-        ParamInfoList::iterator p;
-
         //
         // Unmarshal the required out parameters.
         //
-        for (p = op->outParams.begin(); p != op->outParams.end(); ++p)
+        for (const auto& info : op->outParams)
         {
-            ParamInfoPtr info = *p;
             if (!info->optional)
             {
                 void* closure = reinterpret_cast<void*>(info->pos);
@@ -1444,9 +1298,8 @@ IcePy::Invocation::unmarshalResults(const OperationPtr& op, pair<const byte*, co
         //
         // Unmarshal the optional results. This includes an optional return value.
         //
-        for (p = op->optionalOutParams.begin(); p != op->optionalOutParams.end(); ++p)
+        for (const auto& info : op->optionalOutParams)
         {
-            ParamInfoPtr info = *p;
             if (is.readOptional(info->tag, info->type->optionalFormat()))
             {
                 void* closure = reinterpret_cast<void*>(info->pos);
@@ -1502,7 +1355,7 @@ IcePy::Invocation::unmarshalException(const OperationPtr& op, pair<const byte*, 
     {
         is.endEncapsulation();
 
-        PyObject* ex = r.getException(); // Borrowed reference.
+        PyObject* ex{r.getException()}; // Borrowed reference.
 
         if (validateException(op, ex))
         {
@@ -1527,9 +1380,9 @@ IcePy::Invocation::unmarshalException(const OperationPtr& op, pair<const byte*, 
 bool
 IcePy::Invocation::validateException(const OperationPtr& op, PyObject* ex) const
 {
-    for (ExceptionInfoList::const_iterator p = op->exceptions.begin(); p != op->exceptions.end(); ++p)
+    for (const auto& info : op->exceptions)
     {
-        if (PyObject_IsInstance(ex, (*p)->pythonType))
+        if (PyObject_IsInstance(ex, info->pythonType))
         {
             return true;
         }
@@ -1541,7 +1394,7 @@ IcePy::Invocation::validateException(const OperationPtr& op, PyObject* ex) const
 void
 IcePy::Invocation::checkTwowayOnly(const OperationPtr& op, const Ice::ObjectPrx& proxy) const
 {
-    if ((op->returnType != 0 || !op->outParams.empty() || !op->exceptions.empty()) && !proxy->ice_isTwoway())
+    if ((op->returnType || !op->outParams.empty() || !op->exceptions.empty()) && !proxy->ice_isTwoway())
     {
         throw Ice::TwowayOnlyException{__FILE__, __LINE__, op->sliceName};
     }
@@ -1550,9 +1403,9 @@ IcePy::Invocation::checkTwowayOnly(const OperationPtr& op, const Ice::ObjectPrx&
 //
 // SyncTypedInvocation
 //
-IcePy::SyncTypedInvocation::SyncTypedInvocation(const Ice::ObjectPrx& prx, const OperationPtr& op)
+IcePy::SyncTypedInvocation::SyncTypedInvocation(const Ice::ObjectPrx& prx, OperationPtr op)
     : Invocation(prx),
-      _op(op)
+      _op(std::move(op))
 {
 }
 
@@ -1683,17 +1536,12 @@ IcePy::SyncTypedInvocation::invoke(PyObject* args, PyObject* /* kwds */)
 //
 // AsyncInvocation
 //
-IcePy::AsyncInvocation::AsyncInvocation(const Ice::ObjectPrx& prx, PyObject* pyProxy, const string& operation)
+IcePy::AsyncInvocation::AsyncInvocation(const Ice::ObjectPrx& prx, PyObject* pyProxy, string operation)
     : Invocation(prx),
       _pyProxy(pyProxy),
-      _operation(operation),
-      _twoway(prx->ice_isTwoway()),
-      _sent(false),
-      _sentSynchronously(false),
-      _done(false),
-      _future(0),
-      _ok(false),
-      _exception(0)
+      _operation(std::move(operation)),
+      _twoway(prx->ice_isTwoway())
+
 {
     Py_INCREF(_pyProxy);
 }
@@ -2076,21 +1924,21 @@ PyObject*
 IcePy::SyncBlobjectInvocation::invoke(PyObject* args, PyObject* /* kwds */)
 {
     char* operation;
-    PyObject* mode;
-    PyObject* inParams;
-    PyObject* operationModeType = lookupType("Ice.OperationMode");
-    PyObject* ctx = 0;
+    PyObject* mode{nullptr};
+    PyObject* inParams{nullptr};
+    PyObject* operationModeType{lookupType("Ice.OperationMode")};
+    PyObject* ctx{nullptr};
     if (!PyArg_ParseTuple(args, "sO!O!|O", &operation, operationModeType, &mode, &PyBytes_Type, &inParams, &ctx))
     {
         return nullptr;
     }
 
     PyObjectHandle modeValue{getAttr(mode, "value", true)};
-    Ice::OperationMode opMode = (Ice::OperationMode) static_cast<int>(PyLong_AsLong(modeValue.get()));
+    auto opMode = (Ice::OperationMode) static_cast<int>(PyLong_AsLong(modeValue.get()));
     assert(!PyErr_Occurred());
 
-    Py_ssize_t sz = PyBytes_GET_SIZE(inParams);
-    pair<const ::byte*, const ::byte*> in(static_cast<const byte*>(0), static_cast<const byte*>(0));
+    Py_ssize_t sz{PyBytes_GET_SIZE(inParams)};
+    pair<const ::byte*, const ::byte*> in(static_cast<const byte*>(nullptr), static_cast<const byte*>(nullptr));
     if (sz > 0)
     {
         in.first = reinterpret_cast<byte*>(PyBytes_AS_STRING(inParams));
@@ -2103,7 +1951,7 @@ IcePy::SyncBlobjectInvocation::invoke(PyObject* args, PyObject* /* kwds */)
 
         bool ok;
         Ice::Context context;
-        if (ctx != 0 && ctx != Py_None)
+        if (ctx != nullptr && ctx != Py_None)
         {
             if (!dictionaryToContext(ctx, context))
             {
@@ -2113,12 +1961,8 @@ IcePy::SyncBlobjectInvocation::invoke(PyObject* args, PyObject* /* kwds */)
 
         {
             AllowThreads allowThreads; // Release Python's global interpreter lock during remote invocations.
-            ok = _prx->ice_invoke(
-                operation,
-                opMode,
-                in,
-                out,
-                ctx == 0 || ctx == Py_None ? Ice::noExplicitContext : context);
+            ok =
+                _prx->ice_invoke(operation, opMode, in, out, !ctx || ctx == Py_None ? Ice::noExplicitContext : context);
         }
 
         //
@@ -2166,11 +2010,11 @@ IcePy::AsyncBlobjectInvocation::AsyncBlobjectInvocation(const Ice::ObjectPrx& pr
 function<void()>
 IcePy::AsyncBlobjectInvocation::handleInvoke(PyObject* args, PyObject* /* kwds */)
 {
-    char* operation;
-    PyObject* mode;
-    PyObject* inParams;
-    PyObject* operationModeType = lookupType("Ice.OperationMode");
-    PyObject* ctx = 0;
+    char* operation{nullptr};
+    PyObject* mode{nullptr};
+    PyObject* inParams{nullptr};
+    PyObject* operationModeType{lookupType("Ice.OperationMode")};
+    PyObject* ctx{nullptr};
     if (!PyArg_ParseTuple(args, "sO!O!|O", &operation, operationModeType, &mode, &PyBytes_Type, &inParams, &ctx))
     {
         return nullptr;
@@ -2179,10 +2023,10 @@ IcePy::AsyncBlobjectInvocation::handleInvoke(PyObject* args, PyObject* /* kwds *
     _op = operation;
 
     PyObjectHandle modeValue{getAttr(mode, "value", true)};
-    Ice::OperationMode opMode = (Ice::OperationMode) static_cast<int>(PyLong_AsLong(modeValue.get()));
+    auto opMode = (Ice::OperationMode) static_cast<int>(PyLong_AsLong(modeValue.get()));
     assert(!PyErr_Occurred());
 
-    Py_ssize_t sz = PyBytes_GET_SIZE(inParams);
+    Py_ssize_t sz{PyBytes_GET_SIZE(inParams)};
     pair<const ::byte*, const ::byte*> params{0, 0};
     if (sz > 0)
     {
@@ -2191,7 +2035,7 @@ IcePy::AsyncBlobjectInvocation::handleInvoke(PyObject* args, PyObject* /* kwds *
     }
 
     Ice::Context context;
-    if (ctx != 0 || ctx != Py_None)
+    if (!ctx || ctx != Py_None)
     {
         if (!dictionaryToContext(ctx, context))
         {
@@ -2207,7 +2051,7 @@ IcePy::AsyncBlobjectInvocation::handleInvoke(PyObject* args, PyObject* /* kwds *
         [self](bool ok, pair<const byte*, const byte*> results) { self->response(ok, results); },
         [self](exception_ptr ex) { self->exception(ex); },
         [self](bool sentSynchronously) { self->sent(sentSynchronously); },
-        (ctx == 0 || ctx == Py_None) ? Ice::noExplicitContext : context);
+        (!ctx || ctx == Py_None) ? Ice::noExplicitContext : context);
 }
 
 void
@@ -2269,7 +2113,7 @@ Upcall::dispatchImpl(PyObject* servant, const string& dispatchName, PyObject* ar
 
     // Get the dispatch function from Ice.Dispatch module.
     // lookupType() returns a borrowed reference.
-    PyObject* dispatchMethod = lookupType("Ice.Dispatch.dispatch");
+    PyObject* dispatchMethod{lookupType("Ice.Dispatch.dispatch")};
     assert(dispatchMethod);
     Py_INCREF(dispatchMethod);
     // Ensure we release the reference when this method exist.
@@ -2281,7 +2125,7 @@ Upcall::dispatchImpl(PyObject* servant, const string& dispatchName, PyObject* ar
         throwPythonException();
     }
 
-    DispatchCallbackObject* callback = dispatchCallbackNew(&DispatchCallbackType, 0, 0);
+    DispatchCallbackObject* callback = dispatchCallbackNew(&DispatchCallbackType, nullptr, nullptr);
     if (!callback)
     {
         throwPythonException();
@@ -2295,7 +2139,7 @@ Upcall::dispatchImpl(PyObject* servant, const string& dispatchName, PyObject* ar
     //
     // Ignore the return value of dispatch -- it will use the dispatch callback.
     //
-    PyObjectHandle ignored{PyObject_Call(dispatchMethod, dispatchArgs.get(), 0)};
+    PyObjectHandle ignored{PyObject_Call(dispatchMethod, dispatchArgs.get(), nullptr)};
 
     //
     // Check for exceptions.
@@ -2311,14 +2155,14 @@ Upcall::dispatchImpl(PyObject* servant, const string& dispatchName, PyObject* ar
 // TypedUpcall
 //
 IcePy::TypedUpcall::TypedUpcall(
-    const OperationPtr& op,
+    OperationPtr op,
     function<void(bool, pair<const byte*, const byte*>)> response,
     function<void(std::exception_ptr)> error,
-    const Ice::CommunicatorPtr& communicator)
-    : _op(op),
+    Ice::CommunicatorPtr communicator)
+    : _op(std::move(op)),
       _response(std::move(response)),
       _error(std::move(error)),
-      _communicator(communicator)
+      _communicator(std::move(communicator))
 {
 }
 
@@ -2355,14 +2199,11 @@ IcePy::TypedUpcall::dispatch(PyObject* servant, pair<const byte*, const byte*> i
         {
             is.startEncapsulation();
 
-            ParamInfoList::iterator p;
-
             //
             // Unmarshal the required parameters.
             //
-            for (p = _op->inParams.begin(); p != _op->inParams.end(); ++p)
+            for (const auto& info : _op->inParams)
             {
-                ParamInfoPtr info = *p;
                 if (!info->optional)
                 {
                     void* closure = reinterpret_cast<void*>(info->pos);
@@ -2373,9 +2214,8 @@ IcePy::TypedUpcall::dispatch(PyObject* servant, pair<const byte*, const byte*> i
             //
             // Unmarshal the optional parameters.
             //
-            for (p = _op->optionalInParams.begin(); p != _op->optionalInParams.end(); ++p)
+            for (const auto& info : _op->optionalInParams)
             {
-                ParamInfoPtr info = *p;
                 if (is.readOptional(info->tag, info->type->optionalFormat()))
                 {
                     void* closure = reinterpret_cast<void*>(info->pos);
@@ -2421,7 +2261,7 @@ IcePy::TypedUpcall::response(PyObject* result)
     {
         if (PyObject_IsInstance(result, reinterpret_cast<PyObject*>(&MarshaledResultType)))
         {
-            MarshaledResultObject* mro = reinterpret_cast<MarshaledResultObject*>(result);
+            auto* mro = reinterpret_cast<MarshaledResultObject*>(result);
             _response(true, mro->out->finished());
         }
         else
@@ -2468,7 +2308,7 @@ IcePy::TypedUpcall::exception(PyException& ex)
             //
             ex.checkSystemExit();
 
-            PyObject* userExceptionType = lookupType("Ice.UserException");
+            PyObject* userExceptionType{lookupType("Ice.UserException")};
 
             if (PyObject_IsInstance(ex.ex.get(), userExceptionType))
             {
@@ -2568,7 +2408,7 @@ IcePy::BlobjectUpcall::response(PyObject* result)
             throw Ice::MarshalException(__FILE__, __LINE__, "operation 'ice_invoke' should return a tuple of length 2");
         }
 
-        PyObject* arg = PyTuple_GET_ITEM(result, 0);
+        PyObject* arg{PyTuple_GET_ITEM(result, 0)};
         bool isTrue = PyObject_IsTrue(arg) == 1;
 
         arg = PyTuple_GET_ITEM(result, 1);
@@ -2630,7 +2470,7 @@ PyObject*
 IcePy::invokeBuiltin(PyObject* proxy, const string& builtin, PyObject* args)
 {
     string name = "_op_" + builtin;
-    PyObject* objectType = lookupType("Ice.Object");
+    PyObject* objectType{lookupType("Ice.Object")};
     assert(objectType);
     PyObjectHandle obj{getAttr(objectType, name, false)};
     assert(obj.get());
@@ -2647,7 +2487,7 @@ PyObject*
 IcePy::invokeBuiltinAsync(PyObject* proxy, const string& builtin, PyObject* args)
 {
     string name = "_op_" + builtin;
-    PyObject* objectType = lookupType("Ice.Object");
+    PyObject* objectType{lookupType("Ice.Object")};
     assert(objectType);
     PyObjectHandle obj{getAttr(objectType, name, false)};
     assert(obj.get());
@@ -2679,7 +2519,7 @@ IcePy::iceInvokeAsync(PyObject* proxy, PyObject* args)
 PyObject*
 IcePy::createAsyncInvocationContext(function<void()> cancel, Ice::CommunicatorPtr communicator)
 {
-    AsyncInvocationContextObject* obj = asyncInvocationContextNew(&AsyncInvocationContextType, 0, 0);
+    AsyncInvocationContextObject* obj{asyncInvocationContextNew(&AsyncInvocationContextType, nullptr, nullptr)};
     if (!obj)
     {
         return nullptr;
@@ -2689,14 +2529,7 @@ IcePy::createAsyncInvocationContext(function<void()> cancel, Ice::CommunicatorPt
     return reinterpret_cast<PyObject*>(obj);
 }
 
-IcePy::FlushAsyncCallback::FlushAsyncCallback(const string& op)
-    : _op(op),
-      _future(0),
-      _sent(false),
-      _sentSynchronously(false),
-      _exception(0)
-{
-}
+IcePy::FlushAsyncCallback::FlushAsyncCallback(string op) : _op(std::move(op)) {}
 
 IcePy::FlushAsyncCallback::~FlushAsyncCallback()
 {
@@ -2758,7 +2591,7 @@ IcePy::FlushAsyncCallback::exception(std::exception_ptr ex)
     PyErr_Clear();
 
     Py_DECREF(_future); // Break cyclic dependency.
-    _future = 0;
+    _future = nullptr;
 }
 
 void
@@ -2785,16 +2618,13 @@ IcePy::FlushAsyncCallback::sent(bool sentSynchronously)
     PyErr_Clear();
 
     Py_DECREF(_future); // Break cyclic dependency.
-    _future = 0;
+    _future = nullptr;
 }
 
-IcePy::GetConnectionAsyncCallback::GetConnectionAsyncCallback(
-    const Ice::CommunicatorPtr& communicator,
-    const string& op)
-    : _communicator(communicator),
-      _op(op),
-      _future(0),
-      _exception(0)
+IcePy::GetConnectionAsyncCallback::GetConnectionAsyncCallback(Ice::CommunicatorPtr communicator, string op)
+    : _communicator(std::move(communicator)),
+      _op(std::move(op))
+
 {
 }
 
@@ -2854,7 +2684,7 @@ IcePy::GetConnectionAsyncCallback::response(const Ice::ConnectionPtr& conn)
     PyErr_Clear();
 
     Py_DECREF(_future); // Break cyclic dependency.
-    _future = 0;
+    _future = nullptr;
 }
 
 void
@@ -2876,7 +2706,7 @@ IcePy::GetConnectionAsyncCallback::exception(std::exception_ptr ex)
     PyErr_Clear();
 
     Py_DECREF(_future); // Break cyclic dependency.
-    _future = 0;
+    _future = nullptr;
 }
 
 //
@@ -2947,7 +2777,7 @@ IcePy::TypedServantWrapper::ice_invokeAsync(
                 }
 
                 assert(PyObject_IsInstance(h.get(), reinterpret_cast<PyObject*>(&OperationType)) == 1);
-                OperationObject* obj = reinterpret_cast<OperationObject*>(h.get());
+                auto* obj = reinterpret_cast<OperationObject*>(h.get());
                 op = *obj->op;
                 _lastOp = _operationMap.insert(OperationMap::value_type(current.operation, op)).first;
             }
@@ -3001,8 +2831,8 @@ IcePy::BlobjectServantWrapper::ice_invokeAsync(
 IcePy::ServantWrapperPtr
 IcePy::createServantWrapper(PyObject* servant)
 {
-    PyObject* blobjectType = lookupType("Ice.Blobject");
-    PyObject* blobjectAsyncType = lookupType("Ice.BlobjectAsync");
+    PyObject* blobjectType{lookupType("Ice.Blobject")};
+    PyObject* blobjectAsyncType{lookupType("Ice.BlobjectAsync")};
     if (PyObject_IsInstance(servant, blobjectType) || PyObject_IsInstance(servant, blobjectAsyncType))
     {
         return make_shared<BlobjectServantWrapper>(servant);

--- a/python/modules/IcePy/Operation.h
+++ b/python/modules/IcePy/Operation.h
@@ -29,7 +29,7 @@ namespace IcePy
     class GetConnectionAsyncCallback
     {
     public:
-        GetConnectionAsyncCallback(const Ice::CommunicatorPtr&, const std::string&);
+        GetConnectionAsyncCallback(Ice::CommunicatorPtr, std::string);
         ~GetConnectionAsyncCallback();
 
         void setFuture(PyObject*);
@@ -40,9 +40,9 @@ namespace IcePy
     protected:
         Ice::CommunicatorPtr _communicator;
         std::string _op;
-        PyObject* _future;
+        PyObject* _future{nullptr};
         Ice::ConnectionPtr _connection;
-        PyObject* _exception;
+        PyObject* _exception{nullptr};
     };
     using GetConnectionAsyncCallbackPtr = std::shared_ptr<GetConnectionAsyncCallback>;
 
@@ -50,7 +50,7 @@ namespace IcePy
     class FlushAsyncCallback
     {
     public:
-        FlushAsyncCallback(const std::string&);
+        FlushAsyncCallback(std::string);
         ~FlushAsyncCallback();
 
         void setFuture(PyObject*);
@@ -60,10 +60,10 @@ namespace IcePy
 
     protected:
         std::string _op;
-        PyObject* _future;
-        bool _sent;
-        bool _sentSynchronously;
-        PyObject* _exception;
+        PyObject* _future{nullptr};
+        bool _sent{false};
+        bool _sentSynchronously{false};
+        PyObject* _exception{nullptr};
     };
     using FlushAsyncCallbackPtr = std::shared_ptr<FlushAsyncCallback>;
 
@@ -72,7 +72,7 @@ namespace IcePy
     {
     public:
         ServantWrapper(PyObject*);
-        ~ServantWrapper();
+        ~ServantWrapper() override;
 
         PyObject* getObject();
 

--- a/python/modules/IcePy/Properties.cpp
+++ b/python/modules/IcePy/Properties.cpp
@@ -19,20 +19,20 @@ namespace IcePy
 extern "C" PropertiesObject*
 propertiesNew(PyTypeObject* type, PyObject* /*args*/, PyObject* /*kwds*/)
 {
-    PropertiesObject* self = reinterpret_cast<PropertiesObject*>(type->tp_alloc(type, 0));
+    PropertiesObject* self{reinterpret_cast<PropertiesObject*>(type->tp_alloc(type, 0))};
     if (!self)
     {
         return nullptr;
     }
-    self->properties = 0;
+    self->properties = nullptr;
     return self;
 }
 
 extern "C" int
 propertiesInit(PropertiesObject* self, PyObject* args, PyObject* /*kwds*/)
 {
-    PyObject* arglist = 0;
-    PyObject* defaultsObj = 0;
+    PyObject* arglist{nullptr};
+    PyObject* defaultsObj{nullptr};
 
     if (!PyArg_ParseTuple(args, "|OO", &arglist, &defaultsObj))
     {
@@ -42,8 +42,7 @@ propertiesInit(PropertiesObject* self, PyObject* args, PyObject* /*kwds*/)
     Ice::StringSeq seq;
     if (arglist)
     {
-        PyTypeObject* listType = &PyList_Type; // Necessary to prevent GCC's strict-alias warnings.
-        if (PyObject_IsInstance(arglist, reinterpret_cast<PyObject*>(listType)))
+        if (PyObject_IsInstance(arglist, reinterpret_cast<PyObject*>(&PyList_Type)))
         {
             if (!listToStringSeq(arglist, seq))
             {
@@ -98,7 +97,7 @@ propertiesInit(PropertiesObject* self, PyObject* args, PyObject* /*kwds*/)
     //
     if (arglist && arglist != Py_None)
     {
-        if (PyList_SetSlice(arglist, 0, PyList_Size(arglist), 0) < 0)
+        if (PyList_SetSlice(arglist, 0, PyList_Size(arglist), nullptr) < 0)
         {
             return -1;
         }
@@ -137,7 +136,7 @@ propertiesStr(PropertiesObject* self)
     }
 
     string str;
-    for (Ice::PropertyDict::const_iterator p = dict.begin(); p != dict.end(); ++p)
+    for (auto p = dict.begin(); p != dict.end(); ++p)
     {
         if (p != dict.begin())
         {
@@ -152,7 +151,7 @@ propertiesStr(PropertiesObject* self)
 extern "C" PyObject*
 propertiesGetProperty(PropertiesObject* self, PyObject* args)
 {
-    PyObject* keyObj;
+    PyObject* keyObj{nullptr};
     if (!PyArg_ParseTuple(args, "O", &keyObj))
     {
         return nullptr;
@@ -165,24 +164,13 @@ propertiesGetProperty(PropertiesObject* self, PyObject* args)
     }
 
     assert(self->properties);
-    string value;
-    try
-    {
-        value = (*self->properties)->getProperty(key);
-    }
-    catch (...)
-    {
-        setPythonException(current_exception());
-        return nullptr;
-    }
-
-    return createString(value);
+    return createString((*self->properties)->getProperty(key));
 }
 
 extern "C" PyObject*
 propertiesGetIceProperty(PropertiesObject* self, PyObject* args)
 {
-    PyObject* keyObj;
+    PyObject* keyObj{nullptr};
     if (!PyArg_ParseTuple(args, "O", &keyObj))
     {
         return nullptr;
@@ -212,8 +200,8 @@ propertiesGetIceProperty(PropertiesObject* self, PyObject* args)
 extern "C" PyObject*
 propertiesGetPropertyWithDefault(PropertiesObject* self, PyObject* args)
 {
-    PyObject* keyObj;
-    PyObject* defObj;
+    PyObject* keyObj{nullptr};
+    PyObject* defObj{nullptr};
     if (!PyArg_ParseTuple(args, "OO", &keyObj, &defObj))
     {
         return nullptr;
@@ -231,24 +219,13 @@ propertiesGetPropertyWithDefault(PropertiesObject* self, PyObject* args)
     }
 
     assert(self->properties);
-    string value;
-    try
-    {
-        value = (*self->properties)->getPropertyWithDefault(key, def);
-    }
-    catch (...)
-    {
-        setPythonException(current_exception());
-        return nullptr;
-    }
-
-    return createString(value);
+    return createString((*self->properties)->getPropertyWithDefault(key, def));
 }
 
 extern "C" PyObject*
 propertiesGetPropertyAsInt(PropertiesObject* self, PyObject* args)
 {
-    PyObject* keyObj;
+    PyObject* keyObj{nullptr};
     if (!PyArg_ParseTuple(args, "O", &keyObj))
     {
         return nullptr;
@@ -278,7 +255,7 @@ propertiesGetPropertyAsInt(PropertiesObject* self, PyObject* args)
 extern "C" PyObject*
 propertiesGetIcePropertyAsInt(PropertiesObject* self, PyObject* args)
 {
-    PyObject* keyObj;
+    PyObject* keyObj{nullptr};
     if (!PyArg_ParseTuple(args, "O", &keyObj))
     {
         return nullptr;
@@ -308,7 +285,7 @@ propertiesGetIcePropertyAsInt(PropertiesObject* self, PyObject* args)
 extern "C" PyObject*
 propertiesGetPropertyAsIntWithDefault(PropertiesObject* self, PyObject* args)
 {
-    PyObject* keyObj;
+    PyObject* keyObj{nullptr};
     int def;
     if (!PyArg_ParseTuple(args, "Oi", &keyObj, &def))
     {
@@ -339,7 +316,7 @@ propertiesGetPropertyAsIntWithDefault(PropertiesObject* self, PyObject* args)
 extern "C" PyObject*
 propertiesGetPropertyAsList(PropertiesObject* self, PyObject* args)
 {
-    PyObject* keyObj;
+    PyObject* keyObj{nullptr};
     if (!PyArg_ParseTuple(args, "O", &keyObj))
     {
         return nullptr;
@@ -352,34 +329,25 @@ propertiesGetPropertyAsList(PropertiesObject* self, PyObject* args)
     }
 
     assert(self->properties);
-    Ice::StringSeq value;
-    try
-    {
-        value = (*self->properties)->getPropertyAsList(key);
-    }
-    catch (...)
-    {
-        setPythonException(current_exception());
-        return nullptr;
-    }
+    Ice::StringSeq value = (*self->properties)->getPropertyAsList(key);
 
-    PyObject* list = PyList_New(0);
+    PyObjectHandle list{PyList_New(0)};
     if (!list)
     {
         return nullptr;
     }
-    if (!stringSeqToList(value, list))
+    if (!stringSeqToList(value, list.get()))
     {
         return nullptr;
     }
 
-    return list;
+    return list.release();
 }
 
 extern "C" PyObject*
 propertiesGetIcePropertyAsList(PropertiesObject* self, PyObject* args)
 {
-    PyObject* keyObj;
+    PyObject* keyObj{nullptr};
     if (!PyArg_ParseTuple(args, "O", &keyObj))
     {
         return nullptr;
@@ -403,24 +371,24 @@ propertiesGetIcePropertyAsList(PropertiesObject* self, PyObject* args)
         return nullptr;
     }
 
-    PyObject* list = PyList_New(0);
+    PyObjectHandle list{PyList_New(0)};
     if (!list)
     {
         return nullptr;
     }
-    if (!stringSeqToList(value, list))
+    if (!stringSeqToList(value, list.get()))
     {
         return nullptr;
     }
 
-    return list;
+    return list.release();
 }
 
 extern "C" PyObject*
 propertiesGetPropertyAsListWithDefault(PropertiesObject* self, PyObject* args)
 {
-    PyObject* keyObj;
-    PyObject* defList;
+    PyObject* keyObj{nullptr};
+    PyObject* defList{nullptr};
     if (!PyArg_ParseTuple(args, "OO!", &keyObj, &PyList_Type, &defList))
     {
         return nullptr;
@@ -439,34 +407,25 @@ propertiesGetPropertyAsListWithDefault(PropertiesObject* self, PyObject* args)
         return nullptr;
     }
 
-    Ice::StringSeq value;
-    try
-    {
-        value = (*self->properties)->getPropertyAsListWithDefault(key, def);
-    }
-    catch (...)
-    {
-        setPythonException(current_exception());
-        return nullptr;
-    }
+    Ice::StringSeq value = (*self->properties)->getPropertyAsListWithDefault(key, def);
 
-    PyObject* list = PyList_New(0);
+    PyObjectHandle list{PyList_New(0)};
     if (!list)
     {
         return nullptr;
     }
-    if (!stringSeqToList(value, list))
+    if (!stringSeqToList(value, list.get()))
     {
         return nullptr;
     }
 
-    return list;
+    return list.release();
 }
 
 extern "C" PyObject*
 propertiesGetPropertiesForPrefix(PropertiesObject* self, PyObject* args)
 {
-    PyObject* prefixObj;
+    PyObject* prefixObj{nullptr};
     if (!PyArg_ParseTuple(args, "O", &prefixObj))
     {
         return nullptr;
@@ -479,25 +438,16 @@ propertiesGetPropertiesForPrefix(PropertiesObject* self, PyObject* args)
     }
 
     assert(self->properties);
-    Ice::PropertyDict dict;
-    try
-    {
-        dict = (*self->properties)->getPropertiesForPrefix(prefix);
-    }
-    catch (...)
-    {
-        setPythonException(current_exception());
-        return nullptr;
-    }
+    Ice::PropertyDict dict = (*self->properties)->getPropertiesForPrefix(prefix);
 
     PyObjectHandle result{PyDict_New()};
     if (result.get())
     {
-        for (Ice::PropertyDict::iterator p = dict.begin(); p != dict.end(); ++p)
+        for (const auto& [key, value] : dict)
         {
-            PyObjectHandle key{createString(p->first)};
-            PyObjectHandle val{createString(p->second)};
-            if (!val.get() || PyDict_SetItem(result.get(), key.get(), val.get()) < 0)
+            PyObjectHandle pyKey{createString(key)};
+            PyObjectHandle pyValue{createString(value)};
+            if (!pyValue.get() || PyDict_SetItem(result.get(), pyKey.get(), pyValue.get()) < 0)
             {
                 return nullptr;
             }
@@ -510,8 +460,8 @@ propertiesGetPropertiesForPrefix(PropertiesObject* self, PyObject* args)
 extern "C" PyObject*
 propertiesSetProperty(PropertiesObject* self, PyObject* args)
 {
-    PyObject* keyObj;
-    PyObject* valueObj;
+    PyObject* keyObj{nullptr};
+    PyObject* valueObj{nullptr};
     if (!PyArg_ParseTuple(args, "OO", &keyObj, &valueObj))
     {
         return nullptr;
@@ -545,36 +495,27 @@ propertiesSetProperty(PropertiesObject* self, PyObject* args)
 extern "C" PyObject*
 propertiesGetCommandLineOptions(PropertiesObject* self, PyObject* /*args*/)
 {
-    Ice::StringSeq options;
     assert(self->properties);
-    try
-    {
-        options = (*self->properties)->getCommandLineOptions();
-    }
-    catch (...)
-    {
-        setPythonException(current_exception());
-        return nullptr;
-    }
+    Ice::StringSeq options = (*self->properties)->getCommandLineOptions();
 
-    PyObject* list = PyList_New(0);
+    PyObjectHandle list{PyList_New(0)};
     if (!list)
     {
         return nullptr;
     }
-    if (!stringSeqToList(options, list))
+    if (!stringSeqToList(options, list.get()))
     {
         return nullptr;
     }
 
-    return list;
+    return list.release();
 }
 
 extern "C" PyObject*
 propertiesParseCommandLineOptions(PropertiesObject* self, PyObject* args)
 {
-    PyObject* prefixObj;
-    PyObject* options;
+    PyObject* prefixObj{nullptr};
+    PyObject* options{nullptr};
     if (!PyArg_ParseTuple(args, "OO!", &prefixObj, &PyList_Type, &options))
     {
         return nullptr;
@@ -604,23 +545,23 @@ propertiesParseCommandLineOptions(PropertiesObject* self, PyObject* args)
         return nullptr;
     }
 
-    PyObject* list = PyList_New(0);
+    PyObjectHandle list{PyList_New(0)};
     if (!list)
     {
         return nullptr;
     }
-    if (!stringSeqToList(filteredSeq, list))
+    if (!stringSeqToList(filteredSeq, list.get()))
     {
         return nullptr;
     }
 
-    return list;
+    return list.release();
 }
 
 extern "C" PyObject*
 propertiesParseIceCommandLineOptions(PropertiesObject* self, PyObject* args)
 {
-    PyObject* options;
+    PyObject* options{nullptr};
     if (!PyArg_ParseTuple(args, "O!", &PyList_Type, &options))
     {
         return nullptr;
@@ -644,23 +585,23 @@ propertiesParseIceCommandLineOptions(PropertiesObject* self, PyObject* args)
         return nullptr;
     }
 
-    PyObject* list = PyList_New(0);
+    PyObjectHandle list{PyList_New(0)};
     if (!list)
     {
         return nullptr;
     }
-    if (!stringSeqToList(filteredSeq, list))
+    if (!stringSeqToList(filteredSeq, list.get()))
     {
         return nullptr;
     }
 
-    return list;
+    return list.release();
 }
 
 extern "C" PyObject*
 propertiesLoad(PropertiesObject* self, PyObject* args)
 {
-    PyObject* fileObj;
+    PyObject* fileObj{nullptr};
     if (!PyArg_ParseTuple(args, "O", &fileObj))
     {
         return nullptr;
@@ -763,55 +704,24 @@ static PyMethodDef PropertyMethods[] = {
      PyDoc_STR("parseIceCommandLineOptions(prefix, options) -> list")},
     {"load", reinterpret_cast<PyCFunction>(propertiesLoad), METH_VARARGS, PyDoc_STR("load(file) -> None")},
     {"clone", reinterpret_cast<PyCFunction>(propertiesClone), METH_NOARGS, PyDoc_STR("clone() -> Ice.Properties")},
-    {0, 0} /* sentinel */
+    {nullptr, nullptr} /* sentinel */
 };
 
 namespace IcePy
 {
+    // clang-format off
     PyTypeObject PropertiesType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.Properties", /* tp_name */
-        sizeof(PropertiesObject),                       /* tp_basicsize */
-        0,                                              /* tp_itemsize */
-        /* methods */
-        reinterpret_cast<destructor>(propertiesDealloc), /* tp_dealloc */
-        0,                                               /* tp_print */
-        0,                                               /* tp_getattr */
-        0,                                               /* tp_setattr */
-        0,                                               /* tp_reserved */
-        0,                                               /* tp_repr */
-        0,                                               /* tp_as_number */
-        0,                                               /* tp_as_sequence */
-        0,                                               /* tp_as_mapping */
-        0,                                               /* tp_hash */
-        0,                                               /* tp_call */
-        reinterpret_cast<reprfunc>(propertiesStr),       /* tp_str */
-        0,                                               /* tp_getattro */
-        0,                                               /* tp_setattro */
-        0,                                               /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT,                              /* tp_flags */
-        0,                                               /* tp_doc */
-        0,                                               /* tp_traverse */
-        0,                                               /* tp_clear */
-        0,                                               /* tp_richcompare */
-        0,                                               /* tp_weaklistoffset */
-        0,                                               /* tp_iter */
-        0,                                               /* tp_iternext */
-        PropertyMethods,                                 /* tp_methods */
-        0,                                               /* tp_members */
-        0,                                               /* tp_getset */
-        0,                                               /* tp_base */
-        0,                                               /* tp_dict */
-        0,                                               /* tp_descr_get */
-        0,                                               /* tp_descr_set */
-        0,                                               /* tp_dictoffset */
-        reinterpret_cast<initproc>(propertiesInit),      /* tp_init */
-        0,                                               /* tp_alloc */
-        reinterpret_cast<newfunc>(propertiesNew),        /* tp_new */
-        0,                                               /* tp_free */
-        0,                                               /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.Properties",
+        .tp_basicsize = sizeof(PropertiesObject),
+        .tp_dealloc = reinterpret_cast<destructor>(propertiesDealloc),
+        .tp_str = reinterpret_cast<reprfunc>(propertiesStr),
+        .tp_flags = Py_TPFLAGS_DEFAULT,
+        .tp_methods = PropertyMethods,
+        .tp_init = reinterpret_cast<initproc>(propertiesInit),
+        .tp_new = reinterpret_cast<newfunc>(propertiesNew),
     };
+    // clang-format on
 }
 
 bool
@@ -833,7 +743,7 @@ IcePy::initProperties(PyObject* module)
 PyObject*
 IcePy::createProperties(const Ice::PropertiesPtr& props)
 {
-    PropertiesObject* obj = propertiesNew(&PropertiesType, 0, 0);
+    PropertiesObject* obj{propertiesNew(&PropertiesType, nullptr, nullptr)};
     if (obj)
     {
         obj->properties = new Ice::PropertiesPtr(props);
@@ -844,7 +754,7 @@ IcePy::createProperties(const Ice::PropertiesPtr& props)
 Ice::PropertiesPtr
 IcePy::getProperties(PyObject* p)
 {
-    PropertiesObject* obj = reinterpret_cast<PropertiesObject*>(p);
+    PropertiesObject* obj{reinterpret_cast<PropertiesObject*>(p)};
     if (obj->properties)
     {
         return *obj->properties;
@@ -859,5 +769,5 @@ IcePy_createProperties(PyObject* /*self*/, PyObject* args)
     // Currently the same as "p = Ice.Properties()".
     //
     PyTypeObject* type = &PropertiesType; // Necessary to prevent GCC's strict-alias warnings.
-    return PyObject_Call(reinterpret_cast<PyObject*>(type), args, 0);
+    return PyObject_Call(reinterpret_cast<PyObject*>(type), args, nullptr);
 }

--- a/python/modules/IcePy/PropertiesAdmin.cpp
+++ b/python/modules/IcePy/PropertiesAdmin.cpp
@@ -36,8 +36,8 @@ nativePropertiesAdminDealloc(NativePropertiesAdminObject* self)
 extern "C" PyObject*
 nativePropertiesAdminAddUpdateCB(NativePropertiesAdminObject* self, PyObject* args)
 {
-    PyObject* callbackType = lookupType("Ice.PropertiesAdminUpdateCallback");
-    PyObject* callback;
+    PyObject* callbackType{lookupType("Ice.PropertiesAdminUpdateCallback")};
+    PyObject* callback{nullptr};
     if (!PyArg_ParseTuple(args, "O!", callbackType, &callback))
     {
         return nullptr;
@@ -53,11 +53,11 @@ nativePropertiesAdminAddUpdateCB(NativePropertiesAdminObject* self, PyObject* ar
                     PyObjectHandle result{PyDict_New()};
                     if (result.get())
                     {
-                        for (Ice::PropertyDict::const_iterator p = dict.begin(); p != dict.end(); ++p)
+                        for (const auto& [key, value] : dict)
                         {
-                            PyObjectHandle key{createString(p->first)};
-                            PyObjectHandle val{createString(p->second)};
-                            if (!val.get() || PyDict_SetItem(result.get(), key.get(), val.get()) < 0)
+                            PyObjectHandle pyKey{createString(key)};
+                            PyObjectHandle pyValue{createString(value)};
+                            if (!pyValue.get() || PyDict_SetItem(result.get(), pyKey.get(), pyValue.get()) < 0)
                             {
                                 return;
                             }
@@ -72,7 +72,7 @@ nativePropertiesAdminAddUpdateCB(NativePropertiesAdminObject* self, PyObject* ar
                     }
                 });
 
-    (*self->callbacks).push_back(make_pair(callback, remover));
+    (*self->callbacks).emplace_back(callback, remover);
     Py_INCREF(callback);
 
     return Py_None;
@@ -81,8 +81,8 @@ nativePropertiesAdminAddUpdateCB(NativePropertiesAdminObject* self, PyObject* ar
 extern "C" PyObject*
 nativePropertiesAdminRemoveUpdateCB(NativePropertiesAdminObject* self, PyObject* args)
 {
-    PyObject* callbackType = lookupType("Ice.PropertiesAdminUpdateCallback");
-    PyObject* callback;
+    PyObject* callbackType{lookupType("Ice.PropertiesAdminUpdateCallback")};
+    PyObject* callback{nullptr};
     if (!PyArg_ParseTuple(args, "O!", callbackType, &callback))
     {
         return nullptr;
@@ -111,55 +111,22 @@ static PyMethodDef NativePropertiesAdminMethods[] = {
      reinterpret_cast<PyCFunction>(nativePropertiesAdminRemoveUpdateCB),
      METH_VARARGS,
      PyDoc_STR("removeUpdateCallback(callback) -> None")},
-    {0, 0} /* sentinel */
+    {nullptr, nullptr} /* sentinel */
 };
 
 namespace IcePy
 {
+    // clang-format off
     PyTypeObject NativePropertiesAdminType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.NativePropertiesAdmin", /* tp_name */
-        sizeof(NativePropertiesAdminObject),                       /* tp_basicsize */
-        0,                                                         /* tp_itemsize */
-        /* methods */
-        reinterpret_cast<destructor>(nativePropertiesAdminDealloc), /* tp_dealloc */
-        0,                                                          /* tp_print */
-        0,                                                          /* tp_getattr */
-        0,                                                          /* tp_setattr */
-        0,                                                          /* tp_reserved */
-        0,                                                          /* tp_repr */
-        0,                                                          /* tp_as_number */
-        0,                                                          /* tp_as_sequence */
-        0,                                                          /* tp_as_mapping */
-        0,                                                          /* tp_hash */
-        0,                                                          /* tp_call */
-        0,                                                          /* tp_str */
-        0,                                                          /* tp_getattro */
-        0,                                                          /* tp_setattro */
-        0,                                                          /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT,                                         /* tp_flags */
-        0,                                                          /* tp_doc */
-        0,                                                          /* tp_traverse */
-        0,                                                          /* tp_clear */
-        0,                                                          /* tp_richcompare */
-        0,                                                          /* tp_weaklistoffset */
-        0,                                                          /* tp_iter */
-        0,                                                          /* tp_iternext */
-        NativePropertiesAdminMethods,                               /* tp_methods */
-        0,                                                          /* tp_members */
-        0,                                                          /* tp_getset */
-        0,                                                          /* tp_base */
-        0,                                                          /* tp_dict */
-        0,                                                          /* tp_descr_get */
-        0,                                                          /* tp_descr_set */
-        0,                                                          /* tp_dictoffset */
-        0,                                                          /* tp_init */
-        0,                                                          /* tp_alloc */
-        reinterpret_cast<newfunc>(nativePropertiesAdminNew),        /* tp_new */
-        0,                                                          /* tp_free */
-        0,                                                          /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.NativePropertiesAdmin",
+        .tp_basicsize = sizeof(NativePropertiesAdminObject),
+        .tp_dealloc = reinterpret_cast<destructor>(nativePropertiesAdminDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT,
+        .tp_methods = NativePropertiesAdminMethods,
+        .tp_new = reinterpret_cast<newfunc>(nativePropertiesAdminNew),
     };
+    // clang-format on
 }
 
 bool
@@ -169,8 +136,9 @@ IcePy::initPropertiesAdmin(PyObject* module)
     {
         return false;
     }
-    PyTypeObject* type = &NativePropertiesAdminType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "NativePropertiesAdmin", reinterpret_cast<PyObject*>(type)) < 0)
+
+    if (PyModule_AddObject(module, "NativePropertiesAdmin", reinterpret_cast<PyObject*>(&NativePropertiesAdminType)) <
+        0)
     {
         return false;
     }
@@ -182,7 +150,7 @@ IcePy::createNativePropertiesAdmin(const Ice::NativePropertiesAdminPtr& admin)
 {
     PyTypeObject* type = &NativePropertiesAdminType;
 
-    NativePropertiesAdminObject* p = reinterpret_cast<NativePropertiesAdminObject*>(type->tp_alloc(type, 0));
+    auto* p = reinterpret_cast<NativePropertiesAdminObject*>(type->tp_alloc(type, 0));
     if (!p)
     {
         return nullptr;

--- a/python/modules/IcePy/Proxy.cpp
+++ b/python/modules/IcePy/Proxy.cpp
@@ -15,8 +15,6 @@
 #include "Types.h"
 #include "Util.h"
 
-#include <structmember.h>
-
 using namespace std;
 using namespace IcePy;
 
@@ -39,8 +37,8 @@ namespace IcePy
 static ProxyObject*
 allocateProxy(const Ice::ObjectPrx& proxy, const Ice::CommunicatorPtr& communicator, PyObject* type)
 {
-    PyTypeObject* typeObj = reinterpret_cast<PyTypeObject*>(type);
-    ProxyObject* p = reinterpret_cast<ProxyObject*>(typeObj->tp_alloc(typeObj, 0));
+    auto* typeObj = reinterpret_cast<PyTypeObject*>(type);
+    ProxyObject* p{reinterpret_cast<ProxyObject*>(typeObj->tp_alloc(typeObj, 0))};
     if (!p)
     {
         return nullptr;
@@ -65,7 +63,7 @@ allocateProxy(const Ice::ObjectPrx& proxy, const Ice::CommunicatorPtr& communica
 extern "C" ProxyObject*
 proxyNew(PyTypeObject* type, PyObject* /*args*/, PyObject* /*kwds*/)
 {
-    ProxyObject* self = reinterpret_cast<ProxyObject*>(type->tp_alloc(type, 0));
+    ProxyObject* self{reinterpret_cast<ProxyObject*>(type->tp_alloc(type, 0))};
     if (!self)
     {
         return nullptr;
@@ -78,18 +76,18 @@ proxyNew(PyTypeObject* type, PyObject* /*args*/, PyObject* /*kwds*/)
 extern "C" int
 proxyInit(ProxyObject* self, PyObject* args, PyObject* /*kwds*/)
 {
-    PyObject* communicatorWrapperType = lookupType("Ice.Communicator");
+    PyObject* communicatorWrapperType{lookupType("Ice.Communicator")};
     assert(communicatorWrapperType);
 
-    PyObject* communicatorWrapper;
-    char* proxyString;
+    PyObject* communicatorWrapper{nullptr};
+    char* proxyString{nullptr};
 
     if (!PyArg_ParseTuple(args, "O!s", communicatorWrapperType, &communicatorWrapper, &proxyString))
     {
         return -1;
     }
 
-    PyObject* communicatorImpl = PyObject_GetAttrString(communicatorWrapper, "_impl");
+    PyObject* communicatorImpl{PyObject_GetAttrString(communicatorWrapper, "_impl")};
 
     Ice::CommunicatorPtr communicator = getCommunicator(communicatorImpl);
     try
@@ -121,7 +119,7 @@ proxyCompare(ProxyObject* p1, PyObject* other, int op)
 
     if (PyObject_TypeCheck(other, &ProxyType))
     {
-        ProxyObject* p2 = reinterpret_cast<ProxyObject*>(other);
+        auto* p2 = reinterpret_cast<ProxyObject*>(other);
 
         switch (op)
         {
@@ -191,8 +189,8 @@ proxyIceGetCommunicator(ProxyObject* self, PyObject* /*args*/)
 extern "C" PyObject*
 proxyIceIsA(ProxyObject* self, PyObject* args)
 {
-    PyObject* type;
-    PyObject* ctx = Py_None;
+    PyObject* type{nullptr};
+    PyObject* ctx{Py_None};
     if (!PyArg_ParseTuple(args, "O|O!", &type, &PyDict_Type, &ctx))
     {
         return nullptr;
@@ -209,8 +207,8 @@ proxyIceIsA(ProxyObject* self, PyObject* args)
 extern "C" PyObject*
 proxyIceIsAAsync(ProxyObject* self, PyObject* args)
 {
-    PyObject* type;
-    PyObject* ctx = Py_None;
+    PyObject* type{nullptr};
+    PyObject* ctx{Py_None};
     if (!PyArg_ParseTuple(args, "O|O!", &type, &PyDict_Type, &ctx))
     {
         return nullptr;
@@ -227,7 +225,7 @@ proxyIceIsAAsync(ProxyObject* self, PyObject* args)
 extern "C" PyObject*
 proxyIcePing(ProxyObject* self, PyObject* args)
 {
-    PyObject* ctx = Py_None;
+    PyObject* ctx{Py_None};
     if (!PyArg_ParseTuple(args, "|O!", &PyDict_Type, &ctx))
     {
         return nullptr;
@@ -244,7 +242,7 @@ proxyIcePing(ProxyObject* self, PyObject* args)
 extern "C" PyObject*
 proxyIcePingAsync(ProxyObject* self, PyObject* args)
 {
-    PyObject* ctx = Py_None;
+    PyObject* ctx{Py_None};
     if (!PyArg_ParseTuple(args, "|O!", &PyDict_Type, &ctx))
     {
         return nullptr;
@@ -261,7 +259,7 @@ proxyIcePingAsync(ProxyObject* self, PyObject* args)
 extern "C" PyObject*
 proxyIceIds(ProxyObject* self, PyObject* args)
 {
-    PyObject* ctx = Py_None;
+    PyObject* ctx{Py_None};
     if (!PyArg_ParseTuple(args, "|O!", &PyDict_Type, &ctx))
     {
         return nullptr;
@@ -278,7 +276,7 @@ proxyIceIds(ProxyObject* self, PyObject* args)
 extern "C" PyObject*
 proxyIceIdsAsync(ProxyObject* self, PyObject* args)
 {
-    PyObject* ctx = Py_None;
+    PyObject* ctx{Py_None};
     if (!PyArg_ParseTuple(args, "|O!", &PyDict_Type, &ctx))
     {
         return nullptr;
@@ -295,7 +293,7 @@ proxyIceIdsAsync(ProxyObject* self, PyObject* args)
 extern "C" PyObject*
 proxyIceId(ProxyObject* self, PyObject* args)
 {
-    PyObject* ctx = Py_None;
+    PyObject* ctx{Py_None};
     if (!PyArg_ParseTuple(args, "|O!", &PyDict_Type, &ctx))
     {
         return nullptr;
@@ -348,7 +346,7 @@ proxyIceGetIdentity(ProxyObject* self, PyObject* /*args*/)
 extern "C" PyObject*
 proxyIceIdentity(ProxyObject* self, PyObject* args)
 {
-    PyObject* identityType = lookupType("Ice.Identity");
+    PyObject* identityType{lookupType("Ice.Identity")};
     assert(identityType);
     PyObject* id;
     if (!PyArg_ParseTuple(args, "O!", identityType, &id))
@@ -405,7 +403,7 @@ proxyIceGetContext(ProxyObject* self, PyObject* /*args*/)
 extern "C" PyObject*
 proxyIceContext(ProxyObject* self, PyObject* args)
 {
-    PyObject* dict;
+    PyObject* dict{nullptr};
     if (!PyArg_ParseTuple(args, "O!", &PyDict_Type, &dict))
     {
         return nullptr;
@@ -455,7 +453,7 @@ proxyIceGetFacet(ProxyObject* self, PyObject* /*args*/)
 extern "C" PyObject*
 proxyIceFacet(ProxyObject* self, PyObject* args)
 {
-    PyObject* facetObj;
+    PyObject* facetObj{nullptr};
     if (!PyArg_ParseTuple(args, "O", &facetObj))
     {
         return nullptr;
@@ -549,17 +547,17 @@ proxyIceGetEndpoints(ProxyObject* self, PyObject* /*args*/)
         return nullptr;
     }
 
-    int count = static_cast<int>(endpoints.size());
-    PyObjectHandle result{PyTuple_New(count)};
+    PyObjectHandle result{PyTuple_New(static_cast<int>(endpoints.size()))};
     int i = 0;
-    for (Ice::EndpointSeq::const_iterator p = endpoints.begin(); p != endpoints.end(); ++p, ++i)
+    for (const auto& endpoint : endpoints)
     {
-        PyObjectHandle endp{createEndpoint(*p)};
-        if (!endp.get())
+        PyObjectHandle pythonEndpoint{createEndpoint(endpoint)};
+        if (!pythonEndpoint.get())
         {
             return nullptr;
         }
-        PyTuple_SET_ITEM(result.get(), i, endp.release()); // PyTuple_SET_ITEM steals a reference.
+        // PyTuple_SET_ITEM steals a reference.
+        PyTuple_SET_ITEM(result.get(), i++, pythonEndpoint.release());
     }
 
     return result.release();
@@ -568,7 +566,7 @@ proxyIceGetEndpoints(ProxyObject* self, PyObject* /*args*/)
 extern "C" PyObject*
 proxyIceEndpoints(ProxyObject* self, PyObject* args)
 {
-    PyObject* endpoints;
+    PyObject* endpoints{nullptr};
     if (!PyArg_ParseTuple(args, "O", &endpoints))
     {
         return nullptr;
@@ -609,7 +607,7 @@ proxyIceGetLocatorCacheTimeout(ProxyObject* self, PyObject* /*args*/)
 
     try
     {
-        chrono::seconds timeout = chrono::duration_cast<chrono::seconds>((*self->proxy)->ice_getLocatorCacheTimeout());
+        auto timeout = chrono::duration_cast<chrono::seconds>((*self->proxy)->ice_getLocatorCacheTimeout());
         return PyLong_FromLong(static_cast<int32_t>(timeout.count()));
     }
     catch (...)
@@ -717,26 +715,13 @@ extern "C" PyObject*
 proxyIceIsConnectionCached(ProxyObject* self, PyObject* /*args*/)
 {
     assert(self->proxy);
-
-    PyObject* b;
-    try
-    {
-        b = (*self->proxy)->ice_isConnectionCached() ? Py_True : Py_False;
-    }
-    catch (...)
-    {
-        setPythonException(current_exception());
-        return nullptr;
-    }
-
-    Py_INCREF(b);
-    return b;
+    return (*self->proxy)->ice_isConnectionCached() ? Py_True : Py_False;
 }
 
 extern "C" PyObject*
 proxyIceConnectionCached(ProxyObject* self, PyObject* args)
 {
-    PyObject* flag;
+    PyObject* flag{nullptr};
     if (!PyArg_ParseTuple(args, "O", &flag))
     {
         return nullptr;
@@ -767,43 +752,21 @@ proxyIceConnectionCached(ProxyObject* self, PyObject* args)
 extern "C" PyObject*
 proxyIceGetEndpointSelection(ProxyObject* self, PyObject* /*args*/)
 {
-    PyObject* cls = lookupType("Ice.EndpointSelectionType");
-    assert(cls);
-
-    PyObjectHandle rnd{getAttr(cls, "Random", false)};
-    PyObjectHandle ord{getAttr(cls, "Ordered", false)};
-    assert(rnd.get());
-    assert(ord.get());
-
     assert(self->proxy);
-
-    PyObject* type;
-    try
-    {
-        Ice::EndpointSelectionType val = (*self->proxy)->ice_getEndpointSelection();
-        if (val == Ice::EndpointSelectionType::Random)
-        {
-            type = rnd.get();
-        }
-        else
-        {
-            type = ord.get();
-        }
-    }
-    catch (...)
-    {
-        setPythonException(current_exception());
-        return nullptr;
-    }
-
-    Py_INCREF(type);
-    return type;
+    PyObject* cls{lookupType("Ice.EndpointSelectionType")};
+    assert(cls);
+    PyObjectHandle type{
+        (*self->proxy)->ice_getEndpointSelection() == Ice::EndpointSelectionType::Random
+            ? getAttr(cls, "Random", false)
+            : getAttr(cls, "Ordered", false)};
+    assert(type.get());
+    return type.release();
 }
 
 extern "C" PyObject*
 proxyIceEndpointSelection(ProxyObject* self, PyObject* args)
 {
-    PyObject* cls = lookupType("Ice.EndpointSelectionType");
+    PyObject* cls{lookupType("Ice.EndpointSelectionType")};
     assert(cls);
     PyObject* type;
     if (!PyArg_ParseTuple(args, "O!", cls, &type))
@@ -850,26 +813,13 @@ extern "C" PyObject*
 proxyIceIsSecure(ProxyObject* self, PyObject* /*args*/)
 {
     assert(self->proxy);
-
-    PyObject* b;
-    try
-    {
-        b = (*self->proxy)->ice_isSecure() ? Py_True : Py_False;
-    }
-    catch (...)
-    {
-        setPythonException(current_exception());
-        return nullptr;
-    }
-
-    Py_INCREF(b);
-    return b;
+    return (*self->proxy)->ice_isSecure() ? Py_True : Py_False;
 }
 
 extern "C" PyObject*
 proxyIceSecure(ProxyObject* self, PyObject* args)
 {
-    PyObject* flag;
+    PyObject* flag{nullptr};
     if (!PyArg_ParseTuple(args, "O", &flag))
     {
         return nullptr;
@@ -902,7 +852,7 @@ proxyIceGetEncodingVersion(ProxyObject* self, PyObject* /*args*/)
 {
     assert(self->proxy);
 
-    PyObject* version;
+    PyObject* version{nullptr};
     try
     {
         version = IcePy::createEncodingVersion((*self->proxy)->ice_getEncodingVersion());
@@ -1693,7 +1643,7 @@ checkedCastImpl(ProxyObject* p, const string& id, PyObject* facet, PyObject* ctx
         }
 
         AllowThreads allowThreads; // Release Python's global interpreter lock during remote invocations.
-        b = target->ice_isA(id, (ctx == 0 || ctx == Py_None) ? Ice::noExplicitContext : c);
+        b = target->ice_isA(id, (!ctx || ctx == Py_None) ? Ice::noExplicitContext : c);
     }
     catch (...)
     {
@@ -1716,10 +1666,10 @@ proxyIceCheckedCast(PyObject* type, PyObject* args)
     // ice_checkedCast is called from generated code, therefore we always expect
     // to receive four arguments.
     //
-    PyObject* obj;
-    char* id;
-    PyObject* facetOrContext = 0;
-    PyObject* ctx = 0;
+    PyObject* obj{nullptr};
+    char* id{nullptr};
+    PyObject* facetOrContext{nullptr};
+    PyObject* ctx{nullptr};
     if (!PyArg_ParseTuple(args, "OsOO", &obj, &id, &facetOrContext, &ctx))
     {
         return nullptr;
@@ -1736,7 +1686,7 @@ proxyIceCheckedCast(PyObject* type, PyObject* args)
         return nullptr;
     }
 
-    PyObject* facet = 0;
+    PyObject* facet{nullptr};
 
     if (checkString(facetOrContext))
     {
@@ -1774,7 +1724,7 @@ proxyIceUncheckedCast(PyObject* type, PyObject* args)
     // to receive two arguments.
     //
     PyObject* obj;
-    char* facet = 0;
+    char* facet{nullptr};
     if (!PyArg_ParseTuple(args, "Oz", &obj, &facet))
     {
         return nullptr;
@@ -1791,7 +1741,7 @@ proxyIceUncheckedCast(PyObject* type, PyObject* args)
         return nullptr;
     }
 
-    ProxyObject* p = reinterpret_cast<ProxyObject*>(obj);
+    auto* p = reinterpret_cast<ProxyObject*>(obj);
 
     if (facet)
     {
@@ -1807,8 +1757,8 @@ extern "C" PyObject*
 proxyCheckedCast(PyObject* /*self*/, PyObject* args)
 {
     PyObject* obj;
-    PyObject* arg1 = 0;
-    PyObject* arg2 = 0;
+    PyObject* arg1{nullptr};
+    PyObject* arg2{nullptr};
     if (!PyArg_ParseTuple(args, "O|OO", &obj, &arg1, &arg2))
     {
         return nullptr;
@@ -1825,22 +1775,22 @@ proxyCheckedCast(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
-    PyObject* facet = 0;
-    PyObject* ctx = 0;
+    PyObject* facet{nullptr};
+    PyObject* ctx{nullptr};
 
-    if (arg1 != 0 && arg2 != 0)
+    if (arg1 && arg2)
     {
         if (arg1 == Py_None)
         {
-            arg1 = 0;
+            arg1 = nullptr;
         }
 
         if (arg2 == Py_None)
         {
-            arg2 = 0;
+            arg2 = nullptr;
         }
 
-        if (arg1 != 0)
+        if (arg1)
         {
             if (!checkString(arg1))
             {
@@ -1850,14 +1800,14 @@ proxyCheckedCast(PyObject* /*self*/, PyObject* args)
             facet = arg1;
         }
 
-        if (arg2 != 0 && !PyDict_Check(arg2))
+        if (arg2 && !PyDict_Check(arg2))
         {
             PyErr_Format(PyExc_ValueError, "context argument to checkedCast must be a dictionary");
             return nullptr;
         }
         ctx = arg2;
     }
-    else if (arg1 != 0 && arg1 != Py_None)
+    else if (arg1 && arg1 != Py_None)
     {
         if (checkString(arg1))
         {
@@ -1874,14 +1824,14 @@ proxyCheckedCast(PyObject* /*self*/, PyObject* args)
         }
     }
 
-    return checkedCastImpl(reinterpret_cast<ProxyObject*>(obj), "::Ice::Object", facet, ctx, 0);
+    return checkedCastImpl(reinterpret_cast<ProxyObject*>(obj), "::Ice::Object", facet, ctx, nullptr);
 }
 
 extern "C" PyObject*
 proxyUncheckedCast(PyObject* /*self*/, PyObject* args)
 {
-    PyObject* obj;
-    PyObject* facetObj = 0;
+    PyObject* obj{nullptr};
+    PyObject* facetObj{nullptr};
     if (!PyArg_ParseTuple(args, "O|O", &obj, &facetObj))
     {
         return nullptr;
@@ -1907,7 +1857,7 @@ proxyUncheckedCast(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
-    ProxyObject* p = reinterpret_cast<ProxyObject*>(obj);
+    auto* p = reinterpret_cast<ProxyObject*>(obj);
 
     if (facetObj)
     {
@@ -2171,55 +2121,26 @@ static PyMethodDef ProxyMethods[] = {
      reinterpret_cast<PyCFunction>(proxyIceStaticId),
      METH_NOARGS | METH_STATIC,
      PyDoc_STR("ice_staticId() -> string")},
-    {0, 0} /* sentinel */
+    {nullptr, nullptr} /* sentinel */
 };
 
 namespace IcePy
 {
+    // clang-format off
     PyTypeObject ProxyType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.ObjectPrx", /* tp_name */
-        sizeof(ProxyObject),                           /* tp_basicsize */
-        0,                                             /* tp_itemsize */
-        /* methods */
-        reinterpret_cast<destructor>(proxyDealloc),  /* tp_dealloc */
-        0,                                           /* tp_print */
-        0,                                           /* tp_getattr */
-        0,                                           /* tp_setattr */
-        0,                                           /* tp_reserved */
-        reinterpret_cast<reprfunc>(proxyRepr),       /* tp_repr */
-        0,                                           /* tp_as_number */
-        0,                                           /* tp_as_sequence */
-        0,                                           /* tp_as_mapping */
-        reinterpret_cast<hashfunc>(proxyHash),       /* tp_hash */
-        0,                                           /* tp_call */
-        0,                                           /* tp_str */
-        0,                                           /* tp_getattro */
-        0,                                           /* tp_setattro */
-        0,                                           /* tp_as_buffer */
-        Py_TPFLAGS_BASETYPE,                         /* tp_flags */
-        0,                                           /* tp_doc */
-        0,                                           /* tp_traverse */
-        0,                                           /* tp_clear */
-        reinterpret_cast<richcmpfunc>(proxyCompare), /* tp_richcompare */
-        0,                                           /* tp_weaklistoffset */
-        0,                                           /* tp_iter */
-        0,                                           /* tp_iternext */
-        ProxyMethods,                                /* tp_methods */
-        0,                                           /* tp_members */
-        0,                                           /* tp_getset */
-        0,                                           /* tp_base */
-        0,                                           /* tp_dict */
-        0,                                           /* tp_descr_get */
-        0,                                           /* tp_descr_set */
-        0,                                           /* tp_dictoffset */
-        reinterpret_cast<initproc>(proxyInit),       /* tp_init */
-        0,                                           /* tp_alloc */
-        reinterpret_cast<newfunc>(proxyNew),         /* tp_new */
-        0,                                           /* tp_free */
-        0,                                           /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.ObjectPrx",
+        .tp_basicsize = sizeof(ProxyObject),
+        .tp_dealloc = reinterpret_cast<destructor>(proxyDealloc),
+        .tp_repr = reinterpret_cast<reprfunc>(proxyRepr),
+        .tp_hash = reinterpret_cast<hashfunc>(proxyHash),
+        .tp_flags = Py_TPFLAGS_BASETYPE,
+        .tp_richcompare = reinterpret_cast<richcmpfunc>(proxyCompare),
+        .tp_methods = ProxyMethods,
+        .tp_init = reinterpret_cast<initproc>(proxyInit),
+        .tp_new = reinterpret_cast<newfunc>(proxyNew),
     };
+    // clang-format on
 }
 
 bool
@@ -2229,8 +2150,8 @@ IcePy::initProxy(PyObject* module)
     {
         return false;
     }
-    PyTypeObject* proxyType = &ProxyType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "ObjectPrx", reinterpret_cast<PyObject*>(proxyType)) < 0)
+
+    if (PyModule_AddObject(module, "ObjectPrx", reinterpret_cast<PyObject*>(&ProxyType)) < 0)
     {
         return false;
     }
@@ -2251,15 +2172,14 @@ IcePy::createProxy(const Ice::ObjectPrx& proxy, const Ice::CommunicatorPtr& comm
 bool
 IcePy::checkProxy(PyObject* p)
 {
-    PyTypeObject* type = &ProxyType; // Necessary to prevent GCC's strict-alias warnings.
-    return PyObject_IsInstance(p, reinterpret_cast<PyObject*>(type)) == 1;
+    return PyObject_IsInstance(p, reinterpret_cast<PyObject*>(&ProxyType)) == 1;
 }
 
 Ice::ObjectPrx
 IcePy::getProxy(PyObject* p)
 {
     assert(checkProxy(p));
-    ProxyObject* obj = reinterpret_cast<ProxyObject*>(p);
+    auto* obj = reinterpret_cast<ProxyObject*>(p);
     return *obj->proxy;
 }
 
@@ -2294,7 +2214,7 @@ IcePy::getProxyArg(
     {
         if (p != Py_None)
         {
-            ProxyObject* obj = reinterpret_cast<ProxyObject*>(p);
+            auto* obj = reinterpret_cast<ProxyObject*>(p);
             proxy = *obj->proxy;
         }
         else
@@ -2320,6 +2240,6 @@ Ice::CommunicatorPtr
 IcePy::getProxyCommunicator(PyObject* p)
 {
     assert(checkProxy(p));
-    ProxyObject* obj = reinterpret_cast<ProxyObject*>(p);
+    auto* obj = reinterpret_cast<ProxyObject*>(p);
     return *obj->communicator;
 }

--- a/python/modules/IcePy/Proxy.h
+++ b/python/modules/IcePy/Proxy.h
@@ -12,7 +12,7 @@ namespace IcePy
 
     bool initProxy(PyObject*);
 
-    PyObject* createProxy(const Ice::ObjectPrx&, const Ice::CommunicatorPtr&, PyObject* = 0);
+    PyObject* createProxy(const Ice::ObjectPrx&, const Ice::CommunicatorPtr&, PyObject* = nullptr);
 
     //
     // Verifies that the given Python object is a proxy. A value of None is not considered legal here.

--- a/python/modules/IcePy/Slice.cpp
+++ b/python/modules/IcePy/Slice.cpp
@@ -24,7 +24,7 @@ extern "C" PyObject*
 IcePy_loadSlice(PyObject* /*self*/, PyObject* args)
 {
     char* cmd;
-    PyObject* list = 0;
+    PyObject* list{nullptr};
     if (!PyArg_ParseTuple(args, "s|O!", &cmd, &PyList_Type, &list))
     {
         return nullptr;
@@ -90,25 +90,25 @@ IcePy_loadSlice(PyObject* /*self*/, PyObject* args)
     if (opts.isSet("D"))
     {
         vector<string> optargs = opts.argVec("D");
-        for (vector<string>::const_iterator i = optargs.begin(); i != optargs.end(); ++i)
+        for (const auto& arg : optargs)
         {
-            cppArgs.push_back("-D" + *i);
+            cppArgs.push_back("-D" + arg);
         }
     }
     if (opts.isSet("U"))
     {
         vector<string> optargs = opts.argVec("U");
-        for (vector<string>::const_iterator i = optargs.begin(); i != optargs.end(); ++i)
+        for (const auto& arg : optargs)
         {
-            cppArgs.push_back("-U" + *i);
+            cppArgs.push_back("-U" + arg);
         }
     }
     if (opts.isSet("I"))
     {
         includePaths = opts.argVec("I");
-        for (vector<string>::const_iterator i = includePaths.begin(); i != includePaths.end(); ++i)
+        for (const auto& path : includePaths)
         {
-            cppArgs.push_back("-I" + *i);
+            cppArgs.push_back("-I" + path);
         }
     }
     debug = opts.isSet("d") || opts.isSet("debug");
@@ -119,7 +119,7 @@ IcePy_loadSlice(PyObject* /*self*/, PyObject* args)
         Slice::PreprocessorPtr icecpp = Slice::Preprocessor::create("icecpp", file, cppArgs);
         FILE* cppHandle = icecpp->preprocess(true, "-D__SLICE2PY__");
 
-        if (cppHandle == 0)
+        if (!cppHandle)
         {
             PyErr_Format(PyExc_RuntimeError, "Slice preprocessing failed for `%s'", cmd);
             return nullptr;
@@ -167,7 +167,7 @@ IcePy_loadSlice(PyObject* /*self*/, PyObject* args)
         }
 
         PyDict_SetItemString(globals.get(), "__builtins__", PyEval_GetBuiltins());
-        PyObjectHandle val{PyEval_EvalCode(src.get(), globals.get(), 0)};
+        PyObjectHandle val{PyEval_EvalCode(src.get(), globals.get(), nullptr)};
         if (!val.get())
         {
             return nullptr;
@@ -180,7 +180,7 @@ IcePy_loadSlice(PyObject* /*self*/, PyObject* args)
 extern "C" PyObject*
 IcePy_compile(PyObject* /*self*/, PyObject* args)
 {
-    PyObject* list = 0;
+    PyObject* list{nullptr};
     if (!PyArg_ParseTuple(args, "O!", &PyList_Type, &list))
     {
         return nullptr;

--- a/python/modules/IcePy/Thread.cpp
+++ b/python/modules/IcePy/Thread.cpp
@@ -40,7 +40,7 @@ IcePy::ThreadHook::start()
     if (_threadStart.get())
     {
         PyObjectHandle args{PyTuple_New(0)};
-        PyObjectHandle tmp{PyObject_Call(_threadStart.get(), args.get(), 0)};
+        PyObjectHandle tmp{PyObject_Call(_threadStart.get(), args.get(), nullptr)};
         if (!tmp.get())
         {
             throwPythonException();
@@ -55,7 +55,7 @@ IcePy::ThreadHook::stop()
     if (_threadStop.get())
     {
         PyObjectHandle args{PyTuple_New(0)};
-        PyObjectHandle tmp{PyObject_Call(_threadStop.get(), args.get(), 0)};
+        PyObjectHandle tmp{PyObject_Call(_threadStop.get(), args.get(), nullptr)};
         if (!tmp.get())
         {
             throwPythonException();

--- a/python/modules/IcePy/Types.h
+++ b/python/modules/IcePy/Types.h
@@ -71,7 +71,7 @@ namespace IcePy
     class ReadValueCallback
     {
     public:
-        ReadValueCallback(const ValueInfoPtr&, const UnmarshalCallbackPtr&, PyObject*, void*);
+        ReadValueCallback(ValueInfoPtr, UnmarshalCallbackPtr, PyObject*, void*);
         ~ReadValueCallback();
 
         void invoke(const std::shared_ptr<Ice::Value>&);
@@ -132,15 +132,15 @@ namespace IcePy
     {
     public:
         TypeInfo();
-        virtual std::string getId() const = 0;
+        [[nodiscard]] virtual std::string getId() const = 0;
 
         virtual bool validate(PyObject*) = 0;
 
-        virtual bool variableLength() const = 0;
-        virtual int wireSize() const = 0;
-        virtual Ice::OptionalFormat optionalFormat() const = 0;
+        [[nodiscard]] virtual bool variableLength() const = 0;
+        [[nodiscard]] virtual int wireSize() const = 0;
+        [[nodiscard]] virtual Ice::OptionalFormat optionalFormat() const = 0;
 
-        virtual bool usesClasses() const; // Default implementation returns false.
+        [[nodiscard]] virtual bool usesClasses() const; // Default implementation returns false.
 
         void unmarshaled(PyObject*, PyObject*, void*) override; // Default implementation is assert(false).
 
@@ -182,13 +182,13 @@ namespace IcePy
 
         PrimitiveInfo(Kind);
 
-        std::string getId() const final;
+        [[nodiscard]] std::string getId() const final;
 
         bool validate(PyObject*) final;
 
-        bool variableLength() const final;
-        int wireSize() const final;
-        Ice::OptionalFormat optionalFormat() const final;
+        [[nodiscard]] bool variableLength() const final;
+        [[nodiscard]] int wireSize() const final;
+        [[nodiscard]] Ice::OptionalFormat optionalFormat() const final;
 
         void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
         void unmarshal(
@@ -215,13 +215,13 @@ namespace IcePy
     public:
         EnumInfo(std::string, PyObject*, PyObject*);
 
-        std::string getId() const final;
+        [[nodiscard]] std::string getId() const final;
 
         bool validate(PyObject*) final;
 
-        bool variableLength() const final;
-        int wireSize() const final;
-        Ice::OptionalFormat optionalFormat() const final;
+        [[nodiscard]] bool variableLength() const final;
+        [[nodiscard]] int wireSize() const final;
+        [[nodiscard]] Ice::OptionalFormat optionalFormat() const final;
 
         void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
         void unmarshal(
@@ -237,11 +237,11 @@ namespace IcePy
         void destroy() final;
 
         std::int32_t valueForEnumerator(PyObject*) const;
-        PyObject* enumeratorForValue(std::int32_t) const;
+        [[nodiscard]] PyObject* enumeratorForValue(std::int32_t) const;
 
         const std::string id;
         PyObject* pythonType; // Borrowed reference - the enclosing Python module owns the reference.
-        const std::int32_t maxValue;
+        const std::int32_t maxValue{0};
         const EnumeratorMap enumerators;
     };
     using EnumInfoPtr = std::shared_ptr<EnumInfo>;
@@ -268,15 +268,15 @@ namespace IcePy
     public:
         StructInfo(std::string, PyObject*, PyObject*);
 
-        std::string getId() const final;
+        [[nodiscard]] std::string getId() const final;
 
         bool validate(PyObject*) final;
 
-        bool variableLength() const final;
-        int wireSize() const final;
-        Ice::OptionalFormat optionalFormat() const final;
+        [[nodiscard]] bool variableLength() const final;
+        [[nodiscard]] int wireSize() const final;
+        [[nodiscard]] Ice::OptionalFormat optionalFormat() const final;
 
-        bool usesClasses() const final;
+        [[nodiscard]] bool usesClasses() const final;
 
         void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
         void unmarshal(
@@ -312,15 +312,15 @@ namespace IcePy
     public:
         SequenceInfo(std::string, PyObject*, PyObject*);
 
-        std::string getId() const final;
+        [[nodiscard]] std::string getId() const final;
 
         bool validate(PyObject*) final;
 
-        bool variableLength() const final;
-        int wireSize() const final;
-        Ice::OptionalFormat optionalFormat() const final;
+        [[nodiscard]] bool variableLength() const final;
+        [[nodiscard]] int wireSize() const final;
+        [[nodiscard]] Ice::OptionalFormat optionalFormat() const final;
 
-        bool usesClasses() const final;
+        [[nodiscard]] bool usesClasses() const final;
 
         void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
         void unmarshal(
@@ -367,7 +367,7 @@ namespace IcePy
 
             void unmarshaled(PyObject*, PyObject*, void*) final;
 
-            PyObject* createContainer(int) const;
+            [[nodiscard]] PyObject* createContainer(int) const;
             void setItem(PyObject*, int, PyObject*) const;
 
             Type type;
@@ -402,15 +402,15 @@ namespace IcePy
     public:
         DictionaryInfo(std::string, PyObject*, PyObject*);
 
-        std::string getId() const final;
+        [[nodiscard]] std::string getId() const final;
 
         bool validate(PyObject*) final;
 
-        bool variableLength() const final;
-        int wireSize() const final;
-        Ice::OptionalFormat optionalFormat() const final;
+        [[nodiscard]] bool variableLength() const final;
+        [[nodiscard]] int wireSize() const final;
+        [[nodiscard]] Ice::OptionalFormat optionalFormat() const final;
 
-        bool usesClasses() const final;
+        [[nodiscard]] bool usesClasses() const final;
 
         void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
         void unmarshal(
@@ -457,15 +457,15 @@ namespace IcePy
 
         void define(PyObject*, int, bool, PyObject*, PyObject*);
 
-        std::string getId() const final;
+        [[nodiscard]] std::string getId() const final;
 
         bool validate(PyObject*) final;
 
-        bool variableLength() const final;
-        int wireSize() const final;
-        Ice::OptionalFormat optionalFormat() const final;
+        [[nodiscard]] bool variableLength() const final;
+        [[nodiscard]] int wireSize() const final;
+        [[nodiscard]] Ice::OptionalFormat optionalFormat() const final;
 
-        bool usesClasses() const final;
+        [[nodiscard]] bool usesClasses() const final;
 
         void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
         void unmarshal(
@@ -483,14 +483,14 @@ namespace IcePy
         void printMembers(PyObject*, IceInternal::Output&, PrintObjectHistory*);
 
         const std::string id;
-        const std::int32_t compactId;
-        const bool interface;
+        const std::int32_t compactId{-1};
+        const bool interface{false};
         const ValueInfoPtr base;
         const DataMemberList members;
         const DataMemberList optionalMembers;
         PyObject* pythonType; // Borrowed reference - the enclosing Python module owns the reference.
         PyObject* typeObj;    // Borrowed reference - the "_t_XXX" variable owns the reference.
-        const bool defined;
+        const bool defined{false};
 
     private:
         ValueInfo(std::string);
@@ -506,13 +506,13 @@ namespace IcePy
 
         void define(PyObject*);
 
-        std::string getId() const final;
+        [[nodiscard]] std::string getId() const final;
 
         bool validate(PyObject*) final;
 
-        bool variableLength() const final;
-        int wireSize() const final;
-        Ice::OptionalFormat optionalFormat() const final;
+        [[nodiscard]] bool variableLength() const final;
+        [[nodiscard]] int wireSize() const final;
+        [[nodiscard]] Ice::OptionalFormat optionalFormat() const final;
 
         void marshal(PyObject*, Ice::OutputStream*, ObjectMap*, bool, const Ice::StringSeq* = nullptr) final;
         void unmarshal(
@@ -562,7 +562,7 @@ namespace IcePy
     class ValueWriter final : public Ice::Value
     {
     public:
-        ValueWriter(PyObject*, ObjectMap*, const ValueInfoPtr&);
+        ValueWriter(PyObject*, ObjectMap*, ValueInfoPtr);
         void ice_preMarshal() final;
 
         void _iceWrite(Ice::OutputStream*) const final;
@@ -583,18 +583,18 @@ namespace IcePy
     class ValueReader final : public std::enable_shared_from_this<ValueReader>, public Ice::Value
     {
     public:
-        ValueReader(PyObject*, const ValueInfoPtr&);
+        ValueReader(PyObject*, ValueInfoPtr);
 
         void ice_postUnmarshal() final;
 
         void _iceWrite(Ice::OutputStream*) const final;
         void _iceRead(Ice::InputStream*) final;
 
-        ValueInfoPtr getInfo() const;
+        [[nodiscard]] ValueInfoPtr getInfo() const;
 
-        PyObject* getObject() const; // Borrowed reference.
+        [[nodiscard]] PyObject* getObject() const; // Borrowed reference.
 
-        Ice::SlicedDataPtr getSlicedData() const;
+        [[nodiscard]] Ice::SlicedDataPtr getSlicedData() const;
 
     private:
         PyObjectHandle _object;
@@ -608,19 +608,19 @@ namespace IcePy
     class ExceptionWriter final : public Ice::UserException
     {
     public:
-        ExceptionWriter(const PyObjectHandle&, const ExceptionInfoPtr& = 0) noexcept;
+        ExceptionWriter(const PyObjectHandle&, const ExceptionInfoPtr& = nullptr) noexcept;
         ExceptionWriter(const ExceptionWriter&);
-        ~ExceptionWriter() noexcept;
+        ~ExceptionWriter() noexcept override;
 
         ExceptionWriter& operator=(const ExceptionWriter&) = delete;
 
-        const char* ice_id() const noexcept final;
+        [[nodiscard]] const char* ice_id() const noexcept final;
         void ice_throw() const final;
 
         void _write(Ice::OutputStream*) const final;
         void _read(Ice::InputStream*) final;
 
-        bool _usesClasses() const final;
+        [[nodiscard]] bool _usesClasses() const final;
 
     protected:
         void _writeImpl(Ice::OutputStream*) const final {}
@@ -638,18 +638,18 @@ namespace IcePy
     class ExceptionReader final : public Ice::UserException
     {
     public:
-        ExceptionReader(const ExceptionInfoPtr&) noexcept;
+        ExceptionReader(ExceptionInfoPtr) noexcept;
         ExceptionReader(const ExceptionReader&) = default;
 
-        const char* ice_id() const noexcept final;
+        [[nodiscard]] const char* ice_id() const noexcept final;
         void ice_throw() const final;
 
         void _write(Ice::OutputStream*) const final;
         void _read(Ice::InputStream*) final;
 
-        bool _usesClasses() const final;
+        [[nodiscard]] bool _usesClasses() const final;
 
-        PyObject* getException() const; // Borrowed reference.
+        [[nodiscard]] PyObject* getException() const; // Borrowed reference.
 
     protected:
         void _writeImpl(Ice::OutputStream*) const final {}

--- a/python/modules/IcePy/Util.h
+++ b/python/modules/IcePy/Util.h
@@ -61,7 +61,7 @@ namespace IcePy
 
         operator bool() const { return _p != nullptr; }
 
-        PyObject* get() const;
+        [[nodiscard]] PyObject* get() const;
         PyObject* release();
 
     private:
@@ -96,11 +96,6 @@ namespace IcePy
 
         PyObjectHandle ex;
     };
-
-    //
-    // Convert Ice::ByteSeq to a Python list.
-    //
-    PyObject* byteSeqToList(const Ice::ByteSeq&);
 
     //
     // Convert Ice::StringSeq to and from a Python list.
@@ -194,8 +189,8 @@ namespace IcePy
     //
     // Call a Python method.
     //
-    PyObject* callMethod(PyObject*, const std::string&, PyObject* = 0, PyObject* = 0);
-    PyObject* callMethod(PyObject*, PyObject* = 0, PyObject* = 0);
+    PyObject* callMethod(PyObject*, const std::string&, PyObject* = nullptr, PyObject* = nullptr);
+    PyObject* callMethod(PyObject*, PyObject* = nullptr, PyObject* = nullptr);
 }
 
 extern "C" PyObject* IcePy_stringVersion(PyObject*, PyObject*);

--- a/python/modules/IcePy/ValueFactoryManager.cpp
+++ b/python/modules/IcePy/ValueFactoryManager.cpp
@@ -34,7 +34,7 @@ IcePy::ValueFactoryManager::create()
     // Create a Python wrapper around this object. Note that this is cyclic - we clear the
     // reference in destroy().
     //
-    ValueFactoryManagerObject* obj =
+    auto* obj =
         reinterpret_cast<ValueFactoryManagerObject*>(ValueFactoryManagerType.tp_alloc(&ValueFactoryManagerType, 0));
     assert(obj);
 
@@ -61,7 +61,7 @@ IcePy::ValueFactoryManager::find(string_view typeId) const noexcept
 {
     ValueFactoryPtr factory;
     {
-        CustomFactoryMap::const_iterator p = _customFactories.find(typeId);
+        auto p = _customFactories.find(typeId);
         if (p != _customFactories.end())
         {
             factory = p->second;
@@ -104,7 +104,7 @@ IcePy::ValueFactoryManager::findValueFactory(string_view id) const
 {
     // Called from the Python thread, no need to lock.
 
-    CustomFactoryMap::const_iterator p = _customFactories.find(id);
+    auto p = _customFactories.find(id);
     if (p != _customFactories.end())
     {
         return p->second->getValueFactory();
@@ -198,7 +198,7 @@ IcePy::DefaultValueFactory::create(std::string_view id)
     //
     // Instantiate the object.
     //
-    PyTypeObject* type = reinterpret_cast<PyTypeObject*>(info->pythonType);
+    auto* type = reinterpret_cast<PyTypeObject*>(info->pythonType);
     PyObjectHandle emptyArgs{PyTuple_New(0)};
     PyObjectHandle obj{type->tp_new(type, emptyArgs.get(), nullptr)};
     if (!obj.get())
@@ -277,55 +277,22 @@ valueFactoryManagerFind(ValueFactoryManagerObject* self, PyObject* args)
 static PyMethodDef ValueFactoryManagerMethods[] = {
     {"add", reinterpret_cast<PyCFunction>(valueFactoryManagerAdd), METH_VARARGS, PyDoc_STR("add(factory, id) -> None")},
     {"find", reinterpret_cast<PyCFunction>(valueFactoryManagerFind), METH_VARARGS, PyDoc_STR("find(id) -> function")},
-    {0, 0} /* sentinel */
+    {nullptr, nullptr} /* sentinel */
 };
 
 namespace IcePy
 {
+    // clang-format off
     PyTypeObject ValueFactoryManagerType = {
-        /* The ob_type field must be initialized in the module init function
-         * to be portable to Windows without using C++. */
-        PyVarObject_HEAD_INIT(0, 0) "IcePy.ValueFactoryManager", /* tp_name */
-        sizeof(ValueFactoryManagerObject),                       /* tp_basicsize */
-        0,                                                       /* tp_itemsize */
-        /* methods */
-        reinterpret_cast<destructor>(valueFactoryManagerDealloc), /* tp_dealloc */
-        0,                                                        /* tp_print */
-        0,                                                        /* tp_getattr */
-        0,                                                        /* tp_setattr */
-        0,                                                        /* tp_reserved */
-        0,                                                        /* tp_repr */
-        0,                                                        /* tp_as_number */
-        0,                                                        /* tp_as_sequence */
-        0,                                                        /* tp_as_mapping */
-        0,                                                        /* tp_hash */
-        0,                                                        /* tp_call */
-        0,                                                        /* tp_str */
-        0,                                                        /* tp_getattro */
-        0,                                                        /* tp_setattro */
-        0,                                                        /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT,                                       /* tp_flags */
-        0,                                                        /* tp_doc */
-        0,                                                        /* tp_traverse */
-        0,                                                        /* tp_clear */
-        0,                                                        /* tp_richcompare */
-        0,                                                        /* tp_weaklistoffset */
-        0,                                                        /* tp_iter */
-        0,                                                        /* tp_iternext */
-        ValueFactoryManagerMethods,                               /* tp_methods */
-        0,                                                        /* tp_members */
-        0,                                                        /* tp_getset */
-        0,                                                        /* tp_base */
-        0,                                                        /* tp_dict */
-        0,                                                        /* tp_descr_get */
-        0,                                                        /* tp_descr_set */
-        0,                                                        /* tp_dictoffset */
-        0,                                                        /* tp_init */
-        0,                                                        /* tp_alloc */
-        reinterpret_cast<newfunc>(valueFactoryManagerNew),        /* tp_new */
-        0,                                                        /* tp_free */
-        0,                                                        /* tp_is_gc */
+        PyVarObject_HEAD_INIT(nullptr, 0)
+        .tp_name = "IcePy.ValueFactoryManager",
+        .tp_basicsize = sizeof(ValueFactoryManagerObject),
+        .tp_dealloc = reinterpret_cast<destructor>(valueFactoryManagerDealloc),
+        .tp_flags = Py_TPFLAGS_DEFAULT,
+        .tp_methods = ValueFactoryManagerMethods,
+        .tp_new = reinterpret_cast<newfunc>(valueFactoryManagerNew),
     };
+    // clang-format on
 }
 
 bool
@@ -335,8 +302,8 @@ IcePy::initValueFactoryManager(PyObject* module)
     {
         return false;
     }
-    PyTypeObject* type = &ValueFactoryManagerType; // Necessary to prevent GCC's strict-alias warnings.
-    if (PyModule_AddObject(module, "ValueFactoryManager", reinterpret_cast<PyObject*>(type)) < 0)
+
+    if (PyModule_AddObject(module, "ValueFactoryManager", reinterpret_cast<PyObject*>(&ValueFactoryManagerType)) < 0)
     {
         return false;
     }

--- a/python/modules/IcePy/ValueFactoryManager.h
+++ b/python/modules/IcePy/ValueFactoryManager.h
@@ -32,7 +32,7 @@ namespace IcePy
 
         std::shared_ptr<Ice::Value> create(std::string_view) final;
 
-        PyObject* getValueFactory() const;
+        [[nodiscard]] PyObject* getValueFactory() const;
 
     private:
         PyObject* _valueFactory;
@@ -54,12 +54,12 @@ namespace IcePy
         static std::shared_ptr<ValueFactoryManager> create();
 
         void add(Ice::ValueFactory, std::string_view) final;
-        Ice::ValueFactory find(std::string_view) const noexcept final;
+        [[nodiscard]] Ice::ValueFactory find(std::string_view) const noexcept final;
 
         void add(PyObject*, std::string_view);
-        PyObject* findValueFactory(std::string_view) const;
+        [[nodiscard]] PyObject* findValueFactory(std::string_view) const;
 
-        PyObject* getObject() const;
+        [[nodiscard]] PyObject* getObject() const;
 
         void destroy();
 


### PR DESCRIPTION
This PR modernizes C++ code in Python extension:

* Apply a number of clang-tidy fixes.
* Simplify the initialization of PyTypeObject using designated initializers.
* Remove exception handling when calling C++ noexcept methods.
* Removes workaround for old GCC versions.