### PR TITLE
Prefer Communicator constructor over Util.initialize in Java

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -31,11 +31,10 @@ module VisitorCenter
 
 import com.example.visitorcenter.GreeterPrx;
 import com.zeroc.Ice.Communicator;
-import com.zeroc.Ice.Util;
 
 class Client {
     public static void main(String[] args) {
-        try (Communicator communicator = Util.initialize(args)) {
+        try (var communicator = new Communicator(args)) {
             GreeterPrx greeter =
                 GreeterPrx.createProxy(communicator, "greeter:tcp -h localhost -p 4061");
 
@@ -52,11 +51,10 @@ class Client {
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 class Server {
     public static void main(String[] args) {
-        try (Communicator communicator = Util.initialize(args)) {
+        try (var communicator = new Communicator(args)) {
             ObjectAdapter adapter =
                 communicator.createObjectAdapterWithEndpoints("GreeterAdapter", "tcp -p 4061");
             adapter.add(new Chatbot(), new Identity("greeter", ""));

--- a/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Coordinator.java
+++ b/java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/Coordinator.java
@@ -739,7 +739,7 @@ public class Coordinator {
 
     public Communicator getCommunicator() {
         if (_communicator == null) {
-            _communicator = Util.initialize(_initData);
+            _communicator = new Communicator(_initData);
         }
         return _communicator;
     }
@@ -1609,7 +1609,7 @@ public class Coordinator {
         initData.properties.setProperty("Ice.Default.Router", "");
 
         try {
-            _communicator = Util.initialize(initData);
+            _communicator = new Communicator(initData);
         } catch (LocalException e) {
             JOptionPane.showMessageDialog(
                 parent,

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
@@ -48,7 +48,7 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Constructs a communicator with defaults options.
+     * Constructs a communicator with default options.
      *
      */
     public Communicator() {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
@@ -48,7 +48,6 @@ public final class Communicator implements AutoCloseable {
 
     /**
      * Constructs a communicator with default options.
-     *
      */
     public Communicator() {
         this(new InitializationData());

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
@@ -33,7 +33,6 @@ public final class Communicator implements AutoCloseable {
      * Constructs a communicator with the specified options.
      *
      * @param initData the options for the new communicator
-     *
      */
     public Communicator(InitializationData initData) {
         _instance = new Instance();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
@@ -6,6 +6,7 @@ import com.zeroc.Ice.Instrumentation.CommunicatorObserver;
 import com.zeroc.Ice.SSL.SSLEngineFactory;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -29,8 +30,54 @@ public final class Communicator implements AutoCloseable {
     private final Instance _instance;
 
     /**
-     * Destroy the communicator.
-     * This Java-only method overrides close in java.lang.AutoCloseable and does not throw any exception.
+     * Constructs a communicator with the specified options.
+     *
+     * @param initData the options for the new communicator
+     *
+     */
+    public Communicator(InitializationData initData) {
+        _instance = new Instance();
+        _instance.initialize(this, initData);
+
+        try {
+            _instance.finishSetup(this);
+        } catch (RuntimeException ex) {
+            _instance.destroy(false);
+            throw ex;
+        }
+    }
+
+    /**
+     * Constructs a communicator with defaults options.
+     *
+     */
+    public Communicator() {
+        this(new InitializationData());
+    }
+
+    /**
+     * Constructs a communicator, using Ice properties parsed from command-line arguments. This constructors uses args
+     * to create the {@link Properties} of the new communicator.
+     *
+     * @param args the command-line arguments
+     * @param remainingArgs if non-null, the remaining command-line arguments after parsing Ice properties
+     */
+    public Communicator(String[] args, List<String> remainingArgs) {
+        this(createInitializationData(args, remainingArgs));
+    }
+
+    /**
+     * Constructs a communicator, using Ice properties parsed from command-line arguments. This constructors uses args
+     * to create the {@link Properties} of the new communicator.
+     *
+     * @param args the command-line arguments
+     */
+    public Communicator(String[] args) {
+        this(args, null);
+    }
+
+    /**
+     * Destroys the communicator.
      *
      * @see #destroy
      */
@@ -513,20 +560,6 @@ public final class Communicator implements AutoCloseable {
         return _instance.findAllAdminFacets();
     }
 
-    Communicator(InitializationData initData) {
-        _instance = new Instance();
-        _instance.initialize(this, initData);
-    }
-
-    void finishSetup() {
-        try {
-            _instance.finishSetup(this);
-        } catch (RuntimeException ex) {
-            _instance.destroy(false);
-            throw ex;
-        }
-    }
-
     /**
      * Get the {@code Instance} object associated with this communicator.
      *
@@ -535,5 +568,12 @@ public final class Communicator implements AutoCloseable {
      */
     public Instance getInstance() {
         return _instance;
+    }
+
+    private static InitializationData createInitializationData(String[] args, List<String> remainingArgs) {
+        var properties = new Properties(args, remainingArgs);
+        var initData = new InitializationData();
+        initData.properties = properties;
+        return initData;
     }
 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Communicator.java
@@ -56,7 +56,7 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Constructs a communicator, using Ice properties parsed from command-line arguments. This constructors uses args
+     * Constructs a communicator, using Ice properties parsed from command-line arguments. This constructor uses args
      * to create the {@link Properties} of the new communicator.
      *
      * @param args the command-line arguments
@@ -67,7 +67,7 @@ public final class Communicator implements AutoCloseable {
     }
 
     /**
-     * Constructs a communicator, using Ice properties parsed from command-line arguments. This constructors uses args
+     * Constructs a communicator, using Ice properties parsed from command-line arguments. This constructor uses args
      * to create the {@link Properties} of the new communicator.
      *
      * @param args the command-line arguments

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/LoggerAdminI.java
@@ -329,7 +329,7 @@ final class LoggerAdminI implements LoggerAdmin {
             }
             initData.properties.parseCommandLineOptions("", extraProps);
         }
-        return Util.initialize(initData);
+        return new Communicator(initData);
     }
 
     private final List<LogMessage> _queue = new LinkedList<>();

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
@@ -105,7 +105,7 @@ public final class Util {
      * constructor directly.
      *
      * @param args the command-line arguments
-     * @param remainingArgs if non-null,the remaining command-line arguments after parsing Ice properties
+     * @param remainingArgs if non-null, the remaining command-line arguments after parsing Ice properties
      * @return the new communicator
      */
     public static Communicator initialize(String[] args, List<String> remainingArgs) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
@@ -73,67 +73,55 @@ public final class Util {
      *     {@code args}.
      * @return A new property set.
      */
-    public static Properties createProperties(
-            String[] args, Properties defaults, List<String> remainingArgs) {
+    public static Properties createProperties(String[] args, Properties defaults, List<String> remainingArgs) {
         return new Properties(args, defaults, remainingArgs);
     }
 
     /**
-     * Creates a new communicator.
+     * Creates a new communicator. This method is provided for backwards compatibility. New code should call the
+     * {@link Communicator#Communicator(InitializationData)} constructor directly.
      *
-     * @param initData Options for the new communicator.
-     * @return The new communicator.
+     * @param initData options for the new communicator
+     * @return the new communicator
      * @see InitializationData
      */
     public static Communicator initialize(InitializationData initData) {
-        if (initData == null) {
-            initData = new InitializationData();
-        } else {
-            initData = initData.clone(); // shallow clone
-        }
-
-        var communicator = new Communicator(initData);
-        communicator.finishSetup();
-        return communicator;
+        return new Communicator(initData);
     }
 
     /**
-     * Creates a new communicator with the default options.
+     * Creates a new communicator with the default options. This method is provided for backwards compatibility. New
+     * code should call the {@link Communicator#Communicator()} constructor directly.
      *
-     * @return The new communicator.
+     * @return the new communicator
      */
     public static Communicator initialize() {
-        return initialize((InitializationData) null);
+        return new Communicator();
     }
 
     /**
-     * Creates a new communicator, using Ice properties parsed from command-line arguments.
+     * Creates a new communicator, using Ice properties parsed from command-line arguments. This method is provided for
+     * backwards compatibility. New code should call the {@link Communicator#Communicator(String[], List<String>)}
+     * constructor directly.
      *
-     * @param args A command-line argument vector. This method parses arguments starting with `--` and one of the
-     *     reserved prefixes (Ice, IceSSL, etc.) as properties for the new communicator. If there is an argument
-     *     starting with `--Ice.Config`, this method loads the specified configuration file. When the same property is
-     *     set in a configuration file and through a command-line argument, the command-line setting takes precedence.
-     * @param remainingArgs If non-null, the given list will contain on return the command-line arguments that were
-     *     not used to set properties.
-     * @return The new communicator.
+     * @param args the command-line arguments
+     * @param remainingArgs if non-null,the remaining command-line arguments after parsing Ice properties
+     * @return the new communicator
      */
     public static Communicator initialize(String[] args, List<String> remainingArgs) {
-        var initData = new InitializationData();
-        initData.properties = new Properties(args, remainingArgs);
-        return initialize(initData);
+        return new Communicator(args, remainingArgs);
     }
 
     /**
-     * Creates a new communicator, using Ice properties parsed from command-line arguments.
+     * Creates a new communicator, using Ice properties parsed from command-line arguments. This method is provided for
+     * backwards compatibility. New code should call the {@link Communicator#Communicator(String[])} constructor
+     * directly.
      *
-     * @param args A command-line argument vector. This method parses arguments starting with `--` and one of the
-     *     reserved prefixes (Ice, IceSSL, etc.) as properties for the new communicator. If there is an argument
-     *     starting with `--Ice.Config`, this method loads the specified configuration file. When the same property is
-     *     set in a configuration file and through a command-line argument, the command-line setting takes precedence.
-     * @return The new communicator.
+     * @param args the command-line arguments
+     * @return the new communicator
      */
     public static Communicator initialize(String[] args) {
-        return initialize(args, null);
+        return new Communicator(args);
     }
 
     /**

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/Util.java
@@ -101,7 +101,7 @@ public final class Util {
 
     /**
      * Creates a new communicator, using Ice properties parsed from command-line arguments. This method is provided for
-     * backwards compatibility. New code should call the {@link Communicator#Communicator(String[], List<String>)}
+     * backwards compatibility. New code should call the {@link Communicator#Communicator(String[], java.util.List)}
      * constructor directly.
      *
      * @param args the command-line arguments

--- a/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/Admin.java
+++ b/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/Admin.java
@@ -32,7 +32,7 @@ final class Admin {
         InitializationData initData = new InitializationData();
         initData.properties = new Properties(args, commands, Collections.singletonList("IceBoxAdmin"));
 
-        try (Communicator communicator = Util.initialize(initData)) {
+        try (Communicator communicator = new Communicator(initData)) {
             Runtime.getRuntime().addShutdownHook(new Thread(communicator::destroy));
 
             status = run(communicator, commands);

--- a/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/Server.java
+++ b/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/Server.java
@@ -95,7 +95,7 @@ final class Server {
         initData.properties.setProperty("Ice.Admin.DelayCreation", "1");
         ShutdownHook shutdownHook = null;
 
-        try (Communicator communicator = Util.initialize(initData)) {
+        try (Communicator communicator = new Communicator(initData)) {
             shutdownHook = new ShutdownHook(communicator);
             Runtime.getRuntime().addShutdownHook(shutdownHook);
 

--- a/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/ServiceManagerI.java
+++ b/java/src/com.zeroc.icebox/src/main/java/com/zeroc/IceBox/ServiceManagerI.java
@@ -282,7 +282,7 @@ final class ServiceManagerI implements ServiceManager {
                 String facetNamePrefix = "IceBox.SharedCommunicator.";
                 boolean addFacets = configureAdmin(initData.properties, facetNamePrefix);
 
-                _sharedCommunicator = Util.initialize(initData);
+                _sharedCommunicator = new Communicator(initData);
 
                 if (addFacets) {
                     // Add all facets created on shared communicator to the IceBox communicator but
@@ -447,7 +447,7 @@ final class ServiceManagerI implements ServiceManager {
                 String serviceFacetNamePrefix = "IceBox.Service." + service + ".";
                 boolean addFacets = configureAdmin(initData.properties, serviceFacetNamePrefix);
 
-                info.communicator = Util.initialize(initData);
+                info.communicator = new Communicator(initData);
                 communicator = info.communicator;
 
                 if (addFacets) {

--- a/java/test/android/controller/src/main/java/com/zeroc/testcontroller/ControllerApp.java
+++ b/java/test/android/controller/src/main/java/com/zeroc/testcontroller/ControllerApp.java
@@ -193,7 +193,7 @@ public class ControllerApp extends Application {
                 initData.properties.setProperty("IceDiscovery.DomainId", "TestController");
             }
 
-            _communicator = com.zeroc.Ice.new Communicator(initData);
+            _communicator = new Communicator(initData);
             com.zeroc.Ice.ObjectAdapter adapter =
                     _communicator.createObjectAdapter("ControllerAdapter");
             ProcessControllerPrx processController =

--- a/java/test/android/controller/src/main/java/com/zeroc/testcontroller/ControllerApp.java
+++ b/java/test/android/controller/src/main/java/com/zeroc/testcontroller/ControllerApp.java
@@ -193,7 +193,7 @@ public class ControllerApp extends Application {
                 initData.properties.setProperty("IceDiscovery.DomainId", "TestController");
             }
 
-            _communicator = new Communicator(initData);
+            _communicator = new com.zeroc.Ice.Communicator(initData);
             com.zeroc.Ice.ObjectAdapter adapter =
                     _communicator.createObjectAdapter("ControllerAdapter");
             ProcessControllerPrx processController =

--- a/java/test/android/controller/src/main/java/com/zeroc/testcontroller/ControllerApp.java
+++ b/java/test/android/controller/src/main/java/com/zeroc/testcontroller/ControllerApp.java
@@ -193,7 +193,7 @@ public class ControllerApp extends Application {
                 initData.properties.setProperty("IceDiscovery.DomainId", "TestController");
             }
 
-            _communicator = com.zeroc.Ice.Util.initialize(initData);
+            _communicator = com.zeroc.Ice.new Communicator(initData);
             com.zeroc.Ice.ObjectAdapter adapter =
                     _communicator.createObjectAdapter("ControllerAdapter");
             ProcessControllerPrx processController =

--- a/java/test/src/main/java/test/Glacier2/router/Client.java
+++ b/java/test/src/main/java/test/Glacier2/router/Client.java
@@ -302,9 +302,7 @@ public class Client extends TestHelper {
                 context.put("_fwd", "t");
                 try {
                     CallbackPrx otherCategoryTwoway =
-                        CallbackPrx.uncheckedCast(
-                            twoway.ice_identity(
-                                new Identity("c3/callback", "")));
+                        CallbackPrx.uncheckedCast(twoway.ice_identity(new Identity("callback", "c3")));
                     otherCategoryTwoway.initiateCallback(twowayR, context);
                     test(false);
                 } catch (ObjectNotExistException ex) {

--- a/java/test/src/main/java/test/Glacier2/router/Client.java
+++ b/java/test/src/main/java/test/Glacier2/router/Client.java
@@ -19,7 +19,6 @@ import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.ProcessPrx;
 import com.zeroc.Ice.RouterFinderPrx;
 import com.zeroc.Ice.SocketException;
-import com.zeroc.Ice.Util;
 
 import test.Glacier2.router.Test.CallbackException;
 import test.Glacier2.router.Test.CallbackPrx;
@@ -290,9 +289,7 @@ public class Client extends TestHelper {
                 Map<String, String> context = new HashMap<>();
                 context.put("_fwd", "t");
                 CallbackPrx otherCategoryTwoway =
-                    CallbackPrx.uncheckedCast(
-                        twoway.ice_identity(
-                            Util.stringToIdentity("c2/callback")));
+                    CallbackPrx.uncheckedCast(twoway.ice_identity(new Identity("callback", "c2")));
                 otherCategoryTwoway.initiateCallback(twowayR, context);
                 callbackReceiverImpl.callbackOK();
                 out.println("ok");
@@ -307,7 +304,7 @@ public class Client extends TestHelper {
                     CallbackPrx otherCategoryTwoway =
                         CallbackPrx.uncheckedCast(
                             twoway.ice_identity(
-                                Util.stringToIdentity("c3/callback")));
+                                new Identity("c3/callback", "")));
                     otherCategoryTwoway.initiateCallback(twowayR, context);
                     test(false);
                 } catch (ObjectNotExistException ex) {
@@ -321,9 +318,7 @@ public class Client extends TestHelper {
                 Map<String, String> context = new HashMap<>();
                 context.put("_fwd", "t");
                 CallbackPrx otherCategoryTwoway =
-                    CallbackPrx.uncheckedCast(
-                        twoway.ice_identity(
-                            Util.stringToIdentity("_userid/callback")));
+                    CallbackPrx.uncheckedCast(twoway.ice_identity(new Identity("callback", "_userid")));
                 otherCategoryTwoway.initiateCallback(twowayR, context);
                 callbackReceiverImpl.callbackOK();
                 out.println("ok");

--- a/java/test/src/main/java/test/Glacier2/router/Server.java
+++ b/java/test/src/main/java/test/Glacier2/router/Server.java
@@ -3,10 +3,10 @@
 package test.Glacier2.router;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -25,16 +25,16 @@ public class Server extends TestHelper {
                 communicator.createObjectAdapter("CallbackAdapter");
 
             // The test allows "c1" as category.
-            adapter.add(new CallbackI(), Util.stringToIdentity("c1/callback"));
+            adapter.add(new CallbackI(), new Identity("callback", "c1"));
 
             // The test allows "c2" as category.
-            adapter.add(new CallbackI(), Util.stringToIdentity("c2/callback"));
+            adapter.add(new CallbackI(), new Identity("callback", "c2"));
 
             // The test rejects "c3" as category.
-            adapter.add(new CallbackI(), Util.stringToIdentity("c3/callback"));
+            adapter.add(new CallbackI(), new Identity("callback", "c3"));
 
             // The test allows the prefixed userid.
-            adapter.add(new CallbackI(), Util.stringToIdentity("_userid/callback"));
+            adapter.add(new CallbackI(), new Identity("callback", "_userid"));
             adapter.activate();
             communicator.waitForShutdown();
         }

--- a/java/test/src/main/java/test/Ice/adapterDeactivation/AllTests.java
+++ b/java/test/src/main/java/test/Ice/adapterDeactivation/AllTests.java
@@ -18,7 +18,6 @@ import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.OperationNotExistException;
 import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.RouterPrx;
-import com.zeroc.Ice.Util;
 
 import test.Ice.adapterDeactivation.Test.TestIntfPrx;
 import test.TestHelper;
@@ -419,7 +418,7 @@ public class AllTests {
                     initData.properties = new Properties();
                     initData.properties.setProperty("Ice.ServerIdleTime", "1");
                     try (Communicator idleCommunicator =
-                        Util.initialize(initData)) {
+                        new Communicator(initData)) {
                         ObjectAdapter adapter =
                             idleCommunicator.createObjectAdapterWithEndpoints(
                                 "IdleAdapter", "tcp -h 127.0.0.1");
@@ -435,7 +434,7 @@ public class AllTests {
                     initData.properties = new Properties();
                     initData.properties.setProperty("Ice.ServerIdleTime", "0");
                     try (Communicator idleCommunicator =
-                        Util.initialize(initData)) {
+                        new Communicator(initData)) {
                         ObjectAdapter adapter =
                             idleCommunicator.createObjectAdapterWithEndpoints(
                                 "IdleAdapter", "tcp -h 127.0.0.1");

--- a/java/test/src/main/java/test/Ice/admin/AllTests.java
+++ b/java/test/src/main/java/test/Ice/admin/AllTests.java
@@ -116,7 +116,7 @@ public class AllTests {
             init.properties = new Properties();
             init.properties.setProperty("Ice.Admin.Endpoints", "tcp -h 127.0.0.1");
             init.properties.setProperty("Ice.Admin.InstanceName", "Test");
-            try (Communicator comm = Util.initialize(init)) {
+            try (Communicator comm = new Communicator(init)) {
                 testFacets(comm, true);
             }
         }
@@ -129,7 +129,7 @@ public class AllTests {
             init.properties.setProperty("Ice.Admin.Endpoints", "tcp -h 127.0.0.1");
             init.properties.setProperty("Ice.Admin.InstanceName", "Test");
             init.properties.setProperty("Ice.Admin.Facets", "Properties");
-            try (Communicator comm = Util.initialize(init)) {
+            try (Communicator comm = new Communicator(init)) {
                 testFacets(comm, false);
             }
         }
@@ -137,7 +137,7 @@ public class AllTests {
             //
             // Test: Verify that the operations work correctly with the Admin object disabled.
             //
-            try (Communicator comm = Util.initialize()) {
+            try (Communicator comm = new Communicator()) {
                 testFacets(comm, false);
             }
         }
@@ -148,7 +148,7 @@ public class AllTests {
             InitializationData init = new InitializationData();
             init.properties = new Properties();
             init.properties.setProperty("Ice.Admin.Enabled", "1");
-            try (Communicator comm = Util.initialize(init)) {
+            try (Communicator comm = new Communicator(init)) {
                 test(comm.getAdmin() == null);
                 Identity id = Util.stringToIdentity("test-admin");
                 try {
@@ -172,7 +172,7 @@ public class AllTests {
             init.properties.setProperty("Ice.Admin.Endpoints", "tcp -h 127.0.0.1");
             init.properties.setProperty("Ice.Admin.InstanceName", "Test");
             init.properties.setProperty("Ice.Admin.DelayCreation", "1");
-            try (Communicator comm = Util.initialize(init)) {
+            try (Communicator comm = new Communicator(init)) {
                 testFacets(comm, true);
                 comm.getAdmin();
                 testFacets(comm, true);

--- a/java/test/src/main/java/test/Ice/admin/AllTests.java
+++ b/java/test/src/main/java/test/Ice/admin/AllTests.java
@@ -21,7 +21,6 @@ import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.PropertiesAdminPrx;
 import com.zeroc.Ice.RemoteLoggerAlreadyAttachedException;
 import com.zeroc.Ice.RemoteLoggerPrx;
-import com.zeroc.Ice.Util;
 
 import test.Ice.admin.Test.RemoteCommunicatorFactoryPrx;
 import test.Ice.admin.Test.RemoteCommunicatorPrx;
@@ -150,7 +149,7 @@ public class AllTests {
             init.properties.setProperty("Ice.Admin.Enabled", "1");
             try (Communicator comm = new Communicator(init)) {
                 test(comm.getAdmin() == null);
-                Identity id = Util.stringToIdentity("test-admin");
+                Identity id = new Identity("test-admin", "");
                 try {
                     comm.createAdmin(null, id);
                     test(false);

--- a/java/test/src/main/java/test/Ice/admin/RemoteCommunicatorFactoryI.java
+++ b/java/test/src/main/java/test/Ice/admin/RemoteCommunicatorFactoryI.java
@@ -10,7 +10,6 @@ import com.zeroc.Ice.NativePropertiesAdmin;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.Properties;
-import com.zeroc.Ice.Util;
 
 import test.Ice.admin.Test.RemoteCommunicatorFactory;
 import test.Ice.admin.Test.RemoteCommunicatorPrx;
@@ -60,7 +59,7 @@ public class RemoteCommunicatorFactoryI implements RemoteCommunicatorFactory {
         //
         // Initialize a new communicator.
         //
-        Communicator communicator = Util.initialize(initData);
+        Communicator communicator = new Communicator(initData);
 
         //
         // Install a custom admin facet.

--- a/java/test/src/main/java/test/Ice/admin/Server.java
+++ b/java/test/src/main/java/test/Ice/admin/Server.java
@@ -3,8 +3,8 @@
 package test.Ice.admin;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -18,7 +18,7 @@ public class Server extends TestHelper {
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.add(
                 new RemoteCommunicatorFactoryI(),
-                Util.stringToIdentity("factory"));
+                new Identity("factory", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/ami/Collocated.java
+++ b/java/test/src/main/java/test/Ice/ami/Collocated.java
@@ -3,10 +3,10 @@
 package test.Ice.ami;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -27,12 +27,12 @@ public class Collocated extends TestHelper {
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             ObjectAdapter adapter2 = communicator.createObjectAdapter("ControllerAdapter");
 
-            adapter.add(new TestI(), Util.stringToIdentity("test"));
-            adapter.add(new TestII(), Util.stringToIdentity("test2"));
+            adapter.add(new TestI(), new Identity("test", ""));
+            adapter.add(new TestII(), new Identity("test2", ""));
             // adapter.activate(); // Collocated test doesn't need to activate the OA
             adapter2.add(
                 new TestControllerI(adapter),
-                Util.stringToIdentity("testController"));
+                new Identity("testController", ""));
             // adapter2.activate(); // Collocated test doesn't need to activate the OA
 
             AllTests.allTests(this, true);

--- a/java/test/src/main/java/test/Ice/ami/Server.java
+++ b/java/test/src/main/java/test/Ice/ami/Server.java
@@ -3,10 +3,10 @@
 package test.Ice.ami;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -32,12 +32,12 @@ public class Server extends TestHelper {
             ObjectAdapter adapter2 =
                 communicator.createObjectAdapter("ControllerAdapter");
 
-            adapter.add(new TestI(), Util.stringToIdentity("test"));
-            adapter.add(new TestII(), Util.stringToIdentity("test2"));
+            adapter.add(new TestI(), new Identity("test", ""));
+            adapter.add(new TestII(), new Identity("test2", ""));
             adapter.activate();
             adapter2.add(
                 new TestControllerI(adapter),
-                Util.stringToIdentity("testController"));
+                new Identity("testController", ""));
             adapter2.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/background/Server.java
+++ b/java/test/src/main/java/test/Ice/background/Server.java
@@ -11,7 +11,6 @@ import com.zeroc.Ice.LocatorRegistryPrx;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.Router;
-import com.zeroc.Ice.Util;
 
 import test.Ice.background.PluginFactory.PluginI;
 import test.TestHelper;
@@ -24,7 +23,7 @@ public class Server extends TestHelper {
         @Override
         public ObjectPrx findAdapterById(String adapter, Current current) {
             _controller.checkCallPause(current);
-            return current.adapter.createDirectProxy(Util.stringToIdentity("dummy"));
+            return current.adapter.createDirectProxy(new Identity("dummy", ""));
         }
 
         @Override
@@ -107,18 +106,18 @@ public class Server extends TestHelper {
 
             adapter.add(
                 new BackgroundI(backgroundController),
-                Util.stringToIdentity("background"));
+                new Identity("background", ""));
             adapter.add(
                 new LocatorI(backgroundController),
-                Util.stringToIdentity("locator"));
+                new Identity("locator", ""));
             adapter.add(
                 new RouterI(backgroundController),
-                Util.stringToIdentity("router"));
+                new Identity("router", ""));
             adapter.activate();
 
             adapter2.add(
                 backgroundController,
-                Util.stringToIdentity("backgroundController"));
+                new Identity("backgroundController", ""));
             adapter2.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/binding/AllTests.java
+++ b/java/test/src/main/java/test/Ice/binding/AllTests.java
@@ -8,6 +8,7 @@ import com.zeroc.Ice.Connection;
 import com.zeroc.Ice.DNSException;
 import com.zeroc.Ice.Endpoint;
 import com.zeroc.Ice.EndpointSelectionType;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.LocalException;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.ObjectNotExistException;
@@ -15,7 +16,6 @@ import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.SocketException;
 import com.zeroc.Ice.TwowayOnlyException;
-import com.zeroc.Ice.Util;
 
 import test.Ice.binding.Test.RemoteCommunicatorPrx;
 import test.Ice.binding.Test.RemoteObjectAdapterPrx;
@@ -765,7 +765,7 @@ public class AllTests {
                     }
 
                     String strPrx =
-                        oa.createProxy(Util.stringToIdentity("dummy")).toString();
+                        oa.createProxy(new Identity("dummy", "")).toString();
                     for (Properties q : clientProps) {
                         try (Communicator clientCommunicator = helper.initialize(q)) {
                             ObjectPrx prx = clientCommunicator.stringToProxy(strPrx);

--- a/java/test/src/main/java/test/Ice/binding/RemoteObjectAdapterI.java
+++ b/java/test/src/main/java/test/Ice/binding/RemoteObjectAdapterI.java
@@ -3,8 +3,8 @@
 package test.Ice.binding;
 
 import com.zeroc.Ice.Current;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.Ice.binding.Test.RemoteObjectAdapter;
 import test.Ice.binding.Test.TestIntfPrx;
@@ -14,7 +14,7 @@ public class RemoteObjectAdapterI implements RemoteObjectAdapter {
         _adapter = adapter;
         _testIntf =
             TestIntfPrx.uncheckedCast(
-                _adapter.add(new TestI(), Util.stringToIdentity("test")));
+                _adapter.add(new TestI(), new Identity("test", "")));
         _adapter.activate();
     }
 

--- a/java/test/src/main/java/test/Ice/binding/Server.java
+++ b/java/test/src/main/java/test/Ice/binding/Server.java
@@ -7,7 +7,6 @@ import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.Logger;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -43,7 +42,7 @@ public class Server extends TestHelper {
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            Identity id = Util.stringToIdentity("communicator");
+            Identity id = new Identity("communicator", "");
             adapter.add(new RemoteCommunicatorI(this), id);
             adapter.activate();
             serverReady();

--- a/java/test/src/main/java/test/Ice/classLoader/Server.java
+++ b/java/test/src/main/java/test/Ice/classLoader/Server.java
@@ -3,11 +3,11 @@
 package test.Ice.classLoader;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -22,7 +22,7 @@ public class Server extends TestHelper {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object object = new InitialI(adapter);
-            adapter.add(object, Util.stringToIdentity("initial"));
+            adapter.add(object, new Identity("initial", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/custom/Collocated.java
+++ b/java/test/src/main/java/test/Ice/custom/Collocated.java
@@ -3,9 +3,9 @@
 package test.Ice.custom;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -18,7 +18,7 @@ public class Collocated extends TestHelper {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object test = new TestI(communicator);
-            adapter.add(test, Util.stringToIdentity("test"));
+            adapter.add(test, new Identity("test", ""));
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/custom/Server.java
+++ b/java/test/src/main/java/test/Ice/custom/Server.java
@@ -3,9 +3,9 @@
 package test.Ice.custom;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -18,7 +18,7 @@ public class Server extends TestHelper {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object test = new TestI(communicator);
-            adapter.add(test, Util.stringToIdentity("test"));
+            adapter.add(test, new Identity("test", ""));
 
             adapter.activate();
             serverReady();

--- a/java/test/src/main/java/test/Ice/echo/BlobjectI.java
+++ b/java/test/src/main/java/test/Ice/echo/BlobjectI.java
@@ -4,6 +4,7 @@ package test.Ice.echo;
 
 import com.zeroc.Ice.BlobjectAsync;
 import com.zeroc.Ice.Current;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.Util;

--- a/java/test/src/main/java/test/Ice/echo/BlobjectI.java
+++ b/java/test/src/main/java/test/Ice/echo/BlobjectI.java
@@ -4,7 +4,6 @@ package test.Ice.echo;
 
 import com.zeroc.Ice.BlobjectAsync;
 import com.zeroc.Ice.Current;
-import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.Util;

--- a/java/test/src/main/java/test/Ice/echo/Server.java
+++ b/java/test/src/main/java/test/Ice/echo/Server.java
@@ -4,8 +4,8 @@ package test.Ice.echo;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Current;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.Ice.echo.Test.Echo;
 import test.TestHelper;
@@ -40,7 +40,7 @@ public class Server extends TestHelper {
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             BlobjectI blob = new BlobjectI();
             adapter.addDefaultServant(blob, "");
-            adapter.add(new EchoI(blob), Util.stringToIdentity("__echo"));
+            adapter.add(new EchoI(blob), new Identity("__echo", ""));
             adapter.activate();
             communicator.waitForShutdown();
         }

--- a/java/test/src/main/java/test/Ice/enums/Server.java
+++ b/java/test/src/main/java/test/Ice/enums/Server.java
@@ -3,9 +3,9 @@
 package test.Ice.enums;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -16,7 +16,7 @@ public class Server extends TestHelper {
 
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object test = new TestIntfI();
-            adapter.add(test, Util.stringToIdentity("test"));
+            adapter.add(test, new Identity("test", ""));
 
             adapter.activate();
             serverReady();

--- a/java/test/src/main/java/test/Ice/exceptions/AMDServer.java
+++ b/java/test/src/main/java/test/Ice/exceptions/AMDServer.java
@@ -3,11 +3,11 @@
 package test.Ice.exceptions;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -34,9 +34,9 @@ public class AMDServer extends TestHelper {
             ObjectAdapter adapter2 = communicator.createObjectAdapter("TestAdapter2");
             ObjectAdapter adapter3 = communicator.createObjectAdapter("TestAdapter3");
             Object object = new AMDThrowerI();
-            adapter.add(object, Util.stringToIdentity("thrower"));
-            adapter2.add(object, Util.stringToIdentity("thrower"));
-            adapter3.add(object, Util.stringToIdentity("thrower"));
+            adapter.add(object, new Identity("thrower", ""));
+            adapter2.add(object, new Identity("thrower", ""));
+            adapter3.add(object, new Identity("thrower", ""));
             adapter.activate();
             adapter2.activate();
             adapter3.activate();

--- a/java/test/src/main/java/test/Ice/exceptions/AllTests.java
+++ b/java/test/src/main/java/test/Ice/exceptions/AllTests.java
@@ -24,7 +24,6 @@ import com.zeroc.Ice.SocketException;
 import com.zeroc.Ice.UnknownException;
 import com.zeroc.Ice.UnknownLocalException;
 import com.zeroc.Ice.UnknownUserException;
-import com.zeroc.Ice.Util;
 
 import test.Ice.exceptions.Test.A;
 import test.Ice.exceptions.Test.B;
@@ -85,24 +84,24 @@ public class AllTests {
             communicator.getProperties().setProperty("TestAdapter1.Endpoints", "tcp -h *");
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter1");
             Object obj = new EmptyI();
-            adapter.add(obj, Util.stringToIdentity("x"));
+            adapter.add(obj, new Identity("x", ""));
             try {
-                adapter.add(obj, Util.stringToIdentity("x"));
+                adapter.add(obj, new Identity("x", ""));
                 test(false);
             } catch (AlreadyRegisteredException ex) {}
 
             try {
-                adapter.add(obj, Util.stringToIdentity(""));
+                adapter.add(obj, new Identity("", ""));
                 test(false);
             } catch (IllegalArgumentException ex) {}
             try {
-                adapter.add(null, Util.stringToIdentity("x"));
+                adapter.add(null, new Identity("x", ""));
                 test(false);
             } catch (IllegalArgumentException ex) {}
 
-            adapter.remove(Util.stringToIdentity("x"));
+            adapter.remove(new Identity("x", ""));
             try {
-                adapter.remove(Util.stringToIdentity("x"));
+                adapter.remove(new Identity("x", ""));
                 test(false);
             } catch (NotRegisteredException ex) {}
             adapter.deactivate();
@@ -362,7 +361,7 @@ public class AllTests {
         out.flush();
 
         {
-            Identity id = Util.stringToIdentity("does not exist");
+            Identity id = new Identity("does not exist", "");
             try {
                 ThrowerPrx thrower2 = ThrowerPrx.uncheckedCast(thrower.ice_identity(id));
                 thrower2.ice_ping();
@@ -640,7 +639,7 @@ public class AllTests {
         out.flush();
 
         {
-            Identity id = Util.stringToIdentity("does not exist");
+            Identity id = new Identity("does not exist", "");
             ThrowerPrx thrower2 = ThrowerPrx.uncheckedCast(thrower.ice_identity(id));
             try {
                 thrower2.throwAasAAsync(1).join();

--- a/java/test/src/main/java/test/Ice/exceptions/Collocated.java
+++ b/java/test/src/main/java/test/Ice/exceptions/Collocated.java
@@ -3,11 +3,11 @@
 package test.Ice.exceptions;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -26,7 +26,7 @@ public class Collocated extends TestHelper {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object object = new ThrowerI();
-            adapter.add(object, Util.stringToIdentity("thrower"));
+            adapter.add(object, new Identity("thrower", ""));
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/exceptions/Server.java
+++ b/java/test/src/main/java/test/Ice/exceptions/Server.java
@@ -3,11 +3,11 @@
 package test.Ice.exceptions;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -34,9 +34,9 @@ public class Server extends TestHelper {
             ObjectAdapter adapter2 = communicator.createObjectAdapter("TestAdapter2");
             ObjectAdapter adapter3 = communicator.createObjectAdapter("TestAdapter3");
             Object object = new ThrowerI();
-            adapter.add(object, Util.stringToIdentity("thrower"));
-            adapter2.add(object, Util.stringToIdentity("thrower"));
-            adapter3.add(object, Util.stringToIdentity("thrower"));
+            adapter.add(object, new Identity("thrower", ""));
+            adapter2.add(object, new Identity("thrower", ""));
+            adapter3.add(object, new Identity("thrower", ""));
             adapter.activate();
             adapter2.activate();
             adapter3.activate();

--- a/java/test/src/main/java/test/Ice/executor/Collocated.java
+++ b/java/test/src/main/java/test/Ice/executor/Collocated.java
@@ -3,9 +3,9 @@
 package test.Ice.executor;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -27,11 +27,11 @@ public class Collocated extends TestHelper {
             ObjectAdapter adapter2 =
                 communicator.createObjectAdapter("ControllerAdapter");
 
-            adapter.add(new TestI(executor), Util.stringToIdentity("test"));
+            adapter.add(new TestI(executor), new Identity("test", ""));
             // adapter.activate(); // Don't activate OA to ensure collocation is used.
             adapter2.add(
                 new TestControllerI(adapter),
-                Util.stringToIdentity("testController"));
+                new Identity("testController", ""));
             // adapter2.activate(); // Don't activate OA to ensure collocation is used.
 
             AllTests.allTests(this, executor);

--- a/java/test/src/main/java/test/Ice/executor/Server.java
+++ b/java/test/src/main/java/test/Ice/executor/Server.java
@@ -3,9 +3,9 @@
 package test.Ice.executor;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -31,11 +31,11 @@ public class Server extends TestHelper {
             ObjectAdapter adapter2 =
                 communicator().createObjectAdapter("ControllerAdapter");
 
-            adapter.add(new TestI(executor), Util.stringToIdentity("test"));
+            adapter.add(new TestI(executor), new Identity("test", ""));
             adapter.activate();
             adapter2.add(
                 new TestControllerI(adapter),
-                Util.stringToIdentity("testController"));
+                new Identity("testController", ""));
             adapter2.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/facets/AllTests.java
+++ b/java/test/src/main/java/test/Ice/facets/AllTests.java
@@ -4,11 +4,11 @@ package test.Ice.facets;
 
 import com.zeroc.Ice.AlreadyRegisteredException;
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.NotRegisteredException;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.ObjectPrx;
-import com.zeroc.Ice.Util;
 
 import test.Ice.facets.Test.DPrx;
 import test.Ice.facets.Test.FPrx;
@@ -76,15 +76,15 @@ public class AllTests {
         ObjectAdapter adapter =
             communicator.createObjectAdapter("FacetExceptionTestAdapter");
         Object obj = new EmptyI();
-        adapter.add(obj, Util.stringToIdentity("d"));
-        adapter.addFacet(obj, Util.stringToIdentity("d"), "facetABCD");
+        adapter.add(obj, new Identity("d", ""));
+        adapter.addFacet(obj, new Identity("d", ""), "facetABCD");
         try {
-            adapter.addFacet(obj, Util.stringToIdentity("d"), "facetABCD");
+            adapter.addFacet(obj, new Identity("d", ""), "facetABCD");
             test(false);
         } catch (AlreadyRegisteredException ex) {}
-        adapter.removeFacet(Util.stringToIdentity("d"), "facetABCD");
+        adapter.removeFacet(new Identity("d", ""), "facetABCD");
         try {
-            adapter.removeFacet(Util.stringToIdentity("d"), "facetABCD");
+            adapter.removeFacet(new Identity("d", ""), "facetABCD");
             test(false);
         } catch (NotRegisteredException ex) {}
         out.println("ok");
@@ -92,22 +92,22 @@ public class AllTests {
         out.print("testing removeAllFacets... ");
         Object obj1 = new EmptyI();
         Object obj2 = new EmptyI();
-        adapter.addFacet(obj1, Util.stringToIdentity("id1"), "f1");
-        adapter.addFacet(obj2, Util.stringToIdentity("id1"), "f2");
+        adapter.addFacet(obj1, new Identity("id1", ""), "f1");
+        adapter.addFacet(obj2, new Identity("id1", ""), "f2");
         Object obj3 = new EmptyI();
-        adapter.addFacet(obj1, Util.stringToIdentity("id2"), "f1");
-        adapter.addFacet(obj2, Util.stringToIdentity("id2"), "f2");
-        adapter.addFacet(obj3, Util.stringToIdentity("id2"), "");
+        adapter.addFacet(obj1, new Identity("id2", ""), "f1");
+        adapter.addFacet(obj2, new Identity("id2", ""), "f2");
+        adapter.addFacet(obj3, new Identity("id2", ""), "");
         Map<String, Object> fm =
-            adapter.removeAllFacets(Util.stringToIdentity("id1"));
+            adapter.removeAllFacets(new Identity("id1", ""));
         test(fm.size() == 2);
         test(fm.get("f1") == obj1);
         test(fm.get("f2") == obj2);
         try {
-            adapter.removeAllFacets(Util.stringToIdentity("id1"));
+            adapter.removeAllFacets(new Identity("id1", ""));
             test(false);
         } catch (NotRegisteredException ex) {}
-        fm = adapter.removeAllFacets(Util.stringToIdentity("id2"));
+        fm = adapter.removeAllFacets(new Identity("id2", ""));
         test(fm.size() == 3);
         test(fm.get("f1") == obj1);
         test(fm.get("f2") == obj2);

--- a/java/test/src/main/java/test/Ice/facets/Collocated.java
+++ b/java/test/src/main/java/test/Ice/facets/Collocated.java
@@ -3,9 +3,9 @@
 package test.Ice.facets;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -15,12 +15,12 @@ public class Collocated extends TestHelper {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object d = new DI();
-            adapter.add(d, Util.stringToIdentity("d"));
-            adapter.addFacet(d, Util.stringToIdentity("d"), "facetABCD");
+            adapter.add(d, new Identity("d", ""));
+            adapter.addFacet(d, new Identity("d", ""), "facetABCD");
             Object f = new FI();
-            adapter.addFacet(f, Util.stringToIdentity("d"), "facetEF");
+            adapter.addFacet(f, new Identity("d", ""), "facetEF");
             Object h = new HI(communicator);
-            adapter.addFacet(h, Util.stringToIdentity("d"), "facetGH");
+            adapter.addFacet(h, new Identity("d", ""), "facetGH");
 
             AllTests.allTests(this);
         }

--- a/java/test/src/main/java/test/Ice/facets/Server.java
+++ b/java/test/src/main/java/test/Ice/facets/Server.java
@@ -3,9 +3,9 @@
 package test.Ice.facets;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -15,12 +15,12 @@ public class Server extends TestHelper {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object d = new DI();
-            adapter.add(d, Util.stringToIdentity("d"));
-            adapter.addFacet(d, Util.stringToIdentity("d"), "facetABCD");
+            adapter.add(d, new Identity("d", ""));
+            adapter.addFacet(d, new Identity("d", ""), "facetABCD");
             Object f = new FI();
-            adapter.addFacet(f, Util.stringToIdentity("d"), "facetEF");
+            adapter.addFacet(f, new Identity("d", ""), "facetEF");
             Object h = new HI(communicator);
-            adapter.addFacet(h, Util.stringToIdentity("d"), "facetGH");
+            adapter.addFacet(h, new Identity("d", ""), "facetGH");
 
             adapter.activate();
             serverReady();

--- a/java/test/src/main/java/test/Ice/faultTolerance/Server.java
+++ b/java/test/src/main/java/test/Ice/faultTolerance/Server.java
@@ -3,9 +3,9 @@
 package test.Ice.faultTolerance;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -48,7 +48,7 @@ public class Server extends TestHelper {
                 .setProperty("TestAdapter.Endpoints", getTestEndpoint(port));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object object = new TestI(port);
-            adapter.add(object, Util.stringToIdentity("test"));
+            adapter.add(object, new Identity("test", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/hold/Server.java
+++ b/java/test/src/main/java/test/Ice/hold/Server.java
@@ -3,8 +3,8 @@
 package test.Ice.hold;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -28,10 +28,10 @@ public class Server extends TestHelper {
             Timer timer = new Timer();
 
             ObjectAdapter adapter1 = communicator.createObjectAdapter("TestAdapter1");
-            adapter1.add(new HoldI(timer, adapter1), Util.stringToIdentity("hold"));
+            adapter1.add(new HoldI(timer, adapter1), new Identity("hold", ""));
 
             ObjectAdapter adapter2 = communicator.createObjectAdapter("TestAdapter2");
-            adapter2.add(new HoldI(timer, adapter2), Util.stringToIdentity("hold"));
+            adapter2.add(new HoldI(timer, adapter2), new Identity("hold", ""));
 
             adapter1.activate();
             adapter2.activate();

--- a/java/test/src/main/java/test/Ice/info/Server.java
+++ b/java/test/src/main/java/test/Ice/info/Server.java
@@ -3,8 +3,8 @@
 package test.Ice.info;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -14,7 +14,7 @@ public class Server extends TestHelper {
             communicator.getProperties().setProperty(
                 "TestAdapter.Endpoints", getTestEndpoint(0) + ":" + getTestEndpoint(0, "udp"));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new TestI(), Util.stringToIdentity("test"));
+            adapter.add(new TestI(), new Identity("test", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/inheritance/Collocated.java
+++ b/java/test/src/main/java/test/Ice/inheritance/Collocated.java
@@ -3,8 +3,8 @@
 package test.Ice.inheritance;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -14,7 +14,7 @@ public class Collocated extends TestHelper {
         try (Communicator communicator = initialize(args)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new InitialI(adapter), Util.stringToIdentity("initial"));
+            adapter.add(new InitialI(adapter), new Identity("initial", ""));
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/inheritance/Server.java
+++ b/java/test/src/main/java/test/Ice/inheritance/Server.java
@@ -3,9 +3,9 @@
 package test.Ice.inheritance;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -15,7 +15,7 @@ public class Server extends TestHelper {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object object = new InitialI(adapter);
-            adapter.add(object, Util.stringToIdentity("initial"));
+            adapter.add(object, new Identity("initial", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/interrupt/Collocated.java
+++ b/java/test/src/main/java/test/Ice/interrupt/Collocated.java
@@ -3,10 +3,10 @@
 package test.Ice.interrupt;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -31,9 +31,9 @@ public class Collocated extends TestHelper {
             ObjectAdapter adapter2 =
                 communicator().createObjectAdapter("ControllerAdapter");
             TestControllerI controller = new TestControllerI(adapter);
-            adapter.add(new TestI(controller), Util.stringToIdentity("test"));
+            adapter.add(new TestI(controller), new Identity("test", ""));
             // adapter.activate(); // Don't activate OA to ensure collocation is used.
-            adapter2.add(controller, Util.stringToIdentity("testController"));
+            adapter2.add(controller, new Identity("testController", ""));
             // adapter2.activate(); // Don't activate OA to ensure collocation is used.
             AllTests.allTests(this);
         } catch (InterruptedException ex) {

--- a/java/test/src/main/java/test/Ice/interrupt/Server.java
+++ b/java/test/src/main/java/test/Ice/interrupt/Server.java
@@ -3,10 +3,10 @@
 package test.Ice.interrupt;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -35,9 +35,9 @@ public class Server extends TestHelper {
                 communicator.createObjectAdapter("ControllerAdapter");
 
             TestControllerI controller = new TestControllerI(adapter);
-            adapter.add(new TestI(controller), Util.stringToIdentity("test"));
+            adapter.add(new TestI(controller), new Identity("test", ""));
             adapter.activate();
-            adapter2.add(controller, Util.stringToIdentity("testController"));
+            adapter2.add(controller, new Identity("testController", ""));
             adapter2.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/location/Server.java
+++ b/java/test/src/main/java/test/Ice/location/Server.java
@@ -3,10 +3,10 @@
 package test.Ice.location;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.LocatorRegistryPrx;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -36,18 +36,18 @@ public class Server extends TestHelper {
             //
             ServerLocatorRegistry registry = new ServerLocatorRegistry();
             registry.addObject(
-                adapter.createProxy(Util.stringToIdentity("ServerManager")),
+                adapter.createProxy(new Identity("ServerManager", "")),
                 null);
             Object object = new ServerManagerI(registry, this);
-            adapter.add(object, Util.stringToIdentity("ServerManager"));
+            adapter.add(object, new Identity("ServerManager", ""));
 
             LocatorRegistryPrx registryPrx =
                 LocatorRegistryPrx.uncheckedCast(
-                    adapter.add(registry, Util.stringToIdentity("registry")));
+                    adapter.add(registry, new Identity("registry", "")));
 
             adapter.add(
                 new ServerLocator(registry, registryPrx),
-                Util.stringToIdentity("locator"));
+                new Identity("locator", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/location/ServerManagerI.java
+++ b/java/test/src/main/java/test/Ice/location/ServerManagerI.java
@@ -4,13 +4,13 @@ package test.Ice.location;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Current;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.LocatorPrx;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.SocketException;
-import com.zeroc.Ice.Util;
 
 import test.Ice.location.Test.ServerManager;
 import test.TestHelper;
@@ -76,10 +76,10 @@ public class ServerManagerI implements ServerManager {
 
                 Object object = new TestI(adapter, adapter2, _registry);
                 _registry.addObject(
-                    adapter.add(object, Util.stringToIdentity("test")), null);
+                    adapter.add(object, new Identity("test", "")), null);
                 _registry.addObject(
-                    adapter.add(object, Util.stringToIdentity("test2")), null);
-                adapter.add(object, Util.stringToIdentity("test3"));
+                    adapter.add(object, new Identity("test2", "")), null);
+                adapter.add(object, new Identity("test3", ""));
 
                 adapter.activate();
                 adapter2.activate();

--- a/java/test/src/main/java/test/Ice/location/TestI.java
+++ b/java/test/src/main/java/test/Ice/location/TestI.java
@@ -6,7 +6,6 @@ import com.zeroc.Ice.Current;
 import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.NotRegisteredException;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.Ice.location.Test.HelloPrx;
 import test.Ice.location.Test.TestIntf;
@@ -21,7 +20,7 @@ public class TestI implements TestIntf {
         _registry = registry;
 
         _registry.addObject(
-            _adapter1.add(new HelloI(), Util.stringToIdentity("hello")), null);
+            _adapter1.add(new HelloI(), new Identity("hello", "")), null);
     }
 
     @Override
@@ -32,18 +31,18 @@ public class TestI implements TestIntf {
     @Override
     public HelloPrx getHello(Current current) {
         return HelloPrx.uncheckedCast(
-            _adapter1.createIndirectProxy(Util.stringToIdentity("hello")));
+            _adapter1.createIndirectProxy(new Identity("hello", "")));
     }
 
     @Override
     public HelloPrx getReplicatedHello(Current current) {
         return HelloPrx.uncheckedCast(
-            _adapter1.createProxy(Util.stringToIdentity("hello")));
+            _adapter1.createProxy(new Identity("hello", "")));
     }
 
     @Override
     public void migrateHello(Current current) {
-        final Identity id = Util.stringToIdentity("hello");
+        final Identity id = new Identity("hello", "");
         try {
             _registry.addObject(_adapter2.add(_adapter1.remove(id), id), null);
         } catch (NotRegisteredException ex) {

--- a/java/test/src/main/java/test/Ice/metrics/AMDServer.java
+++ b/java/test/src/main/java/test/Ice/metrics/AMDServer.java
@@ -3,11 +3,11 @@
 package test.Ice.metrics;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Properties;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -25,7 +25,7 @@ public class AMDServer extends TestHelper {
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new AMDMetricsI(), Util.stringToIdentity("metrics"));
+            adapter.add(new AMDMetricsI(), new Identity("metrics", ""));
             adapter.activate();
 
             communicator
@@ -42,7 +42,7 @@ public class AMDServer extends TestHelper {
             ObjectAdapter controllerAdapter =
                 communicator.createObjectAdapter("ControllerAdapter");
             controllerAdapter.add(
-                new ControllerI(adapter), Util.stringToIdentity("controller"));
+                new ControllerI(adapter), new Identity("controller", ""));
             controllerAdapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/metrics/Collocated.java
+++ b/java/test/src/main/java/test/Ice/metrics/Collocated.java
@@ -3,10 +3,10 @@
 package test.Ice.metrics;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 import com.zeroc.IceMX.UnknownMetricsView;
 
 import test.Ice.metrics.Test.MetricsPrx;
@@ -29,7 +29,7 @@ public class Collocated extends TestHelper {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
 
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new MetricsI(), Util.stringToIdentity("metrics"));
+            adapter.add(new MetricsI(), new Identity("metrics", ""));
             // adapter.activate(); // Don't activate OA to ensure collocation is used.
 
             communicator
@@ -45,7 +45,7 @@ public class Collocated extends TestHelper {
             ObjectAdapter controllerAdapter =
                 communicator.createObjectAdapter("ControllerAdapter");
             controllerAdapter.add(
-                new ControllerI(adapter), Util.stringToIdentity("controller"));
+                new ControllerI(adapter), new Identity("controller", ""));
             // controllerAdapter.activate(); // Don't activate OA to ensure collocation is used.
 
             MetricsPrx metrics = AllTests.allTests(this, observer);

--- a/java/test/src/main/java/test/Ice/metrics/Server.java
+++ b/java/test/src/main/java/test/Ice/metrics/Server.java
@@ -3,10 +3,10 @@
 package test.Ice.metrics;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -25,7 +25,7 @@ public class Server extends TestHelper {
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new MetricsI(), Util.stringToIdentity("metrics"));
+            adapter.add(new MetricsI(), new Identity("metrics", ""));
             adapter.activate();
 
             communicator
@@ -42,7 +42,7 @@ public class Server extends TestHelper {
             ObjectAdapter controllerAdapter =
                 communicator.createObjectAdapter("ControllerAdapter");
             controllerAdapter.add(
-                new ControllerI(adapter), Util.stringToIdentity("controller"));
+                new ControllerI(adapter), new Identity("controller", ""));
             controllerAdapter.activate();
 
             serverReady();

--- a/java/test/src/main/java/test/Ice/networkProxy/Server.java
+++ b/java/test/src/main/java/test/Ice/networkProxy/Server.java
@@ -4,8 +4,8 @@ package test.Ice.networkProxy;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Current;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.Ice.networkProxy.Test.TestIntf;
 import test.TestHelper;
@@ -21,7 +21,7 @@ public class Server extends TestHelper {
         try (Communicator communicator = initialize(args)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new TestI(), Util.stringToIdentity("test"));
+            adapter.add(new TestI(), new Identity("test", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/objects/Collocated.java
+++ b/java/test/src/main/java/test/Ice/objects/Collocated.java
@@ -5,10 +5,10 @@ package test.Ice.objects;
 import com.zeroc.Ice.ClassSliceLoader;
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.CompositeSliceLoader;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.Ice.objects.Test.Compact;
 import test.Ice.objects.Test.CompactExt;
@@ -37,10 +37,10 @@ public class Collocated extends TestHelper {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Initial initial = new InitialI(adapter);
-            adapter.add(initial, Util.stringToIdentity("initial"));
-            adapter.add(new F2I(), Util.stringToIdentity("F21"));
+            adapter.add(initial, new Identity("initial", ""));
+            adapter.add(new F2I(), new Identity("F21", ""));
             UnexpectedObjectExceptionTestI object = new UnexpectedObjectExceptionTestI();
-            adapter.add(object, Util.stringToIdentity("uoet"));
+            adapter.add(object, new Identity("uoet", ""));
             AllTests.allTests(this);
             //
             // We must call shutdown even in the collocated case for cyclic dependency cleanup.

--- a/java/test/src/main/java/test/Ice/objects/Server.java
+++ b/java/test/src/main/java/test/Ice/objects/Server.java
@@ -3,10 +3,10 @@
 package test.Ice.objects;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -21,11 +21,11 @@ public class Server extends TestHelper {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
 
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new InitialI(adapter), Util.stringToIdentity("initial"));
-            adapter.add(new F2I(), Util.stringToIdentity("F21"));
+            adapter.add(new InitialI(adapter), new Identity("initial", ""));
+            adapter.add(new F2I(), new Identity("F21", ""));
             adapter.add(
                 new UnexpectedObjectExceptionTestI(),
-                Util.stringToIdentity("uoet"));
+                new Identity("uoet", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/operations/AMDMyDerivedClassI.java
+++ b/java/test/src/main/java/test/Ice/operations/AMDMyDerivedClassI.java
@@ -3,8 +3,8 @@
 package test.Ice.operations;
 
 import com.zeroc.Ice.Current;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.OperationMode;
-import com.zeroc.Ice.Util;
 
 import test.Ice.operations.Test.AsyncMyDerivedClass;
 import test.Ice.operations.Test.MyClass;
@@ -247,7 +247,7 @@ public final class AMDMyDerivedClassI implements AsyncMyDerivedClass {
         r.p3 =
             MyClassPrx.uncheckedCast(
                 current.adapter.createProxy(
-                    Util.stringToIdentity("noSuchIdentity")));
+                    new Identity("noSuchIdentity", "")));
         r.returnValue = MyClassPrx.uncheckedCast(current.adapter.createProxy(current.id));
         return CompletableFuture.completedFuture(r);
     }

--- a/java/test/src/main/java/test/Ice/operations/AMDServer.java
+++ b/java/test/src/main/java/test/Ice/operations/AMDServer.java
@@ -3,10 +3,10 @@
 package test.Ice.operations;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -22,7 +22,7 @@ public class AMDServer extends TestHelper {
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new AMDMyDerivedClassI(), Util.stringToIdentity("test"));
+            adapter.add(new AMDMyDerivedClassI(), new Identity("test", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/operations/Collocated.java
+++ b/java/test/src/main/java/test/Ice/operations/Collocated.java
@@ -3,11 +3,11 @@
 package test.Ice.operations;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.ObjectPrx;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -27,7 +27,7 @@ public class Collocated extends TestHelper {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             ObjectPrx prx =
-                adapter.add(new MyDerivedClassI(), Util.stringToIdentity("test"));
+                adapter.add(new MyDerivedClassI(), new Identity("test", ""));
             // adapter.activate(); // Don't activate OA to ensure collocation is used.
 
             if (prx.ice_getConnection() != null) {
@@ -48,7 +48,7 @@ public class Collocated extends TestHelper {
                 .getProperties()
                 .setProperty("TestAdapter.Endpoints", "tcp -h \"0:0:0:0:0:0:0:1\" -p " + port);
             var adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new MyDerivedClassI(), Util.stringToIdentity("test"));
+            adapter.add(new MyDerivedClassI(), new Identity("test", ""));
 
             var prx = ObjectPrx.createProxy(communicator, "test:tcp -h \"::1\" -p " + port);
             prx.ice_ping();

--- a/java/test/src/main/java/test/Ice/operations/Collocated.java
+++ b/java/test/src/main/java/test/Ice/operations/Collocated.java
@@ -43,7 +43,7 @@ public class Collocated extends TestHelper {
         PrintWriter output = helper.getWriter();
         output.print("testing collocated invocation with normalized IPv6 address... ");
         output.flush();
-        try (var communicator = Util.initialize()) {
+        try (var communicator = new Communicator()) {
             communicator
                 .getProperties()
                 .setProperty("TestAdapter.Endpoints", "tcp -h \"0:0:0:0:0:0:0:1\" -p " + port);

--- a/java/test/src/main/java/test/Ice/operations/MyDerivedClassI.java
+++ b/java/test/src/main/java/test/Ice/operations/MyDerivedClassI.java
@@ -4,8 +4,8 @@ package test.Ice.operations;
 
 import com.zeroc.Ice.BZip2;
 import com.zeroc.Ice.Current;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.OperationMode;
-import com.zeroc.Ice.Util;
 
 import test.Ice.operations.Test.MyClass;
 import test.Ice.operations.Test.MyClass1;
@@ -206,7 +206,7 @@ public final class MyDerivedClassI implements MyDerivedClass {
         r.p3 =
             MyClassPrx.uncheckedCast(
                 current.adapter.createProxy(
-                    Util.stringToIdentity("noSuchIdentity")));
+                    new Identity("noSuchIdentity", "")));
         r.returnValue = MyClassPrx.uncheckedCast(current.adapter.createProxy(current.id));
         return r;
     }

--- a/java/test/src/main/java/test/Ice/operations/Server.java
+++ b/java/test/src/main/java/test/Ice/operations/Server.java
@@ -3,10 +3,10 @@
 package test.Ice.operations;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -22,7 +22,7 @@ public class Server extends TestHelper {
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new MyDerivedClassI(), Util.stringToIdentity("test"));
+            adapter.add(new MyDerivedClassI(), new Identity("test", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/operations/Twoways.java
+++ b/java/test/src/main/java/test/Ice/operations/Twoways.java
@@ -62,6 +62,7 @@ import com.zeroc.Ice.ObjectNotExistException;
 import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.Util;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.Locator;
 
 class Twoways {
@@ -280,14 +281,14 @@ class Twoways {
             test(Util.proxyIdentityAndFacetCompare(r.p2, p) == 0);
             test(Util.proxyIdentityAndFacetCompare(r.p3, p) != 0);
             test(Util.proxyIdentityAndFacetCompare(r.returnValue, p) == 0);
-            test(r.p2.ice_getIdentity().equals(Util.stringToIdentity("test")));
+            test(r.p2.ice_getIdentity().equals(new Identity("test", "")));
             test(
                 r.p3.ice_getIdentity()
-                    .equals(Util.stringToIdentity("noSuchIdentity")));
+                    .equals(new Identity("noSuchIdentity", "")));
             test(
                 r.returnValue
                     .ice_getIdentity()
-                    .equals(Util.stringToIdentity("test")));
+                    .equals(new Identity("test", "")));
             r.returnValue.opVoid();
             r.p2.opVoid();
             try {

--- a/java/test/src/main/java/test/Ice/optional/AMDServer.java
+++ b/java/test/src/main/java/test/Ice/optional/AMDServer.java
@@ -3,10 +3,10 @@
 package test.Ice.optional;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -19,7 +19,7 @@ public class AMDServer extends TestHelper {
         try (Communicator communicator = initialize(initData)) {
             communicator().getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new AMDInitialI(), Util.stringToIdentity("initial"));
+            adapter.add(new AMDInitialI(), new Identity("initial", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/optional/Server.java
+++ b/java/test/src/main/java/test/Ice/optional/Server.java
@@ -3,10 +3,10 @@
 package test.Ice.optional;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -19,7 +19,7 @@ public class Server extends TestHelper {
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new InitialI(), Util.stringToIdentity("initial"));
+            adapter.add(new InitialI(), new Identity("initial", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/packagemd/Server.java
+++ b/java/test/src/main/java/test/Ice/packagemd/Server.java
@@ -3,10 +3,10 @@
 package test.Ice.packagemd;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.Object;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Properties;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -19,7 +19,7 @@ public class Server extends TestHelper {
             properties.setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             Object object = new InitialI();
-            adapter.add(object, Util.stringToIdentity("initial"));
+            adapter.add(object, new Identity("initial", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/properties/Client.java
+++ b/java/test/src/main/java/test/Ice/properties/Client.java
@@ -2,9 +2,9 @@
 
 package test.Ice.properties;
 
+import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.PropertyException;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -133,7 +133,7 @@ public class Client extends TestHelper {
         }
 
         {
-            try (var communicator = Util.initialize()) {
+            try (var communicator = new Communicator()) {
                 var properties = communicator.getProperties();
 
                 System.out.print(

--- a/java/test/src/main/java/test/Ice/proxy/AllTests.java
+++ b/java/test/src/main/java/test/Ice/proxy/AllTests.java
@@ -1092,7 +1092,7 @@ public class AllTests {
         out.print("testing communicator shutdown/destroy... ");
         out.flush();
         {
-            Communicator co = Util.initialize();
+            Communicator co = new Communicator();
             co.shutdown();
             test(co.isShutdown());
             co.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/proxy/AllTests.java
+++ b/java/test/src/main/java/test/Ice/proxy/AllTests.java
@@ -419,7 +419,7 @@ public class AllTests {
 
         // not colloc-optimized target
         if (b1.ice_getConnection() != null) {
-            b2 = b1.ice_getConnection().createProxy(Util.stringToIdentity("fixed"));
+            b2 = b1.ice_getConnection().createProxy(new Identity("fixed", ""));
             String str = communicator.proxyToString(b2);
             test(b2.toString().equals(str));
             String str2 = b1.ice_identity(b2.ice_getIdentity()).toString();

--- a/java/test/src/main/java/test/Ice/proxy/Collocated.java
+++ b/java/test/src/main/java/test/Ice/proxy/Collocated.java
@@ -3,8 +3,8 @@
 package test.Ice.proxy;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -16,8 +16,8 @@ public class Collocated extends TestHelper {
         try (Communicator communicator = initialize(properties)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new MyDerivedClassI(), Util.stringToIdentity("test"));
-            adapter.add(new CI(), Util.stringToIdentity("c"));
+            adapter.add(new MyDerivedClassI(), new Identity("test", ""));
+            adapter.add(new CI(), new Identity("c", ""));
             // adapter.activate(); // Don't activate OA to ensure collocation is used.
             AllTests.allTests(this);
         }

--- a/java/test/src/main/java/test/Ice/proxy/Server.java
+++ b/java/test/src/main/java/test/Ice/proxy/Server.java
@@ -3,8 +3,8 @@
 package test.Ice.proxy;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -16,8 +16,8 @@ public class Server extends TestHelper {
         try (Communicator communicator = initialize(properties)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new MyDerivedClassI(), Util.stringToIdentity("test"));
-            adapter.add(new CI(), Util.stringToIdentity("c"));
+            adapter.add(new MyDerivedClassI(), new Identity("test", ""));
+            adapter.add(new CI(), new Identity("c", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/retry/Collocated.java
+++ b/java/test/src/main/java/test/Ice/retry/Collocated.java
@@ -3,9 +3,9 @@
 package test.Ice.retry;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.Ice.retry.Test.RetryPrx;
 import test.TestHelper;
@@ -15,7 +15,7 @@ public class Collocated extends TestHelper {
 
     private void setupObjectAdapter(Communicator communicator) {
         ObjectAdapter adapter = communicator.createObjectAdapter("");
-        adapter.add(new RetryI(), Util.stringToIdentity("retry"));
+        adapter.add(new RetryI(), new Identity("retry", ""));
         // adapter.activate(); // Don't activate OA to ensure collocation is used.
     }
 

--- a/java/test/src/main/java/test/Ice/retry/Server.java
+++ b/java/test/src/main/java/test/Ice/retry/Server.java
@@ -3,8 +3,8 @@
 package test.Ice.retry;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -17,7 +17,7 @@ public class Server extends TestHelper {
         try (Communicator communicator = initialize(properties)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new RetryI(), Util.stringToIdentity("retry"));
+            adapter.add(new RetryI(), new Identity("retry", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/scope/Server.java
+++ b/java/test/src/main/java/test/Ice/scope/Server.java
@@ -4,10 +4,10 @@ package test.Ice.scope;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Current;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.Ice.scope.Test.MyClass;
 import test.Ice.scope.Test.MyEnum;
@@ -270,10 +270,10 @@ public class Server extends TestHelper {
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new MyInterface1(), Util.stringToIdentity("i1"));
-            adapter.add(new MyInterface2(), Util.stringToIdentity("i2"));
-            adapter.add(new MyInterface3(), Util.stringToIdentity("i3"));
-            adapter.add(new MyInterface4(), Util.stringToIdentity("i4"));
+            adapter.add(new MyInterface1(), new Identity("i1", ""));
+            adapter.add(new MyInterface2(), new Identity("i2", ""));
+            adapter.add(new MyInterface3(), new Identity("i3", ""));
+            adapter.add(new MyInterface4(), new Identity("i4", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/seqMapping/AMDServer.java
+++ b/java/test/src/main/java/test/Ice/seqMapping/AMDServer.java
@@ -3,10 +3,10 @@
 package test.Ice.seqMapping;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -20,7 +20,7 @@ public class AMDServer extends TestHelper {
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new AMDMyClassI(), Util.stringToIdentity("test"));
+            adapter.add(new AMDMyClassI(), new Identity("test", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/seqMapping/Collocated.java
+++ b/java/test/src/main/java/test/Ice/seqMapping/Collocated.java
@@ -3,10 +3,10 @@
 package test.Ice.seqMapping;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -19,7 +19,7 @@ public class Collocated extends TestHelper {
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new MyClassI(), Util.stringToIdentity("test"));
+            adapter.add(new MyClassI(), new Identity("test", ""));
             // adapter.activate(); // Don't activate OA to ensure collocation is used.
             AllTests.allTests(this, true);
         }

--- a/java/test/src/main/java/test/Ice/seqMapping/Server.java
+++ b/java/test/src/main/java/test/Ice/seqMapping/Server.java
@@ -3,10 +3,10 @@
 package test.Ice.seqMapping;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -19,7 +19,7 @@ public class Server extends TestHelper {
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator().createObjectAdapter("TestAdapter");
-            adapter.add(new MyClassI(), Util.stringToIdentity("test"));
+            adapter.add(new MyClassI(), new Identity("test", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/serialize/Server.java
+++ b/java/test/src/main/java/test/Ice/serialize/Server.java
@@ -7,7 +7,6 @@ import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -20,7 +19,7 @@ public class Server extends TestHelper {
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0));
             ObjectAdapter adapter = communicator().createObjectAdapter("TestAdapter");
-            Identity ident = Util.stringToIdentity("initial");
+            Identity ident = new Identity("initial", "");
             adapter.add(new InitialI(adapter, ident), ident);
             adapter.activate();
             serverReady();

--- a/java/test/src/main/java/test/Ice/servantLocator/AMDServer.java
+++ b/java/test/src/main/java/test/Ice/servantLocator/AMDServer.java
@@ -3,10 +3,10 @@
 package test.Ice.servantLocator;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -22,10 +22,10 @@ public class AMDServer extends TestHelper {
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.addServantLocator(new AMDServantLocatorI("category"), "category");
             adapter.addServantLocator(new AMDServantLocatorI(""), "");
-            adapter.add(new AMDTestI(), Util.stringToIdentity("asm"));
+            adapter.add(new AMDTestI(), new Identity("asm", ""));
             adapter.add(
                 new AMDTestActivationI(),
-                Util.stringToIdentity("test/activation"));
+                new Identity("activation", "test"));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/servantLocator/Collocated.java
+++ b/java/test/src/main/java/test/Ice/servantLocator/Collocated.java
@@ -3,10 +3,10 @@
 package test.Ice.servantLocator;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -23,9 +23,9 @@ public class Collocated extends TestHelper {
             ObjectAdapter adapter = communicator().createObjectAdapter("TestAdapter");
             adapter.addServantLocator(new ServantLocatorI("category"), "category");
             adapter.addServantLocator(new ServantLocatorI(""), "");
-            adapter.add(new TestI(), Util.stringToIdentity("asm"));
+            adapter.add(new TestI(), new Identity("asm", ""));
             adapter.add(
-                new TestActivationI(), Util.stringToIdentity("test/activation"));
+                new TestActivationI(), new Identity("activation", "test"));
             AllTests.allTests(this);
         }
     }

--- a/java/test/src/main/java/test/Ice/servantLocator/Server.java
+++ b/java/test/src/main/java/test/Ice/servantLocator/Server.java
@@ -3,10 +3,10 @@
 package test.Ice.servantLocator;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -22,9 +22,9 @@ public class Server extends TestHelper {
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
             adapter.addServantLocator(new ServantLocatorI("category"), "category");
             adapter.addServantLocator(new ServantLocatorI(""), "");
-            adapter.add(new TestI(), Util.stringToIdentity("asm"));
+            adapter.add(new TestI(), new Identity("asm", ""));
             adapter.add(
-                new TestActivationI(), Util.stringToIdentity("test/activation"));
+                new TestActivationI(), new Identity("activation", "test"));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/slicing/exceptions/AMDServer.java
+++ b/java/test/src/main/java/test/Ice/slicing/exceptions/AMDServer.java
@@ -3,10 +3,10 @@
 package test.Ice.slicing.exceptions;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -20,7 +20,7 @@ public class AMDServer extends TestHelper {
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint(0) + " -t 2000");
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new AMDTestI(), Util.stringToIdentity("Test"));
+            adapter.add(new AMDTestI(), new Identity("Test", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/slicing/exceptions/Server.java
+++ b/java/test/src/main/java/test/Ice/slicing/exceptions/Server.java
@@ -3,10 +3,10 @@
 package test.Ice.slicing.exceptions;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -22,7 +22,7 @@ public class Server extends TestHelper {
                 .getProperties()
                 .setProperty("TestAdapter.Endpoints", getTestEndpoint(0) + " -t 2000");
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new TestI(), Util.stringToIdentity("Test"));
+            adapter.add(new TestI(), new Identity("Test", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/slicing/objects/AMDServer.java
+++ b/java/test/src/main/java/test/Ice/slicing/objects/AMDServer.java
@@ -3,10 +3,10 @@
 package test.Ice.slicing.objects;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -22,7 +22,7 @@ public class AMDServer extends TestHelper {
                 .getProperties()
                 .setProperty("TestAdapter.Endpoints", getTestEndpoint(0) + " -t 2000");
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new AMDTestI(), Util.stringToIdentity("Test"));
+            adapter.add(new AMDTestI(), new Identity("Test", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/slicing/objects/Server.java
+++ b/java/test/src/main/java/test/Ice/slicing/objects/Server.java
@@ -3,10 +3,10 @@
 package test.Ice.slicing.objects;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -22,7 +22,7 @@ public class Server extends TestHelper {
                 .getProperties()
                 .setProperty("TestAdapter.Endpoints", getTestEndpoint(0) + " -t 2000");
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new TestI(), Util.stringToIdentity("Test"));
+            adapter.add(new TestI(), new Identity("Test", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/threadPoolPriority/Server.java
+++ b/java/test/src/main/java/test/Ice/threadPoolPriority/Server.java
@@ -3,9 +3,9 @@
 package test.Ice.threadPoolPriority;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.Properties;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -18,7 +18,7 @@ public class Server extends TestHelper {
                 .getProperties()
                 .setProperty("TestAdapter.Endpoints", getTestEndpoint(0) + " -t 10000");
             ObjectAdapter adapter = communicator().createObjectAdapter("TestAdapter");
-            adapter.add(new PriorityI(), Util.stringToIdentity("test"));
+            adapter.add(new PriorityI(), new Identity("test", ""));
             adapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/timeout/Server.java
+++ b/java/test/src/main/java/test/Ice/timeout/Server.java
@@ -3,8 +3,8 @@
 package test.Ice.timeout;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -18,13 +18,13 @@ public class Server extends TestHelper {
             communicator.getProperties().setProperty("ControllerAdapter.ThreadPool.Size", "1");
 
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new TimeoutI(), Util.stringToIdentity("timeout"));
+            adapter.add(new TimeoutI(), new Identity("timeout", ""));
             adapter.activate();
 
             ObjectAdapter controllerAdapter =
                 communicator.createObjectAdapter("ControllerAdapter");
             controllerAdapter.add(
-                new ControllerI(adapter), Util.stringToIdentity("controller"));
+                new ControllerI(adapter), new Identity("controller", ""));
             controllerAdapter.activate();
             serverReady();
             communicator.waitForShutdown();

--- a/java/test/src/main/java/test/Ice/udp/Server.java
+++ b/java/test/src/main/java/test/Ice/udp/Server.java
@@ -3,8 +3,8 @@
 package test.Ice.udp;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -37,13 +37,13 @@ public class Server extends TestHelper {
                 .getProperties()
                 .setProperty("ControlAdapter.Endpoints", getTestEndpoint(num, "tcp"));
             ObjectAdapter adapter = communicator.createObjectAdapter("ControlAdapter");
-            adapter.add(new TestIntfI(), Util.stringToIdentity("control"));
+            adapter.add(new TestIntfI(), new Identity("control", ""));
             adapter.activate();
 
             if (num == 0) {
                 properties.setProperty("TestAdapter.Endpoints", getTestEndpoint(num, "udp"));
                 ObjectAdapter adapter2 = communicator.createObjectAdapter("TestAdapter");
-                adapter2.add(new TestIntfI(), Util.stringToIdentity("test"));
+                adapter2.add(new TestIntfI(), new Identity("test", ""));
                 adapter2.activate();
             }
 
@@ -59,7 +59,7 @@ public class Server extends TestHelper {
 
             // Not used for IPv6 + Android emulator, but doesn't fail either.
             ObjectAdapter mcastAdapter = communicator.createObjectAdapter("McastTestAdapter");
-            mcastAdapter.add(new TestIntfI(), Util.stringToIdentity("test"));
+            mcastAdapter.add(new TestIntfI(), new Identity("test", ""));
             mcastAdapter.activate();
 
             serverReady();

--- a/java/test/src/main/java/test/IceBox/configuration/TestServiceI.java
+++ b/java/test/src/main/java/test/IceBox/configuration/TestServiceI.java
@@ -3,15 +3,15 @@
 package test.IceBox.configuration;
 
 import com.zeroc.Ice.Communicator;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 import com.zeroc.IceBox.Service;
 
 public class TestServiceI implements Service {
     @Override
     public void start(String name, Communicator communicator, String[] args) {
         ObjectAdapter adapter = communicator.createObjectAdapter(name + "OA");
-        adapter.add(new TestI(args), Util.stringToIdentity("test"));
+        adapter.add(new TestI(args), new Identity("test", ""));
         adapter.activate();
     }
 

--- a/java/test/src/main/java/test/IceDiscovery/simple/AllTests.java
+++ b/java/test/src/main/java/test/IceDiscovery/simple/AllTests.java
@@ -7,7 +7,6 @@ import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.LocalException;
 import com.zeroc.Ice.NoEndpointException;
 import com.zeroc.Ice.ObjectNotExistException;
-import com.zeroc.Ice.Util;
 
 import test.IceDiscovery.simple.Test.ControllerPrx;
 import test.IceDiscovery.simple.Test.TestIntfPrx;
@@ -196,7 +195,7 @@ public class AllTests {
                 initData.properties = communicator.getProperties()._clone();
                 initData.properties.setProperty(
                     "IceDiscovery.Lookup", "udp -h " + multicast + " --interface unknown");
-                Communicator comm = Util.initialize(initData);
+                Communicator comm = new Communicator(initData);
                 test(comm.getDefaultLocator() != null);
                 try {
                     comm.stringToProxy("controller0@control0").ice_ping();
@@ -222,7 +221,7 @@ public class AllTests {
                         + " -p "
                         + port
                         + intf);
-                Communicator comm = Util.initialize(initData);
+                Communicator comm = new Communicator(initData);
                 test(comm.getDefaultLocator() != null);
                 comm.stringToProxy("controller0@control0").ice_ping();
                 comm.destroy();

--- a/java/test/src/main/java/test/IceGrid/simple/AllTests.java
+++ b/java/test/src/main/java/test/IceGrid/simple/AllTests.java
@@ -108,7 +108,7 @@ public class AllTests {
                 "AdapterForDiscoveryTest.AdapterId", "discoveryAdapter");
             initData.properties.setProperty("AdapterForDiscoveryTest.Endpoints", "default");
 
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
             test(comm.getDefaultLocator() != null);
             comm.stringToProxy("test @ TestAdapter").ice_ping();
             comm.stringToProxy("test").ice_ping();
@@ -134,7 +134,7 @@ public class AllTests {
             initData.properties.setProperty("IceLocatorDiscovery.InstanceName", "unknown");
             initData.properties.setProperty("IceLocatorDiscovery.RetryCount", "1");
             initData.properties.setProperty("IceLocatorDiscovery.Timeout", "100");
-            comm = Util.initialize(initData);
+            comm = new Communicator(initData);
             test(comm.getDefaultLocator() != null);
             try {
                 comm.stringToProxy("test @ TestAdapter").ice_ping();
@@ -167,7 +167,7 @@ public class AllTests {
             initData.properties.setProperty("Ice.Default.Locator", "");
             initData.properties.setProperty(
                 "IceLocatorDiscovery.Lookup", "udp -h " + multicast + " --interface unknown");
-            comm = Util.initialize(initData);
+            comm = new Communicator(initData);
             test(comm.getDefaultLocator() != null);
             try {
                 comm.stringToProxy("test @ TestAdapter").ice_ping();
@@ -180,7 +180,7 @@ public class AllTests {
             initData.properties.setProperty("IceLocatorDiscovery.RetryCount", "0");
             initData.properties.setProperty(
                 "IceLocatorDiscovery.Lookup", "udp -h " + multicast + " --interface unknown");
-            comm = Util.initialize(initData);
+            comm = new Communicator(initData);
             test(comm.getDefaultLocator() != null);
             try {
                 comm.stringToProxy("test @ TestAdapter").ice_ping();
@@ -208,7 +208,7 @@ public class AllTests {
                         + port
                         + intf);
             }
-            comm = Util.initialize(initData);
+            comm = new Communicator(initData);
             test(comm.getDefaultLocator() != null);
             try {
                 comm.stringToProxy("test @ TestAdapter").ice_ping();

--- a/java/test/src/main/java/test/IceSSL/configuration/AllTests.java
+++ b/java/test/src/main/java/test/IceSSL/configuration/AllTests.java
@@ -14,7 +14,6 @@ import com.zeroc.Ice.Properties;
 import com.zeroc.Ice.SSL.ConnectionInfo;
 import com.zeroc.Ice.SecurityException;
 import com.zeroc.Ice.SocketException;
-import com.zeroc.Ice.Util;
 import com.zeroc.Ice.WSConnectionInfo;
 
 import test.IceSSL.configuration.Test.ServerFactoryPrx;
@@ -132,7 +131,7 @@ public class AllTests {
 
             // Test Ice.SSL.VerifyPeer=0. Client does not have a certificate, but it still verifies the server's.
             initData = createClientProps(defaultProperties, "", "ca1/ca1", keystoreType);
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
             d = createServerProps(defaultProperties, "ca1/server", "", keystoreType);
@@ -150,7 +149,7 @@ public class AllTests {
 
             // Test Ice.SSL.VerifyPeer=1. Client does not have a certificate.
             initData = createClientProps(defaultProperties, "", "ca1/ca1", keystoreType);
-            comm = Util.initialize(initData);
+            comm = new Communicator(initData);
             fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
             d = createServerProps(defaultProperties, "ca1/server", "", keystoreType);
@@ -188,7 +187,7 @@ public class AllTests {
             // Provide "ca1/ca1" to the client to verify the server certificate (without this the client connection
             // wouldn't be able to provide the certificate chain).
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
-            comm = Util.initialize(initData);
+            comm = new Communicator(initData);
             fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
             d = createServerProps(defaultProperties, "ca1/server", "ca1/ca1", keystoreType);
@@ -234,7 +233,7 @@ public class AllTests {
             // Test Ice.SSL.VerifyPeer=1. This should fail because the client doesn't trust the server's CA.
             initData = createClientProps(defaultProperties, "", "", keystoreType);
             initData.properties.setProperty("IceSSL.VerifyPeer", "1");
-            comm = Util.initialize(initData);
+            comm = new Communicator(initData);
             fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
             d = createServerProps(defaultProperties, "ca1/server", "ca1/ca1", keystoreType);
@@ -256,7 +255,7 @@ public class AllTests {
             // Test Ice.SSL.VerifyPeer=1. This should fail because the server doesn't trust the client's CA.
             initData = createClientProps(defaultProperties, "ca2/client", "", keystoreType);
             initData.properties.setProperty("IceSSL.VerifyPeer", "0");
-            comm = Util.initialize(initData);
+            comm = new Communicator(initData);
             fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
             d = createServerProps(defaultProperties, "ca1/server", "", keystoreType);
@@ -279,7 +278,7 @@ public class AllTests {
             // This should succeed because the self signed certificate used by the server is trusted.
             initData = createClientProps(defaultProperties, "", "ca2/ca2", keystoreType);
             initData.properties.setProperty("IceSSL.VerifyPeer", "1");
-            comm = Util.initialize(initData);
+            comm = new Communicator(initData);
             fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
             d = createServerProps(defaultProperties, "ca2/ca2", "", keystoreType);
@@ -297,7 +296,7 @@ public class AllTests {
             // This should fail because the self signed certificate used by the server is not trusted.
             initData = createClientProps(defaultProperties);
             initData.properties.setProperty("IceSSL.VerifyPeer", "1");
-            comm = Util.initialize(initData);
+            comm = new Communicator(initData);
             fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
             d = createServerProps(defaultProperties, "ca2/ca2", "", keystoreType);
@@ -317,7 +316,7 @@ public class AllTests {
 
             // Verify that Ice.SSL.CheckCertName has no effect in a server.
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
-            comm = Util.initialize(initData);
+            comm = new Communicator(initData);
 
             fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -343,7 +342,7 @@ public class AllTests {
                 {
                     initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
                     initData.properties.setProperty("IceSSL.CheckCertName", "1");
-                    comm = Util.initialize(initData);
+                    comm = new Communicator(initData);
 
                     fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
                     test(fact != null);
@@ -363,7 +362,7 @@ public class AllTests {
                 {
                     initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
                     initData.properties.setProperty("IceSSL.CheckCertName", "1");
-                    comm = Util.initialize(initData);
+                    comm = new Communicator(initData);
 
                     fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
                     test(fact != null);
@@ -383,7 +382,7 @@ public class AllTests {
                 {
                     initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
                     initData.properties.setProperty("IceSSL.CheckCertName", "1");
-                    comm = Util.initialize(initData);
+                    comm = new Communicator(initData);
 
                     fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
                     test(fact != null);
@@ -404,7 +403,7 @@ public class AllTests {
                 {
                     initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
                     initData.properties.setProperty("IceSSL.CheckCertName", "1");
-                    comm = Util.initialize(initData);
+                    comm = new Communicator(initData);
 
                     fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
                     test(fact != null);
@@ -425,7 +424,7 @@ public class AllTests {
                 {
                     initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
                     initData.properties.setProperty("IceSSL.CheckCertName", "1");
-                    comm = Util.initialize(initData);
+                    comm = new Communicator(initData);
 
                     fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
                     test(fact != null);
@@ -447,7 +446,7 @@ public class AllTests {
                 {
                     initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
                     initData.properties.setProperty("IceSSL.CheckCertName", "1");
-                    comm = Util.initialize(initData);
+                    comm = new Communicator(initData);
 
                     fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
                     test(fact != null);
@@ -467,7 +466,7 @@ public class AllTests {
                 {
                     initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
                     initData.properties.setProperty("IceSSL.CheckCertName", "1");
-                    comm = Util.initialize(initData);
+                    comm = new Communicator(initData);
 
                     fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
                     test(fact != null);
@@ -487,7 +486,7 @@ public class AllTests {
                 {
                     initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
                     initData.properties.setProperty("IceSSL.CheckCertName", "1");
-                    comm = Util.initialize(initData);
+                    comm = new Communicator(initData);
 
                     fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
                     test(fact != null);
@@ -508,7 +507,7 @@ public class AllTests {
                 {
                     initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
                     initData.properties.setProperty("IceSSL.CheckCertName", "0");
-                    comm = Util.initialize(initData);
+                    comm = new Communicator(initData);
 
                     fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
                     test(fact != null);
@@ -534,7 +533,7 @@ public class AllTests {
         {
             // This should fail because the server's certificate is expired.
             initData = createClientProps(defaultProperties, "ca1/client", "ca5/ca5", keystoreType);
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
             d = createServerProps(defaultProperties, "ca5/server_expired", "ca1/ca1", keystoreType);
@@ -554,7 +553,7 @@ public class AllTests {
 
             // This should fail because the client's certificate is expired.
             initData = createClientProps(defaultProperties, "ca5/client_expired", "ca1/ca1", keystoreType);
-            comm = Util.initialize(initData);
+            comm = new Communicator(initData);
             fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
             d = createServerProps(defaultProperties, "ca1/server", "ca5/ca5", keystoreType);
@@ -580,7 +579,7 @@ public class AllTests {
         out.flush();
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca_all", keystoreType);
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
             d = createServerProps(defaultProperties, "ca2/server", "ca_all", keystoreType);
@@ -608,7 +607,7 @@ public class AllTests {
             initData.properties.setProperty("IceSSL.KeystoreType", keystoreType);
             // Don't specify the password.
             try {
-                Util.initialize(initData);
+                new Communicator(initData);
                 test(false);
             } catch (InitializationException ex) {
                 // Expected.
@@ -627,7 +626,7 @@ public class AllTests {
                 "IceSSL.TrustOnly",
                 "C=US, ST=Florida, L=Jupiter, O=ZeroC, OU=Ice test infrastructure,"
                     + " emailAddress=info@zeroc.com, CN=ca1.server");
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -648,7 +647,7 @@ public class AllTests {
                 "IceSSL.TrustOnly",
                 "!C=US, ST=Florida, L=Jupiter, O=ZeroC, OU=Ice test infrastructure,"
                     + " emailAddress=info@zeroc.com, CN=ca1.server");
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -667,7 +666,7 @@ public class AllTests {
                 "IceSSL.TrustOnly",
                 "C=US, ST=Florida, L=Jupiter, O=ZeroC, OU=Ice test infrastructure,"
                     + " emailAddress=info@zeroc.com, CN=ca1.server");
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -684,7 +683,7 @@ public class AllTests {
         }
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -705,7 +704,7 @@ public class AllTests {
         }
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -725,7 +724,7 @@ public class AllTests {
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
             initData.properties.setProperty("IceSSL.TrustOnly", "CN=ca1.server");
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -743,7 +742,7 @@ public class AllTests {
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
             initData.properties.setProperty("IceSSL.TrustOnly", "!CN=ca1.server");
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -758,7 +757,7 @@ public class AllTests {
         }
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -776,7 +775,7 @@ public class AllTests {
         }
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -793,7 +792,7 @@ public class AllTests {
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
             initData.properties.setProperty("IceSSL.TrustOnly", "CN=ca1.client");
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -808,7 +807,7 @@ public class AllTests {
         }
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -825,7 +824,7 @@ public class AllTests {
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
             initData.properties.setProperty("IceSSL.TrustOnly", "C=Canada,CN=ca1.server");
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -841,7 +840,7 @@ public class AllTests {
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
             initData.properties.setProperty("IceSSL.TrustOnly", "!C=Canada,CN=ca1.server");
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -859,7 +858,7 @@ public class AllTests {
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
             initData.properties.setProperty("IceSSL.TrustOnly", "C=Canada;CN=ca1.server");
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -877,7 +876,7 @@ public class AllTests {
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
             initData.properties.setProperty("IceSSL.TrustOnly", "!C=Canada;!CN=ca1.server");
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -894,7 +893,7 @@ public class AllTests {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
             initData.properties.setProperty(
                 "IceSSL.TrustOnly", "!CN=ca1.server1"); // Should not match "Server"
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -911,7 +910,7 @@ public class AllTests {
         }
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -931,7 +930,7 @@ public class AllTests {
             // Rejection takes precedence (client).
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
             initData.properties.setProperty("IceSSL.TrustOnly", "ST=Florida;!CN=ca1.server;C=US");
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -947,7 +946,7 @@ public class AllTests {
         {
             // Rejection takes precedence (server).
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -971,7 +970,7 @@ public class AllTests {
                 "IceSSL.TrustOnly.Client",
                 "C=US, ST=Florida, L=Jupiter, O=ZeroC,OU=Ice test infrastructure,"
                     + " emailAddress=info@zeroc.com, CN=ca1.server");
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -997,7 +996,7 @@ public class AllTests {
                 "IceSSL.TrustOnly.Client",
                 "!C=US, ST=Florida, L=Jupiter, O=ZeroC,OU=Ice test infrastructure,"
                     + " emailAddress=info@zeroc.com, CN=ca1.server");
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -1012,7 +1011,7 @@ public class AllTests {
         }
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -1032,7 +1031,7 @@ public class AllTests {
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
             initData.properties.setProperty("IceSSL.TrustOnly.Client", "CN=ca1.client");
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -1048,7 +1047,7 @@ public class AllTests {
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
             initData.properties.setProperty("IceSSL.TrustOnly.Client", "!CN=ca1.client");
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -1074,7 +1073,7 @@ public class AllTests {
                 "IceSSL.TrustOnly.Server",
                 "C=US, ST=Florida, L=Jupiter, O=ZeroC,OU=Ice test infrastructure,"
                     + " emailAddress=info@zeroc.com, CN=ca1.client");
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -1095,7 +1094,7 @@ public class AllTests {
         }
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -1116,7 +1115,7 @@ public class AllTests {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
             // Should have no effect.
             initData.properties.setProperty("IceSSL.TrustOnly.Server", "!CN=ca1.server");
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -1133,7 +1132,7 @@ public class AllTests {
         }
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -1149,7 +1148,7 @@ public class AllTests {
         }
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -1169,7 +1168,7 @@ public class AllTests {
         out.flush();
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -1191,7 +1190,7 @@ public class AllTests {
         }
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -1210,7 +1209,7 @@ public class AllTests {
         }
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
 
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
@@ -1226,7 +1225,7 @@ public class AllTests {
         }
         {
             initData = createClientProps(defaultProperties, "ca1/client", "ca1/ca1", keystoreType);
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
             ServerFactoryPrx fact = ServerFactoryPrx.checkedCast(comm.stringToProxy(factoryRef));
             test(fact != null);
             d = createServerProps(defaultProperties, "ca1/server", "ca1/ca1", keystoreType);
@@ -1252,7 +1251,7 @@ public class AllTests {
             int retryCount = 0;
 
             initData = createClientProps(defaultProperties);
-            Communicator comm = Util.initialize(initData);
+            Communicator comm = new Communicator(initData);
             ObjectPrx p =
                 comm.stringToProxy(
                     "dummy:wss -p 443 -h zeroc.com -r /demo-proxy/chat/glacier2");
@@ -1289,7 +1288,7 @@ public class AllTests {
             retryCount = 0;
             initData = createClientProps(defaultProperties);
             initData.properties.setProperty("IceSSL.UsePlatformCAs", "1");
-            comm = Util.initialize(initData);
+            comm = new Communicator(initData);
             p = comm.stringToProxy("dummy:wss -p 443 -h zeroc.com -r /demo-proxy/chat/glacier2");
             while (true) {
                 try {

--- a/java/test/src/main/java/test/IceSSL/configuration/PlatformTests.java
+++ b/java/test/src/main/java/test/IceSSL/configuration/PlatformTests.java
@@ -4,10 +4,10 @@ package test.IceSSL.configuration;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.ConnectionLostException;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.SecurityException;
-import com.zeroc.Ice.Util;
 
 import test.IceSSL.configuration.Test.ServerPrx;
 import test.TestHelper;
@@ -96,7 +96,7 @@ public class PlatformTests {
                     engine.setNeedClientAuth(clientCertificateRequired);
                     return engine;
                 });
-        adapter.add(new ServerI(communicator), Util.stringToIdentity("server"));
+        adapter.add(new ServerI(communicator), new Identity("server", ""));
         adapter.activate();
         return communicator;
     }
@@ -347,7 +347,7 @@ public class PlatformTests {
                         return sslContext.createSSLEngine(peerHost, peerPort);
                     });
             adapter.add(
-                new ServerI(serverCommunicator), Util.stringToIdentity("server"));
+                new ServerI(serverCommunicator), new Identity("server", ""));
             adapter.activate();
 
             try (var clientCommunicator =

--- a/java/test/src/main/java/test/IceSSL/configuration/PlatformTests.java
+++ b/java/test/src/main/java/test/IceSSL/configuration/PlatformTests.java
@@ -86,7 +86,7 @@ public class PlatformTests {
             trustManagerFactory == null ? null : trustManagerFactory.getTrustManagers();
         sslContext.init(keyManagers, trustManagers, null);
 
-        var communicator = Util.initialize();
+        var communicator = new Communicator();
         var adapter =
             communicator.createObjectAdapterWithEndpoints(
                 "ServerAdapter",
@@ -120,7 +120,7 @@ public class PlatformTests {
         var initializationData = new InitializationData();
         initializationData.clientSSLEngineFactory =
             (String peerHost, int peerPort) -> sslContext.createSSLEngine(peerHost, peerPort);
-        return Util.initialize(initializationData);
+        return new Communicator(initializationData);
     }
 
     public static void clientValidatesServerUsingTrustStore(
@@ -335,7 +335,7 @@ public class PlatformTests {
             }
         }
 
-        try (var serverCommunicator = Util.initialize()) {
+        try (var serverCommunicator = new Communicator()) {
             var keyManager = new ReloadableKeyManager(certificatesPath + "/ca1/server.jks");
             var sslContext = SSLContext.getInstance("TLS");
             sslContext.init(new KeyManager[]{keyManager}, null, null);

--- a/java/test/src/main/java/test/IceSSL/configuration/Server.java
+++ b/java/test/src/main/java/test/IceSSL/configuration/Server.java
@@ -5,7 +5,6 @@ package test.IceSSL.configuration;
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 
@@ -25,7 +24,7 @@ public class Server extends TestHelper {
                 .getProperties()
                 .setProperty("TestAdapter.Endpoints", getTestEndpoint(0, "tcp"));
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            Identity id = Util.stringToIdentity("factory");
+            Identity id = new Identity("factory", "");
             adapter.add(new ServerFactoryI(remainingArgs.get(0)), id);
             adapter.activate();
             serverReady();

--- a/java/test/src/main/java/test/IceSSL/configuration/ServerFactoryI.java
+++ b/java/test/src/main/java/test/IceSSL/configuration/ServerFactoryI.java
@@ -9,7 +9,6 @@ import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ObjectAdapter;
 import com.zeroc.Ice.ObjectPrx;
 import com.zeroc.Ice.Properties;
-import com.zeroc.Ice.Util;
 
 import test.IceSSL.configuration.Test.ServerFactory;
 import test.IceSSL.configuration.Test.ServerPrx;
@@ -37,7 +36,7 @@ class ServerFactoryI implements ServerFactory {
             initData.properties.setProperty(i.getKey(), i.getValue());
         }
         initData.properties.setProperty("IceSSL.DefaultDir", _defaultDir);
-        Communicator communicator = Util.initialize(initData);
+        Communicator communicator = new Communicator(initData);
         ObjectAdapter adapter =
             communicator.createObjectAdapterWithEndpoints("ServerAdapter", "ssl");
         ServerI server = new ServerI(communicator);

--- a/java/test/src/main/java/test/Slice/escape/Client.java
+++ b/java/test/src/main/java/test/Slice/escape/Client.java
@@ -4,10 +4,10 @@ package test.Slice.escape;
 
 import com.zeroc.Ice.Communicator;
 import com.zeroc.Ice.Current;
+import com.zeroc.Ice.Identity;
 import com.zeroc.Ice.InitializationData;
 import com.zeroc.Ice.ModuleToPackageSliceLoader;
 import com.zeroc.Ice.ObjectAdapter;
-import com.zeroc.Ice.Util;
 
 import test.TestHelper;
 import test.escaped_abstract.CloneException;
@@ -119,14 +119,14 @@ public class Client extends TestHelper {
         try (Communicator communicator = initialize(initData)) {
             communicator.getProperties().setProperty("TestAdapter.Endpoints", getTestEndpoint());
             ObjectAdapter adapter = communicator.createObjectAdapter("TestAdapter");
-            adapter.add(new _defaultI(), Util.stringToIdentity("test"));
+            adapter.add(new _defaultI(), new Identity("test", ""));
             adapter.activate();
 
             System.out.print("Testing operation name... ");
             System.out.flush();
             _defaultPrx p =
                 _defaultPrx.uncheckedCast(
-                    adapter.createProxy(Util.stringToIdentity("test")));
+                    adapter.createProxy(new Identity("test", "")));
             p._do();
             System.out.println("ok");
         }

--- a/java/test/src/main/java/test/TestHelper.java
+++ b/java/test/src/main/java/test/TestHelper.java
@@ -152,7 +152,7 @@ public abstract class TestHelper {
             }
         }
 
-        Communicator communicator = Util.initialize(initData);
+        Communicator communicator = new Communicator(initData);
         if (_communicator == null) {
             _communicator = communicator;
         }

--- a/matlab/lib/+Ice/initialize.m
+++ b/matlab/lib/+Ice/initialize.m
@@ -1,6 +1,7 @@
 function communicator = initialize(varargin)
-    %INITIALIZE Creates a communicator. This function is provided for consistency with other Ice language mappings,
-    %   and for backwards compatibility. Call instead the Ice.Communicator constructor.
+    %INITIALIZE Creates a communicator.
+    %   This function is provided for backwards compatibility. New code should call the Ice.Communicator
+    %   constructor directly.
     %
     %   Examples:
     %     communicator = Ice.initialize()


### PR DESCRIPTION
This PR is the Java portion of #4590.

Note that I didn't add more try-with-resources in the tests: we still rely on destroy instead of try-with-resources or close in many tests.