### PR TITLE
Fix Random Minor Issues in `slice2js` and `NOLINT`s

### DIFF
--- a/cpp/src/Ice/StringUtil.cpp
+++ b/cpp/src/Ice/StringUtil.cpp
@@ -4,7 +4,7 @@
 #include "Ice/StringConverter.h"
 #include <cassert>
 #include <cstring>
-#include <string.h> // NOLINT(modernize-deprecated-headers):for strerror_r
+#include <string.h> // NOLINT(modernize-deprecated-headers): for strerror_r
 
 #include <iomanip>
 #include <sstream>

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1371,7 +1371,7 @@ Slice::Gen::ForwardDeclVisitor::visitConst(const ConstPtr& p)
     if (!isConstexprType(p->type())) // i.e. string or wstring
     {
         // The string/wstring constructor can throw, which produces a clang-tidy lint for const or static objects.
-        H << " // NOLINT(cert-err58-cpp,modernize-raw-string-literal)";
+        H << " // NOLINT(cert-err58-cpp, modernize-raw-string-literal)";
     }
 }
 

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -245,12 +245,6 @@ Slice::JsVisitor::JsVisitor(Output& out) : _out(out) {}
 
 Slice::JsVisitor::~JsVisitor() = default;
 
-vector<pair<string, string>>
-Slice::JsVisitor::imports() const
-{
-    return _imports;
-}
-
 void
 Slice::JsVisitor::writeMarshalDataMembers(const DataMemberList& dataMembers, const DataMemberList& optionalMembers)
 {

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -2198,7 +2198,9 @@ Slice::Gen::TypeScriptVisitor::visitClassDefStart(const ClassDefPtr& p)
     {
         _out << sp;
         writeDocCommentFor(dataMember);
-        _out << nl << dataMember->mappedName() << ": " << typeToTsString(dataMember->type(), true) << ";";
+        const string optionalModifier = dataMember->optional() ? "?" : "";
+        _out << nl << dataMember->mappedName() << optionalModifier << ": " << typeToTsString(dataMember->type(), true)
+             << ";";
     }
     _out << eb;
 
@@ -2556,7 +2558,6 @@ Slice::Gen::TypeScriptVisitor::visitExceptionStart(const ExceptionPtr& p)
     {
         _out << sp;
         writeDocCommentFor(dataMember);
-        // TODO why do we only have this optional check for exception members, but not for class members?
         const string optionalModifier = dataMember->optional() ? "?" : "";
         _out << nl << dataMember->mappedName() << optionalModifier << ": " << typeToTsString(dataMember->type(), true)
              << ";";

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -241,7 +241,7 @@ namespace
     }
 }
 
-Slice::JsVisitor::JsVisitor(Output& out, const vector<pair<string, string>>& imports) : _out(out), _imports(imports) {}
+Slice::JsVisitor::JsVisitor(Output& out) : _out(out) {}
 
 Slice::JsVisitor::~JsVisitor() = default;
 
@@ -2325,7 +2325,7 @@ bool
 Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     //
-    // Define servant an proxy types
+    // Define servant and proxy types.
     //
     const string prxName = p->mappedName() + "Prx";
     _out << sp;
@@ -2558,13 +2558,17 @@ Slice::Gen::TypeScriptVisitor::visitExceptionStart(const ExceptionPtr& p)
         _out << epar << ";";
     }
 
-    for (const auto& dataMember : allDataMembers)
+    for (const auto& dataMember : dataMembers)
     {
+        _out << sp;
+        writeDocCommentFor(dataMember);
+        // TODO why do we only have this optional check for exception members, but not for class members?
         const string optionalModifier = dataMember->optional() ? "?" : "";
         _out << nl << dataMember->mappedName() << optionalModifier << ": " << typeToTsString(dataMember->type(), true)
              << ";";
     }
     _out << eb;
+
     return false;
 }
 
@@ -2636,10 +2640,10 @@ Slice::Gen::TypeScriptVisitor::visitStructStart(const StructPtr& p)
     {
         _out << sp;
         writeDocCommentFor(dataMember);
-        _out << nl << dataMember->mappedName() << ":" << typeToTsString(dataMember->type(), true) << ";";
+        _out << nl << dataMember->mappedName() << ": " << typeToTsString(dataMember->type(), true) << ";";
     }
-
     _out << eb;
+
     return false;
 }
 

--- a/cpp/src/slice2js/Gen.h
+++ b/cpp/src/slice2js/Gen.h
@@ -13,8 +13,6 @@ namespace Slice
         JsVisitor(::IceInternal::Output& output);
         ~JsVisitor() override;
 
-        [[nodiscard]] std::vector<std::pair<std::string, std::string>> imports() const;
-
     protected:
         void writeMarshalDataMembers(const DataMemberList&, const DataMemberList&);
         void writeUnmarshalDataMembers(const DataMemberList&, const DataMemberList&);
@@ -27,8 +25,6 @@ namespace Slice
         void writeDocCommentFor(const ContainedPtr& p, bool includeDeprecated = true);
 
         ::IceInternal::Output& _out;
-
-        std::vector<std::pair<std::string, std::string>> _imports{};
     };
 
     class Gen final : public JsGenerator

--- a/cpp/src/slice2js/Gen.h
+++ b/cpp/src/slice2js/Gen.h
@@ -10,10 +10,7 @@ namespace Slice
     class JsVisitor : public JsGenerator, public ParserVisitor
     {
     public:
-        JsVisitor(
-            ::IceInternal::Output&,
-            const std::vector<std::pair<std::string, std::string>>& imports =
-                std::vector<std::pair<std::string, std::string>>());
+        JsVisitor(::IceInternal::Output& output);
         ~JsVisitor() override;
 
         [[nodiscard]] std::vector<std::pair<std::string, std::string>> imports() const;
@@ -31,7 +28,7 @@ namespace Slice
 
         ::IceInternal::Output& _out;
 
-        std::vector<std::pair<std::string, std::string>> _imports;
+        std::vector<std::pair<std::string, std::string>> _imports{};
     };
 
     class Gen final : public JsGenerator


### PR DESCRIPTION
While planning out how to add `@remarks` to (Java/Type)Script, I came across a few inconsistencies, that I'd rather fix in a PR separate to the `@remarks` one.

There were also 2 formatting mistakes in our NOLINTs that I've been aware of a little while.
Figured I might as well fix them now too.