### PR TITLE
Cleanup unreachable Python initialize code

### DIFF
--- a/python/python/Ice/Util.py
+++ b/python/python/Ice/Util.py
@@ -70,12 +70,6 @@ def initialize(
             await greeter.greetAsync()
     """
 
-    if initData and args:
-        raise InitializationException("Both args and initData arguments cannot be specified")
-
-    if initData and eventLoop:
-        raise InitializationException("Both initData and eventLoop arguments cannot be specified")
-
     eventLoopAdapter = initData.eventLoopAdapter if initData else None
     if eventLoop:
         eventLoopAdapter = AsyncIOEventLoopAdapter(eventLoop)

--- a/python/python/Ice/Util.py
+++ b/python/python/Ice/Util.py
@@ -70,12 +70,6 @@ def initialize(
             await greeter.greetAsync()
     """
 
-    if args and not isinstance(args, list):
-        raise InitializationException("args must be a list of strings")
-
-    if initData and not isinstance(initData, InitializationData):
-        raise InitializationException("initData must be an instance of Ice.InitializationData")
-
     if initData and args:
         raise InitializationException("Both args and initData arguments cannot be specified")
 
@@ -84,9 +78,6 @@ def initialize(
 
     eventLoopAdapter = initData.eventLoopAdapter if initData else None
     if eventLoop:
-        assert not eventLoopAdapter  # initData is None here
-        if not isinstance(eventLoop, asyncio.AbstractEventLoop):
-            raise InitializationException("The event loop must be an instance of asyncio.AbstractEventLoop")
         eventLoopAdapter = AsyncIOEventLoopAdapter(eventLoop)
 
     if args:

--- a/python/python/Ice/Util.py
+++ b/python/python/Ice/Util.py
@@ -71,7 +71,11 @@ def initialize(
     """
 
     eventLoopAdapter = initData.eventLoopAdapter if initData else None
-    if eventLoop:
+
+    eventLoopAdapter = None
+    if initData:
+        eventLoopAdapter = initData.eventLoopAdapter
+    elif eventLoop:
         eventLoopAdapter = AsyncIOEventLoopAdapter(eventLoop)
 
     if args:


### PR DESCRIPTION
Removed code that is marked as unreachable by the type checker. If you don't use a type checker you need to pay attention to the passed arguments yourself.

Fix #4479