### PR TITLE
Simplify sample service config files

### DIFF
--- a/cpp/config/glacier2router.cfg
+++ b/cpp/config/glacier2router.cfg
@@ -1,96 +1,21 @@
 #
-# Sample configuration file for the Glacier2 router service
+# Sample configuration file for the Glacier2 router.
 #
 
-#
-# Set the instance name. The name you specify here must be used
-# in the client's locator proxy, such as:
-#
-# Ice.Default.Locator=DemoGlacier2Router/Locator ...
-#
-Glacier2.InstanceName=DemoGlacier2Router
+# The client-visible endpoint of the Glacier2 router.
+# You can use the following IANA-registered TCP ports for the Glacier2 router: 4063 (tcp), 4064 (ssl).
+Glacier2.Client.Endpoints=tcp -p 4063
 
-#
-# The client-visible endpoint of Glacier2. This should be an endpoint
-# visible from the public Internet, and it should be secure. To use
-# SSL, configure the SSL endpoint and enable the IceSSL plug-in.
-#
-# IANA-registered TCP ports for the Glacier2 router:
-# - 4063 (insecure)
-# - 4064 (secure, using SSL)
-#
-Glacier2.Client.Endpoints=tcp -p 4063 -h localhost
-#Glacier2.Client.Endpoints=ssl -p 4064 -h localhost
+# The server-visible endpoint of the Glacier2 router.
+# You need to configure this endpoint only when your servers make callbacks (call objects implemented by the clients).
+# If you don't use callbacks, don't set this property.
+# Glacier2.Server.Endpoints=tcp -h 127.0.0.1
 
-#
-# The server-visible endpoint of Glacier2. This endpoint is only
-# required if callbacks are needed (leave empty otherwise). This
-# should be an endpoint on an internal network (like 192.168.x.x), or
-# on the loopback, so that the endpoint is not directly accessible from
-# the Internet.
-#
-Glacier2.Server.Endpoints=tcp -h localhost
+# This Glacier router accepts any username/password combination.
+Glacier2.PermissionsVerifier=Glacier2/NullPermissionsVerifier
 
-#
-# This permissions verifier allows any user-id / password combination;
-# this is not recommended for production!
-#
-Glacier2.PermissionsVerifier=DemoGlacier2Router/NullPermissionsVerifier
-
-#
-# Glacier2 always disables active connection management so there is no
-# need to configure this manually. Connection retry does not need to
-# be disabled, as it's safe for Glacier2 to retry outgoing connections
-# to servers. Retry for incoming connections from clients must be
-# disabled in the clients.
-#
-
-#
-# Various settings to trace requests, overrides, etc.
-#
+# Turn on tracing.
 Glacier2.Client.Trace.Request=1
 Glacier2.Server.Trace.Request=1
-Glacier2.Client.Trace.Override=1
-Glacier2.Server.Trace.Override=1
-Glacier2.Client.Trace.Reject=1
 Glacier2.Trace.Session=1
 Glacier2.Trace.RoutingTable=1
-
-#
-# Warn about connection exceptions
-#
-Ice.Warn.Connections=1
-
-#
-# Network Tracing
-#
-# 0 = no network tracing
-# 1 = trace connection establishment and closure
-# 2 = like 1, but more detailed
-# 3 = like 2, but also trace data transfer
-#
-#Ice.Trace.Network=1
-
-#
-# Protocol Tracing
-#
-# 0 = no protocol tracing
-# 1 = trace protocol messages
-#
-#Ice.Trace.Protocol=1
-
-#
-# Security Tracing
-#
-# 0 = no security tracing
-# 1 = trace messages
-#
-#IceSSL.Trace.Security=1
-
-#
-# SSL Configuration
-#
-#IceSSL.DefaultDir=<path to certs dir>
-
-#IceSSL.CAs=cacert.pem
-#IceSSL.CertFile=server.p12

--- a/cpp/config/icegridnode.cfg
+++ b/cpp/config/icegridnode.cfg
@@ -1,67 +1,38 @@
 #
-# Sample configuration file for the IceGrid node service
+# Sample configuration file for the IceGrid node (node1).
 #
 
-#
-# Proxy to the IceGrid registry - TCP is used by default.
-#
-Ice.Default.Locator=DemoIceGrid/Locator:tcp -h localhost -p 4061
-#Ice.Default.Locator=DemoIceGrid/Locator:ssl -h localhost -p 4062
+# A proxy to the Locator object hosted by the IceGrid registry. In this sample deployment, the IceGrid registry
+# runs on the same host.
+Ice.Default.Locator=IceGrid/Locator:tcp -h localhost -p 4061
 
-#
 # The name of this node - must be unique within an IceGrid deployment.
-#
 IceGrid.Node.Name=node1
 
-#
-# The node's object adapter listens on the loopback interface using an
-# OS-assigned port.
-#
-# These endpoints must be accessible to IceGrid registries.
-#
-# To listen on an additional interface, add an additional endpoint with
-# -h <name | IP address> or remove -h localhost to listen on all
-# interfaces. Note that access to these endpoints can pose a security
-# risk (remote code execution) and therefore these endpoints should be
-# secured. See the Ice manual for more information.
-#
-IceGrid.Node.Endpoints=tcp -h localhost
+# The endpoints of this node's object adapter. This object adapter receives requests from the IceGrid registry.
+# We configure this object adapter to listen on an OS-assigned tcp port on the loopback interface since the IceGrid
+# registry runs on the same host in this deployment.
+IceGrid.Node.Endpoints=tcp -h 127.0.0.1
 
+# The directory where the node stores the config files for the Ice servers it starts.
 #
-# The directory where the IceGrid node maintains its data (such as server
-# configuration files). This directory must already exist when the node
-# starts.
-#
-# The path name below is merely a suggestion, based on the assumption
-# that the node is running under the LocalService account.
-#
+# The path name below is merely a suggestion, based on the assumption that the node is running under the
+# LocalService account.
 IceGrid.Node.Data=C:\Windows\ServiceProfiles\LocalService\AppData\Local\ZeroC\icegrid\node1
 
-#
-# Redirect the stdout and stderr of servers started by icegridnode to
-# files in the specified directory.
-#
+# Redirect the stdout and stderr of servers started by icegridnode to files in the specified directory.
 IceGrid.Node.Output=C:\Windows\ServiceProfiles\LocalService\AppData\Local\ZeroC\icegrid\node1
 
-#
-# Uncomment to redirect the stderr of each server to this server's stdout
-# file.
-#
+# Uncomment to redirect the stderr of each server to this server's stdout file.
 #IceGrid.Node.RedirectErrToOut=1
 
-#
 # Trace properties.
-# You can comment-out these trace properties if you find the resulting
-# traces too verbose.
-#
 IceGrid.Node.Trace.Replica=2
 IceGrid.Node.Trace.Activator=3
 IceGrid.Node.Trace.Adapter=3
 IceGrid.Node.Trace.Server=3
 
-#
 # IceMX configuration
-#
 IceMX.Metrics.Debug.GroupBy=id
 IceMX.Metrics.Debug.Disabled=1
 IceMX.Metrics.Debug.Reject.parent=Ice\.Admin

--- a/cpp/config/icegridregistry.cfg
+++ b/cpp/config/icegridregistry.cfg
@@ -1,80 +1,41 @@
 #
-# Sample configuration file for the IceGrid registry service
+# Sample configuration file for the IceGrid registry.
 #
 
-#
-# The IceGrid instance name - must be unique to distinguish
-# unrelated IceGrid deployments.
-#
-IceGrid.InstanceName=DemoIceGrid
+# The endpoints of this registry's client object adapter. This object adapter receives requests from the clients.
+# It's also used by servers and admin clients.
+# We configure this object adapter to listen on tcp port 4061, on all interfaces.
+IceGrid.Registry.Client.Endpoints=tcp -p 4061
 
-#
-# Client object adapter: listens on the loopback interface by default.
-#
-# IANA-registered TCP ports for the IceGrid registry:
-# - 4061 (insecure)
-# - 4062 (secure, using SSL)
-#
-# These endpoints must be accessible to Ice clients and servers as
-# well as the IceGrid administrative utilities.
-#
-# To listen on an additional interface, add an additional endpoint with
-# -h <name | IP address>, or remove -h localhost to listen on all
-# interfaces.
-#
-IceGrid.Registry.Client.Endpoints=tcp -p 4061 -h localhost
-#IceGrid.Registry.Client.Endpoints=ssl -p 4062 -h localhost
-#IceGrid.Registry.Client.Endpoints=tcp -p 4061 -h localhost:ssl -p 4062 -h localhost
+# The endpoints of this registry's server object adapter. This object adapter receives requests from the servers when
+# they register/unregister themselves or their endpoints with the registry.
+# We configure this object adapter to listen on an OS-assigned tcp port, on all interfaces.
+IceGrid.Registry.Server.Endpoints=tcp
 
-#
-# Server and Internal object adapters: listen on the loopback
-# interface using an OS-assigned port number.
-#
-# The Server endpoints must be accessible to Ice servers deployed on
-# IceGrid nodes or to Ice servers using IceGrid dynamic registration.
-# The Internal endpoints must be accessible to IceGrid nodes.
-#
-# To listen on an additional interface, add an additional endpoint with
-# -h <name | IP address>, or remove -h localhost to listen on all
-# interfaces. Note that access to these endpoints can pose a security
-# risk (remote code execution) and therefore these endpoints should be
-# secured. See the Ice manual for more information.
-#
-IceGrid.Registry.Server.Endpoints=tcp -h localhost
-IceGrid.Registry.Internal.Endpoints=tcp -h localhost
+# The endpoints of this registry's internal object adapter. This object adapter receives requests from the IceGrid
+# nodes.
+# We configure this object adapter to listen on an OS-assigned tcp port, on the loopback interface since the IceGrid
+# node runs on the same host in this sample deployment.
+IceGrid.Registry.Internal.Endpoints=tcp -h 127.0.0.1
 
-#
 # The directory where the IceGrid registry maintains its databases.
 # This directory must already exist when the registry starts.
 #
-# The path name below is merely a suggestion, based on the assumption
-# that the registry is running under the LocalService account.
-#
+# The path name below is merely a suggestion, based on the assumption that the registry is running under the
+# LocalService account.
 IceGrid.Registry.LMDB.Path=C:\Windows\ServiceProfiles\LocalService\AppData\Local\ZeroC\icegrid\registry
 
-#
-# Authentication/authorization
-#
-# Using a NullPermissionsVerifier accepts any username/password
-# combination (not recommended for production).
-#
-IceGrid.Registry.PermissionsVerifier=DemoIceGrid/NullPermissionsVerifier
-IceGrid.Registry.AdminPermissionsVerifier=DemoIceGrid/NullPermissionsVerifier
+# The admin interface of the registry accepts any username/password combination.
+IceGrid.Registry.AdminPermissionsVerifier=IceGrid/NullPermissionsVerifier
 
-#
 # Default templates
-#
 IceGrid.Registry.DefaultTemplates=@installdir@\config\templates.xml
 
-#
 # Trace properties.
-#
 IceGrid.Registry.Trace.Node=1
 IceGrid.Registry.Trace.Replica=1
 
-#
 # IceMX configuration
-#
 IceMX.Metrics.Debug.GroupBy=id
 IceMX.Metrics.Debug.Disabled=1
 IceMX.Metrics.Debug.Reject.parent=Ice\.Admin


### PR DESCRIPTION
This PR simplifies the sample service config files in cpp/config. These are config files for Windows; we should probably move them somewhere else.