### PR TITLE
PIP and GEM build fixes

### DIFF
--- a/cpp/src/IceDiscovery/LookupI.h
+++ b/cpp/src/IceDiscovery/LookupI.h
@@ -6,7 +6,7 @@
 #include "../Ice/Timer.h"
 #include "Ice/Properties.h"
 #include "LocatorI.h"
-#include "Lookup.h"
+#include "./generated/Lookup.h"
 
 #include <chrono>
 #include <set>

--- a/cpp/src/IceLocatorDiscovery/PluginI.cpp
+++ b/cpp/src/IceLocatorDiscovery/PluginI.cpp
@@ -4,7 +4,7 @@
 #include "../Ice/Timer.h"
 #include "Ice/LoggerUtil.h"
 #include "IceLocatorDiscovery/IceLocatorDiscovery.h"
-#include "Lookup.h"
+#include "./generated/Lookup.h"
 #include "Plugin.h"
 
 #include <algorithm>

--- a/python/setup.py
+++ b/python/setup.py
@@ -34,7 +34,9 @@ ice_cpp_sources = [
     "../cpp/src/IceLocatorDiscovery",
     "../cpp/src/slice2py",
     "../cpp/src/Slice",
-    "../cpp/include/Ice"]
+    "../cpp/include/Ice",
+    "../cpp/include/IceDiscovery",
+    "../cpp/include/IceLocatorDiscovery",]
 
 # Include directories for the build process
 include_dirs = [
@@ -48,15 +50,10 @@ if sys.platform == 'win32':
     ice_cpp_sources.append(f"../cpp/include/generated/{platform}/{configuration}/Ice")
     include_dirs.extend([
         f"dist/ice/cpp/include/generated/{platform}/{configuration}",
-        f"dist/ice/cpp/src/IceDiscovery/msbuild/icediscovery/{platform}/{configuration}",
-        f"dist/ice/cpp/src/IceLocatorDiscovery/msbuild/icelocatordiscovery/{platform}/{configuration}",
         f"dist/bzip2-{bzip2_version}"])
 else:
     ice_cpp_sources.append("../cpp/include/generated/Ice")
-    include_dirs.extend([
-        "dist/ice/cpp/include/generated",
-        "dist/ice/cpp/src/IceDiscovery/generated",
-        "dist/ice/cpp/src/IceLocatorDiscovery/generated"])
+    include_dirs.extend(["dist/ice/cpp/include/generated"])
 
 # Define macros used during the build process
 # All the /**/ macros are necessary only on Windows

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -59,7 +59,9 @@ task :generate_sources do
         "../cpp/src/Slice",
         "../cpp/include/Ice",
         "../cpp/include/Ice/SSL",
-        "../cpp/include/generated/Ice"]
+        "../cpp/include/generated/Ice",
+        "../cpp/include/IceDiscovery",
+        "../cpp/include/IceLocatorDiscovery",]
 
     for source_dir in ice_cpp_sources do
         Dir.foreach(source_dir) do |entry|

--- a/ruby/extconf.rb
+++ b/ruby/extconf.rb
@@ -28,8 +28,6 @@ $INCFLAGS << ' -Idist/ice/cpp/include'
 $INCFLAGS << ' -Idist/ice/cpp/include/generated'
 $INCFLAGS << ' -Idist/ice/cpp/src'
 $INCFLAGS << ' -Idist/ice/cpp/src/Ice/generated'
-$INCFLAGS << ' -Idist/ice/cpp/src/IceDiscovery/generated'
-$INCFLAGS << ' -Idist/ice/cpp/src/IceLocatorDiscovery/generated'
 
 $CPPFLAGS << ' -w'
 


### PR DESCRIPTION
This PR fixes the build of PIP and GEM packages. The build was failing due to not include the new IceDiscovery and IceLocatorDiscovery headers.