### PR TITLE
Remove noexcept from functions that can't be noexcept

### DIFF
--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -80,7 +80,7 @@ namespace DataStorm
          *
          * @return The update tag.
          */
-        [[nodiscard]] UpdateTag getUpdateTag() const noexcept;
+        [[nodiscard]] UpdateTag getUpdateTag() const;
 
         /**
          * The timestamp of the sample.
@@ -100,7 +100,7 @@ namespace DataStorm
          *
          * @return The origin of the sample.
          */
-        [[nodiscard]] std::string getOrigin() const noexcept;
+        [[nodiscard]] const std::string& getOrigin() const noexcept;
 
         /**
          * Get the session identifier of the session that received this sample.
@@ -109,7 +109,7 @@ namespace DataStorm
          *
          * @return The session identifier.
          */
-        [[nodiscard]] std::string getSession() const noexcept;
+        [[nodiscard]] const std::string& getSession() const noexcept;
 
         /** @private */
         Sample(const std::shared_ptr<DataStormI::Sample>&) noexcept;
@@ -209,21 +209,21 @@ namespace DataStorm
          *
          * @return The names of the connected writers.
          */
-        [[nodiscard]] std::vector<std::string> getConnectedWriters() const noexcept;
+        [[nodiscard]] std::vector<std::string> getConnectedWriters() const;
 
         /**
          * Get the keys for which writers are connected to this reader.
          *
          * @return The keys for which we have writers connected.
          **/
-        [[nodiscard]] std::vector<Key> getConnectedKeys() const noexcept;
+        [[nodiscard]] std::vector<Key> getConnectedKeys() const;
 
         /**
          * Returns all the unread samples.
          *
          * @return The unread samples.
          */
-        [[nodiscard]] std::vector<Sample<Key, Value, UpdateTag>> getAllUnread() noexcept;
+        [[nodiscard]] std::vector<Sample<Key, Value, UpdateTag>> getAllUnread();
 
         /**
          * Wait for given number of unread samples to be available.
@@ -364,14 +364,14 @@ namespace DataStorm
          *
          * @return The names of the connected readers.
          */
-        [[nodiscard]] std::vector<std::string> getConnectedReaders() const noexcept;
+        [[nodiscard]] std::vector<std::string> getConnectedReaders() const;
 
         /**
          * Get the keys for which readers are connected to this writer.
          *
          * @return The keys for which we have writers connected.
          **/
-        [[nodiscard]] std::vector<Key> getConnectedKeys() const noexcept;
+        [[nodiscard]] std::vector<Key> getConnectedKeys() const;
 
         /**
          * Get the last written sample.
@@ -386,7 +386,7 @@ namespace DataStorm
          *
          * @return The sample history.
          **/
-        [[nodiscard]] std::vector<Sample<Key, Value, UpdateTag>> getAll() noexcept;
+        [[nodiscard]] std::vector<Sample<Key, Value, UpdateTag>> getAll();
 
         /**
          * Calls the given functions to provide the initial set of connected keys and when a key is added or
@@ -1017,7 +1017,7 @@ namespace DataStorm
             const Topic<Key, Value, UpdateTag>& topic,
             const Key& key,
             std::string name = std::string(),
-            const WriterConfig& config = WriterConfig()) noexcept;
+            const WriterConfig& config = WriterConfig());
 
         /**
          * Move constructor.
@@ -1039,7 +1039,7 @@ namespace DataStorm
          *
          * @param value The data element value.
          */
-        void add(const Value& value) noexcept;
+        void add(const Value& value);
 
         /**
          * Update the data element. This generates an {@link Update} sample with the
@@ -1047,7 +1047,7 @@ namespace DataStorm
          *
          * @param value The data element value.
          */
-        void update(const Value& value) noexcept;
+        void update(const Value& value);
 
         /**
          * Get a partial update generator function for the given partial update tag. When called, the returned
@@ -1059,7 +1059,7 @@ namespace DataStorm
          * @param tag The partial update tag.
          */
         template<typename UpdateValue>
-        [[nodiscard]] std::function<void(const UpdateValue&)> partialUpdate(const UpdateTag& tag) noexcept;
+        [[nodiscard]] std::function<void(const UpdateValue&)> partialUpdate(const UpdateTag& tag);
 
         /**
          * Remove the data element. This generates a {@link Remove} sample.
@@ -1093,7 +1093,7 @@ namespace DataStorm
             const Topic<Key, Value, UpdateTag>& topic,
             const std::vector<Key>& keys,
             std::string name = std::string(),
-            const WriterConfig& config = WriterConfig()) noexcept;
+            const WriterConfig& config = WriterConfig());
 
         /**
          * Transfers the given writer to this writer.
@@ -1115,7 +1115,7 @@ namespace DataStorm
          * @param key The key
          * @param value The data element value.
          */
-        void add(const Key& key, const Value& value) noexcept;
+        void add(const Key& key, const Value& value);
 
         /**
          * Update the data element. This generates an {@link Update} sample with the given value.
@@ -1123,7 +1123,7 @@ namespace DataStorm
          * @param key The key
          * @param value The data element value.
          */
-        void update(const Key& key, const Value& value) noexcept;
+        void update(const Key& key, const Value& value);
 
         /**
          * Get a partial update generator function for the given partial update tag. When called, the returned
@@ -1135,7 +1135,7 @@ namespace DataStorm
          * @param tag The partial update tag.
          */
         template<typename UpdateValue>
-        [[nodiscard]] std::function<void(const Key&, const UpdateValue&)> partialUpdate(const UpdateTag& tag) noexcept;
+        [[nodiscard]] std::function<void(const Key&, const UpdateValue&)> partialUpdate(const UpdateTag& tag);
 
         /**
          * Remove the data element. This generates a {@link Remove} sample.
@@ -1163,7 +1163,7 @@ namespace DataStorm
         const Topic<K, V, UT>& topic,
         const typename Topic<K, V, UT>::KeyType& key,
         std::string name = std::string(),
-        const WriterConfig& config = WriterConfig()) noexcept
+        const WriterConfig& config = WriterConfig())
     {
         return SingleKeyWriter<K, V, UT>(topic, key, std::move(name), config);
     }
@@ -1182,7 +1182,7 @@ namespace DataStorm
         const Topic<K, V, UT>& topic,
         const std::vector<typename Topic<K, V, UT>::KeyType>& keys,
         std::string name = std::string(),
-        const WriterConfig& config = WriterConfig()) noexcept
+        const WriterConfig& config = WriterConfig())
     {
         return MultiKeyWriter<K, V, UT>(topic, keys, std::move(name), config);
     }
@@ -1199,7 +1199,7 @@ namespace DataStorm
     [[nodiscard]] MultiKeyWriter<K, V, UT> makeAnyKeyWriter(
         const Topic<K, V, UT>& topic,
         std::string name = std::string(),
-        const WriterConfig& config = WriterConfig()) noexcept
+        const WriterConfig& config = WriterConfig())
     {
         return MultiKeyWriter<K, V, UT>(topic, {}, std::move(name), config);
     }
@@ -1230,7 +1230,7 @@ namespace DataStorm
     }
 
     template<typename Key, typename Value, typename UpdateTag>
-    UpdateTag Sample<Key, Value, UpdateTag>::getUpdateTag() const noexcept
+    UpdateTag Sample<Key, Value, UpdateTag>::getUpdateTag() const
     {
         return _impl->getTag();
     }
@@ -1242,13 +1242,13 @@ namespace DataStorm
     }
 
     template<typename Key, typename Value, typename UpdateTag>
-    std::string Sample<Key, Value, UpdateTag>::getOrigin() const noexcept
+    const std::string& Sample<Key, Value, UpdateTag>::getOrigin() const noexcept
     {
         return _impl->origin;
     }
 
     template<typename Key, typename Value, typename UpdateTag>
-    std::string Sample<Key, Value, UpdateTag>::getSession() const noexcept
+    const std::string& Sample<Key, Value, UpdateTag>::getSession() const noexcept
     {
         return _impl->session;
     }
@@ -1306,13 +1306,13 @@ namespace DataStorm
     }
 
     template<typename Key, typename Value, typename UpdateTag>
-    std::vector<std::string> Reader<Key, Value, UpdateTag>::getConnectedWriters() const noexcept
+    std::vector<std::string> Reader<Key, Value, UpdateTag>::getConnectedWriters() const
     {
         return _impl->getConnectedElements();
     }
 
     template<typename Key, typename Value, typename UpdateTag>
-    std::vector<Key> Reader<Key, Value, UpdateTag>::getConnectedKeys() const noexcept
+    std::vector<Key> Reader<Key, Value, UpdateTag>::getConnectedKeys() const
     {
         std::vector<Key> keys;
         auto connectedKeys = _impl->getConnectedKeys();
@@ -1325,7 +1325,7 @@ namespace DataStorm
     }
 
     template<typename Key, typename Value, typename UpdateTag>
-    std::vector<Sample<Key, Value, UpdateTag>> Reader<Key, Value, UpdateTag>::getAllUnread() noexcept
+    std::vector<Sample<Key, Value, UpdateTag>> Reader<Key, Value, UpdateTag>::getAllUnread()
     {
         auto unread = _impl->getAllUnread();
         std::vector<Sample<Key, Value, UpdateTag>> samples;
@@ -1588,13 +1588,13 @@ namespace DataStorm
     }
 
     template<typename Key, typename Value, typename UpdateTag>
-    std::vector<std::string> Writer<Key, Value, UpdateTag>::getConnectedReaders() const noexcept
+    std::vector<std::string> Writer<Key, Value, UpdateTag>::getConnectedReaders() const
     {
         return _impl->getConnectedElements();
     }
 
     template<typename Key, typename Value, typename UpdateTag>
-    std::vector<Key> Writer<Key, Value, UpdateTag>::getConnectedKeys() const noexcept
+    std::vector<Key> Writer<Key, Value, UpdateTag>::getConnectedKeys() const
     {
         std::vector<Key> keys;
         auto connectedKeys = _impl->getConnectedKeys();
@@ -1618,7 +1618,7 @@ namespace DataStorm
     }
 
     template<typename Key, typename Value, typename UpdateTag>
-    std::vector<Sample<Key, Value, UpdateTag>> Writer<Key, Value, UpdateTag>::getAll() noexcept
+    std::vector<Sample<Key, Value, UpdateTag>> Writer<Key, Value, UpdateTag>::getAll()
     {
         auto all = _impl->getAll();
         std::vector<Sample<Key, Value, UpdateTag>> samples;
@@ -1667,7 +1667,7 @@ namespace DataStorm
         const Topic<Key, Value, UpdateTag>& topic,
         const Key& key,
         std::string name,
-        const WriterConfig& config) noexcept
+        const WriterConfig& config)
         : Writer<Key, Value, UpdateTag>(
               topic.getWriter()->create({topic._keyFactory->create(key)}, std::move(name), config)),
           _tagFactory(topic._tagFactory)
@@ -1690,7 +1690,7 @@ namespace DataStorm
     }
 
     template<typename Key, typename Value, typename UpdateTag>
-    void SingleKeyWriter<Key, Value, UpdateTag>::add(const Value& value) noexcept
+    void SingleKeyWriter<Key, Value, UpdateTag>::add(const Value& value)
     {
         Writer<Key, Value, UpdateTag>::_impl->publish(
             nullptr,
@@ -1698,7 +1698,7 @@ namespace DataStorm
     }
 
     template<typename Key, typename Value, typename UpdateTag>
-    void SingleKeyWriter<Key, Value, UpdateTag>::update(const Value& value) noexcept
+    void SingleKeyWriter<Key, Value, UpdateTag>::update(const Value& value)
     {
         Writer<Key, Value, UpdateTag>::_impl->publish(
             nullptr,
@@ -1707,8 +1707,7 @@ namespace DataStorm
 
     template<typename Key, typename Value, typename UpdateTag>
     template<typename UpdateValue>
-    std::function<void(const UpdateValue&)>
-    SingleKeyWriter<Key, Value, UpdateTag>::partialUpdate(const UpdateTag& tag) noexcept
+    std::function<void(const UpdateValue&)> SingleKeyWriter<Key, Value, UpdateTag>::partialUpdate(const UpdateTag& tag)
     {
         auto impl = Writer<Key, Value, UpdateTag>::_impl;
         auto updateTag = _tagFactory->create(tag);
@@ -1732,7 +1731,7 @@ namespace DataStorm
         const Topic<Key, Value, UpdateTag>& topic,
         const std::vector<Key>& keys,
         std::string name,
-        const WriterConfig& config) noexcept
+        const WriterConfig& config)
         : Writer<Key, Value, UpdateTag>(
               topic.getWriter()->create(topic._keyFactory->create(keys), std::move(name), config)),
           _keyFactory(topic._keyFactory),
@@ -1757,7 +1756,7 @@ namespace DataStorm
     }
 
     template<typename Key, typename Value, typename UpdateTag>
-    void MultiKeyWriter<Key, Value, UpdateTag>::add(const Key& key, const Value& value) noexcept
+    void MultiKeyWriter<Key, Value, UpdateTag>::add(const Key& key, const Value& value)
     {
         Writer<Key, Value, UpdateTag>::_impl->publish(
             _keyFactory->create(key),
@@ -1765,7 +1764,7 @@ namespace DataStorm
     }
 
     template<typename Key, typename Value, typename UpdateTag>
-    void MultiKeyWriter<Key, Value, UpdateTag>::update(const Key& key, const Value& value) noexcept
+    void MultiKeyWriter<Key, Value, UpdateTag>::update(const Key& key, const Value& value)
     {
         Writer<Key, Value, UpdateTag>::_impl->publish(
             _keyFactory->create(key),
@@ -1775,7 +1774,7 @@ namespace DataStorm
     template<typename Key, typename Value, typename UpdateTag>
     template<typename UpdateValue>
     std::function<void(const Key&, const UpdateValue&)>
-    MultiKeyWriter<Key, Value, UpdateTag>::partialUpdate(const UpdateTag& tag) noexcept
+    MultiKeyWriter<Key, Value, UpdateTag>::partialUpdate(const UpdateTag& tag)
     {
         auto impl = Writer<Key, Value, UpdateTag>::_impl;
         auto updateTag = _tagFactory->create(tag);
@@ -1798,8 +1797,7 @@ namespace DataStorm
     }
 
     /** @private */
-    template<typename Value>
-    std::function<std::function<bool(const Value&)>(const std::string&)> makeRegexFilter() noexcept
+    template<typename Value> std::function<std::function<bool(const Value&)>(const std::string&)> makeRegexFilter()
     {
         // std::regex's constructor accepts a const string&; it does not accept a string_view.
         return [](const std::string& criteria)
@@ -1817,7 +1815,7 @@ namespace DataStorm
     /** @private */
     template<typename Key, typename Value, typename UpdateTag>
     std::function<std::function<bool(const Sample<Key, Value, UpdateTag>&)>(const std::vector<SampleEvent>&)>
-    makeSampleEventFilter(const Topic<Key, Value, UpdateTag>&) noexcept
+    makeSampleEventFilter(const Topic<Key, Value, UpdateTag>&)
     {
         return [](const std::vector<SampleEvent>& criteria)
         {

--- a/cpp/include/Ice/Communicator.h
+++ b/cpp/include/Ice/Communicator.h
@@ -216,6 +216,7 @@ namespace Ice
          * communicator. This function returns null unless you set a non-null default object adapter using
          * setDefaultObjectAdapter.
          * @return The object adapter associated by default with new outgoing connections.
+         * @throws CommunicatorDestroyedException if the communicator has been destroyed.
          * @see Connection::getAdapter
          */
         [[nodiscard]] ObjectAdapterPtr getDefaultObjectAdapter() const;
@@ -258,6 +259,7 @@ namespace Ice
         /**
          * Get the default router for this communicator.
          * @return The default router for this communicator.
+         * @throws CommunicatorDestroyedException if the communicator has been destroyed.
          * @see #setDefaultRouter
          * @see Router
          */
@@ -298,6 +300,7 @@ namespace Ice
         /**
          * Get the plug-in manager for this communicator.
          * @return This communicator's plug-in manager.
+         * @throws CommunicatorDestroyedException if the communicator has been destroyed.
          * @see PluginManager
          */
         [[nodiscard]] PluginManagerPtr getPluginManager() const;
@@ -363,6 +366,7 @@ namespace Ice
          * <code>Ice.Admin.InstanceName</code> is not set. If Ice.Admin.DelayCreation is 0 or not set, getAdmin is
          * called by the communicator initialization, after initialization of all plugins.
          * @return A proxy to the main ("") facet of the Admin object, or nullopt if no Admin object is configured.
+         * @throws CommunicatorDestroyedException if the communicator has been destroyed.
          * @see #createAdmin
          */
         std::optional<ObjectPrx> getAdmin() const; // NOLINT(modernize-use-nodiscard)

--- a/cpp/include/Ice/Connection.h
+++ b/cpp/include/Ice/Connection.h
@@ -172,13 +172,14 @@ namespace Ice
          * Return the connection type. This corresponds to the endpoint type, i.e., "tcp", "udp", etc.
          * @return The type of the connection.
          */
-        [[nodiscard]] virtual std::string type() const noexcept = 0;
+        [[nodiscard]] virtual const std::string& type() const noexcept = 0;
 
         /**
          * Return a description of the connection as human readable text, suitable for logging or error messages.
          * @return The description of the connection as human readable text.
+         * @remark This function remains usable after the connection is closed or aborted.
          */
-        [[nodiscard]] virtual std::string toString() const noexcept = 0;
+        [[nodiscard]] virtual std::string toString() const = 0;
 
         /**
          * Returns the connection information.

--- a/cpp/include/Ice/ObjectAdapter.h
+++ b/cpp/include/Ice/ObjectAdapter.h
@@ -33,7 +33,7 @@ namespace Ice
 
         /// Gets the name of this object adapter.
         /// @return This object adapter's name.
-        [[nodiscard]] virtual const std::string& getName() const = 0;
+        [[nodiscard]] virtual const std::string& getName() const noexcept = 0;
 
         /// Gets the communicator this object adapter belongs to.
         /// @return This object adapter's communicator.

--- a/cpp/include/Ice/ObjectAdapter.h
+++ b/cpp/include/Ice/ObjectAdapter.h
@@ -34,8 +34,9 @@ namespace Ice
         /**
          * Get the name of this object adapter.
          * @return This object adapter's name.
+         * @remark This function remains usable after the object adapter has been deactivated.
          */
-        [[nodiscard]] virtual std::string getName() const noexcept = 0;
+        [[nodiscard]] virtual std::string getName() const = 0;
 
         /**
          * Get the communicator this object adapter belongs to.
@@ -434,15 +435,17 @@ namespace Ice
          * Get the set of endpoints configured with this object adapter.
          * @return The set of endpoints.
          * @see Endpoint
+         * @remark This function remains usable after the object adapter has been deactivated.
          */
-        [[nodiscard]] virtual EndpointSeq getEndpoints() const noexcept = 0;
+        [[nodiscard]] virtual EndpointSeq getEndpoints() const = 0;
 
         /**
          * Get the set of endpoints that proxies created by this object adapter will contain.
          * @return The set of published endpoints.
          * @see Endpoint
+         * @remark This function remains usable after the object adapter has been deactivated.
          */
-        [[nodiscard]] virtual EndpointSeq getPublishedEndpoints() const noexcept = 0;
+        [[nodiscard]] virtual EndpointSeq getPublishedEndpoints() const = 0;
 
         /**
          * Set of the endpoints that proxies created by this object adapter will contain.

--- a/cpp/include/Ice/ObjectAdapter.h
+++ b/cpp/include/Ice/ObjectAdapter.h
@@ -31,18 +31,12 @@ namespace Ice
     public:
         virtual ~ObjectAdapter();
 
-        /**
-         * Get the name of this object adapter.
-         * @return This object adapter's name.
-         * @remark This function remains usable after the object adapter has been deactivated.
-         */
-        [[nodiscard]] virtual std::string getName() const = 0;
+        /// Gets the name of this object adapter.
+        /// @return This object adapter's name.
+        [[nodiscard]] virtual const std::string& getName() const = 0;
 
-        /**
-         * Get the communicator this object adapter belongs to.
-         * @return This object adapter's communicator.
-         * @see Communicator
-         */
+        /// Gets the communicator this object adapter belongs to.
+        /// @return This object adapter's communicator.
         [[nodiscard]] virtual CommunicatorPtr getCommunicator() const noexcept = 0;
 
         /**

--- a/cpp/include/Ice/Properties.h
+++ b/cpp/include/Ice/Properties.h
@@ -59,7 +59,7 @@ namespace Ice
          * @return The property value.
          * @see #setProperty
          */
-        std::string getProperty(std::string_view key) noexcept;
+        std::string getProperty(std::string_view key);
 
         /**
          * Get an Ice property by key. If the property is not set, its default value is returned.
@@ -77,7 +77,7 @@ namespace Ice
          * @return The property value or the default value.
          * @see #setProperty
          */
-        std::string getPropertyWithDefault(std::string_view key, std::string_view value) noexcept;
+        std::string getPropertyWithDefault(std::string_view key, std::string_view value);
 
         /**
          * Get a property as an integer. If the property is not set, 0 is returned.
@@ -117,7 +117,7 @@ namespace Ice
          * @return The property value interpreted as a list of strings.
          * @see #setProperty
          */
-        StringSeq getPropertyAsList(std::string_view key) noexcept;
+        StringSeq getPropertyAsList(std::string_view key);
 
         /**
          * Get an Ice property as a list of strings. The strings must be separated by whitespace or comma. If the
@@ -143,7 +143,7 @@ namespace Ice
          * @return The property value interpreted as list of strings, or the default value.
          * @see #setProperty
          */
-        StringSeq getPropertyAsListWithDefault(std::string_view key, const StringSeq& value) noexcept;
+        StringSeq getPropertyAsListWithDefault(std::string_view key, const StringSeq& value);
 
         /**
          * Get all properties whose keys begins with <em>prefix</em>. If <em>prefix</em> is an empty string, then all
@@ -151,7 +151,7 @@ namespace Ice
          * @param prefix The prefix to search for (empty string if none).
          * @return The matching property set.
          */
-        PropertyDict getPropertiesForPrefix(std::string_view prefix) noexcept;
+        PropertyDict getPropertiesForPrefix(std::string_view prefix);
 
         /**
          * Set a property. To unset a property, set it to the empty string.
@@ -166,7 +166,7 @@ namespace Ice
          * sequence is a command-line option of the form <code>--<em>key</em>=<em>value</em></code>.
          * @return The command line options for this property set.
          */
-        StringSeq getCommandLineOptions() noexcept;
+        StringSeq getCommandLineOptions();
 
         /**
          * Convert a sequence of command-line options into properties. All options that begin with

--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -642,7 +642,7 @@ namespace Ice
          * Obtains the identity embedded in this proxy.
          * @return The identity of the target object.
          */
-        [[nodiscard]] Ice::Identity ice_getIdentity() const;
+        [[nodiscard]] const Ice::Identity& ice_getIdentity() const noexcept;
 
         /**
          * Obtains a proxy that is identical to this proxy, except for the identity.
@@ -665,7 +665,7 @@ namespace Ice
          * Obtains the facet for this proxy.
          * @return The facet for this proxy. If the proxy uses the default facet, the return value is the empty string.
          */
-        [[nodiscard]] std::string ice_getFacet() const;
+        [[nodiscard]] const std::string& ice_getFacet() const noexcept;
 
         /**
          * Obtains a proxy that is identical to this proxy, except for the facet.

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -1835,7 +1835,7 @@ Ice::ConnectionI::finish(bool close)
 }
 
 string
-Ice::ConnectionI::toString() const noexcept
+Ice::ConnectionI::toString() const
 {
     return _desc; // No mutex lock, _desc is immutable.
 }
@@ -1846,7 +1846,7 @@ Ice::ConnectionI::getNativeInfo()
     return _transceiver->getNativeInfo();
 }
 
-string
+const string&
 Ice::ConnectionI::type() const noexcept
 {
     return _type; // No mutex lock, _type is immutable.

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -199,11 +199,11 @@ namespace Ice
 
         void message(IceInternal::ThreadPoolCurrent&) final;
         void finished(IceInternal::ThreadPoolCurrent&, bool) final;
-        [[nodiscard]] std::string toString() const noexcept final; // From Connection and EventHandler.
+        [[nodiscard]] std::string toString() const final; // From Connection and EventHandler.
         IceInternal::NativeInfoPtr getNativeInfo() final;
 
-        [[nodiscard]] std::string type() const noexcept final; // From Connection.
-        [[nodiscard]] ConnectionInfoPtr getInfo() const final; // From Connection
+        [[nodiscard]] const std::string& type() const noexcept final; // From Connection.
+        [[nodiscard]] ConnectionInfoPtr getInfo() const final;        // From Connection
 
         void setBufferSize(std::int32_t rcvSize, std::int32_t sndSize) final; // From Connection
 

--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -51,7 +51,7 @@ namespace
 Ice::ObjectAdapter::~ObjectAdapter() = default; // avoid weak vtable
 
 string
-Ice::ObjectAdapterI::getName() const noexcept
+Ice::ObjectAdapterI::getName() const
 {
     //
     // No mutex lock necessary, _name is immutable.
@@ -587,7 +587,7 @@ Ice::ObjectAdapterI::getLocator() const noexcept
 }
 
 EndpointSeq
-Ice::ObjectAdapterI::getEndpoints() const noexcept
+Ice::ObjectAdapterI::getEndpoints() const
 {
     lock_guard lock(_mutex);
 
@@ -601,7 +601,7 @@ Ice::ObjectAdapterI::getEndpoints() const noexcept
 }
 
 EndpointSeq
-Ice::ObjectAdapterI::getPublishedEndpoints() const noexcept
+Ice::ObjectAdapterI::getPublishedEndpoints() const
 {
     lock_guard lock(_mutex);
     return {_publishedEndpoints.begin(), _publishedEndpoints.end()};

--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -46,17 +46,16 @@ using namespace IceInternal;
 namespace
 {
     inline EndpointIPtr toEndpointI(const EndpointPtr& endp) { return dynamic_pointer_cast<EndpointI>(endp); }
+
+    string emptyName{};
 }
 
 Ice::ObjectAdapter::~ObjectAdapter() = default; // avoid weak vtable
 
-string
-Ice::ObjectAdapterI::getName() const
+const string&
+Ice::ObjectAdapterI::getName() const noexcept
 {
-    //
-    // No mutex lock necessary, _name is immutable.
-    //
-    return _noConfig ? string("") : _name;
+    return _noConfig ? emptyName : _name;
 }
 
 CommunicatorPtr

--- a/cpp/src/Ice/ObjectAdapterI.h
+++ b/cpp/src/Ice/ObjectAdapterI.h
@@ -35,7 +35,7 @@ namespace Ice
     class ObjectAdapterI final : public ObjectAdapter, public std::enable_shared_from_this<ObjectAdapterI>
     {
     public:
-        [[nodiscard]] std::string getName() const noexcept final;
+        [[nodiscard]] std::string getName() const final;
 
         [[nodiscard]] CommunicatorPtr getCommunicator() const noexcept final;
 
@@ -75,9 +75,9 @@ namespace Ice
 
         void setLocator(std::optional<LocatorPrx>) final;
         [[nodiscard]] std::optional<LocatorPrx> getLocator() const noexcept override;
-        [[nodiscard]] EndpointSeq getEndpoints() const noexcept override;
+        [[nodiscard]] EndpointSeq getEndpoints() const override;
 
-        [[nodiscard]] EndpointSeq getPublishedEndpoints() const noexcept override;
+        [[nodiscard]] EndpointSeq getPublishedEndpoints() const override;
         void setPublishedEndpoints(EndpointSeq) final;
 
         [[nodiscard]] bool isLocal(const IceInternal::ReferencePtr&) const;

--- a/cpp/src/Ice/ObjectAdapterI.h
+++ b/cpp/src/Ice/ObjectAdapterI.h
@@ -35,7 +35,7 @@ namespace Ice
     class ObjectAdapterI final : public ObjectAdapter, public std::enable_shared_from_this<ObjectAdapterI>
     {
     public:
-        [[nodiscard]] std::string getName() const final;
+        [[nodiscard]] const std::string& getName() const noexcept final;
 
         [[nodiscard]] CommunicatorPtr getCommunicator() const noexcept final;
 

--- a/cpp/src/Ice/Properties.cpp
+++ b/cpp/src/Ice/Properties.cpp
@@ -160,7 +160,7 @@ Ice::Properties::Properties(StringSeq& args, const PropertiesPtr& defaults)
 }
 
 string
-Ice::Properties::getProperty(string_view key) noexcept
+Ice::Properties::getProperty(string_view key)
 {
     lock_guard lock(_mutex);
 
@@ -184,7 +184,7 @@ Ice::Properties::getIceProperty(string_view key)
 }
 
 string
-Ice::Properties::getPropertyWithDefault(string_view key, string_view value) noexcept
+Ice::Properties::getPropertyWithDefault(string_view key, string_view value)
 {
     lock_guard lock(_mutex);
 
@@ -245,7 +245,7 @@ Ice::Properties::getPropertyAsIntWithDefault(string_view key, int32_t value)
 }
 
 Ice::StringSeq
-Ice::Properties::getPropertyAsList(string_view key) noexcept
+Ice::Properties::getPropertyAsList(string_view key)
 {
     return getPropertyAsListWithDefault(key, StringSeq());
 }
@@ -260,7 +260,7 @@ Ice::Properties::getIcePropertyAsList(string_view key)
 }
 
 Ice::StringSeq
-Ice::Properties::getPropertyAsListWithDefault(string_view key, const StringSeq& value) noexcept
+Ice::Properties::getPropertyAsListWithDefault(string_view key, const StringSeq& value)
 {
     lock_guard lock(_mutex);
 
@@ -288,7 +288,7 @@ Ice::Properties::getPropertyAsListWithDefault(string_view key, const StringSeq& 
 }
 
 PropertyDict
-Ice::Properties::getPropertiesForPrefix(string_view prefix) noexcept
+Ice::Properties::getPropertiesForPrefix(string_view prefix)
 {
     lock_guard lock(_mutex);
 
@@ -364,7 +364,7 @@ Ice::Properties::setProperty(string_view key, string_view value)
 }
 
 StringSeq
-Ice::Properties::getCommandLineOptions() noexcept
+Ice::Properties::getCommandLineOptions()
 {
     lock_guard lock(_mutex);
 

--- a/cpp/src/Ice/Proxy.cpp
+++ b/cpp/src/Ice/Proxy.cpp
@@ -70,8 +70,8 @@ Ice::operator<<(ostream& os, const Ice::ObjectPrx& p)
     return os << p.ice_toString();
 }
 
-Identity
-Ice::ObjectPrx::ice_getIdentity() const
+const Identity&
+Ice::ObjectPrx::ice_getIdentity() const noexcept
 {
     return _reference->getIdentity();
 }
@@ -82,8 +82,8 @@ Ice::ObjectPrx::ice_getContext() const
     return _reference->getContext()->getValue();
 }
 
-string
-Ice::ObjectPrx::ice_getFacet() const
+const string&
+Ice::ObjectPrx::ice_getFacet() const noexcept
 {
     return _reference->getFacet();
 }


### PR DESCRIPTION
This PR removes 'noexcept' from various functions that can't be no except - usually because they return a value where the constructor / copy-constructor allocates memory.

It also updates a number of functions to return a `const&` and remain or become noexcept.

Fixes #3701.