### PR TITLE
Add `getTopLevelModule` Method to `Contained`

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -972,13 +972,14 @@ Slice::Contained::getTopLevelModule() const
     while (!p->isTopLevel())
     {
         p = dynamic_pointer_cast<Contained>(p->container());
-        assert(p);
     }
 
     // By the time we reach here, 'p' must be a top-level element; we cast it to a module.
     // Note that this cast can fail for elements erroneously defined outside of a module!
     // However, these are guaranteed not to exist after the parsing stage has completed.
-    return dynamic_pointer_cast<Module>(p);
+    ModulePtr topLevelModule = dynamic_pointer_cast<Module>(p);
+    assert(topLevelModule);
+    return topLevelModule;
 }
 
 string

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -953,6 +953,34 @@ Slice::Contained::isTopLevel() const
     return dynamic_pointer_cast<Unit>(container()) != nullptr;
 }
 
+ModulePtr
+Slice::Contained::getTopLevelModule() const
+{
+    ContainedPtr p;
+
+    // Round-about way to get `ContainedPtr` for this element, since we can't `enable_shared_from_this`.
+    for (const auto& sibling : container()->contents())
+    {
+        if (sibling.get() == this)
+        {
+            p = sibling;
+        }
+    }
+    assert(p);
+
+    // Navigate up through this element's parents until we hit a top-level element.
+    while (!p->isTopLevel())
+    {
+        p = dynamic_pointer_cast<Contained>(p->container());
+        assert(p);
+    }
+
+    // By the time we reach here, 'p' must be a top-level element; we cast it to a module.
+    // Note that this cast can fail for elements erroneously defined outside of a module!
+    // However, these are guaranteed not to exist after the parsing stage has completed.
+    return dynamic_pointer_cast<Module>(p);
+}
+
 string
 Slice::Contained::name() const
 {

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -958,7 +958,7 @@ Slice::Contained::getTopLevelModule() const
 {
     if (auto parent = dynamic_pointer_cast<Contained>(container()))
     {
-        parent->getTopLevelModule();
+        return parent->getTopLevelModule();
     }
     // `Module` has its own implementation of this function. So reaching here means we hit an
     // element which is a top-level non-module. The parser will report an error for it, but
@@ -2440,7 +2440,7 @@ Slice::Module::getTopLevelModule() const
 {
     if (auto parent = dynamic_pointer_cast<Contained>(container()))
     {
-        parent->getTopLevelModule();
+        return parent->getTopLevelModule();
     }
     // Reaching here means that this module is at the top-level! We return it.
     return dynamic_pointer_cast<Module>(shared_from_this());

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -2443,7 +2443,7 @@ Slice::Module::getTopLevelModule() const
         return parent->getTopLevelModule();
     }
     // Reaching here means that this module is at the top-level! We return it.
-    return dynamic_pointer_cast<Module>(shared_from_this());
+    return dynamic_pointer_cast<Module>(const_pointer_cast<Container>(shared_from_this()));
 }
 
 void

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -960,9 +960,9 @@ Slice::Contained::getTopLevelModule() const
     {
         parent->getTopLevelModule();
     }
-    // `Module` has it's own implementation of this function. So reaching here means we hit an element
-    // which is a top-level non-module type. This will cause the parser to report a syntax error, but
-    // but until we exit (at the end of parsing) this element will exist, and needs to be handled.
+    // `Module` has its own implementation of this function. So reaching here means we hit an
+    // element which is a top-level non-module. The parser will report an error for it, but
+    // until we exit (at the end of parsing) this element will exist, and needs to be handled.
     return nullptr;
 }
 

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -382,7 +382,7 @@ namespace Slice
         virtual void destroy() {}
         [[nodiscard]] ContainerPtr container() const;
         [[nodiscard]] bool isTopLevel() const;
-        [[nodiscard]] ModulePtr getTopLevelModule() const;
+        [[nodiscard]] virtual ModulePtr getTopLevelModule() const;
 
         /// Returns the Slice identifier of this element.
         [[nodiscard]] std::string name() const;
@@ -536,6 +536,7 @@ namespace Slice
     public:
         Module(const ContainerPtr& container, const std::string& name, bool nestedSyntax);
         [[nodiscard]] std::string kindOf() const final;
+        [[nodiscard]] ModulePtr getTopLevelModule() const final;
         void visit(ParserVisitor* visitor) final;
         void destroy() final;
 

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -382,6 +382,7 @@ namespace Slice
         virtual void destroy() {}
         [[nodiscard]] ContainerPtr container() const;
         [[nodiscard]] bool isTopLevel() const;
+        [[nodiscard]] ModulePtr getTopLevelModule() const;
 
         /// Returns the Slice identifier of this element.
         [[nodiscard]] std::string name() const;

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -50,8 +50,6 @@ namespace
     static string getCsMappedNamespace(const ContainedPtr& cont)
     {
         ModulePtr topLevelModule = cont->getTopLevelModule();
-        assert(topLevelModule);
-
         string csMappedScope = getCsMappedScope(cont).substr(1);
         csMappedScope = csMappedScope.substr(0, csMappedScope.size() - 1); // Remove the trailing "."
 

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -47,36 +47,21 @@ namespace
     // We cannot use mappedScoped because it depends on the language name used to create the Unit.
     static string getCsMappedScoped(const ContainedPtr& cont) { return getCsMappedScope(cont) + getCsMappedName(cont); }
 
-    static string getCsNamespacePrefix(const ContainedPtr& cont)
-    {
-        // Traverse to the top-level module.
-        ContainedPtr p = cont;
-        while (true)
-        {
-            if (p->isTopLevel())
-            {
-                break;
-            }
-            p = dynamic_pointer_cast<Contained>(p->container());
-            assert(p);
-        }
-        assert(dynamic_pointer_cast<Module>(p));
-
-        return p->getMetadataArgs("cs:namespace").value_or("");
-    }
-
     static string getCsMappedNamespace(const ContainedPtr& cont)
     {
-        string csNamespacePrefix = getCsNamespacePrefix(cont);
+        ModulePtr topLevelModule = cont->getTopLevelModule();
+        assert(topLevelModule);
+
         string csMappedScope = getCsMappedScope(cont).substr(1);
         csMappedScope = csMappedScope.substr(0, csMappedScope.size() - 1); // Remove the trailing "."
-        if (csNamespacePrefix.empty())
+
+        if (auto csNamespacePrefix = topLevelModule->getMetadataArgs("cs:namespace"))
         {
-            return csMappedScope;
+            return *csNamespacePrefix + "." + csMappedScope;
         }
         else
         {
-            return csNamespacePrefix + "." + csMappedScope;
+            return csMappedScope;
         }
     }
 

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -1741,7 +1741,7 @@ bool
 Slice::Gen::TypesVisitor::visitModuleStart(const ModulePtr& p)
 {
     string prefix = getPackagePrefix(p);
-    if (!prefix.empty() && dynamic_pointer_cast<Unit>(p->container())) // generate Marker class for top-level modules
+    if (!prefix.empty() && p->isTopLevel()) // generate Marker class for top-level modules
     {
         string markerClass = prefix + "." + p->mappedName() + "._Marker";
         open(markerClass, p->file());

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -321,17 +321,12 @@ string
 Slice::JavaGenerator::getPackagePrefix(const ContainedPtr& contained)
 {
     // Traverse to the top-level module.
-    ContainedPtr p = contained;
-    while (!p->isTopLevel())
-    {
-        p = dynamic_pointer_cast<Contained>(p->container());
-        assert(p);
-    }
-    assert(dynamic_pointer_cast<Module>(p));
+    ModulePtr topLevelModule = contained->getTopLevelModule();
+    assert(topLevelModule);
 
     // The 'java:package' metadata can be defined as file metadata or applied to a top-level module.
     // We check for the metadata at the top-level module first and then fall back to the global scope.
-    if (auto metadataArgs = p->getMetadataArgs("java:package"))
+    if (auto metadataArgs = topLevelModule->getMetadataArgs("java:package"))
     {
         return *metadataArgs;
     }

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -320,9 +320,7 @@ Slice::JavaGenerator::output() const
 string
 Slice::JavaGenerator::getPackagePrefix(const ContainedPtr& contained)
 {
-    // Traverse to the top-level module.
     ModulePtr topLevelModule = contained->getTopLevelModule();
-    assert(topLevelModule);
 
     // The 'java:package' metadata can be defined as file metadata or applied to a top-level module.
     // We check for the metadata at the top-level module first and then fall back to the global scope.

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2379,18 +2379,13 @@ string
 Slice::Python::getPackageMetadata(const ContainedPtr& cont)
 {
     // Traverse to the top-level module.
-    ContainedPtr p = cont;
-    while (!p->isTopLevel())
-    {
-        p = dynamic_pointer_cast<Contained>(p->container());
-        assert(p);
-    }
-    assert(dynamic_pointer_cast<Module>(p));
+    ModulePtr topLevelModule = cont->getTopLevelModule();
+    assert(topLevelModule);
 
     // The python:package metadata can be defined as file metadata or applied to a top-level module.
     // We check for the metadata at the top-level module first and then fall back to the global scope.
     static const string directive = "python:package";
-    if (auto packageMetadata = p->getMetadataArgs(directive))
+    if (auto packageMetadata = topLevelModule->getMetadataArgs(directive))
     {
         return *packageMetadata;
     }

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2378,9 +2378,7 @@ Slice::Python::generate(const UnitPtr& unit, bool all, const vector<string>& inc
 string
 Slice::Python::getPackageMetadata(const ContainedPtr& cont)
 {
-    // Traverse to the top-level module.
     ModulePtr topLevelModule = cont->getTopLevelModule();
-    assert(topLevelModule);
 
     // The python:package metadata can be defined as file metadata or applied to a top-level module.
     // We check for the metadata at the top-level module first and then fall back to the global scope.

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -206,14 +206,15 @@ Gen::ImportVisitor::writeImports()
 }
 
 void
-Gen::ImportVisitor::addImport(const SyntaxTreeBasePtr& p, const ContainedPtr& toplevel)
+Gen::ImportVisitor::addImport(const SyntaxTreeBasePtr& p, const ContainedPtr& usedBy)
 {
-    // Only add imports for user defined constructs.
+    // Only add imports for user defined constructs...
     auto definition = dynamic_pointer_cast<Contained>(p);
     if (definition)
     {
-        string swiftM1 = getSwiftModule(getTopLevelModule(definition));
-        string swiftM2 = getSwiftModule(getTopLevelModule(toplevel));
+        // ... and only if the type lives in a different module than where it's being used.
+        string swiftM1 = getSwiftModule(definition->getTopLevelModule());
+        string swiftM2 = getSwiftModule(usedBy->getTopLevelModule());
         if (swiftM1 != swiftM2)
         {
             addImport(swiftM1);
@@ -236,7 +237,7 @@ bool
 Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
     const string prefix = getClassResolverPrefix(p->unit());
-    const string swiftModule = getSwiftModule(getTopLevelModule(p));
+    const string swiftModule = getSwiftModule(p->getTopLevelModule());
     const string name = getRelativeTypeString(p, swiftModule);
 
     ClassDefPtr base = p->base();
@@ -369,7 +370,7 @@ Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr&)
 bool
 Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
-    const string swiftModule = getSwiftModule(getTopLevelModule(p));
+    const string swiftModule = getSwiftModule(p->getTopLevelModule());
     const string name = getRelativeTypeString(p, swiftModule);
 
     ExceptionPtr base = p->base();
@@ -500,7 +501,7 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 bool
 Gen::TypesVisitor::visitStructStart(const StructPtr& p)
 {
-    const string swiftModule = getSwiftModule(getTopLevelModule(p));
+    const string swiftModule = getSwiftModule(p->getTopLevelModule());
     const string name = getRelativeTypeString(p, swiftModule);
     const string docName = removeEscaping(name);
     bool isLegalKeyType = Dictionary::isLegalKeyType(p);
@@ -617,7 +618,7 @@ Gen::TypesVisitor::visitStructStart(const StructPtr& p)
 void
 Gen::TypesVisitor::visitSequence(const SequencePtr& p)
 {
-    const string swiftModule = getSwiftModule(getTopLevelModule(p));
+    const string swiftModule = getSwiftModule(p->getTopLevelModule());
     const string name = getRelativeTypeString(p, swiftModule);
     const string unescapedName = removeEscaping(name);
 
@@ -771,7 +772,7 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
 void
 Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
 {
-    const string swiftModule = getSwiftModule(getTopLevelModule(p));
+    const string swiftModule = getSwiftModule(p->getTopLevelModule());
     const string name = getRelativeTypeString(p, swiftModule);
     const string unescapedName = removeEscaping(name);
 
@@ -920,7 +921,7 @@ Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
 void
 Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 {
-    const string swiftModule = getSwiftModule(getTopLevelModule(p));
+    const string swiftModule = getSwiftModule(p->getTopLevelModule());
     const string name = getRelativeTypeString(p, swiftModule);
     const string docName = removeEscaping(name);
     const EnumeratorList enumerators = p->enumerators();
@@ -1017,7 +1018,7 @@ void
 Gen::TypesVisitor::visitConst(const ConstPtr& p)
 {
     const TypePtr type = p->type();
-    const string swiftModule = getSwiftModule(getTopLevelModule(p));
+    const string swiftModule = getSwiftModule(p->getTopLevelModule());
 
     writeDocSummary(out, p);
     out << nl << "public let " << p->mappedName() << ": " << typeToString(type, p) << " = ";
@@ -1030,7 +1031,7 @@ Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     InterfaceList bases = p->bases();
 
-    const string swiftModule = getSwiftModule(getTopLevelModule(p));
+    const string swiftModule = getSwiftModule(p->getTopLevelModule());
     const string unescapedName = removeEscaping(getRelativeTypeString(p, swiftModule));
     const string traits = unescapedName + "Traits";
     const string prx = unescapedName + "Prx";
@@ -1238,7 +1239,7 @@ Gen::ServantVisitor::ServantVisitor(::IceInternal::Output& o) : out(o) {}
 bool
 Gen::ServantVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
-    const string swiftModule = getSwiftModule(getTopLevelModule(p));
+    const string swiftModule = getSwiftModule(p->getTopLevelModule());
 
     const string servant = getRelativeTypeString(p, swiftModule);
     const string unescapedName = removeEscaping(servant);
@@ -1353,7 +1354,7 @@ Gen::ServantVisitor::visitInterfaceDefEnd(const InterfaceDefPtr&)
 void
 Gen::ServantVisitor::visitOperation(const OperationPtr& op)
 {
-    const string swiftModule = getSwiftModule(getTopLevelModule(op));
+    const string swiftModule = getSwiftModule(op->getTopLevelModule());
 
     out << sp;
     writeOpDocSummary(out, op, true);
@@ -1379,7 +1380,7 @@ Gen::ServantExtVisitor::ServantExtVisitor(::IceInternal::Output& o) : out(o) {}
 bool
 Gen::ServantExtVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
-    const string swiftModule = getSwiftModule(getTopLevelModule(p));
+    const string swiftModule = getSwiftModule(p->getTopLevelModule());
 
     out << sp;
     writeServantDocSummary(out, p, swiftModule);

--- a/cpp/src/slice2swift/Gen.h
+++ b/cpp/src/slice2swift/Gen.h
@@ -44,7 +44,7 @@ namespace Slice
             void writeImports();
 
         private:
-            void addImport(const SyntaxTreeBasePtr& p, const ContainedPtr& toplevel);
+            void addImport(const SyntaxTreeBasePtr& p, const ContainedPtr& usedBy);
             void addImport(const std::string& module);
 
             IceInternal::Output& out;

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -65,8 +65,6 @@ namespace
 string
 Slice::getSwiftModule(const ModulePtr& module, string& swiftPrefix)
 {
-    assert(module);
-
     string swiftModule;
     if (auto argument = module->getMetadataArgs("swift:module"))
     {
@@ -959,7 +957,6 @@ SwiftGenerator::writeMembers(
              dynamic_pointer_cast<Dictionary>(type)))
         {
             ModulePtr topLevelModule = (dynamic_pointer_cast<Contained>(type))->getTopLevelModule();
-            assert(topLevelModule);
             alias = removeEscaping(topLevelModule->mappedName()) + "_" + removeEscaping(memberType);
             out << nl << "typealias " << alias << " = " << memberType;
         }
@@ -1124,7 +1121,6 @@ SwiftGenerator::writeMarshalUnmarshalCode(
             if (memberType == memberName)
             {
                 ModulePtr topLevelModule = cl->getTopLevelModule();
-                assert(topLevelModule);
                 alias = removeEscaping(topLevelModule->mappedName()) + "_" + removeEscaping(memberType);
                 out << nl << "typealias " << alias << " = " << memberType;
             }

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -65,6 +65,8 @@ namespace
 string
 Slice::getSwiftModule(const ModulePtr& module, string& swiftPrefix)
 {
+    assert(module);
+
     string swiftModule;
     if (auto argument = module->getMetadataArgs("swift:module"))
     {
@@ -93,29 +95,6 @@ Slice::getSwiftModule(const ModulePtr& module)
 {
     string prefix;
     return getSwiftModule(module, prefix);
-}
-
-ModulePtr
-Slice::getTopLevelModule(const ContainedPtr& cont)
-{
-    // Traverse to the top-level module.
-    ModulePtr m;
-    ContainedPtr p = cont;
-    while (true)
-    {
-        if (dynamic_pointer_cast<Module>(p))
-        {
-            m = dynamic_pointer_cast<Module>(p);
-        }
-
-        if (p->isTopLevel())
-        {
-            break;
-        }
-        p = dynamic_pointer_cast<Contained>(p->container());
-        assert(p);
-    }
-    return m;
 }
 
 void
@@ -608,7 +587,7 @@ SwiftGenerator::getRelativeTypeString(const ContainedPtr& contained, const strin
 
     // Determine which Swift module this element will be mapped into.
     string swiftPrefix;
-    string swiftModule = getSwiftModule(getTopLevelModule(contained), swiftPrefix);
+    string swiftModule = getSwiftModule(contained->getTopLevelModule(), swiftPrefix);
 
     // If a swift prefix was provided, we need to remove any escaping before appending it to the type string.
     string prefixedTypeString;
@@ -744,7 +723,7 @@ SwiftGenerator::writeConstantValue(
 }
 
 string
-SwiftGenerator::typeToString(const TypePtr& type, const ContainedPtr& toplevel, bool optional)
+SwiftGenerator::typeToString(const TypePtr& type, const ContainedPtr& usedBy, bool optional)
 {
     static const char* builtinTable[] = {
         "Swift.UInt8",
@@ -766,12 +745,11 @@ SwiftGenerator::typeToString(const TypePtr& type, const ContainedPtr& toplevel, 
     }
 
     string t = "";
-    //
-    // The current module where the type is being used
-    //
-    string currentModule = getSwiftModule(getTopLevelModule(toplevel));
-    BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
 
+    // The current module where the type is being used
+    string currentModule = getSwiftModule(usedBy->getTopLevelModule());
+
+    BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
     if (builtin)
     {
         if (builtin->kind() == Builtin::KindObject)
@@ -964,7 +942,7 @@ SwiftGenerator::writeMembers(
     const ContainedPtr& p,
     int typeCtx)
 {
-    string swiftModule = getSwiftModule(getTopLevelModule(p));
+    string swiftModule = getSwiftModule(p->getTopLevelModule());
     bool protocol = (typeCtx & TypeContextProtocol) != 0;
     string access = protocol ? "" : "public ";
     for (const auto& member : members)
@@ -980,8 +958,9 @@ SwiftGenerator::writeMembers(
             (dynamic_pointer_cast<Struct>(type) || dynamic_pointer_cast<Sequence>(type) ||
              dynamic_pointer_cast<Dictionary>(type)))
         {
-            ModulePtr m = getTopLevelModule(dynamic_pointer_cast<Contained>(type));
-            alias = removeEscaping(m->mappedName()) + "_" + removeEscaping(memberType);
+            ModulePtr topLevelModule = (dynamic_pointer_cast<Contained>(type))->getTopLevelModule();
+            assert(topLevelModule);
+            alias = removeEscaping(topLevelModule->mappedName()) + "_" + removeEscaping(memberType);
             out << nl << "typealias " << alias << " = " << memberType;
         }
 
@@ -1039,7 +1018,7 @@ SwiftGenerator::writeMarshalUnmarshalCode(
 {
     assert(!(type->isClassType() && tag >= 0)); // Optional classes are disallowed by the parser.
 
-    string swiftModule = getSwiftModule(getTopLevelModule(p));
+    string swiftModule = getSwiftModule(p->getTopLevelModule());
     string stream = dynamic_pointer_cast<Struct>(p) ? "self" : marshal ? "ostr" : "istr";
 
     string args;
@@ -1144,8 +1123,9 @@ SwiftGenerator::writeMarshalUnmarshalCode(
             string alias;
             if (memberType == memberName)
             {
-                ModulePtr m = getTopLevelModule(cl);
-                alias = removeEscaping(m->mappedName()) + "_" + removeEscaping(memberType);
+                ModulePtr topLevelModule = cl->getTopLevelModule();
+                assert(topLevelModule);
+                alias = removeEscaping(topLevelModule->mappedName()) + "_" + removeEscaping(memberType);
                 out << nl << "typealias " << alias << " = " << memberType;
             }
             args += (alias.empty() ? memberType : alias) + ".self";
@@ -1492,7 +1472,7 @@ SwiftGenerator::writeUnmarshalInParams(::IceInternal::Output& out, const Operati
 void
 SwiftGenerator::writeUnmarshalUserException(::IceInternal::Output& out, const OperationPtr& op)
 {
-    const string swiftModule = getSwiftModule(getTopLevelModule(op));
+    const string swiftModule = getSwiftModule(op->getTopLevelModule());
 
     // Arrange exceptions into most-derived to least-derived order. If we don't
     // do this, a base exception handler can appear before a derived exception
@@ -1536,7 +1516,7 @@ SwiftGenerator::writeProxyOperation(::IceInternal::Output& out, const OperationP
 {
     const ParameterList inParams = op->inParameters();
     const bool returnsAnyValues = op->returnsAnyValues();
-    const string swiftModule = getSwiftModule(getTopLevelModule(op));
+    const string swiftModule = getSwiftModule(op->getTopLevelModule());
 
     out << sp;
     writeOpDocSummary(out, op, false);

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -15,7 +15,6 @@ namespace Slice
 
     std::string getSwiftModule(const ModulePtr&, std::string&);
     std::string getSwiftModule(const ModulePtr&);
-    ModulePtr getTopLevelModule(const ContainedPtr&);
 
     class SwiftGenerator
     {


### PR DESCRIPTION
This PR adds a convenience function to `libSlice`: `getTopLevelModule`.
It does what it says on the tin. You invoke it on a Slice element, and it returns the top-level module which contains that element.