### PR TITLE
Disable colloc optimization for datagram endpoints

### DIFF
--- a/CHANGELOG-3.8.md
+++ b/CHANGELOG-3.8.md
@@ -307,6 +307,9 @@ classDiagram
 
 - Removed the `stringToIdentity` method from the Communicator class. This method was deprecated in Ice 3.7.
 
+- The collocation optimization check no longer takes datagram endpoints into account. As a result, a call to a proxy
+  with only UDP endpoints is never collocation-optimized.
+
 ## Slice Language Changes
 
 - Removed local Slice. `local` is no longer a Slice keyword.

--- a/CHANGELOG-3.8.md
+++ b/CHANGELOG-3.8.md
@@ -308,7 +308,9 @@ classDiagram
 - Removed the `stringToIdentity` method from the Communicator class. This method was deprecated in Ice 3.7.
 
 - The collocation optimization check no longer takes datagram endpoints into account. As a result, a call to a proxy
-  with only UDP endpoints is never collocation-optimized.
+  with only UDP endpoints is never collocation-optimized. This change is particularly useful for multicast UDP
+  endpoints (and by extension proxies), since multiple object adapters often listen on the same multicast address/port
+  combination.
 
 ## Slice Language Changes
 

--- a/cpp/src/DataStorm/Instance.cpp
+++ b/cpp/src/DataStorm/Instance.cpp
@@ -130,7 +130,7 @@ Instance::init()
             // propertyToProxy only returns a nullopt proxy when the property is empty.
             lookup = *_communicator->propertyToProxy<DataStormContract::LookupPrx>("DataStorm.Node.Multicast.Proxy");
         }
-        _lookup = lookup->ice_collocationOptimized(false)->ice_datagram();
+        _lookup = lookup->ice_datagram();
     }
 
     _adapter->activate();

--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -676,13 +676,18 @@ Ice::ObjectAdapterI::isLocal(const ReferencePtr& ref) const
         checkForDestruction();
 
         // Proxies which have at least one endpoint in common with the published endpoints are considered local.
+        // This check doesn't take datagram endpoints into account; this effectively disables colloc optimization
+        // for UDP.
         for (const auto& endpoint : ref->getEndpoints())
         {
-            for (const auto& publishedEndpoint : _publishedEndpoints)
+            if (!endpoint->datagram())
             {
-                if (endpoint->equivalent(publishedEndpoint))
+                for (const auto& publishedEndpoint : _publishedEndpoints)
                 {
-                    return true;
+                    if (endpoint->equivalent(publishedEndpoint))
+                    {
+                        return true;
+                    }
                 }
             }
         }

--- a/cpp/src/IceDiscovery/PluginI.cpp
+++ b/cpp/src/IceDiscovery/PluginI.cpp
@@ -116,8 +116,7 @@ PluginI::initialize()
     auto locatorRegistryPrx = _locatorAdapter->addWithUUID<Ice::LocatorRegistryPrx>(locatorRegistry);
 
     LookupPrx lookupPrx(_communicator, "IceDiscovery/Lookup -d:" + lookupEndpoints);
-    // No collocation optimization for the multicast proxy!
-    lookupPrx = lookupPrx->ice_collocationOptimized(false)->ice_router(nullopt);
+    lookupPrx = lookupPrx->ice_router(nullopt);
 
     //
     // Add lookup and lookup reply Ice objects

--- a/cpp/src/IceLocatorDiscovery/PluginI.cpp
+++ b/cpp/src/IceLocatorDiscovery/PluginI.cpp
@@ -256,8 +256,7 @@ PluginI::initialize()
     _locatorAdapter->setLocator(nullopt);
 
     LookupPrx lookupPrx(_communicator, "IceLocatorDiscovery/Lookup -d:" + lookupEndpoints);
-    // No collocation optimization for the multicast proxy!
-    lookupPrx = lookupPrx->ice_collocationOptimized(false)->ice_router(nullopt);
+    lookupPrx = lookupPrx->ice_router(nullopt);
 
     auto voidLocator = _locatorAdapter->addWithUUID<Ice::LocatorPrx>(make_shared<VoidLocatorI>());
 

--- a/cpp/src/IceStorm/Subscriber.cpp
+++ b/cpp/src/IceStorm/Subscriber.cpp
@@ -296,7 +296,7 @@ namespace
     SubscriberLink::SubscriberLink(const shared_ptr<Instance>& instance, const SubscriberRecord& rec)
         : Subscriber(instance, rec, nullopt, -1, 1),
           _obj(Ice::uncheckedCast<TopicLinkPrx>(
-              rec.obj->ice_collocationOptimized(false)->ice_invocationTimeout(instance->sendTimeout())))
+              rec.obj->ice_invocationTimeout(instance->sendTimeout())))
     {
     }
 

--- a/cpp/src/IceStorm/Subscriber.cpp
+++ b/cpp/src/IceStorm/Subscriber.cpp
@@ -295,8 +295,7 @@ namespace
 {
     SubscriberLink::SubscriberLink(const shared_ptr<Instance>& instance, const SubscriberRecord& rec)
         : Subscriber(instance, rec, nullopt, -1, 1),
-          _obj(Ice::uncheckedCast<TopicLinkPrx>(
-              rec.obj->ice_invocationTimeout(instance->sendTimeout())))
+          _obj(Ice::uncheckedCast<TopicLinkPrx>(rec.obj->ice_invocationTimeout(instance->sendTimeout())))
     {
     }
 

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -865,10 +865,12 @@ public sealed class ObjectAdapter
         else
         {
             // Proxies which have at least one endpoint in common with the published endpoints are considered local.
+            // This check doesn't take datagram endpoints into account; this effectively disables colloc optimization
+            // for UDP.
             lock (_mutex)
             {
                 checkForDestruction();
-                EndpointI[] endpoints = r.getEndpoints();
+                IEnumerable<EndpointI> endpoints = r.getEndpoints().Where(e => !e.datagram());
                 return _publishedEndpoints.Any(e => endpoints.Any(e.equivalent));
             }
         }

--- a/csharp/src/IceDiscovery/PluginI.cs
+++ b/csharp/src/IceDiscovery/PluginI.cs
@@ -88,8 +88,7 @@ public sealed class PluginI : Ice.Plugin
             _locatorAdapter.addWithUUID(locatorRegistry));
 
         Ice.ObjectPrx lookupPrx = _communicator.stringToProxy("IceDiscovery/Lookup -d:" + lookupEndpoints);
-        // No colloc optimization or router for the multicast proxy!
-        lookupPrx = lookupPrx.ice_collocationOptimized(false).ice_router(null);
+        lookupPrx = lookupPrx.ice_router(null);
 
         //
         // Add lookup and lookup reply Ice objects

--- a/csharp/src/IceLocatorDiscovery/PluginI.cs
+++ b/csharp/src/IceLocatorDiscovery/PluginI.cs
@@ -643,8 +643,7 @@ internal class PluginI : Ice.Plugin
         _locatorAdapter.setLocator(null);
 
         Ice.ObjectPrx lookupPrx = _communicator.stringToProxy("IceLocatorDiscovery/Lookup -d:" + lookupEndpoints);
-        // No colloc optimization or router for the multicast proxy!
-        lookupPrx = lookupPrx.ice_collocationOptimized(false).ice_router(null);
+        lookupPrx = lookupPrx.ice_router(null);
 
         Ice.LocatorPrx voidLo = Ice.LocatorPrxHelper.uncheckedCast(_locatorAdapter.addWithUUID(new VoidLocatorI()));
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
@@ -933,14 +933,15 @@ public final class ObjectAdapter {
             //
             return ref.getAdapterId().equals(_id) || ref.getAdapterId().equals(_replicaGroupId);
         } else {
-            // Proxies which have at least one endpoint in common with the published endpoints
-            // are considered local.
+            // Proxies which have at least one endpoint in common with the published endpoints are considered local.
+            // This check doesn't take datagram endpoints into account; this effectively disables colloc optimization
+            // for UDP.
             synchronized (this) {
                 checkForDestruction();
 
                 EndpointI[] endpoints = ref.getEndpoints();
-                return Arrays.stream(_publishedEndpoints)
-                    .anyMatch(p -> Arrays.stream(endpoints).anyMatch(p::equivalent));
+                return Arrays.stream(endpoints).filter(e -> !e.datagram())
+                    .anyMatch(p -> Arrays.stream(_publishedEndpoints).anyMatch(p::equivalent));
             }
         }
     }

--- a/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/PluginI.java
+++ b/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/PluginI.java
@@ -79,8 +79,7 @@ class PluginI implements Plugin {
 
         ObjectPrx lookupPrx =
             _communicator.stringToProxy("IceDiscovery/Lookup -d:" + lookupEndpoints);
-        // No collocation optimization for the multicast proxy!
-        lookupPrx = lookupPrx.ice_collocationOptimized(false).ice_router(null);
+        lookupPrx = lookupPrx.ice_router(null);
 
         // Add lookup and lookup reply Ice objects
         LookupI lookup =

--- a/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
+++ b/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
@@ -636,8 +636,7 @@ class PluginI implements Plugin {
 
         ObjectPrx lookupPrx =
             _communicator.stringToProxy("IceLocatorDiscovery/Lookup -d:" + lookupEndpoints);
-        // No collocation optimization or router for the multicast proxy!
-        lookupPrx = lookupPrx.ice_collocationOptimized(false).ice_router(null);
+        lookupPrx = lookupPrx.ice_router(null);
 
         LocatorPrx voidLoc =
             LocatorPrx.uncheckedCast(


### PR DESCRIPTION
This PR disables colloc optimization for datagram (UDP) endpoints. It also removes the various spot where we called `ice_collocationOptimized(false)` on multicast proxies.

Fixes #4142, indirectly.
