### PR TITLE
Update generated _iceI_ methods in Java

### DIFF
--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -2234,36 +2234,6 @@ Slice::JavaVisitor::writeProxyOpDocComment(
 }
 
 void
-Slice::JavaVisitor::writeHiddenProxyDocComment(Output& out, const OperationPtr& p)
-{
-    // the _iceI_ methods are all async
-
-    out << nl << "/**";
-
-    out << nl << " * Invokes the " << p->name()
-        << " operation on this proxy with the given parameters and returns a future that will be completed with the "
-           "result.";
-    out << nl << " *";
-
-    // Show in-params in order of declaration
-    for (const auto& param : p->inParameters())
-    {
-        out << nl << " * @param " << "iceP_" << param->mappedName() << " parameter";
-    }
-    out << nl << " * @param context the request context";
-    out << nl << " * @param sync {@code true} if the operation is synchronous, {@code false} otherwise";
-
-    // There is always a return value since it's async
-    out << nl << " * @return a CompletableFuture that will be completed with the result of the operation";
-
-    // Hide this method generated documentation
-    out << nl << " * @hidden";
-
-    // No throws since it's async
-    out << nl << " **/";
-}
-
-void
 Slice::JavaVisitor::writeServantOpDocComment(Output& out, const OperationPtr& p, const string& package, bool async)
 {
     const optional<DocComment>& dc = p->docComment();

--- a/cpp/src/slice2java/Gen.h
+++ b/cpp/src/slice2java/Gen.h
@@ -162,7 +162,6 @@ namespace Slice
             const std::optional<DocComment>&,
             bool,
             const std::string&);
-        static void writeHiddenProxyDocComment(IceInternal::Output&, const OperationPtr&);
         static void writeServantOpDocComment(IceInternal::Output&, const OperationPtr&, const std::string&, bool);
         static void writeSeeAlso(IceInternal::Output&, const UnitPtr&, const std::string&);
         static void writeParamDocComments(IceInternal::Output& out, const DataMemberList& members);

--- a/cpp/src/slice2java/Gen.h
+++ b/cpp/src/slice2java/Gen.h
@@ -91,8 +91,12 @@ namespace Slice
             IceInternal::Output& out,
             const OperationPtr& p,
             const std::vector<std::string>& params,
-            const ExceptionList& throws,
-            const std::optional<DocComment>& dc,
+            const std::optional<DocComment>& dc);
+
+        static void writeIceIHelperMethods(
+            IceInternal::Output& out,
+            const OperationPtr& p,
+            bool hasExceptionSpecification,
             bool optionalMapping);
 
         static void writeMarshalProxyParams(


### PR DESCRIPTION
This PR updates the generated `_iceI_` proxy methods in Java:
 - they are now `private` instead of `default` (a Java9 feature)
 - they are now generated after the 4 or 8 mapped public methods

