### PR TITLE
Refactor class/exception unmarshaling in Java

### DIFF
--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -1760,8 +1760,6 @@ Slice::Gen::TypesVisitor::visitModuleStart(const ModulePtr& p)
 bool
 Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
-    emitCompactIdHelper(p);
-
     string name = p->mappedName();
     ClassDefPtr baseClass = p->base();
     string package = getPackage(p);
@@ -3567,32 +3565,6 @@ Slice::Gen::TypesVisitor::visitOperation(const OperationPtr& p)
             out << nl << getUnqualified(*t, package) << ".class";
         }
         out << eb << ';';
-    }
-}
-
-void
-Slice::Gen::TypesVisitor::emitCompactIdHelper(const ClassDefPtr& p)
-{
-    if (p->compactId() >= 0)
-    {
-        string prefix = getPackagePrefix(p);
-        if (!prefix.empty())
-        {
-            prefix = prefix + ".";
-        }
-
-        ostringstream os;
-        os << prefix << "com.zeroc.IceCompactId.TypeId_" << p->compactId();
-        open(os.str(), p->file());
-        Output& out = output();
-
-        out << sp;
-        writeHiddenDocComment(out);
-        out << nl << "public class TypeId_" << p->compactId();
-        out << sb;
-        out << nl << "public final static String typeId = \"" << p->scoped() << "\";";
-        out << eb;
-        close();
     }
 }
 

--- a/cpp/src/slice2java/Gen.h
+++ b/cpp/src/slice2java/Gen.h
@@ -163,9 +163,6 @@ namespace Slice
             bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
             void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
             void visitOperation(const OperationPtr&) final;
-
-        private:
-            void emitCompactIdHelper(const ClassDefPtr&);
         };
 
         class ServantVisitor final : public JavaVisitor

--- a/java/src/IceGridGUI/icegridgui.pro
+++ b/java/src/IceGridGUI/icegridgui.pro
@@ -40,11 +40,10 @@
     public **[] values();
 }
 
--dontnote com.zeroc.IceSSL.SSLEngine
 -dontnote com.zeroc.Ice.CommunicatorObserverI*
--dontnote com.zeroc.Ice.InputStream
--dontnote com.zeroc.Ice.InputStream$EncapsDecoder
--dontnote com.zeroc.Ice.InputStream$EncapsDecoder11
+-dontnote com.zeroc.Ice.ClassSliceLoader
+-dontnote com.zeroc.Ice.DefaultPackageSliceLoader
+-dontnote com.zeroc.Ice.ModuleToPackageSliceLoader
 -dontnote com.zeroc.Ice.InvocationObserverI*
 -dontnote com.zeroc.Ice.MetricsMap
 -dontnote com.zeroc.Ice.ObjectPrx

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ClassSliceLoader.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ClassSliceLoader.java
@@ -1,0 +1,48 @@
+// Copyright (c) ZeroC, Inc.
+
+package com.zeroc.Ice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Implements SliceLoader using an array of annotated classes.
+ */
+public final class ClassSliceLoader implements SliceLoader {
+    private final Map<String, Class<?>> _typeIdToClass = new HashMap<>();
+
+    /**
+     * Creates a ClassSliceLoader.
+     *
+     * @param classes An array of classes with the {@link SliceTypeId} and/or {@link CompactSliceTypeId} annotation.
+     */
+    public ClassSliceLoader(Class<?>... classes) {
+        for (Class<?> c : classes) {
+            SliceTypeId typeId = c.getAnnotation(SliceTypeId.class);
+            if (typeId != null) {
+                _typeIdToClass.put(typeId.value(), c);
+            }
+            CompactSliceTypeId compactTypeId = c.getAnnotation(CompactSliceTypeId.class);
+            if (compactTypeId != null) {
+                _typeIdToClass.put(String.valueOf(compactTypeId.value()), c);
+            }
+        }
+    }
+
+    @Override
+    public java.lang.Object newInstance(String typeId) {
+        Class<?> c = _typeIdToClass.get(typeId);
+        if (c != null) {
+            try {
+                return c.getDeclaredConstructor().newInstance();
+            } catch (Exception ex) {
+                throw new MarshalException(
+                    String.format(
+                        "Failed to create an instance of class '%s' for type ID '%s'.",
+                        c.getName(), typeId),
+                    ex);
+            }
+        }
+        return null;
+    }
+}

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ClassSliceLoader.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ClassSliceLoader.java
@@ -14,17 +14,20 @@ public final class ClassSliceLoader implements SliceLoader {
     /**
      * Creates a ClassSliceLoader.
      *
-     * @param classes An array of classes with the {@link SliceTypeId} and/or {@link CompactSliceTypeId} annotation.
+     * @param classes An array of classes with the {@link SliceTypeId} annotation. Each class may also have the
+     * {@link CompactSliceTypeId} annotation.
      */
     public ClassSliceLoader(Class<?>... classes) {
         for (Class<?> c : classes) {
             SliceTypeId typeId = c.getAnnotation(SliceTypeId.class);
             if (typeId != null) {
                 _typeIdToClass.put(typeId.value(), c);
-            }
-            CompactSliceTypeId compactTypeId = c.getAnnotation(CompactSliceTypeId.class);
-            if (compactTypeId != null) {
-                _typeIdToClass.put(String.valueOf(compactTypeId.value()), c);
+
+                // CompactSliceTypeId is always in addition to SliceTypeId.
+                CompactSliceTypeId compactTypeId = c.getAnnotation(CompactSliceTypeId.class);
+                if (compactTypeId != null) {
+                    _typeIdToClass.put(String.valueOf(compactTypeId.value()), c);
+                }
             }
         }
     }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ClassSliceLoader.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ClassSliceLoader.java
@@ -16,6 +16,7 @@ public final class ClassSliceLoader implements SliceLoader {
      *
      * @param classes An array of classes with the {@link SliceTypeId} annotation. Each class may also have the
      * {@link CompactSliceTypeId} annotation.
+     * @throws IllegalArgumentException If any class is not annotated with {@link SliceTypeId}.
      */
     public ClassSliceLoader(Class<?>... classes) {
         for (Class<?> c : classes) {
@@ -28,6 +29,11 @@ public final class ClassSliceLoader implements SliceLoader {
                 if (compactTypeId != null) {
                     _typeIdToClass.put(String.valueOf(compactTypeId.value()), c);
                 }
+            } else {
+                throw new IllegalArgumentException(
+                    String.format(
+                        "Class '%s' is not annotated with @SliceTypeId.",
+                        c.getName()));
             }
         }
     }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CompositeSliceLoader.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CompositeSliceLoader.java
@@ -1,0 +1,33 @@
+// Copyright (c) ZeroC, Inc.
+
+package com.zeroc.Ice;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Implements SliceLoader by combining multiple SliceLoaders.
+ */
+final public class CompositeSliceLoader implements SliceLoader {
+    private final List<SliceLoader> _loaders = new ArrayList<>();
+
+    @Override
+    public java.lang.Object newInstance(String typeId) {
+        for (SliceLoader loader : _loaders) {
+            java.lang.Object instance = loader.newInstance(typeId);
+            if (instance != null) {
+                return instance;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Adds a SliceLoader to the list of loaders.
+     *
+     * @param loader the SliceLoader to add
+     */
+    void add(SliceLoader loader) {
+        _loaders.add(loader);
+    }
+}

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CompositeSliceLoader.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CompositeSliceLoader.java
@@ -23,11 +23,11 @@ final public class CompositeSliceLoader implements SliceLoader {
     }
 
     /**
-     * Adds a SliceLoader to the list of loaders.
+     * Adds a SliceLoader to this CompositeSliceLoader.
      *
-     * @param loader the SliceLoader to add
+     * @param loader The SliceLoader to add.
      */
-    void add(SliceLoader loader) {
+    public void add(SliceLoader loader) {
         _loaders.add(loader);
     }
 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/DefaultPackageSliceLoader.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/DefaultPackageSliceLoader.java
@@ -1,0 +1,63 @@
+// Copyright (c) ZeroC, Inc.
+
+package com.zeroc.Ice;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Implements SliceLoader using a default package.
+ */
+public final class DefaultPackageSliceLoader implements SliceLoader {
+    private final String _packagePrefix;
+    private final ClassLoader _classLoader;
+
+    // We cache successful resolutions. The size of this cache is bounded by the number of Slice classes and exceptions
+    // in the program. We can't cache unsuccessful resolutions because it would create an unbounded cache.
+    private final Map<String, Class<?>> _typeIdToClass = new ConcurrentHashMap<>();
+
+    /**
+     * Creates a DefaultPackageSliceLoader.
+     *
+     * @param defaultPackage The package that holds all Slice classes and exceptions. Can be empty.
+     * @param classLoader The class loader to use to load the classes. Can be null.
+     */
+    public DefaultPackageSliceLoader(String defaultPackage, ClassLoader classLoader) {
+        _packagePrefix = defaultPackage.isEmpty() ? "" : defaultPackage + ".";
+        _classLoader = classLoader;
+    }
+
+    @Override
+    public java.lang.Object newInstance(String typeId) {
+        if (!typeId.startsWith("::")) {
+            // This could be for example a compact ID. This implementation doesn't handle compact IDs.
+            return null;
+        }
+
+        // Check cache.
+        Class<?> mappedClass = _typeIdToClass.get(typeId);
+        if (mappedClass != null) {
+            return newInstance(mappedClass, typeId);
+        }
+
+        String className = typeId.substring(2).replace("::", ".");
+        mappedClass = Util.findClass(_packagePrefix + className, _classLoader);
+        if (mappedClass != null) {
+            _typeIdToClass.putIfAbsent(typeId, mappedClass);
+            return newInstance(mappedClass, typeId);
+        }
+        return null;
+    }
+
+    private static java.lang.Object newInstance(Class<?> mappedClass, String typeId) {
+        try {
+            return mappedClass.getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            throw new MarshalException(String.format(
+                    "Failed to create an instance of class '%s' for type ID '%s'.",
+                    mappedClass.getName(),
+                    typeId),
+                ex);
+        }
+    }
+}

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InitializationData.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InitializationData.java
@@ -85,4 +85,9 @@ public final class InitializationData implements Cloneable {
      * in order, before all other plug-ins.
      */
     public List<PluginFactory> pluginFactories = Collections.emptyList();
+
+    /**
+     * The Slice loader, used to unmarshal Slice classes and exceptions.
+     */
+    public SliceLoader sliceLoader;
 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -13,7 +13,6 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -1439,25 +1439,6 @@ public final class Instance {
     private static boolean _oneOffDone;
     private SSLEngine _sslEngine;
 
-    private final Map<String, String[]> _builtInModulePackagePrefixes =
-        Collections.unmodifiableMap(
-            new HashMap<String, String[]>() {
-                {
-                    put("Glacier2", new String[]{"com.zeroc"});
-                    put("Ice", new String[]{"com.zeroc"});
-                    put("IceBox", new String[]{"com.zeroc"});
-                    put("IceDiscovery", new String[]{"com.zeroc"});
-                    put("IceGrid", new String[]{"com.zeroc"});
-                    put("IceLocatorDiscovery", new String[]{"com.zeroc"});
-                    put(
-                        "IceMX",
-                        new String[]{
-                            "com.zeroc.Ice", "com.zeroc.Glacier2", "com.zeroc.IceStorm"
-                        });
-                    put("IceStorm", new String[]{"com.zeroc"});
-                }
-            });
-
     private ConnectionOptions _clientConnectionOptions;
     private ConnectionOptions _serverConnectionOptions;
 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -548,10 +548,9 @@ public final class Instance {
         return Util.findClass(className, _initData.classLoader);
     }
 
-    //
-    // Only for use by com.zeroc.Ice.Communicator
-    //
-    public void initialize(Communicator communicator, InitializationData initData) {
+    // Only for use by com.zeroc.Ice.Communicator. If the application provides an initData, the initData argument is a
+    // clone.
+    void initialize(Communicator communicator, InitializationData initData) {
         _state = StateActive;
         _initData = initData;
 
@@ -681,12 +680,15 @@ public final class Instance {
                 }
             }
 
+            // Update _initData.sliceLoader.
+
             var sliceLoader = new CompositeSliceLoader();
-            _sliceLoader = sliceLoader;
 
             if (_initData.sliceLoader != null) {
                 sliceLoader.add(_initData.sliceLoader);
             }
+
+            _initData.sliceLoader = sliceLoader;
 
             // Ice.Package.module loader.
             String packagePrefix = "Ice.Package";
@@ -1172,8 +1174,6 @@ public final class Instance {
                 _adminAdapter = null;
                 _adminFacets.clear();
 
-                _sliceTypeIdToClassMap.clear();
-
                 _state = StateDestroyed;
                 notifyAll();
             }
@@ -1224,7 +1224,7 @@ public final class Instance {
     }
 
     SliceLoader sliceLoader() {
-        return _sliceLoader;
+        return _initData.sliceLoader;
     }
 
     ConnectionOptions clientConnectionOptions() {
@@ -1435,8 +1435,6 @@ public final class Instance {
     private final Set<String> _adminFacetFilter = new HashSet<>();
     private Identity _adminIdentity;
     private final Map<Short, BufSizeWarnInfo> _setBufSizeWarn = new HashMap<>();
-
-    private final Map<String, String> _sliceTypeIdToClassMap = new HashMap<>();
 
     private static boolean _oneOffDone;
     private SSLEngine _sslEngine;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ModuleToPackageSliceLoader.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ModuleToPackageSliceLoader.java
@@ -1,0 +1,85 @@
+// Copyright (c) ZeroC, Inc.
+
+package com.zeroc.Ice;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Implements SliceLoader using a map Slice module to Java package.
+ */
+public final class ModuleToPackageSliceLoader implements SliceLoader {
+    private final Map<String, String> _moduleToPackageMap;
+    private final ClassLoader _classLoader;
+
+    // We cache successful resolutions. The size of this cache is bounded by the number of Slice classes and exceptions
+    // in the program. We can't cache unsuccessful resolutions because it would create an unbounded cache.
+    private final Map<String, Class<?>> _typeIdToClass = new ConcurrentHashMap<>();
+
+    /**
+     * Creates a ModuleToPackageSliceLoader.
+     *
+     * @param moduleToPackageMap A map of Slice module names to Java package names.
+     * @param classLoader The class loader to use to load the classes. Can be null.
+     */
+    public ModuleToPackageSliceLoader(Map<String, String> moduleToPackageMap, ClassLoader classLoader) {
+        _moduleToPackageMap = new HashMap<>(moduleToPackageMap);
+        _classLoader = classLoader;
+    }
+
+    /**
+     * Creates a ModuleToPackageSliceLoader using a single module to package mapping.
+     *
+     * @param module The type ID of the Slice module, for example "::VisitorCenter".
+     * @param packageName The Java package name, for example "com.example.visitorcenter".
+     */
+    public ModuleToPackageSliceLoader(String module, String packageName) {
+        this(Map.of(module, packageName), null);
+    }
+
+    @Override
+    public java.lang.Object newInstance(String typeId) {
+        if (!typeId.startsWith("::")) {
+            // This could be for example a compact ID. This implementation doesn't handle compact IDs.
+            return null;
+        }
+
+        // Check cache.
+        Class<?> mappedClass = _typeIdToClass.get(typeId);
+        if (mappedClass != null) {
+            return newInstance(mappedClass, typeId);
+        }
+
+        int pos = typeId.lastIndexOf("::");
+
+        while (pos > 0) {
+            String className = typeId.substring(pos + 2).replace("::", ".");
+            String module = typeId.substring(0, pos);
+            String packageName = _moduleToPackageMap.get(module);
+
+            if (packageName != null) {
+                mappedClass = Util.findClass(packageName + "." + className, _classLoader);
+                if (mappedClass != null) {
+                    _typeIdToClass.putIfAbsent(typeId, mappedClass);
+                    return newInstance(mappedClass, typeId);
+                }
+            }
+
+            pos = module.lastIndexOf("::");
+        }
+        return null;
+    }
+
+    private static java.lang.Object newInstance(Class<?> mappedClass, String typeId) {
+        try {
+            return mappedClass.getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            throw new MarshalException(String.format(
+                    "Failed to create an instance of class '%s' for type ID '%s'.",
+                    mappedClass.getName(),
+                    typeId),
+                ex);
+        }
+    }
+}

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutputStream.java
@@ -1828,7 +1828,12 @@ public final class OutputStream {
             }
 
             for (SliceInfo info : slicedData.slices) {
-                startSlice(info.typeId, info.compactId, info.isLastSlice);
+                if (info.typeId.startsWith("::")) {
+                    startSlice(info.typeId, -1, info.isLastSlice);
+                }
+                else {
+                    startSlice("", Integer.parseInt(info.typeId), info.isLastSlice);
+                }
 
                 //
                 // Write the bytes associated with this slice.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SliceInfo.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SliceInfo.java
@@ -7,9 +7,6 @@ public final class SliceInfo {
     /** The Slice type ID for this slice. */
     public final String typeId;
 
-    /** The Slice compact type ID for this slice. */
-    public final int compactId;
-
     /** The encoded bytes for this slice, including the leading size integer. */
     public final byte[] bytes;
 
@@ -25,12 +22,10 @@ public final class SliceInfo {
     /** The SliceInfo constructor. */
     public SliceInfo(
             String typeId,
-            int compactId,
             byte[] bytes,
             boolean hasOptionalMembers,
             boolean isLastSlice) {
         this.typeId = typeId;
-        this.compactId = compactId;
         this.bytes = bytes;
         this.hasOptionalMembers = hasOptionalMembers;
         this.isLastSlice = isLastSlice;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SliceLoader.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SliceLoader.java
@@ -1,0 +1,18 @@
+// Copyright (c) ZeroC, Inc.
+
+package com.zeroc.Ice;
+
+/**
+ * Creates class and exception instances from Slice type IDs.
+ */
+public interface SliceLoader {
+    /**
+     * Creates an instance of a class mapped from a Slice class or exception based on a Slice type ID.
+     *
+     * @param typeId The Slice type ID or compact type ID.
+     * @return A new instance of the class or exception identified by {@code typeId}, or {@code null} if the
+     *         implementation cannot find the corresponding class.
+     * @throws MarshalException Thrown when the corresponding class was found but its instantiation failed.
+     */
+    java.lang.Object newInstance(String typeId);
+}

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SliceLoader.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SliceLoader.java
@@ -5,6 +5,7 @@ package com.zeroc.Ice;
 /**
  * Creates class and exception instances from Slice type IDs.
  */
+@FunctionalInterface
 public interface SliceLoader {
     /**
      * Creates an instance of a class mapped from a Slice class or exception based on a Slice type ID.

--- a/java/test/src/main/java/test/Ice/admin/RemoteCommunicatorFactoryI.java
+++ b/java/test/src/main/java/test/Ice/admin/RemoteCommunicatorFactoryI.java
@@ -25,7 +25,6 @@ public class RemoteCommunicatorFactoryI implements RemoteCommunicatorFactory {
         // Prepare the property set using the given properties.
         //
         InitializationData initData = new InitializationData();
-        initData.classLoader = current.adapter.getCommunicator().getInstance().getClassLoader();
         initData.properties = new Properties();
         for (Map.Entry<String, String> e : props.entrySet()) {
             initData.properties.setProperty(e.getKey(), e.getValue());

--- a/java/test/src/main/java/test/Ice/objects/Client.java
+++ b/java/test/src/main/java/test/Ice/objects/Client.java
@@ -3,10 +3,14 @@
 package test.Ice.objects;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ClassSliceLoader;
 import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Value;
 import com.zeroc.Ice.ValueFactory;
 
+import test.Ice.objects.Test.Compact;
+import test.Ice.objects.Test.CompactExt;
 import test.Ice.objects.Test.InitialPrx;
 import test.TestHelper;
 
@@ -27,10 +31,13 @@ public class Client extends TestHelper {
     }
 
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.objects");
-        properties.setProperty("Ice.MessageSizeMax", "2048"); // Needed on some Android versions
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Package.Test", "test.Ice.objects");
+        initData.properties.setProperty("Ice.MessageSizeMax", "2048"); // Needed on some Android versions
+        initData.sliceLoader = new ClassSliceLoader(Compact.class, CompactExt.class);
+
+        try (Communicator communicator = initialize(initData)) {
             ValueFactory factory = new MyValueFactory();
             communicator.getValueFactoryManager().add(factory, "::Test::B");
             communicator.getValueFactoryManager().add(factory, "::Test::C");

--- a/java/test/src/main/java/test/Ice/objects/Collocated.java
+++ b/java/test/src/main/java/test/Ice/objects/Collocated.java
@@ -3,12 +3,16 @@
 package test.Ice.objects;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ClassSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 import com.zeroc.Ice.Value;
 import com.zeroc.Ice.ValueFactory;
 
+import test.Ice.objects.Test.Compact;
+import test.Ice.objects.Test.CompactExt;
 import test.Ice.objects.Test.Initial;
 import test.TestHelper;
 
@@ -30,11 +34,13 @@ public class Collocated extends TestHelper {
     }
 
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.objects");
-        properties.setProperty("Ice.Warn.Dispatch", "0");
+        var initData = new InitializationData();
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Package.Test", "test.Ice.objects");
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+        initData.sliceLoader = new ClassSliceLoader(Compact.class, CompactExt.class);
 
-        try (Communicator communicator = initialize(properties)) {
+        try (Communicator communicator = initialize(initData)) {
             ValueFactory factory = new MyValueFactory();
             communicator.getValueFactoryManager().add(factory, "::Test::B");
             communicator.getValueFactoryManager().add(factory, "::Test::C");

--- a/java/test/src/main/java/test/Ice/operations/Client.java
+++ b/java/test/src/main/java/test/Ice/operations/Client.java
@@ -3,7 +3,9 @@
 package test.Ice.operations;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.LocalException;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Properties;
 
 import test.Ice.operations.Test.MyClassPrx;
@@ -16,10 +18,14 @@ public class Client extends TestHelper {
         Properties properties = createTestProperties(args);
         properties.setProperty("Ice.ThreadPool.Client.Size", "2");
         properties.setProperty("Ice.ThreadPool.Client.SizeWarn", "0");
-        properties.setProperty("Ice.Package.Test", "test.Ice.operations");
         properties.setProperty("Ice.BatchAutoFlushSize", "100");
+
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.operations.Test");
+        initData.properties = properties;
+
         PrintWriter out = getWriter();
-        try (Communicator communicator = initialize(properties)) {
+        try (Communicator communicator = initialize(initData)) {
             MyClassPrx myClass = AllTests.allTests(this);
 
             out.print("testing server shutdown... ");

--- a/java/test/src/main/java/test/Ice/operations/Collocated.java
+++ b/java/test/src/main/java/test/Ice/operations/Collocated.java
@@ -3,6 +3,8 @@
 package test.Ice.operations;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.Properties;
@@ -15,8 +17,11 @@ import test.TestHelper;
 public class Collocated extends TestHelper {
     public void run(String[] args) {
         Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.operations");
         properties.setProperty("Ice.BatchAutoFlushSize", "100");
+
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.operations.Test");
+        initData.properties = properties;
 
         //
         // Its possible to have batch oneway requests dispatched
@@ -24,7 +29,7 @@ public class Collocated extends TestHelper {
         // scheduling so we suppress this warning.
         //
         properties.setProperty("Ice.Warn.Dispatch", "0");
-        try (Communicator communicator = initialize(properties)) {
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             ObjectPrx prx =

--- a/java/test/src/main/java/test/Ice/operations/Server.java
+++ b/java/test/src/main/java/test/Ice/operations/Server.java
@@ -3,6 +3,8 @@
 package test.Ice.operations;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
@@ -18,8 +20,12 @@ public class Server extends TestHelper {
         // scheduling so we suppress this warning.
         //
         properties.setProperty("Ice.Warn.Dispatch", "0");
-        properties.setProperty("Ice.Package.Test", "test.Ice.operations");
-        try (Communicator communicator = initialize(properties)) {
+
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.operations.Test");
+        initData.properties = properties;
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new MyDerivedClassI(), Util.stringToIdentity("test"));

--- a/java/test/src/main/java/test/Ice/packagemd/AllTests.java
+++ b/java/test/src/main/java/test/Ice/packagemd/AllTests.java
@@ -3,9 +3,11 @@
 package test.Ice.packagemd;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.MarshalException;
 import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.UnknownUserException;
+import com.zeroc.Ice.Util;
 
 import test.Ice.packagemd.Test.InitialPrx;
 import test.Ice.packagemd.Test1.C1;
@@ -98,56 +100,49 @@ public class AllTests {
             }
 
             {
-                //
-                // Define Ice.Package.Test2=testpkg and try again.
-                //
-                communicator
-                    .getProperties()
-                    .setProperty("Ice.Package.Test2", "test.Ice.packagemd.testpkg");
-                test.Ice.packagemd.testpkg.Test2.C1 c1 = initial.getTest2C2AsC1();
-                test(c1 != null);
-                test(c1 instanceof test.Ice.packagemd.testpkg.Test2.C2);
-                test.Ice.packagemd.testpkg.Test2.C2 c2 = initial.getTest2C2AsC2();
-                test(c2 != null);
-                try {
-                    initial.throwTest2E2AsE1();
-                    test(false);
-                } catch (test.Ice.packagemd.testpkg.Test2.E1 ex) {
-                    test(ex instanceof test.Ice.packagemd.testpkg.Test2.E2);
-                }
-                try {
-                    initial.throwTest2E2AsE2();
-                    test(false);
-                } catch (test.Ice.packagemd.testpkg.Test2.E2 ex) {
-                    // Expected
-                }
-            }
+                var initData = new InitializationData();
+                initData.properties = communicator.getProperties()._clone();
+                initData.properties.setProperty("Ice.Package.Test2", "test.Ice.packagemd.testpkg");
+                initData.properties.setProperty("Ice.Default.Package", "test.Ice.packagemd.modpkg");
 
-            {
-                //
-                // Define Ice.Default.Package=testpkg and try again. We can't retrieve
-                // the Test2.* types again (with this communicator) because factories
-                // have already been cached for them, so now we use the Test3.* types.
-                //
-                communicator
-                    .getProperties()
-                    .setProperty("Ice.Default.Package", "test.Ice.packagemd.modpkg");
-                test.Ice.packagemd.modpkg.Test3.C1 c1 = initial.getTest3C2AsC1();
-                test(c1 != null);
-                test(c1 instanceof test.Ice.packagemd.modpkg.Test3.C2);
-                test.Ice.packagemd.modpkg.Test3.C2 c2 = initial.getTest3C2AsC2();
-                test(c2 != null);
-                try {
-                    initial.throwTest3E2AsE1();
-                    test(false);
-                } catch (test.Ice.packagemd.modpkg.Test3.E1 ex) {
-                    test(ex instanceof test.Ice.packagemd.modpkg.Test3.E2);
-                }
-                try {
-                    initial.throwTest3E2AsE2();
-                    test(false);
-                } catch (test.Ice.packagemd.modpkg.Test3.E2 ex) {
-                    // Expected
+                try (Communicator configuredCommunicator = Util.initialize(initData)) {
+                    var proxy = InitialPrx.createProxy(configuredCommunicator, ref);
+
+                    test.Ice.packagemd.testpkg.Test2.C1 c1 = proxy.getTest2C2AsC1();
+                    test(c1 != null);
+                    test(c1 instanceof test.Ice.packagemd.testpkg.Test2.C2);
+                    test.Ice.packagemd.testpkg.Test2.C2 c2 = proxy.getTest2C2AsC2();
+                    test(c2 != null);
+                    try {
+                        proxy.throwTest2E2AsE1();
+                        test(false);
+                    } catch (test.Ice.packagemd.testpkg.Test2.E1 ex) {
+                        test(ex instanceof test.Ice.packagemd.testpkg.Test2.E2);
+                    }
+                    try {
+                        proxy.throwTest2E2AsE2();
+                        test(false);
+                    } catch (test.Ice.packagemd.testpkg.Test2.E2 ex) {
+                        // Expected
+                    }
+
+                    test.Ice.packagemd.modpkg.Test3.C1 c1bis = proxy.getTest3C2AsC1();
+                    test(c1bis != null);
+                    test(c1bis instanceof test.Ice.packagemd.modpkg.Test3.C2);
+                    test.Ice.packagemd.modpkg.Test3.C2 c2bis = proxy.getTest3C2AsC2();
+                    test(c2bis != null);
+                    try {
+                        proxy.throwTest3E2AsE1();
+                        test(false);
+                    } catch (test.Ice.packagemd.modpkg.Test3.E1 ex) {
+                        test(ex instanceof test.Ice.packagemd.modpkg.Test3.E2);
+                    }
+                    try {
+                        proxy.throwTest3E2AsE2();
+                        test(false);
+                    } catch (test.Ice.packagemd.modpkg.Test3.E2 ex) {
+                        // Expected
+                    }
                 }
             }
 

--- a/java/test/src/main/java/test/Ice/slicing/objects/Client.java
+++ b/java/test/src/main/java/test/Ice/slicing/objects/Client.java
@@ -3,16 +3,23 @@
 package test.Ice.slicing.objects;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ClassSliceLoader;
 import com.zeroc.Ice.Properties;
 
+import test.Ice.slicing.objects.client.Test.CompactPCDerived;
+import test.Ice.slicing.objects.client.Test.CompactPDerived;
 import test.Ice.slicing.objects.client.Test.TestIntfPrx;
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.slicing.objects.client");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Package.Test", "test.Ice.slicing.objects.client");
+        initData.sliceLoader = new ClassSliceLoader(CompactPDerived.class, CompactPCDerived.class);
+
+        try (Communicator communicator = initialize(initData)) {
             TestIntfPrx test = AllTests.allTests(this, false);
             test.shutdown();
         }


### PR DESCRIPTION
This PR refactors the class and exception unmarshaling in Java, while maintaining a large level of backwards compatibility.

Prior to this PR, the class/exception unmarshaling in Java was driven by the Ice.Package.module and Ice.Default.Package properties. And the user had some control over the class unmarshaling with the ValueFactoryManager.

This PR introduces a new interface, SliceLoader, and a new initData.sliceLoader field that allows the user to set his own "Slice loader". A Slice loader is responsible to create an instance of a class/exception from a type ID. This type ID can be either a regular type ID string (`::ClearSky::AtmosphericConditions`) or a compact ID string ("123").

This PR also provides a number of implementations of the SliceLoader interface.

The default behavior is to emulate the 3.7 behavior - see updates in Instance.java.

See also #3835.