### PR TITLE
Do not register an OA without published endpoints

### DIFF
--- a/cpp/include/Ice/ObjectAdapter.h
+++ b/cpp/include/Ice/ObjectAdapter.h
@@ -298,7 +298,8 @@ namespace Ice
         [[nodiscard]] virtual EndpointSeq getPublishedEndpoints() const = 0;
 
         /// Sets the endpoints that proxies created by this object adapter will contain.
-        /// @param newEndpoints The new set of endpoints that the object adapter will embed in proxies.
+        /// @param newEndpoints The new set of endpoints that the object adapter will embed in proxies. Must contain
+        /// at least one endpoint.
         virtual void setPublishedEndpoints(EndpointSeq newEndpoints) = 0;
 
     protected:

--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -114,9 +114,7 @@ Ice::ObjectAdapterI::activate()
     {
         try
         {
-            Ice::Identity dummy;
-            dummy.name = "dummy";
-            updateLocatorRegistry(locatorInfo, createDirectProxy(dummy));
+            updateLocatorRegistry(locatorInfo, createDirectProxy(Identity{.name = "dummy", .category = ""}));
         }
         catch (const Ice::LocalException&)
         {

--- a/cpp/src/Ice/ObjectAdapterI.cpp
+++ b/cpp/src/Ice/ObjectAdapterI.cpp
@@ -69,6 +69,7 @@ Ice::ObjectAdapterI::activate()
 {
     LocatorInfoPtr locatorInfo;
     bool printAdapterReady = false;
+    bool hasPublishedEndpoints = false;
 
     {
         lock_guard lock(_mutex);
@@ -106,28 +107,32 @@ Ice::ObjectAdapterI::activate()
             PropertiesPtr properties = _instance->initializationData().properties;
             printAdapterReady = properties->getIcePropertyAsInt("Ice.PrintAdapterReady") > 0;
         }
+        hasPublishedEndpoints = !_publishedEndpoints.empty();
     }
 
-    try
+    if (hasPublishedEndpoints)
     {
-        Ice::Identity dummy;
-        dummy.name = "dummy";
-        updateLocatorRegistry(locatorInfo, createDirectProxy(dummy));
-    }
-    catch (const Ice::LocalException&)
-    {
-        //
-        // If we couldn't update the locator registry, we let the
-        // exception go through and don't activate the adapter to
-        // allow to user code to retry activating the adapter
-        // later.
-        //
+        try
         {
-            lock_guard lock(_mutex);
-            _state = StateUninitialized;
-            _conditionVariable.notify_all();
+            Ice::Identity dummy;
+            dummy.name = "dummy";
+            updateLocatorRegistry(locatorInfo, createDirectProxy(dummy));
         }
-        throw;
+        catch (const Ice::LocalException&)
+        {
+            //
+            // If we couldn't update the locator registry, we let the
+            // exception go through and don't activate the adapter to
+            // allow to user code to retry activating the adapter
+            // later.
+            //
+            {
+                lock_guard lock(_mutex);
+                _state = StateUninitialized;
+                _conditionVariable.notify_all();
+            }
+            throw;
+        }
     }
 
     if (printAdapterReady)
@@ -181,6 +186,7 @@ Ice::ObjectAdapterI::waitForHold()
 void
 Ice::ObjectAdapterI::deactivate() noexcept
 {
+    bool hasPublishedEndpoints = false;
     {
         unique_lock lock(_mutex);
 
@@ -193,6 +199,7 @@ Ice::ObjectAdapterI::deactivate() noexcept
             return;
         }
         _state = StateDeactivating;
+        hasPublishedEndpoints = !_publishedEndpoints.empty();
     }
 
     //
@@ -200,16 +207,19 @@ Ice::ObjectAdapterI::deactivate() noexcept
     // factory list are immutable at this point.
     //
 
-    try
+    if (hasPublishedEndpoints)
     {
-        updateLocatorRegistry(_locatorInfo, nullopt);
-    }
-    catch (const Ice::LocalException&)
-    {
-        //
-        // We can't throw exceptions in deactivate so we ignore
-        // failures to update the locator registry.
-        //
+        try
+        {
+            updateLocatorRegistry(_locatorInfo, nullopt);
+        }
+        catch (const Ice::LocalException&)
+        {
+            //
+            // We can't throw exceptions in deactivate so we ignore
+            // failures to update the locator registry.
+            //
+        }
     }
 
     for_each(
@@ -611,14 +621,19 @@ Ice::ObjectAdapterI::setPublishedEndpoints(EndpointSeq newEndpoints)
 {
     LocatorInfoPtr locatorInfo;
     vector<EndpointIPtr> oldPublishedEndpoints;
+
+    if (newEndpoints.empty())
+    {
+        throw std::invalid_argument("the newEndpoints argument must contain at least one endpoint");
+    }
+
     {
         lock_guard lock(_mutex);
         checkForDeactivation();
 
         if (_routerInfo)
         {
-            const string s("can't set published endpoints on object adapter associated with a router");
-            throw invalid_argument(s);
+            throw invalid_argument("cannot set published endpoints on an object adapter associated with a router");
         }
 
         oldPublishedEndpoints = _publishedEndpoints;

--- a/cpp/test/Ice/location/AllTests.cpp
+++ b/cpp/test/Ice/location/AllTests.cpp
@@ -626,6 +626,16 @@ allTests(Test::TestHelper* helper, const string& ref)
         cout << "ok" << endl;
     }
 
+    cout << "testing indirect object adapter without published endpoints... " << flush;
+    int32_t setRequestCount = registry.getSetRequestCount();
+    communicator->getProperties()->setProperty("CollocAdapter.AdapterId", "CollocId");
+    ObjectAdapterPtr collocAdapter = communicator->createObjectAdapter("CollocAdapter");
+    collocAdapter->activate();                               // not necessary, but allowed
+    test(setRequestCount == registry->getSetRequestCount()); // no set call on registry
+    collocAdapter->deactivate();
+    test(setRequestCount == registry->getSetRequestCount()); // no set call on registry
+    cout << "ok" << endl;
+
     cout << "shutdown server manager... " << flush;
     manager->shutdown();
     cout << "ok" << endl;

--- a/cpp/test/Ice/location/ServerLocator.cpp
+++ b/cpp/test/Ice/location/ServerLocator.cpp
@@ -15,6 +15,7 @@ ServerLocatorRegistry::ServerLocatorRegistry() = default;
 void
 ServerLocatorRegistry::setAdapterDirectProxy(string adapter, optional<ObjectPrx> object, const Current&)
 {
+    ++_setRequestCount;
     if (!object)
     {
         _adapters.erase(adapter);
@@ -32,6 +33,7 @@ ServerLocatorRegistry::setReplicatedAdapterDirectProxy(
     optional<ObjectPrx> object,
     const Current&)
 {
+    ++_setRequestCount;
     if (!object)
     {
         _adapters.erase(adapter);
@@ -47,12 +49,19 @@ ServerLocatorRegistry::setReplicatedAdapterDirectProxy(
 void
 ServerLocatorRegistry::setServerProcessProxy(string, optional<ProcessPrx>, const Current&)
 {
+    ++_setRequestCount;
 }
 
 void
 ServerLocatorRegistry::addObject(optional<ObjectPrx> object, const Current&)
 {
     addObject(object);
+}
+
+int32_t
+ServerLocatorRegistry::getSetRequestCount(const Current&)
+{
+    return _setRequestCount;
 }
 
 optional<ObjectPrx>

--- a/cpp/test/Ice/location/ServerLocator.h
+++ b/cpp/test/Ice/location/ServerLocator.h
@@ -20,6 +20,8 @@ public:
 
     void addObject(std::optional<Ice::ObjectPrx>, const Ice::Current&) final;
 
+    std::int32_t getSetRequestCount(const Ice::Current&) final;
+
     //
     // Internal method
     //
@@ -30,6 +32,7 @@ public:
 private:
     std::map<std::string, std::optional<Ice::ObjectPrx>> _adapters;
     std::map<Ice::Identity, std::optional<Ice::ObjectPrx>> _objects;
+    std::int32_t _setRequestCount{0};
 };
 using ServerLocatorRegistryPtr = std::shared_ptr<ServerLocatorRegistry>;
 

--- a/cpp/test/Ice/location/Test.ice
+++ b/cpp/test/Ice/location/Test.ice
@@ -13,6 +13,9 @@ module Test
         // Allow remote addition of objects to the locator registry.
         //
         void addObject(Object* obj);
+
+        /// Gets the number of setXxx requests sent to this LocatorRegistry.
+        int getSetRequestCount();
     }
 
     interface TestLocator extends Ice::Locator

--- a/csharp/msbuild/CodeAnalysis.Src.globalconfig
+++ b/csharp/msbuild/CodeAnalysis.Src.globalconfig
@@ -1,6 +1,9 @@
 global_level = 110
 is_global = true
 
+# CA1515: Because an application's API isn't typically referenced from outside the assembly, types can be made internal
+dotnet_diagnostic.CA1515.severity = none
+
 # CA1849: Call async methods when in an async method
 dotnet_diagnostic.CA1849.severity = none
 

--- a/csharp/src/Ice/ObjectAdapter.cs
+++ b/csharp/src/Ice/ObjectAdapter.cs
@@ -825,9 +825,11 @@ public sealed class ObjectAdapter
         lock (_mutex)
         {
             checkForDeactivation();
+
             if (_routerInfo is not null)
             {
-                throw new ArgumentException("can't set published endpoints on object adapter associated with a router");
+                throw new ArgumentException(
+                    "Cannot set published endpoints on an object adapter associated with a router.");
             }
 
             oldPublishedEndpoints = _publishedEndpoints;

--- a/csharp/test/Ice/location/AllTests.cs
+++ b/csharp/test/Ice/location/AllTests.cs
@@ -598,6 +598,17 @@ public class AllTests : global::Test.AllTests
 
         output.WriteLine("ok");
 
+        output.Write("testing indirect object adapter without published endpoints... ");
+        output.Flush();
+        int setRequestCount = registry.getSetRequestCount();
+        communicator.getProperties().setProperty("CollocAdapter.AdapterId", "CollocId");
+        ObjectAdapter collocAdapter = communicator.createObjectAdapter("CollocAdapter");
+        collocAdapter.activate(); // not necessary, but allowed
+        test(setRequestCount == registry.getSetRequestCount()); // no set call on registry
+        collocAdapter.deactivate();
+        test(setRequestCount == registry.getSetRequestCount()); // no set call on registry
+        output.WriteLine("ok");
+
         output.Write("shutdown server manager... ");
         output.Flush();
         manager.shutdown();

--- a/csharp/test/Ice/location/ServerLocatorRegistry.cs
+++ b/csharp/test/Ice/location/ServerLocatorRegistry.cs
@@ -6,6 +6,10 @@ namespace Ice.location;
 
 public class ServerLocatorRegistry : Test.TestLocatorRegistryDisp_
 {
+    private readonly Hashtable _adapters;
+    private readonly Hashtable _objects;
+    private int _setRequestCount;
+
     public ServerLocatorRegistry()
     {
         _adapters = new Hashtable();
@@ -14,6 +18,7 @@ public class ServerLocatorRegistry : Test.TestLocatorRegistryDisp_
 
     public override void setAdapterDirectProxy(string id, ObjectPrx proxy, Current current)
     {
+        ++_setRequestCount;
         if (proxy != null)
         {
             _adapters[id] = proxy;
@@ -30,6 +35,7 @@ public class ServerLocatorRegistry : Test.TestLocatorRegistryDisp_
         ObjectPrx proxy,
         Current current)
     {
+        ++_setRequestCount;
         if (proxy != null)
         {
             _adapters[adapterId] = proxy;
@@ -42,11 +48,12 @@ public class ServerLocatorRegistry : Test.TestLocatorRegistryDisp_
         }
     }
 
-    public override void setServerProcessProxy(string id, Ice.ProcessPrx proxy, Ice.Current current)
-    {
-    }
+    public override void setServerProcessProxy(string id, Ice.ProcessPrx proxy, Ice.Current current) =>
+        ++_setRequestCount;
 
     public override void addObject(Ice.ObjectPrx obj, Ice.Current current) => addObject(obj);
+
+    public override int getSetRequestCount(Current current) => _setRequestCount;
 
     internal void addObject(Ice.ObjectPrx obj) => _objects[obj.ice_getIdentity()] = obj;
 
@@ -61,7 +68,4 @@ public class ServerLocatorRegistry : Test.TestLocatorRegistryDisp_
         object obj = _objects[id] ?? throw new Ice.ObjectNotFoundException();
         return (Ice.ObjectPrx)obj;
     }
-
-    private readonly Hashtable _adapters;
-    private readonly Hashtable _objects;
 }

--- a/csharp/test/Ice/location/Test.ice
+++ b/csharp/test/Ice/location/Test.ice
@@ -14,6 +14,9 @@ module Test
         // Allow remote addition of objects to the locator registry.
         //
         void addObject(Object* obj);
+
+        /// Gets the number of setXxx requests sent to this LocatorRegistry.
+        int getSetRequestCount();
     }
 
     interface TestLocator extends Ice::Locator

--- a/java/test/src/main/java/test/Ice/location/AllTests.java
+++ b/java/test/src/main/java/test/Ice/location/AllTests.java
@@ -600,6 +600,17 @@ public class AllTests {
 
         out.println("ok");
 
+        out.print("testing indirect object adapter without published endpoints... ");
+        out.flush();
+        int setRequestCount = registry.getSetRequestCount();
+        communicator.getProperties().setProperty("CollocAdapter.AdapterId", "CollocId");
+        ObjectAdapter collocAdapter = communicator.createObjectAdapter("CollocAdapter");
+        collocAdapter.activate(); // not necessary, but allowed
+        test(setRequestCount == registry.getSetRequestCount()); // no set call on registry
+        collocAdapter.deactivate();
+        test(setRequestCount == registry.getSetRequestCount()); // no set call on registry
+        out.println("ok");
+
         out.print("shutdown server manager... ");
         out.flush();
         manager.shutdown();

--- a/java/test/src/main/java/test/Ice/location/ServerLocatorRegistry.java
+++ b/java/test/src/main/java/test/Ice/location/ServerLocatorRegistry.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 public class ServerLocatorRegistry implements TestLocatorRegistry {
     @Override
     public void setAdapterDirectProxy(String adapter, ObjectPrx object, Current current) {
+        ++_setRequestCount;
         if (object != null) {
             _adapters.put(adapter, object);
         } else {
@@ -25,6 +26,7 @@ public class ServerLocatorRegistry implements TestLocatorRegistry {
 
     @Override
     public void setReplicatedAdapterDirectProxy(String adapter, String replica, ObjectPrx object, Current current) {
+        ++_setRequestCount;
         if (object != null) {
             _adapters.put(adapter, object);
             _adapters.put(replica, object);
@@ -36,12 +38,17 @@ public class ServerLocatorRegistry implements TestLocatorRegistry {
 
     @Override
     public void setServerProcessProxy(String id, ProcessPrx proxy, Current current) {
-        // No-op
+        ++_setRequestCount;
     }
 
     @Override
     public void addObject(ObjectPrx object, Current current) {
         _objects.put(object.ice_getIdentity(), object);
+    }
+
+    @Override
+    public int getSetRequestCount(Current current) {
+        return _setRequestCount;
     }
 
     public ObjectPrx getAdapter(String adapter) throws AdapterNotFoundException {
@@ -62,4 +69,5 @@ public class ServerLocatorRegistry implements TestLocatorRegistry {
 
     private final HashMap<String, ObjectPrx> _adapters = new HashMap<>();
     private final HashMap<Identity, ObjectPrx> _objects = new HashMap<>();
+    private int _setRequestCount;
 }

--- a/java/test/src/main/java/test/Ice/location/Test.ice
+++ b/java/test/src/main/java/test/Ice/location/Test.ice
@@ -12,6 +12,9 @@ module Test
     {
         /// Allow remote addition of objects to the locator registry.
         void addObject(Object* obj);
+
+        /// Gets the number of setXxx requests sent to this LocatorRegistry.
+        int getSetRequestCount();
     }
 
     interface TestLocator extends Ice::Locator

--- a/swift/test/Ice/adapterDeactivation/AllTests.swift
+++ b/swift/test/Ice/adapterDeactivation/AllTests.swift
@@ -150,7 +150,7 @@ func allTests(_ helper: TestHelper) async throws {
         } catch let error as Ice.LocalException {
             try test(error.ice_id() == "std::invalid_argument")
             try test(
-                error.message == "can't set published endpoints on object adapter associated with a router")
+                error.message == "cannot set published endpoints on an object adapter associated with a router")
         }
         adapter.destroy()
 


### PR DESCRIPTION
This PR updates the ObjectAdapter code in C++, C#, and Java, to ensure an object adapter without published endpoints does not register these endpoints with the locator.

Fixes #4592.