### PR TITLE
Fix small bug in C++ user exception marshaling (C++11 only)

### DIFF
--- a/cpp/include/Ice/ExceptionHelpers.h
+++ b/cpp/include/Ice/ExceptionHelpers.h
@@ -51,7 +51,7 @@ protected:
     /// \cond STREAM
     virtual void _writeImpl(Ice::OutputStream* os) const override
     {
-        os->startSlice(T::ice_staticId(), -1, std::is_same<B, Ice::LocalException>::value ? true : false);
+        os->startSlice(T::ice_staticId(), -1, std::is_same<B, Ice::UserException>::value ? true : false);
         Ice::StreamWriter<T, Ice::OutputStream>::write(os, static_cast<const T&>(*this));
         os->endSlice();
         B::_writeImpl(os);


### PR DESCRIPTION
This PR fixes a small bug in the user exception marshaling in C++. It changes only the C++11 mapping.

It should not have any effect on unmarshaling since other mappings (including C++98) presumably already marshal user exceptions correctly.

Fixes #1938 