### PR TITLE
ice_facet and stringToProxy cleanup

### DIFF
--- a/cpp/src/IceBridge/IceBridge.cpp
+++ b/cpp/src/IceBridge/IceBridge.cpp
@@ -61,11 +61,9 @@ namespace
 
         [[nodiscard]] optional<ObjectPrx> getServerProxy(const Current& current) const final
         {
-            //
-            // We return a non-nil dummy proxy here so that a client is able to configure its
+            // We return a non-null dummy proxy here so that a client is able to configure its
             // callback object adapter with a router proxy.
-            //
-            return current.adapter->getCommunicator()->stringToProxy("dummy");
+            return ObjectPrx{current.adapter->getCommunicator(), "dummy"};
         }
 
         ObjectProxySeq addProxies(ObjectProxySeq, const Current&) final { return {}; }

--- a/cpp/src/IceDiscovery/LocatorI.cpp
+++ b/cpp/src/IceDiscovery/LocatorI.cpp
@@ -14,8 +14,8 @@ using namespace Ice;
 using namespace IceDiscovery;
 
 LocatorRegistryI::LocatorRegistryI(const Ice::CommunicatorPtr& communicator)
-    : _wellKnownProxy(
-          ObjectPrx(communicator, "dummy")->ice_locator(nullopt)->ice_router(nullopt)->ice_collocationOptimized(true))
+    : _wellKnownProxy{
+          ObjectPrx{communicator, "dummy"}.ice_locator(nullopt).ice_router(nullopt).ice_collocationOptimized(true)}
 {
 }
 

--- a/cpp/src/IceGrid/Database.cpp
+++ b/cpp/src/IceGrid/Database.cpp
@@ -1143,7 +1143,7 @@ Database::getAdapterDirectProxy(
     }
     if (!endpoints.empty())
     {
-        return _communicator->stringToProxy("dummy:default")->ice_endpoints(endpoints);
+        return Ice::ObjectPrx{_communicator, "dummy:default"}.ice_endpoints(endpoints);
     }
     return nullopt;
 }

--- a/cpp/src/IceGrid/DescriptorHelper.cpp
+++ b/cpp/src/IceGrid/DescriptorHelper.cpp
@@ -317,7 +317,7 @@ namespace
         {
             try
             {
-                resolver.getCommunicator()->stringToProxy("dummy " + proxyOptions);
+                ObjectPrx proxy{resolver.getCommunicator(), "dummy " + proxyOptions};
             }
             catch (const Ice::ParseException& ex)
             {

--- a/cpp/src/IceGrid/RegistryI.cpp
+++ b/cpp/src/IceGrid/RegistryI.cpp
@@ -309,8 +309,7 @@ RegistryI::startImpl()
     {
         string endpoints = properties->getIceProperty("IceGrid.Registry.Client.Endpoints");
         string strPrx = _instanceName + "/Locator:" + endpoints;
-        _communicator->stringToProxy(strPrx)->ice_invocationTimeout(5s)->ice_ping();
-
+        ObjectPrx{_communicator, strPrx}.ice_invocationTimeout(5s).ice_ping();
         Error out(_communicator->getLogger());
         out << "an IceGrid registry is already running and listening on the client endpoints '" << endpoints << "'";
         return false;

--- a/cpp/src/IceGrid/Util.cpp
+++ b/cpp/src/IceGrid/Util.cpp
@@ -237,14 +237,14 @@ IceGrid::toObjectInfo(
     proxyStr << " @ \"" << adapterId << "\"";
     try
     {
-        info.proxy = communicator->stringToProxy(proxyStr.str());
+        info.proxy = ObjectPrx{communicator, proxyStr.str()};
     }
     catch (const Ice::ParseException&)
     {
         ostringstream fallbackProxyStr;
         fallbackProxyStr << "\"" << communicator->identityToString(obj.id) << "\""
                          << " @ \"" << adapterId << "\"";
-        info.proxy = communicator->stringToProxy(fallbackProxyStr.str());
+        info.proxy = ObjectPrx{communicator, fallbackProxyStr.str()};
     }
     return info;
 }

--- a/cpp/src/IceStorm/Service.cpp
+++ b/cpp/src/IceStorm/Service.cpp
@@ -203,7 +203,7 @@ ServiceI::start([[maybe_unused]] const string& serviceName, const CommunicatorPt
             // We work out the node id by removing the instance name. The node id must follow.
             auto locator = uncheckedCast<IceGrid::LocatorPrx>(communicator->getDefaultLocator().value());
             auto query = locator->getLocalQuery();
-            auto replicas = query->findAllReplicas(communicator->stringToProxy(instanceName + "/TopicManager"));
+            auto replicas = query->findAllReplicas(ObjectPrx{communicator, instanceName + "/TopicManager"});
 
             for (const auto& replica : replicas)
             {

--- a/cpp/src/iceserviceinstall/ServiceInstaller.cpp
+++ b/cpp/src/iceserviceinstall/ServiceInstaller.cpp
@@ -53,6 +53,7 @@ IceServiceInstaller::IceServiceInstaller(int serviceType, const string& configFi
     }
     else
     {
+        // We use stringToProxy because the property can be empty.
         auto defaultLocator =
             _communicator->stringToProxy<LocatorPrx>(_serviceProperties->getIceProperty("Ice.Default.Locator"));
         if (defaultLocator != nullopt)

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -4315,6 +4315,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "ice_endpoints(com.zeroc.Ice.Endpoint[] newEndpoints)",
         "ice_locatorCacheTimeout(int newTimeout)",
         "ice_invocationTimeout(int newTimeout)",
+        "ice_invocationTimeout(java.time.Duration newTimeout)",
         "ice_connectionCached(boolean newCache)",
         "ice_endpointSelection(com.zeroc.Ice.EndpointSelectionType newType)",
         "ice_secure(boolean b)",

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -353,7 +353,7 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     _out << sp << nl << "public static function createProxy($communicator, $proxyString)";
     _out << sb;
-    _out << nl << "return  $communicator->stringToProxy($proxyString, '" << scoped << "');";
+    _out << nl << "return $communicator->stringToProxy($proxyString, '" << scoped << "');";
     _out << eb;
 
     _out << sp << nl << "public static function checkedCast($proxy, ...$args)";

--- a/cpp/test/Ice/metrics/AllTests.cpp
+++ b/cpp/test/Ice/metrics/AllTests.cpp
@@ -389,13 +389,13 @@ allTests(Test::TestHelper* helper, const CommunicatorObserverIPtr& obsv)
     optional<Ice::ObjectPrx> admin = communicator->getAdmin();
     test(admin);
 
-    auto clientProps = Ice::uncheckedCast<Ice::PropertiesAdminPrx>(admin->ice_facet("Properties"));
-    auto clientMetrics = Ice::uncheckedCast<IceMX::MetricsAdminPrx>(admin->ice_facet("Metrics"));
+    auto clientProps = admin->ice_facet<Ice::PropertiesAdminPrx>("Properties");
+    auto clientMetrics = admin->ice_facet<IceMX::MetricsAdminPrx>("Metrics");
 
     admin = metrics->getAdmin();
 
-    auto serverProps = Ice::uncheckedCast<Ice::PropertiesAdminPrx>(admin->ice_facet("Properties"));
-    auto serverMetrics = Ice::uncheckedCast<IceMX::MetricsAdminPrx>(admin->ice_facet("Metrics"));
+    auto serverProps = admin->ice_facet<Ice::PropertiesAdminPrx>("Properties");
+    auto serverMetrics = admin->ice_facet<IceMX::MetricsAdminPrx>("Metrics");
 
     UpdateCallbackIPtr update = make_shared<UpdateCallbackI>(serverProps);
 

--- a/csharp/src/Ice/Internal/LoggerAdminI.cs
+++ b/csharp/src/Ice/Internal/LoggerAdminI.cs
@@ -366,8 +366,8 @@ internal sealed class LoggerAdminI : Ice.LoggerAdminDisp_
             return null;
         }
 
-        Ice.ObjectPrx result = communicator.stringToProxy(prx.ToString());
-        return Ice.RemoteLoggerPrxHelper.uncheckedCast(result.ice_invocationTimeout(prx.ice_getInvocationTimeout()));
+        ObjectPrx result = ObjectPrxHelper.createProxy(communicator, prx.ToString());
+        return RemoteLoggerPrxHelper.uncheckedCast(result.ice_invocationTimeout(prx.ice_getInvocationTimeout()));
     }
 
     private static void copyProperties(string prefix, Ice.Properties from, Ice.Properties to)

--- a/csharp/src/IceDiscovery/LocatorI.cs
+++ b/csharp/src/IceDiscovery/LocatorI.cs
@@ -6,7 +6,8 @@ internal class LocatorRegistryI : Ice.LocatorRegistryDisp_
 {
     public
     LocatorRegistryI(Ice.Communicator com) =>
-        _wellKnownProxy = com.stringToProxy("p").ice_locator(null).ice_router(null).ice_collocationOptimized(true);
+        _wellKnownProxy = Ice.ObjectPrxHelper.createProxy(com, "p").ice_locator(null)
+            .ice_router(null);
 
     public override Task
     setAdapterDirectProxyAsync(string adapterId, Ice.ObjectPrx proxy, Ice.Current current)

--- a/csharp/src/IceDiscovery/LocatorI.cs
+++ b/csharp/src/IceDiscovery/LocatorI.cs
@@ -7,7 +7,7 @@ internal class LocatorRegistryI : Ice.LocatorRegistryDisp_
     public
     LocatorRegistryI(Ice.Communicator com) =>
         _wellKnownProxy = Ice.ObjectPrxHelper.createProxy(com, "p").ice_locator(null)
-            .ice_router(null);
+            .ice_router(null).ice_collocationOptimized(true);
 
     public override Task
     setAdapterDirectProxyAsync(string adapterId, Ice.ObjectPrx proxy, Ice.Current current)

--- a/csharp/src/IceDiscovery/PluginI.cs
+++ b/csharp/src/IceDiscovery/PluginI.cs
@@ -87,7 +87,10 @@ public sealed class PluginI : Ice.Plugin
         Ice.LocatorRegistryPrx locatorRegistryPrx = Ice.LocatorRegistryPrxHelper.uncheckedCast(
             _locatorAdapter.addWithUUID(locatorRegistry));
 
-        Ice.ObjectPrx lookupPrx = _communicator.stringToProxy("IceDiscovery/Lookup -d:" + lookupEndpoints);
+        Ice.ObjectPrx lookupPrx = Ice.ObjectPrxHelper.createProxy(
+            _communicator,
+            "IceDiscovery/Lookup -d:" + lookupEndpoints);
+
         lookupPrx = lookupPrx.ice_router(null);
 
         //

--- a/csharp/src/IceLocatorDiscovery/PluginI.cs
+++ b/csharp/src/IceLocatorDiscovery/PluginI.cs
@@ -642,7 +642,10 @@ internal class PluginI : Ice.Plugin
         _replyAdapter.setLocator(null);
         _locatorAdapter.setLocator(null);
 
-        Ice.ObjectPrx lookupPrx = _communicator.stringToProxy("IceLocatorDiscovery/Lookup -d:" + lookupEndpoints);
+        Ice.ObjectPrx lookupPrx = Ice.ObjectPrxHelper.createProxy(
+            _communicator,
+            "IceLocatorDiscovery/Lookup -d:" + lookupEndpoints);
+
         lookupPrx = lookupPrx.ice_router(null);
 
         Ice.LocatorPrx voidLo = Ice.LocatorPrxHelper.uncheckedCast(_locatorAdapter.addWithUUID(new VoidLocatorI()));

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Coordinator.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Coordinator.java
@@ -2243,9 +2243,7 @@ public class Coordinator {
         }
 
         try {
-            FileParserPrx fileParser =
-                FileParserPrx.checkedCast(
-                    getCommunicator().stringToProxy(_fileParser).ice_router(null));
+            var fileParser = FileParserPrx.createProxy(getCommunicator(), _fileParser).ice_router(null);
             return fileParser.parse(file.getAbsolutePath(), _sessionKeeper.getRoutedAdmin());
         } catch (ParseException e) {
             JOptionPane.showMessageDialog(

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Root.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/LiveDeployment/Root.java
@@ -660,7 +660,7 @@ public class Root extends Communicator {
         ObjectPrx proxy = null;
 
         try {
-            proxy = _coordinator.getCommunicator().stringToProxy(strProxy);
+            proxy = ObjectPrx.createProxy(_coordinator.getCommunicator(), strProxy);
         } catch (LocalException e) {
             JOptionPane.showMessageDialog(
                 _coordinator.getMainFrame(),
@@ -669,13 +669,7 @@ public class Root extends Communicator {
                 JOptionPane.ERROR_MESSAGE);
         }
 
-        if (proxy == null) {
-            JOptionPane.showMessageDialog(
-                _coordinator.getMainFrame(),
-                "You must provide a non-null proxy",
-                "addObject failed",
-                JOptionPane.ERROR_MESSAGE);
-        }
+        assert proxy != null;
 
         String strIdentity =
             _coordinator.getCommunicator().identityToString(proxy.ice_getIdentity());
@@ -718,7 +712,7 @@ public class Root extends Communicator {
     }
 
     void removeObject(String strProxy) {
-        ObjectPrx proxy = _coordinator.getCommunicator().stringToProxy(strProxy);
+        var proxy = ObjectPrx.createProxy(_coordinator.getCommunicator(), strProxy);
         Identity identity = proxy.ice_getIdentity();
         final String strIdentity = _coordinator.getCommunicator().identityToString(identity);
 

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SessionKeeper.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SessionKeeper.java
@@ -1930,7 +1930,9 @@ public class SessionKeeper {
                                     endpoint.append(_coordinator.getCommunicator().identityToString(id));
                                     endpoint.append(":");
                                     endpoint.append(_directCustomEndpointValue.getText());
-                                    _coordinator.getCommunicator().stringToProxy(endpoint.toString());
+
+                                    ObjectPrx.createProxy(_coordinator.getCommunicator(), endpoint.toString());
+
                                     if (containsSecureEndpoints(endpoint.toString())) {
                                         _cardLayout.show(_cardPanel, WizardStep.X509CertificateStep.toString());
                                         _wizardSteps.push(WizardStep.X509CertificateStep);
@@ -1975,7 +1977,9 @@ public class SessionKeeper {
                                     endpoint.append(_coordinator.getCommunicator().identityToString(id));
                                     endpoint.append(":");
                                     endpoint.append(_routedCustomEndpointValue.getText());
-                                    _coordinator.getCommunicator().stringToProxy(endpoint.toString());
+
+                                    ObjectPrx.createProxy(_coordinator.getCommunicator(), endpoint.toString());
+
                                     if (containsSecureEndpoints(endpoint.toString())) {
                                         _cardLayout.show(_cardPanel, WizardStep.X509CertificateStep.toString());
                                         _wizardSteps.push(WizardStep.X509CertificateStep);
@@ -2693,8 +2697,10 @@ public class SessionKeeper {
     }
 
     private boolean containsSecureEndpoints(String str) {
+        var proxy = ObjectPrx.createProxy(_coordinator.getCommunicator(), str);
+
         try {
-            for (Endpoint endpoint : _coordinator.getCommunicator().stringToProxy(str).ice_getEndpoints()) {
+            for (Endpoint endpoint : proxy.ice_getEndpoints()) {
                 if (endpoint.getInfo().secure()) {
                     return true;
                 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminI.java
@@ -342,9 +342,8 @@ final class LoggerAdminI implements LoggerAdmin {
             return null;
         }
 
-        ObjectPrx result = communicator.stringToProxy(prx.toString());
-        return RemoteLoggerPrx.uncheckedCast(
-            result.ice_invocationTimeout(prx.ice_getInvocationTimeout()));
+        return RemoteLoggerPrx.createProxy(
+            communicator, prx.toString()).ice_invocationTimeout(prx.ice_getInvocationTimeout());
     }
 
     private static void copyProperties(String prefix, Properties from, Properties to) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/_ObjectPrxFactoryMethods.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/_ObjectPrxFactoryMethods.java
@@ -2,6 +2,7 @@
 
 package com.zeroc.Ice;
 
+import java.time.Duration;
 import java.util.Map;
 
 /**
@@ -42,6 +43,11 @@ public abstract class _ObjectPrxFactoryMethods<T extends ObjectPrx> extends _Obj
 
     @Override
     public T ice_invocationTimeout(int newTimeout) {
+        return (T) super.ice_invocationTimeout(newTimeout);
+    }
+
+    @Override
+    public T ice_invocationTimeout(Duration newTimeout) {
         return (T) super.ice_invocationTimeout(newTimeout);
     }
 

--- a/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/LocatorRegistryI.java
+++ b/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/LocatorRegistryI.java
@@ -24,7 +24,8 @@ import java.util.concurrent.CompletionStage;
 
 class LocatorRegistryI implements LocatorRegistry {
     public LocatorRegistryI(Communicator com) {
-        _wellKnownProxy = ObjectPrx.createProxy(com, "p").ice_locator(null).ice_router(null);
+        _wellKnownProxy =
+            ObjectPrx.createProxy(com, "p").ice_locator(null).ice_router(null).ice_collocationOptimized(true);
     }
 
     @Override

--- a/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/LocatorRegistryI.java
+++ b/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/LocatorRegistryI.java
@@ -24,11 +24,7 @@ import java.util.concurrent.CompletionStage;
 
 class LocatorRegistryI implements LocatorRegistry {
     public LocatorRegistryI(Communicator com) {
-        _wellKnownProxy =
-            com.stringToProxy("p")
-                .ice_locator(null)
-                .ice_router(null)
-                .ice_collocationOptimized(true);
+        _wellKnownProxy = ObjectPrx.createProxy(com, "p").ice_locator(null).ice_router(null);
     }
 
     @Override

--- a/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/PluginI.java
+++ b/java/src/com.zeroc.icediscovery/src/main/java/com/zeroc/IceDiscovery/PluginI.java
@@ -78,7 +78,7 @@ class PluginI implements Plugin {
                 _locatorAdapter.addWithUUID(locatorRegistry));
 
         ObjectPrx lookupPrx =
-            _communicator.stringToProxy("IceDiscovery/Lookup -d:" + lookupEndpoints);
+            ObjectPrx.createProxy(_communicator, "IceDiscovery/Lookup -d:" + lookupEndpoints);
         lookupPrx = lookupPrx.ice_router(null);
 
         // Add lookup and lookup reply Ice objects

--- a/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
+++ b/java/src/com.zeroc.icelocatordiscovery/src/main/java/com/zeroc/IceLocatorDiscovery/PluginI.java
@@ -635,7 +635,7 @@ class PluginI implements Plugin {
         _locatorAdapter.setLocator(null);
 
         ObjectPrx lookupPrx =
-            _communicator.stringToProxy("IceLocatorDiscovery/Lookup -d:" + lookupEndpoints);
+            ObjectPrx.createProxy(_communicator, "IceLocatorDiscovery/Lookup -d:" + lookupEndpoints);
         lookupPrx = lookupPrx.ice_router(null);
 
         LocatorPrx voidLoc =


### PR DESCRIPTION
This PR reduces the use of stringToProxy in cpp, c# and java (src only). It also fixes:
 - a few ice_facet in the C++ tests
 - an ice_invocationTimeout bug in Java