### PR TITLE
Update `Forward.ice` Test Section in `cpp/Slice/errorDetection`.

### DIFF
--- a/cpp/test/Slice/errorDetection/forward/Forward.ice
+++ b/cpp/test/Slice/errorDetection/forward/Forward.ice
@@ -1,4 +1,0 @@
-module test
-{
-    class F;
-}

--- a/cpp/test/Slice/errorDetection/test.py
+++ b/cpp/test/Slice/errorDetection/test.py
@@ -94,7 +94,7 @@ class SliceErrorDetectionTestCase(ClientTestCase):
             for file in files:
                 try:
                     compiler.run(current, args=[file, "--output-dir", "tmp", "-I" + sliceDir])
-                except:
+                except RuntimeError:
                     failures.append(file)
 
             current.writeln("failed!" if failures else "ok")

--- a/cpp/test/Slice/errorDetection/test.py
+++ b/cpp/test/Slice/errorDetection/test.py
@@ -11,78 +11,105 @@ from Util import ClientTestCase, SliceTranslator, TestSuite
 class SliceErrorDetectionTestCase(ClientTestCase):
     def runClientSide(self, current):
         testdir = current.testsuite.getPath()
-        slice2cpp = SliceTranslator("slice2cpp", quiet=True)
 
+        # Create a temporary directory for all the Slice compilers to write their output to.
         outdir = "{0}/tmp".format(testdir)
         if os.path.exists(outdir):
             shutil.rmtree(outdir)
         os.mkdir(outdir)
 
-        files = glob.glob("{0}/*.ice".format(testdir))
-        files.sort()
         try:
-            for file in files:
-                current.write(os.path.basename(file) + "... ")
-
-                args = ["-I.", file, "--output-dir", "tmp"]
-
-                # Don't print out slice2cpp output and expect failures
-                slice2cpp.run(
-                    current, args=args, exitstatus=0 if file.find("Warning") >= 0 else 1
-                )
-                output = slice2cpp.getOutput(current)
-
-                regex1 = re.compile(r"\.ice$", re.IGNORECASE)
-                lines1 = output.strip().splitlines()
-                with open(os.path.join(testdir, regex1.sub(".err", file)), "r") as f:
-                    lines2 = f.readlines()
-                    if len(lines1) != len(lines2):
-                        current.writeln("lines1 = {0}".format(lines1))
-                        current.writeln("lines2 = {0}".format(lines2))
-                        raise RuntimeError(
-                            "failed (lines1 = {0}, lines2 = {1})!".format(
-                                len(lines1), len(lines2)
-                            )
-                        )
-
-                    regex2 = re.compile("^.*(?=" + os.path.basename(file) + ")")
-                    i = 0
-                    while i < len(lines1):
-                        line1 = regex2.sub("", lines1[i]).strip() # Actual output from slice2cpp
-                        line2 = lines2[i].strip()                 # Expected output from .err file
-                        if line1 != line2:
-                            raise RuntimeError(
-                                'failed! (line1 = "{0}", line2 = "{1}"'.format(
-                                    line1, line2
-                                )
-                            )
-                        i = i + 1
-                    else:
-                        current.writeln("ok")
-
-            current.write("Forward.ice... ")
-            for language in [
-                "cpp",
-                "cs",
-                "html",
-                "java",
-                "js",
-                "matlab",
-                "php",
-                "py",
-                "rb",
-                "swift",
-            ]:
-                compiler = SliceTranslator("slice2%s" % language)
-                if not os.path.isfile(compiler.getCommandLine(current)):
-                    continue
-                compiler.run(
-                    current, args=["forward/Forward.ice", "--output-dir", "tmp"]
-                )
-            current.writeln("ok")
+            self.testForExpectedErrors(current)
+            self.testThatSliceCompilesWithNoErrors(current)
         finally:
+            # Make sure we clean up the 'tmp' directory.
             if os.path.exists(outdir):
                 shutil.rmtree(outdir)
+
+    def testForExpectedErrors(self, current):
+        testdir = current.testsuite.getPath()
+        slice2cpp = SliceTranslator("slice2cpp", quiet=True)
+
+        # Get all the '.ice' files in this script's directory.
+        files = glob.glob("{0}/*.ice".format(testdir))
+        files.sort()
+
+        for file in files:
+            current.write(os.path.basename(file) + "... ")
+
+            args = ["-I.", file, "--output-dir", "tmp"]
+
+            # Don't print out slice2cpp output and expect failures
+            slice2cpp.run(
+                current, args=args, exitstatus=0 if file.find("Warning") >= 0 else 1
+            )
+            output = slice2cpp.getOutput(current)
+
+            regex1 = re.compile(r"\.ice$", re.IGNORECASE)
+            lines1 = output.strip().splitlines()
+            with open(os.path.join(testdir, regex1.sub(".err", file)), "r") as f:
+                lines2 = f.readlines()
+                if len(lines1) != len(lines2):
+                    current.writeln("lines1 = {0}".format(lines1))
+                    current.writeln("lines2 = {0}".format(lines2))
+                    raise RuntimeError(
+                        "failed (lines1 = {0}, lines2 = {1})!".format(
+                            len(lines1), len(lines2)
+                        )
+                    )
+
+                regex2 = re.compile("^.*(?=" + os.path.basename(file) + ")")
+                i = 0
+                while i < len(lines1):
+                    line1 = regex2.sub("", lines1[i]).strip() # Actual output from slice2cpp
+                    line2 = regex2.sub("", lines2[i]).strip() # Expected output from
+                    if line1 != line2:
+                        raise RuntimeError(
+                            'failed! (line1 = "{0}", line2 = "{1}"'.format(
+                                line1, line2
+                            )
+                        )
+                    i = i + 1
+                else:
+                    current.writeln("ok")
+
+
+    def testThatSliceCompilesWithNoErrors(self, current):
+        testdir = current.testsuite.getPath()
+
+        # Get all '.ice' files in the top-level 'slice' folder.
+        sliceDir = "{0}/../../../../slice".format(testdir)
+        files = glob.glob(sliceDir + "/**/*.ice", recursive=True)
+        files.sort()
+
+        # Verify that each compiler can successfully compile those Slice files.
+        for compilerName in [
+            "slice2cpp",
+            "slice2cs",
+            "slice2java",
+            "slice2js",
+            "slice2matlab",
+            "slice2php",
+            "slice2py",
+            "slice2rb",
+            "slice2swift",
+            "ice2slice"
+        ]:
+            compiler = SliceTranslator(compilerName)
+            failures = []
+
+            current.write("testing " + compilerName + "... " )
+            for file in files:
+                try:
+                    compiler.run(current, args=[file, "--output-dir", "tmp", "-I" + sliceDir])
+                except:
+                    failures.append(file)
+
+            current.writeln("failed!" if failures else "ok")
+            if failures:
+                for failure in failures:
+                    current.writeln("    failed to compile '" + failure + "'")
+                raise RuntimeError(compilerName + " failed to compile files in './slice'")
 
 
 TestSuite(__name__, [SliceErrorDetectionTestCase()])

--- a/cpp/test/Slice/errorDetection/test.py
+++ b/cpp/test/Slice/errorDetection/test.py
@@ -52,11 +52,7 @@ class SliceErrorDetectionTestCase(ClientTestCase):
                 if len(lines1) != len(lines2):
                     current.writeln("lines1 = {0}".format(lines1))
                     current.writeln("lines2 = {0}".format(lines2))
-                    raise RuntimeError(
-                        "failed (lines1 = {0}, lines2 = {1})!".format(
-                            len(lines1), len(lines2)
-                        )
-                    )
+                    raise RuntimeError("failed (lines1 = {0}, lines2 = {1})!".format(len(lines1), len(lines2)))
 
                 regex2 = re.compile("^.*(?=" + os.path.basename(file) + ")")
                 i = 0
@@ -64,11 +60,7 @@ class SliceErrorDetectionTestCase(ClientTestCase):
                     line1 = regex2.sub("", lines1[i]).strip() # Actual output from slice2cpp
                     line2 = regex2.sub("", lines2[i]).strip() # Expected output from
                     if line1 != line2:
-                        raise RuntimeError(
-                            'failed! (line1 = "{0}", line2 = "{1}"'.format(
-                                line1, line2
-                            )
-                        )
+                        raise RuntimeError('failed! (line1 = "{0}", line2 = "{1}"'.format(line1, line2))
                     i = i + 1
                 else:
                     current.writeln("ok")


### PR DESCRIPTION
Fixes #3252.

At the bottom of the `Slice/errorDetection` test, we run each of the Slice compilers over `Forward.ice` to make sure they work without errors. But the test file is very small just a single class forward declaration in a module. Also, the list of compilers is also out of date, including `slice2html` (the test silently skips non-existent compilers (not great)).

This PR updates the list of compilers (removes `slice2html` and adds `ice2slice`), will now fail if a compiler doesn't exist, and instead of running them over this small Slice file, runs them against all `*.ice` files in the `./slice` directory.
On my local machine, this added 29 seconds to testing. So about 3s per compiler.

----

While grepping for `ice2slice`, I learned that we _do_ actually have an action (`Run ice2slice`) testing it (added back in January).
But there's something fishy. `iceslice` was broken for a few months until #3827 in April, and yet the action never failed...

Regardless, properly testing `ice2slice` was one of the main reasons behind this PR.
Now that I know the action exists, we should either:
1) close this PR, delete this part of `errorDetection`, and fix the action (possibly to run on more platforms/configurations)
2) or we should delete the action in favor of this PR.

I honestly don't care one way or another. As long as `ice2slice` is being tested, it's fine with me! So I leave it up to you!