### PR TITLE
Fix malformed JavaScript imports when including Glacier2/Session.ice

### DIFF
--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -818,9 +818,9 @@ Slice::Gen::ImportVisitor::writeImports(const UnitPtr& p)
     {
         // Import the required modules from "@zeroc/ice" JavaScript module.
         set<string> iceModules = imports["@zeroc/ice"];
+        _out << nl << "import { ";
         for (auto i = iceModules.begin(); i != iceModules.end();)
         {
-            _out << nl << "import { ";
             _out << (*i);
             if (++i != iceModules.end())
             {


### PR DESCRIPTION
Fix #4913

The import statement was being started inside the loop instead of before it, causing multiple incomplete import statements when more than one module needed to be imported from @zeroc/ice.