### PR TITLE
Improve doc-comments generated by slice2matlab

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -3460,8 +3460,8 @@ Slice::Operation::returnParameter()
             }
         }
 
-        ParameterPtr returnParam = make_shared<Parameter>(
-            shared_from_this(), returnName, _returnType, _returnIsOptional, _returnTag);
+        ParameterPtr returnParam =
+            make_shared<Parameter>(shared_from_this(), returnName, _returnType, _returnIsOptional, _returnTag);
 
         // TODO: presumably, this yields a bad mapped name when the operation name is remapped with xxx:identifier.
         returnParam->setMetadata(getMetadata());

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -698,19 +698,22 @@ namespace Slice
         ParameterPtr createParameter(const std::string& name, const TypePtr& type, bool isOptional, std::int32_t tag);
 
         [[nodiscard]] ParameterList parameters() const;
+
         /// Returns a list of all this operation's in-parameters (all parameters not marked with 'out').
         [[nodiscard]] ParameterList inParameters() const;
+
         /// Returns all of this operation's in-parameters sorted in this order: '(required..., optional...)'.
         /// Required parameters are kept in definition order and optional parameters are sorted by tag.
         [[nodiscard]] ParameterList sortedInParameters() const;
+
         /// Returns a list of all this operation's out-parameters (all parameters marked with 'out').
         [[nodiscard]] ParameterList outParameters() const;
-        /// Returns this operation's out parameters and return type (if the operation is non-void), in that order.
-        /// @param returnsName The name that should be returned by `returnValueParam->name()`.
-        //
-        // Creating this temporary Parameter doesn't introduce cycles, since nothing from the AST points to it,
-        // even if it points back into the AST. So it will be destroyed when the returned list goes out of scope.
-        [[nodiscard]] ParameterList returnAndOutParameters(const std::string& returnsName);
+
+        /// Creates a temporary Parameter that represents this operation's return value.
+        /// @return A dummy Parameter that represents this operation's return value, or nullptr if this operation is
+        /// void.
+        [[nodiscard]] ParameterPtr returnParameter();
+
         /// Returns this operation's out parameters and return type sorted in this order: '(required..., optional...)'.
         /// If the this operation's return type is non-void and non-optional, it is at the end of the 'required' list.
         /// Otherwise, required parameters are kept in definition order and optional parameters are sorted by tag.
@@ -718,11 +721,9 @@ namespace Slice
         /// For convenience, non-void return types are represented by a dummy `Parameter` in this list.
         /// However it's important to note that it is not _actually_ a parameter.
         ///
-        /// @param returnsName The name that should be returned by `returnValueParam->name()`.
-        //
         // Creating this temporary Parameter doesn't introduce cycles, since nothing from the AST points to it,
         // even if it points back into the AST. So it will be destroyed when the returned list goes out of scope.
-        [[nodiscard]] ParameterList sortedReturnAndOutParameters(const std::string& returnsName);
+        [[nodiscard]] ParameterList sortedReturnAndOutParameters();
 
         [[nodiscard]] ExceptionList throws() const;
         void setExceptionList(const ExceptionList& exceptions);

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -697,6 +697,7 @@ namespace Slice
 
         ParameterPtr createParameter(const std::string& name, const TypePtr& type, bool isOptional, std::int32_t tag);
 
+        /// Returns all parameters of this operation.
         [[nodiscard]] ParameterList parameters() const;
 
         /// Returns a list of all this operation's in-parameters (all parameters not marked with 'out').
@@ -710,9 +711,14 @@ namespace Slice
         [[nodiscard]] ParameterList outParameters() const;
 
         /// Creates a temporary Parameter that represents this operation's return value.
+        /// @param name The name of the return parameter.
         /// @return A dummy Parameter that represents this operation's return value, or nullptr if this operation is
         /// void.
-        [[nodiscard]] ParameterPtr returnParameter();
+        /// @remark The returned Parameter is not "saved" by this operation - it's completely ephemeral.
+        /// The provided name is not checked for uniqueness: the caller must ensure it's unique enough for its purpose.
+        /// Furthermore, there is no way to specify a lang:identifier metadata for this parameter, so the mapped
+        /// parameter name is always the default (i.e., simply name).
+        [[nodiscard]] ParameterPtr returnParameter(const std::string& name);
 
         /// Returns this operation's out parameters and return type sorted in this order: '(required..., optional...)'.
         /// If the this operation's return type is non-void and non-optional, it is at the end of the 'required' list.
@@ -723,7 +729,9 @@ namespace Slice
         ///
         // Creating this temporary Parameter doesn't introduce cycles, since nothing from the AST points to it,
         // even if it points back into the AST. So it will be destroyed when the returned list goes out of scope.
-        [[nodiscard]] ParameterList sortedReturnAndOutParameters();
+        /// @param returnName The name of the return parameter. See #returnParameter for more details.
+        /// @return A list of all this operation's out-parameters and return type, sorted in the order described above.
+        [[nodiscard]] ParameterList sortedReturnAndOutParameters(const std::string& returnName);
 
         [[nodiscard]] ExceptionList throws() const;
         void setExceptionList(const ExceptionList& exceptions);

--- a/cpp/src/Slice/SliceUtil.cpp
+++ b/cpp/src/Slice/SliceUtil.cpp
@@ -564,3 +564,16 @@ Slice::getFirstSentence(const StringList& lines)
 
     return ostr.str();
 }
+
+string
+Slice::getEscapedParamName(const ParameterList& params, std::string_view param)
+{
+    for (const auto& p : params)
+    {
+        if (p->mappedName() == param)
+        {
+            return string{param} + "_"; // stop after adding a trailing underscore
+        }
+    }
+    return string{param};
+}

--- a/cpp/src/Slice/Util.h
+++ b/cpp/src/Slice/Util.h
@@ -70,5 +70,12 @@ namespace Slice
 
     /// Returns the first sentence in the provided list of lines.
     std::string getFirstSentence(const StringList& lines);
+
+    /// Checks if @p param collides with any mapped name in @p params. If yes, return param followed by an underscore;
+    /// otherwise, return param as is.
+    /// @param params The parameter list to check against.
+    /// @param param The parameter name to check.
+    /// @return The parameter name, possibly modified to avoid collisions.
+    std::string getEscapedParamName(const ParameterList& params, std::string_view param);
 }
 #endif

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -509,8 +509,19 @@ Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         out << epar;
 
         // Write the operation's return type.
+        string returnValueName = "returnValue";
+        // Make sure returnValueName does not collide with any out parameter name:
+        for (const auto& param : op->outParameters())
+        {
+            if (param->name() == returnValueName)
+            {
+                returnValueName += "_";
+                break; // multiple collisions means the user is trying to get a collision.
+            }
+        }
+
         ParameterList returnAndOutParams = op->outParameters();
-        ParameterPtr returnParam = op->returnParameter();
+        ParameterPtr returnParam = op->returnParameter(returnValueName);
         if (returnParam)
         {
             returnAndOutParams.push_back(returnParam); // push to the back for encoding compatibility

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -509,7 +509,13 @@ Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         out << epar;
 
         // Write the operation's return type.
-        const ParameterList returnAndOutParams = op->returnAndOutParameters("returnValue");
+        ParameterList returnAndOutParams = op->outParameters();
+        ParameterPtr returnParam = op->returnParameter();
+        if (returnParam)
+        {
+            returnAndOutParams.push_back(returnParam); // push to the back for encoding compatibility
+        }
+
         if (returnAndOutParams.size() > 1)
         {
             out << " -> ";

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -269,18 +269,6 @@ namespace
         }
     }
 
-    string getEscapedParamName(const OperationPtr& p, const string& name)
-    {
-        for (const auto& param : p->parameters())
-        {
-            if (param->mappedName() == name)
-            {
-                return name + "_";
-            }
-        }
-        return name;
-    }
-
     string resultStructReturnValueName(const ParameterList& outParams)
     {
         for (const auto& outParam : outParams)
@@ -679,7 +667,7 @@ Slice::CsVisitor::getDispatchParams(
         retS = typeToString(op->returnType(), ns, op->returnIsOptional());
     }
 
-    string currentParamName = getEscapedParamName(op, "current");
+    string currentParamName = getEscapedParamName(op->parameters(), "current");
     params.push_back("Ice.Current " + currentParamName);
     args.push_back(currentParamName);
     return name;
@@ -1812,7 +1800,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 
         ParameterList outParams = op->outParameters();
 
-        string context = getEscapedParamName(op, "context");
+        string context = getEscapedParamName(op->parameters(), "context");
 
         _out << sp;
         _out << nl << "public " << retS << " " << opName << spar << params
@@ -1876,9 +1864,9 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         ParameterList inParams = op->inParameters();
         ParameterList outParams = op->outParameters();
 
-        string context = getEscapedParamName(op, "context");
-        string cancel = getEscapedParamName(op, "cancel");
-        string progress = getEscapedParamName(op, "progress");
+        string context = getEscapedParamName(op->parameters(), "context");
+        string cancel = getEscapedParamName(op->parameters(), "cancel");
+        string progress = getEscapedParamName(op->parameters(), "progress");
 
         TypePtr ret = op->returnType();
 
@@ -2225,7 +2213,7 @@ Slice::Gen::TypesVisitor::visitOperation(const OperationPtr& p)
         //
         // Write the synchronous version of the operation.
         //
-        string context = getEscapedParamName(p, "context");
+        string context = getEscapedParamName(p->parameters(), "context");
         _out << sp;
         writeOpDocComment(p, {"<param name=\"" + context + "\">The request context.</param>"}, false);
         emitObsoleteAttribute(p, _out);
@@ -2238,9 +2226,9 @@ Slice::Gen::TypesVisitor::visitOperation(const OperationPtr& p)
         //
         // Write the async version of the operation (using Async Task API)
         //
-        string context = getEscapedParamName(p, "context");
-        string cancel = getEscapedParamName(p, "cancel");
-        string progress = getEscapedParamName(p, "progress");
+        string context = getEscapedParamName(p->parameters(), "context");
+        string cancel = getEscapedParamName(p->parameters(), "cancel");
+        string progress = getEscapedParamName(p->parameters(), "progress");
 
         _out << sp;
         writeOpDocComment(

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -220,7 +220,7 @@ Slice::JavaVisitor::writeResultTypeMarshalUnmarshalCode(
 {
     int iter = 0;
 
-    for (const auto& param : op->sortedReturnAndOutParameters("returnValue"))
+    for (const auto& param : op->sortedReturnAndOutParameters())
     {
         const bool isOptional = param->optional();
         const bool isReturn = param->isOutParam() == false; // The return value is not an out parameter.

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -57,18 +57,6 @@ namespace
         }
     }
 
-    string getEscapedParamName(const ParameterList& params, const string& name)
-    {
-        for (const auto& param : params)
-        {
-            if (param->mappedName() == name)
-            {
-                return name + "_";
-            }
-        }
-        return name;
-    }
-
     // Returns java.util.OptionalXXX.ofYYY depending on the type
     string ofFactory(const TypePtr& type)
     {
@@ -220,7 +208,9 @@ Slice::JavaVisitor::writeResultTypeMarshalUnmarshalCode(
 {
     int iter = 0;
 
-    for (const auto& param : op->sortedReturnAndOutParameters())
+    const string retval = getEscapedParamName(op->outParameters(), "returnValue");
+
+    for (const auto& param : op->sortedReturnAndOutParameters(retval))
     {
         const bool isOptional = param->optional();
         const bool isReturn = param->isOutParam() == false; // The return value is not an out parameter.

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -1668,10 +1668,9 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             out << nl << "end";
         }
 
-        out << nl << "future = " << self << ".iceInvokeAsync('" << op->name() << "', "
-            << getOperationMode(op->mode()) << ", " << (twowayOnly ? "true" : "false") << ", "
-            << (inParams.empty() ? "[]" : "os_") << ", " << returnAndOutParameters.size() << ", "
-            << (twowayOnly && returnsAnyValues ? "@unmarshal" : "[]");
+        out << nl << "future = " << self << ".iceInvokeAsync('" << op->name() << "', " << getOperationMode(op->mode())
+            << ", " << (twowayOnly ? "true" : "false") << ", " << (inParams.empty() ? "[]" : "os_") << ", "
+            << returnAndOutParameters.size() << ", " << (twowayOnly && returnsAnyValues ? "@unmarshal" : "[]");
         if (exceptions.empty())
         {
             out << ", {}";

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -503,6 +503,9 @@ namespace
     {
         if (!list.empty())
         {
+            // We keep the declaration order for this summary; sorting the properties in alphabetical order would be
+            // confusing wrt the primary constructor.
+
             out << nl << "%";
             out << nl << "%   " << name << " Properties:";
             for (const auto& field : list)
@@ -727,9 +730,12 @@ namespace
         out << nl << "%         character vector";
         out << nl << "%";
         out << nl << "%   " << name << " Methods:";
-        const OperationList ops = p->operations();
+        OperationList ops = p->operations();
         if (!ops.empty())
         {
+            // The summary is in alphabetical order.
+            ops.sort([](const OperationPtr& a, const OperationPtr& b) { return a->mappedName() < b->mappedName(); });
+
             for (const auto& op : ops)
             {
                 const string opName = op->mappedName();

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -388,14 +388,14 @@ namespace
         }
     }
 
-    void writeDocLines(IceInternal::Output& out, const StringList& lines, int indentation = 0)
+    void writeDocLines(IceInternal::Output& out, const StringList& lines, size_t indentation = 0)
     {
         for (const auto& line : lines)
         {
             out << nl << "%";
             if (!line.empty())
             {
-                out << string(indentation + 1, ' ') << line;
+                out << " " << string(indentation, ' ') << line;
             }
         }
     }
@@ -933,7 +933,7 @@ namespace
         const TypePtr& type,
         bool optional,
         StringList docLines,
-        int indentation)
+        size_t indentation)
     {
         auto typeStr = typeToString(type);
 

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -934,7 +934,7 @@ namespace
         bool itemInList)
     {
         auto typeStr = typeToString(type);
-        int indentation = 0;
+        size_t indentation = 0;
 
         if (itemInList)
         {

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -536,7 +536,7 @@ namespace
         if (!docOverview.empty())
         {
             // Use the first line as the summary.
-            out << " - " << docOverview.front();
+            out << " " << docOverview.front();
             docOverview.pop_front();
 
             if (!docOverview.empty())
@@ -578,10 +578,9 @@ namespace
             StringList docOverview = doc->overview();
             if (!docOverview.empty())
             {
-                out << " - ";
                 // TODO: it would be much better to extract and print the first sentence, however, this is currently no
                 // helper to remove this first sentence.
-                out << docOverview.front();
+                out << " " << docOverview.front();
                 docOverview.pop_front();
                 writeDocLines(out, docOverview, 2); // indent with 2 spaces
             }
@@ -700,7 +699,7 @@ namespace
         if (!docOverview.empty())
         {
             // Use the first line as the summary.
-            out << " - " << docOverview.front();
+            out << " " << docOverview.front();
             docOverview.pop_front();
 
             if (!docOverview.empty())

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -536,7 +536,7 @@ namespace
         if (!docOverview.empty())
         {
             // Use the first line as the summary.
-            out << " " << docOverview.front();
+            out << " - " << docOverview.front();
             docOverview.pop_front();
 
             if (!docOverview.empty())
@@ -578,9 +578,10 @@ namespace
             StringList docOverview = doc->overview();
             if (!docOverview.empty())
             {
+                out << " - ";
                 // TODO: it would be much better to extract and print the first sentence, however, this is currently no
                 // helper to remove this first sentence.
-                out << " " << docOverview.front();
+                out << docOverview.front();
                 docOverview.pop_front();
                 writeDocLines(out, docOverview, 2); // indent with 2 spaces
             }
@@ -699,7 +700,7 @@ namespace
         if (!docOverview.empty())
         {
             // Use the first line as the summary.
-            out << " " << docOverview.front();
+            out << " - " << docOverview.front();
             docOverview.pop_front();
 
             if (!docOverview.empty())

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -34,7 +34,8 @@ using namespace IceInternal;
 
 namespace
 {
-    void documentArgument(IceInternal::Output& out, const ParameterPtr& param, const string& argName, StringList docLines);
+    void
+    documentArgument(IceInternal::Output& out, const ParameterPtr& param, const string& argName, StringList docLines);
     void documentProperty(IceInternal::Output& out, const DataMemberPtr& field);
 
     string checkAndEscapeParam(string_view param, const ParameterList& allParams)
@@ -634,8 +635,8 @@ namespace
             out << nl << "%";
             out << nl << "% Output Arguments";
             out << nl << "%   " << futureName
-                << " - A future that will be completed with the result of the invocation. See "
-                << p->mappedName() << ".";
+                << " - A future that will be completed with the result of the invocation. See " << p->mappedName()
+                << ".";
             out << nl << "%     Ice.Future scalar";
         }
         else
@@ -758,7 +759,8 @@ namespace
         }
         out << nl << "%";
         out << nl << "% " << name << " Static Methods:";
-        out << nl << "%   checkedCast - Contacts the remote server to check if the target object implements Slice interface "
+        out << nl
+            << "%   checkedCast - Contacts the remote server to check if the target object implements Slice interface "
             << p->scoped() << ".";
         out << nl << "%   uncheckedCast - Creates a " << name << " from another proxy without any validation.";
 
@@ -1027,8 +1029,13 @@ namespace
     void documentProperty(IceInternal::Output& out, const DataMemberPtr& field)
     {
         optional<DocComment> doc = DocComment::parseFrom(field, matlabLinkFormatter);
-        documentArgumentOrProperty(out, field->mappedScoped("."), field->type(), field->optional(),
-            doc ? doc->overview() : StringList{}, 0);
+        documentArgumentOrProperty(
+            out,
+            field->mappedScoped("."),
+            field->type(),
+            field->optional(),
+            doc ? doc->overview() : StringList{},
+            0);
 
         writeSeeAlso(out, doc, field->container());
         writeDeprecated(out, doc, field);
@@ -1673,9 +1680,10 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             out << nl << "end";
         }
 
-        out << nl << futureName << " = " << self << ".iceInvokeAsync('" << op->name() << "', " << getOperationMode(op->mode())
-            << ", " << (twowayOnly ? "true" : "false") << ", " << (inParams.empty() ? "[]" : "os_") << ", "
-            << returnAndOutParameters.size() << ", " << (twowayOnly && returnsAnyValues ? "@unmarshal" : "[]");
+        out << nl << futureName << " = " << self << ".iceInvokeAsync('" << op->name() << "', "
+            << getOperationMode(op->mode()) << ", " << (twowayOnly ? "true" : "false") << ", "
+            << (inParams.empty() ? "[]" : "os_") << ", " << returnAndOutParameters.size() << ", "
+            << (twowayOnly && returnsAnyValues ? "@unmarshal" : "[]");
         if (exceptions.empty())
         {
             out << ", {}";

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -618,10 +618,10 @@ namespace
         {
             out << nl << "%";
             out << nl << "%   Output Arguments";
-            out << nl << "%     future"
-                << " - A future that will be completed with the result of the invocation. See " << p->mappedName()
-                << ".";
+            out << nl << "%     future - A future that will be completed with the result of the invocation.";
             out << nl << "%       Ice.Future scalar";
+            out << nl << "%";
+            out << nl << "%   See also " << p->mappedName() << ", Ice.Future.";
         }
         else
         {

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -17,20 +17,6 @@ using namespace IceInternal;
 
 namespace
 {
-    string getEscapedParamName(const OperationPtr& p, const string& name)
-    {
-        ParameterList params = p->parameters();
-
-        for (const auto& param : params)
-        {
-            if (param->mappedName() == name)
-            {
-                return name + "_";
-            }
-        }
-        return name;
-    }
-
     const char* const tripleQuotes = R"(""")";
 
     string typeToDocstring(const TypePtr& type, bool optional)
@@ -592,7 +578,7 @@ Slice::Python::CodeVisitor::writeOperations(const InterfaceDefPtr& p)
             }
         }
 
-        const string currentParamName = getEscapedParamName(operation, "current");
+        const string currentParamName = getEscapedParamName(operation->parameters(), "current");
         _out << ", " << currentParamName;
         _out << "):";
         _out.inc();
@@ -868,7 +854,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         {
             _out << ", " << inParamsDecl;
         }
-        const string contextParamName = getEscapedParamName(operation, "context");
+        const string contextParamName = getEscapedParamName(operation->parameters(), "context");
         _out << ", " << contextParamName << "=None):";
         _out.inc();
         writeDocstring(operation, DocSync);
@@ -2199,14 +2185,14 @@ Slice::Python::CodeVisitor::writeDocstring(const OperationPtr& op, DocstringMode
 
         if (mode == DocSync || mode == DocAsync)
         {
-            const string contextParamName = getEscapedParamName(op, "context");
+            const string contextParamName = getEscapedParamName(op->parameters(), "context");
             _out << nl << contextParamName << " : dict[str, str]";
             _out << nl << "    The request context for the invocation.";
         }
 
         if (mode == DocDispatch)
         {
-            const string currentParamName = getEscapedParamName(op, "current");
+            const string currentParamName = getEscapedParamName(op->parameters(), "current");
             _out << nl << currentParamName << " : Ice.Current";
             _out << nl << "    The Current object for the dispatch.";
         }

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -43,7 +43,7 @@ namespace
         Slice::validateMetadata(unit, "ruby", std::move(knownMetadata));
     }
 
-    string getEscapedParamName(const OperationPtr& p, const string& name)
+    string getEscapedRubyParamName(const OperationPtr& p, const string& name)
     {
         for (const auto& param : p->parameters())
         {
@@ -346,7 +346,7 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         {
             _out << inParams << ", ";
         }
-        const string contextParamName = getEscapedParamName(op, "context");
+        const string contextParamName = getEscapedRubyParamName(op, "context");
         _out << contextParamName << "=nil)";
         _out.inc();
         _out << nl << proxyName << "_mixin::OP_" << op->name() << ".invoke(self, [" << inParams;

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -231,15 +231,7 @@ SwiftGenerator::writeOpDocSummary(IceInternal::Output& out, const OperationPtr& 
     }
     if (p->returnType())
     {
-        string returnValueName = "returnValue";
-        for (const auto& q : outParams)
-        {
-            if (q->mappedName() == returnValueName)
-            {
-                returnValueName += '_';
-                break;
-            }
-        }
+        string returnValueName = getEscapedParamName(outParams, "returnValue");
 
         // First, check if the user supplied a message in the doc comment for this return type.
         const StringList& docMessage = doc->returns();
@@ -1318,11 +1310,10 @@ SwiftGenerator::writeMarshalAsyncOutParams(::IceInternal::Output& out, const Ope
     // Marshal parameters in this order '(required..., optional...)'.
 
     out << nl << "let " << operationReturnDeclaration(op) << " = value";
-    for (const auto& param : op->sortedReturnAndOutParameters())
+    for (const auto& param : op->sortedReturnAndOutParameters(getEscapedParamName(op->outParameters(), "returnValue")))
     {
-        // 'isOutParam' fails for return types, and for return types, we don't want the 'mappedName'.
-        const string paramName = (param->isOutParam() ? param->mappedName() : param->name());
-        writeMarshalUnmarshalCode(out, param->type(), op, "iceP_" + removeEscaping(paramName), true, param->tag());
+        writeMarshalUnmarshalCode(out, param->type(), op, "iceP_" + removeEscaping(param->mappedName()), true,
+            param->tag());
     }
     if (op->returnsClasses())
     {
@@ -1348,12 +1339,11 @@ SwiftGenerator::writeUnmarshalOutParams(::IceInternal::Output& out, const Operat
     // 3. optional (including optional return)
     //
 
-    for (const auto& param : op->sortedReturnAndOutParameters())
+    for (const auto& param : op->sortedReturnAndOutParameters(getEscapedParamName(op->outParameters(), "returnValue")))
     {
         const TypePtr paramType = param->type();
         const string typeString = typeToString(paramType, op, param->optional());
-        // 'isOutParam' fails for return types, and for return types, we don't want the 'mappedName'.
-        const string paramName = "iceP_" + removeEscaping((param->isOutParam() ? param->mappedName() : param->name()));
+        const string paramName = "iceP_" + removeEscaping(param->mappedName());
         string paramString;
         if (paramType->isClassType())
         {
@@ -1380,15 +1370,7 @@ SwiftGenerator::writeUnmarshalOutParams(::IceInternal::Output& out, const Operat
 
     if (op->returnType())
     {
-        string returnValueName = "returnValue";
-        for (const auto& q : outParams)
-        {
-            if (removeEscaping(q->mappedName()) == returnValueName)
-            {
-                returnValueName += '_';
-                break;
-            }
-        }
+        string returnValueName = getEscapedParamName(outParams, "returnValue");
         out << ("iceP_" + returnValueName);
     }
     for (const auto& param : outParams)

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -1318,7 +1318,7 @@ SwiftGenerator::writeMarshalAsyncOutParams(::IceInternal::Output& out, const Ope
     // Marshal parameters in this order '(required..., optional...)'.
 
     out << nl << "let " << operationReturnDeclaration(op) << " = value";
-    for (const auto& param : op->sortedReturnAndOutParameters("returnValue"))
+    for (const auto& param : op->sortedReturnAndOutParameters())
     {
         // 'isOutParam' fails for return types, and for return types, we don't want the 'mappedName'.
         const string paramName = (param->isOutParam() ? param->mappedName() : param->name());
@@ -1348,7 +1348,7 @@ SwiftGenerator::writeUnmarshalOutParams(::IceInternal::Output& out, const Operat
     // 3. optional (including optional return)
     //
 
-    for (const auto& param : op->sortedReturnAndOutParameters("returnValue"))
+    for (const auto& param : op->sortedReturnAndOutParameters())
     {
         const TypePtr paramType = param->type();
         const string typeString = typeToString(paramType, op, param->optional());

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -1312,7 +1312,12 @@ SwiftGenerator::writeMarshalAsyncOutParams(::IceInternal::Output& out, const Ope
     out << nl << "let " << operationReturnDeclaration(op) << " = value";
     for (const auto& param : op->sortedReturnAndOutParameters(getEscapedParamName(op->outParameters(), "returnValue")))
     {
-        writeMarshalUnmarshalCode(out, param->type(), op, "iceP_" + removeEscaping(param->mappedName()), true,
+        writeMarshalUnmarshalCode(
+            out,
+            param->type(),
+            op,
+            "iceP_" + removeEscaping(param->mappedName()),
+            true,
             param->tag());
     }
     if (op->returnsClasses())

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -31,6 +31,9 @@ namespace Slice
         // within a single Slice file, that they all map to the same Swift package.
         static void validateSwiftModuleMappings(const UnitPtr&);
 
+        /// Removes any Swift escaping from the provided identifier (any leading or trailing backticks will be removed).
+        static std::string removeEscaping(std::string ident);
+
     protected:
         void writeDocLines(
             IceInternal::Output&,
@@ -48,9 +51,6 @@ namespace Slice
         std::string operationReturnDeclaration(const OperationPtr&);
 
         std::string typeToString(const TypePtr&, const ContainedPtr&, bool = false);
-
-        /// Removes any Swift escaping from the provided identifier (any leading or trailing backticks will be removed).
-        static std::string removeEscaping(std::string ident);
 
         std::string getUnqualified(const std::string&, const std::string&);
         std::string modeToString(Operation::Mode);

--- a/matlab/lib/+Ice/ObjectPrx.m
+++ b/matlab/lib/+Ice/ObjectPrx.m
@@ -151,46 +151,53 @@ classdef ObjectPrx < IceInternal.WrapperObject
             r = obj.iceInvokeAsync('ice_ping', 2, false, [], 0, [], {}, context);
         end
 
-        function r = ice_isA(obj, id, ctx)
-            % ice_isA - Tests whether this object supports a specific
-            %   Slice interface.
+        function r = ice_isA(obj, id, context)
+            %ICE_ISA Tests whether this object supports a specific Slice interface.
             %
-            % Parameters:
-            %   id - The type ID of the Slice interface to test against.
-            %   context - Optional context map for the invocation.
+            %   Input Arguments
+            %     id - The type ID of the Slice interface to test against.
+            %       character vector
+            %     context - The request context.
+            %       unconfigured dictionary (default) | dictionary(string, string) scalar
             %
-            % Returns (logical) - True if the target object has the interface
-            %   specified by id or derives from the interface specified by id.
+            %   Output Arguments
+            %     r - True if the target object implements the Slice interface specified by id or implements a
+            %       derived interface, false otherwise.
+            %       logical scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
                 id (1, :) char
-                ctx (1, 1) dictionary = dictionary
+                context (1, 1) dictionary = dictionary
             end
             os = obj.iceStartWriteParams([]);
             os.writeString(id);
             obj.iceEndWriteParams(os);
-            is = obj.iceInvoke('ice_isA', 2, true, os, true, {}, ctx);
+            is = obj.iceInvoke('ice_isA', 2, true, os, true, {}, context);
             is.startEncapsulation();
             r = is.readBool();
             is.endEncapsulation();
         end
 
-        function r = ice_isAAsync(obj, id, ctx)
-            % ice_isAAsync - Tests whether this object supports a specific
-            %   Slice interface.
+        function r = ice_isAAsync(obj, id, context)
+            %ICE_ISAASYNC Tests whether this object supports a specific Slice interface.
             %
-            % Parameters:
-            %   id - The type ID of the Slice interface to test against.
-            %   context - Optional context map for the invocation.
+            %   Input Arguments
+            %     id - The type ID of the Slice interface to test against.
+            %       character vector
+            %     context - The request context.
+            %       unconfigured dictionary (default) | dictionary(string, string) scalar
             %
-            % Returns (Ice.Future) - A future that will be completed when the
-            %   invocation completes.
+            %   Output Arguments
+            %     r - A future that will be completed with the result of the invocation.
+            %       Ice.Future scalar
+            %
+            %   See also ice_isA, Ice.Future.
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
                 id (1, :) char
-                ctx (1, 1) dictionary = dictionary
+                context (1, 1) dictionary = dictionary
             end
             os = obj.iceStartWriteParams([]);
             os.writeString(id);
@@ -200,96 +207,109 @@ classdef ObjectPrx < IceInternal.WrapperObject
                 varargout{1} = is.readBool();
                 is.endEncapsulation();
             end
-            r = obj.iceInvokeAsync('ice_isA', 2, true, os, 1, @unmarshal, {}, ctx);
+            r = obj.iceInvokeAsync('ice_isA', 2, true, os, 1, @unmarshal, {}, context);
         end
 
-        function r = ice_id(obj, ctx)
-            % ice_id - Returns the Slice type ID of the most-derived interface
-            %   supported by the target object of this proxy.
+        function r = ice_id(obj, context)
+            %ICE_ID Returns the Slice type ID of the most-derived interface supported by the target object of this
+            %   proxy.
             %
-            % Parameters:
-            %   context - Optional context map for the invocation.
+            %   Input Arguments
+            %     context - The request context.
+            %       unconfigured dictionary (default) | dictionary(string, string) scalar
             %
-            % Returns (char) - The Slice type ID of the most-derived interface.
+            %   Output Arguments
+            %     r - The Slice type ID of the most-derived interface.
+            %       character vector
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
-                ctx (1, 1) dictionary = dictionary
+                context (1, 1) dictionary = dictionary
             end
-            is = obj.iceInvoke('ice_id', 2, true, [], true, {}, ctx);
+            is = obj.iceInvoke('ice_id', 2, true, [], true, {}, context);
             is.startEncapsulation();
             r = is.readString();
             is.endEncapsulation();
         end
 
-        function r = ice_idAsync(obj, ctx)
-            % ice_idAsync - Returns the Slice type ID of the most-derived
-            %   interface supported by the target object of this proxy.
+        function r = ice_idAsync(obj, context)
+            %ICE_IDASYNC Returns the Slice type ID of the most-derived interface supported by the target object of this
+            %   proxy.
             %
-            % Parameters:
-            %   context - Optional context map for the invocation.
+            %   Input Arguments
+            %     context - The request context.
+            %       unconfigured dictionary (default) | dictionary(string, string) scalar
             %
-            % Returns (Ice.Future) - A future that will be completed when the
-            %   invocation completes.
+            %   Output Arguments
+            %     r - A future that will be completed with the result of the invocation.
+            %       Ice.Future scalar
+            %
+            %   See also ice_id, Ice.Future.
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
-                ctx (1, 1) dictionary = dictionary
+                context (1, 1) dictionary = dictionary
             end
             function varargout = unmarshal(is)
                 is.startEncapsulation();
                 varargout{1} = is.readString();
                 is.endEncapsulation();
             end
-            r = obj.iceInvokeAsync('ice_id', 2, true, [], 1, @unmarshal, {}, ctx);
+            r = obj.iceInvokeAsync('ice_id', 2, true, [], 1, @unmarshal, {}, context);
         end
 
-        function r = ice_ids(obj, ctx)
-            % ice_ids - Returns the Slice type IDs of the interfaces supported
-            %   by the target object of this proxy.
+        function r = ice_ids(obj, context)
+            %ICE_IDS Returns the Slice type IDs of the interfaces supported by the target object of this proxy.
             %
-            % Parameters:
-            %   context - Optional context map for the invocation.
+            %   Input Arguments
+            %     context - The request context.
+            %       unconfigured dictionary (default) | dictionary(string, string) scalar
             %
-            % Returns (string array) - The Slice type IDs of the
-            %   interfaces supported by the target object, in alphabetical order.
+            %   Output Arguments
+            %     r - The Slice type IDs of the interfaces supported by the target object, in alphabetical order.
+            %       string array
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
-                ctx (1, 1) dictionary = dictionary
+                context (1, 1) dictionary = dictionary
             end
-            is = obj.iceInvoke('ice_ids', 2, true, [], true, {}, ctx);
+            is = obj.iceInvoke('ice_ids', 2, true, [], true, {}, context);
             is.startEncapsulation();
             r = is.readStringSeq();
             is.endEncapsulation();
         end
 
-        function r = ice_idsAsync(obj, ctx)
-            % ice_idsAsync - Returns the Slice type IDs of the interfaces
-            %   supported by the target object of this proxy.
+        function r = ice_idsAsync(obj, context)
+            %ICE_IDSASYNC Returns the Slice type IDs of the interfaces supported by the target object of this proxy.
             %
-            % Parameters:
-            %   context - Optional context map for the invocation.
+            %   Input Arguments
+            %     context - The request context.
+            %       unconfigured dictionary (default) | dictionary(string, string) scalar
             %
-            % Returns (Ice.Future) - A future that will be completed when the
-            %   invocation completes.
+            %   Output Arguments
+            %     r - A future that will be completed with the result of the invocation.
+            %       Ice.Future scalar
+            %
+            %   See also ice_ids, Ice.Future.
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
-                ctx (1, 1) dictionary = dictionary
+                context (1, 1) dictionary = dictionary
             end
             function varargout = unmarshal(is)
                 is.startEncapsulation();
                 varargout{1} = is.readStringSeq();
                 is.endEncapsulation();
             end
-            r = obj.iceInvokeAsync('ice_ids', 2, true, [], 1, @unmarshal, {}, ctx);
+            r = obj.iceInvokeAsync('ice_ids', 2, true, [], 1, @unmarshal, {}, context);
         end
 
         function r = ice_getIdentity(obj)
-            % ice_getIdentity - Returns the identity embedded in this proxy.
+            %ICE_GETIDENTITY Returns the identity embedded in this proxy.
             %
-            % Returns (Ice.Identity) - The identity of the target object.
+            %   Output Arguments
+            %     r - The identity of the target object.
+            %       Ice.Identity scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -298,13 +318,15 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_identity(obj, id)
-            % ice_identity - Returns a proxy that is identical to this proxy,
-            %   except for the identity.
+            %ICE_IDENTITY Returns a proxy that is identical to this proxy, except for the identity.
             %
-            % Parameters:
-            %   id (Ice.Identity) - The identity for the new proxy.
+            %   Input Arguments
+            %     id - The identity for the new proxy.
+            %       Ice.Identity scalar
             %
-            % Returns (Ice.ObjectPrx) - The proxy with the new identity.
+            %   Output Arguments
+            %     r - The proxy with the new identity.
+            %       Ice.ObjectPrx scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -314,11 +336,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_getContext(obj)
-            % ice_getContext - Returns the per-proxy context for this proxy.
+            %ICE_GETCONTEXT Returns the per-proxy context for this proxy.
             %
-            % Returns (dictionary) - The per-proxy context. If the proxy
-            % does not have a per-proxy (implicit) context, the return value
-            % is an empty array.
+            %   Output Arguments
+            %     r - The per-proxy context.
+            %       dictionary(string, string) scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -326,27 +348,30 @@ classdef ObjectPrx < IceInternal.WrapperObject
             r = obj.iceCallWithResult('ice_getContext');
         end
 
-        function r = ice_context(obj, ctx)
-            % ice_context - Returns a proxy that is identical to this proxy,
-            %   except for the per-proxy context.
+        function r = ice_context(obj, context)
+            %ICE_CONTEXT Returns a proxy that is identical to this proxy, except for the per-proxy context.
             %
-            % Parameters:
-            %   ctx (dictionary) - The context for the new proxy.
+            %   Input Arguments
+            %     context - The context for the new proxy.
+            %       dictionary(string, string) scalar
             %
-            % Returns - The proxy with the new per-proxy context.
+            %   Output Arguments
+            %     r - The proxy with the new per-proxy context.
+            %       proxy scalar with the same type as obj
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
-                ctx (1, 1) dictionary {Ice.mustBeStringStringDictionary}
+                context (1, 1) dictionary {Ice.mustBeStringStringDictionary}
             end
-            r = obj.factory_('ice_context', true, ctx);
+            r = obj.factory_('ice_context', true, context);
         end
 
         function r = ice_getFacet(obj)
-            % ice_getFacet - Returns the facet for this proxy.
+            %ICE_GETFACET Returns the facet for this proxy.
             %
-            % Returns (char) - The facet for this proxy. If the proxy uses the
-            %   default facet, the return value is the empty string.
+            %   Output Arguments
+            %     r - The facet for this proxy.
+            %       character vector
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -355,13 +380,15 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_facet(obj, f)
-            % ice_facet - Returns a proxy that is identical to this proxy,
-            %   except for the facet.
+            %ICE_FACET Returns a proxy that is identical to this proxy, except for the facet.
             %
-            % Parameters:
-            %   f (char) - The facet for the new proxy.
+            %   Input Arguments
+            %     f - The facet for the new proxy.
+            %       character vector
             %
-            % Returns (Ice.ObjectPrx) - The proxy with the new facet.
+            %   Output Arguments
+            %     r - The proxy with the new facet.
+            %       Ice.ObjectPrx scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -371,10 +398,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_getAdapterId(obj)
-            % ice_getAdapter - Returns the adapter ID for this proxy.
+            %ICE_GETADAPTERID Returns the adapter ID for this proxy.
             %
-            % Returns (char) - The adapter ID. If the proxy does not have an
-            %   adapter ID, the return value is the empty string.
+            %   Output Arguments
+            %     r - The adapter ID. If the proxy does not have an adapter ID, r is the empty string.
+            %       character vector
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -383,13 +411,15 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_adapterId(obj, id)
-            % ice_adapterId - Returns a proxy that is identical to this proxy,
-            %   except for the adapter ID.
+            %ICE_ADAPTERID Returns a proxy that is identical to this proxy, except for the adapter ID.
             %
-            % Parameters:
-            %   id (char) - The adapter ID for the new proxy.
+            %   Input Arguments
+            %     id - The adapter ID for the new proxy.
+            %       character vector
             %
-            % Returns - The proxy with the new adapter ID.
+            %   Output Arguments
+            %     r - The proxy with the new adapter ID.
+            %        proxy scalar with the same type as obj
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -399,10 +429,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_getEndpoints(obj)
-            % ice_getEndpoints - Returns the endpoints used by this proxy.
+            %ICE_GETENDPOINTS Returns the endpoints used by this proxy.
             %
-            % Returns (cell array of Ice.Endpoint) - The endpoints used by
-            %   this proxy.
+            %   Output Arguments
+            %     r - The endpoints used by this proxy.
+            %       cell array of Ice.Endpoint
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -418,22 +449,23 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_endpoints(obj, endpoints)
-            % ice_endpoints - Returns a proxy that is identical to this proxy, except for the endpoints.
+            %ICE_ENDPOINTS Returns a proxy that is identical to this proxy, except for the endpoints.
             %
-            % Parameters:
-            %   endpoints (cell array of Ice.Endpoint) - The endpoints for the new proxy.
+            %   Input Arguments
+            %     endpoints - The endpoints for the new proxy.
+            %       cell array of Ice.Endpoint
             %
-            % Returns - The proxy with the new endpoints.
-
-            %
-            % It's not clear how we can pass a vector of void* to a C function. So we create a temporary C vector
-            % and populate it one element at a time.
-            %
+            %   Output Arguments
+            %     r - The proxy with the new endpoints.
+            %        proxy scalar with the same type as obj
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
                 endpoints (1, :) cell
             end
+
+            % It's not clear how we can pass a vector of void* to a C function. So we create a temporary C vector
+            % and populate it one element at a time.
             for i = 1:length(endpoints)
                 if ~isa(endpoints{i}, 'Ice.Endpoint')
                    error('Ice:ArgumentException', 'Expected an Ice.Endpoint');
@@ -448,10 +480,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_getLocatorCacheTimeout(obj)
-            % ice_getLocatorCacheTimeout - Returns the locator cache timeout
-            %   of this proxy.
+            %ICE_GETLOCATORCACHETIMEOUT Returns the locator cache timeout of this proxy.
             %
-            % Returns (int32) - The locator cache timeout value (in seconds).
+            %   Output Arguments
+            %     r - The locator cache timeout value (in seconds).
+            %       int32 scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -460,13 +493,16 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_locatorCacheTimeout(obj, t)
-            % ice_locatorCacheTimeout - Returns a proxy that is identical to
-            %   this proxy, except for the locator cache timeout.
+            %ICE_LOCATORCACHETIMEOUT Returns a proxy that is identical to this proxy, except for the locator cache
+            %   timeout.
             %
-            % Parameters:
-            %   t (int32) - The new locator cache timeout (in seconds).
+            %   Input Arguments
+            %     t - The new locator cache timeout (in seconds).
+            %       int32 scalar
             %
-            % Returns - The proxy with the new timeout.
+            %   Output Arguments
+            %     r - The proxy with the new timeout.
+            %       proxy scalar with the same type as obj
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -476,10 +512,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_getInvocationTimeout(obj)
-            % ice_getInvocationTimeout - Returns the invocation timeout of
-            %   this proxy.
+            %ICE_GETINVOCATIONTIMEOUT Returns the invocation timeout of this proxy.
             %
-            % Returns (int32) - The invocation timeout value (in seconds).
+            %   Output Arguments
+            %     r - The invocation timeout value (in seconds).
+            %       int32 scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -488,13 +525,15 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_invocationTimeout(obj, t)
-            % ice_invocationTimeout - Returns a proxy that is identical to
-            %   this proxy, except for the invocation timeout.
+            %ICE_INVOCATIONTIMEOUT Returns a proxy that is identical to this proxy, except for the invocation timeout.
             %
-            % Parameters:
-            %   t (int32) - The new invocation timeout (in seconds).
+            %   Input Arguments
+            %     t - The new invocation timeout (in seconds).
+            %       int32 scalar
             %
-            % Returns - The proxy with the new timeout.
+            %   Output Arguments
+            %     r - The proxy with the new timeout.
+            %       proxy scalar with the same type as obj
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -504,9 +543,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_getConnectionId(obj)
-            % ice_getConnectionId - Returns the connection id of this proxy.
+            %ICE_GETCONNECTIONID Returns the connection ID of this proxy.
             %
-            % Returns (char) - The connection id.
+            %   Output Arguments
+            %      r - The connection ID.
+            %        character vector
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -515,14 +556,15 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_connectionId(obj, id)
-            % ice_connectionId - Returns a proxy that is identical to this
-            %   proxy, except for its connection ID.
+            %ICE_CONNECTIONID Returns a proxy that is identical to this proxy, except for its connection ID.
             %
-            % Parameters:
-            %   id (char) - The connection ID for the new proxy. An empty
-            %   string removes the connection ID.
+            %   Input Arguments
+            %      id - The connection ID for the new proxy. An empty string removes the connection ID.
+            %        character vector
             %
-            % Returns - A proxy with the specified connection ID.
+            %   Output Arguments
+            %      r - A proxy with the specified connection ID.
+            %        proxy scalar with the same type as obj
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -532,11 +574,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_isConnectionCached(obj)
-            % ice_isConnectionCached - Returns whether this proxy caches
-            %   connections.
+            %ICE_ISCONNECTIONCACHED Returns whether this proxy caches connections.
             %
-            % Returns (logical) - True if this proxy caches connections;
-            %   false otherwise.
+            %   Output Arguments
+            %      r - True if this proxy caches connections; false otherwise.
+            %        logical scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -545,14 +587,15 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_connectionCached(obj, b)
-            % ice_connectionCached - Returns a proxy that is identical to this
-            %   proxy, except for connection caching.
+            %ICE_CONNECTIONCACHED Returns a proxy that is identical to this proxy, except for connection caching.
             %
-            % Parameters:
-            %   b (logical) - True if the new proxy should cache connections;
-            %     false otherwise.
+            %   Input Arguments
+            %      b - True if the new proxy should cache connections; false otherwise.
+            %        logical scalar
             %
-            % Returns - The proxy with the specified caching policy.
+            %   Output Arguments
+            %      r - The proxy with the specified caching policy.
+            %        proxy scalar with the same type as obj
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -567,11 +610,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_getEndpointSelection(obj)
-            % ice_getEndpointSelection - Returns how this proxy selects
-            %   endpoints (randomly or ordered).
+            %ICE_GETENDPOINTSELECTION Returns how this proxy selects endpoints (randomly or ordered).
             %
-            % Returns (Ice.EndpointSelectionType) - The endpoint selection
-            %   policy.
+            %   Output Arguments
+            %      r - The endpoint selection policy.
+            %        Ice.EndpointSelectionType scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -580,13 +623,16 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_endpointSelection(obj, t)
-            % ice_endpointSelection - Returns a proxy that is identical to
-            %   this proxy, except for the endpoint selection policy.
+            %ICE_ENDPOINTSELECTION Returns a proxy that is identical to this proxy, except for the endpoint
+            %   selection policy.
             %
-            % Parameters:
-            %   t (Ice.EndpointSelectionType) - The new endpoint selection policy.
+            %   Input Arguments
+            %      t - The new endpoint selection policy.
+            %        Ice.EndpointSelectionType scalar
             %
-            % Returns - The proxy with the specified endpoint selection policy.
+            %   Output Arguments
+            %      r - The proxy with the specified endpoint selection policy.
+            %        proxy scalar with the same type as obj
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -596,10 +642,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_getEncodingVersion(obj)
-            % ice_getEncodingVersion - Returns the encoding version used to
-            %   marshal requests parameters.
+            %ICE_GETENCODINGVERSION Returns the encoding version used to marshal requests parameters.
             %
-            % Returns (Ice.EncodingVersion) - The encoding version.
+            %   Output Arguments
+            %      r - The encoding version.
+            %        Ice.EncodingVersion scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -608,14 +655,16 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_encodingVersion(obj, ver)
-            % ice_encodingVersion - Returns a proxy that is identical to this
-            %   proxy, except for the encoding used to marshal parameters.
+            %ICE_ENCODINGVERSION Returns a proxy that is identical to this proxy, except for the encoding used to
+            %   marshal parameters.
             %
-            % Parameters:
-            %   ver (Ice.EncodingVersion) - The encoding version to use to
-            %   marshal request parameters.
+            %   Input Arguments
+            %      ver - The encoding version to use to marshal request parameters.
+            %        Ice.EncodingVersion scalar
             %
-            % Returns - The proxy with the specified encoding version.
+            %   Output Arguments
+            %      r - The proxy with the specified encoding version.
+            %        proxy scalar with the same type as obj
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -626,11 +675,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_getRouter(obj)
-            % ice_getRouter - Returns the router for this proxy.
+            %ICE_GETROUTER Returns the router for this proxy.
             %
-            % Returns (Ice.RouterPrx) - The router for the proxy. If no router
-            %   is configured for the proxy, the return value is an empty
-            %   array.
+            %   Output Arguments
+            %      r - The router for the proxy.
+            %        Ice.RouterPrx scalar | Ice.RouterPrx empty array
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -645,13 +694,15 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_router(obj, rtr)
-            % ice_router - Returns a proxy that is identical to this proxy,
-            %   except for the router.
+            %ICE_ROUTER Returns a proxy that is identical to this proxy, except for the router.
             %
-            % Parameters:
-            %   rtr (Ice.RouterPrx) - The router for the new proxy.
+            %   Input Arguments
+            %      rtr - The router for the new proxy.
+            %        Ice.RouterPrx scalar | Ice.RouterPrx empty array
             %
-            % Returns - The proxy with the specified router.
+            %   Output Arguments
+            %      r - The proxy with the specified router.
+            %        proxy scalar with the same type as obj
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -666,11 +717,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_getLocator(obj)
-            % ice_getLocator - Returns the locator for this proxy.
+            %ICE_GETLOCATOR Returns the locator for this proxy.
             %
-            % Returns (Ice.LocatorPrx) - The locator for the proxy. If no
-            %   locator is configured for the proxy, the return value is
-            %   an empty array.
+            %   Output Arguments
+            %      r - The locator for the proxy.
+            %        Ice.LocatorPrx scalar | Ice.LocatorPrx empty array
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -685,13 +736,15 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_locator(obj, loc)
-            % ice_locator - Returns a proxy that is identical to this proxy,
-            %   except for the locator.
+            %ICE_LOCATOR Returns a proxy that is identical to this proxy, except for the locator.
             %
-            % Parameters:
-            %   loc (Ice.LocatorPrx) - The locator for the new proxy.
+            %   Input Arguments
+            %      loc - The locator for the new proxy.
+            %        Ice.LocatorPrx scalar | Ice.LocatorPrx empty array
             %
-            % Returns - The proxy with the specified locator.
+            %   Output Arguments
+            %      r - The proxy with the specified locator.
+            %        proxy scalar with the same type as obj
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -706,11 +759,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_isSecure(obj)
-            % ice_isSecure - Returns whether this proxy uses only secure
-            %   endpoints.
+            %ICE_ISSECURE Returns whether this proxy uses only secure endpoints.
             %
-            % Returns (logical) - True if this proxy communicates only via
-            %   secure endpoints; false otherwise.
+            %   Output Arguments
+            %      r - True if this proxy communicates only via secure endpoints; false otherwise.
+            %        logical scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -719,15 +772,16 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_secure(obj, b)
-            % ice_secure - Returns a proxy that is identical to this proxy,
-            %   except for how it selects endpoints.
+            %ICE_SECURE Returns a proxy that is identical to this proxy, except for how it selects endpoints.
             %
-            % Parameters:
-            %   b (logical) - If b is true, only endpoints that use a secure
-            %     transport are used by the new proxy. If b is false, the
-            %     returned proxy uses both secure and insecure endpoints.
+            %   Input Arguments
+            %      b - If b is true, only endpoints that use a secure transport are used by the new proxy. If b is
+            %        false, the returned proxy uses both secure and insecure endpoints.
+            %        logical scalar
             %
-            % Returns - The proxy with the specified selection policy.
+            %   Output Arguments
+            %      r - The proxy with the specified selection policy.
+            %        proxy scalar with the same type as obj
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -742,12 +796,12 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_isPreferSecure(obj)
-            % ice_isPreferSecure - Returns whether this proxy prefers secure
-            %   endpoints.
+            %ICE_ISPREFERSECURE Returns whether this proxy prefers secure endpoints.
             %
-            % Returns (logical) - True if the proxy always attempts to invoke
-            %   via secure endpoints before it attempts to use insecure
-            %   endpoints; false otherwise.
+            %   Output Arguments
+            %      r - True if the proxy always attempts to invoke via secure endpoints before it attempts to use
+            %        insecure endpoints; false otherwise.
+            %        logical scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -756,17 +810,19 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_preferSecure(obj, b)
-            % ice_preferSecure - Returns a proxy that is identical to this
-            %   proxy, except for its endpoint selection policy.
+            %ICE_PREFERSECURE Returns a proxy that is identical to this proxy, except for its endpoint selection
+            %   policy.
             %
-            % Parameters:
-            %   b (logical) - If b is true, the new proxy will use secure
-            %     endpoints for invocations and only use insecure endpoints
-            %     if an invocation cannot be made via secure endpoints.
-            %     If b is false, the proxy prefers insecure endpoints to
-            %     secure ones.
+            %   Input Arguments
+            %      b - If b is true, the new proxy will use secure endpoints for invocations and only use insecure
+            %        endpoints if an invocation cannot be made via secure endpoints. If b is false, the proxy prefers
+            %        insecure endpoints to secure ones.
+            %        logical scalar
+
             %
-            % Returns - The proxy with the specified selection policy.
+            %   Output Arguments
+            %      r - The proxy with the specified selection policy.
+            %        proxy scalar with the same type as obj
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -781,10 +837,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_isTwoway(obj)
-            % ice_isTwoway - Returns whether this proxy uses twoway invocations.
+            %ICE_ISTWOWAY Returns whether this proxy uses twoway invocations.
             %
-            % Returns (logical) - True if this proxy uses twoway invocations;
-            %   false otherwise.
+            %   Output Arguments
+            %     r - True if this proxy uses twoway invocations; false otherwise.
+            %       logical scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -793,10 +850,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_twoway(obj)
-            % ice_twoway - Returns a proxy that is identical to this proxy,
-            %   but uses twoway invocations.
+            %ICE_TWOWAY Returns a proxy that is identical to this proxy, but uses twoway invocations.
             %
-            % Returns - A proxy that uses twoway invocations.
+            %   Output Arguments
+            %     r - A proxy that uses twoway invocations.
+            %       proxy scalar with the same type as obj
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -805,10 +863,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_isOneway(obj)
-            % ice_isOneway - Returns whether this proxy uses oneway invocations.
+            %ICE_ISONEWAY Returns whether this proxy uses oneway invocations.
             %
-            % Returns (logical) - True if this proxy uses oneway invocations;
-            %   false otherwise.
+            %   Output Arguments
+            %     r - True if this proxy uses oneway invocations; false otherwise.
+            %       logical scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -817,10 +876,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_oneway(obj)
-            % ice_oneway - Returns a proxy that is identical to this proxy,
-            %   but uses oneway invocations.
+            %ICE_ONEWAY Returns a proxy that is identical to this proxy, but uses oneway invocations.
             %
-            % Returns - A proxy that uses oneway invocations.
+            %   Output Arguments
+            %     r - A proxy that uses oneway invocations.
+            %       proxy scalar with the same type as obj
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -829,20 +889,24 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_isBatchOneway(obj)
-            % ice_isBatchOneway - Returns whether this proxy uses batch oneway
-            %   invocations.
+            %ICE_ISBATCHONEWAY Returns whether this proxy uses batch oneway invocations.
             %
-            % Returns (logical) - True if this proxy uses batch oneway
-            %   invocations; false otherwise.
+            %   Output Arguments
+            %     r - True if this proxy uses batch oneway invocations; false otherwise.
+            %       logical scalar
 
+            arguments
+                obj (1, 1) Ice.ObjectPrx
+            end
             r = obj.iceCallWithResult('ice_isBatchOneway');
         end
 
         function r = ice_batchOneway(obj)
-            % ice_batchOneway - Returns a proxy that is identical to this
-            %   proxy, but uses batch oneway invocations.
+            %ICE_BATCHONEWAY Returns a proxy that is identical to this proxy, but uses batch oneway invocations.
             %
-            % Returns - A new proxy that uses batch oneway invocations.
+            %   Output Arguments
+            %     r - A new proxy that uses batch oneway invocations.
+            %       proxy scalar with the same type as obj
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -851,11 +915,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_isDatagram(obj)
-            % ice_isDatagram - Returns whether this proxy uses datagram
-            %   invocations.
+            %ICE_ISDATAGRAM Returns whether this proxy uses datagram invocations.
             %
-            % Returns (logical) - True if this proxy uses datagram invocations;
-            %   false otherwise.
+            %   Output Arguments
+            %     r - True if this proxy uses datagram invocations; false otherwise.
+            %       logical scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -864,10 +928,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_datagram(obj)
-            % ice_datagram - Returns a proxy that is identical to this proxy,
-            %   but uses datagram invocations.
+            %ICE_DATAGRAM Returns a proxy that is identical to this proxy, but uses datagram invocations.
             %
-            % Returns - A new proxy that uses datagram invocations.
+            %   Output Arguments
+            %     r - A new proxy that uses datagram invocations.
+            %       proxy scalar with the same type as obj
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -876,11 +941,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_isBatchDatagram(obj)
-            % ice_isBatchDatagram - Returns whether this proxy uses batch
-            %   datagram invocations.
+            %ICE_ISBATCHDATAGRAM Returns whether this proxy uses batch datagram invocations.
             %
-            % Returns (logical) - True if this proxy uses batch datagram
-            %   invocations; false otherwise.
+            %   Output Arguments
+            %     r - True if this proxy uses batch datagram invocations; false otherwise.
+            %       logical scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -889,10 +954,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_batchDatagram(obj)
-            % ice_batchDatagram - Returns a proxy that is identical to this
-            %   proxy, but uses batch datagram invocations.
+            %ICE_BATCHDATAGRAM Returns a proxy that is identical to this proxy, but uses batch datagram invocations.
             %
-            % Returns - A new proxy that uses batch datagram invocations.
+            %   Output Arguments
+            %     r - A new proxy that uses batch datagram invocations.
+            %       proxy scalar with the same type as obj
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -901,14 +967,15 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_compress(obj, b)
-            % ice_compress - Returns a proxy that is identical to this proxy,
-            %   except for compression.
+            %ICE_COMPRESS Returns a proxy that is identical to this proxy, except for compression.
             %
-            % Parameters:
-            %   b (logical) - True enables compression for the new proxy;
-            %     false disables compression.
+            %   Input Arguments
+            %     b - True enables compression for the new proxy; false disables compression.
+            %       logical scalar
             %
-            % Returns - A proxy with the specified compression override setting.
+            %   Output Arguments
+            %     r - A proxy with the specified compression override setting.
+            %       proxy scalar with the same type as obj
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -923,11 +990,12 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_getCompress(obj)
-            % ice_getCompress - Obtains the compression override setting of this proxy.
+            %ICE_GETCOMPRESS Obtains the compression override setting of this proxy.
             %
-            % Returns (optional bool) - The compression override setting. If Ice.Unset
-            %   is returned, no override is set. Otherwise, true if compression is
-            %   enabled, false otherwise.
+            %   Output Arguments
+            %     r - The compression override setting. If Ice.Unset is returned, no override is set. Otherwise,
+            %       true if compression is enabled, false otherwise.
+            %       logical scalar | Ice.Unset scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -941,13 +1009,16 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_fixed(obj, connection)
-            % ice_fixed - Obtains a proxy that is identical to this proxy, except it's
-            %   a fixed proxy bound to the given connection.
+            %ICE_FIXED Obtains a proxy that is identical to this proxy, except it's a fixed proxy bound to the
+            %   given connection.
             %
-            % Parameters:
-            %   connection (Ice.Connection) - The fixed proxy connection.
+            %   Input Arguments
+            %     connection - The fixed proxy connection.
+            %       Ice.Connection scalar
             %
-            % Returns (Ice.ObjectPrx) - A fixed proxy bound to the given connection.
+            %   Output Arguments
+            %     r - A fixed proxy bound to the given connection.
+            %       proxy scalar with the same type as obj
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -957,9 +1028,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_isFixed(obj)
-            % ice_isFixed - Determines whether this proxy is a fixed proxy.
+            %ICE_ISFIXED Determines whether this proxy is a fixed proxy.
             %
-            % Returns (logical) - True if this proxy is a fixed proxy, false otherwise.
+            %   Output Arguments
+            %     r - True if this proxy is a fixed proxy, false otherwise.
+            %       logical scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -968,11 +1041,12 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_getConnection(obj)
-            % ice_getConnection - Returns the Connection for this proxy. If the
-            %   proxy does not yet have an established connection, it first
-            %   attempts to create a connection.
+            %ICE_GETCONNECTION Returns the Connection for this proxy. If the proxy does not yet have an
+            %   established connection, it first attempts to create a connection.
             %
-            % Returns (Ice.Connection) - The Connection for this proxy.
+            %   Output Arguments
+            %     r - The Connection for this proxy.
+            %       Ice.Connection scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -987,12 +1061,12 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_getConnectionAsync(obj)
-            % ice_getConnectionAsync - Returns the Connection for this proxy.
-            %   If the proxy does not yet have an established connection, it
-            %   first attempts to create a connection.
+            %ICE_GETCONNECTIONASYNC Returns the Connection for this proxy.
+            %   If the proxy does not yet have an established connection, it first attempts to create a connection.
             %
-            % Returns (Ice.Future) - A future that will be completed when the
-            %   invocation completes.
+            %   Output Arguments
+            %     r - A future that will be completed when the invocation completes.
+            %       Ice.Future scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -1010,13 +1084,13 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_getCachedConnection(obj)
-            % ice_getCachedConnection - Returns the cached Connection for this
-            %   proxy. If the proxy does not yet have an established
-            %   connection, it does not attempt to create a connection.
+            %ICE_GETCACHEDCONNECTION Returns the cached Connection for this proxy.
+            %   If the proxy does not yet have an established connection, it does not attempt to create a connection.
             %
-            % Returns (Ice.Connection) - The cached Connection for this proxy,
-            %   or an empty array if the proxy does not have an established
-            %   connection.
+            %   Output Arguments
+            %     r - The cached Connection for this proxy, or an empty array if the proxy does not have a cached
+            %       connection.
+            %       Ice.Connection scalar | Ice.Connection empty array
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -1031,8 +1105,8 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function ice_flushBatchRequests(obj)
-            % ice_flushBatchRequests - Flushes any pending batched requests for
-            %   this communicator. The call blocks until the flush is complete.
+            %ICE_FLUSHBATCHREQUESTS Flushes any pending batched requests for this communicator.
+            %   The call blocks until the flush is complete.
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -1041,11 +1115,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_flushBatchRequestsAsync(obj)
-            % ice_flushBatchRequestsAsync - Flushes asynchronously any pending batched
-            %   requests for this communicator.
+            %ICE_FLUSHBATCHREQUESTSASYNC Flushes asynchronously any pending batched requests for this communicator.
             %
-            % Returns (Ice.Future) - A future that will be completed when the
-            %   invocation completes.
+            %   Output Arguments
+            %     r - A future that will be completed when the invocation completes.
+            %       Ice.Future scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -1184,7 +1258,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
             end
         end
 
-        function iceThrowUserException(~, is, varargin) % Varargs are user exception type names
+        function iceThrowUserException(~, is, varargin) % varargs are user exception type names
             try
                 is.startEncapsulation();
                 is.throwException();
@@ -1211,15 +1285,21 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = checkedCast(p, varargin)
-            % checkedCast   Contacts the remote server to verify that the object implements this type.
+            %CHECKEDCAST Contacts the remote server to check if the target object implements the pseudo-Slice interface
+            %   Ice::Object.
             %
-            % Parameters:
-            %   p - The proxy to be check.
-            %   facet - The desired facet (optional).
-            %   context - The request context (optional).
+            %   Input Arguments
+            %     p - The proxy to check.
+            %       Ice.ObjectPrx scalar | empty array of Ice.ObjectPrx
+            %     facet - The desired facet (optional).
+            %       character vector
+            %     context - The request context (optional).
+            %       dictionary(string, string) scalar
             %
-            % Returns (Ice.InitialPrx) - A proxy for this type, or an empty array if the object does not support this
-            %  type.
+            %   Output Arguments
+            %     r - An Ice.ObjectPrx scalar if the target object implements Slice interface
+            %       ::Ice::Object; otherwise, an empty array of Ice.ObjectPrx.
+            %
             arguments
                 p Ice.ObjectPrx {mustBeScalarOrEmpty}
             end
@@ -1230,13 +1310,17 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = uncheckedCast(p, varargin)
-            % uncheckedCast   Downcasts the given proxy to this type without contacting the remote server.
+            %UNCHECKEDCAST Creates an Ice.ObjectPrx from another proxy without any validation.
             %
-            % Parameters:
-            %   p - The proxy to be cast.
-            %   facet - The desired facet (optional).
+            %   Input Arguments
+            %     p - The source proxy.
+            %       Ice.ObjectPrx scalar | empty array of Ice.ObjectPrx
+            %     facet - The desired facet (optional).
+            %       character vector
             %
-            % Returns (Test.InitialPrx) - A proxy for this type.
+            %   Output Arguments
+            %     r - A new Ice.ObjectPrx scalar, or an empty array when p is an empty array.
+            %
             arguments
                 p Ice.ObjectPrx {mustBeScalarOrEmpty}
             end

--- a/matlab/lib/+Ice/ObjectPrx.m
+++ b/matlab/lib/+Ice/ObjectPrx.m
@@ -1,112 +1,15 @@
 classdef ObjectPrx < IceInternal.WrapperObject
-    % ObjectPrx   Summary of ObjectPrx
+    %OBJECTPRX The base class for all Ice proxies.
     %
-    % Base interface of all object proxies.
+    %   Creation
+    %     Syntax
+    %       prx = Ice.ObjectPrx(communicator, proxyString)
     %
-    % ObjectPrx Methods:
-    %   ice_toString - Returns a stringified version of this proxy.
-    %   ice_getCommunicator - Returns the communicator that created this
-    %     proxy.
-    %   ice_ping - Tests whether the target object of this proxy can
-    %     be reached.
-    %   ice_pingAsync - Tests whether the target object of this proxy can
-    %     be reached.
-    %   ice_isA - Tests whether this object supports a specific
-    %     Slice interface.
-    %   ice_isAAsync - Tests whether this object supports a specific
-    %     Slice interface.
-    %   ice_id - Returns the Slice type ID of the most-derived interface
-    %     supported by the target object of this proxy.
-    %   ice_idAsync - Returns the Slice type ID of the most-derived
-    %     interface supported by the target object of this proxy.
-    %   ice_ids - Returns the Slice type IDs of the interfaces supported
-    %     by the target object of this proxy.
-    %   ice_idsAsync - Returns the Slice type IDs of the interfaces
-    %     supported by the target object of this proxy.
-    %   ice_getIdentity - Returns the identity embedded in this proxy.
-    %   ice_identity - Returns a proxy that is identical to this proxy,
-    %     except for the identity.
-    %   ice_getContext - Returns the per-proxy context for this proxy.
-    %   ice_context - Returns a proxy that is identical to this proxy,
-    %     except for the per-proxy context.
-    %   ice_getFacet - Returns the facet for this proxy.
-    %   ice_facet - Returns a proxy that is identical to this proxy,
-    %     except for the facet.
-    %   ice_getAdapter - Returns the adapter ID for this proxy.
-    %   ice_adapterId - Returns a proxy that is identical to this proxy,
-    %     except for the adapter ID.
-    %   ice_getEndpoints - Returns the endpoints used by this proxy.
-    %   ice_endpoints - Returns a proxy that is identical to this proxy,
-    %     except for the endpoints.
-    %   ice_getLocatorCacheTimeout - Returns the locator cache timeout
-    %     of this proxy.
-    %   ice_locatorCacheTimeout - Returns a proxy that is identical to
-    %     this proxy, except for the locator cache timeout.
-    %   ice_getInvocationTimeout - Returns the invocation timeout of
-    %     this proxy.
-    %   ice_invocationTimeout - Returns a proxy that is identical to
-    %     this proxy, except for the invocation timeout.
-    %   ice_getConnectionId - Returns the connection id of this proxy.
-    %   ice_connectionId - Returns a proxy that is identical to this
-    %     proxy, except for its connection ID.
-    %   ice_isConnectionCached - Returns whether this proxy caches
-    %     connections.
-    %   ice_connectionCached - Returns a proxy that is identical to this
-    %     proxy, except for connection caching.
-    %   ice_getEndpointSelection - Returns how this proxy selects
-    %     endpoints (randomly or ordered).
-    %   ice_endpointSelection - Returns a proxy that is identical to
-    %     this proxy, except for the endpoint selection policy.
-    %   ice_getEncodingVersion - Returns the encoding version used to
-    %     marshal requests parameters.
-    %   ice_encodingVersion - Returns a proxy that is identical to this
-    %     proxy, except for the encoding used to marshal parameters.
-    %   ice_getRouter - Returns the router for this proxy.
-    %   ice_router - Returns a proxy that is identical to this proxy,
-    %     except for the router.
-    %   ice_getLocator - Returns the locator for this proxy.
-    %   ice_locator - Returns a proxy that is identical to this proxy,
-    %     except for the locator.
-    %   ice_isSecure - Returns whether this proxy uses only secure
-    %     endpoints.
-    %   ice_secure - Returns a proxy that is identical to this proxy,
-    %     except for how it selects endpoints.
-    %   ice_isPreferSecure - Returns whether this proxy prefers secure
-    %     endpoints.
-    %   ice_preferSecure - Returns a proxy that is identical to this
-    %     proxy, except for its endpoint selection policy.
-    %   ice_isTwoway - Returns whether this proxy uses twoway invocations.
-    %   ice_twoway - Returns a proxy that is identical to this proxy,
-    %     but uses twoway invocations.
-    %   ice_isOneway - Returns whether this proxy uses oneway invocations.
-    %   ice_oneway - Returns a proxy that is identical to this proxy,
-    %     but uses oneway invocations.
-    %   ice_isBatchOneway - Returns whether this proxy uses batch oneway
-    %     invocations.
-    %   ice_batchOneway - Returns a proxy that is identical to this
-    %     proxy, but uses batch oneway invocations.
-    %   ice_isDatagram - Returns whether this proxy uses datagram
-    %     invocations.
-    %   ice_datagram - Returns a proxy that is identical to this proxy,
-    %     but uses datagram invocations.
-    %   ice_isBatchDatagram - Returns whether this proxy uses batch
-    %     datagram invocations.
-    %   ice_batchDatagram - Returns a proxy that is identical to this
-    %     proxy, but uses batch datagram invocations.
-    %   ice_compress - Returns a proxy that is identical to this proxy,
-    %     except for compression.
-    %   ice_getCompress - Obtains the compression override setting of this proxy.
-    %   ice_fixed - Obtains a proxy that is identical to this proxy, except it's
-    %     a fixed proxy bound to the given connection.
-    %   ice_isFixed - Returns whether this proxy is a fixed proxy.
-    %   ice_getConnection - Returns the Connection for this proxy.
-    %   ice_getConnectionAsync - Returns the Connection for this proxy.
-    %   ice_getCachedConnection - Returns the cached Connection for this
-    %     proxy.
-    %   ice_flushBatchRequests - Flushes any pending batched requests for
-    %     this communicator.
-    %   ice_flushBatchRequestsAsync - Flushes any pending batched
-    %     requests for this communicator.
+    %     Input Arguments
+    %       communicator - The associated communicator.
+    %         Ice.Communicator scalar
+    %       proxyString - A stringified proxy, such as 'name:tcp -p localhost -p 4061'.
+    %         character vector
 
     % Copyright (c) ZeroC, Inc.
 
@@ -122,7 +25,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
             %
             %   Output Arguments
             %     obj - The new Ice.ObjectPrx.
-            %
+
             if nargin == 0 % default constructor, typically called with multiple inheritance
                 superArgs = {};
             else
@@ -165,10 +68,9 @@ classdef ObjectPrx < IceInternal.WrapperObject
             % when using multiple inheritance.
         end
 
-        %
-        % Override == operator.
-        %
         function r = eq(obj, other)
+            %EQ Compares this proxy with another Ice.ObjectPrx for equality.
+            %   See also eq.
             if isempty(other) || ~isa(other, 'Ice.ObjectPrx')
                 r = false;
             else
@@ -180,9 +82,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_toString(obj)
-            % ice_toString - Returns a stringified version of this proxy.
+            %ICE_TOSTRING Creates a stringified version of this proxy.
             %
-            % Returns (char) - A stringified proxy.
+            %   Output Arguments
+            %     r - A stringified proxy.
+            %       character vector
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -191,9 +95,8 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function disp(obj)
-            % disp - Displays the stringified version of this proxy.
-            %
-            % This method is called when the object is displayed in the command window.
+            %DISP Displays this proxy as a string.
+            %   This method is called when the object is displayed in the command window.
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -202,11 +105,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = ice_getCommunicator(obj)
-            % ice_getCommunicator - Returns the communicator that created this
-            %   proxy.
+            %ICE_GETCOMMUNICATOR Gets the communicator that created this proxy.
             %
-            % Returns (Ice.Communicator) - The communicator that created this
-            %   proxy.
+            %   Output Arguments
+            %     r - The communicator that created this proxy.
+            %       Ice.Communicator scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
@@ -214,35 +117,38 @@ classdef ObjectPrx < IceInternal.WrapperObject
             r = obj.communicator;
         end
 
-        function ice_ping(obj, ctx)
-            % ice_ping - Tests whether the target object of this proxy can
-            %   be reached.
+        function ice_ping(obj, context)
+            %ICE_PING Tests whether the target object of this proxy can be reached.
             %
-            % Parameters:
-            %   context - Optional context map for the invocation.
+            %   Input Arguments
+            %     context - The request context.
+            %       unconfigured dictionary (default) | dictionary(string, string) scalar
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
-                ctx (1, 1) dictionary = dictionary
+                context (1, 1) dictionary = dictionary
             end
-            obj.iceInvoke('ice_ping', 2, false, [], false, {}, ctx);
+            obj.iceInvoke('ice_ping', 2, false, [], false, {}, context);
         end
 
-        function r = ice_pingAsync(obj, ctx)
-            % ice_pingAsync - Tests whether the target object of this proxy can
-            %   be reached.
+        function r = ice_pingAsync(obj, context)
+            %ICE_PINGASYNC Tests whether the target object of this proxy can be reached.
             %
-            % Parameters:
-            %   context - Optional context map for the invocation.
+            %   Input Arguments
+            %     context - The request context.
+            %       unconfigured dictionary (default) | dictionary(string, string) scalar
             %
-            % Returns (Ice.Future) - A future that will be completed when the
-            %   invocation completes.
+            %   Output Arguments
+            %     future - A future that will be completed with the result of the invocation.
+            %       Ice.Future scalar
+            %
+            %   See also ice_ping, Ice.Future.
 
             arguments
                 obj (1, 1) Ice.ObjectPrx
-                ctx (1, 1) dictionary = dictionary
+                context (1, 1) dictionary = dictionary
             end
-            r = obj.iceInvokeAsync('ice_ping', 2, false, [], 0, [], {}, ctx);
+            r = obj.iceInvokeAsync('ice_ping', 2, false, [], 0, [], {}, context);
         end
 
         function r = ice_isA(obj, id, ctx)

--- a/matlab/lib/+Ice/ObjectPrx.m
+++ b/matlab/lib/+Ice/ObjectPrx.m
@@ -10,6 +10,69 @@ classdef ObjectPrx < IceInternal.WrapperObject
     %         Ice.Communicator scalar
     %       proxyString - A stringified proxy, such as 'name:tcp -p localhost -p 4061'.
     %         character vector
+    %
+    %   ObjectPrx Methods:
+    %     disp - Displays this proxy as a string.
+    %     eq - Compares this proxy with another ObjectPrx for equality.
+    %     ice_adapterId - Returns a proxy that is identical to this proxy, except for the adapter ID.
+    %     ice_batchDatagram - Returns a proxy that is identical to this proxy, but uses batch datagram invocations.
+    %     ice_batchOneway - Returns a proxy that is identical to this proxy, but uses batch oneway invocations.
+    %     ice_compress - Returns a proxy that is identical to this proxy, except for compression.
+    %     ice_connectionCached - Returns a proxy that is identical to this proxy, except for connection caching.
+    %     ice_connectionId - Returns a proxy that is identical to this proxy, except for its connection ID.
+    %     ice_context - Returns a proxy that is identical to this proxy, except for the per-proxy context.
+    %     ice_datagram - Returns a proxy that is identical to this proxy, but uses datagram invocations.
+    %     ice_encodingVersion - Returns a proxy that is identical to this proxy, except for the encoding used to marshal parameters.
+    %     ice_endpointSelection - Returns a proxy that is identical to this proxy, except for the endpoint selection policy.
+    %     ice_endpoints - Returns a proxy that is identical to this proxy, except for the endpoints.
+    %     ice_facet - Returns a proxy that is identical to this proxy, except for the facet.
+    %     ice_fixed - Obtains a proxy that is identical to this proxy, except it's a fixed proxy bound to the given connection.
+    %     ice_flushBatchRequests - Flushes any pending batched requests for this communicator.
+    %     ice_flushBatchRequestsAsync - An asynchronous ice_flushBatchRequests.
+    %     ice_getAdapterId - Returns the adapter ID for this proxy.
+    %     ice_getCachedConnection - Returns the cached Connection for this proxy.
+    %     ice_getCommunicator - Gets the communicator that created this proxy.
+    %     ice_getCompress - Obtains the compression override setting of this proxy.
+    %     ice_getConnection - Returns the Connection for this proxy.
+    %     ice_getConnectionAsync - An asynchronous ice_getConnection.
+    %     ice_getConnectionId - Returns the connection id of this proxy.
+    %     ice_getContext - Returns the per-proxy context for this proxy.
+    %     ice_getEncodingVersion - Returns the encoding version used to marshal requests parameters.
+    %     ice_getEndpoints - Returns the endpoints used by this proxy.
+    %     ice_getEndpointSelection - Returns how this proxy selects endpoints (randomly or ordered).
+    %     ice_getFacet - Returns the facet for this proxy.
+    %     ice_getIdentity - Returns the identity embedded in this proxy.
+    %     ice_getInvocationTimeout - Returns the invocation timeout of this proxy.
+    %     ice_getLocator - Returns the locator for this proxy.
+    %     ice_getLocatorCacheTimeout - Returns the locator cache timeout of this proxy.
+    %     ice_getRouter - Returns the router for this proxy.
+    %     ice_id - Returns the Slice type ID of the most-derived interface supported by the target object of this proxy.
+    %     ice_idAsync - An asynchronous ice_id.
+    %     ice_identity - Returns a proxy that is identical to this proxy, except for the identity.
+    %     ice_ids - Returns the Slice type IDs of the interfaces supported by the target object of this proxy.
+    %     ice_idsAsync - Returns the Slice type IDs of the interfaces supported by the target object of this proxy.
+    %     ice_invocationTimeout - Returns a proxy that is identical to this proxy, except for the invocation timeout.
+    %     ice_isA - Tests whether this object supports a specific Slice interface.
+    %     ice_isAAsync - An asynchronous ice_isA.
+    %     ice_isBatchDatagram - Returns whether this proxy uses batch datagram invocations.
+    %     ice_isBatchOneway - Returns whether this proxy uses batch oneway invocations.
+    %     ice_isConnectionCached - Returns whether this proxy caches connections.
+    %     ice_isDatagram - Returns whether this proxy uses datagram invocations.
+    %     ice_isFixed - Determines whether this proxy is a fixed proxy.
+    %     ice_isOneway - Returns whether this proxy uses oneway invocations.
+    %     ice_isPreferSecure - Returns whether this proxy prefers secure endpoints.
+    %     ice_isSecure - Returns whether this proxy uses only secure endpoints.
+    %     ice_isTwoway - Returns whether this proxy uses twoway invocations.
+    %     ice_locator - Returns a proxy that is identical to this proxy, except for the locator.
+    %     ice_locatorCacheTimeout - Returns a proxy that is identical to this proxy, except for the locator cache timeout.
+    %     ice_oneway - Returns a proxy that is identical to this proxy, but uses oneway invocations.
+    %     ice_ping - Tests whether the target object of this proxy can be reached.
+    %     ice_pingAsync - An asynchronous ice_ping.
+    %     ice_preferSecure - Returns a proxy that is identical to this proxy, except for its endpoint selection policy.
+    %     ice_router - Returns a proxy that is identical to this proxy, except for the router.
+    %     ice_secure - Returns a proxy that is identical to this proxy, except for how it selects endpoints.
+    %     ice_toString - Creates a stringified version of this proxy.
+    %     ice_twoway - Returns a proxy that is identical to this proxy, but uses twoway invocations.
 
     % Copyright (c) ZeroC, Inc.
 
@@ -69,7 +132,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = eq(obj, other)
-            %EQ Compares this proxy with another Ice.ObjectPrx for equality.
+            %EQ Compares this proxy with another ObjectPrx for equality.
             %   See also eq.
             if isempty(other) || ~isa(other, 'Ice.ObjectPrx')
                 r = false;

--- a/matlab/lib/+Ice/ObjectPrx.m
+++ b/matlab/lib/+Ice/ObjectPrx.m
@@ -15,7 +15,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
 
     methods
         function obj = ObjectPrx(communicator, proxyString, impl, encoding)
-            % ObjectPrx - Constructs an Ice.ObjectPrx from a communicator and a proxy string.
+            %OBJECTPRX Constructs an Ice.ObjectPrx from a communicator and a proxy string.
             %
             %   Input Arguments
             %     communicator - The associated communicator.

--- a/matlab/lib/+Ice/ObjectPrx.m
+++ b/matlab/lib/+Ice/ObjectPrx.m
@@ -112,6 +112,17 @@ classdef ObjectPrx < IceInternal.WrapperObject
 
     methods
         function obj = ObjectPrx(communicator, proxyString, impl, encoding)
+            % ObjectPrx - Constructs an Ice.ObjectPrx from a communicator and a proxy string.
+            %
+            %   Input Arguments
+            %     communicator - The associated communicator.
+            %       Ice.Communicator scalar
+            %     proxyString - A stringified proxy, such as 'name:tcp -p localhost -p 4061'.
+            %       character vector
+            %
+            %   Output Arguments
+            %     obj - The new Ice.ObjectPrx.
+            %
             if nargin == 0 % default constructor, typically called with multiple inheritance
                 superArgs = {};
             else

--- a/matlab/lib/msbuild/ice.proj
+++ b/matlab/lib/msbuild/ice.proj
@@ -11,20 +11,7 @@
     </ItemDefinitionGroup>
 
     <ItemGroup>
-        <SliceCompile Include="..\..\..\slice\Ice\BuiltinSequences.ice" />
-        <SliceCompile Include="..\..\..\slice\Ice\Context.ice" />
-        <SliceCompile Include="..\..\..\slice\Ice\EndpointTypes.ice" />
-        <SliceCompile Include="..\..\..\slice\Ice\Identity.ice" />
-        <SliceCompile Include="..\..\..\slice\Ice\Locator.ice" />
-        <SliceCompile Include="..\..\..\slice\Ice\Metrics.ice" />
-        <SliceCompile Include="..\..\..\slice\Ice\OperationMode.ice" />
-        <SliceCompile Include="..\..\..\slice\Ice\Process.ice" />
-        <SliceCompile Include="..\..\..\slice\Ice\PropertiesAdmin.ice" />
-        <SliceCompile Include="..\..\..\slice\Ice\PropertyDict.ice" />
-        <SliceCompile Include="..\..\..\slice\Ice\RemoteLogger.ice" />
-        <SliceCompile Include="..\..\..\slice\Ice\ReplyStatus.ice" />
-        <SliceCompile Include="..\..\..\slice\Ice\Router.ice" />
-        <SliceCompile Include="..\..\..\slice\Ice\Version.ice" />
+        <SliceCompile Include="..\..\..\slice\Ice\*.ice" />
         <SliceCompile Include="..\..\..\slice\Glacier2\*.ice" />
         <SliceCompile Include="..\..\..\slice\IceStorm\*.ice" />
         <SliceCompile Include="..\..\..\slice\IceGrid\*.ice" />


### PR DESCRIPTION
This PR reworks the doc-comment generation by slice2matlab, in particular:

 - switch to the correct terminology (input arguments, output arguments)
 - always generate doc-comment, even when there is no doc-comment in the Slice files
