### PR TITLE
Fixes for publishing Java artifacts to maven central

### DIFF
--- a/.github/workflows/build-maven-packages.yml
+++ b/.github/workflows/build-maven-packages.yml
@@ -118,16 +118,6 @@ jobs:
         run: ./gradlew dist
         working-directory: ice/java
 
-      - name: Sign Ice for Java Files
-        run: |
-          set -euo pipefail
-          echo "$GPG_KEY" | gpg --batch --import
-          find ice/java/lib local-repo -type f \( -name '*.jar' -o -name '*.pom' \) \
-            -exec gpg -u "$GPG_KEY_ID" --armor --detach-sign --batch --yes --output '{}.asc' '{}' \;
-        env:
-          GPG_KEY: ${{ secrets.ICE_3_8_CI_SIGNER_KEY }}
-          GPG_KEY_ID: ${{ secrets.ICE_3_8_CI_SIGNER_KEY_ID }}
-
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -135,7 +125,6 @@ jobs:
           path: |
             ice/java/lib/*.jar
             ice/java/lib/*.pom
-            ice/java/lib/*.asc
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
@@ -143,5 +132,4 @@ jobs:
           name: slice-tools-packages
           path: |
             local-repo/**/*.jar
-            local-repo/**/*.asc
             local-repo/**/*.pom

--- a/.github/workflows/publish-maven-packages.yml
+++ b/.github/workflows/publish-maven-packages.yml
@@ -39,7 +39,7 @@ jobs:
           gh run download "$RUN_ID" --repo zeroc-ice/ice --pattern "java-packages" --dir "${STAGING_DIR}"
           gh run download "$RUN_ID" --repo zeroc-ice/ice --pattern "slice-tools-packages" --dir "${STAGING_DIR}"
 
-      - name: Publish 3.8 Java Packages
+      - name: Publish Java Packages
         run: packaging/maven/publish-maven-release.sh
         env:
           CHANNEL: ${{ inputs.channel }}

--- a/.github/workflows/publish-maven-packages.yml
+++ b/.github/workflows/publish-maven-packages.yml
@@ -39,21 +39,15 @@ jobs:
           gh run download "$RUN_ID" --repo zeroc-ice/ice --pattern "java-packages" --dir "${STAGING_DIR}"
           gh run download "$RUN_ID" --repo zeroc-ice/ice --pattern "slice-tools-packages" --dir "${STAGING_DIR}"
 
-      - name: Publish Nightly Java Packages
-        run: packaging/maven/publish-maven-release.sh
-        env:
-          CHANNEL: ${{ inputs.channel }}
-          MAVEN_USERNAME: "nightly"
-          MAVEN_PASSWORD: ${{ secrets.NEXUS_NIGHTLY_PASSWORD }}
-        if: ${{ inputs.channel == 'nightly' }}
-
       - name: Publish 3.8 Java Packages
         run: packaging/maven/publish-maven-release.sh
         env:
           CHANNEL: ${{ inputs.channel }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_API_KEY }}
-        if: ${{ inputs.channel != 'nightly' }}
+          MAVEN_BEARER_AUTH_TOKEN: ${{ secrets.MAVEN_CENTRAL_BEARER_AUTH_TOKEN }}
+          GPG_KEY: ${{ secrets.ICE_3_8_CI_SIGNER_KEY }}
+          GPG_KEY_ID: ${{ secrets.ICE_3_8_CI_SIGNER_KEY_ID }}
 
       - name: Clean Credentials
         if: always()

--- a/NIGHTLY.md
+++ b/NIGHTLY.md
@@ -73,12 +73,12 @@ https://download.zeroc.com/nexus/repository/nuget-nightly/
 
 ### Ice for Java
 
-The nightly packages are available from the ZeroC maven-nightly repository.
+The nightly packages are available from the maven central snapshots repository.
 
 To use them, add the following Maven repository to your build configuration:
 
 ```shell
-https://download.zeroc.com/nexus/repository/maven-nightly/
+https://central.sonatype.com/repository/maven-snapshots
 ```
 
 #### Gradle <!-- omit in toc -->
@@ -90,9 +90,10 @@ Here’s an example configuration using Kotlin DSL:
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        // This demo uses the nightly build of the Slice Tools plugin, published to the ZeroC Maven Nightly repository.
+        // This demo uses the nightly build of the Slice Tools plugin, published to the maven central snapshots
+        // repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://central.sonatype.com/repository/maven-snapshots")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }
@@ -103,9 +104,9 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // This demo uses the nightly build of Ice, published to the ZeroC Maven Nightly repository.
+        // This demo uses the nightly build of Ice, published to the maven central snapshots repository.
         maven {
-            url = uri("https://download.zeroc.com/nexus/repository/maven-nightly/")
+            url = uri("https://central.sonatype.com/repository/maven-snapshots")
             content {
                 includeGroupByRegex("com\\.zeroc.*")
             }

--- a/NIGHTLY.md
+++ b/NIGHTLY.md
@@ -90,8 +90,7 @@ Here’s an example configuration using Kotlin DSL:
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        // This demo uses the nightly build of the Slice Tools plugin, published to the maven central snapshots
-        // repository.
+        // Use the nightly build of the Slice Tools plugin, published to the maven central snapshots repository.
         maven {
             url = uri("https://central.sonatype.com/repository/maven-snapshots")
             content {
@@ -104,7 +103,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        // This demo uses the nightly build of Ice, published to the maven central snapshots repository.
+        // Use the nightly build of Ice, published to the maven central snapshots repository.
         maven {
             url = uri("https://central.sonatype.com/repository/maven-snapshots")
             content {
@@ -344,7 +343,7 @@ brew install zeroc-ice/nightly/ice
 
 The ice formula includes:
 
-- the Ice for C++ runtime and dev kit
+- the Ice for C++ runtime and dev kit.
 - all Ice services (Glacier2, IceGrid, IceStorm, etc.) and all admin tools except IceGrid GUI.
 
 IceGridGUI is distributed in its own brew cask. This cask is not yet available.

--- a/packaging/maven/publish-maven-release.sh
+++ b/packaging/maven/publish-maven-release.sh
@@ -64,7 +64,6 @@ for component in "${components[@]}"; do
     -DrepositoryId="${REPO_ID}" || { echo "Failed to publish $base_name"; exit 1; }
 done
 
-
 if [ "$CHANNEL" = "3.8" ]; then
   # Tell maven central to validate the deployed artifacts, the deployment needs to be manually published
   # from the maven central web site after it has been validated.

--- a/packaging/maven/publish-maven-release.sh
+++ b/packaging/maven/publish-maven-release.sh
@@ -3,11 +3,11 @@ set -xeuo pipefail
 case "$CHANNEL" in
   "3.8")
     REPO_ID=ossrh
-    SOURCE_URL="https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+    SOURCE_URL="https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
     ;;
   "nightly")
-    REPO_ID=maven-nightly
-    SOURCE_URL="https://download.zeroc.com/nexus/repository/maven-nightly/"
+    REPO_ID=maven-snapshots
+    SOURCE_URL="https://central.sonatype.com/repository/maven-snapshots/"
     ;;
   *)
     echo "Unsupported channel: $CHANNEL"
@@ -32,10 +32,13 @@ cat > ~/.m2/settings.xml <<EOF
 </settings>
 EOF
 
+# Import the signing GPG key.
+echo "$GPG_KEY" | gpg --batch --import
+
+# Copy the JAR and POM files
 mkdir -p lib
 cp -pf "${STAGING_DIR}"/java-packages/*.jar lib
 cp -pf "${STAGING_DIR}"/java-packages/*.pom lib
-cp -pf "${STAGING_DIR}"/java-packages/*.asc lib
 
 ice_version=$(basename "$(ls lib/ice-*-sources.jar)" | sed -E 's/^ice-(.+)-sources\.jar$/\1/')
 components=(ice glacier2 icebt icebox icediscovery icelocatordiscovery icegrid icestorm)
@@ -51,17 +54,26 @@ for component in "${components[@]}"; do
 
   echo "Publishing $base_name"
 
-  mvn deploy:deploy-file \
+  mvn org.apache.maven.plugins:maven-gpg-plugin:3.2.4:sign-and-deploy-file \
+    -Dgpg.keyname="${GPG_KEY_ID}" \
     -Dfile="${jar}" \
     -Djavadoc="${javadoc_jar}" \
     -Dsources="${sources_jar}" \
     -DpomFile="${pom_file}" \
-    -Dfiles="${pom_file}.asc,${jar}.asc,${javadoc_jar}.asc,${sources_jar}.asc" \
-    -Dtypes=pom.asc,jar.asc,javadoc.jar.asc,sources.jar.asc \
-    -Dclassifiers=,jar,javadoc,sources \
     -Durl="${SOURCE_URL}" \
     -DrepositoryId="${REPO_ID}" || { echo "Failed to publish $base_name"; exit 1; }
 done
+
+
+if [ "$CHANNEL" = "3.8" ]; then
+  # Tell maven central to validate the deployed artifacts, the deployment needs to be manually published
+  # from the maven central web site after it has been validated.
+  curl -sS -X POST \
+  -H "Authorization: Bearer ${MAVEN_CENTRAL_BEARER_AUTH_TOKEN}" \
+  -H "Content-Type: application/json" \
+  "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.zeroc" \
+  -d '{"publishing_type":"user_managed"}'
+fi
 
 if [ "$CHANNEL" = "nightly" ]; then
   echo "Publishing Slice Tools plugin"
@@ -71,41 +83,32 @@ if [ "$CHANNEL" = "nightly" ]; then
   plugin_staging_dir="${STAGING_DIR}/slice-tools-packages/com/zeroc/slice-tools"
 
   cp "${plugin_staging_dir}/${ice_version}/"*.jar "plugin/slice-tools-${ice_version}.jar"
-  cp "${plugin_staging_dir}/${ice_version}/"*.jar.asc "plugin/slice-tools-${ice_version}.jar.asc"
   cp "${plugin_staging_dir}/${ice_version}/"*.pom "plugin/slice-tools-${ice_version}.pom"
-  cp "${plugin_staging_dir}/${ice_version}/"*.pom.asc "plugin/slice-tools-${ice_version}.pom.asc"
 
   plugin_jar="plugin/slice-tools-${ice_version}.jar"
   plugin_pom="plugin/slice-tools-${ice_version}.pom"
 
-  mvn deploy:deploy-file \
+  mvn org.apache.maven.plugins:maven-gpg-plugin:3.2.4:sign-and-deploy-file \
+    -Dgpg.keyname="${GPG_KEY_ID}" \
     -Dfile="${plugin_jar}" \
     -DpomFile="${plugin_pom}" \
-    -Dfiles="${plugin_jar}.asc,${plugin_pom}.asc" \
-    -Dtypes=jar.asc,pom.asc \
-    -Dclassifiers=, \
     -Durl="${SOURCE_URL}" \
     -DrepositoryId="${REPO_ID}" || { echo "Failed to publish plugin"; exit 1; }
 
   cp "${plugin_staging_dir}/com.zeroc.slice-tools.gradle.plugin/${ice_version}/"*.pom \
     "plugin/com.zeroc.slice-tools.gradle.plugin-${ice_version}.pom"
-  cp "${plugin_staging_dir}/com.zeroc.slice-tools.gradle.plugin/${ice_version}/"*.pom.asc \
-    "plugin/com.zeroc.slice-tools.gradle.plugin-${ice_version}.pom.asc"
 
   plugin_marker_pom="plugin/com.zeroc.slice-tools.gradle.plugin-${ice_version}.pom"
-  plugin_marker_asc="plugin/com.zeroc.slice-tools.gradle.plugin-${ice_version}.pom.asc"
 
   echo "Publishing plugin marker POM"
 
-  mvn deploy:deploy-file \
+  mvn org.apache.maven.plugins:maven-gpg-plugin:3.2.4:sign-and-deploy-file \
+    -Dgpg.keyname="${GPG_KEY_ID}" \
     -Dfile="${plugin_marker_pom}" \
     -Dpackaging=pom \
     -DgroupId="com.zeroc.slice-tools" \
     -DartifactId="com.zeroc.slice-tools.gradle.plugin" \
     -Dversion="${ice_version}" \
-    -Dfiles="${plugin_marker_asc}" \
-    -Dtypes=pom.asc \
-    -Dclassifiers= \
     -Durl="${SOURCE_URL}" \
     -DrepositoryId="${REPO_ID}" || { echo "Failed to publish plugin marker"; exit 1; }
 fi


### PR DESCRIPTION
This PR upgrades the workflow that publishes Java artifacts to maven central. It also move nightly builds back to maven central snapshots repository.