### PR TITLE
Update Swift doc comments to use standard conventions

### DIFF
--- a/swift/src/Ice/Communicator.swift
+++ b/swift/src/Ice/Communicator.swift
@@ -25,7 +25,7 @@ public protocol Communicator: AnyObject, Sendable {
 
     /// Checks whether or not `shutdown` was called on this communicator.
     ///
-    /// - returns: `Bool` - True if shutdown was called on this communicator; false otherwise.
+    /// - Returns: True if shutdown was called on this communicator; false otherwise.
     func isShutdown() -> Bool
 
     /// Convert a stringified proxy into a proxy.
@@ -34,42 +34,36 @@ public protocol Communicator: AnyObject, Sendable {
     /// "some_host", port 10000. If the stringified proxy does not parse correctly, the operation throws ParseException.
     /// Refer to the Ice manual for a detailed description of the syntax supported by stringified proxies.
     ///
-    /// - parameter str: `String` The stringified proxy to convert into a proxy.
-    ///
-    /// - returns: `ObjectPrx?` - The proxy, or nil if str is an empty string.
+    /// - Parameter str: The stringified proxy to convert into a proxy.
+    /// - Returns: The proxy, or nil if str is an empty string.
     func stringToProxy(_ str: String) throws -> ObjectPrx?
 
     /// Convert a proxy into a string.
     ///
-    /// - parameter obj: `ObjectPrx?` The proxy to convert into a stringified proxy.
-    ///
-    /// - returns: `String` - The stringified proxy, or an empty string if
-    /// obj is nil.
+    /// - Parameter obj: The proxy to convert into a stringified proxy.
+    /// - Returns: The stringified proxy, or an empty string if obj is nil.
     func proxyToString(_ obj: ObjectPrx?) -> String
 
     /// Convert a set of proxy properties into a proxy. The "base" name supplied in the property argument
     /// refers to a property containing a stringified proxy, such as MyProxy=id:tcp -h localhost -p 10000.
     /// Additional properties configure local settings for the proxy.
     ///
-    /// - parameter property: `String` The base property name.
-    ///
-    /// - returns: `ObjectPrx?` - The proxy, or nil if the property is not set.
+    /// - Parameter property: The base property name.
+    /// - Returns: The proxy, or nil if the property is not set.
     func propertyToProxy(_ property: String) throws -> ObjectPrx?
 
     /// Convert a proxy to a set of proxy properties.
     ///
-    /// - parameter proxy: `ObjectPrx` The proxy.
-    ///
-    /// - parameter property: `String` The base property name.
-    ///
-    /// - returns: `PropertyDict` - The property set.
+    /// - Parameters:
+    ///   - proxy: The proxy.
+    ///   - property: The base property name.
+    /// - Returns: The property set.
     func proxyToProperty(proxy: ObjectPrx, property: String) -> PropertyDict
 
     /// Convert an identity into a string.
     ///
-    /// - parameter ident: `Identity` The identity to convert into a string.
-    ///
-    /// - returns: `String` - The "stringified" identity.
+    /// - Parameter ident: The identity to convert into a string.
+    /// - Returns: The "stringified" identity.
     func identityToString(_ ident: Identity) -> String
 
     /// Create a new object adapter. The endpoints for the object adapter are taken from the property
@@ -79,9 +73,8 @@ public protocol Communicator: AnyObject, Sendable {
     /// by the adapter. Attempts to create a named object adapter for which no configuration can be found raise
     /// InitializationException.
     ///
-    /// - parameter name: `String` The object adapter name.
-    ///
-    /// - returns: `ObjectAdapter` - The new object adapter.
+    /// - Parameter name: The object adapter name.
+    /// - Returns: The new object adapter.
     func createObjectAdapter(_ name: String) throws -> ObjectAdapter
 
     /// Create a new object adapter with endpoints. This operation sets the property
@@ -89,56 +82,54 @@ public protocol Communicator: AnyObject, Sendable {
     /// convenience function. Calling this operation with an empty name will result in a UUID being generated for the
     /// name.
     ///
-    /// - parameter name: `String` The object adapter name.
-    ///
-    /// - parameter endpoints: `String` The endpoints for the object adapter.
-    ///
-    /// - returns: `ObjectAdapter` - The new object adapter.
+    /// - Parameters:
+    ///   - name: The object adapter name.
+    ///   - endpoints: The endpoints for the object adapter.
+    /// - Returns: The new object adapter.
     func createObjectAdapterWithEndpoints(name: String, endpoints: String) throws
         -> ObjectAdapter
 
     /// Create a new object adapter with a router. This operation creates a routed object adapter.
     /// Calling this operation with an empty name will result in a UUID being generated for the name.
     ///
-    /// - parameter name: `String` The object adapter name.
-    ///
-    /// - parameter rtr: `RouterPrx` The router.
-    ///
-    /// - returns: `ObjectAdapter` - The new object adapter.
+    /// - Parameters:
+    ///   - name: The object adapter name.
+    ///   - rtr: The router.
+    /// - Returns: The new object adapter.
     func createObjectAdapterWithRouter(name: String, rtr: RouterPrx) throws -> ObjectAdapter
 
     /// Gets the object adapter that is associated by default with new outgoing connections created by this
     /// communicator. This function returns nil unless you set a non-nil default object adapter using
     /// setDefaultObjectAdapter.
     ///
-    /// - returns: The object adapter associated by default with new outgoing connections.
+    /// - Returns: The object adapter associated by default with new outgoing connections.
     func getDefaultObjectAdapter() -> ObjectAdapter?
 
     /// Sets the object adapter that will be associated with new outgoing connections created by this communicator. This
     /// function has no effect on existing outgoing connections, or on incoming connections.
     ///
-    /// - parameter adapter: The object adapter to associate with new outgoing connections.<
+    /// - Parameter adapter: The object adapter to associate with new outgoing connections.
     func setDefaultObjectAdapter(_ adapter: ObjectAdapter?)
 
     /// Get the implicit context associated with this communicator.
     ///
-    /// - returns: `ImplicitContext` - The implicit context associated with this communicator; returns null when the
-    ///                                 property Ice.ImplicitContext is not set or is set to None.
+    /// - Returns: The implicit context associated with this communicator; returns null when the
+    ///            property Ice.ImplicitContext is not set or is set to None.
     func getImplicitContext() -> ImplicitContext?
 
     /// Get the properties for this communicator.
     ///
-    /// - returns: `Properties` - This communicator's properties.
+    /// - Returns: This communicator's properties.
     func getProperties() -> Properties
 
     /// Get the logger for this communicator.
     ///
-    /// - returns: `Logger` - This communicator's logger.
+    /// - Returns: This communicator's logger.
     func getLogger() -> Logger
 
     /// Get the default router for this communicator.
     ///
-    /// - returns: `RouterPrx?` - The default router for this communicator.
+    /// - Returns: The default router for this communicator.
     func getDefaultRouter() -> RouterPrx?
 
     /// Set a default router for this communicator. All newly created proxies will use this default router. To disable
@@ -146,12 +137,12 @@ public protocol Communicator: AnyObject, Sendable {
     /// You can also set a router for an individual proxy by calling the operation ice_router on the
     /// proxy.
     ///
-    /// - parameter rtr: `RouterPrx?` The default router to use for this communicator.
+    /// - Parameter rtr: The default router to use for this communicator.
     func setDefaultRouter(_ rtr: RouterPrx?)
 
     /// Get the default locator for this communicator.
     ///
-    /// - returns: `LocatorPrx?` - The default locator for this communicator.
+    /// - Returns: The default locator for this communicator.
     func getDefaultLocator() -> LocatorPrx?
 
     /// Set a default Ice locator for this communicator. All newly created proxy and object adapters will use this
@@ -160,15 +151,15 @@ public protocol Communicator: AnyObject, Sendable {
     /// You can also set a locator for an individual proxy by calling the operation ice_locator on the
     /// proxy, or for an object adapter by calling ObjectAdapter.setLocator on the object adapter.
     ///
-    /// - parameter loc: `LocatorPrx?` The default locator to use for this communicator.
+    /// - Parameter loc: The default locator to use for this communicator.
     func setDefaultLocator(_ loc: LocatorPrx?)
 
     /// Flush any pending batch requests for this communicator. This means all batch requests invoked on fixed proxies
     /// for all connections associated with the communicator. Any errors that occur while flushing a connection are
     /// ignored.
     ///
-    /// - parameter compress: `CompressBatch` Specifies whether or not the queued batch requests should be compressed before
-    /// being sent over the wire.
+    /// - Parameter compress: Specifies whether or not the queued batch requests should be compressed before
+    ///                       being sent over the wire.
     func flushBatchRequests(_ compress: CompressBatch) async throws
 
     /// Add the Admin object with all its facets to the provided object adapter. If Ice.Admin.ServerId is
@@ -176,12 +167,10 @@ public protocol Communicator: AnyObject, Sendable {
     /// the Locator's LocatorRegistry. createAdmin must only be called once; subsequent calls raise
     /// InitializationException.
     ///
-    /// - parameter adminAdapter: `ObjectAdapter?` The object adapter used to host the Admin object; if null and
-    /// Ice.Admin.Endpoints is set, create, activate and use the Ice.Admin object adapter.
-    ///
-    /// - parameter adminId: `Identity` The identity of the Admin object.
-    ///
-    /// - returns: `ObjectPrx` - A proxy to the main ("") facet of the Admin object. Never returns a null proxy.
+    /// - Parameter adminAdapter: The object adapter used to host the Admin object; if null and
+    ///                          Ice.Admin.Endpoints is set, create, activate and use the Ice.Admin object adapter.
+    /// - Parameter adminId: The identity of the Admin object.
+    /// - Returns: A proxy to the main ("") facet of the Admin object. Never returns a null proxy.
     func createAdmin(adminAdapter: ObjectAdapter?, adminId: Identity) throws -> ObjectPrx
 
     /// Get a proxy to the main facet of the Admin object. getAdmin also creates the Admin object and creates and
@@ -190,38 +179,36 @@ public protocol Communicator: AnyObject, Sendable {
     /// Ice.Admin.InstanceName is not set. If Ice.Admin.DelayCreation is 0 or not set, getAdmin is called
     /// by the communicator initialization, after initialization of all plugins.
     ///
-    /// - returns: `ObjectPrx?` - A proxy to the main ("") facet of the Admin object, or a null proxy if no Admin
-    /// object is configured.
+    /// - Returns: A proxy to the main ("") facet of the Admin object, or a null proxy if no Admin
+    ///            object is configured.
     func getAdmin() throws -> ObjectPrx?
 
     /// Add a new facet to the Admin object. Adding a servant with a facet that is already registered throws
     /// AlreadyRegisteredException.
     ///
-    /// - parameter servant: `Dispatcher` The servant that implements the new Admin facet.
-    ///
-    /// - parameter facet: `String` The name of the new Admin facet.
+    /// - Parameters:
+    ///   - servant: The servant that implements the new Admin facet.
+    ///   - facet: The name of the new Admin facet.
     func addAdminFacet(servant: Dispatcher, facet: String) throws
 
     /// Remove the following facet to the Admin object. Removing a facet that was not previously registered throws
     /// NotRegisteredException.
     ///
-    /// - parameter facet: `String` The name of the Admin facet.
-    ///
-    /// - returns: `Dispatcher` - The servant associated with this Admin facet.
+    /// - Parameter facet: The name of the Admin facet.
+    /// - Returns: The servant associated with this Admin facet.
     @discardableResult
     func removeAdminFacet(_ facet: String) throws -> Dispatcher
 
     /// Returns a facet of the Admin object.
     ///
-    /// - parameter facet: `String` The name of the Admin facet.
-    ///
-    /// - returns: `Dispatcher?` - The servant associated with this Admin facet, or null if no facet is registered with the
-    /// given name.
+    /// - Parameter facet: The name of the Admin facet.
+    /// - Returns: The servant associated with this Admin facet, or null if no facet is registered with the
+    ///            given name.
     func findAdminFacet(_ facet: String) -> Dispatcher?
 
     /// Returns a map of all facets of the Admin object.
     ///
-    /// - returns: `FacetMap` - A collection containing all the facet names and servants of the Admin object.
+    /// - Returns: A collection containing all the facet names and servants of the Admin object.
     func findAllAdminFacets() -> FacetMap
 
     /// Makes a new proxy. This is an internal operation used by the generated code.

--- a/swift/src/Ice/CommunicatorI.swift
+++ b/swift/src/Ice/CommunicatorI.swift
@@ -290,7 +290,7 @@ extension Communicator {
     /// during initialization, the communicator invokes destroy on the plug-ins that have
     /// already been initialized.
     ///
-    /// - throws: `InitializationException` Raised if the plug-ins have already been
+    /// - Throws: Raised if the plug-ins have already been
     ///           initialized.
     public func initializePlugins() throws {
         try autoreleasepool {

--- a/swift/src/Ice/Connection.swift
+++ b/swift/src/Ice/Connection.swift
@@ -19,7 +19,7 @@ public enum CompressBatch: UInt8 {
 extension InputStream {
     /// Read an enumerated value.
     ///
-    /// - returns: `CompressBatch` - The enumerated value.
+    /// - Returns: The enumerated value.
     public func read() throws -> CompressBatch {
         let rawValue: UInt8 = try read(enumMaxValue: 2)
         guard let val = CompressBatch(rawValue: rawValue) else {
@@ -30,9 +30,8 @@ extension InputStream {
 
     /// Read an optional enumerated value from the stream.
     ///
-    /// - parameter tag: `Int32` - The numeric tag associated with the value.
-    ///
-    /// - returns: `CompressBatch` - The enumerated value.
+    /// - Parameter tag: The numeric tag associated with the value.
+    /// - Returns: The enumerated value.
     public func read(tag: Int32) throws -> CompressBatch? {
         guard try readOptional(tag: tag, expectedFormat: .Size) else {
             return nil
@@ -45,16 +44,15 @@ extension InputStream {
 extension OutputStream {
     /// Writes an enumerated value to the stream.
     ///
-    /// - parameter v: `CompressBatch` - The enumerator to write.
+    /// - Parameter v: The enumerator to write.
     public func write(_ v: CompressBatch) {
         write(enum: v.rawValue, maxValue: 2)
     }
 
     /// Writes an optional enumerated value to the stream.
-    ///
-    /// - parameter tag: `Int32` - The numeric tag associated with the value.
-    ///
-    /// - parameter value: `CompressBatch` - The enumerator to write.
+    /// - Parameters:
+    ///   - tag: The numeric tag associated with the value.
+    ///   - value: The enumerator to write.
     public func write(tag: Int32, value: CompressBatch?) {
         guard let v = value else {
             return
@@ -71,7 +69,7 @@ public typealias HeaderDict = [String: String]
 /// This method is called by the connection when the connection is closed. If the callback needs more information
 /// about the closure, it can call Connection.throwException.
 ///
-/// - parameter _: `Connection?` The connection that was closed.
+/// - Parameter _: The connection that was closed.
 public typealias CloseCallback = (Connection?) -> Void
 
 /// The user-level interface to a connection.
@@ -89,9 +87,8 @@ public protocol Connection: AnyObject, CustomStringConvertible, Sendable {
     /// client if the server cannot directly establish a connection to the client, for example because of firewalls. In
     /// this case, the server would create a proxy using an already established connection from the client.
     ///
-    /// - parameter id: `Identity` The identity for which a proxy is to be created.
-    ///
-    /// - returns: `ObjectPrx` - A proxy that matches the given identity and uses this connection.
+    /// - Parameter id: The identity for which a proxy is to be created.
+    /// - Returns: A proxy that matches the given identity and uses this connection.
     func createProxy(_ id: Identity) throws -> ObjectPrx
 
     /// Associates an object adapter with this connection. When a connection receives a request, it dispatches this
@@ -100,23 +97,23 @@ public protocol Connection: AnyObject, CustomStringConvertible, Sendable {
     /// The default object adapter of an incoming connection is the object adapter that created this connection;
     /// the default object adapter of an outgoing connection is the communicator's default object adapter.
     ///
-    /// - parameter adapter: `ObjectAdapter?` The object adapter to associate with the connection.
+    /// - Parameter adapter: The object adapter to associate with the connection.
     func setAdapter(_ adapter: ObjectAdapter?) throws
 
     /// Gets the object adapter associated with this connection.
     ///
-    /// - returns: `ObjectAdapter?` - The object adapter associated with this connection.
+    /// - Returns: The object adapter associated with this connection.
     func getAdapter() -> ObjectAdapter?
 
     /// Get the endpoint from which the connection was created.
     ///
-    /// - returns: `Endpoint` - The endpoint from which the connection was created.
+    /// - Returns: The endpoint from which the connection was created.
     func getEndpoint() -> Endpoint
 
     /// Flush any pending batch requests for this connection. This means all batch requests invoked on fixed proxies
     /// associated with the connection.
     ///
-    /// - parameter compress: `CompressBatch` Specifies whether or not the queued batch requests should be compressed
+    /// - Parameter compress: Specifies whether or not the queued batch requests should be compressed
     /// before being sent over the wire.
     func flushBatchRequests(_ compress: CompressBatch) async throws
 
@@ -124,7 +121,7 @@ public protocol Connection: AnyObject, CustomStringConvertible, Sendable {
     /// is called from the Ice thread pool associated with the connection. If the callback needs more information about
     /// the closure, it can call Connection.throwException.
     ///
-    /// - parameter callback: `CloseCallback?` The close callback object.
+    /// - Parameter callback: The close callback object.
     func setCloseCallback(_ callback: CloseCallback?) throws
 
     /// Disable the inactivity check on this connection.
@@ -132,24 +129,24 @@ public protocol Connection: AnyObject, CustomStringConvertible, Sendable {
 
     /// Return the connection type. This corresponds to the endpoint type, i.e., "tcp", "udp", etc.
     ///
-    /// - returns: `String` - The type of the connection.
+    /// - Returns: The type of the connection.
     func type() -> String
 
     /// Return a description of the connection as human readable text, suitable for logging or error messages.
     ///
-    /// - returns: `String` - The description of the connection as human readable text.
+    /// - Returns: The description of the connection as human readable text.
     func toString() -> String
 
     /// Returns the connection information.
     ///
-    /// - returns: `ConnectionInfo` - The connection information.
+    /// - Returns: The connection information.
     func getInfo() throws -> ConnectionInfo
 
     /// Set the connection buffer receive/send size.
     ///
-    /// - parameter rcvSize: `Int32` The connection receive buffer size.
-    ///
-    /// - parameter sndSize: `Int32` The connection send buffer size.
+    /// - Parameters:
+    ///   - rcvSize: The connection receive buffer size.
+    ///   - sndSize: The connection send buffer size.
     func setBufferSize(rcvSize: Int32, sndSize: Int32) throws
 
     /// Throw an exception indicating the reason for connection closure. For example,

--- a/swift/src/Ice/CtrlCHandler.swift
+++ b/swift/src/Ice/CtrlCHandler.swift
@@ -13,7 +13,7 @@ public struct CtrlCHandler {
 
     /// Sets the signal callback. If there was a previous callback, it is replaced.
     /// - Parameter callback: The callback to call when a signal is caught; its parameter is the signal number.
-    /// When nil, the signal is ignored.
+    ///   When nil, the signal is ignored.
     public func setCallback(_ callback: ((Int32) -> Void)?) {
         self.handle.setCallback(callback)
     }

--- a/swift/src/Ice/Endpoint.swift
+++ b/swift/src/Ice/Endpoint.swift
@@ -6,12 +6,12 @@ import Foundation
 public protocol Endpoint: AnyObject, CustomStringConvertible {
     /// Return a string representation of the endpoint.
     ///
-    /// - returns: `String` - The string representation of the endpoint.
+    /// - Returns: The string representation of the endpoint.
     func toString() -> String
 
     /// Returns the endpoint information.
     ///
-    /// - returns: `EndpointInfo?` - The endpoint information class.
+    /// - Returns: The endpoint information class.
     func getInfo() -> EndpointInfo?
 }
 
@@ -27,21 +27,21 @@ open class EndpointInfo {
 
     /// Returns the type of the endpoint.
     ///
-    /// - returns: `Int16` - The endpoint type.
+    /// - Returns: The endpoint type.
     public func type() -> Int16 {
         underlying?.type() ?? -1
     }
 
     /// Returns true if this endpoint is a datagram endpoint.
     ///
-    /// - returns: `Bool` - True for a datagram endpoint.
+    /// - Returns: True for a datagram endpoint.
     public func datagram() -> Bool {
         underlying?.datagram() ?? false
     }
 
     /// Returns true if this endpoint is a secure endpoint.
     ///
-    /// - returns: `Bool` - True for a secure endpoint.
+    /// - Returns: True for a secure endpoint.
     public func secure() -> Bool {
         underlying?.secure() ?? false
     }

--- a/swift/src/Ice/EndpointSelectionType.swift
+++ b/swift/src/Ice/EndpointSelectionType.swift
@@ -17,7 +17,7 @@ public enum EndpointSelectionType: UInt8 {
 extension InputStream {
     /// Read an enumerated value.
     ///
-    /// - returns: `EndpointSelectionType` - The enumarated value.
+    /// - Returns: The enumarated value.
     public func read() throws -> EndpointSelectionType {
         let rawValue: UInt8 = try read(enumMaxValue: 1)
         guard let val = EndpointSelectionType(rawValue: rawValue) else {
@@ -28,9 +28,8 @@ extension InputStream {
 
     /// Read an optional enumerated value from the stream.
     ///
-    /// - parameter tag: `Int32` - The numeric tag associated with the value.
-    ///
-    /// - returns: `EndpointSelectionType` - The enumerated value.
+    /// - Parameter tag: The numeric tag associated with the value.
+    /// - Returns: The enumerated value.
     public func read(tag: Int32) throws -> EndpointSelectionType? {
         guard try readOptional(tag: tag, expectedFormat: .Size) else {
             return nil
@@ -43,16 +42,15 @@ extension InputStream {
 extension OutputStream {
     /// Writes an enumerated value to the stream.
     ///
-    /// - parameter value: `EndpointSelectionType` - The enumerator to write.
+    /// - Parameter value: The enumerator to write.
     public func write(_ value: EndpointSelectionType) {
         write(enum: value.rawValue, maxValue: 1)
     }
 
     /// Writes an optional enumerated value to the stream.
     ///
-    /// - parameter tag: `Int32` - The numeric tag associated with the value.
-    ///
-    /// - parameter value: `EndpointSelectionType` - The enumerator to write.
+    /// - Parameter tag: The numeric tag associated with the value.
+    /// - Parameter value: The enumerator to write.
     public func write(tag: Int32, value: EndpointSelectionType?) {
         guard let v = value else {
             return

--- a/swift/src/Ice/ImplicitContext.swift
+++ b/swift/src/Ice/ImplicitContext.swift
@@ -20,44 +20,40 @@ import Foundation
 public protocol ImplicitContext: AnyObject {
     /// Get a copy of the underlying context.
     ///
-    /// - returns: `Context` - A copy of the underlying context.
+    /// - Returns: A copy of the underlying context.
     func getContext() -> Context
 
     /// Set the underlying context.
     ///
-    /// - parameter newContext: `Context` The new context.
+    /// - Parameter newContext: The new context.
     func setContext(_ newContext: Context)
 
     /// Check if this key has an associated value in the underlying context.
     ///
-    /// - parameter key: `String` The key.
-    ///
-    /// - returns: `Bool` - True if the key has an associated value, False otherwise.
+    /// - Parameter key: The key.
+    /// - Returns: True if the key has an associated value, False otherwise.
     func containsKey(_ key: String) -> Bool
 
     /// Get the value associated with the given key in the underlying context. Returns an empty string if no value is
     /// associated with the key. containsKey allows you to distinguish between an empty-string value and no
     /// value at all.
     ///
-    /// - parameter key: `String` The key.
-    ///
-    /// - returns: `String` - The value associated with the key.
+    /// - Parameter key: The key.
+    /// - Returns: The value associated with the key.
     func get(_ key: String) -> String
 
     /// Create or update a key/value entry in the underlying context.
     ///
-    /// - parameter key: `String` The key.
+    /// - Parameter key: The key.
     ///
-    /// - parameter value: `String` The value.
-    ///
-    /// - returns: `String` - The previous value associated with the key, if any.
+    /// - Parameter value: The value.
+    /// - Returns: The previous value associated with the key, if any.
     @discardableResult
     func put(key: String, value: String) -> String
 
     /// Remove the entry for the given key in the underlying context.
     ///
-    /// - parameter key: `String` The key.
-    ///
-    /// - returns: `String` - The value associated with the key, if any.
+    /// - Parameter key: The key.
+    /// - Returns: The value associated with the key, if any.
     func remove(_ key: String) -> String
 }

--- a/swift/src/Ice/IncomingRequest.swift
+++ b/swift/src/Ice/IncomingRequest.swift
@@ -8,9 +8,10 @@ public struct IncomingRequest {
     public let inputStream: InputStream
 
     /// Constructs an incoming request.
-    /// - parameter current: The current object for the request.
-    /// - parameter inputStream: The input stream buffer over the incoming Ice protocol request message. The stream is
-    /// positioned at the beginning of the encapsulation in the request.
+    /// - Parameters:
+    ///   - current: The current object for the request.
+    ///   - inputStream: The input stream buffer over the incoming Ice protocol request message. The stream is
+    ///     positioned at the beginning of the encapsulation in the request.
     public init(current: Current, inputStream: InputStream) {
         self.current = current
         self.inputStream = inputStream

--- a/swift/src/Ice/Initialize.swift
+++ b/swift/src/Ice/Initialize.swift
@@ -24,7 +24,6 @@ let factoriesRegistered: Bool = {
 ///   reserved prefixes (Ice, IceSSL, etc.) as properties for the new communicator. If there is an argument starting
 ///   with `--Ice.Config`, this function loads the specified configuration file. When the same property is set in a
 ///   configuration file and through a command-line argument, the command-line setting takes precedence.
-///
 /// - Returns: The new communicator.
 public func initialize(_ args: [String]) throws -> Communicator {
     try initialize(InitializationData(properties: createProperties(args)))
@@ -36,7 +35,6 @@ public func initialize(_ args: [String]) throws -> Communicator {
 ///   with `--Ice.Config`, this function loads the specified configuration file. When the same property is set in a
 ///   configuration file and through a command-line argument, the command-line setting takes precedence. This function
 ///   modifies args by removing any Ice-related options.
-///
 /// - Returns: The new communicator.
 public func initialize(_ args: inout [String]) throws -> Communicator {
     try initialize(InitializationData(properties: createProperties(&args)))
@@ -98,7 +96,7 @@ public func initialize(_ initData: InitializationData = InitializationData()) th
 
 /// Creates a new empty property set.
 ///
-/// - returns: `Properties` - A new empty property set.
+/// - Returns: A new empty property set.
 public func createProperties() -> Properties {
     guard factoriesRegistered else {
         fatalError("Unable to initialize Ice")
@@ -108,16 +106,13 @@ public func createProperties() -> Properties {
 
 /// Creates a property set initialized from an argument array.
 ///
-/// - parameter args: `[String]` - A command-line argument array, possibly containing options to
-///   set properties. If the command-line options include a `--Ice.Config` option, the
-///   corresponding configuration files are parsed. If the same property is set in a configuration
-///   file and in the argument array, the argument array takes precedence.
-///
-/// - parameter defaults: `Ice.Properties` - Optional default values for the property set. Settings in
-///   configuration files and argument array override these defaults.
-///
-/// - returns: `Ice.Properties` - A new property set initialized with the property settings from the arguments
-///   array and defaults.
+/// - Parameters:
+///   - args: A command-line argument array, possibly containing options to set properties. If the
+///     command-line options include `--Ice.Config`, the corresponding configuration files are parsed. If the same
+///     property is set in a configuration file and in the argument array, the argument array takes precedence.
+///   - defaults: Optional default values for the property set. Settings in configuration files and the
+///     argument array override these defaults.
+/// - Returns: A new property set initialized with the property settings from the arguments array and defaults.
 public func createProperties(_ args: [String], defaults: Properties? = nil) throws -> Properties {
     guard factoriesRegistered else {
         fatalError("Unable to initialize Ice")
@@ -133,17 +128,14 @@ public func createProperties(_ args: [String], defaults: Properties? = nil) thro
 
 /// Creates a property set initialized from an argument array.
 ///
-/// - parameter args: `[String]` - A command-line argument array, possibly containing options to
-///   set properties. If the command-line options include a `--Ice.Config` option, the
-///   corresponding configuration files are parsed. If the same property is set in a configuration
-///   file and in the argument array, the argument array takes precedence. This method modifies the
-///   argument array by removing any Ice-related options.
-///
-/// - parameter defaults: `Ice.Properties` - Optional default values for the property set. Settings in
-///   configuration files and argument array override these defaults.
-///
-/// - returns: `Ice.Properties` - A new property set initialized with the property settings from args
-///   and defaults.
+/// - Parameters:
+///   - args: A command-line argument array, possibly containing options to set properties. If the
+///     command-line options include `--Ice.Config`, the corresponding configuration files are parsed. If the same
+///     property is set in a configuration file and in the argument array, the argument array takes precedence. This
+///     method modifies the argument array by removing any Ice-related options.
+///   - defaults: Optional default values for the property set. Settings in configuration files and the
+///     argument array override these defaults.
+/// - Returns: A new property set initialized with the property settings from the arguments and defaults.
 public func createProperties(_ args: inout [String], defaults: Properties? = nil) throws
     -> Properties
 {
@@ -181,9 +173,8 @@ public let currentEncoding = Encoding_1_1
 
 /// Converts a string to an object identity.
 ///
-/// - parameter string: `String` - The string to convert.
-///
-/// - returns: `Ice.Identity` - The converted object identity.
+/// - Parameter string: The string to convert.
+/// - Returns: The converted object identity.
 public func stringToIdentity(_ string: String) throws -> Identity {
     guard factoriesRegistered else {
         fatalError("Unable to initialize Ice")
@@ -198,12 +189,10 @@ public func stringToIdentity(_ string: String) throws -> Identity {
 
 /// Converts an object identity to a string.
 ///
-/// - parameter id: `Ice.Identity` - The object identity to convert.
-///
-/// - parameter mode: `ToStringMode` - Specifies if and how non-printable ASCII characters are escaped
-///   in the result.
-///
-/// - returns: `String` - The string representation of the object identity.
+/// - Parameters:
+///   - id: The object identity to convert.
+///   - mode: Specifies if and how non-printable ASCII characters are escaped in the result.
+/// - Returns: The string representation of the object identity.
 public func identityToString(id: Identity, mode: ToStringMode = .Unicode) -> String {
     precondition(!id.name.isEmpty, "Invalid identity with an empty name")
     return ICEUtil.identityToString(name: id.name, category: id.category, mode: mode.rawValue)
@@ -211,9 +200,8 @@ public func identityToString(id: Identity, mode: ToStringMode = .Unicode) -> Str
 
 /// Converts an encoding version to a string.
 ///
-/// - parameter encoding: `Ice.EncodingVersion` - The encoding version to convert.
-///
-/// - returns: `String` - The converted string.
+/// - Parameter encoding: The encoding version to convert.
+/// - Returns: The converted string.
 public func encodingVersionToString(_ encoding: EncodingVersion) -> String {
     return ICEUtil.encodingVersionToString(major: encoding.major, minor: encoding.minor)
 }

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -50,7 +50,7 @@ public final class InputStream {
 
     /// Reads an encapsulation from the stream.
     ///
-    /// - returns: `(bytes: Data, encoding: EncodingVersion)` The encapsulation.
+    /// - Returns: The encapsulation.
     public func readEncapsulation() throws -> (bytes: Data, encoding: EncodingVersion) {
         let sz: Int32 = try read()
         if sz < 6 {
@@ -70,7 +70,7 @@ public final class InputStream {
 
     /// Reads the start of an encapsulation.
     ///
-    /// - returns: `Ice.EncodingVersion` - The encapsulation encoding version.
+    /// - Returns: The encapsulation encoding version.
     @discardableResult
     public func startEncapsulation() throws -> EncodingVersion {
         precondition(encaps == nil, "Nested or sequential encapsulations are not supported")
@@ -125,7 +125,7 @@ public final class InputStream {
 
     /// Skips an empty encapsulation.
     ///
-    /// - returns: `Ice.EncodingVersion` - The encapsulation's encoding version.
+    /// - Returns: The encapsulation's encoding version.
     @discardableResult
     public func skipEmptyEncapsulation() throws -> EncodingVersion {
         let sz: Int32 = try read()
@@ -158,7 +158,7 @@ public final class InputStream {
 
     /// Skips over an encapsulation.
     ///
-    /// - returns: `Ice.EncodingVersion` - The encoding version of the skipped encapsulation.
+    /// - Returns: The encoding version of the skipped encapsulation.
     func skipEncapsulation() throws -> EncodingVersion {
         let sz: Int32 = try read()
 
@@ -281,7 +281,7 @@ public final class InputStream {
 
     /// Skips the given number of bytes.
     ///
-    /// - parameter count: `Int` - The number of bytes to skip.
+    /// - Parameter count: The number of bytes to skip.
     public func skip(_ count: Int) throws {
         precondition(count >= 0, "skip count is negative")
         try changePos(offset: count)
@@ -289,7 +289,7 @@ public final class InputStream {
 
     /// Skips the given number of bytes.
     ///
-    /// - parameter count: `Int32` - The number of bytes to skip.
+    /// - Parameter count: The number of bytes to skip.
     public func skip(_ count: Int32) throws {
         try changePos(offset: Int(count))
     }
@@ -310,7 +310,7 @@ public final class InputStream {
 
     /// Marks the end of a class instance.
     ///
-    /// - returns: `Ice.SlicedData` - A SlicedData object containing the preserved slices for unknown types.
+    /// - Returns: A SlicedData object containing the preserved slices for unknown types.
     @discardableResult
     public func endValue() throws -> SlicedData? {
         precondition(encaps.decoder != nil)
@@ -373,7 +373,7 @@ public final class InputStream {
 extension InputStream {
     /// Reads a numeric value from the stream.
     ///
-    /// - returns: `Element` - The numeric value read from the stream.
+    /// - Returns: The numeric value read from the stream.
     public func read<Element>() throws -> Element where Element: StreamableNumeric {
         let size = MemoryLayout<Element>.size
         guard size <= remaining else {
@@ -392,9 +392,8 @@ extension InputStream {
 
     /// Reads an optional numeric value from the stream.
     ///
-    /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
-    ///
-    /// - returns: `Element?` - The optional numeric value read from the stream.
+    /// - Parameter tag: The tag of the optional data member or parameter.
+    /// - Returns: The optional numeric value read from the stream.
     public func read<Element>(tag: Int32) throws -> Element? where Element: StreamableNumeric {
         let expectedFormat = OptionalFormat(fixedSize: MemoryLayout<Element>.size)
         guard try readOptional(tag: tag, expectedFormat: expectedFormat!) else {
@@ -405,7 +404,7 @@ extension InputStream {
 
     /// Reads a sequence of numeric values from the stream.
     ///
-    /// - returns: `[Element]` - The sequence of numeric values read from the stream.
+    /// - Returns: The sequence of numeric values read from the stream.
     public func read<Element>() throws -> [Element] where Element: StreamableNumeric {
         let sz = try readAndCheckSeqSize(minSize: MemoryLayout<Element>.size)
 
@@ -433,9 +432,8 @@ extension InputStream {
 
     /// Reads an optional sequence of numeric values from the stream.
     ///
-    /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
-    ///
-    /// - returns: `[Element]?` - The optional sequence read from the stream.
+    /// - Parameter tag: The tag of the optional data member or parameter.
+    /// - Returns: The optional sequence read from the stream.
     public func read<Element>(tag: Int32) throws -> [Element]? where Element: StreamableNumeric {
         guard try readOptional(tag: tag, expectedFormat: .VSize) else {
             return nil
@@ -448,7 +446,7 @@ extension InputStream {
 
     /// Reads a byte from the stream.
     ///
-    /// - returns: `UInt8` - The byte read from the stream.
+    /// - Returns: The byte read from the stream.
     public func read() throws -> UInt8 {
         guard remaining > 0 else {
             throw MarshalException(endOfBufferMessage)
@@ -460,7 +458,7 @@ extension InputStream {
 
     /// Reads a sequence of bytes from the stream.
     ///
-    /// - returns: `[UInt8]` - The sequence of bytes read from the stream.
+    /// - Returns: The sequence of bytes read from the stream.
     public func read() throws -> [UInt8] {
         let sz = try readAndCheckSeqSize(minSize: 1)
         let start = pos
@@ -470,7 +468,7 @@ extension InputStream {
 
     /// Reads a sequence of bytes from the stream.
     ///
-    /// - returns: `Data` - The sequence of bytes read from the stream.
+    /// - Returns: The sequence of bytes read from the stream.
     public func read() throws -> Data {
         let sz = try readAndCheckSeqSize(minSize: 1)
         let start = pos
@@ -480,9 +478,8 @@ extension InputStream {
 
     /// Reads an optional sequence of bytes from the stream.
     ///
-    /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
-    ///
-    /// - returns: `Data?` - The optional sequence of bytes read from the stream.
+    /// - Parameter tag: The tag of the optional data member or parameter.
+    /// - Returns: The optional sequence of bytes read from the stream.
     public func read(tag: Int32) throws -> Data? {
         guard try readOptional(tag: tag, expectedFormat: .VSize) else {
             return nil
@@ -493,7 +490,7 @@ extension InputStream {
 
     /// Reads a boolean value from the stream.
     ///
-    /// - returns: `Bool` - The boolean value read from the stream.
+    /// - Returns: The boolean value read from the stream.
     public func read() throws -> Bool {
         let value: UInt8 = try read()
         return value == 1
@@ -501,9 +498,8 @@ extension InputStream {
 
     /// Reads an optional boolean value from the stream.
     ///
-    /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
-    ///
-    /// - returns: `Bool?` - The optional boolean value read from the stream.
+    /// - Parameter tag: The tag of the optional data member or parameter.
+    /// - Returns: The optional boolean value read from the stream.
     public func read(tag: Int32) throws -> Bool? {
         guard try readOptional(tag: tag, expectedFormat: .F1) else {
             return nil
@@ -513,7 +509,7 @@ extension InputStream {
 
     /// Reads a sequence of boolean value from the stream.
     ///
-    /// - returns: `[Bool]` - The sequence of boolean values read from the stream.
+    /// - Returns: The sequence of boolean values read from the stream.
     public func read() throws -> [Bool] {
         let sz = try readAndCheckSeqSize(minSize: 1)
 
@@ -533,9 +529,8 @@ extension InputStream {
 
     /// Reads an optional sequence of boolean value from the stream.
     ///
-    /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
-    ///
-    /// - returns: `[Bool]?` - The optional sequence of boolean values read from the stream.
+    /// - Parameter tag: The tag of the optional data member or parameter.
+    /// - Returns: The optional sequence of boolean values read from the stream.
     public func read(tag: Int32) throws -> [Bool]? {
         guard try readOptional(tag: tag, expectedFormat: .VSize) else {
             return nil
@@ -545,7 +540,7 @@ extension InputStream {
 
     /// Reads a size from the stream.
     ///
-    /// - returns: `Int32` - The size read from the stream.
+    /// - Returns: The size read from the stream.
     public func readSize() throws -> Int32 {
         let byteVal: UInt8 = try read()
         if byteVal == 255 {
@@ -558,9 +553,8 @@ extension InputStream {
     /// Reads a sequence size from the stream and ensures the stream has enough
     /// bytes for `size` elements, where each element's size is at least minSize.
     ///
-    /// - parameter minSize: `Int` - The mininum element size to use for the check.
-    ///
-    /// - returns: `Int` - The size read from the stream.
+    /// - Parameter minSize: The mininum element size to use for the check.
+    /// - Returns: The size read from the stream.
     public func readAndCheckSeqSize(minSize: Int) throws -> Int {
         let sz = try Int(readSize())
 
@@ -658,9 +652,8 @@ extension InputStream {
 
     /// Reads an enumerator from the stream, as a byte.
     ///
-    /// - parameter enumMaxValue: `Int32` - The maximum value for the enumerators (used only for the 1.0 encoding).
-    ///
-    /// - returns: `UInt8` - The enumerator's byte value.
+    /// - Parameter enumMaxValue: The maximum value for the enumerators (used only for the 1.0 encoding).
+    /// - Returns: The enumerator's byte value.
     public func read(enumMaxValue: Int32) throws -> UInt8 {
         if currentEncoding == Encoding_1_0 {
             if enumMaxValue < 127 {
@@ -689,9 +682,8 @@ extension InputStream {
 
     /// Reads an enumerator from the stream, as a Int32.
     ///
-    /// - parameter enumMaxValue: `Int32` - The maximum value for the enumerators (used only for the 1.0 encoding).
-    ///
-    /// - returns: `Int32` - The enumerator's Int32 value.
+    /// - Parameter enumMaxValue: The maximum value for the enumerators (used only for the 1.0 encoding).
+    /// - Returns: The enumerator's Int32 value.
     public func read(enumMaxValue: Int32) throws -> Int32 {
         if currentEncoding == Encoding_1_0 {
             if enumMaxValue < 127 {
@@ -708,7 +700,7 @@ extension InputStream {
 
     /// Reads a string from the stream.
     ///
-    /// - returns: `String` - The string read from the stream.
+    /// - Returns: The string read from the stream.
     public func read() throws -> String {
         let size = try readSize()
         if size == 0 {
@@ -726,9 +718,8 @@ extension InputStream {
 
     /// Reads an optional string from the stream.
     ///
-    /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
-    ///
-    /// - returns: `String?` - The optional string read from the stream.
+    /// - Parameter tag: The tag of the optional data member or parameter.
+    /// - Returns: The optional string read from the stream.
     public func read(tag: Int32) throws -> String? {
         guard try readOptional(tag: tag, expectedFormat: .VSize) else {
             return nil
@@ -738,7 +729,7 @@ extension InputStream {
 
     /// Reads a sequence of strings from the stream.
     ///
-    /// - returns: `[String]` - The sequence of strings read from the stream.
+    /// - Returns: The sequence of strings read from the stream.
     public func read() throws -> [String] {
         let sz = try readAndCheckSeqSize(minSize: 1)
         var r = [String]()
@@ -751,9 +742,8 @@ extension InputStream {
 
     /// Reads an optional sequence of strings from the stream.
     ///
-    /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
-    ///
-    /// - returns: `[String]?` - The optional sequence of strings read from the stream.
+    /// - Parameter tag: The tag of the optional data member or parameter.
+    /// - Returns: The optional sequence of strings read from the stream.
     public func read(tag: Int32) throws -> [String]? {
         guard try readOptional(tag: tag, expectedFormat: .FSize) else {
             return nil
@@ -764,16 +754,15 @@ extension InputStream {
 
     /// Reads a proxy from the stream (internal helper).
     ///
-    /// - returns: `ProxyImpl?` - The proxy read from the stream.
+    /// - Returns: The proxy read from the stream.
     public func read<ProxyImpl>() throws -> ProxyImpl? where ProxyImpl: ObjectPrxI {
         return try ProxyImpl.ice_read(from: self)
     }
 
     /// Reads an optional proxy from the stream (internal helper).
     ///
-    /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
-    ///
-    /// - returns: `ProxyImpl?` - The proxy read from the stream.
+    /// - Parameter tag: The tag of the optional data member or parameter.
+    /// - Returns: The proxy read from the stream.
     public func read<ProxyImpl>(tag: Int32) throws -> ProxyImpl?
     where ProxyImpl: ObjectPrxI {
         guard try readOptional(tag: tag, expectedFormat: .FSize) else {
@@ -785,18 +774,17 @@ extension InputStream {
 
     /// Reads a base proxy from the stream.
     ///
-    /// - returns: `ObjectPrx?` - The proxy read from the stream.
+    /// - Returns: The proxy read from the stream.
     public func read(_: ObjectPrx.Protocol) throws -> ObjectPrx? {
         return try read() as ObjectPrxI?
     }
 
     /// Reads an optional base proxy from the stream.
     ///
-    /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
-    ///
-    /// - parameter type: `ObjectPrx.Protocol` - The proxy type.
-    ///
-    /// - returns: `ObjectPrx?` - The proxy read from the stream.
+    /// - Parameters:
+    ///   - tag: The tag of the optional data member or parameter.
+    ///   - type: The proxy type.
+    /// - Returns: The proxy read from the stream.
     public func read(tag: Int32, type _: ObjectPrx.Protocol) throws -> ObjectPrx? {
         return try read(tag: tag) as ObjectPrxI?
     }

--- a/swift/src/Ice/Logger.swift
+++ b/swift/src/Ice/Logger.swift
@@ -8,35 +8,33 @@ public protocol Logger: AnyObject {
     /// Print a message. The message is printed literally, without any decorations such as executable name or time
     /// stamp.
     ///
-    /// - parameter message: `String` The message to log.
+    /// - Parameter message: The message to log.
     func print(_ message: String)
 
     /// Log a trace message.
-    ///
-    /// - parameter category: `String` The trace category.
-    ///
-    /// - parameter message: `String` The trace message to log.
+    /// - Parameters:
+    ///   - category: The trace category.
+    ///   - message: The trace message to log.
     func trace(category: String, message: String)
 
     /// Log a warning message.
     ///
-    /// - parameter message: `String` The warning message to log.
+    /// - Parameter message: The warning message to log.
     func warning(_ message: String)
 
     /// Log an error message.
     ///
-    /// - parameter message: `String` The error message to log.
+    /// - Parameter message: The error message to log.
     func error(_ message: String)
 
     /// Returns this logger's prefix.
     ///
-    /// - returns: `String` - The prefix.
+    /// - Returns: The prefix.
     func getPrefix() -> String
 
     /// Returns a clone of the logger with a new prefix.
     ///
-    /// - parameter prefix: `String` The new prefix for the logger.
-    ///
-    /// - returns: `Logger` - A logger instance.
+    /// - Parameter prefix: The new prefix for the logger.
+    /// - Returns: A logger instance.
     func cloneWithPrefix(_ prefix: String) -> Logger
 }

--- a/swift/src/Ice/NativePropertiesAdmin.swift
+++ b/swift/src/Ice/NativePropertiesAdmin.swift
@@ -4,7 +4,7 @@ import IceImpl
 
 /// Closure called when the communicator's properties have been updated.
 ///
-/// - parameter: `PropertyDict` A dictionary containing the properties that were added,
+/// - Parameter: `PropertyDict` A dictionary containing the properties that were added,
 ///   changed or removed, with a removed property denoted by an entry whose value is an
 ///   empty string.
 public typealias PropertiesAdminUpdateCallback = (PropertyDict) -> Void
@@ -40,9 +40,8 @@ public struct NativePropertiesAdmin: PropertiesAdmin {
 
     /// Registers an update callback that will be invoked when property updates occur.
     ///
-    /// - parameter cb: `PropertiesAdminUpdateCallback` - The callback.
-    ///
-    /// - returns: A closure that can be invoked to remove the callback.
+    /// - Parameter cb: The callback.
+    /// - Returns: A closure that can be invoked to remove the callback.
     public func addUpdateCallback(_ cb: @escaping PropertiesAdminUpdateCallback) -> PropertiesAdminRemoveCallback {
         return handle.addUpdateCallback { (props: PropertyDict) in
             cb(props)

--- a/swift/src/Ice/Object.swift
+++ b/swift/src/Ice/Object.swift
@@ -16,31 +16,27 @@ public protocol SliceTraits {
 public protocol Object {
     /// Returns the Slice type ID of the most-derived interface supported by this object.
     ///
-    /// - parameter current: `Ice.Current` - The Current object for the dispatch.
-    ///
-    /// - returns: `String` - The Slice type ID of the most-derived interface.
+    /// - Parameter current: The Current object for the dispatch.
+    /// - Returns: The Slice type ID of the most-derived interface.
     func ice_id(current: Current) async throws -> String
 
     /// Returns the Slice type IDs of the interfaces supported by this object.
     ///
-    /// - parameter current: `Ice.Current` - The Current object for the dispatch.
-    ///
-    /// - returns: `[String]` The Slice type IDs of the interfaces supported by this object, in alphabetical order.
+    /// - Parameter current: The Current object for the dispatch.
+    /// - Returns: `[String]` The Slice type IDs of the interfaces supported by this object, in alphabetical order.
     func ice_ids(current: Current) async throws -> [String]
 
     /// Tests whether this object supports a specific Slice interface.
-    ///
-    /// - parameter id: `String` - The type ID of the Slice interface to test against.
-    ///
-    /// - parameter current: `Ice.Current` - The Current object for the dispatch.
-    ///
-    /// - returns: `Bool` - True if this object has the interface specified by s or
+    /// - Parameters:
+    ///   - id: The type ID of the Slice interface to test against.
+    ///   - current: The Current object for the dispatch.
+    /// - Returns: True if this object has the interface specified by s or
     ///   derives from the interface specified by s.
     func ice_isA(id: String, current: Current) async throws -> Bool
 
     /// Tests whether this object can be reached.
     ///
-    /// - parameter current: The Current object for the dispatch.
+    /// - Parameter current: The Current object for the dispatch.
     func ice_ping(current: Current) async throws
 }
 

--- a/swift/src/Ice/ObjectAdapter.swift
+++ b/swift/src/Ice/ObjectAdapter.swift
@@ -12,12 +12,12 @@ public protocol ObjectAdapter: AnyObject, Sendable {
 
     /// Get the name of this object adapter.
     ///
-    /// - returns: `String` - This object adapter's name.
+    /// - Returns: This object adapter's name.
     func getName() -> String
 
     /// Get the communicator this object adapter belongs to.
     ///
-    /// - returns: `Communicator` - This object adapter's communicator.
+    /// - Returns: This object adapter's communicator.
     func getCommunicator() -> Communicator
 
     /// Activate all endpoints that belong to this object adapter. After activation, the object adapter can dispatch
@@ -48,7 +48,7 @@ public protocol ObjectAdapter: AnyObject, Sendable {
 
     /// Checks if this object adapter has been deactivated.
     ///
-    /// - returns: `Bool` - Whether adapter has been deactivated.
+    /// - Returns: Whether adapter has been deactivated.
     func isDeactivated() -> Bool
 
     /// Destroys this object adapter and cleans up all resources held by this object adapter.
@@ -71,24 +71,21 @@ public protocol ObjectAdapter: AnyObject, Sendable {
     /// objects by registering the servant with multiple identities. Adding a servant with an identity that is in the
     /// map already throws AlreadyRegisteredException.
     ///
-    /// - parameter servant: `Dispatcher` The servant to add.
-    ///
-    /// - parameter id: `Identity` The identity of the Ice object that is implemented by the servant.
-    ///
-    /// - returns: `ObjectPrx` - A proxy that matches the given identity and this object adapter.
+    /// - Parameters:
+    ///   - servant: The servant to add.
+    ///   - id: The identity of the Ice object that is implemented by the servant.
+    /// - Returns: A proxy that matches the given identity and this object adapter.
     @discardableResult
     func add(servant: Dispatcher, id: Identity) throws -> ObjectPrx
 
     /// Like add, but with a facet. Calling add(servant, id) is equivalent to calling
     /// addFacet with an empty facet.
     ///
-    /// - parameter servant: `Dispatcher` The servant to add.
-    ///
-    /// - parameter id: `Identity` The identity of the Ice object that is implemented by the servant.
-    ///
-    /// - parameter facet: `String` The facet. An empty facet means the default facet.
-    ///
-    /// - returns: `ObjectPrx` - A proxy that matches the given identity, facet, and this object adapter.
+    /// - Parameters:
+    ///   - servant: The servant to add.
+    ///   - id: The identity of the Ice object that is implemented by the servant.
+    ///   - facet: The facet. An empty facet means the default facet.
+    /// - Returns: A proxy that matches the given identity, facet, and this object adapter.
     @discardableResult
     func addFacet(servant: Dispatcher, id: Identity, facet: String) throws -> ObjectPrx
 
@@ -96,20 +93,18 @@ public protocol ObjectAdapter: AnyObject, Sendable {
     /// identity. Note that the generated UUID identity can be accessed using the proxy's ice_getIdentity
     /// operation.
     ///
-    /// - parameter servant: `Dispatcher` The servant to add.
-    ///
-    /// - returns: `ObjectPrx` - A proxy that matches the generated UUID identity and this object adapter.
+    /// - Parameter servant: The servant to add.
+    /// - Returns: A proxy that matches the generated UUID identity and this object adapter.
     @discardableResult
     func addWithUUID(_ servant: Dispatcher) throws -> ObjectPrx
 
     /// Like addWithUUID, but with a facet. Calling addWithUUID(servant) is equivalent to calling
     /// addFacetWithUUID with an empty facet.
     ///
-    /// - parameter servant: `Dispatcher` The servant to add.
-    ///
-    /// - parameter facet: `String` The facet. An empty facet means the default facet.
-    ///
-    /// - returns: `ObjectPrx` - A proxy that matches the generated UUID identity, facet, and this object adapter.
+    /// - Parameters:
+    ///   - servant: The servant to add.
+    ///   - facet: The facet. An empty facet means the default facet.
+    /// - Returns: A proxy that matches the generated UUID identity, facet, and this object adapter.
     @discardableResult
     func addFacetWithUUID(servant: Dispatcher, facet: String) throws -> ObjectPrx
 
@@ -126,30 +121,28 @@ public protocol ObjectAdapter: AnyObject, Sendable {
     /// If no servant has been found by any of the preceding steps, the object adapter gives up and the caller
     /// receives ObjectNotExistException or FacetNotExistException.
     ///
-    /// - parameter servant: `Dispatcher` The default servant.
-    ///
-    /// - parameter category: `String` The category for which the default servant is registered. An empty
-    /// category means it will handle all categories.
+    /// - Parameters:
+    ///   - servant: The default servant.
+    ///   - category: The category for which the default servant is registered. An empty
+    ///               category means it will handle all categories.
     func addDefaultServant(servant: Dispatcher, category: String) throws
 
     /// Remove a servant (that is, the default facet) from the object adapter's Active Servant Map.
     ///
-    /// - parameter id: `Identity` The identity of the Ice object that is implemented by the servant. If the servant
-    /// implements multiple Ice objects, remove has to be called for all those Ice objects. Removing an identity
-    /// that is not in the map throws NotRegisteredException.
-    ///
-    /// - returns: `Dispatcher` - The removed servant.
+    /// - Parameter id: The identity of the Ice object that is implemented by the servant. If the servant
+    ///                 implements multiple Ice objects, remove has to be called for all those Ice objects. Removing an identity
+    ///                 that is not in the map throws NotRegisteredException.
+    /// - Returns: The removed servant.
     @discardableResult
     func remove(_ id: Identity) throws -> Dispatcher
 
     /// Like remove, but with a facet. Calling remove(id) is equivalent to calling
     /// removeFacet with an empty facet.
     ///
-    /// - parameter id: `Identity` The identity of the Ice object that is implemented by the servant.
-    ///
-    /// - parameter facet: `String` The facet. An empty facet means the default facet.
-    ///
-    /// - returns: `Dispatcher` - The removed servant.
+    /// - Parameters:
+    ///   - id: The identity of the Ice object that is implemented by the servant.
+    ///   - facet: The facet. An empty facet means the default facet.
+    /// - Returns: The removed servant.
     @discardableResult
     func removeFacet(id: Identity, facet: String) throws -> Dispatcher
 
@@ -157,18 +150,16 @@ public protocol ObjectAdapter: AnyObject, Sendable {
     /// object, including its default facet. Removing an identity that is not in the map throws
     /// NotRegisteredException.
     ///
-    /// - parameter id: `Identity` The identity of the Ice object to be removed.
-    ///
-    /// - returns: `FacetMap` - A collection containing all the facet names and servants of the removed Ice object.
+    /// - Parameter id: The identity of the Ice object to be removed.
+    /// - Returns: A collection containing all the facet names and servants of the removed Ice object.
     @discardableResult
     func removeAllFacets(_ id: Identity) throws -> FacetMap
 
     /// Remove the default servant for a specific category. Attempting to remove a default servant for a category that
     /// is not registered throws NotRegisteredException.
     ///
-    /// - parameter category: `String` The category of the default servant to remove.
-    ///
-    /// - returns: `Dispatcher` - The default servant.
+    /// - Parameter category: The category of the default servant to remove.
+    /// - Returns: The default servant.
     @discardableResult
     func removeDefaultServant(_ category: String) throws -> Dispatcher
 
@@ -176,28 +167,25 @@ public protocol ObjectAdapter: AnyObject, Sendable {
     /// This operation only tries to look up a servant in the Active Servant Map. It does not attempt
     /// to find a servant by using any installed ServantLocator.
     ///
-    /// - parameter id: `Identity` The identity of the Ice object for which the servant should be returned.
-    ///
-    /// - returns: `Dispatcher?` - The servant that implements the Ice object with the given identity, or null if no such
-    /// servant has been found.
+    /// - Parameter id: The identity of the Ice object for which the servant should be returned.
+    /// - Returns: The servant that implements the Ice object with the given identity, or null if no such
+    ///            servant has been found.
     func find(_ id: Identity) -> Dispatcher?
 
     /// Like find, but with a facet. Calling find(id) is equivalent to calling findFacet
     /// with an empty facet.
     ///
-    /// - parameter id: `Identity` The identity of the Ice object for which the servant should be returned.
-    ///
-    /// - parameter facet: `String` The facet. An empty facet means the default facet.
-    ///
-    /// - returns: `Dispatcher?` - The servant that implements the Ice object with the given identity and facet, or null if
-    /// no such servant has been found.
+    /// - Parameters:
+    ///   - id: The identity of the Ice object for which the servant should be returned.
+    ///   - facet: The facet. An empty facet means the default facet.
+    /// - Returns: The servant that implements the Ice object with the given identity and facet, or null if
+    ///            no such servant has been found.
     func findFacet(id: Identity, facet: String) -> Dispatcher?
 
     /// Find all facets with the given identity in the Active Servant Map.
     ///
-    /// - parameter id: `Identity` The identity of the Ice object for which the facets should be returned.
-    ///
-    /// - returns: `FacetMap` - A collection containing all the facet names and servants that have been found, or an
+    /// - Parameter id: The identity of the Ice object for which the facets should be returned.
+    /// - Returns: A collection containing all the facet names and servants that have been found, or an
     /// empty map if there is no facet for the given identity.
     func findAllFacets(_ id: Identity) -> FacetMap
 
@@ -205,9 +193,8 @@ public protocol ObjectAdapter: AnyObject, Sendable {
     /// This operation only tries to lookup a servant in the Active Servant Map. It does not attempt to
     /// find a servant by using any installed ServantLocator.
     ///
-    /// - parameter proxy: `ObjectPrx` The proxy for which the servant should be returned.
-    ///
-    /// - returns: `Dispatcher?` - The servant that matches the proxy, or null if no such servant has been found.
+    /// - Parameter proxy: The proxy for which the servant should be returned.
+    /// - Returns: The servant that matches the proxy, or null if no such servant has been found.
     func findByProxy(_ proxy: ObjectPrx) -> Dispatcher?
 
     /// Add a Servant Locator to this object adapter. Adding a servant locator for a category for which a servant
@@ -227,36 +214,35 @@ public protocol ObjectAdapter: AnyObject, Sendable {
     ///
     /// Only one locator for the empty category can be installed.
     ///
-    /// - parameter locator: `ServantLocator` The locator to add.
-    ///
-    /// - parameter category: `String` The category for which the Servant Locator can locate servants, or an
-    /// empty string if the Servant Locator does not belong to any specific category.
+    /// - Parameters:
+    ///   - locator: The locator to add.
+    ///   - category: The category for which the Servant Locator can locate servants, or an
+    ///     empty string if the Servant Locator does not belong to any specific category.
     func addServantLocator(locator: ServantLocator, category: String) throws
 
     /// Remove a Servant Locator from this object adapter.
     ///
-    /// - parameter category: `String` The category for which the Servant Locator can locate servants, or an empty
+    /// - Parameter category: The category for which the Servant Locator can locate servants, or an empty
     /// string if the Servant Locator does not belong to any specific category.
     ///
-    /// - returns: `ServantLocator` - The Servant Locator, or throws NotRegisteredException if no Servant Locator was
+    /// - Returns: The Servant Locator, or throws NotRegisteredException if no Servant Locator was
     /// found for the given category.
     @discardableResult
     func removeServantLocator(_ category: String) throws -> ServantLocator
 
     /// Find a Servant Locator installed with this object adapter.
     ///
-    /// - parameter category: `String` The category for which the Servant Locator can locate servants, or an empty
+    /// - Parameter category: The category for which the Servant Locator can locate servants, or an empty
     /// string if the Servant Locator does not belong to any specific category.
     ///
-    /// - returns: `ServantLocator?` - The Servant Locator, or null if no Servant Locator was found for the given
+    /// - Returns: The Servant Locator, or null if no Servant Locator was found for the given
     /// category.
     func findServantLocator(_ category: String) -> ServantLocator?
 
     /// Find the default servant for a specific category.
     ///
-    /// - parameter category: `String` The category of the default servant to find.
-    ///
-    /// - returns: `Dispatcher?` - The default servant or null if no default servant was registered for the category.
+    /// - Parameter category: The category of the default servant to find.
+    /// - Returns: The default servant or null if no default servant was registered for the category.
     func findDefaultServant(_ category: String) -> Dispatcher?
 
     /// Create a proxy for the object with the given identity. If this object adapter is configured with an adapter id,
@@ -264,26 +250,23 @@ public protocol ObjectAdapter: AnyObject, Sendable {
     /// return value is an indirect proxy that refers to the replica group id. Otherwise, if no adapter id is defined,
     /// the return value is a direct proxy containing this object adapter's published endpoints.
     ///
-    /// - parameter id: `Identity` The object's identity.
-    ///
-    /// - returns: `ObjectPrx` - A proxy for the object with the given identity.
+    /// - Parameter id: The object's identity.
+    /// - Returns: A proxy for the object with the given identity.
     func createProxy(_ id: Identity) throws -> ObjectPrx
 
     /// Create a direct proxy for the object with the given identity. The returned proxy contains this object adapter's
     /// published endpoints.
     ///
-    /// - parameter id: `Identity` The object's identity.
-    ///
-    /// - returns: `ObjectPrx` - A proxy for the object with the given identity.
+    /// - Parameter id: The object's identity.
+    /// - Returns: A proxy for the object with the given identity.
     func createDirectProxy(_ id: Identity) throws -> ObjectPrx
 
     /// Create an indirect proxy for the object with the given identity. If this object adapter is configured with an
     /// adapter id, the return value refers to the adapter id. Otherwise, the return value contains only the object
     /// identity.
     ///
-    /// - parameter id: `Identity` The object's identity.
-    ///
-    /// - returns: `ObjectPrx` - A proxy for the object with the given identity.
+    /// - Parameter id: The object's identity.
+    /// - Returns: A proxy for the object with the given identity.
     func createIndirectProxy(_ id: Identity) throws -> ObjectPrx
 
     /// Set an Ice locator for this object adapter. By doing so, the object adapter will register itself with the
@@ -291,27 +274,27 @@ public protocol ObjectAdapter: AnyObject, Sendable {
     /// adapter will contain the adapter identifier instead of its endpoints. The adapter identifier must be configured
     /// using the AdapterId property.
     ///
-    /// - parameter loc: `LocatorPrx?` The locator used by this object adapter.
+    /// - Parameter loc: The locator used by this object adapter.
     func setLocator(_ loc: LocatorPrx?) throws
 
     /// Get the Ice locator used by this object adapter.
     ///
-    /// - returns: `LocatorPrx?` - The locator used by this object adapter, or null if no locator is used by this
+    /// - Returns: The locator used by this object adapter, or null if no locator is used by this
     /// object adapter.
     func getLocator() -> LocatorPrx?
 
     /// Get the set of endpoints configured with this object adapter.
     ///
-    /// - returns: `EndpointSeq` - The set of endpoints.
+    /// - Returns: The set of endpoints.
     func getEndpoints() -> EndpointSeq
 
     /// Get the set of endpoints that proxies created by this object adapter will contain.
     ///
-    /// - returns: `EndpointSeq` - The set of published endpoints.
+    /// - Returns: The set of published endpoints.
     func getPublishedEndpoints() -> EndpointSeq
 
     /// Set of the endpoints that proxies created by this object adapter will contain.
     ///
-    /// - parameter newEndpoints: `EndpointSeq` The new set of endpoints that the object adapter will embed in proxies.
+    /// - Parameter newEndpoints: The new set of endpoints that the object adapter will embed in proxies.
     func setPublishedEndpoints(_ newEndpoints: EndpointSeq) throws
 }

--- a/swift/src/Ice/OutputStream.swift
+++ b/swift/src/Ice/OutputStream.swift
@@ -16,15 +16,16 @@ public final class OutputStream {
     }
 
     /// Constructs an output stream using an encoding version and a class format.
-    /// - parameter encoding: The encoding version.
-    /// - parameter format: The class format.
+    /// - Parameters:
+    ///   - encoding: The encoding version.
+    ///   - format: The class format.
     public init(encoding: EncodingVersion, format: FormatType) {
         self.encoding = encoding
         self.format = format
     }
 
     /// Constructs an output stream using a communicator.
-    /// - parameter communicator: A communicator that supplies the encoding version and the class format.
+    /// - Parameter communicator: A communicator that supplies the encoding version and the class format.
     public convenience init(communicator: Communicator) {
         let defaultsAndOverrides = (communicator as! CommunicatorI).defaultsAndOverrides
         self.init(
@@ -32,8 +33,9 @@ public final class OutputStream {
     }
 
     /// Constructs an output stream using a communicator and an encoding version.
-    /// - parameter communicator: A communicator that supplies the class format.
-    /// - parameter encoding: The encoding version.
+    /// - Parameters:
+    ///   - communicator: A communicator that supplies the class format.
+    ///   - encoding: The encoding version.
     public convenience init(communicator: Communicator, encoding: EncodingVersion) {
         let defaultsAndOverrides = (communicator as! CommunicatorI).defaultsAndOverrides
         self.init(encoding: encoding, format: defaultsAndOverrides.defaultFormat)
@@ -46,9 +48,9 @@ public final class OutputStream {
 
     /// Writes the start of an encapsulation to the stream.
     ///
-    /// - parameter encoding: `Ice.EncodingVersion` - The encoding version of the encapsulation.
-    ///
-    /// - parameter format: `Ice.FormatType` - Specify the compact or sliced format.
+    /// - Parameters:
+    ///   - encoding: The encoding version of the encapsulation.
+    ///   - format: Specify the compact or sliced format.
     public func startEncapsulation(encoding: EncodingVersion, format: FormatType?) {
         precondition(encaps == nil, "Nested or sequential encapsulations are not supported")
         encaps = Encaps(encoding: encoding, format: format, start: data.count)
@@ -66,7 +68,7 @@ public final class OutputStream {
 
     /// Writes an empty encapsulation using the given encoding version.
     ///
-    /// - parameter encoding: `Ice.EncodingVersion` - The encoding version of the encapsulation.
+    /// - Parameter encoding: The encoding version of the encapsulation.
     func writeEmptyEncapsulation(_ encoding: EncodingVersion) {
         write(Int32(6))  // Size
         write(encoding)
@@ -74,7 +76,7 @@ public final class OutputStream {
 
     /// Writes a pre-encoded encapsulation.
     ///
-    /// - parameter v: `Data` - The encapsulation data.
+    /// - Parameter v: The encapsulation data.
     func writeEncapsulation(_ v: Data) {
         precondition(v.count >= 6, "Encapsulation is invalid. Size is too small.")
         data.append(v)
@@ -96,7 +98,7 @@ public final class OutputStream {
 
     /// Marks the start of a class instance.
     ///
-    /// - parameter data: `Ice.SlicedData?` - Preserved slices for this instance, or nil.
+    /// - Parameter data: Preserved slices for this instance, or nil.
     public func startValue(data: SlicedData?) {
         precondition(encaps.encoder != nil)
         encaps.encoder.startInstance(type: .ValueSlice, data: data)
@@ -159,13 +161,11 @@ public final class OutputStream {
     }
 
     /// Marks the start of a new slice for a class instance or user exception.
-    ///
-    /// - parameter typeId: `String` - The Slice type ID corresponding to this slice.
-    ///
-    /// - parameter compactId: `Int32` - The Slice compact type ID corresponding to this
-    ///   slice or -1 if no compact ID is defined for the type ID.
-    ///
-    /// - parameter last: `Bool` - True if this is the last slice, false otherwise.
+    /// - Parameters:
+    ///   - typeId: The Slice type ID corresponding to this slice.
+    ///   - compactId: The Slice compact type ID corresponding to this
+    ///     slice or -1 if no compact ID is defined for the type ID.
+    ///   - last: True if this is the last slice, false otherwise.
     public func startSlice(typeId: String, compactId: Int32, last: Bool) {
         precondition(encaps != nil && encaps.encoder != nil)
         encaps.encoder.startSlice(typeId: typeId, compactId: compactId, last: last)
@@ -181,7 +181,7 @@ public final class OutputStream {
 extension OutputStream {
     /// Writes a numeric value to the stream.
     ///
-    /// - parameter v: `Element` - The numeric value to write.
+    /// - Parameter v: The numeric value to write.
     public func write<Element>(_ v: Element) where Element: StreamableNumeric {
         // We assume a little-endian platform
         withUnsafePointer(to: v) { ptr in
@@ -191,9 +191,9 @@ extension OutputStream {
 
     /// Writes an optional numeric value to the stream.
     ///
-    /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
-    ///
-    /// - parameter value: `Element?` - The numeric value to write.
+    /// - Parameters:
+    ///   - tag: The tag of the optional data member or parameter.
+    ///   - value: The numeric value to write.
     public func write<Element>(tag: Int32, value: Element?) where Element: StreamableNumeric {
         let format = OptionalFormat(fixedSize: MemoryLayout<Element>.size)
         if let val = value {
@@ -205,7 +205,7 @@ extension OutputStream {
 
     /// Writes a sequence of numeric values to the stream.
     ///
-    /// - parameter v: `[Element]` - The sequence of numeric values.
+    /// - Parameter v: The sequence of numeric values.
     public func write<Element>(_ v: [Element]) where Element: StreamableNumeric {
         write(size: v.count)
 
@@ -222,9 +222,9 @@ extension OutputStream {
 
     /// Writes an optional sequence of numeric values to the stream.
     ///
-    /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
-    ///
-    /// - parameter value: `[Element]?` - The sequence of numeric numeric values to write.
+    /// - Parameters:
+    ///   - tag: The tag of the optional data member or parameter.
+    ///   - value: The sequence of numeric values to write.
     public func write<Element>(tag: Int32, value: [Element]?) where Element: StreamableNumeric {
         if let val = value {
             if writeOptionalVSize(tag: tag, len: val.count, elemSize: MemoryLayout<Element>.size) {
@@ -239,14 +239,14 @@ extension OutputStream {
 
     /// Writes a byte to the stream.
     ///
-    /// - parameter v: `UInt8` - The byte to write.
+    /// - Parameter v: The byte to write.
     public func write(_ v: UInt8) {
         data.append(v)
     }
 
     /// Writes bytes to the stream.
     ///
-    /// - parameter v: `[UInt8]` - The bytes to write.
+    /// - Parameter v: The bytes to write.
     public func writeBlob(_ v: [UInt8]) {
         if v.count > 0 {
             data.append(contentsOf: v)
@@ -255,7 +255,7 @@ extension OutputStream {
 
     /// Writes a sequence of bytes to the stream (including the size).
     ///
-    /// - parameter v: `[UInt8]` - The sequence of bytes to write.
+    /// - Parameter v: The sequence of bytes to write.
     public func write(_ v: [UInt8]) {
         write(size: v.count)
         if v.count > 0 {
@@ -265,7 +265,7 @@ extension OutputStream {
 
     /// Writes a sequence of bytes to the stream (including the size).
     ///
-    /// - parameter v: `Data` - The sequence of bytes to write.
+    /// - Parameter v: The sequence of bytes to write.
     public func write(_ v: Data) {
         write(size: v.count)
         if v.count > 0 {
@@ -275,9 +275,9 @@ extension OutputStream {
 
     /// Writes an optional sequence of bytes to the stream.
     ///
-    /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
-    ///
-    /// - parameter value: `Data` - The sequence of bytes to write.
+    /// - Parameters:
+    ///   - tag: The tag of the optional data member or parameter.
+    ///   - value: The sequence of bytes to write.
     public func write(tag: Int32, value: Data?) {
         if let val = value {
             // Note: not the same as larger Numeric
@@ -289,16 +289,16 @@ extension OutputStream {
 
     /// Writes a boolean value to the stream.
     ///
-    /// - parameter v: `Bool` - The boolean value to write.
+    /// - Parameter v: The boolean value to write.
     public func write(_ v: Bool) {
         write(UInt8(v == true ? 1 : 0))
     }
 
     /// Writes an optional boolean value to the stream.
     ///
-    /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
-    ///
-    /// - parameter value: `Bool?` - The boolean value to write.
+    /// - Parameters:
+    ///   - tag: The tag of the optional data member or parameter.
+    ///   - value: The boolean value to write.
     public func write(tag: Int32, value: Bool?) {
         if let val = value {
             if writeOptional(tag: tag, format: .F1) {
@@ -309,7 +309,7 @@ extension OutputStream {
 
     /// Writes a sequence of boolean values to the stream.
     ///
-    /// - parameter v: `[Bool]` - The sequence of boolean values to write.
+    /// - Parameter v: The sequence of boolean values to write.
     public func write(_ v: [Bool]) {
         write(size: v.count)
         if MemoryLayout<Bool>.size == 1, MemoryLayout<Bool>.stride == 1 {
@@ -322,10 +322,9 @@ extension OutputStream {
     }
 
     /// Writes an optional sequence of boolean values to the stream.
-    ///
-    /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
-    ///
-    /// - parameter value: `[Bool]?` - The sequence of boolean values to write.
+    /// - Parameters:
+    ///   - tag: The tag of the optional data member or parameter.
+    ///   - value: The sequence of boolean values to write.
     public func write(tag: Int32, value: [Bool]?) {
         if let val = value {
             if writeOptional(tag: tag, format: .VSize) {
@@ -336,7 +335,7 @@ extension OutputStream {
 
     /// Writes a size to the stream.
     ///
-    /// - parameter size: `Int32` - The size to write.
+    /// - Parameter size: The size to write.
     public func write(size: Int32) {
         if size > 254 {
             write(UInt8(255))
@@ -348,7 +347,7 @@ extension OutputStream {
 
     /// Writes a size to the stream.
     ///
-    /// - parameter size: `Int` - The size to write.
+    /// - Parameter size: The size to write.
     public func write(size: Int) {
         precondition(size <= Int32.max, "Size is too large")
         write(size: Int32(size))
@@ -366,11 +365,10 @@ extension OutputStream {
     }
 
     /// Writes an enumerator to the stream.
-    ///
-    /// - parameter val: `UInt8` - The value of the enumerator to write.
-    ///
-    /// - parameter maxValue: `Int32` - The maximum value for the enumeration's enumerators
-    /// (used only for the 1.0 encoding).
+    /// - Parameters:
+    ///   - val: The value of the enumerator to write.
+    ///   - maxValue: The maximum value for the enumeration's enumerators
+    ///     (used only for the 1.0 encoding).
     public func write(enum val: UInt8, maxValue: Int32) {
         if currentEncoding == Encoding_1_0 {
             if maxValue < 127 {
@@ -386,13 +384,11 @@ extension OutputStream {
     }
 
     /// Writes an optional enumerator to the stream.
-    ///
-    /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
-    ///
-    /// - parameter val: `UInt8` - The value of the enumerator to write.
-    ///
-    /// - parameter maxValue: `Int32` - The maximum value for the enumeration's enumerators
-    /// (used only for the 1.0 encoding).
+    /// - Parameters:
+    ///   - tag: The tag of the optional data member or parameter.
+    ///   - val: The value of the enumerator to write.
+    ///   - maxValue: The maximum value for the enumeration's enumerators
+    ///     (used only for the 1.0 encoding).
     public func write(tag: Int32, val: UInt8, maxValue: Int32) {
         if writeOptional(tag: tag, format: .Size) {
             write(enum: val, maxValue: maxValue)
@@ -400,11 +396,10 @@ extension OutputStream {
     }
 
     /// Writes an enumerator to the stream.
-    ///
-    /// - parameter val: `Int32` - The value of the enumerator to write.
-    ///
-    /// - parameter maxValue: `Int32` - The maximum value for the enumeration's enumerators
-    /// (used only for the 1.0 encoding).
+    /// - Parameters:
+    ///   - val: The value of the enumerator to write.
+    ///   - maxValue: The maximum value for the enumeration's enumerators
+    ///     (used only for the 1.0 encoding).
     public func write(enum val: Int32, maxValue: Int32) {
         if currentEncoding == Encoding_1_0 {
             if maxValue < 127 {
@@ -420,13 +415,11 @@ extension OutputStream {
     }
 
     /// Writes an optional enumerator to the stream.
-    ///
-    /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
-    ///
-    /// - parameter val: `Int32` - The value of the enumerator to write.
-    ///
-    /// - parameter maxValue: `Int32` - The maximum value for the enumeration's enumerators
-    /// (used only for the 1.0 encoding).
+    /// - Parameters:
+    ///   - tag: The tag of the optional data member or parameter.
+    ///   - val: The value of the enumerator to write.
+    ///   - maxValue: The maximum value for the enumeration's enumerators
+    ///     (used only for the 1.0 encoding).
     public func write(tag: Int32, val: Int32, maxValue: Int32) {
         if writeOptional(tag: tag, format: .Size) {
             write(enum: val, maxValue: maxValue)
@@ -435,7 +428,7 @@ extension OutputStream {
 
     /// Writes a string to the stream.
     ///
-    /// - parameter v: `String` - The string to write.
+    /// - Parameter v: The string to write.
     public func write(_ v: String) {
         let bytes = v.data(using: .utf8)!
         write(size: bytes.count)
@@ -443,10 +436,9 @@ extension OutputStream {
     }
 
     /// Writes a string to the stream.
-    ///
-    /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
-    ///
-    /// - parameter v: `String?` - The string to write.
+    /// - Parameters:
+    ///   - tag: The tag of the optional data member or parameter.
+    ///   - v: The string to write.
     public func write(tag: Int32, value v: String?) {
         if let val = v {
             if writeOptional(tag: tag, format: .VSize) {
@@ -457,7 +449,7 @@ extension OutputStream {
 
     /// Writes a sequence of strings to the stream.
     ///
-    /// - parameter v: `String` - The sequence of strings to write.
+    /// - Parameter v: The sequence of strings to write.
     public func write(_ v: [String]) {
         write(size: v.count)
         for s in v {
@@ -466,10 +458,9 @@ extension OutputStream {
     }
 
     /// Writes an optional sequence of strings to the stream.
-    ///
-    /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
-    ///
-    /// - parameter v: `[String]?` - The sequence of strings to write.
+    /// - Parameters:
+    ///   - tag: The tag of the optional data member or parameter.
+    ///   - v: The sequence of strings to write.
     public func write(tag: Int32, value v: [String]?) {
         if let val = v {
             if writeOptional(tag: tag, format: .FSize) {
@@ -482,7 +473,7 @@ extension OutputStream {
 
     /// Writes a proxy to the stream.
     ///
-    /// - parameter v: `ObjectPrx?` - The proxy to write.
+    /// - Parameter v: The proxy to write.
     public func write(_ v: ObjectPrx?) {
         if let prxImpl = v as? ObjectPrxI {
             prxImpl.ice_write(to: self)
@@ -495,10 +486,9 @@ extension OutputStream {
     }
 
     /// Writes an optional proxy to the stream.
-    ///
-    /// - parameter tag: `Int32` - The tag of the optional data member or parameter.
-    ///
-    /// - parameter v: `ObjectPrx?` - The proxy to write.
+    /// - Parameters:
+    ///   - tag: The tag of the optional data member or parameter.
+    ///   - v: The proxy to write.
     public func write(tag: Int32, value v: ObjectPrx?) {
         if let val = v {
             if writeOptional(tag: tag, format: .FSize) {
@@ -511,7 +501,7 @@ extension OutputStream {
 
     /// Writes a value to the stream.
     ///
-    /// - parameter v: `Value?` - The value to write.
+    /// - Parameter v: The value to write.
     public func write(_ v: Value?) {
         initEncaps()
         encaps.encoder.writeValue(v: v)
@@ -519,7 +509,7 @@ extension OutputStream {
 
     /// Writes a user exception to the stream.
     ///
-    /// - parameter v: `UserException` - The user exception to write.
+    /// - Parameter v: The user exception to write.
     public func write(_ v: UserException) {
         initEncaps()
         // Exceptions are always encoded with the sliced format.
@@ -566,7 +556,7 @@ extension OutputStream {
 
     /// Writes bytes to the stream.
     ///
-    /// - parameter raw: `Data` - The bytes to write as-is.
+    /// - Parameter raw: The bytes to write as-is.
     public func write(raw: Data) {
         data.append(raw)
     }

--- a/swift/src/Ice/Properties.swift
+++ b/swift/src/Ice/Properties.swift
@@ -7,55 +7,40 @@ import Foundation
 /// application-name[.category[.sub-category]].name.
 public protocol Properties: AnyObject {
     /// Get a property by key. If the property is not set, an empty string is returned.
-    ///
-    /// - parameter key: `String` The property key.
-    ///
-    /// - returns: `String` - The property value.
+    /// - Parameter key: The property key.
+    /// - Returns: The property value.
     func getProperty(_ key: String) -> String
 
     /// Get an Ice property by key. If the property is not set, its default value is returned.
-    ///
-    /// - parameter key: `String` The property key.
-    ///
-    /// - returns: `String` - The property value or the default value.
+    /// - Parameter key: The property key.
+    /// - Returns: The property value or the default value.
     func getIceProperty(_ key: String) -> String
 
     /// Get a property by key. If the property is not set, the given default value is returned.
-    ///
-    /// - parameter key: `String` The property key.
-    ///
-    /// - parameter value: `String` The default value to use if the property does not exist.
-    ///
-    /// - returns: `String` - The property value or the default value.
+    /// - Parameters:
+    ///   - key: The property key.
+    ///   - value: The default value to use if the property does not exist.
+    /// - Returns: The property value or the default value.
     func getPropertyWithDefault(key: String, value: String) -> String
 
     /// Get a property as an integer. If the property is not set, 0 is returned.
-    ///
-    /// - parameter key: `String` The property key.
-    ///
-    /// - returns: `Int32` - The property value interpreted as an integer.
-    ///
-    /// - throws: `PropertyException` when the property value is not a valid integer.
+    /// - Parameter key: The property key.
+    /// - Returns: The property value interpreted as an integer.
+    /// - Throws: `PropertyException` when the property value is not a valid integer.
     func getPropertyAsInt(_ key: String) throws -> Int32
 
     /// Get an Ice property as an integer. If the property is not set,its default value is returned.
-    ///
-    /// - parameter key: `String` The property key.
-    ///
-    /// - returns: `Int32` - The property value interpreted as an integer, or the default value.
-    ///
-    /// - throws: `PropertyException` when the property value is not a valid integer.
+    /// - Parameter key: The property key.
+    /// - Returns: The property value interpreted as an integer, or the default value.
+    /// - Throws: `PropertyException` when the property value is not a valid integer.
     func getIcePropertyAsInt(_ key: String) throws -> Int32
 
     /// Get a property as an integer. If the property is not set, the given default value is returned.
-    ///
-    /// - parameter key: `String` The property key.
-    ///
-    /// - parameter value: `Int32` The default value to use if the property does not exist.
-    ///
-    /// - returns: `Int32` - The property value interpreted as an integer, or the default value.
-    ///
-    /// - throws: `PropertyException` when the property value is not a valid integer.
+    /// - Parameters:
+    ///   - key: The property key.
+    ///   - value: The default value to use if the property does not exist.
+    /// - Returns: The property value interpreted as an integer, or the default value.
+    /// - Throws: `PropertyException` when the property value is not a valid integer.
     func getPropertyAsIntWithDefault(key: String, value: Int32) throws -> Int32
 
     /// Get a property as a list of strings. The strings must be separated by whitespace or comma. If the property is
@@ -63,10 +48,8 @@ public protocol Properties: AnyObject {
     /// enclosed in single or double quotes. If quotes are mismatched, an empty list is returned. Within single quotes
     /// or double quotes, you can escape the quote in question with a backslash, e.g. O'Reilly can be written as
     /// O'Reilly, "O'Reilly" or 'O\'Reilly'.
-    ///
-    /// - parameter key: `String` The property key.
-    ///
-    /// - returns: `StringSeq` - The property value interpreted as a list of strings.
+    /// - Parameter key: The property key.
+    /// - Returns: The property value interpreted as a list of strings.
     func getPropertyAsList(_ key: String) -> StringSeq
 
     /// Get an Ice property as a list of strings.  The strings must be separated by whitespace or comma. If the property
@@ -74,10 +57,8 @@ public protocol Properties: AnyObject {
     /// enclosed in single or double quotes. If quotes are mismatched, the default list is returned. Within single
     /// quotes or double quotes, you can escape the quote in question with a backslash, e.g. O'Reilly can be written as
     /// O'Reilly, "O'Reilly" or 'O\'Reilly'.
-    ///
-    /// - parameter key: `String` The property key.
-    ///
-    /// - returns: `StringSeq` - The property value interpreted as list of strings, or the default value.
+    /// - Parameter key: The property key.
+    /// - Returns: The property value interpreted as list of strings, or the default value.
     func getIcePropertyAsList(_ key: String) -> StringSeq
 
     /// Get a property as a list of strings.  The strings must be separated by whitespace or comma. If the property is
@@ -85,65 +66,56 @@ public protocol Properties: AnyObject {
     /// enclosed in single or double quotes. If quotes are mismatched, the default list is returned. Within single
     /// quotes or double quotes, you can escape the quote in question with a backslash, e.g. O'Reilly can be written as
     /// O'Reilly, "O'Reilly" or 'O\'Reilly'.
-    ///
-    /// - parameter key: `String` The property key.
-    ///
-    /// - parameter value: `StringSeq` The default value to use if the property is not set.
-    ///
-    /// - returns: `StringSeq` - The property value interpreted as list of strings, or the default value.
+    /// - Parameters:
+    ///   - key: The property key.
+    ///   - value: The default value to use if the property is not set.
+    /// - Returns: The property value interpreted as list of strings, or the default value.
     func getPropertyAsListWithDefault(key: String, value: StringSeq) -> StringSeq
 
     /// Get all properties whose keys begins with prefix. If prefix is an empty string, then all
     /// properties are returned.
-    ///
-    /// - parameter prefix: `String` The prefix to search for (empty string if none).
-    ///
-    /// - returns: `PropertyDict` - The matching property set.
+    /// - Parameter prefix: The prefix to search for (empty string if none).
+    /// - Returns: The matching property set.
     func getPropertiesForPrefix(_ prefix: String) -> PropertyDict
 
     /// Set a property. To unset a property, set it to the empty string.
-    ///
-    /// - parameter key: `String` The property key.
-    ///
-    /// - parameter value: `String` The property value.
+    /// - Parameters:
+    ///   - key: The property key.
+    ///   - value: The property value.
     func setProperty(key: String, value: String)
 
     /// Get a sequence of command-line options that is equivalent to this property set. Each element of the returned
     /// sequence is a command-line option of the form --key=value.
     ///
-    /// - returns: `StringSeq` - The command line options for this property set.
+    /// - Returns: The command line options for this property set.
     func getCommandLineOptions() -> StringSeq
 
     /// Convert a sequence of command-line options into properties. All options that begin with
     /// --prefix. are converted into properties. If the prefix is empty, all options that begin with
     /// -- are converted to properties.
-    ///
-    /// - parameter prefix: `String` The property prefix, or an empty string to convert all options starting
-    /// with --.
-    ///
-    /// - parameter options: `StringSeq` The command-line options.
-    ///
-    /// - returns: `StringSeq` - The command-line options that do not start with the specified prefix, in their
-    /// original order.
+    /// - Parameters:
+    ///   - prefix: The property prefix, or an empty string to convert all options starting
+    ///     with --.
+    ///   - options: The command-line options.
+    /// - Returns: The command-line options that do not start with the specified prefix, in their
+    ///   original order.
     func parseCommandLineOptions(prefix: String, options: StringSeq) throws -> StringSeq
 
     /// Convert a sequence of command-line options into properties. All options that begin with one of the following
     /// prefixes are converted into properties: --Ice, --IceBox, --IceGrid,
     /// --IceSSL, --IceStorm, and --Glacier2.
-    ///
-    /// - parameter options: `StringSeq` The command-line options.
-    ///
-    /// - returns: `StringSeq` - The command-line options that do not start with one of the listed prefixes,
-    /// in their original order.
+    /// - Parameter options: The command-line options.
+    /// - Returns: The command-line options that do not start with one of the listed prefixes,
+    ///   in their original order.
     func parseIceCommandLineOptions(_ options: StringSeq) throws -> StringSeq
 
     /// Load properties from a file.
     ///
-    /// - parameter file: `String` The property file.
+    /// - Parameter file: The property file.
     func load(_ file: String) throws
 
     /// Create a copy of this property set.
     ///
-    /// - returns: `Properties` - A copy of this property set.
+    /// - Returns: A copy of this property set.
     func clone() -> Properties
 }

--- a/swift/src/Ice/Proxy.swift
+++ b/swift/src/Ice/Proxy.swift
@@ -7,269 +7,269 @@ import IceImpl
 public protocol ObjectPrx: CustomStringConvertible, AnyObject, Sendable {
     /// Returns the communicator that created this proxy.
     ///
-    /// - returns: `Ice.Communicator` - The communicator that created this proxy.
+    /// - Returns: The communicator that created this proxy.
     func ice_getCommunicator() -> Communicator
 
     /// Returns the identity embedded in this proxy.
     ///
-    /// - returns: `Ice.Identity` - The identity of the target object.
+    /// - Returns: The identity of the target object.
     func ice_getIdentity() -> Identity
 
     /// Creates a new proxy that is identical to this proxy, except for the identity.
     ///
-    /// - parameter id: `Ice.Identity` - The identity for the new proxy.
+    /// - Parameter id: The identity for the new proxy.
     ///
-    /// - returns: A proxy with the new identity.
+    /// - Returns: A proxy with the new identity.
     func ice_identity(_ id: Identity) -> Self
 
     /// Returns the per-proxy context for this proxy.
     ///
-    /// - returns: `Ice.Context` - The per-proxy context.
+    /// - Returns: The per-proxy context.
     func ice_getContext() -> Context
 
     /// Creates a new proxy that is identical to this proxy, except for the per-proxy context.
     ///
-    /// - parameter context: `Ice.Context` - The context for the new proxy.
+    /// - Parameter context: The context for the new proxy.
     ///
-    /// - returns: The proxy with the new per-proxy context.
+    /// - Returns: The proxy with the new per-proxy context.
     func ice_context(_ context: Context) -> Self
 
     /// Returns the facet for this proxy.
     ///
-    /// - returns: `String` - The facet for this proxy. If the proxy uses the default facet,
+    /// - Returns: The facet for this proxy. If the proxy uses the default facet,
     ///   the return value is the empty string.
     func ice_getFacet() -> String
 
     /// Creates a new proxy that is identical to this proxy, except for the facet.
     ///
-    /// - parameter facet: `String` - The facet for the new proxy.
+    /// - Parameter facet: The facet for the new proxy.
     ///
-    /// - returns: `Ice.ObjectPrx` - The proxy with the new facet.
+    /// - Returns: The proxy with the new facet.
     func ice_facet(_ facet: String) -> ObjectPrx
 
     /// Returns the adapter ID for this proxy.
     ///
-    /// - returns: `String` - The adapter ID. If the proxy does not have an adapter ID, the return value is the
+    /// - Returns: The adapter ID. If the proxy does not have an adapter ID, the return value is the
     ///   empty string.
     func ice_getAdapterId() -> String
 
     /// Creates a new proxy that is identical to this proxy, except for the adapter ID.
     ///
-    /// - parameter id: `String` - The adapter ID for the new proxy.
+    /// - Parameter id: The adapter ID for the new proxy.
     ///
-    /// - returns: The proxy with the new adapter ID.
+    /// - Returns: The proxy with the new adapter ID.
     func ice_adapterId(_ id: String) -> Self
 
     /// Returns the endpoints used by this proxy.
     ///
-    /// - returns: `EndpointSeq` - The endpoints used by this proxy.
+    /// - Returns: The endpoints used by this proxy.
     func ice_getEndpoints() -> EndpointSeq
 
     /// Creates a new proxy that is identical to this proxy, except for the endpoints.
     ///
-    /// - parameter endpoints: `EndpointSeq` - The endpoints for the new proxy.
+    /// - Parameter endpoints: The endpoints for the new proxy.
     ///
-    /// - returns: The proxy with the new endpoints.
+    /// - Returns: The proxy with the new endpoints.
     func ice_endpoints(_ endpoints: EndpointSeq) -> Self
 
     /// Returns the locator cache timeout of this proxy.
     ///
-    /// - returns: `Int32` - The locator cache timeout value (in seconds).
+    /// - Returns: The locator cache timeout value (in seconds).
     func ice_getLocatorCacheTimeout() -> Int32
 
     /// Creates a new proxy that is identical to this proxy, except for the locator cache timeout.
     ///
-    /// - parameter timeout: `Int32` - The new locator cache timeout (in seconds).
+    /// - Parameter timeout: The new locator cache timeout (in seconds).
     ///
-    /// - returns: A new proxy with the specified cache timeout.
+    /// - Returns: A new proxy with the specified cache timeout.
     func ice_locatorCacheTimeout(_ timeout: Int32) -> Self
 
     /// Returns the invocation timeout of this proxy.
     ///
-    /// - returns: `Int32` - The invocation timeout value (in seconds).
+    /// - Returns: The invocation timeout value (in seconds).
     func ice_getInvocationTimeout() -> Int32
 
     /// Creates a new proxy that is identical to this proxy, except for the invocation timeout.
     ///
-    /// - parameter timeout: `Int32` - The new invocation timeout (in seconds).
+    /// - Parameter timeout: The new invocation timeout (in seconds).
     ///
-    /// - returns: A new proxy with the specified invocation timeout.
+    /// - Returns: A new proxy with the specified invocation timeout.
     func ice_invocationTimeout(_ timeout: Int32) -> Self
 
     /// Returns the connection id of this proxy.
     ///
-    /// returns: `String` - The connection id.
+    /// - Returns: The connection id.
     func ice_getConnectionId() -> String
 
     /// Creates a new proxy that is identical to this proxy, except for its connection ID.
     ///
-    /// - parameter id: `String` - The connection ID for the new proxy. An empty string removes the
+    /// - Parameter id: The connection ID for the new proxy. An empty string removes the
     ///   connection ID.
     ///
-    /// - returns: A new proxy with the specified connection ID.
+    /// - Returns: A new proxy with the specified connection ID.
     func ice_connectionId(_ id: String) -> Self
 
     /// Returns whether this proxy caches connections.
     ///
-    /// - returns: `Bool` - True if this proxy caches connections; false, otherwise.
+    /// - Returns: True if this proxy caches connections; false, otherwise.
     func ice_isConnectionCached() -> Bool
 
     /// Creates a new proxy that is identical to this proxy, except for connection caching.
     ///
-    /// - parameter cached: `Bool` - True if the new proxy should cache connections; false, otherwise.
+    /// - Parameter cached: True if the new proxy should cache connections; false, otherwise.
     ///
-    /// - returns: The new proxy with the specified caching policy.
+    /// - Returns: The new proxy with the specified caching policy.
     func ice_connectionCached(_ cached: Bool) -> Self
 
     /// Returns how this proxy selects endpoints (randomly or ordered).
     ///
-    /// - returns: `Ice.EndpointSelectionType` - The endpoint selection policy.
+    /// - Returns: The endpoint selection policy.
     func ice_getEndpointSelection() -> EndpointSelectionType
 
     /// Creates a new proxy that is identical to this proxy, except for the endpoint selection policy.
     ///
-    /// - parameter type: `Ice.EndpointSelectionType` - The new endpoint selection policy.
+    /// - Parameter type: The new endpoint selection policy.
     ///
-    /// - returns: The new proxy with the specified endpoint selection policy.
+    /// - Returns: The new proxy with the specified endpoint selection policy.
     func ice_endpointSelection(_ type: EndpointSelectionType) -> Self
 
     /// Returns the encoding version used to marshal requests parameters.
     ///
-    /// - returns: `Ice.EncodingVersion` - The encoding version.
+    /// - Returns: The encoding version.
     func ice_getEncodingVersion() -> EncodingVersion
 
     /// Creates a new proxy that is identical to this proxy, except for the encoding used to marshal
     /// parameters.
     ///
-    /// - parameter encoding: `Ice.EncodingVersion` - The encoding version to use to marshal requests parameters.
+    /// - Parameter encoding: The encoding version to use to marshal requests parameters.
     ///
-    /// - returns: The new proxy with the specified encoding version.
+    /// - Returns: The new proxy with the specified encoding version.
     func ice_encodingVersion(_ encoding: EncodingVersion) -> Self
 
     /// Returns the router for this proxy.
     ///
-    /// - returns: `Ice.RouterPrx?` - The router for the proxy. If no router is configured for the proxy,
+    /// - Returns: The router for the proxy. If no router is configured for the proxy,
     ///   the return value is nil.
     func ice_getRouter() -> RouterPrx?
 
     /// Creates a new proxy that is identical to this proxy, except for the router.
     ///
-    /// - parameter router: `Ice.RouterPrx?` - The router for the new proxy.
+    /// - Parameter router: The router for the new proxy.
     ///
-    /// - returns: The new proxy with the specified router.
+    /// - Returns: The new proxy with the specified router.
     func ice_router(_ router: RouterPrx?) -> Self
 
     /// Returns the locator for this proxy.
     ///
-    /// - returns: `Ice.LocatorPrx?` - The locator for this proxy. If no locator is configured, the
+    /// - Returns: The locator for this proxy. If no locator is configured, the
     ///   return value is nil.
     func ice_getLocator() -> LocatorPrx?
 
     /// Creates a new proxy that is identical to this proxy, except for the locator.
     ///
-    /// - parameter locator: `Ice.LocatorPrx` The locator for the new proxy.
+    /// - Parameter locator: The locator for the new proxy.
     ///
-    /// - returns: The new proxy with the specified locator.
+    /// - Returns: The new proxy with the specified locator.
     func ice_locator(_ locator: LocatorPrx?) -> Self
 
     /// Returns whether this proxy uses twoway invocations.
     ///
-    /// - returns: `Bool` - True if this proxy uses twoway invocations; false, otherwise.
+    /// - Returns: True if this proxy uses twoway invocations; false, otherwise.
     func ice_isTwoway() -> Bool
 
     /// Creates a new proxy that is identical to this proxy, but uses twoway invocations.
     ///
-    /// - returns: A new proxy that uses twoway invocations.
+    /// - Returns: A new proxy that uses twoway invocations.
     func ice_twoway() -> Self
 
     /// Returns whether this proxy uses oneway invocations.
     ///
-    /// - returns: `Bool` - True if this proxy uses oneway invocations; false, otherwise.
+    /// - Returns: True if this proxy uses oneway invocations; false, otherwise.
     func ice_isOneway() -> Bool
 
     /// Creates a new proxy that is identical to this proxy, but uses oneway invocations.
     ///
-    /// - returns: A new proxy that uses oneway invocations.
+    /// - Returns: A new proxy that uses oneway invocations.
     func ice_oneway() -> Self
 
     /// Returns whether this proxy uses batch oneway invocations.
     ///
-    /// - returns: `Bool` - True if this proxy uses batch oneway invocations; false, otherwise.
+    /// - Returns: True if this proxy uses batch oneway invocations; false, otherwise.
     func ice_isBatchOneway() -> Bool
 
     /// Creates a new proxy that is identical to this proxy, but uses batch oneway invocations.
     ///
-    /// - returns: A new proxy that uses batch oneway invocations.
+    /// - Returns: A new proxy that uses batch oneway invocations.
     func ice_batchOneway() -> Self
 
     /// Returns whether this proxy uses datagram invocations.
     ///
-    /// - returns: `Bool` - True if this proxy uses datagram invocations; false, otherwise.
+    /// - Returns: True if this proxy uses datagram invocations; false, otherwise.
     func ice_isDatagram() -> Bool
 
     /// Creates a new proxy that is identical to this proxy, but uses datagram invocations.
     ///
-    /// - returns: A new proxy that uses datagram invocations.
+    /// - Returns: A new proxy that uses datagram invocations.
     func ice_datagram() -> Self
 
     /// Returns whether this proxy uses batch datagram invocations.
     ///
-    /// - returns: `Bool` - True if this proxy uses batch datagram invocations; false, otherwise.
+    /// - Returns: True if this proxy uses batch datagram invocations; false, otherwise.
     func ice_isBatchDatagram() -> Bool
 
     /// Creates a new proxy that is identical to this proxy, but uses batch datagram invocations.
     ///
-    /// - returns: A new proxy that uses batch datagram invocations.
+    /// - Returns: A new proxy that uses batch datagram invocations.
     func ice_batchDatagram() -> Self
 
     /// Obtains the compression override setting of this proxy.
     ///
-    /// - returns: `Bool` - The compression override setting. If no optional value is present, no override is
+    /// - Returns: The compression override setting. If no optional value is present, no override is
     ///   set. Otherwise, true if compression is enabled, false otherwise.
     func ice_getCompress() -> Bool?
 
     /// Creates a new proxy that is identical to this proxy, except for compression.
     ///
-    /// - parameter compress: `Bool` - True enables compression for the new proxy; false disables compression.
+    /// - Parameter compress: True enables compression for the new proxy; false disables compression.
     ///
-    /// - returns: A new proxy with the specified compression setting.
+    /// - Returns: A new proxy with the specified compression setting.
     func ice_compress(_ compress: Bool) -> Self
 
     /// Returns a proxy that is identical to this proxy, except it's a fixed proxy bound
     /// to the given connection.
     ///
-    /// - parameter connection: `Ice.Connection` - The fixed proxy connection.
+    /// - Parameter connection: The fixed proxy connection.
     ///
-    /// - returns: A fixed proxy bound to the given connection.
+    /// - Returns: A fixed proxy bound to the given connection.
     func ice_fixed(_ connection: Connection) -> Self
 
     /// Returns whether this proxy is a fixed proxy.
     ///
-    /// - returns: `Bool` - True if this is a fixed proxy, false otherwise.
+    /// - Returns: True if this is a fixed proxy, false otherwise.
     func ice_isFixed() -> Bool
 
     /// Returns the cached Connection for this proxy. If the proxy does not yet have an established
     /// connection, it does not attempt to create a connection.
     ///
-    /// - returns: `Ice.Connection?` - The cached Connection for this proxy (nil if the proxy does not have
+    /// - Returns: The cached Connection for this proxy (nil if the proxy does not have
     ///   an established connection).
     func ice_getCachedConnection() -> Connection?
 
     /// Returns the stringified form of this proxy.
     ///
-    /// - returns: `String` - The stringified proxy
+    /// - Returns: The stringified proxy
     func ice_toString() -> String
 
     /// Returns whether this proxy uses collocation optimization.
     ///
-    /// - returns: `Bool` - True if the proxy uses collocation optimization; false, otherwise.
+    /// - Returns: True if the proxy uses collocation optimization; false, otherwise.
     func ice_isCollocationOptimized() -> Bool
 
     /// Creates a new proxy that is identical to this proxy, except for collocation optimization.
     ///
-    /// - parameter collocated: `Bool` - True if the new proxy enables collocation optimization; false, otherwise.
+    /// - Parameter collocated: True if the new proxy enables collocation optimization; false, otherwise.
     ///
-    /// - returns: The new proxy the specified collocation optimization.
+    /// - Returns: The new proxy the specified collocation optimization.
     func ice_collocationOptimized(_ collocated: Bool) -> Self
 }
 
@@ -289,18 +289,18 @@ public func makeProxy(communicator: Ice.Communicator, proxyString: String, type:
 
 /// Creates a new proxy from an existing proxy after confirming the target object's type via a remote invocation.
 ///
-/// - parameter prx: `Ice.ObjectPrx` - The source proxy.
+/// - Parameter prx: The source proxy.
 ///
-/// - parameter type: `Ice.ObjectPrx.Protocol` - The type of the new proxy.
+/// - Parameter type: The type of the new proxy.
 ///
-/// - parameter facet: `String?` - The optional facet for the new proxy.
+/// - Parameter facet: The optional facet for the new proxy.
 ///
-/// - parameter context: `Ice.Context?` - The optional context dictionary for the invocation.
+/// - Parameter context: The optional context dictionary for the invocation.
 ///
-/// - throws: Throws an Ice local exception if the target object does not exist, the specified facet
+/// - Throws: Throws an Ice local exception if the target object does not exist, the specified facet
 ///   does not exist, or the server cannot be reached.
 ///
-/// - returns: A new proxy with the specified facet or nil if the target object does not support the specified
+/// - Returns: A new proxy with the specified facet or nil if the target object does not support the specified
 ///   interface.
 public func checkedCast(
     prx: Ice.ObjectPrx,
@@ -313,13 +313,13 @@ public func checkedCast(
 
 /// Creates a new proxy from an existing proxy.
 ///
-/// - parameter prx: `Ice.ObjectPrx` - The source proxy.
+/// - Parameter prx: The source proxy.
 ///
-/// - parameter type: `Ice.ObjectPrx.Protocol` - The type of the new proxy.
+/// - Parameter type: The type of the new proxy.
 ///
-/// - parameter facet: `String?` - The optional facet for the new proxy.
+/// - Parameter facet: The optional facet for the new proxy.
 ///
-/// - returns: A new proxy with the specified facet.
+/// - Returns: A new proxy with the specified facet.
 public func uncheckedCast(
     prx: Ice.ObjectPrx,
     type _: ObjectPrx.Protocol,
@@ -330,7 +330,7 @@ public func uncheckedCast(
 
 /// Returns the Slice type id of the interface or class associated with this proxy class.
 ///
-/// - returns: `String` - The type id, "::Ice::Object".
+/// - Returns: The type id, "::Ice::Object".
 public func ice_staticId(_: ObjectPrx.Protocol) -> String {
     return ObjectTraits.staticId
 }
@@ -361,7 +361,7 @@ extension ObjectPrx {
 
     /// Sends ping request to the target object.
     ///
-    /// - parameter context: `Ice.Context` - The optional context dictionary for the invocation.
+    /// - Parameter context: The optional context dictionary for the invocation.
     public func ice_ping(context: Context? = nil) async throws {
         return try await _impl._invoke(
             operation: "ice_ping",
@@ -371,11 +371,11 @@ extension ObjectPrx {
 
     /// Tests whether this object supports a specific Slice interface.
     ///
-    /// - parameter id: `String` - The type ID of the Slice interface to test against.
+    /// - Parameter id: The type ID of the Slice interface to test against.
     ///
-    /// - parameter context: `Ice.Context` - The optional context dictionary for the invocation.
+    /// - Parameter context: The optional context dictionary for the invocation.
     ///
-    /// - returns: `Bool` - The result of the invocation.
+    /// - Returns: The result of the invocation.
     public func ice_isA(id: String, context: Context? = nil) async throws -> Bool {
         return try await _impl._invoke(
             operation: "ice_isA",
@@ -389,9 +389,9 @@ extension ObjectPrx {
 
     /// Returns the Slice type ID of the most-derived interface supported by the target object of this proxy.
     ///
-    /// - parameter context: `Ice.Context?` - The optional context dictionary for the invocation.
+    /// - Parameter context: The optional context dictionary for the invocation.
     ///
-    /// - returns: `String` The result of the invocation.
+    /// - Returns: `String` The result of the invocation.
     public func ice_id(context: Context? = nil) async throws -> String {
         return try await _impl._invoke(
             operation: "ice_id",
@@ -402,9 +402,9 @@ extension ObjectPrx {
 
     /// Returns the Slice type IDs of the interfaces supported by the target object of this proxy.
     ///
-    /// - parameter context: `Ice.Context?` - The optional context dictionary for the invocation.
+    /// - Parameter context: The optional context dictionary for the invocation.
     ///
-    /// - returns: `Ice.StringSeq` - The result of the invocation.
+    /// - Returns: The result of the invocation.
     public func ice_ids(context: Context? = nil) async throws -> StringSeq {
         return try await _impl._invoke(
             operation: "ice_ids",
@@ -415,15 +415,15 @@ extension ObjectPrx {
 
     /// Invokes an operation dynamically.
     ///
-    /// - parameter operation: `String` - The name of the operation to invoke.
+    /// - Parameter operation: The name of the operation to invoke.
     ///
-    /// - parameter mode: `Ice.OperationMode` - The operation mode (normal or idempotent).
+    /// - Parameter mode: The operation mode (normal or idempotent).
     ///
-    /// - parameter inEncaps: `Data` - The encoded in-parameters for the operation.
+    /// - Parameter inEncaps: The encoded in-parameters for the operation.
     ///
-    /// - parameter context: `Ice.Context` - The context dictionary for the invocation.
+    /// - Parameter context: The context dictionary for the invocation.
     ///
-    /// - returns: `(ok: Bool, outEncaps: Data)` - The result of the invocation.
+    /// - Returns: The result of the invocation.
     public func ice_invoke(
         operation: String,
         mode: OperationMode,
@@ -486,7 +486,7 @@ extension ObjectPrx {
     /// Returns the connection for this proxy. If the proxy does not yet have an established connection,
     /// it first attempts to create a connection.
     ///
-    /// - returns: `Ice.Connection?` - The result of the invocation.
+    /// - Returns: The result of the invocation.
     public func ice_getConnection() async throws -> Connection? {
         return try await withCheckedThrowingContinuation { continuation in
             self._impl.handle.ice_getConnection(

--- a/swift/src/Ice/ServantLocator.swift
+++ b/swift/src/Ice/ServantLocator.swift
@@ -14,18 +14,12 @@ public protocol ServantLocator: Sendable {
     /// If you call locate from your own code, you must also call finished
     /// when you have finished using the servant, provided that locate returned a non-null servant.
     ///
-    /// - parameter curr: `Current` Information about the current operation for which a servant is required.
-    ///
-    /// - returns: `(returnValue: Dispatcher?, cookie: AnyObject?)`:
-    ///
-    ///   - returnValue: `Dispatcher?` - The located servant, or null if no suitable servant has been found.
-    ///
-    ///   - cookie: `AnyObject?` - A "cookie" that will be passed to finished.
-    ///
-    /// - throws:
-    ///
-    ///   - UserException - The implementation can raise a UserException and the run time will marshal it as the
-    ///     result of the invocation.
+    /// - Parameter curr: Information about the current operation for which a servant is required.
+    /// - Returns: A tuple containing:
+    ///   - `returnValue`: The located servant of type `Dispatcher?`, or `nil` if no suitable servant has been found.
+    ///   - `cookie`: A value of type `AnyObject?` that will be passed to `finished`.
+    /// - Throws:
+    ///   - `UserException`: The implementation can raise a `UserException`, which the runtime will marshal as the result of the invocation.
     func locate(_ curr: Current) throws -> (returnValue: Dispatcher?, cookie: AnyObject?)
 
     /// Called by the object adapter after a request has been made. This operation is only called if
@@ -37,21 +31,15 @@ public protocol ServantLocator: Sendable {
     /// If both the operation and finished throw an exception, the exception thrown by
     /// finished is marshaled back to the client.
     ///
-    /// - parameter curr: `Current` Information about the current operation call for which a servant was located by
-    /// locate.
-    ///
-    /// - parameter servant: `Dispatcher` The servant that was returned by locate.
-    ///
-    /// - parameter cookie: `AnyObject?` The cookie that was returned by locate.
-    ///
-    /// - throws:
-    ///
-    ///   - UserException - The implementation can raise a UserException and the run time will marshal it as the
-    ///     result of the invocation.
+    /// - Parameters:
+    ///   - curr: Information about the current operation call for which a servant was located by `locate`.
+    ///   - servant: The servant that was returned by `locate`.
+    ///   - cookie: The cookie that was returned by `locate`.
+    /// - Throws: The implementation can raise a `UserException`, which the runtime will marshal as the result of the invocation.
     func finished(curr: Current, servant: Dispatcher, cookie: AnyObject?) throws
 
     /// Called when the object adapter in which this servant locator is installed is destroyed.
     ///
-    /// - parameter category: `String` Indicates for which category the servant locator is being deactivated.
+    /// - Parameter category: Indicates for which category the servant locator is being deactivated.
     func deactivate(_ category: String)
 }

--- a/swift/src/Ice/ToStringMode.swift
+++ b/swift/src/Ice/ToStringMode.swift
@@ -28,7 +28,7 @@ public enum ToStringMode: UInt8 {
 extension InputStream {
     /// Read an enumerated value.
     ///
-    /// - returns: `ToStringMode` - The enumarated value.
+    /// - Returns: The enumarated value.
     public func read() throws -> ToStringMode {
         let rawValue: UInt8 = try read(enumMaxValue: 2)
         guard let val = ToStringMode(rawValue: rawValue) else {
@@ -39,9 +39,8 @@ extension InputStream {
 
     /// Read an optional enumerated value from the stream.
     ///
-    /// - parameter tag: `Int32` - The numeric tag associated with the value.
-    ///
-    /// - returns: `ToStringMode` - The enumerated value.
+    /// - Parameter tag: The numeric tag associated with the value.
+    /// - Returns: The enumerated value.
     public func read(tag: Int32) throws -> ToStringMode? {
         guard try readOptional(tag: tag, expectedFormat: .Size) else {
             return nil
@@ -54,16 +53,16 @@ extension InputStream {
 extension OutputStream {
     /// Writes an enumerated value to the stream.
     ///
-    /// - parameter value: `ToStringMode` - The enumerator to write.
+    /// - Parameter value: The enumerator to write.
     public func write(_ value: ToStringMode) {
         write(enum: value.rawValue, maxValue: 2)
     }
 
     /// Writes an optional enumerated value to the stream.
     ///
-    /// - parameter tag: `Int32` - The numeric tag associated with the value.
-    ///
-    /// - parameter value: `ToStringMode` - The enumerator to write.
+    /// - Parameters:
+    ///   - tag: The numeric tag associated with the value.
+    ///   - value: The enumerator to write.
     public func write(tag: Int32, value: ToStringMode?) {
         guard let v = value else {
             return

--- a/swift/src/Ice/UnknownSlicedValue.swift
+++ b/swift/src/Ice/UnknownSlicedValue.swift
@@ -14,7 +14,7 @@ public final class UnknownSlicedValue: Value {
 
     /// Returns the Slice type ID associated with this object.
     ///
-    /// - returns: `String` - The type ID.
+    /// - Returns: The type ID.
     override public func ice_id() -> String {
         return unknownTypeId
     }

--- a/swift/src/Ice/Util.swift
+++ b/swift/src/Ice/Util.swift
@@ -5,9 +5,8 @@ import IceImpl
 
 /// Converts a string to an encoding version.
 ///
-/// - parameter s: `String` - The string to convert.
-///
-/// - returns: `Ice.EncodingVersion` - The converted encoding version.</returns>
+/// - Parameter s: The string to convert.
+/// - Returns: The converted encoding version.
 func stringToEncodingVersion(_ s: String) throws -> EncodingVersion {
     let (major, minor) = try stringToMajorMinor(s)
     return EncodingVersion(major: major, minor: minor)

--- a/swift/src/Ice/Value.swift
+++ b/swift/src/Ice/Value.swift
@@ -30,7 +30,7 @@ open class Value {
     /// Returns the sliced data if the value has a preserved-slice base class and has been sliced during
     /// un-marshaling of the value, nil is returned otherwise.
     ///
-    /// - returns: `SlicedData?` - The sliced data or nil.
+    /// - Returns: The sliced data or nil.
     open func ice_getSlicedData() -> SlicedData? {
         return slicedData
     }


### PR DESCRIPTION
This changes were made with the help of Copilot. 

In a follow-up PR I plan to review the generated code doc comments.  