### PR TITLE
Override `dispatch` Doc-Comments in C# and Java

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2593,12 +2593,16 @@ Slice::Gen::ServantVisitor::writeDispatch(const InterfaceDefPtr& p)
     {
         _out << sp;
         _out << nl << "/// <summary>";
-        _out << nl << "/// Dispatches an incoming request to one of the methods of this generated class, based on the operation name carried by the request.";
+        _out << nl
+             << "/// Dispatches an incoming request to one of the methods of this generated class, based on the "
+                "operation name carried by the request.";
         _out << nl << "/// </summary>";
         _out << nl << "/// <param name=\"request\">The incoming request.</param>";
         _out << nl << "/// <returns>A value task that holds the outgoing response.</returns>";
         _out << nl << "/// <remarks>Ice marshals any exception thrown by this method into the response.</remarks>";
-        _out << nl << "public global::System.Threading.Tasks.ValueTask<Ice.OutgoingResponse> dispatchAsync(Ice.IncomingRequest request) =>";
+        _out << nl
+             << "public global::System.Threading.Tasks.ValueTask<Ice.OutgoingResponse> "
+                "dispatchAsync(Ice.IncomingRequest request) =>";
         _out.inc();
         _out << nl << "request.current.operation switch";
         _out << sb;

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2592,9 +2592,13 @@ Slice::Gen::ServantVisitor::writeDispatch(const InterfaceDefPtr& p)
     if (!allOps.empty())
     {
         _out << sp;
-        _out << nl
-             << "public global::System.Threading.Tasks.ValueTask<Ice.OutgoingResponse> "
-                "dispatchAsync(Ice.IncomingRequest request) =>";
+        _out << nl << "/// <summary>";
+        _out << nl << "/// Dispatches an incoming request to one of the methods of this generated class, based on the operation name carried by the request.";
+        _out << nl << "/// </summary>";
+        _out << nl << "/// <param name=\"request\">The incoming request.</param>";
+        _out << nl << "/// <returns>A value task that holds the outgoing response.</returns>";
+        _out << nl << "/// <remarks>Ice marshals any exception thrown by this method into the response.</remarks>";
+        _out << nl << "public global::System.Threading.Tasks.ValueTask<Ice.OutgoingResponse> dispatchAsync(Ice.IncomingRequest request) =>";
         _out.inc();
         _out << nl << "request.current.operation switch";
         _out << sb;

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -4788,7 +4788,8 @@ Slice::Gen::ServantVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         out << nl << " * @param request the incoming request";
         out << nl << " * @return the outgoing response";
         out << nl
-            << " * @throws com.zeroc.Ice.UserException if a {@code UserException} is thrown, Ice will marshal it as the response payload.";
+            << " * @throws com.zeroc.Ice.UserException if a {@code UserException} is thrown, Ice will marshal it as "
+               "the response payload.";
         out << nl << " */";
         out << nl << "@Override";
         out << nl << "default java.util.concurrent.CompletionStage<com.zeroc.Ice.OutgoingResponse> dispatch("

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -4788,7 +4788,7 @@ Slice::Gen::ServantVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         out << nl << " * @param request the incoming request";
         out << nl << " * @return the outgoing response";
         out << nl
-            << " * @throws com.zeroc.Ice.UserException when the response payload contains a {@code UserException}.";
+            << " * @throws com.zeroc.Ice.UserException if a {@code UserException} is thrown, Ice will marshal it as the response payload.";
         out << nl << " */";
         out << nl << "@Override";
         out << nl << "default java.util.concurrent.CompletionStage<com.zeroc.Ice.OutgoingResponse> dispatch("

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -4787,7 +4787,8 @@ Slice::Gen::ServantVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         out << nl << " *";
         out << nl << " * @param request the incoming request";
         out << nl << " * @return the outgoing response";
-        out << nl << " * @throws UserException when the response payload contains a {@code UserException}.";
+        out << nl
+            << " * @throws com.zeroc.Ice.UserException when the response payload contains a {@code UserException}.";
         out << nl << " */";
         out << nl << "@Override";
         out << nl << "default java.util.concurrent.CompletionStage<com.zeroc.Ice.OutgoingResponse> dispatch("

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -4780,7 +4780,15 @@ Slice::Gen::ServantVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     if (!allOps.empty())
     {
         out << sp;
-        out << nl << "@Override" << nl
+        out << nl << "/**";
+        out << nl << " * Dispatches an incoming request to one of the methods of this generated interface, based on the operation name carried by the request.";
+        out << nl << " *";
+        out << nl << " * @param request the incoming request";
+        out << nl << " * @return the outgoing response";
+        out << nl << " * @throws UserException when the response payload contains a {@code UserException}.";
+        out << nl << " */";
+        out << nl << "@Override";
+        out << nl
             << "default java.util.concurrent.CompletionStage<com.zeroc.Ice.OutgoingResponse> dispatch("
             << "com.zeroc.Ice.IncomingRequest request)";
         out.inc();

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -4781,15 +4781,16 @@ Slice::Gen::ServantVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     {
         out << sp;
         out << nl << "/**";
-        out << nl << " * Dispatches an incoming request to one of the methods of this generated interface, based on the operation name carried by the request.";
+        out << nl
+            << " * Dispatches an incoming request to one of the methods of this generated interface, based on the "
+               "operation name carried by the request.";
         out << nl << " *";
         out << nl << " * @param request the incoming request";
         out << nl << " * @return the outgoing response";
         out << nl << " * @throws UserException when the response payload contains a {@code UserException}.";
         out << nl << " */";
         out << nl << "@Override";
-        out << nl
-            << "default java.util.concurrent.CompletionStage<com.zeroc.Ice.OutgoingResponse> dispatch("
+        out << nl << "default java.util.concurrent.CompletionStage<com.zeroc.Ice.OutgoingResponse> dispatch("
             << "com.zeroc.Ice.IncomingRequest request)";
         out.inc();
         out << nl << "throws com.zeroc.Ice.UserException";

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Object.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Object.java
@@ -108,7 +108,7 @@ public interface Object {
      *
      * @param request The incoming request.
      * @return The outgoing response.
-     * @throws UserException when the response payload contains a {@code UserException}.
+     * @throws UserException If a {@code UserException} is thrown, Ice will marshal it as the response payload.
      */
     default CompletionStage<OutgoingResponse> dispatch(IncomingRequest request)
         throws UserException {


### PR DESCRIPTION
This PR implements #4006 for C# and Java.
Instead of the generated `dispatch` methods inheriting an incorrect doc-comment from `Object.dispatch`,
now `slice2cs` and `slice2java` will generate an overriding doc-comment on `dispatch`.

The new comments are based off of the relevant comment in C++:
https://github.com/zeroc-ice/ice/blob/1b7f68f822a5ff474ccc8d3a0b2d52db141b1a35/cpp/src/slice2cpp/Gen.cpp#L2860-L2865
Including some language-specific things taken from each language's `Object.dispatch`.