### PR TITLE
Bringing back 'requires' files for packages in Ruby

### DIFF
--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -33,5 +33,9 @@ install:: | $(DESTDIR)$(install_rubydir)
 	$(Q)$(INSTALL) -m 644 $(lang_srcdir)/ruby/*.rb $(DESTDIR)$(install_rubydir)
 
 $(eval $(call make-ruby-package,$(slicedir),$(lang_srcdir)/ruby,Ice))
+$(eval $(call make-ruby-package,$(slicedir),$(lang_srcdir)/ruby,Glacier2))
+$(eval $(call make-ruby-package,$(slicedir),$(lang_srcdir)/ruby,IceBox))
+$(eval $(call make-ruby-package,$(slicedir),$(lang_srcdir)/ruby,IceGrid))
+$(eval $(call make-ruby-package,$(slicedir),$(lang_srcdir)/ruby,IceStorm))
 
 all:: srcs

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -84,7 +84,11 @@ task :generate_sources do
 
     # Define source Slice directories included in the gem.
     ice_slice_sources = [
+        "../slice/Glacier2",
         "../slice/Ice",
+        "../slice/IceBox",
+        "../slice/IceGrid",
+        "../slice/IceStorm",
     ]
 
     for source_dir in ice_slice_sources do

--- a/ruby/ruby/Glacier2.rb
+++ b/ruby/ruby/Glacier2.rb
@@ -1,0 +1,7 @@
+#
+# Copyright (c) ZeroC, Inc. All rights reserved.
+#
+
+require 'Glacier2/Router'
+require 'Glacier2/PermissionsVerifier'
+require 'Glacier2/Metrics'

--- a/ruby/ruby/Glacier2.rb
+++ b/ruby/ruby/Glacier2.rb
@@ -1,4 +1,4 @@
-# Copyright (c) ZeroC, Inc. All rights reserved.
+# Copyright (c) ZeroC, Inc.
 
 require 'Glacier2/Router'
 require 'Glacier2/PermissionsVerifier'

--- a/ruby/ruby/Glacier2.rb
+++ b/ruby/ruby/Glacier2.rb
@@ -1,6 +1,4 @@
-#
 # Copyright (c) ZeroC, Inc. All rights reserved.
-#
 
 require 'Glacier2/Router'
 require 'Glacier2/PermissionsVerifier'

--- a/ruby/ruby/IceBox.rb
+++ b/ruby/ruby/IceBox.rb
@@ -1,0 +1,5 @@
+#
+# Copyright (c) ZeroC, Inc. All rights reserved.
+#
+
+require 'IceBox/IceBox'

--- a/ruby/ruby/IceBox.rb
+++ b/ruby/ruby/IceBox.rb
@@ -1,5 +1,3 @@
-#
 # Copyright (c) ZeroC, Inc. All rights reserved.
-#
 
-require 'IceBox/IceBox'
+require 'IceBox/ServiceManager.rb'

--- a/ruby/ruby/IceBox.rb
+++ b/ruby/ruby/IceBox.rb
@@ -1,3 +1,3 @@
-# Copyright (c) ZeroC, Inc. All rights reserved.
+# Copyright (c) ZeroC, Inc.
 
 require 'IceBox/ServiceManager.rb'

--- a/ruby/ruby/IceGrid.rb
+++ b/ruby/ruby/IceGrid.rb
@@ -1,0 +1,9 @@
+#
+# Copyright (c) ZeroC, Inc. All rights reserved.
+#
+
+require 'IceGrid/Admin.rb'
+require 'IceGrid/Descriptor.rb'
+require 'IceGrid/FileParser.rb'
+require 'IceGrid/Registry.rb'
+require 'IceGrid/UserAccountMapper.rb'

--- a/ruby/ruby/IceGrid.rb
+++ b/ruby/ruby/IceGrid.rb
@@ -1,9 +1,9 @@
-#
 # Copyright (c) ZeroC, Inc. All rights reserved.
-#
 
 require 'IceGrid/Admin.rb'
 require 'IceGrid/Descriptor.rb'
+require 'IceGrid/Exception.rb'
 require 'IceGrid/FileParser.rb'
 require 'IceGrid/Registry.rb'
+require 'IceGrid/Session.rb'
 require 'IceGrid/UserAccountMapper.rb'

--- a/ruby/ruby/IceGrid.rb
+++ b/ruby/ruby/IceGrid.rb
@@ -1,4 +1,4 @@
-# Copyright (c) ZeroC, Inc. All rights reserved.
+# Copyright (c) ZeroC, Inc.
 
 require 'IceGrid/Admin.rb'
 require 'IceGrid/Descriptor.rb'

--- a/ruby/ruby/IceStorm.rb
+++ b/ruby/ruby/IceStorm.rb
@@ -1,0 +1,6 @@
+#
+# Copyright (c) ZeroC, Inc. All rights reserved.
+#
+
+require 'IceStorm/IceStorm'
+require 'IceStorm/Metrics'

--- a/ruby/ruby/IceStorm.rb
+++ b/ruby/ruby/IceStorm.rb
@@ -1,6 +1,4 @@
-#
 # Copyright (c) ZeroC, Inc. All rights reserved.
-#
 
 require 'IceStorm/IceStorm'
 require 'IceStorm/Metrics'

--- a/ruby/ruby/IceStorm.rb
+++ b/ruby/ruby/IceStorm.rb
@@ -1,4 +1,4 @@
-# Copyright (c) ZeroC, Inc. All rights reserved.
+# Copyright (c) ZeroC, Inc.
 
 require 'IceStorm/IceStorm'
 require 'IceStorm/Metrics'


### PR DESCRIPTION
This PR brings back the files to connect Ice for Ruby with some of the various packages that were included in the past. Someone using an installation of Ice for Ruby will still have to use `requires 'PackageName'` in order to use the packages that are being brought back through this PR.