### PR TITLE
First Round of Checkstyle Updates

### DIFF
--- a/config/makeprops.py
+++ b/config/makeprops.py
@@ -367,8 +367,7 @@ class JavaPropertyHandler(PropertyHandler):
 {commonPreamble}
 package com.zeroc.Ice;
 
-final class PropertyNames
-{{
+final class PropertyNames {{
 """)
 
     @override

--- a/java/config/checkstyle/checkstyle.xml
+++ b/java/config/checkstyle/checkstyle.xml
@@ -106,28 +106,17 @@
       <property name="tokens"
                value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE"/>
     </module>
+
+    <!-- Left curly-braces should be placed on the same line as the statement they're attached to. -->
+    <!-- They should not be placed on a separate line. -->
+    <!-- See: https://checkstyle.org/checks/blocks/leftcurly.html -->
     <module name="LeftCurly">
-      <property name="id" value="LeftCurlyEol"/>
-      <property name="tokens"
-                value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
-                    INTERFACE_DEF, LAMBDA, LITERAL_CATCH,
-                    LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF,
-                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF,
-                    OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF"/>
+      <property name="option" value="eol"/>
     </module>
-    <module name="LeftCurly">
-      <property name="id" value="LeftCurlyNl"/>
-      <property name="option" value="nl"/>
-      <property name="tokens"
-                value="LITERAL_CASE, LITERAL_DEFAULT"/>
-    </module>
-    <module name="SuppressionXpathSingleFilter">
-      <!-- LITERAL_CASE, LITERAL_DEFAULT are reused in SWITCH_RULE  -->
-      <property name="id" value="LeftCurlyNl"/>
-      <property name="query" value="//SWITCH_RULE/SLIST"/>
-    </module>
+
     <module name="RightCurly">
       <property name="id" value="RightCurlySame"/>
+      <property name="option" value="same"/>
       <property name="tokens"
                value="LITERAL_TRY, LITERAL_CATCH, LITERAL_IF, LITERAL_ELSE,
                     LITERAL_DO"/>
@@ -138,7 +127,7 @@
       <property name="tokens"
                value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
                     INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
-                    COMPACT_CTOR_DEF, LITERAL_SWITCH, LITERAL_CASE, LITERAL_FINALLY"/>
+                    COMPACT_CTOR_DEF, LITERAL_SWITCH, LITERAL_FINALLY"/>
     </module>
     <module name="SuppressionXpathSingleFilter">
       <!-- suppression is required till https://github.com/checkstyle/checkstyle/issues/7541 -->

--- a/java/config/checkstyle/checkstyle.xml
+++ b/java/config/checkstyle/checkstyle.xml
@@ -73,6 +73,14 @@
     <property name="ignorePattern" value="^(package|import|\s*&quot;).*|(http|https|ftp)://"/>
   </module>
 
+  <!-- Reject trailing whitespace. -->
+  <!-- This is a custom rule that allows you to match any regular expression as disallowed. -->
+  <!-- See https://checkstyle.org/checks/regexp/regexpsingleline.html -->
+  <module name="RegexpSingleline">
+    <property name="format" value="\s+$"/>
+    <property name="message" value="trailing whitespace detected"/>
+  </module>
+
   <!-- 'TreeWalker' is what Checkstyle uses to traverse the source code's AST. -->
   <!-- Any checks that require some language awareness must be in this module. -->
   <module name="TreeWalker">

--- a/java/config/checkstyle/checkstyle.xml
+++ b/java/config/checkstyle/checkstyle.xml
@@ -26,56 +26,56 @@
 
 <module name="Checker">
 
+  <!-- General configuration for Checkstyle -->
+  <!-- See https://checkstyle.org/config.html#Checker -->
   <property name="charset" value="UTF-8"/>
-
+  <property name="tabWidth" value="4"/>
+  <property name="fileExtensions" value="java"/>
   <property name="severity" value="${org.checkstyle.google.severity}" default="warning"/>
 
-  <!-- It's standard practice to separate any exceptions/suppressions into a separate XML file. -->
-  <module name="SuppressionFilter">
-    <property name="file" value="${config_loc}/suppressions.xml" />
-  </module>
-
-  <property name="fileExtensions" value="java, properties, xml"/>
-  <!-- Excludes all 'module-info.java' files              -->
+  <!-- Fine-grained exclusion rules -->
   <!-- See https://checkstyle.org/filefilters/index.html -->
   <module name="BeforeExecutionExclusionFileFilter">
+    <!-- Exclude all 'module-info.java' files -->
     <property name="fileNamePattern" value="module\-info\.java$"/>
   </module>
 
-  <module name="SuppressWarningsFilter"/>
+  <!-- Warning Suppression -->
 
-  <!-- https://checkstyle.org/filters/suppressionfilter.html -->
+  <!-- It's standard practice to place suppression rules in a separate XML file. -->
+  <!-- See https://checkstyle.org/filters/suppressionfilter.html -->
   <module name="SuppressionFilter">
-    <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
-           default="checkstyle-suppressions.xml" />
+    <property name="file" value="${config_loc}/suppressions.xml" />
     <property name="optional" value="true"/>
   </module>
 
-  <module name="SuppressWarningsFilter"/>
-
-  <!-- https://checkstyle.org/filters/suppresswithnearbytextfilter.html -->
+  <!-- Allows you to suppress checkstyle warnings on a single line by writing '// CHECKSTYLE.SUPPRESS: <RULE> '-->
+  <!-- See https://checkstyle.org/filters/suppresswithnearbytextfilter.html -->
   <module name="SuppressWithNearbyTextFilter">
-    <property name="nearbyTextPattern"
-              value="CHECKSTYLE.SUPPRESS\: (\w+) for ([+-]\d+) lines"/>
+    <property name="nearbyTextPattern" value="CHECKSTYLE.SUPPRESS\: (\w+)"/>
     <property name="checkPattern" value="$1"/>
-    <property name="lineRange" value="$2"/>
   </module>
 
-  <!-- Checks for whitespace                               -->
-  <!-- See http://checkstyle.org/checks/whitespace/index.html -->
+  <!-- Basic Formatting Checks -->
+
+  <!-- Reject tabs in source code -->
+  <!-- See https://checkstyle.org/checks/whitespace/filetabcharacter.html -->
   <module name="FileTabCharacter">
     <property name="eachLine" value="true"/>
   </module>
 
+  <!-- Enforce a line length limit of 120 columns in all '.java' files. -->
+  <!-- See https://checkstyle.org/checks/sizes/linelength.html -->
   <module name="LineLength">
     <property name="fileExtensions" value="java"/>
     <property name="max" value="120"/>
-    <property name="ignorePattern"
-             value="^package.*|^import.*|^\s*&quot;|href\s*=\s*&quot;[^&quot;]*&quot;|http://|https://|ftp://"/>
+    <!-- Exceptions to the line-length limit. -->
+    <property name="ignorePattern" value="^(package|import|\s*&quot;).*|(http|https|ftp)://"/>
   </module>
 
+  <!-- 'TreeWalker' is what Checkstyle uses to traverse the source code's AST. -->
+  <!-- Any checks that require some language awareness must be in this module. -->
   <module name="TreeWalker">
-  <module name="SuppressWarningsHolder"/>
     <module name="OuterTypeFilename"/>
     <module name="IllegalTokenText">
       <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
@@ -98,8 +98,7 @@
       <property name="tokens"
                value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE"/>
     </module>
-    <!-- TODO: Please enable this and fix presented warnings in a follow-up PR.-->
-    <!--<module name="LeftCurly">
+    <module name="LeftCurly">
       <property name="id" value="LeftCurlyEol"/>
       <property name="tokens"
                 value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
@@ -107,7 +106,7 @@
                     LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF,
                     LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF,
                     OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF"/>
-    </module>-->
+    </module>
     <module name="LeftCurly">
       <property name="id" value="LeftCurlyNl"/>
       <property name="option" value="nl"/>
@@ -146,8 +145,7 @@
                     LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_CATCH, LAMBDA,
                     LITERAL_YIELD, LITERAL_CASE, LITERAL_WHEN"/>
     </module>
-    <!-- TODO: Please enable this and fix presented warnings in a follow-up PR. -->
-    <!--<module name="WhitespaceAround">
+    <module name="WhitespaceAround">
       <property name="allowEmptyConstructors" value="true"/>
       <property name="allowEmptyLambdas" value="true"/>
       <property name="allowEmptyMethods" value="true"/>
@@ -169,7 +167,7 @@
                may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
       <message key="ws.notPreceded"
               value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
-    </module>-->
+    </module>
     <module name="SuppressionXpathSingleFilter">
       <property name="checks" value="WhitespaceAround"/>
       <property name="query" value="//*[self::LITERAL_IF or self::LITERAL_ELSE or self::STATIC_INIT
@@ -297,7 +295,9 @@
       <message key="name.invalidPattern"
              value="Interface type name ''{0}'' must match pattern ''{1}''."/>
     </module> -->
-    <module name="NoFinalizer"/>
+
+    <!-- We rely on finalizers in a number of places. -->
+    <!-- <module name="NoFinalizer"/> -->
     <module name="GenericWhitespace">
       <message key="ws.followed"
              value="GenericWhitespace ''{0}'' is followed by whitespace."/>
@@ -307,13 +307,6 @@
              value="GenericWhitespace ''{0}'' should followed by whitespace."/>
       <message key="ws.notPreceded"
              value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
-    </module>
-    <!-- Suppression for block code until we find a way to detect them properly
-         until https://github.com/checkstyle/checkstyle/issues/15769 -->
-    <module name="SuppressionXpathSingleFilter">
-      <property name="checks" value="Indentation"/>
-      <property name="query" value="//SLIST[not(parent::CASE_GROUP)]/SLIST
-                                   | //SLIST[not(parent::CASE_GROUP)]/SLIST/RCURLY"/>
     </module>
     <!-- TODO: Please enable the following modules and fix presented warnings in a follow-up PR.-->
     <!--<module name="OverloadMethodsDeclarationOrder"/>-->
@@ -406,14 +399,6 @@
       <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,
                                    COMPACT_CTOR_DEF"/>
     </module>-->
-    <module name="SuppressionXpathSingleFilter">
-      <property name="checks" value="MissingJavadocMethod"/>
-      <property name="query" value="//*[self::METHOD_DEF or self::CTOR_DEF
-                                 or self::ANNOTATION_FIELD_DEF or self::COMPACT_CTOR_DEF]
-                                 [ancestor::*[self::INTERFACE_DEF or self::CLASS_DEF
-                                 or self::RECORD_DEF or self::ENUM_DEF]
-                                 [not(./MODIFIERS/LITERAL_PUBLIC)]]"/>
-    </module>
     <!-- TODO: Please enable this and fix presented warnings in a follow-up PR.-->
     <!--<module name="MissingJavadocType">
       <property name="scope" value="protected"/>
@@ -422,13 +407,6 @@
                       RECORD_DEF, ANNOTATION_DEF"/>
       <property name="excludeScope" value="nothing"/>
     </module>-->
-    <module name="SuppressionXpathSingleFilter">
-      <property name="checks" value="MethodName"/>
-      <property name="query" value="//METHOD_DEF[
-                                     ./MODIFIERS/ANNOTATION//IDENT[contains(@text, 'Test')]
-                                   ]/IDENT"/>
-      <property name="message" value="'[a-z][a-z0-9][a-zA-Z0-9]*(?:_[a-z][a-z0-9][a-zA-Z0-9]*)*'"/>
-    </module>
     <module name="SingleLineJavadoc"/>
     <!-- TODO: Please enable this and fix presented warnings in a follow-up PR.-->
     <!--<module name="EmptyCatchBlock">
@@ -436,12 +414,6 @@
     </module>-->
     <module name="CommentsIndentation">
       <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>
-    </module>
-    <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
-    <module name="SuppressionXpathFilter">
-      <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
-             default="checkstyle-xpath-suppressions.xml" />
-      <property name="optional" value="true"/>
     </module>
     <module name="SuppressWarningsHolder" />
     <module name="SuppressionCommentFilter">

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/GraphView.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/GraphView.java
@@ -1011,60 +1011,21 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
 
         @Override
         public Class<?> getColumnClass(int columnIndex) {
-            switch (columnIndex) {
-                case 0: // Visible
-                    {
-                        return Boolean.class;
-                    }
-                case 1: // Component Name
-                    {
-                        return String.class;
-                    }
-                case 2: // View Name
-                    {
-                        return String.class;
-                    }
-                case 3: // Metrics Name
-                    {
-                        return String.class;
-                    }
-                case 4: // Metrics Id
-                    {
-                        return String.class;
-                    }
-                case 5: // Column Name
-                    {
-                        return String.class;
-                    }
-                case 6: // Scale factor
-                    {
-                        return Double.class;
-                    }
-                case 7: // Last value
-                    {
-                        return Double.class;
-                    }
-                case 8: // Average value
-                    {
-                        return Double.class;
-                    }
-                case 9: // Min value
-                    {
-                        return Double.class;
-                    }
-                case 10: // Max value
-                    {
-                        return Double.class;
-                    }
-                case 11: // Color
-                    {
-                        return Color.class;
-                    }
-                default:
-                {
-                    return null;
-                }
-            }
+            return switch (columnIndex) {
+                case 0 -> Boolean.class; // Visible
+                case 1 -> String.class; // Component Name
+                case 2 -> String.class; // View Name
+                case 3 -> String.class; // Metrics Name
+                case 4 -> String.class; // Metrics Id
+                case 5 -> String.class; // Column Name
+                case 6 -> Double.class; // Scale factor
+                case 7 -> Double.class; // Last value
+                case 8 -> Double.class; // Average value
+                case 9 -> Double.class; // Min value
+                case 10 -> Double.class; // Max value
+                case 11 -> Color.class; // Color
+                default -> null;
+            };
         }
 
         @Override
@@ -1073,60 +1034,21 @@ public class GraphView extends JFrame implements MetricsFieldContext, Coordinato
                 return null;
             }
             MetricsRow row = _rows.get(rowIndex);
-            switch (columnIndex) {
-                case 0:
-                {
-                    return row.visible;
-                }
-                case 1:
-                {
-                    return row.info.component;
-                }
-                case 2:
-                {
-                    return row.info.view;
-                }
-                case 3:
-                {
-                    return row.cell.getField().getMetricsName();
-                }
-                case 4:
-                {
-                    return row.cell.getId();
-                }
-                case 5:
-                {
-                    return row.cell.getField().getColumnName();
-                }
-                case 6:
-                {
-                    return row.cell.getScaleFactor();
-                }
-                case 7:
-                {
-                    return row.cell.getLast();
-                }
-                case 8:
-                {
-                    return row.cell.getAverage();
-                }
-                case 9:
-                {
-                    return row.cell.getMin();
-                }
-                case 10:
-                {
-                    return row.cell.getMax();
-                }
-                case 11:
-                {
-                    return new Color(Integer.parseInt(row.color.substring(1), 16));
-                }
-                default:
-                {
-                    return null;
-                }
-            }
+            return switch (columnIndex) {
+                case 0 -> row.visible;
+                case 1 -> row.info.component;
+                case 2 -> row.info.view;
+                case 3 -> row.cell.getField().getMetricsName();
+                case 4 -> row.cell.getId();
+                case 5 -> row.cell.getField().getColumnName();
+                case 6 -> row.cell.getScaleFactor();
+                case 7 -> row.cell.getLast();
+                case 8 -> row.cell.getAverage();
+                case 9 -> row.cell.getMin();
+                case 10 -> row.cell.getMax();
+                case 11 -> new Color(Integer.parseInt(row.color.substring(1), 16));
+                default -> null;
+            };
         }
 
         @Override

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/LogFilterDialog.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/LogFilterDialog.java
@@ -97,10 +97,10 @@ class LogFilterDialog extends JDialog {
                             return;
                         }
 
-                        if (traceCategoryFilter.length == 0) // only separators
-                            {
-                                traceCategoryFilter = null;
-                            }
+                        // If the traceCategory only contained separators.
+                        if (traceCategoryFilter.length == 0) {
+                            traceCategoryFilter = null;
+                        }
                     }
 
                     Set<LogMessageType> messageTypeFilterSet =

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ShowIceLogDialog.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ShowIceLogDialog.java
@@ -536,13 +536,13 @@ class ShowIceLogDialog extends JDialog {
                     int row = rowAtPoint(p);
                     int col = columnAtPoint(p);
 
-                    if (col == 3 && row >= 0) // Log message
-                        {
-                            Object obj = getValueAt(row, col);
-                            if (obj != null) {
-                                tip = "<html>" + obj.toString().replace("\n", "<br>") + "</html>";
-                            }
+                    // Log message
+                    if (col == 3 && row >= 0) {
+                        Object obj = getValueAt(row, col);
+                        if (obj != null) {
+                            tip = "<html>" + obj.toString().replace("\n", "<br>") + "</html>";
                         }
+                    }
                     return tip;
                 }
             };

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ShowIceLogDialog.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/ShowIceLogDialog.java
@@ -503,26 +503,10 @@ class ShowIceLogDialog extends JDialog {
                             (LogMessageType) getModel().getValueAt(modelRow, 1);
                         if (type != null) {
                             switch (type) {
-                                case ErrorMessage:
-                                {
-                                    c.setBackground(Color.RED);
-                                    break;
-                                }
-                                case WarningMessage:
-                                {
-                                    c.setBackground(Color.ORANGE);
-                                    break;
-                                }
-                                case PrintMessage:
-                                {
-                                    c.setBackground(Color.LIGHT_GRAY);
-                                    break;
-                                }
-                                default:
-                                {
-                                    c.setBackground(getBackground());
-                                    break;
-                                }
+                                case ErrorMessage -> c.setBackground(Color.RED);
+                                case WarningMessage -> c.setBackground(Color.ORANGE);
+                                case PrintMessage -> c.setBackground(Color.LIGHT_GRAY);
+                                default -> c.setBackground(getBackground());
                             }
                         }
                     }

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SessionKeeper.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SessionKeeper.java
@@ -2593,18 +2593,18 @@ public class SessionKeeper {
                         return false;
                     }
                 }
-            } else // Routed
-                {
-                    if (_routedDefaultEndpoints.isSelected()) {
-                        if (!validateWizardStep(WizardStep.RoutedDefaultEndpointStep)) {
-                            return false;
-                        }
-                    } else {
-                        if (!validateWizardStep(WizardStep.RoutedCustomEndpointStep)) {
-                            return false;
-                        }
+            } else {
+                // Routed
+                if (_routedDefaultEndpoints.isSelected()) {
+                    if (!validateWizardStep(WizardStep.RoutedDefaultEndpointStep)) {
+                        return false;
+                    }
+                } else {
+                    if (!validateWizardStep(WizardStep.RoutedCustomEndpointStep)) {
+                        return false;
                     }
                 }
+            }
 
             if (_x509CertificateYesButton.isSelected()) {
                 if (_directConnection.isSelected()) {
@@ -4544,144 +4544,144 @@ public class SessionKeeper {
                     _authDialog.showDialog();
                 }
             }
-        } else // X509CertificateAuthDialog dialog
-            {
-                class X509CertificateAuthDialog extends AuthDialog {
-                    X509CertificateAuthDialog() {
-                        super(parent, "Login - IceGrid GUI");
+        } else {
+            // X509CertificateAuthDialog dialog
+            class X509CertificateAuthDialog extends AuthDialog {
+                X509CertificateAuthDialog() {
+                    super(parent, "Login - IceGrid GUI");
 
-                        Container contentPane = getContentPane();
-                        contentPane.setLayout(new BoxLayout(contentPane, BoxLayout.Y_AXIS));
+                    Container contentPane = getContentPane();
+                    contentPane.setLayout(new BoxLayout(contentPane, BoxLayout.Y_AXIS));
 
-                        {
-                            // Build the basic login panel.
-                            FormLayout layout = new FormLayout("pref, 2dlu, pref:grow, 2dlu, pref", "");
-                            DefaultFormBuilder builder = new DefaultFormBuilder(layout);
-                            builder.border(Borders.DIALOG);
+                    {
+                        // Build the basic login panel.
+                        FormLayout layout = new FormLayout("pref, 2dlu, pref:grow, 2dlu, pref", "");
+                        DefaultFormBuilder builder = new DefaultFormBuilder(layout);
+                        builder.border(Borders.DIALOG);
 
-                            builder.append(new JLabel("Key Password"), _keyPassword);
-                            builder.nextLine();
-                            _storeKeyPassword = new JCheckBox("Save Key Password.");
-                            _storeKeyPassword.setEnabled(false);
-                            _keyPassword
-                                .getDocument()
-                                .addDocumentListener(
-                                    new DocumentListener() {
-                                        @Override
-                                        public void changedUpdate(DocumentEvent e) {
-                                            _storeKeyPassword.setEnabled(
-                                                _keyPassword.getPassword() != null
-                                                    && _keyPassword.getPassword().length
-                                                    > 0);
-                                        }
-
-                                        @Override
-                                        public void removeUpdate(DocumentEvent e) {
-                                            _storeKeyPassword.setEnabled(
-                                                _keyPassword.getPassword() != null
-                                                    && _keyPassword.getPassword().length
-                                                    > 0);
-                                        }
-
-                                        @Override
-                                        public void insertUpdate(DocumentEvent e) {
-                                            _storeKeyPassword.setEnabled(
-                                                _keyPassword.getPassword() != null
-                                                    && _keyPassword.getPassword().length
-                                                    > 0);
-                                        }
-                                    });
-                            builder.append("", _storeKeyPassword);
-                            builder.nextLine();
-                            contentPane.add(builder.getPanel());
-                        }
-
-                        JButton okButton = new JButton();
-                        JButton cancelButton = new JButton();
-
-                        AbstractAction okAction =
-                            new AbstractAction("OK") {
-                                @Override
-                                public void actionPerformed(ActionEvent e) {
-                                    if (_session != null) {
-                                        logout(true);
+                        builder.append(new JLabel("Key Password"), _keyPassword);
+                        builder.nextLine();
+                        _storeKeyPassword = new JCheckBox("Save Key Password.");
+                        _storeKeyPassword.setEnabled(false);
+                        _keyPassword
+                            .getDocument()
+                            .addDocumentListener(
+                                new DocumentListener() {
+                                    @Override
+                                    public void changedUpdate(DocumentEvent e) {
+                                        _storeKeyPassword.setEnabled(
+                                            _keyPassword.getPassword() != null
+                                                && _keyPassword.getPassword().length
+                                                > 0);
                                     }
-                                    assert _session == null;
 
-                                    info.setKeyPassword(_keyPassword.getPassword());
-
-                                    if (checkCertificateRequirePassword(info.getAlias())
-                                        && !checkCertificatePassword(
-                                        info.getAlias(), info.getKeyPassword())) {
-                                        dispose();
-                                        permissionDenied(
-                                            parent, info, "Invalid certificate password");
-                                    } else {
-                                        _authDialog.setCursor(
-                                            Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-                                        _authDialog.setDefaultCloseOperation(
-                                            WindowConstants.DO_NOTHING_ON_CLOSE);
-                                        Utils.removeEscapeListener(_authDialog);
-                                        okButton.setEnabled(false);
-                                        cancelButton.setEnabled(false);
-                                        _coordinator.login(SessionKeeper.this, info, parent);
+                                    @Override
+                                    public void removeUpdate(DocumentEvent e) {
+                                        _storeKeyPassword.setEnabled(
+                                            _keyPassword.getPassword() != null
+                                                && _keyPassword.getPassword().length
+                                                > 0);
                                     }
-                                }
-                            };
-                        okButton.setAction(okAction);
 
-                        AbstractAction cancelAction =
-                            new AbstractAction("Cancel") {
-                                @Override
-                                public void actionPerformed(ActionEvent e) {
-                                    dispose();
-                                }
-                            };
-                        cancelButton.setAction(cancelAction);
-
-                        JComponent buttonBar =
-                            new ButtonBarBuilder()
-                                .addGlue()
-                                .addButton(okButton, cancelButton)
-                                .addGlue()
-                                .build();
-                        buttonBar.setBorder(Borders.DIALOG);
-                        contentPane.add(buttonBar);
-
-                        getRootPane().setDefaultButton(okButton);
-                        pack();
-                        setResizable(false);
+                                    @Override
+                                    public void insertUpdate(DocumentEvent e) {
+                                        _storeKeyPassword.setEnabled(
+                                            _keyPassword.getPassword() != null
+                                                && _keyPassword.getPassword().length
+                                                > 0);
+                                    }
+                                });
+                        builder.append("", _storeKeyPassword);
+                        builder.nextLine();
+                        contentPane.add(builder.getPanel());
                     }
 
-                    private JPasswordField _keyPassword = new JPasswordField(20);
-                    private JCheckBox _storeKeyPassword;
+                    JButton okButton = new JButton();
+                    JButton cancelButton = new JButton();
+
+                    AbstractAction okAction =
+                        new AbstractAction("OK") {
+                            @Override
+                            public void actionPerformed(ActionEvent e) {
+                                if (_session != null) {
+                                    logout(true);
+                                }
+                                assert _session == null;
+
+                                info.setKeyPassword(_keyPassword.getPassword());
+
+                                if (checkCertificateRequirePassword(info.getAlias())
+                                    && !checkCertificatePassword(
+                                    info.getAlias(), info.getKeyPassword())) {
+                                    dispose();
+                                    permissionDenied(
+                                        parent, info, "Invalid certificate password");
+                                } else {
+                                    _authDialog.setCursor(
+                                        Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+                                    _authDialog.setDefaultCloseOperation(
+                                        WindowConstants.DO_NOTHING_ON_CLOSE);
+                                    Utils.removeEscapeListener(_authDialog);
+                                    okButton.setEnabled(false);
+                                    cancelButton.setEnabled(false);
+                                    _coordinator.login(SessionKeeper.this, info, parent);
+                                }
+                            }
+                        };
+                    okButton.setAction(okAction);
+
+                    AbstractAction cancelAction =
+                        new AbstractAction("Cancel") {
+                            @Override
+                            public void actionPerformed(ActionEvent e) {
+                                dispose();
+                            }
+                        };
+                    cancelButton.setAction(cancelAction);
+
+                    JComponent buttonBar =
+                        new ButtonBarBuilder()
+                            .addGlue()
+                            .addButton(okButton, cancelButton)
+                            .addGlue()
+                            .build();
+                    buttonBar.setBorder(Borders.DIALOG);
+                    contentPane.add(buttonBar);
+
+                    getRootPane().setDefaultButton(okButton);
+                    pack();
+                    setResizable(false);
                 }
 
-                // If the certificate requires a password and the password isn't provided, we show the
-                // login dialog.
-                if ((info.getKeyPassword() == null || info.getKeyPassword().length == 0)
-                    && checkCertificateRequirePassword(info.getAlias())) {
-                    _authDialog = new X509CertificateAuthDialog();
-                    Utils.addEscapeListener(_authDialog);
-                    _authDialog.showDialog();
-                } else {
-                    if (_session != null) {
-                        logout(true);
-                    }
-                    assert _session == null;
+                private JPasswordField _keyPassword = new JPasswordField(20);
+                private JCheckBox _storeKeyPassword;
+            }
 
-                    if (checkCertificateRequirePassword(info.getAlias())
-                        && !checkCertificatePassword(info.getAlias(), info.getKeyPassword())) {
-                        permissionDenied(parent, info, "Invalid certificate password");
-                    } else {
-                        _authDialog = new StoredPasswordAuthDialog(parent);
-                        _authDialog.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-                        _authDialog.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
-                        _coordinator.login(SessionKeeper.this, info, parent);
-                        _authDialog.showDialog();
-                    }
+            // If the certificate requires a password and the password isn't provided, we show the
+            // login dialog.
+            if ((info.getKeyPassword() == null || info.getKeyPassword().length == 0)
+                && checkCertificateRequirePassword(info.getAlias())) {
+                _authDialog = new X509CertificateAuthDialog();
+                Utils.addEscapeListener(_authDialog);
+                _authDialog.showDialog();
+            } else {
+                if (_session != null) {
+                    logout(true);
+                }
+                assert _session == null;
+
+                if (checkCertificateRequirePassword(info.getAlias())
+                    && !checkCertificatePassword(info.getAlias(), info.getKeyPassword())) {
+                    permissionDenied(parent, info, "Invalid certificate password");
+                } else {
+                    _authDialog = new StoredPasswordAuthDialog(parent);
+                    _authDialog.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+                    _authDialog.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+                    _coordinator.login(SessionKeeper.this, info, parent);
+                    _authDialog.showDialog();
                 }
             }
+        }
     }
 
     public void loginSuccess(

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SessionKeeper.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SessionKeeper.java
@@ -1817,50 +1817,34 @@ public class SessionKeeper {
                         _nextButton.setEnabled(false);
                         WizardStep step = _wizardSteps.elementAt(_wizardSteps.size() - 1);
                         switch (step) {
-                            case ConnectionTypeStep:
-                            {
+                            case ConnectionTypeStep -> {
                                 if (_directConnection.isSelected()) {
-                                    _cardLayout.show(
-                                        _cardPanel,
-                                        WizardStep.DirectMasterStep.toString());
+                                    _cardLayout.show(_cardPanel, WizardStep.DirectMasterStep.toString());
                                     _wizardSteps.push(WizardStep.DirectMasterStep);
                                 } else {
-                                    _cardLayout.show(
-                                        _cardPanel,
-                                        WizardStep.RoutedEndpointStep.toString());
+                                    _cardLayout.show(_cardPanel, WizardStep.RoutedEndpointStep.toString());
                                     _wizardSteps.push(WizardStep.RoutedEndpointStep);
                                 }
-                                break;
                             }
 
-                            case DirectMasterStep:
-                            {
-                                _cardLayout.show(
-                                    _cardPanel,
-                                    WizardStep.DirectDiscoveryChooseStep.toString());
+                            case DirectMasterStep -> {
+                                _cardLayout.show(_cardPanel, WizardStep.DirectDiscoveryChooseStep.toString());
                                 _wizardSteps.push(WizardStep.DirectDiscoveryChooseStep);
                                 if (_directDiscoveryDiscoveredLocators.isSelected()) {
                                     refreshDiscoveryLocators();
                                 }
-                                break;
                             }
 
-                            case DirectDiscoveryChooseStep:
-                            {
+                            case DirectDiscoveryChooseStep -> {
                                 if (_directDiscoveryManualEndpoint.isSelected()) {
-                                    _cardLayout.show(
-                                        _cardPanel,
-                                        WizardStep.DirectEndpointStep.toString());
+                                    _cardLayout.show(_cardPanel, WizardStep.DirectEndpointStep.toString());
                                     _wizardSteps.push(WizardStep.DirectEndpointStep);
                                 } else {
-                                    LocatorPrx locator =
-                                        _directDiscoveryLocatorList.getSelectedValue();
-                                    _directInstanceName.setText(
-                                        locator.ice_getIdentity().category);
+                                    LocatorPrx locator = _directDiscoveryLocatorList.getSelectedValue();
+                                    _directInstanceName.setText(locator.ice_getIdentity().category);
 
                                     String endpoints = null;
-                                    for (Endpoint endpoint :
-                                                    locator.ice_getEndpoints()) {
+                                    for (Endpoint endpoint : locator.ice_getEndpoints()) {
                                         if (endpoints == null) {
                                             endpoints = endpoint.toString();
                                         } else {
@@ -1870,63 +1854,40 @@ public class SessionKeeper {
                                     _directCustomEndpointValue.setText(endpoints);
                                     _directCustomEndpoints.setSelected(true);
 
-                                    _cardLayout.show(
-                                        _cardPanel,
-                                        WizardStep.DirectCustomEndpointStep.toString());
+                                    _cardLayout.show(_cardPanel, WizardStep.DirectCustomEndpointStep.toString());
                                     _wizardSteps.push(WizardStep.DirectCustomEndpointStep);
                                 }
-                                break;
                             }
 
-                            case DirectEndpointStep:
-                            {
+                            case DirectEndpointStep -> {
                                 if (_directDefaultEndpoints.isSelected()) {
-                                    _cardLayout.show(
-                                        _cardPanel,
-                                        WizardStep.DirectDefaultEndpointStep
-                                            .toString());
+                                    _cardLayout.show(_cardPanel, WizardStep.DirectDefaultEndpointStep.toString());
                                     _wizardSteps.push(WizardStep.DirectDefaultEndpointStep);
                                 } else {
-                                    _cardLayout.show(
-                                        _cardPanel,
-                                        WizardStep.DirectCustomEndpointStep.toString());
+                                    _cardLayout.show(_cardPanel, WizardStep.DirectCustomEndpointStep.toString());
                                     _wizardSteps.push(WizardStep.DirectCustomEndpointStep);
                                 }
-                                break;
                             }
 
-                            case RoutedEndpointStep:
-                            {
+                            case RoutedEndpointStep -> {
                                 if (_routedDefaultEndpoints.isSelected()) {
-                                    _cardLayout.show(
-                                        _cardPanel,
-                                        WizardStep.RoutedDefaultEndpointStep
-                                            .toString());
+                                    _cardLayout.show(_cardPanel, WizardStep.RoutedDefaultEndpointStep.toString());
                                     _wizardSteps.push(WizardStep.RoutedDefaultEndpointStep);
                                 } else {
-                                    _cardLayout.show(
-                                        _cardPanel,
-                                        WizardStep.RoutedCustomEndpointStep.toString());
+                                    _cardLayout.show(_cardPanel, WizardStep.RoutedCustomEndpointStep.toString());
                                     _wizardSteps.push(WizardStep.RoutedCustomEndpointStep);
                                 }
-                                break;
                             }
 
-                            case DirectDefaultEndpointStep:
-                            {
+                            case DirectDefaultEndpointStep -> {
                                 if (_directDefaultEndpointSSL.isSelected()) {
-                                    _cardLayout.show(
-                                        _cardPanel,
-                                        WizardStep.X509CertificateStep.toString());
+                                    _cardLayout.show(_cardPanel, WizardStep.X509CertificateStep.toString());
                                     _wizardSteps.push(WizardStep.X509CertificateStep);
                                 } else {
                                     _cardLayout.show(
                                         _cardPanel,
-                                        WizardStep.DirectUsernamePasswordCredentialsStep
-                                            .toString());
-                                    _wizardSteps.push(
-                                        WizardStep
-                                            .DirectUsernamePasswordCredentialsStep);
+                                        WizardStep.DirectUsernamePasswordCredentialsStep.toString());
+                                    _wizardSteps.push(WizardStep.DirectUsernamePasswordCredentialsStep);
                                 }
                                 if (_x509CertificateDefault) {
                                     if (_directDefaultEndpointSSL.isSelected()) {
@@ -1937,24 +1898,17 @@ public class SessionKeeper {
                                         _usernamePasswordAuthButton.setSelected(true);
                                     }
                                 }
-                                break;
                             }
 
-                            case RoutedDefaultEndpointStep:
-                            {
+                            case RoutedDefaultEndpointStep -> {
                                 if (_routedDefaultEndpointSSL.isSelected()) {
-                                    _cardLayout.show(
-                                        _cardPanel,
-                                        WizardStep.X509CertificateStep.toString());
+                                    _cardLayout.show(_cardPanel, WizardStep.X509CertificateStep.toString());
                                     _wizardSteps.push(WizardStep.X509CertificateStep);
                                 } else {
                                     _cardLayout.show(
                                         _cardPanel,
-                                        WizardStep.RoutedUsernamePasswordCredentialsStep
-                                            .toString());
-                                    _wizardSteps.push(
-                                        WizardStep
-                                            .RoutedUsernamePasswordCredentialsStep);
+                                        WizardStep.RoutedUsernamePasswordCredentialsStep.toString());
+                                    _wizardSteps.push(WizardStep.RoutedUsernamePasswordCredentialsStep);
                                 }
                                 if (_x509CertificateDefault) {
                                     if (_routedDefaultEndpointSSL.isSelected()) {
@@ -1965,39 +1919,26 @@ public class SessionKeeper {
                                         _usernamePasswordAuthButton.setSelected(true);
                                     }
                                 }
-                                break;
                             }
 
-                            case DirectCustomEndpointStep:
-                            {
+                            case DirectCustomEndpointStep -> {
                                 try {
-                                    Identity id =
-                                        new Identity();
+                                    Identity id = new Identity();
                                     id.name = "Locator";
                                     id.category = _directInstanceName.getText();
                                     StringBuilder endpoint = new StringBuilder();
-                                    endpoint.append(_coordinator
-                                        .getCommunicator()
-                                        .identityToString(id));
+                                    endpoint.append(_coordinator.getCommunicator().identityToString(id));
                                     endpoint.append(":");
                                     endpoint.append(_directCustomEndpointValue.getText());
-                                    _coordinator
-                                        .getCommunicator()
-                                        .stringToProxy(endpoint.toString());
+                                    _coordinator.getCommunicator().stringToProxy(endpoint.toString());
                                     if (containsSecureEndpoints(endpoint.toString())) {
-                                        _cardLayout.show(
-                                            _cardPanel,
-                                            WizardStep.X509CertificateStep.toString());
+                                        _cardLayout.show(_cardPanel, WizardStep.X509CertificateStep.toString());
                                         _wizardSteps.push(WizardStep.X509CertificateStep);
                                     } else {
                                         _cardLayout.show(
                                             _cardPanel,
-                                            WizardStep
-                                                .DirectUsernamePasswordCredentialsStep
-                                                .toString());
-                                        _wizardSteps.push(
-                                            WizardStep
-                                                .DirectUsernamePasswordCredentialsStep);
+                                            WizardStep.DirectUsernamePasswordCredentialsStep.toString());
+                                        _wizardSteps.push(WizardStep.DirectUsernamePasswordCredentialsStep);
                                     }
                                 } catch (ParseException ex) {
                                     JOptionPane.showMessageDialog(
@@ -2024,38 +1965,25 @@ public class SessionKeeper {
                                         _usernamePasswordAuthButton.setSelected(true);
                                     }
                                 }
-                                break;
                             }
-                            case RoutedCustomEndpointStep:
-                            {
+                            case RoutedCustomEndpointStep -> {
                                 try {
-                                    Identity id =
-                                        new Identity();
+                                    Identity id = new Identity();
                                     id.name = "router";
                                     id.category = _routedInstanceName.getText();
                                     StringBuilder endpoint = new StringBuilder();
-                                    endpoint.append(_coordinator
-                                        .getCommunicator()
-                                        .identityToString(id));
+                                    endpoint.append(_coordinator.getCommunicator().identityToString(id));
                                     endpoint.append(":");
                                     endpoint.append(_routedCustomEndpointValue.getText());
-                                    _coordinator
-                                        .getCommunicator()
-                                        .stringToProxy(endpoint.toString());
+                                    _coordinator.getCommunicator().stringToProxy(endpoint.toString());
                                     if (containsSecureEndpoints(endpoint.toString())) {
-                                        _cardLayout.show(
-                                            _cardPanel,
-                                            WizardStep.X509CertificateStep.toString());
+                                        _cardLayout.show(_cardPanel, WizardStep.X509CertificateStep.toString());
                                         _wizardSteps.push(WizardStep.X509CertificateStep);
                                     } else {
                                         _cardLayout.show(
                                             _cardPanel,
-                                            WizardStep
-                                                .RoutedUsernamePasswordCredentialsStep
-                                                .toString());
-                                        _wizardSteps.push(
-                                            WizardStep
-                                                .RoutedUsernamePasswordCredentialsStep);
+                                            WizardStep.RoutedUsernamePasswordCredentialsStep.toString());
+                                        _wizardSteps.push(WizardStep.RoutedUsernamePasswordCredentialsStep);
                                     }
                                 } catch (ParseException ex) {
                                     JOptionPane.showMessageDialog(
@@ -2075,90 +2003,54 @@ public class SessionKeeper {
                                         _usernamePasswordAuthButton.setSelected(true);
                                     }
                                 }
-                                break;
                             }
 
-                            case X509CertificateStep:
-                            {
+                            case X509CertificateStep -> {
                                 if (_x509CertificateYesButton.isSelected()) {
                                     if (_directConnection.isSelected()) {
                                         loadCertificateAliases(_directCertificateAliases);
-                                        _cardLayout.show(
-                                            _cardPanel,
-                                            WizardStep.DirectX509CredentialsStep
-                                                .toString());
-                                        _wizardSteps.push(
-                                            WizardStep.DirectX509CredentialsStep);
+                                        _cardLayout.show(_cardPanel, WizardStep.DirectX509CredentialsStep.toString());
+                                        _wizardSteps.push(WizardStep.DirectX509CredentialsStep);
                                     } else {
                                         loadCertificateAliases(_routedCertificateAliases);
-                                        _cardLayout.show(
-                                            _cardPanel,
-                                            WizardStep.RoutedX509CredentialsStep
-                                                .toString());
-                                        _wizardSteps.push(
-                                            WizardStep.RoutedX509CredentialsStep);
+                                        _cardLayout.show(_cardPanel, WizardStep.RoutedX509CredentialsStep.toString());
+                                        _wizardSteps.push(WizardStep.RoutedX509CredentialsStep);
                                     }
                                 } else {
                                     if (_directConnection.isSelected()) {
                                         _cardLayout.show(
                                             _cardPanel,
-                                            WizardStep
-                                                .DirectUsernamePasswordCredentialsStep
-                                                .toString());
-                                        _wizardSteps.push(
-                                            WizardStep
-                                                .DirectUsernamePasswordCredentialsStep);
+                                            WizardStep.DirectUsernamePasswordCredentialsStep.toString());
+                                        _wizardSteps.push(WizardStep.DirectUsernamePasswordCredentialsStep);
                                     } else {
                                         _cardLayout.show(
                                             _cardPanel,
-                                            WizardStep
-                                                .RoutedUsernamePasswordCredentialsStep
-                                                .toString());
-                                        _wizardSteps.push(
-                                            WizardStep
-                                                .RoutedUsernamePasswordCredentialsStep);
+                                            WizardStep.RoutedUsernamePasswordCredentialsStep.toString());
+                                        _wizardSteps.push(WizardStep.RoutedUsernamePasswordCredentialsStep);
                                     }
                                 }
-                                break;
                             }
-                            case RoutedX509CredentialsStep:
-                            case DirectX509CredentialsStep:
-                            {
-                                _cardLayout.show(
-                                    _cardPanel, WizardStep.AuthStep.toString());
+                            case RoutedX509CredentialsStep, DirectX509CredentialsStep -> {
+                                _cardLayout.show(_cardPanel, WizardStep.AuthStep.toString());
                                 _wizardSteps.push(WizardStep.AuthStep);
-                                break;
                             }
-                            case AuthStep:
-                            {
+                            case AuthStep -> {
                                 if (_usernamePasswordAuthButton.isSelected()) {
                                     if (_directConnection.isSelected()) {
                                         _cardLayout.show(
                                             _cardPanel,
-                                            WizardStep
-                                                .DirectUsernamePasswordCredentialsStep
-                                                .toString());
-                                        _wizardSteps.push(
-                                            WizardStep
-                                                .DirectUsernamePasswordCredentialsStep);
+                                            WizardStep.DirectUsernamePasswordCredentialsStep.toString());
+                                        _wizardSteps.push(WizardStep.DirectUsernamePasswordCredentialsStep);
                                     } else {
                                         _cardLayout.show(
                                             _cardPanel,
-                                            WizardStep
-                                                .RoutedUsernamePasswordCredentialsStep
-                                                .toString());
-                                        _wizardSteps.push(
-                                            WizardStep
-                                                .RoutedUsernamePasswordCredentialsStep);
+                                            WizardStep.RoutedUsernamePasswordCredentialsStep.toString());
+                                        _wizardSteps.push(WizardStep.RoutedUsernamePasswordCredentialsStep);
                                     }
                                 }
-                                break;
                             }
 
-                            default:
-                            {
-                                break;
-                            }
+                            default -> {}
                         }
                         if (!_wizardSteps.isEmpty()) {
                             _backButton.setEnabled(true);
@@ -2205,13 +2097,11 @@ public class SessionKeeper {
                             }
 
                             if (_x509CertificateYesButton.isSelected()) {
-                                inf.setAlias(
-                                    (String) _directCertificateAliases.getSelectedItem());
+                                inf.setAlias((String) _directCertificateAliases.getSelectedItem());
                                 if (_directCertificatePassword.getPassword() != null
                                     && _directCertificatePassword.getPassword().length
                                     > 0) {
-                                    inf.setKeyPassword(
-                                        _directCertificatePassword.getPassword());
+                                    inf.setKeyPassword(_directCertificatePassword.getPassword());
                                     inf.setStoreKeyPassword(true);
                                 } else {
                                     inf.setKeyPassword(null);
@@ -2251,13 +2141,11 @@ public class SessionKeeper {
                             }
 
                             if (_x509CertificateYesButton.isSelected()) {
-                                inf.setAlias(
-                                    (String) _routedCertificateAliases.getSelectedItem());
+                                inf.setAlias((String) _routedCertificateAliases.getSelectedItem());
                                 if (_routedCertificatePassword.getPassword() != null
                                     && _routedCertificatePassword.getPassword().length
                                     > 0) {
-                                    inf.setKeyPassword(
-                                        _routedCertificatePassword.getPassword());
+                                    inf.setKeyPassword(_routedCertificatePassword.getPassword());
                                     inf.setStoreKeyPassword(true);
                                 } else {
                                     inf.setKeyPassword(null);
@@ -2341,101 +2229,72 @@ public class SessionKeeper {
 
             boolean lastStep = false; // No next step
             switch (step) {
-                case DirectDiscoveryChooseStep:
-                {
+                case DirectDiscoveryChooseStep -> {
                     if (_directDiscoveryManualEndpoint.isSelected()) {
                         _directDiscoveryManualEndpoint.requestFocusInWindow();
                     } else {
                         _directDiscoveryLocatorList.requestFocusInWindow();
                     }
-                    break;
                 }
 
-                case DirectEndpointStep:
-                {
+                case DirectEndpointStep -> {
                     if (_directDefaultEndpoints.isSelected()) {
                         _directDefaultEndpoints.requestFocusInWindow();
                     } else {
                         _directCustomEndpoints.requestFocusInWindow();
                     }
-                    break;
                 }
-                case DirectDefaultEndpointStep:
-                {
+                case DirectDefaultEndpointStep -> {
                     _directDefaultEndpointHost.requestFocusInWindow();
-                    break;
                 }
-                case DirectCustomEndpointStep:
-                {
+                case DirectCustomEndpointStep -> {
                     _directCustomEndpointValue.requestFocusInWindow();
-                    break;
                 }
 
-                case RoutedEndpointStep:
-                {
+                case RoutedEndpointStep -> {
                     if (_routedDefaultEndpoints.isSelected()) {
                         _routedDefaultEndpoints.requestFocusInWindow();
                     } else {
                         _routedCustomEndpoints.requestFocusInWindow();
                     }
-                    break;
                 }
-                case RoutedDefaultEndpointStep:
-                {
+                case RoutedDefaultEndpointStep -> {
                     _routedDefaultEndpointHost.requestFocusInWindow();
-                    break;
                 }
-                case RoutedCustomEndpointStep:
-                {
+                case RoutedCustomEndpointStep -> {
                     _routedCustomEndpointValue.requestFocusInWindow();
-                    break;
                 }
-                case X509CertificateStep:
-                {
+                case X509CertificateStep -> {
                     if (_x509CertificateYesButton.isSelected()) {
                         _x509CertificateYesButton.requestFocusInWindow();
                     } else {
                         _x509CertificateNoButton.requestFocusInWindow();
                     }
-                    break;
                 }
-                case DirectX509CredentialsStep:
-                {
+                case DirectX509CredentialsStep -> {
                     _directCertificateAliases.requestFocusInWindow();
-                    break;
                 }
-                case RoutedX509CredentialsStep:
-                {
+                case RoutedX509CredentialsStep -> {
                     _routedCertificateAliases.requestFocusInWindow();
-                    break;
                 }
-                case AuthStep:
-                {
+                case AuthStep -> {
                     if (_usernamePasswordAuthButton.isSelected()) {
                         _usernamePasswordAuthButton.requestFocusInWindow();
                     } else {
                         lastStep = true;
                         _certificateAuthButton.requestFocusInWindow();
                     }
-                    break;
                 }
-                case DirectUsernamePasswordCredentialsStep:
-                {
+                case DirectUsernamePasswordCredentialsStep -> {
                     lastStep = true;
                     _directUsername.requestFocusInWindow();
-                    break;
                 }
-                case RoutedUsernamePasswordCredentialsStep:
-                {
+                case RoutedUsernamePasswordCredentialsStep -> {
                     lastStep = true;
                     _routedUsername.requestFocusInWindow();
-                    break;
                 }
 
-                default:
-                {
-                    break;
-                }
+                default -> {}
             }
 
             boolean validated = validateWizardStep(step);
@@ -2459,24 +2318,19 @@ public class SessionKeeper {
         boolean validateWizardStep(WizardStep step) {
             boolean validated = false;
             switch (step) {
-                case ConnectionTypeStep:
-                {
+                case ConnectionTypeStep -> {
                     validated = true;
-                    break;
                 }
 
-                case DirectDiscoveryChooseStep:
-                {
+                case DirectDiscoveryChooseStep -> {
                     if (_directDiscoveryManualEndpoint.isSelected()) {
                         validated = true;
                     } else {
                         validated = _directDiscoveryLocatorList.getSelectedValue() != null;
                     }
-                    break;
                 }
 
-                case DirectDefaultEndpointStep:
-                {
+                case DirectDefaultEndpointStep -> {
                     validated =
                         _directDefaultEndpointHost.getText() != null
                             && _directDefaultEndpointHost.getText().length() > 0;
@@ -2493,18 +2347,14 @@ public class SessionKeeper {
                                 JOptionPane.ERROR_MESSAGE);
                         }
                     }
-                    break;
                 }
-                case DirectCustomEndpointStep:
-                {
+                case DirectCustomEndpointStep -> {
                     validated =
                         _directCustomEndpointValue.getText() != null
                             && _directCustomEndpointValue.getText().length() > 0;
-                    break;
                 }
 
-                case RoutedDefaultEndpointStep:
-                {
+                case RoutedDefaultEndpointStep -> {
                     validated =
                         _routedDefaultEndpointHost.getText() != null
                             && _routedDefaultEndpointHost.getText().length() > 0;
@@ -2521,53 +2371,34 @@ public class SessionKeeper {
                                 JOptionPane.ERROR_MESSAGE);
                         }
                     }
-                    break;
                 }
-                case RoutedCustomEndpointStep:
-                {
+                case RoutedCustomEndpointStep -> {
                     validated =
                         _routedCustomEndpointValue.getText() != null
                             && _routedCustomEndpointValue.getText().length() > 0;
-                    break;
                 }
-                case DirectX509CredentialsStep:
-                {
+                case DirectX509CredentialsStep -> {
                     validated = _directCertificateAliases.getSelectedItem() != null;
-                    break;
                 }
-                case RoutedX509CredentialsStep:
-                {
+                case RoutedX509CredentialsStep -> {
                     validated = _routedCertificateAliases.getSelectedItem() != null;
-                    break;
                 }
-                case DirectUsernamePasswordCredentialsStep:
-                {
+                case DirectUsernamePasswordCredentialsStep -> {
                     validated =
                         _directUsername.getText() != null
                             && _directUsername.getText().length() > 0;
-                    break;
                 }
-                case RoutedUsernamePasswordCredentialsStep:
-                {
+                case RoutedUsernamePasswordCredentialsStep -> {
                     validated =
                         _routedUsername.getText() != null
                             && _routedUsername.getText().length() > 0;
-                    break;
                 }
 
-                case DirectMasterStep:
-                case RoutedEndpointStep:
-                case DirectEndpointStep:
-                case AuthStep:
-                case X509CertificateStep:
-                {
+                case DirectMasterStep, RoutedEndpointStep, DirectEndpointStep, AuthStep, X509CertificateStep -> {
                     validated = true;
-                    break;
                 }
-                default:
-                {
-                    break;
-                }
+
+                default -> {}
             }
             return validated;
         }
@@ -2672,14 +2503,12 @@ public class SessionKeeper {
                         if (_conf.getSSL()) {
                             _directDefaultEndpointSSL.setSelected(true);
                             if (!_conf.getDefaultPort()) {
-                                _directDefaultEndpointPort.setText(
-                                    Integer.toString(_conf.getPort()));
+                                _directDefaultEndpointPort.setText(Integer.toString(_conf.getPort()));
                             }
                         } else {
                             _directDefaultEndpointTCP.setSelected(true);
                             if (!_conf.getDefaultPort()) {
-                                _directDefaultEndpointPort.setText(
-                                    Integer.toString(_conf.getPort()));
+                                _directDefaultEndpointPort.setText(Integer.toString(_conf.getPort()));
                             }
                         }
                     } else {
@@ -2711,14 +2540,12 @@ public class SessionKeeper {
                         if (_conf.getSSL()) {
                             _routedDefaultEndpointSSL.setSelected(true);
                             if (!_conf.getDefaultPort()) {
-                                _routedDefaultEndpointPort.setText(
-                                    Integer.toString(_conf.getPort()));
+                                _routedDefaultEndpointPort.setText(Integer.toString(_conf.getPort()));
                             }
                         } else {
                             _routedDefaultEndpointTCP.setSelected(true);
                             if (!_conf.getDefaultPort()) {
-                                _routedDefaultEndpointPort.setText(
-                                    Integer.toString(_conf.getPort()));
+                                _routedDefaultEndpointPort.setText(Integer.toString(_conf.getPort()));
                             }
                         }
                     } else {
@@ -2867,8 +2694,7 @@ public class SessionKeeper {
 
     private boolean containsSecureEndpoints(String str) {
         try {
-            for (Endpoint endpoint :
-                    _coordinator.getCommunicator().stringToProxy(str).ice_getEndpoints()) {
+            for (Endpoint endpoint : _coordinator.getCommunicator().stringToProxy(str).ice_getEndpoints()) {
                 if (endpoint.getInfo().secure()) {
                     return true;
                 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CommunicatorFlushBatch.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/CommunicatorFlushBatch.java
@@ -109,10 +109,9 @@ class CommunicatorFlushBatch extends InvocationFuture<Void> {
         } catch (ExecutionException ee) {
             try {
                 throw ee.getCause().fillInStackTrace();
-            } catch (RuntimeException ex) // Includes LocalException
-                {
-                    throw ex;
-                } catch (Throwable ex) {
+            } catch (RuntimeException ex /* Includes LocalException */) {
+                throw ex;
+            } catch (Throwable ex) {
                 throw new UnknownException(ex);
             }
         }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -716,16 +716,15 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                 // thread and let IO be performed on this new leader thread while this thread
                 // continues with dispatching the up-calls.
                 current.ioCompleted();
-            } catch (DatagramLimitException ex) // Expected.
-                {
-                    if (_warnUdp) {
-                        _logger.warning("maximum datagram size of " + _readStream.pos() + " exceeded");
-                    }
-                    _readStream.resize(Protocol.headerSize);
-                    _readStream.pos(0);
-                    _readHeader = true;
-                    return;
-                } catch (SocketException ex) {
+            } catch (DatagramLimitException expected) {
+                if (_warnUdp) {
+                    _logger.warning("maximum datagram size of " + _readStream.pos() + " exceeded");
+                }
+                _readStream.resize(Protocol.headerSize);
+                _readStream.pos(0);
+                _readHeader = true;
+                return;
+            } catch (SocketException ex) {
                 setState(StateClosed, ex);
                 return;
             } catch (LocalException ex) {
@@ -744,10 +743,10 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
             }
         }
 
-        if (!_executor) // Optimization, call upcall() directly if there's no executor.
-            {
-                upcall(startCB, sentCBs, info);
-            } else {
+        if (!_executor) {
+            // Optimization, call upcall() directly if there's no executor.
+            upcall(startCB, sentCBs, info);
+        } else {
             if (info != null) {
                 //
                 // Create a new stream for the dispatch instead of using the thread pool's thread
@@ -888,11 +887,10 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
         }
 
         current.ioCompleted();
-        if (!_executor) // Optimization, call finish() directly if there's no
-            // executor.
-            {
-                finish(close);
-            } else {
+        if (!_executor) {
+            // Optimization, call finish() directly if there's no executor.
+            finish(close);
+        } else {
             _threadPool.executeFromThisThread(
                 new RunnableThreadPoolWorkItem(this) {
                     @Override
@@ -975,10 +973,11 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
             for (OutgoingMessage p : _sendStreams) {
                 p.completed(_exception);
-                if (p.requestId > 0) // Make sure finished isn't called twice.
-                    {
-                        _asyncRequests.remove(p.requestId);
-                    }
+
+                // Make sure finished isn't called twice.
+                if (p.requestId > 0) {
+                    _asyncRequests.remove(p.requestId);
+                }
             }
             _sendStreams.clear();
         }
@@ -1267,32 +1266,23 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
     private static final int StateFinished = 7;
 
     private void setState(int state, LocalException ex) {
-        //
-        // If setState() is called with an exception, then only closed
-        // and closing states are permissible.
-        //
+        // If setState() is called with an exception, then only closed and closing states are permissible.
         assert state >= StateClosing;
 
-        if (_state == state) // Don't switch twice.
-            {
-                return;
-            }
+        // Don't switch twice.
+        if (_state == state) {
+            return;
+        }
 
         if (_exception == null) {
-            //
             // If we are in closed state, an exception must be set.
-            //
             assert (_state != StateClosed);
 
             _exception = ex;
 
-            //
             // We don't warn if we are not validated.
-            //
             if (_warn && _validated) {
-                //
                 // Don't warn about certain expected exceptions.
-                //
                 if (!(_exception instanceof CloseConnectionException
                     || _exception instanceof ConnectionAbortedException
                     || _exception instanceof ConnectionClosedException
@@ -1306,26 +1296,19 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
             }
         }
 
-        //
-        // We must set the new state before we notify requests of any
-        // exceptions. Otherwise new requests may retry on a connection that is not yet marked as
-        // closed or closing.
-        //
+        // We must set the new state before we notify requests of any exceptions.
+        // Otherwise new requests may retry on a connection that is not yet marked as closed or closing.
         setState(state);
     }
 
     private void setState(int state) {
-        //
         // We don't want to send close connection messages if the endpoint
         // only supports oneway transmission from client to server.
-        //
         if (_endpoint.datagram() && state == StateClosing) {
             state = StateClosed;
         }
 
-        //
         // Skip graceful shutdown if we are destroyed before validation.
-        //
         if (_state <= StateNotValidated && state == StateClosing) {
             state = StateClosed;
         }
@@ -1369,16 +1352,13 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                             _idleTimeoutTransceiver.enableIdleCheck();
                         }
                     }
-                    // else don't resume reading since we're at or over the _maxDispatches
-                    // limit.
+                    // else don't resume reading since we're at or over the _maxDispatches limit.
                     break;
                 }
 
                 case StateHolding:
                 {
-                    //
                     // Can only switch from active or not validated to holding.
-                    //
                     if (_state != StateActive && _state != StateNotValidated) {
                         return;
                     }
@@ -1389,17 +1369,14 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                             _idleTimeoutTransceiver.disableIdleCheck();
                         }
                     }
-                    // else reads are already disabled because the _maxDispatches limit is
-                    // reached or exceeded.
+                    // else reads are already disabled because the _maxDispatches limit is reached or exceeded.
                     break;
                 }
 
                 case StateClosing:
                 case StateClosingPending:
                 {
-                    //
                     // Can't change back from closing pending.
-                    //
                     if (_state >= StateClosingPending) {
                         return;
                     }
@@ -1414,10 +1391,8 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
                     _batchRequestQueue.destroy(_exception);
 
-                    //
                     // Don't need to close now for connections so only close the transceiver if
-                    // the selector request it.
-                    //
+                    // the selector requested it.
                     if (_threadPool.finish(this, false)) {
                         _transceiver.close();
                     }
@@ -1537,113 +1512,112 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
     }
 
     private boolean validate(int operation) {
-        if (!_endpoint.datagram()) // Datagram connections are always implicitly
-            // validated.
-            {
-                if (_connector == null) // The server side has the active role for
-                    // connection validation.
-                    {
-                        if (_writeStream.isEmpty()) {
-                            _writeStream.writeBlob(Protocol.magic);
-                            Protocol.currentProtocol.ice_writeMembers(_writeStream);
-                            Protocol.currentProtocolEncoding.ice_writeMembers(_writeStream);
-                            _writeStream.writeByte(Protocol.validateConnectionMsg);
-                            _writeStream.writeByte((byte) 0); // Compression status
-                            // (always zero for validate connection).
-                            _writeStream.writeInt(Protocol.headerSize); // Message size.
-                            TraceUtil.traceSend(_writeStream, _instance, this, _logger, _traceLevels);
-                            _writeStream.prepareWrite();
-                        }
+        // Datagram connections are always implicitly validated.
+        if (!_endpoint.datagram()) {
+            if (_connector == null) {
+                // The server side has the active role for connection validation.
 
-                        if (_observer != null) {
-                            observerStartWrite(_writeStream.getBuffer());
-                        }
+                if (_writeStream.isEmpty()) {
+                    _writeStream.writeBlob(Protocol.magic);
+                    Protocol.currentProtocol.ice_writeMembers(_writeStream);
+                    Protocol.currentProtocolEncoding.ice_writeMembers(_writeStream);
+                    _writeStream.writeByte(Protocol.validateConnectionMsg);
+                    _writeStream.writeByte((byte) 0); // Compression status
+                    // (always zero for validate connection).
+                    _writeStream.writeInt(Protocol.headerSize); // Message size.
+                    TraceUtil.traceSend(_writeStream, _instance, this, _logger, _traceLevels);
+                    _writeStream.prepareWrite();
+                }
 
-                        if (_writeStream.pos() != _writeStream.size()) {
-                            int op = write(_writeStream.getBuffer());
-                            if (op != 0) {
-                                _threadPool.update(this, operation, op);
-                                return false;
-                            }
-                        }
+                if (_observer != null) {
+                    observerStartWrite(_writeStream.getBuffer());
+                }
 
-                        if (_observer != null) {
-                            observerFinishWrite(_writeStream.getBuffer());
-                        }
-                    } else
-                // The client side has the passive role for connection validation.
-                {
-                    if (_readStream.isEmpty()) {
-                        _readStream.resize(Protocol.headerSize);
-                        _readStream.pos(0);
-                    }
-
-                    if (_observer != null) {
-                        observerStartRead(_readStream.getBuffer());
-                    }
-
-                    if (_readStream.pos() != _readStream.size()) {
-                        int op = read(_readStream.getBuffer());
-                        if (op != 0) {
-                            _threadPool.update(this, operation, op);
-                            return false;
-                        }
-                    }
-
-                    if (_observer != null) {
-                        observerFinishRead(_readStream.getBuffer());
-                    }
-
-                    _validated = true;
-
-                    assert (_readStream.pos() == Protocol.headerSize);
-                    _readStream.pos(0);
-                    byte[] m = _readStream.readBlob(4);
-                    if (m[0] != Protocol.magic[0]
-                        || m[1] != Protocol.magic[1]
-                        || m[2] != Protocol.magic[2]
-                        || m[3] != Protocol.magic[3]) {
-                        throw new ProtocolException(
-                            "Bad magic in message header: "
-                                + Integer.toHexString(m[0])
-                                + " "
-                                + Integer.toHexString(m[1])
-                                + " "
-                                + Integer.toHexString(m[2])
-                                + " "
-                                + Integer.toHexString(m[3]));
-                    }
-
-                    _readProtocol.ice_readMembers(_readStream);
-                    Protocol.checkSupportedProtocol(_readProtocol);
-
-                    _readProtocolEncoding.ice_readMembers(_readStream);
-                    Protocol.checkSupportedProtocolEncoding(_readProtocolEncoding);
-
-                    byte messageType = _readStream.readByte();
-                    if (messageType != Protocol.validateConnectionMsg) {
-                        throw new ProtocolException(
-                            "Received message of type "
-                                + messageType
-                                + " over a connection that is not yet validated.");
-                    }
-                    _readStream.readByte(); // Ignore compression status for validate connection.
-                    int size = _readStream.readInt();
-                    if (size != Protocol.headerSize) {
-                        throw new MarshalException(
-                            "Received ValidateConnection message with unexpected size "
-                                + size
-                                + ".");
-                    }
-                    TraceUtil.traceRecv(_readStream, this, _logger, _traceLevels);
-
-                    // Client connection starts sending heartbeats once it has received the
-                    // ValidateConnection message.
-                    if (_idleTimeoutTransceiver != null) {
-                        _idleTimeoutTransceiver.scheduleHeartbeat();
+                if (_writeStream.pos() != _writeStream.size()) {
+                    int op = write(_writeStream.getBuffer());
+                    if (op != 0) {
+                        _threadPool.update(this, operation, op);
+                        return false;
                     }
                 }
+
+                if (_observer != null) {
+                    observerFinishWrite(_writeStream.getBuffer());
+                }
+            } else {
+                // The client side has the passive role for connection validation.
+
+                if (_readStream.isEmpty()) {
+                    _readStream.resize(Protocol.headerSize);
+                    _readStream.pos(0);
+                }
+
+                if (_observer != null) {
+                    observerStartRead(_readStream.getBuffer());
+                }
+
+                if (_readStream.pos() != _readStream.size()) {
+                    int op = read(_readStream.getBuffer());
+                    if (op != 0) {
+                        _threadPool.update(this, operation, op);
+                        return false;
+                    }
+                }
+
+                if (_observer != null) {
+                    observerFinishRead(_readStream.getBuffer());
+                }
+
+                _validated = true;
+
+                assert (_readStream.pos() == Protocol.headerSize);
+                _readStream.pos(0);
+                byte[] m = _readStream.readBlob(4);
+                if (m[0] != Protocol.magic[0]
+                    || m[1] != Protocol.magic[1]
+                    || m[2] != Protocol.magic[2]
+                    || m[3] != Protocol.magic[3]) {
+                    throw new ProtocolException(
+                        "Bad magic in message header: "
+                            + Integer.toHexString(m[0])
+                            + " "
+                            + Integer.toHexString(m[1])
+                            + " "
+                            + Integer.toHexString(m[2])
+                            + " "
+                            + Integer.toHexString(m[3]));
+                }
+
+                _readProtocol.ice_readMembers(_readStream);
+                Protocol.checkSupportedProtocol(_readProtocol);
+
+                _readProtocolEncoding.ice_readMembers(_readStream);
+                Protocol.checkSupportedProtocolEncoding(_readProtocolEncoding);
+
+                byte messageType = _readStream.readByte();
+                if (messageType != Protocol.validateConnectionMsg) {
+                    throw new ProtocolException(
+                        "Received message of type "
+                            + messageType
+                            + " over a connection that is not yet validated.");
+                }
+                _readStream.readByte(); // Ignore compression status for validate connection.
+                int size = _readStream.readInt();
+                if (size != Protocol.headerSize) {
+                    throw new MarshalException(
+                        "Received ValidateConnection message with unexpected size "
+                            + size
+                            + ".");
+                }
+                TraceUtil.traceRecv(_readStream, this, _logger, _traceLevels);
+
+                // Client connection starts sending heartbeats once it has received the
+                // ValidateConnection message.
+                if (_idleTimeoutTransceiver != null) {
+                    _idleTimeoutTransceiver.scheduleHeartbeat();
+                }
             }
+        }
 
         _writeStream.resize(0);
         _writeStream.pos(0);
@@ -2235,11 +2209,10 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
     private ConnectionInfo initConnectionInfo() {
         // Called in synchronization
 
-        if (_state > StateNotInitialized
-            && _info != null) // Update the connection information until it's initialized
-            {
-                return _info;
-            }
+        // Update the connection information until it's initialized
+        if (_state > StateNotInitialized && _info != null) {
+            return _info;
+        }
 
         boolean incoming = _connector == null;
         _info =

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -115,19 +115,14 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
     public synchronized void destroy(int reason) {
         switch (reason) {
-            case ObjectAdapterDeactivated:
-            {
+            case ObjectAdapterDeactivated -> {
                 setState(
                     StateClosing,
-                    new ObjectAdapterDeactivatedException(
-                        _adapter != null ? _adapter.getName() : ""));
-                break;
+                    new ObjectAdapterDeactivatedException(_adapter != null ? _adapter.getName() : ""));
             }
 
-            case CommunicatorDestroyed:
-            {
+            case CommunicatorDestroyed -> {
                 setState(StateClosing, new CommunicatorDestroyedException());
-                break;
             }
         }
     }
@@ -1324,23 +1319,18 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
 
         try {
             switch (state) {
-                case StateNotInitialized:
-                {
+                case StateNotInitialized -> {
                     assert false;
-                    break;
                 }
 
-                case StateNotValidated:
-                {
+                case StateNotValidated -> {
                     if (_state != StateNotInitialized) {
                         assert (_state == StateClosed);
                         return;
                     }
-                    break;
                 }
 
-                case StateActive:
-                {
+                case StateActive -> {
                     // Can only switch from holding or not validated to active.
                     if (_state != StateHolding && _state != StateNotValidated) {
                         return;
@@ -1353,11 +1343,9 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                         }
                     }
                     // else don't resume reading since we're at or over the _maxDispatches limit.
-                    break;
                 }
 
-                case StateHolding:
-                {
+                case StateHolding -> {
                     // Can only switch from active or not validated to holding.
                     if (_state != StateActive && _state != StateNotValidated) {
                         return;
@@ -1370,21 +1358,16 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                         }
                     }
                     // else reads are already disabled because the _maxDispatches limit is reached or exceeded.
-                    break;
                 }
 
-                case StateClosing:
-                case StateClosingPending:
-                {
+                case StateClosing, StateClosingPending -> {
                     // Can't change back from closing pending.
                     if (_state >= StateClosingPending) {
                         return;
                     }
-                    break;
                 }
 
-                case StateClosed:
-                {
+                case StateClosed -> {
                     if (_state == StateFinished) {
                         return;
                     }
@@ -1396,14 +1379,11 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                     if (_threadPool.finish(this, false)) {
                         _transceiver.close();
                     }
-                    break;
                 }
 
-                case StateFinished:
-                {
+                case StateFinished -> {
                     assert (_state == StateClosed);
                     _communicator = null;
-                    break;
                 }
             }
         } catch (LocalException ex) {
@@ -1922,8 +1902,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
             info.stream.pos(Protocol.headerSize);
 
             switch (messageType) {
-                case Protocol.closeConnectionMsg:
-                {
+                case Protocol.closeConnectionMsg: {
                     TraceUtil.traceRecv(info.stream, this, _logger, _traceLevels);
                     if (_endpoint.datagram()) {
                         if (_warn) {
@@ -1948,8 +1927,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                     break;
                 }
 
-                case Protocol.requestMsg:
-                {
+                case Protocol.requestMsg: {
                     if (_state >= StateClosing) {
                         TraceUtil.trace(
                             "received request during closing\n"
@@ -1971,8 +1949,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                     break;
                 }
 
-                case Protocol.requestBatchMsg:
-                {
+                case Protocol.requestBatchMsg: {
                     if (_state >= StateClosing) {
                         TraceUtil.trace(
                             "received batch request during closing\n"
@@ -2000,8 +1977,7 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                     break;
                 }
 
-                case Protocol.replyMsg:
-                {
+                case Protocol.replyMsg: {
                     TraceUtil.traceRecv(info.stream, this, _logger, _traceLevels);
                     info.requestId = info.stream.readInt();
 
@@ -2016,14 +1992,12 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                     break;
                 }
 
-                case Protocol.validateConnectionMsg:
-                {
+                case Protocol.validateConnectionMsg: {
                     TraceUtil.traceRecv(info.stream, this, _logger, _traceLevels);
                     break;
                 }
 
-                default:
-                {
+                default: {
                     TraceUtil.trace(
                         "received unknown message\n(invalid, closing connection)",
                         info.stream,

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/FixedReference.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/FixedReference.java
@@ -178,23 +178,16 @@ class FixedReference extends Reference {
         // `changeConnection()` clones then sets the connection.
 
         switch (getMode()) {
-            case Reference.ModeTwoway:
-            case Reference.ModeOneway:
-            case Reference.ModeBatchOneway:
-            {
+            case Reference.ModeTwoway, Reference.ModeOneway, Reference.ModeBatchOneway -> {
                 if (_fixedConnection.endpoint().datagram()) {
                     throw new NoEndpointException(new _ObjectPrxI(this));
                 }
-                break;
             }
 
-            case Reference.ModeDatagram:
-            case Reference.ModeBatchDatagram:
-            {
+            case Reference.ModeDatagram, Reference.ModeBatchDatagram -> {
                 if (!_fixedConnection.endpoint().datagram()) {
                     throw new NoEndpointException(new _ObjectPrxI(this));
                 }
-                break;
             }
         }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/HttpParser.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/HttpParser.java
@@ -98,15 +98,15 @@ final class HttpParser {
                 }
                 case TypeCheck:
                 {
-                    if (c == 'T') // Continuing "H_T_TP/1.1"
-                        {
-                            _state = State.Response;
-                        } else if (c == 'E') // Expecting "HEAD"
-                        {
-                            _state = State.Request;
-                            _method.append('H');
-                            _method.append('E');
-                        } else {
+                    if (c == 'T') {
+                        // Continuing "H_T_TP/1.1"
+                        _state = State.Response;
+                    } else if (c == 'E') {
+                        // Expecting "HEAD"
+                        _state = State.Request;
+                        _method.append('H');
+                        _method.append('E');
+                    } else {
                         throw new WebSocketException("malformed request or response");
                     }
                     break;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/HttpParser.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/HttpParser.java
@@ -69,8 +69,7 @@ final class HttpParser {
             char c = (char) buf.get(p);
 
             switch (_state) {
-                case Init:
-                {
+                case Init: {
                     _method.setLength(0);
                     _uri.setLength(0);
                     _versionMajor = -1;
@@ -81,14 +80,11 @@ final class HttpParser {
                     _state = State.Type;
                     continue;
                 }
-                case Type:
-                {
+                case Type: {
                     if (c == CR || c == LF) {
                         break;
                     } else if (c == 'H') {
-                        //
                         // Could be the start of "HTTP/1.1" or "HEAD".
-                        //
                         _state = State.TypeCheck;
                         break;
                     } else {
@@ -96,8 +92,7 @@ final class HttpParser {
                         continue;
                     }
                 }
-                case TypeCheck:
-                {
+                case TypeCheck: {
                     if (c == 'T') {
                         // Continuing "H_T_TP/1.1"
                         _state = State.Response;
@@ -111,14 +106,12 @@ final class HttpParser {
                     }
                     break;
                 }
-                case Request:
-                {
+                case Request: {
                     _type = Type.Request;
                     _state = State.RequestMethod;
                     continue;
                 }
-                case RequestMethod:
-                {
+                case RequestMethod: {
                     if (c == ' ' || c == CR || c == LF) {
                         _state = State.RequestMethodSP;
                         continue;
@@ -126,8 +119,7 @@ final class HttpParser {
                     _method.append(c);
                     break;
                 }
-                case RequestMethodSP:
-                {
+                case RequestMethodSP: {
                     if (c == ' ') {
                         break;
                     } else if (c == CR || c == LF) {
@@ -136,8 +128,7 @@ final class HttpParser {
                     _state = State.RequestURI;
                     continue;
                 }
-                case RequestURI:
-                {
+                case RequestURI: {
                     if (c == ' ' || c == CR || c == LF) {
                         _state = State.RequestURISP;
                         continue;
@@ -145,8 +136,7 @@ final class HttpParser {
                     _uri.append(c);
                     break;
                 }
-                case RequestURISP:
-                {
+                case RequestURISP: {
                     if (c == ' ') {
                         break;
                     } else if (c == CR || c == LF) {
@@ -155,21 +145,17 @@ final class HttpParser {
                     _state = State.Version;
                     continue;
                 }
-                case RequestLF:
-                {
+                case RequestLF: {
                     if (c != LF) {
                         throw new WebSocketException("malformed request");
                     }
                     _state = State.HeaderFieldStart;
                     break;
                 }
-                case HeaderFieldStart:
-                {
-                    //
+                case HeaderFieldStart: {
                     // We've already seen a LF to reach this state.
                     //
                     // Another CR or LF indicates the end of the header fields.
-                    //
                     if (c == CR) {
                         _state = State.HeaderFieldEndLF;
                         break;
@@ -177,9 +163,7 @@ final class HttpParser {
                         _state = State.Complete;
                         break;
                     } else if (c == ' ') {
-                        //
                         // Could be a continuation line.
-                        //
                         _state = State.HeaderFieldContStart;
                         break;
                     }
@@ -187,8 +171,7 @@ final class HttpParser {
                     _state = State.HeaderFieldNameStart;
                     continue;
                 }
-                case HeaderFieldContStart:
-                {
+                case HeaderFieldContStart: {
                     if (c == ' ') {
                         break;
                     }
@@ -197,8 +180,7 @@ final class HttpParser {
                     start = p;
                     continue;
                 }
-                case HeaderFieldCont:
-                {
+                case HeaderFieldCont: {
                     if (c == CR || c == LF) {
                         if (p > start) {
                             if (_headerName.isEmpty()) {
@@ -223,16 +205,14 @@ final class HttpParser {
 
                     break;
                 }
-                case HeaderFieldNameStart:
-                {
+                case HeaderFieldNameStart: {
                     assert (c != ' ');
                     start = p;
                     _headerName = "";
                     _state = State.HeaderFieldName;
                     continue;
                 }
-                case HeaderFieldName:
-                {
+                case HeaderFieldName: {
                     if (c == ' ' || c == ':') {
                         _state = State.HeaderFieldNameEnd;
                         continue;
@@ -241,8 +221,7 @@ final class HttpParser {
                     }
                     break;
                 }
-                case HeaderFieldNameEnd:
-                {
+                case HeaderFieldNameEnd: {
                     if (_headerName.isEmpty()) {
                         StringBuffer str = new StringBuffer();
                         for (int i = start; i < p; i++) {
@@ -267,8 +246,7 @@ final class HttpParser {
                     _state = State.HeaderFieldValueStart;
                     break;
                 }
-                case HeaderFieldValueStart:
-                {
+                case HeaderFieldValueStart: {
                     if (c == ' ') {
                         break;
                     }
@@ -288,16 +266,14 @@ final class HttpParser {
                     _state = State.HeaderFieldValue;
                     continue;
                 }
-                case HeaderFieldValue:
-                {
+                case HeaderFieldValue: {
                     if (c == CR || c == LF) {
                         _state = State.HeaderFieldValueEnd;
                         continue;
                     }
                     break;
                 }
-                case HeaderFieldValueEnd:
-                {
+                case HeaderFieldValueEnd: {
                     assert (c == CR || c == LF);
                     if (p > start) {
                         StringBuffer str = new StringBuffer();
@@ -319,64 +295,56 @@ final class HttpParser {
                     }
                     break;
                 }
-                case HeaderFieldLF:
-                {
+                case HeaderFieldLF: {
                     if (c != LF) {
                         throw new WebSocketException("malformed header");
                     }
                     _state = State.HeaderFieldStart;
                     break;
                 }
-                case HeaderFieldEndLF:
-                {
+                case HeaderFieldEndLF: {
                     if (c != LF) {
                         throw new WebSocketException("malformed header");
                     }
                     _state = State.Complete;
                     break;
                 }
-                case Version:
-                {
+                case Version: {
                     if (c != 'H') {
                         throw new WebSocketException("malformed version");
                     }
                     _state = State.VersionH;
                     break;
                 }
-                case VersionH:
-                {
+                case VersionH: {
                     if (c != 'T') {
                         throw new WebSocketException("malformed version");
                     }
                     _state = State.VersionHT;
                     break;
                 }
-                case VersionHT:
-                {
+                case VersionHT: {
                     if (c != 'T') {
                         throw new WebSocketException("malformed version");
                     }
                     _state = State.VersionHTT;
                     break;
                 }
-                case VersionHTT:
-                {
+                case VersionHTT: {
                     if (c != 'P') {
                         throw new WebSocketException("malformed version");
                     }
                     _state = State.VersionHTTP;
                     break;
                 }
-                case VersionHTTP:
-                {
+                case VersionHTTP: {
                     if (c != '/') {
                         throw new WebSocketException("malformed version");
                     }
                     _state = State.VersionMajor;
                     break;
                 }
-                case VersionMajor:
-                {
+                case VersionMajor: {
                     if (c == '.') {
                         if (_versionMajor == -1) {
                             throw new WebSocketException("malformed version");
@@ -393,8 +361,7 @@ final class HttpParser {
                     _versionMajor += c - '0';
                     break;
                 }
-                case VersionMinor:
-                {
+                case VersionMinor: {
                     if (c == CR) {
                         if (_versionMinor == -1 || _type != Type.Request) {
                             throw new WebSocketException("malformed version");
@@ -423,14 +390,12 @@ final class HttpParser {
                     _versionMinor += c - '0';
                     break;
                 }
-                case Response:
-                {
+                case Response: {
                     _type = Type.Response;
                     _state = State.VersionHT;
                     continue;
                 }
-                case ResponseVersionSP:
-                {
+                case ResponseVersionSP: {
                     if (c == ' ') {
                         break;
                     }
@@ -438,8 +403,7 @@ final class HttpParser {
                     _state = State.ResponseStatus;
                     continue;
                 }
-                case ResponseStatus:
-                {
+                case ResponseStatus: {
                     // TODO: Is reason string optional?
                     if (c == CR) {
                         if (_status == -1) {
@@ -469,8 +433,7 @@ final class HttpParser {
                     _status += c - '0';
                     break;
                 }
-                case ResponseReasonStart:
-                {
+                case ResponseReasonStart: {
                     //
                     // Skip leading spaces.
                     //
@@ -482,8 +445,7 @@ final class HttpParser {
                     start = p;
                     continue;
                 }
-                case ResponseReason:
-                {
+                case ResponseReason: {
                     if (c == CR || c == LF) {
                         if (p > start) {
                             StringBuffer str = new StringBuffer();
@@ -497,16 +459,14 @@ final class HttpParser {
 
                     break;
                 }
-                case ResponseLF:
-                {
+                case ResponseLF: {
                     if (c != LF) {
                         throw new WebSocketException("malformed status line");
                     }
                     _state = State.HeaderFieldStart;
                     break;
                 }
-                case Complete:
-                {
+                case Complete: {
                     assert false; // Shouldn't reach
                 }
             }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IncomingConnectionFactory.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IncomingConnectionFactory.java
@@ -135,17 +135,14 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
         return connections;
     }
 
-    public void flushAsyncBatchRequests(
-            CompressBatch compressBatch, CommunicatorFlushBatch outAsync) {
-        for (ConnectionI c :
-                connections()) // connections() is synchronized, no need to synchronize here.
-            {
-                try {
-                    outAsync.flushConnection(c, compressBatch);
-                } catch (LocalException ex) {
-                    // Ignore.
-                }
+    public void flushAsyncBatchRequests(CompressBatch compressBatch, CommunicatorFlushBatch outAsync) {
+        // connections() is synchronized, no need to synchronize here.
+        for (ConnectionI c : connections()) {
+            try {
+                outAsync.flushConnection(c, compressBatch);
+            } catch (LocalException ignored) {
             }
+        }
     }
 
     //
@@ -437,18 +434,18 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
     private static final int StateFinished = 3;
 
     private void setState(int state) {
-        if (_state == state) // Don't switch twice.
-            {
-                return;
-            }
+        // Don't switch twice.
+        if (_state == state) {
+            return;
+        }
 
         switch (state) {
             case StateActive:
             {
-                if (_state != StateHolding) // Can only switch from holding to active.
-                    {
-                        return;
-                    }
+                // Can only switch from holding to active.
+                if (_state != StateHolding) {
+                    return;
+                }
                 if (_acceptor != null) {
                     if (_instance.traceLevels().network >= 1) {
                         StringBuffer s = new StringBuffer("accepting ");
@@ -471,10 +468,10 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
 
             case StateHolding:
             {
-                if (_state != StateActive) // Can only switch from active to holding.
-                    {
-                        return;
-                    }
+                // Can only switch from active to holding.
+                if (_state != StateActive) {
+                    return;
+                }
                 if (_acceptor != null) {
                     // Stop accepting new connections.
                     if (_instance.traceLevels().network >= 1) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IncomingConnectionFactory.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IncomingConnectionFactory.java
@@ -440,8 +440,7 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
         }
 
         switch (state) {
-            case StateActive:
-            {
+            case StateActive -> {
                 // Can only switch from holding to active.
                 if (_state != StateHolding) {
                     return;
@@ -463,11 +462,9 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
                 for (ConnectionI connection : _connections) {
                     connection.activate();
                 }
-                break;
             }
 
-            case StateHolding:
-            {
+            case StateHolding -> {
                 // Can only switch from active to holding.
                 if (_state != StateActive) {
                     return;
@@ -490,11 +487,9 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
                 for (ConnectionI connection : _connections) {
                     connection.hold();
                 }
-                break;
             }
 
-            case StateClosed:
-            {
+            case StateClosed -> {
                 if (_acceptorStarted) {
                     //
                     // If possible, close the acceptor now to prevent new connections from being
@@ -513,13 +508,10 @@ final class IncomingConnectionFactory extends EventHandler implements Connection
                 for (ConnectionI connection : _connections) {
                     connection.destroy(ConnectionI.ObjectAdapterDeactivated);
                 }
-                break;
             }
 
-            case StateFinished:
-            {
+            case StateFinished -> {
                 assert (_state == StateClosed);
-                break;
             }
         }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -1969,7 +1969,7 @@ public final class InputStream {
                 // derive an index into the indirection table that we'll read
                 // at the end of the slice.
                 //
-                
+
                 // Lazy initialization
                 if (_current.indirectPatchList == null) {
                     _current.indirectPatchList = new ArrayDeque<>();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -1397,45 +1397,14 @@ public final class InputStream {
 
     private void skipOptional(OptionalFormat format) {
         switch (format) {
-            case F1:
-            {
-                skip(1);
-                break;
-            }
-            case F2:
-            {
-                skip(2);
-                break;
-            }
-            case F4:
-            {
-                skip(4);
-                break;
-            }
-            case F8:
-            {
-                skip(8);
-                break;
-            }
-            case Size:
-            {
-                skipSize();
-                break;
-            }
-            case VSize:
-            {
-                skip(readSize());
-                break;
-            }
-            case FSize:
-            {
-                skip(readInt());
-                break;
-            }
-            case Class:
-            {
-                throw new MarshalException("cannot skip an optional class");
-            }
+            case F1 -> skip(1);
+            case F2 -> skip(2);
+            case F4 -> skip(4);
+            case F8 -> skip(8);
+            case Size -> skipSize();
+            case VSize -> skip(readSize());
+            case FSize -> skip(readInt());
+            case Class -> throw new MarshalException("cannot skip an optional class");
         }
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -239,15 +239,15 @@ public final class Instance {
             throw new CommunicatorDestroyedException();
         }
 
-        if (_serverThreadPool == null) // Lazy initialization.
-            {
-                if (_state == StateDestroyInProgress) {
-                    throw new CommunicatorDestroyedException();
-                }
-
-                int timeout = _initData.properties.getIcePropertyAsInt("Ice.ServerIdleTime");
-                _serverThreadPool = new ThreadPool(this, "Ice.ThreadPool.Server", timeout);
+        // Lazy initialization.
+        if (_serverThreadPool == null) {
+            if (_state == StateDestroyInProgress) {
+                throw new CommunicatorDestroyedException();
             }
+
+            int timeout = _initData.properties.getIcePropertyAsInt("Ice.ServerIdleTime");
+            _serverThreadPool = new ThreadPool(this, "Ice.ThreadPool.Server", timeout);
+        }
 
         return _serverThreadPool;
     }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LocatorInfo.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LocatorInfo.java
@@ -83,12 +83,10 @@ final class LocatorInfo {
             synchronized (this) {
                 if (!_response && _exception == null) {
                     _callbacks.add(callback);
-                    if (wellKnownRef
-                        != null) // This request is to resolve the endpoints of a cached
-                        // well-known object ref
-                        {
-                            _wellKnownRefs.add(wellKnownRef);
-                        }
+                    if (wellKnownRef != null) {
+                        // This request is to resolve the endpoints of a cached well-known object ref.
+                        _wellKnownRefs.add(wellKnownRef);
+                    }
                     if (!_sent) {
                         _sent = true;
                         send();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LocatorTable.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LocatorTable.java
@@ -14,13 +14,12 @@ final class LocatorTable {
         _objectTable.clear();
     }
 
-    synchronized EndpointI[] getAdapterEndpoints(
-            String adapter, Duration ttl, Holder<Boolean> cached) {
-        if (ttl.isZero()) // Locator cache disabled.
-            {
-                cached.value = false;
-                return null;
-            }
+    synchronized EndpointI[] getAdapterEndpoints(String adapter, Duration ttl, Holder<Boolean> cached) {
+        // If the locator cache is disabled.
+        if (ttl.isZero()) {
+            cached.value = false;
+            return null;
+        }
 
         EndpointTableEntry entry = _adapterEndpointsTable.get(adapter);
         if (entry != null) {
@@ -42,11 +41,11 @@ final class LocatorTable {
     }
 
     synchronized Reference getObjectReference(Identity id, Duration ttl, Holder<Boolean> cached) {
-        if (ttl.isZero()) // Locator cache disabled.
-            {
-                cached.value = false;
-                return null;
-            }
+        // If the locator cache is disabled.
+        if (ttl.isZero()) {
+            cached.value = false;
+            return null;
+        }
 
         ReferenceTableEntry entry = _objectTable.get(id);
         if (entry != null) {
@@ -68,10 +67,9 @@ final class LocatorTable {
 
     private boolean checkTTL(long time, Duration ttl) {
         assert (!ttl.isZero());
-        if (ttl.compareTo(Duration.ZERO) < 0) // TTL = infinite
-            {
-                return true;
-            } else {
+        if (ttl.compareTo(Duration.ZERO) < 0 /* TTL = infinite */) {
+            return true;
+        } else {
             return Time.currentMonotonicTimeMillis() - time <= ttl.toMillis();
         }
     }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OpaqueEndpointI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OpaqueEndpointI.java
@@ -258,8 +258,7 @@ final class OpaqueEndpointI extends EndpointI {
     @Override
     protected boolean checkOption(String option, String argument, String endpoint) {
         switch (option.charAt(1)) {
-            case 't':
-            {
+            case 't': {
                 if (_type > -1) {
                     throw new ParseException(
                         "multiple -t options in endpoint '" + endpoint + "'");
@@ -297,8 +296,7 @@ final class OpaqueEndpointI extends EndpointI {
                 return true;
             }
 
-            case 'v':
-            {
+            case 'v': {
                 if (_rawBytes.length > 0) {
                     throw new ParseException(
                         "multiple -v options in endpoint '" + endpoint + "'");
@@ -319,8 +317,7 @@ final class OpaqueEndpointI extends EndpointI {
                 return true;
             }
 
-            case 'e':
-            {
+            case 'e': {
                 if (argument == null) {
                     throw new ParseException(
                         "no argument provided for -e option in endpoint '"
@@ -342,8 +339,7 @@ final class OpaqueEndpointI extends EndpointI {
                 return true;
             }
 
-            default:
-            {
+            default: {
                 return false;
             }
         }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OpaqueEndpointI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OpaqueEndpointI.java
@@ -209,54 +209,51 @@ final class OpaqueEndpointI extends EndpointI {
         return s;
     }
 
-    //
     // Compare endpoints for sorting purposes
-    //
     @Override
-    public int compareTo(EndpointI obj) // From java.lang.Comparable
-        {
-            if (!(obj instanceof OpaqueEndpointI)) {
-                return type() < obj.type() ? -1 : 1;
-            }
+    public int compareTo(EndpointI obj) {
+        if (!(obj instanceof OpaqueEndpointI)) {
+            return type() < obj.type() ? -1 : 1;
+        }
 
-            OpaqueEndpointI p = (OpaqueEndpointI) obj;
-            if (this == p) {
-                return 0;
-            }
-
-            if (_type < p._type) {
-                return -1;
-            } else if (p._type < _type) {
-                return 1;
-            }
-
-            if (_rawEncoding.major < p._rawEncoding.major) {
-                return -1;
-            } else if (p._rawEncoding.major < _rawEncoding.major) {
-                return 1;
-            }
-
-            if (_rawEncoding.minor < p._rawEncoding.minor) {
-                return -1;
-            } else if (p._rawEncoding.minor < _rawEncoding.minor) {
-                return 1;
-            }
-
-            if (_rawBytes.length < p._rawBytes.length) {
-                return -1;
-            } else if (p._rawBytes.length < _rawBytes.length) {
-                return 1;
-            }
-            for (int i = 0; i < _rawBytes.length; i++) {
-                if (_rawBytes[i] < p._rawBytes[i]) {
-                    return -1;
-                } else if (p._rawBytes[i] < _rawBytes[i]) {
-                    return 1;
-                }
-            }
-
+        OpaqueEndpointI p = (OpaqueEndpointI) obj;
+        if (this == p) {
             return 0;
         }
+
+        if (_type < p._type) {
+            return -1;
+        } else if (p._type < _type) {
+            return 1;
+        }
+
+        if (_rawEncoding.major < p._rawEncoding.major) {
+            return -1;
+        } else if (p._rawEncoding.major < _rawEncoding.major) {
+            return 1;
+        }
+
+        if (_rawEncoding.minor < p._rawEncoding.minor) {
+            return -1;
+        } else if (p._rawEncoding.minor < _rawEncoding.minor) {
+            return 1;
+        }
+
+        if (_rawBytes.length < p._rawBytes.length) {
+            return -1;
+        } else if (p._rawBytes.length < _rawBytes.length) {
+            return 1;
+        }
+        for (int i = 0; i < _rawBytes.length; i++) {
+            if (_rawBytes[i] < p._rawBytes[i]) {
+                return -1;
+            } else if (p._rawBytes[i] < _rawBytes[i]) {
+                return 1;
+            }
+        }
+
+        return 0;
+    }
 
     @Override
     protected boolean checkOption(String option, String argument, String endpoint) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Options.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Options.java
@@ -111,21 +111,23 @@ public final class Options {
                             arg.append('\\');
                         }
                         arg.append(c);
-                    } else if (c == '"') // End of double-quote mode.
-                        {
-                            state = NormalState;
-                        } else {
-                        arg.append(c); // Everything else is taken literally.
+                    } else if (c == '"') {
+                        // End of double-quote mode.
+                        state = NormalState;
+                    } else {
+                        // Everything else is taken literally.
+                        arg.append(c);
                     }
                     break;
                 }
                 case SingleQuoteState:
                 {
-                    if (c == '\'') // End of single-quote mode.
-                        {
-                            state = NormalState;
-                        } else {
-                        arg.append(c); // Everything else is taken literally.
+                    if (c == '\'') {
+                        // End of single-quote mode.
+                        state = NormalState;
+                    } else {
+                        // Everything else is taken literally.
+                        arg.append(c);
                     }
                     break;
                 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Options.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Options.java
@@ -29,13 +29,10 @@ public final class Options {
         for (int i = 0; i < line.length(); i++) {
             char c = line.charAt(i);
             switch (state) {
-                case NormalState:
-                {
+                case NormalState: {
                     switch (c) {
-                        case '\\':
-                        {
-                            // Ignore a backslash at the end of the string, and strip
-                            // backslash-newline pairs.
+                        case '\\' -> {
+                            // Ignore a backslash at the end of the string, and strip backslash-newline pairs.
                             //
                             // If a backslash comes before a space, single quote, double
                             // quote, or dollar sign we drop the backslash, but still write
@@ -45,62 +42,46 @@ public final class Options {
                             // we don't drop backslashes from Windows path names.
                             if (i < line.length() - 1 && line.charAt(++i) != '\n') {
                                 char nextChar = line.charAt(i);
-                                // TODO: comment says we should be checking single quotes
-                                // here, but we aren't?
-                                if (nextChar != ' '
-                                    && nextChar != '$'
-                                    && nextChar != '\\'
-                                    && nextChar != '"') {
+                                // TODO: comment says we should be checking single quotes here, but we aren't?
+                                if (nextChar != ' ' && nextChar != '$' && nextChar != '\\' && nextChar != '"') {
                                     arg.append('\\');
                                 }
                                 arg.append(nextChar);
                             }
-                            break;
                         }
-                        case '\'':
-                        {
+                        case '\'' -> {
                             state = SingleQuoteState;
-                            break;
                         }
-                        case '"':
-                        {
+                        case '"' -> {
                             state = DoubleQuoteState;
-                            break;
                         }
-                        case '$':
-                        {
+                        case '$' -> {
                             if (i < line.length() - 1 && line.charAt(i + 1) == '\'') {
-                                // Bash uses $'<text>' to allow ANSI escape sequences within
-                                // <text>.
+                                // Bash uses $'<text>' to allow ANSI escape sequences within <text>.
                                 state = ANSIQuoteState;
                                 ++i;
                             } else {
                                 arg.append('$');
                             }
-                            break;
                         }
-                        default:
-                        {
+                        default -> {
                             if (IFS.indexOf(line.charAt(i)) != -1) {
                                 vec.add(arg.toString());
                                 arg = new StringBuilder(128);
 
                                 // Move to start of next argument.
-                                while (++i < line.length()
-                                    && IFS.indexOf(line.charAt(i)) != -1) {
+                                while (++i < line.length() && IFS.indexOf(line.charAt(i)) != -1) {
                                     continue;
                                 }
                                 --i;
                             } else {
                                 arg.append(line.charAt(i));
                             }
-                            break;
                         }
                     }
                     break;
                 }
-                case DoubleQuoteState:
-                {
+                case DoubleQuoteState: {
                     // Within double quotes, only backslash retains its special meaning,
                     // and only if followed by a double quote, backslash, or newline.
                     // Both the backslash and the character are preserved for any other
@@ -120,8 +101,7 @@ public final class Options {
                     }
                     break;
                 }
-                case SingleQuoteState:
-                {
+                case SingleQuoteState: {
                     if (c == '\'') {
                         // End of single-quote mode.
                         state = NormalState;
@@ -131,77 +111,29 @@ public final class Options {
                     }
                     break;
                 }
-                case ANSIQuoteState:
-                {
+                case ANSIQuoteState: {
                     switch (c) {
-                        case '\\':
-                        {
+                        case '\\': {
                             if (i == line.length() - 1) {
                                 break;
                             }
                             switch (c = line.charAt(++i)) {
                                 // Single-letter escape sequences.
-                                case 'a':
-                                {
-                                    arg.append('\007');
-                                    break;
-                                }
-                                case 'b':
-                                {
-                                    arg.append('\b');
-                                    break;
-                                }
-                                case 'f':
-                                {
-                                    arg.append('\f');
-                                    break;
-                                }
-                                case 'n':
-                                {
-                                    arg.append('\n');
-                                    break;
-                                }
-                                case 'r':
-                                {
-                                    arg.append('\r');
-                                    break;
-                                }
-                                case 't':
-                                {
-                                    arg.append('\t');
-                                    break;
-                                }
-                                case 'v':
-                                {
-                                    arg.append('\013');
-                                    break;
-                                }
-                                case '\\':
-                                {
-                                    arg.append('\\');
-                                    break;
-                                }
-                                case '\'':
-                                {
-                                    arg.append('\'');
-                                    break;
-                                }
-                                case 'e': // Not ANSI-C, but used by bash.
-                                    {
-                                        arg.append('\033');
-                                        break;
-                                    }
+                                case 'a' ->  arg.append('\007');
+                                case 'b' ->  arg.append('\b');
+                                case 'f' ->  arg.append('\f');
+                                case 'n' ->  arg.append('\n');
+                                case 'r' ->  arg.append('\r');
+                                case 't' ->  arg.append('\t');
+                                case 'v' ->  arg.append('\013');
+                                case '\\' ->  arg.append('\\');
+                                case '\'' ->  arg.append('\'');
+
+                                // Not ANSI-C, but used by bash.
+                                case 'e' -> arg.append('\033');
 
                                 // Process up to three octal digits.
-                                case '0':
-                                case '1':
-                                case '2':
-                                case '3':
-                                case '4':
-                                case '5':
-                                case '6':
-                                case '7':
-                                {
+                                case '0', '1', '2', '3', '4', '5', '6', '7' -> {
                                     final String octalDigits = "01234567";
                                     short us = 0;
                                     int j;
@@ -216,60 +148,44 @@ public final class Options {
                                     }
                                     i = j - 1;
                                     arg.append((char) us);
-                                    break;
                                 }
 
                                 // Process up to two hex digits.
-                                case 'x':
-                                {
+                                case 'x' -> {
                                     final String hexDigits = "0123456789abcdefABCDEF";
-                                    if (i < line.length() - 1
-                                        && hexDigits.indexOf(line.charAt(i + 1))
-                                        == -1) {
+                                    if (i < line.length() - 1 && hexDigits.indexOf(line.charAt(i + 1)) == -1) {
                                         arg.append('\\');
                                         arg.append('x');
-                                        break;
-                                    }
-
-                                    short s = 0;
-                                    int j;
-                                    for (j = i + 1;
-                                                        j < i + 3
-                                                                && j < line.length()
-                                                                && hexDigits.indexOf(
-                                                                                c = line.charAt(j))
-                                                                        != -1;
-                                                        j++) {
-                                        s *= (short) 16;
-                                        if (Character.isDigit(c)) {
-                                            s += (short) (c - '0');
-                                        } else if (Character.isLowerCase(c)) {
-                                            s += (short) (c - 'a' + 10);
-                                        } else {
-                                            s += (short) (c - 'A' + 10);
+                                    } else {
+                                        short s = 0;
+                                        int j;
+                                        for (j = i + 1; j < i + 3 && j < line.length()
+                                                    && hexDigits.indexOf(c = line.charAt(j)) != -1; j++) {
+                                            s *= (short) 16;
+                                            if (Character.isDigit(c)) {
+                                                s += (short) (c - '0');
+                                            } else if (Character.isLowerCase(c)) {
+                                                s += (short) (c - 'a' + 10);
+                                            } else {
+                                                s += (short) (c - 'A' + 10);
+                                            }
                                         }
+                                        i = j - 1;
+                                        arg.append((char) s);
                                     }
-                                    i = j - 1;
-                                    arg.append((char) s);
-                                    break;
                                 }
 
                                 // Process control-chars.
-                                case 'c':
-                                {
+                                case 'c' -> {
                                     c = line.charAt(++i);
                                     if ((Character.toUpperCase(c) >= 'A'
                                         && Character.toUpperCase(c) <= 'Z')
                                         || c == '@'
                                         || (c >= '[' && c <= '_')) {
-                                        arg.append(
-                                            (char)
-                                                (Character.toUpperCase(c)
-                                                    - '@'));
+                                        arg.append((char) (Character.toUpperCase(c) - '@'));
                                     } else {
                                         // Bash does not define what should happen if a
-                                        // \c is not followed by a recognized control
-                                        // character.
+                                        // \c is not followed by a recognized control character.
                                         // We simply treat this case like other
                                         // unrecognized escape sequences, that is, we
                                         // preserve the escape sequence unchanged.
@@ -277,64 +193,45 @@ public final class Options {
                                         arg.append('c');
                                         arg.append(c);
                                     }
-                                    break;
                                 }
 
-                                // If inside an ANSI-quoted string, a backslash isn't
-                                // followed by
+                                // If inside an ANSI-quoted string, a backslash isn't followed by
                                 // one of the recognized characters, both the backslash and
                                 // the character are preserved.
-                                default:
-                                {
+                                default -> {
                                     arg.append('\\');
                                     arg.append(c);
-                                    break;
                                 }
                             }
                             break;
                         }
-                        case '\'': // End of ANSI-quote mode.
-                            {
-                                state = NormalState;
-                                break;
-                            }
-                        default:
-                        {
-                            arg.append(c); // Everything else is taken literally.
+
+                        // End of ANSI-quote mode.
+                        case '\'': {
+                            state = NormalState;
+                            break;
+                        }
+
+                        // Everything else is taken literally.
+                        default: {
+                            arg.append(c);
                             break;
                         }
                     }
                     break;
                 }
-                default:
+                default: {
                     assert false;
-                    break;
+                }
             }
         }
 
         switch (state) {
-            case NormalState:
-            {
-                vec.add(arg.toString());
-                break;
-            }
-            case SingleQuoteState:
-            {
-                throw new ParseException("missing closing single quote");
-            }
-            case DoubleQuoteState:
-            {
-                throw new ParseException("missing closing double quote");
-            }
-            case ANSIQuoteState:
-            {
-                throw new ParseException("unterminated $' quote");
-            }
-            default:
-            {
-                assert false;
-                break;
-            }
+            case NormalState -> vec.add(arg.toString());
+            case SingleQuoteState -> throw new ParseException("missing closing single quote");
+            case DoubleQuoteState -> throw new ParseException("missing closing double quote");
+            case ANSIQuoteState -> throw new ParseException("unterminated $' quote");
+            default -> throw new AssertionError();
         }
 
         return vec.toArray(new String[0]);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingAsync.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingAsync.java
@@ -138,8 +138,7 @@ public class OutgoingAsync<T> extends ProxyOutgoingAsyncBase<T> {
         } catch (ExecutionException ee) {
             try {
                 throw ee.getCause().fillInStackTrace();
-            } catch (RuntimeException ex /* Includes LocalException */)
-            {
+            } catch (RuntimeException ex /* Includes LocalException */) {
                 throw ex;
             } catch (UserException ex) {
                 throw ex;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingAsyncBase.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingAsyncBase.java
@@ -59,10 +59,9 @@ abstract class OutgoingAsyncBase<T> extends InvocationFuture<T> {
         } catch (ExecutionException ee) {
             try {
                 throw ee.getCause().fillInStackTrace();
-            } catch (RuntimeException ex) // Includes LocalException
-                {
-                    throw ex;
-                } catch (Throwable ex) {
+            } catch (RuntimeException ex /* Includes LocalException */) {
+                throw ex;
+            } catch (Throwable ex) {
                 throw new UnknownException(ex);
             }
         }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingConnectionFactory.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutgoingConnectionFactory.java
@@ -260,16 +260,15 @@ final class OutgoingConnectionFactory {
             }
 
             for (ConnectionI connection : connectionList) {
-                if (connection
-                    .isActiveOrHolding()) // Don't return destroyed or un-validated connections
-                    {
-                        if (defaultsAndOverrides.overrideCompress.isPresent()) {
-                            compress.value = defaultsAndOverrides.overrideCompress.get();
-                        } else {
-                            compress.value = endpoint.compress();
-                        }
-                        return connection;
+                // Don't return destroyed or un-validated connections
+                if (connection.isActiveOrHolding()) {
+                    if (defaultsAndOverrides.overrideCompress.isPresent()) {
+                        compress.value = defaultsAndOverrides.overrideCompress.get();
+                    } else {
+                        compress.value = endpoint.compress();
                     }
+                    return connection;
+                }
             }
         }
 
@@ -301,16 +300,15 @@ final class OutgoingConnectionFactory {
             }
 
             for (ConnectionI connection : connectionList) {
-                if (connection
-                    .isActiveOrHolding()) // Don't return destroyed or un-validated connections
-                    {
-                        if (defaultsAndOverrides.overrideCompress.isPresent()) {
-                            compress.value = defaultsAndOverrides.overrideCompress.get();
-                        } else {
-                            compress.value = ci.endpoint.compress();
-                        }
-                        return connection;
+                // Don't return destroyed or un-validated connections
+                if (connection.isActiveOrHolding()) {
+                    if (defaultsAndOverrides.overrideCompress.isPresent()) {
+                        compress.value = defaultsAndOverrides.overrideCompress.get();
+                    } else {
+                        compress.value = ci.endpoint.compress();
                     }
+                    return connection;
+                }
             }
         }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/OutputStream.java
@@ -1468,10 +1468,10 @@ public final class OutputStream {
         void writePendingValues() {}
 
         protected int registerTypeId(String typeId) {
-            if (_typeIdMap == null) // Lazy initialization
-                {
-                    _typeIdMap = new TreeMap<>();
-                }
+            // Lazy initialization
+            if (_typeIdMap == null) {
+                _typeIdMap = new TreeMap<>();
+            }
 
             Integer p = _typeIdMap.get(typeId);
             if (p != null) {
@@ -1659,11 +1659,11 @@ public final class OutputStream {
             if (v == null) {
                 _stream.writeSize(0);
             } else if (_current != null && _encaps.format == FormatType.SlicedFormat) {
-                if (_current.indirectionTable == null) // Lazy initialization
-                    {
-                        _current.indirectionTable = new ArrayList<>();
-                        _current.indirectionMap = new IdentityHashMap<>();
-                    }
+                // Lazy initialization
+                if (_current.indirectionTable == null) {
+                    _current.indirectionTable = new ArrayList<>();
+                    _current.indirectionMap = new IdentityHashMap<>();
+                }
 
                 //
                 // If writing an instance within a slice and using the sliced format, write an index
@@ -1846,15 +1846,13 @@ public final class OutputStream {
                     _current.sliceFlags |= Protocol.FLAG_HAS_OPTIONAL_MEMBERS;
                 }
 
-                //
                 // Make sure to also re-write the instance indirection table.
-                //
                 if (info.instances != null && info.instances.length > 0) {
-                    if (_current.indirectionTable == null) // Lazy initialization
-                        {
-                            _current.indirectionTable = new ArrayList<>();
-                            _current.indirectionMap = new IdentityHashMap<>();
-                        }
+                    // Lazy initialization
+                    if (_current.indirectionTable == null) {
+                        _current.indirectionTable = new ArrayList<>();
+                        _current.indirectionMap = new IdentityHashMap<>();
+                    }
                     for (Value o : info.instances) {
                         _current.indirectionTable.add(o);
                     }
@@ -1953,29 +1951,29 @@ public final class OutputStream {
     private Encaps _encapsCache;
 
     private void initEncaps() {
-        if (_encapsStack == null) // Lazy initialization
-            {
-                _encapsStack = _encapsCache;
-                if (_encapsStack != null) {
-                    _encapsCache = _encapsCache.next;
-                } else {
-                    _encapsStack = new Encaps();
-                }
-                _encapsStack.setEncoding(_encoding);
+        // Lazy initialization
+        if (_encapsStack == null) {
+            _encapsStack = _encapsCache;
+            if (_encapsStack != null) {
+                _encapsCache = _encapsCache.next;
+            } else {
+                _encapsStack = new Encaps();
             }
+            _encapsStack.setEncoding(_encoding);
+        }
 
         if (_encapsStack.format == null) {
             _encapsStack.format = _format;
         }
 
-        if (_encapsStack.encoder == null) // Lazy initialization.
-            {
-                if (_encapsStack.encoding_1_0) {
-                    _encapsStack.encoder = new EncapsEncoder10(this, _encapsStack);
-                } else {
-                    _encapsStack.encoder = new EncapsEncoder11(this, _encapsStack);
-                }
+        // Lazy initialization.
+        if (_encapsStack.encoder == null) {
+            if (_encapsStack.encoding_1_0) {
+                _encapsStack.encoder = new EncapsEncoder10(this, _encapsStack);
+            } else {
+                _encapsStack.encoder = new EncapsEncoder11(this, _encapsStack);
             }
+        }
     }
 
     /**

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProcessI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProcessI.java
@@ -15,16 +15,8 @@ class ProcessI implements Process {
     @Override
     public void writeMessage(String message, int fd, Current current) {
         switch (fd) {
-            case 1:
-            {
-                System.out.println(message);
-                break;
-            }
-            case 2:
-            {
-                System.err.println(message);
-                break;
-            }
+            case 1 -> System.out.println(message);
+            case 2 -> System.err.println(message);
         }
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Properties.java
@@ -657,8 +657,7 @@ public final class Properties {
         for (int i = 0; i < line.length(); i++) {
             char c = line.charAt(i);
             switch (state) {
-                case ParseStateKey:
-                {
+                case ParseStateKey: {
                     switch (c) {
                         case '\\':
                             if (i < line.length() - 1) {
@@ -718,8 +717,7 @@ public final class Properties {
                     break;
                 }
 
-                case ParseStateValue:
-                {
+                case ParseStateValue: {
                     switch (c) {
                         case '\\':
                             if (i < line.length() - 1) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PropertyNames.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PropertyNames.java
@@ -6,8 +6,7 @@
 
 package com.zeroc.Ice;
 
-final class PropertyNames
-{
+final class PropertyNames {
     public static final PropertyArray ProxyProps = new PropertyArray(
         "Proxy",
         false,

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyOutgoingAsyncBase.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyOutgoingAsyncBase.java
@@ -51,6 +51,7 @@ abstract class ProxyOutgoingAsyncBase<T> extends OutgoingAsyncBase<T> {
             var replyStatus = ReplyStatus.valueOf(replyStatusInt);
 
             if (replyStatus != null) {
+                //CHECKSTYLE.OFF: FallThrough
                 switch (replyStatus) {
                     case Ok:
                         break;
@@ -64,7 +65,6 @@ abstract class ProxyOutgoingAsyncBase<T> extends OutgoingAsyncBase<T> {
                     case ObjectNotExist:
                     case FacetNotExist:
                     case OperationNotExist:
-                    {
                         Identity id = Identity.ice_read(is);
 
                         //
@@ -87,18 +87,12 @@ abstract class ProxyOutgoingAsyncBase<T> extends OutgoingAsyncBase<T> {
                         String operation = is.readString();
 
                         switch (replyStatus) {
-                            case ObjectNotExist ->
-                                throw new ObjectNotExistException(id, facet, operation);
-                            case FacetNotExist ->
-                                throw new FacetNotExistException(id, facet, operation);
-                            default ->
-                                throw new OperationNotExistException(id, facet, operation);
+                            case ObjectNotExist -> throw new ObjectNotExistException(id, facet, operation);
+                            case FacetNotExist -> throw new FacetNotExistException(id, facet, operation);
+                            default -> throw new OperationNotExistException(id, facet, operation);
                         }
-                    }
 
-                    //CHECKSTYLE:OFF: FallThrough
                     default:
-                    {
                         String message = is.readString();
                         switch (replyStatus) {
                             case UnknownException -> throw new UnknownException(message);
@@ -106,9 +100,8 @@ abstract class ProxyOutgoingAsyncBase<T> extends OutgoingAsyncBase<T> {
                             case UnknownUserException -> throw new UnknownUserException(message);
                             default -> throw new DispatchException(replyStatusInt, message);
                         }
-                    }
-                    //CHECKSTYLE:OFF: FallThrough
                 }
+                //CHECKSTYLE.ON: FallThrough
                 return finished(replyStatus == ReplyStatus.Ok, true);
 
             } else {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyOutgoingAsyncBase.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ProxyOutgoingAsyncBase.java
@@ -210,12 +210,12 @@ abstract class ProxyOutgoingAsyncBase<T> extends OutgoingAsyncBase<T> {
                                 invocationTimeout.toMillis(),
                                 TimeUnit.MILLISECONDS);
                 }
-            } else // If not called from the user thread, it's called from the retry queue
-                {
-                    if (_observer != null) {
-                        _observer.retried();
-                    }
+            } else {
+                // If not called from the user thread, it's called from the retry queue.
+                if (_observer != null) {
+                    _observer.retried();
                 }
+            }
 
             while (true) {
                 try {
@@ -259,10 +259,10 @@ abstract class ProxyOutgoingAsyncBase<T> extends OutgoingAsyncBase<T> {
             // will be caught by the caller and handled using abort().
             if (userThread) {
                 throw ex;
-            } else if (finished(ex)) // No retries, we're done
-                {
-                    invokeCompletedAsync();
-                }
+            } else if (finished(ex)) {
+                // No retries, we're done
+                invokeCompletedAsync();
+            }
         }
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Reference.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Reference.java
@@ -570,35 +570,11 @@ public abstract class Reference implements Cloneable {
         }
 
         switch (_mode) {
-            case ModeTwoway:
-            {
-                // Don't print the default mode.
-                break;
-            }
-
-            case ModeOneway:
-            {
-                s.append(" -o");
-                break;
-            }
-
-            case ModeBatchOneway:
-            {
-                s.append(" -O");
-                break;
-            }
-
-            case ModeDatagram:
-            {
-                s.append(" -d");
-                break;
-            }
-
-            case ModeBatchDatagram:
-            {
-                s.append(" -D");
-                break;
-            }
+            case ModeTwoway -> {} // Don't print the default mode.
+            case ModeOneway -> s.append(" -o");
+            case ModeBatchOneway -> s.append(" -O");
+            case ModeDatagram -> s.append(" -d");
+            case ModeBatchDatagram -> s.append(" -D");
         }
 
         if (_secure) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ReferenceFactory.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ReferenceFactory.java
@@ -58,9 +58,7 @@ final class ReferenceFactory {
             _communicator,
             ident,
             "", // Facet
-            fixedConnection.endpoint().datagram()
-                ? Reference.ModeDatagram
-                : Reference.ModeTwoway,
+            fixedConnection.endpoint().datagram() ? Reference.ModeDatagram : Reference.ModeTwoway,
             fixedConnection.endpoint().secure(),
             Optional.empty(),
             Util.Protocol_1_0,
@@ -90,8 +88,7 @@ final class ReferenceFactory {
 
         beg = StringUtil.findFirstNotOf(s, delim, end);
         if (beg == -1) {
-            throw new ParseException(
-                "no non-whitespace characters found in proxy string '" + s + "'");
+            throw new ParseException("no non-whitespace characters found in proxy string '" + s + "'");
         }
 
         //
@@ -101,8 +98,7 @@ final class ReferenceFactory {
         String idstr = null;
         end = StringUtil.checkQuote(s, beg);
         if (end == -1) {
-            throw new ParseException(
-                "mismatched quotes around identity in proxy string '" + s + "'");
+            throw new ParseException("mismatched quotes around identity in proxy string '" + s + "'");
         } else if (end == 0) {
             end = StringUtil.findFirstOf(s, delim + ":@", beg);
             if (end == -1) {
@@ -119,22 +115,15 @@ final class ReferenceFactory {
             throw new ParseException("no identity in proxy string '" + s + "'");
         }
 
-        //
         // Parsing the identity may raise ParseException.
-        //
         Identity ident = Util.stringToIdentity(idstr);
 
         if (ident.name.isEmpty()) {
-            //
-            // An identity with an empty name and a non-empty
-            // category is illegal.
-            //
+            // An identity with an empty name and a non-empty category is illegal.
             if (ident.category.length() > 0) {
-                throw new ParseException(
-                    "The category of a null Ice object identity must be empty.");
+                throw new ParseException("The category of a null Ice object identity must be empty.");
             } else if (StringUtil.findFirstNotOf(s, delim, end) != -1) {
-                throw new ParseException(
-                    "invalid characters after identity in proxy string '" + s + "'");
+                throw new ParseException("invalid characters after identity in proxy string '" + s + "'");
             } else {
                 return null;
             }
@@ -176,11 +165,8 @@ final class ReferenceFactory {
                         + "'");
             }
 
-            //
-            // Check for the presence of an option argument. The
-            // argument may be enclosed in single or double
-            // quotation marks.
-            //
+            // Check for the presence of an option argument.
+            // The argument may be enclosed in single or double quotation marks.
             String argument = null;
             int argumentBeg = StringUtil.findFirstNotOf(s, delim, end);
             if (argumentBeg != -1) {
@@ -209,32 +195,24 @@ final class ReferenceFactory {
                 }
             }
 
-            //
             // If any new options are added here,
             // com.zeroc.Ice.Reference.toString() and its derived classes must be updated as well.
-            //
             switch (option.charAt(1)) {
-                case 'f':
-                {
+                case 'f': {
                     if (argument == null) {
-                        throw new ParseException(
-                            "no argument provided for -f option in proxy string '"
-                                + s
-                                + "'");
+                        throw new ParseException("no argument provided for -f option in proxy string '" + s + "'");
                     }
 
                     try {
                         facet = StringUtil.unescapeString(argument, 0, argument.length(), "");
                     } catch (IllegalArgumentException ex) {
-                        throw new ParseException(
-                            "invalid facet in proxy string '" + s + "'", ex);
+                        throw new ParseException("invalid facet in proxy string '" + s + "'", ex);
                     }
 
                     break;
                 }
 
-                case 't':
-                {
+                case 't': {
                     if (argument != null) {
                         throw new ParseException(
                             "unexpected argument '"
@@ -247,8 +225,7 @@ final class ReferenceFactory {
                     break;
                 }
 
-                case 'o':
-                {
+                case 'o': {
                     if (argument != null) {
                         throw new ParseException(
                             "unexpected argument '"
@@ -261,8 +238,7 @@ final class ReferenceFactory {
                     break;
                 }
 
-                case 'O':
-                {
+                case 'O': {
                     if (argument != null) {
                         throw new ParseException(
                             "unexpected argument '"
@@ -275,8 +251,7 @@ final class ReferenceFactory {
                     break;
                 }
 
-                case 'd':
-                {
+                case 'd': {
                     if (argument != null) {
                         throw new ParseException(
                             "unexpected argument '"
@@ -289,8 +264,7 @@ final class ReferenceFactory {
                     break;
                 }
 
-                case 'D':
-                {
+                case 'D': {
                     if (argument != null) {
                         throw new ParseException(
                             "unexpected argument '"
@@ -303,8 +277,7 @@ final class ReferenceFactory {
                     break;
                 }
 
-                case 's':
-                {
+                case 's': {
                     if (argument != null) {
                         throw new ParseException(
                             "unexpected argument '"
@@ -317,13 +290,9 @@ final class ReferenceFactory {
                     break;
                 }
 
-                case 'e':
-                {
+                case 'e': {
                     if (argument == null) {
-                        throw new ParseException(
-                            "no argument provided for -e option in in proxy string '"
-                                + s
-                                + "'");
+                        throw new ParseException("no argument provided for -e option in in proxy string '" + s + "'");
                     }
 
                     try {
@@ -340,13 +309,9 @@ final class ReferenceFactory {
                     break;
                 }
 
-                case 'p':
-                {
+                case 'p': {
                     if (argument == null) {
-                        throw new ParseException(
-                            "no argument provided for -p option in proxy string '"
-                                + s
-                                + "'");
+                        throw new ParseException("no argument provided for -p option in proxy string '" + s + "'");
                     }
 
                     try {
@@ -363,26 +328,14 @@ final class ReferenceFactory {
                     break;
                 }
 
-                default:
-                {
-                    throw new ParseException(
-                        "unknown option '" + option + "' in proxy string '" + s + "'");
+                default: {
+                    throw new ParseException("unknown option '" + option + "' in proxy string '" + s + "'");
                 }
             }
         }
 
         if (beg == -1) {
-            return create(
-                ident,
-                facet,
-                mode,
-                secure,
-                Optional.empty(),
-                protocol,
-                encoding,
-                null,
-                null,
-                propertyPrefix);
+            return create(ident, facet, mode, secure, Optional.empty(), protocol, encoding, null, null, propertyPrefix);
         }
 
         ArrayList<EndpointI> endpoints = new ArrayList<>();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RoutableReference.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RoutableReference.java
@@ -580,17 +580,10 @@ class RoutableReference extends Reference {
             }
         }
 
-        //
         // Filter out endpoints according to the mode of the reference.
-        //
         switch (getMode()) {
-            case Reference.ModeTwoway:
-            case Reference.ModeOneway:
-            case Reference.ModeBatchOneway:
-            {
-                //
+            case Reference.ModeTwoway, Reference.ModeOneway, Reference.ModeBatchOneway -> {
                 // Filter out datagram endpoints.
-                //
                 Iterator<EndpointI> i = endpoints.iterator();
                 while (i.hasNext()) {
                     EndpointI endpoint = i.next();
@@ -598,15 +591,10 @@ class RoutableReference extends Reference {
                         i.remove();
                     }
                 }
-                break;
             }
 
-            case Reference.ModeDatagram:
-            case Reference.ModeBatchDatagram:
-            {
-                //
+            case Reference.ModeDatagram, Reference.ModeBatchDatagram -> {
                 // Filter out non-datagram endpoints.
-                //
                 Iterator<EndpointI> i = endpoints.iterator();
                 while (i.hasNext()) {
                     EndpointI endpoint = i.next();
@@ -614,37 +602,19 @@ class RoutableReference extends Reference {
                         i.remove();
                     }
                 }
-                break;
             }
         }
 
-        //
         // Sort the endpoints according to the endpoint selection type.
-        //
         switch (getEndpointSelection()) {
-            case Random:
-            {
-                Collections.shuffle(endpoints);
-                break;
-            }
-            case Ordered:
-            {
-                // Nothing to do.
-                break;
-            }
-            default:
-            {
-                assert false;
-                break;
-            }
+            case Random -> Collections.shuffle(endpoints);
+            case Ordered -> { /* Nothing to do. */ }
+            default -> throw new AssertionError();
         }
 
-        //
-        // If a secure connection is requested or secure overrides is
-        // set, remove all non-secure endpoints. Otherwise if preferSecure is set
-        // make secure endpoints preferred. By default make non-secure
-        // endpoints preferred over secure endpoints.
-        //
+        // If a secure connection is requested or secure overrides is set, remove all non-secure endpoints.
+        // Otherwise if preferSecure is set make secure endpoints preferred.
+        // By default make non-secure endpoints preferred over secure endpoints.
         DefaultsAndOverrides overrides = getInstance().defaultsAndOverrides();
         if (overrides.overrideSecure.isPresent() ? overrides.overrideSecure.get() : getSecure()) {
             Iterator<EndpointI> i = endpoints.iterator();
@@ -663,8 +633,7 @@ class RoutableReference extends Reference {
         return endpoints.toArray(new EndpointI[endpoints.size()]);
     }
 
-    protected void createConnection(
-            EndpointI[] allEndpoints, final GetConnectionCallback callback) {
+    protected void createConnection(EndpointI[] allEndpoints, final GetConnectionCallback callback) {
         final EndpointI[] endpoints = filterEndpoints(allEndpoints);
         if (endpoints.length == 0) {
             callback.setException(new NoEndpointException(new _ObjectPrxI(this)));

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RoutableReference.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RoutableReference.java
@@ -100,16 +100,14 @@ class RoutableReference extends Reference {
     @Override
     public Reference changeCompress(boolean newCompress) {
         RoutableReference r = (RoutableReference) super.changeCompress(newCompress);
-        if (r != this
-            && _endpoints.length
-            > 0) // Also override the compress flag on the endpoints if it was updated.
-            {
-                EndpointI[] newEndpoints = new EndpointI[_endpoints.length];
-                for (int i = 0; i < _endpoints.length; i++) {
-                    newEndpoints[i] = _endpoints[i].compress(newCompress);
-                }
-                r._endpoints = newEndpoints;
+        if (r != this && _endpoints.length > 0) {
+            // Also override the compress flag on the endpoints if it was updated.
+            EndpointI[] newEndpoints = new EndpointI[_endpoints.length];
+            for (int i = 0; i < _endpoints.length; i++) {
+                newEndpoints[i] = _endpoints[i].compress(newCompress);
             }
+            r._endpoints = newEndpoints;
+        }
         return r;
     }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RouterInfo.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/RouterInfo.java
@@ -51,18 +51,16 @@ final class RouterInfo {
     }
 
     public RouterPrx getRouter() {
-        //
         // No mutex lock necessary, _router is immutable.
-        //
         return _router;
     }
 
     public EndpointI[] getClientEndpoints() {
         synchronized (this) {
-            if (_clientEndpoints != null) // Lazy initialization.
-                {
-                    return _clientEndpoints;
-                }
+            // Lazy initialization.
+            if (_clientEndpoints != null) {
+                return _clientEndpoints;
+            }
         }
 
         Router.GetClientProxyResult r = _router.getClientProxy();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/EndpointI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/EndpointI.java
@@ -184,23 +184,20 @@ final class EndpointI extends com.zeroc.Ice.EndpointI {
         return _delegate.options();
     }
 
-    //
     // Compare endpoints for sorting purposes
-    //
     @Override
-    public int compareTo(com.zeroc.Ice.EndpointI obj) // From java.lang.Comparable
-        {
-            if (!(obj instanceof EndpointI)) {
-                return type() < obj.type() ? -1 : 1;
-            }
-
-            EndpointI p = (EndpointI) obj;
-            if (this == p) {
-                return 0;
-            }
-
-            return _delegate.compareTo(p._delegate);
+    public int compareTo(com.zeroc.Ice.EndpointI obj) {
+        if (!(obj instanceof EndpointI)) {
+            return type() < obj.type() ? -1 : 1;
         }
+
+        EndpointI p = (EndpointI) obj;
+        if (this == p) {
+            return 0;
+        }
+
+        return _delegate.compareTo(p._delegate);
+    }
 
     @Override
     protected boolean checkOption(String option, String argument, String endpoint) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/StringUtil.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/StringUtil.java
@@ -64,68 +64,31 @@ public final class StringUtil {
     private static void encodeChar(
             char c, StringBuilder sb, String special, ToStringMode toStringMode) {
         switch (c) {
-            case '\\':
-            {
-                sb.append("\\\\");
-                break;
-            }
-            case '\'':
-            {
-                sb.append("\\'");
-                break;
-            }
-            case '"':
-            {
-                sb.append("\\\"");
-                break;
-            }
-            case '\007':
-            {
+            case '\\' -> sb.append("\\\\");
+            case '\'' -> sb.append("\\'");
+            case '"' -> sb.append("\\\"");
+            case '\007' -> {
                 if (toStringMode == ToStringMode.Compat) {
                     // Octal escape for compatibility with 3.6 and earlier
                     sb.append("\\007");
                 } else {
                     sb.append("\\a");
                 }
-                break;
             }
-            case '\b':
-            {
-                sb.append("\\b");
-                break;
-            }
-            case '\f':
-            {
-                sb.append("\\f");
-                break;
-            }
-            case '\n':
-            {
-                sb.append("\\n");
-                break;
-            }
-            case '\r':
-            {
-                sb.append("\\r");
-                break;
-            }
-            case '\t':
-            {
-                sb.append("\\t");
-                break;
-            }
-            case '\013':
-            {
+            case '\b' -> sb.append("\\b");
+            case '\f' -> sb.append("\\f");
+            case '\n' -> sb.append("\\n");
+            case '\r' -> sb.append("\\r");
+            case '\t' -> sb.append("\\t");
+            case '\013' -> {
                 if (toStringMode == ToStringMode.Compat) {
                     // Octal escape for compatibility with 3.6 and earlier
                     sb.append("\\013");
                 } else {
                     sb.append("\\v");
                 }
-                break;
             }
-            default:
-            {
+            default -> {
                 if (special != null && special.indexOf(c) != -1) {
                     sb.append('\\');
                     sb.append(c);
@@ -148,9 +111,7 @@ public final class StringUtil {
                                 sb.append('0');
                             }
                             sb.append(octal);
-                        } else if (c < 32
-                            || c == 127
-                            || toStringMode == ToStringMode.ASCII) {
+                        } else if (c < 32 || c == 127 || toStringMode == ToStringMode.ASCII) {
                             // append \\unnnn
                             sb.append("\\u");
                             String hex = Integer.toHexString(c);
@@ -167,7 +128,6 @@ public final class StringUtil {
                         sb.append(c);
                     }
                 }
-                break;
             }
         }
     }
@@ -274,60 +234,40 @@ public final class StringUtil {
             char c = s.charAt(++start);
 
             switch (c) {
-                case '\\':
-                case '\'':
-                case '"':
-                case '?':
-                {
+                case '\\', '\'', '"', '?' -> {
                     ++start;
                     result.append(c);
-                    break;
                 }
-                case 'a':
-                {
+                case 'a' -> {
                     ++start;
                     result.append('\u0007');
-                    break;
                 }
-                case 'b':
-                {
+                case 'b' -> {
                     ++start;
                     result.append('\b');
-                    break;
                 }
-                case 'f':
-                {
+                case 'f' -> {
                     ++start;
                     result.append('\f');
-                    break;
                 }
-                case 'n':
-                {
+                case 'n' -> {
                     ++start;
                     result.append('\n');
-                    break;
                 }
-                case 'r':
-                {
+                case 'r' -> {
                     ++start;
                     result.append('\r');
-                    break;
                 }
-                case 't':
-                {
+                case 't' -> {
                     ++start;
                     result.append('\t');
-                    break;
                 }
-                case 'v':
-                {
+                case 'v' -> {
                     ++start;
                     result.append('\u000b');
-                    break;
                 }
-                case 'u':
-                case 'U':
-                {
+
+                case 'u', 'U' -> {
                     int codePoint = 0;
                     boolean inBMP = c == 'u';
                     int size = inBMP ? 4 : 8;
@@ -360,21 +300,10 @@ public final class StringUtil {
                     } else {
                         result.append(Character.toChars(codePoint));
                     }
-                    break;
                 }
 
-                case '0':
-                case '1':
-                case '2':
-                case '3':
-                case '4':
-                case '5':
-                case '6':
-                case '7':
-                case 'x':
-                {
-                    // UTF-8 byte sequence encoded with octal or hex escapes
-
+                // UTF-8 byte sequence encoded with octal or hex escapes
+                case '0', '1', '2', '3', '4', '5', '6', '7', 'x' -> {
                     byte[] arr = new byte[end - start];
                     int i = 0;
                     boolean more = true;
@@ -415,11 +344,7 @@ public final class StringUtil {
                             }
                             if (val > 255) {
                                 String msg =
-                                    "octal value \\"
-                                        + Integer.toOctalString(val)
-                                        + " ("
-                                        + val
-                                        + ") is out of range";
+                                    "octal value \\" + Integer.toOctalString(val) + " (" + val + ") is out of range";
                                 throw new IllegalArgumentException(msg);
                             }
                         }
@@ -442,15 +367,13 @@ public final class StringUtil {
                     } catch (UnsupportedEncodingException ex) {
                         throw new IllegalArgumentException("unsupported encoding", ex);
                     }
-                    break;
                 }
-                default:
-                {
+
+                default -> {
                     if (special == null || special.isEmpty() || special.indexOf(c) == -1) {
                         result.append('\\'); // not in special, so we keep the backslash
                     }
                     result.append(checkChar(s, start++));
-                    break;
                 }
             }
         }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpEndpointI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpEndpointI.java
@@ -222,8 +222,7 @@ final class TcpEndpointI extends IPEndpointI {
         }
 
         switch (option.charAt(1)) {
-            case 't':
-            {
+            case 't': {
                 if (argument == null) {
                     throw new ParseException(
                         "no argument provided for -t option in endpoint '"
@@ -258,8 +257,7 @@ final class TcpEndpointI extends IPEndpointI {
                 return true;
             }
 
-            case 'z':
-            {
+            case 'z': {
                 if (argument != null) {
                     throw new ParseException(
                         "unexpected argument '"
@@ -274,8 +272,7 @@ final class TcpEndpointI extends IPEndpointI {
                 return true;
             }
 
-            default:
-            {
+            default: {
                 return false;
             }
         }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TraceUtil.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TraceUtil.java
@@ -162,29 +162,10 @@ final class TraceUtil {
             byte mode = stream.readByte();
             out.write("\nmode = " + (int) mode + ' ');
             switch (OperationMode.values()[mode]) {
-                case Normal:
-                {
-                    out.write("(normal)");
-                    break;
-                }
-
-                case Nonmutating:
-                {
-                    out.write("(nonmutating)");
-                    break;
-                }
-
-                case Idempotent:
-                {
-                    out.write("(idempotent)");
-                    break;
-                }
-
-                default:
-                {
-                    out.write("(unknown)");
-                    break;
-                }
+                case Normal -> out.write("(normal)");
+                case Nonmutating -> out.write("(nonmutating)");
+                case Idempotent -> out.write("(idempotent)");
+                default -> out.write("(unknown)");
             }
 
             int sz = stream.readSize();
@@ -233,29 +214,10 @@ final class TraceUtil {
             byte compress = stream.readByte();
             out.write("\ncompression status = " + (int) compress + ' ');
             switch (compress) {
-                case (byte) 0:
-                {
-                    out.write("(not compressed; do not compress response, if any)");
-                    break;
-                }
-
-                case (byte) 1:
-                {
-                    out.write("(not compressed; compress response, if any)");
-                    break;
-                }
-
-                case (byte) 2:
-                {
-                    out.write("(compressed; compress response, if any)");
-                    break;
-                }
-
-                default:
-                {
-                    out.write("(unknown)");
-                    break;
-                }
+                case (byte) 0 -> out.write("(not compressed; do not compress response, if any)");
+                case (byte) 1 -> out.write("(not compressed; compress response, if any)");
+                case (byte) 2 -> out.write("(compressed; compress response, if any)");
+                default -> out.write("(unknown)");
             }
 
             int size = stream.readInt();
@@ -267,40 +229,15 @@ final class TraceUtil {
         }
     }
 
-    private static byte printMessage(
-            StringWriter s, InputStream str, ConnectionI connection) {
+    private static byte printMessage(StringWriter s, InputStream str, ConnectionI connection) {
         byte type = printHeader(s, str);
 
         switch (type) {
-            case Protocol.closeConnectionMsg:
-            case Protocol.validateConnectionMsg:
-            {
-                // We're done.
-                break;
-            }
-
-            case Protocol.requestMsg:
-            {
-                printRequest(s, str);
-                break;
-            }
-
-            case Protocol.requestBatchMsg:
-            {
-                printBatchRequest(s, str);
-                break;
-            }
-
-            case Protocol.replyMsg:
-            {
-                printReply(s, str);
-                break;
-            }
-
-            default:
-            {
-                break;
-            }
+            case Protocol.closeConnectionMsg, Protocol.validateConnectionMsg -> { /* we're done */ }
+            case Protocol.requestMsg -> printRequest(s, str);
+            case Protocol.requestBatchMsg -> printBatchRequest(s, str);
+            case Protocol.replyMsg -> printReply(s, str);
+            default -> {}
         }
 
         if (connection != null) {
@@ -318,20 +255,14 @@ final class TraceUtil {
     }
 
     private static String getMessageTypeAsString(byte type) {
-        switch (type) {
-            case Protocol.requestMsg:
-                return "request";
-            case Protocol.requestBatchMsg:
-                return "batch request";
-            case Protocol.replyMsg:
-                return "reply";
-            case Protocol.closeConnectionMsg:
-                return "close connection";
-            case Protocol.validateConnectionMsg:
-                return "validate connection";
-            default:
-                return "unknown";
-        }
+        return switch (type) {
+            case Protocol.requestMsg -> "request";
+            case Protocol.requestBatchMsg -> "batch request";
+            case Protocol.replyMsg -> "reply";
+            case Protocol.closeConnectionMsg -> "close connection";
+            case Protocol.validateConnectionMsg -> "validate connection";
+            default -> "unknown";
+        };
     }
 
     private TraceUtil() {}

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSEndpoint.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSEndpoint.java
@@ -235,25 +235,15 @@ final class WSEndpoint extends EndpointI {
 
     @Override
     protected boolean checkOption(String option, String argument, String endpoint) {
-        switch (option.charAt(1)) {
-            case 'r':
-            {
-                if (argument == null) {
-                    throw new ParseException(
-                        "no argument provided for -r option in endpoint '"
-                            + endpoint
-                            + _delegate.options()
-                            + "'");
-                }
-                _resource = argument;
-                return true;
+        if (option.charAt(1) == 'r') {
+            if (argument == null) {
+                throw new ParseException(
+                    "no argument provided for -r option in endpoint '" + endpoint + _delegate.options() + "'");
             }
-
-            default:
-            {
-                return false;
-            }
+            _resource = argument;
+            return true;
         }
+        return false;
     }
 
     private final ProtocolInstance _instance;

--- a/java/src/com.zeroc.icebt/src/main/java/com/zeroc/IceBT/EndpointI.java
+++ b/java/src/com.zeroc.icebt/src/main/java/com/zeroc/IceBT/EndpointI.java
@@ -374,15 +374,15 @@ final class EndpointI extends com.zeroc.Ice.EndpointI {
                     ex);
             }
 
-            if (_channel < 0 || _channel > 30) // RFCOMM channel limit is 30
-                {
-                    throw new ParseException(
-                        "channel value '"
-                            + argument
-                            + "' out of range in endpoint '"
-                            + endpoint
-                            + "'");
-                }
+            // RFCOMM channel limit is 30
+            if (_channel < 0 || _channel > 30) {
+                throw new ParseException(
+                    "channel value '"
+                        + argument
+                        + "' out of range in endpoint '"
+                        + endpoint
+                        + "'");
+            }
         } else if ("-t".equals(option)) {
             if (argument == null) {
                 throw new ParseException(

--- a/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/LookupI.java
+++ b/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/LookupI.java
@@ -338,32 +338,25 @@ class LookupI implements Lookup {
         }
     }
 
-    synchronized void foundObject(
-            Identity id, String requestId, ObjectPrx proxy) {
+    synchronized void foundObject(Identity id, String requestId, ObjectPrx proxy) {
+        // Ignore responses from old requests
         ObjectRequest request = _objectRequests.get(id);
-        if (request != null
-            && request.getRequestId().equals(requestId)) // Ignore responses from old requests
-            {
-                request.response(proxy);
-                request.cancelTimer();
-                _objectRequests.remove(id);
-            }
+        if (request != null && request.getRequestId().equals(requestId)) {
+            request.response(proxy);
+            request.cancelTimer();
+            _objectRequests.remove(id);
+        }
     }
 
-    synchronized void foundAdapter(
-            String adapterId,
-            String requestId,
-            ObjectPrx proxy,
-            boolean isReplicaGroup) {
+    synchronized void foundAdapter(String adapterId, String requestId, ObjectPrx proxy, boolean isReplicaGroup) {
+        // Ignore responses from old requests
         AdapterRequest request = _adapterRequests.get(adapterId);
-        if (request != null
-            && request.getRequestId().equals(requestId)) // Ignore responses from old requests
-            {
-                if (request.response(proxy, isReplicaGroup)) {
-                    request.cancelTimer();
-                    _adapterRequests.remove(adapterId);
-                }
+        if (request != null && request.getRequestId().equals(requestId)) {
+            if (request.response(proxy, isReplicaGroup)) {
+                request.cancelTimer();
+                _adapterRequests.remove(adapterId);
             }
+        }
     }
 
     synchronized void objectRequestTimedOut(ObjectRequest request) {

--- a/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
+++ b/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
@@ -293,13 +293,13 @@ class PluginI implements Plugin {
                 return;
             }
 
-            if (_pending) // No need to continue, we found a locator
-                {
-                    _future.cancel(false);
-                    _future = null;
-                    _pendingRetryCount = 0;
-                    _pending = false;
-                }
+            if (_pending) {
+                // No need to continue, we found a locator
+                _future.cancel(false);
+                _future = null;
+                _pendingRetryCount = 0;
+                _pending = false;
+            }
 
             if (_traceLevel > 0) {
                 StringBuffer s = new StringBuffer("locator lookup succeeded:\nlocator = ");
@@ -374,57 +374,57 @@ class PluginI implements Plugin {
                     _pendingRequests.add(request);
                 }
 
-                if (!_pending) // No request in progress
-                    {
-                        _pending = true;
-                        _pendingRetryCount = _retryCount;
-                        _failureCount = 0;
-                        try {
-                            if (_traceLevel > 1) {
-                                StringBuilder s = new StringBuilder("looking up locator:\nlookup = ");
-                                s.append(_lookup);
-                                if (!_instanceName.isEmpty()) {
-                                    s.append("\ninstance name = ").append(_instanceName);
-                                }
-                                _lookup.ice_getCommunicator().getLogger().trace("Lookup", s.toString());
+                // If there are no requests in progress.
+                if (!_pending) {
+                    _pending = true;
+                    _pendingRetryCount = _retryCount;
+                    _failureCount = 0;
+                    try {
+                        if (_traceLevel > 1) {
+                            StringBuilder s = new StringBuilder("looking up locator:\nlookup = ");
+                            s.append(_lookup);
+                            if (!_instanceName.isEmpty()) {
+                                s.append("\ninstance name = ").append(_instanceName);
                             }
-                            for (Map.Entry<LookupPrx, LookupReplyPrx> entry : _lookups.entrySet()) {
-                                entry.getKey()
-                                    .findLocatorAsync(_instanceName, entry.getValue())
-                                    .whenCompleteAsync(
-                                        (v, ex) -> {
-                                            if (ex != null) {
-                                                exception(ex);
-                                            }
-                                        },
-                                        entry.getKey()
-                                            .ice_executor()); // Send multicast request.
-                            }
-                            _future =
-                                _timer.schedule(
-                                    _retryTask,
-                                    _timeout,
-                                    TimeUnit.MILLISECONDS);
-                        } catch (LocalException ex) {
-                            if (_traceLevel > 0) {
-                                StringBuilder s =
-                                    new StringBuilder("locator lookup failed:\nlookup = ");
-                                s.append(_lookup);
-                                if (!_instanceName.isEmpty()) {
-                                    s.append("\ninstance name = ").append(_instanceName);
-                                }
-                                s.append("\n").append(ex);
-                                _lookup.ice_getCommunicator().getLogger().trace("Lookup", s.toString());
-                            }
-
-                            for (Request req : _pendingRequests) {
-                                req.invoke(_voidLocator);
-                            }
-                            _pendingRequests.clear();
-                            _pending = false;
-                            _pendingRetryCount = 0;
+                            _lookup.ice_getCommunicator().getLogger().trace("Lookup", s.toString());
                         }
+                        for (Map.Entry<LookupPrx, LookupReplyPrx> entry : _lookups.entrySet()) {
+                            entry.getKey()
+                                .findLocatorAsync(_instanceName, entry.getValue())
+                                .whenCompleteAsync(
+                                    (v, ex) -> {
+                                        if (ex != null) {
+                                            exception(ex);
+                                        }
+                                    },
+                                    entry.getKey()
+                                        .ice_executor()); // Send multicast request.
+                        }
+                        _future =
+                            _timer.schedule(
+                                _retryTask,
+                                _timeout,
+                                TimeUnit.MILLISECONDS);
+                    } catch (LocalException ex) {
+                        if (_traceLevel > 0) {
+                            StringBuilder s =
+                                new StringBuilder("locator lookup failed:\nlookup = ");
+                            s.append(_lookup);
+                            if (!_instanceName.isEmpty()) {
+                                s.append("\ninstance name = ").append(_instanceName);
+                            }
+                            s.append("\n").append(ex);
+                            _lookup.ice_getCommunicator().getLogger().trace("Lookup", s.toString());
+                        }
+
+                        for (Request req : _pendingRequests) {
+                            req.invoke(_voidLocator);
+                        }
+                        _pendingRequests.clear();
+                        _pending = false;
+                        _pendingRetryCount = 0;
                     }
+                }
             }
         }
 

--- a/java/test/src/main/java/test/Ice/ami/AllTests.java
+++ b/java/test/src/main/java/test/Ice/ami/AllTests.java
@@ -878,11 +878,10 @@ public class AllTests {
                 try {
                     InvocationFuture<Void> r = null;
                     byte[] seq = new byte[10024];
-                    for (int i = 0; i < 200; i++) // 2MB
-                        {
-                            r = Util.getInvocationFuture(p.opWithPayloadAsync(seq));
-                            results.add(r);
-                        }
+                    for (int i = 0; i < 200 /*2MB*/; i++) {
+                        r = Util.getInvocationFuture(p.opWithPayloadAsync(seq));
+                        results.add(r);
+                    }
 
                     test(!r.isSent());
 

--- a/java/test/src/main/java/test/Ice/ami/AllTests.java
+++ b/java/test/src/main/java/test/Ice/ami/AllTests.java
@@ -114,19 +114,9 @@ public class AllTests {
 
     private static void throwEx(ThrowType t) {
         switch (t) {
-            case LocalException:
-            {
-                throw new ObjectNotExistException();
-            }
-            case OtherException:
-            {
-                throw new RuntimeException();
-            }
-            default:
-            {
-                assert false;
-                break;
-            }
+            case LocalException -> throw new ObjectNotExistException();
+            case OtherException -> throw new RuntimeException();
+            default -> throw new AssertionError();
         }
     }
 

--- a/java/test/src/main/java/test/Ice/ami/TestI.java
+++ b/java/test/src/main/java/test/Ice/ami/TestI.java
@@ -172,12 +172,11 @@ public class TestI implements TestIntf {
     public synchronized void finishDispatch(Current current) {
         if (_shutdown) {
             return;
-        } else if (_pending
-            != null) // Pending might not be set yet if startDispatch is dispatch out-of-order
-            {
-                _pending.complete(null);
-                _pending = null;
-            }
+        } else if (_pending != null) {
+            // Pending might not be set yet if startDispatch is dispatch out-of-order
+            _pending.complete(null);
+            _pending = null;
+        }
     }
 
     @Override

--- a/java/test/src/main/java/test/Ice/background/AllTests.java
+++ b/java/test/src/main/java/test/Ice/background/AllTests.java
@@ -111,11 +111,11 @@ public class AllTests {
                 }
 
                 try {
-                    if (++count == 10) // Don't blast the connection with only oneway's
-                        {
-                            count = 0;
-                            _background.ice_twoway().ice_ping();
-                        }
+                    // Don't blast the connection with only oneways
+                    if (++count == 10) {
+                        count = 0;
+                        _background.ice_twoway().ice_ping();
+                    }
                     _background.op();
                     try {
                         Thread.sleep(1);
@@ -124,10 +124,10 @@ public class AllTests {
             }
         }
 
-        public synchronized void _destroy() // Thread.destroy is deprecated
-            {
-                _destroyed = true;
-            }
+        // Thread.destroy is deprecated
+        public synchronized void _destroy() {
+            _destroyed = true;
+        }
 
         private boolean _destroyed;
         private BackgroundPrx _background;
@@ -893,10 +893,9 @@ public class AllTests {
         new Random().nextBytes(seq); // Make sure the request doesn't compress too well.
 
         // Fill up the receive and send buffers
-        for (int i = 0; i < 200; i++) // 2MB
-            {
-                backgroundOneway.opWithPayloadAsync(seq).whenComplete((result, ex) -> test(false));
-            }
+        for (int i = 0; i < 200 /*2MB*/; i++) {
+            backgroundOneway.opWithPayloadAsync(seq).whenComplete((result, ex) -> test(false));
+        }
 
         OpAMICallback cb = new OpAMICallback();
         CompletableFuture<Void> r1 = background.opAsync();

--- a/java/test/src/main/java/test/Ice/operations/BatchOneways.java
+++ b/java/test/src/main/java/test/Ice/operations/BatchOneways.java
@@ -87,13 +87,12 @@ class BatchOneways {
         }
 
         int count = 0;
-        while (count < 27) // 3 * 9 requests auto-flushed.
-            {
-                count += p.opByteSOnewayCallCount();
-                try {
-                    Thread.sleep(10);
-                } catch (InterruptedException ex) {}
-            }
+        while (count < 27 /* 3*9 requests auto-flushed */) {
+            count += p.opByteSOnewayCallCount();
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException ex) {}
+        }
 
         final boolean bluetooth =
             properties.getIceProperty("Ice.Default.Protocol").indexOf("bt") == 0;

--- a/java/test/src/main/java/test/Ice/operations/BatchOnewaysAMI.java
+++ b/java/test/src/main/java/test/Ice/operations/BatchOnewaysAMI.java
@@ -70,13 +70,12 @@ class BatchOnewaysAMI {
         }
 
         int count = 0;
-        while (count < 27) // 3 * 9 requests auto-flushed.
-            {
-                count += p.opByteSOnewayCallCount();
-                try {
-                    Thread.sleep(10);
-                } catch (InterruptedException ex) {}
-            }
+        while (count < 27 /* 3*9 requests auto-flushed */) {
+            count += p.opByteSOnewayCallCount();
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException ex) {}
+        }
 
         final boolean bluetooth =
             properties.getIceProperty("Ice.Default.Protocol").indexOf("bt") == 0;

--- a/java/test/src/main/java/test/Ice/proxy/AllTests.java
+++ b/java/test/src/main/java/test/Ice/proxy/AllTests.java
@@ -420,19 +420,19 @@ public class AllTests {
         ObjectPrx b2 = communicator.stringToProxy(communicator.proxyToString(b1));
         test(b1.equals(b2));
 
-        if (b1.ice_getConnection() != null) // not colloc-optimized target
-            {
-                b2 = b1.ice_getConnection().createProxy(Util.stringToIdentity("fixed"));
-                String str = communicator.proxyToString(b2);
-                test(b2.toString().equals(str));
-                String str2 =
-                    b1.ice_identity(b2.ice_getIdentity()).ice_secure(b2.ice_isSecure()).toString();
+        // not colloc-optimized target
+        if (b1.ice_getConnection() != null) {
+            b2 = b1.ice_getConnection().createProxy(Util.stringToIdentity("fixed"));
+            String str = communicator.proxyToString(b2);
+            test(b2.toString().equals(str));
+            String str2 =
+                b1.ice_identity(b2.ice_getIdentity()).ice_secure(b2.ice_isSecure()).toString();
 
-                // Verify that the stringified fixed proxy is the same as a regular stringified proxy
-                // but without endpoints
-                test(str2.startsWith(str));
-                test(str2.charAt(str.length()) == ':');
-            }
+            // Verify that the stringified fixed proxy is the same as a regular stringified proxy
+            // but without endpoints
+            test(str2.startsWith(str));
+            test(str2.charAt(str.length()) == ':');
+        }
         out.println("ok");
 
         out.print("testing propertyToProxy... ");

--- a/java/test/src/main/java/test/Ice/seqMapping/Serialize/Large.java
+++ b/java/test/src/main/java/test/Ice/seqMapping/Serialize/Large.java
@@ -4,8 +4,8 @@ package test.Ice.seqMapping.Serialize;
 
 import java.io.Serializable;
 
-public class Large implements Serializable // More than 254 bytes when serialized.
-{
+// More than 254 bytes when serialized.
+public class Large implements Serializable {
     public double d1;
     public double d2;
     public double d3;

--- a/java/test/src/main/java/test/Ice/seqMapping/Serialize/Small.java
+++ b/java/test/src/main/java/test/Ice/seqMapping/Serialize/Small.java
@@ -4,7 +4,7 @@ package test.Ice.seqMapping.Serialize;
 
 import java.io.Serializable;
 
-public class Small implements Serializable // Fewer than 254 bytes when serialized.
-{
+// Fewer than 254 bytes when serialized.
+public class Small implements Serializable {
     public int i;
 }

--- a/java/test/src/main/java/test/Ice/seqMapping/Serialize/Struct.java
+++ b/java/test/src/main/java/test/Ice/seqMapping/Serialize/Struct.java
@@ -4,9 +4,8 @@ package test.Ice.seqMapping.Serialize;
 
 import java.io.Serializable;
 
-public class Struct
-    implements Serializable // Used to test that null members marshal correctly.
-{
+// Used to test that null members marshal correctly.
+public class Struct implements Serializable {
     public Object o;
     public Object o2;
     public String s;

--- a/java/test/src/main/java/test/Ice/stream/Serialize/Small.java
+++ b/java/test/src/main/java/test/Ice/stream/Serialize/Small.java
@@ -4,7 +4,7 @@ package test.Ice.stream.Serialize;
 
 import java.io.Serializable;
 
-public class Small implements Serializable // Fewer than 254 bytes when serialized.
-{
+// Fewer than 254 bytes when serialized.
+public class Small implements Serializable {
     public int i;
 }

--- a/java/test/src/main/java/test/TestHelper.java
+++ b/java/test/src/main/java/test/TestHelper.java
@@ -64,24 +64,12 @@ public abstract class TestHelper {
         if (protocol.indexOf("bt") == 0) {
             // For Bluetooth, there's no need to specify a port (channel) number.
             // The client locates the server using its address and a UUID.
-            switch (num) {
-                case 0:
-                {
-                    return "default -u 5e08f4de-5015-4507-abe1-a7807002db3d";
-                }
-                case 1:
-                {
-                    return "default -u dae56460-2485-46fd-a3ca-8b730e1e868b";
-                }
-                case 2:
-                {
-                    return "default -u 99e08bc6-fcda-4758-afd0-a8c00655c999";
-                }
-                default:
-                {
-                    assert false;
-                }
-            }
+            return switch (num) {
+                case 0 -> "default -u 5e08f4de-5015-4507-abe1-a7807002db3d";
+                case 1 -> "default -u dae56460-2485-46fd-a3ca-8b730e1e868b";
+                case 2 -> "default -u 99e08bc6-fcda-4758-afd0-a8c00655c999";
+                default -> throw new AssertionError();
+            };
         }
         return protocol + " -p " + Integer.toString(basePort + num);
     }


### PR DESCRIPTION
The primary tool we use for checking formatting and lints in Java is Checkstyle.
This PR cleans up our checkstyle configuration file, enabling some extra rules we have commented out, adding some comments to the file, and removing some rules we don't need.

I also updated the checkstyle config file in the `ice-demos` repo to match these changes. See https://github.com/zeroc-ice/ice-demos/pull/549