### PR TITLE
Suppress logging of ONE when session destroyed via SessionControl (Glacier2)

### DIFF
--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -65,7 +65,7 @@ namespace Glacier2
                     {
                         rethrow_exception(e);
                     }
-                    catch (const Ice::ObjectNotExistException& ex)
+                    catch (const Ice::ObjectNotExistException&)
                     {
                         // Ignored. This typically occurs when the application-provided session calls
                         // SessionControl::destroy in its own destroy implementation.

--- a/cpp/src/Glacier2/SessionRouterI.h
+++ b/cpp/src/Glacier2/SessionRouterI.h
@@ -136,15 +136,22 @@ namespace Glacier2
         [[nodiscard]] Ice::ObjectPtr getClientBlobject(const Ice::ConnectionPtr&, const Ice::Identity&) const;
         [[nodiscard]] Ice::ObjectPtr getServerBlobject(const std::string&) const;
 
-        void destroySession(const Ice::ConnectionPtr&);
+        /// Destroys the Glacier2 internal session.
+        /// @param connection The client->Glacier router connection that identifies the session to destroy.
+        /// @param error A callback that the implementation calls when the destruction of the application-provided
+        /// session fails (see SessionManager). When nullptr (the default), the implementation uses a default error
+        /// handler that logs all exceptions.
+        void
+        destroySession(const Ice::ConnectionPtr& connection, std::function<void(std::exception_ptr)> error = nullptr);
 
         [[nodiscard]] int sessionTraceLevel() const { return _sessionTraceLevel; }
+
+        /// Provides the default handling of exceptions thrown by the destruction of application-provided sessions.
+        void sessionDestroyException(std::exception_ptr);
 
     private:
         [[nodiscard]] std::shared_ptr<RouterI>
         getRouterImpl(const Ice::ConnectionPtr&, const Ice::Identity&, bool) const;
-
-        void sessionDestroyException(std::exception_ptr);
 
         bool startCreateSession(const std::shared_ptr<CreateSession>&, const Ice::ConnectionPtr&);
         void finishCreateSession(const Ice::ConnectionPtr&, const std::shared_ptr<RouterI>&);

--- a/cpp/src/Glacier2/SessionRouterI.h
+++ b/cpp/src/Glacier2/SessionRouterI.h
@@ -137,7 +137,7 @@ namespace Glacier2
         [[nodiscard]] Ice::ObjectPtr getServerBlobject(const std::string&) const;
 
         /// Destroys the Glacier2 internal session.
-        /// @param connection The client->Glacier router connection that identifies the session to destroy.
+        /// @param connection The client->Glacier2 router connection that identifies the session to destroy.
         /// @param error A callback that the implementation calls when the destruction of the application-provided
         /// session fails (see SessionManager). When nullptr (the default), the implementation uses a default error
         /// handler that logs all exceptions.

--- a/cpp/src/Glacier2/SessionRouterI.h
+++ b/cpp/src/Glacier2/SessionRouterI.h
@@ -8,6 +8,7 @@
 #include "Ice/Ice.h"
 #include "Instrumentation.h"
 
+#include <functional>
 #include <set>
 
 namespace Glacier2
@@ -139,17 +140,17 @@ namespace Glacier2
         /// Destroys the Glacier2 internal session.
         /// @param connection The client->Glacier2 router connection that identifies the session to destroy.
         /// @param error A callback that the implementation calls when the destruction of the application-provided
-        /// session fails (see SessionManager). When nullptr (the default), the implementation uses a default error
-        /// handler that logs all exceptions.
-        void
-        destroySession(const Ice::ConnectionPtr& connection, std::function<void(std::exception_ptr)> error = nullptr);
+        /// session fails (see SessionManager).
+        void destroySession(const Ice::ConnectionPtr& connection, std::function<void(std::exception_ptr)> error);
 
         [[nodiscard]] int sessionTraceLevel() const { return _sessionTraceLevel; }
 
         /// Provides the default handling of exceptions thrown by the destruction of application-provided sessions.
-        void sessionDestroyException(std::exception_ptr);
+        [[nodiscard]] std::function<void(std::exception_ptr)> defaultSessionDestroyExceptionHandler() const;
 
     private:
+        void sessionDestroyException(std::exception_ptr) const;
+
         [[nodiscard]] std::shared_ptr<RouterI>
         getRouterImpl(const Ice::ConnectionPtr&, const Ice::Identity&, bool) const;
 


### PR DESCRIPTION
When you create sessions with a Glacier2 session manager, it's common to get the following code flow:

MySession::destroy calls destroy SessionControl proxy
SessionControl::destroy calls destroy on Session proxy, implemented by MySession

To avoid an infinite recursion, MySession::destroy unregisters itself from its object adapter before calling destroy on the SessionControl proxy. That's what the Glacier2/Session demo shows.

This PR updates the Glacier2 router code to avoid logging ObjectNotExistException when the call to the Session proxy (via SessionControl), since that's expected behavior.