### PR TITLE
Make Doc-Comment Parsing a Discrete Compilation Phase

### DIFF
--- a/cpp/src/Slice/DocCommentParser.cpp
+++ b/cpp/src/Slice/DocCommentParser.cpp
@@ -26,6 +26,8 @@ namespace Slice
         void visitEnum(const EnumPtr& p) final;
         void visitConst(const ConstPtr& p) final;
 
+        bool shouldVisitIncludedDefinitions() const final { return true; }
+
     private:
         void parseDocCommentFor(const ContainedPtr& p);
 

--- a/cpp/src/Slice/DocCommentParser.cpp
+++ b/cpp/src/Slice/DocCommentParser.cpp
@@ -1,0 +1,143 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "DocCommentParser.h"
+
+using namespace std;
+using namespace Slice;
+
+namespace Slice
+{
+    class DocCommentParser final : public ParserVisitor
+    {
+    public:
+        DocCommentParser(DocLinkFormatter linkFormatter) : _linkFormatter(std::move(linkFormatter)) {};
+
+        bool visitModuleStart(const ModulePtr& p) final;
+        void visitClassDecl(const ClassDeclPtr& p) final;
+        bool visitClassDefStart(const ClassDefPtr& p) final;
+        void visitInterfaceDecl(const InterfaceDeclPtr& p) final;
+        bool visitInterfaceDefStart(const InterfaceDefPtr& p) final;
+        bool visitExceptionStart(const ExceptionPtr& p) final;
+        bool visitStructStart(const StructPtr& p) final;
+        void visitOperation(const OperationPtr& p) final;
+        void visitParameter(const ParameterPtr& p) final;
+        void visitDataMember(const DataMemberPtr& p) final;
+        void visitSequence(const SequencePtr& p) final;
+        void visitDictionary(const DictionaryPtr& p) final;
+        void visitEnum(const EnumPtr& p) final;
+        void visitConst(const ConstPtr& p) final;
+
+    private:
+        void parseDocCommentFor(const ContainedPtr& p);
+
+        DocLinkFormatter _linkFormatter;
+    };
+}
+
+void
+Slice::parseAllDocCommentsWithin(const UnitPtr& unit)
+{
+    if (auto linkFormatter = unit->linkFormatter())
+    {
+        DocCommentParser visitor{*linkFormatter};
+        unit->visit(&visitor);
+    }
+}
+
+bool
+DocCommentParser::visitModuleStart(const ModulePtr& p)
+{
+    parseDocCommentFor(p);
+    return true;
+}
+
+void
+DocCommentParser::visitClassDecl(const ClassDeclPtr& p)
+{
+    parseDocCommentFor(p);
+}
+
+bool
+DocCommentParser::visitClassDefStart(const ClassDefPtr& p)
+{
+    parseDocCommentFor(p);
+    return true;
+}
+
+void
+DocCommentParser::visitInterfaceDecl(const InterfaceDeclPtr& p)
+{
+    parseDocCommentFor(p);
+}
+
+bool
+DocCommentParser::visitInterfaceDefStart(const InterfaceDefPtr& p)
+{
+    parseDocCommentFor(p);
+    return true;
+}
+
+bool
+DocCommentParser::visitExceptionStart(const ExceptionPtr& p)
+{
+    parseDocCommentFor(p);
+    return true;
+}
+
+bool
+DocCommentParser::visitStructStart(const StructPtr& p)
+{
+    parseDocCommentFor(p);
+    return true;
+}
+
+void
+DocCommentParser::visitOperation(const OperationPtr& p)
+{
+    parseDocCommentFor(p);
+}
+
+void
+DocCommentParser::visitParameter(const ParameterPtr& p)
+{
+    parseDocCommentFor(p);
+}
+
+void
+DocCommentParser::visitDataMember(const DataMemberPtr& p)
+{
+    parseDocCommentFor(p);
+}
+
+void
+DocCommentParser::visitSequence(const SequencePtr& p)
+{
+    parseDocCommentFor(p);
+}
+
+void
+DocCommentParser::visitDictionary(const DictionaryPtr& p)
+{
+    parseDocCommentFor(p);
+}
+
+void
+DocCommentParser::visitEnum(const EnumPtr& p)
+{
+    parseDocCommentFor(p);
+}
+
+void
+DocCommentParser::visitConst(const ConstPtr& p)
+{
+    parseDocCommentFor(p);
+}
+
+void
+DocCommentParser::parseDocCommentFor(const ContainedPtr& p)
+{
+    if (auto& docComment = p->_docComment)
+    {
+        docComment->parse(p, _linkFormatter);
+    }
+}

--- a/cpp/src/Slice/DocCommentParser.cpp
+++ b/cpp/src/Slice/DocCommentParser.cpp
@@ -36,13 +36,10 @@ namespace Slice
 }
 
 void
-Slice::parseAllDocCommentsWithin(const UnitPtr& unit)
+Slice::parseAllDocCommentsWithin(const UnitPtr& unit, DocLinkFormatter linkFormatter)
 {
-    if (auto linkFormatter = unit->linkFormatter())
-    {
-        DocCommentParser visitor{*linkFormatter};
-        unit->visit(&visitor);
-    }
+    DocCommentParser visitor{std::move(linkFormatter)};
+    unit->visit(&visitor);
 }
 
 bool

--- a/cpp/src/Slice/DocCommentParser.cpp
+++ b/cpp/src/Slice/DocCommentParser.cpp
@@ -20,7 +20,6 @@ namespace Slice
         bool visitExceptionStart(const ExceptionPtr& p) final;
         bool visitStructStart(const StructPtr& p) final;
         void visitOperation(const OperationPtr& p) final;
-        void visitParameter(const ParameterPtr& p) final;
         void visitDataMember(const DataMemberPtr& p) final;
         void visitSequence(const SequencePtr& p) final;
         void visitDictionary(const DictionaryPtr& p) final;
@@ -95,12 +94,10 @@ void
 DocCommentParser::visitOperation(const OperationPtr& p)
 {
     parseDocCommentFor(p);
-}
-
-void
-DocCommentParser::visitParameter(const ParameterPtr& p)
-{
-    parseDocCommentFor(p);
+    for (const auto& param : p->parameters())
+    {
+        parseDocCommentFor(param);
+    }
 }
 
 void
@@ -125,6 +122,10 @@ void
 DocCommentParser::visitEnum(const EnumPtr& p)
 {
     parseDocCommentFor(p);
+    for (const auto& enumerator : p->enumerators())
+    {
+        parseDocCommentFor(enumerator);
+    }
 }
 
 void

--- a/cpp/src/Slice/DocCommentParser.h
+++ b/cpp/src/Slice/DocCommentParser.h
@@ -8,6 +8,6 @@
 namespace Slice
 {
     /// Parses all doc-comments within the provided unit (in-place).
-    void parseAllDocCommentsWithin(const UnitPtr& unit);
+    void parseAllDocCommentsWithin(const UnitPtr& unit, DocLinkFormatter linkFormatter);
 }
 #endif

--- a/cpp/src/Slice/DocCommentParser.h
+++ b/cpp/src/Slice/DocCommentParser.h
@@ -1,0 +1,13 @@
+// Copyright (c) ZeroC, Inc.
+
+#ifndef DOC_COMMENT_PARSER_H
+#define DOC_COMMENT_PARSER_H
+
+#include "Parser.h"
+
+namespace Slice
+{
+    /// Parses all doc-comments within the provided unit (in-place).
+    void parseAllDocCommentsWithin(const UnitPtr& unit);
+}
+#endif

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -5129,6 +5129,7 @@ Slice::Unit::parse(const string& filename, FILE* file, bool debugMode)
         assert(_definitionContextStack.size() == 1);
         popDefinitionContext();
 
+        parseAllDocCommentsWithin(unit());
         emitDeprecationWarningsFor(unit());
     }
 

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -2,6 +2,7 @@
 
 #include "Parser.h"
 #include "DeprecationReporter.h"
+#include "DocCommentParser.h"
 #include "Ice/StringUtil.h"
 #include "Util.h"
 

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -4729,21 +4729,15 @@ Slice::DataMember::DataMember(
 // ----------------------------------------------------------------------
 
 UnitPtr
-Slice::Unit::createUnit(string languageName, std::optional<DocLinkFormatter> linkFormatter, bool all)
+Slice::Unit::createUnit(string languageName, bool all)
 {
-    return make_shared<Unit>(std::move(languageName), linkFormatter, all);
+    return make_shared<Unit>(std::move(languageName), all);
 }
 
 string
 Slice::Unit::languageName() const
 {
     return _languageName;
-}
-
-const optional<DocLinkFormatter>&
-Slice::Unit::linkFormatter() const
-{
-    return _linkFormatter;
 }
 
 void
@@ -5129,7 +5123,6 @@ Slice::Unit::parse(const string& filename, FILE* file, bool debugMode)
         assert(_definitionContextStack.size() == 1);
         popDefinitionContext();
 
-        parseAllDocCommentsWithin(unit());
         emitDeprecationWarningsFor(unit());
     }
 
@@ -5220,9 +5213,8 @@ Slice::Unit::getTopLevelModules(const string& file) const
     }
 }
 
-Slice::Unit::Unit(string languageName, optional<DocLinkFormatter> linkFormatter, bool all)
+Slice::Unit::Unit(string languageName, bool all)
     : _languageName(std::move(languageName)),
-      _linkFormatter(linkFormatter),
       _all(all)
 {
     if (!languageName.empty())

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -407,8 +407,12 @@ namespace
 }
 
 optional<DocComment>
-Slice::DocComment::parseFrom(const ContainedPtr& p, bool escapeXml)
+Slice::DocComment::parseFrom(const ContainedPtr& p)
 {
+    // TODO: this is a temporary hack since only "csharp" happens to set 'escapeXML'.
+    // If true, escapes all XML special characters in the parsed comment. Defaults to false.
+    const bool escapeXML = (p->unit()->languageName() == "cs");
+
     const optional<DocLinkFormatter>& linkFormatter = p->unit()->linkFormatter();
     // Some compilers don't generate doc-comments, and so don't provide a link formatter.
     // But, these compilers should also never be calling `parseFrom` in the first place.

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -259,6 +259,8 @@ namespace Slice
     using DocLinkFormatter =
         std::string (*)(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target);
 
+    class DocCommentParser;
+
     class DocComment final
     {
     public:
@@ -448,6 +450,8 @@ namespace Slice
         [[nodiscard]] virtual std::string kindOf() const = 0;
 
     protected:
+        friend class DocCommentParser;
+
         Contained(const ContainerPtr& container, std::string name);
 
         ContainerPtr _container;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -262,13 +262,18 @@ namespace Slice
     class DocComment final
     {
     public:
-        /// Parses the raw doc-comment attached to `p` into a structured `DocComment`.
-        ///
-        /// @param p The slice element whose doc-comment should be parsed.
-        ///
-        /// @return A `DocComment` instance containing a parsed representation of `p`'s doc-comment, if a doc-comment
-        /// was present. If no doc-comment was present (or it contained only whitespace) this returns `nullopt` instead.
-        [[nodiscard]] static std::optional<DocComment> parseFrom(const ContainedPtr& p);
+        /// TODO
+        [[nodiscard]] static std::optional<DocComment> createUnparsed(std::string rawDocComment);
+
+        /// TODO
+        void parse(const ContainedPtr& p, const DocLinkFormatter& linkFormatter);
+
+        // Parses the raw doc-comment attached to `p` into a structured `DocComment`.
+        //
+        // @param p The slice element whose doc-comment should be parsed.
+        //
+        // @return A `DocComment` instance containing a parsed representation of `p`'s doc-comment, if a doc-comment
+        // was present. If no doc-comment was present (or it contained only whitespace) this returns `nullopt` instead.
 
         [[nodiscard]] bool isDeprecated() const;
         [[nodiscard]] const StringList& deprecated() const;
@@ -288,6 +293,8 @@ namespace Slice
         [[nodiscard]] const std::map<std::string, StringList>& exceptions() const;
 
     private:
+        StringList _rawDocCommentLines;
+
         bool _isDeprecated{false};
         StringList _deprecated;
         StringList _overview;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -246,7 +246,7 @@ namespace Slice
     // DocComment
     // ----------------------------------------------------------------------
 
-    /// Functions of this type are used by `DocComment::parseFrom` to map link tags into each language's link syntax.
+    /// Functions of this type are used to map link tags into each language's link syntax.
     /// In Slice, links are of the form: '{@link <rawLink>}'.
     ///
     /// The first argument (`rawLink`) is the raw link text, taken verbatim from the doc-comment.
@@ -254,8 +254,8 @@ namespace Slice
     /// The third argument (`target`) is a pointer to the Slice element that is being linked to.
     /// If the parser could not resolve the link, this will be `nullptr`.
     ///
-    /// This function should return the fully formatted link.
-    /// `DocComment::parseFrom` replaces the entire '{@link <rawLink>}' by the string this function returns.
+    /// This function should return the fully formatted link, which will replace the entire '{@link <rawLink>}'
+    /// in a raw doc-comment.
     using DocLinkFormatter =
         std::string (*)(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target);
 
@@ -264,18 +264,16 @@ namespace Slice
     class DocComment final
     {
     public:
-        /// TODO
+        /// Returns an unparsed 'DocComment' instance containing the provided string.
+        /// If the provided string is empty or only contains whitespace, this returns 'nullopt' instead.
         [[nodiscard]] static std::optional<DocComment> createUnparsed(std::string rawDocComment);
 
-        /// TODO
+        /// Parses this doc-comment in-place, using the provided formatter to map language-specific elements.
+        /// @param p The Slice element that this doc-comment is applied to.
+        /// @param linkFormatter This function is used to replace '{@link ...}' tags with their corresponding
+        ///                      representation in a target language.
+        /// @remark This function must be called on a doc-comment before it's usable for code-gen purposes.
         void parse(const ContainedPtr& p, const DocLinkFormatter& linkFormatter);
-
-        // Parses the raw doc-comment attached to `p` into a structured `DocComment`.
-        //
-        // @param p The slice element whose doc-comment should be parsed.
-        //
-        // @return A `DocComment` instance containing a parsed representation of `p`'s doc-comment, if a doc-comment
-        // was present. If no doc-comment was present (or it contained only whitespace) this returns `nullopt` instead.
 
         [[nodiscard]] bool isDeprecated() const;
         [[nodiscard]] const StringList& deprecated() const;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -1073,13 +1073,11 @@ namespace Slice
     class Unit final : public Container
     {
     public:
-        static UnitPtr createUnit(std::string languageName, std::optional<DocLinkFormatter> linkFormatter, bool all);
+        static UnitPtr createUnit(std::string languageName, bool all);
 
-        Unit(std::string languageName, std::optional<DocLinkFormatter> linkFormatter, bool all);
+        Unit(std::string languageName, bool all);
 
         [[nodiscard]] std::string languageName() const;
-
-        [[nodiscard]] const std::optional<DocLinkFormatter>& linkFormatter() const;
 
         /// Sets `_currentDocComment` to the provided string, erasing anything currently stored in it.
         /// @param comment The raw comment string. It can span multiple lines and include comment formatting characters
@@ -1151,7 +1149,6 @@ namespace Slice
         void popDefinitionContext();
 
         const std::string _languageName;
-        const std::optional<DocLinkFormatter> _linkFormatter;
         bool _all;
         int _errors{0};
         std::string _currentDocComment;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -265,11 +265,10 @@ namespace Slice
         /// Parses the raw doc-comment attached to `p` into a structured `DocComment`.
         ///
         /// @param p The slice element whose doc-comment should be parsed.
-        /// @param escapeXml If true, escapes all XML special characters in the parsed comment. Defaults to false.
         ///
         /// @return A `DocComment` instance containing a parsed representation of `p`'s doc-comment, if a doc-comment
         /// was present. If no doc-comment was present (or it contained only whitespace) this returns `nullopt` instead.
-        [[nodiscard]] static std::optional<DocComment> parseFrom(const ContainedPtr& p, bool escapeXml = false);
+        [[nodiscard]] static std::optional<DocComment> parseFrom(const ContainedPtr& p);
 
         [[nodiscard]] bool isDeprecated() const;
         [[nodiscard]] const StringList& deprecated() const;
@@ -415,7 +414,7 @@ namespace Slice
         [[nodiscard]] const std::string& file() const;
         [[nodiscard]] int line() const;
 
-        [[nodiscard]] std::string docComment() const;
+        [[nodiscard]] const std::optional<DocComment>& docComment() const;
 
         [[nodiscard]] int includeLevel() const;
         [[nodiscard]] DefinitionContextPtr definitionContext() const;
@@ -448,7 +447,7 @@ namespace Slice
         std::string _name;
         std::string _file;
         int _line;
-        std::string _docComment;
+        std::optional<DocComment> _docComment;
         int _includeLevel;
         DefinitionContextPtr _definitionContext;
         MetadataList _metadata;

--- a/cpp/src/Slice/msbuild/slice.vcxproj
+++ b/cpp/src/Slice/msbuild/slice.vcxproj
@@ -93,6 +93,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\DeprecationReporter.cpp" />
+    <ClCompile Include="..\DocCommentParser.cpp" />
     <ClCompile Include="..\FileTracker.cpp" />
     <ClCompile Include="..\Grammar.cpp" />
     <ClCompile Include="..\MetadataValidation.cpp" />
@@ -104,6 +105,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\DeprecationReporter.h" />
+    <ClInclude Include="..\DocCommentParser.h" />
     <ClInclude Include="..\FileTracker.h" />
     <ClInclude Include="..\Grammar.h" />
     <ClInclude Include="..\GrammarUtil.h" />

--- a/cpp/src/Slice/msbuild/slice.vcxproj.filters
+++ b/cpp/src/Slice/msbuild/slice.vcxproj.filters
@@ -16,6 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\DeprecationReporter.cpp" />
+    <ClCompile Include="..\DocCommentParser.cpp" />
     <ClCompile Include="..\FileTracker.cpp" />
     <ClCompile Include="..\Grammar.cpp" />
     <ClCompile Include="..\MetadataValidation.cpp" />
@@ -27,6 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\DeprecationReporter.h" />
+    <ClCompile Include="..\DocCommentParser.h" />
     <ClInclude Include="..\FileTracker.h" />
     <ClInclude Include="..\Grammar.h" />
     <ClInclude Include="..\GrammarUtil.h" />

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -221,7 +221,7 @@ namespace
 
     void writeDocComment(const ContainedPtr& contained, Output& out)
     {
-        optional<DocComment> comment = DocComment::parseFrom(contained);
+        const optional<DocComment>& comment = contained->docComment();
         if (!comment)
         {
             return;

--- a/cpp/src/ice2slice/Main.cpp
+++ b/cpp/src/ice2slice/Main.cpp
@@ -2,6 +2,7 @@
 
 #include "../Ice/ConsoleUtil.h"
 #include "../Ice/Options.h"
+#include "../Slice/DocCommentParser.h"
 #include "../Slice/FileTracker.h"
 #include "../Slice/Preprocessor.h"
 #include "../Slice/Util.h"
@@ -158,7 +159,7 @@ compile(const vector<string>& argv)
             return EXIT_FAILURE;
         }
 
-        UnitPtr p = Unit::createUnit("", Slice::slice2LinkFormatter, false);
+        UnitPtr p = Unit::createUnit("", false);
         int parseStatus = p->parse(*i, cppHandle, debug);
 
         if (!icecpp->close())
@@ -173,6 +174,8 @@ compile(const vector<string>& argv)
         }
         else
         {
+            parseAllDocCommentsWithin(p, Slice::slice2LinkFormatter);
+
             DefinitionContextPtr dc = p->findDefinitionContext(p->topLevelFile());
             assert(dc);
 

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -266,7 +266,7 @@ namespace
 
     void writeDocSummary(Output& out, const ContainedPtr& p, DocSummaryOptions options = {})
     {
-        optional<DocComment> doc = DocComment::parseFrom(p);
+        const optional<DocComment>& doc = p->docComment();
         if (!doc)
         {
             return;
@@ -1441,7 +1441,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
 
     const string deprecatedAttribute = getDeprecatedAttribute(p);
 
-    optional<DocComment> comment = DocComment::parseFrom(p);
+    const optional<DocComment>& comment = p->docComment();
     const string contextDoc = "@param " + contextParam + " The request context.";
 
     H << sp;
@@ -1889,7 +1889,7 @@ Slice::Gen::DataDefVisitor::visitExceptionStart(const ExceptionPtr& p)
     DataMemberList baseDataMembers;
 
     vector<string> allParameters;
-    map<string, DocComment> allDocComments;
+    map<string, string> allOverviews;
 
     for (const auto& dataMember : allDataMembers)
     {
@@ -1897,9 +1897,9 @@ Slice::Gen::DataDefVisitor::visitExceptionStart(const ExceptionPtr& p)
             typeToString(dataMember->type(), dataMember->optional(), scope, dataMember->getMetadata(), _useWstring);
         allParameters.push_back(typeName + " " + dataMember->mappedName());
 
-        if (auto comment = DocComment::parseFrom(dataMember))
+        if (const auto& comment = dataMember->docComment())
         {
-            allDocComments[dataMember->name()] = std::move(*comment);
+            allOverviews[dataMember->name()] = comment->overview();
         }
     }
 
@@ -1935,11 +1935,11 @@ Slice::Gen::DataDefVisitor::visitExceptionStart(const ExceptionPtr& p)
             H << nl << "/// One-shot constructor to initialize all data members.";
             for (const auto& dataMember : allDataMembers)
             {
-                auto r = allDocComments.find(dataMember->name());
-                if (r != allDocComments.end())
+                auto r = allOverviews.find(dataMember->name());
+                if (r != allOverviews.end())
                 {
                     H << nl << "/// @param " << dataMember->mappedName() << " "
-                      << getFirstSentence(r->second.overview());
+                      << getFirstSentence(r->second);
                 }
             }
             H << nl << name << "(";
@@ -2342,7 +2342,7 @@ Slice::Gen::DataDefVisitor::emitOneShotConstructor(const ClassDefPtr& p)
     if (!allDataMembers.empty())
     {
         vector<string> allParameters;
-        map<string, DocComment> allDocComments;
+        map<string, string> allOverviews;
         DataMemberList dataMembers = p->dataMembers();
 
         for (const auto& dataMember : allDataMembers)
@@ -2350,9 +2350,9 @@ Slice::Gen::DataDefVisitor::emitOneShotConstructor(const ClassDefPtr& p)
             string typeName =
                 typeToString(dataMember->type(), dataMember->optional(), scope, dataMember->getMetadata(), _useWstring);
             allParameters.push_back(typeName + " " + dataMember->mappedName());
-            if (auto comment = DocComment::parseFrom(dataMember))
+            if (const auto& comment = dataMember->docComment())
             {
-                allDocComments[dataMember->name()] = std::move(*comment);
+                allOverviews[dataMember->name()] = comment->docComment();
             }
         }
 
@@ -2360,10 +2360,10 @@ Slice::Gen::DataDefVisitor::emitOneShotConstructor(const ClassDefPtr& p)
         H << nl << "/// One-shot constructor to initialize all data members.";
         for (const auto& dataMember : allDataMembers)
         {
-            auto r = allDocComments.find(dataMember->name());
-            if (r != allDocComments.end())
+            auto r = allOverviews.find(dataMember->name());
+            if (r != allOverviews.end())
             {
-                H << nl << "/// @param " << dataMember->mappedName() << " " << getFirstSentence(r->second.overview());
+                H << nl << "/// @param " << dataMember->mappedName() << " " << getFirstSentence(r->second);
             }
         }
         H << nl;
@@ -2697,7 +2697,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
     const string currentTypeDecl = "const Ice::Current&";
     const string currentDecl = currentTypeDecl + " " + currentParam;
 
-    optional<DocComment> comment = DocComment::parseFrom(p);
+    const optional<DocComment>& comment = p->docComment();
 
     string isConst = p->hasMetadata("cpp:const") ? " const" : "";
     string noDiscard = "";

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1889,7 +1889,7 @@ Slice::Gen::DataDefVisitor::visitExceptionStart(const ExceptionPtr& p)
     DataMemberList baseDataMembers;
 
     vector<string> allParameters;
-    map<string, string> allOverviews;
+    map<string, StringList> allOverviews;
 
     for (const auto& dataMember : allDataMembers)
     {
@@ -2342,7 +2342,7 @@ Slice::Gen::DataDefVisitor::emitOneShotConstructor(const ClassDefPtr& p)
     if (!allDataMembers.empty())
     {
         vector<string> allParameters;
-        map<string, string> allOverviews;
+        map<string, StringList> allOverviews;
         DataMemberList dataMembers = p->dataMembers();
 
         for (const auto& dataMember : allDataMembers)
@@ -2352,7 +2352,7 @@ Slice::Gen::DataDefVisitor::emitOneShotConstructor(const ClassDefPtr& p)
             allParameters.push_back(typeName + " " + dataMember->mappedName());
             if (const auto& comment = dataMember->docComment())
             {
-                allOverviews[dataMember->name()] = comment->docComment();
+                allOverviews[dataMember->name()] = comment->overview();
             }
         }
 

--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -2,6 +2,7 @@
 
 #include "../Ice/ConsoleUtil.h"
 #include "../Ice/Options.h"
+#include "../Slice/DocCommentParser.h"
 #include "../Slice/FileTracker.h"
 #include "../Slice/Preprocessor.h"
 #include "../Slice/Util.h"
@@ -200,7 +201,7 @@ compile(const vector<string>& argv)
                 return EXIT_FAILURE;
             }
 
-            UnitPtr u = Unit::createUnit("cpp", Slice::cppLinkFormatter, false);
+            UnitPtr u = Unit::createUnit("cpp", false);
             int parseStatus = u->parse(*i, cppHandle, debug);
 
             DefinitionContextPtr dc = u->findDefinitionContext(u->topLevelFile());
@@ -239,7 +240,7 @@ compile(const vector<string>& argv)
                 return EXIT_FAILURE;
             }
 
-            UnitPtr u = Unit::createUnit("cpp", Slice::cppLinkFormatter, false);
+            UnitPtr u = Unit::createUnit("cpp", false);
             int parseStatus = u->parse(*i, cppHandle, debug);
 
             if (!icecpp->close())
@@ -254,6 +255,8 @@ compile(const vector<string>& argv)
             }
             else
             {
+                parseAllDocCommentsWithin(u, Slice::cppLinkFormatter);
+
                 try
                 {
                     Gen gen(

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -676,7 +676,7 @@ Slice::CsVisitor::writeDataMemberInitializers(const DataMemberList& dataMembers)
 void
 Slice::CsVisitor::writeDocComment(const ContainedPtr& p, const string& generatedType, const string& notes)
 {
-    optional<DocComment> comment = DocComment::parseFrom(p, true);
+    const optional<DocComment>& comment = p->docComment();
     StringList remarks;
     if (comment)
     {
@@ -736,7 +736,7 @@ Slice::CsVisitor::writeHelperDocComment(
 void
 Slice::CsVisitor::writeOpDocComment(const OperationPtr& op, const vector<string>& extraParams, bool isAsync)
 {
-    optional<DocComment> comment = DocComment::parseFrom(op, true);
+    const optional<DocComment>& comment = op->docComment();
     if (!comment)
     {
         return;

--- a/cpp/src/slice2cs/Main.cpp
+++ b/cpp/src/slice2cs/Main.cpp
@@ -2,6 +2,7 @@
 
 #include "../Ice/ConsoleUtil.h"
 #include "../Ice/Options.h"
+#include "../Slice/DocCommentParser.h"
 #include "../Slice/FileTracker.h"
 #include "../Slice/Preprocessor.h"
 #include "../Slice/Util.h"
@@ -178,7 +179,7 @@ compile(const vector<string>& argv)
                 return EXIT_FAILURE;
             }
 
-            UnitPtr u = Unit::createUnit("cs", Slice::Csharp::csLinkFormatter, false);
+            UnitPtr u = Unit::createUnit("cs", false);
             int parseStatus = u->parse(*i, cppHandle, debug);
             u->destroy();
 
@@ -211,7 +212,7 @@ compile(const vector<string>& argv)
                 return EXIT_FAILURE;
             }
 
-            UnitPtr p = Unit::createUnit("cs", Slice::Csharp::csLinkFormatter, false);
+            UnitPtr p = Unit::createUnit("cs", false);
             int parseStatus = p->parse(*i, cppHandle, debug);
 
             if (!icecpp->close())
@@ -226,6 +227,8 @@ compile(const vector<string>& argv)
             }
             else
             {
+                parseAllDocCommentsWithin(p, Slice::Csharp::csLinkFormatter);
+
                 try
                 {
                     Gen gen(icecpp->getBaseName(), includePaths, output);

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -2266,7 +2266,7 @@ Slice::JavaVisitor::writeHiddenProxyDocComment(Output& out, const OperationPtr& 
 void
 Slice::JavaVisitor::writeServantOpDocComment(Output& out, const OperationPtr& p, const string& package, bool async)
 {
-    optional<DocComment> dc = DocComment::parseFrom(p);
+    const optional<DocComment>& dc = p->docComment();
     if (!dc)
     {
         return;
@@ -2414,7 +2414,7 @@ Slice::JavaVisitor::writeParamDocComments(IceInternal::Output& out, const DataMe
     bool first = true;
     for (const auto& member : members)
     {
-        if (const auto docComment = DocComment::parseFrom(member))
+        if (const auto& docComment = member->docComment())
         {
             if (first)
             {
@@ -2494,7 +2494,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     // Slice interfaces map to Java interfaces.
     out << sp;
-    optional<DocComment> dc = DocComment::parseFrom(p);
+    const optional<DocComment>& dc = p->docComment();
     writeDocComment(out, p->unit(), dc);
     if (dc && dc->isDeprecated())
     {
@@ -2795,7 +2795,7 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 
     out << sp;
 
-    optional<DocComment> dc = DocComment::parseFrom(p);
+    const optional<DocComment>& dc = p->docComment();
     writeDocComment(out, p->unit(), dc);
     if (dc && dc->isDeprecated())
     {
@@ -3049,7 +3049,7 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
     Output& out = output();
     out << sp;
 
-    optional<DocComment> dc = DocComment::parseFrom(p);
+    const optional<DocComment>& dc = p->docComment();
     writeDocComment(out, p->unit(), dc);
     if (dc && dc->isDeprecated())
     {
@@ -3420,7 +3420,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
 
     out << sp;
 
-    optional<DocComment> dc = DocComment::parseFrom(p);
+    const optional<DocComment>& dc = p->docComment();
     writeDocComment(out, p->unit(), dc);
     if (dc && dc->isDeprecated())
     {
@@ -3696,7 +3696,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 
     out << sp;
 
-    optional<DocComment> dc = DocComment::parseFrom(p);
+    const optional<DocComment>& dc = p->docComment();
     writeDocComment(out, p->unit(), dc);
     if (dc && dc->isDeprecated())
     {
@@ -3712,7 +3712,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
         {
             out << ',';
         }
-        optional<DocComment> edc = DocComment::parseFrom(*en);
+        const optional<DocComment>& edc = (*en)->docComment();
         writeDocComment(out, p->unit(), edc);
         if (edc && edc->isDeprecated())
         {
@@ -4203,7 +4203,7 @@ Slice::Gen::TypesVisitor::visitConst(const ConstPtr& p)
 
     out << sp;
 
-    optional<DocComment> dc = DocComment::parseFrom(p);
+    const optional<DocComment>& dc = p->docComment();
     writeDocComment(out, p->unit(), dc);
     if (dc && dc->isDeprecated())
     {
@@ -4231,7 +4231,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     // Generate a Java interface as the user-visible type
     out << sp;
-    optional<DocComment> dc = DocComment::parseFrom(p);
+    const optional<DocComment>& dc = p->docComment();
     writeDocComment(out, p->unit(), dc);
     if (dc && dc->isDeprecated())
     {
@@ -4424,7 +4424,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 
     outi << sp;
     writeHiddenDocComment(outi);
-    optional<DocComment> dc = DocComment::parseFrom(p);
+    const optional<DocComment>& dc = p->docComment();
     if (dc && dc->isDeprecated())
     {
         outi << nl << "@Deprecated";
@@ -4463,7 +4463,7 @@ Slice::Gen::TypesVisitor::visitOperation(const OperationPtr& p)
     const vector<string> params = getParamsProxy(p, package, false);
     const vector<string> paramsOpt = getParamsProxy(p, package, true);
     const bool sendsOptionals = p->sendsOptionals();
-    const optional<DocComment> dc = DocComment::parseFrom(p);
+    const optional<DocComment>& dc = p->docComment();
 
     // Arrange exceptions into most-derived to least-derived order. If we don't
     // do this, a base exception handler can appear before a derived exception
@@ -4520,7 +4520,7 @@ Slice::Gen::ServantVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     Output& out = output();
 
     out << sp;
-    optional<DocComment> dc = DocComment::parseFrom(p);
+    const optional<DocComment>& dc = p->docComment();
     writeDocComment(out, p->unit(), dc);
 
     out << nl << "@com.zeroc.Ice.SliceTypeId(value = \"" << p->scoped() << "\")";
@@ -4833,7 +4833,7 @@ Slice::Gen::ServantVisitor::visitOperation(const OperationPtr& p)
 
     Output& out = output();
 
-    optional<DocComment> dc = DocComment::parseFrom(p);
+    const optional<DocComment>& dc = p->docComment();
 
     // Generate the "Result" type needed by operations that return multiple values.
     if (p->returnsMultipleValues())

--- a/cpp/src/slice2java/Main.cpp
+++ b/cpp/src/slice2java/Main.cpp
@@ -2,6 +2,7 @@
 
 #include "../Ice/ConsoleUtil.h"
 #include "../Ice/Options.h"
+#include "../Slice/DocCommentParser.h"
 #include "../Slice/FileTracker.h"
 #include "../Slice/Preprocessor.h"
 #include "../Slice/Util.h"
@@ -168,7 +169,7 @@ compile(const vector<string>& argv)
                 return EXIT_FAILURE;
             }
 
-            UnitPtr u = Unit::createUnit("java", Slice::Java::javaLinkFormatter, false);
+            UnitPtr u = Unit::createUnit("java", false);
             int parseStatus = u->parse(*i, cppHandle, debug);
             u->destroy();
 
@@ -201,7 +202,7 @@ compile(const vector<string>& argv)
                 break;
             }
 
-            UnitPtr p = Unit::createUnit("java", Slice::Java::javaLinkFormatter, false);
+            UnitPtr p = Unit::createUnit("java", false);
             int parseStatus = p->parse(*i, cppHandle, debug);
 
             if (!icecpp->close())
@@ -218,6 +219,8 @@ compile(const vector<string>& argv)
             }
             else
             {
+                parseAllDocCommentsWithin(p, Slice::Java::javaLinkFormatter);
+
                 try
                 {
                     Gen gen(icecpp->getBaseName(), includePaths, output);

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -369,7 +369,7 @@ void
 Slice::JsVisitor::writeDocCommentFor(const ContainedPtr& p, bool includeRemarks, bool includeDeprecated)
 {
     assert(!dynamic_pointer_cast<Operation>(p));
-    optional<DocComment> comment = DocComment::parseFrom(p);
+    const optional<DocComment>& comment = p->docComment();
     if (!comment && (!includeDeprecated || !p->isDeprecated()))
     {
         // There's nothing to write for this doc-comment.
@@ -2143,7 +2143,7 @@ Slice::Gen::TypeScriptVisitor::visitClassDefStart(const ClassDefPtr& p)
     _out << nl << " * One-shot constructor to initialize all data members.";
     for (const auto& dataMember : allDataMembers)
     {
-        if (auto comment = DocComment::parseFrom(dataMember))
+        if (const auto& comment = dataMember->docComment())
         {
             _out << nl << " * @param " << dataMember->mappedName() << " " << getFirstSentence(comment->overview());
         }
@@ -2195,7 +2195,7 @@ Slice::Gen::TypeScriptVisitor::writeOpDocSummary(Output& out, const OperationPtr
     out << nl << "/**";
 
     map<string, StringList> paramDoc;
-    optional<DocComment> comment = DocComment::parseFrom(op);
+    const optional<DocComment>& comment = op->docComment();
     if (comment)
     {
         const StringList& overview = comment->overview();
@@ -2519,7 +2519,7 @@ Slice::Gen::TypeScriptVisitor::visitExceptionStart(const ExceptionPtr& p)
         _out << nl << " * One-shot constructor to initialize all data members.";
         for (const auto& dataMember : allDataMembers)
         {
-            if (auto comment = DocComment::parseFrom(dataMember))
+            if (const auto& comment = dataMember->docComment())
             {
                 _out << nl << " * @param " << dataMember->mappedName() << " " << getFirstSentence(comment->overview());
             }

--- a/cpp/src/slice2js/Main.cpp
+++ b/cpp/src/slice2js/Main.cpp
@@ -2,6 +2,7 @@
 
 #include "../Ice/ConsoleUtil.h"
 #include "../Ice/Options.h"
+#include "../Slice/DocCommentParser.h"
 #include "../Slice/FileTracker.h"
 #include "../Slice/Preprocessor.h"
 #include "../Slice/Util.h"
@@ -210,7 +211,7 @@ compile(const vector<string>& argv)
 
         if (depend || dependJSON || dependXml)
         {
-            UnitPtr u = Unit::createUnit("js", Slice::JavaScript::jsLinkFormatter, false);
+            UnitPtr u = Unit::createUnit("js", false);
             int parseStatus = u->parse(*i, cppHandle, debug);
             u->destroy();
 
@@ -247,7 +248,7 @@ compile(const vector<string>& argv)
         }
         else
         {
-            UnitPtr p = Unit::createUnit("js", Slice::JavaScript::jsLinkFormatter, false);
+            UnitPtr p = Unit::createUnit("js", false);
             int parseStatus = p->parse(*i, cppHandle, debug);
 
             if (!preprocessor->close())
@@ -262,6 +263,8 @@ compile(const vector<string>& argv)
             }
             else
             {
+                parseAllDocCommentsWithin(p, Slice::JavaScript::jsLinkFormatter);
+
                 DefinitionContextPtr dc = p->findDefinitionContext(p->topLevelFile());
                 assert(dc);
                 try

--- a/cpp/src/slice2matlab/Gen.cpp
+++ b/cpp/src/slice2matlab/Gen.cpp
@@ -426,7 +426,7 @@ namespace
             for (const auto& field : list)
             {
                 out << nl << "%     " << field->mappedName();
-                if (auto fieldDoc = DocComment::parseFrom(field))
+                if (const auto& fieldDoc = field->docComment())
                 {
                     const StringList& fieldOverview = fieldDoc->overview();
                     if (!fieldOverview.empty())
@@ -446,7 +446,7 @@ namespace
         // No space and upper-case, per MATLAB conventions.
         out << nl << "%" << toUpper(name);
 
-        optional<DocComment> doc = DocComment::parseFrom(p);
+        const optional<DocComment>& doc = p->docComment();
         StringList docOverview;
         if (doc)
         {
@@ -492,7 +492,7 @@ namespace
     {
         out << nl << "%" << toUpper(p->mappedName() + (async ? "Async" : ""));
 
-        optional<DocComment> doc = DocComment::parseFrom(p);
+        const optional<DocComment>& doc = p->docComment();
         if (doc)
         {
             StringList docOverview = doc->overview();
@@ -613,7 +613,7 @@ namespace
         const string name = p->mappedName() + "Prx";
         out << nl << "%" << toUpper(name);
 
-        optional<DocComment> doc = DocComment::parseFrom(p);
+        const optional<DocComment>& doc = p->docComment();
         StringList docOverview;
         if (doc)
         {
@@ -657,7 +657,7 @@ namespace
             for (const auto& op : ops)
             {
                 const string opName = op->mappedName();
-                const optional<DocComment> opdoc = DocComment::parseFrom(op);
+                const optional<DocComment>& opdoc = op->docComment();
                 out << nl << "%     " << opName;
                 if (opdoc)
                 {
@@ -883,7 +883,7 @@ namespace
 
     void documentProperty(IceInternal::Output& out, const DataMemberPtr& field)
     {
-        optional<DocComment> doc = DocComment::parseFrom(field);
+        const optional<DocComment>& doc = field->docComment();
         documentArgumentOrProperty(
             out,
             toUpper(field->mappedName()),

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -3,6 +3,7 @@
 #include "../Ice/ConsoleUtil.h"
 #include "../Ice/FileUtil.h"
 #include "../Ice/Options.h"
+#include "../Slice/DocCommentParser.h"
 #include "../Slice/FileTracker.h"
 #include "../Slice/MetadataValidation.h"
 #include "../Slice/Preprocessor.h"
@@ -211,7 +212,7 @@ namespace
                     return EXIT_FAILURE;
                 }
 
-                UnitPtr u = Unit::createUnit("matlab", Slice::matlabLinkFormatter, false);
+                UnitPtr u = Unit::createUnit("matlab", false);
                 int parseStatus = u->parse(*i, cppHandle, debug);
                 u->destroy();
 
@@ -242,7 +243,7 @@ namespace
                     return EXIT_FAILURE;
                 }
 
-                UnitPtr u = Unit::createUnit("matlab", Slice::matlabLinkFormatter, all);
+                UnitPtr u = Unit::createUnit("matlab", all);
                 int parseStatus = u->parse(*i, cppHandle, debug);
 
                 if (!icecpp->close())
@@ -257,6 +258,8 @@ namespace
                 }
                 else
                 {
+                    parseAllDocCommentsWithin(u, Slice::matlabLinkFormatter);
+
                     string base = icecpp->getBaseName();
                     string::size_type pos = base.find_last_of("/\\");
                     if (pos != string::npos)

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -1287,7 +1287,7 @@ compile(const vector<string>& argv)
                 return EXIT_FAILURE;
             }
 
-            UnitPtr u = Unit::createUnit("php", nullopt, false);
+            UnitPtr u = Unit::createUnit("php", false);
             int parseStatus = u->parse(*i, cppHandle, debug);
             u->destroy();
 
@@ -1320,7 +1320,7 @@ compile(const vector<string>& argv)
                 return EXIT_FAILURE;
             }
 
-            UnitPtr u = Unit::createUnit("php", nullopt, all);
+            UnitPtr u = Unit::createUnit("php", all);
             int parseStatus = u->parse(*i, cppHandle, debug);
 
             if (!icecpp->close())

--- a/cpp/src/slice2py/Python.cpp
+++ b/cpp/src/slice2py/Python.cpp
@@ -3,6 +3,7 @@
 #include "../Ice/ConsoleUtil.h"
 #include "../Ice/FileUtil.h"
 #include "../Ice/Options.h"
+#include "../Slice/DocCommentParser.h"
 #include "../Slice/FileTracker.h"
 #include "../Slice/Preprocessor.h"
 #include "../Slice/Util.h"
@@ -239,7 +240,7 @@ Slice::Python::staticCompile(const vector<string>& argv)
             return EXIT_FAILURE;
         }
 
-        UnitPtr unit = Unit::createUnit("python", pyLinkFormatter, false);
+        UnitPtr unit = Unit::createUnit("python", false);
         int parseStatus = unit->parse(fileName, cppHandle, debug);
 
         if (parseStatus == EXIT_FAILURE)
@@ -262,6 +263,8 @@ Slice::Python::staticCompile(const vector<string>& argv)
         }
         else
         {
+            parseAllDocCommentsWithin(unit, Slice::Python::pyLinkFormatter);
+
             try
             {
                 if (buildArg == "modules" || buildArg == "all")

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2,6 +2,7 @@
 
 #include "PythonUtil.h"
 #include "../Ice/FileUtil.h"
+#include "../Slice/DocCommentParser.h"
 #include "../Slice/FileTracker.h"
 #include "../Slice/MetadataValidation.h"
 #include "../Slice/Preprocessor.h"
@@ -2494,7 +2495,7 @@ Slice::Python::dynamicCompile(const vector<string>& files, const vector<string>&
             throw runtime_error("Failed to preprocess Slice files");
         }
 
-        UnitPtr unit = Unit::createUnit("python", Slice::Python::pyLinkFormatter, debug);
+        UnitPtr unit = Unit::createUnit("python", debug);
         int parseStatus = unit->parse(fileName, cppHandle, false);
 
         if (parseStatus == EXIT_FAILURE)
@@ -2503,6 +2504,7 @@ Slice::Python::dynamicCompile(const vector<string>& files, const vector<string>&
             throw runtime_error("Failed to parse Slice files");
         }
 
+        parseAllDocCommentsWithin(unit, Slice::Python::pyLinkFormatter);
         validatePythonMetadata(unit);
 
         unit->visit(&packageVisitor);

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1027,7 +1027,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     out << nl << "class " << valueName << '(' << (base ? getImportAlias(base) : "Ice_Value") << "):";
     out.inc();
 
-    writeDocstring(DocComment::parseFrom(p), members, out);
+    writeDocstring(p->docComment(), members, out);
 
     // __init__
     out << nl << "def __init__(";
@@ -1537,7 +1537,7 @@ Slice::Python::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     out << nl << "class " << name << '(' << (base ? getImportAlias(base) : "Ice_UserException") << "):";
     out.inc();
 
-    writeDocstring(DocComment::parseFrom(p), members, out);
+    writeDocstring(p->docComment(), members, out);
 
     // __init__
     out << nl << "def __init__(";
@@ -1621,7 +1621,7 @@ Slice::Python::CodeVisitor::visitStructStart(const StructPtr& p)
     out << nl << "class " << name << ":";
     out.inc();
 
-    writeDocstring(DocComment::parseFrom(p), members, out);
+    writeDocstring(p->docComment(), members, out);
 
     for (const auto& field : members)
     {
@@ -1714,7 +1714,7 @@ Slice::Python::CodeVisitor::visitEnum(const EnumPtr& p)
     out << nl << "class " << name << "(Enum):";
     out.inc();
 
-    writeDocstring(DocComment::parseFrom(p), p, out);
+    writeDocstring(p->docComment(), p, out);
 
     out << nl;
     for (const auto& enumerator : enumerators)
@@ -2051,7 +2051,7 @@ Slice::Python::CodeVisitor::writeDocstring(
     map<string, list<string>> docs;
     for (const auto& member : members)
     {
-        if (auto memberDoc = DocComment::parseFrom(member))
+        if (const auto& memberDoc = member->docComment())
         {
             const StringList& memberOverview = memberDoc->overview();
             if (!memberOverview.empty())
@@ -2121,7 +2121,7 @@ Slice::Python::CodeVisitor::writeDocstring(const optional<DocComment>& comment, 
     map<string, list<string>> docs;
     for (const auto& enumerator : enumerators)
     {
-        if (auto enumeratorDoc = DocComment::parseFrom(enumerator))
+        if (const auto& enumeratorDoc = enumerator->docComment())
         {
             const StringList& enumeratorOverview = enumeratorDoc->overview();
             if (!enumeratorOverview.empty())
@@ -2176,7 +2176,7 @@ Slice::Python::CodeVisitor::writeDocstring(const optional<DocComment>& comment, 
 void
 Slice::Python::CodeVisitor::writeDocstring(const OperationPtr& op, MethodKind methodKind, Output& out)
 {
-    optional<DocComment> comment = DocComment::parseFrom(op);
+    const optional<DocComment>& comment = op->docComment();
     if (!comment)
     {
         return;

--- a/cpp/src/slice2rb/Ruby.cpp
+++ b/cpp/src/slice2rb/Ruby.cpp
@@ -167,7 +167,7 @@ Slice::Ruby::compile(const vector<string>& argv)
                 return EXIT_FAILURE;
             }
 
-            UnitPtr u = Unit::createUnit("ruby", nullopt, false);
+            UnitPtr u = Unit::createUnit("ruby", false);
             int parseStatus = u->parse(*i, cppHandle, debug);
             u->destroy();
 
@@ -200,7 +200,7 @@ Slice::Ruby::compile(const vector<string>& argv)
                 return EXIT_FAILURE;
             }
 
-            UnitPtr u = Unit::createUnit("ruby", nullopt, all);
+            UnitPtr u = Unit::createUnit("ruby", all);
             int parseStatus = u->parse(*i, cppHandle, debug);
 
             if (!icecpp->close())

--- a/cpp/src/slice2swift/Main.cpp
+++ b/cpp/src/slice2swift/Main.cpp
@@ -2,6 +2,7 @@
 
 #include "../Ice/ConsoleUtil.h"
 #include "../Ice/Options.h"
+#include "../Slice/DocCommentParser.h"
 #include "../Slice/FileTracker.h"
 #include "../Slice/Parser.h"
 #include "../Slice/Preprocessor.h"
@@ -181,7 +182,7 @@ compile(const vector<string>& argv)
                 return EXIT_FAILURE;
             }
 
-            UnitPtr u = Unit::createUnit("swift", Slice::Swift::swiftLinkFormatter, false);
+            UnitPtr u = Unit::createUnit("swift", false);
             int parseStatus = u->parse(*i, cppHandle, debug);
             u->destroy();
 
@@ -214,7 +215,7 @@ compile(const vector<string>& argv)
                 return EXIT_FAILURE;
             }
 
-            UnitPtr u = Unit::createUnit("swift", Slice::Swift::swiftLinkFormatter, false);
+            UnitPtr u = Unit::createUnit("swift", false);
             int parseStatus = u->parse(*i, cppHandle, debug);
 
             if (!icecpp->close())
@@ -229,6 +230,8 @@ compile(const vector<string>& argv)
             }
             else
             {
+                parseAllDocCommentsWithin(u, Slice::Swift::swiftLinkFormatter);
+
                 string base = icecpp->getBaseName();
                 string::size_type pos = base.find_last_of("/\\");
                 if (pos != string::npos)

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -89,7 +89,7 @@ Slice::Swift::getSwiftModule(const ModulePtr& module)
 void
 Slice::Swift::writeDocSummary(IceInternal::Output& out, const ContainedPtr& p)
 {
-    optional<DocComment> doc = DocComment::parseFrom(p);
+    const optional<DocComment>& doc = p->docComment();
     if (!doc)
     {
         return;
@@ -123,7 +123,7 @@ Slice::Swift::writeDocSummary(IceInternal::Output& out, const ContainedPtr& p)
 void
 Slice::Swift::writeOpDocSummary(IceInternal::Output& out, const OperationPtr& p, bool dispatch)
 {
-    optional<DocComment> doc = DocComment::parseFrom(p);
+    const optional<DocComment>& doc = p->docComment();
     if (!doc)
     {
         return;
@@ -267,7 +267,7 @@ Slice::Swift::writeOpDocSummary(IceInternal::Output& out, const OperationPtr& p,
 void
 Slice::Swift::writeProxyDocSummary(IceInternal::Output& out, const InterfaceDefPtr& p, const string& swiftModule)
 {
-    optional<DocComment> doc = DocComment::parseFrom(p);
+    const optional<DocComment>& doc = p->docComment();
     if (!doc)
     {
         return;
@@ -292,7 +292,7 @@ Slice::Swift::writeProxyDocSummary(IceInternal::Output& out, const InterfaceDefP
         out << nl << "/// " << prx << " Methods:";
         for (const auto& op : ops)
         {
-            optional<DocComment> opdoc = DocComment::parseFrom(op);
+            const optional<DocComment>& opdoc = op->docComment();
             optional<StringList> opDocOverview;
             if (opdoc)
             {
@@ -323,7 +323,7 @@ Slice::Swift::writeProxyDocSummary(IceInternal::Output& out, const InterfaceDefP
 void
 Slice::Swift::writeServantDocSummary(IceInternal::Output& out, const InterfaceDefPtr& p, const string& swiftModule)
 {
-    optional<DocComment> doc = DocComment::parseFrom(p);
+    const optional<DocComment>& doc = p->docComment();
     if (!doc)
     {
         return;
@@ -349,7 +349,7 @@ Slice::Swift::writeServantDocSummary(IceInternal::Output& out, const InterfaceDe
         for (const auto& op : ops)
         {
             out << nl << "///  - " << removeEscaping(op->mappedName());
-            optional<DocComment> opdoc = DocComment::parseFrom(op);
+            const optional<DocComment>& opdoc = op->docComment();
             if (opdoc)
             {
                 const StringList& opdocOverview = opdoc->overview();

--- a/python/modules/IcePy/msbuild/icepy.vcxproj
+++ b/python/modules/IcePy/msbuild/icepy.vcxproj
@@ -22,6 +22,7 @@
     <ClCompile Include="..\..\..\..\cpp\src\slice2py\Python.cpp" />
     <ClCompile Include="..\..\..\..\cpp\src\slice2py\PythonUtil.cpp" />
     <ClCompile Include="..\..\..\..\cpp\src\Slice\DeprecationReporter.cpp" />
+    <ClCompile Include="..\..\..\..\cpp\src\Slice\DocCommentParser.cpp" />
     <ClCompile Include="..\..\..\..\cpp\src\Slice\FileTracker.cpp" />
     <ClCompile Include="..\..\..\..\cpp\src\Slice\Grammar.cpp" />
     <ClCompile Include="..\..\..\..\cpp\src\Slice\MetadataValidation.cpp" />

--- a/python/modules/IcePy/msbuild/icepy.vcxproj.filters
+++ b/python/modules/IcePy/msbuild/icepy.vcxproj.filters
@@ -75,6 +75,9 @@
     <ClCompile Include="..\..\..\..\cpp\src\Slice\DeprecationReporter.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\cpp\src\Slice\DocCommentParser.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\cpp\src\Slice\FileTracker.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/ruby/src/IceRuby/Slice.cpp
+++ b/ruby/src/IceRuby/Slice.cpp
@@ -114,7 +114,7 @@ IceRuby_loadSlice(int argc, VALUE* argv, VALUE /*self*/)
                 throw RubyException(rb_eArgError, "Slice preprocessing failed for `%s'", cmd.c_str());
             }
 
-            UnitPtr u = Unit::createUnit("ruby", nullopt, all);
+            UnitPtr u = Unit::createUnit("ruby", all);
             int parseStatus = u->parse(file, cppHandle, debug);
 
             if (!icecpp->close() || parseStatus == EXIT_FAILURE)


### PR DESCRIPTION
This PR implements #3853.

Currently, we parse doc-comments on-demand, scattered throughout the code-gen.

Now, we perform all the parsing in a single, discrete phase.
When the Slice parser runs, it stores any doc-comments it sees as a raw `StringList`.
Then later on, each compiler will call `parseDocCommentsWithin` to parse those raw doc-comments in place.

Compilers that don't care about doc-comments (php and ruby) simply don't call this function.