### PR TITLE
Remove chunking from JavaScript TCP transport

### DIFF
--- a/config/PropertyNames.xml
+++ b/config/PropertyNames.xml
@@ -117,7 +117,7 @@
         <property name="SyslogPort" languages="java" default="514"/>
         <property name="TCP.Backlog" languages="cpp,csharp,java" default="511" />
         <property name="TCP.RcvSize" languages="cpp,csharp,java" />
-        <property name="TCP.SndSize" languages="cpp,csharp,java" />
+        <property name="TCP.SndSize" languages="cpp,csharp,java,js" />
         <property name="ThreadPool.Client" class="ThreadPool" languages="cpp,csharp,java" />
         <property name="ThreadPool.Server" class="ThreadPool" languages="cpp,csharp,java" />
         <property name="ThreadPriority" languages="csharp,java" />

--- a/js/src/Ice/PropertyNames.js
+++ b/js/src/Ice/PropertyNames.js
@@ -61,6 +61,7 @@ PropertyNames.IceProps.properties = [
     new Property("MessageSizeMax", false, "1024", false, null),
     new Property("ProgramName", false, "", false, null),
     new Property("RetryIntervals", false, "0", false, null),
+    new Property("TCP.SndSize", false, "", false, null),
     new Property("ToStringMode", false, "Unicode", false, null),
     new Property("Trace.Dispatch", false, "0", false, null),
     new Property("Trace.Locator", false, "0", false, null),

--- a/js/src/Ice/TcpTransceiver.js
+++ b/js/src/Ice/TcpTransceiver.js
@@ -131,7 +131,7 @@ class TcpTransceiver {
     }
 
     /**
-     * Write the given byte buffer to the socket. The buffer is written using multiple socket write calls.
+     * Write the given byte buffer to the socket.
      *
      * @param byteBuffer the byte buffer to write.
      * @returns Whether or not the write operation completed synchronously.
@@ -144,32 +144,15 @@ class TcpTransceiver {
         let packetSize = byteBuffer.remaining;
         console.assert(packetSize > 0);
 
-        if (this._maxSendPacketSize > 0 && packetSize > this._maxSendPacketSize) {
-            packetSize = this._maxSendPacketSize;
-        }
-
-        while (packetSize > 0) {
-            const slice = byteBuffer.b.slice(byteBuffer.position, byteBuffer.position + packetSize);
-            let sync = true;
-            sync = this._fd.write(Buffer.from(slice), null, () => {
-                if (!sync) {
-                    this._bytesWrittenCallback();
-                }
-            });
-
-            byteBuffer.position += packetSize;
-
+        const slice = byteBuffer.b.slice(byteBuffer.position, byteBuffer.position + packetSize);
+        let sync = true;
+        sync = this._fd.write(Buffer.from(slice), null, () => {
             if (!sync) {
-                return false; // Wait for callback to be called before sending more data.
+                this._bytesWrittenCallback();
             }
-
-            if (this._maxSendPacketSize > 0 && byteBuffer.remaining > this._maxSendPacketSize) {
-                packetSize = this._maxSendPacketSize;
-            } else {
-                packetSize = byteBuffer.remaining;
-            }
-        }
-        return true;
+        });
+        byteBuffer.position += packetSize;
+        return sync;
     }
 
     read(byteBuffer, moreData) {

--- a/js/test/Common/TestHelper.d.ts
+++ b/js/test/Common/TestHelper.d.ts
@@ -25,7 +25,6 @@ export class TestHelper {
     setControllerHelper(controllerHelper: ControllerHelper): void;
     serverReady(): void;
 
-    static isSafari(): boolean;
     static isBrowser(): boolean;
     static isWorker(): boolean;
 }

--- a/js/test/Common/TestHelper.js
+++ b/js/test/Common/TestHelper.js
@@ -122,10 +122,6 @@ export class TestHelper {
         this.controllerHelper.serverReady();
     }
 
-    static isSafari() {
-        return typeof navigator !== "undefined" && /^((?!chrome).)*safari/i.test(navigator.userAgent);
-    }
-
     static isBrowser() {
         return typeof window !== "undefined" || TestHelper.isWorker();
     }

--- a/js/test/Ice/ami/Client.ts
+++ b/js/test/Ice/ami/Client.ts
@@ -150,9 +150,8 @@ export class Client extends TestHelper {
         {
             let r1: Ice.AsyncResult<void>;
             let r2: Ice.AsyncResult<void>;
-            if (!TestHelper.isSafari()) {
-                // Safari WebSocket implementation accepts lots of data before apply back-pressure
-                // making this test very slow.
+
+            {
                 await testController.holdAdapter();
                 const requests: Ice.AsyncResult<void>[] = [];
                 try {
@@ -234,9 +233,7 @@ export class Client extends TestHelper {
             }
         }
 
-        if (!TestHelper.isSafari()) {
-            // Safari WebSocket implementation accepts lots of data before apply backpressure
-            // making this test very slow.
+        {
             await testController.holdAdapter();
             const seq = new Uint8Array(new Array(100000));
             let r;

--- a/js/test/Ice/binding/Client.ts
+++ b/js/test/Ice/binding/Client.ts
@@ -531,21 +531,8 @@ export class Client extends TestHelper {
     async run(args: string[]) {
         let communicator: Ice.Communicator | null = null;
         try {
-            const out = this.getWriter();
             [communicator, args] = this.initialize(args);
-            if (TestHelper.isSafari() && TestHelper.isWorker()) {
-                //
-                // BUGFIX:
-                //
-                // With Safari 9.1 and WebWorkers, this test hangs in communicator destruction. The
-                // web socket send() method never returns for the sending of close connection message.
-                //
-                out.writeLine("Test not supported with Safari web workers.");
-                const prx = new Test.RemoteCommunicatorPrx(communicator, `communicator:${this.getTestEndpoint()}`);
-                await prx.shutdown();
-            } else {
-                await this.allTests();
-            }
+            await this.allTests();
         } finally {
             if (communicator) {
                 await communicator.destroy();


### PR DESCRIPTION
This PR:
- Removes chunking from JavaScript TCP transport.
- Updates comments in WS transport to explain why it still uses chunking
- Removes a workaround for old Safari version bug.