### PR TITLE
Fix back pressure test in C#

### DIFF
--- a/cpp/test/Ice/ami/AllTests.cpp
+++ b/cpp/test/Ice/ami/AllTests.cpp
@@ -1292,13 +1292,13 @@ allTests(TestHelper* helper, bool collocated)
                 auto onewayProxy = Ice::uncheckedCast<Test::TestIntfPrx>(p->ice_oneway());
 
                 // Sending should block because the TCP send/receive buffer size on the server is set to 50KB.
-                // We loop up to 3 times because on Windows with TCP, the Socket.Send call appears to always succeed
+                // We loop up to 4 times because on Windows with TCP, the Socket.Send call appears to always succeed
                 // twice before blocking.
                 Ice::ByteSeq seq;
                 seq.resize(768 * 1024);
 
                 bool timedOut = false;
-                for (int i = 0; i < 3; ++i)
+                for (int i = 0; i < 4; ++i)
                 {
                     auto future = onewayProxy->opWithPayloadAsync(seq);
                     if (future.wait_for(200ms) == future_status::timeout)

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -920,9 +920,9 @@ public class AllTests : global::Test.AllTests
                     // Sending should be canceled because the TCP send/receive buffer size on the server is set
                     // to 50KB. Note: we don't use the cancel parameter of the operation here because the
                     // cancellation doesn't cancel the operation whose payload is being sent.
-                    // We loop up to 3 times because on Windows with TCP, the Socket.Send call appears to always succeed
+                    // We loop up to 4 times because on Windows with TCP, the Socket.Send call appears to always succeed
                     // twice before blocking.
-                    for (int i = 0; i < 3; ++i)
+                    for (int i = 0; i < 4; ++i)
                     {
                         using var cts = new CancellationTokenSource(200);
                         await onewayProxy.opWithPayloadAsync(new byte[768 * 1024]).WaitAsync(cts.Token);

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -913,7 +913,6 @@ public class AllTests : global::Test.AllTests
                 Task sleep2Task = p.sleepAsync(1500);
                 Task sleep3Task = p.sleepAsync(1500);
                 bool canceled = false;
-                using var cts = new CancellationTokenSource(200);
                 try
                 {
                     var onewayProxy = (Test.TestIntfPrx)p.ice_oneway();
@@ -925,6 +924,7 @@ public class AllTests : global::Test.AllTests
                     // twice before blocking.
                     for (int i = 0; i < 3; ++i)
                     {
+                        using var cts = new CancellationTokenSource(200);
                         await onewayProxy.opWithPayloadAsync(new byte[768 * 1024]).WaitAsync(cts.Token);
                     }
                 }

--- a/csharp/test/Ice/ami/AllTests.cs
+++ b/csharp/test/Ice/ami/AllTests.cs
@@ -932,7 +932,9 @@ public class AllTests : global::Test.AllTests
                 {
                     canceled = true;
                 }
-                test(canceled && !sleep1Task.IsCompleted);
+                test(canceled);
+                test(!sleep1Task.IsCompleted);
+
                 await sleep1Task;
                 await sleep2Task;
                 await sleep3Task;

--- a/java/test/src/main/java/test/Ice/ami/AllTests.java
+++ b/java/test/src/main/java/test/Ice/ami/AllTests.java
@@ -1100,10 +1100,8 @@ public class AllTests {
                 CompletableFuture<Void> sleep3Future = p.sleepAsync(1000);
                 TestIntfPrx onewayProxy = p.ice_oneway();
 
-                // Sending should block because the TCP send/receive buffer size on the server is
-                // set to 50KB.
-                CompletableFuture<Void> future =
-                    onewayProxy.opWithPayloadAsync(new byte[768 * 1024]);
+                // Sending should block because the TCP send/receive buffer size on the server is set to 50KB.
+                CompletableFuture<Void> future = onewayProxy.opWithPayloadAsync(new byte[768 * 1024]);
                 boolean timeout = false;
                 try {
                     future.get(200, TimeUnit.MILLISECONDS);
@@ -1114,7 +1112,6 @@ public class AllTests {
                 test(!sleep1Future.isDone());
 
                 sleep1Future.get();
-
                 sleep2Future.get();
                 sleep3Future.get();
             } catch (Exception ex) {


### PR DESCRIPTION
Fixes #4646. The CTS code was bogus. Also fix formatting of corresponding test in Java.