### PR TITLE
Remove Communicator.destroyAsync in MATLAB

### DIFF
--- a/matlab/lib/+Ice/Communicator.m
+++ b/matlab/lib/+Ice/Communicator.m
@@ -7,7 +7,6 @@ classdef Communicator < IceInternal.WrapperObject
     %   Communicator Methods:
     %     Communicator - Constructs a new communicator.
     %     destroy - Destroys the communicator.
-    %     destroyAsync - An asynchronous destroy.
     %     flushBatchRequests - Flushes any pending batch requests for this communicator.
     %     flushBatchRequestsAsync - An asynchronous flushBatchRequests.
     %     getDefaultLocator - Gets the default locator for this communicator.
@@ -110,23 +109,6 @@ classdef Communicator < IceInternal.WrapperObject
                 obj (1, 1) Ice.Communicator
             end
             obj.iceCall('destroy');
-        end
-
-        function f = destroyAsync(obj)
-            %DESTROYASYNC Asynchronously destroys the communicator.
-            %   This method closes all outgoing connections.
-            %
-            %   Output Arguments
-            %     f - A future that will be completed when the destruction completes.
-            %       Ice.Future scalar
-
-            arguments
-                obj (1, 1) Ice.Communicator
-            end
-            future = libpointer('voidPtr');
-            obj.iceCall('destroyAsync', future);
-            assert(~isNull(future));
-            f = Ice.Future(future, 'destroy', 0, 'Ice_SimpleFuture', @(fut) fut.iceCall('check'));
         end
 
         function r = stringToProxy(obj, str)

--- a/matlab/src/Communicator.cpp
+++ b/matlab/src/Communicator.cpp
@@ -25,30 +25,6 @@ extern "C"
         return createEmptyArray();
     }
 
-    mxArray* Ice_Communicator_destroyAsync(void* self, void** future)
-    {
-        *future = 0;
-        auto c = deref<Ice::Communicator>(self);
-        auto f = make_shared<SimpleFuture>();
-
-        thread t(
-            [c, f]
-            {
-                try
-                {
-                    c->destroy();
-                    f->done();
-                }
-                catch (const std::exception&)
-                {
-                    f->exception(current_exception());
-                }
-            });
-        t.detach();
-        *future = new shared_ptr<SimpleFuture>(move(f));
-        return createEmptyArray();
-    }
-
     mxArray* Ice_Communicator_stringToProxy(void* self, const char* s, void** proxy)
     {
         try

--- a/matlab/src/ice.h
+++ b/matlab/src/ice.h
@@ -32,7 +32,6 @@ extern "C"
 
     ICE_MATLAB_API mxArray* Ice_Communicator_unref(void*);
     ICE_MATLAB_API mxArray* Ice_Communicator_destroy(void*);
-    ICE_MATLAB_API mxArray* Ice_Communicator_destroyAsync(void*, void**);
     ICE_MATLAB_API mxArray* Ice_Communicator_stringToProxy(void*, const char*, void**);
     ICE_MATLAB_API mxArray* Ice_Communicator_proxyToString(void*, void*);
     ICE_MATLAB_API mxArray* Ice_Communicator_propertyToProxy(void*, const char*, void**);


### PR DESCRIPTION
destroy is always synchronous for a pure client app.