### PR TITLE
Use dataclass for mapped structs in Python

### DIFF
--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1290,7 +1290,7 @@ Slice::Python::CodeVisitor::visitStructStart(const StructPtr& p)
         else if (auto st = dynamic_pointer_cast<Struct>(field->type()))
         {
             // See writeAssign.
-            _out << " = " << getTypeReference(st) << "()";
+            _out << " = " << "field(default_factory=" << getTypeReference(st) << ')';
         }
         else
         {
@@ -2248,7 +2248,7 @@ Slice::Python::generate(const UnitPtr& unit, bool all, const vector<string>& inc
     }
     if (unit->contains<Struct>())
     {
-        out << nl << "from dataclasses import dataclass";
+        out << nl << "from dataclasses import dataclass, field";
     }
 
     out << nl << "import Ice";

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1261,12 +1261,11 @@ Slice::Python::CodeVisitor::visitStructStart(const StructPtr& p)
     writeModuleHasDefinitionCheck(_out, p, name);
     _out.inc();
     _out << nl << abs << " = None";
-    _out << nl << "@dataclass(order=True";
+    _out << nl << "@dataclass";
     if (Dictionary::isLegalKeyType(p))
     {
-        _out << ", unsafe_hash=True";
+        _out << "(order=True, unsafe_hash=True)";
     }
-    _out << ')';
 
     _out << nl << "class " << name << ":";
     _out.inc();


### PR DESCRIPTION
This PR is an attempt to use `@dataclass` for mapped structs in Python.