### PR TITLE
IceGrid interop/upgrade fixes

### DIFF
--- a/CHANGELOG-3.8.md
+++ b/CHANGELOG-3.8.md
@@ -1065,6 +1065,8 @@ service.
     registry.
   - Use only the 3.8 admin tools (icegridadmin, IceGridUI) when administering an IceGrid 3.8 registry. The 3.7 tools may
     not operate reliably due to updates in the session management code.
+  - If you've written your own IceGrid admin tool using Ice 3.7, it should still work with a 3.8 registry. But make sure
+    you turn on heartbeats (see Idle timeout earlier). Or upgrade this tool to use Ice 3.8.
   - The registry database schema remains the same as in Ice 3.7. As a result, you can start a 3.8 registry with a
     database created by a 3.7 registry, or vice-versa.
 

--- a/CHANGELOG-3.8.md
+++ b/CHANGELOG-3.8.md
@@ -1063,10 +1063,10 @@ service.
 - Interop/upgrade from 3.7
   - IceGrid registry and IceGrid node must all use version 3.8. For example, you can't use a 3.7 node with a 3.8
     registry.
-  - Use only the 3.8 admin tools (icegridadmin, IceGridUI) when administering an IceGrid 3.8 registry. The 3.7 tools may
-    not operate reliably due to updates in the session management code.
-  - If you've written your own IceGrid admin tool using Ice 3.7, it should still work with a 3.8 registry. But make sure
-    you turn on heartbeats (see Idle timeout earlier). Or upgrade this tool to use Ice 3.8.
+  - IceGridGUI 3.7 cannot connect to an IceGrid registry 3.8, and we recommend using icegridadmin 3.8 with IceGrid
+    registry 3.8.
+  - If you've written your own IceGrid admin tool using Ice 3.7, it may or may not work with a 3.8 registry, depending
+    on the APIs you're using. You should upgrade this tool to Ice 3.8.
   - The registry database schema remains the same as in Ice 3.7. As a result, you can start a 3.8 registry with a
     database created by a 3.7 registry, or vice-versa.
 

--- a/CHANGELOG-3.8.md
+++ b/CHANGELOG-3.8.md
@@ -1054,9 +1054,19 @@ initialization. See `InitializationData.pluginFactories`.
 - Removed deprecated server and application distributions in IceGrid. These distributions relied on the IcePatch2
 service.
 
+- Removed deprecated Freeze database environments (DbEnv).
+
 - Removed client and admin-client session timeouts configured using `IceGrid.Registry.SessionTimeout`. IceGrid now
   relies on the common idle check described under [General Changes](#general-changes) for these connection-bound
   sessions.
+
+- Interop/upgrade from 3.7
+  - IceGrid registry and IceGrid node must all use version 3.8. For example, you can't use a 3.7 node with a 3.8
+    registry.
+  - Use only the 3.8 admin tools (icegridadmin, IceGridUI) when administering an IceGrid 3.8 registry. The 3.7 tools may
+    not operate reliably due to updates in the session management code.
+  - The registry database schema remains the same as in Ice 3.7. As a result, you can start a 3.8 registry with a
+    database created by a 3.7 registry, or vice-versa.
 
 #### IcePatch2
 

--- a/cpp/src/IceGrid/Internal.ice
+++ b/cpp/src/IceGrid/Internal.ice
@@ -13,16 +13,8 @@
 
 module IceGrid
 {
-    // This class is no longer used. We keep it only for interop with IceGrid 3.7.
-    class InternalDbEnvDescriptor
-    {
-        /// The name of the database environment.
-        string name;
-
-        /// The database properties.
-        PropertyDescriptorSeq properties;
-    }
-    sequence<InternalDbEnvDescriptor> InternalDbEnvDescriptorSeq;
+    // These Internal descriptors are used for registry-node communications. InternalServerDescriptor changed in 3.8
+    // so a registry 3.8 cannot communicate with a node 3.7 or older.
 
     class InternalAdapterDescriptor
     {
@@ -85,9 +77,6 @@ module IceGrid
 
         /// The indirect object adapters.
         InternalAdapterDescriptorSeq adapters;
-
-        // Not used, always empty. Kept only for interop with IceGrid 3.7.
-        InternalDbEnvDescriptorSeq dbEnvs;
 
         /// The configuration files of the server.
         PropertyDescriptorSeqDict properties;

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Communicator.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/Communicator.java
@@ -4,6 +4,7 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.AdapterDescriptor;
 import com.zeroc.IceGrid.CommunicatorDescriptor;
+import com.zeroc.IceGrid.DbEnvDescriptor;
 import com.zeroc.IceGrid.ObjectDescriptor;
 import com.zeroc.IceGrid.PropertyDescriptor;
 import com.zeroc.IceGrid.PropertySetDescriptor;
@@ -473,6 +474,7 @@ abstract class Communicator extends TreeNode implements DescriptorHolder {
                     new LinkedList<AdapterDescriptor>(),
                     new PropertySetDescriptor(
                         new String[0], new LinkedList<PropertyDescriptor>()),
+                    new DbEnvDescriptor[0],
                     new String[0],
                     "",
                     "NewService",

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PlainServer.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/PlainServer.java
@@ -4,6 +4,7 @@ package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.AdapterDescriptor;
 import com.zeroc.IceGrid.CommunicatorDescriptor;
+import com.zeroc.IceGrid.DbEnvDescriptor;
 import com.zeroc.IceGrid.DistributionDescriptor;
 import com.zeroc.IceGrid.IceBoxDescriptor;
 import com.zeroc.IceGrid.PropertyDescriptor;
@@ -60,6 +61,7 @@ class PlainServer extends Communicator implements Server {
             new LinkedList<AdapterDescriptor>(),
             new PropertySetDescriptor(
                 new String[0], new LinkedList<PropertyDescriptor>()),
+            new DbEnvDescriptor[0],
             new String[0],
             "",
             "NewServer",
@@ -82,6 +84,7 @@ class PlainServer extends Communicator implements Server {
             new LinkedList<AdapterDescriptor>(),
             new PropertySetDescriptor(
                 new String[0], new LinkedList<PropertyDescriptor>()),
+            new DbEnvDescriptor[0],
             new String[0],
             "",
             "NewIceBox",

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServiceTemplates.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Application/ServiceTemplates.java
@@ -3,6 +3,7 @@
 package com.zeroc.IceGridGUI.Application;
 
 import com.zeroc.IceGrid.AdapterDescriptor;
+import com.zeroc.IceGrid.DbEnvDescriptor;
 import com.zeroc.IceGrid.PropertyDescriptor;
 import com.zeroc.IceGrid.PropertySetDescriptor;
 import com.zeroc.IceGrid.ServiceDescriptor;
@@ -62,6 +63,7 @@ class ServiceTemplates extends Templates {
                 new LinkedList<AdapterDescriptor>(),
                 new PropertySetDescriptor(
                     new String[0], new LinkedList<PropertyDescriptor>()),
+                new DbEnvDescriptor[0],
                 new String[0],
                 "",
                 "",

--- a/slice/IceGrid/Descriptor.ice
+++ b/slice/IceGrid/Descriptor.ice
@@ -116,6 +116,7 @@ module IceGrid
         string dbHome;
 
         /// The configuration properties of the database environment.
+        ["matlab:identifier:propertyDescriptors"]
         PropertyDescriptorSeq properties;
     }
 

--- a/slice/IceGrid/Descriptor.ice
+++ b/slice/IceGrid/Descriptor.ice
@@ -102,6 +102,27 @@ module IceGrid
     ["java:type:java.util.LinkedList<AdapterDescriptor>"]
     sequence<AdapterDescriptor> AdapterDescriptorSeq;
 
+    /// A Freeze database environment descriptor (deprecated, no longer used).
+    ["deprecated:This descriptor is provided for schema compatibility. It is no longer used as of Ice 3.8."]
+    struct DbEnvDescriptor
+    {
+        /// The name of the database environment.
+        string name;
+
+        /// The description of this database environment.
+        string description;
+
+        /// The home of the database environment.
+        string dbHome;
+
+        /// The configuration properties of the database environment.
+        PropertyDescriptorSeq properties;
+    }
+
+    /// A sequence of {@link DbEnvDescriptor}.
+    ["deprecated:This descriptor is provided for schema compatibility. It is no longer used as of Ice 3.8."]
+    sequence<DbEnvDescriptor> DbEnvDescriptorSeq;
+
     /// Describes an Ice communicator.
     class CommunicatorDescriptor
     {
@@ -110,6 +131,10 @@ module IceGrid
 
         /// The property set.
         PropertySetDescriptor propertySet;
+
+        /// The database environments.
+        ["deprecated"]
+        DbEnvDescriptorSeq dbEnvs;
 
         /// The path of each log file.
         Ice::StringSeq logs;


### PR DESCRIPTION
This PR makes 3 related fixes:
 - adds back the DbEnvDescriptor for database schema compatibility with 3.7
   - this also provides better interop with the 3.7 admin tools, and user-written admin tools, but we don't really care about these.
 - remove the InternalDbEnvDescriptor (and more) from Internal.ice to break even more the registry<-> node interop when mixing 3.7 and 3.8
   - we don't want this interop, and it didn't interop before this PR either
- update the CHANGELOG to explain all this.