### PR TITLE
Build additional languages with CI

### DIFF
--- a/.github/actions/setup-dotnet-framework/action.yml
+++ b/.github/actions/setup-dotnet-framework/action.yml
@@ -1,0 +1,21 @@
+name: Setup .NET Framework
+description: "Install .NET Framework Developer/Targeting Packs for building .NET Framework projects"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install .NET Framework 4.5.1 Developer Pack
+      if: runner.os == 'Windows'
+      shell: powershell
+      run: |
+        # Install .NET Framework 4.5.1 Developer Pack using Chocolatey (pre-installed on GitHub runners)
+        Write-Host "Installing .NET Framework 4.5.1 Developer Pack via Chocolatey..."
+        choco install netfx-4.5.1-devpack -y --no-progress
+
+        # Verify the targeting pack is installed
+        $targetingPackPath = "${env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.1"
+        if (Test-Path $targetingPackPath) {
+            Write-Host "Targeting pack verified at: $targetingPackPath"
+        } else {
+            throw "Targeting pack not found at expected location: $targetingPackPath"
+        }

--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -1,0 +1,9 @@
+name: Setup Java
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Oracle Java 17
+      uses: actions/setup-java@v4
+      with:
+        distribution: "oracle"
+        java-version: "17"

--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -1,0 +1,13 @@
+name: "Setup PHP"
+runs:
+  using: "composite"
+  steps:
+    - name: Install PHP on macOS
+      run: brew install php
+      shell: bash
+      if: runner.os == 'macOS'
+
+    - name: Install PHP on Linux
+      run: sudo apt-get update && sudo apt-get install -y php-cli php-dev
+      shell: bash
+      if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
     # The branches below must be a subset of the branches above
     branches: ["3.7"]
 
+# See https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     name: ${{ matrix.config }} on ${{ matrix.os }}
@@ -28,17 +33,24 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup .NET Framework
+        uses: ./.github/actions/setup-dotnet-framework
+        if: runner.os == 'Windows'
+
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
 
       - name: Setup Python
         uses: ./.github/actions/setup-python
 
+      - name: Setup PHP
+        uses: ./.github/actions/setup-php
+
+      - name: Setup Java
+        uses: ./.github/actions/setup-java
+
       - name: Build ${{ matrix.config }} on ${{ matrix.os }}
         uses: ./.github/actions/build
-        with:
-          working_directory: "cpp"
-          msbuild_project: "msbuild/ice.proj"
         timeout-minutes: 90
 
       - name: Install testing dependencies from pip
@@ -49,6 +61,6 @@ jobs:
         uses: ./.github/actions/test
         timeout-minutes: 45
         with:
-          working_directory: "cpp"
           # TODO: Filter out IceSSL/configuration see https://github.com/zeroc-ice/ice/issues/4805
-          flags: "--all --rfilter IceSSL/configuration"
+          # TODO: Filter out IceGrid/replication see https://github.com/zeroc-ice/ice/issues/4818
+          flags: "--all --rfilter IceSSL/configuration --rfilter IceGrid/replication"

--- a/csharp/BUILDING.md
+++ b/csharp/BUILDING.md
@@ -28,8 +28,8 @@ A source build of Ice for .NET on Windows produces two sets of assemblies:
 In order to build Ice for .NET from source, you need:
 
 * A [supported version][3] of Visual Studio when building .NET Framework 4.5 Assemblies.
-* Visual Studio 2022 with [.NET 6.0 SDK][4] or [.NET 7.0 SDK][5] when building the .NET Standard 2.0 Assemblies.
-* Visual Studio 2022 with [.NET 6.0 SDK][4] and [.NET 7.0 SDK][5] when building the NuGet packages.
+* Visual Studio 2022 with [.NET 8.0 SDK][4] or [.NET 7.0 SDK][5] when building the .NET Standard 2.0 Assemblies.
+* Visual Studio 2022 with [.NET 8.0 SDK][4] and [.NET 7.0 SDK][5] when building the NuGet packages.
 
 ### Compiling Ice for .NET on Windows
 
@@ -67,13 +67,13 @@ the test suite.
 
 > Note: Visual Studio 2022 version or higher is required for .NET Standard 2.0 builds.
 
-The .NET Standard build of iceboxnet and test applications target `net6.0` You can change
+The .NET Standard build of iceboxnet and test applications target `net8.0` You can change
 the target framework by setting the `AppTargetFramework` property to a different
 
 Target Framework Moniker value, for example:
 
 ```shell
-msbuild msbuild\ice.proj /p:"AppTargetFramework=net7.0"
+msbuild msbuild\ice.proj /p:"AppTargetFramework=net10.0"
 ```
 
 This builds the test programs for `net7.0`. The target frameworks you specify
@@ -126,7 +126,7 @@ necessary.
 
 ### Linux and macOS Build Requirements
 
-You need the [.NET 6.0 SDK][4] or [.NET 7.0 SDK][5] to build Ice for .NET from source.
+You need the [.NET 8.0 SDK][4] or [.NET 7.0 SDK][5] to build Ice for .NET from source.
 
 ### Compiling Ice for .NET on Linux or macOS
 
@@ -178,13 +178,13 @@ python allTests.py
 If everything worked out, you should see lots of `ok` messages. In case of a
 failure, the tests abort with `failed`.
 
-`allTests.py` executes by default the tests for .NET 6.0. If you want to run
+`allTests.py` executes by default the tests for .NET 8.0. If you want to run
 the test with a different .NET Framework you must use `--framework` option.
 
-For example, to run .NET 7.0 tests:
+For example, to run .NET 10.0 tests:
 
 ```shell
-python allTests.py --framework=net7.0
+python allTests.py --framework=net10.0
 ```
 
 or to run .NET Framework 4.5 tests on Windows:
@@ -221,6 +221,6 @@ directory.
 [1]: https://zeroc.com/downloads/ice
 [2]: https://blogs.msdn.microsoft.com/dotnet/2017/08/14/announcing-net-standard-2-0
 [3]: https://doc.zeroc.com/ice/3.7/release-notes/supported-platforms-for-ice-3-7-10
-[4]: https://dotnet.microsoft.com/en-us/download/dotnet/6.0
-[5]: https://dotnet.microsoft.com/en-us/download/dotnet/7.0
+[4]: https://dotnet.microsoft.com/en-us/download/dotnet/8.0
+[5]: https://dotnet.microsoft.com/en-us/download/dotnet/10.0
 [6]: https://docs.microsoft.com/en-us/dotnet/framework/app-domains/enhanced-strong-naming

--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <AppTargetFramework Condition="'$(AppTargetFramework)' == ''">net6.0</AppTargetFramework>
+        <AppTargetFramework Condition="'$(AppTargetFramework)' == ''">net8.0</AppTargetFramework>
     </PropertyGroup>
 </Project>

--- a/csharp/msbuild/ice.common.props
+++ b/csharp/msbuild/ice.common.props
@@ -25,6 +25,9 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/zeroc-ice/ice</RepositoryUrl>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+
+    <!-- Avoid warnings about end-of-line target framework -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <!-- Import Ice version settings -->

--- a/csharp/msbuild/ice.nuget.targets
+++ b/csharp/msbuild/ice.nuget.targets
@@ -13,7 +13,7 @@
        <Net45IceBox Include="$(IcePdbRootDir)bin\net45\iceboxnet.pdb"/>
 
         <!--
-             With .Net Core and .NET6 we have to pack the dependencies next to iceboxnet.dll,
+             With .Net Core and .NET8 we have to pack the dependencies next to iceboxnet.dll,
              the .exe native executable is exclude as it is platform dependend
         -->
         <NetStandardIceBox Include="$(IceSrcRootDir)bin\**\publish\*"
@@ -23,7 +23,7 @@
         <Assemblies Include="$(IceSrcRootDir)lib\**\*.dll;
                              $(IceSrcRootDir)lib\**\*.xml"/>
 
-        <Net6Pdbs Include="$(IceSrcRootDir)lib\net6.0\*.pdb" />
+        <Net8Pdbs Include="$(IceSrcRootDir)lib\net8.0\*.pdb" />
         <Net45Pdbs Include="$(IcePdbRootDir)\lib\net45\*.pdb" />
         <NetStandardPdbs Include="$(IceSrcRootDir)lib\netstandard2.0\*.pdb" />
 
@@ -35,7 +35,7 @@
     <!-- Copy required files to the package specific directories -->
     <Target Name="NugetPack">
         <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(PackageDirectory)\lib\%(Assemblies.RecursiveDir)"/>
-        <Copy SourceFiles="@(Net6Pdbs)" DestinationFolder="$(PackageDirectory)\lib\net6.0"/>
+        <Copy SourceFiles="@(Net8Pdbs)" DestinationFolder="$(PackageDirectory)\lib\net8.0"/>
         <Copy SourceFiles="@(Net45Pdbs)" DestinationFolder="$(PackageDirectory)\lib\net45"/>
         <Copy SourceFiles="@(NetStandardPdbs)" DestinationFolder="$(PackageDirectory)\lib\netstandard2.0"
               Condition="'$(NetStandardTargets)' == 'true'"/>

--- a/ice.proj
+++ b/ice.proj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <Platform Condition="'$(Platform)' == ''">Win32</Platform>
+    <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
   </PropertyGroup>
 
@@ -27,31 +27,6 @@
 
     <Projects Include="$(MSBuildThisFileDirectory)java-compat\msbuild\ice.proj" Condition="'$(DefaultPlatformToolset)' != 'v100'">
       <Properties>Platform=$(Platform);Configuration=$(Configuration)</Properties>
-    </Projects>
-
-    <!-- For PHP build both thread safe and non thread safe configurations -->
-    <Projects Include="$(MSBuildThisFileDirectory)php\msbuild\ice.proj" Condition="'$(DefaultPlatformToolset)' == 'v140'">
-      <Properties>Platform=$(Platform);Configuration=$(Configuration);BuildWithPhpVersion=7.1</Properties>
-    </Projects>
-
-    <Projects Include="$(MSBuildThisFileDirectory)php\msbuild\ice.proj" Condition="'$(DefaultPlatformToolset)' == 'v140'">
-      <Properties>Platform=$(Platform);Configuration=NTS-$(Configuration);BuildWithPHPVersion=7.1</Properties>
-    </Projects>
-
-    <Projects Include="$(MSBuildThisFileDirectory)php\msbuild\ice.proj" Condition="'$(DefaultPlatformToolset)' == 'v141'">
-      <Properties>Platform=$(Platform);Configuration=$(Configuration);BuildWithPhpVersion=7.2</Properties>
-    </Projects>
-
-    <Projects Include="$(MSBuildThisFileDirectory)php\msbuild\ice.proj" Condition="'$(DefaultPlatformToolset)' == 'v141'">
-      <Properties>Platform=$(Platform);Configuration=NTS-$(Configuration);BuildWithPHPVersion=7.2</Properties>
-    </Projects>
-
-    <Projects Include="$(MSBuildThisFileDirectory)php\msbuild\ice.proj" Condition="'$(DefaultPlatformToolset)' == 'v142'">
-      <Properties>Platform=$(Platform);Configuration=$(Configuration);BuildWithPhpVersion=8.0</Properties>
-    </Projects>
-
-    <Projects Include="$(MSBuildThisFileDirectory)php\msbuild\ice.proj" Condition="'$(DefaultPlatformToolset)' == 'v142'">
-      <Properties>Platform=$(Platform);Configuration=NTS-$(Configuration);BuildWithPHPVersion=8.0</Properties>
     </Projects>
 
     <Projects Include="$(MSBuildThisFileDirectory)js\msbuild\ice.proj">

--- a/matlab/src/msbuild/ice/ice.vcxproj
+++ b/matlab/src/msbuild/ice/ice.vcxproj
@@ -13,7 +13,6 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{89C40F1A-1761-46C1-B326-5B20BE6F8173}</ProjectGuid>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
     <IceLanguageMapping>matlab</IceLanguageMapping>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/matlab/src/msbuild/icethunk/icethunk.vcxproj
+++ b/matlab/src/msbuild/icethunk/icethunk.vcxproj
@@ -12,7 +12,6 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{EC87DC16-51CB-4229-845D-23840A3CC8CB}</ProjectGuid>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/objective-c/src/Ice/Object.mm
+++ b/objective-c/src/Ice/Object.mm
@@ -330,7 +330,7 @@ static NSString* ICEObject_ids[1] =
 -(BOOL) ice_isA:(NSString*)__unused typeId current:(ICECurrent*)__unused current
 {
     NSAssert(NO, @"ice_isA requires override");
-    return nil;
+    return false;
 }
 -(void) ice_ping:(ICECurrent*)__unused current
 {

--- a/objective-c/src/Ice/ObjectAdapterI.mm
+++ b/objective-c/src/Ice/ObjectAdapterI.mm
@@ -91,10 +91,18 @@ public:
     {
     }
 
+#if defined(__clang__)
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#   pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
+#endif
     ~ExceptionWriter() throw()
     {
         [_ex release];
     }
+#if defined(__clang__)
+#   pragma clang diagnostic pop
+#endif
 
     void
     _write(Ice::OutputStream* s) const

--- a/objective-c/src/Ice/Util.h
+++ b/objective-c/src/Ice/Util.h
@@ -221,8 +221,15 @@ public:
 
     Exception(id<NSObject>);
     Exception(const Exception&);
+#if defined(__clang__)
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#   pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
+#endif
     virtual ~Exception() throw();
-
+#if defined(__clang__)
+#   pragma clang diagnostic pop
+#endif
     virtual std::string ice_id() const;
     virtual void ice_print(std::ostream& os) const;
     virtual Exception* ice_clone() const;

--- a/objective-c/src/Ice/Util.mm
+++ b/objective-c/src/Ice/Util.mm
@@ -409,10 +409,18 @@ IceObjC::Exception::Exception(const IceObjC::Exception& ex) : _ex([ex._ex retain
 {
 }
 
+#if defined(__clang__)
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#   pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
+#endif
 IceObjC::Exception::~Exception() throw()
 {
     [_ex release];
 }
+#if defined(__clang__)
+#   pragma clang diagnostic pop
+#endif
 
 std::string
 IceObjC::Exception::ice_id() const

--- a/php/src/php/Types.cpp
+++ b/php/src/php/Types.cpp
@@ -3434,18 +3434,27 @@ IcePHP::ExceptionReader::ExceptionReader(const CommunicatorInfoPtr& communicator
     ZVAL_UNDEF(&_ex);
 }
 
+#if defined(__clang__)
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#   pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
+#endif
+
 IcePHP::ExceptionReader::~ExceptionReader()
     throw()
 {
-#ifdef NDEBUG
+#    ifdef NDEBUG
     // BUGFIX: releasing this object trigers an assert in PHP objects_store
     // https://github.com/php/php-src/issues/10593
     if (!Z_ISUNDEF(_ex))
     {
         zval_ptr_dtor(&_ex);
     }
-#endif
+#    endif
 }
+#if defined(__clang__)
+#   pragma clang diagnostic pop
+#endif
 
 string
 IcePHP::ExceptionReader::ice_id() const

--- a/php/src/php/Types.h
+++ b/php/src/php/Types.h
@@ -587,7 +587,15 @@ class ExceptionReader : public Ice::UserException
 public:
 
     ExceptionReader(const CommunicatorInfoPtr&, const ExceptionInfoPtr&);
+#if defined(__clang__)
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#   pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
+#endif
     ~ExceptionReader() throw();
+#if defined(__clang__)
+#   pragma clang diagnostic pop
+#endif
 
     virtual std::string ice_id() const;
     virtual ExceptionReader* ice_clone() const;

--- a/python/modules/IcePy/msbuild/icepy.vcxproj
+++ b/python/modules/IcePy/msbuild/icepy.vcxproj
@@ -85,7 +85,6 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{18BF13D3-85D3-43A5-8C96-E52EB0672F72}</ProjectGuid>
     <RootNamespace>IceGrid</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/scripts/Util.py
+++ b/scripts/Util.py
@@ -417,7 +417,7 @@ class Windows(Platform):
         pass # Nothing to do, we don't support the make build system on Windows
 
     def getDefaultBuildPlatform(self):
-        return "x64" if "X64" in os.environ.get("PLATFORM", "") else "Win32"
+        return "Win32" if "Win32" in os.environ.get("PLATFORM", "") else "x64"
 
     def getDefaultBuildConfig(self):
         return "Release"
@@ -3316,13 +3316,13 @@ class CSharpMapping(Mapping):
         def usage(self):
             print("")
             print("C# mapping options:")
-            print("--framework=net45|net6.0|net7.0   Choose the framework used to run .NET tests")
+            print("--framework=net45|net8.0|net10.0   Choose the framework used to run .NET tests")
 
         def __init__(self, options=[]):
             Mapping.Config.__init__(self, options)
 
             if self.framework == "":
-                self.framework = "net6.0"
+                self.framework = "net8.0"
 
             self.dotnet = not isinstance(platform, Windows) or self.framework != "net45"
 


### PR DESCRIPTION
This PR updates CI workflow on the 3.7 branch to test additional language mappings, and fixes some build issues.

The job is based on what we have in main, but there is no cache support. I was initially thinking of adding it in a follow up PR. We are already hitting the cache limit with our main and 3.8 builds so there is no point in adding more entries to the cache.