### PR TITLE
Simplify `slice2java` OptionalMode

### DIFF
--- a/cpp/src/slice2java/Gen.h
+++ b/cpp/src/slice2java/Gen.h
@@ -14,9 +14,7 @@ namespace Slice
     enum OptionalMode
     {
         OptionalNone,
-        OptionalInParam,
-        OptionalOutParam,
-        OptionalReturnParam,
+        OptionalParam, // Also used for return values.
         OptionalMember
     };
 


### PR DESCRIPTION
So, `slice2java` has this enum:
```cpp
enum OptionalMode
{
    OptionalNone,
    OptionalInParam,
    OptionalOutParam,
    OptionalReturnParam,
    OptionalMember
};
```
Turns out we never ever distinguish between `OptionalInParam`, `OptionalOutParam`, `OptionalReturnParam`.
They all cause the exact same code to be generated, so... I just combined them all into a single `OptionalParam` value instead.