### PR TITLE
Add non-idempotent check in Swift

### DIFF
--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -1612,7 +1612,9 @@ SwiftGenerator::writeDispatchOperation(::IceInternal::Output& out, const Operati
     out << sb;
     out << nl;
 
-    // TODO: check operation mode
+    if (op->mode() == Operation::Mode::Normal) {
+        out << nl << "try request.checkNonIdempotent()";
+    }
 
     if (inParams.empty())
     {

--- a/swift/src/Ice/IncomingRequest.swift
+++ b/swift/src/Ice/IncomingRequest.swift
@@ -16,3 +16,17 @@ public final class IncomingRequest {
         self.inputStream = inputStream
     }
 }
+
+extension IncomingRequest {
+    /// Makes sure the operation mode received with the request is not idempotent.
+    /// - Throws: `MarshalException` if the operation mode is idempotent or nonmutating.
+    public func checkNonIdempotent() throws {
+        if current.mode != .normal {  // i.e. idempotent or non-mutating
+            // The caller believes the operation is idempotent or non-mutating, but the implementation (the local code)
+            // doesn't. This is a problem, as the Ice runtime could retry automatically when it shouldn't.
+            throw MarshalException(
+                "Operation mode mismatch for operation '\(current.operation)': received \(current.mode) for non-idempotent operation"
+            )
+        }
+    }
+}


### PR DESCRIPTION
This check was missing in Swift.