### PR TITLE
Remove membio support in OpenSSL transceiver

### DIFF
--- a/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/OpenSSLTransceiverI.cpp
@@ -593,9 +593,6 @@ OpenSSL::TransceiverI::TransceiverI(
       _peerCertificate(nullptr),
       _ssl(nullptr),
       _sslCtx(nullptr),
-      _sentBytes(0),
-      _maxSendPacketSize(0),
-      _maxRecvPacketSize(0),
       _localSSLContextSelectionCallback(
           serverAuthenticationOptions.serverSSLContextSelectionCallback
               ? serverAuthenticationOptions.serverSSLContextSelectionCallback
@@ -623,9 +620,6 @@ OpenSSL::TransceiverI::TransceiverI(
       _peerCertificate(nullptr),
       _ssl(nullptr),
       _sslCtx(nullptr),
-      _sentBytes(0),
-      _maxSendPacketSize(0),
-      _maxRecvPacketSize(0),
       _localSSLContextSelectionCallback(
           clientAuthenticationOptions.clientSSLContextSelectionCallback
               ? clientAuthenticationOptions.clientSSLContextSelectionCallback

--- a/cpp/src/Ice/SSL/OpenSSLTransceiverI.h
+++ b/cpp/src/Ice/SSL/OpenSSLTransceiverI.h
@@ -68,9 +68,6 @@ namespace Ice::SSL::OpenSSL
         SSL_CTX* _sslCtx;
         IceInternal::Buffer _writeBuffer;
         IceInternal::Buffer _readBuffer;
-        int _sentBytes;
-        size_t _maxSendPacketSize;
-        size_t _maxRecvPacketSize;
         std::function<SSL_CTX*(const std::string&)> _localSSLContextSelectionCallback;
         std::function<bool(bool, X509_STORE_CTX*, const Ice::SSL::ConnectionInfoPtr&)>
             _remoteCertificateVerificationCallback;


### PR DESCRIPTION
This PR removes membio support in OpenSSL transceiver, that can be used by non socket based transport. As far as I see we don't have any non-socket based transports.