### PR TITLE
Remove {@link ...} syntax from C++ doc-comments

### DIFF
--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -839,29 +839,27 @@ namespace DataStorm
         /// @param writer The writer.
         SingleKeyWriter& operator=(SingleKeyWriter&& writer) noexcept;
 
-        /// Add the data element. This generates an {@link Add} sample with the
-        /// given value.
+        /// Add the data element. This generates an SampleEvent::Add sample with the given value.
         ///
         /// @param value The data element value.
         void add(const Value& value);
 
-        /// Update the data element. This generates an {@link Update} sample with the
-        /// given value.
+        /// Update the data element. This generates an SampleEvent::Update sample with the given value.
         ///
         /// @param value The data element value.
         void update(const Value& value);
 
         /// Get a partial update generator function for the given partial update tag. When called, the returned
-        /// function generates a {@link PartialUpdate} sample with the given partial update value.
+        /// function generates a SampleEvent::PartialUpdate sample with the given partial update value.
         ///
         /// The UpdateValue template parameter must match the UpdateValue type used to register the updater with
-        /// the {@link Topic::setUpdater} method.
+        /// the Topic::setUpdater method.
         ///
         /// @param tag The partial update tag.
         template<typename UpdateValue>
         [[nodiscard]] std::function<void(const UpdateValue&)> partialUpdate(const UpdateTag& tag);
 
-        /// Remove the data element. This generates a {@link Remove} sample.
+        /// Remove the data element. This generates a SampleEvent::Remove sample.
         void remove() noexcept;
 
     private:
@@ -899,29 +897,29 @@ namespace DataStorm
         /// @param writer The writer.
         MultiKeyWriter& operator=(MultiKeyWriter&& writer) noexcept;
 
-        /// Add the data element. This generates an {@link Add} sample with the given value.
+        /// Add the data element. This generates a SampleEvent::Add sample with the given value.
         ///
         /// @param key The key
         /// @param value The data element value.
         void add(const Key& key, const Value& value);
 
-        /// Update the data element. This generates an {@link Update} sample with the given value.
+        /// Update the data element. This generates a SampleEvent::Update sample with the given value.
         ///
         /// @param key The key
         /// @param value The data element value.
         void update(const Key& key, const Value& value);
 
         /// Get a partial update generator function for the given partial update tag. When called, the returned
-        /// function generates a {@link PartialUpdate} sample with the given partial update value.
+        /// function generates a SampleEvent::PartialUpdate sample with the given partial update value.
         ///
         /// The UpdateValue template parameter must match the UpdateValue type used to register the updater with
-        /// the {@link Topic::setUpdater} method.
+        /// the Topic::setUpdater method.
         ///
         /// @param tag The partial update tag.
         template<typename UpdateValue>
         [[nodiscard]] std::function<void(const Key&, const UpdateValue&)> partialUpdate(const UpdateTag& tag);
 
-        /// Remove the data element. This generates a {@link Remove} sample.
+        /// Remove the data element. This generates a TopicEvent::Remove sample.
 
         /// @param key The key
         void remove(const Key& key) noexcept;

--- a/cpp/include/DataStorm/DataStorm.h
+++ b/cpp/include/DataStorm/DataStorm.h
@@ -839,12 +839,12 @@ namespace DataStorm
         /// @param writer The writer.
         SingleKeyWriter& operator=(SingleKeyWriter&& writer) noexcept;
 
-        /// Add the data element. This generates an SampleEvent::Add sample with the given value.
+        /// Add the data element. This generates a SampleEvent::Add sample with the given value.
         ///
         /// @param value The data element value.
         void add(const Value& value);
 
-        /// Update the data element. This generates an SampleEvent::Update sample with the given value.
+        /// Update the data element. This generates a SampleEvent::Update sample with the given value.
         ///
         /// @param value The data element value.
         void update(const Value& value);

--- a/cpp/include/Ice/Instrumentation.h
+++ b/cpp/include/Ice/Instrumentation.h
@@ -191,10 +191,10 @@ namespace Ice::Instrumentation
     };
 
     /// The observer updater interface. This interface is implemented by the Ice run-time and an instance of this
-    /// interface is provided by the Ice communicator on initialization to the {@link CommunicatorObserver} object set
-    /// with the communicator initialization data. The Ice communicator calls {@link
-    /// CommunicatorObserver#setObserverUpdater} to provide the observer updater. This interface can be used by add-ins
-    /// implementing the {@link CommunicatorObserver} interface to update the observers of connections and threads.
+    /// interface is provided by the Ice communicator on initialization to the CommunicatorObserver object set
+    /// with the communicator initialization data. The Ice communicator calls CommunicatorObserver::setObserverUpdater
+    /// to provide the observer updater. This interface can be used by add-ins implementing the CommunicatorObserver
+    /// interface to update the observers of connections and threads.
     /// @headerfile Ice/Ice.h
     class ObserverUpdater
     {
@@ -204,13 +204,13 @@ namespace Ice::Instrumentation
         /// Update connection observers associated with each of the Ice connection from the communicator and its object
         /// adapters.
         /// When called, this method goes through all the connections and for each connection
-        /// {@link CommunicatorObserver#getConnectionObserver} is called. The implementation of getConnectionObserver
+        /// CommunicatorObserver::getConnectionObserver is called. The implementation of getConnectionObserver
         /// has the possibility to return an updated observer if necessary.
         virtual void updateConnectionObservers() = 0;
 
         /// Update thread observers associated with each of the Ice thread from the communicator and its object
         /// adapters. When called, this method goes through all the threads and for each thread
-        /// {@link CommunicatorObserver#getThreadObserver} is called. The implementation of getThreadObserver has the
+        /// CommunicatorObserver::getThreadObserver is called. The implementation of getThreadObserver has the
         /// possibility to return an updated observer if necessary.
         virtual void updateThreadObservers() = 0;
     };
@@ -243,7 +243,7 @@ namespace Ice::Instrumentation
 
         /// This method should return a connection observer for the given connection. The Ice run-time calls this method
         /// for each new connection and for all the Ice communicator connections when
-        /// {@link ObserverUpdater#updateConnectionObservers} is called.
+        /// ObserverUpdater::updateConnectionObservers is called.
         /// @param c The connection information.
         /// @param e The connection endpoint.
         /// @param s The state of the connection.
@@ -256,8 +256,8 @@ namespace Ice::Instrumentation
             const ConnectionObserverPtr& o) = 0;
 
         /// This method should return a thread observer for the given thread. The Ice run-time calls this method for
-        /// each new thread and for all the Ice communicator threads when {@link ObserverUpdater#updateThreadObservers}
-        /// is called.
+        /// each new thread and for all the Ice communicator threads when ObserverUpdater::updateThreadObservers is
+        /// called.
         /// @param parent The parent of the thread.
         /// @param id The ID of the thread to observe.
         /// @param s The state of the thread.

--- a/cpp/include/Ice/LocalExceptions.h
+++ b/cpp/include/Ice/LocalExceptions.h
@@ -348,8 +348,7 @@ namespace Ice
     //
 
     /// This exception is raised if a system error occurred in the server or client process. There are many possible
-    /// causes for such a system exception. For details on the cause, {@link SyscallException#error} should be
-    /// inspected.
+    /// causes for such a system exception. For details on the cause, SyscallException::error should be inspected.
     /// @headerfile Ice/Ice.h
     class ICE_API SyscallException : public LocalException
     {
@@ -403,8 +402,7 @@ namespace Ice
         ErrorCode _error;
     };
 
-    /// This exception indicates a DNS problem. For details on the cause, {@link DNSException#error} should be
-    /// inspected.
+    /// This exception indicates a DNS problem.
     /// @headerfile Ice/Ice.h
     class ICE_API DNSException final : public SyscallException
     {
@@ -549,7 +547,7 @@ namespace Ice
         std::shared_ptr<std::string> _id;
     };
 
-    /// This exception is raised if the {@link Communicator} has been destroyed.
+    /// This exception is raised if the Communicator has been destroyed.
     /// @see Communicator#destroy
     /// @headerfile Ice/Ice.h
     class ICE_API CommunicatorDestroyedException final : public LocalException
@@ -716,7 +714,7 @@ namespace Ice
         std::shared_ptr<std::string> _id;
     };
 
-    /// This exception is raised if an attempt is made to use a deactivated {@link ObjectAdapter}.
+    /// This exception is raised if an attempt is made to use a deactivated ObjectAdapter.
     /// @see ObjectAdapter#deactivate
     /// @see Communicator#shutdown
     /// @headerfile Ice/Ice.h
@@ -752,8 +750,8 @@ namespace Ice
         [[nodiscard]] const char* ice_id() const noexcept final;
     };
 
-    /// This exception is raised if an {@link ObjectAdapter} cannot be activated. This happens if the {@link Locator}
-    /// detects another active {@link ObjectAdapter} with the same adapter id.
+    /// This exception is raised if an ObjectAdapter cannot be activated. This happens if the Locator
+    /// detects another active ObjectAdapter with the same adapter id.
     /// @headerfile Ice/Ice.h
     class ICE_API ObjectAdapterIdInUseException final : public LocalException
     {

--- a/cpp/include/Ice/Plugin.h
+++ b/cpp/include/Ice/Plugin.h
@@ -11,7 +11,7 @@ namespace Ice
 {
     /// A communicator plug-in. A plug-in generally adds a feature to a communicator, such as support for a protocol.
     /// The communicator loads its plug-ins in two stages: the first stage creates the plug-ins, and the second stage
-    /// invokes {@link Plugin#initialize} on each one.
+    /// invokes Plugin::initialize on each one.
     /// @headerfile Ice/Ice.h
     class ICE_API Plugin
     {
@@ -37,7 +37,7 @@ namespace Ice
 
         /// Initialize the configured plug-ins. The communicator automatically initializes the plug-ins by default, but
         /// an application may need to interact directly with a plug-in prior to initialization. In this case, the
-        /// application must set <code>Ice.InitPlugins=0</code> and then invoke {@link #initializePlugins} manually. The
+        /// application must set <code>Ice.InitPlugins=0</code> and then invoke `initializePlugins` manually. The
         /// plug-ins are initialized in the order in which they are loaded. If a plug-in raises an exception during
         /// initialization, the communicator invokes destroy on the plug-ins that have already been initialized.
         /// @throws InitializationException Raised if the plug-ins have already been initialized.

--- a/cpp/include/IceBox/Service.h
+++ b/cpp/include/IceBox/Service.h
@@ -26,20 +26,19 @@ namespace IceBox
         [[nodiscard]] const char* ice_id() const noexcept final;
     };
 
-    /// An application service managed by a {@link ServiceManager}.
+    /// An application service managed by an IceBox service manager.
     /// @headerfile IceBox/IceBox.h
     class ICEBOX_API Service
     {
     public:
         virtual ~Service();
 
-        /// Start the service. The given communicator is created by the {@link ServiceManager} for use by the service.
-        /// This communicator may also be used by other services, depending on the service configuration. <p
-        /// class="Note">The {@link ServiceManager} owns this communicator, and is responsible for destroying it.
+        /// Start the service. The given communicator is created by the service manager for use by the service.
+        /// This communicator may also be used by other services, depending on the service configuration.
+        /// @remark The service manager owns this communicator, and is responsible for destroying it.
         /// @param name The service's name, as determined by the configuration.
         /// @param communicator A communicator for use by the service.
         /// @param args The service arguments that were not converted into properties.
-        /// @throws IceBox::FailureException Raised if {@link #start} failed.
         virtual void
         start(const std::string& name, const Ice::CommunicatorPtr& communicator, const Ice::StringSeq& args) = 0;
 

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -282,7 +282,7 @@ namespace
         }
         else
         {
-            return "{@link " + rawLink + "}";
+            return rawLink; // rely on doxygen autolink.
         }
     }
 

--- a/slice/IceBox/ServiceManager.ice
+++ b/slice/IceBox/ServiceManager.ice
@@ -63,7 +63,7 @@ module IceBox
         void stopService(string service)
             throws AlreadyStoppedException, NoSuchServiceException;
 
-        /// Registers a new observer with this ServiceManager.
+        /// Registers a new observer with this service manager.
         /// @param observer The new observer.
         void addObserver(ServiceObserver* observer);
 


### PR DESCRIPTION
This undocumented syntax breaks the VScode doxygen support.