### PR TITLE
Fix clang c++23 build

### DIFF
--- a/cpp/include/Ice/UserExceptionFactory.h
+++ b/cpp/include/Ice/UserExceptionFactory.h
@@ -11,6 +11,8 @@
 
 #ifdef ICE_CPP11_MAPPING
 
+#include <functional>
+
 namespace Ice
 {
 

--- a/cpp/include/IceUtil/CtrlCHandler.h
+++ b/cpp/include/IceUtil/CtrlCHandler.h
@@ -8,6 +8,10 @@
 #include <IceUtil/Config.h>
 #include <IceUtil/Exception.h>
 
+#ifdef ICE_CPP11_MAPPING
+#   include <functional>
+#endif
+
 namespace IceUtil
 {
 

--- a/cpp/src/Glacier2/RouterI.cpp
+++ b/cpp/src/Glacier2/RouterI.cpp
@@ -163,7 +163,7 @@ string
 Glacier2::RouterI::getCategoryForClient(const Ice::Current&) const
 {
     assert(false); // Must not be called in this router implementation.
-    return 0;
+    return "";
 }
 
 void

--- a/cpp/src/Ice/Proxy.cpp
+++ b/cpp/src/Ice/Proxy.cpp
@@ -56,9 +56,12 @@ const string ice_ping_name = "ice_ping";
 const string ice_ids_name = "ice_ids";
 const string ice_id_name = "ice_id";
 const string ice_isA_name = "ice_isA";
-const string ice_invoke_name = "ice_invoke";
 const string ice_getConnection_name = "ice_getConnection";
 const string ice_flushBatchRequests_name = "ice_flushBatchRequests";
+
+#ifndef ICE_CPP11_MAPPING
+const string ice_invoke_name = "ice_invoke";
+#endif
 
 }
 

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -6219,17 +6219,21 @@ Slice::Gen::Cpp11DeclVisitor::visitClassDefStart(const ClassDefPtr& p)
         allOpNames.sort();
         allOpNames.unique();
 
-        C << nl << "const ::std::string iceC" << p->flattenedScope() << p->name() << "_ops[] =";
-        C << sb;
-        for(StringList::const_iterator q = allOpNames.begin(); q != allOpNames.end();)
+        if(allOpNames.size() > 4)
         {
-            C << nl << '"' << *q << '"';
-            if(++q != allOpNames.end())
+            C << nl << "const ::std::string iceC" << p->flattenedScope() << p->name() << "_ops[] =";
+            C << sb;
+            for(StringList::const_iterator q = allOpNames.begin(); q != allOpNames.end();)
             {
-                C << ',';
+                C << nl << '"' << *q << '"';
+                if(++q != allOpNames.end())
+                {
+                    C << ',';
+                }
             }
+            C << eb << ';';
         }
-        C << eb << ';';
+        // else, we don't use the ops array.
     }
 
     return true;


### PR DESCRIPTION
Small fixes to build the 3.7 branch with clang -std=c++23.

Fixes #4803.