### PR TITLE
Fix for publishing nightly brew packages

### DIFF
--- a/.github/workflows/build-macos-packages.yml
+++ b/.github/workflows/build-macos-packages.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           prefix: build-brew-packages
 
-      - name: Update and Push Nightly Tap
+      - name: Update Nightly Tap
         run: |
           ./packaging/brew/update-nightly-tap.sh "${{ inputs.ice_version }}" "https://download.zeroc.com/ice/nightly"
 

--- a/.github/workflows/publish-misc-packages.yml
+++ b/.github/workflows/publish-misc-packages.yml
@@ -162,10 +162,15 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          repository: zeroc-ice/homebrew-nightly
+          path: homebrew-nightly
+
       - name: Publish Homebrew Patch
         run: |
           set -euo pipefail
-          cd "$(brew --repo zeroc-ice/nightly)"
           # Configure git for pushing the patch
           git config user.name "ZeroC"
           git config user.email "git@zeroc.com"
@@ -174,3 +179,4 @@ jobs:
           git apply staging/homebrew-bottle/*.patch
           # Push the updated formula
           git push origin main || { echo "Push failed"; exit 1; }
+        working-directory: homebrew-nightly


### PR DESCRIPTION
This is a fix for 

```
/Users/runner/work/_temp/46db40f0-5452-41bd-9e4a-c25792497ac4.sh: line 2: cd: /opt/homebrew/Library/Taps/zeroc-ice/homebrew-nightly: No such file or directory
```

In latest Nightly build https://github.com/zeroc-ice/ice/actions/runs/18580544553/job/52977241268