### PR TITLE
Remove Ruby InitializationData logger

### DIFF
--- a/ruby/.gitignore
+++ b/ruby/.gitignore
@@ -1,2 +1,6 @@
 dist
 *.gem
+ruby/Glacier2/*
+ruby/IceBox/*
+ruby/IceGrid/*
+ruby/IceStorm/*

--- a/ruby/ruby/Ice/InitializationData.rb
+++ b/ruby/ruby/Ice/InitializationData.rb
@@ -2,12 +2,11 @@
 
 module Ice
     class InitializationData
-        def initialize(properties=nil, logger=nil, sliceLoader=nil)
+        def initialize(properties=nil, sliceLoader=nil)
             @properties = properties
-            @logger = logger
             @sliceLoader = sliceLoader
         end
 
-        attr_accessor :properties, :logger, :sliceLoader
+        attr_accessor :properties, :sliceLoader
     end
 end

--- a/ruby/src/IceRuby/Communicator.cpp
+++ b/ruby/src/IceRuby/Communicator.cpp
@@ -155,20 +155,13 @@ IceRuby_initialize(int argc, VALUE* argv, VALUE /*self*/)
 
         if (!NIL_P(initData))
         {
-            volatile VALUE properties = callRuby(rb_iv_get, initData, "@properties");
-            volatile VALUE logger = callRuby(rb_iv_get, initData, "@logger");
-            volatile VALUE initDataSliceLoader = callRuby(rb_iv_get, initData, "@sliceLoader");
-
+            VALUE properties = callRuby(rb_iv_get, initData, "@properties");
             if (!NIL_P(properties))
             {
                 data.properties = getProperties(properties);
             }
 
-            if (!NIL_P(logger))
-            {
-                throw RubyException(rb_eArgError, "custom logger is not supported");
-            }
-
+            VALUE initDataSliceLoader = callRuby(rb_iv_get, initData, "@sliceLoader");
             if (!NIL_P(initDataSliceLoader))
             {
                 auto compositeSliceLoader = make_shared<Ice::CompositeSliceLoader>();


### PR DESCRIPTION
This PR removes the logger data member from Ruby InitializationData, as there is no point in providing a data member that cannot be set.