### PR TITLE
Rename IceSliceToolsAssembly -> SliceToolsAssembly

### DIFF
--- a/cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/ZeroC.Ice.Slice.Tools.Cpp.targets
+++ b/cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/ZeroC.Ice.Slice.Tools.Cpp.targets
@@ -13,25 +13,25 @@
     <Choose>
         <When Condition="Exists('$(MSBuildThisFileDirectory)..\tasks\netstandard2.0\ZeroC.Ice.Slice.Tools.Cpp.dll')">
             <PropertyGroup>
-                <IceSliceToolsAssembly>$(MSBuildThisFileDirectory)..\tasks\netstandard2.0\ZeroC.Ice.Slice.Tools.Cpp.dll</IceSliceToolsAssembly>
+                <SliceToolsAssembly>$(MSBuildThisFileDirectory)..\tasks\netstandard2.0\ZeroC.Ice.Slice.Tools.Cpp.dll</SliceToolsAssembly>
             </PropertyGroup>
         </When>
         <When Condition="Exists('$(MSBuildThisFileDirectory)bin\Any CPU\$(Configuration)\netstandard2.0\ZeroC.Ice.Slice.Tools.Cpp.dll')">
             <PropertyGroup>
-                <IceSliceToolsAssembly>$(MSBuildThisFileDirectory)bin\Any CPU\$(Configuration)\netstandard2.0\ZeroC.Ice.Slice.Tools.Cpp.dll</IceSliceToolsAssembly>
+                <SliceToolsAssembly>$(MSBuildThisFileDirectory)bin\Any CPU\$(Configuration)\netstandard2.0\ZeroC.Ice.Slice.Tools.Cpp.dll</SliceToolsAssembly>
             </PropertyGroup>
         </When>
         <Otherwise>
             <!-- Fallback to bin directory without "Any CPU" subdirectory -->
             <PropertyGroup>
-                <IceSliceToolsAssembly>$(MSBuildThisFileDirectory)bin\$(Configuration)\netstandard2.0\ZeroC.Ice.Slice.Tools.Cpp.dll</IceSliceToolsAssembly>
+                <SliceToolsAssembly>$(MSBuildThisFileDirectory)bin\$(Configuration)\netstandard2.0\ZeroC.Ice.Slice.Tools.Cpp.dll</SliceToolsAssembly>
             </PropertyGroup>
         </Otherwise>
     </Choose>
 
     <!-- Import the MSBuild tasks required to compile Slice files using the slice2cpp compiler. -->
-    <UsingTask TaskName="ZeroC.Ice.Slice.Tools.Cpp.Slice2CppTask" AssemblyFile="$(IceSliceToolsAssembly)"/>
-    <UsingTask TaskName="ZeroC.Ice.Slice.Tools.Cpp.Slice2CppDependTask" AssemblyFile="$(IceSliceToolsAssembly)"/>
+    <UsingTask TaskName="ZeroC.Ice.Slice.Tools.Cpp.Slice2CppTask" AssemblyFile="$(SliceToolsAssembly)"/>
+    <UsingTask TaskName="ZeroC.Ice.Slice.Tools.Cpp.Slice2CppDependTask" AssemblyFile="$(SliceToolsAssembly)"/>
 
     <PropertyGroup>
         <EnableDefaultSliceCompileItems Condition="'$(EnableDefaultSliceCompileItems)' == ''">true</EnableDefaultSliceCompileItems>


### PR DESCRIPTION
A minor fix for consistency between C# and C++ SliceTools