### PR TITLE
Fix Ice.AcceptClassCycles property

### DIFF
--- a/config/PropertyNames.xml
+++ b/config/PropertyNames.xml
@@ -61,7 +61,8 @@
     </class> -->
 
     <section name="Ice" opt-in="false">
-        <property name="AcceptClassCycles" languages="cpp,csharp,java" default="0" />
+        <!-- AcceptClassCycles is implemented in C++ and Swift. -->
+        <property name="AcceptClassCycles" languages="cpp" default="0" />
         <property name="Admin" class="ObjectAdapter" languages="cpp,csharp,java" />
         <property name="Admin.DelayCreation" languages="cpp,csharp,java" default="0" />
         <property name="Admin.Enabled" languages="cpp,csharp,java" />

--- a/csharp/src/Ice/Internal/PropertyNames.cs
+++ b/csharp/src/Ice/Internal/PropertyNames.cs
@@ -75,7 +75,6 @@ internal sealed class PropertyNames
         false,
         false,
         [
-            new(pattern: @"AcceptClassCycles", usesRegex: false, defaultValue: "0", deprecated: false, propertyArray: null),
             new(pattern: @"Admin", usesRegex: false, defaultValue: "", deprecated: false, propertyArray: ObjectAdapterProps),
             new(pattern: @"Admin.DelayCreation", usesRegex: false, defaultValue: "0", deprecated: false, propertyArray: null),
             new(pattern: @"Admin.Enabled", usesRegex: false, defaultValue: "", deprecated: false, propertyArray: null),

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PropertyNames.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PropertyNames.java
@@ -74,7 +74,6 @@ final class PropertyNames {
         false,
         false,
         new Property[] {
-            new Property("AcceptClassCycles", false, "0", false, null),
             new Property("Admin", false, "", false, PropertyNames.ObjectAdapterProps),
             new Property("Admin.DelayCreation", false, "0", false, null),
             new Property("Admin.Enabled", false, "", false, null),

--- a/matlab/src/Init.cpp
+++ b/matlab/src/Init.cpp
@@ -35,8 +35,7 @@ extern "C"
                 initData.properties = Ice::createProperties();
             }
 
-            // Always accept cycles in MATLAB.
-            initData.properties->setProperty("Ice.AcceptClassCycles", "1");
+            // We don't implement Ice.AcceptClassCycles in InputStream, and ignore the value of this property.
 
             // Add IceDiscovery/IceLocatorDiscovery if these plug-ins are configured via Ice.Plugin.name.
             if (!initData.properties->getIceProperty("Ice.Plugin.IceDiscovery").empty())

--- a/php/src/Communicator.cpp
+++ b/php/src/Communicator.cpp
@@ -959,7 +959,7 @@ ZEND_FUNCTION(Ice_initialize)
         initData.properties = Ice::createProperties();
     }
 
-    // Always accept cycles in PHP
+    // Always accept class cycles during the unmarshaling of PHP objects by the C++ code.
     initData.properties->setProperty("Ice.AcceptClassCycles", "1");
 
     // Add IceDiscovery/IceLocatorDiscovery if these plug-ins are configured via Ice.Plugin.name.

--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -191,7 +191,7 @@ communicatorInit(CommunicatorObject* self, PyObject* args, PyObject* /*kwds*/)
         return -1;
     }
 
-    // Always accept cycles in Python
+    // Always accept class cycles during the unmarshaling of Python objects by the C++ code.
     data.properties->setProperty("Ice.AcceptClassCycles", "1");
 
     // Add IceDiscovery/IceLocatorDiscovery if these plug-ins are configured via Ice.Plugin.name.

--- a/ruby/src/IceRuby/Communicator.cpp
+++ b/ruby/src/IceRuby/Communicator.cpp
@@ -193,7 +193,7 @@ IceRuby_initialize(int argc, VALUE* argv, VALUE /*self*/)
             data.properties = Ice::createProperties(seq, data.properties);
         }
 
-        // Always accept cycles in Ruby
+        // Always accept class cycles during the unmarshaling of Ruby objects by the C++ code.
         data.properties->setProperty("Ice.AcceptClassCycles", "1");
 
         // Add IceDiscovery/IceLocatorDiscovery if these plug-ins are configured via Ice.Plugin.name.


### PR DESCRIPTION
This property is only implemented in C++ and Swift, and we need to set it to "1" only in GCed C++-based languages that rely on the C++ InputStream for unmarshaling, namely Python, PHP and Ruby.