### PR TITLE
Add Connection::disableInactivityCheck in C++, use it in IceGrid

### DIFF
--- a/cpp/include/Ice/Connection.h
+++ b/cpp/include/Ice/Connection.h
@@ -129,6 +129,9 @@ namespace Ice
         /// @param callback The close callback object.
         virtual void setCloseCallback(CloseCallback callback) = 0;
 
+        /// Disables the inactivity check on this connection.
+        virtual void disableInactivityCheck() = 0;
+
         /// Returns the connection type. This corresponds to the endpoint type, such as "tcp", "udp", etc.
         /// @return The type of the connection.
         [[nodiscard]] virtual const std::string& type() const noexcept = 0;

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -798,6 +798,14 @@ Ice::ConnectionI::setCloseCallback(CloseCallback callback)
 }
 
 void
+Ice::ConnectionI::disableInactivityCheck()
+{
+    std::lock_guard lock{_mutex};
+    cancelInactivityTimerTask();
+    _inactivityTimerTask = nullptr;
+}
+
+void
 Ice::ConnectionI::closeCallback(const CloseCallback& callback)
 {
     try

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -177,6 +177,8 @@ namespace Ice
 
         void setCloseCallback(CloseCallback) final;
 
+        void disableInactivityCheck() final;
+
         void asyncRequestCanceled(const IceInternal::OutgoingAsyncBasePtr&, std::exception_ptr) final;
 
         [[nodiscard]] IceInternal::EndpointIPtr endpoint() const;

--- a/cpp/src/IceGrid/AdminSessionI.cpp
+++ b/cpp/src/IceGrid/AdminSessionI.cpp
@@ -486,7 +486,7 @@ AdminSessionFactory::createGlacier2Session(
         }
     }
 
-    // We can't use a non-0 timeout. As of Ice 3.8, heartbeats may not be sent  at all on a busy connection.
+    // We can't use a non-0 timeout. As of Ice 3.8, heartbeats may not be sent at all on a busy connection.
     // Furthermore, as of Ice 3.8, Glacier2 no longer "converts" heartbeats into keepAlive requests.
     _reaper->add(make_shared<SessionReapable<AdminSessionI>>(_database->getTraceLevels()->logger, session), 0s, con);
     return Ice::uncheckedCast<Glacier2::SessionPrx>(proxy);

--- a/cpp/src/IceGrid/AdminSessionI.cpp
+++ b/cpp/src/IceGrid/AdminSessionI.cpp
@@ -486,9 +486,8 @@ AdminSessionFactory::createGlacier2Session(
         }
     }
 
-    // We can't use a non-0 timeout such as the Glacier2 session timeout. As of Ice 3.8, heartbeats may not be sent
-    // at all on a busy connection. Furthermore, as of Ice 3.8, Glacier2 no longer "converts" heartbeats into
-    // keepAlive requests.
+    // We can't use a non-0 timeout. As of Ice 3.8, heartbeats may not be sent  at all on a busy connection.
+    // Furthermore, as of Ice 3.8, Glacier2 no longer "converts" heartbeats into keepAlive requests.
     _reaper->add(make_shared<SessionReapable<AdminSessionI>>(_database->getTraceLevels()->logger, session), 0s, con);
     return Ice::uncheckedCast<Glacier2::SessionPrx>(proxy);
 }

--- a/cpp/src/IceGrid/IceGridNode.cpp
+++ b/cpp/src/IceGrid/IceGridNode.cpp
@@ -743,18 +743,6 @@ NodeService::initializeCommunicator(int& argc, char* argv[], InitializationData 
         initData.properties->setProperty("Ice.Admin.Enabled", "1");
     }
 
-    // In case of a collocated registry. Doesn't hurt otherwise.
-    // Turn-off the inactivity timeout for the IceGrid.Registry.Client object adapter unless the application sets this
-    // property. That's because the IceGrid.Registry.Client object adapter hosts connection-bound sessions
-    // (admin sessions and resource allocation sessions).
-    // We use getProperty and not getIceProperty on purpose here!
-    // TODO: replace this code by switching off the inactivity timeout programmatically on incoming connections with
-    // associated sessions.
-    if (initData.properties->getProperty("IceGrid.Registry.Client.Connection.InactivityTimeout").empty())
-    {
-        initData.properties->setProperty("IceGrid.Registry.Client.Connection.InactivityTimeout", "0");
-    }
-
     //
     // Setup the client thread pool size.
     //

--- a/cpp/src/IceGrid/IceGridRegistry.cpp
+++ b/cpp/src/IceGrid/IceGridRegistry.cpp
@@ -179,17 +179,6 @@ RegistryService::initializeCommunicator(int& argc, char* argv[], InitializationD
         initData.properties->setProperty("Ice.Admin.Enabled", "1");
     }
 
-    // Turn-off the inactivity timeout for the IceGrid.Registry.Client object adapter unless the application sets this
-    // property. That's because the IceGrid.Registry.Client object adapter hosts connection-bound sessions
-    // (admin sessions and resource allocation sessions).
-    // We use getProperty and not getIceProperty on purpose here!
-    // TODO: replace this code by switching off the inactivity timeout programmatically on incoming connections with
-    // associated sessions.
-    if (initData.properties->getProperty("IceGrid.Registry.Client.Connection.InactivityTimeout").empty())
-    {
-        initData.properties->setProperty("IceGrid.Registry.Client.Connection.InactivityTimeout", "0");
-    }
-
     //
     // Setup the client thread pool size.
     //

--- a/cpp/src/IceGrid/ReapThread.cpp
+++ b/cpp/src/IceGrid/ReapThread.cpp
@@ -146,6 +146,11 @@ ReapThread::add(const shared_ptr<Reapable>& reapable, chrono::seconds timeout, c
         auto p = _connections.find(connection);
         if (p == _connections.end())
         {
+            // Disable the inactivity check on this connection since it's bound to a session.
+            // This is useful for incoming connections managed by the IceGrid.Registry.Client object adapter; for
+            // other object adapters, the inactivity timeout is 0 and the check is already disabled.
+            connection->disableInactivityCheck();
+
             p = _connections.insert({connection, {}}).first;
             connection->setCloseCallback(_closeCallback);
         }

--- a/cpp/src/IceGrid/SessionI.cpp
+++ b/cpp/src/IceGrid/SessionI.cpp
@@ -308,9 +308,8 @@ ClientSessionFactory::createGlacier2Session(
         }
     }
 
-    // We can't use a non-0 timeout such as the Glacier2 session timeout. As of Ice 3.8, heartbeats may not be sent
-    // at all on a busy connection. Furthermore, as of Ice 3.8, Glacier2 no longer "converts" heartbeats into
-    // keepAlive requests.
+    // We can't use a non-0 timeout. As of Ice 3.8, heartbeats may not be sent at all on a busy connection. Furthermore,
+    // as of Ice 3.8, Glacier2 no longer "converts" heartbeats into keepAlive requests.
     _reaper->add(make_shared<SessionReapable<SessionI>>(_database->getTraceLevels()->logger, session), 0s, con);
     return Ice::uncheckedCast<Glacier2::SessionPrx>(proxy);
 }

--- a/cpp/test/Ice/inactivityTimeout/Test.ice
+++ b/cpp/test/Ice/inactivityTimeout/Test.ice
@@ -9,6 +9,8 @@ module Test
         ["amd"]
         void sleep(int ms);
 
+        void disableInactivityCheck();
+
         void shutdown();
     }
 }

--- a/cpp/test/Ice/inactivityTimeout/TestI.cpp
+++ b/cpp/test/Ice/inactivityTimeout/TestI.cpp
@@ -20,6 +20,12 @@ TestIntfI::sleepAsync(int32_t ms, function<void()> response, function<void(excep
 }
 
 void
+TestIntfI::disableInactivityCheck(const Ice::Current& current)
+{
+    current.con->disableInactivityCheck();
+}
+
+void
 TestIntfI::shutdown(const Ice::Current& current)
 {
     current.adapter->getCommunicator()->shutdown();

--- a/cpp/test/Ice/inactivityTimeout/TestI.h
+++ b/cpp/test/Ice/inactivityTimeout/TestI.h
@@ -14,6 +14,7 @@ public:
         std::function<void(std::exception_ptr)> exception,
         const Ice::Current& current) final;
 
+    void disableInactivityCheck(const Ice::Current&) final;
     void shutdown(const Ice::Current&) final;
 
 private:


### PR DESCRIPTION
This PR adds a new disableInactivityCheck function on Ice::Connection (C++ only), and uses this new function in IceGrid.

With this update, "regular" connections to the IceGrid (client) registry are again subject to the server-side inactivity check, while connections bound to sessions are not.

Fixes #4402.