### PR TITLE
C# StyleCop - Organize usings

### DIFF
--- a/csharp/.editorconfig
+++ b/csharp/.editorconfig
@@ -11,8 +11,8 @@ tab_width = 4
 #### .NET Coding Conventions ####
 
 # Organize usings
-dotnet_separate_import_directive_groups = false
-dotnet_sort_system_directives_first = false
+dotnet_separate_import_directive_groups = false:warning
+dotnet_sort_system_directives_first = false:warning
 
 # this. and Me. preferences
 dotnet_style_qualification_for_event = false:suggestion

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -2,8 +2,8 @@
 
 #nullable enable
 
-using Ice.Internal;
 using System.Net.Security;
+using Ice.Internal;
 
 namespace Ice;
 

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -1,9 +1,9 @@
 // Copyright (c) ZeroC, Inc.
 
-using Ice.Instrumentation;
-using Ice.Internal;
 using System.Diagnostics;
 using System.Text;
+using Ice.Instrumentation;
+using Ice.Internal;
 
 namespace Ice;
 

--- a/csharp/src/Ice/CurrentExtensions.cs
+++ b/csharp/src/Ice/CurrentExtensions.cs
@@ -2,8 +2,8 @@
 
 #nullable enable
 
-using Ice.Internal;
 using System.Diagnostics;
+using Ice.Internal;
 
 namespace Ice;
 

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -2,9 +2,9 @@
 
 #nullable enable
 
-using Ice.Internal;
 using System.Diagnostics;
 using System.Globalization;
+using Ice.Internal;
 using Protocol = Ice.Internal.Protocol;
 
 namespace Ice;

--- a/csharp/src/Ice/Internal/InstrumentationI.cs
+++ b/csharp/src/Ice/Internal/InstrumentationI.cs
@@ -1,8 +1,8 @@
 // Copyright (c) ZeroC, Inc.
 
-using IceMX;
 using System.Diagnostics;
 using System.Text;
+using IceMX;
 
 namespace Ice.Internal;
 

--- a/csharp/src/Ice/MetricsObserverI.cs
+++ b/csharp/src/Ice/MetricsObserverI.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
-using Ice.Internal;
 using System.Diagnostics;
+using Ice.Internal;
 
 namespace IceMX;
 

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -2,12 +2,12 @@
 
 #nullable enable
 
-using Ice.Instrumentation;
-using Ice.Internal;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Security;
 using System.Text;
+using Ice.Instrumentation;
+using Ice.Internal;
 
 namespace Ice;
 

--- a/csharp/src/Ice/Properties.cs
+++ b/csharp/src/Ice/Properties.cs
@@ -2,10 +2,10 @@
 
 #nullable enable
 
-using Ice.Internal;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
+using Ice.Internal;
 
 namespace Ice;
 

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -2,9 +2,9 @@
 
 #nullable enable
 
-using Ice.Internal;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using Ice.Internal;
 
 namespace Ice;
 

--- a/csharp/src/Ice/SSL/SSLEngine.cs
+++ b/csharp/src/Ice/SSL/SSLEngine.cs
@@ -1,12 +1,12 @@
 // Copyright (c) ZeroC, Inc.
 
-using Ice.Internal;
 using System.Diagnostics;
 using System.Net.Security;
 using System.Security;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using Ice.Internal;
 
 namespace Ice.SSL;
 


### PR DESCRIPTION
Escalates the `# Organize usings` section of .editorconfig to `warning` and uses dotnet format to reformat based on this.