### PR TITLE
Make generated Swift structs Sendable

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,8 @@
     "[java]": {
         "editor.formatOnSave": false
     },
+    "[swift]": {
+        "editor.formatOnSave": false
+    },
     "gradle.nestedProjects": true,
 }

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -534,7 +534,7 @@ Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     }
     if (!usesClasses)
     {
-        structProtocols.emplace_back("Sendable");
+        structProtocols.emplace_back("Swift.Sendable");
     }
 
     if (!structProtocols.empty())

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -539,7 +539,7 @@ Gen::TypesVisitor::visitStructStart(const StructPtr& p)
 
     if (!structProtocols.empty())
     {
-        out << " : ";
+        out << ": ";
         out.spar("");
         out << structProtocols;
         out.epar("");

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -541,10 +541,7 @@ Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     {
         out << " : ";
         out.spar("");
-        for (const auto& protocol : structProtocols)
-        {
-            out << protocol;
-        }
+        out << structProtocols;
         out.epar("");
     }
 

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -526,11 +526,28 @@ Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     writeSwiftAttributes(out, p->getMetadata());
     out << nl << "public " << (usesClasses ? "class " : "struct ") << name;
 
-    // Only generate Hashable if this struct is a legal dictionary key type.
+    // Vector of protocols this struct conforms to.
+    vector<string> structProtocols;
     if (isLegalKeyType)
     {
-        out << ": Swift.Hashable";
+        structProtocols.emplace_back("Swift.Hashable");
     }
+    if (!usesClasses)
+    {
+        structProtocols.emplace_back("Sendable");
+    }
+
+    if (!structProtocols.empty())
+    {
+        out << " : ";
+        out.spar("");
+        for (const auto& protocol : structProtocols)
+        {
+            out << protocol;
+        }
+        out.epar("");
+    }
+
     out << sb;
 
     writeMembers(out, members, p);

--- a/swift/src/Ice/CurrentExtensions.swift
+++ b/swift/src/Ice/CurrentExtensions.swift
@@ -169,7 +169,7 @@ extension Current {
     }
 }
 
-nonisolated(unsafe) private let currentProtocolEncoding = EncodingVersion(major: 1, minor: 0)
+private let currentProtocolEncoding = EncodingVersion(major: 1, minor: 0)
 
 private let replyHdr: [UInt8] = [
     0x49, 0x63, 0x65, 0x50,  // IceP magic

--- a/swift/src/Ice/Initialize.swift
+++ b/swift/src/Ice/Initialize.swift
@@ -28,8 +28,7 @@ let factoriesRegistered: Bool = {
 ///   settings in args override property settings in initData.
 ///
 /// - returns: The initialized communicator.
-public func initialize(_ args: [String], initData: InitializationData? = nil) throws -> Communicator
-{
+public func initialize(_ args: [String], initData: InitializationData? = nil) throws -> Communicator {
     return try initializeImpl(
         args: args, initData: initData ?? InitializationData(), withConfigFile: true
     ).0

--- a/swift/src/Ice/Initialize.swift
+++ b/swift/src/Ice/Initialize.swift
@@ -28,7 +28,8 @@ let factoriesRegistered: Bool = {
 ///   settings in args override property settings in initData.
 ///
 /// - returns: The initialized communicator.
-public func initialize(_ args: [String], initData: InitializationData? = nil) throws -> Communicator {
+public func initialize(_ args: [String], initData: InitializationData? = nil) throws -> Communicator
+{
     return try initializeImpl(
         args: args, initData: initData ?? InitializationData(), withConfigFile: true
     ).0
@@ -168,10 +169,12 @@ private func initializeImpl(
             initData.sliceLoader = DefaultSliceLoader()
         }
 
-        let notFoundCacheSize = try initData.properties!.getIcePropertyAsInt("Ice.SliceLoader.NotFoundCacheSize")
+        let notFoundCacheSize = try initData.properties!.getIcePropertyAsInt(
+            "Ice.SliceLoader.NotFoundCacheSize")
         if notFoundCacheSize > 0 {
             let cacheFullLogger =
-                try initData.properties!.getIcePropertyAsInt("Ice.Warn.SliceLoader") > 0 ? initData.logger : nil
+                try initData.properties!.getIcePropertyAsInt("Ice.Warn.SliceLoader") > 0
+                ? initData.logger : nil
             initData.sliceLoader = NotFoundSliceLoaderDecorator(
                 initData.sliceLoader!,
                 cacheSize: notFoundCacheSize,
@@ -267,10 +270,10 @@ public let intVersion: Int = 30850
 /// B indicates the minor version, and C indicates the patch level.
 public let stringVersion: String = "3.8.0-alpha.0"
 
-nonisolated(unsafe) public let Encoding_1_0 = EncodingVersion(major: 1, minor: 0)
-nonisolated(unsafe) public let Encoding_1_1 = EncodingVersion(major: 1, minor: 1)
+public let Encoding_1_0 = EncodingVersion(major: 1, minor: 0)
+public let Encoding_1_1 = EncodingVersion(major: 1, minor: 1)
 
-nonisolated(unsafe) public let currentEncoding = Encoding_1_1
+public let currentEncoding = Encoding_1_1
 
 /// Converts a string to an object identity.
 ///

--- a/swift/src/Ice/Initialize.swift
+++ b/swift/src/Ice/Initialize.swift
@@ -168,12 +168,10 @@ private func initializeImpl(
             initData.sliceLoader = DefaultSliceLoader()
         }
 
-        let notFoundCacheSize = try initData.properties!.getIcePropertyAsInt(
-            "Ice.SliceLoader.NotFoundCacheSize")
+        let notFoundCacheSize = try initData.properties!.getIcePropertyAsInt("Ice.SliceLoader.NotFoundCacheSize")
         if notFoundCacheSize > 0 {
             let cacheFullLogger =
-                try initData.properties!.getIcePropertyAsInt("Ice.Warn.SliceLoader") > 0
-                ? initData.logger : nil
+                try initData.properties!.getIcePropertyAsInt("Ice.Warn.SliceLoader") > 0 ? initData.logger : nil
             initData.sliceLoader = NotFoundSliceLoaderDecorator(
                 initData.sliceLoader!,
                 cacheSize: notFoundCacheSize,


### PR DESCRIPTION
This PR adds updates the Swift mapping for generated structs to make them conform to Sendable when they do not use classes. 