### PR TITLE
Deprecate Ice::emptyCurrent (C++)

### DIFF
--- a/cpp/include/Ice/Current.h
+++ b/cpp/include/Ice/Current.h
@@ -44,8 +44,8 @@ namespace Ice
         EncodingVersion encoding;
     };
 
-    /// @private
     /// A default-initialized Current instance.
+    [[deprecated("Avoid calling generated functions with a trailing Current parameter.")]]
     ICE_API extern const Current emptyCurrent;
 
     /// Makes sure the operation mode of an incoming request is not idempotent.

--- a/cpp/src/Glacier2/RouterI.cpp
+++ b/cpp/src/Glacier2/RouterI.cpp
@@ -100,7 +100,6 @@ Glacier2::RouterI::getClientProxy(optional<bool>& hasRoutingTable, const Current
 optional<ObjectPrx>
 Glacier2::RouterI::getServerProxy(const Current&) const
 {
-    // No mutex lock necessary, _serverProxy is immutable and is never destroyed.
     return _serverProxy;
 }
 

--- a/cpp/src/Glacier2/RouterI.h
+++ b/cpp/src/Glacier2/RouterI.h
@@ -56,6 +56,8 @@ namespace Glacier2
 
         [[nodiscard]] std::string toString() const;
 
+        [[nodiscard]] const std::optional<Ice::ObjectPrx>& serverProxy() const noexcept { return _serverProxy; }
+
     private:
         const std::shared_ptr<Instance> _instance;
         const std::shared_ptr<RoutingTable> _routingTable;

--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -941,7 +941,7 @@ SessionRouterI::finishCreateSession(const ConnectionPtr& connection, const share
 
     if (_instance->serverObjectAdapter())
     {
-        string category = router->getServerProxy(Ice::emptyCurrent)->ice_getIdentity().category;
+        string category = router->serverProxy()->ice_getIdentity().category;
         assert(!category.empty());
         auto rc = _routersByCategory.insert({category, router});
         assert(rc.second);

--- a/cpp/src/Ice/Current.cpp
+++ b/cpp/src/Ice/Current.cpp
@@ -7,7 +7,14 @@
 
 using namespace std;
 
+#if defined(__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 const Ice::Current Ice::emptyCurrent{};
+#if defined(__GNUC__)
+#    pragma GCC diagnostic pop
+#endif
 
 void
 Ice::checkNonIdempotent(const Current& current)

--- a/cpp/src/Ice/DisableWarnings.h
+++ b/cpp/src/Ice/DisableWarnings.h
@@ -1,16 +1,9 @@
 // Copyright (c) ZeroC, Inc.
 
-#ifndef ICE_DISABLEWARNINGS_H
-#define ICE_DISABLEWARNINGS_H
+#ifndef ICE_DISABLE_WARNINGS_H
+#define ICE_DISABLE_WARNINGS_H
 
-//
-// This header file disables various compiler warnings that we don't want.
-//
-// IMPORTANT: Do *not* include this header file in another public header file!
-//            Doing this may potentially disable the warnings in the source
-//            code of our customers, which would be bad. Only include this
-//            header file in Ice *source* files!
-//
+// Disable mostly deprecated warnings.
 
 //
 // Microsoft Visual C++

--- a/cpp/src/IceGrid/Activator.cpp
+++ b/cpp/src/IceGrid/Activator.cpp
@@ -1120,7 +1120,7 @@ Activator::destroy()
         //
         try
         {
-            proc.server->stopAsync(nullptr, nullptr, Ice::emptyCurrent);
+            proc.server->stopAsync(nullptr, nullptr);
         }
         catch (const ServerStopException&)
         {

--- a/cpp/src/IceGrid/NodeCache.cpp
+++ b/cpp/src/IceGrid/NodeCache.cpp
@@ -144,7 +144,7 @@ NodeEntry::setSession(const shared_ptr<NodeSessionI>& session)
                 {
                     try
                     {
-                        s->destroy(Ice::emptyCurrent);
+                        s->destroy();
                     }
                     catch (const Ice::ObjectNotExistException&)
                     {
@@ -313,7 +313,7 @@ NodeEntry::loadServer(
             unique_lock lock(_mutex);
             checkSession(lock);
             node = _session->getNode();
-            sessionTimeout = chrono::seconds(_session->getTimeout(Ice::emptyCurrent));
+            sessionTimeout = _session->timeout();
 
             //
             // Check if we should use a specific timeout (the load

--- a/cpp/src/IceGrid/NodeI.cpp
+++ b/cpp/src/IceGrid/NodeI.cpp
@@ -466,7 +466,7 @@ NodeI::observerUpdateServer(const ServerDynamicInfo& info)
         {
             queueUpdate(
                 observer.second,
-                [observer = observer.second, info, name = getName(Ice::emptyCurrent)](auto&& response, auto&& exception)
+                [observer = observer.second, info, name = _name](auto&& response, auto&& exception)
                 { observer->updateServerAsync(name, info, std::move(response), std::move(exception)); });
 
             sent.insert(observer.second);
@@ -501,7 +501,7 @@ NodeI::observerUpdateAdapter(const AdapterDynamicInfo& info)
         {
             queueUpdate(
                 observer.second,
-                [observer = observer.second, info, name = getName(Ice::emptyCurrent)](auto&& response, auto&& exception)
+                [observer = observer.second, info, name = _name](auto&& response, auto&& exception)
                 { observer->updateAdapterAsync(name, info, std::move(response), std::move(exception)); });
             sent.insert(observer.second);
         }

--- a/cpp/src/IceGrid/NodeSessionI.cpp
+++ b/cpp/src/IceGrid/NodeSessionI.cpp
@@ -174,9 +174,15 @@ NodeSessionI::waitForApplicationUpdateAsync(
 }
 
 void
-NodeSessionI::destroy(const Ice::Current&)
+NodeSessionI::destroy()
 {
     destroyImpl(false);
+}
+
+void
+NodeSessionI::destroy(const Ice::Current&)
+{
+    destroy();
 }
 
 optional<chrono::steady_clock::time_point>

--- a/cpp/src/IceGrid/NodeSessionI.h
+++ b/cpp/src/IceGrid/NodeSessionI.h
@@ -34,6 +34,8 @@ namespace IceGrid
             std::function<void()>,
             std::function<void(std::exception_ptr)>,
             const Ice::Current&) const final;
+
+        void destroy();
         void destroy(const Ice::Current&) final;
 
         [[nodiscard]] std::optional<std::chrono::steady_clock::time_point> timestamp() const noexcept;
@@ -45,6 +47,8 @@ namespace IceGrid
         [[nodiscard]] NodeSessionPrx getProxy() const;
 
         [[nodiscard]] bool isDestroyed() const;
+
+        [[nodiscard]] std::chrono::seconds timeout() const noexcept { return _timeout; }
 
     private:
         NodeSessionI(

--- a/cpp/src/IceGrid/ReplicaCache.cpp
+++ b/cpp/src/IceGrid/ReplicaCache.cpp
@@ -68,7 +68,7 @@ ReplicaCache::add(const string& name, const shared_ptr<ReplicaSessionI>& session
             {
                 try
                 {
-                    s->destroy(Ice::emptyCurrent);
+                    s->destroy();
                 }
                 catch (const Ice::LocalException&)
                 {

--- a/cpp/src/IceGrid/ReplicaSessionI.cpp
+++ b/cpp/src/IceGrid/ReplicaSessionI.cpp
@@ -240,9 +240,15 @@ ReplicaSessionI::receivedUpdate(TopicName topicName, int serial, string failure,
 }
 
 void
-ReplicaSessionI::destroy(const Ice::Current&)
+ReplicaSessionI::destroy()
 {
     destroyImpl(false);
+}
+
+void
+ReplicaSessionI::destroy(const Ice::Current&)
+{
+    destroy();
 }
 
 optional<chrono::steady_clock::time_point>

--- a/cpp/src/IceGrid/ReplicaSessionI.h
+++ b/cpp/src/IceGrid/ReplicaSessionI.h
@@ -31,6 +31,8 @@ namespace IceGrid
         void
         setAdapterDirectProxy(std::string, std::string, std::optional<Ice::ObjectPrx>, const Ice::Current&) override;
         void receivedUpdate(TopicName, int, std::string, const Ice::Current&) override;
+
+        void destroy();
         void destroy(const Ice::Current&) override;
 
         [[nodiscard]] std::optional<std::chrono::steady_clock::time_point> timestamp() const noexcept;

--- a/cpp/src/IceGrid/ServerAdapterI.cpp
+++ b/cpp/src/IceGrid/ServerAdapterI.cpp
@@ -67,8 +67,8 @@ ServerAdapterI::activateAsync(
         {
             return;
         }
-        _activateAfterDeactivating = _server->getState(Ice::emptyCurrent) >= ServerState::Deactivating &&
-                                     _server->getState(Ice::emptyCurrent) < ServerState::Destroying;
+        _activateAfterDeactivating =
+            _server->getState() >= ServerState::Deactivating && _server->getState() < ServerState::Destroying;
     }
 
     //
@@ -121,7 +121,7 @@ ServerAdapterI::getDirectProxy(const Ice::Current&) const
 }
 
 void
-ServerAdapterI::setDirectProxy(optional<Ice::ObjectPrx> proxy, const Ice::Current&)
+ServerAdapterI::setDirectProxy(optional<Ice::ObjectPrx> proxy)
 {
     lock_guard lock(_mutex);
 
@@ -133,7 +133,7 @@ ServerAdapterI::setDirectProxy(optional<Ice::ObjectPrx> proxy, const Ice::Curren
     {
         if (proxy && _proxy)
         {
-            if (_server->getState(Ice::emptyCurrent) == ServerState::Active)
+            if (_server->getState() == ServerState::Active)
             {
                 throw AdapterActiveException();
             }
@@ -149,8 +149,8 @@ ServerAdapterI::setDirectProxy(optional<Ice::ObjectPrx> proxy, const Ice::Curren
     // now. The server is going to be activated again and the adapter
     // activated.
     //
-    if (_server->getState(Ice::emptyCurrent) < ServerState::Deactivating ||
-        _server->getState(Ice::emptyCurrent) >= ServerState::Destroying || !_activateAfterDeactivating)
+    if (_server->getState() < ServerState::Deactivating || _server->getState() >= ServerState::Destroying ||
+        !_activateAfterDeactivating)
     {
         for (const auto& response : _activateCB)
         {
@@ -185,6 +185,12 @@ ServerAdapterI::setDirectProxy(optional<Ice::ObjectPrx> proxy, const Ice::Curren
 }
 
 void
+ServerAdapterI::setDirectProxy(optional<Ice::ObjectPrx> proxy, const Ice::Current&)
+{
+    setDirectProxy(std::move(proxy));
+}
+
+void
 ServerAdapterI::destroy()
 {
     activationFailed("adapter destroyed");
@@ -202,7 +208,7 @@ void
 ServerAdapterI::updateEnabled()
 {
     lock_guard lock(_mutex);
-    _enabled = _server->isEnabled(Ice::emptyCurrent);
+    _enabled = _server->isEnabled();
 }
 
 void

--- a/cpp/src/IceGrid/ServerAdapterI.h
+++ b/cpp/src/IceGrid/ServerAdapterI.h
@@ -21,6 +21,8 @@ namespace IceGrid
             std::function<void(std::exception_ptr)>,
             const Ice::Current&) override;
         [[nodiscard]] std::optional<Ice::ObjectPrx> getDirectProxy(const Ice::Current&) const override;
+
+        void setDirectProxy(std::optional<Ice::ObjectPrx>);
         void setDirectProxy(std::optional<Ice::ObjectPrx>, const Ice::Current&) override;
 
         void destroy();

--- a/cpp/src/IceGrid/ServerI.h
+++ b/cpp/src/IceGrid/ServerI.h
@@ -55,14 +55,18 @@ namespace IceGrid
         void waitForApplicationUpdateCompleted();
 
         void startAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
+
+        void stopAsync(std::function<void()>, std::function<void(std::exception_ptr)>);
         void stopAsync(std::function<void()>, std::function<void(std::exception_ptr)>, const Ice::Current&) override;
         void sendSignal(std::string, const Ice::Current&) override;
         void writeMessage(std::string, int, const Ice::Current&) override;
 
+        [[nodiscard]] ServerState getState() const;
         [[nodiscard]] ServerState getState(const Ice::Current&) const override;
         [[nodiscard]] int getPid(const Ice::Current&) const override;
 
         void setEnabled(bool, const Ice::Current&) override;
+        [[nodiscard]] bool isEnabled() const;
         [[nodiscard]] bool isEnabled(const Ice::Current&) const override;
         void setProcessAsync(
             std::optional<Ice::ProcessPrx>,

--- a/cpp/src/IceGrid/SessionI.cpp
+++ b/cpp/src/IceGrid/SessionI.cpp
@@ -165,9 +165,15 @@ SessionI::setAllocationTimeout(int timeout, const Ice::Current&)
 }
 
 void
-SessionI::destroy(const Ice::Current&)
+SessionI::destroy()
 {
     destroyImpl(false);
+}
+
+void
+SessionI::destroy(const Ice::Current&)
+{
+    destroy();
 }
 
 int

--- a/cpp/src/IceGrid/SessionI.h
+++ b/cpp/src/IceGrid/SessionI.h
@@ -69,6 +69,8 @@ namespace IceGrid
             const Ice::Current& current) final;
         void releaseObject(Ice::Identity, const Ice::Current&) final;
         void setAllocationTimeout(int, const Ice::Current&) final;
+
+        void destroy();
         void destroy(const Ice::Current&) final;
 
         [[nodiscard]] int getAllocationTimeout() const;

--- a/cpp/test/Ice/admin/TestI.cpp
+++ b/cpp/test/Ice/admin/TestI.cpp
@@ -58,7 +58,7 @@ RemoteCommunicatorI::getChanges(const Current&)
 }
 
 void
-RemoteCommunicatorI::addUpdateCallback(const Current&)
+RemoteCommunicatorI::addUpdateCallback()
 {
     lock_guard lock(_mutex);
 
@@ -69,6 +69,12 @@ RemoteCommunicatorI::addUpdateCallback(const Current&)
         assert(admin);
         _removeCallback = admin->addUpdateCallback([this](const PropertyDict& changes) { updated(changes); });
     }
+}
+
+void
+RemoteCommunicatorI::addUpdateCallback(const Current&)
+{
+    addUpdateCallback();
 }
 
 void
@@ -171,7 +177,7 @@ RemoteCommunicatorFactoryI::createCommunicator(PropertyDict props, const Current
     // Set the callback on the admin facet.
     //
     RemoteCommunicatorIPtr servant = make_shared<RemoteCommunicatorI>(communicator);
-    servant->addUpdateCallback(emptyCurrent);
+    servant->addUpdateCallback();
 
     return current.adapter->addWithUUID<RemoteCommunicatorPrx>(servant);
 }

--- a/cpp/test/Ice/admin/TestI.h
+++ b/cpp/test/Ice/admin/TestI.h
@@ -14,6 +14,7 @@ public:
     std::optional<Ice::ObjectPrx> getAdmin(const Ice::Current&) final;
     Ice::PropertyDict getChanges(const Ice::Current&) final;
 
+    void addUpdateCallback();
     void addUpdateCallback(const Ice::Current&) final;
     void removeUpdateCallback(const Ice::Current&) final;
 

--- a/cpp/test/Ice/library/Consumer.cpp
+++ b/cpp/test/Ice/library/Consumer.cpp
@@ -27,7 +27,10 @@ consume(const Ice::ObjectPtr& o, const Ice::ObjectPrx& p)
     test(proxy);
 
     proxy->op(false);
+#include "Ice/PushDisableWarnings.h"
+    // emptyCurrent is deprecated
     servant->op(false, Ice::emptyCurrent);
+#include "Ice/PopDisableWarnings.h"
 
     cout << "ok" << endl;
 
@@ -48,7 +51,7 @@ consume(const Ice::ObjectPtr& o, const Ice::ObjectPrx& p)
 
     try
     {
-        servant->op(true, Ice::emptyCurrent);
+        servant->op(true, Ice::Current{});
     }
     catch (const Test::UserError&)
     {


### PR DESCRIPTION
This PR deprecates Ice::emptyCurrent, and removes its usage from the C++ source code.