### PR TITLE
Add support for MATLAB 2025a

### DIFF
--- a/matlab/lib/+Ice/Communicator.m
+++ b/matlab/lib/+Ice/Communicator.m
@@ -84,7 +84,7 @@ classdef Communicator < IceInternal.WrapperObject
 
             enc = obj.getProperties().getProperty('Ice.Default.EncodingVersion');
             if isempty(enc)
-                obj.encoding = Ice.currentEncoding();
+                obj.encoding = IceInternal.Protocol.CurrentEncoding;
             else
                 arr = sscanf(enc, '%u.%u');
                 if length(arr) ~= 2

--- a/matlab/lib/+Ice/OutputStream.m
+++ b/matlab/lib/+Ice/OutputStream.m
@@ -8,7 +8,7 @@ classdef OutputStream < handle
     methods
         function obj = OutputStream(encoding, format)
             arguments
-                encoding (1, 1) Ice.EncodingVersion = Ice.currentEncoding();
+                encoding (1, 1) Ice.EncodingVersion = IceInternal.Protocol.CurrentEncoding;
                 format (1, 1) uint8 = Ice.FormatType.CompactFormat;
             end
             obj.encoding = encoding;

--- a/matlab/lib/+Ice/currentEncoding.m
+++ b/matlab/lib/+Ice/currentEncoding.m
@@ -1,9 +1,0 @@
-function r = currentEncoding()
-    % currentEncoding  Returns the supported Ice encoding version.
-    %
-    % Returns (Ice.EncodingVersion) - The Ice encoding version.
-
-    % Copyright (c) ZeroC, Inc.
-
-    r = IceInternal.Util.callWithResult('Ice_currentEncoding');
-end

--- a/matlab/lib/+Ice/currentProtocol.m
+++ b/matlab/lib/+Ice/currentProtocol.m
@@ -1,9 +1,0 @@
-function r = currentProtocol()
-    % currentProtocol  Returns the supported Ice protocol version.
-    %
-    % Returns (Ice.ProtocolVersion) - The supported Ice protocol version.
-
-    % Copyright (c) ZeroC, Inc.
-
-    r = IceInternal.Util.callWithResult('Ice_currentProtocol');
-end

--- a/matlab/lib/+Ice/currentProtocolEncoding.m
+++ b/matlab/lib/+Ice/currentProtocolEncoding.m
@@ -1,9 +1,0 @@
-function r = currentProtocolEncoding()
-    % currentProtocolEncoding  Returns the encoding version for the Ice protocol.
-    %
-    % Returns (Ice.EncodingVersion) - The encoding version for the Ice protocol.
-
-    % Copyright (c) ZeroC, Inc.
-
-    r = IceInternal.Util.callWithResult('Ice_currentProtocolEncoding');
-end

--- a/matlab/lib/+Ice/identityToString.m
+++ b/matlab/lib/+Ice/identityToString.m
@@ -14,5 +14,5 @@ function r = identityToString(id, mode)
         id (1, 1) Ice.Identity
         mode (1, 1) Ice.ToStringMode = Ice.ToStringMode.Unicode
     end
-    r = IceInternal.Util.callWithResult('Ice_identityToString', id, int32(mode));
+    r = IceInternal.Util.callWithResult('Ice_identityToString', id, mode);
 end

--- a/matlab/lib/+IceInternal/Protocol.m
+++ b/matlab/lib/+IceInternal/Protocol.m
@@ -14,5 +14,6 @@ classdef Protocol
 
         Encoding_1_0 = Ice.EncodingVersion(1, 0)
         Encoding_1_1 = Ice.EncodingVersion(1, 1)
+        CurrentEncoding = Ice.EncodingVersion(1, 1)
     end
 end

--- a/matlab/src/Communicator.cpp
+++ b/matlab/src/Communicator.cpp
@@ -16,13 +16,13 @@ extern "C"
     mxArray* Ice_Communicator_unref(void* self)
     {
         delete reinterpret_cast<shared_ptr<Ice::Communicator>*>(self);
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_Communicator_destroy(void* self)
     {
         deref<Ice::Communicator>(self)->destroy();
-        return 0;
+        return createEmptyArray();;
     }
 
     mxArray* Ice_Communicator_destroyAsync(void* self, void** future)
@@ -46,7 +46,7 @@ extern "C"
             });
         t.detach();
         *future = new shared_ptr<SimpleFuture>(move(f));
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_Communicator_stringToProxy(void* self, const char* s, void** proxy)
@@ -54,12 +54,12 @@ extern "C"
         try
         {
             *proxy = createProxy(deref<Ice::Communicator>(self)->stringToProxy(s));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Communicator_proxyToString(void* self, void* proxy)
@@ -81,12 +81,12 @@ extern "C"
         try
         {
             *proxy = createProxy(deref<Ice::Communicator>(self)->propertyToProxy(prop));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Communicator_proxyToProperty(void* self, void* proxy, const char* prop)
@@ -124,12 +124,12 @@ extern "C"
         {
             auto p = deref<Ice::Communicator>(self)->getImplicitContext();
             *ctx = createShared<Ice::ImplicitContext>(p);
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Communicator_getProperties(void* self, void** props)
@@ -138,12 +138,12 @@ extern "C"
         {
             auto p = deref<Ice::Communicator>(self)->getProperties();
             *props = new shared_ptr<Ice::Properties>(move(p));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Communicator_getLogger(void* self, void** logger)
@@ -152,12 +152,12 @@ extern "C"
         {
             auto l = deref<Ice::Communicator>(self)->getLogger();
             *logger = createShared<Ice::Logger>(l);
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Communicator_getDefaultRouter(void* self, void** proxy)
@@ -165,12 +165,12 @@ extern "C"
         try
         {
             *proxy = createProxy(deref<Ice::Communicator>(self)->getDefaultRouter());
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Communicator_setDefaultRouter(void* self, void* proxy)
@@ -179,12 +179,12 @@ extern "C"
         {
             optional<Ice::RouterPrx> p = Ice::uncheckedCast<Ice::RouterPrx>(restoreNullableProxy(proxy));
             deref<Ice::Communicator>(self)->setDefaultRouter(p);
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Communicator_getDefaultLocator(void* self, void** proxy)
@@ -192,12 +192,12 @@ extern "C"
         try
         {
             *proxy = createProxy(deref<Ice::Communicator>(self)->getDefaultLocator());
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Communicator_setDefaultLocator(void* self, void* proxy)
@@ -206,12 +206,12 @@ extern "C"
         {
             optional<Ice::LocatorPrx> p = Ice::uncheckedCast<Ice::LocatorPrx>(restoreNullableProxy(proxy));
             deref<Ice::Communicator>(self)->setDefaultLocator(p);
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Communicator_flushBatchRequests(void* self, mxArray* mode)
@@ -220,12 +220,12 @@ extern "C"
         {
             auto m = static_cast<Ice::CompressBatch>(getEnumerator(mode, "Ice.CompressBatch"));
             deref<Ice::Communicator>(self)->flushBatchRequests(m);
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Communicator_flushBatchRequestsAsync(void* self, mxArray* mode, void** future)
@@ -242,11 +242,11 @@ extern "C"
                 [f](bool /*sentSynchronously*/) { f->done(); });
             f->token(token);
             *future = new shared_ptr<SimpleFuture>(move(f));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 }

--- a/matlab/src/Communicator.cpp
+++ b/matlab/src/Communicator.cpp
@@ -22,7 +22,7 @@ extern "C"
     mxArray* Ice_Communicator_destroy(void* self)
     {
         deref<Ice::Communicator>(self)->destroy();
-        return createEmptyArray();;
+        return createEmptyArray();
     }
 
     mxArray* Ice_Communicator_destroyAsync(void* self, void** future)

--- a/matlab/src/Connection.cpp
+++ b/matlab/src/Connection.cpp
@@ -123,7 +123,7 @@ extern "C"
     mxArray* Ice_Connection_unref(void* self)
     {
         delete reinterpret_cast<shared_ptr<Ice::Connection>*>(self);
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_Connection_equals(void* self, void* other)
@@ -142,7 +142,7 @@ extern "C"
     mxArray* Ice_Connection_abort(void* self)
     {
         deref<Ice::Connection>(self)->abort();
-        return nullptr;
+        return createEmptyArray();
     }
 
     mxArray* Ice_Connection_close(void* self, void** future)
@@ -155,7 +155,7 @@ extern "C"
             [futurePtr](exception_ptr closeException) { futurePtr->exception(closeException); });
 
         *future = new shared_ptr<SimpleFuture>(move(futurePtr));
-        return nullptr;
+        return createEmptyArray();
     }
 
     mxArray* Ice_Connection_createProxy(void* self, mxArray* id, void** r)
@@ -166,12 +166,12 @@ extern "C"
             getIdentity(id, ident);
             Ice::ObjectPrx proxy = deref<Ice::Connection>(self)->createProxy(ident);
             *r = createProxy(std::move(proxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Connection_flushBatchRequests(void* self, mxArray* c)
@@ -180,12 +180,12 @@ extern "C"
         {
             auto mode = static_cast<Ice::CompressBatch>(getEnumerator(c, "Ice.CompressBatch"));
             deref<Ice::Connection>(self)->flushBatchRequests(mode);
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Connection_flushBatchRequestsAsync(void* self, mxArray* c, void** future)
@@ -202,12 +202,12 @@ extern "C"
                 [f](bool /*sentSynchronously*/) { f->done(); });
             f->token(token);
             *future = new shared_ptr<SimpleFuture>(move(f));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Connection_getEndpoint(void* self, void** endpoint)
@@ -215,12 +215,12 @@ extern "C"
         try
         {
             *endpoint = createShared<Ice::Endpoint>(deref<Ice::Connection>(self)->getEndpoint());
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Connection_type(void* self)
@@ -265,12 +265,12 @@ extern "C"
         try
         {
             deref<Ice::Connection>(self)->setBufferSize(rcvSize, sndSize);
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Connection_throwException(void* self)
@@ -278,11 +278,11 @@ extern "C"
         try
         {
             deref<Ice::Connection>(self)->throwException();
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 }

--- a/matlab/src/Endpoint.cpp
+++ b/matlab/src/Endpoint.cpp
@@ -119,7 +119,7 @@ extern "C"
     mxArray* Ice_Endpoint_unref(void* self)
     {
         delete reinterpret_cast<shared_ptr<Ice::Endpoint>*>(self);
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_Endpoint_equals(void* self, void* other)

--- a/matlab/src/Future.cpp
+++ b/matlab/src/Future.cpp
@@ -141,7 +141,7 @@ extern "C"
     mxArray* Ice_SimpleFuture_unref(void* self)
     {
         delete reinterpret_cast<shared_ptr<SimpleFuture>*>(self);
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_SimpleFuture_wait(void* self)
@@ -172,7 +172,7 @@ extern "C"
     mxArray* Ice_SimpleFuture_cancel(void* self)
     {
         deref<SimpleFuture>(self)->cancel();
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_SimpleFuture_check(void* self)
@@ -193,6 +193,6 @@ extern "C"
         //
         delete reinterpret_cast<shared_ptr<SimpleFuture>*>(self);
 
-        return 0;
+        return createEmptyArray();
     }
 }

--- a/matlab/src/ImplicitContext.cpp
+++ b/matlab/src/ImplicitContext.cpp
@@ -12,7 +12,7 @@ extern "C"
     mxArray* Ice_ImplicitContext_unref(void* self)
     {
         delete reinterpret_cast<shared_ptr<Ice::ImplicitContext>*>(self);
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_ImplicitContext_getContext(void* self)
@@ -36,12 +36,12 @@ extern "C"
             Ice::Context ctx;
             getContext(newContext, ctx);
             deref<Ice::ImplicitContext>(self)->setContext(ctx);
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ImplicitContext_containsKey(void* self, mxArray* key)

--- a/matlab/src/Init.cpp
+++ b/matlab/src/Init.cpp
@@ -97,15 +97,6 @@ extern "C"
         return 0;
     }
 
-    mxArray* Ice_currentEncoding() { return createResultValue(createEncodingVersion(Ice::currentEncoding)); }
-
-    mxArray* Ice_currentProtocol() { return createResultValue(createProtocolVersion(Ice::currentProtocol)); }
-
-    mxArray* Ice_currentProtocolEncoding()
-    {
-        return createResultValue(createEncodingVersion(Ice::currentProtocolEncoding));
-    }
-
     //
     // This function exists so that mex may be used to compile the library. It is not otherwise needed.
     //

--- a/matlab/src/Logger.cpp
+++ b/matlab/src/Logger.cpp
@@ -12,7 +12,7 @@ extern "C"
     mxArray* Ice_Logger_unref(void* self)
     {
         delete reinterpret_cast<shared_ptr<Ice::Logger>*>(self);
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_Logger_print(void* self, mxArray* message)
@@ -20,12 +20,12 @@ extern "C"
         try
         {
             deref<Ice::Logger>(self)->print(getStringFromUTF16(message));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Logger_trace(void* self, mxArray* category, mxArray* message)
@@ -33,12 +33,12 @@ extern "C"
         try
         {
             deref<Ice::Logger>(self)->trace(getStringFromUTF16(category), getStringFromUTF16(message));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Logger_warning(void* self, mxArray* message)
@@ -46,12 +46,12 @@ extern "C"
         try
         {
             deref<Ice::Logger>(self)->warning(getStringFromUTF16(message));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Logger_error(void* self, mxArray* message)
@@ -59,12 +59,12 @@ extern "C"
         try
         {
             deref<Ice::Logger>(self)->error(getStringFromUTF16(message));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Logger_getPrefix(void* self)
@@ -86,11 +86,11 @@ extern "C"
             auto logger = deref<Ice::Logger>(self);
             auto newLogger = logger->cloneWithPrefix(getStringFromUTF16(prefix));
             *r = newLogger == logger ? 0 : new shared_ptr<Ice::Logger>(move(newLogger));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 }

--- a/matlab/src/ObjectPrx.cpp
+++ b/matlab/src/ObjectPrx.cpp
@@ -152,7 +152,7 @@ extern "C"
     mxArray* Ice_ObjectPrx_unref(void* self)
     {
         delete reinterpret_cast<Ice::ObjectPrx*>(self);
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_ObjectPrx_equals(void* self, void* other)
@@ -186,12 +186,12 @@ extern "C"
             in.read(proxy);
             *r = createProxy(std::move(proxy)); // can return nullptr for a null proxy
             *bytesRead = static_cast<int>(in.pos());
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_write(void* proxy, void* communicator, mxArray* encoding)
@@ -256,7 +256,6 @@ extern "C"
         {
             return createResultException(convertException(std::current_exception()));
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_invokeAsync(
@@ -303,12 +302,12 @@ extern "C"
                 *ctxPtr);
             f->token(token);
             *future = new shared_ptr<InvocationFuture>(move(f));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_toString(void* self)
@@ -330,12 +329,12 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_identity(ident);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_getContext(void* self)
@@ -353,12 +352,12 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_context(ctx);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_getFacet(void* self)
@@ -373,12 +372,12 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_facet(f);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_getAdapterId(void* self)
@@ -393,12 +392,12 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_adapterId(id);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_getNumEndpoints(void* self)
@@ -423,18 +422,18 @@ extern "C"
                 throw std::invalid_argument("index outside range");
             }
             *r = createShared<Ice::Endpoint>(endpoints[idx]);
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_createEndpointList(void* /*self*/, unsigned int num, void** r)
     {
         *r = new vector<shared_ptr<Ice::Endpoint>>(num);
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_ObjectPrx_ice_setEndpoint(void* /*self*/, void* arr, unsigned int idx, void* e)
@@ -451,12 +450,12 @@ extern "C"
                 throw std::invalid_argument("index outside range");
             }
             (*v)[idx] = deref<Ice::Endpoint>(e);
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_endpoints(void* self, void** r, void* arr)
@@ -473,12 +472,12 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_endpoints(tmp);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_getLocatorCacheTimeout(void* self)
@@ -495,12 +494,12 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_locatorCacheTimeout(t);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_getInvocationTimeout(void* self)
@@ -516,12 +515,12 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_invocationTimeout(t);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_getConnectionId(void* self)
@@ -537,12 +536,12 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_connectionId(id);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_isConnectionCached(void* self)
@@ -557,12 +556,12 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_connectionCached(v == 1);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_getEndpointSelection(void* self)
@@ -585,12 +584,12 @@ extern "C"
             auto newProxy = proxy->ice_endpointSelection(
                 static_cast<Ice::EndpointSelectionType>(getEnumerator(type, "Ice.EndpointSelectionType")));
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_getEncodingVersion(void* self)
@@ -607,19 +606,19 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_encodingVersion(ev);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_getRouter(void* self, void** r)
     {
         auto router = restoreProxy(self)->ice_getRouter();
         *r = createProxy(std::move(router));
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_ObjectPrx_ice_router(void* self, void** r, void* rtr)
@@ -630,19 +629,19 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_router(Ice::uncheckedCast<Ice::RouterPrx>(router));
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_getLocator(void* self, void** r)
     {
         auto locator = restoreProxy(self)->ice_getLocator();
         *r = createProxy(std::move(locator));
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_ObjectPrx_ice_locator(void* self, void** r, void* loc)
@@ -653,12 +652,12 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_locator(Ice::uncheckedCast<Ice::LocatorPrx>(locator));
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_isSecure(void* self)
@@ -673,12 +672,12 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_secure(b == 1);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_isPreferSecure(void* self)
@@ -693,12 +692,12 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_preferSecure(b == 1);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_isTwoway(void* self)
@@ -713,12 +712,12 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_twoway();
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_isOneway(void* self)
@@ -733,12 +732,12 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_oneway();
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_isBatchOneway(void* self)
@@ -753,12 +752,12 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_batchOneway();
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_isDatagram(void* self)
@@ -773,12 +772,12 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_datagram();
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_isBatchDatagram(void* self)
@@ -793,12 +792,12 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_batchDatagram();
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_compress(void* self, void** r, unsigned char b)
@@ -808,12 +807,12 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_compress(b == 1);
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_getCompress(void* self)
@@ -837,12 +836,12 @@ extern "C"
             auto proxy = restoreProxy(self);
             auto newProxy = proxy->ice_fixed(deref<Ice::Connection>(connection));
             *r = newProxy == proxy ? nullptr : new Ice::ObjectPrx(std::move(newProxy));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_isFixed(void* self)
@@ -860,12 +859,12 @@ extern "C"
             {
                 *r = new shared_ptr<Ice::Connection>(move(conn));
             }
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_getConnectionAsync(void* self, void** future)
@@ -881,12 +880,12 @@ extern "C"
                 nullptr);
             f->token(token);
             *future = new shared_ptr<GetConnectionFuture>(move(f));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_getCachedConnection(void* self, void** r)
@@ -899,12 +898,12 @@ extern "C"
             {
                 *r = new shared_ptr<Ice::Connection>(move(conn));
             }
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_flushBatchRequests(void* self)
@@ -912,12 +911,12 @@ extern "C"
         try
         {
             restoreProxy(self)->ice_flushBatchRequests();
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_ice_flushBatchRequestsAsync(void* self, void** future)
@@ -932,30 +931,30 @@ extern "C"
                 [f](bool /*sentSynchronously*/) { f->done(); });
             f->token(token);
             *future = new shared_ptr<SimpleFuture>(move(f));
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_ObjectPrx_clone(void* self, void** r)
     {
         *r = createProxy(restoreProxy(self));
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_InvocationFuture_unref(void* self)
     {
         delete reinterpret_cast<shared_ptr<InvocationFuture>*>(self);
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_InvocationFuture_id(void* self, unsigned long long* id)
     {
         *id = reinterpret_cast<unsigned long long>(self);
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_InvocationFuture_wait(void* self)
@@ -1013,7 +1012,7 @@ extern "C"
     mxArray* Ice_InvocationFuture_cancel(void* self)
     {
         deref<InvocationFuture>(self)->cancel();
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_InvocationFuture_check(void* self)
@@ -1034,19 +1033,19 @@ extern "C"
         //
         delete reinterpret_cast<shared_ptr<InvocationFuture>*>(self);
 
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_GetConnectionFuture_unref(void* self)
     {
         delete reinterpret_cast<shared_ptr<GetConnectionFuture>*>(self);
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_GetConnectionFuture_id(void* self, unsigned long long* id)
     {
         *id = reinterpret_cast<unsigned long long>(self);
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_GetConnectionFuture_wait(void* self)
@@ -1089,7 +1088,7 @@ extern "C"
         //
         delete reinterpret_cast<shared_ptr<GetConnectionFuture>*>(self);
 
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_GetConnectionFuture_state(void* self)
@@ -1100,6 +1099,6 @@ extern "C"
     mxArray* Ice_GetConnectionFuture_cancel(void* self)
     {
         deref<GetConnectionFuture>(self)->cancel();
-        return 0;
+        return createEmptyArray();
     }
 }

--- a/matlab/src/Properties.cpp
+++ b/matlab/src/Properties.cpp
@@ -38,7 +38,7 @@ extern "C"
     mxArray* Ice_Properties_unref(void* self)
     {
         delete reinterpret_cast<shared_ptr<Ice::Properties>*>(self);
-        return 0;
+        return createEmptyArray();
     }
 
     mxArray* Ice_Properties_getProperty(void* self, const char* key)
@@ -83,12 +83,12 @@ extern "C"
         try
         {
             *r = deref<Ice::Properties>(self)->getPropertyAsInt(key);
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Properties_getIcePropertyAsInt(void* self, const char* key, int* r)
@@ -96,12 +96,12 @@ extern "C"
         try
         {
             *r = deref<Ice::Properties>(self)->getIcePropertyAsInt(key);
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Properties_getPropertyAsIntWithDefault(void* self, const char* key, int dflt, int* r)
@@ -109,12 +109,12 @@ extern "C"
         try
         {
             *r = deref<Ice::Properties>(self)->getPropertyAsIntWithDefault(key, dflt);
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Properties_getPropertyAsList(void* self, const char* key)
@@ -176,12 +176,12 @@ extern "C"
         try
         {
             deref<Ice::Properties>(self)->setProperty(key, value);
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Properties_getCommandLineOptions(void* self)
@@ -232,12 +232,12 @@ extern "C"
         try
         {
             deref<Ice::Properties>(self)->load(file);
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 
     mxArray* Ice_Properties_clone(void* self, void** r)
@@ -245,11 +245,11 @@ extern "C"
         try
         {
             *r = new shared_ptr<Ice::Properties>(deref<Ice::Properties>(self)->clone());
+            return createEmptyArray();
         }
         catch (...)
         {
             return convertException(std::current_exception());
         }
-        return 0;
     }
 }

--- a/matlab/src/Util.cpp
+++ b/matlab/src/Util.cpp
@@ -120,6 +120,7 @@ IceMatlab::getEnumerator(mxArray* p, const string& type)
     mxArray* i;
     mexCallMATLAB(1, &i, 1, &p, "int32");
     int r = static_cast<int>(mxGetScalar(i));
+
     mxDestroyArray(i);
     return r;
 }

--- a/matlab/src/Util.h
+++ b/matlab/src/Util.h
@@ -5,6 +5,9 @@
 
 namespace IceMatlab
 {
+    // We return an empty mxArray to signal success when calling a "void" function with calllib.
+    inline mxArray* createEmptyArray() { return mxCreateDoubleMatrix(0, 0, mxREAL); }
+
     mxArray* createStringFromUTF8(const std::string&);
     std::string getStringFromUTF16(mxArray*);
     mxArray* createBool(bool);

--- a/matlab/src/ice.h
+++ b/matlab/src/ice.h
@@ -29,9 +29,6 @@ extern "C"
     ICE_MATLAB_API mxArray* Ice_identityToString(mxArray*, mxArray*);
     ICE_MATLAB_API mxArray* Ice_stringVersion();
     ICE_MATLAB_API mxArray* Ice_intVersion(int*);
-    ICE_MATLAB_API mxArray* Ice_currentEncoding();
-    ICE_MATLAB_API mxArray* Ice_currentProtocol();
-    ICE_MATLAB_API mxArray* Ice_currentProtocolEncoding();
 
     ICE_MATLAB_API mxArray* Ice_Communicator_unref(void*);
     ICE_MATLAB_API mxArray* Ice_Communicator_destroy(void*);

--- a/matlab/test/Ice/objects/Client.m
+++ b/matlab/test/Ice/objects/Client.m
@@ -10,7 +10,7 @@ function client(args)
 
     % We need to use the ClassSliceLoader for the classes with compact IDs. Naturally, it also works for classes
     % without a compact ID.
-    properties = Ice.Properties(args)
+    properties = Ice.Properties(args);
     properties.setProperty('Ice.Warn.Connections', '0');
 
     sliceLoader = Ice.CompositeSliceLoader(CustomSliceLoader(), ...

--- a/matlab/test/Ice/proxy/AllTests.m
+++ b/matlab/test/Ice/proxy/AllTests.m
@@ -367,7 +367,6 @@ classdef AllTests
 
             assert(strcmp(communicator.identityToString(base.ice_identity(Ice.stringToIdentity('other')).ice_getIdentity()), 'other'));
 
-
             % Verify that ToStringMode is passed correctly
             %
             % Testing bytes 127 (\x7F) and €

--- a/matlab/test/Ice/proxy/AllTests.m
+++ b/matlab/test/Ice/proxy/AllTests.m
@@ -367,33 +367,31 @@ classdef AllTests
 
             assert(strcmp(communicator.identityToString(base.ice_identity(Ice.stringToIdentity('other')).ice_getIdentity()), 'other'));
 
-            %{
-            % TODO
-            %
+
             % Verify that ToStringMode is passed correctly
             %
-            euroStr = sprintf('\x7F\xE2\x82\xAC');
+            % Testing bytes 127 (\x7F) and €
+            euroStr = char([0x007F, 0x20AC]);
             ident = Ice.Identity('test', euroStr);
 
             idStr = Ice.identityToString(ident, Ice.ToStringMode.Unicode);
-            assert(strcmp(idStr, sprintf('\x007f\xe2\x82\xac/test')));
+            assert(strcmp(idStr, sprintf('\\u007f\x20ac/test')));
             ident2 = Ice.stringToIdentity(idStr);
             assert(ident == ident2);
             assert(strcmp(Ice.identityToString(ident), idStr));
 
-            idStr = Ice.identityToString(ident, Ice.ToStringMode.ASCII)
-            assert(idStr == "\\u007f\\u20ac/test")
-            ident2 = Ice.stringToIdentity(idStr)
-            assert(ident == ident2)
+            idStr = Ice.identityToString(ident, Ice.ToStringMode.ASCII);
+            assert(strcmp(idStr, sprintf('\\u007f\\u20ac/test')));
+            ident2 = Ice.stringToIdentity(idStr);
+            assert(ident == ident2);
 
-            idStr = Ice.identityToString(ident, Ice.ToStringMode.Compat)
-            assert(idStr == "\\177\\342\\202\\254/test")
-            ident2 = Ice.stringToIdentity(idStr)
-            assert(ident == ident2)
+            idStr = Ice.identityToString(ident, Ice.ToStringMode.Compat);
+            assert(strcmp(idStr, '\177\342\202\254/test'));
+            ident2 = Ice.stringToIdentity(idStr);
+            assert(ident == ident2);
 
-            ident2 = Ice.stringToIdentity(communicator.identityToString(ident))
-            assert(ident == ident2)
-            %}
+            ident2 = Ice.stringToIdentity(communicator.identityToString(ident));
+            assert(ident == ident2);
 
             assert(strcmp(base.ice_facet('facet').ice_getFacet(), 'facet'));
             assert(strcmp(base.ice_adapterId('id').ice_getAdapterId(), 'id'));


### PR DESCRIPTION
This PR updates the source code to support MATLAB 2025a.

Previously, we were returning a 0/nullptr `mxArray*` to mean "success", but this no longer works. So I replaced all these `return 0` by `return createEmptyArray()`.

This PR also removes a few function / constants that should be never used.