### PR TITLE
Do not try to enable bluetooth on the emulator

### DIFF
--- a/java/test/android/controller/build.gradle
+++ b/java/test/android/controller/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.0'
+        classpath 'com.android.tools.build:gradle:8.13.2'
     }
 }
 

--- a/java/test/android/controller/src/main/java/com/zeroc/testcontroller/ControllerActivity.java
+++ b/java/test/android/controller/src/main/java/com/zeroc/testcontroller/ControllerActivity.java
@@ -58,7 +58,11 @@ public class ControllerActivity extends Activity {
         super.onStart();
 
         if (!_isSetupComplete) {
-            initializeBluetooth();
+            if (ControllerApp.isEmulator()) {
+                completeSetup(false);
+            } else {
+                initializeBluetooth();
+            }
         }
     }
 


### PR DESCRIPTION
This PR try to fix Android CI failures by updating the controller to avoid enabling BT on the emulator. When I tested locally it was displaying a dialog asking for the required permissions.