### PR TITLE
Move XML Escaping Logic

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -2209,7 +2209,7 @@ Slice::Container::checkIntroduced(const string& scopedName, ContainedPtr namedTh
         // We've previously introduced the first component to the current scope, check that it has not changed meaning.
         if (it->second->scoped() != namedThing->scoped())
         {
-            // Parameter and data members are in their own scopes.
+            // Parameters and data members are in their own scopes.
             if (!(dynamic_pointer_cast<Parameter>(it->second) && !dynamic_pointer_cast<Parameter>(namedThing)) &&
                 !(!dynamic_pointer_cast<Parameter>(it->second) && dynamic_pointer_cast<Parameter>(namedThing)) &&
                 !(dynamic_pointer_cast<DataMember>(it->second) && !dynamic_pointer_cast<DataMember>(namedThing)) &&

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -2219,7 +2219,7 @@ Slice::Container::checkIntroduced(const string& scopedName, ContainedPtr namedTh
             // For example, if one is a parameter and the other is a class, they're logically in different scopes.
             // But, if both of them _are_ a parameter, or both of them _are not_ a parameter, then they're in the same
             // scope, and we should report an error. The same applies for data members.
-            if ((isFirstAParameter == isSecondAParameter) || (isFirstADataMember == isSecondADataMember))
+            if ((isFirstAParameter == isSecondAParameter) && (isFirstADataMember == isSecondADataMember))
             {
                 unit()->error("'" + firstComponent + "' has changed meaning");
             }

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -2147,7 +2147,7 @@ Slice::Container::checkIntroduced(const string& scopedName, ContainedPtr namedTh
 {
     if (scopedName[0] == ':') // Only unscoped names introduce anything.
     {
-        return true;
+        return;
     }
 
     // Split off first component.
@@ -2160,7 +2160,7 @@ Slice::Container::checkIntroduced(const string& scopedName, ContainedPtr namedTh
         ContainedList cl = lookupContained(firstComponent, false);
         if (cl.empty())
         {
-            return true; // Ignore types whose creation failed previously.
+            return; // Ignore types whose creation failed previously.
         }
         namedThing = cl.front();
     }
@@ -2209,26 +2209,16 @@ Slice::Container::checkIntroduced(const string& scopedName, ContainedPtr namedTh
         // We've previously introduced the first component to the current scope, check that it has not changed meaning.
         if (it->second->scoped() != namedThing->scoped())
         {
-            // Parameter are in its own scope.
-            if ((dynamic_pointer_cast<Parameter>(it->second) && !dynamic_pointer_cast<Parameter>(namedThing)) ||
-                (!dynamic_pointer_cast<Parameter>(it->second) && dynamic_pointer_cast<Parameter>(namedThing)))
+            // Parameter and data members are in their own scopes.
+            if (!(dynamic_pointer_cast<Parameter>(it->second) && !dynamic_pointer_cast<Parameter>(namedThing)) &&
+                !(!dynamic_pointer_cast<Parameter>(it->second) && dynamic_pointer_cast<Parameter>(namedThing)) &&
+                !(dynamic_pointer_cast<DataMember>(it->second) && !dynamic_pointer_cast<DataMember>(namedThing)) &&
+                !(!dynamic_pointer_cast<DataMember>(it->second) && dynamic_pointer_cast<DataMember>(namedThing)))
             {
-                return true;
+                unit()->error("'" + firstComponent + "' has changed meaning");
             }
-
-            // Data members are in its own scope.
-            if ((dynamic_pointer_cast<DataMember>(it->second) && !dynamic_pointer_cast<DataMember>(namedThing)) ||
-                (!dynamic_pointer_cast<DataMember>(it->second) && dynamic_pointer_cast<DataMember>(namedThing)))
-            {
-                return true;
-            }
-
-            unit()->error("'" + firstComponent + "' has changed meaning");
-
-            return false;
         }
     }
-    return true;
 }
 
 bool

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -501,7 +501,7 @@ namespace Slice
         [[nodiscard]] ContainedList contents() const;
         void visitContents(ParserVisitor* visitor);
 
-        bool checkIntroduced(const std::string& scopedName, ContainedPtr namedThing = nullptr);
+        void checkIntroduced(const std::string& scopedName, ContainedPtr namedThing = nullptr);
 
         /// Returns `true` if this container is the global scope (i.e. it's of type `Unit`), and `false` otherwise.
         /// If false, we emit an error message. So this function should only be called for types which cannot appear at


### PR DESCRIPTION
This small PR:
1) Moves the XML escaping code from `splitComment` to `DocComent::parseFrom`.
Escaping XML really just doesn't have anything to do with splitting lines.

2) `checkIntroduced` currently returns a bool, but we never check it.
So I removed the return type, and simplified the function a little.