### PR TITLE
Move destructor of RegistryPluginFacade out of line

### DIFF
--- a/cpp/include/IceGrid/PluginFacade.h
+++ b/cpp/include/IceGrid/PluginFacade.h
@@ -60,7 +60,7 @@ namespace IceGrid
     class RegistryPluginFacade
     {
     public:
-        virtual ~RegistryPluginFacade() = default;
+        virtual ~RegistryPluginFacade();
 
         /// Get an application descriptor.
         /// @param name The application name.

--- a/cpp/src/IceGrid/PluginFacadeI.cpp
+++ b/cpp/src/IceGrid/PluginFacadeI.cpp
@@ -38,6 +38,9 @@ namespace
     }
 }
 
+// The plugin facade is constructed and destroyed by the IceGrid registry, never a plugin.
+RegistryPluginFacade::~RegistryPluginFacade() = default;
+
 ApplicationInfo
 RegistryPluginFacadeI::getApplicationInfo(const string& name) const
 {


### PR DESCRIPTION
A plugin sees this destructor but (in theory) never calls it since it can't / shouldn't instantiate this class.