### PR TITLE
Fix extraction of Slice files in the Gradle user directory

### DIFF
--- a/java/tools/slice-tools/src/main/kotlin/com/zeroc/slice/tools/SliceToolsResourceExtractor.kt
+++ b/java/tools/slice-tools/src/main/kotlin/com/zeroc/slice/tools/SliceToolsResourceExtractor.kt
@@ -79,7 +79,9 @@ object SliceToolsResourceExtractor {
                 .toList()
 
             for (resource in resourcePaths) {
-                val relativePath = resource.removePrefix("resources/slice/")
+                // Remove the leading "/resources/slice/" to get the relative path, the resourcePath contains a leading "/"
+                // which is not include in the jar entry resource name.
+                val relativePath = resource.removePrefix(resourcePath.removePrefix("/"))
 
                 val outputFile = File(targetDir, relativePath)
 


### PR DESCRIPTION
A small for an issue reported by @InsertCreativityHere when trying to include the built-in Slice files.

The files where extracted to `slice-tools-3.8.0-nightly-20251016.1-SNAPSHOT\slice\resources\slice` instead of `slice-tools-3.8.0-nightly-20251016.1-SNAPSHOT\slice\`