### PR TITLE
Fix '@link' Mapping in MATLAB

### DIFF
--- a/cpp/src/slice2matlab/Gen.cpp
+++ b/cpp/src/slice2matlab/Gen.cpp
@@ -274,16 +274,17 @@ namespace
         }
     }
 
-    /// Returns a MATLAB formatted link to the provided Slice identifier.
+    /// Returns a MATLAB formatted link (an 'href') for the provided Slice identifier.
     string matlabLinkFormatter(const string& rawLink, const ContainedPtr&, const SyntaxTreeBasePtr& target)
     {
-        string displayText;
-        string linkText;
+        string displayText; // The hyperlink text that will be visible to the user.
+        string linkText;    // The fully-scoped name of a MATLAB element, which the link resolves to when clicked.
 
         if (auto contained = dynamic_pointer_cast<Contained>(target))
         {
             if (dynamic_pointer_cast<DataMember>(contained) || dynamic_pointer_cast<Enumerator>(contained))
             {
+                // Data member & enumerator links should be of the form "<ScopedType>/<propertyName>".
                 auto container = dynamic_pointer_cast<Contained>(contained->container());
                 assert(container);
                 displayText = container->mappedName() + "/" + contained->mappedName();
@@ -291,6 +292,7 @@ namespace
             }
             else if (auto opTarget = dynamic_pointer_cast<Operation>(target))
             {
+                // Operation links should be of the form "<ScopedProxy>/<functionName>".
                 auto interfaceDef = opTarget->interface();
                 displayText = opTarget->mappedName();
                 linkText = interfaceDef->mappedScoped(".") + "Prx" + "/" + displayText;
@@ -318,7 +320,7 @@ namespace
             displayText = linkText = std::regex_replace(rawLink, separatorRegex, ".");
         }
 
-        // MATLAB allows you to run arbitrary commands inside an 'href' with the 'matlab:' prefix.
+        // MATLAB allows you to run arbitrary commands inside an 'href', using the 'matlab:' command prefix.
         return "<a href=\"matlab:help " + linkText + " -displayBanner\">" + displayText + "</a>";
     }
 


### PR DESCRIPTION
This PR updates MATLAB to property map `@link` for all Slice types.
The generated links work well in the 'Command Window' (via the `help` command).
And also show up well in the browser (via the `doc` command).

I did not check the generated HTML you get with publish, because I couldn't get `publish` working...

Included below are the generated code, and how it renders with `help` and `doc` respectively:

----

----

**This Slice definition:**
```
    /// The Glacier2 specialization of the {@link Ice::Router} interface.
    interface Router extends Ice::Router { ... }
```
**will produce this generated code:**
```
classdef RouterPrx < Ice.RouterPrx
    %ROUTERPRX The Glacier2 specialization of the <a href="matlab:help Ice.RouterPrx -displayBanner">RouterPrx</a> interface.
    % ... more stuff
```
**This is what it looks like in the command window:**
![image](https://github.com/user-attachments/assets/f3316db4-0027-40ec-8463-17c1341e8a5b)
**And what it looks in the rendered doc page (with `doc Glacier2.RouterPrx`):**
![image](https://github.com/user-attachments/assets/b3832eb2-ce44-48d6-93c5-58084ceaaa78)

----

----

**And then one other example, here's the Slice definition for `RemoteLogger::log`:**
```
        /// Logs a LogMessage.
        /// @param message The message to log.
        /// @remark {@link log} may be called by {@link LoggerAdmin} before {@link init}.
        void log(LogMessage message);
```
**This is the generated code for it:**
```
            %LOG Logs a LogMessage.
            %
            %   Input Arguments
            %     message - The message to log.
            %       Ice.LogMessage scalar
            %     context - The request context.
            %       unconfigured dictionary (default) | dictionary(string, string) scalar
            %
            %   Remarks
            %     <a href="matlab:help Ice.RemoteLoggerPrx/log -displayBanner">log</a> may be called by <a href="matlab:help Ice.LoggerAdminPrx -displayBanner">LoggerAdminPrx</a> before <a href="matlab:help Ice.RemoteLoggerPrx/init -displayBanner">init</a>.
```
**Here's the output of `help Ice/RemoteLoggerPrx/log`, including what happens when you click the `init` link:**
![image](https://github.com/user-attachments/assets/7bde73f9-d0a2-4598-a135-6cadadfc3a0a)
**And here's the rendered doc-page (`doc Ice/RemoteLoggerPrx/log`):**
![image](https://github.com/user-attachments/assets/28411e4d-72d6-4bfb-a917-11cba5ee5425)