### PR TITLE
Changing rewriteDryRun to *not* fail by default. 

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -14,8 +14,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup C++
+        uses: ./.github/actions/setup-cpp
+
       - name: Setup Java
         uses: ./.github/actions/setup-java
+
+      - name: Build slice2java
+        run: make -C cpp slice2java
 
       - name: Run rewriteDryRun with build failure enabled
         run: ./java/gradlew rewriteDryRun -PenableDryRunFail --project-dir ./java/

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -18,4 +18,4 @@ jobs:
         uses: ./.github/actions/setup-java
 
       - name: Run rewriteDryRun with build failure enabled
-        uses: ./java/gradlew rewriteDryRun -PenableDryRunFail
+        run: ./java/gradlew rewriteDryRun -PenableDryRunFail

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -24,4 +24,5 @@ jobs:
         run: make -C cpp slice2java
 
       - name: Run rewriteDryRun with build failure enabled
-        run: ./java/gradlew rewriteDryRun -PenableDryRunFail -PenableCops --project-dir ./java/
+        working-directory: java
+        run: ./java/gradlew rewriteDryRun -PenableCops -PfailOnDryRunResults

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       - name: Setup Java
         uses: ./.github/actions/setup-java
 

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -11,6 +11,9 @@ jobs:
   rewriteCatch:
     runs-on: ubuntu-24.04
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
       - name: Setup Java
         uses: ./.github/actions/setup-java
 

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -18,4 +18,4 @@ jobs:
         uses: ./.github/actions/setup-java
 
       - name: Run rewriteDryRun with build failure enabled
-        run: ./java/gradlew rewriteDryRun -PenableDryRunFail
+        run: cd java | ./gradlew rewriteDryRun -PenableDryRunFail | cd ..

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -25,4 +25,4 @@ jobs:
 
       - name: Run rewriteDryRun with build failure enabled
         working-directory: java
-        run: ./gradlew rewriteDryRun -PenableCops -PfailOnDryRunResults
+        run: ./gradlew rewriteDryRun -PenableCodeAnalysis=true

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -1,0 +1,18 @@
+name: Java
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: ["main"]
+
+jobs:
+  rewriteCatch:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Setup Java
+        uses: ./.github/actions/setup-java
+
+      - name: Run rewriteDryRun with build failure enabled
+        uses: ./java/gradlew rewriteDryRun -PenableDryRunFail

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -18,4 +18,4 @@ jobs:
         uses: ./.github/actions/setup-java
 
       - name: Run rewriteDryRun with build failure enabled
-        run: cd java | ./gradlew rewriteDryRun -PenableDryRunFail | cd ..
+        run: ./java/gradlew rewriteDryRun -PenableDryRunFail --project-dir ./java/

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -25,4 +25,4 @@ jobs:
 
       - name: Run rewriteDryRun with build failure enabled
         working-directory: java
-        run: ./java/gradlew rewriteDryRun -PenableCops -PfailOnDryRunResults
+        run: ./gradlew rewriteDryRun -PenableCops -PfailOnDryRunResults

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -24,4 +24,4 @@ jobs:
         run: make -C cpp slice2java
 
       - name: Run rewriteDryRun with build failure enabled
-        run: ./java/gradlew rewriteDryRun -PenableDryRunFail --project-dir ./java/
+        run: ./java/gradlew rewriteDryRun -PenableDryRunFail -PenableCops --project-dir ./java/

--- a/cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/BUILDING.md
+++ b/cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/BUILDING.md
@@ -25,3 +25,4 @@ This task is packaged with the Ice for C++ `ZeroC.Ice.Cpp` NuGet package. Refer 
 [build instructions][cpp-building] for more information.
 
 [cpp-building]: ../../BUILDING.md
+   

--- a/cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/BUILDING.md
+++ b/cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/BUILDING.md
@@ -25,4 +25,3 @@ This task is packaged with the Ice for C++ `ZeroC.Ice.Cpp` NuGet package. Refer 
 [build instructions][cpp-building] for more information.
 
 [cpp-building]: ../../BUILDING.md
-   

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -155,7 +155,6 @@ tasks.named('rewriteDryRun') {
     task ->
         task.enabled = project.hasProperty("enableCops")
     rewrite.failOnDryRunResults = project.hasProperty("failOnDryRunResults")
-    
 }
 
 tasks.named('rewriteRun') {

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -47,7 +47,13 @@ subprojects {
     }
 
     // We want Checkstyle to generally run after Rewrite and to exclude files generated from Slice.
+    // You need to use -PenableCops to be able to invoke the checkstyle, rewriteRun, and rewriteDryRun tasks
+    // The tasks still need to be manually called if nothing else invokes them.
     tasks.withType(Checkstyle) {
+        task ->
+            if (!project.hasProperty("enableCops")) {
+                task.enabled = false 
+            }
         dependsOn(rewriteDryRun)
         exclude(
             '**/generated/**'
@@ -145,9 +151,21 @@ dependencies {
 }
 
 // Use -PenableDryRunFail in the command line to enable failing the project during any operation with rewriteDryRun.
-task rewriteDryRunFailable {
+// You need to use -PenableCops to be able to invoke the checkstyle, rewriteRun, and rewriteDryRun tasks.
+// The tasks still need to be manually called if nothing else invokes them.
+tasks.named('rewriteDryRun') {
+    task ->
+        if (!project.hasProperty("enableCops")) {
+            task.enabled = false
+        }
     if (project.hasProperty("enableDryRunFail")) {
         rewrite.failOnDryRunResults = true
     }
-    finalizedBy rewriteDryRun
+}
+
+tasks.named('rewriteRun') {
+    task ->
+        if (!project.hasProperty("enableCops")) {
+            task.enabled = false
+        }
 }

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -144,9 +144,9 @@ dependencies {
     )
 }
 
-// Use -PdryRunFailSkip in the command line to avoid failing the project during an OpenRewrite dryRun.
+// Use -PenableDryRunFail in the command line to enable failing the project during any operation with rewriteDryRun.
 task rewriteDryRunFailable {
-    if (!project.hasProperty("dryRunFailSkip")) {
+    if (project.hasProperty("enableDryRunFail")) {
         rewrite.failOnDryRunResults = true
     }
     finalizedBy rewriteDryRun

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -51,9 +51,7 @@ subprojects {
     // The tasks still need to be manually called if nothing else invokes them.
     tasks.withType(Checkstyle) {
         task ->
-            if (!project.hasProperty("enableCops")) {
-                task.enabled = false
-            }
+            task.enabled = project.hasProperty("enableCops")
         dependsOn(rewriteDryRun)
         exclude(
             '**/generated/**'
@@ -150,22 +148,17 @@ dependencies {
     )
 }
 
-// Use -PenableDryRunFail in the command line to enable failing the project during any operation with rewriteDryRun.
+// Use -PfailOnDryRunResults in the command line to enable failing the project during any operation with rewriteDryRun.
 // You need to use -PenableCops to be able to invoke the checkstyle, rewriteRun, and rewriteDryRun tasks.
 // The tasks still need to be manually called if nothing else invokes them.
 tasks.named('rewriteDryRun') {
     task ->
-        if (!project.hasProperty("enableCops")) {
-            task.enabled = false
-        }
-    if (project.hasProperty("enableDryRunFail")) {
-        rewrite.failOnDryRunResults = true
-    }
+        task.enabled = project.hasProperty("enableCops")
+    rewrite.failOnDryRunResults = project.hasProperty("failOnDryRunResults")
+    
 }
 
 tasks.named('rewriteRun') {
     task ->
-        if (!project.hasProperty("enableCops")) {
-            task.enabled = false
-        }
+        task.enabled = project.hasProperty("enableCops")
 }

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -52,7 +52,7 @@ subprojects {
     tasks.withType(Checkstyle) {
         task ->
             if (!project.hasProperty("enableCops")) {
-                task.enabled = false 
+                task.enabled = false
             }
         dependsOn(rewriteDryRun)
         exclude(

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -12,6 +12,9 @@ allprojects {
     }
 }
 
+// Defines and initializes enableCodeAnalysis to the corresponding property in gradle.properties.
+def enableCodeAnalysis = project.property('enableCodeAnalysis').toBoolean()
+
 subprojects {
     project.ext.topSrcDir = "$rootProject.projectDir/.."
 
@@ -47,11 +50,11 @@ subprojects {
     }
 
     // We want Checkstyle to generally run after Rewrite and to exclude files generated from Slice.
-    // You need to use -PenableCops to be able to invoke the checkstyle, rewriteRun, and rewriteDryRun tasks
+    // You need to use -PenableCodeAnalysis to be able to invoke the checkstyle, rewriteRun, and rewriteDryRun tasks
     // The tasks still need to be manually called if nothing else invokes them.
     tasks.withType(Checkstyle) {
         task ->
-            task.enabled = project.hasProperty("enableCops")
+            task.enabled = enableCodeAnalysis
         dependsOn(rewriteDryRun)
         exclude(
             '**/generated/**'
@@ -148,16 +151,17 @@ dependencies {
     )
 }
 
-// Use -PfailOnDryRunResults in the command line to enable failing the project during any operation with rewriteDryRun.
-// You need to use -PenableCops to be able to invoke the checkstyle, rewriteRun, and rewriteDryRun tasks.
+// You need to use -PenableCodeAnalysis to be able to invoke the checkstyle, rewriteRun, and rewriteDryRun tasks.
 // The tasks still need to be manually called if nothing else invokes them.
 tasks.named('rewriteDryRun') {
     task ->
-        task.enabled = project.hasProperty("enableCops")
-    rewrite.failOnDryRunResults = project.hasProperty("failOnDryRunResults")
+        task.enabled = enableCodeAnalysis
+    project.logger.lifecycle(enableCodeAnalysis.toString())
+    project.logger.lifecycle(task.enabled.toString())
+    rewrite.failOnDryRunResults = true
 }
 
 tasks.named('rewriteRun') {
     task ->
-        task.enabled = project.hasProperty("enableCops")
+        task.enabled = enableCodeAnalysis
 }

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -156,8 +156,6 @@ dependencies {
 tasks.named('rewriteDryRun') {
     task ->
         task.enabled = enableCodeAnalysis
-    project.logger.lifecycle(enableCodeAnalysis.toString())
-    project.logger.lifecycle(task.enabled.toString())
     rewrite.failOnDryRunResults = true
 }
 

--- a/java/gradle.properties
+++ b/java/gradle.properties
@@ -50,3 +50,7 @@ DESTDIR =
 
 # More heap!
 org.gradle.jvmargs = -Xmx1024m
+
+# Changes whether a set of code analysis tasks are enabled. This should be set to false by default.
+# This set includes rewriteRun, rewriteDryRun, and checkstyle.
+enableCodeAnalysis = false


### PR DESCRIPTION
This PR inverts the behavior of `rewriteDryRun` in regards to failing. Now, `gradlew rewriteDryRun` will **not** cause a build failure. Instead, to cause it to fail while building, one must invoke `-PenableDryRunFail`. CI builds should still fail when OpenRewrite would make changes.