### PR TITLE
Fixes for GEM and PIP build failures

### DIFF
--- a/cpp/src/IceDiscovery/LookupI.h
+++ b/cpp/src/IceDiscovery/LookupI.h
@@ -5,8 +5,8 @@
 
 #include "../Ice/Timer.h"
 #include "Ice/Properties.h"
+#include "IceDiscovery/Lookup.h"
 #include "LocatorI.h"
-#include "Lookup.h"
 
 #include <chrono>
 #include <set>

--- a/cpp/src/IceDiscovery/Makefile.mk
+++ b/cpp/src/IceDiscovery/Makefile.mk
@@ -4,6 +4,8 @@ $(project)_libraries := IceDiscovery
 
 # Tell the slice2cpp rule to ignore the top-level IceDiscovery include directory.
 IceDiscovery_includedir                 := $(project)/generated/IceDiscovery
+$(project)_generated_srcdir             := $(project)/generated/IceDiscovery
+$(project)_generated_includedir         := $(project)/generated/IceDiscovery
 
 IceDiscovery_targetdir                  := $(libdir)
 IceDiscovery_dependencies               := Ice

--- a/cpp/src/IceDiscovery/msbuild/icediscovery/icediscovery.vcxproj
+++ b/cpp/src/IceDiscovery/msbuild/icediscovery/icediscovery.vcxproj
@@ -93,31 +93,33 @@
     <ResourceCompile Include="..\..\IceDiscovery.rc" />
   </ItemGroup>
   <ItemGroup>
-    <SliceCompile Include="..\..\..\..\..\slice\IceDiscovery\Lookup.ice" />
+    <SliceCompile Include="..\..\..\..\..\slice\IceDiscovery\Lookup.ice">
+      <OutputDir>$(IntDir)IceDiscovery</OutputDir>
+    </SliceCompile>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\LocatorI.cpp" />
     <ClCompile Include="..\..\LookupI.cpp" />
     <ClCompile Include="..\..\PluginI.cpp" />
-    <ClCompile Include="Win32\Debug\Lookup.cpp">
+    <ClCompile Include="Win32\Debug\IceDiscovery\Lookup.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\..\slice\IceDiscovery\Lookup.ice</SliceCompileSource>
     </ClCompile>
-    <ClCompile Include="Win32\Release\Lookup.cpp">
+    <ClCompile Include="Win32\Release\IceDiscovery\Lookup.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\..\slice\IceDiscovery\Lookup.ice</SliceCompileSource>
     </ClCompile>
-    <ClCompile Include="x64\Debug\Lookup.cpp">
+    <ClCompile Include="x64\Debug\IceDiscovery\Lookup.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\..\slice\IceDiscovery\Lookup.ice</SliceCompileSource>
     </ClCompile>
-    <ClCompile Include="x64\Release\Lookup.cpp">
+    <ClCompile Include="x64\Release\IceDiscovery\Lookup.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
@@ -128,25 +130,25 @@
     <ClInclude Include="..\..\LocatorI.h" />
     <ClInclude Include="..\..\LookupI.h" />
     <ClInclude Include="..\..\PluginI.h" />
-    <ClInclude Include="Win32\Debug\Lookup.h">
+    <ClInclude Include="Win32\Debug\IceDiscovery\Lookup.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\..\slice\IceDiscovery\Lookup.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\Lookup.h">
+    <ClInclude Include="Win32\Release\IceDiscovery\Lookup.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\..\slice\IceDiscovery\Lookup.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\Lookup.h">
+    <ClInclude Include="x64\Debug\IceDiscovery\Lookup.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\..\slice\IceDiscovery\Lookup.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\Lookup.h">
+    <ClInclude Include="x64\Release\IceDiscovery\Lookup.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>

--- a/cpp/src/IceDiscovery/msbuild/icediscovery/icediscovery.vcxproj.filters
+++ b/cpp/src/IceDiscovery/msbuild/icediscovery/icediscovery.vcxproj.filters
@@ -64,16 +64,16 @@
     <ClCompile Include="..\..\LocatorI.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Win32\Debug\Lookup.cpp">
+    <ClCompile Include="Win32\Debug\IceDiscovery\Lookup.cpp">
       <Filter>Source Files\Win32\Debug</Filter>
     </ClCompile>
-    <ClCompile Include="x64\Debug\Lookup.cpp">
+    <ClCompile Include="x64\Debug\IceDiscovery\Lookup.cpp">
       <Filter>Source Files\x64\Debug</Filter>
     </ClCompile>
-    <ClCompile Include="Win32\Release\Lookup.cpp">
+    <ClCompile Include="Win32\Release\IceDiscovery\Lookup.cpp">
       <Filter>Source Files\Win32\Release</Filter>
     </ClCompile>
-    <ClCompile Include="x64\Release\Lookup.cpp">
+    <ClCompile Include="x64\Release\IceDiscovery\Lookup.cpp">
       <Filter>Source Files\x64\Release</Filter>
     </ClCompile>
   </ItemGroup>
@@ -87,16 +87,16 @@
     <ClInclude Include="..\..\LocatorI.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="Win32\Debug\Lookup.h">
+    <ClInclude Include="Win32\Debug\IceDiscovery\Lookup.h">
       <Filter>Header Files\Win32\Debug</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Debug\Lookup.h">
+    <ClInclude Include="x64\Debug\IceDiscovery\Lookup.h">
       <Filter>Header Files\x64\Debug</Filter>
     </ClInclude>
-    <ClInclude Include="Win32\Release\Lookup.h">
+    <ClInclude Include="Win32\Release\IceDiscovery\Lookup.h">
       <Filter>Header Files\Win32\Release</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Release\Lookup.h">
+    <ClInclude Include="x64\Release\IceDiscovery\Lookup.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
   </ItemGroup>

--- a/cpp/src/IceLocatorDiscovery/Makefile.mk
+++ b/cpp/src/IceLocatorDiscovery/Makefile.mk
@@ -4,6 +4,8 @@ $(project)_libraries := IceLocatorDiscovery
 
 # Tell the slice2cpp rule to ignore the top-level IceLocatorDiscovery include directory.
 IceLocatorDiscovery_includedir                  := $(project)/generated/IceLocatorDiscovery
+$(project)_generated_srcdir                     := $(project)/generated/IceLocatorDiscovery
+$(project)_generated_includedir                 := $(project)/generated/IceLocatorDiscovery
 
 IceLocatorDiscovery_targetdir                   := $(libdir)
 IceLocatorDiscovery_dependencies                := Ice

--- a/cpp/src/IceLocatorDiscovery/PluginI.cpp
+++ b/cpp/src/IceLocatorDiscovery/PluginI.cpp
@@ -4,7 +4,7 @@
 #include "../Ice/Timer.h"
 #include "Ice/LoggerUtil.h"
 #include "IceLocatorDiscovery/IceLocatorDiscovery.h"
-#include "Lookup.h"
+#include "IceLocatorDiscovery/Lookup.h"
 #include "Plugin.h"
 
 #include <algorithm>

--- a/cpp/src/IceLocatorDiscovery/msbuild/icelocatordiscovery/icelocatordiscovery.vcxproj
+++ b/cpp/src/IceLocatorDiscovery/msbuild/icelocatordiscovery/icelocatordiscovery.vcxproj
@@ -94,25 +94,25 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\PluginI.cpp" />
-    <ClCompile Include="Win32\Debug\Lookup.cpp">
+    <ClCompile Include="Win32\Debug\IceLocatorDiscovery\Lookup.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\..\slice\IceLocatorDiscovery\Lookup.ice</SliceCompileSource>
     </ClCompile>
-    <ClCompile Include="Win32\Release\Lookup.cpp">
+    <ClCompile Include="Win32\Release\IceLocatorDiscovery\Lookup.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\..\slice\IceLocatorDiscovery\Lookup.ice</SliceCompileSource>
     </ClCompile>
-    <ClCompile Include="x64\Debug\Lookup.cpp">
+    <ClCompile Include="x64\Debug\IceLocatorDiscovery\Lookup.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\..\slice\IceLocatorDiscovery\Lookup.ice</SliceCompileSource>
     </ClCompile>
-    <ClCompile Include="x64\Release\Lookup.cpp">
+    <ClCompile Include="x64\Release\IceLocatorDiscovery\Lookup.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
@@ -121,25 +121,25 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Plugin.h" />
-    <ClInclude Include="Win32\Debug\Lookup.h">
+    <ClInclude Include="Win32\Debug\IceLocatorDiscovery\Lookup.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\..\slice\IceLocatorDiscovery\Lookup.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="Win32\Release\Lookup.h">
+    <ClInclude Include="Win32\Release\IceLocatorDiscovery\Lookup.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\..\slice\IceLocatorDiscovery\Lookup.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Debug\Lookup.h">
+    <ClInclude Include="x64\Debug\IceLocatorDiscovery\Lookup.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <SliceCompileSource>..\..\..\..\..\slice\IceLocatorDiscovery\Lookup.ice</SliceCompileSource>
     </ClInclude>
-    <ClInclude Include="x64\Release\Lookup.h">
+    <ClInclude Include="x64\Release\IceLocatorDiscovery\Lookup.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
@@ -147,7 +147,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <SliceCompile Include="..\..\..\..\..\slice\IceLocatorDiscovery\Lookup.ice" />
+    <SliceCompile Include="..\..\..\..\..\slice\IceLocatorDiscovery\Lookup.ice">
+      <OutputDir>$(IntDir)\IceLocatorDiscovery</OutputDir>
+    </SliceCompile>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />

--- a/cpp/src/IceLocatorDiscovery/msbuild/icelocatordiscovery/icelocatordiscovery.vcxproj.filters
+++ b/cpp/src/IceLocatorDiscovery/msbuild/icelocatordiscovery/icelocatordiscovery.vcxproj.filters
@@ -2,16 +2,16 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="..\..\PluginI.cpp" />
-    <ClCompile Include="Win32\Debug\Lookup.cpp">
+    <ClCompile Include="Win32\Debug\IceLocatorDiscovery\Lookup.cpp">
       <Filter>Source Files\Win32\Debug</Filter>
     </ClCompile>
-    <ClCompile Include="x64\Debug\Lookup.cpp">
+    <ClCompile Include="x64\Debug\IceLocatorDiscovery\Lookup.cpp">
       <Filter>Source Files\x64\Debug</Filter>
     </ClCompile>
-    <ClCompile Include="Win32\Release\Lookup.cpp">
+    <ClCompile Include="Win32\Release\IceLocatorDiscovery\Lookup.cpp">
       <Filter>Source Files\Win32\Release</Filter>
     </ClCompile>
-    <ClCompile Include="x64\Release\Lookup.cpp">
+    <ClCompile Include="x64\Release\IceLocatorDiscovery\Lookup.cpp">
       <Filter>Source Files\x64\Release</Filter>
     </ClCompile>
   </ItemGroup>
@@ -20,16 +20,16 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Plugin.h" />
-    <ClInclude Include="Win32\Debug\Lookup.h">
+    <ClInclude Include="Win32\Debug\IceLocatorDiscovery\Lookup.h">
       <Filter>Header Files\Win32\Debug</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Debug\Lookup.h">
+    <ClInclude Include="x64\Debug\IceLocatorDiscovery\Lookup.h">
       <Filter>Header Files\x64\Debug</Filter>
     </ClInclude>
-    <ClInclude Include="Win32\Release\Lookup.h">
+    <ClInclude Include="Win32\Release\IceLocatorDiscovery\Lookup.h">
       <Filter>Header Files\Win32\Release</Filter>
     </ClInclude>
-    <ClInclude Include="x64\Release\Lookup.h">
+    <ClInclude Include="x64\Release\IceLocatorDiscovery\Lookup.h">
       <Filter>Header Files\x64\Release</Filter>
     </ClInclude>
   </ItemGroup>

--- a/python/setup.py
+++ b/python/setup.py
@@ -34,7 +34,9 @@ ice_cpp_sources = [
     "../cpp/src/IceLocatorDiscovery",
     "../cpp/src/slice2py",
     "../cpp/src/Slice",
-    "../cpp/include/Ice"]
+    "../cpp/include/Ice",
+    "../cpp/include/IceDiscovery",
+    "../cpp/include/IceLocatorDiscovery",]
 
 # Include directories for the build process
 include_dirs = [

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -52,14 +52,16 @@ task :generate_sources do
         "../cpp/src/Ice/generated",
         "../cpp/src/Ice/SSL",
         "../cpp/src/IceDiscovery",
-        "../cpp/src/IceDiscovery/generated",
+        "../cpp/src/IceDiscovery/generated/IceDiscovery",
         "../cpp/src/IceLocatorDiscovery",
-        "../cpp/src/IceLocatorDiscovery/generated",
+        "../cpp/src/IceLocatorDiscovery/generated/IceLocatorDiscovery",
         "../cpp/src/slice2rb",
         "../cpp/src/Slice",
         "../cpp/include/Ice",
         "../cpp/include/Ice/SSL",
-        "../cpp/include/generated/Ice"]
+        "../cpp/include/generated/Ice",
+        "../cpp/include/IceDiscovery",
+        "../cpp/include/IceLocatorDiscovery",]
 
     for source_dir in ice_cpp_sources do
         Dir.foreach(source_dir) do |entry|


### PR DESCRIPTION
This PR fixes PIP and GEM build issues related to Lookup.h being available under both IceDiscovery and IceLocatorDiscovery. This is problematic because we build both in the same shared library and we end up with ambiguity of what header should be included.