### PR TITLE
Cleanup `CsUtil` in `slice2cs`

### DIFF
--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -24,7 +24,8 @@ namespace Slice::Csharp
     /// Returns the namespace prefix of a Contained entity.
     [[nodiscard]] std::string getNamespacePrefix(const ContainedPtr& p);
 
-    [[nodiscard]] std::string resultStructName(const std::string& className, const std::string& opName, bool marshaledResult = false);
+    [[nodiscard]] std::string
+    resultStructName(const std::string& className, const std::string& opName, bool marshaledResult = false);
     [[nodiscard]] std::string resultType(const OperationPtr& op, const std::string& package, bool dispatch = false);
     [[nodiscard]] std::string taskResultType(const OperationPtr& op, const std::string& scope, bool dispatch = false);
     [[nodiscard]] std::string getOptionalFormat(const TypePtr& type);

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -47,14 +47,14 @@ namespace Slice::Csharp
     //
     // Generate code to marshal or unmarshal a type
     //
-    [[nodiscard]] void writeMarshalUnmarshalCode(
+    void writeMarshalUnmarshalCode(
         ::IceInternal::Output& out,
         const TypePtr& type,
         const std::string& package,
         const std::string& param,
         bool marshal,
         const std::string& customStream = "");
-    [[nodiscard]] void writeOptionalMarshalUnmarshalCode(
+    void writeOptionalMarshalUnmarshalCode(
         ::IceInternal::Output& out,
         const TypePtr& type,
         const std::string& scope,
@@ -62,7 +62,7 @@ namespace Slice::Csharp
         std::int32_t tag,
         bool marshal,
         const std::string& customStream = "");
-    [[nodiscard]] void writeSequenceMarshalUnmarshalCode(
+    void writeSequenceMarshalUnmarshalCode(
         ::IceInternal::Output& out,
         const SequencePtr& seq,
         const std::string& scope,
@@ -70,7 +70,7 @@ namespace Slice::Csharp
         bool marshal,
         bool useHelper,
         const std::string& customStream = "");
-    [[nodiscard]] void writeOptionalSequenceMarshalUnmarshalCode(
+    void writeOptionalSequenceMarshalUnmarshalCode(
         ::IceInternal::Output& out,
         const SequencePtr& seq,
         const std::string& scope,

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -34,7 +34,7 @@ namespace Slice::Csharp
     [[nodiscard]] bool isValueType(const TypePtr& type);
 
     /// Is this Slice struct mapped to a C# class?
-    [[nodiscard]] bool isMappedToClass(const StructPtr& p) { return !isValueType(p); }
+    [[nodiscard]] inline bool isMappedToClass(const StructPtr& p) { return !isValueType(p); }
 
     /// Is the mapped C# type for this field a non-nullable C# reference type?
     [[nodiscard]] bool isMappedToNonNullableReference(const DataMemberPtr& p);

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -6,88 +6,77 @@
 #include "../Ice/OutputUtil.h"
 #include "../Slice/Parser.h"
 
-namespace Slice
+namespace Slice::Csharp
 {
-    class CsGenerator
-    {
-    public:
-        CsGenerator() = default;
-        CsGenerator(const CsGenerator&) = delete;
-        virtual ~CsGenerator() = default;
+    /// Convert a dimension-less array declaration to one with a dimension.
+    [[nodiscard]] std::string toArrayAlloc(const std::string& decl, const std::string& size);
 
-        CsGenerator& operator=(const CsGenerator&) = delete;
+    /// Returns the namespace of a Contained entity.
+    [[nodiscard]] std::string getNamespace(const ContainedPtr& p);
 
-        /// Convert a dimension-less array declaration to one with a dimension.
-        [[nodiscard]] static std::string toArrayAlloc(const std::string& decl, const std::string& sz);
+    [[nodiscard]] std::string getUnqualified(const ContainedPtr& p, const std::string& package);
 
-        /// Returns the namespace of a Contained entity.
-        [[nodiscard]] static std::string getNamespace(const ContainedPtr&);
+    /// Removes a leading '@' character from the provided identifier (if one is present).
+    [[nodiscard]] std::string removeEscapePrefix(const std::string& identifier);
 
-        [[nodiscard]] static std::string getUnqualified(const ContainedPtr&, const std::string& package);
+    [[nodiscard]] std::string typeToString(const TypePtr& type, const std::string& package, bool optional = false);
 
-        /// Removes a leading '@' character from the provided identifier (if one is present).
-        [[nodiscard]] static std::string removeEscapePrefix(const std::string& identifier);
+    /// Returns the namespace prefix of a Contained entity.
+    [[nodiscard]] std::string getNamespacePrefix(const ContainedPtr& p);
 
-        static std::string typeToString(const TypePtr&, const std::string&, bool = false);
+    [[nodiscard]] std::string resultStructName(const std::string& className, const std::string& opName, bool marshaledResult = false);
+    [[nodiscard]] std::string resultType(const OperationPtr& op, const std::string& package, bool dispatch = false);
+    [[nodiscard]] std::string taskResultType(const OperationPtr& op, const std::string& scope, bool dispatch = false);
+    [[nodiscard]] std::string getOptionalFormat(const TypePtr& type);
+    [[nodiscard]] std::string getStaticId(const TypePtr& type);
 
-    protected:
-        /// Returns the namespace prefix of a Contained entity.
-        static std::string getNamespacePrefix(const ContainedPtr&);
+    /// Is this Slice type mapped to a C# value type?
+    [[nodiscard]] bool isValueType(const TypePtr& type);
 
-        static std::string resultStructName(const std::string&, const std::string&, bool = false);
-        static std::string resultType(const OperationPtr&, const std::string&, bool = false);
-        static std::string taskResultType(const OperationPtr&, const std::string&, bool = false);
-        static std::string getOptionalFormat(const TypePtr&);
-        static std::string getStaticId(const TypePtr&);
+    /// Is this Slice struct mapped to a C# class?
+    [[nodiscard]] bool isMappedToClass(const StructPtr& p) { return !isValueType(p); }
 
-        // Is this Slice type mapped to a C# value type?
-        static bool isValueType(const TypePtr&);
+    /// Is the mapped C# type for this field a non-nullable C# reference type?
+    [[nodiscard]] bool isMappedToNonNullableReference(const DataMemberPtr& p);
 
-        // Is this Slice struct mapped to a C# class?
-        static bool isMappedToClass(const StructPtr& p) { return !isValueType(p); }
+    /// Is the mapped C# type for this field a non-nullable reference type?
+    /// string fields are not included since they have a "" default.
+    [[nodiscard]] bool isMappedToRequiredField(const DataMemberPtr& p);
 
-        // Is the mapped C# type for this field a non-nullable C# reference type?
-        static bool isMappedToNonNullableReference(const DataMemberPtr& p);
-
-        // Is the mapped C# type for this field a non-nullable reference type?
-        // string fields are not included since they have a "" default.
-        static bool isMappedToRequiredField(const DataMemberPtr&);
-
-        //
-        // Generate code to marshal or unmarshal a type
-        //
-        void writeMarshalUnmarshalCode(
-            ::IceInternal::Output&,
-            const TypePtr&,
-            const std::string&,
-            const std::string&,
-            bool,
-            const std::string& = "");
-        void writeOptionalMarshalUnmarshalCode(
-            ::IceInternal::Output&,
-            const TypePtr&,
-            const std::string&,
-            const std::string&,
-            std::int32_t,
-            bool,
-            const std::string& = "");
-        void writeSequenceMarshalUnmarshalCode(
-            ::IceInternal::Output&,
-            const SequencePtr&,
-            const std::string&,
-            const std::string&,
-            bool,
-            bool,
-            const std::string& = "");
-        void writeOptionalSequenceMarshalUnmarshalCode(
-            ::IceInternal::Output&,
-            const SequencePtr&,
-            const std::string&,
-            const std::string&,
-            int,
-            bool,
-            const std::string& = "");
-    };
+    //
+    // Generate code to marshal or unmarshal a type
+    //
+    [[nodiscard]] void writeMarshalUnmarshalCode(
+        ::IceInternal::Output& out,
+        const TypePtr& type,
+        const std::string& package,
+        const std::string& param,
+        bool marshal,
+        const std::string& customStream = "");
+    [[nodiscard]] void writeOptionalMarshalUnmarshalCode(
+        ::IceInternal::Output& out,
+        const TypePtr& type,
+        const std::string& scope,
+        const std::string& param,
+        std::int32_t tag,
+        bool marshal,
+        const std::string& customStream = "");
+    [[nodiscard]] void writeSequenceMarshalUnmarshalCode(
+        ::IceInternal::Output& out,
+        const SequencePtr& seq,
+        const std::string& scope,
+        const std::string& param,
+        bool marshal,
+        bool useHelper,
+        const std::string& customStream = "");
+    [[nodiscard]] void writeOptionalSequenceMarshalUnmarshalCode(
+        ::IceInternal::Output& out,
+        const SequencePtr& seq,
+        const std::string& scope,
+        const std::string& param,
+        int tag,
+        bool marshal,
+        const std::string& customStream = "");
 }
 
 #endif

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -22,6 +22,7 @@
 
 using namespace std;
 using namespace Slice;
+using namespace Slice::Csharp;
 using namespace Ice;
 using namespace IceInternal;
 
@@ -113,7 +114,7 @@ namespace
         {
             if (auto builtinTarget = dynamic_pointer_cast<Builtin>(target))
             {
-                string typeS = CsGenerator::typeToString(builtinTarget, "");
+                string typeS = typeToString(builtinTarget, "");
                 if (builtinTarget->kind() == Builtin::KindObjectProxy || builtinTarget->kind() == Builtin::KindValue)
                 {
                     // Remove trailing '?':
@@ -135,17 +136,17 @@ namespace
                 if (auto operationTarget = dynamic_pointer_cast<Operation>(target))
                 {
                     // link to the method on the proxy interface
-                    result << CsGenerator::getUnqualified(operationTarget->interface(), sourceScope) << "Prx."
+                    result << getUnqualified(operationTarget->interface(), sourceScope) << "Prx."
                            << operationTarget->mappedName();
                 }
                 else if (auto interfaceTarget = dynamic_pointer_cast<InterfaceDecl>(target))
                 {
                     // link to the proxy interface
-                    result << CsGenerator::getUnqualified(interfaceTarget, sourceScope) << "Prx";
+                    result << getUnqualified(interfaceTarget, sourceScope) << "Prx";
                 }
                 else
                 {
-                    result << CsGenerator::getUnqualified(dynamic_pointer_cast<Contained>(target), sourceScope);
+                    result << getUnqualified(dynamic_pointer_cast<Contained>(target), sourceScope);
                 }
                 result << "\"";
             }

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -7,7 +7,7 @@
 
 namespace Slice
 {
-    class CsVisitor : public CsGenerator, public ParserVisitor
+    class CsVisitor : public ParserVisitor
     {
     public:
         CsVisitor(IceInternal::Output&);


### PR DESCRIPTION
The `CsGenerator` class has no members, and all its functions are effectively static.
This PR replaces this class with what it logically is: a nested namespace.

I also added `[[nodiscard]]`s and parameter names where appropriate.