### PR TITLE
Update min macos version to 14.0 (3.7)

### DIFF
--- a/config/Make.rules.Darwin
+++ b/config/Make.rules.Darwin
@@ -5,7 +5,7 @@
 supported-platforms             = macosx iphoneos iphonesimulator
 
 macosx_ar                       = libtool
-macosx_cppflags                 = -mmacosx-version-min=10.14
+macosx_cppflags                 = -mmacosx-version-min=14.0
 macosx_ldflags                  = $(macosx_cppflags) \
                                   $(if $(filter yes, $(allow-undefined-symbols)),-undefined dynamic_lookup,)
 macosx_targetdir                = $(if $(filter %/build,$5),/macosx)

--- a/cpp/src/Glacier2CryptPermissionsVerifier/CryptPermissionsVerifierI.cpp
+++ b/cpp/src/Glacier2CryptPermissionsVerifier/CryptPermissionsVerifierI.cpp
@@ -19,6 +19,7 @@
 #elif defined(__FreeBSD__)
 #   include <unistd.h>
 #elif defined(__APPLE__)
+#   pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #   include <CoreFoundation/CoreFoundation.h>
 #   include <Security/Security.h>
 #   include <CommonCrypto/CommonCrypto.h>
@@ -38,7 +39,7 @@ namespace
 #if defined(__FreeBSD__) && !defined(__GLIBC__)
 
 //
-// FreeBSD crypt is no reentrat we use this global mutex
+// FreeBSD crypt is not reentrant we use this global mutex
 // to serialize access.
 //
 IceUtil::Mutex* _staticMutex = 0;


### PR DESCRIPTION
It used to be 10.4. Without this change, we get a warning when linking with the "newer" libmcpp.