### PR TITLE
Pass test args to Slice tests

### DIFF
--- a/scripts/Component.py
+++ b/scripts/Component.py
@@ -137,7 +137,7 @@ class Ice(Util.Component):
         return False  # By default, tests support being run concurrently
 
     def getDefaultProcesses(self, mapping, processType, testId):
-        if testId.startswith("IceUtil") or testId.startswith("Slice"):
+        if testId.startswith("IceUtil"):
             return [Util.SimpleClient()]
         elif testId.startswith("IceGrid"):
             if processType in ["client", "collocated"]:


### PR DESCRIPTION
This PR updates the test suite to not use the `SimpleClient` class for Slice tests. 

The issue with `SimpleClient` is that it doesn't receive any of the Ice command line args. As such it never receives `Test.BasePort` which is necessary when running with workers and using `getTestEndpoint`, which `Slice/escape` does.

Potentially fixes #4363