### PR TITLE
Use ABC for abstract base classes in Python

### DIFF
--- a/python/python/Ice/Logger.py
+++ b/python/python/Ice/Logger.py
@@ -1,16 +1,15 @@
 # Copyright (c) ZeroC, Inc.
 
-class Logger:
+from abc import ABC, abstractmethod
+
+class Logger(ABC):
     """
     The Ice message logger.
 
     Applications can provide their own logger by implementing this interface and installing it in a communicator.
     """
 
-    def __init__(self):
-        if type(self) is Logger:
-            raise RuntimeError("Ice.Logger is an abstract class")
-
+    @abstractmethod
     def _print(self, message):
         """
         Print a message.
@@ -22,8 +21,9 @@ class Logger:
         message : str
             The message to log.
         """
-        raise NotImplementedError("method '_print' not implemented")
+        pass
 
+    @abstractmethod
     def trace(self, category, message):
         """
         Log a trace message.
@@ -35,8 +35,9 @@ class Logger:
         message : str
             The trace message to log.
         """
-        raise NotImplementedError("method 'trace' not implemented")
+        pass
 
+    @abstractmethod
     def warning(self, message):
         """
         Log a warning message.
@@ -46,8 +47,9 @@ class Logger:
         message : str
             The warning message to log.
         """
-        raise NotImplementedError("method 'warning' not implemented")
+        pass
 
+    @abstractmethod
     def error(self, message):
         """
         Log an error message.
@@ -57,8 +59,9 @@ class Logger:
         message : str
             The error message to log.
         """
-        raise NotImplementedError("method 'error' not implemented")
+        pass
 
+    @abstractmethod
     def getPrefix(self):
         """
         Get this logger's prefix.
@@ -68,8 +71,9 @@ class Logger:
         str
             The prefix of this logger.
         """
-        raise NotImplementedError("method 'getPrefix' not implemented")
+        pass
 
+    @abstractmethod
     def cloneWithPrefix(self, prefix):
         """
         Return a clone of the logger with a new prefix.
@@ -84,4 +88,4 @@ class Logger:
         Logger
             A new logger instance with the specified prefix.
         """
-        raise NotImplementedError("method 'cloneWithPrefix' not implemented")
+        pass

--- a/python/python/Ice/ServantLocator.py
+++ b/python/python/Ice/ServantLocator.py
@@ -1,14 +1,13 @@
 # Copyright (c) ZeroC, Inc.
 
-class ServantLocator:
+from abc import ABC, abstractmethod
+
+class ServantLocator(ABC):
     """
     A servant locator is called by an object adapter to locate a servant that is not found in its active servant map.
     """
 
-    def __init__(self):
-        if type(self) is ServantLocator:
-            raise RuntimeError("Ice.ServantLocator is an abstract class")
-
+    @abstractmethod
     def locate(self, current):
         """
         Called before a request is dispatched if a servant cannot be found in the object adapter's active servant map.
@@ -43,8 +42,9 @@ class ServantLocator:
         UserException
             The implementation can raise a `UserException` and the runtime will marshal it as the result of the invocation.
         """
-        raise NotImplementedError("method 'locate' not implemented")
+        pass
 
+    @abstractmethod
     def finished(self, current, servant, cookie):
         """
         Called by the object adapter after a request has been made.
@@ -71,8 +71,9 @@ class ServantLocator:
         UserException
             The implementation can raise a `UserException` and the runtime will marshal it as the result of the invocation.
         """
-        raise NotImplementedError("method 'finished' not implemented")
+        pass
 
+    @abstractmethod
     def deactivate(self, category):
         """
         Called when the object adapter in which this servant locator is installed is destroyed.
@@ -82,4 +83,4 @@ class ServantLocator:
         category : str
             Indicates for which category the servant locator is being deactivated.
         """
-        raise NotImplementedError("method 'deactivate' not implemented")
+        pass

--- a/python/test/Slice/escape/Client.py
+++ b/python/test/Slice/escape/Client.py
@@ -11,7 +11,7 @@ import escaped_and
 
 
 class delI(escaped_and._del):
-    def _elifAsync(self, _else, current):
+    def _elif(self, _else, current):
         pass
 
 
@@ -21,7 +21,7 @@ class execI(escaped_and._exec):
 
 
 class ifI(escaped_and._if):
-    def _elifAsync(self, _else, current):
+    def _elif(self, _else, current):
         pass
 
     def _finally(self, current):


### PR DESCRIPTION
This PR updates the generated skeleton classes to use ABC.