### PR TITLE
Simplify initialize in PHP

### DIFF
--- a/php/src/Communicator.cpp
+++ b/php/src/Communicator.cpp
@@ -908,7 +908,7 @@ ZEND_FUNCTION(Ice_initialize)
     // Make sure we have a Properties object.
     if (!initData.properties)
     {
-       initData.properties = make_shared<Ice::Properties>();
+        initData.properties = make_shared<Ice::Properties>();
     }
 
     // Always accept class cycles during the unmarshaling of PHP objects by the C++ code.

--- a/php/src/Communicator.cpp
+++ b/php/src/Communicator.cpp
@@ -908,7 +908,7 @@ ZEND_FUNCTION(Ice_initialize)
     // Make sure we have a Properties object.
     if (!initData.properties)
     {
-        initData.properties = make_shared<Ice::Properties>();
+        initData.properties = std::make_shared<Ice::Properties>();
     }
 
     // Always accept class cycles during the unmarshaling of PHP objects by the C++ code.

--- a/php/src/Connection.h
+++ b/php/src/Connection.h
@@ -16,6 +16,6 @@ namespace IcePHP
 
     bool createConnectionInfo(zval*, const Ice::ConnectionInfoPtr&);
 
-} // End of namespace IcePHP
+}
 
 #endif

--- a/php/src/Init.cpp
+++ b/php/src/Init.cpp
@@ -16,9 +16,7 @@ using namespace IcePHP;
 ZEND_DECLARE_MODULE_GLOBALS(ice)
 
 ZEND_BEGIN_ARG_INFO_EX(Ice_initialize_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(0))
-ZEND_ARG_INFO(1, args)
-ZEND_ARG_INFO(1, properties)
-ZEND_ARG_INFO(1, initData)
+ZEND_ARG_INFO(1, argsOrInitData)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(Ice_createProperties_arginfo, 1, ZEND_RETURN_VALUE, static_cast<zend_ulong>(0))

--- a/php/test/Ice/properties/Client.php
+++ b/php/test/Ice/properties/Client.php
@@ -78,5 +78,12 @@ class Client extends TestHelper
         } catch (\Ice\PropertyException $ex) {
         }
         echo "ok\n";
+
+        echo "testing Ice.initialize with args... ";
+        $args = ["--Foo.Bar=1", "--Foo.Bar=2", "--Ice.Trace.Network=3"];
+        $communicator = Ice\initialize($args);
+        test($communicator->getProperties()->getIceProperty("Ice.Trace.Network") == "3");
+        test(count($args) == 2);
+        echo "ok\n";
     }
 }


### PR DESCRIPTION
The updated version accepts either one parameter or no parameter, and the single parameter can be an args vector or an initData.