### PR TITLE
Make the execinfo.h detection more portable

### DIFF
--- a/cpp/src/Ice/LocalException.cpp
+++ b/cpp/src/Ice/LocalException.cpp
@@ -48,7 +48,7 @@
 #        endif
 #    endif
 
-#    if !defined(__FreeBSD__)
+#    if __has_include(<execinfo.h>)
 #        include <cstdint>
 #        include <execinfo.h>
 #        define ICE_BACKTRACE


### PR DESCRIPTION
Fix #4886 