### PR TITLE
Don't set SO_REUSEADDR for UDP unicast

### DIFF
--- a/cpp/src/Ice/TcpAcceptor.cpp
+++ b/cpp/src/Ice/TcpAcceptor.cpp
@@ -196,18 +196,8 @@ IceInternal::TcpAcceptor::TcpAcceptor(
     setTcpBufSize(_fd, _instance);
 
 #    ifndef _WIN32
-    //
-    // Enable SO_REUSEADDR on Unix platforms to allow re-using the
-    // socket even if it's in the TIME_WAIT state. On Windows,
-    // this doesn't appear to be necessary and enabling
-    // SO_REUSEADDR would actually not be a good thing since it
-    // allows a second process to bind to an address even it's
-    // already bound by another process.
-    //
-    // TODO: using SO_EXCLUSIVEADDRUSE on Windows would probably
-    // be better but it's only supported by recent Windows
-    // versions (XP SP2, Windows Server 2003).
-    //
+    // Set SO_REUSEADDR socket option on Unix platforms to allow re-using the address even if the socket remains in
+    // the TIME_WAIT state. On Windows this isn't necessary.
     setReuseAddress(_fd, true);
 #    endif
 }

--- a/cpp/src/Ice/UdpTransceiver.cpp
+++ b/cpp/src/Ice/UdpTransceiver.cpp
@@ -80,6 +80,7 @@ IceInternal::UdpTransceiver::bind()
 {
     if (isMulticast(_addr))
     {
+        // Set SO_REUSEADDR socket option to allow multiple sockets to bind to the same multicast address.
         setReuseAddress(_fd, true);
         _mcastAddr = _addr;
 
@@ -103,21 +104,6 @@ IceInternal::UdpTransceiver::bind()
     }
     else
     {
-#ifndef _WIN32
-        //
-        // Enable SO_REUSEADDR on Unix platforms to allow re-using
-        // the socket even if it's in the TIME_WAIT state. On
-        // Windows, this doesn't appear to be necessary and
-        // enabling SO_REUSEADDR would actually not be a good
-        // thing since it allows a second process to bind to an
-        // address even it's already bound by another process.
-        //
-        // TODO: using SO_EXCLUSIVEADDRUSE on Windows would
-        // probably be better but it's only supported by recent
-        // Windows versions (XP SP2, Windows Server 2003).
-        //
-        setReuseAddress(_fd, true);
-#endif
         const_cast<Address&>(_addr) = doBind(_fd, _addr);
     }
 

--- a/cpp/src/Ice/UdpTransceiver.cpp
+++ b/cpp/src/Ice/UdpTransceiver.cpp
@@ -85,13 +85,7 @@ IceInternal::UdpTransceiver::bind()
         _mcastAddr = _addr;
 
 #ifdef _WIN32
-        //
-        // Windows does not allow binding to the mcast address itself
-        // so we bind to INADDR_ANY (0.0.0.0) instead. As a result,
-        // bi-directional connection won't work because the source
-        // address won't be the multicast address and the client will
-        // therefore reject the datagram.
-        //
+        // Windows does not allow binding to the mcast address itself so we bind to INADDR_ANY instead.
         const_cast<Address&>(_addr) = getAddressForServer("", _port, getProtocolSupport(_addr), false, false);
 #endif
 

--- a/csharp/src/Ice/Internal/UdpTransceiver.cs
+++ b/csharp/src/Ice/Internal/UdpTransceiver.cs
@@ -74,21 +74,10 @@ internal sealed class UdpTransceiver : Transceiver
             _mcastAddr = (IPEndPoint)_addr;
             if (AssemblyUtil.isWindows)
             {
-                //
-                // Windows does not allow binding to the mcast address itself
-                // so we bind to INADDR_ANY (0.0.0.0) instead. As a result,
-                // bi-directional connection won't work because the source
-                // address won't the multicast address and the client will
-                // therefore reject the datagram.
-                //
-                if (_addr.AddressFamily == AddressFamily.InterNetwork)
-                {
-                    _addr = new IPEndPoint(IPAddress.Any, _port);
-                }
-                else
-                {
-                    _addr = new IPEndPoint(IPAddress.IPv6Any, _port);
-                }
+                // Windows does not allow binding to the mcast address itself so we bind to INADDR_ANY instead.
+                _addr = new IPEndPoint(
+                    _addr.AddressFamily == AddressFamily.InterNetwork ? IPAddress.Any : IPAddress.IPv6Any,
+                    _port);
             }
 
             _addr = Network.doBind(_fd, _addr);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpAcceptor.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/TcpAcceptor.java
@@ -72,18 +72,8 @@ class TcpAcceptor implements Acceptor {
             Network.setBlock(_fd, false);
             Network.setTcpBufSize(_fd, instance);
             if (!System.getProperty("os.name").startsWith("Windows")) {
-                //
-                // Enable SO_REUSEADDR on Unix platforms to allow re-using the
-                // socket even if it's in the TIME_WAIT state. On Windows,
-                // this doesn't appear to be necessary and enabling
-                // SO_REUSEADDR would actually not be a good thing since it
-                // allows a second process to bind to an address even it's
-                // already bound by another process.
-                //
-                // TODO: using SO_EXCLUSIVEADDRUSE on Windows would probably
-                // be better but it's only supported by recent Windows
-                // versions (XP SP2, Windows Server 2003).
-                //
+                // Set SO_REUSEADDR socket option on Unix platforms to allow re-using the address even if the socket
+                // remains in the TIME_WAIT state. On Windows this isn't necessary.
                 Network.setReuseAddress(_fd, true);
             }
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpTransceiver.java
@@ -54,12 +54,7 @@ final class UdpTransceiver implements Transceiver {
             Network.setReuseAddress(_fd, true);
             _mcastAddr = _addr;
             if (System.getProperty("os.name").startsWith("Windows")) {
-                //
-                // Windows does not allow binding to the mcast address itself so we bind to
-                // INADDR_ANY (0.0.0.0) instead. As a result, bi-directional connection won't work
-                // because the source address won't be the multicast address and the client will
-                // therefore reject the datagram.
-                //
+                // Windows does not allow binding to the mcast address itself so we bind to INADDR_ANY instead.
                 int protocolSupport = Network.getProtocolSupport(_mcastAddr);
                 _addr =
                     Network.getAddressForServer(

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/UdpTransceiver.java
@@ -50,6 +50,7 @@ final class UdpTransceiver implements Transceiver {
     @Override
     public EndpointI bind() {
         if (_addr.getAddress().isMulticastAddress()) {
+            // Set SO_REUSEADDR socket option to allow multiple sockets to bind to the same multicast address.
             Network.setReuseAddress(_fd, true);
             _mcastAddr = _addr;
             if (System.getProperty("os.name").startsWith("Windows")) {
@@ -71,19 +72,6 @@ final class UdpTransceiver implements Transceiver {
             }
             Network.setMcastGroup(_fd, _mcastAddr, _mcastInterface);
         } else {
-            if (!System.getProperty("os.name").startsWith("Windows")) {
-                //
-                // Enable SO_REUSEADDR on Unix platforms to allow re-using the socket even if it's
-                // in the TIME_WAIT state. On Windows, this doesn't appear to be necessary and
-                // enabling SO_REUSEADDR would actually not be a good thing since it allows a second
-                // process to bind to an address even it's already bound by another process.
-                //
-                // TODO: using SO_EXCLUSIVEADDRUSE on Windows would probably be better but it's only
-                // supported by recent
-                // Windows versions (XP SP2, Windows Server 2003).
-                //
-                Network.setReuseAddress(_fd, true);
-            }
             _addr = Network.doBind(_fd, _addr);
         }
 


### PR DESCRIPTION
Fix #4316

This fixes the root cause of #4142, where the server was considering the reply address of the client collocated because both were using the same UDP address.