### PR TITLE
Update tests to use one log file per communicator

### DIFF
--- a/cpp/test/Common/TestHelper.cpp
+++ b/cpp/test/Common/TestHelper.cpp
@@ -255,6 +255,18 @@ Test::TestHelper::getTestPort(const Ice::PropertiesPtr& properties, int num)
     return properties->getPropertyAsIntWithDefault("Test.BasePort", 12010) + num;
 }
 
+void
+Test::TestHelper::updateLogFileProperty(const Ice::PropertiesPtr& properties, const string& suffix)
+{
+    string logFile = properties->getIceProperty("Ice.LogFile");
+    if (!logFile.empty())
+    {
+        string newLogFile = logFile.substr(0, logFile.find_last_of('.')) + suffix +
+            logFile.substr(logFile.find_last_of('.'));
+        properties->setProperty("Ice.LogFile", newLogFile);
+    }
+}
+
 Ice::PropertiesPtr
 Test::TestHelper::createTestProperties(int& argc, char* argv[], const Ice::PropertiesPtr& defaults)
 {

--- a/cpp/test/Common/TestHelper.cpp
+++ b/cpp/test/Common/TestHelper.cpp
@@ -261,8 +261,8 @@ Test::TestHelper::updateLogFileProperty(const Ice::PropertiesPtr& properties, co
     string logFile = properties->getIceProperty("Ice.LogFile");
     if (!logFile.empty())
     {
-        string newLogFile = logFile.substr(0, logFile.find_last_of('.')) + suffix +
-            logFile.substr(logFile.find_last_of('.'));
+        string newLogFile =
+            logFile.substr(0, logFile.find_last_of('.')) + suffix + logFile.substr(logFile.find_last_of('.'));
         properties->setProperty("Ice.LogFile", newLogFile);
     }
 }

--- a/cpp/test/Common/TestHelper.cpp
+++ b/cpp/test/Common/TestHelper.cpp
@@ -261,8 +261,16 @@ Test::TestHelper::updateLogFileProperty(const Ice::PropertiesPtr& properties, co
     string logFile = properties->getIceProperty("Ice.LogFile");
     if (!logFile.empty())
     {
-        string newLogFile = logFile.substr(0, logFile.find_last_of('.')) + suffix +
-            logFile.substr(logFile.find_last_of('.'));
+        size_t pos = logFile.find_last_of('.');
+        string newLogFile;
+        if (pos != string::npos)
+        {
+            newLogFile = logFile.substr(0, pos) + suffix + logFile.substr(pos);
+        }
+        else
+        {
+            newLogFile = logFile + suffix;
+        }
         properties->setProperty("Ice.LogFile", newLogFile);
     }
 }

--- a/cpp/test/Common/TestHelper.cpp
+++ b/cpp/test/Common/TestHelper.cpp
@@ -263,13 +263,13 @@ Test::TestHelper::updateLogFileProperty(const Ice::PropertiesPtr& properties, co
     {
         size_t pos = logFile.find_last_of('.');
         string newLogFile;
-        if (pos != string::npos)
+        if (pos == string::npos)
         {
-            newLogFile = logFile.substr(0, pos) + suffix + logFile.substr(pos);
+            newLogFile = logFile + suffix;
         }
         else
         {
-            newLogFile = logFile + suffix;
+            newLogFile = logFile.substr(0, pos) + suffix + logFile.substr(pos);
         }
         properties->setProperty("Ice.LogFile", newLogFile);
     }

--- a/cpp/test/Ice/idleTimeout/AllTests.cpp
+++ b/cpp/test/Ice/idleTimeout/AllTests.cpp
@@ -35,6 +35,7 @@ testConnectionAbortedByIdleCheck(const string& proxyString, const PropertiesPtr&
     initData.properties = properties->clone();
     initData.properties->setProperty("Ice.Connection.Client.IdleTimeout", "3");
     initData.properties->setProperty("Ice.Warn.Connections", "0");
+    TestHelper::updateLogFileProperty(initData.properties, "-idleTimeout=3s");
     installTransport(initData);
     Ice::CommunicatorHolder holder = initialize(initData);
     TestIntfPrx p(holder.communicator(), proxyString);
@@ -68,6 +69,7 @@ testEnableDisableIdleCheck(bool enabled, const string& proxyString, const Proper
     initData.properties->setProperty("Ice.Connection.Client.IdleTimeout", "1");
     initData.properties->setProperty("Ice.Connection.Client.EnableIdleCheck", enabled ? "1" : "0");
     initData.properties->setProperty("Ice.Warn.Connections", "0");
+    TestHelper::updateLogFileProperty(initData.properties, "-idleTimeout=1s");
     installTransport(initData);
     Ice::CommunicatorHolder holder = initialize(initData);
     TestIntfPrx p(holder.communicator(), proxyString);
@@ -97,6 +99,7 @@ testNoIdleTimeout(const string& proxyString, const PropertiesPtr& properties)
     Ice::InitializationData initData;
     initData.properties = properties->clone();
     initData.properties->setProperty("Ice.Connection.Client.IdleTimeout", "0");
+    TestHelper::updateLogFileProperty(initData.properties, "-idleTimeout=0");
     installTransport(initData);
     Ice::CommunicatorHolder holder = initialize(initData);
     TestIntfPrx p(holder.communicator(), proxyString);

--- a/cpp/test/Ice/inactivityTimeout/AllTests.cpp
+++ b/cpp/test/Ice/inactivityTimeout/AllTests.cpp
@@ -43,6 +43,7 @@ testServerInactivityTimeout(const string& proxyString, const PropertiesPtr& prop
     Ice::InitializationData initData;
     initData.properties = properties->clone();
     initData.properties->setProperty("Ice.Connection.Client.InactivityTimeout", "5");
+    TestHelper::updateLogFileProperty(initData.properties, "-inactivityTimeout=5s");
     installTransport(initData);
     Ice::CommunicatorHolder holder = initialize(initData);
     TestIntfPrx p(holder.communicator(), proxyString);

--- a/cpp/test/include/TestHelper.h
+++ b/cpp/test/include/TestHelper.h
@@ -96,6 +96,8 @@ namespace Test
         [[nodiscard]] int getTestPort(int port = 0) const;
         static int getTestPort(const Ice::PropertiesPtr&, int port = 0);
 
+        static void updateLogFileProperty(const Ice::PropertiesPtr& properties, const std::string& suffix);
+
         static Ice::PropertiesPtr createTestProperties(int&, char*[], const Ice::PropertiesPtr& = nullptr);
 
         Ice::CommunicatorPtr initialize(int& argc, char* argv[], const Ice::PropertiesPtr& properties = nullptr);

--- a/csharp/test/Ice/idleTimeout/AllTests.cs
+++ b/csharp/test/Ice/idleTimeout/AllTests.cs
@@ -59,7 +59,8 @@ internal class AllTests : global::Test.AllTests
         properties = properties.Clone();
         properties.setProperty("Ice.Connection.Client.IdleTimeout", "3");
         properties.setProperty("Ice.Warn.Connections", "0");
-        Communicator communicator = Util.initialize(new InitializationData { properties = properties });
+        global::Test.TestHelper.updateLogFileProperty(properties, "-idleTimeout=3s");
+        await using Communicator communicator = Util.initialize(new InitializationData { properties = properties });
         Test.TestIntfPrx p = Test.TestIntfPrxHelper.createProxy(communicator, proxyString);
 
         // Establish connection.
@@ -96,7 +97,8 @@ internal class AllTests : global::Test.AllTests
         properties.setProperty("Ice.Connection.Client.IdleTimeout", "1");
         properties.setProperty("Ice.Connection.Client.EnableIdleCheck", enabled ? "1" : "0");
         properties.setProperty("Ice.Warn.Connections", "0");
-        Communicator communicator = Util.initialize(new InitializationData { properties = properties });
+        global::Test.TestHelper.updateLogFileProperty(properties, "-idleTimeout=1s");
+        await using Communicator communicator = Util.initialize(new InitializationData { properties = properties });
         Test.TestIntfPrx p = Test.TestIntfPrxHelper.createProxy(communicator, proxyString);
 
         Connection? connection = await p.ice_getConnectionAsync();
@@ -123,7 +125,8 @@ internal class AllTests : global::Test.AllTests
         // Create a new communicator with the desired properties.
         properties = properties.Clone();
         properties.setProperty("Ice.Connection.Client.IdleTimeout", "0");
-        Communicator communicator = Util.initialize(new InitializationData { properties = properties });
+        global::Test.TestHelper.updateLogFileProperty(properties, "-idleTimeout=0");
+        await using Communicator communicator = Util.initialize(new InitializationData { properties = properties });
         Test.TestIntfPrx p = Test.TestIntfPrxHelper.createProxy(communicator, proxyString);
 
         Connection? connection = await p.ice_getConnectionAsync();

--- a/csharp/test/Ice/inactivityTimeout/AllTests.cs
+++ b/csharp/test/Ice/inactivityTimeout/AllTests.cs
@@ -59,7 +59,10 @@ internal class AllTests : global::Test.AllTests
         // Create a new communicator with the desired properties.
         properties = properties.Clone();
         properties.setProperty("Ice.Connection.Client.InactivityTimeout", "5");
-        Communicator communicator = Util.initialize(new InitializationData { properties = properties });
+        // Switch to a separate log file
+        global::Test.TestHelper.updateLogFileProperty(properties, "-inactivityTimeout=5s");
+
+        await using Communicator communicator = Util.initialize(new InitializationData { properties = properties });
         Test.TestIntfPrx p = Test.TestIntfPrxHelper.createProxy(communicator, proxyString);
 
         await p.ice_pingAsync();

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -81,9 +81,9 @@ public abstract class TestHelper
         if (logFile.Length > 0)
         {
             int dotIndex = logFile.LastIndexOf('.');
-            string newLogFile = dotIndex >= 0
-                ? logFile.Insert(dotIndex, suffix)
-                : logFile + suffix;
+            string newLogFile = dotIndex == -1
+                ? $"{logFile}{suffix}"
+                : logFile.Insert(dotIndex, suffix);
             properties.setProperty("Ice.LogFile", newLogFile);
         }
     }

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -75,6 +75,16 @@ public abstract class TestHelper
     public static int getTestPort(Ice.Properties properties, int num) =>
         properties.getPropertyAsIntWithDefault("Test.BasePort", 12010) + num;
 
+    public static void updateLogFileProperty(Ice.Properties properties, string suffix)
+    {
+        string logFile = properties.getIceProperty("Ice.LogFile");
+        if (logFile.Length > 0)
+        {
+            string newLogFile = logFile.Insert(logFile.LastIndexOf('.'), suffix);
+            properties.setProperty("Ice.LogFile", newLogFile);
+        }
+    }
+
     public TextWriter getWriter()
     {
         if (_writer == null)

--- a/csharp/test/TestCommon/TestHelper.cs
+++ b/csharp/test/TestCommon/TestHelper.cs
@@ -80,7 +80,10 @@ public abstract class TestHelper
         string logFile = properties.getIceProperty("Ice.LogFile");
         if (logFile.Length > 0)
         {
-            string newLogFile = logFile.Insert(logFile.LastIndexOf('.'), suffix);
+            int dotIndex = logFile.LastIndexOf('.');
+            string newLogFile = dotIndex >= 0
+                ? logFile.Insert(dotIndex, suffix)
+                : logFile + suffix;
             properties.setProperty("Ice.LogFile", newLogFile);
         }
     }

--- a/java/test/src/main/java/test/Ice/idleTimeout/AllTests.java
+++ b/java/test/src/main/java/test/Ice/idleTimeout/AllTests.java
@@ -69,6 +69,7 @@ public class AllTests {
         properties = properties._clone();
         properties.setProperty("Ice.Connection.Client.IdleTimeout", "3");
         properties.setProperty("Ice.Warn.Connections", "0");
+        TestHelper.updateLogFileProperty(properties, "-idleTimeout=3s");
         var initData = new InitializationData();
         initData.properties = properties;
         try (var communicator = helper.initialize(initData)) {
@@ -107,6 +108,7 @@ public class AllTests {
         properties.setProperty("Ice.Connection.Client.IdleTimeout", "1");
         properties.setProperty("Ice.Connection.Client.EnableIdleCheck", enabled ? "1" : "0");
         properties.setProperty("Ice.Warn.Connections", "0");
+        TestHelper.updateLogFileProperty(properties, "-idleTimeout=1s");
         var initData = new InitializationData();
         initData.properties = properties;
         try (var communicator = helper.initialize(initData)) {
@@ -134,6 +136,7 @@ public class AllTests {
         // Create a new communicator with the desired properties.
         properties = properties._clone();
         properties.setProperty("Ice.Connection.Client.IdleTimeout", "0");
+        TestHelper.updateLogFileProperty(properties, "-idleTimeout=0");
         var initData = new InitializationData();
         initData.properties = properties;
         try (var communicator = helper.initialize(initData)) {

--- a/java/test/src/main/java/test/Ice/inactivityTimeout/AllTests.java
+++ b/java/test/src/main/java/test/Ice/inactivityTimeout/AllTests.java
@@ -67,6 +67,7 @@ public class AllTests {
         // Create a new communicator with the desired properties.
         properties = properties._clone();
         properties.setProperty("Ice.Connection.Client.InactivityTimeout", "5");
+        TestHelper.updateLogFileProperty(properties, "-inactivityTimeout=5s");
         var initData = new InitializationData();
         initData.properties = properties;
         try (var communicator = helper.initialize(initData)) {

--- a/java/test/src/main/java/test/TestHelper.java
+++ b/java/test/src/main/java/test/TestHelper.java
@@ -98,6 +98,15 @@ public abstract class TestHelper {
         return properties.getPropertyAsIntWithDefault("Test.BasePort", 12010) + num;
     }
 
+    public static void updateLogFileProperty(Properties properties, String suffix) {
+        String logFile = properties.getIceProperty("Ice.LogFile");
+        if (logFile.length() > 0) {
+            String newLogFile = logFile.substring(0, logFile.lastIndexOf('.')) + suffix +
+                logFile.substring(logFile.lastIndexOf('.'));
+            properties.setProperty("Ice.LogFile", newLogFile);
+        }
+    }
+
     public Properties createTestProperties(String[] args) {
         return createTestProperties(args, null);
     }

--- a/java/test/src/main/java/test/TestHelper.java
+++ b/java/test/src/main/java/test/TestHelper.java
@@ -102,7 +102,7 @@ public abstract class TestHelper {
         String logFile = properties.getIceProperty("Ice.LogFile");
         assert logFile != null; // getIceProperty never returns null
 
-        if (logFile.length() > 0) {
+        if (!logFile.isEmpty()) {
             int dotIndex = logFile.lastIndexOf('.');
             String newLogFile;
             if (dotIndex == -1) {

--- a/js/test/Common/TestHelper.d.ts
+++ b/js/test/Common/TestHelper.d.ts
@@ -11,6 +11,8 @@ export class TestHelper {
     getTestProtocol(properties: Ice.Properties): string;
     getTestPort(num?: number): number;
 
+    updateLogFileProperty(properties: Ice.Properties, suffix: string): void;
+
     createTestProperties(args?: string[]): [Ice.Properties, string[]];
 
     initialize(initData: Ice.InitializationData): [Ice.Communicator, string[]];

--- a/js/test/Common/TestHelper.js
+++ b/js/test/Common/TestHelper.js
@@ -78,9 +78,10 @@ export class TestHelper {
         const logFile = properties.getIceProperty("Ice.LogFile");
         if (logFile) {
             const dotIndex = logFile.lastIndexOf(".");
-            const newLogFile = dotIndex !== -1
-                ? logFile.substring(0, dotIndex) + suffix + logFile.substring(dotIndex)
-                : logFile + suffix;
+            const newLogFile =
+                dotIndex !== -1
+                    ? logFile.substring(0, dotIndex) + suffix + logFile.substring(dotIndex)
+                    : logFile + suffix;
             properties.setProperty("Ice.LogFile", newLogFile);
         }
     }

--- a/js/test/Common/TestHelper.js
+++ b/js/test/Common/TestHelper.js
@@ -76,12 +76,12 @@ export class TestHelper {
 
     updateLogFileProperty(properties, suffix) {
         const logFile = properties.getIceProperty("Ice.LogFile");
-        if (logFile) {
+        if (logFile.length > 0) {
             const dotIndex = logFile.lastIndexOf(".");
             const newLogFile =
-                dotIndex !== -1
-                    ? logFile.substring(0, dotIndex) + suffix + logFile.substring(dotIndex)
-                    : logFile + suffix;
+                dotIndex == -1
+                    ? logFile + suffix
+                    : logFile.substring(0, dotIndex) + suffix + logFile.substring(dotIndex);
             properties.setProperty("Ice.LogFile", newLogFile);
         }
     }

--- a/js/test/Common/TestHelper.js
+++ b/js/test/Common/TestHelper.js
@@ -74,6 +74,15 @@ export class TestHelper {
         return properties.getPropertyAsIntWithDefault("Test.BasePort", 12010) + num;
     }
 
+    updateLogFileProperty(properties, suffix) {
+        const logFile = properties.getIceProperty("Ice.LogFile");
+        if (logFile) {
+            const newLogFile =
+                logFile.substring(0, logFile.lastIndexOf(".")) + suffix + logFile.substring(logFile.lastIndexOf("."));
+            properties.setProperty("Ice.LogFile", newLogFile);
+        }
+    }
+
     createTestProperties(args = []) {
         const properties = new Ice.Properties(args);
         args = properties.parseCommandLineOptions("Test", args);

--- a/js/test/Common/TestHelper.js
+++ b/js/test/Common/TestHelper.js
@@ -77,8 +77,10 @@ export class TestHelper {
     updateLogFileProperty(properties, suffix) {
         const logFile = properties.getIceProperty("Ice.LogFile");
         if (logFile) {
-            const newLogFile =
-                logFile.substring(0, logFile.lastIndexOf(".")) + suffix + logFile.substring(logFile.lastIndexOf("."));
+            const dotIndex = logFile.lastIndexOf(".");
+            const newLogFile = dotIndex !== -1
+                ? logFile.substring(0, dotIndex) + suffix + logFile.substring(dotIndex)
+                : logFile + suffix;
             properties.setProperty("Ice.LogFile", newLogFile);
         }
     }


### PR DESCRIPTION
This PR updates the idleTimeout and inactivityTimeout tests to use a log file for each communicator.