### PR TITLE
Applies article to generated doc-comment

### DIFF
--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -736,7 +736,7 @@ Slice::writeStreamReader(Output& out, const StructPtr& p, const DataMemberList& 
     out << nl << "template<>";
     out << nl << "struct StreamReader<" << fullName << ">";
     out << sb;
-    out << nl << "/// Unmarshals a " << fullName << " from the input stream.";
+    out << nl << "/// Unmarshals " << getArticleFor(fullName) << ' ' << fullName << " from the input stream.";
     out << nl << "static void read(InputStream* istr, " << fullName << "& v)";
     out << sb;
 

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1254,7 +1254,7 @@ Slice::Gen::ForwardDeclVisitor::visitEnum(const EnumPtr& p)
 
     H << sp;
     H << nl << "/// Outputs the enumerator name or underlying value of " << getArticleFor(mappedName) << ' '
-        << mappedName << " to a stream.";
+      << mappedName << " to a stream.";
     H << nl << "/// @param os The output stream.";
     H << nl << "/// @param value The value to output.";
     H << nl << "/// @return The output stream.";
@@ -2106,7 +2106,7 @@ Slice::Gen::DataDefVisitor::visitStructEnd(const StructPtr& p)
 
     H << sp;
     H << nl << "/// Outputs the description of " << getArticleFor(p->mappedName()) << ' ' << p->mappedName()
-        << " to a stream, including all its fields.";
+      << " to a stream, including all its fields.";
     H << nl << "/// @param os The output stream.";
     H << nl << "/// @param value The instance to output.";
     H << nl << "/// @return The output stream.";

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1162,7 +1162,7 @@ Slice::Gen::ForwardDeclVisitor::visitClassDecl(const ClassDeclPtr& p)
     H << nl << "class " << name << ';';
 
     H << sp;
-    H << nl << "/// A shared pointer to a " << name << ".";
+    H << nl << "/// A shared pointer to " << getArticleFor(name) << ' ' << name << ".";
     H << nl << "using " << name << "Ptr " << getDeprecatedAttribute(p) << "= std::shared_ptr<" << name << ">;";
 }
 
@@ -1253,7 +1253,8 @@ Slice::Gen::ForwardDeclVisitor::visitEnum(const EnumPtr& p)
     H << eb << ';';
 
     H << sp;
-    H << nl << "/// Outputs the enumerator name or underlying value of a " << mappedName << " to a stream.";
+    H << nl << "/// Outputs the enumerator name or underlying value of " << getArticleFor(mappedName) << ' '
+        << mappedName << " to a stream.";
     H << nl << "/// @param os The output stream.";
     H << nl << "/// @param value The value to output.";
     H << nl << "/// @return The output stream.";
@@ -2104,7 +2105,8 @@ Slice::Gen::DataDefVisitor::visitStructEnd(const StructPtr& p)
     C << eb;
 
     H << sp;
-    H << nl << "/// Outputs the description of a " << p->mappedName() << " to a stream, including all its fields.";
+    H << nl << "/// Outputs the description of " << getArticleFor(p->mappedName()) << ' ' << p->mappedName()
+        << " to a stream, including all its fields.";
     H << nl << "/// @param os The output stream.";
     H << nl << "/// @param value The instance to output.";
     H << nl << "/// @return The output stream.";
@@ -2942,7 +2944,7 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     H << eb << ';';
 
     H << sp;
-    H << nl << "/// A shared pointer to a " << name << ".";
+    H << nl << "/// A shared pointer to " << getArticleFor(name) << ' ' << name << ".";
     H << nl << "using " << name << "Ptr = std::shared_ptr<" << name << ">;";
 
     _useWstring = resetUseWstring(_useWstringHist);

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1612,7 +1612,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     _out << sp;
     ostringstream classComment;
     classComment << "Provides methods to marshal and unmarshal " << getArticleFor(name) << " <see cref=\"" << name
-        << "\" />.";
+                 << "\" />.";
     writeHelperDocComment(p, classComment.str(), "enum helper class");
     _out << nl << "public sealed class " << name << "Helper";
     _out << sb;

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1611,7 +1611,8 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 
     _out << sp;
     ostringstream classComment;
-    classComment << "Provides methods to marshal and unmarshal a <see cref=\"" << name << "\" />.";
+    classComment << "Provides methods to marshal and unmarshal " << getArticleFor(name) << " <see cref=\"" << name
+        << "\" />.";
     writeHelperDocComment(p, classComment.str(), "enum helper class");
     _out << nl << "public sealed class " << name << "Helper";
     _out << sb;
@@ -2031,7 +2032,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out.dec();
 
     ostringstream checkedCastSummary;
-    checkedCastSummary << "Downcasts a proxy to a <see cref=\"" << name
+    checkedCastSummary << "Downcasts a proxy to " << getArticleFor(name) << " <see cref=\"" << name
                        << "Prx\" /> after checking that the target object implements Slice interface <c>" << p->name()
                        << "</c>.";
 
@@ -2053,7 +2054,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out.dec();
 
     ostringstream checkedCastWithFacetSummary;
-    checkedCastWithFacetSummary << "Downcasts a proxy to a <see cref=\"" << name
+    checkedCastWithFacetSummary << "Downcasts a proxy to " << getArticleFor(name) << " <see cref=\"" << name
                                 << "Prx\" /> after checking that the target facet implements Slice interface <c>"
                                 << p->name() << "</c>.";
 
@@ -2102,7 +2103,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out.dec();
 
     ostringstream uncheckedCastSummary;
-    uncheckedCastSummary << "Downcasts a proxy to a <see cref=\"" << name
+    uncheckedCastSummary << "Downcasts a proxy to " << getArticleFor(name) << " <see cref=\"" << name
                          << "Prx\" />. This method does not perform any check.";
 
     _out << sp;
@@ -2116,7 +2117,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out.dec();
 
     ostringstream uncheckedCastWithFacetSummary;
-    uncheckedCastWithFacetSummary << "Downcasts a proxy to a <see cref=\"" << name
+    uncheckedCastWithFacetSummary << "Downcasts a proxy to " << getArticleFor(name) << " <see cref=\"" << name
                                   << "Prx\" /> after changing its facet. This method does not perform any check.";
 
     _out << sp;

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -908,7 +908,8 @@ Slice::Ruby::CodeVisitor::visitEnum(const EnumPtr& p)
     //
     _out << sp << nl << "def <=>(other)";
     _out.inc();
-    _out << nl << "other.is_a?(" << name << ") or raise ArgumentError, \"value must be a " << name << "\"";
+    _out << nl << "other.is_a?(" << name << ") or raise ArgumentError, \"value must be " << getArticleFor(name) << ' '
+        << name << "\"";
     _out << nl << "@value <=> other.to_i";
     _out.dec();
     _out << nl << "end";

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -909,7 +909,7 @@ Slice::Ruby::CodeVisitor::visitEnum(const EnumPtr& p)
     _out << sp << nl << "def <=>(other)";
     _out.inc();
     _out << nl << "other.is_a?(" << name << ") or raise ArgumentError, \"value must be " << getArticleFor(name) << ' '
-        << name << "\"";
+         << name << "\"";
     _out << nl << "@value <=> other.to_i";
     _out.dec();
     _out << nl << "end";


### PR DESCRIPTION
Updates the Slice compilers to generate "a" or "an" in doc-comments as appropriate.