### PR TITLE
Move __repr__ implementation to the Python generated code

### DIFF
--- a/python/modules/IcePy/Init.cpp
+++ b/python/modules/IcePy/Init.cpp
@@ -95,11 +95,6 @@ static PyMethodDef methods[] = {
      reinterpret_cast<PyCFunction>(IcePy_defineException),
      METH_VARARGS,
      PyDoc_STR("internal function")},
-    {"stringify", reinterpret_cast<PyCFunction>(IcePy_stringify), METH_VARARGS, PyDoc_STR("internal function")},
-    {"stringifyException",
-     reinterpret_cast<PyCFunction>(IcePy_stringifyException),
-     METH_VARARGS,
-     PyDoc_STR("internal function")},
     {"loadSlice", reinterpret_cast<PyCFunction>(IcePy_loadSlice), METH_VARARGS, PyDoc_STR("loadSlice(cmd) -> None")},
     {"compile", reinterpret_cast<PyCFunction>(IcePy_compile), METH_VARARGS, PyDoc_STR("internal function")},
     {} /* sentinel */

--- a/python/modules/IcePy/Types.h
+++ b/python/modules/IcePy/Types.h
@@ -156,8 +156,6 @@ namespace IcePy
             void*,
             bool,
             const Ice::StringSeq* = nullptr) = 0;
-
-        virtual void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) = 0;
     };
     using TypeInfoPtr = std::shared_ptr<TypeInfo>;
 
@@ -198,8 +196,6 @@ namespace IcePy
             bool,
             const Ice::StringSeq* = nullptr) final;
 
-        void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
-
         const Kind kind;
     };
     using PrimitiveInfoPtr = std::shared_ptr<PrimitiveInfo>;
@@ -230,8 +226,6 @@ namespace IcePy
             void*,
             bool,
             const Ice::StringSeq* = nullptr) final;
-
-        void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
 
         void destroy() final;
 
@@ -286,8 +280,6 @@ namespace IcePy
             bool,
             const Ice::StringSeq* = nullptr) final;
 
-        void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
-
         void destroy() final;
 
         static PyObject* instantiate(PyObject*);
@@ -329,8 +321,6 @@ namespace IcePy
             void*,
             bool,
             const Ice::StringSeq* = nullptr) final;
-
-        void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
 
         void destroy() final;
 
@@ -421,8 +411,6 @@ namespace IcePy
             const Ice::StringSeq* = nullptr) final;
         void unmarshaled(PyObject*, PyObject*, void*) final;
 
-        void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
-
         void destroy() final;
 
         class KeyCallback final : public UnmarshalCallback
@@ -475,11 +463,7 @@ namespace IcePy
             bool,
             const Ice::StringSeq* = nullptr) final;
 
-        void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
-
         void destroy() final;
-
-        void printMembers(PyObject*, IceInternal::Output&, PrintObjectHistory*);
 
         const std::string id;
         const std::int32_t compactId{-1};
@@ -522,8 +506,6 @@ namespace IcePy
             bool,
             const Ice::StringSeq* = nullptr) final;
 
-        void print(PyObject*, IceInternal::Output&, PrintObjectHistory*) final;
-
         const std::string id;
         PyObject* pythonType; // Borrowed reference - the enclosing Python module owns the reference.
         PyObject* typeObj;    // Borrowed reference - the "_t_XXX" variable owns the reference.
@@ -540,9 +522,6 @@ namespace IcePy
     public:
         void marshal(PyObject*, Ice::OutputStream*, ObjectMap*);
         PyObject* unmarshal(Ice::InputStream*);
-
-        void print(PyObject*, IceInternal::Output&);
-        void printMembers(PyObject*, IceInternal::Output&, PrintObjectHistory*);
 
         std::string id;
         ExceptionInfoPtr base;
@@ -682,7 +661,5 @@ extern "C" PyObject* IcePy_defineProxy(PyObject*, PyObject*);
 extern "C" PyObject* IcePy_declareValue(PyObject*, PyObject*);
 extern "C" PyObject* IcePy_defineValue(PyObject*, PyObject*);
 extern "C" PyObject* IcePy_defineException(PyObject*, PyObject*);
-extern "C" PyObject* IcePy_stringify(PyObject*, PyObject*);
-extern "C" PyObject* IcePy_stringifyException(PyObject*, PyObject*);
 
 #endif

--- a/python/python/Ice/EnumBase.py
+++ b/python/python/Ice/EnumBase.py
@@ -5,11 +5,6 @@ class EnumBase(object):
         self._name = _n
         self._value = _v
 
-    def __str__(self):
-        return self._name
-
-    __repr__ = __str__
-
     def __hash__(self):
         return self._value
 
@@ -60,6 +55,9 @@ class EnumBase(object):
 
     def _getValue(self):
         return self._value
+
+    def __str__(self):
+        return repr(self)
 
     name = property(_getName)
     value = property(_getValue)

--- a/python/python/Ice/ObjectPrx.py
+++ b/python/python/Ice/ObjectPrx.py
@@ -937,5 +937,15 @@ class ObjectPrx(IcePy.ObjectPrx):
         """
         return super().ice_flushBatchRequests()
 
+    def __repr__(self):
+        return (
+            f"{self.__class__.__module__}.{self.__class__.__qualname__}("
+            f"communicator={self.ice_getCommunicator()!r}, "
+            f"proxyString={self.ice_toString()!r})"
+        )
+
+    def __str__(self):
+        return repr(self)
+
 
     __module__ = 'Ice'

--- a/python/python/Ice/UserException.py
+++ b/python/python/Ice/UserException.py
@@ -10,4 +10,7 @@ class UserException(Exception):
     def __init__(self):
         super().__init__()
 
+    def __str__(self):
+        return repr(self)
+
 __all__ = ["UserException"]

--- a/python/python/Ice/Util.py
+++ b/python/python/Ice/Util.py
@@ -4,6 +4,7 @@
 import asyncio
 import os
 import sys
+import threading
 import IcePy
 from .InitializationData import InitializationData
 from .Properties import Properties
@@ -193,5 +194,24 @@ def getSliceDir():
             return dir
 
     return None
+
+_repr_running = threading.local()
+
+def safe_repr(obj):
+    if not hasattr(_repr_running, "set"):
+        _repr_running.set = set()
+
+    obj_id = id(obj)
+    if obj_id in _repr_running.set:
+        return "..."
+
+    _repr_running.set.add(obj_id)
+    try:
+        return repr(obj)
+    finally:
+        _repr_running.set.remove(obj_id)
+
+def format_fields(**fields):
+    return ", ".join(f"{k}={safe_repr(v)}" for k, v in fields.items())
 
 __all__ = [ "initialize", "identityToString", "stringToIdentity", "createProperties", "getSliceDir" ]

--- a/python/python/Ice/Value.py
+++ b/python/python/Ice/Value.py
@@ -47,4 +47,7 @@ class Value(object):
         """
         return getattr(self, "_ice_slicedData", None)
 
+    def __str__(self):
+        return repr(self)
+
 IcePy._t_Value = IcePy.defineValue("::Ice::Object", Value, -1, (), False, None, ())


### PR DESCRIPTION
This PR reworks the Python `__repr__` and `__str__` implementations:
- The methods are now implemented in the generated code rather than in IcePy C++.
- `__str__` now calls `__repr__`, instead of the other way around.

The reason for this change is to allow users to reimplement `__str__` without interfering with `__repr__`.
`__str__` is intended to produce a user-friendly output, while `__repr__` is meant for developers and, if possible, should allow recreating the object.

Fix #3819