### PR TITLE
Update JavaScript API doc structure

### DIFF
--- a/js/Makefile
+++ b/js/Makefile
@@ -24,4 +24,4 @@ npminstall:
 doc: srcs
 	mkdir -p dist
 	node dts-bundle.js
-	npx typedoc dist/bundle.d.ts --disableGit --disableSources
+	npx typedoc --router structure dist/bundle.d.ts --disableGit --disableSources

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -27,7 +27,7 @@
                 "jshint": "^2.13.6",
                 "prettier": "^3.3.3",
                 "pump": "^3.0.0",
-                "typedoc": "^0.26.6",
+                "typedoc": "^0.28.4",
                 "typescript": "^5.5.4",
                 "typescript-formatter": "^7.2.2",
                 "vinyl": "^3.0.0",
@@ -271,6 +271,20 @@
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@gerrit0/mini-shiki": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.4.0.tgz",
+            "integrity": "sha512-48lKoQegmfJ0iyR/jRz5OrYOSM3WewG9YWCPqUvYFEC54shQO8RsAaspaK/2PRHVVnjekRqfAFvq8pwCpIo5ig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/engine-oniguruma": "^3.4.0",
+                "@shikijs/langs": "^3.4.0",
+                "@shikijs/themes": "^3.4.0",
+                "@shikijs/types": "^3.4.0",
+                "@shikijs/vscode-textmate": "^10.0.2"
             }
         },
         "node_modules/@gulpjs/messages": {
@@ -597,10 +611,52 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
-        "node_modules/@shikijs/core": {
-            "version": "1.10.1",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.10.1.tgz",
-            "integrity": "sha512-qdiJS5a/QGCff7VUFIqd0hDdWly9rDp8lhVmXVrS11aazX8LOTRLHAXkkEeONNsS43EcCd7gax9LLoOz4vlFQA==",
+        "node_modules/@shikijs/engine-oniguruma": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.4.0.tgz",
+            "integrity": "sha512-zwcWlZ4OQuJ/+1t32ClTtyTU1AiDkK1lhtviRWoq/hFqPjCNyLj22bIg9rB7BfoZKOEOfrsGz7No33BPCf+WlQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/types": "3.4.0",
+                "@shikijs/vscode-textmate": "^10.0.2"
+            }
+        },
+        "node_modules/@shikijs/langs": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.4.0.tgz",
+            "integrity": "sha512-bQkR+8LllaM2duU9BBRQU0GqFTx7TuF5kKlw/7uiGKoK140n1xlLAwCgXwSxAjJ7Htk9tXTFwnnsJTCU5nDPXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/types": "3.4.0"
+            }
+        },
+        "node_modules/@shikijs/themes": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.4.0.tgz",
+            "integrity": "sha512-YPP4PKNFcFGLxItpbU0ZW1Osyuk8AyZ24YEFaq04CFsuCbcqydMvMUTi40V2dkc0qs1U2uZFrnU6s5zI6IH+uA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/types": "3.4.0"
+            }
+        },
+        "node_modules/@shikijs/types": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.4.0.tgz",
+            "integrity": "sha512-EUT/0lGiE//7j5N/yTMNMT3eCWNcHJLrRKxT0NDXWIfdfSmFJKfPX7nMmRBrQnWboAzIsUziCThrYMMhjbMS1A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/vscode-textmate": "^10.0.2",
+                "@types/hast": "^3.0.4"
+            }
+        },
+        "node_modules/@shikijs/vscode-textmate": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+            "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
             "dev": true,
             "license": "MIT"
         },
@@ -609,6 +665,16 @@
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
             "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
             "dev": true
+        },
+        "node_modules/@types/hast": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+            "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "*"
+            }
         },
         "node_modules/@types/istanbul-lib-coverage": {
             "version": "2.0.6",
@@ -633,6 +699,13 @@
             "dependencies": {
                 "undici-types": "~6.19.2"
             }
+        },
+        "node_modules/@types/unist": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+            "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/acorn": {
             "version": "8.14.1",
@@ -4579,16 +4652,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/shiki": {
-            "version": "1.10.1",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.10.1.tgz",
-            "integrity": "sha512-uafV7WCgN4YYrccH6yxpnps6k38sSTlFRrwc4jycWmhWxJIm9dPrk+XkY1hZ2t0I7jmacMNb15Lf2fspa/Y3lg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@shikijs/core": "1.10.1"
-            }
-        },
         "node_modules/side-channel": {
             "version": "1.0.6",
             "dev": true,
@@ -4986,26 +5049,27 @@
             }
         },
         "node_modules/typedoc": {
-            "version": "0.26.6",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.6.tgz",
-            "integrity": "sha512-SfEU3SH3wHNaxhFPjaZE2kNl/NFtLNW5c1oHsg7mti7GjmUj1Roq6osBQeMd+F4kL0BoRBBr8gQAuqBlfFu8LA==",
+            "version": "0.28.4",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.4.tgz",
+            "integrity": "sha512-xKvKpIywE1rnqqLgjkoq0F3wOqYaKO9nV6YkkSat6IxOWacUCc/7Es0hR3OPmkIqkPoEn7U3x+sYdG72rstZQA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
+                "@gerrit0/mini-shiki": "^3.2.2",
                 "lunr": "^2.3.9",
                 "markdown-it": "^14.1.0",
                 "minimatch": "^9.0.5",
-                "shiki": "^1.9.1",
-                "yaml": "^2.4.5"
+                "yaml": "^2.7.1"
             },
             "bin": {
                 "typedoc": "bin/typedoc"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 18",
+                "pnpm": ">= 10"
             },
             "peerDependencies": {
-                "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x"
+                "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
             }
         },
         "node_modules/typedoc/node_modules/brace-expansion": {
@@ -5363,9 +5427,9 @@
             "license": "ISC"
         },
         "node_modules/yaml": {
-            "version": "2.4.5",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
-            "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+            "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
             "dev": true,
             "license": "ISC",
             "bin": {

--- a/js/package.json
+++ b/js/package.json
@@ -44,7 +44,7 @@
         "jshint": "^2.13.6",
         "prettier": "^3.3.3",
         "pump": "^3.0.0",
-        "typedoc": "^0.26.6",
+        "typedoc": "^0.28.4",
         "typescript": "^5.5.4",
         "typescript-formatter": "^7.2.2",
         "vinyl": "^3.0.0",


### PR DESCRIPTION
Update TypeDoc to use `--router structure` that generate the files using the modules structure, instead of per class, function, interface categories. 