### PR TITLE
Add Support for `@remarks` to `slice2js`

### DIFF
--- a/cpp/src/slice2js/Gen.h
+++ b/cpp/src/slice2js/Gen.h
@@ -22,7 +22,7 @@ namespace Slice
 
         std::string writeConstantValue(const TypePtr&, const SyntaxTreeBasePtr&, const std::string&);
 
-        void writeDocCommentFor(const ContainedPtr& p, bool includeDeprecated = true);
+        void writeDocCommentFor(const ContainedPtr& p, bool includeRemarks = true, bool includeDeprecated = true);
 
         ::IceInternal::Output& _out;
     };

--- a/cpp/src/slice2js/Gen.h
+++ b/cpp/src/slice2js/Gen.h
@@ -22,6 +22,11 @@ namespace Slice
 
         std::string writeConstantValue(const TypePtr&, const SyntaxTreeBasePtr&, const std::string&);
 
+        /// Generates and outputs a doc-comment for Slice definition \p p.
+        /// @param p The Slice definition to be documented.
+        /// @param includeRemarks If false, '@remarks' tags in \p p's doc-comment will be ignored.
+        ///     This should always be 'true' for typescript generated code, and 'false' for javascript generated code.
+        /// @param includeDeprecated If false, '@deprecated' tags in \p p's doc-comment will be ignored.
         void writeDocCommentFor(const ContainedPtr& p, bool includeRemarks = true, bool includeDeprecated = true);
 
         ::IceInternal::Output& _out;


### PR DESCRIPTION
This PR adds the code for `slice2js` to map `@remarks` doc-comment sections.

This comment tag is supported on all Slice constructs, but we only map it in Typescript generated code.
It makes no appearance in the normal Javascript generated code. This is for 2 reasons:
1) TypeDoc supports `@remarks`, but `JSDoc` doesn't seem to support this tag.
2) The generated Javascript code already has pretty lackluster doc-comment generation.
    Whereas the generated Typescript code is very well documented.

----

Here's what the rendered API reference looks like:

----

![Screenshot 2025-06-18 142434](https://github.com/user-attachments/assets/7522a3f3-ed24-49cc-be75-e981b5086084)

----

![Screenshot 2025-06-18 142400](https://github.com/user-attachments/assets/3a2aa34d-b3a1-4806-9f53-0a724a36bf50)

----

![Screenshot 2025-06-18 135234](https://github.com/user-attachments/assets/9c756a77-ab9e-49a2-8dbc-c1ae7b1c5ae5)