### PR TITLE
Rework Python import statement generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
         timeout-minutes: 45
         with:
           working_directory: ${{ matrix.working_directory || '.' }}
-          flags: "${{ matrix.test_flags }} --load-slice"
+          flags: "${{ matrix.test_flags }} --load-slice --language=python"
         if: matrix.python_tests == true
 
       - name: Generate API Reference

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -99,13 +99,29 @@ Slice::Python::getImportAlias(
     // Whether we need to use an alias for the import.
     bool useAlias = false;
 
+    string importName;
+    if (name.empty())
+    {
+        /// If `name` is empty, compute the import name as the last component of the module name.
+        /// For example:
+        ///   - If `moduleName` is "numpy", the import name is "numpy".
+        ///   - If `moduleName` is "numpy.typing", the import name is "typing".
+        auto pos = moduleName.rfind('.');
+        importName = pos == string::npos ? moduleName : moduleName.substr(pos + 1);
+    }
+    else
+    {
+        // Otherwise, we use the name as the import name.
+        importName = name;
+    }
+
     if (moduleName == source->mappedScoped("."))
     {
         // If the source module is the same as the module name being imported. We are using a
         // definition from the current module and we don't need an alias.
         useAlias = false;
     }
-    else if (find(all.begin(), all.end(), name) != all.end())
+    else if (find(all.begin(), all.end(), importName) != all.end())
     {
         // The name being bound comes from a different module and conflicts with one of the names
         // exported by the source module. We need to use an alias.
@@ -114,22 +130,23 @@ Slice::Python::getImportAlias(
     else
     {
         // If the name being bound is already imported from a different module, we need to use an alias.
-        auto p = allImports.find(name);
-        if (p != allImports.end())
-        {
-            useAlias = p->second != moduleName;
-        }
+        auto p = allImports.find(importName);
+        useAlias = p != allImports.end() && p->second != moduleName;
     }
 
     if (useAlias)
     {
-        string alias = "_m_" + moduleName + "_" + name;
+        string alias = "_m_" + moduleName;
+        if (!name.empty())
+        {
+            alias += "_" + name;
+        }
         std::replace(alias.begin(), alias.end(), '.', '_');
         return alias;
     }
     else
     {
-        return name;
+        return importName;
     }
 }
 
@@ -232,10 +249,11 @@ Slice::Python::CodeVisitor::typeToTypeHintString(
             bool isByteSequence = elementType && elementType->kind() == Builtin::KindByte;
             if (forMarshaling)
             {
+                const string sequenceAlias = getImportAlias(source, "collections.abc", "Sequence");
                 // For marshaling, we use a generic Sequence type hint, additionally we accept a bytes object for byte
                 // sequences, and for sequences with NumPy metadata we use the NumPy NDArray type hint because it
                 // doesn't conform to the generic sequence type.
-                os << "Sequence[" + typeToTypeHintString(seq->type(), false, source, forMarshaling) + "]";
+                os << sequenceAlias << "[" + typeToTypeHintString(seq->type(), false, source, forMarshaling) + "]";
                 if (isByteSequence)
                 {
                     os << " | bytes";
@@ -243,7 +261,9 @@ Slice::Python::CodeVisitor::typeToTypeHintString(
                 if (seq->hasMetadata("python:numpy.ndarray"))
                 {
                     assert(elementType && elementType->kind() <= Builtin::KindDouble);
-                    os << " | numpy.typing.NDArray[numpy." << numpyBuiltinTable[elementType->kind()] << "]";
+                    const string numpyAlias = getImportAlias(source, "numpy");
+                    os << " | " << numpyAlias << ".typing.NDArray[" << numpyAlias << "."
+                       << numpyBuiltinTable[elementType->kind()] << "]";
                 }
             }
             else if (seq->hasMetadata("python:list"))
@@ -257,12 +277,15 @@ Slice::Python::CodeVisitor::typeToTypeHintString(
             else if (seq->hasMetadata("python:numpy.ndarray"))
             {
                 assert(elementType && elementType->kind() <= Builtin::KindDouble);
-                os << "numpy.typing.NDArray[numpy." << numpyBuiltinTable[elementType->kind()] << "]";
+                const string numpyAlias = getImportAlias(source, "numpy");
+                os << numpyAlias << ".typing.NDArray[" << numpyAlias << "." << numpyBuiltinTable[elementType->kind()]
+                   << "]";
             }
             else if (seq->hasMetadata("python:array.array"))
             {
                 assert(elementType && elementType->kind() <= Builtin::KindDouble);
-                os << "array.array[" << typeToTypeHintString(seq->type(), false, source, forMarshaling) << "]";
+                const string arrayAlias = getImportAlias(source, "array");
+                os << arrayAlias << ".array[" << typeToTypeHintString(seq->type(), false, source, forMarshaling) << "]";
             }
             else if (isByteSequence)
             {
@@ -332,12 +355,14 @@ Slice::Python::CodeVisitor::returnTypeHint(const OperationPtr& operation, Method
         returnTypeHint = "None";
     }
 
+    const string awaitableAlias = getImportAlias(source, "collections.abc", "Awaitable");
+
     switch (methodKind)
     {
         case MethodKind::AsyncInvocation:
-            return "Awaitable[" + returnTypeHint + "]";
+            return awaitableAlias + "[" + returnTypeHint + "]";
         case MethodKind::Dispatch:
-            return returnTypeHint + " | Awaitable[" + returnTypeHint + "]";
+            return returnTypeHint + " | " + awaitableAlias + "[" + returnTypeHint + "]";
         case MethodKind::SyncInvocation:
         default:
             return returnTypeHint;
@@ -578,8 +603,8 @@ Slice::Python::ImportVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     {
         for (const auto& base : bases)
         {
-            addRuntimeImport(base, p, TypeContext::Proxy);
-            addRuntimeImport(base, p, TypeContext::Servant);
+            addRuntimeImport(base, p, InterfaceTypeContext::Proxy);
+            addRuntimeImport(base, p, InterfaceTypeContext::Servant);
         }
     }
 
@@ -708,7 +733,7 @@ void
 Slice::Python::ImportVisitor::addRuntimeImport(
     const SyntaxTreeBasePtr& definition,
     const ContainedPtr& source,
-    TypeContext typeContext)
+    InterfaceTypeContext typeContext)
 {
     // The module containing the definition we want to import.
     auto definitionModule = getPythonModuleForDefinition(definition);
@@ -745,7 +770,7 @@ Slice::Python::ImportVisitor::addRuntimeImport(
 
         name = contained->mappedName();
         if ((dynamic_pointer_cast<InterfaceDef>(definition) || dynamic_pointer_cast<InterfaceDecl>(definition)) &&
-            typeContext == TypeContext::Proxy)
+            typeContext == InterfaceTypeContext::Proxy)
         {
             name += "Prx";
         }
@@ -758,12 +783,12 @@ Slice::Python::ImportVisitor::addRuntimeImport(
 
     if (name == alias)
     {
-        definitionImports.insert({name, ""});
+        definitionImports.definitions.insert({name, ""});
         allImports[name] = definitionModule;
     }
     else
     {
-        definitionImports.insert({name, alias});
+        definitionImports.definitions.insert({name, alias});
         allImports[alias] = definitionModule;
     }
 }
@@ -784,30 +809,51 @@ Slice::Python::ImportVisitor::addRuntimeImport(
     }
 
     auto& sourceModuleImports = _runtimeImports[sourceModule];
-    if (definition.empty())
+
+    auto& allImports = _allImports[sourceModule];
+    string alias = getImportAlias(source, allImports, definitionModule, definition);
+
+    auto it = sourceModuleImports.find(definitionModule);
+    ModuleImports& definitionImports =
+        it == sourceModuleImports.end() ? sourceModuleImports[definitionModule] : it->second;
+    if (it == sourceModuleImports.end())
     {
-        if (sourceModuleImports.find(definitionModule) == sourceModuleImports.end())
-        {
-            // If the package does not exist, we create an empty map for it.
-            sourceModuleImports[definitionModule] = {};
-        }
-        return;
-    }
-
-    auto& definitionImports = sourceModuleImports[definitionModule];
-
-    auto& imports = _allImports[sourceModule];
-    string alias = getImportAlias(source, imports, definitionModule, definition);
-
-    if (definition == alias)
-    {
-        definitionImports.insert({definition, ""});
-        imports[definition] = definitionModule;
+        // If the module does not exist, we create an empty map for it.
+        definitionImports = sourceModuleImports[definitionModule];
+        definitionImports.moduleName = definitionModule;
+        definitionImports.moduleAlias = "";
+        definitionImports.imported = false;
     }
     else
     {
-        definitionImports.insert({definition, alias});
-        imports[alias] = definitionModule;
+        definitionImports = it->second;
+    }
+
+    if (definition.empty())
+    {
+        definitionImports.imported = true;
+        definitionImports.moduleName = definitionModule;
+        if (alias == definitionModule)
+        {
+            auto pos = definitionModule.rfind('.');
+            const string importName = pos == string::npos ? definitionModule : definitionModule.substr(pos + 1);
+            allImports[importName] = definitionModule;
+        }
+        else
+        {
+            definitionImports.moduleAlias = alias;
+            allImports[alias] = definitionModule;
+        }
+    }
+    else if (definition == alias)
+    {
+        definitionImports.definitions.insert({definition, ""});
+        allImports[definition] = definitionModule;
+    }
+    else
+    {
+        definitionImports.definitions.insert({definition, alias});
+        allImports[alias] = definitionModule;
     }
 }
 
@@ -827,12 +873,12 @@ Slice::Python::ImportVisitor::addTypingImport(
 
     if (definition == alias)
     {
-        definitionImports.insert({definition, ""});
+        definitionImports.definitions.insert({definition, ""});
         imports[definition] = moduleName;
     }
     else
     {
-        definitionImports.insert({definition, alias});
+        definitionImports.definitions.insert({definition, alias});
         imports[alias] = moduleName;
     }
 
@@ -926,8 +972,21 @@ Slice::Python::ImportVisitor::addRuntimeImportForMetaType(
     }
 
     auto& sourceModuleImports = _runtimeImports[sourceModule];
-    auto& definitionImports = sourceModuleImports[definitionModule];
-    definitionImports.insert({getMetaType(definition), ""});
+
+    auto it = sourceModuleImports.find(definitionModule);
+    if (it == sourceModuleImports.end())
+    {
+        sourceModuleImports[definitionModule] = ModuleImports{
+            .moduleName = definitionModule,
+            .moduleAlias = "",
+            .imported = false,
+            .definitions = {{getMetaType(definition), ""}},
+        };
+    }
+    else
+    {
+        it->second.definitions.insert({getMetaType(definition), ""});
+    }
 }
 
 bool
@@ -1090,8 +1149,9 @@ Slice::Python::CodeVisitor::writeOperations(const InterfaceDefPtr& p, Output& ou
             out.dec();
         }
 
+        const string abstractMethodAlias = getImportAlias(p, "abc", "abstractmethod");
         out << sp;
-        out << nl << "@abstractmethod";
+        out << nl << "@" << abstractMethodAlias;
         out << nl << "def " << mappedName << spar << "self";
 
         for (const auto& param : operation->inParameters())
@@ -1121,7 +1181,7 @@ Slice::Python::CodeVisitor::visitStructStart(const StructPtr& p)
     auto& out = *_out;
 
     out << sp;
-    out << nl << "@dataclass";
+    out << nl << "@" << getImportAlias(p, "dataclasses", "dataclass");
     if (Dictionary::isLegalKeyType(p))
     {
         out << "(order=True, unsafe_hash=True)";
@@ -1162,6 +1222,7 @@ Slice::Python::CodeVisitor::visitStructEnd(const StructPtr& p)
 
     out << sp;
     out << nl << "__all__ = [\"" << name << "\", \"" << metaTypeName << "\"]";
+    out << nl;
 
     _codeFragments.push_back(createCodeFragmentForPythonModule(p, out.str()));
     _out.reset();
@@ -1190,7 +1251,7 @@ Slice::Python::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     auto& out = *_out;
 
     // Equality for Slice classes is reference equality, so we disable the dataclass eq.
-    out << nl << "@dataclass(eq=False)";
+    out << nl << "@" << getImportAlias(p, "dataclasses", "dataclass") << "(eq=False)";
     out << nl << "class " << valueName << '('
         << (base ? getImportAlias(p, base) : getImportAlias(p, "Ice.Value", "Value")) << "):";
     out.inc();
@@ -1244,6 +1305,7 @@ Slice::Python::CodeVisitor::visitClassDefEnd(const ClassDefPtr& p)
 
     out << sp;
     out << nl << "__all__ = [\"" << valueName << "\", \"" << metaType << "\"]";
+    out << nl;
 
     _codeFragments.push_back(createCodeFragmentForPythonModule(p, out.str()));
     _out.reset();
@@ -1262,7 +1324,7 @@ Slice::Python::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     const DataMemberList members = p->dataMembers();
 
     out << sp;
-    out << nl << "@dataclass";
+    out << nl << "@" << getImportAlias(p, "dataclasses", "dataclass");
     out << nl << "class " << name << '('
         << (base ? getImportAlias(p, base) : getImportAlias(p, "Ice.UserException", "UserException")) << "):";
     out.inc();
@@ -1311,6 +1373,7 @@ Slice::Python::CodeVisitor::visitExceptionEnd(const ExceptionPtr& p)
 
     out << sp;
     out << nl << "__all__ = [\"" << name << "\", \"" << metaType << "\"]";
+    out << nl;
 
     _codeFragments.push_back(createCodeFragmentForPythonModule(p, out.str()));
     _out.reset();
@@ -1322,6 +1385,8 @@ Slice::Python::CodeVisitor::visitDataMember(const DataMemberPtr& p)
     assert(_out);
     auto& out = *_out;
     auto parent = dynamic_pointer_cast<Contained>(p->container());
+
+    const string fieldAlias = getImportAlias(parent, "dataclasses", "field");
 
     out << nl << p->mappedName() << ": " << typeToTypeHintString(p->type(), p->optional(), parent, false);
 
@@ -1355,14 +1420,14 @@ Slice::Python::CodeVisitor::visitDataMember(const DataMemberPtr& p)
     }
     else if (dynamic_pointer_cast<Struct>(p->type()))
     {
-        out << " = field(default_factory=" << getImportAlias(parent, p->type()) << ")";
+        out << " = " << fieldAlias << "(default_factory=" << getImportAlias(parent, p->type()) << ")";
     }
     else if (auto seq = dynamic_pointer_cast<Sequence>(p->type()))
     {
         auto elementType = dynamic_pointer_cast<Builtin>(seq->type());
         bool isByteSequence = elementType && elementType->kind() == Builtin::KindByte;
 
-        out << " = field(default_factory=";
+        out << " = " << fieldAlias << "(default_factory=";
         if (seq->hasMetadata("python:list"))
         {
             out << "list";
@@ -1375,13 +1440,16 @@ Slice::Python::CodeVisitor::visitDataMember(const DataMemberPtr& p)
         {
             assert(elementType && elementType->kind() <= Builtin::KindDouble);
             static const char* builtinTable[] = {"int8", "bool", "int16", "int32", "int64", "float32", "float64"};
-            out << "lambda: numpy.empty(0, numpy." << builtinTable[elementType->kind()] << ")";
+            const string numpyAlias = getImportAlias(parent, "numpy");
+            out << "lambda: " << numpyAlias << ".empty(0, " << numpyAlias << "." << builtinTable[elementType->kind()]
+                << ")";
         }
         else if (seq->hasMetadata("python:array.array"))
         {
             assert(elementType && elementType->kind() <= Builtin::KindDouble);
             static const char* builtinTable[] = {"b", "b", "h", "i", "q", "f", "d"};
-            out << "lambda: array.array('" << builtinTable[elementType->kind()] << "')";
+            const string arrayAlias = getImportAlias(parent, "array");
+            out << "lambda: " << arrayAlias << ".array('" << builtinTable[elementType->kind()] << "')";
         }
         else if (isByteSequence)
         {
@@ -1395,7 +1463,7 @@ Slice::Python::CodeVisitor::visitDataMember(const DataMemberPtr& p)
     }
     else if (dynamic_pointer_cast<Dictionary>(p->type()))
     {
-        out << " = field(default_factory=dict)";
+        out << " = " << fieldAlias << "(default_factory=dict)";
     }
     else
     {
@@ -1545,6 +1613,8 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     out << nl << "return checkedCast(" << prxName << ", proxy, facet, context)";
     out.dec();
 
+    const string awaitableAlias = getImportAlias(p, "collections.abc", "Awaitable");
+
     out << sp;
     out << nl << "@staticmethod";
     out << nl << "def checkedCastAsync(";
@@ -1553,19 +1623,20 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     out << nl << "facet: str | None = None,";
     out << nl << "context: dict[str, str] | None = None";
     out.dec();
-    out << nl << ") -> Awaitable[" << prxName << " | None ]:";
+    out << nl << ") -> " << awaitableAlias << "[" << prxName << " | None ]:";
     out.inc();
     out << nl << "return checkedCastAsync(" << prxName << ", proxy, facet, context)";
     out.dec();
 
-    out << sp << nl << "@overload";
+    const string overloadAlias = getImportAlias(p, "typing", "overload");
+    out << sp << nl << "@" << overloadAlias;
     out << nl << "@staticmethod";
     out << nl << "def uncheckedCast(proxy: " << objectPrxAlias << ", facet: str | None = None) -> " << prxName << ":";
     out.inc();
     out << nl << "...";
     out.dec();
 
-    out << sp << nl << "@overload";
+    out << sp << nl << "@" << overloadAlias;
     out << nl << "@staticmethod";
     out << nl << "def uncheckedCast(proxy: None, facet: str | None = None) -> None:";
     out.inc();
@@ -1607,12 +1678,13 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             out << getImportAlias(p, base);
         }
     }
-    out << "ABC" << epar << ':';
+    out << getImportAlias(p, "abc", "ABC") << epar << ':';
     out.inc();
 
     out << sp;
     // Declare _ice_ids class variable to hold the ice_ids.
-    out << nl << "_ice_ids: Sequence[str] = (";
+    const string sequenceAlias = getImportAlias(p, "collections.abc", "Sequence");
+    out << nl << "_ice_ids: " << sequenceAlias << "[str] = (";
     auto ids = p->ids();
     for (const auto& id : ids)
     {
@@ -1793,6 +1865,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     out << sp;
     out << nl << "__all__ = [\"" << className << "\", \"" << prxName << "\", \"" << metaType << "\"]";
+    out << nl;
 
     _codeFragments.push_back(createCodeFragmentForPythonModule(p, out.str()));
     return false;
@@ -1811,6 +1884,7 @@ Slice::Python::CodeVisitor::visitSequence(const SequencePtr& p)
 
     out << sp;
     out << nl << "__all__ = [\"" << metaType << "\"]";
+    out << nl;
 
     _codeFragments.push_back(createCodeFragmentForPythonModule(p, out.str()));
 }
@@ -1826,6 +1900,7 @@ Slice::Python::CodeVisitor::visitDictionary(const DictionaryPtr& p)
 
     out << sp;
     out << nl << "__all__ = [\"" << metaType << "\"]";
+    out << nl;
 
     _codeFragments.push_back(createCodeFragmentForPythonModule(p, out.str()));
 }
@@ -1839,7 +1914,7 @@ Slice::Python::CodeVisitor::visitEnum(const EnumPtr& p)
     EnumeratorList enumerators = p->enumerators();
 
     BufferedOutput out;
-    out << nl << "class " << name << "(Enum):";
+    out << nl << "class " << name << "(" << getImportAlias(p, "enum", "Enum") << "):";
     out.inc();
 
     writeDocstring(p->docComment(), p, out);
@@ -1874,6 +1949,7 @@ Slice::Python::CodeVisitor::visitEnum(const EnumPtr& p)
 
     out << sp;
     out << nl << "__all__ = [\"" << name << "\", \"" << metaType << "\"]";
+    out << nl;
 
     _codeFragments.push_back(createCodeFragmentForPythonModule(p, out.str()));
 }
@@ -1889,6 +1965,7 @@ Slice::Python::CodeVisitor::visitConst(const ConstPtr& p)
 
     out << sp;
     out << nl << "__all__ = [\"" << name << "\"]";
+    out << nl;
 
     _codeFragments.push_back(createCodeFragmentForPythonModule(p, out.str()));
 }
@@ -2479,12 +2556,26 @@ namespace
         set<string> allImports;
 
         // Write the runtime imports.
-        for (const auto& [moduleName, definitions] : runtimeImports)
+        for (const auto& [moduleName, moduleImports] : runtimeImports)
         {
             out << sp;
-            if (!definitions.empty())
+            if (moduleImports.imported)
             {
-                for (const auto& [name, alias] : definitions)
+                out << nl << "import " << moduleName;
+                if (moduleImports.moduleAlias.empty())
+                {
+                    allImports.insert(moduleName);
+                }
+                else
+                {
+                    out << " as " << moduleImports.moduleAlias;
+                    allImports.insert(moduleImports.moduleAlias);
+                }
+            }
+
+            if (!moduleImports.definitions.empty())
+            {
+                for (const auto& [name, alias] : moduleImports.definitions)
                 {
                     out << nl << "from " << moduleName << " import " << name;
                     if (!alias.empty())
@@ -2498,12 +2589,6 @@ namespace
                     }
                 }
             }
-            else
-            {
-                // If there are no definitions, we just import the module.
-                out << nl << "import " << moduleName;
-                allImports.insert(moduleName);
-            }
         }
 
         // Write typing imports
@@ -2514,11 +2599,26 @@ namespace
             outT << nl << "if TYPE_CHECKING:";
             outT.inc();
             bool hasTypingImports = false;
-            for (const auto& [moduleName, definitions] : typingImports)
+            for (const auto& [moduleName, moduleImports] : typingImports)
             {
-                if (!definitions.empty())
+                if (moduleImports.imported)
                 {
-                    for (const auto& [name, alias] : definitions)
+                    out << nl << "import " << moduleName;
+                    if (moduleImports.moduleAlias.empty())
+                    {
+                        allImports.insert(moduleName);
+                    }
+                    else
+                    {
+                        out << " as " << moduleImports.moduleAlias;
+                        allImports.insert(moduleImports.moduleAlias);
+                    }
+                    hasTypingImports = true;
+                }
+
+                if (!moduleImports.definitions.empty())
+                {
+                    for (const auto& [name, alias] : moduleImports.definitions)
                     {
                         bool allreadyImported = !allImports.insert(alias.empty() ? name : alias).second;
 
@@ -2534,14 +2634,6 @@ namespace
                         }
                         hasTypingImports = true;
                     }
-                }
-                else
-                {
-                    // If there are no definitions, we still need to import the module to ensure that the type hints
-                    // are available.
-                    outT << nl << "import " << moduleName;
-                    allImports.insert(moduleName);
-                    hasTypingImports = true;
                 }
             }
             outT.dec();

--- a/cpp/src/slice2py/PythonUtil.h
+++ b/cpp/src/slice2py/PythonUtil.h
@@ -32,26 +32,41 @@ namespace Slice::Python
     };
 
     // The context a type will be used in.
-    enum class TypeContext
+    enum class InterfaceTypeContext
     {
         // If the type is an interface, it is used as a servant (base type).
         Servant,
         // If the type is an interface, it is used as a proxy (base type or parameter).
         Proxy,
-        // A field of a class or struct
-        Field,
-        // A parameter
-        Parameter,
-        // A return type or out parameter
-        Return
+    };
+
+    /// Represents the set of symbols imported from a given Python module.
+    ///
+    /// This includes whether the module itself is imported (possibly with an alias)
+    /// and the set of specific definitions (with optional aliases) imported from that module.
+    struct ModuleImports
+    {
+        /// The name of the module being imported.
+        std::string moduleName;
+
+        /// The alias used for the module import if not empty and `imported` is true.
+        /// For example, for `import Foo as _m_Bar_Foo`, the alias is "_m_Bar_Foo".
+        std::string moduleAlias;
+
+        /// Indicates whether the module itself must be imported.
+        /// If true, the module will be imported as `import <moduleName>` or
+        /// `import <moduleName> as <moduleAlias>`, depending on whether `moduleAlias` is empty.
+        bool imported = false;
+
+        /// The set of definitions (with optional aliases) imported from the module.
+        /// Each pair consists of the definition name and its alias (the alias may be empty).
+        std::set<std::pair<std::string, std::string>> definitions;
     };
 
     /// A map with the import statements for a generated Python module.
     /// - Key: the imported module name, e.g., "Ice.Communicator".
-    /// - Value: a set of pairs representing the imported name and its alias. The first element of the pair is the
-    ///   imported name, and the second element is the alias used in the generated code. When the alias is empty,
-    ///   the imported name is used directly.
-    using ModuleImportsMap = std::map<std::string, std::set<std::pair<std::string, std::string>>>;
+    /// - Value: the module imports object, representing the definitions imported from the module.
+    using ModuleImportsMap = std::map<std::string, ModuleImports>;
 
     // Maps import statements per generated Python module.
     // - Key: the generated module name, e.g., "Ice.Locator_ice" (we generate one Python module per each unique Slice
@@ -290,13 +305,12 @@ namespace Slice::Python
         void addRuntimeImport(
             const SyntaxTreeBasePtr& definition,
             const ContainedPtr& source,
-            TypeContext typeContext = TypeContext::Proxy);
+            InterfaceTypeContext typeContext = InterfaceTypeContext::Proxy);
 
         /// Adds a runtime import for the given definition from the specified Python module.
         ///
         /// @param moduleName The fully qualified name of the Python module to import from.
-        /// @param definition A pair consisting of the name and alias to use for the imported symbol.
-        ///                   If the alias is empty, the name is used as the alias.
+        /// @param definition The definition to import.
         /// @param source The Slice definition that requires this import.
         void addRuntimeImport(const std::string& moduleName, const std::string& definition, const ContainedPtr& source);
 
@@ -428,7 +442,8 @@ namespace Slice::Python
         void writeDocstring(const OperationPtr&, MethodKind, IceInternal::Output&);
 
         std::string getImportAlias(const ContainedPtr& source, const SyntaxTreeBasePtr& definition);
-        std::string getImportAlias(const ContainedPtr& source, const std::string& moduleName, const std::string& name);
+        std::string
+        getImportAlias(const ContainedPtr& source, const std::string& moduleName, const std::string& name = "");
 
         // The list of generated Python code fragments in the current translation unit.
         // Each fragment corresponds to a Python module generated from a Slice definition with the same name.

--- a/python/test/Slice/escape/Clash.ice
+++ b/python/test/Slice/escape/Clash.ice
@@ -3,6 +3,8 @@
 ["python:identifier:generated.test.Slice.escape.Test"]
 module Test
 {
+    class field;
+
     interface Intf
     {
         void context();
@@ -21,6 +23,7 @@ module Test
         void opOut(out string context, out string current, out string response, out string ex,
             out string sent, out string cookie, out string sync, out string result, out string istr,
             out string ostr, out optional(1) string proxy);
+        void opField(field name, field value);
     }
 
     class Cls
@@ -55,5 +58,24 @@ module Test
     {
         short istr;
         int ostr;
+    }
+
+    class field
+    {
+        St name;
+        St value;
+    }
+
+    sequence<int> IntSeq;
+
+    interface Sequence
+    {
+        void sendIntSeq(IntSeq seq);
+        void abstractmethod();
+    }
+
+    interface Awaitable
+    {
+        void op();
     }
 }

--- a/python/test/Slice/escape/Client.py
+++ b/python/test/Slice/escape/Client.py
@@ -10,6 +10,8 @@ if "--load-slice" in sys.argv:
     TestHelper.loadSlice("Key.ice Clash.ice")
 
 from generated.test.Slice.escape.Test import escaped_and
+from generated.test.Slice.escape.Test import Sequence, SequencePrx
+from collections.abc import Sequence as SequenceABC
 
 import Ice
 
@@ -32,6 +34,14 @@ class ifI(escaped_and._if):
         pass
 
     def _raise(self, _else, _return, _while, _yield, _or, _global):
+        pass
+
+class SequenceI(Sequence):
+
+    def sendIntSeq(self, seq: list[int], current: Ice.Current):
+        pass
+
+    def abstractmethod(self, current: Ice.Current):
         pass
 
 
@@ -77,12 +87,16 @@ class Client(TestHelper):
             communicator.getProperties().setProperty("TestAdapter.Endpoints", self.getTestEndpoint())
             adapter = communicator.createObjectAdapter("TestAdapter")
             adapter.add(execI(), Ice.stringToIdentity("test"))
+            adapter.add(SequenceI(), Ice.stringToIdentity("sequence"))
             adapter.activate()
 
             sys.stdout.write("Testing operation name... ")
             sys.stdout.flush()
             p = escaped_and._execPrx.uncheckedCast(adapter.createProxy(Ice.stringToIdentity("test")))
             p._finally()
+
+            p = SequencePrx.uncheckedCast(adapter.createProxy(Ice.stringToIdentity("sequence")))
+            p.abstractmethod()
             print("ok")
 
             testtypes()

--- a/python/test/Slice/escape/Client.py
+++ b/python/test/Slice/escape/Client.py
@@ -9,9 +9,7 @@ from TestHelper import TestHelper
 if "--load-slice" in sys.argv:
     TestHelper.loadSlice("Key.ice Clash.ice")
 
-from generated.test.Slice.escape.Test import escaped_and
-from generated.test.Slice.escape.Test import Sequence, SequencePrx
-from collections.abc import Sequence as SequenceABC
+from generated.test.Slice.escape.Test import Sequence, SequencePrx, escaped_and
 
 import Ice
 

--- a/python/test/Slice/escape/Client.py
+++ b/python/test/Slice/escape/Client.py
@@ -34,8 +34,8 @@ class ifI(escaped_and._if):
     def _raise(self, _else, _return, _while, _yield, _or, _global):
         pass
 
-class SequenceI(Sequence):
 
+class SequenceI(Sequence):
     def sendIntSeq(self, seq: list[int], current: Ice.Current):
         pass
 


### PR DESCRIPTION
This PR rework the Python import statement generation, to better handle `import xxx` style.

It also updates the code to use appropriate alias to import the non built-in types we depend on like "dataclass", "field", "Sequence", "Awaitable", and a few others.