### PR TITLE
Fix prune artifact to not use a subshell

### DIFF
--- a/.github/workflows/prune-nightly-artifacts.yml
+++ b/.github/workflows/prune-nightly-artifacts.yml
@@ -20,5 +20,3 @@ jobs:
             run: |
               chmod +x ./packaging/release/prune-nightly-artifacts.sh
               ./packaging/release/prune-nightly-artifacts.sh
-            # Allow the release to proceed even if pruning fails
-            continue-on-error: true


### PR DESCRIPTION
This is an attempt to fix https://github.com/zeroc-ice/ice/actions/runs/20062708096/job/57548655148