### PR TITLE
Fix Over-Tolerant Parsing of Doc-Comment Tags

### DIFF
--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.err
@@ -4,25 +4,28 @@ WarningInvalidComment.ice:11: warning: the '@exception' tag is only valid on ope
 WarningInvalidComment.ice:11: warning: the '@return' tag is only valid on operations
 WarningInvalidComment.ice:15: warning: missing link target after '@see' tag
 WarningInvalidComment.ice:17: warning: ignoring trailing '.' character in '@see' tag
-WarningInvalidComment.ice:40: warning: '@param NoParam' does not correspond to any parameter in operation 'voidOp'
-WarningInvalidComment.ice:40: warning: '@return' is only valid on operations with non-void return types
-WarningInvalidComment.ice:40: warning: '@throws FakeException': no exception with this name could be found from the current scope
-WarningInvalidComment.ice:40: warning: '@throws CommentDummy': this exception is not listed in nor derived from any exception in this operation's specification
-WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@param value'
-WarningInvalidComment.ice:51: warning: '@param namess' does not correspond to any parameter in operation 'stringOp'
-WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@return'
-WarningInvalidComment.ice:51: warning: '@throws SomeOtherException': this exception is not listed in nor derived from any exception in this operation's specification
-WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@throws CommentDummy'
-WarningInvalidComment.ice:26: warning: ignoring unknown doc tag '@something' in comment
-WarningInvalidComment.ice:26: warning: '@see' tags cannot span multiple lines and must be of the form: '@see identifier'
-WarningInvalidComment.ice:26: warning: ignoring unknown doc tag '@bad' in comment
-WarningInvalidComment.ice:30: warning: ignoring duplicate doc-comment tag: '@deprecated'
-WarningInvalidComment.ice:40: warning: '@param NoParam' does not correspond to any parameter in operation 'voidOp'
-WarningInvalidComment.ice:40: warning: '@return' is only valid on operations with non-void return types
-WarningInvalidComment.ice:40: warning: '@throws FakeException': no exception with this name could be found from the current scope
-WarningInvalidComment.ice:40: warning: '@throws CommentDummy': this exception is not listed in nor derived from any exception in this operation's specification
-WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@param value'
-WarningInvalidComment.ice:51: warning: '@param namess' does not correspond to any parameter in operation 'stringOp'
-WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@return'
-WarningInvalidComment.ice:51: warning: '@throws SomeOtherException': this exception is not listed in nor derived from any exception in this operation's specification
-WarningInvalidComment.ice:51: warning: ignoring duplicate doc-comment tag: '@throws CommentDummy'
+WarningInvalidComment.ice:43: warning: '@param NoParam' does not correspond to any parameter in operation 'voidOp'
+WarningInvalidComment.ice:43: warning: '@return' is only valid on operations with non-void return types
+WarningInvalidComment.ice:43: warning: '@throws FakeException': no exception with this name could be found from the current scope
+WarningInvalidComment.ice:43: warning: '@throws CommentDummy': this exception is not listed in nor derived from any exception in this operation's specification
+WarningInvalidComment.ice:54: warning: ignoring duplicate doc-comment tag: '@param value'
+WarningInvalidComment.ice:54: warning: '@param namess' does not correspond to any parameter in operation 'stringOp'
+WarningInvalidComment.ice:54: warning: ignoring duplicate doc-comment tag: '@return'
+WarningInvalidComment.ice:54: warning: '@throws SomeOtherException': this exception is not listed in nor derived from any exception in this operation's specification
+WarningInvalidComment.ice:54: warning: ignoring duplicate doc-comment tag: '@throws CommentDummy'
+WarningInvalidComment.ice:29: warning: ignoring unknown doc tag '@something' in comment
+WarningInvalidComment.ice:29: warning: ignoring unknown doc tag '@params' in comment
+WarningInvalidComment.ice:29: warning: ignoring unknown doc tag '@throwss' in comment
+WarningInvalidComment.ice:29: warning: ignoring unknown doc tag '@deprecated:' in comment
+WarningInvalidComment.ice:29: warning: '@see' tags cannot span multiple lines and must be of the form: '@see identifier'
+WarningInvalidComment.ice:29: warning: ignoring unknown doc tag '@bad' in comment
+WarningInvalidComment.ice:33: warning: ignoring duplicate doc-comment tag: '@deprecated'
+WarningInvalidComment.ice:43: warning: '@param NoParam' does not correspond to any parameter in operation 'voidOp'
+WarningInvalidComment.ice:43: warning: '@return' is only valid on operations with non-void return types
+WarningInvalidComment.ice:43: warning: '@throws FakeException': no exception with this name could be found from the current scope
+WarningInvalidComment.ice:43: warning: '@throws CommentDummy': this exception is not listed in nor derived from any exception in this operation's specification
+WarningInvalidComment.ice:54: warning: ignoring duplicate doc-comment tag: '@param value'
+WarningInvalidComment.ice:54: warning: '@param namess' does not correspond to any parameter in operation 'stringOp'
+WarningInvalidComment.ice:54: warning: ignoring duplicate doc-comment tag: '@return'
+WarningInvalidComment.ice:54: warning: '@throws SomeOtherException': this exception is not listed in nor derived from any exception in this operation's specification
+WarningInvalidComment.ice:54: warning: ignoring duplicate doc-comment tag: '@throws CommentDummy'

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.ice
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.ice
@@ -18,11 +18,14 @@ module Test
     }
 
     /// This is a test overview.
-    /// @something: This is an unknown comment tag which spans 1 line.
-    /// @see: CommentDummy
-    ///       But then we write a 2nd line, which isn't allowed for 'see' tags.
-    /// @bad: Another unknown comment tag, but this will span 2 lines.
-    ///       This 2nd line should be ignored, but won't trigger another error.
+    /// @something This is an unknown comment tag which spans 1 line.
+    /// @params This is an unknown comment tag, even though it starts with a known tag,
+    ///     @throwss     Another unknown comment tag, which starts with a known tag.
+    /// @deprecated: comment tags must be followed by whitespace, not colons.
+    /// @see CommentDummy
+    ///      But then we write a 2nd line, which isn't allowed for 'see' tags.
+    /// @bad Another unknown comment tag, but this will span 2 lines.
+    ///      This 2nd line should be ignored, but won't trigger another error.
     exception CommentDummy {}
 
     /// @deprecated Message1


### PR DESCRIPTION
This PR fixes #4129, which was caused by the parser not checking the _end_ of a doc-comment tag.
All we checked was basically `text.find("@param") == 0`, which will match `@param`, but also `@paramdghkjdgf`.
Not great.

This PR updates the parser to enforce that the character after a tag must be whitespace or a line-break.