### PR TITLE
Rename Java Slice Tools plugin

### DIFF
--- a/java/BUILDING.md
+++ b/java/BUILDING.md
@@ -57,7 +57,7 @@ For example, when using a C++ `Debug` build for `Win32`, you can run:
 
 ### Slice Tools for Java
 
-By default, the Slice Tools for Java package `com.zeroc.ice.slice-tools` includes only the `slice2java` compiler created
+By default, the Slice Tools for Java package `com.zeroc.slice-tools` includes only the `slice2java` compiler created
 by the local C++ build. Refer to [Building Slice Tools for Ice](./tools/slice-tools/BUILDING.md) for instructions on
 including the `slice2java` compilers for all supported platforms.
 

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 plugins {
-    id 'com.zeroc.ice.slice-tools' apply false
+    id 'com.zeroc.slice-tools' apply false
     id 'checkstyle'
     id 'org.openrewrite.rewrite' version '7.7.0'
 }
@@ -20,7 +20,7 @@ subprojects {
 
     apply plugin: 'checkstyle'
     apply plugin: 'java'
-    apply plugin: 'com.zeroc.ice.slice-tools'
+    apply plugin: 'com.zeroc.slice-tools'
     apply from: "$rootProject.projectDir/gradle/ice.gradle"
 
     repositories {

--- a/java/test/android/controller/build.gradle
+++ b/java/test/android/controller/build.gradle
@@ -13,11 +13,11 @@ buildscript {
 }
 
 plugins {
-    id 'com.zeroc.ice.slice-tools' apply false
+    id 'com.zeroc.slice-tools' apply false
 }
 
 apply plugin: 'com.android.application'
-apply plugin: 'com.zeroc.ice.slice-tools'
+apply plugin: 'com.zeroc.slice-tools'
 
 def topSrcDir = new File("$rootProject.projectDir/../../../..").getCanonicalPath()
 

--- a/java/tools/slice-tools/README.md
+++ b/java/tools/slice-tools/README.md
@@ -6,7 +6,7 @@ integrates seamlessly with the Gradle build system.
 
 > Note: This Gradle plugin replaces the Ice Builder for Gradle plugin (com.zeroc.gradle.ice-builder.slice). While the
 > Ice Builder for Gradle is still compatible with Ice 3.8, we recommend using the Slice Tools for Ice and Java
-> (com.zeroc.ice.slice-tools) for better integration with Ice 3.8.
+> (com.zeroc.slice-tools) for better integration with Ice 3.8.
 
 ## Features
 
@@ -29,7 +29,7 @@ Apply the plugin to your `build.gradle` (Groovy) or `build.gradle.kts` (Kotlin):
 
 ```groovy
 plugins {
-    id 'com.zeroc.ice.slice-tools' version '3.8.0-alpha.0'
+    id 'com.zeroc.slice-tools' version '3.8.0-alpha.0'
 }
 ```
 
@@ -37,7 +37,7 @@ plugins {
 
 ```kotlin
 plugins {
-    id("com.zeroc.ice.slice-tools") version "3.8.0-alpha.0"
+    id("com.zeroc.slice-tools") version "3.8.0-alpha.0"
 }
 ```
 
@@ -178,7 +178,7 @@ A minimal Java project with Slice support:
 ```groovy
 plugins {
     id 'java'
-    id 'com.zeroc.ice.slice-tools' version '3.8.0-alpha.0'
+    id 'com.zeroc.slice-tools' version '3.8.0-alpha.0'
 }
 ```
 

--- a/java/tools/slice-tools/build.gradle.kts
+++ b/java/tools/slice-tools/build.gradle.kts
@@ -33,13 +33,13 @@ dependencies {
 // Plugin version management
 val sliceToolsVersion: String by project
 version = sliceToolsVersion
-group = "com.zeroc.ice"
+group = "com.zeroc"
 
 gradlePlugin {
     plugins {
         create("sliceTools") {
-            id = "com.zeroc.ice.slice-tools"
-            implementationClass = "com.zeroc.ice.slice.tools.SliceToolsPlugin"
+            id = "com.zeroc.slice-tools"
+            implementationClass = "com.zeroc.slice.tools.SliceToolsPlugin"
         }
     }
 }

--- a/java/tools/slice-tools/src/functionalTest/kotlin/com/zeroc/slice/tools/SliceToolsJavaPluginFunctionalTest.kt
+++ b/java/tools/slice-tools/src/functionalTest/kotlin/com/zeroc/slice/tools/SliceToolsJavaPluginFunctionalTest.kt
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-package com.zeroc.ice.slice.tools
+package com.zeroc.slice.tools
 
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.io.TempDir
@@ -27,7 +27,7 @@ class SliceToolsJavaPluginFunctionalTest {
             """
             plugins {
                 id('java')
-                id('com.zeroc.ice.slice-tools')
+                id('com.zeroc.slice-tools')
             }
 
             slice {

--- a/java/tools/slice-tools/src/main/kotlin/com/zeroc/slice/tools/SliceExtension.kt
+++ b/java/tools/slice-tools/src/main/kotlin/com/zeroc/slice/tools/SliceExtension.kt
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-package com.zeroc.ice.slice.tools
+package com.zeroc.slice.tools
 
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project

--- a/java/tools/slice-tools/src/main/kotlin/com/zeroc/slice/tools/SliceSourceSet.kt
+++ b/java/tools/slice-tools/src/main/kotlin/com/zeroc/slice/tools/SliceSourceSet.kt
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-package com.zeroc.ice.slice.tools
+package com.zeroc.slice.tools
 
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.SourceDirectorySet

--- a/java/tools/slice-tools/src/main/kotlin/com/zeroc/slice/tools/SliceTask.kt
+++ b/java/tools/slice-tools/src/main/kotlin/com/zeroc/slice/tools/SliceTask.kt
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-package com.zeroc.ice.slice.tools
+package com.zeroc.slice.tools
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException

--- a/java/tools/slice-tools/src/main/kotlin/com/zeroc/slice/tools/SliceToolsAndroid.kt
+++ b/java/tools/slice-tools/src/main/kotlin/com/zeroc/slice/tools/SliceToolsAndroid.kt
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-package com.zeroc.ice.slice.tools
+package com.zeroc.slice.tools
 
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.variant.AndroidComponentsExtension

--- a/java/tools/slice-tools/src/main/kotlin/com/zeroc/slice/tools/SliceToolsJava.kt
+++ b/java/tools/slice-tools/src/main/kotlin/com/zeroc/slice/tools/SliceToolsJava.kt
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-package com.zeroc.ice.slice.tools
+package com.zeroc.slice.tools
 
 import org.gradle.api.GradleException
 import org.gradle.api.Project

--- a/java/tools/slice-tools/src/main/kotlin/com/zeroc/slice/tools/SliceToolsPlugin.kt
+++ b/java/tools/slice-tools/src/main/kotlin/com/zeroc/slice/tools/SliceToolsPlugin.kt
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-package com.zeroc.ice.slice.tools
+package com.zeroc.slice.tools
 
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin

--- a/java/tools/slice-tools/src/main/kotlin/com/zeroc/slice/tools/SliceToolsResourceExtractor.kt
+++ b/java/tools/slice-tools/src/main/kotlin/com/zeroc/slice/tools/SliceToolsResourceExtractor.kt
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-package com.zeroc.ice.slice.tools
+package com.zeroc.slice.tools
 
 import org.gradle.api.Project
 import java.io.File

--- a/java/tools/slice-tools/src/main/kotlin/com/zeroc/slice/tools/SliceToolsUtil.kt
+++ b/java/tools/slice-tools/src/main/kotlin/com/zeroc/slice/tools/SliceToolsUtil.kt
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-package com.zeroc.ice.slice.tools
+package com.zeroc.slice.tools
 
 import org.gradle.api.Project
 import org.gradle.api.Task

--- a/java/tools/slice-tools/src/main/kotlin/com/zeroc/slice/tools/XmlExtensions.kt
+++ b/java/tools/slice-tools/src/main/kotlin/com/zeroc/slice/tools/XmlExtensions.kt
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-package com.zeroc.ice.slice.tools
+package com.zeroc.slice.tools
 
 import org.w3c.dom.Node
 import org.w3c.dom.NodeList

--- a/java/tools/slice-tools/src/test/kotlin/com/zeroc/slice/tools/SliceToolsJavaPluginTest.kt
+++ b/java/tools/slice-tools/src/test/kotlin/com/zeroc/slice/tools/SliceToolsJavaPluginTest.kt
@@ -1,13 +1,13 @@
 // Copyright (c) ZeroC, Inc.
 
-package com.zeroc.ice.slice.tools
+package com.zeroc.slice.tools
 
 import org.gradle.testfixtures.ProjectBuilder
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 
 /**
- * A simple unit test for the 'com.zeroc.ice.slice-tools' plugin.
+ * A simple unit test for the 'com.zeroc.slice-tools' plugin.
  */
 class SliceToolsJavaPluginTest {
     @Test fun `plugin registers task`() {
@@ -15,7 +15,7 @@ class SliceToolsJavaPluginTest {
         val project = ProjectBuilder.builder().build()
         project.extensions.extraProperties.set("sliceToolsVersion", "3.8.0-alpha.0")
         project.plugins.apply("java")
-        project.plugins.apply("com.zeroc.ice.slice-tools")
+        project.plugins.apply("com.zeroc.slice-tools")
 
         // Set toolsPath in the plugin extension
         val extension = project.extensions.getByType(SliceExtension::class.java)

--- a/packaging/maven/publish-maven-release.sh
+++ b/packaging/maven/publish-maven-release.sh
@@ -1,4 +1,4 @@
-set -euo pipefail
+set -xeuo pipefail
 
 case "$CHANNEL" in
   "3.8")
@@ -68,7 +68,7 @@ if [ "$CHANNEL" = "nightly" ]; then
 
   mkdir -p plugin
 
-  plugin_staging_dir="${STAGING_DIR}/slice-tools-packages/com/zeroc/ice/slice-tools"
+  plugin_staging_dir="${STAGING_DIR}/slice-tools-packages/com/zeroc/slice-tools"
 
   cp "${plugin_staging_dir}/${ice_version}/"*.jar "plugin/slice-tools-${ice_version}.jar"
   cp "${plugin_staging_dir}/${ice_version}/"*.jar.asc "plugin/slice-tools-${ice_version}.jar.asc"
@@ -87,21 +87,21 @@ if [ "$CHANNEL" = "nightly" ]; then
     -Durl="${SOURCE_URL}" \
     -DrepositoryId="${REPO_ID}" || { echo "Failed to publish plugin"; exit 1; }
 
-  cp "${plugin_staging_dir}/com.zeroc.ice.slice-tools.gradle.plugin/${ice_version}/"*.pom \
-    "plugin/com.zeroc.ice.slice-tools.gradle.plugin-${ice_version}.pom"
-  cp "${plugin_staging_dir}/com.zeroc.ice.slice-tools.gradle.plugin/${ice_version}/"*.pom.asc \
-    "plugin/com.zeroc.ice.slice-tools.gradle.plugin-${ice_version}.pom.asc"
+  cp "${plugin_staging_dir}/com.zeroc.slice-tools.gradle.plugin/${ice_version}/"*.pom \
+    "plugin/com.zeroc.slice-tools.gradle.plugin-${ice_version}.pom"
+  cp "${plugin_staging_dir}/com.zeroc.slice-tools.gradle.plugin/${ice_version}/"*.pom.asc \
+    "plugin/com.zeroc.slice-tools.gradle.plugin-${ice_version}.pom.asc"
 
-  plugin_marker_pom="plugin/com.zeroc.ice.slice-tools.gradle.plugin-${ice_version}.pom"
-  plugin_marker_asc="plugin/com.zeroc.ice.slice-tools.gradle.plugin-${ice_version}.pom.asc"
+  plugin_marker_pom="plugin/com.zeroc.slice-tools.gradle.plugin-${ice_version}.pom"
+  plugin_marker_asc="plugin/com.zeroc.slice-tools.gradle.plugin-${ice_version}.pom.asc"
 
   echo "Publishing plugin marker POM"
 
   mvn deploy:deploy-file \
     -Dfile="${plugin_marker_pom}" \
     -Dpackaging=pom \
-    -DgroupId="com.zeroc.ice.slice-tools" \
-    -DartifactId="com.zeroc.ice.slice-tools.gradle.plugin" \
+    -DgroupId="com.zeroc.slice-tools" \
+    -DartifactId="com.zeroc.slice-tools.gradle.plugin" \
     -Dversion="${ice_version}" \
     -Dfiles="${plugin_marker_asc}" \
     -Dtypes=pom.asc \


### PR DESCRIPTION
This PR renames the Slice Tools for Java Gradle plugin

The new plugin ID is `com.zeroc.slice-tools`, the previous ID `com.zeroc.ice.slice-tools` was problematic. The nesting packages triggered a nexus bug. https://github.com/sonatype/nexus-public/issues/742