### PR TITLE
Add plugin publishing plugin

### DIFF
--- a/java/tools/slice-tools/build.gradle.kts
+++ b/java/tools/slice-tools/build.gradle.kts
@@ -40,7 +40,7 @@ group = "com.zeroc"
 
 gradlePlugin {
     website = "https://zeroc.com"
-    vcsUrl = "https://github.com/zeroc-ice/ice.git"
+    vcsUrl = "https://github.com/zeroc-ice/ice"
     plugins {
         create("sliceTools") {
             id = "com.zeroc.slice-tools"


### PR DESCRIPTION
This PR adds the gradle-publish-plugin to Java Slice tools. This is required to publish to the plugin portal.

I will update the release workflow in a follow up PR to use it.