### PR TITLE
Finish Cleaning up `errorDetection` Test

### DIFF
--- a/cpp/test/Slice/errorDetection/DictionaryRedefinition.err
+++ b/cpp/test/Slice/errorDetection/DictionaryRedefinition.err
@@ -1,1 +1,1 @@
-DictionaryRedefinition.ice:8: redefinition of dictionary 'foo' as dictionary
+DictionaryRedefinition.ice:6: redefinition of dictionary 'Dictionary' as dictionary

--- a/cpp/test/Slice/errorDetection/DictionaryRedefinition.err
+++ b/cpp/test/Slice/errorDetection/DictionaryRedefinition.err
@@ -1,1 +1,1 @@
-DictionaryRedefinition.ice:6: redefinition of dictionary 'Dictionary' as dictionary
+DictionaryRedefinition.ice:6: redefinition of dictionary 'foo' as dictionary

--- a/cpp/test/Slice/errorDetection/DictionaryRedefinition.ice
+++ b/cpp/test/Slice/errorDetection/DictionaryRedefinition.ice
@@ -2,8 +2,6 @@
 
 module Test
 {
-    // dictionary<int, long> Dictionary;
-    // dictionary<int, long> Dictionary;
     dictionary<int, long> foo;
     dictionary<int, long> foo;
 }

--- a/cpp/test/Slice/errorDetection/IllegalDictionary.err
+++ b/cpp/test/Slice/errorDetection/IllegalDictionary.err
@@ -2,6 +2,6 @@ IllegalDictionary.ice:12: dictionary 'b1' uses an illegal key type
 IllegalDictionary.ice:13: dictionary 'b2' uses an illegal key type
 IllegalDictionary.ice:14: dictionary 'b3' uses an illegal key type
 IllegalDictionary.ice:15: dictionary 'b4' uses an illegal key type
-IllegalDictionary.ice:19: dictionary 'd7' uses an illegal key type
-IllegalDictionary.ice:33: dictionary 'b8' uses an illegal key type
-IllegalDictionary.ice:38: dictionary 'b9' uses an illegal key type
+IllegalDictionary.ice:18: dictionary 'd7' uses an illegal key type
+IllegalDictionary.ice:32: dictionary 'b8' uses an illegal key type
+IllegalDictionary.ice:37: dictionary 'b9' uses an illegal key type

--- a/cpp/test/Slice/errorDetection/IllegalDictionary.ice
+++ b/cpp/test/Slice/errorDetection/IllegalDictionary.ice
@@ -13,7 +13,6 @@ module Test
     dictionary<double, long> b2;            // Bad
     dictionary<Object, long> b3;            // Bad
     dictionary<Object*, long> b4;           // Bad
-    // dictionary<LocalObject, long> b5;       // Bad
 
     sequence<byte> s1;
     dictionary<s1, long> d7;                // Bad

--- a/cpp/test/Slice/errorDetection/IllegalMI.ice
+++ b/cpp/test/Slice/errorDetection/IllegalMI.ice
@@ -18,8 +18,8 @@ module M1
     }
 
     interface A3 extends A2, B2
-    {       // OK
-        void ia3();
+    {
+        void ia3(); // OK
     }
 }
 

--- a/cpp/test/Slice/errorDetection/NameCanNotBeUsed.err
+++ b/cpp/test/Slice/errorDetection/NameCanNotBeUsed.err
@@ -1,1 +1,1 @@
-NameCanNotBeUsed.ice:13: interface name 'IFoo' cannot be used as operation name
+NameCanNotBeUsed.ice:7: interface name 'IFoo' cannot be used as operation name

--- a/cpp/test/Slice/errorDetection/NameCanNotBeUsed.ice
+++ b/cpp/test/Slice/errorDetection/NameCanNotBeUsed.ice
@@ -2,12 +2,6 @@
 
 module Test
 {
-    /*class Foo
-    {
-        // void Foo();
-        long l;
-    }*/
-
     interface IFoo
     {
         void IFoo();


### PR DESCRIPTION
This PR fixes #3739.

The `errorDetection` test had various parts commented out with no explanation.
Most of this has been uncommented or removed over time, but this PR removes the few remaining stragglers.