### PR TITLE
Make InvocationCanceledException package private.

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InvocationCanceledException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InvocationCanceledException.java
@@ -3,11 +3,11 @@
 package com.zeroc.Ice;
 
 /**
- * This exception indicates that an asynchronous invocation failed because it was canceled
- * explicitly by the user.
+ * This exception is used internally to propagate an invocation cancellation. This exception is created by a call to
+ * cancel() on the future returned by an asynchronous invocation.
  */
-public final class InvocationCanceledException extends LocalException {
-    public InvocationCanceledException() {
+final class InvocationCanceledException extends LocalException {
+    InvocationCanceledException() {
         super("Invocation canceled.");
     }
 


### PR DESCRIPTION
The user can never catch this exception; however, we use it internally.