### PR TITLE
Remove view-type from dictionary, improve Ice/span test

### DIFF
--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -155,9 +155,9 @@ namespace
         {
             return true;
         }
-        if (dynamic_pointer_cast<Sequence>(type) || dynamic_pointer_cast<Dictionary>(type))
+        if (dynamic_pointer_cast<Sequence>(type))
         {
-            // Return true for view-type (sequence and dictionary) and array (sequence only)
+            // Return true for view-type and array.
             for (const auto& meta : metadata)
             {
                 string_view directive = meta->directive();

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1038,7 +1038,7 @@ Slice::Gen::validateMetadata(const UnitPtr& u)
 
     // "cpp:view-type"
     MetadataInfo viewTypeInfo = {
-        .validOn = {typeid(Sequence), typeid(Dictionary)},
+        .validOn = {typeid(Sequence)},
         .acceptedArgumentKind = MetadataArgumentKind::RequiredTextArgument,
         .acceptedContext = MetadataApplicationContext::ParameterTypeReferences,
     };

--- a/cpp/test/Ice/span/AllTests.cpp
+++ b/cpp/test/Ice/span/AllTests.cpp
@@ -40,9 +40,9 @@ allTests(TestHelper* helper)
     }
 
     {
-        vector<string> v{"a", "bb", "ccc", "dddd", "eeeee"};
+        vector<string_view> v{"a", "bb", "ccc", "dddd", "eeeee"};
 
-        auto dataIn = span<string>{v}.subspan(1, 3);
+        auto dataIn = span<string_view>{v}.subspan(1, 3);
         vector<string> dataOut;
         auto r = prx->opStringSpan(dataIn, dataOut);
         vector<string> dataInVec{dataIn.begin(), dataIn.end()};
@@ -75,9 +75,9 @@ allTests(TestHelper* helper)
     }
 
     {
-        vector<string> v{"a", "bb", "ccc", "dddd", "eeeee"};
+        vector<string_view> v{"a", "bb", "ccc", "dddd", "eeeee"};
 
-        auto dataIn = span<string>{v}.subspan(1, 3);
+        auto dataIn = span<string_view>{v}.subspan(1, 3);
         optional<vector<string>> dataOut;
         auto r = prx->opOptionalStringSpan(dataIn, dataOut);
         vector<string> dataInVec{dataIn.begin(), dataIn.end()};

--- a/cpp/test/Ice/span/Test.ice
+++ b/cpp/test/Ice/span/Test.ice
@@ -12,31 +12,31 @@ module Test
 
     interface TestIntf
     {
-        ["cpp:view-type:std::span<const std::byte>"] ByteSeq opByteSpan(
+        ByteSeq opByteSpan(
             ["cpp:view-type:std::span<const std::byte>"] ByteSeq dataIn,
-            ["cpp:view-type:std::span<const std::byte>"] out ByteSeq dataOut);
+            out ByteSeq dataOut);
 
-        ["cpp:view-type:std::span<const std::int16_t>"] ShortSeq opShortSpan(
+        ShortSeq opShortSpan(
             ["cpp:view-type:std::span<const std::int16_t>"] ShortSeq dataIn,
-            ["cpp:view-type:std::span<const std::int16_t>"] out ShortSeq dataOut);
+            out ShortSeq dataOut);
 
-        ["cpp:view-type:std::span<std::string>"] StringSeq opStringSpan(
-            ["cpp:view-type:std::span<std::string>"] StringSeq dataIn,
-            ["cpp:view-type:std::span<std::string>"] out StringSeq dataOut);
+        StringSeq opStringSpan(
+            ["cpp:view-type:std::span<const std::string_view>"] StringSeq dataIn,
+            out StringSeq dataOut);
 
         // Same with optionals
 
-        ["cpp:view-type:std::span<const std::byte>"] optional(10) ByteSeq opOptionalByteSpan(
+        optional(10) ByteSeq opOptionalByteSpan(
             ["cpp:view-type:std::span<const std::byte>"] optional(1) ByteSeq dataIn,
-            ["cpp:view-type:std::span<const std::byte>"] out optional(11) ByteSeq dataOut);
+            out optional(11) ByteSeq dataOut);
 
-        ["cpp:view-type:std::span<const std::int16_t>"] optional(10) ShortSeq opOptionalShortSpan(
+        optional(10) ShortSeq opOptionalShortSpan(
             ["cpp:view-type:std::span<const std::int16_t>"] optional(1) ShortSeq dataIn,
-            ["cpp:view-type:std::span<const std::int16_t>"] out optional(11) ShortSeq dataOut);
+            out optional(11) ShortSeq dataOut);
 
-        ["cpp:view-type:std::span<std::string>"] optional(10) StringSeq opOptionalStringSpan(
-            ["cpp:view-type:std::span<std::string>"] optional(1) StringSeq dataIn,
-            ["cpp:view-type:std::span<std::string>"] out optional(11) StringSeq dataOut);
+        optional(10) StringSeq opOptionalStringSpan(
+            ["cpp:view-type:std::span<const std::string_view>"] optional(1) StringSeq dataIn,
+            out optional(11) StringSeq dataOut);
 
         void shutdown();
     }

--- a/cpp/test/Ice/span/TestAMD.ice
+++ b/cpp/test/Ice/span/TestAMD.ice
@@ -10,7 +10,7 @@ module Test
     sequence<short> ShortSeq;
     sequence<string> StringSeq;
 
-    // No metadata on in-parameters are we don't use this generated code for the client.
+    // No metadata on in-parameters and we don't use this generated code for the client.
 
     ["amd"]
     interface TestIntf

--- a/cpp/test/Ice/span/TestAMD.ice
+++ b/cpp/test/Ice/span/TestAMD.ice
@@ -10,34 +10,36 @@ module Test
     sequence<short> ShortSeq;
     sequence<string> StringSeq;
 
+    // No metadata on in-parameters are we don't use this generated code for the client.
+
     ["amd"]
     interface TestIntf
     {
         ["cpp:view-type:std::span<const std::byte>"] ByteSeq opByteSpan(
-            ["cpp:view-type:std::span<const std::byte>"] ByteSeq dataIn,
+            ByteSeq dataIn,
             ["cpp:view-type:std::span<const std::byte>"] out ByteSeq dataOut);
 
         ["cpp:view-type:std::span<const std::int16_t>"] ShortSeq opShortSpan(
-            ["cpp:view-type:std::span<const std::int16_t>"] ShortSeq dataIn,
+            ShortSeq dataIn,
             ["cpp:view-type:std::span<const std::int16_t>"] out ShortSeq dataOut);
 
-        ["cpp:view-type:std::span<std::string>"] StringSeq opStringSpan(
-            ["cpp:view-type:std::span<std::string>"] StringSeq dataIn,
-            ["cpp:view-type:std::span<std::string>"] out StringSeq dataOut);
+        ["cpp:view-type:std::span<const std::string_view>"] StringSeq opStringSpan(
+            StringSeq dataIn,
+            ["cpp:view-type:std::span<const std::string_view>"] out StringSeq dataOut);
 
         // Same with optionals
 
         ["cpp:view-type:std::span<const std::byte>"] optional(10) ByteSeq opOptionalByteSpan(
-            ["cpp:view-type:std::span<const std::byte>"] optional(1) ByteSeq dataIn,
+            optional(1) ByteSeq dataIn,
             ["cpp:view-type:std::span<const std::byte>"] out optional(11) ByteSeq dataOut);
 
         ["cpp:view-type:std::span<const std::int16_t>"] optional(10) ShortSeq opOptionalShortSpan(
-            ["cpp:view-type:std::span<const std::int16_t>"] optional(1) ShortSeq dataIn,
+            optional(1) ShortSeq dataIn,
             ["cpp:view-type:std::span<const std::int16_t>"] out optional(11) ShortSeq dataOut);
 
-        ["cpp:view-type:std::span<std::string>"] optional(10) StringSeq opOptionalStringSpan(
-            ["cpp:view-type:std::span<std::string>"] optional(1) StringSeq dataIn,
-            ["cpp:view-type:std::span<std::string>"] out optional(11) StringSeq dataOut);
+        ["cpp:view-type:std::span<const std::string_view>"] optional(10) StringSeq opOptionalStringSpan(
+            optional(1) StringSeq dataIn,
+            ["cpp:view-type:std::span<const std::string_view>"] out optional(11) StringSeq dataOut);
 
         void shutdown();
     }

--- a/cpp/test/Ice/span/TestAMDI.cpp
+++ b/cpp/test/Ice/span/TestAMDI.cpp
@@ -28,11 +28,12 @@ TestIntfAMDI::opShortSpanAsync(
 void
 TestIntfAMDI::opStringSpanAsync(
     StringSeq dataIn,
-    function<void(span<string> returnValue, span<string> dataOut)> response,
+    function<void(span<const string_view> returnValue, span<const string_view> dataOut)> response,
     function<void(exception_ptr)>,
     const Ice::Current&)
 {
-    response(dataIn, dataIn);
+    vector<string_view> dataInView{dataIn.begin(), dataIn.end()};
+    response(dataInView, dataInView);
 }
 
 void
@@ -58,13 +59,14 @@ TestIntfAMDI::opOptionalShortSpanAsync(
 void
 TestIntfAMDI::opOptionalStringSpanAsync(
     optional<StringSeq> dataIn,
-    function<void(optional<span<string>> returnValue, optional<span<string>> dataOut)> response,
+    function<void(optional<span<const string_view>> returnValue, optional<span<const string_view>> dataOut)> response,
     function<void(exception_ptr)>,
     const Ice::Current&)
 {
     if (dataIn)
     {
-        response(*dataIn, *dataIn);
+        vector<string_view> dataInView{dataIn->begin(), dataIn->end()};
+        response(dataInView, dataInView);
     }
     else
     {

--- a/cpp/test/Ice/span/TestAMDI.h
+++ b/cpp/test/Ice/span/TestAMDI.h
@@ -22,7 +22,8 @@ public:
 
     void opStringSpanAsync(
         Test::StringSeq dataIn,
-        std::function<void(std::span<std::string> returnValue, std::span<std::string> dataOut)> response,
+        std::function<void(std::span<const std::string_view> returnValue, std::span<const std::string_view> dataOut)>
+            response,
         std::function<void(std::exception_ptr)> exception,
         const Ice::Current& current) final;
 
@@ -44,9 +45,9 @@ public:
 
     void opOptionalStringSpanAsync(
         std::optional<Test::StringSeq> dataIn,
-        std::function<
-            void(std::optional<std::span<std::string>> returnValue, std::optional<std::span<std::string>> dataOut)>
-            response,
+        std::function<void(
+            std::optional<std::span<const std::string_view>> returnValue,
+            std::optional<std::span<const std::string_view>> dataOut)> response,
         std::function<void(std::exception_ptr)> exception,
         const Ice::Current& current) final;
 


### PR DESCRIPTION
This PR removes the cpp:view-type metadata from dictionary because:
 - we don't provide any type (such as span) to use it with
   - it was only useful in the event to added your own view-type handling with a StreamHelper
 - we didn't have any test for dictionary view-types

This PR also improves the existing Ice/span test for cpp:view-type on sequences to map StringSeq to `std::span<const std::string_view>` (a true view type) and not `std::span<std::string>` (which worked but was lame).

