### PR TITLE
Initial support for Python type hints

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -35,3 +35,11 @@ all:: srcs
 #
 all generate-srcs clean distclean install::
 	+$(Q)$(MAKE) -C python $@
+
+#
+# Translate the Slice files from test directories
+#
+$(eval $(call load-translator-dependencies,$(top_srcdir)/cpp/src/slice2py))
+tests := $(call tests-without-project-makefile,py)
+include $(shell find test -name Makefile.mk)
+$(foreach t,$(tests),$(eval $(call make-python-test-project,$(t))))

--- a/python/config/Make.rules
+++ b/python/config/Make.rules
@@ -110,3 +110,55 @@ $2/$3/$(or $4,%)_ice.py: $1/$3/$(or $4,%).ice $2/$3/.depend/$(or $4,%).ice.d $(s
 	$(Q)$(slice2py_path) -I$1 --output-dir $2 $5 $$<
 
 endef
+
+#
+# $(call make-python-test-project,$1=testdir)
+#
+define make-python-test-project
+
+$1/.depend/client/%.ice.d: | $1/.depend/client ;
+
+$1/.depend/server/%.ice.d: | $1/.depend/server ;
+
+$1/.depend/client $1/.depend/server:
+	$(Q)$(MKDIR) -p $$@
+
+.PRECIOUS: $1/.depend/client/%.ice.d $1/.depend/server/%.ice.d
+
+ifeq ($(filter %clean,$(MAKECMDGOALS)),)
+    # Include the dependencies
+    -include $(addprefix $1/.depend/client/, \
+        $(call source-to-dependency,$(filter-out $1/Server%.ice,$(wildcard $1/*.ice))))
+    -include $(addprefix $1/.depend/server/, \
+        $(call source-to-dependency,$(filter-out $1/Client%.ice,$(wildcard $1/*.ice))))
+endif
+
+$1/generated/client/%_ice.py: $1/%.ice $1/.depend/client/%.ice.d $(slice2py_path)
+	$(E) "Compiling $$<"
+	$(Q) mkdir -p $1/generated/client
+	$(Q)'$(slice2py_path)' $(slice2py_flags) -I$(slicedir) -I$1 --output-dir $1 $$($1_sliceflags) --depend $$< | \
+		sed 's/\(.*: \\\)/$(subst /,\/,$2)\/$3\/\1/' > $1/.depend/client/$$(*F).ice.d
+	$(Q)$(slice2py_path) $(slice2py_flags) -I$(slicedir) -I$1 --output-dir $1/generated/client $$($1_sliceflags) $$<
+
+$1/generated/server/%_ice.py: $1/%.ice $1/.depend/server/%.ice.d $(slice2py_path)
+	$(E) "Compiling $$<"
+	$(Q) mkdir -p $1/generated/server
+	$(Q)'$(slice2py_path)' $(slice2py_flags) -I$(slicedir) -I$1 --output-dir $1 $$($1_sliceflags) --depend $$< | \
+		sed 's/\(.*: \\\)/$(subst /,\/,$2)\/$3\/\1/' > $1/.depend/server/$$(*F).ice.d
+	$(Q)$(slice2py_path) $(slice2py_flags) -I$(slicedir) -I$1 --output-dir $1/generated/server $$($1_sliceflags) $$<
+
+distclean clean::
+	$(E) "Cleaning $1"
+	$(Q)$(RM) -r $1/.depend
+	$(Q)$(RM) $(patsubst $1/%.ice,$1/generated/client/%_ice.py, \
+		$(filter-out $1/Server%.ice,$(wildcard $1/*.ice)))
+	$(Q)$(RM) $(patsubst $1/%.ice,$1/generated/server/%_ice.py, \
+		$(filter-out $1/Client%.ice,$(wildcard $1/*.ice)))
+
+tests generate-srcs srcs all:: \
+	$(patsubst $1/%.ice,$1/generated/client/%_ice.py, \
+		$(filter-out $1/Server%.ice,$(wildcard $1/*.ice))) \
+	$(patsubst $1/%.ice,$1/generated/server/%_ice.py, \
+		$(filter-out $1/Client%.ice,$(wildcard $1/*.ice)))
+
+endef

--- a/python/msbuild/ice.proj
+++ b/python/msbuild/ice.proj
@@ -46,6 +46,15 @@
         <PythonGenerated Include="$(MSBuildThisFileDirectory)\..\python\**\*_ice.py"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <ClientSliceCompile Include="$(MSBuildThisFileDirectory)..\test\**\*.ice" Exclude="**\Server*.ice">
+            <OutputDir>$(MSBuildThisFileDirectory)..\test\%(RecursiveDir)\generated\client</OutputDir>
+        </ClientSliceCompile>
+        <ServerSliceCompile Include="$(MSBuildThisFileDirectory)..\test\**\*.ice" Exclude="**\Client*.ice">
+            <OutputDir>$(MSBuildThisFileDirectory)..\test\%(RecursiveDir)\generated\server</OutputDir>
+        </ServerSliceCompile>
+    </ItemGroup>
+
     <Target Name="BuildCppDist" DependsOnTargets="NuGetRestore">
         <MSBuild Projects="$(MSBuildThisFileDirectory)..\..\cpp\tools\ZeroC.Ice.Slice.Tools.Cpp\ZeroC.Ice.Slice.Tools.Cpp.sln"
                  Properties="Platform=Any CPU;Configuration=$(Configuration)"
@@ -66,6 +75,11 @@
     </Target>
 
     <Target Name="Build" DependsOnTargets="BuildDist">
+        <MakeDir Directories="@(ClientSliceCompile->'%(OutputDir)')"/>
+        <Exec Command="&quot;$(MSBuildThisFileDirectory)..\..\cpp\bin\$(Platform)\$(Configuration)\slice2py.exe&quot; --output-dir %(ClientSliceCompile.OutputDir) -I&quot;$(IceHome)\slice&quot; @(ClientSliceCompile->'%(Identity)', ' ')" />
+
+        <MakeDir Directories="@(ServerSliceCompile->'%(OutputDir)')"/>
+        <Exec Command="&quot;$(MSBuildThisFileDirectory)..\..\cpp\bin\$(Platform)\$(Configuration)\slice2py.exe&quot; --output-dir %(ServerSliceCompile.OutputDir) -I&quot;$(IceHome)\slice&quot; @(ServerSliceCompile->'%(Identity)', ' ')" />
     </Target>
 
     <Target Name="Clean">

--- a/python/python/Ice/SliceInfo.py
+++ b/python/python/Ice/SliceInfo.py
@@ -1,0 +1,21 @@
+# Copyright (c) ZeroC, Inc.
+
+class SliceInfo:
+    """
+    Encapsulates the details of a slice with an unknown type.
+
+    Attributes
+    ----------
+    typeId : str
+        The Slice type ID for this slice.
+    compactId : int
+        The Slice compact type ID for this slice.
+    bytes : bytes
+        The encoded bytes for this slice, including the leading size integer.
+    hasOptionalMembers : bool
+        Whether or not the slice contains optional members.
+    isLastSlice : bool
+        Whether or not this is the last slice.
+    """
+
+    pass

--- a/python/python/Ice/SlicedData.py
+++ b/python/python/Ice/SlicedData.py
@@ -1,0 +1,13 @@
+# Copyright (c) ZeroC, Inc.
+
+class SlicedData:
+    """
+    Holds class slices that cannot be unmarshaled because their types are not known locally.
+
+    Attributes
+    ----------
+    slices : tuple of SliceInfo
+        The details of each slice, in order of most-derived to least-derived.
+    """
+
+    pass

--- a/python/python/Ice/ToStringMode.py
+++ b/python/python/Ice/ToStringMode.py
@@ -1,6 +1,7 @@
 # Copyright (c) ZeroC, Inc.
 
 from .EnumBase import EnumBase
+from typing import Self
 
 class ToStringMode(EnumBase):
     """
@@ -28,7 +29,7 @@ class ToStringMode(EnumBase):
     def __init__(self, _n, _v):
         EnumBase.__init__(self, _n, _v)
 
-    def valueOf(self, value):
+    def valueOf(self, value: int) -> Self | None:
         """
         Get the enumerator corresponding to the given value.
 

--- a/python/python/Ice/UnknownSlicedValue.py
+++ b/python/python/Ice/UnknownSlicedValue.py
@@ -16,40 +16,6 @@ class UnknownSlicedValue(Value):
     def ice_id(self):
         return self.unknownTypeId
 
-
-class SlicedData:
-    """
-    Holds class slices that cannot be unmarshaled because their types are not known locally.
-
-    Attributes
-    ----------
-    slices : tuple of SliceInfo
-        The details of each slice, in order of most-derived to least-derived.
-    """
-
-    pass
-
-
-class SliceInfo:
-    """
-    Encapsulates the details of a slice with an unknown type.
-
-    Attributes
-    ----------
-    typeId : str
-        The Slice type ID for this slice.
-    compactId : int
-        The Slice compact type ID for this slice.
-    bytes : bytes
-        The encoded bytes for this slice, including the leading size integer.
-    hasOptionalMembers : bool
-        Whether or not the slice contains optional members.
-    isLastSlice : bool
-        Whether or not this is the last slice.
-    """
-
-    pass
-
 IcePy._t_UnknownSlicedValue = IcePy.defineValue(
     "::Ice::UnknownSlicedValue", UnknownSlicedValue, -1, (), False, None, ()
 )

--- a/python/python/Ice/UserException.py
+++ b/python/python/Ice/UserException.py
@@ -8,7 +8,7 @@ class UserException(IceException):
     def __init__(self):
         super().__init__()
 
-    def __str__(self):
+    def __str__(self) -> str:
         return repr(self)
 
 __all__ = ["UserException"]

--- a/python/python/Ice/Util.py
+++ b/python/python/Ice/Util.py
@@ -10,10 +10,28 @@ from .InitializationData import InitializationData
 from .Properties import Properties
 from .Communicator import Communicator
 from .LocalExceptions import InitializationException
+from .EventLoopAdapter import EventLoopAdapter
 from .asyncio.EventLoopAdapter import EventLoopAdapter as AsyncIOEventLoopAdapter
+from typing import overload
+from .ToStringMode import ToStringMode
+import Ice
 
 __name__ = "Ice"
 
+@overload
+def initialize() -> Communicator: ...
+
+@overload
+def initialize(args: list[str]) -> Communicator: ...
+
+@overload
+def initialize(args: list[str], initData: InitializationData) -> Communicator: ...
+
+@overload
+def initialize(
+    args: list[str],
+    configFile: str | None = None,
+    eventLoop: EventLoopAdapter | None = None) -> Communicator: ...
 
 def initialize(args=None, initData=None, configFile=None, eventLoop=None):
     """
@@ -76,7 +94,7 @@ def initialize(args=None, initData=None, configFile=None, eventLoop=None):
     communicator = IcePy.Communicator(args, initData, configFile)
     return Communicator(communicator, eventLoopAdapter)
 
-def identityToString(identity, toStringMode=None):
+def identityToString(identity: Ice.Identity, toStringMode: ToStringMode=None) -> str:
     """
     Convert an object identity to a string.
 
@@ -95,7 +113,7 @@ def identityToString(identity, toStringMode=None):
     return IcePy.identityToString(identity, toStringMode)
 
 
-def stringToIdentity(str):
+def stringToIdentity(str: str) -> Ice.Identity:
     """
     Convert a string to an object identity.
 
@@ -117,7 +135,7 @@ def stringToIdentity(str):
     return IcePy.stringToIdentity(str)
 
 
-def createProperties(args=None, defaults=None):
+def createProperties(args: list[str]=None, defaults: Properties=None) -> Properties:
     """
     Creates a new property set.
 
@@ -162,7 +180,7 @@ def createProperties(args=None, defaults=None):
     return Properties(properties)
 
 
-def getSliceDir():
+def getSliceDir() -> str | None:
     """
     Returns the path to the directory where the Ice Slice files are installed.
 

--- a/python/python/Ice/Value.py
+++ b/python/python/Ice/Value.py
@@ -1,9 +1,11 @@
 # Copyright (c) ZeroC, Inc.
 
 import IcePy
+from .SlicedData import SlicedData
 
 class Value(object):
-    def ice_id(self):
+
+    def ice_id(self) -> str:
         """
         Obtain the type ID corresponding to the most-derived Slice interface supported by the target object.
 
@@ -15,7 +17,7 @@ class Value(object):
         return "::Ice::Object"
 
     @staticmethod
-    def ice_staticId():
+    def ice_staticId() -> str:
         """
         Obtain the type ID of this Slice class or interface.
 
@@ -35,7 +37,7 @@ class Value(object):
     # def ice_postUnmarshal(self):
     #    pass
 
-    def ice_getSlicedData(self):
+    def ice_getSlicedData(self) -> SlicedData | None:
         """
         Return the sliced data if the value has a preserved-slice base class and has been sliced during
         un-marshaling of the value. Return None otherwise.
@@ -47,7 +49,7 @@ class Value(object):
         """
         return getattr(self, "_ice_slicedData", None)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return repr(self)
 
 IcePy._t_Value = IcePy.defineValue("::Ice::Object", Value, -1, (), False, None, ())

--- a/python/python/Ice/_ArrayUtil.py
+++ b/python/python/Ice/_ArrayUtil.py
@@ -35,7 +35,7 @@ try:
     import numpy
 
     BuiltinNumpyTypes = [
-        numpy.bool_,
+        numpy.bool,
         numpy.int8,
         numpy.int16,
         numpy.int32,

--- a/python/python/Ice/__init__.py
+++ b/python/python/Ice/__init__.py
@@ -43,7 +43,8 @@ from .Object import Object
 from .ObjectPrx import ObjectPrx, checkedCast, checkedCastAsync, uncheckedCast
 from .Blobject import Blobject
 from .FormatType import *
-from .Util import *
+from .SlicedData import SlicedData
+from .SliceInfo import SliceInfo
 from .UnknownSlicedValue import *
 from .ToStringMode import *
 from .Exception import *
@@ -79,6 +80,8 @@ import Ice.RemoteLogger_ice
 import Ice.Router_ice
 import Ice.Version_ice
 import Ice.Metrics_ice
+
+from .Util import *
 
 #
 # Add EndpointInfo alias in Ice module.

--- a/python/test/Glacier2/router/Client.py
+++ b/python/test/Glacier2/router/Client.py
@@ -9,8 +9,6 @@ import Glacier2
 
 from TestHelper import TestHelper
 
-TestHelper.loadSlice(f"--all {Ice.getSliceDir()}/Glacier2/Router.ice")
-TestHelper.loadSlice("Callback.ice")
 import Test
 
 

--- a/python/test/Glacier2/router/Server.py
+++ b/python/test/Glacier2/router/Server.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Callback.ice")
 import Ice
 import Test
 

--- a/python/test/Ice/adapterDeactivation/Client.py
+++ b/python/test/Ice/adapterDeactivation/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/adapterDeactivation/Collocated.py
+++ b/python/test/Ice/adapterDeactivation/Collocated.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 import TestI
 

--- a/python/test/Ice/adapterDeactivation/Server.py
+++ b/python/test/Ice/adapterDeactivation/Server.py
@@ -1,8 +1,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import TestI
 
 

--- a/python/test/Ice/admin/Client.py
+++ b/python/test/Ice/admin/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/admin/Server.py
+++ b/python/test/Ice/admin/Server.py
@@ -4,8 +4,6 @@
 
 import Ice
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import TestI
 
 

--- a/python/test/Ice/ami/Client.py
+++ b/python/test/Ice/ami/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/ami/Collocated.py
+++ b/python/test/Ice/ami/Collocated.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 import TestI
 import Ice

--- a/python/test/Ice/ami/Server.py
+++ b/python/test/Ice/ami/Server.py
@@ -4,8 +4,6 @@
 
 import Ice
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import TestI
 
 

--- a/python/test/Ice/asyncio/Client.py
+++ b/python/test/Ice/asyncio/Client.py
@@ -5,7 +5,6 @@
 import asyncio
 import Ice
 from TestHelper import TestHelper
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/asyncio/Server.py
+++ b/python/test/Ice/asyncio/Server.py
@@ -5,7 +5,6 @@
 import Ice
 import asyncio
 from TestHelper import TestHelper
-TestHelper.loadSlice("Test.ice")
 import TestI
 
 

--- a/python/test/Ice/blobject/Client.py
+++ b/python/test/Ice/blobject/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import sys
 import Ice
 import Test

--- a/python/test/Ice/blobject/Server.py
+++ b/python/test/Ice/blobject/Server.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import Ice
 import Test
 import time

--- a/python/test/Ice/current/Client.py
+++ b/python/test/Ice/current/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/current/Collocated.py
+++ b/python/test/Ice/current/Collocated.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import Ice
 import TestI
 import AllTests

--- a/python/test/Ice/current/Server.py
+++ b/python/test/Ice/current/Server.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import Ice
 import TestI
 

--- a/python/test/Ice/custom/AllTests.py
+++ b/python/test/Ice/custom/AllTests.py
@@ -1,9 +1,18 @@
 # Copyright (c) ZeroC, Inc.
 
 import sys
-import Test
 import array
+try:
+    import numpy
 
+    hasNumPy = True
+except ImportError:
+    hasNumPy = False
+    pass
+import Test
+
+if hasNumPy:
+    import Test.NumPy
 
 def test(b):
     if not b:
@@ -344,9 +353,7 @@ def allTests(helper, communicator):
 
     print("ok")
 
-    try:
-        import numpy
-
+    if hasNumPy:
         ref = "test.numpy:{0}".format(helper.getTestEndpoint())
         base = communicator.stringToProxy(ref)
         test(base)
@@ -613,8 +620,5 @@ def allTests(helper, communicator):
             pass
 
         print("ok")
-    except ImportError:
-        print("numpy not installed skiping python:numpy.ndarray testing")
-        pass
 
     return custom

--- a/python/test/Ice/custom/Client.py
+++ b/python/test/Ice/custom/Client.py
@@ -3,14 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
-
-try:
-    TestHelper.loadSlice("TestNumPy.ice")
-except ImportError:
-    pass
-
 import AllTests
 
 

--- a/python/test/Ice/custom/Server.py
+++ b/python/test/Ice/custom/Server.py
@@ -4,9 +4,6 @@
 
 from TestHelper import TestHelper
 
-TestHelper.loadSlice("Test.ice")
-
-
 try:
     import numpy
 
@@ -15,16 +12,9 @@ except ImportError:
     hasNumPy = False
     pass
 
-#
-# Use separate try/except to ensure loadSlice correctly report ImportError
-# in ausence of numpy.
-#
-try:
-    TestHelper.loadSlice("TestNumPy.ice")
-except ImportError:
-    pass
-
 import Test
+if hasNumPy:
+    import Test.NumPy
 import Ice
 import array
 

--- a/python/test/Ice/defaultServant/Client.py
+++ b/python/test/Ice/defaultServant/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/defaultValue/Client.py
+++ b/python/test/Ice/defaultValue/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/enums/Client.py
+++ b/python/test/Ice/enums/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/enums/Server.py
+++ b/python/test/Ice/enums/Server.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import Ice
 import Test
 

--- a/python/test/Ice/exceptions/Client.py
+++ b/python/test/Ice/exceptions/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/exceptions/Collocated.py
+++ b/python/test/Ice/exceptions/Collocated.py
@@ -4,8 +4,6 @@
 
 import Ice
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import TestI
 import AllTests
 

--- a/python/test/Ice/exceptions/Server.py
+++ b/python/test/Ice/exceptions/Server.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import Ice
 import TestI
 

--- a/python/test/Ice/exceptions/ServerAMD.py
+++ b/python/test/Ice/exceptions/ServerAMD.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import Ice
 import Test
 

--- a/python/test/Ice/executor/Client.py
+++ b/python/test/Ice/executor/Client.py
@@ -5,8 +5,6 @@
 import Ice
 import Executor
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/executor/Server.py
+++ b/python/test/Ice/executor/Server.py
@@ -4,8 +4,6 @@
 
 import Ice
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import TestI
 import Executor
 

--- a/python/test/Ice/facets/Client.py
+++ b/python/test/Ice/facets/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/facets/Collocated.py
+++ b/python/test/Ice/facets/Collocated.py
@@ -4,8 +4,6 @@
 
 import Ice
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import TestI
 import AllTests
 

--- a/python/test/Ice/facets/Server.py
+++ b/python/test/Ice/facets/Server.py
@@ -4,8 +4,6 @@
 
 import Ice
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import TestI
 
 

--- a/python/test/Ice/faultTolerance/AllTests.py
+++ b/python/test/Ice/faultTolerance/AllTests.py
@@ -3,8 +3,6 @@
 import Ice
 import sys
 import threading
-
-Ice.loadSlice("Test.ice")
 import Test
 
 

--- a/python/test/Ice/faultTolerance/Server.py
+++ b/python/test/Ice/faultTolerance/Server.py
@@ -5,8 +5,6 @@
 import os
 import Ice
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import Test
 
 

--- a/python/test/Ice/info/Client.py
+++ b/python/test/Ice/info/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/info/Server.py
+++ b/python/test/Ice/info/Server.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import Ice
 import TestI
 

--- a/python/test/Ice/inheritance/Client.py
+++ b/python/test/Ice/inheritance/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/inheritance/Collocated.py
+++ b/python/test/Ice/inheritance/Collocated.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import Ice
 import TestI
 import AllTests

--- a/python/test/Ice/inheritance/Server.py
+++ b/python/test/Ice/inheritance/Server.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import TestI
 import Ice
 

--- a/python/test/Ice/location/Client.py
+++ b/python/test/Ice/location/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/location/Server.py
+++ b/python/test/Ice/location/Server.py
@@ -4,8 +4,6 @@
 
 import Ice
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import Test
 
 

--- a/python/test/Ice/objects/Client.py
+++ b/python/test/Ice/objects/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice Forward.ice ClientPrivate.ice")
 import AllTests
 import Ice
 import TestI

--- a/python/test/Ice/objects/Collocated.py
+++ b/python/test/Ice/objects/Collocated.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice Forward.ice ClientPrivate.ice")
 import Ice
 import TestI
 import AllTests

--- a/python/test/Ice/objects/Server.py
+++ b/python/test/Ice/objects/Server.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice Forward.ice ServerPrivate.ice")
 import TestI
 import Ice
 

--- a/python/test/Ice/operations/Client.py
+++ b/python/test/Ice/operations/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/operations/Collocated.py
+++ b/python/test/Ice/operations/Collocated.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import Ice
 import TestI
 import AllTests

--- a/python/test/Ice/operations/Server.py
+++ b/python/test/Ice/operations/Server.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import Ice
 import TestI
 

--- a/python/test/Ice/operations/ServerAMD.py
+++ b/python/test/Ice/operations/ServerAMD.py
@@ -2,7 +2,7 @@
 
 # Copyright (c) ZeroC, Inc.
 
-#
+# TODO: This is no longer relevant. All supported Python versions provide async/await keywords.
 # We want to test coroutines but older versions of Python cannot
 # load a source file that uses the async/await keywords, so we
 # have two versions of MyDerivedClassI.
@@ -10,8 +10,6 @@
 from TestAMDCoroI import MyDerivedClassI
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import Ice
 
 

--- a/python/test/Ice/operations/TestAMDCoroI.py
+++ b/python/test/Ice/operations/TestAMDCoroI.py
@@ -2,18 +2,10 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import sys
 import threading
 import time
 import concurrent.futures
 import Ice
-
-slice_dir = Ice.getSliceDir()
-if not slice_dir:
-    print(sys.argv[0] + ": Slice directory not found.")
-    sys.exit(1)
-
-Ice.loadSlice("'-I" + slice_dir + "' Test.ice")
 import Test
 
 

--- a/python/test/Ice/operations/TestAMDI.py
+++ b/python/test/Ice/operations/TestAMDI.py
@@ -2,17 +2,9 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import sys
 import threading
 import time
 import Ice
-
-slice_dir = Ice.getSliceDir()
-if not slice_dir:
-    print(sys.argv[0] + ": Slice directory not found.")
-    sys.exit(1)
-
-Ice.loadSlice("'-I" + slice_dir + "' Test.ice")
 import Test
 
 

--- a/python/test/Ice/optional/Client.py
+++ b/python/test/Ice/optional/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("--all -I. ClientPrivate.ice")
 import AllTests
 
 

--- a/python/test/Ice/optional/Server.py
+++ b/python/test/Ice/optional/Server.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import Ice
 import Test
 

--- a/python/test/Ice/optional/ServerAMD.py
+++ b/python/test/Ice/optional/ServerAMD.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import Ice
 import Test
 

--- a/python/test/Ice/packagemd/Client.py
+++ b/python/test/Ice/packagemd/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("--all -I. Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/packagemd/Server.py
+++ b/python/test/Ice/packagemd/Server.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("--all -I. Test.ice")
 import Test
 import Test1
 import testpkg

--- a/python/test/Ice/proxy/Client.py
+++ b/python/test/Ice/proxy/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/proxy/Server.py
+++ b/python/test/Ice/proxy/Server.py
@@ -5,8 +5,6 @@
 
 import Ice
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import TestI
 
 

--- a/python/test/Ice/scope/Client.py
+++ b/python/test/Ice/scope/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/scope/Server.py
+++ b/python/test/Ice/scope/Server.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import Test
 import Inner
 import Ice

--- a/python/test/Ice/servantLocator/Client.py
+++ b/python/test/Ice/servantLocator/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/servantLocator/Collocated.py
+++ b/python/test/Ice/servantLocator/Collocated.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import Ice
 import TestI
 import AllTests

--- a/python/test/Ice/servantLocator/Server.py
+++ b/python/test/Ice/servantLocator/Server.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import Ice
 import TestI
 import TestActivationI

--- a/python/test/Ice/servantLocator/ServerAMD.py
+++ b/python/test/Ice/servantLocator/ServerAMD.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import Ice
 import TestAMDI
 import TestActivationAMDI

--- a/python/test/Ice/slicing/exceptions/AllTests.py
+++ b/python/test/Ice/slicing/exceptions/AllTests.py
@@ -2,11 +2,8 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import Ice
 import threading
 import sys
-
-Ice.loadSlice("-I. --all Test.ice")
 import Test
 
 

--- a/python/test/Ice/slicing/exceptions/Client.py
+++ b/python/test/Ice/slicing/exceptions/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/slicing/exceptions/Server.py
+++ b/python/test/Ice/slicing/exceptions/Server.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("-I. --all ServerPrivate.ice")
 import Ice
 import Test
 

--- a/python/test/Ice/slicing/exceptions/ServerAMD.py
+++ b/python/test/Ice/slicing/exceptions/ServerAMD.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("-I. --all ServerPrivate.ice")
 import Ice
 import Test
 

--- a/python/test/Ice/slicing/objects/AllTests.py
+++ b/python/test/Ice/slicing/objects/AllTests.py
@@ -6,8 +6,6 @@ import Ice
 import gc
 import sys
 import threading
-
-Ice.loadSlice("-I. --all ClientPrivate.ice")
 import Test
 
 
@@ -496,7 +494,8 @@ def allTests(helper, communicator):
             test(sb.sb == "SBSUnknownDerived.sb")
         except Ice.OperationNotExistException:
             pass
-        except Exception:
+        except Exception as ex:
+            print(f"Unexpected exception: {ex}")
             test(False)
     else:
         try:
@@ -511,7 +510,8 @@ def allTests(helper, communicator):
         except Ice.MarshalException:
             # Expected.
             pass
-        except Exception:
+        except Exception as ex:
+            print(f"Unexpected exception: {ex}")
             test(False)
     print("ok")
 

--- a/python/test/Ice/slicing/objects/Server.py
+++ b/python/test/Ice/slicing/objects/Server.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("-I. --all ServerPrivate.ice")
 import Ice
 import Test
 

--- a/python/test/Ice/slicing/objects/ServerAMD.py
+++ b/python/test/Ice/slicing/objects/ServerAMD.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("-I. --all ServerPrivate.ice")
 import Ice
 import Test
 

--- a/python/test/Ice/thread/Client.py
+++ b/python/test/Ice/thread/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/thread/Server.py
+++ b/python/test/Ice/thread/Server.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import Ice
 import TestI
 

--- a/python/test/Ice/timeout/Client.py
+++ b/python/test/Ice/timeout/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import AllTests
 
 

--- a/python/test/Ice/timeout/Server.py
+++ b/python/test/Ice/timeout/Server.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import threading
 import time
 import Ice

--- a/python/test/Slice/escape/Client.py
+++ b/python/test/Slice/escape/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Key.ice Clash.ice")
 import sys
 import Ice
 import escaped_and

--- a/python/test/Slice/macros/Client.py
+++ b/python/test/Slice/macros/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import sys
 import Ice
 import Test

--- a/python/test/Slice/structure/Client.py
+++ b/python/test/Slice/structure/Client.py
@@ -3,8 +3,6 @@
 # Copyright (c) ZeroC, Inc.
 
 from TestHelper import TestHelper
-
-TestHelper.loadSlice("Test.ice")
 import sys
 import copy
 import Test

--- a/python/test/TestHelper.py
+++ b/python/test/TestHelper.py
@@ -70,14 +70,6 @@ class TestHelper:
             self._communicator.shutdown()
 
     @classmethod
-    def loadSlice(self, args):
-        sliceDir = Ice.getSliceDir()
-        if not sliceDir:
-            print(sys.argv[0] + ": Slice directory not found.")
-            sys.exit(1)
-        Ice.loadSlice("'-I{0}' {1}".format(sliceDir, args))
-
-    @classmethod
     def run(self):
         try:
             moduleName = os.path.splitext(sys.argv[1])[0]

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -4030,6 +4030,10 @@ class PythonMapping(CppBasedMapping):
                 self.component.getInstallDir(self, current), current.config
             )
         dirs += [current.testcase.getPath(current)]
+        if isinstance(process, Server):
+            dirs += [os.path.join(current.testcase.getPath(current), "generated", "server")]
+        else:
+            dirs += [os.path.join(current.testcase.getPath(current), "generated", "client")]
         env["PYTHONPATH"] = os.pathsep.join(dirs)
         return env
 


### PR DESCRIPTION
This PR is an initial step in adding support for type-hints to Ice for Python:

- Add type hints to proxy classes, and servant-skeleton classes.
- Update Python tests to use slice2py generated code. 
