### PR TITLE
Remove IceBuilder from test project files

### DIFF
--- a/cpp/src/DataStorm/msbuild/datastorm/datastorm.vcxproj
+++ b/cpp/src/DataStorm/msbuild/datastorm/datastorm.vcxproj
@@ -62,7 +62,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
-  <PropertyGroup Label="IceBuilder" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>DATASTORM_API_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -99,7 +98,7 @@
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
+  <ItemDefinitionGroup>
     <SliceCompile>
       <OutputDir>$(Platform)\$(Configuration)</OutputDir>
       <HeaderOutputDir>$(IceSrcRootDir)\include\generated\$(Platform)\$(Configuration)\DataStorm</HeaderOutputDir>

--- a/cpp/src/Glacier2/msbuild/glacier2router.vcxproj
+++ b/cpp/src/Glacier2/msbuild/glacier2router.vcxproj
@@ -97,7 +97,7 @@
       <AdditionalDependencies>crypt32.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
+  <ItemDefinitionGroup>
     <SliceCompile>
       <HeaderOutputDir>$(Platform)\$(Configuration)\Glacier2</HeaderOutputDir>
       <BaseDirectoryForGeneratedInclude>Glacier2</BaseDirectoryForGeneratedInclude>

--- a/cpp/src/Glacier2Lib/msbuild/glacier2/glacier2.vcxproj
+++ b/cpp/src/Glacier2Lib/msbuild/glacier2/glacier2.vcxproj
@@ -82,7 +82,7 @@
       <PreprocessorDefinitions>GLACIER2_API_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
+  <ItemDefinitionGroup>
     <SliceCompile>
       <HeaderOutputDir>$(IceSrcRootDir)\include\generated\$(Platform)\$(Configuration)\Glacier2\</HeaderOutputDir>
       <BaseDirectoryForGeneratedInclude>Glacier2</BaseDirectoryForGeneratedInclude>

--- a/cpp/src/Ice/msbuild/ice/ice.vcxproj
+++ b/cpp/src/Ice/msbuild/ice/ice.vcxproj
@@ -97,7 +97,7 @@
       <AdditionalDependencies>advapi32.lib;ws2_32.lib;Iphlpapi.lib;rpcrt4.lib;DbgHelp.lib;Shlwapi.lib;secur32.lib;crypt32.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
+  <ItemDefinitionGroup>
     <SliceCompile>
       <HeaderOutputDir>$(IceSrcRootDir)\include\generated\$(Platform)\$(Configuration)\Ice\</HeaderOutputDir>
       <BaseDirectoryForGeneratedInclude>Ice</BaseDirectoryForGeneratedInclude>

--- a/cpp/src/IceBox/msbuild/iceboxlib/iceboxlib.vcxproj
+++ b/cpp/src/IceBox/msbuild/iceboxlib/iceboxlib.vcxproj
@@ -94,7 +94,7 @@
       <PreprocessorDefinitions>ICEBOX_API_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
+  <ItemDefinitionGroup>
     <SliceCompile>
       <HeaderOutputDir>$(IceSrcRootDir)\include\generated\$(Platform)\$(Configuration)\IceBox\</HeaderOutputDir>
       <BaseDirectoryForGeneratedInclude>IceBox</BaseDirectoryForGeneratedInclude>

--- a/cpp/src/IceDiscovery/msbuild/icediscovery/icediscovery.vcxproj
+++ b/cpp/src/IceDiscovery/msbuild/icediscovery/icediscovery.vcxproj
@@ -86,9 +86,6 @@
       <AdditionalIncludeDirectories>$(Platform)\$(Configuration);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\IceDiscovery.rc" />
   </ItemGroup>

--- a/cpp/src/IceGrid/msbuild/icegridadmin/icegridadmin.vcxproj
+++ b/cpp/src/IceGrid/msbuild/icegridadmin/icegridadmin.vcxproj
@@ -86,9 +86,6 @@
       <AdditionalIncludeDirectories>$(Platform)\$(Configuration)\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Client.cpp" />
     <ClCompile Include="..\..\DescriptorBuilder.cpp" />

--- a/cpp/src/IceGrid/msbuild/icegridnode/icegridnode.vcxproj
+++ b/cpp/src/IceGrid/msbuild/icegridnode/icegridnode.vcxproj
@@ -98,9 +98,6 @@
       <AdditionalIncludeDirectories>$(Platform)\$(Configuration)\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\IceGridNode.rc" />
   </ItemGroup>

--- a/cpp/src/IceGrid/msbuild/icegridregistry/icegridregistry.vcxproj
+++ b/cpp/src/IceGrid/msbuild/icegridregistry/icegridregistry.vcxproj
@@ -98,9 +98,6 @@
       <AdditionalIncludeDirectories>$(Platform)\$(Configuration)\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\IceGridRegistry.rc" />
   </ItemGroup>

--- a/cpp/src/IceGridLib/msbuild/icegrid/icegrid.vcxproj
+++ b/cpp/src/IceGridLib/msbuild/icegrid/icegrid.vcxproj
@@ -86,7 +86,7 @@
       <DisableSpecificWarnings>4250;4251;4275;4503</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
+  <ItemDefinitionGroup>
     <SliceCompile>
       <HeaderOutputDir>$(IceSrcRootDir)\include\generated\$(Platform)\$(Configuration)\IceGrid\</HeaderOutputDir>
       <BaseDirectoryForGeneratedInclude>IceGrid</BaseDirectoryForGeneratedInclude>

--- a/cpp/src/IceLocatorDiscovery/msbuild/icelocatordiscovery/icelocatordiscovery.vcxproj
+++ b/cpp/src/IceLocatorDiscovery/msbuild/icelocatordiscovery/icelocatordiscovery.vcxproj
@@ -86,9 +86,6 @@
       <AdditionalIncludeDirectories>$(Platform)\$(Configuration);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\IceLocatorDiscovery.rc" />
   </ItemGroup>

--- a/cpp/src/IceStorm/msbuild/icestormadmin/icestormadmin.vcxproj
+++ b/cpp/src/IceStorm/msbuild/icestormadmin/icestormadmin.vcxproj
@@ -81,9 +81,6 @@
       <AdditionalIncludeDirectories>$(Platform)\$(Configuration)\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Admin.cpp" />
     <ClCompile Include="..\..\Grammar.cpp" />

--- a/cpp/src/IceStorm/msbuild/icestormdb/icestormdb.vcxproj
+++ b/cpp/src/IceStorm/msbuild/icestormdb/icestormdb.vcxproj
@@ -93,9 +93,6 @@
       <AdditionalDependencies>advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\IceStormDB.rc" />
   </ItemGroup>

--- a/cpp/src/IceStorm/msbuild/icestormservice/icestormservice.vcxproj
+++ b/cpp/src/IceStorm/msbuild/icestormservice/icestormservice.vcxproj
@@ -99,9 +99,6 @@
       <AdditionalDependencies>advapi32.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Election.ice" />
     <SliceCompile Include="..\..\IceStormInternal.ice" />

--- a/cpp/src/IceStormLib/msbuild/icestorm/icestorm.vcxproj
+++ b/cpp/src/IceStormLib/msbuild/icestorm/icestorm.vcxproj
@@ -81,7 +81,7 @@
       <PreprocessorDefinitions>ICESTORM_API_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
+  <ItemDefinitionGroup>
     <SliceCompile>
       <HeaderOutputDir>$(IceSrcRootDir)\include\generated\$(Platform)\$(Configuration)\IceStorm\</HeaderOutputDir>
       <BaseDirectoryForGeneratedInclude>IceStorm</BaseDirectoryForGeneratedInclude>

--- a/cpp/src/icegriddb/msbuild/icegriddb.vcxproj
+++ b/cpp/src/icegriddb/msbuild/icegriddb.vcxproj
@@ -98,9 +98,6 @@
       <AdditionalDependencies>advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ResourceCompile Include="..\IceGridDB.rc" />
   </ItemGroup>

--- a/cpp/test/DataStorm/api/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/api/msbuild/writer/writer.vcxproj
@@ -118,7 +118,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
-  <PropertyGroup Label="IceBuilder" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>generated;..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -139,8 +138,6 @@
       <AdditionalIncludeDirectories>generated;..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/DataStorm/events/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/events/msbuild/reader/reader.vcxproj
@@ -118,7 +118,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
-  <PropertyGroup Label="IceBuilder" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>generated;..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -139,8 +138,6 @@
       <AdditionalIncludeDirectories>generated;..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/DataStorm/events/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/events/msbuild/writer/writer.vcxproj
@@ -118,7 +118,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
-  <PropertyGroup Label="IceBuilder" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>generated;..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -139,8 +138,6 @@
       <AdditionalIncludeDirectories>generated;..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/DataStorm/partial/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/partial/msbuild/reader/reader.vcxproj
@@ -118,7 +118,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
-  <PropertyGroup Label="IceBuilder" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>generated;..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -139,8 +138,6 @@
       <AdditionalIncludeDirectories>generated;..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/DataStorm/partial/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/partial/msbuild/writer/writer.vcxproj
@@ -118,7 +118,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
-  <PropertyGroup Label="IceBuilder" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>generated;..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -139,8 +138,6 @@
       <AdditionalIncludeDirectories>generated;..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/DataStorm/types/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/types/msbuild/reader/reader.vcxproj
@@ -118,7 +118,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
-  <PropertyGroup Label="IceBuilder" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>generated;..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -139,8 +138,6 @@
       <AdditionalIncludeDirectories>generated;..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/DataStorm/types/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/types/msbuild/writer/writer.vcxproj
@@ -118,7 +118,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
-  <PropertyGroup Label="IceBuilder" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>generated;..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -139,8 +138,6 @@
       <AdditionalIncludeDirectories>generated;..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Glacier2/attack/msbuild/client/client.vcxproj
+++ b/cpp/test/Glacier2/attack/msbuild/client/client.vcxproj
@@ -58,9 +58,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\BackendI.cpp" />
     <ClCompile Include="..\..\Client.cpp" />

--- a/cpp/test/Glacier2/attack/msbuild/server/server.vcxproj
+++ b/cpp/test/Glacier2/attack/msbuild/server/server.vcxproj
@@ -57,9 +57,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\BackendI.cpp" />
     <ClCompile Include="..\..\Server.cpp" />

--- a/cpp/test/Glacier2/dynamicFiltering/msbuild/client/client.vcxproj
+++ b/cpp/test/Glacier2/dynamicFiltering/msbuild/client/client.vcxproj
@@ -58,9 +58,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Client.cpp" />
     <ClCompile Include="Win32\Debug\Test.cpp">

--- a/cpp/test/Glacier2/dynamicFiltering/msbuild/server/server.vcxproj
+++ b/cpp/test/Glacier2/dynamicFiltering/msbuild/server/server.vcxproj
@@ -57,9 +57,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\BackendI.cpp" />
     <ClCompile Include="..\..\Server.cpp" />

--- a/cpp/test/Glacier2/router/msbuild/client/client.vcxproj
+++ b/cpp/test/Glacier2/router/msbuild/client/client.vcxproj
@@ -116,8 +116,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Glacier2/router/msbuild/server/server.vcxproj
+++ b/cpp/test/Glacier2/router/msbuild/server/server.vcxproj
@@ -57,9 +57,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\CallbackI.cpp" />
     <ClCompile Include="..\..\Server.cpp" />

--- a/cpp/test/Glacier2/sessionControl/msbuild/client/client.vcxproj
+++ b/cpp/test/Glacier2/sessionControl/msbuild/client/client.vcxproj
@@ -114,8 +114,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Glacier2/sessionControl/msbuild/server/server.vcxproj
+++ b/cpp/test/Glacier2/sessionControl/msbuild/server/server.vcxproj
@@ -57,9 +57,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Server.cpp" />
     <ClCompile Include="..\..\SessionI.cpp" />

--- a/cpp/test/Glacier2/staticFiltering/msbuild/client/client.vcxproj
+++ b/cpp/test/Glacier2/staticFiltering/msbuild/client/client.vcxproj
@@ -115,8 +115,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Glacier2/staticFiltering/msbuild/server/server.vcxproj
+++ b/cpp/test/Glacier2/staticFiltering/msbuild/server/server.vcxproj
@@ -57,9 +57,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\BackendI.cpp" />
     <ClCompile Include="..\..\Server.cpp" />

--- a/cpp/test/Ice/adapterDeactivation/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/adapterDeactivation/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/adapterDeactivation/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/adapterDeactivation/msbuild/collocated/collocated.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/adapterDeactivation/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/adapterDeactivation/msbuild/server/server.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/admin/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/admin/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/admin/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/admin/msbuild/server/server.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/ami/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/ami/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/ami/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/ami/msbuild/collocated/collocated.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/ami/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/ami/msbuild/server/server.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/background/msbuild/testtransport/testtransport.vcxproj
+++ b/cpp/test/Ice/background/msbuild/testtransport/testtransport.vcxproj
@@ -84,9 +84,6 @@
       <AdditionalIncludeDirectories>..\..;..\..\..\..\..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/binding/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/binding/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/binding/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/binding/msbuild/server/server.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/custom/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/custom/msbuild/client/client.vcxproj
@@ -84,9 +84,6 @@
       <PreprocessorDefinitions>NDEBUG;ICE_UNALIGNED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
     <SliceCompile Include="..\..\Wstring.ice" />

--- a/cpp/test/Ice/custom/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/custom/msbuild/collocated/collocated.vcxproj
@@ -83,9 +83,6 @@
       <PreprocessorDefinitions>NDEBUG;ICE_UNALIGNED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
     <SliceCompile Include="..\..\Wstring.ice" />

--- a/cpp/test/Ice/custom/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/custom/msbuild/server/server.vcxproj
@@ -83,9 +83,6 @@
       <PreprocessorDefinitions>NDEBUG;ICE_UNALIGNED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
     <SliceCompile Include="..\..\Wstring.ice" />

--- a/cpp/test/Ice/custom/msbuild/serveramd/serveramd.vcxproj
+++ b/cpp/test/Ice/custom/msbuild/serveramd/serveramd.vcxproj
@@ -83,9 +83,6 @@
       <PreprocessorDefinitions>NDEBUG;ICE_UNALIGNED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\MyByteSeq.cpp" />
     <ClCompile Include="..\..\ServerAMD.cpp" />

--- a/cpp/test/Ice/defaultServant/msbuild/client.vcxproj
+++ b/cpp/test/Ice/defaultServant/msbuild/client.vcxproj
@@ -80,9 +80,6 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\AllTests.cpp" />
     <ClCompile Include="..\Client.cpp" />

--- a/cpp/test/Ice/defaultValue/msbuild/client.vcxproj
+++ b/cpp/test/Ice/defaultValue/msbuild/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\AllTests.cpp" />
     <ClCompile Include="..\Client.cpp" />

--- a/cpp/test/Ice/echo/msbuild/server.vcxproj
+++ b/cpp/test/Ice/echo/msbuild/server.vcxproj
@@ -80,9 +80,6 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/enums/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/enums/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/enums/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/enums/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/exceptions/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/exceptions/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/exceptions/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/exceptions/msbuild/collocated/collocated.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/exceptions/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/exceptions/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/exceptions/msbuild/serveramd/serveramd.vcxproj
+++ b/cpp/test/Ice/exceptions/msbuild/serveramd/serveramd.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\ServerAMD.cpp" />
     <ClCompile Include="..\..\TestAMDI.cpp" />

--- a/cpp/test/Ice/executor/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/executor/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/executor/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/executor/msbuild/collocated/collocated.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/executor/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/executor/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/facets/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/facets/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/facets/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/facets/msbuild/collocated/collocated.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/facets/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/facets/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/faultTolerance/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/faultTolerance/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/faultTolerance/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/faultTolerance/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/hash/msbuild/client.vcxproj
+++ b/cpp/test/Ice/hash/msbuild/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\Client.cpp" />
   </ItemGroup>

--- a/cpp/test/Ice/hold/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/hold/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/hold/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/hold/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/idleTimeout/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/idleTimeout/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/idleTimeout/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/idleTimeout/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/inactivityTimeout/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/inactivityTimeout/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/inactivityTimeout/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/inactivityTimeout/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/info/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/info/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/info/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/info/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/inheritance/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/inheritance/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/inheritance/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/inheritance/msbuild/collocated/collocated.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/inheritance/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/inheritance/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/invoke/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/invoke/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/invoke/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/invoke/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/library/msbuild/gencode/gencode.vcxproj
+++ b/cpp/test/Ice/library/msbuild/gencode/gencode.vcxproj
@@ -64,9 +64,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/location/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/location/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/location/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/location/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/maxConnections/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/maxConnections/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/maxConnections/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/maxConnections/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/maxDispatches/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/maxDispatches/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/maxDispatches/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/maxDispatches/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/metrics/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/metrics/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/metrics/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/metrics/msbuild/collocated/collocated.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/metrics/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/metrics/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/metrics/msbuild/serveramd/serveramd.vcxproj
+++ b/cpp/test/Ice/metrics/msbuild/serveramd/serveramd.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\ServerAMD.cpp" />
     <ClCompile Include="..\..\TestAMDI.cpp" />

--- a/cpp/test/Ice/middleware/msbuild/client.vcxproj
+++ b/cpp/test/Ice/middleware/msbuild/client.vcxproj
@@ -80,9 +80,6 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\AllTests.cpp" />
     <ClCompile Include="..\Client.cpp" />

--- a/cpp/test/Ice/networkProxy/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/networkProxy/msbuild/client/client.vcxproj
@@ -137,8 +137,6 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/networkProxy/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/networkProxy/msbuild/server/server.vcxproj
@@ -136,8 +136,6 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Ice/objects/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/objects/msbuild/client/client.vcxproj
@@ -92,7 +92,7 @@
     <ClCompile>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
+  <ItemDefinitionGroup>
     <SliceCompile>
       <IncludeDirectories>..\..;%(IncludeDirectories)</IncludeDirectories>
     </SliceCompile>

--- a/cpp/test/Ice/operations/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/operations/msbuild/client/client.vcxproj
@@ -80,9 +80,6 @@
       <DisableSpecificWarnings>4503;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/operations/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/operations/msbuild/collocated/collocated.vcxproj
@@ -79,9 +79,6 @@
       <DisableSpecificWarnings>4503;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/operations/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/operations/msbuild/server/server.vcxproj
@@ -79,9 +79,6 @@
       <DisableSpecificWarnings>4503;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/operations/msbuild/serveramd/serveramd.vcxproj
+++ b/cpp/test/Ice/operations/msbuild/serveramd/serveramd.vcxproj
@@ -79,9 +79,6 @@
       <DisableSpecificWarnings>4503;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\ServerAMD.cpp" />
     <ClCompile Include="..\..\TestAMDI.cpp" />

--- a/cpp/test/Ice/optional/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/optional/msbuild/client/client.vcxproj
@@ -80,9 +80,6 @@
       <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/optional/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/optional/msbuild/server/server.vcxproj
@@ -79,9 +79,6 @@
       <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/optional/msbuild/serveramd/serveramd.vcxproj
+++ b/cpp/test/Ice/optional/msbuild/serveramd/serveramd.vcxproj
@@ -79,9 +79,6 @@
       <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\ServerAMD.cpp" />
     <ClCompile Include="..\..\TestAMDI.cpp" />

--- a/cpp/test/Ice/proxy/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/proxy/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/proxy/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/proxy/msbuild/collocated/collocated.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/proxy/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/proxy/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/retry/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/retry/msbuild/client/client.vcxproj
@@ -80,9 +80,6 @@
       <AdditionalIncludeDirectories>generated;..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/retry/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/retry/msbuild/collocated/collocated.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/retry/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/retry/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/scope/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/scope/msbuild/client/client.vcxproj
@@ -80,9 +80,6 @@
       <DisableSpecificWarnings>4503;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/scope/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/scope/msbuild/server/server.vcxproj
@@ -79,9 +79,6 @@
       <DisableSpecificWarnings>4503;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/servantLocator/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/servantLocator/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/servantLocator/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/servantLocator/msbuild/collocated/collocated.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/servantLocator/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/servantLocator/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/servantLocator/msbuild/serveramd/serveramd.vcxproj
+++ b/cpp/test/Ice/servantLocator/msbuild/serveramd/serveramd.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\ServantLocatorI.cpp" />
     <ClCompile Include="..\..\ServerAMD.cpp" />

--- a/cpp/test/Ice/services/msbuild/client.vcxproj
+++ b/cpp/test/Ice/services/msbuild/client.vcxproj
@@ -80,9 +80,6 @@
       <DisableSpecificWarnings>4250;4251;4275;4503</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\AllTests.cpp" />
     <ClCompile Include="..\Client.cpp" />

--- a/cpp/test/Ice/span/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/span/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/span/msbuild/collocated/collocated.vcxproj
+++ b/cpp/test/Ice/span/msbuild/collocated/collocated.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/span/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/span/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/span/msbuild/serveramd/serveramd.vcxproj
+++ b/cpp/test/Ice/span/msbuild/serveramd/serveramd.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\ServerAMD.cpp" />
     <ClCompile Include="..\..\TestAMDI.cpp" />

--- a/cpp/test/Ice/stream/msbuild/client.vcxproj
+++ b/cpp/test/Ice/stream/msbuild/client.vcxproj
@@ -72,9 +72,6 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile />
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\Client.cpp" />
     <ClCompile Include="Win32\Debug\Test.cpp">

--- a/cpp/test/Ice/stringConverter/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/stringConverter/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/stringConverter/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/stringConverter/msbuild/server/server.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/timeout/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/timeout/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/timeout/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/timeout/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/udp/msbuild/client/client.vcxproj
+++ b/cpp/test/Ice/udp/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/Ice/udp/msbuild/server/server.vcxproj
+++ b/cpp/test/Ice/udp/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceBox/admin/msbuild/client/client.vcxproj
+++ b/cpp/test/IceBox/admin/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\AllTests.cpp" />
     <ClCompile Include="..\..\Client.cpp" />

--- a/cpp/test/IceBox/admin/msbuild/testservice/testservice.vcxproj
+++ b/cpp/test/IceBox/admin/msbuild/testservice/testservice.vcxproj
@@ -117,9 +117,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetName>$(ProjectName)d</TargetName>

--- a/cpp/test/IceBox/configuration/msbuild/client/client.vcxproj
+++ b/cpp/test/IceBox/configuration/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\AllTests.cpp" />
     <ClCompile Include="..\..\Client.cpp" />

--- a/cpp/test/IceBox/configuration/msbuild/testservice/testservice.vcxproj
+++ b/cpp/test/IceBox/configuration/msbuild/testservice/testservice.vcxproj
@@ -117,9 +117,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetName>$(ProjectName)d</TargetName>

--- a/cpp/test/IceBridge/simple/msbuild/client/client.vcxproj
+++ b/cpp/test/IceBridge/simple/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\AllTests.cpp" />
     <ClCompile Include="..\..\Client.cpp" />

--- a/cpp/test/IceBridge/simple/msbuild/server/server.vcxproj
+++ b/cpp/test/IceBridge/simple/msbuild/server/server.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\TestI.cpp" />
     <ClCompile Include="..\..\Server.cpp" />

--- a/cpp/test/IceDiscovery/simple/msbuild/client/client.vcxproj
+++ b/cpp/test/IceDiscovery/simple/msbuild/client/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceDiscovery/simple/msbuild/server/server.vcxproj
+++ b/cpp/test/IceDiscovery/simple/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceGrid/activation/msbuild/client/client.vcxproj
+++ b/cpp/test/IceGrid/activation/msbuild/client/client.vcxproj
@@ -58,9 +58,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceGrid/activation/msbuild/server/server.vcxproj
+++ b/cpp/test/IceGrid/activation/msbuild/server/server.vcxproj
@@ -58,9 +58,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceGrid/allocation/msbuild/client/client.vcxproj
+++ b/cpp/test/IceGrid/allocation/msbuild/client/client.vcxproj
@@ -58,9 +58,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceGrid/allocation/msbuild/server/server.vcxproj
+++ b/cpp/test/IceGrid/allocation/msbuild/server/server.vcxproj
@@ -58,9 +58,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceGrid/deployer/msbuild/client/client.vcxproj
+++ b/cpp/test/IceGrid/deployer/msbuild/client/client.vcxproj
@@ -58,9 +58,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceGrid/deployer/msbuild/server/server.vcxproj
+++ b/cpp/test/IceGrid/deployer/msbuild/server/server.vcxproj
@@ -58,9 +58,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceGrid/deployer/msbuild/testservice/testservice.vcxproj
+++ b/cpp/test/IceGrid/deployer/msbuild/testservice/testservice.vcxproj
@@ -70,9 +70,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <TargetName>$(ProjectName)</TargetName>
   </PropertyGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceGrid/noRestartUpdate/msbuild/client/client.vcxproj
+++ b/cpp/test/IceGrid/noRestartUpdate/msbuild/client/client.vcxproj
@@ -58,9 +58,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceGrid/noRestartUpdate/msbuild/server/server.vcxproj
+++ b/cpp/test/IceGrid/noRestartUpdate/msbuild/server/server.vcxproj
@@ -58,9 +58,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceGrid/noRestartUpdate/msbuild/testservice/testservice.vcxproj
+++ b/cpp/test/IceGrid/noRestartUpdate/msbuild/testservice/testservice.vcxproj
@@ -70,9 +70,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetName>$(ProjectName)d</TargetName>
   </PropertyGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceGrid/replicaGroup/msbuild/client/client.vcxproj
+++ b/cpp/test/IceGrid/replicaGroup/msbuild/client/client.vcxproj
@@ -58,9 +58,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceGrid/replicaGroup/msbuild/server/server.vcxproj
+++ b/cpp/test/IceGrid/replicaGroup/msbuild/server/server.vcxproj
@@ -58,9 +58,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceGrid/replicaGroup/msbuild/testservice/testservice.vcxproj
+++ b/cpp/test/IceGrid/replicaGroup/msbuild/testservice/testservice.vcxproj
@@ -70,9 +70,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <TargetName>$(ProjectName)</TargetName>
   </PropertyGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceGrid/replication/msbuild/client/client.vcxproj
+++ b/cpp/test/IceGrid/replication/msbuild/client/client.vcxproj
@@ -58,9 +58,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceGrid/replication/msbuild/server/server.vcxproj
+++ b/cpp/test/IceGrid/replication/msbuild/server/server.vcxproj
@@ -58,9 +58,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceGrid/session/msbuild/client/client.vcxproj
+++ b/cpp/test/IceGrid/session/msbuild/client/client.vcxproj
@@ -58,9 +58,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\AllTests.cpp" />
     <ClCompile Include="..\..\Client.cpp" />

--- a/cpp/test/IceGrid/session/msbuild/server/server.vcxproj
+++ b/cpp/test/IceGrid/session/msbuild/server/server.vcxproj
@@ -58,9 +58,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Server.cpp" />
   </ItemGroup>

--- a/cpp/test/IceGrid/session/msbuild/verifier/verifier.vcxproj
+++ b/cpp/test/IceGrid/session/msbuild/verifier/verifier.vcxproj
@@ -58,9 +58,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\PermissionsVerifier.cpp" />
   </ItemGroup>

--- a/cpp/test/IceGrid/simple/msbuild/client/client.vcxproj
+++ b/cpp/test/IceGrid/simple/msbuild/client/client.vcxproj
@@ -78,9 +78,6 @@
       <DisableSpecificWarnings>4503;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceGrid/simple/msbuild/server/server.vcxproj
+++ b/cpp/test/IceGrid/simple/msbuild/server/server.vcxproj
@@ -58,9 +58,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceGrid/update/msbuild/client/client.vcxproj
+++ b/cpp/test/IceGrid/update/msbuild/client/client.vcxproj
@@ -58,9 +58,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceGrid/update/msbuild/server/server.vcxproj
+++ b/cpp/test/IceGrid/update/msbuild/server/server.vcxproj
@@ -58,9 +58,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceSSL/configuration/msbuild/client/client.vcxproj
+++ b/cpp/test/IceSSL/configuration/msbuild/client/client.vcxproj
@@ -80,9 +80,6 @@
       <AdditionalDependencies>advapi32.lib;crypt32.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceSSL/configuration/msbuild/server/server.vcxproj
+++ b/cpp/test/IceSSL/configuration/msbuild/server/server.vcxproj
@@ -59,9 +59,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <SliceCompile Include="..\..\Test.ice" />
   </ItemGroup>

--- a/cpp/test/IceStorm/federation/msbuild/publisher/publisher.vcxproj
+++ b/cpp/test/IceStorm/federation/msbuild/publisher/publisher.vcxproj
@@ -114,8 +114,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/federation/msbuild/subscriber/subscriber.vcxproj
+++ b/cpp/test/IceStorm/federation/msbuild/subscriber/subscriber.vcxproj
@@ -113,9 +113,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <PropertyGroup Label="UserMacros" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/federation2/msbuild/publisher/publisher.vcxproj
+++ b/cpp/test/IceStorm/federation2/msbuild/publisher/publisher.vcxproj
@@ -114,8 +114,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/federation2/msbuild/subscriber/subscriber.vcxproj
+++ b/cpp/test/IceStorm/federation2/msbuild/subscriber/subscriber.vcxproj
@@ -113,9 +113,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <PropertyGroup Label="UserMacros" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/persistent/msbuild/client/client.vcxproj
+++ b/cpp/test/IceStorm/persistent/msbuild/client/client.vcxproj
@@ -61,8 +61,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/rep1/msbuild/publisher/publisher.vcxproj
+++ b/cpp/test/IceStorm/rep1/msbuild/publisher/publisher.vcxproj
@@ -114,8 +114,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/rep1/msbuild/sub/sub.vcxproj
+++ b/cpp/test/IceStorm/rep1/msbuild/sub/sub.vcxproj
@@ -113,9 +113,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <PropertyGroup Label="UserMacros" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/rep1/msbuild/subscriber/subscriber.vcxproj
+++ b/cpp/test/IceStorm/rep1/msbuild/subscriber/subscriber.vcxproj
@@ -113,9 +113,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <PropertyGroup Label="UserMacros" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/repgrid/msbuild/client.vcxproj
+++ b/cpp/test/IceStorm/repgrid/msbuild/client.vcxproj
@@ -114,8 +114,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/repstress/msbuild/control/control.vcxproj
+++ b/cpp/test/IceStorm/repstress/msbuild/control/control.vcxproj
@@ -162,9 +162,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <PropertyGroup Label="UserMacros" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/repstress/msbuild/publisher/publisher.vcxproj
+++ b/cpp/test/IceStorm/repstress/msbuild/publisher/publisher.vcxproj
@@ -163,8 +163,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/repstress/msbuild/subscriber/subscriber.vcxproj
+++ b/cpp/test/IceStorm/repstress/msbuild/subscriber/subscriber.vcxproj
@@ -162,9 +162,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <PropertyGroup Label="UserMacros" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/single/msbuild/publisher/publisher.vcxproj
+++ b/cpp/test/IceStorm/single/msbuild/publisher/publisher.vcxproj
@@ -114,8 +114,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/single/msbuild/subscriber/subscriber.vcxproj
+++ b/cpp/test/IceStorm/single/msbuild/subscriber/subscriber.vcxproj
@@ -113,9 +113,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <PropertyGroup Label="UserMacros" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/stress/msbuild/publisher/publisher.vcxproj
+++ b/cpp/test/IceStorm/stress/msbuild/publisher/publisher.vcxproj
@@ -114,8 +114,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/IceStorm/stress/msbuild/subscriber/subscriber.vcxproj
+++ b/cpp/test/IceStorm/stress/msbuild/subscriber/subscriber.vcxproj
@@ -113,9 +113,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <PropertyGroup Label="UserMacros" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/cpp/test/Slice/deprecated/msbuild/client.vcxproj
+++ b/cpp/test/Slice/deprecated/msbuild/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\Client.cpp" />
     <ClCompile Include="Win32\Debug\Test.cpp">

--- a/cpp/test/Slice/escape/msbuild/client.vcxproj
+++ b/cpp/test/Slice/escape/msbuild/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\Client.cpp" />
     <ClCompile Include="Win32\Debug\Clash.cpp">

--- a/cpp/test/Slice/macros/msbuild/client.vcxproj
+++ b/cpp/test/Slice/macros/msbuild/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\Client.cpp" />
     <ClCompile Include="Win32\Debug\Test.cpp">

--- a/cpp/test/Slice/parser/msbuild/client.vcxproj
+++ b/cpp/test/Slice/parser/msbuild/client.vcxproj
@@ -161,7 +161,7 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
+  <ItemDefinitionGroup>
     <SliceCompile>
       <IncludeDirectories>..\;%(IncludeDirectories)</IncludeDirectories>
     </SliceCompile>

--- a/cpp/test/Slice/print/msbuild/client.vcxproj
+++ b/cpp/test/Slice/print/msbuild/client.vcxproj
@@ -80,9 +80,6 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\AllTests.cpp" />
     <ClCompile Include="..\Client.cpp" />

--- a/cpp/test/Slice/structure/msbuild/client.vcxproj
+++ b/cpp/test/Slice/structure/msbuild/client.vcxproj
@@ -60,9 +60,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Label="IceBuilder">
-    <SliceCompile />
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\Client.cpp" />
     <ClCompile Include="Win32\Debug\Test.cpp">

--- a/cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/SliceCompile.Cpp.File.xaml
+++ b/cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/SliceCompile.Cpp.File.xaml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c) 2009-2018 ZeroC, Inc. All rights reserved. -->
+<!-- Copyright (c) ZeroC, Inc. -->
 <Rule
     Name="SliceCompileFile"
-    DisplayName="Ice Builder"
+    DisplayName="Slice Tools for C++"
     PageTemplate="generic"
-    Description="Ice Builder file settings"
+    Description="Slice Tools for C++ file settings"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
 
     <Rule.DataSource>
         <DataSource Persistence="ProjectFile"
                     ItemType="SliceCompile"
-                    Label="IceBuilder"
+                    Label="SliceTools"
                     HasConfigurationCondition="false"/>
     </Rule.DataSource>
 
@@ -23,7 +23,7 @@
         <StringProperty.DataSource>
             <DataSource Persistence="ProjectFile"
                         ItemType="SliceCompile"
-                        Label="IceBuilder"
+                        Label="SliceTools"
                         HasConfigurationCondition="false"/>
         </StringProperty.DataSource>
     </StringProperty>
@@ -37,7 +37,7 @@
         <StringProperty.DataSource>
             <DataSource Persistence="ProjectFile"
                         ItemType="SliceCompile"
-                        Label="IceBuilder"
+                        Label="SliceTools"
                         HasConfigurationCondition="false"/>
         </StringProperty.DataSource>
     </StringProperty>
@@ -52,7 +52,7 @@
         <StringListProperty.DataSource>
             <DataSource Persistence="ProjectFile"
                         ItemType="SliceCompile"
-                        Label="IceBuilder"
+                        Label="SliceTools"
                         HasConfigurationCondition="false"/>
         </StringListProperty.DataSource>
     </StringListProperty>
@@ -66,7 +66,7 @@
         <StringProperty.DataSource>
             <DataSource Persistence="ProjectFile"
                         ItemType="SliceCompile"
-                        Label="IceBuilder"
+                        Label="SliceTools"
                         HasConfigurationCondition="false"/>
         </StringProperty.DataSource>
     </StringProperty>
@@ -91,7 +91,7 @@
         <EnumProperty.DataSource>
             <DataSource Persistence="ProjectFile"
                         ItemType="SliceCompile"
-                        Label="IceBuilder"
+                        Label="SliceTools"
                         HasConfigurationCondition="false"/>
         </EnumProperty.DataSource>
     </EnumProperty>
@@ -113,7 +113,7 @@
         <EnumProperty.DataSource>
             <DataSource Persistence="ProjectFile"
                         ItemType="SliceCompile"
-                        Label="IceBuilder"
+                        Label="SliceTools"
                         HasConfigurationCondition="false"/>
         </EnumProperty.DataSource>
     </EnumProperty>
@@ -125,7 +125,7 @@
         <StringListProperty.DataSource>
             <DataSource Persistence="ProjectFile"
                         ItemType="SliceCompile"
-                        Label="IceBuilder"
+                        Label="SliceTools"
                         HasConfigurationCondition="false"/>
         </StringListProperty.DataSource>
     </StringListProperty>
@@ -138,7 +138,7 @@
         <StringProperty.DataSource>
             <DataSource Persistence="ProjectFile"
                         ItemType="SliceCompile"
-                        Label="IceBuilder"
+                        Label="SliceTools"
                         HasConfigurationCondition="true"/>
         </StringProperty.DataSource>
     </StringProperty>

--- a/cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/SliceCompile.Cpp.xaml
+++ b/cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/SliceCompile.Cpp.xaml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c) 2009-2018 ZeroC, Inc. All rights reserved. -->
+<!-- Copyright (c) ZeroC, Inc. -->
 <Rule
     Name="SliceCompile"
-    DisplayName="Ice Builder"
+    DisplayName="Slice Tools for C++"
     PageTemplate="generic"
-    Description="Ice Builder project settings"
+    Description="Slice Tools for C++ project settings"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
 
     <Rule.DataSource>
         <DataSource Persistence="ProjectFile"
                     ItemType=""
-                    Label="IceBuilder"
+                    Label="SliceTools"
                     HasConfigurationCondition="false"/>
     </Rule.DataSource>
 
@@ -23,7 +23,7 @@
         <StringProperty.DataSource>
             <DataSource Persistence="ProjectFile"
                         ItemType="SliceCompile"
-                        Label="IceBuilder"
+                        Label="SliceTools"
                         HasConfigurationCondition="false"/>
         </StringProperty.DataSource>
     </StringProperty>
@@ -37,7 +37,7 @@
         <StringProperty.DataSource>
             <DataSource Persistence="ProjectFile"
                         ItemType="SliceCompile"
-                        Label="IceBuilder"
+                        Label="SliceTools"
                         HasConfigurationCondition="false"/>
         </StringProperty.DataSource>
     </StringProperty>
@@ -52,7 +52,7 @@
         <StringListProperty.DataSource>
             <DataSource Persistence="ProjectFile"
                         ItemType="SliceCompile"
-                        Label="IceBuilder"
+                        Label="SliceTools"
                         HasConfigurationCondition="false"/>
         </StringListProperty.DataSource>
     </StringListProperty>
@@ -66,7 +66,7 @@
         <StringProperty.DataSource>
             <DataSource Persistence="ProjectFile"
                         ItemType="SliceCompile"
-                        Label="IceBuilder"
+                        Label="SliceTools"
                         HasConfigurationCondition="false"/>
         </StringProperty.DataSource>
     </StringProperty>
@@ -91,7 +91,7 @@
         <EnumProperty.DataSource>
             <DataSource Persistence="ProjectFile"
                         ItemType="SliceCompile"
-                        Label="IceBuilder"
+                        Label="SliceTools"
                         HasConfigurationCondition="false"/>
         </EnumProperty.DataSource>
     </EnumProperty>
@@ -113,7 +113,7 @@
         <EnumProperty.DataSource>
             <DataSource Persistence="ProjectFile"
                         ItemType="SliceCompile"
-                        Label="IceBuilder"
+                        Label="SliceTools"
                         HasConfigurationCondition="false"/>
         </EnumProperty.DataSource>
     </EnumProperty>
@@ -125,7 +125,7 @@
         <StringListProperty.DataSource>
             <DataSource Persistence="ProjectFile"
                         ItemType="SliceCompile"
-                        Label="IceBuilder"
+                        Label="SliceTools"
                         HasConfigurationCondition="false"/>
         </StringListProperty.DataSource>
     </StringListProperty>
@@ -138,7 +138,7 @@
         <StringProperty.DataSource>
             <DataSource Persistence="ProjectFile"
                         ItemType="SliceCompile"
-                        Label="IceBuilder"
+                        Label="SliceTools"
                         HasConfigurationCondition="true"/>
         </StringProperty.DataSource>
     </StringProperty>


### PR DESCRIPTION
This PR removes all references to IceBuilder in the C++ test project files.