### PR TITLE
Use python-config --includes instead of --cflags

### DIFF
--- a/python/config/Make.rules
+++ b/python/config/Make.rules
@@ -21,7 +21,7 @@ ifeq ($(os),Linux)
 endif
 
 python_cppflags         := $(or $(PYTHON_CPPFLAGS),$(shell $(python-config) --includes))
-python_ldflags          := $(or $(PYTHON_LDLFLAGS),$(shell $(python-config) --ldflags))
+python_ldflags          := $(PYTHON_LDLFLAGS)
 
 # Use .so as default value --extension-suffix is not supported by python-config in all platforms
 python_extsuffix        := $(or $(shell $(python-config) --extension-suffix 2> /dev/null),.so)


### PR DESCRIPTION
The `--cflags` option returns C compiler flags which can include C-specific options that are invalid for C++ compilation. 
    
By using `--includes` instead, we only get the Python include paths (`-I` flags) which is all we need. This also simplifies the Makefile by removing the filter-out logic that was stripping problematic C flags.
    
I think this was the likely cause for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1067911

Fix #2033