### PR TITLE
Cleanup `JsUtil` in `slice2js`

### DIFF
--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -16,6 +16,7 @@
 
 using namespace std;
 using namespace Slice;
+using namespace Slice::JavaScript;
 using namespace Ice;
 using namespace IceInternal;
 
@@ -30,7 +31,7 @@ namespace
         {
             if (auto builtinTarget = dynamic_pointer_cast<Builtin>(target))
             {
-                result << JsGenerator::typeToJsString(builtinTarget, true);
+                result << typeToJsString(builtinTarget, true);
             }
             else
             {

--- a/cpp/src/slice2js/Gen.h
+++ b/cpp/src/slice2js/Gen.h
@@ -7,7 +7,7 @@
 
 namespace Slice
 {
-    class JsVisitor : public JsGenerator, public ParserVisitor
+    class JsVisitor : public ParserVisitor
     {
     public:
         JsVisitor(::IceInternal::Output& output);
@@ -32,14 +32,14 @@ namespace Slice
         ::IceInternal::Output& _out;
     };
 
-    class Gen final : public JsGenerator
+    class Gen final
     {
     public:
         Gen(const std::string&, const std::vector<std::string>&, const std::string&, bool);
 
         Gen(const std::string&, const std::vector<std::string>&, const std::string&, bool, std::ostream&);
 
-        ~Gen() override;
+        ~Gen();
 
         void generate(const UnitPtr&);
 

--- a/cpp/src/slice2js/JsUtil.cpp
+++ b/cpp/src/slice2js/JsUtil.cpp
@@ -21,13 +21,13 @@ using namespace Slice;
 using namespace IceInternal;
 
 string
-Slice::JavaScript::relativePath(const string& p1, const string& p2)
+Slice::JavaScript::relativePath(const string& path1, const string& path2)
 {
     vector<string> tokens1;
     vector<string> tokens2;
 
-    splitString(p1, "/\\", tokens1);
-    splitString(p2, "/\\", tokens2);
+    splitString(path1, "/\\", tokens1);
+    splitString(path2, "/\\", tokens2);
 
     string f1 = tokens1.back();
     string f2 = tokens2.back();
@@ -49,7 +49,7 @@ Slice::JavaScript::relativePath(const string& p1, const string& p2)
     //
     if (i1 == tokens1.begin() && i2 == tokens2.begin())
     {
-        return p1;
+        return path1;
     }
 
     string newPath;

--- a/cpp/src/slice2js/JsUtil.cpp
+++ b/cpp/src/slice2js/JsUtil.cpp
@@ -21,7 +21,7 @@ using namespace Slice;
 using namespace IceInternal;
 
 string
-Slice::relativePath(const string& p1, const string& p2)
+Slice::JavaScript::relativePath(const string& p1, const string& p2)
 {
     vector<string> tokens1;
     vector<string> tokens2;
@@ -79,7 +79,7 @@ Slice::relativePath(const string& p1, const string& p2)
 }
 
 string
-Slice::getJavaScriptModule(const DefinitionContextPtr& dc)
+Slice::JavaScript::getJavaScriptModule(const DefinitionContextPtr& dc)
 {
     // Check if the file contains the 'js:module' file metadata.
     assert(dc);
@@ -87,7 +87,7 @@ Slice::getJavaScriptModule(const DefinitionContextPtr& dc)
 }
 
 string
-Slice::JsGenerator::typeToJsString(const TypePtr& type, bool definition)
+Slice::JavaScript::typeToJsString(const TypePtr& type, bool definition)
 {
     if (!type)
     {
@@ -169,7 +169,7 @@ Slice::JsGenerator::typeToJsString(const TypePtr& type, bool definition)
 }
 
 void
-Slice::JsGenerator::writeMarshalUnmarshalCode(Output& out, const TypePtr& type, const string& param, bool marshal)
+Slice::JavaScript::writeMarshalUnmarshalCode(Output& out, const TypePtr& type, const string& param, bool marshal)
 {
     string stream = marshal ? "ostr" : "istr";
 
@@ -365,7 +365,7 @@ Slice::JsGenerator::writeMarshalUnmarshalCode(Output& out, const TypePtr& type, 
 }
 
 void
-Slice::JsGenerator::writeOptionalMarshalUnmarshalCode(
+Slice::JavaScript::writeOptionalMarshalUnmarshalCode(
     Output& out,
     const TypePtr& type,
     const string& param,
@@ -400,7 +400,7 @@ Slice::JsGenerator::writeOptionalMarshalUnmarshalCode(
 }
 
 std::string
-Slice::JsGenerator::getHelper(const TypePtr& type)
+Slice::JavaScript::getHelper(const TypePtr& type)
 {
     BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
     if (builtin)

--- a/cpp/src/slice2js/JsUtil.h
+++ b/cpp/src/slice2js/JsUtil.h
@@ -15,7 +15,9 @@ namespace Slice::JavaScript
 
     [[nodiscard]] std::string getHelper(const TypePtr& type);
 
+    //
     // Generate code to marshal or unmarshal a type
+    //
     [[nodiscard]] void writeMarshalUnmarshalCode(IceInternal::Output& out, const TypePtr& type , const std::string& param, bool marshal);
     [[nodiscard]] void writeOptionalMarshalUnmarshalCode(IceInternal::Output& out, const TypePtr& type, const std::string& param, std::int32_t tag, bool marshal);
 }

--- a/cpp/src/slice2js/JsUtil.h
+++ b/cpp/src/slice2js/JsUtil.h
@@ -18,9 +18,9 @@ namespace Slice::JavaScript
     //
     // Generate code to marshal or unmarshal a type
     //
-    [[nodiscard]] void
+    void
     writeMarshalUnmarshalCode(IceInternal::Output& out, const TypePtr& type, const std::string& param, bool marshal);
-    [[nodiscard]] void writeOptionalMarshalUnmarshalCode(
+    void writeOptionalMarshalUnmarshalCode(
         IceInternal::Output& out,
         const TypePtr& type,
         const std::string& param,

--- a/cpp/src/slice2js/JsUtil.h
+++ b/cpp/src/slice2js/JsUtil.h
@@ -6,30 +6,20 @@
 #include "../Ice/OutputUtil.h"
 #include "../Slice/Parser.h"
 
-namespace Slice
+namespace Slice::JavaScript
 {
     std::string relativePath(const std::string&, const std::string&);
     std::string getJavaScriptModule(const DefinitionContextPtr&);
 
-    class JsGenerator
-    {
-    public:
-        JsGenerator() = default;
-        JsGenerator(const JsGenerator&) = delete;
-        virtual ~JsGenerator() = default;
+    std::string typeToJsString(const TypePtr&, bool definition = false);
 
-        JsGenerator& operator=(const JsGenerator&) = delete;
+    std::string getHelper(const TypePtr&);
 
-        static std::string typeToJsString(const TypePtr&, bool definition = false);
+    // Generate code to marshal or unmarshal a type
+    void writeMarshalUnmarshalCode(IceInternal::Output&, const TypePtr&, const std::string&, bool);
 
-        static std::string getHelper(const TypePtr&);
-        //
-        // Generate code to marshal or unmarshal a type
-        //
-        void writeMarshalUnmarshalCode(IceInternal::Output&, const TypePtr&, const std::string&, bool);
-        void
-        writeOptionalMarshalUnmarshalCode(IceInternal::Output&, const TypePtr&, const std::string&, std::int32_t, bool);
-    };
+    void
+    writeOptionalMarshalUnmarshalCode(IceInternal::Output&, const TypePtr&, const std::string&, std::int32_t, bool);
 }
 
 #endif

--- a/cpp/src/slice2js/JsUtil.h
+++ b/cpp/src/slice2js/JsUtil.h
@@ -8,18 +8,16 @@
 
 namespace Slice::JavaScript
 {
-    std::string relativePath(const std::string&, const std::string&);
-    std::string getJavaScriptModule(const DefinitionContextPtr&);
+    [[nodiscard]] std::string relativePath(const std::string& path1, const std::string& path2);
+    [[nodiscard]] std::string getJavaScriptModule(const DefinitionContextPtr& dc);
 
-    std::string typeToJsString(const TypePtr&, bool definition = false);
+    [[nodiscard]] std::string typeToJsString(const TypePtr& type, bool definition = false);
 
-    std::string getHelper(const TypePtr&);
+    [[nodiscard]] std::string getHelper(const TypePtr& type);
 
     // Generate code to marshal or unmarshal a type
-    void writeMarshalUnmarshalCode(IceInternal::Output&, const TypePtr&, const std::string&, bool);
-
-    void
-    writeOptionalMarshalUnmarshalCode(IceInternal::Output&, const TypePtr&, const std::string&, std::int32_t, bool);
+    [[nodiscard]] void writeMarshalUnmarshalCode(IceInternal::Output& out, const TypePtr& type , const std::string& param, bool marshal);
+    [[nodiscard]] void writeOptionalMarshalUnmarshalCode(IceInternal::Output& out, const TypePtr& type, const std::string& param, std::int32_t tag, bool marshal);
 }
 
 #endif

--- a/cpp/src/slice2js/JsUtil.h
+++ b/cpp/src/slice2js/JsUtil.h
@@ -18,8 +18,14 @@ namespace Slice::JavaScript
     //
     // Generate code to marshal or unmarshal a type
     //
-    [[nodiscard]] void writeMarshalUnmarshalCode(IceInternal::Output& out, const TypePtr& type , const std::string& param, bool marshal);
-    [[nodiscard]] void writeOptionalMarshalUnmarshalCode(IceInternal::Output& out, const TypePtr& type, const std::string& param, std::int32_t tag, bool marshal);
+    [[nodiscard]] void
+    writeMarshalUnmarshalCode(IceInternal::Output& out, const TypePtr& type, const std::string& param, bool marshal);
+    [[nodiscard]] void writeOptionalMarshalUnmarshalCode(
+        IceInternal::Output& out,
+        const TypePtr& type,
+        const std::string& param,
+        std::int32_t tag,
+        bool marshal);
 }
 
 #endif


### PR DESCRIPTION
The `JsGenerator` class has no members, and only static functions.
This PR replaces this class with what it logically is: a nested namespace.

I also added `[[nodiscard]]`s and parameter names where appropriate.