### PR TITLE
Report exceptions from DataStorm session creation.

### DIFF
--- a/cpp/src/DataStorm/Contract.ice
+++ b/cpp/src/DataStorm/Contract.ice
@@ -394,20 +394,17 @@ module DataStormContract
     /// The reason for the session creation failure.
     enum SessionError
     {
-        // The session is already connected.
+        /// The session is already connected.
         AlreadyConnected,
 
-        // Node is shutting down.
+        /// Node is shutting down.
         NodeShutdown,
 
-        // The connection failed
-        ConnectionFailure,
-
-        // A confirmation was received for a session that doesn't exist.
+        /// A confirmation was received for a session that doesn't exist.
         SessionNotFound,
 
-        // The session failed for an unknown reason.
-        UnknownError,
+        /// The session creation failed due to an internal error.
+        Internal,
     }
 
     /// Throws when the session cannot be created.

--- a/cpp/src/DataStorm/Contract.ice
+++ b/cpp/src/DataStorm/Contract.ice
@@ -391,6 +391,31 @@ module DataStormContract
         void s(long topicId, long elementId, DataSample sample);
     }
 
+    /// The reason for the session creation failure.
+    enum SessionError
+    {
+        // The session is already connected.
+        AlreadyConnected,
+
+        // Node is shutting down.
+        NodeShutdown,
+
+        // The connection failed
+        ConnectionFailure,
+
+        // A confirmation was received for a session that doesn't exist.
+        SessionNotFound,
+
+        // The session failed for an unknown reason.
+        UnknownError,
+    }
+
+    /// Throws when the session cannot be created.
+    exception SessionCreationException
+    {
+        SessionError error;
+    }
+
     /// The Node interface allows DataStorm nodes to create publisher and subscriber sessions with each other.
     ///
     /// When a node has a writer for a topic that another node is reading, the node initiates the creation of a
@@ -406,8 +431,9 @@ module DataStormContract
         /// reader for which this node has a corresponding topic writer.
         ///
         /// @param publisher The publisher node initiating the session. The proxy is never null.
+        /// @throws SessionCreationException if the session cannot be created.
         /// @see Lookup::announceTopicReader
-        void initiateCreateSession(Node* publisher);
+        ["amd"] void initiateCreateSession(Node* publisher) throws SessionCreationException;
 
         /// Initiates the creation of a subscriber session with a node. The subscriber node sends this request to a
         /// publisher node in one of the following scenarios:
@@ -423,13 +449,16 @@ module DataStormContract
         /// @param subscriber The subscriber node initiating the session. This proxy is never null.
         /// @param session The subscriber session being created. This proxy is never null.
         /// @param fromRelay Indicates whether the session is being created from a relay node.
-        void createSession(Node* subscriber, SubscriberSession* session, bool fromRelay);
+        /// @throws SessionCreationException if the session cannot be created.
+        ["amd"] void createSession(Node* subscriber, SubscriberSession* session, bool fromRelay)
+            throws SessionCreationException;
 
         /// Confirm the creation of a publisher session with a node.
         ///
         /// @param publisher The publisher node confirming the session. The proxy is never null.
         /// @param session The publisher session being confirmed. The proxy is never null.
-        void confirmCreateSession(Node* publisher, PublisherSession* session);
+        /// @throws SessionCreationException if the session cannot be created.
+        ["amd"] void confirmCreateSession(Node* publisher, PublisherSession* session) throws SessionCreationException;
     }
 
     /// The lookup interface is used by DataStorm nodes to announce their topic readers and writers to other connected

--- a/cpp/src/DataStorm/Contract.ice
+++ b/cpp/src/DataStorm/Contract.ice
@@ -392,7 +392,7 @@ module DataStormContract
     }
 
     /// The reason for the session creation failure.
-    enum SessionError
+    enum SessionCreationError
     {
         /// The session is already connected.
         AlreadyConnected,
@@ -410,7 +410,7 @@ module DataStormContract
     /// Throws when the session cannot be created.
     exception SessionCreationException
     {
-        SessionError error;
+        SessionCreationError error;
     }
 
     /// The Node interface allows DataStorm nodes to create publisher and subscriber sessions with each other.

--- a/cpp/src/DataStorm/Contract.ice
+++ b/cpp/src/DataStorm/Contract.ice
@@ -428,7 +428,7 @@ module DataStormContract
         /// reader for which this node has a corresponding topic writer.
         ///
         /// @param publisher The publisher node initiating the session. The proxy is never null.
-        /// @throws SessionCreationException if the session cannot be created.
+        /// @throws SessionCreationException Thrown when the session cannot be created.
         /// @see Lookup::announceTopicReader
         ["amd"] void initiateCreateSession(Node* publisher) throws SessionCreationException;
 
@@ -446,7 +446,7 @@ module DataStormContract
         /// @param subscriber The subscriber node initiating the session. This proxy is never null.
         /// @param session The subscriber session being created. This proxy is never null.
         /// @param fromRelay Indicates whether the session is being created from a relay node.
-        /// @throws SessionCreationException if the session cannot be created.
+        /// @throws SessionCreationException Thrown when the session cannot be created.
         ["amd"] void createSession(Node* subscriber, SubscriberSession* session, bool fromRelay)
             throws SessionCreationException;
 
@@ -454,7 +454,7 @@ module DataStormContract
         ///
         /// @param publisher The publisher node confirming the session. The proxy is never null.
         /// @param session The publisher session being confirmed. The proxy is never null.
-        /// @throws SessionCreationException if the session cannot be created.
+        /// @throws SessionCreationException Thrown when the session cannot be created.
         ["amd"] void confirmCreateSession(Node* publisher, PublisherSession* session) throws SessionCreationException;
     }
 

--- a/cpp/src/DataStorm/NodeI.cpp
+++ b/cpp/src/DataStorm/NodeI.cpp
@@ -208,7 +208,8 @@ NodeI::createSessionAsync(
                         out << "node '" << current.id << "' is ignoring '" << current.operation << "' request from '"
                             << subscriber << "' because session '" << session->getId() << "' is already connected";
                     }
-                    exception(std::make_exception_ptr(SessionCreationException{SessionCreationError::AlreadyConnected}));
+                    exception(
+                        std::make_exception_ptr(SessionCreationException{SessionCreationError::AlreadyConnected}));
                     return;
                 }
                 response();

--- a/cpp/src/DataStorm/NodeI.cpp
+++ b/cpp/src/DataStorm/NodeI.cpp
@@ -146,9 +146,23 @@ NodeI::initiateCreateSessionAsync(
         createPublisherSession(*publisher, current.con, nullptr);
         response();
     }
-    catch (const std::exception&)
+    catch (const SessionCreationException&)
     {
         exception(current_exception());
+    }
+    catch (const CommunicatorDestroyedException&)
+    {
+        // The node is shutting down, don't retry.
+        exception(make_exception_ptr(SessionCreationException{SessionCreationError::NodeShutdown}));
+    }
+    catch (const ObjectAdapterDestroyedException&)
+    {
+        // The node is shutting down, don't retry.
+        exception(make_exception_ptr(SessionCreationException{SessionCreationError::NodeShutdown}));
+    }
+    catch (const std::exception&)
+    {
+        exception(make_exception_ptr(SessionCreationException{SessionCreationError::Internal}));
     }
 }
 

--- a/cpp/src/DataStorm/NodeI.cpp
+++ b/cpp/src/DataStorm/NodeI.cpp
@@ -355,6 +355,9 @@ NodeI::createSubscriberSession(
     auto instance = _instance.lock();
     assert(instance);
 
+    // The publisher session is null when we are creating a new session, in response to a topic reader announcement. It
+    // is not null when we are attempting to reconnect an existing session.
+
     try
     {
         subscriber = getNodeWithExistingConnection(instance, subscriber, subscriberConnection);
@@ -368,7 +371,7 @@ NodeI::createSubscriberSession(
                 {
                     self->retryPublisherSessionCreation(subscriber, session, ex);
                 }
-                // Else node is shutting down.
+                // Else node is shutting down, or the session was established by a concurrent call.
             });
     }
     catch (const CommunicatorDestroyedException&)
@@ -385,6 +388,7 @@ NodeI::createSubscriberSession(
         {
             retryPublisherSessionCreation(subscriber, session, current_exception());
         }
+        // Else node is shutting down, or the session was established by a concurrent call.
     }
 }
 

--- a/cpp/src/DataStorm/NodeI.cpp
+++ b/cpp/src/DataStorm/NodeI.cpp
@@ -160,7 +160,7 @@ NodeI::initiateCreateSessionAsync(
         // The node is shutting down, don't retry.
         exception(make_exception_ptr(SessionCreationException{SessionCreationError::NodeShutdown}));
     }
-    catch (const std::exception&)
+    catch (const LocalException&)
     {
         exception(make_exception_ptr(SessionCreationException{SessionCreationError::Internal}));
     }
@@ -212,7 +212,6 @@ NodeI::createSessionAsync(
         s->ice_getConnectionAsync(
             [=, self = shared_from_this()](const auto& connection) mutable
             {
-                assert(session);
                 if (session->checkSession())
                 {
                     // The session is already connected.
@@ -382,8 +381,10 @@ NodeI::createSubscriberSession(
     }
     catch (const LocalException&)
     {
-        assert(session);
-        retryPublisherSessionCreation(subscriber, session, current_exception());
+        if (session)
+        {
+            retryPublisherSessionCreation(subscriber, session, current_exception());
+        }
     }
 }
 

--- a/cpp/src/DataStorm/NodeI.h
+++ b/cpp/src/DataStorm/NodeI.h
@@ -57,6 +57,16 @@ namespace DataStormI
             const Ice::ConnectionPtr&,
             std::shared_ptr<SubscriberSessionI>);
 
+        void retrySubscriberSessionCreation(
+            const DataStormContract::NodePrx&,
+            const std::shared_ptr<SubscriberSessionI>&,
+            std::exception_ptr);
+
+        void retryPublisherSessionCreation(
+            const DataStormContract::NodePrx&,
+            const std::shared_ptr<PublisherSessionI>&,
+            std::exception_ptr);
+
         void removeSubscriberSession(
             const DataStormContract::NodePrx&,
             const std::shared_ptr<SubscriberSessionI>&,

--- a/cpp/src/DataStorm/NodeI.h
+++ b/cpp/src/DataStorm/NodeI.h
@@ -26,17 +26,25 @@ namespace DataStormI
         void init();
         void destroy(bool);
 
-        void initiateCreateSession(std::optional<DataStormContract::NodePrx>, const Ice::Current&) final;
+        void initiateCreateSessionAsync(
+            std::optional<DataStormContract::NodePrx>,
+            std::function<void()>,
+            std::function<void(std::exception_ptr)>,
+            const Ice::Current&) final;
 
-        void createSession(
+        void createSessionAsync(
             std::optional<DataStormContract::NodePrx>,
             std::optional<DataStormContract::SubscriberSessionPrx>,
             bool,
+            std::function<void()>,
+            std::function<void(std::exception_ptr)>,
             const Ice::Current&) final;
 
-        void confirmCreateSession(
+        void confirmCreateSessionAsync(
             std::optional<DataStormContract::NodePrx>,
             std::optional<DataStormContract::PublisherSessionPrx>,
+            std::function<void()>,
+            std::function<void(std::exception_ptr)>,
             const Ice::Current&) final;
 
         void createSubscriberSession(

--- a/cpp/src/DataStorm/NodeSessionI.cpp
+++ b/cpp/src/DataStorm/NodeSessionI.cpp
@@ -51,7 +51,7 @@ namespace
                 }
                 catch (const CommunicatorDestroyedException&)
                 {
-                    exception(make_exception_ptr(SessionCreationException{SessionError::NodeShutdown}));
+                    exception(make_exception_ptr(SessionCreationException{SessionCreationError::NodeShutdown}));
                 }
             }
         }
@@ -87,7 +87,7 @@ namespace
                 }
                 catch (const CommunicatorDestroyedException&)
                 {
-                    exception(make_exception_ptr(SessionCreationException{SessionError::NodeShutdown}));
+                    exception(make_exception_ptr(SessionCreationException{SessionCreationError::NodeShutdown}));
                 }
             }
         }
@@ -120,7 +120,7 @@ namespace
                 }
                 catch (const CommunicatorDestroyedException&)
                 {
-                    exception(make_exception_ptr(SessionCreationException{SessionError::NodeShutdown}));
+                    exception(make_exception_ptr(SessionCreationException{SessionCreationError::NodeShutdown}));
                 }
             }
         }

--- a/cpp/src/DataStorm/NodeSessionI.cpp
+++ b/cpp/src/DataStorm/NodeSessionI.cpp
@@ -33,7 +33,11 @@ namespace
         {
         }
 
-        void initiateCreateSession(optional<NodePrx> publisher, const Current& current) final
+        void initiateCreateSessionAsync(
+            optional<NodePrx> publisher,
+            function<void()> response,
+            function<void(exception_ptr)> exception,
+            const Current& current) final
         {
             checkNotNull(publisher, __FILE__, __LINE__, current);
             if (auto nodeSession = _nodeSession.lock())
@@ -42,19 +46,22 @@ namespace
                 {
                     optional<SessionPrx> sessionPrx;
                     updateNodeAndSessionProxy(*publisher, sessionPrx, current);
-                    // Forward the call to the target Node object, don't need to wait for the result.
-                    _node->initiateCreateSessionAsync(publisher, nullptr);
+                    // Forward the call to the target Node.
+                    _node->initiateCreateSessionAsync(publisher, response, exception);
                 }
                 catch (const CommunicatorDestroyedException&)
                 {
+                    exception(make_exception_ptr(SessionCreationException{SessionError::NodeShutdown}));
                 }
             }
         }
 
-        void createSession(
+        void createSessionAsync(
             optional<NodePrx> subscriber,
             optional<SubscriberSessionPrx> subscriberSession,
             bool /* fromRelay */,
+            function<void()> response,
+            function<void(exception_ptr)> exception,
             const Current& current) final
         {
             checkNotNull(subscriber, __FILE__, __LINE__, current);
@@ -75,18 +82,21 @@ namespace
                     nodeSession->addSession(
                         subscriberIsHostedOnRelay ? subscriberSession->ice_fixed(current.con) : *subscriberSession);
 
-                    // Forward the call to the target Node object, don't need to wait for the result.
-                    _node->createSessionAsync(subscriber, subscriberSessionForwarder, true, nullptr);
+                    // Forward the call to the target Node.
+                    _node->createSessionAsync(subscriber, subscriberSessionForwarder, true, response, exception);
                 }
                 catch (const CommunicatorDestroyedException&)
                 {
+                    exception(make_exception_ptr(SessionCreationException{SessionError::NodeShutdown}));
                 }
             }
         }
 
-        void confirmCreateSession(
+        void confirmCreateSessionAsync(
             optional<NodePrx> publisher,
             optional<PublisherSessionPrx> publisherSession,
+            function<void()> response,
+            function<void(exception_ptr)> exception,
             const Current& current) final
         {
             checkNotNull(publisher, __FILE__, __LINE__, current);
@@ -106,10 +116,11 @@ namespace
                     nodeSession->addSession(
                         publisherIsHostedOnRelay ? publisherSession->ice_fixed(current.con) : *publisherSession);
                     // Forward the request to the target subscriber.
-                    _node->confirmCreateSessionAsync(publisher, publisherSessionForwarder, nullptr);
+                    _node->confirmCreateSessionAsync(publisher, publisherSessionForwarder, response, exception);
                 }
                 catch (const CommunicatorDestroyedException&)
                 {
+                    exception(make_exception_ptr(SessionCreationException{SessionError::NodeShutdown}));
                 }
             }
         }

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -669,7 +669,7 @@ SessionI::retry(NodePrx node, exception_ptr exception)
         }
         catch (const SessionCreationException& ex)
         {
-            if (ex.error == SessionError::NodeShutdown)
+            if (ex.error == SessionCreationError::NodeShutdown)
             {
                 // Don't need to retry if the target node is being shut down.
                 return false;

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -667,12 +667,14 @@ SessionI::retry(NodePrx node, exception_ptr exception)
         {
             rethrow_exception(exception);
         }
-        catch (const DataStormContract::SessionCreationException& ex)
+        catch (const SessionCreationException& ex)
         {
             if (ex.error == SessionError::NodeShutdown)
             {
+                // Don't need to retry if the target node is being shut down.
                 return false;
             }
+            // Else, for other error codes we can retry.
         }
         catch (const ObjectAdapterDestroyedException&)
         {
@@ -684,6 +686,7 @@ SessionI::retry(NodePrx node, exception_ptr exception)
         }
         catch (const std::exception&)
         {
+            // Ignore other exceptions and retry.
         }
     }
 

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -667,6 +667,13 @@ SessionI::retry(NodePrx node, exception_ptr exception)
         {
             rethrow_exception(exception);
         }
+        catch (const DataStormContract::SessionCreationException& ex)
+        {
+            if (ex.error == SessionError::NodeShutdown)
+            {
+                return false;
+            }
+        }
         catch (const ObjectAdapterDestroyedException&)
         {
             return false;
@@ -769,15 +776,15 @@ SessionI::destroyImpl(const exception_ptr& ex)
             }
             catch (const LocalException& e)
             {
-                out << "\n:" << e.what() << "\n" << e.ice_stackTrace();
+                out << ":\n" << e.what() << "\n" << e.ice_stackTrace();
             }
             catch (const exception& e)
             {
-                out << "\n:" << e.what();
+                out << ":\n" << e.what();
             }
             catch (...)
             {
-                out << "\n: unexpected exception";
+                out << ":\n unexpected exception";
             }
         }
     }

--- a/cpp/src/DataStorm/TopicFactoryI.cpp
+++ b/cpp/src/DataStorm/TopicFactoryI.cpp
@@ -228,6 +228,14 @@ TopicFactoryI::createPublisherSession(
             //
             // In all cases, no further action is required, and the exception can safely be ignored.
         }
+        catch (const CommunicatorDestroyedException&)
+        {
+            // The node is shutting down.
+        }
+        catch (const ObjectAdapterDestroyedException&)
+        {
+            // The node is shutting down.
+        }
     }
 }
 

--- a/cpp/src/DataStorm/TopicFactoryI.cpp
+++ b/cpp/src/DataStorm/TopicFactoryI.cpp
@@ -113,7 +113,20 @@ TopicFactoryI::createTopicWriter(
         auto nodePrx = node->getProxy();
         if (hasReaders)
         {
-            node->createPublisherSession(nodePrx, nullptr, nullptr);
+            try
+            {
+                node->createPublisherSession(nodePrx, nullptr, nullptr);
+            }
+            catch (const SessionCreationException&)
+            {
+                // Session creation failed upon receiving a writer announcement. This can happen if:
+                //
+                // - The session is already connected.
+                // - The node that sent the announcement is shutting down.
+                // - This node is shutting down.
+                //
+                // In all cases, no further action is required, and the exception can safely be ignored.
+            }
         }
         node->getPublisherForwarder()->announceTopics({TopicInfo{.name = name, .ids = {writer->getId()}}}, false);
         instance->getNodeSessionManager()->announceTopicWriter(name, nodePrx);
@@ -201,7 +214,20 @@ TopicFactoryI::createPublisherSession(
     {
         auto instance = _instance.lock();
         assert(instance);
-        instance->getNode()->createPublisherSession(publisher, connection, nullptr);
+        try
+        {
+            instance->getNode()->createPublisherSession(publisher, connection, nullptr);
+        }
+        catch (const SessionCreationException&)
+        {
+            // Session creation failed upon receiving a writer announcement. This can happen if:
+            //
+            // - The session is already connected.
+            // - The node that sent the announcement is shutting down.
+            // - This node is shutting down.
+            //
+            // In all cases, no further action is required, and the exception can safely be ignored.
+        }
     }
 }
 


### PR DESCRIPTION
This PR updates DataStorm publisher and subscriber session creation to report errors. This allows to retry the session creation when the state of the session gets out of sync, meaning on peer detects the closure before the other and is trying to migrate the session to a new connection.