### PR TITLE
Remove --interface 127.0.0.1 and ::1 from UDP tests

### DIFF
--- a/cpp/test/Ice/udp/AllTests.cpp
+++ b/cpp/test/Ice/udp/AllTests.cpp
@@ -116,16 +116,10 @@ allTests(Test::TestHelper* helper)
     if (communicator->getProperties()->getIceProperty("Ice.IPv6") == "1")
     {
         endpoint << "udp -h \"ff15::1:1\" -p " << helper->getTestPort(10);
-#if defined(__APPLE__) || defined(_WIN32)
-        endpoint << " --interface \"::1\""; // Use loopback to prevent other machines to answer. the multicast requests.
-#endif
     }
     else
     {
         endpoint << "udp -h 239.255.1.1 -p " << helper->getTestPort(10);
-#if defined(__APPLE__) || defined(_WIN32)
-        endpoint << " --interface 127.0.0.1"; // Use loopback to prevent other machines to answer.
-#endif
     }
 
     TestIntfPrx objMcast(communicator, "test -d:" + endpoint.str());

--- a/cpp/test/Ice/udp/AllTests.cpp
+++ b/cpp/test/Ice/udp/AllTests.cpp
@@ -116,10 +116,18 @@ allTests(Test::TestHelper* helper)
     if (communicator->getProperties()->getIceProperty("Ice.IPv6") == "1")
     {
         endpoint << "udp -h \"ff15::1:1\" -p " << helper->getTestPort(10);
+#if defined(__APPLE__)
+        // Use loopback on macOS to run successfully on GitHub runners.
+        endpoint << " --interface \"::1\"";
+#endif
     }
     else
     {
         endpoint << "udp -h 239.255.1.1 -p " << helper->getTestPort(10);
+#if defined(__APPLE__)
+        // Use loopback on macOS to run successfully on GitHub runners.
+        endpoint << " --interface 127.0.0.1";
+#endif
     }
 
     TestIntfPrx objMcast(communicator, "test -d:" + endpoint.str());

--- a/cpp/test/Ice/udp/Server.cpp
+++ b/cpp/test/Ice/udp/Server.cpp
@@ -41,16 +41,10 @@ Server::run(int argc, char** argv)
     if (communicator->getProperties()->getIceProperty("Ice.IPv6") == "1")
     {
         endpoint << "udp -h \"ff15::1:1\" -p " << getTestPort(10);
-#if defined(__APPLE__) || defined(_WIN32)
-        endpoint << " --interface \"::1\""; // Use loopback to prevent other machines to answer.
-#endif
     }
     else
     {
         endpoint << "udp -h 239.255.1.1 -p " << getTestPort(10);
-#if defined(__APPLE__) || defined(_WIN32)
-        endpoint << " --interface 127.0.0.1"; // Use loopback to prevent other machines to answer.
-#endif
     }
     communicator->getProperties()->setProperty("McastTestAdapter.Endpoints", endpoint.str());
 

--- a/csharp/test/Ice/udp/AllTests.cs
+++ b/csharp/test/Ice/udp/AllTests.cs
@@ -148,18 +148,10 @@ public class AllTests : global::Test.AllTests
         if (communicator.getProperties().getIceProperty("Ice.IPv6") == "1")
         {
             endpoint.Append("udp -h \"ff15::1:1\"");
-            if (Ice.Internal.AssemblyUtil.isWindows || Ice.Internal.AssemblyUtil.isMacOS)
-            {
-                endpoint.Append(" --interface \"::1\"");
-            }
         }
         else
         {
             endpoint.Append("udp -h 239.255.1.1");
-            if (Ice.Internal.AssemblyUtil.isWindows || Ice.Internal.AssemblyUtil.isMacOS)
-            {
-                endpoint.Append(" --interface 127.0.0.1");
-            }
         }
         endpoint.Append(" -p ");
         endpoint.Append(helper.getTestPort(10));

--- a/csharp/test/Ice/udp/AllTests.cs
+++ b/csharp/test/Ice/udp/AllTests.cs
@@ -148,10 +148,20 @@ public class AllTests : global::Test.AllTests
         if (communicator.getProperties().getIceProperty("Ice.IPv6") == "1")
         {
             endpoint.Append("udp -h \"ff15::1:1\"");
+            // Use loopback on macOS to run successfully on GitHub runners.
+            if (Ice.Internal.AssemblyUtil.isMacOS)
+            {
+                endpoint.Append(" --interface \"::1\"");
+            }
         }
         else
         {
             endpoint.Append("udp -h 239.255.1.1");
+            // Use loopback on macOS to run successfully on GitHub runners.
+            if (Ice.Internal.AssemblyUtil.isMacOS)
+            {
+                endpoint.Append(" --interface 127.0.0.1");
+            }
         }
         endpoint.Append(" -p ");
         endpoint.Append(helper.getTestPort(10));

--- a/csharp/test/Ice/udp/Server.cs
+++ b/csharp/test/Ice/udp/Server.cs
@@ -47,18 +47,10 @@ public class Server : global::Test.TestHelper
         if (properties.getIceProperty("Ice.IPv6") == "1")
         {
             endpoint.Append("udp -h \"ff15::1:1\"");
-            if (Ice.Internal.AssemblyUtil.isWindows || Ice.Internal.AssemblyUtil.isMacOS)
-            {
-                endpoint.Append(" --interface \"::1\"");
-            }
         }
         else
         {
             endpoint.Append("udp -h 239.255.1.1");
-            if (Ice.Internal.AssemblyUtil.isWindows || Ice.Internal.AssemblyUtil.isMacOS)
-            {
-                endpoint.Append(" --interface 127.0.0.1");
-            }
         }
         endpoint.Append(" -p ");
         endpoint.Append(getTestPort(properties, 10));

--- a/java/test/src/main/java/test/Ice/udp/AllTests.java
+++ b/java/test/src/main/java/test/Ice/udp/AllTests.java
@@ -136,21 +136,9 @@ public class AllTests {
             if ("1".equals(communicator.getProperties().getIceProperty("Ice.IPv6"))) {
                 endpoint.append("udp -h \"ff15::1:1\" -p ");
                 endpoint.append(helper.getTestPort(communicator.getProperties(), 10));
-                if (System.getProperty("os.name").contains("OS X")
-                    || System.getProperty("os.name").startsWith("Windows")) {
-                    endpoint.append(
-                        " --interface \"::1\""); // Use loopback to prevent other machines to
-                    // answer.
-                }
             } else {
                 endpoint.append("udp -h 239.255.1.1 -p ");
                 endpoint.append(helper.getTestPort(communicator.getProperties(), 10));
-                if (System.getProperty("os.name").contains("OS X")
-                    || System.getProperty("os.name").startsWith("Windows")) {
-                    endpoint.append(
-                        " --interface 127.0.0.1"); // Use loopback to prevent other machines to
-                    // answer.
-                }
             }
             base = communicator.stringToProxy("test -d:" + endpoint.toString());
             TestIntfPrx objMcast = TestIntfPrx.uncheckedCast(base);

--- a/java/test/src/main/java/test/Ice/udp/AllTests.java
+++ b/java/test/src/main/java/test/Ice/udp/AllTests.java
@@ -136,9 +136,17 @@ public class AllTests {
             if ("1".equals(communicator.getProperties().getIceProperty("Ice.IPv6"))) {
                 endpoint.append("udp -h \"ff15::1:1\" -p ");
                 endpoint.append(helper.getTestPort(communicator.getProperties(), 10));
+                if (System.getProperty("os.name").contains("OS X")) {
+                    // Use loopback on macOS to run successfully on GitHub runners.
+                    endpoint.append(" --interface \"::1\"");
+                }
             } else {
                 endpoint.append("udp -h 239.255.1.1 -p ");
                 endpoint.append(helper.getTestPort(communicator.getProperties(), 10));
+                if (System.getProperty("os.name").contains("OS X")) {
+                    // Use loopback on macOS to run successfully on GitHub runners.
+                    endpoint.append(" --interface 127.0.0.1");
+                }
             }
             base = communicator.stringToProxy("test -d:" + endpoint.toString());
             TestIntfPrx objMcast = TestIntfPrx.uncheckedCast(base);

--- a/java/test/src/main/java/test/Ice/udp/Server.java
+++ b/java/test/src/main/java/test/Ice/udp/Server.java
@@ -21,12 +21,7 @@ public class Server extends TestHelper {
         {
             String endpoint;
             if ("1".equals(properties.getIceProperty("Ice.IPv6"))) {
-                // We don't do this on Linux because the loopback interface doesn't support multicast.
-                if (System.getProperty("os.name").contains("OS X")) {
-                    endpoint = "udp -h \"ff15::1:1\" -p 12020 --interface \"::1\"";
-                } else {
-                    endpoint = "udp -h \"ff15::1:1\" -p 12020";
-                }
+                endpoint = "udp -h \"ff15::1:1\" -p 12020";
             } else {
                 endpoint = "udp -h 239.255.1.1 -p 12020";
             }
@@ -54,21 +49,10 @@ public class Server extends TestHelper {
             if ("1".equals(properties.getIceProperty("Ice.IPv6"))) {
                 endpoint.append("udp -h \"ff15::1:1\" -p ");
                 endpoint.append(getTestPort(10));
-                if (System.getProperty("os.name").contains("OS X")
-                    || System.getProperty("os.name").startsWith("Windows")) {
-                    endpoint.append(
-                        " --interface \"::1\""); // Use loopback to prevent other machines to
-                    // answer.
-                }
             } else {
                 endpoint.append("udp -h 239.255.1.1 -p ");
                 endpoint.append(getTestPort(10));
-                if (System.getProperty("os.name").contains("OS X")
-                    || System.getProperty("os.name").startsWith("Windows")) {
-                    endpoint.append(
-                        " --interface 127.0.0.1"); // Use loopback to prevent other machines to
-                    // answer.
-                }
+
             }
             properties.setProperty("McastTestAdapter.Endpoints", endpoint.toString());
 

--- a/java/test/src/main/java/test/Ice/udp/Server.java
+++ b/java/test/src/main/java/test/Ice/udp/Server.java
@@ -52,7 +52,6 @@ public class Server extends TestHelper {
             } else {
                 endpoint.append("udp -h 239.255.1.1 -p ");
                 endpoint.append(getTestPort(10));
-
             }
             properties.setProperty("McastTestAdapter.Endpoints", endpoint.toString());
 

--- a/scripts/DataStormUtil.py
+++ b/scripts/DataStormUtil.py
@@ -62,7 +62,13 @@ class Reader(Server, DataStormProcess):
         if ("DataStorm.Node.Multicast.Enabled", 1) in props.items():
             port = current.driver.getTestPort(20)
             props["DataStorm.Node.Multicast.Endpoints"] = f"udp -h 239.255.0.1 -p {port}"
-            props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup -d:udp -h 239.255.0.1 -p {port}"
+            # Use loopback on macOS to run successfully on GitHub runners.
+            if isinstance(platform, Darwin):
+                props["DataStorm.Node.Multicast.Proxy"] = (
+                    f"DataStorm/Lookup -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"
+                )
+            else:
+                props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup -d:udp -h 239.255.0.1 -p {port}"
         elif not any(key.startswith("DataStorm.Node.") for key in props):
             # Default properties for tests that don't specify any DataStorm.Node.* properties
             props.update(

--- a/scripts/DataStormUtil.py
+++ b/scripts/DataStormUtil.py
@@ -31,7 +31,7 @@ class Writer(Client, DataStormProcess):
         if ("DataStorm.Node.Multicast.Enabled", 1) in props.items():
             port = current.driver.getTestPort(20)
             props["DataStorm.Node.Multicast.Endpoints"] = f"udp -h 239.255.0.1 -p {port}"
-             # Need to use --interface 127.0.0.1 for the macOS GitHub runners.
+            # Need to use --interface 127.0.0.1 for the macOS GitHub runners.
             if isinstance(platform, Darwin):
                 props["DataStorm.Node.Multicast.Proxy"] = (
                     f"DataStorm/Lookup -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"

--- a/scripts/DataStormUtil.py
+++ b/scripts/DataStormUtil.py
@@ -30,7 +30,8 @@ class Writer(Client, DataStormProcess):
         props = DataStormProcess.getEffectiveProps(self, current, props)
         if ("DataStorm.Node.Multicast.Enabled", 1) in props.items():
             port = current.driver.getTestPort(20)
-            # Use loopback on macOS to run successfully on GitHub runners.
+            props["DataStorm.Node.Multicast.Endpoints"] = f"udp -h 239.255.0.1 -p {port}"
+             # Need to use --interface 127.0.0.1 for the macOS GitHub runners.
             if isinstance(platform, Darwin):
                 props["DataStorm.Node.Multicast.Proxy"] = (
                     f"DataStorm/Lookup -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"
@@ -62,7 +63,7 @@ class Reader(Server, DataStormProcess):
         if ("DataStorm.Node.Multicast.Enabled", 1) in props.items():
             port = current.driver.getTestPort(20)
             props["DataStorm.Node.Multicast.Endpoints"] = f"udp -h 239.255.0.1 -p {port}"
-            # Use loopback on macOS to run successfully on GitHub runners.
+            # Need to use --interface 127.0.0.1 for the macOS GitHub runners.
             if isinstance(platform, Darwin):
                 props["DataStorm.Node.Multicast.Proxy"] = (
                     f"DataStorm/Lookup -d:udp -h 239.255.0.1 -p {port} --interface 127.0.0.1"

--- a/scripts/DataStormUtil.py
+++ b/scripts/DataStormUtil.py
@@ -2,7 +2,7 @@
 
 import re
 
-from Util import Client, ClientServerTestCase, Linux, Mapping, Process, ProcessFromBinDir, Server, platform
+from Util import Client, ClientServerTestCase, Mapping, Process, ProcessFromBinDir, Server
 
 # Regex pattern to match placeholders like {port1}, {port2}, ..., {portXX}
 port_pattern = re.compile(r"{port(\d+)}")
@@ -31,13 +31,7 @@ class Writer(Client, DataStormProcess):
         if ("DataStorm.Node.Multicast.Enabled", 1) in props.items():
             port = current.driver.getTestPort(20)
             props["DataStorm.Node.Multicast.Endpoints"] = f"udp -h 239.255.0.1 -p {port}"
-            # We can't use --interface 127.0.0.1 on Linux: the loopback interface may not support multicast.
-            if isinstance(platform, Linux):
-                props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup -d:udp -h 239.255.0.1 -p {port}"
-            else:
-                props["DataStorm.Node.Multicast.Proxy"] = (
-                    f"DataStorm/Lookup -d:udp -h 239.255.0.1 --interface 127.0.0.1 -p {port}"
-                )
+            props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup -d:udp -h 239.255.0.1 -p {port}"
         elif not any(key.startswith("DataStorm.Node.") for key in props):
             # Default properties for tests that don't specify any DataStorm.Node.* properties
             props.update(
@@ -63,13 +57,7 @@ class Reader(Server, DataStormProcess):
         if ("DataStorm.Node.Multicast.Enabled", 1) in props.items():
             port = current.driver.getTestPort(20)
             props["DataStorm.Node.Multicast.Endpoints"] = f"udp -h 239.255.0.1 -p {port}"
-            # We can't use --interface 127.0.0.1 on Linux: the loopback interface may not support multicast.
-            if isinstance(platform, Linux):
-                props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup -d:udp -h 239.255.0.1 -p {port}"
-            else:
-                props["DataStorm.Node.Multicast.Proxy"] = (
-                    f"DataStorm/Lookup -d:udp -h 239.255.0.1 --interface 127.0.0.1 -p {port}"
-                )
+            props["DataStorm.Node.Multicast.Proxy"] = f"DataStorm/Lookup -d:udp -h 239.255.0.1 -p {port}"
         elif not any(key.startswith("DataStorm.Node.") for key in props):
             # Default properties for tests that don't specify any DataStorm.Node.* properties
             props.update(

--- a/swift/test/Ice/udp/AllTests.swift
+++ b/swift/test/Ice/udp/AllTests.swift
@@ -107,14 +107,11 @@ public func allTests(_ helper: TestHelper) async throws {
     output.writeLine("ok")
 
     output.write("testing udp multicast... ")
-    var endpoint = ""
-    //
-    // Use loopback to prevent other machines to answer.
-    //
+    var endpoint = "udp -h "
     if communicator.getProperties().getIceProperty("Ice.IPv6") == "1" {
-        endpoint += "udp -h \"ff15::1:1\" --interface \"::1\""
+        endpoint += "\"ff15::1:1\""
     } else {
-        endpoint += "udp -h 239.255.1.1 --interface 127.0.0.1"
+        endpoint += "239.255.1.1"
     }
     endpoint += " -p "
     endpoint += "\(helper.getTestPort(num: 10))"

--- a/swift/test/Ice/udp/AllTests.swift
+++ b/swift/test/Ice/udp/AllTests.swift
@@ -109,9 +109,9 @@ public func allTests(_ helper: TestHelper) async throws {
     output.write("testing udp multicast... ")
     var endpoint = "udp -h "
     if communicator.getProperties().getIceProperty("Ice.IPv6") == "1" {
-        endpoint += "\"ff15::1:1\""
+        endpoint += "\"ff15::1:1\" --interface \"::1\""
     } else {
-        endpoint += "239.255.1.1"
+        endpoint += "239.255.1.1 --interface 127.0.0.1"
     }
     endpoint += " -p "
     endpoint += "\(helper.getTestPort(num: 10))"

--- a/swift/test/Ice/udp/Server.swift
+++ b/swift/test/Ice/udp/Server.swift
@@ -31,14 +31,14 @@ class Server: TestHelperI, @unchecked Sendable {
             try adapter2.activate()
         }
 
-        var endpoint = ""
+        var endpoint = "udp -h "
         //
         // Use loopback to prevent other machines to answer.
         //
         if properties.getIceProperty("Ice.IPv6") == "1" {
-            endpoint += "udp -h \"ff15::1:1\" --interface \"::1\""
+            endpoint += "\"ff15::1:1\""
         } else {
-            endpoint += "udp -h 239.255.1.1 --interface 127.0.0.1"
+            endpoint += "239.255.1.1"
         }
         endpoint += " -p "
         endpoint += "\(getTestPort(properties: properties, num: 10))"


### PR DESCRIPTION
We run these tests on GitHub runners that should be isolated from other runners.