### PR TITLE
Fix NullPointerException in Java Selector

### DIFF
--- a/java-compat/src/Ice/src/main/java/IceInternal/Selector.java
+++ b/java-compat/src/Ice/src/main/java/IceInternal/Selector.java
@@ -34,14 +34,17 @@ public final class Selector
 
     void destroy()
     {
-        try
+        if(_selector != null)
         {
-            _selector.close();
+            try
+            {
+                _selector.close();
+            }
+            catch(java.io.IOException ex)
+            {
+            }
+            _selector = null;
         }
-        catch(java.io.IOException ex)
-        {
-        }
-        _selector = null;
     }
 
     void initialize(EventHandler handler)

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/Selector.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/Selector.java
@@ -35,14 +35,17 @@ public final class Selector
 
     void destroy()
     {
-        try
+        if(_selector != null)
         {
-            _selector.close();
+            try
+            {
+                _selector.close();
+            }
+            catch(java.io.IOException ex)
+            {
+            }
+            _selector = null;
         }
-        catch(java.io.IOException ex)
-        {
-        }
-        _selector = null;
     }
 
     void initialize(EventHandler handler)


### PR DESCRIPTION
Add null check before closing the selector in destroy() to prevent NullPointerException.

Fixes https://github.com/zeroc-ice/ice/issues/3765 Backport of https://github.com/zeroc-ice/ice/pull/3981