### PR TITLE
Remove InvocationCanceledException from Ruby and PHP

### DIFF
--- a/php/lib/Ice/LocalExceptions.php
+++ b/php/lib/Ice/LocalExceptions.php
@@ -101,8 +101,6 @@ final class FixedProxyException extends LocalException {}
 
 final class InitializationException extends LocalException {}
 
-final class InvocationCanceledException extends LocalException {}
-
 final class NoEndpointException extends LocalException {}
 
 final class NotRegisteredException extends LocalException

--- a/ruby/ruby/Ice/LocalExceptions.rb
+++ b/ruby/ruby/Ice/LocalExceptions.rb
@@ -139,9 +139,6 @@ module Ice
     class InitializationException < LocalException
     end
 
-    class InvocationCanceledException < LocalException
-    end
-
     class NoEndpointException < LocalException
     end
 


### PR DESCRIPTION
Ruby and PHP support only synchronous invocations, and as a result, this exception is never thrown.