### PR TITLE
C#: Ensure Ssl handshake completes before disposing SslStream

### DIFF
--- a/csharp/src/Ice/SSL/TransceiverI.cs
+++ b/csharp/src/Ice/SSL/TransceiverI.cs
@@ -91,6 +91,20 @@ internal sealed class TransceiverI : Ice.Internal.Transceiver
     public void destroy()
     {
         _delegate.destroy();
+        if (!_verified && _writeResult is not null)
+        {
+            // If the SSL handshake is still in progress cancel it and wait for it ot finish before disposing the stream
+            _sslHandshakeCts.Cancel();
+            try
+            {
+                _writeResult.Wait();
+                _writeResult = null;
+            }
+            catch
+            {
+            }
+        }
+        Debug.Assert(_writeResult is null || _writeResult.IsCompleted);
         _sslStream?.Dispose();
     }
 
@@ -366,13 +380,15 @@ internal sealed class TransceiverI : Ice.Internal.Transceiver
             {
                 _writeResult = _sslStream.AuthenticateAsServerAsync(
                     _serverAuthenticationOptions ??
-                    _instance.engine().createServerAuthenticationOptions(validationCallback));
+                    _instance.engine().createServerAuthenticationOptions(validationCallback),
+                    _sslHandshakeCts.Token);
             }
             else
             {
                 _writeResult = _sslStream.AuthenticateAsClientAsync(
                     _instance.initializationData().clientAuthenticationOptions ??
-                    _instance.engine().createClientAuthenticationOptions(validationCallback, _host));
+                    _instance.engine().createClientAuthenticationOptions(validationCallback, _host),
+                    _sslHandshakeCts.Token);
             }
             _writeResult.ContinueWith(
                 task =>
@@ -510,4 +526,5 @@ internal sealed class TransceiverI : Ice.Internal.Transceiver
     private string _cipher;
     private bool _verified;
     private readonly SslServerAuthenticationOptions _serverAuthenticationOptions;
+    private readonly CancellationTokenSource _sslHandshakeCts = new();
 }

--- a/csharp/src/Ice/SSL/TransceiverI.cs
+++ b/csharp/src/Ice/SSL/TransceiverI.cs
@@ -93,7 +93,8 @@ internal sealed class TransceiverI : Ice.Internal.Transceiver
         _delegate.destroy();
         if (!_verified && _writeResult is not null)
         {
-            // If the SSL handshake is still in progress cancel it and wait for it ot finish before disposing the stream
+            // If the SSL handshake is still in progress, cancel it and wait for its completion before disposing of the
+            // stream.
             _sslHandshakeCts.Cancel();
             try
             {
@@ -106,6 +107,7 @@ internal sealed class TransceiverI : Ice.Internal.Transceiver
         }
         Debug.Assert(_writeResult is null || _writeResult.IsCompleted);
         _sslStream?.Dispose();
+        _sslHandshakeCts.Dispose();
     }
 
     public int write(Ice.Internal.Buffer buf) =>


### PR DESCRIPTION
Fix #1745 