### PR TITLE
Python: improve type-hint for sequence types

### DIFF
--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1340,13 +1340,13 @@ Slice::Python::CodeVisitor::visitDataMember(const DataMemberPtr& p)
             "None"}; // Builtin::KindValue.
         out << " = " << builtinTable[builtin->kind()];
     }
-    else if (p->type()->isClassType() || isProxyType(p->type()))
-    {
-        out << " = None";
-    }
     else if (auto enumeration = dynamic_pointer_cast<Enum>(p->type()))
     {
         out << " = " << getImportAlias(parent, enumeration) << "." + enumeration->enumerators().front()->mappedName();
+    }
+    else if (dynamic_pointer_cast<Struct>(p->type()))
+    {
+        out << " = field(default_factory=" << getImportAlias(parent, p->type()) << ")";
     }
     else if (auto seq = dynamic_pointer_cast<Sequence>(p->type()))
     {
@@ -1384,10 +1384,13 @@ Slice::Python::CodeVisitor::visitDataMember(const DataMemberPtr& p)
         }
         out << ")";
     }
+    else if (dynamic_pointer_cast<Dictionary>(p->type()))
+    {
+        out << " = field(default_factory=dict)";
+    }
     else
     {
-        assert(dynamic_pointer_cast<Dictionary>(p->type()));
-        out << " = field(default_factory=dict)";
+        out << " = None";
     }
 }
 

--- a/cpp/src/slice2py/PythonUtil.h
+++ b/cpp/src/slice2py/PythonUtil.h
@@ -139,11 +139,6 @@ namespace Slice::Python
     /// Helper method to emit the generated code that format the fields of a type in __repr__ implementation.
     std::string formatFields(const DataMemberList& members);
 
-    /// Checks if the given Slice type corresponds to non-optional type which can be used as default value in Python.
-    /// This is really anything that is not a Python dataclass, sequence, or dictionary type. Slice classes and
-    /// interfaces are always mapped as optional.
-    bool canBeUsedAsDefaultValue(const TypePtr& type);
-
     PythonCodeFragment createCodeFragmentForPythonModule(const ContainedPtr& contained, const std::string& code);
 
     // Get a list of all definitions exported for the Python module corresponding to the given Slice definition.
@@ -273,7 +268,10 @@ namespace Slice::Python
         }
 
     private:
-        void visitDataMembers(const ContainedPtr&, const std::list<DataMemberPtr>&);
+        /// Add the runtime imports for the given Sequence definition.
+        /// @param definition is the Sequence definition being imported.
+        /// @param source is the Slice definition that requires the import.
+        void addRuntimeImportForSequence(const SequencePtr& definition, const ContainedPtr& source);
 
         /// Adds a runtime import for the given Slice definition if it comes from a different module.
         /// @param definition is the Slice definition to import.
@@ -391,13 +389,6 @@ namespace Slice::Python
 
         // Emit Python code for operations
         void writeOperations(const InterfaceDefPtr&, IceInternal::Output&);
-
-        /// Get the default value for initializing a given type.
-        /// @param source The Slice definition that is initializing the type.
-        /// @param member The data member to initialize.
-        /// @param forConstructor If true, the initialization is for a constructor parameter, otherwise it is for a
-        /// dataclass field.
-        std::string getTypeInitializer(const ContainedPtr& source, const DataMemberPtr& member, bool forConstructor);
 
         // Write Python metadata as a tuple.
         void writeMetadata(const MetadataList&, IceInternal::Output&);

--- a/cpp/src/slice2py/PythonUtil.h
+++ b/cpp/src/slice2py/PythonUtil.h
@@ -269,13 +269,13 @@ namespace Slice::Python
 
     private:
         /// Add the runtime imports for the given Sequence definition.
-        /// @param definition is the Sequence definition being imported.
-        /// @param source is the Slice definition that requires the import.
-        void addRuntimeImportForSequence(const SequencePtr& definition, const ContainedPtr& source);
+        /// @param sequence The Sequence definition being imported.
+        /// @param source The Slice definition that requires the import.
+        void addRuntimeImportForSequence(const SequencePtr& sequence, const ContainedPtr& source);
 
         /// Adds a runtime import for the given Slice definition if it comes from a different module.
-        /// @param definition is the Slice definition to import.
-        /// @param source is the Slice definition that requires the import.
+        /// @param definition The Slice definition to import.
+        /// @param source The Slice definition that requires the import.
         void addRuntimeImport(
             const SyntaxTreeBasePtr& definition,
             const ContainedPtr& source,

--- a/python/test/Ice/custom/Test.ice
+++ b/python/test/Ice/custom/Test.ice
@@ -63,6 +63,17 @@ module Test
         optional(7) DoubleSeq1 doubleSeq;
     }
 
+    class E
+    {
+        BoolSeq1 boolSeq;
+        ByteSeq1 byteSeq;
+        ShortSeq1 shortSeq;
+        IntSeq1 intSeq;
+        LongSeq1 longSeq;
+        FloatSeq1 floatSeq;
+        DoubleSeq1 doubleSeq;
+    }
+
     interface Custom
     {
         ByteString opByteString1(ByteString b1, out ByteString b2);

--- a/python/test/Ice/custom/TestNumPy.ice
+++ b/python/test/Ice/custom/TestNumPy.ice
@@ -41,6 +41,17 @@ module Test
             optional(7) DoubleSeq1 doubleSeq;
         }
 
+        class E
+        {
+            BoolSeq1 boolSeq;
+            ByteSeq1 byteSeq;
+            ShortSeq1 shortSeq;
+            IntSeq1 intSeq;
+            LongSeq1 longSeq;
+            FloatSeq1 floatSeq;
+            DoubleSeq1 doubleSeq;
+        }
+
         interface Custom
         {
             BoolSeq1 opBoolSeq(BoolSeq1 v1, out BoolSeq2 v2);


### PR DESCRIPTION
This PR improve the Python generated type hint for sequence types to account for the metadata. It also update the initialization of sequence fields to use a factory appropriate for the mapped type.