### PR TITLE
Avoid calling `string(nullptr)` constructor

### DIFF
--- a/cpp/src/Glacier2/RouterI.cpp
+++ b/cpp/src/Glacier2/RouterI.cpp
@@ -159,11 +159,11 @@ Glacier2::RouterI::addProxies(const ObjectProxySeq& proxies, const Current& curr
     return _routingTable->add(proxies, current);
 }
 
-string
+std::string
 Glacier2::RouterI::getCategoryForClient(const Ice::Current&) const
 {
     assert(false); // Must not be called in this router implementation.
-    return 0;
+    return std::string();
 }
 
 void


### PR DESCRIPTION
The `std::string` constructor from `nullptr` has been explicitly deleted in C++23, which makes the code fail to compile even if the constructor is never called.