### PR TITLE
Gradle build fixes

### DIFF
--- a/java-compat/test/build.gradle
+++ b/java-compat/test/build.gradle
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+import org.gradle.util.GradleVersion
+
 ext.testDir = "${projectDir}/src/main/java/test"
 apply from: "slice.gradle"
 

--- a/java-compat/test/lambda/build.gradle
+++ b/java-compat/test/lambda/build.gradle
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+import org.gradle.util.GradleVersion
+
 // Override defaults otherwise this code won't compile!
 //
 sourceCompatibility = 1.8

--- a/java-compat/test/plugins/build.gradle
+++ b/java-compat/test/plugins/build.gradle
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+import org.gradle.util.GradleVersion
+
 sourceSets {
     main {
         java {

--- a/java/gradle/ice.gradle
+++ b/java/gradle/ice.gradle
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+import org.gradle.util.GradleVersion
+
 buildscript {
     //
     // If iceBuilderHome is set add its lib directory it to the local maven repositories

--- a/java/gradle/library.gradle
+++ b/java/gradle/library.gradle
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+import org.gradle.util.GradleVersion
+
 jar {
     if (GradleVersion.current() >= GradleVersion.version('8.0')) {
         destinationDirectory = new File("${libDir}")

--- a/java/src/IceGridGUI/plain-jar.gradle
+++ b/java/src/IceGridGUI/plain-jar.gradle
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+import org.gradle.util.GradleVersion
+
 task copyTmpJars(type: Copy) {
     if (GradleVersion.current() >= GradleVersion.version('8.0')) {
         from jar.archiveFile

--- a/java/test/build.gradle
+++ b/java/test/build.gradle
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+import org.gradle.util.GradleVersion
+
 ext.testDir = "${projectDir}/src/main/java/test"
 apply from: "slice.gradle"
 

--- a/java/test/plugins/build.gradle
+++ b/java/test/plugins/build.gradle
@@ -2,6 +2,8 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 //
 
+import org.gradle.util.GradleVersion
+
 // Don't generate javadoc
 javadoc.enabled = false
 

--- a/packaging/deb/debian/rules
+++ b/packaging/deb/debian/rules
@@ -36,7 +36,8 @@ endif
 
 # GRADLE_OPTS memory setting to work around FTBFS on armel
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1069538
-export GRADLE_OPTS=-Xmx512M
+# Disable the Debian gradle hook to suppress ClassNotFoundException when not using dh --buildsystem=gradle
+export GRADLE_OPTS=-Xmx512M -Dgradle-debian-helper.hook.enabled=false
 
 export GRADLEARGS	= --gradle-user-home $(CURDIR)/.gradle \
 			  --info \


### PR DESCRIPTION
- Fix warnings related to GraldeVersion not being imported
- Fix ClassNotFoundException: org.debian.gradle.plugin.MavenResolverHook in debian builds

See #4505 