### PR TITLE
Enable tracing for Ice/binding test

### DIFF
--- a/scripts/tests/Ice/binding.py
+++ b/scripts/tests/Ice/binding.py
@@ -1,0 +1,11 @@
+# Copyright (c) ZeroC, Inc.
+
+# Enable some tracing to allow investigating test failures
+from Util import ClientServerTestCase, TestSuite
+
+
+traceProps = {"Ice.Trace.Network": 2, "Ice.Trace.Retry": 1, "Ice.Trace.Protocol": 1}
+
+testcases = [ClientServerTestCase(traceProps=traceProps)]
+
+TestSuite(__name__, testcases)


### PR DESCRIPTION
Enabled tracing to figure out  #3510 failure.