### PR TITLE
Do not require a specific Java toolchain

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -28,9 +28,6 @@ subprojects {
     }
 
     java {
-        toolchain {
-            languageVersion = JavaLanguageVersion.of(targetJavaRelease)
-        }
         withSourcesJar()
         withJavadocJar()
     }


### PR DESCRIPTION
This PR remove the toolchain setting, this avoid requiring a specific toolchain. Ice for Java should build with any toolchain compatible with Java 17.

We already set JavaCompile options.release to 17.

If we want to keep the toolchain requirement, all systems need to install JDK 17, this give consistent builds but I think is better to just use the available JDK if possible.

There is also a Gradle plugin to download the toolchains https://github.com/gradle/foojay-toolchains
But it seems overkill, when you have one already installed.