### PR TITLE
Fix Ruby macOS build failures

### DIFF
--- a/ruby/src/IceRuby/Connection.cpp
+++ b/ruby/src/IceRuby/Connection.cpp
@@ -2,6 +2,10 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+#if defined(__clang__)
+#   pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include <Connection.h>
 #include <Endpoint.h>
 #include <Types.h>

--- a/ruby/src/IceRuby/Endpoint.cpp
+++ b/ruby/src/IceRuby/Endpoint.cpp
@@ -2,6 +2,10 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+#if defined(__clang__)
+#   pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include <Endpoint.h>
 #include <Util.h>
 #include <Ice/Object.h>

--- a/ruby/src/IceRuby/ImplicitContext.cpp
+++ b/ruby/src/IceRuby/ImplicitContext.cpp
@@ -2,6 +2,10 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+#if defined(__clang__)
+#   pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include <ImplicitContext.h>
 #include <Util.h>
 #include <Ice/Initialize.h>

--- a/ruby/src/IceRuby/Logger.cpp
+++ b/ruby/src/IceRuby/Logger.cpp
@@ -2,6 +2,10 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+#if defined(__clang__)
+#   pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include <Logger.h>
 #include <Util.h>
 #include <Ice/Initialize.h>

--- a/ruby/src/IceRuby/Operation.cpp
+++ b/ruby/src/IceRuby/Operation.cpp
@@ -2,6 +2,10 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+#if defined(__clang__)
+#   pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include <Operation.h>
 #include <Proxy.h>
 #include <Types.h>

--- a/ruby/src/IceRuby/Properties.cpp
+++ b/ruby/src/IceRuby/Properties.cpp
@@ -2,6 +2,10 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+#if defined(__clang__)
+#   pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include <Properties.h>
 #include <Util.h>
 #include <Ice/Initialize.h>

--- a/ruby/src/IceRuby/Types.cpp
+++ b/ruby/src/IceRuby/Types.cpp
@@ -2,6 +2,10 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+#if defined(__clang__)
+#   pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include <Types.h>
 #include <Proxy.h>
 #include <Util.h>
@@ -2886,11 +2890,18 @@ IceRuby::ExceptionReader::ExceptionReader(const ExceptionInfoPtr& info) :
 {
 }
 
-IceRuby::ExceptionReader::~ExceptionReader()
-    throw()
+#if defined(__clang__)
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#   pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
+#endif
+IceRuby::ExceptionReader::~ExceptionReader() throw()
 {
     rb_gc_unregister_address(&_ex);
 }
+#if defined(__clang__)
+#   pragma clang diagnostic pop
+#endif
 
 string
 IceRuby::ExceptionReader::ice_id() const

--- a/ruby/src/IceRuby/Types.h
+++ b/ruby/src/IceRuby/Types.h
@@ -541,7 +541,16 @@ class ExceptionReader : public Ice::UserException
 public:
 
     ExceptionReader(const ExceptionInfoPtr&);
+#if defined(__clang__)
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#   pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
+#endif
     ~ExceptionReader() throw();
+#if defined(__clang__)
+#   pragma clang diagnostic pop
+#endif
+
 
     virtual std::string ice_id() const;
 #ifndef ICE_CPP11_MAPPING

--- a/ruby/src/IceRuby/ValueFactoryManager.cpp
+++ b/ruby/src/IceRuby/ValueFactoryManager.cpp
@@ -2,6 +2,10 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+#if defined(__clang__)
+#   pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include <ValueFactoryManager.h>
 #include <Types.h>
 #include <Util.h>


### PR DESCRIPTION
This PR fixes building Ruby on macOS from the 3.7 branch. I just disabled the deprecation warnings all tests pass.