### PR TITLE
Reject duplicated options when parsing an endpoint string

### DIFF
--- a/CHANGELOG-3.8.md
+++ b/CHANGELOG-3.8.md
@@ -386,6 +386,10 @@ classDiagram
 
   In C++, the first element of the `argv` array is still used if passed to `initialize`.
 
+- Duplicated options are now rejected when parsing a stringified endpoint. For example,
+  "greeter:tcp -h host1 -h host2 -p 4061" was a valid proxy string in prior Ice releases. Its parsing now fails with a
+  ParseException.
+
 ### Packaging Changes
 
 - The Windows MSI installer is now built using the WiX Toolset. The WiX project files are included in the packaging/msi

--- a/cpp/src/Ice/EndpointI.cpp
+++ b/cpp/src/Ice/EndpointI.cpp
@@ -101,10 +101,7 @@ IceInternal::EndpointI::initWithOptions(vector<string>& args)
         {
             if (!knownOptions.insert(option).second)
             {
-                throw Ice::ParseException{
-                    __FILE__,
-                    __LINE__,
-                    "duplicate option '" + option + "' in endpoint " + str};
+                throw Ice::ParseException{__FILE__, __LINE__, "duplicate option '" + option + "' in endpoint " + str};
             }
         }
         else

--- a/cpp/src/Ice/EndpointI.cpp
+++ b/cpp/src/Ice/EndpointI.cpp
@@ -1,8 +1,10 @@
 // Copyright (c) ZeroC, Inc.
 
 #include "EndpointI.h"
+#include "Ice/LocalExceptions.h"
 #include "Ice/OutputStream.h"
 
+#include <set>
 #include <sstream>
 
 using namespace std;
@@ -63,7 +65,7 @@ IceInternal::EndpointI::initWithOptions(vector<string>& args)
     vector<string> unknown;
 
     ostringstream ostr;
-    ostr << '`' << protocol() << " ";
+    ostr << "'" << protocol() << " "; // protocol means transport here
     for (const auto& arg : args)
     {
         if (arg.find_first_of(" \t\n\r") != string::npos)
@@ -77,6 +79,8 @@ IceInternal::EndpointI::initWithOptions(vector<string>& args)
     }
     ostr << "'";
     const string str = ostr.str();
+
+    set<string> knownOptions;
 
     for (vector<string>::size_type n = 0; n < args.size(); ++n)
     {
@@ -93,7 +97,17 @@ IceInternal::EndpointI::initWithOptions(vector<string>& args)
             argument = args[++n];
         }
 
-        if (!checkOption(option, argument, str))
+        if (checkOption(option, argument, str))
+        {
+            if (!knownOptions.insert(option).second)
+            {
+                throw Ice::ParseException{
+                    __FILE__,
+                    __LINE__,
+                    "duplicate option '" + option + "' in endpoint " + str};
+            }
+        }
+        else
         {
             unknown.push_back(option);
             if (!argument.empty())

--- a/cpp/test/Ice/proxy/AllTests.cpp
+++ b/cpp/test/Ice/proxy/AllTests.cpp
@@ -413,6 +413,46 @@ allTests(TestHelper* helper)
     id2 = Ice::stringToIdentity(idStr);
     test(id == id2);
 
+    //
+    // Test proxies with duplicated endpoint option.
+    //
+
+    std::optional<Ice::ObjectPrx> objPrx = communicator->stringToProxy("hello:tcp -h host1 -p 4061");
+    test(objPrx);
+    try
+    {
+        communicator->stringToProxy("hello:tcp -h host1 -p 4061 -h host2");
+        test(false);
+    }
+    catch (const Ice::ParseException&)
+    {
+        // expected
+    }
+
+    objPrx = communicator->stringToProxy("hello:udp -p 10000 -h host1");
+    test(objPrx);
+    try
+    {
+        communicator->stringToProxy("hello:udp -p 10000 -h host1 -p 11000");
+        test(false);
+    }
+    catch (const Ice::ParseException&)
+    {
+        // expected
+    }
+
+    objPrx = communicator->stringToProxy("hello:udp -h host1 -p 10000 --sourceAddress 127.0.0.1");
+    test(objPrx);
+    try
+    {
+        communicator->stringToProxy("hello:udp -h host1 -p 10000 --sourceAddress 127.0.0.1 --sourceAddress 10.0.0.1");
+        test(false);
+    }
+    catch (const Ice::ParseException&)
+    {
+        // expected
+    }
+
     cout << "ok" << endl;
 
     cout << "testing proxyToString... " << flush;

--- a/cpp/test/Ice/proxy/AllTests.cpp
+++ b/cpp/test/Ice/proxy/AllTests.cpp
@@ -416,41 +416,22 @@ allTests(TestHelper* helper)
     //
     // Test proxies with duplicated endpoint option.
     //
+    string goodBase = "hello:default -h host1 -p 4061 --sourceAddress 127.0.0.1";
+    test(communicator->stringToProxy(goodBase));
 
-    std::optional<Ice::ObjectPrx> objPrx = communicator->stringToProxy("hello:tcp -h host1 -p 4061");
-    test(objPrx);
-    try
-    {
-        communicator->stringToProxy("hello:tcp -h host1 -p 4061 -h host2");
-        test(false);
-    }
-    catch (const Ice::ParseException&)
-    {
-        // expected
-    }
+    array<string, 3> dupOptions = {" -h host2", " -p 4062", " --sourceAddress 10.0.0.1"};
 
-    objPrx = communicator->stringToProxy("hello:udp -p 10000 -h host1");
-    test(objPrx);
-    try
+    for (const string& opt : dupOptions)
     {
-        communicator->stringToProxy("hello:udp -p 10000 -h host1 -p 11000");
-        test(false);
-    }
-    catch (const Ice::ParseException&)
-    {
-        // expected
-    }
-
-    objPrx = communicator->stringToProxy("hello:udp -h host1 -p 10000 --sourceAddress 127.0.0.1");
-    test(objPrx);
-    try
-    {
-        communicator->stringToProxy("hello:udp -h host1 -p 10000 --sourceAddress 127.0.0.1 --sourceAddress 10.0.0.1");
-        test(false);
-    }
-    catch (const Ice::ParseException&)
-    {
-        // expected
+        try
+        {
+            communicator->stringToProxy(goodBase + opt);
+            test(false);
+        }
+        catch (const ParseException&)
+        {
+            // expected
+        }
     }
 
     cout << "ok" << endl;

--- a/cpp/test/Ice/proxy/AllTests.cpp
+++ b/cpp/test/Ice/proxy/AllTests.cpp
@@ -7,6 +7,7 @@
 #include "Test.h"
 #include "TestHelper.h"
 
+#include <array>
 #include <stdexcept>
 
 #ifdef _MSC_VER

--- a/csharp/src/Ice/Internal/EndpointI.cs
+++ b/csharp/src/Ice/Internal/EndpointI.cs
@@ -150,7 +150,7 @@ public abstract class EndpointI : Ice.Endpoint, IComparable<EndpointI>
     {
         var unknown = new List<string>();
 
-        string str = "`" + protocol() + " ";
+        string str = "'" + protocol() + " ";
         foreach (string p in args)
         {
             if (Ice.UtilInternal.StringUtil.findFirstOf(p, " \t\n\r") != -1)
@@ -163,6 +163,8 @@ public abstract class EndpointI : Ice.Endpoint, IComparable<EndpointI>
             }
         }
         str += "'";
+
+        var knownOptions = new HashSet<string>();
 
         for (int n = 0; n < args.Count; ++n)
         {
@@ -179,7 +181,14 @@ public abstract class EndpointI : Ice.Endpoint, IComparable<EndpointI>
                 argument = args[++n];
             }
 
-            if (!checkOption(option, argument, str))
+            if (checkOption(option, argument, str))
+            {
+                if (!knownOptions.Add(option))
+                {
+                    throw new ParseException($"Duplicate option '{option}' in endpoint {str}.");
+                }
+            }
+            else
             {
                 unknown.Add(option);
                 if (argument != null)

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -355,14 +355,14 @@ public class AllTests : global::Test.AllTests
         string goodBase = "hello:default -h host1 -p 4061 --sourceAddress 127.0.0.1";
         test(communicator.stringToProxy(goodBase) != null);
 
-        var dupOptions = new string[]
+        string[] dupOptions = new string[]
         {
             " -h host2",
             " -p 4062",
             " --sourceAddress 10.0.0.1"
         };
 
-        foreach (var opt in dupOptions)
+        foreach (string opt in dupOptions)
         {
             try
             {

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -349,6 +349,46 @@ public class AllTests : global::Test.AllTests
         test(idStr == "greek \\360\\220\\205\\252/banana \\016-\\360\\237\\215\\214\\342\\202\\254\\302\\242$");
         test(id.Equals(id2));
 
+        //
+        // Test proxies with duplicated endpoint option.
+        //
+
+        ObjectPrx objPrx = communicator.stringToProxy("hello:tcp -h host1 -p 4061");
+        test(objPrx != null);
+        try
+        {
+            communicator.stringToProxy("hello:tcp -h host1 -p 4061 -h host2");
+            test(false);
+        }
+        catch (ParseException)
+        {
+            // expected
+        }
+
+        objPrx = communicator.stringToProxy("hello:udp -p 10000 -h host1");
+        test(objPrx != null);
+        try
+        {
+            communicator.stringToProxy("hello:udp -p 10000 -h host1 -p 11000");
+            test(false);
+        }
+        catch (ParseException)
+        {
+            // expected
+        }
+
+        objPrx = communicator.stringToProxy("hello:udp -h host1 -p 10000 --sourceAddress 127.0.0.1");
+        test(objPrx != null);
+        try
+        {
+            communicator.stringToProxy("hello:udp -h host1 -p 10000 --sourceAddress 127.0.0.1 --sourceAddress 10.0.0.1");
+            test(false);
+        }
+        catch (ParseException)
+        {
+            // expected
+        }
+
         output.WriteLine("ok");
 
         output.Write("testing proxyToString... ");

--- a/csharp/test/Ice/proxy/AllTests.cs
+++ b/csharp/test/Ice/proxy/AllTests.cs
@@ -352,41 +352,27 @@ public class AllTests : global::Test.AllTests
         //
         // Test proxies with duplicated endpoint option.
         //
+        string goodBase = "hello:default -h host1 -p 4061 --sourceAddress 127.0.0.1";
+        test(communicator.stringToProxy(goodBase) != null);
 
-        ObjectPrx objPrx = communicator.stringToProxy("hello:tcp -h host1 -p 4061");
-        test(objPrx != null);
-        try
+        var dupOptions = new string[]
         {
-            communicator.stringToProxy("hello:tcp -h host1 -p 4061 -h host2");
-            test(false);
-        }
-        catch (ParseException)
-        {
-            // expected
-        }
+            " -h host2",
+            " -p 4062",
+            " --sourceAddress 10.0.0.1"
+        };
 
-        objPrx = communicator.stringToProxy("hello:udp -p 10000 -h host1");
-        test(objPrx != null);
-        try
+        foreach (var opt in dupOptions)
         {
-            communicator.stringToProxy("hello:udp -p 10000 -h host1 -p 11000");
-            test(false);
-        }
-        catch (ParseException)
-        {
-            // expected
-        }
-
-        objPrx = communicator.stringToProxy("hello:udp -h host1 -p 10000 --sourceAddress 127.0.0.1");
-        test(objPrx != null);
-        try
-        {
-            communicator.stringToProxy("hello:udp -h host1 -p 10000 --sourceAddress 127.0.0.1 --sourceAddress 10.0.0.1");
-            test(false);
-        }
-        catch (ParseException)
-        {
-            // expected
+            try
+            {
+                communicator.stringToProxy(goodBase + opt);
+                test(false);
+            }
+            catch (ParseException)
+            {
+                // expected
+            }
         }
 
         output.WriteLine("ok");

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointI.java
@@ -123,8 +123,7 @@ public abstract class EndpointI implements Endpoint, Comparable<EndpointI> {
                 if (!knownOptions.add(option)) {
                     throw new ParseException("Duplicate option '" + option + "' in endpoint " + str + ".");
                 }
-            }
-            else {
+            } else {
                 unknown.add(option);
                 if (argument != null) {
                     unknown.add(argument);

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/EndpointI.java
@@ -95,7 +95,7 @@ public abstract class EndpointI implements Endpoint, Comparable<EndpointI> {
     public void initWithOptions(ArrayList<String> args) {
         ArrayList<String> unknown = new ArrayList<>();
 
-        String str = "`" + protocol() + " ";
+        String str = "'" + protocol() + " ";
         for (String p : args) {
             if (StringUtil.findFirstOf(p, " \t\n\r") != -1) {
                 str += " \"" + p + "\"";
@@ -104,6 +104,8 @@ public abstract class EndpointI implements Endpoint, Comparable<EndpointI> {
             }
         }
         str += "'";
+
+        var knownOptions = new java.util.HashSet<String>();
 
         for (int n = 0; n < args.size(); n++) {
             String option = args.get(n);
@@ -117,7 +119,12 @@ public abstract class EndpointI implements Endpoint, Comparable<EndpointI> {
                 argument = args.get(++n);
             }
 
-            if (!checkOption(option, argument, str)) {
+            if (checkOption(option, argument, str)) {
+                if (!knownOptions.add(option)) {
+                    throw new ParseException("Duplicate option '" + option + "' in endpoint " + str + ".");
+                }
+            }
+            else {
                 unknown.add(option);
                 if (argument != null) {
                     unknown.add(argument);

--- a/java/test/src/main/java/test/Ice/proxy/AllTests.java
+++ b/java/test/src/main/java/test/Ice/proxy/AllTests.java
@@ -408,6 +408,34 @@ public class AllTests {
                     + " \\016-\\360\\237\\215\\214\\342\\202\\254\\302\\242$"));
         test(id.equals(id2));
 
+        //
+        // Test proxies with duplicated endpoint option.
+        //
+
+        ObjectPrx objPrx = communicator.stringToProxy("hello:tcp -h host1 -p 4061");
+        test(objPrx != null);
+        try {
+            communicator.stringToProxy("hello:tcp -h host1 -p 4061 -h host2");
+            test(false);
+        } catch (ParseException expected) {
+        }
+
+        objPrx = communicator.stringToProxy("hello:udp -p 10000 -h host1");
+        test(objPrx != null);
+        try {
+            communicator.stringToProxy("hello:udp -p 10000 -h host1 -p 11000");
+            test(false);
+        } catch (ParseException expected) {
+        }
+
+        objPrx = communicator.stringToProxy("hello:udp -h host1 -p 10000 --sourceAddress 127.0.0.1");
+        test(objPrx != null);
+        try {
+            communicator.stringToProxy("hello:udp -h host1 -p 10000 --sourceAddress 127.0.0.1 --sourceAddress 10.0.0.1");
+            test(false);
+        } catch (ParseException expected) {
+        }
+
         out.println("ok");
         //CHECKSTYLE:ON: AvoidEscapedUnicodeCharacters
 

--- a/java/test/src/main/java/test/Ice/proxy/AllTests.java
+++ b/java/test/src/main/java/test/Ice/proxy/AllTests.java
@@ -414,10 +414,10 @@ public class AllTests {
         String goodBase = "hello:default -h host1 -p 4061 --sourceAddress 127.0.0.1";
         test(communicator.stringToProxy(goodBase) != null);
 
-        var dupOptions = new String[] {
-                " -h host2",
-                " -p 4062",
-                " --sourceAddress 10.0.0.1"
+        var dupOptions = new String[]{
+            " -h host2",
+            " -p 4062",
+            " --sourceAddress 10.0.0.1"
         };
 
         for (String opt : dupOptions) {

--- a/java/test/src/main/java/test/Ice/proxy/AllTests.java
+++ b/java/test/src/main/java/test/Ice/proxy/AllTests.java
@@ -411,30 +411,21 @@ public class AllTests {
         //
         // Test proxies with duplicated endpoint option.
         //
+        String goodBase = "hello:default -h host1 -p 4061 --sourceAddress 127.0.0.1";
+        test(communicator.stringToProxy(goodBase) != null);
 
-        ObjectPrx objPrx = communicator.stringToProxy("hello:tcp -h host1 -p 4061");
-        test(objPrx != null);
-        try {
-            communicator.stringToProxy("hello:tcp -h host1 -p 4061 -h host2");
-            test(false);
-        } catch (ParseException expected) {
-        }
+        var dupOptions = new String[] {
+                " -h host2",
+                " -p 4062",
+                " --sourceAddress 10.0.0.1"
+        };
 
-        objPrx = communicator.stringToProxy("hello:udp -p 10000 -h host1");
-        test(objPrx != null);
-        try {
-            communicator.stringToProxy("hello:udp -p 10000 -h host1 -p 11000");
-            test(false);
-        } catch (ParseException expected) {
-        }
-
-        objPrx = communicator.stringToProxy("hello:udp -h host1 -p 10000 --sourceAddress 127.0.0.1");
-        test(objPrx != null);
-        try {
-            communicator.stringToProxy(
-                "hello:udp -h host1 -p 10000 --sourceAddress 127.0.0.1 --sourceAddress 10.0.0.1");
-            test(false);
-        } catch (ParseException expected) {
+        for (String opt : dupOptions) {
+            try {
+                communicator.stringToProxy(goodBase + opt);
+                test(false);
+            } catch (ParseException expected) {
+            }
         }
 
         out.println("ok");

--- a/java/test/src/main/java/test/Ice/proxy/AllTests.java
+++ b/java/test/src/main/java/test/Ice/proxy/AllTests.java
@@ -431,7 +431,8 @@ public class AllTests {
         objPrx = communicator.stringToProxy("hello:udp -h host1 -p 10000 --sourceAddress 127.0.0.1");
         test(objPrx != null);
         try {
-            communicator.stringToProxy("hello:udp -h host1 -p 10000 --sourceAddress 127.0.0.1 --sourceAddress 10.0.0.1");
+            communicator.stringToProxy(
+                "hello:udp -h host1 -p 10000 --sourceAddress 127.0.0.1 --sourceAddress 10.0.0.1");
             test(false);
         } catch (ParseException expected) {
         }

--- a/js/src/Ice/EndpointI.js
+++ b/js/src/Ice/EndpointI.js
@@ -1,5 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
+import { ParseException } from "./LocalExceptions.js";
+
 export class EndpointI {
     toString() {
         //
@@ -15,7 +17,7 @@ export class EndpointI {
     initWithOptions(args) {
         const unknown = [];
 
-        let str = "`" + this.protocol();
+        let str = "'" + this.protocol();
         for (let i = 0; i < args.length; ++i) {
             if (args[i].search(/[ \t\n\r]+/) !== -1) {
                 str += ' "' + args[i] + '"';
@@ -24,6 +26,8 @@ export class EndpointI {
             }
         }
         str += "'";
+
+        let knownOptions = new Set();
 
         for (let i = 0; i < args.length; ) {
             const option = args[i++];
@@ -37,7 +41,12 @@ export class EndpointI {
                 argument = args[i++];
             }
 
-            if (!this.checkOption(option, argument, str)) {
+            if (this.checkOption(option, argument, str)) {
+                if (knownOptions.has(option)) {
+                    throw new ParseException(`duplicate option '${option}' in endpoint ${str}`);
+                }
+                knownOptions.add(option);
+            } else {
                 unknown.push(option);
                 if (argument !== null) {
                     unknown.push(argument);

--- a/js/test/Ice/proxy/Client.ts
+++ b/js/test/Ice/proxy/Client.ts
@@ -419,34 +419,18 @@ export class Client extends TestHelper {
         //
         // Test proxies with duplicated endpoint option.
         //
+        const goodBase = "hello:default -h host1 -p 4061 --sourceAddress 127.0.0.1";
+        test(communicator.stringToProxy(goodBase) !== null);
 
-        let objPrx = communicator.stringToProxy("hello:tcp -h host1 -p 4061");
-        test(objPrx !== null);
-        try {
-            communicator.stringToProxy("hello:tcp -h host1 -p 4061 -h host2");
-            test(false);
-        } catch (ex) {
-            test(ex instanceof Ice.ParseException, ex as Error);
-        }
+        const dupOptions = [" -h host2", " -p 4062", " --sourceAddress 10.0.0.1"];
 
-        objPrx = communicator.stringToProxy("hello:tcp -p 10000 -h host1");
-        test(objPrx !== null);
-        try {
-            communicator.stringToProxy("hello:tcp -p 10000 -h host1 -p 11000");
-            test(false);
-        } catch (ex) {
-            test(ex instanceof Ice.ParseException, ex as Error);
-        }
-
-        objPrx = communicator.stringToProxy("hello:tcp -h host1 -p 10000 --sourceAddress 127.0.0.1");
-        test(objPrx !== null);
-        try {
-            communicator.stringToProxy(
-                "hello:tcp -h host1 -p 10000 --sourceAddress 127.0.0.1 --sourceAddress 10.0.0.1",
-            );
-            test(false);
-        } catch (ex) {
-            test(ex instanceof Ice.ParseException, ex as Error);
+        for (const opt of dupOptions) {
+            try {
+                communicator.stringToProxy(goodBase + opt);
+                test(false);
+            } catch (ex) {
+                test(ex instanceof Ice.ParseException, ex as Error);
+            }
         }
 
         out.writeLine("ok");

--- a/js/test/Ice/proxy/Client.ts
+++ b/js/test/Ice/proxy/Client.ts
@@ -442,7 +442,8 @@ export class Client extends TestHelper {
         test(objPrx !== null);
         try {
             communicator.stringToProxy(
-                "hello:tcp -h host1 -p 10000 --sourceAddress 127.0.0.1 --sourceAddress 10.0.0.1");
+                "hello:tcp -h host1 -p 10000 --sourceAddress 127.0.0.1 --sourceAddress 10.0.0.1",
+            );
             test(false);
         } catch (ex) {
             test(ex instanceof Ice.ParseException, ex as Error);

--- a/js/test/Ice/proxy/Client.ts
+++ b/js/test/Ice/proxy/Client.ts
@@ -416,6 +416,38 @@ export class Client extends TestHelper {
         id2 = Ice.stringToIdentity(idStr);
         test(id.equals(id2));
 
+        //
+        // Test proxies with duplicated endpoint option.
+        //
+
+        let objPrx = communicator.stringToProxy("hello:tcp -h host1 -p 4061");
+        test(objPrx !== null);
+        try {
+            communicator.stringToProxy("hello:tcp -h host1 -p 4061 -h host2");
+            test(false);
+        } catch (ex) {
+            test(ex instanceof Ice.ParseException, ex as Error);
+        }
+
+        objPrx = communicator.stringToProxy("hello:tcp -p 10000 -h host1");
+        test(objPrx !== null);
+        try {
+            communicator.stringToProxy("hello:tcp -p 10000 -h host1 -p 11000");
+            test(false);
+        } catch (ex) {
+            test(ex instanceof Ice.ParseException, ex as Error);
+        }
+
+        objPrx = communicator.stringToProxy("hello:tcp -h host1 -p 10000 --sourceAddress 127.0.0.1");
+        test(objPrx !== null);
+        try {
+            communicator.stringToProxy(
+                "hello:tcp -h host1 -p 10000 --sourceAddress 127.0.0.1 --sourceAddress 10.0.0.1");
+            test(false);
+        } catch (ex) {
+            test(ex instanceof Ice.ParseException, ex as Error);
+        }
+
         out.writeLine("ok");
 
         out.write("testing propertyToProxy... ");


### PR DESCRIPTION
Fixes #487 in all languages + add tests.