### PR TITLE
Update CI to test additional Python versions

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -3,7 +3,7 @@ name: Setup Python
 inputs:
   python-version:
     description: "The version of Python to set up."
-    default: "3.13"
+    default: "3.14"
 
 runs:
   using: "composite"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,54 @@ jobs:
             test_flags: "--target-framework=net10.0"
             build_cpp_and_python: true
 
+          # Python 3.12 testing
+          - os: windows-2025
+            config: "Python312"
+            working_directory: "python"
+            build_flags: "/p:Platform=x64"
+            msbuild_project: "msbuild/ice.proj"
+            build_cpp_and_python: true
+            python_version: "3.12"
+            python_tests: true
+
+          - os: macos-26
+            config: "Python312"
+            working_directory: "python"
+            build_cpp_and_python: true
+            python_version: "3.12"
+            python_tests: true
+
+          - os: ubuntu-24.04
+            config: "Python312"
+            working_directory: "python"
+            build_cpp_and_python: true
+            python_version: "3.12"
+            python_tests: true
+
+          # Python 3.13 testing
+          - os: windows-2025
+            config: "Python313"
+            working_directory: "python"
+            build_flags: "/p:Platform=x64"
+            msbuild_project: "msbuild/ice.proj"
+            build_cpp_and_python: true
+            python_version: "3.13"
+            python_tests: true
+
+          - os: macos-26
+            config: "Python313"
+            working_directory: "python"
+            build_cpp_and_python: true
+            python_version: "3.13"
+            python_tests: true
+
+          - os: ubuntu-24.04
+            config: "Python313"
+            working_directory: "python"
+            build_cpp_and_python: true
+            python_version: "3.13"
+            python_tests: true
+
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
@@ -155,6 +203,8 @@ jobs:
 
       - name: Setup Python
         uses: ./.github/actions/setup-python
+        with:
+          python-version: ${{ matrix.python_version || '3.14' }}
 
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet

--- a/python/BUILDING.md
+++ b/python/BUILDING.md
@@ -67,13 +67,13 @@ MSBuild msbuild\ice.proj
 
 By default, the Windows build uses the Python installation located at:
 
-* `C:\Program Files\Python312` for `x64` builds
-* `C:\Program Files (x86)\Python312-32` for `Win32` builds
+* `C:\Program Files\Python314` for `x64` builds
+* `C:\Program Files (x86)\Python314-32` for `Win32` builds
 
 If your Python installation is in a different location, set the `PythonHome` MSBuild property:
 
 ```shell
-MSBuild msbuild\ice.proj /p:PythonHome=C:\Python312
+MSBuild msbuild\ice.proj /p:PythonHome=C:\Python314
 ```
 
 To build a debug version for use with `python_d`, set the `Configuration` property to `Debug`:

--- a/python/msbuild/ice.props
+++ b/python/msbuild/ice.props
@@ -5,10 +5,10 @@
   </PropertyGroup>
   <Import Project="..\..\cpp\msbuild\Ice.Cpp.props" />
   <PropertyGroup Label="UserMacros" Condition="'$(Platform)'=='Win32'">
-    <PythonHome Condition="'$(PythonHome)' == ''">C:\Program Files (x86)\Python312-32</PythonHome>
+    <PythonHome Condition="'$(PythonHome)' == ''">C:\Program Files (x86)\Python314-32</PythonHome>
   </PropertyGroup>
   <PropertyGroup Label="UserMacros" Condition="'$(Platform)'=='x64'">
-    <PythonHome Condition="'$(PythonHome)' == ''">C:\Program Files\Python312</PythonHome>
+    <PythonHome Condition="'$(PythonHome)' == ''">C:\Program Files\Python314</PythonHome>
   </PropertyGroup>
   <ItemGroup>
     <BuildMacro Include="PythonHome">


### PR DESCRIPTION
This PR updates the default Python version used in CI to 3.14, and add jobs to also test Python 3.12 and Python 3.13.

This are the same changes that I have in #4686, but without the Python code updates.