### PR TITLE
Fix deadlock in DataStorm session creation

### DIFF
--- a/cpp/src/DataStorm/NodeI.cpp
+++ b/cpp/src/DataStorm/NodeI.cpp
@@ -183,11 +183,6 @@ NodeI::createSession(
             return; // Shutting down.
         }
 
-        // Unlock the mutex to prevent a deadlock. If ice_getConnectionAsync completes synchronously, the callback will
-        // execute with the mutex locked. This could cause a deadlock if the callback calls createSession again—for
-        // example, during session->reconnect.
-        lock.unlock();
-
         s->ice_getConnectionAsync(
             [=, self = shared_from_this()](const auto& connection) mutable
             {


### PR DESCRIPTION
Fix #3462

I wanted to add a test for this code path, but it is not simple. The connection and recovery is all handled automatically...