### PR TITLE
Add default values to generated memberwise initializer in Swift

### DIFF
--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -1020,7 +1020,7 @@ namespace Slice
         [[nodiscard]] bool optional() const;
         [[nodiscard]] int tag() const;
 
-        // defaultValue() and defaultValueType() are either both null (not default value) or both non-null.
+        // defaultValue() and defaultValueType() are either both null (no default value) or both non-null.
         [[nodiscard]] std::optional<std::string> defaultValue() const;
         [[nodiscard]] SyntaxTreeBasePtr defaultValueType() const;
         [[nodiscard]] std::string kindOf() const final;

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -905,12 +905,33 @@ SwiftGenerator::writeMemberwiseInitializer(
     {
         out << sp;
         out << nl;
-        out << "public init" << spar;
+        out << "public init(";
+        bool firstMember = true;
         for (const auto& m : allMembers)
         {
-            out << (m->mappedName() + ": " + typeToString(m->type(), p, m->optional()));
+            if (firstMember)
+            {
+                firstMember = false;
+            }
+            else
+            {
+                out << ", ";
+            }
+
+            out << m->mappedName() << ": " + typeToString(m->type(), p, m->optional());
+            if (m->defaultValueType())
+            {
+                out << " = ";
+                writeConstantValue(
+                    out,
+                    m->type(),
+                    m->defaultValueType(),
+                    m->defaultValue().value_or(""),
+                    getSwiftModule(p->getTopLevelModule()),
+                    m->optional());
+            }
         }
-        out << epar;
+        out << ")";
         out << sb;
         for (const auto& m : members)
         {
@@ -976,7 +997,7 @@ SwiftGenerator::writeMembers(
                     out,
                     type,
                     member->defaultValueType(),
-                    member->defaultValue().value_or(""), // TODO: revisit this code
+                    member->defaultValue().value_or(""),
                     swiftModule,
                     member->optional());
             }

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -918,7 +918,7 @@ SwiftGenerator::writeMemberwiseInitializer(
                 out << ", ";
             }
 
-            out << m->mappedName() << ": " + typeToString(m->type(), p, m->optional());
+            out << m->mappedName() << ": " << typeToString(m->type(), p, m->optional());
             if (m->defaultValueType())
             {
                 out << " = ";

--- a/swift/test/Ice/ami/Collocated.swift
+++ b/swift/test/Ice/ami/Collocated.swift
@@ -44,7 +44,7 @@ class Collocated: TestHelperI {
 
         try adapter.add(
             servant: TestIntfDisp(TestI(helper: self)),
-            id: Ice.stringToIdentity("test"))
+            id: Ice.Identity(name: "test"))
         try adapter.add(
             servant: OuterInnerTestIntfDisp(TestII()),
             id: Ice.stringToIdentity("test2"))

--- a/swift/test/Ice/ami/Server.swift
+++ b/swift/test/Ice/ami/Server.swift
@@ -44,7 +44,7 @@ class Server: TestHelperI {
         let adapter = try communicator.createObjectAdapter("TestAdapter")
         let adapter2 = try communicator.createObjectAdapter("ControllerAdapter")
 
-        try adapter.add(servant: TestIntfDisp(TestI(helper: self)), id: Ice.stringToIdentity("test"))
+        try adapter.add(servant: TestIntfDisp(TestI(helper: self)), id: Ice.Identity(name: "test"))
         try adapter.add(servant: OuterInnerTestIntfDisp(TestII()), id: Ice.stringToIdentity("test2"))
         try adapter.activate()
         try adapter2.add(

--- a/swift/test/Ice/defaultValue/AllTests.swift
+++ b/swift/test/Ice/defaultValue/AllTests.swift
@@ -87,6 +87,12 @@ func allTests(_ helper: TestHelper) async throws {
     }
 
     do {
+        let v = Struct4(bar: "bar")
+        try test(v.foo == "foo")
+        try test(v.bar == "bar")
+    }
+
+    do {
         let v = Base()
         try test(!v.boolFalse)
         try test(v.boolTrue)

--- a/swift/test/Ice/defaultValue/Test.ice
+++ b/swift/test/Ice/defaultValue/Test.ice
@@ -110,6 +110,12 @@ module Test
         double zeroDotD = 0;
     }
 
+    struct Struct4
+    {
+        string foo = "foo";
+        string bar;
+    }
+
     class Base
     {
         bool boolFalse = false;

--- a/swift/test/Ice/enums/Server.swift
+++ b/swift/test/Ice/enums/Server.swift
@@ -14,7 +14,7 @@ class Server: TestHelperI {
         communicator.getProperties().setProperty(
             key: "TestAdapter.Endpoints", value: getTestEndpoint(num: 0))
         let adapter = try communicator.createObjectAdapter("TestAdapter")
-        try adapter.add(servant: TestIntfDisp(TestI()), id: Ice.stringToIdentity("test"))
+        try adapter.add(servant: TestIntfDisp(TestI()), id: Ice.Identity(name: "test"))
         try adapter.activate()
         serverReady()
         communicator.waitForShutdown()

--- a/swift/test/Ice/info/Server.swift
+++ b/swift/test/Ice/info/Server.swift
@@ -16,7 +16,7 @@ class Server: TestHelperI {
             value: "\(getTestEndpoint(num: 0)):\(getTestEndpoint(num: 0, prot: "udp"))"
         )
         let adapter = try communicator.createObjectAdapter("TestAdapter")
-        try adapter.add(servant: TestIntfDisp(TestI()), id: Ice.stringToIdentity("test"))
+        try adapter.add(servant: TestIntfDisp(TestI()), id: Ice.Identity(name: "test"))
         try adapter.activate()
         serverReady()
         communicator.waitForShutdown()

--- a/swift/test/Ice/location/TestI.swift
+++ b/swift/test/Ice/location/TestI.swift
@@ -117,7 +117,7 @@ class ServerManagerI: ServerManager {
 
                 let object = try TestI(adapter1: adapter, adapter2: adapter2, registry: _registry)
                 try _registry.addObject(
-                    adapter.add(servant: TestIntfDisp(object), id: Ice.stringToIdentity("test")))
+                    adapter.add(servant: TestIntfDisp(object), id: Ice.Identity(name: "test")))
                 try _registry.addObject(
                     adapter.add(servant: TestIntfDisp(object), id: Ice.stringToIdentity("test2")))
                 _ = try adapter.add(servant: TestIntfDisp(object), id: Ice.stringToIdentity("test3"))

--- a/swift/test/Ice/middleware/AllTests.swift
+++ b/swift/test/Ice/middleware/AllTests.swift
@@ -22,7 +22,7 @@ func allTests(_ helper: TestHelper) async throws {
             name: "MyOA", endpoints: "tcp -h 127.0.0.1 -p 0")
         let log = MiddlewareLog()
 
-        let objPrx = try oa.add(servant: MyObjectDisp(MyObjectI()), id: Ice.stringToIdentity("test"))
+        let objPrx = try oa.add(servant: MyObjectDisp(MyObjectI()), id: Ice.Identity(name: "test"))
         oa.use { next in
             Middleware(next, "A", log)
         }.use { next in

--- a/swift/test/Ice/operations/Collocated.swift
+++ b/swift/test/Ice/operations/Collocated.swift
@@ -35,7 +35,7 @@ class Collocated: TestHelperI {
         let adapter = try communicator.createObjectAdapter("TestAdapter")
         try adapter.add(
             servant: MyDerivedClassDisp(MyDerivedClassI(self)),
-            id: Ice.stringToIdentity("test"))
+            id: Ice.Identity(name: "test"))
         // try adapter.activate() // Don't activate OA to ensure collocation is used.
         _ = try await allTests(helper: self)
     }

--- a/swift/test/Ice/operations/Server.swift
+++ b/swift/test/Ice/operations/Server.swift
@@ -29,7 +29,7 @@ class Server: TestHelperI {
             key: "TestAdapter.Endpoints", value: getTestEndpoint(num: 0))
         let adapter = try communicator.createObjectAdapter("TestAdapter")
         try adapter.add(
-            servant: MyDerivedClassDisp(MyDerivedClassI(self)), id: Ice.stringToIdentity("test"))
+            servant: MyDerivedClassDisp(MyDerivedClassI(self)), id: Ice.Identity(name: "test"))
         try adapter.activate()
         serverReady()
         communicator.waitForShutdown()

--- a/swift/test/Ice/operations/Twoways.swift
+++ b/swift/test/Ice/operations/Twoways.swift
@@ -219,9 +219,9 @@ func testClasses(helper: TestHelper, prx p: MyClassPrx) async throws {
     do {
         var (r, c1, c2) = try await p.opMyClass(p)
 
-        try test(c1!.ice_getIdentity() == Ice.stringToIdentity("test"))
+        try test(c1!.ice_getIdentity() == Ice.Identity(name: "test"))
         try test(c2!.ice_getIdentity() == Ice.stringToIdentity("noSuchIdentity"))
-        try test(r!.ice_getIdentity() == Ice.stringToIdentity("test"))
+        try test(r!.ice_getIdentity() == Ice.Identity(name: "test"))
         try await r!.opVoid()
         try await c1!.opVoid()
 

--- a/swift/test/Ice/proxy/Collocated.swift
+++ b/swift/test/Ice/proxy/Collocated.swift
@@ -19,7 +19,7 @@ class Collocated: TestHelperI {
         let adapter = try communicator.createObjectAdapter("TestAdapter")
         try adapter.add(
             servant: MyDerivedClassDisp(MyDerivedClassI()),
-            id: Ice.stringToIdentity("test"))
+            id: Ice.Identity(name: "test"))
         // try adapter.activate() // Don't activate OA to ensure collocation is used.
         _ = try await allTests(self)
     }

--- a/swift/test/Ice/proxy/Server.swift
+++ b/swift/test/Ice/proxy/Server.swift
@@ -21,7 +21,7 @@ class Server: TestHelperI {
         let adapter = try communicator.createObjectAdapter("TestAdapter")
         try adapter.add(
             servant: MyDerivedClassDisp(MyDerivedClassI()),
-            id: Ice.stringToIdentity("test"))
+            id: Ice.Identity(name: "test"))
         try adapter.activate()
         serverReady()
         communicator.waitForShutdown()

--- a/swift/test/Ice/udp/Server.swift
+++ b/swift/test/Ice/udp/Server.swift
@@ -27,7 +27,7 @@ class Server: TestHelperI {
                 key: "TestAdapter.Endpoints",
                 value: getTestEndpoint(num: 0, prot: "udp"))
             let adapter2 = try communicator.createObjectAdapter("TestAdapter")
-            try adapter2.add(servant: TestIntfDisp(TestIntfI()), id: Ice.stringToIdentity("test"))
+            try adapter2.add(servant: TestIntfDisp(TestIntfI()), id: Ice.Identity(name: "test"))
             try adapter2.activate()
         }
 
@@ -44,7 +44,7 @@ class Server: TestHelperI {
         endpoint += "\(getTestPort(properties: properties, num: 10))"
         communicator.getProperties().setProperty(key: "McastTestAdapter.Endpoints", value: endpoint)
         let mcastAdapter = try communicator.createObjectAdapter("McastTestAdapter")
-        try mcastAdapter.add(servant: TestIntfDisp(TestIntfI()), id: Ice.stringToIdentity("test"))
+        try mcastAdapter.add(servant: TestIntfDisp(TestIntfI()), id: Ice.Identity(name: "test"))
         try mcastAdapter.activate()
         communicator.waitForShutdown()
     }

--- a/swift/test/Slice/escape/Client.swift
+++ b/swift/test/Slice/escape/Client.swift
@@ -41,14 +41,14 @@ public class Client: TestHelperI {
         communicator.getProperties().setProperty(
             key: "TestAdapter.Endpoints", value: getTestEndpoint(num: 0))
         let adapter = try communicator.createObjectAdapter("TestAdapter")
-        try adapter.add(servant: breakDisp(BreakI()), id: Ice.stringToIdentity("test"))
+        try adapter.add(servant: breakDisp(BreakI()), id: Ice.Identity(name: "test"))
         try adapter.add(servant: doDisp(DoI()), id: Ice.stringToIdentity("test1"))
         try adapter.activate()
 
         let out = getWriter()
         out.write("testing operation name... ")
         let p = try await checkedCast(
-            prx: adapter.createProxy(Ice.stringToIdentity("test")), type: breakPrx.self)!
+            prx: adapter.createProxy(Ice.Identity(name: "test")), type: breakPrx.self)!
         _ = try await p.case(0)
         out.writeLine("ok")
 


### PR DESCRIPTION
This PR add default values to the generated memberwise initializer in Swift (for structs, classes, and maybe exceptions).

This matches the behavior of the default memberwise initializer for structs, that we can't use because it's internal:
https://docs.swift.org/swift-book/documentation/the-swift-programming-language/initialization/#Default-Initializers
 