### PR TITLE
Sort Python API class/enum/etc Members by Source, not Alphabetically

### DIFF
--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -69,6 +69,7 @@ autodoc_typehints = "both"
 autodoc_typehints_description_target = "all"
 add_module_names = True
 python_use_unqualified_type_names = False
+autodoc_member_order = "bysource"
 
 # =============================================================================
 # Intersphinx Configuration


### PR DESCRIPTION
When Sphinx generates the Python reference for a class, exception, enum, etc., it's members are sorted alphabetically.
This PR changes this so that now members retain the order they have in the source file (i.e. they aren't sorted anymore).

----

With the current behavior things which are logically grouped in our source end up randomly placed in the API reference. This looks especially bad for enums where enumerators are not sorted by value, how I'd expect.

Like look at `CompressBatch`, the enumerators are completely reversed from how they are in the source:
<img width="188" height="111" alt="Screenshot 2026-01-02 at 15 44 46" src="https://github.com/user-attachments/assets/40820443-0589-469a-8ace-68a87c4d22a9" />
Or worse, `ReplyStatus`, which looks completely random:
<img width="261" height="328" alt="Screenshot 2026-01-02 at 15 47 25" src="https://github.com/user-attachments/assets/de00a09f-4211-45aa-8a10-331f31eb9f7a" />

I haven't consumed alot of Python API references, so maybe alphabetized members is what everyone expects, and enumerator values are inconsequential. If so, feel free to reject this PR.