### PR TITLE
Fix clang build for c++23 and c++26

### DIFF
--- a/cpp/include/Ice/ObserverHelper.h
+++ b/cpp/include/Ice/ObserverHelper.h
@@ -6,6 +6,7 @@
 #include "InstanceF.h"
 #include "Instrumentation.h"
 
+#include <exception>
 #include <string_view>
 
 #if defined(_MSC_VER)

--- a/cpp/src/Ice/Demangle.cpp
+++ b/cpp/src/Ice/Demangle.cpp
@@ -3,6 +3,7 @@
 #include "Ice/Demangle.h"
 
 #if defined(__GNUC__) || defined(__clang__)
+#    include <cstdlib>
 #    include <cxxabi.h>
 #endif
 

--- a/cpp/src/Ice/StringConverter.cpp
+++ b/cpp/src/Ice/StringConverter.cpp
@@ -7,8 +7,8 @@
 #elif (__cplusplus >= 201703L)
 #    include "DisableWarnings.h"
 #    if defined(__clang__) // for clang in C++26 mode
-#       define _LIBCPP_ENABLE_CXX26_REMOVED_CODECVT
-#       define _LIBCPP_ENABLE_CXX26_REMOVED_WSTRING_CONVERT
+#        define _LIBCPP_ENABLE_CXX26_REMOVED_CODECVT
+#        define _LIBCPP_ENABLE_CXX26_REMOVED_WSTRING_CONVERT
 #    endif
 #endif
 

--- a/cpp/src/Ice/StringConverter.cpp
+++ b/cpp/src/Ice/StringConverter.cpp
@@ -6,6 +6,10 @@
 #    define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 #elif (__cplusplus >= 201703L)
 #    include "DisableWarnings.h"
+#    if defined(__clang__) // for clang in C++26 mode
+#       define _LIBCPP_ENABLE_CXX26_REMOVED_CODECVT
+#       define _LIBCPP_ENABLE_CXX26_REMOVED_WSTRING_CONVERT
+#    endif
 #endif
 
 #include "Ice/StringConverter.h"

--- a/cpp/src/Ice/StringConverter.cpp
+++ b/cpp/src/Ice/StringConverter.cpp
@@ -6,9 +6,9 @@
 #    define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 #elif (__cplusplus >= 201703L)
 #    include "DisableWarnings.h"
-#    if defined(__clang__) // for clang in C++26 mode
-#        define _LIBCPP_ENABLE_CXX26_REMOVED_CODECVT
-#        define _LIBCPP_ENABLE_CXX26_REMOVED_WSTRING_CONVERT
+#    if defined(__clang__)                                   // for clang in C++26 mode
+#        define _LIBCPP_ENABLE_CXX26_REMOVED_CODECVT         // NOLINT(cert-dcl37-c,cert-dcl51-cpp)
+#        define _LIBCPP_ENABLE_CXX26_REMOVED_WSTRING_CONVERT // NOLINT(cert-dcl37-c,cert-dcl51-cpp)
 #    endif
 #endif
 

--- a/cpp/src/Slice/FileTracker.h
+++ b/cpp/src/Slice/FileTracker.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <memory>
 #include <stdexcept>
+#include <string>
 
 namespace Slice
 {

--- a/cpp/test/include/TestHelper.h
+++ b/cpp/test/include/TestHelper.h
@@ -16,6 +16,8 @@
 #    pragma comment(lib, ICE_LIBNAME("testcommon"))
 #endif
 
+// On macOS, atomic includes a test function, so we need to include atomic before defining our test macro.
+#include <atomic>
 #include <cassert>
 #include <cstdlib>
 #include <iostream>


### PR DESCRIPTION
This PR makes small fixes to allow building Ice C++ with the latest Apple clang in c++23 and c++26 mode (we currently use c++20).

```
% clang --version
Apple clang version 17.0.0 (clang-1700.4.4.1)
Target: arm64-apple-darwin25.1.0
Thread model: posix
```