### PR TITLE
Enable network tracing for DataStorm/reliability

### DIFF
--- a/cpp/test/DataStorm/reliability/test.py
+++ b/cpp/test/DataStorm/reliability/test.py
@@ -8,6 +8,7 @@ traceProps = {
     "DataStorm.Trace.Session": 3,
     "DataStorm.Trace.Data": 2,
     "Ice.Trace.Protocol": 1,
+    "Ice.Trace.Network": 3,
 }
 
 # A client connected to the default server


### PR DESCRIPTION
related to #4349

Without network tracing is not clear what the failure was about, and I cannot reproduce it.