### PR TITLE
Add SliceTypeId annotations in Java

### DIFF
--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -1780,6 +1780,11 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
         out << nl << "@Deprecated";
     }
 
+    out << nl << "@com.zeroc.Ice.SliceTypeId(value = \"" << p->scoped() << "\")";
+    if (p->compactId() >= 0)
+    {
+        out << nl << "@com.zeroc.Ice.CompactSliceTypeId(value = " << p->compactId() << ")";
+    }
     out << nl << "public class " << name;
     out.useCurrentPosAsIndent();
 
@@ -2057,6 +2062,7 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
         out << nl << "@Deprecated";
     }
 
+    out << nl << "@com.zeroc.Ice.SliceTypeId(value = \"" << p->scoped() << "\")";
     out << nl << "public class " << name << " extends ";
 
     if (!base)
@@ -3298,6 +3304,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     {
         out << nl << "@Deprecated";
     }
+    out << nl << "@com.zeroc.Ice.SliceTypeId(value = \"" << p->scoped() << "\")";
     out << nl << "public interface " << p->mappedName() << "Prx extends ";
     out.useCurrentPosAsIndent();
     if (bases.empty())
@@ -3605,6 +3612,7 @@ Slice::Gen::ServantVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     optional<DocComment> dc = DocComment::parseFrom(p, javaLinkFormatter);
     writeDocComment(out, p->unit(), dc);
 
+    out << nl << "@com.zeroc.Ice.SliceTypeId(value = \"" << p->scoped() << "\")";
     out << nl << "public interface " << p->mappedName() << " extends ";
     auto q = bases.begin();
     out.useCurrentPosAsIndent();
@@ -3666,33 +3674,6 @@ Slice::Gen::ServantVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
             out << ';';
         }
     }
-
-    StringList ids = p->ids();
-
-    out << sp;
-    writeHiddenDocComment(out);
-    out << nl << "static final String[] _iceIds =";
-    out << sb;
-
-    for (auto q = ids.begin(); q != ids.end();)
-    {
-        out << nl << '"' << *q << '"';
-        if (++q != ids.end())
-        {
-            out << ',';
-        }
-    }
-    out << eb << ';';
-
-    out << sp << nl << "@Override" << nl << "default String[] ice_ids(com.zeroc.Ice.Current current)";
-    out << sb;
-    out << nl << "return _iceIds;";
-    out << eb;
-
-    out << sp << nl << "@Override" << nl << "default String ice_id(com.zeroc.Ice.Current current)";
-    out << sb;
-    out << nl << "return ice_staticId();";
-    out << eb;
 
     out << sp << nl;
     out << "static String ice_staticId()";

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CompactSliceTypeId.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CompactSliceTypeId.java
@@ -1,0 +1,21 @@
+// Copyright (c) ZeroC, Inc.
+
+package com.zeroc.Ice;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Assigns a compact Slice type ID to a class.
+ *
+ * The Slice compiler assigns both a Slice type ID and a compact Slice type ID to the mapped class of a Slice class that
+ * specifies a compact type ID.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface CompactSliceTypeId {
+    /** The compact ID of this class.*/
+    int value();
+}

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Object.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Object.java
@@ -2,7 +2,6 @@
 
 package com.zeroc.Ice;
 
-import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.SortedSet;
@@ -171,7 +170,7 @@ public interface Object {
 
     // Implements ice_isA by checking all interfaces recursively.
     private static boolean isA(Class<?> type, String typeId) {
-         for (var directInterface : type.getInterfaces()) {
+        for (var directInterface : type.getInterfaces()) {
             var sliceTypeIdAnnotation = directInterface.getAnnotation(SliceTypeId.class);
             if (sliceTypeIdAnnotation != null) {
                 if (sliceTypeIdAnnotation.value().equals(typeId)) {
@@ -188,7 +187,7 @@ public interface Object {
 
     // Helper for ice_ids.
     private static void addTypeIds(Class<?> type, SortedSet<String> typeIds) {
-         for (var directInterface : type.getInterfaces()) {
+        for (var directInterface : type.getInterfaces()) {
             var sliceTypeIdAnnotation = directInterface.getAnnotation(SliceTypeId.class);
             if (sliceTypeIdAnnotation != null) {
                 typeIds.add(sliceTypeIdAnnotation.value());

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SliceTypeId.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SliceTypeId.java
@@ -1,0 +1,22 @@
+
+// Copyright (c) ZeroC, Inc.
+
+package com.zeroc.Ice;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Assigns a Slice type ID to a class or to an interface.
+ *
+ * The Slice compiler assigns Slice type IDs to the classes and interfaces it generates from Slice classes, exceptions,
+ * and interfaces.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface SliceTypeId {
+    /** The Slice type ID of this class or interface. */
+    String value();
+}

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SliceTypeId.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SliceTypeId.java
@@ -1,4 +1,3 @@
-
 // Copyright (c) ZeroC, Inc.
 
 package com.zeroc.Ice;


### PR DESCRIPTION
This PR adds new annotation classes for Slice type ID and compact ID, updates slice2java to generate them as appropriate.

It also updates the implementation of the Object methods (ice_isA etc.) to use these annotations.