### PR TITLE
Do not Parse the Inside of Code-Snippets and CHANGELOG Updates

### DIFF
--- a/CHANGELOG-3.8.md
+++ b/CHANGELOG-3.8.md
@@ -374,6 +374,47 @@ classDiagram
   int sendRequest(string message);
   ```
 
+- Added support for 2 new doc-comment tags: `@remark` and `@p`
+  `@remark` can be used to provide additional (often non-critical) information in a doc-comment:
+
+  ```slice
+  /// Provides access to a radar scanner.
+  /// @remark for sonar, use {@link SonarScan} instead.
+  class RadarScan {}
+  ```
+
+  `@p` can only be used on operations, and provides a way to reference it's parameters in the doc-comment.
+  This is different than `@param` which is used to describe a parameter, not reference one. For example:
+
+  ```slice
+  /// Returns how many seconds passed between start and end.
+  /// @param start The starting time.
+  /// @param end The ending time. Must be greater than @p start.
+  int getDuration(int start, int end);
+  ```
+
+- Added support for Markdown code-snippets in doc-comments:
+
+  ```slice
+  /// This is `true`, and can be used as a default value: `bool b = ConstBool;`
+  const bool ConstBool = true;
+  ```
+
+  You can use any number of backticks to mark the beginning/end of the code-snippet, but they must match in number.
+  This is useful if the code-snippet itself will contain backticks:
+
+  ```slice
+  /// This snippet ``contains a ` character!`` just fine.
+  ```
+
+  Outside of code-snippets, you can escape a backtick with a backslash to get a normal textual backtick character:
+
+  ```slice
+  /// This character \` doesn't start a code-snippet and will appear like a normal backtick character.
+  ```
+
+- `@link` tags are now mapped to proper documentation links in Swift and MATLAB.
+
 - Lists of metadata can be split into separate brackets now, allowing for longer metadata to be placed on separate lines
   or for metadata to be grouped by functionality. For example, you can now write:
 
@@ -430,6 +471,8 @@ classDiagram
   should be used to generate Slice API documentation.
 
 - Removed the `--impl` argument from the Slice compilers.
+
+- Removed the `-E` flag from the Slice compilers.
 
 - You can now use identifiers with underscores or with the Ice prefix without any special compiler option.
 

--- a/cpp/src/Slice/DocCommentParser.cpp
+++ b/cpp/src/Slice/DocCommentParser.cpp
@@ -261,6 +261,168 @@ namespace
         ContainedList results = linkSourceScope->lookupContained(linkText, false);
         return (results.empty() ? nullptr : results.front());
     }
+
+    /// Formats a code-snippet starting at \p pos.
+    /// Slice fully supports Markdown's backtick handling, so normal text backticks can be escaped with a backslash
+    /// '\`', and we allow multiple backticks to be used as a single delimiter: '`` wow ` is cool``'.
+    /// @param line The line containing the code-snippet. This line will be edited in place to remove the original
+    ///             Slice-style code-snippet and replace it with a properly formatted code-snippet.
+    /// @param pos The position where the '`' appears in the line. This value should be updated to account for
+    ///            any characters this function inserts to avoid double-parsing things.
+    void formatCodeElement(const ContainedPtr& p, DocCommentFormatter& formatter, string& line, size_t& pos)
+    {
+        // If this backtick is escaped with a backslash, remove the backslash but do nothing else.
+        // This isn't a code-snippet, just a normal backtick.
+        if (pos > 0 && line[pos - 1] == '\\')
+        {
+            line.erase(pos - 1, 1);
+            return;
+        }
+
+        // Count the number of successive backticks. The end of the code-snippet must have the same number.
+        auto openingEnd = line.find_first_not_of('`', pos);
+        openingEnd = (openingEnd == string::npos ? line.size() : openingEnd);
+        auto count = openingEnd - pos;
+
+        // Find the closing delimeter, starting for the end of the opening delimeter.
+        auto delimiter = string(count, '`');
+        auto closingStart = line.find(delimiter, openingEnd);
+        if (closingStart == string::npos)
+        {
+            // No matching delimeter was found. Emit a warning, then skip to the next line. This one is broken.
+            const string msg = "unterminated code snippet: missing closing backtick delimiter";
+            p->unit()->warning(p->file(), p->line(), InvalidComment, msg);
+
+            pos = line.size();
+        }
+        else
+        {
+            // Format the snippet's text, and replace the entire raw code-snippet with the returned string.
+            const string snippetText = line.substr(openingEnd, closingStart - openingEnd);
+            const string formattedSnippet = formatter.formatCode(snippetText);
+            line.erase(pos, closingStart + count - pos);
+            line.insert(pos, formattedSnippet);
+
+            // Go on to check for the next code-snippet, skipping past the one we just formatted.
+            pos += formattedSnippet.size();
+        }
+    }
+
+    /// Formats an `@link` element starting at \p pos.
+    /// @param line The line containing the link. This line will be edited in place to remove the original
+    ///             Slice-style link and replace it with a properly formatted link for the target language.
+    /// @param pos The starting position of the `@link` in the line. This value should be updated to account for
+    ///            any characters this function inserts to avoid double-parsing things.
+    void formatLinkElement(const ContainedPtr& p, DocCommentFormatter& formatter, string& line, size_t& pos)
+    {
+        const string linkTag = "{@link ";
+
+        auto endpos = line.find('}', pos);
+        if (endpos != string::npos)
+        {
+            // Extract the linked-to identifier.
+            auto identStart = line.find_first_not_of(" \t", pos + linkTag.size());
+            auto identEnd = line.find_last_not_of(" \t", endpos);
+            string linkText = line.substr(identStart, identEnd - identStart);
+
+            // Then erase the entire '{@link foo}' tag from the comment.
+            line.erase(pos, endpos - pos + 1);
+
+            // Attempt to resolve the link, and issue a warning if the link is invalid.
+            SyntaxTreeBasePtr linkTarget = resolveDocLink(linkText, p);
+            if (!linkTarget)
+            {
+                string msg = "no Slice element with identifier '" + linkText + "' could be found in this context";
+                p->unit()->warning(p->file(), p->line(), InvalidComment, msg);
+            }
+            if (dynamic_pointer_cast<Parameter>(linkTarget))
+            {
+                // We don't support linking to parameters with '@link' tags.
+                // Parameter links must be done with '@p' tags, and can only appear on the enclosing operation.
+                string msg = "cannot link parameter '" + linkText + "'; parameters can only be referenced with @p";
+                p->unit()->warning(p->file(), p->line(), InvalidComment, msg);
+                linkTarget = nullptr;
+            }
+
+            // Finally, insert a correctly formatted link where the '{@link foo}' used to be.
+            string formattedLink = formatter.formatLink(linkText, p, linkTarget);
+            line.insert(pos, formattedLink);
+            pos += formattedLink.length();
+        }
+    }
+
+
+    /// Formats an `@p name` element starting at \p pos.
+    /// @param line The line containing the paramref. This line will be edited in place to remove the original
+    ///             Slice-style paramref and replace it with a properly formatted paramref for the target language.
+    /// @param pos The starting position of the `@p` in the line. This value should be updated to account for
+    ///            any characters this function inserts to avoid double-parsing things.
+    void formatParamrefElement(const ContainedPtr& p, DocCommentFormatter& formatter, string& line, size_t& pos)
+    {
+        const string paramrefTag = "@p";
+
+        // Param-refs always look like "@p<whitespace><name>".
+        // First we find the starting position of the name.
+        auto nameStart = line.find_first_not_of(" \t", pos + paramrefTag.size());
+
+        // If we hit EOL before finding a non-whitespace character, then the 'name' is missing.
+        if (nameStart == string::npos)
+        {
+            p->unit()->warning(p->file(), p->line(), InvalidComment, "missing parameter name after '@p' tag");
+            pos += 2; // Skip the '@p' tag and continue parsing.
+            return;
+        }
+        // If a non-whitespace character comes directly after '@p', it's probably '@param'. Just skip it.
+        if (nameStart == pos + paramrefTag.size())
+        {
+            pos = nameStart;
+            return;
+        }
+
+        // Then find the ending position of the name.
+        const string identifierChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
+        auto nameEnd = line.find_first_not_of(identifierChars, nameStart);
+        if (nameEnd == string::npos)
+        {
+            // If there isn't any whitespace after the name, that means it runs to the end of the line.
+            nameEnd = line.size();
+        }
+
+        // Extract the parameter's name and check if matches an operation parameter.
+        // If it does, make sure to use the mapped name instead of the Slice name.
+        string parameterName = line.substr(nameStart, nameEnd - nameStart);
+        if (auto operationTarget = dynamic_pointer_cast<Operation>(p))
+        {
+            bool doesParameterExist = false;
+            for (const auto& param : operationTarget->parameters())
+            {
+                if (param->name() == parameterName)
+                {
+                    parameterName = param->mappedName();
+                    doesParameterExist = true;
+                    break;
+                }
+            }
+            if (!doesParameterExist)
+            {
+                string opName = operationTarget->name();
+                string msg = "No parameter named '" + parameterName + "' exists on operation '" + opName + "'";
+                p->unit()->warning(p->file(), p->line(), InvalidComment, msg);
+            }
+        }
+        else
+        {
+            p->unit()->warning(p->file(), p->line(), InvalidComment, "'@p' tags can only be used on operations");
+        }
+
+        // Format the parameter's name and insert it in-place of the original '@p name'.
+        const string formattedParamName = formatter.formatParamRef(parameterName);
+        line.erase(pos, nameEnd - pos);
+        line.insert(pos, formattedParamName);
+
+        // Check for the next '@p' tag, skipping past the formatted tag we just emitted.
+        pos += formattedParamName.size();
+    }
 }
 
 void
@@ -277,89 +439,44 @@ DocCommentParser::parseDocCommentFor(const ContainedPtr& p)
     StringList lines = docComment->_rawDocCommentLines;
     _formatter.preprocess(lines);
 
-    const string ws = " \t";
-
-    // Format any code-snippets. Slice fully supports Markdown's backtick handling.
-    // Normal text backticks can be escaped with a backslash: '\`',
-    // And we allow multiple backticks to be used as a single delimiter: '`` wow ` is cool``'.
+    // Then, validate and map any inline tags/formatting characters.
     for (auto& line : lines)
     {
         size_t pos = 0;
-        while ((pos = line.find('`', pos)) != string::npos)
+        while(true)
         {
-            // If this backtick is escaped with a backslash, skip it.
-            if (pos > 0 && line[pos - 1] == '\\')
+            // We check for all inline tags all at the same time, to prevent overlap.
+            // For example: `@p hello` should _only_ be a code-snippet, not also a param-ref.
+            size_t nextBacktickPos = line.find('`', pos);
+            size_t nextLinkPos = line.find("{@link ", pos);
+            size_t nextParamrefPos = line.find("@p", pos);
+
+            // If the next element to handle is a code-snippet.
+            if (nextBacktickPos != string::npos && (nextBacktickPos < nextLinkPos && nextBacktickPos < nextParamrefPos))
             {
-                pos += 1;
+                pos = nextBacktickPos;
+                formatCodeElement(p, _formatter, line, pos);
                 continue;
             }
 
-            // Count the number of successive backticks. The end of the code-snippet must have the same number.
-            auto openingEnd = line.find_first_not_of('`', pos);
-            openingEnd = (openingEnd == string::npos ? line.size() : openingEnd);
-            auto count = openingEnd - pos;
-
-            // Find the closing delimeter, starting for the end of the opening delimeter.
-            auto delimiter = string(count, '`');
-            auto closingStart = line.find(delimiter, openingEnd);
-            if (closingStart == string::npos)
+            // If the next element to handle is a link.
+            if (nextLinkPos != string::npos && (nextLinkPos < nextBacktickPos && nextLinkPos < nextParamrefPos))
             {
-                // No matching delimeter was found.
-                const string msg = "unterminated code snippet: missing closing backtick delimiter";
-                p->unit()->warning(p->file(), p->line(), InvalidComment, msg);
-                break; // Skip to the next line, this line is broken.
+                pos = nextLinkPos;
+                formatLinkElement(p, _formatter, line, pos);
+                continue;
             }
 
-            // Format the snippet's text, and replace the entire raw code-snippet with the returned string.
-            const string snippetText = line.substr(openingEnd, closingStart - openingEnd);
-            const string formattedSnippet = _formatter.formatCode(snippetText);
-            line.erase(pos, closingStart + count - pos);
-            line.insert(pos, formattedSnippet);
-
-            // Go on to check for the next code-snippet, skipping past the one we just formatted.
-            pos += formattedSnippet.size();
-        }
-    }
-
-    // Fix any link tags using the provided link formatter.
-    const string link = "{@link ";
-    for (auto& line : lines)
-    {
-        size_t pos = 0;
-        while ((pos = line.find(link, pos)) != string::npos)
-        {
-            auto endpos = line.find('}', pos);
-            if (endpos != string::npos)
+            // If the next element to handle is a param-ref.
+            if (nextParamrefPos != string::npos && (nextParamrefPos < nextBacktickPos && nextParamrefPos < nextLinkPos))
             {
-                // Extract the linked-to identifier.
-                auto identStart = line.find_first_not_of(ws, pos + link.size());
-                auto identEnd = line.find_last_not_of(ws, endpos);
-                string linkText = line.substr(identStart, identEnd - identStart);
-
-                // Then erase the entire '{@link foo}' tag from the comment.
-                line.erase(pos, endpos - pos + 1);
-
-                // Attempt to resolve the link, and issue a warning if the link is invalid.
-                SyntaxTreeBasePtr linkTarget = resolveDocLink(linkText, p);
-                if (!linkTarget)
-                {
-                    string msg = "no Slice element with identifier '" + linkText + "' could be found in this context";
-                    p->unit()->warning(p->file(), p->line(), InvalidComment, msg);
-                }
-                if (dynamic_pointer_cast<Parameter>(linkTarget))
-                {
-                    // We don't support linking to parameters with '@link' tags.
-                    // Parameter links must be done with '@p' tags, and can only appear on the enclosing operation.
-                    string msg = "cannot link parameter '" + linkText + "'; parameters can only be referenced with @p";
-                    p->unit()->warning(p->file(), p->line(), InvalidComment, msg);
-                    linkTarget = nullptr;
-                }
-
-                // Finally, insert a correctly formatted link where the '{@link foo}' used to be.
-                string formattedLink = _formatter.formatLink(linkText, p, linkTarget);
-                line.insert(pos, formattedLink);
-                pos += formattedLink.length();
+                pos = nextParamrefPos;
+                formatParamrefElement(p, _formatter, line, pos);
+                continue;
             }
+
+            // If there's no more inline tags to fix on this line, move on to the next line.
+            break;
         }
     }
 
@@ -367,76 +484,7 @@ DocCommentParser::parseDocCommentFor(const ContainedPtr& p)
     // And we need a reference to the operation to make sure any names used in the tag match the names in the operation.
     OperationPtr operationTarget = dynamic_pointer_cast<Operation>(p);
 
-    // Fix any '@p' tags using the provided param-ref formatter.
-    const string paramref = "@p";
-    for (auto& line : lines)
-    {
-        size_t pos = 0;
-        while ((pos = line.find(paramref, pos)) != string::npos)
-        {
-            // Param-refs always look like "@p<whitespace><name>".
-            // First we find the starting position of the name.
-            auto nameStart = line.find_first_not_of(ws, pos + paramref.size());
-
-            // If we hit EOL before finding a non-whitespace character, then the 'name' is missing.
-            if (nameStart == string::npos)
-            {
-                p->unit()->warning(p->file(), p->line(), InvalidComment, "missing parameter name after '@p' tag");
-                break; // Since we hit EOL, we know we're done parsing this line. Skip to the next line.
-            }
-            // If a non-whitespace character comes directly after '@p', it's probably '@param'. Just skip it.
-            if (nameStart == pos + paramref.size())
-            {
-                pos = nameStart;
-                continue;
-            }
-
-            // Then find the ending position of the name.
-            const string identifierChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
-            auto nameEnd = line.find_first_not_of(identifierChars, nameStart);
-            if (nameEnd == string::npos)
-            {
-                // If there isn't any whitespace after the name, that means it runs to the end of the line.
-                nameEnd = line.size();
-            }
-
-            // Extract the parameter's name and check if matches an operation parameter.
-            // If it does, make sure to use the mapped name instead of the Slice name.
-            string parameterName = line.substr(nameStart, nameEnd - nameStart);
-            if (operationTarget)
-            {
-                bool doesParameterExist = false;
-                for (const auto& param : operationTarget->parameters())
-                {
-                    if (param->name() == parameterName)
-                    {
-                        parameterName = param->mappedName();
-                        doesParameterExist = true;
-                        break;
-                    }
-                }
-                if (!doesParameterExist)
-                {
-                    string opName = operationTarget->name();
-                    string msg = "No parameter named '" + parameterName + "' exists on operation '" + opName + "'";
-                    p->unit()->warning(p->file(), p->line(), InvalidComment, msg);
-                }
-            }
-            else
-            {
-                p->unit()->warning(p->file(), p->line(), InvalidComment, "'@p' tags can only be used on operations");
-            }
-
-            // Format the parameter's name and insert it in-place of the original '@p name'.
-            const string formattedParamName = _formatter.formatParamRef(parameterName);
-            line.erase(pos, nameEnd - pos);
-            line.insert(pos, formattedParamName);
-
-            // Check for the next '@p' tag, skipping past the formatted tag we just emitted.
-            pos += formattedParamName.size();
-        }
-    }
-
+    const string ws = " \t";
     const string paramTag = "@param";
     const string throwsTag = "@throws";
     const string exceptionTag = "@exception";

--- a/cpp/src/Slice/DocCommentParser.cpp
+++ b/cpp/src/Slice/DocCommentParser.cpp
@@ -351,7 +351,6 @@ namespace
         }
     }
 
-
     /// Formats an `@p name` element starting at \p pos.
     /// @param line The line containing the paramref. This line will be edited in place to remove the original
     ///             Slice-style paramref and replace it with a properly formatted paramref for the target language.
@@ -443,7 +442,7 @@ DocCommentParser::parseDocCommentFor(const ContainedPtr& p)
     for (auto& line : lines)
     {
         size_t pos = 0;
-        while(true)
+        while (true)
         {
             // We check for all inline tags all at the same time, to prevent overlap.
             // For example: `@p hello` should _only_ be a code-snippet, not also a param-ref.


### PR DESCRIPTION
This PR updates the 3.8 changelog to include all the new doc-comment changes, and the removal of the `-E` compiler option.

It also updates the doc-comment parsing in 2 ways:
1) The logic for fixing `@link`, `@p`, and code-snippets was moved out into helper functions, instead of being in one giant monolith function. The logic was kept identical, it was just moved. That's all.
2) Previously we would handle each tag in separate passes, but this had bad side effects like letting this: `` `@p param` `` get picked up as _both_ a code-snippet and a param-ref, which is wrong. Now we handle all the inline tags in a single pass, preventing any parsing 'overlap'.