### PR TITLE
Remove Disp structs in Swift, part 1

### DIFF
--- a/swift/test/Ice/inheritance/TestI.swift
+++ b/swift/test/Ice/inheritance/TestI.swift
@@ -9,40 +9,27 @@ class IAI: MAIA {
     }
 }
 
-class IB1I: MBIB1 {
-    func iaop(p: MAIAPrx?, current _: Ice.Current) async throws -> MAIAPrx? {
-        return p
-    }
-
+// Tests implementation reuse by deriving from IAI.
+class IB1I: IAI, MBIB1 {
     func ib1op(p: MBIB1Prx?, current _: Ice.Current) async throws -> MBIB1Prx? {
         return p
     }
 }
 
-class IB2I: MBIB2 {
-    func iaop(p: MAIAPrx?, current _: Ice.Current) async throws -> MAIAPrx? {
-        return p
-    }
-
+// Tests implementation reuse by deriving from IAI.
+class IB2I: IAI, MBIB2 {
     func ib2op(p: MBIB2Prx?, current _: Ice.Current) async throws -> MBIB2Prx? {
         return p
     }
 }
 
-class ICI: MAIC {
-    func iaop(p: MAIAPrx?, current _: Ice.Current) async throws -> MAIAPrx? {
+// Tests implementation reuse by deriving from IAI.
+class ICI: IB1I, MAIC {
+    func ib2op(p: MBIB2Prx?, current _: Ice.Current) async throws -> MBIB2Prx? {
         return p
     }
 
     func icop(p: MAICPrx?, current _: Ice.Current) async throws -> MAICPrx? {
-        return p
-    }
-
-    func ib1op(p: MBIB1Prx?, current _: Ice.Current) async throws -> MBIB1Prx? {
-        return p
-    }
-
-    func ib2op(p: MBIB2Prx?, current _: Ice.Current) async throws -> MBIB2Prx? {
         return p
     }
 }

--- a/swift/test/Ice/inheritance/TestI.swift
+++ b/swift/test/Ice/inheritance/TestI.swift
@@ -7,6 +7,12 @@ class IAI: MAIA {
     func iaop(p: MAIAPrx?, current _: Ice.Current) async throws -> MAIAPrx? {
         return p
     }
+
+    // Since we plan to reuse this implementation, we need to define an overridable dispatch method in the base class.
+    func dispatch(_ request: Ice.IncomingRequest) async throws -> Ice.OutgoingResponse {
+        // The implementation forwards to the static dispatch method defined on the generated protocol extension.
+        try await Self.dispatch(self, request: request)
+    }
 }
 
 // Tests implementation reuse by deriving from IAI.
@@ -14,12 +20,24 @@ class IB1I: IAI, MBIB1 {
     func ib1op(p: MBIB1Prx?, current _: Ice.Current) async throws -> MBIB1Prx? {
         return p
     }
+
+    // Override the dispatch method with the correct implementation.
+    override func dispatch(_ request: Ice.IncomingRequest) async throws -> Ice.OutgoingResponse {
+        // The implementation forwards to the static dispatch method defined on the generated protocol extension.
+        try await Self.dispatch(self, request: request)
+    }
 }
 
 // Tests implementation reuse by deriving from IAI.
 class IB2I: IAI, MBIB2 {
     func ib2op(p: MBIB2Prx?, current _: Ice.Current) async throws -> MBIB2Prx? {
         return p
+    }
+
+    // Override the dispatch method with the correct implementation.
+    override func dispatch(_ request: Ice.IncomingRequest) async throws -> Ice.OutgoingResponse {
+        // The implementation forwards to the static dispatch method defined on the generated protocol extension.
+        try await Self.dispatch(self, request: request)
     }
 }
 
@@ -32,6 +50,12 @@ class ICI: IB1I, MAIC {
     func icop(p: MAICPrx?, current _: Ice.Current) async throws -> MAICPrx? {
         return p
     }
+
+    // Override the dispatch method with the correct implementation.
+    override func dispatch(_ request: Ice.IncomingRequest) async throws -> Ice.OutgoingResponse {
+        // The implementation forwards to the static dispatch method defined on the generated protocol extension.
+        try await Self.dispatch(self, request: request)
+    }
 }
 
 class InitialI: Initial {
@@ -41,10 +65,10 @@ class InitialI: Initial {
     let _ic: MAICPrx
 
     init(_ adapter: Ice.ObjectAdapter) throws {
-        _ia = try uncheckedCast(prx: adapter.addWithUUID(MAIADisp(IAI())), type: MAIAPrx.self)
-        _ib1 = try uncheckedCast(prx: adapter.addWithUUID(MBIB1Disp(IB1I())), type: MBIB1Prx.self)
-        _ib2 = try uncheckedCast(prx: adapter.addWithUUID(MBIB2Disp(IB2I())), type: MBIB2Prx.self)
-        _ic = try uncheckedCast(prx: adapter.addWithUUID(MAICDisp(ICI())), type: MAICPrx.self)
+        _ia = try uncheckedCast(prx: adapter.addWithUUID(IAI()), type: MAIAPrx.self)
+        _ib1 = try uncheckedCast(prx: adapter.addWithUUID(IB1I()), type: MBIB1Prx.self)
+        _ib2 = try uncheckedCast(prx: adapter.addWithUUID(IB2I()), type: MBIB2Prx.self)
+        _ic = try uncheckedCast(prx: adapter.addWithUUID(ICI()), type: MAICPrx.self)
     }
 
     func iaop(current _: Ice.Current) async throws -> MAIAPrx? {

--- a/swift/test/Ice/inheritance/TestI.swift
+++ b/swift/test/Ice/inheritance/TestI.swift
@@ -23,7 +23,7 @@ class IB2I: IAI, MBIB2 {
     }
 }
 
-// Tests implementation reuse by deriving from IAI.
+// Tests implementation reuse by deriving from IB1I.
 class ICI: IB1I, MAIC {
     func ib2op(p: MBIB2Prx?, current _: Ice.Current) async throws -> MBIB2Prx? {
         return p

--- a/swift/test/Ice/inheritance/TestI.swift
+++ b/swift/test/Ice/inheritance/TestI.swift
@@ -42,7 +42,7 @@ class IB2I: IAI, MBIB2 {
 }
 
 // Tests implementation reuse by deriving from IB1I.
-class ICI: IB1I, MAIC {
+final class ICI: IB1I, MAIC {
     func ib2op(p: MBIB2Prx?, current _: Ice.Current) async throws -> MBIB2Prx? {
         return p
     }

--- a/swift/test/Ice/operations/Server.swift
+++ b/swift/test/Ice/operations/Server.swift
@@ -29,7 +29,7 @@ class Server: TestHelperI {
             key: "TestAdapter.Endpoints", value: getTestEndpoint(num: 0))
         let adapter = try communicator.createObjectAdapter("TestAdapter")
         try adapter.add(
-            servant: MyDerivedClassDisp(MyDerivedClassI(self)), id: Ice.Identity(name: "test"))
+            servant: MyDerivedClassI(self), id: Ice.Identity(name: "test"))
         try adapter.activate()
         serverReady()
         communicator.waitForShutdown()

--- a/swift/test/Ice/proxy/Collocated.swift
+++ b/swift/test/Ice/proxy/Collocated.swift
@@ -18,7 +18,7 @@ class Collocated: TestHelperI {
             key: "TestAdapter.Endpoints", value: getTestEndpoint(num: 0))
         let adapter = try communicator.createObjectAdapter("TestAdapter")
         try adapter.add(
-            servant: MyDerivedClassDisp(MyDerivedClassI()),
+            servant: MyDerivedClassI(),
             id: Ice.Identity(name: "test"))
         // try adapter.activate() // Don't activate OA to ensure collocation is used.
         _ = try await allTests(self)

--- a/swift/test/Ice/proxy/Server.swift
+++ b/swift/test/Ice/proxy/Server.swift
@@ -20,7 +20,7 @@ class Server: TestHelperI {
             key: "TestAdapter.Endpoints", value: getTestEndpoint(num: 0))
         let adapter = try communicator.createObjectAdapter("TestAdapter")
         try adapter.add(
-            servant: MyDerivedClassDisp(MyDerivedClassI()),
+            servant: MyDerivedClassI(),
             id: Ice.Identity(name: "test"))
         try adapter.activate()
         serverReady()


### PR DESCRIPTION
This is part 1 of the removal of the generated Disp structs in Swift.

## Background

Currently, for each Slice interface Name, we generate on the server-side:
 - protocol Name
 - extension Name
 - struct NameDisp that conforms to protocol Dispatcher

struct NameDisp holds onto a servant of type Name. NameDisp uses servant to implement Dispatcher.dispatch.

The reason for this complicated setup is our desire to support implementation reuse, as demonstrated by the filesystem demo. And, more importantly, this well-known Swift bug:
https://github.com/swiftlang/swift/issues/42725

prevents us from "overriding" protocol extension automatically.

## Proposed fix

The proposed fix, implemented by this PR, boils down to:

- while supporting implementation reuse is nice feature, it's a very rare use-case. So it's desirable to make the standard use-case (no impl reuse) simpler, while requiring extra work from the user in the reuse case.
- in 3.8, the dispatch method is now public / explained / documented, so we can user to override it in the advanced impl-reuse use-case

And that's exactly what this PR does:
- in the standard use-case, you just use the non-overridable dispatch implementation provided by the generated protocol extension
- in the impl-reuse use-case, you need to define an overridable dispatch instance method (or override this method from a base class), and provide a trivial implementation, namely:

```swift
func dispatch(_ request: Ice.IncomingRequest) async throws -> Ice.OutgoingResponse {
        // The implementation forwards to the static dispatch method defined on the generated protocol extension.
        try await Self.dispatch(self, request: request)
    }
```

See the Ice/inheritance test for an example.

Note:
- This PR includes #4014.
- This PR does not remove NameDisp, just stops using it in 3 tests. A follow-up PR will actually remove NameDisp.
