### PR TITLE
Fix Slice tools to correctly compute include search path

### DIFF
--- a/cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/Slice2CppTask.cs
+++ b/cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/Slice2CppTask.cs
@@ -55,9 +55,9 @@ public class Slice2CppTask : SliceCompilerTask
         return builder.ToString();
     }
 
-    protected override Dictionary<string, string> GetOptions()
+    protected override Dictionary<string, string> GetOptions(ITaskItem source)
     {
-        var options = base.GetOptions();
+        var options = base.GetOptions(source);
         if (!string.IsNullOrEmpty(HeaderOutputDir))
         {
             options["HeaderOutputDir"] = HeaderOutputDir;

--- a/csharp/tools/ZeroC.Ice.Slice.Tools/Common/SliceDependTask.cs
+++ b/csharp/tools/ZeroC.Ice.Slice.Tools/Common/SliceDependTask.cs
@@ -48,14 +48,10 @@ public abstract class SliceDependTask : Task
             ["OutputDir"] = item.GetMetadata("OutputDir").TrimEnd('\\')
         };
 
-        var value = item.GetMetadata("IncludeDirectories");
+        var value = item.GetMetadata("IncludeDirectories").Trim(';');
         if (!string.IsNullOrEmpty(value))
         {
-            value = value.Trim(';');
-            if (!string.IsNullOrEmpty(value))
-            {
-                options["IncludeDirectories"] = value;
-            }
+            options["IncludeDirectories"] = value;
         }
         value = item.GetMetadata("AdditionalOptions");
         if (!string.IsNullOrEmpty(value))

--- a/csharp/tools/ZeroC.Ice.Slice.Tools/ZeroC.Ice.Slice.Tools.targets
+++ b/csharp/tools/ZeroC.Ice.Slice.Tools/ZeroC.Ice.Slice.Tools.targets
@@ -79,7 +79,6 @@
         <ItemGroup>
             <_SliceCompileNormalized Include="@(SliceCompile)">
                 <OutputDir>$([MSBuild]::NormalizePath('%(SliceCompile.OutputDir)'))</OutputDir>
-                <IncludeDirectories>$([MSBuild]::NormalizePath('%(SliceCompile.IncludeDirectories)'))</IncludeDirectories>
             </_SliceCompileNormalized>
         </ItemGroup>
 


### PR DESCRIPTION
This PR fixes a bug in the Slice tools tasks that results in bogus include path used when there are multiple IncludeDirectories.