### PR TITLE
Improve 'slice2py' to Generate Doc-comments for Constants

### DIFF
--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2033,9 +2033,9 @@ Slice::Python::CodeVisitor::visitConst(const ConstPtr& p)
     out << sp;
 
     string name = p->mappedName();
-    writeConstDocstring(p, out);
     out << nl << name << " = ";
     writeConstantValue(p, p->type(), p->valueType(), p->value(), out);
+    writeDocstring(p, out, "constant");
 
     out << sp;
     out << nl << "__all__ = [\"" << name << "\"]";
@@ -2433,55 +2433,6 @@ Slice::Python::CodeVisitor::writeEnumDocstring(const EnumPtr& p, Output& out)
     writeRemarksDocComment(remarks, !overview.empty() || !docs.empty(), out);
     writeSeeAlso(seeAlso, !overview.empty() || !docs.empty() || !remarks.empty(), out);
     out << nl << tripleQuotes;
-}
-
-void
-Slice::Python::CodeVisitor::writeConstDocstring(const ConstPtr& p, IceInternal::Output& out)
-{
-    const optional<DocComment>& comment = p->docComment();
-
-    StringList overview;
-    StringList remarks;
-    StringList seeAlso;
-    if (comment)
-    {
-        overview = comment->overview();
-        remarks = comment->remarks();
-        seeAlso = comment->seeAlso();
-    }
-
-    for (const auto& line : overview)
-    {
-        out << nl << "#: " << line;
-    }
-
-    if (!remarks.empty())
-    {
-        remarks.emplace_back(""); // empty line
-    }
-    remarks.push_back("The Slice compiler generated this constant from Slice constant ``" + p->scoped() + "``.");
-    if (!overview.empty())
-    {
-        out << nl << "#:";
-    }
-    out << nl << "#: " << "Notes";
-    out << nl << "#: " << "-----";
-    for (const auto& line : remarks)
-    {
-        out << nl << "#:     " << line;
-    }
-
-    if (!seeAlso.empty())
-    {
-        out << nl << "#:";
-
-        out << nl << "#: " << "See Also";
-        out << nl << "#: " << "--------";
-        for (const string& line : seeAlso)
-        {
-            out << nl << "#:     " << line;
-        }
-    }
 }
 
 void

--- a/cpp/src/slice2py/PythonUtil.h
+++ b/cpp/src/slice2py/PythonUtil.h
@@ -460,8 +460,6 @@ namespace Slice::Python
 
         void writeEnumDocstring(const EnumPtr&, IceInternal::Output&);
 
-        void writeConstDocstring(const ConstPtr&, IceInternal::Output&);
-
         void writeOpDocstring(const OperationPtr&, MethodKind, IceInternal::Output&);
 
         std::string getImportAlias(const ContainedPtr& source, const SyntaxTreeBasePtr& definition);


### PR DESCRIPTION
This PR implements most of #4709.

We now generate doc-strings on constants.
Doc-comments take the form of `#:` and come before the thing being documented.
Doc-strings take the form of `""" ... """` and come after the thing being documented.

While Sphinx has full support for both of these, the official VsCode "Python" extension only supports doc-strings.

----

I say "most of", because these comments don't appear in our generated API reference.
That is an issue with how we re-export things though, not with the code-gen.
The generated code will still have these comments, and the extension detects and displays them in VsCode.