### PR TITLE
Enable DataStorm property prefix all the time

### DIFF
--- a/config/PropertyNames.xml
+++ b/config/PropertyNames.xml
@@ -396,7 +396,7 @@
         <property name="Trace.Session" languages="cpp" default="0" />
     </section>
 
-    <section name="DataStorm" opt-in="true">
+    <section name="DataStorm" opt-in="false">
         <property name="Node.ConnectTo" languages="cpp" />
         <property name="Node.Multicast" class="ObjectAdapter" languages="cpp" />
         <property name="Node.Multicast.Enabled" default="1" languages="cpp" />

--- a/cpp/include/DataStorm/Node.h
+++ b/cpp/include/DataStorm/Node.h
@@ -103,11 +103,8 @@ namespace DataStorm
     private:
         template<typename ArgvT> NodeOptions createNodeOptions(int& argc, ArgvT argv)
         {
-            Ice::InitializationData initData;
-            initData.properties = std::make_shared<Ice::Properties>(argc, argv, "DataStorm");
-
             NodeOptions options;
-            options.communicator = Ice::initialize(std::move(initData));
+            options.communicator = Ice::initialize(argc, argv);
             options.nodeOwnsCommunicator = true;
             return options;
         }

--- a/cpp/src/DataStorm/Node.cpp
+++ b/cpp/src/DataStorm/Node.cpp
@@ -10,15 +10,6 @@ using namespace std;
 using namespace DataStorm;
 using namespace Ice;
 
-namespace
-{
-    CommunicatorPtr createCommunicator()
-    {
-        InitializationData initData{.properties = make_shared<Properties>("DataStorm")};
-        return initialize(std::move(initData));
-    }
-}
-
 const char*
 NodeShutdownException::what() const noexcept
 {
@@ -35,7 +26,7 @@ Node::Node(NodeOptions options)
     else
     {
         _ownsCommunicator = true;
-        communicator = createCommunicator(); // the only call that can throw up to here
+        communicator = Ice::initialize(); // the only call that can throw up to here
     }
 
     try

--- a/cpp/src/Ice/PropertyNames.cpp
+++ b/cpp/src/Ice/PropertyNames.cpp
@@ -580,7 +580,7 @@ const PropertyArray PropertyNames::DataStormProps
 {
     .name="DataStorm",
     .prefixOnly=false,
-    .isOptIn=true,
+    .isOptIn=false,
     .properties=DataStormPropsData,
     .length=19
 };

--- a/cpp/test/DataStorm/api/Writer.cpp
+++ b/cpp/test/DataStorm/api/Writer.cpp
@@ -31,32 +31,10 @@ void ::Writer::run(int argc, char* argv[])
         }
 
         {
-            // Communicators shared with DataStorm must have a property set that can use the "DataStorm" opt-in prefix.
-            Ice::InitializationData initData;
-            initData.properties = make_shared<Ice::Properties>("DataStorm");
-            Ice::CommunicatorHolder communicatorHolder{Ice::initialize(initData)};
-            Node n2{communicatorHolder.communicator()};
+            Ice::CommunicatorPtr communicator = Ice::initialize();
+            Ice::CommunicatorHolder communicatorHolder{communicator};
+            Node n2{communicator};
         }
-
-        Ice::InitializationData initData;
-        initData.properties = make_shared<Ice::Properties>("DataStorm");
-        auto c = Ice::initialize(initData);
-        {
-            Node n22(c);
-        }
-        {
-            const Ice::CommunicatorPtr& c2 = c;
-            Node n23(c2);
-        }
-        {
-            const Ice::CommunicatorPtr& c3 = c;
-            Node n24(c3);
-        }
-        {
-            Ice::CommunicatorPtr& c4 = c;
-            Node n25(c4);
-        }
-        c->destroy();
 
         Node n3;
 

--- a/cpp/test/DataStorm/callbacks/Reader.cpp
+++ b/cpp/test/DataStorm/callbacks/Reader.cpp
@@ -30,9 +30,8 @@ void ::Reader::run(int argc, char* argv[])
         }
     }
 
-    Ice::InitializationData initData{.properties = Ice::createProperties(argc, argv, "DataStorm")};
     NodeOptions options{
-        .communicator = Ice::initialize(std::move(initData)),
+        .communicator = Ice::initialize(argc, argv),
         .nodeOwnsCommunicator = true,
         .customExecutor = std::move(customExecutor)};
 

--- a/cpp/test/DataStorm/callbacks/Writer.cpp
+++ b/cpp/test/DataStorm/callbacks/Writer.cpp
@@ -30,9 +30,8 @@ void ::Writer::run(int argc, char* argv[])
         }
     }
 
-    Ice::InitializationData initData{.properties = Ice::createProperties(argc, argv, "DataStorm")};
     NodeOptions options{
-        .communicator = Ice::initialize(std::move(initData)),
+        .communicator = Ice::initialize(argc, argv),
         .nodeOwnsCommunicator = true,
         .customExecutor = std::move(customExecutor)};
 

--- a/csharp/src/Ice/Internal/PropertyNames.cs
+++ b/csharp/src/Ice/Internal/PropertyNames.cs
@@ -294,7 +294,7 @@ internal sealed class PropertyNames
     internal static PropertyArray DataStormProps = new(
         "DataStorm",
         false,
-        true,
+        false,
         []);
 
     internal static PropertyArray[] validProps =

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PropertyNames.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/PropertyNames.java
@@ -317,7 +317,7 @@ final class PropertyNames {
     public static final PropertyArray DataStormProps = new PropertyArray(
         "DataStorm",
         false,
-        true,
+        false,
         new Property[] {
         });
 

--- a/js/src/Ice/PropertyNames.js
+++ b/js/src/Ice/PropertyNames.js
@@ -131,7 +131,7 @@ PropertyNames.Glacier2Props = new PropertyArray("Glacier2", false, true);
 PropertyNames.Glacier2Props.properties = [
 ];
 
-PropertyNames.DataStormProps = new PropertyArray("DataStorm", false, true);
+PropertyNames.DataStormProps = new PropertyArray("DataStorm", false, false);
 PropertyNames.DataStormProps.properties = [
 ];
 


### PR DESCRIPTION
This PR enables the DataStorm property prefix all the time, because it's legitimate for user applications to create their own communicators with DataStorm properties.