### PR TITLE
Update IcePy to use SliceLoader

### DIFF
--- a/cpp/include/Ice/DefaultSliceLoader.h
+++ b/cpp/include/Ice/DefaultSliceLoader.h
@@ -121,7 +121,7 @@ namespace IceInternal
             {
                 return p->second;
             }
-            return {};
+            return std::to_string(compactId);
         }
 
     private:

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -11,6 +11,7 @@
 #include "Logger.h"
 #include "ReferenceF.h"
 #include "SlicedDataF.h"
+#include "SliceLoader.h"
 #include "StreamableTraits.h"
 #include "UserExceptionFactory.h"
 #include "ValueF.h"
@@ -58,30 +59,34 @@ namespace Ice
         /// Constructs an InputStream using a communicator and this communicator's default encoding version.
         /// @param communicator The communicator to use for unmarshaling tasks.
         /// @param bytes The encoded data.
-        InputStream(const CommunicatorPtr& communicator, const std::vector<std::byte>& bytes);
+        /// @param sliceLoader The Slice loader. When nullptr, use the communicator's Slice loader.
+        InputStream(const CommunicatorPtr& communicator, const std::vector<std::byte>& bytes,
+                    SliceLoaderPtr sliceLoader = nullptr);
 
-        /// @copydoc InputStream(const CommunicatorPtr&, const std::vector<std::byte>&)
-        InputStream(const CommunicatorPtr& communicator, std::pair<const std::byte*, const std::byte*> bytes);
+        /// @copydoc InputStream(const CommunicatorPtr&, const std::vector<std::byte>&, SliceLoaderPtr)
+        InputStream(const CommunicatorPtr& communicator, std::pair<const std::byte*, const std::byte*> bytes, SliceLoaderPtr sliceLoader = nullptr);
 
         /// Constructs an InputStream using a communicator and encoding version.
         /// @param communicator The communicator to use for unmarshaling tasks.
         /// @param encoding The encoding version used to encode the data to be unmarshaled.
         /// @param bytes The encoded data.
-        InputStream(const CommunicatorPtr& communicator, EncodingVersion encoding, const std::vector<std::byte>& bytes);
+        /// @param sliceLoader The Slice loader. When nullptr, use the communicator's Slice loader.
+        InputStream(const CommunicatorPtr& communicator, EncodingVersion encoding, const std::vector<std::byte>& bytes, SliceLoaderPtr sliceLoader = nullptr);
 
-        /// @copydoc InputStream(const CommunicatorPtr&, EncodingVersion, const std::vector<std::byte>&)
+        /// @copydoc InputStream(const CommunicatorPtr&, EncodingVersion, const std::vector<std::byte>&, SliceLoaderPtr)
         InputStream(
             const CommunicatorPtr& communicator,
             EncodingVersion encoding,
-            std::pair<const std::byte*, const std::byte*> bytes);
+            std::pair<const std::byte*, const std::byte*> bytes,
+            SliceLoaderPtr sliceLoader = nullptr);
 
         /// @private
         /// Constructs a stream with an empty buffer.
-        InputStream(IceInternal::Instance* instance, EncodingVersion encoding);
+        InputStream(IceInternal::Instance* instance, EncodingVersion encoding, SliceLoaderPtr sliceLoader = nullptr);
 
         /// @private
         /// Constructs a stream with the specified encoding and buffer.
-        InputStream(IceInternal::Instance* instance, EncodingVersion encoding, IceInternal::Buffer& buf, bool adopt);
+        InputStream(IceInternal::Instance* instance, EncodingVersion encoding, IceInternal::Buffer& buf, bool adopt, SliceLoaderPtr sliceLoader = nullptr);
 
         /// Move constructor.
         /// @param other The input stream to move into this input stream.
@@ -657,7 +662,7 @@ namespace Ice
 #endif
 
         // The primary constructor, called by all other constructors. It requires a non-null instance.
-        InputStream(IceInternal::Instance* instance, EncodingVersion encoding, IceInternal::Buffer&& buf);
+        InputStream(IceInternal::Instance* instance, EncodingVersion encoding, IceInternal::Buffer&& buf, SliceLoaderPtr sliceLoader);
 
         // Reads a reference from the stream; the return value can be null.
         IceInternal::ReferencePtr readReference();
@@ -909,7 +914,7 @@ namespace Ice
         //
         EncodingVersion _encoding;
 
-        Encaps* _currentEncaps;
+        Encaps* _currentEncaps{nullptr};
 
         void initEncaps();
 
@@ -918,13 +923,15 @@ namespace Ice
         // Retrieved during construction and cached.
         const size_t _classGraphDepthMax;
 
-        void* _closure;
+        void* _closure{nullptr};
 
-        int _startSeq;
-        int _minSeqSize;
+        int _startSeq{-1};
+        int _minSeqSize{0};
 
         // Retrieved from instance during construction and cached. Never null.
         const ValueFactoryManagerPtr _valueFactoryManager;
+
+        const SliceLoaderPtr _sliceLoader; // never null
 
         std::vector<std::function<void()>> _deleters;
     };

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -10,8 +10,8 @@
 #include "LocalException.h"
 #include "Logger.h"
 #include "ReferenceF.h"
-#include "SlicedDataF.h"
 #include "SliceLoader.h"
+#include "SlicedDataF.h"
 #include "StreamableTraits.h"
 #include "UserExceptionFactory.h"
 #include "ValueF.h"
@@ -60,18 +60,27 @@ namespace Ice
         /// @param communicator The communicator to use for unmarshaling tasks.
         /// @param bytes The encoded data.
         /// @param sliceLoader The Slice loader. When nullptr, use the communicator's Slice loader.
-        InputStream(const CommunicatorPtr& communicator, const std::vector<std::byte>& bytes,
-                    SliceLoaderPtr sliceLoader = nullptr);
+        InputStream(
+            const CommunicatorPtr& communicator,
+            const std::vector<std::byte>& bytes,
+            SliceLoaderPtr sliceLoader = nullptr);
 
         /// @copydoc InputStream(const CommunicatorPtr&, const std::vector<std::byte>&, SliceLoaderPtr)
-        InputStream(const CommunicatorPtr& communicator, std::pair<const std::byte*, const std::byte*> bytes, SliceLoaderPtr sliceLoader = nullptr);
+        InputStream(
+            const CommunicatorPtr& communicator,
+            std::pair<const std::byte*, const std::byte*> bytes,
+            SliceLoaderPtr sliceLoader = nullptr);
 
         /// Constructs an InputStream using a communicator and encoding version.
         /// @param communicator The communicator to use for unmarshaling tasks.
         /// @param encoding The encoding version used to encode the data to be unmarshaled.
         /// @param bytes The encoded data.
         /// @param sliceLoader The Slice loader. When nullptr, use the communicator's Slice loader.
-        InputStream(const CommunicatorPtr& communicator, EncodingVersion encoding, const std::vector<std::byte>& bytes, SliceLoaderPtr sliceLoader = nullptr);
+        InputStream(
+            const CommunicatorPtr& communicator,
+            EncodingVersion encoding,
+            const std::vector<std::byte>& bytes,
+            SliceLoaderPtr sliceLoader = nullptr);
 
         /// @copydoc InputStream(const CommunicatorPtr&, EncodingVersion, const std::vector<std::byte>&, SliceLoaderPtr)
         InputStream(
@@ -86,7 +95,12 @@ namespace Ice
 
         /// @private
         /// Constructs a stream with the specified encoding and buffer.
-        InputStream(IceInternal::Instance* instance, EncodingVersion encoding, IceInternal::Buffer& buf, bool adopt, SliceLoaderPtr sliceLoader = nullptr);
+        InputStream(
+            IceInternal::Instance* instance,
+            EncodingVersion encoding,
+            IceInternal::Buffer& buf,
+            bool adopt,
+            SliceLoaderPtr sliceLoader = nullptr);
 
         /// Move constructor.
         /// @param other The input stream to move into this input stream.
@@ -662,7 +676,11 @@ namespace Ice
 #endif
 
         // The primary constructor, called by all other constructors. It requires a non-null instance.
-        InputStream(IceInternal::Instance* instance, EncodingVersion encoding, IceInternal::Buffer&& buf, SliceLoaderPtr sliceLoader);
+        InputStream(
+            IceInternal::Instance* instance,
+            EncodingVersion encoding,
+            IceInternal::Buffer&& buf,
+            SliceLoaderPtr sliceLoader);
 
         // Reads a reference from the stream; the return value can be null.
         IceInternal::ReferencePtr readReference();

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -121,7 +121,8 @@ Ice::InputStream::InputStream(
 }
 
 Ice::InputStream::InputStream(InputStream&& other) noexcept
-    : InputStream{other._instance, other._encoding, std::move(other), nullptr} // only moves (and resets) the base class
+    // only moves (and resets) the base class
+    : InputStream{other._instance, other._encoding, std::move(other), other._sliceLoader}
 {
     _closure = other._closure;
     _startSeq = other._startSeq;

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -80,7 +80,10 @@ Ice::InputStream::InputStream(const CommunicatorPtr& communicator, const vector<
 {
 }
 
-Ice::InputStream::InputStream(const CommunicatorPtr& communicator, pair<const byte*, const byte*> p, SliceLoaderPtr sliceLoader)
+Ice::InputStream::InputStream(
+    const CommunicatorPtr& communicator,
+    pair<const byte*, const byte*> p,
+    SliceLoaderPtr sliceLoader)
     : InputStream{
           getInstance(communicator).get(),
           getInstance(communicator)->defaultsAndOverrides()->defaultEncoding,
@@ -89,7 +92,11 @@ Ice::InputStream::InputStream(const CommunicatorPtr& communicator, pair<const by
 {
 }
 
-Ice::InputStream::InputStream(const CommunicatorPtr& communicator, EncodingVersion encoding, const vector<byte>& v, SliceLoaderPtr sliceLoader)
+Ice::InputStream::InputStream(
+    const CommunicatorPtr& communicator,
+    EncodingVersion encoding,
+    const vector<byte>& v,
+    SliceLoaderPtr sliceLoader)
     : InputStream{getInstance(communicator).get(), encoding, Buffer{v}, std::move(sliceLoader)}
 {
 }
@@ -103,7 +110,12 @@ Ice::InputStream::InputStream(
 {
 }
 
-Ice::InputStream::InputStream(Instance* instance, EncodingVersion encoding, Buffer& buf, bool adopt, SliceLoaderPtr sliceLoader)
+Ice::InputStream::InputStream(
+    Instance* instance,
+    EncodingVersion encoding,
+    Buffer& buf,
+    bool adopt,
+    SliceLoaderPtr sliceLoader)
     : InputStream{instance, encoding, Buffer{buf, adopt}, std::move(sliceLoader)}
 {
 }
@@ -1854,8 +1866,7 @@ Ice::InputStream::EncapsDecoder11::throwException(UserExceptionFactory exception
         //
         if (!exceptionFactory)
         {
-            std::exception_ptr exceptionPtr =
-                _stream->_sliceLoader->newExceptionInstance(_current->typeId);
+            std::exception_ptr exceptionPtr = _stream->_sliceLoader->newExceptionInstance(_current->typeId);
 
             if (exceptionPtr)
             {

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -66,46 +66,50 @@ IceInternal::Ex::throwMarshalException(const char* file, int line, string reason
     throw Ice::MarshalException{file, line, std::move(reason)};
 }
 
-Ice::InputStream::InputStream(Instance* instance, EncodingVersion encoding) : InputStream{instance, encoding, Buffer{}}
+Ice::InputStream::InputStream(Instance* instance, EncodingVersion encoding, SliceLoaderPtr sliceLoader)
+    : InputStream{instance, encoding, Buffer{}, std::move(sliceLoader)}
 {
 }
 
-Ice::InputStream::InputStream(const CommunicatorPtr& communicator, const vector<byte>& v)
+Ice::InputStream::InputStream(const CommunicatorPtr& communicator, const vector<byte>& v, SliceLoaderPtr sliceLoader)
     : InputStream{
           getInstance(communicator).get(),
           getInstance(communicator)->defaultsAndOverrides()->defaultEncoding,
-          Buffer{v}}
+          Buffer{v},
+          std::move(sliceLoader)}
 {
 }
 
-Ice::InputStream::InputStream(const CommunicatorPtr& communicator, pair<const byte*, const byte*> p)
+Ice::InputStream::InputStream(const CommunicatorPtr& communicator, pair<const byte*, const byte*> p, SliceLoaderPtr sliceLoader)
     : InputStream{
           getInstance(communicator).get(),
           getInstance(communicator)->defaultsAndOverrides()->defaultEncoding,
-          Buffer{p.first, p.second}}
+          Buffer{p.first, p.second},
+          std::move(sliceLoader)}
 {
 }
 
-Ice::InputStream::InputStream(const CommunicatorPtr& communicator, EncodingVersion encoding, const vector<byte>& v)
-    : InputStream{getInstance(communicator).get(), encoding, Buffer{v}}
+Ice::InputStream::InputStream(const CommunicatorPtr& communicator, EncodingVersion encoding, const vector<byte>& v, SliceLoaderPtr sliceLoader)
+    : InputStream{getInstance(communicator).get(), encoding, Buffer{v}, std::move(sliceLoader)}
 {
 }
 
 Ice::InputStream::InputStream(
     const CommunicatorPtr& communicator,
     EncodingVersion encoding,
-    pair<const byte*, const byte*> p)
-    : InputStream{getInstance(communicator).get(), encoding, Buffer{p.first, p.second}}
+    pair<const byte*, const byte*> p,
+    SliceLoaderPtr sliceLoader)
+    : InputStream{getInstance(communicator).get(), encoding, Buffer{p.first, p.second}, std::move(sliceLoader)}
 {
 }
 
-Ice::InputStream::InputStream(Instance* instance, EncodingVersion encoding, Buffer& buf, bool adopt)
-    : InputStream{instance, encoding, Buffer{buf, adopt}}
+Ice::InputStream::InputStream(Instance* instance, EncodingVersion encoding, Buffer& buf, bool adopt, SliceLoaderPtr sliceLoader)
+    : InputStream{instance, encoding, Buffer{buf, adopt}, std::move(sliceLoader)}
 {
 }
 
 Ice::InputStream::InputStream(InputStream&& other) noexcept
-    : InputStream{other._instance, other._encoding, std::move(other)} // only moves (and resets) the base class
+    : InputStream{other._instance, other._encoding, std::move(other), nullptr} // only moves (and resets) the base class
 {
     _closure = other._closure;
     _startSeq = other._startSeq;
@@ -1034,18 +1038,16 @@ Ice::InputStream::read(vector<wstring>& v)
     }
 }
 
-Ice::InputStream::InputStream(Instance* instance, EncodingVersion encoding, Buffer&& buf)
+Ice::InputStream::InputStream(Instance* instance, EncodingVersion encoding, Buffer&& buf, SliceLoaderPtr sliceLoader)
     : Buffer(std::move(buf)),
       _instance(instance),
       _encoding(encoding),
-      _currentEncaps(nullptr),
       _classGraphDepthMax(instance->classGraphDepthMax()),
-      _closure(nullptr),
-      _startSeq(-1),
-      _minSeqSize(0),
-      _valueFactoryManager(instance->initializationData().valueFactoryManager)
+      _valueFactoryManager(instance->initializationData().valueFactoryManager),
+      _sliceLoader{sliceLoader ? std::move(sliceLoader) : instance->sliceLoader()}
 {
     assert(_valueFactoryManager);
+    assert(_sliceLoader);
 }
 
 ReferencePtr
@@ -1373,7 +1375,7 @@ Ice::InputStream::EncapsDecoder::newInstance(string_view typeId)
 
     if (!v)
     {
-        v = _stream->instance()->sliceLoader()->newClassInstance(typeId);
+        v = _stream->_sliceLoader->newClassInstance(typeId);
     }
 
     return v;
@@ -1557,7 +1559,7 @@ Ice::InputStream::EncapsDecoder10::throwException(UserExceptionFactory exception
         //
         if (!exceptionFactory)
         {
-            std::exception_ptr exceptionPtr = _stream->instance()->sliceLoader()->newExceptionInstance(_typeId);
+            std::exception_ptr exceptionPtr = _stream->_sliceLoader->newExceptionInstance(_typeId);
 
             if (exceptionPtr)
             {
@@ -1853,7 +1855,7 @@ Ice::InputStream::EncapsDecoder11::throwException(UserExceptionFactory exception
         if (!exceptionFactory)
         {
             std::exception_ptr exceptionPtr =
-                _stream->instance()->sliceLoader()->newExceptionInstance(_current->typeId);
+                _stream->_sliceLoader->newExceptionInstance(_current->typeId);
 
             if (exceptionPtr)
             {

--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -176,8 +176,6 @@ communicatorInit(CommunicatorObject* self, PyObject* args, PyObject* /*kwds*/)
         return -1;
     }
 
-    data.compactIdResolver = resolveCompactId;
-
     // Always accept cycles in Python
     data.properties->setProperty("Ice.AcceptClassCycles", "1");
 

--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -2,6 +2,7 @@
 
 #include "Communicator.h"
 #include "BatchRequestInterceptor.h"
+#include "DefaultSliceLoader.h"
 #include "Executor.h"
 #include "Future.h"
 #include "Ice/DisableWarnings.h"
@@ -151,6 +152,8 @@ communicatorInit(CommunicatorObject* self, PyObject* args, PyObject* /*kwds*/)
 
         // We always supply our own implementation of ValueFactoryManager.
         data.valueFactoryManager = ValueFactoryManager::create();
+
+        data.sliceLoader = make_shared<DefaultSliceLoader>();
 
         if (!data.properties)
         {

--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -153,7 +153,7 @@ communicatorInit(CommunicatorObject* self, PyObject* args, PyObject* /*kwds*/)
         // We always supply our own implementation of ValueFactoryManager.
         data.valueFactoryManager = ValueFactoryManager::create();
 
-        data.sliceLoader = make_shared<DefaultSliceLoader>();
+        // data.sliceLoader remains null as we don't want to change the Slice loader for the Ice C++ runtime.
 
         if (!data.properties)
         {
@@ -1558,6 +1558,14 @@ IcePy::getCommunicator(PyObject* obj)
     assert(PyObject_IsInstance(obj, reinterpret_cast<PyObject*>(&CommunicatorType)));
     auto* cobj = reinterpret_cast<CommunicatorObject*>(obj);
     return *cobj->communicator;
+}
+
+Ice::SliceLoaderPtr
+IcePy::getSliceLoader(const Ice::CommunicatorPtr&)
+{
+    // For now, we just return the default Slice loader singleton. In the future, we need to return a composite loader
+    // when the user install a Slice loader written in Python in initData.
+    return DefaultSliceLoader::instance();
 }
 
 PyObject*

--- a/python/modules/IcePy/Communicator.h
+++ b/python/modules/IcePy/Communicator.h
@@ -5,6 +5,7 @@
 
 #include "Config.h"
 #include "Ice/CommunicatorF.h"
+#include "Ice/SliceLoader.h"
 
 namespace IcePy
 {
@@ -13,6 +14,7 @@ namespace IcePy
     bool initCommunicator(PyObject*);
 
     Ice::CommunicatorPtr getCommunicator(PyObject*);
+    Ice::SliceLoaderPtr getSliceLoader(const Ice::CommunicatorPtr&);
 
     PyObject* createCommunicator(const Ice::CommunicatorPtr&);
     PyObject* getCommunicatorWrapper(const Ice::CommunicatorPtr&);

--- a/python/modules/IcePy/DefaultSliceLoader.cpp
+++ b/python/modules/IcePy/DefaultSliceLoader.cpp
@@ -35,7 +35,7 @@ IcePy::DefaultSliceLoader::newClassInstance(string_view typeId) const
     auto* type = reinterpret_cast<PyTypeObject*>(info->pythonType);
     PyObjectHandle emptyArgs{PyTuple_New(0)};
     PyObjectHandle obj{type->tp_new(type, emptyArgs.get(), nullptr)};
-    if (!obj.get())
+    if (!obj)
     {
         assert(PyErr_Occurred());
         throw AbortMarshaling();

--- a/python/modules/IcePy/DefaultSliceLoader.cpp
+++ b/python/modules/IcePy/DefaultSliceLoader.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "DefaultSliceLoader.h"
+#include "Thread.h"
+#include "Types.h"
+
+using namespace std;
+using namespace IcePy;
+
+Ice::ValuePtr
+IcePy::DefaultSliceLoader::newClassInstance(string_view typeId) const
+{
+    AdoptThread adoptThread; // Ensure the current thread is able to call into Python.
+
+    // Get the type information.
+    ValueInfoPtr info =
+        typeId == Ice::Value::ice_staticId() ? lookupValueInfo("::Ice::UnknownSlicedValue") : lookupValueInfo(typeId);
+
+    if (!info)
+    {
+        return nullptr;
+    }
+
+    // Instantiate the object.
+    auto* type = reinterpret_cast<PyTypeObject*>(info->pythonType);
+    PyObjectHandle emptyArgs{PyTuple_New(0)};
+    PyObjectHandle obj{type->tp_new(type, emptyArgs.get(), nullptr)};
+    if (!obj.get())
+    {
+        assert(PyErr_Occurred());
+        throw AbortMarshaling();
+    }
+
+    return make_shared<ValueReader>(obj.get(), info);
+}

--- a/python/modules/IcePy/DefaultSliceLoader.h
+++ b/python/modules/IcePy/DefaultSliceLoader.h
@@ -4,8 +4,8 @@
 #define ICEPY_DEFAULT_SLICE_LOADER_H
 
 #include "Config.h"
-#include "Util.h"
 #include "Ice/Ice.h"
+#include "Util.h"
 
 #include <map>
 #include <mutex>

--- a/python/modules/IcePy/DefaultSliceLoader.h
+++ b/python/modules/IcePy/DefaultSliceLoader.h
@@ -1,0 +1,23 @@
+// Copyright (c) ZeroC, Inc.
+
+#ifndef ICEPY_DEFAULT_SLICE_LOADER_H
+#define ICEPY_DEFAULT_SLICE_LOADER_H
+
+#include "Config.h"
+#include "Util.h"
+#include "Ice/Ice.h"
+
+#include <map>
+#include <mutex>
+
+namespace IcePy
+{
+    class DefaultSliceLoader final : public Ice::SliceLoader
+    {
+    public:
+        [[nodiscard]] Ice::ValuePtr newClassInstance(std::string_view typeId) const final;
+        // [[nodiscard]] std::exception_ptr newExceptionInstance(std::string_view typeId) const final;
+    };
+}
+
+#endif

--- a/python/modules/IcePy/DefaultSliceLoader.h
+++ b/python/modules/IcePy/DefaultSliceLoader.h
@@ -12,11 +12,17 @@
 
 namespace IcePy
 {
+    /// Instantiates generated Python classes/exceptions based on the Slice type ID.
     class DefaultSliceLoader final : public Ice::SliceLoader
     {
     public:
+        static Ice::SliceLoaderPtr instance();
+
         [[nodiscard]] Ice::ValuePtr newClassInstance(std::string_view typeId) const final;
-        // [[nodiscard]] std::exception_ptr newExceptionInstance(std::string_view typeId) const final;
+        [[nodiscard]] std::exception_ptr newExceptionInstance(std::string_view typeId) const final;
+
+    private:
+        DefaultSliceLoader() = default;
     };
 }
 

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -1221,7 +1221,7 @@ IcePy::Invocation::unmarshalResults(const OperationPtr& op, pair<const byte*, co
     PyObjectHandle results{PyTuple_New(numResults)};
     if (results.get() && numResults > 0)
     {
-        Ice::InputStream is(_communicator, bytes);
+        Ice::InputStream is{_communicator, bytes, getSliceLoader(_communicator)};
 
         //
         // Store a pointer to a local StreamUtil object as the stream's closure.
@@ -1287,7 +1287,7 @@ IcePy::Invocation::unmarshalResults(const OperationPtr& op, pair<const byte*, co
 PyObject*
 IcePy::Invocation::unmarshalException(const OperationPtr& op, pair<const byte*, const byte*> bytes)
 {
-    Ice::InputStream is(_communicator, bytes);
+    Ice::InputStream is{_communicator, bytes, getSliceLoader(_communicator)};
 
     //
     // Store a pointer to a local StreamUtil object as the stream's closure.
@@ -1301,15 +1301,7 @@ IcePy::Invocation::unmarshalException(const OperationPtr& op, pair<const byte*, 
 
     try
     {
-        is.throwException(
-            [](string_view id)
-            {
-                ExceptionInfoPtr info = lookupExceptionInfo(id);
-                if (info)
-                {
-                    throw ExceptionReader(info);
-                }
-            });
+        is.throwException();
     }
     catch (const ExceptionReader& r)
     {
@@ -1499,7 +1491,6 @@ IcePy::AsyncInvocation::AsyncInvocation(const Ice::ObjectPrx& prx, PyObject* pyP
       _pyProxy(Py_NewRef(pyProxy)),
       _operation(std::move(operation)),
       _twoway(prx->ice_isTwoway())
-
 {
 }
 
@@ -2139,7 +2130,7 @@ IcePy::TypedUpcall::dispatch(PyObject* servant, pair<const byte*, const byte*> i
 
     if (!_op->inParams.empty())
     {
-        Ice::InputStream is(_communicator, inBytes);
+        Ice::InputStream is{_communicator, inBytes, getSliceLoader(_communicator)};
 
         //
         // Store a pointer to a local StreamUtil object as the stream's closure.

--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -27,9 +27,6 @@ using namespace IceInternal;
 using ValueInfoMap = map<string, ValueInfoPtr, std::less<>>;
 static ValueInfoMap valueInfoMap;
 
-using CompactIdMap = map<int32_t, ValueInfoPtr>;
-static CompactIdMap compactIdMap;
-
 using ProxyInfoMap = map<string, ProxyInfoPtr, std::less<>>;
 static ProxyInfoMap proxyInfoMap;
 
@@ -3721,20 +3718,6 @@ IcePy::ExceptionReader::getException() const
 }
 
 //
-// IdResolver
-//
-string
-IcePy::resolveCompactId(int32_t id)
-{
-    auto p = compactIdMap.find(id);
-    if (p != compactIdMap.end())
-    {
-        return p->second->id;
-    }
-    return {};
-}
-
-//
 // lookupValueInfo()
 //
 IcePy::ValueInfoPtr
@@ -4112,12 +4095,12 @@ IcePy_defineValue(PyObject*, PyObject* args)
 
     if (info->compactId != -1)
     {
-        auto q = compactIdMap.find(info->compactId);
-        if (q != compactIdMap.end())
+        // Insert a second entry for the compact ID.
+        string compactIdStr = to_string(info->compactId);
+        if (!lookupValueInfo(compactIdStr))
         {
-            compactIdMap.erase(q);
+            addValueInfo(compactIdStr, info);
         }
-        compactIdMap.insert(CompactIdMap::value_type(info->compactId, info));
     }
 
     return r;

--- a/python/modules/IcePy/Types.h
+++ b/python/modules/IcePy/Types.h
@@ -659,8 +659,6 @@ namespace IcePy
         PyObjectHandle _ex;
     };
 
-    std::string resolveCompactId(std::int32_t id);
-
     ValueInfoPtr lookupValueInfo(std::string_view);
     ExceptionInfoPtr lookupExceptionInfo(std::string_view);
 

--- a/python/modules/IcePy/ValueFactoryManager.h
+++ b/python/modules/IcePy/ValueFactoryManager.h
@@ -40,14 +40,6 @@ namespace IcePy
 
     using CustomValueFactoryPtr = std::shared_ptr<CustomValueFactory>;
 
-    // The default Python value factory as a C++ value factory.
-    class DefaultValueFactory final : public ValueFactory
-    {
-    public:
-        std::shared_ptr<Ice::Value> create(std::string_view) final;
-    };
-    using DefaultValueFactoryPtr = std::shared_ptr<DefaultValueFactory>;
-
     class ValueFactoryManager final : public Ice::ValueFactoryManager
     {
     public:
@@ -70,7 +62,6 @@ namespace IcePy
 
         PyObjectHandle _self;
         CustomFactoryMap _customFactories;
-        const DefaultValueFactoryPtr _defaultFactory;
     };
 
     using ValueFactoryManagerPtr = std::shared_ptr<ValueFactoryManager>;

--- a/python/modules/IcePy/msbuild/icepy.vcxproj
+++ b/python/modules/IcePy/msbuild/icepy.vcxproj
@@ -34,6 +34,7 @@
     <ClCompile Include="..\Connection.cpp" />
     <ClCompile Include="..\ConnectionInfo.cpp" />
     <ClCompile Include="..\Current.cpp" />
+    <ClCompile Include="..\DefaultSliceLoader.cpp" />
     <ClCompile Include="..\Executor.cpp" />
     <ClCompile Include="..\Future.cpp" />
     <ClCompile Include="..\Endpoint.cpp" />
@@ -60,6 +61,7 @@
     <ClInclude Include="..\Connection.h" />
     <ClInclude Include="..\ConnectionInfo.h" />
     <ClInclude Include="..\Current.h" />
+    <ClInclude Include="..\DefaultSliceLoader.h" />
     <ClInclude Include="..\Executor.h" />
     <ClInclude Include="..\Endpoint.h" />
     <ClInclude Include="..\EndpointInfo.h" />
@@ -155,7 +157,6 @@
       <ImportLibrary />
     </Link>
     <ClCompile>
-
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -163,7 +164,6 @@
       <ImportLibrary />
     </Link>
     <ClCompile>
-
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -171,7 +171,6 @@
       <ImportLibrary />
     </Link>
     <ClCompile>
-
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -179,7 +178,6 @@
       <ImportLibrary />
     </Link>
     <ClCompile>
-
     </ClCompile>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/python/modules/IcePy/msbuild/icepy.vcxproj.filters
+++ b/python/modules/IcePy/msbuild/icepy.vcxproj.filters
@@ -106,6 +106,9 @@
     <ClCompile Include="..\..\..\..\cpp\src\slice2py\PythonUtil.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\DefaultSliceLoader.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\BatchRequestInterceptor.h">
@@ -175,6 +178,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\..\cpp\src\slice2py\PythonUtil.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\DefaultSliceLoader.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
This PR updates the InputStream constructors in C++ to accept an optional SliceLoaderPtr parameter.

This Slice loader parameter is used by IcePy to inject its Python-specific Slice loader, that creates Python class instances and the C++ ExceptionReader for exceptions (like before).


