### PR TITLE
Suppress doc for some server-side classes (C++)

### DIFF
--- a/cpp/doxygen/Doxyfile
+++ b/cpp/doxygen/Doxyfile
@@ -1029,7 +1029,47 @@ EXCLUDE_SYMBOLS        = DataStormI \
                          IceInternal \
                          IceUtilInternal \
                          Glacier2Internal \
-                         std
+                         std \
+                         Glacier2::IdentitySet \
+                         Glacier2::IdentitySetPtr \
+                         Glacier2::Router \
+                         Glacier2::RouterPtr \
+                         Glacier2::SessionControl \
+                         Glacier2::SessionControlPtr \
+                         Glacier2::StringSet \
+                         Glacier2::StringSetPtr \
+                         Ice::LoggerAdmin \
+                         Ice::LoggerAdminPtr \
+                         Ice::Process \
+                         Ice::ProcessPtr \
+                         Ice::PropertiesAdmin \
+                         Ice::PropertiesAdminPtr \
+                         IceMX::MetricsAdmin \
+                         IceMX::MetricsAdminPtr \
+                         IceBox::ServiceManager \
+                         IceBox::ServiceManagerPtr \
+                         IceGrid::Admin \
+                         IceGrid::AdminPtr \
+                         IceGrid::AdminSession \
+                         IceGrid::AdminSessionPtr \
+                         IceGrid::FileIterator \
+                         IceGrid::FileIteratorPtr \
+                         IceGrid::FileParser \
+                         IceGrid::FileParserPtr \
+                         IceGrid::Locator \
+                         IceGrid::LocatorPtr \
+                         IceGrid::Query \
+                         IceGrid::QueryPtr \
+                         IceGrid::Registry \
+                         IceGrid::RegistryPtr \
+                         IceGrid::Session \
+                         IceGrid::SessionPtr \
+                         IceStorm::Finder \
+                         IceStorm::FinderPtr \
+                         IceStorm::Topic \
+                         IceStorm::TopicPtr \
+                         IceStorm::TopicManager \
+                         IceStorm::TopicManagerPtr
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include


### PR DESCRIPTION
This is equivalent to the DocGen*.cs files in C#.

Note that the suppression doesn't fully work:
 - the Ptr aliases are still there
 - the suppressed classes are still listed as namespace members
 