### PR TITLE
Fix bogus sent callback in C++ echo server used by JavaScript tests

### DIFF
--- a/cpp/test/Ice/echo/BlobjectI.cpp
+++ b/cpp/test/Ice/echo/BlobjectI.cpp
@@ -69,9 +69,9 @@ BlobjectI::ice_invokeAsync(
                 current.operation,
                 current.mode,
                 inEncaps,
-                [](bool, const std::vector<byte>&) { assert(0); },
+                [](bool, const std::vector<byte>&) { assert(false); },
                 ex,
-                [&](bool) { response(true, vector<byte>()); },
+                [response = std::move(response)](bool) { response(true, vector<byte>()); },
                 current.ctx);
         }
     }
@@ -82,7 +82,14 @@ BlobjectI::ice_invokeAsync(
             obj = obj->ice_facet(current.facet);
         }
 
-        obj->ice_invokeAsync(current.operation, current.mode, inEncaps, response, ex, nullptr, current.ctx);
+        obj->ice_invokeAsync(
+            current.operation,
+            current.mode,
+            inEncaps,
+            std::move(response),
+            std::move(ex),
+            nullptr,
+            current.ctx);
     }
 }
 

--- a/cpp/test/Ice/echo/Server.cpp
+++ b/cpp/test/Ice/echo/Server.cpp
@@ -38,7 +38,7 @@ Server::run(int argc, char** argv)
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     BlobjectIPtr blob = make_shared<BlobjectI>();
     adapter->addDefaultServant(blob, "");
-    adapter->add(make_shared<EchoI>(blob), Ice::stringToIdentity("__echo"));
+    adapter->add(make_shared<EchoI>(blob), Ice::Identity{.name = "__echo"});
     adapter->activate();
     serverReady();
     communicator->waitForShutdown();


### PR DESCRIPTION
I think this is likely the cause why Echo server was crashing. Fix #3957
