### PR TITLE
Print icegridnode ready to standard out instead of using the logger

### DIFF
--- a/cpp/src/IceGrid/IceGridNode.cpp
+++ b/cpp/src/IceGrid/IceGridNode.cpp
@@ -496,7 +496,7 @@ NodeService::startImpl(int argc, char* argv[], int& status)
         {
             //
             // Create was interrupted, return true as if the service was
-            // correctly initiliazed to make sure it's properly stopped.
+            // correctly initialized to make sure it's properly stopped.
             //
             return true;
         }
@@ -579,7 +579,7 @@ NodeService::startImpl(int argc, char* argv[], int& status)
 
     if (!bundleName.empty())
     {
-        print(bundleName + " ready");
+        consoleOut << bundleName << " ready" << endl;
     }
 
     return true;


### PR DESCRIPTION
Fix #528 

One curios thing not fixed that by this PR is that we still print the reading message when there is a deployment error. See handing of DeploymentException above.