### PR TITLE
Add support to run Python tests with dynamic generated code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
             config: "release"
             # We want to test C++ and Swift only (in each direction)
             cross_test_flags: "--all-cross --filter cpp --filter swift"
+            python_tests: true
           - os: ubuntu-24.04
             config: "release"
             cross_test_flags: "--all-cross"
@@ -32,22 +33,26 @@ jobs:
             config: "release"
             build_flags: "SKIP=csharp" # Skip C# on ARM as .NET compiler keeps crashing
             test_flags: "--rfilter=java/Ice/udp --rfilter=csharp" # Remove rfilter once https://github.com/zeroc-ice/ice/issues/3389 is fixed
+            python_tests: true
           - os: windows-2022
             config: "release"
             build_flags: "/p:Platform=x64"
             test_flags: "--platform=x64"
+            python_tests: true
           - os: windows-2022
             config: "cpp-win32-release"
             working_directory: "cpp"
             build_flags: "/p:Platform=Win32"
             msbuild_project: "msbuild/ice.proj"
             test_flags: "--platform=Win32"
+            python_tests: true
 
           # Debug builds
           - os: macos-15
             config: "debug"
             build_flags: "OPTIMIZE=no"
             test_flags: "--swift-config=debug --csharp-config=Debug"
+            python_tests: true
           - os: ubuntu-24.04
             config: "debug"
             build_flags: "OPTIMIZE=no"
@@ -59,6 +64,7 @@ jobs:
             build_flags: "/p:Platform=x64 /p:Configuration=Debug"
             test_flags: "--platform=x64 --config=Debug"
             msbuild_project: "msbuild/ice.proj"
+            python_tests: true
 
           # iOS
           - os: macos-15
@@ -181,6 +187,22 @@ jobs:
           working_directory: ${{ matrix.working_directory || '.' }}
           flags: ${{ matrix.cross_test_flags }}
         if: matrix.cross_test_flags != ''
+
+      - name: Remove Python tests generated
+        run: |
+          # Remove generated files from previous runs before to test with loadSlice
+          # to ensure we use the dynamically generated code.
+          find python/test -name generated -exec rm -rf {} +
+        shell: bash
+        if: matrix.python_tests == 'true'
+
+      - name: Python loadSlice Test ${{ matrix.config }} on ${{ matrix.os }}
+        uses: ./.github/actions/test
+        timeout-minutes: 45
+        with:
+          working_directory: ${{ matrix.working_directory || '.' }}
+          flags: "${{ matrix.test_flags }} --load-slice"
+        if: matrix.python_tests == 'true'
 
       - name: Generate API Reference
         uses: ./.github/actions/documentation

--- a/cpp/src/slice2py/PythonUtil.h
+++ b/cpp/src/slice2py/PythonUtil.h
@@ -149,7 +149,7 @@ namespace Slice::Python
     // Get a list of all definitions exported for the Python module corresponding to the given Slice definition.
     std::vector<std::string> getAll(const ContainedPtr& definition);
 
-    // A helper class to initialize the _outBuffer member of BufferedOutput before is passed toe the Output
+    // A helper class to initialize the _outBuffer member of BufferedOutput before is passed to the Output
     // constructor.
     class BufferedOutputBase
     {

--- a/python/modules/IcePy/Slice.cpp
+++ b/python/modules/IcePy/Slice.cpp
@@ -114,6 +114,7 @@ IcePy_loadSlice(PyObject* /*self*/, PyObject* args)
         // The file name is set to the Slice file the code was generated from, or to the package index file name for
         // package index fragments.
         string inputFile = fragment.isPackageIndex ? fragment.fileName : fragment.sliceFileName;
+
         PyObjectHandle code{Py_CompileString(fragment.code.c_str(), inputFile.c_str(), Py_file_input)};
         if (!code)
         {
@@ -146,6 +147,9 @@ IcePy_loadSlice(PyObject* /*self*/, PyObject* args)
                 PyDict_SetItemString(parentDict, childName.c_str(), moduleRef);
             }
         }
+
+        PyObject* builtins = PyEval_GetBuiltins();
+        PyDict_SetItemString(moduleDict, "__builtins__", builtins);
 
         PyObjectHandle result{PyEval_EvalCode(code.get(), moduleDict, moduleDict)};
         if (!result)

--- a/python/modules/IcePy/Util.cpp
+++ b/python/modules/IcePy/Util.cpp
@@ -565,12 +565,11 @@ IcePy::lookupType(const string& typeName)
     PyObject* dict{nullptr};
     if (!module)
     {
-        //
         // Not found, so we need to import the module.
-        //
         PyObjectHandle h{PyImport_ImportModule(const_cast<char*>(moduleName.c_str()))};
         if (!h.get())
         {
+            PyErr_Print(); // Print full Python exception and traceback
             return nullptr;
         }
 

--- a/python/python/Ice/__init__.py
+++ b/python/python/Ice/__init__.py
@@ -45,6 +45,7 @@ from .Communicator import Communicator
 from .CompressBatch import CompressBatch
 from .Context import _Ice_Context_t
 from .Current import Current
+from .Dispatch import dispatch
 from .DoubleSeq import _Ice_DoubleSeq_t
 from .EncodingVersion import EncodingVersion, _Ice_EncodingVersion_t
 from .EndpointSelectionType import EndpointSelectionType
@@ -337,6 +338,7 @@ __all__ = [
     "currentEncoding",
     "currentProtocol",
     "currentProtocolEncoding",
+    "dispatch",
     "encodingVersionToString",
     "format_fields",
     "getProcessLogger",

--- a/python/test/Glacier2/router/Client.py
+++ b/python/test/Glacier2/router/Client.py
@@ -6,8 +6,12 @@ import sys
 import threading
 from typing import Any
 
-from generated.test.Glacier2.router import Test
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Callback.ice")
+
+from generated.test.Glacier2.router import Test
 
 import Glacier2
 import Ice

--- a/python/test/Glacier2/router/Server.py
+++ b/python/test/Glacier2/router/Server.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-from generated.test.Glacier2.router import Test
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Callback.ice")
+
+from generated.test.Glacier2.router import Test
 
 import Ice
 

--- a/python/test/Ice/adapterDeactivation/Client.py
+++ b/python/test/Ice/adapterDeactivation/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 

--- a/python/test/Ice/adapterDeactivation/Collocated.py
+++ b/python/test/Ice/adapterDeactivation/Collocated.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import TestI
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+import TestI
 
 import AllTests
 

--- a/python/test/Ice/adapterDeactivation/Server.py
+++ b/python/test/Ice/adapterDeactivation/Server.py
@@ -1,7 +1,14 @@
 # Copyright (c) ZeroC, Inc.
 
-import TestI
+
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+import TestI
 
 
 class Server(TestHelper):

--- a/python/test/Ice/admin/Client.py
+++ b/python/test/Ice/admin/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 

--- a/python/test/Ice/admin/Server.py
+++ b/python/test/Ice/admin/Server.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import TestI
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+import TestI
 
 import Ice
 

--- a/python/test/Ice/ami/Client.py
+++ b/python/test/Ice/ami/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 

--- a/python/test/Ice/ami/Collocated.py
+++ b/python/test/Ice/ami/Collocated.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import TestI
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+import TestI
 
 import AllTests
 import Ice

--- a/python/test/Ice/ami/Server.py
+++ b/python/test/Ice/ami/Server.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import TestI
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+import TestI
 
 import Ice
 

--- a/python/test/Ice/asyncio/Client.py
+++ b/python/test/Ice/asyncio/Client.py
@@ -3,8 +3,12 @@
 # Copyright (c) ZeroC, Inc.
 
 import asyncio
+import sys
 
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 import Ice

--- a/python/test/Ice/asyncio/Server.py
+++ b/python/test/Ice/asyncio/Server.py
@@ -3,9 +3,14 @@
 # Copyright (c) ZeroC, Inc.
 
 import asyncio
+import sys
+
+from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import TestI
-from TestHelper import TestHelper
 
 import Ice
 

--- a/python/test/Ice/blobject/Client.py
+++ b/python/test/Ice/blobject/Client.py
@@ -4,9 +4,13 @@
 
 import sys
 
+from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
 import RouterI
 from generated.test.Ice.blobject import Test
-from TestHelper import TestHelper
 
 import Ice
 

--- a/python/test/Ice/blobject/Server.py
+++ b/python/test/Ice/blobject/Server.py
@@ -2,10 +2,15 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
 import time
 
-from generated.test.Ice.blobject import Test
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+from generated.test.Ice.blobject import Test
 
 import Ice
 

--- a/python/test/Ice/current/Client.py
+++ b/python/test/Ice/current/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 

--- a/python/test/Ice/current/Collocated.py
+++ b/python/test/Ice/current/Collocated.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import TestI
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+import TestI
 
 import AllTests
 import Ice

--- a/python/test/Ice/current/Server.py
+++ b/python/test/Ice/current/Server.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import TestI
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+import TestI
 
 import Ice
 

--- a/python/test/Ice/custom/AllTests.py
+++ b/python/test/Ice/custom/AllTests.py
@@ -3,6 +3,11 @@
 import array
 import sys
 
+from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
 try:
     import numpy
 
@@ -14,6 +19,10 @@ except ImportError:
 from generated.test.Ice.custom import Test
 
 if hasNumPy:
+
+    if "--load-slice" in sys.argv:
+        TestHelper.loadSlice("TestNumPy.ice")
+
     from generated.test.Ice.custom.Test import NumPy
 
 

--- a/python/test/Ice/custom/Server.py
+++ b/python/test/Ice/custom/Server.py
@@ -2,7 +2,7 @@
 
 # Copyright (c) ZeroC, Inc.
 
-from TestHelper import TestHelper
+import sys
 
 try:
     import numpy
@@ -12,9 +12,17 @@ except ImportError:
     hasNumPy = False
     pass
 
+from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
 from generated.test.Ice.custom import Test
 
 if hasNumPy:
+    if "--load-slice" in sys.argv:
+        TestHelper.loadSlice("TestNumPy.ice")
+
     from generated.test.Ice.custom.Test import NumPy
 import array
 

--- a/python/test/Ice/defaultServant/Client.py
+++ b/python/test/Ice/defaultServant/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 

--- a/python/test/Ice/defaultValue/Client.py
+++ b/python/test/Ice/defaultValue/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 

--- a/python/test/Ice/enums/Client.py
+++ b/python/test/Ice/enums/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 

--- a/python/test/Ice/enums/Server.py
+++ b/python/test/Ice/enums/Server.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-from generated.test.Ice.enums import Test
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+from generated.test.Ice.enums import Test
 
 import Ice
 

--- a/python/test/Ice/exceptions/Client.py
+++ b/python/test/Ice/exceptions/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 

--- a/python/test/Ice/exceptions/Collocated.py
+++ b/python/test/Ice/exceptions/Collocated.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import TestI
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+import TestI
 
 import AllTests
 import Ice

--- a/python/test/Ice/exceptions/Server.py
+++ b/python/test/Ice/exceptions/Server.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import TestI
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+import TestI
 
 import Ice
 

--- a/python/test/Ice/exceptions/ServerAMD.py
+++ b/python/test/Ice/exceptions/ServerAMD.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-from generated.test.Ice.exceptions import Test
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+from generated.test.Ice.exceptions import Test
 
 import Ice
 

--- a/python/test/Ice/executor/Client.py
+++ b/python/test/Ice/executor/Client.py
@@ -2,8 +2,13 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 import Executor
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 import Ice

--- a/python/test/Ice/executor/Server.py
+++ b/python/test/Ice/executor/Server.py
@@ -2,9 +2,15 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 import Executor
-import TestI
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+import TestI
 
 import Ice
 

--- a/python/test/Ice/facets/Client.py
+++ b/python/test/Ice/facets/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 

--- a/python/test/Ice/facets/Collocated.py
+++ b/python/test/Ice/facets/Collocated.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import TestI
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+import TestI
 
 import AllTests
 import Ice

--- a/python/test/Ice/facets/Server.py
+++ b/python/test/Ice/facets/Server.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import TestI
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+import TestI
 
 import Ice
 

--- a/python/test/Ice/faultTolerance/Client.py
+++ b/python/test/Ice/faultTolerance/Client.py
@@ -2,8 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
 
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 

--- a/python/test/Ice/faultTolerance/Server.py
+++ b/python/test/Ice/faultTolerance/Server.py
@@ -3,9 +3,14 @@
 # Copyright (c) ZeroC, Inc.
 
 import os
+import sys
+
+from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 from generated.test.Ice.faultTolerance import Test
-from TestHelper import TestHelper
 
 import Ice
 

--- a/python/test/Ice/info/Client.py
+++ b/python/test/Ice/info/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 

--- a/python/test/Ice/info/Server.py
+++ b/python/test/Ice/info/Server.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import TestI
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+import TestI
 
 import Ice
 

--- a/python/test/Ice/inheritance/Client.py
+++ b/python/test/Ice/inheritance/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 

--- a/python/test/Ice/inheritance/Collocated.py
+++ b/python/test/Ice/inheritance/Collocated.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import TestI
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+import TestI
 
 import AllTests
 import Ice

--- a/python/test/Ice/inheritance/Server.py
+++ b/python/test/Ice/inheritance/Server.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import TestI
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+import TestI
 
 import Ice
 

--- a/python/test/Ice/location/Client.py
+++ b/python/test/Ice/location/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 

--- a/python/test/Ice/location/Server.py
+++ b/python/test/Ice/location/Server.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-from generated.test.Ice.location import Test
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+from generated.test.Ice.location import Test
 
 import Ice
 

--- a/python/test/Ice/objects/Client.py
+++ b/python/test/Ice/objects/Client.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import TestI
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("-I. Test.ice Forward.ice ClientPrivate.ice")
+
+from Objects import customSliceLoader
 
 import AllTests
 import Ice
@@ -13,7 +19,7 @@ class Client(TestHelper):
     def run(self, args):
         initData = Ice.InitializationData()
         initData.properties = self.createTestProperties(args)
-        initData.sliceLoader = TestI.customSliceLoader
+        initData.sliceLoader = customSliceLoader
         with self.initialize(initData=initData) as communicator:
             initial = AllTests.allTests(self, communicator)
             initial.shutdown()

--- a/python/test/Ice/objects/Collocated.py
+++ b/python/test/Ice/objects/Collocated.py
@@ -2,8 +2,15 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import TestI
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("-I. Test.ice Forward.ice ClientPrivate.ice ServerPrivate.ice")
+
+import TestI
+from Objects import customSliceLoader
 
 import AllTests
 import Ice
@@ -14,7 +21,7 @@ class Collocated(TestHelper):
         initData = Ice.InitializationData()
         initData.properties = self.createTestProperties(args)
         initData.properties.setProperty("Ice.Warn.Dispatch", "0")
-        initData.sliceLoader = TestI.customSliceLoader
+        initData.sliceLoader = customSliceLoader
         with self.initialize(initData=initData) as communicator:
             communicator.getProperties().setProperty("TestAdapter.Endpoints", self.getTestEndpoint())
             adapter = communicator.createObjectAdapter("TestAdapter")

--- a/python/test/Ice/objects/Objects.py
+++ b/python/test/Ice/objects/Objects.py
@@ -1,0 +1,51 @@
+# Copyright (c) ZeroC, Inc.
+
+from generated.test.Ice.objects import Test
+
+
+class BI(Test.B):
+    def __init__(self):
+        self.preMarshalInvoked = False
+        self.postUnmarshalInvoked = False
+
+    def ice_preMarshal(self):
+        self.preMarshalInvoked = True
+
+    def ice_postUnmarshal(self):
+        self.postUnmarshalInvoked = True
+
+
+class CI(Test.C):
+    def __init__(self):
+        self.preMarshalInvoked = False
+        self.postUnmarshalInvoked = False
+
+    def ice_preMarshal(self):
+        self.preMarshalInvoked = True
+
+    def ice_postUnmarshal(self):
+        self.postUnmarshalInvoked = True
+
+
+class DI(Test.D):
+    def __init__(self):
+        self.preMarshalInvoked = False
+        self.postUnmarshalInvoked = False
+
+    def ice_preMarshal(self):
+        self.preMarshalInvoked = True
+
+    def ice_postUnmarshal(self):
+        self.postUnmarshalInvoked = True
+
+
+def customSliceLoader(typeId):
+    match typeId:
+        case "::Test::B":
+            return BI()
+        case "::Test::C":
+            return CI()
+        case "::Test::D":
+            return DI()
+        case _:
+            return None

--- a/python/test/Ice/objects/Server.py
+++ b/python/test/Ice/objects/Server.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import TestI
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("-I. Test.ice Forward.ice ServerPrivate.ice")
+
+import TestI
 
 import Ice
 

--- a/python/test/Ice/objects/TestI.py
+++ b/python/test/Ice/objects/TestI.py
@@ -2,56 +2,9 @@
 
 from generated.test.Ice.objects import Test
 from generated.test.Ice.objects.server_private.Test import UnexpectedObjectExceptionTest
+from Objects import BI, CI, DI
 
 import Ice
-
-
-class BI(Test.B):
-    def __init__(self):
-        self.preMarshalInvoked = False
-        self.postUnmarshalInvoked = False
-
-    def ice_preMarshal(self):
-        self.preMarshalInvoked = True
-
-    def ice_postUnmarshal(self):
-        self.postUnmarshalInvoked = True
-
-
-class CI(Test.C):
-    def __init__(self):
-        self.preMarshalInvoked = False
-        self.postUnmarshalInvoked = False
-
-    def ice_preMarshal(self):
-        self.preMarshalInvoked = True
-
-    def ice_postUnmarshal(self):
-        self.postUnmarshalInvoked = True
-
-
-class DI(Test.D):
-    def __init__(self):
-        self.preMarshalInvoked = False
-        self.postUnmarshalInvoked = False
-
-    def ice_preMarshal(self):
-        self.preMarshalInvoked = True
-
-    def ice_postUnmarshal(self):
-        self.postUnmarshalInvoked = True
-
-
-def customSliceLoader(typeId):
-    match typeId:
-        case "::Test::B":
-            return BI()
-        case "::Test::C":
-            return CI()
-        case "::Test::D":
-            return DI()
-        case _:
-            return None
 
 
 class InitialI(Test.Initial):

--- a/python/test/Ice/operations/Client.py
+++ b/python/test/Ice/operations/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 

--- a/python/test/Ice/operations/Collocated.py
+++ b/python/test/Ice/operations/Collocated.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import TestI
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+import TestI
 
 import AllTests
 import Ice

--- a/python/test/Ice/operations/Server.py
+++ b/python/test/Ice/operations/Server.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import TestI
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+import TestI
 
 import Ice
 

--- a/python/test/Ice/operations/ServerAMD.py
+++ b/python/test/Ice/operations/ServerAMD.py
@@ -2,13 +2,19 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
+from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
 # TODO: This is no longer relevant. All supported Python versions provide async/await keywords.
 # We want to test coroutines but older versions of Python cannot
 # load a source file that uses the async/await keywords, so we
 # have two versions of MyDerivedClassI.
 #
 from TestAMDCoroI import MyDerivedClassI
-from TestHelper import TestHelper
 
 import Ice
 

--- a/python/test/Ice/optional/Client.py
+++ b/python/test/Ice/optional/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice ClientPrivate.ice")
 
 import AllTests
 

--- a/python/test/Ice/optional/Server.py
+++ b/python/test/Ice/optional/Server.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-from generated.test.Ice.optional import Test
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+from generated.test.Ice.optional import Test
 
 import Ice
 

--- a/python/test/Ice/optional/ServerAMD.py
+++ b/python/test/Ice/optional/ServerAMD.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-from generated.test.Ice.optional import Test
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+from generated.test.Ice.optional import Test
 
 import Ice
 

--- a/python/test/Ice/proxy/Client.py
+++ b/python/test/Ice/proxy/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 

--- a/python/test/Ice/proxy/Server.py
+++ b/python/test/Ice/proxy/Server.py
@@ -2,9 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
+from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import TestI
-from TestHelper import TestHelper
 
 import Ice
 

--- a/python/test/Ice/scope/Client.py
+++ b/python/test/Ice/scope/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 

--- a/python/test/Ice/scope/Server.py
+++ b/python/test/Ice/scope/Server.py
@@ -2,11 +2,17 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
+from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
 from generated.test.Ice.scope import Test
 from generated.test.Ice.scope.Inner.Test.Inner2 import MyInterface as Inner_Test_Inner2_MyInterface
 from generated.test.Ice.scope.Test.Inner import MyInterface as Test_Inner_MyInterface
 from generated.test.Ice.scope.Test.Inner.Inner2 import MyInterface as Test_Inner_Inner2_MyInterface
-from TestHelper import TestHelper
 
 import Ice
 

--- a/python/test/Ice/servantLocator/Client.py
+++ b/python/test/Ice/servantLocator/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 

--- a/python/test/Ice/servantLocator/Collocated.py
+++ b/python/test/Ice/servantLocator/Collocated.py
@@ -2,9 +2,15 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
+from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
 import TestActivationI
 import TestI
-from TestHelper import TestHelper
 
 import AllTests
 import Ice

--- a/python/test/Ice/servantLocator/Server.py
+++ b/python/test/Ice/servantLocator/Server.py
@@ -2,9 +2,15 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
+from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
 import TestActivationI
 import TestI
-from TestHelper import TestHelper
 
 import Ice
 

--- a/python/test/Ice/servantLocator/ServerAMD.py
+++ b/python/test/Ice/servantLocator/ServerAMD.py
@@ -2,9 +2,15 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
+from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
 import TestActivationAMDI
 import TestAMDI
-from TestHelper import TestHelper
 
 import Ice
 

--- a/python/test/Ice/slicing/exceptions/Client.py
+++ b/python/test/Ice/slicing/exceptions/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 

--- a/python/test/Ice/slicing/exceptions/Server.py
+++ b/python/test/Ice/slicing/exceptions/Server.py
@@ -2,9 +2,15 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
+from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice ServerPrivate.ice")
+
 from generated.test.Ice.slicing.exceptions import Test
 from generated.test.Ice.slicing.exceptions.server_private import Test as ServerPrivateTest
-from TestHelper import TestHelper
 
 import Ice
 

--- a/python/test/Ice/slicing/exceptions/ServerAMD.py
+++ b/python/test/Ice/slicing/exceptions/ServerAMD.py
@@ -2,9 +2,15 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
+from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice ServerPrivate.ice")
+
 from generated.test.Ice.slicing.exceptions import Test
 from generated.test.Ice.slicing.exceptions.server_private import Test as ServerPrivateTest
-from TestHelper import TestHelper
 
 import Ice
 

--- a/python/test/Ice/slicing/objects/Client.py
+++ b/python/test/Ice/slicing/objects/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice ClientPrivate.ice")
 
 import AllTests
 import Ice

--- a/python/test/Ice/slicing/objects/Server.py
+++ b/python/test/Ice/slicing/objects/Server.py
@@ -2,9 +2,15 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
+from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice ServerPrivate.ice")
+
 from generated.test.Ice.slicing.objects import Test
 from generated.test.Ice.slicing.objects.server_private import Test as ServerPrivateTest
-from TestHelper import TestHelper
 
 import Ice
 

--- a/python/test/Ice/slicing/objects/ServerAMD.py
+++ b/python/test/Ice/slicing/objects/ServerAMD.py
@@ -2,9 +2,15 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
+from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice ServerPrivate.ice")
+
 from generated.test.Ice.slicing.objects import Test
 from generated.test.Ice.slicing.objects.server_private import Test as ServerPrivateTest
-from TestHelper import TestHelper
 
 import Ice
 

--- a/python/test/Ice/thread/Client.py
+++ b/python/test/Ice/thread/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 

--- a/python/test/Ice/thread/Server.py
+++ b/python/test/Ice/thread/Server.py
@@ -2,8 +2,14 @@
 
 # Copyright (c) ZeroC, Inc.
 
-import TestI
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+import TestI
 
 import Ice
 

--- a/python/test/Ice/timeout/Client.py
+++ b/python/test/Ice/timeout/Client.py
@@ -2,7 +2,12 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
+
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
 
 import AllTests
 

--- a/python/test/Ice/timeout/Server.py
+++ b/python/test/Ice/timeout/Server.py
@@ -2,11 +2,16 @@
 
 # Copyright (c) ZeroC, Inc.
 
+import sys
 import threading
 import time
 
-from generated.test.Ice.timeout import Test
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+from generated.test.Ice.timeout import Test
 
 import Ice
 

--- a/python/test/Slice/escape/Client.py
+++ b/python/test/Slice/escape/Client.py
@@ -4,8 +4,12 @@
 
 import sys
 
-from generated.test.Slice.escape.Test import escaped_and
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Key.ice Clash.ice")
+
+from generated.test.Slice.escape.Test import escaped_and
 
 import Ice
 

--- a/python/test/Slice/import/Client.py
+++ b/python/test/Slice/import/Client.py
@@ -4,12 +4,16 @@
 
 import sys
 
+from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test1.ice Test2.ice")
+
 from generated.test.Slice.import_test.Test.SubA.SubSubA1 import Value1 as Test_SubA_SubSubA1_Value1
 from generated.test.Slice.import_test.Test.SubA.SubSubA1 import Value2 as Test_SubA_SubSubA1_Value2
 from generated.test.Slice.import_test.Test.SubA.SubSubA2 import Value1 as Test_SubA_SubSubA2_Value1
 from generated.test.Slice.import_test.Test.SubB.SubSubB1 import Value1 as Test_SubB_SubSubB1_Value1
 from generated.test.Slice.import_test.Test.SubB.SubSubB1 import Value2 as Test_SubB_SubSubB1_Value2
-from TestHelper import TestHelper
 
 
 def test(b):

--- a/python/test/Slice/macros/Client.py
+++ b/python/test/Slice/macros/Client.py
@@ -4,8 +4,12 @@
 
 import sys
 
-from generated.test.Slice.macros import Test
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+from generated.test.Slice.macros import Test
 
 import Ice
 

--- a/python/test/Slice/structure/Client.py
+++ b/python/test/Slice/structure/Client.py
@@ -5,8 +5,12 @@
 import copy
 import sys
 
-from generated.test.Slice.structure import Test
 from TestHelper import TestHelper
+
+if "--load-slice" in sys.argv:
+    TestHelper.loadSlice("Test.ice")
+
+from generated.test.Slice.structure import Test
 
 
 def test(b):

--- a/python/test/TestHelper.py
+++ b/python/test/TestHelper.py
@@ -10,6 +10,7 @@ import Ice
 
 
 class TestHelper(ABC):
+
     def __init__(self) -> None:
         self._communicator: Ice.Communicator | None = None
 
@@ -88,13 +89,13 @@ class TestHelper(ABC):
     @abstractmethod
     def run(self, args: list[str]) -> None: ...
 
-    @classmethod
-    def loadSlice(cls, args: list[str]) -> None:
+    @staticmethod
+    def loadSlice(args: str) -> None:
         sliceDir = Ice.getSliceDir()
         if not sliceDir:
             print(sys.argv[0] + ": Slice directory not found.")
             sys.exit(1)
-        Ice.loadSlice("'-I{0}' {1}".format(sliceDir, args))
+        Ice.loadSlice(f"'-I{sliceDir}' {args}")
 
     @classmethod
     def runTest(cls) -> int:

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -623,8 +623,9 @@ class Mapping(object):
             self.avd = ""
             self.phpVersion = "7.1"
             self.python = sys.executable
+            self.loadSlice = False  # Use Ice.loadSlice instead of the static generated code
 
-            parseOptions(self, options, {"config": "buildConfig", "platform": "buildPlatform"})
+            parseOptions(self, options, {"config": "buildConfig", "platform": "buildPlatform", "load-slice": "loadSlice"})
 
         def __str__(self):
             s = []
@@ -3657,13 +3658,14 @@ class PythonMapping(CppBasedMapping):
 
         @classmethod
         def getSupportedArgs(self):
-            return ("", ["python="])
+            return ("", ["python=", "load-slice"])
 
         @classmethod
         def usage(self):
             print("")
             print("Python mapping options:")
             print("--python=<interpreter>   Choose the interperter used to run python tests")
+            print("--load-slice             Use Ice.loadSlice instead of the slice2py static generated code.")
 
         def __init__(self, options=[]):
             Mapping.Config.__init__(self, options)
@@ -3684,6 +3686,10 @@ class PythonMapping(CppBasedMapping):
             return self.pythonVersion
 
     def getCommandLine(self, current, process, exe, args):
+
+        if current.config.loadSlice:
+            args = f"--load-slice {args}"
+
         return '"{0}"  {1} {2} {3}'.format(
             current.config.python,
             os.path.join(self.path, "test", "TestHelper.py"),
@@ -3699,7 +3705,8 @@ class PythonMapping(CppBasedMapping):
             # the Ice python directory to PYTHONPATH
             dirs += self.getPythonDirs(self.component.getInstallDir(self, current), current.config)
         dirs += [current.testcase.getPath(current)]
-        dirs += [os.path.join(current.testcase.getPath(current), "generated")]
+        if not current.config.loadSlice:
+            dirs += [os.path.join(current.testcase.getPath(current), "generated")]
         env["PYTHONPATH"] = os.pathsep.join(dirs)
         return env
 


### PR DESCRIPTION
This PR add support to run the Python test suite with the dynamic generated code. Pass `--load-slice` to allTests.py.

I updated CI to also run tests with this flag, and removed the generated code to be sure things work as expected.

There are some updates for `loadSlice` implementation for tests that were not working correctly with the new implementation.