### PR TITLE
Remove --depend from slice2java and slice2matlab

### DIFF
--- a/cpp/src/Slice/Preprocessor.cpp
+++ b/cpp/src/Slice/Preprocessor.cpp
@@ -566,54 +566,6 @@ Slice::Preprocessor::printMakefileDependencies(
         }
         case SliceXML:
             break;
-        case Java:
-        case MATLAB:
-        {
-            //
-            // We want to shift the files left one position, so that
-            // "x.h: x.ice y.ice" becomes "x.ice: y.ice".
-            //
-
-            //
-            // Remove the first file.
-            //
-            string::size_type start = result.find(suffix);
-            assert(start != string::npos);
-            start = result.find_first_not_of(" \t\r\n\\", start + suffix.size()); // Skip to beginning of next file.
-            assert(start != string::npos);
-            result.erase(0, start);
-
-            //
-            // Find end of next file.
-            //
-            pos = 0;
-            while ((pos = result.find_first_of(" :\t\r\n\\", pos + 1)) != string::npos)
-            {
-                if (result[pos] == ':')
-                {
-                    result.insert(pos, 1, '\\'); // Escape colons.
-                    ++pos;
-                }
-                else if (result[pos] == '\\') // Ignore escaped characters.
-                {
-                    ++pos;
-                }
-                else
-                {
-                    break;
-                }
-            }
-
-            if (pos == string::npos)
-            {
-                result.append(":");
-            }
-            else
-            {
-                result.insert(pos, 1, ':');
-            }
-            break;
-        }
         case CSharp:
         {
             //

--- a/cpp/src/Slice/Preprocessor.cpp
+++ b/cpp/src/Slice/Preprocessor.cpp
@@ -627,16 +627,6 @@ Slice::Preprocessor::printMakefileDependencies(
             }
             break;
         }
-        case ObjC:
-        {
-            pos = result.find(suffix);
-            if (pos != string::npos)
-            {
-                string name = result.substr(0, pos);
-                result.replace(0, pos + suffix.size() - 1, name + ".h " + name + ".m");
-            }
-            break;
-        }
         case Swift:
         {
             //

--- a/cpp/src/Slice/Preprocessor.h
+++ b/cpp/src/Slice/Preprocessor.h
@@ -33,7 +33,6 @@ namespace Slice
             PHP,
             JavaScript,
             JavaScriptJSON,
-            ObjC,
             SliceXML,
             Swift
         };

--- a/cpp/src/Slice/Preprocessor.h
+++ b/cpp/src/Slice/Preprocessor.h
@@ -27,7 +27,6 @@ namespace Slice
         enum Language
         {
             CPlusPlus,
-            Java,
             CSharp,
             Python,
             Ruby,
@@ -36,7 +35,6 @@ namespace Slice
             JavaScriptJSON,
             ObjC,
             SliceXML,
-            MATLAB,
             Swift
         };
 

--- a/cpp/src/slice2java/Main.cpp
+++ b/cpp/src/slice2java/Main.cpp
@@ -181,11 +181,7 @@ compile(const vector<string>& argv)
                 return EXIT_FAILURE;
             }
 
-            if (!icecpp->printMakefileDependencies(
-                    os,
-                    Preprocessor::SliceXML,
-                    includePaths,
-                    "-D__SLICE2JAVA__"))
+            if (!icecpp->printMakefileDependencies(os, Preprocessor::SliceXML, includePaths, "-D__SLICE2JAVA__"))
             {
                 return EXIT_FAILURE;
             }

--- a/cpp/src/slice2java/Main.cpp
+++ b/cpp/src/slice2java/Main.cpp
@@ -43,7 +43,6 @@ usage(const string& n)
                   "-E                       Print preprocessor output on stdout.\n"
                   "--output-dir DIR         Create files in the directory DIR.\n"
                   "-d, --debug              Print debug messages.\n"
-                  "--depend                 Generate Makefile dependencies.\n"
                   "--depend-xml             Generate dependencies in XML format.\n"
                   "--depend-file FILE       Write dependencies to FILE instead of standard output.\n"
                   "--validate               Validate command line options.\n"
@@ -62,7 +61,6 @@ compile(const vector<string>& argv)
     opts.addOpt("I", "", IceInternal::Options::NeedArg, "", IceInternal::Options::Repeat);
     opts.addOpt("E");
     opts.addOpt("", "output-dir", IceInternal::Options::NeedArg);
-    opts.addOpt("", "depend");
     opts.addOpt("", "depend-xml");
     opts.addOpt("", "depend-file", IceInternal::Options::NeedArg, "");
     opts.addOpt("", "list-generated");
@@ -120,7 +118,6 @@ compile(const vector<string>& argv)
 
     string output = opts.optArg("output-dir");
 
-    bool depend = opts.isSet("depend");
     bool dependxml = opts.isSet("depend-xml");
     string dependFile = opts.optArg("depend-file");
 
@@ -131,16 +128,6 @@ compile(const vector<string>& argv)
     if (args.empty())
     {
         consoleErr << argv[0] << ": error: no input file" << endl;
-        if (!validate)
-        {
-            usage(argv[0]);
-        }
-        return EXIT_FAILURE;
-    }
-
-    if (depend && dependxml)
-    {
-        consoleErr << argv[0] << ": error: cannot specify both --depend and --depend-xml" << endl;
         if (!validate)
         {
             usage(argv[0]);
@@ -175,7 +162,7 @@ compile(const vector<string>& argv)
             continue;
         }
 
-        if (depend || dependxml)
+        if (dependxml)
         {
             PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
             FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2JAVA__");
@@ -196,7 +183,7 @@ compile(const vector<string>& argv)
 
             if (!icecpp->printMakefileDependencies(
                     os,
-                    depend ? Preprocessor::Java : Preprocessor::SliceXML,
+                    Preprocessor::SliceXML,
                     includePaths,
                     "-D__SLICE2JAVA__"))
             {
@@ -291,10 +278,6 @@ compile(const vector<string>& argv)
     if (dependxml)
     {
         os << "</dependencies>\n";
-    }
-
-    if (depend || dependxml)
-    {
         writeDependencies(os.str(), dependFile);
     }
 

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -3419,7 +3419,6 @@ usage(const string& n)
                   "-E                       Print preprocessor output on stdout.\n"
                   "--output-dir DIR         Create files in the directory DIR.\n"
                   "-d, --debug              Print debug messages.\n"
-                  "--depend                 Generate Makefile dependencies.\n"
                   "--depend-xml             Generate dependencies in XML format.\n"
                   "--depend-file FILE       Write dependencies to FILE instead of standard output.\n"
                   "--validate               Validate command line options.\n"
@@ -3439,7 +3438,6 @@ compile(const vector<string>& argv)
     opts.addOpt("I", "", IceInternal::Options::NeedArg, "", IceInternal::Options::Repeat);
     opts.addOpt("E");
     opts.addOpt("", "output-dir", IceInternal::Options::NeedArg);
-    opts.addOpt("", "depend");
     opts.addOpt("", "depend-xml");
     opts.addOpt("", "depend-file", IceInternal::Options::NeedArg, "");
     opts.addOpt("", "list-generated");
@@ -3499,8 +3497,6 @@ compile(const vector<string>& argv)
 
     string output = opts.optArg("output-dir");
 
-    bool depend = opts.isSet("depend");
-
     bool dependxml = opts.isSet("depend-xml");
 
     string dependFile = opts.optArg("depend-file");
@@ -3514,16 +3510,6 @@ compile(const vector<string>& argv)
     if (args.empty())
     {
         consoleErr << argv[0] << ": error: no input file" << endl;
-        if (!validate)
-        {
-            usage(argv[0]);
-        }
-        return EXIT_FAILURE;
-    }
-
-    if (depend && dependxml)
-    {
-        consoleErr << argv[0] << ": error: cannot specify both --depend and --depend-xml" << endl;
         if (!validate)
         {
             usage(argv[0]);
@@ -3558,7 +3544,7 @@ compile(const vector<string>& argv)
             continue;
         }
 
-        if (depend || dependxml)
+        if (dependxml)
         {
             PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
             FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2MATLAB__");
@@ -3579,7 +3565,7 @@ compile(const vector<string>& argv)
 
             if (!icecpp->printMakefileDependencies(
                     os,
-                    depend ? Preprocessor::MATLAB : Preprocessor::SliceXML,
+                    Preprocessor::SliceXML,
                     includePaths,
                     "-D__SLICE2MATLAB__"))
             {
@@ -3680,10 +3666,6 @@ compile(const vector<string>& argv)
     if (dependxml)
     {
         os << "</dependencies>\n";
-    }
-
-    if (depend || dependxml)
-    {
         writeDependencies(os.str(), dependFile);
     }
 

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -3563,11 +3563,7 @@ compile(const vector<string>& argv)
                 return EXIT_FAILURE;
             }
 
-            if (!icecpp->printMakefileDependencies(
-                    os,
-                    Preprocessor::SliceXML,
-                    includePaths,
-                    "-D__SLICE2MATLAB__"))
+            if (!icecpp->printMakefileDependencies(os, Preprocessor::SliceXML, includePaths, "-D__SLICE2MATLAB__"))
             {
                 return EXIT_FAILURE;
             }

--- a/man/man1/slice2java.1
+++ b/man/man1/slice2java.1
@@ -64,13 +64,6 @@ Place the generated files into directory DIR.
 Print debug information showing the operation of the Slice parser.
 
 .TP
-.BR \-\-depend\fR
-.br
-Print dependency information to standard output by default, or to the
-file specified by the --depend-file option. No code is generated when
-this option is specified.
-
-.TP
 .BR \-\-depend\-xml\fR
 .br
 Print dependency information in XML format to standard output by default,
@@ -80,8 +73,7 @@ when this option is specified.
 .TP
 .BR \-\-depend\-file " " FILE\fR
 .br
-Directs dependency information to the specified file. The output
-format depends on whether --depend or --depend-xml is also specified.
+Directs dependency information to the specified file.
 
 .TP
 .BR \-\-validate\fR

--- a/man/man1/slice2matlab.1
+++ b/man/man1/slice2matlab.1
@@ -64,13 +64,6 @@ Place the generated files into directory DIR.
 Print debug information showing the operation of the Slice parser.
 
 .TP
-.BR \-\-depend\fR
-.br
-Print dependency information to standard output by default, or to the
-file specified by the --depend-file option. No code is generated when
-this option is specified.
-
-.TP
 .BR \-\-depend\-xml\fR
 .br
 Print dependency information in XML format to standard output by default,
@@ -80,8 +73,7 @@ when this option is specified.
 .TP
 .BR \-\-depend\-file " " FILE\fR
 .br
-Directs dependency information to the specified file. The output
-format depends on whether --depend or --depend-xml is also specified.
+Directs dependency information to the specified file.
 
 .TP
 .BR \-\-validate\fR

--- a/man/man1/slice2matlab.1
+++ b/man/man1/slice2matlab.1
@@ -73,7 +73,8 @@ when this option is specified.
 .TP
 .BR \-\-depend\-file " " FILE\fR
 .br
-Directs dependency information to the specified file.
+Directs dependency information to the specified file. Has no effect unless
+--depend-xml is also specified.
 
 .TP
 .BR \-\-validate\fR


### PR DESCRIPTION
The logic is you should never use makefile-style depend files with these languages.

See #3642.