### PR TITLE
Avoid using PHP end tags in pure PHP files

### DIFF
--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -1387,8 +1387,6 @@ compile(const vector<string>& argv)
 
                         // Generate the PHP mapping.
                         generate(u, all, includePaths, out);
-
-                        out << "?>\n";
                         out.close();
                     }
                     catch (const Slice::FileException& ex)

--- a/php/lib/Glacier2.php
+++ b/php/lib/Glacier2.php
@@ -4,4 +4,3 @@
 require_once 'Glacier2/Router.php';
 require_once 'Glacier2/PermissionsVerifier.php';
 require_once 'Glacier2/Metrics.php';
-?>

--- a/php/lib/Ice.php
+++ b/php/lib/Ice.php
@@ -46,5 +46,3 @@ IcePHP_defineOperation($Ice__t_ObjectPrx, 'ice_isA', 'ice_isA', 2, 0, array(arra
 IcePHP_defineOperation($Ice__t_ObjectPrx, 'ice_ping', 'ice_ping', 2, 0, null, null, null, null);
 IcePHP_defineOperation($Ice__t_ObjectPrx, 'ice_id', 'ice_id', 2, 0, null, null, array($IcePHP__t_string), null);
 IcePHP_defineOperation($Ice__t_ObjectPrx, 'ice_ids', 'ice_ids', 2, 0, null, null, array($Ice__t_StringSeq), null);
-
-?>

--- a/php/lib/Ice/CompressBatch.php
+++ b/php/lib/Ice/CompressBatch.php
@@ -9,5 +9,3 @@ class CompressBatch
     const No = 1;
     const BasedOnProxy = 2;
 }
-
-?>

--- a/php/lib/Ice/EndpointSelectionType.php
+++ b/php/lib/Ice/EndpointSelectionType.php
@@ -8,5 +8,3 @@ class EndpointSelectionType
     const Random = 0;
     const Ordered = 1;
 }
-
-?>

--- a/php/lib/Ice/Exception.php
+++ b/php/lib/Ice/Exception.php
@@ -11,5 +11,3 @@ abstract class UserException extends Exception
 {
     abstract public function ice_id();
 }
-
-?>

--- a/php/lib/Ice/InitializationData.php
+++ b/php/lib/Ice/InitializationData.php
@@ -24,5 +24,3 @@ class InitializationData
     public ?\IcePHP_Logger $logger;
     public ?SliceLoader $sliceLoader;
 }
-
-?>

--- a/php/lib/Ice/Proxy.php
+++ b/php/lib/Ice/Proxy.php
@@ -74,5 +74,3 @@ function proxyIdentityAndFacetEqual($lhs, $rhs)
 {
     return proxyIdentityAndFacetCompare($lhs, $rhs) == 0;
 }
-
-?>

--- a/php/lib/Ice/ToStringMode.php
+++ b/php/lib/Ice/ToStringMode.php
@@ -9,5 +9,3 @@ class ToStringMode
     const ASCII = 1;
     const Compat = 2;
 }
-
-?>

--- a/php/lib/Ice/Value.php
+++ b/php/lib/Ice/Value.php
@@ -58,5 +58,3 @@ class SliceInfo
     public $hasOptionalMembers;
     public $isLastSlice;
 }
-
-?>

--- a/php/lib/IceBox.php
+++ b/php/lib/IceBox.php
@@ -2,4 +2,3 @@
 // Copyright (c) ZeroC, Inc.
 
 require_once 'IceBox/IceBox.php';
-?>

--- a/php/lib/IceGrid.php
+++ b/php/lib/IceGrid.php
@@ -6,4 +6,3 @@ require_once 'IceGrid/Descriptor.php';
 require_once 'IceGrid/FileParser.php';
 require_once 'IceGrid/Registry.php';
 require_once 'IceGrid/UserAccountMapper.php';
-?>

--- a/php/lib/IceStorm.php
+++ b/php/lib/IceStorm.php
@@ -3,4 +3,3 @@
 
 require_once 'IceStorm/IceStorm.php';
 require_once 'IceStorm/Metrics.php';
-?>

--- a/php/test/Ice/defaultValue/Client.php
+++ b/php/test/Ice/defaultValue/Client.php
@@ -140,4 +140,3 @@ class Client extends TestHelper
         allTests();
     }
 }
-?>

--- a/php/test/Ice/enums/Client.php
+++ b/php/test/Ice/enums/Client.php
@@ -183,4 +183,3 @@ class Client extends TestHelper
         }
     }
 }
-?>

--- a/php/test/Ice/exceptions/Client.php
+++ b/php/test/Ice/exceptions/Client.php
@@ -355,4 +355,3 @@ class Client extends TestHelper
         }
     }
 }
-?>

--- a/php/test/Ice/facets/Client.php
+++ b/php/test/Ice/facets/Client.php
@@ -115,4 +115,3 @@ class Client extends TestHelper
         }
     }
 }
-?>

--- a/php/test/Ice/inheritance/Client.php
+++ b/php/test/Ice/inheritance/Client.php
@@ -124,4 +124,3 @@ class Client extends TestHelper
         }
     }
 }
-?>

--- a/php/test/Ice/objects/Client.php
+++ b/php/test/Ice/objects/Client.php
@@ -420,4 +420,3 @@ class Client extends TestHelper
         $communicator->destroy();
     }
 }
-?>

--- a/php/test/Ice/operations/Client.php
+++ b/php/test/Ice/operations/Client.php
@@ -1052,5 +1052,3 @@ class Client extends TestHelper
         }
     }
 }
-
-?>

--- a/php/test/Ice/optional/Client.php
+++ b/php/test/Ice/optional/Client.php
@@ -736,4 +736,3 @@ class Client extends TestHelper
        }
     }
 }
-?>

--- a/php/test/Ice/scope/Client.php
+++ b/php/test/Ice/scope/Client.php
@@ -130,5 +130,3 @@ class Client extends TestHelper
        }
     }
 }
-
-?>

--- a/php/test/Ice/slicing/exceptions/Client.php
+++ b/php/test/Ice/slicing/exceptions/Client.php
@@ -251,4 +251,3 @@ class Client extends TestHelper
        }
     }
 }
-?>

--- a/php/test/Ice/slicing/objects/Client.php
+++ b/php/test/Ice/slicing/objects/Client.php
@@ -1094,4 +1094,3 @@ class Client extends TestHelper
        }
     }
 }
-?>

--- a/php/test/Ice/timeout/Client.php
+++ b/php/test/Ice/timeout/Client.php
@@ -115,4 +115,3 @@ class Client extends TestHelper
         }
     }
 }
-?>

--- a/php/test/Slice/escape/Client.php
+++ b/php/test/Slice/escape/Client.php
@@ -48,4 +48,3 @@ class Client extends TestHelper
         }
     }
 }
-?>

--- a/php/test/Slice/macros/Client.php
+++ b/php/test/Slice/macros/Client.php
@@ -30,4 +30,3 @@ class Client extends TestHelper
         allTests();
     }
 }
-?>

--- a/php/test/Slice/structure/Client.php
+++ b/php/test/Slice/structure/Client.php
@@ -207,4 +207,3 @@ class Client extends TestHelper
         }
     }
 }
-?>


### PR DESCRIPTION
As mentioned by copilot in previous PR is best to avoid PHP end tags in pure PHP files. This PR removes all PHP end tags, for generated and non-generated PHP files.