### PR TITLE
Simplify getInvocationFuture

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
@@ -496,7 +496,8 @@ public final class Util {
      *
      * @param f The CompletableFuture returned by an asynchronous invocation.
      * @param <T> The result type.
-     * @return The InvocationFuture object.
+     * @return f casted to an {@code InvocationFuture<T>}.
+     * @throws ClassCastException if f is not an {@code InvocationFuture<T>}.
      */
     public static <T> InvocationFuture<T> getInvocationFuture(CompletableFuture<T> f) {
         return (InvocationFuture<T>) f;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
@@ -492,18 +492,13 @@ public final class Util {
     }
 
     /**
-     * Returns the InvocationFuture equivalent of the given CompletableFuture.
+     * Downcasts a {@code CompletableFuture<T>} to an {@code InvocationFuture<T>} object.
      *
-     * @param f The CompletableFuture returned by an asynchronous Ice proxy invocation.
+     * @param f The CompletableFuture returned by an asynchronous invocation.
      * @param <T> The result type.
      * @return The InvocationFuture object.
      */
-    public static <T> InvocationFuture<T> getInvocationFuture(
-            CompletableFuture<T> f) {
-        if (!(f instanceof InvocationFuture)) {
-            throw new IllegalArgumentException(
-                "future did not originate from an asynchronous proxy invocation");
-        }
+    public static <T> InvocationFuture<T> getInvocationFuture(CompletableFuture<T> f) {
         return (InvocationFuture<T>) f;
     }
 


### PR DESCRIPTION
A tiny update to Ice.getInvocationFuture.

getInvocationFuture is just a convenience method:

```java
var f = Util.getInvocationFuture(cf);
```

is equivalent to:
```java
var f = (InvocationFuture<String>)cf;
```

except you don't need to specify the type.