### PR TITLE
Include more details in Python (...) local exceptions

### DIFF
--- a/matlab/src/Util.cpp
+++ b/matlab/src/Util.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <locale>
 #include <string>
+#include <strstream>
 
 using namespace std;
 
@@ -404,7 +405,7 @@ IceMatlab::convertException(const std::exception_ptr exc)
     {
         ostringstream os;
         e.ice_print(os);
-        result = createMatlabException(e.ice_id(), os.str().c_str());
+        result = createMatlabException(e.ice_id(), os.str());
     }
     catch (const std::exception& e)
     {

--- a/matlab/src/Util.cpp
+++ b/matlab/src/Util.cpp
@@ -6,8 +6,8 @@
 
 #include <array>
 #include <locale>
-#include <string>
 #include <sstream>
+#include <string>
 
 using namespace std;
 

--- a/matlab/src/Util.cpp
+++ b/matlab/src/Util.cpp
@@ -7,7 +7,7 @@
 #include <array>
 #include <locale>
 #include <string>
-#include <strstream>
+#include <sstream>
 
 using namespace std;
 

--- a/matlab/src/Util.cpp
+++ b/matlab/src/Util.cpp
@@ -290,10 +290,10 @@ namespace
     }
 
     // Create a "standard" MATLAB exception for the given typeId then fallback to LocalException.
-    mxArray* createMatlabException(const char* typeId, const char* what)
+    mxArray* createMatlabException(const char* typeId, const string& message)
     {
         string errID = replace(string{typeId}.substr(2), "::", ":");
-        std::array params{IceMatlab::createStringFromUTF8(errID), IceMatlab::createStringFromUTF8(what)};
+        std::array params{IceMatlab::createStringFromUTF8(errID), IceMatlab::createStringFromUTF8(message)};
 
         string className = replace(string{typeId}.substr(2), "::", ".");
         mxArray* ex;
@@ -402,7 +402,9 @@ IceMatlab::convertException(const std::exception_ptr exc)
     }
     catch (const Ice::LocalException& e)
     {
-        result = createMatlabException(e.ice_id(), e.what());
+        ostringstream os;
+        e.ice_print(os);
+        result = createMatlabException(e.ice_id(), os.str().c_str());
     }
     catch (const std::exception& e)
     {

--- a/php/src/Util.cpp
+++ b/php/src/Util.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <ctype.h>
+#include <strstream>
 
 using namespace std;
 using namespace IcePHP;
@@ -532,7 +533,9 @@ IcePHP::convertException(zval* zex, std::exception_ptr ex)
         {
             return;
         }
-        setStringMember(zex, "message", e.what());
+        ostringstream os;
+        e.ice_print(os);
+        setStringMember(zex, "message", os.str());
     }
     catch (const std::invalid_argument& e)
     {

--- a/php/src/Util.cpp
+++ b/php/src/Util.cpp
@@ -6,7 +6,7 @@
 
 #include <algorithm>
 #include <ctype.h>
-#include <strstream>
+#include <sstream>
 
 using namespace std;
 using namespace IcePHP;

--- a/php/test/Ice/properties/Client.php
+++ b/php/test/Ice/properties/Client.php
@@ -65,7 +65,7 @@ class Client extends TestHelper
             $properties->getIceProperty("Ice.UnknownProperty");
             test(False);
         } catch (\Ice\PropertyException $ex) {
-            test($ex->getMessage() == "unknown Ice property: Ice.UnknownProperty");
+            test(str_contains($ex->getMessage(), "unknown Ice property: Ice.UnknownProperty"));
         }
         echo "ok\n";
 

--- a/python/modules/IcePy/Util.cpp
+++ b/python/modules/IcePy/Util.cpp
@@ -9,6 +9,7 @@
 #include <compile.h>
 #include <cstddef>
 #include <frameobject.h>
+#include <strstream>
 
 using namespace std;
 using namespace Slice::Python;
@@ -599,7 +600,7 @@ namespace
     createPythonException(const char* typeId, std::array<PyObject*, N> args, bool fallbackToLocalException = false)
     {
         // Convert the exception's typeId to its mapped Python type by replacing "::Ice::" with "Ice.".
-        // This function should only ever be called on Ice local exceptions which don't use 'python:identifier'.
+        // This function should only ever be called on Ice local exceptions.
         string result = typeId;
         assert(result.find("::Ice::") == 0);
         result.replace(0, 7, "Ice.");
@@ -695,7 +696,9 @@ IcePy::convertException(std::exception_ptr exPtr)
     // Then all other exceptions.
     catch (const Ice::LocalException& ex)
     {
-        std::array args{IcePy::createString(ex.what())};
+        ostringstream os;
+        ex.ice_print(os);
+        std::array args{IcePy::createString(os.str())};
         return createPythonException(ex.ice_id(), args, true);
     }
     catch (const std::exception& ex)

--- a/python/modules/IcePy/Util.cpp
+++ b/python/modules/IcePy/Util.cpp
@@ -9,7 +9,7 @@
 #include <compile.h>
 #include <cstddef>
 #include <frameobject.h>
-#include <strstream>
+#include <sstream>
 
 using namespace std;
 using namespace Slice::Python;

--- a/ruby/src/IceRuby/Util.cpp
+++ b/ruby/src/IceRuby/Util.cpp
@@ -3,8 +3,8 @@
 #include "Util.h"
 #include "Ice/LocalExceptions.h"
 #include "Ice/VersionFunctions.h"
-#include <stdarg.h>
 #include <sstream>
+#include <stdarg.h>
 
 using namespace std;
 using namespace IceRuby;

--- a/ruby/src/IceRuby/Util.cpp
+++ b/ruby/src/IceRuby/Util.cpp
@@ -4,7 +4,7 @@
 #include "Ice/LocalExceptions.h"
 #include "Ice/VersionFunctions.h"
 #include <stdarg.h>
-#include <strstream>
+#include <sstream>
 
 using namespace std;
 using namespace IceRuby;

--- a/ruby/src/IceRuby/Util.cpp
+++ b/ruby/src/IceRuby/Util.cpp
@@ -4,6 +4,7 @@
 #include "Ice/LocalExceptions.h"
 #include "Ice/VersionFunctions.h"
 #include <stdarg.h>
+#include <strstream>
 
 using namespace std;
 using namespace IceRuby;
@@ -623,7 +624,9 @@ IceRuby::convertException(std::exception_ptr eptr)
         // Then all other exceptions.
         catch (const Ice::LocalException& ex)
         {
-            std::array args{IceRuby::createString(ex.what())};
+            ostringstream os;
+            ex.ice_print(os);
+            std::array args{IceRuby::createString(os.str())};
             return createRubyException(ex.ice_id(), std::move(args), true);
         }
         catch (const std::exception& ex)


### PR DESCRIPTION
This PR updates the wrapping of local exceptions in MATLAB, Python, PHP and Ruby. 

For "non-mapped" local exceptions, we now include the full ice_print instead of what. With debug builds, ice_print includes the stack trace by default. For example:

```
Ice.DNSException: src/Ice/Network.cpp:634 Ice::DNSException cannot resolve DNS host 'pro14.local': nodename nor servname provided, or not known
stack trace:
  0 Ice::LocalException::LocalException(char const*, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>) in libIce.38a0.dylib
  1 Ice::SyscallException::SyscallException(char const*, int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, int, std::__1::function<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> (int)> const&) in libIce.38a0.dylib
  2 Ice::DNSException::DNSException(char const*, int, int, std::__1::basic_string_view<char, std::__1::char_traits<char>>) in libIce.38a0.dylib
  3 Ice::DNSException::DNSException(char const*, int, int, std::__1::basic_string_view<char, std::__1::char_traits<char>>) in libIce.38a0.dylib
  4 IceInternal::getAddresses(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, int, IceInternal::ProtocolSupport, bool, bool) in libIce.38a0.dylib
  5 IceInternal::EndpointHostResolver::run() in libIce.38a0.dylib
  6 IceInternal::Instance::finishSetup(std::__1::shared_ptr<Ice::Communicator> const&)::$_1::operator()() const in libIce.38a0.dylib
  7 decltype(std::declval<IceInternal::Instance::finishSetup(std::__1::shared_ptr<Ice::Communicator> const&)::$_1>()()) std::__1::__invoke[abi:ne200100]<IceInternal::Instance::finishSetup(std::__1::shared_ptr<Ice::Communicator> const&)::$_1>(IceInternal::Instance::finishSetup(std::__1::shared_ptr<Ice::Communicator> const&)::$_1&&) in libIce.38a0.dylib
  8 void std::__1::__thread_execute[abi:ne200100]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, IceInternal::Instance::finishSetup(std::__1::shared_ptr<Ice::Communicator> const&)::$_1>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, IceInternal::Instance::finishSetup(std::__1::shared_ptr<Ice::Communicator> const&)::$_1>&, std::__1::__tuple_indices<>) in libIce.38a0.dylib
  9 void* std::__1::__thread_proxy[abi:ne200100]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, IceInternal::Instance::finishSetup(std::__1::shared_ptr<Ice::Communicator> const&)::$_1>>(void*) in libIce.38a0.dylib
 10 _pthread_start in libsystem_pthread.dylib
 11 thread_start in libsystem_pthread.dylib
```