### PR TITLE
Better iOS simulator boot

### DIFF
--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -2701,7 +2701,7 @@ class iOSSimulatorDevice:
             return device["state"] == "Booted"
         return False
 
-    def get() -> dict[str, str] | None:
+    def get(self) -> dict[str, str] | None:
         output = run("xcrun simctl list devices --json")
         data = json.loads(output)
         for runtime, device_list in data["devices"].items():


### PR DESCRIPTION
For reasons unknown `xcrun simctl bootstatus` seems to hang quite often on the GitHub runner. When I tried printing the simulator state after a timeout the simulator seems to be booted. 

Instead of using this command, this PR polls the boot status (similar to what we do for Android).

It also adds a log file for the Python  driver communicator. 