### PR TITLE
Use venv for PIP package uploading

### DIFF
--- a/.github/workflows/build-pip-packages.yml
+++ b/.github/workflows/build-pip-packages.yml
@@ -99,8 +99,10 @@ jobs:
             cp -vf $file ${{ github.workspace }}/dist
           done
 
-          python3 -m pip install twine --user
-          python3 -m twine upload --verbose --repository-url ${{ inputs.repository_url }} ${{ github.workspace }}/dist/*
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install twine
+          twine upload --verbose --repository-url ${{ inputs.repository_url }} ${{ github.workspace }}/dist/*
         env:
           TWINE_USERNAME: ${{ inputs.repository_username }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
This is an attempt to fix the PIP package uploading errors we are seeing with Nightly builds.

The nightly build fails with:

```
Uploading distributions to 
https://download.zeroc.com/nexus/repository/pypi-nightly/
ERROR    InvalidDistribution: Invalid distribution metadata: unrecognized or    
         malformed field 'license-expression'    
```

It is working fine with a local Ubuntu 24.04 VM, it is likely an issue with one of the twine dependencies. Hopefully switching to a virtual environment sorts out the issue.