### PR TITLE
Disable inactivity check for DataStorm session connections

### DIFF
--- a/cpp/src/DataStorm/ConnectionManager.cpp
+++ b/cpp/src/DataStorm/ConnectionManager.cpp
@@ -17,11 +17,10 @@ ConnectionManager::add(
     shared_ptr<void> object,
     function<void(const ConnectionPtr&, exception_ptr)> callback)
 {
-    lock_guard<mutex> lock(_mutex);
-
     // Disable the inactivity timeout on the connection.
     connection->disableInactivityCheck();
 
+    lock_guard<mutex> lock(_mutex);
     auto& objects = _connections[connection];
     if (objects.empty())
     {


### PR DESCRIPTION
Fix #4618
