### PR TITLE
Update IceTargets.cmake to include ICE_RUNTIME_DLLS property

### DIFF
--- a/cpp/config/IceTargets.cmake
+++ b/cpp/config/IceTargets.cmake
@@ -161,6 +161,14 @@ include(CMakeFindDependencyMacro)
 find_package(Threads REQUIRED QUIET)
 
 add_ice_library(Ice Threads::Threads)
+if(WIN32)
+  # Bzip2 is included in the Ice NuGet package and is a runtime dependency of Ice.
+  # This property can be used to copy the correct DLLs to the target directory at build time.
+  set_property(TARGET Ice::Ice PROPERTY ICE_RUNTIME_DLLS
+    "$<$<CONFIG:Debug>:${Ice_PREFIX}/build/native/bin/${Ice_WIN32_PLATFORM}/Debug/bzip2d.dll>"
+    "$<$<CONFIG:Release>:${Ice_PREFIX}/build/native/bin/${Ice_WIN32_PLATFORM}/Release/bzip2.dll>"
+  )
+endif()
 add_ice_library(DataStorm Ice::Ice)
 add_ice_library(Glacier2 Ice::Ice)
 add_ice_library(IceBox Ice::Ice)


### PR DESCRIPTION
CMake doesn't have a builtin way to easily copy "private" dependencies for an imported target (at least one that I can find).

This primarily an issue for the bzip2 dependency on Windows. 

- We can't use `$<TARGET_RUNTIME_DLLS:foo>`  as we don't want bzip2 to be a transitive public dependency. 
- There's not really anywhere else to list the "private" dependency. 

See also https://discourse.cmake.org/t/how-to-install-additional-runtime-dll-dependencies-of-an-imported-target/7508

This PR adds new property (`ICE_RUNTIME_DLLS`) to the `Ice::Ice` target.

Users (and our demos) can use it as follows:

```
$<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
```

For example:
```
add_custom_command(TARGET client POST_BUILD
  COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:client>
    $<TARGET_RUNTIME_DLLS:client>
    $<GENEX_EVAL:$<TARGET_PROPERTY:Ice::Ice,ICE_RUNTIME_DLLS>>
  COMMAND_EXPAND_LISTS
)
```
