### PR TITLE
Don't use IceSSL.Keystore as fallback for IceSSL.Truststore

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
@@ -278,11 +278,9 @@ public class SSLEngine {
                     }
                 }
 
-                //
-                // Collect the trust managers. Use IceSSL.Truststore if specified, otherwise use the
-                // Java root CAs if Ice.Use.PlatformCAs is enabled. If none of these are enabled,
-                // use the keystore or a dummy trust manager which rejects any certificate.
-                //
+                // Collect the trust managers. Use IceSSL.Truststore if specified, otherwise use the Java root CAs if
+                // Ice.Use.PlatformCAs is enabled. If none of these are enabled use a dummy trust manager which
+                // rejects any certificate.
                 javax.net.ssl.TrustManager[] trustManagers = null;
                 {
                     String algorithm = TrustManagerFactory.getDefaultAlgorithm();
@@ -291,36 +289,33 @@ public class SSLEngine {
                     KeyStore trustStore = null;
                     if (ts != null) {
                         trustStore = ts;
-                    } else if (properties.getIcePropertyAsInt("IceSSL.UsePlatformCAs") <= 0) {
-                        if (keys != null) {
-                            trustStore = keys;
-                        } else {
-                            trustManagers =
-                                new javax.net.ssl.TrustManager[]{
-                                    new X509TrustManager() {
-                                        @Override
-                                        public void checkClientTrusted(
-                                                    X509Certificate[] chain, String authType)
-                                            throws CertificateException {
-                                            throw new CertificateException("no trust anchors");
-                                        }
-
-                                        @Override
-                                        public void checkServerTrusted(
-                                                    X509Certificate[] chain, String authType)
-                                            throws CertificateException {
-                                            throw new CertificateException("no trust anchors");
-                                        }
-
-                                        @Override
-                                        public X509Certificate[] getAcceptedIssuers() {
-                                            return new X509Certificate[0];
-                                        }
-                                    }
-                                };
-                        }
+                    } else if (properties.getIcePropertyAsInt("IceSSL.UsePlatformCAs") > 0) {
+                        // Set trustManagers to null to use the platform CAs
+                        trustManagers = null;
                     } else {
-                        trustStore = null;
+                        trustManagers =
+                            new javax.net.ssl.TrustManager[]{
+                                new X509TrustManager() {
+                                    @Override
+                                    public void checkClientTrusted(
+                                                X509Certificate[] chain, String authType)
+                                        throws CertificateException {
+                                        throw new CertificateException("no trust anchors");
+                                    }
+
+                                    @Override
+                                    public void checkServerTrusted(
+                                                X509Certificate[] chain, String authType)
+                                        throws CertificateException {
+                                        throw new CertificateException("no trust anchors");
+                                    }
+
+                                    @Override
+                                    public X509Certificate[] getAcceptedIssuers() {
+                                        return new X509Certificate[0];
+                                    }
+                                }
+                            };
                     }
 
                     //

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
@@ -51,84 +51,54 @@ public class SSLEngine {
     public void initialize() {
         Properties properties = communicator().getProperties();
 
-        //
-        // CheckCertName determines whether we compare the name in a peer's certificate against its
-        // hostname.
-        //
+        // CheckCertName determines whether we compare the name in a peer's certificate against its hostname.
         _checkCertName = properties.getIcePropertyAsInt("IceSSL.CheckCertName") > 0;
 
-        //
-        // CheckCertName > 1 enables SNI, the SNI extension applies to client connections,
-        // indicating the hostname to the server (must be DNS hostname, not an IP address).
-        //
+        // CheckCertName > 1 enables SNI, the SNI extension applies to client connections, indicating the hostname to
+        // the server (must be DNS hostname, not an IP address).
         _serverNameIndication = properties.getIcePropertyAsInt("IceSSL.CheckCertName") > 1;
 
-        //
         // VerifyPeer determines whether certificate validation failures abort a connection.
-        //
         _verifyPeer = properties.getIcePropertyAsInt("IceSSL.VerifyPeer");
 
-        //
-        // If the user doesn't supply an SSLContext, we need to create one based on property
-        // settings.
-        //
+        // If the user doesn't supply an SSLContext, we need to create one based on property settings.
         if (_context == null) {
             try {
-                //
-                // Check for a default directory. We look in this directory for files mentioned in
-                // the configuration.
-                //
+                // Check for a default directory. We look in this directory for files mentioned in the configuration.
                 _defaultDir = properties.getIceProperty("IceSSL.DefaultDir");
 
-                //
                 // The keystore holds private keys and associated certificates.
-                //
                 String keystorePath = properties.getIceProperty("IceSSL.Keystore");
 
-                //
                 // The password for the keys.
-                //
                 String password = properties.getIceProperty("IceSSL.Password");
 
-                //
                 // The password for the keystore.
-                //
                 String keystorePassword = properties.getIceProperty("IceSSL.KeystorePassword");
 
-                //
-                // The default keystore type is usually "JKS", but the legal values are determined
-                // by the JVM implementation. Other possibilities include "PKCS12" and "BKS".
-                //
+                // The default keystore type is usually "JKS", but the legal values are determined by the JVM
+                // implementation. Other possibilities include "PKCS12" and "BKS".
                 final String defaultType = KeyStore.getDefaultType();
                 final String keystoreType =
                     properties.getPropertyWithDefault("IceSSL.KeystoreType", defaultType);
 
-                //
                 // The alias of the key to use in authentication.
-                //
                 String alias = properties.getIceProperty("IceSSL.Alias");
                 boolean overrideAlias = !alias.isEmpty(); // Always use the configured alias
 
-                //
+
                 // The truststore holds the certificates of trusted CAs.
-                //
                 String truststorePath = properties.getIceProperty("IceSSL.Truststore");
 
-                //
                 // The password for the truststore.
-                //
                 String truststorePassword = properties.getIceProperty("IceSSL.TruststorePassword");
 
-                //
-                // The default truststore type is usually "JKS", but the legal values are determined
-                // by the JVM implementation. Other possibilities include "PKCS12" and "BKS".
-                //
+                // The default truststore type is usually "JKS", but the legal values are determined by the JVM
+                // implementation. Other possibilities include "PKCS12" and "BKS".
                 final String truststoreType =
                     properties.getPropertyWithDefault("IceSSL.TruststoreType", defaultType);
 
-                //
                 // Collect the key managers.
-                //
                 KeyManager[] keyManagers = null;
                 KeyStore keys = null;
                 if (!keystorePath.isEmpty()) {
@@ -169,8 +139,7 @@ public class SSLEngine {
                     }
 
                     String algorithm = KeyManagerFactory.getDefaultAlgorithm();
-                    KeyManagerFactory kmf =
-                        KeyManagerFactory.getInstance(algorithm);
+                    KeyManagerFactory kmf = KeyManagerFactory.getInstance(algorithm);
                     char[] passwordChars = new char[0]; // This password cannot be null.
                     if (!password.isEmpty()) {
                         passwordChars = password.toCharArray();
@@ -182,30 +151,22 @@ public class SSLEngine {
                     password = null;
                     keyManagers = kmf.getKeyManagers();
 
-                    //
                     // If no alias is specified, we look for the first key entry in the key store.
                     //
-                    // This is required to force the key manager to always choose a certificate
-                    // even if there's no certificate signed by any of the CA names sent by the
-                    // server. Ice servers might indeed not always send the CA names of their
-                    // trusted roots.
-                    //
+                    // This is required to force the key manager to always choose a certificate even if there's no
+                    // certificate signed by any of the CA names sent by the server. Ice servers might indeed not
+                    // always send the CA names of their trusted roots.
                     if (alias.isEmpty()) {
-                        for (Enumeration<String> e = keys.aliases();
-                                e.hasMoreElements(); ) {
+                        for (Enumeration<String> e = keys.aliases(); e.hasMoreElements(); ) {
                             String a = e.nextElement();
                             if (keys.isKeyEntry(a)) {
                                 alias = a;
                                 break;
                             }
                         }
-                    }
-
-                    if (!alias.isEmpty()) {
-                        //
-                        // If the user selected a specific alias, we need to wrap the key managers
-                        // in order to return the desired alias.
-                        //
+                    } else {
+                        // If the user selected a specific alias, we need to wrap the key managers in order to return
+                        // the desired alias.
                         if (!keys.isKeyEntry(alias)) {
                             throw new InitializationException(
                                 "SSL transport: keystore does not contain an entry with alias `"
@@ -223,40 +184,33 @@ public class SSLEngine {
                     }
                 }
 
-                //
                 // Load the truststore.
-                //
-                KeyStore ts = null;
+                KeyStore truststore = null;
                 if (!truststorePath.isEmpty()) {
-                    //
-                    // If the trust store and the key store are the same file, don't
-                    // create another key store.
-                    //
+                    // If the trust store and the key store are the same file, don't create another key store.
                     if (truststorePath.equals(keystorePath)) {
                         assert keys != null;
-                        ts = keys;
+                        truststore = keys;
                     } else {
                         InputStream truststoreStream = null;
                         try {
                             truststoreStream = openResource(truststorePath);
                             if (truststoreStream == null) {
                                 throw new InitializationException(
-                                    "SSL transport: truststore not found:\n"
-                                        + truststorePath);
+                                    "SSL transport: truststore not found:\n" + truststorePath);
                             }
 
-                            ts = KeyStore.getInstance(truststoreType);
+                            truststore = KeyStore.getInstance(truststoreType);
 
                             char[] passwordChars = null;
                             if (!truststorePassword.isEmpty()) {
                                 passwordChars = truststorePassword.toCharArray();
-                            } else if ("BKS".equals(truststoreType)
-                                || "PKCS12".equals(truststoreType)) {
+                            } else if ("BKS".equals(truststoreType) || "PKCS12".equals(truststoreType)) {
                                 // Bouncy Castle or PKCS12 does not permit null passwords.
                                 passwordChars = new char[0];
                             }
 
-                            ts.load(truststoreStream, passwordChars);
+                            truststore.load(truststoreStream, passwordChars);
 
                             if (passwordChars != null) {
                                 Arrays.fill(passwordChars, '\0');
@@ -283,16 +237,23 @@ public class SSLEngine {
                 // rejects any certificate.
                 javax.net.ssl.TrustManager[] trustManagers = null;
                 {
-                    String algorithm = TrustManagerFactory.getDefaultAlgorithm();
-                    TrustManagerFactory tmf =
-                        TrustManagerFactory.getInstance(algorithm);
-                    KeyStore trustStore = null;
-                    if (ts != null) {
-                        trustStore = ts;
+                    if (truststore != null) {
+                        String algorithm = TrustManagerFactory.getDefaultAlgorithm();
+                        TrustManagerFactory tmf = TrustManagerFactory.getInstance(algorithm);
+                        // Attempting to establish an outgoing connection with an empty truststore can cause hangs that
+                        // eventually result in an exception such as: `InvalidAlgorithmParameterException` the
+                        // trustAnchors parameter must be non-empty.
+                        if (truststore.size() == 0) {
+                            throw new InitializationException("SSL transport: truststore is empty");
+                        }
+                        tmf.init(truststore);
+                        trustManagers = tmf.getTrustManagers();
+                        assert (trustManagers != null);
                     } else if (properties.getIcePropertyAsInt("IceSSL.UsePlatformCAs") > 0) {
                         // Set trustManagers to null to use the platform CAs
                         trustManagers = null;
                     } else {
+                        // Use a custom trust manager that rejects all certificates.
                         trustManagers =
                             new javax.net.ssl.TrustManager[]{
                                 new X509TrustManager() {
@@ -317,28 +278,9 @@ public class SSLEngine {
                                 }
                             };
                     }
-
-                    //
-                    // Attempting to establish an outgoing connection with an empty truststore can
-                    // cause hangs that eventually result in an exception such as:
-                    //
-                    // java.security.InvalidAlgorithmParameterException: the trustAnchors parameter
-                    // must be non-empty
-                    //
-                    if (trustStore != null && trustStore.size() == 0) {
-                        throw new InitializationException("SSL transport: truststore is empty");
-                    }
-
-                    if (trustManagers == null) {
-                        tmf.init(trustStore);
-                        trustManagers = tmf.getTrustManagers();
-                    }
-                    assert (trustManagers != null);
                 }
 
-                //
                 // Initialize the SSL context.
-                //
                 _context = SSLContext.getInstance("TLS");
                 _context.init(keyManagers, trustManagers, null);
             } catch (GeneralSecurityException ex) {
@@ -346,12 +288,6 @@ public class SSLEngine {
                     "SSL transport: unable to initialize context", ex);
             }
         }
-
-        //
-        // Clear cached input streams.
-        //
-        _keystoreStream = null;
-        _truststoreStream = null;
     }
 
     int securityTraceLevel() {
@@ -372,8 +308,7 @@ public class SSLEngine {
             }
             engine.setUseClientMode(!incoming);
         } catch (Exception ex) {
-            throw new SecurityException(
-                "SSL transport: couldn't create SSL engine", ex);
+            throw new SecurityException("SSL transport: couldn't create SSL engine", ex);
         }
 
         if (incoming) {
@@ -386,9 +321,7 @@ public class SSLEngine {
                 engine.setNeedClientAuth(true);
             }
         } else {
-            //
             // Enable the HTTPS hostname verification algorithm
-            //
             if (_checkCertName && _verifyPeer > 0 && host != null) {
                 SSLParameters params = new SSLParameters();
                 params.setEndpointIdentificationAlgorithm("HTTPS");
@@ -435,10 +368,8 @@ public class SSLEngine {
     }
 
     void verifyPeer(String address, ConnectionInfo info, String desc) {
-        //
-        // IceSSL.VerifyPeer is translated into the proper SSLEngine configuration
-        // for a server, but we have to do it ourselves for a client.
-        //
+        // IceSSL.VerifyPeer is translated into the proper SSLEngine configuration for a server, but we have to do it
+        // ourselves for a client.
         if (!info.incoming) {
             if (_verifyPeer > 0 && !info.verified) {
                 throw new SecurityException(
@@ -488,22 +419,16 @@ public class SSLEngine {
             isAbsolute = f.isAbsolute();
         }
 
-        InitializationData initData =
-            _communicator.getInstance().initializationData();
+        InitializationData initData = _communicator.getInstance().initializationData();
 
         ClassLoader classLoader =
             initData.classLoader != null ? initData.classLoader : getClass().getClassLoader();
 
         InputStream stream = Util.openResource(classLoader, path);
 
-        //
-        // If the first attempt fails and IceSSL.DefaultDir is defined and the original
-        // path is relative, we prepend the default directory and try again.
-        //
+        // Retry with default directory if the first attempt failed and the path is relative.
         if (stream == null && !_defaultDir.isEmpty() && !isAbsolute) {
-            stream =
-                Util.openResource(
-                    classLoader, _defaultDir + File.separator + path);
+            stream = Util.openResource(classLoader, _defaultDir + File.separator + path);
         }
 
         if (stream != null) {
@@ -523,6 +448,4 @@ public class SSLEngine {
     private boolean _serverNameIndication;
     private int _verifyPeer;
     private final TrustManager _trustManager;
-    private InputStream _keystoreStream;
-    private InputStream _truststoreStream;
 }


### PR DESCRIPTION
This PR updates Java IceSSL configuration to not use IceSSL.Truststore as a fallback for IceSSL.Keystore.

There is some additional cleanup, but nothing else should change behaviors.