### PR TITLE
Enable tracing for Ice/udp test

### DIFF
--- a/java/test/src/main/java/test/Ice/udp/AllTests.java
+++ b/java/test/src/main/java/test/Ice/udp/AllTests.java
@@ -80,7 +80,7 @@ public class AllTests {
             obj.ping(reply);
             obj.ping(reply);
             obj.ping(reply);
-            ret = replyI.waitReply(3, 2000);
+            ret = replyI.waitReply(3, 2000, out);
             if (ret) {
                 break; // Success
             }
@@ -104,7 +104,7 @@ public class AllTests {
                     seq = new byte[seq.length * 2 + 10];
                     replyI.reset();
                     obj.sendByteSeq(seq, reply);
-                    replyI.waitReply(1, 10000);
+                    replyI.waitReply(1, 10000, out);
                 }
             } catch (DatagramLimitException ex) {
                 test(seq.length > 16384);
@@ -120,7 +120,7 @@ public class AllTests {
                 // We don't expect a reply because the server's value for Ice.UDP.RcvSize is too
                 // small.
                 //
-                test(!replyI.waitReply(1, 500));
+                test(!replyI.waitReply(1, 500, out));
             } catch (LocalException ex) {
                 ex.printStackTrace();
                 test(false);
@@ -176,7 +176,7 @@ public class AllTests {
                     }
                     throw ex;
                 }
-                ret = replyI.waitReply(numServers, 2000);
+                ret = replyI.waitReply(numServers, 2000, out);
                 if (ret) {
                     break; // Success
                 }
@@ -199,7 +199,7 @@ public class AllTests {
                 obj.pingBiDir(reply.ice_getIdentity());
                 obj.pingBiDir(reply.ice_getIdentity());
                 obj.pingBiDir(reply.ice_getIdentity());
-                ret = replyI.waitReply(3, 2000);
+                ret = replyI.waitReply(3, 2000, out);
                 if (ret) {
                     break; // Success
                 }

--- a/java/test/src/main/java/test/Ice/udp/AllTests.java
+++ b/java/test/src/main/java/test/Ice/udp/AllTests.java
@@ -35,7 +35,7 @@ public class AllTests {
             _replies = 0;
         }
 
-        public synchronized boolean waitReply(int expectedReplies, long timeout) {
+        public synchronized boolean waitReply(int expectedReplies, long timeout, PrintWriter out) {
             long end = System.currentTimeMillis() + timeout;
             while (_replies < expectedReplies) {
                 long delay = end - System.currentTimeMillis();
@@ -46,6 +46,9 @@ public class AllTests {
                 } else {
                     break;
                 }
+            }
+            if (_replies != expectedReplies) {
+                out.println("Expected " + expectedReplies + " replies, got " + _replies);
             }
             return _replies == expectedReplies;
         }

--- a/scripts/tests/Ice/udp.py
+++ b/scripts/tests/Ice/udp.py
@@ -3,21 +3,22 @@
 
 from Util import Client, ClientServerTestCase, Server, TestSuite
 
+traceProps = {"Ice.Trace.Network": 2, "Ice.Trace.Retry": 1, "Ice.Trace.Protocol": 1}
 
 class UdpTestCase(ClientServerTestCase):
     def setupServerSide(self, current):
         if current.config.android:
-            self.servers = [Server(ready="McastTestAdapter")]
+            self.servers = [Server(ready="McastTestAdapter", traceProps=traceProps)]
         else:
             self.servers = [
-                Server(args=[i], ready="McastTestAdapter") for i in range(0, 5)
+                Server(args=[i], props = {"Ice.ProgramName" : f"server-{i}"}, ready="McastTestAdapter", traceProps=traceProps) for i in range(0, 5)
             ]
 
     def setupClientSide(self, current):
         if current.config.android:
-            self.clients = [Client()]
+            self.clients = [Client(traceProps=traceProps)]
         else:
-            self.clients = [Client(args=[5])]
+            self.clients = [Client(args=[5], traceProps=traceProps)]
 
 
 TestSuite(__name__, [UdpTestCase()], multihost=False)


### PR DESCRIPTION
This PR enables tracing for Ice/udp test to figure out #3389 failure. I will close #3389 and we can reopen if it fails again with the additional trace.