### PR TITLE
Replace `'java:package' -> 'java:identifier'` and `setProperty("Ice.Package.xxx") -> initData.sliceLoader`

### DIFF
--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -1720,11 +1720,10 @@ Slice::JavaGenerator::validateMetadata(const UnitPtr& u)
     MetadataInfo packageInfo = {
         .validOn = {typeid(Unit), typeid(Module)},
         .acceptedArgumentKind = MetadataArgumentKind::SingleArgument,
-        .extraValidation = [](const MetadataPtr&, const SyntaxTreeBasePtr& p) -> optional<string>
+        .extraValidation = [](const MetadataPtr& metadata, const SyntaxTreeBasePtr& p) -> optional<string>
         {
-            // TODO uncomment after replacing 'java:package' with 'java:identifier'.
-            // const string msg = "'java:package' is deprecated; use 'java:identifier' to remap modules instead";
-            // p->unit()->warning(metadata->file(), metadata->line(), Deprecated, msg);
+            const string msg = "'java:package' is deprecated; use 'java:identifier' to remap modules instead";
+            p->unit()->warning(metadata->file(), metadata->line(), Deprecated, msg);
 
             if (auto element = dynamic_pointer_cast<Contained>(p); element && element->hasMetadata("java:identifier"))
             {

--- a/java/test/src/main/java/test/Glacier2/router/Callback.ice
+++ b/java/test/src/main/java/test/Glacier2/router/Callback.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Glacier2.router"]]
+["java:identifier:test.Glacier2.router.Test"]
 module Test
 {
     exception CallbackException

--- a/java/test/src/main/java/test/Glacier2/router/Client.java
+++ b/java/test/src/main/java/test/Glacier2/router/Client.java
@@ -9,13 +9,14 @@ import com.zeroc.Glacier2.SessionNotExistException;
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.ConnectionLostException;
 import com.zeroc.Ice.Identity;
+import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.LocalException;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.ObjectNotExistException;
 import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.ProcessPrx;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.RouterFinderPrx;
 import com.zeroc.Ice.SocketException;
 import com.zeroc.Ice.Util;
@@ -32,12 +33,13 @@ import java.util.stream.Stream;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Warn.Dispatch", "0");
-        properties.setProperty("Ice.Warn.Connections", "0");
-        properties.setProperty("Ice.Package.Test", "test.Glacier2.router");
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Glacier2.router.Test");
+        initData.properties =  createTestProperties(args);
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+        initData.properties.setProperty("Ice.Warn.Connections", "0");
 
-        try (Communicator communicator = initialize(properties)) {
+        try (Communicator communicator = initialize(initData)) {
             ObjectPrx routerBase;
 
             PrintWriter out = getWriter();

--- a/java/test/src/main/java/test/Glacier2/router/Client.java
+++ b/java/test/src/main/java/test/Glacier2/router/Client.java
@@ -35,7 +35,7 @@ public class Client extends TestHelper {
     public void run(String[] args) {
         var initData = new InitializationData();
         initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Glacier2.router.Test");
-        initData.properties =  createTestProperties(args);
+        initData.properties = createTestProperties(args);
         initData.properties.setProperty("Ice.Warn.Dispatch", "0");
         initData.properties.setProperty("Ice.Warn.Connections", "0");
 

--- a/java/test/src/main/java/test/Glacier2/router/Server.java
+++ b/java/test/src/main/java/test/Glacier2/router/Server.java
@@ -3,8 +3,9 @@
 package test.Glacier2.router;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
@@ -12,9 +13,11 @@ import test.TestHelper;
 public class Server extends TestHelper {
 
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Glacier2.router");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Glacier2.router.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             communicator
                 .getProperties()
                 .setProperty("CallbackAdapter.Endpoints", getTestEndpoint(0));

--- a/java/test/src/main/java/test/Ice/adapterDeactivation/Client.java
+++ b/java/test/src/main/java/test/Ice/adapterDeactivation/Client.java
@@ -3,15 +3,18 @@
 package test.Ice.adapterDeactivation;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.adapterDeactivation");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.adapterDeactivation.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/adapterDeactivation/Client.java
+++ b/java/test/src/main/java/test/Ice/adapterDeactivation/Client.java
@@ -3,18 +3,12 @@
 package test.Ice.adapterDeactivation;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.adapterDeactivation.Test");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/adapterDeactivation/Collocated.java
+++ b/java/test/src/main/java/test/Ice/adapterDeactivation/Collocated.java
@@ -3,19 +3,13 @@
 package test.Ice.adapterDeactivation;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 
 import test.TestHelper;
 
 public class Collocated extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.adapterDeactivation.Test");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             //
             // 2 threads are necessary to dispatch the collocated transient() call with AMI
             //

--- a/java/test/src/main/java/test/Ice/adapterDeactivation/Collocated.java
+++ b/java/test/src/main/java/test/Ice/adapterDeactivation/Collocated.java
@@ -3,17 +3,19 @@
 package test.Ice.adapterDeactivation;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 
 import test.TestHelper;
 
 public class Collocated extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.adapterDeactivation");
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.adapterDeactivation.Test");
+        initData.properties = createTestProperties(args);
 
-        try (Communicator communicator = initialize(properties)) {
+        try (Communicator communicator = initialize(initData)) {
             //
             // 2 threads are necessary to dispatch the collocated transient() call with AMI
             //

--- a/java/test/src/main/java/test/Ice/adapterDeactivation/Server.java
+++ b/java/test/src/main/java/test/Ice/adapterDeactivation/Server.java
@@ -3,16 +3,19 @@
 package test.Ice.adapterDeactivation;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.adapterDeactivation");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.adapterDeactivation.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.addServantLocator(new ServantLocatorI(), "");

--- a/java/test/src/main/java/test/Ice/adapterDeactivation/Server.java
+++ b/java/test/src/main/java/test/Ice/adapterDeactivation/Server.java
@@ -3,19 +3,13 @@
 package test.Ice.adapterDeactivation;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.adapterDeactivation.Test");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.addServantLocator(new ServantLocatorI(), "");

--- a/java/test/src/main/java/test/Ice/adapterDeactivation/Test.ice
+++ b/java/test/src/main/java/test/Ice/adapterDeactivation/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.adapterDeactivation"]]
+["java:identifier:test.Ice.adapterDeactivation.Test"]
 module Test
 {
     interface TestIntf

--- a/java/test/src/main/java/test/Ice/admin/Server.java
+++ b/java/test/src/main/java/test/Ice/admin/Server.java
@@ -3,19 +3,22 @@
 package test.Ice.admin;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.admin");
-        properties.setProperty("Ice.Warn.Dispatch", "0");
-        try (Communicator communicator = initialize(properties)) {
-            properties.setProperty("TestAdapter.Endpoints", getTestEndpoint());
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.admin.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+
+        try (Communicator communicator = initialize(initData)) {
+            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(
                 new RemoteCommunicatorFactoryI(),

--- a/java/test/src/main/java/test/Ice/admin/Server.java
+++ b/java/test/src/main/java/test/Ice/admin/Server.java
@@ -3,8 +3,6 @@
 package test.Ice.admin;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
 
@@ -12,12 +10,10 @@ import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.admin.Test");
-        initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+        var properties = createTestProperties(args);
+        properties.setProperty("Ice.Warn.Dispatch", "0");
 
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(properties)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(

--- a/java/test/src/main/java/test/Ice/admin/Test.ice
+++ b/java/test/src/main/java/test/Ice/admin/Test.ice
@@ -5,7 +5,7 @@
 
 #include "Ice/PropertyDict.ice"
 
-[["java:package:test.Ice.admin"]]
+["java:identifier:test.Ice.admin.Test"]
 module Test
 {
     interface RemoteCommunicator

--- a/java/test/src/main/java/test/Ice/ami/Client.java
+++ b/java/test/src/main/java/test/Ice/ami/Client.java
@@ -3,23 +3,23 @@
 package test.Ice.ami;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.ami");
-        properties.setProperty("Ice.Warn.AMICallback", "0");
-        properties.setProperty("Ice.Warn.Connections", "0");
-
-        //
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.ami.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Warn.AMICallback", "0");
+        initData.properties.setProperty("Ice.Warn.Connections", "0");
         // Limit the send buffer size, this test relies on the socket
         // send() blocking after sending a given amount of data.
-        //
-        properties.setProperty("Ice.TCP.SndSize", "50000");
-        try (Communicator communicator = initialize(properties)) {
+        initData.properties.setProperty("Ice.TCP.SndSize", "50000");
+
+        try (Communicator communicator = initialize(initData)) {
             AllTests.allTests(this, false);
         }
     }

--- a/java/test/src/main/java/test/Ice/ami/Collocated.java
+++ b/java/test/src/main/java/test/Ice/ami/Collocated.java
@@ -3,18 +3,21 @@
 package test.Ice.ami;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Collocated extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.ami");
-        properties.setProperty("Ice.Warn.AMICallback", "0");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.ami.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Warn.AMICallback", "0");
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             communicator
                 .getProperties()
@@ -22,8 +25,7 @@ public class Collocated extends TestHelper {
             communicator.getProperties().setProperty("ControllerAdapter.ThreadPool.Size", "1");
 
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            ObjectAdapter adapter2 =
-                communicator.createObjectAdapter("ControllerAdapter");
+            ObjectAdapter adapter2 = communicator.createObjectAdapter("ControllerAdapter");
 
             adapter.add(new TestI(), Util.stringToIdentity("test"));
             adapter.add(new TestII(), Util.stringToIdentity("test2"));

--- a/java/test/src/main/java/test/Ice/ami/Server.java
+++ b/java/test/src/main/java/test/Ice/ami/Server.java
@@ -13,7 +13,7 @@ import test.TestHelper;
 public class Server extends TestHelper {
     public void run(String[] args) {
         var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.adapterDeactivation.Test");
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.ami.Test");
         initData.properties = createTestProperties(args);
         // This test kills connections, so we don't want warnings.
         initData.properties.setProperty("Ice.Warn.Connections", "0");

--- a/java/test/src/main/java/test/Ice/ami/Server.java
+++ b/java/test/src/main/java/test/Ice/ami/Server.java
@@ -3,28 +3,25 @@
 package test.Ice.ami;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.ami");
-        //
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.adapterDeactivation.Test");
+        initData.properties = createTestProperties(args);
         // This test kills connections, so we don't want warnings.
-        //
-        properties.setProperty("Ice.Warn.Connections", "0");
-
-        //
+        initData.properties.setProperty("Ice.Warn.Connections", "0");
         // Limit the recv buffer size, this test relies on the socket
         // send() blocking after sending a given amount of data.
-        //
-        properties.setProperty("Ice.TCP.RcvSize", "50000");
+        initData.properties.setProperty("Ice.TCP.RcvSize", "50000");
 
-        try (Communicator communicator = initialize(properties)) {
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             communicator
                 .getProperties()

--- a/java/test/src/main/java/test/Ice/ami/Test.ice
+++ b/java/test/src/main/java/test/Ice/ami/Test.ice
@@ -5,7 +5,7 @@
 #include "Ice/BuiltinSequences.ice"
 #include "Ice/Identity.ice"
 
-[["java:package:test.Ice.ami"]]
+["java:identifier:test.Ice.ami.Test"]
 module Test
 {
     exception TestIntfException

--- a/java/test/src/main/java/test/Ice/background/Client.java
+++ b/java/test/src/main/java/test/Ice/background/Client.java
@@ -4,7 +4,6 @@ package test.Ice.background;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import java.util.Collections;
 
@@ -15,7 +14,6 @@ import test.TestHelper;
 public class Client extends TestHelper {
     public void run(String[] args) {
         var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.background.Test");
         // Install transport plug-in.
         initData.pluginFactories = Collections.singletonList(new PluginFactory());
 

--- a/java/test/src/main/java/test/Ice/background/Client.java
+++ b/java/test/src/main/java/test/Ice/background/Client.java
@@ -4,7 +4,7 @@ package test.Ice.background;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import java.util.Collections;
 
@@ -14,33 +14,21 @@ import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        //
-        // For this test, we want to disable retries.
-        //
-        properties.setProperty("Ice.RetryIntervals", "-1");
-
-        //
-        // This test kills connections, so we don't want warnings.
-        //
-        properties.setProperty("Ice.Warn.Connections", "0");
-
-        //
-        // This test relies on filling the TCP send/recv buffer, so we rely on a fixed value for
-        // these buffers.
-        //
-        properties.setProperty("Ice.TCP.SndSize", "50000");
-
-        properties.setProperty(
-            "Ice.Default.Protocol",
-            "test-" + properties.getIceProperty("Ice.Default.Protocol"));
-
-        properties.setProperty("Ice.Package.Test", "test.Ice.background");
-
-        // Install transport plug-in.
         var initData = new InitializationData();
-        initData.properties = properties;
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.background.Test");
+        // Install transport plug-in.
         initData.pluginFactories = Collections.singletonList(new PluginFactory());
+
+        initData.properties = createTestProperties(args);
+        // For this test, we want to disable retries.
+        initData.properties.setProperty("Ice.RetryIntervals", "-1");
+        // This test kills connections, so we don't want warnings.
+        initData.properties.setProperty("Ice.Warn.Connections", "0");
+        // This test relies on filling the TCP send/recv buffer, so we rely on a fixed value for these buffers.
+        initData.properties.setProperty("Ice.TCP.SndSize", "50000");
+        initData.properties.setProperty(
+            "Ice.Default.Protocol",
+            "test-" + initData.properties.getIceProperty("Ice.Default.Protocol"));
 
         try (Communicator communicator = initialize(initData)) {
             PluginI plugin = (PluginI) communicator().getPluginManager().getPlugin("Test");

--- a/java/test/src/main/java/test/Ice/background/Server.java
+++ b/java/test/src/main/java/test/Ice/background/Server.java
@@ -8,7 +8,6 @@ import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.Locator;
 import com.zeroc.Ice.LocatorRegistryPrx;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.Router;
@@ -82,7 +81,6 @@ public class Server extends TestHelper {
     @Override
     public void run(String[] args) {
         var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.background.Test");
         // Install transport plug-in.
         initData.pluginFactories = Collections.singletonList(new PluginFactory());
 

--- a/java/test/src/main/java/test/Ice/background/Server.java
+++ b/java/test/src/main/java/test/Ice/background/Server.java
@@ -8,9 +8,9 @@ import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.Locator;
 import com.zeroc.Ice.LocatorRegistryPrx;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.ObjectPrx;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Router;
 import com.zeroc.Ice.Util;
 
@@ -81,27 +81,20 @@ public class Server extends TestHelper {
 
     @Override
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-
-        //
-        // This test kills connections, so we don't want warnings.
-        //
-        properties.setProperty("Ice.Warn.Connections", "0");
-        properties.setProperty("Ice.MessageSizeMax", "50000");
-
-        // This test relies on filling the TCP send/recv buffer, so we rely on a fixed value for
-        // these buffers.
-        properties.setProperty("Ice.TCP.RcvSize", "50000");
-
-        properties.setProperty(
-            "Ice.Default.Protocol",
-            "test-" + properties.getIceProperty("Ice.Default.Protocol"));
-        properties.setProperty("Ice.Package.Test", "test.Ice.background");
-
-        // Install transport plug-in.
         var initData = new InitializationData();
-        initData.properties = properties;
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.background.Test");
+        // Install transport plug-in.
         initData.pluginFactories = Collections.singletonList(new PluginFactory());
+
+        initData.properties = createTestProperties(args);
+        // This test kills connections, so we don't want warnings.
+        initData.properties.setProperty("Ice.Warn.Connections", "0");
+        initData.properties.setProperty("Ice.MessageSizeMax", "50000");
+        // This test relies on filling the TCP send/recv buffer, so we rely on a fixed value for these buffers.
+        initData.properties.setProperty("Ice.TCP.RcvSize", "50000");
+        initData.properties.setProperty(
+            "Ice.Default.Protocol",
+            "test-" + initData.properties.getIceProperty("Ice.Default.Protocol"));
 
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));

--- a/java/test/src/main/java/test/Ice/background/Test.ice
+++ b/java/test/src/main/java/test/Ice/background/Test.ice
@@ -4,7 +4,7 @@
 
 #include "Ice/BuiltinSequences.ice"
 
-[["java:package:test.Ice.background"]]
+["java:identifier:test.Ice.background.Test"]
 module Test
 {
     interface Background

--- a/java/test/src/main/java/test/Ice/binding/Client.java
+++ b/java/test/src/main/java/test/Ice/binding/Client.java
@@ -3,18 +3,12 @@
 package test.Ice.binding;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.binding.Test");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/binding/Client.java
+++ b/java/test/src/main/java/test/Ice/binding/Client.java
@@ -3,15 +3,18 @@
 package test.Ice.binding;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.binding");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.binding.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/binding/Server.java
+++ b/java/test/src/main/java/test/Ice/binding/Server.java
@@ -6,6 +6,7 @@ import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.Logger;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
 
@@ -14,8 +15,8 @@ import test.TestHelper;
 public class Server extends TestHelper {
     public void run(String[] args) {
         InitializationData initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.binding.Test");
         initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.Package.Test", "test.Ice.binding");
         initData.logger =
             new Logger() {
                 @Override

--- a/java/test/src/main/java/test/Ice/binding/Server.java
+++ b/java/test/src/main/java/test/Ice/binding/Server.java
@@ -6,7 +6,6 @@ import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.Logger;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
 
@@ -15,7 +14,6 @@ import test.TestHelper;
 public class Server extends TestHelper {
     public void run(String[] args) {
         InitializationData initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.binding.Test");
         initData.properties = createTestProperties(args);
         initData.logger =
             new Logger() {

--- a/java/test/src/main/java/test/Ice/binding/Test.ice
+++ b/java/test/src/main/java/test/Ice/binding/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.binding"]]
+["java:identifier:test.Ice.binding.Test"]
 module Test
 {
     interface TestIntf

--- a/java/test/src/main/java/test/Ice/classLoader/Client.java
+++ b/java/test/src/main/java/test/Ice/classLoader/Client.java
@@ -3,15 +3,18 @@
 package test.Ice.classLoader;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.classLoader");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.classLoader.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             AllTests.allTests(this, false);
         }
     }

--- a/java/test/src/main/java/test/Ice/classLoader/Server.java
+++ b/java/test/src/main/java/test/Ice/classLoader/Server.java
@@ -3,19 +3,22 @@
 package test.Ice.classLoader;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.classLoader");
-        properties.setProperty("Ice.Default.SlicedFormat", "1");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.classLoader.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Default.SlicedFormat", "1");
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object object = new InitialI(adapter);

--- a/java/test/src/main/java/test/Ice/classLoader/Test.ice
+++ b/java/test/src/main/java/test/Ice/classLoader/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.classLoader"]]
+["java:identifier:test.Ice.classLoader.Test"]
 module Test
 {
     class ConcreteClass

--- a/java/test/src/main/java/test/Ice/custom/Client.java
+++ b/java/test/src/main/java/test/Ice/custom/Client.java
@@ -3,17 +3,20 @@
 package test.Ice.custom;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.custom.Test.TestIntfPrx;
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.custom");
-        properties.setProperty("Ice.CacheMessageBuffers", "0");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.custom.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.CacheMessageBuffers", "0");
+
+        try (Communicator communicator = initialize(initData)) {
             TestIntfPrx test = AllTests.allTests(this);
             test.shutdown();
         }

--- a/java/test/src/main/java/test/Ice/custom/Client.java
+++ b/java/test/src/main/java/test/Ice/custom/Client.java
@@ -3,20 +3,16 @@
 package test.Ice.custom;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.custom.Test.TestIntfPrx;
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.custom.Test");
-        initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.CacheMessageBuffers", "0");
+        var properties = createTestProperties(args);
+        properties.setProperty("Ice.CacheMessageBuffers", "0");
 
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(properties)) {
             TestIntfPrx test = AllTests.allTests(this);
             test.shutdown();
         }

--- a/java/test/src/main/java/test/Ice/custom/Collocated.java
+++ b/java/test/src/main/java/test/Ice/custom/Collocated.java
@@ -3,8 +3,6 @@
 package test.Ice.custom;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
@@ -13,12 +11,10 @@ import test.TestHelper;
 
 public class Collocated extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.custom.Test");
-        initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.CacheMessageBuffers", "0");
+        var properties = createTestProperties(args);
+        properties.setProperty("Ice.CacheMessageBuffers", "0");
 
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(properties)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object test = new TestI(communicator);

--- a/java/test/src/main/java/test/Ice/custom/Collocated.java
+++ b/java/test/src/main/java/test/Ice/custom/Collocated.java
@@ -3,19 +3,22 @@
 package test.Ice.custom;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Collocated extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.custom");
-        properties.setProperty("Ice.CacheMessageBuffers", "0");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.custom.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.CacheMessageBuffers", "0");
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object test = new TestI(communicator);

--- a/java/test/src/main/java/test/Ice/custom/Server.java
+++ b/java/test/src/main/java/test/Ice/custom/Server.java
@@ -3,20 +3,23 @@
 package test.Ice.custom;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.custom");
-        properties.setProperty("Ice.CacheMessageBuffers", "0");
-        try (Communicator communicator = initialize(properties)) {
-            properties.setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.custom.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.CacheMessageBuffers", "0");
+
+        try (Communicator communicator = initialize(initData)) {
+            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object test = new TestI(communicator);
             adapter.add(test, Util.stringToIdentity("test"));

--- a/java/test/src/main/java/test/Ice/custom/Server.java
+++ b/java/test/src/main/java/test/Ice/custom/Server.java
@@ -3,8 +3,6 @@
 package test.Ice.custom;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
@@ -13,12 +11,10 @@ import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.custom.Test");
-        initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.CacheMessageBuffers", "0");
+        var properties = createTestProperties(args);
+        properties.setProperty("Ice.CacheMessageBuffers", "0");
 
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(properties)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object test = new TestI(communicator);

--- a/java/test/src/main/java/test/Ice/custom/Test.ice
+++ b/java/test/src/main/java/test/Ice/custom/Test.ice
@@ -4,7 +4,7 @@
 
 #include "Ice/BuiltinSequences.ice"
 
-[["java:package:test.Ice.custom"]]
+["java:identifier:test.Ice.custom.Test"]
 module Test
 {
     struct A

--- a/java/test/src/main/java/test/Ice/defaultServant/Test.ice
+++ b/java/test/src/main/java/test/Ice/defaultServant/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.defaultServant"]]
+["java:identifier:test.Ice.defaultServant.Test"]
 module Test
 {
     interface MyObject

--- a/java/test/src/main/java/test/Ice/defaultValue/Test.ice
+++ b/java/test/src/main/java/test/Ice/defaultValue/Test.ice
@@ -2,10 +2,9 @@
 
 #pragma once
 
-[["java:package:test.Ice.defaultValue"]]
-
 [["suppress-warning:deprecated"]] // For enumerator references
 
+["java:identifier:test.Ice.defaultValue.Test"]
 module Test
 {
     enum Color { red, green, blue }

--- a/java/test/src/main/java/test/Ice/echo/Server.java
+++ b/java/test/src/main/java/test/Ice/echo/Server.java
@@ -4,8 +4,6 @@ package test.Ice.echo;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Current;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
 
@@ -37,11 +35,7 @@ public class Server extends TestHelper {
     }
 
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.echo.Test");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             BlobjectI blob = new BlobjectI();

--- a/java/test/src/main/java/test/Ice/echo/Server.java
+++ b/java/test/src/main/java/test/Ice/echo/Server.java
@@ -4,8 +4,9 @@ package test.Ice.echo;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Current;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.Ice.echo.Test.Echo;
@@ -36,9 +37,11 @@ public class Server extends TestHelper {
     }
 
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.echo");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.echo.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             BlobjectI blob = new BlobjectI();

--- a/java/test/src/main/java/test/Ice/echo/Test.ice
+++ b/java/test/src/main/java/test/Ice/echo/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.echo"]]
+["java:identifier:test.Ice.echo.Test"]
 module Test
 {
     //

--- a/java/test/src/main/java/test/Ice/enums/Client.java
+++ b/java/test/src/main/java/test/Ice/enums/Client.java
@@ -3,16 +3,19 @@
 package test.Ice.enums;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.enums.Test.TestIntfPrx;
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.enums");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.enums.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             TestIntfPrx test = AllTests.allTests(this);
             test.shutdown();
         }

--- a/java/test/src/main/java/test/Ice/enums/Client.java
+++ b/java/test/src/main/java/test/Ice/enums/Client.java
@@ -3,19 +3,13 @@
 package test.Ice.enums;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.enums.Test.TestIntfPrx;
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.enums.Test");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             TestIntfPrx test = AllTests.allTests(this);
             test.shutdown();
         }

--- a/java/test/src/main/java/test/Ice/enums/Server.java
+++ b/java/test/src/main/java/test/Ice/enums/Server.java
@@ -3,8 +3,6 @@
 package test.Ice.enums;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
@@ -13,11 +11,7 @@ import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.enums.Test");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
 
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");

--- a/java/test/src/main/java/test/Ice/enums/Server.java
+++ b/java/test/src/main/java/test/Ice/enums/Server.java
@@ -3,19 +3,22 @@
 package test.Ice.enums;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.enums");
-        try (Communicator communicator = initialize(properties)) {
-            properties.setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.enums.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
+            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
 
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object test = new TestIntfI();

--- a/java/test/src/main/java/test/Ice/enums/Test.ice
+++ b/java/test/src/main/java/test/Ice/enums/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.enums"]]
+["java:identifier:test.Ice.enums.Test"]
 module Test
 {
     const byte ByteConst1 = 10;

--- a/java/test/src/main/java/test/Ice/exceptions/AMDServer.java
+++ b/java/test/src/main/java/test/Ice/exceptions/AMDServer.java
@@ -4,6 +4,7 @@ package test.Ice.exceptions;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
@@ -13,18 +14,15 @@ import test.TestHelper;
 public class AMDServer extends TestHelper {
     public void run(String[] args) {
         InitializationData initData = new InitializationData();
-
-        //
-        // For this test, we need a dummy logger, otherwise the
-        // assertion test will print an error message.
-        //
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.exceptions.AMD.Test");
+        // For this test, we need a dummy logger, otherwise the assertion test will print an error message.
         initData.logger = new DummyLogger();
 
         initData.properties = createTestProperties(args);
         initData.properties.setProperty("Ice.Warn.Dispatch", "0");
         initData.properties.setProperty("Ice.Warn.Connections", "0");
-        initData.properties.setProperty("Ice.Package.Test", "test.Ice.exceptions.AMD");
         initData.properties.setProperty("Ice.MessageSizeMax", "10"); // 10KB max
+
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             communicator.getProperties().setProperty("TestAdapter2.Endpoints", getTestEndpoint(1));

--- a/java/test/src/main/java/test/Ice/exceptions/Client.java
+++ b/java/test/src/main/java/test/Ice/exceptions/Client.java
@@ -3,18 +3,21 @@
 package test.Ice.exceptions;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.exceptions.Test.ThrowerPrx;
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.exceptions");
-        properties.setProperty("Ice.Warn.Connections", "0");
-        properties.setProperty("Ice.MessageSizeMax", "10"); // 10KB max
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.exceptions.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Warn.Connections", "0");
+        initData.properties.setProperty("Ice.MessageSizeMax", "10"); // 10KB max
+
+        try (Communicator communicator = initialize(initData)) {
             ThrowerPrx thrower = AllTests.allTests(this);
             thrower.shutdown();
         }

--- a/java/test/src/main/java/test/Ice/exceptions/Collocated.java
+++ b/java/test/src/main/java/test/Ice/exceptions/Collocated.java
@@ -4,6 +4,7 @@ package test.Ice.exceptions;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
@@ -13,17 +14,15 @@ import test.TestHelper;
 public class Collocated extends TestHelper {
     public void run(String[] args) {
         InitializationData initData = new InitializationData();
-        //
-        // For this test, we need a dummy logger, otherwise the
-        // assertion test will print an error message.
-        //
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.exceptions.Test");
+        // For this test, we need a dummy logger, otherwise the assertion test will print an error message.
         initData.logger = new DummyLogger();
 
         initData.properties = createTestProperties(args);
         initData.properties.setProperty("Ice.Warn.Dispatch", "0");
         initData.properties.setProperty("Ice.Warn.Connections", "0");
-        initData.properties.setProperty("Ice.Package.Test", "test.Ice.exceptions");
         initData.properties.setProperty("Ice.MessageSizeMax", "10"); // 10KB max
+
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");

--- a/java/test/src/main/java/test/Ice/exceptions/Server.java
+++ b/java/test/src/main/java/test/Ice/exceptions/Server.java
@@ -4,6 +4,7 @@ package test.Ice.exceptions;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
@@ -13,16 +14,15 @@ import test.TestHelper;
 public class Server extends TestHelper {
     public void run(String[] args) {
         InitializationData initData = new InitializationData();
-        //
-        // For this test, we need a dummy logger, otherwise the
-        // assertion test will print an error message.
-        //
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.exceptions.Test");
+        // For this test, we need a dummy logger, otherwise the assertion test will print an error message.
         initData.logger = new DummyLogger();
+
         initData.properties = createTestProperties(args);
         initData.properties.setProperty("Ice.Warn.Dispatch", "0");
         initData.properties.setProperty("Ice.Warn.Connections", "0");
-        initData.properties.setProperty("Ice.Package.Test", "test.Ice.exceptions");
         initData.properties.setProperty("Ice.MessageSizeMax", "10"); // 10KB max
+
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             communicator.getProperties().setProperty("TestAdapter2.Endpoints", getTestEndpoint(1));

--- a/java/test/src/main/java/test/Ice/exceptions/Test.ice
+++ b/java/test/src/main/java/test/Ice/exceptions/Test.ice
@@ -4,7 +4,7 @@
 
 #include "Ice/BuiltinSequences.ice"
 
-[["java:package:test.Ice.exceptions"]]
+["java:identifier:test.Ice.exceptions.Test"]
 module Test
 {
     interface Empty

--- a/java/test/src/main/java/test/Ice/exceptions/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/exceptions/TestAMD.ice
@@ -4,7 +4,7 @@
 
 #include "Ice/BuiltinSequences.ice"
 
-[["java:package:test.Ice.exceptions.AMD"]]
+["java:identifier:test.Ice.exceptions.AMD.Test"]
 module Test
 {
     interface Thrower;

--- a/java/test/src/main/java/test/Ice/executor/Client.java
+++ b/java/test/src/main/java/test/Ice/executor/Client.java
@@ -4,14 +4,12 @@ package test.Ice.executor;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
         InitializationData initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.executor.Test");
         initData.properties = createTestProperties(args);
         // Limit the send buffer size, this test relies on the socket
         // send() blocking after sending a given amount of data.

--- a/java/test/src/main/java/test/Ice/executor/Client.java
+++ b/java/test/src/main/java/test/Ice/executor/Client.java
@@ -4,23 +4,22 @@ package test.Ice.executor;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
         InitializationData initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.executor.Test");
         initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.Package.Test", "test.Ice.executor");
-
-        CustomExecutor executor = new CustomExecutor();
-        //
         // Limit the send buffer size, this test relies on the socket
         // send() blocking after sending a given amount of data.
-        //
         initData.properties.setProperty("Ice.TCP.SndSize", "50000");
 
+        CustomExecutor executor = new CustomExecutor();
         initData.executor = executor;
+
         try (Communicator communicator = initialize(initData)) {
             AllTests.allTests(this, executor);
         }

--- a/java/test/src/main/java/test/Ice/executor/Collocated.java
+++ b/java/test/src/main/java/test/Ice/executor/Collocated.java
@@ -4,7 +4,6 @@ package test.Ice.executor;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
 
@@ -13,7 +12,6 @@ import test.TestHelper;
 public class Collocated extends TestHelper {
     public void run(String[] args) {
         InitializationData initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.executor.Test");
         initData.properties = createTestProperties(args);
 
         CustomExecutor executor = new CustomExecutor();

--- a/java/test/src/main/java/test/Ice/executor/Collocated.java
+++ b/java/test/src/main/java/test/Ice/executor/Collocated.java
@@ -4,6 +4,7 @@ package test.Ice.executor;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
 
@@ -12,10 +13,12 @@ import test.TestHelper;
 public class Collocated extends TestHelper {
     public void run(String[] args) {
         InitializationData initData = new InitializationData();
-        CustomExecutor executor = new CustomExecutor();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.executor.Test");
         initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.Package.Test", "test.Ice.executor");
+
+        CustomExecutor executor = new CustomExecutor();
         initData.executor = executor;
+
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             communicator

--- a/java/test/src/main/java/test/Ice/executor/Server.java
+++ b/java/test/src/main/java/test/Ice/executor/Server.java
@@ -4,6 +4,7 @@ package test.Ice.executor;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
 
@@ -12,15 +13,15 @@ import test.TestHelper;
 public class Server extends TestHelper {
     public void run(String[] args) {
         InitializationData initData = new InitializationData();
-        CustomExecutor executor = new CustomExecutor();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.executor.Test");
         initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.Package.Test", "test.Ice.executor");
-        //
         // Limit the recv buffer size, this test relies on the socket
         // send() blocking after sending a given amount of data.
-        //
         initData.properties.setProperty("Ice.TCP.RcvSize", "50000");
+
+        CustomExecutor executor = new CustomExecutor();
         initData.executor = executor;
+
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             communicator

--- a/java/test/src/main/java/test/Ice/executor/Server.java
+++ b/java/test/src/main/java/test/Ice/executor/Server.java
@@ -4,7 +4,6 @@ package test.Ice.executor;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
 
@@ -13,7 +12,6 @@ import test.TestHelper;
 public class Server extends TestHelper {
     public void run(String[] args) {
         InitializationData initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.executor.Test");
         initData.properties = createTestProperties(args);
         // Limit the recv buffer size, this test relies on the socket
         // send() blocking after sending a given amount of data.

--- a/java/test/src/main/java/test/Ice/executor/Test.ice
+++ b/java/test/src/main/java/test/Ice/executor/Test.ice
@@ -4,7 +4,7 @@
 
 #include "Ice/BuiltinSequences.ice"
 
-[["java:package:test.Ice.executor"]]
+["java:identifier:test.Ice.executor.Test"]
 module Test
 {
     interface TestIntf

--- a/java/test/src/main/java/test/Ice/facets/Client.java
+++ b/java/test/src/main/java/test/Ice/facets/Client.java
@@ -3,19 +3,13 @@
 package test.Ice.facets;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.facets.Test.GPrx;
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "FAIL_IF_NONE");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             GPrx g = AllTests.allTests(this);
             g.shutdown();
         }

--- a/java/test/src/main/java/test/Ice/facets/Client.java
+++ b/java/test/src/main/java/test/Ice/facets/Client.java
@@ -3,16 +3,19 @@
 package test.Ice.facets;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.facets.Test.GPrx;
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.facets");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "FAIL_IF_NONE");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             GPrx g = AllTests.allTests(this);
             g.shutdown();
         }

--- a/java/test/src/main/java/test/Ice/facets/Collocated.java
+++ b/java/test/src/main/java/test/Ice/facets/Collocated.java
@@ -3,8 +3,6 @@
 package test.Ice.facets;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
@@ -13,11 +11,7 @@ import test.TestHelper;
 
 public class Collocated extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "FAIL_IF_NONE");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object d = new DI();

--- a/java/test/src/main/java/test/Ice/facets/Collocated.java
+++ b/java/test/src/main/java/test/Ice/facets/Collocated.java
@@ -3,18 +3,21 @@
 package test.Ice.facets;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Collocated extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.facets");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "FAIL_IF_NONE");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object d = new DI();

--- a/java/test/src/main/java/test/Ice/facets/Server.java
+++ b/java/test/src/main/java/test/Ice/facets/Server.java
@@ -3,8 +3,6 @@
 package test.Ice.facets;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
@@ -13,11 +11,7 @@ import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "FAIL_IF_NONE");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object d = new DI();

--- a/java/test/src/main/java/test/Ice/facets/Server.java
+++ b/java/test/src/main/java/test/Ice/facets/Server.java
@@ -3,19 +3,22 @@
 package test.Ice.facets;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.facets");
-        try (Communicator communicator = initialize(properties)) {
-            properties.setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "FAIL_IF_NONE");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
+            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object d = new DI();
             adapter.add(d, Util.stringToIdentity("d"));

--- a/java/test/src/main/java/test/Ice/facets/Test.ice
+++ b/java/test/src/main/java/test/Ice/facets/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.facets"]]
+["java:identifier:test.Ice.facets.Test"]
 module Test
 {
     interface Empty

--- a/java/test/src/main/java/test/Ice/faultTolerance/Client.java
+++ b/java/test/src/main/java/test/Ice/faultTolerance/Client.java
@@ -3,7 +3,8 @@
 package test.Ice.faultTolerance;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
@@ -17,14 +18,13 @@ public class Client extends TestHelper {
 
     public void run(String[] args) {
         List<String> remainingArgs = new ArrayList<String>();
-        Properties properties = createTestProperties(args, remainingArgs);
-        properties.setProperty("Ice.Package.Test", "test.Ice.faultTolerance");
-        //
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.faultTolerance.Test");
+        initData.properties = createTestProperties(args, remainingArgs);
         // This test aborts servers, so we don't want warnings.
-        //
-        properties.setProperty("Ice.Warn.Connections", "0");
+        initData.properties.setProperty("Ice.Warn.Connections", "0");
 
-        try (Communicator communicator = initialize(properties)) {
+        try (Communicator communicator = initialize(initData)) {
             List<Integer> ports = new ArrayList<>(args.length);
             for (String arg : remainingArgs) {
                 if (arg.charAt(0) == '-') {

--- a/java/test/src/main/java/test/Ice/faultTolerance/Client.java
+++ b/java/test/src/main/java/test/Ice/faultTolerance/Client.java
@@ -3,8 +3,6 @@
 package test.Ice.faultTolerance;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
@@ -18,13 +16,11 @@ public class Client extends TestHelper {
 
     public void run(String[] args) {
         List<String> remainingArgs = new ArrayList<String>();
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.faultTolerance.Test");
-        initData.properties = createTestProperties(args, remainingArgs);
+        var properties = createTestProperties(args, remainingArgs);
         // This test aborts servers, so we don't want warnings.
-        initData.properties.setProperty("Ice.Warn.Connections", "0");
+        properties.setProperty("Ice.Warn.Connections", "0");
 
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(properties)) {
             List<Integer> ports = new ArrayList<>(args.length);
             for (String arg : remainingArgs) {
                 if (arg.charAt(0) == '-') {

--- a/java/test/src/main/java/test/Ice/faultTolerance/Server.java
+++ b/java/test/src/main/java/test/Ice/faultTolerance/Server.java
@@ -3,8 +3,6 @@
 package test.Ice.faultTolerance;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
@@ -21,11 +19,9 @@ public class Server extends TestHelper {
 
     public void run(String[] args) {
         List<String> remainingArgs = new ArrayList<String>();
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.faultTolerance.Test");
-        initData.properties = createTestProperties(args, remainingArgs);
+        var properties = createTestProperties(args, remainingArgs);
 
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(properties)) {
             int port = 0;
             for (String arg : remainingArgs) {
                 if (arg.charAt(0) == '-') {

--- a/java/test/src/main/java/test/Ice/faultTolerance/Server.java
+++ b/java/test/src/main/java/test/Ice/faultTolerance/Server.java
@@ -3,9 +3,10 @@
 package test.Ice.faultTolerance;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
@@ -20,9 +21,11 @@ public class Server extends TestHelper {
 
     public void run(String[] args) {
         List<String> remainingArgs = new ArrayList<String>();
-        Properties properties = createTestProperties(args, remainingArgs);
-        properties.setProperty("Ice.Package.Test", "test.Ice.faultTolerance");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.faultTolerance.Test");
+        initData.properties = createTestProperties(args, remainingArgs);
+
+        try (Communicator communicator = initialize(initData)) {
             int port = 0;
             for (String arg : remainingArgs) {
                 if (arg.charAt(0) == '-') {

--- a/java/test/src/main/java/test/Ice/faultTolerance/Test.ice
+++ b/java/test/src/main/java/test/Ice/faultTolerance/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.faultTolerance"]]
+["java:identifier:test.Ice.faultTolerance.Test"]
 module Test
 {
     interface TestIntf

--- a/java/test/src/main/java/test/Ice/hash/Test.ice
+++ b/java/test/src/main/java/test/Ice/hash/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.hash"]]
+["java:identifier:test.Ice.hash.Test"]
 module Test
 {
     struct PointF

--- a/java/test/src/main/java/test/Ice/hold/Client.java
+++ b/java/test/src/main/java/test/Ice/hold/Client.java
@@ -3,15 +3,18 @@
 package test.Ice.hold;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.hold");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.hold.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/hold/Client.java
+++ b/java/test/src/main/java/test/Ice/hold/Client.java
@@ -3,18 +3,12 @@
 package test.Ice.hold;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.hold.Test");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/hold/Server.java
+++ b/java/test/src/main/java/test/Ice/hold/Server.java
@@ -3,8 +3,6 @@
 package test.Ice.hold;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
 
@@ -14,11 +12,7 @@ import java.util.Timer;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.hold.Test");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             communicator.getProperties().setProperty("TestAdapter1.Endpoints", getTestEndpoint(0));
             communicator.getProperties().setProperty("TestAdapter1.ThreadPool.Size", "5");
             communicator.getProperties().setProperty("TestAdapter1.ThreadPool.SizeMax", "5");

--- a/java/test/src/main/java/test/Ice/hold/Server.java
+++ b/java/test/src/main/java/test/Ice/hold/Server.java
@@ -3,8 +3,9 @@
 package test.Ice.hold;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
@@ -13,9 +14,11 @@ import java.util.Timer;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.hold");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.hold.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter1.Endpoints", getTestEndpoint(0));
             communicator.getProperties().setProperty("TestAdapter1.ThreadPool.Size", "5");
             communicator.getProperties().setProperty("TestAdapter1.ThreadPool.SizeMax", "5");

--- a/java/test/src/main/java/test/Ice/hold/Test.ice
+++ b/java/test/src/main/java/test/Ice/hold/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.hold"]]
+["java:identifier:test.Ice.hold.Test"]
 module Test
 {
     interface Hold

--- a/java/test/src/main/java/test/Ice/idleTimeout/Client.java
+++ b/java/test/src/main/java/test/Ice/idleTimeout/Client.java
@@ -2,20 +2,15 @@
 
 package test.Ice.idleTimeout;
 
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
-
 import test.TestHelper;
 
 public class Client extends TestHelper {
     @Override
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.idleTimeout.Test");
-        initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.Connection.Client.IdleTimeout", "1");
+        var properties = createTestProperties(args);
+        properties.setProperty("Ice.Connection.Client.IdleTimeout", "1");
 
-        try (var communicator = initialize(initData)) {
+        try (var communicator = initialize(properties)) {
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/idleTimeout/Client.java
+++ b/java/test/src/main/java/test/Ice/idleTimeout/Client.java
@@ -2,16 +2,20 @@
 
 package test.Ice.idleTimeout;
 
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
+
 import test.TestHelper;
 
 public class Client extends TestHelper {
     @Override
     public void run(String[] args) {
-        var properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.idleTimeout");
-        properties.setProperty("Ice.Connection.Client.IdleTimeout", "1");
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.idleTimeout.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Connection.Client.IdleTimeout", "1");
 
-        try (var communicator = initialize(properties)) {
+        try (var communicator = initialize(initData)) {
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/idleTimeout/Server.java
+++ b/java/test/src/main/java/test/Ice/idleTimeout/Server.java
@@ -3,21 +3,17 @@
 package test.Ice.idleTimeout;
 
 import com.zeroc.Ice.Identity;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.idleTimeout.Test");
-        initData.properties = createTestProperties(args);
-        initData.properties.setProperty("TestAdapter.Connection.IdleTimeout", "1"); // 1 second
-        initData.properties.setProperty("TestAdapter.Connection.MaxDispatches", "1");
-        initData.properties.setProperty("Ice.Warn.Connections", "0");
+        var properties = createTestProperties(args);
+        properties.setProperty("TestAdapter.Connection.IdleTimeout", "1"); // 1 second
+        properties.setProperty("TestAdapter.Connection.MaxDispatches", "1");
+        properties.setProperty("Ice.Warn.Connections", "0");
 
-        try (var communicator = initialize(initData)) {
+        try (var communicator = initialize(properties)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
             var adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new TestIntfI(), new Identity("test", ""));

--- a/java/test/src/main/java/test/Ice/idleTimeout/Server.java
+++ b/java/test/src/main/java/test/Ice/idleTimeout/Server.java
@@ -3,18 +3,21 @@
 package test.Ice.idleTimeout;
 
 import com.zeroc.Ice.Identity;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        var properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.idleTimeout");
-        properties.setProperty("TestAdapter.Connection.IdleTimeout", "1"); // 1 second
-        properties.setProperty("TestAdapter.Connection.MaxDispatches", "1");
-        properties.setProperty("Ice.Warn.Connections", "0");
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.idleTimeout.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("TestAdapter.Connection.IdleTimeout", "1"); // 1 second
+        initData.properties.setProperty("TestAdapter.Connection.MaxDispatches", "1");
+        initData.properties.setProperty("Ice.Warn.Connections", "0");
 
-        try (var communicator = initialize(properties)) {
+        try (var communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
             var adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new TestIntfI(), new Identity("test", ""));

--- a/java/test/src/main/java/test/Ice/idleTimeout/Test.ice
+++ b/java/test/src/main/java/test/Ice/idleTimeout/Test.ice
@@ -2,8 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.idleTimeout"]]
-
+["java:identifier:test.Ice.idleTimeout.Test"]
 module Test
 {
     interface TestIntf

--- a/java/test/src/main/java/test/Ice/inactivityTimeout/Client.java
+++ b/java/test/src/main/java/test/Ice/inactivityTimeout/Client.java
@@ -2,23 +2,18 @@
 
 package test.Ice.inactivityTimeout;
 
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
-
 import test.TestHelper;
 
 public class Client extends TestHelper {
     @Override
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.inactivityTimeout.Test");
-        initData.properties = createTestProperties(args);
+        var properties = createTestProperties(args);
         // We configure a low idle timeout to make sure we send heartbeats frequently. It's the
         // sending of the heartbeats that schedules the inactivity timer task.
-        initData.properties.setProperty("Ice.Connection.Client.IdleTimeout", "1");
-        initData.properties.setProperty("Ice.Connection.Client.InactivityTimeout", "3");
+        properties.setProperty("Ice.Connection.Client.IdleTimeout", "1");
+        properties.setProperty("Ice.Connection.Client.InactivityTimeout", "3");
 
-        try (var communicator = initialize(initData)) {
+        try (var communicator = initialize(properties)) {
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/inactivityTimeout/Client.java
+++ b/java/test/src/main/java/test/Ice/inactivityTimeout/Client.java
@@ -2,20 +2,23 @@
 
 package test.Ice.inactivityTimeout;
 
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
+
 import test.TestHelper;
 
 public class Client extends TestHelper {
     @Override
     public void run(String[] args) {
-        var properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.inactivityTimeout");
-
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.inactivityTimeout.Test");
+        initData.properties = createTestProperties(args);
         // We configure a low idle timeout to make sure we send heartbeats frequently. It's the
         // sending of the heartbeats that schedules the inactivity timer task.
-        properties.setProperty("Ice.Connection.Client.IdleTimeout", "1");
-        properties.setProperty("Ice.Connection.Client.InactivityTimeout", "3");
+        initData.properties.setProperty("Ice.Connection.Client.IdleTimeout", "1");
+        initData.properties.setProperty("Ice.Connection.Client.InactivityTimeout", "3");
 
-        try (var communicator = initialize(properties)) {
+        try (var communicator = initialize(initData)) {
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/inactivityTimeout/Server.java
+++ b/java/test/src/main/java/test/Ice/inactivityTimeout/Server.java
@@ -3,20 +3,23 @@
 package test.Ice.inactivityTimeout;
 
 import com.zeroc.Ice.Identity;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        var properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.inactivityTimeout");
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.inactivityTimeout.Test");
+        initData.properties = createTestProperties(args);
         // We configure a low idle timeout to make sure we send heartbeats frequently. It's the
         // sending of the heartbeats that schedules the inactivity timer.
-        properties.setProperty("Ice.Connection.Server.IdleTimeout", "1");
-        properties.setProperty("TestAdapter.Connection.InactivityTimeout", "5");
-        properties.setProperty("TestAdapter3s.Connection.InactivityTimeout", "3");
+        initData.properties.setProperty("Ice.Connection.Server.IdleTimeout", "1");
+        initData.properties.setProperty("TestAdapter.Connection.InactivityTimeout", "5");
+        initData.properties.setProperty("TestAdapter3s.Connection.InactivityTimeout", "3");
 
-        try (var communicator = initialize(properties)) {
+        try (var communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
             communicator.getProperties().setProperty("TestAdapter3s.Endpoints", getTestEndpoint(1));
 

--- a/java/test/src/main/java/test/Ice/inactivityTimeout/Server.java
+++ b/java/test/src/main/java/test/Ice/inactivityTimeout/Server.java
@@ -3,23 +3,19 @@
 package test.Ice.inactivityTimeout;
 
 import com.zeroc.Ice.Identity;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.inactivityTimeout.Test");
-        initData.properties = createTestProperties(args);
+        var properties = createTestProperties(args);
         // We configure a low idle timeout to make sure we send heartbeats frequently. It's the
         // sending of the heartbeats that schedules the inactivity timer.
-        initData.properties.setProperty("Ice.Connection.Server.IdleTimeout", "1");
-        initData.properties.setProperty("TestAdapter.Connection.InactivityTimeout", "5");
-        initData.properties.setProperty("TestAdapter3s.Connection.InactivityTimeout", "3");
+        properties.setProperty("Ice.Connection.Server.IdleTimeout", "1");
+        properties.setProperty("TestAdapter.Connection.InactivityTimeout", "5");
+        properties.setProperty("TestAdapter3s.Connection.InactivityTimeout", "3");
 
-        try (var communicator = initialize(initData)) {
+        try (var communicator = initialize(properties)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
             communicator.getProperties().setProperty("TestAdapter3s.Endpoints", getTestEndpoint(1));
 

--- a/java/test/src/main/java/test/Ice/inactivityTimeout/Test.ice
+++ b/java/test/src/main/java/test/Ice/inactivityTimeout/Test.ice
@@ -2,8 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.inactivityTimeout"]]
-
+["java:identifier:test.Ice.inactivityTimeout.Test"]
 module Test
 {
     interface TestIntf

--- a/java/test/src/main/java/test/Ice/info/Client.java
+++ b/java/test/src/main/java/test/Ice/info/Client.java
@@ -3,18 +3,12 @@
 package test.Ice.info;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.info.Test");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/info/Client.java
+++ b/java/test/src/main/java/test/Ice/info/Client.java
@@ -3,15 +3,18 @@
 package test.Ice.info;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.info");
-        try (Communicator communicator = initialize(args)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.info.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/info/Server.java
+++ b/java/test/src/main/java/test/Ice/info/Server.java
@@ -3,8 +3,6 @@
 package test.Ice.info;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
 
@@ -12,11 +10,7 @@ import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.info.Test");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             communicator.getProperties().setProperty(
                 "TestAdapter.Endpoints", getTestEndpoint(0) + ":" + getTestEndpoint(0, "udp"));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");

--- a/java/test/src/main/java/test/Ice/info/Server.java
+++ b/java/test/src/main/java/test/Ice/info/Server.java
@@ -3,18 +3,21 @@
 package test.Ice.info;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.proxy");
-        try (Communicator communicator = initialize(properties)) {
-            properties.setProperty(
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.info.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
+            communicator.getProperties().setProperty(
                 "TestAdapter.Endpoints", getTestEndpoint(0) + ":" + getTestEndpoint(0, "udp"));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new TestI(), Util.stringToIdentity("test"));

--- a/java/test/src/main/java/test/Ice/info/Test.ice
+++ b/java/test/src/main/java/test/Ice/info/Test.ice
@@ -4,7 +4,7 @@
 
 #include "Ice/Context.ice"
 
-[["java:package:test.Ice.info"]]
+["java:identifier:test.Ice.info.Test"]
 module Test
 {
     interface TestIntf

--- a/java/test/src/main/java/test/Ice/inheritance/Client.java
+++ b/java/test/src/main/java/test/Ice/inheritance/Client.java
@@ -3,16 +3,19 @@
 package test.Ice.inheritance;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.inheritance.Test.InitialPrx;
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.inheritance");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.inheritance.Test");
+        initData.properties = createTestProperties(args);
+    
+        try (Communicator communicator = initialize(initData)) {
             InitialPrx initial = AllTests.allTests(this);
             initial.shutdown();
         }

--- a/java/test/src/main/java/test/Ice/inheritance/Client.java
+++ b/java/test/src/main/java/test/Ice/inheritance/Client.java
@@ -3,19 +3,13 @@
 package test.Ice.inheritance;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.inheritance.Test.InitialPrx;
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.inheritance.Test");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             InitialPrx initial = AllTests.allTests(this);
             initial.shutdown();
         }

--- a/java/test/src/main/java/test/Ice/inheritance/Client.java
+++ b/java/test/src/main/java/test/Ice/inheritance/Client.java
@@ -14,7 +14,7 @@ public class Client extends TestHelper {
         var initData = new InitializationData();
         initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.inheritance.Test");
         initData.properties = createTestProperties(args);
-    
+
         try (Communicator communicator = initialize(initData)) {
             InitialPrx initial = AllTests.allTests(this);
             initial.shutdown();

--- a/java/test/src/main/java/test/Ice/inheritance/Collocated.java
+++ b/java/test/src/main/java/test/Ice/inheritance/Collocated.java
@@ -3,8 +3,6 @@
 package test.Ice.inheritance;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
 
@@ -13,11 +11,7 @@ import test.TestHelper;
 public class Collocated extends TestHelper {
     @Override
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.inheritance.Test");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new InitialI(adapter), Util.stringToIdentity("initial"));

--- a/java/test/src/main/java/test/Ice/inheritance/Collocated.java
+++ b/java/test/src/main/java/test/Ice/inheritance/Collocated.java
@@ -3,8 +3,9 @@
 package test.Ice.inheritance;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
@@ -12,9 +13,11 @@ import test.TestHelper;
 public class Collocated extends TestHelper {
     @Override
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.inheritance");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.inheritance.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new InitialI(adapter), Util.stringToIdentity("initial"));

--- a/java/test/src/main/java/test/Ice/inheritance/Server.java
+++ b/java/test/src/main/java/test/Ice/inheritance/Server.java
@@ -3,8 +3,6 @@
 package test.Ice.inheritance;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
@@ -13,11 +11,7 @@ import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.inheritance.Test");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object object = new InitialI(adapter);

--- a/java/test/src/main/java/test/Ice/inheritance/Server.java
+++ b/java/test/src/main/java/test/Ice/inheritance/Server.java
@@ -3,18 +3,21 @@
 package test.Ice.inheritance;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.inheritance");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.inheritance.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object object = new InitialI(adapter);

--- a/java/test/src/main/java/test/Ice/inheritance/Test.ice
+++ b/java/test/src/main/java/test/Ice/inheritance/Test.ice
@@ -2,8 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.inheritance"]]
-
+["java:identifier:test.Ice.inheritance.Test"]
 module Test
 {
     module MA

--- a/java/test/src/main/java/test/Ice/interrupt/Client.java
+++ b/java/test/src/main/java/test/Ice/interrupt/Client.java
@@ -3,30 +3,26 @@
 package test.Ice.interrupt;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.interrupt");
-        //
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.interrupt.Test");
+        initData.properties = createTestProperties(args);
         // We need to send messages large enough to cause the transport buffers to fill up.
-        //
-        properties.setProperty("Ice.MessageSizeMax", "20000");
-        //
+        initData.properties.setProperty("Ice.MessageSizeMax", "20000");
         // Retry up to 2 times, sleep 2s for the last retry. This is
         // useful to test interrupting the retry sleep
-        //
-        properties.setProperty("Ice.RetryIntervals", "0 2000");
-        //
+        initData.properties.setProperty("Ice.RetryIntervals", "0 2000");
         // Limit the send buffer size, this test relies on the socket
         // send() blocking after sending a given amount of data.
-        //
-        properties.setProperty("Ice.TCP.SndSize", "50000");
+        initData.properties.setProperty("Ice.TCP.SndSize", "50000");
 
-        try (Communicator communicator = initialize(properties)) {
+        try (Communicator communicator = initialize(initData)) {
             AllTests.allTests(this);
         } catch (InterruptedException ex) {
             throw new RuntimeException(ex);

--- a/java/test/src/main/java/test/Ice/interrupt/Collocated.java
+++ b/java/test/src/main/java/test/Ice/interrupt/Collocated.java
@@ -3,27 +3,24 @@
 package test.Ice.interrupt;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Collocated extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.interrupt");
-        //
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.interrupt.Test");
+        initData.properties = createTestProperties(args);
         // We need to send messages large enough to cause the transport buffers to fill up.
-        //
-        properties.setProperty("Ice.MessageSizeMax", "20000");
-        //
-        // opIdempotent raises UnknownException, we disable dispatch
-        // warnings to prevent warnings.
-        //
-        properties.setProperty("Ice.Warn.Dispatch", "0");
+        initData.properties.setProperty("Ice.MessageSizeMax", "20000");
+        // opIdempotent raises UnknownException, we disable dispatch warnings to prevent warnings.
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
 
-        try (Communicator communicator = initialize(properties)) {
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             communicator
                 .getProperties()

--- a/java/test/src/main/java/test/Ice/interrupt/Server.java
+++ b/java/test/src/main/java/test/Ice/interrupt/Server.java
@@ -3,32 +3,27 @@
 package test.Ice.interrupt;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.interrupt");
-        //
-        // We need to send messages large enough to cause the transport
-        // buffers to fill up.
-        //
-        properties.setProperty("Ice.MessageSizeMax", "20000");
-        //
-        // opIdempotent raises UnknownException, we disable dispatch
-        // warnings to prevent warnings.
-        //
-        properties.setProperty("Ice.Warn.Dispatch", "0");
-        //
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.interrupt.Test");
+        initData.properties = createTestProperties(args);
+        // We need to send messages large enough to cause the transport buffers to fill up.
+        initData.properties.setProperty("Ice.MessageSizeMax", "20000");
+        // opIdempotent raises UnknownException, we disable dispatch warnings to prevent warnings.
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
         // Limit the recv buffer size, this test relies on the socket
         // send() blocking after sending a given amount of data.
-        //
-        properties.setProperty("Ice.TCP.RcvSize", "50000");
-        try (Communicator communicator = initialize(properties)) {
+        initData.properties.setProperty("Ice.TCP.RcvSize", "50000");
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             communicator
                 .getProperties()

--- a/java/test/src/main/java/test/Ice/interrupt/Test.ice
+++ b/java/test/src/main/java/test/Ice/interrupt/Test.ice
@@ -4,7 +4,7 @@
 
 #include "Ice/BuiltinSequences.ice"
 
-[["java:package:test.Ice.interrupt"]]
+["java:identifier:test.Ice.interrupt.Test"]
 module Test
 {
     exception InterruptedException

--- a/java/test/src/main/java/test/Ice/invoke/Client.java
+++ b/java/test/src/main/java/test/Ice/invoke/Client.java
@@ -3,16 +3,19 @@
 package test.Ice.invoke;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.invoke.Test.MyClassPrx;
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.invoke");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.invoke.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             MyClassPrx myClass = AllTests.allTests(this);
             myClass.shutdown();
         }

--- a/java/test/src/main/java/test/Ice/invoke/Server.java
+++ b/java/test/src/main/java/test/Ice/invoke/Server.java
@@ -3,8 +3,9 @@
 package test.Ice.invoke;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 
 import test.TestHelper;
 
@@ -12,9 +13,11 @@ import java.util.stream.Stream;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.invoke");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.invoke.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             boolean async = Stream.of(args).anyMatch(v -> "--async".equals(v));
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");

--- a/java/test/src/main/java/test/Ice/invoke/Test.ice
+++ b/java/test/src/main/java/test/Ice/invoke/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.invoke"]]
+["java:identifier:test.Ice.invoke.Test"]
 module Test
 {
     exception MyException

--- a/java/test/src/main/java/test/Ice/location/Client.java
+++ b/java/test/src/main/java/test/Ice/location/Client.java
@@ -3,16 +3,19 @@
 package test.Ice.location;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.location");
-        properties.setProperty("Ice.Default.Locator", "locator:" + getTestEndpoint(properties, 0));
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.location.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Default.Locator", "locator:" + getTestEndpoint(initData.properties, 0));
+
+        try (Communicator communicator = initialize(initData)) {
             AllTests.allTests(this);
         } catch (Exception ex) {
             throw new RuntimeException(ex);

--- a/java/test/src/main/java/test/Ice/location/Client.java
+++ b/java/test/src/main/java/test/Ice/location/Client.java
@@ -3,19 +3,15 @@
 package test.Ice.location;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.location.Test");
-        initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.Default.Locator", "locator:" + getTestEndpoint(initData.properties, 0));
+        var properties = createTestProperties(args);
+        properties.setProperty("Ice.Default.Locator", "locator:" + getTestEndpoint(properties, 0));
 
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(properties)) {
             AllTests.allTests(this);
         } catch (Exception ex) {
             throw new RuntimeException(ex);

--- a/java/test/src/main/java/test/Ice/location/Server.java
+++ b/java/test/src/main/java/test/Ice/location/Server.java
@@ -3,9 +3,7 @@
 package test.Ice.location;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.LocatorRegistryPrx;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
@@ -14,13 +12,11 @@ import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.location.Test");
-        initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.ThreadPool.Server.Size", "2");
-        initData.properties.setProperty("Ice.ThreadPool.Server.SizeWarn", "0");
+        var properties = createTestProperties(args);
+        properties.setProperty("Ice.ThreadPool.Server.Size", "2");
+        properties.setProperty("Ice.ThreadPool.Server.SizeWarn", "0");
 
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(properties)) {
             communicator
                 .getProperties()
                 .setProperty("ServerManagerAdapter.Endpoints", getTestEndpoint(0));

--- a/java/test/src/main/java/test/Ice/location/Server.java
+++ b/java/test/src/main/java/test/Ice/location/Server.java
@@ -3,22 +3,24 @@
 package test.Ice.location;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.LocatorRegistryPrx;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.location");
-        properties.setProperty("Ice.ThreadPool.Server.Size", "2");
-        properties.setProperty("Ice.ThreadPool.Server.SizeWarn", "0");
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.location.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.ThreadPool.Server.Size", "2");
+        initData.properties.setProperty("Ice.ThreadPool.Server.SizeWarn", "0");
 
-        try (Communicator communicator = initialize(properties)) {
+        try (Communicator communicator = initialize(initData)) {
             communicator
                 .getProperties()
                 .setProperty("ServerManagerAdapter.Endpoints", getTestEndpoint(0));

--- a/java/test/src/main/java/test/Ice/location/Test.ice
+++ b/java/test/src/main/java/test/Ice/location/Test.ice
@@ -5,7 +5,7 @@
 #include "Ice/Locator.ice"
 #include "Ice/LocatorRegistry.ice"
 
-[["java:package:test.Ice.location"]]
+["java:identifier:test.Ice.location.Test"]
 module Test
 {
     interface TestLocatorRegistry extends Ice::LocatorRegistry

--- a/java/test/src/main/java/test/Ice/location/Test.ice
+++ b/java/test/src/main/java/test/Ice/location/Test.ice
@@ -10,17 +10,13 @@ module Test
 {
     interface TestLocatorRegistry extends Ice::LocatorRegistry
     {
-        //
-        // Allow remote addition of objects to the locator registry.
-        //
+        /// Allow remote addition of objects to the locator registry.
         void addObject(Object* obj);
     }
 
     interface TestLocator extends Ice::Locator
     {
-        //
-        // Returns the number of request on the locator interface.
-        //
+        /// Returns the number of request on the locator interface.
         idempotent int getRequestCount();
     }
 

--- a/java/test/src/main/java/test/Ice/maxConnections/Client.java
+++ b/java/test/src/main/java/test/Ice/maxConnections/Client.java
@@ -2,21 +2,18 @@
 
 package test.Ice.maxConnections;
 
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
+import com.zeroc.Ice.Properties;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     @Override
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.maxConnections.Test");
-        initData.properties = createTestProperties(args);
+        Properties properties = createTestProperties(args);
         // We disable retries to make the logs clearer and avoid hiding potential issues.
-        initData.properties.setProperty("Ice.RetryIntervals", "-1");
+        properties.setProperty("Ice.RetryIntervals", "-1");
 
-        try (var communicator = initialize(initData)) {
+        try (var communicator = initialize(properties)) {
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/maxConnections/Client.java
+++ b/java/test/src/main/java/test/Ice/maxConnections/Client.java
@@ -2,18 +2,21 @@
 
 package test.Ice.maxConnections;
 
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
+
 import test.TestHelper;
 
 public class Client extends TestHelper {
     @Override
     public void run(String[] args) {
-        var properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.maxConnections");
-
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.maxConnections.Test");
+        initData.properties = createTestProperties(args);
         // We disable retries to make the logs clearer and avoid hiding potential issues.
-        properties.setProperty("Ice.RetryIntervals", "-1");
+        initData.properties.setProperty("Ice.RetryIntervals", "-1");
 
-        try (var communicator = initialize(properties)) {
+        try (var communicator = initialize(initData)) {
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/maxConnections/Client.java
+++ b/java/test/src/main/java/test/Ice/maxConnections/Client.java
@@ -2,14 +2,12 @@
 
 package test.Ice.maxConnections;
 
-import com.zeroc.Ice.Properties;
-
 import test.TestHelper;
 
 public class Client extends TestHelper {
     @Override
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
+        var properties = createTestProperties(args);
         // We disable retries to make the logs clearer and avoid hiding potential issues.
         properties.setProperty("Ice.RetryIntervals", "-1");
 

--- a/java/test/src/main/java/test/Ice/maxConnections/Server.java
+++ b/java/test/src/main/java/test/Ice/maxConnections/Server.java
@@ -3,18 +3,12 @@
 package test.Ice.maxConnections;
 
 import com.zeroc.Ice.Identity;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.maxConnections.Test");
-        initData.properties = createTestProperties(args);
-
-        try (var communicator = initialize(initData)) {
+        try (var communicator = initialize(args)) {
             // Plain adapter with no limit.
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
             var adapter = communicator.createObjectAdapter("TestAdapter");

--- a/java/test/src/main/java/test/Ice/maxConnections/Server.java
+++ b/java/test/src/main/java/test/Ice/maxConnections/Server.java
@@ -3,15 +3,18 @@
 package test.Ice.maxConnections;
 
 import com.zeroc.Ice.Identity;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        var properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.maxConnections");
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.maxConnections.Test");
+        initData.properties = createTestProperties(args);
 
-        try (var communicator = initialize(properties)) {
+        try (var communicator = initialize(initData)) {
             // Plain adapter with no limit.
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
             var adapter = communicator.createObjectAdapter("TestAdapter");

--- a/java/test/src/main/java/test/Ice/maxConnections/Test.ice
+++ b/java/test/src/main/java/test/Ice/maxConnections/Test.ice
@@ -2,8 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.maxConnections"]]
-
+["java:identifier:test.Ice.maxConnections.Test"]
 module Test
 {
     interface TestIntf

--- a/java/test/src/main/java/test/Ice/maxDispatches/Client.java
+++ b/java/test/src/main/java/test/Ice/maxDispatches/Client.java
@@ -2,19 +2,12 @@
 
 package test.Ice.maxDispatches;
 
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
-
 import test.TestHelper;
 
 public class Client extends TestHelper {
     @Override
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.maxDispatches.Tests");
-        initData.properties = createTestProperties(args);
-
-        try (var communicator = initialize(initData)) {
+        try (var communicator = initialize(args)) {
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/maxDispatches/Client.java
+++ b/java/test/src/main/java/test/Ice/maxDispatches/Client.java
@@ -2,15 +2,19 @@
 
 package test.Ice.maxDispatches;
 
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
+
 import test.TestHelper;
 
 public class Client extends TestHelper {
     @Override
     public void run(String[] args) {
-        var properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.maxDispatches");
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.maxDispatches.Tests");
+        initData.properties = createTestProperties(args);
 
-        try (var communicator = initialize(properties)) {
+        try (var communicator = initialize(initData)) {
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/maxDispatches/Server.java
+++ b/java/test/src/main/java/test/Ice/maxDispatches/Server.java
@@ -3,17 +3,20 @@
 package test.Ice.maxDispatches;
 
 import com.zeroc.Ice.Identity;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        var properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.maxDispatches");
-        properties.setProperty(
-            "Ice.ThreadPool.Server.Size", "10"); // plenty of threads to handle the requests
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.maxDispatches.Test");
+        initData.properties = createTestProperties(args);
+         // plenty of threads to handle the requests
+        initData.properties.setProperty("Ice.ThreadPool.Server.Size", "10");
 
-        try (var communicator = initialize(properties)) {
+        try (var communicator = initialize(initData)) {
 
             var responder = new ResponderI();
             var testIntf = new TestIntfI(responder);

--- a/java/test/src/main/java/test/Ice/maxDispatches/Server.java
+++ b/java/test/src/main/java/test/Ice/maxDispatches/Server.java
@@ -3,20 +3,17 @@
 package test.Ice.maxDispatches;
 
 import com.zeroc.Ice.Identity;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
+import com.zeroc.Ice.Properties;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.maxDispatches.Test");
-        initData.properties = createTestProperties(args);
+        Properties properties = createTestProperties(args);
          // plenty of threads to handle the requests
-        initData.properties.setProperty("Ice.ThreadPool.Server.Size", "10");
+        properties.setProperty("Ice.ThreadPool.Server.Size", "10");
 
-        try (var communicator = initialize(initData)) {
+        try (var communicator = initialize(properties)) {
 
             var responder = new ResponderI();
             var testIntf = new TestIntfI(responder);

--- a/java/test/src/main/java/test/Ice/maxDispatches/Server.java
+++ b/java/test/src/main/java/test/Ice/maxDispatches/Server.java
@@ -9,7 +9,7 @@ import test.TestHelper;
 public class Server extends TestHelper {
     public void run(String[] args) {
         var properties = createTestProperties(args);
-         // plenty of threads to handle the requests
+        // plenty of threads to handle the requests
         properties.setProperty("Ice.ThreadPool.Server.Size", "10");
 
         try (var communicator = initialize(properties)) {

--- a/java/test/src/main/java/test/Ice/maxDispatches/Server.java
+++ b/java/test/src/main/java/test/Ice/maxDispatches/Server.java
@@ -3,13 +3,12 @@
 package test.Ice.maxDispatches;
 
 import com.zeroc.Ice.Identity;
-import com.zeroc.Ice.Properties;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
+        var properties = createTestProperties(args);
          // plenty of threads to handle the requests
         properties.setProperty("Ice.ThreadPool.Server.Size", "10");
 

--- a/java/test/src/main/java/test/Ice/maxDispatches/Test.ice
+++ b/java/test/src/main/java/test/Ice/maxDispatches/Test.ice
@@ -2,8 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.maxDispatches"]]
-
+["java:identifier:test.Ice.maxDispatches.Test"]
 module Test
 {
     interface TestIntf

--- a/java/test/src/main/java/test/Ice/metrics/AMDServer.java
+++ b/java/test/src/main/java/test/Ice/metrics/AMDServer.java
@@ -3,6 +3,8 @@
 package test.Ice.metrics;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
@@ -11,15 +13,16 @@ import test.TestHelper;
 
 public class AMDServer extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.retry");
-        properties.setProperty("Ice.Admin.Endpoints", "tcp");
-        properties.setProperty("Ice.Admin.InstanceName", "server");
-        properties.setProperty("Ice.Warn.Connections", "0");
-        properties.setProperty("Ice.Warn.Dispatch", "0");
-        properties.setProperty("Ice.MessageSizeMax", "50000");
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.metrics.AMD.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Admin.Endpoints", "tcp");
+        initData.properties.setProperty("Ice.Admin.InstanceName", "server");
+        initData.properties.setProperty("Ice.Warn.Connections", "0");
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+        initData.properties.setProperty("Ice.MessageSizeMax", "50000");
 
-        try (Communicator communicator = initialize(properties)) {
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new AMDMetricsI(), Util.stringToIdentity("metrics"));

--- a/java/test/src/main/java/test/Ice/metrics/Client.java
+++ b/java/test/src/main/java/test/Ice/metrics/Client.java
@@ -5,6 +5,7 @@ package test.Ice.metrics;
 import com.zeroc.Ice.Communicator;
 import com.zeroc.IceMX.UnknownMetricsView;
 import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.metrics.Test.MetricsPrx;
 import test.TestHelper;
@@ -13,16 +14,15 @@ public class Client extends TestHelper {
     public void run(String[] args) {
         CommunicatorObserverI observer = new CommunicatorObserverI();
         InitializationData initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.metrics.Test");
         initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.Package.Test", "test.Ice.metrics");
         initData.properties.setProperty("Ice.Admin.Endpoints", "tcp");
         initData.properties.setProperty("Ice.Admin.InstanceName", "client");
         initData.properties.setProperty("Ice.Admin.DelayCreation", "1");
         initData.properties.setProperty("Ice.Warn.Connections", "0");
         initData.properties.setProperty("Ice.Default.Host", "127.0.0.1");
-        initData.properties.setProperty(
-            "Ice.Connection.Client.ConnectTimeout",
-            "1"); // speed up connection establishment tests
+        // speed up connection establishment tests
+        initData.properties.setProperty("Ice.Connection.Client.ConnectTimeout", "1");
         initData.observer = observer;
 
         try (Communicator communicator = initialize(initData)) {

--- a/java/test/src/main/java/test/Ice/metrics/Collocated.java
+++ b/java/test/src/main/java/test/Ice/metrics/Collocated.java
@@ -5,6 +5,7 @@ package test.Ice.metrics;
 import com.zeroc.Ice.Communicator;
 import com.zeroc.IceMX.UnknownMetricsView;
 import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
 
@@ -15,8 +16,8 @@ public class Collocated extends TestHelper {
     public void run(String[] args) {
         CommunicatorObserverI observer = new CommunicatorObserverI();
         InitializationData initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.metrics.Test");
         initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.Package.Test", "test.Ice.metrics");
         initData.properties.setProperty("Ice.Admin.Endpoints", "tcp");
         initData.properties.setProperty("Ice.Admin.InstanceName", "client");
         initData.properties.setProperty("Ice.Admin.DelayCreation", "1");

--- a/java/test/src/main/java/test/Ice/metrics/Server.java
+++ b/java/test/src/main/java/test/Ice/metrics/Server.java
@@ -3,24 +3,26 @@
 package test.Ice.metrics;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.retry");
-        properties.setProperty("Ice.Admin.Endpoints", "tcp");
-        properties.setProperty("Ice.Admin.InstanceName", "server");
-        properties.setProperty("Ice.Warn.Connections", "0");
-        properties.setProperty("Ice.Warn.Dispatch", "0");
-        properties.setProperty("Ice.MessageSizeMax", "50000");
-        properties.setProperty("Ice.Default.Host", "127.0.0.1");
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.metrics.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Admin.Endpoints", "tcp");
+        initData.properties.setProperty("Ice.Admin.InstanceName", "server");
+        initData.properties.setProperty("Ice.Warn.Connections", "0");
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+        initData.properties.setProperty("Ice.MessageSizeMax", "50000");
+        initData.properties.setProperty("Ice.Default.Host", "127.0.0.1");
 
-        try (Communicator communicator = initialize(properties)) {
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new MetricsI(), Util.stringToIdentity("metrics"));

--- a/java/test/src/main/java/test/Ice/metrics/Test.ice
+++ b/java/test/src/main/java/test/Ice/metrics/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.metrics"]]
+["java:identifier:test.Ice.metrics.Test"]
 module Test
 {
     exception UserEx

--- a/java/test/src/main/java/test/Ice/metrics/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/metrics/TestAMD.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.metrics.AMD"]]
+["java:identifier:test.Ice.metrics.AMD.Test"]
 module Test
 {
     exception UserEx

--- a/java/test/src/main/java/test/Ice/middleware/Test.ice
+++ b/java/test/src/main/java/test/Ice/middleware/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.middleware"]]
+["java:identifier:test.Ice.middleware.Test"]
 module Test
 {
     interface MyObject

--- a/java/test/src/main/java/test/Ice/networkProxy/Client.java
+++ b/java/test/src/main/java/test/Ice/networkProxy/Client.java
@@ -3,18 +3,12 @@
 package test.Ice.networkProxy;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.networkProxy.Test");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/networkProxy/Client.java
+++ b/java/test/src/main/java/test/Ice/networkProxy/Client.java
@@ -3,15 +3,18 @@
 package test.Ice.networkProxy;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.networkProxy");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.networkProxy.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/networkProxy/Server.java
+++ b/java/test/src/main/java/test/Ice/networkProxy/Server.java
@@ -4,8 +4,6 @@ package test.Ice.networkProxy;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Current;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
 
@@ -20,11 +18,7 @@ public class Server extends TestHelper {
     }
 
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.networkProxy.Test");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new TestI(), Util.stringToIdentity("test"));

--- a/java/test/src/main/java/test/Ice/networkProxy/Server.java
+++ b/java/test/src/main/java/test/Ice/networkProxy/Server.java
@@ -4,8 +4,9 @@ package test.Ice.networkProxy;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Current;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.Ice.networkProxy.Test.TestIntf;
@@ -19,9 +20,11 @@ public class Server extends TestHelper {
     }
 
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.networkProxy");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.networkProxy.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new TestI(), Util.stringToIdentity("test"));

--- a/java/test/src/main/java/test/Ice/networkProxy/Test.ice
+++ b/java/test/src/main/java/test/Ice/networkProxy/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.networkProxy"]]
+["java:identifier:test.Ice.networkProxy.Test"]
 module Test
 {
     interface TestIntf

--- a/java/test/src/main/java/test/Ice/objects/Client.java
+++ b/java/test/src/main/java/test/Ice/objects/Client.java
@@ -6,7 +6,7 @@ import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ClassSliceLoader;
 import com.zeroc.Ice.CompositeSliceLoader;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.objects.Test.Compact;
 import test.Ice.objects.Test.CompactExt;
@@ -17,7 +17,6 @@ public class Client extends TestHelper {
     public void run(String[] args) {
         var initData = new InitializationData();
         initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.Package.Test", "test.Ice.objects");
         initData.properties.setProperty("Ice.MessageSizeMax", "2048"); // Needed on some Android versions
         initData.sliceLoader =
             new CompositeSliceLoader(
@@ -29,7 +28,8 @@ public class Client extends TestHelper {
                         default -> null;
                     };
                 },
-                new ClassSliceLoader(Compact.class, CompactExt.class));
+                new ClassSliceLoader(Compact.class, CompactExt.class),
+                new ModuleToPackageSliceLoader("::Test", "test.Ice.objects.Test"));
 
         try (Communicator communicator = initialize(initData)) {
             InitialPrx initial = AllTests.allTests(this);

--- a/java/test/src/main/java/test/Ice/objects/Collocated.java
+++ b/java/test/src/main/java/test/Ice/objects/Collocated.java
@@ -6,8 +6,8 @@ import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ClassSliceLoader;
 import com.zeroc.Ice.CompositeSliceLoader;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.Ice.objects.Test.Compact;
@@ -19,7 +19,6 @@ public class Collocated extends TestHelper {
     public void run(String[] args) {
         var initData = new InitializationData();
         initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.Package.Test", "test.Ice.objects");
         initData.properties.setProperty("Ice.Warn.Dispatch", "0");
         initData.sliceLoader =
             new CompositeSliceLoader(
@@ -31,7 +30,8 @@ public class Collocated extends TestHelper {
                         default -> null;
                     };
                 },
-                new ClassSliceLoader(Compact.class, CompactExt.class));
+                new ClassSliceLoader(Compact.class, CompactExt.class),
+                new ModuleToPackageSliceLoader("::Test", "test.Ice.objects.Test"));
 
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));

--- a/java/test/src/main/java/test/Ice/objects/Forward.ice
+++ b/java/test/src/main/java/test/Ice/objects/Forward.ice
@@ -2,8 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.objects"]]
-
+["java:identifier:test.Ice.objects.Test"]
 module Test
 {
     class F1

--- a/java/test/src/main/java/test/Ice/objects/Server.java
+++ b/java/test/src/main/java/test/Ice/objects/Server.java
@@ -3,18 +3,21 @@
 package test.Ice.objects;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.objects");
-        properties.setProperty("Ice.Warn.Dispatch", "0");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.objects.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
 
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");

--- a/java/test/src/main/java/test/Ice/objects/Test.ice
+++ b/java/test/src/main/java/test/Ice/objects/Test.ice
@@ -2,8 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.objects"]]
-
+["java:identifier:test.Ice.objects.Test"]
 module Test
 {
     struct S

--- a/java/test/src/main/java/test/Ice/operations/AMDServer.java
+++ b/java/test/src/main/java/test/Ice/operations/AMDServer.java
@@ -3,23 +3,22 @@
 package test.Ice.operations;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class AMDServer extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        //
-        // It's possible to have batch oneway requests dispatched
-        // after the adapter is deactivated due to thread
-        // scheduling so we suppress this warning.
-        //
-        properties.setProperty("Ice.Warn.Dispatch", "0");
-        properties.setProperty("Ice.Package.Test", "test.Ice.operations.AMD");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.operations.AMD.Test");
+        initData.properties = createTestProperties(args);
+        // It's possible to have batch oneway requests dispatched after the adapter is deactivated due to thread scheduling so we suppress this warning.
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new AMDMyDerivedClassI(), Util.stringToIdentity("test"));

--- a/java/test/src/main/java/test/Ice/operations/Client.java
+++ b/java/test/src/main/java/test/Ice/operations/Client.java
@@ -6,7 +6,6 @@ import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.LocalException;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
-import com.zeroc.Ice.Properties;
 
 import test.Ice.operations.Test.MyClassPrx;
 import test.TestHelper;
@@ -15,14 +14,12 @@ import java.io.PrintWriter;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.ThreadPool.Client.Size", "2");
-        properties.setProperty("Ice.ThreadPool.Client.SizeWarn", "0");
-        properties.setProperty("Ice.BatchAutoFlushSize", "100");
-
         var initData = new InitializationData();
         initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.operations.Test");
-        initData.properties = properties;
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.ThreadPool.Client.Size", "2");
+        initData.properties.setProperty("Ice.ThreadPool.Client.SizeWarn", "0");
+        initData.properties.setProperty("Ice.BatchAutoFlushSize", "100");
 
         PrintWriter out = getWriter();
         try (Communicator communicator = initialize(initData)) {

--- a/java/test/src/main/java/test/Ice/operations/Collocated.java
+++ b/java/test/src/main/java/test/Ice/operations/Collocated.java
@@ -7,7 +7,6 @@ import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.ObjectPrx;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import java.io.PrintWriter;
@@ -16,19 +15,13 @@ import test.TestHelper;
 
 public class Collocated extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.BatchAutoFlushSize", "100");
-
         var initData = new InitializationData();
         initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.operations.Test");
-        initData.properties = properties;
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.BatchAutoFlushSize", "100");
+        // It's possible to have batch oneway requests dispatched after the adapter is deactivated due to thread scheduling so we suppress this warning.
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
 
-        //
-        // Its possible to have batch oneway requests dispatched
-        // after the adapter is deactivated due to thread
-        // scheduling so we suppress this warning.
-        //
-        properties.setProperty("Ice.Warn.Dispatch", "0");
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");

--- a/java/test/src/main/java/test/Ice/operations/Server.java
+++ b/java/test/src/main/java/test/Ice/operations/Server.java
@@ -6,24 +6,17 @@ import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        //
-        // It's possible to have batch oneway requests dispatched
-        // after the adapter is deactivated due to thread
-        // scheduling so we suppress this warning.
-        //
-        properties.setProperty("Ice.Warn.Dispatch", "0");
-
         var initData = new InitializationData();
         initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.operations.Test");
-        initData.properties = properties;
+        initData.properties = createTestProperties(args);
+        // It's possible to have batch oneway requests dispatched after the adapter is deactivated due to thread scheduling so we suppress this warning.
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
 
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));

--- a/java/test/src/main/java/test/Ice/operations/Test.ice
+++ b/java/test/src/main/java/test/Ice/operations/Test.ice
@@ -4,7 +4,7 @@
 
 #include "Ice/Context.ice"
 
-[["java:package:test.Ice.operations"]]
+["java:identifier:test.Ice.operations.Test"]
 module Test
 {
     enum MyEnum

--- a/java/test/src/main/java/test/Ice/operations/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/operations/TestAMD.ice
@@ -4,7 +4,7 @@
 
 #include "Ice/Context.ice"
 
-[["java:package:test.Ice.operations.AMD"]]
+["java:identifier:test.Ice.operations.AMD.Test"]
 module Test
 {
     enum MyEnum

--- a/java/test/src/main/java/test/Ice/optional/AMDServer.java
+++ b/java/test/src/main/java/test/Ice/optional/AMDServer.java
@@ -3,17 +3,20 @@
 package test.Ice.optional;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class AMDServer extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.optional.AMD");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.optional.AMD.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             communicator().getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new AMDInitialI(), Util.stringToIdentity("initial"));

--- a/java/test/src/main/java/test/Ice/optional/Client.java
+++ b/java/test/src/main/java/test/Ice/optional/Client.java
@@ -3,8 +3,9 @@
 package test.Ice.optional;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.CompositeSliceLoader;
 import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.optional.Test.InitialPrx;
 import test.TestHelper;
@@ -13,9 +14,10 @@ public class Client extends TestHelper {
     public void run(String[] args) {
         var initData = new InitializationData();
         initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.Package.Test", "test.Ice.optional");
         var customSliceLoader = new AllTests.CustomSliceLoader();
-        initData.sliceLoader = customSliceLoader;
+        initData.sliceLoader = new CompositeSliceLoader(
+            customSliceLoader,
+            new ModuleToPackageSliceLoader("::Test", "test.Ice.optional.Test"));
 
         try (Communicator communicator = initialize(initData)) {
             InitialPrx initial = AllTests.allTests(this, customSliceLoader);

--- a/java/test/src/main/java/test/Ice/optional/Server.java
+++ b/java/test/src/main/java/test/Ice/optional/Server.java
@@ -3,17 +3,20 @@
 package test.Ice.optional;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.optional");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.optional.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new InitialI(), Util.stringToIdentity("initial"));

--- a/java/test/src/main/java/test/Ice/optional/Test.ice
+++ b/java/test/src/main/java/test/Ice/optional/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.optional"]]
+["java:identifier:test.Ice.optional.Test"]
 module Test
 {
     class OneOptional

--- a/java/test/src/main/java/test/Ice/optional/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/optional/TestAMD.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.optional.AMD"]]
+["java:identifier:test.Ice.optional.AMD.Test"]
 module Test
 {
     class OneOptional

--- a/java/test/src/main/java/test/Ice/packagemd/NoPackage.ice
+++ b/java/test/src/main/java/test/Ice/packagemd/NoPackage.ice
@@ -2,7 +2,9 @@
 
 #pragma once
 
-[["java:package:test.Ice.packagemd"]]
+[["suppress-warning:deprecated"]] // for 'java:package' metadata
+
+["java:package:test.Ice.packagemd"]
 module Test1
 {
     class C1

--- a/java/test/src/main/java/test/Ice/packagemd/Package.ice
+++ b/java/test/src/main/java/test/Ice/packagemd/Package.ice
@@ -2,6 +2,8 @@
 
 #pragma once
 
+[["suppress-warning:deprecated"]] // for 'java:package' metadata
+
 [["java:package:test.Ice.packagemd.testpkg"]]
 
 module Test2

--- a/java/test/src/main/java/test/Ice/packagemd/Test.ice
+++ b/java/test/src/main/java/test/Ice/packagemd/Test.ice
@@ -5,7 +5,10 @@
 #include "Package.ice"
 #include "NoPackage.ice"
 
+[["suppress-warning:deprecated"]] // for 'java:package' metadata
+
 [["java:package:test.Ice.packagemd"]]
+
 module Test
 {
     interface Initial

--- a/java/test/src/main/java/test/Ice/proxy/AMDServer.java
+++ b/java/test/src/main/java/test/Ice/proxy/AMDServer.java
@@ -3,19 +3,22 @@
 package test.Ice.proxy;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class AMDServer extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.proxy.AMD");
-        properties.setProperty("Ice.Warn.Dispatch", "0");
-        try (Communicator communicator = initialize(properties)) {
-            properties.setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.proxy.AMD.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+
+        try (Communicator communicator = initialize(initData)) {
+            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new AMDMyDerivedClassI(), Util.stringToIdentity("test"));
             adapter.activate();

--- a/java/test/src/main/java/test/Ice/proxy/AMDServer.java
+++ b/java/test/src/main/java/test/Ice/proxy/AMDServer.java
@@ -3,21 +3,18 @@
 package test.Ice.proxy;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
+import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class AMDServer extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.proxy.AMD.Test");
-        initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+        Properties properties = createTestProperties(args);
+        properties.setProperty("Ice.Warn.Dispatch", "0");
 
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(properties)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new AMDMyDerivedClassI(), Util.stringToIdentity("test"));

--- a/java/test/src/main/java/test/Ice/proxy/AMDServer.java
+++ b/java/test/src/main/java/test/Ice/proxy/AMDServer.java
@@ -4,14 +4,13 @@ package test.Ice.proxy;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class AMDServer extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
+        var properties = createTestProperties(args);
         properties.setProperty("Ice.Warn.Dispatch", "0");
 
         try (Communicator communicator = initialize(properties)) {

--- a/java/test/src/main/java/test/Ice/proxy/Client.java
+++ b/java/test/src/main/java/test/Ice/proxy/Client.java
@@ -3,16 +3,19 @@
 package test.Ice.proxy;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.proxy.Test.MyClassPrx;
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.proxy");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.proxy.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             MyClassPrx myClass = AllTests.allTests(this);
             myClass.shutdown();
         }

--- a/java/test/src/main/java/test/Ice/proxy/Client.java
+++ b/java/test/src/main/java/test/Ice/proxy/Client.java
@@ -3,19 +3,13 @@
 package test.Ice.proxy;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.proxy.Test.MyClassPrx;
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.proxy.Test");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             MyClassPrx myClass = AllTests.allTests(this);
             myClass.shutdown();
         }

--- a/java/test/src/main/java/test/Ice/proxy/Collocated.java
+++ b/java/test/src/main/java/test/Ice/proxy/Collocated.java
@@ -4,14 +4,13 @@ package test.Ice.proxy;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Collocated extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
+        var properties = createTestProperties(args);
         properties.setProperty("Ice.Warn.Dispatch", "0");
 
         try (Communicator communicator = initialize(properties)) {

--- a/java/test/src/main/java/test/Ice/proxy/Collocated.java
+++ b/java/test/src/main/java/test/Ice/proxy/Collocated.java
@@ -3,18 +3,21 @@
 package test.Ice.proxy;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Collocated extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.proxy");
-        properties.setProperty("Ice.Warn.Dispatch", "0");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.proxy.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new MyDerivedClassI(), Util.stringToIdentity("test"));

--- a/java/test/src/main/java/test/Ice/proxy/Collocated.java
+++ b/java/test/src/main/java/test/Ice/proxy/Collocated.java
@@ -3,21 +3,18 @@
 package test.Ice.proxy;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
+import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Collocated extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.proxy.Test");
-        initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+        Properties properties = createTestProperties(args);
+        properties.setProperty("Ice.Warn.Dispatch", "0");
 
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(properties)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new MyDerivedClassI(), Util.stringToIdentity("test"));

--- a/java/test/src/main/java/test/Ice/proxy/Server.java
+++ b/java/test/src/main/java/test/Ice/proxy/Server.java
@@ -3,19 +3,22 @@
 package test.Ice.proxy;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.proxy");
-        properties.setProperty("Ice.Warn.Dispatch", "0");
-        try (Communicator communicator = initialize(properties)) {
-            properties.setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.proxy.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+
+        try (Communicator communicator = initialize(initData)) {
+            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new MyDerivedClassI(), Util.stringToIdentity("test"));
             adapter.activate();

--- a/java/test/src/main/java/test/Ice/proxy/Server.java
+++ b/java/test/src/main/java/test/Ice/proxy/Server.java
@@ -4,14 +4,13 @@ package test.Ice.proxy;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
+        var properties = createTestProperties(args);
         properties.setProperty("Ice.Warn.Dispatch", "0");
 
         try (Communicator communicator = initialize(properties)) {

--- a/java/test/src/main/java/test/Ice/proxy/Server.java
+++ b/java/test/src/main/java/test/Ice/proxy/Server.java
@@ -3,21 +3,18 @@
 package test.Ice.proxy;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
+import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.proxy.Test");
-        initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+        Properties properties = createTestProperties(args);
+        properties.setProperty("Ice.Warn.Dispatch", "0");
 
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(properties)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new MyDerivedClassI(), Util.stringToIdentity("test"));

--- a/java/test/src/main/java/test/Ice/proxy/Test.ice
+++ b/java/test/src/main/java/test/Ice/proxy/Test.ice
@@ -4,7 +4,7 @@
 
 #include "Ice/Context.ice"
 
-[["java:package:test.Ice.proxy"]]
+["java:identifier:test.Ice.proxy.Test"]
 module Test
 {
     interface MyClass

--- a/java/test/src/main/java/test/Ice/proxy/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/proxy/TestAMD.ice
@@ -4,7 +4,7 @@
 
 #include"Ice/Context.ice"
 
-[["java:package:test.Ice.proxy.AMD"]]
+["java:identifier:test.Ice.proxy.AMD.Test"]
 module Test
 {
     ["amd"] interface MyClass

--- a/java/test/src/main/java/test/Ice/retry/Client.java
+++ b/java/test/src/main/java/test/Ice/retry/Client.java
@@ -4,6 +4,7 @@ package test.Ice.retry;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.retry.Test.RetryPrx;
 import test.TestHelper;
@@ -13,13 +14,11 @@ public class Client extends TestHelper {
 
     public void run(String[] args) {
         InitializationData initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.retry.Test");
         initData.observer = instrumentation.getObserver();
         initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.Package.Test", "test.Ice.retry");
         initData.properties.setProperty("Ice.RetryIntervals", "0 1 400 1");
-        //
         // We don't want connection warnings because of the timeout
-        //
         initData.properties.setProperty("Ice.Warn.Connections", "0");
 
         try (Communicator communicator = initialize(initData)) {

--- a/java/test/src/main/java/test/Ice/retry/Client.java
+++ b/java/test/src/main/java/test/Ice/retry/Client.java
@@ -4,7 +4,6 @@ package test.Ice.retry;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.retry.Test.RetryPrx;
 import test.TestHelper;
@@ -14,7 +13,6 @@ public class Client extends TestHelper {
 
     public void run(String[] args) {
         InitializationData initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.retry.Test");
         initData.observer = instrumentation.getObserver();
         initData.properties = createTestProperties(args);
         initData.properties.setProperty("Ice.RetryIntervals", "0 1 400 1");

--- a/java/test/src/main/java/test/Ice/retry/Collocated.java
+++ b/java/test/src/main/java/test/Ice/retry/Collocated.java
@@ -4,6 +4,7 @@ package test.Ice.retry;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
 
@@ -22,15 +23,14 @@ public class Collocated extends TestHelper {
     @Override
     public void run(String[] args) {
         InitializationData initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.retry.Test");
         initData.observer = instrumentation.getObserver();
         initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.Package.Test", "test.Ice.retry");
         initData.properties.setProperty("Ice.RetryIntervals", "0 1 10 1");
-        //
         // We don't want connection warnings because of the timeout
-        //
         initData.properties.setProperty("Ice.Warn.Connections", "0");
         initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+
         try (Communicator communicator = initialize(initData)) {
             //
             // Configure a second communicator for the invocation timeout

--- a/java/test/src/main/java/test/Ice/retry/Collocated.java
+++ b/java/test/src/main/java/test/Ice/retry/Collocated.java
@@ -4,7 +4,6 @@ package test.Ice.retry;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
 
@@ -23,7 +22,6 @@ public class Collocated extends TestHelper {
     @Override
     public void run(String[] args) {
         InitializationData initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.retry.Test");
         initData.observer = instrumentation.getObserver();
         initData.properties = createTestProperties(args);
         initData.properties.setProperty("Ice.RetryIntervals", "0 1 10 1");

--- a/java/test/src/main/java/test/Ice/retry/Server.java
+++ b/java/test/src/main/java/test/Ice/retry/Server.java
@@ -3,19 +3,22 @@
 package test.Ice.retry;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.retry");
-        properties.setProperty("Ice.Warn.Dispatch", "0");
-        properties.setProperty("Ice.Warn.Connections", "0");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.retry.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+        initData.properties.setProperty("Ice.Warn.Connections", "0");
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new RetryI(), Util.stringToIdentity("retry"));

--- a/java/test/src/main/java/test/Ice/retry/Server.java
+++ b/java/test/src/main/java/test/Ice/retry/Server.java
@@ -3,8 +3,6 @@
 package test.Ice.retry;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
 
@@ -12,13 +10,11 @@ import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.retry.Test");
-        initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
-        initData.properties.setProperty("Ice.Warn.Connections", "0");
+        var properties = createTestProperties(args);
+        properties.setProperty("Ice.Warn.Dispatch", "0");
+        properties.setProperty("Ice.Warn.Connections", "0");
 
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(properties)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new RetryI(), Util.stringToIdentity("retry"));

--- a/java/test/src/main/java/test/Ice/retry/Test.ice
+++ b/java/test/src/main/java/test/Ice/retry/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.retry"]]
+["java:identifier:test.Ice.retry.Test"]
 module Test
 {
     interface Retry

--- a/java/test/src/main/java/test/Ice/scope/Client.java
+++ b/java/test/src/main/java/test/Ice/scope/Client.java
@@ -3,18 +3,25 @@
 package test.Ice.scope;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 import java.io.PrintWriter;
+import java.util.Map;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.scope");
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader(
+            Map.of("::Test", "test.Ice.scope.Test", "::Inner", "test.Ice.scope.Inner"),
+            null
+        );
+        initData.properties = createTestProperties(args);
+
         PrintWriter out = getWriter();
-        try (Communicator communicator = initialize(properties)) {
+        try (Communicator communicator = initialize(initData)) {
             out.print("test using same type name in different Slice modules... ");
             out.flush();
             AllTests.allTests(this);

--- a/java/test/src/main/java/test/Ice/scope/Server.java
+++ b/java/test/src/main/java/test/Ice/scope/Server.java
@@ -4,8 +4,9 @@ package test.Ice.scope;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Current;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
@@ -259,9 +260,14 @@ public class Server extends TestHelper {
     }
 
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.scope");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader(
+            Map.of("::Test", "test.Ice.scope.Test", "::Inner", "test.Ice.scope.Inner"),
+            null
+        );
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new MyInterface1(), Util.stringToIdentity("i1"));

--- a/java/test/src/main/java/test/Ice/scope/Test.ice
+++ b/java/test/src/main/java/test/Ice/scope/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.scope"]]
+["java:identifier:test.Ice.scope.Test"]
 module Test
 {
     struct MyStruct
@@ -136,18 +136,22 @@ module Test
     }
 }
 
-module Inner::Test::Inner2
+["java:identifier:test.Ice.scope.Inner"]
+module Inner
 {
-    interface MyInterface
+    module Test::Inner2
     {
-        Test::MyStruct opMyStruct(Test::MyStruct s1, out Test::MyStruct s2);
-        Test::MyStructSeq opMyStructSeq(Test::MyStructSeq s1, out Test::MyStructSeq s2);
-        Test::MyStructMap opMyStructMap(Test::MyStructMap s1, out Test::MyStructMap s2);
+        interface MyInterface
+        {
+            Test::MyStruct opMyStruct(Test::MyStruct s1, out Test::MyStruct s2);
+            Test::MyStructSeq opMyStructSeq(Test::MyStructSeq s1, out Test::MyStructSeq s2);
+            Test::MyStructMap opMyStructMap(Test::MyStructMap s1, out Test::MyStructMap s2);
 
-        Test::MyClass opMyClass(Test::MyClass c1, out Test::MyClass c2);
-        Test::MyClassSeq opMyClassSeq(Test::MyClassSeq c1, out Test::MyClassSeq c2);
-        Test::MyClassMap opMyClassMap(Test::MyClassMap c1, out Test::MyClassMap c2);
+            Test::MyClass opMyClass(Test::MyClass c1, out Test::MyClass c2);
+            Test::MyClassSeq opMyClassSeq(Test::MyClassSeq c1, out Test::MyClassSeq c2);
+            Test::MyClassMap opMyClassMap(Test::MyClassMap c1, out Test::MyClassMap c2);
 
-        void shutdown();
+            void shutdown();
+        }
     }
 }

--- a/java/test/src/main/java/test/Ice/seqMapping/AMDServer.java
+++ b/java/test/src/main/java/test/Ice/seqMapping/AMDServer.java
@@ -3,8 +3,9 @@
 package test.Ice.seqMapping;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
@@ -12,10 +13,12 @@ import test.TestHelper;
 public class AMDServer extends TestHelper {
     @Override
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.seqMapping.AMD");
-        try (Communicator communicator = initialize(properties)) {
-            properties.setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.seqMapping.AMD.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
+            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new AMDMyClassI(), Util.stringToIdentity("test"));
             adapter.activate();

--- a/java/test/src/main/java/test/Ice/seqMapping/Client.java
+++ b/java/test/src/main/java/test/Ice/seqMapping/Client.java
@@ -3,7 +3,8 @@
 package test.Ice.seqMapping;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.seqMapping.Test.MyClassPrx;
 import test.TestHelper;
@@ -13,11 +14,12 @@ import java.io.PrintWriter;
 public class Client extends TestHelper {
     @Override
     public void run(String[] args) {
-        PrintWriter out = getWriter();
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.seqMapping.Test");
+        initData.properties = createTestProperties(args);
 
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.seqMapping");
-        try (Communicator communicator = initialize(properties)) {
+        PrintWriter out = getWriter();
+        try (Communicator communicator = initialize(initData)) {
             MyClassPrx myClass = AllTests.allTests(this, false);
 
             out.print("shutting down server... ");

--- a/java/test/src/main/java/test/Ice/seqMapping/Collocated.java
+++ b/java/test/src/main/java/test/Ice/seqMapping/Collocated.java
@@ -3,17 +3,20 @@
 package test.Ice.seqMapping;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Collocated extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.seqMapping");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.seqMapping.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new MyClassI(), Util.stringToIdentity("test"));

--- a/java/test/src/main/java/test/Ice/seqMapping/Server.java
+++ b/java/test/src/main/java/test/Ice/seqMapping/Server.java
@@ -3,17 +3,20 @@
 package test.Ice.seqMapping;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.seqMapping");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.seqMapping.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator().createObjectAdapter("TestAdapter");
             adapter.add(new MyClassI(), Util.stringToIdentity("test"));

--- a/java/test/src/main/java/test/Ice/seqMapping/Test.ice
+++ b/java/test/src/main/java/test/Ice/seqMapping/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.seqMapping"]]
+["java:identifier:test.Ice.seqMapping.Test"]
 module Test
 {
     ["java:serializable:test.Ice.seqMapping.Serialize.Small"] sequence<byte> SerialSmall;

--- a/java/test/src/main/java/test/Ice/seqMapping/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/seqMapping/TestAMD.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.seqMapping.AMD"]]
+["java:identifier:test.Ice.seqMapping.AMD.Test"]
 module Test
 {
     ["java:serializable:test.Ice.seqMapping.Serialize.Small"] sequence<byte> SerialSmall;

--- a/java/test/src/main/java/test/Ice/serialize/Client.java
+++ b/java/test/src/main/java/test/Ice/serialize/Client.java
@@ -3,16 +3,19 @@
 package test.Ice.serialize;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.serialize.Test.InitialPrx;
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.serialize");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.serialize.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             InitialPrx initial = AllTests.allTests(this, false);
             initial.shutdown();
         }

--- a/java/test/src/main/java/test/Ice/serialize/Server.java
+++ b/java/test/src/main/java/test/Ice/serialize/Server.java
@@ -4,17 +4,20 @@ package test.Ice.serialize;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Identity;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.serialize");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.serialize.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator().createObjectAdapter("TestAdapter");
             Identity ident = Util.stringToIdentity("initial");

--- a/java/test/src/main/java/test/Ice/serialize/Test.ice
+++ b/java/test/src/main/java/test/Ice/serialize/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.serialize"]]
+["java:identifier:test.Ice.serialize.Test"]
 module Test
 {
     enum MyEnum

--- a/java/test/src/main/java/test/Ice/servantLocator/AMDServer.java
+++ b/java/test/src/main/java/test/Ice/servantLocator/AMDServer.java
@@ -4,17 +4,20 @@ package test.Ice.servantLocator;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class AMDServer extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.servantLocator.AMD");
-        properties.setProperty("Ice.Warn.Dispatch", "0");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.servantLocator.AMD.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.addServantLocator(new AMDServantLocatorI("category"), "category");

--- a/java/test/src/main/java/test/Ice/servantLocator/Client.java
+++ b/java/test/src/main/java/test/Ice/servantLocator/Client.java
@@ -3,16 +3,19 @@
 package test.Ice.servantLocator;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.servantLocator.Test.TestIntfPrx;
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.servantLocator");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.servantLocator.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             TestIntfPrx obj = AllTests.allTests(this);
             obj.shutdown();
         }

--- a/java/test/src/main/java/test/Ice/servantLocator/Collocated.java
+++ b/java/test/src/main/java/test/Ice/servantLocator/Collocated.java
@@ -3,8 +3,9 @@
 package test.Ice.servantLocator;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
@@ -12,10 +13,12 @@ import test.TestHelper;
 public class Collocated extends TestHelper {
     @Override
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.servantLocator");
-        properties.setProperty("Ice.Warn.Dispatch", "0");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.servantLocator.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator().createObjectAdapter("TestAdapter");
             adapter.addServantLocator(new ServantLocatorI("category"), "category");

--- a/java/test/src/main/java/test/Ice/servantLocator/Server.java
+++ b/java/test/src/main/java/test/Ice/servantLocator/Server.java
@@ -3,18 +3,21 @@
 package test.Ice.servantLocator;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.servantLocator");
-        properties.setProperty("Ice.Warn.Dispatch", "0");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.servantLocator.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.addServantLocator(new ServantLocatorI("category"), "category");

--- a/java/test/src/main/java/test/Ice/servantLocator/Test.ice
+++ b/java/test/src/main/java/test/Ice/servantLocator/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.servantLocator"]]
+["java:identifier:test.Ice.servantLocator.Test"]
 module Test
 {
     exception TestIntfUserException

--- a/java/test/src/main/java/test/Ice/servantLocator/TestAMD.ice
+++ b/java/test/src/main/java/test/Ice/servantLocator/TestAMD.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.servantLocator.AMD"]]
+["java:identifier:test.Ice.servantLocator.AMD.Test"]
 module Test
 {
     exception TestIntfUserException

--- a/java/test/src/main/java/test/Ice/slicing/exceptions/AMDServer.java
+++ b/java/test/src/main/java/test/Ice/slicing/exceptions/AMDServer.java
@@ -3,19 +3,22 @@
 package test.Ice.slicing.exceptions;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class AMDServer extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.slicing.exceptions.serverAMD");
-        properties.setProperty("Ice.Warn.Dispatch", "0");
-        try (Communicator communicator = initialize(properties)) {
-            properties.setProperty("TestAdapter.Endpoints", getTestEndpoint(0) + " -t 2000");
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.slicing.exceptions.serverAMD.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+
+        try (Communicator communicator = initialize(initData)) {
+            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0) + " -t 2000");
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new AMDTestI(), Util.stringToIdentity("Test"));
             adapter.activate();

--- a/java/test/src/main/java/test/Ice/slicing/exceptions/Client.java
+++ b/java/test/src/main/java/test/Ice/slicing/exceptions/Client.java
@@ -3,16 +3,19 @@
 package test.Ice.slicing.exceptions;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.slicing.exceptions.client.Test.TestIntfPrx;
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.slicing.exceptions.client");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.slicing.exceptions.client.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             TestIntfPrx test = AllTests.allTests(this, false);
             test.shutdown();
         }

--- a/java/test/src/main/java/test/Ice/slicing/exceptions/Server.java
+++ b/java/test/src/main/java/test/Ice/slicing/exceptions/Server.java
@@ -3,18 +3,21 @@
 package test.Ice.slicing.exceptions;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.slicing.exceptions.server");
-        properties.setProperty("Ice.Warn.Dispatch", "0");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.slicing.exceptions.server.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+
+        try (Communicator communicator = initialize(initData)) {
             communicator
                 .getProperties()
                 .setProperty("TestAdapter.Endpoints", getTestEndpoint(0) + " -t 2000");

--- a/java/test/src/main/java/test/Ice/slicing/exceptions/ServerPrivate.ice
+++ b/java/test/src/main/java/test/Ice/slicing/exceptions/ServerPrivate.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.slicing.exceptions.server"]]
+["java:identifier:test.Ice.slicing.exceptions.server.Test"]
 module Test
 {
     //

--- a/java/test/src/main/java/test/Ice/slicing/exceptions/ServerPrivateAMD.ice
+++ b/java/test/src/main/java/test/Ice/slicing/exceptions/ServerPrivateAMD.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.slicing.exceptions.serverAMD"]]
+["java:identifier:test.Ice.slicing.exceptions.serverAMD.Test"]
 module Test
 {
     //

--- a/java/test/src/main/java/test/Ice/slicing/exceptions/Test.ice
+++ b/java/test/src/main/java/test/Ice/slicing/exceptions/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.slicing.exceptions.client"]]
+["java:identifier:test.Ice.slicing.exceptions.client.Test"]
 module Test
 {
     //

--- a/java/test/src/main/java/test/Ice/slicing/objects/AMDServer.java
+++ b/java/test/src/main/java/test/Ice/slicing/objects/AMDServer.java
@@ -3,18 +3,21 @@
 package test.Ice.slicing.objects;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class AMDServer extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.slicing.objects.serverAMD");
-        properties.setProperty("Ice.Warn.Dispatch", "0");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.slicing.objects.serverAMD.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+
+        try (Communicator communicator = initialize(initData)) {
             communicator
                 .getProperties()
                 .setProperty("TestAdapter.Endpoints", getTestEndpoint(0) + " -t 2000");

--- a/java/test/src/main/java/test/Ice/slicing/objects/Client.java
+++ b/java/test/src/main/java/test/Ice/slicing/objects/Client.java
@@ -3,10 +3,10 @@
 package test.Ice.slicing.objects;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ClassSliceLoader;
 import com.zeroc.Ice.CompositeSliceLoader;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.slicing.objects.client.Test.CompactPCDerived;
 import test.Ice.slicing.objects.client.Test.CompactPDerived;
@@ -17,12 +17,12 @@ public class Client extends TestHelper {
     public void run(String[] args) {
         var initData = new InitializationData();
         initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.Package.Test", "test.Ice.slicing.objects.client");
         initData.properties.setProperty("Ice.SliceLoader.NotFoundCacheSize", "5");
         initData.properties.setProperty("Ice.Warn.SliceLoader", "0"); // comment out to see the warning
         initData.sliceLoader = new CompositeSliceLoader(
             new AllTests.CustomSliceLoader(),
-            new ClassSliceLoader(CompactPDerived.class, CompactPCDerived.class));
+            new ClassSliceLoader(CompactPDerived.class, CompactPCDerived.class),
+            new ModuleToPackageSliceLoader("::Test", "test.Ice.slicing.objects.client.Test"));
 
         try (Communicator communicator = initialize(initData)) {
             TestIntfPrx test = AllTests.allTests(this, false);

--- a/java/test/src/main/java/test/Ice/slicing/objects/ClientPrivate.ice
+++ b/java/test/src/main/java/test/Ice/slicing/objects/ClientPrivate.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.slicing.objects.client"]]
+["java:identifier:test.Ice.slicing.objects.client.Test"]
 module Test
 {
     //

--- a/java/test/src/main/java/test/Ice/slicing/objects/Server.java
+++ b/java/test/src/main/java/test/Ice/slicing/objects/Server.java
@@ -3,18 +3,21 @@
 package test.Ice.slicing.objects;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.slicing.objects.server");
-        properties.setProperty("Ice.Warn.Dispatch", "0");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.slicing.objects.server.Test");
+        initData.properties = createTestProperties(args);
+        initData.properties.setProperty("Ice.Warn.Dispatch", "0");
+
+        try (Communicator communicator = initialize(initData)) {
             communicator
                 .getProperties()
                 .setProperty("TestAdapter.Endpoints", getTestEndpoint(0) + " -t 2000");

--- a/java/test/src/main/java/test/Ice/slicing/objects/ServerPrivate.ice
+++ b/java/test/src/main/java/test/Ice/slicing/objects/ServerPrivate.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.slicing.objects.server"]]
+["java:identifier:test.Ice.slicing.objects.server.Test"]
 module Test
 {
     //

--- a/java/test/src/main/java/test/Ice/slicing/objects/ServerPrivateAMD.ice
+++ b/java/test/src/main/java/test/Ice/slicing/objects/ServerPrivateAMD.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.slicing.objects.serverAMD"]]
+["java:identifier:test.Ice.slicing.objects.serverAMD.Test"]
 module Test
 {
     //

--- a/java/test/src/main/java/test/Ice/stream/Client.java
+++ b/java/test/src/main/java/test/Ice/stream/Client.java
@@ -3,11 +3,12 @@
 package test.Ice.stream;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.CompositeSliceLoader;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.InputStream;
 import com.zeroc.Ice.MarshalException;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.OutputStream;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.SliceLoader;
 import com.zeroc.Ice.UserException;
 import com.zeroc.Ice.Util;
@@ -107,11 +108,12 @@ public class Client extends TestHelper {
     }
 
     public void run(String[] args) {
+        var customSliceLoader = new CustomSliceLoader();
         var initData = new InitializationData();
         initData.properties = createTestProperties(args);
-        initData.properties.setProperty("Ice.Package.Test", "test.Ice.stream");
-        var customSliceLoader = new CustomSliceLoader();
-        initData.sliceLoader = customSliceLoader;
+        initData.sliceLoader = new CompositeSliceLoader(
+            customSliceLoader,
+            new ModuleToPackageSliceLoader("::Test", "test.Ice.stream.Test"));
 
         try (Communicator communicator = initialize(initData)) {
             InputStream in;

--- a/java/test/src/main/java/test/Ice/stream/Test.ice
+++ b/java/test/src/main/java/test/Ice/stream/Test.ice
@@ -4,7 +4,7 @@
 
 #include "Ice/BuiltinSequences.ice"
 
-[["java:package:test.Ice.stream"]]
+["java:identifier:test.Ice.stream.Test"]
 module Test
 {
     enum MyEnum

--- a/java/test/src/main/java/test/Ice/threadPoolPriority/Test.ice
+++ b/java/test/src/main/java/test/Ice/threadPoolPriority/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.threadPoolPriority"]]
+["java:identifier:test.Ice.threadPoolPriority.Test"]
 module Test
 {
     interface Priority

--- a/java/test/src/main/java/test/Ice/timeout/Client.java
+++ b/java/test/src/main/java/test/Ice/timeout/Client.java
@@ -3,14 +3,13 @@
 package test.Ice.timeout;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     @Override
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
+        var properties = createTestProperties(args);
 
         // For this test, we want to disable retries.
         properties.setProperty("Ice.RetryIntervals", "-1");

--- a/java/test/src/main/java/test/Ice/timeout/Client.java
+++ b/java/test/src/main/java/test/Ice/timeout/Client.java
@@ -3,25 +3,22 @@
 package test.Ice.timeout;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
+import com.zeroc.Ice.Properties;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     @Override
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.timeout.Test");
-        initData.properties = createTestProperties(args);
+        Properties properties = createTestProperties(args);
 
         // For this test, we want to disable retries.
-        initData.properties.setProperty("Ice.RetryIntervals", "-1");
+        properties.setProperty("Ice.RetryIntervals", "-1");
 
-        initData.properties.setProperty("Ice.Connection.Client.ConnectTimeout", "1");
-        initData.properties.setProperty("Ice.Connection.Client.CloseTimeout", "1");
+        properties.setProperty("Ice.Connection.Client.ConnectTimeout", "1");
+        properties.setProperty("Ice.Connection.Client.CloseTimeout", "1");
 
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(properties)) {
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/timeout/Client.java
+++ b/java/test/src/main/java/test/Ice/timeout/Client.java
@@ -3,25 +3,25 @@
 package test.Ice.timeout;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     @Override
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.timeout");
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.timeout.Test");
+        initData.properties = createTestProperties(args);
 
-        //
         // For this test, we want to disable retries.
-        //
-        properties.setProperty("Ice.RetryIntervals", "-1");
+        initData.properties.setProperty("Ice.RetryIntervals", "-1");
 
-        properties.setProperty("Ice.Connection.Client.ConnectTimeout", "1");
-        properties.setProperty("Ice.Connection.Client.CloseTimeout", "1");
+        initData.properties.setProperty("Ice.Connection.Client.ConnectTimeout", "1");
+        initData.properties.setProperty("Ice.Connection.Client.CloseTimeout", "1");
 
-        try (Communicator communicator = initialize(properties)) {
+        try (Communicator communicator = initialize(initData)) {
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/timeout/Server.java
+++ b/java/test/src/main/java/test/Ice/timeout/Server.java
@@ -3,18 +3,20 @@
 package test.Ice.timeout;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.Ice.timeout");
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.timeout.Test");
+        initData.properties = createTestProperties(args);
 
-        try (Communicator communicator = initialize(properties)) {
+        try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             communicator
                 .getProperties()

--- a/java/test/src/main/java/test/Ice/timeout/Server.java
+++ b/java/test/src/main/java/test/Ice/timeout/Server.java
@@ -3,8 +3,6 @@
 package test.Ice.timeout;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
 
@@ -12,11 +10,7 @@ import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.timeout.Test");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             communicator
                 .getProperties()

--- a/java/test/src/main/java/test/Ice/timeout/Test.ice
+++ b/java/test/src/main/java/test/Ice/timeout/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Ice.timeout"]]
+["java:identifier:test.Ice.timeout.Test"]
 module Test
 {
     sequence<byte> ByteSeq;

--- a/java/test/src/main/java/test/Ice/udp/Client.java
+++ b/java/test/src/main/java/test/Ice/udp/Client.java
@@ -3,7 +3,8 @@
 package test.Ice.udp;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.Ice.udp.Test.TestIntfPrx;
 import test.TestHelper;
@@ -13,18 +14,19 @@ import java.util.List;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        List<String> rargs = new ArrayList<String>();
-        Properties properties = createTestProperties(args, rargs);
-        properties.setProperty("Ice.Package.Test", "test.Ice.udp");
-        properties.setProperty("Ice.Warn.Connections", "0");
-        properties.setProperty("Ice.UDP.RcvSize", "16384");
-        properties.setProperty("Ice.UDP.SndSize", "16384");
+        List<String> remainingArgs = new ArrayList<String>();
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "FAIL_IF_NONE");
+        initData.properties = createTestProperties(args, remainingArgs);
+        initData.properties.setProperty("Ice.Warn.Connections", "0");
+        initData.properties.setProperty("Ice.UDP.RcvSize", "16384");
+        initData.properties.setProperty("Ice.UDP.SndSize", "16384");
 
-        try (Communicator communicator = initialize(properties)) {
+        try (Communicator communicator = initialize(initData)) {
             AllTests.allTests(this);
             int num;
             try {
-                num = rargs.size() == 1 ? Integer.parseInt(rargs.get(0)) : 1;
+                num = remainingArgs.size() == 1 ? Integer.parseInt(remainingArgs.get(0)) : 1;
             } catch (NumberFormatException ex) {
                 num = 1;
             }

--- a/java/test/src/main/java/test/Ice/udp/Client.java
+++ b/java/test/src/main/java/test/Ice/udp/Client.java
@@ -3,8 +3,7 @@
 package test.Ice.udp;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
+import com.zeroc.Ice.Properties;
 
 import test.Ice.udp.Test.TestIntfPrx;
 import test.TestHelper;
@@ -15,14 +14,12 @@ import java.util.List;
 public class Client extends TestHelper {
     public void run(String[] args) {
         List<String> remainingArgs = new ArrayList<String>();
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "FAIL_IF_NONE");
-        initData.properties = createTestProperties(args, remainingArgs);
-        initData.properties.setProperty("Ice.Warn.Connections", "0");
-        initData.properties.setProperty("Ice.UDP.RcvSize", "16384");
-        initData.properties.setProperty("Ice.UDP.SndSize", "16384");
+        Properties properties = createTestProperties(args, remainingArgs);
+        properties.setProperty("Ice.Warn.Connections", "0");
+        properties.setProperty("Ice.UDP.RcvSize", "16384");
+        properties.setProperty("Ice.UDP.SndSize", "16384");
 
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(properties)) {
             AllTests.allTests(this);
             int num;
             try {

--- a/java/test/src/main/java/test/Ice/udp/Client.java
+++ b/java/test/src/main/java/test/Ice/udp/Client.java
@@ -3,7 +3,6 @@
 package test.Ice.udp;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
 
 import test.Ice.udp.Test.TestIntfPrx;
 import test.TestHelper;
@@ -14,7 +13,7 @@ import java.util.List;
 public class Client extends TestHelper {
     public void run(String[] args) {
         List<String> remainingArgs = new ArrayList<String>();
-        Properties properties = createTestProperties(args, remainingArgs);
+        var properties = createTestProperties(args, remainingArgs);
         properties.setProperty("Ice.Warn.Connections", "0");
         properties.setProperty("Ice.UDP.RcvSize", "16384");
         properties.setProperty("Ice.UDP.SndSize", "16384");

--- a/java/test/src/main/java/test/Ice/udp/Server.java
+++ b/java/test/src/main/java/test/Ice/udp/Server.java
@@ -4,7 +4,6 @@ package test.Ice.udp;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
@@ -15,7 +14,7 @@ import java.util.List;
 public class Server extends TestHelper {
     public void run(String[] args) {
         List<String> remainingArgs = new ArrayList<String>();
-        Properties properties = createTestProperties(args, remainingArgs);
+        var properties = createTestProperties(args, remainingArgs);
         properties.setProperty("Ice.Warn.Connections", "0");
         properties.setProperty("Ice.UDP.RcvSize", "16384");
         properties.setProperty("Ice.UDP.SndSize", "16384");

--- a/java/test/src/main/java/test/Ice/udp/Server.java
+++ b/java/test/src/main/java/test/Ice/udp/Server.java
@@ -3,8 +3,6 @@
 package test.Ice.udp;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
@@ -21,11 +19,6 @@ public class Server extends TestHelper {
         properties.setProperty("Ice.Warn.Connections", "0");
         properties.setProperty("Ice.UDP.RcvSize", "16384");
         properties.setProperty("Ice.UDP.SndSize", "16384");
-
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "FAIL_IF_NONE");
-        initData.properties = properties;
-
         {
             String endpoint;
             if ("1".equals(properties.getIceProperty("Ice.IPv6"))) {
@@ -40,7 +33,7 @@ public class Server extends TestHelper {
             properties.setProperty("McastTestAdapter.Endpoints", endpoint);
         }
 
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(properties)) {
             int num = remainingArgs.size() == 1 ? Integer.parseInt(remainingArgs.get(0)) : 0;
 
             communicator

--- a/java/test/src/main/java/test/Ice/udp/Test.ice
+++ b/java/test/src/main/java/test/Ice/udp/Test.ice
@@ -3,7 +3,7 @@
 #pragma once
 #include "Ice/Identity.ice"
 
-[["java:package:test.Ice.udp"]]
+["java:identifier:test.Ice.udp.Test"]
 module Test
 {
     interface PingReply

--- a/java/test/src/main/java/test/IceBox/admin/Test.ice
+++ b/java/test/src/main/java/test/IceBox/admin/Test.ice
@@ -5,7 +5,7 @@
 
 #include "Ice/PropertyDict.ice"
 
-[["java:package:test.IceBox.admin"]]
+["java:identifier:test.IceBox.admin.Test"]
 module Test
 {
     interface TestFacet

--- a/java/test/src/main/java/test/IceBox/configuration/Client.java
+++ b/java/test/src/main/java/test/IceBox/configuration/Client.java
@@ -4,15 +4,18 @@ package test.IceBox.configuration;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.ProcessPrx;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.IceBox.configuration");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.IceBox.configuration.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             AllTests.allTests(this);
 
             // Shutdown the IceBox server.

--- a/java/test/src/main/java/test/IceBox/configuration/Client.java
+++ b/java/test/src/main/java/test/IceBox/configuration/Client.java
@@ -4,18 +4,12 @@ package test.IceBox.configuration;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.ProcessPrx;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.IceBox.configuration.Test");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             AllTests.allTests(this);
 
             // Shutdown the IceBox server.

--- a/java/test/src/main/java/test/IceBox/configuration/Test.ice
+++ b/java/test/src/main/java/test/IceBox/configuration/Test.ice
@@ -4,7 +4,7 @@
 
 #include "Ice/BuiltinSequences.ice"
 
-[["java:package:test.IceBox.configuration"]]
+["java:identifier:test.IceBox.configuration.Test"]
 module Test
 {
     interface TestIntf

--- a/java/test/src/main/java/test/IceBox/configuration/TestServiceI.java
+++ b/java/test/src/main/java/test/IceBox/configuration/TestServiceI.java
@@ -10,6 +10,7 @@ import com.zeroc.IceBox.Service;
 public class TestServiceI implements Service {
     @Override
     public void start(String name, Communicator communicator, String[] args) {
+        // TODO How should we configure a sliceLoader here?
         communicator.getProperties().setProperty("Ice.Package.Test", "test.IceBox.configuration");
 
         ObjectAdapter adapter = communicator.createObjectAdapter(name + "OA");

--- a/java/test/src/main/java/test/IceBox/configuration/TestServiceI.java
+++ b/java/test/src/main/java/test/IceBox/configuration/TestServiceI.java
@@ -10,9 +10,6 @@ import com.zeroc.IceBox.Service;
 public class TestServiceI implements Service {
     @Override
     public void start(String name, Communicator communicator, String[] args) {
-        // TODO How should we configure a sliceLoader here?
-        communicator.getProperties().setProperty("Ice.Package.Test", "test.IceBox.configuration");
-
         ObjectAdapter adapter = communicator.createObjectAdapter(name + "OA");
         adapter.add(new TestI(args), Util.stringToIdentity("test"));
         adapter.activate();

--- a/java/test/src/main/java/test/IceDiscovery/simple/Test.ice
+++ b/java/test/src/main/java/test/IceDiscovery/simple/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.IceDiscovery.simple"]]
+["java:identifier:test.IceDiscovery.simple.Test"]
 module Test
 {
     interface TestIntf

--- a/java/test/src/main/java/test/IceGrid/simple/Client.java
+++ b/java/test/src/main/java/test/IceGrid/simple/Client.java
@@ -3,7 +3,8 @@
 package test.IceGrid.simple;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
@@ -11,9 +12,11 @@ import java.util.stream.Stream;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.Test", "test.IceGrid.simple");
-        try (Communicator communicator = initialize(properties)) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.IceDiscovery.simple.Test");
+        initData.properties = createTestProperties(args);
+
+        try (Communicator communicator = initialize(initData)) {
             boolean withDeploy = Stream.of(args).anyMatch(v -> "--with-deploy".equals(v));
 
             if (!withDeploy) {

--- a/java/test/src/main/java/test/IceGrid/simple/Client.java
+++ b/java/test/src/main/java/test/IceGrid/simple/Client.java
@@ -3,8 +3,6 @@
 package test.IceGrid.simple;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.TestHelper;
 
@@ -12,11 +10,7 @@ import java.util.stream.Stream;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.IceDiscovery.simple.Test");
-        initData.properties = createTestProperties(args);
-
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(args)) {
             boolean withDeploy = Stream.of(args).anyMatch(v -> "--with-deploy".equals(v));
 
             if (!withDeploy) {

--- a/java/test/src/main/java/test/IceGrid/simple/Server.java
+++ b/java/test/src/main/java/test/IceGrid/simple/Server.java
@@ -6,14 +6,13 @@ import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.ObjectAdapterDeactivatedException;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        Properties properties = createTestProperties(args);
+        var properties = createTestProperties(args);
         // It's possible to have batch oneway requests dispatched after the adapter is deactivated
         // due to thread scheduling so we suppress this warning.
         properties.setProperty("Ice.Warn.Dispatch", "0");

--- a/java/test/src/main/java/test/IceGrid/simple/Server.java
+++ b/java/test/src/main/java/test/IceGrid/simple/Server.java
@@ -14,12 +14,11 @@ import test.TestHelper;
 public class Server extends TestHelper {
     public void run(String[] args) {
         Properties properties = createTestProperties(args);
-
         // It's possible to have batch oneway requests dispatched after the adapter is deactivated
         // due to thread scheduling so we suppress this warning.
         properties.setProperty("Ice.Warn.Dispatch", "0");
-        properties.setProperty("Ice.Package.Test", "test.IceGrid.simple");
-        try (Communicator communicator = initialize(args)) {
+
+        try (Communicator communicator = initialize(properties)) {
             communicator.getProperties().parseCommandLineOptions("TestAdapter", args);
 
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");

--- a/java/test/src/main/java/test/IceGrid/simple/Test.ice
+++ b/java/test/src/main/java/test/IceGrid/simple/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.IceGrid.simple"]]
+["java:identifier:test.IceGrid.simple.Test"]
 module Test
 {
     interface TestIntf

--- a/java/test/src/main/java/test/IceSSL/configuration/Client.java
+++ b/java/test/src/main/java/test/IceSSL/configuration/Client.java
@@ -3,8 +3,6 @@
 package test.IceSSL.configuration;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.IceSSL.configuration.Test.ServerFactoryPrx;
 import test.TestHelper;
@@ -15,15 +13,13 @@ import java.util.List;
 public class Client extends TestHelper {
     public void run(String[] args) {
         List<String> remainingArgs = new ArrayList<String>();
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.IceSSL.configuration.Test");
-        initData.properties = createTestProperties(args, remainingArgs);
+        var properties = createTestProperties(args, remainingArgs);
         if (remainingArgs.size() < 1) {
             throw new RuntimeException("Usage: client testdir");
         }
 
         String testDir = remainingArgs.get(0);
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(properties)) {
             PlatformTests.allTests(this, testDir);
             ServerFactoryPrx factory = AllTests.allTests(this, testDir);
             factory.shutdown();

--- a/java/test/src/main/java/test/IceSSL/configuration/Client.java
+++ b/java/test/src/main/java/test/IceSSL/configuration/Client.java
@@ -3,7 +3,8 @@
 package test.IceSSL.configuration;
 
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Properties;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 
 import test.IceSSL.configuration.Test.ServerFactoryPrx;
 import test.TestHelper;
@@ -13,16 +14,16 @@ import java.util.List;
 
 public class Client extends TestHelper {
     public void run(String[] args) {
-        List<String> rargs = new ArrayList<String>();
-        Properties properties = createTestProperties(args, rargs);
-        if (rargs.size() < 1) {
+        List<String> remainingArgs = new ArrayList<String>();
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.IceSSL.configuration.Test");
+        initData.properties = createTestProperties(args, remainingArgs);
+        if (remainingArgs.size() < 1) {
             throw new RuntimeException("Usage: client testdir");
         }
 
-        String testDir = rargs.get(0);
-
-        properties.setProperty("Ice.Package.Test", "test.IceSSL.configuration");
-        try (Communicator communicator = initialize(properties)) {
+        String testDir = remainingArgs.get(0);
+        try (Communicator communicator = initialize(initData)) {
             PlatformTests.allTests(this, testDir);
             ServerFactoryPrx factory = AllTests.allTests(this, testDir);
             factory.shutdown();

--- a/java/test/src/main/java/test/IceSSL/configuration/Server.java
+++ b/java/test/src/main/java/test/IceSSL/configuration/Server.java
@@ -4,8 +4,6 @@ package test.IceSSL.configuration;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Identity;
-import com.zeroc.Ice.InitializationData;
-import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Util;
 
@@ -17,14 +15,12 @@ import java.util.List;
 public class Server extends TestHelper {
     public void run(String[] args) {
         List<String> remainingArgs = new ArrayList<String>();
-        var initData = new InitializationData();
-        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "FAIL_IF_NONE");
-        initData.properties = createTestProperties(args, remainingArgs);
+        var properties = createTestProperties(args, remainingArgs);
         if (remainingArgs.size() < 1) {
             throw new RuntimeException("Usage: server testdir");
         }
 
-        try (Communicator communicator = initialize(initData)) {
+        try (Communicator communicator = initialize(properties)) {
             communicator
                 .getProperties()
                 .setProperty("TestAdapter.Endpoints", getTestEndpoint(0, "tcp"));

--- a/java/test/src/main/java/test/IceSSL/configuration/Server.java
+++ b/java/test/src/main/java/test/IceSSL/configuration/Server.java
@@ -4,8 +4,9 @@ package test.IceSSL.configuration;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Identity;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
 import test.TestHelper;
@@ -15,20 +16,21 @@ import java.util.List;
 
 public class Server extends TestHelper {
     public void run(String[] args) {
-        List<String> rargs = new ArrayList<String>();
-        Properties properties = createTestProperties(args, rargs);
-        if (rargs.size() < 1) {
+        List<String> remainingArgs = new ArrayList<String>();
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "FAIL_IF_NONE");
+        initData.properties = createTestProperties(args, remainingArgs);
+        if (remainingArgs.size() < 1) {
             throw new RuntimeException("Usage: server testdir");
         }
 
-        properties.setProperty("Ice.Package.Test", "test.IceSSL.configuration");
-        try (Communicator communicator = initialize(properties)) {
+        try (Communicator communicator = initialize(initData)) {
             communicator
                 .getProperties()
                 .setProperty("TestAdapter.Endpoints", getTestEndpoint(0, "tcp"));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Identity id = Util.stringToIdentity("factory");
-            adapter.add(new ServerFactoryI(rargs.get(0) + "/../certs"), id);
+            adapter.add(new ServerFactoryI(remainingArgs.get(0) + "/../certs"), id);
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/IceSSL/configuration/Test.ice
+++ b/java/test/src/main/java/test/IceSSL/configuration/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.IceSSL.configuration"]]
+["java:identifier:test.IceSSL.configuration.Test"]
 module Test
 {
     interface Server

--- a/java/test/src/main/java/test/Slice/escape/Clash.ice
+++ b/java/test/src/main/java/test/Slice/escape/Clash.ice
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-[["java:package:test.Slice.escape"]]
-
+["java:identifier:test.Slice.escape.Clash"]
 module Clash
 {
     interface Intf

--- a/java/test/src/main/java/test/Slice/escape/Client.java
+++ b/java/test/src/main/java/test/Slice/escape/Client.java
@@ -4,22 +4,23 @@ package test.Slice.escape;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Current;
+import com.zeroc.Ice.InitializationData;
+import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
 
-import test.Slice.escape.escaped_abstract._assert;
-import test.Slice.escape.escaped_abstract._break;
-import test.Slice.escape.escaped_abstract._catch;
-import test.Slice.escape.escaped_abstract._catchPrx;
-import test.Slice.escape.escaped_abstract._default;
-import test.Slice.escape.escaped_abstract._defaultPrx;
-import test.Slice.escape.escaped_abstract._finalize;
-import test.Slice.escape.escaped_abstract._finalizePrx;
-import test.Slice.escape.escaped_abstract.clone;
-import test.Slice.escape.escaped_abstract.escaped_synchronized;
-import test.Slice.escape.escaped_abstract.hashCode;
-import test.Slice.escape.escaped_abstract.notify;
+import test.escaped_abstract._assert;
+import test.escaped_abstract._break;
+import test.escaped_abstract._catch;
+import test.escaped_abstract._catchPrx;
+import test.escaped_abstract._default;
+import test.escaped_abstract._defaultPrx;
+import test.escaped_abstract._finalize;
+import test.escaped_abstract._finalizePrx;
+import test.escaped_abstract._hashCode;
+import test.escaped_abstract._notify;
+import test.escaped_abstract.CloneException;
+import test.escaped_abstract.escaped_synchronized;
 import test.TestHelper;
 
 import java.util.concurrent.CompletableFuture;
@@ -46,7 +47,7 @@ public class Client extends TestHelper {
         }
     }
 
-    public static class notifyI extends notify {
+    public static class notifyI extends _notify {
         public notifyI() {}
     }
 
@@ -64,12 +65,12 @@ public class Client extends TestHelper {
         @Override
         public _assert _notify(
                 _break escaped_notifyAll,
-                notify escaped_null,
+                _notify escaped_null,
                 _finalizePrx escaped_package,
                 _defaultPrx escaped_return,
                 int escaped_super,
                 Current current)
-            throws hashCode, clone {
+            throws _hashCode, CloneException {
             return null;
         }
     }
@@ -87,7 +88,7 @@ public class Client extends TestHelper {
         _defaultPrx d = null;
         d._do();
         _default d1 = new _defaultI();
-        notify e1 = new notifyI();
+        _notify e1 = new notifyI();
         e1.foo = 0;
         e1._equals = null;
 
@@ -95,9 +96,9 @@ public class Client extends TestHelper {
         f.myCheckedCast(0);
         f._do();
 
-        hashCode i = new hashCode();
+        _hashCode i = new _hashCode();
         i.bar = 0;
-        clone j = new clone();
+        CloneException j = new CloneException();
         j.bar = 0;
         j.escaped_native = "native";
         _finalize k = new finalizeServantI();
@@ -105,17 +106,18 @@ public class Client extends TestHelper {
     }
 
     public void run(String[] args) {
+        var initData = new InitializationData();
+        initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.escaped_abstract");
+        initData.properties = createTestProperties(args);
         // In this test, we need at least two threads in the client side thread pool for nested AMI.
-        Properties properties = createTestProperties(args);
-        properties.setProperty("Ice.Package.escaped_abstract", "test.Slice.escape");
-        properties.setProperty("Ice.ThreadPool.Client.Size", "2");
-        properties.setProperty("Ice.ThreadPool.Client.SizeWarn", "0");
-        properties.setProperty("TestAdapter.Endpoints", "default");
-
+        initData.properties.setProperty("Ice.ThreadPool.Client.Size", "2");
+        initData.properties.setProperty("Ice.ThreadPool.Client.SizeWarn", "0");
+        initData.properties.setProperty("TestAdapter.Endpoints", "default");
         // We must set MessageSizeMax to an explicit value,
         // because we run tests to check whether Ice.MarshalException is raised as expected.
-        properties.setProperty("Ice.MessageSizeMax", "100");
-        try (Communicator communicator = initialize(properties)) {
+        initData.properties.setProperty("Ice.MessageSizeMax", "100");
+
+        try (Communicator communicator = initialize(initData)) {
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new _defaultI(), Util.stringToIdentity("test"));
             adapter.activate();

--- a/java/test/src/main/java/test/Slice/escape/Key.ice
+++ b/java/test/src/main/java/test/Slice/escape/Key.ice
@@ -2,9 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Slice.escape"]]
-
-["java:identifier:escaped_abstract"]
+["java:identifier:test.escaped_abstract"]
 module abstract
 {
     ["java:identifier:_assert"]
@@ -36,17 +34,20 @@ module abstract
         void do();
     }
 
+    ["java:identifier:_notify"]
     class notify
     {
         ["java:identifier:foo"] int if;
         ["java:identifier:_equals"] default* equals;
     }
 
+    ["java:identifier:_hashCode"]
     exception hashCode
     {
         ["java:identifier:bar"] int if;
     }
 
+    ["java:identifier:CloneException"]
     exception clone extends hashCode
     {
         ["java:identifier:escaped_native"] string native;

--- a/java/test/src/main/java/test/Slice/generation/File1.ice
+++ b/java/test/src/main/java/test/Slice/generation/File1.ice
@@ -2,8 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Slice.generation"]]
-
+["java:identifier:test.Slice.generation.Test"]
 module Test
 {
     interface Interface1
@@ -12,7 +11,7 @@ module Test
     }
 }
 
-["java:package:test.Slice.generation.modpkg"]
+["java:identifier:test.Slice.generation.modpkg.Test2"]
 module Test2
 {
     class Class1 {}

--- a/java/test/src/main/java/test/Slice/generation/File2.ice
+++ b/java/test/src/main/java/test/Slice/generation/File2.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Slice.generation"]]
+["java:identifier:test.Slice.generation.Test"]
 module Test
 {
     interface Interface2

--- a/java/test/src/main/java/test/Slice/generation/list-generated.out
+++ b/java/test/src/main/java/test/Slice/generation/list-generated.out
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <generated>
   <source name="File1.ice">
-    <file name="classes/test/Slice/generation/Test/_Marker.java"/>
     <file name="classes/test/Slice/generation/Test/Interface1Prx.java"/>
     <file name="classes/test/Slice/generation/Test/_Interface1PrxI.java"/>
-    <file name="classes/test/Slice/generation/modpkg/Test2/_Marker.java"/>
     <file name="classes/test/Slice/generation/modpkg/Test2/Class1.java"/>
     <file name="classes/test/Slice/generation/Test/Interface1.java"/>
   </source>
   <source name="File2.ice">
-    <file name="classes/test/Slice/generation/Test/_Marker.java"/>
     <file name="classes/test/Slice/generation/Test/Interface2Prx.java"/>
     <file name="classes/test/Slice/generation/Test/_Interface2PrxI.java"/>
     <file name="classes/test/Slice/generation/Test/Interface2.java"/>

--- a/java/test/src/main/java/test/Slice/macros/Test.ice
+++ b/java/test/src/main/java/test/Slice/macros/Test.ice
@@ -2,8 +2,6 @@
 
 #pragma once
 
-[["java:package:test.Slice.macros"]]
-
 //
 // This macro sets the default value only when compiling with slice2java.
 //
@@ -22,6 +20,7 @@
 #   define NODEFAULT(X) /**/
 #endif
 
+["java:identifier:test.Slice.macros.Test"]
 module Test
 {
     class Default

--- a/java/test/src/main/java/test/Slice/structure/Test.ice
+++ b/java/test/src/main/java/test/Slice/structure/Test.ice
@@ -2,7 +2,7 @@
 
 #pragma once
 
-[["java:package:test.Slice.structure"]]
+["java:identifier:test.Slice.structure.Test"]
 module Test
 {
     sequence<string> StringSeq;

--- a/java/tools/slice-tools/README.md
+++ b/java/tools/slice-tools/README.md
@@ -185,7 +185,7 @@ plugins {
 With an `.ice` file in `src/main/slice/Greeter.ice`:
 
 ```slice
-["java:package:com.zeroc.demos"]
+["java:identifier:com.zeroc.demos.VisitorCenter"]
 module VisitorCenter {
     interface Greeter {
         string greet(string name);

--- a/scripts/tests/Slice/generation.py
+++ b/scripts/tests/Slice/generation.py
@@ -8,7 +8,7 @@ class SliceGenerationTestCase(ClientTestCase):
     def runClientSide(self, current):
         current.write("testing list-generated... ")
 
-        slice2java = SliceTranslator("slice2java")
+        slice2java = SliceTranslator("slice2java", quiet=True)
         current.mkdirs("classes")
 
         slice2java.run(

--- a/slice/Glacier2/Metrics.ice
+++ b/slice/Glacier2/Metrics.ice
@@ -8,12 +8,12 @@
 
 [["cpp:include:Glacier2/Config.h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Glacier2"]]
 
 #include "Ice/Metrics.ice"
 
+["java:identifier:com.zeroc.IceMX"]
 ["swift:identifier:Glacier2"]
 module IceMX
 {

--- a/slice/Glacier2/PermissionsVerifier.ice
+++ b/slice/Glacier2/PermissionsVerifier.ice
@@ -8,12 +8,12 @@
 
 [["cpp:include:Glacier2/Config.h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Glacier2"]]
 
 #include "SSLInfo.ice"
 
+["java:identifier:com.zeroc.Glacier2"]
 module Glacier2
 {
     /// The exception that is thrown when a client is not allowed to create a session.

--- a/slice/Glacier2/Router.ice
+++ b/slice/Glacier2/Router.ice
@@ -8,7 +8,6 @@
 
 [["cpp:include:Glacier2/Config.h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Glacier2"]]
 
@@ -17,6 +16,7 @@
 #include "Session.ice"
 
 /// Communicate through firewalls and across NATs.
+["java:identifier:com.zeroc.Glacier2"]
 module Glacier2
 {
     /// The exception that is thrown when a client tries to destroy a session with a router, but no session exists for

--- a/slice/Glacier2/SSLInfo.ice
+++ b/slice/Glacier2/SSLInfo.ice
@@ -8,12 +8,12 @@
 
 [["cpp:include:Glacier2/Config.h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Glacier2"]]
 
 #include "Ice/BuiltinSequences.ice"
 
+["java:identifier:com.zeroc.Glacier2"]
 module Glacier2
 {
     /// Represents information gathered from an incoming SSL connection and used for authentication and authorization.

--- a/slice/Glacier2/Session.ice
+++ b/slice/Glacier2/Session.ice
@@ -8,7 +8,6 @@
 
 [["cpp:include:Glacier2/Config.h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Glacier2"]]
 
@@ -16,6 +15,7 @@
 #include "Ice/Identity.ice"
 #include "SSLInfo.ice"
 
+["java:identifier:com.zeroc.Glacier2"]
 module Glacier2
 {
     interface Router; // So that doc-comments can link to `Glacier2::Router`.

--- a/slice/Ice/BuiltinSequences.ice
+++ b/slice/Ice/BuiltinSequences.ice
@@ -16,10 +16,10 @@
 [["cpp:include:string"]]
 [["cpp:include:vector"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Ice"]]
 
+["java:identifier:com.zeroc.Ice"]
 module Ice
 {
     /// A sequence of bools.

--- a/slice/Ice/Context.ice
+++ b/slice/Ice/Context.ice
@@ -11,10 +11,10 @@
 [["cpp:include:map"]]
 [["cpp:include:string"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Ice"]]
 
+["java:identifier:com.zeroc.Ice"]
 module Ice
 {
     /// Represents additional information carried by an Ice request. This information is filled-in by the application

--- a/slice/Ice/EndpointTypes.ice
+++ b/slice/Ice/EndpointTypes.ice
@@ -10,13 +10,13 @@
 [["cpp:include:Ice/Config.h"]]
 [["cpp:include:cstdint"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Ice"]]
 
 // The endpoint types are called transport codes in IceRPC. They are used to marshal endpoints (as part of proxies) with
 // the Slice 1.x encoding.
 
+["java:identifier:com.zeroc.Ice"]
 module Ice
 {
     /// Identifies endpoints marshaled as URI strings.

--- a/slice/Ice/Identity.ice
+++ b/slice/Ice/Identity.ice
@@ -13,11 +13,11 @@
 [["cpp:include:string"]]
 [["cpp:include:vector"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Ice"]]
 
 /// Full-featured RPC framework.
+["java:identifier:com.zeroc.Ice"]
 module Ice
 {
     /// Represents the identity of an Ice object. It is comparable to the path of a URI. Its string representation is

--- a/slice/Ice/Locator.ice
+++ b/slice/Ice/Locator.ice
@@ -8,12 +8,12 @@
 
 [["cpp:source-include:Ice/LocatorRegistry.h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Ice"]]
 
 #include "Identity.ice"
 
+["java:identifier:com.zeroc.Ice"]
 module Ice
 {
     /// The exception that is thrown by a {@link Locator} implementation when it cannot find an object adapter with the

--- a/slice/Ice/LocatorRegistry.ice
+++ b/slice/Ice/LocatorRegistry.ice
@@ -8,12 +8,12 @@
 
 [["cpp:source-include:Ice/Process.h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Ice"]]
 
 #include "Locator.ice"
 
+["java:identifier:com.zeroc.Ice"]
 module Ice
 {
     interface Process;

--- a/slice/Ice/Metrics.ice
+++ b/slice/Ice/Metrics.ice
@@ -6,13 +6,13 @@
 [["cpp:doxygen:include:Ice/Ice.h"]]
 [["cpp:header-ext:h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Ice"]]
 
 #include "BuiltinSequences.ice"
 
 /// The Ice Management eXtension facility.
+["java:identifier:com.zeroc.IceMX"]
 ["swift:identifier:Ice"]
 module IceMX
 {

--- a/slice/Ice/OperationMode.ice
+++ b/slice/Ice/OperationMode.ice
@@ -10,10 +10,10 @@
 [["cpp:include:Ice/Config.h"]]
 [["cpp:include:Ice/StreamHelpers.h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Ice"]]
 
+["java:identifier:com.zeroc.Ice"]
 module Ice
 {
     /// Specifies if an operation is idempotent, which affects the retry behavior of the Ice client runtime.

--- a/slice/Ice/Process.ice
+++ b/slice/Ice/Process.ice
@@ -6,12 +6,12 @@
 [["cpp:doxygen:include:Ice/Ice.h"]]
 [["cpp:header-ext:h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Ice"]]
 
 #include "LocatorRegistry.ice"
 
+["java:identifier:com.zeroc.Ice"]
 module Ice
 {
     /// A server application managed by a locator implementation such as IceGrid hosts a Process object and registers a

--- a/slice/Ice/PropertiesAdmin.ice
+++ b/slice/Ice/PropertiesAdmin.ice
@@ -6,12 +6,12 @@
 [["cpp:doxygen:include:Ice/Ice.h"]]
 [["cpp:header-ext:h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Ice"]]
 
 #include "PropertyDict.ice"
 
+["java:identifier:com.zeroc.Ice"]
 module Ice
 {
     /// Provides remote access to the properties of a communicator.

--- a/slice/Ice/PropertyDict.ice
+++ b/slice/Ice/PropertyDict.ice
@@ -11,10 +11,10 @@
 [["cpp:include:map"]]
 [["cpp:include:string"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Ice"]]
 
+["java:identifier:com.zeroc.Ice"]
 module Ice
 {
     /// A simple collection of properties, represented as a dictionary of key/value pairs. Both key and value are

--- a/slice/Ice/RemoteLogger.ice
+++ b/slice/Ice/RemoteLogger.ice
@@ -8,12 +8,12 @@
 
 [["cpp:include:list"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Ice"]]
 
 #include "BuiltinSequences.ice"
 
+["java:identifier:com.zeroc.Ice"]
 module Ice
 {
     /// Represents the different types of log messages.

--- a/slice/Ice/ReplyStatus.ice
+++ b/slice/Ice/ReplyStatus.ice
@@ -10,10 +10,10 @@
 [["cpp:include:Ice/Config.h"]]
 [["cpp:include:Ice/StreamHelpers.h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Ice"]]
 
+["java:identifier:com.zeroc.Ice"]
 module Ice
 {
     /// Represents the status of a reply.

--- a/slice/Ice/Router.ice
+++ b/slice/Ice/Router.ice
@@ -6,12 +6,12 @@
 [["cpp:doxygen:include:Ice/Ice.h"]]
 [["cpp:header-ext:h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Ice"]]
 
 #include "BuiltinSequences.ice"
 
+["java:identifier:com.zeroc.Ice"]
 module Ice
 {
     /// Represents an intermediary object that routes requests and replies between clients and Ice objects that are not

--- a/slice/Ice/SliceChecksumDict.ice
+++ b/slice/Ice/SliceChecksumDict.ice
@@ -6,10 +6,10 @@
 [["cpp:doxygen:include:Ice/Ice.h"]]
 [["cpp:header-ext:h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Ice"]]
 
+["java:identifier:com.zeroc.Ice"]
 module Ice
 {
     /// Mapping from type IDs to Slice checksums. This dictionary allows verification at runtime that a client and a

--- a/slice/Ice/Version.ice
+++ b/slice/Ice/Version.ice
@@ -13,10 +13,10 @@
 [["cpp:include:cstdint"]]
 [["cpp:include:ostream"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:Ice"]]
 
+["java:identifier:com.zeroc.Ice"]
 module Ice
 {
     /// Represents a version of the Ice protocol. The only version implemented and supported by Ice is version 1.0.

--- a/slice/IceBox/ServiceManager.ice
+++ b/slice/IceBox/ServiceManager.ice
@@ -8,13 +8,13 @@
 
 [["cpp:include:IceBox/Config.h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:IceBox"]]
 
 #include "Ice/BuiltinSequences.ice"
 
 /// Host multiple independent services in the same Ice server.
+["java:identifier:com.zeroc.IceBox"]
 module IceBox
 {
     /// The exception that is thrown when attempting to start a service that is already running.

--- a/slice/IceDiscovery/Lookup.ice
+++ b/slice/IceDiscovery/Lookup.ice
@@ -4,12 +4,12 @@
 
 [["cpp:header-ext:h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:IceDiscovery"]]
 
 #include "Ice/Identity.ice"
 
+["java:identifier:com.zeroc.IceDiscovery"]
 module IceDiscovery
 {
     /// Represents a callback object implemented by IceDiscovery clients. It allows IceDiscovery clients to receive

--- a/slice/IceGrid/Admin.ice
+++ b/slice/IceGrid/Admin.ice
@@ -8,7 +8,6 @@
 
 [["cpp:include:IceGrid/Config.h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:IceGrid"]]
 
@@ -18,6 +17,7 @@
 #include "Ice/BuiltinSequences.ice"
 #include "Ice/Identity.ice"
 
+["java:identifier:com.zeroc.IceGrid"]
 module IceGrid
 {
     interface Registry; // So that doc-comments can link to `IceGrid::Registry`.

--- a/slice/IceGrid/Descriptor.ice
+++ b/slice/IceGrid/Descriptor.ice
@@ -8,13 +8,13 @@
 
 [["cpp:include:IceGrid/Config.h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:IceGrid"]]
 
 #include "Ice/BuiltinSequences.ice"
 #include "Ice/Identity.ice"
 
+["java:identifier:com.zeroc.IceGrid"]
 module IceGrid
 {
     /// A mapping of string to string.

--- a/slice/IceGrid/Exception.ice
+++ b/slice/IceGrid/Exception.ice
@@ -8,13 +8,13 @@
 
 [["cpp:include:IceGrid/Config.h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:IceGrid"]]
 
 #include "Ice/BuiltinSequences.ice"
 #include "Ice/Identity.ice"
 
+["java:identifier:com.zeroc.IceGrid"]
 module IceGrid
 {
     /// The exception that is thrown when IceGrid does not know an application with the provided name.

--- a/slice/IceGrid/FileParser.ice
+++ b/slice/IceGrid/FileParser.ice
@@ -8,12 +8,12 @@
 
 [["cpp:include:IceGrid/Config.h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:IceGrid"]]
 
 #include "Admin.ice"
 
+["java:identifier:com.zeroc.IceGrid"]
 module IceGrid
 {
     /// The exception that is thrown when an error occurs during the parsing of an IceGrid XML file.

--- a/slice/IceGrid/Registry.ice
+++ b/slice/IceGrid/Registry.ice
@@ -8,7 +8,6 @@
 
 [["cpp:include:IceGrid/Config.h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:IceGrid"]]
 
@@ -18,6 +17,7 @@
 #include "Session.ice"
 
 /// Deploy and manage Ice servers.
+["java:identifier:com.zeroc.IceGrid"]
 module IceGrid
 {
     /// Determines which load sampling interval to use.

--- a/slice/IceGrid/Session.ice
+++ b/slice/IceGrid/Session.ice
@@ -8,13 +8,13 @@
 
 [["cpp:include:IceGrid/Config.h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:IceGrid"]]
 
 #include "Exception.ice"
 #include "Glacier2/Session.ice"
 
+["java:identifier:com.zeroc.IceGrid"]
 module IceGrid
 {
     interface Registry; // For doc-comments.

--- a/slice/IceGrid/UserAccountMapper.ice
+++ b/slice/IceGrid/UserAccountMapper.ice
@@ -8,10 +8,10 @@
 
 [["cpp:include:IceGrid/Config.h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:IceGrid"]]
 
+["java:identifier:com.zeroc.IceGrid"]
 module IceGrid
 {
     /// The exception that is thrown when a user account for a given session identifier can't be found.

--- a/slice/IceLocatorDiscovery/Lookup.ice
+++ b/slice/IceLocatorDiscovery/Lookup.ice
@@ -4,7 +4,6 @@
 
 [["cpp:header-ext:h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:IceLocatorDiscovery"]]
 
@@ -12,6 +11,7 @@
 
 /// IceLocatorDiscovery is an Ice plug-in that enables the discovery of Ice locators (such as IceGrid) via UDP
 /// multicast.
+["java:identifier:com.zeroc.IceLocatorDiscovery"]
 module IceLocatorDiscovery
 {
     /// Represents a callback object implemented by IceLocatorDiscovery clients. It allows IceLocatorDiscovery clients

--- a/slice/IceStorm/IceStorm.ice
+++ b/slice/IceStorm/IceStorm.ice
@@ -8,7 +8,6 @@
 
 [["cpp:include:IceStorm/Config.h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:IceStorm"]]
 
@@ -16,6 +15,7 @@
 #include "Metrics.ice"
 
 /// Lightweight publish/subscribe framework, available for all Ice language mappings.
+["java:identifier:com.zeroc.IceStorm"]
 module IceStorm
 {
     interface Topic;

--- a/slice/IceStorm/Metrics.ice
+++ b/slice/IceStorm/Metrics.ice
@@ -8,12 +8,12 @@
 
 [["cpp:include:IceStorm/Config.h"]]
 
-[["java:package:com.zeroc"]]
 [["js:module:@zeroc/ice"]]
 [["python:pkgdir:IceStorm"]]
 
 #include "Ice/Metrics.ice"
 
+["java:identifier:com.zeroc.IceMX"]
 ["swift:identifier:IceStorm"]
 module IceMX
 {


### PR DESCRIPTION
This PR:
- Deprecates the old `java:package` metadata.
- Replaces the `java:package` metadata with the `java:identifier` metadata.
- Updates all the java tests to use `initData.sliceLoader = ...` instead of `properties.setProperty("Ice.Package.XXX", "YYY")`.

In 64% of the tests, I just deleted `"Ice.Package.XXX"` without adding `sliceLoader`, because they didn't actually need it
(ie. they never unmarshalled a class/exception). I'm sure there's still more tests where it could of been deleted, but where it wasn't as obvious. But, I don't want to waste too much time going after these, when there's more important stuff to focus on.