### PR TITLE
Fix AMI test in C# and Swift

### DIFF
--- a/csharp/test/Ice/ami/Server.cs
+++ b/csharp/test/Ice/ami/Server.cs
@@ -11,11 +11,6 @@ public class Server : TestHelper
         Ice.Properties properties = createTestProperties(ref args);
 
         //
-        // Disable collocation optimization to test async/await dispatch.
-        //
-        properties.setProperty("Ice.Default.CollocationOptimized", "0");
-
-        //
         // This test kills connections, so we don't want warnings.
         //
         properties.setProperty("Ice.Warn.Connections", "0");

--- a/swift/test/Ice/ami/Collocated.swift
+++ b/swift/test/Ice/ami/Collocated.swift
@@ -9,6 +9,11 @@ class Collocated: TestHelperI, @unchecked Sendable {
         let properties = try createTestProperties(args)
 
         //
+        // Disable collocation optimization to test async/await dispatch.
+        //
+        properties.setProperty(key: "Ice.Default.CollocationOptimized", value: "0")
+
+        //
         // This test kills connections, so we don't want warnings.
         //
         properties.setProperty(key: "Ice.Warn.Connections", value: "0")

--- a/swift/test/Ice/ami/Collocated.swift
+++ b/swift/test/Ice/ami/Collocated.swift
@@ -9,11 +9,6 @@ class Collocated: TestHelperI, @unchecked Sendable {
         let properties = try createTestProperties(args)
 
         //
-        // Disable collocation optimization to test async/await dispatch.
-        //
-        properties.setProperty(key: "Ice.Default.CollocationOptimized", value: "0")
-
-        //
         // This test kills connections, so we don't want warnings.
         //
         properties.setProperty(key: "Ice.Warn.Connections", value: "0")

--- a/swift/test/Ice/ami/Server.swift
+++ b/swift/test/Ice/ami/Server.swift
@@ -9,11 +9,6 @@ class Server: TestHelperI, @unchecked Sendable {
         let properties = try createTestProperties(args)
 
         //
-        // Disable collocation optimization to test async/await dispatch.
-        //
-        properties.setProperty(key: "Ice.Default.CollocationOptimized", value: "0")
-
-        //
         // This test kills connections, so we don't want warnings.
         //
         properties.setProperty(key: "Ice.Warn.Connections", value: "0")


### PR DESCRIPTION
Both test servers were setting Ice.Default.CollocationOptimized to 0 for no good reason.