### PR TITLE
Fix Places Where Null Doc-Comments Could Be Mistakenly Accessed

### DIFF
--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -386,13 +386,16 @@ Slice::JavaVisitor::writeResultType(
     out << sp;
     if (ret)
     {
-        const StringList& returns = dc->returns();
-        if (dc && !returns.empty())
+        if (dc)
         {
-            out << nl << "/**";
-            out << nl << " * ";
-            writeDocCommentLines(out, returns);
-            out << nl << " **/";
+            const StringList& returns = dc->returns();
+            if (!returns.empty())
+            {
+                out << nl << "/**";
+                out << nl << " * ";
+                writeDocCommentLines(out, returns);
+                out << nl << " **/";
+            }
         }
         out << nl << "public "
             << typeToString(ret, TypeModeIn, package, op->getMetadata(), true, op->returnIsOptional()) << ' ' << retval

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -196,18 +196,22 @@ namespace
     {
         // JavaScript doesn't provide a way to deprecate elements other than by using a comment, so we map both the
         // Slice @deprecated tag and the deprecated metadata argument to a `@deprecated` JSDoc tag.
-        if ((comment && comment->isDeprecated()) || contained->isDeprecated())
+        if (comment && comment->isDeprecated())
         {
-            out << nl << " * @deprecated";
-            // If a reason was supplied, append it after the `@deprecated` tag. If no reason was supplied, fallback to
-            // the deprecated metadata argument.
+            // If a reason was supplied, append it after the `@deprecated` tag.
             const StringList& deprecatedDoc = comment->deprecated();
             if (!deprecatedDoc.empty())
             {
-                out << " ";
+                out << nl << " * @deprecated ";
                 writeDocLines(out, deprecatedDoc, false);
+                return;
             }
-            else if (auto deprecated = contained->getDeprecationReason())
+        }
+        if ((comment && comment->isDeprecated()) || contained->isDeprecated())
+        {
+            // If no reason was supplied, fallback to the 'deprecated' metadata argument.
+            out << nl << " * @deprecated";
+            if (auto deprecated = contained->getDeprecationReason())
             {
                 out << " " << *deprecated;
             }


### PR DESCRIPTION
While updating the API for `DocComment` to use const references, I came across two places where it's possible for us to accidentally dereference a null doc-comment (bad).

This PR fixes these two places to check that the comment is non-null before accessing it.

I looked through all the places where DocComments were used, and I believe these are the only 2 places.