### PR TITLE
Simplify ice_id in Python

### DIFF
--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1188,13 +1188,6 @@ Slice::Python::CodeVisitor::visitClassDefEnd(const ClassDefPtr& p)
     assert(_out);
     auto& out = *_out;
 
-    // ice_id
-    out << sp;
-    out << nl << "def ice_id(self) -> str:";
-    out.inc();
-    out << nl << "return \"" << scoped << "\"";
-    out.dec();
-
     // ice_staticId
     out << sp;
     out << nl << "@staticmethod";
@@ -1554,13 +1547,6 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         out << "\"" << *q << "\"";
     }
     out << ')';
-    out.dec();
-
-    // ice_id
-    out << sp;
-    out << nl << "def ice_id(self, current: " << currentAlias << ") -> str | Awaitable[str]:";
-    out.inc();
-    out << nl << "return \"" << scoped << "\"";
     out.dec();
 
     // ice_staticId

--- a/python/python/Ice/Object.py
+++ b/python/python/Ice/Object.py
@@ -137,7 +137,7 @@ class Object:
         str
             The type ID.
         """
-        # Call ice_staticId() on self get the value from the most-derived class.
+        # Call ice_staticId() on self to get the value from the most-derived class.
         return self.ice_staticId()
 
     @staticmethod

--- a/python/python/Ice/Object.py
+++ b/python/python/Ice/Object.py
@@ -137,12 +137,13 @@ class Object:
         str
             The type ID.
         """
-        return Object.ice_staticId()
+        # Call ice_staticId() on self get the value from the most-derived class.
+        return self.ice_staticId()
 
     @staticmethod
     def ice_staticId() -> str:
         """
-        Obtain the type ID of this Slice class or interface.
+        Obtain the type ID of the Slice interface.
 
         Returns
         -------

--- a/python/python/Ice/Value.py
+++ b/python/python/Ice/Value.py
@@ -15,7 +15,8 @@ class Value(object):
         str
             The type ID.
         """
-        return "::Ice::Object"
+        # Call ice_staticId() on self get the value from the most-derived class.
+        return self.ice_staticId()
 
     @staticmethod
     def ice_staticId() -> str:

--- a/python/python/Ice/Value.py
+++ b/python/python/Ice/Value.py
@@ -15,7 +15,7 @@ class Value(object):
         str
             The type ID.
         """
-        # Call ice_staticId() on self get the value from the most-derived class.
+        # Call ice_staticId() on self to get the value from the most-derived class.
         return self.ice_staticId()
 
     @staticmethod


### PR DESCRIPTION
We don't need to generate ice_id, as the base class can provide a shared implementation.