### PR TITLE
Test only the default Python version in main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,54 +135,6 @@ jobs:
             test_flags: "--target-framework=net10.0"
             build_cpp_and_python: true
 
-          # Python 3.12 testing
-          - os: windows-2025
-            config: "Python312"
-            working_directory: "python"
-            build_flags: "/p:Platform=x64"
-            msbuild_project: "msbuild/ice.proj"
-            build_cpp_and_python: true
-            python_version: "3.12"
-            python_tests: true
-
-          - os: macos-26
-            config: "Python312"
-            working_directory: "python"
-            build_cpp_and_python: true
-            python_version: "3.12"
-            python_tests: true
-
-          - os: ubuntu-24.04
-            config: "Python312"
-            working_directory: "python"
-            build_cpp_and_python: true
-            python_version: "3.12"
-            python_tests: true
-
-          # Python 3.13 testing
-          - os: windows-2025
-            config: "Python313"
-            working_directory: "python"
-            build_flags: "/p:Platform=x64"
-            msbuild_project: "msbuild/ice.proj"
-            build_cpp_and_python: true
-            python_version: "3.13"
-            python_tests: true
-
-          - os: macos-26
-            config: "Python313"
-            working_directory: "python"
-            build_cpp_and_python: true
-            python_version: "3.13"
-            python_tests: true
-
-          - os: ubuntu-24.04
-            config: "Python313"
-            working_directory: "python"
-            build_cpp_and_python: true
-            python_version: "3.13"
-            python_tests: true
-
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
@@ -203,8 +155,6 @@ jobs:
 
       - name: Setup Python
         uses: ./.github/actions/setup-python
-        with:
-          python-version: ${{ matrix.python_version || '3.14' }}
 
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet


### PR DESCRIPTION
We should only test the default Python version in main. 3.14 install by default with our setup-python action.

In 3.8 we keep testing all the versions we intend to support there.

One consequence of this for Python PRs.

When you port a Python change from main to 3.8, don't just cherry-pick and push to 3.8. Create a separate PR for 3.8 after merging to main so that CI can test all the other versions.