### PR TITLE
Make javabean field private

### DIFF
--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -3380,7 +3380,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
         out << nl << "@Deprecated";
     }
 
-    if (isOptional)
+    if (getSet || isOptional)
     {
         out << nl << "private " << s << ' ' << name << ';';
     }


### PR DESCRIPTION
This PR updates the JavaBean-style mapping field to be private, just like for optional fields.