### PR TITLE
Add back Ice services generated files to PHP

### DIFF
--- a/php/.gitignore
+++ b/php/.gitignore
@@ -4,3 +4,9 @@
 # phpDoc install dir and cache
 /.phive
 /tools
+
+# Generated PHP files
+lib/Glacier2/
+lib/IceBox/
+lib/IceGrid/
+lib/IceStorm/

--- a/php/Makefile
+++ b/php/Makefile
@@ -32,9 +32,13 @@ srcs:: $(projects)
 
 install:: | $(DESTDIR)$(install_phpdir)
 	$(E) "Installing generated code"
-	$(Q)$(INSTALL) -m 644 lib/Ice.php $(DESTDIR)$(install_phpdir)
+	$(Q)$(INSTALL) -m 644 lib/Glacier2.php lib/Ice.php lib/IceBox.php  lib/IceGrid.php lib/IceStorm.php $(DESTDIR)$(install_phpdir)
 
 $(eval $(call make-php-package,$(slicedir),lib,Ice))
+$(eval $(call make-php-package,$(slicedir),lib,Glacier2))
+$(eval $(call make-php-package,$(slicedir),lib,IceBox))
+$(eval $(call make-php-package,$(slicedir),lib,IceGrid))
+$(eval $(call make-php-package,$(slicedir),lib,IceStorm))
 
 #
 # Translate the Slice files from test directories

--- a/php/lib/Glacier2.php
+++ b/php/lib/Glacier2.php
@@ -1,0 +1,7 @@
+<?php
+// Copyright (c) ZeroC, Inc.
+
+require_once 'Glacier2/Router.php';
+require_once 'Glacier2/PermissionsVerifier.php';
+require_once 'Glacier2/Metrics.php';
+?>

--- a/php/lib/IceBox.php
+++ b/php/lib/IceBox.php
@@ -1,0 +1,5 @@
+<?php
+// Copyright (c) ZeroC, Inc.
+
+require_once 'IceBox/IceBox.php';
+?>

--- a/php/lib/IceGrid.php
+++ b/php/lib/IceGrid.php
@@ -1,0 +1,9 @@
+<?php
+// Copyright (c) ZeroC, Inc.
+
+require_once 'IceGrid/Admin.php';
+require_once 'IceGrid/Descriptor.php';
+require_once 'IceGrid/FileParser.php';
+require_once 'IceGrid/Registry.php';
+require_once 'IceGrid/UserAccountMapper.php';
+?>

--- a/php/lib/IceStorm.php
+++ b/php/lib/IceStorm.php
@@ -1,0 +1,6 @@
+<?php
+// Copyright (c) ZeroC, Inc.
+
+require_once 'IceStorm/IceStorm.php';
+require_once 'IceStorm/Metrics.php';
+?>


### PR DESCRIPTION
This generated code was earlier removed, but we already decide to bring it back in other mappings, just doing the same on PHP for convenience.