### PR TITLE
Use 'getTestEndpoint' in 'Slice/escape' Tests

### DIFF
--- a/cpp/test/Ice/ami/Collocated.cpp
+++ b/cpp/test/Ice/ami/Collocated.cpp
@@ -18,7 +18,7 @@ Collocated::run(int argc, char** argv)
     Ice::PropertiesPtr properties = createTestProperties(argc, argv);
     properties->setProperty("Ice.Warn.AMICallback", "0");
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
-    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
+    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
     communicator->getProperties()->setProperty("ControllerAdapter.Endpoints", getTestEndpoint(1));
     communicator->getProperties()->setProperty("ControllerAdapter.ThreadPool.Size", "1");
 

--- a/cpp/test/Ice/ami/Server.cpp
+++ b/cpp/test/Ice/ami/Server.cpp
@@ -32,7 +32,7 @@ Server::run(int argc, char** argv)
 
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
 
-    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
+    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
     communicator->getProperties()->setProperty("ControllerAdapter.Endpoints", getTestEndpoint(1));
     communicator->getProperties()->setProperty("ControllerAdapter.ThreadPool.Size", "1");
 

--- a/cpp/test/Ice/exceptions/Server.cpp
+++ b/cpp/test/Ice/exceptions/Server.cpp
@@ -22,7 +22,7 @@ Server::run(int argc, char** argv)
 
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
 
-    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
+    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
     communicator->getProperties()->setProperty("TestAdapter2.Endpoints", getTestEndpoint(1));
     communicator->getProperties()->setProperty("TestAdapter2.MessageSizeMax", "0");
     communicator->getProperties()->setProperty("TestAdapter3.Endpoints", getTestEndpoint(2));

--- a/cpp/test/Ice/executor/Collocated.cpp
+++ b/cpp/test/Ice/executor/Collocated.cpp
@@ -23,7 +23,7 @@ Collocated::run(int argc, char** argv)
     { executor->execute(make_shared<ExecutorCall>(call), conn); };
     Ice::CommunicatorHolder communicator = initialize(argc, argv, initData);
 
-    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
+    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
     communicator->getProperties()->setProperty("ControllerAdapter.Endpoints", getTestEndpoint(1, "tcp"));
     communicator->getProperties()->setProperty("ControllerAdapter.ThreadPool.Size", "1");
 

--- a/cpp/test/Ice/executor/Server.cpp
+++ b/cpp/test/Ice/executor/Server.cpp
@@ -31,7 +31,7 @@ Server::run(int argc, char** argv)
     {
         Ice::CommunicatorHolder communicator = initialize(argc, argv, initData);
 
-        communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
+        communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         communicator->getProperties()->setProperty("ControllerAdapter.Endpoints", getTestEndpoint(1, "tcp"));
         communicator->getProperties()->setProperty("ControllerAdapter.ThreadPool.Size", "1");
 

--- a/cpp/test/Ice/idleTimeout/Server.cpp
+++ b/cpp/test/Ice/idleTimeout/Server.cpp
@@ -22,7 +22,7 @@ Server::run(int argc, char** argv)
     initData.properties->setProperty("TestAdapter.Connection.MaxDispatches", "1");
 
     Ice::CommunicatorHolder communicator = initialize(argc, argv, initData);
-    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
+    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
     adapter->activate();

--- a/cpp/test/Ice/inactivityTimeout/Server.cpp
+++ b/cpp/test/Ice/inactivityTimeout/Server.cpp
@@ -23,7 +23,7 @@ Server::run(int argc, char** argv)
     initData.properties->setProperty("TestAdapter3s.Connection.InactivityTimeout", "3");
 
     Ice::CommunicatorHolder communicator = initialize(argc, argv, initData);
-    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
+    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
     communicator->getProperties()->setProperty("TestAdapter3s.Endpoints", getTestEndpoint(1));
 
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");

--- a/cpp/test/Ice/maxConnections/Server.cpp
+++ b/cpp/test/Ice/maxConnections/Server.cpp
@@ -16,7 +16,7 @@ Server::run(int argc, char** argv)
 {
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
     // Plain adapter with no limit.
-    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
+    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     adapter->add(std::make_shared<TestIntfI>(), Ice::stringToIdentity("test"));
     adapter->activate();

--- a/cpp/test/Ice/maxDispatches/Server.cpp
+++ b/cpp/test/Ice/maxDispatches/Server.cpp
@@ -22,7 +22,7 @@ Server::run(int argc, char** argv)
     auto responder = make_shared<ResponderI>();
     auto testIntf = make_shared<TestIntfI>(responder);
 
-    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
+    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     adapter->add(testIntf, Ice::stringToIdentity("test"));
     adapter->activate();

--- a/cpp/test/Ice/metrics/Collocated.cpp
+++ b/cpp/test/Ice/metrics/Collocated.cpp
@@ -28,7 +28,7 @@ Collocated::run(int argc, char** argv)
     initData.observer = observer;
     Ice::CommunicatorHolder communicator = initialize(argc, argv, initData);
 
-    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
+    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     adapter->add(make_shared<MetricsI>(), Ice::stringToIdentity("metrics"));
     // adapter->activate(); // Don't activate OA to ensure collocation is used.

--- a/cpp/test/Ice/metrics/Server.cpp
+++ b/cpp/test/Ice/metrics/Server.cpp
@@ -23,7 +23,7 @@ Server::run(int argc, char** argv)
     properties->setProperty("Ice.MessageSizeMax", "50000");
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
 
-    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
+    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     adapter->add(make_shared<MetricsI>(), Ice::stringToIdentity("metrics"));
     adapter->activate();

--- a/cpp/test/Ice/metrics/ServerAMD.cpp
+++ b/cpp/test/Ice/metrics/ServerAMD.cpp
@@ -23,7 +23,7 @@ ServerAMD::run(int argc, char** argv)
     properties->setProperty("Ice.MessageSizeMax", "50000");
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
 
-    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
+    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     adapter->add(make_shared<MetricsI>(), Ice::stringToIdentity("metrics"));
     adapter->activate();

--- a/cpp/test/Ice/timeout/Server.cpp
+++ b/cpp/test/Ice/timeout/Server.cpp
@@ -34,7 +34,7 @@ Server::run(int argc, char** argv)
 
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);
 
-    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
+    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
     communicator->getProperties()->setProperty("ControllerAdapter.Endpoints", getTestEndpoint(1));
     communicator->getProperties()->setProperty("ControllerAdapter.ThreadPool.Size", "1");
 

--- a/cpp/test/Slice/escape/Client.cpp
+++ b/cpp/test/Slice/escape/Client.cpp
@@ -118,7 +118,7 @@ void
 Client::run(int argc, char** argv)
 {
     Ice::CommunicatorHolder communicator = initialize(argc, argv);
-    communicator->getProperties()->setProperty("TestAdapter.Endpoints", "default");
+    communicator->getProperties()->setProperty("TestAdapter.Endpoints", getTestEndpoint());
     Ice::ObjectAdapterPtr adapter = communicator->createObjectAdapter("TestAdapter");
     adapter->add(std::make_shared<breakI>(), Ice::stringToIdentity("test"));
     adapter->activate();

--- a/csharp/test/Ice/idleTimeout/Server.cs
+++ b/csharp/test/Ice/idleTimeout/Server.cs
@@ -14,7 +14,7 @@ public class Server : global::Test.TestHelper
         properties.setProperty("TestAdapter.Connection.MaxDispatches", "1");
 
         using var communicator = initialize(properties);
-        communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
+        communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         var adapter = communicator.createObjectAdapter("TestAdapter");
         adapter.add(new TestIntfI(), Ice.Util.stringToIdentity("test"));
         adapter.activate();

--- a/csharp/test/Ice/inactivityTimeout/Server.cs
+++ b/csharp/test/Ice/inactivityTimeout/Server.cs
@@ -15,7 +15,7 @@ public class Server : global::Test.TestHelper
         properties.setProperty("TestAdapter3s.Connection.InactivityTimeout", "3");
 
         using var communicator = initialize(properties);
-        communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
+        communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         communicator.getProperties().setProperty("TestAdapter3s.Endpoints", getTestEndpoint(1));
 
         var adapter = communicator.createObjectAdapter("TestAdapter");

--- a/csharp/test/Ice/maxConnections/Server.cs
+++ b/csharp/test/Ice/maxConnections/Server.cs
@@ -11,7 +11,7 @@ public class Server : global::Test.TestHelper
         using var communicator = initialize(ref args);
 
         // Plain adapter with no limit.
-        communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
+        communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         var adapter = communicator.createObjectAdapter("TestAdapter");
         adapter.add(new TestIntfI(), Ice.Util.stringToIdentity("test"));
         adapter.activate();

--- a/csharp/test/Ice/maxDispatches/Server.cs
+++ b/csharp/test/Ice/maxDispatches/Server.cs
@@ -15,7 +15,7 @@ public class Server : global::Test.TestHelper
         var responder = new ResponderI();
         var testIntf = new TestIntfI(responder);
 
-        communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
+        communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         var adapter = communicator.createObjectAdapter("TestAdapter");
         adapter.add(testIntf, Ice.Util.stringToIdentity("test"));
         adapter.activate();

--- a/csharp/test/Slice/escape/Client.cs
+++ b/csharp/test/Slice/escape/Client.cs
@@ -85,7 +85,7 @@ public class Client : Test.TestHelper
     public override void run(string[] args)
     {
         using var communicator = initialize(ref args);
-        communicator.getProperties().setProperty("TestAdapter.Endpoints", "default");
+        communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         Ice.ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
         adapter.add(new decimalI(), Ice.Util.stringToIdentity("test"));
         adapter.add(new Test1I(), Ice.Util.stringToIdentity("test1"));

--- a/java/test/src/main/java/test/Ice/adapterDeactivation/Collocated.java
+++ b/java/test/src/main/java/test/Ice/adapterDeactivation/Collocated.java
@@ -14,7 +14,7 @@ public class Collocated extends TestHelper {
             // 2 threads are necessary to dispatch the collocated transient() call with AMI
             //
             communicator.getProperties().setProperty("TestAdapter.ThreadPool.Size", "2");
-            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
+            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.addServantLocator(new ServantLocatorI(), "");
             AllTests.allTests(this);

--- a/java/test/src/main/java/test/Ice/adapterDeactivation/Server.java
+++ b/java/test/src/main/java/test/Ice/adapterDeactivation/Server.java
@@ -10,7 +10,7 @@ import test.TestHelper;
 public class Server extends TestHelper {
     public void run(String[] args) {
         try (Communicator communicator = initialize(args)) {
-            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
+            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.addServantLocator(new ServantLocatorI(), "");
             adapter.activate();

--- a/java/test/src/main/java/test/Ice/admin/Server.java
+++ b/java/test/src/main/java/test/Ice/admin/Server.java
@@ -14,7 +14,7 @@ public class Server extends TestHelper {
         properties.setProperty("Ice.Warn.Dispatch", "0");
 
         try (Communicator communicator = initialize(properties)) {
-            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
+            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(
                 new RemoteCommunicatorFactoryI(),

--- a/java/test/src/main/java/test/Ice/idleTimeout/AllTests.java
+++ b/java/test/src/main/java/test/Ice/idleTimeout/AllTests.java
@@ -16,7 +16,7 @@ import java.io.PrintWriter;
 public class AllTests {
     static void allTests(TestHelper helper) {
         Communicator communicator = helper.communicator();
-        String proxyString = "test: " + helper.getTestEndpoint();
+        String proxyString = "test: " + helper.getTestEndpoint(0);
         var p = TestIntfPrx.createProxy(communicator, proxyString);
 
         String proxyStringDefaultMax = "test: " + helper.getTestEndpoint(1);

--- a/java/test/src/main/java/test/Ice/idleTimeout/Server.java
+++ b/java/test/src/main/java/test/Ice/idleTimeout/Server.java
@@ -14,7 +14,7 @@ public class Server extends TestHelper {
         properties.setProperty("Ice.Warn.Connections", "0");
 
         try (var communicator = initialize(properties)) {
-            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
+            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             var adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new TestIntfI(), new Identity("test", ""));
             adapter.activate();

--- a/java/test/src/main/java/test/Ice/inactivityTimeout/AllTests.java
+++ b/java/test/src/main/java/test/Ice/inactivityTimeout/AllTests.java
@@ -15,7 +15,7 @@ import java.io.PrintWriter;
 public class AllTests {
     static void allTests(TestHelper helper) {
         Communicator communicator = helper.communicator();
-        String proxyString = "test: " + helper.getTestEndpoint();
+        String proxyString = "test: " + helper.getTestEndpoint(0);
         TestIntfPrx p = TestIntfPrx.uncheckedCast(communicator.stringToProxy(proxyString));
 
         String proxyString3s = "test: " + helper.getTestEndpoint(1);

--- a/java/test/src/main/java/test/Ice/inactivityTimeout/Server.java
+++ b/java/test/src/main/java/test/Ice/inactivityTimeout/Server.java
@@ -16,7 +16,7 @@ public class Server extends TestHelper {
         properties.setProperty("TestAdapter3s.Connection.InactivityTimeout", "3");
 
         try (var communicator = initialize(properties)) {
-            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
+            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             communicator.getProperties().setProperty("TestAdapter3s.Endpoints", getTestEndpoint(1));
 
             var adapter = communicator.createObjectAdapter("TestAdapter");

--- a/java/test/src/main/java/test/Ice/maxConnections/AllTests.java
+++ b/java/test/src/main/java/test/Ice/maxConnections/AllTests.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 public class AllTests {
     static void allTests(TestHelper helper) {
         Communicator communicator = helper.communicator();
-        String proxyString = "test: " + helper.getTestEndpoint();
+        String proxyString = "test: " + helper.getTestEndpoint(0);
         var p = TestIntfPrx.createProxy(communicator, proxyString);
 
         String proxyStringMax10 = "test: " + helper.getTestEndpoint(1);

--- a/java/test/src/main/java/test/Ice/maxConnections/Server.java
+++ b/java/test/src/main/java/test/Ice/maxConnections/Server.java
@@ -10,7 +10,7 @@ public class Server extends TestHelper {
     public void run(String[] args) {
         try (var communicator = initialize(args)) {
             // Plain adapter with no limit.
-            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
+            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             var adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(new TestIntfI(), new Identity("test", ""));
             adapter.activate();

--- a/java/test/src/main/java/test/Ice/maxDispatches/AllTests.java
+++ b/java/test/src/main/java/test/Ice/maxDispatches/AllTests.java
@@ -15,7 +15,7 @@ import java.util.concurrent.CompletableFuture;
 public class AllTests {
     static void allTests(TestHelper helper) {
         Communicator communicator = helper.communicator();
-        String proxyString = "test: " + helper.getTestEndpoint();
+        String proxyString = "test: " + helper.getTestEndpoint(0);
         var p = TestIntfPrx.createProxy(communicator, proxyString);
 
         String responderString = "responder: " + helper.getTestEndpoint(1);

--- a/java/test/src/main/java/test/Ice/maxDispatches/Server.java
+++ b/java/test/src/main/java/test/Ice/maxDispatches/Server.java
@@ -17,7 +17,7 @@ public class Server extends TestHelper {
             var responder = new ResponderI();
             var testIntf = new TestIntfI(responder);
 
-            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
+            communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             var adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(testIntf, new Identity("test", ""));
             adapter.activate();

--- a/java/test/src/main/java/test/Slice/escape/Client.java
+++ b/java/test/src/main/java/test/Slice/escape/Client.java
@@ -112,7 +112,7 @@ public class Client extends TestHelper {
         // In this test, we need at least two threads in the client side thread pool for nested AMI.
         initData.properties.setProperty("Ice.ThreadPool.Client.Size", "2");
         initData.properties.setProperty("Ice.ThreadPool.Client.SizeWarn", "0");
-        initData.properties.setProperty("TestAdapter.Endpoints", "default");
+        initData.properties.setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         // We must set MessageSizeMax to an explicit value,
         // because we run tests to check whether Ice.MarshalException is raised as expected.
         initData.properties.setProperty("Ice.MessageSizeMax", "100");

--- a/java/test/src/main/java/test/TestHelper.java
+++ b/java/test/src/main/java/test/TestHelper.java
@@ -32,6 +32,10 @@ public abstract class TestHelper {
         void serverReady();
     }
 
+    public String getTestEndpoint() {
+        return getTestEndpoint(_communicator.getProperties(), 0, "");
+    }
+
     public static String getTestEndpoint(Properties properties) {
         return getTestEndpoint(properties, 0, "");
     }

--- a/java/test/src/main/java/test/TestHelper.java
+++ b/java/test/src/main/java/test/TestHelper.java
@@ -32,10 +32,6 @@ public abstract class TestHelper {
         void serverReady();
     }
 
-    public String getTestEndpoint() {
-        return getTestEndpoint(_communicator.getProperties(), 0, "");
-    }
-
     public static String getTestEndpoint(Properties properties) {
         return getTestEndpoint(properties, 0, "");
     }

--- a/python/test/Slice/escape/Client.py
+++ b/python/test/Slice/escape/Client.py
@@ -70,7 +70,7 @@ class Client(TestHelper):
         #
         properties.setProperty("Ice.Warn.Dispatch", "0")
         with self.initialize(properties=properties) as communicator:
-            communicator.getProperties().setProperty("TestAdapter.Endpoints", "default")
+            communicator.getProperties().setProperty("TestAdapter.Endpoints", self.getTestEndpoint())
             adapter = communicator.createObjectAdapter("TestAdapter")
             adapter.add(execI(), Ice.stringToIdentity("test"))
             adapter.activate()


### PR DESCRIPTION
This PR fixes #4201.
The 'Slice/escape' tests were setting `XXX.Endpoints` properties to `"default"` instead of using `getTestEndpoint`.
I looked through all the tests, and there's only other place where we did this (mentioned below).

I updated 'Slice/escape' in C++, C#, Java, and Python. Swift was already fine:
https://github.com/zeroc-ice/ice/blob/bad509c7765dffcabe6d47215c95cca61c7c6f37/swift/test/Slice/escape/Client.swift#L41-L42

I also updated some calls to `getTestEndpoint` to be consistent about when we pass explicit numbers.

If a test called `getTestEndpoint` multiple times, we would almost always explicitly pass in `0`.
Except for a few exceptions in each language. So I updated those exceptions for consistency's sake.
If you'd rather leave it implicit, I'm totally fine undoing this change.
It was just a spur-of-the-moment thing I noticed while searching through all the tests.