### PR TITLE
No need to cancel invocations after the future is done

### DIFF
--- a/python/python/Ice/InvocationFuture.py
+++ b/python/python/Ice/InvocationFuture.py
@@ -40,8 +40,10 @@ class InvocationFuture(Future):
         After cancellation, `done()` returns `True`, and attempting to retrieve the result will raise
         an `Ice.InvocationCanceledException`.
         """
-        self._asyncInvocationContext.cancel()
-        return Future.cancel(self)
+        canceled = Future.cancel(self)
+        if canceled:
+            self._asyncInvocationContext.cancel()
+        return canceled
 
     def is_sent(self):
         """


### PR DESCRIPTION
This is a minor fix for Python Invocation futures to avoid calling the cancel closure via the async invocation context if the future is already done.