### PR TITLE
Remove ClassInfo::interface, which was always false.

### DIFF
--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -269,8 +269,7 @@ CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     // Emit the type information.
     const string abs = p->mappedScoped(R"(\\)");
-    _out << nl << type << " = IcePHP_defineClass('" << scoped << "', '" << abs << "', " << p->compactId()
-         << ", ";
+    _out << nl << type << " = IcePHP_defineClass('" << scoped << "', '" << abs << "', " << p->compactId() << ", ";
     if (!base)
     {
         _out << "$Ice__t_Value";

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -270,7 +270,7 @@ CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     // Emit the type information.
     const string abs = p->mappedScoped(R"(\\)");
     _out << nl << type << " = IcePHP_defineClass('" << scoped << "', '" << abs << "', " << p->compactId()
-         << ", false, ";
+         << ", ";
     if (!base)
     {
         _out << "$Ice__t_Value";

--- a/php/lib/Ice/Value.php
+++ b/php/lib/Ice/Value.php
@@ -24,7 +24,7 @@ class Value
 }
 
 global $Ice__t_Value;
-$Ice__t_Value = IcePHP_defineClass('::Ice::Object', "\\Ice\\Value", -1, false, null, null);
+$Ice__t_Value = IcePHP_defineClass('::Ice::Object', "\\Ice\\Value", -1, null, null);
 
 class UnknownSlicedValue extends Value
 {
@@ -41,7 +41,7 @@ class UnknownSlicedValue extends Value
 }
 
 global $Ice__t_UnknownSlicedValue;
-$Ice__t_UnknownSlicedValue = IcePHP_defineClass('::Ice::UnknownSlicedValue', "\\Ice\\UnknownSlicedValue", -1, false,
+$Ice__t_UnknownSlicedValue = IcePHP_defineClass('::Ice::UnknownSlicedValue', "\\Ice\\UnknownSlicedValue", -1,
                                                 $Ice__t_Value, null);
 
 class SlicedData

--- a/php/src/Types.cpp
+++ b/php/src/Types.cpp
@@ -2317,18 +2317,16 @@ IcePHP::DictionaryInfo::destroy()
 IcePHP::ClassInfo::ClassInfo(string ident)
     : id(std::move(ident)),
       compactId(-1),
-      interface(false),
       zce(0),
       defined(false)
 {
 }
 
 void
-IcePHP::ClassInfo::define(const string& n, int32_t compact, bool intf, zval* b, zval* m)
+IcePHP::ClassInfo::define(const string& n, int32_t compact, zval* b, zval* m)
 {
     const_cast<string&>(name) = n;
     const_cast<int32_t&>(compactId) = static_cast<int32_t>(compact);
-    const_cast<bool&>(interface) = intf;
 
     if (b)
     {
@@ -2426,6 +2424,7 @@ IcePHP::ClassInfo::marshal(zval* zv, Ice::OutputStream* os, ObjectMap* objectMap
     }
 
     // Give the writer to the stream. The stream will eventually call write() on it.
+    assert(writer);
     os->write(writer);
 }
 
@@ -2837,18 +2836,14 @@ IcePHP::ValueWriter::ValueWriter(zval* object, ObjectMap* objectMap, ClassInfoPt
 {
     // Copy zval and increase ref count
     ZVAL_COPY(&_object, object);
-    if (!_formal || !_formal->interface)
-    {
-        //
-        // For non interface types we need to determine the most-derived Slice type supported by
-        // this object. This is typically a Slice class, but it can also be an interface.
-        //
-        // The caller may have provided a ClassInfo representing the formal type, in
-        // which case we ensure that the actual type is compatible with the formal type.
-        //
-        _info = getClassInfoByClass(Z_OBJCE_P(object), formal ? const_cast<zend_class_entry*>(formal->zce) : 0);
-        assert(_info);
-    }
+
+    // We need to determine the most-derived Slice type supported by this object. This is typically a Slice class,
+    // but it can also be an interface.
+    //
+    // The caller may have provided a ClassInfo representing the formal type, in which case we ensure that the
+    // actual type is compatible with the formal type.
+    _info = getClassInfoByClass(Z_OBJCE_P(object), formal ? const_cast<zend_class_entry*>(formal->zce) : 0);
+    assert(_info);
 }
 
 IcePHP::ValueWriter::~ValueWriter() { zval_ptr_dtor(&_object); }
@@ -2874,59 +2869,21 @@ IcePHP::ValueWriter::_iceWrite(Ice::OutputStream* os) const
         StreamUtil::getSlicedDataMember(const_cast<zval*>(&_object), const_cast<ObjectMap*>(_map));
 
     os->startValue(slicedData);
-
-    if (_formal && _formal->interface)
+    if (_info->id != "::Ice::UnknownSlicedValue")
     {
-        // For an interface by value we just marshal the Ice type id of the object in its own slice.
-        zval ret;
-        ZVAL_UNDEF(&ret);
-
-        zend_try
+        ClassInfoPtr info = _info;
+        while (info && info->id != Ice::Value::ice_staticId())
         {
-            assert(Z_TYPE(_object) == IS_OBJECT);
-            zend_call_method(Z_OBJ_P(&_object), 0, 0, const_cast<char*>("ice_id"), sizeof("ice_id") - 1, &ret, 0, 0, 0);
-        }
-        zend_catch
-        {
-            // ret;
-        }
-        zend_end_try();
+            assert(info->base); // All classes have the Ice::Value base type.
+            const bool lastSlice = info->base->id == Ice::Value::ice_staticId();
+            os->startSlice(info->id, info->compactId, lastSlice);
 
-        // Bail out if an exception has already been thrown.
-        if (Z_ISUNDEF(ret) || EG(exception))
-        {
-            throw AbortMarshaling();
-        }
+            writeMembers(os, info->members);
+            writeMembers(os, info->optionalMembers); // The optional members have already been sorted by tag.
 
-        AutoDestroy destroy(&ret);
+            os->endSlice();
 
-        if (Z_TYPE(ret) != IS_STRING)
-        {
-            throw AbortMarshaling();
-        }
-
-        string id(Z_STRVAL(ret), Z_STRLEN(ret));
-        os->startSlice(id, -1, true);
-        os->endSlice();
-    }
-    else
-    {
-        if (_info->id != "::Ice::UnknownSlicedValue")
-        {
-            ClassInfoPtr info = _info;
-            while (info && info->id != Ice::Value::ice_staticId())
-            {
-                assert(info->base); // All classes have the Ice::Value base type.
-                const bool lastSlice = info->base->id == Ice::Value::ice_staticId();
-                os->startSlice(info->id, info->compactId, lastSlice);
-
-                writeMembers(os, info->members);
-                writeMembers(os, info->optionalMembers); // The optional members have already been sorted by tag.
-
-                os->endSlice();
-
-                info = info->base;
-            }
+            info = info->base;
         }
     }
     os->endValue();
@@ -3129,7 +3086,7 @@ IcePHP::ReadObjectCallback::invoke(const shared_ptr<Ice::Value>& p)
         assert(reader);
 
         // Verify that the unmarshaled object is compatible with the formal type.
-        if (!_info->interface && !reader->getInfo()->isA(_info->id))
+        if (!reader->getInfo()->isA(_info->id))
         {
             throw MarshalException{
                 __FILE__,
@@ -3543,19 +3500,17 @@ ZEND_FUNCTION(IcePHP_defineClass)
     char* name;
     size_t nameLen;
     zend_long compactId;
-    zend_bool interface;
     zval* base;
     zval* members;
 
     if (zend_parse_parameters(
             ZEND_NUM_ARGS(),
-            const_cast<char*>("sslbo!a!"),
+            const_cast<char*>("sslo!a!"),
             &id,
             &idLen,
             &name,
             &nameLen,
             &compactId,
-            &interface,
             &base,
             &members) == FAILURE)
     {
@@ -3569,13 +3524,9 @@ ZEND_FUNCTION(IcePHP_defineClass)
         addClassInfoById(type);
     }
 
-    type->define(name, static_cast<int32_t>(compactId), interface ? true : false, base, members);
+    type->define(name, static_cast<int32_t>(compactId), base, members);
 
-    if (!interface)
-    {
-        addClassInfoByName(type);
-    }
-
+    addClassInfoByName(type);
     if (type->compactId != -1)
     {
         addClassInfoByCompactId(type);

--- a/php/src/Types.cpp
+++ b/php/src/Types.cpp
@@ -2314,13 +2314,7 @@ IcePHP::DictionaryInfo::destroy()
 }
 
 // ClassInfo implementation.
-IcePHP::ClassInfo::ClassInfo(string ident)
-    : id(std::move(ident)),
-      compactId(-1),
-      zce(0),
-      defined(false)
-{
-}
+IcePHP::ClassInfo::ClassInfo(string ident) : id(std::move(ident)), compactId(-1), zce(0), defined(false) {}
 
 void
 IcePHP::ClassInfo::define(const string& n, int32_t compact, zval* b, zval* m)

--- a/php/src/Types.h
+++ b/php/src/Types.h
@@ -345,7 +345,7 @@ namespace IcePHP
     public:
         ClassInfo(std::string);
 
-        void define(const std::string&, std::int32_t, bool, zval*, zval*);
+        void define(const std::string&, std::int32_t, zval*, zval*);
 
         std::string getId() const final;
 
@@ -369,7 +369,6 @@ namespace IcePHP
         const std::string id;
         const std::string name; // PHP class name
         const std::int32_t compactId;
-        const bool interface;
         ClassInfoPtr base;
         const DataMemberList members;
         const DataMemberList optionalMembers;


### PR DESCRIPTION
Fix #3897

I will rename ClassInfo to ValueInfo in a follow-up PR.