### PR TITLE
Remove colloc from client-only languages

### DIFF
--- a/config/PropertyNames.xml
+++ b/config/PropertyNames.xml
@@ -101,7 +101,7 @@
         <property name="InitPlugins" languages="cpp,csharp,java" default="1" />
         <property name="IPv4" languages="cpp,csharp,java" default="1" />
         <property name="IPv6" languages="cpp,csharp,java" default="1" />
-        <property name="LogFile" languages="cpp,csharp,java,js" />
+        <property name="LogFile" languages="all" />
         <property name="LogFile.SizeMax" languages="cpp" default="0" />
         <property name="LogStdErr.Convert" languages="cpp" default="1" />
         <property name="MessageSizeMax" languages="all" default="1024" />
@@ -116,7 +116,7 @@
         <property name="PrintAdapterReady" languages="cpp,csharp,java" />
         <property name="PrintProcessId" languages="cpp,csharp" />
         <property name="PrintStackTraces" languages="cpp" default="0" />
-        <property name="ProgramName" languages="cpp,csharp,java,js" />
+        <property name="ProgramName" languages="all" />
         <property name="RetryIntervals" languages="all" default="0" />
         <property name="ServerIdleTime" languages="cpp,csharp,java" default="0" />
         <!-- SliceLoader.NotFoundCacheSize: cpp is a stand-in for swift and matlab -->

--- a/matlab/test/Ice/proxy/AllTests.m
+++ b/matlab/test/Ice/proxy/AllTests.m
@@ -332,7 +332,6 @@ classdef AllTests
             assert(proxyProps.numEntries == 21);
 
             assert(strcmp(proxyProps('Test'), 'test -e 1.0'));
-            %assert(strcmp(proxyProps('Test.CollocationOptimized'), '1'));
             assert(strcmp(proxyProps('Test.ConnectionCached'), '1'));
             assert(strcmp(proxyProps('Test.PreferSecure'), '0'));
             assert(strcmp(proxyProps('Test.EndpointSelection'), 'Ordered'));
@@ -340,7 +339,6 @@ classdef AllTests
             assert(strcmp(proxyProps('Test.InvocationTimeout'), '1234'));
 
             assert(strcmp(proxyProps('Test.Locator'), 'locator'));
-            %assert(strcmp(proxyProps('Test.Locator.CollocationOptimized'), '1'));
             assert(strcmp(proxyProps('Test.Locator.ConnectionCached'), '0'));
             assert(strcmp(proxyProps('Test.Locator.PreferSecure'), '1'));
             assert(strcmp(proxyProps('Test.Locator.EndpointSelection'), 'Random'));
@@ -348,7 +346,6 @@ classdef AllTests
             assert(strcmp(proxyProps('Test.Locator.InvocationTimeout'), '1500'));
 
             assert(strcmp(proxyProps('Test.Locator.Router'), 'router'));
-            %assert(strcmp(proxyProps('Test.Locator.Router.CollocationOptimized'), '0'));
             assert(strcmp(proxyProps('Test.Locator.Router.ConnectionCached'), '1'));
             assert(strcmp(proxyProps('Test.Locator.Router.PreferSecure'), '1'));
             assert(strcmp(proxyProps('Test.Locator.Router.EndpointSelection'), 'Random'));
@@ -401,8 +398,6 @@ classdef AllTests
             assert(base.ice_batchDatagram().ice_isBatchDatagram());
             assert(base.ice_secure(true).ice_isSecure());
             assert(~base.ice_secure(false).ice_isSecure());
-            %assert(base.ice_collocationOptimized(true).ice_isCollocationOptimized());
-            %assert(~base.ice_collocationOptimized(false).ice_isCollocationOptimized());
             assert(base.ice_preferSecure(true).ice_isPreferSecure());
             assert(~base.ice_preferSecure(false).ice_isPreferSecure());
             assert(base.ice_encodingVersion(Ice.EncodingVersion(1, 0)).ice_getEncodingVersion() == Ice.EncodingVersion(1, 0));
@@ -470,11 +465,6 @@ classdef AllTests
             assert(compObj.ice_secure(false) ~= compObj.ice_secure(true));
             %assert(compObj.ice_secure(false) < compObj.ice_secure(true));
             %assert(~(compObj.ice_secure(true) < compObj.ice_secure(false)));
-
-            %assert(compObj.ice_collocationOptimized(true) == compObj.ice_collocationOptimized(true));
-            %assert(compObj.ice_collocationOptimized(false) ~= compObj.ice_collocationOptimized(true));
-            %assert(compObj.ice_collocationOptimized(false) < compObj.ice_collocationOptimized(true));
-            %assert(~(compObj.ice_collocationOptimized(true) < compObj.ice_collocationOptimized(false)));
 
             assert(compObj.ice_connectionCached(true) == compObj.ice_connectionCached(true));
             assert(compObj.ice_connectionCached(false) ~= compObj.ice_connectionCached(true));

--- a/php/test/Ice/proxy/Client.php
+++ b/php/test/Ice/proxy/Client.php
@@ -273,20 +273,12 @@ function allTests($helper)
     test($b1->ice_getEndpointSelection() == Ice\EndpointSelectionType::Ordered);
     $communicator->getProperties()->setProperty($property, "");
 
-    //$property = $propertyPrefix . ".CollocationOptimized";
-    //test($b1->ice_isCollocationOptimized());
-    //$communicator->getProperties()->setProperty($property, "0");
-    //$b1 = $communicator->propertyToProxy($propertyPrefix);
-    //test(!$b1->ice_isCollocationOptimized());
-    //$communicator->getProperties()->setProperty($property, "");
-
     echo "ok\n";
 
     echo "testing proxyToProperty... ";
     flush();
 
     $b1 = $communicator->stringToProxy("test");
-    //$b1 = $b1->ice_collocationOptimized(true);
     $b1 = $b1->ice_connectionCached(true);
     $b1 = $b1->ice_preferSecure(false);
     $b1 = $b1->ice_endpointSelection(Ice\EndpointSelectionType::Ordered);
@@ -294,14 +286,12 @@ function allTests($helper)
     $b1 = $b1->ice_encodingVersion(new Ice\EncodingVersion(1, 0));
 
     $router = Ice\RouterPrxHelper::createProxy($communicator, "router");
-    //$router = $router->ice_collocationOptimized(false);
     $router = $router->ice_connectionCached(true);
     $router = $router->ice_preferSecure(true);
     $router = $router->ice_endpointSelection(Ice\EndpointSelectionType::Random);
     $router = $router->ice_locatorCacheTimeout(200);
 
     $locator = Ice\LocatorPrxHelper::createProxy($communicator, "locator");
-    //$locator = $locator->ice_collocationOptimized(true);
     $locator = $locator->ice_connectionCached(false);
     $locator = $locator->ice_preferSecure(true);
     $locator = $locator->ice_endpointSelection(Ice\EndpointSelectionType::Random);
@@ -314,21 +304,18 @@ function allTests($helper)
     test(count($proxyProps) == 21);
 
     test($proxyProps["Test"] == "test -e 1.0");
-    //test($proxyProps["Test.CollocationOptimized"] == "1");
     test($proxyProps["Test.ConnectionCached"] == "1");
     test($proxyProps["Test.PreferSecure"] == "0");
     test($proxyProps["Test.EndpointSelection"] == "Ordered");
     test($proxyProps["Test.LocatorCacheTimeout"] == "100");
 
     test($proxyProps["Test.Locator"] == "locator");
-    //test($proxyProps["Test.Locator.CollocationOptimized"] == "1");
     test($proxyProps["Test.Locator.ConnectionCached"] == "0");
     test($proxyProps["Test.Locator.PreferSecure"] == "1");
     test($proxyProps["Test.Locator.EndpointSelection"] == "Random");
     test($proxyProps["Test.Locator.LocatorCacheTimeout"] == "300");
 
     test($proxyProps["Test.Locator.Router"] == "router");
-    //test($proxyProps["Test.Locator.Router.CollocationOptimized"] == "0");
     test($proxyProps["Test.Locator.Router.ConnectionCached"] == "1");
     test($proxyProps["Test.Locator.Router.PreferSecure"] == "1");
     test($proxyProps["Test.Locator.Router.EndpointSelection"] == "Random");

--- a/ruby/test/Ice/exceptions/AllTests.rb
+++ b/ruby/test/Ice/exceptions/AllTests.rb
@@ -189,10 +189,7 @@ def allTests(helper, communicator)
             thrower.throwUndeclaredA(1)
             test(false)
         rescue Ice::UnknownUserException
-            #
-            # We get an unknown user exception without collocation
-            # optimization.
-            #
+            # expected
         rescue
             print $!.backtrace.join("\n")
             test(false)
@@ -202,10 +199,7 @@ def allTests(helper, communicator)
             thrower.throwUndeclaredB(1, 2)
             test(false)
         rescue Ice::UnknownUserException
-            #
-            # We get an unknown user exception without collocation
-            # optimization.
-            #
+            # expected
         rescue
             print $!.backtrace.join("\n")
             test(false)
@@ -215,10 +209,7 @@ def allTests(helper, communicator)
             thrower.throwUndeclaredC(1, 2, 3)
             test(false)
         rescue Ice::UnknownUserException
-            #
-            # We get an unknown user exception without collocation
-            # optimization.
-            #
+            # expected
         rescue
             print $!.backtrace.join("\n")
             test(false)
@@ -311,10 +302,7 @@ def allTests(helper, communicator)
         thrower.throwLocalException()
         test(false)
     rescue Ice::UnknownLocalException
-        #
-        # We get an unknown local exception without collocation
-        # optimization.
-        #
+        # expected
     rescue
         print $!.backtrace.join("\n")
         test(false)
@@ -324,10 +312,7 @@ def allTests(helper, communicator)
         thrower.throwLocalExceptionIdempotent()
         test(false)
     rescue Ice::UnknownLocalException
-        #
-        # We get an unknown local exception without collocation
-        # optimization.
-        #
+        # expected
     rescue Ice::OperationNotExistException
     rescue
         print $!.backtrace.join("\n")
@@ -343,10 +328,7 @@ def allTests(helper, communicator)
         thrower.throwNonIceException()
         test(false)
     rescue Ice::UnknownException
-        #
-        # We get an unknown exception without collocation
-        # optimization.
-        #
+        # expected
     rescue
         print $!.backtrace.join("\n")
         test(false)

--- a/ruby/test/Ice/proxy/AllTests.rb
+++ b/ruby/test/Ice/proxy/AllTests.rb
@@ -273,24 +273,12 @@ def allTests(helper, communicator)
     test(b1.ice_getEndpointSelection() == Ice::EndpointSelectionType::Ordered)
     prop.setProperty(property, "")
 
-    #
-    # isCollocationOptimized is not implemented because the
-    # collocation optimization is permanently disabled with IcePy.
-    #
-    #property = propertyPrefix + ".CollocationOptimized"
-    #test(b1.ice_isCollocationOptimized())
-    #prop.setProperty(property, "0")
-    #b1 = communicator.propertyToProxy(propertyPrefix)
-    #test(!b1.ice_isCollocationOptimized())
-    #prop.setProperty(property, "")
-
     puts "ok"
 
     print "testing proxyToProperty... "
     STDOUT.flush
 
     b1 = communicator.stringToProxy("test")
-    #b1 = b1.ice_collocationOptimized(true)
     b1 = b1.ice_connectionCached(true)
     b1 = b1.ice_preferSecure(false)
     b1 = b1.ice_endpointSelection(Ice::EndpointSelectionType::Ordered)
@@ -319,7 +307,6 @@ def allTests(helper, communicator)
     test(proxyProps.length() == 21)
 
     test(proxyProps["Test"] == "test -e 1.0")
-    #test(proxyProps["Test.CollocationOptimized"] == "1")
     test(proxyProps["Test.ConnectionCached"] == "1")
     test(proxyProps["Test.PreferSecure"] == "0")
     test(proxyProps["Test.EndpointSelection"] == "Ordered")
@@ -327,7 +314,6 @@ def allTests(helper, communicator)
     test(proxyProps["Test.InvocationTimeout"] == "1234");
 
     test(proxyProps["Test.Locator"] == "locator")
-    #test(proxyProps["Test.Locator.CollocationOptimized"] == "1")
     test(proxyProps["Test.Locator.ConnectionCached"] == "0")
     test(proxyProps["Test.Locator.PreferSecure"] == "1")
     test(proxyProps["Test.Locator.EndpointSelection"] == "Random")
@@ -335,7 +321,6 @@ def allTests(helper, communicator)
     test(proxyProps["Test.Locator.InvocationTimeout"] == "1500");
 
     test(proxyProps["Test.Locator.Router"] == "router");
-    #test(proxyProps["Test.Locator.Router.CollocationOptimized"] == "0")
     test(proxyProps["Test.Locator.Router.ConnectionCached"] == "1")
     test(proxyProps["Test.Locator.Router.PreferSecure"] == "1")
     test(proxyProps["Test.Locator.Router.EndpointSelection"] == "Random")
@@ -455,11 +440,6 @@ def allTests(helper, communicator)
     test(compObj.ice_secure(false) != compObj.ice_secure(true))
     #test(compObj.ice_secure(false) < compObj.ice_secure(true))
     #test(!(compObj.ice_secure(true) < compObj.ice_secure(false)))
-
-    #test(compObj.ice_collocationOptimized(true) == compObj.ice_collocationOptimized(true))
-    #test(compObj.ice_collocationOptimized(false) != compObj.ice_collocationOptimized(true))
-    #test(compObj.ice_collocationOptimized(false) < compObj.ice_collocationOptimized(true))
-    #test(!(compObj.ice_collocationOptimized(true) < compObj.ice_collocationOptimized(false)))
 
     test(compObj.ice_connectionCached(true) == compObj.ice_connectionCached(true))
     test(compObj.ice_connectionCached(false) != compObj.ice_connectionCached(true))


### PR DESCRIPTION
This PR removes all references to colloc (= commented out tests) in client-only languages.