### PR TITLE
Remove leading `::` in Swift exception description

### DIFF
--- a/swift/src/Ice/LocalException.swift
+++ b/swift/src/Ice/LocalException.swift
@@ -10,7 +10,7 @@ public class LocalException: Exception, CustomStringConvertible {
     public let line: Int32
 
     /// A textual representation of this Ice exception.
-    public var description: String { "\(file):\(line) \(ice_id()) \(message)" }
+    public var description: String { "\(file):\(line) \(ice_id().dropFirst(2)) \(message)" }
 
     /// Creates a LocalException.
     /// - Parameters:


### PR DESCRIPTION
Tiny fix for consistency with C++'s ice_print:

https://github.com/zeroc-ice/ice/blob/9bb298db7786d7d37456d7b2342c4ea2d9305fd4/cpp/src/Ice/LocalException.cpp#L432

Note that the file/line in Swift often corresponds to a file/line in a C++ file.