### PR TITLE
Simplify Default Constructor Argument Generation in `slice2js`

### DIFF
--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -1028,33 +1028,17 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
         for (const auto& dataMember : dataMembers)
         {
             string value;
-            if (dataMember->optional())
+            if (dataMember->defaultValue())
             {
-                if (dataMember->defaultValue())
-                {
-                    value = writeConstantValue(
-                        dataMember->type(),
-                        dataMember->defaultValueType(),
-                        *dataMember->defaultValue());
-                }
-                else
-                {
-                    value = "undefined";
-                }
+                value = writeConstantValue(dataMember->type(), dataMember->defaultValueType(), *dataMember->defaultValue());
+            }
+            else if (dataMember->optional())
+            {
+                value = "undefined";
             }
             else
             {
-                if (dataMember->defaultValue())
-                {
-                    value = writeConstantValue(
-                        dataMember->type(),
-                        dataMember->defaultValueType(),
-                        *dataMember->defaultValue());
-                }
-                else
-                {
-                    value = getValue(dataMember->type());
-                }
+                value = getValue(dataMember->type());
             }
             _out << (dataMember->mappedName() + (value.empty() ? value : (" = " + value)));
         }
@@ -1470,29 +1454,17 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     for (const auto& dataMember : dataMembers)
     {
         string value;
-        if (dataMember->optional())
+        if (dataMember->defaultValue())
         {
-            if (dataMember->defaultValue())
-            {
-                value =
-                    writeConstantValue(dataMember->type(), dataMember->defaultValueType(), *dataMember->defaultValue());
-            }
-            else
-            {
-                value = "undefined";
-            }
+            value = writeConstantValue(dataMember->type(), dataMember->defaultValueType(), *dataMember->defaultValue());
+        }
+        else if (dataMember->optional())
+        {
+            value = "undefined";
         }
         else
         {
-            if (dataMember->defaultValue())
-            {
-                value =
-                    writeConstantValue(dataMember->type(), dataMember->defaultValueType(), *dataMember->defaultValue());
-            }
-            else
-            {
-                value = getValue(dataMember->type());
-            }
+            value = getValue(dataMember->type());
         }
         _out << (dataMember->mappedName() + (value.empty() ? value : (" = " + value)));
     }
@@ -1574,29 +1546,17 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     for (const auto& dataMember : dataMembers)
     {
         string value;
-        if (dataMember->optional())
+        if (dataMember->defaultValue())
         {
-            if (dataMember->defaultValue())
-            {
-                value =
-                    writeConstantValue(dataMember->type(), dataMember->defaultValueType(), *dataMember->defaultValue());
-            }
-            else
-            {
-                value = "undefined";
-            }
+            value = writeConstantValue(dataMember->type(), dataMember->defaultValueType(), *dataMember->defaultValue());
+        }
+        else if (dataMember->optional())
+        {
+            value = "undefined";
         }
         else
         {
-            if (dataMember->defaultValue())
-            {
-                value =
-                    writeConstantValue(dataMember->type(), dataMember->defaultValueType(), *dataMember->defaultValue());
-            }
-            else
-            {
-                value = getValue(dataMember->type());
-            }
+            value = getValue(dataMember->type());
         }
         _out << (dataMember->mappedName() + (value.empty() ? value : (" = " + value)));
     }

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -1030,7 +1030,8 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
             string value;
             if (dataMember->defaultValue())
             {
-                value = writeConstantValue(dataMember->type(), dataMember->defaultValueType(), *dataMember->defaultValue());
+                value =
+                    writeConstantValue(dataMember->type(), dataMember->defaultValueType(), *dataMember->defaultValue());
             }
             else if (dataMember->optional())
             {

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -298,22 +298,22 @@ Slice::JsVisitor::writeUnmarshalDataMembers(const DataMemberList& dataMembers, c
 void
 Slice::JsVisitor::writeOneShotConstructorArguments(const DataMemberList& members)
 {
-    for (const auto& dataMember : dataMembers)
+    for (const auto& member : members)
     {
         string value;
-        if (dataMember->defaultValue())
+        if (member->defaultValue())
         {
-            value = writeConstantValue(dataMember->type(), dataMember->defaultValueType(), *dataMember->defaultValue());
+            value = writeConstantValue(member->type(), member->defaultValueType(), *member->defaultValue());
         }
-        else if (dataMember->optional())
+        else if (member->optional())
         {
             value = "undefined";
         }
         else
         {
-            value = getValue(dataMember->type());
+            value = getValue(member->type());
         }
-        _out << (dataMember->mappedName() + (value.empty() ? value : (" = " + value)));
+        _out << (member->mappedName() + (value.empty() ? value : (" = " + value)));
     }
 }
 

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -295,6 +295,28 @@ Slice::JsVisitor::writeUnmarshalDataMembers(const DataMemberList& dataMembers, c
     }
 }
 
+void
+Slice::JsVisitor::writeOneShotConstructorArguments(const DataMemberList& members)
+{
+    for (const auto& dataMember : dataMembers)
+    {
+        string value;
+        if (dataMember->defaultValue())
+        {
+            value = writeConstantValue(dataMember->type(), dataMember->defaultValueType(), *dataMember->defaultValue());
+        }
+        else if (dataMember->optional())
+        {
+            value = "undefined";
+        }
+        else
+        {
+            value = getValue(dataMember->type());
+        }
+        _out << (dataMember->mappedName() + (value.empty() ? value : (" = " + value)));
+    }
+}
+
 string
 Slice::JsVisitor::getValue(const TypePtr& type)
 {
@@ -1025,24 +1047,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
             _out << baseDataMember->mappedName();
         }
 
-        for (const auto& dataMember : dataMembers)
-        {
-            string value;
-            if (dataMember->defaultValue())
-            {
-                value =
-                    writeConstantValue(dataMember->type(), dataMember->defaultValueType(), *dataMember->defaultValue());
-            }
-            else if (dataMember->optional())
-            {
-                value = "undefined";
-            }
-            else
-            {
-                value = getValue(dataMember->type());
-            }
-            _out << (dataMember->mappedName() + (value.empty() ? value : (" = " + value)));
-        }
+        writeOneShotConstructorArguments(dataMembers);
 
         _out << epar << sb;
         _out << nl << "super" << spar << baseParamNames << epar << ';';
@@ -1452,23 +1457,7 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
         _out << baseDataMember->mappedName();
     }
 
-    for (const auto& dataMember : dataMembers)
-    {
-        string value;
-        if (dataMember->defaultValue())
-        {
-            value = writeConstantValue(dataMember->type(), dataMember->defaultValueType(), *dataMember->defaultValue());
-        }
-        else if (dataMember->optional())
-        {
-            value = "undefined";
-        }
-        else
-        {
-            value = getValue(dataMember->type());
-        }
-        _out << (dataMember->mappedName() + (value.empty() ? value : (" = " + value)));
-    }
+    writeOneShotConstructorArguments(dataMembers);
 
     _out << "_cause = \"\"" << epar;
     _out << sb;
@@ -1544,23 +1533,7 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
 
     _out << nl << "constructor" << spar;
 
-    for (const auto& dataMember : dataMembers)
-    {
-        string value;
-        if (dataMember->defaultValue())
-        {
-            value = writeConstantValue(dataMember->type(), dataMember->defaultValueType(), *dataMember->defaultValue());
-        }
-        else if (dataMember->optional())
-        {
-            value = "undefined";
-        }
-        else
-        {
-            value = getValue(dataMember->type());
-        }
-        _out << (dataMember->mappedName() + (value.empty() ? value : (" = " + value)));
-    }
+    writeOneShotConstructorArguments(dataMembers);
 
     _out << epar;
     _out << sb;

--- a/cpp/src/slice2js/Gen.h
+++ b/cpp/src/slice2js/Gen.h
@@ -21,7 +21,7 @@ namespace Slice
     protected:
         void writeMarshalDataMembers(const DataMemberList&, const DataMemberList&);
         void writeUnmarshalDataMembers(const DataMemberList&, const DataMemberList&);
-        void writeInitDataMembers(const DataMemberList&);
+        void writeOneShotConstructorArguments(const DataMemberList& members);
 
         std::string getValue(const TypePtr&);
 


### PR DESCRIPTION
Just a small PR to move some triplicated code into a helper function.
We copy/pasted the exact same code for classes, exceptions, and structs.
Might as well move it into a helper function I figured.