### PR TITLE
Fix the Android test controller layout

### DIFF
--- a/java/test/android/controller/src/main/java/com/zeroc/testcontroller/ControllerActivity.java
+++ b/java/test/android/controller/src/main/java/com/zeroc/testcontroller/ControllerActivity.java
@@ -3,7 +3,6 @@
 package com.zeroc.testcontroller;
 
 import android.app.Activity;
-import android.app.ListActivity;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothManager;
 import android.content.Context;
@@ -13,6 +12,7 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
+import android.widget.ListView;
 import android.widget.Spinner;
 import android.widget.Toast;
 
@@ -20,10 +20,11 @@ import java.util.LinkedList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-public class ControllerActivity extends ListActivity
+public class ControllerActivity extends Activity
 {
     private final LinkedList<String> _output = new LinkedList<>();
     private ArrayAdapter<String> _outputAdapter;
+    private ListView _outputListView;
 
     private static final int REQUEST_ENABLE_BT = 1;
 
@@ -32,6 +33,12 @@ public class ControllerActivity extends ListActivity
     {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main);
+
+        _outputListView = findViewById(R.id.outputList);
+        if(_outputListView == null)
+        {
+            throw new IllegalStateException("Layout must include a View with android:id=\"@+id/outputList\"");
+        }
 
         WifiManager wifiManager = (WifiManager) getApplicationContext().getSystemService(Context.WIFI_SERVICE);
         WifiManager.MulticastLock lock = wifiManager.createMulticastLock("com.zeroc.testcontroller");
@@ -89,7 +96,7 @@ public class ControllerActivity extends ListActivity
     private synchronized void setup(boolean bluetooth)
     {
         _outputAdapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, _output);
-        setListAdapter(_outputAdapter);
+        _outputListView.setAdapter(_outputAdapter);
         final ControllerApp app = (ControllerApp)getApplication();
         final java.util.List<String> ipv4Addresses = app.getAddresses(false);
         ArrayAdapter<String> ipv4Adapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_dropdown_item, ipv4Addresses);

--- a/java/test/android/controller/src/main/res/layout/main.xml
+++ b/java/test/android/controller/src/main/res/layout/main.xml
@@ -1,54 +1,58 @@
-<?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
     <LinearLayout
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:paddingBottom="5dip">
+        android:paddingStart="16dp"
+        android:paddingBottom="16dp"
+        android:weightSum="4">
+
         <TextView
-            android:layout_width="5dip"
-            android:layout_weight="25"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@string/ipv4"
-            android:layout_gravity="center_vertical"/>
+            android:gravity="center_vertical"/>
 
         <Spinner
             android:id="@+id/ipv4"
-            android:layout_width="5dip"
-            android:layout_weight="75"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:drawSelectorOnTop="false"/>
+            android:layout_weight="3"/>
     </LinearLayout>
 
     <LinearLayout
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:paddingBottom="5dip">
+        android:paddingStart="16dp"
+        android:paddingBottom="16dp"
+        android:weightSum="4">
+
         <TextView
-            android:layout_width="0dip"
-            android:layout_weight="25"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@string/ipv6"
-            android:layout_gravity="center_vertical"/>
+            android:gravity="center_vertical"/>
 
         <Spinner
             android:id="@+id/ipv6"
-            android:layout_width="0dip"
-            android:layout_weight="75"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:drawSelectorOnTop="false"/>
+            android:layout_weight="3"/>
     </LinearLayout>
 
     <ListView
-        android:id="@android:id/list"
-        android:layout_width="fill_parent"
-        android:layout_height="0dip"
+        android:id="@+id/outputList"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
         android:layout_weight="1"
         android:stackFromBottom="true"
         android:transcriptMode="alwaysScroll"/>


### PR DESCRIPTION
The spinners used to select IPv4 and IPv6 addresses where not visible.

Replaced the deprecated ListActivity with Activity+ListView