### PR TITLE
Add Support for `@remarks` Tag to `slice2swift`

### DIFF
--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -107,7 +107,7 @@ namespace
 
         if (needsNewline)
         {
-            out << nl;
+            out << nl << "///";
         }
         out << nl << "/// ## Remarks";
         writeDocLines(out, remarks);

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -32,11 +32,6 @@ namespace Slice
         static void validateSwiftModuleMappings(const UnitPtr&);
 
     protected:
-        void writeDocLines(
-            IceInternal::Output&,
-            const StringList&,
-            bool commentFirst = true,
-            const std::string& space = " ");
         void writeDocSummary(IceInternal::Output&, const ContainedPtr&);
         void writeOpDocSummary(IceInternal::Output&, const OperationPtr&, bool);
 


### PR DESCRIPTION
This PR adds support for `@remarks`, and also refactors some existing doc-gen code to be a little cleaner.
Like the other languages, we always generate `Remarks` at the end of the doc-comment.

This is what the rendered documentation looks like:

----

For a mapped dictionary type-alias:
<img width="922" alt="Screenshot 2025-06-23 at 13 58 57" src="https://github.com/user-attachments/assets/193f4372-dfa2-4657-971d-c4c80d25ed47" />

----

For an enumerator:
<img width="915" alt="Screenshot 2025-06-23 at 13 59 18" src="https://github.com/user-attachments/assets/57f96bee-3bf3-4e3a-82a0-3d2a9afcbbff" />

----

For an operation:
<img width="1087" alt="Screenshot 2025-06-23 at 13 59 41" src="https://github.com/user-attachments/assets/920346bf-f064-4bf5-bdad-e1d00c7f46d0" />
