### PR TITLE
Slice2py string quotes

### DIFF
--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -186,29 +186,77 @@ namespace
     }
 
     /// Returns a DocString formatted link to the provided Slice identifier.
-    /// TODO: this is temporary and will be replaced when we add 'python:identifier' support.
-    string pyLinkFormatter(const string& rawLink, const ContainedPtr&, const SyntaxTreeBasePtr&)
+    string pyLinkFormatter(const string& rawLink, const ContainedPtr&, const SyntaxTreeBasePtr& target)
     {
-        ostringstream os;
-        os << "`";
-
-        auto hashPos = rawLink.find('#');
-        if (hashPos != string::npos)
+        ostringstream result;
+        if (target)
         {
-            if (hashPos != 0)
+            if (auto builtinTarget = dynamic_pointer_cast<Builtin>(target))
             {
-                os << rawLink.substr(0, hashPos);
-                os << ".";
+                if (builtinTarget->kind() == Builtin::KindObject)
+                {
+                    result << ":class:`Ice.Object`";
+                }
+                else if (builtinTarget->kind() == Builtin::KindValue)
+                {
+                    result << ":class:`Ice.Value`";
+                }
+                else if (builtinTarget->kind() == Builtin::KindObjectProxy)
+                {
+                    result << ":class:`Ice.ObjectPrx`";
+                }
+                else
+                {
+                    result << "``" << typeToDocstring(builtinTarget, false) << "``";
+                }
             }
-            os << rawLink.substr(hashPos + 1);
+            else
+            {
+                if (auto operationTarget = dynamic_pointer_cast<Operation>(target))
+                {
+                    string targetScoped = operationTarget->interface()->mappedScoped(".").substr(1);
+
+                    // link to the method on the proxy interface
+                    result << ":meth:`" << targetScoped << "Prx." << operationTarget->mappedName() << "`";
+                }
+                else
+                {
+                    string targetScoped = dynamic_pointer_cast<Contained>(target)->mappedScoped(".").substr(1);
+                    result << ":class:`";
+                    if (auto interfaceTarget = dynamic_pointer_cast<InterfaceDecl>(target))
+                    {
+                        // link to the proxy interface
+                        result << targetScoped << "Prx";
+                    }
+                    else
+                    {
+                        result << targetScoped;
+                    }
+                    result << "`";
+                }
+            }
         }
         else
         {
-            os << rawLink;
-        }
+            result << "``";
 
-        os << "`";
-        return os.str();
+            auto hashPos = rawLink.find('#');
+            if (hashPos != string::npos)
+            {
+                if (hashPos != 0)
+                {
+                    result << rawLink.substr(0, hashPos) << ".";
+                }
+                result << rawLink.substr(hashPos + 1);
+            }
+            else
+            {
+                result << rawLink;
+            }
+
+            result << "``";
+        }
+        return result.str();
     }
 
     string formatFields(const DataMemberList& members)

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -210,30 +210,23 @@ namespace
                     result << "``" << typeToDocstring(builtinTarget, false) << "``";
                 }
             }
+            else if (auto operationTarget = dynamic_pointer_cast<Operation>(target))
+            {
+                string targetScoped = operationTarget->interface()->mappedScoped(".").substr(1);
+
+                // link to the method on the proxy interface
+                result << ":meth:`" << targetScoped << "Prx." << operationTarget->mappedName() << "`";
+            }
             else
             {
-                if (auto operationTarget = dynamic_pointer_cast<Operation>(target))
+                string targetScoped = dynamic_pointer_cast<Contained>(target)->mappedScoped(".").substr(1);
+                result << ":class:`" << targetScoped;
+                if (auto interfaceTarget = dynamic_pointer_cast<InterfaceDecl>(target))
                 {
-                    string targetScoped = operationTarget->interface()->mappedScoped(".").substr(1);
-
-                    // link to the method on the proxy interface
-                    result << ":meth:`" << targetScoped << "Prx." << operationTarget->mappedName() << "`";
+                    // link to the proxy interface
+                    result << "Prx";
                 }
-                else
-                {
-                    string targetScoped = dynamic_pointer_cast<Contained>(target)->mappedScoped(".").substr(1);
-                    result << ":class:`";
-                    if (auto interfaceTarget = dynamic_pointer_cast<InterfaceDecl>(target))
-                    {
-                        // link to the proxy interface
-                        result << targetScoped << "Prx";
-                    }
-                    else
-                    {
-                        result << targetScoped;
-                    }
-                    result << "`";
-                }
+                result << "`";
             }
         }
         else

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -289,7 +289,7 @@ namespace Slice::Python
     // ModuleVisitor finds all of the Slice modules whose include level is greater
     // than 0 and emits a statement of the following form:
     //
-    // _M_Foo = Ice.openModule('Foo')
+    // _M_Foo = Ice.openModule("Foo")
     //
     // This statement allows the code generated for this translation unit to refer
     // to types residing in those included modules.
@@ -403,7 +403,7 @@ writeModuleHasDefinitionCheck(Output& out, const ContainedPtr& cont, const strin
         scope = package + "." + scope;
     }
 
-    out << sp << nl << "if '" << name << "' not in _M_" << scope << "__dict__:";
+    out << sp << nl << "if \"" << name << "\" not in _M_" << scope << "__dict__:";
 }
 
 //
@@ -435,7 +435,7 @@ Slice::Python::ModuleVisitor::visitModuleStart(const ModulePtr& p)
                         mod = mod.empty() ? q : mod + "." + q;
                         if (_history.count(mod) == 0)
                         {
-                            _out << nl << "_M_" << mod << " = Ice.openModule('" << mod << "')";
+                            _out << nl << "_M_" << mod << " = Ice.openModule(\"" << mod << "\")";
                             _history.insert(mod);
                         }
                     }
@@ -443,7 +443,7 @@ Slice::Python::ModuleVisitor::visitModuleStart(const ModulePtr& p)
             }
 
             _out << sp << nl << "# Included module " << abs;
-            _out << nl << "_M_" << abs << " = Ice.openModule('" << abs << "')";
+            _out << nl << "_M_" << abs << " = Ice.openModule(\"" << abs << "\")";
             _history.insert(abs);
         }
     }
@@ -464,14 +464,14 @@ Slice::Python::CodeVisitor::visitModuleStart(const ModulePtr& p)
     //
     // As each module is opened, we emit the statement
     //
-    // __name__ = 'Foo'
+    // __name__ = "Foo"
     //
     // This renames the current module to 'Foo' so that subsequent
     // type definitions have the proper fully-qualified name.
     //
     // We also emit the statement
     //
-    // _M_Foo = Ice.openModule('Foo')
+    // _M_Foo = Ice.openModule("Foo")
     //
     // This allows us to create types in the module Foo.
     //
@@ -495,16 +495,16 @@ Slice::Python::CodeVisitor::visitModuleStart(const ModulePtr& p)
                     mod = mod.empty() ? q : mod + "." + q;
                     if (_moduleHistory.count(mod) == 0) // Don't emit this more than once for each module.
                     {
-                        _out << nl << "_M_" << mod << " = Ice.openModule('" << mod << "')";
+                        _out << nl << "_M_" << mod << " = Ice.openModule(\"" << mod << "\")";
                         _moduleHistory.insert(mod);
                     }
                 }
             }
         }
-        _out << nl << "_M_" << abs << " = Ice.openModule('" << abs << "')";
+        _out << nl << "_M_" << abs << " = Ice.openModule(\"" << abs << "\")";
         _moduleHistory.insert(abs);
     }
-    _out << nl << "__name__ = '" << abs << "'";
+    _out << nl << "__name__ = \"" << abs << "\"";
 
     writeDocstring(DocComment::parseFrom(p, pyLinkFormatter, true), "_M_" + abs + ".__doc__ = ");
 
@@ -521,7 +521,7 @@ Slice::Python::CodeVisitor::visitModuleEnd(const ModulePtr&)
 
     if (!_moduleStack.empty())
     {
-        _out << sp << nl << "__name__ = '" << _moduleStack.front() << "'";
+        _out << sp << nl << "__name__ = \"" << _moduleStack.front() << "\"";
     }
 }
 
@@ -534,7 +534,7 @@ Slice::Python::CodeVisitor::visitClassDecl(const ClassDeclPtr& p)
     {
         writeModuleHasDefinitionCheck(_out, p, p->mappedName());
         _out.inc();
-        _out << nl << getMetaTypeReference(p) << " = IcePy.declareValue('" << scoped << "')";
+        _out << nl << getMetaTypeReference(p) << " = IcePy.declareValue(\"" << scoped << "\")";
         _out.dec();
         _classHistory.insert(scoped); // Avoid redundant declarations.
     }
@@ -549,7 +549,7 @@ Slice::Python::CodeVisitor::visitInterfaceDecl(const InterfaceDeclPtr& p)
     {
         writeModuleHasDefinitionCheck(_out, p, p->mappedName());
         _out.inc();
-        _out << nl << getMetaTypeReference(p) << "Prx" << " = IcePy.declareProxy('" << scoped << "')";
+        _out << nl << getMetaTypeReference(p) << "Prx" << " = IcePy.declareProxy(\"" << scoped << "\")";
         _out.dec();
         _classHistory.insert(scoped); // Avoid redundant declarations.
     }
@@ -672,7 +672,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     //
     _out << sp << nl << "def ice_id(self):";
     _out.inc();
-    _out << nl << "return '" << scoped << "'";
+    _out << nl << "return \"" << scoped << "\"";
     _out.dec();
 
     //
@@ -681,7 +681,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     _out << sp << nl << "@staticmethod";
     _out << nl << "def ice_staticId():";
     _out.inc();
-    _out << nl << "return '" << scoped << "'";
+    _out << nl << "return \"" << scoped << "\"";
     _out.dec();
 
     // Generate the __repr__ method for this Value class.
@@ -693,7 +693,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     _out.dec();
 
-    _out << sp << nl << type << " = IcePy.defineValue('" << scoped << "', " << valueName << ", " << p->compactId()
+    _out << sp << nl << type << " = IcePy.defineValue(\"" << scoped << "\", " << valueName << ", " << p->compactId()
          << ", ";
     writeMetadata(p->getMetadata());
     _out << ", False, ";
@@ -711,7 +711,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     //
     // Data members are represented as a tuple:
     //
-    //   ('MemberName', MemberMetadata, MemberType, Optional, Tag)
+    //   ("MemberName", MemberMetadata, MemberType, Optional, Tag)
     //
     // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a user-defined type.
     //
@@ -727,8 +727,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
         {
             _out << ',' << nl;
         }
-        _out << "('";
-        _out << (*r)->mappedName() << "', ";
+        _out << "(\"" << (*r)->mappedName() << "\", ";
         writeMetadata((*r)->getMetadata());
         _out << ", ";
         writeType((*r)->type());
@@ -933,12 +932,12 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << sp << nl << "@staticmethod";
     _out << nl << "def ice_staticId():";
     _out.inc();
-    _out << nl << "return '" << scoped << "'";
+    _out << nl << "return \"" << scoped << "\"";
     _out.dec();
 
     _out.dec(); // end prx class
 
-    _out << nl << getMetaTypeReference(p) << "Prx" << " = IcePy.defineProxy('" << scoped << "', " << prxName << ")";
+    _out << nl << getMetaTypeReference(p) << "Prx" << " = IcePy.defineProxy(\"" << scoped << "\", " << prxName << ")";
 
     registerName(prxName);
 
@@ -988,7 +987,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         {
             _out << ", ";
         }
-        _out << "'" << *q << "'";
+        _out << "\"" << *q << "\"";
     }
     _out << ')';
     _out.dec();
@@ -998,7 +997,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     //
     _out << sp << nl << "def ice_id(self, current):";
     _out.inc();
-    _out << nl << "return '" << scoped << "'";
+    _out << nl << "return \"" << scoped << "\"";
     _out.dec();
 
     //
@@ -1007,7 +1006,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << sp << nl << "@staticmethod";
     _out << nl << "def ice_staticId():";
     _out.inc();
-    _out << nl << "return '" << scoped << "'";
+    _out << nl << "return \"" << scoped << "\"";
     _out.dec();
 
     writeOperations(p);
@@ -1017,7 +1016,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     //
     // Define each operation. The arguments to the IcePy.Operation constructor are:
     //
-    // 'sliceOpName', 'mappedOpName', Mode, AMD, Format, Metadata, (InParams), (OutParams), ReturnParam, (Exceptions)
+    // "sliceOpName", "mappedOpName", Mode, AMD, Format, Metadata, (InParams), (OutParams), ReturnParam, (Exceptions)
     //
     // where InParams and OutParams are tuples of type descriptions, and Exceptions
     // is a tuple of exception type ids.
@@ -1026,6 +1025,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     {
         _out << sp;
     }
+
     for (const auto& operation : operations)
     {
         ParameterList params = operation->parameters();
@@ -1054,8 +1054,8 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
         const string sliceName = operation->name();
 
-        _out << nl << className << "._op_" << sliceName << " = IcePy.Operation('" << sliceName << "', '"
-             << operation->mappedName() << "', " << getOperationMode(operation->mode()) << ", " << format << ", ";
+        _out << nl << className << "._op_" << sliceName << " = IcePy.Operation(\"" << sliceName << "\", \""
+             << operation->mappedName() << "\", " << getOperationMode(operation->mode()) << ", " << format << ", ";
         writeMetadata(operation->getMetadata());
         _out << ", (";
         for (t = params.begin(), count = 0; t != params.end(); ++t)
@@ -1217,7 +1217,7 @@ Slice::Python::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     //
     // _ice_id
     //
-    _out << sp << nl << "_ice_id = '" << scoped << "'";
+    _out << sp << nl << "_ice_id = \"" << scoped << "\"";
 
     _out.dec();
 
@@ -1225,7 +1225,7 @@ Slice::Python::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     // Emit the type information.
     //
     string type = getMetaTypeReference(p);
-    _out << sp << nl << type << " = IcePy.defineException('" << scoped << "', " << name << ", ";
+    _out << sp << nl << type << " = IcePy.defineException(\"" << scoped << "\", " << name << ", ";
     writeMetadata(p->getMetadata());
     _out << ", ";
     if (!base)
@@ -1245,7 +1245,7 @@ Slice::Python::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     //
     // Data members are represented as a tuple:
     //
-    //   ('MemberName', MemberMetadata, MemberType, Optional, Tag)
+    //   ("MemberName", MemberMetadata, MemberType, Optional, Tag)
     //
     // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a user-defined type.
     //
@@ -1255,7 +1255,7 @@ Slice::Python::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
         {
             _out << ',' << nl;
         }
-        _out << "('" << (*dmli)->mappedName() << "', ";
+        _out << "(\"" << (*dmli)->mappedName() << "\", ";
         writeMetadata((*dmli)->getMetadata());
         _out << ", ";
         writeType((*dmli)->type());
@@ -1504,13 +1504,13 @@ Slice::Python::CodeVisitor::visitStructStart(const StructPtr& p)
     //
     // Emit the type information.
     //
-    _out << sp << nl << getMetaTypeReference(p) << " = IcePy.defineStruct('" << scoped << "', " << name << ", ";
+    _out << sp << nl << getMetaTypeReference(p) << " = IcePy.defineStruct(\"" << scoped << "\", " << name << ", ";
     writeMetadata(p->getMetadata());
     _out << ", (";
     //
     // Data members are represented as a tuple:
     //
-    //   ('MemberName', MemberMetadata, MemberType)
+    //   ("MemberName", MemberMetadata, MemberType)
     //
     // where MemberType is either a primitive type constant (T_INT, etc.) or the id of a user-defined type.
     //
@@ -1525,7 +1525,7 @@ Slice::Python::CodeVisitor::visitStructStart(const StructPtr& p)
         {
             _out << ',' << nl;
         }
-        _out << "('" << (*r)->mappedName() << "', ";
+        _out << "(\"" << (*r)->mappedName() << "\", ";
         writeMetadata((*r)->getMetadata());
         _out << ", ";
         writeType((*r)->type());
@@ -1555,7 +1555,7 @@ Slice::Python::CodeVisitor::visitSequence(const SequencePtr& p)
     // Emit the type information.
     writeModuleHasDefinitionCheck(_out, p, "_t_" + p->mappedName());
     _out.inc();
-    _out << nl << getMetaTypeReference(p) << " = IcePy.defineSequence('" << p->scoped() << "', ";
+    _out << nl << getMetaTypeReference(p) << " = IcePy.defineSequence(\"" << p->scoped() << "\", ";
     writeMetadata(p->getMetadata());
     _out << ", ";
     writeType(p->type());
@@ -1569,7 +1569,7 @@ Slice::Python::CodeVisitor::visitDictionary(const DictionaryPtr& p)
     // Emit the type information.
     writeModuleHasDefinitionCheck(_out, p, "_t_" + p->mappedName());
     _out.inc();
-    _out << nl << getMetaTypeReference(p) << " = IcePy.defineDictionary('" << p->scoped() << "', ";
+    _out << nl << getMetaTypeReference(p) << " = IcePy.defineDictionary(\"" << p->scoped() << "\", ";
     writeMetadata(p->getMetadata());
     _out << ", ";
     writeType(p->keyType());
@@ -1646,7 +1646,7 @@ Slice::Python::CodeVisitor::visitEnum(const EnumPtr& p)
     //
     // Emit the type information.
     //
-    _out << sp << nl << getMetaTypeReference(p) << " = IcePy.defineEnum('" << scoped << "', " << name << ", ";
+    _out << sp << nl << getMetaTypeReference(p) << " = IcePy.defineEnum(\"" << scoped << "\", " << name << ", ";
     writeMetadata(p->getMetadata());
     _out << ", " << name << "._enumerators)";
 
@@ -1775,7 +1775,7 @@ Slice::Python::CodeVisitor::writeInitializer(const DataMemberPtr& m)
             }
             case Builtin::KindString:
             {
-                _out << "''";
+                _out << "\"\"";
                 break;
             }
             case Builtin::KindValue:
@@ -1853,7 +1853,7 @@ Slice::Python::CodeVisitor::writeMetadata(const MetadataList& metadata)
             {
                 _out << ", ";
             }
-            _out << "'" << *meta << "'";
+            _out << "\"" << *meta << "\"";
             ++i;
         }
     }


### PR DESCRIPTION
This PR updates the Python generated code to consistently use `"xxx"`  for strings, instead of a mix of `'xxx' and `"xxx"`. 

We have code like:

```
def __init__(self, name='', category=""):
```

We were using mostly `''` but I switched to `""` because seems like the more common supported on all major languages.

This includes the fixes for #3966