### PR TITLE
Update doc comment for generated Java constructor for mapped structs

### DIFF
--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -3061,9 +3061,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
 
         out << sp;
         out << nl << "/**";
-        out << nl << " * Constructs a {@code " << name
-            << "} with values for all fields in the Slice definition for {@code " << p->scoped()
-            << "}.";
+        out << nl << " * Constructs a {@code " << name << "} with values for all its fields.";
         writeParamDocComments(out, members);
         out << nl << " */";
         out << nl << "public " << name << spar << parameters << epar;

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -3062,7 +3062,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
         out << sp;
         out << nl << "/**";
         out << nl << " * Constructs a {@code " << name
-            << "} with values for all fields not marked optional in the Slice definition for {@code " << p->scoped()
+            << "} with values for all fields in the Slice definition for {@code " << p->scoped()
             << "}.";
         writeParamDocComments(out, members);
         out << nl << " */";


### PR DESCRIPTION
I did not change the message for classes and exceptions as both of these constructors are inside:

```
if (!requiredMembers.empty() && !optionalMembers.empty())
{
...
```

Fixes #4247