### PR TITLE
Fix UDP test in C# and Swift

### DIFF
--- a/csharp/test/Ice/udp/AllTests.cs
+++ b/csharp/test/Ice/udp/AllTests.cs
@@ -130,10 +130,7 @@ public class AllTests : global::Test.AllTests
                 //
                 test(!b);
             }
-            catch (Ice.DatagramLimitException)
-            {
-            }
-            catch (Ice.LocalException ex)
+            catch (LocalException ex)
             {
                 Console.Out.WriteLine(ex);
                 test(false);

--- a/swift/test/Ice/udp/AllTests.swift
+++ b/swift/test/Ice/udp/AllTests.swift
@@ -99,7 +99,10 @@ public func allTests(_ helper: TestHelper) async throws {
             // should not be delivered.
             //
             try test(!b)
-        } catch is Ice.DatagramLimitException {}
+        } catch {
+            print("Failed to send large request over udp: \(error)")
+            try test(false)
+        }
     }
     output.writeLine("ok")
 


### PR DESCRIPTION
This Ice/udp is implemented for C++, C#, Java, and Swift.
It's not clear why we have a Swift version since the code being tested is C++ code.

In any case, both the C# and Swift test were catching/ignoring DatagramLimitException, unlike C++ and Java.