### PR TITLE
Remove leftover 'implements' from Slice files and random cleanup.

### DIFF
--- a/cpp/test/Slice/errorDetection/IdentAsKeyword.err
+++ b/cpp/test/Slice/errorDetection/IdentAsKeyword.err
@@ -31,7 +31,8 @@ IdentAsKeyword.ice:32: interfaces can only be defined within a module
 IdentAsKeyword.ice:33: keyword 'long' cannot be used as interface name
 IdentAsKeyword.ice:33: interfaces can only be defined within a module
 IdentAsKeyword.ice:35: sequences can only be defined within a module
-IdentAsKeyword.ice:36: sequence 'implements' differs only in capitalization from sequence 'impLEments'
+IdentAsKeyword.ice:36: sequence 'extends' differs only in capitalization from sequence 'EXtends'
+IdentAsKeyword.ice:36: keyword 'extends' cannot be used as sequence name
 IdentAsKeyword.ice:37: sequences can only be defined within a module
 IdentAsKeyword.ice:37: keyword 'short' cannot be used as sequence name
 IdentAsKeyword.ice:39: syntax error

--- a/cpp/test/Slice/errorDetection/IdentAsKeyword.ice
+++ b/cpp/test/Slice/errorDetection/IdentAsKeyword.ice
@@ -32,8 +32,8 @@ module Test
     interface object { void op(); }
     interface long { void op(); }
 
-    sequence<long> impLEments;
-    sequence<long> implements;
+    sequence<long> EXtends;
+    sequence<long> extends;
     sequence<long> short;
 
     sequence<module> seq1;

--- a/cpp/test/Slice/errorDetection/IllegalUseOfKeyword.err
+++ b/cpp/test/Slice/errorDetection/IllegalUseOfKeyword.err
@@ -1,23 +1,26 @@
-IllegalUseOfKeyword.ice:7: keyword 'module' cannot be used as exception name
-IllegalUseOfKeyword.ice:7: exceptions cannot be forward declared
-IllegalUseOfKeyword.ice:8: keyword 'void' cannot be used as exception name
-IllegalUseOfKeyword.ice:13: keyword 'exception' cannot be used as struct name
-IllegalUseOfKeyword.ice:13: structs cannot be forward declared
-IllegalUseOfKeyword.ice:14: keyword 'class' cannot be used as struct name
-IllegalUseOfKeyword.ice:19: keyword 'interface' cannot be used as class name
-IllegalUseOfKeyword.ice:20: keyword 'struct' cannot be used as class name
-IllegalUseOfKeyword.ice:27: keyword 'extends' cannot be used as interface name
-IllegalUseOfKeyword.ice:36: keyword 'throws' cannot be used as parameter name
-IllegalUseOfKeyword.ice:36: keyword 'void' cannot be used as parameter name
-IllegalUseOfKeyword.ice:38: keyword 'byte' cannot be used as parameter name
-IllegalUseOfKeyword.ice:38: keyword 'short' cannot be used as parameter name
-IllegalUseOfKeyword.ice:43: keyword 'int' cannot be used as data member name
-IllegalUseOfKeyword.ice:44: keyword 'long' cannot be used as data member name
-IllegalUseOfKeyword.ice:45: keyword 'float' cannot be used as data member name
-IllegalUseOfKeyword.ice:46: keyword 'double' cannot be used as data member name
-IllegalUseOfKeyword.ice:49: keyword 'Object' cannot be used as sequence name
-IllegalUseOfKeyword.ice:53: keyword 'string' cannot be used as enumeration name
-IllegalUseOfKeyword.ice:60: keyword 'sequence' cannot be used as enumerator
-IllegalUseOfKeyword.ice:61: keyword 'dictionary' cannot be used as enumerator
-IllegalUseOfKeyword.ice:62: keyword 'enum' cannot be used as enumerator
-IllegalUseOfKeyword.ice:66: illegal inheritance from type Object
+IllegalUseOfKeyword.ice:5: keyword 'module' cannot be used as exception name
+IllegalUseOfKeyword.ice:5: exceptions cannot be forward declared
+IllegalUseOfKeyword.ice:6: keyword 'void' cannot be used as exception name
+IllegalUseOfKeyword.ice:11: keyword 'exception' cannot be used as struct name
+IllegalUseOfKeyword.ice:11: structs cannot be forward declared
+IllegalUseOfKeyword.ice:12: keyword 'class' cannot be used as struct name
+IllegalUseOfKeyword.ice:17: keyword 'idempotent' cannot be used as class name
+IllegalUseOfKeyword.ice:18: keyword 'struct' cannot be used as class name
+IllegalUseOfKeyword.ice:23: keyword 'interface' cannot be used as interface name
+IllegalUseOfKeyword.ice:24: keyword 'extends' cannot be used as interface name
+IllegalUseOfKeyword.ice:31: keyword 'module' cannot be used as operation name
+IllegalUseOfKeyword.ice:33: keyword 'throws' cannot be used as parameter name
+IllegalUseOfKeyword.ice:33: keyword 'void' cannot be used as parameter name
+IllegalUseOfKeyword.ice:35: keyword 'byte' cannot be used as parameter name
+IllegalUseOfKeyword.ice:35: keyword 'short' cannot be used as parameter name
+IllegalUseOfKeyword.ice:40: keyword 'int' cannot be used as data member name
+IllegalUseOfKeyword.ice:41: keyword 'long' cannot be used as data member name
+IllegalUseOfKeyword.ice:42: keyword 'float' cannot be used as data member name
+IllegalUseOfKeyword.ice:43: keyword 'double' cannot be used as data member name
+IllegalUseOfKeyword.ice:46: keyword 'Object' cannot be used as sequence name
+IllegalUseOfKeyword.ice:48: keyword 'dictionary' cannot be used as dictionary name
+IllegalUseOfKeyword.ice:50: keyword 'string' cannot be used as enumeration name
+IllegalUseOfKeyword.ice:57: keyword 'sequence' cannot be used as enumerator
+IllegalUseOfKeyword.ice:58: keyword 'dictionary' cannot be used as enumerator
+IllegalUseOfKeyword.ice:59: keyword 'enum' cannot be used as enumerator
+IllegalUseOfKeyword.ice:63: illegal inheritance from type Object

--- a/cpp/test/Slice/errorDetection/IllegalUseOfKeyword.ice
+++ b/cpp/test/Slice/errorDetection/IllegalUseOfKeyword.ice
@@ -1,7 +1,5 @@
 // Copyright (c) ZeroC, Inc.
 
-//
-
 module Test
 {
     exception module;
@@ -16,14 +14,13 @@ module Test
         int i;
     }
 
-    class interface;
+    class idempotent;
     class struct
     {
-        // void f();
         int i;
     }
 
-    // interface local;
+    interface interface;
     interface extends
     {
         void f();
@@ -31,7 +28,7 @@ module Test
 
     interface Foo
     {
-        void implements();
+        void module();
 
         int bar(string throws, long l, out bool void, out short s);
 
@@ -48,7 +45,7 @@ module Test
 
     sequence<int> Object;
 
-    // dictionary<int, int> LocalObject;
+    dictionary<int, int> dictionary;
 
     enum string
     {

--- a/cpp/test/Slice/errorDetection/NotType.err
+++ b/cpp/test/Slice/errorDetection/NotType.err
@@ -1,7 +1,10 @@
-NotType.ice:10: 'Mod' is not a type
-NotType.ice:11: 'Mod' is not a type
-NotType.ice:12: 'Mod' is not a type
-NotType.ice:13: 'Mod' is not a type
+NotType.ice:9: 'MyModule' is not a type
+NotType.ice:14: 'MyModule' is not a type
+NotType.ice:15: 'Mod' is not a type
+NotType.ice:16: 'E' is an exception, which cannot be used as a type
+NotType.ice:16: 'MyModule' is not a type
+NotType.ice:17: 'Mod' is not a type
+NotType.ice:17: 'E' is an exception, which cannot be used as a type
 NotType.ice:22: 'E' is an exception, which cannot be used as a type
 NotType.ice:23: struct 'S' must have at least one member
 NotType.ice:27: 'E' is an exception, which cannot be used as a type

--- a/cpp/test/Slice/errorDetection/NotType.ice
+++ b/cpp/test/Slice/errorDetection/NotType.ice
@@ -2,29 +2,29 @@
 
 module Test
 {
-    module Module1 { }
-    module Module2 { }
-    module Module3 { }
-    module Mod
+    module MyModule {}
+
+    exception E
     {
-        sequence<Mod> Seq;
-        dictionary<int, Mod> Dict;
-        interface BarIntf extends Mod { void op(); }
-        class BarClass1 extends Mod { long l; }
-        // class BarClass2 implements Module1, Module2, Module3 { long l; }
-        // class BarClass3 extends Mod implements Module1, Module2, Module3 { long l; }
+        MyModule exceptionField;
     }
 
-    exception E { }
+    module Mod
+    {
+        sequence<MyModule> Seq;
+        dictionary<int, Mod> Dict;
+        interface BarIntf extends MyModule, E { void op(); }
+        class BarClass1 extends Mod { E l; }
+    }
 
     struct S
     {
-        E e;
+        E structField;
     }
 
     interface I
     {
         E foo(E e1; E e2);
-        void op();
+        S op(S s1, S s2);
     }
 }

--- a/php/src/Connection.cpp
+++ b/php/src/Connection.cpp
@@ -348,7 +348,7 @@ handleConnectionInfoFreeStorage(zend_object* object)
 bool
 IcePHP::connectionInit(void)
 {
-    // We register an interface and a class that implements the interface. This allows  applications to safely include
+    // We register an interface and a class that implements the interface. This allows applications to safely include
     // the Slice-generated code for the type.
 
     // Register the Connection interface.

--- a/php/src/Operation.cpp
+++ b/php/src/Operation.cpp
@@ -135,7 +135,7 @@ void
 IcePHP::ResultCallback::unmarshaled(zval* val, zval*, void*)
 {
     // Copy the unmarshaled value into this result callback. This increases the refcount for refcounted values and
-    // coppies non-refcound values.
+    // copies non-refcounted values.
     ZVAL_COPY(&zv, val);
 }
 

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -1195,8 +1195,7 @@ class Mapping(object):
 
 
 #
-# A Runnable can be used as a "client" for in test cases, it provides
-# implements run, setup and teardown methods.
+# A Runnable can be used as a "client" for in test cases, it provides run, setup, and teardown methods.
 #
 
 


### PR DESCRIPTION
`implements` used to a Slice keyword, used when a `class` implemented an `interface`. We removed this, and the keyword.

`implements` is also a keyword in PHP, so I was checking our `*.ice` files for it (so I could apply `php:identifier` where necessary,
and I stumbled across some places where the old `implements` keyword wasn't properly removed.

This PR fixes those places, and some other random things I found while working on `php:identifier`.