### PR TITLE
Add Support for '@remarks' to the Java Mapping

### DIFF
--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -1315,7 +1315,7 @@ Slice::JavaVisitor::writeRemarksDocComment(Output& out, const DocComment& commen
     }
 
     out << nl << " * <p><b>Remarks:</b>";
-    out << " * ";
+    out << nl << " * ";
     writeDocCommentLines(out, remarks);
     out << "</p>";
 }

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -699,7 +699,7 @@ Slice::JavaVisitor::writeSyncIceInvokeMethods(
 
     // Generate a synchronous version of this operation which doesn't takes a context parameter.
     out << sp;
-    writeProxyDocComment(out, p, package, dc, false, "");
+    writeProxyOpDocComment(out, p, package, dc, false, "");
     if (dc && dc->isDeprecated())
     {
         out << nl << "@Deprecated";
@@ -717,7 +717,7 @@ Slice::JavaVisitor::writeSyncIceInvokeMethods(
 
     // Generate a synchronous version of this operation which takes a context parameter.
     out << sp;
-    writeProxyDocComment(out, p, package, dc, false, contextDoc);
+    writeProxyOpDocComment(out, p, package, dc, false, contextDoc);
     if (dc && dc->isDeprecated())
     {
         out << nl << "@Deprecated";
@@ -787,7 +787,7 @@ Slice::JavaVisitor::writeAsyncIceInvokeMethods(
 
     // Generate an overload of '<NAME>Async' that doesn't take a context parameter.
     out << sp;
-    writeProxyDocComment(out, p, package, dc, true, "");
+    writeProxyOpDocComment(out, p, package, dc, true, "");
     if (dc && dc->isDeprecated())
     {
         out << nl << "@Deprecated";
@@ -799,7 +799,7 @@ Slice::JavaVisitor::writeAsyncIceInvokeMethods(
 
     // Generate an overload of '<NAME>Async' that takes a context parameter.
     out << sp;
-    writeProxyDocComment(out, p, package, dc, true, contextDoc);
+    writeProxyOpDocComment(out, p, package, dc, true, contextDoc);
     if (dc && dc->isDeprecated())
     {
         out << nl << "@Deprecated";
@@ -1306,6 +1306,21 @@ Slice::JavaVisitor::writeExceptionDocComment(Output& out, const OperationPtr& op
 }
 
 void
+Slice::JavaVisitor::writeRemarksDocComment(Output& out, const DocComment& comment)
+{
+    const StringList& remarks = comment.remarks();
+    if (remarks.empty())
+    {
+        return;
+    }
+
+    out << nl << " * <p><b>Remarks:</b>";
+    out << " * ";
+    writeDocCommentLines(out, remarks);
+    out << "</p>";
+}
+
+void
 Slice::JavaVisitor::writeHiddenDocComment(Output& out)
 {
     out << nl << "/** @hidden */";
@@ -1397,6 +1412,7 @@ Slice::JavaVisitor::writeDocComment(Output& out, const UnitPtr& unt, const optio
         out << nl << " * ";
         writeDocCommentLines(out, overview);
     }
+    writeRemarksDocComment(out, *dc);
 
     const StringList& seeAlso = dc->seeAlso();
     if (!seeAlso.empty())
@@ -1436,7 +1452,7 @@ Slice::JavaVisitor::writeDocComment(Output& out, const string& text)
 }
 
 void
-Slice::JavaVisitor::writeProxyDocComment(
+Slice::JavaVisitor::writeProxyOpDocComment(
     Output& out,
     const OperationPtr& p,
     const string& package,
@@ -1456,6 +1472,7 @@ Slice::JavaVisitor::writeProxyDocComment(
         out << nl << " * ";
         writeDocCommentLines(out, overview);
     }
+    writeRemarksDocComment(out, *dc);
 
     //
     // Show in-params in order of declaration, but only those with docs.
@@ -1592,7 +1609,7 @@ Slice::JavaVisitor::writeHiddenProxyDocComment(Output& out, const OperationPtr& 
 }
 
 void
-Slice::JavaVisitor::writeServantDocComment(Output& out, const OperationPtr& p, const string& package, bool async)
+Slice::JavaVisitor::writeServantOpDocComment(Output& out, const OperationPtr& p, const string& package, bool async)
 {
     optional<DocComment> dc = DocComment::parseFrom(p, javaLinkFormatter);
     if (!dc)
@@ -1611,6 +1628,7 @@ Slice::JavaVisitor::writeServantDocComment(Output& out, const OperationPtr& p, c
         out << nl << " * ";
         writeDocCommentLines(out, overview);
     }
+    writeRemarksDocComment(out, *dc);
 
     // Show in-params in order of declaration, but only those with docs.
     for (const auto& param : p->inParameters())
@@ -3862,7 +3880,7 @@ Slice::Gen::ServantVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         ExceptionList throws = op->throws();
 
         out << sp;
-        writeServantDocComment(out, op, package, amd);
+        writeServantOpDocComment(out, op, package, amd);
 
         if (amd)
         {

--- a/cpp/src/slice2java/Gen.h
+++ b/cpp/src/slice2java/Gen.h
@@ -106,12 +106,13 @@ namespace Slice
         // Handle doc comments.
         //
         void writeExceptionDocComment(IceInternal::Output& out, const OperationPtr& op, const DocComment& dc);
+        void writeRemarksDocComment(IceInternal::Output& out, const DocComment& comment);
         void writeHiddenDocComment(IceInternal::Output&);
         void writeDocCommentLines(IceInternal::Output&, const StringList&);
         void writeDocCommentLines(IceInternal::Output&, const std::string&);
         void writeDocComment(IceInternal::Output&, const UnitPtr&, const std::optional<DocComment>&);
         void writeDocComment(IceInternal::Output&, const std::string&);
-        void writeProxyDocComment(
+        void writeProxyOpDocComment(
             IceInternal::Output&,
             const OperationPtr&,
             const std::string&,
@@ -119,7 +120,7 @@ namespace Slice
             bool,
             const std::string&);
         void writeHiddenProxyDocComment(IceInternal::Output&, const OperationPtr&);
-        void writeServantDocComment(IceInternal::Output&, const OperationPtr&, const std::string&, bool);
+        void writeServantOpDocComment(IceInternal::Output&, const OperationPtr&, const std::string&, bool);
         void writeSeeAlso(IceInternal::Output&, const UnitPtr&, const std::string&);
         void writeParamDocComments(IceInternal::Output& out, const DataMemberList& members);
     };

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -80,7 +80,10 @@ task alljavadoc(type: Javadoc) {
     destinationDir = file("$buildDir/docs/javadoc")
     options.encoding = 'UTF-8'
     // Where to find source files for the different modules
-    options.addStringOption('-module-source-path', './src/*/src/main/java/:./src/*/build/generated/source/slice/main')
+    options.addStringOption(
+        '-module-source-path',
+        './src/*/src/main/java/' + File.pathSeparator + './src/*/build/generated/source/slice/main'
+    )
     options.addBooleanOption('html5', true)
     options.header = 'Ice for Java'
     options.docTitle = "Ice ${iceVersion} API Reference"


### PR DESCRIPTION
Unfortunately, Java has no support for `@remarks`, or anything even resembling it.
The best we can do is append it to the end of the summary.

Here's what the new generated code looks like for `@remarks`, and what it looks like in the generated API reference:

----

This is what `EncodingVersion` looks like now:

```diff
 /**
  * Represents a version of the Ice encoding. Ice supports version 1.0 and 1.1 of this encoding.
+ * <p><b>Remarks:</b>
+ * The Ice encoding is also known as the Slice encoding.</p>
  **/
 public final class EncodingVersion implements java.lang.Cloneable,
```
![image](https://github.com/user-attachments/assets/c48db95d-115a-4c0c-9ae4-fc91b717161e)

----

----

And this is what `RemoteLoggerPrx.log` looks like now:

```diff
     /**
      * Logs a LogMessage.
+     * <p><b>Remarks:</b>
+     * {@link com.zeroc.Ice.RemoteLoggerPrx#log} may be called by {@link com.zeroc.Ice.LoggerAdminPrx} before {@link com.zeroc.Ice.RemoteLoggerPrx#init}.</p>
      * @param message The message to log.
      * @param context The Context map to send with the invocation.
      **/
     default void log(LogMessage message, java.util.Map<String, String> context)
```
![image](https://github.com/user-attachments/assets/9f6de6a5-f56c-44a2-8b03-648351a72bd9)
Compared to before this PR:
![image](https://github.com/user-attachments/assets/11a6efd1-b5ef-40f3-a797-5b06fe75179b)
