### PR TITLE
Allow `java:identifier` on Classes & Exceptions

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1798,6 +1798,12 @@ Slice::CsGenerator::validateMetadata(const UnitPtr& u)
             const string msg = "'cs:namespace' is deprecated; use 'cs:identifier' to remap modules instead";
             p->unit()->warning(metadata->file(), metadata->line(), Deprecated, msg);
 
+            if (auto cont = dynamic_pointer_cast<Contained>(p); cont && cont->hasMetadata("cs:identifier"))
+            {
+                return "the 'cs:namespace' metadata cannot be used alongside 'cs:identifier' - both change the name of "
+                       "the mapped module";
+            }
+
             // 'cs:namespace' can only be applied to top-level modules
             // Top-level modules are contained by the 'Unit'. Non-top-level modules are contained in 'Module's.
             if (auto mod = dynamic_pointer_cast<Module>(p); mod && !mod->isTopLevel())

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -1800,8 +1800,7 @@ Slice::CsGenerator::validateMetadata(const UnitPtr& u)
 
             if (auto cont = dynamic_pointer_cast<Contained>(p); cont && cont->hasMetadata("cs:identifier"))
             {
-                return "the 'cs:namespace' metadata cannot be used alongside 'cs:identifier' - both change the name of "
-                       "the mapped module";
+                return "A Slice element can only have one of 'cs:namespace' and 'cs:identifier' applied to it";
             }
 
             // 'cs:namespace' can only be applied to top-level modules

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -1722,8 +1722,9 @@ Slice::JavaGenerator::validateMetadata(const UnitPtr& u)
         .acceptedArgumentKind = MetadataArgumentKind::SingleArgument,
         .extraValidation = [](const MetadataPtr& metadata, const SyntaxTreeBasePtr& p) -> optional<string>
         {
-            const string msg = "'java:package' is deprecated; use 'java:identifier' to remap modules instead";
-            p->unit()->warning(metadata->file(), metadata->line(), Deprecated, msg);
+            // TODO uncomment after replacing 'java:package' with 'java:identifier'.
+            // const string msg = "'java:package' is deprecated; use 'java:identifier' to remap modules instead";
+            // p->unit()->warning(metadata->file(), metadata->line(), Deprecated, msg);
 
             if (auto cont = dynamic_pointer_cast<Contained>(p); cont && cont->hasMetadata("java:identifier"))
             {

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -1720,7 +1720,7 @@ Slice::JavaGenerator::validateMetadata(const UnitPtr& u)
     MetadataInfo packageInfo = {
         .validOn = {typeid(Unit), typeid(Module)},
         .acceptedArgumentKind = MetadataArgumentKind::SingleArgument,
-        .extraValidation = [](const MetadataPtr& metadata, const SyntaxTreeBasePtr& p) -> optional<string>
+        .extraValidation = [](const MetadataPtr&, const SyntaxTreeBasePtr& p) -> optional<string>
         {
             // TODO uncomment after replacing 'java:package' with 'java:identifier'.
             // const string msg = "'java:package' is deprecated; use 'java:identifier' to remap modules instead";

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -1726,10 +1726,9 @@ Slice::JavaGenerator::validateMetadata(const UnitPtr& u)
             // const string msg = "'java:package' is deprecated; use 'java:identifier' to remap modules instead";
             // p->unit()->warning(metadata->file(), metadata->line(), Deprecated, msg);
 
-            if (auto cont = dynamic_pointer_cast<Contained>(p); cont && cont->hasMetadata("java:identifier"))
+            if (auto element = dynamic_pointer_cast<Contained>(p); element && element->hasMetadata("java:identifier"))
             {
-                return "the 'java:package' metadata cannot be used alongside 'java:identifier' - both change the name "
-                       "of the mapped module";
+                return "A Slice element can only have one of 'java:package' and 'java:identifier' applied to it";
             }
 
             // If 'java:package' is applied to a module, it must be a top-level module.

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2439,6 +2439,12 @@ Slice::Python::validateMetadata(const UnitPtr& unit)
             const string msg = "'python:package' is deprecated; use 'python:identifier' to remap modules instead";
             p->unit()->warning(metadata->file(), metadata->line(), Deprecated, msg);
 
+            if (auto cont = dynamic_pointer_cast<Contained>(p); cont && cont->hasMetadata("python:identifier"))
+            {
+                return "the 'python:package' metadata cannot be used alongside 'python:identifier' - both change the "
+                       "name of the mapped module";
+            }
+
             // If 'python:package' is applied to a module, it must be a top-level module.
             // Top-level modules are contained by the 'Unit'. Non-top-level modules are contained in 'Module's.
             if (auto mod = dynamic_pointer_cast<Module>(p); mod && !mod->isTopLevel())

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2441,8 +2441,7 @@ Slice::Python::validateMetadata(const UnitPtr& unit)
 
             if (auto cont = dynamic_pointer_cast<Contained>(p); cont && cont->hasMetadata("python:identifier"))
             {
-                return "the 'python:package' metadata cannot be used alongside 'python:identifier' - both change the "
-                       "name of the mapped module";
+                return "A Slice element can only have one of 'python:package' and 'python:identifier' applied to it";
             }
 
             // If 'python:package' is applied to a module, it must be a top-level module.

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -536,13 +536,10 @@ SwiftGenerator::validateMetadata(const UnitPtr& u)
             const string msg = "'swift:module' is deprecated; use 'swift:identifier' to remap modules instead";
             p->unit()->warning(metadata->file(), metadata->line(), Deprecated, msg);
 
-            if (auto contained = dynamic_pointer_cast<Contained>(p))
+            if (auto cont = dynamic_pointer_cast<Contained>(p); cont && cont->hasMetadata("swift:identifier"))
             {
-                if (contained->hasMetadata("swift:identifier"))
-                {
-                    return "the 'swift:module' metadata cannot be used alongside 'swift:identifier' - both change the "
-                           "name of the mapped module";
-                }
+                return "the 'swift:module' metadata cannot be used alongside 'swift:identifier' - both change the name "
+                        "of the mapped module";
             }
             return nullopt;
         }};

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -539,7 +539,7 @@ SwiftGenerator::validateMetadata(const UnitPtr& u)
             if (auto cont = dynamic_pointer_cast<Contained>(p); cont && cont->hasMetadata("swift:identifier"))
             {
                 return "the 'swift:module' metadata cannot be used alongside 'swift:identifier' - both change the name "
-                        "of the mapped module";
+                       "of the mapped module";
             }
             return nullopt;
         }};

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -538,8 +538,7 @@ SwiftGenerator::validateMetadata(const UnitPtr& u)
 
             if (auto cont = dynamic_pointer_cast<Contained>(p); cont && cont->hasMetadata("swift:identifier"))
             {
-                return "the 'swift:module' metadata cannot be used alongside 'swift:identifier' - both change the name "
-                       "of the mapped module";
+                return "A Slice element can only have one of 'swift:module' and 'swift:identifier' applied to it";
             }
             return nullopt;
         }};


### PR DESCRIPTION
Fixes #3534 now that we have the machinery to handle remapped type-ids (ie. `SliceLoader`).
This PR also disallows mixing `java:package` with `java:identifier`, and updates other languages accordingly.

----

Note: this doesn't actually update any Slice files. this was split off into a separate PR (see #3931).
Switching from `java:package` to `java:identifier` has to be done at the same time as the switch from `setProperty("Ice.Package...")` to `SliceLoader`s.
Needless to say, this changes many lines of code in the tests.
