### PR TITLE
Update Slice-to-C# struct mapping

### DIFF
--- a/CHANGELOG-3.8.md
+++ b/CHANGELOG-3.8.md
@@ -508,7 +508,9 @@ was executed in a thread managed by the same Ice thread pool unless you specifie
 - Replaced the `Ice.Util.registerPluginFactory` mechanism by plug-in factories on InitializationData. The corresponding
 plug-ins are created during communicator initialization. See `InitializationData.pluginFactories`.
 
-- Slice structs are now mapped to record structs or record classes.
+- Slice structs are now mapped to record structs or record classes:
+  - a Slice struct with only numeric, bool, enum, or record struct fields is mapped to a record struct.
+  - a Slice struct with any other field type is mapped to a sealed record class.
 
 - Updated Ice.Communicator to implement IAsyncDisposable. The preferred way to create and dispose of a communicator is
   now:

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -277,7 +277,7 @@ Slice::CsGenerator::isValueType(const TypePtr& type)
         DataMemberList dm = s->dataMembers();
         for (const auto& i : dm)
         {
-            if (!isValueType(i->type()) || i->defaultValue())
+            if (!isValueType(i->type()))
             {
                 return false;
             }

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1715,7 +1715,6 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
         addSemicolon = false;
     }
 
-    // Generate the default value for this field unless the enclosing type is a struct.
     if (p->defaultValue())
     {
         string defaultValue = *p->defaultValue();

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1564,6 +1564,27 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     _out << nl << "ice_initialize();";
     _out << eb;
 
+    // If the struct is mapped to a struct and there is at least one default value, we need an explicit parameterless
+    // constructor to initialize the default values.
+    if (!isMappedToClass(p))
+    {
+        bool hasDefaultValue = false;
+        for (const auto& q : dataMembers)
+        {
+            if (q->defaultValue())
+            {
+                hasDefaultValue = true;
+                break;
+            }
+        }
+        if (hasDefaultValue)
+        {
+            _out << sp;
+            writeDocLine(_out, "summary", "Initializes a new instance of the <see cref=\"" + name + "\" /> struct.");
+            _out << nl << "public " << name << "() => ice_initialize();";
+        }
+    }
+
     // Unmarshaling constructor
     _out << sp;
     writeDocLine(
@@ -1695,30 +1716,28 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
     }
 
     // Generate the default value for this field unless the enclosing type is a struct.
-    if (!st || isMappedToClass(st))
+    if (p->defaultValue())
     {
-        if (p->defaultValue())
-        {
-            string defaultValue = *p->defaultValue();
-            BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(p->type());
+        string defaultValue = *p->defaultValue();
+        BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(p->type());
 
-            // Don't explicitly initialize to default value.
-            if (!builtin || builtin->kind() == Builtin::KindString || defaultValue != "0")
-            {
-                _out << " = ";
-                writeConstantValue(p->type(), p->defaultValueType(), defaultValue);
-                addSemicolon = true;
-            }
-        }
-        else if (!p->optional())
+        // Don't explicitly initialize to default value.
+        if (!builtin || builtin->kind() == Builtin::KindString || defaultValue != "0")
         {
-            BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(p->type());
-            if (builtin && builtin->kind() == Builtin::KindString)
-            {
-                // This behavior is unfortunate but kept for backwards compatibility.
-                _out << " = \"\"";
-                addSemicolon = true;
-            }
+            _out << " = ";
+            writeConstantValue(p->type(), p->defaultValueType(), defaultValue);
+            addSemicolon = true;
+        }
+    }
+    else if (!p->optional())
+    {
+        BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(p->type());
+        if (builtin && builtin->kind() == Builtin::KindString)
+        {
+            // This behavior is unfortunate but kept for backwards compatibility.
+            // Note that since string is a reference type, the enclosing type can't be a record struct.
+            _out << " = \"\"";
+            addSemicolon = true;
         }
     }
 

--- a/csharp/test/Ice/defaultValue/AllTests.cs
+++ b/csharp/test/Ice/defaultValue/AllTests.cs
@@ -4,13 +4,25 @@ using Ice.defaultValue.Test;
 
 namespace Ice.defaultValue;
 
-public class AllTests : global::Test.AllTests
-{
-    public static void allTests(global::Test.TestHelper helper)
-    {
+public class AllTests : global::Test.AllTests {
+    public static void allTests(global::Test.TestHelper helper) {
         var output = helper.getWriter();
         output.Write("testing default values... ");
         output.Flush();
+
+        {
+            var point = new Point();
+            test(point.x == 0);
+            test(point.y == 42);
+
+            point = default;
+            test(point.x == 0);
+            test(point.y == 0);
+
+            point = new Point { x = 13 };
+            test(point.x == 13);
+            test(point.y == 42);
+        }
 
         {
             var v = new Struct1();
@@ -22,7 +34,8 @@ public class AllTests : global::Test.AllTests
             test(v.l == 4);
             test(v.f == (float)5.1);
             test(v.d == 6.2);
-            test(v.str.Equals("foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
+            test(v.str.Equals(
+                "foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
             test(v.c1 == Color.red);
             test(v.c2 == Color.green);
             test(v.c3 == Color.blue);
@@ -72,8 +85,8 @@ public class AllTests : global::Test.AllTests
             test(v.l == 4);
             test(v.f == 5.1F);
             test(v.d == 6.2);
-            // test(v.str.Equals("foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
-            // test(v.str == "foo bar");
+            // test(v.str.Equals("foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007
+            // \u0007")); test(v.str == "foo bar");
             test(v.c1 == Color.red);
             test(v.c2 == Color.green);
             test(v.c3 == Color.blue);
@@ -99,8 +112,8 @@ public class AllTests : global::Test.AllTests
             test(v.l == 4);
             test(v.f == 5.1F);
             test(v.d == 6.2);
-            // test(v.str.Equals("foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
-            // test(v.str == "foo bar");
+            // test(v.str.Equals("foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007
+            // \u0007")); test(v.str == "foo bar");
             test(v.c1 == Color.red);
             test(v.c2 == Color.green);
             test(v.c3 == Color.blue);
@@ -126,7 +139,8 @@ public class AllTests : global::Test.AllTests
             test(v.l == 4);
             test(v.f == 5.1F);
             test(v.d == 6.2);
-            test(v.str.Equals("foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
+            test(v.str.Equals(
+                "foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
             test(v.noDefault.Length == 0);
             test(v.zeroI == 0);
             test(v.zeroL == 0);
@@ -146,7 +160,8 @@ public class AllTests : global::Test.AllTests
             test(v.l == 4);
             test(v.f == 5.1F);
             test(v.d == 6.2);
-            test(v.str.Equals("foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
+            test(v.str.Equals(
+                "foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
             test(v.c1 == Color.red);
             test(v.c2 == Color.green);
             test(v.c3 == Color.blue);
@@ -172,7 +187,8 @@ public class AllTests : global::Test.AllTests
             test(v.l == 4);
             test(v.f == 5.1F);
             test(v.d == 6.2);
-            test(v.str == "foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007");
+            test(v.str ==
+                 "foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007");
             test(v.noDefault.Length == 0);
             test(v.zeroI == 0);
             test(v.zeroL == 0);
@@ -192,7 +208,8 @@ public class AllTests : global::Test.AllTests
             test(v.l == 4);
             test(v.f == 5.1F);
             test(v.d == 6.2);
-            test(v.str == "foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007");
+            test(v.str ==
+                 "foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007");
             test(v.noDefault.Length == 0);
             test(v.c1 == Color.red);
             test(v.c2 == Color.green);
@@ -271,7 +288,8 @@ public class AllTests : global::Test.AllTests
         output.Write("testing non-primary constructor... ");
         output.Flush();
         {
-            var v = new StructNoDefaults(bs: [], iseq: [], st2: new(), dict: []);
+            var v =
+                new StructNoDefaults(bs: [], iseq: [], st2: new(), dict: []);
             test(v.bo == false);
             test(v.b == 0);
             test(v.s == 0);

--- a/csharp/test/Ice/defaultValue/AllTests.cs
+++ b/csharp/test/Ice/defaultValue/AllTests.cs
@@ -4,8 +4,10 @@ using Ice.defaultValue.Test;
 
 namespace Ice.defaultValue;
 
-public class AllTests : global::Test.AllTests {
-    public static void allTests(global::Test.TestHelper helper) {
+public class AllTests : global::Test.AllTests
+{
+    public static void allTests(global::Test.TestHelper helper)
+    {
         var output = helper.getWriter();
         output.Write("testing default values... ");
         output.Flush();

--- a/csharp/test/Ice/defaultValue/AllTests.cs
+++ b/csharp/test/Ice/defaultValue/AllTests.cs
@@ -50,8 +50,7 @@ public class AllTests : global::Test.AllTests
             test(v.l == 4);
             test(v.f == (float)5.1);
             test(v.d == 6.2);
-            test(v.str.Equals(
-                "foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
+            test(v.str.Equals("foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
             test(v.c1 == Color.red);
             test(v.c2 == Color.green);
             test(v.c3 == Color.blue);
@@ -101,8 +100,8 @@ public class AllTests : global::Test.AllTests
             test(v.l == 4);
             test(v.f == 5.1F);
             test(v.d == 6.2);
-            // test(v.str.Equals("foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007
-            // \u0007")); test(v.str == "foo bar");
+            // test(v.str.Equals("foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
+            // test(v.str == "foo bar");
             test(v.c1 == Color.red);
             test(v.c2 == Color.green);
             test(v.c3 == Color.blue);
@@ -128,8 +127,8 @@ public class AllTests : global::Test.AllTests
             test(v.l == 4);
             test(v.f == 5.1F);
             test(v.d == 6.2);
-            // test(v.str.Equals("foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007
-            // \u0007")); test(v.str == "foo bar");
+            // test(v.str.Equals("foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
+            // test(v.str == "foo bar");
             test(v.c1 == Color.red);
             test(v.c2 == Color.green);
             test(v.c3 == Color.blue);
@@ -155,8 +154,7 @@ public class AllTests : global::Test.AllTests
             test(v.l == 4);
             test(v.f == 5.1F);
             test(v.d == 6.2);
-            test(v.str.Equals(
-                "foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
+            test(v.str.Equals("foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
             test(v.noDefault.Length == 0);
             test(v.zeroI == 0);
             test(v.zeroL == 0);
@@ -176,8 +174,7 @@ public class AllTests : global::Test.AllTests
             test(v.l == 4);
             test(v.f == 5.1F);
             test(v.d == 6.2);
-            test(v.str.Equals(
-                "foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
+            test(v.str.Equals("foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007"));
             test(v.c1 == Color.red);
             test(v.c2 == Color.green);
             test(v.c3 == Color.blue);
@@ -203,8 +200,7 @@ public class AllTests : global::Test.AllTests
             test(v.l == 4);
             test(v.f == 5.1F);
             test(v.d == 6.2);
-            test(v.str ==
-                 "foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007");
+            test(v.str == "foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007");
             test(v.noDefault.Length == 0);
             test(v.zeroI == 0);
             test(v.zeroL == 0);
@@ -224,8 +220,7 @@ public class AllTests : global::Test.AllTests
             test(v.l == 4);
             test(v.f == 5.1F);
             test(v.d == 6.2);
-            test(v.str ==
-                 "foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007");
+            test(v.str == "foo \\ \"bar\n \r\n\t\u000b\f\u0007\b? \u0007 \u0007");
             test(v.noDefault.Length == 0);
             test(v.c1 == Color.red);
             test(v.c2 == Color.green);
@@ -304,8 +299,7 @@ public class AllTests : global::Test.AllTests
         output.Write("testing non-primary constructor... ");
         output.Flush();
         {
-            var v =
-                new StructNoDefaults(bs: [], iseq: [], st2: new(), dict: []);
+            var v = new StructNoDefaults(bs: [], iseq: [], st2: new(), dict: []);
             test(v.bo == false);
             test(v.b == 0);
             test(v.s == 0);

--- a/csharp/test/Ice/defaultValue/AllTests.cs
+++ b/csharp/test/Ice/defaultValue/AllTests.cs
@@ -27,6 +27,20 @@ public class AllTests : global::Test.AllTests
         }
 
         {
+            var point = new PointProp();
+            test(point.x == 0);
+            test(point.y == 42);
+
+            point = default;
+            test(point.x == 0);
+            test(point.y == 0);
+
+            point = new PointProp { x = 13 };
+            test(point.x == 13);
+            test(point.y == 42);
+        }
+
+        {
             var v = new Struct1();
             test(!v.boolFalse);
             test(v.boolTrue);

--- a/csharp/test/Ice/defaultValue/Test.ice
+++ b/csharp/test/Ice/defaultValue/Test.ice
@@ -16,6 +16,9 @@ module Test
 
     struct Point { int x; int y = 42; }
 
+    ["cs:property"]
+    struct PointProp { int x; int y = 42; }
+
     //
     // Struct1 maps to a C# class because it contains string members.
     //

--- a/csharp/test/Ice/defaultValue/Test.ice
+++ b/csharp/test/Ice/defaultValue/Test.ice
@@ -14,6 +14,8 @@ module Test
         enum Color { red, green, blue }
     }
 
+    struct Point { int x; int y = 42; }
+
     //
     // Struct1 maps to a C# class because it contains string members.
     //
@@ -121,9 +123,7 @@ module Test
     }
 
     //
-    // Struct4 would normally map to a C# struct because we have omitted
-    // the string members, and don't contains cs:class metadata, but as it
-    // contains default values it is mapped to a class.
+    // Struct4 maps to a record struct
     //
     struct Struct4
     {


### PR DESCRIPTION
This is a small update to the Slice to C# mapping for struct.

Before this PR, a struct with only "value type" field was mapped to a struct only if none of its fields had default values.

This PR removes the default value condition.  A modern C# struct can have default values for its fields / properties.