### PR TITLE
Upgrade MSI Path settings

### DIFF
--- a/packaging/msi/Package.wxs
+++ b/packaging/msi/Package.wxs
@@ -21,6 +21,9 @@
         <!-- Embed CAB files in MSI -->
         <MediaTemplate EmbedCab="yes" />
 
+        <!-- Default settings -->
+        <Property Id="ADD_TO_PATH" Value="1" />
+
         <!-- Reference the UI Fragment -->
         <PropertyRef Id="UiFragment"/>
 

--- a/packaging/msi/UI.wxs
+++ b/packaging/msi/UI.wxs
@@ -15,7 +15,6 @@
 
         <!-- Customize Exit Dialog -->
         <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="View Release Notes" />
-        <Property Id="WIXUI_EXITDIALOGOPTIONALTEXT" Value="You need to reboot your computer to get the updated system path." />
 
         <!-- Use the default WixUI_InstallDir dialog set and personalize the license an images -->
         <WixVariable Id="WixUILicenseRtf" Value="!(bindpath.SOURCE_ROOT)packaging\msi\docs\LICENSE.rtf"/>


### PR DESCRIPTION
A minor update for the MSI:

- Add to path is now enabled by default.
- Removed text about reboot, it is not required.