### PR TITLE
Fix segmentation fault in Communicator destroyAsync

### DIFF
--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -268,8 +268,8 @@ communicatorDealloc(CommunicatorObject* self)
         delete self->communicator;
         delete self->shutdownException;
         delete self->shutdownFuture;
-        delete self->executor;
     }
+    delete self->executor;
     Py_TYPE(self)->tp_free(reinterpret_cast<PyObject*>(self));
 }
 

--- a/python/test/Ice/asyncio/Server.py
+++ b/python/test/Ice/asyncio/Server.py
@@ -15,18 +15,16 @@ class Server(TestHelper):
 
         async def runAsync():
 
-            loop = asyncio.get_running_loop()
-
             initData = Ice.InitializationData()
             initData.properties = self.createTestProperties(args)
             initData.properties.setProperty("Ice.Warn.Dispatch", "0")
-            initData.eventLoopAdapter = Ice.asyncio.EventLoopAdapter(loop)
+            initData.eventLoopAdapter = Ice.asyncio.EventLoopAdapter(asyncio.get_running_loop())
 
             async with self.initialize(initData) as communicator:
                 communicator.getProperties().setProperty("TestAdapter.Endpoints", self.getTestEndpoint())
                 adapter = communicator.createObjectAdapter("TestAdapter")
                 adapter.add(TestI.TestIntfI(), Ice.stringToIdentity("test"))
                 adapter.activate()
-                await loop.run_in_executor(None, communicator.waitForShutdown)
+                await communicator.shutdownCompleted()
 
         asyncio.run(runAsync(), debug=True)


### PR DESCRIPTION
This PR fixes #3824 and #3840

It replaces #3838 and uses what I think is a better approach.

This PR uses a promise to wait for the destroy async callback to complete in communicator dealloc. This should prevent Python to start finalize before the callback completed.