### PR TITLE
Remove cpp:const from operations implemented by Ice services

### DIFF
--- a/cpp/src/Glacier2/RouterI.cpp
+++ b/cpp/src/Glacier2/RouterI.cpp
@@ -111,7 +111,7 @@ Glacier2::RouterI::addProxies(ObjectProxySeq proxies, const Current& current)
 }
 
 string
-Glacier2::RouterI::getCategoryForClient(const Current&) const
+Glacier2::RouterI::getCategoryForClient(const Current&)
 {
     assert(false); // Must not be called in this router implementation.
     return {};
@@ -144,14 +144,14 @@ Glacier2::RouterI::destroySession(const Current&)
 }
 
 int64_t
-Glacier2::RouterI::getSessionTimeout(const Current&) const
+Glacier2::RouterI::getSessionTimeout(const Current&)
 {
     assert(false); // Must not be called in this router implementation.
     return 0;
 }
 
 int32_t
-Glacier2::RouterI::getACMTimeout(const Current&) const
+Glacier2::RouterI::getACMTimeout(const Current&)
 {
     assert(false); // Must not be called in this router implementation.
     return 0;

--- a/cpp/src/Glacier2/RouterI.h
+++ b/cpp/src/Glacier2/RouterI.h
@@ -31,7 +31,7 @@ namespace Glacier2
         std::optional<Ice::ObjectPrx> getClientProxy(std::optional<bool>&, const Ice::Current&) const final;
         [[nodiscard]] std::optional<Ice::ObjectPrx> getServerProxy(const Ice::Current&) const final;
         Ice::ObjectProxySeq addProxies(Ice::ObjectProxySeq, const Ice::Current&) final;
-        [[nodiscard]] std::string getCategoryForClient(const Ice::Current&) const final;
+        [[nodiscard]] std::string getCategoryForClient(const Ice::Current&) final;
         void createSessionAsync(
             std::string,
             std::string,
@@ -44,8 +44,8 @@ namespace Glacier2
             const Ice::Current&) final;
         void refreshSession(const Ice::Current&) final {}
         void destroySession(const Ice::Current&) final;
-        [[nodiscard]] std::int64_t getSessionTimeout(const Ice::Current&) const final;
-        [[nodiscard]] int getACMTimeout(const Ice::Current&) const final;
+        [[nodiscard]] std::int64_t getSessionTimeout(const Ice::Current&) final;
+        [[nodiscard]] int getACMTimeout(const Ice::Current&) final;
 
         [[nodiscard]] std::shared_ptr<ClientBlobject> getClientBlobject() const;
         [[nodiscard]] std::shared_ptr<ServerBlobject> getServerBlobject() const;

--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -579,7 +579,7 @@ SessionRouterI::addProxies(ObjectProxySeq proxies, const Current& current)
 }
 
 string
-SessionRouterI::getCategoryForClient(const Ice::Current& current) const
+SessionRouterI::getCategoryForClient(const Ice::Current& current)
 {
     // Forward to the per-client router.
     if (_instance->serverObjectAdapter())
@@ -738,13 +738,13 @@ SessionRouterI::destroySession(const ConnectionPtr& connection)
 }
 
 int64_t
-SessionRouterI::getSessionTimeout(const Ice::Current& current) const
+SessionRouterI::getSessionTimeout(const Ice::Current& current)
 {
     return getACMTimeout(current);
 }
 
 int
-SessionRouterI::getACMTimeout(const Ice::Current&) const
+SessionRouterI::getACMTimeout(const Ice::Current&)
 {
     int idleTimeout = _instance->properties()->getIcePropertyAsInt("Ice.Connection.Server.IdleTimeout");
     return _instance->properties()->getPropertyAsIntWithDefault("Glacier2.Client.Connection.IdleTimeout", idleTimeout);

--- a/cpp/src/Glacier2/SessionRouterI.h
+++ b/cpp/src/Glacier2/SessionRouterI.h
@@ -71,7 +71,7 @@ namespace Glacier2
         std::optional<Ice::ObjectPrx> getClientProxy(std::optional<bool>&, const Ice::Current&) const final;
         [[nodiscard]] std::optional<Ice::ObjectPrx> getServerProxy(const Ice::Current&) const final;
         Ice::ObjectProxySeq addProxies(Ice::ObjectProxySeq, const Ice::Current&) final;
-        [[nodiscard]] std::string getCategoryForClient(const Ice::Current&) const final;
+        [[nodiscard]] std::string getCategoryForClient(const Ice::Current&) final;
         void createSessionAsync(
             std::string,
             std::string,
@@ -84,8 +84,8 @@ namespace Glacier2
             const Ice::Current&) final;
         void refreshSession(const Ice::Current&) final {}
         void destroySession(const Ice::Current&) final;
-        [[nodiscard]] std::int64_t getSessionTimeout(const Ice::Current&) const final;
-        [[nodiscard]] int getACMTimeout(const Ice::Current&) const final;
+        [[nodiscard]] std::int64_t getSessionTimeout(const Ice::Current&) final;
+        [[nodiscard]] int getACMTimeout(const Ice::Current&) final;
 
         void updateSessionObservers() final;
 

--- a/cpp/src/IceGrid/AdminI.cpp
+++ b/cpp/src/IceGrid/AdminI.cpp
@@ -213,13 +213,13 @@ AdminI::instantiateServer(string app, string node, ServerInstanceDescriptor desc
 }
 
 ApplicationInfo
-AdminI::getApplicationInfo(string name, const Current&) const
+AdminI::getApplicationInfo(string name, const Current&)
 {
     return _database->getApplicationInfo(name);
 }
 
 ApplicationDescriptor
-AdminI::getDefaultApplicationDescriptor(const Current& current) const
+AdminI::getDefaultApplicationDescriptor(const Current& current)
 {
     auto properties = current.adapter->getCommunicator()->getProperties();
     string path = properties->getIceProperty("IceGrid.Registry.DefaultTemplates");
@@ -267,39 +267,39 @@ AdminI::getDefaultApplicationDescriptor(const Current& current) const
 }
 
 Ice::StringSeq
-AdminI::getAllApplicationNames(const Current&) const
+AdminI::getAllApplicationNames(const Current&)
 {
     return _database->getAllApplications();
 }
 
 ServerInfo
-AdminI::getServerInfo(string id, const Current&) const
+AdminI::getServerInfo(string id, const Current&)
 {
     return _database->getServer(id)->getInfo(true);
 }
 
 ServerState
-AdminI::getServerState(string id, const Current&) const
+AdminI::getServerState(string id, const Current&)
 {
     auto proxy = ServerProxyWrapper::create(_database, std::move(id));
     return proxy.invoke(&ServerPrx::getState);
 }
 
 int
-AdminI::getServerPid(string id, const Current&) const
+AdminI::getServerPid(string id, const Current&)
 {
     auto proxy = ServerProxyWrapper::create(_database, std::move(id));
     return proxy.invoke(&ServerPrx::getPid);
 }
 
 string
-AdminI::getServerAdminCategory(const Current&) const
+AdminI::getServerAdminCategory(const Current&)
 {
     return _registry->getServerAdminCategory();
 }
 
 optional<ObjectPrx>
-AdminI::getServerAdmin(string id, const Current& current) const
+AdminI::getServerAdmin(string id, const Current& current)
 {
     auto proxy = ServerProxyWrapper::create(_database, id); // Ensure that the server exists and loaded on the node.
 
@@ -355,7 +355,7 @@ AdminI::sendSignal(string id, string signal, const Current&)
 }
 
 StringSeq
-AdminI::getAllServerIds(const Current&) const
+AdminI::getAllServerIds(const Current&)
 {
     return _database->getServerCache().getAll("");
 }
@@ -368,14 +368,14 @@ AdminI::enableServer(string id, bool enable, const Ice::Current&)
 }
 
 bool
-AdminI::isServerEnabled(string id, const Ice::Current&) const
+AdminI::isServerEnabled(string id, const Ice::Current&)
 {
     auto proxy = ServerProxyWrapper::create(_database, std::move(id));
     return proxy.invoke(&ServerPrx::isEnabled);
 }
 
 AdapterInfoSeq
-AdminI::getAdapterInfo(string id, const Current&) const
+AdminI::getAdapterInfo(string id, const Current&)
 {
     return _database->getAdapterInfo(id);
 }
@@ -388,7 +388,7 @@ AdminI::removeAdapter(string adapterId, const Ice::Current&)
 }
 
 StringSeq
-AdminI::getAllAdapterIds(const Current&) const
+AdminI::getAllAdapterIds(const Current&)
 {
     return _database->getAllAdapters();
 }
@@ -473,31 +473,31 @@ AdminI::removeObject(Ice::Identity id, const Ice::Current&)
 }
 
 ObjectInfo
-AdminI::getObjectInfo(Ice::Identity id, const Ice::Current&) const
+AdminI::getObjectInfo(Ice::Identity id, const Ice::Current&)
 {
     return _database->getObjectInfo(id);
 }
 
 ObjectInfoSeq
-AdminI::getObjectInfosByType(string type, const Ice::Current&) const
+AdminI::getObjectInfosByType(string type, const Ice::Current&)
 {
     return _database->getObjectInfosByType(type);
 }
 
 ObjectInfoSeq
-AdminI::getAllObjectInfos(string expression, const Ice::Current&) const
+AdminI::getAllObjectInfos(string expression, const Ice::Current&)
 {
     return _database->getAllObjectInfos(expression);
 }
 
 NodeInfo
-AdminI::getNodeInfo(string name, const Ice::Current&) const
+AdminI::getNodeInfo(string name, const Ice::Current&)
 {
     return toNodeInfo(_database->getNode(name)->getInfo());
 }
 
 optional<ObjectPrx>
-AdminI::getNodeAdmin(string name, const Current& current) const
+AdminI::getNodeAdmin(string name, const Current& current)
 {
     //
     // Check if the node exists
@@ -508,7 +508,7 @@ AdminI::getNodeAdmin(string name, const Current& current) const
 }
 
 bool
-AdminI::pingNode(string name, const Current&) const
+AdminI::pingNode(string name, const Current&)
 {
     try
     {
@@ -530,7 +530,7 @@ AdminI::pingNode(string name, const Current&) const
 }
 
 LoadInfo
-AdminI::getNodeLoad(string name, const Current&) const
+AdminI::getNodeLoad(string name, const Current&)
 {
     try
     {
@@ -549,7 +549,7 @@ AdminI::getNodeLoad(string name, const Current&) const
 }
 
 int
-AdminI::getNodeProcessorSocketCount(string name, const Current&) const
+AdminI::getNodeProcessorSocketCount(string name, const Current&)
 {
     try
     {
@@ -593,7 +593,7 @@ AdminI::shutdownNode(string name, const Current&)
 }
 
 string
-AdminI::getNodeHostname(string name, const Current&) const
+AdminI::getNodeHostname(string name, const Current&)
 {
     try
     {
@@ -612,13 +612,13 @@ AdminI::getNodeHostname(string name, const Current&) const
 }
 
 StringSeq
-AdminI::getAllNodeNames(const Current&) const
+AdminI::getAllNodeNames(const Current&)
 {
     return _database->getNodeCache().getAll("");
 }
 
 RegistryInfo
-AdminI::getRegistryInfo(string name, const Ice::Current&) const
+AdminI::getRegistryInfo(string name, const Ice::Current&)
 {
     if (name == _registry->getName())
     {
@@ -631,7 +631,7 @@ AdminI::getRegistryInfo(string name, const Ice::Current&) const
 }
 
 optional<ObjectPrx>
-AdminI::getRegistryAdmin(string name, const Current& current) const
+AdminI::getRegistryAdmin(string name, const Current& current)
 {
     if (name != _registry->getName())
     {
@@ -645,7 +645,7 @@ AdminI::getRegistryAdmin(string name, const Current& current) const
 }
 
 bool
-AdminI::pingRegistry(string name, const Current&) const
+AdminI::pingRegistry(string name, const Current&)
 {
     if (name == _registry->getName())
     {
@@ -693,7 +693,7 @@ AdminI::shutdownRegistry(string name, const Current&)
 }
 
 StringSeq
-AdminI::getAllRegistryNames(const Current&) const
+AdminI::getAllRegistryNames(const Current&)
 {
     Ice::StringSeq replicas = _database->getReplicaCache().getAll("");
     replicas.push_back(_registry->getName());

--- a/cpp/src/IceGrid/AdminI.h
+++ b/cpp/src/IceGrid/AdminI.h
@@ -27,15 +27,15 @@ namespace IceGrid
         void updateApplicationWithoutRestart(ApplicationUpdateDescriptor, const Ice::Current&) final;
         void removeApplication(std::string, const Ice::Current&) final;
         void instantiateServer(std::string, std::string, ServerInstanceDescriptor, const Ice::Current&) final;
-        [[nodiscard]] ApplicationInfo getApplicationInfo(std::string, const Ice::Current&) const final;
-        [[nodiscard]] ApplicationDescriptor getDefaultApplicationDescriptor(const Ice::Current&) const final;
-        [[nodiscard]] Ice::StringSeq getAllApplicationNames(const Ice::Current&) const final;
+        [[nodiscard]] ApplicationInfo getApplicationInfo(std::string, const Ice::Current&) final;
+        [[nodiscard]] ApplicationDescriptor getDefaultApplicationDescriptor(const Ice::Current&) final;
+        [[nodiscard]] Ice::StringSeq getAllApplicationNames(const Ice::Current&) final;
 
-        [[nodiscard]] ServerInfo getServerInfo(std::string, const Ice::Current&) const final;
-        [[nodiscard]] ServerState getServerState(std::string, const Ice::Current&) const final;
-        [[nodiscard]] std::int32_t getServerPid(std::string, const Ice::Current&) const final;
-        [[nodiscard]] std::string getServerAdminCategory(const Ice::Current&) const final;
-        [[nodiscard]] std::optional<Ice::ObjectPrx> getServerAdmin(std::string, const Ice::Current&) const final;
+        [[nodiscard]] ServerInfo getServerInfo(std::string, const Ice::Current&) final;
+        [[nodiscard]] ServerState getServerState(std::string, const Ice::Current&) final;
+        [[nodiscard]] std::int32_t getServerPid(std::string, const Ice::Current&) final;
+        [[nodiscard]] std::string getServerAdminCategory(const Ice::Current&) final;
+        [[nodiscard]] std::optional<Ice::ObjectPrx> getServerAdmin(std::string, const Ice::Current&) final;
         void startServerAsync(
             std::string,
             std::function<void()>,
@@ -48,36 +48,36 @@ namespace IceGrid
             const Ice::Current&) final;
 
         void sendSignal(std::string, std::string, const Ice::Current&) final;
-        [[nodiscard]] Ice::StringSeq getAllServerIds(const Ice::Current&) const final;
+        [[nodiscard]] Ice::StringSeq getAllServerIds(const Ice::Current&) final;
         void enableServer(std::string, bool, const Ice::Current&) final;
-        [[nodiscard]] bool isServerEnabled(std::string, const Ice::Current&) const final;
+        [[nodiscard]] bool isServerEnabled(std::string, const Ice::Current&) final;
 
-        [[nodiscard]] AdapterInfoSeq getAdapterInfo(std::string, const Ice::Current&) const final;
+        [[nodiscard]] AdapterInfoSeq getAdapterInfo(std::string, const Ice::Current&) final;
         void removeAdapter(std::string, const Ice::Current&) final;
-        [[nodiscard]] Ice::StringSeq getAllAdapterIds(const Ice::Current&) const final;
+        [[nodiscard]] Ice::StringSeq getAllAdapterIds(const Ice::Current&) final;
 
         void addObject(std::optional<Ice::ObjectPrx>, const Ice::Current&) final;
         void updateObject(std::optional<Ice::ObjectPrx>, const Ice::Current&) final;
         void addObjectWithType(std::optional<Ice::ObjectPrx>, std::string, const Ice::Current&) final;
         void removeObject(Ice::Identity, const Ice::Current&) final;
-        [[nodiscard]] ObjectInfo getObjectInfo(Ice::Identity, const Ice::Current&) const final;
-        [[nodiscard]] ObjectInfoSeq getObjectInfosByType(std::string, const Ice::Current&) const final;
-        [[nodiscard]] ObjectInfoSeq getAllObjectInfos(std::string, const Ice::Current&) const final;
+        [[nodiscard]] ObjectInfo getObjectInfo(Ice::Identity, const Ice::Current&) final;
+        [[nodiscard]] ObjectInfoSeq getObjectInfosByType(std::string, const Ice::Current&) final;
+        [[nodiscard]] ObjectInfoSeq getAllObjectInfos(std::string, const Ice::Current&) final;
 
-        [[nodiscard]] NodeInfo getNodeInfo(std::string, const Ice::Current&) const final;
-        [[nodiscard]] std::optional<Ice::ObjectPrx> getNodeAdmin(std::string, const Ice::Current&) const final;
-        [[nodiscard]] bool pingNode(std::string, const Ice::Current&) const final;
-        [[nodiscard]] LoadInfo getNodeLoad(std::string, const Ice::Current&) const final;
-        [[nodiscard]] int getNodeProcessorSocketCount(std::string, const Ice::Current&) const final;
+        [[nodiscard]] NodeInfo getNodeInfo(std::string, const Ice::Current&) final;
+        [[nodiscard]] std::optional<Ice::ObjectPrx> getNodeAdmin(std::string, const Ice::Current&) final;
+        [[nodiscard]] bool pingNode(std::string, const Ice::Current&) final;
+        [[nodiscard]] LoadInfo getNodeLoad(std::string, const Ice::Current&) final;
+        [[nodiscard]] int getNodeProcessorSocketCount(std::string, const Ice::Current&) final;
         void shutdownNode(std::string, const Ice::Current&) final;
-        [[nodiscard]] std::string getNodeHostname(std::string, const Ice::Current&) const final;
-        [[nodiscard]] Ice::StringSeq getAllNodeNames(const Ice::Current&) const final;
+        [[nodiscard]] std::string getNodeHostname(std::string, const Ice::Current&) final;
+        [[nodiscard]] Ice::StringSeq getAllNodeNames(const Ice::Current&) final;
 
-        [[nodiscard]] RegistryInfo getRegistryInfo(std::string, const Ice::Current&) const final;
-        [[nodiscard]] std::optional<Ice::ObjectPrx> getRegistryAdmin(std::string, const Ice::Current&) const final;
-        [[nodiscard]] bool pingRegistry(std::string, const Ice::Current&) const final;
+        [[nodiscard]] RegistryInfo getRegistryInfo(std::string, const Ice::Current&) final;
+        [[nodiscard]] std::optional<Ice::ObjectPrx> getRegistryAdmin(std::string, const Ice::Current&) final;
+        [[nodiscard]] bool pingRegistry(std::string, const Ice::Current&) final;
         void shutdownRegistry(std::string, const Ice::Current&) final;
-        [[nodiscard]] Ice::StringSeq getAllRegistryNames(const Ice::Current&) const final;
+        [[nodiscard]] Ice::StringSeq getAllRegistryNames(const Ice::Current&) final;
 
         void shutdown(const Ice::Current&) final;
 

--- a/cpp/src/IceGrid/AdminSessionI.cpp
+++ b/cpp/src/IceGrid/AdminSessionI.cpp
@@ -118,13 +118,13 @@ AdminSessionI::_register(
 }
 
 optional<AdminPrx>
-AdminSessionI::getAdmin(const Ice::Current&) const
+AdminSessionI::getAdmin(const Ice::Current&)
 {
     return _admin;
 }
 
 std::optional<Ice::ObjectPrx>
-AdminSessionI::getAdminCallbackTemplate(const Ice::Current&) const
+AdminSessionI::getAdminCallbackTemplate(const Ice::Current&)
 {
     return _adminCallbackTemplate;
 }
@@ -243,7 +243,7 @@ AdminSessionI::finishUpdate(const Ice::Current&)
 }
 
 string
-AdminSessionI::getReplicaName(const Ice::Current&) const
+AdminSessionI::getReplicaName(const Ice::Current&)
 {
     return _replicaName;
 }

--- a/cpp/src/IceGrid/AdminSessionI.h
+++ b/cpp/src/IceGrid/AdminSessionI.h
@@ -22,8 +22,8 @@ namespace IceGrid
 
         void keepAlive(const Ice::Current&) final {} // no-op
 
-        [[nodiscard]] std::optional<AdminPrx> getAdmin(const Ice::Current&) const final;
-        [[nodiscard]] std::optional<Ice::ObjectPrx> getAdminCallbackTemplate(const Ice::Current&) const final;
+        [[nodiscard]] std::optional<AdminPrx> getAdmin(const Ice::Current&) final;
+        [[nodiscard]] std::optional<Ice::ObjectPrx> getAdminCallbackTemplate(const Ice::Current&) final;
 
         void setObservers(
             std::optional<RegistryObserverPrx>,
@@ -44,7 +44,7 @@ namespace IceGrid
         int startUpdate(const Ice::Current&) final;
         void finishUpdate(const Ice::Current&) final;
 
-        [[nodiscard]] std::string getReplicaName(const Ice::Current&) const final;
+        [[nodiscard]] std::string getReplicaName(const Ice::Current&) final;
 
         std::optional<FileIteratorPrx> openServerLog(std::string, std::string, int, const Ice::Current&) final;
         std::optional<FileIteratorPrx> openServerStdOut(std::string, int, const Ice::Current&) final;

--- a/cpp/src/IceGrid/Internal.ice
+++ b/cpp/src/IceGrid/Internal.ice
@@ -117,7 +117,7 @@ module IceGrid
         /// Get the adapter direct proxy. The adapter direct proxy is a proxy created with the object adapter. The proxy
         /// contains the last known adapter endpoints.
         /// @return A direct proxy containing the last known adapter endpoints if the adapter is already active.
-        ["cpp:const"] idempotent Object* getDirectProxy()
+        idempotent Object* getDirectProxy()
             throws AdapterNotActiveException;
 
         /// Set the direct proxy for this adapter.
@@ -140,11 +140,11 @@ module IceGrid
     interface FileReader
     {
         /// Count the number of given lines from the end of the file and return the file offset.
-        ["cpp:const"] idempotent long getOffsetFromEnd(string filename, int lines)
+        idempotent long getOffsetFromEnd(string filename, int lines)
             throws FileNotAvailableException;
 
         /// Read lines (or size bytes) at the specified position from the given file.
-        ["cpp:const"] idempotent bool read(string filename, long pos, int size, out long newPos, out Ice::StringSeq lines)
+        idempotent bool read(string filename, long pos, int size, out long newPos, out Ice::StringSeq lines)
             throws FileNotAvailableException;
     }
 
@@ -169,7 +169,7 @@ module IceGrid
         void setEnabled(bool enable);
 
         /// Check if the server is enabled.
-        ["cpp:const"] idempotent bool isEnabled();
+        idempotent bool isEnabled();
 
         /// Send signal to the server
         void sendSignal(string signal)
@@ -181,11 +181,11 @@ module IceGrid
         /// Return the server state.
         /// @return The server state.
         /// @see ServerState
-        ["cpp:const"] idempotent ServerState getState();
+        idempotent ServerState getState();
 
         /// Get the server pid. Note that the value returned by this method is system dependant. On Unix operating systems,
         /// it's the pid value returned by the fork() system call and converted to an integer.
-        ["cpp:const"] idempotent int getPid();
+        idempotent int getPid();
 
         /// Set the process proxy.
         ["amd"] void setProcess(Ice::Process* proc);
@@ -240,19 +240,19 @@ module IceGrid
         void registerWithReplica(InternalRegistry* replica);
 
         /// Get the node name.
-        ["cpp:const"] idempotent string getName();
+        idempotent string getName();
 
         /// Get the node hostname.
-        ["cpp:const"] idempotent string getHostname();
+        idempotent string getHostname();
 
         /// Get the node load.
-        ["cpp:const"] idempotent LoadInfo getLoad();
+        idempotent LoadInfo getLoad();
 
         /// Get the number of processor sockets for the machine where this node is running.
-        ["cpp:const"] idempotent int getProcessorSocketCount();
+        idempotent int getProcessorSocketCount();
 
         /// Shutdown the node.
-        ["cpp:const"] idempotent void shutdown();
+        idempotent void shutdown();
     }
 
     sequence<Node*> NodePrxSeq;
@@ -272,21 +272,21 @@ module IceGrid
         void setReplicaObserver(ReplicaObserver* observer);
 
         /// Return the node session timeout.
-        ["cpp:const"] idempotent int getTimeout();
+        idempotent int getTimeout();
 
         /// Return the node observer.
-        ["cpp:const"] idempotent NodeObserver* getObserver();
+        idempotent NodeObserver* getObserver();
 
         /// Ask the registry to load the servers on the node.
-        ["amd"] ["cpp:const"] idempotent void loadServers();
+        ["amd"] idempotent void loadServers();
 
         /// Get the name of the servers deployed on the node.
-        ["cpp:const"] idempotent Ice::StringSeq getServers();
+        idempotent Ice::StringSeq getServers();
 
         /// Wait for the application update to complete (the application is completely updated once all the registry
         /// replicas have been updated). This is used by the node to ensure that before to start a server all the
         /// replicas have the up-to-date descriptor of the server.
-        ["amd"] ["cpp:const"] void waitForApplicationUpdate(string application, int revision);
+        ["amd"] void waitForApplicationUpdate(string application, int revision);
 
         /// Destroy the session.
         void destroy();
@@ -318,7 +318,7 @@ module IceGrid
         void keepAlive();
 
         /// Return the replica session timeout.
-        ["cpp:const"] idempotent int getTimeout();
+        idempotent int getTimeout();
 
         /// Set the database observer. Once the observer is subscribed, it will receive the database and database updates.
         idempotent void setDatabaseObserver(DatabaseObserver* dbObs, optional(1) StringLongDict serials)
@@ -414,17 +414,17 @@ module IceGrid
         void registerWithReplica(InternalRegistry* prx);
 
         /// Return the proxies of all the nodes known by this registry.
-        ["cpp:const"] idempotent NodePrxSeq getNodes();
+        idempotent NodePrxSeq getNodes();
 
         /// Return the proxies of all the registry replicas known by this registry.
-        ["cpp:const"] idempotent InternalRegistryPrxSeq getReplicas();
+        idempotent InternalRegistryPrxSeq getReplicas();
 
         /// Return applications, adapters, objects from this replica.
-        ["cpp:const"] idempotent ApplicationInfoSeq getApplications(out long serial);
-        ["cpp:const"] idempotent AdapterInfoSeq getAdapters(out long serial);
-        ["cpp:const"] idempotent ObjectInfoSeq getObjects(out long serial);
+        idempotent ApplicationInfoSeq getApplications(out long serial);
+        idempotent AdapterInfoSeq getAdapters(out long serial);
+        idempotent ObjectInfoSeq getObjects(out long serial);
 
         /// Shutdown this registry.
-        ["cpp:const"] idempotent void shutdown();
+        idempotent void shutdown();
     }
 }

--- a/cpp/src/IceGrid/InternalRegistryI.cpp
+++ b/cpp/src/IceGrid/InternalRegistryI.cpp
@@ -129,7 +129,7 @@ InternalRegistryI::registerWithReplica(optional<InternalRegistryPrx> replica, co
 }
 
 NodePrxSeq
-InternalRegistryI::getNodes(const Ice::Current&) const
+InternalRegistryI::getNodes(const Ice::Current&)
 {
     NodePrxSeq nodes;
     for (const auto& proxy : _database->getInternalObjectsByType(string{Node::ice_staticId()}))
@@ -141,7 +141,7 @@ InternalRegistryI::getNodes(const Ice::Current&) const
 }
 
 InternalRegistryPrxSeq
-InternalRegistryI::getReplicas(const Ice::Current&) const
+InternalRegistryI::getReplicas(const Ice::Current&)
 {
     InternalRegistryPrxSeq replicas;
     for (const auto& proxy : _database->getObjectsByType(string{InternalRegistry::ice_staticId()}))
@@ -153,31 +153,31 @@ InternalRegistryI::getReplicas(const Ice::Current&) const
 }
 
 ApplicationInfoSeq
-InternalRegistryI::getApplications(int64_t& serial, const Ice::Current&) const
+InternalRegistryI::getApplications(int64_t& serial, const Ice::Current&)
 {
     return _database->getApplications(serial);
 }
 
 AdapterInfoSeq
-InternalRegistryI::getAdapters(int64_t& serial, const Ice::Current&) const
+InternalRegistryI::getAdapters(int64_t& serial, const Ice::Current&)
 {
     return _database->getAdapters(serial);
 }
 
 ObjectInfoSeq
-InternalRegistryI::getObjects(int64_t& serial, const Ice::Current&) const
+InternalRegistryI::getObjects(int64_t& serial, const Ice::Current&)
 {
     return _database->getObjects(serial);
 }
 
 void
-InternalRegistryI::shutdown(const Ice::Current& /*current*/) const
+InternalRegistryI::shutdown(const Ice::Current&)
 {
     _registry->shutdown();
 }
 
 int64_t
-InternalRegistryI::getOffsetFromEnd(string filename, int count, const Ice::Current&) const
+InternalRegistryI::getOffsetFromEnd(string filename, int count, const Ice::Current&)
 {
     return _fileCache->getOffsetFromEnd(getFilePath(filename), count);
 }
@@ -189,7 +189,7 @@ InternalRegistryI::read(
     int size,
     int64_t& newPos,
     Ice::StringSeq& lines,
-    const Ice::Current&) const
+    const Ice::Current&)
 {
     return _fileCache->read(getFilePath(filename), pos, size, newPos, lines);
 }

--- a/cpp/src/IceGrid/InternalRegistryI.h
+++ b/cpp/src/IceGrid/InternalRegistryI.h
@@ -35,17 +35,17 @@ namespace IceGrid
 
         void registerWithReplica(std::optional<InternalRegistryPrx>, const Ice::Current&) final;
 
-        [[nodiscard]] NodePrxSeq getNodes(const Ice::Current&) const final;
-        [[nodiscard]] InternalRegistryPrxSeq getReplicas(const Ice::Current&) const final;
+        [[nodiscard]] NodePrxSeq getNodes(const Ice::Current&) final;
+        [[nodiscard]] InternalRegistryPrxSeq getReplicas(const Ice::Current&) final;
 
-        ApplicationInfoSeq getApplications(std::int64_t&, const Ice::Current&) const final;
-        AdapterInfoSeq getAdapters(std::int64_t&, const Ice::Current&) const final;
-        ObjectInfoSeq getObjects(std::int64_t&, const Ice::Current&) const final;
+        ApplicationInfoSeq getApplications(std::int64_t&, const Ice::Current&) final;
+        AdapterInfoSeq getAdapters(std::int64_t&, const Ice::Current&) final;
+        ObjectInfoSeq getObjects(std::int64_t&, const Ice::Current&) final;
 
-        void shutdown(const Ice::Current&) const final;
+        void shutdown(const Ice::Current&) final;
 
-        [[nodiscard]] std::int64_t getOffsetFromEnd(std::string, int, const Ice::Current&) const final;
-        bool read(std::string, std::int64_t, int, std::int64_t&, Ice::StringSeq&, const Ice::Current&) const final;
+        [[nodiscard]] std::int64_t getOffsetFromEnd(std::string, int, const Ice::Current&) final;
+        bool read(std::string, std::int64_t, int, std::int64_t&, Ice::StringSeq&, const Ice::Current&) final;
 
     private:
         [[nodiscard]] std::string getFilePath(const std::string&) const;

--- a/cpp/src/IceGrid/LocatorI.cpp
+++ b/cpp/src/IceGrid/LocatorI.cpp
@@ -795,13 +795,13 @@ LocatorI::getRegistry(const Ice::Current&) const
 }
 
 optional<RegistryPrx>
-LocatorI::getLocalRegistry(const Ice::Current&) const
+LocatorI::getLocalRegistry(const Ice::Current&)
 {
     return _localRegistry;
 }
 
 optional<QueryPrx>
-LocatorI::getLocalQuery(const Ice::Current&) const
+LocatorI::getLocalQuery(const Ice::Current&)
 {
     return _localQuery;
 }

--- a/cpp/src/IceGrid/LocatorI.h
+++ b/cpp/src/IceGrid/LocatorI.h
@@ -50,8 +50,8 @@ namespace IceGrid
             const Ice::Current&) const override;
 
         [[nodiscard]] std::optional<Ice::LocatorRegistryPrx> getRegistry(const Ice::Current&) const override;
-        [[nodiscard]] std::optional<RegistryPrx> getLocalRegistry(const Ice::Current&) const override;
-        [[nodiscard]] std::optional<QueryPrx> getLocalQuery(const Ice::Current&) const override;
+        [[nodiscard]] std::optional<RegistryPrx> getLocalRegistry(const Ice::Current&) override;
+        [[nodiscard]] std::optional<QueryPrx> getLocalQuery(const Ice::Current&) override;
 
         [[nodiscard]] const Ice::CommunicatorPtr& getCommunicator() const;
         [[nodiscard]] const std::shared_ptr<TraceLevels>& getTraceLevels() const;

--- a/cpp/src/IceGrid/NodeI.cpp
+++ b/cpp/src/IceGrid/NodeI.cpp
@@ -199,43 +199,43 @@ NodeI::replicaRemoved(optional<InternalRegistryPrx> replica, const Ice::Current&
 }
 
 std::string
-NodeI::getName(const Ice::Current&) const
+NodeI::getName(const Ice::Current&)
 {
     return _name;
 }
 
 std::string
-NodeI::getHostname(const Ice::Current&) const
+NodeI::getHostname(const Ice::Current&)
 {
     return _platform.getHostname();
 }
 
 LoadInfo
-NodeI::getLoad(const Ice::Current&) const
+NodeI::getLoad(const Ice::Current&)
 {
     return _platform.getLoadInfo();
 }
 
 int
-NodeI::getProcessorSocketCount(const Ice::Current&) const
+NodeI::getProcessorSocketCount(const Ice::Current&)
 {
     return _platform.getProcessorSocketCount();
 }
 
 void
-NodeI::shutdown(const Ice::Current&) const
+NodeI::shutdown(const Ice::Current&)
 {
     _activator->shutdown();
 }
 
 int64_t
-NodeI::getOffsetFromEnd(string filename, int count, const Ice::Current&) const
+NodeI::getOffsetFromEnd(string filename, int count, const Ice::Current&)
 {
     return _fileCache->getOffsetFromEnd(getFilePath(filename), count);
 }
 
 bool
-NodeI::read(string filename, int64_t pos, int size, int64_t& newPos, Ice::StringSeq& lines, const Ice::Current&) const
+NodeI::read(string filename, int64_t pos, int size, int64_t& newPos, Ice::StringSeq& lines, const Ice::Current&)
 {
     return _fileCache->read(getFilePath(filename), pos, size, newPos, lines);
 }

--- a/cpp/src/IceGrid/NodeI.h
+++ b/cpp/src/IceGrid/NodeI.h
@@ -87,14 +87,14 @@ namespace IceGrid
         void replicaAdded(std::optional<InternalRegistryPrx>, const Ice::Current&) override;
         void replicaRemoved(std::optional<InternalRegistryPrx>, const Ice::Current&) override;
 
-        [[nodiscard]] std::string getName(const Ice::Current&) const override;
-        [[nodiscard]] std::string getHostname(const Ice::Current&) const override;
-        [[nodiscard]] LoadInfo getLoad(const Ice::Current&) const override;
-        [[nodiscard]] int getProcessorSocketCount(const Ice::Current&) const override;
-        void shutdown(const Ice::Current&) const override;
+        [[nodiscard]] std::string getName(const Ice::Current&) override;
+        [[nodiscard]] std::string getHostname(const Ice::Current&) override;
+        [[nodiscard]] LoadInfo getLoad(const Ice::Current&) override;
+        [[nodiscard]] int getProcessorSocketCount(const Ice::Current&) override;
+        void shutdown(const Ice::Current&) override;
 
-        [[nodiscard]] std::int64_t getOffsetFromEnd(std::string, int, const Ice::Current&) const override;
-        bool read(std::string, std::int64_t, int, std::int64_t&, Ice::StringSeq&, const Ice::Current&) const override;
+        [[nodiscard]] std::int64_t getOffsetFromEnd(std::string, int, const Ice::Current&) override;
+        bool read(std::string, std::int64_t, int, std::int64_t&, Ice::StringSeq&, const Ice::Current&) override;
 
         void shutdown();
 

--- a/cpp/src/IceGrid/NodeSessionI.cpp
+++ b/cpp/src/IceGrid/NodeSessionI.cpp
@@ -116,20 +116,20 @@ NodeSessionI::setReplicaObserver(std::optional<ReplicaObserverPrx> observer, con
 }
 
 int
-NodeSessionI::getTimeout(const Ice::Current&) const
+NodeSessionI::getTimeout(const Ice::Current&)
 {
     return secondsToInt(_timeout);
 }
 
 optional<NodeObserverPrx>
-NodeSessionI::getObserver(const Ice::Current&) const
+NodeSessionI::getObserver(const Ice::Current&)
 {
     return dynamic_pointer_cast<NodeObserverTopic>(_database->getObserverTopic(TopicName::NodeObserver))
         ->getPublisher();
 }
 
 void
-NodeSessionI::loadServersAsync(function<void()> response, function<void(exception_ptr)>, const Ice::Current&) const
+NodeSessionI::loadServersAsync(function<void()> response, function<void(exception_ptr)>, const Ice::Current&)
 {
     //
     // No need to wait for the servers to be loaded. If we were
@@ -151,7 +151,7 @@ NodeSessionI::loadServersAsync(function<void()> response, function<void(exceptio
 }
 
 Ice::StringSeq
-NodeSessionI::getServers(const Ice::Current&) const
+NodeSessionI::getServers(const Ice::Current&)
 {
     auto servers = _database->getNode(_info->name)->getServers();
     Ice::StringSeq names;
@@ -168,7 +168,7 @@ NodeSessionI::waitForApplicationUpdateAsync(
     int revision,
     function<void()> response,
     function<void(exception_ptr)> exception,
-    const Ice::Current&) const
+    const Ice::Current&)
 {
     _database->waitForApplicationUpdate(application, revision, std::move(response), std::move(exception));
 }

--- a/cpp/src/IceGrid/NodeSessionI.h
+++ b/cpp/src/IceGrid/NodeSessionI.h
@@ -23,17 +23,17 @@ namespace IceGrid
 
         void keepAlive(LoadInfo, const Ice::Current&) final;
         void setReplicaObserver(std::optional<ReplicaObserverPrx>, const Ice::Current&) final;
-        [[nodiscard]] int getTimeout(const Ice::Current&) const final;
-        [[nodiscard]] std::optional<NodeObserverPrx> getObserver(const Ice::Current&) const final;
-        void loadServersAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&)
-            const final;
-        [[nodiscard]] Ice::StringSeq getServers(const Ice::Current&) const final;
+        [[nodiscard]] int getTimeout(const Ice::Current&) final;
+        [[nodiscard]] std::optional<NodeObserverPrx> getObserver(const Ice::Current&) final;
+        void
+        loadServersAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) final;
+        [[nodiscard]] Ice::StringSeq getServers(const Ice::Current&) final;
         void waitForApplicationUpdateAsync(
             std::string,
             int,
             std::function<void()>,
             std::function<void(std::exception_ptr)>,
-            const Ice::Current&) const final;
+            const Ice::Current&) final;
         void destroy(const Ice::Current&) final;
 
         [[nodiscard]] std::optional<std::chrono::steady_clock::time_point> timestamp() const noexcept;

--- a/cpp/src/IceGrid/QueryI.cpp
+++ b/cpp/src/IceGrid/QueryI.cpp
@@ -15,7 +15,7 @@ QueryI::QueryI(CommunicatorPtr communicator, const shared_ptr<Database>& databas
 }
 
 optional<Ice::ObjectPrx>
-QueryI::findObjectById(Ice::Identity id, const Ice::Current&) const
+QueryI::findObjectById(Ice::Identity id, const Ice::Current&)
 {
     try
     {
@@ -28,25 +28,25 @@ QueryI::findObjectById(Ice::Identity id, const Ice::Current&) const
 }
 
 optional<Ice::ObjectPrx>
-QueryI::findObjectByType(string type, const Ice::Current& current) const
+QueryI::findObjectByType(string type, const Ice::Current& current)
 {
     return _database->getObjectByType(type, current.con, current.ctx);
 }
 
 optional<Ice::ObjectPrx>
-QueryI::findObjectByTypeOnLeastLoadedNode(string type, LoadSample sample, const Ice::Current& current) const
+QueryI::findObjectByTypeOnLeastLoadedNode(string type, LoadSample sample, const Ice::Current& current)
 {
     return _database->getObjectByTypeOnLeastLoadedNode(type, sample, current.con, current.ctx);
 }
 
 Ice::ObjectProxySeq
-QueryI::findAllObjectsByType(string type, const Ice::Current& current) const
+QueryI::findAllObjectsByType(string type, const Ice::Current& current)
 {
     return _database->getObjectsByType(type, current.con, current.ctx);
 }
 
 Ice::ObjectProxySeq
-QueryI::findAllReplicas(optional<Ice::ObjectPrx> proxy, const Ice::Current& current) const
+QueryI::findAllReplicas(optional<Ice::ObjectPrx> proxy, const Ice::Current& current)
 {
     if (!proxy)
     {

--- a/cpp/src/IceGrid/QueryI.h
+++ b/cpp/src/IceGrid/QueryI.h
@@ -15,17 +15,16 @@ namespace IceGrid
     public:
         QueryI(Ice::CommunicatorPtr, const std::shared_ptr<Database>&);
 
-        [[nodiscard]] std::optional<Ice::ObjectPrx> findObjectById(Ice::Identity, const Ice::Current&) const override;
+        [[nodiscard]] std::optional<Ice::ObjectPrx> findObjectById(Ice::Identity, const Ice::Current&) override;
 
-        [[nodiscard]] std::optional<Ice::ObjectPrx> findObjectByType(std::string, const Ice::Current&) const override;
+        [[nodiscard]] std::optional<Ice::ObjectPrx> findObjectByType(std::string, const Ice::Current&) override;
 
         [[nodiscard]] std::optional<Ice::ObjectPrx>
-        findObjectByTypeOnLeastLoadedNode(std::string, LoadSample, const Ice::Current&) const override;
+        findObjectByTypeOnLeastLoadedNode(std::string, LoadSample, const Ice::Current&) override;
 
-        [[nodiscard]] Ice::ObjectProxySeq findAllObjectsByType(std::string, const Ice::Current&) const override;
+        [[nodiscard]] Ice::ObjectProxySeq findAllObjectsByType(std::string, const Ice::Current&) override;
 
-        [[nodiscard]] Ice::ObjectProxySeq
-        findAllReplicas(std::optional<Ice::ObjectPrx>, const Ice::Current&) const override;
+        [[nodiscard]] Ice::ObjectProxySeq findAllReplicas(std::optional<Ice::ObjectPrx>, const Ice::Current&) override;
 
     private:
         const Ice::CommunicatorPtr _communicator;

--- a/cpp/src/IceGrid/RegistryI.cpp
+++ b/cpp/src/IceGrid/RegistryI.cpp
@@ -1064,7 +1064,7 @@ RegistryI::createAdminSessionFromSecureConnection(const Current& current)
 }
 
 int
-RegistryI::getSessionTimeout(const Ice::Current&) const
+RegistryI::getSessionTimeout(const Ice::Current&)
 {
     // getSessionTimeout is called by clients that create sessions (resource allocation sessions aka client sessions and
     // admin sessions) directly using the IceGrid::Registry interface. These sessions are hosted by the

--- a/cpp/src/IceGrid/RegistryI.h
+++ b/cpp/src/IceGrid/RegistryI.h
@@ -46,7 +46,7 @@ namespace IceGrid
         std::optional<SessionPrx> createSessionFromSecureConnection(const Ice::Current&) override;
         std::optional<AdminSessionPrx> createAdminSessionFromSecureConnection(const Ice::Current&) override;
 
-        [[nodiscard]] int getSessionTimeout(const Ice::Current&) const override;
+        [[nodiscard]] int getSessionTimeout(const Ice::Current&) override;
 
         [[nodiscard]] std::string getName() const;
         [[nodiscard]] RegistryInfo getInfo() const;

--- a/cpp/src/IceGrid/ReplicaSessionI.cpp
+++ b/cpp/src/IceGrid/ReplicaSessionI.cpp
@@ -97,7 +97,7 @@ ReplicaSessionI::keepAlive(const Ice::Current&)
 }
 
 int
-ReplicaSessionI::getTimeout(const Ice::Current&) const
+ReplicaSessionI::getTimeout(const Ice::Current&)
 {
     return secondsToInt(_timeout);
 }

--- a/cpp/src/IceGrid/ReplicaSessionI.h
+++ b/cpp/src/IceGrid/ReplicaSessionI.h
@@ -23,7 +23,7 @@ namespace IceGrid
             std::chrono::seconds);
 
         void keepAlive(const Ice::Current&) override;
-        [[nodiscard]] int getTimeout(const Ice::Current&) const override;
+        [[nodiscard]] int getTimeout(const Ice::Current&) override;
         void setDatabaseObserver(std::optional<DatabaseObserverPrx>, std::optional<StringLongDict>, const Ice::Current&)
             final;
         void setEndpoints(StringObjectProxyDict, const Ice::Current&) override;

--- a/cpp/src/IceGrid/ServerAdapterI.cpp
+++ b/cpp/src/IceGrid/ServerAdapterI.cpp
@@ -102,7 +102,7 @@ ServerAdapterI::activateAsync(
 }
 
 optional<Ice::ObjectPrx>
-ServerAdapterI::getDirectProxy(const Ice::Current&) const
+ServerAdapterI::getDirectProxy(const Ice::Current&)
 {
     lock_guard lock(_mutex);
 

--- a/cpp/src/IceGrid/ServerAdapterI.h
+++ b/cpp/src/IceGrid/ServerAdapterI.h
@@ -20,7 +20,7 @@ namespace IceGrid
             std::function<void(const std::optional<Ice::ObjectPrx>&)>, // TODO: pass by value!
             std::function<void(std::exception_ptr)>,
             const Ice::Current&) override;
-        [[nodiscard]] std::optional<Ice::ObjectPrx> getDirectProxy(const Ice::Current&) const override;
+        [[nodiscard]] std::optional<Ice::ObjectPrx> getDirectProxy(const Ice::Current&) override;
         void setDirectProxy(std::optional<Ice::ObjectPrx>, const Ice::Current&) override;
 
         void destroy();

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -790,7 +790,7 @@ ServerI::writeMessage(string message, int fd, const Ice::Current&)
 }
 
 ServerState
-ServerI::getState(const Ice::Current&) const
+ServerI::getState(const Ice::Current&)
 {
     lock_guard lock(_mutex);
     checkDestroyed();
@@ -798,7 +798,7 @@ ServerI::getState(const Ice::Current&) const
 }
 
 int32_t
-ServerI::getPid(const Ice::Current&) const
+ServerI::getPid(const Ice::Current&)
 {
     return _node->getActivator()->getServerPid(_id);
 }
@@ -876,7 +876,7 @@ ServerI::setEnabled(bool enabled, const Ice::Current&)
 }
 
 bool
-ServerI::isEnabled(const Ice::Current&) const
+ServerI::isEnabled(const Ice::Current&)
 {
     lock_guard lock(_mutex);
     checkDestroyed();
@@ -937,13 +937,13 @@ ServerI::setProcessAsync(
 }
 
 int64_t
-ServerI::getOffsetFromEnd(string filename, int count, const Ice::Current&) const
+ServerI::getOffsetFromEnd(string filename, int count, const Ice::Current&)
 {
     return _node->getFileCache()->getOffsetFromEnd(getFilePath(filename), count);
 }
 
 bool
-ServerI::read(string filename, int64_t pos, int size, int64_t& newPos, Ice::StringSeq& lines, const Ice::Current&) const
+ServerI::read(string filename, int64_t pos, int size, int64_t& newPos, Ice::StringSeq& lines, const Ice::Current&)
 {
     return _node->getFileCache()->read(getFilePath(filename), pos, size, newPos, lines);
 }

--- a/cpp/src/IceGrid/ServerI.h
+++ b/cpp/src/IceGrid/ServerI.h
@@ -59,19 +59,19 @@ namespace IceGrid
         void sendSignal(std::string, const Ice::Current&) override;
         void writeMessage(std::string, int, const Ice::Current&) override;
 
-        [[nodiscard]] ServerState getState(const Ice::Current&) const override;
-        [[nodiscard]] int getPid(const Ice::Current&) const override;
+        [[nodiscard]] ServerState getState(const Ice::Current&) override;
+        [[nodiscard]] int getPid(const Ice::Current&) override;
 
         void setEnabled(bool, const Ice::Current&) override;
-        [[nodiscard]] bool isEnabled(const Ice::Current&) const override;
+        [[nodiscard]] bool isEnabled(const Ice::Current&) override;
         void setProcessAsync(
             std::optional<Ice::ProcessPrx>,
             std::function<void()>,
             std::function<void(std::exception_ptr)>,
             const Ice::Current&) override;
 
-        [[nodiscard]] std::int64_t getOffsetFromEnd(std::string, int, const Ice::Current&) const override;
-        bool read(std::string, std::int64_t, int, std::int64_t&, Ice::StringSeq&, const Ice::Current&) const override;
+        [[nodiscard]] std::int64_t getOffsetFromEnd(std::string, int, const Ice::Current&) override;
+        bool read(std::string, std::int64_t, int, std::int64_t&, Ice::StringSeq&, const Ice::Current&) override;
 
         [[nodiscard]] bool isAdapterActivatable(const std::string&) const;
         [[nodiscard]] const std::string& getId() const;

--- a/cpp/src/IceStorm/Election.ice
+++ b/cpp/src/IceStorm/Election.ice
@@ -170,24 +170,24 @@ module IceStormElection
 
         /// Determine if this node is a coordinator.
         /// @return `true` if the node is a coordinator, `false` otherwise.
-        ["cpp:const"] idempotent bool areYouCoordinator();
+        idempotent bool areYouCoordinator();
 
         /// Determine if the node is a member of the given group with the given coordinator.
         /// @param gn The group name.
         /// @param j The group coordinator.
         /// @return `true` if the node is a member, `false` otherwise.
-        ["cpp:const"] idempotent bool areYouThere(string gn, int j);
+        idempotent bool areYouThere(string gn, int j);
 
         /// Get the sync object for the replica hosted by this node.
         /// @return The sync object.
-        ["cpp:const"] idempotent Object* sync();
+        idempotent Object* sync();
 
         /// Get the replication group information.
         /// @return The set of configured nodes and the associated priority.
-        ["cpp:const"] idempotent NodeInfoSeq nodes();
+        idempotent NodeInfoSeq nodes();
 
         /// Get the query information for the given node.
         /// @return The query information.
-        ["cpp:const"] idempotent QueryInfo query();
+        idempotent QueryInfo query();
     }
 }

--- a/cpp/src/IceStorm/IceStormInternal.ice
+++ b/cpp/src/IceStorm/IceStormInternal.ice
@@ -65,6 +65,6 @@ module IceStorm
     {
         /// Return the replica node proxy for this topic manager.
         /// @return The replica proxy, or null if this instance is not replicated.
-        ["cpp:const"] idempotent IceStormElection::Node* getReplicaNode();
+        idempotent IceStormElection::Node* getReplicaNode();
     }
 } // End module IceStorm

--- a/cpp/src/IceStorm/NodeI.cpp
+++ b/cpp/src/IceStorm/NodeI.cpp
@@ -904,27 +904,27 @@ NodeI::accept(
 }
 
 bool
-NodeI::areYouCoordinator(const Ice::Current&) const
+NodeI::areYouCoordinator(const Ice::Current&)
 {
     lock_guard lock(_mutex);
     return _state != NodeState::NodeStateElection && _state != NodeState::NodeStateReorganization && _coord == _id;
 }
 
 bool
-NodeI::areYouThere(string gn, int j, const Ice::Current&) const
+NodeI::areYouThere(string gn, int j, const Ice::Current&)
 {
     lock_guard lock(_mutex);
     return _group == gn && _coord == _id && _up.find(GroupNodeInfo(j)) != _up.end();
 }
 
 optional<Ice::ObjectPrx>
-NodeI::sync(const Ice::Current&) const
+NodeI::sync(const Ice::Current&)
 {
     return _replica->getSync();
 }
 
 NodeInfoSeq
-NodeI::nodes(const Ice::Current&) const
+NodeI::nodes(const Ice::Current&)
 {
     NodeInfoSeq seq;
     for (const auto& n : _nodes)
@@ -936,7 +936,7 @@ NodeI::nodes(const Ice::Current&) const
 }
 
 QueryInfo
-NodeI::query(const Ice::Current&) const
+NodeI::query(const Ice::Current&)
 {
     lock_guard lock(_mutex);
     QueryInfo info;

--- a/cpp/src/IceStorm/NodeI.h
+++ b/cpp/src/IceStorm/NodeI.h
@@ -36,11 +36,11 @@ namespace IceStormElection
         void ready(int, std::string, std::optional<Ice::ObjectPrx>, int, std::int64_t, const Ice::Current&) final;
         void
         accept(int, std::string, Ice::IntSeq, std::optional<Ice::ObjectPrx>, LogUpdate, int, const Ice::Current&) final;
-        [[nodiscard]] bool areYouCoordinator(const Ice::Current&) const final;
-        [[nodiscard]] bool areYouThere(std::string, int, const Ice::Current&) const final;
-        [[nodiscard]] std::optional<Ice::ObjectPrx> sync(const Ice::Current&) const final;
-        [[nodiscard]] NodeInfoSeq nodes(const Ice::Current&) const final;
-        [[nodiscard]] QueryInfo query(const Ice::Current&) const final;
+        [[nodiscard]] bool areYouCoordinator(const Ice::Current&) final;
+        [[nodiscard]] bool areYouThere(std::string, int, const Ice::Current&) final;
+        [[nodiscard]] std::optional<Ice::ObjectPrx> sync(const Ice::Current&) final;
+        [[nodiscard]] NodeInfoSeq nodes(const Ice::Current&) final;
+        [[nodiscard]] QueryInfo query(const Ice::Current&) final;
         void recovery(std::int64_t = -1);
 
         void destroy();

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -268,10 +268,7 @@ namespace
             return _impl->getLinkInfoSeq();
         }
 
-        [[nodiscard]] Ice::IdentitySeq getSubscribers(const Ice::Current&) override
-        {
-            return _impl->getSubscribers();
-        }
+        [[nodiscard]] Ice::IdentitySeq getSubscribers(const Ice::Current&) override { return _impl->getSubscribers(); }
 
         void destroy(const Ice::Current& current) override
         {

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -90,21 +90,21 @@ namespace
         {
         }
 
-        [[nodiscard]] string getName(const Ice::Current&) const override
+        [[nodiscard]] string getName(const Ice::Current&) override
         {
             // Use cached reads.
             CachedReadHelper unlock(_instance->node(), __FILE__, __LINE__);
             return _impl->getName();
         }
 
-        [[nodiscard]] optional<Ice::ObjectPrx> getPublisher(const Ice::Current&) const override
+        [[nodiscard]] optional<Ice::ObjectPrx> getPublisher(const Ice::Current&) override
         {
             // Use cached reads.
             CachedReadHelper unlock(_instance->node(), __FILE__, __LINE__);
             return _impl->getPublisher();
         }
 
-        [[nodiscard]] optional<Ice::ObjectPrx> getNonReplicatedPublisher(const Ice::Current&) const override
+        [[nodiscard]] optional<Ice::ObjectPrx> getNonReplicatedPublisher(const Ice::Current&) override
         {
             // Use cached reads.
             CachedReadHelper unlock(_instance->node(), __FILE__, __LINE__);
@@ -261,14 +261,14 @@ namespace
             }
         }
 
-        [[nodiscard]] LinkInfoSeq getLinkInfoSeq(const Ice::Current&) const override
+        [[nodiscard]] LinkInfoSeq getLinkInfoSeq(const Ice::Current&) override
         {
             // Use cached reads.
             CachedReadHelper unlock(_instance->node(), __FILE__, __LINE__);
             return _impl->getLinkInfoSeq();
         }
 
-        [[nodiscard]] Ice::IdentitySeq getSubscribers(const Ice::Current&) const override
+        [[nodiscard]] Ice::IdentitySeq getSubscribers(const Ice::Current&) override
         {
             return _impl->getSubscribers();
         }

--- a/cpp/src/IceStorm/TopicManagerI.cpp
+++ b/cpp/src/IceStorm/TopicManagerI.cpp
@@ -78,7 +78,7 @@ namespace
             return _impl->retrieveAll();
         }
 
-        [[nodiscard]] optional<NodePrx> getReplicaNode(const Ice::Current&) const final
+        [[nodiscard]] optional<NodePrx> getReplicaNode(const Ice::Current&) final
         {
             // This doesn't require the replication to be running.
             return _instance->nodeProxy();

--- a/cpp/src/IceStorm/TransientTopicI.cpp
+++ b/cpp/src/IceStorm/TransientTopicI.cpp
@@ -107,14 +107,14 @@ TransientTopicImpl::TransientTopicImpl(shared_ptr<Instance> instance, std::strin
 }
 
 string
-TransientTopicImpl::getName(const Ice::Current&) const
+TransientTopicImpl::getName(const Ice::Current&)
 {
     // Immutable
     return _name;
 }
 
 optional<Ice::ObjectPrx>
-TransientTopicImpl::getPublisher(const Ice::Current&) const
+TransientTopicImpl::getPublisher(const Ice::Current&)
 {
     // Immutable
     assert(_publisherPrx);
@@ -122,7 +122,7 @@ TransientTopicImpl::getPublisher(const Ice::Current&) const
 }
 
 optional<Ice::ObjectPrx>
-TransientTopicImpl::getNonReplicatedPublisher(const Ice::Current&) const
+TransientTopicImpl::getNonReplicatedPublisher(const Ice::Current&)
 {
     // Immutable
     assert(_publisherPrx);
@@ -292,7 +292,7 @@ TransientTopicImpl::unlink(optional<TopicPrx> topic, const Ice::Current&)
 }
 
 LinkInfoSeq
-TransientTopicImpl::getLinkInfoSeq(const Ice::Current&) const
+TransientTopicImpl::getLinkInfoSeq(const Ice::Current&)
 {
     lock_guard lock(_mutex);
 
@@ -313,7 +313,7 @@ TransientTopicImpl::getLinkInfoSeq(const Ice::Current&) const
 }
 
 Ice::IdentitySeq
-TransientTopicImpl::getSubscribers(const Ice::Current&) const
+TransientTopicImpl::getSubscribers(const Ice::Current&)
 {
     lock_guard lock(_mutex);
 

--- a/cpp/src/IceStorm/TransientTopicI.h
+++ b/cpp/src/IceStorm/TransientTopicI.h
@@ -17,17 +17,17 @@ namespace IceStorm
         static std::shared_ptr<TransientTopicImpl>
         create(const std::shared_ptr<Instance>&, const std::string&, const Ice::Identity&);
 
-        [[nodiscard]] std::string getName(const Ice::Current&) const override;
-        [[nodiscard]] std::optional<Ice::ObjectPrx> getNonReplicatedPublisher(const Ice::Current&) const override;
-        [[nodiscard]] std::optional<Ice::ObjectPrx> getPublisher(const Ice::Current&) const override;
+        [[nodiscard]] std::string getName(const Ice::Current&) override;
+        [[nodiscard]] std::optional<Ice::ObjectPrx> getNonReplicatedPublisher(const Ice::Current&) override;
+        [[nodiscard]] std::optional<Ice::ObjectPrx> getPublisher(const Ice::Current&) override;
         std::optional<Ice::ObjectPrx>
         subscribeAndGetPublisher(QoS, std::optional<Ice::ObjectPrx>, const Ice::Current&) override;
         void unsubscribe(std::optional<Ice::ObjectPrx>, const Ice::Current&) override;
         std::optional<TopicLinkPrx> getLinkProxy(const Ice::Current&) override;
         void link(std::optional<TopicPrx>, int, const Ice::Current&) override;
         void unlink(std::optional<TopicPrx>, const Ice::Current&) override;
-        [[nodiscard]] LinkInfoSeq getLinkInfoSeq(const Ice::Current&) const override;
-        [[nodiscard]] Ice::IdentitySeq getSubscribers(const Ice::Current&) const override;
+        [[nodiscard]] LinkInfoSeq getLinkInfoSeq(const Ice::Current&) override;
+        [[nodiscard]] Ice::IdentitySeq getSubscribers(const Ice::Current&) override;
         void destroy(const Ice::Current&) override;
         void reap(Ice::IdentitySeq, const Ice::Current&) override;
 

--- a/cpp/src/IceStorm/TransientTopicManagerI.cpp
+++ b/cpp/src/IceStorm/TransientTopicManagerI.cpp
@@ -92,7 +92,7 @@ TransientTopicManagerImpl::retrieveAll(const Ice::Current&)
 }
 
 optional<IceStormElection::NodePrx>
-TransientTopicManagerImpl::getReplicaNode(const Ice::Current&) const
+TransientTopicManagerImpl::getReplicaNode(const Ice::Current&)
 {
     return nullopt;
 }

--- a/cpp/src/IceStorm/TransientTopicManagerI.h
+++ b/cpp/src/IceStorm/TransientTopicManagerI.h
@@ -19,7 +19,7 @@ namespace IceStorm
         std::optional<TopicPrx> create(std::string, const Ice::Current&) final;
         std::optional<TopicPrx> retrieve(std::string, const Ice::Current&) final;
         TopicDict retrieveAll(const Ice::Current&) final;
-        [[nodiscard]] std::optional<IceStormElection::NodePrx> getReplicaNode(const Ice::Current&) const final;
+        [[nodiscard]] std::optional<IceStormElection::NodePrx> getReplicaNode(const Ice::Current&) final;
 
         void reap();
         void shutdown();

--- a/cpp/test/Ice/location/ServerLocator.cpp
+++ b/cpp/test/Ice/location/ServerLocator.cpp
@@ -147,7 +147,7 @@ ServerLocator::getRegistry(const Current&) const
 }
 
 int
-ServerLocator::getRequestCount(const Current&) const
+ServerLocator::getRequestCount(const Current&)
 {
     return _requestCount;
 }

--- a/cpp/test/Ice/location/ServerLocator.h
+++ b/cpp/test/Ice/location/ServerLocator.h
@@ -67,7 +67,7 @@ public:
 
     [[nodiscard]] std::optional<Ice::LocatorRegistryPrx> getRegistry(const Ice::Current&) const final;
 
-    [[nodiscard]] int getRequestCount(const Ice::Current&) const final;
+    [[nodiscard]] int getRequestCount(const Ice::Current&) final;
 
 private:
     ServerLocatorRegistryPtr _registry;

--- a/cpp/test/Ice/location/Test.ice
+++ b/cpp/test/Ice/location/Test.ice
@@ -20,7 +20,7 @@ module Test
         //
         // Returns the number of request on the locator interface.
         //
-        ["cpp:const"] idempotent int getRequestCount();
+        idempotent int getRequestCount();
     }
 
     interface ServerManager

--- a/slice/Glacier2/Router.ice
+++ b/slice/Glacier2/Router.ice
@@ -32,7 +32,7 @@ module Glacier2
         /// Gets a unique category that identifies the client (caller) in the router. This category must be used in the
         /// identities of all the client's callback objects.
         /// @return The category. It's an empty string when `Glacier2.Server.Endpoints` is not configured.
-        ["cpp:const"] idempotent string getCategoryForClient();
+        idempotent string getCategoryForClient();
 
         /// Creates a session for the client (caller) with the router. If a {@link SessionManager} is configured,
         /// a proxy to a {@link Session} object is returned to the client. Otherwise, null is returned and only an
@@ -86,10 +86,10 @@ module Glacier2
 
         /// Gets the idle timeout used by the server-side of the connection.
         /// @return The idle timeout (in seconds).
-        ["cpp:const"] idempotent long getSessionTimeout();
+        idempotent long getSessionTimeout();
 
         /// Gets the idle timeout used by the server-side of the connection.
         /// @return The idle timeout (in seconds).
-        ["cpp:const"] idempotent int getACMTimeout();
+        idempotent int getACMTimeout();
     }
 }

--- a/slice/Ice/Locator.ice
+++ b/slice/Ice/Locator.ice
@@ -42,7 +42,9 @@ module Ice
         /// @return A dummy proxy, or null if an object with the requested identity was not found.
         /// @throws ObjectNotFoundException Thrown when an object with the requested identity was not found. The caller
         /// should treat this exception like a null return value.
-        ["amd"] ["cpp:const"] idempotent Object* findObjectById(Identity id)
+        ["amd"]
+        ["cpp:const"]
+        idempotent Object* findObjectById(Identity id)
             throws ObjectNotFoundException;
 
         /// Finds an object adapter by adapter ID and returns a dummy proxy with the object adapter's endpoint(s).
@@ -50,12 +52,15 @@ module Ice
         /// @return A dummy proxy with the adapter's endpoints, or null if an object adapter with @p id was not found.
         /// @throws AdapterNotFoundException Thrown when an object adapter with this adapter ID was not found. The
         /// caller should treat this exception like a null return value.
-        ["amd"] ["cpp:const"] idempotent Object* findAdapterById(string id)
+        ["amd"]
+        ["cpp:const"]
+        idempotent Object* findAdapterById(string id)
             throws AdapterNotFoundException;
 
         /// Gets a proxy to the locator registry.
         /// @return A proxy to the locator registry, or null if this locator has no associated registry.
-        ["cpp:const"] idempotent LocatorRegistry* getRegistry();
+        ["cpp:const"]
+        idempotent LocatorRegistry* getRegistry();
     }
 
     /// Provides access to a {@link Locator} object via a fixed identity.

--- a/slice/Ice/Router.ice
+++ b/slice/Ice/Router.ice
@@ -24,13 +24,15 @@ module Ice
         /// runtime will call {@link addProxies} to populate the routing table. The Ice runtime assumes the router has
         /// a routing table when @p hasRoutingTable is not set. Introduced in Ice 3.7.
         /// @return The router's client proxy.
-        ["cpp:const"] idempotent Object* getClientProxy(out optional(1) bool hasRoutingTable);
+        ["cpp:const"]
+        idempotent Object* getClientProxy(out optional(1) bool hasRoutingTable);
 
         /// Gets the router's server proxy, i.e., the proxy to use for forwarding requests from the server to the
         /// router. The Ice runtime uses the endpoints of this proxy as the published endpoints of bi-dir object
         /// adapters.
         /// @return The router's server proxy.
-        ["cpp:const"] idempotent Object* getServerProxy();
+        ["cpp:const"]
+        idempotent Object* getServerProxy();
 
         /// Adds new proxy information to the router's routing table.
         /// @param proxies The proxies to add. Adding a null proxy is an error.

--- a/slice/IceGrid/Admin.ice
+++ b/slice/IceGrid/Admin.ice
@@ -284,27 +284,23 @@ module IceGrid
         /// @param name The application name.
         /// @return The application descriptor.
         /// @throws ApplicationNotExistException Thrown when the application doesn't exist.
-        ["cpp:const"]
         idempotent ApplicationInfo getApplicationInfo(string name)
             throws ApplicationNotExistException;
 
         /// Gets the default application descriptor.
         /// @return The default application descriptor.
         /// @throws DeploymentException Thrown when the default application descriptor is invalid or unreachable.
-        ["cpp:const"]
         idempotent ApplicationDescriptor getDefaultApplicationDescriptor()
             throws DeploymentException;
 
         /// Gets all the IceGrid applications currently registered.
         /// @return The application names.
-        ["cpp:const"]
         idempotent Ice::StringSeq getAllApplicationNames();
 
         /// Gets information about a server.
         /// @param id The server ID.
         /// @throws ServerNotExistException Thrown when the server doesn't exist.
         /// @return The server information.
-        ["cpp:const"]
         idempotent ServerInfo getServerInfo(string id)
             throws ServerNotExistException;
 
@@ -314,7 +310,6 @@ module IceGrid
         /// @throws ServerNotExistException Thrown when the server doesn't exist.
         /// @throws NodeUnreachableException Thrown when the node is unreachable.
         /// @throws DeploymentException Thrown when the deployment of the server failed.
-        ["cpp:const"]
         idempotent ServerState getServerState(string id)
             throws ServerNotExistException, NodeUnreachableException, DeploymentException;
 
@@ -324,14 +319,12 @@ module IceGrid
         /// @throws ServerNotExistException Thrown when the server doesn't exist.
         /// @throws NodeUnreachableException Thrown when the node is unreachable.
         /// @throws DeploymentException Thrown when the deployment of the server failed.
-        ["cpp:const"]
         idempotent int getServerPid(string id)
             throws ServerNotExistException, NodeUnreachableException, DeploymentException;
 
         /// Gets the category for server admin objects. You can manufacture a server admin proxy from the admin proxy by
         /// changing its identity: use the server ID as name and the returned category as category.
         /// @return The category for server admin objects.
-        ["cpp:const"]
         idempotent string getServerAdminCategory();
 
         /// Gets a proxy to the admin object of a server.
@@ -340,7 +333,6 @@ module IceGrid
         /// @throws ServerNotExistException Thrown when the server doesn't exist.
         /// @throws NodeUnreachableException Thrown when the node is unreachable.
         /// @throws DeploymentException Thrown when the deployment of the server failed.
-        ["cpp:const"]
         idempotent Object* getServerAdmin(string id)
             throws ServerNotExistException, NodeUnreachableException, DeploymentException;
 
@@ -361,7 +353,6 @@ module IceGrid
         /// @throws ServerNotExistException Thrown when the server doesn't exist.
         /// @throws NodeUnreachableException Thrown when the node is unreachable.
         /// @throws DeploymentException Thrown when the deployment of the server failed.
-        ["cpp:const"]
         idempotent bool isServerEnabled(string id)
             throws ServerNotExistException, NodeUnreachableException, DeploymentException;
 
@@ -397,7 +388,6 @@ module IceGrid
 
         /// Gets the IDs of all the servers registered with IceGrid.
         /// @return The server IDs.
-        ["cpp:const"]
         idempotent Ice::StringSeq getAllServerIds();
 
         /// Gets adapter information for the replica group or adapter with the given ID.
@@ -406,7 +396,6 @@ module IceGrid
         /// If @p id refers to a replica group, this sequence contains adapter information for each member of the
         /// replica group.
         /// @throws AdapterNotExistException Thrown when the adapter or replica group doesn't exist.
-        ["cpp:const"]
         idempotent AdapterInfoSeq getAdapterInfo(string id)
             throws AdapterNotExistException;
 
@@ -419,7 +408,6 @@ module IceGrid
 
         /// Gets the IDs of all adapters registered with IceGrid.
         /// @return The adapter IDs.
-        ["cpp:const"]
         idempotent Ice::StringSeq getAllAdapterIds();
 
         /// Adds an object to the object registry. IceGrid gets the object type by calling `ice_id` on @p obj. The
@@ -458,28 +446,24 @@ module IceGrid
         /// @param id The identity of the object.
         /// @return The object info.
         /// @throws ObjectNotRegisteredException Thrown when the object isn't registered with the registry.
-        ["cpp:const"]
         idempotent ObjectInfo getObjectInfo(Ice::Identity id)
             throws ObjectNotRegisteredException;
 
         /// Gets the object info of all the registered objects with a given type.
         /// @param type The type name.
         /// @return The object infos.
-        ["cpp:const"]
         idempotent ObjectInfoSeq getObjectInfosByType(string type);
 
         /// Gets the object info of all the registered objects whose stringified identities match the given expression.
         /// @param expr The expression to match against the stringified identities of registered objects. The expression
         /// may contain a trailing wildcard (`*`) character.
         /// @return All the object infos with a stringified identity matching the given expression.
-        ["cpp:const"]
         idempotent ObjectInfoSeq getAllObjectInfos(string expr);
 
         /// Pings an IceGrid node to see if it is active.
         /// @param name The node name.
         /// @return `true` if the node ping succeeded, `false` otherwise.
         /// @throws NodeNotExistException Thrown when the node doesn't exist.
-        ["cpp:const"]
         idempotent bool pingNode(string name)
             throws NodeNotExistException;
 
@@ -488,7 +472,6 @@ module IceGrid
         /// @return The node load information.
         /// @throws NodeNotExistException Thrown when the node doesn't exist.
         /// @throws NodeUnreachableException Thrown when the node is unreachable.
-        ["cpp:const"]
         idempotent LoadInfo getNodeLoad(string name)
             throws NodeNotExistException, NodeUnreachableException;
 
@@ -497,7 +480,6 @@ module IceGrid
         /// @return The node information.
         /// @throws NodeNotExistException Thrown when the node doesn't exist.
         /// @throws NodeUnreachableException Thrown when the node is unreachable.
-        ["cpp:const"]
         idempotent NodeInfo getNodeInfo(string name)
             throws NodeNotExistException, NodeUnreachableException;
 
@@ -506,7 +488,6 @@ module IceGrid
         /// @return A proxy to the IceGrid node's admin object. This proxy is never null.
         /// @throws NodeNotExistException Thrown when the node doesn't exist.
         /// @throws NodeUnreachableException Thrown when the node is unreachable.
-        ["cpp:const"]
         idempotent Object* getNodeAdmin(string name)
             throws NodeNotExistException, NodeUnreachableException;
 
@@ -517,7 +498,6 @@ module IceGrid
         /// @return The number of processor sockets or 1 if the number of sockets can't be determined.
         /// @throws NodeNotExistException Thrown when the node doesn't exist.
         /// @throws NodeUnreachableException Thrown when the node is unreachable.
-        ["cpp:const"]
         idempotent int getNodeProcessorSocketCount(string name)
             throws NodeNotExistException, NodeUnreachableException;
 
@@ -533,20 +513,18 @@ module IceGrid
         /// @return The node hostname.
         /// @throws NodeNotExistException Thrown when the node doesn't exist.
         /// @throws NodeUnreachableException Thrown when the node is unreachable.
-        ["cpp:const"]
         idempotent string getNodeHostname(string name)
             throws NodeNotExistException, NodeUnreachableException;
 
         /// Gets the names of all IceGrid nodes currently registered.
         /// @return The node names.
-        ["cpp:const"]
         idempotent Ice::StringSeq getAllNodeNames();
 
         /// Pings an IceGrid registry to see if it is active.
         /// @param name The registry name.
         /// @return `true` if the registry ping succeeded, `false` otherwise.
         /// @throws RegistryNotExistException Thrown when the registry doesn't exist.
-        ["cpp:const"] idempotent bool pingRegistry(string name)
+        idempotent bool pingRegistry(string name)
             throws RegistryNotExistException;
 
         /// Gets the registry information of an IceGrid registry.
@@ -554,14 +532,14 @@ module IceGrid
         /// @return The registry information.
         /// @throws RegistryNotExistException Thrown when the registry doesn't exist.
         /// @throws RegistryUnreachableException Thrown when the registry is unreachable.
-        ["cpp:const"] idempotent RegistryInfo getRegistryInfo(string name)
+        idempotent RegistryInfo getRegistryInfo(string name)
             throws RegistryNotExistException, RegistryUnreachableException;
 
         /// Gets a proxy to the admin object of an IceGrid registry.
         /// @param name The registry name.
         /// @return A proxy to the admin object of an IceGrid registry. This proxy is never null.
         /// @throws RegistryNotExistException Thrown when the registry doesn't exist.
-        ["cpp:const"] idempotent Object* getRegistryAdmin(string name)
+        idempotent Object* getRegistryAdmin(string name)
             throws RegistryNotExistException;
 
         /// Shuts down an IceGrid registry.
@@ -573,7 +551,7 @@ module IceGrid
 
         /// Gets the names of all the IceGrid registries currently registered.
         /// @return The registry names.
-        ["cpp:const"] idempotent Ice::StringSeq getAllRegistryNames();
+        idempotent Ice::StringSeq getAllRegistryNames();
 
         /// Shuts down the IceGrid registry.
         void shutdown();
@@ -766,13 +744,11 @@ module IceGrid
         /// Gets a proxy to the IceGrid admin object. The admin object returned by this operation can only be accessed
         /// by the session.
         /// @return A proxy to the IceGrid admin object. This proxy is never null.
-        ["cpp:const"]
         idempotent Admin* getAdmin();
 
         /// Gets a "template" proxy for admin callback objects. An Admin client uses this proxy to set the category of
         /// its callback objects, and the published endpoints of the object adapter hosting the admin callback objects.
         /// @return A template proxy. The returned proxy is null when the Admin session was established using Glacier2.
-        ["cpp:const"]
         idempotent Object* getAdminCallbackTemplate();
 
         /// Sets the observer proxies that receive notifications when the state of the registry or nodes changes.
@@ -821,7 +797,6 @@ module IceGrid
 
         /// Gets the name of the registry replica hosting this session.
         /// @return The replica name of the registry.
-        ["cpp:const"]
         idempotent string getReplicaName();
 
         /// Opens a server log file for reading.

--- a/slice/IceGrid/Registry.ice
+++ b/slice/IceGrid/Registry.ice
@@ -43,13 +43,13 @@ module IceGrid
         /// Find a well-known object by identity.
         /// @param id The identity.
         /// @return The proxy or null if no such object has been found.
-        ["cpp:const"] idempotent Object* findObjectById(Ice::Identity id);
+        idempotent Object* findObjectById(Ice::Identity id);
 
         /// Find a well-known object by type. If there are several objects registered for the given type, the object is
         /// randomly selected.
         /// @param type The object type.
         /// @return The proxy or null, if no such object has been found.
-        ["cpp:const"] idempotent Object* findObjectByType(string type);
+        idempotent Object* findObjectByType(string type);
 
         /// Find a well-known object by type on the least-loaded node. If the registry does not know which node hosts
         /// the object (for example, because the object was registered with a direct proxy), the registry assumes the
@@ -57,20 +57,19 @@ module IceGrid
         /// @param type The object type.
         /// @param sample The sampling interval.
         /// @return The proxy or null, if no such object has been found.
-        ["cpp:const"]
         idempotent Object* findObjectByTypeOnLeastLoadedNode(string type, LoadSample sample);
 
         /// Find all the well-known objects with the given type.
         /// @param type The object type.
         /// @return The proxies or an empty sequence, if no such objects have been found.
-        ["cpp:const"] idempotent Ice::ObjectProxySeq findAllObjectsByType(string type);
+        idempotent Ice::ObjectProxySeq findAllObjectsByType(string type);
 
         /// Find all the object replicas associated with the given proxy. If the given proxy is not an indirect proxy
         /// from a replica group, an empty sequence is returned.
         /// @param proxy The object proxy.
         /// @return The proxies of each object replica or an empty sequence, if the given proxy is not from a replica
         /// group.
-        ["cpp:const"] idempotent Ice::ObjectProxySeq findAllReplicas(Object* proxy);
+        idempotent Ice::ObjectProxySeq findAllReplicas(Object* proxy);
     }
 
     /// The IceGrid registry allows clients create sessions directly with the registry.
@@ -114,7 +113,7 @@ module IceGrid
         /// send heartbeats (using ACM) or call {@link Session#keepAlive} (resp. {@link AdminSession#keepAlive}) to keep
         /// a session alive in the IceGrid registry.
         /// @return The session timeout (in seconds).
-        ["cpp:const"] ["deprecated"] idempotent int getSessionTimeout();
+        ["deprecated"] idempotent int getSessionTimeout();
     }
 
     /// The IceGrid locator interface provides access to the {@link Query} and {@link Registry} object of the IceGrid
@@ -125,10 +124,10 @@ module IceGrid
     {
         /// Get the proxy of the registry object hosted by this IceGrid registry.
         /// @return The proxy of the registry object. The returned proxy is never null.
-        ["cpp:const"] idempotent Registry* getLocalRegistry();
+        idempotent Registry* getLocalRegistry();
 
         /// Get the proxy of the query object hosted by this IceGrid registry.
         /// @return The proxy of the query object. The returned proxy is never null.
-        ["cpp:const"] idempotent Query* getLocalQuery();
+        idempotent Query* getLocalQuery();
     }
 }

--- a/slice/IceStorm/IceStorm.ice
+++ b/slice/IceStorm/IceStorm.ice
@@ -74,18 +74,18 @@ module IceStorm
         /// Gets the name of this topic.
         /// @return The name of the topic.
         /// @see TopicManager#create
-        ["cpp:const"] idempotent string getName();
+        idempotent string getName();
 
         /// Gets a proxy to a publisher object for this topic. To publish data to a topic, a publisher calls this
         /// operation and then creates a proxy with the publisher type from this proxy. If a replicated IceStorm
         /// deployment is used, this call may return a replicated proxy.
         /// @return A proxy to publish data on this topic. This proxy is never null.
-        ["cpp:const"] idempotent Object* getPublisher();
+        idempotent Object* getPublisher();
 
         /// Gets a non-replicated proxy to a publisher object for this topic. To publish data to a topic, a publisher
         /// calls this operation and then creates a proxy with the publisher type from this proxy.
         /// @return A proxy to publish data on this topic. This proxy is never null.
-        ["cpp:const"] idempotent Object* getNonReplicatedPublisher();
+        idempotent Object* getNonReplicatedPublisher();
 
         /// Subscribes to this topic.
         /// @param theQoS The quality of service parameters for this subscription.
@@ -115,11 +115,11 @@ module IceStorm
 
         /// Gets information on the current links.
         /// @return A sequence of LinkInfo objects.
-        ["cpp:const"] idempotent LinkInfoSeq getLinkInfoSeq();
+        idempotent LinkInfoSeq getLinkInfoSeq();
 
         /// Gets the list of subscribers for this topic.
         /// @return The sequence of Ice identities for the subscriber objects.
-        ["cpp:const"] Ice::IdentitySeq getSubscribers();
+        Ice::IdentitySeq getSubscribers();
 
         /// Destroys this topic.
         void destroy();


### PR DESCRIPTION
This PR removes the `cpp:const` metadata from all operations implemented by Ice services (Glacier2, IceGrid, IceStorm).
I did remove the `cpp:const` metadata itself and kept it on "callback" interfaces and other interfaces that users may reasonably implement, such as Locator, Router and PermissionsVerifier.

The `cpp:const` metadata is useless since:
 - all dispatches in C++ are performed through a `shared_ptr<non-const T>`
 - dispatch functions are not supposed to be called locally for other purposes ... the only situation where they could be called on a const object.

Nevertheless, we keep it for backward compatibility. There is no need to keep it for interfaces that only these Ice services implement, hence this PR.