### PR TITLE
slice2cpp doc update: shows [out] parameters

### DIFF
--- a/cpp/include/Ice/Object.h
+++ b/cpp/include/Ice/Object.h
@@ -46,40 +46,39 @@ namespace Ice
 
         /// Tests whether this object supports a specific Slice interface.
         /// @param s The type ID of the Slice interface to test against.
-        /// @param current The Current object for the invocation.
-        /// @return True if this object has the interface
-        /// specified by s or derives from the interface
-        /// specified by s.
+        /// @param current The Current object of the incoming request.
+        /// @return @c true if this object has the interface specified by @p s or derives from the interface specified
+        /// by @p s.
         [[nodiscard]] virtual bool ice_isA(std::string s, const Current& current) const;
-        /// \cond INTERNAL
+
+        /// @private
         void _iceD_ice_isA(IncomingRequest&, std::function<void(OutgoingResponse)>);
-        /// \endcond
 
         /// Tests whether this object can be reached.
-        /// @param current The Current object for the invocation.
+        /// @param current The Current object of the incoming request.
         virtual void ice_ping(const Current& current) const;
-        /// \cond INTERNAL
-        void _iceD_ice_ping(IncomingRequest&, std::function<void(OutgoingResponse)>);
-        /// \endcond
 
-        /// Gets the Slice type IDs of the interfaces supported by this object.
-        /// @param current The Current object for the invocation.
+        /// @private
+        void _iceD_ice_ping(IncomingRequest&, std::function<void(OutgoingResponse)>);
+
+        /// Gets the Slice interfaces supported by this object as a list of type IDs.
+        /// @param current The Current object of the incoming request.
         /// @return The Slice type IDs of the interfaces supported by this object, in alphabetical order.
         [[nodiscard]] virtual std::vector<std::string> ice_ids(const Current& current) const;
-        /// \cond INTERNAL
-        void _iceD_ice_ids(IncomingRequest&, std::function<void(OutgoingResponse)>);
-        /// \endcond
 
-        /// Gets the Slice type ID of the most-derived interface supported by this object.
-        /// @param current The Current object for the invocation.
+        /// @private
+        void _iceD_ice_ids(IncomingRequest&, std::function<void(OutgoingResponse)>);
+
+        /// Gets the type ID of the most-derived Slice interface supported by this object.
+        /// @param current The Current object of the incoming request.
         /// @return The Slice type ID of the most-derived interface.
         [[nodiscard]] virtual std::string ice_id(const Current& current) const;
-        /// \cond INTERNAL
-        void _iceD_ice_id(IncomingRequest&, std::function<void(OutgoingResponse)>);
-        /// \endcond
 
-        /// Gets the Slice type ID of this type.
-        /// @return The return value is always "::Ice::Object".
+        /// @private
+        void _iceD_ice_id(IncomingRequest&, std::function<void(OutgoingResponse)>);
+
+        /// Gets the type ID of the associated Slice interface.
+        /// @return The string @c "::Ice::Object".
         static const char* ice_staticId() noexcept;
     };
 
@@ -89,11 +88,11 @@ namespace Ice
     class ICE_API Blobject : public Object
     {
     public:
-        /// Dispatch an incoming request.
+        /// Dispatches an incoming request.
         ///
         /// @param inEncaps An encapsulation containing the encoded in-parameters for the operation.
         /// @param outEncaps An encapsulation containing the encoded results for the operation.
-        /// @param current The Current object for the invocation.
+        /// @param current The Current object of the incoming request.
         /// @return True if the operation completed successfully, in which case outEncaps contains
         /// an encapsulation of the encoded results, or false if the operation raised a user exception,
         /// in which case outEncaps contains an encapsulation of the encoded user exception.
@@ -111,11 +110,11 @@ namespace Ice
     class ICE_API BlobjectArray : public Object
     {
     public:
-        /// Dispatch an incoming request.
+        /// Dispatches an incoming request.
         ///
         /// @param inEncaps An encapsulation containing the encoded in-parameters for the operation.
         /// @param outEncaps An encapsulation containing the encoded results for the operation.
-        /// @param current The Current object for the invocation.
+        /// @param current The Current object of the incoming request.
         /// @return True if the operation completed successfully, in which case outEncaps contains
         /// an encapsulation of the encoded results, or false if the operation raised a user exception,
         /// in which case outEncaps contains an encapsulation of the encoded user exception.
@@ -143,7 +142,7 @@ namespace Ice
         /// the semantics.
         /// @param error A callback the implementation should invoke when the invocation completes
         /// with an exception.
-        /// @param current The Current object for the invocation.
+        /// @param current The Current object of the incoming request.
         /// @throws UserException A user exception can be raised directly and the
         /// run time will marshal it.
         virtual void ice_invokeAsync(
@@ -169,7 +168,7 @@ namespace Ice
         /// the semantics.
         /// @param error A callback the implementation should invoke when the invocation completes
         /// with an exception.
-        /// @param current The Current object for the invocation.
+        /// @param current The Current object of the incoming request.
         /// @throws UserException A user exception can be raised directly and the
         /// run time will marshal it.
         virtual void ice_invokeAsync(

--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -296,8 +296,8 @@ namespace Ice
         /// @param typeId The type ID of the Slice interface to test against.
         /// @param context The request context.
         /// @return The future object for the invocation.
-        [[nodiscard]] std::future<bool> ice_isAAsync(
-            std::string_view typeId, const Ice::Context& context = Ice::noExplicitContext) const;
+        [[nodiscard]] std::future<bool>
+        ice_isAAsync(std::string_view typeId, const Ice::Context& context = Ice::noExplicitContext) const;
 
         /// @private
         void _iceI_isA(const std::shared_ptr<IceInternal::OutgoingAsyncT<bool>>&, std::string_view, const Ice::Context&)
@@ -349,8 +349,8 @@ namespace Ice
         /// Gets the Slice interfaces supported by this object as a list of type IDs.
         /// @param context The request context.
         /// @return The future object for the invocation.
-        [[nodiscard]] std::future<std::vector<std::string>> ice_idsAsync(
-            const Ice::Context& context = Ice::noExplicitContext) const;
+        [[nodiscard]] std::future<std::vector<std::string>>
+        ice_idsAsync(const Ice::Context& context = Ice::noExplicitContext) const;
 
         /// @private
         void _iceI_ids(

--- a/cpp/include/Ice/Proxy.h
+++ b/cpp/include/Ice/Proxy.h
@@ -272,7 +272,7 @@ namespace Ice
 
         /// Tests whether this object supports a specific Slice interface.
         /// @param typeId The type ID of the Slice interface to test against.
-        /// @param context The context map for the invocation.
+        /// @param context The request context.
         /// @return true if the target object has the interface
         /// specified by id or derives from the interface specified by id.
         [[nodiscard]] bool ice_isA(std::string_view typeId, const Ice::Context& context = Ice::noExplicitContext) const;
@@ -282,7 +282,7 @@ namespace Ice
         /// @param response The response callback.
         /// @param ex The exception callback.
         /// @param sent The sent callback.
-        /// @param context The context map for the invocation.
+        /// @param context The request context.
         /// @return A function that can be called to cancel the invocation locally.
         // NOLINTNEXTLINE(modernize-use-nodiscard)
         std::function<void()> ice_isAAsync(
@@ -294,25 +294,24 @@ namespace Ice
 
         /// Tests whether this object supports a specific Slice interface.
         /// @param typeId The type ID of the Slice interface to test against.
-        /// @param context The context map for the invocation.
+        /// @param context The request context.
         /// @return The future object for the invocation.
-        [[nodiscard]] std::future<bool>
-        ice_isAAsync(std::string_view typeId, const Ice::Context& context = Ice::noExplicitContext) const;
+        [[nodiscard]] std::future<bool> ice_isAAsync(
+            std::string_view typeId, const Ice::Context& context = Ice::noExplicitContext) const;
 
-        /// \cond INTERNAL
+        /// @private
         void _iceI_isA(const std::shared_ptr<IceInternal::OutgoingAsyncT<bool>>&, std::string_view, const Ice::Context&)
             const;
-        /// \endcond
 
         /// Tests whether the target object of this proxy can be reached.
-        /// @param context The context map for the invocation.
+        /// @param context The request context.
         void ice_ping(const Ice::Context& context = Ice::noExplicitContext) const;
 
         /// Tests whether the target object of this proxy can be reached.
         /// @param response The response callback.
         /// @param ex The exception callback.
         /// @param sent The sent callback.
-        /// @param context The context map for the invocation.
+        /// @param context The request context.
         /// @return A function that can be called to cancel the invocation locally.
         // NOLINTNEXTLINE(modernize-use-nodiscard)
         std::function<void()> ice_pingAsync(
@@ -322,24 +321,23 @@ namespace Ice
             const Ice::Context& context = Ice::noExplicitContext) const;
 
         /// Tests whether the target object of this proxy can be reached.
-        /// @param context The context map for the invocation.
+        /// @param context The request context.
         /// @return The future object for the invocation.
         [[nodiscard]] std::future<void> ice_pingAsync(const Ice::Context& context = Ice::noExplicitContext) const;
 
-        /// \cond INTERNAL
+        /// @private
         void _iceI_ping(const std::shared_ptr<IceInternal::OutgoingAsyncT<void>>&, const Ice::Context&) const;
-        /// \endcond
 
-        /// Returns the Slice type IDs of the interfaces supported by the target object of this proxy.
-        /// @param context The context map for the invocation.
-        /// @return The Slice type IDs of the interfaces supported by the target object, in alphabetical order.
+        /// Gets the Slice interfaces supported by this object as a list of type IDs.
+        /// @param context The request context.
+        /// @return The Slice type IDs of the interfaces supported by this object, in alphabetical order.
         [[nodiscard]] std::vector<std::string> ice_ids(const Ice::Context& context = Ice::noExplicitContext) const;
 
-        /// Returns the Slice type IDs of the interfaces supported by the target object of this proxy.
+        /// Gets the Slice interfaces supported by this object as a list of type IDs.
         /// @param response The response callback.
         /// @param ex The exception callback.
         /// @param sent The sent callback.
-        /// @param context The context map for the invocation.
+        /// @param context The request context.
         /// @return A function that can be called to cancel the invocation locally.
         // NOLINTNEXTLINE(modernize-use-nodiscard)
         std::function<void()> ice_idsAsync(
@@ -348,28 +346,27 @@ namespace Ice
             std::function<void(bool)> sent = nullptr,
             const Ice::Context& context = Ice::noExplicitContext) const;
 
-        /// Returns the Slice type IDs of the interfaces supported by the target object of this proxy.
-        /// @param context The context map for the invocation.
+        /// Gets the Slice interfaces supported by this object as a list of type IDs.
+        /// @param context The request context.
         /// @return The future object for the invocation.
-        [[nodiscard]] std::future<std::vector<std::string>>
-        ice_idsAsync(const Ice::Context& context = Ice::noExplicitContext) const;
+        [[nodiscard]] std::future<std::vector<std::string>> ice_idsAsync(
+            const Ice::Context& context = Ice::noExplicitContext) const;
 
-        /// \cond INTERNAL
+        /// @private
         void _iceI_ids(
             const std::shared_ptr<IceInternal::OutgoingAsyncT<std::vector<std::string>>>&,
             const Ice::Context&) const;
-        /// \endcond
 
-        /// Returns the Slice type ID of the most-derived interface supported by the target object of this proxy.
-        /// @param context The context map for the invocation.
+        /// Gets the type ID of the most-derived Slice interface supported by this object.
+        /// @param context The request context.
         /// @return The Slice type ID of the most-derived interface.
         [[nodiscard]] std::string ice_id(const Ice::Context& context = Ice::noExplicitContext) const;
 
-        /// Returns the Slice type ID of the most-derived interface supported by the target object of this proxy.
+        /// Gets the type ID of the most-derived Slice interface supported by this object.
         /// @param response The response callback.
         /// @param ex The exception callback.
         /// @param sent The sent callback.
-        /// @param context The context map for the invocation.
+        /// @param context The request context.
         /// @return A function that can be called to cancel the invocation locally.
         // NOLINTNEXTLINE(modernize-use-nodiscard)
         std::function<void()> ice_idAsync(
@@ -378,21 +375,20 @@ namespace Ice
             std::function<void(bool)> sent = nullptr,
             const Ice::Context& context = Ice::noExplicitContext) const;
 
-        /// Returns the Slice type ID of the most-derived interface supported by the target object of this proxy.
-        /// @param context The context map for the invocation.
+        /// Gets the type ID of the most-derived Slice interface supported by this object.
+        /// @param context The request context.
         /// @return The future object for the invocation.
         [[nodiscard]] std::future<std::string> ice_idAsync(const Ice::Context& context = Ice::noExplicitContext) const;
 
-        /// \cond INTERNAL
+        /// @private
         void _iceI_id(const std::shared_ptr<IceInternal::OutgoingAsyncT<std::string>>&, const Ice::Context&) const;
-        /// \endcond
 
         /// Invokes an operation dynamically.
         /// @param operation The name of the operation to invoke.
         /// @param mode The operation mode (normal or idempotent).
         /// @param inParams An encapsulation containing the encoded in-parameters for the operation.
         /// @param outParams An encapsulation containing the encoded results.
-        /// @param context The context map for the invocation.
+        /// @param context The request context.
         /// @return True if the operation completed successfully, in which case outParams contains
         /// the encoded out parameters. False if the operation raised a user exception, in which
         /// case outParams contains the encoded user exception. If the operation raises a run-time
@@ -408,7 +404,7 @@ namespace Ice
         /// @param operation The name of the operation to invoke.
         /// @param mode The operation mode (normal or idempotent).
         /// @param inParams An encapsulation containing the encoded in-parameters for the operation.
-        /// @param context The context map for the invocation.
+        /// @param context The request context.
         /// @return The future object for the invocation.
         [[nodiscard]] std::future<std::tuple<bool, std::vector<std::byte>>> ice_invokeAsync(
             std::string_view operation,
@@ -423,7 +419,7 @@ namespace Ice
         /// @param response The response callback.
         /// @param ex The exception callback.
         /// @param sent The sent callback.
-        /// @param context The context map for the invocation.
+        /// @param context The request context.
         /// @return A function that can be called to cancel the invocation locally.
         // NOLINTNEXTLINE(modernize-use-nodiscard)
         std::function<void()> ice_invokeAsync(
@@ -440,7 +436,7 @@ namespace Ice
         /// @param mode The operation mode (normal or idempotent).
         /// @param inParams An encapsulation containing the encoded in-parameters for the operation.
         /// @param outParams An encapsulation containing the encoded results.
-        /// @param context The context map for the invocation.
+        /// @param context The request context.
         /// @return True if the operation completed successfully, in which case outParams contains
         /// the encoded out parameters. False if the operation raised a user exception, in which
         /// case outParams contains the encoded user exception. If the operation raises a run-time
@@ -456,7 +452,7 @@ namespace Ice
         /// @param operation The name of the operation to invoke.
         /// @param mode The operation mode (normal or idempotent).
         /// @param inParams An encapsulation containing the encoded in-parameters for the operation.
-        /// @param context The context map for the invocation.
+        /// @param context The request context.
         /// @return The future object for the invocation.
         [[nodiscard]] std::future<std::tuple<bool, std::vector<std::byte>>> ice_invokeAsync(
             std::string_view operation,
@@ -471,7 +467,7 @@ namespace Ice
         /// @param response The response callback.
         /// @param ex The exception callback.
         /// @param sent The sent callback.
-        /// @param context The context map for the invocation.
+        /// @param context The request context.
         /// @return A function that can be called to cancel the invocation locally.
         // NOLINTNEXTLINE(modernize-use-nodiscard)
         std::function<void()> ice_invokeAsync(
@@ -507,9 +503,8 @@ namespace Ice
         /// @return The future object for the invocation.
         [[nodiscard]] std::future<Ice::ConnectionPtr> ice_getConnectionAsync() const;
 
-        /// \cond INTERNAL
+        /// @private
         void _iceI_getConnection(const std::shared_ptr<IceInternal::ProxyGetConnection>&) const;
-        /// \endcond
 
         /// Obtains the cached Connection for this proxy. If the proxy does not yet have an established
         /// connection, it does not attempt to create a connection.
@@ -658,9 +653,10 @@ namespace Ice
         /// @return A stringified proxy.
         [[nodiscard]] std::string ice_toString() const;
 
-        /// \cond INTERNAL
+        /// @private
         void _iceI_flushBatchRequests(const std::shared_ptr<IceInternal::ProxyFlushBatchAsync>&) const;
 
+        /// @cond INTERNAL
         static ObjectPrx _fromReference(IceInternal::ReferencePtr ref) { return ObjectPrx(std::move(ref)); }
 
         [[nodiscard]] const IceInternal::ReferencePtr& _getReference() const noexcept { return _reference; }
@@ -674,16 +670,14 @@ namespace Ice
         [[nodiscard]] size_t _hash() const noexcept;
 
         void _write(OutputStream&) const;
-        /// \endcond
 
     protected:
-        /// \cond INTERNAL
         // This constructor is never called; it allows Proxy's default constructor to compile.
         ObjectPrx() = default;
 
         // The constructor used by _fromReference.
         explicit ObjectPrx(IceInternal::ReferencePtr&&);
-        /// \endcond
+        /// @endcond
 
     private:
         template<typename Prx, typename... Bases> friend class Proxy;

--- a/cpp/include/Ice/ProxyFunctions.h
+++ b/cpp/include/Ice/ProxyFunctions.h
@@ -18,7 +18,7 @@ namespace Ice
     /// @param prx The proxy to check.
     /// @param file The source file name.
     /// @param line The source line number.
-    /// @param current The Current object for the invocation.
+    /// @param current The Current object of the incoming request.
     /// @throw MarshalException If the proxy is null.
     template<typename Prx, std::enable_if_t<std::is_base_of_v<ObjectPrx, Prx>, bool> = true>
     void checkNotNull(const std::optional<Prx>& prx, const char* file, int line, const Current& current)
@@ -88,7 +88,7 @@ namespace Ice
 
     /// Downcasts a proxy after confirming the target object's type via a remote invocation.
     /// @param proxy The source proxy.
-    /// @param context The context map for the invocation.
+    /// @param context The request context.
     /// @return A proxy with the requested type, or nullopt if the target object does not support the requested type.
     template<typename Prx, std::enable_if_t<std::is_base_of_v<ObjectPrx, Prx>, bool> = true>
     std::optional<Prx> checkedCast(const ObjectPrx& proxy, const Context& context = noExplicitContext)
@@ -105,7 +105,7 @@ namespace Ice
 
     /// Downcasts a proxy after confirming the target object's type via a remote invocation.
     /// @param proxy The source proxy (can be nullopt).
-    /// @param context The context map for the invocation.
+    /// @param context The request context.
     /// @return A proxy with the requested type, or nullopt if the source proxy is nullopt or if the target object does
     /// not support the requested type.
     template<typename Prx, std::enable_if_t<std::is_base_of_v<ObjectPrx, Prx>, bool> = true>
@@ -117,7 +117,7 @@ namespace Ice
     /// Downcasts a proxy after confirming the target object's type via a remote invocation.
     /// @param proxy The source proxy.
     /// @param facet A facet name.
-    /// @param context The context map for the invocation.
+    /// @param context The request context.
     /// @return A proxy with the requested type and facet, or nullopt if the target facet is not of the requested
     /// type.
     template<typename Prx, std::enable_if_t<std::is_base_of_v<ObjectPrx, Prx>, bool> = true>
@@ -130,7 +130,7 @@ namespace Ice
     /// Downcasts a proxy after confirming the target object's type via a remote invocation.
     /// @param proxy The source proxy (can be nullopt).
     /// @param facet A facet name.
-    /// @param context The context map for the invocation.
+    /// @param context The request context.
     /// @return A proxy with the requested type and facet, or nullopt if the source proxy is nullopt, or if the target
     /// facet is not of the requested type.
     template<typename Prx, std::enable_if_t<std::is_base_of_v<ObjectPrx, Prx>, bool> = true>

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -2820,14 +2820,8 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     StringList ids = p->ids();
 
     H << sp;
-    H << nl << "/// Gets the Slice interfaces supported by this object as a list of type IDs.";
-    H << nl << "/// @param current The Current object of the incoming request.";
-    H << nl << "/// @return The Slice type IDs of the interfaces supported by this object, in alphabetical order.";
     H << nl << "[[nodiscard]] std::vector<std::string> ice_ids(const Ice::Current& current) const override;";
     H << sp;
-    H << nl << "/// Gets the type ID of the most-derived Slice interface supported by this object.";
-    H << nl << "/// @param current The Current object of the incoming request.";
-    H << nl << "/// @return The Slice type ID of the most-derived interface.";
     H << nl << "[[nodiscard]] std::string ice_id(const Ice::Current& current) const override;";
     H << sp;
     H << nl << "/// Gets the type ID of the associated Slice interface.";

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -2216,8 +2216,7 @@ Slice::Gen::DataDefVisitor::visitExceptionStart(const ExceptionPtr& p)
                 auto r = allDocComments.find(dataMember->name());
                 if (r != allDocComments.end())
                 {
-                    H << nl << "/// @param " << dataMember->mappedName() << " "
-                        << getDocSentence(r->second.overview());
+                    H << nl << "/// @param " << dataMember->mappedName() << " " << getDocSentence(r->second.overview());
                 }
             }
             H << nl << name << "(";
@@ -2886,6 +2885,11 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         string_view outgoingResponseType = inIceModule ? "OutgoingResponse" : "Ice::OutgoingResponse";
 
         H << sp;
+        H << nl
+          << "/// Dispatches an incoming request to one of the member functions of this generated class, based on the "
+             "operation name carried by the request.";
+        H << nl << "/// @param request The incoming request.";
+        H << nl << "/// @param sendResponse The callback to send the response.";
         H << nl << "void dispatch(" << incomingRequestType << "& request, std::function<void(" << outgoingResponseType
           << ")> sendResponse) override;";
 

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -443,7 +443,7 @@ Slice::JavaVisitor::writeMarshaledResultType(
                 writeDocCommentLines(out, q->second);
             }
         }
-        out << nl << " * @param " << currentParamName << " The Current object for the invocation.";
+        out << nl << " * @param " << currentParamName << " The Current object of the incoming request.";
         out << nl << " **/";
     }
 
@@ -512,7 +512,7 @@ Slice::JavaVisitor::writeMarshaledResultType(
                     writeDocCommentLines(out, q->second);
                 }
             }
-            out << nl << " * @param " << currentParamName << " The Current object for the invocation.";
+            out << nl << " * @param " << currentParamName << " The Current object of the incoming request.";
             out << nl << " **/";
         }
 
@@ -1551,7 +1551,7 @@ Slice::JavaVisitor::writeServantDocComment(Output& out, const OperationPtr& p, c
 
     map<string, StringList> paramDocs = dc->parameters();
     const string currentParamName = getEscapedParamName(p->parameters(), "current");
-    const string currentParam = " * @param " + currentParamName + " The Current object for the invocation.";
+    const string currentParam = " * @param " + currentParamName + " The Current object of the incoming request.";
 
     out << nl << "/**";
     if (!dc->overview().empty())

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -2519,7 +2519,7 @@ Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << nl << " * Downcasts a proxy after confirming the target object's type via a remote invocation.";
     _out << nl << " * @param prx The target proxy.";
     _out << nl << " * @param facet A facet name.";
-    _out << nl << " * @param context The context map for the invocation.";
+    _out << nl << " * @param context The request context.";
     _out << nl
          << " * @returns A proxy with the requested type and facet, or nil if the target proxy is nil or the target";
     _out << nl << " * object does not support the requested type.";


### PR DESCRIPTION
This PR updates slice2cpp to document out parameters with `@param[out]`.

and misc other updates