### PR TITLE
Fix operation mode check in C++, C# and Java

### DIFF
--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -21,7 +21,7 @@ namespace
         switch (opMode)
         {
             case Operation::Normal:
-                mode = "null"; // shorthand for most common case
+                mode += "Normal";
                 break;
             case Operation::Idempotent:
                 mode += "Idempotent";

--- a/csharp/src/Ice/Object.cs
+++ b/csharp/src/Ice/Object.cs
@@ -127,17 +127,12 @@ public abstract class ObjectImpl : Object
 
     public static void iceCheckMode(OperationMode expected, OperationMode received)
     {
-        Debug.Assert(expected is OperationMode.Normal or OperationMode.Idempotent); // We never expect Nonmutating
-        if (expected != received)
+        if (received is not OperationMode.Normal && expected is OperationMode.Normal)
         {
-            if (expected is OperationMode.Idempotent && received is not OperationMode.Normal)
-            {
-                // Fine: typically an old client still using the deprecated nonmutating keyword/mode.
-            }
-            else
-            {
-                throw new MarshalException($"unexpected operation mode: expected = {expected} received = {received}");
-            }
+            // The caller believes the operation is idempotent or non-mutating, but the implementation (the local code)
+            // doesn't. This is a problem, as the Ice runtime could retry automatically when it shouldn't. Other
+            // mismatches are not a concern.
+            throw new MarshalException($"Operation mode mismatch: expected = {expected} received = {received}");
         }
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Object.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Object.java
@@ -162,45 +162,19 @@ public interface Object {
 
     /**
      * @hidden
-     * @param mode -
-     * @return -
-     */
-    static String _iceOperationModeToString(OperationMode mode) {
-        if (mode == OperationMode.Normal) {
-            return "::Ice::Normal";
-        }
-        if (mode == OperationMode.Nonmutating) {
-            return "::Ice::Nonmutating";
-        }
-
-        if (mode == OperationMode.Idempotent) {
-            return "::Ice::Idempotent";
-        }
-
-        return "???";
-    }
-
-    /**
-     * @hidden
      * @param expected -
      * @param received -
      */
     static void _iceCheckMode(OperationMode expected, OperationMode received) {
-        if (expected == null) {
-            expected = OperationMode.Normal;
-        }
-
-        assert expected != OperationMode.Nonmutating; // We never expect Nonmutating
-        if (expected != received) {
-            if (expected == OperationMode.Idempotent && received == OperationMode.Nonmutating) {
-                // Fine: typically an old client still using the deprecated nonmutating keyword
-            } else {
-                throw new MarshalException(
-                        "unexpected operation mode: expected = "
-                                + _iceOperationModeToString(expected)
-                                + " received = "
-                                + _iceOperationModeToString(received));
-            }
+        if (received != OperationMode.Normal && expected == OperationMode.Normal) {
+            // The caller believes the operation is idempotent or non-mutating, but the
+            // implementation (the local code) doesn't. This is a problem, as the Ice runtime
+            // could retry automatically when it shouldn't. Other mismatches are not a concern.
+            throw new MarshalException(
+                    "Operation mode mismatch: expected = "
+                            + expected.toString()
+                            + " received = "
+                            + received.toString());
         }
     }
 }


### PR DESCRIPTION
Fixes #3679.

We should be checking this operation mode for mismatch in all languages with server-side support, but currently only check it in C++, C#, Java and Python.

We have a TODO in slice2swift:
https://github.com/zeroc-ice/ice/blob/db9df33024761cc5fb281fbb8f390b415cc041b4/cpp/src/slice2swift/SwiftUtil.cpp#L1615

I can't find where we check it in JS (if we check it).