### PR TITLE
Update ObjectAdapter thread pool creation condition

### DIFF
--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -929,13 +929,7 @@ Ice::ObjectAdapterI::initialize(optional<RouterPrx> router)
         // Otherwise the OA will use the default server thread pool.
         // This is done before the creation of the incoming connection factory as the thread pool is needed during
         // creation for the call to incFdsInUse.
-        bool createThreadPool = !properties->getProperty(_name + ".ThreadPool.Serialize").empty() ||
-                                !properties->getProperty(_name + ".ThreadPool.Size").empty() ||
-                                !properties->getProperty(_name + ".ThreadPool.SizeMax").empty() ||
-                                !properties->getProperty(_name + ".ThreadPool.SizeWarn").empty() ||
-                                !properties->getProperty(_name + ".ThreadPool.ThreadIdleTime").empty();
-
-        if (createThreadPool)
+        if (properties->getPropertiesForPrefix(_name + ".ThreadPool.").size() > 0)
         {
             _threadPool = ThreadPool::create(_instance, _name + ".ThreadPool", 0);
         }

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -1088,15 +1088,7 @@ public sealed class ObjectAdapter
         {
             // If the user configured any of the ObjectAdapter.ThreadPool properties, create a per-adapter thread pool.
             // Otherwise the OA will use the default server thread pool.
-            bool createThreadPool =
-                properties.getProperty(_name + ".ThreadPool.Serialize").Length > 0 ||
-                properties.getProperty(_name + ".ThreadPool.Size").Length > 0 ||
-                properties.getProperty(_name + ".ThreadPool.SizeMax").Length > 0 ||
-                properties.getProperty(_name + ".ThreadPool.SizeWarn").Length > 0 ||
-                properties.getProperty(_name + ".ThreadPool.StackSize").Length > 0 ||
-                properties.getProperty(_name + ".ThreadPool.ThreadIdleTime").Length > 0 ||
-                properties.getProperty(_name + ".ThreadPool.ThreadPriority").Length > 0;
-            if (createThreadPool)
+            if (properties.getPropertiesForPrefix(_name + ".ThreadPool.").Count > 0)
             {
                 _threadPool = new Ice.Internal.ThreadPool(_instance, _name + ".ThreadPool", 0);
             }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ObjectAdapter.java
@@ -1171,15 +1171,7 @@ public final class ObjectAdapter {
         try {
             // If the user configured any of the ObjectAdapter.ThreadPool properties, create a per-adapter thread pool.
             // Otherwise the OA will use the default server thread pool.
-            boolean createThreadPool =
-                !properties.getProperty(_name + ".ThreadPool.Serialize").isEmpty()
-                    || !properties.getProperty(_name + ".ThreadPool.Size").isEmpty()
-                    || !properties.getProperty(_name + ".ThreadPool.SizeMax").isEmpty()
-                    || !properties.getProperty(_name + ".ThreadPool.SizeWarn").isEmpty()
-                    || !properties.getProperty(_name + ".ThreadPool.StackSize").isEmpty()
-                    || !properties.getProperty(_name + ".ThreadPool.ThreadIdleTime").isEmpty()
-                    || !properties.getProperty(_name + ".ThreadPool.ThreadPriority").isEmpty();
-            if (createThreadPool) {
+            if (!properties.getPropertiesForPrefix(_name + ".ThreadPool.").isEmpty()) {
                 _threadPool = new ThreadPool(_instance, _name + ".ThreadPool", 0);
             }
 


### PR DESCRIPTION
This PR updates the creation of the per-OA thread pool to ensure that if any OA thread pool property is set, we create the per-OA thread pool. Previously the code only checked `ThreadPool.Size` and `ThreadPool.SizeMax` properties.