### PR TITLE
Output parameters on separate lines and add missing params to checkedCastAsync (C#)

### DIFF
--- a/cpp/src/Ice/OutputUtil.cpp
+++ b/cpp/src/Ice/OutputUtil.cpp
@@ -250,7 +250,15 @@ IceInternal::Output::print(const string& s)
     {
         if (++_par > 1) // No comma for the first parameter.
         {
-            _out << ", ";
+            if (_parOnNewLine)
+            {
+                _out << ','; // no trailing whitespace
+                newline();
+            }
+            else
+            {
+                _out << ", ";
+            }
         }
     }
     OutputBase::print(s);
@@ -301,17 +309,28 @@ IceInternal::Output::eb()
 }
 
 void
-IceInternal::Output::spar(string_view s)
+IceInternal::Output::spar(string_view s, bool parOnNewLine)
 {
     _emptyBlock = false;
     _out << s;
     _par = 0;
+    _parOnNewLine = parOnNewLine;
+    if (_parOnNewLine)
+    {
+        inc();
+        newline();
+    }
 }
 
 void
 IceInternal::Output::epar(string_view s)
 {
     _par = -1;
+    if (_parOnNewLine)
+    {
+        dec();
+        _parOnNewLine = false;
+    }
     _out << s;
 }
 

--- a/cpp/src/Ice/OutputUtil.h
+++ b/cpp/src/Ice/OutputUtil.h
@@ -90,7 +90,7 @@ namespace IceInternal
         void eb(); // End a block.
 
         void spar(std::string_view s = "(", bool parOnNewLine = false); // Start a parameter list.
-        void epar(std::string_view s = ")"); // End a parameter list.
+        void epar(std::string_view s = ")");                            // End a parameter list.
 
     private:
         std::string _blockStart;

--- a/cpp/src/Ice/OutputUtil.h
+++ b/cpp/src/Ice/OutputUtil.h
@@ -89,13 +89,14 @@ namespace IceInternal
         void sb(); // Start a block.
         void eb(); // End a block.
 
-        void spar(std::string_view s = "("); // Start a parameter list.
+        void spar(std::string_view s = "(", bool parOnNewLine = false); // Start a parameter list.
         void epar(std::string_view s = ")"); // End a parameter list.
 
     private:
         std::string _blockStart;
         std::string _blockEnd;
         int _par;                     // If >= 0, we are writing a parameter list.
+        bool _parOnNewLine{false};    // When true, each parameter is written on a new line.
         const bool _breakBeforeBlock; // If true break before starting a new block.
         const bool _shortEmptyBlock;  // If true, an empty block is written <sb><eb>.
         bool _emptyBlock;

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2067,14 +2067,14 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 
     _out << sp;
     writeDocLine(_out, "summary", checkedCastSummary.str());
-    writeDocLine(_out, R"(param name="b")", "The source proxy.", "param");
-    writeDocLine(_out, R"(param name="ctx")", "The request context.", "param");
+    writeDocLine(_out, R"(param name="proxy")", "The source proxy.", "param");
+    writeDocLine(_out, R"(param name="context")", "The request context.", "param");
     writeDocLine(_out, "returns", checkedCastReturns.str());
     _out << nl << "public static " << name
-         << "Prx? checkedCast(Ice.ObjectPrx? b, global::System.Collections.Generic.Dictionary<string, string>? ctx = "
+         << "Prx? checkedCast(Ice.ObjectPrx? proxy, global::System.Collections.Generic.Dictionary<string, string>? context = "
             "null) =>";
     _out.inc();
-    _out << nl << "b is not null && b.ice_isA(ice_staticId(), ctx) ? new " << name << "PrxHelper(b) : null;";
+    _out << nl << "proxy is not null && proxy.ice_isA(ice_staticId(), context) ? new " << name << "PrxHelper(proxy) : null;";
     _out.dec();
 
     ostringstream checkedCastWithFacetSummary;
@@ -2089,41 +2089,41 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 
     _out << sp;
     writeDocLine(_out, "summary", checkedCastWithFacetSummary.str());
-    writeDocLine(_out, R"(param name="b")", "The source proxy.", "param");
-    writeDocLine(_out, R"(param name="f")", "The facet.", "param");
-    writeDocLine(_out, R"(param name="ctx")", "The request context.", "param");
+    writeDocLine(_out, R"(param name="proxy")", "The source proxy.", "param");
+    writeDocLine(_out, R"(param name="facet")", "The facet.", "param");
+    writeDocLine(_out, R"(param name="context")", "The request context.", "param");
     writeDocLine(_out, "returns", checkedCastWithFacetReturns.str());
     _out << nl << "public static " << name
-         << "Prx? checkedCast(Ice.ObjectPrx? b, string f, global::System.Collections.Generic.Dictionary<string, "
-            "string>? ctx = null) =>";
+         << "Prx? checkedCast(Ice.ObjectPrx? proxy, string facet, global::System.Collections.Generic.Dictionary<string, "
+            "string>? context = null) =>";
     _out.inc();
-    _out << nl << "checkedCast(b?.ice_facet(f), ctx);";
+    _out << nl << "checkedCast(proxy?.ice_facet(facet), context);";
     _out.dec();
 
     _out << sp;
     writeDocLine(_out, "summary", checkedCastSummary.str());
-    writeDocLine(_out, R"(param name="b")", "The source proxy.", "param");
-    writeDocLine(_out, R"(param name="ctx")", "The request context.", "param");
+    writeDocLine(_out, R"(param name="proxy")", "The source proxy.", "param");
+    writeDocLine(_out, R"(param name="context")", "The request context.", "param");
     writeDocLine(_out, "returns", checkedCastReturns.str());
     _out << nl << "public static async global::System.Threading.Tasks.Task<" << name
-         << "Prx?> checkedCastAsync(Ice.ObjectPrx b, global::System.Collections.Generic.Dictionary<string, string>? "
-            "ctx = null) =>";
+         << "Prx?> checkedCastAsync(Ice.ObjectPrx proxy, global::System.Collections.Generic.Dictionary<string, string>? "
+            "context = null, global::System.IProgress<bool>? progress = null, global::System.Threading.CancellationToken cancel = default) =>";
     _out.inc();
-    _out << nl << "await b.ice_isAAsync(ice_staticId(), ctx).ConfigureAwait(false) ? new " << name
-         << "PrxHelper(b) : null;";
+    _out << nl << "await proxy.ice_isAAsync(ice_staticId(), context, progress, cancel).ConfigureAwait(false) ? new " << name
+         << "PrxHelper(proxy) : null;";
     _out.dec();
 
     _out << sp;
     writeDocLine(_out, "summary", checkedCastWithFacetSummary.str());
-    writeDocLine(_out, R"(param name="b")", "The source proxy.", "param");
-    writeDocLine(_out, R"(param name="f")", "The facet.", "param");
-    writeDocLine(_out, R"(param name="ctx")", "The request context.", "param");
+    writeDocLine(_out, R"(param name="proxy")", "The source proxy.", "param");
+    writeDocLine(_out, R"(param name="facet")", "The facet.", "param");
+    writeDocLine(_out, R"(param name="context")", "The request context.", "param");
     writeDocLine(_out, "returns", checkedCastWithFacetReturns.str());
     _out << nl << "public static global::System.Threading.Tasks.Task<" << name
-         << "Prx?> checkedCastAsync(Ice.ObjectPrx b, string f, global::System.Collections.Generic.Dictionary<string, "
-            "string>? ctx = null) =>";
+         << "Prx?> checkedCastAsync(Ice.ObjectPrx proxy, string facet, global::System.Collections.Generic.Dictionary<string, "
+            "string>? context = null, global::System.IProgress<bool>? progress = null, global::System.Threading.CancellationToken cancel = default) =>";
     _out.inc();
-    _out << nl << "checkedCastAsync(b.ice_facet(f), ctx);";
+    _out << nl << "checkedCastAsync(proxy.ice_facet(facet), context, progress, cancel);";
     _out.dec();
 
     ostringstream uncheckedCastSummary;
@@ -2132,12 +2132,12 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 
     _out << sp;
     writeDocLine(_out, "summary", uncheckedCastSummary.str());
-    writeDocLine(_out, R"(param name="b")", "The source proxy.", "param");
+    writeDocLine(_out, R"(param name="proxy")", "The source proxy.", "param");
     writeDocLine(_out, "returns", "A proxy with the requested type, or null if the source proxy is null.");
-    _out << nl << "[return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(b))]";
-    _out << nl << "public static " << name << "Prx? uncheckedCast(Ice.ObjectPrx? b) =>";
+    _out << nl << "[return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(proxy))]";
+    _out << nl << "public static " << name << "Prx? uncheckedCast(Ice.ObjectPrx? proxy) =>";
     _out.inc();
-    _out << nl << "b is not null ? new " << name << "PrxHelper(b) : null;";
+    _out << nl << "proxy is not null ? new " << name << "PrxHelper(proxy) : null;";
     _out.dec();
 
     ostringstream uncheckedCastWithFacetSummary;
@@ -2146,13 +2146,13 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 
     _out << sp;
     writeDocLine(_out, "summary", uncheckedCastWithFacetSummary.str());
-    writeDocLine(_out, R"(param name="b")", "The source proxy.", "param");
-    writeDocLine(_out, R"(param name="f")", "The facet.", "param");
+    writeDocLine(_out, R"(param name="proxy")", "The source proxy.", "param");
+    writeDocLine(_out, R"(param name="facet")", "The facet.", "param");
     writeDocLine(_out, "returns", "A proxy with the requested type, or null if the source proxy is null.");
-    _out << nl << "[return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(b))]";
-    _out << nl << "public static " << name << "Prx? uncheckedCast(Ice.ObjectPrx? b, string f) =>";
+    _out << nl << "[return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(proxy))]";
+    _out << nl << "public static " << name << "Prx? uncheckedCast(Ice.ObjectPrx? proxy, string facet) =>";
     _out.inc();
-    _out << nl << "uncheckedCast(b?.ice_facet(f));";
+    _out << nl << "uncheckedCast(proxy?.ice_facet(facet));";
     _out.dec();
 
     ostringstream staticId;

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2241,8 +2241,8 @@ Slice::Gen::TypesVisitor::visitOperation(const OperationPtr& p)
         _out << nl << retS << " " << name;
         _out.spar("(", true);
         _out << getParams(p, ns);
-        _out << ("global::System.Collections.Generic.Dictionary<string, string>? " + context + " = null")
-            << epar << ';';
+        _out << ("global::System.Collections.Generic.Dictionary<string, string>? " + context + " = null") << epar
+             << ';';
     }
 
     {

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2241,7 +2241,8 @@ Slice::Gen::TypesVisitor::visitOperation(const OperationPtr& p)
         _out << nl << retS << " " << name;
         _out.spar("(", true);
         _out << getParams(p, ns);
-        _out << "global::System.Collections.Generic.Dictionary<string, string>? " + context + " = null" << epar << ';';
+        _out << ("global::System.Collections.Generic.Dictionary<string, string>? " + context + " = null")
+            << epar << ';';
     }
 
     {

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1803,8 +1803,10 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         string context = getEscapedParamName(op->parameters(), "context");
 
         _out << sp;
-        _out << nl << "public " << retS << " " << opName << spar << params
-             << ("global::System.Collections.Generic.Dictionary<string, string>? " + context + " = null") << epar;
+        _out << nl << "public " << retS << " " << opName;
+        _out.spar("(", true);
+        _out << params << ("global::System.Collections.Generic.Dictionary<string, string>? " + context + " = null")
+             << epar;
         _out << sb;
         _out << nl << "try";
         _out << sb;
@@ -1886,8 +1888,9 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         {
             _out << "<" << returnTypeS << ">";
         }
-        _out << " " << opName << "Async" << spar << paramsAMI
-             << ("global::System.Collections.Generic.Dictionary<string, string>? " + context + " = null")
+        _out << " " << opName << "Async";
+        _out.spar("(", true);
+        _out << paramsAMI << ("global::System.Collections.Generic.Dictionary<string, string>? " + context + " = null")
              << ("global::System.IProgress<bool>? " + progress + " = null")
              << ("global::System.Threading.CancellationToken " + cancel + " = default") << epar;
 
@@ -1905,8 +1908,9 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         {
             _out << "<" << returnTypeS << ">";
         }
-        _out << " _iceI_" << removeEscapePrefix(opName) << "Async" << spar << getInParams(op, ns, true)
-             << "global::System.Collections.Generic.Dictionary<string, string>? context"
+        _out << " _iceI_" << removeEscapePrefix(opName) << "Async";
+        _out.spar("(", true);
+        _out << getInParams(op, ns, true) << "global::System.Collections.Generic.Dictionary<string, string>? context"
              << "global::System.IProgress<bool>? progress"
              << "global::System.Threading.CancellationToken cancel"
              << "bool synchronous" << epar;
@@ -1941,8 +1945,9 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         // Write the common invoke method
         //
         _out << sp << nl;
-        _out << "private void _iceI_" << removeEscapePrefix(opName) << spar << getInParams(op, ns, true)
-             << "global::System.Collections.Generic.Dictionary<string, string>? context"
+        _out << "private void _iceI_" << removeEscapePrefix(opName);
+        _out.spar("(", true);
+        _out << getInParams(op, ns, true) << "global::System.Collections.Generic.Dictionary<string, string>? context"
              << "bool synchronous"
              << "Ice.Internal.OutgoingAsyncCompletionCallback completed" << epar;
         _out << sb;
@@ -2070,11 +2075,14 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="proxy")", "The source proxy.", "param");
     writeDocLine(_out, R"(param name="context")", "The request context.", "param");
     writeDocLine(_out, "returns", checkedCastReturns.str());
-    _out << nl << "public static " << name
-         << "Prx? checkedCast(Ice.ObjectPrx? proxy, global::System.Collections.Generic.Dictionary<string, string>? context = "
-            "null) =>";
+    _out << nl << "public static " << name << "Prx? checkedCast";
+    _out.spar("(", true);
+    _out << "Ice.ObjectPrx? proxy"
+         << "global::System.Collections.Generic.Dictionary<string, string>? context = null";
+    _out << epar << " =>";
     _out.inc();
-    _out << nl << "proxy is not null && proxy.ice_isA(ice_staticId(), context) ? new " << name << "PrxHelper(proxy) : null;";
+    _out << nl << "proxy is not null && proxy.ice_isA(ice_staticId(), context) ? new " << name
+         << "PrxHelper(proxy) : null;";
     _out.dec();
 
     ostringstream checkedCastWithFacetSummary;
@@ -2093,9 +2101,11 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="facet")", "The facet.", "param");
     writeDocLine(_out, R"(param name="context")", "The request context.", "param");
     writeDocLine(_out, "returns", checkedCastWithFacetReturns.str());
-    _out << nl << "public static " << name
-         << "Prx? checkedCast(Ice.ObjectPrx? proxy, string facet, global::System.Collections.Generic.Dictionary<string, "
-            "string>? context = null) =>";
+    _out << nl << "public static " << name << "Prx? checkedCast";
+    _out.spar("(", true);
+    _out << "Ice.ObjectPrx? proxy"
+         << "string facet"
+         << "global::System.Collections.Generic.Dictionary<string, string>? context = null" << epar << " =>";
     _out.inc();
     _out << nl << "checkedCast(proxy?.ice_facet(facet), context);";
     _out.dec();
@@ -2104,13 +2114,18 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, "summary", checkedCastSummary.str());
     writeDocLine(_out, R"(param name="proxy")", "The source proxy.", "param");
     writeDocLine(_out, R"(param name="context")", "The request context.", "param");
+    writeDocLine(_out, R"(param name="progress")", "The sent progress reporter.", "param");
+    writeDocLine(_out, R"(param name="cancel")", "The cancellation token.", "param");
     writeDocLine(_out, "returns", checkedCastReturns.str());
-    _out << nl << "public static async global::System.Threading.Tasks.Task<" << name
-         << "Prx?> checkedCastAsync(Ice.ObjectPrx proxy, global::System.Collections.Generic.Dictionary<string, string>? "
-            "context = null, global::System.IProgress<bool>? progress = null, global::System.Threading.CancellationToken cancel = default) =>";
+    _out << nl << "public static async global::System.Threading.Tasks.Task<" << name << "Prx?> checkedCastAsync";
+    _out.spar("(", true);
+    _out << "Ice.ObjectPrx proxy"
+         << "global::System.Collections.Generic.Dictionary<string, string>? context = null"
+         << "global::System.IProgress<bool>? progress = null"
+         << "global::System.Threading.CancellationToken cancel = default" << epar << " =>";
     _out.inc();
-    _out << nl << "await proxy.ice_isAAsync(ice_staticId(), context, progress, cancel).ConfigureAwait(false) ? new " << name
-         << "PrxHelper(proxy) : null;";
+    _out << nl << "await proxy.ice_isAAsync(ice_staticId(), context, progress, cancel).ConfigureAwait(false) ? new "
+         << name << "PrxHelper(proxy) : null;";
     _out.dec();
 
     _out << sp;
@@ -2118,10 +2133,16 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="proxy")", "The source proxy.", "param");
     writeDocLine(_out, R"(param name="facet")", "The facet.", "param");
     writeDocLine(_out, R"(param name="context")", "The request context.", "param");
+    writeDocLine(_out, R"(param name="progress")", "The sent progress reporter.", "param");
+    writeDocLine(_out, R"(param name="cancel")", "The cancellation token.", "param");
     writeDocLine(_out, "returns", checkedCastWithFacetReturns.str());
-    _out << nl << "public static global::System.Threading.Tasks.Task<" << name
-         << "Prx?> checkedCastAsync(Ice.ObjectPrx proxy, string facet, global::System.Collections.Generic.Dictionary<string, "
-            "string>? context = null, global::System.IProgress<bool>? progress = null, global::System.Threading.CancellationToken cancel = default) =>";
+    _out << nl << "public static global::System.Threading.Tasks.Task<" << name << "Prx?> checkedCastAsync";
+    _out.spar("(", true);
+    _out << "Ice.ObjectPrx proxy"
+         << "string facet"
+         << "global::System.Collections.Generic.Dictionary<string, string>? context = null"
+         << "global::System.IProgress<bool>? progress = null"
+         << "global::System.Threading.CancellationToken cancel = default" << epar << " =>";
     _out.inc();
     _out << nl << "checkedCastAsync(proxy.ice_facet(facet), context, progress, cancel);";
     _out.dec();
@@ -2217,9 +2238,10 @@ Slice::Gen::TypesVisitor::visitOperation(const OperationPtr& p)
         _out << sp;
         writeOpDocComment(p, {"<param name=\"" + context + "\">The request context.</param>"}, false);
         emitObsoleteAttribute(p, _out);
-        _out << nl << retS << " " << name << spar << getParams(p, ns)
-             << ("global::System.Collections.Generic.Dictionary<string, string>? " + context + " = null") << epar
-             << ';';
+        _out << nl << retS << " " << name;
+        _out.spar("(", true);
+        _out << getParams(p, ns);
+        _out << "global::System.Collections.Generic.Dictionary<string, string>? " + context + " = null" << epar << ';';
     }
 
     {
@@ -2239,8 +2261,9 @@ Slice::Gen::TypesVisitor::visitOperation(const OperationPtr& p)
             true);
         emitObsoleteAttribute(p, _out);
         _out << nl << taskResultType(p, ns);
-        _out << " " << name << "Async" << spar << inParams
-             << ("global::System.Collections.Generic.Dictionary<string, string>? " + context + " = null")
+        _out << " " << name << "Async";
+        _out.spar("(", true);
+        _out << inParams << ("global::System.Collections.Generic.Dictionary<string, string>? " + context + " = null")
              << ("global::System.IProgress<bool>? " + progress + " = null")
              << ("global::System.Threading.CancellationToken " + cancel + " = default") << epar << ";";
     }
@@ -2456,10 +2479,13 @@ Slice::Gen::ServantVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 
     for (const auto& op : p->allOperations())
     {
+        const bool amd = p->hasMetadata("amd") || op->hasMetadata("amd");
         string retS;
         vector<string> params, args;
         string opName = getDispatchParams(op, retS, params, args, ns);
-        _out << sp << nl << "public abstract " << retS << " " << opName << spar << params << epar << ';';
+        _out << sp << nl << "public abstract " << retS << " " << opName;
+        _out.spar("(", amd);
+        _out << params << epar << ';';
     }
 
     _out << sp;
@@ -2488,7 +2514,9 @@ Slice::Gen::ServantVisitor::visitOperation(const OperationPtr& op)
     writeOpDocComment(op, {"<param name=\"" + args.back() + "\">The Current object for the dispatch.</param>"}, amd);
 
     emitObsoleteAttribute(op, _out);
-    _out << nl << retS << " " << opName << spar << params << epar << ";";
+    _out << nl << retS << " " << opName;
+    _out.spar("(", amd); // use newlines for AMD because it's much longer.
+    _out << params << epar << ";";
 
     _out << sp;
     emitNonBrowsableAttribute();

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -1821,8 +1821,8 @@ public class ObjectPrxHelper : ObjectPrxHelperBase
     /// <param name="context">The request context.</param>
     /// <param name="progress">Sent progress provider.</param>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
-    /// <returns>A proxy with the requested type, or null if the source proxy is null or if the target object does not
-    /// support the requested type.</returns>
+    /// <returns>A proxy with the requested type, or null if the target object does not support the requested type.
+    /// </returns>
     public static async Task<ObjectPrx?> checkedCastAsync(
         ObjectPrx proxy,
         Dictionary<string, string>? context = null,
@@ -1838,8 +1838,8 @@ public class ObjectPrxHelper : ObjectPrxHelperBase
     /// <param name="context">The request context.</param>
     /// <param name="progress">Sent progress provider.</param>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
-    /// <returns>A proxy with the requested type and facet, or null if the source proxy is null or if the target facet
-    /// does not support the requested type.</returns>
+    /// <returns>A proxy with the requested type and facet, or null if the target facet does not support the requested
+    /// type.</returns>
     public static Task<ObjectPrx?> checkedCastAsync(
         ObjectPrx proxy,
         string facet,

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -1794,80 +1794,79 @@ public class ObjectPrxHelper : ObjectPrxHelperBase
     }
 
     /// <summary>
-    /// Casts a proxy to <see cref="ObjectPrx" />. This call contacts
-    /// the server and throws an Ice run-time exception if the target
-    /// object does not exist or the server cannot be reached.
+    /// Downcasts a proxy after confirming the target object's type via a remote invocation.
     /// </summary>
-    /// <param name="proxy">The proxy to cast to ObjectPrx.</param>
-    /// <param name="context">The Context map for the invocation.</param>
-    /// <returns>proxy.</returns>
+    /// <param name="proxy">The source proxy.</param>
+    /// <param name="context">The request context.</param>
+    /// <returns>A proxy with the requested type, or null if the source proxy is null or if the target object does not
+    /// support the requested type.</returns>
     public static ObjectPrx? checkedCast(ObjectPrx? proxy, Dictionary<string, string>? context = null) =>
         proxy is not null && proxy.ice_isA("::Ice::Object", context) ? proxy : null;
 
     /// <summary>
-    /// Creates a new proxy that is identical to the passed proxy, except
-    /// for its facet. This call contacts
-    /// the server and throws an Ice run-time exception if the target
-    /// object does not exist, the specified facet does not exist, or the server cannot be reached.
+    /// Downcasts a proxy after confirming the target object's type via a remote invocation.
     /// </summary>
-    /// <param name="proxy">The proxy to cast to ObjectPrx.</param>
-    /// <param name="facet">The facet for the new proxy.</param>
-    /// <param name="context">The Context map for the invocation.</param>
-    /// <returns>The new proxy with the specified facet.</returns>
+    /// <param name="proxy">The source proxy (can be null).</param>
+    /// <param name="facet">A facet name.</param>
+    /// <param name="context">The request context.</param>
+    /// <returns>A proxy with the requested type and facet, or null if the source proxy is null or if the target facet
+    /// does not support the requested type.</returns>
     public static ObjectPrx? checkedCast(ObjectPrx? proxy, string facet, Dictionary<string, string>? context = null) =>
         checkedCast(proxy?.ice_facet(facet), context);
 
     /// <summary>
-    /// Casts a proxy to <see cref="ObjectPrx" />. This call contacts
-    /// the server and throws an Ice run-time exception if the target
-    /// object does not exist or the server cannot be reached.
+    /// Downcasts a proxy after confirming the target object's type via a remote invocation.
     /// </summary>
-    /// <param name="proxy">The proxy to cast to ObjectPrx.</param>
-    /// <param name="context">The Context map for the invocation.</param>
-    /// <returns>proxy.</returns>
+    /// <param name="proxy">The source proxy.</param>
+    /// <param name="context">The request context.</param>
+    /// <param name="progress">Sent progress provider.</param>
+    /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
+    /// <returns>A proxy with the requested type, or null if the source proxy is null or if the target object does not
+    /// support the requested type.</returns>
     public static async Task<ObjectPrx?> checkedCastAsync(
         ObjectPrx proxy,
-        Dictionary<string, string>? context = null) =>
-       await proxy.ice_isAAsync("::Ice::Object", context).ConfigureAwait(false) ? proxy : null;
+        Dictionary<string, string>? context = null,
+        IProgress<bool>? progress = null,
+        CancellationToken cancel = default) =>
+       await proxy.ice_isAAsync("::Ice::Object", context, progress, cancel).ConfigureAwait(false) ? proxy : null;
 
     /// <summary>
-    /// Creates a new proxy that is identical to the passed proxy, except
-    /// for its facet. This call contacts
-    /// the server and throws an Ice run-time exception if the target
-    /// object does not exist, the specified facet does not exist, or the server cannot be reached.
+    /// Downcasts a proxy after confirming the target object's type via a remote invocation.
     /// </summary>
-    /// <param name="proxy">The proxy to cast to ObjectPrx.</param>
-    /// <param name="facet">The facet for the new proxy.</param>
-    /// <param name="context">The Context map for the invocation.</param>
-    /// <returns>The new proxy with the specified facet.</returns>
+    /// <param name="proxy">The source proxy.</param>
+    /// <param name="facet">A facet name.</param>
+    /// <param name="context">The request context.</param>
+    /// <param name="progress">Sent progress provider.</param>
+    /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
+    /// <returns>A proxy with the requested type and facet, or null if the source proxy is null or if the target facet
+    /// does not support the requested type.</returns>
     public static Task<ObjectPrx?> checkedCastAsync(
         ObjectPrx proxy,
         string facet,
-        Dictionary<string, string>? context = null) =>
-        checkedCastAsync(proxy.ice_facet(facet), context);
+        Dictionary<string, string>? context = null,
+        IProgress<bool>? progress = null,
+        CancellationToken cancel = default) =>
+        checkedCastAsync(proxy.ice_facet(facet), context, progress, cancel);
 
     /// <summary>
-    /// Casts a proxy to <see cref="ObjectPrx" />. This call does
-    /// not contact the server and always succeeds.
+    /// Downcasts a proxy without confirming the target object's type via a remote invocation.
     /// </summary>
-    /// <param name="proxy">The proxy to cast to ObjectPrx.</param>
-    /// <returns>b.</returns>
-    [return: NotNullIfNotNull("proxy")]
+    /// <param name="proxy">The source proxy.</param>
+    /// <returns>A proxy with the requested type.</returns>
+    [return: NotNullIfNotNull(nameof(proxy))]
     public static ObjectPrx? uncheckedCast(ObjectPrx? proxy) => proxy;
 
     /// <summary>
-    /// Creates a new proxy that is identical to the passed proxy, except
-    /// for its facet. This call does not contact the server and always succeeds.
+    /// Downcasts a proxy without confirming the target object's type via a remote invocation.
     /// </summary>
-    /// <param name="proxy">The proxy to cast to ObjectPrx.</param>
-    /// <param name="facet">The facet for the new proxy.</param>
-    /// <returns>The new proxy with the specified facet.</returns>
-    [return: NotNullIfNotNull("proxy")]
+    /// <param name="proxy">The source proxy.</param>
+    /// <param name="facet">A facet name.</param>
+    /// <returns>A proxy with the requested type and facet.</returns>
+    [return: NotNullIfNotNull(nameof(proxy))]
     public static ObjectPrx? uncheckedCast(ObjectPrx? proxy, string facet) => proxy?.ice_facet(facet);
 
     /// <summary>
-    /// Gets the Slice type id of the interface or class associated
-    /// with this proxy class.
+    /// Gets the Slice type id of the interface or class associated with this proxy class.
     /// </summary>
     /// <returns>The type id, "::Ice::Object".</returns>
     public static string ice_staticId() => ObjectImpl.ice_staticId();


### PR DESCRIPTION
This PR updates spar in IceInternal::Output to give the option to output parameters on separate lines (one param per line), as opposed to all parameters on the same line.

Then, applied this option to slice2cs for generated proxy methods, and server-side AMD methods.

For example:
```csharp
        /// <summary>Finds an object by identity and returns a dummy proxy with the endpoint(s) that can be used to reach this
        /// object. This dummy proxy may be an indirect proxy that requires further resolution using
        /// <see cref="global::Ice.LocatorPrx.findAdapterById" />.</summary>
        /// <param name="id">The identity.</param>
        /// <param name="context">The request context.</param>
        /// <returns>A dummy proxy, or null if an object with the requested identity was not found.</returns>
        /// <exception cref="Ice.ObjectNotFoundException">Thrown when an object with the requested identity was not found. The caller
        /// should treat this exception like a null return value.</exception>
        Ice.ObjectPrx? findObjectById(
            Identity id,
            global::System.Collections.Generic.Dictionary<string, string>? context = null);

        /// <summary>Finds an object by identity and returns a dummy proxy with the endpoint(s) that can be used to reach this
        /// object. This dummy proxy may be an indirect proxy that requires further resolution using
        /// <see cref="global::Ice.LocatorPrx.findAdapterById" />.</summary>
        /// <param name="id">The identity.</param>
        /// <param name="context">The request context.</param>
        /// <param name="progress">The sent progress provider.</param>
        /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
        /// <returns>A task that represents the asynchronous operation.</returns>
        /// <exception cref="Ice.ObjectNotFoundException">Thrown when an object with the requested identity was not found. The caller
        /// should treat this exception like a null return value.</exception>
        global::System.Threading.Tasks.Task<Ice.ObjectPrx?> findObjectByIdAsync(
            Identity id,
            global::System.Collections.Generic.Dictionary<string, string>? context = null,
            global::System.IProgress<bool>? progress = null,
            global::System.Threading.CancellationToken cancel = default);
```

Also added missing parameters (progress and cancel) to checkedCastAsync.