### PR TITLE
Improve handling of future references in communicatorShutdownConmpleted

### DIFF
--- a/python/modules/IcePy/Connection.cpp
+++ b/python/modules/IcePy/Connection.cpp
@@ -239,7 +239,7 @@ connectionClose(ConnectionObject* self, PyObject* /* args */)
                 {
                     // Ensure the current thread is able to call into Python.
                     AdoptThread adoptThread;
-                    // Adopt the future handle so it is released within this scope.
+                    // Adopt the future object so it is released within this scope.
                     PyObjectHandle futureGuard{futureObject};
                     PyObjectHandle discard{callMethod(futureGuard.get(), "set_result", Py_None)};
                 },
@@ -247,7 +247,7 @@ connectionClose(ConnectionObject* self, PyObject* /* args */)
                 {
                     // Ensure the current thread is able to call into Python.
                     AdoptThread adoptThread;
-                    // Adopt the future handle so it is released within this scope.
+                    // Adopt the future object so it is released within this scope.
                     PyObjectHandle futureGuard{futureObject};
                     PyObjectHandle pythonException{convertException(ex)};
                     PyObjectHandle discard{callMethod(futureGuard.get(), "set_exception", pythonException.get())};


### PR DESCRIPTION
This PR updates the handling of Python future objects in communicatorShutdownCompleted implementation to use the same patter used in connectionClose.