### PR TITLE
Add Communicator.addSliceLoader in C++, C# and Java

### DIFF
--- a/cpp/include/Ice/Communicator.h
+++ b/cpp/include/Ice/Communicator.h
@@ -205,6 +205,14 @@ namespace Ice
         /// @return This communicator's logger.
         [[nodiscard]] LoggerPtr getLogger() const noexcept;
 
+        /// Adds a Slice loader to this communicator, after the Slice loader set in InitializationData (if any) and
+        /// after other Slice loaders added by this function.
+        /// @param loader The Slice loader to add.
+        /// @remarks This function is not thread-safe and should only be called right after the communicator is created.
+        /// It's provided for applications that cannot set the Slice loader in the InitializationData of the
+        /// communicator, such as IceBox services.
+        void addSliceLoader(SliceLoaderPtr loader) noexcept;
+
         /// Gets the observer object of this communicator.
         /// @return This communicator's observer object.
         [[nodiscard]] Instrumentation::CommunicatorObserverPtr getObserver() const noexcept;

--- a/cpp/src/Ice/Communicator.cpp
+++ b/cpp/src/Ice/Communicator.cpp
@@ -216,6 +216,12 @@ Ice::Communicator::getLogger() const noexcept
     return _instance->initializationData().logger;
 }
 
+void
+Ice::Communicator::addSliceLoader(SliceLoaderPtr sliceLoader) noexcept
+{
+    _instance->addSliceLoader(std::move(sliceLoader));
+}
+
 Ice::Instrumentation::CommunicatorObserverPtr
 Ice::Communicator::getObserver() const noexcept
 {

--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -1126,7 +1126,7 @@ IceInternal::Instance::initialize(const Ice::CommunicatorPtr& communicator)
 
         if (_initData.sliceLoader)
         {
-            _applicationSliceLoader->add(_applicationSliceLoader);
+            _applicationSliceLoader->add(_initData.sliceLoader);
         }
 
         auto compositeSliceLoader = make_shared<CompositeSliceLoader>();

--- a/cpp/src/Ice/Instance.h
+++ b/cpp/src/Ice/Instance.h
@@ -92,7 +92,9 @@ namespace IceInternal
         [[nodiscard]] Ice::ToStringMode toStringMode() const { return _toStringMode; }
         [[nodiscard]] bool acceptClassCycles() const { return _acceptClassCycles; }
 
+        void addSliceLoader(Ice::SliceLoaderPtr loader) noexcept { _applicationSliceLoader->add(std::move(loader)); }
         [[nodiscard]] const Ice::SliceLoaderPtr& sliceLoader() const noexcept { return _initData.sliceLoader; }
+
         [[nodiscard]] const Ice::ConnectionOptions& clientConnectionOptions() const noexcept
         {
             return _clientConnectionOptions;
@@ -203,6 +205,10 @@ namespace IceInternal
         // Only set when _implicitContextKind == Shared.
         Ice::ImplicitContextPtr _sharedImplicitContext;
         Ice::SSL::SSLEnginePtr _sslEngine;
+
+        // The Slice loader(s) added by the application: initData.sliceLoader followed by the loaders added by
+        // addSliceLoader.
+        const Ice::CompositeSliceLoaderPtr _applicationSliceLoader;
     };
 
     class ProcessI final : public Ice::Process

--- a/csharp/src/Ice/Communicator.cs
+++ b/csharp/src/Ice/Communicator.cs
@@ -278,6 +278,16 @@ public sealed class Communicator : IDisposable, IAsyncDisposable
     public Logger getLogger() => instance.initializationData().logger!;
 
     /// <summary>
+    /// Adds a Slice loader to this communicator, after the Slice loader set in <see cref="InitializationData" />(if
+    /// any) and after other Slice loaders added by this method.
+    /// </summary>
+    /// <param name="loader"> The Slice loader to add.</param>
+    /// <remarks>This method is not thread-safe and should only be called right after the communicator is created.
+    /// It's provided for applications that cannot set the Slice loader in the <see cref="InitializationData" /> of the
+    /// communicator, such as IceBox services.</remarks>
+    public void addSliceLoader(SliceLoader loader) => instance.addSliceLoader(loader);
+
+    /// <summary>
     /// Gets the observer resolver object for this communicator.
     /// </summary>
     /// <returns>This communicator's observer resolver object.</returns>

--- a/csharp/src/Ice/Internal/Instance.cs
+++ b/csharp/src/Ice/Internal/Instance.cs
@@ -568,6 +568,8 @@ public sealed class Instance
         _initData.threadStop = threadStop;
     }
 
+    internal void addSliceLoader(SliceLoader loader) => _applicationSliceLoader.add(loader);
+
     //
     // Only for use by Ice.Communicator
     //
@@ -708,22 +710,17 @@ public sealed class Instance
 
             // Update _initData.sliceLoader
 
+            if (_initData.sliceLoader is not null)
+            {
+                _applicationSliceLoader.add(_initData.sliceLoader);
+            }
+
             // We create a lazy Slice loader that searches assemblies the first time we unmarshal a class or
             // exception. At that time, all the assemblies should have been loaded.
             var lazySliceLoader = new LazySliceLoader(
                 () => SliceLoader.fromAssemblies(AppDomain.CurrentDomain.GetAssemblies()));
 
-            if (_initData.sliceLoader is null)
-            {
-                _initData.sliceLoader = lazySliceLoader;
-            }
-            else
-            {
-                var compositeSliceLoader = new CompositeSliceLoader();
-                compositeSliceLoader.add(_initData.sliceLoader);
-                compositeSliceLoader.add(lazySliceLoader);
-                _initData.sliceLoader = compositeSliceLoader;
-            }
+            _initData.sliceLoader = new CompositeSliceLoader(_applicationSliceLoader, lazySliceLoader);
 
             string toStringModeStr = _initData.properties.getIceProperty("Ice.ToStringMode");
             if (toStringModeStr == "Unicode")
@@ -1415,5 +1412,10 @@ public sealed class Instance
     private readonly Dictionary<short, BufSizeWarnInfo> _setBufSizeWarn = new();
     private ConnectionOptions _serverConnectionOptions; // set in initialize
     private Ice.SSL.SSLEngine _sslEngine;
+
+    // The Slice loader(s) added by the application: initData.sliceLoader followed by the loaders added by
+    // addSliceLoader.
+    private readonly CompositeSliceLoader _applicationSliceLoader = new();
+
     private readonly object _mutex = new object();
 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
@@ -345,6 +345,19 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
+     * Adds a Slice loader to this communicator, after the Slice loader set in {@link InitializationData}
+     * (if any) and after other Slice loaders added by this method.
+     *
+     * This method is not thread-safe and should only be called right after the communicator is created.
+     * It's provided for applications that cannot set the Slice loader in the {@link InitializationData} of the
+     * communicator, such as IceBox services.
+     * @param loader The Slice loader to add.
+     */
+    public void addSliceLoader(SliceLoader loader) {
+        _instance.addSliceLoader(loader);
+    }
+
+    /**
      * Get the observer resolver object for this communicator.
      *
      * @return This communicator's observer resolver object.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -543,6 +543,10 @@ public final class Instance {
         _initData.threadStop = threadStop;
     }
 
+    void addSliceLoader(SliceLoader loader) {
+       _applicationSliceLoader.add(loader);
+    }
+
     Class<?> findClass(String className) {
         return Util.findClass(className, _initData.classLoader);
     }
@@ -681,26 +685,11 @@ public final class Instance {
 
             // Update _initData.sliceLoader.
 
-            var sliceLoader = new CompositeSliceLoader();
-
             if (_initData.sliceLoader != null) {
-                sliceLoader.add(_initData.sliceLoader);
+                _applicationSliceLoader.add(_initData.sliceLoader);
             }
 
-            final int notFoundCacheSize =
-                properties.getIcePropertyAsInt("Ice.SliceLoader.NotFoundCacheSize");
-
-            if (notFoundCacheSize <= 0) {
-                _initData.sliceLoader = sliceLoader;
-            } else {
-                final Logger cacheFullLogger =
-                    properties.getIcePropertyAsInt("Ice.Warn.SliceLoader") > 0 ? _initData.logger : null;
-
-                _initData.sliceLoader = new NotFoundSliceLoaderDecorator(
-                    sliceLoader,
-                    notFoundCacheSize,
-                    cacheFullLogger);
-            }
+            var sliceLoader = new CompositeSliceLoader(_applicationSliceLoader);
 
             // Ice.Package.module loader.
             String packagePrefix = "Ice.Package";
@@ -742,6 +731,22 @@ public final class Instance {
 
             // Empty package prefix: module ::VisitorCenter maps to package VisitorCenter.
             sliceLoader.add(new DefaultPackageSliceLoader("", _initData.classLoader));
+
+            // Finally add decorator that caches NotFound, if needed.
+            final int notFoundCacheSize =
+                properties.getIcePropertyAsInt("Ice.SliceLoader.NotFoundCacheSize");
+
+            if (notFoundCacheSize <= 0) {
+                _initData.sliceLoader = sliceLoader;
+            } else {
+                final Logger cacheFullLogger =
+                    properties.getIcePropertyAsInt("Ice.Warn.SliceLoader") > 0 ? _initData.logger : null;
+
+                _initData.sliceLoader = new NotFoundSliceLoaderDecorator(
+                    sliceLoader,
+                    notFoundCacheSize,
+                    cacheFullLogger);
+            }
 
             String toStringModeStr = properties.getIceProperty("Ice.ToStringMode");
             if ("Unicode".equals(toStringModeStr)) {
@@ -1457,4 +1462,6 @@ public final class Instance {
 
     private ConnectionOptions _clientConnectionOptions;
     private ConnectionOptions _serverConnectionOptions;
+
+    private final CompositeSliceLoader _applicationSliceLoader = new CompositeSliceLoader();
 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -1463,5 +1463,7 @@ public final class Instance {
     private ConnectionOptions _clientConnectionOptions;
     private ConnectionOptions _serverConnectionOptions;
 
+    // The Slice loader(s) added by the application: initData.sliceLoader followed by the loaders added by
+    // addSliceLoader.
     private final CompositeSliceLoader _applicationSliceLoader = new CompositeSliceLoader();
 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -544,7 +544,7 @@ public final class Instance {
     }
 
     void addSliceLoader(SliceLoader loader) {
-       _applicationSliceLoader.add(loader);
+        _applicationSliceLoader.add(loader);
     }
 
     Class<?> findClass(String className) {


### PR DESCRIPTION
This PR adds addSliceLoader to Communicator in C++, C# and Java. Fixes #3943.