### PR TITLE
Add transparent comparator (std::less<>) to C++ maps

### DIFF
--- a/cpp/include/Ice/Connection.h
+++ b/cpp/include/Ice/Connection.h
@@ -39,7 +39,7 @@ namespace Ice
     };
 
     /// Represents a collection of HTTP headers.
-    using HeaderDict = std::map<std::string, std::string>;
+    using HeaderDict = std::map<std::string, std::string, std::less<>>;
 
     /// The callback function given to Connection::setCloseCallback.
     /// @param con The connection that was closed. It's never a nullptr.

--- a/cpp/include/Ice/Properties.h
+++ b/cpp/include/Ice/Properties.h
@@ -166,8 +166,7 @@ namespace Ice
         /// @param prefix The prefix to match.
         /// @param options The options to parse.
         /// @return A pair containing a map of matched key value pairs and a sequence of unmatched options.
-        static std::pair<std::map<std::string, std::string>, StringSeq>
-        parseOptions(std::string_view prefix, const StringSeq& options);
+        static std::pair<PropertyDict, StringSeq> parseOptions(std::string_view prefix, const StringSeq& options);
 
     private:
         static std::optional<std::pair<std::string, std::string>>

--- a/cpp/src/Ice/HttpParser.cpp
+++ b/cpp/src/Ice/HttpParser.cpp
@@ -672,10 +672,10 @@ IceInternal::HttpParser::getHeader(const string& name, string& value, bool toLow
     return false;
 }
 
-map<string, string>
+map<string, string, std::less<>>
 IceInternal::HttpParser::getHeaders() const
 {
-    map<string, string> headers;
+    map<string, string, std::less<>> headers;
     for (const auto& header : _headers)
     {
         headers.insert(make_pair(header.second.first, IceInternal::trim(header.second.second)));

--- a/cpp/src/Ice/HttpParser.h
+++ b/cpp/src/Ice/HttpParser.h
@@ -50,7 +50,7 @@ namespace IceInternal
 
         bool getHeader(const std::string&, std::string&, bool) const;
 
-        [[nodiscard]] std::map<std::string, std::string> getHeaders() const;
+        [[nodiscard]] std::map<std::string, std::string, std::less<>> getHeaders() const;
 
     private:
         Type _type{TypeUnknown};

--- a/cpp/src/Ice/Properties.cpp
+++ b/cpp/src/Ice/Properties.cpp
@@ -573,10 +573,10 @@ Ice::Properties::getUnusedProperties()
     return unusedProperties;
 }
 
-pair<map<string, string>, StringSeq>
+pair<PropertyDict, StringSeq>
 Ice::Properties::parseOptions(string_view prefix, const StringSeq& options)
 {
-    map<string, string> matched;
+    PropertyDict matched;
 
     string pfx = string{prefix};
     if (!pfx.empty() && pfx[pfx.size() - 1] != '.')

--- a/cpp/test/Ice/proxy/AllTests.cpp
+++ b/cpp/test/Ice/proxy/AllTests.cpp
@@ -1217,7 +1217,7 @@ allTests(TestHelper* helper)
         optional<ObjectPrx> p = communicator->stringToProxy("test:tcp -h localhost -p 10000 -t 20000");
         p = p->ice_invocationTimeout(10000);
         p = p->ice_locatorCacheTimeout(20000);
-        map<string, string> properties = communicator->proxyToProperty(p, "Test");
+        PropertyDict properties = communicator->proxyToProperty(p, "Test");
         test(properties["Test"] == "test:tcp -h localhost -p 10000 -t 20000");
         test(properties["Test.InvocationTimeout"] == "10000");
         test(properties["Test.LocatorCacheTimeout"] == "20000");

--- a/matlab/src/Util.cpp
+++ b/matlab/src/Util.cpp
@@ -136,38 +136,7 @@ IceMatlab::getIdentity(mxArray* p, Ice::Identity& id)
 }
 
 mxArray*
-IceMatlab::createStringMap(const map<string, string>& m)
-{
-    mxArray* r;
-    if (m.empty())
-    {
-        mexCallMATLAB(1, &r, 0, 0, "containers.Map");
-    }
-    else
-    {
-        mwSize dims[2] = {1, 0};
-        dims[1] = static_cast<int>(m.size());
-        auto keys = mxCreateCellArray(2, dims);
-        auto values = mxCreateCellArray(2, dims);
-        int idx = 0;
-        for (auto p : m)
-        {
-            mxSetCell(keys, idx, createStringFromUTF8(p.first));
-            mxSetCell(values, idx, createStringFromUTF8(p.second));
-            idx++;
-        }
-        mxArray* params[2];
-        params[0] = keys;
-        params[1] = values;
-        mexCallMATLAB(1, &r, 2, params, "containers.Map");
-    }
-    return r;
-}
-
-// TODO: reduce duplication with code above
-
-mxArray*
-IceMatlab::createContext(const Ice::Context& m)
+IceMatlab::createStringMap(const map<string, string, std::less<>>& m)
 {
     mxArray* r;
     if (m.empty())

--- a/matlab/src/Util.h
+++ b/matlab/src/Util.h
@@ -13,10 +13,11 @@ namespace IceMatlab
     int getEnumerator(mxArray*, const std::string&);
     mxArray* createIdentity(const Ice::Identity&);
     void getIdentity(mxArray*, Ice::Identity&);
-    mxArray* createStringMap(const std::map<std::string, std::string>&);
-    void getStringMap(mxArray*, std::map<std::string, std::string>&);
-    mxArray* createContext(const Ice::Context&);
+
+    mxArray* createStringMap(const std::map<std::string, std::string, std::less<>>&);
+    inline mxArray* createContext(const Ice::Context& ctx) { return createStringMap(ctx); }
     void getContext(mxArray*, Ice::Context&);
+
     mxArray* createProtocolVersion(const Ice::ProtocolVersion&);
     mxArray* createEncodingVersion(const Ice::EncodingVersion&);
     void getEncodingVersion(mxArray*, Ice::EncodingVersion&);

--- a/php/src/Util.cpp
+++ b/php/src/Util.cpp
@@ -290,31 +290,11 @@ IcePHP::extractIdentity(zval* zv, Ice::Identity& id)
 }
 
 bool
-IcePHP::createStringMap(zval* zv, const map<string, string>& ctx)
+IcePHP::createStringMap(zval* zv, const map<string, string, std::less<>>& map)
 {
     array_init(zv);
 
-    for (auto p = ctx.begin(); p != ctx.end(); ++p)
-    {
-        add_assoc_stringl_ex(
-            zv,
-            const_cast<char*>(p->first.c_str()),
-            static_cast<uint32_t>(p->first.length()),
-            const_cast<char*>(p->second.c_str()),
-            static_cast<uint32_t>(p->second.length()));
-    }
-
-    return true;
-}
-
-// TODO: avoid duplication with code above.
-
-bool
-IcePHP::createContext(zval* zv, const Ice::Context& ctx)
-{
-    array_init(zv);
-
-    for (auto p = ctx.begin(); p != ctx.end(); ++p)
+    for (auto p = map.begin(); p != map.end(); ++p)
     {
         add_assoc_stringl_ex(
             zv,

--- a/php/src/Util.h
+++ b/php/src/Util.h
@@ -70,9 +70,9 @@ namespace IcePHP
     bool createIdentity(zval*, const Ice::Identity&);
     bool extractIdentity(zval*, Ice::Identity&);
 
-    bool createStringMap(zval*, const std::map<std::string, std::string>&);
+    bool createStringMap(zval*, const std::map<std::string, std::string, std::less<>>&);
 
-    bool createContext(zval*, const Ice::Context&);
+    inline bool createContext(zval* zv, const Ice::Context& ctx) { return createStringMap(zv, ctx); }
     bool extractContext(zval*, Ice::Context&);
 
     bool createStringArray(zval*, const Ice::StringSeq&);

--- a/slice/Ice/PropertyDict.ice
+++ b/slice/Ice/PropertyDict.ice
@@ -20,5 +20,6 @@ module Ice
     /// A simple collection of properties, represented as a dictionary of key/value pairs. Both key and value are
     /// strings.
     /// @see PropertiesAdmin#getPropertiesForPrefix
+    ["cpp:type:std::map<std::string, std::string, std::less<>>"]
     dictionary<string, string> PropertyDict;
 }


### PR DESCRIPTION
This PR adds `std::less<>` to a few additional `std::map<std::string, ...>`.

This indirectly removes duplicated code in PHP and MATLAB.