### PR TITLE
Simplify and unify generation of dependency files

### DIFF
--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -217,10 +217,12 @@ namespace Slice
         DefinitionContext(int includeLevel);
 
         [[nodiscard]] const std::string& filename() const;
+        [[nodiscard]] const std::string& resolvedFilename() const;
+        [[nodiscard]] int line() const;
         [[nodiscard]] int includeLevel() const;
         [[nodiscard]] bool seenDefinition() const;
 
-        void setFilename(std::string filename);
+        void setFilename(std::string filename, std::string resolvedFilename);
         void setSeenDefinition();
 
         [[nodiscard]] const MetadataList& getMetadata() const;
@@ -237,6 +239,7 @@ namespace Slice
         int _includeLevel;
         MetadataList _metadata;
         std::string _filename;
+        std::string _resolvedFilename;
         bool _seenDefinition{false};
         std::set<WarningCategory> _suppressedWarnings;
     };
@@ -1095,7 +1098,7 @@ namespace Slice
         [[nodiscard]] const std::string& topLevelFile() const;
         [[nodiscard]] int currentLine() const;
 
-        int setCurrentFile(const std::string& currentFile, int lineNumber);
+        int setCurrentFile(std::string currentFile, int lineNumber);
         [[nodiscard]] int currentIncludeLevel() const;
 
         void addFileMetadata(MetadataList metadata);
@@ -1159,6 +1162,7 @@ namespace Slice
         std::map<std::string, DefinitionContextPtr, std::less<>> _definitionContextMap;
         std::map<std::int32_t, std::string> _typeIds;
         std::map<std::string, std::set<std::string>> _fileTopLevelModules;
+        StringList _allFiles;
     };
 
     extern Unit* currentUnit; // The current parser for bison/flex

--- a/cpp/src/Slice/Preprocessor.cpp
+++ b/cpp/src/Slice/Preprocessor.cpp
@@ -126,19 +126,17 @@ Slice::Preprocessor::normalizeIncludePath(const string& path)
 
 namespace
 {
-    vector<string> baseArgs(vector<string> args, bool keepComments, const string& languageArg, const string& fileName)
+    vector<string> baseArgs(vector<string> args, const string& languageArg, const string& fileName)
     {
-        if (keepComments)
-        {
-            args.emplace_back("-C");
-        }
+        // -C keep comments
+        args.emplace_back("-C");
+
+        // UTF-8 encoding
         args.emplace_back("-e");
         args.emplace_back("en_us.utf8");
 
-        //
-        // Define version macros __ICE_VERSION__ is preferred. We keep
-        // ICE_VERSION for backward compatibility with 3.5.0.
-        //
+        // Define version macros __ICE_VERSION__ is preferred. We keep ICE_VERSION for backward compatibility
+        // with 3.5.0.
         const string version[2] = {"ICE_VERSION", "__ICE_VERSION__"};
         for (const auto& i : version)
         {
@@ -154,17 +152,12 @@ namespace
 }
 
 FILE*
-Slice::Preprocessor::preprocess(bool keepComments, const string& languageArg)
+Slice::Preprocessor::preprocess(const string& languageArg)
 {
-    if (!checkInputFile())
-    {
-        return nullptr;
-    }
+    checkInputFile();
 
-    //
     // Build arguments list.
-    //
-    vector<string> args = baseArgs(_args, keepComments, languageArg, _fileName);
+    vector<string> args = baseArgs(_args, languageArg, _fileName);
     const char** argv = new const char*[args.size() + 1];
     argv[0] = "mcpp";
     for (unsigned int i = 0; i < args.size(); ++i)
@@ -172,16 +165,12 @@ Slice::Preprocessor::preprocess(bool keepComments, const string& languageArg)
         argv[i + 1] = args[i].c_str();
     }
 
-    //
     // Call mcpp using memory buffer.
-    //
     mcpp_use_mem_buffers(1);
     int status = mcpp_lib_main(static_cast<int>(args.size()) + 1, const_cast<char**>(argv));
     delete[] argv;
 
-    //
     // Display any errors.
-    //
     char* err = mcpp_get_mem_buffer(Err);
     if (err)
     {
@@ -229,9 +218,7 @@ Slice::Preprocessor::preprocess(bool keepComments, const string& languageArg)
         _cppHandle = tmpfile();
 #endif
 
-        //
         // If that fails try to open file in current directory.
-        //
         if (_cppHandle == nullptr)
         {
 #ifdef _WIN32
@@ -252,398 +239,19 @@ Slice::Preprocessor::preprocess(bool keepComments, const string& languageArg)
         }
         else
         {
-            consoleErr << _path << ": error: could not open temporary file: " << _cppFile << endl;
+            // Calling this again causes the memory buffers to be freed.
+            mcpp_use_mem_buffers(1);
+            throw runtime_error(_path + ": error: could not open temporary file: " + _cppFile);
         }
     }
 
-    //
     // Calling this again causes the memory buffers to be freed.
-    //
     mcpp_use_mem_buffers(1);
 
     return _cppHandle;
 }
 
-bool
-Slice::Preprocessor::printMakefileDependencies(
-    ostream& out,
-    Language lang,
-    const vector<string>& includePaths,
-    const string& languageArg,
-    const string& optValue)
-{
-    if (!checkInputFile())
-    {
-        return false;
-    }
-
-    string cppHeaderExt;
-    if (lang == CPlusPlus)
-    {
-        cppHeaderExt = optValue;
-    }
-    else
-    {
-        assert(optValue.empty() || lang == SliceXML);
-    }
-
-    //
-    // Build arguments list.
-    //
-    vector<string> args = _args;
-    args.emplace_back("-M");
-    args = baseArgs(args, false, languageArg, _fileName);
-
-    const char** argv = new const char*[args.size() + 1];
-    for (unsigned int i = 0; i < args.size(); ++i)
-    {
-        argv[i + 1] = args[i].c_str();
-    }
-
-    //
-    // Call mcpp using memory buffer.
-    //
-    mcpp_use_mem_buffers(1);
-    int status = mcpp_lib_main(static_cast<int>(args.size() + 1), const_cast<char**>(argv));
-    delete[] argv;
-
-    //
-    // Print errors to stderr.
-    //
-    char* err = mcpp_get_mem_buffer(Err);
-    if (err)
-    {
-        vector<string> messages = filterMcppWarnings(err);
-        for (const auto& message : messages)
-        {
-            emitRaw(message.c_str());
-        }
-    }
-
-    if (status != 0)
-    {
-        //
-        // Calling this again causes the memory buffers to be freed.
-        //
-        mcpp_use_mem_buffers(1);
-        return false;
-    }
-
-    //
-    // Get mcpp output.
-    //
-    string unprocessed;
-    char* buf = mcpp_get_mem_buffer(Out);
-    if (buf)
-    {
-        unprocessed = string(buf);
-    }
-
-    //
-    // Calling this again causes the memory buffers to be freed.
-    //
-    mcpp_use_mem_buffers(1);
-
-    //
-    // We now need to massage the result to get the desired output.
-    // First remove the backslash used to escape new lines.
-    //
-    string::size_type pos;
-    while ((pos = unprocessed.find(" \\\n")) != string::npos)
-    {
-        unprocessed.replace(pos, 3, "\n");
-    }
-
-    //
-    // Split filenames in separate lines:
-    //
-    // /foo/A.ice /foo/B.ice becomes
-    // /foo/A.ice
-    // /foo/B.ice
-    //
-    // C:\foo\A.ice C:\foo\B.ice becomes
-    // C:\foo\A.ice
-    // C:\foo\B.ice
-    //
-    pos = 0;
-#ifdef _WIN32
-    while ((pos = unprocessed.find(".ice ", pos)) != string::npos)
-    {
-        if (unprocessed.find(":", pos) == pos + 6)
-        {
-            unprocessed.replace(pos, 5, ".ice\n");
-            pos += 5;
-        }
-    }
-#else
-    while ((pos = unprocessed.find(".ice /", pos)) != string::npos)
-    {
-        unprocessed.replace(pos, 5, ".ice\n");
-    }
-#endif
-
-    //
-    // Get the main output file name.
-    //
-#ifdef _MSC_VER
-    string suffix = ".obj:";
-#else
-    string suffix = ".o:";
-#endif
-    pos = unprocessed.find(suffix) + suffix.size();
-    string result;
-    if (lang != SliceXML)
-    {
-        result = unprocessed.substr(0, pos);
-    }
-
-    vector<string> fullIncludePaths;
-    fullIncludePaths.reserve(includePaths.size());
-    for (const auto& includePath : includePaths)
-    {
-        fullIncludePaths.push_back(fullPath(includePath));
-    }
-
-    //
-    // Process each dependency.
-    //
-    string sourceFile;
-    vector<string> dependencies;
-
-    string::size_type end;
-    while ((end = unprocessed.find('\n', pos)) != string::npos)
-    {
-        end += 1;
-        string file = IceInternal::trim(unprocessed.substr(pos, end - pos));
-        if (file.rfind(".ice") == file.size() - 4)
-        {
-            if (IceInternal::isAbsolutePath(file))
-            {
-                if (file == _fileName)
-                {
-                    file = _shortFileName;
-                }
-                else
-                {
-                    //
-                    // Transform back full paths generated by mcpp to paths relative to the specified
-                    // include paths.
-                    //
-                    string newFile = file;
-                    for (auto p = fullIncludePaths.begin(); p != fullIncludePaths.end(); ++p)
-                    {
-                        if (file.compare(0, p->length(), *p) == 0)
-                        {
-                            string s = includePaths[static_cast<size_t>(p - fullIncludePaths.begin())] +
-                                       file.substr(p->length());
-                            if (IceInternal::isAbsolutePath(newFile) || s.size() < newFile.size())
-                            {
-                                newFile = s;
-                            }
-                        }
-                    }
-                    file = newFile;
-                }
-            }
-
-            if (lang == SliceXML)
-            {
-                if (result.size() == 0)
-                {
-                    result = "  <source name=\"" + file + "\">";
-                }
-                else
-                {
-                    result += "\n    <dependsOn name=\"" + file + "\"/>";
-                }
-            }
-            else if (lang == JavaScriptJSON)
-            {
-                if (sourceFile.empty())
-                {
-                    sourceFile = file;
-                }
-                else
-                {
-                    dependencies.push_back(file);
-                }
-            }
-            else
-            {
-                //
-                // Escape spaces in the file name.
-                //
-                string::size_type space = 0;
-                while ((space = file.find(' ', space)) != string::npos)
-                {
-                    file.replace(space, 1, "\\ ");
-                    space += 2;
-                }
-
-                //
-                // Add to result
-                //
-                result += " \\\n " + file;
-            }
-        }
-        pos = end;
-    }
-    if (lang == SliceXML)
-    {
-        result += "\n  </source>\n";
-    }
-    else if (lang == JavaScriptJSON)
-    {
-        result = "\"" + sourceFile + "\":" + (dependencies.empty() ? "[]" : "[");
-        for (auto i = dependencies.begin(); i != dependencies.end();)
-        {
-            string file = *i;
-            result += "\n    \"" + file + "\"";
-            if (++i == dependencies.end())
-            {
-                result += "]";
-            }
-            else
-            {
-                result += ",";
-            }
-        }
-
-        pos = 0;
-        while ((pos = result.find('\\', pos + 1)) != string::npos)
-        {
-            result.insert(pos, 1, '\\');
-            ++pos;
-        }
-    }
-    else
-    {
-        result += "\n";
-    }
-
-    /*
-     * Emit dependencies in any of the following formats, depending on the
-     * length of the filenames:
-     *
-     * x.o[bj]: /path/x.ice /path/y.ice
-     *
-     * x.o[bj]: /path/x.ice \
-     *  /path/y.ice
-     *
-     * x.o[bj]: /path/x.ice /path/y.ice \
-     *  /path/z.ice
-     *
-     * x.o[bj]: \
-     *  /path/x.ice
-     *
-     * x.o[bj]: \
-     *  /path/x.ice \
-     *  /path/y.ice
-     *
-     * Spaces embedded within filenames are escaped with a backslash. Note that
-     * Windows filenames may contain colons.
-     *
-     */
-    switch (lang)
-    {
-        case CPlusPlus:
-        {
-            //
-            // Change .o[bj] suffix to the h header extension suffix.
-            //
-            pos = result.find(suffix);
-            if (pos != string::npos)
-            {
-                string name = result.substr(0, pos);
-                result.replace(0, pos + suffix.size() - 1, name + "." + cppHeaderExt);
-            }
-            break;
-        }
-        case SliceXML:
-            break;
-        case CSharp:
-        {
-            //
-            // Change .o[bj] suffix to .cs suffix.
-            //
-            if ((pos = result.find(suffix)) != string::npos)
-            {
-                result.replace(pos, suffix.size() - 1, ".cs");
-            }
-            break;
-        }
-        case JavaScriptJSON:
-            break;
-        case JavaScript:
-        {
-            //
-            // Change .o[bj] suffix to .js suffix.
-            //
-            if ((pos = result.find(suffix)) != string::npos)
-            {
-                result.replace(pos, suffix.size() - 1, ".js");
-            }
-            break;
-        }
-        case Python:
-        {
-            //
-            // Change .o[bj] suffix to .py suffix.
-            //
-            if ((pos = result.find(suffix)) != string::npos)
-            {
-                result.replace(pos, suffix.size() - 1, ".py");
-            }
-            break;
-        }
-        case Ruby:
-        {
-            //
-            // Change .o[bj] suffix to .rb suffix.
-            //
-            if ((pos = result.find(suffix)) != string::npos)
-            {
-                result.replace(pos, suffix.size() - 1, ".rb");
-            }
-            break;
-        }
-        case PHP:
-        {
-            //
-            // Change .o[bj] suffix to .php suffix.
-            //
-            if ((pos = result.find(suffix)) != string::npos)
-            {
-                result.replace(pos, suffix.size() - 1, ".php");
-            }
-            break;
-        }
-        case Swift:
-        {
-            //
-            // Change .o[bj] suffix to .swift suffix.
-            //
-            if ((pos = result.find(suffix)) != string::npos)
-            {
-                result.replace(pos, suffix.size() - 1, ".swift");
-            }
-            break;
-        }
-        default:
-        {
-            assert(false);
-            break;
-        }
-    }
-
-    //
-    // Output result
-    //
-    out << result;
-    return true;
-}
-
-bool
+void
 Slice::Preprocessor::close()
 {
     if (_cppHandle != nullptr)
@@ -658,14 +266,12 @@ Slice::Preprocessor::close()
 
         if (status != 0)
         {
-            return false;
+            throw runtime_error("failed to close preprocessor file: " + IceInternal::lastErrorToString());
         }
     }
-
-    return true;
 }
 
-bool
+void
 Slice::Preprocessor::checkInputFile()
 {
     string base(_fileName);
@@ -677,17 +283,13 @@ Slice::Preprocessor::checkInputFile()
     }
     if (suffix != ".ice")
     {
-        consoleErr << _path << ": error: input files must end with `.ice'" << endl;
-        return false;
+        throw runtime_error(_path + ": error: input files must end with `.ice'");
     }
 
     ifstream test(IceInternal::streamFilename(_fileName).c_str());
     if (!test)
     {
-        consoleErr << _path << ": error: cannot open '" << _fileName << "' for reading" << endl;
-        return false;
+        throw runtime_error(_path + ": error: cannot open '" + _fileName + "' for reading");
     }
     test.close();
-
-    return true;
 }

--- a/cpp/src/Slice/Preprocessor.h
+++ b/cpp/src/Slice/Preprocessor.h
@@ -21,28 +21,8 @@ namespace Slice
         Preprocessor(std::string path, const std::string& fileName, const std::vector<std::string>& args);
         ~Preprocessor();
 
-        FILE* preprocess(bool keepComments, const std::string& languageArg = "");
-        bool close();
-
-        enum Language
-        {
-            CPlusPlus,
-            CSharp,
-            Python,
-            Ruby,
-            PHP,
-            JavaScript,
-            JavaScriptJSON,
-            SliceXML,
-            Swift
-        };
-
-        bool printMakefileDependencies(
-            std::ostream& out,
-            Language lang,
-            const std::vector<std::string>& includePaths,
-            const std::string& languageArg = "",
-            const std::string& optValue = "");
+        FILE* preprocess(const std::string& languageArg = "");
+        void close();
 
         std::string getFileName();
         std::string getBaseName();
@@ -50,7 +30,7 @@ namespace Slice
         static std::string normalizeIncludePath(const std::string& path);
 
     private:
-        bool checkInputFile();
+        void checkInputFile();
 
         const std::string _path;
         const std::string _fileName;

--- a/cpp/src/Slice/SliceUtil.cpp
+++ b/cpp/src/Slice/SliceUtil.cpp
@@ -18,63 +18,61 @@ using namespace std;
 using namespace Slice;
 using namespace IceInternal;
 
-namespace
+string
+Slice::normalizePath(const string& path)
 {
-    string normalizePath(const string& path)
-    {
-        string result = path;
+    string result = path;
 
-        replace(result.begin(), result.end(), '\\', '/');
+    replace(result.begin(), result.end(), '\\', '/');
 
-        string::size_type startReplace = 0;
+    string::size_type startReplace = 0;
 #ifdef _WIN32
-        //
-        // For UNC paths we need to ensure they are in the format that is
-        // returned by MCPP. IE. "//MACHINE/PATH"
-        //
-        if (result.find("//") == 0)
-        {
-            startReplace = 2;
-        }
-#endif
-        string::size_type pos;
-        while ((pos = result.find("//", startReplace)) != string::npos)
-        {
-            result.replace(pos, 2, "/");
-        }
-        pos = 0;
-        while ((pos = result.find("/./", pos)) != string::npos)
-        {
-            result.erase(pos, 2);
-        }
-        pos = 0;
-        while ((pos = result.find("/..", pos)) != string::npos)
-        {
-            string::size_type last = result.find_last_of('/', pos - 1);
-            if (last != string::npos && result.substr(last, 4) != "/../")
-            {
-                result.erase(last, pos - last + 3);
-                pos = last;
-            }
-            else
-            {
-                ++pos;
-            }
-        }
-
-        if (result.size() > 1) // Remove trailing "/" or "/."
-        {
-            if (result[result.size() - 1] == '/')
-            {
-                result.erase(result.size() - 1);
-            }
-            else if (result[result.size() - 2] == '/' && result[result.size() - 1] == '.')
-            {
-                result.erase(result.size() - (result.size() == 2 ? 1 : 2));
-            }
-        }
-        return result;
+    //
+    // For UNC paths we need to ensure they are in the format that is
+    // returned by MCPP. IE. "//MACHINE/PATH"
+    //
+    if (result.find("//") == 0)
+    {
+        startReplace = 2;
     }
+#endif
+    string::size_type pos;
+    while ((pos = result.find("//", startReplace)) != string::npos)
+    {
+        result.replace(pos, 2, "/");
+    }
+    pos = 0;
+    while ((pos = result.find("/./", pos)) != string::npos)
+    {
+        result.erase(pos, 2);
+    }
+    pos = 0;
+    while ((pos = result.find("/..", pos)) != string::npos)
+    {
+        string::size_type last = result.find_last_of('/', pos - 1);
+        if (last != string::npos && result.substr(last, 4) != "/../")
+        {
+            result.erase(last, pos - last + 3);
+            pos = last;
+        }
+        else
+        {
+            ++pos;
+        }
+    }
+
+    if (result.size() > 1) // Remove trailing "/" or "/."
+    {
+        if (result[result.size() - 1] == '/')
+        {
+            result.erase(result.size() - 1);
+        }
+        else if (result[result.size() - 2] == '/' && result[result.size() - 1] == '.')
+        {
+            result.erase(result.size() - (result.size() == 2 ? 1 : 2));
+        }
+    }
+    return result;
 }
 
 string
@@ -98,7 +96,7 @@ Slice::fullPath(const string& path)
         string cwd;
         if (IceInternal::getcwd(cwd) == 0)
         {
-            result = string(cwd) + '/' + result;
+            result = cwd + '/' + result;
         }
     }
 
@@ -218,6 +216,27 @@ Slice::baseName(const string& path)
         baseName.erase(0, pos + 1);
     }
     return baseName;
+}
+
+string
+Slice::dirName(const string& path)
+{
+    string::size_type pos = path.find_last_of("/\\");
+    if (pos == string::npos)
+    {
+        // If there is no slash, return the current directory.
+        return ".";
+    }
+    else if (pos == 0)
+    {
+        // If the last slash is the first character, return the root directory.
+        return "/";
+    }
+    else
+    {
+        // Otherwise, return the directory part of the path.
+        return path.substr(0, pos);
+    }
 }
 
 void
@@ -604,4 +623,138 @@ Slice::getTypeScopedName(const TypePtr& type)
         assert(contained);
         return contained->scoped();
     }
+}
+
+string
+Slice::relativePath(const string& path1, const string& path2)
+{
+    vector<string> tokens1;
+    vector<string> tokens2;
+
+    splitString(path1, "/\\", tokens1);
+    splitString(path2, "/\\", tokens2);
+
+    string f1 = tokens1.back();
+
+    tokens1.pop_back();
+
+    auto i1 = tokens1.begin();
+    auto i2 = tokens2.begin();
+
+    while (i1 != tokens1.end() && i2 != tokens2.end() && *i1 == *i2)
+    {
+        i1++;
+        i2++;
+    }
+
+    //
+    // Different volumes, relative path not possible.
+    //
+    if (i1 == tokens1.begin() && i2 == tokens2.begin())
+    {
+        return path1;
+    }
+
+    string newPath;
+    if (i2 == tokens2.end())
+    {
+        newPath += "./";
+        for (; i1 != tokens1.end(); ++i1)
+        {
+            newPath += *i1 + "/";
+        }
+    }
+    else
+    {
+        for (vector<string>::difference_type i = tokens2.end() - i2; i > 0; i--)
+        {
+            newPath += "../";
+        }
+
+        for (; i1 != tokens1.end(); ++i1)
+        {
+            newPath += *i1 + "/";
+        }
+    }
+    newPath += f1;
+
+    return newPath;
+}
+
+void
+Slice::DependencyVisitor::visitUnitEnd(const UnitPtr& unit)
+{
+    _dependencyMap[unit->topLevelFile()] = unit->allFiles();
+}
+
+void
+Slice::DependencyVisitor::writeMakefileDependencies(
+    const string& dependFile,
+    const string& source,
+    const std::string& target)
+{
+    ostringstream os;
+    StringList dependencies = _dependencyMap[source];
+    // Write the target
+    if (dependencies.empty())
+    {
+        os << target << ":" << std::endl;
+    }
+    else
+    {
+        os << target << ": \\" << std::endl;
+        for (const auto& dependency : dependencies)
+        {
+            os << " " << dependency;
+            if (dependency != dependencies.back())
+            {
+                os << " \\";
+            }
+            os << std::endl;
+        }
+    }
+    writeDependencies(os.str(), dependFile);
+}
+
+void
+Slice::DependencyVisitor::writeXMLDependencies(const std::string& dependFile)
+{
+    ostringstream os;
+    os << R"(<?xml version="1.0" encoding="UTF-8"?>)";
+    os << endl << "<dependencies>";
+    for (auto [_, dependencies] : _dependencyMap)
+    {
+        string source = dependencies.front();
+        dependencies.pop_front();
+        string dirName = Slice::dirName(source);
+        os << endl << "  <source name=\"" << source << "\">";
+        for (const auto& dependency : dependencies)
+        {
+            os << endl << "    <dependsOn name=\"" << dependency << "\" />";
+        }
+        os << endl << "  </source>";
+    }
+    os << endl << "</dependencies>";
+    writeDependencies(os.str(), dependFile);
+}
+
+void
+Slice::DependencyVisitor::writeJSONDependencies(const std::string& dependFile)
+{
+    ostringstream os;
+    os << "{";
+    for (auto [_, dependencies] : _dependencyMap)
+    {
+        string source = dependencies.front();
+        dependencies.pop_front();
+        string dirName = Slice::dirName(source);
+        os << endl << "  \"" << source << "\" : [";
+        for (const auto& dependency : dependencies)
+        {
+            os << endl << "    \"" << normalizePath(dirName + "/" + dependency) << "\"";
+        }
+        os << endl << "  ]";
+    }
+    os << endl << "}";
+    writeDependencies(os.str(), dependFile);
 }

--- a/cpp/src/Slice/Util.h
+++ b/cpp/src/Slice/Util.h
@@ -8,10 +8,12 @@
 
 namespace Slice
 {
+    std::string normalizePath(const std::string& path);
     std::string fullPath(const std::string& path);
     std::string changeInclude(const std::string& path, const std::vector<std::string>& includePaths);
     std::string removeExtension(const std::string& path);
     std::string baseName(const std::string& path);
+    std::string dirName(const std::string& path);
     void emitError(std::string_view file, int line, std::string_view message);
     void emitWarning(std::string_view file, int line, std::string_view message);
     void emitRaw(const char* message);
@@ -83,5 +85,42 @@ namespace Slice
     /// @param type The type.
     /// @return The fully qualified name of the type.
     std::string getTypeScopedName(const TypePtr& type);
+
+    [[nodiscard]] std::string relativePath(const std::string& path1, const std::string& path2);
+
+    /// The DependencyVisitor class is used to collect dependencies of Slice units.
+    class DependencyVisitor : public ParserVisitor
+    {
+    public:
+        void visitUnitEnd(const UnitPtr& unit) final;
+
+        /// Writes the dependencies in Makefile format to the specified file. If the file is empty, it writes the
+        /// dependencies to the standard output.
+        ///
+        /// @param dependFile The file to write the dependencies to or empty to write to standard output.
+        /// @param source The source file for which dependencies are being written.
+        /// @param target The target file that is generated from the source. This is used as the Makefile target.
+        void
+        writeMakefileDependencies(const std::string& dependFile, const std::string& source, const std::string& target);
+
+        /// Writes the dependencies in XML format to the specified file. If the file is empty, it writes the
+        /// dependencies to the standard output.
+        ///
+        /// This method write the dependencies for all visited units in a single XML document.
+        ///
+        /// @param dependFile The file to write the dependencies to or empty to write to standard output.
+        void writeXMLDependencies(const std::string& dependFile);
+
+        /// Writes the dependencies in JSON format to the specified file. If the file is empty, it writes the
+        /// dependencies to the standard output.
+        ///
+        /// This method write the dependencies for all visited units in a single JSON document.
+        ///
+        /// @param dependFile The file to write the dependencies to or empty to write to standard output.
+        void writeJSONDependencies(const std::string& dependFile);
+
+    private:
+        std::map<std::string, StringList> _dependencyMap;
+    };
 }
 #endif

--- a/cpp/src/ice2slice/Main.cpp
+++ b/cpp/src/ice2slice/Main.cpp
@@ -61,10 +61,10 @@ compile(const vector<string>& argv)
 
     bool validate = find(argv.begin(), argv.end(), "--validate") != argv.end();
 
-    vector<string> args;
+    vector<string> sliceFiles;
     try
     {
-        args = opts.parse(argv);
+        sliceFiles = opts.parse(argv);
     }
     catch (const IceInternal::BadOptException& e)
     {
@@ -88,24 +88,24 @@ compile(const vector<string>& argv)
         return EXIT_SUCCESS;
     }
 
-    vector<string> cppArgs;
+    vector<string> preprocessorArgs;
     vector<string> optargs = opts.argVec("D");
-    cppArgs.reserve(optargs.size()); // not quite sufficient but keeps clang-tidy happy
+    preprocessorArgs.reserve(optargs.size()); // not quite sufficient but keeps clang-tidy happy
     for (const auto& optarg : optargs)
     {
-        cppArgs.push_back("-D" + optarg);
+        preprocessorArgs.push_back("-D" + optarg);
     }
 
     optargs = opts.argVec("U");
     for (const auto& optarg : optargs)
     {
-        cppArgs.push_back("-U" + optarg);
+        preprocessorArgs.push_back("-U" + optarg);
     }
 
     vector<string> includePaths = opts.argVec("I");
     for (const auto& includePath : includePaths)
     {
-        cppArgs.push_back("-I" + Preprocessor::normalizeIncludePath(includePath));
+        preprocessorArgs.push_back("-I" + Preprocessor::normalizeIncludePath(includePath));
     }
 
     string outputDir = opts.optArg("output-dir");
@@ -116,7 +116,7 @@ compile(const vector<string>& argv)
 
     bool debug = opts.isSet("debug");
 
-    if (args.empty())
+    if (sliceFiles.empty())
     {
         consoleErr << argv[0] << ": error: no input file" << endl;
         if (!validate)
@@ -138,75 +138,55 @@ compile(const vector<string>& argv)
 
     ostringstream os;
 
-    // Create a copy of args without the duplicates.
-    vector<string> sources;
-    for (const auto& arg : args)
+    for (const auto& fileName : sliceFiles)
     {
-        auto p = find(sources.begin(), sources.end(), arg);
-        if (p == sources.end())
+        UnitPtr unit;
+        try
         {
-            sources.push_back(arg);
-        }
-    }
+            PreprocessorPtr preprocessor = Preprocessor::create(argv[0], fileName, preprocessorArgs);
+            FILE* preprocessedHandle = preprocessor->preprocess("-D__ICE2SLICE__");
+            assert(preprocessedHandle);
 
-    for (auto i = sources.begin(); i != sources.end();)
-    {
-        PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
-        FILE* cppHandle = icecpp->preprocess(true, "-D__ICE2SLICE__");
+            unit = Unit::createUnit("", false);
+            int parseStatus = unit->parse(fileName, preprocessedHandle, debug);
 
-        if (cppHandle == nullptr)
-        {
-            return EXIT_FAILURE;
-        }
+            preprocessor->close();
 
-        UnitPtr p = Unit::createUnit("", false);
-        int parseStatus = p->parse(*i, cppHandle, debug);
-
-        if (!icecpp->close())
-        {
-            p->destroy();
-            return EXIT_FAILURE;
-        }
-
-        if (parseStatus == EXIT_FAILURE)
-        {
-            status = EXIT_FAILURE;
-        }
-        else
-        {
-            parseAllDocComments(p, Slice::slice2LinkFormatter);
-
-            DefinitionContextPtr dc = p->findDefinitionContext(p->topLevelFile());
-            assert(dc);
-
-            string baseName = icecpp->getBaseName();
-            // Remove any directory components from the base name.
-            string::size_type pos = baseName.find_last_of("/\\");
-            if (pos != string::npos)
+            if (parseStatus == EXIT_FAILURE)
             {
-                baseName = baseName.substr(pos);
+                status = EXIT_FAILURE;
             }
-
-            try
+            else
             {
+                parseAllDocComments(unit, Slice::slice2LinkFormatter);
+
+                DefinitionContextPtr dc = unit->findDefinitionContext(unit->topLevelFile());
+                assert(dc);
+
+                string baseName = preprocessor->getBaseName();
+                // Remove any directory components from the base name.
+                string::size_type pos = baseName.find_last_of("/\\");
+                if (pos != string::npos)
+                {
+                    baseName = baseName.substr(pos);
+                }
+
                 Gen gen(outputDir + baseName);
-                gen.generate(p);
+                gen.generate(unit);
             }
-            catch (const Slice::FileException& ex)
-            {
-                //
-                // If a file could not be created, then clean up any created files.
-                //
-                FileTracker::instance()->cleanup();
-                p->destroy();
-                consoleErr << argv[0] << ": error: " << ex.what() << endl;
-                return EXIT_FAILURE;
-            }
-        }
 
-        status |= p->getStatus();
-        p->destroy();
-        ++i;
+            status |= unit->getStatus();
+            unit->destroy();
+        }
+        catch (...)
+        {
+            FileTracker::instance()->cleanup();
+            if (unit)
+            {
+                unit->destroy();
+            }
+            throw;
+        }
 
         {
             lock_guard lock(globalMutex);
@@ -241,8 +221,7 @@ main(int argc, char* argv[])
     }
     catch (...)
     {
-        consoleErr << args[0] << ": error:"
-                   << "unknown exception" << endl;
+        consoleErr << args[0] << ": error:unknown exception" << endl;
         return EXIT_FAILURE;
     }
 }

--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -77,10 +77,10 @@ compile(const vector<string>& argv)
     opts.addOpt("d", "debug");
 
     bool validate = find(argv.begin(), argv.end(), "--validate") != argv.end();
-    vector<string> args;
+    vector<string> sliceFiles;
     try
     {
-        args = opts.parse(argv);
+        sliceFiles = opts.parse(argv);
     }
     catch (const IceInternal::BadOptException& e)
     {
@@ -109,25 +109,25 @@ compile(const vector<string>& argv)
 
     vector<string> extraHeaders = opts.argVec("add-header");
 
-    vector<string> cppArgs;
+    vector<string> preprocessorArgs;
     vector<string> optargs = opts.argVec("D");
-    cppArgs.reserve(optargs.size()); // not quite sufficient but keeps clang-tidy happy
+    preprocessorArgs.reserve(optargs.size()); // not quite sufficient but keeps clang-tidy happy
     for (const auto& optarg : optargs)
     {
-        cppArgs.push_back("-D" + optarg);
+        preprocessorArgs.push_back("-D" + optarg);
     }
 
     optargs = opts.argVec("U");
     for (const auto& optarg : optargs)
     {
-        cppArgs.push_back("-U" + optarg);
+        preprocessorArgs.push_back("-U" + optarg);
     }
 
     vector<string> includePaths;
     includePaths = opts.argVec("I");
     for (const auto& includePath : includePaths)
     {
-        cppArgs.push_back("-I" + Preprocessor::normalizeIncludePath(includePath));
+        preprocessorArgs.push_back("-I" + Preprocessor::normalizeIncludePath(includePath));
     }
 
     string include = opts.optArg("include-dir");
@@ -138,13 +138,13 @@ compile(const vector<string>& argv)
 
     bool depend = opts.isSet("depend");
 
-    bool dependxml = opts.isSet("depend-xml");
+    bool dependXML = opts.isSet("depend-xml");
 
     string dependFile = opts.optArg("depend-file");
 
     bool debug = opts.isSet("debug");
 
-    if (args.empty())
+    if (sliceFiles.empty())
     {
         consoleErr << argv[0] << ": error: no input file" << endl;
         if (!validate)
@@ -154,7 +154,7 @@ compile(const vector<string>& argv)
         return EXIT_FAILURE;
     }
 
-    if (depend && dependxml)
+    if (depend && dependXML)
     {
         consoleErr << argv[0] << ": error: cannot specify both --depend and --depend-xml" << endl;
         if (!validate)
@@ -174,115 +174,68 @@ compile(const vector<string>& argv)
     Ice::CtrlCHandler ctrlCHandler;
     ctrlCHandler.setCallback(interruptedCallback);
 
-    ostringstream os;
-    if (dependxml)
+    std::map<string, StringList> dependencyMap;
+
+    DependencyVisitor dependencyVisitor;
+
+    for (const auto& fileName : sliceFiles)
     {
-        os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<dependencies>" << endl;
-    }
-
-    for (auto i = args.begin(); i != args.end(); ++i)
-    {
-        //
-        // Ignore duplicates.
-        //
-        auto p = find(args.begin(), args.end(), *i);
-        if (p != i)
+        UnitPtr unit;
+        try
         {
-            continue;
-        }
+            PreprocessorPtr preprocessor = Preprocessor::create(argv[0], fileName, preprocessorArgs);
+            FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2CPP__");
+            assert(preprocessedHandle);
 
-        if (depend || dependxml)
-        {
-            PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
-            FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2CPP__");
+            unit = Unit::createUnit("cpp", false);
+            int parseStatus = unit->parse(fileName, preprocessedHandle, debug);
 
-            if (cppHandle == nullptr)
-            {
-                return EXIT_FAILURE;
-            }
-
-            UnitPtr u = Unit::createUnit("cpp", false);
-            int parseStatus = u->parse(*i, cppHandle, debug);
-
-            DefinitionContextPtr dc = u->findDefinitionContext(u->topLevelFile());
-            assert(dc);
-            string ext = dc->getMetadataArgs("cpp:header-ext").value_or(headerExtension);
-
-            u->destroy();
-
-            if (parseStatus == EXIT_FAILURE)
-            {
-                return EXIT_FAILURE;
-            }
-
-            if (!icecpp->printMakefileDependencies(
-                    os,
-                    depend ? Preprocessor::CPlusPlus : Preprocessor::SliceXML,
-                    includePaths,
-                    "-D__SLICE2CPP__",
-                    ext))
-            {
-                return EXIT_FAILURE;
-            }
-
-            if (!icecpp->close())
-            {
-                return EXIT_FAILURE;
-            }
-        }
-        else
-        {
-            PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
-            FILE* cppHandle = icecpp->preprocess(true, "-D__SLICE2CPP__");
-
-            if (cppHandle == nullptr)
-            {
-                return EXIT_FAILURE;
-            }
-
-            UnitPtr u = Unit::createUnit("cpp", false);
-            int parseStatus = u->parse(*i, cppHandle, debug);
-
-            if (!icecpp->close())
-            {
-                u->destroy();
-                return EXIT_FAILURE;
-            }
+            preprocessor->close();
 
             if (parseStatus == EXIT_FAILURE)
             {
                 status = EXIT_FAILURE;
             }
+            else if (depend || dependXML)
+            {
+                unit->visit(&dependencyVisitor);
+                if (depend)
+                {
+                    DefinitionContextPtr dc = unit->findDefinitionContext(unit->topLevelFile());
+                    assert(dc);
+                    string target = removeExtension(baseName(fileName)) + "." +
+                                    dc->getMetadataArgs("cpp:header-ext").value_or(headerExtension);
+                    dependencyVisitor.writeMakefileDependencies(dependFile, unit->topLevelFile(), target);
+                }
+                // else XML dependencies are written below after all units have been processed.
+            }
             else
             {
-                parseAllDocComments(u, Slice::cppLinkFormatter);
+                parseAllDocComments(unit, Slice::cppLinkFormatter);
 
-                try
-                {
-                    Gen gen(
-                        icecpp->getBaseName(),
-                        headerExtension,
-                        sourceExtension,
-                        extraHeaders,
-                        include,
-                        includePaths,
-                        dllExport,
-                        output);
-                    gen.generate(u);
-                }
-                catch (const Slice::FileException& ex)
-                {
-                    // If a file could not be created, then
-                    // cleanup any created files.
-                    FileTracker::instance()->cleanup();
-                    u->destroy();
-                    consoleErr << argv[0] << ": error: " << ex.what() << endl;
-                    return EXIT_FAILURE;
-                }
+                Gen gen(
+                    preprocessor->getBaseName(),
+                    headerExtension,
+                    sourceExtension,
+                    extraHeaders,
+                    include,
+                    includePaths,
+                    dllExport,
+                    output);
+                gen.generate(unit);
+
+                status |= unit->getStatus();
             }
-
-            status |= u->getStatus();
-            u->destroy();
+            unit->destroy();
+        }
+        catch (...)
+        {
+            FileTracker::instance()->cleanup();
+            if (unit)
+            {
+                unit->destroy();
+            }
+            throw;
         }
 
         {
@@ -295,14 +248,16 @@ compile(const vector<string>& argv)
         }
     }
 
-    if (dependxml)
+    if (status == EXIT_FAILURE)
     {
-        os << "</dependencies>\n";
+        // If the compilation failed, clean up any created files.
+        FileTracker::instance()->cleanup();
+        return status;
     }
 
-    if (depend || dependxml)
+    if (dependXML)
     {
-        writeDependencies(os.str(), dependFile);
+        dependencyVisitor.writeXMLDependencies(dependFile);
     }
 
     return status;
@@ -328,8 +283,7 @@ main(int argc, char* argv[])
     }
     catch (...)
     {
-        consoleErr << args[0] << ": error:"
-                   << "unknown exception" << endl;
+        consoleErr << args[0] << ": error:unknown exception" << endl;
         return EXIT_FAILURE;
     }
 }

--- a/cpp/src/slice2cs/Main.cpp
+++ b/cpp/src/slice2cs/Main.cpp
@@ -10,6 +10,7 @@
 #include "Ice/CtrlCHandler.h"
 
 #include <algorithm>
+#include <cassert>
 #include <mutex>
 
 using namespace std;
@@ -65,10 +66,10 @@ compile(const vector<string>& argv)
     opts.addOpt("d", "debug");
 
     bool validate = find(argv.begin(), argv.end(), "--validate") != argv.end();
-    vector<string> args;
+    vector<string> sliceFiles;
     try
     {
-        args = opts.parse(argv);
+        sliceFiles = opts.parse(argv);
     }
     catch (const IceInternal::BadOptException& e)
     {
@@ -92,37 +93,37 @@ compile(const vector<string>& argv)
         return EXIT_SUCCESS;
     }
 
-    vector<string> cppArgs;
+    vector<string> preprocessorArgs;
     vector<string> optargs = opts.argVec("D");
-    cppArgs.reserve(optargs.size()); // not quite sufficient but keeps clang-tidy happy
+    preprocessorArgs.reserve(optargs.size()); // not quite sufficient but keeps clang-tidy happy
     for (const auto& optarg : optargs)
     {
-        cppArgs.push_back("-D" + optarg);
+        preprocessorArgs.push_back("-D" + optarg);
     }
 
     optargs = opts.argVec("U");
     for (const auto& optarg : optargs)
     {
-        cppArgs.push_back("-U" + optarg);
+        preprocessorArgs.push_back("-U" + optarg);
     }
 
     vector<string> includePaths = opts.argVec("I");
     for (const auto& includePath : includePaths)
     {
-        cppArgs.push_back("-I" + Preprocessor::normalizeIncludePath(includePath));
+        preprocessorArgs.push_back("-I" + Preprocessor::normalizeIncludePath(includePath));
     }
 
     string output = opts.optArg("output-dir");
 
     bool depend = opts.isSet("depend");
 
-    bool dependxml = opts.isSet("depend-xml");
+    bool dependXML = opts.isSet("depend-xml");
 
     string dependFile = opts.optArg("depend-file");
 
     bool debug = opts.isSet("debug");
 
-    if (args.empty())
+    if (sliceFiles.empty())
     {
         consoleErr << argv[0] << ": error: no input file" << endl;
         if (!validate)
@@ -132,7 +133,7 @@ compile(const vector<string>& argv)
         return EXIT_FAILURE;
     }
 
-    if (depend && dependxml)
+    if (depend && dependXML)
     {
         consoleErr << argv[0] << ": error: cannot specify both --depend and --depend-xml" << endl;
         if (!validate)
@@ -152,101 +153,55 @@ compile(const vector<string>& argv)
     Ice::CtrlCHandler ctrlCHandler;
     ctrlCHandler.setCallback(interruptedCallback);
 
-    ostringstream os;
-    if (dependxml)
+    DependencyVisitor dependencyVisitor;
+
+    for (const auto& fileName : sliceFiles)
     {
-        os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<dependencies>" << endl;
-    }
-
-    for (auto i = args.begin(); i != args.end(); ++i)
-    {
-        //
-        // Ignore duplicates.
-        //
-        auto j = find(args.begin(), args.end(), *i);
-        if (j != i)
+        UnitPtr unit;
+        try
         {
-            continue;
-        }
+            PreprocessorPtr preprocessor = Preprocessor::create(argv[0], fileName, preprocessorArgs);
+            FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2CS__");
+            assert(preprocessedHandle);
 
-        if (depend || dependxml)
-        {
-            PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
-            FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2CS__");
+            unit = Unit::createUnit("cs", false);
+            int parseStatus = unit->parse(fileName, preprocessedHandle, debug);
 
-            if (cppHandle == nullptr)
-            {
-                return EXIT_FAILURE;
-            }
-
-            UnitPtr u = Unit::createUnit("cs", false);
-            int parseStatus = u->parse(*i, cppHandle, debug);
-            u->destroy();
-
-            if (parseStatus == EXIT_FAILURE)
-            {
-                return EXIT_FAILURE;
-            }
-
-            if (!icecpp->printMakefileDependencies(
-                    os,
-                    depend ? Preprocessor::CSharp : Preprocessor::SliceXML,
-                    includePaths,
-                    "-D__SLICE2CS__"))
-            {
-                return EXIT_FAILURE;
-            }
-
-            if (!icecpp->close())
-            {
-                return EXIT_FAILURE;
-            }
-        }
-        else
-        {
-            PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
-            FILE* cppHandle = icecpp->preprocess(true, "-D__SLICE2CS__");
-
-            if (cppHandle == nullptr)
-            {
-                return EXIT_FAILURE;
-            }
-
-            UnitPtr p = Unit::createUnit("cs", false);
-            int parseStatus = p->parse(*i, cppHandle, debug);
-
-            if (!icecpp->close())
-            {
-                p->destroy();
-                return EXIT_FAILURE;
-            }
+            preprocessor->close();
 
             if (parseStatus == EXIT_FAILURE)
             {
                 status = EXIT_FAILURE;
             }
+            else if (depend || dependXML)
+            {
+                unit->visit(&dependencyVisitor);
+                if (depend)
+                {
+                    string target = removeExtension(baseName(fileName)) + ".cs";
+                    dependencyVisitor.writeMakefileDependencies(dependFile, unit->topLevelFile(), target);
+                }
+                // else XML dependencies are written below after all units have been processed.
+            }
             else
             {
-                parseAllDocComments(p, Slice::Csharp::csLinkFormatter);
+                parseAllDocComments(unit, Slice::Csharp::csLinkFormatter);
 
-                try
-                {
-                    Gen gen(icecpp->getBaseName(), includePaths, output);
-                    gen.generate(p);
-                }
-                catch (const Slice::FileException& ex)
-                {
-                    // If a file could not be created, then
-                    // cleanup any created files.
-                    FileTracker::instance()->cleanup();
-                    p->destroy();
-                    consoleErr << argv[0] << ": error: " << ex.what() << endl;
-                    return EXIT_FAILURE;
-                }
+                Gen gen(preprocessor->getBaseName(), includePaths, output);
+                gen.generate(unit);
+
+                status |= unit->getStatus();
             }
-
-            status |= p->getStatus();
-            p->destroy();
+            unit->destroy();
+        }
+        catch (...)
+        {
+            FileTracker::instance()->cleanup();
+            if (unit)
+            {
+                unit->destroy();
+            }
+            throw;
         }
 
         {
@@ -259,14 +214,16 @@ compile(const vector<string>& argv)
         }
     }
 
-    if (dependxml)
+    if (status == EXIT_FAILURE)
     {
-        os << "</dependencies>\n";
+        // If the compilation failed, clean up any created files.
+        FileTracker::instance()->cleanup();
+        return status;
     }
 
-    if (depend || dependxml)
+    if (dependXML)
     {
-        writeDependencies(os.str(), dependFile);
+        dependencyVisitor.writeXMLDependencies(dependFile);
     }
 
     return status;
@@ -292,8 +249,7 @@ main(int argc, char* argv[])
     }
     catch (...)
     {
-        consoleErr << args[0] << ": error:"
-                   << "unknown exception" << endl;
+        consoleErr << args[0] << ": error:unknown exception" << endl;
         return EXIT_FAILURE;
     }
 }

--- a/cpp/src/slice2java/Main.cpp
+++ b/cpp/src/slice2java/Main.cpp
@@ -10,6 +10,7 @@
 #include "Ice/CtrlCHandler.h"
 
 #include <algorithm>
+#include <cassert>
 #include <iterator>
 #include <mutex>
 
@@ -66,10 +67,10 @@ compile(const vector<string>& argv)
     opts.addOpt("d", "debug");
 
     bool validate = find(argv.begin(), argv.end(), "--validate") != argv.end();
-    vector<string> args;
+    vector<string> sliceFiles;
     try
     {
-        args = opts.parse(argv);
+        sliceFiles = opts.parse(argv);
     }
     catch (const IceInternal::BadOptException& e)
     {
@@ -93,36 +94,36 @@ compile(const vector<string>& argv)
         return EXIT_SUCCESS;
     }
 
-    vector<string> cppArgs;
+    vector<string> preprocessorArgs;
     vector<string> optargs = opts.argVec("D");
-    cppArgs.reserve(optargs.size()); // not quite sufficient but keeps clang-tidy happy
+    preprocessorArgs.reserve(optargs.size()); // not quite sufficient but keeps clang-tidy happy
     for (const auto& optarg : optargs)
     {
-        cppArgs.push_back("-D" + optarg);
+        preprocessorArgs.push_back("-D" + optarg);
     }
 
     optargs = opts.argVec("U");
     for (const auto& optarg : optargs)
     {
-        cppArgs.push_back("-U" + optarg);
+        preprocessorArgs.push_back("-U" + optarg);
     }
 
     vector<string> includePaths = opts.argVec("I");
     for (const auto& includePath : includePaths)
     {
-        cppArgs.push_back("-I" + Preprocessor::normalizeIncludePath(includePath));
+        preprocessorArgs.push_back("-I" + Preprocessor::normalizeIncludePath(includePath));
     }
 
     string output = opts.optArg("output-dir");
 
-    bool dependxml = opts.isSet("depend-xml");
+    bool dependXML = opts.isSet("depend-xml");
     string dependFile = opts.optArg("depend-file");
 
     bool debug = opts.isSet("debug");
 
     bool listGenerated = opts.isSet("list-generated");
 
-    if (args.empty())
+    if (sliceFiles.empty())
     {
         consoleErr << argv[0] << ": error: no input file" << endl;
         if (!validate)
@@ -143,105 +144,50 @@ compile(const vector<string>& argv)
     ctrlCHandler.setCallback(interruptedCallback);
 
     ostringstream os;
-    if (dependxml)
+    DependencyVisitor dependencyVisitor;
+
+    for (const auto& fileName : sliceFiles)
     {
-        os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<dependencies>" << endl;
-    }
-
-    for (auto i = args.begin(); i != args.end(); ++i)
-    {
-        //
-        // Ignore duplicates.
-        //
-        auto j = find(args.begin(), args.end(), *i);
-        if (j != i)
+        UnitPtr unit;
+        try
         {
-            continue;
-        }
+            FileTracker::instance()->setSource(fileName);
+            PreprocessorPtr preprocessor = Preprocessor::create(argv[0], fileName, preprocessorArgs);
+            FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2JAVA__");
+            assert(preprocessedHandle);
 
-        if (dependxml)
-        {
-            PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
-            FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2JAVA__");
+            unit = Unit::createUnit("java", false);
+            int parseStatus = unit->parse(fileName, preprocessedHandle, debug);
 
-            if (cppHandle == nullptr)
-            {
-                return EXIT_FAILURE;
-            }
-
-            UnitPtr u = Unit::createUnit("java", false);
-            int parseStatus = u->parse(*i, cppHandle, debug);
-            u->destroy();
+            preprocessor->close();
 
             if (parseStatus == EXIT_FAILURE)
             {
-                return EXIT_FAILURE;
-            }
-
-            if (!icecpp->printMakefileDependencies(os, Preprocessor::SliceXML, includePaths, "-D__SLICE2JAVA__"))
-            {
-                return EXIT_FAILURE;
-            }
-
-            if (!icecpp->close())
-            {
-                return EXIT_FAILURE;
-            }
-        }
-        else
-        {
-            FileTracker::instance()->setSource(*i);
-
-            PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
-            FILE* cppHandle = icecpp->preprocess(true, "-D__SLICE2JAVA__");
-
-            if (cppHandle == nullptr)
-            {
-                FileTracker::instance()->error();
                 status = EXIT_FAILURE;
-                break;
             }
-
-            UnitPtr p = Unit::createUnit("java", false);
-            int parseStatus = p->parse(*i, cppHandle, debug);
-
-            if (!icecpp->close())
+            else if (dependXML)
             {
-                p->destroy();
-                FileTracker::instance()->error();
-                return EXIT_FAILURE;
-            }
-
-            if (parseStatus == EXIT_FAILURE)
-            {
-                p->destroy();
-                status = EXIT_FAILURE;
+                unit->visit(&dependencyVisitor);
             }
             else
             {
-                parseAllDocComments(p, Slice::Java::javaLinkFormatter);
+                parseAllDocComments(unit, Slice::Java::javaLinkFormatter);
 
-                try
-                {
-                    Gen gen(icecpp->getBaseName(), includePaths, output);
-                    gen.generate(p);
-                }
-                catch (const Slice::FileException& ex)
-                {
-                    //
-                    // If a file could not be created then cleanup any files we've already created.
-                    //
-                    FileTracker::instance()->cleanup();
-                    p->destroy();
-                    consoleErr << argv[0] << ": error: " << ex.what() << endl;
-                    status = EXIT_FAILURE;
-                    FileTracker::instance()->error();
-                    break;
-                }
+                Gen gen(preprocessor->getBaseName(), includePaths, output);
+                gen.generate(unit);
+
+                status |= unit->getStatus();
             }
-
-            status |= p->getStatus();
-            p->destroy();
+            unit->destroy();
+        }
+        catch (...)
+        {
+            FileTracker::instance()->cleanup();
+            if (unit)
+            {
+                unit->destroy();
+            }
+            throw;
         }
 
         {
@@ -254,10 +200,16 @@ compile(const vector<string>& argv)
         }
     }
 
-    if (dependxml)
+    if (status == EXIT_FAILURE)
     {
-        os << "</dependencies>\n";
-        writeDependencies(os.str(), dependFile);
+        // If the compilation failed, clean up any created files.
+        FileTracker::instance()->cleanup();
+        return status;
+    }
+
+    if (dependXML)
+    {
+        dependencyVisitor.writeXMLDependencies(dependFile);
     }
 
     if (listGenerated)
@@ -288,8 +240,7 @@ main(int argc, char* argv[])
     }
     catch (...)
     {
-        consoleErr << args[0] << ": error:"
-                   << "unknown exception" << endl;
+        consoleErr << args[0] << ": error:unknown exception" << endl;
         return EXIT_FAILURE;
     }
 }

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -757,7 +757,7 @@ Slice::Gen::ImportVisitor::writeImports(const UnitPtr& p)
             if (IceInternal::isAbsolutePath(f))
             {
                 // If the include file is an absolute path, we need to generate a relative path.
-                f = relativePath(f, p->topLevelFile());
+                f = relativePath(f, Slice::dirName(p->topLevelFile()));
             }
             else if (f[0] != '.')
             {
@@ -1709,7 +1709,7 @@ Slice::Gen::TypeScriptImportVisitor::addImport(const ContainedPtr& definition)
                 if (IceInternal::isAbsolutePath(f))
                 {
                     // If the include file is an absolute path, we need to generate a relative path.
-                    f = relativePath(f, _filename);
+                    f = relativePath(f, Slice::dirName(_filename));
                 }
                 else if (f[0] != '.')
                 {
@@ -1756,7 +1756,7 @@ Slice::Gen::TypeScriptImportVisitor::visitUnitStart(const UnitPtr& unit)
                 if (IceInternal::isAbsolutePath(f))
                 {
                     // If the include file is an absolute path, we need to generate a relative path.
-                    f = relativePath(f, _filename);
+                    f = relativePath(f, Slice::dirName(_filename));
                 }
                 else if (f[0] != '.')
                 {

--- a/cpp/src/slice2js/JsUtil.cpp
+++ b/cpp/src/slice2js/JsUtil.cpp
@@ -22,64 +22,6 @@ using namespace Slice;
 using namespace IceInternal;
 
 string
-Slice::JavaScript::relativePath(const string& path1, const string& path2)
-{
-    vector<string> tokens1;
-    vector<string> tokens2;
-
-    splitString(path1, "/\\", tokens1);
-    splitString(path2, "/\\", tokens2);
-
-    string f1 = tokens1.back();
-    string f2 = tokens2.back();
-
-    tokens1.pop_back();
-    tokens2.pop_back();
-
-    auto i1 = tokens1.begin();
-    auto i2 = tokens2.begin();
-
-    while (i1 != tokens1.end() && i2 != tokens2.end() && *i1 == *i2)
-    {
-        i1++;
-        i2++;
-    }
-
-    //
-    // Different volumes, relative path not possible.
-    //
-    if (i1 == tokens1.begin() && i2 == tokens2.begin())
-    {
-        return path1;
-    }
-
-    string newPath;
-    if (i2 == tokens2.end())
-    {
-        newPath += "./";
-        for (; i1 != tokens1.end(); ++i1)
-        {
-            newPath += *i1 + "/";
-        }
-    }
-    else
-    {
-        for (vector<string>::difference_type i = tokens2.end() - i2; i > 0; i--)
-        {
-            newPath += "../";
-        }
-
-        for (; i1 != tokens1.end(); ++i1)
-        {
-            newPath += *i1 + "/";
-        }
-    }
-    newPath += f1;
-
-    return newPath;
-}
-
-string
 Slice::JavaScript::getJavaScriptModule(const DefinitionContextPtr& dc)
 {
     // Check if the file contains the 'js:module' file metadata.

--- a/cpp/src/slice2js/JsUtil.h
+++ b/cpp/src/slice2js/JsUtil.h
@@ -8,7 +8,6 @@
 
 namespace Slice::JavaScript
 {
-    [[nodiscard]] std::string relativePath(const std::string& path1, const std::string& path2);
     [[nodiscard]] std::string getJavaScriptModule(const DefinitionContextPtr& dc);
 
     [[nodiscard]] std::string typeToJsString(const TypePtr& type, bool definition = false);

--- a/cpp/src/slice2js/Main.cpp
+++ b/cpp/src/slice2js/Main.cpp
@@ -74,10 +74,10 @@ compile(const vector<string>& argv)
 
     bool validate = find(argv.begin(), argv.end(), "--validate") != argv.end();
 
-    vector<string> args;
+    vector<string> sliceFiles;
     try
     {
-        args = opts.parse(argv);
+        sliceFiles = opts.parse(argv);
     }
     catch (const IceInternal::BadOptException& e)
     {
@@ -126,7 +126,7 @@ compile(const vector<string>& argv)
 
     bool dependJSON = opts.isSet("depend-json");
 
-    bool dependXml = opts.isSet("depend-xml");
+    bool dependXML = opts.isSet("depend-xml");
 
     string dependFile = opts.optArg("depend-file");
 
@@ -134,7 +134,7 @@ compile(const vector<string>& argv)
 
     bool typeScript = opts.isSet("typescript");
 
-    if (args.empty())
+    if (sliceFiles.empty())
     {
         consoleErr << argv[0] << ": error: no input file" << endl;
         if (!validate)
@@ -154,7 +154,7 @@ compile(const vector<string>& argv)
         return EXIT_FAILURE;
     }
 
-    if (depend && dependXml)
+    if (depend && dependXML)
     {
         consoleErr << argv[0] << ": error: cannot specify both --depend and --depend-xml" << endl;
         if (!validate)
@@ -164,7 +164,7 @@ compile(const vector<string>& argv)
         return EXIT_FAILURE;
     }
 
-    if (dependXml && dependJSON)
+    if (dependXML && dependJSON)
     {
         consoleErr << argv[0] << ": error: cannot specify both --depend-xml and --depend-json" << endl;
         if (!validate)
@@ -184,117 +184,63 @@ compile(const vector<string>& argv)
     Ice::CtrlCHandler ctrlCHandler;
     ctrlCHandler.setCallback(interruptedCallback);
 
-    ostringstream os;
-    if (dependJSON)
+    DependencyVisitor dependencyVisitor;
+
+    for (const auto& fileName : sliceFiles)
     {
-        os << "{" << endl;
-    }
-    else if (dependXml)
-    {
-        os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<dependencies>" << endl;
-    }
-
-    //
-    // Create a copy of args without the duplicates.
-    //
-    set<string> sources(args.begin(), args.end());
-
-    for (auto i = sources.cbegin(); i != sources.cend();)
-    {
-        PreprocessorPtr preprocessor = Preprocessor::create(argv[0], *i, preprocessorArgs);
-        FILE* cppHandle = preprocessor->preprocess(true, "-D__SLICE2JS__");
-
-        if (cppHandle == nullptr)
+        UnitPtr unit;
+        try
         {
-            return EXIT_FAILURE;
-        }
+            PreprocessorPtr preprocessor = Preprocessor::create(argv[0], fileName, preprocessorArgs);
+            FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2JS__");
+            assert(preprocessedHandle);
 
-        if (depend || dependJSON || dependXml)
-        {
-            UnitPtr u = Unit::createUnit("js", false);
-            int parseStatus = u->parse(*i, cppHandle, debug);
-            u->destroy();
+            unit = Unit::createUnit("js", false);
+            int parseStatus = unit->parse(fileName, preprocessedHandle, debug);
 
-            if (parseStatus == EXIT_FAILURE)
-            {
-                return EXIT_FAILURE;
-            }
-
-            bool last = (++i == sources.cend());
-
-            if (!preprocessor->printMakefileDependencies(
-                    os,
-                    depend ? Preprocessor::JavaScript
-                           : (dependJSON ? Preprocessor::JavaScriptJSON : Preprocessor::SliceXML),
-                    includePaths,
-                    "-D__SLICE2JS__"))
-            {
-                return EXIT_FAILURE;
-            }
-
-            if (!preprocessor->close())
-            {
-                return EXIT_FAILURE;
-            }
-
-            if (dependJSON)
-            {
-                if (!last)
-                {
-                    os << ",";
-                }
-                os << "\n";
-            }
-        }
-        else
-        {
-            UnitPtr p = Unit::createUnit("js", false);
-            int parseStatus = p->parse(*i, cppHandle, debug);
-
-            if (!preprocessor->close())
-            {
-                p->destroy();
-                return EXIT_FAILURE;
-            }
+            preprocessor->close();
 
             if (parseStatus == EXIT_FAILURE)
             {
                 status = EXIT_FAILURE;
             }
+            else if (depend | dependJSON | dependXML)
+            {
+                unit->visit(&dependencyVisitor);
+                if (depend)
+                {
+                    string target = removeExtension(baseName(fileName)) + ".js";
+                    dependencyVisitor.writeMakefileDependencies(dependFile, unit->topLevelFile(), target);
+                }
+                // Else JSON and XML dependencies are written below after all units have been processed.
+            }
             else
             {
-                parseAllDocComments(p, Slice::JavaScript::jsLinkFormatter);
+                parseAllDocComments(unit, Slice::JavaScript::jsLinkFormatter);
 
-                DefinitionContextPtr dc = p->findDefinitionContext(p->topLevelFile());
-                assert(dc);
-                try
+                if (useStdout)
                 {
-                    if (useStdout)
-                    {
-                        Gen gen(preprocessor->getBaseName(), includePaths, output, typeScript, cout);
-                        gen.generate(p);
-                    }
-                    else
-                    {
-                        Gen gen(preprocessor->getBaseName(), includePaths, output, typeScript);
-                        gen.generate(p);
-                    }
+                    Gen gen(preprocessor->getBaseName(), includePaths, output, typeScript, cout);
+                    gen.generate(unit);
                 }
-                catch (const Slice::FileException& ex)
+                else
                 {
-                    //
-                    // If a file could not be created, then clean up any created files.
-                    //
-                    FileTracker::instance()->cleanup();
-                    p->destroy();
-                    consoleErr << argv[0] << ": error: " << ex.what() << endl;
-                    return EXIT_FAILURE;
+                    Gen gen(preprocessor->getBaseName(), includePaths, output, typeScript);
+                    gen.generate(unit);
                 }
+
+                status |= unit->getStatus();
             }
-
-            status |= p->getStatus();
-            p->destroy();
-            ++i;
+            unit->destroy();
+        }
+        catch (...)
+        {
+            FileTracker::instance()->cleanup();
+            if (unit)
+            {
+                unit->destroy();
+            }
+            throw;
         }
 
         {
@@ -307,18 +253,20 @@ compile(const vector<string>& argv)
         }
     }
 
-    if (dependJSON)
+    if (status == EXIT_FAILURE)
     {
-        os << "}\n";
-    }
-    else if (dependXml)
-    {
-        os << "</dependencies>\n";
+        // If the compilation failed, clean up any created files.
+        FileTracker::instance()->cleanup();
+        return status;
     }
 
-    if (depend || dependJSON || dependXml)
+    if (dependJSON)
     {
-        writeDependencies(os.str(), dependFile);
+        dependencyVisitor.writeJSONDependencies(dependFile);
+    }
+    else if (dependXML)
+    {
+        dependencyVisitor.writeXMLDependencies(dependFile);
     }
 
     return status;

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -106,10 +106,10 @@ namespace
 
         bool validate = find(argv.begin(), argv.end(), "--validate") != argv.end();
 
-        vector<string> args;
+        vector<string> sliceFiles;
         try
         {
-            args = opts.parse(argv);
+            sliceFiles = opts.parse(argv);
         }
         catch (const IceInternal::BadOptException& e)
         {
@@ -133,29 +133,29 @@ namespace
             return EXIT_SUCCESS;
         }
 
-        vector<string> cppArgs;
+        vector<string> preprocessorArgs;
         vector<string> optargs = opts.argVec("D");
-        cppArgs.reserve(optargs.size()); // keeps clang-tidy happy
+        preprocessorArgs.reserve(optargs.size()); // keeps clang-tidy happy
         for (const auto& arg : optargs)
         {
-            cppArgs.push_back("-D" + arg);
+            preprocessorArgs.push_back("-D" + arg);
         }
 
         optargs = opts.argVec("U");
         for (const auto& arg : optargs)
         {
-            cppArgs.push_back("-U" + arg);
+            preprocessorArgs.push_back("-U" + arg);
         }
 
         vector<string> includePaths = opts.argVec("I");
         for (const auto& includePath : includePaths)
         {
-            cppArgs.push_back("-I" + Preprocessor::normalizeIncludePath(includePath));
+            preprocessorArgs.push_back("-I" + Preprocessor::normalizeIncludePath(includePath));
         }
 
         string output = opts.optArg("output-dir");
 
-        bool dependxml = opts.isSet("depend-xml");
+        bool dependXML = opts.isSet("depend-xml");
 
         string dependFile = opts.optArg("depend-file");
 
@@ -165,7 +165,7 @@ namespace
 
         bool listGenerated = opts.isSet("list-generated");
 
-        if (args.empty())
+        if (sliceFiles.empty())
         {
             consoleErr << argv[0] << ": error: no input file" << endl;
             if (!validate)
@@ -185,111 +185,53 @@ namespace
         Ice::CtrlCHandler ctrlCHandler;
         ctrlCHandler.setCallback(interruptedCallback);
 
-        ostringstream os;
-        if (dependxml)
+        DependencyVisitor dependencyVisitor;
+
+        for (const auto& fileName : sliceFiles)
         {
-            os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<dependencies>" << endl;
-        }
-
-        for (auto i = args.begin(); i != args.end(); ++i)
-        {
-            //
-            // Ignore duplicates.
-            //
-            auto p = find(args.begin(), args.end(), *i);
-            if (p != i)
+            UnitPtr unit;
+            try
             {
-                continue;
-            }
+                PreprocessorPtr preprocessor = Preprocessor::create(argv[0], fileName, preprocessorArgs);
+                FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2MATLAB__");
+                assert(preprocessedHandle);
 
-            if (dependxml)
-            {
-                PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
-                FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2MATLAB__");
+                unit = Unit::createUnit("matlab", all);
+                int parseStatus = unit->parse(fileName, preprocessedHandle, debug);
 
-                if (cppHandle == nullptr)
-                {
-                    return EXIT_FAILURE;
-                }
-
-                UnitPtr u = Unit::createUnit("matlab", false);
-                int parseStatus = u->parse(*i, cppHandle, debug);
-                u->destroy();
-
-                if (parseStatus == EXIT_FAILURE)
-                {
-                    return EXIT_FAILURE;
-                }
-
-                if (!icecpp->printMakefileDependencies(os, Preprocessor::SliceXML, includePaths, "-D__SLICE2MATLAB__"))
-                {
-                    return EXIT_FAILURE;
-                }
-
-                if (!icecpp->close())
-                {
-                    return EXIT_FAILURE;
-                }
-            }
-            else
-            {
-                FileTracker::instance()->setSource(*i);
-
-                PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
-                FILE* cppHandle = icecpp->preprocess(true, "-D__SLICE2MATLAB__");
-
-                if (cppHandle == nullptr)
-                {
-                    return EXIT_FAILURE;
-                }
-
-                UnitPtr u = Unit::createUnit("matlab", all);
-                int parseStatus = u->parse(*i, cppHandle, debug);
-
-                if (!icecpp->close())
-                {
-                    u->destroy();
-                    return EXIT_FAILURE;
-                }
+                preprocessor->close();
 
                 if (parseStatus == EXIT_FAILURE)
                 {
                     status = EXIT_FAILURE;
                 }
+                else if (dependXML)
+                {
+                    unit->visit(&dependencyVisitor);
+                }
                 else
                 {
-                    parseAllDocComments(u, Slice::matlabLinkFormatter);
+                    FileTracker::instance()->setSource(fileName);
 
-                    string base = icecpp->getBaseName();
-                    string::size_type pos = base.find_last_of("/\\");
-                    if (pos != string::npos)
-                    {
-                        base.erase(0, pos + 1);
-                    }
+                    parseAllDocComments(unit, Slice::matlabLinkFormatter);
 
-                    try
-                    {
-                        validateMatlabMetadata(u);
+                    validateMatlabMetadata(unit);
 
-                        CodeVisitor codeVisitor(output);
-                        u->visit(&codeVisitor);
-                    }
-                    catch (const Slice::FileException& ex)
-                    {
-                        //
-                        // If a file could not be created, then cleanup any created files.
-                        //
-                        FileTracker::instance()->cleanup();
-                        u->destroy();
-                        consoleErr << argv[0] << ": error: " << ex.what() << endl;
-                        status = EXIT_FAILURE;
-                        FileTracker::instance()->error();
-                        break;
-                    }
+                    CodeVisitor codeVisitor(output);
+                    unit->visit(&codeVisitor);
+
+                    status |= unit->getStatus();
                 }
-
-                status |= u->getStatus();
-                u->destroy();
+                unit->destroy();
+            }
+            catch (...)
+            {
+                FileTracker::instance()->cleanup();
+                if (unit)
+                {
+                    unit->destroy();
+                }
+                throw;
             }
 
             {
@@ -302,10 +244,16 @@ namespace
             }
         }
 
-        if (dependxml)
+        if (status == EXIT_FAILURE)
         {
-            os << "</dependencies>\n";
-            writeDependencies(os.str(), dependFile);
+            // If the compilation failed, clean up any created files.
+            FileTracker::instance()->cleanup();
+            return status;
+        }
+
+        if (dependXML)
+        {
+            dependencyVisitor.writeXMLDependencies(dependFile);
         }
 
         if (listGenerated)
@@ -337,8 +285,7 @@ main(int argc, char* argv[])
     }
     catch (...)
     {
-        consoleErr << args[0] << ": error:"
-                   << "unknown exception" << endl;
+        consoleErr << args[0] << ": error:unknown exception" << endl;
         return EXIT_FAILURE;
     }
 }

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -1170,10 +1170,10 @@ compile(const vector<string>& argv)
 
     bool validate = find(argv.begin(), argv.end(), "--validate") != argv.end();
 
-    vector<string> args;
+    vector<string> sliceFiles;
     try
     {
-        args = opts.parse(argv);
+        sliceFiles = opts.parse(argv);
     }
     catch (const IceInternal::BadOptException& e)
     {
@@ -1197,31 +1197,31 @@ compile(const vector<string>& argv)
         return EXIT_SUCCESS;
     }
 
-    vector<string> cppArgs;
+    vector<string> preprocessorArgs;
     vector<string> optargs = opts.argVec("D");
-    cppArgs.reserve(optargs.size()); // keep clang-tidy happy
+    preprocessorArgs.reserve(optargs.size()); // keep clang-tidy happy
     for (const auto& optarg : optargs)
     {
-        cppArgs.push_back("-D" + optarg);
+        preprocessorArgs.push_back("-D" + optarg);
     }
 
     optargs = opts.argVec("U");
     for (const auto& optarg : optargs)
     {
-        cppArgs.push_back("-U" + optarg);
+        preprocessorArgs.push_back("-U" + optarg);
     }
 
     vector<string> includePaths = opts.argVec("I");
     for (const auto& includePath : includePaths)
     {
-        cppArgs.push_back("-I" + Preprocessor::normalizeIncludePath(includePath));
+        preprocessorArgs.push_back("-I" + Preprocessor::normalizeIncludePath(includePath));
     }
 
     string output = opts.optArg("output-dir");
 
     bool depend = opts.isSet("depend");
 
-    bool dependxml = opts.isSet("depend-xml");
+    bool dependXML = opts.isSet("depend-xml");
 
     string dependFile = opts.optArg("depend-file");
 
@@ -1229,7 +1229,7 @@ compile(const vector<string>& argv)
 
     bool all = opts.isSet("all");
 
-    if (args.empty())
+    if (sliceFiles.empty())
     {
         consoleErr << argv[0] << ": error: no input file" << endl;
         if (!validate)
@@ -1239,7 +1239,7 @@ compile(const vector<string>& argv)
         return EXIT_FAILURE;
     }
 
-    if (depend && dependxml)
+    if (depend && dependXML)
     {
         consoleErr << argv[0] << ": error: cannot specify both --depend and --depend-xml" << endl;
         if (!validate)
@@ -1259,85 +1259,39 @@ compile(const vector<string>& argv)
     Ice::CtrlCHandler ctrlCHandler;
     ctrlCHandler.setCallback(interruptedCallback);
 
-    ostringstream os;
-    if (dependxml)
+    DependencyVisitor dependencyVisitor;
+
+    for (const auto& fileName : sliceFiles)
     {
-        os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<dependencies>" << endl;
-    }
-
-    for (auto i = args.begin(); i != args.end(); ++i)
-    {
-        // Ignore duplicates.
-        auto p = find(args.begin(), args.end(), *i);
-        if (p != i)
+        UnitPtr unit;
+        try
         {
-            continue;
-        }
+            PreprocessorPtr preprocessor = Preprocessor::create(argv[0], fileName, preprocessorArgs);
+            FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2PHP__");
+            assert(preprocessedHandle);
 
-        if (depend || dependxml)
-        {
-            PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
-            FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2PHP__");
+            unit = Unit::createUnit("php", all);
+            int parseStatus = unit->parse(fileName, preprocessedHandle, debug);
 
-            if (cppHandle == nullptr)
-            {
-                return EXIT_FAILURE;
-            }
-
-            UnitPtr u = Unit::createUnit("php", false);
-            int parseStatus = u->parse(*i, cppHandle, debug);
-            u->destroy();
-
-            if (parseStatus == EXIT_FAILURE)
-            {
-                return EXIT_FAILURE;
-            }
-
-            if (!icecpp->printMakefileDependencies(
-                    os,
-                    depend ? Preprocessor::PHP : Preprocessor::SliceXML,
-                    includePaths,
-                    "-D__SLICE2PHP__"))
-            {
-                return EXIT_FAILURE;
-            }
-
-            if (!icecpp->close())
-            {
-                return EXIT_FAILURE;
-            }
-        }
-        else
-        {
-            PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
-            FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2PHP__");
-
-            if (cppHandle == nullptr)
-            {
-                return EXIT_FAILURE;
-            }
-
-            UnitPtr u = Unit::createUnit("php", all);
-            int parseStatus = u->parse(*i, cppHandle, debug);
-
-            if (!icecpp->close())
-            {
-                u->destroy();
-                return EXIT_FAILURE;
-            }
+            preprocessor->close();
 
             if (parseStatus == EXIT_FAILURE)
             {
                 status = EXIT_FAILURE;
             }
+            else if (depend | dependXML)
+            {
+                unit->visit(&dependencyVisitor);
+                if (depend)
+                {
+                    string target = removeExtension(baseName(fileName)) + ".php";
+                    dependencyVisitor.writeMakefileDependencies(dependFile, unit->topLevelFile(), target);
+                }
+                // Else XML dependencies are handled below after all units have been processed.
+            }
             else
             {
-                string base = icecpp->getBaseName();
-                string::size_type pos = base.find_last_of("/\\");
-                if (pos != string::npos)
-                {
-                    base.erase(0, pos + 1);
-                }
+                string base = removeExtension(baseName(fileName));
 
                 string file = base + ".php";
                 if (!output.empty())
@@ -1345,44 +1299,36 @@ compile(const vector<string>& argv)
                     file = output + '/' + file;
                 }
 
-                try
+                IceInternal::Output out;
+                out.open(file.c_str());
+                if (!out)
                 {
-                    IceInternal::Output out;
-                    out.open(file.c_str());
-                    if (!out)
-                    {
-                        ostringstream os;
-                        os << "cannot open '" << file << "': " << IceInternal::errorToString(errno);
-                        throw FileException(os.str());
-                    }
-                    FileTracker::instance()->addFile(file);
+                    ostringstream os;
+                    os << "cannot open '" << file << "': " << IceInternal::errorToString(errno);
+                    throw FileException(os.str());
+                }
+                FileTracker::instance()->addFile(file);
 
-                    out << "<?php\n";
-                    printHeader(out);
-                    printGeneratedHeader(out, base + ".ice");
+                out << "<?php\n";
+                printHeader(out);
+                printGeneratedHeader(out, base + ".ice");
 
-                    // Generate the PHP mapping.
-                    generate(u, all, includePaths, out);
-                    out.close();
-                }
-                catch (const Slice::FileException& ex)
-                {
-                    // If a file could not be created, then cleanup any  created files.
-                    FileTracker::instance()->cleanup();
-                    u->destroy();
-                    consoleErr << argv[0] << ": error: " << ex.what() << endl;
-                    return EXIT_FAILURE;
-                }
-                catch (const exception& ex)
-                {
-                    FileTracker::instance()->cleanup();
-                    consoleErr << argv[0] << ": error: " << ex.what() << endl;
-                    status = EXIT_FAILURE;
-                }
+                // Generate the PHP mapping.
+                generate(unit, all, includePaths, out);
+                out.close();
+
+                status |= unit->getStatus();
             }
-
-            status |= u->getStatus();
-            u->destroy();
+            unit->destroy();
+        }
+        catch (...)
+        {
+            FileTracker::instance()->cleanup();
+            if (unit)
+            {
+                unit->destroy();
+            }
+            throw;
         }
 
         {
@@ -1395,14 +1341,16 @@ compile(const vector<string>& argv)
         }
     }
 
-    if (dependxml)
+    if (status == EXIT_FAILURE)
     {
-        os << "</dependencies>\n";
+        // If the compilation failed, clean up any created files.
+        FileTracker::instance()->cleanup();
+        return status;
     }
 
-    if (depend || dependxml)
+    if (dependXML)
     {
-        writeDependencies(os.str(), dependFile);
+        dependencyVisitor.writeXMLDependencies(dependFile);
     }
 
     return status;
@@ -1428,8 +1376,7 @@ main(int argc, char* argv[])
     }
     catch (...)
     {
-        consoleErr << args[0] << ": error:"
-                   << "unknown exception" << endl;
+        consoleErr << args[0] << ": error:unknown exception" << endl;
         return EXIT_FAILURE;
     }
 }

--- a/cpp/src/slice2py/Main.cpp
+++ b/cpp/src/slice2py/Main.cpp
@@ -11,6 +11,7 @@
 #include "PythonUtil.h"
 
 #include <algorithm>
+#include <cassert>
 #include <iostream>
 #include <mutex>
 #include <string>
@@ -146,31 +147,31 @@ main(int argc, char* argv[])
             return EXIT_SUCCESS;
         }
 
-        vector<string> cppArgs;
+        vector<string> preprocessorArgs;
         vector<string> optargs = opts.argVec("D");
-        cppArgs.reserve(optargs.size());
+        preprocessorArgs.reserve(optargs.size());
         for (const auto& arg : optargs)
         {
-            cppArgs.push_back("-D" + arg);
+            preprocessorArgs.push_back("-D" + arg);
         }
 
         optargs = opts.argVec("U");
         for (const auto& arg : optargs)
         {
-            cppArgs.push_back("-U" + arg);
+            preprocessorArgs.push_back("-U" + arg);
         }
 
         vector<string> includePaths = opts.argVec("I");
         for (const auto& includePath : includePaths)
         {
-            cppArgs.push_back("-I" + Preprocessor::normalizeIncludePath(includePath));
+            preprocessorArgs.push_back("-I" + Preprocessor::normalizeIncludePath(includePath));
         }
 
         string outputDir = opts.optArg("output-dir");
 
         bool depend = opts.isSet("depend");
 
-        bool dependxml = opts.isSet("depend-xml");
+        bool dependXML = opts.isSet("depend-xml");
 
         string dependFile = opts.optArg("depend-file");
 
@@ -187,9 +188,9 @@ main(int argc, char* argv[])
             return EXIT_FAILURE;
         }
 
-        if (depend && dependxml)
+        if (depend && dependXML)
         {
-            consoleErr << args[0] << ": error: cannot specify both --depend and --dependxml" << endl;
+            consoleErr << args[0] << ": error: cannot specify both --depend and --depend-xml" << endl;
             usage(args[0]);
             return EXIT_FAILURE;
         }
@@ -219,76 +220,57 @@ main(int argc, char* argv[])
         Ice::CtrlCHandler ctrlCHandler;
         ctrlCHandler.setCallback(interruptedCallback);
 
-        ostringstream os;
-        if (dependxml)
-        {
-            os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<dependencies>" << endl;
-        }
-
+        DependencyVisitor dependencyVisitor;
         PackageVisitor packageVisitor;
+
+        std::map<string, StringList> dependencyMap;
 
         for (const auto& fileName : sliceFiles)
         {
-            PreprocessorPtr preprocessor = Preprocessor::create(args[0], fileName, cppArgs);
-            FILE* cppHandle = preprocessor->preprocess(true, "-D__SLICE2PY__");
-
-            if (cppHandle == nullptr)
+            UnitPtr unit;
+            try
             {
-                FileTracker::instance()->cleanup();
-                return EXIT_FAILURE;
-            }
+                PreprocessorPtr preprocessor = Preprocessor::create(args[0], fileName, preprocessorArgs);
+                FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2PY__");
+                assert(preprocessedHandle);
 
-            UnitPtr unit = Unit::createUnit("python", false);
-            int parseStatus = unit->parse(fileName, cppHandle, debug);
+                unit = Unit::createUnit("python", false);
+                int parseStatus = unit->parse(fileName, preprocessedHandle, debug);
 
-            if (parseStatus == EXIT_FAILURE)
-            {
-                FileTracker::instance()->cleanup();
-                unit->destroy();
-                return EXIT_FAILURE;
-            }
+                preprocessor->close();
 
-            if (depend || dependxml)
-            {
-                if (!preprocessor->printMakefileDependencies(
-                        os,
-                        depend ? Preprocessor::Python : Preprocessor::SliceXML,
-                        includePaths,
-                        "-D__SLICE2PY__"))
+                if (parseStatus == EXIT_FAILURE)
                 {
-                    return EXIT_FAILURE;
+                    status = EXIT_FAILURE;
                 }
-            }
-            else
-            {
-                parseAllDocComments(unit, Slice::Python::pyLinkFormatter);
-
-                try
+                else
                 {
-                    if (buildArg == "modules" || buildArg == "all")
-                    {
-                        // Generate Python code.
-                        generate(unit, outputDir);
-                    }
+                    // Collect the dependencies of the unit.
+                    unit->visit(&dependencyVisitor);
 
                     // Collect the package imports and generated files.
                     unit->visit(&packageVisitor);
-                }
-                catch (const FileException&)
-                {
-                    // If a file could not be created, then clean up any created files.
-                    FileTracker::instance()->cleanup();
-                    throw;
-                }
-            }
 
-            if (!preprocessor->close())
+                    if (buildArg == "modules" || buildArg == "all")
+                    {
+                        parseAllDocComments(unit, Slice::Python::pyLinkFormatter);
+
+                        generate(unit, outputDir);
+                    }
+
+                    status |= unit->getStatus();
+                }
+                unit->destroy();
+            }
+            catch (...)
             {
-                return EXIT_FAILURE;
+                FileTracker::instance()->cleanup();
+                if (unit)
+                {
+                    unit->destroy();
+                }
+                throw;
             }
-
-            status |= unit->getStatus();
-            unit->destroy();
         }
 
         if (status == EXIT_FAILURE)
@@ -298,22 +280,42 @@ main(int argc, char* argv[])
             return status;
         }
 
-        if (!listArg.empty())
+        if (depend)
         {
-            if (listArg == "modules" || listArg == "all")
+            for (const auto& [source, files] : packageVisitor.generated())
             {
-                for (const auto& moduleName : packageVisitor.generatedModules())
+                for (const auto& file : files)
                 {
-                    cout << moduleName << endl;
+                    dependencyVisitor.writeMakefileDependencies(dependFile, source, file);
+                }
+            }
+        }
+        else if (dependXML)
+        {
+            dependencyVisitor.writeXMLDependencies(dependFile);
+        }
+        else if (!listArg.empty())
+        {
+            std::set<string> generated;
+
+            for (const auto& [source, files] : packageVisitor.generated())
+            {
+                for (const auto& file : files)
+                {
+                    bool skip = (listArg == "modules" && file.find("/__init__.py") != string::npos) ||
+                                (listArg == "index" && file.find("/__init__.py") == string::npos);
+
+                    if (skip)
+                    {
+                        continue;
+                    }
+                    generated.insert(file);
                 }
             }
 
-            if (listArg == "index" || listArg == "all")
+            for (const auto& file : generated)
             {
-                for (const auto& fileName : packageVisitor.packageIndexFiles())
-                {
-                    cout << fileName << endl;
-                }
+                cout << file << endl;
             }
         }
         else if (buildArg == "index" || buildArg == "all")
@@ -333,16 +335,6 @@ main(int argc, char* argv[])
                 FileTracker::instance()->cleanup();
                 return EXIT_FAILURE;
             }
-        }
-
-        if (dependxml)
-        {
-            os << "</dependencies>\n";
-        }
-
-        if (depend || dependxml)
-        {
-            writeDependencies(os.str(), dependFile);
         }
 
         return status;

--- a/cpp/src/slice2py/PythonUtil.h
+++ b/cpp/src/slice2py/PythonUtil.h
@@ -230,8 +230,7 @@ namespace Slice::Python
         {
             return _imports;
         }
-        [[nodiscard]] const std::set<std::string>& generatedModules() const { return _generatedModules; }
-        [[nodiscard]] const std::set<std::string>& packageIndexFiles() const { return _packageIndexFiles; }
+        [[nodiscard]] const std::map<std::string, std::set<std::string>>& generated() { return _generated; }
 
     private:
         void addRuntimeImport(const ContainedPtr& definition, const std::string& prefix = "");
@@ -245,11 +244,7 @@ namespace Slice::Python
         //   "__Foo_Bar_t", corresponding to the class itself and its associated meta-type.
         std::map<std::string, std::map<std::string, std::set<std::string>>> _imports;
 
-        // The set of generated Python modules.
-        std::set<std::string> _generatedModules;
-
-        // The se of generated package index files.
-        std::set<std::string> _packageIndexFiles;
+        std::map<std::string, std::set<std::string>> _generated;
     };
 
     // Collect the import statements required by each generated Python module.

--- a/cpp/src/slice2rb/Main.cpp
+++ b/cpp/src/slice2rb/Main.cpp
@@ -27,8 +27,7 @@ main(int argc, char* argv[])
     }
     catch (...)
     {
-        consoleErr << args[0] << ": error:"
-                   << "unknown exception" << endl;
+        consoleErr << args[0] << ": error:unknown exception" << endl;
         return EXIT_FAILURE;
     }
 }

--- a/cpp/src/slice2rb/Ruby.cpp
+++ b/cpp/src/slice2rb/Ruby.cpp
@@ -10,6 +10,7 @@
 #include "RubyUtil.h"
 
 #include <algorithm>
+#include <cassert>
 #include <mutex>
 
 #include <cstring>
@@ -65,10 +66,10 @@ Slice::Ruby::compile(const vector<string>& argv)
     opts.addOpt("d", "debug");
     opts.addOpt("", "all");
 
-    vector<string> args;
+    vector<string> sliceFiles;
     try
     {
-        args = opts.parse(argv);
+        sliceFiles = opts.parse(argv);
     }
     catch (const IceInternal::BadOptException& e)
     {
@@ -89,31 +90,31 @@ Slice::Ruby::compile(const vector<string>& argv)
         return EXIT_SUCCESS;
     }
 
-    vector<string> cppArgs;
+    vector<string> preprocessorArgs;
     vector<string> optargs = opts.argVec("D");
-    cppArgs.reserve(optargs.size()); // not quite sufficient but keeps clang-tidy happy
+    preprocessorArgs.reserve(optargs.size()); // not quite sufficient but keeps clang-tidy happy
     for (const auto& optarg : optargs)
     {
-        cppArgs.push_back("-D" + optarg);
+        preprocessorArgs.push_back("-D" + optarg);
     }
 
     optargs = opts.argVec("U");
     for (const auto& optarg : optargs)
     {
-        cppArgs.push_back("-U" + optarg);
+        preprocessorArgs.push_back("-U" + optarg);
     }
 
     vector<string> includePaths = opts.argVec("I");
     for (const auto& includePath : includePaths)
     {
-        cppArgs.push_back("-I" + Preprocessor::normalizeIncludePath(includePath));
+        preprocessorArgs.push_back("-I" + Preprocessor::normalizeIncludePath(includePath));
     }
 
     string output = opts.optArg("output-dir");
 
     bool depend = opts.isSet("depend");
 
-    bool dependxml = opts.isSet("depend-xml");
+    bool dependXML = opts.isSet("depend-xml");
 
     string dependFile = opts.optArg("depend-file");
 
@@ -121,16 +122,16 @@ Slice::Ruby::compile(const vector<string>& argv)
 
     bool all = opts.isSet("all");
 
-    if (args.empty())
+    if (sliceFiles.empty())
     {
         consoleErr << argv[0] << ": error: no input file" << endl;
         usage(argv[0]);
         return EXIT_FAILURE;
     }
 
-    if (depend && dependxml)
+    if (depend && dependXML)
     {
-        consoleErr << argv[0] << ": error: cannot specify both --depend and --dependxml" << endl;
+        consoleErr << argv[0] << ": error: cannot specify both --depend and --depend-xml" << endl;
         usage(argv[0]);
         return EXIT_FAILURE;
     }
@@ -140,87 +141,39 @@ Slice::Ruby::compile(const vector<string>& argv)
     Ice::CtrlCHandler ctrlCHandler;
     ctrlCHandler.setCallback(interruptedCallback);
 
-    ostringstream os;
-    if (dependxml)
+    DependencyVisitor dependencyVisitor;
+
+    for (const auto& fileName : sliceFiles)
     {
-        os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<dependencies>" << endl;
-    }
-
-    for (auto i = args.begin(); i != args.end(); ++i)
-    {
-        //
-        // Ignore duplicates.
-        //
-        auto p = find(args.begin(), args.end(), *i);
-        if (p != i)
+        UnitPtr unit;
+        try
         {
-            continue;
-        }
+            PreprocessorPtr preprocessor = Preprocessor::create(argv[0], fileName, preprocessorArgs);
+            FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2RB__");
+            assert(preprocessedHandle);
 
-        if (depend || dependxml)
-        {
-            PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
-            FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2RB__");
+            unit = Unit::createUnit("ruby", all);
+            int parseStatus = unit->parse(fileName, preprocessedHandle, debug);
 
-            if (cppHandle == nullptr)
-            {
-                return EXIT_FAILURE;
-            }
-
-            UnitPtr u = Unit::createUnit("ruby", false);
-            int parseStatus = u->parse(*i, cppHandle, debug);
-            u->destroy();
-
-            if (parseStatus == EXIT_FAILURE)
-            {
-                return EXIT_FAILURE;
-            }
-
-            if (!icecpp->printMakefileDependencies(
-                    os,
-                    depend ? Preprocessor::Ruby : Preprocessor::SliceXML,
-                    includePaths,
-                    "-D__SLICE2RB__"))
-            {
-                return EXIT_FAILURE;
-            }
-
-            if (!icecpp->close())
-            {
-                return EXIT_FAILURE;
-            }
-        }
-        else
-        {
-            PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
-            FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2RB__");
-
-            if (cppHandle == nullptr)
-            {
-                return EXIT_FAILURE;
-            }
-
-            UnitPtr u = Unit::createUnit("ruby", all);
-            int parseStatus = u->parse(*i, cppHandle, debug);
-
-            if (!icecpp->close())
-            {
-                u->destroy();
-                return EXIT_FAILURE;
-            }
+            preprocessor->close();
 
             if (parseStatus == EXIT_FAILURE)
             {
                 status = EXIT_FAILURE;
             }
+            else if (depend | dependXML)
+            {
+                unit->visit(&dependencyVisitor);
+                if (depend)
+                {
+                    string target = removeExtension(baseName(fileName)) + ".rb";
+                    dependencyVisitor.writeMakefileDependencies(dependFile, unit->topLevelFile(), target);
+                }
+                // Else XML dependencies are written below after all units have been processed.
+            }
             else
             {
-                string base = icecpp->getBaseName();
-                string::size_type pos = base.find_last_of("/\\");
-                if (pos != string::npos)
-                {
-                    base.erase(0, pos + 1);
-                }
+                string base = removeExtension(baseName(fileName));
 
                 string file = base + ".rb";
                 if (!output.empty())
@@ -228,42 +181,37 @@ Slice::Ruby::compile(const vector<string>& argv)
                     file = output + '/' + file;
                 }
 
-                try
+                IceInternal::Output out;
+                out.open(file.c_str());
+                if (!out)
                 {
-                    IceInternal::Output out;
-                    out.open(file.c_str());
-                    if (!out)
-                    {
-                        ostringstream oss;
-                        oss << "cannot open '" << file << "': " << IceInternal::errorToString(errno);
-                        throw FileException(oss.str());
-                    }
-                    FileTracker::instance()->addFile(file);
-
-                    printHeader(out);
-                    printGeneratedHeader(out, base + ".ice", "#");
-                    out << sp;
-
-                    //
-                    // Generate the Ruby mapping.
-                    //
-                    generate(u, all, includePaths, out);
-
-                    out.close();
+                    ostringstream oss;
+                    oss << "cannot open '" << file << "': " << IceInternal::errorToString(errno);
+                    throw FileException(oss.str());
                 }
-                catch (const Slice::FileException& ex)
-                {
-                    // If a file could not be created, then cleanup
-                    // any created files.
-                    FileTracker::instance()->cleanup();
-                    u->destroy();
-                    consoleErr << argv[0] << ": error: " << ex.what() << endl;
-                    return EXIT_FAILURE;
-                }
+                FileTracker::instance()->addFile(file);
+
+                printHeader(out);
+                printGeneratedHeader(out, base + ".ice", "#");
+                out << sp;
+
+                // Generate the Ruby mapping.
+                generate(unit, all, includePaths, out);
+
+                out.close();
+
+                status |= unit->getStatus();
             }
-
-            status |= u->getStatus();
-            u->destroy();
+            unit->destroy();
+        }
+        catch (...)
+        {
+            FileTracker::instance()->cleanup();
+            if (unit)
+            {
+                unit->destroy();
+            }
+            throw;
         }
 
         {
@@ -276,14 +224,16 @@ Slice::Ruby::compile(const vector<string>& argv)
         }
     }
 
-    if (dependxml)
+    if (status == EXIT_FAILURE)
     {
-        os << "</dependencies>\n";
+        // If the compilation failed, clean up any created files.
+        FileTracker::instance()->cleanup();
+        return status;
     }
 
-    if (depend || dependxml)
+    if (dependXML)
     {
-        writeDependencies(os.str(), dependFile);
+        dependencyVisitor.writeXMLDependencies(dependFile);
     }
 
     return status;

--- a/cpp/src/slice2swift/Main.cpp
+++ b/cpp/src/slice2swift/Main.cpp
@@ -11,6 +11,7 @@
 #include "Ice/CtrlCHandler.h"
 
 #include <algorithm>
+#include <cassert>
 #include <climits>
 #include <cstring>
 #include <mutex>
@@ -69,10 +70,10 @@ compile(const vector<string>& argv)
 
     bool validate = find(argv.begin(), argv.end(), "--validate") != argv.end();
 
-    vector<string> args;
+    vector<string> sliceFiles;
     try
     {
-        args = opts.parse(argv);
+        sliceFiles = opts.parse(argv);
     }
     catch (const IceInternal::BadOptException& e)
     {
@@ -96,37 +97,37 @@ compile(const vector<string>& argv)
         return EXIT_SUCCESS;
     }
 
-    vector<string> cppArgs;
+    vector<string> preprocessorArgs;
     vector<string> optargs = opts.argVec("D");
-    cppArgs.reserve(optargs.size()); // not quite sufficient but keeps clang-tidy happy
+    preprocessorArgs.reserve(optargs.size()); // not quite sufficient but keeps clang-tidy happy
     for (const auto& optarg : optargs)
     {
-        cppArgs.push_back("-D" + optarg);
+        preprocessorArgs.push_back("-D" + optarg);
     }
 
     optargs = opts.argVec("U");
     for (const auto& optarg : optargs)
     {
-        cppArgs.push_back("-U" + optarg);
+        preprocessorArgs.push_back("-U" + optarg);
     }
 
     vector<string> includePaths = opts.argVec("I");
     for (const auto& includePath : includePaths)
     {
-        cppArgs.push_back("-I" + Preprocessor::normalizeIncludePath(includePath));
+        preprocessorArgs.push_back("-I" + Preprocessor::normalizeIncludePath(includePath));
     }
 
     string output = opts.optArg("output-dir");
 
     bool depend = opts.isSet("depend");
 
-    bool dependxml = opts.isSet("depend-xml");
+    bool dependXML = opts.isSet("depend-xml");
 
     string dependFile = opts.optArg("depend-file");
 
     bool debug = opts.isSet("debug");
 
-    if (args.empty())
+    if (sliceFiles.empty())
     {
         consoleErr << argv[0] << ": error: no input file" << endl;
         if (!validate)
@@ -136,7 +137,7 @@ compile(const vector<string>& argv)
         return EXIT_FAILURE;
     }
 
-    if (depend && dependxml)
+    if (depend && dependXML)
     {
         consoleErr << argv[0] << ": error: cannot specify both --depend and --depend-xml" << endl;
         if (!validate)
@@ -156,109 +157,54 @@ compile(const vector<string>& argv)
     Ice::CtrlCHandler ctrlCHandler;
     ctrlCHandler.setCallback(interruptedCallback);
 
-    ostringstream os;
-    if (dependxml)
+    DependencyVisitor dependencyVisitor;
+
+    for (const auto& fileName : sliceFiles)
     {
-        os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<dependencies>" << endl;
-    }
-
-    for (auto i = args.begin(); i != args.end(); ++i)
-    {
-        //
-        // Ignore duplicates.
-        //
-        if (find(args.begin(), args.end(), *i) != i)
+        UnitPtr unit;
+        try
         {
-            continue;
-        }
+            PreprocessorPtr preprocessor = Preprocessor::create(argv[0], fileName, preprocessorArgs);
+            FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2SWIFT__");
+            assert(preprocessedHandle);
 
-        if (depend || dependxml)
-        {
-            PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
-            FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2SWIFT__");
+            unit = Unit::createUnit("swift", false);
+            int parseStatus = unit->parse(fileName, preprocessedHandle, debug);
 
-            if (cppHandle == nullptr)
-            {
-                return EXIT_FAILURE;
-            }
-
-            UnitPtr u = Unit::createUnit("swift", false);
-            int parseStatus = u->parse(*i, cppHandle, debug);
-            u->destroy();
-
-            if (parseStatus == EXIT_FAILURE)
-            {
-                return EXIT_FAILURE;
-            }
-
-            if (!icecpp->printMakefileDependencies(
-                    os,
-                    depend ? Preprocessor::Swift : Preprocessor::SliceXML,
-                    includePaths,
-                    "-D__SLICE2SWIFT__"))
-            {
-                return EXIT_FAILURE;
-            }
-
-            if (!icecpp->close())
-            {
-                return EXIT_FAILURE;
-            }
-        }
-        else
-        {
-            PreprocessorPtr icecpp = Preprocessor::create(argv[0], *i, cppArgs);
-            FILE* cppHandle = icecpp->preprocess(true, "-D__SLICE2SWIFT__");
-
-            if (cppHandle == nullptr)
-            {
-                return EXIT_FAILURE;
-            }
-
-            UnitPtr u = Unit::createUnit("swift", false);
-            int parseStatus = u->parse(*i, cppHandle, debug);
-
-            if (!icecpp->close())
-            {
-                u->destroy();
-                return EXIT_FAILURE;
-            }
+            preprocessor->close();
 
             if (parseStatus == EXIT_FAILURE)
             {
                 status = EXIT_FAILURE;
             }
+            else if (depend | dependXML)
+            {
+                unit->visit(&dependencyVisitor);
+                if (depend)
+                {
+                    string target = removeExtension(baseName(fileName)) + ".swift";
+                    dependencyVisitor.writeMakefileDependencies(dependFile, unit->topLevelFile(), target);
+                }
+                // Else XML dependencies are written below after all units have been processed.
+            }
             else
             {
-                parseAllDocComments(u, Slice::Swift::swiftLinkFormatter);
+                parseAllDocComments(unit, Slice::Swift::swiftLinkFormatter);
+                Gen gen(preprocessor->getBaseName(), includePaths, output);
+                gen.generate(unit);
 
-                string base = icecpp->getBaseName();
-                string::size_type pos = base.find_last_of("/\\");
-                if (pos != string::npos)
-                {
-                    base.erase(0, pos + 1);
-                }
-
-                try
-                {
-                    Gen gen(icecpp->getBaseName(), includePaths, output);
-                    gen.generate(u);
-                }
-                catch (const Slice::FileException& ex)
-                {
-                    //
-                    // If a file could not be created, then cleanup any created files.
-                    //
-                    FileTracker::instance()->cleanup();
-                    u->destroy();
-                    consoleErr << argv[0] << ": error: " << ex.what() << endl;
-                    status = EXIT_FAILURE;
-                    break;
-                }
+                status |= unit->getStatus();
             }
-
-            status |= u->getStatus();
-            u->destroy();
+            unit->destroy();
+        }
+        catch (...)
+        {
+            FileTracker::instance()->cleanup();
+            if (unit)
+            {
+                unit->destroy();
+            }
+            throw;
         }
 
         {
@@ -271,14 +217,16 @@ compile(const vector<string>& argv)
         }
     }
 
-    if (dependxml)
+    if (status == EXIT_FAILURE)
     {
-        os << "</dependencies>\n";
+        // If the compilation failed, clean up any created files.
+        FileTracker::instance()->cleanup();
+        return status;
     }
 
-    if (depend || dependxml)
+    if (dependXML)
     {
-        writeDependencies(os.str(), dependFile);
+        dependencyVisitor.writeXMLDependencies(dependFile);
     }
 
     return status;
@@ -304,8 +252,7 @@ main(int argc, char* argv[])
     }
     catch (...)
     {
-        consoleErr << args[0] << ": error:"
-                   << "unknown exception" << endl;
+        consoleErr << args[0] << ": error:unknown exception" << endl;
         return EXIT_FAILURE;
     }
 }

--- a/csharp/tools/ZeroC.Ice.Slice.Tools/Common/DependUtil.cs
+++ b/csharp/tools/ZeroC.Ice.Slice.Tools/Common/DependUtil.cs
@@ -1,0 +1,27 @@
+
+using System;
+using System.IO;
+using System.Xml;
+
+namespace ZeroC.Ice.Slice.Tools.Common;
+
+static class DependUtil
+{
+    internal static XmlNode? FindSourceNode(XmlDocument dependsDoc, string sourcePath)
+    {
+        var sourceFile = new FileInfo(sourcePath);
+
+        foreach (XmlNode sourceNode in dependsDoc.SelectNodes("/dependencies/source"))
+        {
+            if (sourceNode.Attributes?["name"] is XmlAttribute nameAttr)
+            {
+                var nodeFile = new FileInfo(nameAttr.Value);
+                if (sourceFile.FullName.Equals(nodeFile.FullName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return sourceNode;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/csharp/tools/ZeroC.Ice.Slice.Tools/Common/SliceCompilerTask.cs
+++ b/csharp/tools/ZeroC.Ice.Slice.Tools/Common/SliceCompilerTask.cs
@@ -114,9 +114,8 @@ public abstract class SliceCompilerTask : ToolTask
                 foreach (ITaskItem source in Sources)
                 {
                     var inputs = new List<string>();
-                    var depends = dependsDoc.DocumentElement.SelectNodes(
-                        string.Format("/dependencies/source[@name='{0}']/dependsOn",
-                                        source.GetMetadata("Identity")));
+                    XmlNode? sourceNode = DependUtil.FindSourceNode(dependsDoc, source.GetMetadata("FullPath"));
+                    XmlNodeList? depends = sourceNode?.SelectNodes("dependsOn");
                     if (depends != null)
                     {
                         foreach (XmlNode depend in depends)
@@ -131,7 +130,7 @@ public abstract class SliceCompilerTask : ToolTask
                     var doc = new XDocument(
                         new XDeclaration("1.0", "utf-8", "yes"),
                         new XElement("dependencies",
-                            new XElement("source", new XAttribute("name", source.GetMetadata("Identity")),
+                            new XElement("source", new XAttribute("name", source.GetMetadata("FullPath")),
                                 inputs.Select(path => new XElement("dependsOn", new XAttribute("name", path))),
                                 new XElement("options",
                                     GetOptions().Select(e => new XElement(e.Key, e.Value))))));

--- a/csharp/tools/ZeroC.Ice.Slice.Tools/Common/SliceDependTask.cs
+++ b/csharp/tools/ZeroC.Ice.Slice.Tools/Common/SliceDependTask.cs
@@ -197,9 +197,8 @@ public abstract class SliceDependTask : Task
 
             if (skip)
             {
-                XmlNodeList options = dependsDoc.DocumentElement.SelectNodes(
-                    string.Format("/dependencies/source[@name='{0}']/options/child::node()",
-                                    source.GetMetadata("Identity")));
+                XmlNode? sourceNode = DependUtil.FindSourceNode(dependsDoc, source.GetMetadata("FullPath"));
+                XmlNodeList? options = sourceNode?.SelectNodes("options/*");
                 if (options != null)
                 {
                     var newOptions = GetOptions(source);
@@ -221,9 +220,8 @@ public abstract class SliceDependTask : Task
 
             if (skip)
             {
-                XmlNodeList depends = dependsDoc.DocumentElement.SelectNodes(
-                    string.Format("/dependencies/source[@name='{0}']/dependsOn", source.GetMetadata("Identity")));
-
+                XmlNode? sourceNode = DependUtil.FindSourceNode(dependsDoc, source.GetMetadata("FullPath"));
+                XmlNodeList? depends = sourceNode?.SelectNodes("dependsOn");
                 if (depends != null)
                 {
                     var inputs = new List<string>();

--- a/ruby/src/IceRuby/Slice.cpp
+++ b/ruby/src/IceRuby/Slice.cpp
@@ -107,7 +107,7 @@ IceRuby_loadSlice(int argc, VALUE* argv, VALUE /*self*/)
         {
             string file = *p;
             PreprocessorPtr icecpp = Preprocessor::create("icecpp", file, cppArgs);
-            FILE* cppHandle = icecpp->preprocess(false, "-D__SLICE2RB__");
+            FILE* cppHandle = icecpp->preprocess("-D__SLICE2RB__");
 
             if (cppHandle == 0)
             {
@@ -117,7 +117,9 @@ IceRuby_loadSlice(int argc, VALUE* argv, VALUE /*self*/)
             UnitPtr u = Unit::createUnit("ruby", all);
             int parseStatus = u->parse(file, cppHandle, debug);
 
-            if (!icecpp->close() || parseStatus == EXIT_FAILURE)
+            icecpp->close();
+
+            if (parseStatus == EXIT_FAILURE)
             {
                 u->destroy();
                 throw RubyException(rb_eArgError, "Slice parsing failed for `%s'", cmd.c_str());
@@ -180,8 +182,7 @@ IceRuby_compile(int argc, VALUE* argv, VALUE /*self*/)
         }
         catch (...)
         {
-            cerr << argSeq[0] << ": error:"
-                 << "unknown exception" << endl;
+            cerr << argSeq[0] << ": error:unknown exception" << endl;
             rc = EXIT_FAILURE;
         }
         return INT2FIX(rc);


### PR DESCRIPTION
This PR reworks how Slice compiler generate dependency files. Slice compiler support three different formats for dependency files:

- Makefile style dependencies (--depend).
- Dependencies encoded as XML (--depend-xml).
- Dependencies encoded as JSON (--depend-json) slice2js only.

Before this PR this work but parsing the output of `mcpp -M`, which emits Makefile style dependencies, and transform it to the desired style.

The new implementation gets the dependencies directly from the parser `Unit::getAllFiles` returns all files that were parsed by the unit, in other words its dependencies, and then a regular visitor that collects and emit the dependencies in the desired format.

There is some additional cleanup for Slice compilers main.