### PR TITLE
Set Ice.ProgramName in initialize

### DIFF
--- a/cpp/include/Ice/Properties.h
+++ b/cpp/include/Ice/Properties.h
@@ -76,7 +76,7 @@ namespace Ice
         /// @param defaults Default values for the new Properties object. Settings in configuration files and the
         /// arguments override these defaults.
         /// @remarks This constructor loads properties from files specified by the `ICE_CONFIG` environment variable
-        /// when there is no `--Ice.Config` command-line argument. It also gives `Ice.ProgramName` a default value.
+        /// when there is no `--Ice.Config` command-line argument.
         explicit Properties(StringSeq& args, const PropertiesPtr& defaults = nullptr);
 
         /// Constructs a property set, loads the configuration files specified by the `Ice.Config` property or the
@@ -92,7 +92,7 @@ namespace Ice
         /// @param defaults Default values for the new Properties object. Settings in configuration files and the
         /// arguments override these defaults.
         /// @remarks This constructor loads properties from files specified by the `ICE_CONFIG` environment variable
-        /// when there is no `--Ice.Config` command-line argument. It also gives `Ice.ProgramName` a default value.
+        /// when there is no `--Ice.Config` command-line argument.
         template<typename ArgvT>
         Properties(int& argc, ArgvT argv, const PropertiesPtr& defaults = nullptr) : Properties{defaults}
         {
@@ -124,7 +124,7 @@ namespace Ice
         /// @param firstOptInPrefix The first opt-in prefix.
         /// @param remainingOptInPrefixes The remaining opt-in prefixes.
         /// @remarks This constructor loads properties from files specified by the `ICE_CONFIG` environment variable
-        /// when there is no `--Ice.Config` command-line argument. It also gives `Ice.ProgramName` a default value.
+        /// when there is no `--Ice.Config` command-line argument.
         template<typename ArgvT, typename... T>
         Properties(int& argc, ArgvT argv, std::string firstOptInPrefix, T... remainingOptInPrefixes)
             : Properties{std::move(firstOptInPrefix), std::move(remainingOptInPrefixes)...}

--- a/cpp/src/Ice/Properties.cpp
+++ b/cpp/src/Ice/Properties.cpp
@@ -841,33 +841,10 @@ Ice::Properties::Properties(const PropertiesPtr& defaults)
 void
 Ice::Properties::loadArgs(StringSeq& args)
 {
-    auto q = args.begin();
-
-    auto p = _propertySet.find("Ice.ProgramName");
-    if (p == _propertySet.end())
-    {
-        if (q != args.end())
-        {
-            //
-            // Use the first argument as the value for Ice.ProgramName. Replace
-            // any backslashes in this value with forward slashes, in case this
-            // value is used by the event logger.
-            //
-            string name = *q;
-            replace(name.begin(), name.end(), '\\', '/');
-
-            PropertyValue pv{std::move(name), true};
-            _propertySet["Ice.ProgramName"] = pv;
-        }
-    }
-    else
-    {
-        p->second.used = true;
-    }
-
     StringSeq tmp;
-
     bool loadConfigFiles = false;
+
+    auto q = args.begin();
     while (q != args.end())
     {
         string s = *q;

--- a/cpp/test/Ice/properties/Client.cpp
+++ b/cpp/test/Ice/properties/Client.cpp
@@ -235,7 +235,6 @@ Client::run(int, char**)
         Ice::PropertiesPtr properties = Ice::createProperties(args);
         test(args.size() == 1);
         test(args[0] == "--Foo=Bar");
-        test(properties->getIceProperty("Ice.ProgramName") == "--Foo=Bar");
         test(properties->getIceProperty("Ice.Trace.Network") == "3");
         cout << "ok" << endl;
     }

--- a/csharp/src/Ice/Internal/Instance.cs
+++ b/csharp/src/Ice/Internal/Instance.cs
@@ -580,7 +580,15 @@ public sealed class Instance
 
         try
         {
-            _initData.properties ??= new Ice.Properties();
+            _initData.properties ??= new Properties();
+
+            string programName = _initData.properties.getIceProperty("Ice.ProgramName");
+            if (programName.Length == 0)
+            {
+                _initData.properties.setProperty("Ice.ProgramName", AppDomain.CurrentDomain.FriendlyName);
+                // Re-read it to mark it as used.
+                programName = _initData.properties.getIceProperty("Ice.ProgramName");
+            }
 
             lock (_staticLock)
             {
@@ -637,17 +645,15 @@ public sealed class Instance
                 string logfile = _initData.properties.getIceProperty("Ice.LogFile");
                 if (logfile.Length != 0)
                 {
-                    _initData.logger =
-                        new Ice.FileLoggerI(_initData.properties.getIceProperty("Ice.ProgramName"), logfile);
+                    _initData.logger = new FileLoggerI(programName, logfile);
                 }
-                else if (Ice.Util.getProcessLogger() is Ice.LoggerI)
+                else if (Ice.Util.getProcessLogger() is LoggerI)
                 {
                     //
                     // Ice.ConsoleListener is enabled by default.
                     //
                     bool console = _initData.properties.getIcePropertyAsInt("Ice.ConsoleListener") > 0;
-                    _initData.logger =
-                        new Ice.TraceLoggerI(_initData.properties.getIceProperty("Ice.ProgramName"), console);
+                    _initData.logger = new Ice.TraceLoggerI(programName, console);
                 }
                 else
                 {

--- a/csharp/src/Ice/Properties.cs
+++ b/csharp/src/Ice/Properties.cs
@@ -43,8 +43,7 @@ public sealed class Properties
     /// <param name="defaults">Default values for the new Properties object. Settings in configuration files and the
     /// arguments override these defaults.</param>
     /// <remarks>This constructor loads properties from files specified by the <c>ICE_CONFIG</c> environment variable
-    /// when there is no <c>--Ice.Config</c> command-line argument. It also gives <c>Ice.ProgramName</c> a default
-    /// value.</remarks>
+    /// when there is no <c>--Ice.Config</c> command-line argument.</remarks>
     public Properties(ref string[] args, Properties? defaults = null)
         : this(defaults) =>
         loadArgs(ref args);
@@ -61,8 +60,7 @@ public sealed class Properties
     /// precedence.</param>
     /// <param name="optInPrefixes">Optional reserved prefixes to enable in this new Properties object.</param>
     /// <remarks>This constructor loads properties from files specified by the <c>ICE_CONFIG</c> environment variable
-    /// when there is no <c>--Ice.Config</c> command-line argument. It also gives <c>Ice.ProgramName</c> a default
-    /// value.</remarks>
+    /// when there is no <c>--Ice.Config</c> command-line argument.</remarks>
     [EditorBrowsable(EditorBrowsableState.Never)] // hidden because optInPrefixes is only for internal use in C#
     public Properties(ref string[] args, ImmutableList<string> optInPrefixes)
     {
@@ -623,15 +621,6 @@ public sealed class Properties
     // Helper method called exclusively by constructors.
     private void loadArgs(ref string[] args)
     {
-        if (_propertySet.TryGetValue("Ice.ProgramName", out PropertyValue? pv))
-        {
-            pv.used = true;
-        }
-        else
-        {
-            _propertySet["Ice.ProgramName"] = new PropertyValue(AppDomain.CurrentDomain.FriendlyName, true);
-        }
-
         bool loadConfigFiles = false;
 
         for (int i = 0; i < args.Length; i++)

--- a/csharp/test/Ice/admin/AllTests.cs
+++ b/csharp/test/Ice/admin/AllTests.cs
@@ -211,9 +211,10 @@ public class AllTests : global::Test.AllTests
             // Test: PropertiesAdmin::getProperties()
             //
             Dictionary<string, string> pd = pa.getPropertiesForPrefix("");
-            test(pd.Count == 5);
+            test(pd.Count == 6);
             test(pd["Ice.Admin.Endpoints"] == "tcp -h 127.0.0.1");
             test(pd["Ice.Admin.InstanceName"] == "Test");
+            test(pd["Ice.ProgramName"] == "server");
             test(pd["Prop1"] == "1");
             test(pd["Prop2"] == "2");
             test(pd["Prop3"] == "3");

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Instance.java
@@ -564,6 +564,9 @@ public final class Instance {
 
             Properties properties = _initData.properties;
 
+            // TODO: set a fallback value like in C#.
+            String programName = properties.getIceProperty("Ice.ProgramName");
+
             synchronized (Instance.class) {
                 if (!_oneOffDone) {
                     String stdOut = properties.getIceProperty("Ice.StdOut");
@@ -620,18 +623,16 @@ public final class Instance {
                     }
                     _initData.logger =
                         new SysLoggerI(
-                            properties.getIceProperty("Ice.ProgramName"),
+                            programName,
                             properties.getIceProperty("Ice.SyslogFacility"),
                             properties.getIceProperty("Ice.SyslogHost"),
                             properties.getIcePropertyAsInt("Ice.SyslogPort"));
                 } else if (!logFile.isEmpty()) {
-                    _initData.logger =
-                        new FileLoggerI(properties.getIceProperty("Ice.ProgramName"), logFile);
+                    _initData.logger = new FileLoggerI(programName, logFile);
                 } else {
                     _initData.logger = Util.getProcessLogger();
                     if (_initData.logger instanceof LoggerI) {
-                        _initData.logger =
-                            new LoggerI(properties.getIceProperty("Ice.ProgramName"));
+                        _initData.logger = new LoggerI(programName);
                     }
                 }
             }


### PR DESCRIPTION
This PR updates the C++ and C# code to set Ice.ProgramName in initialize instead of the Properties code itself.

This is a partial fix for #4565.