### PR TITLE
Add missing TypeID constant

### DIFF
--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -1957,9 +1957,15 @@ CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     }
     out.dec();
     out << nl << "end";
-
     out.dec();
     out << nl << "end";
+
+    out << nl << "properties(Constant, Access=private)";
+    out.inc();
+    out << nl << "TypeId char = '" << p->scoped() << "'";
+    out.dec();
+    out << nl << "end";
+
     out.dec();
     out << nl << "end";
     out << nl;


### PR DESCRIPTION
slice2matlab now generates TypeId for Exceptions.