### PR TITLE
Replace containers.Map by dictionary in MATLAB marshaling code

### DIFF
--- a/matlab/lib/+IceInternal/EncapsDecoder.m
+++ b/matlab/lib/+IceInternal/EncapsDecoder.m
@@ -10,7 +10,6 @@ classdef (Abstract) EncapsDecoder < handle
             obj.patchMap = {};
             obj.patchMapLength = 0;
             obj.unmarshaledMap = {};
-            obj.typeIdMap = {};
             obj.valueList = {};
             obj.delayedPostUnmarshal = {};
         end
@@ -182,7 +181,7 @@ classdef (Abstract) EncapsDecoder < handle
     end
     properties(Access=private)
         unmarshaledMap
-        typeIdMap
+        typeIdMap cell = {} % a cell array in this class
         valueList
         delayedPostUnmarshal
     end

--- a/matlab/lib/+IceInternal/EncapsDecoder11_InstanceData.m
+++ b/matlab/lib/+IceInternal/EncapsDecoder11_InstanceData.m
@@ -10,7 +10,6 @@ classdef EncapsDecoder11_InstanceData < handle
             obj.slices = {};
             obj.indirectionTables = {};
             obj.sliceFlags = uint8(0);
-            obj.indirectPatchList = [];
         end
     end
     properties
@@ -23,7 +22,7 @@ classdef EncapsDecoder11_InstanceData < handle
         typeId
         typeIdIndex
         compactId
-        indirectPatchList
+        indirectPatchList dictionary = dictionary % unconfigured dictionary
         previous
         next
     end

--- a/matlab/lib/+IceInternal/EncapsEncoder.m
+++ b/matlab/lib/+IceInternal/EncapsEncoder.m
@@ -5,7 +5,6 @@ classdef (Abstract) EncapsEncoder < handle
         function obj = EncapsEncoder(os, encaps)
             obj.os = os;
             obj.encaps = encaps;
-            obj.typeIdMap = containers.Map('KeyType', 'char', 'ValueType', 'int32');
             obj.typeIdIndex = 0;
         end
 
@@ -42,7 +41,7 @@ classdef (Abstract) EncapsEncoder < handle
         encaps
     end
     properties(Access=private)
-        typeIdMap
+        typeIdMap dictionary = configureDictionary('char', 'int32')
         typeIdIndex
     end
 end

--- a/matlab/lib/+IceInternal/EncapsEncoder11.m
+++ b/matlab/lib/+IceInternal/EncapsEncoder11.m
@@ -59,7 +59,6 @@ classdef EncapsEncoder11 < IceInternal.EncapsEncoder
 
         function startSlice(obj, typeId, compactId, last)
             import IceInternal.Protocol;
-            %assert(isempty(obj.current.indirectionTable) && isempty(obj.current.indirectionMap));
 
             obj.current.sliceFlagsPos = obj.os.getPos() + 1;
 
@@ -147,7 +146,7 @@ classdef EncapsEncoder11 < IceInternal.EncapsEncoder
                     obj.writeInstance(obj.current.indirectionTable{i});
                 end
                 obj.current.indirectionTable = {};
-                obj.current.indirectionMap = containers.Map('KeyType', 'int32', 'ValueType', 'int32');
+                obj.current.indirectionMap = configureDictionary('int32', 'int32'); % clear dictionary
             end
 
             %

--- a/matlab/lib/+IceInternal/EncapsEncoder11.m
+++ b/matlab/lib/+IceInternal/EncapsEncoder11.m
@@ -6,7 +6,6 @@ classdef EncapsEncoder11 < IceInternal.EncapsEncoder
             obj@IceInternal.EncapsEncoder(os, encaps);
             obj.current = [];
             obj.valueIdIndex = 1;
-            obj.marshaledMap = containers.Map('KeyType', 'int32', 'ValueType', 'int32');
         end
 
         function writeValue(obj, v)
@@ -237,6 +236,6 @@ classdef EncapsEncoder11 < IceInternal.EncapsEncoder
     properties(Access=private)
         current
         valueIdIndex
-        marshaledMap
+        marshaledMap dictionary = configureDictionary('int32', 'int32');
     end
 end

--- a/matlab/lib/+IceInternal/EncapsEncoder11_InstanceData.m
+++ b/matlab/lib/+IceInternal/EncapsEncoder11_InstanceData.m
@@ -9,7 +9,6 @@ classdef EncapsEncoder11_InstanceData < handle
             obj.previous = previous;
             obj.next = [];
             obj.indirectionTable = {};
-            obj.indirectionMap = containers.Map('KeyType', 'int32', 'ValueType', 'int32');
         end
     end
     properties
@@ -21,7 +20,7 @@ classdef EncapsEncoder11_InstanceData < handle
         writeSlice    % Position of the slice data members
         sliceFlagsPos % Position of the slice flags
         indirectionTable
-        indirectionMap
+        indirectionMap dictionary = configureDictionary('int32', 'int32')
         previous
         next
     end


### PR DESCRIPTION
This PR replaces all containers.Map by dictionary in the internal marshaling/unmarshaling code, except in the EncapsEncoder10 class.

The EncapsEncoder10 code is complicated, rarely used, and I'd rather not break it by accident.