### PR TITLE
Add Support for `@remarks` to `slice2matlab`

### DIFF
--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -388,13 +388,9 @@ namespace
         }
     }
 
-    void writeSeeAlso(IceInternal::Output& out, const optional<DocComment>& doc, const ContainerPtr& container)
+    void writeSeeAlso(IceInternal::Output& out, const DocComment& doc, const ContainerPtr& container)
     {
-        if (!doc)
-        {
-            return;
-        }
-        const StringList& seeAlso = doc->seeAlso();
+        const StringList& seeAlso = doc.seeAlso();
         if (seeAlso.empty())
         {
             return;
@@ -476,6 +472,19 @@ namespace
                 out << ": " << *deprecationReason;
             }
         }
+    }
+
+    void writeRemarks(IceInternal::Output& out, const DocComment& doc)
+    {
+        const StringList& remarks = doc.remarks();
+        if (remarks.empty())
+        {
+            return;
+        }
+
+        out << nl << "%";
+        out << nl << "%% Remarks";
+        writeDocLines(out, remarks, 4);
     }
 
     void writeConstructorDoc(IceInternal::Output& out, const string& name, const DataMemberList& fields)
@@ -568,8 +577,12 @@ namespace
             writePropertiesSummary(out, name, ex->dataMembers());
         }
 
-        writeSeeAlso(out, doc, p->container());
         writeDeprecated(out, doc, p);
+        if (doc)
+        {
+            writeSeeAlso(out, *doc, p->container());
+            writeRemarks(out, *doc);
+        }
     }
 
     void writeOpDocSummary(IceInternal::Output& out, const OperationPtr& p, bool async)
@@ -686,7 +699,12 @@ namespace
             }
         }
 
-        writeSeeAlso(out, doc, p->container());
+        if (doc)
+        {
+            writeSeeAlso(out, *doc, p->container());
+            writeRemarks(out, *doc);
+        }
+
         out << nl;
     }
 
@@ -760,8 +778,12 @@ namespace
             << p->scoped() << ".";
         out << nl << "%     uncheckedCast - Creates a " << name << " from another proxy without any validation.";
 
-        writeSeeAlso(out, doc, p->container());
         writeDeprecated(out, doc, p);
+        if (doc)
+        {
+            writeSeeAlso(out, *doc, p->container());
+            writeRemarks(out, *doc);
+        }
     }
 
     void declareProperty(IceInternal::Output& out, const DataMemberPtr& field)
@@ -1054,8 +1076,12 @@ namespace
             doc ? doc->overview() : StringList{},
             false);
 
-        writeSeeAlso(out, doc, field->container());
         writeDeprecated(out, doc, field);
+        if (doc)
+        {
+            writeSeeAlso(out, *doc, field->container());
+            writeRemarks(out, *doc);
+        }
     }
 
     void writeArguments(

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -388,9 +388,13 @@ namespace
         }
     }
 
-    void writeSeeAlso(IceInternal::Output& out, const DocComment& doc, const ContainerPtr& container)
+    void writeSeeAlso(IceInternal::Output& out, const optional<DocComment>& doc, const ContainerPtr& container)
     {
-        const StringList& seeAlso = doc.seeAlso();
+        if (!doc)
+        {
+            return;
+        }
+        const StringList& seeAlso = doc->seeAlso();
         if (seeAlso.empty())
         {
             return;
@@ -474,16 +478,20 @@ namespace
         }
     }
 
-    void writeRemarks(IceInternal::Output& out, const DocComment& doc)
+    void writeRemarks(IceInternal::Output& out, const optional<DocComment>& doc)
     {
-        const StringList& remarks = doc.remarks();
+        if (!doc)
+        {
+            return;
+        }
+        const StringList& remarks = doc->remarks();
         if (remarks.empty())
         {
             return;
         }
 
         out << nl << "%";
-        out << nl << "%% Remarks";
+        out << nl << "%   Remarks";
         writeDocLines(out, remarks, 4);
     }
 
@@ -578,11 +586,8 @@ namespace
         }
 
         writeDeprecated(out, doc, p);
-        if (doc)
-        {
-            writeSeeAlso(out, *doc, p->container());
-            writeRemarks(out, *doc);
-        }
+        writeSeeAlso(out, doc, p->container());
+        writeRemarks(out, doc);
     }
 
     void writeOpDocSummary(IceInternal::Output& out, const OperationPtr& p, bool async)
@@ -699,11 +704,8 @@ namespace
             }
         }
 
-        if (doc)
-        {
-            writeSeeAlso(out, *doc, p->container());
-            writeRemarks(out, *doc);
-        }
+        writeSeeAlso(out, doc, p->container());
+        writeRemarks(out, doc);
 
         out << nl;
     }
@@ -779,11 +781,8 @@ namespace
         out << nl << "%     uncheckedCast - Creates a " << name << " from another proxy without any validation.";
 
         writeDeprecated(out, doc, p);
-        if (doc)
-        {
-            writeSeeAlso(out, *doc, p->container());
-            writeRemarks(out, *doc);
-        }
+        writeSeeAlso(out, *doc, p->container());
+        writeRemarks(out, *doc);
     }
 
     void declareProperty(IceInternal::Output& out, const DataMemberPtr& field)
@@ -1077,11 +1076,8 @@ namespace
             false);
 
         writeDeprecated(out, doc, field);
-        if (doc)
-        {
-            writeSeeAlso(out, *doc, field->container());
-            writeRemarks(out, *doc);
-        }
+        writeSeeAlso(out, *doc, field->container());
+        writeRemarks(out, *doc);
     }
 
     void writeArguments(

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -1076,8 +1076,8 @@ namespace
             false);
 
         writeDeprecated(out, doc, field);
-        writeSeeAlso(out, *doc, field->container());
-        writeRemarks(out, *doc);
+        writeSeeAlso(out, doc, field->container());
+        writeRemarks(out, doc);
     }
 
     void writeArguments(

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -781,8 +781,8 @@ namespace
         out << nl << "%     uncheckedCast - Creates a " << name << " from another proxy without any validation.";
 
         writeDeprecated(out, doc, p);
-        writeSeeAlso(out, *doc, p->container());
-        writeRemarks(out, *doc);
+        writeSeeAlso(out, doc, p->container());
+        writeRemarks(out, doc);
     }
 
     void declareProperty(IceInternal::Output& out, const DataMemberPtr& field)


### PR DESCRIPTION
This PR just does what it says.
MATLAB has no special documentation thing for remarks or notes, so we just generate a normal section named `Remarks`.
We always generate this at the end, after the summary, properties, see-also-s etc.

Here is the changes my PR causes to the generated code:

----

For the `EncodingVersion` struct:
```diff
@@ -12,6 +12,9 @@ classdef (Sealed) EncodingVersion
     %     major - The major version of the Ice encoding.
     %     minor - The minor version of the Ice encoding.
     %
+    %% Remarks
+    %     The Ice encoding is also known as the Slice encoding.
+    %
     %   Generated from Version.ice by slice2matlab version 3.8.0-alpha.0
```

and for the `LookupPrx` proxy:
```diff
@@ -21,6 +21,12 @@ classdef LookupPrx < Ice.ObjectPrx
     %
     %   See also IceLocatorDiscovery.LookupReply
     %
+    %% Remarks
+    %     This interface is implemented by Ice locator implementations and can be used by clients to find
+    %     available Ice locators on the network.
+    %     Ice locator implementations provide a well-known 'Ice/LocatorLookup' object accessible through UDP multicast.
+    %     Clients typically make a multicast findLocator request to find the locator proxy.
+    %
     %   Generated from Lookup.ice by slice2matlab version 3.8.0-alpha.0

     methods
```

----

And here is what the `help` output looks like within MATLAB (for an enumerator and an operation):

----

![Screenshot 2025-06-23 154919](https://github.com/user-attachments/assets/70b242d7-27d5-445a-a44c-62971e725083)

----

![Screenshot 2025-06-23 154928](https://github.com/user-attachments/assets/08b31a95-ab79-4271-bc23-c8f0c4787084)