### PR TITLE
Update doc-comments for checkedCast and uncheckedCast

### DIFF
--- a/cpp/include/Ice/ProxyFunctions.h
+++ b/cpp/include/Ice/ProxyFunctions.h
@@ -30,22 +30,20 @@ namespace Ice
         }
     }
 
-    /// Downcasts a proxy without confirming the target object's type via a remote invocation.
+    /// Creates a new proxy from an existing proxy.
     /// @param proxy The source proxy.
-    /// @return A proxy with the requested type.
-    /// @remark The preferred syntax is to construct the proxy from another proxy using the explicit proxy
-    /// constructor.
+    /// @return A new proxy with the requested type.
+    /// @remark This is a purely local operation.
     template<typename Prx, std::enable_if_t<std::is_base_of_v<ObjectPrx, Prx>, bool> = true>
     Prx uncheckedCast(const ObjectPrx& proxy)
     {
         return Prx::_fromReference(proxy._getReference());
     }
 
-    /// Downcasts a proxy without confirming the target object's type via a remote invocation.
+    /// Creates a new proxy from an existing proxy.
     /// @param proxy The source proxy (can be nullopt).
-    /// @return A proxy with the requested type.
-    /// @remark The preferred syntax is to construct the proxy from another proxy using the explicit ObjectPrx
-    /// constructor.
+    /// @return A new proxy with the requested type, or nullopt if the source proxy is nullopt.
+    /// @remark This is a purely local operation.
     template<typename Prx, std::enable_if_t<std::is_base_of_v<ObjectPrx, Prx>, bool> = true>
     std::optional<Prx> uncheckedCast(const std::optional<ObjectPrx>& proxy)
     {
@@ -59,20 +57,22 @@ namespace Ice
         }
     }
 
-    /// Downcasts a proxy without confirming the target object's type via a remote invocation.
+    /// Creates a new proxy from an existing proxy.
     /// @param proxy The source proxy.
     /// @param facet A facet name.
-    /// @return A proxy with the requested type and facet.
+    /// @return A new proxy with the requested type and facet.
+    /// @remark This is a purely local operation.
     template<typename Prx, std::enable_if_t<std::is_base_of_v<ObjectPrx, Prx>, bool> = true>
     Prx uncheckedCast(const ObjectPrx& proxy, std::string facet)
     {
         return uncheckedCast<Prx>(proxy->ice_facet(std::move(facet)));
     }
 
-    /// Downcasts a proxy without confirming the target object's type via a remote invocation.
-    /// @param proxy The source proxy.
+    /// Creates a new proxy from an existing proxy.
+    /// @param proxy The source proxy (can be nullopt).
     /// @param facet A facet name.
-    /// @return A proxy with the requested type and facet.
+    /// @return A new proxy with the requested type and facet, or nullopt if the source proxy is nullopt.
+    /// @remark This is a purely local operation.
     template<typename Prx, std::enable_if_t<std::is_base_of_v<ObjectPrx, Prx>, bool> = true>
     std::optional<Prx> uncheckedCast(const std::optional<ObjectPrx>& proxy, std::string facet)
     {
@@ -86,10 +86,11 @@ namespace Ice
         }
     }
 
-    /// Downcasts a proxy after confirming the target object's type via a remote invocation.
+    /// Creates a new proxy from an existing proxy after confirming the target object's type via a remote invocation.
     /// @param proxy The source proxy.
     /// @param context The request context.
-    /// @return A proxy with the requested type, or nullopt if the target object does not support the requested type.
+    /// @return A new proxy with the requested type, or nullopt if the target object does not support the requested
+    /// type.
     template<typename Prx, std::enable_if_t<std::is_base_of_v<ObjectPrx, Prx>, bool> = true>
     std::optional<Prx> checkedCast(const ObjectPrx& proxy, const Context& context = noExplicitContext)
     {
@@ -103,22 +104,22 @@ namespace Ice
         }
     }
 
-    /// Downcasts a proxy after confirming the target object's type via a remote invocation.
+    /// Creates a new proxy from an existing proxy after confirming the target object's type via a remote invocation.
     /// @param proxy The source proxy (can be nullopt).
     /// @param context The request context.
-    /// @return A proxy with the requested type, or nullopt if the source proxy is nullopt or if the target object does
-    /// not support the requested type.
+    /// @return A new proxy with the requested type, or nullopt if the target object does not support the requested
+    /// type.
     template<typename Prx, std::enable_if_t<std::is_base_of_v<ObjectPrx, Prx>, bool> = true>
     std::optional<Prx> checkedCast(const std::optional<ObjectPrx>& proxy, const Context& context = noExplicitContext)
     {
         return proxy ? checkedCast<Prx>(proxy.value(), context) : std::nullopt;
     }
 
-    /// Downcasts a proxy after confirming the target object's type via a remote invocation.
+    /// Creates a new proxy from an existing proxy after confirming the target object's type via a remote invocation.
     /// @param proxy The source proxy.
     /// @param facet A facet name.
     /// @param context The request context.
-    /// @return A proxy with the requested type and facet, or nullopt if the target facet is not of the requested
+    /// @return A new proxy with the requested type and facet, or nullopt if the target facet is not of the requested
     /// type.
     template<typename Prx, std::enable_if_t<std::is_base_of_v<ObjectPrx, Prx>, bool> = true>
     std::optional<Prx>
@@ -127,12 +128,12 @@ namespace Ice
         return checkedCast<Prx>(proxy->ice_facet(std::move(facet)), context);
     }
 
-    /// Downcasts a proxy after confirming the target object's type via a remote invocation.
+    /// Creates a new proxy from an existing proxy after confirming the target object's type via a remote invocation.
     /// @param proxy The source proxy (can be nullopt).
     /// @param facet A facet name.
     /// @param context The request context.
-    /// @return A proxy with the requested type and facet, or nullopt if the source proxy is nullopt, or if the target
-    /// facet is not of the requested type.
+    /// @return A new proxy with the requested type and facet, or nullopt if the target facet is not of the requested
+    /// type.
     template<typename Prx, std::enable_if_t<std::is_base_of_v<ObjectPrx, Prx>, bool> = true>
     std::optional<Prx>
     checkedCast(const std::optional<ObjectPrx>& proxy, std::string facet, const Context& context = noExplicitContext)

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -1988,12 +1988,11 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out.dec();
 
     ostringstream checkedCastSummary;
-    checkedCastSummary << "Downcasts a proxy to " << getArticleFor(name) << " <see cref=\"" << name
-                       << "Prx\" /> after checking that the target object implements Slice interface <c>" << p->name()
-                       << "</c>.";
+    checkedCastSummary << "Creates a new <see cref=\"" << name << "Prx\" /> from an existing proxy after checking that "
+                       << "the target object implements Slice interface <c>" << p->name() << "</c>.";
 
     ostringstream checkedCastReturns;
-    checkedCastReturns << "A proxy with the requested type, or null if the target object does not implement Slice"
+    checkedCastReturns << "A new proxy with the requested type, or null if the target object does not implement Slice"
                           " interface <c>"
                        << p->name() << "</c>.";
 
@@ -2013,12 +2012,12 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out.dec();
 
     ostringstream checkedCastWithFacetSummary;
-    checkedCastWithFacetSummary << "Downcasts a proxy to " << getArticleFor(name) << " <see cref=\"" << name
-                                << "Prx\" /> after checking that the target facet implements Slice interface <c>"
-                                << p->name() << "</c>.";
+    checkedCastWithFacetSummary << "Creates a new <see cref=\"" << name << "Prx\" /> from an existing proxy after "
+                                << "checking that the target facet implements Slice interface <c>" << p->name()
+                                << "</c>.";
 
     ostringstream checkedCastWithFacetReturns;
-    checkedCastWithFacetReturns << "A proxy with the requested type, or null if the target facet does not implement"
+    checkedCastWithFacetReturns << "A new proxy with the requested type, or null if the target facet does not implement"
                                    " Slice interface <c>"
                                 << p->name() << "</c>.";
 
@@ -2075,13 +2074,11 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out.dec();
 
     ostringstream uncheckedCastSummary;
-    uncheckedCastSummary << "Downcasts a proxy to " << getArticleFor(name) << " <see cref=\"" << name
-                         << "Prx\" />. This method does not perform any check.";
-
+    uncheckedCastSummary << "Creates a new <see cref=\"" << name << "Prx\" /> from an existing proxy.";
     _out << sp;
     writeDocLine(_out, "summary", uncheckedCastSummary.str());
     writeDocLine(_out, R"(param name="proxy")", "The source proxy.", "param");
-    writeDocLine(_out, "returns", "A proxy with the requested type, or null if the source proxy is null.");
+    writeDocLine(_out, "returns", "A new proxy with the requested type, or null if the source proxy is null.");
     _out << nl << "[return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(proxy))]";
     _out << nl << "public static " << name << "Prx? uncheckedCast(Ice.ObjectPrx? proxy) =>";
     _out.inc();
@@ -2089,14 +2086,14 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out.dec();
 
     ostringstream uncheckedCastWithFacetSummary;
-    uncheckedCastWithFacetSummary << "Downcasts a proxy to " << getArticleFor(name) << " <see cref=\"" << name
-                                  << "Prx\" /> after changing its facet. This method does not perform any check.";
+    uncheckedCastWithFacetSummary << "Creates a new <see cref=\"" << name
+                                  << "Prx\" /> from an existing proxy after changing its facet.";
 
     _out << sp;
     writeDocLine(_out, "summary", uncheckedCastWithFacetSummary.str());
     writeDocLine(_out, R"(param name="proxy")", "The source proxy.", "param");
     writeDocLine(_out, R"(param name="facet")", "The facet.", "param");
-    writeDocLine(_out, "returns", "A proxy with the requested type, or null if the source proxy is null.");
+    writeDocLine(_out, "returns", "A new proxy with the requested type, or null if the source proxy is null.");
     _out << nl << "[return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(proxy))]";
     _out << nl << "public static " << name << "Prx? uncheckedCast(Ice.ObjectPrx? proxy, string facet) =>";
     _out.inc();

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -4231,9 +4231,10 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     out << sp;
     writeDocComment(
         out,
-        "Contacts the remote server to verify that the object implements this type.\n"
-        "Raises a local exception if a communication error occurs.\n"
-        "@param obj The untyped proxy.\n"
+        "Creates a new proxy from an existing proxy after confirming the target object's type via a remote "
+        "invocation.\n"
+        "Throws a local exception if a communication error occurs.\n"
+        "@param obj The source proxy.\n"
         "@return A proxy for this type, or null if the object does not support this type.");
     out << nl << "static " << prxName << " checkedCast(com.zeroc.Ice.ObjectPrx obj)";
     out << sb;
@@ -4243,11 +4244,12 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     out << sp;
     writeDocComment(
         out,
-        "Contacts the remote server to verify that the object implements this type.\n"
-        "Raises a local exception if a communication error occurs.\n"
-        "@param obj The untyped proxy.\n"
+        "Creates a new proxy from an existing proxy after confirming the target object's type via a remote "
+        "invocation.\n"
+        "Throws a local exception if a communication error occurs.\n"
+        "@param obj The source proxy.\n"
         "@param context The Context map to send with the invocation.\n"
-        "@return A proxy for this type, or null if the object does not support this type.");
+        "@return A new proxy for this type, or null if the object does not support this type.");
     out << nl << "static " << prxName << " checkedCast(com.zeroc.Ice.ObjectPrx obj, " << contextParam << ')';
     out << sb;
     out << nl << "return (obj != null && obj.ice_isA(ice_staticId(), context)) ? new " << prxIName << "(obj) : null;";
@@ -4256,11 +4258,12 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     out << sp;
     writeDocComment(
         out,
-        "Contacts the remote server to verify that a facet of the object implements this type.\n"
-        "Raises a local exception if a communication error occurs.\n"
-        "@param obj The untyped proxy.\n"
+        "Creates a new proxy from an existing proxy after confirming the target object's type via a remote "
+        "invocation.\n"
+        "Throws a local exception if a communication error occurs.\n"
+        "@param obj The source proxy.\n"
         "@param facet The name of the desired facet.\n"
-        "@return A proxy for this type, or null if the object does not support this type.");
+        "@return A new proxy for this type, or null if the facet does not support this type.");
     out << nl << "static " << prxName << " checkedCast(com.zeroc.Ice.ObjectPrx obj, java.lang.String facet)";
     out << sb;
     out << nl << "return checkedCast(obj, facet, noExplicitContext);";
@@ -4269,12 +4272,13 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     out << sp;
     writeDocComment(
         out,
-        "Contacts the remote server to verify that a facet of the object implements this type.\n"
-        "Raises a local exception if a communication error occurs.\n"
-        "@param obj The untyped proxy.\n"
+        "Creates a new proxy from an existing proxy after confirming the target object's type via a remote "
+        "invocation.\n"
+        "Throws a local exception if a communication error occurs.\n"
+        "@param obj The source proxy.\n"
         "@param facet The name of the desired facet.\n"
         "@param context The Context map to send with the invocation.\n"
-        "@return A proxy for this type, or null if the object does not support this type.");
+        "@return A new proxy for this type, or null if the object does not support this type.");
     out << nl << "static " << prxName << " checkedCast(com.zeroc.Ice.ObjectPrx obj, java.lang.String facet, "
         << contextParam << ')';
     out << sb;
@@ -4284,9 +4288,9 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     out << sp;
     writeDocComment(
         out,
-        "Downcasts the given proxy to this type without contacting the remote server.\n"
+        "Creates a new proxy from an existing proxy.\n"
         "@param obj The untyped proxy.\n"
-        "@return A proxy for this type.");
+        "@return A new proxy for this type.");
     out << nl << "static " << prxName << " uncheckedCast(com.zeroc.Ice.ObjectPrx obj)";
     out << sb;
     out << nl << "return (obj == null) ? null : new " << prxIName << "(obj);";
@@ -4295,10 +4299,10 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     out << sp;
     writeDocComment(
         out,
-        "Downcasts the given proxy to this type without contacting the remote server.\n"
+        "Creates a new proxy from an existing proxy.\n"
         "@param obj The untyped proxy.\n"
         "@param facet The name of the desired facet.\n"
-        "@return A proxy for this type.");
+        "@return A new proxy for this type.");
     out << nl << "static " << prxName << " uncheckedCast(com.zeroc.Ice.ObjectPrx obj, java.lang.String facet)";
     out << sb;
     out << nl << "return (obj == null) ? null : new " << prxIName << "(obj.ice_facet(facet));";

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -2394,10 +2394,10 @@ Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     _out << sp;
     _out << nl << "/**";
-    _out << nl << " * Downcasts a proxy without confirming the target object's type via a remote invocation.";
-    _out << nl << " * @param prx The target proxy.";
+    _out << nl << " * Creates a new proxy from an existing proxy.";
+    _out << nl << " * @param prx The source proxy.";
     _out << nl << " * @param facet An optional facet name.";
-    _out << nl << " * @returns A proxy with the requested type and facet, or null if the target proxy is null.";
+    _out << nl << " * @returns A new proxy with the requested type and facet, or null if the source proxy is null.";
     _out << nl << " */";
     _out << nl << "static uncheckedCast(prx: " << _iceImportPrefix << "Ice.ObjectPrx"
          << ", "
@@ -2405,10 +2405,10 @@ Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     _out << sp;
     _out << nl << "/**";
-    _out << nl << " * Downcasts a proxy without confirming the target object's type via a remote invocation.";
-    _out << nl << " * @param prx The target proxy.";
+    _out << nl << " * Creates a new proxy from an existing proxy.";
+    _out << nl << " * @param prx The source proxy.";
     _out << nl << " * @param facet An optional facet name.";
-    _out << nl << " * @returns A proxy with the requested type and facet, or null if the target proxy is null.";
+    _out << nl << " * @returns A new proxy with the requested type and facet, or null if the source proxy is null.";
     _out << nl << " */";
     _out << nl << "static uncheckedCast(prx: " << _iceImportPrefix << "Ice.ObjectPrx | null"
          << ", "
@@ -2416,13 +2416,15 @@ Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     _out << sp;
     _out << nl << "/**";
-    _out << nl << " * Downcasts a proxy after confirming the target object's type via a remote invocation.";
-    _out << nl << " * @param prx The target proxy.";
+    _out << nl
+         << " * Creates a new proxy from an existing proxy after confirming the target object's type via a remote "
+            "invocation.";
+    _out << nl << " * @param prx The source proxy.";
     _out << nl << " * @param facet An optional facet name.";
     _out << nl << " * @param context The request context.";
     _out << nl
-         << " * @returns A proxy with the requested type and facet, or null if the target proxy is null or the target";
-    _out << nl << " * object does not support the requested type.";
+         << " * @returns A proxy with the requested type and facet, or null if the target object does not support the "
+            "requested type.";
     _out << nl << " */";
     _out << nl << "static checkedCast(prx: " << _iceImportPrefix << "Ice.ObjectPrx | null"
          << ", "

--- a/cpp/src/slice2matlab/Gen.cpp
+++ b/cpp/src/slice2matlab/Gen.cpp
@@ -669,11 +669,8 @@ namespace
         }
         out << nl << "%";
         out << nl << "%   " << name << " Static Methods:";
-        out << nl
-            << "%     checkedCast - Contacts the remote server to check if the target object implements Slice "
-               "interface "
-            << p->scoped() << ".";
-        out << nl << "%     uncheckedCast - Creates a " << name << " from another proxy without any validation.";
+        out << nl << "%     checkedCast - Creates a new proxy from an existing proxy after checking the target's type.";
+        out << nl << "%     uncheckedCast - Creates a new " << name << " from an existing proxy.";
 
         writeDeprecated(out, doc, p);
         writeSeeAlso(out, doc, p->container());
@@ -1523,11 +1520,13 @@ CodeVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     out << sp;
     out << nl << "function r = checkedCast(p, varargin)";
     out.inc();
-    out << nl << "%CHECKEDCAST Contacts the remote server to check if the target object implements Slice interface "
+    out << nl
+        << "%CHECKEDCAST Creates a new proxy from an existing proxy after confirming the target object implements "
+           "Slice interface "
         << p->scoped() << ".";
     out << nl << "%";
     out << nl << "%   Input Arguments";
-    out << nl << "%     p - The proxy to check.";
+    out << nl << "%     p - The source proxy.";
     out << nl << "%       Ice.ObjectPrx scalar | empty array of Ice.ObjectPrx";
     out << nl << "%     facet - The desired facet (optional).";
     out << nl << "%       character vector";
@@ -1535,7 +1534,7 @@ CodeVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     out << nl << "%       dictionary(string, string) scalar";
     out << nl << "%";
     out << nl << "%   Output Arguments";
-    out << nl << "%     r - A " << prxAbs << " scalar if the target object implements Slice interface ";
+    out << nl << "%     r - A new " << prxAbs << " scalar if the target object implements Slice interface ";
     out << nl << "%       " << p->scoped() << "; otherwise, an empty array of " << prxAbs << ".";
     out << nl << "%";
     out << nl << "arguments";
@@ -1555,7 +1554,7 @@ CodeVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     out << sp;
     out << nl << "function r = uncheckedCast(p, varargin)";
     out.inc();
-    out << nl << "%UNCHECKEDCAST Creates a " << prxAbs << " from another proxy without any validation.";
+    out << nl << "%UNCHECKEDCAST Creates a new " << prxAbs << " from an existing proxy.";
     out << nl << "%";
     out << nl << "%   Input Arguments";
     out << nl << "%     p - The source proxy.";

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -1186,19 +1186,21 @@ Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     // checkedCast
     //
     out << sp;
-    out << nl << "/// Casts a proxy to the requested type. This call contacts the server and verifies that the object";
-    out << nl << "/// implements this type.";
+    out << nl
+        << "/// Creates a new proxy from an existing proxy after confirming the target object's type via a remote "
+           "invocation.";
     out << nl << "///";
-    out << nl << "/// It will throw a local exception if a communication error occurs. You can optionally supply a";
+    out << nl << "/// This call throws a local exception if a communication error occurs. You can optionally supply a";
     out << nl << "/// facet name and a context map.";
     out << nl << "///";
     out << nl << "/// - Parameters:";
-    out << nl << "///   - prx: The proxy to be cast.";
-    out << nl << "///   - type: The proxy type to cast to.";
+    out << nl << "///   - prx: The source proxy.";
+    out << nl << "///   - type: The type of the new proxy.";
     out << nl << "///   - facet: The optional name of the desired facet.";
     out << nl << "///   - context: The optional context dictionary for the remote invocation.";
     out << nl << "///";
-    out << nl << "/// - Returns: A proxy with the requested type or nil if the objet does not support this type.";
+    out << nl
+        << "/// - Returns: A proxy with the requested type or nil if the target object does not support this type.";
     out << nl << "///";
     out << nl << "/// - Throws: `Ice.LocalException` if a communication error occurs.";
     out << nl << "public func checkedCast" << spar << ("prx: " + getUnqualified("Ice.ObjectPrx", swiftModule))
@@ -1214,14 +1216,14 @@ Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     // uncheckedCast
     //
     out << sp;
-    out << nl << "/// Downcasts the given proxy to this type without contacting the remote server.";
+    out << nl << "/// Creates a new proxy from an existing proxy.";
     out << nl << "///";
     out << nl << "/// - Parameters:";
-    out << nl << "///   - prx: The proxy to be cast.";
-    out << nl << "///   - type: The proxy type to cast to.";
+    out << nl << "///   - prx: The source proxy.";
+    out << nl << "///   - type: The type of the new proxy.";
     out << nl << "///   - facet: The optional name of the desired facet.";
     out << nl << "///";
-    out << nl << "/// - Returns: A proxy with the requested type.";
+    out << nl << "/// - Returns: A new proxy with the requested type.";
     out << nl << "public func uncheckedCast" << spar << ("prx: " + getUnqualified("Ice.ObjectPrx", swiftModule))
         << ("type: " + prx + ".Protocol") << ("facet: Swift.String? = nil") << epar << " -> " << prx;
     out << sb;

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -1794,34 +1794,34 @@ public class ObjectPrxHelper : ObjectPrxHelperBase
     }
 
     /// <summary>
-    /// Downcasts a proxy after confirming the target object's type via a remote invocation.
+    /// Creates a new proxy from an existing proxy after confirming the target object's type via a remote invocation.
     /// </summary>
     /// <param name="proxy">The source proxy.</param>
     /// <param name="context">The request context.</param>
-    /// <returns>A proxy with the requested type, or null if the source proxy is null or if the target object does not
-    /// support the requested type.</returns>
+    /// <returns>A new proxy with the requested type, or null if the target object does not support the requested type.
+    /// </returns>
     public static ObjectPrx? checkedCast(ObjectPrx? proxy, Dictionary<string, string>? context = null) =>
         proxy is not null && proxy.ice_isA("::Ice::Object", context) ? proxy : null;
 
     /// <summary>
-    /// Downcasts a proxy after confirming the target object's type via a remote invocation.
+    /// Creates a new proxy from an existing proxy after confirming the target object's type via a remote invocation.
     /// </summary>
     /// <param name="proxy">The source proxy (can be null).</param>
     /// <param name="facet">A facet name.</param>
     /// <param name="context">The request context.</param>
-    /// <returns>A proxy with the requested type and facet, or null if the source proxy is null or if the target facet
-    /// does not support the requested type.</returns>
+    /// <returns>A new proxy with the requested type and facet, or null if the target facet does not support the
+    /// requested type.</returns>
     public static ObjectPrx? checkedCast(ObjectPrx? proxy, string facet, Dictionary<string, string>? context = null) =>
         checkedCast(proxy?.ice_facet(facet), context);
 
     /// <summary>
-    /// Downcasts a proxy after confirming the target object's type via a remote invocation.
+    /// Creates a new proxy from an existing proxy after confirming the target object's type via a remote invocation.
     /// </summary>
     /// <param name="proxy">The source proxy.</param>
     /// <param name="context">The request context.</param>
     /// <param name="progress">Sent progress provider.</param>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
-    /// <returns>A proxy with the requested type, or null if the target object does not support the requested type.
+    /// <returns>A new proxy with the requested type, or null if the target object does not support the requested type.
     /// </returns>
     public static async Task<ObjectPrx?> checkedCastAsync(
         ObjectPrx proxy,
@@ -1831,15 +1831,15 @@ public class ObjectPrxHelper : ObjectPrxHelperBase
        await proxy.ice_isAAsync("::Ice::Object", context, progress, cancel).ConfigureAwait(false) ? proxy : null;
 
     /// <summary>
-    /// Downcasts a proxy after confirming the target object's type via a remote invocation.
+    /// Creates a new proxy from an existing proxy after confirming the target object's type via a remote invocation.
     /// </summary>
     /// <param name="proxy">The source proxy.</param>
     /// <param name="facet">A facet name.</param>
     /// <param name="context">The request context.</param>
     /// <param name="progress">Sent progress provider.</param>
     /// <param name="cancel">A cancellation token that receives the cancellation requests.</param>
-    /// <returns>A proxy with the requested type and facet, or null if the target facet does not support the requested
-    /// type.</returns>
+    /// <returns>A new proxy with the requested type and facet, or null if the target facet does not support the
+    /// requested type.</returns>
     public static Task<ObjectPrx?> checkedCastAsync(
         ObjectPrx proxy,
         string facet,
@@ -1849,19 +1849,21 @@ public class ObjectPrxHelper : ObjectPrxHelperBase
         checkedCastAsync(proxy.ice_facet(facet), context, progress, cancel);
 
     /// <summary>
-    /// Downcasts a proxy without confirming the target object's type via a remote invocation.
+    /// Creates a new proxy from an existing proxy.
     /// </summary>
     /// <param name="proxy">The source proxy.</param>
-    /// <returns>A proxy with the requested type.</returns>
+    /// <returns>A new proxy with the requested type.</returns>
+    /// <remarks>This is a purely local operation.</remarks>
     [return: NotNullIfNotNull(nameof(proxy))]
     public static ObjectPrx? uncheckedCast(ObjectPrx? proxy) => proxy;
 
     /// <summary>
-    /// Downcasts a proxy without confirming the target object's type via a remote invocation.
+    /// Creates a new proxy from an existing proxy.
     /// </summary>
     /// <param name="proxy">The source proxy.</param>
     /// <param name="facet">A facet name.</param>
-    /// <returns>A proxy with the requested type and facet, or null if the source proxy is null.</returns>
+    /// <returns>A new proxy with the requested type and facet, or null if the source proxy is null.</returns>
+    /// <remarks>This is a purely local operation.</remarks>
     [return: NotNullIfNotNull(nameof(proxy))]
     public static ObjectPrx? uncheckedCast(ObjectPrx? proxy, string facet) => proxy?.ice_facet(facet);
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
@@ -712,7 +712,7 @@ public interface ObjectPrx {
      * @param obj The source proxy.
      * @param facet The facet for the new proxy.
      * @return A new proxy with the specified facet, or {@code null} if the target facet does not support the specified
-     * type.
+     *         type.
      */
     static ObjectPrx checkedCast(ObjectPrx obj, String facet) {
         return checkedCast(obj, facet, noExplicitContext);
@@ -725,7 +725,7 @@ public interface ObjectPrx {
      * @param facet The facet for the new proxy.
      * @param context The <code>Context</code> map for the invocation.
      * @return A new proxy with the specified facet, or {@code null} if the target facet does not support the specified
-     * type.
+     *         type.
      */
     static ObjectPrx checkedCast(
             ObjectPrx obj, String facet, Map<String, String> context) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectPrx.java
@@ -686,52 +686,46 @@ public interface ObjectPrx {
     }
 
     /**
-     * Casts a proxy to {@link ObjectPrx}. For user-defined types, this call contacts the server and
-     * will throw an Ice run-time exception if the target object does not exist or the server cannot
-     * be reached.
+     * Creates a new proxy from an existing proxy after confirming the target object's type via a remote invocation.
      *
-     * @param obj The proxy to cast to {@link ObjectPrx}.
-     * @return {@code obj}.
+     * @param obj The source proxy.
+     * @return A new proxy or {@code null} if the target object does not support the specified type.
      */
     static ObjectPrx checkedCast(ObjectPrx obj) {
         return checkedCast(obj, noExplicitContext);
     }
 
     /**
-     * Casts a proxy to {@link ObjectPrx}. For user-defined types, this call contacts the server and
-     * throws an Ice run-time exception if the target object does not exist or the server cannot be
-     * reached.
+     * Creates a new proxy from an existing proxy after confirming the target object's type via a remote invocation.
      *
-     * @param obj The proxy to cast to {@link ObjectPrx}.
+     * @param obj The source proxy.
      * @param context The {@code Context} map for the invocation.
-     * @return {@code obj}.
+     * @return A new proxy or {@code null} if the target object does not support the specified type.
      */
     static ObjectPrx checkedCast(ObjectPrx obj, Map<String, String> context) {
         return obj != null && obj.ice_isA(ice_staticId, context) ? obj : null;
     }
 
     /**
-     * Creates a new proxy that is identical to the passed proxy, except for its facet. This call
-     * contacts the server and throws an Ice run-time exception if the target object does not exist,
-     * the specified facet does not exist, or the server cannot be reached.
+     * Creates a new proxy from an existing proxy after confirming the target object's type via a remote invocation.
      *
-     * @param obj The proxy to cast to {@link ObjectPrx}.
+     * @param obj The source proxy.
      * @param facet The facet for the new proxy.
-     * @return The new proxy with the specified facet.
+     * @return A new proxy with the specified facet, or {@code null} if the target facet does not support the specified
+     * type.
      */
     static ObjectPrx checkedCast(ObjectPrx obj, String facet) {
         return checkedCast(obj, facet, noExplicitContext);
     }
 
     /**
-     * Creates a new proxy that is identical to the passed proxy, except for its facet. This call
-     * contacts the server and throws an Ice run-time exception if the target object does not exist,
-     * the specified facet does not exist, or the server cannot be reached.
+    * Creates a new proxy from an existing proxy after confirming the target object's type via a remote invocation.
      *
-     * @param obj The proxy to cast to {@link ObjectPrx}.
+     * @param obj The source proxy.
      * @param facet The facet for the new proxy.
      * @param context The <code>Context</code> map for the invocation.
-     * @return The new proxy with the specified facet.
+     * @return A new proxy with the specified facet, or {@code null} if the target facet does not support the specified
+     * type.
      */
     static ObjectPrx checkedCast(
             ObjectPrx obj, String facet, Map<String, String> context) {
@@ -739,23 +733,21 @@ public interface ObjectPrx {
     }
 
     /**
-     * Casts a proxy to {@link ObjectPrx}. This call does not contact the server and always
-     * succeeds.
+     * Creates a new proxy from an existing proxy.
      *
-     * @param obj The proxy to cast to {@link ObjectPrx}.
-     * @return {@code obj}.
+     * @param obj The source proxy.
+     * @return A new proxy with the desired type or {@code null} if {@code obj} is {@code null}.
      */
     static ObjectPrx uncheckedCast(ObjectPrx obj) {
         return obj;
     }
 
     /**
-     * Creates a new proxy that is identical to the passed proxy, except for its facet. This call
-     * does not contact the server and always succeeds.
+    * Creates a new proxy from an existing proxy.
      *
-     * @param obj The proxy to cast to {@link ObjectPrx}.
+     * @param obj The source proxy.
      * @param facet The facet for the new proxy.
-     * @return The new proxy with the specified facet.
+     * @return A new proxy with the desired type or {@code null} if {@code obj} is {@code null}.
      */
     static ObjectPrx uncheckedCast(ObjectPrx obj, String facet) {
         return obj == null ? null : obj.ice_facet(facet);

--- a/js/src/Ice/ObjectPrx.d.ts
+++ b/js/src/Ice/ObjectPrx.d.ts
@@ -427,27 +427,28 @@ declare module "@zeroc/ice" {
             equals(other: ObjectPrx | null | undefined): boolean;
 
             /**
-             * Downcasts a proxy without confirming the target object's type via a remote invocation.
+             * Creates a new proxy from an existing proxy.
              *
-             * @param prx - The target proxy to be downcast.
+             * @param prx - The source proxy.
              * @param facet - An optional facet name.
              * @returns A proxy with the requested type and facet, or null if the source proxy is null.
              */
             static uncheckedCast(prx: ObjectPrx, facet?: string): ObjectPrx;
 
             /**
-             * Downcasts a proxy without confirming the target object's type via a remote invocation.
+             * Creates a new proxy from an existing proxy.
              *
-             * @param prx - The target proxy to be downcast.
+             * @param prx - The source proxy.
              * @param facet - An optional facet name.
              * @returns A proxy with the requested type and facet, or null if the source proxy is null.
              */
             static uncheckedCast(prx: ObjectPrx | null, facet?: string): ObjectPrx | null;
 
             /**
-             * Downcasts a proxy after confirming the target object's type via a remote invocation.
+             * Creates a new proxy from an existing proxy after confirming the target object's type via a remote
+             * invocation.
              *
-             * @param prx - The target proxy to be downcast.
+             * @param prx - The source proxy.
              * @param facet - An optional facet name.
              * @param context - An optional context map for the invocation.
              * @returns An asynchronous result resolving to a proxy with the requested type and facet, or `null` if the

--- a/matlab/lib/+Ice/ObjectPrx.m
+++ b/matlab/lib/+Ice/ObjectPrx.m
@@ -1350,11 +1350,11 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = checkedCast(p, varargin)
-            %CHECKEDCAST Contacts the remote server to check if the target object implements the pseudo-Slice interface
-            %   Ice::Object.
+            %CHECKEDCAST Creates a proxy from an existing proxy after contacting the server to check if the target
+            %   object implements pseudo-Slice interface Ice::Object.
             %
             %   Input Arguments
-            %     p - The proxy to check.
+            %     p - The source proxy.
             %       Ice.ObjectPrx scalar | empty array of Ice.ObjectPrx
             %     facet - The desired facet (optional).
             %       character vector
@@ -1362,7 +1362,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
             %       dictionary(string, string) scalar
             %
             %   Output Arguments
-            %     r - An Ice.ObjectPrx scalar if the target object implements Slice interface
+            %     r - A new Ice.ObjectPrx scalar if the target object implements Slice interface
             %       ::Ice::Object; otherwise, an empty array of Ice.ObjectPrx.
             %
             arguments
@@ -1375,7 +1375,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
         end
 
         function r = uncheckedCast(p, varargin)
-            %UNCHECKEDCAST Creates an Ice.ObjectPrx from another proxy without any validation.
+            %UNCHECKEDCAST Creates a new Ice.ObjectPrx from an existing proxy without any validation.
             %
             %   Input Arguments
             %     p - The source proxy.

--- a/python/python/Ice/ObjectPrx.py
+++ b/python/python/Ice/ObjectPrx.py
@@ -33,7 +33,7 @@ def uncheckedCast(type: Type[T], proxy: None, facet: str | None = None) -> None:
 
 def uncheckedCast(type: Type[T], proxy: ObjectPrx | None, facet: str | None = None) -> T | None:
     """
-    Downcasts a proxy without confirming the target object's type via a remote invocation.
+    Creates a new proxy from an existing proxy.
 
     Parameters
     ----------
@@ -49,7 +49,7 @@ def uncheckedCast(type: Type[T], proxy: ObjectPrx | None, facet: str | None = No
     Returns
     -------
     ObjectPrx | None
-        A proxy with the requested type.
+        A new proxy with the requested type, or None if the source proxy is None.
     """
     if proxy is None:
         return None
@@ -62,7 +62,7 @@ def checkedCast(
     type: Type[T], proxy: ObjectPrx | None, facet: str | None = None, context: dict[str, str] | None = None
 ) -> T | None:
     """
-    Downcasts a proxy after confirming the target object's type via a remote invocation.
+    Creates a new proxy from an existing proxy after confirming the target object's type via a remote invocation.
 
     Parameters
     ----------
@@ -81,7 +81,8 @@ def checkedCast(
     Returns
     -------
     ObjectPrx | None
-        A proxy with the requested type, or None if the target object does not support the requested type.
+        A new proxy with the requested type, or None if the source proxy is None or if the target object does not
+        support the requested type.
     """
     if proxy is None:
         return None
@@ -94,7 +95,7 @@ async def checkedCastAsync(
     type: Type[T], proxy: ObjectPrx | None, facet: str | None = None, context: dict[str, str] | None = None
 ) -> T | None:
     """
-    Downcasts a proxy after confirming the target object's type via a remote invocation.
+    Creates a new proxy from an existing proxy after confirming the target object's type via a remote invocation.
 
     Parameters
     ----------
@@ -113,7 +114,8 @@ async def checkedCastAsync(
     Returns
     -------
     ObjectPrx | None
-        A proxy with the requested type, or None if the target object does not support the requested type.
+        A new proxy with the requested type, or None if the source proxy is None or if the target object does not
+        support the requested type.
     """
     if proxy is None:
         return None
@@ -129,9 +131,9 @@ class ObjectPrx(IcePy.ObjectPrx):
     """
 
     @staticmethod
-    def uncheckedCast(proxy: ObjectPrx, facet: str | None = None) -> ObjectPrx | None:
+    def uncheckedCast(proxy: ObjectPrx | None, facet: str | None = None) -> ObjectPrx | None:
         """
-        Downcasts a proxy without confirming the target object's type via a remote invocation.
+        Creates a new proxy from an existing proxy.
 
         Parameters
         ----------
@@ -144,16 +146,16 @@ class ObjectPrx(IcePy.ObjectPrx):
         Returns
         -------
         ObjectPrx | None
-            A proxy with the requested type, or None if the target object does not support the requested type.
+            A new proxy with the requested type, or None if the source proxy is None.
         """
         return uncheckedCast(ObjectPrx, proxy, facet)
 
     @staticmethod
     def checkedCast(
-        proxy: ObjectPrx, facet: str | None = None, context: dict[str, str] | None = None
+        proxy: ObjectPrx | None, facet: str | None = None, context: dict[str, str] | None = None
     ) -> ObjectPrx | None:
         """
-        Downcasts a proxy after confirming the target object's type via a remote invocation.
+        Creates a new proxy from an existing proxy after confirming the target object's type via a remote invocation.
 
         Parameters
         ----------
@@ -169,7 +171,8 @@ class ObjectPrx(IcePy.ObjectPrx):
         Returns
         -------
         ObjectPrx | None
-            A proxy with the requested type, or None if the target object does not support the requested type.
+            A new proxy with the requested type, or None if the source proxy is None or if the target object does not
+            support the requested type.
         """
         return checkedCast(ObjectPrx, proxy, facet, context)
 
@@ -178,7 +181,7 @@ class ObjectPrx(IcePy.ObjectPrx):
         proxy: ObjectPrx, facet: str | None = None, context: dict[str, str] | None = None
     ) -> Awaitable[ObjectPrx | None]:
         """
-        Downcasts a proxy after confirming the target object's type via a remote invocation.
+        Creates a new proxy from an existing proxy after confirming the target object's type via a remote invocation.
 
         Parameters
         ----------
@@ -194,7 +197,8 @@ class ObjectPrx(IcePy.ObjectPrx):
         Returns
         -------
         ObjectPrx | None
-            A proxy with the requested type, or None if the target object does not support the requested type.
+            A new proxy with the requested type, or None if the source proxy is None or if the target object does not
+            support the requested type.
         """
         return checkedCastAsync(ObjectPrx, proxy, facet, context)
 

--- a/swift/src/Ice/CommunicatorI.swift
+++ b/swift/src/Ice/CommunicatorI.swift
@@ -286,7 +286,7 @@ extension Communicator {
     /// the plug-ins by default, but an application may need to interact directly with
     /// a plug-in prior to initialization. In this case, the application must set
     /// `Ice.InitPlugins=0` and then invoke `initializePlugins` manually. The plug-ins are
-    /// initialized in the order in which they are loaded. If a plug-in raises an exception
+    /// initialized in the order in which they are loaded. If a plug-in throws an exception
     /// during initialization, the communicator invokes destroy on the plug-ins that have
     /// already been initialized.
     ///

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -1091,7 +1091,7 @@ private class EncapsDecoder10: EncapsDecoder {
                 //
                 // An oversight in the 1.0 encoding means there is no marker to indicate
                 // the last slice of an exception. As a result, we just try to read the
-                // next type ID, which raises MarshalException when the
+                // next type ID, which throws MarshalException when the
                 // input buffer underflows.
 
                 throw MarshalException("unknown exception type '\(mostDerivedId)'")

--- a/swift/src/Ice/Proxy.swift
+++ b/swift/src/Ice/Proxy.swift
@@ -315,21 +315,20 @@ public func makeProxy(communicator: Ice.Communicator, proxyString: String, type:
     try communicator.makeProxyImpl(proxyString) as ObjectPrxI
 }
 
-/// Casts a proxy to `Ice.ObjectPrx`. This call contacts the server and will throw an Ice run-time exception
-/// if the target object does not exist or the server cannot be reached.
+/// Creates a new proxy from an existing proxy after confirming the target object's type via a remote invocation.
 ///
-/// - parameter prx: `Ice.ObjectPrx` - The proxy to cast to `Ice.ObjectPrx`.
+/// - parameter prx: `Ice.ObjectPrx` - The source proxy.
 ///
-/// - parameter type: `Ice.ObjectPrx.Protocol` - The proxy type to cast to.
+/// - parameter type: `Ice.ObjectPrx.Protocol` - The type of the new proxy.
 ///
 /// - parameter facet: `String?` - The optional facet for the new proxy.
 ///
 /// - parameter context: `Ice.Context?` - The optional context dictionary for the invocation.
 ///
-/// - throws: Throws an Ice run-time exception if the target object does not exist, the specified facet
+/// - throws: Throws an Ice local exception if the target object does not exist, the specified facet
 ///   does not exist, or the server cannot be reached.
 ///
-/// - returns: The new proxy with the specified facet or nil if the target object does not support the specified
+/// - returns: A new proxy with the specified facet or nil if the target object does not support the specified
 ///   interface.
 public func checkedCast(
     prx: Ice.ObjectPrx,
@@ -340,16 +339,15 @@ public func checkedCast(
     return try await ObjectPrxI.checkedCast(prx: prx, facet: facet, context: context) as ObjectPrxI?
 }
 
-/// Creates a new proxy that is identical to the passed proxy, except for its facet. This call does
-/// not contact the server and always succeeds.
+/// Creates a new proxy from an existing proxy.
 ///
-/// - parameter prx: `Ice.ObjectPrx` - The proxy to cast to `Ice.ObjectPrx`.
+/// - parameter prx: `Ice.ObjectPrx` - The source proxy.
 ///
-/// - parameter type: `Ice.ObjectPrx.Protocol` - The proxy type to cast to.
+/// - parameter type: `Ice.ObjectPrx.Protocol` - The type of the new proxy.
 ///
 /// - parameter facet: `String?` - The optional facet for the new proxy.
 ///
-/// - returns: The new proxy with the specified facet.
+/// - returns: A new proxy with the specified facet.
 public func uncheckedCast(
     prx: Ice.ObjectPrx,
     type _: ObjectPrx.Protocol,


### PR DESCRIPTION
This PR updates the doc-comments for checkedCast and uncheckedCast, and avoids using the term "downcast" and "cast".

Both checkedCast and uncheckedCast are factory methods. They don't perform any casting.