### PR TITLE
Add Support for `@remarks` to `slice2py` and Fix Enum Doc-Comments

### DIFF
--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -371,6 +371,9 @@ namespace Slice::Python
         /// Write constructor parameters with default values.
         void writeConstructorParams(const DataMemberList& members);
 
+        /// Writes the provided @p remarks in its own subheading in the current comment (if @p remarks is non-empty).
+        void writeRemarksDocComment(const StringList& remarks, bool needsNewline);
+
         void writeDocstring(const optional<DocComment>&, const string& = "");
         void writeDocstring(const optional<DocComment>&, const DataMemberList&);
         void writeDocstring(const optional<DocComment>&, const EnumeratorList&);
@@ -1975,20 +1978,44 @@ Slice::Python::CodeVisitor::getOperationMode(Slice::Operation::Mode mode)
 }
 
 void
+Slice::Python::CodeVisitor::writeRemarksDocComment(const StringList& remarks, bool needsNewline)
+{
+    if (!remarks.empty())
+    {
+        if (needsNewline)
+        {
+            _out << nl;
+        }
+        _out << nl << "Notes";
+        _out << nl << "-----";
+        for (const auto& line : remarks)
+        {
+            _out << nl << "    " << line;
+        }
+    }
+}
+
+void
 Slice::Python::CodeVisitor::writeDocstring(const optional<DocComment>& comment, const string& prefix)
 {
     if (comment)
     {
         const StringList& overview = comment->overview();
-        if (!overview.empty())
+        const StringList& remarks = comment->remarks();
+        if (overview.empty() && remarks.empty())
         {
-            _out << nl << prefix << tripleQuotes;
-            for (const auto& line : overview)
-            {
-                _out << nl << line;
-            }
-            _out << nl << tripleQuotes;
+            return;
         }
+
+        _out << nl << prefix << tripleQuotes;
+        for (const auto& line : overview)
+        {
+            _out << nl << line;
+        }
+
+        writeRemarksDocComment(remarks, !overview.empty());
+
+        _out << nl << tripleQuotes;
     }
 }
 
@@ -2015,7 +2042,8 @@ Slice::Python::CodeVisitor::writeDocstring(const optional<DocComment>& comment, 
     }
 
     const StringList& overview = comment->overview();
-    if (overview.empty() && docs.empty())
+    const StringList& remarks = comment->remarks();
+    if (overview.empty() && remarks.empty() && docs.empty())
     {
         return;
     }
@@ -2050,6 +2078,8 @@ Slice::Python::CodeVisitor::writeDocstring(const optional<DocComment>& comment, 
         }
     }
 
+    writeRemarksDocComment(remarks, !overview.empty() || !docs.empty());
+
     _out << nl << tripleQuotes;
 }
 
@@ -2076,7 +2106,8 @@ Slice::Python::CodeVisitor::writeDocstring(const optional<DocComment>& comment, 
     }
 
     const StringList& overview = comment->overview();
-    if (overview.empty() && docs.empty())
+    const StringList& remarks = comment->remarks();
+    if (overview.empty() && remarks.empty() && docs.empty())
     {
         return;
     }
@@ -2098,21 +2129,20 @@ Slice::Python::CodeVisitor::writeDocstring(const optional<DocComment>& comment, 
         _out << nl << "Enumerators:";
         for (const auto& enumerator : enumerators)
         {
-            _out << nl << enumerator->mappedName() << " -- ";
+            _out << nl << nl << "- " << enumerator->mappedName();
             auto p = docs.find(enumerator->name());
             if (p != docs.end())
             {
-                for (auto q = p->second.begin(); q != p->second.end(); ++q)
+                _out << ":"; // Only emit a trailing ':' if there's documentation to emit for it.
+                for (const auto& line : p->second)
                 {
-                    if (q != p->second.begin())
-                    {
-                        _out << nl;
-                    }
-                    _out << *q;
+                    _out << nl << "    " << line;
                 }
             }
         }
     }
+
+    writeRemarksDocComment(remarks, !overview.empty() || !docs.empty());
 
     _out << nl << tripleQuotes;
 }
@@ -2132,11 +2162,12 @@ Slice::Python::CodeVisitor::writeDocstring(const OperationPtr& op, DocstringMode
     ParameterList outParams = op->outParameters();
 
     const StringList& overview = comment->overview();
+    const StringList& remarks = comment->remarks();
     const StringList& returnsDoc = comment->returns();
     const auto& parametersDoc = comment->parameters();
     const auto& exceptionsDoc = comment->exceptions();
 
-    if (overview.empty())
+    if (overview.empty() && remarks.empty())
     {
         if ((mode == DocSync || mode == DocDispatch) && parametersDoc.empty() && exceptionsDoc.empty() &&
             returnsDoc.empty())
@@ -2333,6 +2364,9 @@ Slice::Python::CodeVisitor::writeDocstring(const OperationPtr& op, DocstringMode
             }
         }
     }
+
+    writeRemarksDocComment(remarks, true);
+
     _out << nl << tripleQuotes;
 }
 

--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -6,6 +6,8 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('../python'))
+if sys.platform == 'win32':
+    sys.path.insert(0, os.path.abspath('../python/x64/Release'))
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information

--- a/python/python/Ice/CompressBatch.py
+++ b/python/python/Ice/CompressBatch.py
@@ -6,13 +6,15 @@ class CompressBatch(EnumBase):
     """
     The batch compression option when flushing queued batch requests.
 
-    Enumerators
-    -----------
-    Yes : CompressBatch
+    Enumerators:
+
+    - Yes:
         Compress the batch requests.
-    No : CompressBatch
+
+    - No:
         Don't compress the batch requests.
-    BasedOnProxy : CompressBatch
+
+    - BasedOnProxy:
         Compress the batch requests if at least one request was made on a compressed proxy.
     """
 

--- a/python/python/Ice/ToStringMode.py
+++ b/python/python/Ice/ToStringMode.py
@@ -10,16 +10,19 @@ class ToStringMode(EnumBase):
 
     Enumerators:
 
-    - Unicode:  Characters with ordinal values greater than 127 are kept as-is in the resulting string. Non-printable ASCII
-      characters with ordinal values 127 and below are encoded as \\t, \\n (etc.) or \\unnnn.
+    - Unicode:
+          Characters with ordinal values greater than 127 are kept as-is in the resulting string. Non-printable ASCII
+          characters with ordinal values 127 and below are encoded as \\t, \\n (etc.) or \\unnnn.
 
-    - ASCII:  Characters with ordinal values greater than 127 are encoded as universal character names in the resulting
-      string \\unnnn for BMP characters and \\Unnnnnnnn for non-BMP characters. Non-printable ASCII characters
-      with ordinal values 127 and below are encoded as \\t, \\n (etc.) or \\unnnn.
+    - ASCII:
+          Characters with ordinal values greater than 127 are encoded as universal character names in the resulting
+          string \\unnnn for BMP characters and \\Unnnnnnnn for non-BMP characters. Non-printable ASCII characters
+          with ordinal values 127 and below are encoded as \\t, \\n (etc.) or \\unnnn.
 
-    - Compat: Characters with ordinal values greater than 127 are encoded as a sequence of UTF-8 bytes using octal escapes.
-      Characters with ordinal values 127 and below are encoded as \\t, \\n (etc.) or an octal escape. Use this mode
-      to generate strings compatible with Ice 3.6 and earlier.
+    - Compat:
+          Characters with ordinal values greater than 127 are encoded as a sequence of UTF-8 bytes using octal escapes.
+          Characters with ordinal values 127 and below are encoded as \\t, \\n (etc.) or an octal escape. Use this mode
+          to generate strings compatible with Ice 3.6 and earlier.
     """
 
     def __init__(self, _n, _v):


### PR DESCRIPTION
This PR does what it says on the tin!

# Support for `@remarks`

We use a tool named `sphinx` for generating Python documentation, and sphinx supports a `Notes` section.
This is what we map `@remarks` to in Python, because it fits the bill pretty well.
(https://the-ultimate-sphinx-tutorial.readthedocs.io/en/latest/_guide/_styleguides/docstrings-guidelines.html#notes)
The documentation only explicitly mentions it being used to document methods and modules, but it seems to render just fine everywhere where I tried it.

We always generate the notes at the end of the doc-comment, which matches our convention, and sphinx's.

Here's what the rendered notes sections look like:

----

for a function:
![Screenshot 2025-06-18 120828](https://github.com/user-attachments/assets/6a317d3e-d8dc-41bb-b1ab-7112a6d81dc6)

----

for anything else:
![Screenshot 2025-06-18 120843](https://github.com/user-attachments/assets/2cda1fe2-06b3-42e8-911f-c1d8dd4cddd7)

----

Definitely doesn't look... amazing, but that's an issue with the HTML output, not the generated-code.

# Enum Doc-Comments.
On main, this is what the rendered output for a Slice-generated enum looks like:

----

![Screenshot 2025-06-18 120925](https://github.com/user-attachments/assets/df8b5ab5-bfbc-4cf1-8511-a85a14894580)

----

This is what my PR makes it look like:

----

![Screenshot 2025-06-18 120943](https://github.com/user-attachments/assets/cc517fef-3257-4381-bd03-284bbb329831)

----

I'd argue it looks much better now.
For the code we document by hand, we don't seem to have a consistent style, I fixed 2 of ours, just while testing, but we should really look through all of our Python doc-comments and fix them. I'm sure these issues aren't exclusive to enums...
