### PR TITLE
More Python type hinting fixes

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,6 +1,7 @@
 {
     "include": ["python"],
     "extraPaths": ["python/python"],
+    // "stubPath": "python/stubs",
     "typeCheckingMode": "standard",
     "reportMissingTypeAnnotation": "error",
     "reportMissingParameterType": "error",

--- a/python/python/Ice/EventLoopAdapter.py
+++ b/python/python/Ice/EventLoopAdapter.py
@@ -7,7 +7,7 @@ from collections.abc import Awaitable, Coroutine
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import Ice
+    from .Future import Future, FutureLike
 
 
 class EventLoopAdapter(ABC):
@@ -16,7 +16,7 @@ class EventLoopAdapter(ABC):
     """
 
     @abstractmethod
-    def runCoroutine(self, coroutine: Coroutine) -> Ice.FutureLike:
+    def runCoroutine(self, coroutine: Coroutine) -> FutureLike:
         """
         Run a coroutine in the application configured event loop. The Ice run time will call this method to run
         coroutines returned by async dispatch methods. This method is called from the Ice dispatch thread.
@@ -34,7 +34,7 @@ class EventLoopAdapter(ABC):
         pass
 
     @abstractmethod
-    def wrapFuture(self, future: Ice.Future) -> Awaitable:
+    def wrapFuture(self, future: Future) -> Awaitable:
         """
         Wraps an Ice.Future so that it can be awaited in the application event loop. The Ice run time calls this method
         before returning a future to the application.

--- a/python/python/Ice/InvocationFuture.py
+++ b/python/python/Ice/InvocationFuture.py
@@ -1,7 +1,6 @@
 # Copyright (c) ZeroC, Inc.
 
 import logging
-import traceback
 from collections.abc import Callable
 
 import IcePy

--- a/python/python/Ice/ObjectAdapter.py
+++ b/python/python/Ice/ObjectAdapter.py
@@ -8,7 +8,12 @@ from typing import TYPE_CHECKING, final
 import IcePy
 
 if TYPE_CHECKING:
-    import Ice
+    from .Communicator import Communicator
+    from .Identity import Identity
+    from .Locator import LocatorPrx
+    from .Object import Object
+    from .ObjectPrx import ObjectPrx
+    from .ServantLocator import ServantLocator
 
 
 @final
@@ -40,7 +45,7 @@ class ObjectAdapter:
 
         Returns
         -------
-        Ice.Communicator
+        Communicator
             The communicator this object adapter belongs to.
         """
         communicator = self._impl.getCommunicator()
@@ -128,7 +133,7 @@ class ObjectAdapter:
         """
         self._impl.destroy()
 
-    def add(self, servant: Ice.Object, id: Ice.Identity) -> Ice.ObjectPrx:
+    def add(self, servant: Object, id: Identity) -> ObjectPrx:
         """
         Add a servant to this object adapter's Active Servant Map.
 
@@ -137,19 +142,19 @@ class ObjectAdapter:
 
         Parameters
         ----------
-        servant : Ice.Object
+        servant : Object
             The servant to add.
-        id : Ice.Identity
+        id : Identity
             The identity of the Ice object that is implemented by the servant.
 
         Returns
         -------
-        Ice.ObjectPrx
+        ObjectPrx
             A proxy that matches the given identity and this object adapter.
         """
         return self._impl.add(servant, id)
 
-    def addFacet(self, servant: Ice.Object, id: Ice.Identity, facet: str = "") -> Ice.ObjectPrx:
+    def addFacet(self, servant: Object, id: Identity, facet: str = "") -> ObjectPrx:
         """
         Add a servant with a facet to this object adapter's Active Servant Map.
 
@@ -157,21 +162,21 @@ class ObjectAdapter:
 
         Parameters
         ----------
-        servant : Ice.Object
+        servant : Object
             The servant to add.
-        id : Ice.Identity
+        id : Identity
             The identity of the Ice object that is implemented by the servant.
         facet : str
             The facet. An empty facet means the default facet.
 
         Returns
         -------
-        Ice.ObjectPrx
+        ObjectPrx
             A proxy that matches the given identity, facet, and this object adapter.
         """
         return self._impl.addFacet(servant, id, facet)
 
-    def addWithUUID(self, servant: Ice.Object) -> Ice.ObjectPrx:
+    def addWithUUID(self, servant: Object) -> ObjectPrx:
         """
         Add a servant to this object adapter's Active Servant Map, using an automatically generated UUID as its identity.
 
@@ -179,17 +184,17 @@ class ObjectAdapter:
 
         Parameters
         ----------
-        servant : Ice.Object
+        servant : Object
             The servant to add.
 
         Returns
         -------
-        Ice.ObjectPrx
+        ObjectPrx
             A proxy that matches the generated UUID identity and this object adapter.
         """
         return self._impl.addWithUUID(servant)
 
-    def addFacetWithUUID(self, servant: Ice.Object, facet: str) -> Ice.ObjectPrx:
+    def addFacetWithUUID(self, servant: Object, facet: str) -> ObjectPrx:
         """
         Add a servant with a facet to this object adapter's Active Servant Map, using an automatically generated UUID as its identity.
 
@@ -197,19 +202,19 @@ class ObjectAdapter:
 
         Parameters
         ----------
-        servant : Ice.Object
+        servant : Object
             The servant to add.
         facet : str
             The facet. An empty facet means the default facet.
 
         Returns
         -------
-        Ice.ObjectPrx
+        ObjectPrx
             A proxy that matches the generated UUID identity, facet, and this object adapter.
         """
         return self._impl.addFacetWIthUUID(servant, facet)
 
-    def addDefaultServant(self, servant: Ice.Object, category: str) -> None:
+    def addDefaultServant(self, servant: Object, category: str) -> None:
         """
         Add a default servant to handle requests for a specific category.
 
@@ -228,14 +233,14 @@ class ObjectAdapter:
 
         Parameters
         ----------
-        servant : Ice.Object
+        servant : Object
             The default servant.
         category : str
             The category for which the default servant is registered. An empty category means it will handle all categories.
         """
         self._impl.addDefaultServant(servant, category)
 
-    def remove(self, id: Ice.Identity) -> Ice.Object:
+    def remove(self, id: Identity) -> Object:
         """
         Remove a servant (that is, the default facet) from the object adapter's Active Servant Map.
 
@@ -243,18 +248,18 @@ class ObjectAdapter:
 
         Parameters
         ----------
-        id : Ice.Identity
+        id : Identity
             The identity of the Ice object that is implemented by the servant. If the servant implements multiple Ice
             objects, `remove` has to be called for all those Ice objects.
 
         Returns
         -------
-        Ice.Object
+        Object
             The removed servant.
         """
         return self._impl.remove(id)
 
-    def removeFacet(self, id: Ice.Identity, facet: str) -> Ice.Object:
+    def removeFacet(self, id: Identity, facet: str) -> Object:
         """
         Remove a servant with a facet from the object adapter's Active Servant Map.
 
@@ -262,19 +267,19 @@ class ObjectAdapter:
 
         Parameters
         ----------
-        id : Ice.Identity
+        id : Identity
             The identity of the Ice object that is implemented by the servant.
         facet : str
             The facet. An empty facet means the default facet.
 
         Returns
         -------
-        Ice.Object
+        Object
             The removed servant.
         """
         return self._impl.removeFacet(id, facet)
 
-    def removeAllFacets(self, id: Ice.Identity) -> dict[str, Ice.Object]:
+    def removeAllFacets(self, id: Identity) -> dict[str, Object]:
         """
         Remove all facets with the given identity from the Active Servant Map.
 
@@ -283,17 +288,17 @@ class ObjectAdapter:
 
         Parameters
         ----------
-        id : Ice.Identity
+        id : Identity
             The identity of the Ice object to be removed.
 
         Returns
         -------
-        dict[str, Ice.Object]
+        dict[str, Object]
             A collection containing all the facet names and servants of the removed Ice object.
         """
         return self._impl.removeAllFacets(id)
 
-    def removeDefaultServant(self, category: str) -> Ice.Object:
+    def removeDefaultServant(self, category: str) -> Object:
         """
         Remove the default servant for a specific category.
 
@@ -306,12 +311,12 @@ class ObjectAdapter:
 
         Returns
         -------
-        Ice.Object
+        Object
             The default servant.
         """
         return self._impl.removeDefaultServant(category)
 
-    def find(self, id: Ice.Identity) -> Ice.Object | None:
+    def find(self, id: Identity) -> Object | None:
         """
         Look up a servant in this object adapter's Active Servant Map by the identity of the Ice object it implements.
 
@@ -320,17 +325,17 @@ class ObjectAdapter:
 
         Parameters
         ----------
-        id : Ice.Identity
+        id : Identity
             The identity of the Ice object for which the servant should be returned.
 
         Returns
         -------
-        Ice.Object | None
+        Object | None
             The servant that implements the Ice object with the given identity, or None if no such servant has been found.
         """
         return self._impl.find(id)
 
-    def findFacet(self, id: Ice.Identity, facet: str) -> Ice.Object | None:
+    def findFacet(self, id: Identity, facet: str) -> Object | None:
         """
         Look up a servant in this object adapter's Active Servant Map by the identity and facet of the Ice object it implements.
 
@@ -338,36 +343,36 @@ class ObjectAdapter:
 
         Parameters
         ----------
-        id : Ice.Identity
+        id : Identity
             The identity of the Ice object for which the servant should be returned.
         facet : str
             The facet. An empty facet means the default facet.
 
         Returns
         -------
-        Ice.Object | None
+        Object | None
             The servant that implements the Ice object with the given identity and facet, or None if no such servant has been found.
         """
         return self._impl.findFacet(id, facet)
 
-    def findAllFacets(self, id: Ice.Identity) -> dict[str, Ice.Object]:
+    def findAllFacets(self, id: Identity) -> dict[str, Object]:
         """
         Find all facets with the given identity in the Active Servant Map.
 
         Parameters
         ----------
-        id : Ice.Identity
+        id : Identity
             The identity of the Ice object for which the facets should be returned.
 
         Returns
         -------
-        dict[str, Ice.Object]
+        dict[str, Object]
             A dictionary containing all the facet names and servants that have been found, or an empty dictionary if
             there is no facet for the given identity.
         """
         return self._impl.findAllFacets(id)
 
-    def findByProxy(self, proxy: Ice.ObjectPrx) -> Ice.Object | None:
+    def findByProxy(self, proxy: ObjectPrx) -> Object | None:
         """
         Look up a servant in this object adapter's Active Servant Map, given a proxy.
 
@@ -376,17 +381,17 @@ class ObjectAdapter:
 
         Parameters
         ----------
-        proxy : Ice.ObjectPrx
+        proxy : ObjectPrx
             The proxy for which the servant should be returned.
 
         Returns
         -------
-        Ice.Object | None
+        Object | None
             The servant that matches the proxy, or None if no such servant has been found.
         """
         return self._impl.findByProxy(proxy)
 
-    def addServantLocator(self, locator: Ice.ServantLocator, category: str) -> None:
+    def addServantLocator(self, locator: ServantLocator, category: str) -> None:
         """
         Add a Servant Locator to this object adapter.
 
@@ -408,7 +413,7 @@ class ObjectAdapter:
 
         Parameters
         ----------
-        locator : Ice.ServantLocator
+        locator : ServantLocator
             The locator to add.
         category : str
             The category for which the Servant Locator can locate servants, or an empty string if the Servant Locator
@@ -416,7 +421,7 @@ class ObjectAdapter:
         """
         self._impl.addServantLocator(locator, category)
 
-    def removeServantLocator(self, category: str) -> Ice.ServantLocator:
+    def removeServantLocator(self, category: str) -> ServantLocator:
         """
         Remove a Servant Locator from this object adapter.
 
@@ -428,7 +433,7 @@ class ObjectAdapter:
 
         Returns
         -------
-        Ice.ServantLocator
+        ServantLocator
             The Servant Locator.
 
         Raises
@@ -438,7 +443,7 @@ class ObjectAdapter:
         """
         return self._impl.removeServantLocator(category)
 
-    def findServantLocator(self, category: str) -> Ice.ServantLocator | None:
+    def findServantLocator(self, category: str) -> ServantLocator | None:
         """
         Find a Servant Locator installed with this object adapter.
 
@@ -450,12 +455,12 @@ class ObjectAdapter:
 
         Returns
         -------
-        Ice.ServantLocator | None
+        ServantLocator | None
             The Servant Locator, or None if no Servant Locator was found for the given category.
         """
         return self._impl.findServantLocator(category)
 
-    def findDefaultServant(self, category: str) -> Ice.Object | None:
+    def findDefaultServant(self, category: str) -> Object | None:
         """
         Find the default servant for a specific category.
 
@@ -466,12 +471,12 @@ class ObjectAdapter:
 
         Returns
         -------
-        Ice.Object or None
+        Object or None
             The default servant, or None if no default servant was registered for the category.
         """
         return self._impl.findDefaultServant(category)
 
-    def createProxy(self, id: Ice.Identity) -> Ice.ObjectPrx:
+    def createProxy(self, id: Identity) -> ObjectPrx:
         """
         Create a proxy for the object with the given identity.
 
@@ -482,17 +487,17 @@ class ObjectAdapter:
 
         Parameters
         ----------
-        id : Ice.Identity
+        id : Identity
             The object's identity.
 
         Returns
         -------
-        Ice.ObjectPrx
+        ObjectPrx
             A proxy for the object with the given identity.
         """
         return self._impl.createProxy(id)
 
-    def createDirectProxy(self, id: Ice.Identity) -> Ice.ObjectPrx:
+    def createDirectProxy(self, id: Identity) -> ObjectPrx:
         """
         Create a direct proxy for the object with the given identity.
 
@@ -500,17 +505,17 @@ class ObjectAdapter:
 
         Parameters
         ----------
-        id : Ice.Identity
+        id : Identity
             The object's identity.
 
         Returns
         -------
-        Ice.ObjectPrx
+        ObjectPrx
             A proxy for the object with the given identity.
         """
         return self._impl.createDirectProxy(id)
 
-    def createIndirectProxy(self, id: Ice.Identity) -> Ice.ObjectPrx:
+    def createIndirectProxy(self, id: Identity) -> ObjectPrx:
         """
         Create an indirect proxy for the object with the given identity.
 
@@ -519,17 +524,17 @@ class ObjectAdapter:
 
         Parameters
         ----------
-        id : Ice.Identity
+        id : Identity
             The object's identity.
 
         Returns
         -------
-        Ice.ObjectPrx
+        ObjectPrx
             A proxy for the object with the given identity.
         """
         return self._impl.createIndirectProxy(id)
 
-    def setLocator(self, locator: Ice.LocatorPrx) -> None:
+    def setLocator(self, locator: LocatorPrx) -> None:
         """
         Set an Ice locator for this object adapter.
 
@@ -539,18 +544,18 @@ class ObjectAdapter:
 
         Parameters
         ----------
-        locator : Ice.LocatorPrx
+        locator : LocatorPrx
             The locator used by this object adapter.
         """
         self._impl.setLocator(locator)
 
-    def getLocator(self) -> Ice.LocatorPrx | None:
+    def getLocator(self) -> LocatorPrx | None:
         """
         Get the Ice locator used by this object adapter.
 
         Returns
         -------
-        Ice.LocatorPrx | None
+        LocatorPrx | None
             The locator used by this object adapter, or None if no locator is used by this object adapter.
         """
         return self._impl.getLocator()

--- a/python/python/Ice/ObjectPrx.py
+++ b/python/python/Ice/ObjectPrx.py
@@ -11,10 +11,19 @@ import IcePy
 from .Object import Object
 
 if TYPE_CHECKING:
-    import Ice
+    from typing import Type, TypeVar
+
+    from .Communicator import Communicator
+    from .EncodingVersion import EncodingVersion
+    from .EndpointSelectionType import EndpointSelectionType
+    from .Identity import Identity
+    from .Locator import LocatorPrx
+    from .Router import RouterPrx
+
+    T = TypeVar("T", bound=ObjectPrx)
 
 
-def uncheckedCast(type, proxy, facet=None):
+def uncheckedCast(type: Type[T], proxy: ObjectPrx, facet: str | None = None) -> T | None:
     """
     Downcasts a proxy without confirming the target object's type via a remote invocation.
 
@@ -40,7 +49,9 @@ def uncheckedCast(type, proxy, facet=None):
     return IcePy.ObjectPrx.newProxy(type, proxy)
 
 
-def checkedCast(type, proxy, facet=None, context: dict[str, str] | None = None):
+def checkedCast(
+    type: Type[T], proxy: ObjectPrx, facet: str | None = None, context: dict[str, str] | None = None
+) -> T | None:
     """
     Downcasts a proxy after confirming the target object's type via a remote invocation.
 
@@ -69,7 +80,9 @@ def checkedCast(type, proxy, facet=None, context: dict[str, str] | None = None):
     return IcePy.ObjectPrx.newProxy(type, proxy) if proxy.ice_isA(type.ice_staticId(), context=context) else None
 
 
-async def checkedCastAsync(type, proxy, facet=None, context: dict[str, str] | None = None):
+async def checkedCastAsync(
+    type: Type[T], proxy: ObjectPrx, facet: str | None = None, context: dict[str, str] | None = None
+) -> T | None:
     """
     Downcasts a proxy after confirming the target object's type via a remote invocation.
 
@@ -99,13 +112,14 @@ async def checkedCastAsync(type, proxy, facet=None, context: dict[str, str] | No
     return IcePy.ObjectPrx.newProxy(type, proxy) if b else None
 
 
-class ObjectPrx(IcePy.ObjectPrx):
+# TODO: fix type hinting for IcePy.ObjectPrx
+class ObjectPrx(IcePy.ObjectPrx):  # type: ignore
     """
     The base class for all proxies.
     """
 
     @staticmethod
-    def uncheckedCast(proxy: ObjectPrx, facet=None):
+    def uncheckedCast(proxy: ObjectPrx, facet: str | None = None) -> ObjectPrx | None:
         """
         Downcasts a proxy without confirming the target object's type via a remote invocation.
 
@@ -125,7 +139,9 @@ class ObjectPrx(IcePy.ObjectPrx):
         return uncheckedCast(ObjectPrx, proxy, facet)
 
     @staticmethod
-    def checkedCast(proxy: ObjectPrx, facet: str | None = None, context: dict[str, str] | None = None):
+    def checkedCast(
+        proxy: ObjectPrx, facet: str | None = None, context: dict[str, str] | None = None
+    ) -> ObjectPrx | None:
         """
         Downcasts a proxy after confirming the target object's type via a remote invocation.
 
@@ -148,7 +164,9 @@ class ObjectPrx(IcePy.ObjectPrx):
         return checkedCast(ObjectPrx, proxy, facet, context)
 
     @staticmethod
-    def checkedCastAsync(proxy: ObjectPrx, facet: str | None = None, context: dict[str, str] | None = None):
+    def checkedCastAsync(
+        proxy: ObjectPrx, facet: str | None = None, context: dict[str, str] | None = None
+    ) -> Awaitable[ObjectPrx | None]:
         """
         Downcasts a proxy after confirming the target object's type via a remote invocation.
 
@@ -182,7 +200,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         """
         return "::Ice::Object"
 
-    def ice_getCommunicator(self) -> Ice.Communicator:
+    def ice_getCommunicator(self) -> Communicator:
         """
         Return the communicator that created this proxy.
 
@@ -323,18 +341,18 @@ class ObjectPrx(IcePy.ObjectPrx):
         """
         return Object._op_ice_id.invokeAsync(self, ((), context))
 
-    def ice_getIdentity(self) -> Ice.Identity:
+    def ice_getIdentity(self) -> Identity:
         """
         Return the identity embedded in this proxy.
 
         Returns
         -------
-        Ice.Identity
+        Identity
             The identity of the target object.
         """
         return super().ice_getIdentity()
 
-    def ice_identity(self, newIdentity: Ice.Identity) -> Self:
+    def ice_identity(self, newIdentity: Identity) -> Self:
         """
         Create a new proxy that is identical to this proxy, except for the per-proxy context.
 
@@ -431,24 +449,24 @@ class ObjectPrx(IcePy.ObjectPrx):
         """
         return super().ice_adapterId(newAdapterId)
 
-    def ice_getEndpoints(self) -> list[Ice.Endpoint]:
+    def ice_getEndpoints(self) -> list[IcePy.Endpoint]:
         """
         Returns the endpoints used by this proxy.
 
         Returns
         -------
-        list of Ice.Endpoint
+        list of Endpoint
             The endpoints used by this proxy.
         """
         return super().ice_getEndpoints()
 
-    def ice_endpoints(self, newEndpoints: list[Ice.Endpoint]) -> Self:
+    def ice_endpoints(self, newEndpoints: list[IcePy.Endpoint]) -> Self:
         """
         Creates a new proxy that is identical to this proxy, except for the endpoints.
 
         Parameters
         ----------
-        newEndpoints : list of Ice.Endpoint
+        newEndpoints : list of Endpoint
             The endpoints for the new proxy.
 
         Returns
@@ -539,7 +557,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         """
         return super().ice_connectionCached(newCache)
 
-    def ice_getEndpointSelection(self) -> Ice.EndpointSelectionType:
+    def ice_getEndpointSelection(self) -> EndpointSelectionType:
         """
         Returns how this proxy selects endpoints (randomly or ordered).
 
@@ -550,7 +568,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         """
         return super().ice_getEndpointSelection()
 
-    def ice_endpointSelection(self, newType: Ice.EndpointSelectionType) -> Self:
+    def ice_endpointSelection(self, newType: EndpointSelectionType) -> Self:
         """
         Creates a new proxy that is identical to this proxy, except for the endpoint selection policy.
 
@@ -594,7 +612,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         """
         return super().ice_secure(secure)
 
-    def ice_encodingVersion(self, version: Ice.EncodingVersion) -> Self:
+    def ice_encodingVersion(self, version: EncodingVersion) -> Self:
         """
         Creates a new proxy that is identical to this proxy, except for the encoding used to marshal parameters.
 
@@ -610,7 +628,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         """
         return super().ice_encodingVersion(version)
 
-    def ice_getEncodingVersion(self) -> Ice.EncodingVersion:
+    def ice_getEncodingVersion(self) -> EncodingVersion:
         """
         Returns the encoding version used to marshal requests parameters.
 
@@ -649,7 +667,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         """
         return super().ice_preferSecure(preferSecure)
 
-    def ice_getRouter(self) -> Ice.RouterPrx | None:
+    def ice_getRouter(self) -> RouterPrx | None:
         """
         Returns the router for this proxy.
 
@@ -660,7 +678,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         """
         return super().ice_getRouter()
 
-    def ice_router(self, router: Ice.RouterPrx | None) -> Self:
+    def ice_router(self, router: RouterPrx | None) -> Self:
         """
         Creates a new proxy that is identical to this proxy, except for the router.
 
@@ -676,7 +694,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         """
         return super().ice_router(router)
 
-    def ice_getLocator(self) -> Ice.LocatorPrx | None:
+    def ice_getLocator(self) -> LocatorPrx | None:
         """
         Returns the locator for this proxy.
 
@@ -687,7 +705,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         """
         return super().ice_getLocator()
 
-    def ice_locator(self, locator: Ice.LocatorPrx | None) -> Self:
+    def ice_locator(self, locator: LocatorPrx | None) -> Self:
         """
         Creates a new proxy that is identical to this proxy, except for the locator.
 

--- a/python/python/Ice/Util.py
+++ b/python/python/Ice/Util.py
@@ -40,7 +40,8 @@ def initialize(
 ) -> Ice.Communicator: ...
 
 
-def initialize(
+# TODO: pyright type hint fixes
+def initialize(  # type: ignore
     args: list[str] | None = None,
     initData: Ice.InitializationData | None = None,
     configFile: str | None = None,


### PR DESCRIPTION
Various updates to Python mapping for type hinting. 

In Ice and Glacier2, just a few warnings left (including generated code):

```
❯ pyright python/Glacier2 python/Ice
/Users/joe/Developer/zeroc-ice/ice/python/python/Glacier2/SSLInfo.py
  /Users/joe/Developer/zeroc-ice/ice/python/python/Glacier2/SSLInfo.py:46:12 - error: "Sequence" is not defined (reportUndefinedVariable)
/Users/joe/Developer/zeroc-ice/ice/python/python/Ice/__init__.py
  /Users/joe/Developer/zeroc-ice/ice/python/python/Ice/__init__.py:181:16 - error: Module is not callable (reportCallIssue)
2 errors, 0 warnings, 0 informations 
```

Still need to fix these and issues in IceGrid/IceMx