### PR TITLE
Rework Ice::SSL and WIN32 doc to use ICE_DOXYGEN

### DIFF
--- a/cpp/doxygen/Doxyfile
+++ b/cpp/doxygen/Doxyfile
@@ -378,7 +378,7 @@ MARKDOWN_ID_STYLE      = DOXYGEN
 
 AUTOLINK_SUPPORT       = YES
 
-AUTOLINK_IGNORE_WORDS  = DataStorm Glacier2 Ice IceBox IceGrid IceMX IceStorm
+AUTOLINK_IGNORE_WORDS  = DataStorm Glacier2 Ice IceBox IceGrid IceMX IceStorm SSL
 
 # If you use STL classes (i.e. std::string, std::vector, etc.) but do not want
 # to include (a tag file for) the STL sources as input, then you should set this
@@ -2409,7 +2409,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = ICE_USE_SCHANNEL ICE_USE_SECURE_TRANSPORT ICE_USE_OPENSSL ICE_DOXYGEN
+PREDEFINED             = ICE_DOXYGEN
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/cpp/include/DataStorm/Node.h
+++ b/cpp/include/DataStorm/Node.h
@@ -55,7 +55,7 @@ namespace DataStorm
         {
         }
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(ICE_DOXYGEN)
         /// Constructs a DataStorm node.
         /// A node is the main DataStorm object. It is required to construct topics.
         /// @param argc The number of arguments in argv.
@@ -63,6 +63,7 @@ namespace DataStorm
         /// @param configFile The path to an optional Ice configuration file.
         /// @param customExecutor An optional executor used to execute user callbacks, if no callback executor is
         /// provided the Node will use the default callback executor that executes callback in a dedicated thread.
+        /// @remark Windows only.
         Node(
             int& argc,
             const wchar_t* argv[],
@@ -76,7 +77,7 @@ namespace DataStorm
         /// @param configFile The path to an optional Ice configuration file.
         /// @param customExecutor An optional executor used to execute user callbacks, if no callback executor is
         /// provided the Node will use the default callback executor that executes callback in a dedicated thread.
-        ///
+        //// @remark Windows only.
         Node(
             int& argc,
             wchar_t* argv[],

--- a/cpp/include/Ice/Communicator.h
+++ b/cpp/include/Ice/Communicator.h
@@ -138,7 +138,7 @@ namespace Ice
         /// It is legal to create an object adapter with the empty string as its name. Such an object adapter is
         /// accessible via bidirectional connections or by collocated invocations.
         /// @param name The object adapter name.
-        /// @param serverAuthenticationOptions The SSL configuration properties for server connections.
+        /// @param serverAuthenticationOptions The SSL options for server connections.
         /// @return The new object adapter.
         /// @see #createObjectAdapterWithEndpoints
         /// @see ObjectAdapter
@@ -155,7 +155,7 @@ namespace Ice
         /// name will result in a UUID being generated for the name.
         /// @param name The object adapter name.
         /// @param endpoints The endpoints of the object adapter.
-        /// @param serverAuthenticationOptions The SSL configuration properties for server connections.
+        /// @param serverAuthenticationOptions The SSL options for server connections.
         /// @return The new object adapter.
         /// @see #createObjectAdapter
         /// @see ObjectAdapter

--- a/cpp/include/Ice/Communicator.h
+++ b/cpp/include/Ice/Communicator.h
@@ -139,8 +139,6 @@ namespace Ice
         /// accessible via bidirectional connections or by collocated invocations.
         /// @param name The object adapter name.
         /// @param serverAuthenticationOptions The SSL configuration properties for server connections.
-        /// The `SSL::ServerAuthenticationOptions` type is an alias to the platform specific SSL server authentication
-        /// options.
         /// @return The new object adapter.
         /// @see #createObjectAdapterWithEndpoints
         /// @see ObjectAdapter
@@ -158,8 +156,6 @@ namespace Ice
         /// @param name The object adapter name.
         /// @param endpoints The endpoints of the object adapter.
         /// @param serverAuthenticationOptions The SSL configuration properties for server connections.
-        /// The `SSL::ServerAuthenticationOptions` type is an alias to the platform specific SSL server authentication
-        /// options.
         /// @return The new object adapter.
         /// @see #createObjectAdapter
         /// @see ObjectAdapter

--- a/cpp/include/Ice/Communicator.h
+++ b/cpp/include/Ice/Communicator.h
@@ -138,8 +138,8 @@ namespace Ice
         /// It is legal to create an object adapter with the empty string as its name. Such an object adapter is
         /// accessible via bidirectional connections or by collocated invocations.
         /// @param name The object adapter name.
-        /// @param serverAuthenticationOptions The %SSL configuration properties for server connections.
-        /// The `SSL::ServerAuthenticationOptions` type is an alias to the platform specific %SSL server authentication
+        /// @param serverAuthenticationOptions The SSL configuration properties for server connections.
+        /// The `SSL::ServerAuthenticationOptions` type is an alias to the platform specific SSL server authentication
         /// options.
         /// @return The new object adapter.
         /// @see #createObjectAdapterWithEndpoints
@@ -157,8 +157,8 @@ namespace Ice
         /// name will result in a UUID being generated for the name.
         /// @param name The object adapter name.
         /// @param endpoints The endpoints of the object adapter.
-        /// @param serverAuthenticationOptions The %SSL configuration properties for server connections.
-        /// The `SSL::ServerAuthenticationOptions` type is an alias to the platform specific %SSL server authentication
+        /// @param serverAuthenticationOptions The SSL configuration properties for server connections.
+        /// The `SSL::ServerAuthenticationOptions` type is an alias to the platform specific SSL server authentication
         /// options.
         /// @return The new object adapter.
         /// @see #createObjectAdapter

--- a/cpp/include/Ice/Initialize.h
+++ b/cpp/include/Ice/Initialize.h
@@ -121,8 +121,7 @@ namespace Ice
         ValueFactoryManagerPtr valueFactoryManager{};
 
         /// The authentication options for SSL client connections. When set, the SSL transport ignores all IceSSL
-        /// configuration properties and uses these options. The `SSL::ClientAuthenticationOptions` type is an alias for
-        /// the platform specific SSL client authentication options.
+        /// configuration properties and uses these options.
         /// @see SSL::OpenSSLClientAuthenticationOptions
         /// @see SSL::SecureTransportClientAuthenticationOptions
         /// @see SSL::SchannelClientAuthenticationOptions

--- a/cpp/include/Ice/Initialize.h
+++ b/cpp/include/Ice/Initialize.h
@@ -120,9 +120,9 @@ namespace Ice
         /// The value factory manager.
         ValueFactoryManagerPtr valueFactoryManager{};
 
-        /// The authentication options for %SSL client connections. When set, the %SSL transport ignores all IceSSL
+        /// The authentication options for SSL client connections. When set, the SSL transport ignores all IceSSL
         /// configuration properties and uses these options. The `SSL::ClientAuthenticationOptions` type is an alias for
-        /// the platform specific %SSL client authentication options.
+        /// the platform specific SSL client authentication options.
         /// @see SSL::OpenSSLClientAuthenticationOptions
         /// @see SSL::SecureTransportClientAuthenticationOptions
         /// @see SSL::SchannelClientAuthenticationOptions

--- a/cpp/include/Ice/Initialize.h
+++ b/cpp/include/Ice/Initialize.h
@@ -25,8 +25,9 @@ namespace Ice
     /// @return A string sequence containing the arguments.
     ICE_API StringSeq argsToStringSeq(int argc, const char* const argv[]);
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(ICE_DOXYGEN)
     /// @copydoc argsToStringSeq(int, const char* const[])
+    /// @remark Windows only.
     ICE_API StringSeq argsToStringSeq(int argc, const wchar_t* const argv[]);
 #endif
 
@@ -44,11 +45,13 @@ namespace Ice
         return stringSeqToArgs(seq, argc, const_cast<const char**>(argv));
     }
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(ICE_DOXYGEN)
     /// @copydoc stringSeqToArgs(const StringSeq&, int&, const char*[])
+    /// @remark Windows only.
     ICE_API void stringSeqToArgs(const StringSeq& seq, int& argc, const wchar_t* argv[]);
 
     /// @copydoc stringSeqToArgs(const StringSeq&, int&, const char*[])
+    /// @remark Windows only.
     inline void stringSeqToArgs(const StringSeq& seq, int& argc, wchar_t* argv[])
     {
         return stringSeqToArgs(seq, argc, const_cast<const wchar_t**>(argv));
@@ -159,20 +162,24 @@ namespace Ice
         return initialize(argc, const_cast<const char**>(argv), configFile);
     }
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(ICE_DOXYGEN)
     /// @copydoc initialize(int&, const char*[], InitializationData)
+    /// @remark Windows only.
     ICE_API CommunicatorPtr initialize(int& argc, const wchar_t* argv[], InitializationData initData = {});
 
     /// @copydoc initialize(int&, const char*[], InitializationData)
+    /// @remark Windows only.
     inline CommunicatorPtr initialize(int& argc, wchar_t* argv[], InitializationData initData = {})
     {
         return initialize(argc, const_cast<const wchar_t**>(argv), std::move(initData));
     }
 
     // @copydoc initialize(int&, const char*[], std::string_view)
+    /// @remark Windows only.
     ICE_API CommunicatorPtr initialize(int& argc, const wchar_t* argv[], std::string_view configFile);
 
     // @copydoc initialize(int&, const char*[], std::string_view)
+    /// @remark Windows only.
     inline CommunicatorPtr initialize(int& argc, wchar_t* argv[], std::string_view configFile)
     {
         return initialize(argc, const_cast<const wchar_t**>(argv), configFile);

--- a/cpp/include/Ice/Properties.h
+++ b/cpp/include/Ice/Properties.h
@@ -226,11 +226,13 @@ namespace Ice
         return createProperties(argc, const_cast<const char**>(argv), defaults);
     }
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(ICE_DOXYGEN)
     /// @copydoc createProperties(int&, const char*[], const PropertiesPtr&)
+    /// @remark Windows only.
     ICE_API PropertiesPtr createProperties(int& argc, const wchar_t* argv[], const PropertiesPtr& defaults = nullptr);
 
     /// @copydoc createProperties(int&, const char*[], const PropertiesPtr&)
+    /// @remark Windows only.
     inline PropertiesPtr createProperties(int& argc, wchar_t* argv[], const PropertiesPtr& defaults = nullptr)
     {
         return createProperties(argc, const_cast<const wchar_t**>(argv), defaults);

--- a/cpp/include/Ice/SSL/ClientAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ClientAuthenticationOptions.h
@@ -20,7 +20,7 @@ namespace Ice::SSL
 #endif
 
 #if defined(ICE_USE_SCHANNEL) || defined(ICE_DOXYGEN)
-    /// %SSL transport configuration properties for client connections on Windows.
+    /// SSL transport configuration properties for client connections on Windows.
     ///
     /// The SchannelClientAuthenticationOptions structure is only available when the %Ice library is built on Windows.
     /// For Linux, refer to OpenSSLClientAuthenticationOptions, and for macOS and iOS, refer to
@@ -28,15 +28,15 @@ namespace Ice::SSL
     /// @see ::Ice::SSL::ClientAuthenticationOptions
     struct SchannelClientAuthenticationOptions
     {
-        /// A callback for selecting the client's %SSL credentials based on the target host name.
+        /// A callback for selecting the client's SSL credentials based on the target host name.
         ///
-        /// This callback is invoked by the %SSL transport for each new outgoing connection before starting the %SSL
+        /// This callback is invoked by the SSL transport for each new outgoing connection before starting the SSL
         /// handshake to determine the appropriate client credentials. The callback must return a `SCH_CREDENTIALS` that
-        /// represents the client's credentials. The %SSL transport takes ownership of the credentials' `paCred` and
+        /// represents the client's credentials. The SSL transport takes ownership of the credentials' `paCred` and
         /// `hRootStore` members and releases them when the connection is closed.
         ///
         /// @param host The target host name.
-        /// @return The client %SSL credentials.
+        /// @return The client SSL credentials.
         ///
         /// Example of setting `clientCertificateSelectionCallback`:
         /// @snippet Ice/SSL/SchannelClientAuthenticationOptions.cpp clientCertificateSelectionCallback
@@ -47,7 +47,7 @@ namespace Ice::SSL
         /// https://learn.microsoft.com/en-us/windows/win32/api/schannel/ns-schannel-sch_credentials
         std::function<SCH_CREDENTIALS(const std::string& host)> clientCredentialsSelectionCallback;
 
-        /// A callback invoked before initiating a new %SSL handshake, providing an opportunity to customize the %SSL
+        /// A callback invoked before initiating a new SSL handshake, providing an opportunity to customize the SSL
         /// parameters for the session based on specific client settings or requirements.
         ///
         /// @param context An opaque type that represents the security context associated with the current connection.
@@ -92,7 +92,7 @@ namespace Ice::SSL
 #endif
 
 #if defined(ICE_USE_SECURE_TRANSPORT) || defined(ICE_DOXYGEN)
-    /// %SSL transport configuration properties for client connections on macOS and iOS.
+    /// SSL transport configuration properties for client connections on macOS and iOS.
     ///
     /// The SecureTransportClientAuthenticationOptions structure is only available when the %Ice library is built on
     /// macOS and iOS. For Linux, refer to OpenSSLClientAuthenticationOptions, and for Windows, refer to
@@ -100,12 +100,12 @@ namespace Ice::SSL
     /// @see ::Ice::SSL::ClientAuthenticationOptions
     struct SecureTransportClientAuthenticationOptions
     {
-        /// A callback for selecting the client's %SSL certificate chain based on the target host name.
+        /// A callback for selecting the client's SSL certificate chain based on the target host name.
         ///
-        /// This callback is invoked by the %SSL transport for each new outgoing connection before starting the %SSL
+        /// This callback is invoked by the SSL transport for each new outgoing connection before starting the SSL
         /// handshake to determine the appropriate client certificate chain. The callback must return a `CFArrayRef`
         /// that represents the client's certificate chain, or nullptr if no certificate chain should be used for the
-        /// connection. The %SSL transport takes ownership of the returned `CFArrayRef` and releases it when the
+        /// connection. The SSL transport takes ownership of the returned `CFArrayRef` and releases it when the
         /// connection is closed.
         ///
         /// @param host The target host name.
@@ -121,10 +121,10 @@ namespace Ice::SSL
         /// https://developer.apple.com/documentation/security/1392400-sslsetcertificate?changes=_3&language=objc
         std::function<CFArrayRef(const std::string& host)> clientCertificateSelectionCallback;
 
-        /// A callback invoked before initiating a new %SSL handshake, providing an opportunity to customize the %SSL
+        /// A callback invoked before initiating a new SSL handshake, providing an opportunity to customize the SSL
         /// parameters for the session based on specific client settings or requirements.
         ///
-        /// @param context An opaque type that represents an %SSL session context object.
+        /// @param context An opaque type that represents an SSL session context object.
         /// @param host The target host name.
         ///
         /// Example of setting `sslNewSessionCallback`:
@@ -187,7 +187,7 @@ namespace Ice::SSL
 #endif
 
 #if defined(ICE_USE_OPENSSL) || defined(ICE_DOXYGEN)
-    /// %SSL transport configuration properties for client connections on Linux.
+    /// SSL transport configuration properties for client connections on Linux.
     ///
     /// The OpenSSLClientAuthenticationOptions structure is only available when the %Ice library is built on
     /// Linux. For macOS and iOS, refer to SecureTransportClientAuthenticationOptions, and for Windows, refer to
@@ -197,19 +197,19 @@ namespace Ice::SSL
     {
         /// A callback that selects the client's [SSL_CTX][SSL_CTX_new] object based on the target host name.
         ///
-        /// This callback associates a specific %SSL configuration with an outgoing connection identified by the target
+        /// This callback associates a specific SSL configuration with an outgoing connection identified by the target
         /// host name. The callback must return a pointer to a valid `SSL_CTX` object previously initialized using the
-        /// OpenSSL API. The %SSL transport takes ownership of the returned `SSL_CTX` object and releases it after
+        /// OpenSSL API. The SSL transport takes ownership of the returned `SSL_CTX` object and releases it after
         /// closing the connection.
         ///
-        /// If the application does not provide a callback, the %SSL transport will use an `SSL_CTX` object created with
+        /// If the application does not provide a callback, the SSL transport will use an `SSL_CTX` object created with
         /// `SSL_CTX_new()`, which uses the default OpenSSL configuration.
         ///
-        /// The %SSL transport calls this callback for each new outgoing connection to obtain the `SSL_CTX` object
-        /// before starting the %SSL handshake.
+        /// The SSL transport calls this callback for each new outgoing connection to obtain the `SSL_CTX` object
+        /// before starting the SSL handshake.
         ///
         /// @param host The target host name.
-        /// @return A pointer to an `SSL_CTX` object representing the %SSL configuration for the new outgoing
+        /// @return A pointer to an `SSL_CTX` object representing the SSL configuration for the new outgoing
         /// connection.
         ///
         /// Example of setting `clientSSLContextSelectionCallback`:
@@ -218,10 +218,10 @@ namespace Ice::SSL
         /// [SSL_CTX_new]: https://www.openssl.org/docs/manmaster/man3/SSL_CTX_new.html
         std::function<SSL_CTX*(const std::string& host)> clientSSLContextSelectionCallback{};
 
-        /// A callback invoked before initiating a new %SSL handshake, providing an opportunity to customize the %SSL
+        /// A callback invoked before initiating a new SSL handshake, providing an opportunity to customize the SSL
         /// parameters for the connection.
         ///
-        /// @param ssl A pointer to the %SSL object representing the connection.
+        /// @param ssl A pointer to the SSL object representing the connection.
         /// @param host The target host name.
         ///
         /// Example of setting `sslNewSessionCallback`:

--- a/cpp/include/Ice/SSL/ClientAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ClientAuthenticationOptions.h
@@ -22,7 +22,7 @@ namespace Ice::SSL
 #if defined(ICE_USE_SCHANNEL) || defined(ICE_DOXYGEN)
     /// SSL transport configuration properties for client connections on Windows.
     ///
-    /// The SchannelClientAuthenticationOptions structure is only available when the %Ice library is built on Windows.
+    /// The SchannelClientAuthenticationOptions structure is only available when the Ice library is built on Windows.
     /// For Linux, refer to OpenSSLClientAuthenticationOptions, and for macOS and iOS, refer to
     /// SecureTransportClientAuthenticationOptions.
     /// @see ::Ice::SSL::ClientAuthenticationOptions
@@ -94,7 +94,7 @@ namespace Ice::SSL
 #if defined(ICE_USE_SECURE_TRANSPORT) || defined(ICE_DOXYGEN)
     /// SSL transport configuration properties for client connections on macOS and iOS.
     ///
-    /// The SecureTransportClientAuthenticationOptions structure is only available when the %Ice library is built on
+    /// The SecureTransportClientAuthenticationOptions structure is only available when the Ice library is built on
     /// macOS and iOS. For Linux, refer to OpenSSLClientAuthenticationOptions, and for Windows, refer to
     /// SchannelClientAuthenticationOptions.
     /// @see ::Ice::SSL::ClientAuthenticationOptions
@@ -189,7 +189,7 @@ namespace Ice::SSL
 #if defined(ICE_USE_OPENSSL) || defined(ICE_DOXYGEN)
     /// SSL transport configuration properties for client connections on Linux.
     ///
-    /// The OpenSSLClientAuthenticationOptions structure is only available when the %Ice library is built on
+    /// The OpenSSLClientAuthenticationOptions structure is only available when the Ice library is built on
     /// Linux. For macOS and iOS, refer to SecureTransportClientAuthenticationOptions, and for Windows, refer to
     /// SchannelClientAuthenticationOptions.
     /// @see ::Ice::SSL::ClientAuthenticationOptions

--- a/cpp/include/Ice/SSL/ClientAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ClientAuthenticationOptions.h
@@ -20,7 +20,7 @@ namespace Ice::SSL
 #endif
 
 #if defined(ICE_USE_SCHANNEL) || defined(ICE_DOXYGEN)
-    /// SSL transport configuration properties for client connections on Windows.
+    /// SSL transport options for client connections on Windows.
     ///
     /// The SchannelClientAuthenticationOptions structure is only available when the Ice library is built on Windows.
     /// For Linux, refer to OpenSSLClientAuthenticationOptions, and for macOS and iOS, refer to
@@ -92,7 +92,7 @@ namespace Ice::SSL
 #endif
 
 #if defined(ICE_USE_SECURE_TRANSPORT) || defined(ICE_DOXYGEN)
-    /// SSL transport configuration properties for client connections on macOS and iOS.
+    /// SSL transport options for client connections on macOS and iOS.
     ///
     /// The SecureTransportClientAuthenticationOptions structure is only available when the Ice library is built on
     /// macOS and iOS. For Linux, refer to OpenSSLClientAuthenticationOptions, and for Windows, refer to
@@ -187,7 +187,7 @@ namespace Ice::SSL
 #endif
 
 #if defined(ICE_USE_OPENSSL) || defined(ICE_DOXYGEN)
-    /// SSL transport configuration properties for client connections on Linux.
+    /// SSL transport options for client connections on Linux.
     ///
     /// The OpenSSLClientAuthenticationOptions structure is only available when the Ice library is built on
     /// Linux. For macOS and iOS, refer to SecureTransportClientAuthenticationOptions, and for Windows, refer to

--- a/cpp/include/Ice/SSL/ClientAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ClientAuthenticationOptions.h
@@ -10,19 +10,22 @@
 
 // This file defines the `XxxClientAuthenticationOptions` structure for each platform-specific SSL implementation. The
 // `#if defined(ICE_USE_XXX)/#endif` directives are used to include the appropriate structure based on the platform. We
-// avoid using `#elif` directives because, we want to define all the structures when building the doxygen documentation.
+// avoid using `#elif` directives because we want to define all the structures when building the doxygen documentation.
 
 namespace Ice::SSL
 {
-#if defined(ICE_USE_SCHANNEL)
+#if defined(ICE_DOXYGEN)
+    /// An alias for the platform-specific implementation of the SSL %ClientAuthenticationOptions.
+    using ClientAuthenticationOptions = ...;
+#endif
+
+#if defined(ICE_USE_SCHANNEL) || defined(ICE_DOXYGEN)
     /// %SSL transport configuration properties for client connections on Windows.
     ///
     /// The SchannelClientAuthenticationOptions structure is only available when the %Ice library is built on Windows.
     /// For Linux, refer to OpenSSLClientAuthenticationOptions, and for macOS and iOS, refer to
     /// SecureTransportClientAuthenticationOptions.
-    ///
-    /// Additionally, the `ClientAuthenticationOptions` alias is defined for use in portable code, representing the
-    /// platform-specific options class.
+    /// @see ::Ice::SSL::ClientAuthenticationOptions
     struct SchannelClientAuthenticationOptions
     {
         /// A callback for selecting the client's %SSL credentials based on the target host name.
@@ -83,20 +86,18 @@ namespace Ice::SSL
     };
 
     /// @cond INTERNAL
-    // Alias for the platform-specific implementation of ClientAuthenticationOptions on Windows.
+    /// An alias for the platform-specific implementation of the SSL ClientAuthenticationOptions on Windows.
     using ClientAuthenticationOptions = SchannelClientAuthenticationOptions;
     /// @endcond
 #endif
 
-#if defined(ICE_USE_SECURE_TRANSPORT)
+#if defined(ICE_USE_SECURE_TRANSPORT) || defined(ICE_DOXYGEN)
     /// %SSL transport configuration properties for client connections on macOS and iOS.
     ///
     /// The SecureTransportClientAuthenticationOptions structure is only available when the %Ice library is built on
     /// macOS and iOS. For Linux, refer to OpenSSLClientAuthenticationOptions, and for Windows, refer to
     /// SchannelClientAuthenticationOptions.
-    ///
-    /// Additionally, the `ClientAuthenticationOptions` alias is defined for use in portable code, representing the
-    /// platform-specific options class.
+    /// @see ::Ice::SSL::ClientAuthenticationOptions
     struct SecureTransportClientAuthenticationOptions
     {
         /// A callback for selecting the client's %SSL certificate chain based on the target host name.
@@ -180,20 +181,18 @@ namespace Ice::SSL
     };
 
     /// @cond INTERNAL
-    // Alias for the platform-specific implementation of ClientAuthenticationOptions on macOS and iOS.
+    // An alias for the platform-specific implementation of the SSL ClientAuthenticationOptions on macOS and iOS.
     using ClientAuthenticationOptions = SecureTransportClientAuthenticationOptions;
     /// @endcond
 #endif
 
-#if defined(ICE_USE_OPENSSL)
+#if defined(ICE_USE_OPENSSL) || defined(ICE_DOXYGEN)
     /// %SSL transport configuration properties for client connections on Linux.
     ///
     /// The OpenSSLClientAuthenticationOptions structure is only available when the %Ice library is built on
     /// Linux. For macOS and iOS, refer to SecureTransportClientAuthenticationOptions, and for Windows, refer to
     /// SchannelClientAuthenticationOptions.
-    ///
-    /// Additionally, the `ClientAuthenticationOptions` alias is defined for use in portable code, representing the
-    /// platform-specific options class.
+    /// @see ::Ice::SSL::ClientAuthenticationOptions
     struct OpenSSLClientAuthenticationOptions
     {
         /// A callback that selects the client's [SSL_CTX][SSL_CTX_new] object based on the target host name.
@@ -259,7 +258,7 @@ namespace Ice::SSL
     };
 
     /// @cond INTERNAL
-    // Alias for the platform-specific implementation of ClientAuthenticationOptions on Linux.
+    // An alias for the platform-specific implementation of the SSL ClientAuthenticationOptions on Linux.
     using ClientAuthenticationOptions = OpenSSLClientAuthenticationOptions;
     /// @endcond
 #endif

--- a/cpp/include/Ice/SSL/ConnectionInfo.h
+++ b/cpp/include/Ice/SSL/ConnectionInfo.h
@@ -25,7 +25,7 @@ namespace Ice::SSL
 #if defined(ICE_USE_SCHANNEL) || defined(ICE_DOXYGEN)
     /// Provides access to the connection details of an SSL connection.
     ///
-    /// The SchannelConnectionInfo class is only available when the %Ice library is built on Windows. For Linux,
+    /// The SchannelConnectionInfo class is only available when the Ice library is built on Windows. For Linux,
     /// refer to OpenSSLConnectionInfo, and for macOS and iOS, refer to SecureTransportConnectionInfo.
     /// @see ::Ice::SSL::ConnectionInfo
     class ICE_API SchannelConnectionInfo final : public Ice::ConnectionInfo
@@ -50,7 +50,7 @@ namespace Ice::SSL
 #if defined(ICE_USE_SECURE_TRANSPORT) || defined(ICE_DOXYGEN)
     /// Provides access to the connection details of an SSL connection.
     ///
-    /// The SecureTransportConnectionInfo class is only available when the %Ice library is built on macOS or iOS. For
+    /// The SecureTransportConnectionInfo class is only available when the Ice library is built on macOS or iOS. For
     /// Linux, refer to OpenSSLConnectionInfo, and for Windows, refer to SchannelConnectionInfo.
     /// @see ::Ice::SSL::ConnectionInfo
     class ICE_API SecureTransportConnectionInfo final : public Ice::ConnectionInfo
@@ -75,7 +75,7 @@ namespace Ice::SSL
 #if defined(ICE_USE_OPENSSL) || defined(ICE_DOXYGEN)
     /// Provides access to the connection details of an SSL connection.
     ///
-    /// The OpenSSLConnectionInfo class is only available when the %Ice library is built on Linux. For Windows,
+    /// The OpenSSLConnectionInfo class is only available when the Ice library is built on Linux. For Windows,
     /// refer to SchannelConnectionInfo, and for macOS and iOS, refer to SecureTransportConnectionInfo.
     /// @see ::Ice::SSL::ConnectionInfo
     class ICE_API OpenSSLConnectionInfo final : public Ice::ConnectionInfo

--- a/cpp/include/Ice/SSL/ConnectionInfo.h
+++ b/cpp/include/Ice/SSL/ConnectionInfo.h
@@ -17,19 +17,17 @@
 
 // This file defines the `XxxConnectionInfo` class for each platform-specific SSL implementation. The
 // `#if defined(ICE_USE_XXX)/#endif` directives are used to include the appropriate structure based on the platform. We
-// avoid using `#elif` directives because, we want to define all the classes when building the doxygen documentation.
+// avoid using `#elif` directives because we want to define all the classes when building the doxygen documentation.
 
 /// Secure connections with SSL/TLS.
 namespace Ice::SSL
 {
-#if defined(ICE_USE_SCHANNEL)
+#if defined(ICE_USE_SCHANNEL) || defined(ICE_DOXYGEN)
     /// Provides access to the connection details of an SSL connection.
     ///
     /// The SchannelConnectionInfo class is only available when the %Ice library is built on Windows. For Linux,
     /// refer to OpenSSLConnectionInfo, and for macOS and iOS, refer to SecureTransportConnectionInfo.
-    ///
-    /// Additionally, the `ConnectionInfo` alias is defined for use in portable code, representing the
-    /// platform-specific connection info class.
+    /// @see ::Ice::SSL::ConnectionInfo
     class ICE_API SchannelConnectionInfo final : public Ice::ConnectionInfo
     {
     public:
@@ -49,14 +47,12 @@ namespace Ice::SSL
     };
 #endif
 
-#if defined(ICE_USE_SECURE_TRANSPORT)
+#if defined(ICE_USE_SECURE_TRANSPORT) || defined(ICE_DOXYGEN)
     /// Provides access to the connection details of an SSL connection.
     ///
     /// The SecureTransportConnectionInfo class is only available when the %Ice library is built on macOS or iOS. For
     /// Linux, refer to OpenSSLConnectionInfo, and for Windows, refer to SchannelConnectionInfo.
-    ///
-    /// Additionally, the `ConnectionInfo` alias is defined for use in portable code, representing the
-    /// platform-specific connection info class.
+    /// @see ::Ice::SSL::ConnectionInfo
     class ICE_API SecureTransportConnectionInfo final : public Ice::ConnectionInfo
     {
     public:
@@ -76,14 +72,12 @@ namespace Ice::SSL
     };
 #endif
 
-#if defined(ICE_USE_OPENSSL)
+#if defined(ICE_USE_OPENSSL) || defined(ICE_DOXYGEN)
     /// Provides access to the connection details of an SSL connection.
     ///
     /// The OpenSSLConnectionInfo class is only available when the %Ice library is built on Linux. For Windows,
     /// refer to SchannelConnectionInfo, and for macOS and iOS, refer to SecureTransportConnectionInfo.
-    ///
-    /// Additionally, the `ConnectionInfo` alias is defined for use in portable code, representing the
-    /// platform-specific connection info class.
+    /// @see ::Ice::SSL::ConnectionInfo
     class ICE_API OpenSSLConnectionInfo final : public Ice::ConnectionInfo
     {
     public:

--- a/cpp/include/Ice/SSL/ConnectionInfoF.h
+++ b/cpp/include/Ice/SSL/ConnectionInfoF.h
@@ -9,27 +9,30 @@
 
 namespace Ice::SSL
 {
-#if defined(ICE_USE_SCHANNEL)
+#if defined(ICE_DOXYGEN)
+    /// An alias for the platform-specific implementation of the SSL ConnectionInfo.
+    using ConnectionInfo = ...;
+
+    /// A shared pointer to a #ConnectionInfo.
+    using ConnectionInfoPtr = std::shared_ptr<ConnectionInfo>;
+#elif defined(ICE_USE_SCHANNEL)
     class SchannelConnectionInfo;
-    /// @cond INTERNAL
-    // Alias for the platform-specific implementation of ConnectionInfo on Windows.
+
+    /// An alias for the platform-specific implementation of the SSL ConnectionInfo on Windows.
     using ConnectionInfo = SchannelConnectionInfo;
     using ConnectionInfoPtr = std::shared_ptr<SchannelConnectionInfo>;
-    /// @endcond
 #elif defined(ICE_USE_SECURE_TRANSPORT)
     class SecureTransportConnectionInfo;
-    /// @cond INTERNAL
-    // Alias for the platform-specific implementation of ConnectionInfo on macOS and iOS.
+
+    /// An alias for the platform-specific implementation of the SSL ConnectionInfo on macOS and iOS.
     using ConnectionInfo = SecureTransportConnectionInfo;
     using ConnectionInfoPtr = std::shared_ptr<SecureTransportConnectionInfo>;
-    /// @endcond
 #else
     class OpenSSLConnectionInfo;
-    /// @cond INTERNAL
-    // Alias for the platform-specific implementation of ConnectionInfo on Linux.
+
+    /// An alias for the platform-specific implementation of the SSL ConnectionInfo on Linux.
     using ConnectionInfo = OpenSSLConnectionInfo;
     using ConnectionInfoPtr = std::shared_ptr<OpenSSLConnectionInfo>;
-    /// @endcond
 #endif
 }
 

--- a/cpp/include/Ice/SSL/ConnectionInfoF.h
+++ b/cpp/include/Ice/SSL/ConnectionInfoF.h
@@ -10,7 +10,7 @@
 namespace Ice::SSL
 {
 #if defined(ICE_DOXYGEN)
-    /// An alias for the platform-specific implementation of the SSL ConnectionInfo.
+    /// An alias for the platform-specific implementation of the SSL %ConnectionInfo.
     using ConnectionInfo = ...;
 
     /// A shared pointer to a #ConnectionInfo.

--- a/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
@@ -20,7 +20,7 @@ namespace Ice::SSL
 #endif
 
 #if defined(ICE_USE_SCHANNEL) || defined(ICE_DOXYGEN)
-    /// The SSL transport configuration properties for server connections on Windows.
+    /// The SSL transport options for server connections on Windows.
     ///
     /// The SchannelServerAuthenticationOptions structure is only available when the Ice library is built on
     /// Windows. For macOS and iOS, see SecureTransportServerAuthenticationOptions, and for Linux, see
@@ -96,7 +96,7 @@ namespace Ice::SSL
 #endif
 
 #if defined(ICE_USE_SECURE_TRANSPORT) || defined(ICE_DOXYGEN)
-    /// SSL transport configuration properties for server connections on macOS and iOS.
+    /// SSL transport options for server connections on macOS and iOS.
     ///
     /// The SecureTransportServerAuthenticationOptions structure is only available when the Ice library is built on
     /// macOS and iOS. For Linux, refer to OpenSSLServerAuthenticationOptions, and for Windows, refer to
@@ -197,7 +197,7 @@ namespace Ice::SSL
 #endif
 
 #if defined(ICE_USE_OPENSSL) || defined(ICE_DOXYGEN)
-    /// SSL transport configuration properties for server connections on Linux.
+    /// SSL transport options for server connections on Linux.
     ///
     /// The OpenSSLServerAuthenticationOptions structure is only available when the Ice library is built on
     /// Linux. For macOS and iOS, refer to SecureTransportServerAuthenticationOptions, and for Windows, refer to

--- a/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
@@ -22,7 +22,7 @@ namespace Ice::SSL
 #if defined(ICE_USE_SCHANNEL) || defined(ICE_DOXYGEN)
     /// The SSL transport configuration properties for server connections on Windows.
     ///
-    /// The SchannelServerAuthenticationOptions structure is only available when the %Ice library is built on
+    /// The SchannelServerAuthenticationOptions structure is only available when the Ice library is built on
     /// Windows. For macOS and iOS, see SecureTransportServerAuthenticationOptions, and for Linux, see
     /// OpenSSLServerAuthenticationOptions.
     /// @see ::Ice::SSL::ServerAuthenticationOptions
@@ -98,7 +98,7 @@ namespace Ice::SSL
 #if defined(ICE_USE_SECURE_TRANSPORT) || defined(ICE_DOXYGEN)
     /// SSL transport configuration properties for server connections on macOS and iOS.
     ///
-    /// The SecureTransportServerAuthenticationOptions structure is only available when the %Ice library is built on
+    /// The SecureTransportServerAuthenticationOptions structure is only available when the Ice library is built on
     /// macOS and iOS. For Linux, refer to OpenSSLServerAuthenticationOptions, and for Windows, refer to
     /// SchannelServerAuthenticationOptions.
     /// @see ::Ice::SSL::ServerAuthenticationOptions
@@ -199,7 +199,7 @@ namespace Ice::SSL
 #if defined(ICE_USE_OPENSSL) || defined(ICE_DOXYGEN)
     /// SSL transport configuration properties for server connections on Linux.
     ///
-    /// The OpenSSLServerAuthenticationOptions structure is only available when the %Ice library is built on
+    /// The OpenSSLServerAuthenticationOptions structure is only available when the Ice library is built on
     /// Linux. For macOS and iOS, refer to SecureTransportServerAuthenticationOptions, and for Windows, refer to
     /// SchannelServerAuthenticationOptions.
     /// @see ::Ice::SSL::ServerAuthenticationOptions

--- a/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
@@ -10,19 +10,22 @@
 
 // This file defines the `XxxServerAuthenticationOptions` structure for each platform-specific SSL implementation. The
 // `#if defined(ICE_USE_XXX)/#endif` directives are used to include the appropriate structure based on the platform. We
-// avoid using `#elif` directives because, we want to define all the structures when building the doxygen documentation.
+// avoid using `#elif` directives because we want to define all the structures when building the doxygen documentation.
 
 namespace Ice::SSL
 {
-#if defined(ICE_USE_SCHANNEL)
+#if defined(ICE_DOXYGEN)
+    /// An alias for the platform-specific implementation of the SSL %ServerAuthenticationOptions.
+    using ServerAuthenticationOptions = ...;
+#endif
+
+#if defined(ICE_USE_SCHANNEL) || defined(ICE_DOXYGEN)
     /// The %SSL transport configuration properties for server connections on Windows.
     ///
     /// The SchannelServerAuthenticationOptions structure is only available when the %Ice library is built on
     /// Windows. For macOS and iOS, see SecureTransportServerAuthenticationOptions, and for Linux, see
     /// OpenSSLServerAuthenticationOptions.
-    ///
-    /// Additionally, the `ServerAuthenticationOptions` alias is defined for use in portable code,
-    /// representing the platform-specific options class.
+    /// @see ::Ice::SSL::ServerAuthenticationOptions
     struct SchannelServerAuthenticationOptions
     {
         /// A callback for selecting the server's %SSL credentials based on the name of the object adapter that accepts
@@ -87,20 +90,18 @@ namespace Ice::SSL
     };
 
     /// @cond INTERNAL
-    /// Alias for the platform-specific implementation of ClientAuthenticationOptions on Windows.
+    /// An alias for the platform-specific implementation of ClientAuthenticationOptions on Windows.
     using ServerAuthenticationOptions = SchannelServerAuthenticationOptions;
     /// @endcond
 #endif
 
-#if defined(ICE_USE_SECURE_TRANSPORT)
+#if defined(ICE_USE_SECURE_TRANSPORT) || defined(ICE_DOXYGEN)
     /// %SSL transport configuration properties for server connections on macOS and iOS.
     ///
     /// The SecureTransportServerAuthenticationOptions structure is only available when the %Ice library is built on
     /// macOS and iOS. For Linux, refer to OpenSSLServerAuthenticationOptions, and for Windows, refer to
     /// SchannelServerAuthenticationOptions.
-    ///
-    /// Additionally, the `ServerAuthenticationOptions` alias is defined for use in portable code, representing the
-    /// platform-specific options class.
+    /// @see ::Ice::SSL::ServerAuthenticationOptions
     struct SecureTransportServerAuthenticationOptions
     {
         /// A callback for selecting the server's %SSL certificate chain based on the name of the object adapter that
@@ -190,20 +191,18 @@ namespace Ice::SSL
     };
 
     /// @cond INTERNAL
-    // Alias for the platform-specific implementation of ClientAuthenticationOptions on macOS and iOS.
+    // An alias for the platform-specific implementation of ClientAuthenticationOptions on macOS and iOS.
     using ServerAuthenticationOptions = SecureTransportServerAuthenticationOptions;
-/// @endcond
+    /// @endcond
 #endif
 
-#if defined(ICE_USE_OPENSSL)
+#if defined(ICE_USE_OPENSSL) || defined(ICE_DOXYGEN)
     /// %SSL transport configuration properties for server connections on Linux.
     ///
     /// The OpenSSLServerAuthenticationOptions structure is only available when the %Ice library is built on
     /// Linux. For macOS and iOS, refer to SecureTransportServerAuthenticationOptions, and for Windows, refer to
     /// SchannelServerAuthenticationOptions.
-    ///
-    /// Additionally, the `ServerAuthenticationOptions` alias is defined for use in portable code, representing the
-    /// platform-specific options class.
+    /// @see ::Ice::SSL::ServerAuthenticationOptions
     struct OpenSSLServerAuthenticationOptions
     {
         /// A callback that selects the server's [SSL_CTX][SSL_CTX_new] object based on the name of the object
@@ -270,9 +269,9 @@ namespace Ice::SSL
     };
 
     /// @cond INTERNAL
-    // Alias for the platform-specific implementation of ClientAuthenticationOptions on Linux.
+    // An alias for the platform-specific implementation of ClientAuthenticationOptions on Linux.
     using ServerAuthenticationOptions = OpenSSLServerAuthenticationOptions;
-/// @endcond
+    /// @endcond
 #endif
 }
 

--- a/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
@@ -20,7 +20,7 @@ namespace Ice::SSL
 #endif
 
 #if defined(ICE_USE_SCHANNEL) || defined(ICE_DOXYGEN)
-    /// The %SSL transport configuration properties for server connections on Windows.
+    /// The SSL transport configuration properties for server connections on Windows.
     ///
     /// The SchannelServerAuthenticationOptions structure is only available when the %Ice library is built on
     /// Windows. For macOS and iOS, see SecureTransportServerAuthenticationOptions, and for Linux, see
@@ -28,16 +28,16 @@ namespace Ice::SSL
     /// @see ::Ice::SSL::ServerAuthenticationOptions
     struct SchannelServerAuthenticationOptions
     {
-        /// A callback for selecting the server's %SSL credentials based on the name of the object adapter that accepts
+        /// A callback for selecting the server's SSL credentials based on the name of the object adapter that accepts
         /// the connection.
         ///
-        /// This callback is invoked by the %SSL transport for each new incoming connection before starting the %SSL
+        /// This callback is invoked by the SSL transport for each new incoming connection before starting the SSL
         /// handshake to determine the appropriate server credentials. The callback must return a `SCH_CREDENTIALS` that
-        /// represents the server's credentials. The %SSL transport takes ownership of the credentials' `paCred` and
+        /// represents the server's credentials. The SSL transport takes ownership of the credentials' `paCred` and
         /// `hRootStore` members and releases them when the connection is closed.
         ///
         /// @param adapterName The name of the object adapter that accepted the connection.
-        /// @return The server %SSL credentials.
+        /// @return The server SSL credentials.
         ///
         /// Example of setting `serverCertificateSelectionCallback`:
         /// @snippet Ice/SSL/SchannelServerAuthenticationOptions.cpp serverCertificateSelectionCallback
@@ -48,7 +48,7 @@ namespace Ice::SSL
         /// https://learn.microsoft.com/en-us/windows/win32/api/schannel/ns-schannel-sch_credentials
         std::function<SCH_CREDENTIALS(const std::string& adapterName)> serverCredentialsSelectionCallback;
 
-        /// A callback invoked before initiating a new %SSL handshake, providing an opportunity to customize the %SSL
+        /// A callback invoked before initiating a new SSL handshake, providing an opportunity to customize the SSL
         /// parameters for the session based on specific server settings or requirements.
         ///
         /// @param context An opaque type that represents the security context associated with the current connection.
@@ -96,7 +96,7 @@ namespace Ice::SSL
 #endif
 
 #if defined(ICE_USE_SECURE_TRANSPORT) || defined(ICE_DOXYGEN)
-    /// %SSL transport configuration properties for server connections on macOS and iOS.
+    /// SSL transport configuration properties for server connections on macOS and iOS.
     ///
     /// The SecureTransportServerAuthenticationOptions structure is only available when the %Ice library is built on
     /// macOS and iOS. For Linux, refer to OpenSSLServerAuthenticationOptions, and for Windows, refer to
@@ -104,13 +104,13 @@ namespace Ice::SSL
     /// @see ::Ice::SSL::ServerAuthenticationOptions
     struct SecureTransportServerAuthenticationOptions
     {
-        /// A callback for selecting the server's %SSL certificate chain based on the name of the object adapter that
+        /// A callback for selecting the server's SSL certificate chain based on the name of the object adapter that
         /// accepts the connection.
         ///
-        /// This callback is invoked by the %SSL transport for each new incoming connection before starting the %SSL
+        /// This callback is invoked by the SSL transport for each new incoming connection before starting the SSL
         /// handshake to determine the appropriate server certificate chain. The callback must return a `CFArrayRef`
         /// that represents the server's certificate chain, or nullptr if no certificate chain should be used for the
-        /// connection. The %SSL transport takes ownership of the returned `CFArrayRef` and releases it when the
+        /// connection. The SSL transport takes ownership of the returned `CFArrayRef` and releases it when the
         /// connection is closed.
         ///
         /// @param adapterName The name of the object adapter that accepted the connection.
@@ -126,10 +126,10 @@ namespace Ice::SSL
         /// https://developer.apple.com/documentation/security/1392400-sslsetcertificate?changes=_3&language=objc
         std::function<CFArrayRef(const std::string& adapterName)> serverCertificateSelectionCallback;
 
-        /// A callback invoked before initiating a new %SSL handshake, providing an opportunity to customize the %SSL
+        /// A callback invoked before initiating a new SSL handshake, providing an opportunity to customize the SSL
         /// parameters for the session based on specific server settings or requirements.
         ///
-        /// @param context An opaque type that represents an %SSL session context object.
+        /// @param context An opaque type that represents an SSL session context object.
         /// @param adapterName The name of the object adapter that accepted the connection.
         ///
         /// Example of setting `sslNewSessionCallback`:
@@ -197,7 +197,7 @@ namespace Ice::SSL
 #endif
 
 #if defined(ICE_USE_OPENSSL) || defined(ICE_DOXYGEN)
-    /// %SSL transport configuration properties for server connections on Linux.
+    /// SSL transport configuration properties for server connections on Linux.
     ///
     /// The OpenSSLServerAuthenticationOptions structure is only available when the %Ice library is built on
     /// Linux. For macOS and iOS, refer to SecureTransportServerAuthenticationOptions, and for Windows, refer to
@@ -208,19 +208,19 @@ namespace Ice::SSL
         /// A callback that selects the server's [SSL_CTX][SSL_CTX_new] object based on the name of the object
         /// adapter that accepted the connection.
         ///
-        /// This callback associates a specific %SSL configuration with an incoming connection identified by
+        /// This callback associates a specific SSL configuration with an incoming connection identified by
         /// the name of the object adapter that accepted the connection. The callback must return a pointer to a valid
-        /// `SSL_CTX` object previously initialized using the OpenSSL API. The %SSL transport takes ownership of the
+        /// `SSL_CTX` object previously initialized using the OpenSSL API. The SSL transport takes ownership of the
         /// returned `SSL_CTX` object and releases it after closing the connection.
         ///
-        /// If the application does not provide a callback, the %SSL transport will use an `SSL_CTX` object created with
+        /// If the application does not provide a callback, the SSL transport will use an `SSL_CTX` object created with
         /// `SSL_CTX_new()`, which uses the default OpenSSL configuration.
         ///
-        /// The %SSL transport calls this callback for each new incoming connection to obtain the `SSL_CTX` object
-        /// before starting the %SSL handshake.
+        /// The SSL transport calls this callback for each new incoming connection to obtain the `SSL_CTX` object
+        /// before starting the SSL handshake.
         ///
         /// @param adapterName The name of the object adapter that accepted the connection.
-        /// @return A pointer to an `SSL_CTX` object representing the %SSL configuration for the new incoming
+        /// @return A pointer to an `SSL_CTX` object representing the SSL configuration for the new incoming
         /// connection.
         ///
         /// Example of setting `serverSSLContextSelectionCallback`:
@@ -229,10 +229,10 @@ namespace Ice::SSL
         /// [SSL_CTX_new]: https://www.openssl.org/docs/manmaster/man3/SSL_CTX_new.html
         std::function<SSL_CTX*(const std::string& adapterName)> serverSSLContextSelectionCallback{};
 
-        /// A callback invoked before initiating a new %SSL handshake, providing an opportunity to customize the %SSL
+        /// A callback invoked before initiating a new SSL handshake, providing an opportunity to customize the SSL
         /// parameters for the connection.
         ///
-        /// @param ssl A pointer to the %SSL object representing the connection.
+        /// @param ssl A pointer to the SSL object representing the connection.
         /// @param adapterName The name of the object adapter that accepted the connection.
         ///
         /// Example of setting `sslNewSessionCallback`:

--- a/cpp/include/Ice/StringConverter.h
+++ b/cpp/include/Ice/StringConverter.h
@@ -123,12 +123,12 @@ namespace Ice
     /// @return A native narrow string.
     ICE_API std::string UTF8ToNative(std::string_view str, const StringConverterPtr& nc);
 
-#ifdef _WIN32
-
+#if defined(_WIN32) || defined(ICE_DOXYGEN)
     /// Creates a StringConverter that converts to and from narrow chars
     /// in the given code page, using MultiByteToWideChar and WideCharToMultiByte.
     /// @param page The code page.
     /// @return The string converter.
+    /// @remark Windows only.
     ICE_API StringConverterPtr createWindowsStringConverter(unsigned int page);
 #endif
 


### PR DESCRIPTION
This PR updates the Ice::SSL and _WIN32 API doc to use ICE_DOXYGEN.