### PR TITLE
Simplify loading of plug-ins

### DIFF
--- a/cpp/src/Ice/Instance.cpp
+++ b/cpp/src/Ice/Instance.cpp
@@ -1349,8 +1349,9 @@ IceInternal::Instance::~Instance()
     }
 }
 
+// TODO: remove argc/argv.
 void
-IceInternal::Instance::finishSetup(int& argc, const char* argv[], const Ice::CommunicatorPtr& communicator)
+IceInternal::Instance::finishSetup(int&, const char*[], const Ice::CommunicatorPtr& communicator)
 {
     // Load plug-ins.
     assert(!_serverThreadPool);
@@ -1358,7 +1359,7 @@ IceInternal::Instance::finishSetup(int& argc, const char* argv[], const Ice::Com
     assert(pluginManagerImpl);
 
     addDefaultPluginFactories(_initData.pluginFactories);
-    bool libraryLoaded = pluginManagerImpl->loadPlugins(argc, argv);
+    bool libraryLoaded = pluginManagerImpl->loadPlugins();
 
     // On Windows, if we loaded any plugin and stack trace collection is enabled, we need to call
     // ice_enableStackTraceCollection() again to refresh the module list. This refresh is fairly slow so we make it only

--- a/cpp/src/Ice/PluginManagerI.h
+++ b/cpp/src/Ice/PluginManagerI.h
@@ -29,14 +29,10 @@ namespace Ice
         // Loads all the plugins (internal).
         // Returns true when one or more libraries may have been loaded dynamically; returns false when definitely no
         // library was loaded dynamically.
-        bool loadPlugins(int& argc, const char* argv[]);
+        bool loadPlugins();
 
     private:
-        bool loadPlugin(
-            PluginFactoryFunc pluginFactoryFunc,
-            const std::string& name,
-            const std::string& pluginSpec,
-            StringSeq& cmdArgs);
+        bool loadPlugin(PluginFactoryFunc pluginFactoryFunc, const std::string& name, const std::string& pluginSpec);
 
         [[nodiscard]] PluginPtr findPlugin(std::string_view) const;
 

--- a/csharp/src/Ice/Internal/Instance.cs
+++ b/csharp/src/Ice/Internal/Instance.cs
@@ -846,18 +846,19 @@ public sealed class Instance
         }
     }
 
-    public void finishSetup(ref string[] args, Ice.Communicator communicator)
+    // TODO: remove args
+    internal void finishSetup(ref string[] args, Ice.Communicator communicator)
     {
         //
         // Load plug-ins.
         //
         Debug.Assert(_serverThreadPool == null);
         var pluginManagerImpl = (Ice.PluginManagerI)_pluginManager;
-        pluginManagerImpl.loadPlugins(ref args);
+        pluginManagerImpl.loadPlugins();
 
         //
         // Initialize the endpoint factories once all the plugins are loaded. This gives
-        // the opportunity for the endpoint factories to find underyling factories.
+        // the opportunity for the endpoint factories to find underlying factories.
         //
         _endpointFactoryManager.initialize();
 

--- a/csharp/src/Ice/PluginManagerI.cs
+++ b/csharp/src/Ice/PluginManagerI.cs
@@ -171,7 +171,7 @@ internal sealed class PluginManagerI : PluginManager
         _initialized = false;
     }
 
-    public void loadPlugins(ref string[] cmdArgs)
+    internal void loadPlugins()
     {
         Debug.Assert(_communicator is not null);
         string prefix = "Ice.Plugin.";
@@ -185,12 +185,12 @@ internal sealed class PluginManagerI : PluginManager
             string key = $"Ice.Plugin.{name}";
             if (plugins.TryGetValue(key, out string? pluginSpec))
             {
-                loadPlugin(pluginFactory, name, pluginSpec, ref cmdArgs);
+                loadPlugin(pluginFactory, name, pluginSpec);
                 plugins.Remove(key);
             }
             else
             {
-                loadPlugin(pluginFactory, name, "", ref cmdArgs);
+                loadPlugin(pluginFactory, name, "");
             }
         }
 
@@ -228,7 +228,7 @@ internal sealed class PluginManagerI : PluginManager
             plugins.TryGetValue(key, out string? value);
             if (value is not null)
             {
-                loadPlugin(null, loadOrder[i], value, ref cmdArgs);
+                loadPlugin(null, loadOrder[i], value);
                 plugins.Remove(key);
             }
             else
@@ -242,11 +242,11 @@ internal sealed class PluginManagerI : PluginManager
         //
         foreach (KeyValuePair<string, string> entry in plugins)
         {
-            loadPlugin(null, entry.Key[prefix.Length..], entry.Value, ref cmdArgs);
+            loadPlugin(null, entry.Key[prefix.Length..], entry.Value);
         }
     }
 
-    private void loadPlugin(PluginFactory? pluginFactory, string name, string pluginSpec, ref string[] cmdArgs)
+    private void loadPlugin(PluginFactory? pluginFactory, string name, string pluginSpec)
     {
         Debug.Assert(_communicator is not null);
 
@@ -283,15 +283,9 @@ internal sealed class PluginManagerI : PluginManager
             Array.Copy(args, 1, tmp, 0, args.Length - 1);
             args = tmp;
 
-            //
-            // Convert command-line options into properties. First
-            // we convert the options from the plug-in
-            // configuration, then we convert the options from the
-            // application command-line.
-            //
+            // Convert command-line options into properties.
             Properties properties = _communicator.getProperties();
             args = properties.parseCommandLineOptions(name, args);
-            cmdArgs = properties.parseCommandLineOptions(name, cmdArgs);
         }
 
         string err = "unable to load plug-in `" + entryPoint + "': ";

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -866,7 +866,8 @@ public final class Instance {
         }
     }
 
-    public String[] finishSetup(String[] args, Communicator communicator) {
+    // TODO: remove args and return void
+    String[] finishSetup(String[] args, Communicator communicator) {
 
         Properties properties = _initData.properties;
         //
@@ -874,7 +875,7 @@ public final class Instance {
         //
         assert (_serverThreadPool == null);
         PluginManagerI pluginManagerImpl = (PluginManagerI) _pluginManager;
-        args = pluginManagerImpl.loadPlugins(args);
+        pluginManagerImpl.loadPlugins();
 
         //
         // Initialize the endpoint factories once all the plugins are loaded. This gives

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PluginManagerI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PluginManagerI.java
@@ -135,7 +135,7 @@ final class PluginManagerI implements PluginManager {
         _initialized = false;
     }
 
-    public String[] loadPlugins(String[] cmdArgs) {
+    void loadPlugins() {
         assert (_communicator != null);
 
         final String prefix = "Ice.Plugin.";
@@ -147,10 +147,10 @@ final class PluginManagerI implements PluginManager {
             String name = pluginFactory.getPluginName();
             String key = "Ice.Plugin." + name;
             if (plugins.containsKey(key)) {
-                cmdArgs = loadPlugin(pluginFactory, name, plugins.get(key), cmdArgs);
+                loadPlugin(pluginFactory, name, plugins.get(key));
                 plugins.remove(key);
             } else {
-                cmdArgs = loadPlugin(pluginFactory, name, "", cmdArgs);
+                loadPlugin(pluginFactory, name, "");
             }
         }
 
@@ -176,7 +176,7 @@ final class PluginManagerI implements PluginManager {
             boolean hasKey = plugins.containsKey(key);
             if (hasKey) {
                 final String value = plugins.get(key);
-                cmdArgs = loadPlugin(null, name, value, cmdArgs);
+                loadPlugin(null, name, value);
                 plugins.remove(key);
             } else {
                 throw new PluginInitializationException("plug-in '" + name + "' not defined");
@@ -187,15 +187,11 @@ final class PluginManagerI implements PluginManager {
         // Load any remaining plug-ins that weren't specified in PluginLoadOrder.
         //
         for (var entry : plugins.entrySet()) {
-            cmdArgs =
-                loadPlugin(
-                    null, entry.getKey().substring(prefix.length()), entry.getValue(), cmdArgs);
+            loadPlugin(null, entry.getKey().substring(prefix.length()), entry.getValue());
         }
-
-        return cmdArgs;
     }
 
-    private String[] loadPlugin(PluginFactory pluginFactory, String name, String pluginSpec, String[] cmdArgs) {
+    private void loadPlugin(PluginFactory pluginFactory, String name, String pluginSpec) {
         assert (_communicator != null);
 
         if (findPlugin(name) != null) {
@@ -278,14 +274,9 @@ final class PluginManagerI implements PluginManager {
             System.arraycopy(args, 1, tmp, 0, args.length - 1);
             args = tmp;
 
-            //
-            // Convert command-line options into properties. First we
-            // convert the options from the plug-in configuration, then
-            // we convert the options from the application command-line.
-            //
+            // Convert command-line options into properties.
             Properties properties = _communicator.getProperties();
             args = properties.parseCommandLineOptions(name, args);
-            cmdArgs = properties.parseCommandLineOptions(name, cmdArgs);
         }
 
         if (pluginFactory == null) {
@@ -399,8 +390,6 @@ final class PluginManagerI implements PluginManager {
         info.name = name;
         info.plugin = plugin;
         _plugins.add(info);
-
-        return cmdArgs;
     }
 
     private Plugin findPlugin(String name) {


### PR DESCRIPTION
This PR is a small simplification of the PluginManager, and a preliminary step for #4428.

Prior to this PR, `Ice::initialize` transmitted the command-line arguments to the plug-in manager (through an internal API). This allowed the plug-in manager to "parse-out" these command-line args into properties based on the plug-in name, before loading the plug-in.

This was obviously over the top, and also not documented.