### PR TITLE
Add back Python packages for Glacier2, IceBox, IceGrid, and IceStorm

### DIFF
--- a/python/dist/lib/Glacier2/.gitignore
+++ b/python/dist/lib/Glacier2/.gitignore
@@ -1,0 +1,1 @@
+# Empty directory populated by sdist build

--- a/python/dist/lib/IceBox/.gitignore
+++ b/python/dist/lib/IceBox/.gitignore
@@ -1,0 +1,1 @@
+# Empty directory populated by sdist build

--- a/python/dist/lib/IceGrid/.gitignore
+++ b/python/dist/lib/IceGrid/.gitignore
@@ -1,0 +1,1 @@
+# Empty directory populated by sdist build

--- a/python/dist/lib/IceStorm/.gitignore
+++ b/python/dist/lib/IceStorm/.gitignore
@@ -1,0 +1,1 @@
+# Empty directory populated by sdist build

--- a/python/msbuild/ice.proj
+++ b/python/msbuild/ice.proj
@@ -36,10 +36,13 @@
                       Exclude="..\..\slice\Ice\Metrics.ice">
             <AdditionalOptions>--no-package %(AdditionalOptions)</AdditionalOptions>
         </SliceCompile>
-        <!-- Generate this file individually without the "no-package" option to ensure the
-             IceMX package is updated. -->
-        <SliceCompile Include="..\..\slice\Ice\Metrics.ice">
-        </SliceCompile>
+
+        <!-- Generate this file individually without the "no-package" option to ensure the IceMX package is updated. -->
+        <SliceCompile Include="..\..\slice\Ice\Metrics.ice" />
+        <SliceCompile Include="..\..\slice\Glacier2\*.ice" />
+        <SliceCompile Include="..\..\slice\IceBox\*.ice" />
+        <SliceCompile Include="..\..\slice\IceGrid\*.ice" />
+        <SliceCompile Include="..\..\slice\IceStorm\*.ice" />
         <PythonGenerated Include="$(MSBuildThisFileDirectory)\..\python\**\*_ice.py"/>
     </ItemGroup>
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,12 +7,11 @@ authors = [
 ]
 requires-python = ">=3.12"
 readme = "README.md"
-license = {text = "GPLv2 License"}
+license = "GPL-2.0-only"
 keywords = ["ice", "RPC"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",

--- a/python/python/.gitignore
+++ b/python/python/.gitignore
@@ -2,5 +2,6 @@ IceGrid/*
 IceMX/*
 IceStorm/*
 IceBox/*
+Glacier2/*
 *_ice.py
 IcePy.*

--- a/python/python/Makefile
+++ b/python/python/Makefile
@@ -15,6 +15,10 @@ $(eval $(call load-translator-dependencies,$(top_srcdir)/cpp/src/slice2py))
 
 $(eval $(call make-python-package,$(slicedir),$(lang_srcdir)/python,Ice,--no-package))
 $(eval $(call make-python-package,$(slicedir),$(lang_srcdir)/python,IceMX))
+$(eval $(call make-python-package,$(slicedir),$(lang_srcdir)/python,Glacier2))
+$(eval $(call make-python-package,$(slicedir),$(lang_srcdir)/python,IceBox))
+$(eval $(call make-python-package,$(slicedir),$(lang_srcdir)/python,IceGrid))
+$(eval $(call make-python-package,$(slicedir),$(lang_srcdir)/python,IceStorm))
 
 # Generate this file individually without the --no-package option to ensure the
 # IceMX package is updated.

--- a/python/setup.py
+++ b/python/setup.py
@@ -25,7 +25,7 @@ platform = os.getenv('CPP_PLATFORM', "x64")
 configuration = os.getenv('CPP_CONFIGURATION', "Release")
 
 # Define Python packages to be included
-packages = ['Ice', 'IceMX', 'slice']
+packages = ['Glacier2', 'Ice', 'IceBox', 'IceGrid', 'IceMX', 'IceStorm', 'slice']
 
 # Define source directories for Ice C++
 ice_cpp_sources = [


### PR DESCRIPTION
I didn't add these packages when moving pip to Ice repository, they were included in 3.7. Now when starting to port more  demos seems pretty convenient to include them.