### PR TITLE
Use implicit default for MATLAB properties

### DIFF
--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -927,7 +927,7 @@ namespace
         string defaultValueStr = defaultValue(field);
         if (!defaultValueStr.empty())
         {
-            out << " = " << defaultValue(field);
+            out << " = " << defaultValueStr;
         }
     }
 

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -257,7 +257,6 @@ namespace
             {
                 switch (builtin->kind())
                 {
-                    case Builtin::KindString:
                     case Builtin::KindBool:
                     case Builtin::KindByte:
                     case Builtin::KindShort:
@@ -265,8 +264,10 @@ namespace
                     case Builtin::KindLong:
                     case Builtin::KindFloat:
                     case Builtin::KindDouble:
-                    case Builtin::KindObjectProxy:
+                    case Builtin::KindString:
                         return ""; // use implicit default
+                    case Builtin::KindObjectProxy:
+                       return "Ice.ObjectPrx.empty";
                     case Builtin::KindObject:
                     case Builtin::KindValue:
                         return "Ice.UnknownSlicedValue.empty";
@@ -290,9 +291,11 @@ namespace
                 return "{}";
             }
 
-            if (dynamic_pointer_cast<Struct>(m->type()) || m->type()->usesClasses())
+            if (dynamic_pointer_cast<InterfaceDecl>(m->type()) ||
+                dynamic_pointer_cast<Struct>(m->type()) ||
+                 m->type()->usesClasses())
             {
-                // Use .empty for structs and untyped properties.
+                // Use .empty for proxies, structs and untyped properties.
                 return typeToString(m->type()) + ".empty";
             }
 

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -267,7 +267,7 @@ namespace
                     case Builtin::KindString:
                         return ""; // use implicit default
                     case Builtin::KindObjectProxy:
-                       return "Ice.ObjectPrx.empty";
+                        return "Ice.ObjectPrx.empty";
                     case Builtin::KindObject:
                     case Builtin::KindValue:
                         return "Ice.UnknownSlicedValue.empty";
@@ -291,9 +291,8 @@ namespace
                 return "{}";
             }
 
-            if (dynamic_pointer_cast<InterfaceDecl>(m->type()) ||
-                dynamic_pointer_cast<Struct>(m->type()) ||
-                 m->type()->usesClasses())
+            if (dynamic_pointer_cast<InterfaceDecl>(m->type()) || dynamic_pointer_cast<Struct>(m->type()) ||
+                m->type()->usesClasses())
             {
                 // Use .empty for proxies, structs and untyped properties.
                 return typeToString(m->type()) + ".empty";

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -241,7 +241,7 @@ namespace
 
     string defaultValue(const DataMemberPtr& m)
     {
-        if (m->defaultValue())
+        if (m->defaultValue()) // explicit default value
         {
             return constantValue(m->type(), m->defaultValueType(), *m->defaultValue());
         }
@@ -258,26 +258,24 @@ namespace
                 switch (builtin->kind())
                 {
                     case Builtin::KindString:
-                        return "''";
                     case Builtin::KindBool:
-                        return "false";
                     case Builtin::KindByte:
                     case Builtin::KindShort:
                     case Builtin::KindInt:
                     case Builtin::KindLong:
                     case Builtin::KindFloat:
                     case Builtin::KindDouble:
-                        return "0";
                     case Builtin::KindObjectProxy:
-                        return "Ice.ObjectPrx.empty";
-                    default: // Object, Value
+                        return ""; // use implicit default
+                    case Builtin::KindObject:
+                    case Builtin::KindValue:
                         return "Ice.UnknownSlicedValue.empty";
                 }
             }
 
-            DictionaryPtr dict = dynamic_pointer_cast<Dictionary>(m->type());
-            if (dict)
+            if (auto dict = dynamic_pointer_cast<Dictionary>(m->type()))
             {
+                // Generate configured empty dictionary.
                 const TypePtr key = dict->keyType();
                 const TypePtr value = dict->valueType();
                 ostringstream ostr;
@@ -286,31 +284,19 @@ namespace
                 return ostr.str();
             }
 
-            EnumPtr en = dynamic_pointer_cast<Enum>(m->type());
-            if (en)
+            if (auto seq = dynamic_pointer_cast<Sequence>(m->type()); seq && seq->type()->usesClasses())
             {
-                const EnumeratorList enumerators = en->enumerators();
-                return (*enumerators.begin())->mappedScoped(".").substr(1);
+                // Property has not type, so we need to generate empty cell array.
+                return "{}";
             }
 
-            if (auto seq = dynamic_pointer_cast<Sequence>(m->type()))
+            if (dynamic_pointer_cast<Struct>(m->type()) || m->type()->usesClasses())
             {
-                if (isMappedToScalar(seq->type()))
-                {
-                    // Empty array with the correct type.
-                    return typeToString(seq->type()) + ".empty";
-                }
-                else
-                {
-                    // Empty cell array.
-                    return "{}";
-                }
+                // Use .empty for structs and untyped properties.
+                return typeToString(m->type()) + ".empty";
             }
 
-            // Use .empty for all other types. Note that .empty is not a valid value for a struct field/property;
-            // so either Ice later unmarshals into this property or the struct must replace this value before
-            // marshaling this instance.
-            return typeToString(m->type()) + ".empty";
+            return ""; // use implicit default
         }
     }
 
@@ -937,8 +923,12 @@ namespace
             out << " {mustBeScalarOrEmpty}";
         }
 
-        // Always specify the default value.
-        out << " = " << defaultValue(field);
+        // Specify the default value.
+        string defaultValueStr = defaultValue(field);
+        if (!defaultValueStr.empty())
+        {
+            out << " = " << defaultValue(field);
+        }
     }
 
     void validateMetadata(const UnitPtr& unit)

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -286,7 +286,7 @@ namespace
 
             if (auto seq = dynamic_pointer_cast<Sequence>(m->type()); seq && seq->type()->usesClasses())
             {
-                // Property has not type, so we need to generate empty cell array.
+                // Property has no type, so we need to generate an empty cell array.
                 return "{}";
             }
 

--- a/matlab/test/Ice/defaultValue/AllTests.m
+++ b/matlab/test/Ice/defaultValue/AllTests.m
@@ -109,6 +109,10 @@ classdef AllTests
             assert(isempty(v.is));
             assert(isempty(v.st));
             assert(v.dict.numEntries == 0);
+            assert(iscell(v.derivedSeq));
+            assert(isempty(v.derivedSeq));
+            assert(iscell(v.intSeqSeq));
+            assert(isempty(v.intSeqSeq));
 
             % Check we can assign empty into bs and is.
             v.bs = uint8.empty;

--- a/matlab/test/Ice/defaultValue/Test.ice
+++ b/matlab/test/Ice/defaultValue/Test.ice
@@ -116,6 +116,8 @@ module Test
 
     sequence<byte> ByteSeq;
     sequence<int> IntSeq;
+    sequence<IntSeq> IntSeqSeq;
+    sequence<Derived> DerivedSeq;
     dictionary<int, string> IntStringDict;
 
     struct InnerStruct
@@ -138,6 +140,8 @@ module Test
         IntSeq is;
         InnerStruct st;
         IntStringDict dict;
+        DerivedSeq derivedSeq;
+        IntSeqSeq intSeqSeq;
     }
 
     class ClassNoDefaultsBase


### PR DESCRIPTION
This PR updates the Slice compiler for MATLAB to use implicit default value for properties other than:
 - properties mapped from fields with an explicit default value
 - untyped properties (class and "use class" properties, and properties mapped from optional fields)
 - dictionary properties
 - struct properties (not strictly necessary but clear since they have no dimension)