### PR TITLE
Sync Java doc comments with C++

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/AlreadyRegisteredException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/AlreadyRegisteredException.java
@@ -3,9 +3,7 @@
 package com.zeroc.Ice;
 
 /**
- * An attempt was made to register something more than once with the Ice run time. This exception is
- * raised if an attempt is made to register a servant, servant locator, facet,
- * plug-in, or object adapter more than once for the same ID.
+ * The exception that is thrown when you attempt to register an object more than once with the Ice runtime.
  */
 public final class AlreadyRegisteredException extends LocalException {
     /**

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CloseConnectionException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CloseConnectionException.java
@@ -3,12 +3,11 @@
 package com.zeroc.Ice;
 
 /**
- * This exception indicates that the connection has been gracefully shut down by the server. The
- * operation call that caused this exception has not been executed by the server. In most cases you
- * will not get this exception, because the client will automatically retry the operation call in
- * case the server shut down the connection. However, if upon retry the server shuts down the
- * connection again, and the retry limit has been reached, then this exception is propagated to the
- * application code.
+ * The exception that is thrown when the connection has been gracefully shut down by the server. The request
+ * that returned this exception has not been executed by the server. In most cases you will not get this exception,
+ * because the client will automatically retry the invocation. However, if upon retry the server shuts down the
+ * connection again, and the retry limit has been reached, then this exception is propagated to the application
+ * code.
  */
 public final class CloseConnectionException extends ProtocolException {
     /**

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CloseTimeoutException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CloseTimeoutException.java
@@ -2,7 +2,7 @@
 
 package com.zeroc.Ice;
 
-/** This exception indicates a connection closure timeout condition. */
+/** The exception that is thrown when a graceful connection closure times out. */
 public final class CloseTimeoutException extends TimeoutException {
     /**
      * Constructs a CloseTimeoutException.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
@@ -13,8 +13,14 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * The central object in Ice. One or more communicators can be instantiated for an Ice application.
- * Communicator instantiation is language-specific, and not specified in Slice code.
+ * The central object in Ice. Its responsibilities include:
+ * - creating and managing outgoing connections
+ * - executing callbacks in its client thread pool
+ * - creating and destroying object adapters
+ * - loading plug-ins
+ * - managing properties (configuration), retries, logging, instrumentation, and more.
+ * You create a communicator with {@code Ice.initialize}, and it's usually the first object you create when programming
+ * with Ice. You can create multiple communicators in a single program, but this is not common.
  *
  * @see Logger
  * @see ObjectAdapter
@@ -36,9 +42,10 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Destroy the communicator. This operation calls {@link #shutdown} implicitly. Calling {@link
-     * #destroy} cleans up memory, and shuts down this communicator's client functionality and
-     * destroys all object adapters. Subsequent calls to {@link #destroy} are ignored.
+     * Destroys this communicator. This method calls {@link #shutdown} implicitly. Calling {@link
+     * #destroy} destroys all object adapters, and closes all outgoing connections. {@code destroy} waits for all
+     * outstanding dispatches to complete before returning. This includes "bidirectional dispatches" that execute on
+     * outgoing connections.
      *
      * @see #shutdown
      * @see ObjectAdapter#destroy
@@ -48,7 +55,7 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Shuts down this communicator: call {@link ObjectAdapter#deactivate} on all object adapters
+     * Shuts down this communicator. This method calls {@link ObjectAdapter#deactivate} on all object adapters
      * created by this communicator. Shutting down a communicator has no effect on outgoing
      * connections.
      *
@@ -65,13 +72,9 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Wait until the application has called {@link #shutdown} (or {@link #destroy}). On the server
-     * side, this operation blocks the calling thread until all currently-executing operations have
-     * completed. On the client side, the operation simply blocks until another thread has called
-     * {@link #shutdown} or {@link #destroy}. A typical use of this operation is to call it from the
-     * main thread, which then waits until some other thread calls {@link #shutdown}. After
-     * shut-down is complete, the main thread returns and can do some cleanup work before it finally
-     * calls {@link #destroy} to shut down the client functionality, and then exits the application.
+     * Waits for shutdown to complete. This method calls {@link ObjectAdapter#waitForDeactivate} on all object adapters
+     * created by this communicator. In a client application that does not accept incoming connections, this
+     * method returns as soon as another thread calls {@link #shutdown} or {@link #destroy} on this communicator.
      *
      * @see #shutdown
      * @see #destroy
@@ -86,9 +89,9 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Check whether communicator has been shut down.
+     * Checks whether or not {@link #shutdown} was called on this communicator.
      *
-     * @return True if the communicator has been shut down; false otherwise.
+     * @return {@code true} if {@link #shutdown} was called on this communicator, {@code false} otherwise.
      * @see #shutdown
      */
     public boolean isShutdown() {
@@ -100,15 +103,11 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Convert a stringified proxy into a proxy. For example, <code>
-     * MyCategory/MyObject:tcp -h some_host -p 10000</code> creates a proxy that refers to the Ice
-     * object having an identity with a name "MyObject" and a category "MyCategory", with the server
-     * running on host "some_host", port 10000. If the stringified proxy does not parse correctly,
-     * the operation throws ParseException. Refer to the Ice manual for a detailed description of
-     * the syntax supported by stringified proxies.
+     * Converts a stringified proxy into a proxy.
      *
      * @param str The stringified proxy to convert into a proxy.
-     * @return The proxy, or nil if <code>str</code> is an empty string.
+     * @return The proxy, or null if {@code str} is an empty string.
+     * @throws ParseException Thrown when {@code str} is not a valid proxy string.
      * @see #proxyToString
      */
     public ObjectPrx stringToProxy(String str) {
@@ -117,10 +116,10 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Convert a proxy into a string.
+     * Converts a proxy into a string.
      *
      * @param proxy The proxy to convert into a stringified proxy.
-     * @return The stringified proxy, or an empty string if <code>obj</code> is nil.
+     * @return The stringified proxy, or an empty string if {@code proxy} is null.
      * @see #stringToProxy
      */
     public String proxyToString(ObjectPrx proxy) {
@@ -128,15 +127,14 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Convert a set of proxy properties into a proxy. The "base" name supplied in the <code>
-     * property
-     * </code> argument refers to a property containing a stringified proxy, such as <code>
-     * MyProxy=id:tcp -h localhost -p 10000</code>. Additional properties configure local settings
-     * for the proxy, such as <code>MyProxy.PreferSecure=1</code>. The "Properties" appendix in the
+     * Converts a set of proxy properties into a proxy. The "base" name supplied in the {@code
+     * prefix} argument refers to a property containing a stringified proxy, such as {@code
+     * MyProxy=id:tcp -h localhost -p 10000}. Additional properties configure local settings
+     * for the proxy, such as {@code MyProxy.PreferSecure=1}. The "Properties" appendix in the
      * Ice manual describes each of the supported proxy properties.
      *
      * @param prefix The base property name.
-     * @return The proxy.
+     * @return The proxy, or null if the property is not set.
      */
     public ObjectPrx propertyToProxy(String prefix) {
         String proxy = _instance.initializationData().properties.getProperty(prefix);
@@ -145,7 +143,7 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Convert a proxy to a set of proxy properties.
+     * Converts a proxy into a set of proxy properties.
      *
      * @param proxy The proxy.
      * @param prefix The base property name.
@@ -158,7 +156,7 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Convert an identity into a string.
+     * Converts an identity into a string.
      *
      * @param ident The identity to convert into a string.
      * @return The "stringified" identity.
@@ -168,12 +166,11 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Create a new object adapter. The endpoints for the object adapter are taken from the property
-     * <code><em>name</em>.Endpoints</code>. It is legal to create an object adapter with the empty
-     * string as its name. Such an object adapter is accessible via bidirectional connections or by
-     * collocated invocations that originate from the same communicator as is used by the adapter.
-     * Attempts to create a named object adapter for which no configuration can be found raise
-     * InitializationException.
+     * Creates a new object adapter. The endpoints for the object adapter are taken from the property
+     * {@code name.Endpoints}.
+     *
+     * It is legal to create an object adapter with the empty string as its name. Such an object adapter is
+     * accessible via bidirectional connections or by collocated invocations.
      *
      * @param name The object adapter name.
      * @return The new object adapter.
@@ -186,12 +183,11 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Create a new object adapter. The endpoints for the object adapter are taken from the property
-     * <code><em>name</em>.Endpoints</code>. It is legal to create an object adapter with the empty
-     * string as its name. Such an object adapter is accessible via bidirectional connections or by
-     * collocated invocations that originate from the same communicator as is used by the adapter.
-     * Attempts to create a named object adapter for which no configuration can be found raise
-     * InitializationException.
+     * Creates a new object adapter. The endpoints for the object adapter are taken from the property
+     * {@code name.Endpoints}.
+     *
+     * It is legal to create an object adapter with the empty string as its name. Such an object adapter is
+     * accessible via bidirectional connections or by collocated invocations.
      *
      * <p>It is an error to pass a non-null sslEngineFactory when the name is empty, this raises
      * IllegalArgumentException.
@@ -217,13 +213,13 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Create a new object adapter with endpoints. This operation sets the property <code>
-     * <em>name</em>.Endpoints</code>, and then calls {@link #createObjectAdapter}. It is provided
-     * as a convenience function. Calling this operation with an empty name will result in a UUID
+     * Creates a new object adapter with endpoints. This method sets the property
+     * {@code name.Endpoints}, and then calls {@link #createObjectAdapter}. It is provided
+     * as a convenience method. Calling this method with an empty name will result in a UUID
      * being generated for the name.
      *
      * @param name The object adapter name.
-     * @param endpoints The endpoints for the object adapter.
+     * @param endpoints The endpoints of the object adapter.
      * @return The new object adapter.
      * @see #createObjectAdapter
      * @see ObjectAdapter
@@ -234,13 +230,13 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Create a new object adapter with endpoints. This operation sets the property <code>
-     * <em>name</em>.Endpoints</code>, and then calls {@link #createObjectAdapter}. It is provided
-     * as a convenience function. Calling this operation with an empty name will result in a UUID
+     * Creates a new object adapter with endpoints. This method sets the property
+     * {@code name.Endpoints}, and then calls {@link #createObjectAdapter}. It is provided
+     * as a convenience method. Calling this method with an empty name will result in a UUID
      * being generated for the name.
      *
      * @param name The object adapter name.
-     * @param endpoints The endpoints for the object adapter.
+     * @param endpoints The endpoints of the object adapter.
      * @param sslEngineFactory The SSL engine factory used by the server-side ssl transport of the
      *     new object adapter. When set to a non-null value all Ice.SSL configuration properties are
      *     ignored, and any SSL configuration must be done through the SSLEngineFactory. Pass null
@@ -263,8 +259,8 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Create a new object adapter with a router. This operation creates a routed object adapter.
-     * Calling this operation with an empty name will result in a UUID being generated for the name.
+     * Creates a new object adapter with a router. This method creates a routed object adapter.
+     * Calling this method with an empty name will result in a UUID being generated for the name.
      *
      * @param name The object adapter name.
      * @param router The router.
@@ -314,17 +310,17 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Get the implicit context associated with this communicator.
+     * Gets the implicit context associated with this communicator.
      *
      * @return The implicit context associated with this communicator; returns null when the
-     *     property Ice.ImplicitContext is not set or is set to None.
+     *     property {@code Ice.ImplicitContext} is not set or is set to {@code None}.
      */
     public ImplicitContext getImplicitContext() {
         return _instance.getImplicitContext();
     }
 
     /**
-     * Get the properties for this communicator.
+     * Gets the properties of this communicator.
      *
      * @return This communicator's properties.
      * @see Properties
@@ -334,7 +330,7 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Get the logger for this communicator.
+     * Gets the logger of this communicator.
      *
      * @return This communicator's logger.
      * @see Logger
@@ -358,18 +354,18 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Get the observer resolver object for this communicator.
+     * Gets the observer object of this communicator.
      *
-     * @return This communicator's observer resolver object.
+     * @return This communicator's observer object.
      */
     public CommunicatorObserver getObserver() {
         return _instance.initializationData().observer;
     }
 
     /**
-     * Get the default router for this communicator.
+     * Gets the default router of this communicator.
      *
-     * @return The default router for this communicator.
+     * @return The default router of this communicator.
      * @see #setDefaultRouter
      * @see Router
      */
@@ -378,12 +374,10 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Set a default router for this communicator. All newly created proxies will use this default
-     * router. To disable the default router, null can be used. Note that this operation has no
-     * effect on existing proxies. You can also set a router for an individual proxy by calling the
-     * operation <code>ice_router</code> on the proxy.
+     * Sets the default router of this communicator. All newly created proxies will use this default router.
+     * This method has no effect on existing proxies.
      *
-     * @param router The default router to use for this communicator.
+     * @param router The new default router. Use null to remove the default router.
      * @see #getDefaultRouter
      * @see #createObjectAdapterWithRouter
      * @see Router
@@ -393,9 +387,9 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Get the default locator for this communicator.
+     * Gets the default locator of this communicator.
      *
-     * @return The default locator for this communicator.
+     * @return The default locator of this communicator.
      * @see #setDefaultLocator
      * @see Locator
      */
@@ -404,14 +398,10 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Set a default Ice locator for this communicator. All newly created proxy and object adapters
-     * will use this default locator. To disable the default locator, null can be used. Note that
-     * this operation has no effect on existing proxies or object adapters. You can also set a
-     * locator for an individual proxy by calling the operation <code>ice_locator</code> on the
-     * proxy, or for an object adapter by calling {@link ObjectAdapter#setLocator} on the object
-     * adapter.
+     * Sets the default locator of this communicator. All newly created proxies will use this default locator.
+     * This method has no effect on existing proxies or object adapters.
      *
-     * @param locator The default locator to use for this communicator.
+     * @param locator The new default locator. Use null to remove the default locator.
      * @see #getDefaultLocator
      * @see Locator
      * @see ObjectAdapter#setLocator
@@ -421,7 +411,7 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Get the plug-in manager for this communicator.
+     * Gets the plug-in manager of this communicator.
      *
      * @return This communicator's plug-in manager.
      * @see PluginManager
@@ -431,8 +421,8 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Flush any pending batch requests for this communicator. This means all batch requests invoked
-     * on fixed proxies for all connections associated with the communicator. Any errors that occur
+     * Flushes any pending batch requests of this communicator. This means all batch requests invoked
+     * on fixed proxies for all connections associated with the communicator. Errors that occur
      * while flushing a connection are ignored.
      *
      * @param compressBatch Specifies whether or not the queued batch requests should be compressed
@@ -443,8 +433,8 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Flush any pending batch requests for this communicator. This means all batch requests invoked
-     * on fixed proxies for all connections associated with the communicator. Any errors that occur
+     * Flushes any pending batch requests of this communicator. This means all batch requests invoked
+     * on fixed proxies for all connections associated with the communicator. Errors that occur
      * while flushing a connection are ignored.
      *
      * @param compressBatch Specifies whether or not the queued batch requests should be compressed
@@ -467,16 +457,17 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Add the Admin object with all its facets to the provided object adapter. If <code>
-     * Ice.Admin.ServerId</code> is set and the provided object adapter has a {@link Locator},
+     * Adds the Admin object with all its facets to the provided object adapter. If
+     * {@code Ice.Admin.ServerId} is set and the provided object adapter has a {@link Locator},
      * createAdmin registers the Admin's Process facet with the {@link Locator}'s {@link
-     * LocatorRegistry}. createAdmin must only be called once; subsequent calls raise
-     * InitializationException.
+     * LocatorRegistry}.
      *
      * @param adminAdapter The object adapter used to host the Admin object; if null and
-     *     Ice.Admin.Endpoints is set, create, activate and use the Ice.Admin object adapter.
+     *     {@code Ice.Admin.Endpoints} is set, this method uses the {@code Ice.Admin} object adapter, after creating and
+     *     activating this adapter.
      * @param adminId The identity of the Admin object.
-     * @return A proxy to the main ("") facet of the Admin object. Never returns a null proxy.
+     * @return A proxy to the main ("") facet of the Admin object.
+     * @throws InitializationException Thrown when createAdmin is called more than once.
      * @see #getAdmin
      */
     public ObjectPrx createAdmin(ObjectAdapter adminAdapter, Identity adminId) {
@@ -484,14 +475,13 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Get a proxy to the main facet of the Admin object. getAdmin also creates the Admin object and
-     * creates and activates the Ice.Admin object adapter to host this Admin object if
-     * Ice.Admin.Endpoints is set. The identity of the Admin object created by getAdmin is {value of
-     * Ice.Admin.InstanceName}/admin, or {UUID}/admin when <code>Ice.Admin.InstanceName</code> is
-     * not set. If Ice.Admin.DelayCreation is 0 or not set, getAdmin is called by the communicator
-     * initialization, after initialization of all plugins.
+     * Gets a proxy to the main facet of the Admin object. getAdmin also creates the Admin object and creates and
+     * activates the {@code Ice.Admin} object adapter to host this Admin object if {@code Ice.Admin.Endpoints} is set. The
+     * identity of the Admin object created by getAdmin is {@code {value of Ice.Admin.InstanceName}/admin}, or
+     * {@code {UUID}/admin} when {@code Ice.Admin.InstanceName} is not set. If {@code Ice.Admin.DelayCreation} is {@code 0} or not set,
+     * getAdmin is called by the communicator initialization, after initialization of all plugins.
      *
-     * @return A proxy to the main ("") facet of the Admin object, or a null proxy if no Admin
+     * @return A proxy to the main ("") facet of the Admin object, or null if no Admin
      *     object is configured.
      * @see #createAdmin
      */
@@ -500,22 +490,22 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Add a new facet to the Admin object. Adding a servant with a facet that is already registered
-     * throws AlreadyRegisteredException.
+     * Adds a new facet to the Admin object.
      *
      * @param servant The servant that implements the new Admin facet.
      * @param facet The name of the new Admin facet.
+     * @throws AlreadyRegisteredException Thrown when a facet with the same name is already registered.
      */
     public void addAdminFacet(Object servant, String facet) {
         _instance.addAdminFacet(servant, facet);
     }
 
     /**
-     * Remove the following facet to the Admin object. Removing a facet that was not previously
-     * registered throws NotRegisteredException.
+     * Removes a facet from the Admin object.
      *
      * @param facet The name of the Admin facet.
      * @return The servant associated with this Admin facet.
+     * @throws NotRegisteredException Thrown when no facet with the given name is registered.
      */
     public Object removeAdminFacet(String facet) {
         return _instance.removeAdminFacet(facet);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CommunicatorDestroyedException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CommunicatorDestroyedException.java
@@ -3,7 +3,7 @@
 package com.zeroc.Ice;
 
 /**
- * This exception is raised if the {@link Communicator} has been destroyed.
+ * The exception that is thrown when an operation fails because the communicator has been destroyed.
  *
  * @see Communicator#destroy
  */

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectTimeoutException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectTimeoutException.java
@@ -2,7 +2,7 @@
 
 package com.zeroc.Ice;
 
-/** This exception indicates a connection establishment timeout condition. */
+/** The exception that is thrown when a connection establishment times out. */
 public final class ConnectTimeoutException extends TimeoutException {
     /**
      * Constructs a ConnectTimeoutException.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Connection.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Connection.java
@@ -17,13 +17,10 @@ public interface Connection {
     void close();
 
     /**
-     * Create a special proxy that always uses this connection. This can be used for callbacks from
-     * a server to a client if the server cannot directly establish a connection to the client, for
-     * example because of firewalls. In this case, the server would create a proxy using an already
-     * established connection from the client.
+     * Creates a special proxy (a "fixed proxy") that always uses this connection.
      *
-     * @param id The identity for which a proxy is to be created.
-     * @return A proxy that matches the given identity and uses this connection.
+     * @param id The identity of the target object.
+     * @return A fixed proxy with the provided identity.
      * @see #setAdapter
      */
     ObjectPrx createProxy(Identity id);
@@ -53,15 +50,15 @@ public interface Connection {
     ObjectAdapter getAdapter();
 
     /**
-     * Get the endpoint from which the connection was created.
+     * Gets the endpoint from which the connection was created.
      *
      * @return The endpoint from which the connection was created.
      */
     Endpoint getEndpoint();
 
     /**
-     * Flush any pending batch requests for this connection. This means all batch requests invoked
-     * on fixed proxies associated with the connection.
+     * Flushes any pending batch requests for this connection. This corresponds to all batch requests invoked on
+     * fixed proxies associated with the connection.
      *
      * @param compress Specifies whether or not the queued batch requests should be compressed
      *     before being sent over the wire.
@@ -69,61 +66,59 @@ public interface Connection {
     void flushBatchRequests(CompressBatch compress);
 
     /**
-     * Flush any pending batch requests for this connection. This means all batch requests invoked
-     * on fixed proxies associated with the connection.
+     * Flushes any pending batch requests for this connection. This corresponds to all batch requests invoked on
+     * fixed proxies associated with the connection.
      *
      * @param compress Specifies whether or not the queued batch requests should be compressed
      *     before being sent over the wire.
-     * @return A future that will be completed when the invocation completes.
+     * @return A future that becomes available when the flush completes.
      */
     CompletableFuture<Void> flushBatchRequestsAsync(CompressBatch compress);
 
     /**
-     * Set a close callback on the connection. The callback is called by the connection when it's
-     * closed. The callback is called from the Ice thread pool associated with the connection. If
-     * the callback needs more information about the closure, it can call {@link
-     * Connection#throwException}.
+     * Sets a close callback on the connection. The callback is called by the connection when it's closed. The
+     * callback is called from the Ice thread pool associated with the connection.
      *
      * @param callback The close callback object.
      */
     void setCloseCallback(CloseCallback callback);
 
     /**
-     * Return the connection type. This corresponds to the endpoint type, i.e., "tcp", "udp", etc.
+     * Gets the connection type. This corresponds to the endpoint type, such as "tcp", "udp", etc.
      *
      * @return The type of the connection.
      */
     String type();
 
     /**
-     * Return a description of the connection as human readable text, suitable for logging or error
+     * Gets a description of the connection as human readable text, suitable for logging or error
      * messages.
      *
      * @return The description of the connection as human readable text.
+     * @remark This method remains usable after the connection is closed or aborted.
      */
     String _toString();
 
     /**
-     * Returns the connection information.
+     * Gets the connection information.
      *
      * @return The connection information.
      */
     ConnectionInfo getInfo();
 
     /**
-     * Set the connection buffer receive/send size.
+     * Sets the size of the receive and send buffers.
      *
-     * @param rcvSize The connection receive buffer size.
-     * @param sndSize The connection send buffer size.
+     * @param rcvSize The size of the receive buffer.
+     * @param sndSize The size of the send buffer.
      */
     void setBufferSize(int rcvSize, int sndSize);
 
     /**
-     * Throw an exception indicating the reason for connection closure. For example, {@link
-     * CloseConnectionException} is raised if the connection was closed gracefully, whereas {@link
-     * ConnectionAbortedException}/{@link ConnectionClosedException} is raised if the connection was
-     * manually closed by the application. This operation does nothing if the connection is not yet
-     * closed.
+     * Throws an exception that provides the reason for the closure of this connection. For example, this method
+     * throws CloseConnectionException when the connection was closed gracefully by the peer; it throws
+     * ConnectionAbortedException when the connection is aborted. This method does nothing if the
+     * connection is not yet closed.
      */
     void throwException();
 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionAbortedException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionAbortedException.java
@@ -2,7 +2,7 @@
 
 package com.zeroc.Ice;
 
-/** This exception indicates that a connection was closed forcefully. */
+/** The exception that is thrown when an operation fails because the connection has been aborted. */
 public final class ConnectionAbortedException extends LocalException {
     /**
      * Constructs a ConnectionAbortedException.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionClosedException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionClosedException.java
@@ -2,7 +2,7 @@
 
 package com.zeroc.Ice;
 
-/** This exception indicates that a connection was closed gracefully. */
+/** The exception that is thrown when an operation fails because the connection has been closed gracefully. */
 public final class ConnectionClosedException extends LocalException {
     /**
      * Constructs a ConnectionClosedException.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionLostException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionLostException.java
@@ -2,7 +2,7 @@
 
 package com.zeroc.Ice;
 
-/** This exception indicates a lost connection. */
+/** The exception that is thrown when an established connection is lost. */
 public final class ConnectionLostException extends SocketException {
     /**
      * Constructs a ConnectionLostException.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionRefusedException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionRefusedException.java
@@ -3,8 +3,7 @@
 package com.zeroc.Ice;
 
 /**
- * This exception indicates a connection failure for which the server host actively refuses a
- * connection.
+ * The exception that is thrown when the server host actively refuses a connection.
  */
 public final class ConnectionRefusedException extends ConnectFailedException {
     /**

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/DatagramLimitException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/DatagramLimitException.java
@@ -3,9 +3,8 @@
 package com.zeroc.Ice;
 
 /**
- * A datagram exceeds the configured size. This exception is raised if a datagram exceeds the
- * configured send or receive buffer size, or exceeds the maximum payload size of a UDP packet
- * (65507 bytes).
+ * The exception that is thrown when a datagram exceeds the configured send or receive buffer size, or exceeds the
+ * maximum payload size of a UDP packet (65507 bytes).
  */
 public final class DatagramLimitException extends ProtocolException {
     /**

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/FacetNotExistException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/FacetNotExistException.java
@@ -3,8 +3,8 @@
 package com.zeroc.Ice;
 
 /**
- * This exception is raised if no facet with the given name exists, that is, if the dispatch could
- * not find a servant for the identity + facet carried by the request.
+ * The exception that is thrown when a dispatch cannot find a servant for the identity + facet carried by the
+ * request.
  */
 public final class FacetNotExistException extends RequestFailedException {
     /**

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/FeatureNotSupportedException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/FeatureNotSupportedException.java
@@ -2,7 +2,7 @@
 
 package com.zeroc.Ice;
 
-/** This exception is raised if an unsupported feature is used. */
+/** The exception that is thrown when attempting to use an unsupported feature. */
 public final class FeatureNotSupportedException extends LocalException {
     /**
      * Constructs a FeatureNotSupportedException with a message.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InvocationCanceledException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InvocationCanceledException.java
@@ -3,8 +3,8 @@
 package com.zeroc.Ice;
 
 /**
- * This exception is used internally to propagate an invocation cancellation. This exception is created by a call to
- * cancel() on the future returned by an asynchronous invocation.
+ * The exception that is thrown when an asynchronous invocation fails because it was canceled explicitly by the
+ * user.
  */
 final class InvocationCanceledException extends LocalException {
     /**

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InvocationTimeoutException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InvocationTimeoutException.java
@@ -2,7 +2,7 @@
 
 package com.zeroc.Ice;
 
-/** This exception indicates that an invocation failed because it timed out. */
+/** The exception that is thrown when an invocation times out. */
 public final class InvocationTimeoutException extends TimeoutException {
     /**
      * Constructs an InvocationTimeoutException.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/MarshalException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/MarshalException.java
@@ -2,7 +2,7 @@
 
 package com.zeroc.Ice;
 
-/** This exception is raised for errors during marshaling or unmarshaling. */
+/** The exception that is thrown when an error occurs during marshaling or unmarshaling. */
 public final class MarshalException extends ProtocolException {
     /**
      * Constructs a MarshalException with a message.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/NoEndpointException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/NoEndpointException.java
@@ -2,7 +2,7 @@
 
 package com.zeroc.Ice;
 
-/** This exception is raised if no suitable endpoint is available. */
+/** The exception that is thrown when the Ice runtime cannot find a suitable endpoint to connect to. */
 public final class NoEndpointException extends LocalException {
     /**
      * Constructs a NoEndpointException with a message.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/NotRegisteredException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/NotRegisteredException.java
@@ -3,10 +3,8 @@
 package com.zeroc.Ice;
 
 /**
- * An attempt was made to find or deregister something that is not registered with the Ice run time
- * or Ice locator. This exception is raised if an attempt is made to remove a servant, servant
- * locator, facet, plug-in, or object adapter that is not currently registered. It's also raised if the Ice locator
- * can't find an object or object adapter when resolving an indirect proxy or when an object adapter is activated.
+ * The exception that is thrown when you attempt to find or deregister something that is not registered with the
+ * Ice runtime or Ice locator.
  */
 public final class NotRegisteredException extends LocalException {
     /**

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectNotExistException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectNotExistException.java
@@ -3,8 +3,7 @@
 package com.zeroc.Ice;
 
 /**
- * This exception is raised if an object does not exist on the server, that is, if the dispatch
- * could not find a servant for the identity carried by the request.
+ * The exception that is thrown when a dispatch cannot find a servant for the identity carried by the request.
  */
 public final class ObjectNotExistException extends RequestFailedException {
     /**

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
@@ -12,7 +12,7 @@ import java.util.concurrent.Executor;
 /** Base interface of all object proxies. */
 public interface ObjectPrx {
     /**
-     * Returns the communicator that created this proxy.
+     * Gets the communicator that created this proxy.
      *
      * @return The communicator that created this proxy.
      */
@@ -22,8 +22,8 @@ public interface ObjectPrx {
      * Tests whether this object supports a specific Slice interface.
      *
      * @param id The type ID of the Slice interface to test against.
-     * @return <code>true</code> if the target object has the interface specified by <code>id</code>
-     *     or derives from the interface specified by <code>id</code>.
+     * @return {@code true} if the target object has the interface specified by {@code id}
+     *     or derives from the interface specified by {@code id}.
      */
     boolean ice_isA(String id);
 
@@ -32,8 +32,8 @@ public interface ObjectPrx {
      *
      * @param id The type ID of the Slice interface to test against.
      * @param context The context map for the invocation.
-     * @return <code>true</code> if the target object has the interface specified by <code>id</code>
-     *     or derives from the interface specified by <code>id</code>.
+     * @return {@code true} if the target object has the interface specified by {@code id}
+     *     or derives from the interface specified by {@code id}.
      */
     boolean ice_isA(String id, Map<String, String> context);
 
@@ -82,7 +82,7 @@ public interface ObjectPrx {
             Map<String, String> context);
 
     /**
-     * Returns the Slice type IDs of the interfaces supported by the target object of this proxy.
+     * Gets the Slice type IDs of the interfaces supported by the target object of this proxy.
      *
      * @return The Slice type IDs of the interfaces supported by the target object, in alphabetical
      *     order.
@@ -90,7 +90,7 @@ public interface ObjectPrx {
     String[] ice_ids();
 
     /**
-     * Returns the Slice type IDs of the interfaces supported by the target object of this proxy.
+     * Gets the Slice type IDs of the interfaces supported by the target object of this proxy.
      *
      * @param context The context map for the invocation.
      * @return The Slice type IDs of the interfaces supported by the target object, in alphabetical
@@ -115,7 +115,7 @@ public interface ObjectPrx {
             Map<String, String> context);
 
     /**
-     * Returns the Slice type ID of the most-derived interface supported by the target object of
+     * Gets the Slice type ID of the most-derived interface supported by the target object of
      * this proxy.
      *
      * @return The Slice type ID of the most-derived interface.
@@ -123,7 +123,7 @@ public interface ObjectPrx {
     String ice_id();
 
     /**
-     * Returns the Slice type ID of the most-derived interface supported by the target object of
+     * Gets the Slice type ID of the most-derived interface supported by the target object of
      * this proxy.
      *
      * @param context The context map for the invocation.
@@ -180,7 +180,7 @@ public interface ObjectPrx {
             Map<String, String> context);
 
     /**
-     * Invokes an operation dynamically and asynchronously.
+     * Invokes an operation asynchronously.
      *
      * @param operation The name of the operation to invoke.
      * @param mode The operation mode (normal or idempotent).
@@ -193,12 +193,11 @@ public interface ObjectPrx {
             String operation, OperationMode mode, byte[] inParams);
 
     /**
-     * Invokes an operation dynamically and asynchronously.
+     * Invokes an operation asynchronously.
      *
      * @param operation The name of the operation to invoke.
      * @param mode The operation mode (normal or idempotent).
-     * @param inParams The encoded in-parameters for the operation. for the operation. The return
-     *     value follows any out-parameters.
+     * @param inParams The encoded in-parameters for the operation.
      * @param context The context map for the invocation.
      * @return A future for the completion of the request.
      * @see Blobject
@@ -211,38 +210,38 @@ public interface ObjectPrx {
             Map<String, String> context);
 
     /**
-     * Returns the identity embedded in this proxy.
+     * Gets the identity embedded in this proxy.
      *
      * @return The identity of the target object.
      */
     Identity ice_getIdentity();
 
     /**
-     * Returns a proxy that is identical to this proxy, except for the identity.
+     * Creates a proxy that is identical to this proxy, except for the identity.
      *
      * @param newIdentity The identity for the new proxy.
-     * @return The proxy with the new identity.
+     * @return A proxy with the new identity.
      */
     ObjectPrx ice_identity(Identity newIdentity);
 
     /**
-     * Returns the per-proxy context for this proxy.
+     * Gets the per-proxy context for this proxy.
      *
      * @return The per-proxy context. If the proxy does not have a per-proxy (implicit) context, the
-     *     return value is <code>null</code>.
+     *     return value is null.
      */
     Map<String, String> ice_getContext();
 
     /**
-     * Returns a proxy that is identical to this proxy, except for the per-proxy context.
+     * Creates a proxy that is identical to this proxy, except for the per-proxy context.
      *
      * @param newContext The context for the new proxy.
-     * @return The proxy with the new per-proxy context.
+     * @return A proxy with the new per-proxy context.
      */
     ObjectPrx ice_context(Map<String, String> newContext);
 
     /**
-     * Returns the facet for this proxy.
+     * Gets the facet for this proxy.
      *
      * @return The facet for this proxy. If the proxy uses the default facet, the return value is
      *     the empty string.
@@ -250,15 +249,15 @@ public interface ObjectPrx {
     String ice_getFacet();
 
     /**
-     * Returns a proxy that is identical to this proxy, except for the facet.
+     * Creates a proxy that is identical to this proxy, except for the facet.
      *
      * @param newFacet The facet for the new proxy.
-     * @return The proxy with the new facet.
+     * @return A proxy with the new facet.
      */
     ObjectPrx ice_facet(String newFacet);
 
     /**
-     * Returns the adapter ID for this proxy.
+     * Gets the adapter ID for this proxy.
      *
      * @return The adapter ID. If the proxy does not have an adapter ID, the return value is the
      *     empty string.
@@ -266,15 +265,15 @@ public interface ObjectPrx {
     String ice_getAdapterId();
 
     /**
-     * Returns a proxy that is identical to this proxy, except for the adapter ID.
+     * Creates a proxy that is identical to this proxy, except for the adapter ID.
      *
      * @param newAdapterId The adapter ID for the new proxy.
-     * @return The proxy with the new adapter ID.
+     * @return A proxy with the new adapter ID.
      */
     ObjectPrx ice_adapterId(String newAdapterId);
 
     /**
-     * Returns the endpoints used by this proxy.
+     * Gets the endpoints used by this proxy.
      *
      * @return The endpoints used by this proxy.
      * @see Endpoint
@@ -282,15 +281,15 @@ public interface ObjectPrx {
     Endpoint[] ice_getEndpoints();
 
     /**
-     * Returns a proxy that is identical to this proxy, except for the endpoints.
+     * Creates a proxy that is identical to this proxy, except for the endpoints.
      *
      * @param newEndpoints The endpoints for the new proxy.
-     * @return The proxy with the new endpoints.
+     * @return A proxy with the new endpoints.
      */
     ObjectPrx ice_endpoints(Endpoint[] newEndpoints);
 
     /**
-     * Returns the locator cache timeout of this proxy.
+     * Gets the locator cache timeout of this proxy.
      *
      * @return The locator cache timeout value.
      * @see Locator
@@ -298,21 +297,21 @@ public interface ObjectPrx {
     Duration ice_getLocatorCacheTimeout();
 
     /**
-     * Returns the invocation timeout of this proxy.
+     * Gets the invocation timeout of this proxy.
      *
      * @return The invocation timeout value.
      */
     Duration ice_getInvocationTimeout();
 
     /**
-     * Returns the connection id of this proxy.
+     * Gets the connection id of this proxy.
      *
      * @return The connection id.
      */
     String ice_getConnectionId();
 
     /**
-     * Returns a proxy that is identical to this proxy, except it's a fixed proxy bound the given
+     * Creates a proxy that is identical to this proxy, except it's a fixed proxy bound to the given
      * connection.
      *
      * @param connection The fixed proxy connection.
@@ -321,17 +320,17 @@ public interface ObjectPrx {
     ObjectPrx ice_fixed(Connection connection);
 
     /**
-     * Returns whether this proxy is a fixed proxy.
+     * Determines whether this proxy is a fixed proxy.
      *
-     * @return <code>true</code> if this is a fixed proxy, <code>false</code> otherwise.
+     * @return {@code true} if this is a fixed proxy, {@code false} otherwise.
      */
     boolean ice_isFixed();
 
     /**
-     * Returns a proxy that is identical to this proxy, except for the locator cache timeout.
+     * Creates a proxy that is identical to this proxy, except for the locator cache timeout.
      *
      * @param newTimeout The new locator cache timeout (in seconds).
-     * @return The proxy with the new timeout.
+     * @return A proxy with the new timeout.
      * @see Locator
      */
     ObjectPrx ice_locatorCacheTimeout(int newTimeout);
@@ -362,9 +361,9 @@ public interface ObjectPrx {
     ObjectPrx ice_invocationTimeout(Duration newTimeout);
 
     /**
-     * Returns whether this proxy caches connections.
+     * Determines whether this proxy caches connections.
      *
-     * @return <code>true</code> if this proxy caches connections; <code>false</code> otherwise.
+     * @return {@code true} if this proxy caches connections, {@code false} otherwise.
      */
     boolean ice_isConnectionCached();
 
@@ -378,7 +377,7 @@ public interface ObjectPrx {
     ObjectPrx ice_connectionCached(boolean newCache);
 
     /**
-     * Returns how this proxy selects endpoints (randomly or ordered).
+     * Gets the endpoint selection policy for this proxy (randomly or ordered).
      *
      * @return The endpoint selection policy.
      * @see EndpointSelectionType
@@ -395,10 +394,10 @@ public interface ObjectPrx {
     ObjectPrx ice_endpointSelection(EndpointSelectionType newType);
 
     /**
-     * Returns whether this proxy uses only secure endpoints.
+     * Determines whether this proxy uses only secure endpoints.
      *
-     * @return <code>True</code> if this proxy communicates only via secure endpoints; <code>false
-     *     </code> otherwise.
+     * @return {@code true} if this proxy communicates only via secure endpoints, {@code false}
+     *     otherwise.
      */
     boolean ice_isSecure();
 
@@ -422,17 +421,17 @@ public interface ObjectPrx {
     ObjectPrx ice_encodingVersion(EncodingVersion e);
 
     /**
-     * Returns the encoding version used to marshal request parameters.
+     * Gets the encoding version used to marshal request parameters.
      *
      * @return The encoding version.
      */
     EncodingVersion ice_getEncodingVersion();
 
     /**
-     * Returns whether this proxy prefers secure endpoints.
+     * Determines whether this proxy prefers secure endpoints.
      *
-     * @return <code>true</code> if the proxy always attempts to invoke via secure endpoints before
-     *     it attempts to use insecure endpoints; <code>false</code> otherwise.
+     * @return {@code true} if the proxy always attempts to invoke via secure endpoints before
+     *     it attempts to use insecure endpoints, {@code false} otherwise.
      */
     boolean ice_isPreferSecure();
 
@@ -448,10 +447,10 @@ public interface ObjectPrx {
     ObjectPrx ice_preferSecure(boolean b);
 
     /**
-     * Returns the router for this proxy.
+     * Gets the router for this proxy.
      *
      * @return The router for the proxy. If no router is configured for the proxy, the return value
-     *     is <code>null</code>.
+     *     is null.
      */
     RouterPrx ice_getRouter();
 
@@ -464,11 +463,9 @@ public interface ObjectPrx {
     ObjectPrx ice_router(RouterPrx router);
 
     /**
-     * Returns the locator for this proxy.
+     * Gets the locator for this proxy.
      *
-     * @return The locator for this proxy. If no locator is configured, the return value is <code>
-     *     null
-     *     </code>.
+     * @return The locator for this proxy. If no locator is configured, the return value is null.
      */
     LocatorPrx ice_getLocator();
 
@@ -481,9 +478,9 @@ public interface ObjectPrx {
     ObjectPrx ice_locator(LocatorPrx locator);
 
     /**
-     * Returns whether this proxy uses collocation optimization.
+     * Determines whether this proxy uses collocation optimization.
      *
-     * @return <code>true</code> if the proxy uses collocation optimization; <code>false</code>
+     * @return {@code true} if the proxy uses collocation optimization, {@code false}
      *     otherwise.
      */
     boolean ice_isCollocationOptimized();
@@ -498,76 +495,76 @@ public interface ObjectPrx {
     ObjectPrx ice_collocationOptimized(boolean b);
 
     /**
-     * Returns a proxy that is identical to this proxy, but uses twoway invocations.
+     * Creates a proxy that is identical to this proxy, but uses twoway invocations.
      *
      * @return A proxy that uses twoway invocations.
      */
     ObjectPrx ice_twoway();
 
     /**
-     * Returns whether this proxy uses twoway invocations.
+     * Determines whether this proxy uses twoway invocations.
      *
-     * @return <code>true</code> if this proxy uses twoway invocations; <code>false</code>
+     * @return {@code true} if this proxy uses twoway invocations, {@code false}
      *     otherwise.
      */
     boolean ice_isTwoway();
 
     /**
-     * Returns a proxy that is identical to this proxy, but uses oneway invocations.
+     * Creates a proxy that is identical to this proxy, but uses oneway invocations.
      *
      * @return A proxy that uses oneway invocations.
      */
     ObjectPrx ice_oneway();
 
     /**
-     * Returns whether this proxy uses oneway invocations.
+     * Determines whether this proxy uses oneway invocations.
      *
-     * @return <code>true</code> if this proxy uses oneway invocations; <code>false</code>
+     * @return {@code true} if this proxy uses oneway invocations, {@code false}
      *     otherwise.
      */
     boolean ice_isOneway();
 
     /**
-     * Returns a proxy that is identical to this proxy, but uses batch oneway invocations.
+     * Creates a proxy that is identical to this proxy, but uses batch oneway invocations.
      *
-     * @return A new proxy that uses batch oneway invocations.
+     * @return A proxy that uses batch oneway invocations.
      */
     ObjectPrx ice_batchOneway();
 
     /**
-     * Returns whether this proxy uses batch oneway invocations.
+     * Determines whether this proxy uses batch oneway invocations.
      *
-     * @return <code>true</code> if this proxy uses batch oneway invocations; <code>false</code>
+     * @return {@code true} if this proxy uses batch oneway invocations, {@code false}
      *     otherwise.
      */
     boolean ice_isBatchOneway();
 
     /**
-     * Returns a proxy that is identical to this proxy, but uses datagram invocations.
+     * Creates a proxy that is identical to this proxy, but uses datagram invocations.
      *
-     * @return A new proxy that uses datagram invocations.
+     * @return A proxy that uses datagram invocations.
      */
     ObjectPrx ice_datagram();
 
     /**
-     * Returns whether this proxy uses datagram invocations.
+     * Determines whether this proxy uses datagram invocations.
      *
-     * @return <code>true</code> if this proxy uses datagram invocations; <code>false</code>
+     * @return {@code true} if this proxy uses datagram invocations, {@code false}
      *     otherwise.
      */
     boolean ice_isDatagram();
 
     /**
-     * Returns a proxy that is identical to this proxy, but uses batch datagram invocations.
+     * Creates a proxy that is identical to this proxy, but uses batch datagram invocations.
      *
-     * @return A new proxy that uses batch datagram invocations.
+     * @return A proxy that uses batch datagram invocations.
      */
     ObjectPrx ice_batchDatagram();
 
     /**
-     * Returns whether this proxy uses batch datagram invocations.
+     * Determines whether this proxy uses batch datagram invocations.
      *
-     * @return <code>true</code> if this proxy uses batch datagram invocations; <code>false</code>
+     * @return {@code true} if this proxy uses batch datagram invocations, {@code false}
      *     otherwise.
      */
     boolean ice_isBatchDatagram();
@@ -583,7 +580,7 @@ public interface ObjectPrx {
     ObjectPrx ice_compress(boolean co);
 
     /**
-     * Obtains the compression override setting of this proxy.
+     * Gets the compression override setting of this proxy.
      *
      * @return The compression override setting. If no optional value is present, no override is
      *     set. Otherwise, true if compression is enabled, false otherwise.
@@ -600,7 +597,7 @@ public interface ObjectPrx {
     ObjectPrx ice_connectionId(String connectionId);
 
     /**
-     * Returns the {@link Connection} for this proxy. If the proxy does not yet have an established
+     * Gets the connection for this proxy. If the proxy does not yet have an established
      * connection, it first attempts to create a connection.
      *
      * @return The {@link Connection} for this proxy.
@@ -609,7 +606,7 @@ public interface ObjectPrx {
     Connection ice_getConnection();
 
     /**
-     * Returns an executor object that uses the Ice thread pool.
+     * Gets an executor object that uses the Ice thread pool.
      *
      * @return The Executor object.
      */
@@ -618,30 +615,30 @@ public interface ObjectPrx {
     }
 
     /**
-     * Asynchronously gets the connection for this proxy. The call does not block.
+     * Gets the connection for this proxy asynchronously. The call does not block.
      *
      * @return A future for the completion of the request.
      */
     CompletableFuture<Connection> ice_getConnectionAsync();
 
     /**
-     * Returns the cached {@link Connection} for this proxy. If the proxy does not yet have an
+     * Gets the cached {@link Connection} for this proxy. If the proxy does not yet have an
      * established connection, it does not attempt to create a connection.
      *
-     * @return The cached {@link Connection} for this proxy (<code>null</code> if the proxy does not
+     * @return The cached {@link Connection} for this proxy (null if the proxy does not
      *     have an established connection).
      * @see Connection
      */
     Connection ice_getCachedConnection();
 
     /**
-     * Flushes any pending batched requests for this communicator. The call blocks until the flush
+     * Flushes any pending batched requests for this proxy. The call blocks until the flush
      * is complete.
      */
     void ice_flushBatchRequests();
 
     /**
-     * Asynchronously flushes any pending batched requests for this communicator. The call does not
+     * Flushes any pending batched requests for this proxy asynchronously. The call does not
      * block.
      *
      * @return A future for the completion of the request.
@@ -649,12 +646,12 @@ public interface ObjectPrx {
     CompletableFuture<Void> ice_flushBatchRequestsAsync();
 
     /**
-     * Returns whether this proxy equals the passed object. Two proxies are equal if they are equal
+     * Determines whether this proxy equals the passed object. Two proxies are equal if they are equal
      * in all respects, that is, if their object identity, endpoints timeout settings, and so on are
      * all equal.
      *
      * @param r The object to compare this proxy with.
-     * @return <code>true</code> if this proxy is equal to <code>r</code>; <code>false</code>
+     * @return {@code true} if this proxy is equal to {@code r}, {@code false}
      *     otherwise.
      */
     @Override
@@ -664,7 +661,7 @@ public interface ObjectPrx {
     static final String ice_staticId = "::Ice::Object";
 
     /**
-     * Returns the Slice type ID associated with this type.
+     * Gets the Slice type ID associated with this type.
      *
      * @return The Slice type ID.
      */
@@ -678,7 +675,7 @@ public interface ObjectPrx {
      * @param communicator The communicator of the new proxy.
      * @param proxyString The string representation of the proxy.
      * @return The new proxy.
-     * @throws ParseException Thrown when <code>proxyString</code> is not a valid proxy string.
+     * @throws ParseException Thrown when {@code proxyString} is not a valid proxy string.
      */
     public static ObjectPrx createProxy(Communicator communicator, String proxyString) {
         var ref = communicator.getInstance().referenceFactory().create(proxyString, null);
@@ -693,8 +690,8 @@ public interface ObjectPrx {
      * will throw an Ice run-time exception if the target object does not exist or the server cannot
      * be reached.
      *
-     * @param obj The proxy to cast to @{link ObjectPrx}.
-     * @return <code>obj</code>.
+     * @param obj The proxy to cast to {@link ObjectPrx}.
+     * @return {@code obj}.
      */
     static ObjectPrx checkedCast(ObjectPrx obj) {
         return checkedCast(obj, noExplicitContext);
@@ -706,8 +703,8 @@ public interface ObjectPrx {
      * reached.
      *
      * @param obj The proxy to cast to {@link ObjectPrx}.
-     * @param context The <code>Context</code> map for the invocation.
-     * @return <code>obj</code>.
+     * @param context The {@code Context} map for the invocation.
+     * @return {@code obj}.
      */
     static ObjectPrx checkedCast(ObjectPrx obj, Map<String, String> context) {
         return obj != null && obj.ice_isA(ice_staticId, context) ? obj : null;
@@ -746,7 +743,7 @@ public interface ObjectPrx {
      * succeeds.
      *
      * @param obj The proxy to cast to {@link ObjectPrx}.
-     * @return <code>obj</code>.
+     * @return {@code obj}.
      */
     static ObjectPrx uncheckedCast(ObjectPrx obj) {
         return obj;
@@ -778,7 +775,7 @@ public interface ObjectPrx {
      * Reads a proxy from the stream.
      *
      * @param istr The source stream.
-     * @return A new proxy or null for a nil proxy.
+     * @return A new proxy or null for a null proxy.
      */
     static ObjectPrx read(InputStream istr) {
         return istr.readProxy();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OperationNotExistException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OperationNotExistException.java
@@ -3,9 +3,9 @@
 package com.zeroc.Ice;
 
 /**
- * This exception is raised if an operation for a given object does not exist on the server. This is
- * typically due to a mismatch in the Slice definitions, such as the client using Slice definitions
- * newer than the server's.
+ * The exception that is thrown when a dispatch cannot find the operation carried by the request on the target
+ * servant. This is typically due to a mismatch in the Slice definitions, such as the client using Slice
+ * definitions newer than the server's.
  */
 public final class OperationNotExistException extends RequestFailedException {
     /**

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SecurityException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SecurityException.java
@@ -2,7 +2,7 @@
 
 package com.zeroc.Ice;
 
-/** This exception indicates a failure in a security subsystem. */
+/** The exception that is thrown when a failure occurs in the security subsystem. This includes IceSSL errors. */
 public final class SecurityException extends LocalException {
     /**
      * Constructs a SecurityException with a message.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TwowayOnlyException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TwowayOnlyException.java
@@ -3,10 +3,9 @@
 package com.zeroc.Ice;
 
 /**
- * The operation can only be invoked with a twoway request. This exception is raised if an attempt
- * is made to invoke an operation with <code>ice_oneway</code>, <code>ice_batchOneway</code>, <code>
- * ice_datagram</code>, or <code>ice_batchDatagram</code> and the operation has a return value,
- * out-parameters, or an exception specification.
+ * The exception that is thrown when attempting to invoke an operation with {@code ice_oneway}, {@code ice_batchOneway},
+ * {@code ice_datagram}, or {@code ice_batchDatagram}, and the operation has a return value, an out parameter, or an exception
+ * specification.
  */
 public final class TwowayOnlyException extends LocalException {
     /**

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UnknownException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UnknownException.java
@@ -3,8 +3,8 @@
 package com.zeroc.Ice;
 
 /**
- * This exception is raised if an operation call on a server raises an unknown exception, that is,
- * any exception which does not derive from {@link LocalException} or {@link UserException}.
+ * The exception that is thrown when a dispatch failed with an exception that is not a LocalException or a
+ * UserException.
  */
 public class UnknownException extends DispatchException {
     /**

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UnknownLocalException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UnknownLocalException.java
@@ -3,11 +3,7 @@
 package com.zeroc.Ice;
 
 /**
- * This exception is raised if an operation call on a server raises a local exception. Because local
- * exceptions are not transmitted by the Ice protocol, the client receives all local exceptions
- * raised by the server as {@link UnknownLocalException}. The only exception to this rule are all
- * exceptions derived from {@link DispatchException}, which are transmitted by the Ice protocol even
- * though they are declared <code>local</code>.
+ * The exception that is thrown when a dispatch failed with a LocalException that is not a DispatchException.
  */
 public final class UnknownLocalException extends UnknownException {
     /**

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UnknownUserException.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UnknownUserException.java
@@ -3,10 +3,8 @@
 package com.zeroc.Ice;
 
 /**
- * The dispatch returned a {@link UserException} that was not declared in the operation's exception
- * specification (the <code>throws</code> clause). This is necessary in order to not violate the
- * contract established by an operation's signature: Only local exceptions and user exceptions
- * declared in the <code>throws</code> clause can be raised.
+ * The exception that is thrown when a client receives a UserException that was not declared in the operation's
+ * exception specification.
  */
 public final class UnknownUserException extends UnknownException {
     /**

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadFactory;
 
-/** Utility methods for the Ice run time. */
+/** Utility methods for the Ice runtime. */
 public final class Util {
     /**
      * Creates a new empty property set.
@@ -41,11 +41,11 @@ public final class Util {
     }
 
     /**
-     * Creates a property set initialized from an argument vector and return the remaining
+     * Creates a property set initialized from an argument vector and returns the remaining
      * arguments.
      *
      * @param args A command-line argument vector, possibly containing options to set properties. If
-     *     the command-line options include a <code>--Ice.Config</code> option, the corresponding
+     *     the command-line options include a {@code --Ice.Config} option, the corresponding
      *     configuration files are parsed. If the same property is set in a configuration file and
      *     in the argument vector, the argument vector takes precedence.
      * @param remainingArgs If non null, the given list will contain on return the command-line
@@ -63,12 +63,11 @@ public final class Util {
      * Creates a property set initialized from an argument vector.
      *
      * @param args A command-line argument vector, possibly containing options to set properties. If
-     *     the command-line options include a <code>--Ice.Config</code> option, the corresponding
+     *     the command-line options include a {@code --Ice.Config} option, the corresponding
      *     configuration files are parsed. If the same property is set in a configuration file and
      *     in the argument vector, the argument vector takes precedence.
      * @param defaults Default values for the property set. Settings in configuration files and
-     *     <code>
-     *     args</code> override these defaults.
+     *     {@code args} override these defaults.
      * @return A new property set initialized with the property settings that were removed from the
      *     argument vector.
      * @deprecated Use {@link Properties#Properties(String[], Properties)} instead.
@@ -79,16 +78,15 @@ public final class Util {
     }
 
     /**
-     * Creates a property set initialized from an argument vector and return the remaining
+     * Creates a property set initialized from an argument vector and returns the remaining
      * arguments.
      *
      * @param args A command-line argument vector, possibly containing options to set properties. If
-     *     the command-line options include a <code>--Ice.Config</code> option, the corresponding
+     *     the command-line options include a {@code --Ice.Config} option, the corresponding
      *     configuration files are parsed. If the same property is set in a configuration file and
      *     in the argument vector, the argument vector takes precedence.
      * @param defaults Default values for the property set. Settings in configuration files and
-     *     <code>
-     *     args</code> override these defaults.
+     *     {@code args} override these defaults.
      * @param remainingArgs If non null, the given list will contain on return the command-line
      *     arguments that were not used to set properties.
      * @return A new property set initialized with the property settings that were removed from the
@@ -102,16 +100,16 @@ public final class Util {
     }
 
     /**
-     * Creates a communicator using a default configuration.
+     * Creates a new communicator.
      *
-     * @return A new communicator instance.
+     * @return The new communicator.
      */
     public static Communicator initialize() {
         return initialize(new InitializationData());
     }
 
     /**
-     * Creates a communicator.
+     * Creates a new communicator.
      *
      * @param args A command-line argument vector. Any Ice-related options in this vector are used
      *     to initialize the communicator.
@@ -122,7 +120,7 @@ public final class Util {
     }
 
     /**
-     * Creates a communicator.
+     * Creates a new communicator.
      *
      * @param args A command-line argument vector. Any Ice-related options in this vector are used
      *     to initialize the communicator.
@@ -135,7 +133,7 @@ public final class Util {
     }
 
     /**
-     * Creates a communicator.
+     * Creates a new communicator.
      *
      * @param initData Additional initialization data.
      * @return The new communicator.
@@ -145,7 +143,7 @@ public final class Util {
     }
 
     /**
-     * Creates a communicator.
+     * Creates a new communicator.
      *
      * @param args A command-line argument vector. Any Ice-related options in this vector are used
      *     to initialize the communicator.
@@ -157,7 +155,7 @@ public final class Util {
     }
 
     /**
-     * Creates a communicator.
+     * Creates a new communicator.
      *
      * @param args A command-line argument vector. Any Ice-related options in this vector are used
      *     to initialize the communicator.
@@ -169,12 +167,12 @@ public final class Util {
     }
 
     /**
-     * Creates a communicator.
+     * Creates a new communicator.
      *
      * @param args A command-line argument vector. Any Ice-related options in this vector are used
      *     to initialize the communicator.
-     * @param initData Additional initialization data. Property settings in <code>args</code>
-     *     override property settings in <code>initData</code>.
+     * @param initData Additional initialization data. Property settings in {@code args}
+     *     override property settings in {@code initData}.
      * @param remainingArgs If non null, the given list will contain on return the command-line
      *     arguments that were not used to set properties.
      * @return The new communicator.
@@ -200,7 +198,7 @@ public final class Util {
     }
 
     /**
-     * Creates a communicator.
+     * Creates a new communicator.
      *
      * @param args A command-line argument vector. Any Ice-related options in this vector are used
      *     to initialize the communicator.
@@ -222,7 +220,7 @@ public final class Util {
     }
 
     /**
-     * Converts a string to an object identity.
+     * Converts a stringified identity into an Identity.
      *
      * @param s The string to convert.
      * @return The converted object identity.
@@ -285,11 +283,10 @@ public final class Util {
     }
 
     /**
-     * Converts an object identity to a string.
+     * Converts an Identity into a string using the specified mode.
      *
      * @param ident The object identity to convert.
-     * @param toStringMode Specifies if and how non-printable ASCII characters are escaped in the
-     *     result.
+     * @param toStringMode Specifies how to handle non-ASCII characters and non-printable ASCII characters.
      * @return The string representation of the object identity.
      */
     public static String identityToString(Identity ident, ToStringMode toStringMode) {
@@ -317,8 +314,8 @@ public final class Util {
      *
      * @param lhs A proxy.
      * @param rhs A proxy.
-     * @return -1 if the identity in <code>lhs</code> compares less than the identity in <code>rhs
-     *     </code>; 0 if the identities compare equal; 1, otherwise.
+     * @return -1 if the identity in {@code lhs} compares less than the identity in {@code rhs};
+     *     0 if the identities compare equal; 1, otherwise.
      * @see ProxyIdentityKey
      * @see ProxyIdentityFacetKey
      * @see #proxyIdentityAndFacetCompare
@@ -346,8 +343,8 @@ public final class Util {
      *
      * @param lhs A proxy.
      * @param rhs A proxy.
-     * @return -1 if the identity and facet in <code>lhs</code> compare less than the identity and
-     *     facet in <code>rhs</code>; 0 if the identities and facets compare equal; 1, otherwise.
+     * @return -1 if the identity and facet in {@code lhs} compare less than the identity and
+     *     facet in {@code rhs}; 0 if the identities and facets compare equal; 1, otherwise.
      * @see ProxyIdentityFacetKey
      * @see ProxyIdentityKey
      * @see #proxyIdentityCompare
@@ -384,9 +381,10 @@ public final class Util {
     }
 
     /**
-     * Returns the process-wide logger.
+     * Gets the per-process logger. This logger is used by all communicators that do not have their own specific logger
+     * configured at the time the communicator is created.
      *
-     * @return The process-wide logger.
+     * @return The current per-process logger instance.
      */
     public static Logger getProcessLogger() {
         synchronized (_processLoggerMutex) {
@@ -402,9 +400,10 @@ public final class Util {
     }
 
     /**
-     * Changes the process-wide logger.
+     * Sets the per-process logger. This logger is used by all communicators that do not have their own specific logger
+     * configured at the time the communicator is created.
      *
-     * @param logger The new process-wide logger.
+     * @param logger The new per-process logger instance.
      */
     public static void setProcessLogger(Logger logger) {
         synchronized (_processLoggerMutex) {
@@ -413,8 +412,8 @@ public final class Util {
     }
 
     /**
-     * Returns the Ice version in the form <code>A.B.C</code>, where <code>A</code> indicates the
-     * major version, <code>B</code> indicates the minor version, and <code>C</code> indicates the
+     * Returns the Ice version in the form {@code A.B.C}, where {@code A} indicates the
+     * major version, {@code B} indicates the minor version, and {@code C} indicates the
      * patch level.
      *
      * @return The Ice version.
@@ -424,8 +423,8 @@ public final class Util {
     }
 
     /**
-     * Returns the Ice version as an integer in the form <code>A.BB.CC</code>, where <code>A</code>
-     * indicates the major version, <code>BB</code> indicates the minor version, and <code>CC</code>
+     * Returns the Ice version as an integer in the form {@code A.BB.CC}, where {@code A}
+     * indicates the major version, {@code BB} indicates the minor version, and {@code CC}
      * indicates the patch level. For example, for Ice 3.3.1, the returned value is 30301.
      *
      * @return The Ice version.
@@ -511,7 +510,7 @@ public final class Util {
     /**
      * Translates a Slice type id to a Java class name.
      *
-     * @param id The Slice type id, such as <code>::Module::Type</code>.
+     * @param id The Slice type id, such as {@code ::Module::Type}.
      * @return The equivalent Java class name, or null if the type id is malformed.
      */
     public static String typeIdToClass(String id) {


### PR DESCRIPTION
This PR syncs Java doc comments with their C++ counterparts. 

Namely:

- Communicator
- ObjectAdater
- Connection
- ObjectPrx
- *Exception
- Util/Initialize