### PR TITLE
Remove work-around in C# UdpTransceiver

### DIFF
--- a/csharp/src/Ice/Internal/UdpTransceiver.cs
+++ b/csharp/src/Ice/Internal/UdpTransceiver.cs
@@ -200,9 +200,7 @@ internal sealed class UdpTransceiver : Transceiver
                     }
                 }
 
-                // TODO: Workaround for https://github.com/dotnet/corefx/issues/31182
-                if (_state == StateConnected ||
-                   (AssemblyUtil.isMacOS && _fd.AddressFamily == AddressFamily.InterNetworkV6 && _fd.DualMode))
+                if (_state == StateConnected)
                 {
                     ret = _fd.Receive(buf.b.rawBytes(), 0, buf.b.limit(), SocketFlags.None);
                 }
@@ -272,9 +270,7 @@ internal sealed class UdpTransceiver : Transceiver
 
         try
         {
-            // TODO: Workaround for https://github.com/dotnet/corefx/issues/31182
-            if (_state == StateConnected ||
-               (AssemblyUtil.isMacOS && _fd.AddressFamily == AddressFamily.InterNetworkV6 && _fd.DualMode))
+            if (_state == StateConnected)
             {
                 _readCallback = callback;
                 _readEventArgs.UserToken = state;
@@ -326,9 +322,7 @@ internal sealed class UdpTransceiver : Transceiver
                 throw new System.Net.Sockets.SocketException((int)_readEventArgs.SocketError);
             }
             ret = _readEventArgs.BytesTransferred;
-            // TODO: Workaround for https://github.com/dotnet/corefx/issues/31182
-            if (_state != StateConnected &&
-               !(AssemblyUtil.isMacOS && _fd.AddressFamily == AddressFamily.InterNetworkV6 && _fd.DualMode))
+            if (_state != StateConnected)
             {
                 _peerAddr = _readEventArgs.RemoteEndPoint;
             }

--- a/csharp/test/Ice/udp/Server.cs
+++ b/csharp/test/Ice/udp/Server.cs
@@ -11,11 +11,6 @@ public class Server : global::Test.TestHelper
         Ice.Properties properties = createTestProperties(ref args);
         properties.setProperty("Ice.Warn.Connections", "0");
         properties.setProperty("Ice.UDP.RcvSize", "16384");
-        if (Ice.Internal.AssemblyUtil.isMacOS && properties.getIcePropertyAsInt("Ice.IPv6") > 0)
-        {
-            // Disable dual mode sockets on macOS, see https://github.com/dotnet/corefx/issues/31182
-            properties.setProperty("Ice.IPv4", "0");
-        }
 
         using var communicator = initialize(properties);
         int num = 0;


### PR DESCRIPTION
The bug was fixed, we no longer need the work-around.