### PR TITLE
Update Swift build output flags

### DIFF
--- a/swift/Makefile
+++ b/swift/Makefile
@@ -6,7 +6,7 @@ include $(top_srcdir)/config/Make.rules
 
 CONFIG ?= $(if $(filter $(OPTIMIZE),no),Debug,Release)
 
-SWIFT_BUILD_FLAGS ?= -Xswiftc -warnings-as-errors $(if $(V),,--quiet) --configuration  $(shell echo $(CONFIG) | tr '[:upper:]' '[:lower:]')
+SWIFT_BUILD_FLAGS ?= -Xswiftc -warnings-as-errors $(if $(V),--verbose,) --configuration  $(shell echo $(CONFIG) | tr '[:upper:]' '[:lower:]')
 
 # $(call make-xcodebuild-rule,$1=rule,$2=platform,$3=action)
 define xcode-test-app-rule


### PR DESCRIPTION
```
LOGGING:
  -v, --verbose           Increase verbosity to include informational output.
  --very-verbose, --vv    Increase verbosity to include debug output.
  -q, --quiet             Decrease verbosity to only include error output.
```
As of Xcode 26 they seemed to have changed/fixed the logging output.

We were previously using `--quiet` which used to actually output non-error things. That's no longer the case. Now we use the default by default and `--verbose` when we set `V=1`