### PR TITLE
Add Communicator::destroyAsync in C++

### DIFF
--- a/cpp/include/Ice/Communicator.h
+++ b/cpp/include/Ice/Communicator.h
@@ -37,10 +37,8 @@ namespace Ice
         /// Destroys this communicator asynchronously.
         /// @param completed The callback to call when the destruction is complete. This callback must not throw any
         /// exception.
-        /// @remark This function starts a background thread to call @p completed unless you call this function on a
-        /// communicator that has already been destroyed, in which case @p completed is called by the current thread.
-        /// You need to be careful when calling this function, and not exit your application while this background
-        /// thread is still running.
+        /// @remark This function starts a thread to call @p completed unless you call this function on a communicator
+        /// that has already been destroyed, in which case @p completed is called by the current thread.
         /// @see #destroy
         void destroyAsync(std::function<void()> completed) noexcept;
 

--- a/cpp/include/Ice/Communicator.h
+++ b/cpp/include/Ice/Communicator.h
@@ -29,11 +29,20 @@ namespace Ice
     public:
         ~Communicator();
 
-        /// Destroys the communicator. This function calls #shutdown implicitly. Calling #destroy destroys all object
-        /// adapters, shuts down this communicator's client functionality, and cleans up memory. Subsequent calls to
-        /// #destroy are no-op.
+        /// Destroys this communicator. This function calls #shutdown implicitly. Calling #destroy destroys all object
+        /// adapters, shuts down this communicator's client functionality, and cleans up memory.
         /// @see CommunicatorHolder
         void destroy() noexcept;
+
+        /// Destroys this communicator asynchronously.
+        /// @param completed The callback to call when the destruction is complete. This callback must not throw any
+        /// exception.
+        /// @remark This function starts a background thread to call @p completed unless you call this function on a
+        /// communicator that has already been destroyed, in which case @p completed is called by the current thread.
+        /// You need to be careful when calling this function, and not exit your application while this background
+        /// thread is still running.
+        /// @see #destroy
+        void destroyAsync(std::function<void()> completed) noexcept;
 
         /// Shuts down this communicator. This function calls ObjectAdapter::deactivate on all object adapters created
         /// by this communicator. Shutting down a communicator has no effect on outgoing connections.
@@ -314,6 +323,8 @@ namespace Ice
         void postToClientThreadPool(std::function<void()> call);
 
     private:
+        Communicator() = default;
+
         static CommunicatorPtr create(InitializationData);
 
         // Certain initialization tasks need to be completed after the constructor.

--- a/cpp/src/Ice/Communicator.cpp
+++ b/cpp/src/Ice/Communicator.cpp
@@ -39,10 +39,20 @@ Ice::Communicator::flushBatchRequestsAsync(CompressBatch compress)
 void
 Ice::Communicator::destroy() noexcept
 {
-    if (_instance)
+    if (_instance) // see create implementation
     {
         _instance->destroy();
     }
+}
+
+void
+Ice::Communicator::destroyAsync(function<void()> completed) noexcept
+{
+    if (completed)
+    {
+        _instance->destroyAsync(std::move(completed));
+    }
+    // we tolerate null callbacks, they do nothing
 }
 
 void
@@ -323,7 +333,7 @@ Ice::Communicator::findAllAdminFacets()
 CommunicatorPtr
 Ice::Communicator::create(InitializationData initData)
 {
-    Ice::CommunicatorPtr communicator = make_shared<Communicator>();
+    CommunicatorPtr communicator{new Communicator()};
     try
     {
         const_cast<InstancePtr&>(communicator->_instance) = Instance::create(communicator, std::move(initData));

--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -1764,11 +1764,12 @@ IceInternal::Instance::destroyAsync(function<void()> completed) noexcept
         {
             // Start a thread that calls destroy() and then executes the callback.
             // We join these threads in the destructor. It's important to capture this and not shared_from_this() here.
-            _destroyThreads.emplace_back(std::thread{[this, completed = std::move(completed)]()
-                                                     {
-                                                         this->destroy();
-                                                         completed();
-                                                     }});
+            _destroyThreads.emplace_back(
+                [this, completed = std::move(completed)]()
+                {
+                    this->destroy();
+                    completed();
+                });
         }
     }
 

--- a/cpp/src/Ice/Instance.h
+++ b/cpp/src/Ice/Instance.h
@@ -124,7 +124,8 @@ namespace IceInternal
         Instance(Ice::InitializationData);
         void initialize(const Ice::CommunicatorPtr&);
         void finishSetup(int&, const char*[], const Ice::CommunicatorPtr&);
-        void destroy();
+        void destroy() noexcept;
+        void destroyAsync(std::function<void()> completed) noexcept;
 
         friend class Ice::Communicator;
 

--- a/cpp/src/Ice/Instance.h
+++ b/cpp/src/Ice/Instance.h
@@ -32,6 +32,8 @@
 #include "TraceLevelsF.h"
 
 #include <list>
+#include <thread>
+#include <vector>
 
 namespace IceInternal
 {
@@ -187,6 +189,8 @@ namespace IceInternal
         std::mutex _setBufSizeWarnMutex;
         mutable std::recursive_mutex _mutex;
         std::condition_variable_any _conditionVariable;
+
+        std::vector<std::thread> _destroyThreads;
 
         enum ImplicitContextKind
         {


### PR DESCRIPTION
Updated to join the threads in the destructor.