### PR TITLE
Add package to install DEB repository

### DIFF
--- a/.github/workflows/build-deb-ice-repo-packages.yml
+++ b/.github/workflows/build-deb-ice-repo-packages.yml
@@ -42,12 +42,12 @@ jobs:
         run: |
           docker run --rm \
             -v "$GITHUB_WORKSPACE:/workspace" \
-            -e PLATFORM="${{ matrix.distribution }}" \
-            -e CHANNEL="${{ matrix.channel }}" \
-            -e GPG_KEY="${{ secrets.ICE_3_8_CI_SIGNER_KEY }}"
-            -e GPG_KEY_ID="${{ secrets.ICE_3_8_CI_SIGNER_KEY_ID }}"
+            -e GPG_KEY="${{ secrets.ICE_3_8_CI_SIGNER_KEY }}" \
+            -e GPG_KEY_ID="${{ secrets.ICE_3_8_CI_SIGNER_KEY_ID }}" \
             ghcr.io/zeroc-ice/ice-deb-builder-${{ matrix.distribution }} \
-            /workspace/ice/packaging/deb/build-repo-package.sh
+            /workspace/ice/packaging/deb/build-repo-package.sh \
+            --distribution="${{ matrix.distribution }}" \
+            --channel="${{ matrix.channel }}"
 
       - name: Sync DEB packages to S3
         run: |

--- a/.github/workflows/build-deb-ice-repo-packages.yml
+++ b/.github/workflows/build-deb-ice-repo-packages.yml
@@ -1,0 +1,89 @@
+name: "Build Ice Repo DEB Packages"
+
+on:
+  workflow_dispatch
+
+jobs:
+  build:
+    name: "Build Ice Repo DEB packages for ${{ matrix.distribution }}"
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include:
+          - distribution: debian12
+            channel: 3.8
+
+          - distribution: ubuntu24.04
+            channel: 3.8
+
+          - distribution: debian12
+            channel: nightly
+
+          - distribution: ubuntu24.04
+            channel: nightly
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          path: ice
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: zeroc-ice
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build DEB packages
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/workspace" \
+            -e PLATFORM="${{ matrix.distribution }}" \
+            -e CHANNEL="${{ matrix.channel }}" \
+            -e GPG_KEY="${{ secrets.ICE_3_8_CI_SIGNER_KEY }}"
+            -e GPG_KEY_ID="${{ secrets.ICE_3_8_CI_SIGNER_KEY_ID }}"
+            ghcr.io/zeroc-ice/ice-deb-builder-${{ matrix.distribution }} \
+            /workspace/ice/packaging/deb/build-repo-package.sh
+
+      - name: Sync DEB packages to S3
+        run: |
+          # Validate CHANNEL
+          case "$CHANNEL" in
+            3.8|nightly) ;;
+            *)
+              echo "Invalid CHANNEL: $CHANNEL"
+              exit 1
+              ;;
+          esac
+
+          # Validate DISTRIBUTION
+          case "$DISTRIBUTION" in
+            debian12|ubuntu24.04) ;;
+            *)
+              echo "Invalid DISTRIBUTION: $DISTRIBUTION"
+              exit 1
+              ;;
+          esac
+
+          mkdir -p "$DISTRIBUTION"
+          aws s3 sync s3://zeroc-downloads/ice/$CHANNEL/$DISTRIBUTION $DISTRIBUTION
+
+          cp -pn "build/*.deb" "${DISTRIBUTION}/"
+
+          aws s3 sync "$DISTRIBUTION" s3://zeroc-downloads/ice/$CHANNEL/$DISTRIBUTION
+        env:
+          CHANNEL: ${{ matrix.channel }}
+          DISTRIBUTION: ${{ matrix.distribution }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: deb-packages-${{ matrix.channel }}-${{ matrix.distribution }}
+          path: |
+            build/*.deb

--- a/.github/workflows/build-rpm-ice-repo-packages.yml
+++ b/.github/workflows/build-rpm-ice-repo-packages.yml
@@ -48,10 +48,10 @@ jobs:
         run: |
           docker run --rm \
             -v "$GITHUB_WORKSPACE:/workspace" \
-            -e PLATFORM="${{ matrix.distribution }}" \
-            -e CHANNEL="${{ matrix.channel }}" \
             ghcr.io/zeroc-ice/ice-rpm-builder-${{ matrix.distribution }} \
-            /workspace/ice/packaging/rpm/build-repo-package.sh
+            /workspace/ice/packaging/rpm/build-repo-package.sh \
+            --distribution "${{ matrix.distribution }}" \
+            --channel "${{ matrix.channel }}" \
 
       - name: Sign RPM packages and create repository
         run: |

--- a/packaging/deb/build-repo-package.sh
+++ b/packaging/deb/build-repo-package.sh
@@ -61,7 +61,7 @@ fi
 
 # Configuration
 REPO_BASE_URL="https://download.zeroc.com/ice/${CHANNEL}"
-OUT_DIR="build"
+OUT_DIR="/workspace/build"
 VERSION="1.0"
 KEYRING_NAME="zeroc-archive-keyring.gpg"
 PACKAGE_NAME="ice-repo-${CHANNEL}"

--- a/packaging/deb/build-repo-package.sh
+++ b/packaging/deb/build-repo-package.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Required environment: GPG_KEY, GPG_KEY_ID
+
+# Default values
+DISTRIBUTION=""
+CHANNEL=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --distribution)
+            DISTRIBUTION="$2"
+            shift 2
+            ;;
+        --channel)
+            CHANNEL="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Validate required inputs
+: "${DISTRIBUTION:?Missing --distribution}"
+: "${CHANNEL:?Missing --channel}"
+: "${GPG_KEY:?GPG_KEY environment variable is not set}"
+: "${GPG_KEY_ID:?GPG_KEY_ID environment variable is not set}"
+
+# Validate distribution
+case "$DISTRIBUTION" in
+    debian12|ubuntu24.04) ;;
+    *)
+        echo "Error: DISTRIBUTION must be 'debian12' or 'ubuntu24.04'" >&2
+        exit 1
+        ;;
+esac
+
+# Validate channel
+case "$CHANNEL" in
+    3.8|nightly) ;;
+    *)
+        echo "Error: CHANNEL must be '3.8' or 'nightly'" >&2
+        exit 1
+        ;;
+esac
+
+# Import the GPG key
+echo "$GPG_KEY" | gpg --batch --import
+
+# Check that the key was successfully imported
+if ! gpg --list-secret-keys "$GPG_KEY_ID" > /dev/null 2>&1; then
+  echo "Error: GPG key ID $GPG_KEY_ID was not imported successfully."
+  exit 1
+fi
+
+# Configuration
+REPO_BASE_URL="https://download.zeroc.com/ice/${CHANNEL}"
+OUT_DIR="build"
+VERSION="1.0"
+KEYRING_NAME="zeroc-archive-keyring.gpg"
+PACKAGE_NAME="ice-repo-${CHANNEL}"
+KEYRING_PATH="usr/share/keyrings/${KEYRING_NAME}"
+SOURCE_LIST_PATH="etc/apt/sources.list.d/ice-repo-${CHANNEL}.list"
+
+# Create keyring if needed
+mkdir -p "${OUT_DIR}/keyrings"
+KEYRING_OUTPUT="${OUT_DIR}/keyrings/${KEYRING_NAME}"
+if [[ ! -f "$KEYRING_OUTPUT" ]]; then
+  echo "Generating keyring..."
+  gpg --export "$GPG_KEY_ID" | gpg --dearmor -o "$KEYRING_OUTPUT"
+fi
+
+# Create package layout
+PKG_DIR="${OUT_DIR}/${PACKAGE_NAME}"
+mkdir -p "${PKG_DIR}/DEBIAN"
+mkdir -p "${PKG_DIR}/$(dirname "$SOURCE_LIST_PATH")"
+mkdir -p "${PKG_DIR}/$(dirname "$KEYRING_PATH")"
+
+# Create control file
+cat > "${PKG_DIR}/DEBIAN/control" <<EOF
+Package: ice-repo-${CHANNEL}
+Version: ${VERSION}
+Architecture: all
+Maintainer: ZeroC, Inc. <info@zeroc.com>
+Description: ZeroC APT repository configuration for Ice ${CHANNEL}
+ This package installs the APT repository and GPG key for the ZeroC Ice ${CHANNEL} repository on ${DISTRIBUTION}.
+EOF
+
+# Create sources.list.d entry
+cat > "${PKG_DIR}/${SOURCE_LIST_PATH}" <<EOF
+deb [signed-by=/${KEYRING_PATH}] ${REPO_BASE_URL}/${DISTRIBUTION} ${CHANNEL} main
+EOF
+
+# Copy keyring
+cp "$KEYRING_OUTPUT" "${PKG_DIR}/${KEYRING_PATH}"
+
+# Build the .deb package
+DEB_FILE="${PACKAGE_NAME}_${VERSION}_all.deb"
+dpkg-deb --build "$PKG_DIR" "${OUT_DIR}/${DEB_FILE}"
+
+echo "✅ Created ${OUT_DIR}/${DEB_FILE}"


### PR DESCRIPTION
This PR adds a new workflow for creating `ice-repo-3.8` and `ice-repo-nightly` debian packages, this packages can be used to install the corresponding debian repository.

This would simplify the setup instructions, and is consistent with what we already do for RPM distributions.