### PR TITLE
Don't use build cache for package builds

### DIFF
--- a/.github/workflows/build-brew-packages.yml
+++ b/.github/workflows/build-brew-packages.yml
@@ -40,11 +40,6 @@ jobs:
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
 
-      - name: Setup Cache
-        uses: ./.github/actions/setup-cache
-        with:
-          prefix: build-brew-packages
-
       - name: Update Nightly Tap
         run: |
           ./packaging/brew/update-nightly-tap.sh "${{ inputs.ice_version }}" "https://download.zeroc.com/ice/${{ inputs.quality }}/${{ inputs.channel }}"

--- a/.github/workflows/build-gem-packages.yml
+++ b/.github/workflows/build-gem-packages.yml
@@ -26,11 +26,6 @@ jobs:
       - name: Setup Ruby
         uses: ./.github/actions/setup-ruby
 
-      - name: Setup Cache
-        uses: ./.github/actions/setup-cache
-        with:
-          prefix: build-gem-packages
-
       - name: Install Build Dependencies
         run: gem install rake
 

--- a/.github/workflows/build-matlab-packages.yml
+++ b/.github/workflows/build-matlab-packages.yml
@@ -32,11 +32,6 @@ jobs:
       - name: Setup MATLAB
         uses: ./.github/actions/setup-matlab
 
-      - name: Setup Cache
-        uses: ./.github/actions/setup-cache
-        with:
-          prefix: build-matlab-packages
-
       - name: Ice Package Version
         if: ${{ inputs.ice_version != '' }}
         run: |

--- a/.github/workflows/build-pip-packages.yml
+++ b/.github/workflows/build-pip-packages.yml
@@ -49,11 +49,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Setup Cache
-        uses: ./.github/actions/setup-cache
-        with:
-          prefix: build-pip-packages
-
       - name: Install Build Dependencies
         run: |
           python3 -m pip install --upgrade pip

--- a/.github/workflows/build-xcframework-packages.yml
+++ b/.github/workflows/build-xcframework-packages.yml
@@ -32,11 +32,6 @@ jobs:
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
 
-      - name: Setup Cache
-        uses: ./.github/actions/setup-cache
-        with:
-          prefix: build-xcframework-packages
-
       - name: Build XCFramework Packages
         run: make OPTIMIZE=yes PLATFORMS="all" CONFIGS="static" srcs
         working-directory: cpp


### PR DESCRIPTION
This PR disable cache action usage for the workflows that build the packages. I think is clear to clean builds for the packages to avoid cache issues. Package builds are not that frequent and the cache is not that important here.