### PR TITLE
Rework handling of builtin operations in Python ObjectPrx

### DIFF
--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -803,7 +803,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << sp << nl << "@staticmethod";
     _out << nl << "def uncheckedCast(proxy, facet=None):";
     _out.inc();
-    _out << nl << "return " << prxAbs << ".ice_uncheckedCast(proxy, facet)";
+    _out << nl << "return Ice.uncheckedCast(" << prxAbs << ", proxy, facet)";
     _out.dec();
 
     //

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -308,13 +308,6 @@ namespace IcePy
 
 namespace
 {
-    OperationPtr getOperation(PyObject* p)
-    {
-        assert(PyObject_IsInstance(p, reinterpret_cast<PyObject*>(&OperationType)) == 1);
-        auto* obj = reinterpret_cast<OperationObject*>(p);
-        return *obj->op;
-    }
-
     void handleException()
     {
         assert(PyErr_Occurred());
@@ -2425,40 +2418,6 @@ IcePy::BlobjectUpcall::exception(PyException& ex)
     {
         _error(current_exception());
     }
-}
-
-PyObject*
-IcePy::invokeBuiltin(PyObject* proxy, const string& builtin, PyObject* args)
-{
-    string name = "_op_" + builtin;
-    PyObject* objectType{lookupType("Ice.Object")};
-    assert(objectType);
-    PyObjectHandle obj{getAttr(objectType, name, false)};
-    assert(obj.get());
-
-    OperationPtr op = getOperation(obj.get());
-    assert(op);
-
-    Ice::ObjectPrx prx = getProxy(proxy);
-    InvocationPtr i = make_shared<SyncTypedInvocation>(prx, op);
-    return i->invoke(args);
-}
-
-PyObject*
-IcePy::invokeBuiltinAsync(PyObject* proxy, const string& builtin, PyObject* args)
-{
-    string name = "_op_" + builtin;
-    PyObject* objectType{lookupType("Ice.Object")};
-    assert(objectType);
-    PyObjectHandle obj{getAttr(objectType, name, false)};
-    assert(obj.get());
-
-    OperationPtr op = getOperation(obj.get());
-    assert(op);
-
-    Ice::ObjectPrx prx = getProxy(proxy);
-    InvocationPtr i = make_shared<AsyncTypedInvocation>(prx, proxy, op);
-    return i->invoke(args);
 }
 
 PyObject*

--- a/python/modules/IcePy/Operation.h
+++ b/python/modules/IcePy/Operation.h
@@ -17,10 +17,6 @@ namespace IcePy
 
     extern PyTypeObject AsyncInvocationContextType;
 
-    // Builtin operations.
-    PyObject* invokeBuiltin(PyObject*, const std::string&, PyObject*);
-    PyObject* invokeBuiltinAsync(PyObject*, const std::string&, PyObject*);
-
     // Blobject invocations.
     PyObject* iceInvoke(PyObject*, PyObject*);
     PyObject* iceInvokeAsync(PyObject*, PyObject*);

--- a/python/modules/IcePy/Proxy.cpp
+++ b/python/modules/IcePy/Proxy.cpp
@@ -1460,12 +1460,6 @@ proxyNewProxy(PyObject*, PyObject* args)
     return createProxy(*p->proxy, *p->communicator, proxyType);
 }
 
-extern "C" PyObject*
-proxyIceStaticId(PyObject* /*self*/, PyObject* /*args*/)
-{
-    return createString(Ice::Object::ice_staticId());
-}
-
 static PyMethodDef ProxyMethods[] = {
     {"ice_getCommunicator",
      reinterpret_cast<PyCFunction>(proxyIceGetCommunicator),
@@ -1676,10 +1670,6 @@ static PyMethodDef ProxyMethods[] = {
      reinterpret_cast<PyCFunction>(proxyNewProxy),
      METH_VARARGS | METH_STATIC,
      PyDoc_STR("newProxy(proxyType, proxy) -> proxy")},
-    {"ice_staticId",
-     reinterpret_cast<PyCFunction>(proxyIceStaticId),
-     METH_NOARGS | METH_STATIC,
-     PyDoc_STR("ice_staticId() -> string")},
     {} /* sentinel */
 };
 

--- a/python/modules/IcePy/Proxy.cpp
+++ b/python/modules/IcePy/Proxy.cpp
@@ -1451,12 +1451,11 @@ proxyNewProxy(PyObject*, PyObject* args)
 
     if (!checkProxy(obj))
     {
-        PyErr_Format(PyExc_ValueError, "newProxy requires a proxy argument");
+        PyErr_Format(PyExc_ValueError, "newProxy 2nd argument must be a proxy");
         return nullptr;
     }
 
     auto* p = reinterpret_cast<ProxyObject*>(obj);
-
     return createProxy(*p->proxy, *p->communicator, proxyType);
 }
 

--- a/python/modules/IcePy/Proxy.cpp
+++ b/python/modules/IcePy/Proxy.cpp
@@ -44,17 +44,6 @@ allocateProxy(const Ice::ObjectPrx& proxy, const Ice::CommunicatorPtr& communica
     {
         return nullptr;
     }
-
-    //
-    // Disabling collocation optimization can cause subtle problems with proxy
-    // comparison (such as in RouterInfo::get) if a proxy from IcePy is
-    // compared with a proxy from Ice/C++.
-    //
-    // if(proxy)
-    //{
-    //    p->proxy = new Ice::ObjectPrx(proxy->ice_collocationOptimized(false));
-    //}
-    //
     p->proxy = new Ice::ObjectPrx(proxy);
     p->communicator = new Ice::CommunicatorPtr(communicator);
 
@@ -185,144 +174,6 @@ extern "C" PyObject*
 proxyIceGetCommunicator(ProxyObject* self, PyObject* /*args*/)
 {
     return getCommunicatorWrapper(*self->communicator);
-}
-
-extern "C" PyObject*
-proxyIceIsA(ProxyObject* self, PyObject* args)
-{
-    PyObject* type{nullptr};
-    PyObject* ctx{Py_None};
-    if (!PyArg_ParseTuple(args, "O|O!", &type, &PyDict_Type, &ctx))
-    {
-        return nullptr;
-    }
-
-    //
-    // We need to reformat the arguments to match what is used by the generated code: ((params...), ctx|None)
-    //
-    PyObjectHandle newArgs{Py_BuildValue("((O), O)", type, ctx)};
-
-    return invokeBuiltin(reinterpret_cast<PyObject*>(self), "ice_isA", newArgs.get());
-}
-
-extern "C" PyObject*
-proxyIceIsAAsync(ProxyObject* self, PyObject* args)
-{
-    PyObject* type{nullptr};
-    PyObject* ctx{Py_None};
-    if (!PyArg_ParseTuple(args, "O|O!", &type, &PyDict_Type, &ctx))
-    {
-        return nullptr;
-    }
-
-    //
-    // We need to reformat the arguments to match what is used by the generated code: ((params...), ctx|None)
-    //
-    PyObjectHandle newArgs{Py_BuildValue("((O), O)", type, ctx)};
-
-    return invokeBuiltinAsync(reinterpret_cast<PyObject*>(self), "ice_isA", newArgs.get());
-}
-
-extern "C" PyObject*
-proxyIcePing(ProxyObject* self, PyObject* args)
-{
-    PyObject* ctx{Py_None};
-    if (!PyArg_ParseTuple(args, "|O!", &PyDict_Type, &ctx))
-    {
-        return nullptr;
-    }
-
-    //
-    // We need to reformat the arguments to match what is used by the generated code: ((params...), ctx|None)
-    //
-    PyObjectHandle newArgs{Py_BuildValue("((), O)", ctx)};
-
-    return invokeBuiltin(reinterpret_cast<PyObject*>(self), "ice_ping", newArgs.get());
-}
-
-extern "C" PyObject*
-proxyIcePingAsync(ProxyObject* self, PyObject* args)
-{
-    PyObject* ctx{Py_None};
-    if (!PyArg_ParseTuple(args, "|O!", &PyDict_Type, &ctx))
-    {
-        return nullptr;
-    }
-
-    //
-    // We need to reformat the arguments to match what is used by the generated code: ((params...), ctx|None)
-    //
-    PyObjectHandle newArgs{Py_BuildValue("((), O)", ctx)};
-
-    return invokeBuiltinAsync(reinterpret_cast<PyObject*>(self), "ice_ping", newArgs.get());
-}
-
-extern "C" PyObject*
-proxyIceIds(ProxyObject* self, PyObject* args)
-{
-    PyObject* ctx{Py_None};
-    if (!PyArg_ParseTuple(args, "|O!", &PyDict_Type, &ctx))
-    {
-        return nullptr;
-    }
-
-    //
-    // We need to reformat the arguments to match what is used by the generated code: ((params...), ctx|None)
-    //
-    PyObjectHandle newArgs{Py_BuildValue("((), O)", ctx)};
-
-    return invokeBuiltin(reinterpret_cast<PyObject*>(self), "ice_ids", newArgs.get());
-}
-
-extern "C" PyObject*
-proxyIceIdsAsync(ProxyObject* self, PyObject* args)
-{
-    PyObject* ctx{Py_None};
-    if (!PyArg_ParseTuple(args, "|O!", &PyDict_Type, &ctx))
-    {
-        return nullptr;
-    }
-
-    //
-    // We need to reformat the arguments to match what is used by the generated code: ((params...), ctx|None)
-    //
-    PyObjectHandle newArgs{Py_BuildValue("((), O)", ctx)};
-
-    return invokeBuiltinAsync(reinterpret_cast<PyObject*>(self), "ice_ids", newArgs.get());
-}
-
-extern "C" PyObject*
-proxyIceId(ProxyObject* self, PyObject* args)
-{
-    PyObject* ctx{Py_None};
-    if (!PyArg_ParseTuple(args, "|O!", &PyDict_Type, &ctx))
-    {
-        return nullptr;
-    }
-
-    //
-    // We need to reformat the arguments to match what is used by the generated code: ((params...), ctx|None)
-    //
-    PyObjectHandle newArgs{Py_BuildValue("((), O)", ctx)};
-
-    return invokeBuiltin(reinterpret_cast<PyObject*>(self), "ice_id", newArgs.get());
-}
-
-extern "C" PyObject*
-proxyIceIdAsync(ProxyObject* self, PyObject* args)
-{
-    PyObject* ctx = Py_None;
-    if (!PyArg_ParseTuple(args, "|O!", &PyDict_Type, &ctx))
-    {
-        return nullptr;
-    }
-
-    //
-    // We need to reformat the arguments to match what is used by the generated code: ((params...), ctx|None)
-    //
-    PyObjectHandle newArgs{Py_BuildValue("((), O)", ctx)};
-
-    return invokeBuiltinAsync(reinterpret_cast<PyObject*>(self), "ice_id", newArgs.get());
 }
 
 extern "C" PyObject*
@@ -1578,49 +1429,18 @@ proxyIceInvokeAsync(ProxyObject* self, PyObject* args, PyObject* /*kwds*/)
 }
 
 extern "C" PyObject*
-proxyIceUncheckedCast(PyObject* type, PyObject* args)
+proxyNewProxy(PyObject*, PyObject* args)
 {
-    //
-    // ice_uncheckedCast is called from generated code, therefore we always expect
-    // to receive two arguments.
-    //
-    PyObject* obj;
-    char* facet{nullptr};
-    if (!PyArg_ParseTuple(args, "Oz", &obj, &facet))
-    {
-        return nullptr;
-    }
-
-    if (obj == Py_None)
-    {
-        return Py_None;
-    }
-
-    if (!checkProxy(obj))
-    {
-        PyErr_Format(PyExc_ValueError, "ice_uncheckedCast requires a proxy argument");
-        return nullptr;
-    }
-
-    auto* p = reinterpret_cast<ProxyObject*>(obj);
-
-    if (facet)
-    {
-        return createProxy((*p->proxy)->ice_facet(facet), *p->communicator, type);
-    }
-    else
-    {
-        return createProxy(*p->proxy, *p->communicator, type);
-    }
-}
-
-extern "C" PyObject*
-proxyUncheckedCast(PyObject* /*self*/, PyObject* args)
-{
+    PyObject* proxyType{nullptr};
     PyObject* obj{nullptr};
-    PyObject* facetObj{nullptr};
-    if (!PyArg_ParseTuple(args, "O|O", &obj, &facetObj))
+    if (!PyArg_ParseTuple(args, "OO", &proxyType, &obj))
     {
+        return nullptr;
+    }
+
+    if (proxyType == Py_None)
+    {
+        PyErr_Format(PyExc_ValueError, "newProxy 1st argument must be a proxy type");
         return nullptr;
     }
 
@@ -1629,31 +1449,15 @@ proxyUncheckedCast(PyObject* /*self*/, PyObject* args)
         return Py_None;
     }
 
-    string facet;
-    if (facetObj)
-    {
-        if (!getStringArg(facetObj, "facet", facet))
-        {
-            return nullptr;
-        }
-    }
-
     if (!checkProxy(obj))
     {
-        PyErr_Format(PyExc_ValueError, "uncheckedCast requires a proxy argument");
+        PyErr_Format(PyExc_ValueError, "newProxy requires a proxy argument");
         return nullptr;
     }
 
     auto* p = reinterpret_cast<ProxyObject*>(obj);
 
-    if (facetObj)
-    {
-        return createProxy((*p->proxy)->ice_facet(facet), *p->communicator);
-    }
-    else
-    {
-        return createProxy(*p->proxy, *p->communicator);
-    }
+    return createProxy(*p->proxy, *p->communicator, proxyType);
 }
 
 extern "C" PyObject*
@@ -1668,26 +1472,6 @@ static PyMethodDef ProxyMethods[] = {
      METH_NOARGS,
      PyDoc_STR("ice_getCommunicator() -> Ice.Communicator")},
     {"ice_toString", reinterpret_cast<PyCFunction>(proxyRepr), METH_NOARGS, PyDoc_STR("ice_toString() -> string")},
-    {"ice_isA", reinterpret_cast<PyCFunction>(proxyIceIsA), METH_VARARGS, PyDoc_STR("ice_isA(type, [ctx]) -> bool")},
-    {"ice_isAAsync",
-     reinterpret_cast<PyCFunction>(proxyIceIsAAsync),
-     METH_VARARGS,
-     PyDoc_STR("ice_isAAsync(type, [ctx]) -> Ice.Future")},
-    {"ice_ping", reinterpret_cast<PyCFunction>(proxyIcePing), METH_VARARGS, PyDoc_STR("ice_ping([ctx]) -> None")},
-    {"ice_pingAsync",
-     reinterpret_cast<PyCFunction>(proxyIcePingAsync),
-     METH_VARARGS,
-     PyDoc_STR("ice_pingAsync([ctx]) -> Ice.Future")},
-    {"ice_ids", reinterpret_cast<PyCFunction>(proxyIceIds), METH_VARARGS, PyDoc_STR("ice_ids([ctx]) -> list")},
-    {"ice_idsAsync",
-     reinterpret_cast<PyCFunction>(proxyIceIdsAsync),
-     METH_VARARGS,
-     PyDoc_STR("ice_idsAsync([ctx]) -> Ice.Future")},
-    {"ice_id", reinterpret_cast<PyCFunction>(proxyIceId), METH_VARARGS, PyDoc_STR("ice_id([ctx]) -> string")},
-    {"ice_idAsync",
-     reinterpret_cast<PyCFunction>(proxyIceIdAsync),
-     METH_VARARGS,
-     PyDoc_STR("ice_idAsync([ctx]) -> Ice.Future")},
     {"ice_getIdentity",
      reinterpret_cast<PyCFunction>(proxyIceGetIdentity),
      METH_NOARGS,
@@ -1888,14 +1672,10 @@ static PyMethodDef ProxyMethods[] = {
      reinterpret_cast<PyCFunction>(proxyIceInvokeAsync),
      METH_VARARGS | METH_KEYWORDS,
      PyDoc_STR("ice_invokeAsync(op, mode, inParams[, context]) -> Ice.Future")},
-    {"ice_uncheckedCast",
-     reinterpret_cast<PyCFunction>(proxyIceUncheckedCast),
-     METH_VARARGS | METH_CLASS,
-     PyDoc_STR("ice_uncheckedCast(proxy) -> proxy")},
-    {"uncheckedCast",
-     reinterpret_cast<PyCFunction>(proxyUncheckedCast),
+    {"newProxy",
+     reinterpret_cast<PyCFunction>(proxyNewProxy),
      METH_VARARGS | METH_STATIC,
-     PyDoc_STR("uncheckedCast(proxy) -> proxy")},
+     PyDoc_STR("newProxy(proxyType, proxy) -> proxy")},
     {"ice_staticId",
      reinterpret_cast<PyCFunction>(proxyIceStaticId),
      METH_NOARGS | METH_STATIC,

--- a/python/python/Ice/ObjectPrx.py
+++ b/python/python/Ice/ObjectPrx.py
@@ -1,5 +1,31 @@
 
 import IcePy
+from .Object import Object
+
+def uncheckedCast(type, proxy, facet=None):
+    """
+    Downcasts a proxy without confirming the target object's type via a remote invocation.
+
+    Parameters
+    ----------
+    type : type
+        The proxy target type.
+    proxy : ObjectPrx
+        The source proxy (can be None).
+
+    facet : str, optional
+        A facet name.
+
+    Returns
+    -------
+    ObjectPrx|None
+        A proxy with the requested type and facet.
+    """
+    if proxy is None:
+        return None
+    if facet is not None:
+        proxy = proxy.ice_facet(facet)
+    return IcePy.ObjectPrx.newProxy(type, proxy)
 
 def checkedCast(type, proxy, facet=None, context=None):
     """
@@ -21,13 +47,13 @@ def checkedCast(type, proxy, facet=None, context=None):
     Returns
     -------
     ObjectPrx|None
-        A proxy with the requested type, or None if the target object does not support the requested type.
+        A proxy with the requested type and facet, or None if the target object does not support the requested type.
     """
     if proxy is None:
         return None
     if facet is not None:
         proxy = proxy.ice_facet(facet)
-    return type.uncheckedCast(proxy) if proxy.ice_isA(type.ice_staticId(), context=context) else None
+    return IcePy.ObjectPrx.newProxy(type, proxy) if proxy.ice_isA(type.ice_staticId(), context=context) else None
 
 async def checkedCastAsync(type, proxy, facet=None, context=None):
     """
@@ -49,19 +75,39 @@ async def checkedCastAsync(type, proxy, facet=None, context=None):
     Returns
     -------
     ObjectPrx|None
-        A proxy with the requested type, or None if the target object does not support the requested type.
+        A proxy with the requested type and facet, or None if the target object does not support the requested type.
     """
     if proxy is None:
         return None
     if facet is not None:
         proxy = proxy.ice_facet(facet)
     b = await proxy.ice_isAAsync(type.ice_staticId(), context=context)
-    return type.uncheckedCast(proxy) if b else None
+    return IcePy.ObjectPrx.newProxy(type, proxy) if b else None
 
 class ObjectPrx(IcePy.ObjectPrx):
     """
     The base class for all proxies.
     """
+
+    @staticmethod
+    def uncheckedCast(proxy, facet=None):
+        """
+        Downcasts a proxy without confirming the target object's type via a remote invocation.
+
+        Parameters
+        ----------
+        proxy : ObjectPrx
+            The source proxy (can be None).
+
+        facet : str, optional
+            A facet name.
+
+        Returns
+        -------
+        ObjectPrx|None
+            A proxy with the requested type and facet, or None if the target object does not support the requested type.
+        """
+        return uncheckedCast(ObjectPrx, proxy, facet)
 
     @staticmethod
     def checkedCast(proxy, facet=None, context=None):
@@ -82,7 +128,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         Returns
         -------
         ObjectPrx|None
-            A proxy with the requested type, or None if the target object does not support the requested type.
+            A proxy with the requested type and facet, or None if the target object does not support the requested type.
         """
         return checkedCast(ObjectPrx, proxy, facet, context)
 
@@ -148,10 +194,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         bool
             True if the target object has the interface specified by id or derives from the interface specified by id.
         """
-        if context is None:
-            return super().ice_isA(id)
-        else:
-            return super().ice_isA(id, context)
+        return Object._op_ice_isA.invoke(self, ((id,), context))
 
     def ice_isAAsync(self, id, context=None):
         """
@@ -169,10 +212,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         bool
             True if the target object has the interface specified by id or derives from the interface specified by id.
         """
-        if context is None:
-            return super().ice_isAAsync(id)
-        else:
-            return super().ice_isAAsync(id, context)
+        return Object._op_ice_isA.invokeAsync(self, ((id,), context))
 
     def ice_ping(self, context=None):
         """
@@ -187,10 +227,22 @@ class ObjectPrx(IcePy.ObjectPrx):
         --------
         >>> obj.ice_ping(context={'key': 'value'})
         """
-        if context is None:
-            super().ice_ping()
-        else:
-            super().ice_ping(context)
+        Object._op_ice_ping.invoke(self, ((), context))
+
+    def ice_pingAsync(self, context=None):
+        """
+        Test whether the target object of this proxy can be reached.
+
+        Parameters
+        ----------
+        context : dict, optional
+            The context dictionary for the invocation.
+
+        Examples
+        --------
+        >>> obj.ice_ping(context={'key': 'value'})
+        """
+        return Object._op_ice_ping.invokeAsync(self, ((), context))
 
     def ice_ids(self, context=None):
         """
@@ -206,10 +258,23 @@ class ObjectPrx(IcePy.ObjectPrx):
         list of str
             The Slice type IDs of the interfaces supported by the target object, in alphabetical order.
         """
-        if context is None:
-            return super().ice_ids()
-        else:
-            return super().ice_ids(context)
+        return Object._op_ice_ids.invoke(self, ((), context))
+
+    def ice_idsAsync(self, context=None):
+        """
+        Return the Slice type IDs of the interfaces supported by the target object of this proxy.
+
+        Parameters
+        ----------
+        context : dict, optional
+            The context dictionary for the invocation.
+
+        Returns
+        -------
+        list of str
+            The Slice type IDs of the interfaces supported by the target object, in alphabetical order.
+        """
+        return Object._op_ice_ids.invokeAsync(self, ((), context))
 
     def ice_id(self, context=None):
         """
@@ -225,10 +290,23 @@ class ObjectPrx(IcePy.ObjectPrx):
         str
             The Slice type ID of the most-derived interface.
         """
-        if context is None:
-            return super().ice_id()
-        else:
-            return super().ice_id(context)
+        return Object._op_ice_id.invoke(self, ((), context))
+
+    def ice_idAsync(self, context=None):
+        """
+        Return the Slice type ID of the most-derived interface supported by the target object of this proxy.
+
+        Parameters
+        ----------
+        context : dict, optional
+            The context dictionary for the invocation.
+
+        Returns
+        -------
+        str
+            The Slice type ID of the most-derived interface.
+        """
+        return Object._op_ice_id.invokeAsync(self, ((), context))
 
     def ice_getIdentity(self):
         """

--- a/python/python/Ice/ObjectPrx.py
+++ b/python/python/Ice/ObjectPrx.py
@@ -19,7 +19,7 @@ def uncheckedCast(type, proxy, facet=None):
     Returns
     -------
     ObjectPrx|None
-        A proxy with the requested type and facet.
+        A proxy with the requested type.
     """
     if proxy is None:
         return None
@@ -47,7 +47,7 @@ def checkedCast(type, proxy, facet=None, context=None):
     Returns
     -------
     ObjectPrx|None
-        A proxy with the requested type and facet, or None if the target object does not support the requested type.
+        A proxy with the requested type, or None if the target object does not support the requested type.
     """
     if proxy is None:
         return None
@@ -75,7 +75,7 @@ async def checkedCastAsync(type, proxy, facet=None, context=None):
     Returns
     -------
     ObjectPrx|None
-        A proxy with the requested type and facet, or None if the target object does not support the requested type.
+        A proxy with the requested type, or None if the target object does not support the requested type.
     """
     if proxy is None:
         return None
@@ -105,7 +105,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         Returns
         -------
         ObjectPrx|None
-            A proxy with the requested type and facet, or None if the target object does not support the requested type.
+            A proxy with the requested type, or None if the target object does not support the requested type.
         """
         return uncheckedCast(ObjectPrx, proxy, facet)
 
@@ -128,7 +128,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         Returns
         -------
         ObjectPrx|None
-            A proxy with the requested type and facet, or None if the target object does not support the requested type.
+            A proxy with the requested type, or None if the target object does not support the requested type.
         """
         return checkedCast(ObjectPrx, proxy, facet, context)
 

--- a/python/python/Ice/__init__.py
+++ b/python/python/Ice/__init__.py
@@ -13,7 +13,6 @@ from .EnumBase import EnumBase
 #
 # Add some symbols to the Ice module.
 #
-from .ObjectPrx import ObjectPrx, checkedCast, checkedCastAsync
 stringVersion = IcePy.stringVersion
 intVersion = IcePy.intVersion
 currentProtocol = IcePy.currentProtocol
@@ -41,6 +40,7 @@ from .Future import *
 from .InvocationFuture import *
 from .Value import *
 from .Object import Object
+from .ObjectPrx import ObjectPrx, checkedCast, checkedCastAsync, uncheckedCast
 from .Blobject import Blobject
 from .BlobjectAsync import BlobjectAsync
 from .FormatType import *


### PR DESCRIPTION
This PR reworks the handling of the 4 builtin operations and uncheckedCat in Python proxy implementation. They are now handled in the Python code rather than in the C++ extension. Removed the special C++ code for handing this operations and treat them as other RPCs.