### PR TITLE
Do not reuse adapter IDs in IceDiscovery tests

### DIFF
--- a/cpp/test/IceDiscovery/simple/AllTests.cpp
+++ b/cpp/test/IceDiscovery/simple/AllTests.cpp
@@ -51,18 +51,18 @@ allTests(Test::TestHelper* helper, int num)
     {
         try
         {
-            ObjectPrx(communicator, "object @ oa1")->ice_ping();
+            ObjectPrx(communicator, "object @ oa10")->ice_ping();
             test(false);
         }
         catch (const Ice::NoEndpointException&)
         {
         }
 
-        proxies[0]->activateObjectAdapter("oa", "oa1", "");
+        proxies[0]->activateObjectAdapter("oa", "oa10", "");
 
         try
         {
-            ObjectPrx(communicator, "object @ oa1")->ice_ping();
+            ObjectPrx(communicator, "object @ oa10")->ice_ping();
             test(false);
         }
         catch (const Ice::ObjectNotExistException&)
@@ -73,7 +73,7 @@ allTests(Test::TestHelper* helper, int num)
 
         try
         {
-            ObjectPrx(communicator, "object @ oa1")->ice_ping();
+            ObjectPrx(communicator, "object @ oa10")->ice_ping();
             test(false);
         }
         catch (const Ice::NoEndpointException&)
@@ -84,15 +84,15 @@ allTests(Test::TestHelper* helper, int num)
 
     cout << "testing object adapter migration..." << flush;
     {
-        proxies[0]->activateObjectAdapter("oa", "oa1", "");
+        proxies[0]->activateObjectAdapter("oa", "oa20", "");
         proxies[0]->addObject("oa", "object");
-        ObjectPrx(communicator, "object @ oa1")->ice_ping();
+        ObjectPrx(communicator, "object @ oa20")->ice_ping();
         proxies[0]->removeObject("oa", "object");
         proxies[0]->deactivateObjectAdapter("oa");
 
-        proxies[1]->activateObjectAdapter("oa", "oa1", "");
+        proxies[1]->activateObjectAdapter("oa", "oa20", "");
         proxies[1]->addObject("oa", "object");
-        ObjectPrx(communicator, "object @ oa1")->ice_ping();
+        ObjectPrx(communicator, "object @ oa20")->ice_ping();
         proxies[1]->removeObject("oa", "object");
         proxies[1]->deactivateObjectAdapter("oa");
     }
@@ -100,29 +100,29 @@ allTests(Test::TestHelper* helper, int num)
 
     cout << "testing object migration..." << flush;
     {
-        proxies[0]->activateObjectAdapter("oa", "oa1", "");
-        proxies[1]->activateObjectAdapter("oa", "oa2", "");
+        proxies[0]->activateObjectAdapter("oa", "oa31", "");
+        proxies[1]->activateObjectAdapter("oa", "oa32", "");
 
         proxies[0]->addObject("oa", "object");
-        ObjectPrx(communicator, "object @ oa1")->ice_ping();
+        ObjectPrx(communicator, "object @ oa31")->ice_ping();
         ObjectPrx(communicator, "object")->ice_ping();
         proxies[0]->removeObject("oa", "object");
 
         proxies[1]->addObject("oa", "object");
-        ObjectPrx(communicator, "object @ oa2")->ice_ping();
+        ObjectPrx(communicator, "object @ oa32")->ice_ping();
         ObjectPrx(communicator, "object")->ice_ping();
         proxies[1]->removeObject("oa", "object");
 
         try
         {
-            ObjectPrx(communicator, "object @ oa1")->ice_ping();
+            ObjectPrx(communicator, "object @ oa31")->ice_ping();
         }
         catch (const Ice::ObjectNotExistException&)
         {
         }
         try
         {
-            ObjectPrx(communicator, "object @ oa2")->ice_ping();
+            ObjectPrx(communicator, "object @ oa32")->ice_ping();
         }
         catch (const Ice::ObjectNotExistException&)
         {
@@ -135,24 +135,24 @@ allTests(Test::TestHelper* helper, int num)
 
     cout << "testing replica groups..." << flush;
     {
-        proxies[0]->activateObjectAdapter("oa", "oa1", "rg");
-        proxies[1]->activateObjectAdapter("oa", "oa2", "rg");
-        proxies[2]->activateObjectAdapter("oa", "oa3", "rg");
+        proxies[0]->activateObjectAdapter("oa", "oa41", "rg");
+        proxies[1]->activateObjectAdapter("oa", "oa42", "rg");
+        proxies[2]->activateObjectAdapter("oa", "oa43", "rg");
 
         proxies[0]->addObject("oa", "object");
         proxies[1]->addObject("oa", "object");
         proxies[2]->addObject("oa", "object");
 
-        ObjectPrx(communicator, "object @ oa1")->ice_ping();
-        ObjectPrx(communicator, "object @ oa2")->ice_ping();
-        ObjectPrx(communicator, "object @ oa3")->ice_ping();
+        ObjectPrx(communicator, "object @ oa41")->ice_ping();
+        ObjectPrx(communicator, "object @ oa42")->ice_ping();
+        ObjectPrx(communicator, "object @ oa43")->ice_ping();
 
         ObjectPrx(communicator, "object @ rg")->ice_ping();
 
         set<string> adapterIds;
-        adapterIds.insert("oa1");
-        adapterIds.insert("oa2");
-        adapterIds.insert("oa3");
+        adapterIds.insert("oa41");
+        adapterIds.insert("oa42");
+        adapterIds.insert("oa43");
         TestIntfPrx intf(communicator, "object");
         intf = intf->ice_connectionCached(false)->ice_locatorCacheTimeout(0);
         while (!adapterIds.empty())
@@ -162,9 +162,9 @@ allTests(Test::TestHelper* helper, int num)
 
         while (true)
         {
-            adapterIds.insert("oa1");
-            adapterIds.insert("oa2");
-            adapterIds.insert("oa3");
+            adapterIds.insert("oa41");
+            adapterIds.insert("oa42");
+            adapterIds.insert("oa43");
             intf = TestIntfPrx(communicator, "object @ rg")->ice_connectionCached(false);
             int nRetry = 100;
             while (!adapterIds.empty() && --nRetry > 0)
@@ -182,12 +182,12 @@ allTests(Test::TestHelper* helper, int num)
 
         proxies[0]->deactivateObjectAdapter("oa");
         proxies[1]->deactivateObjectAdapter("oa");
-        test(TestIntfPrx(communicator, "object @ rg")->getAdapterId() == "oa3");
+        test(TestIntfPrx(communicator, "object @ rg")->getAdapterId() == "oa43");
         proxies[2]->deactivateObjectAdapter("oa");
 
-        proxies[0]->activateObjectAdapter("oa", "oa1", "rg");
+        proxies[0]->activateObjectAdapter("oa", "oa41", "rg");
         proxies[0]->addObject("oa", "object");
-        test(TestIntfPrx(communicator, "object @ rg")->getAdapterId() == "oa1");
+        test(TestIntfPrx(communicator, "object @ rg")->getAdapterId() == "oa41");
         proxies[0]->deactivateObjectAdapter("oa");
     }
     cout << "ok" << endl;

--- a/csharp/test/IceDiscovery/simple/AllTests.cs
+++ b/csharp/test/IceDiscovery/simple/AllTests.cs
@@ -14,8 +14,8 @@ public class AllTests : Test.AllTests
         for (int i = 0; i < num; ++i)
         {
             string id = "controller" + i;
-            proxies.Add(ControllerPrxHelper.uncheckedCast(communicator.stringToProxy(id)));
-            indirectProxies.Add(ControllerPrxHelper.uncheckedCast(communicator.stringToProxy(id + "@control" + i)));
+            proxies.Add(ControllerPrxHelper.createProxy(communicator, id));
+            indirectProxies.Add(ControllerPrxHelper.createProxy(communicator, id + "@control" + i));
         }
 
         output.Write("testing indirect proxies... ");
@@ -43,18 +43,18 @@ public class AllTests : Test.AllTests
         {
             try
             {
-                communicator.stringToProxy("object @ oa1").ice_ping();
+                communicator.stringToProxy("object @ oa10").ice_ping();
                 test(false);
             }
             catch (Ice.NoEndpointException)
             {
             }
 
-            proxies[0].activateObjectAdapter("oa", "oa1", "");
+            proxies[0].activateObjectAdapter("oa", "oa10", "");
 
             try
             {
-                communicator.stringToProxy("object @ oa1").ice_ping();
+                communicator.stringToProxy("object @ oa10").ice_ping();
                 test(false);
             }
             catch (Ice.ObjectNotExistException)
@@ -65,7 +65,7 @@ public class AllTests : Test.AllTests
 
             try
             {
-                communicator.stringToProxy("object @ oa1").ice_ping();
+                communicator.stringToProxy("object @ oa10").ice_ping();
                 test(false);
             }
             catch (Ice.NoEndpointException)
@@ -77,15 +77,15 @@ public class AllTests : Test.AllTests
         output.Write("testing object adapter migration...");
         output.Flush();
         {
-            proxies[0].activateObjectAdapter("oa", "oa1", "");
+            proxies[0].activateObjectAdapter("oa", "oa21", "");
             proxies[0].addObject("oa", "object");
-            communicator.stringToProxy("object @ oa1").ice_ping();
+            communicator.stringToProxy("object @ oa21").ice_ping();
             proxies[0].removeObject("oa", "object");
             proxies[0].deactivateObjectAdapter("oa");
 
-            proxies[1].activateObjectAdapter("oa", "oa1", "");
+            proxies[1].activateObjectAdapter("oa", "oa21", "");
             proxies[1].addObject("oa", "object");
-            communicator.stringToProxy("object @ oa1").ice_ping();
+            communicator.stringToProxy("object @ oa21").ice_ping();
             proxies[1].removeObject("oa", "object");
             proxies[1].deactivateObjectAdapter("oa");
         }
@@ -94,29 +94,29 @@ public class AllTests : Test.AllTests
         output.Write("testing object migration...");
         output.Flush();
         {
-            proxies[0].activateObjectAdapter("oa", "oa1", "");
-            proxies[1].activateObjectAdapter("oa", "oa2", "");
+            proxies[0].activateObjectAdapter("oa", "oa31", "");
+            proxies[1].activateObjectAdapter("oa", "oa32", "");
 
             proxies[0].addObject("oa", "object");
-            communicator.stringToProxy("object @ oa1").ice_ping();
+            communicator.stringToProxy("object @ oa31").ice_ping();
             communicator.stringToProxy("object").ice_ping();
             proxies[0].removeObject("oa", "object");
 
             proxies[1].addObject("oa", "object");
-            communicator.stringToProxy("object @ oa2").ice_ping();
+            communicator.stringToProxy("object @ oa32").ice_ping();
             communicator.stringToProxy("object").ice_ping();
             proxies[1].removeObject("oa", "object");
 
             try
             {
-                communicator.stringToProxy("object @ oa1").ice_ping();
+                communicator.stringToProxy("object @ oa31").ice_ping();
             }
             catch (Ice.ObjectNotExistException)
             {
             }
             try
             {
-                communicator.stringToProxy("object @ oa2").ice_ping();
+                communicator.stringToProxy("object @ oa32").ice_ping();
             }
             catch (Ice.ObjectNotExistException)
             {
@@ -130,25 +130,25 @@ public class AllTests : Test.AllTests
         output.Write("testing replica groups...");
         output.Flush();
         {
-            proxies[0].activateObjectAdapter("oa", "oa1", "rg");
-            proxies[1].activateObjectAdapter("oa", "oa2", "rg");
-            proxies[2].activateObjectAdapter("oa", "oa3", "rg");
+            proxies[0].activateObjectAdapter("oa", "oa41", "rg");
+            proxies[1].activateObjectAdapter("oa", "oa42", "rg");
+            proxies[2].activateObjectAdapter("oa", "oa43", "rg");
 
             proxies[0].addObject("oa", "object");
             proxies[1].addObject("oa", "object");
             proxies[2].addObject("oa", "object");
 
-            communicator.stringToProxy("object @ oa1").ice_ping();
-            communicator.stringToProxy("object @ oa2").ice_ping();
-            communicator.stringToProxy("object @ oa3").ice_ping();
+            communicator.stringToProxy("object @ oa41").ice_ping();
+            communicator.stringToProxy("object @ oa42").ice_ping();
+            communicator.stringToProxy("object @ oa43").ice_ping();
 
             communicator.stringToProxy("object @ rg").ice_ping();
 
             var adapterIds = new List<string>
             {
-                "oa1",
-                "oa2",
-                "oa3"
+                "oa41",
+                "oa42",
+                "oa43"
             };
             TestIntfPrx intf = TestIntfPrxHelper.uncheckedCast(communicator.stringToProxy("object"));
             intf = (TestIntfPrx)intf.ice_connectionCached(false).ice_locatorCacheTimeout(0);
@@ -159,9 +159,9 @@ public class AllTests : Test.AllTests
 
             while (true)
             {
-                adapterIds.Add("oa1");
-                adapterIds.Add("oa2");
-                adapterIds.Add("oa3");
+                adapterIds.Add("oa41");
+                adapterIds.Add("oa42");
+                adapterIds.Add("oa43");
                 intf = TestIntfPrxHelper.uncheckedCast(
                     communicator.stringToProxy("object @ rg").ice_connectionCached(false));
                 int nRetry = 100;
@@ -181,13 +181,13 @@ public class AllTests : Test.AllTests
             proxies[0].deactivateObjectAdapter("oa");
             proxies[1].deactivateObjectAdapter("oa");
             test(TestIntfPrxHelper.uncheckedCast(
-                     communicator.stringToProxy("object @ rg")).getAdapterId() == "oa3");
+                     communicator.stringToProxy("object @ rg")).getAdapterId() == "oa43");
             proxies[2].deactivateObjectAdapter("oa");
 
-            proxies[0].activateObjectAdapter("oa", "oa1", "rg");
+            proxies[0].activateObjectAdapter("oa", "oa41", "rg");
             proxies[0].addObject("oa", "object");
             test(TestIntfPrxHelper.uncheckedCast(
-                     communicator.stringToProxy("object @ rg")).getAdapterId() == "oa1");
+                     communicator.stringToProxy("object @ rg")).getAdapterId() == "oa41");
             proxies[0].deactivateObjectAdapter("oa");
         }
         output.WriteLine("ok");

--- a/java/test/src/main/java/test/IceDiscovery/simple/AllTests.java
+++ b/java/test/src/main/java/test/IceDiscovery/simple/AllTests.java
@@ -58,21 +58,21 @@ public class AllTests {
         System.out.flush();
         {
             try {
-                communicator.stringToProxy("object @ oa1").ice_ping();
+                communicator.stringToProxy("object @ oa10").ice_ping();
                 test(false);
             } catch (NoEndpointException ex) {}
 
-            proxies.get(0).activateObjectAdapter("oa", "oa1", "");
+            proxies.get(0).activateObjectAdapter("oa", "oa10", "");
 
             try {
-                communicator.stringToProxy("object @ oa1").ice_ping();
+                communicator.stringToProxy("object @ oa10").ice_ping();
                 test(false);
             } catch (ObjectNotExistException ex) {}
 
             proxies.get(0).deactivateObjectAdapter("oa");
 
             try {
-                communicator.stringToProxy("object @ oa1").ice_ping();
+                communicator.stringToProxy("object @ oa10").ice_ping();
                 test(false);
             } catch (NoEndpointException ex) {}
         }
@@ -81,15 +81,15 @@ public class AllTests {
         System.out.print("testing object adapter migration...");
         System.out.flush();
         {
-            proxies.get(0).activateObjectAdapter("oa", "oa1", "");
+            proxies.get(0).activateObjectAdapter("oa", "oa21", "");
             proxies.get(0).addObject("oa", "object");
-            communicator.stringToProxy("object @ oa1").ice_ping();
+            communicator.stringToProxy("object @ oa21").ice_ping();
             proxies.get(0).removeObject("oa", "object");
             proxies.get(0).deactivateObjectAdapter("oa");
 
-            proxies.get(1).activateObjectAdapter("oa", "oa1", "");
+            proxies.get(1).activateObjectAdapter("oa", "oa21", "");
             proxies.get(1).addObject("oa", "object");
-            communicator.stringToProxy("object @ oa1").ice_ping();
+            communicator.stringToProxy("object @ oa21").ice_ping();
             proxies.get(1).removeObject("oa", "object");
             proxies.get(1).deactivateObjectAdapter("oa");
         }
@@ -98,24 +98,24 @@ public class AllTests {
         System.out.print("testing object migration...");
         System.out.flush();
         {
-            proxies.get(0).activateObjectAdapter("oa", "oa1", "");
-            proxies.get(1).activateObjectAdapter("oa", "oa2", "");
+            proxies.get(0).activateObjectAdapter("oa", "oa31", "");
+            proxies.get(1).activateObjectAdapter("oa", "oa32", "");
 
             proxies.get(0).addObject("oa", "object");
-            communicator.stringToProxy("object @ oa1").ice_ping();
+            communicator.stringToProxy("object @ oa31").ice_ping();
             communicator.stringToProxy("object").ice_ping();
             proxies.get(0).removeObject("oa", "object");
 
             proxies.get(1).addObject("oa", "object");
-            communicator.stringToProxy("object @ oa2").ice_ping();
+            communicator.stringToProxy("object @ oa32").ice_ping();
             communicator.stringToProxy("object").ice_ping();
             proxies.get(1).removeObject("oa", "object");
 
             try {
-                communicator.stringToProxy("object @ oa1").ice_ping();
+                communicator.stringToProxy("object @ oa31").ice_ping();
             } catch (ObjectNotExistException ex) {}
             try {
-                communicator.stringToProxy("object @ oa2").ice_ping();
+                communicator.stringToProxy("object @ oa32").ice_ping();
             } catch (ObjectNotExistException ex) {}
 
             proxies.get(0).deactivateObjectAdapter("oa");
@@ -126,24 +126,24 @@ public class AllTests {
         System.out.print("testing replica groups...");
         System.out.flush();
         {
-            proxies.get(0).activateObjectAdapter("oa", "oa1", "rg");
-            proxies.get(1).activateObjectAdapter("oa", "oa2", "rg");
-            proxies.get(2).activateObjectAdapter("oa", "oa3", "rg");
+            proxies.get(0).activateObjectAdapter("oa", "oa41", "rg");
+            proxies.get(1).activateObjectAdapter("oa", "oa42", "rg");
+            proxies.get(2).activateObjectAdapter("oa", "oa43", "rg");
 
             proxies.get(0).addObject("oa", "object");
             proxies.get(1).addObject("oa", "object");
             proxies.get(2).addObject("oa", "object");
 
-            communicator.stringToProxy("object @ oa1").ice_ping();
-            communicator.stringToProxy("object @ oa2").ice_ping();
-            communicator.stringToProxy("object @ oa3").ice_ping();
+            communicator.stringToProxy("object @ oa41").ice_ping();
+            communicator.stringToProxy("object @ oa42").ice_ping();
+            communicator.stringToProxy("object @ oa43").ice_ping();
 
             communicator.stringToProxy("object @ rg").ice_ping();
 
             Set<String> adapterIds = new HashSet<>();
-            adapterIds.add("oa1");
-            adapterIds.add("oa2");
-            adapterIds.add("oa3");
+            adapterIds.add("oa41");
+            adapterIds.add("oa42");
+            adapterIds.add("oa43");
             var intf = TestIntfPrx.createProxy(communicator, "object");
             intf = intf.ice_connectionCached(false).ice_locatorCacheTimeout(0);
             while (!adapterIds.isEmpty()) {
@@ -151,9 +151,9 @@ public class AllTests {
             }
 
             while (true) {
-                adapterIds.add("oa1");
-                adapterIds.add("oa2");
-                adapterIds.add("oa3");
+                adapterIds.add("oa41");
+                adapterIds.add("oa42");
+                adapterIds.add("oa43");
                 intf =
                     TestIntfPrx.createProxy(communicator, "object @ rg")
                         .ice_connectionCached(false);
@@ -171,12 +171,12 @@ public class AllTests {
 
             proxies.get(0).deactivateObjectAdapter("oa");
             proxies.get(1).deactivateObjectAdapter("oa");
-            test("oa3".equals(TestIntfPrx.createProxy(communicator, "object @ rg").getAdapterId()));
+            test("oa43".equals(TestIntfPrx.createProxy(communicator, "object @ rg").getAdapterId()));
             proxies.get(2).deactivateObjectAdapter("oa");
 
-            proxies.get(0).activateObjectAdapter("oa", "oa1", "rg");
+            proxies.get(0).activateObjectAdapter("oa", "oa41", "rg");
             proxies.get(0).addObject("oa", "object");
-            test("oa1".equals(TestIntfPrx.createProxy(communicator, "object @ rg").getAdapterId()));
+            test("oa41".equals(TestIntfPrx.createProxy(communicator, "object @ rg").getAdapterId()));
             proxies.get(0).deactivateObjectAdapter("oa");
         }
         System.out.println("ok");


### PR DESCRIPTION
Fix #4256 