### PR TITLE
Collect binaries and PDBs from Windows crash dumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,11 +215,23 @@ jobs:
           if-no-files-found: ignore
         if: runner.os == 'macOS' && always()
 
-      - name: Upload Windows crash dumps
+      - name: Process Windows crash dumps
+        if: runner.os == 'Windows' && always()
+        shell: pwsh
+        run: |
+          $dumpDir   = Join-Path $env:GITHUB_WORKSPACE 'LocalDumps'
+          $reportsDir = Join-Path $env:GITHUB_WORKSPACE 'LocalDumpReports'
+
+          python scripts\process_crash_dumps.py `
+              --dumps     $dumpDir `
+              --workspace $env:GITHUB_WORKSPACE `
+              --reports   $reportsDir
+
+      - name: Upload Windows crash dump reports
         uses: actions/upload-artifact@v4
         with:
           name: crash-dumps-${{ matrix.config }}-${{ matrix.os }}
-          path: ${{ github.workspace }}/LocalDumps/*
+          path: ${{ github.workspace }}/LocalDumpReports/*
           if-no-files-found: ignore
         if: runner.os == 'Windows' && always()
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,8 @@ jobs:
           python scripts\process_crash_dumps.py `
               --dumps     $dumpDir `
               --workspace $env:GITHUB_WORKSPACE `
-              --reports   $reportsDir
+              --reports   $reportsDir `
+              --cdb "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe"
 
       - name: Upload Windows crash dump reports
         uses: actions/upload-artifact@v4

--- a/cpp/test/Ice/binding/Client.cpp
+++ b/cpp/test/Ice/binding/Client.cpp
@@ -17,6 +17,7 @@ Client::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     void allTests(Test::TestHelper*);
     allTests(this);
+    assert(false); // Testing dumps
 }
 
 DEFINE_TEST(Client)

--- a/cpp/test/Ice/binding/Client.cpp
+++ b/cpp/test/Ice/binding/Client.cpp
@@ -17,7 +17,6 @@ Client::run(int argc, char** argv)
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     void allTests(Test::TestHelper*);
     allTests(this);
-    assert(false); // Testing dumps
 }
 
 DEFINE_TEST(Client)

--- a/scripts/process_crash_dumps.py
+++ b/scripts/process_crash_dumps.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+
+# Copyright (c) ZeroC, Inc.
+
+"""
+process_crash_dumps.py - gather binaries & PDBs referenced by crash dumps
+
+For every *.dmp* file found in a dumps directory this script:
+  1. Launches `cdb.exe` to generate a *modules.txt* file containing the
+     verbose module list (equivalent to Visual Studio's **Modules** window).
+  2. Parses that text, keeps only the modules whose Image paths live inside
+     the current GitHub workspace (or an explicitly supplied workspace path).
+  3. Copies each matching binary **and** its companion PDB (if found) to a
+     dedicated sub-folder under *Reports/<dump file name>/*.`
+
+Example folder structure created:
+
+    Reports/
+      server.exe.9568.dmp/
+        modules.txt
+        server.exe
+        server.pdb
+        ice38a0.dll
+        ice38a0.pdb
+
+Usage (run from CI):
+
+    python process_crash_dumps.py \
+        --dumps "C:\\dumps" \
+        --workspace "%GITHUB_WORKSPACE%" \
+        --reports Reports
+
+Arguments:
+  --dumps       Path containing *.dmp files (default: ./dumps)
+  --workspace   Root of your GitHub checkout (default: env GITHUB_WORKSPACE or cwd)
+  --reports     Where to write the per-dump report folders (default: ./Reports)
+  --cdb         Full path to cdb.exe if it isn't in PATH
+
+Requires Python 3.13+.
+"""
+
+import argparse
+import logging
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Iterable, List
+
+LOGGER = logging.getLogger(__name__)
+
+IMAGE_PATH_RE = re.compile(r"^\s*Image\s+path:\s+(.+)$", re.IGNORECASE)
+
+
+def run_cdb(dump: Path, modules_txt: Path, cdb_exe: str) -> None:
+    """Run *cdb* on *dump* and write its verbose module list to *modules_txt*."""
+    LOGGER.debug("Running cdb on %s", dump)
+    cmd: List[str] = [
+        cdb_exe,
+        "-z",
+        str(dump),
+        "-c",
+        ".symfix; .reload; lmv; q",
+        "-logo",
+        str(modules_txt),
+    ]
+    try:
+        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except FileNotFoundError as exc:
+        LOGGER.error("Could not find cdb.exe – specify with --cdb or add it to PATH")
+        raise SystemExit(1) from exc
+
+
+def parse_image_paths(modules_txt: Path) -> Iterable[Path]:
+    """Yield absolute *Path* objects for every `Image path:` found."""
+    with modules_txt.open(encoding="utf-8", errors="ignore") as fp:
+        for line in fp:
+            m = IMAGE_PATH_RE.match(line)
+            if m:
+                raw = m.group(1).strip().strip("\r\n\"')(")  # clean quotes/newlines
+                if raw:
+                    yield Path(raw)
+
+
+def inside_workspace(path: Path, workspace: Path) -> bool:
+    """Return *True* if *path* is located inside *workspace* (case-insensitive)."""
+    try:
+        return Path(os.path.commonpath([workspace.resolve(), path.resolve()])) == workspace.resolve()
+    except ValueError:  # drives differ on Windows, cannot be inside
+        return False
+
+
+def copy_with_pdb(binary: Path, dest_dir: Path) -> None:
+    """Copy *binary* and its sibling .pdb (if any) into *dest_dir*."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    for src in (binary, binary.with_suffix(".pdb")):
+        if src.exists():
+            shutil.copy2(src, dest_dir / src.name)
+            LOGGER.info("Copied %s → %s", src, dest_dir / src.name)
+        else:
+            LOGGER.debug("PDB not found: %s", src)
+
+
+def process_dump(dump: Path, workspace: Path, reports_root: Path, cdb_exe: str) -> None:
+    """Generate report folder for a single dump file."""
+    report_dir = reports_root / dump.name
+    report_dir.mkdir(parents=True, exist_ok=True)
+
+    modules_txt = report_dir / "modules.txt"
+    run_cdb(dump, modules_txt, cdb_exe)
+
+    for img_path in parse_image_paths(modules_txt):
+        if inside_workspace(img_path, workspace):
+            copy_with_pdb(img_path, report_dir)
+        else:
+            LOGGER.debug("Skipping non-workspace module: %s", img_path)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Collect dump-related binaries and PDBs")
+    parser.add_argument("--dumps", type=Path, default=Path("dumps"), help="Folder containing .dmp files")
+    parser.add_argument("--workspace", type=Path, default=Path(os.getenv("GITHUB_WORKSPACE", ".")).resolve(), help="GitHub workspace root")
+    parser.add_argument("--reports", type=Path, default=Path("Reports"), help="Output folder for reports")
+    parser.add_argument("--cdb", default="cdb", help="Path to cdb.exe (defaults to one on PATH)")
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="Increase logging verbosity (-v or -vv)")
+    return parser
+
+
+def configure_logging(verbosity: int) -> None:
+    level = logging.WARNING - (10 * min(verbosity, 2))  # WARNING→INFO→DEBUG
+    logging.basicConfig(format="%(levelname)s: %(message)s", level=level)
+
+
+def main(argv: List[str] | None = None) -> None:
+    args = build_arg_parser().parse_args(argv)
+    configure_logging(args.verbose)
+
+    LOGGER.info("Workspace root: %s", args.workspace)
+
+    dumps_found = list(args.dumps.glob("*.dmp"))
+    if not dumps_found:
+        LOGGER.warning("No .dmp files found in %s", args.dumps)
+        return
+
+    for dump in dumps_found:
+        LOGGER.info("Processing %s", dump)
+        try:
+            process_dump(dump, args.workspace, args.reports, args.cdb)
+        except subprocess.CalledProcessError as exc:
+            LOGGER.error("cdb failed for %s (exit code %s)", dump, exc.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/process_crash_dumps.py
+++ b/scripts/process_crash_dumps.py
@@ -121,11 +121,35 @@ def process_dump(dump: Path, workspace: Path, reports_root: Path, cdb_exe: str) 
 
 def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Collect dump-related binaries and PDBs")
-    parser.add_argument("--dumps", type=Path, default=Path("dumps"), help="Folder containing .dmp files")
-    parser.add_argument("--workspace", type=Path, default=Path(os.getenv("GITHUB_WORKSPACE", ".")).resolve(), help="GitHub workspace root")
-    parser.add_argument("--reports", type=Path, default=Path("Reports"), help="Output folder for reports")
-    parser.add_argument("--cdb", default="cdb", help="Path to cdb.exe (defaults to one on PATH)")
-    parser.add_argument("-v", "--verbose", action="count", default=0, help="Increase logging verbosity (-v or -vv)")
+    parser.add_argument(
+        "--dumps",
+        type=Path,
+        default=Path("dumps"),
+        help="Folder containing .dmp Windows dump files")
+
+    parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path(os.getenv("GITHUB_WORKSPACE", ".")).resolve(),
+        help="GitHub workspace root")
+
+    parser.add_argument(
+        "--reports",
+        type=Path,
+        default=Path("Reports"),
+        help="Output folder for reports")
+
+    parser.add_argument(
+        "--cdb",
+        default="cdb",
+        help="Path to cdb.exe (defaults to one on PATH)")
+
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase logging verbosity (-v or -vv)")
     return parser
 
 

--- a/scripts/process_crash_dumps.py
+++ b/scripts/process_crash_dumps.py
@@ -111,6 +111,9 @@ def process_dump(dump: Path, workspace: Path, reports_root: Path, cdb_exe: str) 
         else:
             LOGGER.debug("Skipping non-workspace module: %s", img_path)
 
+    # Copy the dump file itself to the report directory
+    shutil.copy2(dump, report_dir / dump.name)
+
 
 # ---------------------------------------------------------------------------
 # CLI

--- a/scripts/process_crash_dumps.py
+++ b/scripts/process_crash_dumps.py
@@ -68,7 +68,7 @@ def run_cdb(dump: Path, modules_txt: Path, cdb_exe: str) -> None:
     try:
         subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     except FileNotFoundError as exc:
-        LOGGER.error("Could not find cdb.exe – specify with --cdb or add it to PATH")
+        LOGGER.error("Could not find cdb.exe - specify with --cdb or add it to PATH")
         raise SystemExit(1) from exc
 
 


### PR DESCRIPTION
This PR adds a new `process_crash_dumps.py` script to collect the binaries and PDBs referenced by a Windows crash dump.

In CI, this script is used to process dump files generated during test failures. It extracts the relevant modules loaded by the crashed process, filters those that are part of the current workspace, and copies the corresponding binaries and PDBs into a report directory.

The collected data is then uploaded as an artifact, allowing developers to download the dump and all required symbols for local debugging.

Fix #3956