### PR TITLE
Fix C# multicast bug on Windows 

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Network.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Network.java
@@ -634,7 +634,8 @@ public final class Network {
         return addresses;
     }
 
-    public static ArrayList<InetAddress> getLocalAddresses(int protocol) {
+    // Only used for multicast.
+    private static ArrayList<InetAddress> getLocalAddresses(int protocol) {
         ArrayList<InetAddress> result = new ArrayList<>();
         try {
             Enumeration<NetworkInterface> ifaces =
@@ -660,8 +661,7 @@ public final class Network {
         return result;
     }
 
-    public static List<String> getInterfacesForMulticast(
-            String intf, int protocolSupport) {
+    public static List<String> getInterfacesForMulticast(String intf, int protocolSupport) {
         ArrayList<String> interfaces = new ArrayList<>();
         if (isWildcard(intf)) {
             for (InetAddress addr : getLocalAddresses(protocolSupport)) {


### PR DESCRIPTION
This PR fixes #3882.

The root issue was that getLocalAddresses was returning sometimes on Windows 11 169.x addresses (C# only).

This PR also simplifies the corresponding C++ code.