### PR TITLE
Swift iOS Controller Async updates

### DIFF
--- a/swift/test/ios/TestDriverApp/ControllerI.swift
+++ b/swift/test/ios/TestDriverApp/ControllerI.swift
@@ -229,7 +229,7 @@ class ControllerHelperI: ControllerHelper, TextWriter, @unchecked Sendable {
             try await Task.sleep(for: .milliseconds(100))
         }
 
-        throw CommonProcessFailedException(reason: "timed out waiting for the process to succeed")
+        throw CommonProcessFailedException(reason: "timed out waiting for the process to be ready")
     }
 
     public func waitSuccess(timeout: Int32) async throws -> Int32 {


### PR DESCRIPTION
This PR updates the Swift iOS controller to not block the dispatch thread. This thread is from the Swift async/await thread pool and there are not many of them. 

I'd like to use better async types than a loop with an async sleep. However, the Swift async types are tricky to use in the way we need to use them. We can improve in a followup PR. 