### PR TITLE
Make DataStorm decode non noexcept

### DIFF
--- a/cpp/include/DataStorm/Types.h
+++ b/cpp/include/DataStorm/Types.h
@@ -169,7 +169,7 @@ namespace DataStorm
         /// @param communicator The communicator associated with the node.
         /// @param value The byte sequence to decode.
         /// @return The resulting value.
-        static T decode(const Ice::CommunicatorPtr& communicator, const Ice::ByteSeq& value) noexcept;
+        static T decode(const Ice::CommunicatorPtr& communicator, const Ice::ByteSeq& value);
     };
 
     /// The Cloner template provides a method to clone user types.
@@ -205,7 +205,7 @@ namespace DataStorm
 
     // Decoder template implementation.
     template<typename T, typename E>
-    T Decoder<T, E>::decode(const Ice::CommunicatorPtr& communicator, const Ice::ByteSeq& value) noexcept
+    T Decoder<T, E>::decode(const Ice::CommunicatorPtr& communicator, const Ice::ByteSeq& value)
     {
         T v;
         if (value.empty())


### PR DESCRIPTION
Declaring decode as `noexcept` is bad because a bogus encoded sample will bring readers decoding it down.

With this change the error will show up in the reader log as a MarshalException, the writer isn't notify because samples are send using oneway requests.

```
-- 10/09/25 12:52:01.682 build/Debug/reader.exe: Protocol: received request
   message type = 0 (request)
   compression status = 0 (not compressed; do not compress response, if any)
   message size = 88
   request id = 0 (oneway)
   identity = s/3
   facet =
   operation = s
   mode = 0 (normal)
   context =
   encoding = 1.1
   transport = tcp
   local address = 172.23.48.1:57041
   remote address = 172.23.48.1:57040
-! 10/09/25 12:52:01.685 build/Debug/reader.exe: warning: failed to dispatch s to s/3 over 172.23.48.1:57041<->172.23.48.1:57040:
   C:\Users\jose\source\repos\3.8\ice\cpp\src\Ice\InputStream.cpp:895 Ice::MarshalException attempting to unmarshal past the end of the buffer
   stack trace:
```