### PR TITLE
Remove static cppflags

### DIFF
--- a/cpp/config/Make.rules
+++ b/cpp/config/Make.rules
@@ -97,10 +97,6 @@ define create-cpp-test-project
 $1_srcext               := cpp
 $1_dependencies         := $$(or $$($1_dependencies),TestCommon Ice)
 
-# Also link with IceBT (Debian/Ubuntu/Yocto) when compiling the project with the static configuration
-$1[static]_cppflags     += -DICE_STATIC_LIBS $(if $(IceBT_system_libs),-DICE_HAS_BT)
-$1[static]_dependencies := $(if $(IceBT_system_libs),IceBT)
-
 # Dependencies and target dirs for iOS test project
 $1[iphoneos-static]_targetdir                 := test/ios/bundles/Bundles-iphoneos/$(subst /,_,$1)
 $1[iphonesimulator-static]_targetdir          := test/ios/bundles/Bundles-iphonesimulator/$(subst /,_,$1)


### PR DESCRIPTION
This PR removes `-DICE_STATIC_LIBS` and `-DICE_HAS_BT` that are not checked anywhere.