### PR TITLE
Remove Sendable from admin facet servants

### DIFF
--- a/swift/src/Ice/AdminFacetFactory.swift
+++ b/swift/src/Ice/AdminFacetFactory.swift
@@ -2,11 +2,11 @@
 
 import IceImpl
 
-final class AdminFacetFacade: ICEDispatchAdapter {
+final class AdminFacetFacade: ICEDispatchAdapter, @unchecked Sendable {
     private let communicator: Communicator
-    let servant: Dispatcher & Sendable
+    let servant: Dispatcher
 
-    init(communicator: Communicator, servant: Dispatcher & Sendable) {
+    init(communicator: Communicator, servant: Dispatcher) {
         self.communicator = communicator
         self.servant = servant
     }

--- a/swift/src/Ice/Communicator.swift
+++ b/swift/src/Ice/Communicator.swift
@@ -210,7 +210,7 @@ public protocol Communicator: AnyObject, Sendable {
     /// - parameter servant: `Dispatcher` The servant that implements the new Admin facet.
     ///
     /// - parameter facet: `String` The name of the new Admin facet.
-    func addAdminFacet(servant: Dispatcher & Sendable, facet: String) throws
+    func addAdminFacet(servant: Dispatcher, facet: String) throws
 
     /// Remove the following facet to the Admin object. Removing a facet that was not previously registered throws
     /// NotRegisteredException.

--- a/swift/src/Ice/CommunicatorI.swift
+++ b/swift/src/Ice/CommunicatorI.swift
@@ -216,7 +216,7 @@ class CommunicatorI: LocalObject<ICECommunicator>, Communicator, @unchecked Send
         }
     }
 
-    func addAdminFacet(servant: Dispatcher & Sendable, facet: String) throws {
+    func addAdminFacet(servant: Dispatcher, facet: String) throws {
         try autoreleasepool {
             try handle.addAdminFacet(
                 AdminFacetFacade(communicator: self, servant: servant), facet: facet)

--- a/swift/src/Ice/Dispatcher.swift
+++ b/swift/src/Ice/Dispatcher.swift
@@ -1,6 +1,5 @@
 // Copyright (c) ZeroC, Inc.
 
-// TODO: Make Dispatcher Sendable
 /// A dispatcher accepts incoming requests and returns outgoing responses.
 public protocol Dispatcher {
     /// Dispatches an incoming request and returns the corresponding outgoing response.


### PR DESCRIPTION
This PR removes Sendable from the admin facet servant.

See also #4058.