### PR TITLE
Fix make install to install IceDiscovery and IceLocatorDiscovery

### DIFF
--- a/config/Make.project.rules
+++ b/config/Make.project.rules
@@ -397,6 +397,7 @@ $2_configs      := $$(filter $(configs) $$($2_always_enable_configs),$$(call uni
 
 # Install files necessary for development.
 $2_devinstall   := $$(call var-with-default,$2_devinstall,yes)
+$2_install_generated_headers := $$(call var-with-default,$2_install_generated_headers,yes)
 
 # Set default target directory if we're not building the component, this is used
 # when building against the component binary distribution.
@@ -678,7 +679,7 @@ $2_distclean::
 ifeq ($$($2_devinstall),yes)
 ifneq ($$(and $$($2_components),$(filter library,$3),$$(filter $(includedir)/%,$$($2_includedir))),)
 $$(eval $$(call install-data-files,$$(wildcard $$($2_includedir)/*.h) $$(wildcard $$($2_includedir)/**/*.h),$(includedir),$(install_includedir),$2_install))
-ifneq ($$($2_do_not_install_generated_headers),yes)
+ifeq ($$($2_install_generated_headers),yes)
 ifneq ($$($2_generated_headers),)
 $$(eval $$(call install-data-files,$$($2_generated_headers),$(includedir)/generated,$(install_includedir),$2_install))
 endif

--- a/config/Make.project.rules
+++ b/config/Make.project.rules
@@ -678,8 +678,10 @@ $2_distclean::
 ifeq ($$($2_devinstall),yes)
 ifneq ($$(and $$($2_components),$(filter library,$3),$$(filter $(includedir)/%,$$($2_includedir))),)
 $$(eval $$(call install-data-files,$$(wildcard $$($2_includedir)/*.h) $$(wildcard $$($2_includedir)/**/*.h),$(includedir),$(install_includedir),$2_install))
+ifneq ($$($2_do_not_install_generated_headers),yes)
 ifneq ($$($2_generated_headers),)
 $$(eval $$(call install-data-files,$$($2_generated_headers),$(includedir)/generated,$(install_includedir),$2_install))
+endif
 endif
 endif
 endif

--- a/cpp/msbuild/ice.nuget.targets
+++ b/cpp/msbuild/ice.nuget.targets
@@ -34,9 +34,7 @@
                  Exclude="$(IceSrcRootDir)include\IceBT\*.h;
                           $(IceSrcRootDir)include\generated\**\*.h"/>
 
-        <Headers Include="$(IceSrcRootDir)include\generated\$(Platform)\$(Configuration)\**\*.h"
-                 Exclude="$(IceSrcRootDir)include\generated\$(Platform)\$(Configuration)\IceDiscovery\*.h;
-                          $(IceSrcRootDir)include\generated\$(Platform)\$(Configuration)\IceLocatorDiscovery\*.h"/>
+        <Headers Include="$(IceSrcRootDir)include\generated\$(Platform)\$(Configuration)\**\*.h"/>
 
         <Slices Include="$(IceSrcRootDir)..\slice\**\*.ice"
                 Exclude="$(IceSrcRootDir)..\slice\IceDiscovery\*.ice;

--- a/cpp/src/IceDiscovery/LookupI.h
+++ b/cpp/src/IceDiscovery/LookupI.h
@@ -5,8 +5,8 @@
 
 #include "../Ice/Timer.h"
 #include "Ice/Properties.h"
-#include "LocatorI.h"
 #include "IceDiscovery/Lookup.h"
+#include "LocatorI.h"
 
 #include <chrono>
 #include <set>

--- a/cpp/src/IceDiscovery/LookupI.h
+++ b/cpp/src/IceDiscovery/LookupI.h
@@ -6,7 +6,7 @@
 #include "../Ice/Timer.h"
 #include "Ice/Properties.h"
 #include "LocatorI.h"
-#include "Lookup.h"
+#include "IceDiscovery/Lookup.h"
 
 #include <chrono>
 #include <set>

--- a/cpp/src/IceDiscovery/Makefile.mk
+++ b/cpp/src/IceDiscovery/Makefile.mk
@@ -2,9 +2,9 @@
 
 $(project)_libraries := IceDiscovery
 
-# Tell the slice2cpp rule to ignore the top-level IceDiscovery include directory.
-IceDiscovery_includedir                 := $(project)/generated/IceDiscovery
+IceDiscovery_do_not_install_generated_headers := yes
 
+IceDiscovery_sliceflags                 := --include-dir IceDiscovery
 IceDiscovery_targetdir                  := $(libdir)
 IceDiscovery_dependencies               := Ice
 IceDiscovery_cppflags                   := -DICE_DISCOVERY_API_EXPORTS $(api_exports_cppflags)

--- a/cpp/src/IceDiscovery/Makefile.mk
+++ b/cpp/src/IceDiscovery/Makefile.mk
@@ -2,11 +2,11 @@
 
 $(project)_libraries := IceDiscovery
 
-IceDiscovery_do_not_install_generated_headers := yes
-
 IceDiscovery_sliceflags                 := --include-dir IceDiscovery
 IceDiscovery_targetdir                  := $(libdir)
 IceDiscovery_dependencies               := Ice
 IceDiscovery_cppflags                   := -DICE_DISCOVERY_API_EXPORTS $(api_exports_cppflags)
+
+IceDiscovery_install_generated_headers  := no
 
 projects += $(project)

--- a/cpp/src/IceDiscovery/msbuild/icediscovery/icediscovery.vcxproj
+++ b/cpp/src/IceDiscovery/msbuild/icediscovery/icediscovery.vcxproj
@@ -93,7 +93,10 @@
     <ResourceCompile Include="..\..\IceDiscovery.rc" />
   </ItemGroup>
   <ItemGroup>
-    <SliceCompile Include="..\..\..\..\..\slice\IceDiscovery\Lookup.ice" />
+    <SliceCompile Include="..\..\..\..\..\slice\IceDiscovery\Lookup.ice">
+      <HeaderOutputDir>$(IntDir)IceDiscovery</HeaderOutputDir>
+      <BaseDirectoryForGeneratedInclude>IceDiscovery</BaseDirectoryForGeneratedInclude>
+    </SliceCompile>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\LocatorI.cpp" />

--- a/cpp/src/IceLocatorDiscovery/Makefile.mk
+++ b/cpp/src/IceLocatorDiscovery/Makefile.mk
@@ -2,11 +2,11 @@
 
 $(project)_libraries := IceLocatorDiscovery
 
-IceLocatorDiscovery_do_not_install_generated_headers := yes
-
 IceLocatorDiscovery_sliceflags                  := --include-dir IceLocatorDiscovery
 IceLocatorDiscovery_targetdir                   := $(libdir)
 IceLocatorDiscovery_dependencies                := Ice
 IceLocatorDiscovery_cppflags                    := -DICE_LOCATOR_DISCOVERY_API_EXPORTS $(api_exports_cppflags)
+
+IceLocatorDiscovery_install_generated_headers   := no
 
 projects += $(project)

--- a/cpp/src/IceLocatorDiscovery/Makefile.mk
+++ b/cpp/src/IceLocatorDiscovery/Makefile.mk
@@ -2,9 +2,9 @@
 
 $(project)_libraries := IceLocatorDiscovery
 
-# Tell the slice2cpp rule to ignore the top-level IceLocatorDiscovery include directory.
-IceLocatorDiscovery_includedir                  := $(project)/generated/IceLocatorDiscovery
+IceLocatorDiscovery_do_not_install_generated_headers := yes
 
+IceLocatorDiscovery_sliceflags                  := --include-dir IceLocatorDiscovery
 IceLocatorDiscovery_targetdir                   := $(libdir)
 IceLocatorDiscovery_dependencies                := Ice
 IceLocatorDiscovery_cppflags                    := -DICE_LOCATOR_DISCOVERY_API_EXPORTS $(api_exports_cppflags)

--- a/cpp/src/IceLocatorDiscovery/PluginI.cpp
+++ b/cpp/src/IceLocatorDiscovery/PluginI.cpp
@@ -4,7 +4,7 @@
 #include "../Ice/Timer.h"
 #include "Ice/LoggerUtil.h"
 #include "IceLocatorDiscovery/IceLocatorDiscovery.h"
-#include "Lookup.h"
+#include "IceLocatorDiscovery/Lookup.h"
 #include "Plugin.h"
 
 #include <algorithm>

--- a/cpp/src/IceLocatorDiscovery/msbuild/icelocatordiscovery/icelocatordiscovery.vcxproj
+++ b/cpp/src/IceLocatorDiscovery/msbuild/icelocatordiscovery/icelocatordiscovery.vcxproj
@@ -147,7 +147,10 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <SliceCompile Include="..\..\..\..\..\slice\IceLocatorDiscovery\Lookup.ice" />
+    <SliceCompile Include="..\..\..\..\..\slice\IceLocatorDiscovery\Lookup.ice">
+      <HeaderOutputDir>$(IntDir)IceLocatorDiscovery</HeaderOutputDir>
+      <BaseDirectoryForGeneratedInclude>IceLocatorDiscovery</BaseDirectoryForGeneratedInclude>
+    </SliceCompile>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />


### PR DESCRIPTION
This PR fixes "make install" to install IceDiscovery/IceDiscovery.h and IceLocatorDiscovery/IceLocatorDiscovery.h.

This may fix #3866.

See also #3862. Maybe #3861 is more appropriate with this PR.