### PR TITLE
Add workflow for building docker images

### DIFF
--- a/.github/workflows/build-container-images.yml
+++ b/.github/workflows/build-container-images.yml
@@ -1,0 +1,110 @@
+name: "Build Docker CI Images"
+
+on:
+  workflow_dispatch
+
+jobs:
+  build-images:
+    name: "Build ${{ matrix.image }} (${{ matrix.platform }})"
+    runs-on: ${{ matrix.platform == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    strategy:
+      matrix:
+        include:
+          - platform: amd64
+            image: rpm-repo-builder
+            context: packaging/rpm/docker/rpm-repo-builder
+          - platform: arm64
+            image: rpm-repo-builder
+            context: packaging/rpm/docker/rpm-repo-builder
+          - platform: amd64
+            image: ice-rpm-builder-rhel9
+            context: packaging/rpm/docker/rhel9
+          - platform: arm64
+            image: ice-rpm-builder-rhel10
+            context: packaging/rpm/docker/rhel10
+          - platform: amd64
+            image: ice-rpm-builder-rhel10
+            context: packaging/rpm/docker/rhel10
+          - platform: arm64
+            image: ice-rpm-builder-rhel10
+            context: packaging/rpm/docker/rhel10
+          - platform: amd64
+            image: ice-rpm-builder-amzn2023
+            context: packaging/rpm/docker/amzn2023
+          - platform: arm64
+            image: ice-rpm-builder-amzn2023
+            context: packaging/rpm/docker/amzn2023
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          path: ice
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: zeroc-ice
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add RH credentials
+        if: ${{ matrix.image == 'ice-rpm-builder-rhel10' }}
+        run: |
+          umask 077
+          echo "RH_USERNAME=\"${{ secrets.RH_USERNAME }}\"" >> rh_credentials
+          echo "RH_PASSWORD=\"${{ secrets.RH_PASSWORD }}\"" >> rh_credentials
+
+      - name: Build and push image
+        run: |
+          args=(
+            --platform "linux/${{ matrix.platform }}"
+            --tag "ghcr.io/zeroc-ice/${{ matrix.image }}:${{ matrix.platform }}"
+            --push
+            -f Dockerfile
+          )
+
+          # Add secret mount only for RHEL10
+          if [[ "${{ matrix.image }}" == "ice-rpm-builder-rhel10" ]]; then
+            args+=( --secret id=rh_credentials,src=rh_credentials )
+          fi
+
+          docker buildx build "${args[@]}" .
+        working-directory: ice/${{ matrix.context }}
+
+      - name: Clean up RH credentials
+        if: ${{ always() && matrix.image == 'ice-rpm-builder-rhel10' }}
+        run: rm -f rh_credentials
+
+  create-manifests:
+    name: "Create and Push Multi-Arch Manifests"
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        image:
+          - rpm-repo-builder
+          - ice-rpm-builder-rhel9
+          - ice-rpm-builder-rhel10
+          - ice-rpm-builder-amzn2023
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: zeroc-ice
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest
+        run: |
+          docker manifest create ghcr.io/zeroc-ice/${{ matrix.image }}:latest \
+            --amend ghcr.io/zeroc-ice/${{ matrix.image }}:amd64 \
+            --amend ghcr.io/zeroc-ice/${{ matrix.image }}:arm64
+
+          docker manifest push ghcr.io/zeroc-ice/${{ matrix.image }}:latest

--- a/.github/workflows/build-container-images.yml
+++ b/.github/workflows/build-container-images.yml
@@ -12,28 +12,32 @@ jobs:
         include:
           - platform: amd64
             image: rpm-repo-builder
-            context: packaging/rpm/docker/rpm-repo-builder
+            dockerfile: packaging/rpm/docker/rpm-repo-builder/Dockerfile
           - platform: arm64
             image: rpm-repo-builder
-            context: packaging/rpm/docker/rpm-repo-builder
+            dockerfile: packaging/rpm/docker/rpm-repo-builder/Dockerfile
           - platform: amd64
             image: ice-rpm-builder-rhel9
-            context: packaging/rpm/docker/rhel9
+            dockerfile: packaging/rpm/docker/rhel9/Dockerfile
           - platform: arm64
-            image: ice-rpm-builder-rhel10
-            context: packaging/rpm/docker/rhel10
+            image: ice-rpm-builder-rhel9
+            dockerfile: packaging/rpm/docker/rhel9/Dockerfile
           - platform: amd64
             image: ice-rpm-builder-rhel10
-            context: packaging/rpm/docker/rhel10
+            dockerfile: packaging/rpm/docker/rhel10/Dockerfile
           - platform: arm64
             image: ice-rpm-builder-rhel10
-            context: packaging/rpm/docker/rhel10
+            dockerfile: packaging/rpm/docker/rhel10/Dockerfile
           - platform: amd64
             image: ice-rpm-builder-amzn2023
-            context: packaging/rpm/docker/amzn2023
+            dockerfile: packaging/rpm/docker/amzn2023/Dockerfile
           - platform: arm64
             image: ice-rpm-builder-amzn2023
-            context: packaging/rpm/docker/amzn2023
+            dockerfile: packaging/rpm/docker/amzn2023/Dockerfile
+
+    # On Red Hat-based images, we need to provide credentials to access the Red Hat repositories.
+    env:
+      USE_RH_CREDENTIALS: ${{ startsWith(matrix.image, 'ice-rpm-builder-rhel') && 'true' || 'false' }}
 
     steps:
       - name: Check out repository
@@ -52,7 +56,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add RH credentials
-        if: ${{ matrix.image == 'ice-rpm-builder-rhel10' }}
+        if: env.USE_RH_CREDENTIALS == 'true'
         run: |
           umask 077
           echo "RH_USERNAME=\"${{ secrets.RH_USERNAME }}\"" >> rh_credentials
@@ -64,19 +68,19 @@ jobs:
             --platform "linux/${{ matrix.platform }}"
             --tag "ghcr.io/zeroc-ice/${{ matrix.image }}:${{ matrix.platform }}"
             --push
-            -f Dockerfile
+            -f ${{ matrix.dockerfile }}
           )
 
-          # Add secret mount only for RHEL10
-          if [[ "${{ matrix.image }}" == "ice-rpm-builder-rhel10" ]]; then
+          # Add secret with Red Hat credentials if needed
+          if [[ "$USE_RH_CREDENTIALS" == "true" ]]; then
             args+=( --secret id=rh_credentials,src=rh_credentials )
           fi
 
           docker buildx build "${args[@]}" .
-        working-directory: ice/${{ matrix.context }}
+        working-directory: ice
 
       - name: Clean up RH credentials
-        if: ${{ always() && matrix.image == 'ice-rpm-builder-rhel10' }}
+        if: always() && env.USE_RH_CREDENTIALS == 'true'
         run: rm -f rh_credentials
 
   create-manifests:

--- a/packaging/rpm/docker/amzn2023/Dockerfile
+++ b/packaging/rpm/docker/amzn2023/Dockerfile
@@ -2,7 +2,7 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
 # Copy Ice spec file into the container
-COPY ice/packaging/rpm/ice.spec /usr/src/ice.spec
+COPY packaging/rpm/ice.spec /usr/src/ice.spec
 
 # Install required build tools and dependencies
 RUN dnf config-manager --set-enabled codeready-builder-for-rhel-9-$(arch)-rpms && \

--- a/packaging/rpm/docker/amzn2023/Dockerfile
+++ b/packaging/rpm/docker/amzn2023/Dockerfile
@@ -1,8 +1,12 @@
 # Use the official Amazon Linux 2023 image
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
+# Copy Ice spec file into the container
+COPY ice/packaging/rpm/ice.spec /usr/src/ice.spec
+
 # Install required build tools and dependencies
-RUN dnf install --setopt=multilib_policy=all -y \
+RUN dnf config-manager --set-enabled codeready-builder-for-rhel-9-$(arch)-rpms && \
+    dnf install -y \
     rpmdevtools \
     make \
     curl-minimal \
@@ -13,16 +17,5 @@ RUN dnf install --setopt=multilib_policy=all -y \
     redhat-rpm-config \
     glibc-static \
     libstdc++-static && \
-    dnf clean all
-
-# Copy Ice spec file into the container
-COPY packaging/rpm/ice.spec /usr/src/ice.spec
-
-# Install build dependencies. Do not use dnf builddep as it doesn't obey multilib_policy=all.
-RUN rpmspec --parse /usr/src/ice.spec 2>/dev/null | \
-    grep '^BuildRequires:' | \
-    sed -E 's/BuildRequires:\s*//' | \
-    tr ',' '\n' | awk '{print $1}' | sort -u > /tmp/dependencies.txt && \
-    dnf install --setopt=multilib_policy=all -y $(cat /tmp/dependencies.txt) && \
-    rm -f /tmp/dependencies.txt /usr/src/ice.spec && \
+    dnf builddep /usr/src/ice.spec && \
     dnf clean all

--- a/packaging/rpm/docker/rhel10/Dockerfile
+++ b/packaging/rpm/docker/rhel10/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9
+FROM registry.access.redhat.com/ubi10
 
 # Copy Ice spec file into the container
 COPY ice/packaging/rpm/ice.spec /usr/src/ice.spec
@@ -12,8 +12,8 @@ COPY ice/packaging/rpm/ice.spec /usr/src/ice.spec
 RUN --mount=type=secret,id=rh_credentials \
     source /run/secrets/rh_credentials && \
     subscription-manager register --username "$RH_USERNAME" --password "$RH_PASSWORD" && \
-    dnf install -y https://zeroc.com/download/ice/3.8/el9/ice-repo-3.8-1.el9.noarch.rpm && \
-    dnf config-manager --set-enabled codeready-builder-for-rhel-9-$(arch)-rpms && \
+    dnf install -y https://zeroc.com/download/ice/3.8/el10/ice-repo-3.8-1.el10.noarch.rpm && \
+    dnf config-manager --set-enabled codeready-builder-for-rhel-10-$(arch)-rpms && \
     dnf install -y \
     rpmdevtools \
     make \

--- a/packaging/rpm/docker/rhel10/Dockerfile
+++ b/packaging/rpm/docker/rhel10/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi10
 
 # Copy Ice spec file into the container
-COPY ice/packaging/rpm/ice.spec /usr/src/ice.spec
+COPY packaging/rpm/ice.spec /usr/src/ice.spec
 
 # Install required tools and build dependencies:
 # - Enable the Ice 3.8 repository to install mcpp-devel

--- a/packaging/rpm/docker/rhel9/Dockerfile
+++ b/packaging/rpm/docker/rhel9/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9
 
 # Copy Ice spec file into the container
-COPY ice/packaging/rpm/ice.spec /usr/src/ice.spec
+COPY packaging/rpm/ice.spec /usr/src/ice.spec
 
 # Install required tools and build dependencies:
 # - Enable the Ice 3.8 repository to install mcpp-devel

--- a/packaging/rpm/docker/rpm-repo-builder/Dockerfile
+++ b/packaging/rpm/docker/rpm-repo-builder/Dockerfile
@@ -1,0 +1,11 @@
+FROM rockylinux:9
+
+RUN dnf install -y \
+    rpmdevtools \
+    createrepo_c \
+    gnupg2 \
+    rpm-sign && \
+    dnf clean all
+
+COPY ice/packaging/rpm/rpm-sign.sh /usr/local/bin/rpm-sign
+RUN chmod +x /usr/local/bin/rpm-sign

--- a/packaging/rpm/docker/rpm-repo-builder/README.md
+++ b/packaging/rpm/docker/rpm-repo-builder/README.md
@@ -1,0 +1,17 @@
+# ZeroC Ice RPM Repo Builder
+
+This Docker image provides a minimal, RHEL-compatible environment for:
+
+- Signing RPM packages using GPG
+- Generating signed YUM repositories using `createrepo_c`
+
+## Image Name
+
+`ghcr.io/zeroc-ice/rpm-repo-builder`
+
+## Included Tools
+
+- rpm-sign
+- createrepo_c
+- gnupg2
+- rpmdevtools

--- a/packaging/rpm/ice.spec
+++ b/packaging/rpm/ice.spec
@@ -7,6 +7,16 @@
   %define archive_tag main
 %endif
 
+%define javaversion 17-openjdk
+
+%if "%{dist}" == ".amzn2023"
+%define javaversion 17-amazon-corretto
+%endif
+
+%if "%{dist}" == ".el10"
+%define javaversion 21-openjdk
+%endif
+
 %define shadow shadow-utils
 %define javapackagestools javapackages-tools
 # Unfortunately bzip2-devel does not provide pkgconfig(bzip2) as of EL7
@@ -63,11 +73,7 @@ BuildRequires: libmcpp-devel
 BuildRequires: pkgconfig(mcpp)
 %endif
 
-%if "%{dist}" == ".amzn2023"
-BuildRequires: java-17-amazon-corretto, java-17-amazon-corretto-jmods
-%else
-BuildRequires: java-17-openjdk, java-17-openjdk-jmods
-%endif
+BuildRequires: java-%{javaversion}, java-%{javaversion}-jmods
 
 %ifarch %{_host_cpu}
 BuildRequires: %{phpname}-devel

--- a/packaging/rpm/rpm-sign.sh
+++ b/packaging/rpm/rpm-sign.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ensure GPG_KEY and GPG_KEY_ID are set
+: "${GPG_KEY:?GPG_KEY environment variable is not set}"
+: "${GPG_KEY_ID:?GPG_KEY_ID environment variable is not set}"
+
+# mutt GPG tty setting
+export GPG_TTY=$(tty)
+
+# Import the GPG key
+echo "$GPG_KEY" | gpg --batch --import
+
+# Check that the key was successfully imported
+if ! gpg --list-secret-keys "$GPG_KEY_ID" > /dev/null 2>&1; then
+  echo "Error: GPG key ID $GPG_KEY_ID was not imported successfully."
+  exit 1
+fi
+
+# Set up ~/.rpmmacros for rpmsign
+cat > ~/.rpmmacros <<EOF
+%_signature gpg
+%_gpg_name $GPG_KEY_ID
+%_gpg_path ~/.gnupg
+%__gpg_check_password_cmd /bin/true
+%__gpg /usr/bin/gpg
+EOF
+
+# Directory containing the RPMs
+BUILD_DIR="${1:?Usage: $0 <build-dir>}"
+
+# Find all RPMs for the current arch
+mapfile -t rpms < <(find "$BUILD_DIR" -type f -name "*.rpm")
+
+for rpm in "${rpms[@]}"; do
+  echo "Signing: $(basename "$rpm")"
+  rpmsign --addsign "$rpm"
+done


### PR DESCRIPTION
This PR introduces a new workflow for building the Docker container images used for RPM builds.

It builds the following images:

- rpm-repo-builder (A image used to sign RPMs and create RPM repositories)
- ice-rpm-builder-rhel9 (Ice 3.8 RPM builder for rhel9)
- ice-rpm-builder-rhel10 (Ice 3.8 RPM builder for rhel10)
- packaging/rpm/docker/amzn2023 (Ice 3.8 RPM builder for amzn2023)

There is a few minor fixes to ice.spec for compatibility with Red Hat 10, but more cleanup to remove i686 is left for a follow up PR.

Added a new rpm-sign.sh script that is used by the rpm-repo-builder container for signing RPMs. The idea is we would upload the signed RPMs to the job run, or tag. Which allow us to regenerate the repositories from the GitHub artifacts.