### PR TITLE
Deprecate and Replace `python:package` and `cs:namespace` with `python:identifier` and `cs:identifier`.

### DIFF
--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -14,36 +14,20 @@ namespace
 {
     static string getCSharpNamespace(const ContainedPtr& cont, bool& hasCSharpNamespaceAttribute)
     {
-        // Traverse to the top-level module.
-        ModulePtr m;
         ContainedPtr p = cont;
         string csharpNamespace;
         while (true)
         {
             if (dynamic_pointer_cast<Module>(p))
             {
-                m = dynamic_pointer_cast<Module>(p);
-                if (csharpNamespace.empty())
-                {
-                    csharpNamespace = m->name();
-                }
-                else
-                {
-                    csharpNamespace = m->name() + "." + csharpNamespace;
-                }
-            }
-
-            if (p->isTopLevel())
-            {
+                csharpNamespace = p->mappedScoped(".").substr(1);
                 break;
             }
             p = dynamic_pointer_cast<Contained>(p->container());
             assert(p);
         }
 
-        assert(m);
-
-        if (auto metadata = m->getMetadataArgs("cs:namespace"))
+        if (auto metadata = p->getMetadataArgs("cs:namespace"))
         {
             hasCSharpNamespaceAttribute = true;
             return *metadata + "." + csharpNamespace;

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -14,13 +14,32 @@ namespace
 {
     static string getCSharpNamespace(const ContainedPtr& cont, bool& hasCSharpNamespaceAttribute)
     {
+        // Traverse to the top-level module.
         ContainedPtr p = cont;
-        while (!dynamic_pointer_cast<Module>(p))
+        string csharpNamespace;
+        while (true)
         {
+            if (dynamic_pointer_cast<Module>(p))
+            {
+                // TODO we should be using the `mappedName` here, not the slice `name`.
+                if (csharpNamespace.empty())
+                {
+                    csharpNamespace = p->name();
+                }
+                else
+                {
+                    csharpNamespace = p->name() + "." + csharpNamespace;
+                }
+            }
+
+            if (p->isTopLevel())
+            {
+                break;
+            }
             p = dynamic_pointer_cast<Contained>(p->container());
             assert(p);
         }
-        const string csharpNamespace = p->scoped().substr(1);
+        assert(dynamic_pointer_cast<Module>(p));
 
         if (auto metadata = p->getMetadataArgs("cs:namespace"))
         {

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -15,17 +15,12 @@ namespace
     static string getCSharpNamespace(const ContainedPtr& cont, bool& hasCSharpNamespaceAttribute)
     {
         ContainedPtr p = cont;
-        string csharpNamespace;
-        while (true)
+        while (!dynamic_pointer_cast<Module>(p))
         {
-            if (dynamic_pointer_cast<Module>(p))
-            {
-                csharpNamespace = p->mappedScoped(".").substr(1);
-                break;
-            }
             p = dynamic_pointer_cast<Contained>(p->container());
             assert(p);
         }
+        const string csharpNamespace = p->mappedScoped(".").substr(1);
 
         if (auto metadata = p->getMetadataArgs("cs:namespace"))
         {

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -20,7 +20,7 @@ namespace
             p = dynamic_pointer_cast<Contained>(p->container());
             assert(p);
         }
-        const string csharpNamespace = p->mappedScoped(".").substr(1);
+        const string csharpNamespace = p->scoped().substr(1);
 
         if (auto metadata = p->getMetadataArgs("cs:namespace"))
         {

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -783,16 +783,12 @@ Slice::writeIceTuple(IceInternal::Output& out, const DataMemberList& dataMembers
     out << "> ice_tuple() const";
 
     out << sb;
-    out << nl << "return std::tie(";
-    for (auto pi = dataMembers.begin(); pi != dataMembers.end(); ++pi)
+    out << nl << "return std::tie" << spar;
+    for (const auto& member : dataMembers)
     {
-        if (pi != dataMembers.begin())
-        {
-            out << ", ";
-        }
-        out << (*pi)->mappedName();
+        out << member->mappedName();
     }
-    out << ");" << eb;
+    out << epar << ";" << eb;
 }
 
 string

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -2131,6 +2131,7 @@ Slice::Gen::DataDefVisitor::visitStructEnd(const StructPtr& p)
     H << eb << ';';
 
     const string scoped = p->mappedScoped();
+    const string name = p->mappedName();
 
     C << sp << nl << "void";
     C << nl << scoped.substr(2) << "::ice_printFields(std::ostream& os) const";
@@ -2139,12 +2140,12 @@ Slice::Gen::DataDefVisitor::visitStructEnd(const StructPtr& p)
     C << eb;
 
     H << sp;
-    H << nl << "/// Outputs the description of " << getArticleFor(p->mappedName()) << ' ' << p->mappedName()
+    H << nl << "/// Outputs the description of " << getArticleFor(name) << ' ' << name
       << " to a stream, including all its fields.";
     H << nl << "/// @param os The output stream.";
     H << nl << "/// @param value The instance to output.";
     H << nl << "/// @return The output stream.";
-    H << nl << _dllExport << "std::ostream& operator<<(std::ostream& os, const " << p->mappedName() << "& value);";
+    H << nl << _dllExport << "std::ostream& operator<<(std::ostream& os, const " << name << "& value);";
 
     if (!p->hasMetadata("cpp:custom-print"))
     {

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -24,29 +24,16 @@ using namespace IceInternal;
 string
 Slice::CsGenerator::getNamespacePrefix(const ContainedPtr& cont)
 {
-    //
     // Traverse to the top-level module.
-    //
-    ModulePtr m;
     ContainedPtr p = cont;
-    while (true)
+    while (!p->isTopLevel())
     {
-        if (dynamic_pointer_cast<Module>(p))
-        {
-            m = dynamic_pointer_cast<Module>(p);
-        }
-
-        if (p->isTopLevel())
-        {
-            break;
-        }
         p = dynamic_pointer_cast<Contained>(p->container());
         assert(p);
     }
+    assert(dynamic_pointer_cast<Module>(p));
 
-    assert(m);
-
-    return m->getMetadataArgs("cs:namespace").value_or("");
+    return p->getMetadataArgs("cs:namespace").value_or("");
 }
 
 string
@@ -1808,8 +1795,8 @@ Slice::CsGenerator::validateMetadata(const UnitPtr& u)
         .acceptedArgumentKind = MetadataArgumentKind::SingleArgument,
         .extraValidation = [](const MetadataPtr& metadata, const SyntaxTreeBasePtr& p) -> optional<string>
         {
-            const string msg = "'cs:namespace' is deprecated; use 'cs:identifier' instead";
-            p->unit()->warning( metadata->file(), metadata->line(), Deprecated, msg);
+            const string msg = "'cs:namespace' is deprecated; use 'cs:identifier' to rename modules instead";
+            p->unit()->warning(metadata->file(), metadata->line(), Deprecated, msg);
 
             // 'cs:namespace' can only be applied to top-level modules
             // Top-level modules are contained by the 'Unit'. Non-top-level modules are contained in 'Module's.

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1795,7 +1795,7 @@ Slice::CsGenerator::validateMetadata(const UnitPtr& u)
         .acceptedArgumentKind = MetadataArgumentKind::SingleArgument,
         .extraValidation = [](const MetadataPtr& metadata, const SyntaxTreeBasePtr& p) -> optional<string>
         {
-            const string msg = "'cs:namespace' is deprecated; use 'cs:identifier' to rename modules instead";
+            const string msg = "'cs:namespace' is deprecated; use 'cs:identifier' to remap modules instead";
             p->unit()->warning(metadata->file(), metadata->line(), Deprecated, msg);
 
             // 'cs:namespace' can only be applied to top-level modules

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1806,8 +1806,11 @@ Slice::CsGenerator::validateMetadata(const UnitPtr& u)
     MetadataInfo namespaceInfo = {
         .validOn = {typeid(Module)},
         .acceptedArgumentKind = MetadataArgumentKind::SingleArgument,
-        .extraValidation = [](const MetadataPtr&, const SyntaxTreeBasePtr& p) -> optional<string>
+        .extraValidation = [](const MetadataPtr& metadata, const SyntaxTreeBasePtr& p) -> optional<string>
         {
+            const string msg = "'cs:namespace' is deprecated; use 'cs:identifier' instead";
+            p->unit()->warning( metadata->file(), metadata->line(), Deprecated, msg);
+
             // 'cs:namespace' can only be applied to top-level modules
             // Top-level modules are contained by the 'Unit'. Non-top-level modules are contained in 'Module's.
             if (auto mod = dynamic_pointer_cast<Module>(p); mod && !mod->isTopLevel())

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -874,27 +874,21 @@ Slice::CsVisitor::writeParameterDocComments(const DocComment& comment, const Par
 void
 Slice::CsVisitor::moduleStart(const ModulePtr& p)
 {
-    if (p->isTopLevel())
+    string ns = getNamespacePrefix(p);
+    if (!ns.empty())
     {
-        string ns = getNamespacePrefix(p);
-        if (!ns.empty())
-        {
-            _out << sp;
-            _out << nl << "namespace " << ns;
-            _out << sb;
-        }
+        _out << sp;
+        _out << nl << "namespace " << ns;
+        _out << sb;
     }
 }
 
 void
 Slice::CsVisitor::moduleEnd(const ModulePtr& p)
 {
-    if (p->isTopLevel())
+    if (!getNamespacePrefix(p).empty())
     {
-        if (!getNamespacePrefix(p).empty())
-        {
-            _out << eb;
-        }
+        _out << eb;
     }
 }
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -872,7 +872,7 @@ Slice::CsVisitor::writeParameterDocComments(const DocComment& comment, const Par
 }
 
 void
-Slice::CsVisitor::moduleStart(const ModulePtr& p)
+Slice::CsVisitor::modulePrefixStart(const ModulePtr& p)
 {
     string ns = getNamespacePrefix(p);
     if (!ns.empty())
@@ -884,7 +884,7 @@ Slice::CsVisitor::moduleStart(const ModulePtr& p)
 }
 
 void
-Slice::CsVisitor::moduleEnd(const ModulePtr& p)
+Slice::CsVisitor::modulePrefixEnd(const ModulePtr& p)
 {
     if (!getNamespacePrefix(p).empty())
     {
@@ -983,7 +983,7 @@ Slice::Gen::TypesVisitor::TypesVisitor(IceInternal::Output& out) : CsVisitor(out
 bool
 Slice::Gen::TypesVisitor::visitModuleStart(const ModulePtr& p)
 {
-    moduleStart(p);
+    modulePrefixStart(p);
     _out << sp;
     _out << nl << "namespace " << p->mappedName();
     _out << sb;
@@ -995,7 +995,7 @@ void
 Slice::Gen::TypesVisitor::visitModuleEnd(const ModulePtr& p)
 {
     _out << eb;
-    moduleEnd(p);
+    modulePrefixEnd(p);
 }
 
 bool
@@ -2264,7 +2264,7 @@ Slice::Gen::ResultVisitor::visitModuleStart(const ModulePtr& p)
 {
     if (hasResultType(p))
     {
-        moduleStart(p);
+        modulePrefixStart(p);
         _out << sp << nl << "namespace " << p->mappedName();
         _out << sb;
         return true;
@@ -2276,7 +2276,7 @@ void
 Slice::Gen::ResultVisitor::visitModuleEnd(const ModulePtr& p)
 {
     _out << eb;
-    moduleEnd(p);
+    modulePrefixEnd(p);
 }
 
 void
@@ -2355,7 +2355,7 @@ Slice::Gen::ServantVisitor::visitModuleStart(const ModulePtr& p)
         return false;
     }
 
-    moduleStart(p);
+    modulePrefixStart(p);
     _out << sp << nl << "namespace " << p->mappedName();
     _out << sb;
     return true;
@@ -2365,7 +2365,7 @@ void
 Slice::Gen::ServantVisitor::visitModuleEnd(const ModulePtr& p)
 {
     _out << eb;
-    moduleEnd(p);
+    modulePrefixEnd(p);
 }
 
 bool

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -72,8 +72,8 @@ namespace Slice
         writeOpDocComment(const OperationPtr& operation, const std::vector<std::string>& extraParams, bool isAsync);
         void writeParameterDocComments(const DocComment&, const ParameterList&);
 
-        void moduleStart(const ModulePtr&);
-        void moduleEnd(const ModulePtr&);
+        void modulePrefixStart(const ModulePtr&);
+        void modulePrefixEnd(const ModulePtr&);
 
         IceInternal::Output& _out;
     };

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -1724,7 +1724,7 @@ Slice::JavaGenerator::validateMetadata(const UnitPtr& u)
             if (!dynamic_pointer_cast<Unit>(p))
             {
                 const string msg = "'java:package' is deprecated; use 'java:identifier' instead";
-                p->unit()->warning( metadata->file(), metadata->line(), Deprecated, msg);
+                p->unit()->warning(metadata->file(), metadata->line(), Deprecated, msg);
             }
 
             // If 'java:package' is applied to a module, it must be a top-level module.

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -1718,15 +1718,8 @@ Slice::JavaGenerator::validateMetadata(const UnitPtr& u)
     MetadataInfo packageInfo = {
         .validOn = {typeid(Unit), typeid(Module)},
         .acceptedArgumentKind = MetadataArgumentKind::SingleArgument,
-        .extraValidation = [](const MetadataPtr& metadata, const SyntaxTreeBasePtr& p) -> optional<string>
+        .extraValidation = [](const MetadataPtr&, const SyntaxTreeBasePtr& p) -> optional<string>
         {
-            // 'java:package' is deprecated, except as file metadata.
-            if (!dynamic_pointer_cast<Unit>(p))
-            {
-                const string msg = "'java:package' is deprecated; use 'java:identifier' instead";
-                p->unit()->warning(metadata->file(), metadata->line(), Deprecated, msg);
-            }
-
             // If 'java:package' is applied to a module, it must be a top-level module.
             // // Top-level modules are contained by the 'Unit'. Non-top-level modules are contained in 'Module's.
             if (auto mod = dynamic_pointer_cast<Module>(p); mod && !mod->isTopLevel())

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2436,7 +2436,7 @@ Slice::Python::validateMetadata(const UnitPtr& unit)
         .acceptedArgumentKind = MetadataArgumentKind::SingleArgument,
         .extraValidation = [](const MetadataPtr& metadata, const SyntaxTreeBasePtr& p) -> optional<string>
         {
-            const string msg = "'python:package' is deprecated; use 'python:identifier' to rename modules instead";
+            const string msg = "'python:package' is deprecated; use 'python:identifier' to remap modules instead";
             p->unit()->warning(metadata->file(), metadata->line(), Deprecated, msg);
 
             // If 'python:package' is applied to a module, it must be a top-level module.

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2434,8 +2434,11 @@ Slice::Python::validateMetadata(const UnitPtr& unit)
     MetadataInfo packageInfo = {
         .validOn = {typeid(Module), typeid(Unit)},
         .acceptedArgumentKind = MetadataArgumentKind::SingleArgument,
-        .extraValidation = [](const MetadataPtr&, const SyntaxTreeBasePtr& p) -> optional<string>
+        .extraValidation = [](const MetadataPtr& metadata, const SyntaxTreeBasePtr& p) -> optional<string>
         {
+            const string msg = "'python:package' is deprecated; use 'python:identifier' to rename modules instead";
+            p->unit()->warning(metadata->file(), metadata->line(), Deprecated, msg);
+
             // If 'python:package' is applied to a module, it must be a top-level module.
             // Top-level modules are contained by the 'Unit'. Non-top-level modules are contained in 'Module's.
             if (auto mod = dynamic_pointer_cast<Module>(p); mod && !mod->isTopLevel())

--- a/csharp/test/Ice/adapterDeactivation/Test.ice
+++ b/csharp/test/Ice/adapterDeactivation/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.adapterDeactivation"]
+["cs:identifier:Ice.adapterDeactivation.Test"]
 module Test
 {
     interface TestIntf

--- a/csharp/test/Ice/admin/Test.ice
+++ b/csharp/test/Ice/admin/Test.ice
@@ -5,7 +5,7 @@
 
 #include "Ice/PropertyDict.ice"
 
-["cs:namespace:Ice.admin"]
+["cs:identifier:Ice.admin.Test"]
 module Test
 {
     interface RemoteCommunicator

--- a/csharp/test/Ice/ami/Test.ice
+++ b/csharp/test/Ice/ami/Test.ice
@@ -5,7 +5,7 @@
 #include "Ice/BuiltinSequences.ice"
 #include "Ice/Identity.ice"
 
-["cs:namespace:Ice.ami"]
+["cs:identifier:Ice.ami.Test"]
 module Test
 {
     exception TestIntfException

--- a/csharp/test/Ice/binding/Test.ice
+++ b/csharp/test/Ice/binding/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.binding"]
+["cs:identifier:Ice.binding.Test"]
 module Test
 {
     interface TestIntf

--- a/csharp/test/Ice/defaultServant/Test.ice
+++ b/csharp/test/Ice/defaultServant/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.defaultServant"]
+["cs:identifier:Ice.defaultServant.Test"]
 module Test
 {
     interface MyObject

--- a/csharp/test/Ice/defaultValue/Test.ice
+++ b/csharp/test/Ice/defaultValue/Test.ice
@@ -4,7 +4,7 @@
 
 [["suppress-warning:deprecated"]] // For enumerator references
 
-["cs:namespace:Ice.defaultValue"]
+["cs:identifier:Ice.defaultValue.Test"]
 module Test
 {
     enum Color { red, green, blue }

--- a/csharp/test/Ice/dictMapping/Test.ice
+++ b/csharp/test/Ice/dictMapping/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.dictMapping"]
+["cs:identifier:Ice.dictMapping.Test"]
 module Test
 {
     dictionary<int, int> NV;

--- a/csharp/test/Ice/dictMapping/TestAMD.ice
+++ b/csharp/test/Ice/dictMapping/TestAMD.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.dictMapping.AMD"]
+["cs:identifier:Ice.dictMapping.AMD.Test"]
 module Test
 {
     dictionary<int, int> NV;

--- a/csharp/test/Ice/enums/Test.ice
+++ b/csharp/test/Ice/enums/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.enums"]
+["cs:identifier:Ice.enums.Test"]
 module Test
 {
     const byte ByteConst1 = 10;

--- a/csharp/test/Ice/exceptions/Test.ice
+++ b/csharp/test/Ice/exceptions/Test.ice
@@ -4,7 +4,7 @@
 
 #include "Ice/BuiltinSequences.ice"
 
-["cs:namespace:Ice.exceptions"]
+["cs:identifier:Ice.exceptions.Test"]
 module Test
 {
     interface Empty

--- a/csharp/test/Ice/exceptions/TestAMD.ice
+++ b/csharp/test/Ice/exceptions/TestAMD.ice
@@ -4,7 +4,7 @@
 
 #include "Ice/BuiltinSequences.ice"
 
-["cs:namespace:Ice.exceptions.AMD"]
+["cs:identifier:Ice.exceptions.AMD.Test"]
 module Test
 {
     interface Empty

--- a/csharp/test/Ice/facets/Test.ice
+++ b/csharp/test/Ice/facets/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.facets"]
+["cs:identifier:Ice.facets.Test"]
 module Test
 {
     interface Empty

--- a/csharp/test/Ice/hold/Test.ice
+++ b/csharp/test/Ice/hold/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.hold"]
+["cs:identifier:Ice.hold.Test"]
 module Test
 {
     interface Hold

--- a/csharp/test/Ice/idleTimeout/Test.ice
+++ b/csharp/test/Ice/idleTimeout/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.idleTimeout"]
+["cs:identifier:Ice.idleTimeout.Test"]
 module Test
 {
     interface TestIntf

--- a/csharp/test/Ice/inactivityTimeout/Test.ice
+++ b/csharp/test/Ice/inactivityTimeout/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.inactivityTimeout"]
+["cs:identifier:Ice.inactivityTimeout.Test"]
 module Test
 {
     interface TestIntf

--- a/csharp/test/Ice/info/Test.ice
+++ b/csharp/test/Ice/info/Test.ice
@@ -4,7 +4,7 @@
 
 #include "Ice/Context.ice"
 
-["cs:namespace:Ice.info"]
+["cs:identifier:Ice.info.Test"]
 module Test
 {
     interface TestIntf

--- a/csharp/test/Ice/inheritance/Test.ice
+++ b/csharp/test/Ice/inheritance/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.inheritance"]
+["cs:identifier:Ice.inheritance.Test"]
 module Test
 {
     module MA

--- a/csharp/test/Ice/invoke/Test.ice
+++ b/csharp/test/Ice/invoke/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.invoke"]
+["cs:identifier:Ice.invoke.Test"]
 module Test
 {
     exception MyException

--- a/csharp/test/Ice/location/Test.ice
+++ b/csharp/test/Ice/location/Test.ice
@@ -5,7 +5,7 @@
 #include "Ice/Locator.ice"
 #include "Ice/LocatorRegistry.ice"
 
-["cs:namespace:Ice.location"]
+["cs:identifier:Ice.location.Test"]
 module Test
 {
     interface TestLocatorRegistry extends Ice::LocatorRegistry

--- a/csharp/test/Ice/maxConnections/Test.ice
+++ b/csharp/test/Ice/maxConnections/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.maxConnections"]
+["cs:identifier:Ice.maxConnections.Test"]
 module Test
 {
     interface TestIntf

--- a/csharp/test/Ice/maxDispatches/Test.ice
+++ b/csharp/test/Ice/maxDispatches/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.maxDispatches"]
+["cs:identifier:Ice.maxDispatches.Test"]
 module Test
 {
     interface TestIntf

--- a/csharp/test/Ice/middleware/Test.ice
+++ b/csharp/test/Ice/middleware/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.middleware"]
+["cs:identifier:Ice.middleware.Test"]
 module Test
 {
     interface MyObject

--- a/csharp/test/Ice/namespacemd/Namespace.ice
+++ b/csharp/test/Ice/namespacemd/Namespace.ice
@@ -2,6 +2,8 @@
 
 #pragma once
 
+[["suppress-warning:deprecated"]] // For 'cs:namespace' metadata.
+
 ["cs:namespace:Ice.namespacemd"]
 module WithNamespace
 {

--- a/csharp/test/Ice/namespacemd/Namespace.ice
+++ b/csharp/test/Ice/namespacemd/Namespace.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["suppress-warning:deprecated"]] // For 'cs:namespace' metadata.
+[["suppress-warning:deprecated"]] // for 'cs:namespace' metadata
 
 ["cs:namespace:Ice.namespacemd"]
 module WithNamespace

--- a/csharp/test/Ice/namespacemd/Test.ice
+++ b/csharp/test/Ice/namespacemd/Test.ice
@@ -5,7 +5,7 @@
 #include "Namespace.ice"
 #include "NoNamespace.ice"
 
-[["suppress-warning:deprecated"]] // For 'cs:namespace' metadata.
+[["suppress-warning:deprecated"]] // for 'cs:namespace' metadata
 
 ["cs:namespace:Ice.namespacemd"]
 module Test

--- a/csharp/test/Ice/namespacemd/Test.ice
+++ b/csharp/test/Ice/namespacemd/Test.ice
@@ -5,6 +5,8 @@
 #include "Namespace.ice"
 #include "NoNamespace.ice"
 
+[["suppress-warning:deprecated"]] // For 'cs:namespace' metadata.
+
 ["cs:namespace:Ice.namespacemd"]
 module Test
 {

--- a/csharp/test/Ice/objects/Forward.ice
+++ b/csharp/test/Ice/objects/Forward.ice
@@ -1,7 +1,8 @@
 // Copyright (c) ZeroC, Inc.
 
 #pragma once
-["cs:namespace:Ice.objects"]
+
+["cs:identifier:Ice.objects.Test"]
 
 module Test
 {

--- a/csharp/test/Ice/objects/Forward.ice
+++ b/csharp/test/Ice/objects/Forward.ice
@@ -3,7 +3,6 @@
 #pragma once
 
 ["cs:identifier:Ice.objects.Test"]
-
 module Test
 {
     class F1

--- a/csharp/test/Ice/objects/Test.ice
+++ b/csharp/test/Ice/objects/Test.ice
@@ -1,7 +1,8 @@
 // Copyright (c) ZeroC, Inc.
 
 #pragma once
-["cs:namespace:Ice.objects"]
+
+["cs:identifier:Ice.objects.Test"]
 module Test
 {
     struct S

--- a/csharp/test/Ice/operations/Test.ice
+++ b/csharp/test/Ice/operations/Test.ice
@@ -4,7 +4,7 @@
 
 #include "Ice/Context.ice"
 
-["cs:namespace:Ice.operations"]
+["cs:identifier:Ice.operations.Test"]
 module Test
 {
     enum MyEnum

--- a/csharp/test/Ice/operations/TestAMD.ice
+++ b/csharp/test/Ice/operations/TestAMD.ice
@@ -4,7 +4,7 @@
 
 #include "Ice/Context.ice"
 
-["cs:namespace:Ice.operations.AMD"]
+["cs:identifier:Ice.operations.AMD.Test"]
 module Test
 {
     enum MyEnum

--- a/csharp/test/Ice/optional/Test.ice
+++ b/csharp/test/Ice/optional/Test.ice
@@ -1,7 +1,8 @@
 // Copyright (c) ZeroC, Inc.
 
 #pragma once
-["cs:namespace:Ice.optional"]
+
+["cs:identifier:Ice.optional.Test"]
 module Test
 {
     class OneOptional

--- a/csharp/test/Ice/optional/TestAMD.ice
+++ b/csharp/test/Ice/optional/TestAMD.ice
@@ -1,7 +1,8 @@
 // Copyright (c) ZeroC, Inc.
 
 #pragma once
-["cs:namespace:Ice.optional.AMD"]
+
+["cs:identifier:Ice.optional.AMD.Test"]
 module Test
 {
     class OneOptional

--- a/csharp/test/Ice/proxy/Test.ice
+++ b/csharp/test/Ice/proxy/Test.ice
@@ -4,7 +4,7 @@
 
 #include "Ice/Context.ice"
 
-["cs:namespace:Ice.proxy"]
+["cs:identifier:Ice.proxy.Test"]
 module Test
 {
     interface MyClass

--- a/csharp/test/Ice/proxy/TestAMD.ice
+++ b/csharp/test/Ice/proxy/TestAMD.ice
@@ -4,7 +4,7 @@
 
 #include "Ice/Context.ice"
 
-["cs:namespace:Ice.proxy.AMD"]
+["cs:identifier:Ice.proxy.AMD.Test"]
 module Test
 {
     ["amd"] interface MyClass

--- a/csharp/test/Ice/retry/Test.ice
+++ b/csharp/test/Ice/retry/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.retry"]
+["cs:identifier:Ice.retry.Test"]
 module Test
 {
     interface Retry

--- a/csharp/test/Ice/scope/Test.ice
+++ b/csharp/test/Ice/scope/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.scope"]
+["cs:identifier:Ice.scope.Test"]
 module Test
 {
     struct MyStruct

--- a/csharp/test/Ice/seqMapping/Test.ice
+++ b/csharp/test/Ice/seqMapping/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.seqMapping"]
+["cs:identifier:Ice.seqMapping.Test"]
 module Test
 {
     sequence<byte> AByteS;

--- a/csharp/test/Ice/seqMapping/TestAMD.ice
+++ b/csharp/test/Ice/seqMapping/TestAMD.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.seqMapping.AMD"]
+["cs:identifier:Ice.seqMapping.AMD.Test"]
 module Test
 {
     sequence<byte> AByteS;

--- a/csharp/test/Ice/servantLocator/Test.ice
+++ b/csharp/test/Ice/servantLocator/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.servantLocator"]
+["cs:identifier:Ice.servantLocator.Test"]
 module Test
 {
     exception TestIntfUserException

--- a/csharp/test/Ice/servantLocator/TestAMD.ice
+++ b/csharp/test/Ice/servantLocator/TestAMD.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.servantLocator.AMD"]
+["cs:identifier:Ice.servantLocator.AMD.Test"]
 module Test
 {
     exception TestIntfUserException

--- a/csharp/test/Ice/stream/Test.ice
+++ b/csharp/test/Ice/stream/Test.ice
@@ -2,12 +2,12 @@
 
 #pragma once
 
+#include "Ice/BuiltinSequences.ice"
+
 // Suppress invalid metadata warnings which we expect this test to generate.
 [["suppress-warning"]]
 
-#include "Ice/BuiltinSequences.ice"
-
-["cs:namespace:Ice.stream"]
+["cs:identifier:Ice.stream.Test"]
 module Test
 {
     enum MyEnum

--- a/csharp/test/Ice/threadPoolPriority/Test.ice
+++ b/csharp/test/Ice/threadPoolPriority/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.threadPoolPriority"]
+["cs:identifier:Ice.threadPoolPriority.Test"]
 module Test
 {
     interface Priority

--- a/csharp/test/Ice/timeout/Test.ice
+++ b/csharp/test/Ice/timeout/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-["cs:namespace:Ice.timeout"]
+["cs:identifier:Ice.timeout.Test"]
 module Test
 {
     sequence<byte> ByteSeq;

--- a/csharp/test/Ice/udp/Test.ice
+++ b/csharp/test/Ice/udp/Test.ice
@@ -4,7 +4,7 @@
 
 #include "Ice/Identity.ice"
 
-["cs:namespace:Ice.udp"]
+["cs:identifier:Ice.udp.Test"]
 module Test
 {
     interface PingReply

--- a/python/test/Ice/packagemd/Package.ice
+++ b/python/test/Ice/packagemd/Package.ice
@@ -2,6 +2,8 @@
 
 #pragma once
 
+[["suppress-warning:deprecated"]] // for 'python:package'
+
 [["python:package:testpkg"]]
 module Test2
 {


### PR DESCRIPTION
The title pretty much says it all. `swift:module` and `java:package` are next.

I also simplified some `while` loops we were using to check for metadata on top-level modules.