### PR TITLE
Add Module Prefixing to Generated Swift Constants

### DIFF
--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -1079,10 +1079,11 @@ Gen::TypesVisitor::visitConst(const ConstPtr& p)
 {
     const TypePtr type = p->type();
     const string swiftModule = getSwiftModule(p->getTopLevelModule());
+    const string mappedName = getRelativeTypeString(p, swiftModule);
 
     out << sp;
     writeDocSummary(out, p);
-    out << nl << "public let " << p->mappedName() << ": " << typeToString(type, p) << " = ";
+    out << nl << "public let " << mappedName << ": " << typeToString(type, p) << " = ";
     writeConstantValue(out, type, p->valueType(), p->value(), swiftModule);
 }
 


### PR DESCRIPTION
This PR fixes the small issue I found with generated constants in Swift, where we weren't applying nested-module prefixes to them like we do for every other Slice construct. This PR fixes that.

For example, take this Slice definition from 'python/test/Slice/import/Test1.ice'
```slice
module Test
{
    module SubA::SubSubA1
    {
        const int Value1 = 10;
    }

    module SubB::SubSubB1
    {
        const int Value1 = 20;
    }
}
```

Here is the generated code before and after my PR:
```diff
 import Foundation
 import Ice

-public let Value1: Swift.Int32 = 10
+public let SubASubSubA1Value1: Swift.Int32 = 10

-public let Value1: Swift.Int32 = 20
+public let SubBSubSubB1Value1: Swift.Int32 = 20
```
Without the module prefix, there would be a name collision here.