### PR TITLE
Fix C++ buffer memory leak

### DIFF
--- a/cpp/src/Ice/Buffer.cpp
+++ b/cpp/src/Ice/Buffer.cpp
@@ -90,6 +90,11 @@ IceInternal::Buffer::Container::operator=(Container&& other) noexcept
 {
     if (this != &other)
     {
+        // If we own the buffer, free it first.
+        if (_buf && _owned)
+        {
+            ::free(_buf);
+        }
         _buf = other._buf;
         _size = other._size;
         _capacity = other._capacity;


### PR DESCRIPTION
This PR fixes a memory leak in the Ice::Buffer move assignment operator.

Fixes #3726 and  #3634 (hopefully 😄)