### PR TITLE
Fix Slice Compiler Hang when Preprocessor Returns Non-Zero Status

### DIFF
--- a/cpp/src/ice2slice/Main.cpp
+++ b/cpp/src/ice2slice/Main.cpp
@@ -167,7 +167,10 @@ compile(const vector<string>& argv)
         {
             PreprocessorPtr preprocessor = Preprocessor::create(argv[0], fileName, preprocessorArgs);
             FILE* preprocessedHandle = preprocessor->preprocess("-D__ICE2SLICE__");
-            assert(preprocessedHandle);
+            if (preprocessedHandle == nullptr)
+            {
+                return EXIT_FAILURE;
+            }
 
             unit = Unit::createUnit("", false);
             int parseStatus = unit->parse(fileName, preprocessedHandle, debug);

--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -196,7 +196,10 @@ compile(const vector<string>& argv)
         {
             preprocessor = Preprocessor::create(argv[0], fileName, preprocessorArgs);
             FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2CPP__");
-            assert(preprocessedHandle);
+            if (preprocessedHandle == nullptr)
+            {
+                return EXIT_FAILURE;
+            }
 
             unit = Unit::createUnit("cpp", false);
             int parseStatus = unit->parse(fileName, preprocessedHandle, debug);

--- a/cpp/src/slice2cs/Main.cpp
+++ b/cpp/src/slice2cs/Main.cpp
@@ -201,7 +201,10 @@ compile(const vector<string>& argv)
         {
             preprocessor = Preprocessor::create(argv[0], fileName, preprocessorArgs);
             FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2CS__");
-            assert(preprocessedHandle);
+            if (preprocessedHandle == nullptr)
+            {
+                return EXIT_FAILURE;
+            }
 
             unit = Unit::createUnit("cs", false);
             int parseStatus = unit->parse(fileName, preprocessedHandle, debug);

--- a/cpp/src/slice2java/Main.cpp
+++ b/cpp/src/slice2java/Main.cpp
@@ -165,7 +165,10 @@ compile(const vector<string>& argv)
             FileTracker::instance()->setSource(fileName);
             preprocessor = Preprocessor::create(argv[0], fileName, preprocessorArgs);
             FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2JAVA__");
-            assert(preprocessedHandle);
+            if (preprocessedHandle == nullptr)
+            {
+                return EXIT_FAILURE;
+            }
 
             unit = Unit::createUnit("java", false);
             int parseStatus = unit->parse(fileName, preprocessedHandle, debug);

--- a/cpp/src/slice2js/Main.cpp
+++ b/cpp/src/slice2js/Main.cpp
@@ -202,7 +202,10 @@ compile(const vector<string>& argv)
         {
             preprocessor = Preprocessor::create(argv[0], fileName, preprocessorArgs);
             FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2JS__");
-            assert(preprocessedHandle);
+            if (preprocessedHandle == nullptr)
+            {
+                return EXIT_FAILURE;
+            }
 
             unit = Unit::createUnit("js", false);
             int parseStatus = unit->parse(fileName, preprocessedHandle, debug);

--- a/cpp/src/slice2matlab/Main.cpp
+++ b/cpp/src/slice2matlab/Main.cpp
@@ -205,7 +205,10 @@ namespace
             {
                 preprocessor = Preprocessor::create(argv[0], fileName, preprocessorArgs);
                 FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2MATLAB__");
-                assert(preprocessedHandle);
+                if (preprocessedHandle == nullptr)
+                {
+                    return EXIT_FAILURE;
+                }
 
                 unit = Unit::createUnit("matlab", all);
                 int parseStatus = unit->parse(fileName, preprocessedHandle, debug);

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -1244,7 +1244,10 @@ compile(const vector<string>& argv)
         {
             PreprocessorPtr preprocessor = Preprocessor::create(argv[0], fileName, preprocessorArgs);
             FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2PHP__");
-            assert(preprocessedHandle);
+            if (preprocessedHandle == nullptr)
+            {
+                return EXIT_FAILURE;
+            }
 
             unit = Unit::createUnit("php", all);
             int parseStatus = unit->parse(fileName, preprocessedHandle, debug);

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2791,6 +2791,10 @@ Slice::Python::compile(
         {
             preprocessor = Preprocessor::create(programName, fileName, preprocessorArgs);
             FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2PY__");
+            if (preprocessedHandle == nullptr)
+            {
+                throw runtime_error("Failed to preprocess Slice file: " + fileName);
+            }
 
             unit = Unit::createUnit("python", debug);
             int parseStatus = unit->parse(fileName, preprocessedHandle, false);

--- a/cpp/src/slice2rb/Ruby.cpp
+++ b/cpp/src/slice2rb/Ruby.cpp
@@ -151,7 +151,10 @@ Slice::Ruby::compile(const vector<string>& argv)
         {
             preprocessor = Preprocessor::create(argv[0], fileName, preprocessorArgs);
             FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2RB__");
-            assert(preprocessedHandle);
+            if (preprocessedHandle == nullptr)
+            {
+                return EXIT_FAILURE;
+            }
 
             unit = Unit::createUnit("ruby", all);
             int parseStatus = unit->parse(fileName, preprocessedHandle, debug);

--- a/cpp/src/slice2swift/Main.cpp
+++ b/cpp/src/slice2swift/Main.cpp
@@ -175,7 +175,10 @@ compile(const vector<string>& argv)
         {
             preprocessor = Preprocessor::create(argv[0], fileName, preprocessorArgs);
             FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2SWIFT__");
-            assert(preprocessedHandle);
+            if (preprocessedHandle == nullptr)
+            {
+                return EXIT_FAILURE;
+            }
 
             unit = Unit::createUnit("swift", false);
             int parseStatus = unit->parse(fileName, preprocessedHandle, debug);

--- a/ruby/src/IceRuby/Slice.cpp
+++ b/ruby/src/IceRuby/Slice.cpp
@@ -95,8 +95,7 @@ IceRuby_loadSlice(int argc, VALUE* argv, VALUE /*self*/)
                 string file = *p;
                 preprocessor = Preprocessor::create("preprocessor", file, cppArgs);
                 FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2RB__");
-
-                if (preprocessedHandle == 0)
+                if (preprocessedHandle == nullptr)
                 {
                     throw RubyException(rb_eArgError, "Slice preprocessing failed");
                 }


### PR DESCRIPTION
This PR fixes #4387.

Our entry point into MCPP is `preprocessor->preprocess` which either returns a handle if everything worked, or `nullptr` if it failed to preprocess. In the past we correctly checked for `nullptr` and exited early, but this was removed during the MCPP refactoring 2 months ago. Instead this check was replaced with an `assert`, which as far as I can tell is incorrect here.

If you replicate #4387 with a debug build, you'll see the assert hit on this line.