### PR TITLE
Replace `swift:module` with `swift:identifier`

### DIFF
--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -541,7 +541,7 @@ SwiftGenerator::validateMetadata(const UnitPtr& u)
                 if (contained->hasMetadata("swift:identifier"))
                 {
                     return "the 'swift:module' metadata cannot be used alongside 'swift:identifier' - both change the "
-                           "mapped name of this module";
+                           "name of the mapped module";
                 }
             }
             return nullopt;

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -540,12 +540,12 @@ SwiftGenerator::validateMetadata(const UnitPtr& u)
             {
                 if (contained->hasMetadata("swift:identifier"))
                 {
-                    return "the 'swift:module' metadata cannot be used alongside 'swift:identifier' - both change the mapped name of this module";
+                    return "the 'swift:module' metadata cannot be used alongside 'swift:identifier' - both change the "
+                           "mapped name of this module";
                 }
             }
             return nullopt;
-        }
-    };
+        }};
     knownMetadata.emplace("swift:module", moduleInfo);
 
     // Pass this information off to the parser's metadata validation logic.

--- a/slice/Glacier2/Metrics.ice
+++ b/slice/Glacier2/Metrics.ice
@@ -14,7 +14,7 @@
 
 #include "Ice/Metrics.ice"
 
-["swift:module:Glacier2:MX"]
+["swift:identifier:Glacier2"]
 module IceMX
 {
     /// Provides information about Glacier2 sessions.

--- a/slice/Ice/Metrics.ice
+++ b/slice/Ice/Metrics.ice
@@ -13,7 +13,7 @@
 #include "BuiltinSequences.ice"
 
 /// The Ice Management eXtension facility.
-["swift:module:Ice:MX"]
+["swift:identifier:Ice"]
 module IceMX
 {
     /// A dictionary of strings to integers.

--- a/slice/IceStorm/Metrics.ice
+++ b/slice/IceStorm/Metrics.ice
@@ -14,7 +14,7 @@
 
 #include "Ice/Metrics.ice"
 
-["swift:module:IceStorm:MX"]
+["swift:identifier:IceStorm"]
 module IceMX
 {
     /// Provides information about one or more IceStorm topics.

--- a/swift/test/Ice/operations/Test.ice
+++ b/swift/test/Ice/operations/Test.ice
@@ -415,15 +415,12 @@ module Test
     const string wsu2 = "\U00000128\U00000178\U000000FF\U00000100\U00001F00\U00010194\U0001016A\U00010198\U0001F340\U0001F341\U0001F342\U0001F343";
 }
 
-["swift:module:Test:Test2"]
+["swift:identifier:Test"]
 module Test2
 {
-    /**
-    *
-    * Makes sure that proxy operations are correctly generated when extending an interface from
-    * a different module (ICE-7639).
-    *
-    **/
+    // Makes sure that proxy operations are correctly generated when extending an interface from
+    // a different module (ICE-7639).
+    ["swift:identifier:Test2MyDerivedClass"]
     interface MyDerivedClass extends Test::MyClass
     {
     }

--- a/swift/test/Ice/scope/Test.ice
+++ b/swift/test/Ice/scope/Test.ice
@@ -2,6 +2,8 @@
 
 #pragma once
 
+[["suppress-warning:deprecated"]] // for 'swift:module'
+
 module Test
 {
     struct MyStruct

--- a/swift/test/Ice/stream/Test.ice
+++ b/swift/test/Ice/stream/Test.ice
@@ -117,9 +117,10 @@ module Test
     }
 }
 
-["swift:module:Test:Test2"]
+["swift:identifier:Test"]
 module Test2
 {
+    ["swift:identifier:Test2Sub2"]
     module Sub2
     {
         enum NestedEnum2


### PR DESCRIPTION
This PR follows in the footsteps of #3833 (which handled `cs:namespace` and `python:package`), working towards #3368.

As-of this PR, the Slice compiler still supports `swift:module`, but it's deprecated, and I have removed it's use from all of our Slice files (except the scope test), replacing it with `swift:identifier`.

Unlike the other module remapping metadata, `swift:module` supported a special 2nd argument, for adding a prefix to all a module's contents. In some tests, I manually emulated this (by using `swift:identifier` on the module's contents), in other cases (like for IceMX), I just fully dropped the prefix.