### PR TITLE
Increase ConnectTimeout to 2 s in metrics test

### DIFF
--- a/cpp/test/Ice/metrics/Client.cpp
+++ b/cpp/test/Ice/metrics/Client.cpp
@@ -23,9 +23,9 @@ Client::run(int argc, char** argv)
     initData.properties->setProperty("Ice.Admin.InstanceName", "client");
     initData.properties->setProperty("Ice.Admin.DelayCreation", "1");
     initData.properties->setProperty("Ice.Warn.Connections", "0");
-    initData.properties->setProperty(
-        "Ice.Connection.Client.ConnectTimeout",
-        "1"); // speed up connection establishment test
+
+    // speed up connection establishment test
+    initData.properties->setProperty("Ice.Connection.Client.ConnectTimeout", "2");
     CommunicatorObserverIPtr observer = make_shared<CommunicatorObserverI>();
     initData.observer = observer;
     Ice::CommunicatorHolder communicator = initialize(initData);

--- a/csharp/test/Ice/metrics/Client.cs
+++ b/csharp/test/Ice/metrics/Client.cs
@@ -25,7 +25,7 @@ public class Client : Test.TestHelper
         initData.properties.setProperty("Ice.Default.Host", "127.0.0.1");
 
         // speed up connection establishment test
-        initData.properties.setProperty("Ice.Connection.Client.ConnectTimeout", "1");
+        initData.properties.setProperty("Ice.Connection.Client.ConnectTimeout", "2");
 
         await using Communicator communicator = initialize(initData);
         Test.MetricsPrx metrics = await AllTests.allTests(this, observer);

--- a/java/test/src/main/java/test/Ice/metrics/Client.java
+++ b/java/test/src/main/java/test/Ice/metrics/Client.java
@@ -22,7 +22,7 @@ public class Client extends TestHelper {
         initData.properties.setProperty("Ice.Warn.Connections", "0");
         initData.properties.setProperty("Ice.Default.Host", "127.0.0.1");
         // speed up connection establishment tests
-        initData.properties.setProperty("Ice.Connection.Client.ConnectTimeout", "1");
+        initData.properties.setProperty("Ice.Connection.Client.ConnectTimeout", "2");
         initData.observer = observer;
 
         try (Communicator communicator = initialize(initData)) {


### PR DESCRIPTION
Fixes #4682.

This low ConnectTimeout is to speed-up connection failures on Windows. But it should not be so low that connection establishment that should succeed actually fail.