### PR TITLE
Fix Intellisense warnings about uninitialized fields

### DIFF
--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -759,10 +759,10 @@ namespace Ice
 
             // Instance attributes
             SliceType _sliceType{NoSlice};
-            bool _skipFirstSlice;
+            bool _skipFirstSlice{false};
 
             // Slice attributes
-            std::int32_t _sliceSize;
+            std::int32_t _sliceSize{0};
             std::string _typeId;
         };
 
@@ -824,19 +824,19 @@ namespace Ice
                 }
 
                 // Instance attributes
-                SliceType sliceType;
-                bool skipFirstSlice;
+                SliceType sliceType{NoSlice};
+                bool skipFirstSlice{false};
                 SliceInfoSeq slices; // Preserved slices.
                 IndexListList indirectionTables;
 
                 // Slice attributes
-                std::uint8_t sliceFlags;
-                std::int32_t sliceSize;
+                std::uint8_t sliceFlags{0};
+                std::int32_t sliceSize{0};
                 std::string typeId;
-                int compactId;
+                int compactId{0};
                 IndirectPatchList indirectPatchList;
 
-                InstanceData* previous;
+                InstanceData* previous{nullptr};
                 InstanceData* next{nullptr};
             };
             InstanceData _preAllocatedInstanceData;

--- a/cpp/include/Ice/OutputStream.h
+++ b/cpp/include/Ice/OutputStream.h
@@ -732,7 +732,7 @@ namespace Ice
             SliceType _sliceType{NoSlice};
 
             // Slice attributes
-            Container::size_type _writeSlice; // Position of the slice data members
+            Container::size_type _writeSlice{0}; // Position of the slice data members
 
             // Encapsulation attributes for value marshaling.
             std::int32_t _valueIdIndex{0};
@@ -781,17 +781,17 @@ namespace Ice
                 }
 
                 // Instance attributes
-                SliceType sliceType;
-                bool firstSlice;
+                SliceType sliceType{NoSlice};
+                bool firstSlice{false};
 
                 // Slice attributes
-                std::uint8_t sliceFlags;
-                Container::size_type writeSlice;    // Position of the slice data members
-                Container::size_type sliceFlagsPos; // Position of the slice flags
+                std::uint8_t sliceFlags{0};
+                Container::size_type writeSlice{0};    // Position of the slice data members
+                Container::size_type sliceFlagsPos{0}; // Position of the slice flags
                 PtrToIndexMap indirectionMap;
                 ValueList indirectionTable;
 
-                InstanceData* previous;
+                InstanceData* previous{nullptr};
                 InstanceData* next{nullptr};
             };
             InstanceData _preAllocatedInstanceData;


### PR DESCRIPTION
I believe they were all initialized correctly later, but it's indeed cleaner to always initialize these fields.