### PR TITLE
Fix PyPi build

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -34,7 +34,9 @@ ice_cpp_sources = [
     "../cpp/src/IceLocatorDiscovery",
     "../cpp/src/slice2py",
     "../cpp/src/Slice",
-    "../cpp/include/Ice"]
+    "../cpp/include/Ice",
+    "../cpp/include/IceDiscovery",
+    "../cpp/include/IceLocatorDiscovery"]
 
 # Include directories for the build process
 include_dirs = [
@@ -45,18 +47,19 @@ include_dirs = [
 
 # Platform-specific adjustments
 if sys.platform == 'win32':
-    ice_cpp_sources.append(f"../cpp/include/generated/{platform}/{configuration}/Ice")
+    ice_cpp_sources.extend([f"../cpp/include/generated/{platform}/{configuration}/Ice",
+                            f"../cpp/include/generated/{platform}/{configuration}/IceDiscovery",
+                            f"../cpp/include/generated/{platform}/{configuration}/IceLocatorDiscovery"])
     include_dirs.extend([
         f"dist/ice/cpp/include/generated/{platform}/{configuration}",
         f"dist/ice/cpp/src/IceDiscovery/msbuild/icediscovery/{platform}/{configuration}",
         f"dist/ice/cpp/src/IceLocatorDiscovery/msbuild/icelocatordiscovery/{platform}/{configuration}",
         f"dist/bzip2-{bzip2_version}"])
 else:
-    ice_cpp_sources.append("../cpp/include/generated/Ice")
-    include_dirs.extend([
-        "dist/ice/cpp/include/generated",
-        "dist/ice/cpp/src/IceDiscovery/generated",
-        "dist/ice/cpp/src/IceLocatorDiscovery/generated"])
+    ice_cpp_sources.extend(["../cpp/include/generated/Ice",
+                            "../cpp/include/generated/IceDiscovery",
+                            "../cpp/include/generated/IceLocatorDiscovery"])
+    include_dirs.extend(["dist/ice/cpp/include/generated"])
 
 # Define macros used during the build process
 # All the /**/ macros are necessary only on Windows


### PR DESCRIPTION
This PR fixes the PyPi build. With the changes to IceDiscovery and IceLocatorDiscovery. Namely 

- We need to include cpp/include/{IceDiscovery,IceLocatorDiscovery}
- On Linux/macOS the generated internal headers are now in cpp/include/generated.