### PR TITLE
Require `@throws` to Exactly Match Exception Specifications

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -579,11 +579,11 @@ Slice::DocComment::parseFrom(const ContainedPtr& p, DocLinkFormatter linkFormatt
                     // ... and matches one of the exceptions in the operation's specification.
                     const ExceptionList exceptionSpec = operationTarget->throws();
                     const auto exceptionCheck = [&exceptionTarget](const ExceptionPtr& ex)
-                    { return ex->isBaseOf(exceptionTarget) || ex->scoped() == exceptionTarget->scoped(); };
+                    { return ex->scoped() == exceptionTarget->scoped(); };
                     if (std::none_of(exceptionSpec.begin(), exceptionSpec.end(), exceptionCheck))
                     {
-                        const string msg = "'" + actualTag + " " + name + "': this exception is not listed in nor " +
-                                           "derived from any exception in this operation's specification";
+                        const string msg = "'" + actualTag + " " + name + "': this exception is not listed in this " +
+                                           "operation's exception specification";
                         p->unit()->warning(p->file(), p->line(), InvalidComment, msg);
                     }
 

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.err
@@ -7,11 +7,12 @@ WarningInvalidComment.ice:17: warning: ignoring trailing '.' character in '@see'
 WarningInvalidComment.ice:43: warning: '@param NoParam' does not correspond to any parameter in operation 'voidOp'
 WarningInvalidComment.ice:43: warning: '@return' is only valid on operations with non-void return types
 WarningInvalidComment.ice:43: warning: '@throws FakeException': no exception with this name could be found from the current scope
-WarningInvalidComment.ice:43: warning: '@throws CommentDummy': this exception is not listed in nor derived from any exception in this operation's specification
+WarningInvalidComment.ice:43: warning: '@throws CommentDummy': this exception is not listed in this operation's exception specification
 WarningInvalidComment.ice:54: warning: ignoring duplicate doc-comment tag: '@param value'
 WarningInvalidComment.ice:54: warning: '@param namess' does not correspond to any parameter in operation 'stringOp'
 WarningInvalidComment.ice:54: warning: ignoring duplicate doc-comment tag: '@return'
-WarningInvalidComment.ice:54: warning: '@throws SomeOtherException': this exception is not listed in nor derived from any exception in this operation's specification
+WarningInvalidComment.ice:54: warning: '@throws DerivedFromDummy': this exception is not listed in this operation's exception specification
+WarningInvalidComment.ice:54: warning: '@throws SomeOtherException': this exception is not listed in this operation's exception specification
 WarningInvalidComment.ice:54: warning: ignoring duplicate doc-comment tag: '@throws CommentDummy'
 WarningInvalidComment.ice:29: warning: ignoring unknown doc tag '@something' in comment
 WarningInvalidComment.ice:29: warning: ignoring unknown doc tag '@params' in comment
@@ -23,9 +24,10 @@ WarningInvalidComment.ice:33: warning: ignoring duplicate doc-comment tag: '@dep
 WarningInvalidComment.ice:43: warning: '@param NoParam' does not correspond to any parameter in operation 'voidOp'
 WarningInvalidComment.ice:43: warning: '@return' is only valid on operations with non-void return types
 WarningInvalidComment.ice:43: warning: '@throws FakeException': no exception with this name could be found from the current scope
-WarningInvalidComment.ice:43: warning: '@throws CommentDummy': this exception is not listed in nor derived from any exception in this operation's specification
+WarningInvalidComment.ice:43: warning: '@throws CommentDummy': this exception is not listed in this operation's exception specification
 WarningInvalidComment.ice:54: warning: ignoring duplicate doc-comment tag: '@param value'
 WarningInvalidComment.ice:54: warning: '@param namess' does not correspond to any parameter in operation 'stringOp'
 WarningInvalidComment.ice:54: warning: ignoring duplicate doc-comment tag: '@return'
-WarningInvalidComment.ice:54: warning: '@throws SomeOtherException': this exception is not listed in nor derived from any exception in this operation's specification
+WarningInvalidComment.ice:54: warning: '@throws DerivedFromDummy': this exception is not listed in this operation's exception specification
+WarningInvalidComment.ice:54: warning: '@throws SomeOtherException': this exception is not listed in this operation's exception specification
 WarningInvalidComment.ice:54: warning: ignoring duplicate doc-comment tag: '@throws CommentDummy'

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.ice
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.ice
@@ -47,7 +47,7 @@ module Test
         /// @param namess should give a no-matching-parameter warning.
         /// @return Something because it's non-void.
         /// @return Should give a duplicate-tag warning.
-        /// @throws DerivedFromDummy should be fine, since this is a sub-exception of `CommentDummy`.
+        /// @throws DerivedFromDummy should give a warning despite being a sub-exception of `CommentDummy`.
         /// @throws CommentDummy should be fine, this matches the exception specification.
         /// @throws SomeOtherException should give a not-thrown-by-this-operation warning.
         /// @throws CommentDummy should give a duplicate-tag warning.


### PR DESCRIPTION
Fixes #4132.