### PR TITLE
Fix crash when validating dispatch out parameters in Ice for Python

### DIFF
--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -713,7 +713,7 @@ Operation::marshalResult(Ice::OutputStream& os, PyObject* result)
                 {
                     throwPythonException();
                 }
-                catch (const Ice::UnknownException& ex)
+                catch (const Ice::LocalException& ex)
                 {
                     ostr << "':\n" << ex.what();
                 }
@@ -735,7 +735,7 @@ Operation::marshalResult(Ice::OutputStream& os, PyObject* result)
                 {
                     throwPythonException();
                 }
-                catch (const Ice::UnknownException& ex)
+                catch (const Ice::LocalException& ex)
                 {
                     ostr << ":\n" << ex.what();
                 }


### PR DESCRIPTION
Fix #4705 