### PR TITLE
Add 3.7 CI workflow using GitHub actions

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,67 @@
+name: Build Ice
+description: "Build Ice project"
+
+inputs:
+  working_directory:
+    description: "The working directory to run the build in"
+    default: "."
+
+  build_flags:
+    description: "Additional flags to pass to the build"
+    default: ""
+
+  msbuild_project:
+    description: "The project file to build"
+    default: "ice.proj"
+
+  msbuild_command:
+    description: "The msbuild command to use"
+    default: "msbuild /m"
+
+  build_cpp_and_python:
+    description: "Build C++ and Python"
+    default: "false"
+
+  build_android_controller:
+    description: "Build Android Controller"
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    # macOS and Linux
+    - name: Build C++ and Python
+      run: |
+        make ${{ inputs.build_flags }} -C cpp srcs
+        make -C python
+      shell: bash
+      if: (runner.os == 'macOS' || runner.os == 'Linux') && inputs.build_cpp_and_python == 'true'
+    - name: Build
+      working-directory: ${{ inputs.working_directory }}
+      run: make ${{ inputs.build_flags }}
+      shell: bash
+      if: runner.os == 'macOS' || runner.os == 'Linux'
+
+    # Android
+    - name: Build Android
+      working-directory: ${{ inputs.working_directory }}
+      run: |
+        cd test/android/controller
+        ./gradlew build checkstyle
+        ./gradlew rewriteDryRun --no-parallel --no-configuration-cache
+      shell: bash
+      if: inputs.build_android_controller == 'true'
+
+    # Windows
+    - name: Build C++ and Python
+      run: |
+        msbuild /m ${{ inputs.build_flags }} /t:BuildDist cpp/msbuild/ice.proj
+        msbuild /m ${{ inputs.build_flags }} python/msbuild/ice.proj
+      shell: powershell
+      if: runner.os == 'Windows' && inputs.build_cpp_and_python == 'true'
+
+    - name: Build
+      working-directory: ${{ inputs.working_directory }}
+      run: ${{ inputs.msbuild_command }} ${{ inputs.build_flags }} ${{ inputs.msbuild_project }}
+      shell: powershell
+      if: runner.os == 'Windows'

--- a/.github/actions/setup-cpp/action.yml
+++ b/.github/actions/setup-cpp/action.yml
@@ -1,0 +1,40 @@
+name: Setup C++
+runs:
+  using: "composite"
+  steps:
+    - name: Install dependencies on macOS
+      if: runner.os == 'macOS'
+      shell: bash
+      run: brew install mcpp lmdb
+
+    - name: Install dependencies on Linux
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update && sudo apt-get install -y \
+            libbz2-dev libssl-dev libffi-dev \
+            libmcpp-dev libedit-dev liblmdb-dev libexpat1-dev libsystemd-dev \
+            libbluetooth-dev libdbus-1-dev \
+            gdb
+
+    # This is needed for GDB to work on Linux runners
+    - name: Disable ptrace protection on Linux
+      if: runner.os == 'Linux'
+      shell: bash
+      run: echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+
+    - name: Set macOS MAKEFLAGS
+      run: echo "MAKEFLAGS=-j$(sysctl -n hw.ncpu) V=1" >> $GITHUB_ENV
+      shell: bash
+      if: runner.os == 'macOS'
+
+    - name: Set Linux MAKEFLAGS
+      run: echo "MAKEFLAGS=-j$(nproc) V=1" >> $GITHUB_ENV
+      shell: bash
+      if: runner.os == 'Linux'
+
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v2
+      with:
+        msbuild-architecture: x64
+      if: runner.os == 'Windows'

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -1,0 +1,19 @@
+name: Setup Python
+
+inputs:
+  python-version:
+    description: "The version of Python to set up."
+    default: "3.14"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Configure Windows Python Environment
+      run: |
+        echo "PythonHome=$env:Python_ROOT_DIR"  >> $env:GITHUB_ENV
+      shell: powershell
+      if: runner.os == 'Windows'

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,0 +1,32 @@
+name: Test Ice
+
+inputs:
+  working_directory:
+    description: "The working directory to run the tests in"
+
+  flags:
+    description: "Flags to pass to the test"
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Test
+      working-directory: ${{ inputs.working_directory }}
+      run: python3 allTests.py --debug --all --continue --workers=4 --export-xml=test-report.xml ${{ inputs.flags }}
+      shell: bash
+      if: runner.os == 'macOS'
+
+    - name: Test
+      working-directory: ${{ inputs.working_directory }}
+      run: |
+        ulimit -c unlimited
+        python3 allTests.py --debug --all --continue --workers=4 --export-xml=test-report.xml ${{ inputs.flags }}
+      shell: bash
+      if: runner.os == 'Linux'
+
+    - name: Test
+      working-directory: ${{ inputs.working_directory }}
+      run: python allTests.py --debug --all --continue --workers=4 --export-xml=test-report.xml ${{ inputs.flags }}
+      shell: powershell
+      if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["3.7"]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: ["3.7"]
+
+jobs:
+  ci:
+    name: ${{ matrix.config }} on ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Release builds
+          - os: ubuntu-24.04
+            config: release
+          - os: windows-2025
+            config: release
+          - os: macos-26
+            config: release
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup C++
+        uses: ./.github/actions/setup-cpp
+
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
+
+      - name: Build ${{ matrix.config }} on ${{ matrix.os }}
+        uses: ./.github/actions/build
+        with:
+          working_directory: "cpp"
+          msbuild_project: "msbuild/ice.proj"
+        timeout-minutes: 90
+
+      - name: Install testing dependencies from pip
+        run: python3 -m pip install passlib cryptography numpy
+        shell: bash
+
+      - name: Test ${{ matrix.config }} on ${{ matrix.os }}
+        uses: ./.github/actions/test
+        timeout-minutes: 45
+        with:
+          working_directory: "cpp"
+          # TODO: Filter out IceSSL/configuration see https://github.com/zeroc-ice/ice/issues/4805
+          flags: "--all --rfilter IceSSL/configuration"


### PR DESCRIPTION
This PR adds CI to the 3.7 branch. The setup is similar to what we already have in main and 3.8 branches.

For the initial backport just added C++, I will add other languages in subsequent PRs.

I filter out IceSSL/configuration test until we fix #4805