### PR TITLE
Add Full Support for `@p` and Code-Snippets to Slice Doc-Comments

### DIFF
--- a/cpp/src/Slice/DocCommentParser.cpp
+++ b/cpp/src/Slice/DocCommentParser.cpp
@@ -14,7 +14,7 @@ namespace Slice
     class DocCommentParser final : public ParserVisitor
     {
     public:
-        DocCommentParser(DocLinkFormatter linkFormatter) : _linkFormatter(linkFormatter) {}
+        DocCommentParser(DocCommentFormatter& formatter) : _formatter(formatter) {}
 
         bool visitModuleStart(const ModulePtr& p) final;
         void visitClassDecl(const ClassDeclPtr& p) final;
@@ -37,14 +37,14 @@ namespace Slice
         /// @remark This function must be called on a doc-comment before it's usable for code-gen purposes.
         void parseDocCommentFor(const ContainedPtr& p);
 
-        DocLinkFormatter _linkFormatter;
+        DocCommentFormatter& _formatter;
     };
 }
 
 void
-Slice::parseAllDocComments(const UnitPtr& unit, DocLinkFormatter linkFormatter)
+Slice::parseAllDocComments(const UnitPtr& unit, DocCommentFormatter& formatter)
 {
-    DocCommentParser visitor{linkFormatter};
+    DocCommentParser visitor{formatter};
     unit->visit(&visitor);
 }
 
@@ -256,44 +256,50 @@ DocCommentParser::parseDocCommentFor(const ContainedPtr& p)
         return;
     }
 
-    // TODO: this is a temporary hack since only "csharp" happens to set 'escapeXml'.
-    // If true, escapes all XML special characters in the parsed comment. Defaults to false.
-    const bool escapeXml = (p->unit()->languageName() == "cs");
-
-    // Split the comment's raw text up into lines.
+    // Get the comment's raw lines, and let the formatter perform any preprocessing it wants to.
     StringList lines = docComment->_rawDocCommentLines;
+    _formatter.preprocess(lines);
 
-    // Escape any XML entities if necessary.
-    if (escapeXml)
+    const string ws = " \t";
+
+    // Format any code-snippets. Slice fully supports Markdown's backtick handling.
+    // Normal text backticks can be escaped with a backslash: '\`',
+    // And we allow multiple backticks to be used as a single delimiter: '`` wow ` is cool``'.
+    for (auto& line : lines)
     {
-        const string amp = "&amp;";
-        const string lt = "&lt;";
-        const string gt = "&gt;";
-
-        for (auto& line : lines)
+        size_t pos = 0;
+        while ((pos = line.find('`', pos)) != string::npos)
         {
-            string::size_type pos = 0;
-            while ((pos = line.find_first_of("&<>", pos)) != string::npos)
+            // If this backtick is escaped with a backslash, skip it.
+            if (pos > 0 && line[pos-1] == '\'')
             {
-                switch (line[pos])
-                {
-                    case '&':
-                        line.replace(pos, 1, amp);
-                        pos += amp.size();
-                        break;
-                    case '<':
-                        line.replace(pos, 1, lt);
-                        pos += lt.size();
-                        break;
-                    case '>':
-                        line.replace(pos, 1, gt);
-                        pos += gt.size();
-                        break;
-                    default:
-                        assert(false);
-                        break;
-                }
+                pos += 1;
+                continue;
             }
+
+            // Count the number of successive backticks. The end of the code-snippet must have the same number.
+            auto openingEnd = line.find_first_not_of('`', pos);
+            openingEnd = (openingEnd == string::npos ? line.size() : openingEnd);
+            auto count = openingEnd - pos;
+
+            // Find the closing delimeter, starting for the end of the opening delimeter.
+            auto delimiter = string(count, '`');
+            auto closingStart = line.find(delimiter, openingEnd);
+            if (closingStart == string::npos)
+            {
+                // No matching delimeter was found.
+                p->unit()->warning(p->file(), p->line(), InvalidComment, "missing parameter name after '@p' tag");
+                break; // Skip to the next line, this line is broken.
+            }
+
+            // Format the snippet's text, and replace the entire raw code-snippet with the returned string.
+            const string snippetText = line.substr(openingEnd, closingStart - openingEnd);
+            const string formattedSnippet = _formatter.formatCode(snippetText);
+            line.erase(pos, closingStart + count - pos);
+            line.insert(pos, formattedSnippet);
+
+            // Go on to check for the next code-snippet, skipping past the one we just formatted.
+            pos += formattedSnippet.size();
         }
     }
 
@@ -301,15 +307,15 @@ DocCommentParser::parseDocCommentFor(const ContainedPtr& p)
     const string link = "{@link ";
     for (auto& line : lines)
     {
-        auto pos = line.find(link);
-        while (pos != string::npos)
+        size_t pos = 0;
+        while ((pos = line.find(link, pos)) != string::npos)
         {
             auto endpos = line.find('}', pos);
             if (endpos != string::npos)
             {
                 // Extract the linked-to identifier.
-                auto identStart = line.find_first_not_of(" \t", pos + link.size());
-                auto identEnd = line.find_last_not_of(" \t", endpos);
+                auto identStart = line.find_first_not_of(ws, pos + link.size());
+                auto identEnd = line.find_last_not_of(ws, endpos);
                 string linkText = line.substr(identStart, identEnd - identStart);
 
                 // Then erase the entire '{@link foo}' tag from the comment.
@@ -332,11 +338,53 @@ DocCommentParser::parseDocCommentFor(const ContainedPtr& p)
                 }
 
                 // Finally, insert a correctly formatted link where the '{@link foo}' used to be.
-                string formattedLink = (*_linkFormatter)(linkText, p, linkTarget);
+                string formattedLink = _formatter.formatLink(linkText, p, linkTarget);
                 line.insert(pos, formattedLink);
                 pos += formattedLink.length();
             }
-            pos = line.find(link, pos);
+        }
+    }
+
+    // Fix any '@p' tags using the provided param-ref formatter.
+    const string paramref = "@p";
+    for (auto& line : lines)
+    {
+        size_t pos = 0;
+        while ((pos = line.find(paramref, pos)) != string::npos)
+        {
+            // Param-refs always look like "@p<whitespace><name>".
+            // First we find the starting position of the name.
+            auto nameStart = line.find_first_not_of(ws, pos + paramref.size());
+
+            // If we hit EOL before finding a non-whitespace character, then the 'name' is missing.
+            if (nameStart == string::npos)
+            {
+                p->unit()->warning(p->file(), p->line(), InvalidComment, "missing parameter name after '@p' tag");
+                break; // Since we hit EOL, we know we're done parsing this line. Skip to the next line.
+            }
+            // If a non-whitespace character comes directly after '@p', it's probably '@param'. Just skip it.
+            if (nameStart == pos + paramref.size())
+            {
+                pos = nameStart;
+                continue;
+            }
+
+            // Then find the ending position of the name.
+            auto nameEnd = line.find_first_of(ws, nameStart);
+            if (nameEnd == string::npos)
+            {
+                // If there isn't any whitespace after the name, that means it runs to the end of the line.
+                nameEnd = line.size();
+            }
+
+            // Format the parameter's name, skipping past the one we just formatted.
+            const string parameterName = line.substr(nameStart, nameEnd - nameStart);
+            const string formattedParamName = _formatter.formatParamRef(parameterName);
+            line.erase(pos, nameEnd - pos);
+            line.insert(pos, formattedParamName);
+
+            // Check for the next '@p' tag, skipping past the formatted tag we just emitted.
+            pos += formattedParamName.size();
         }
     }
 
@@ -344,7 +392,6 @@ DocCommentParser::parseDocCommentFor(const ContainedPtr& p)
     // And we need a reference to the operation to make sure any names used in the tag match the names in the operation.
     OperationPtr operationTarget = dynamic_pointer_cast<Operation>(p);
 
-    const string ws = " \t";
     const string paramTag = "@param";
     const string throwsTag = "@throws";
     const string exceptionTag = "@exception";

--- a/cpp/src/Slice/DocCommentParser.h
+++ b/cpp/src/Slice/DocCommentParser.h
@@ -7,7 +7,50 @@
 
 namespace Slice
 {
+    class DocCommentFormatter
+    {
+    public:
+        /// Gives the formatter a chance to preprocess a comment before it's parsed.
+        /// @param rawComment The raw lines of the doc-comment (as it's written in the Slice file) minus any formatting
+        /// characters like leading '///' and '*' characters or leading whitespace.
+        //
+        // By default we perform no preprocessing.
+        virtual void preprocess(StringList&) {}
+
+        /// This function is called by the doc-comment parser to map code-snippets (`<rawText>`) into each language's
+        /// syntax.
+        /// @param rawText The raw text contained within the backticks (the backticks are NOT included).
+        /// @return A properly formatted code snippet in the target language. The doc-comment parser will replace the
+        /// entire "`...`" string with the returned value.
+        //
+        // By default we just re-emit the text with the original number of backticks around it.
+        [[nodiscard]] virtual std::string formatCode(std::string rawText)
+        {
+            return "`" + rawText + "`";
+        }
+
+        /// This function is called by the doc-comment parser to map '@p' tags into each language's syntax.
+        /// @param param The mapped name of the parameter that is being referenced.
+        /// @return A properly formatted parameters reference in the target language. The doc-comment parser will
+        /// replace the entire "@p <rawParamName>" string with the returned value.
+        //
+        // By default we just emit the parameter's name in code formatting.
+        [[nodiscard]] virtual std::string formatParamRef(const std::string& param) { return formatCode(param); }
+
+        /// This function is called by the doc-comment parser to map doc-links ('{@link <rawLink>}') into each
+        /// language's syntax.
+        /// @param rawLink The link's raw text taken verbatim from the doc-comment.
+        /// @param source A pointer to the Slice element that the doc-comment (and link) are written on.
+        /// @param target A pointer to the Slice element that is being linked to, or `nullptr` if it doesn't exist.
+        /// @return A properly formatted doc-link in the target language. The doc-comment parser will replace the
+        /// entire "{@link <rawLink>}" string with the returned value.
+        [[nodiscard]] virtual std::string formatLink(
+            const std::string& rawLink,
+            const ContainedPtr& source,
+            const SyntaxTreeBasePtr& target) = 0;
+    };
+
     /// Parses all doc-comments within the provided unit (in-place).
-    void parseAllDocComments(const UnitPtr& unit, DocLinkFormatter linkFormatter);
+    void parseAllDocComments(const UnitPtr& unit, DocCommentFormatter& formatter);
 }
 #endif

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -256,19 +256,6 @@ namespace Slice
     // DocComment
     // ----------------------------------------------------------------------
 
-    /// Functions of this type are used to map link tags into each language's link syntax.
-    /// In Slice, links are of the form: '{@link <rawLink>}'.
-    ///
-    /// The first argument (`rawLink`) is the raw link text, taken verbatim from the doc-comment.
-    /// The second argument (`source`) is a pointer to the Slice element that the doc comment (and link) are written on.
-    /// The third argument (`target`) is a pointer to the Slice element that is being linked to.
-    /// If the parser could not resolve the link, this will be `nullptr`.
-    ///
-    /// This function should return the fully formatted link, which will replace the entire '{@link <rawLink>}'
-    /// in a raw doc-comment.
-    using DocLinkFormatter =
-        std::string (*)(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target);
-
     class DocCommentParser;
 
     class DocComment final

--- a/cpp/src/ice2slice/Gen.cpp
+++ b/cpp/src/ice2slice/Gen.cpp
@@ -768,23 +768,3 @@ Gen::TypesVisitor::getOutput(const ContainedPtr& contained)
         return *(inserted.first->second);
     }
 }
-
-string
-Slice::slice2LinkFormatter(const string& rawLink, const ContainedPtr&, const SyntaxTreeBasePtr&)
-{
-    // The only difference with '@link' between the 'Ice' and 'Slice' syntaxes
-    // is that the 'Ice' syntax uses '#' whereas the 'Slice' syntax uses '::'.
-    string formattedLink = rawLink;
-    auto separatorPos = formattedLink.find('#');
-    if (separatorPos == 0)
-    {
-        // We want to avoid converting the relative link '#member' into the global link '::member'.
-        // Instead we simply convert it to 'member' with no prefix.
-        formattedLink = formattedLink.substr(1);
-    }
-    else if (separatorPos != string::npos)
-    {
-        formattedLink.replace(separatorPos, 1, "::");
-    }
-    return "{@link " + formattedLink + "}";
-}

--- a/cpp/src/ice2slice/Gen.h
+++ b/cpp/src/ice2slice/Gen.h
@@ -75,9 +75,6 @@ namespace Slice
             std::map<std::string, std::unique_ptr<IceInternal::Output>> _outputs;
         };
     };
-
-    std::string
-    slice2LinkFormatter(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target);
 }
 
 #endif

--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -23,6 +23,24 @@ namespace
     bool interrupted = false;
 }
 
+class CppDocCommentFormatter final : public DocCommentFormatter
+{
+    string formatCode(string rawText) final
+    {
+        return "<tt>" + rawText + "</tt>";
+    }
+
+    string formatParamRef(const string& param) final
+    {
+        return "@p " + param;
+    }
+
+    string formatLink(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target) final
+    {
+        return Slice::cppLinkFormatter(rawLink, source, target);
+    }
+};
+
 void
 interruptedCallback(int /*signal*/)
 {
@@ -212,7 +230,8 @@ compile(const vector<string>& argv)
             }
             else
             {
-                parseAllDocComments(unit, Slice::cppLinkFormatter);
+                CppDocCommentFormatter formatter;
+                parseAllDocComments(unit, formatter);
 
                 Gen gen(
                     preprocessor->getBaseName(),

--- a/cpp/src/slice2cs/Main.cpp
+++ b/cpp/src/slice2cs/Main.cpp
@@ -23,6 +23,50 @@ namespace
     bool interrupted = false;
 }
 
+class CsharpDocCommentFormatter final : public DocCommentFormatter
+{
+    void preprocess(StringList& rawComment) final
+    {
+        for (auto& line : rawComment)
+        {
+            // Escape any XML special characters in the comment.
+            string::size_type pos = 0;
+            while ((pos = line.find_first_of("&<>", pos)) != string::npos)
+            {
+                switch (line[pos])
+                {
+                    case '&':
+                        line.replace(pos, 1, "&amp;");
+                        break;
+                    case '<':
+                        line.replace(pos, 1, "&lt;");
+                        break;
+                    case '>':
+                        line.replace(pos, 1, "&gt;");
+                        break;
+                }
+                // Skip over the leading '&' character to avoid 'find'ing it again.
+                pos += 1;
+            }
+        }
+    }
+
+    string formatCode(string rawText) final
+    {
+        return "<c>" + rawText + "</c>";
+    }
+
+    string formatParamRef(const string& param) final
+    {
+        return "<paramref name=\"" + param + "\">";
+    }
+
+    string formatLink(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target) final
+    {
+        return Slice::Csharp::csLinkFormatter(rawLink, source, target);
+    }
+};
+
 void
 interruptedCallback(int /*signal*/)
 {
@@ -186,7 +230,8 @@ compile(const vector<string>& argv)
             }
             else
             {
-                parseAllDocComments(unit, Slice::Csharp::csLinkFormatter);
+                CsharpDocCommentFormatter formatter;
+                parseAllDocComments(unit, formatter);
 
                 Gen gen(preprocessor->getBaseName(), includePaths, output);
                 gen.generate(unit);

--- a/cpp/src/slice2java/Main.cpp
+++ b/cpp/src/slice2java/Main.cpp
@@ -24,6 +24,19 @@ namespace
     bool interrupted = false;
 }
 
+class JavaDocCommentFormatter final : public DocCommentFormatter
+{
+    string formatCode(string rawText) final
+    {
+        return "{@code " + rawText + "}";
+    }
+
+    string formatLink(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target) final
+    {
+        return Slice::Java::javaLinkFormatter(rawLink, source, target);
+    }
+};
+
 void
 interruptedCallback(int /*signal*/)
 {
@@ -172,7 +185,8 @@ compile(const vector<string>& argv)
             }
             else
             {
-                parseAllDocComments(unit, Slice::Java::javaLinkFormatter);
+                JavaDocCommentFormatter formatter;
+                parseAllDocComments(unit, formatter);
 
                 Gen gen(preprocessor->getBaseName(), includePaths, output);
                 gen.generate(unit);

--- a/cpp/src/slice2js/Main.cpp
+++ b/cpp/src/slice2js/Main.cpp
@@ -24,6 +24,14 @@ namespace
     bool interrupted = false;
 }
 
+class JSDocCommentFormatter final : public DocCommentFormatter
+{
+    string formatLink(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target) final
+    {
+        return Slice::JavaScript::jsLinkFormatter(rawLink, source, target);
+    }
+};
+
 void
 interruptedCallback(int /*signal*/)
 {
@@ -217,7 +225,8 @@ compile(const vector<string>& argv)
             }
             else
             {
-                parseAllDocComments(unit, Slice::JavaScript::jsLinkFormatter);
+                JSDocCommentFormatter formatter;
+                parseAllDocComments(unit, formatter);
 
                 if (useStdout)
                 {

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -35,6 +35,20 @@ namespace
     mutex globalMutex;
     bool interrupted = false;
 
+
+    class MatlabDocCommentFormatter final : public DocCommentFormatter
+    {
+        string formatCode(string rawText) final
+        {
+            return "|" + rawText + "|";
+        }
+
+        string formatLink(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target) final
+        {
+            return Slice::matlabLinkFormatter(rawLink, source, target);
+        }
+    };
+
     void interruptedCallback(int /*signal*/)
     {
         lock_guard lock(globalMutex);
@@ -214,7 +228,8 @@ namespace
                 {
                     FileTracker::instance()->setSource(fileName);
 
-                    parseAllDocComments(unit, Slice::matlabLinkFormatter);
+                    MatlabDocCommentFormatter formatter;
+                    parseAllDocComments(unit, formatter);
 
                     validateMatlabMetadata(unit);
 

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -31,6 +31,20 @@ namespace
     const char* const tripleQuotes = R"(""")";
 }
 
+class PythonDocCommentFormatter final : public DocCommentFormatter
+{
+    string formatCode(string rawText) final
+    {
+        // We target Sphinx (RST) for Python doc-comments, which use double backticks for code formatting.
+        return "``" + rawText + "``";
+    }
+
+    string formatLink(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target) final
+    {
+        return Slice::Python::pyLinkFormatter(rawLink, source, target);
+    }
+};
+
 string
 Slice::Python::getPythonModuleForDefinition(const SyntaxTreeBasePtr& p)
 {
@@ -2649,7 +2663,8 @@ Slice::Python::compile(
                     dependencyGenerator->addDependenciesFor(unit);
                 }
 
-                parseAllDocComments(unit, Slice::Python::pyLinkFormatter);
+                PythonDocCommentFormatter formatter;
+                parseAllDocComments(unit, formatter);
                 validatePythonMetadata(unit);
 
                 unit->visit(&packageVisitor);

--- a/cpp/src/slice2swift/Main.cpp
+++ b/cpp/src/slice2swift/Main.cpp
@@ -26,6 +26,14 @@ namespace
     bool interrupted = false;
 }
 
+class SwiftDocCommentFormatter final : public DocCommentFormatter
+{
+    string formatLink(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target) final
+    {
+        return Slice::Swift::swiftLinkFormatter(rawLink, source, target);
+    }
+};
+
 static void
 interruptedCallback(int /*signal*/)
 {
@@ -190,7 +198,8 @@ compile(const vector<string>& argv)
             }
             else
             {
-                parseAllDocComments(unit, Slice::Swift::swiftLinkFormatter);
+                SwiftDocCommentFormatter formatter;
+                parseAllDocComments(unit, formatter);
                 Gen gen(preprocessor->getBaseName(), includePaths, output);
                 gen.generate(unit);
 


### PR DESCRIPTION
This PR adds full support (parsing _and_ code-gen in all languages) for `@p` (paramref) tags and markdown code-snippets.
Note: these are different than code-blocks which we do not support.

Instead of each language providing a single `DocLinkFormatter`, each language now provides a `DocCommentFormatter`, which provides functions for formatting links, code-snippets, and param-refs.

To see the exact changes this PR makes to the generated code, see this commit:
https://github.com/InsertCreativityHere/compiler-comparison/commit/fd75d6482836e3ce7e1e0cd281163b74f78e341e#diff-1df6277f7efe2c45afd0c3267f483bb86b73dfb6db309a3e4fdd1f9da629ad4b