### PR TITLE
Update C++ Windows builds to keep PDBs and sources

### DIFF
--- a/.github/workflows/build-cpp-nuget-packages.yml
+++ b/.github/workflows/build-cpp-nuget-packages.yml
@@ -6,11 +6,18 @@ on:
       ice_version:
         required: false
         type: string
+      run_id:
+        description: "The run ID to use for downloading artifacts"
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       ice_version:
         description: "The Ice version to build"
         required: false
+      run_id:
+        description: "The run ID to use for downloading artifacts"
+        required: true
 
 jobs:
   build-cpp-nuget-packages:
@@ -22,28 +29,14 @@ jobs:
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
 
-      - name: Setup Java
-        uses: ./.github/actions/setup-java
-
-      - name: Build C++ Binaries
-        run: msbuild /m ice.proj /t:BuildDist /p:BuildAllConfigurations=yes
-        working-directory: cpp/msbuild
-
-      - name: Sign C++ Binaries with Trusted Signing
-        uses: azure/trusted-signing-action@v0
-        with:
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-          endpoint: https://eus.codesigning.azure.net/
-          trusted-signing-account-name: zeroc
-          certificate-profile-name: zeroc-ice
-          files-folder: ./cpp/bin
-          files-folder-recurse: true
-          files-folder-filter: exe,dll
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
+      - name: Download C++ Binaries
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run download "${{ inputs.run_id }}" --repo ${{ github.repository }} --name windows-cpp-x64-Release-build --dir cpp
+          gh run download "${{ inputs.run_id }}" --repo ${{ github.repository }} --name windows-cpp-x64-Debug-build --dir cpp
+          gh run download "${{ inputs.run_id }}" --repo ${{ github.repository }} --name windows-cpp-Win32-Release-build --dir cpp
+          gh run download "${{ inputs.run_id }}" --repo ${{ github.repository }} --name windows-cpp-Win32-Debug-build --dir cpp
 
       - name: Ice Package Version
         if: ${{ inputs.ice_version != '' }}
@@ -61,10 +54,3 @@ jobs:
           name: windows-cpp-nuget-packages
           path: |
             cpp/msbuild/ZeroC.Ice.Cpp/*.nupkg
-
-      - name: Upload C++ Binaries
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-cpp-binaries
-          path: |
-            cpp/bin/x64/Release/

--- a/.github/workflows/build-cpp-windows-binaries.yml
+++ b/.github/workflows/build-cpp-windows-binaries.yml
@@ -1,0 +1,65 @@
+name: "Build C++ Windows Binaries"
+
+on:
+  workflow_call:
+    inputs:
+      ice_version:
+        required: false
+        type: string
+  workflow_dispatch:
+    inputs:
+      ice_version:
+        description: "The Ice version to build"
+        required: false
+
+jobs:
+  build-cpp-windows-binaries:
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        include:
+          - platform: x64
+            configuration: Release
+          - platform: x64
+            configuration: Debug
+          - platform: Win32
+            configuration: Release
+          - platform: Win32
+            configuration: Debug
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup C++
+        uses: ./.github/actions/setup-cpp
+
+      - name: Build C++ Binaries
+        run: |
+          msbuild /m ice.proj /t:BuildDist /p:Configuration=${{ matrix.configuration }} /p:Platform=${{ matrix.platform }}
+        working-directory: cpp/msbuild
+
+      - name: Sign C++ Binaries with Trusted Signing
+        uses: azure/trusted-signing-action@v0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: https://eus.codesigning.azure.net/
+          trusted-signing-account-name: zeroc
+          certificate-profile-name: zeroc-ice
+          files-folder: ./cpp/bin/${{ matrix.platform }}/${{ matrix.configuration }}
+          files-folder-filter: exe,dll
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Upload C++ Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-cpp-${{ matrix.platform }}-${{ matrix.configuration }}-build
+          path: |
+            cpp/bin/${{ matrix.platform }}/${{ matrix.configuration }}/
+            cpp/lib/${{ matrix.platform }}/${{ matrix.configuration }}/
+            cpp/include/generated/${{ matrix.platform }}/${{ matrix.configuration }}/
+            cpp/src/**/msbuild/**/${{ matrix.platform }}/${{ matrix.configuration }}/*.cpp
+            cpp/src/**/msbuild/**/${{ matrix.platform }}/${{ matrix.configuration }}/*.h

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -159,12 +159,23 @@ jobs:
       ice_version: ${{ needs.set-version.outputs.rpm_version }}
     secrets: inherit
 
-  build-cpp-nuget-packages:
-    name: Build C++ NuGet Packages
-    uses: ./.github/workflows/build-cpp-nuget-packages.yml
+  build-cpp-windows-binaries:
+    name: Build C++ Windows Binaries
+    uses: ./.github/workflows/build-cpp-windows-binaries.yml
     needs: set-version
     with:
       ice_version: ${{ needs.set-version.outputs.semver_version }}
+    secrets: inherit
+
+  build-cpp-nuget-packages:
+    name: Build C++ NuGet Packages
+    uses: ./.github/workflows/build-cpp-nuget-packages.yml
+    needs:
+      - set-version
+      - build-cpp-windows-binaries
+    with:
+      ice_version: ${{ needs.set-version.outputs.semver_version }}
+      run_id: ${{ github.run_id }}
     secrets: inherit
 
   build-icegridgui-jar:
@@ -180,7 +191,7 @@ jobs:
     uses: ./.github/workflows/build-windows-msi.yml
     needs:
       - set-version
-      - build-cpp-nuget-packages
+      - build-cpp-windows-binaries
       - build-icegridgui-jar
     with:
       ice_version: ${{ needs.set-version.outputs.semver_version }}

--- a/.github/workflows/build-windows-msi.yml
+++ b/.github/workflows/build-windows-msi.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh run download "${{ inputs.run_id }}" --repo ${{ github.repository }} --name windows-cpp-binaries --dir cpp/bin/x64/Release
+          gh run download "${{ inputs.run_id }}" --repo ${{ github.repository }} --name windows-cpp-x64-Release-build --dir cpp
           gh run download "${{ inputs.run_id }}" --repo ${{ github.repository }} --name icegridgui-jar --dir java/lib
 
       # MSI packaging depends on VCInstallDir to locate The C++ merge modules


### PR DESCRIPTION
This PR splits the building of C++ windows binaries from the NuGet package creation.

The new `build-cpp-nuget-packages.yml` workflow builds the Windows C++ binaries in a matrix. This should speed-up the Windows build which is currently the slowest part of the release build process.

The new workflow also uploads the PDBs, and sources from the build, which we will use later to create source/symbols server (For a separate PR).

The MSI, and NuGet workflows depend on the new workflow and reuse its binaries.