### PR TITLE
Move IceGridGUI shortcut to start menu (Remove Ice X.X.X folder)

### DIFF
--- a/packaging/msi/InstallFolderComponent.wxs
+++ b/packaging/msi/InstallFolderComponent.wxs
@@ -10,9 +10,7 @@
                 <Directory Id="ConfigFolder" Name="config" />
             </Directory>
         </StandardDirectory>
-        <StandardDirectory Id="ProgramMenuFolder">
-            <Directory Id="IceStartMenu" Name="Ice $(Version)" />
-        </StandardDirectory>
+        <StandardDirectory Id="ProgramMenuFolder" />
 
         <Component Id="AddToPath" Guid="361FB9AF-3452-45F8-93E9-AAA1E97CB1AA" Condition="ADD_TO_PATH = 1">
             <Environment

--- a/packaging/msi/StartMenu.wxs
+++ b/packaging/msi/StartMenu.wxs
@@ -12,7 +12,7 @@
         <ComponentGroup Id="StartMenuComponents">
             <Component
                 Id="IceStartMenuShortcuts"
-                Directory="IceStartMenu"
+                Directory="ProgramMenuFolder"
                 Guid="618E2B68-1829-478A-AB46-47D65887F351">
                 <Shortcut
                     Id="IceGridGUIShortcut"
@@ -22,7 +22,6 @@
                         Icon="IceGridGUIIcon"
                         Advertise="no"/>
                 <RegistryValue Root="HKCU" Key="ZeroC\Ice-Services-$(Version)\Installed" Value="1" Type="string" KeyPath="yes" />
-                <RemoveFolder Id="IceStartMenu" On="uninstall"/>
             </Component>
         </ComponentGroup>
     </Fragment>


### PR DESCRIPTION
This PR move the IceGridGUI shortcut in MSI installed to the start menu, and avoids creating an Ice 3.8.0 folder for just this shortcut.