### PR TITLE
Fix bug in writeExtraHeaders

### DIFF
--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -852,8 +852,8 @@ Slice::Gen::writeExtraHeaders(IceInternal::Output& out)
         string::size_type pos = header.rfind(',');
         if (pos != string::npos)
         {
-            header = header.substr(0, pos);
             guard = header.substr(pos + 1);
+            header = header.substr(0, pos);
         }
         if (!guard.empty())
         {


### PR DESCRIPTION
Fixes a small bug introduced during the clang-tidy cleanup. We didn't catch it because we have no test of `--add-header`.