### PR TITLE
Fix for retry on selector internal errors

### DIFF
--- a/cpp/src/Ice/Selector.cpp
+++ b/cpp/src/Ice/Selector.cpp
@@ -14,6 +14,7 @@
 #include <chrono>
 #include <thread>
 
+#ifndef ICE_USE_CFSTREAM
 // Constants shared across Windows and Unix selector implementations.
 
 // Warn every 100 iterations if there is an unexpected selector error. To avoid flooding the log.
@@ -21,6 +22,7 @@ static constexpr int selectorRetryWarnEvery = 100;
 
 // Backoff duration for transient errors. This is the time we wait before retrying to avoid overloading the CPU.
 static constexpr auto transientErrorBackoff = std::chrono::milliseconds(1);
+#endif
 
 using namespace std;
 using namespace IceInternal;


### PR DESCRIPTION
See #4441

Two issues fixed in this PR:

- The getNextHandler IOCP implementation was returning a null handler if GetQueuedCompletionStatus failed without returning an overlapped structure. We now loop and retry after a small 1 ms delay. This indicates an internal error; the assumption is the system is under high load and cannot allocate resources.
- The Linux/macOS implementation that calls epoll and kevent respectively was missing a continue, which prevented the selector from retrying in this condition. We also reduced the sleep_for timeout to 1 ms (from 5 s).
