### PR TITLE
Improve Error Message for Unmatched Swift Modules

### DIFF
--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -492,7 +492,8 @@ SwiftGenerator::validateSwiftModuleMappings(const UnitPtr& unit)
         else if (swiftModule != mappedModuleName)
         {
             ostringstream os;
-            os << "invalid module mapping: Slice module '" << mod->scoped() << "' should map to Swift module '"
+            os << "invalid module mapping: the contents of a Slice file must map to a single Swift module" << endl;
+            os << "note: you can use 'swift:identifier:" << mappedModuleName << "' metadata to map Slice module '" << mod->scoped() << "' to Swift module '"
                << mappedModuleName << "'" << endl;
             unit->error(mod->file(), mod->line(), os.str());
         }

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -493,8 +493,8 @@ SwiftGenerator::validateSwiftModuleMappings(const UnitPtr& unit)
         {
             ostringstream os;
             os << "invalid module mapping: the contents of a Slice file must map to a single Swift module" << endl;
-            os << "note: you can use 'swift:identifier:" << mappedModuleName << "' metadata to map Slice module '" << mod->scoped() << "' to Swift module '"
-               << mappedModuleName << "'" << endl;
+            os << "note: you can use 'swift:identifier:" << mappedModuleName << "' metadata to map Slice module '"
+               << mod->scoped() << "' to Swift module '" << mappedModuleName << "'" << endl;
             unit->error(mod->file(), mod->line(), os.str());
         }
     }


### PR DESCRIPTION
Fix for #4080.
`slice2swift` requires a Slice file maps it's contents to a single Swift module.
So, a Slice definition like this is illegal without some metadata to customize it:
```slice
module Hello {}

module There {}
```
The error message you get is not great though.

This PR updates the error message to be more clear, and to tell you that `swift:identifier` is the way you'll want to fix it.
(Technically, `swift:module` would also work, but... no).

----

For context, this is new error message you'd get when compiling the above Slice definition.
```
D:/Code/Workspace/ice/test.ice:3: invalid module mapping: the contents of a Slice file must map to a single Swift module
note: you can use 'swift:identifier:Hello' metadata to map Slice module '::There' to Swift module 'Hello'
```