### PR TITLE
Fix test for collocated invocation with IPv6 normalized address

### DIFF
--- a/cpp/test/Ice/operations/Collocated.cpp
+++ b/cpp/test/Ice/operations/Collocated.cpp
@@ -31,11 +31,9 @@ namespace
         // Don't activate OA to ensure collocation is used.
 
         auto prx = Ice::ObjectPrx{communicator.communicator(), "test:" + endpoint1};
-        prx = prx->ice_invocationTimeout(100ms);
         prx->ice_ping();
 
         prx = Ice::ObjectPrx{communicator.communicator(), "test:" + endpoint2};
-        prx = prx->ice_invocationTimeout(100ms);
         prx->ice_ping();
         cout << "ok" << endl;
     }

--- a/csharp/test/Ice/operations/Collocated.cs
+++ b/csharp/test/Ice/operations/Collocated.cs
@@ -41,11 +41,9 @@ public class Collocated : TestHelper
         adapter.add(new MyDerivedClassI(), Ice.Util.stringToIdentity("test"));
 
         var prx = Ice.ObjectPrxHelper.createProxy(communicator, $"test:tcp -h \"::1\" -p {port}");
-        prx = prx.ice_invocationTimeout(TimeSpan.FromMilliseconds(100));
         prx.ice_ping();
 
         prx = Ice.ObjectPrxHelper.createProxy(communicator, $"test:tcp -h \"0:0:0:0:0:0:0:1\" -p {port}");
-        prx = prx.ice_invocationTimeout(TimeSpan.FromMilliseconds(100));
         prx.ice_ping();
         output.WriteLine();
     }

--- a/java/test/src/main/java/test/Ice/operations/Collocated.java
+++ b/java/test/src/main/java/test/Ice/operations/Collocated.java
@@ -50,11 +50,9 @@ public class Collocated extends TestHelper {
             adapter.add(new MyDerivedClassI(), Util.stringToIdentity("test"));
 
             var prx = ObjectPrx.createProxy(communicator, "test:tcp -h \"::1\" -p " + port);
-            prx = prx.ice_invocationTimeout(100);
             prx.ice_ping();
 
             prx = ObjectPrx.createProxy(communicator, "test:tcp -h \"0:0:0:0:0:0:0:1\" -p " + port);
-            prx = prx.ice_invocationTimeout(100);
             prx.ice_ping();
             output.println();
         }


### PR DESCRIPTION
The invocation timeout is not really necessary for the test, and is causing the sporadic failures in Java.

Fix #3505
