### PR TITLE
Remove ICE_CLASS and ICE_MEMBER function macros

### DIFF
--- a/cpp/include/Ice/Config.h
+++ b/cpp/include/Ice/Config.h
@@ -7,22 +7,12 @@
 #if defined(_MSC_VER)
 #    define ICE_DECLSPEC_EXPORT __declspec(dllexport)
 #    define ICE_DECLSPEC_IMPORT __declspec(dllimport)
-//  With Visual Studio, we can import/export member functions without importing/exporting the whole class.
-#    define ICE_MEMBER_IMPORT_EXPORT
 #elif defined(__GNUC__) || defined(__clang__)
 #    define ICE_DECLSPEC_EXPORT __attribute__((visibility("default")))
 #    define ICE_DECLSPEC_IMPORT __attribute__((visibility("default")))
 #else
 #    define ICE_DECLSPEC_EXPORT /**/
 #    define ICE_DECLSPEC_IMPORT /**/
-#endif
-
-#ifdef ICE_MEMBER_IMPORT_EXPORT
-#    define ICE_CLASS(API) /**/
-#    define ICE_MEMBER(API) API
-#else
-#    define ICE_CLASS(API) API
-#    define ICE_MEMBER(API) /**/
 #endif
 
 #ifndef ICE_API

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -135,7 +135,7 @@ namespace Slice
         class DataDefVisitor final : public ParserVisitor
         {
         public:
-            DataDefVisitor(IceInternal::Output&, IceInternal::Output&, const std::string&);
+            DataDefVisitor(IceInternal::Output&, IceInternal::Output&, std::string);
             DataDefVisitor(const DataDefVisitor&) = delete;
 
             bool visitModuleStart(const ModulePtr&) final;
@@ -159,8 +159,6 @@ namespace Slice
             IceInternal::Output& C;
 
             std::string _dllExport;
-            std::string _dllClassExport;
-            std::string _dllMemberExport;
             TypeContext _useWstring{TypeContext::None};
             std::list<TypeContext> _useWstringHist;
             bool _firstElement{true};


### PR DESCRIPTION
This PR removes the ICE_CLASS and ICE_MEMBER macros.

They were introduced to reduce the number of symbols exported by the generated code on Windows, when the generated code made heavy use of inline functions for generated proxies, classes etc.

In 3.8, we moved all this code out of line, and as a result these macros are no longer useful.

Note: prior to this PR, we no longer used these macros for proxies. We used them only for exceptions and classes.