### PR TITLE
Build PIP packages with multiple Python versions

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -1,10 +1,16 @@
 name: Setup Python
+
+inputs:
+  python-version:
+    description: "The version of Python to set up."
+    default: "3.13"
+
 runs:
   using: "composite"
   steps:
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.13"
+        python-version: ${{ inputs.python-version }}
 
     - name: Configure Windows Python Environment
       run: |

--- a/.github/workflows/build-pip-packages.yml
+++ b/.github/workflows/build-pip-packages.yml
@@ -18,7 +18,22 @@ jobs:
       matrix:
         include:
           - os: macos-26
+            python-version: "3.12"
+
+          - os: macos-26
+            python-version: "3.13"
+
+          - os: macos-26
+            python-version: "3.14"
+
           - os: windows-2022
+            python-version: "3.12"
+
+          - os: windows-2022
+            python-version: "3.13"
+
+          - os: windows-2022
+            python-version: "3.14"
 
     runs-on: ${{ matrix.os }}
 
@@ -31,6 +46,8 @@ jobs:
 
       - name: Setup Python
         uses: ./.github/actions/setup-python
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Setup Cache
         uses: ./.github/actions/setup-cache
@@ -54,24 +71,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: pip-packages-${{ matrix.os }}
+          name: pip-packages-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
             python/dist/zeroc_ice-*.whl
             python/dist/zeroc_ice-*.tar.gz
-
-  publish-python-packages:
-    runs-on: ubuntu-latest
-    needs: build-python-packages
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: ./.github/actions/setup-python
-
-      - name: Download All PIP Package Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-          pattern: pip-packages-*


### PR DESCRIPTION
This PR updates nightly release pipeline to build wheel packages with multiple Python versions