### PR TITLE
Remove 'Forward.ice' Test from `cpp/errorDetection`

### DIFF
--- a/cpp/test/Slice/errorDetection/forward/Forward.ice
+++ b/cpp/test/Slice/errorDetection/forward/Forward.ice
@@ -1,4 +1,0 @@
-module test
-{
-    class F;
-}

--- a/cpp/test/Slice/errorDetection/test.py
+++ b/cpp/test/Slice/errorDetection/test.py
@@ -13,11 +13,13 @@ class SliceErrorDetectionTestCase(ClientTestCase):
         testdir = current.testsuite.getPath()
         slice2cpp = SliceTranslator("slice2cpp", quiet=True)
 
+        # Create a temporary directory for all the Slice compilers to write their output to.
         outdir = "{0}/tmp".format(testdir)
         if os.path.exists(outdir):
             shutil.rmtree(outdir)
         os.mkdir(outdir)
 
+        # Get all the '.ice' files in this script's directory.
         files = glob.glob("{0}/*.ice".format(testdir))
         files.sort()
         try:
@@ -59,28 +61,8 @@ class SliceErrorDetectionTestCase(ClientTestCase):
                         i = i + 1
                     else:
                         current.writeln("ok")
-
-            current.write("Forward.ice... ")
-            for language in [
-                "cpp",
-                "cs",
-                "html",
-                "java",
-                "js",
-                "matlab",
-                "php",
-                "py",
-                "rb",
-                "swift",
-            ]:
-                compiler = SliceTranslator("slice2%s" % language)
-                if not os.path.isfile(compiler.getCommandLine(current)):
-                    continue
-                compiler.run(
-                    current, args=["forward/Forward.ice", "--output-dir", "tmp"]
-                )
-            current.writeln("ok")
         finally:
+            # Make sure we clean up the 'tmp' directory.
             if os.path.exists(outdir):
                 shutil.rmtree(outdir)
 


### PR DESCRIPTION
After talking about it #3945, this test is pointless and should be deleted.
We should be (and already do) testing of forward declaring classes in each language mapping.

But, we should still expand our testing of `ice2slice` to also run on a debug build, and maybe even other platforms.