### PR TITLE
Remove TypeContext Code from `slice2swift`

### DIFF
--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -912,7 +912,8 @@ SwiftGenerator::writeMembers(IceInternal::Output& out, const DataMemberList& mem
 
         // If the member type is equal to the member name, create a local type alias to avoid ambiguity.
         string alias;
-        if (memberName == memberType && (dynamic_pointer_cast<Struct>(type) || dynamic_pointer_cast<Sequence>(type) || dynamic_pointer_cast<Dictionary>(type)))
+        if (memberName == memberType && (dynamic_pointer_cast<Struct>(type) || dynamic_pointer_cast<Sequence>(type) ||
+                                         dynamic_pointer_cast<Dictionary>(type)))
         {
             ModulePtr topLevelModule = (dynamic_pointer_cast<Contained>(type))->getTopLevelModule();
             alias = removeEscaping(topLevelModule->mappedName()) + "_" + removeEscaping(memberType);

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -10,9 +10,6 @@ using StringPairList = std::list<std::pair<std::string, std::string>>;
 
 namespace Slice
 {
-    const int TypeContextInParam = 1;
-    const int TypeContextProtocol = 2;
-
     std::string getSwiftModule(const ModulePtr&, std::string&);
     std::string getSwiftModule(const ModulePtr&);
 
@@ -76,7 +73,7 @@ namespace Slice
             const DataMemberList&,
             const ContainedPtr&,
             bool rootClass);
-        void writeMembers(IceInternal::Output&, const DataMemberList&, const ContainedPtr&, int = 0);
+        void writeMembers(IceInternal::Output&, const DataMemberList&, const ContainedPtr&);
 
         void writeMarshalUnmarshalCode(
             ::IceInternal::Output&,


### PR DESCRIPTION
The `writeMembers` function takes a 4th argument with a default value of `0`.
We never passed this argument when calling it so it was always `0`.

We also had some useless `TypeContext` constants hanging around that could also be deleted.

Came across this while trying to fix Swift link generation.