### PR TITLE
Add not found caching to Java SliceLoader

### DIFF
--- a/config/PropertyNames.xml
+++ b/config/PropertyNames.xml
@@ -123,6 +123,7 @@
         <property name="ProgramName" languages="cpp,csharp,java" />
         <property name="RetryIntervals" languages="all" default="0" />
         <property name="ServerIdleTime" languages="cpp,csharp,java" default="0" />
+        <property name="SliceLoader.NotFoundCacheSize" languages="java" default="100" />
         <property name="SOCKSProxyHost" languages="cpp,csharp,java" />
         <property name="SOCKSProxyPort" languages="cpp,csharp,java" default="1080" />
         <property name="StdErr" languages="cpp,csharp,java" />
@@ -157,6 +158,7 @@
         <property name="Warn.Dispatch" languages="all" default="1" />
         <property name="Warn.Endpoints" languages="all" default="1" />
         <property name="Warn.Executor" languages="cpp,csharp,java" default="1" />
+        <property name="Warn.SliceLoader" languages="java" default="1" />
         <property name="Warn.UnusedProperties" languages="all" default="0" />
         <property name="CacheMessageBuffers" languages="csharp,java" default="2" />
     </section>

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -687,7 +687,20 @@ public final class Instance {
                 sliceLoader.add(_initData.sliceLoader);
             }
 
-            _initData.sliceLoader = sliceLoader;
+            final int notFoundCacheSize =
+                properties.getIcePropertyAsInt("Ice.SliceLoader.NotFoundCacheSize");
+
+            if (notFoundCacheSize <= 0) {
+               _initData.sliceLoader = sliceLoader;
+            } else {
+                final Logger cacheFullLogger =
+                    properties.getIcePropertyAsInt("Ice.Warn.SliceLoader") > 0 ? _initData.logger : null;
+
+                _initData.sliceLoader = new NotFoundSliceLoaderDecorator(
+                    sliceLoader,
+                    notFoundCacheSize,
+                    cacheFullLogger);
+            }
 
             // Ice.Package.module loader.
             String packagePrefix = "Ice.Package";

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -691,7 +691,7 @@ public final class Instance {
                 properties.getIcePropertyAsInt("Ice.SliceLoader.NotFoundCacheSize");
 
             if (notFoundCacheSize <= 0) {
-               _initData.sliceLoader = sliceLoader;
+                _initData.sliceLoader = sliceLoader;
             } else {
                 final Logger cacheFullLogger =
                     properties.getIcePropertyAsInt("Ice.Warn.SliceLoader") > 0 ? _initData.logger : null;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/NotFoundSliceLoaderDecorator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/NotFoundSliceLoaderDecorator.java
@@ -1,0 +1,51 @@
+// Copyright (c) ZeroC, Inc.
+
+package com.zeroc.Ice;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Decorates SliceLoader to cache null results.
+ */
+final class NotFoundSliceLoaderDecorator implements SliceLoader {
+    private final SliceLoader _decoratee;
+    private final int _cacheSize;
+    private Logger _logger;
+    private final Set<String> _notFoundSet = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Creates a NotFoundSliceLoaderDecorator.
+     *
+     * @param decoratee The SliceLoader to decorate.
+     * @param cacheSize The maximum number of type IDs that can be cached.
+     * @param logger The logger used to warn when the cache is full. It's null when Ice.Warn.SliceLoader is set to 0.
+     */
+    NotFoundSliceLoaderDecorator(SliceLoader decoratee, int cacheSize, Logger logger) {
+        _decoratee = decoratee;
+        _cacheSize = cacheSize;
+        _logger = logger;
+    }
+
+    @Override
+    public java.lang.Object newInstance(String typeId) {
+        if (_notFoundSet.contains(typeId)) {
+            return null;
+        }
+
+        java.lang.Object instance = _decoratee.newInstance(typeId);
+        if (instance == null) {
+            if (_notFoundSet.size() < _cacheSize) {
+                _notFoundSet.add(typeId);
+            } else if (_logger != null) {
+                _logger.warning(String.format(
+                    "SliceLoader: Type ID '%s' not found and the not found cache is full. " +
+                        "The cache size is set to %d. " +
+                        "You can increase the cache size by setting property Ice.SliceLoader.NotFoundCacheSize.",
+                    typeId, _cacheSize));
+                _logger = null; // we only warn once, or possibly a few times from different threads.
+            }
+        }
+        return instance;
+    }
+}

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PropertyNames.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PropertyNames.java
@@ -12,7 +12,7 @@ final class PropertyNames
         "Proxy",
         false,
         false,
-        new Property[] {
+        new Property[]{
             new Property("EndpointSelection", false, "", false, null),
             new Property("ConnectionCached", false, "", false, null),
             new Property("PreferSecure", false, "", false, null),
@@ -28,7 +28,7 @@ final class PropertyNames
         "Connection",
         true,
         false,
-        new Property[] {
+        new Property[]{
             new Property("CloseTimeout", false, "10", false, null),
             new Property("ConnectTimeout", false, "10", false, null),
             new Property("EnableIdleCheck", false, "1", false, null),
@@ -41,7 +41,7 @@ final class PropertyNames
         "ThreadPool",
         true,
         false,
-        new Property[] {
+        new Property[]{
             new Property("Size", false, "1", false, null),
             new Property("SizeMax", false, "", false, null),
             new Property("SizeWarn", false, "0", false, null),
@@ -55,7 +55,7 @@ final class PropertyNames
         "ObjectAdapter",
         true,
         false,
-        new Property[] {
+        new Property[]{
             new Property("AdapterId", false, "", false, null),
             new Property("Connection", false, "", false, PropertyNames.ConnectionProps),
             new Property("Endpoints", false, "", false, null),
@@ -74,14 +74,14 @@ final class PropertyNames
         "LMDB",
         true,
         false,
-        new Property[] {
-        });
+        new Property[]{
+            });
 
     public static final PropertyArray IceProps = new PropertyArray(
         "Ice",
         false,
         false,
-        new Property[] {
+        new Property[]{
             new Property("AcceptClassCycles", false, "0", false, null),
             new Property("Admin", false, "", false, PropertyNames.ObjectAdapterProps),
             new Property("Admin.DelayCreation", false, "0", false, null),
@@ -173,7 +173,7 @@ final class PropertyNames
         "IceMX",
         false,
         false,
-        new Property[] {
+        new Property[]{
             new Property("Metrics\\.[^\\s]+\\.GroupBy", true, "", false, null),
             new Property("Metrics\\.[^\\s]+\\.Map", true, "", false, null),
             new Property("Metrics\\.[^\\s]+\\.RetainDetached", true, "10", false, null),
@@ -186,7 +186,7 @@ final class PropertyNames
         "IceDiscovery",
         false,
         false,
-        new Property[] {
+        new Property[]{
             new Property("Multicast", false, "", false, PropertyNames.ObjectAdapterProps),
             new Property("Reply", false, "", false, PropertyNames.ObjectAdapterProps),
             new Property("Locator", false, "", false, PropertyNames.ObjectAdapterProps),
@@ -204,7 +204,7 @@ final class PropertyNames
         "IceLocatorDiscovery",
         false,
         false,
-        new Property[] {
+        new Property[]{
             new Property("Reply", false, "", false, PropertyNames.ObjectAdapterProps),
             new Property("Locator", false, "", false, PropertyNames.ObjectAdapterProps),
             new Property("Lookup", false, "", false, null),
@@ -222,7 +222,7 @@ final class PropertyNames
         "IceBox",
         false,
         true,
-        new Property[] {
+        new Property[]{
             new Property("InheritProperties", false, "", false, null),
             new Property("LoadOrder", false, "", false, null),
             new Property("PrintServicesReady", false, "", false, null),
@@ -235,7 +235,7 @@ final class PropertyNames
         "IceBoxAdmin",
         false,
         true,
-        new Property[] {
+        new Property[]{
             new Property("ServiceManager.Proxy", false, "", false, PropertyNames.ProxyProps)
         });
 
@@ -243,14 +243,14 @@ final class PropertyNames
         "IceBridge",
         false,
         true,
-        new Property[] {
-        });
+        new Property[]{
+            });
 
     public static final PropertyArray IceGridAdminProps = new PropertyArray(
         "IceGridAdmin",
         false,
         true,
-        new Property[] {
+        new Property[]{
             new Property("MetricsConfig", false, "", false, null),
             new Property("Trace.Observers", false, "", false, null),
             new Property("Trace.SaveToRegistry", false, "", false, null)
@@ -260,14 +260,14 @@ final class PropertyNames
         "IceGrid",
         false,
         true,
-        new Property[] {
-        });
+        new Property[]{
+            });
 
     public static final PropertyArray IceSSLProps = new PropertyArray(
         "IceSSL",
         false,
         false,
-        new Property[] {
+        new Property[]{
             new Property("Alias", false, "", false, null),
             new Property("CheckCertName", false, "0", false, null),
             new Property("DefaultDir", false, "", false, null),
@@ -291,21 +291,21 @@ final class PropertyNames
         "IceStorm",
         false,
         true,
-        new Property[] {
-        });
+        new Property[]{
+            });
 
     public static final PropertyArray IceStormAdminProps = new PropertyArray(
         "IceStormAdmin",
         false,
         true,
-        new Property[] {
-        });
+        new Property[]{
+            });
 
     public static final PropertyArray IceBTProps = new PropertyArray(
         "IceBT",
         false,
         false,
-        new Property[] {
+        new Property[]{
             new Property("RcvSize", false, "", false, null),
             new Property("SndSize", false, "", false, null)
         });
@@ -314,32 +314,35 @@ final class PropertyNames
         "Glacier2",
         false,
         true,
-        new Property[] {
-        });
+        new Property[]{
+            });
 
     public static final PropertyArray DataStormProps = new PropertyArray(
         "DataStorm",
         false,
         true,
-        new Property[] {
-        });
+        new Property[]{
+            });
 
     public static final PropertyArray validProps[] =
-    {
-        IceProps,
-        IceMXProps,
-        IceDiscoveryProps,
-        IceLocatorDiscoveryProps,
-        IceBoxProps,
-        IceBoxAdminProps,
-        IceBridgeProps,
-        IceGridAdminProps,
-        IceGridProps,
-        IceSSLProps,
-        IceStormProps,
-        IceStormAdminProps,
-        IceBTProps,
-        Glacier2Props,
-        DataStormProps
-    };
+        {
+            IceProps,
+            IceMXProps,
+            IceDiscoveryProps,
+            IceLocatorDiscoveryProps,
+            IceBoxProps,
+            IceBoxAdminProps,
+            IceBridgeProps,
+            IceGridAdminProps,
+            IceGridProps,
+            IceSSLProps,
+            IceStormProps,
+            IceStormAdminProps,
+            IceBTProps,
+            Glacier2Props,
+            DataStormProps
+        };
+
+    private PropertyNames() {
+    }
 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PropertyNames.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PropertyNames.java
@@ -12,7 +12,7 @@ final class PropertyNames
         "Proxy",
         false,
         false,
-        new Property[]{
+        new Property[] {
             new Property("EndpointSelection", false, "", false, null),
             new Property("ConnectionCached", false, "", false, null),
             new Property("PreferSecure", false, "", false, null),
@@ -28,7 +28,7 @@ final class PropertyNames
         "Connection",
         true,
         false,
-        new Property[]{
+        new Property[] {
             new Property("CloseTimeout", false, "10", false, null),
             new Property("ConnectTimeout", false, "10", false, null),
             new Property("EnableIdleCheck", false, "1", false, null),
@@ -41,7 +41,7 @@ final class PropertyNames
         "ThreadPool",
         true,
         false,
-        new Property[]{
+        new Property[] {
             new Property("Size", false, "1", false, null),
             new Property("SizeMax", false, "", false, null),
             new Property("SizeWarn", false, "0", false, null),
@@ -55,7 +55,7 @@ final class PropertyNames
         "ObjectAdapter",
         true,
         false,
-        new Property[]{
+        new Property[] {
             new Property("AdapterId", false, "", false, null),
             new Property("Connection", false, "", false, PropertyNames.ConnectionProps),
             new Property("Endpoints", false, "", false, null),
@@ -74,13 +74,14 @@ final class PropertyNames
         "LMDB",
         true,
         false,
-        new Property[]{});
+        new Property[] {
+        });
 
     public static final PropertyArray IceProps = new PropertyArray(
         "Ice",
         false,
         false,
-        new Property[]{
+        new Property[] {
             new Property("AcceptClassCycles", false, "0", false, null),
             new Property("Admin", false, "", false, PropertyNames.ObjectAdapterProps),
             new Property("Admin.DelayCreation", false, "0", false, null),
@@ -130,6 +131,7 @@ final class PropertyNames
             new Property("ProgramName", false, "", false, null),
             new Property("RetryIntervals", false, "0", false, null),
             new Property("ServerIdleTime", false, "0", false, null),
+            new Property("SliceLoader.NotFoundCacheSize", false, "100", false, null),
             new Property("SOCKSProxyHost", false, "", false, null),
             new Property("SOCKSProxyPort", false, "1080", false, null),
             new Property("StdErr", false, "", false, null),
@@ -162,6 +164,7 @@ final class PropertyNames
             new Property("Warn.Dispatch", false, "1", false, null),
             new Property("Warn.Endpoints", false, "1", false, null),
             new Property("Warn.Executor", false, "1", false, null),
+            new Property("Warn.SliceLoader", false, "1", false, null),
             new Property("Warn.UnusedProperties", false, "0", false, null),
             new Property("CacheMessageBuffers", false, "2", false, null)
         });
@@ -170,7 +173,7 @@ final class PropertyNames
         "IceMX",
         false,
         false,
-        new Property[]{
+        new Property[] {
             new Property("Metrics\\.[^\\s]+\\.GroupBy", true, "", false, null),
             new Property("Metrics\\.[^\\s]+\\.Map", true, "", false, null),
             new Property("Metrics\\.[^\\s]+\\.RetainDetached", true, "10", false, null),
@@ -183,7 +186,7 @@ final class PropertyNames
         "IceDiscovery",
         false,
         false,
-        new Property[]{
+        new Property[] {
             new Property("Multicast", false, "", false, PropertyNames.ObjectAdapterProps),
             new Property("Reply", false, "", false, PropertyNames.ObjectAdapterProps),
             new Property("Locator", false, "", false, PropertyNames.ObjectAdapterProps),
@@ -201,7 +204,7 @@ final class PropertyNames
         "IceLocatorDiscovery",
         false,
         false,
-        new Property[]{
+        new Property[] {
             new Property("Reply", false, "", false, PropertyNames.ObjectAdapterProps),
             new Property("Locator", false, "", false, PropertyNames.ObjectAdapterProps),
             new Property("Lookup", false, "", false, null),
@@ -219,7 +222,7 @@ final class PropertyNames
         "IceBox",
         false,
         true,
-        new Property[]{
+        new Property[] {
             new Property("InheritProperties", false, "", false, null),
             new Property("LoadOrder", false, "", false, null),
             new Property("PrintServicesReady", false, "", false, null),
@@ -232,7 +235,7 @@ final class PropertyNames
         "IceBoxAdmin",
         false,
         true,
-        new Property[]{
+        new Property[] {
             new Property("ServiceManager.Proxy", false, "", false, PropertyNames.ProxyProps)
         });
 
@@ -240,13 +243,14 @@ final class PropertyNames
         "IceBridge",
         false,
         true,
-        new Property[]{});
+        new Property[] {
+        });
 
     public static final PropertyArray IceGridAdminProps = new PropertyArray(
         "IceGridAdmin",
         false,
         true,
-        new Property[]{
+        new Property[] {
             new Property("MetricsConfig", false, "", false, null),
             new Property("Trace.Observers", false, "", false, null),
             new Property("Trace.SaveToRegistry", false, "", false, null)
@@ -256,13 +260,14 @@ final class PropertyNames
         "IceGrid",
         false,
         true,
-        new Property[]{});
+        new Property[] {
+        });
 
     public static final PropertyArray IceSSLProps = new PropertyArray(
         "IceSSL",
         false,
         false,
-        new Property[]{
+        new Property[] {
             new Property("Alias", false, "", false, null),
             new Property("CheckCertName", false, "0", false, null),
             new Property("DefaultDir", false, "", false, null),
@@ -286,19 +291,21 @@ final class PropertyNames
         "IceStorm",
         false,
         true,
-        new Property[]{});
+        new Property[] {
+        });
 
     public static final PropertyArray IceStormAdminProps = new PropertyArray(
         "IceStormAdmin",
         false,
         true,
-        new Property[]{});
+        new Property[] {
+        });
 
     public static final PropertyArray IceBTProps = new PropertyArray(
         "IceBT",
         false,
         false,
-        new Property[]{
+        new Property[] {
             new Property("RcvSize", false, "", false, null),
             new Property("SndSize", false, "", false, null)
         });
@@ -307,32 +314,32 @@ final class PropertyNames
         "Glacier2",
         false,
         true,
-        new Property[]{});
+        new Property[] {
+        });
 
     public static final PropertyArray DataStormProps = new PropertyArray(
         "DataStorm",
         false,
         true,
-        new Property[]{});
+        new Property[] {
+        });
 
     public static final PropertyArray validProps[] =
-        {
-            IceProps,
-            IceMXProps,
-            IceDiscoveryProps,
-            IceLocatorDiscoveryProps,
-            IceBoxProps,
-            IceBoxAdminProps,
-            IceBridgeProps,
-            IceGridAdminProps,
-            IceGridProps,
-            IceSSLProps,
-            IceStormProps,
-            IceStormAdminProps,
-            IceBTProps,
-            Glacier2Props,
-            DataStormProps
-        };
-
-    private PropertyNames() {}
+    {
+        IceProps,
+        IceMXProps,
+        IceDiscoveryProps,
+        IceLocatorDiscoveryProps,
+        IceBoxProps,
+        IceBoxAdminProps,
+        IceBridgeProps,
+        IceGridAdminProps,
+        IceGridProps,
+        IceSSLProps,
+        IceStormProps,
+        IceStormAdminProps,
+        IceBTProps,
+        Glacier2Props,
+        DataStormProps
+    };
 }

--- a/java/test/src/main/java/test/Ice/slicing/objects/Client.java
+++ b/java/test/src/main/java/test/Ice/slicing/objects/Client.java
@@ -17,6 +17,8 @@ public class Client extends TestHelper {
         var initData = new InitializationData();
         initData.properties = createTestProperties(args);
         initData.properties.setProperty("Ice.Package.Test", "test.Ice.slicing.objects.client");
+        initData.properties.setProperty("Ice.SliceLoader.NotFoundCacheSize", "5");
+        initData.properties.setProperty("Ice.Warn.SliceLoader", "0"); // comment out to see the warning
         initData.sliceLoader = new ClassSliceLoader(CompactPDerived.class, CompactPCDerived.class);
 
         try (Communicator communicator = initialize(initData)) {


### PR DESCRIPTION
This PR adds a bound no found to the Java SliceLoader. This caching is controlled by two new properties:

Ice.SliceLoader.NotFoundCacheSize (default = 100)
Ice.Warn.SliceLoader (default = 1)

When Ice.SliceLoader.NotFoundCacheSize is <= 0, the communicator doesn't cache null result.
When Ice.Warn.SliceLoader > 0, the internal not found cache issues a one-time warning when the cache is full.

See also #3874.