### PR TITLE
Only save caches on main push

### DIFF
--- a/.github/actions/setup-cache/action.yml
+++ b/.github/actions/setup-cache/action.yml
@@ -55,6 +55,7 @@ runs:
         max-size: 1G
         evict-old-files: job
         variant: ${{ runner.os == 'Windows' && 'ccache' || 'ccache' }}
+        save: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
 
     - name: Configure ccache path
       if: runner.os == 'macOS' || runner.os == 'Linux'


### PR DESCRIPTION
This PR updates our cache setup to only save caches on main. PRs can still use this caches but don't save their own. I will merge this to 3.8 later if approved so we don't save caches from 3.8 too.

I think is better to have fast builds with cache on main where development happens, 3.8 changes are going to be mostly cherry-pick from main.

We are currently trashing the cache with each build, because we save too many things. Also importantly other branches can use the default branches cache.