### PR TITLE
Simplify compact IDs in C++

### DIFF
--- a/cpp/include/Ice/DefaultSliceLoader.h
+++ b/cpp/include/Ice/DefaultSliceLoader.h
@@ -44,8 +44,6 @@ namespace IceInternal
 
             if (compactId >= 0)
             {
-                _compactIdTable[compactId] = T::ice_staticId();
-
                 std::string compactIdStr{std::to_string(compactId)};
                 p = _classFactories.find(compactIdStr);
                 if (p == _classFactories.end())
@@ -112,18 +110,6 @@ namespace IceInternal
             }
         }
 
-        // temporary
-        std::string resolveCompactId(int compactId) const
-        {
-            std::lock_guard lock{_mutex};
-            auto p = _compactIdTable.find(compactId);
-            if (p != _compactIdTable.end())
-            {
-                return p->second;
-            }
-            return std::to_string(compactId);
-        }
-
     private:
         using ClassFactory = std::function<Ice::ValuePtr()>;
         using ExceptionFactory = std::function<std::exception_ptr()>;
@@ -134,9 +120,6 @@ namespace IceInternal
 
         std::map<std::string, std::pair<ClassFactory, int>, std::less<>> _classFactories;
         std::map<std::string, std::pair<ExceptionFactory, int>, std::less<>> _exceptionFactories;
-
-        // temporary
-        std::map<int, std::string> _compactIdTable;
     };
 
     template<class T> class ClassInit

--- a/cpp/include/Ice/DefaultSliceLoader.h
+++ b/cpp/include/Ice/DefaultSliceLoader.h
@@ -42,7 +42,7 @@ namespace IceInternal
                 p->second.second++;
             }
 
-            if (compactId >= 0)
+            if (compactId != -1)
             {
                 std::string compactIdStr{std::to_string(compactId)};
                 p = _classFactories.find(compactIdStr);
@@ -69,7 +69,7 @@ namespace IceInternal
                 }
             }
 
-            if (compactId >= 0)
+            if (compactId != -1)
             {
                 std::string compactIdStr{std::to_string(compactId)};
                 p = _classFactories.find(compactIdStr);

--- a/cpp/include/Ice/Initialize.h
+++ b/cpp/include/Ice/Initialize.h
@@ -89,9 +89,6 @@ namespace Ice
         /// @param con The connection associated with this call. May be null.
         std::function<void(std::function<void()> call, const Ice::ConnectionPtr& con)> executor{};
 
-        /// @private
-        std::function<std::string(int id)> compactIdResolver{};
-
         /// The batch request interceptor, which is called by the Ice runtime to enqueue a batch request.
         /// @param req An object representing the batch request.
         /// @param count The number of requests currently in the queue.

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -222,11 +222,10 @@ namespace Ice
         EncodingVersion skipEncapsulation();
 
         /// Reads the start of a value or exception slice.
-        /// @return The Slice type ID for this slice.
-        std::string startSlice()
+        void startSlice()
         {
             assert(_currentEncaps && _currentEncaps->decoder);
-            return _currentEncaps->decoder->startSlice();
+            _currentEncaps->decoder->startSlice();
         }
 
         /// Indicates that the end of a value or exception slice has been reached.
@@ -714,7 +713,7 @@ namespace Ice
 
             virtual void startInstance(SliceType) = 0;
             virtual SlicedDataPtr endInstance() = 0;
-            virtual const std::string& startSlice() = 0;
+            virtual void startSlice() = 0;
             virtual void endSlice() = 0;
             virtual void skipSlice() = 0;
 
@@ -784,7 +783,7 @@ namespace Ice
 
             void startInstance(SliceType) override;
             SlicedDataPtr endInstance() override;
-            const std::string& startSlice() override;
+            void startSlice() override;
             void endSlice() override;
             void skipSlice() override;
 
@@ -820,7 +819,7 @@ namespace Ice
 
             void startInstance(SliceType) override;
             SlicedDataPtr endInstance() override;
-            const std::string& startSlice() override;
+            void startSlice() override;
             void endSlice() override;
             void skipSlice() override;
 

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -689,8 +689,6 @@ namespace Ice
 
         void throwUnmarshalOutOfBoundsException(const char*, int);
 
-        [[nodiscard]] std::string resolveCompactId(int) const;
-
         class Encaps;
         enum SliceType
         {
@@ -871,7 +869,7 @@ namespace Ice
                 std::uint8_t sliceFlags{0};
                 std::int32_t sliceSize{0};
                 std::string typeId;
-                int compactId{0};
+                int compactId{-1};
                 IndirectPatchList indirectPatchList;
 
                 InstanceData* previous{nullptr};

--- a/cpp/include/Ice/SlicedData.h
+++ b/cpp/include/Ice/SlicedData.h
@@ -7,6 +7,7 @@
 #include "SlicedDataF.h"
 #include "Value.h"
 
+#include <cassert>
 #include <string>
 
 #if defined(__clang__)
@@ -23,7 +24,7 @@ namespace Ice
     /// @headerfile Ice/Ice.h
     struct SliceInfo
     {
-        /// The Slice type ID for this slice.
+        /// The Slice type ID for this slice. It's empty when the compact ID is set (not `-1`).
         const std::string typeId;
 
         /// The Slice compact type ID for this slice. No compact ID is encoded as `-1`.
@@ -59,6 +60,14 @@ namespace Ice
               hasOptionalMembers(hasOptionalMembers),
               isLastSlice(isLastSlice)
         {
+            if (compactId == -1)
+            {
+                assert(typeId.empty());
+            }
+            else
+            {
+                assert(!typeId.empty());
+            }
         }
     };
 

--- a/cpp/include/Ice/SlicedData.h
+++ b/cpp/include/Ice/SlicedData.h
@@ -60,7 +60,14 @@ namespace Ice
               hasOptionalMembers(hasOptionalMembers),
               isLastSlice(isLastSlice)
         {
-            assert((compactId == -1) == typeId.empty());
+            if (compactId == -1)
+            {
+                assert(!this->typeId.empty());
+            }
+            else
+            {
+                assert(this->typeId.empty());
+            }
         }
     };
 

--- a/cpp/include/Ice/SlicedData.h
+++ b/cpp/include/Ice/SlicedData.h
@@ -60,14 +60,7 @@ namespace Ice
               hasOptionalMembers(hasOptionalMembers),
               isLastSlice(isLastSlice)
         {
-            if (compactId == -1)
-            {
-                assert(typeId.empty());
-            }
-            else
-            {
-                assert(!typeId.empty());
-            }
+            assert((compactId == -1) == typeId.empty());
         }
     };
 

--- a/cpp/src/Ice/OutputStream.cpp
+++ b/cpp/src/Ice/OutputStream.cpp
@@ -1282,7 +1282,7 @@ Ice::OutputStream::EncapsEncoder11::startSlice(string_view typeId, int compactId
         //
         if (_encaps->format == FormatType::SlicedFormat || _current->firstSlice)
         {
-            if (compactId >= 0)
+            if (compactId != -1)
             {
                 _current->sliceFlags |= FLAG_HAS_TYPE_ID_COMPACT;
                 _stream->writeSize(compactId);

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -2684,7 +2684,7 @@ Slice::ClassDef::ClassDef(const ContainerPtr& container, const string& name, int
       _base(std::move(base)),
       _compactId(id)
 {
-    if (_compactId >= 0)
+    if (_compactId != -1)
     {
         unit()->addTypeId(_compactId, scoped());
     }

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1442,7 +1442,7 @@ Slice::Gen::SliceLoaderVisitor::visitClassDefStart(const ClassDefPtr& p)
     const string flatScopedName = p->mappedScoped("_");
 
     C << nl << "const IceInternal::ClassInit<" << scopedName << "> iceC" << flatScopedName << "_init";
-    if (p->compactId() >= 0)
+    if (p->compactId() != -1)
     {
         C << '{' << p->compactId() << '}';
     }

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1007,7 +1007,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     _out << sp;
     writeDocComment(p, "class");
     _out << nl << "[Ice.SliceTypeId(\"" << p->scoped() << "\")]";
-    if (p->compactId() >= 0)
+    if (p->compactId() != -1)
     {
         _out << nl << "[Ice.CompactSliceTypeId(" << p->compactId() << ")]";
     }

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -1779,7 +1779,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     }
 
     out << nl << "@com.zeroc.Ice.SliceTypeId(value = \"" << p->scoped() << "\")";
-    if (p->compactId() >= 0)
+    if (p->compactId() != -1)
     {
         out << nl << "@com.zeroc.Ice.CompactSliceTypeId(value = " << p->compactId() << ")";
     }

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -616,7 +616,7 @@ bool
 Slice::Gen::ImportVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
     _seenClass = true;
-    if (p->compactId() >= 0)
+    if (p->compactId() != -1)
     {
         _seenCompactId = true;
     }
@@ -1120,7 +1120,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     _out << sp;
 
     _out << nl << "Ice.defineValue(" << scopedName << ", \"" << p->scoped() << "\"";
-    if (p->compactId() >= 0)
+    if (p->compactId() != -1)
     {
         _out << ", " << p->compactId();
     }

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -1350,7 +1350,7 @@ CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     out.close();
 
-    if (p->compactId() >= 0)
+    if (p->compactId() != -1)
     {
         ostringstream ostr;
         ostr << "IceCompactId.TypeId_" << p->compactId();

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -252,7 +252,7 @@ Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     out << eb;
     out << eb;
 
-    if (p->compactId() >= 0)
+    if (p->compactId() != -1)
     {
         // For each Value class using a compact id we generate an extension method in TypeIdResolver.
         out << sp;

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -3,7 +3,6 @@
 #nullable enable
 
 using System.Diagnostics;
-using System.Globalization;
 
 using Protocol = Ice.Internal.Protocol;
 
@@ -2141,14 +2140,7 @@ public sealed class OutputStream
 
             foreach (SliceInfo info in slicedData.slices)
             {
-                if (info.typeId.StartsWith("::", StringComparison.Ordinal))
-                {
-                    startSlice(info.typeId, -1, info.isLastSlice);
-                }
-                else
-                {
-                    startSlice("", int.Parse(info.typeId, CultureInfo.InvariantCulture), info.isLastSlice);
-                }
+                startSlice(info.typeId, info.compactId, info.isLastSlice);
 
                 //
                 // Write the bytes associated with this slice.

--- a/csharp/src/Ice/OutputStream.cs
+++ b/csharp/src/Ice/OutputStream.cs
@@ -2021,7 +2021,7 @@ public sealed class OutputStream
                 //
                 if (_encaps.format == FormatType.SlicedFormat || _current.firstSlice)
                 {
-                    if (compactId >= 0)
+                    if (compactId != -1)
                     {
                         _current.sliceFlags |= Protocol.FLAG_HAS_TYPE_ID_COMPACT;
                         _stream.writeSize(compactId);

--- a/csharp/src/Ice/SlicedData.cs
+++ b/csharp/src/Ice/SlicedData.cs
@@ -13,12 +13,14 @@ public sealed record class SlicedData(SliceInfo[] slices);
 /// <summary>
 /// Encapsulates the details of a slice with an unknown type.
 /// </summary>
-/// <param name="typeId">The Slice type ID or compact type ID for this slice.</param>
+/// <param name="typeId">The Slice type ID for this slice.</param>
+/// <param name="compactId">The Slice compact type ID for this slice.</param>
 /// <param name="bytes">The encoded bytes for this slice, including the leading size integer.</param>
 /// <param name="hasOptionalMembers">Whether or not the slice contains optional members.</param>
 /// <param name="isLastSlice">Whether or not this is the last slice.</param>
 public sealed record class SliceInfo(
     string typeId,
+    int compactId,
     byte[] bytes,
     bool hasOptionalMembers,
     bool isLastSlice)

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutputStream.java
@@ -1731,7 +1731,7 @@ public final class OutputStream {
                 // Encode the type ID (only in the first slice for the compact encoding).
                 //
                 if (_encaps.format == FormatType.SlicedFormat || _current.firstSlice) {
-                    if (compactId >= 0) {
+                    if (compactId != -1) {
                         _current.sliceFlags |= Protocol.FLAG_HAS_TYPE_ID_COMPACT;
                         _stream.writeSize(compactId);
                     } else {
@@ -1828,12 +1828,7 @@ public final class OutputStream {
             }
 
             for (SliceInfo info : slicedData.slices) {
-                if (info.typeId.startsWith("::")) {
-                    startSlice(info.typeId, -1, info.isLastSlice);
-                }
-                else {
-                    startSlice("", Integer.parseInt(info.typeId), info.isLastSlice);
-                }
+                startSlice(info.typeId, info.compactId, info.isLastSlice);
 
                 //
                 // Write the bytes associated with this slice.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SliceInfo.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SliceInfo.java
@@ -7,6 +7,9 @@ public final class SliceInfo {
     /** The Slice type ID for this slice. */
     public final String typeId;
 
+    /** The Slice compact type ID for this slice. */
+    public final int compactId;
+
     /** The encoded bytes for this slice, including the leading size integer. */
     public final byte[] bytes;
 
@@ -22,10 +25,12 @@ public final class SliceInfo {
     /** The SliceInfo constructor. */
     public SliceInfo(
             String typeId,
+            int compactId,
             byte[] bytes,
             boolean hasOptionalMembers,
             boolean isLastSlice) {
         this.typeId = typeId;
+        this.compactId = compactId;
         this.bytes = bytes;
         this.hasOptionalMembers = hasOptionalMembers;
         this.isLastSlice = isLastSlice;

--- a/js/src/Ice/InputStream.js
+++ b/js/src/Ice/InputStream.js
@@ -723,7 +723,7 @@ class EncapsDecoder11 extends EncapsDecoder {
         this.startSlice();
         const mostDerivedId = this._current.typeId;
         while (true) {
-            if (this._current.compactId >= 0) {
+            if (this._current.compactId != -1) {
                 //
                 // Translate a compact (numeric) type ID into a string type ID.
                 //

--- a/js/src/Ice/OutputStream.js
+++ b/js/src/Ice/OutputStream.js
@@ -306,7 +306,7 @@ class EncapsEncoder11 extends EncapsEncoder {
             // encoding).
             //
             if (this._encaps.format === FormatType.SlicedFormat || this._current.firstSlice) {
-                if (compactId >= 0) {
+                if (compactId != -1) {
                     this._current.sliceFlags |= Protocol.FLAG_HAS_TYPE_ID_COMPACT;
                     this._stream.writeSize(compactId);
                 } else {

--- a/matlab/lib/+IceInternal/EncapsDecoder11.m
+++ b/matlab/lib/+IceInternal/EncapsDecoder11.m
@@ -329,7 +329,7 @@ classdef EncapsDecoder11 < IceInternal.EncapsDecoder
             v = [];
             while true
                 compactId = current.compactId;
-                if compactId >= 0
+                if compactId != -1
                     if compactId <= length(obj.compactIdCache)
                         constructor = obj.compactIdCache{compactId};
                     else

--- a/matlab/lib/+IceInternal/EncapsDecoder11.m
+++ b/matlab/lib/+IceInternal/EncapsDecoder11.m
@@ -329,7 +329,7 @@ classdef EncapsDecoder11 < IceInternal.EncapsDecoder
             v = [];
             while true
                 compactId = current.compactId;
-                if compactId != -1
+                if compactId ~= -1
                     if compactId <= length(obj.compactIdCache)
                         constructor = obj.compactIdCache{compactId};
                     else

--- a/matlab/lib/+IceInternal/EncapsEncoder11.m
+++ b/matlab/lib/+IceInternal/EncapsEncoder11.m
@@ -86,7 +86,7 @@ classdef EncapsEncoder11 < IceInternal.EncapsEncoder
                 % Encode the type ID (only in the first slice for the compact encoding).
                 %
                 if obj.encaps.format == Ice.FormatType.SlicedFormat || obj.current.firstSlice
-                    if compactId != -1
+                    if compactId ~= -1
                         obj.current.sliceFlags = bitor(obj.current.sliceFlags, Protocol.FLAG_HAS_TYPE_ID_COMPACT);
                         obj.os.writeSize(compactId);
                     else

--- a/matlab/lib/+IceInternal/EncapsEncoder11.m
+++ b/matlab/lib/+IceInternal/EncapsEncoder11.m
@@ -86,7 +86,7 @@ classdef EncapsEncoder11 < IceInternal.EncapsEncoder
                 % Encode the type ID (only in the first slice for the compact encoding).
                 %
                 if obj.encaps.format == Ice.FormatType.SlicedFormat || obj.current.firstSlice
-                    if compactId >= 0
+                    if compactId != -1
                         obj.current.sliceFlags = bitor(obj.current.sliceFlags, Protocol.FLAG_HAS_TYPE_ID_COMPACT);
                         obj.os.writeSize(compactId);
                     else

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -1658,7 +1658,7 @@ private class EncapsDecoder11: EncapsDecoder {
         while true {
             var updateCache = false
 
-            if current.compactId >= 0 {
+            if current.compactId != -1 {
                 updateCache = true
 
                 //
@@ -1689,7 +1689,7 @@ private class EncapsDecoder11: EncapsDecoder {
 
             if let v = v {
                 if updateCache {
-                    precondition(current.compactId >= 0)
+                    precondition(current.compactId != -1)
                     compactIdCache[current.compactId] = type(of: v)
                 }
 

--- a/swift/src/Ice/OutputStream.swift
+++ b/swift/src/Ice/OutputStream.swift
@@ -914,7 +914,7 @@ private final class EncapsEncoder11: EncapsEncoder {
             // encoding).
             //
             if encaps.format == FormatType.slicedFormat || current.firstSlice {
-                if compactId >= 0 {
+                if compactId != -1 {
                     current.sliceFlags.insert(.FLAG_HAS_TYPE_ID_COMPACT)
                     os.write(size: compactId)
                 } else {


### PR DESCRIPTION
This PR simplifies the handling of compact IDs in C++. 

It also:
 - updates C# and Java to be in sync in C++
 - updates all languages to compare compactId with `-1` (meaning not set), and not `>= 0`.

