### PR TITLE
Fix Swift docc warnings

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,14 +14,14 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
-        "version" : "1.3.0"
+        "revision" : "85e4bb4e1cd62cec64a4b8e769dcefdf0c5b9d64",
+        "version" : "1.4.3"
       }
     },
     {
       "identity" : "swift-docc-symbolkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
       "state" : {
         "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/zeroc-ice/mcpp.git", branch: "master"),
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0"),
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.3"),
     ],
     targets: [
         .target(

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -716,7 +716,7 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     out << nl << "/// Write a `" << unescapedName << "` sequence to the stream.";
     out << nl << "///";
     out << nl << "/// - Parameter ostr: The stream to write to.";
-    out << nl << "/// - Parameter value: The sequence value to write to the stream.";
+    out << nl << "/// - Parameter v: The sequence value to write to the stream.";
     out << nl << "public static func write(to ostr: " << ostr << ", value v: " << name << ")";
     out << sb;
     out << nl << "ostr.write(size: v.count)";
@@ -732,7 +732,7 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     out << nl << "/// - Parameters:";
     out << nl << "///   - ostr: The stream to write to.";
     out << nl << "///   - tag: The numeric tag associated with the value.";
-    out << nl << "///   - value: The sequence value to write to the stream.";
+    out << nl << "///   - v: The sequence value to write to the stream.";
     out << nl << "public static func write(to ostr: " << ostr << ",  tag: Swift.Int32, value v: " << name << "?)";
     out << sb;
     out << nl << "guard let val = v else";
@@ -872,7 +872,7 @@ Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     out << nl << "/// Write a `" << unescapedName << "` dictionary to the stream.";
     out << nl << "///";
     out << nl << "/// - Parameter ostr: The stream to write to.";
-    out << nl << "/// - Parameter value: The dictionary value to write to the stream.";
+    out << nl << "/// - Parameter v: The dictionary value to write to the stream.";
     out << nl << "public static func write(to ostr: " << ostr << ", value v: " << name << ")";
     out << sb;
     out << nl << "ostr.write(size: v.count)";
@@ -889,7 +889,7 @@ Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     out << nl << "/// - Parameters:";
     out << nl << "///   - ostr: The stream to write to.";
     out << nl << "///   - tag: The numeric tag associated with the value.";
-    out << nl << "///   - value: The dictionary value to write to the stream.";
+    out << nl << "///   - v: The dictionary value to write to the stream.";
     out << nl << "public static func write(to ostr: " << ostr << ", tag: Swift.Int32, value v: " << name << "?)";
     out << sb;
     out << nl << "guard let val = v else";

--- a/swift/src/Ice/Communicator.swift
+++ b/swift/src/Ice/Communicator.swift
@@ -41,14 +41,14 @@ public protocol Communicator: AnyObject {
     /// "some_host", port 10000. If the stringified proxy does not parse correctly, the operation throws ParseException.
     /// Refer to the Ice manual for a detailed description of the syntax supported by stringified proxies.
     ///
-    /// - parameter _: `String` The stringified proxy to convert into a proxy.
+    /// - parameter str: `String` The stringified proxy to convert into a proxy.
     ///
     /// - returns: `ObjectPrx?` - The proxy, or nil if str is an empty string.
     func stringToProxy(_ str: String) throws -> ObjectPrx?
 
     /// Convert a proxy into a string.
     ///
-    /// - parameter _: `ObjectPrx?` The proxy to convert into a stringified proxy.
+    /// - parameter obj: `ObjectPrx?` The proxy to convert into a stringified proxy.
     ///
     /// - returns: `String` - The stringified proxy, or an empty string if
     /// obj is nil.
@@ -59,7 +59,7 @@ public protocol Communicator: AnyObject {
     /// Additional properties configure local settings for the proxy, such as MyProxy.PreferSecure=1. The
     /// "Properties" appendix in the Ice manual describes each of the supported proxy properties.
     ///
-    /// - parameter _: `String` The base property name.
+    /// - parameter property: `String` The base property name.
     ///
     /// - returns: `ObjectPrx?` - The proxy.
     func propertyToProxy(_ property: String) throws -> ObjectPrx?
@@ -75,7 +75,7 @@ public protocol Communicator: AnyObject {
 
     /// Convert an identity into a string.
     ///
-    /// - parameter _: `Identity` The identity to convert into a string.
+    /// - parameter ident: `Identity` The identity to convert into a string.
     ///
     /// - returns: `String` - The "stringified" identity.
     func identityToString(_ ident: Identity) -> String
@@ -87,7 +87,7 @@ public protocol Communicator: AnyObject {
     /// by the adapter. Attempts to create a named object adapter for which no configuration can be found raise
     /// InitializationException.
     ///
-    /// - parameter _: `String` The object adapter name.
+    /// - parameter name: `String` The object adapter name.
     ///
     /// - returns: `ObjectAdapter` - The new object adapter.
     func createObjectAdapter(_ name: String) throws -> ObjectAdapter
@@ -155,7 +155,7 @@ public protocol Communicator: AnyObject {
     /// You can also set a router for an individual proxy by calling the operation ice_router on the
     /// proxy.
     ///
-    /// - parameter _: `RouterPrx?` The default router to use for this communicator.
+    /// - parameter rtr: `RouterPrx?` The default router to use for this communicator.
     func setDefaultRouter(_ rtr: RouterPrx?)
 
     /// Get the default locator for this communicator.
@@ -169,14 +169,14 @@ public protocol Communicator: AnyObject {
     /// You can also set a locator for an individual proxy by calling the operation ice_locator on the
     /// proxy, or for an object adapter by calling ObjectAdapter.setLocator on the object adapter.
     ///
-    /// - parameter _: `LocatorPrx?` The default locator to use for this communicator.
+    /// - parameter loc: `LocatorPrx?` The default locator to use for this communicator.
     func setDefaultLocator(_ loc: LocatorPrx?)
 
     /// Flush any pending batch requests for this communicator. This means all batch requests invoked on fixed proxies
     /// for all connections associated with the communicator. Any errors that occur while flushing a connection are
     /// ignored.
     ///
-    /// - parameter _: `CompressBatch` Specifies whether or not the queued batch requests should be compressed before
+    /// - parameter compress: `CompressBatch` Specifies whether or not the queued batch requests should be compressed before
     /// being sent over the wire.
     func flushBatchRequests(
         _ compress: CompressBatch
@@ -216,7 +216,7 @@ public protocol Communicator: AnyObject {
     /// Remove the following facet to the Admin object. Removing a facet that was not previously registered throws
     /// NotRegisteredException.
     ///
-    /// - parameter _: `String` The name of the Admin facet.
+    /// - parameter facet: `String` The name of the Admin facet.
     ///
     /// - returns: `Dispatcher` - The servant associated with this Admin facet.
     @discardableResult
@@ -224,7 +224,7 @@ public protocol Communicator: AnyObject {
 
     /// Returns a facet of the Admin object.
     ///
-    /// - parameter _: `String` The name of the Admin facet.
+    /// - parameter facet: `String` The name of the Admin facet.
     ///
     /// - returns: `Dispatcher?` - The servant associated with this Admin facet, or null if no facet is registered with the
     /// given name.

--- a/swift/src/Ice/Connection.swift
+++ b/swift/src/Ice/Connection.swift
@@ -45,16 +45,16 @@ extension InputStream {
 extension OutputStream {
     /// Writes an enumerated value to the stream.
     ///
-    /// parameter v: `CompressBatch` - The enumerator to write.
+    /// - parameter v: `CompressBatch` - The enumerator to write.
     public func write(_ v: CompressBatch) {
         write(enum: v.rawValue, maxValue: 2)
     }
 
     /// Writes an optional enumerated value to the stream.
     ///
-    /// parameter tag: `Int32` - The numeric tag associated with the value.
+    /// - parameter tag: `Int32` - The numeric tag associated with the value.
     ///
-    /// parameter value: `CompressBatch` - The enumerator to write.
+    /// - parameter value: `CompressBatch` - The enumerator to write.
     public func write(tag: Int32, value: CompressBatch?) {
         guard let v = value else {
             return

--- a/swift/src/Ice/Connection.swift
+++ b/swift/src/Ice/Connection.swift
@@ -45,7 +45,7 @@ extension InputStream {
 extension OutputStream {
     /// Writes an enumerated value to the stream.
     ///
-    /// parameter _: `CompressBatch` - The enumerator to write.
+    /// parameter v: `CompressBatch` - The enumerator to write.
     public func write(_ v: CompressBatch) {
         write(enum: v.rawValue, maxValue: 2)
     }
@@ -54,7 +54,7 @@ extension OutputStream {
     ///
     /// parameter tag: `Int32` - The numeric tag associated with the value.
     ///
-    /// parameter _: `CompressBatch` - The enumerator to write.
+    /// parameter value: `CompressBatch` - The enumerator to write.
     public func write(tag: Int32, value: CompressBatch?) {
         guard let v = value else {
             return
@@ -89,7 +89,7 @@ public protocol Connection: AnyObject, CustomStringConvertible {
     /// client if the server cannot directly establish a connection to the client, for example because of firewalls. In
     /// this case, the server would create a proxy using an already established connection from the client.
     ///
-    /// - parameter _: `Identity` The identity for which a proxy is to be created.
+    /// - parameter id: `Identity` The identity for which a proxy is to be created.
     ///
     /// - returns: `ObjectPrx` - A proxy that matches the given identity and uses this connection.
     func createProxy(_ id: Identity) throws -> ObjectPrx
@@ -100,7 +100,7 @@ public protocol Connection: AnyObject, CustomStringConvertible {
     /// The default object adapter of an incoming connection is the object adapter that created this connection;
     /// the default object adapter of an outgoing connection is the communicator's default object adapter.
     ///
-    /// - parameter _: `ObjectAdapter?` The object adapter to associate with the connection.
+    /// - parameter adapter: `ObjectAdapter?` The object adapter to associate with the connection.
     func setAdapter(_ adapter: ObjectAdapter?) throws
 
     /// Gets the object adapter associated with this connection.
@@ -116,7 +116,7 @@ public protocol Connection: AnyObject, CustomStringConvertible {
     /// Flush any pending batch requests for this connection. This means all batch requests invoked on fixed proxies
     /// associated with the connection.
     ///
-    /// - parameter _: `CompressBatch` Specifies whether or not the queued batch requests should be compressed before
+    /// - parameter compress: `CompressBatch` Specifies whether or not the queued batch requests should be compressed before
     /// being sent over the wire.
     func flushBatchRequests(
         _ compress: CompressBatch
@@ -126,7 +126,7 @@ public protocol Connection: AnyObject, CustomStringConvertible {
     /// is called from the Ice thread pool associated with the connection. If the callback needs more information about
     /// the closure, it can call Connection.throwException.
     ///
-    /// - parameter _: `CloseCallback?` The close callback object.
+    /// - parameter callback: `CloseCallback?` The close callback object.
     func setCloseCallback(_ callback: CloseCallback?) throws
 
     /// Return the connection type. This corresponds to the endpoint type, i.e., "tcp", "udp", etc.

--- a/swift/src/Ice/EndpointSelectionType.swift
+++ b/swift/src/Ice/EndpointSelectionType.swift
@@ -43,16 +43,16 @@ extension InputStream {
 extension OutputStream {
     /// Writes an enumerated value to the stream.
     ///
-    /// parameter v: `EndpointSelectionType` - The enumerator to write.
-    public func write(_ v: EndpointSelectionType) {
-        write(enum: v.rawValue, maxValue: 1)
+    /// - parameter value: `EndpointSelectionType` - The enumerator to write.
+    public func write(_ value: EndpointSelectionType) {
+        write(enum: value.rawValue, maxValue: 1)
     }
 
     /// Writes an optional enumerated value to the stream.
     ///
-    /// parameter tag: `Int32` - The numeric tag associated with the value.
+    /// - parameter tag: `Int32` - The numeric tag associated with the value.
     ///
-    /// parameter value: `EndpointSelectionType` - The enumerator to write.
+    /// - parameter value: `EndpointSelectionType` - The enumerator to write.
     public func write(tag: Int32, value: EndpointSelectionType?) {
         guard let v = value else {
             return

--- a/swift/src/Ice/EndpointSelectionType.swift
+++ b/swift/src/Ice/EndpointSelectionType.swift
@@ -43,7 +43,7 @@ extension InputStream {
 extension OutputStream {
     /// Writes an enumerated value to the stream.
     ///
-    /// parameter _: `EndpointSelectionType` - The enumerator to write.
+    /// parameter v: `EndpointSelectionType` - The enumerator to write.
     public func write(_ v: EndpointSelectionType) {
         write(enum: v.rawValue, maxValue: 1)
     }
@@ -52,7 +52,7 @@ extension OutputStream {
     ///
     /// parameter tag: `Int32` - The numeric tag associated with the value.
     ///
-    /// parameter _: `EndpointSelectionType` - The enumerator to write.
+    /// parameter value: `EndpointSelectionType` - The enumerator to write.
     public func write(tag: Int32, value: EndpointSelectionType?) {
         guard let v = value else {
             return

--- a/swift/src/Ice/ImplicitContext.swift
+++ b/swift/src/Ice/ImplicitContext.swift
@@ -25,12 +25,12 @@ public protocol ImplicitContext: AnyObject {
 
     /// Set the underlying context.
     ///
-    /// - parameter _: `Context` The new context.
+    /// - parameter newContext: `Context` The new context.
     func setContext(_ newContext: Context)
 
     /// Check if this key has an associated value in the underlying context.
     ///
-    /// - parameter _: `String` The key.
+    /// - parameter key: `String` The key.
     ///
     /// - returns: `Bool` - True if the key has an associated value, False otherwise.
     func containsKey(_ key: String) -> Bool
@@ -39,7 +39,7 @@ public protocol ImplicitContext: AnyObject {
     /// associated with the key. containsKey allows you to distinguish between an empty-string value and no
     /// value at all.
     ///
-    /// - parameter _: `String` The key.
+    /// - parameter key: `String` The key.
     ///
     /// - returns: `String` - The value associated with the key.
     func get(_ key: String) -> String
@@ -55,7 +55,7 @@ public protocol ImplicitContext: AnyObject {
 
     /// Remove the entry for the given key in the underlying context.
     ///
-    /// - parameter _: `String` The key.
+    /// - parameter key: `String` The key.
     ///
     /// - returns: `String` - The value associated with the key, if any.
     func remove(_ key: String) -> String

--- a/swift/src/Ice/Initialize.swift
+++ b/swift/src/Ice/Initialize.swift
@@ -21,7 +21,7 @@ let factoriesRegistered: Bool = {
 
 /// Creates a communicator.
 ///
-/// - parameter _: `[String]` - A command-line argument vector. Any Ice-related options
+/// - parameter args: `[String]` - A command-line argument vector. Any Ice-related options
 ///   in this vector are used to initialize the communicator.
 ///
 /// - parameter initData: `Ice.InitializationData` - Additional initialization data. Property
@@ -36,7 +36,7 @@ public func initialize(_ args: [String], initData: InitializationData? = nil) th
 
 /// Creates a communicator.
 ///
-/// - parameter _: `[String]` - A command-line argument vector. Any Ice-related options
+/// - parameter args: `[String]` - A command-line argument vector. Any Ice-related options
 ///   in this vector are used to initialize the communicator. This method modifies the
 ///   argument vector by removing any Ice-related options.
 ///
@@ -90,7 +90,7 @@ public func initialize(args: inout [String], configFile: String) throws -> Commu
 
 /// Creates a communicator.
 ///
-/// - parameter _: `Ice.InitializationData` - Additional initialization data.
+/// - parameter initData: `Ice.InitializationData` - Additional initialization data.
 ///
 /// - returns: `Ice.Communicator` - The initialized communicator.
 public func initialize(_ initData: InitializationData? = nil) throws -> Communicator {
@@ -102,7 +102,7 @@ public func initialize(_ initData: InitializationData? = nil) throws -> Communic
 
 /// Creates a communicator.
 ///
-/// - parameter _: `String` - Path to a config file that sets the new communicator's default
+/// - parameter configFile: `String` - Path to a config file that sets the new communicator's default
 ///   properties.
 ///
 /// - returns: `Ice.Communicator` - The initialized communicator.
@@ -201,7 +201,7 @@ public func createProperties() -> Properties {
 
 /// Creates a property set initialized from an argument array.
 ///
-/// - parameter _: `[String]` - A command-line argument array, possibly containing options to
+/// - parameter args: `[String]` - A command-line argument array, possibly containing options to
 ///   set properties. If the command-line options include a `--Ice.Config` option, the
 ///   corresponding configuration files are parsed. If the same property is set in a configuration
 ///   file and in the argument array, the argument array takes precedence.
@@ -226,7 +226,7 @@ public func createProperties(_ args: [String], defaults: Properties? = nil) thro
 
 /// Creates a property set initialized from an argument array.
 ///
-/// - parameter _: `[String]` - A command-line argument array, possibly containing options to
+/// - parameter args: `[String]` - A command-line argument array, possibly containing options to
 ///   set properties. If the command-line options include a `--Ice.Config` option, the
 ///   corresponding configuration files are parsed. If the same property is set in a configuration
 ///   file and in the argument array, the argument array takes precedence. This method modifies the
@@ -274,7 +274,7 @@ public let currentEncoding = Encoding_1_1
 
 /// Converts a string to an object identity.
 ///
-/// - parameter _: `String` - The string to convert.
+/// - parameter string: `String` - The string to convert.
 ///
 /// - returns: `Ice.Identity` - The converted object identity.
 public func stringToIdentity(_ string: String) throws -> Identity {
@@ -304,7 +304,7 @@ public func identityToString(id: Identity, mode: ToStringMode = ToStringMode.Uni
 
 /// Converts an encoding version to a string.
 ///
-/// - parameter _: `Ice.EncodingVersion` - The encoding version to convert.
+/// - parameter encoding: `Ice.EncodingVersion` - The encoding version to convert.
 ///
 /// - returns: `String` - The converted string.
 public func encodingVersionToString(_ encoding: EncodingVersion) -> String {

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -281,7 +281,7 @@ public class InputStream {
 
     /// Skips the given number of bytes.
     ///
-    /// - parameter _: `Int` - The number of bytes to skip.
+    /// - parameter count: `Int` - The number of bytes to skip.
     public func skip(_ count: Int) throws {
         precondition(count >= 0, "skip count is negative")
         try changePos(offset: count)
@@ -289,7 +289,7 @@ public class InputStream {
 
     /// Skips the given number of bytes.
     ///
-    /// - parameter _: `Int32` - The number of bytes to skip.
+    /// - parameter count: `Int32` - The number of bytes to skip.
     public func skip(_ count: Int32) throws {
         try changePos(offset: Int(count))
     }
@@ -324,9 +324,6 @@ public class InputStream {
     }
 
     /// Marks the end of a user exception.
-    ///
-    /// - returns: `Ice.SlicedData?` - A `SlicedData` object containing the preserved slices for unknown
-    ///   types.
     public func endException() throws {
         precondition(encaps.decoder != nil)
         _ = try encaps.decoder.endInstance()
@@ -794,6 +791,8 @@ extension InputStream {
     /// Reads an optional base proxy from the stream.
     ///
     /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
+    ///
+    /// - parameter type: `ObjectPrx.Protocol` - The proxy type.
     ///
     /// - returns: `ObjectPrx?` - The proxy read from the stream.
     public func read(tag: Int32, type _: ObjectPrx.Protocol) throws -> ObjectPrx? {

--- a/swift/src/Ice/LocalExceptions.swift
+++ b/swift/src/Ice/LocalExceptions.swift
@@ -89,7 +89,6 @@ public final class ObjectNotExistException: RequestFailedException {
     ///   - id: The identity of the target Ice object carried by the request.
     ///   - facet: The facet of the target Ice object.
     ///   - operation: The operation name carried by the request.
-    ///   - message: The exception message.
     ///   - file: The file where the exception was thrown.
     ///   - line: The line where the exception was thrown.
     public convenience init(
@@ -116,7 +115,6 @@ public final class FacetNotExistException: RequestFailedException {
     ///   - id: The identity of the target Ice object carried by the request.
     ///   - facet: The facet of the target Ice object.
     ///   - operation: The operation name carried by the request.
-    ///   - message: The exception message.
     ///   - file: The file where the exception was thrown.
     ///   - line: The line where the exception was thrown.
     public convenience init(
@@ -144,7 +142,6 @@ public final class OperationNotExistException: RequestFailedException {
     ///   - id: The identity of the target Ice object carried by the request.
     ///   - facet: The facet of the target Ice object.
     ///   - operation: The operation name carried by the request.
-    ///   - message: The exception message.
     ///   - file: The file where the exception was thrown.
     ///   - line: The line where the exception was thrown.
     public convenience init(

--- a/swift/src/Ice/Logger.swift
+++ b/swift/src/Ice/Logger.swift
@@ -8,7 +8,7 @@ public protocol Logger: AnyObject {
     /// Print a message. The message is printed literally, without any decorations such as executable name or time
     /// stamp.
     ///
-    /// - parameter _: `String` The message to log.
+    /// - parameter message: `String` The message to log.
     func print(_ message: String)
 
     /// Log a trace message.
@@ -20,12 +20,12 @@ public protocol Logger: AnyObject {
 
     /// Log a warning message.
     ///
-    /// - parameter _: `String` The warning message to log.
+    /// - parameter message: `String` The warning message to log.
     func warning(_ message: String)
 
     /// Log an error message.
     ///
-    /// - parameter _: `String` The error message to log.
+    /// - parameter message: `String` The error message to log.
     func error(_ message: String)
 
     /// Returns this logger's prefix.
@@ -35,7 +35,7 @@ public protocol Logger: AnyObject {
 
     /// Returns a clone of the logger with a new prefix.
     ///
-    /// - parameter _: `String` The new prefix for the logger.
+    /// - parameter prefix: `String` The new prefix for the logger.
     ///
     /// - returns: `Logger` - A logger instance.
     func cloneWithPrefix(_ prefix: String) -> Logger

--- a/swift/src/Ice/Object.swift
+++ b/swift/src/Ice/Object.swift
@@ -29,7 +29,7 @@ public protocol Object {
 
     /// Tests whether this object supports a specific Slice interface.
     ///
-    /// - parameter s: `String` - The type ID of the Slice interface to test against.
+    /// - parameter id: `String` - The type ID of the Slice interface to test against.
     ///
     /// - parameter current: `Ice.Current` - The Current object for the dispatch.
     ///

--- a/swift/src/Ice/ObjectAdapter.swift
+++ b/swift/src/Ice/ObjectAdapter.swift
@@ -96,7 +96,7 @@ public protocol ObjectAdapter: AnyObject {
     /// identity. Note that the generated UUID identity can be accessed using the proxy's ice_getIdentity
     /// operation.
     ///
-    /// - parameter _: `Dispatcher` The servant to add.
+    /// - parameter servant: `Dispatcher` The servant to add.
     ///
     /// - returns: `ObjectPrx` - A proxy that matches the generated UUID identity and this object adapter.
     @discardableResult
@@ -134,7 +134,7 @@ public protocol ObjectAdapter: AnyObject {
 
     /// Remove a servant (that is, the default facet) from the object adapter's Active Servant Map.
     ///
-    /// - parameter _: `Identity` The identity of the Ice object that is implemented by the servant. If the servant
+    /// - parameter id: `Identity` The identity of the Ice object that is implemented by the servant. If the servant
     /// implements multiple Ice objects, remove has to be called for all those Ice objects. Removing an identity
     /// that is not in the map throws NotRegisteredException.
     ///
@@ -157,7 +157,7 @@ public protocol ObjectAdapter: AnyObject {
     /// object, including its default facet. Removing an identity that is not in the map throws
     /// NotRegisteredException.
     ///
-    /// - parameter _: `Identity` The identity of the Ice object to be removed.
+    /// - parameter id: `Identity` The identity of the Ice object to be removed.
     ///
     /// - returns: `FacetMap` - A collection containing all the facet names and servants of the removed Ice object.
     @discardableResult
@@ -166,7 +166,7 @@ public protocol ObjectAdapter: AnyObject {
     /// Remove the default servant for a specific category. Attempting to remove a default servant for a category that
     /// is not registered throws NotRegisteredException.
     ///
-    /// - parameter _: `String` The category of the default servant to remove.
+    /// - parameter category: `String` The category of the default servant to remove.
     ///
     /// - returns: `Dispatcher` - The default servant.
     @discardableResult
@@ -176,7 +176,7 @@ public protocol ObjectAdapter: AnyObject {
     /// This operation only tries to look up a servant in the Active Servant Map. It does not attempt
     /// to find a servant by using any installed ServantLocator.
     ///
-    /// - parameter _: `Identity` The identity of the Ice object for which the servant should be returned.
+    /// - parameter id: `Identity` The identity of the Ice object for which the servant should be returned.
     ///
     /// - returns: `Dispatcher?` - The servant that implements the Ice object with the given identity, or null if no such
     /// servant has been found.
@@ -195,7 +195,7 @@ public protocol ObjectAdapter: AnyObject {
 
     /// Find all facets with the given identity in the Active Servant Map.
     ///
-    /// - parameter _: `Identity` The identity of the Ice object for which the facets should be returned.
+    /// - parameter id: `Identity` The identity of the Ice object for which the facets should be returned.
     ///
     /// - returns: `FacetMap` - A collection containing all the facet names and servants that have been found, or an
     /// empty map if there is no facet for the given identity.
@@ -205,7 +205,7 @@ public protocol ObjectAdapter: AnyObject {
     /// This operation only tries to lookup a servant in the Active Servant Map. It does not attempt to
     /// find a servant by using any installed ServantLocator.
     ///
-    /// - parameter _: `ObjectPrx` The proxy for which the servant should be returned.
+    /// - parameter proxy: `ObjectPrx` The proxy for which the servant should be returned.
     ///
     /// - returns: `Dispatcher?` - The servant that matches the proxy, or null if no such servant has been found.
     func findByProxy(_ proxy: ObjectPrx) -> Dispatcher?
@@ -235,7 +235,7 @@ public protocol ObjectAdapter: AnyObject {
 
     /// Remove a Servant Locator from this object adapter.
     ///
-    /// - parameter _: `String` The category for which the Servant Locator can locate servants, or an empty
+    /// - parameter category: `String` The category for which the Servant Locator can locate servants, or an empty
     /// string if the Servant Locator does not belong to any specific category.
     ///
     /// - returns: `ServantLocator` - The Servant Locator, or throws NotRegisteredException if no Servant Locator was
@@ -245,7 +245,7 @@ public protocol ObjectAdapter: AnyObject {
 
     /// Find a Servant Locator installed with this object adapter.
     ///
-    /// - parameter _: `String` The category for which the Servant Locator can locate servants, or an empty
+    /// - parameter category: `String` The category for which the Servant Locator can locate servants, or an empty
     /// string if the Servant Locator does not belong to any specific category.
     ///
     /// - returns: `ServantLocator?` - The Servant Locator, or null if no Servant Locator was found for the given
@@ -254,7 +254,7 @@ public protocol ObjectAdapter: AnyObject {
 
     /// Find the default servant for a specific category.
     ///
-    /// - parameter _: `String` The category of the default servant to find.
+    /// - parameter category: `String` The category of the default servant to find.
     ///
     /// - returns: `Dispatcher?` - The default servant or null if no default servant was registered for the category.
     func findDefaultServant(_ category: String) -> Dispatcher?
@@ -264,7 +264,7 @@ public protocol ObjectAdapter: AnyObject {
     /// return value is an indirect proxy that refers to the replica group id. Otherwise, if no adapter id is defined,
     /// the return value is a direct proxy containing this object adapter's published endpoints.
     ///
-    /// - parameter _: `Identity` The object's identity.
+    /// - parameter id: `Identity` The object's identity.
     ///
     /// - returns: `ObjectPrx` - A proxy for the object with the given identity.
     func createProxy(_ id: Identity) throws -> ObjectPrx
@@ -272,7 +272,7 @@ public protocol ObjectAdapter: AnyObject {
     /// Create a direct proxy for the object with the given identity. The returned proxy contains this object adapter's
     /// published endpoints.
     ///
-    /// - parameter _: `Identity` The object's identity.
+    /// - parameter id: `Identity` The object's identity.
     ///
     /// - returns: `ObjectPrx` - A proxy for the object with the given identity.
     func createDirectProxy(_ id: Identity) throws -> ObjectPrx
@@ -281,7 +281,7 @@ public protocol ObjectAdapter: AnyObject {
     /// adapter id, the return value refers to the adapter id. Otherwise, the return value contains only the object
     /// identity.
     ///
-    /// - parameter _: `Identity` The object's identity.
+    /// - parameter id: `Identity` The object's identity.
     ///
     /// - returns: `ObjectPrx` - A proxy for the object with the given identity.
     func createIndirectProxy(_ id: Identity) throws -> ObjectPrx
@@ -291,7 +291,7 @@ public protocol ObjectAdapter: AnyObject {
     /// adapter will contain the adapter identifier instead of its endpoints. The adapter identifier must be configured
     /// using the AdapterId property.
     ///
-    /// - parameter _: `LocatorPrx?` The locator used by this object adapter.
+    /// - parameter loc: `LocatorPrx?` The locator used by this object adapter.
     func setLocator(_ loc: LocatorPrx?) throws
 
     /// Get the Ice locator used by this object adapter.
@@ -312,6 +312,6 @@ public protocol ObjectAdapter: AnyObject {
 
     /// Set of the endpoints that proxies created by this object adapter will contain.
     ///
-    /// - parameter _: `EndpointSeq` The new set of endpoints that the object adapter will embed in proxies.
+    /// - parameter newEndpoints: `EndpointSeq` The new set of endpoints that the object adapter will embed in proxies.
     func setPublishedEndpoints(_ newEndpoints: EndpointSeq) throws
 }

--- a/swift/src/Ice/OutputStream.swift
+++ b/swift/src/Ice/OutputStream.swift
@@ -74,7 +74,7 @@ public final class OutputStream {
 
     /// Writes a pre-encoded encapsulation.
     ///
-    /// - parameter _: `Data` - The encapsulation data.
+    /// - parameter v: `Data` - The encapsulation data.
     func writeEncapsulation(_ v: Data) {
         precondition(v.count >= 6, "Encapsulation is invalid. Size is too small.")
         data.append(v)
@@ -181,7 +181,7 @@ public final class OutputStream {
 extension OutputStream {
     /// Writes a numeric value to the stream.
     ///
-    /// - parameter _: `Element` - The numeric value to write.
+    /// - parameter v: `Element` - The numeric value to write.
     public func write<Element>(_ v: Element) where Element: StreamableNumeric {
         // We assume a little-endian platform
         withUnsafePointer(to: v) { ptr in
@@ -205,7 +205,7 @@ extension OutputStream {
 
     /// Writes a sequence of numeric values to the stream.
     ///
-    /// - parameter _: `[Element]` - The sequence of numeric values.
+    /// - parameter v: `[Element]` - The sequence of numeric values.
     public func write<Element>(_ v: [Element]) where Element: StreamableNumeric {
         write(size: v.count)
 
@@ -239,14 +239,14 @@ extension OutputStream {
 
     /// Writes a byte to the stream.
     ///
-    /// - parameter _: `UInt8` - The byte to write.
+    /// - parameter v: `UInt8` - The byte to write.
     public func write(_ v: UInt8) {
         data.append(v)
     }
 
     /// Writes bytes to the stream.
     ///
-    /// - parameter _: `[UInt8]` - The bytes to write.
+    /// - parameter v: `[UInt8]` - The bytes to write.
     public func writeBlob(_ v: [UInt8]) {
         if v.count > 0 {
             data.append(contentsOf: v)
@@ -255,7 +255,7 @@ extension OutputStream {
 
     /// Writes a sequence of bytes to the stream (including the size).
     ///
-    /// - parameter _: `[UInt8]` - The sequence of bytes to write.
+    /// - parameter v: `[UInt8]` - The sequence of bytes to write.
     public func write(_ v: [UInt8]) {
         write(size: v.count)
         if v.count > 0 {
@@ -265,7 +265,7 @@ extension OutputStream {
 
     /// Writes a sequence of bytes to the stream (including the size).
     ///
-    /// - parameter _: `Data` - The sequence of bytes to write.
+    /// - parameter v: `Data` - The sequence of bytes to write.
     public func write(_ v: Data) {
         write(size: v.count)
         if v.count > 0 {
@@ -289,7 +289,7 @@ extension OutputStream {
 
     /// Writes a boolean value to the stream.
     ///
-    /// - parameter _: `Bool` - The boolean value to write.
+    /// - parameter v: `Bool` - The boolean value to write.
     public func write(_ v: Bool) {
         write(UInt8(v == true ? 1 : 0))
     }
@@ -309,7 +309,7 @@ extension OutputStream {
 
     /// Writes a sequence of boolean values to the stream.
     ///
-    /// - parameter _: `[Bool]` - The sequence of boolean values to write.
+    /// - parameter v: `[Bool]` - The sequence of boolean values to write.
     public func write(_ v: [Bool]) {
         write(size: v.count)
         if MemoryLayout<Bool>.size == 1, MemoryLayout<Bool>.stride == 1 {
@@ -435,7 +435,7 @@ extension OutputStream {
 
     /// Writes a string to the stream.
     ///
-    /// - parameter _: `String` - The string to write.
+    /// - parameter v: `String` - The string to write.
     public func write(_ v: String) {
         let bytes = v.data(using: .utf8)!
         write(size: bytes.count)
@@ -446,7 +446,7 @@ extension OutputStream {
     ///
     /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
     ///
-    /// - parameter value: `String?` - The string to write.
+    /// - parameter v: `String?` - The string to write.
     public func write(tag: Int32, value v: String?) {
         if let val = v {
             if writeOptional(tag: tag, format: .VSize) {
@@ -457,7 +457,7 @@ extension OutputStream {
 
     /// Writes a sequence of strings to the stream.
     ///
-    /// - parameter _: `String` - The sequence of strings to write.
+    /// - parameter v: `String` - The sequence of strings to write.
     public func write(_ v: [String]) {
         write(size: v.count)
         for s in v {
@@ -469,7 +469,7 @@ extension OutputStream {
     ///
     /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
     ///
-    /// - parameter value: `[String]?` - The sequence of strings to write.
+    /// - parameter v: `[String]?` - The sequence of strings to write.
     public func write(tag: Int32, value v: [String]?) {
         if let val = v {
             if writeOptional(tag: tag, format: .FSize) {
@@ -482,7 +482,7 @@ extension OutputStream {
 
     /// Writes a proxy to the stream.
     ///
-    /// - parameter _: `ObjectPrx?` - The proxy to write.
+    /// - parameter v: `ObjectPrx?` - The proxy to write.
     public func write(_ v: ObjectPrx?) {
         if let prxImpl = v as? ObjectPrxI {
             prxImpl.ice_write(to: self)
@@ -498,7 +498,7 @@ extension OutputStream {
     ///
     /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
     ///
-    /// - parameter value: `ObjectPrx?` - The proxy to write.
+    /// - parameter v: `ObjectPrx?` - The proxy to write.
     public func write(tag: Int32, value v: ObjectPrx?) {
         if let val = v {
             if writeOptional(tag: tag, format: .FSize) {
@@ -511,7 +511,7 @@ extension OutputStream {
 
     /// Writes a value to the stream.
     ///
-    /// - parameter _: `Value?` - The value to write.
+    /// - parameter v: `Value?` - The value to write.
     public func write(_ v: Value?) {
         initEncaps()
         encaps.encoder.writeValue(v: v)
@@ -519,7 +519,7 @@ extension OutputStream {
 
     /// Writes a user exception to the stream.
     ///
-    /// - parameter _: `UserException` - The user exception to write.
+    /// - parameter v: `UserException` - The user exception to write.
     public func write(_ v: UserException) {
         initEncaps()
         // Exceptions are always encoded with the sliced format.

--- a/swift/src/Ice/Properties.swift
+++ b/swift/src/Ice/Properties.swift
@@ -8,7 +8,7 @@ import Foundation
 public protocol Properties: AnyObject {
     /// Get a property by key. If the property is not set, an empty string is returned.
     ///
-    /// - parameter _: `String` The property key.
+    /// - parameter key: `String` The property key.
     ///
     /// - returns: `String` - The property value.
     func getProperty(_ key: String) -> String
@@ -32,7 +32,7 @@ public protocol Properties: AnyObject {
     /// Get a property as an integer. If the property is not set, 0 is returned.
     /// Throws PropertyException if the property value is not a valid integer.
     ///
-    /// - parameter _: `String` The property key.
+    /// - parameter key: `String` The property key.
     ///
     /// - returns: `Int32` - The property value interpreted as an integer.
     func getPropertyAsInt(_ key: String) throws -> Int32
@@ -61,7 +61,7 @@ public protocol Properties: AnyObject {
     /// or double quotes, you can escape the quote in question with a backslash, e.g. O'Reilly can be written as
     /// O'Reilly, "O'Reilly" or 'O\'Reilly'.
     ///
-    /// - parameter _: `String` The property key.
+    /// - parameter key: `String` The property key.
     ///
     /// - returns: `StringSeq` - The property value interpreted as a list of strings.
     func getPropertyAsList(_ key: String) -> StringSeq
@@ -93,7 +93,7 @@ public protocol Properties: AnyObject {
     /// Get all properties whose keys begins with prefix. If prefix is an empty string, then all
     /// properties are returned.
     ///
-    /// - parameter _: `String` The prefix to search for (empty string if none).
+    /// - parameter prefix: `String` The prefix to search for (empty string if none).
     ///
     /// - returns: `PropertyDict` - The matching property set.
     func getPropertiesForPrefix(_ prefix: String) -> PropertyDict
@@ -128,7 +128,7 @@ public protocol Properties: AnyObject {
     /// prefixes are converted into properties: --Ice, --IceBox, --IceGrid,
     /// --IceSSL, --IceStorm, and --Glacier2.
     ///
-    /// - parameter _: `StringSeq` The command-line options.
+    /// - parameter options: `StringSeq` The command-line options.
     ///
     /// - returns: `StringSeq` - The command-line options that do not start with one of the listed prefixes,
     /// in their original order.
@@ -136,7 +136,7 @@ public protocol Properties: AnyObject {
 
     /// Load properties from a file.
     ///
-    /// - parameter _: `String` The property file.
+    /// - parameter file: `String` The property file.
     func load(_ file: String) throws
 
     /// Create a copy of this property set.

--- a/swift/src/Ice/Proxy.swift
+++ b/swift/src/Ice/Proxy.swift
@@ -17,7 +17,7 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject {
 
     /// Creates a new proxy that is identical to this proxy, except for the identity.
     ///
-    /// - parameter _: `Ice.Identity` - The identity for the new proxy.
+    /// - parameter id: `Ice.Identity` - The identity for the new proxy.
     ///
     /// - returns: A proxy with the new identity.
     func ice_identity(_ id: Identity) -> Self
@@ -29,7 +29,7 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject {
 
     /// Creates a new proxy that is identical to this proxy, except for the per-proxy context.
     ///
-    /// - parameter newContext: `Ice.Context` - The context for the new proxy.
+    /// - parameter context: `Ice.Context` - The context for the new proxy.
     ///
     /// - returns: The proxy with the new per-proxy context.
     func ice_context(_ context: Context) -> Self
@@ -42,7 +42,7 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject {
 
     /// Creates a new proxy that is identical to this proxy, except for the facet.
     ///
-    /// - parameter _: `String` - The facet for the new proxy.
+    /// - parameter facet: `String` - The facet for the new proxy.
     ///
     /// - returns: `Ice.ObjectPrx` - The proxy with the new facet.
     func ice_facet(_ facet: String) -> ObjectPrx
@@ -55,7 +55,7 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject {
 
     /// Creates a new proxy that is identical to this proxy, except for the adapter ID.
     ///
-    /// - parameter _: `String` - The adapter ID for the new proxy.
+    /// - parameter id: `String` - The adapter ID for the new proxy.
     ///
     /// - returns: The proxy with the new adapter ID.
     func ice_adapterId(_ id: String) -> Self
@@ -67,7 +67,7 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject {
 
     /// Creates a new proxy that is identical to this proxy, except for the endpoints.
     ///
-    /// - parameter _: `EndpointSeq` - The endpoints for the new proxy.
+    /// - parameter endpoints: `EndpointSeq` - The endpoints for the new proxy.
     ///
     /// - returns: The proxy with the new endpoints.
     func ice_endpoints(_ endpoints: EndpointSeq) -> Self
@@ -79,7 +79,7 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject {
 
     /// Creates a new proxy that is identical to this proxy, except for the locator cache timeout.
     ///
-    /// - parameter _: `Int32` - The new locator cache timeout (in seconds).
+    /// - parameter timeout: `Int32` - The new locator cache timeout (in seconds).
     ///
     /// - returns: A new proxy with the specified cache timeout.
     func ice_locatorCacheTimeout(_ timeout: Int32) -> Self
@@ -91,7 +91,7 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject {
 
     /// Creates a new proxy that is identical to this proxy, except for the invocation timeout.
     ///
-    /// - parameter _: `Int32` - The new invocation timeout (in seconds).
+    /// - parameter timeout: `Int32` - The new invocation timeout (in seconds).
     ///
     /// - returns: A new proxy with the specified invocation timeout.
     func ice_invocationTimeout(_ timeout: Int32) -> Self
@@ -103,7 +103,7 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject {
 
     /// Creates a new proxy that is identical to this proxy, except for its connection ID.
     ///
-    /// - parameter _: `String` - The connection ID for the new proxy. An empty string removes the
+    /// - parameter id: `String` - The connection ID for the new proxy. An empty string removes the
     ///   connection ID.
     ///
     /// - returns: A new proxy with the specified connection ID.
@@ -116,7 +116,7 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject {
 
     /// Creates a new proxy that is identical to this proxy, except for connection caching.
     ///
-    /// - parameter _: `Bool` - True if the new proxy should cache connections; false, otherwise.
+    /// - parameter cached: `Bool` - True if the new proxy should cache connections; false, otherwise.
     ///
     /// - returns: The new proxy with the specified caching policy.
     func ice_connectionCached(_ cached: Bool) -> Self
@@ -128,7 +128,7 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject {
 
     /// Creates a new proxy that is identical to this proxy, except for the endpoint selection policy.
     ///
-    /// - parameter _: `Ice.EndpointSelectionType` - The new endpoint selection policy.
+    /// - parameter type: `Ice.EndpointSelectionType` - The new endpoint selection policy.
     ///
     /// - returns: The new proxy with the specified endpoint selection policy.
     func ice_endpointSelection(_ type: EndpointSelectionType) -> Self
@@ -141,7 +141,7 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject {
     /// Creates a new proxy that is identical to this proxy, except for the encoding used to marshal
     /// parameters.
     ///
-    /// - parameter _: `Ice.EncodingVersion` - The encoding version to use to marshal requests parameters.
+    /// - parameter encoding: `Ice.EncodingVersion` - The encoding version to use to marshal requests parameters.
     ///
     /// - returns: The new proxy with the specified encoding version.
     func ice_encodingVersion(_ encoding: EncodingVersion) -> Self
@@ -167,7 +167,7 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject {
 
     /// Creates a new proxy that is identical to this proxy, except for the locator.
     ///
-    /// - parameter _: `Ice.LocatorPrx` The locator for the new proxy.
+    /// - parameter locator: `Ice.LocatorPrx` The locator for the new proxy.
     ///
     /// - returns: The new proxy with the specified locator.
     func ice_locator(_ locator: LocatorPrx?) -> Self
@@ -179,7 +179,7 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject {
 
     /// Creates a new proxy that is identical to this proxy, except for how it selects endpoints.
     ///
-    /// - parameter _: `Bool` - If true only endpoints that use a secure transport are used by the new proxy.
+    /// - parameter secure: `Bool` - If true only endpoints that use a secure transport are used by the new proxy.
     ///   otherwise the returned proxy uses both secure and insecure endpoints.
     ///
     /// - returns: The new proxy with the specified selection policy.
@@ -193,7 +193,7 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject {
 
     /// Creates a new proxy that is identical to this proxy, except for its endpoint selection policy.
     ///
-    /// - parameter _: `Bool` - If true, the new proxy will use secure endpoints for invocations
+    /// - parameter preferSecure: `Bool` - If true, the new proxy will use secure endpoints for invocations
     ///   and only use insecure endpoints if an invocation cannot be made via secure endpoints. Otherwise
     ///   the proxy prefers insecure endpoints to secure ones.
     ///
@@ -258,7 +258,7 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject {
 
     /// Creates a new proxy that is identical to this proxy, except for compression.
     ///
-    /// - parameter _: `Bool` - True enables compression for the new proxy; false disables compression.
+    /// - parameter compress: `Bool` - True enables compression for the new proxy; false disables compression.
     ///
     /// - returns: A new proxy with the specified compression setting.
     func ice_compress(_ compress: Bool) -> Self
@@ -266,7 +266,7 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject {
     /// Returns a proxy that is identical to this proxy, except it's a fixed proxy bound
     /// to the given connection.
     ///
-    /// - parameter _: `Ice.Connection` - The fixed proxy connection.
+    /// - parameter connection: `Ice.Connection` - The fixed proxy connection.
     ///
     /// - returns: A fixed proxy bound to the given connection.
     func ice_fixed(_ connection: Connection) -> Self
@@ -295,7 +295,7 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject {
 
     /// Creates a new proxy that is identical to this proxy, except for collocation optimization.
     ///
-    /// - parameter _: `Bool` - True if the new proxy enables collocation optimization; false, otherwise.
+    /// - parameter collocated: `Bool` - True if the new proxy enables collocation optimization; false, otherwise.
     ///
     /// - returns: The new proxy the specified collocation optimization.
     func ice_collocationOptimized(_ collocated: Bool) -> Self

--- a/swift/src/Ice/ServantLocator.swift
+++ b/swift/src/Ice/ServantLocator.swift
@@ -14,7 +14,7 @@ public protocol ServantLocator: AnyObject {
     /// If you call locate from your own code, you must also call finished
     /// when you have finished using the servant, provided that locate returned a non-null servant.
     ///
-    /// - parameter _: `Current` Information about the current operation for which a servant is required.
+    /// - parameter curr: `Current` Information about the current operation for which a servant is required.
     ///
     /// - returns: `(returnValue: Dispatcher?, cookie: AnyObject?)`:
     ///
@@ -52,6 +52,6 @@ public protocol ServantLocator: AnyObject {
 
     /// Called when the object adapter in which this servant locator is installed is destroyed.
     ///
-    /// - parameter _: `String` Indicates for which category the servant locator is being deactivated.
+    /// - parameter category: `String` Indicates for which category the servant locator is being deactivated.
     func deactivate(_ category: String)
 }

--- a/swift/src/Ice/ToStringMode.swift
+++ b/swift/src/Ice/ToStringMode.swift
@@ -54,16 +54,16 @@ extension InputStream {
 extension OutputStream {
     /// Writes an enumerated value to the stream.
     ///
-    /// parameter v: `ToStringMode` - The enumerator to write.
-    public func write(_ v: ToStringMode) {
-        write(enum: v.rawValue, maxValue: 2)
+    /// - parameter value: `ToStringMode` - The enumerator to write.
+    public func write(_ value: ToStringMode) {
+        write(enum: value.rawValue, maxValue: 2)
     }
 
     /// Writes an optional enumerated value to the stream.
     ///
-    /// parameter tag: `Int32` - The numeric tag associated with the value.
+    /// - parameter tag: `Int32` - The numeric tag associated with the value.
     ///
-    /// parameter v: `ToStringMode` - The enumerator to write.
+    /// - parameter value: `ToStringMode` - The enumerator to write.
     public func write(tag: Int32, value: ToStringMode?) {
         guard let v = value else {
             return

--- a/swift/src/Ice/ToStringMode.swift
+++ b/swift/src/Ice/ToStringMode.swift
@@ -54,7 +54,7 @@ extension InputStream {
 extension OutputStream {
     /// Writes an enumerated value to the stream.
     ///
-    /// parameter _: `ToStringMode` - The enumerator to write.
+    /// parameter v: `ToStringMode` - The enumerator to write.
     public func write(_ v: ToStringMode) {
         write(enum: v.rawValue, maxValue: 2)
     }
@@ -63,7 +63,7 @@ extension OutputStream {
     ///
     /// parameter tag: `Int32` - The numeric tag associated with the value.
     ///
-    /// parameter _: `ToStringMode` - The enumerator to write.
+    /// parameter v: `ToStringMode` - The enumerator to write.
     public func write(tag: Int32, value: ToStringMode?) {
         guard let v = value else {
             return

--- a/swift/src/Ice/Util.swift
+++ b/swift/src/Ice/Util.swift
@@ -5,7 +5,7 @@ import IceImpl
 
 /// Converts a string to an encoding version.
 ///
-/// - parameter _: `String` - The string to convert.
+/// - parameter s: `String` - The string to convert.
 ///
 /// - returns: `Ice.EncodingVersion` - The converted encoding version.</returns>
 func stringToEncodingVersion(_ s: String) throws -> EncodingVersion {


### PR DESCRIPTION
This PR fixes various warnings I noticed when reviewing the Swift doc action.  Some were just missing parameters, others were caused by documentation the "external value" of a parameter. For example:

```
warning: External name 'value' used to document parameter
- .build/plugins/outputs/ice/Ice/destination/CompileSlice/BuiltinSequences.swift:71:21-71:26
///
69
70
71 +
/// - Parameter ostr: The stream to write to.
/// - Parameter value: The sequence value to write to the stream. suggestion: Replace 'value' with 'v'
72
73
public static func write(to ostr: OutputStream, value v: ObjectSeq)
ostr.write(size: v.count)
warning: External name 'value' used to document parameter
```

I also updated the `swift-docc-plugin` plugin version to the latest.