### PR TITLE
Fixed Assertion Hit in `csLinkFormatter` Fallback Case

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -480,6 +480,14 @@ Slice::DocComment::parseFrom(const ContainedPtr& p, DocLinkFormatter linkFormatt
                     string msg = "no Slice element with identifier '" + linkText + "' could be found in this context";
                     p->unit()->warning(p->file(), p->line(), InvalidComment, msg);
                 }
+                if (dynamic_pointer_cast<Parameter>(linkTarget))
+                {
+                    // We don't support linking to parameters with '@link' tags.
+                    // Parameter links must be done with '@p' tags, and can only appear on the enclosing operation.
+                    string msg = "cannot link parameter '" + linkText + "'; parameters can only be referenced with @p";
+                    p->unit()->warning(p->file(), p->line(), InvalidComment, msg);
+                    linkTarget = nullptr;
+                }
 
                 // Finally, insert a correctly formatted link where the '{@link foo}' used to be.
                 string formattedLink = linkFormatter(linkText, p, linkTarget);

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -422,7 +422,7 @@ namespace
 
         // Then, before checking for user-defined types, we determine which scope we'll be searching relative to.
         ContainerPtr linkSourceScope = dynamic_pointer_cast<Container>(source);
-        if (!linkSourceScope)
+        if (!linkSourceScope || dynamic_pointer_cast<Operation>(source))
         {
             linkSourceScope = source->container();
         }

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -166,7 +166,7 @@ namespace
             // Replace any '#' scope separators with '.'s.
             replace(targetS.begin(), targetS.end(), '#', '.');
             // Remove any leading scope separators.
-            if (targetS.find(".") == 0)
+            if (targetS.find('.') == 0)
             {
                 targetS.erase(0, 1);
             }

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -155,8 +155,21 @@ namespace
             // Replace "::"" by "." in the raw link. This is for the situation where the user passes a Slice type
             // reference but (a) the source Slice file does not include this type and (b) there is no cs:identifier or
             // other identifier renaming.
-            string targetS = joinString(splitScopedName(rawLink, false), ".");
+            string targetS = rawLink;
+            // Replace any "::" scope separators with '.'s.
+            auto pos = targetS.find("::");
+            while (pos != string::npos)
+            {
+                targetS.replace(pos, 2, ".");
+                pos = targetS.find("::", pos);
+            }
+            // Replace any '#' scope separators with '.'s.
             replace(targetS.begin(), targetS.end(), '#', '.');
+            // Remove any leading scope separators.
+            if (targetS.find(".") == 0)
+            {
+                targetS.erase(0, 1);
+            }
             result << "cref=\"" << targetS << "\"";
         }
 


### PR DESCRIPTION
This PR fixes 3 bugs in how the Slice compiler handles `@link` tags:

1) We no long support linking to parameters with `@link`. In the future we will support `@p` tags for this.
2) Using a relative link like `#myOperation` on an operation, will search inside that operation's _interface_ instead of it's parameters. For example:
```
interface Hello {
    /// Before this PR, #myOperation linked to the parameter.
    /// Now it will link to the operation underneath here.
    greet(bool myOperation);

    myOperation();
}
```

3) Removes the call to `splitScopedName` in the fallback case of `csLinkFormatter`.
This function requires it's argument to be scoped, but a user could type `{@link Hello}`; `Hello` is unscoped, and would crash the compiler. Instead of calling this function, we perform the replacement by hand.

We should also be removing any leading scope separators. Not related to the bugs here, but we should be.

----

Note that 1 and 2 match the behavior of Doxygen.
So this PR brings us closer to Doxygen.