### PR TITLE
Remove KindObject from builtin table

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -821,7 +821,7 @@ Slice::Builtin::unit() const
 bool
 Slice::Builtin::isClassType() const
 {
-    return _kind == KindObject || _kind == KindValue;
+    return _kind == KindValue;
 }
 
 size_t
@@ -845,8 +845,6 @@ Slice::Builtin::minWireSize() const
             return 8;
         case KindString:
             return 1; // at least one byte for an empty string.
-        case KindObject:
-            return 1; // at least one byte (to marshal an index instead of an instance).
         case KindObjectProxy:
             return 2; // at least an empty identity for a nil proxy, that is, 2 bytes.
         case KindValue:
@@ -875,7 +873,6 @@ Slice::Builtin::getOptionalFormat() const
             return "F8";
         case KindString:
             return "VSize";
-        case KindObject:
         case KindValue:
             return "Class";
         case KindObjectProxy:
@@ -892,7 +889,6 @@ Slice::Builtin::isVariableLength() const
     switch (_kind)
     {
         case KindString:
-        case KindObject:
         case KindObjectProxy:
         case KindValue:
             return true;
@@ -948,6 +944,12 @@ Slice::Builtin::kindAsString() const
 optional<Slice::Builtin::Kind>
 Slice::Builtin::kindFromString(string_view str)
 {
+    // Object is an alias for Value that we don't put in the builtinTable.
+    if (str == "Object")
+    {
+        return KindValue;
+    }
+
     for (size_t i = 0; i < builtinTable.size(); i++)
     {
         if (str == builtinTable[i])
@@ -4306,7 +4308,6 @@ Slice::Dictionary::isLegalKeyType(const TypePtr& type)
 
             case Builtin::KindFloat:
             case Builtin::KindDouble:
-            case Builtin::KindObject:
             case Builtin::KindObjectProxy:
             case Builtin::KindValue:
             {

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -347,7 +347,6 @@ namespace Slice
             KindFloat,
             KindDouble,
             KindString,
-            KindObject,
             KindObjectProxy,
             KindValue
         };
@@ -369,8 +368,8 @@ namespace Slice
         static std::optional<Kind> kindFromString(std::string_view str);
 
         // NOLINTNEXTLINE(cert-err58-cpp)
-        inline static const std::array<std::string, 11> builtinTable =
-            {"byte", "bool", "short", "int", "long", "float", "double", "string", "Object", "Object*", "Value"};
+        inline static const std::array<std::string, 10> builtinTable =
+            {"byte", "bool", "short", "int", "long", "float", "double", "string", "Object*", "Value"};
 
     private:
         const Kind _kind;

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -104,7 +104,6 @@ namespace
             "float32",                 // KindFloat
             "float64",                 // KindDouble
             "string",                  // KindString
-            "AnyClass?",               // KindObject
             "IceRpc::ServiceAddress?", // KindObjectProxy
             "AnyClass?"                // KindValue
         };
@@ -154,7 +153,6 @@ namespace
             "float",                           // KindFloat
             "double",                          // KindDouble
             "string",                          // KindString
-            "AnyClass",                        // KindObject
             "IceRpc.Slice.Ice.IceObjectProxy", // KindObjectProxy
             "AnyClass"                         // KindValue
         };

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -413,7 +413,6 @@ Slice::isMovable(const TypePtr& type)
         switch (builtin->kind())
         {
             case Builtin::KindString:
-            case Builtin::KindObject:
             case Builtin::KindObjectProxy:
             case Builtin::KindValue:
             {
@@ -489,7 +488,6 @@ Slice::typeToString(
         "float",
         "double",
         "****", // string or wstring, see below
-        "Ice::ValuePtr",
         "std::optional<Ice::ObjectPrx>",
         "Ice::ValuePtr"};
 
@@ -502,14 +500,7 @@ Slice::typeToString(
         }
         else
         {
-            if (builtin->kind() == Builtin::KindObject)
-            {
-                return string{builtinTable[Builtin::KindValue]};
-            }
-            else
-            {
-                return string{builtinTable[builtin->kind()]};
-            }
+            return string{builtinTable[builtin->kind()]};
         }
     }
 

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -32,7 +32,6 @@ namespace
                 case Builtin::KindFloat:
                 case Builtin::KindDouble:
                 case Builtin::KindValue:
-                case Builtin::KindObject:
                 case Builtin::KindObjectProxy:
                 {
                     return true;

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -110,30 +110,13 @@ Slice::Csharp::typeToString(const TypePtr& type, const string& package, bool opt
     }
     // else, just use the regular mapping. null represents "not set".
 
-    static const char* builtinTable[] = {
-        "byte",
-        "bool",
-        "short",
-        "int",
-        "long",
-        "float",
-        "double",
-        "string",
-        "Ice.Object", // not used anymore
-        "Ice.ObjectPrx?",
-        "Ice.Value?"};
+    static const char* builtinTable[] =
+        {"byte", "bool", "short", "int", "long", "float", "double", "string", "Ice.ObjectPrx?", "Ice.Value?"};
 
     BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
     if (builtin)
     {
-        if (builtin->kind() == Builtin::KindObject)
-        {
-            return builtinTable[Builtin::KindValue];
-        }
-        else
-        {
-            return builtinTable[builtin->kind()];
-        }
+        return builtinTable[builtin->kind()];
     }
 
     ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
@@ -248,7 +231,6 @@ Slice::Csharp::isValueType(const TypePtr& type)
         switch (builtin->kind())
         {
             case Builtin::KindString:
-            case Builtin::KindObject:
             case Builtin::KindObjectProxy:
             case Builtin::KindValue:
             {
@@ -448,7 +430,6 @@ Slice::Csharp::writeMarshalUnmarshalCode(
                 }
                 return;
             }
-            case Builtin::KindObject:
             case Builtin::KindValue:
             {
                 // Handled by isClassType below.
@@ -688,7 +669,6 @@ Slice::Csharp::writeOptionalMarshalUnmarshalCode(
                 }
                 break;
             }
-            case Builtin::KindObject:
             case Builtin::KindValue:
             {
                 // Unreachable because we reject all class types at the start of the function.
@@ -943,7 +923,6 @@ Slice::Csharp::writeSequenceMarshalUnmarshalCode(
         switch (kind)
         {
             case Builtin::KindValue:
-            case Builtin::KindObject:
             case Builtin::KindObjectProxy:
             {
                 if (marshal)
@@ -975,8 +954,7 @@ Slice::Csharp::writeSequenceMarshalUnmarshalCode(
                                 << ".GetEnumerator();";
                             out << nl << "while (e.MoveNext())";
                             out << sb;
-                            string func = (kind == Builtin::KindObject || kind == Builtin::KindValue) ? "writeValue"
-                                                                                                      : "writeProxy";
+                            string func = (kind == Builtin::KindValue) ? "writeValue" : "writeProxy";
                             out << nl << stream << '.' << func << "(e.Current);";
                             out << eb;
                         }
@@ -985,8 +963,7 @@ Slice::Csharp::writeSequenceMarshalUnmarshalCode(
                     {
                         out << nl << "for (int ix = 0; ix < " << param << '.' << limitID << "; ++ix)";
                         out << sb;
-                        string func =
-                            (kind == Builtin::KindObject || kind == Builtin::KindValue) ? "writeValue" : "writeProxy";
+                        string func = (kind == Builtin::KindValue) ? "writeValue" : "writeProxy";
                         out << nl << stream << '.' << func << '(' << param << "[ix]);";
                         out << eb;
                     }
@@ -1000,7 +977,7 @@ Slice::Csharp::writeSequenceMarshalUnmarshalCode(
                     {
                         out << nl << param << " = new ";
                     }
-                    if ((kind == Builtin::KindObject || kind == Builtin::KindValue))
+                    if (kind == Builtin::KindValue)
                     {
                         string patcherName;
                         if (isArray)
@@ -1580,7 +1557,6 @@ Slice::Csharp::writeOptionalSequenceMarshalUnmarshalCode(
             }
 
             case Builtin::KindValue:
-            case Builtin::KindObject:
             case Builtin::KindObjectProxy:
             {
                 if (marshal)

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -167,7 +167,6 @@ Slice::JavaVisitor::writeMarshalUnmarshalCode(
                 }
                 return;
             }
-            case Builtin::KindObject:
             case Builtin::KindValue:
             {
                 assert(false); // already handled by 'isClassType' check above.
@@ -1871,7 +1870,6 @@ Slice::JavaVisitor::writeConstantValue(
                 case Builtin::KindShort:
                 case Builtin::KindInt:
                 case Builtin::KindDouble:
-                case Builtin::KindObject:
                 case Builtin::KindObjectProxy:
                 case Builtin::KindValue:
                 {
@@ -3117,7 +3115,6 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
                 }
 
                 case Builtin::KindString:
-                case Builtin::KindObject:
                 case Builtin::KindObjectProxy:
                 case Builtin::KindValue:
                 {

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -233,7 +233,7 @@ Slice::Java::mapsToJavaBuiltinType(const TypePtr& p)
 {
     if (auto builtin = dynamic_pointer_cast<Builtin>(p))
     {
-        return builtin->kind() < Builtin::KindObject;
+        return builtin->kind() <= Builtin::KindString;
     }
     return false;
 }
@@ -303,11 +303,7 @@ Slice::Java::getStaticId(const TypePtr& type, const string& package)
 
     assert((b && b->usesClasses()) || cl);
 
-    if (b && b->kind() == Builtin::KindObject)
-    {
-        return "com.zeroc.Ice.Object.ice_staticId()";
-    }
-    else if (b && b->kind() == Builtin::KindValue)
+    if (b && b->kind() == Builtin::KindValue)
     {
         return "com.zeroc.Ice.Value.ice_staticId()";
     }
@@ -341,7 +337,6 @@ Slice::Java::typeToString(
         "float",
         "double",
         "String",
-        "com.zeroc.Ice.Object",
         "com.zeroc.Ice.ObjectPrx",
         "com.zeroc.Ice.Value"};
 
@@ -353,7 +348,6 @@ Slice::Java::typeToString(
         "java.util.OptionalLong",
         "java.util.Optional<java.lang.Float>",
         "java.util.OptionalDouble",
-        "???",
         "???",
         "???",
         "???"};
@@ -382,7 +376,6 @@ Slice::Java::typeToString(
                     return getUnqualified(builtinOptionalTable[builtin->kind()], package);
                 }
                 case Builtin::KindString:
-                case Builtin::KindObject:
                 case Builtin::KindObjectProxy:
                 case Builtin::KindValue:
                 {
@@ -392,14 +385,7 @@ Slice::Java::typeToString(
         }
         else
         {
-            if (builtin->kind() == Builtin::KindObject)
-            {
-                return getUnqualified(builtinTable[Builtin::KindValue], package);
-            }
-            else
-            {
-                return getUnqualified(builtinTable[builtin->kind()], package);
-            }
+            return getUnqualified(builtinTable[builtin->kind()], package);
         }
     }
 
@@ -469,7 +455,6 @@ Slice::Java::typeToObjectString(
         "java.lang.Float",
         "java.lang.Double",
         "java.lang.String",
-        "com.zeroc.Ice.Value",
         "com.zeroc.Ice.ObjectPrx",
         "com.zeroc.Ice.Value"};
 

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -38,7 +38,6 @@ namespace
             "java.nio.DoubleBuffer",
             "???",
             "???",
-            "???",
             "???"};
 
         BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -616,7 +616,7 @@ Slice::Gen::ImportVisitor::visitSequence(const SequencePtr& seq)
     {
         switch (builtin->kind())
         {
-            case Builtin::KindObject:
+            case Builtin::KindValue:
                 _seenObjectSeq = true;
                 break;
             case Builtin::KindObjectProxy:
@@ -637,7 +637,7 @@ Slice::Gen::ImportVisitor::visitDictionary(const DictionaryPtr& dict)
     {
         switch (builtin->kind())
         {
-            case Builtin::KindObject:
+            case Builtin::KindValue:
                 _seenObjectDict = true;
                 break;
             case Builtin::KindObjectProxy:
@@ -1622,17 +1622,16 @@ Slice::Gen::TypesVisitor::encodeTypeForOperation(const TypePtr& type)
     assert(type);
 
     static const char* builtinTable[] = {
-        "0",  // byte
-        "1",  // bool
-        "2",  // short
-        "3",  // int
-        "4",  // long
-        "5",  // float
-        "6",  // double
-        "7",  // string
-        "8",  // Ice.Object
-        "9",  // Ice.ObjectPrx
-        "10", // Ice.Value
+        "0", // byte
+        "1", // bool
+        "2", // short
+        "3", // int
+        "4", // long
+        "5", // float
+        "6", // double
+        "7", // string
+        "8", // Ice.ObjectPrx
+        "9", // Ice.Value
     };
 
     BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
@@ -1937,7 +1936,6 @@ Slice::Gen::TypeScriptVisitor::typeToTsString(const TypePtr& type, bool nullable
         "number",  // float
         "number",  // double
         "string",
-        "Ice.Value", // Ice.Object
         "Ice.ObjectPrx",
         "Ice.Value"};
 
@@ -1956,7 +1954,6 @@ Slice::Gen::TypeScriptVisitor::typeToTsString(const TypePtr& type, bool nullable
                 }
                 break;
             }
-            case Builtin::KindObject:
             case Builtin::KindObjectProxy:
             case Builtin::KindValue:
             {

--- a/cpp/src/slice2js/JsUtil.cpp
+++ b/cpp/src/slice2js/JsUtil.cpp
@@ -104,7 +104,6 @@ Slice::JavaScript::typeToJsString(const TypePtr& type, bool definition)
         "Number",  // float
         "Number",  // double
         "String",
-        "Ice.Value",
         "Ice.ObjectPrx",
         "Ice.Value"};
 
@@ -275,7 +274,6 @@ Slice::JavaScript::writeMarshalUnmarshalCode(Output& out, const TypePtr& type, c
                 }
                 return;
             }
-            case Builtin::KindObject:
             case Builtin::KindValue:
             {
                 // Handled by isClassType below.
@@ -440,7 +438,6 @@ Slice::JavaScript::getHelper(const TypePtr& type)
             {
                 return "Ice.StringHelper";
             }
-            case Builtin::KindObject:
             case Builtin::KindValue:
             {
                 return "Ice.ObjectHelper";

--- a/cpp/src/slice2matlab/Gen.cpp
+++ b/cpp/src/slice2matlab/Gen.cpp
@@ -3036,10 +3036,9 @@ CodeVisitor::marshal(
         const TypePtr content = seq->type();
         const BuiltinPtr b = dynamic_pointer_cast<Builtin>(content);
 
-        if (b && b->kind() != Builtin::KindObjectProxy && b->kind() != Builtin::KindValue)
+        if (b && b->kind() <= Builtin::KindString)
         {
-            static const char* builtinTable[] =
-                {"Byte", "Bool", "Short", "Int", "Long", "Float", "Double", "String", "???", "???"};
+            static const char* builtinTable[] = {"Byte", "Bool", "Short", "Int", "Long", "Float", "Double", "String"};
             string bs = builtinTable[b->kind()];
             out << nl << stream << ".write" << builtinTable[b->kind()] << "Seq";
             if (optional)
@@ -3277,10 +3276,9 @@ CodeVisitor::unmarshal(
         const TypePtr content = seq->type();
         const BuiltinPtr b = dynamic_pointer_cast<Builtin>(content);
 
-        if (b && b->kind() != Builtin::KindObjectProxy && b->kind() != Builtin::KindValue)
+        if (b && b->kind() <= Builtin::KindString)
         {
-            static const char* builtinTable[] =
-                {"Byte", "Bool", "Short", "Int", "Long", "Float", "Double", "String", "???", "???"};
+            static const char* builtinTable[] = {"Byte", "Bool", "Short", "Int", "Long", "Float", "Double", "String"};
             string bs = builtinTable[b->kind()];
             out << nl << v << " = " << stream << ".read" << builtinTable[b->kind()] << "Seq";
             if (optional)

--- a/cpp/src/slice2matlab/Gen.cpp
+++ b/cpp/src/slice2matlab/Gen.cpp
@@ -3039,7 +3039,6 @@ CodeVisitor::marshal(
         if (b && b->kind() <= Builtin::KindString)
         {
             static const char* builtinTable[] = {"Byte", "Bool", "Short", "Int", "Long", "Float", "Double", "String"};
-            string bs = builtinTable[b->kind()];
             out << nl << stream << ".write" << builtinTable[b->kind()] << "Seq";
             if (optional)
             {
@@ -3279,7 +3278,6 @@ CodeVisitor::unmarshal(
         if (b && b->kind() <= Builtin::KindString)
         {
             static const char* builtinTable[] = {"Byte", "Bool", "Short", "Int", "Long", "Float", "Double", "String"};
-            string bs = builtinTable[b->kind()];
             out << nl << v << " = " << stream << ".read" << builtinTable[b->kind()] << "Seq";
             if (optional)
             {

--- a/cpp/src/slice2matlab/Gen.cpp
+++ b/cpp/src/slice2matlab/Gen.cpp
@@ -55,7 +55,6 @@ namespace
             "single",
             "double",
             "char",
-            "Ice.Value",     // Object
             "Ice.ObjectPrx", // ObjectPrx
             "Ice.Value"      // Value
         };
@@ -136,7 +135,6 @@ namespace
                     case Builtin::KindLong:
                     case Builtin::KindFloat:
                     case Builtin::KindDouble:
-                    case Builtin::KindObject:
                     case Builtin::KindObjectProxy:
                     case Builtin::KindValue:
                     {
@@ -191,7 +189,6 @@ namespace
                         return ""; // use implicit default
                     case Builtin::KindObjectProxy:
                         return "Ice.ObjectPrx.empty";
-                    case Builtin::KindObject:
                     case Builtin::KindValue:
                         return "Ice.UnknownSlicedValue.empty";
                 }
@@ -699,7 +696,6 @@ namespace
                 case Builtin::KindString:
                     out << " (1, :)";
                     break;
-                case Builtin::KindObject:
                 case Builtin::KindObjectProxy:
                 case Builtin::KindValue:
                     mustBeScalarOrEmpty = true;
@@ -810,7 +806,6 @@ namespace
                 case Builtin::KindString:
                     out << "character vector";
                     break;
-                case Builtin::KindObject:
                 case Builtin::KindObjectProxy:
                 case Builtin::KindValue:
                     out << typeStr << " scalar | empty array of " << typeStr;
@@ -2111,7 +2106,6 @@ CodeVisitor::visitSequence(const SequencePtr& p)
             {
                 return;
             }
-            case Builtin::KindObject:
             case Builtin::KindObjectProxy:
             case Builtin::KindValue:
             {
@@ -2950,7 +2944,6 @@ CodeVisitor::marshal(
                 }
                 return;
             }
-            case Builtin::KindObject:
             case Builtin::KindValue:
             {
                 // Handled by isClassType below.
@@ -3043,11 +3036,10 @@ CodeVisitor::marshal(
         const TypePtr content = seq->type();
         const BuiltinPtr b = dynamic_pointer_cast<Builtin>(content);
 
-        if (b && b->kind() != Builtin::KindObject && b->kind() != Builtin::KindObjectProxy &&
-            b->kind() != Builtin::KindValue)
+        if (b && b->kind() != Builtin::KindObjectProxy && b->kind() != Builtin::KindValue)
         {
             static const char* builtinTable[] =
-                {"Byte", "Bool", "Short", "Int", "Long", "Float", "Double", "String", "???", "???", "???", "???"};
+                {"Byte", "Bool", "Short", "Int", "Long", "Float", "Double", "String", "???", "???"};
             string bs = builtinTable[b->kind()];
             out << nl << stream << ".write" << builtinTable[b->kind()] << "Seq";
             if (optional)
@@ -3187,7 +3179,6 @@ CodeVisitor::unmarshal(
                 }
                 break;
             }
-            case Builtin::KindObject:
             case Builtin::KindValue:
             {
                 assert(!optional); // Optional classes are disallowed by the parser.
@@ -3286,11 +3277,10 @@ CodeVisitor::unmarshal(
         const TypePtr content = seq->type();
         const BuiltinPtr b = dynamic_pointer_cast<Builtin>(content);
 
-        if (b && b->kind() != Builtin::KindObject && b->kind() != Builtin::KindObjectProxy &&
-            b->kind() != Builtin::KindValue)
+        if (b && b->kind() != Builtin::KindObjectProxy && b->kind() != Builtin::KindValue)
         {
             static const char* builtinTable[] =
-                {"Byte", "Bool", "Short", "Int", "Long", "Float", "Double", "String", "???", "???", "???", "???"};
+                {"Byte", "Bool", "Short", "Int", "Long", "Float", "Double", "String", "???", "???"};
             string bs = builtinTable[b->kind()];
             out << nl << v << " = " << stream << ".read" << builtinTable[b->kind()] << "Seq";
             if (optional)

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -882,7 +882,6 @@ CodeVisitor::getType(const TypePtr& p)
             {
                 return "$IcePHP__t_string";
             }
-            case Builtin::KindObject:
             case Builtin::KindValue:
             {
                 return "$Ice__t_Value";
@@ -938,7 +937,6 @@ CodeVisitor::writeDefaultValue(const DataMemberPtr& m)
                 _out << "''";
                 break;
             }
-            case Builtin::KindObject:
             case Builtin::KindObjectProxy:
             case Builtin::KindValue:
             {
@@ -1032,7 +1030,6 @@ CodeVisitor::writeConstantValue(const TypePtr& type, const SyntaxTreeBasePtr& va
                     _out << "\"" << toStringLiteral(value, "\f\n\r\t\v\x1b", "$", Octal, 0) << "\"";
                     break;
                 }
-                case Slice::Builtin::KindObject:
                 case Slice::Builtin::KindObjectProxy:
                 case Slice::Builtin::KindValue:
                     assert(false);

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -896,7 +896,6 @@ Slice::Ruby::CodeVisitor::writeType(const TypePtr& p)
                 break;
             }
             case Builtin::KindValue:
-            case Builtin::KindObject:
             {
                 _out << "Ice::T_Value";
                 break;
@@ -952,7 +951,6 @@ Slice::Ruby::CodeVisitor::getInitializer(const DataMemberPtr& m)
                 return "''";
             }
             case Builtin::KindValue:
-            case Builtin::KindObject:
             case Builtin::KindObjectProxy:
             {
                 return "nil";
@@ -1007,7 +1005,6 @@ Slice::Ruby::CodeVisitor::writeConstantValue(
             }
 
             case Builtin::KindValue:
-            case Builtin::KindObject:
             case Builtin::KindObjectProxy:
                 assert(false);
         }

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -703,7 +703,6 @@ Slice::Swift::typeToString(const TypePtr& type, const ContainedPtr& usedBy, bool
         "Swift.Float",
         "Swift.Double",
         "Swift.String",
-        "Ice.Value",     // Object, which is instead mapped to `Value` here.
         "Ice.ObjectPrx", // ObjectPrx
         "Ice.Value"      // Value
     };
@@ -796,7 +795,6 @@ Slice::Swift::isNullableType(const TypePtr& type)
     {
         switch (builtin->kind())
         {
-            case Builtin::KindObject:
             case Builtin::KindObjectProxy:
             case Builtin::KindValue:
             {
@@ -1034,7 +1032,6 @@ Slice::Swift::writeMarshalUnmarshalCode(
                 }
                 break;
             }
-            case Builtin::KindObject:
             case Builtin::KindValue:
             {
                 if (marshal)

--- a/cpp/test/Slice/errorDetection/ConstDef.err
+++ b/cpp/test/Slice/errorDetection/ConstDef.err
@@ -2,7 +2,7 @@ ConstDef.ice:65: 'XXX' is not defined
 ConstDef.ice:66: redefinition of constant 'f11' as constant
 ConstDef.ice:67: constant 'F10' differs only in capitalization from constant 'f10'
 ConstDef.ice:70: constant 'ic2' has illegal type
-ConstDef.ice:71: constant 'ic3' has illegal type: 'Object'
+ConstDef.ice:71: constant 'ic3' has illegal type: 'Value'
 ConstDef.ice:73: initializer of type 'long' is incompatible with the type 'bool' of constant 'ic4'
 ConstDef.ice:74: initializer of type 'string' is incompatible with the type 'byte' of constant 'ic5'
 ConstDef.ice:75: initializer of type 'double' is incompatible with the type 'short' of constant 'ic6'

--- a/js/src/Ice/Operation.js
+++ b/js/src/Ice/Operation.js
@@ -28,7 +28,6 @@ const builtinHelpers = [
     FloatHelper,
     DoubleHelper,
     StringHelper,
-    Value,
     ObjectPrx,
     Value,
 ];


### PR DESCRIPTION
This cleanup PR removes KindObject from the Parser's builtin table.

`Object` without `*` is an alias for `Value`, and it was odd to keep this separate entry, especially since the "natural" mapping, Ice.Object, is never a mapped type.

The only slight downside is the error message when using `Object` incorrectly: it now says `Value`.