### PR TITLE
Un-deprecate createProperties in C#, Java, and MATLAB

### DIFF
--- a/cpp/include/Ice/Properties.h
+++ b/cpp/include/Ice/Properties.h
@@ -294,6 +294,8 @@ namespace Ice
     /// Creates a new shared Properties object.
     /// @param args The arguments to forward to `make_shared<Properties>`.
     /// @return A new property set.
+    /// @remarks This function is provided for backwards compatibility. New code should call
+    /// `std::make_shared<Properties>` directly.
     template<class... T> inline PropertiesPtr createProperties(T&&... args)
     {
         return std::make_shared<Properties>(std::forward<T>(args)...);

--- a/csharp/src/Ice/Util.cs
+++ b/csharp/src/Ice/Util.cs
@@ -15,7 +15,8 @@ public sealed class Util
     /// Creates a new empty property set.
     /// </summary>
     /// <returns>A new empty property set.</returns>
-    [Obsolete("Use the Ice.Properties parameterless constructor instead.")]
+    /// <remarks>This method is provided for backwards compatibility. New code should call the
+    /// <see cref="Properties.Properties()" /> constructor directly.</remarks>
     public static Properties createProperties() => new();
 
     /// <summary>
@@ -24,9 +25,8 @@ public sealed class Util
     /// <param name="args">The command-line arguments.</param>
     /// <param name="defaults">Default values for the new property set.</param>
     /// <returns>A new property set.</returns>
-    /// <remarks>See <see cref="Properties.Properties(ref string[], Properties?)" /> for a detailed description of the behavior of
-    /// this deprecated factory method.</remarks>
-    [Obsolete("Use the Ice.Properties constructor instead.")]
+    /// <remarks>This method is provided for backwards compatibility. New code should call the
+    /// <see cref="Properties.Properties(ref string[], Properties?)" /> constructor directly.</remarks>
     public static Properties createProperties(ref string[] args, Properties? defaults = null) =>
         new(ref args, defaults);
 

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
@@ -6,7 +6,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.Identity;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadFactory;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.security.Identity;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadFactory;
@@ -13,65 +14,58 @@ import java.util.concurrent.ThreadFactory;
 /** Utility methods for the Ice runtime. */
 public final class Util {
     /**
-     * Creates a new empty property set.
+     * Creates a new empty property set. This method is provided for backwards compatibility. New code should call the
+     * {@link Properties#Properties()} constructor directly.
      *
      * @return A new empty property set.
-     * @deprecated Use {@link Properties#Properties()} instead.
      */
-    @Deprecated
     public static Properties createProperties() {
         return new Properties();
     }
 
     /**
-     * Creates a property set initialized from command-line arguments. See {@link Properties#Properties(String[])} for
-     * a detailed description of the behavior of this deprecated factory method.
+     * Creates a property set initialized from command-line arguments. This method is provided for backwards
+     * compatibility. New code should call the {@link Properties#Properties(String[])} constructor directly.
      *
      * @param args The command-line arguments.
      * @return A new property set.
-     * @deprecated Use {@link Properties#Properties(String[])} instead.
      */
-    @Deprecated
     public static Properties createProperties(String[] args) {
         return new Properties(args);
     }
 
     /**
-     * Creates a property set initialized from command-line arguments. See
-     * {@link Properties#Properties(String[], java.util.List)} for a detailed description of the behavior of this
-     * deprecated factory method.
+     * Creates a property set initialized from command-line arguments. This method is provided for backwards
+     * compatibility. New code should call the {@link Properties#Properties(String[], java.util.List)} constructor
+     * directly.
      *
      * @param args The command-line arguments.
      * @param remainingArgs If non-null, the command-line arguments that remain after parsing Ice properties out of
      *     {@code args}.
      * @return A new property set.
-     * @deprecated Use {@link Properties#Properties(String[], java.util.List)} instead.
      */
-    @Deprecated
     public static Properties createProperties(String[] args, List<String> remainingArgs) {
         return new Properties(args, remainingArgs);
     }
 
     /**
-     * Creates a property set initialized from command-line arguments and default properties. See
-     * {@link Properties#Properties(String[], Properties)} for a detailed description of the behavior of this deprecated
-     * factory method.
+     * Creates a property set initialized from command-line arguments and default properties. This method is provided
+     * for backwards compatibility. New code should call the {@link Properties#Properties(String[], Properties)}
+     * constructor directly.
      *
      * @param args The command-line arguments.
      * @param defaults Default values for the property set. Settings in configuration files and
      *     {@code args} override these defaults.
      * @return A new property set.
-     * @deprecated Use {@link Properties#Properties(String[], Properties)} instead.
      */
-    @Deprecated
     public static Properties createProperties(String[] args, Properties defaults) {
         return new Properties(args, defaults);
     }
 
     /**
-     * Creates a property set initialized from command-line arguments and default properties. See
-     * {@link Properties#Properties(String[], Properties, java.util.List)} for a detailed description of the behavior of
-     * this deprecated factory method.
+     * Creates a property set initialized from command-line arguments and default properties. This method is provided
+     * for backwards compatibility. New code should call the
+     * {@link Properties#Properties(String[], Properties, java.util.List)} constructor directly.
      *
      * @param args The command-line arguments.
      * @param defaults Default values for the property set. Settings in configuration files and
@@ -79,9 +73,7 @@ public final class Util {
      * @param remainingArgs If non-null, the command-line arguments that remain after parsing Ice properties out of
      *     {@code args}.
      * @return A new property set.
-     * @deprecated Use {@link Properties#Properties(String[], Properties, java.util.List)} instead.
      */
-    @Deprecated
     public static Properties createProperties(
             String[] args, Properties defaults, List<String> remainingArgs) {
         return new Properties(args, defaults, remainingArgs);

--- a/matlab/lib/+Ice/createProperties.m
+++ b/matlab/lib/+Ice/createProperties.m
@@ -1,6 +1,7 @@
 function [properties, remArgs] = createProperties(args, defaults)
-    %CREATEPROPERTIES Deprecated function to create an Ice.Properties object. Use the Ice.Properties constructor
-    %   instead.
+    %CREATEPROPERTIES Creates an Ice.Properties object.
+    %   This function is provided for backwards compatibility. New code should call the Ice.Properties constructor
+    %   directly.
     %
     %   Input Arguments
     %     args - An optional argument vector.
@@ -15,6 +16,9 @@ function [properties, remArgs] = createProperties(args, defaults)
     %       string array
     %
     %   See also Ice.Properties/Properties.
+
+    % Copyright (c) ZeroC, Inc.
+
     arguments
         args (1, :) string = string.empty
         defaults Ice.Properties {mustBeScalarOrEmpty} = Ice.Properties.empty

--- a/matlab/test/Ice/properties/Client.m
+++ b/matlab/test/Ice/properties/Client.m
@@ -35,7 +35,7 @@ function client(args)
     fprintf('ok\n');
 
     fprintf('testing ice properties with set default values...');
-    props = Ice.createProperties(); % deprecated function
+    props = Ice.createProperties();
     toStringMode = props.getIceProperty('Ice.ToStringMode');
     assert(strcmp(toStringMode, 'Unicode'));
     closeTimeout = props.getIcePropertyAsInt('Ice.Connection.Client.CloseTimeout');


### PR DESCRIPTION
This PR undeprecates createProperties in  C#, Java, and MATLAB, and adds comments like:

```
This method is provided for backwards compatibility. New code should call the {@link Properties#Properties(String[], java.util.List)} constructor directly.
```

It was one of the very newly deprecated functions in 3.8. Furthermore, in many languages (Swift, Python, PHP, Ruby), createProperties is actually the only API to create properties.