### PR TITLE
Make Communicator async disposable (C#)

### DIFF
--- a/csharp/test/Ice/adapterDeactivation/Client.cs
+++ b/csharp/test/Ice/adapterDeactivation/Client.cs
@@ -8,7 +8,7 @@ public class Client : TestHelper
 {
     public override async Task runAsync(string[] args)
     {
-        using var communicator = initialize(ref args);
+        await using var communicator = initialize(ref args);
         await AllTests.allTests(this);
     }
 

--- a/csharp/test/Ice/adapterDeactivation/Collocated.cs
+++ b/csharp/test/Ice/adapterDeactivation/Collocated.cs
@@ -8,7 +8,7 @@ public class Collocated : TestHelper
 {
     public override async Task runAsync(string[] args)
     {
-        using var communicator = initialize(ref args);
+        await using var communicator = initialize(ref args);
         communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
 
         //

--- a/csharp/test/Ice/ami/Client.cs
+++ b/csharp/test/Ice/ami/Client.cs
@@ -23,7 +23,7 @@ public class Client : TestHelper
         // send() blocking after sending a given amount of data.
         //
         properties.setProperty("Ice.TCP.SndSize", "50000");
-        using var communicator = initialize(properties);
+        await using var communicator = initialize(properties);
         await AllTests.allTestsAsync(this, false);
     }
 

--- a/csharp/test/Ice/ami/Collocated.cs
+++ b/csharp/test/Ice/ami/Collocated.cs
@@ -18,7 +18,7 @@ public class Collocated : TestHelper
 
         // We use a client thread pool with more than one thread to test that task inlining works.
         properties.setProperty("Ice.ThreadPool.Client.Size", "5");
-        using var communicator = initialize(properties);
+        await using var communicator = initialize(properties);
         communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         communicator.getProperties().setProperty("ControllerAdapter.Endpoints", getTestEndpoint(1));
         communicator.getProperties().setProperty("ControllerAdapter.ThreadPool.Size", "1");

--- a/csharp/test/Ice/background/Client.cs
+++ b/csharp/test/Ice/background/Client.cs
@@ -34,7 +34,7 @@ public class Client : Test.TestHelper
         properties.setProperty("Ice.Default.Protocol",
                                "test-" + properties.getIceProperty("Ice.Default.Protocol"));
 
-        using var communicator = initialize(properties);
+        await using var communicator = initialize(properties);
         var plugin = new PluginI(communicator);
         plugin.initialize();
         communicator.getPluginManager().addPlugin("Test", plugin);

--- a/csharp/test/Ice/binding/Client.cs
+++ b/csharp/test/Ice/binding/Client.cs
@@ -8,7 +8,7 @@ public class Client : TestHelper
 {
     public override async Task runAsync(string[] args)
     {
-        using var communicator = initialize(ref args);
+        await using var communicator = initialize(ref args);
         await AllTests.allTests(this);
     }
 

--- a/csharp/test/Ice/dictMapping/Client.cs
+++ b/csharp/test/Ice/dictMapping/Client.cs
@@ -8,7 +8,7 @@ public class Client : TestHelper
 {
     public override async Task runAsync(string[] args)
     {
-        using var communicator = initialize(ref args);
+        await using var communicator = initialize(ref args);
         var output = getWriter();
         var myClass = await AllTests.allTests(this, false);
         output.Write("shutting down server... ");

--- a/csharp/test/Ice/dictMapping/Collocated.cs
+++ b/csharp/test/Ice/dictMapping/Collocated.cs
@@ -8,7 +8,7 @@ public class Collocated : TestHelper
 {
     public override async Task runAsync(string[] args)
     {
-        using var communicator = initialize(ref args);
+        await using var communicator = initialize(ref args);
         communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         var adapter = communicator.createObjectAdapter("TestAdapter");
         adapter.add(new MyClassI(), Util.stringToIdentity("test"));

--- a/csharp/test/Ice/exceptions/Client.cs
+++ b/csharp/test/Ice/exceptions/Client.cs
@@ -12,7 +12,7 @@ public class Client : TestHelper
         initData.properties = createTestProperties(ref args);
         initData.properties.setProperty("Ice.Warn.Connections", "0");
         initData.properties.setProperty("Ice.MessageSizeMax", "10"); // 10KB max
-        using var communicator = initialize(initData);
+        await using var communicator = initialize(initData);
         communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         var thrower = await AllTests.allTests(this);
         thrower.shutdown();

--- a/csharp/test/Ice/exceptions/Collocated.cs
+++ b/csharp/test/Ice/exceptions/Collocated.cs
@@ -13,7 +13,7 @@ public class Collocated : TestHelper
         initData.properties.setProperty("Ice.Warn.Connections", "0");
         initData.properties.setProperty("Ice.Warn.Dispatch", "0");
         initData.properties.setProperty("Ice.MessageSizeMax", "10"); // 10KB max
-        using var communicator = initialize(initData);
+        await using var communicator = initialize(initData);
         communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         Ice.ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
         Ice.Object obj = new ThrowerI();

--- a/csharp/test/Ice/facets/Client.cs
+++ b/csharp/test/Ice/facets/Client.cs
@@ -8,7 +8,7 @@ public class Client : TestHelper
 {
     public override async Task runAsync(string[] args)
     {
-        using var communicator = initialize(ref args);
+        await using var communicator = initialize(ref args);
         var g = await AllTests.allTests(this);
         g.shutdown();
     }

--- a/csharp/test/Ice/facets/Collocated.cs
+++ b/csharp/test/Ice/facets/Collocated.cs
@@ -8,7 +8,7 @@ public class Collocated : TestHelper
 {
     public override async Task runAsync(string[] args)
     {
-        using var communicator = initialize(ref args);
+        await using var communicator = initialize(ref args);
         communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         Ice.ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
         Ice.Object d = new DI();

--- a/csharp/test/Ice/faultTolerance/Client.cs
+++ b/csharp/test/Ice/faultTolerance/Client.cs
@@ -14,7 +14,7 @@ public class Client : Test.TestHelper
     {
         Ice.Properties properties = createTestProperties(ref args);
         properties.setProperty("Ice.Warn.Connections", "0");
-        using var communicator = initialize(properties);
+        await using var communicator = initialize(properties);
         var ports = args.Select(v => int.Parse(v)).ToList();
         if (ports.Count == 0)
         {

--- a/csharp/test/Ice/hold/Client.cs
+++ b/csharp/test/Ice/hold/Client.cs
@@ -8,7 +8,7 @@ public class Client : TestHelper
 {
     public override async Task runAsync(string[] args)
     {
-        using var communicator = initialize(ref args);
+        await using var communicator = initialize(ref args);
         await AllTests.allTests(this);
     }
 

--- a/csharp/test/Ice/idleTimeout/Client.cs
+++ b/csharp/test/Ice/idleTimeout/Client.cs
@@ -8,7 +8,7 @@ public class Client : global::Test.TestHelper
     {
         var properties = createTestProperties(ref args);
         properties.setProperty("Ice.Connection.Client.IdleTimeout", "1");
-        using var communicator = initialize(properties);
+        await using var communicator = initialize(properties);
         await AllTests.allTests(this);
     }
 

--- a/csharp/test/Ice/inactivityTimeout/Client.cs
+++ b/csharp/test/Ice/inactivityTimeout/Client.cs
@@ -12,7 +12,7 @@ public class Client : global::Test.TestHelper
         // heartbeats that schedules the inactivity timer task.
         properties.setProperty("Ice.Connection.Client.IdleTimeout", "1");
         properties.setProperty("Ice.Connection.Client.InactivityTimeout", "3");
-        using var communicator = initialize(properties);
+        await using var communicator = initialize(properties);
         await AllTests.allTests(this);
     }
 

--- a/csharp/test/Ice/location/Client.cs
+++ b/csharp/test/Ice/location/Client.cs
@@ -10,7 +10,7 @@ public class Client : TestHelper
     {
         Ice.Properties properties = createTestProperties(ref args);
         properties.setProperty("Ice.Default.Locator", "locator:" + getTestEndpoint(properties, 0));
-        using var communicator = initialize(properties);
+        await using var communicator = initialize(properties);
         await AllTests.allTests(this);
     }
 

--- a/csharp/test/Ice/maxConnections/Client.cs
+++ b/csharp/test/Ice/maxConnections/Client.cs
@@ -12,7 +12,7 @@ public class Client : global::Test.TestHelper
         // We disable retries to make the logs clearer and avoid hiding potential issues.
         properties.setProperty("Ice.RetryIntervals", "-1");
 
-        using var communicator = initialize(properties);
+        await using var communicator = initialize(properties);
         await AllTests.allTests(this);
     }
 

--- a/csharp/test/Ice/maxDispatches/Client.cs
+++ b/csharp/test/Ice/maxDispatches/Client.cs
@@ -8,7 +8,7 @@ public class Client : global::Test.TestHelper
 {
     public override async Task runAsync(string[] args)
     {
-        using var communicator = initialize(ref args);
+        await using var communicator = initialize(ref args);
         await AllTests.allTests(this);
     }
 

--- a/csharp/test/Ice/metrics/Client.cs
+++ b/csharp/test/Ice/metrics/Client.cs
@@ -25,7 +25,7 @@ public class Client : Test.TestHelper
         // speed up connection establishment test
         initData.properties.setProperty("Ice.Connection.Client.ConnectTimeout", "1");
 
-        using var communicator = initialize(initData);
+        await using var communicator = initialize(initData);
         Test.MetricsPrx metrics = await AllTests.allTests(this, observer);
         metrics.shutdown();
     }

--- a/csharp/test/Ice/metrics/Collocated.cs
+++ b/csharp/test/Ice/metrics/Collocated.cs
@@ -23,7 +23,7 @@ public class Collocated : Test.TestHelper
         initData.properties.setProperty("Ice.Warn.Dispatch", "0");
         initData.properties.setProperty("Ice.Default.Host", "127.0.0.1");
 
-        using var communicator = initialize(initData);
+        await using var communicator = initialize(initData);
         communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         Ice.ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
         adapter.add(new MetricsI(), Ice.Util.stringToIdentity("metrics"));

--- a/csharp/test/Ice/operations/Client.cs
+++ b/csharp/test/Ice/operations/Client.cs
@@ -13,7 +13,7 @@ public class Client : TestHelper
         initData.properties.setProperty("Ice.ThreadPool.Client.Size", "2");
         initData.properties.setProperty("Ice.ThreadPool.Client.SizeWarn", "0");
         initData.properties.setProperty("Ice.BatchAutoFlushSize", "100");
-        using var communicator = initialize(initData);
+        await using var communicator = initialize(initData);
         var myClass = await AllTests.allTests(this);
 
         Console.Out.Write("testing server shutdown... ");

--- a/csharp/test/Ice/operations/Collocated.cs
+++ b/csharp/test/Ice/operations/Collocated.cs
@@ -13,7 +13,7 @@ public class Collocated : TestHelper
         initData.properties.setProperty("Ice.ThreadPool.Client.Size", "2");
         initData.properties.setProperty("Ice.ThreadPool.Client.SizeWarn", "0");
         initData.properties.setProperty("Ice.BatchAutoFlushSize", "100");
-        using var communicator = initialize(initData);
+        await using var communicator = initialize(initData);
         communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
         ObjectPrx prx = adapter.add(new MyDerivedClassI(), Ice.Util.stringToIdentity("test"));

--- a/csharp/test/Ice/operations/Server.cs
+++ b/csharp/test/Ice/operations/Server.cs
@@ -20,7 +20,7 @@ public class Server : TestHelper
         // We don't want connection warnings because of the timeout test.
         //
         initData.properties.setProperty("Ice.Warn.Connections", "0");
-        using var communicator = initialize(initData);
+        await using var communicator = initialize(initData);
         communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         Ice.ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
         adapter.add(new MyDerivedClassI(), Ice.Util.stringToIdentity("test"));

--- a/csharp/test/Ice/operations/ServerAMD.cs
+++ b/csharp/test/Ice/operations/ServerAMD.cs
@@ -23,7 +23,7 @@ namespace Ice.operations
                 // We don't want connection warnings because of the timeout test.
                 //
                 initData.properties.setProperty("Ice.Warn.Connections", "0");
-                using var communicator = initialize(initData);
+                await using var communicator = initialize(initData);
                 communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
                 Ice.ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
                 adapter.add(new MyDerivedClassI(), Ice.Util.stringToIdentity("test"));

--- a/csharp/test/Ice/optional/Client.cs
+++ b/csharp/test/Ice/optional/Client.cs
@@ -10,7 +10,7 @@ public class Client : TestHelper
     {
         var initData = new InitializationData();
         initData.properties = createTestProperties(ref args);
-        using var communicator = initialize(initData);
+        await using var communicator = initialize(initData);
         var initial = await AllTests.allTests(this);
         initial.shutdown();
     }

--- a/csharp/test/Ice/proxy/Client.cs
+++ b/csharp/test/Ice/proxy/Client.cs
@@ -8,7 +8,7 @@ public class Client : TestHelper
 {
     public override async Task runAsync(string[] args)
     {
-        using var communicator = initialize(ref args);
+        await using var communicator = initialize(ref args);
         var myClass = await AllTests.allTests(this);
         myClass.shutdown();
     }

--- a/csharp/test/Ice/proxy/Collocated.cs
+++ b/csharp/test/Ice/proxy/Collocated.cs
@@ -13,7 +13,7 @@ public class Collocated : TestHelper
         properties.setProperty("Ice.ThreadPool.Client.SizeWarn", "0");
         properties.setProperty("Ice.Warn.Dispatch", "0");
 
-        using var communicator = initialize(properties);
+        await using var communicator = initialize(properties);
         communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         var adapter = communicator.createObjectAdapter("TestAdapter");
         adapter.add(new MyDerivedClassI(), Ice.Util.stringToIdentity("test"));

--- a/csharp/test/Ice/retry/Client.cs
+++ b/csharp/test/Ice/retry/Client.cs
@@ -18,7 +18,7 @@ public class Client : TestHelper
         // This test kills connections, so we don't want warnings.
         //
         initData.properties.setProperty("Ice.Warn.Connections", "0");
-        using var communicator = initialize(initData);
+        await using var communicator = initialize(initData);
         //
         // Configure a second communicator for the invocation timeout
         // + retry test, we need to configure a large retry interval

--- a/csharp/test/Ice/retry/Collocated.cs
+++ b/csharp/test/Ice/retry/Collocated.cs
@@ -19,7 +19,7 @@ public class Collocated : TestHelper
         // This test kills connections, so we don't want warnings.
         //
         initData.properties.setProperty("Ice.Warn.Connections", "0");
-        using var communicator = initialize(initData);
+        await using var communicator = initialize(initData);
         //
         // Configure a second communicator for the invocation timeout
         // + retry test, we need to configure a large retry interval

--- a/csharp/test/Ice/seqMapping/Client.cs
+++ b/csharp/test/Ice/seqMapping/Client.cs
@@ -10,7 +10,7 @@ public class Client : TestHelper
     {
         var initData = new InitializationData();
         initData.properties = createTestProperties(ref args);
-        using var communicator = initialize(initData);
+        await using var communicator = initialize(initData);
         var myClass = await AllTests.allTests(this, false);
         Console.Out.Write("shutting down server... ");
         Console.Out.Flush();

--- a/csharp/test/Ice/seqMapping/Collocated.cs
+++ b/csharp/test/Ice/seqMapping/Collocated.cs
@@ -10,7 +10,7 @@ public class Collocated : TestHelper
     {
         var initData = new InitializationData();
         initData.properties = createTestProperties(ref args);
-        using var communicator = initialize(initData);
+        await using var communicator = initialize(initData);
         communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         var adapter = communicator.createObjectAdapter("TestAdapter");
         adapter.add(new MyClassI(), Ice.Util.stringToIdentity("test"));

--- a/csharp/test/Ice/slicing/exceptions/Client.cs
+++ b/csharp/test/Ice/slicing/exceptions/Client.cs
@@ -6,7 +6,7 @@ public class Client : Test.TestHelper
 {
     public override async Task runAsync(string[] args)
     {
-        using var communicator = initialize(ref args);
+        await using var communicator = initialize(ref args);
         TestIntfPrx test = await AllTests.allTests(this, false);
         test.shutdown();
     }

--- a/csharp/test/Ice/timeout/Client.cs
+++ b/csharp/test/Ice/timeout/Client.cs
@@ -16,7 +16,7 @@ public class Client : global::Test.TestHelper
         properties.setProperty("Ice.Connection.Client.ConnectTimeout", "1");
         properties.setProperty("Ice.Connection.Client.CloseTimeout", "1");
 
-        using var communicator = initialize(properties);
+        await using var communicator = initialize(properties);
         await AllTests.allTests(this);
     }
 

--- a/csharp/test/Ice/udp/Client.cs
+++ b/csharp/test/Ice/udp/Client.cs
@@ -9,7 +9,7 @@ public class Client : global::Test.TestHelper
         var properties = createTestProperties(ref args);
         properties.setProperty("Ice.Warn.Connections", "0");
         properties.setProperty("Ice.UDP.SndSize", "16384");
-        using var communicator = initialize(properties);
+        await using var communicator = initialize(properties);
 
         await AllTests.allTests(this);
 


### PR DESCRIPTION
This PR make Ice.Communicator async disposable.