### PR TITLE
The Parser Now Stores Enumerators, Tags, and Compact-IDs in `int32_t` Instead of `int`.

### DIFF
--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -774,11 +774,11 @@ static const yytype_int16 yyrline[] =
     1519,  1531,  1544,  1558,  1571,  1579,  1593,  1594,  1600,  1601,
     1607,  1611,  1620,  1623,  1631,  1632,  1633,  1634,  1635,  1636,
     1637,  1638,  1639,  1640,  1645,  1649,  1654,  1659,  1669,  1673,
-    1759,  1765,  1773,  1783,  1793,  1797,  1806,  1815,  1824,  1859,
-    1866,  1873,  1885,  1894,  1908,  1909,  1910,  1911,  1912,  1913,
-    1914,  1915,  1916,  1917,  1918,  1919,  1920,  1921,  1922,  1923,
-    1924,  1925,  1926,  1927,  1928,  1929,  1930,  1931,  1932,  1933,
-    1934
+    1758,  1764,  1772,  1782,  1792,  1796,  1805,  1814,  1823,  1858,
+    1865,  1872,  1884,  1893,  1907,  1908,  1909,  1910,  1911,  1912,
+    1913,  1914,  1915,  1916,  1917,  1918,  1919,  1920,  1921,  1922,
+    1923,  1924,  1925,  1926,  1927,  1928,  1929,  1930,  1931,  1932,
+    1933
 };
 #endif
 
@@ -2280,11 +2280,11 @@ yyreduce:
 #line 612 "src/Slice/Grammar.y"
 {
     auto integer = dynamic_pointer_cast<IntegerTok>(yyvsp[-1]);
-    int tag = -1;
+    int32_t tag = -1;
 
     if (integer && checkIntegerBounds(integer, "tag"))
     {
-        tag = static_cast<int>(integer->v);
+        tag = static_cast<int32_t>(integer->v);
     }
 
     auto m = make_shared<OptionalDefTok>(tag);
@@ -2437,11 +2437,11 @@ yyreduce:
 #line 751 "src/Slice/Grammar.y"
 {
     auto integer = dynamic_pointer_cast<IntegerTok>(yyvsp[-1]);
-    int id = -1;
+    int32_t id = -1;
 
     if (integer && checkIntegerBounds(integer, "compact id"))
     {
-        id = static_cast<int>(integer->v);
+        id = static_cast<int32_t>(integer->v);
         string typeId = currentUnit->getTypeId(id);
         if (!typeId.empty())
         {
@@ -3317,7 +3317,7 @@ yyreduce:
     {
         // We report numbers that are out of range, but always create the enumerator no matter what.
         checkIntegerBounds(intVal, "enumerator value");
-        yyval = cont->createEnumerator(ident->v, static_cast<int>(intVal->v));
+        yyval = cont->createEnumerator(ident->v, static_cast<int32_t>(intVal->v));
     }
     else
     {
@@ -3587,7 +3587,7 @@ yyreduce:
         }
     }
 
-    optional<int> integerValue;
+    optional<int64_t> integerValue;
     if (cl.empty())
     {
         // If we couldn't find any Slice types matching the provided name, report an error.
@@ -3601,8 +3601,7 @@ yyreduce:
             auto b = dynamic_pointer_cast<Builtin>(constant->type());
             if (b && b->isIntegralType())
             {
-                int64_t l = std::stoll(constant->value(), nullptr, 0);
-                integerValue = static_cast<int>(l);
+                integerValue = std::stoll(constant->value(), nullptr, 0);
             }
         }
         else if (auto enumerator = dynamic_pointer_cast<Enumerator>(cl.front()))
@@ -3630,28 +3629,28 @@ yyreduce:
         yyval = nullptr;
     }
 }
-#line 3634 "src/Slice/Grammar.cpp"
+#line 3633 "src/Slice/Grammar.cpp"
     break;
 
   case 170: /* string_literal: ICE_STRING_LITERAL string_literal  */
-#line 1760 "src/Slice/Grammar.y"
+#line 1759 "src/Slice/Grammar.y"
 {
     auto str1 = dynamic_pointer_cast<StringTok>(yyvsp[-1]);
     auto str2 = dynamic_pointer_cast<StringTok>(yyvsp[0]);
     str1->v += str2->v;
 }
-#line 3644 "src/Slice/Grammar.cpp"
+#line 3643 "src/Slice/Grammar.cpp"
     break;
 
   case 171: /* string_literal: ICE_STRING_LITERAL  */
-#line 1766 "src/Slice/Grammar.y"
+#line 1765 "src/Slice/Grammar.y"
 {
 }
-#line 3651 "src/Slice/Grammar.cpp"
+#line 3650 "src/Slice/Grammar.cpp"
     break;
 
   case 172: /* metadata_list: metadata_list ',' string_literal  */
-#line 1774 "src/Slice/Grammar.y"
+#line 1773 "src/Slice/Grammar.y"
 {
     auto str = dynamic_pointer_cast<StringTok>(yyvsp[0]);
     auto metadataList = dynamic_pointer_cast<MetadataListTok>(yyvsp[-2]);
@@ -3661,11 +3660,11 @@ yyreduce:
 
     yyval = metadataList;
 }
-#line 3665 "src/Slice/Grammar.cpp"
+#line 3664 "src/Slice/Grammar.cpp"
     break;
 
   case 173: /* metadata_list: string_literal  */
-#line 1784 "src/Slice/Grammar.y"
+#line 1783 "src/Slice/Grammar.y"
 {
     auto str = dynamic_pointer_cast<StringTok>(yyvsp[0]);
     auto metadataList = make_shared<MetadataListTok>();
@@ -3675,27 +3674,27 @@ yyreduce:
 
     yyval = metadataList;
 }
-#line 3679 "src/Slice/Grammar.cpp"
+#line 3678 "src/Slice/Grammar.cpp"
     break;
 
   case 174: /* metadata_list: metadata_list ',' BAD_TOKEN  */
-#line 1794 "src/Slice/Grammar.y"
+#line 1793 "src/Slice/Grammar.y"
 {
     yyval = yyvsp[-2];
 }
-#line 3687 "src/Slice/Grammar.cpp"
+#line 3686 "src/Slice/Grammar.cpp"
     break;
 
   case 175: /* metadata_list: BAD_TOKEN  */
-#line 1798 "src/Slice/Grammar.y"
+#line 1797 "src/Slice/Grammar.y"
 {
     yyval = make_shared<MetadataListTok>();
 }
-#line 3695 "src/Slice/Grammar.cpp"
+#line 3694 "src/Slice/Grammar.cpp"
     break;
 
   case 176: /* const_initializer: ICE_INTEGER_LITERAL  */
-#line 1807 "src/Slice/Grammar.y"
+#line 1806 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindLong);
     auto intVal = dynamic_pointer_cast<IntegerTok>(yyvsp[0]);
@@ -3704,11 +3703,11 @@ yyreduce:
     auto def = make_shared<ConstDefTok>(type, sstr.str());
     yyval = def;
 }
-#line 3708 "src/Slice/Grammar.cpp"
+#line 3707 "src/Slice/Grammar.cpp"
     break;
 
   case 177: /* const_initializer: ICE_FLOATING_POINT_LITERAL  */
-#line 1816 "src/Slice/Grammar.y"
+#line 1815 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindDouble);
     auto floatVal = dynamic_pointer_cast<FloatingTok>(yyvsp[0]);
@@ -3717,11 +3716,11 @@ yyreduce:
     auto def = make_shared<ConstDefTok>(type, sstr.str());
     yyval = def;
 }
-#line 3721 "src/Slice/Grammar.cpp"
+#line 3720 "src/Slice/Grammar.cpp"
     break;
 
   case 178: /* const_initializer: scoped_name  */
-#line 1825 "src/Slice/Grammar.y"
+#line 1824 "src/Slice/Grammar.y"
 {
     auto scoped = dynamic_pointer_cast<StringTok>(yyvsp[0]);
     ConstDefTokPtr def;
@@ -3756,44 +3755,44 @@ yyreduce:
     }
     yyval = def;
 }
-#line 3760 "src/Slice/Grammar.cpp"
+#line 3759 "src/Slice/Grammar.cpp"
     break;
 
   case 179: /* const_initializer: ICE_STRING_LITERAL  */
-#line 1860 "src/Slice/Grammar.y"
+#line 1859 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindString);
     auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
     auto def = make_shared<ConstDefTok>(type, literal->v);
     yyval = def;
 }
-#line 3771 "src/Slice/Grammar.cpp"
+#line 3770 "src/Slice/Grammar.cpp"
     break;
 
   case 180: /* const_initializer: ICE_FALSE  */
-#line 1867 "src/Slice/Grammar.y"
+#line 1866 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindBool);
     auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
     auto def = make_shared<ConstDefTok>(type, "false");
     yyval = def;
 }
-#line 3782 "src/Slice/Grammar.cpp"
+#line 3781 "src/Slice/Grammar.cpp"
     break;
 
   case 181: /* const_initializer: ICE_TRUE  */
-#line 1874 "src/Slice/Grammar.y"
+#line 1873 "src/Slice/Grammar.y"
 {
     BuiltinPtr type = currentUnit->createBuiltin(Builtin::KindBool);
     auto literal = dynamic_pointer_cast<StringTok>(yyvsp[0]);
     auto def = make_shared<ConstDefTok>(type, "true");
     yyval = def;
 }
-#line 3793 "src/Slice/Grammar.cpp"
+#line 3792 "src/Slice/Grammar.cpp"
     break;
 
   case 182: /* const_def: ICE_CONST metadata type ICE_IDENTIFIER '=' const_initializer  */
-#line 1886 "src/Slice/Grammar.y"
+#line 1885 "src/Slice/Grammar.y"
 {
     auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-4]);
     auto const_type = dynamic_pointer_cast<Type>(yyvsp[-3]);
@@ -3802,11 +3801,11 @@ yyreduce:
     yyval = currentUnit->currentContainer()->createConst(ident->v, const_type, std::move(metadata->v), value->v,
                                                       value->valueAsString);
 }
-#line 3806 "src/Slice/Grammar.cpp"
+#line 3805 "src/Slice/Grammar.cpp"
     break;
 
   case 183: /* const_def: ICE_CONST metadata type '=' const_initializer  */
-#line 1895 "src/Slice/Grammar.y"
+#line 1894 "src/Slice/Grammar.y"
 {
     auto metadata = dynamic_pointer_cast<MetadataListTok>(yyvsp[-3]);
     auto const_type = dynamic_pointer_cast<Type>(yyvsp[-2]);
@@ -3815,173 +3814,173 @@ yyreduce:
     yyval = currentUnit->currentContainer()->createConst(Ice::generateUUID(), const_type, std::move(metadata->v),
                                                       value->v, value->valueAsString, Dummy); // Dummy
 }
-#line 3819 "src/Slice/Grammar.cpp"
+#line 3818 "src/Slice/Grammar.cpp"
     break;
 
   case 184: /* keyword: ICE_MODULE  */
-#line 1908 "src/Slice/Grammar.y"
+#line 1907 "src/Slice/Grammar.y"
              {}
-#line 3825 "src/Slice/Grammar.cpp"
+#line 3824 "src/Slice/Grammar.cpp"
     break;
 
   case 185: /* keyword: ICE_CLASS  */
-#line 1909 "src/Slice/Grammar.y"
+#line 1908 "src/Slice/Grammar.y"
             {}
-#line 3831 "src/Slice/Grammar.cpp"
+#line 3830 "src/Slice/Grammar.cpp"
     break;
 
   case 186: /* keyword: ICE_INTERFACE  */
-#line 1910 "src/Slice/Grammar.y"
+#line 1909 "src/Slice/Grammar.y"
                 {}
-#line 3837 "src/Slice/Grammar.cpp"
+#line 3836 "src/Slice/Grammar.cpp"
     break;
 
   case 187: /* keyword: ICE_EXCEPTION  */
-#line 1911 "src/Slice/Grammar.y"
+#line 1910 "src/Slice/Grammar.y"
                 {}
-#line 3843 "src/Slice/Grammar.cpp"
+#line 3842 "src/Slice/Grammar.cpp"
     break;
 
   case 188: /* keyword: ICE_STRUCT  */
-#line 1912 "src/Slice/Grammar.y"
+#line 1911 "src/Slice/Grammar.y"
              {}
-#line 3849 "src/Slice/Grammar.cpp"
+#line 3848 "src/Slice/Grammar.cpp"
     break;
 
   case 189: /* keyword: ICE_SEQUENCE  */
-#line 1913 "src/Slice/Grammar.y"
+#line 1912 "src/Slice/Grammar.y"
                {}
-#line 3855 "src/Slice/Grammar.cpp"
+#line 3854 "src/Slice/Grammar.cpp"
     break;
 
   case 190: /* keyword: ICE_DICTIONARY  */
-#line 1914 "src/Slice/Grammar.y"
+#line 1913 "src/Slice/Grammar.y"
                  {}
-#line 3861 "src/Slice/Grammar.cpp"
+#line 3860 "src/Slice/Grammar.cpp"
     break;
 
   case 191: /* keyword: ICE_ENUM  */
-#line 1915 "src/Slice/Grammar.y"
+#line 1914 "src/Slice/Grammar.y"
            {}
-#line 3867 "src/Slice/Grammar.cpp"
+#line 3866 "src/Slice/Grammar.cpp"
     break;
 
   case 192: /* keyword: ICE_OUT  */
-#line 1916 "src/Slice/Grammar.y"
+#line 1915 "src/Slice/Grammar.y"
           {}
-#line 3873 "src/Slice/Grammar.cpp"
+#line 3872 "src/Slice/Grammar.cpp"
     break;
 
   case 193: /* keyword: ICE_EXTENDS  */
-#line 1917 "src/Slice/Grammar.y"
+#line 1916 "src/Slice/Grammar.y"
               {}
-#line 3879 "src/Slice/Grammar.cpp"
+#line 3878 "src/Slice/Grammar.cpp"
     break;
 
   case 194: /* keyword: ICE_THROWS  */
-#line 1918 "src/Slice/Grammar.y"
+#line 1917 "src/Slice/Grammar.y"
              {}
-#line 3885 "src/Slice/Grammar.cpp"
+#line 3884 "src/Slice/Grammar.cpp"
     break;
 
   case 195: /* keyword: ICE_VOID  */
-#line 1919 "src/Slice/Grammar.y"
+#line 1918 "src/Slice/Grammar.y"
            {}
-#line 3891 "src/Slice/Grammar.cpp"
+#line 3890 "src/Slice/Grammar.cpp"
     break;
 
   case 196: /* keyword: ICE_BOOL  */
-#line 1920 "src/Slice/Grammar.y"
+#line 1919 "src/Slice/Grammar.y"
            {}
-#line 3897 "src/Slice/Grammar.cpp"
+#line 3896 "src/Slice/Grammar.cpp"
     break;
 
   case 197: /* keyword: ICE_BYTE  */
-#line 1921 "src/Slice/Grammar.y"
+#line 1920 "src/Slice/Grammar.y"
            {}
-#line 3903 "src/Slice/Grammar.cpp"
+#line 3902 "src/Slice/Grammar.cpp"
     break;
 
   case 198: /* keyword: ICE_SHORT  */
-#line 1922 "src/Slice/Grammar.y"
+#line 1921 "src/Slice/Grammar.y"
             {}
-#line 3909 "src/Slice/Grammar.cpp"
+#line 3908 "src/Slice/Grammar.cpp"
     break;
 
   case 199: /* keyword: ICE_INT  */
-#line 1923 "src/Slice/Grammar.y"
+#line 1922 "src/Slice/Grammar.y"
           {}
-#line 3915 "src/Slice/Grammar.cpp"
+#line 3914 "src/Slice/Grammar.cpp"
     break;
 
   case 200: /* keyword: ICE_LONG  */
-#line 1924 "src/Slice/Grammar.y"
+#line 1923 "src/Slice/Grammar.y"
            {}
-#line 3921 "src/Slice/Grammar.cpp"
+#line 3920 "src/Slice/Grammar.cpp"
     break;
 
   case 201: /* keyword: ICE_FLOAT  */
-#line 1925 "src/Slice/Grammar.y"
+#line 1924 "src/Slice/Grammar.y"
             {}
-#line 3927 "src/Slice/Grammar.cpp"
+#line 3926 "src/Slice/Grammar.cpp"
     break;
 
   case 202: /* keyword: ICE_DOUBLE  */
-#line 1926 "src/Slice/Grammar.y"
+#line 1925 "src/Slice/Grammar.y"
              {}
-#line 3933 "src/Slice/Grammar.cpp"
+#line 3932 "src/Slice/Grammar.cpp"
     break;
 
   case 203: /* keyword: ICE_STRING  */
-#line 1927 "src/Slice/Grammar.y"
+#line 1926 "src/Slice/Grammar.y"
              {}
-#line 3939 "src/Slice/Grammar.cpp"
+#line 3938 "src/Slice/Grammar.cpp"
     break;
 
   case 204: /* keyword: ICE_OBJECT  */
-#line 1928 "src/Slice/Grammar.y"
+#line 1927 "src/Slice/Grammar.y"
              {}
-#line 3945 "src/Slice/Grammar.cpp"
+#line 3944 "src/Slice/Grammar.cpp"
     break;
 
   case 205: /* keyword: ICE_CONST  */
-#line 1929 "src/Slice/Grammar.y"
+#line 1928 "src/Slice/Grammar.y"
             {}
-#line 3951 "src/Slice/Grammar.cpp"
+#line 3950 "src/Slice/Grammar.cpp"
     break;
 
   case 206: /* keyword: ICE_FALSE  */
-#line 1930 "src/Slice/Grammar.y"
+#line 1929 "src/Slice/Grammar.y"
             {}
-#line 3957 "src/Slice/Grammar.cpp"
+#line 3956 "src/Slice/Grammar.cpp"
     break;
 
   case 207: /* keyword: ICE_TRUE  */
-#line 1931 "src/Slice/Grammar.y"
+#line 1930 "src/Slice/Grammar.y"
            {}
-#line 3963 "src/Slice/Grammar.cpp"
+#line 3962 "src/Slice/Grammar.cpp"
     break;
 
   case 208: /* keyword: ICE_IDEMPOTENT  */
-#line 1932 "src/Slice/Grammar.y"
+#line 1931 "src/Slice/Grammar.y"
                  {}
-#line 3969 "src/Slice/Grammar.cpp"
+#line 3968 "src/Slice/Grammar.cpp"
     break;
 
   case 209: /* keyword: ICE_OPTIONAL  */
-#line 1933 "src/Slice/Grammar.y"
+#line 1932 "src/Slice/Grammar.y"
                {}
-#line 3975 "src/Slice/Grammar.cpp"
+#line 3974 "src/Slice/Grammar.cpp"
     break;
 
   case 210: /* keyword: ICE_VALUE  */
-#line 1934 "src/Slice/Grammar.y"
+#line 1933 "src/Slice/Grammar.y"
             {}
-#line 3981 "src/Slice/Grammar.cpp"
+#line 3980 "src/Slice/Grammar.cpp"
     break;
 
 
-#line 3985 "src/Slice/Grammar.cpp"
+#line 3984 "src/Slice/Grammar.cpp"
 
       default: break;
     }
@@ -4179,7 +4178,7 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 1937 "src/Slice/Grammar.y"
+#line 1936 "src/Slice/Grammar.y"
 
 
 // NOLINTEND

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -611,11 +611,11 @@ optional
 : ICE_OPTIONAL_OPEN integer_constant ')'
 {
     auto integer = dynamic_pointer_cast<IntegerTok>($2);
-    int tag = -1;
+    int32_t tag = -1;
 
     if (integer && checkIntegerBounds(integer, "tag"))
     {
-        tag = static_cast<int>(integer->v);
+        tag = static_cast<int32_t>(integer->v);
     }
 
     auto m = make_shared<OptionalDefTok>(tag);
@@ -750,11 +750,11 @@ class_id
 : ICE_CLASS ICE_IDENT_OPEN integer_constant ')'
 {
     auto integer = dynamic_pointer_cast<IntegerTok>($3);
-    int id = -1;
+    int32_t id = -1;
 
     if (integer && checkIntegerBounds(integer, "compact id"))
     {
-        id = static_cast<int>(integer->v);
+        id = static_cast<int32_t>(integer->v);
         string typeId = currentUnit->getTypeId(id);
         if (!typeId.empty())
         {
@@ -1509,7 +1509,7 @@ enumerator
     {
         // We report numbers that are out of range, but always create the enumerator no matter what.
         checkIntegerBounds(intVal, "enumerator value");
-        $$ = cont->createEnumerator(ident->v, static_cast<int>(intVal->v));
+        $$ = cont->createEnumerator(ident->v, static_cast<int32_t>(intVal->v));
     }
     else
     {
@@ -1708,7 +1708,7 @@ integer_constant
         }
     }
 
-    optional<int> integerValue;
+    optional<int64_t> integerValue;
     if (cl.empty())
     {
         // If we couldn't find any Slice types matching the provided name, report an error.
@@ -1722,8 +1722,7 @@ integer_constant
             auto b = dynamic_pointer_cast<Builtin>(constant->type());
             if (b && b->isIntegralType())
             {
-                int64_t l = std::stoll(constant->value(), nullptr, 0);
-                integerValue = static_cast<int>(l);
+                integerValue = std::stoll(constant->value(), nullptr, 0);
             }
         }
         else if (auto enumerator = dynamic_pointer_cast<Enumerator>(cl.front()))

--- a/cpp/src/Slice/GrammarUtil.h
+++ b/cpp/src/Slice/GrammarUtil.h
@@ -95,13 +95,13 @@ namespace Slice
         TypePtr type;
         std::string name;
         const bool isOptional{false};
-        const int tag{0};
+        const int32_t tag{0};
     };
 
     struct ClassIdTok final : public GrammarBase
     {
         std::string v;
-        int t{0};
+        int32_t t{0};
     };
 
     struct TokenContext

--- a/cpp/src/Slice/GrammarUtil.h
+++ b/cpp/src/Slice/GrammarUtil.h
@@ -95,13 +95,13 @@ namespace Slice
         TypePtr type;
         std::string name;
         const bool isOptional{false};
-        const int32_t tag{0};
+        const std::int32_t tag{0};
     };
 
     struct ClassIdTok final : public GrammarBase
     {
         std::string v;
-        int32_t t{0};
+        std::int32_t t{0};
     };
 
     struct TokenContext

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -4603,7 +4603,12 @@ Slice::Parameter::visit(ParserVisitor* visitor)
     visitor->visitParameter(shared_from_this());
 }
 
-Slice::Parameter::Parameter(const ContainerPtr& container, const string& name, TypePtr type, bool isOptional, int32_t tag)
+Slice::Parameter::Parameter(
+    const ContainerPtr& container,
+    const string& name,
+    TypePtr type,
+    bool isOptional,
+    int32_t tag)
     : Contained(container, name),
       _type(std::move(type)),
       _optional(isOptional),

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -25,13 +25,6 @@ Slice::containedEqual(const ContainedPtr& lhs, const ContainedPtr& rhs)
     return lhs->scoped() == rhs->scoped();
 }
 
-template<typename T>
-bool
-compareTag(const T& lhs, const T& rhs)
-{
-    return lhs->tag() < rhs->tag();
-}
-
 // NOTE: It is important that this list is kept in alphabetical order!
 constexpr string_view languages[] = {"cpp", "cs", "java", "js", "matlab", "php", "python", "ruby", "swift"};
 
@@ -1227,7 +1220,7 @@ Slice::Container::createModule(const string& name, bool nestedSyntax)
 }
 
 ClassDefPtr
-Slice::Container::createClassDef(const string& name, int id, const ClassDefPtr& base)
+Slice::Container::createClassDef(const string& name, int32_t id, const ClassDefPtr& base)
 {
     ContainedList matches = unit()->findContents(thisScope() + name);
     for (const auto& p : matches)
@@ -2573,7 +2566,7 @@ Slice::ClassDef::createDataMember(
     const string& name,
     const TypePtr& type,
     bool isOptional,
-    int tag,
+    int32_t tag,
     SyntaxTreeBasePtr defaultValueType,
     optional<string> defaultValueString)
 {
@@ -2780,7 +2773,7 @@ Slice::ClassDef::visit(ParserVisitor* visitor)
     }
 }
 
-int
+int32_t
 Slice::ClassDef::compactId() const
 {
     return _compactId;
@@ -2804,7 +2797,7 @@ Slice::ClassDef::appendMetadata(MetadataList metadata)
     _declaration->appendMetadata(std::move(metadata));
 }
 
-Slice::ClassDef::ClassDef(const ContainerPtr& container, const string& name, int id, ClassDefPtr base)
+Slice::ClassDef::ClassDef(const ContainerPtr& container, const string& name, int32_t id, ClassDefPtr base)
     : Contained(container, name),
       _base(std::move(base)),
       _compactId(id)
@@ -3042,7 +3035,7 @@ Slice::InterfaceDef::createOperation(
     const string& name,
     const TypePtr& returnType,
     bool isOptional,
-    int tag,
+    int32_t tag,
     Operation::Mode mode)
 {
     ContainedList matches = unit()->findContents(thisScope() + name);
@@ -3284,7 +3277,7 @@ Slice::Operation::returnIsOptional() const
     return _returnIsOptional;
 }
 
-int
+int32_t
 Slice::Operation::returnTag() const
 {
     return _returnTag;
@@ -3321,7 +3314,7 @@ Slice::Operation::hasMarshaledResult() const
 }
 
 ParameterPtr
-Slice::Operation::createParameter(const string& name, const TypePtr& type, bool isOptional, int tag)
+Slice::Operation::createParameter(const string& name, const TypePtr& type, bool isOptional, int32_t tag)
 {
     ContainedList matches = unit()->findContents(thisScope() + name);
     if (!matches.empty())
@@ -3688,7 +3681,7 @@ Slice::Operation::Operation(
     const string& name,
     TypePtr returnType,
     bool returnIsOptional,
-    int returnTag,
+    int32_t returnTag,
     Mode mode)
     : Contained(container, name),
       _returnType(std::move(returnType)),
@@ -3714,7 +3707,7 @@ Slice::Exception::createDataMember(
     const string& name,
     const TypePtr& type,
     bool isOptional,
-    int tag,
+    int32_t tag,
     SyntaxTreeBasePtr defaultValueType,
     optional<string> defaultValueString)
 {
@@ -3945,7 +3938,7 @@ Slice::Struct::createDataMember(
     const string& name,
     const TypePtr& type,
     bool isOptional,
-    int tag,
+    int32_t tag,
     SyntaxTreeBasePtr defaultValueType,
     optional<string> defaultValueString)
 {
@@ -4320,7 +4313,7 @@ Slice::Dictionary::Dictionary(
 // ----------------------------------------------------------------------
 
 EnumeratorPtr
-Slice::Enum::createEnumerator(const string& name, optional<int> explicitValue)
+Slice::Enum::createEnumerator(const string& name, optional<int32_t> explicitValue)
 {
     // Validate the enumerator's name.
     ContainedList matches = unit()->findContents(thisScope() + name);
@@ -4343,7 +4336,7 @@ Slice::Enum::createEnumerator(const string& name, optional<int> explicitValue)
     checkIdentifier(name); // Ignore return value.
 
     // Determine the enumerator's value, and check that it's valid.
-    int nextValue;
+    int32_t nextValue;
     if (explicitValue)
     {
         // If an explicit value was provided, the parser already checks that it's between `0` and `int32_t::max`.
@@ -4403,13 +4396,13 @@ Slice::Enum::hasExplicitValues() const
     return _hasExplicitValues;
 }
 
-int
+int32_t
 Slice::Enum::minValue() const
 {
     return static_cast<int>(_minValue);
 }
 
-int
+int32_t
 Slice::Enum::maxValue() const
 {
     return static_cast<int>(_maxValue);
@@ -4479,7 +4472,7 @@ Slice::Enumerator::hasExplicitValue() const
     return _hasExplicitValue;
 }
 
-int
+int32_t
 Slice::Enumerator::value() const
 {
     return _value;
@@ -4491,7 +4484,7 @@ Slice::Enumerator::visit(ParserVisitor*)
     // TODO we should probably visit enumerators, even if only for validation purposes.
 }
 
-Slice::Enumerator::Enumerator(const ContainerPtr& container, const string& name, int value, bool hasExplicitValue)
+Slice::Enumerator::Enumerator(const ContainerPtr& container, const string& name, int32_t value, bool hasExplicitValue)
     : Contained(container, name),
       _hasExplicitValue(hasExplicitValue),
       _value(value)
@@ -4592,7 +4585,7 @@ Slice::Parameter::optional() const
     return _optional;
 }
 
-int
+int32_t
 Slice::Parameter::tag() const
 {
     return _tag;
@@ -4610,7 +4603,7 @@ Slice::Parameter::visit(ParserVisitor* visitor)
     visitor->visitParameter(shared_from_this());
 }
 
-Slice::Parameter::Parameter(const ContainerPtr& container, const string& name, TypePtr type, bool isOptional, int tag)
+Slice::Parameter::Parameter(const ContainerPtr& container, const string& name, TypePtr type, bool isOptional, int32_t tag)
     : Contained(container, name),
       _type(std::move(type)),
       _optional(isOptional),
@@ -4634,7 +4627,7 @@ Slice::DataMember::optional() const
     return _optional;
 }
 
-int
+int32_t
 Slice::DataMember::tag() const
 {
     return _tag;
@@ -4669,7 +4662,7 @@ Slice::DataMember::DataMember(
     const string& name,
     TypePtr type,
     bool isOptional,
-    int tag,
+    int32_t tag,
     SyntaxTreeBasePtr defaultValueType,
     std::optional<string> defaultValueString)
     : Contained(container, name),
@@ -5007,13 +5000,13 @@ Slice::Unit::findContents(const string& scopedName) const
 }
 
 void
-Slice::Unit::addTypeId(int compactId, const std::string& typeId)
+Slice::Unit::addTypeId(int32_t compactId, const std::string& typeId)
 {
     _typeIds.insert(make_pair(compactId, typeId));
 }
 
 std::string
-Slice::Unit::getTypeId(int compactId) const
+Slice::Unit::getTypeId(int32_t compactId) const
 {
     auto p = _typeIds.find(compactId);
     if (p != _typeIds.end())

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -107,10 +107,7 @@ namespace Slice
     bool containedCompare(const ContainedPtr& lhs, const ContainedPtr& rhs);
     bool containedEqual(const ContainedPtr& lhs, const ContainedPtr& rhs);
 
-    template<typename T> bool compareTag(const T& lhs, const T& rhs)
-    {
-        return lhs->tag() < rhs->tag();
-    }
+    template<typename T> bool compareTag(const T& lhs, const T& rhs) { return lhs->tag() < rhs->tag(); }
 
     // ----------------------------------------------------------------------
     // CICompare -- function object to do case-insensitive string comparison.
@@ -987,7 +984,12 @@ namespace Slice
     class Parameter final : public Contained, public std::enable_shared_from_this<Parameter>
     {
     public:
-        Parameter(const ContainerPtr& container, const std::string& name, TypePtr type, bool isOptional, std::int32_t tag);
+        Parameter(
+            const ContainerPtr& container,
+            const std::string& name,
+            TypePtr type,
+            bool isOptional,
+            std::int32_t tag);
         [[nodiscard]] TypePtr type() const;
         [[nodiscard]] bool isOutParam() const;
         void setIsOutParam();

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -90,9 +90,6 @@ namespace Slice
     using ConstPtr = std::shared_ptr<Const>;
     using UnitPtr = std::shared_ptr<Unit>;
 
-    bool containedCompare(const ContainedPtr& lhs, const ContainedPtr& rhs);
-    bool containedEqual(const ContainedPtr& lhs, const ContainedPtr& rhs);
-
     using StringList = std::list<std::string>;
     using MetadataList = std::list<MetadataPtr>;
     using TypeList = std::list<TypePtr>;
@@ -106,6 +103,14 @@ namespace Slice
     using DataMemberList = std::list<DataMemberPtr>;
     using ParameterList = std::list<ParameterPtr>;
     using EnumeratorList = std::list<EnumeratorPtr>;
+
+    bool containedCompare(const ContainedPtr& lhs, const ContainedPtr& rhs);
+    bool containedEqual(const ContainedPtr& lhs, const ContainedPtr& rhs);
+
+    template<typename T> bool compareTag(const T& lhs, const T& rhs)
+    {
+        return lhs->tag() < rhs->tag();
+    }
 
     // ----------------------------------------------------------------------
     // CICompare -- function object to do case-insensitive string comparison.
@@ -449,7 +454,7 @@ namespace Slice
     public:
         void destroyContents();
         ModulePtr createModule(const std::string& name, bool nestedSyntax);
-        [[nodiscard]] ClassDefPtr createClassDef(const std::string& name, int id, const ClassDefPtr& base);
+        [[nodiscard]] ClassDefPtr createClassDef(const std::string& name, std::int32_t id, const ClassDefPtr& base);
         [[nodiscard]] ClassDeclPtr createClassDecl(const std::string& name);
         [[nodiscard]] InterfaceDefPtr createInterfaceDef(const std::string& name, const InterfaceList& bases);
         [[nodiscard]] InterfaceDeclPtr createInterfaceDecl(const std::string& name);
@@ -580,13 +585,13 @@ namespace Slice
     class ClassDef final : public Container, public Contained
     {
     public:
-        ClassDef(const ContainerPtr& container, const std::string& name, int id, ClassDefPtr base);
+        ClassDef(const ContainerPtr& container, const std::string& name, std::int32_t id, ClassDefPtr base);
         void destroy() final;
         DataMemberPtr createDataMember(
             const std::string& name,
             const TypePtr& type,
             bool isOptional,
-            int tag,
+            std::int32_t tag,
             SyntaxTreeBasePtr defaultValueType,
             std::optional<std::string> defaultValueString);
         [[nodiscard]] ClassDeclPtr declaration() const;
@@ -598,7 +603,7 @@ namespace Slice
         [[nodiscard]] DataMemberList classDataMembers() const;
         [[nodiscard]] bool canBeCyclic() const;
         void visit(ParserVisitor* visitor) final;
-        [[nodiscard]] int compactId() const;
+        [[nodiscard]] std::int32_t compactId() const;
         [[nodiscard]] std::string kindOf() const final;
 
         // Class metadata is always stored on the underlying decl type, not the definition.
@@ -612,7 +617,7 @@ namespace Slice
 
         ClassDeclPtr _declaration;
         ClassDefPtr _base;
-        int _compactId;
+        std::int32_t _compactId;
     };
 
     // ----------------------------------------------------------------------
@@ -671,15 +676,15 @@ namespace Slice
             Idempotent = 2
         };
 
-        Operation(const ContainerPtr&, const std::string&, TypePtr, bool, int, Mode);
+        Operation(const ContainerPtr&, const std::string&, TypePtr, bool, std::int32_t, Mode);
         [[nodiscard]] InterfaceDefPtr interface() const;
         [[nodiscard]] TypePtr returnType() const;
         [[nodiscard]] bool returnIsOptional() const;
-        [[nodiscard]] int returnTag() const;
+        [[nodiscard]] std::int32_t returnTag() const;
         [[nodiscard]] Mode mode() const;
         [[nodiscard]] bool hasMarshaledResult() const;
 
-        ParameterPtr createParameter(const std::string& name, const TypePtr& type, bool isOptional, int tag);
+        ParameterPtr createParameter(const std::string& name, const TypePtr& type, bool isOptional, std::int32_t tag);
 
         [[nodiscard]] ParameterList parameters() const;
         /// Returns a list of all this operation's in-parameters (all parameters not marked with 'out').
@@ -729,7 +734,7 @@ namespace Slice
     private:
         TypePtr _returnType;
         bool _returnIsOptional;
-        int _returnTag;
+        std::int32_t _returnTag;
         ExceptionList _throws;
         Mode _mode;
     };
@@ -754,7 +759,7 @@ namespace Slice
             const std::string& name,
             const TypePtr& returnType,
             bool isOptional,
-            int tag,
+            std::int32_t tag,
             Operation::Mode mode = Operation::Normal);
 
         [[nodiscard]] InterfaceDeclPtr declaration() const;
@@ -796,7 +801,7 @@ namespace Slice
             const std::string& name,
             const TypePtr& type,
             bool isOptional,
-            int tag,
+            std::int32_t tag,
             SyntaxTreeBasePtr defaultValueType,
             std::optional<std::string> defaultValueString);
         [[nodiscard]] DataMemberList dataMembers() const;
@@ -826,7 +831,7 @@ namespace Slice
             const std::string& name,
             const TypePtr& type,
             bool isOptional,
-            int tag,
+            std::int32_t tag,
             SyntaxTreeBasePtr defaultValueType,
             std::optional<std::string> defaultValueString);
         [[nodiscard]] DataMemberList dataMembers() const;
@@ -907,10 +912,10 @@ namespace Slice
     {
     public:
         Enum(const ContainerPtr& container, const std::string& name);
-        EnumeratorPtr createEnumerator(const std::string& name, std::optional<int> explicitValue);
+        EnumeratorPtr createEnumerator(const std::string& name, std::optional<std::int32_t> explicitValue);
         [[nodiscard]] bool hasExplicitValues() const;
-        [[nodiscard]] int minValue() const;
-        [[nodiscard]] int maxValue() const;
+        [[nodiscard]] std::int32_t minValue() const;
+        [[nodiscard]] std::int32_t maxValue() const;
         [[nodiscard]] size_t minWireSize() const final;
         [[nodiscard]] std::string getOptionalFormat() const final;
         [[nodiscard]] bool isVariableLength() const final;
@@ -920,9 +925,9 @@ namespace Slice
 
     private:
         bool _hasExplicitValues{false};
-        std::int64_t _minValue;
-        std::int64_t _maxValue{0};
-        int _lastValue{-1};
+        std::int32_t _minValue;
+        std::int32_t _maxValue{0};
+        std::int32_t _lastValue{-1};
     };
 
     // ----------------------------------------------------------------------
@@ -932,18 +937,18 @@ namespace Slice
     class Enumerator final : public Contained
     {
     public:
-        Enumerator(const ContainerPtr& container, const std::string& name, int value, bool hasExplicitValue);
+        Enumerator(const ContainerPtr& container, const std::string& name, std::int32_t value, bool hasExplicitValue);
         [[nodiscard]] EnumPtr type() const;
         [[nodiscard]] std::string kindOf() const final;
 
         [[nodiscard]] bool hasExplicitValue() const;
-        [[nodiscard]] int value() const;
+        [[nodiscard]] std::int32_t value() const;
 
         void visit(ParserVisitor* visitor) final;
 
     private:
         bool _hasExplicitValue;
-        int _value;
+        std::int32_t _value;
     };
 
     // ----------------------------------------------------------------------
@@ -982,12 +987,12 @@ namespace Slice
     class Parameter final : public Contained, public std::enable_shared_from_this<Parameter>
     {
     public:
-        Parameter(const ContainerPtr& container, const std::string& name, TypePtr type, bool isOptional, int tag);
+        Parameter(const ContainerPtr& container, const std::string& name, TypePtr type, bool isOptional, std::int32_t tag);
         [[nodiscard]] TypePtr type() const;
         [[nodiscard]] bool isOutParam() const;
         void setIsOutParam();
         [[nodiscard]] bool optional() const;
-        [[nodiscard]] int tag() const;
+        [[nodiscard]] std::int32_t tag() const;
         [[nodiscard]] std::string kindOf() const final;
         void visit(ParserVisitor* visitor) final;
 
@@ -995,7 +1000,7 @@ namespace Slice
         TypePtr _type;
         bool _isOutParam{false};
         bool _optional;
-        int _tag;
+        std::int32_t _tag;
     };
 
     // ----------------------------------------------------------------------
@@ -1010,12 +1015,12 @@ namespace Slice
             const std::string& name,
             TypePtr type,
             bool isOptional,
-            int tag,
+            std::int32_t tag,
             SyntaxTreeBasePtr defaultValueType,
             std::optional<std::string> defaultValueString);
         [[nodiscard]] TypePtr type() const;
         [[nodiscard]] bool optional() const;
-        [[nodiscard]] int tag() const;
+        [[nodiscard]] std::int32_t tag() const;
 
         // defaultValue() and defaultValueType() are either both null (no default value) or both non-null.
         [[nodiscard]] std::optional<std::string> defaultValue() const;
@@ -1026,7 +1031,7 @@ namespace Slice
     private:
         TypePtr _type;
         bool _optional;
-        int _tag;
+        std::int32_t _tag;
         SyntaxTreeBasePtr _defaultValueType;
         std::optional<std::string> _defaultValue;
     };
@@ -1073,8 +1078,8 @@ namespace Slice
         void addContent(const ContainedPtr& contained);
         [[nodiscard]] ContainedList findContents(const std::string& scopedName) const;
 
-        void addTypeId(int compactId, const std::string& typeId);
-        [[nodiscard]] std::string getTypeId(int compactId) const;
+        void addTypeId(std::int32_t compactId, const std::string& typeId);
+        [[nodiscard]] std::string getTypeId(std::int32_t compactId) const;
 
         // Returns the path names of the files included directly by the top-level file.
         [[nodiscard]] StringList includeFiles() const;
@@ -1113,7 +1118,7 @@ namespace Slice
         std::map<Builtin::Kind, BuiltinPtr> _builtins;
         std::map<std::string, ContainedList> _contentMap;
         std::map<std::string, DefinitionContextPtr, std::less<>> _definitionContextMap;
-        std::map<int, std::string> _typeIds;
+        std::map<std::int32_t, std::string> _typeIds;
         std::map<std::string, std::set<std::string>> _fileTopLevelModules;
     };
 

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -118,6 +118,7 @@ namespace
         }
     }
 
+    // TODO this is probably unnecessary. Search for `orderedOptionalDataMembers` in 'libSlice'.
     /// Split data members in required and optional members; the optional members are sorted in tag order.
     std::pair<DataMemberList, DataMemberList> split(const DataMemberList& dataMembers)
     {
@@ -137,8 +138,7 @@ namespace
         }
 
         // Sort optional data members
-        optionalMembers.sort([](const DataMemberPtr& lhs, const DataMemberPtr& rhs)
-                             { return lhs->tag() < rhs->tag(); });
+        optionalMembers.sort(Slice::compareTag<DataMemberPtr>);
 
         return {requiredMembers, optionalMembers};
     }
@@ -245,15 +245,7 @@ namespace
             //
             // Sort optional parameters by tag.
             //
-            class SortFn
-            {
-            public:
-                static bool compare(const ParameterPtr& lhs, const ParameterPtr& rhs)
-                {
-                    return lhs->tag() < rhs->tag();
-                }
-            };
-            optionals.sort(SortFn::compare);
+            optionals.sort(Slice::compareTag<ParameterPtr>);
 
             out << nl;
             if (marshal)

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1228,7 +1228,7 @@ Slice::Gen::ForwardDeclVisitor::visitEnum(const EnumPtr& p)
         // an explicit value for *all* enumerators.
         if (hasExplicitValues)
         {
-            H << " = " << std::to_string(enumerator->value());
+            H << " = " << enumerator->value();
         }
     }
     H << eb << ';';

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -567,7 +567,7 @@ Slice::CsGenerator::writeOptionalMarshalUnmarshalCode(
     const TypePtr& type,
     const string& scope,
     const string& param,
-    int tag,
+    int32_t tag,
     bool marshal,
     const string& customStream)
 {

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -68,7 +68,7 @@ namespace Slice
             const TypePtr&,
             const std::string&,
             const std::string&,
-            int32_t,
+            std::int32_t,
             bool,
             const std::string& = "");
         void writeSequenceMarshalUnmarshalCode(

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -68,7 +68,7 @@ namespace Slice
             const TypePtr&,
             const std::string&,
             const std::string&,
-            int,
+            int32_t,
             bool,
             const std::string& = "");
         void writeSequenceMarshalUnmarshalCode(

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -378,12 +378,7 @@ Slice::CsVisitor::writeMarshalUnmarshalParams(
     //
     // Sort optional parameters by tag.
     //
-    class SortFn
-    {
-    public:
-        static bool compare(const ParameterPtr& lhs, const ParameterPtr& rhs) { return lhs->tag() < rhs->tag(); }
-    };
-    optionals.sort(SortFn::compare);
+    optionals.sort(Slice::compareTag<ParameterPtr>);
 
     //
     // Handle optional parameters.

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -906,7 +906,7 @@ Slice::JavaVisitor::writeUnmarshalProxyResults(Output& out, const string& packag
 
         bool optional;
         TypePtr type;
-        int tag;
+        int32_t tag;
         MetadataList metadata;
         if (ret)
         {
@@ -1004,7 +1004,7 @@ Slice::JavaVisitor::writeMarshalServantResults(
         bool optional;
         OptionalMode mode;
         TypePtr type;
-        int tag;
+        int32_t tag;
         MetadataList metadata;
         if (op->returnType())
         {

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -568,7 +568,7 @@ Slice::JavaGenerator::writeMarshalUnmarshalCode(
     const TypePtr& type,
     OptionalMode mode,
     bool optionalMapping,
-    int tag,
+    int32_t tag,
     const string& param,
     bool marshal,
     int& iter,

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -150,7 +150,7 @@ namespace Slice
             const TypePtr&,
             OptionalMode,
             bool,
-            int,
+            std::int32_t,
             const std::string&,
             bool,
             int&,

--- a/cpp/src/slice2js/JsUtil.cpp
+++ b/cpp/src/slice2js/JsUtil.cpp
@@ -369,7 +369,7 @@ Slice::JsGenerator::writeOptionalMarshalUnmarshalCode(
     Output& out,
     const TypePtr& type,
     const string& param,
-    int tag,
+    int32_t tag,
     bool marshal)
 {
     assert(!type->isClassType()); // Optional classes are disallowed by the parser.

--- a/cpp/src/slice2js/JsUtil.h
+++ b/cpp/src/slice2js/JsUtil.h
@@ -27,7 +27,7 @@ namespace Slice
         // Generate code to marshal or unmarshal a type
         //
         void writeMarshalUnmarshalCode(IceInternal::Output&, const TypePtr&, const std::string&, bool);
-        void writeOptionalMarshalUnmarshalCode(IceInternal::Output&, const TypePtr&, const std::string&, int, bool);
+        void writeOptionalMarshalUnmarshalCode(IceInternal::Output&, const TypePtr&, const std::string&, int32_t, bool);
     };
 }
 

--- a/cpp/src/slice2js/JsUtil.h
+++ b/cpp/src/slice2js/JsUtil.h
@@ -27,7 +27,8 @@ namespace Slice
         // Generate code to marshal or unmarshal a type
         //
         void writeMarshalUnmarshalCode(IceInternal::Output&, const TypePtr&, const std::string&, bool);
-        void writeOptionalMarshalUnmarshalCode(IceInternal::Output&, const TypePtr&, const std::string&, int32_t, bool);
+        void
+        writeOptionalMarshalUnmarshalCode(IceInternal::Output&, const TypePtr&, const std::string&, std::int32_t, bool);
     };
 }
 

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -1005,8 +1005,8 @@ private:
     string getOptionalFormat(const TypePtr&);
     string getFormatType(FormatType);
 
-    void marshal(IceInternal::Output&, const string&, const string&, const TypePtr&, bool, int);
-    void unmarshal(IceInternal::Output&, const string&, const string&, const TypePtr&, bool, int);
+    void marshal(IceInternal::Output&, const string&, const string&, const TypePtr&, bool, int32_t);
+    void unmarshal(IceInternal::Output&, const string&, const string&, const TypePtr&, bool, int32_t);
 
     void unmarshalStruct(IceInternal::Output&, const StructPtr&, const string&);
     void convertStruct(IceInternal::Output&, const StructPtr&, const string&);
@@ -1290,7 +1290,7 @@ CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     out << nl << "TypeId char = '" << scoped << "'";
     if (p->compactId() != -1)
     {
-        out << nl << "CompactId char = '" << to_string(p->compactId()) << "'";
+        out << nl << "CompactId char = '" << p->compactId() << "'";
     }
     out.dec();
     out << nl << "end";
@@ -2797,7 +2797,7 @@ CodeVisitor::marshal(
     const string& v,
     const TypePtr& type,
     bool optional,
-    int tag)
+    int32_t tag)
 {
     BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
     if (builtin)
@@ -3034,7 +3034,7 @@ CodeVisitor::unmarshal(
     const string& v,
     const TypePtr& type,
     bool optional,
-    int tag)
+    int32_t tag)
 {
     BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
     if (builtin)

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -842,7 +842,7 @@ Slice::Ruby::CodeVisitor::visitEnum(const EnumPtr& p)
     _out.spar("{");
     for (const auto& enumerator : enumerators)
     {
-        _out << enumerator->value() + "=>" + getMappedName(enumerator, IdentToUpper);
+        _out << std::to_string(enumerator->value()) + "=>" + getMappedName(enumerator, IdentToUpper);
     }
     _out.epar("}");
 

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -842,7 +842,7 @@ Slice::Ruby::CodeVisitor::visitEnum(const EnumPtr& p)
     _out.spar("{");
     for (const auto& enumerator : enumerators)
     {
-        _out << to_string(enumerator->value()) + "=>" + getMappedName(enumerator, IdentToUpper);
+        _out << enumerator->value() + "=>" + getMappedName(enumerator, IdentToUpper);
     }
     _out.epar("}");
 

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -975,7 +975,7 @@ SwiftGenerator::writeMarshalUnmarshalCode(
     const ContainedPtr& p,
     const string& param,
     bool marshal,
-    int tag)
+    int32_t tag)
 {
     assert(!(type->isClassType() && tag >= 0)); // Optional classes are disallowed by the parser.
 

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -90,7 +90,7 @@ namespace Slice
             const ContainedPtr&,
             const std::string&,
             bool,
-            int = -1);
+            int32_t = -1);
 
         bool usesMarshalHelper(const TypePtr&);
         void writeMarshalInParams(::IceInternal::Output&, const OperationPtr&);

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -90,7 +90,7 @@ namespace Slice
             const ContainedPtr&,
             const std::string&,
             bool,
-            int32_t = -1);
+            std::int32_t = -1);
 
         bool usesMarshalHelper(const TypePtr&);
         void writeMarshalInParams(::IceInternal::Output&, const OperationPtr&);

--- a/cpp/test/Slice/errorDetection/OptionalMembers.err
+++ b/cpp/test/Slice/errorDetection/OptionalMembers.err
@@ -6,7 +6,7 @@ OptionalMembers.ice:37: invalid tag '-0x80000001': tags cannot be negative
 OptionalMembers.ice:38: invalid tag '-1': tags cannot be negative
 OptionalMembers.ice:40: tag for optional data member 'm8' is already in use
 OptionalMembers.ice:41: invalid tag 'C3' (-1): tags cannot be negative
-OptionalMembers.ice:42: invalid tag 'C4' (-2147483647): tags cannot be negative
+OptionalMembers.ice:42: invalid tag 'C4' (2147483649): tags must be less than or equal to '2147483647'
 OptionalMembers.ice:43: constant 'C5' cannot be used as an integer constant
 OptionalMembers.ice:45: tag for optional data member 'm13' is already in use
 OptionalMembers.ice:46: enumerator 'e2' could designate '::Test::E::e2' or '::Test::Ebis::e2' or '::Test::Eter::e2'
@@ -19,7 +19,7 @@ OptionalMembers.ice:67: invalid tag '-0x80000001': tags cannot be negative
 OptionalMembers.ice:68: invalid tag '-1': tags cannot be negative
 OptionalMembers.ice:70: tag for optional data member 'm8' is already in use
 OptionalMembers.ice:71: invalid tag 'C3' (-1): tags cannot be negative
-OptionalMembers.ice:72: invalid tag 'C4' (-2147483647): tags cannot be negative
+OptionalMembers.ice:72: invalid tag 'C4' (2147483649): tags must be less than or equal to '2147483647'
 OptionalMembers.ice:73: constant 'C5' cannot be used as an integer constant
 OptionalMembers.ice:75: tag for optional data member 'm13' is already in use
 OptionalMembers.ice:78: tag for optional data member 'm16' is already in use

--- a/cpp/test/Slice/errorDetection/OptionalParams.err
+++ b/cpp/test/Slice/errorDetection/OptionalParams.err
@@ -5,7 +5,7 @@ OptionalParams.ice:33: invalid tag '0x80000000': tags must be less than or equal
 OptionalParams.ice:34: invalid tag '-0x80000001': tags cannot be negative
 OptionalParams.ice:35: invalid tag '-1': tags cannot be negative
 OptionalParams.ice:37: invalid tag 'C3' (-1): tags cannot be negative
-OptionalParams.ice:38: invalid tag 'C4' (-2147483647): tags cannot be negative
+OptionalParams.ice:38: invalid tag 'C4' (2147483649): tags must be less than or equal to '2147483647'
 OptionalParams.ice:39: constant 'C5' cannot be used as an integer constant
 OptionalParams.ice:42: syntax error
 OptionalParams.ice:44: missing tag
@@ -15,7 +15,7 @@ OptionalParams.ice:47: invalid tag '0x80000000': tags must be less than or equal
 OptionalParams.ice:48: invalid tag '-0x80000001': tags cannot be negative
 OptionalParams.ice:49: invalid tag '-1': tags cannot be negative
 OptionalParams.ice:51: invalid tag 'C3' (-1): tags cannot be negative
-OptionalParams.ice:52: invalid tag 'C4' (-2147483647): tags cannot be negative
+OptionalParams.ice:52: invalid tag 'C4' (2147483649): tags must be less than or equal to '2147483647'
 OptionalParams.ice:53: constant 'C5' cannot be used as an integer constant
 OptionalParams.ice:57: missing tag
 OptionalParams.ice:58: missing tag
@@ -24,7 +24,7 @@ OptionalParams.ice:60: invalid tag '0x80000000': tags must be less than or equal
 OptionalParams.ice:61: invalid tag '-0x80000001': tags cannot be negative
 OptionalParams.ice:62: invalid tag '-1': tags cannot be negative
 OptionalParams.ice:64: invalid tag 'C3' (-1): tags cannot be negative
-OptionalParams.ice:65: invalid tag 'C4' (-2147483647): tags cannot be negative
+OptionalParams.ice:65: invalid tag 'C4' (2147483649): tags must be less than or equal to '2147483647'
 OptionalParams.ice:66: constant 'C5' cannot be used as an integer constant
 OptionalParams.ice:68: enumerator 'e1' could designate '::Test::E::e1' or '::Test::Ebis::e1'
 OptionalParams.ice:72: tag for optional parameter 'o' is already in use


### PR DESCRIPTION
This PR updates the Slice parser and code-gen to use `int32_t` for storing compact IDs, tags, and enum values, per https://github.com/zeroc-ice/ice/pull/4009#discussion_r2109412209. These values are bounded between `0` and `int32_t::MAX`, so it's sensible to use `int32_t`, instead of the platform-dependent type `int`.

Using my comparison script, this PR causes no changes to the generated code.

----

While updating `tag()`, I also came a couple places that were sorting parameters by tag.
The parser already defines a function for sorting by tag, but that was 'internal'.
I added this function to the `Parser.h` header, and now we use that in the language compilers, instead of re-inventing the wheel.