### PR TITLE
Don't set connection properties in colloc tests

### DIFF
--- a/cpp/test/Ice/exceptions/Collocated.cpp
+++ b/cpp/test/Ice/exceptions/Collocated.cpp
@@ -17,8 +17,7 @@ void
 Collocated::run(int argc, char** argv)
 {
     Ice::PropertiesPtr properties = createTestProperties(argc, argv);
-    properties->setProperty("Ice.MessageSizeMax", "10"); // 10KB max
-    properties->setProperty("Ice.Warn.Connections", "0");
+    // No need to set connection properties such as Ice.Warn.Connections or Ice.MessageSizeMax.
     properties->setProperty("Ice.Warn.Dispatch", "0");
 
     Ice::CommunicatorHolder communicator = initialize(argc, argv, properties);

--- a/cpp/test/Ice/metrics/Collocated.cpp
+++ b/cpp/test/Ice/metrics/Collocated.cpp
@@ -22,7 +22,6 @@ Collocated::run(int argc, char** argv)
     initData.properties->setProperty("Ice.Admin.Endpoints", "tcp");
     initData.properties->setProperty("Ice.Admin.InstanceName", "client");
     initData.properties->setProperty("Ice.Admin.DelayCreation", "1");
-    initData.properties->setProperty("Ice.Warn.Connections", "0");
     initData.properties->setProperty("Ice.Warn.Dispatch", "0");
     CommunicatorObserverIPtr observer = make_shared<CommunicatorObserverI>();
     initData.observer = observer;

--- a/cpp/test/Ice/retry/Collocated.cpp
+++ b/cpp/test/Ice/retry/Collocated.cpp
@@ -33,11 +33,6 @@ Collocated::run(int argc, char** argv)
     initData.observer = getObserver();
 
     initData.properties->setProperty("Ice.RetryIntervals", "0 1 10 1");
-
-    //
-    // This test kills connections, so we don't want warnings.
-    //
-    initData.properties->setProperty("Ice.Warn.Connections", "0");
     initData.properties->setProperty("Ice.Warn.Dispatch", "0");
 
     installTransport(initData);

--- a/csharp/test/Ice/exceptions/Collocated.cs
+++ b/csharp/test/Ice/exceptions/Collocated.cs
@@ -10,9 +10,8 @@ public class Collocated : TestHelper
     {
         var initData = new InitializationData();
         initData.properties = createTestProperties(ref args);
-        initData.properties.setProperty("Ice.Warn.Connections", "0");
         initData.properties.setProperty("Ice.Warn.Dispatch", "0");
-        initData.properties.setProperty("Ice.MessageSizeMax", "10"); // 10KB max
+        // No need to set connection properties such as Ice.Warn.Connections or Ice.MessageSizeMax.
         await using var communicator = initialize(initData);
         communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
         Ice.ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");

--- a/csharp/test/Ice/metrics/Collocated.cs
+++ b/csharp/test/Ice/metrics/Collocated.cs
@@ -19,7 +19,6 @@ public class Collocated : Test.TestHelper
         initData.properties.setProperty("Ice.Admin.Endpoints", "tcp");
         initData.properties.setProperty("Ice.Admin.InstanceName", "client");
         initData.properties.setProperty("Ice.Admin.DelayCreation", "1");
-        initData.properties.setProperty("Ice.Warn.Connections", "0");
         initData.properties.setProperty("Ice.Warn.Dispatch", "0");
         initData.properties.setProperty("Ice.Default.Host", "127.0.0.1");
 

--- a/csharp/test/Ice/retry/Collocated.cs
+++ b/csharp/test/Ice/retry/Collocated.cs
@@ -14,11 +14,6 @@ public class Collocated : TestHelper
         initData.properties = createTestProperties(ref args);
         initData.properties.setProperty("Ice.RetryIntervals", "0 1 10 1");
         initData.properties.setProperty("Ice.Warn.Dispatch", "0");
-
-        //
-        // This test kills connections, so we don't want warnings.
-        //
-        initData.properties.setProperty("Ice.Warn.Connections", "0");
         await using var communicator = initialize(initData);
         //
         // Configure a second communicator for the invocation timeout

--- a/java/test/src/main/java/test/Ice/exceptions/Collocated.java
+++ b/java/test/src/main/java/test/Ice/exceptions/Collocated.java
@@ -20,8 +20,7 @@ public class Collocated extends TestHelper {
 
         initData.properties = createTestProperties(args);
         initData.properties.setProperty("Ice.Warn.Dispatch", "0");
-        initData.properties.setProperty("Ice.Warn.Connections", "0");
-        initData.properties.setProperty("Ice.MessageSizeMax", "10"); // 10KB max
+        // No need to set connection properties such as Ice.Warn.Connections or Ice.MessageSizeMax.
 
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));

--- a/java/test/src/main/java/test/Ice/interrupt/Collocated.java
+++ b/java/test/src/main/java/test/Ice/interrupt/Collocated.java
@@ -15,8 +15,8 @@ public class Collocated extends TestHelper {
         var initData = new InitializationData();
         initData.sliceLoader = new ModuleToPackageSliceLoader("::Test", "test.Ice.interrupt.Test");
         initData.properties = createTestProperties(args);
-        // We need to send messages large enough to cause the transport buffers to fill up.
-        initData.properties.setProperty("Ice.MessageSizeMax", "20000");
+        // No need to set connection properties such as Ice.MessageSizeMax.
+
         // opIdempotent raises UnknownException, we disable dispatch warnings to prevent warnings.
         initData.properties.setProperty("Ice.Warn.Dispatch", "0");
 

--- a/java/test/src/main/java/test/Ice/metrics/Collocated.java
+++ b/java/test/src/main/java/test/Ice/metrics/Collocated.java
@@ -21,7 +21,6 @@ public class Collocated extends TestHelper {
         initData.properties.setProperty("Ice.Admin.Endpoints", "tcp");
         initData.properties.setProperty("Ice.Admin.InstanceName", "client");
         initData.properties.setProperty("Ice.Admin.DelayCreation", "1");
-        initData.properties.setProperty("Ice.Warn.Connections", "0");
         initData.properties.setProperty("Ice.Warn.Dispatch", "0");
         initData.properties.setProperty("Ice.Default.Host", "127.0.0.1");
         initData.observer = observer;

--- a/java/test/src/main/java/test/Ice/retry/Collocated.java
+++ b/java/test/src/main/java/test/Ice/retry/Collocated.java
@@ -25,8 +25,6 @@ public class Collocated extends TestHelper {
         initData.observer = instrumentation.getObserver();
         initData.properties = createTestProperties(args);
         initData.properties.setProperty("Ice.RetryIntervals", "0 1 10 1");
-        // We don't want connection warnings because of the timeout
-        initData.properties.setProperty("Ice.Warn.Connections", "0");
         initData.properties.setProperty("Ice.Warn.Dispatch", "0");
 
         try (Communicator communicator = initialize(initData)) {

--- a/python/test/Ice/ami/Collocated.py
+++ b/python/test/Ice/ami/Collocated.py
@@ -19,10 +19,6 @@ class Collocated(TestHelper):
     def run(self, args: list[str]):
         properties = self.createTestProperties(args)
         properties.setProperty("Ice.Warn.AMICallback", "0")
-        #
-        # This test kills connections, so we don't want warnings.
-        #
-        properties.setProperty("Ice.Warn.Connections", "0")
 
         with self.initialize(properties=properties) as communicator:
             communicator.getProperties().setProperty("TestAdapter.Endpoints", self.getTestEndpoint())

--- a/python/test/Ice/exceptions/Collocated.py
+++ b/python/test/Ice/exceptions/Collocated.py
@@ -18,7 +18,6 @@ import Ice
 class Collocated(TestHelper):
     def run(self, args: list[str]):
         properties = self.createTestProperties(args)
-        properties.setProperty("Ice.MessageSizeMax", "10")
 
         with self.initialize(properties=properties) as communicator:
             communicator.getProperties().setProperty("Ice.Warn.Dispatch", "0")

--- a/swift/test/Ice/ami/Collocated.swift
+++ b/swift/test/Ice/ami/Collocated.swift
@@ -6,24 +6,6 @@ import TestCommon
 
 class Collocated: TestHelperI, @unchecked Sendable {
     override public func run(args: [String]) async throws {
-        let properties = try createTestProperties(args)
-
-        //
-        // Disable collocation optimization to test async/await dispatch.
-        //
-        properties.setProperty(key: "Ice.Default.CollocationOptimized", value: "0")
-
-        //
-        // This test kills connections, so we don't want warnings.
-        //
-        properties.setProperty(key: "Ice.Warn.Connections", value: "0")
-
-        //
-        // Limit the recv buffer size, this test relies on the socket
-        // send() blocking after sending a given amount of data.
-        //
-        properties.setProperty(key: "Ice.TCP.RcvSize", value: "50000")
-
         let communicator = try initialize(args)
         defer {
             communicator.destroy()

--- a/swift/test/Ice/exceptions/Collocated.swift
+++ b/swift/test/Ice/exceptions/Collocated.swift
@@ -7,8 +7,7 @@ class Collocated: TestHelperI, @unchecked Sendable {
     override public func run(args: [String]) async throws {
         let properties = try createTestProperties(args)
         properties.setProperty(key: "Ice.Warn.Dispatch", value: "0")
-        properties.setProperty(key: "Ice.Warn.Connections", value: "0")
-        properties.setProperty(key: "Ice.MessageSizeMax", value: "10")  // 10KB max
+        // No need to set connection properties such as Ice.Warn.Connections or Ice.MessageSizeMax.
 
         let initData = Ice.InitializationData(properties: properties, sliceLoader: DefaultSliceLoader("IceExceptions"))
 
@@ -21,10 +20,8 @@ class Collocated: TestHelperI, @unchecked Sendable {
             key: "TestAdapter.Endpoints", value: getTestEndpoint(num: 0))
         communicator.getProperties().setProperty(
             key: "TestAdapter2.Endpoints", value: getTestEndpoint(num: 1))
-        communicator.getProperties().setProperty(key: "TestAdapter2.MessageSizeMax", value: "0")
         communicator.getProperties().setProperty(
             key: "TestAdapter3.Endpoints", value: getTestEndpoint(num: 2))
-        communicator.getProperties().setProperty(key: "TestAdapter3.MessageSizeMax", value: "1")
 
         let adapter = try communicator.createObjectAdapter("TestAdapter")
 

--- a/swift/test/Ice/operations/Collocated.swift
+++ b/swift/test/Ice/operations/Collocated.swift
@@ -17,10 +17,6 @@ class Collocated: TestHelperI, @unchecked Sendable {
         // scheduling so we suppress this warning.
         //
         properties.setProperty(key: "Ice.Warn.Dispatch", value: "0")
-        //
-        // We don't want connection warnings because of the timeout test.
-        //
-        properties.setProperty(key: "Ice.Warn.Connections", value: "0")
 
         let initData = Ice.InitializationData(properties: properties, sliceLoader: DefaultSliceLoader("IceOperations"))
         let communicator = try initialize(initData)

--- a/swift/test/Ice/retry/Collocated.swift
+++ b/swift/test/Ice/retry/Collocated.swift
@@ -7,11 +7,6 @@ class Collocated: TestHelperI, @unchecked Sendable {
     override public func run(args: [String]) async throws {
         var properties = try createTestProperties(args)
         properties.setProperty(key: "Ice.RetryIntervals", value: "0 1 10 1")
-
-        //
-        // This test kills connections, so we don't want warnings.
-        //
-        properties.setProperty(key: "Ice.Warn.Connections", value: "0")
         properties.setProperty(key: "Ice.Warn.Dispatch", value: "0")
 
         properties.setProperty(key: "TestAdapter.AdapterId", value: "RetryAdapter")


### PR DESCRIPTION
This PR removes the setting of connection properties in various colloc tests. These properties have no effect on colloc.