### PR TITLE
Finish `slice2java` Cleanup for Now

### DIFF
--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -345,7 +345,7 @@ Slice::JavaVisitor::writeMarshalUnmarshalCode(
                 {
                     const size_t sz = keyType->minWireSize() + valueType->minWireSize();
                     out << nl << "final int optSize = " << d << " == null ? 0 : " << d << ".size();";
-                    out << nl << stream << ".writeSize((optSize * " << sz << ") + (optSize > 254 ? 5 : 1))";
+                    out << nl << stream << ".writeSize((optSize * " << sz << ") + (optSize > 254 ? 5 : 1));";
                 }
                 writeDictionaryMarshalUnmarshalCode(out, package, dict, d, marshal, iter, true, customStream, metadata);
                 if (usesVariableLengthTypes)

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -643,7 +643,17 @@ Slice::JavaVisitor::writeDictionaryMarshalUnmarshalCode(
         out << "for(java.util.Map.Entry<" << keyObjectS << ", " << valueObjectS << "> e : " << param << ".entrySet())";
         out << sb;
         writeMarshalUnmarshalCode(out, package, key, OptionalNone, false, 0, "e.getKey()", true, iter, customStream);
-        writeMarshalUnmarshalCode(out, package, value, OptionalNone, false, 0, "e.getValue()", true, iter, customStream);
+        writeMarshalUnmarshalCode(
+            out,
+            package,
+            value,
+            OptionalNone,
+            false,
+            0,
+            "e.getValue()",
+            true,
+            iter,
+            customStream);
         out << eb;
         out << eb;
     }
@@ -681,7 +691,7 @@ Slice::JavaVisitor::writeDictionaryMarshalUnmarshalCode(
         }
         else
         {
-            out << nl << "final " << keyS << " key;";
+            out << nl << keyS << " key;";
             writeMarshalUnmarshalCode(out, package, key, OptionalNone, false, 0, "key", false, iter, customStream);
 
             out << nl << valueS << " value;";

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -326,7 +326,7 @@ Slice::JavaVisitor::writeMarshalUnmarshalCode(
             {
                 if (optionalParam)
                 {
-                    out << nl << "if(";
+                    out << nl << "if (";
                     if (optionalMapping)
                     {
                         out << param << " != null && " << param << ".isPresent() && ";
@@ -363,7 +363,7 @@ Slice::JavaVisitor::writeMarshalUnmarshalCode(
                 const string d = optionalParam ? "optDict" : param;
                 if (optionalParam)
                 {
-                    out << nl << "if(" << stream << ".readOptional(" << tag << ", " << getOptionalFormat(type) << "))";
+                    out << nl << "if (" << stream << ".readOptional(" << tag << ", " << getOptionalFormat(type) << "))";
                     out << sb;
                     out << nl << typeS << ' ' << d << ';';
                 }
@@ -462,12 +462,12 @@ Slice::JavaVisitor::writeMarshalUnmarshalCode(
                     out << nl;
                     if (optionalMapping)
                     {
-                        out << "if(" << param << " != null && " << param << ".isPresent() && " << stream
+                        out << "if (" << param << " != null && " << param << ".isPresent() && " << stream
                             << ".writeOptional(" << tag << ", " << getOptionalFormat(type) << "))";
                     }
                     else
                     {
-                        out << "if(" << stream << ".writeOptional(" << tag << ", " << getOptionalFormat(type) << "))";
+                        out << "if (" << stream << ".writeOptional(" << tag << ", " << getOptionalFormat(type) << "))";
                     }
                     out << sb;
                 }
@@ -521,7 +521,7 @@ Slice::JavaVisitor::writeMarshalUnmarshalCode(
                 string s = optionalParam ? "optSeq" : param;
                 if (optionalParam)
                 {
-                    out << nl << "if(" << stream << ".readOptional(" << tag << ", " << getOptionalFormat(type) << "))";
+                    out << nl << "if (" << stream << ".readOptional(" << tag << ", " << getOptionalFormat(type) << "))";
                     out << sb;
                     out << nl << typeS << ' ' << s << ';';
                 }
@@ -630,7 +630,7 @@ Slice::JavaVisitor::writeDictionaryMarshalUnmarshalCode(
 
     if (marshal)
     {
-        out << nl << "if(" << param << " == null)";
+        out << nl << "if (" << param << " == null)";
         out << sb;
         out << nl << "ostr.writeSize(0);";
         out << eb;
@@ -839,7 +839,7 @@ Slice::JavaVisitor::writeSequenceMarshalUnmarshalCode(
         string cont = o.str();
         if (marshal)
         {
-            out << nl << "if(" << param << " == null)";
+            out << nl << "if (" << param << " == null)";
             out << sb;
             out << nl << stream << ".writeSize(0);";
             out << eb;
@@ -923,7 +923,7 @@ Slice::JavaVisitor::writeSequenceMarshalUnmarshalCode(
         {
             if (marshal)
             {
-                out << nl << "if(" << param << " == null)";
+                out << nl << "if (" << param << " == null)";
                 out << sb;
                 out << nl << stream << ".writeSize(0);";
                 out << eb;
@@ -1898,7 +1898,7 @@ Slice::JavaVisitor::writeMarshalDataMember(
     if (member->optional())
     {
         assert(!forStruct);
-        out << nl << "if(_" << memberName << ")";
+        out << nl << "if (_" << memberName << ")";
         out << sb;
         writeMarshalUnmarshalCode(
             out,
@@ -1951,7 +1951,7 @@ Slice::JavaVisitor::writeUnmarshalDataMember(
     if (member->optional())
     {
         assert(!forStruct);
-        out << nl << "if(_" << memberName << " = istr_.readOptional(" << member->tag() << ", "
+        out << nl << "if (_" << memberName << " = istr_.readOptional(" << member->tag() << ", "
             << getOptionalFormat(member->type()) << "))";
         out << sb;
         writeMarshalUnmarshalCode(
@@ -3289,16 +3289,16 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     out << nl << "@Override";
     out << nl << "public boolean equals(java.lang.Object rhs)";
     out << sb;
-    out << nl << "if(this == rhs)";
+    out << nl << "if (this == rhs)";
     out << sb;
     out << nl << "return true;";
     out << eb;
     out << nl << typeS << " r = null;";
-    out << nl << "if(rhs instanceof " << typeS << ")";
+    out << nl << "if (rhs instanceof " << typeS << ")";
     out << sb;
     out << nl << "r = (" << typeS << ")rhs;";
     out << eb;
-    out << sp << nl << "if(r != null)";
+    out << sp << nl << "if (r != null)";
     out << sb;
     for (const auto& member : members)
     {
@@ -3316,7 +3316,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
                 case Builtin::KindFloat:
                 case Builtin::KindDouble:
                 {
-                    out << nl << "if(this." << memberName << " != r." << memberName << ')';
+                    out << nl << "if (this." << memberName << " != r." << memberName << ')';
                     out << sb;
                     out << nl << "return false;";
                     out << eb;
@@ -3328,9 +3328,9 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
                 case Builtin::KindObjectProxy:
                 case Builtin::KindValue:
                 {
-                    out << nl << "if(this." << memberName << " != r." << memberName << ')';
+                    out << nl << "if (this." << memberName << " != r." << memberName << ')';
                     out << sb;
-                    out << nl << "if(this." << memberName << " == null || r." << memberName << " == null || !this."
+                    out << nl << "if (this." << memberName << " == null || r." << memberName << " == null || !this."
                         << memberName << ".equals(r." << memberName << "))";
                     out << sb;
                     out << nl << "return false;";
@@ -3355,9 +3355,9 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
             {
                 if (hasTypeMetadata(seq, member->getMetadata()))
                 {
-                    out << nl << "if(this." << memberName << " != r." << memberName << ')';
+                    out << nl << "if (this." << memberName << " != r." << memberName << ')';
                     out << sb;
-                    out << nl << "if(this." << memberName << " == null || r." << memberName << " == null || !this."
+                    out << nl << "if (this." << memberName << " == null || r." << memberName << " == null || !this."
                         << memberName << ".equals(r." << memberName << "))";
                     out << sb;
                     out << nl << "return false;";
@@ -3369,7 +3369,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
                     //
                     // Arrays.equals() handles null values.
                     //
-                    out << nl << "if(!java.util.Arrays.equals(this." << memberName << ", r." << memberName << "))";
+                    out << nl << "if (!java.util.Arrays.equals(this." << memberName << ", r." << memberName << "))";
                     out << sb;
                     out << nl << "return false;";
                     out << eb;
@@ -3377,9 +3377,9 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
             }
             else
             {
-                out << nl << "if(this." << memberName << " != r." << memberName << ')';
+                out << nl << "if (this." << memberName << " != r." << memberName << ')';
                 out << sb;
-                out << nl << "if(this." << memberName << " == null || r." << memberName << " == null || !this."
+                out << nl << "if (this." << memberName << " == null || r." << memberName << " == null || !this."
                     << memberName << ".equals(r." << memberName << "))";
                 out << sb;
                 out << nl << "return false;";
@@ -3463,7 +3463,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     out << nl << " */";
     out << nl << "static public void ice_write(com.zeroc.Ice.OutputStream ostr, " << name << " v)";
     out << sb;
-    out << nl << "if(v == null)";
+    out << nl << "if (v == null)";
     out << sb;
     out << nl << "_nullMarshalValue.ice_writeMembers(ostr);";
     out << eb;
@@ -3498,7 +3498,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     out << nl << " */";
     out << nl << "static public void ice_write(com.zeroc.Ice.OutputStream ostr, int tag, " << optName << " v)";
     out << sb;
-    out << nl << "if(v != null && v.isPresent())";
+    out << nl << "if (v != null && v.isPresent())";
     out << sb;
     out << nl << "ice_write(ostr, tag, v.get());";
     out << eb;
@@ -3514,7 +3514,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     out << nl << " */";
     out << nl << "static public void ice_write(com.zeroc.Ice.OutputStream ostr, int tag, " << name << " v)";
     out << sb;
-    out << nl << "if(ostr.writeOptional(tag, " << getOptionalFormat(p) << "))";
+    out << nl << "if (ostr.writeOptional(tag, " << getOptionalFormat(p) << "))";
     out << sb;
     if (p->isVariableLength())
     {
@@ -3540,7 +3540,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
     out << nl << " */";
     out << nl << "static public " << optName << " ice_read(com.zeroc.Ice.InputStream istr, int tag)";
     out << sb;
-    out << nl << "if(istr.readOptional(tag, " << getOptionalFormat(p) << "))";
+    out << nl << "if (istr.readOptional(tag, " << getOptionalFormat(p) << "))";
     out << sb;
     if (p->isVariableLength())
     {
@@ -3628,7 +3628,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
         out << sb;
         if (isOptional)
         {
-            out << nl << "if(!_" << name << ')';
+            out << nl << "if (!_" << name << ')';
             out << sb;
             out << nl << "throw new java.util.NoSuchElementException(\"" << name << " is not set\");";
             out << eb;
@@ -3691,7 +3691,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
             }
             out << nl << "public void optional" << capName << '(' << optType << " v)";
             out << sb;
-            out << nl << "if(v == null || !v.isPresent())";
+            out << nl << "if (v == null || !v.isPresent())";
             out << sb;
             out << nl << "_" << name << " = false;";
             out << eb;
@@ -3725,7 +3725,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
             }
             out << nl << "public " << optType << " optional" << capName << "()";
             out << sb;
-            out << nl << "if(_" << name << ')';
+            out << nl << "if (_" << name << ')';
             out << sb;
             if (classType)
             {
@@ -3784,7 +3784,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
             out << sb;
             if (isOptional)
             {
-                out << nl << "if(!_" << name << ')';
+                out << nl << "if (!_" << name << ')';
                 out << sb;
                 out << nl << "throw new java.util.NoSuchElementException(\"" << name << " is not set\");";
                 out << eb;
@@ -3816,7 +3816,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
                 out << sb;
                 if (isOptional)
                 {
-                    out << nl << "if(!_" << name << ')';
+                    out << nl << "if (!_" << name << ')';
                     out << sb;
                     out << nl << "throw new java.util.NoSuchElementException(\"" << name << " is not set\");";
                     out << eb;
@@ -3836,7 +3836,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
                 out << sb;
                 if (isOptional)
                 {
-                    out << nl << "if(!_" << name << ')';
+                    out << nl << "if (!_" << name << ')';
                     out << sb;
                     out << nl << "throw new java.util.NoSuchElementException(\"" << name << " is not set\");";
                     out << eb;
@@ -3909,7 +3909,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     out << nl << " */";
     out << nl << "public static " << name << " valueOf(int v)";
     out << sb;
-    out << nl << "switch(v)";
+    out << nl << "switch (v)";
     out << sb;
     out.dec();
     for (const auto& enumerator : enumerators)
@@ -3949,7 +3949,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     out << nl << " */";
     out << nl << "public static void ice_write(com.zeroc.Ice.OutputStream ostr, " << name << " v)";
     out << sb;
-    out << nl << "if(v == null)";
+    out << nl << "if (v == null)";
     out << sb;
     string firstEnum = enumerators.front()->mappedName();
     out << nl << "ostr.writeEnum(" << absolute << '.' << firstEnum << ".value(), " << p->maxValue() << ");";
@@ -3984,7 +3984,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     out << nl << " */";
     out << nl << "public static void ice_write(com.zeroc.Ice.OutputStream ostr, int tag, " << optName << " v)";
     out << sb;
-    out << nl << "if(v != null && v.isPresent())";
+    out << nl << "if (v != null && v.isPresent())";
     out << sb;
     out << nl << "ice_write(ostr, tag, v.get());";
     out << eb;
@@ -4000,7 +4000,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     out << nl << " */";
     out << nl << "public static void ice_write(com.zeroc.Ice.OutputStream ostr, int tag, " << name << " v)";
     out << sb;
-    out << nl << "if(ostr.writeOptional(tag, " << getOptionalFormat(p) << "))";
+    out << nl << "if (ostr.writeOptional(tag, " << getOptionalFormat(p) << "))";
     out << sb;
     out << nl << "ice_write(ostr, v);";
     out << eb;
@@ -4016,7 +4016,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     out << nl << " */";
     out << nl << "public static " << optName << " ice_read(com.zeroc.Ice.InputStream istr, int tag)";
     out << sb;
-    out << nl << "if(istr.readOptional(tag, " << getOptionalFormat(p) << "))";
+    out << nl << "if (istr.readOptional(tag, " << getOptionalFormat(p) << "))";
     out << sb;
     out << nl << "return java.util.Optional.of(ice_read(istr));";
     out << eb;
@@ -4029,7 +4029,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
     out << sp << nl << "private static " << name << " validate(int v)";
     out << sb;
     out << nl << "final " << name << " e = valueOf(v);";
-    out << nl << "if(e == null)";
+    out << nl << "if (e == null)";
     out << sb;
     out << nl << R"(throw new com.zeroc.Ice.MarshalException("enumerator value " + v + " is out of range");)";
     out << eb;
@@ -4157,7 +4157,7 @@ Slice::Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     out << nl << " */";
     out << nl << "public static void write(com.zeroc.Ice.OutputStream ostr, int tag, " << optTypeS << " v)";
     out << sb;
-    out << nl << "if(v != null && v.isPresent())";
+    out << nl << "if (v != null && v.isPresent())";
     out << sb;
     out << nl << "write(ostr, tag, v.get());";
     out << eb;
@@ -4173,7 +4173,7 @@ Slice::Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     out << nl << " */";
     out << nl << "public static void write(com.zeroc.Ice.OutputStream ostr, int tag, " << typeS << " v)";
     out << sb;
-    out << nl << "if(ostr.writeOptional(tag, " << getOptionalFormat(p) << "))";
+    out << nl << "if (ostr.writeOptional(tag, " << getOptionalFormat(p) << "))";
     out << sb;
     if (p->type()->isVariableLength())
     {
@@ -4207,7 +4207,7 @@ Slice::Gen::TypesVisitor::visitSequence(const SequencePtr& p)
     out << nl << " */";
     out << nl << "public static " << optTypeS << " read(com.zeroc.Ice.InputStream istr, int tag)";
     out << sb;
-    out << nl << "if(istr.readOptional(tag, " << getOptionalFormat(p) << "))";
+    out << nl << "if (istr.readOptional(tag, " << getOptionalFormat(p) << "))";
     out << sb;
     if (p->type()->isVariableLength())
     {
@@ -4287,7 +4287,7 @@ Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     out << nl << " */";
     out << nl << "public static void write(com.zeroc.Ice.OutputStream ostr, int tag, " << optTypeS << " v)";
     out << sb;
-    out << nl << "if(v != null && v.isPresent())";
+    out << nl << "if (v != null && v.isPresent())";
     out << sb;
     out << nl << "write(ostr, tag, v.get());";
     out << eb;
@@ -4303,7 +4303,7 @@ Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     out << nl << " */";
     out << nl << "public static void write(com.zeroc.Ice.OutputStream ostr, int tag, " << formalType << " v)";
     out << sb;
-    out << nl << "if(ostr.writeOptional(tag, " << getOptionalFormat(p) << "))";
+    out << nl << "if (ostr.writeOptional(tag, " << getOptionalFormat(p) << "))";
     out << sb;
     TypePtr keyType = p->keyType();
     TypePtr valueType = p->valueType();
@@ -4333,7 +4333,7 @@ Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     out << nl << " */";
     out << nl << "public static " << optTypeS << " read(com.zeroc.Ice.InputStream istr, int tag)";
     out << sb;
-    out << nl << "if(istr.readOptional(tag, " << getOptionalFormat(p) << "))";
+    out << nl << "if (istr.readOptional(tag, " << getOptionalFormat(p) << "))";
     out << sb;
     if (keyType->isVariableLength() || valueType->isVariableLength())
     {

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -1126,7 +1126,7 @@ Slice::JavaVisitor::writeResultType(
     Output& out,
     const OperationPtr& op,
     const string& package,
-    const optional<DocComment>& dc)
+    const optional<DocComment>& comment)
 {
     string opName = op->mappedName();
     opName[0] = static_cast<char>(toupper(static_cast<unsigned char>(opName[0])));
@@ -1167,7 +1167,7 @@ Slice::JavaVisitor::writeResultType(
 
         out << sp;
 
-        if (dc)
+        if (comment)
         {
             //
             // Emit a doc comment for the constructor if necessary.
@@ -1183,13 +1183,13 @@ Slice::JavaVisitor::writeResultType(
                 out << '.';
             }
 
-            const StringList& returns = dc->returns();
+            const StringList& returns = comment->returns();
             if (ret && !returns.empty())
             {
                 out << nl << " * @param " << retval << ' ';
                 writeDocCommentLines(out, returns);
             }
-            const map<string, StringList>& paramDocs = dc->parameters();
+            const map<string, StringList>& paramDocs = comment->parameters();
             for (const auto& outParam : outParams)
             {
                 auto q = paramDocs.find(outParam->name());
@@ -1264,9 +1264,9 @@ Slice::JavaVisitor::writeResultType(
     out << sp;
     if (ret)
     {
-        if (dc)
+        if (comment)
         {
-            const StringList& returns = dc->returns();
+            const StringList& returns = comment->returns();
             if (!returns.empty())
             {
                 out << nl << "/**";
@@ -1282,9 +1282,9 @@ Slice::JavaVisitor::writeResultType(
 
     for (const auto& outParam : outParams)
     {
-        if (dc)
+        if (comment)
         {
-            const map<string, StringList>& paramDocs = dc->parameters();
+            const map<string, StringList>& paramDocs = comment->parameters();
             auto q = paramDocs.find(outParam->name());
             if (q != paramDocs.end() && !q->second.empty())
             {
@@ -1327,7 +1327,7 @@ Slice::JavaVisitor::writeMarshaledResultType(
     Output& out,
     const OperationPtr& op,
     const string& package,
-    const optional<DocComment>& dc)
+    const optional<DocComment>& comment)
 {
     string opName = op->mappedName();
     const TypePtr ret = op->returnType();
@@ -1348,18 +1348,18 @@ Slice::JavaVisitor::writeMarshaledResultType(
     //
     // Emit a doc comment for the constructor if necessary.
     //
-    if (dc)
+    if (comment)
     {
         out << nl << "/**";
         out << nl << " * This constructor marshals the results of operation " << op->mappedName() << " immediately.";
 
-        const StringList& returns = dc->returns();
+        const StringList& returns = comment->returns();
         if (ret && !returns.empty())
         {
             out << nl << " * @param " << retval << ' ';
             writeDocCommentLines(out, returns);
         }
-        const map<string, StringList>& paramDocs = dc->parameters();
+        const map<string, StringList>& paramDocs = comment->parameters();
         for (const auto& outParam : outParams)
         {
             auto q = paramDocs.find(outParam->name());
@@ -1417,19 +1417,19 @@ Slice::JavaVisitor::writeMarshaledResultType(
         //
         // Emit a doc comment for the constructor if necessary.
         //
-        if (dc)
+        if (comment)
         {
             out << nl << "/**";
             out << nl << " * This constructor marshals the results of operation " << op->mappedName()
                 << " immediately (overload without Optional parameters).";
 
-            const StringList& returns = dc->returns();
+            const StringList& returns = comment->returns();
             if (ret && !returns.empty())
             {
                 out << nl << " * @param " << retval << ' ';
                 writeDocCommentLines(out, returns);
             }
-            const map<string, StringList>& paramDocs = dc->parameters();
+            const map<string, StringList>& paramDocs = comment->parameters();
             for (const auto& outParam : outParams)
             {
                 auto q = paramDocs.find(outParam->name());

--- a/cpp/src/slice2java/Gen.h
+++ b/cpp/src/slice2java/Gen.h
@@ -39,9 +39,7 @@ namespace Slice
             const MetadataList& metadata = MetadataList(),
             const std::string& patchParams = "");
 
-        //
-        // Generate code to marshal or unmarshal a dictionary type.
-        //
+        /// Generate code to marshal or unmarshal a dictionary type.
         static void writeDictionaryMarshalUnmarshalCode(
             IceInternal::Output& out,
             const std::string& package,
@@ -53,9 +51,7 @@ namespace Slice
             const std::string& customStream = "",
             const MetadataList& metadata = MetadataList());
 
-        //
-        // Generate code to marshal or unmarshal a sequence type.
-        //
+        /// Generate code to marshal or unmarshal a sequence type.
         static void writeSequenceMarshalUnmarshalCode(
             IceInternal::Output& out,
             const std::string& package,
@@ -76,18 +72,18 @@ namespace Slice
             bool isMarshalling);
 
         static void writeResultType(
-            IceInternal::Output&,
-            const OperationPtr&,
-            const std::string&,
-            const std::optional<DocComment>&);
+            IceInternal::Output& out,
+            const OperationPtr& op,
+            const std::string& package,
+            const std::optional<DocComment>& comment);
         static void writeMarshaledResultType(
-            IceInternal::Output&,
-            const OperationPtr&,
-            const std::string&,
-            const std::optional<DocComment>&);
+            IceInternal::Output& out,
+            const OperationPtr& op,
+            const std::string& package,
+            const std::optional<DocComment>& comment);
 
-        static void allocatePatcher(IceInternal::Output&, const TypePtr&, const std::string&, const std::string&);
-        static std::string getPatcher(const TypePtr&, const std::string&, const std::string&);
+        static void allocatePatcher(IceInternal::Output& out, const TypePtr& type, const std::string& package, const std::string& name);
+        static std::string getPatcher(const TypePtr& type, const std::string& package, const std::string& dest);
 
         static void writeSyncIceInvokeMethods(
             IceInternal::Output& out,
@@ -104,19 +100,16 @@ namespace Slice
             const std::optional<DocComment>& dc,
             bool optionalMapping);
 
-        static void writeMarshalProxyParams(IceInternal::Output&, const std::string&, const OperationPtr&, bool);
-        static void writeUnmarshalProxyResults(IceInternal::Output&, const std::string&, const OperationPtr&);
-        static void
-        writeMarshalServantResults(IceInternal::Output&, const std::string&, const OperationPtr&, const std::string&);
+        static void writeMarshalProxyParams(IceInternal::Output& out, const std::string& package, const OperationPtr& op, bool optionalMapping);
+        static void writeUnmarshalProxyResults(IceInternal::Output& out , const std::string& package, const OperationPtr& op);
+        static void writeMarshalServantResults(IceInternal::Output& out, const std::string& package, const OperationPtr& op, const std::string& param);
 
-        //
-        // Generate a throws clause containing only checked exceptions.
-        // op is provided only when we want to check for the java:UserException metadata
-        //
+        /// Generate a throws clause containing only checked exceptions.
+        /// @remark \p op is provided only when we want to check for the 'java:UserException' metadata.
         static void writeThrowsClause(
-            IceInternal::Output&,
-            const std::string&,
-            const ExceptionList&,
+            IceInternal::Output& out,
+            const std::string& package,
+            const ExceptionList& throws,
             const OperationPtr& op = nullptr);
 
         //
@@ -127,9 +120,7 @@ namespace Slice
         static void
         writeUnmarshalDataMember(IceInternal::Output&, const std::string&, const DataMemberPtr&, int&, bool = false);
 
-        //
-        // Write a constant or default value initializer.
-        //
+        /// Write a constant or default value initializer.
         static void writeConstantValue(
             IceInternal::Output&,
             const TypePtr&,
@@ -137,9 +128,7 @@ namespace Slice
             const std::string&,
             const std::string&);
 
-        //
-        // Generate assignment statements for those data members that have default values.
-        //
+        /// Generate assignment statements for those data members that have default values.
         static void writeDataMemberInitializers(IceInternal::Output&, const DataMemberList&, const std::string&);
 
         //

--- a/cpp/src/slice2java/Gen.h
+++ b/cpp/src/slice2java/Gen.h
@@ -82,7 +82,11 @@ namespace Slice
             const std::string& package,
             const std::optional<DocComment>& comment);
 
-        static void allocatePatcher(IceInternal::Output& out, const TypePtr& type, const std::string& package, const std::string& name);
+        static void allocatePatcher(
+            IceInternal::Output& out,
+            const TypePtr& type,
+            const std::string& package,
+            const std::string& name);
         static std::string getPatcher(const TypePtr& type, const std::string& package, const std::string& dest);
 
         static void writeSyncIceInvokeMethods(
@@ -100,9 +104,18 @@ namespace Slice
             const std::optional<DocComment>& dc,
             bool optionalMapping);
 
-        static void writeMarshalProxyParams(IceInternal::Output& out, const std::string& package, const OperationPtr& op, bool optionalMapping);
-        static void writeUnmarshalProxyResults(IceInternal::Output& out , const std::string& package, const OperationPtr& op);
-        static void writeMarshalServantResults(IceInternal::Output& out, const std::string& package, const OperationPtr& op, const std::string& param);
+        static void writeMarshalProxyParams(
+            IceInternal::Output& out,
+            const std::string& package,
+            const OperationPtr& op,
+            bool optionalMapping);
+        static void
+        writeUnmarshalProxyResults(IceInternal::Output& out, const std::string& package, const OperationPtr& op);
+        static void writeMarshalServantResults(
+            IceInternal::Output& out,
+            const std::string& package,
+            const OperationPtr& op,
+            const std::string& param);
 
         /// Generate a throws clause containing only checked exceptions.
         /// @remark \p op is provided only when we want to check for the 'java:UserException' metadata.

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -18,35 +18,32 @@ namespace Slice
             TypeModeReturn
         };
 
-        std::string getResultType(const OperationPtr&, const std::string&, bool, bool);
+        [[nodiscard]] std::string getResultType(const OperationPtr& op, const std::string& package, bool object, bool dispatch);
 
         /// Returns a vector of this operation's parameters with each of them formatted as 'paramType paramName'.
         /// If 'internal' is true, the names will be prefixed with "iceP_".
-        std::vector<std::string>
-        getParamsProxy(const OperationPtr& op, const std::string& package, bool optionalMapping, bool internal = false);
+        [[nodiscard]] std::vector<std::string> getParamsProxy(const OperationPtr& op, const std::string& package, bool optionalMapping, bool internal = false);
 
         /// Returns a vector of this operation's parameter's names in order.
         /// If 'internal' is true, the names will be prefixed with "iceP_".
-        std::vector<std::string> getInArgs(const OperationPtr& op, bool internal = false);
+        [[nodiscard]] std::vector<std::string> getInArgs(const OperationPtr& op, bool internal = false);
 
         //
         // These functions should only be called for classes, exceptions, and structs.
         // Enums automatically implement Serializable (Java just serializes the enumerator's identifier),
         // and proxies get their implementation from `_ObjectPrxI`.
         //
-        std::string getSerialVersionUID(const ContainedPtr&);
-        std::int64_t computeDefaultSerialVersionUID(const ContainedPtr&);
+        [[nodiscard]] std::string getSerialVersionUID(const ContainedPtr& p);
+        [[nodiscard]] std::int64_t computeDefaultSerialVersionUID(const ContainedPtr& p);
 
-        //
-        // Returns true if we can generate a method from the given data member list. A Java method
-        // can have a maximum of 255 parameters (including the implicit 'this') where each parameter
-        // is counted as 1 unit, except for long and double which are counted as 2 units.
-        // See https://docs.oracle.com/javase/specs/jvms/se20/html/jvms-4.html#jvms-4.3.3
-        //
-        bool isValidMethodParameterList(const DataMemberList&, int additionalUnits = 0);
+        /// Returns true if we can generate a method from the given data member list. A Java method
+        /// can have a maximum of 255 parameters (including the implicit 'this') where each parameter
+        /// is counted as 1 unit, except for long and double which are counted as 2 units.
+        /// See https://docs.oracle.com/javase/specs/jvms/se20/html/jvms-4.html#jvms-4.3.3
+        [[nodiscard]] bool isValidMethodParameterList(const DataMemberList& members, int additionalUnits = 0);
 
         /// Returns true if and only if 'p' maps to one of the builtin Java types (ie. a primitive type or a string).
-        bool mapsToJavaBuiltinType(const TypePtr& p);
+        [[nodiscard]] bool mapsToJavaBuiltinType(const TypePtr& p);
 
         /// Returns a package prefix specified by the 'java:package' metadata if present, or the empty string if not.
         [[nodiscard]] std::string getPackagePrefix(const ContainedPtr& contained);
@@ -54,7 +51,7 @@ namespace Slice
         /// Returns the Java package that 'contained' will be mapped into.
         [[nodiscard]] std::string getPackage(const ContainedPtr& contained);
 
-        // Returns the Java type without a package if the package matches the current package
+        /// Returns the Java type without a package if the package matches the current package
         [[nodiscard]] std::string getUnqualified(const std::string& type, const std::string& package);
 
         /// Returns the qualified Java name that 'contained' will be mapped to (ie. package + '.' + name).
@@ -63,14 +60,10 @@ namespace Slice
         /// so if 'contained' lives within this package, the returned name will have no qualification.
         [[nodiscard]] std::string getUnqualified(const ContainedPtr& cont, const std::string& package = std::string());
 
-        //
-        // Return the method call necessary to obtain the static type ID for an object type.
-        //
+        /// Returns the method call necessary to obtain the static type ID for an object type.
         [[nodiscard]] std::string getStaticId(const TypePtr& type, const std::string& package);
 
-        //
-        // Returns the optional type corresponding to the given Slice type.
-        //
+        /// Returns the optional type corresponding to the given Slice type.
         [[nodiscard]] std::string getOptionalFormat(const TypePtr& type);
 
         [[nodiscard]] std::string typeToString(
@@ -81,11 +74,8 @@ namespace Slice
             bool formal = true,
             bool optional = false);
 
-        //
-        // Get the Java object name for a type. For primitive types, this returns the
-        // Java class type (e.g., Integer). For all other types, this function delegates
-        // to typeToString.
-        //
+        /// Get the Java object name for a type. For primitive types, this returns the Java class type (e.g., Integer).
+        /// For all other types, this function delegates to typeToString.
         [[nodiscard]] std::string typeToObjectString(
             const TypePtr& type,
             TypeMode mode,
@@ -93,24 +83,16 @@ namespace Slice
             const MetadataList& metadata = MetadataList(),
             bool formal = true);
 
-        //
-        // Returns` true` if the metadata has an entry with the given directive, and `false` otherwise.
-        //
+        /// Returns `true` if the metadata has an entry with the given directive, and `false` otherwise.
         [[nodiscard]] bool hasMetadata(const std::string& directive, const MetadataList& metadata);
 
-        //
-        // Get custom type metadata. If metadata is found, the abstract and
-        // concrete types are extracted and the function returns true. If an
-        // abstract type is not specified, it is set to an empty string.
-        //
-        [[nodiscard]] bool
-        getTypeMetadata(const MetadataList& metadata, std::string& instanceType, std::string& formalType);
+        /// Gets any custom type metadata.
+        /// If metadata is found, the abstract and concrete types are extracted and the function returns true.
+        /// If an abstract type is not specified, it is set to an empty string.
+        [[nodiscard]] bool getTypeMetadata(const MetadataList& metadata, std::string& instanceType, std::string& formalType);
 
-        //
-        // Determine whether a custom type is defined. The function checks the
-        // metadata of the type's original definition, as well as any optional
-        // metadata that typically represents a data member or parameter.
-        //
+        /// Determine whether a custom type is defined. The function checks the metadata of the type's original
+        /// definition, as well as any optional metadata that typically represents a data member or parameter.
         [[nodiscard]] bool hasTypeMetadata(const SequencePtr& seq, const MetadataList& localMetadata = MetadataList());
 
         //

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -18,11 +18,13 @@ namespace Slice
             TypeModeReturn
         };
 
-        [[nodiscard]] std::string getResultType(const OperationPtr& op, const std::string& package, bool object, bool dispatch);
+        [[nodiscard]] std::string
+        getResultType(const OperationPtr& op, const std::string& package, bool object, bool dispatch);
 
         /// Returns a vector of this operation's parameters with each of them formatted as 'paramType paramName'.
         /// If 'internal' is true, the names will be prefixed with "iceP_".
-        [[nodiscard]] std::vector<std::string> getParamsProxy(const OperationPtr& op, const std::string& package, bool optionalMapping, bool internal = false);
+        [[nodiscard]] std::vector<std::string>
+        getParamsProxy(const OperationPtr& op, const std::string& package, bool optionalMapping, bool internal = false);
 
         /// Returns a vector of this operation's parameter's names in order.
         /// If 'internal' is true, the names will be prefixed with "iceP_".
@@ -89,7 +91,8 @@ namespace Slice
         /// Gets any custom type metadata.
         /// If metadata is found, the abstract and concrete types are extracted and the function returns true.
         /// If an abstract type is not specified, it is set to an empty string.
-        [[nodiscard]] bool getTypeMetadata(const MetadataList& metadata, std::string& instanceType, std::string& formalType);
+        [[nodiscard]] bool
+        getTypeMetadata(const MetadataList& metadata, std::string& instanceType, std::string& formalType);
 
         /// Determine whether a custom type is defined. The function checks the metadata of the type's original
         /// definition, as well as any optional metadata that typically represents a data member or parameter.


### PR DESCRIPTION
This PR adds `nodiscard`s and parameter names to `slice2java`, like how I did for the other compilers.

I wanted to tease apart the `writeMarshalUnmarshalCode` method (this single function is 460 lines and takes 12 parameters!), but it's just too large an undertaking right now. So I only did some small cleanup of it's logic.