### PR TITLE
Remove ICE_API from internal classes/functions

### DIFF
--- a/cpp/src/Ice/Base64.h
+++ b/cpp/src/Ice/Base64.h
@@ -10,7 +10,7 @@
 
 namespace IceInternal
 {
-    class ICE_API Base64
+    class Base64
     {
     public:
         static std::string encode(const std::vector<std::byte>&);

--- a/cpp/src/Ice/EventHandler.h
+++ b/cpp/src/Ice/EventHandler.h
@@ -14,7 +14,7 @@ namespace IceInternal
 {
     class ThreadPoolCurrent;
 
-    class ICE_API EventHandler : public std::enable_shared_from_this<EventHandler>
+    class EventHandler : public std::enable_shared_from_this<EventHandler>
     {
     public:
 #if defined(ICE_USE_IOCP)

--- a/cpp/src/Ice/IPEndpointI.h
+++ b/cpp/src/Ice/IPEndpointI.h
@@ -16,7 +16,7 @@
 
 namespace IceInternal
 {
-    class ICE_API IPEndpointI : public EndpointI, public std::enable_shared_from_this<IPEndpointI>
+    class IPEndpointI : public EndpointI, public std::enable_shared_from_this<IPEndpointI>
     {
     public:
         void streamWriteImpl(Ice::OutputStream*) const override;
@@ -65,7 +65,7 @@ namespace IceInternal
         const std::string _connectionId;
     };
 
-    class ICE_API EndpointHostResolver final
+    class EndpointHostResolver final
     {
     public:
         EndpointHostResolver(const InstancePtr&);

--- a/cpp/src/Ice/NetworkProxy.h
+++ b/cpp/src/Ice/NetworkProxy.h
@@ -8,7 +8,7 @@
 
 namespace IceInternal
 {
-    class ICE_API NetworkProxy
+    class NetworkProxy
     {
     public:
         virtual ~NetworkProxy();

--- a/cpp/src/Ice/SSL/RFC2253.h
+++ b/cpp/src/Ice/SSL/RFC2253.h
@@ -25,7 +25,7 @@ namespace Ice::SSL::RFC2253
 {
     using RDNSeq = std::list<std::pair<std::string, std::string>>;
 
-    struct ICE_API RDNEntry
+    struct RDNEntry
     {
         RDNSeq rdn;
         bool negate;
@@ -38,7 +38,7 @@ namespace Ice::SSL::RFC2253
     // The function returns a list of RDNEntry structures. Any failure in
     // parsing results in a ParseException being thrown.
     //
-    ICE_API RDNEntrySeq parse(const std::string&);
+    RDNEntrySeq parse(const std::string&);
 
     //
     // RDNs are separated with ',' and ';'.
@@ -46,12 +46,12 @@ namespace Ice::SSL::RFC2253
     // This function returns a list of RDN pairs. Any failure in parsing
     // results in a ParseException being thrown.
     //
-    ICE_API RDNSeq parseStrict(const std::string&);
+    RDNSeq parseStrict(const std::string&);
 
     //
     // Unescape the string.
     //
-    ICE_API std::string unescape(const std::string&);
+    std::string unescape(const std::string&);
 
 }
 

--- a/cpp/src/Ice/SSL/SSLEngine.h
+++ b/cpp/src/Ice/SSL/SSLEngine.h
@@ -19,7 +19,7 @@
 
 namespace Ice::SSL
 {
-    class ICE_API SSLEngine
+    class SSLEngine
     {
     public:
         SSLEngine(const IceInternal::InstancePtr&);

--- a/cpp/src/Ice/SSL/SSLInstance.h
+++ b/cpp/src/Ice/SSL/SSLInstance.h
@@ -9,7 +9,7 @@
 
 namespace Ice::SSL
 {
-    class ICE_API Instance final : public IceInternal::ProtocolInstance
+    class Instance final : public IceInternal::ProtocolInstance
     {
     public:
         Instance(const SSLEnginePtr&, std::int16_t, const std::string&);

--- a/cpp/src/Ice/SSL/SSLUtil.cpp
+++ b/cpp/src/Ice/SSL/SSLUtil.cpp
@@ -633,7 +633,8 @@ Ice::SSL::encodeCertificate(X509* certificate)
     BIO_free(out);
     return result;
 }
-ICE_API X509*
+
+X509*
 Ice::SSL::decodeCertificate(const string& data)
 {
     BIO* cert = BIO_new_mem_buf(static_cast<void*>(const_cast<char*>(&data[0])), static_cast<int>(data.size()));

--- a/cpp/src/Ice/StreamSocket.h
+++ b/cpp/src/Ice/StreamSocket.h
@@ -11,7 +11,7 @@
 
 namespace IceInternal
 {
-    class ICE_API StreamSocket : public NativeInfo
+    class StreamSocket : public NativeInfo
     {
     public:
         StreamSocket(ProtocolInstancePtr, const NetworkProxyPtr&, const Address&, const Address&);

--- a/cpp/src/Ice/WSEndpoint.h
+++ b/cpp/src/Ice/WSEndpoint.h
@@ -66,7 +66,7 @@ namespace IceInternal
         const std::string _resource;
     };
 
-    class ICE_API WSEndpointFactory final : public EndpointFactoryWithUnderlying
+    class WSEndpointFactory final : public EndpointFactoryWithUnderlying
     {
     public:
         WSEndpointFactory(const ProtocolInstancePtr&, std::int16_t);


### PR DESCRIPTION
It's easier to add ICE_API in a patch release then remove it.