### PR TITLE
Fix Java Rewrite Parsing Issue

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSTransceiver.java
@@ -823,7 +823,7 @@ final class WSTransceiver implements Transceiver {
                         throw new ProtocolException("text frames not supported");
                     }
 
-                    case OP_CONT /* Continuation frame */,  OP_DATA /* Data frame */ -> {
+                    case OP_CONT, OP_DATA /* Continuation frame or Data frame */ -> {
                         if (_instance.traceLevel() >= 2) {
                             _instance
                                 .logger()


### PR DESCRIPTION
Bernard discovered that running `./gradlew rewriteRun` doesn't work, because it's failing on `WSTransciever.java`:
```
...
2025-10-03T16:13:42.5595523Z Scanning sources in project :
2025-10-03T16:13:42.5604743Z Using active styles [com.zeroc.IceRewriteStyle, org.openrewrite.java.Checkstyle]
2025-10-03T16:13:49.3593807Z There were problems parsing some source files, run with --info to see full stack traces
2025-10-03T16:13:49.3599314Z There were problems parsing java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSTransceiver.java
2025-10-03T16:14:01.7614627Z All sources parsed, running active recipes: com.zeroc.IceRewriteRecipes
2025-10-03T16:14:07.3593754Z Applying recipes would make no changes. No report generated.
```
I have no idea why this is tripping it up, but looking through it's debug output, this is what rewrite doesn't like.
So I'm just fixing it so that it 'works' again.

But I have no idea why it's suddenly angry about this line, especially since the line seems perfectly fine to me.