### PR TITLE
Fix for Checkstyle exclusion regarding generated files

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -57,7 +57,7 @@ subprojects {
             task.enabled = enableCodeAnalysis
         dependsOn(rewriteDryRun)
         exclude(
-            '**/generated/**'
+            '**/generated/**/*'
         )
     }
 


### PR DESCRIPTION
There was an issue with Checkstyle's exclude arguments. Now, Gradle will glob correctly in order to exclude generated files from Checkstyle's scans.