### PR TITLE
Fix swift nightly publish when there are no changes

### DIFF
--- a/packaging/swift/update-ice-swift-nightly.sh
+++ b/packaging/swift/update-ice-swift-nightly.sh
@@ -69,6 +69,10 @@ done
 git add .
 git config user.name "ZeroC"
 git config user.email "git@zeroc.com"
-git commit -m "ice: ${version} ${QUALITY} build"
-git tag -a "${version}" -m "ice: ${version} ${QUALITY} build"
-git push origin ${CHANNEL} --tags
+if ! git diff --cached --quiet; then
+    git commit -m "ice: ${version} ${QUALITY} build"
+    git tag -a "${version}" -m "ice: ${version} ${QUALITY} build"
+    git push origin ${CHANNEL} --tags
+else
+    echo "No changes to commit"
+fi


### PR DESCRIPTION
The 3.8 nightly build job fails when trying to create a commit if there is no changes. 

The no changes is related to https://github.com/zeroc-ice/ice/issues/4875