### PR TITLE
Allow 'xxx:identifier' on 'Normal' Modules

### DIFF
--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -982,7 +982,8 @@ Slice::Gen::validateMetadata(const UnitPtr& u)
     // "cpp:identifier"
     MetadataInfo identifierInfo = {
         .validOn =
-            {typeid(InterfaceDecl),
+            {typeid(Module),
+             typeid(InterfaceDecl),
              typeid(Operation),
              typeid(ClassDecl),
              typeid(Slice::Exception),

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1785,7 +1785,8 @@ Slice::CsGenerator::validateMetadata(const UnitPtr& u)
     // "cs:identifier"
     MetadataInfo identifierInfo = {
         .validOn =
-            {typeid(InterfaceDecl),
+            {typeid(Module),
+             typeid(InterfaceDecl),
              typeid(Operation),
              typeid(ClassDecl),
              typeid(Slice::Exception),

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -1712,7 +1712,8 @@ Slice::JavaGenerator::validateMetadata(const UnitPtr& u)
     // "java:identifier"
     MetadataInfo identifierInfo = {
         .validOn =
-            {typeid(InterfaceDecl),
+            {typeid(Module),
+             typeid(InterfaceDecl),
              typeid(Operation),
              typeid(Struct),
              typeid(Sequence),

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -2863,7 +2863,8 @@ Slice::Gen::validateMetadata(const UnitPtr& u)
     // "js:identifier"
     MetadataInfo identifierInfo = {
         .validOn =
-            {typeid(InterfaceDecl),
+            {typeid(Module),
+             typeid(InterfaceDecl),
              typeid(Operation),
              typeid(ClassDecl),
              typeid(Slice::Exception),

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -1017,7 +1017,8 @@ namespace
         // "matlab:identifier"
         MetadataInfo identifierInfo = {
             .validOn =
-                {typeid(InterfaceDecl),
+                {typeid(Module),
+                 typeid(InterfaceDecl),
                  typeid(Operation),
                  typeid(Struct),
                  typeid(Sequence),

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -50,7 +50,8 @@ namespace
         // "php:identifier"
         MetadataInfo identifierInfo = {
             .validOn =
-                {typeid(InterfaceDecl),
+                {typeid(Module),
+                 typeid(InterfaceDecl),
                  typeid(Operation),
                  typeid(ClassDecl),
                  typeid(Slice::Exception),

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2404,7 +2404,8 @@ Slice::Python::validateMetadata(const UnitPtr& unit)
     // "python:identifier"
     MetadataInfo identifierInfo = {
         .validOn =
-            {typeid(InterfaceDecl),
+            {typeid(Module),
+             typeid(InterfaceDecl),
              typeid(Operation),
              typeid(ClassDecl),
              typeid(Slice::Exception),

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -22,7 +22,8 @@ namespace
         // "ruby:identifier"
         MetadataInfo identifierInfo = {
             .validOn =
-                {typeid(InterfaceDecl),
+                {typeid(Module),
+                 typeid(InterfaceDecl),
                  typeid(Operation),
                  typeid(ClassDecl),
                  typeid(Slice::Exception),

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -509,7 +509,8 @@ SwiftGenerator::validateMetadata(const UnitPtr& u)
     // "swift:identifier"
     MetadataInfo identifierInfo = {
         .validOn =
-            {typeid(InterfaceDecl),
+            {typeid(Module),
+             typeid(InterfaceDecl),
              typeid(Operation),
              typeid(ClassDecl),
              typeid(Slice::Exception),

--- a/cpp/test/Slice/escape/Key.ice
+++ b/cpp/test/Slice/escape/Key.ice
@@ -1,8 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
-// TODO figure out how to escape identifiers on modules!
-//["cpp:identifier:escaped_and"] This should be `module and` which is mapped to `escaped_and`.
-module escaped_and
+["cpp:identifier:escaped_and"]
+module and
 {
     ["cpp:identifier:escaped_continue"]
     enum continue

--- a/csharp/test/Slice/escape/Client.cs
+++ b/csharp/test/Slice/escape/Client.cs
@@ -2,20 +2,20 @@
 
 public class Client : Test.TestHelper
 {
-    public sealed class caseI : escaped_abstract.caseDisp_
+    public sealed class caseI : @abstract.caseDisp_
     {
         public override Task<int>
         catchAsync(int @checked, Ice.Current current) => Task<int>.FromResult(0);
     }
 
-    public sealed class decimalI : escaped_abstract.decimalDisp_
+    public sealed class decimalI : @abstract.decimalDisp_
     {
         public override void @default(Ice.Current current)
         {
         }
     }
 
-    public sealed class TotallyDifferentI : escaped_abstract.TotallyDifferentDisp_
+    public sealed class TotallyDifferentI : @abstract.TotallyDifferentDisp_
     {
         public override Task<int>
         catchAsync(int @checked, Ice.Current current) => Task<int>.FromResult(0);
@@ -23,7 +23,7 @@ public class Client : Test.TestHelper
         public override void @default(Ice.Current current) => test(current.operation == "default");
     }
 
-    public sealed class Test1I : escaped_abstract.System.TestDisp_
+    public sealed class Test1I : @abstract.System.TestDisp_
     {
         public override void op(Ice.Current c)
         {
@@ -40,45 +40,45 @@ public class Client : Test.TestHelper
     private static void
     testtypes()
     {
-        escaped_abstract.@as a = escaped_abstract.@as.@base;
-        test(a == escaped_abstract.@as.@base);
-        var b = new escaped_abstract.@break();
+        @abstract.@as a = @abstract.@as.@base;
+        test(a == @abstract.@as.@base);
+        var b = new @abstract.@break();
         b.@readonly = 0;
         test(b.@readonly == 0);
-        escaped_abstract.@case c = new caseI();
+        @abstract.@case c = new caseI();
         test(c != null);
-        escaped_abstract.@casePrx c1 = null;
+        @abstract.@casePrx c1 = null;
         test(c1 == null);
         c1?.@catch(0, out _);
-        escaped_abstract.@decimal d = new decimalI();
+        @abstract.@decimal d = new decimalI();
         test(d != null);
-        escaped_abstract.@decimalPrx d1 = null;
+        @abstract.@decimalPrx d1 = null;
         d1?.@default();
         test(d1 == null);
-        var e = new escaped_abstract.@delegate();
+        var e = new @abstract.@delegate();
         test(e != null);
-        escaped_abstract.@delegate e1 = null;
+        @abstract.@delegate e1 = null;
         test(e1 == null);
-        escaped_abstract.@TotallyDifferentPrx f1 = null;
+        @abstract.@TotallyDifferentPrx f1 = null;
         if (f1 != null)
         {
             f1.@catch(0, out _);
             f1.@default();
         }
         test(f1 == null);
-        var g2 = new Dictionary<string, escaped_abstract.@break>();
+        var g2 = new Dictionary<string, @abstract.@break>();
         test(g2 != null);
-        var h = new escaped_abstract.@fixed();
+        var h = new @abstract.@fixed();
         h.@for = 0;
         test(h != null);
-        var i = new escaped_abstract.@foreach();
+        var i = new @abstract.@foreach();
         i.@for = 0;
         i.@goto = 1;
         i.@if = 2;
         test(i != null);
-        int j = escaped_abstract.@protected.value;
+        int j = @abstract.@protected.value;
         test(j == 0);
-        int k = escaped_abstract.@struct.value;
+        int k = @abstract.@struct.value;
         test(k == 1);
     }
 
@@ -94,15 +94,15 @@ public class Client : Test.TestHelper
 
         Console.Out.Write("testing operation name... ");
         Console.Out.Flush();
-        escaped_abstract.@decimalPrx p =
-            escaped_abstract.@decimalPrxHelper.uncheckedCast(adapter.createProxy(Ice.Util.stringToIdentity("test")));
+        @abstract.@decimalPrx p =
+            @abstract.@decimalPrxHelper.uncheckedCast(adapter.createProxy(Ice.Util.stringToIdentity("test")));
         p.@default();
         Console.Out.WriteLine("ok");
 
         Console.Out.Write("testing System as module name... ");
         Console.Out.Flush();
-        escaped_abstract.System.TestPrx t1 =
-            escaped_abstract.System.TestPrxHelper.uncheckedCast(
+        @abstract.System.TestPrx t1 =
+            @abstract.System.TestPrxHelper.uncheckedCast(
                 adapter.createProxy(Ice.Util.stringToIdentity("test1")));
         t1.op();
 

--- a/csharp/test/Slice/escape/Key.ice
+++ b/csharp/test/Slice/escape/Key.ice
@@ -2,8 +2,8 @@
 
 #pragma once
 
-// TODO: figure out a better way to map module names.
-module escaped_abstract
+["cs:identifier:@abstract"]
+module abstract
 {
     ["cs:identifier:@as"]
     enum as

--- a/java/test/src/main/java/test/Slice/escape/Key.ice
+++ b/java/test/src/main/java/test/Slice/escape/Key.ice
@@ -4,8 +4,8 @@
 
 [["java:package:test.Slice.escape"]]
 
-// TODO: figure out a better way to map module names.
-module escaped_abstract
+["java:identifier:escaped_abstract"]
+module abstract
 {
     ["java:identifier:_assert"]
     enum assert

--- a/js/test/Slice/escape/Key.ice
+++ b/js/test/Slice/escape/Key.ice
@@ -2,8 +2,8 @@
 
 #pragma once
 
-// TODO we need a better way to remap modules.
-module escapedAwait
+["js:identifier:escapedAwait"]
+module await
 {
     ["js:identifier:_var"]
     enum var

--- a/matlab/test/Slice/escape/AllTests.m
+++ b/matlab/test/Slice/escape/AllTests.m
@@ -7,37 +7,37 @@ classdef AllTests
 
             fprintf('testing enum... ');
 
-            members = enumeration('escaped_classdef.persistent_');
-            for i = 0:int32(escaped_classdef.persistent_.LAST) - 1
+            members = enumeration('classdef_.persistent_');
+            for i = 0:int32(classdef_.persistent_.LAST) - 1
                 % Every enumerator should be escaped and therefore have a trailing underscore.
                 name = char(members(i + 1));
                 assert(strcmp(name(length(name)), '_'));
                 % Ensure ice_getValue is generated correctly.
-                assert(members(i + 1) == escaped_classdef.persistent_.ice_getValue(i));
+                assert(members(i + 1) == classdef_.persistent_.ice_getValue(i));
             end
 
             fprintf('ok\n');
 
             fprintf('testing struct... ');
 
-            s = escaped_classdef.global_();
-            assert(s.case_ == escaped_classdef.persistent_.catch_);
+            s = classdef_.global_();
+            assert(s.case_ == classdef_.persistent_.catch_);
             assert(s.continue_ == 1);
             assert(s.eq_ == 2);
             % Exercise the marshaling code.
             os = Ice.OutputStream(communicator.getEncoding());
-            escaped_classdef.global_.ice_write(os, s);
+            classdef_.global_.ice_write(os, s);
             is = Ice.InputStream(communicator, os.getEncoding(), os.finished());
-            s2 = escaped_classdef.global_.ice_read(is);
+            s2 = classdef_.global_.ice_read(is);
             assert(isequal(s, s2));
 
             fprintf('ok\n');
 
             fprintf('testing class... ');
 
-            c = escaped_classdef.logical();
-            assert(c.else_ == escaped_classdef.persistent_.break_);
-            assert(c.for_.case_ == escaped_classdef.persistent_.catch_);
+            c = classdef_.logical();
+            assert(c.else_ == classdef_.persistent_.break_);
+            assert(c.for_.case_ == classdef_.persistent_.catch_);
             assert(c.for_.continue_ == 1);
             assert(c.for_.eq_ == 2);
             assert(c.int64 == true);
@@ -47,7 +47,7 @@ classdef AllTests
             os.writePendingValues();
             is = Ice.InputStream(communicator, os.getEncoding(), os.finished());
             v = IceInternal.ValueHolder();
-            is.readValue(@v.set, 'escaped_classdef.logical');
+            is.readValue(@v.set, 'classdef_.logical');
             is.readPendingValues();
             assert(v.value.else_ == c.else_);
             assert(v.value.for_.case_ == c.for_.case_);
@@ -55,9 +55,9 @@ classdef AllTests
             assert(v.value.for_.eq_ == c.for_.eq_);
             assert(v.value.int64 == c.int64);
 
-            d = escaped_classdef.xor();
-            assert(d.else_ == escaped_classdef.persistent_.break_);
-            assert(d.for_.case_ == escaped_classdef.persistent_.catch_);
+            d = classdef_.xor();
+            assert(d.else_ == classdef_.persistent_.break_);
+            assert(d.for_.case_ == classdef_.persistent_.catch_);
             assert(d.for_.continue_ == 1);
             assert(d.for_.eq_ == 2);
             assert(d.int64 == true);
@@ -68,7 +68,7 @@ classdef AllTests
             os.writePendingValues();
             is = Ice.InputStream(communicator, os.getEncoding(), os.finished());
             v = IceInternal.ValueHolder();
-            is.readValue(@v.set, 'escaped_classdef.xor');
+            is.readValue(@v.set, 'classdef_.xor');
             is.readPendingValues();
             assert(v.value.else_ == d.else_);
             assert(v.value.for_.case_ == d.for_.case_);
@@ -77,7 +77,7 @@ classdef AllTests
             assert(v.value.int64 == d.int64);
             assert(v.value.return_ == d.return_);
 
-            p = escaped_classdef.Derived();
+            p = classdef_.Derived();
             assert(p.while_ == 1);
             assert(p.if_ == 2);
             assert(isempty(p.spmd_));
@@ -88,7 +88,7 @@ classdef AllTests
             os.writePendingValues();
             is = Ice.InputStream(communicator, os.getEncoding(), os.finished());
             v = IceInternal.ValueHolder();
-            is.readValue(@v.set, 'escaped_classdef.Derived');
+            is.readValue(@v.set, 'classdef_.Derived');
             is.readPendingValues();
             assert(v.value.while_ == p.while_);
             assert(v.value.if_ == p.if_);
@@ -97,12 +97,12 @@ classdef AllTests
 
             fprintf('testing exception... ');
 
-            e = escaped_classdef.bitand();
+            e = classdef_.bitand();
             assert(isempty(e.identifier_));
             assert(isempty(e.message_));
             assert(isempty(e.end_));
 
-            g = escaped_classdef.bitor();
+            g = classdef_.bitor();
             assert(isempty(g.identifier_));
             assert(isempty(g.message_));
             assert(isempty(g.end_));
@@ -112,8 +112,8 @@ classdef AllTests
 
             fprintf('testing interface... ');
 
-            assert(exist('escaped_classdef.MyInterfacePrx', 'class') ~= 0);
-            m = methods('escaped_classdef.MyInterfacePrx');
+            assert(exist('classdef_.MyInterfacePrx', 'class') ~= 0);
+            m = methods('classdef_.MyInterfacePrx');
             assert(ismember('foobar', m));
             assert(ismember('foobarAsync', m));
             assert(ismember('func', m));
@@ -123,7 +123,7 @@ classdef AllTests
 
             fprintf('testing constant... ');
 
-            assert(escaped_classdef.methods_.value == 1);
+            assert(classdef_.methods_.value == 1);
 
             fprintf('ok\n');
         end

--- a/matlab/test/Slice/escape/Test.ice
+++ b/matlab/test/Slice/escape/Test.ice
@@ -2,8 +2,8 @@
 
 #pragma once
 
-// TODO come up with a better way to escape modules.
-module escaped_classdef
+["matlab:identifier:classdef_"]
+module classdef
 {
     ["matlab:identifier:persistent_"]
     enum persistent

--- a/php/test/Slice/escape/Key.ice
+++ b/php/test/Slice/escape/Key.ice
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
-// TODO find a better way to escape module names.
-module escapedAnd
+["php:identifier:escapedAnd"]
+module and
 {
     ["php:identifier:another_name"]
     const int require_once = 1;

--- a/python/test/Slice/escape/Client.py
+++ b/python/test/Slice/escape/Client.py
@@ -7,20 +7,20 @@ from TestHelper import TestHelper
 TestHelper.loadSlice("Key.ice Clash.ice")
 import sys
 import Ice
-import escapedAnd
+import escaped_and
 
 
-class delI(escapedAnd._del):
+class delI(escaped_and._del):
     def _elifAsync(self, _else, current):
         pass
 
 
-class execI(escapedAnd._exec):
+class execI(escaped_and._exec):
     def _finally(self, current):
         assert current.operation == "finally"
 
 
-class ifI(escapedAnd._if):
+class ifI(escaped_and._if):
     def _elifAsync(self, _else, current):
         pass
 
@@ -34,29 +34,29 @@ class ifI(escapedAnd._if):
 def testtypes():
     sys.stdout.write("Testing generated type names... ")
     sys.stdout.flush()
-    _a = escapedAnd._assert._break
-    b = escapedAnd._continue
+    _a = escaped_and._assert._break
+    b = escaped_and._continue
     b._def = 0
-    _c = escapedAnd._delPrx.uncheckedCast(None)
-    assert "_elif" in dir(escapedAnd._delPrx)
+    _c = escaped_and._delPrx.uncheckedCast(None)
+    assert "_elif" in dir(escaped_and._delPrx)
     _c1 = delI()
-    _d = escapedAnd._execPrx.uncheckedCast(None)
-    assert "_finally" in dir(escapedAnd._execPrx)
+    _d = escaped_and._execPrx.uncheckedCast(None)
+    assert "_finally" in dir(escaped_and._execPrx)
     _d1 = execI()
 
-    _e1 = escapedAnd._for()
-    _f = escapedAnd._ifPrx.uncheckedCast(None)
+    _e1 = escaped_and._for()
+    _f = escaped_and._ifPrx.uncheckedCast(None)
 
-    assert "_finally" in dir(escapedAnd._ifPrx)
-    assert "_elif" in dir(escapedAnd._ifPrx)
+    assert "_finally" in dir(escaped_and._ifPrx)
+    assert "_elif" in dir(escaped_and._ifPrx)
     _f1 = ifI()
-    g = escapedAnd._is()
+    g = escaped_and._is()
     g.bar = 0
-    h = escapedAnd._not()
+    h = escaped_and._not()
     h.bar = 0
     h._pass = 2
-    _j = escapedAnd._lambda
-    _en = escapedAnd.EnumNone._None
+    _j = escaped_and._lambda
+    _en = escaped_and.EnumNone._None
     print("ok")
 
 
@@ -77,7 +77,7 @@ class Client(TestHelper):
 
             sys.stdout.write("Testing operation name... ")
             sys.stdout.flush()
-            p = escapedAnd._execPrx.uncheckedCast(
+            p = escaped_and._execPrx.uncheckedCast(
                 adapter.createProxy(Ice.stringToIdentity("test"))
             )
             p._finally()

--- a/python/test/Slice/escape/Key.ice
+++ b/python/test/Slice/escape/Key.ice
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
-// TODO find a better solution for remapping modules.
-module escapedAnd
+["python:identifier:escaped_and"]
+module and
 {
     ["python:identifier:_assert"]
     enum assert

--- a/ruby/test/Slice/escape/Key.ice
+++ b/ruby/test/Slice/escape/Key.ice
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
-// TODO replace this with 'ruby:identifier'.
-module EscapedBEGIN
+["ruby:identifier:EscapedBEGIN"]
+module BEGIN
 {
     ["ruby:identifier:END_"]
     enum END

--- a/swift/test/Slice/escape/Key.ice
+++ b/swift/test/Slice/escape/Key.ice
@@ -1,6 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
-module and
+["swift:identifier:escapedImport"]
+module import
 {
     ["swift:identifier:`continue`"]
     enum continue


### PR DESCRIPTION
This PR allows the `xxx:identifier` metadata to appear on Slice modules.
Note that _all_ metadata is disallowed on nested-module-syntax-modules. This is true for `xxx:identifier` as well.

All the heavy lifting was done in my previous PRs, so all I did was add `Module` to the list of `validOn` types we pass to the metadata validation. And then update the `escape` tests to use it, to make sure that the re-mapping works.
