### PR TITLE
Inject 'linkFormatter' Functions Up-Front via `createUnit`

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -5203,7 +5203,10 @@ Slice::Unit::getTopLevelModules(const string& file) const
     }
 }
 
-Slice::Unit::Unit(string languageName, optional<DocLinkFormatter> linkFormatter, bool all) : _languageName(std::move(languageName)), _linkFormatter(std::move(linkFormatter)), _all(all)
+Slice::Unit::Unit(string languageName, optional<DocLinkFormatter> linkFormatter, bool all)
+    : _languageName(std::move(languageName)),
+      _linkFormatter(std::move(linkFormatter)),
+      _all(all)
 {
     if (!languageName.empty())
     {

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -440,8 +440,13 @@ namespace
 }
 
 optional<DocComment>
-Slice::DocComment::parseFrom(const ContainedPtr& p, DocLinkFormatter linkFormatter, bool escapeXml)
+Slice::DocComment::parseFrom(const ContainedPtr& p, bool escapeXml)
 {
+    const optional<DocLinkFormatter>& linkFormatter = p->unit()->linkFormatter();
+    // Some compilers don't generate doc-comments, and so don't provide a link formatter.
+    // But, these compilers should also never be calling `parseFrom` in the first place.
+    assert(linkFormatter.has_value());
+
     // Split the comment's raw text up into lines.
     StringList lines = splitComment(p->docComment(), escapeXml);
     if (lines.empty())
@@ -484,7 +489,7 @@ Slice::DocComment::parseFrom(const ContainedPtr& p, DocLinkFormatter linkFormatt
                 }
 
                 // Finally, insert a correctly formatted link where the '{@link foo}' used to be.
-                string formattedLink = linkFormatter(linkText, p, linkTarget);
+                string formattedLink = (*linkFormatter)(linkText, p, linkTarget);
                 line.insert(pos, formattedLink);
                 pos += formattedLink.length();
             }
@@ -4709,15 +4714,21 @@ Slice::DataMember::DataMember(
 // ----------------------------------------------------------------------
 
 UnitPtr
-Slice::Unit::createUnit(string languageName, bool all)
+Slice::Unit::createUnit(string languageName, std::optional<DocLinkFormatter> linkFormatter, bool all)
 {
-    return make_shared<Unit>(std::move(languageName), all);
+    return make_shared<Unit>(std::move(languageName), std::move(linkFormatter), all);
 }
 
 string
 Slice::Unit::languageName() const
 {
     return _languageName;
+}
+
+const optional<DocLinkFormatter>&
+Slice::Unit::linkFormatter() const
+{
+    return _linkFormatter;
 }
 
 void
@@ -5192,7 +5203,7 @@ Slice::Unit::getTopLevelModules(const string& file) const
     }
 }
 
-Slice::Unit::Unit(string languageName, bool all) : _languageName(std::move(languageName)), _all(all)
+Slice::Unit::Unit(string languageName, optional<DocLinkFormatter> linkFormatter, bool all) : _languageName(std::move(languageName)), _linkFormatter(std::move(linkFormatter)), _all(all)
 {
     if (!languageName.empty())
     {

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -265,13 +265,11 @@ namespace Slice
         /// Parses the raw doc-comment attached to `p` into a structured `DocComment`.
         ///
         /// @param p The slice element whose doc-comment should be parsed.
-        /// @param linkFormatter A function used to format links according to the target language's syntax.
         /// @param escapeXml If true, escapes all XML special characters in the parsed comment. Defaults to false.
         ///
         /// @return A `DocComment` instance containing a parsed representation of `p`'s doc-comment, if a doc-comment
         /// was present. If no doc-comment was present (or it contained only whitespace) this returns `nullopt` instead.
-        [[nodiscard]] static std::optional<DocComment>
-        parseFrom(const ContainedPtr& p, DocLinkFormatter linkFormatter, bool escapeXml = false);
+        [[nodiscard]] static std::optional<DocComment> parseFrom(const ContainedPtr& p, bool escapeXml = false);
 
         [[nodiscard]] bool isDeprecated() const;
         [[nodiscard]] const StringList& deprecated() const;
@@ -1068,11 +1066,13 @@ namespace Slice
     class Unit final : public Container
     {
     public:
-        static UnitPtr createUnit(std::string languageName, bool all);
+        static UnitPtr createUnit(std::string languageName, std::optional<DocLinkFormatter> linkFormatter, bool all);
 
-        Unit(std::string languageName, bool all);
+        Unit(std::string languageName, std::optional<DocLinkFormatter> linkFormatter, bool all);
 
         [[nodiscard]] std::string languageName() const;
+
+        [[nodiscard]] const std::optional<DocLinkFormatter>& linkFormatter() const;
 
         /// Sets `_currentDocComment` to the provided string, erasing anything currently stored in it.
         /// @param comment The raw comment string. It can span multiple lines and include comment formatting characters
@@ -1144,6 +1144,7 @@ namespace Slice
         void popDefinitionContext();
 
         const std::string _languageName;
+        const std::optional<DocLinkFormatter> _linkFormatter;
         bool _all;
         int _errors{0};
         std::string _currentDocComment;

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -221,7 +221,7 @@ namespace
 
     void writeDocComment(const ContainedPtr& contained, Output& out)
     {
-        optional<DocComment> comment = DocComment::parseFrom(contained, slice2LinkFormatter);
+        optional<DocComment> comment = DocComment::parseFrom(contained);
         if (!comment)
         {
             return;

--- a/cpp/src/ice2slice/Main.cpp
+++ b/cpp/src/ice2slice/Main.cpp
@@ -179,7 +179,7 @@ compile(const vector<string>& argv)
         }
         else
         {
-            UnitPtr p = Unit::createUnit("", false);
+            UnitPtr p = Unit::createUnit("", Slice::slice2LinkFormatter, false);
             int parseStatus = p->parse(*i, cppHandle, debug);
 
             if (!icecpp->close())

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -4,7 +4,6 @@
 #include "../Ice/FileUtil.h"
 #include "../Slice/FileTracker.h"
 #include "../Slice/Util.h"
-#include "CPlusPlusUtil.h"
 #include "Ice/StringUtil.h"
 
 #include <algorithm>
@@ -267,7 +266,7 @@ namespace
 
     void writeDocSummary(Output& out, const ContainedPtr& p, DocSummaryOptions options = {})
     {
-        optional<DocComment> doc = DocComment::parseFrom(p, cppLinkFormatter);
+        optional<DocComment> doc = DocComment::parseFrom(p);
         if (!doc)
         {
             return;
@@ -1442,7 +1441,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
 
     const string deprecatedAttribute = getDeprecatedAttribute(p);
 
-    optional<DocComment> comment = DocComment::parseFrom(p, cppLinkFormatter);
+    optional<DocComment> comment = DocComment::parseFrom(p);
     const string contextDoc = "@param " + contextParam + " The request context.";
 
     H << sp;
@@ -1898,7 +1897,7 @@ Slice::Gen::DataDefVisitor::visitExceptionStart(const ExceptionPtr& p)
             typeToString(dataMember->type(), dataMember->optional(), scope, dataMember->getMetadata(), _useWstring);
         allParameters.push_back(typeName + " " + dataMember->mappedName());
 
-        if (auto comment = DocComment::parseFrom(dataMember, cppLinkFormatter))
+        if (auto comment = DocComment::parseFrom(dataMember))
         {
             allDocComments[dataMember->name()] = std::move(*comment);
         }
@@ -2351,7 +2350,7 @@ Slice::Gen::DataDefVisitor::emitOneShotConstructor(const ClassDefPtr& p)
             string typeName =
                 typeToString(dataMember->type(), dataMember->optional(), scope, dataMember->getMetadata(), _useWstring);
             allParameters.push_back(typeName + " " + dataMember->mappedName());
-            if (auto comment = DocComment::parseFrom(dataMember, cppLinkFormatter))
+            if (auto comment = DocComment::parseFrom(dataMember))
             {
                 allDocComments[dataMember->name()] = std::move(*comment);
             }
@@ -2698,7 +2697,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
     const string currentTypeDecl = "const Ice::Current&";
     const string currentDecl = currentTypeDecl + " " + currentParam;
 
-    optional<DocComment> comment = DocComment::parseFrom(p, cppLinkFormatter);
+    optional<DocComment> comment = DocComment::parseFrom(p);
 
     string isConst = p->hasMetadata("cpp:const") ? " const" : "";
     string noDiscard = "";

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -5,6 +5,7 @@
 
 #include "../Ice/OutputUtil.h"
 #include "../Slice/Parser.h"
+#include "CPlusPlusUtil.h"
 #include "TypeContext.h"
 
 namespace Slice

--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -204,7 +204,7 @@ compile(const vector<string>& argv)
                 return EXIT_FAILURE;
             }
 
-            UnitPtr u = Unit::createUnit("cpp", false);
+            UnitPtr u = Unit::createUnit("cpp", Slice::cppLinkFormatter, false);
             int parseStatus = u->parse(*i, cppHandle, debug);
 
             DefinitionContextPtr dc = u->findDefinitionContext(u->topLevelFile());
@@ -260,7 +260,7 @@ compile(const vector<string>& argv)
             }
             else
             {
-                UnitPtr u = Unit::createUnit("cpp", false);
+                UnitPtr u = Unit::createUnit("cpp", Slice::cppLinkFormatter, false);
                 int parseStatus = u->parse(*i, cppHandle, debug);
 
                 if (!icecpp->close())

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -676,7 +676,7 @@ Slice::CsVisitor::writeDataMemberInitializers(const DataMemberList& dataMembers)
 void
 Slice::CsVisitor::writeDocComment(const ContainedPtr& p, const string& generatedType, const string& notes)
 {
-    optional<DocComment> comment = DocComment::parseFrom(p, csLinkFormatter, true);
+    optional<DocComment> comment = DocComment::parseFrom(p, true);
     StringList remarks;
     if (comment)
     {
@@ -736,7 +736,7 @@ Slice::CsVisitor::writeHelperDocComment(
 void
 Slice::CsVisitor::writeOpDocComment(const OperationPtr& op, const vector<string>& extraParams, bool isAsync)
 {
-    optional<DocComment> comment = DocComment::parseFrom(op, csLinkFormatter, true);
+    optional<DocComment> comment = DocComment::parseFrom(op, true);
     if (!comment)
     {
         return;

--- a/cpp/src/slice2cs/Main.cpp
+++ b/cpp/src/slice2cs/Main.cpp
@@ -182,7 +182,7 @@ compile(const vector<string>& argv)
                 return EXIT_FAILURE;
             }
 
-            UnitPtr u = Unit::createUnit("cs", false);
+            UnitPtr u = Unit::createUnit("cs", Slice::Csharp::csLinkFormatter, false);
             int parseStatus = u->parse(*i, cppHandle, debug);
             u->destroy();
 
@@ -231,7 +231,7 @@ compile(const vector<string>& argv)
             }
             else
             {
-                UnitPtr p = Unit::createUnit("cs", false);
+                UnitPtr p = Unit::createUnit("cs", Slice::Csharp::csLinkFormatter, false);
                 int parseStatus = p->parse(*i, cppHandle, debug);
 
                 if (!icecpp->close())

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -2266,7 +2266,7 @@ Slice::JavaVisitor::writeHiddenProxyDocComment(Output& out, const OperationPtr& 
 void
 Slice::JavaVisitor::writeServantOpDocComment(Output& out, const OperationPtr& p, const string& package, bool async)
 {
-    optional<DocComment> dc = DocComment::parseFrom(p, javaLinkFormatter);
+    optional<DocComment> dc = DocComment::parseFrom(p);
     if (!dc)
     {
         return;
@@ -2414,7 +2414,7 @@ Slice::JavaVisitor::writeParamDocComments(IceInternal::Output& out, const DataMe
     bool first = true;
     for (const auto& member : members)
     {
-        if (const auto docComment = DocComment::parseFrom(member, javaLinkFormatter))
+        if (const auto docComment = DocComment::parseFrom(member))
         {
             if (first)
             {
@@ -2494,7 +2494,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     // Slice interfaces map to Java interfaces.
     out << sp;
-    optional<DocComment> dc = DocComment::parseFrom(p, javaLinkFormatter);
+    optional<DocComment> dc = DocComment::parseFrom(p);
     writeDocComment(out, p->unit(), dc);
     if (dc && dc->isDeprecated())
     {
@@ -2795,7 +2795,7 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 
     out << sp;
 
-    optional<DocComment> dc = DocComment::parseFrom(p, javaLinkFormatter);
+    optional<DocComment> dc = DocComment::parseFrom(p);
     writeDocComment(out, p->unit(), dc);
     if (dc && dc->isDeprecated())
     {
@@ -3049,7 +3049,7 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     Output& out = output();
     out << sp;
 
-    optional<DocComment> dc = DocComment::parseFrom(p, javaLinkFormatter);
+    optional<DocComment> dc = DocComment::parseFrom(p);
     writeDocComment(out, p->unit(), dc);
     if (dc && dc->isDeprecated())
     {
@@ -3420,7 +3420,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
 
     out << sp;
 
-    optional<DocComment> dc = DocComment::parseFrom(p, javaLinkFormatter);
+    optional<DocComment> dc = DocComment::parseFrom(p);
     writeDocComment(out, p->unit(), dc);
     if (dc && dc->isDeprecated())
     {
@@ -3696,7 +3696,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 
     out << sp;
 
-    optional<DocComment> dc = DocComment::parseFrom(p, javaLinkFormatter);
+    optional<DocComment> dc = DocComment::parseFrom(p);
     writeDocComment(out, p->unit(), dc);
     if (dc && dc->isDeprecated())
     {
@@ -3712,7 +3712,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
         {
             out << ',';
         }
-        optional<DocComment> edc = DocComment::parseFrom(*en, javaLinkFormatter);
+        optional<DocComment> edc = DocComment::parseFrom(*en);
         writeDocComment(out, p->unit(), edc);
         if (edc && edc->isDeprecated())
         {
@@ -4203,7 +4203,7 @@ Slice::Gen::TypesVisitor::visitConst(const ConstPtr& p)
 
     out << sp;
 
-    optional<DocComment> dc = DocComment::parseFrom(p, javaLinkFormatter);
+    optional<DocComment> dc = DocComment::parseFrom(p);
     writeDocComment(out, p->unit(), dc);
     if (dc && dc->isDeprecated())
     {
@@ -4231,7 +4231,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     // Generate a Java interface as the user-visible type
     out << sp;
-    optional<DocComment> dc = DocComment::parseFrom(p, javaLinkFormatter);
+    optional<DocComment> dc = DocComment::parseFrom(p);
     writeDocComment(out, p->unit(), dc);
     if (dc && dc->isDeprecated())
     {
@@ -4424,7 +4424,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 
     outi << sp;
     writeHiddenDocComment(outi);
-    optional<DocComment> dc = DocComment::parseFrom(p, javaLinkFormatter);
+    optional<DocComment> dc = DocComment::parseFrom(p);
     if (dc && dc->isDeprecated())
     {
         outi << nl << "@Deprecated";
@@ -4463,7 +4463,7 @@ Slice::Gen::TypesVisitor::visitOperation(const OperationPtr& p)
     const vector<string> params = getParamsProxy(p, package, false);
     const vector<string> paramsOpt = getParamsProxy(p, package, true);
     const bool sendsOptionals = p->sendsOptionals();
-    const optional<DocComment> dc = DocComment::parseFrom(p, javaLinkFormatter);
+    const optional<DocComment> dc = DocComment::parseFrom(p);
 
     // Arrange exceptions into most-derived to least-derived order. If we don't
     // do this, a base exception handler can appear before a derived exception
@@ -4520,7 +4520,7 @@ Slice::Gen::ServantVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     Output& out = output();
 
     out << sp;
-    optional<DocComment> dc = DocComment::parseFrom(p, javaLinkFormatter);
+    optional<DocComment> dc = DocComment::parseFrom(p);
     writeDocComment(out, p->unit(), dc);
 
     out << nl << "@com.zeroc.Ice.SliceTypeId(value = \"" << p->scoped() << "\")";
@@ -4822,7 +4822,7 @@ Slice::Gen::ServantVisitor::visitOperation(const OperationPtr& p)
 
     Output& out = output();
 
-    optional<DocComment> dc = DocComment::parseFrom(p, javaLinkFormatter);
+    optional<DocComment> dc = DocComment::parseFrom(p);
 
     // Generate the "Result" type needed by operations that return multiple values.
     if (p->returnsMultipleValues())

--- a/cpp/src/slice2java/Main.cpp
+++ b/cpp/src/slice2java/Main.cpp
@@ -172,7 +172,7 @@ compile(const vector<string>& argv)
                 return EXIT_FAILURE;
             }
 
-            UnitPtr u = Unit::createUnit("java", false);
+            UnitPtr u = Unit::createUnit("java", Slice::Java::javaLinkFormatter, false);
             int parseStatus = u->parse(*i, cppHandle, debug);
             u->destroy();
 
@@ -222,7 +222,7 @@ compile(const vector<string>& argv)
             }
             else
             {
-                UnitPtr p = Unit::createUnit("java", false);
+                UnitPtr p = Unit::createUnit("java", Slice::Java::javaLinkFormatter, false);
                 int parseStatus = p->parse(*i, cppHandle, debug);
 
                 if (!icecpp->close())

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -369,7 +369,7 @@ void
 Slice::JsVisitor::writeDocCommentFor(const ContainedPtr& p, bool includeRemarks, bool includeDeprecated)
 {
     assert(!dynamic_pointer_cast<Operation>(p));
-    optional<DocComment> comment = DocComment::parseFrom(p, jsLinkFormatter);
+    optional<DocComment> comment = DocComment::parseFrom(p);
     if (!comment && (!includeDeprecated || !p->isDeprecated()))
     {
         // There's nothing to write for this doc-comment.
@@ -2143,7 +2143,7 @@ Slice::Gen::TypeScriptVisitor::visitClassDefStart(const ClassDefPtr& p)
     _out << nl << " * One-shot constructor to initialize all data members.";
     for (const auto& dataMember : allDataMembers)
     {
-        if (auto comment = DocComment::parseFrom(dataMember, jsLinkFormatter))
+        if (auto comment = DocComment::parseFrom(dataMember))
         {
             _out << nl << " * @param " << dataMember->mappedName() << " " << getFirstSentence(comment->overview());
         }
@@ -2195,7 +2195,7 @@ Slice::Gen::TypeScriptVisitor::writeOpDocSummary(Output& out, const OperationPtr
     out << nl << "/**";
 
     map<string, StringList> paramDoc;
-    optional<DocComment> comment = DocComment::parseFrom(op, jsLinkFormatter);
+    optional<DocComment> comment = DocComment::parseFrom(op);
     if (comment)
     {
         const StringList& overview = comment->overview();
@@ -2519,7 +2519,7 @@ Slice::Gen::TypeScriptVisitor::visitExceptionStart(const ExceptionPtr& p)
         _out << nl << " * One-shot constructor to initialize all data members.";
         for (const auto& dataMember : allDataMembers)
         {
-            if (auto comment = DocComment::parseFrom(dataMember, jsLinkFormatter))
+            if (auto comment = DocComment::parseFrom(dataMember))
             {
                 _out << nl << " * @param " << dataMember->mappedName() << " " << getFirstSentence(comment->overview());
             }

--- a/cpp/src/slice2js/Main.cpp
+++ b/cpp/src/slice2js/Main.cpp
@@ -214,7 +214,7 @@ compile(const vector<string>& argv)
 
         if (depend || dependJSON || dependXml)
         {
-            UnitPtr u = Unit::createUnit("js", false);
+            UnitPtr u = Unit::createUnit("js", Slice::JavaScript::jsLinkFormatter, false);
             int parseStatus = u->parse(*i, cppHandle, debug);
             u->destroy();
 
@@ -268,7 +268,7 @@ compile(const vector<string>& argv)
             }
             else
             {
-                UnitPtr p = Unit::createUnit("js", false);
+                UnitPtr p = Unit::createUnit("js", Slice::JavaScript::jsLinkFormatter, false);
                 int parseStatus = p->parse(*i, cppHandle, debug);
 
                 if (!preprocessor->close())

--- a/cpp/src/slice2matlab/Gen.cpp
+++ b/cpp/src/slice2matlab/Gen.cpp
@@ -426,7 +426,7 @@ namespace
             for (const auto& field : list)
             {
                 out << nl << "%     " << field->mappedName();
-                if (auto fieldDoc = DocComment::parseFrom(field, matlabLinkFormatter))
+                if (auto fieldDoc = DocComment::parseFrom(field))
                 {
                     const StringList& fieldOverview = fieldDoc->overview();
                     if (!fieldOverview.empty())
@@ -446,7 +446,7 @@ namespace
         // No space and upper-case, per MATLAB conventions.
         out << nl << "%" << toUpper(name);
 
-        optional<DocComment> doc = DocComment::parseFrom(p, matlabLinkFormatter);
+        optional<DocComment> doc = DocComment::parseFrom(p);
         StringList docOverview;
         if (doc)
         {
@@ -492,7 +492,7 @@ namespace
     {
         out << nl << "%" << toUpper(p->mappedName() + (async ? "Async" : ""));
 
-        optional<DocComment> doc = DocComment::parseFrom(p, matlabLinkFormatter);
+        optional<DocComment> doc = DocComment::parseFrom(p);
         if (doc)
         {
             StringList docOverview = doc->overview();
@@ -613,7 +613,7 @@ namespace
         const string name = p->mappedName() + "Prx";
         out << nl << "%" << toUpper(name);
 
-        optional<DocComment> doc = DocComment::parseFrom(p, matlabLinkFormatter);
+        optional<DocComment> doc = DocComment::parseFrom(p);
         StringList docOverview;
         if (doc)
         {
@@ -657,7 +657,7 @@ namespace
             for (const auto& op : ops)
             {
                 const string opName = op->mappedName();
-                const optional<DocComment> opdoc = DocComment::parseFrom(op, matlabLinkFormatter);
+                const optional<DocComment> opdoc = DocComment::parseFrom(op);
                 out << nl << "%     " << opName;
                 if (opdoc)
                 {
@@ -883,7 +883,7 @@ namespace
 
     void documentProperty(IceInternal::Output& out, const DataMemberPtr& field)
     {
-        optional<DocComment> doc = DocComment::parseFrom(field, matlabLinkFormatter);
+        optional<DocComment> doc = DocComment::parseFrom(field);
         documentArgumentOrProperty(
             out,
             toUpper(field->mappedName()),

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -215,7 +215,7 @@ namespace
                     return EXIT_FAILURE;
                 }
 
-                UnitPtr u = Unit::createUnit("matlab", false);
+                UnitPtr u = Unit::createUnit("matlab", Slice::matlabLinkFormatter, false);
                 int parseStatus = u->parse(*i, cppHandle, debug);
                 u->destroy();
 
@@ -263,7 +263,7 @@ namespace
                 }
                 else
                 {
-                    UnitPtr u = Unit::createUnit("matlab", all);
+                    UnitPtr u = Unit::createUnit("matlab", Slice::matlabLinkFormatter, all);
                     int parseStatus = u->parse(*i, cppHandle, debug);
 
                     if (!icecpp->close())

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -1291,7 +1291,7 @@ compile(const vector<string>& argv)
                 return EXIT_FAILURE;
             }
 
-            UnitPtr u = Unit::createUnit("php", false);
+            UnitPtr u = Unit::createUnit("php", nullopt, false);
             int parseStatus = u->parse(*i, cppHandle, debug);
             u->destroy();
 
@@ -1341,7 +1341,7 @@ compile(const vector<string>& argv)
             }
             else
             {
-                UnitPtr u = Unit::createUnit("php", all);
+                UnitPtr u = Unit::createUnit("php", nullopt, all);
                 int parseStatus = u->parse(*i, cppHandle, debug);
 
                 if (!icecpp->close())

--- a/cpp/src/slice2py/Python.cpp
+++ b/cpp/src/slice2py/Python.cpp
@@ -570,7 +570,7 @@ Slice::Python::compile(const vector<string>& argv)
                 return EXIT_FAILURE;
             }
 
-            UnitPtr u = Unit::createUnit("python", false);
+            UnitPtr u = Unit::createUnit("python", Slice::Python::pyLinkFormatter, false);
             int parseStatus = u->parse(*i, cppHandle, debug);
             u->destroy();
 
@@ -621,7 +621,7 @@ Slice::Python::compile(const vector<string>& argv)
             }
             else
             {
-                UnitPtr u = Unit::createUnit("python", all);
+                UnitPtr u = Unit::createUnit("python", Slice::Python::pyLinkFormatter, all);
                 int parseStatus = u->parse(*i, cppHandle, debug);
 
                 if (!icecpp->close())

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -407,7 +407,7 @@ Slice::Python::CodeVisitor::visitModuleStart(const ModulePtr& p)
     }
     _out << nl << "__name__ = \"" << abs << "\"";
 
-    writeDocstring(DocComment::parseFrom(p, pyLinkFormatter), "_M_" + abs + ".__doc__ = ");
+    writeDocstring(DocComment::parseFrom(p), "_M_" + abs + ".__doc__ = ");
 
     _moduleStack.push_front(abs);
     return true;
@@ -539,7 +539,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     _out.inc();
 
-    writeDocstring(DocComment::parseFrom(p, pyLinkFormatter), members);
+    writeDocstring(DocComment::parseFrom(p), members);
 
     //
     // __init__
@@ -1079,7 +1079,7 @@ Slice::Python::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     _out << "):";
     _out.inc();
 
-    writeDocstring(DocComment::parseFrom(p, pyLinkFormatter), members);
+    writeDocstring(DocComment::parseFrom(p), members);
 
     // __init__
     _out << nl << "def __init__(self";
@@ -1204,7 +1204,7 @@ Slice::Python::CodeVisitor::visitStructStart(const StructPtr& p)
     _out << nl << "class " << name << "(object):";
     _out.inc();
 
-    writeDocstring(DocComment::parseFrom(p, pyLinkFormatter), members);
+    writeDocstring(DocComment::parseFrom(p), members);
 
     _out << nl << "def __init__(self";
     writeConstructorParams(p->dataMembers());
@@ -1508,7 +1508,7 @@ Slice::Python::CodeVisitor::visitEnum(const EnumPtr& p)
     _out << nl << "class " << name << "(Ice.EnumBase):";
     _out.inc();
 
-    writeDocstring(DocComment::parseFrom(p, pyLinkFormatter), enumerators);
+    writeDocstring(DocComment::parseFrom(p), enumerators);
 
     _out << sp << nl << "def __init__(self, _n, _v):";
     _out.inc();
@@ -1951,7 +1951,7 @@ Slice::Python::CodeVisitor::writeDocstring(const optional<DocComment>& comment, 
     map<string, list<string>> docs;
     for (const auto& member : members)
     {
-        if (auto memberDoc = DocComment::parseFrom(member, pyLinkFormatter))
+        if (auto memberDoc = DocComment::parseFrom(member))
         {
             const StringList& memberOverview = memberDoc->overview();
             if (!memberOverview.empty())
@@ -2015,7 +2015,7 @@ Slice::Python::CodeVisitor::writeDocstring(const optional<DocComment>& comment, 
     map<string, list<string>> docs;
     for (const auto& enumerator : enumerators)
     {
-        if (auto enumeratorDoc = DocComment::parseFrom(enumerator, pyLinkFormatter))
+        if (auto enumeratorDoc = DocComment::parseFrom(enumerator))
         {
             const StringList& enumeratorOverview = enumeratorDoc->overview();
             if (!enumeratorOverview.empty())
@@ -2070,7 +2070,7 @@ Slice::Python::CodeVisitor::writeDocstring(const optional<DocComment>& comment, 
 void
 Slice::Python::CodeVisitor::writeDocstring(const OperationPtr& op, OperationMode mode)
 {
-    optional<DocComment> comment = DocComment::parseFrom(op, pyLinkFormatter);
+    optional<DocComment> comment = DocComment::parseFrom(op);
     if (!comment)
     {
         return;

--- a/cpp/src/slice2rb/Ruby.cpp
+++ b/cpp/src/slice2rb/Ruby.cpp
@@ -171,7 +171,7 @@ Slice::Ruby::compile(const vector<string>& argv)
                 return EXIT_FAILURE;
             }
 
-            UnitPtr u = Unit::createUnit("ruby", false);
+            UnitPtr u = Unit::createUnit("ruby", nullopt, false);
             int parseStatus = u->parse(*i, cppHandle, debug);
             u->destroy();
 
@@ -221,7 +221,7 @@ Slice::Ruby::compile(const vector<string>& argv)
             }
             else
             {
-                UnitPtr u = Unit::createUnit("ruby", all);
+                UnitPtr u = Unit::createUnit("ruby", nullopt, all);
                 int parseStatus = u->parse(*i, cppHandle, debug);
 
                 if (!icecpp->close())

--- a/cpp/src/slice2swift/Main.cpp
+++ b/cpp/src/slice2swift/Main.cpp
@@ -185,7 +185,7 @@ compile(const vector<string>& argv)
                 return EXIT_FAILURE;
             }
 
-            UnitPtr u = Unit::createUnit("swift", false);
+            UnitPtr u = Unit::createUnit("swift", Slice::Swift::swiftLinkFormatter, false);
             int parseStatus = u->parse(*i, cppHandle, debug);
             u->destroy();
 
@@ -235,7 +235,7 @@ compile(const vector<string>& argv)
             }
             else
             {
-                UnitPtr u = Unit::createUnit("swift", false);
+                UnitPtr u = Unit::createUnit("swift", Slice::Swift::swiftLinkFormatter, false);
                 int parseStatus = u->parse(*i, cppHandle, debug);
 
                 if (!icecpp->close())

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -89,7 +89,7 @@ Slice::Swift::getSwiftModule(const ModulePtr& module)
 void
 Slice::Swift::writeDocSummary(IceInternal::Output& out, const ContainedPtr& p)
 {
-    optional<DocComment> doc = DocComment::parseFrom(p, swiftLinkFormatter);
+    optional<DocComment> doc = DocComment::parseFrom(p);
     if (!doc)
     {
         return;
@@ -123,7 +123,7 @@ Slice::Swift::writeDocSummary(IceInternal::Output& out, const ContainedPtr& p)
 void
 Slice::Swift::writeOpDocSummary(IceInternal::Output& out, const OperationPtr& p, bool dispatch)
 {
-    optional<DocComment> doc = DocComment::parseFrom(p, swiftLinkFormatter);
+    optional<DocComment> doc = DocComment::parseFrom(p);
     if (!doc)
     {
         return;
@@ -267,7 +267,7 @@ Slice::Swift::writeOpDocSummary(IceInternal::Output& out, const OperationPtr& p,
 void
 Slice::Swift::writeProxyDocSummary(IceInternal::Output& out, const InterfaceDefPtr& p, const string& swiftModule)
 {
-    optional<DocComment> doc = DocComment::parseFrom(p, swiftLinkFormatter);
+    optional<DocComment> doc = DocComment::parseFrom(p);
     if (!doc)
     {
         return;
@@ -292,7 +292,7 @@ Slice::Swift::writeProxyDocSummary(IceInternal::Output& out, const InterfaceDefP
         out << nl << "/// " << prx << " Methods:";
         for (const auto& op : ops)
         {
-            optional<DocComment> opdoc = DocComment::parseFrom(op, swiftLinkFormatter);
+            optional<DocComment> opdoc = DocComment::parseFrom(op);
             optional<StringList> opDocOverview;
             if (opdoc)
             {
@@ -323,7 +323,7 @@ Slice::Swift::writeProxyDocSummary(IceInternal::Output& out, const InterfaceDefP
 void
 Slice::Swift::writeServantDocSummary(IceInternal::Output& out, const InterfaceDefPtr& p, const string& swiftModule)
 {
-    optional<DocComment> doc = DocComment::parseFrom(p, swiftLinkFormatter);
+    optional<DocComment> doc = DocComment::parseFrom(p);
     if (!doc)
     {
         return;
@@ -349,7 +349,7 @@ Slice::Swift::writeServantDocSummary(IceInternal::Output& out, const InterfaceDe
         for (const auto& op : ops)
         {
             out << nl << "///  - " << removeEscaping(op->mappedName());
-            optional<DocComment> opdoc = DocComment::parseFrom(op, swiftLinkFormatter);
+            optional<DocComment> opdoc = DocComment::parseFrom(op);
             if (opdoc)
             {
                 const StringList& opdocOverview = opdoc->overview();

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -13,6 +13,7 @@ namespace Slice::Swift
     std::string getSwiftModule(const ModulePtr&, std::string&);
     std::string getSwiftModule(const ModulePtr&);
 
+    /// Returns a DocC formatted link for the given Slice identifier.
     std::string
     swiftLinkFormatter(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target);
 

--- a/python/modules/IcePy/Slice.cpp
+++ b/python/modules/IcePy/Slice.cpp
@@ -125,7 +125,7 @@ IcePy_loadSlice(PyObject* /*self*/, PyObject* args)
             return nullptr;
         }
 
-        UnitPtr u = Slice::Unit::createUnit("python", all);
+        UnitPtr u = Slice::Unit::createUnit("python", Slice::Python::pyLinkFormatter, all);
         int parseStatus = u->parse(file, cppHandle, debug);
 
         if (!icecpp->close() || parseStatus == EXIT_FAILURE)

--- a/ruby/src/IceRuby/Slice.cpp
+++ b/ruby/src/IceRuby/Slice.cpp
@@ -114,7 +114,7 @@ IceRuby_loadSlice(int argc, VALUE* argv, VALUE /*self*/)
                 throw RubyException(rb_eArgError, "Slice preprocessing failed for `%s'", cmd.c_str());
             }
 
-            UnitPtr u = Unit::createUnit("ruby", all);
+            UnitPtr u = Unit::createUnit("ruby", nullopt, all);
             int parseStatus = u->parse(file, cppHandle, debug);
 
             if (!icecpp->close() || parseStatus == EXIT_FAILURE)


### PR DESCRIPTION
Currently, whenever one of the compiler wants to generate a doc-comment, it has to call `parseFrom` and provide a linkFormatter.
Having to repeatedly provide this `linkFormatter` is unnecessary though, since it never changes.

This PR changes things so now we inject a `linkFormatter` into `libSlice` once, when we first call `createUnit`.
And the doc-comment parsing code simply retrieves the injected `linkFormatter` when necessary.

This doesn't make a huge difference right now, but will be very important for supporting `@p` tags and code-snippets, which will need their own `xxxFormatter` functions as well.