### PR TITLE
Remove InvocationCanceledException in Swift

### DIFF
--- a/swift/src/Ice/LocalExceptions.swift
+++ b/swift/src/Ice/LocalExceptions.swift
@@ -370,9 +370,6 @@ public final class FixedProxyException: LocalException {}
 /// This exception is raised when a failure occurs during initialization.
 public final class InitializationException: LocalException {}
 
-/// This exception indicates that an asynchronous invocation failed because it was canceled explicitly by the user.
-public final class InvocationCanceledException: LocalException {}
-
 /// This exception is raised if no suitable endpoint is available.
 public final class NoEndpointException: LocalException {
     /// Creates a NoEndpointException.


### PR DESCRIPTION
We currently don't support invocation cancellation in Swift, so it is (or would be) confusing to provide this local exception.