### PR TITLE
Improve the InitializationData API in MATLAB

### DIFF
--- a/matlab/lib/+Ice/Communicator.m
+++ b/matlab/lib/+Ice/Communicator.m
@@ -40,8 +40,8 @@ classdef Communicator < IceInternal.WrapperObject
             % The caller (initialize) consumes initData.properties_ and we don't use them at all in this class.
             obj.initData = initData;
 
-            if obj.initData.sliceLoader ~= IceInternal.DefaultSliceLoader.Instance
-                obj.initData.sliceLoader = Ice.CompositeSliceLoader(obj.initData.sliceLoader, ...
+            if obj.initData.SliceLoader ~= IceInternal.DefaultSliceLoader.Instance
+                obj.initData.SliceLoader = Ice.CompositeSliceLoader(obj.initData.SliceLoader, ...
                     IceInternal.DefaultSliceLoader.Instance);
             end
 
@@ -54,8 +54,8 @@ classdef Communicator < IceInternal.WrapperObject
                     cacheFullLogger = [];
                 end
 
-                obj.initData.sliceLoader = IceInternal.NotFoundSliceLoaderDecorator(...
-                    obj.initData.sliceLoader, notFoundCacheSize, cacheFullLogger);
+                obj.initData.SliceLoader = IceInternal.NotFoundSliceLoaderDecorator(...
+                    obj.initData.SliceLoader, notFoundCacheSize, cacheFullLogger);
             end
 
             enc = obj.getProperties().getProperty('Ice.Default.EncodingVersion');
@@ -341,7 +341,7 @@ classdef Communicator < IceInternal.WrapperObject
             r = obj.format;
         end
         function r = getSliceLoader(obj)
-            r = obj.initData.sliceLoader;
+            r = obj.initData.SliceLoader;
         end
     end
     properties(Access=private)

--- a/matlab/lib/+Ice/InitializationData.m
+++ b/matlab/lib/+Ice/InitializationData.m
@@ -10,7 +10,7 @@ classdef (Sealed) InitializationData
 
         SliceLoader (1, 1) Ice.SliceLoader = IceInternal.DefaultSliceLoader.Instance % The Slice loader.
     end
-    properties (Dependent)
+    properties (Dependent, Hidden)
         properties_ (1, 1) Ice.Properties % Deprecated: Use Properties instead.
     end
     methods

--- a/matlab/lib/+Ice/InitializationData.m
+++ b/matlab/lib/+Ice/InitializationData.m
@@ -2,14 +2,32 @@ classdef (Sealed) InitializationData
     % InitializationData   Represents a set of options that you can specify when initializing a communicator.
     %
     % InitializationData Properties:
-    %   properties_ - The properties of the communicator.
-    %   sliceLoader - The Slice loader, used to unmarshal Slice classes and exceptions.
+    %   Properties - The properties of the communicator.
+    %   SliceLoader - The Slice loader, used to unmarshal Slice classes and exceptions.
 
     properties
-        % properties_ (Ice.Properties) - The properties for the communicator.
-        properties_ Ice.Properties
+        Properties (1, 1) Ice.Properties = Ice.createProperties() % The properties of the communicator.
 
-        % sliceLoader (Ice.SliceLoader) - The Slice loader, used to unmarshal Slice classes and exceptions.
-        sliceLoader Ice.SliceLoader = IceInternal.DefaultSliceLoader.Instance
+        SliceLoader (1, 1) Ice.SliceLoader = IceInternal.DefaultSliceLoader.Instance % The Slice loader.
+    end
+    properties (Dependent)
+        properties_ (1, 1) Ice.Properties % Deprecated: Use Properties instead.
+    end
+    methods
+        function obj = InitializationData(options)
+            arguments
+                options.?Ice.InitializationData
+            end
+            for prop = string(fieldnames(options))'
+                obj.(prop) = options.(prop);
+            end
+        end
+
+        function value = get.properties_(obj)
+            value = obj.Properties;
+        end
+        function obj = set.properties_(obj, value)
+            obj.Properties = value;
+        end
     end
 end

--- a/matlab/lib/+Ice/initialize.m
+++ b/matlab/lib/+Ice/initialize.m
@@ -52,8 +52,7 @@ function [communicator, args] = initialize(varargin)
         initData = Ice.InitializationData();
 
         if ~isempty(configFile)
-            initData.properties_ = Ice.createProperties();
-            initData.properties_.load(configFile);
+            initData.Properties.load(configFile);
         end
     end
 
@@ -63,14 +62,7 @@ function [communicator, args] = initialize(varargin)
     % We need to extract and pass the libpointer object for properties to the C function. Passing the wrapper
     % (Ice.Properties) object won't work because the C code has no way to obtain the inner pointer.
     %
-    props = libpointer('voidPtr');
-    if ~isempty(initData.properties_)
-        if ~isa(initData.properties_, 'Ice.Properties')
-            throw(Ice.LocalException('Ice:ArgumentException', 'invalid value for properties_ member'));
-        else
-            props = initData.properties_.impl_;
-        end
-    end
+    props = initData.Properties.impl_;
 
     impl = libpointer('voidPtr');
     args = IceInternal.Util.callWithResult('Ice_initialize', args, props, impl);

--- a/matlab/test/Ice/objects/Client.m
+++ b/matlab/test/Ice/objects/Client.m
@@ -7,17 +7,16 @@ function client(args)
     end
 
     helper = TestHelper();
-    initData = Ice.InitializationData();
-    initData.properties_ = helper.createTestProperties(args);
-    initData.properties_.setProperty('Ice.Warn.Connections', '0');
 
     % We need to use the ClassSliceLoader for the classes with compact IDs. Naturally, it also works for classes
     % without a compact ID.
-    initData.sliceLoader = Ice.CompositeSliceLoader(CustomSliceLoader(), ...
-        Ice.ClassSliceLoader([?DI, ?Test.Compact, ?Test.CompactExt]));
+    initData = Ice.InitializationData(Properties = Ice.createProperties(args), ...
+        SliceLoader = Ice.CompositeSliceLoader(CustomSliceLoader(), ...
+            Ice.ClassSliceLoader([?DI, ?Test.Compact, ?Test.CompactExt])));
+
+    initData.Properties.setProperty('Ice.Warn.Connections', '0');
 
     communicator = helper.initialize(initData);
-
     cleanup = onCleanup(@() communicator.destroy());
 
     initial = AllTests.allTests(helper);

--- a/matlab/test/Ice/slicing/objects/Client.m
+++ b/matlab/test/Ice/slicing/objects/Client.m
@@ -7,13 +7,13 @@ function client(args)
     end
 
     helper = TestHelper();
-    initData = Ice.InitializationData();
-    initData.properties_ = helper.createTestProperties(args);
+    customSliceLoader = CustomSliceLoader();
+
+    initData = Ice.InitializationData(SliceLoader = customSliceLoader, Properties = Ice.createProperties(args));
+
+    % Use deprecated properties_ field to check it still works.
     initData.properties_.setProperty('Ice.SliceLoader.NotFoundCacheSize', '5');
     initData.properties_.setProperty('Ice.Warn.SliceLoader', '0'); % comment out to see the warning
-
-    customSliceLoader = CustomSliceLoader();
-    initData.sliceLoader = customSliceLoader;
 
     communicator = helper.initialize(initData);
     cleanup = onCleanup(@() communicator.destroy());

--- a/matlab/test/Slice/escape/Client.m
+++ b/matlab/test/Slice/escape/Client.m
@@ -7,9 +7,11 @@ function client(args)
     end
 
     helper = TestHelper();
-    initData = Ice.InitializationData();
-    initData.properties_ = helper.createTestProperties(args);
-    initData.sliceLoader = Ice.ClassSliceLoader([?classdef_.logical_, ?classdef_.escaped_xor, ?classdef_.Base, ?classdef_.Derived, ?classdef_.bitand_, ?classdef_.escaped_bitor]);
+
+    % Can even use deprecated properties_ name in constructor (not recommended obviously).
+    initData = Ice.InitializationData(properties_ = helper.createTestProperties(args));
+    initData.SliceLoader = Ice.ClassSliceLoader([?classdef_.logical_, ?classdef_.escaped_xor, ?classdef_.Base, ...
+        ?classdef_.Derived, ?classdef_.bitand_, ?classdef_.escaped_bitor]);
 
     communicator = helper.initialize(initData);
     cleanup = onCleanup(@() communicator.destroy());

--- a/matlab/test/lib/TestHelper.m
+++ b/matlab/test/lib/TestHelper.m
@@ -104,9 +104,9 @@ classdef TestHelper < handle
                 else
                     initData = Ice.InitializationData();
                     if isa(varargin{1}, 'Ice.Properties')
-                        initData.properties_ = varargin{1};
+                        initData.Properties = varargin{1};
                     else
-                        initData.properties_ = obj.createTestProperties(varargin{1});
+                        initData.Properties = obj.createTestProperties(varargin{1});
                     end
                 end
             end


### PR DESCRIPTION
This PR:
 - changes the two properties of InitializationData to use PascalCase - the usual casing in MATLAB
 - this allows us to use Properties instead of `properties_`
 - keeps `properties_` as a Dependent property for backwards compatibility with Ice 3.7
 - adds a name=value constructor to InitializationData; see https://www.mathworks.com/help/matlab/matlab_oop/class-constructor-methods.html#mw_749777e1-ea34-4e8e-b4d3-317d6d61131c
