### PR TITLE
Finish Operation Doc Comment Validation

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -586,7 +586,7 @@ Slice::DocComment::parseFrom(const ContainedPtr& p, DocLinkFormatter linkFormatt
                     { return ex->isBaseOf(exceptionTarget) || ex->scoped() == exceptionTarget->scoped(); };
                     if (std::find_if(exceptionSpec.begin(), exceptionSpec.end(), exceptionCheck) == exceptionSpec.end())
                     {
-                        const string msg = "'" + actualTag + " " + name + "': this exception is not listed in" +
+                        const string msg = "'" + actualTag + " " + name + "': this exception is not listed in " +
                                            "(or a sub-exception of) this operation's exception specification";
                         p->unit()->warning(p->file(), p->line(), InvalidComment, msg);
                     }

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -536,7 +536,8 @@ Slice::DocComment::parseFrom(const ContainedPtr& p, DocLinkFormatter linkFormatt
                 const auto paramNameCheck = [&name](const ParameterPtr& p) { return p->name() == name; };
                 if (std::find_if(params.begin(), params.end(), paramNameCheck) == params.end())
                 {
-                    const string msg = "'" + paramTag + " " + name + "' does not correspond to any parameter in operation '" + p->name() + "'";
+                    const string msg = "'" + paramTag + " " + name +
+                                       "' does not correspond to any parameter in operation '" + p->name() + "'";
                     p->unit()->warning(p->file(), p->line(), InvalidComment, msg);
                 }
 
@@ -554,10 +555,12 @@ Slice::DocComment::parseFrom(const ContainedPtr& p, DocLinkFormatter linkFormatt
                 }
             }
         }
-        else if (parseNamedCommentLine(l, throwsTag, name, lineText) || parseNamedCommentLine(l, exceptionTag, name, lineText))
+        else if (
+            parseNamedCommentLine(l, throwsTag, name, lineText) ||
+            parseNamedCommentLine(l, exceptionTag, name, lineText))
         {
             // '@throws' and '@exception' are equivalent. But we want to use the correct one in our warning messages.
-            const string actualTag = (l.find(throwsTag) == 0)? throwsTag : exceptionTag;
+            const string actualTag = (l.find(throwsTag) == 0) ? throwsTag : exceptionTag;
             if (!operationTarget)
             {
                 // If '@throws'/'@exception' was put on anything other than an operation, ignore it and issue a warning.
@@ -571,17 +574,20 @@ Slice::DocComment::parseFrom(const ContainedPtr& p, DocLinkFormatter linkFormatt
                 const ExceptionPtr exceptionTarget = operationTarget->lookupException(name, false);
                 if (!exceptionTarget)
                 {
-                    const string msg = "'" + actualTag + " " + name + "': no exception with this name could be found from the current scope";
+                    const string msg = "'" + actualTag + " " + name +
+                                       "': no exception with this name could be found from the current scope";
                     p->unit()->warning(p->file(), p->line(), InvalidComment, msg);
                 }
                 else
                 {
                     // ... and matches one of the exceptions in the operation's specification.
                     const ExceptionList exceptionSpec = operationTarget->throws();
-                    const auto exceptionCheck = [&name, &exceptionTarget](const ExceptionPtr& ex) { return ex->isBaseOf(exceptionTarget) || ex->scoped() == exceptionTarget->scoped(); };
+                    const auto exceptionCheck = [&name, &exceptionTarget](const ExceptionPtr& ex)
+                    { return ex->isBaseOf(exceptionTarget) || ex->scoped() == exceptionTarget->scoped(); };
                     if (std::find_if(exceptionSpec.begin(), exceptionSpec.end(), exceptionCheck) == exceptionSpec.end())
                     {
-                        const string msg = "'" + actualTag + " " + name + "': this exception is not listed in (or a sub-exception of) this operation's exception specification";
+                        const string msg = "'" + actualTag + " " + name + "': this exception is not listed in" +
+                                           "(or a sub-exception of) this operation's exception specification";
                         p->unit()->warning(p->file(), p->line(), InvalidComment, msg);
                     }
 

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -586,7 +586,7 @@ Slice::DocComment::parseFrom(const ContainedPtr& p, DocLinkFormatter linkFormatt
                     { return ex->isBaseOf(exceptionTarget) || ex->scoped() == exceptionTarget->scoped(); };
                     if (std::none_of(exceptionSpec.begin(), exceptionSpec.end(), exceptionCheck))
                     {
-                        const string msg = "'" + actualTag + " " + name + "': this exception is not listed in nor" +
+                        const string msg = "'" + actualTag + " " + name + "': this exception is not listed in nor " +
                                            "derived from any exception in this operation's specification";
                         p->unit()->warning(p->file(), p->line(), InvalidComment, msg);
                     }

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -533,7 +533,7 @@ Slice::DocComment::parseFrom(const ContainedPtr& p, DocLinkFormatter linkFormatt
             {
                 // Check that the '@param <name>' corresponds to an actual parameter in the operation.
                 const ParameterList params = operationTarget->parameters();
-                const auto paramNameCheck = [&name](const ParameterPtr& p) { return p->name() == name; };
+                const auto paramNameCheck = [&name](const ParameterPtr& param) { return param->name() == name; };
                 if (std::find_if(params.begin(), params.end(), paramNameCheck) == params.end())
                 {
                     const string msg = "'" + paramTag + " " + name +

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -582,7 +582,7 @@ Slice::DocComment::parseFrom(const ContainedPtr& p, DocLinkFormatter linkFormatt
                 {
                     // ... and matches one of the exceptions in the operation's specification.
                     const ExceptionList exceptionSpec = operationTarget->throws();
-                    const auto exceptionCheck = [&name, &exceptionTarget](const ExceptionPtr& ex)
+                    const auto exceptionCheck = [&exceptionTarget](const ExceptionPtr& ex)
                     { return ex->isBaseOf(exceptionTarget) || ex->scoped() == exceptionTarget->scoped(); };
                     if (std::find_if(exceptionSpec.begin(), exceptionSpec.end(), exceptionCheck) == exceptionSpec.end())
                     {

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.err
@@ -7,11 +7,11 @@ WarningInvalidComment.ice:17: warning: ignoring trailing '.' character in '@see'
 WarningInvalidComment.ice:40: warning: '@param NoParam' does not correspond to any parameter in operation 'voidOp'
 WarningInvalidComment.ice:40: warning: '@return' is only valid on operations with non-void return types
 WarningInvalidComment.ice:40: warning: '@throws FakeException': no exception with this name could be found from the current scope
-WarningInvalidComment.ice:40: warning: '@throws CommentDummy': this exception is not listed in nor derived from any exception in this operation's specification
+WarningInvalidComment.ice:40: warning: '@throws CommentDummy': this exception is not listed in nor derived from any exception in this operation'sq specification
 WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@param value'
 WarningInvalidComment.ice:51: warning: '@param namess' does not correspond to any parameter in operation 'stringOp'
 WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@return'
-WarningInvalidComment.ice:51: warning: '@throws SomeOtherException': this exception is not listed in nor derived from any exception in this operation's specification
+WarningInvalidComment.ice:51: warning: '@throws SomeOtherException': this exception is not listed in nor derived from any exception in this operation'sq specification
 WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@throws CommentDummy'
 WarningInvalidComment.ice:26: warning: ignoring unknown doc tag '@remark' in comment
 WarningInvalidComment.ice:26: warning: '@see' tags cannot span multiple lines and must be of the form: '@see identifier'
@@ -20,9 +20,9 @@ WarningInvalidComment.ice:30: warning: ignoring duplicate doc-comment tag: '@dep
 WarningInvalidComment.ice:40: warning: '@param NoParam' does not correspond to any parameter in operation 'voidOp'
 WarningInvalidComment.ice:40: warning: '@return' is only valid on operations with non-void return types
 WarningInvalidComment.ice:40: warning: '@throws FakeException': no exception with this name could be found from the current scope
-WarningInvalidComment.ice:40: warning: '@throws CommentDummy': this exception is not listed in nor derived from any exception in this operation's specification
+WarningInvalidComment.ice:40: warning: '@throws CommentDummy': this exception is not listed in nor derived from any exception in this operation'sq specification
 WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@param value'
 WarningInvalidComment.ice:51: warning: '@param namess' does not correspond to any parameter in operation 'stringOp'
 WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@return'
-WarningInvalidComment.ice:51: warning: '@throws SomeOtherException': this exception is not listed in nor derived from any exception in this operation's specification
+WarningInvalidComment.ice:51: warning: '@throws SomeOtherException': this exception is not listed in nor derived from any exception in this operation'sq specification
 WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@throws CommentDummy'

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.err
@@ -7,11 +7,11 @@ WarningInvalidComment.ice:17: warning: ignoring trailing '.' character in '@see'
 WarningInvalidComment.ice:40: warning: '@param NoParam' does not correspond to any parameter in operation 'voidOp'
 WarningInvalidComment.ice:40: warning: '@return' is only valid on operations with non-void return types
 WarningInvalidComment.ice:40: warning: '@throws FakeException': no exception with this name could be found from the current scope
-WarningInvalidComment.ice:40: warning: '@throws CommentDummy': this exception is not listed in (or a sub-exception of) this operation's exception specification
+WarningInvalidComment.ice:40: warning: '@throws CommentDummy': this exception is not listed in nor derived from any exception in this operation's specification
 WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@param value'
 WarningInvalidComment.ice:51: warning: '@param namess' does not correspond to any parameter in operation 'stringOp'
 WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@return'
-WarningInvalidComment.ice:51: warning: '@throws SomeOtherException': this exception is not listed in (or a sub-exception of) this operation's exception specification
+WarningInvalidComment.ice:51: warning: '@throws SomeOtherException': this exception is not listed in nor derived from any exception in this operation's specification
 WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@throws CommentDummy'
 WarningInvalidComment.ice:26: warning: ignoring unknown doc tag '@remark' in comment
 WarningInvalidComment.ice:26: warning: '@see' tags cannot span multiple lines and must be of the form: '@see identifier'
@@ -20,9 +20,9 @@ WarningInvalidComment.ice:30: warning: ignoring duplicate doc-comment tag: '@dep
 WarningInvalidComment.ice:40: warning: '@param NoParam' does not correspond to any parameter in operation 'voidOp'
 WarningInvalidComment.ice:40: warning: '@return' is only valid on operations with non-void return types
 WarningInvalidComment.ice:40: warning: '@throws FakeException': no exception with this name could be found from the current scope
-WarningInvalidComment.ice:40: warning: '@throws CommentDummy': this exception is not listed in (or a sub-exception of) this operation's exception specification
+WarningInvalidComment.ice:40: warning: '@throws CommentDummy': this exception is not listed in nor derived from any exception in this operation's specification
 WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@param value'
 WarningInvalidComment.ice:51: warning: '@param namess' does not correspond to any parameter in operation 'stringOp'
 WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@return'
-WarningInvalidComment.ice:51: warning: '@throws SomeOtherException': this exception is not listed in (or a sub-exception of) this operation's exception specification
+WarningInvalidComment.ice:51: warning: '@throws SomeOtherException': this exception is not listed in nor derived from any exception in this operation's specification
 WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@throws CommentDummy'

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.err
@@ -7,11 +7,11 @@ WarningInvalidComment.ice:17: warning: ignoring trailing '.' character in '@see'
 WarningInvalidComment.ice:40: warning: '@param NoParam' does not correspond to any parameter in operation 'voidOp'
 WarningInvalidComment.ice:40: warning: '@return' is only valid on operations with non-void return types
 WarningInvalidComment.ice:40: warning: '@throws FakeException': no exception with this name could be found from the current scope
-WarningInvalidComment.ice:40: warning: '@throws CommentDummy': this exception is not listed in nor derived from any exception in this operation'sq specification
+WarningInvalidComment.ice:40: warning: '@throws CommentDummy': this exception is not listed in nor derived from any exception in this operation's specification
 WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@param value'
 WarningInvalidComment.ice:51: warning: '@param namess' does not correspond to any parameter in operation 'stringOp'
 WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@return'
-WarningInvalidComment.ice:51: warning: '@throws SomeOtherException': this exception is not listed in nor derived from any exception in this operation'sq specification
+WarningInvalidComment.ice:51: warning: '@throws SomeOtherException': this exception is not listed in nor derived from any exception in this operation's specification
 WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@throws CommentDummy'
 WarningInvalidComment.ice:26: warning: ignoring unknown doc tag '@remark' in comment
 WarningInvalidComment.ice:26: warning: '@see' tags cannot span multiple lines and must be of the form: '@see identifier'
@@ -20,9 +20,9 @@ WarningInvalidComment.ice:30: warning: ignoring duplicate doc-comment tag: '@dep
 WarningInvalidComment.ice:40: warning: '@param NoParam' does not correspond to any parameter in operation 'voidOp'
 WarningInvalidComment.ice:40: warning: '@return' is only valid on operations with non-void return types
 WarningInvalidComment.ice:40: warning: '@throws FakeException': no exception with this name could be found from the current scope
-WarningInvalidComment.ice:40: warning: '@throws CommentDummy': this exception is not listed in nor derived from any exception in this operation'sq specification
+WarningInvalidComment.ice:40: warning: '@throws CommentDummy': this exception is not listed in nor derived from any exception in this operation's specification
 WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@param value'
 WarningInvalidComment.ice:51: warning: '@param namess' does not correspond to any parameter in operation 'stringOp'
 WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@return'
-WarningInvalidComment.ice:51: warning: '@throws SomeOtherException': this exception is not listed in nor derived from any exception in this operation'sq specification
+WarningInvalidComment.ice:51: warning: '@throws SomeOtherException': this exception is not listed in nor derived from any exception in this operation's specification
 WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@throws CommentDummy'

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.err
@@ -4,6 +4,25 @@ WarningInvalidComment.ice:11: warning: the '@exception' tag is only valid on ope
 WarningInvalidComment.ice:11: warning: the '@return' tag is only valid on operations
 WarningInvalidComment.ice:15: warning: missing link target after '@see' tag
 WarningInvalidComment.ice:17: warning: ignoring trailing '.' character in '@see' tag
+WarningInvalidComment.ice:40: warning: '@param NoParam' does not correspond to any parameter in operation 'voidOp'
+WarningInvalidComment.ice:40: warning: '@return' is only valid on operations with non-void return types
+WarningInvalidComment.ice:40: warning: '@throws FakeException': no exception with this name could be found from the current scope
+WarningInvalidComment.ice:40: warning: '@throws CommentDummy': this exception is not listed in (or a sub-exception of) this operation's exception specification
+WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@param value'
+WarningInvalidComment.ice:51: warning: '@param namess' does not correspond to any parameter in operation 'stringOp'
+WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@return'
+WarningInvalidComment.ice:51: warning: '@throws SomeOtherException': this exception is not listed in (or a sub-exception of) this operation's exception specification
+WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@throws CommentDummy'
 WarningInvalidComment.ice:26: warning: ignoring unknown doc tag '@remark' in comment
 WarningInvalidComment.ice:26: warning: '@see' tags cannot span multiple lines and must be of the form: '@see identifier'
 WarningInvalidComment.ice:26: warning: ignoring unknown doc tag '@bad' in comment
+WarningInvalidComment.ice:30: warning: ignoring duplicate doc-comment tag: '@deprecated'
+WarningInvalidComment.ice:40: warning: '@param NoParam' does not correspond to any parameter in operation 'voidOp'
+WarningInvalidComment.ice:40: warning: '@return' is only valid on operations with non-void return types
+WarningInvalidComment.ice:40: warning: '@throws FakeException': no exception with this name could be found from the current scope
+WarningInvalidComment.ice:40: warning: '@throws CommentDummy': this exception is not listed in (or a sub-exception of) this operation's exception specification
+WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@param value'
+WarningInvalidComment.ice:51: warning: '@param namess' does not correspond to any parameter in operation 'stringOp'
+WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@return'
+WarningInvalidComment.ice:51: warning: '@throws SomeOtherException': this exception is not listed in (or a sub-exception of) this operation's exception specification
+WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@throws CommentDummy'

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.ice
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.ice
@@ -23,5 +23,31 @@ module Test
     ///       But then we write a 2nd line, which isn't allowed for 'see' tags.
     /// @bad: Another unknown comment tag, but this will span 2 lines.
     ///       This 2nd line should be ignored, but won't trigger another error.
-    class CommentDummy {}
+    exception CommentDummy {}
+
+    /// @deprecated Message1
+    /// @deprecated Message2
+    exception DerivedFromDummy extends CommentDummy {}
+
+    exception SomeOtherException {}
+
+    interface MyInterface
+    {
+        /// @param NoParam should give a no-matching-parameter warning.
+        /// @return Nothing because it's void.
+        /// @throws FakeException should give a not-an-exception warning.
+        /// @throws CommentDummy should give a not-thrown-by-this-operation warning.
+        void voidOp();
+
+        /// @param value no warning, because this ia a real parameter.
+        /// @param value should give a duplicate-tag warning.
+        /// @param namess should give a no-matching-parameter warning.
+        /// @return Something because it's non-void.
+        /// @return Should give a duplicate-tag warning.
+        /// @throws DerivedFromDummy should be fine, since this is a sub-exception of `CommentDummy`.
+        /// @throws CommentDummy should be fine, this matches the exception specification.
+        /// @throws SomeOtherException should give a not-thrown-by-this-operation warning.
+        /// @throws CommentDummy should give a duplicate-tag warning.
+        string stringOp(string name, int value) throws CommentDummy;
+    }
 }


### PR DESCRIPTION
This PR finishes implementing #2998.

Now the parser will:
- reject `@param foo` if `foo` isn't the name of an operation parameter
- reject `@return` if it's applied to a `void `operation
- reject `@throws Foo` if `Foo` isn't in it's exception specific (or derived from an exception that is)

We also now reject duplicate tags.
So a comment can't have more than one `@deprecated`, or more than one `@return`.
And for 'named' tags, you can't use the same name more than once either.
```
@param foo this is totally fine (if you have a parameter named `foo`)
@param Foo this will be rejected, because you already did `@param foo`.
@param bar totally fine because it's a different name.
```