### PR TITLE
Sign MATLAB binaries on Windows

### DIFF
--- a/.github/workflows/build-matlab-packages.yml
+++ b/.github/workflows/build-matlab-packages.yml
@@ -12,6 +12,12 @@ on:
     secrets:
       REPOSITORY_PASSWORD:
         required: false
+      AZURE_TENANT_ID:
+        required: true
+      AZURE_CLIENT_ID:
+        required: true
+      AZURE_CLIENT_SECRET:
+        required: true
   workflow_dispatch:
     inputs:
       repository_url:
@@ -55,6 +61,33 @@ jobs:
         if: runner.os == 'Linux'
 
       - name: Build Windows MATLAB ToolBox
+        run: MSBuild /p:Configuration=Release /p:Platform=x64 /t:BuildDist matlab\msbuild\ice.proj
+        if: runner.os == 'Windows'
+
+      - name: Collect Files To Sign
+        if: runner.os == 'Windows'
+        run: |
+          Get-ChildItem -Path matlab\lib\x64\Release -Include *.dll, *.mexw64 -Recurse -File | ForEach-Object {
+            $_.FullName.
+          } | Set-Content -Path "${{ github.workspace }}\catalog.txt" -Encoding UTF8
+          Add-Content -Path "${{ github.workspace }}\catalog.txt" -Value "cpp\bin\x64\Release\slice2matlab.exe"
+
+      - name: Sign C++ Binaries
+        uses: azure/trusted-signing-action@v0
+        if: runner.os == 'Windows'
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: https://eus.codesigning.azure.net/
+          trusted-signing-account-name: zeroc
+          certificate-profile-name: zeroc-ice
+          files-catalog: ${{ github.workspace }}\catalog.txt
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Package Windows MATLAB ToolBox
         run: MSBuild /p:Configuration=Release /p:Platform=x64 /t:Package matlab\msbuild\ice.proj
         if: runner.os == 'Windows'
 

--- a/.github/workflows/build-matlab-packages.yml
+++ b/.github/workflows/build-matlab-packages.yml
@@ -68,7 +68,7 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           Get-ChildItem -Path matlab\lib\x64\Release -Include *.dll, *.mexw64 -Recurse -File | ForEach-Object {
-            $_.FullName.
+            $_.FullName
           } | Set-Content -Path "${{ github.workspace }}\catalog.txt" -Encoding UTF8
           Add-Content -Path "${{ github.workspace }}\catalog.txt" -Value "cpp\bin\x64\Release\slice2matlab.exe"
 

--- a/.github/workflows/build-nightly-release-workflow.yml
+++ b/.github/workflows/build-nightly-release-workflow.yml
@@ -158,6 +158,9 @@ jobs:
       repository_username: ${{ inputs.repository_username }}
     secrets:
       REPOSITORY_PASSWORD: ${{ secrets.NEXUS_NIGHTLY_PASSWORD }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
 
   build-maven-packages:
     name: Build Maven Packages

--- a/cpp/BUILDING.md
+++ b/cpp/BUILDING.md
@@ -183,12 +183,6 @@ You can also skip the build of the test suite with the `BuildDist` target:
 msbuild /m msbuild\ice.proj /t:BuildDist /p:Platform=x64
 ```
 
-You can also sign the Ice binaries with Authenticode, by setting the following environment variables:
-
-- `SIGN_CERTIFICATE` to your Authenticode certificate
-- `SIGN_PASSWORD` to the certificate password
-- `SIGN_SHA1` the SHA1 hash of the signing certificate
-
 ### Build Using Visual Studio
 
 Open the [msbuild/ice.sln](./msbuild/ice.sln) Visual Studio solution.

--- a/matlab/msbuild/ice.proj
+++ b/matlab/msbuild/ice.proj
@@ -103,7 +103,7 @@
         </Task>
     </UsingTask>
 
-    <Target Name="Package" DependsOnTargets="BuildDist">
+    <Target Name="Package">
         <RemoveDir Directories="$(ToolboxDir)" />
         <MakeDir Directories="$(ToolboxDir);$(ToolboxDir)\doc" />
 


### PR DESCRIPTION
This is a follow up to #3932 for signing the MATLAB binaries included in the MATLAB Windows toolbox.