### PR TITLE
Fix missing MarshaledResult record in C#

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -2207,7 +2207,7 @@ namespace
         {
             for (const auto& op : interface->operations())
             {
-                if (op->returnsMultipleValues())
+                if (op->returnsMultipleValues() || op->hasMarshaledResult())
                 {
                     return true;
                 }


### PR DESCRIPTION
This PR fixes slice2cs to generate the MarshaledResult record struct in simple Slice files.