### PR TITLE
Remove finalizers from C# tests

### DIFF
--- a/csharp/test/Ice/adapterDeactivation/ServantLocatorI.cs
+++ b/csharp/test/Ice/adapterDeactivation/ServantLocatorI.cs
@@ -26,14 +26,6 @@ public sealed class ServantLocatorI : Ice.ServantLocator
         _deactivated = false;
     }
 
-    ~ServantLocatorI()
-    {
-        lock (this)
-        {
-            test(_deactivated);
-        }
-    }
-
     private static void test(bool b) => global::Test.TestHelper.test(b);
 
     public Ice.Object locate(Ice.Current current, out System.Object cookie)

--- a/csharp/test/Ice/plugin/PluginFactory.cs
+++ b/csharp/test/Ice/plugin/PluginFactory.cs
@@ -16,6 +16,7 @@ public class PluginFactory : Ice.PluginFactory
 
         public void initialize()
         {
+            test(!_initialized);
             _initialized = true;
             test(_args.Length == 3);
             test(_args[0] == "C:\\Program Files\\");
@@ -25,25 +26,12 @@ public class PluginFactory : Ice.PluginFactory
 
         public void destroy()
         {
-            _destroyed = true;
-        }
-
-        ~Plugin()
-        {
-            if (!_initialized)
-            {
-                Console.WriteLine("Plugin not initialized");
-            }
-            if (!_destroyed)
-            {
-                Console.WriteLine("Plugin not destroyed");
-            }
+            test(_initialized);
         }
 
         private static void test(bool b) => global::Test.TestHelper.test(b);
 
         private bool _initialized = false;
-        private bool _destroyed = false;
         private string[] _args;
     }
 }

--- a/csharp/test/Ice/plugin/PluginOneFailFactory.cs
+++ b/csharp/test/Ice/plugin/PluginOneFailFactory.cs
@@ -31,17 +31,5 @@ public class PluginOneFailFactory : Ice.PluginFactory
             test(!_three.isDestroyed());
             _destroyed = true;
         }
-
-        ~PluginOneFail()
-        {
-            if (!_initialized)
-            {
-                Console.WriteLine("PluginOneFail not initialized");
-            }
-            if (!_destroyed)
-            {
-                Console.WriteLine("PluginOneFail not destroyed");
-            }
-        }
     }
 }

--- a/csharp/test/Ice/plugin/PluginThreeFailFactory.cs
+++ b/csharp/test/Ice/plugin/PluginThreeFailFactory.cs
@@ -22,17 +22,5 @@ public class PluginThreeFailFactory : Ice.PluginFactory
         {
             test(false);
         }
-
-        ~PluginThreeFail()
-        {
-            if (_initialized)
-            {
-                Console.WriteLine("PluginThreeFail was initialized");
-            }
-            if (_destroyed)
-            {
-                Console.WriteLine("PluginThreeFail was destroyed");
-            }
-        }
     }
 }

--- a/csharp/test/Ice/plugin/PluginTwoFailFactory.cs
+++ b/csharp/test/Ice/plugin/PluginTwoFailFactory.cs
@@ -31,17 +31,5 @@ public class PluginTwoFailFactory : Ice.PluginFactory
             test(!_three.isDestroyed());
             _destroyed = true;
         }
-
-        ~PluginTwoFail()
-        {
-            if (!_initialized)
-            {
-                Console.WriteLine("PluginTwoFail not initialized");
-            }
-            if (!_destroyed)
-            {
-                Console.WriteLine("PluginTwoFail not destroyed");
-            }
-        }
     }
 }

--- a/csharp/test/Ice/servantLocator/ServantLocatorAMDI.cs
+++ b/csharp/test/Ice/servantLocator/ServantLocatorAMDI.cs
@@ -13,14 +13,6 @@ namespace Ice.servantLocator
                 _requestId = -1;
             }
 
-            ~ServantLocatorI()
-            {
-                lock (this)
-                {
-                    test(_deactivated);
-                }
-            }
-
             private static void test(bool b) => global::Test.TestHelper.test(b);
 
             public Ice.Object locate(Ice.Current current, out object cookie)

--- a/csharp/test/Ice/servantLocator/ServantLocatorI.cs
+++ b/csharp/test/Ice/servantLocator/ServantLocatorI.cs
@@ -11,14 +11,6 @@ public sealed class ServantLocatorI : Ice.ServantLocator
         _requestId = -1;
     }
 
-    ~ServantLocatorI()
-    {
-        lock (this)
-        {
-            test(_deactivated);
-        }
-    }
-
     private static void test(bool b) => global::Test.TestHelper.test(b);
 
     public Ice.Object locate(Ice.Current current, out object cookie)


### PR DESCRIPTION
Fix #3687

The C# finalizers are no longer called, this PR removes them.