### PR TITLE
Rework handling of builtin operations in Ruby ObjectPrx

### DIFF
--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -358,7 +358,6 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     _out << sp << nl << "class " << proxyName << " < Ice::ObjectPrx";
     _out.inc();
-    _out << nl << "include Ice::Proxy_mixin";
     _out << nl << "include " << proxyName << "_mixin";
     _out.dec();
     _out << nl << "end"; // End of proxy class.

--- a/ruby/ruby/Ice.rb
+++ b/ruby/ruby/Ice.rb
@@ -23,6 +23,7 @@ require_relative 'Ice/ToStringMode.rb'
 require_relative 'Ice/Version.rb'
 
 # Files that define proxies must be last.
+require_relative 'Ice/ProxyFunctions.rb'
 require_relative 'Ice/Locator.rb'
 require_relative 'Ice/LocatorRegistry.rb'
 require_relative 'Ice/Metrics.rb'

--- a/ruby/ruby/Ice/Proxy.rb
+++ b/ruby/ruby/Ice/Proxy.rb
@@ -12,14 +12,42 @@ module Ice
                 self::ICE_ID
             end
 
-            def checkedCast(proxy, facetOrContext=nil, context=nil)
-                ice_checkedCast(proxy, self::ICE_ID, facetOrContext, context)
+            def checkedCast(proxy, facet: nil, context: nil)
+                if proxy.nil?
+                    return nil
+                end
+
+                unless facet.nil?
+                    proxy = proxy.ice_facet(facet)
+                end
+
+                if proxy.ice_isA(self::ICE_ID, context)
+                    return self::create(proxy)
+                else
+                    return nil
+                end
+            end
+
+            def uncheckedCast(proxy, facet: nil)
+                if proxy.nil?
+                    return nil
+                end
+
+                unless facet.nil?
+                    proxy = proxy.ice_facet(facet)
+                end
+
+                self::create(proxy)
             end
         end
 
       def self.included(base)
           base.extend(ClassMethods)
       end
+    end
+
+    class ObjectPrx
+        include Proxy_mixin
     end
 
     # Proxy comparison functions.

--- a/ruby/ruby/Ice/ProxyFunctions.rb
+++ b/ruby/ruby/Ice/ProxyFunctions.rb
@@ -1,0 +1,69 @@
+# Copyright (c) ZeroC, Inc.
+
+require_relative 'Proxy.rb'
+require_relative 'OperationMode.rb'
+require_relative 'BuiltinSequences.rb'
+
+module ::Ice
+    module ObjectPrx_mixin
+        def ice_ping(context=nil)
+            ObjectPrx_mixin::OP_ice_ping.invoke(self, [], context)
+        end
+
+        def ice_ids(context=nil)
+            return ObjectPrx_mixin::OP_ice_ids.invoke(self, [], context)
+        end
+
+        def ice_isA(id, context=nil)
+            return ObjectPrx_mixin::OP_ice_isA.invoke(self, [id], context)
+        end
+
+        def ice_id(context=nil)
+            ObjectPrx_mixin::OP_ice_id.invoke(self, [], context)
+        end
+    end
+
+    class ObjectPrx
+        include ObjectPrx_mixin
+    end
+
+    ObjectPrx_mixin::OP_ice_ping = Ice::__defineOperation(
+        'ice_ping',
+        'ice_ping',
+        Ice::OperationMode::Idempotent,
+        nil,
+        [],
+        [],
+        nil,
+        [])
+
+    ObjectPrx_mixin::OP_ice_ids = Ice::__defineOperation(
+        'ice_ids',
+        'ice_ids',
+        Ice::OperationMode::Idempotent,
+        nil,
+        [],
+        [],
+        [::Ice::T_StringSeq, false, 0],
+        [])
+
+    ObjectPrx_mixin::OP_ice_id = Ice::__defineOperation(
+        'ice_id',
+        'ice_id',
+        Ice::OperationMode::Idempotent,
+        nil,
+        [],
+        [],
+        [Ice::T_string, false, 0],
+        [])
+
+    ObjectPrx_mixin::OP_ice_isA = Ice::__defineOperation(
+        'ice_isA',
+        'ice_isA',
+        Ice::OperationMode::Idempotent,
+        nil,
+        [[Ice::T_string, false, 0]],
+        [],
+        [Ice::T_bool, false, 0],
+        [])
+end

--- a/ruby/src/IceRuby/Proxy.cpp
+++ b/ruby/src/IceRuby/Proxy.cpp
@@ -862,10 +862,7 @@ IceRuby_ObjectPrx_new(VALUE self, VALUE communicator, VALUE proxyString)
 extern "C" VALUE
 IceRuby_ObjectPrx_create(VALUE self, VALUE proxy)
 {
-    ICE_RUBY_TRY
-    {
-        return createProxy(getProxy(proxy), self);
-    }
+    ICE_RUBY_TRY { return createProxy(getProxy(proxy), self); }
     ICE_RUBY_CATCH
     return Qnil;
 }

--- a/ruby/test/Ice/facets/AllTests.rb
+++ b/ruby/test/Ice/facets/AllTests.rb
@@ -40,19 +40,19 @@ def allTests(helper, communicator)
     STDOUT.flush
     obj = Ice::ObjectPrx::uncheckedCast(db)
     test(obj.ice_getFacet() == "")
-    obj = Ice::ObjectPrx::uncheckedCast(db, "facetABCD")
+    obj = Ice::ObjectPrx::uncheckedCast(db, facet: "facetABCD")
     test(obj.ice_getFacet() == "facetABCD")
     obj2 = Ice::ObjectPrx::uncheckedCast(obj)
     test(obj2.ice_getFacet() == "facetABCD")
-    obj3 = Ice::ObjectPrx::uncheckedCast(obj, "")
+    obj3 = Ice::ObjectPrx::uncheckedCast(obj, facet: "")
     test(obj3.ice_getFacet() == "")
     d = Test::DPrx::uncheckedCast(db)
     test(d.ice_getFacet() == "")
-    df = Test::DPrx::uncheckedCast(db, "facetABCD")
+    df = Test::DPrx::uncheckedCast(db, facet: "facetABCD")
     test(df.ice_getFacet() == "facetABCD")
     df2 = Test::DPrx::uncheckedCast(df)
     test(df2.ice_getFacet() == "facetABCD")
-    df3 = Test::DPrx::uncheckedCast(df, "")
+    df3 = Test::DPrx::uncheckedCast(df, facet: "")
     test(df3.ice_getFacet() == "")
     puts "ok"
 
@@ -60,19 +60,19 @@ def allTests(helper, communicator)
     STDOUT.flush
     obj = Ice::ObjectPrx.checkedCast(db)
     test(obj.ice_getFacet() == "")
-    obj = Ice::ObjectPrx.checkedCast(db, "facetABCD")
+    obj = Ice::ObjectPrx.checkedCast(db, facet: "facetABCD")
     test(obj.ice_getFacet() == "facetABCD")
     obj2 = Ice::ObjectPrx.checkedCast(obj)
     test(obj2.ice_getFacet() == "facetABCD")
-    obj3 = Ice::ObjectPrx.checkedCast(obj, "")
+    obj3 = Ice::ObjectPrx.checkedCast(obj, facet: "")
     test(obj3.ice_getFacet() == "")
     d = Test::DPrx.checkedCast(db)
     test(d.ice_getFacet() == "")
-    df = Test::DPrx.checkedCast(db, "facetABCD")
+    df = Test::DPrx.checkedCast(db, facet: "facetABCD")
     test(df.ice_getFacet() == "facetABCD")
     df2 = Test::DPrx.checkedCast(df)
     test(df2.ice_getFacet() == "facetABCD")
-    df3 = Test::DPrx.checkedCast(df, "")
+    df3 = Test::DPrx.checkedCast(df, facet: "")
     test(df3.ice_getFacet() == "")
     puts "ok"
 
@@ -86,7 +86,7 @@ def allTests(helper, communicator)
 
     print "testing facets A, B, C, and D... "
     STDOUT.flush
-    df = Test::DPrx.checkedCast(d, "facetABCD")
+    df = Test::DPrx.checkedCast(d, facet: "facetABCD")
     test(df)
     test(df.callA() == "A")
     test(df.callB() == "B")
@@ -96,7 +96,7 @@ def allTests(helper, communicator)
 
     print "testing facets E and F... "
     STDOUT.flush
-    ff = Test::FPrx.checkedCast(d, "facetEF")
+    ff = Test::FPrx.checkedCast(d, facet: "facetEF")
     test(ff)
     test(ff.callE() == "E")
     test(ff.callF() == "F")
@@ -104,7 +104,7 @@ def allTests(helper, communicator)
 
     print "testing facet G... "
     STDOUT.flush
-    gf = Test::GPrx.checkedCast(ff, "facetGH")
+    gf = Test::GPrx.checkedCast(ff, facet: "facetGH")
     test(gf)
     test(gf.callG() == "G")
     puts "ok"

--- a/ruby/test/Ice/proxy/AllTests.rb
+++ b/ruby/test/Ice/proxy/AllTests.rb
@@ -593,7 +593,7 @@ def allTests(helper, communicator)
     test(derived == base)
     test(cl == derived)
     begin
-        Test::MyDerivedClassPrx.checkedCast(cl, "facet")
+        Test::MyDerivedClassPrx.checkedCast(cl, facet: "facet")
         test(false)
     rescue Ice::FacetNotExistException
     end
@@ -622,7 +622,7 @@ def allTests(helper, communicator)
     c = { }
     c["one"] = "hello"
     c["two"] =  "world"
-    tccp = Test::MyClassPrx.checkedCast(base, c)
+    tccp = Test::MyClassPrx.checkedCast(base, context: c)
     c2 = tccp.getContext()
     test(c == c2)
     puts "ok"


### PR DESCRIPTION
This PR reworks the handling of the 4 builtin operations in Ruby proxies, they are now treated like regular user defined operations and they use they use the same code path.

The implementation of checked and unchecked was moved to Ruby too.