### PR TITLE
Remove XML Stripping from Doc-Comment Parsing

### DIFF
--- a/cpp/src/IceGrid/Internal.ice
+++ b/cpp/src/IceGrid/Internal.ice
@@ -389,7 +389,7 @@ module IceGrid
     interface InternalRegistry extends FileReader
     {
         /// Register a node with the registry. If a node with the same name is already registered,
-        /// <code>registerNode</code> overrides the existing registration only when the previously
+        /// registerNode overrides the existing registration only when the previously
         /// registered node is not active.
         /// @param info Some information on the node.
         /// @param prx The proxy of the node.
@@ -400,7 +400,7 @@ module IceGrid
             throws NodeActiveException, PermissionDeniedException;
 
         /// Register a replica with the registry. If a replica with the same name is already registered,
-        /// <code>registerReplica</code> overrides the existing registration only when the previously
+        /// registerReplica overrides the existing registration only when the previously
         /// registered node is not active.
         /// @param info Some information on the replica.
         /// @param prx The proxy of the replica.

--- a/cpp/src/IceGrid/Internal.ice
+++ b/cpp/src/IceGrid/Internal.ice
@@ -389,7 +389,7 @@ module IceGrid
     interface InternalRegistry extends FileReader
     {
         /// Register a node with the registry. If a node with the same name is already registered,
-        /// registerNode overrides the existing registration only when the previously
+        /// this operation overrides the existing registration only when the previously
         /// registered node is not active.
         /// @param info Some information on the node.
         /// @param prx The proxy of the node.
@@ -400,7 +400,7 @@ module IceGrid
             throws NodeActiveException, PermissionDeniedException;
 
         /// Register a replica with the registry. If a replica with the same name is already registered,
-        /// registerReplica overrides the existing registration only when the previously
+        /// this operation overrides the existing registration only when the previously
         /// registered node is not active.
         /// @param info Some information on the replica.
         /// @param prx The proxy of the replica.

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -300,23 +300,9 @@ namespace
         }
     }
 
-    StringList splitComment(string comment, bool stripMarkup, bool escapeXml)
+    StringList splitComment(string comment, bool escapeXml)
     {
         string::size_type pos = 0;
-
-        if (stripMarkup)
-        {
-            // Strip HTML markup.
-            while ((pos = comment.find('<', pos)) != string::npos)
-            {
-                string::size_type endpos = comment.find('>', pos);
-                if (endpos == string::npos)
-                {
-                    break;
-                }
-                comment.erase(pos, endpos - pos + 1);
-            }
-        }
 
         // Escape XML entities.
         if (escapeXml)
@@ -446,10 +432,10 @@ namespace
 }
 
 optional<DocComment>
-Slice::DocComment::parseFrom(const ContainedPtr& p, DocLinkFormatter linkFormatter, bool stripMarkup, bool escapeXml)
+Slice::DocComment::parseFrom(const ContainedPtr& p, DocLinkFormatter linkFormatter, bool escapeXml)
 {
     // Split the comment's raw text up into lines.
-    StringList lines = splitComment(p->docComment(), stripMarkup, escapeXml);
+    StringList lines = splitComment(p->docComment(), escapeXml);
     if (lines.empty())
     {
         return nullopt;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -269,10 +269,8 @@ namespace Slice
         ///
         /// @return A `DocComment` instance containing a parsed representation of `p`'s doc-comment, if a doc-comment
         /// was present. If no doc-comment was present (or it contained only whitespace) this returns `nullopt` instead.
-        [[nodiscard]] static std::optional<DocComment> parseFrom(
-            const ContainedPtr& p,
-            DocLinkFormatter linkFormatter,
-            bool escapeXml = false);
+        [[nodiscard]] static std::optional<DocComment>
+        parseFrom(const ContainedPtr& p, DocLinkFormatter linkFormatter, bool escapeXml = false);
 
         [[nodiscard]] bool isDeprecated() const;
         [[nodiscard]] StringList deprecated() const;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -272,7 +272,6 @@ namespace Slice
         [[nodiscard]] static std::optional<DocComment> parseFrom(
             const ContainedPtr& p,
             DocLinkFormatter linkFormatter,
-            bool stripMarkup = false,
             bool escapeXml = false);
 
         [[nodiscard]] bool isDeprecated() const;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -264,7 +264,6 @@ namespace Slice
         ///
         /// @param p The slice element whose doc-comment should be parsed.
         /// @param linkFormatter A function used to format links according to the target language's syntax.
-        /// @param stripMarkup If true, removes all HTML markup from the parsed comment. Defaults to false.
         /// @param escapeXml If true, escapes all XML special characters in the parsed comment. Defaults to false.
         ///
         /// @return A `DocComment` instance containing a parsed representation of `p`'s doc-comment, if a doc-comment

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -238,7 +238,7 @@ namespace
 
     void writeDocComment(const ContainedPtr& contained, Output& out)
     {
-        optional<DocComment> comment = DocComment::parseFrom(contained, slice2LinkFormatter, true);
+        optional<DocComment> comment = DocComment::parseFrom(contained, slice2LinkFormatter);
         if (!comment)
         {
             return;

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -767,7 +767,7 @@ Slice::CsVisitor::writeDataMemberInitializers(const DataMemberList& dataMembers)
 void
 Slice::CsVisitor::writeDocComment(const ContainedPtr& p, const string& generatedType, const string& notes)
 {
-    optional<DocComment> comment = DocComment::parseFrom(p, csLinkFormatter, true, true);
+    optional<DocComment> comment = DocComment::parseFrom(p, csLinkFormatter, true);
     StringList remarks;
     if (comment)
     {
@@ -827,7 +827,7 @@ Slice::CsVisitor::writeHelperDocComment(
 void
 Slice::CsVisitor::writeOpDocComment(const OperationPtr& op, const vector<string>& extraParams, bool isAsync)
 {
-    optional<DocComment> comment = DocComment::parseFrom(op, csLinkFormatter, true, true);
+    optional<DocComment> comment = DocComment::parseFrom(op, csLinkFormatter, true);
     if (!comment)
     {
         return;

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -596,7 +596,7 @@ namespace
 
     void writeDocSummary(IceInternal::Output& out, const ContainedPtr& p)
     {
-        optional<DocComment> doc = DocComment::parseFrom(p, matlabLinkFormatter, true);
+        optional<DocComment> doc = DocComment::parseFrom(p, matlabLinkFormatter);
         if (!doc)
         {
             return;
@@ -626,7 +626,7 @@ namespace
                 for (const auto& enumerator : enumerators)
                 {
                     out << nl << "%   " << enumerator->mappedName();
-                    if (auto enumeratorDoc = DocComment::parseFrom(enumerator, matlabLinkFormatter, true))
+                    if (auto enumeratorDoc = DocComment::parseFrom(enumerator, matlabLinkFormatter))
                     {
                         StringList enumeratorOverview = enumeratorDoc->overview();
                         if (!enumeratorOverview.empty())
@@ -648,7 +648,7 @@ namespace
                 for (const auto& member : members)
                 {
                     out << nl << "%   " << member->mappedName();
-                    if (auto memberDoc = DocComment::parseFrom(member, matlabLinkFormatter, true))
+                    if (auto memberDoc = DocComment::parseFrom(member, matlabLinkFormatter))
                     {
                         StringList memberOverview = memberDoc->overview();
                         if (!memberOverview.empty())
@@ -670,7 +670,7 @@ namespace
                 for (const auto& member : members)
                 {
                     out << nl << "%   " << member->mappedName();
-                    if (auto memberDoc = DocComment::parseFrom(member, matlabLinkFormatter, true))
+                    if (auto memberDoc = DocComment::parseFrom(member, matlabLinkFormatter))
                     {
                         StringList memberOverview = memberDoc->overview();
                         if (!memberOverview.empty())
@@ -692,7 +692,7 @@ namespace
                 for (const auto& member : members)
                 {
                     out << nl << "%   " << member->mappedName();
-                    if (auto memberDoc = DocComment::parseFrom(member, matlabLinkFormatter, true))
+                    if (auto memberDoc = DocComment::parseFrom(member, matlabLinkFormatter))
                     {
                         StringList memberOverview = memberDoc->overview();
                         if (!memberOverview.empty())
@@ -730,7 +730,7 @@ namespace
 
     void writeOpDocSummary(IceInternal::Output& out, const OperationPtr& p, bool async)
     {
-        optional<DocComment> doc = DocComment::parseFrom(p, matlabLinkFormatter, true);
+        optional<DocComment> doc = DocComment::parseFrom(p, matlabLinkFormatter);
         if (!doc)
         {
             return;
@@ -891,7 +891,7 @@ namespace
 
     void writeProxyDocSummary(IceInternal::Output& out, const InterfaceDefPtr& p)
     {
-        optional<DocComment> doc = DocComment::parseFrom(p, matlabLinkFormatter, true);
+        optional<DocComment> doc = DocComment::parseFrom(p, matlabLinkFormatter);
         if (!doc)
         {
             return;
@@ -919,7 +919,7 @@ namespace
             for (const auto& op : ops)
             {
                 const string opName = op->mappedName();
-                const optional<DocComment> opdoc = DocComment::parseFrom(op, matlabLinkFormatter, true);
+                const optional<DocComment> opdoc = DocComment::parseFrom(op, matlabLinkFormatter);
                 out << nl << "%   " << opName;
                 if (opdoc)
                 {
@@ -970,7 +970,7 @@ namespace
 
     void writeMemberDoc(IceInternal::Output& out, const DataMemberPtr& p)
     {
-        optional<DocComment> doc = DocComment::parseFrom(p, matlabLinkFormatter, true);
+        optional<DocComment> doc = DocComment::parseFrom(p, matlabLinkFormatter);
         if (!doc)
         {
             return;

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -499,7 +499,7 @@ Slice::Python::CodeVisitor::visitModuleStart(const ModulePtr& p)
     }
     _out << nl << "__name__ = \"" << abs << "\"";
 
-    writeDocstring(DocComment::parseFrom(p, pyLinkFormatter, true), "_M_" + abs + ".__doc__ = ");
+    writeDocstring(DocComment::parseFrom(p, pyLinkFormatter), "_M_" + abs + ".__doc__ = ");
 
     _moduleStack.push_front(abs);
     return true;
@@ -629,7 +629,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     _out.inc();
 
-    writeDocstring(DocComment::parseFrom(p, pyLinkFormatter, true), members);
+    writeDocstring(DocComment::parseFrom(p, pyLinkFormatter), members);
 
     //
     // __init__
@@ -1169,7 +1169,7 @@ Slice::Python::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     _out << "):";
     _out.inc();
 
-    writeDocstring(DocComment::parseFrom(p, pyLinkFormatter, true), members);
+    writeDocstring(DocComment::parseFrom(p, pyLinkFormatter), members);
 
     //
     // __init__
@@ -1288,7 +1288,7 @@ Slice::Python::CodeVisitor::visitStructStart(const StructPtr& p)
     _out << nl << "class " << name << "(object):";
     _out.inc();
 
-    writeDocstring(DocComment::parseFrom(p, pyLinkFormatter, true), members);
+    writeDocstring(DocComment::parseFrom(p, pyLinkFormatter), members);
 
     _out << nl << "def __init__(self";
     writeConstructorParams(p->dataMembers());
@@ -1585,7 +1585,7 @@ Slice::Python::CodeVisitor::visitEnum(const EnumPtr& p)
     _out << nl << "class " << name << "(Ice.EnumBase):";
     _out.inc();
 
-    writeDocstring(DocComment::parseFrom(p, pyLinkFormatter, true), enumerators);
+    writeDocstring(DocComment::parseFrom(p, pyLinkFormatter), enumerators);
 
     _out << sp << nl << "def __init__(self, _n, _v):";
     _out.inc();
@@ -2006,7 +2006,7 @@ Slice::Python::CodeVisitor::writeDocstring(const optional<DocComment>& comment, 
     map<string, list<string>> docs;
     for (const auto& member : members)
     {
-        if (auto memberDoc = DocComment::parseFrom(member, pyLinkFormatter, true))
+        if (auto memberDoc = DocComment::parseFrom(member, pyLinkFormatter))
         {
             auto memberOverview = memberDoc->overview();
             if (!memberOverview.empty())
@@ -2068,7 +2068,7 @@ Slice::Python::CodeVisitor::writeDocstring(const optional<DocComment>& comment, 
     map<string, list<string>> docs;
     for (const auto& enumerator : enumerators)
     {
-        if (auto enumeratorDoc = DocComment::parseFrom(enumerator, pyLinkFormatter, true))
+        if (auto enumeratorDoc = DocComment::parseFrom(enumerator, pyLinkFormatter))
         {
             auto enumeratorOverview = enumeratorDoc->overview();
             if (!enumeratorOverview.empty())
@@ -2122,7 +2122,7 @@ Slice::Python::CodeVisitor::writeDocstring(const optional<DocComment>& comment, 
 void
 Slice::Python::CodeVisitor::writeDocstring(const OperationPtr& op, DocstringMode mode)
 {
-    optional<DocComment> comment = DocComment::parseFrom(op, pyLinkFormatter, true);
+    optional<DocComment> comment = DocComment::parseFrom(op, pyLinkFormatter);
     if (!comment)
     {
         return;

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -172,7 +172,7 @@ SwiftGenerator::writeDocSentence(IceInternal::Output& out, const StringList& lin
 void
 SwiftGenerator::writeDocSummary(IceInternal::Output& out, const ContainedPtr& p)
 {
-    optional<DocComment> doc = DocComment::parseFrom(p, swiftLinkFormatter, true);
+    optional<DocComment> doc = DocComment::parseFrom(p, swiftLinkFormatter);
     if (!doc)
     {
         return;
@@ -207,7 +207,7 @@ SwiftGenerator::writeDocSummary(IceInternal::Output& out, const ContainedPtr& p)
 void
 SwiftGenerator::writeOpDocSummary(IceInternal::Output& out, const OperationPtr& p, bool dispatch)
 {
-    optional<DocComment> doc = DocComment::parseFrom(p, swiftLinkFormatter, true);
+    optional<DocComment> doc = DocComment::parseFrom(p, swiftLinkFormatter);
     if (!doc)
     {
         return;
@@ -365,7 +365,7 @@ SwiftGenerator::writeOpDocSummary(IceInternal::Output& out, const OperationPtr& 
 void
 SwiftGenerator::writeProxyDocSummary(IceInternal::Output& out, const InterfaceDefPtr& p, const string& swiftModule)
 {
-    optional<DocComment> doc = DocComment::parseFrom(p, swiftLinkFormatter, true);
+    optional<DocComment> doc = DocComment::parseFrom(p, swiftLinkFormatter);
     if (!doc)
     {
         return;
@@ -390,7 +390,7 @@ SwiftGenerator::writeProxyDocSummary(IceInternal::Output& out, const InterfaceDe
         out << nl << "/// " << prx << " Methods:";
         for (const auto& op : ops)
         {
-            optional<DocComment> opdoc = DocComment::parseFrom(op, swiftLinkFormatter, true);
+            optional<DocComment> opdoc = DocComment::parseFrom(op, swiftLinkFormatter);
             optional<StringList> opDocOverview;
             if (opdoc)
             {
@@ -423,7 +423,7 @@ SwiftGenerator::writeProxyDocSummary(IceInternal::Output& out, const InterfaceDe
 void
 SwiftGenerator::writeServantDocSummary(IceInternal::Output& out, const InterfaceDefPtr& p, const string& swiftModule)
 {
-    optional<DocComment> doc = DocComment::parseFrom(p, swiftLinkFormatter, true);
+    optional<DocComment> doc = DocComment::parseFrom(p, swiftLinkFormatter);
     if (!doc)
     {
         return;
@@ -449,7 +449,7 @@ SwiftGenerator::writeServantDocSummary(IceInternal::Output& out, const Interface
         for (const auto& op : ops)
         {
             out << nl << "///  - " << removeEscaping(op->mappedName());
-            optional<DocComment> opdoc = DocComment::parseFrom(op, swiftLinkFormatter, true);
+            optional<DocComment> opdoc = DocComment::parseFrom(op, swiftLinkFormatter);
             if (opdoc)
             {
                 StringList opdocOverview = opdoc->overview();


### PR DESCRIPTION
Currently, the doc-comment parser can strip out XML tags from doc-comments, controlled by a bool `stripMarkup`. However, Slice doc-comments have no special logic for XML tags, and we don't recommend using them.

This PR removes this logic. So now any XML tags in comments will be preserved.
This only affects `ice2slice`, `slice2cs`, `slice2matlab`, `slice2py`, and `slice2swift`; the only languages where `true` was passed for this bool.