### PR TITLE
Python sequence mapping improvements

### DIFF
--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -286,6 +286,11 @@ Slice::Python::CodeVisitor::typeToTypeHintString(
                     os << " | bytes";
                 }
 
+                if (elementType && elementType->kind() <= Builtin::KindDouble)
+                {
+                    os << " | memoryview";
+                }
+
                 if (metadataDirective == "python:array.array" && isBoolSequence)
                 {
                     // For boolean sequences "python:array.array" is mapped to array.array('b'), whose type-hint

--- a/python/test/Ice/custom/AllTests.py
+++ b/python/test/Ice/custom/AllTests.py
@@ -368,7 +368,6 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator) -> Test.CustomP
         v = [True, False, True, False, True]
         a = numpy.array(v, numpy.bool_)
         v1, v2 = custom.opBoolSeq(memoryview(a), a)
-        print(type(v1), type(v2))
         test(isinstance(v1, numpy.ndarray))
         test(isinstance(v2, numpy.ndarray))
         test(len(v1) == len(v))

--- a/python/test/Ice/custom/AllTests.py
+++ b/python/test/Ice/custom/AllTests.py
@@ -366,7 +366,9 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator) -> Test.CustomP
         sys.stdout.flush()
 
         v = [True, False, True, False, True]
-        v1, v2 = custom.opBoolSeq(numpy.array(v, numpy.bool_))
+        a = numpy.array(v, numpy.bool_)
+        v1, v2 = custom.opBoolSeq(memoryview(a), a)
+        print(type(v1), type(v2))
         test(isinstance(v1, numpy.ndarray))
         test(isinstance(v2, numpy.ndarray))
         test(len(v1) == len(v))
@@ -376,14 +378,16 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator) -> Test.CustomP
             test(v2[i] == v[i])
 
         v = []
-        v1, v2 = custom.opBoolSeq(numpy.array(v, numpy.bool_))
+        a = numpy.array(v, numpy.bool_)
+        v1, v2 = custom.opBoolSeq(memoryview(a), a)
         test(isinstance(v1, numpy.ndarray))
         test(isinstance(v2, numpy.ndarray))
         test(len(v1) == 0)
         test(len(v2) == 0)
 
         v = [0, 2, 4, 8, 16, 32, 64, 127]
-        v1, v2 = custom.opByteSeq(numpy.array(v, numpy.int8))
+        a = numpy.array(v, numpy.int8)
+        v1, v2 = custom.opByteSeq(memoryview(a), a)
         test(isinstance(v1, numpy.ndarray))
         test(isinstance(v2, numpy.ndarray))
         test(len(v1) == len(v))
@@ -393,14 +397,16 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator) -> Test.CustomP
             test(v2[i] == v[i])
 
         v = []
-        v1, v2 = custom.opByteSeq(numpy.array(v, numpy.int8))
+        a = numpy.array(v, numpy.int8)
+        v1, v2 = custom.opByteSeq(memoryview(a), a)
         test(isinstance(v1, numpy.ndarray))
         test(isinstance(v2, numpy.ndarray))
         test(len(v1) == 0)
         test(len(v2) == 0)
 
         v = [0, 2, 4, 8, 16, 32, 64, 128, 256]
-        v1, v2 = custom.opShortSeq(numpy.array(v, numpy.int16))
+        a = numpy.array(v, numpy.int16)
+        v1, v2 = custom.opShortSeq(memoryview(a), a)
         test(isinstance(v1, numpy.ndarray))
         test(isinstance(v2, numpy.ndarray))
         test(len(v1) == len(v))
@@ -410,14 +416,16 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator) -> Test.CustomP
             test(v2[i] == v[i])
 
         v = []
-        v1, v2 = custom.opShortSeq(numpy.array(v, numpy.int16))
+        a = numpy.array(v, numpy.int16)
+        v1, v2 = custom.opShortSeq(memoryview(a), a)
         test(isinstance(v1, numpy.ndarray))
         test(isinstance(v2, numpy.ndarray))
         test(len(v1) == 0)
         test(len(v2) == 0)
 
         v = [0, 2, 4, 8, 16, 32, 64, 128, 256]
-        v1, v2 = custom.opIntSeq(numpy.array(v, numpy.int32))
+        a = numpy.array(v, numpy.int32)
+        v1, v2 = custom.opIntSeq(memoryview(a), a)
         test(isinstance(v1, numpy.ndarray))
         test(isinstance(v2, numpy.ndarray))
         test(len(v1) == len(v))
@@ -427,14 +435,16 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator) -> Test.CustomP
             test(v2[i] == v[i])
 
         v = []
-        v1, v2 = custom.opIntSeq(numpy.array(v, numpy.int32))
+        a = numpy.array(v, numpy.int32)
+        v1, v2 = custom.opIntSeq(memoryview(a), a)
         test(isinstance(v1, numpy.ndarray))
         test(isinstance(v2, numpy.ndarray))
         test(len(v1) == 0)
         test(len(v2) == 0)
 
         v = [0, 2, 4, 8, 16, 32, 64, 128, 256]
-        v1, v2 = custom.opLongSeq(numpy.array(v, numpy.int64))
+        a = numpy.array(v, numpy.int64)
+        v1, v2 = custom.opLongSeq(memoryview(a), a)
         test(isinstance(v1, numpy.ndarray))
         test(isinstance(v2, numpy.ndarray))
         test(len(v1) == len(v))
@@ -444,14 +454,16 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator) -> Test.CustomP
             test(v2[i] == v[i])
 
         v = []
-        v1, v2 = custom.opLongSeq(numpy.array(v, numpy.int64))
+        a = numpy.array(v, numpy.int64)
+        v1, v2 = custom.opLongSeq(memoryview(a), a)
         test(isinstance(v1, numpy.ndarray))
         test(isinstance(v2, numpy.ndarray))
         test(len(v1) == 0)
         test(len(v2) == 0)
 
         v = [0.1, 0.2, 0.4, 0.8, 0.16, 0.32, 0.64, 0.128, 0.256]
-        v1, v2 = custom.opFloatSeq(numpy.array(v, numpy.float32))
+        a = numpy.array(v, numpy.float32)
+        v1, v2 = custom.opFloatSeq(memoryview(a), a)
         test(isinstance(v1, numpy.ndarray))
         test(isinstance(v2, numpy.ndarray))
         test(len(v1) == len(v))
@@ -461,14 +473,16 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator) -> Test.CustomP
             test(round(float(v2[i]), 1) == round(v[i], 1))
 
         v = []
-        v1, v2 = custom.opFloatSeq(numpy.array(v, numpy.float32))
+        a = numpy.array(v, numpy.float32)
+        v1, v2 = custom.opFloatSeq(memoryview(a), a)
         test(isinstance(v1, numpy.ndarray))
         test(isinstance(v2, numpy.ndarray))
         test(len(v1) == 0)
         test(len(v2) == 0)
 
         v = [0.1, 0.2, 0.4, 0.8, 0.16, 0.32, 0.64, 0.128, 0.256]
-        v1, v2 = custom.opDoubleSeq(numpy.array(v, numpy.float64))
+        a = numpy.array(v, numpy.float64)
+        v1, v2 = custom.opDoubleSeq(memoryview(a), a)
         test(isinstance(v1, numpy.ndarray))
         test(isinstance(v2, numpy.ndarray))
         test(len(v1) == len(v))
@@ -478,7 +492,8 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator) -> Test.CustomP
             test(round(float(v2[i]), 1) == round(v[i], 1))
 
         v = []
-        v1, v2 = custom.opDoubleSeq(numpy.array(v, numpy.float64))
+        a = numpy.array(v, numpy.float64)
+        v1, v2 = custom.opDoubleSeq(memoryview(a), a)
         test(isinstance(v1, numpy.ndarray))
         test(isinstance(v2, numpy.ndarray))
         test(len(v1) == 0)

--- a/python/test/Ice/custom/Server.py
+++ b/python/test/Ice/custom/Server.py
@@ -162,39 +162,39 @@ try:
 
     class NumPyCustomI(NumPy.Custom):
         @override
-        def opBoolSeq(self, v1: numpy.typing.NDArray[numpy.bool], current: Ice.Current):
-            test(isinstance(v1, numpy.ndarray))
-            return v1, v1
+        def opBoolSeq(self, v1: list[bool], v2: numpy.typing.NDArray[numpy.bool], current: Ice.Current):
+            test(isinstance(v2, numpy.ndarray))
+            return v2, v2
 
         @override
-        def opByteSeq(self, v1: numpy.typing.NDArray[numpy.int8], current: Ice.Current):
-            test(isinstance(v1, numpy.ndarray))
-            return v1, v1
+        def opByteSeq(self, v1: bytes, v2: numpy.typing.NDArray[numpy.int8], current: Ice.Current):
+            test(isinstance(v2, numpy.ndarray))
+            return v2, v2
 
         @override
-        def opShortSeq(self, v1: numpy.typing.NDArray[numpy.int16], current: Ice.Current):
-            test(isinstance(v1, numpy.ndarray))
-            return v1, v1
+        def opShortSeq(self, v1: list[int], v2: numpy.typing.NDArray[numpy.int16], current: Ice.Current):
+            test(isinstance(v2, numpy.ndarray))
+            return v2, v2
 
         @override
-        def opIntSeq(self, v1: numpy.typing.NDArray[numpy.int32], current: Ice.Current):
-            test(isinstance(v1, numpy.ndarray))
-            return v1, v1
+        def opIntSeq(self, v1: list[int], v2: numpy.typing.NDArray[numpy.int32], current: Ice.Current):
+            test(isinstance(v2, numpy.ndarray))
+            return v2, v2
 
         @override
-        def opLongSeq(self, v1: numpy.typing.NDArray[numpy.int64], current: Ice.Current):
-            test(isinstance(v1, numpy.ndarray))
-            return v1, v1
+        def opLongSeq(self, v1: list[int], v2: numpy.typing.NDArray[numpy.int64], current: Ice.Current):
+            test(isinstance(v2, numpy.ndarray))
+            return v2, v2
 
         @override
-        def opFloatSeq(self, v1: numpy.typing.NDArray[numpy.float32], current: Ice.Current):
-            test(isinstance(v1, numpy.ndarray))
-            return v1, v1
+        def opFloatSeq(self, v1: list[float], v2: numpy.typing.NDArray[numpy.float32], current: Ice.Current):
+            test(isinstance(v2, numpy.ndarray))
+            return v2, v2
 
         @override
-        def opDoubleSeq(self, v1: numpy.typing.NDArray[numpy.float64], current: Ice.Current):
-            test(isinstance(v1, numpy.ndarray))
-            return v1, v1
+        def opDoubleSeq(self, v1: list[float], v2: numpy.typing.NDArray[numpy.float64], current: Ice.Current):
+            test(isinstance(v2, numpy.ndarray))
+            return v2, v2
 
         @override
         def opComplex128Seq(self, v1: numpy.typing.NDArray[numpy.complex128], current: Ice.Current):

--- a/python/test/Ice/custom/TestNumPy.ice
+++ b/python/test/Ice/custom/TestNumPy.ice
@@ -7,60 +7,67 @@ module Test
 {
     module NumPy
     {
-        ["python:numpy.ndarray"] sequence<bool> BoolSeq1;
-        ["python:memoryview:CustomFactory.myNumPyBoolSeq:numpy.ndarray"] sequence<bool> BoolSeq2;
+        sequence<bool> BoolSeq1;
+        ["python:numpy.ndarray"] sequence<bool> BoolSeq2;
+        ["python:memoryview:CustomFactory.myNumPyBoolSeq:numpy.ndarray"] sequence<bool> BoolSeq3;
 
-        ["python:numpy.ndarray"] sequence<byte> ByteSeq1;
-        ["python:memoryview:CustomFactory.myNumPyByteSeq:numpy.ndarray"] sequence<byte> ByteSeq2;
+        sequence<byte> ByteSeq1;
+        ["python:numpy.ndarray"] sequence<byte> ByteSeq2;
+        ["python:memoryview:CustomFactory.myNumPyByteSeq:numpy.ndarray"] sequence<byte> ByteSeq3;
 
-        ["python:numpy.ndarray"] sequence<short> ShortSeq1;
-        ["python:memoryview:CustomFactory.myNumPyShortSeq:numpy.ndarray"] sequence<short> ShortSeq2;
+        sequence<short> ShortSeq1;
+        ["python:numpy.ndarray"] sequence<short> ShortSeq2;
+        ["python:memoryview:CustomFactory.myNumPyShortSeq:numpy.ndarray"] sequence<short> ShortSeq3;
 
-        ["python:numpy.ndarray"] sequence<int> IntSeq1;
-        ["python:memoryview:CustomFactory.myNumPyIntSeq:numpy.ndarray"] sequence<int> IntSeq2;
+        sequence<int> IntSeq1;
+        ["python:numpy.ndarray"] sequence<int> IntSeq2;
+        ["python:memoryview:CustomFactory.myNumPyIntSeq:numpy.ndarray"] sequence<int> IntSeq3;
 
-        ["python:numpy.ndarray"] sequence<long> LongSeq1;
-        ["python:memoryview:CustomFactory.myNumPyLongSeq:numpy.ndarray"] sequence<long> LongSeq2;
+        sequence<long> LongSeq1;
+        ["python:numpy.ndarray"] sequence<long> LongSeq2;
+        ["python:memoryview:CustomFactory.myNumPyLongSeq:numpy.ndarray"] sequence<long> LongSeq3;
 
-        ["python:numpy.ndarray"] sequence<float> FloatSeq1;
-        ["python:memoryview:CustomFactory.myNumPyFloatSeq:numpy.ndarray"] sequence<float> FloatSeq2;
+        sequence<float> FloatSeq1;
+        ["python:numpy.ndarray"] sequence<float> FloatSeq2;
+        ["python:memoryview:CustomFactory.myNumPyFloatSeq:numpy.ndarray"] sequence<float> FloatSeq3;
 
-        ["python:numpy.ndarray"] sequence<double> DoubleSeq1;
-        ["python:memoryview:CustomFactory.myNumPyDoubleSeq:numpy.ndarray"] sequence<double> DoubleSeq2;
+        sequence<double> DoubleSeq1;
+        ["python:numpy.ndarray"] sequence<double> DoubleSeq2;
+        ["python:memoryview:CustomFactory.myNumPyDoubleSeq:numpy.ndarray"] sequence<double> DoubleSeq3;
 
         ["python:memoryview:CustomFactory.myNumPyComplex128Seq:numpy.ndarray"] sequence<byte> Complex128Seq;
 
         class D
         {
-            optional(1) BoolSeq1 boolSeq;
-            optional(2) ByteSeq1 byteSeq;
-            optional(3) ShortSeq1 shortSeq;
-            optional(4) IntSeq1 intSeq;
-            optional(5) LongSeq1 longSeq;
-            optional(6) FloatSeq1 floatSeq;
-            optional(7) DoubleSeq1 doubleSeq;
+            optional(1) BoolSeq2 boolSeq;
+            optional(2) ByteSeq2 byteSeq;
+            optional(3) ShortSeq2 shortSeq;
+            optional(4) IntSeq2 intSeq;
+            optional(5) LongSeq2 longSeq;
+            optional(6) FloatSeq2 floatSeq;
+            optional(7) DoubleSeq2 doubleSeq;
         }
 
         class E
         {
-            BoolSeq1 boolSeq;
-            ByteSeq1 byteSeq;
-            ShortSeq1 shortSeq;
-            IntSeq1 intSeq;
-            LongSeq1 longSeq;
-            FloatSeq1 floatSeq;
-            DoubleSeq1 doubleSeq;
+            BoolSeq2 boolSeq;
+            ByteSeq2 byteSeq;
+            ShortSeq2 shortSeq;
+            IntSeq2 intSeq;
+            LongSeq2 longSeq;
+            FloatSeq2 floatSeq;
+            DoubleSeq2 doubleSeq;
         }
 
         interface Custom
         {
-            BoolSeq1 opBoolSeq(BoolSeq1 v1, out BoolSeq2 v2);
-            ByteSeq1 opByteSeq(ByteSeq1 v1, out ByteSeq2 v2);
-            ShortSeq1 opShortSeq(ShortSeq1 v1, out ShortSeq2 v2);
-            IntSeq1 opIntSeq(IntSeq1 v1, out IntSeq2 v2);
-            LongSeq1 opLongSeq(LongSeq1 v1, out LongSeq2 v2);
-            FloatSeq1 opFloatSeq(FloatSeq1 v1, out FloatSeq2 v2);
-            DoubleSeq1 opDoubleSeq(DoubleSeq1 v1, out DoubleSeq2 v2);
+            BoolSeq2 opBoolSeq(BoolSeq1 v1, BoolSeq2 v2, out BoolSeq3 v3);
+            ByteSeq2 opByteSeq(ByteSeq1 v1, ByteSeq2 v2, out ByteSeq3 v3);
+            ShortSeq2 opShortSeq(ShortSeq1 v1, ShortSeq2 v2, out ShortSeq3 v3);
+            IntSeq2 opIntSeq(IntSeq1 v1, IntSeq2 v2, out IntSeq3 v3);
+            LongSeq2 opLongSeq(LongSeq1 v1, LongSeq2 v2, out LongSeq3 v3);
+            FloatSeq2 opFloatSeq(FloatSeq1 v1, FloatSeq2 v2, out FloatSeq3 v3);
+            DoubleSeq2 opDoubleSeq(DoubleSeq1 v1, DoubleSeq2 v2, out DoubleSeq3 v3);
             Complex128Seq opComplex128Seq(Complex128Seq v1);
 
             ["python:memoryview:CustomFactory.myNumPyMatrix3x3:numpy.ndarray"] BoolSeq1 opBoolMatrix();


### PR DESCRIPTION
For sequences of integral numeric now includes memoryview, this make simple to accept any object that implements the buffer protocol by wrapping it in a memoryview.

Ice for Python runtime already accepts any object that implements the buffer protocol as a valid sequence for sequences of numeric types and bool. With this change the typehint for a sequence of these types will also include "memoryview" this allow to wrap your buffer object into a memoryview and keep the type-checker happy.

```
// Slice

sequence<int> IntSeq;

void opIntSeq(IntSeq s);

// Python
import numpy

a = numpy.array([0, 1, 2], numpy.int32)

// This works with 3.7 even if we didn't map sequence<int> to numpy.array.
// Because we accept any object that implements the buffer protocol and numpy.array does.
p.opIntSeq(a)

// With 3.8 the type hint for opIntSeq is `s:Sequence[int]` and the analyzer will flag this
// code even if it works at runtime.

// With this PR we add ` | memoryview` to the type and have the user can write this instead:
p.opIntSeq(memoryview(a))
```

Here memoryview just wraps the object but doesn't not copy the data, and it implements the buffer protocol delegating to the underlying object.