### PR TITLE
Fix invocation timeout doc-comments

### DIFF
--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -4807,7 +4807,7 @@ Slice::Gen::ProxyVisitor::visitClassDefEnd(const ClassDefPtr& p)
     out << sp;
     writeDocComment(out,
                     "Returns a proxy that is identical to this proxy, except for the invocation timeout.\n"
-                    "@param newTimeout The new invocation timeout (in seconds).\n"
+                    "@param newTimeout The new invocation timeout (in milliseconds).\n"
                     "@return A proxy with the specified invocation timeout.");
     out << nl << "@Override";
     out << nl << "default " << p->name() << "Prx ice_invocationTimeout(int newTimeout)";

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -477,13 +477,13 @@ namespace Ice
         /// <summary>
         /// Creates a new proxy that is identical to this proxy, except for the invocation timeout.
         /// </summary>
-        /// <param name="timeout">The new invocation timeout (in seconds).</param>
+        /// <param name="timeout">The new invocation timeout (in milliseconds).</param>
         ObjectPrx ice_invocationTimeout(int timeout);
 
         /// <summary>
         /// Returns the invocation timeout of this proxy.
         /// </summary>
-        /// <returns>The invocation timeout value (in seconds).</returns>
+        /// <returns>The invocation timeout value (in milliseconds).</returns>
         int ice_getInvocationTimeout();
 
         /// <summary>
@@ -1710,7 +1710,7 @@ namespace Ice
         /// <summary>
         /// Returns the invocation timeout of this proxy.
         /// </summary>
-        /// <returns>The invocation timeout value (in seconds).</returns>
+        /// <returns>The invocation timeout value (in milliseconds).</returns>
         public int ice_getInvocationTimeout()
         {
             return _reference.getInvocationTimeout();
@@ -1719,7 +1719,7 @@ namespace Ice
         /// <summary>
         /// Creates a new proxy that is identical to this proxy, except for the invocation timeout.
         /// </summary>
-        /// <param name="newTimeout">The new invocation timeout (in seconds).</param>
+        /// <param name="newTimeout">The new invocation timeout (in milliseconds).</param>
         public ObjectPrx ice_invocationTimeout(int newTimeout)
         {
             if(newTimeout < 1 && newTimeout != -1 && newTimeout != -2)

--- a/java-compat/src/Ice/src/main/java/Ice/ObjectPrx.java
+++ b/java-compat/src/Ice/src/main/java/Ice/ObjectPrx.java
@@ -833,7 +833,7 @@ public interface ObjectPrx
     /**
      * Returns the invocation timeout of this proxy.
      *
-     * @return The invocation timeout value (in seconds).
+     * @return The invocation timeout value (in milliseconds).
      **/
     int ice_getInvocationTimeout();
 
@@ -858,7 +858,7 @@ public interface ObjectPrx
     /**
      * Creates a new proxy that is identical to this proxy, except for the invocation timeout.
      *
-     * @param newTimeout The new invocation timeout (in seconds).
+     * @param newTimeout The new invocation timeout (in milliseconds).
      * @return The new proxy with the specified invocation timeout.
      *
      **/

--- a/java-compat/src/Ice/src/main/java/Ice/ObjectPrxHelperBase.java
+++ b/java-compat/src/Ice/src/main/java/Ice/ObjectPrxHelperBase.java
@@ -1692,7 +1692,7 @@ public class ObjectPrxHelperBase implements ObjectPrx, java.io.Serializable
     /**
      * Returns the invocation timeout of this proxy.
      *
-     * @return The invocation timeout value (in seconds).
+     * @return The invocation timeout value (in milliseconds).
      **/
     @Override
     public final int
@@ -1742,7 +1742,7 @@ public class ObjectPrxHelperBase implements ObjectPrx, java.io.Serializable
     /**
      * Creates a new proxy that is identical to this proxy, except for the invocation timeout.
      *
-     * @param newTimeout The new invocation timeout (in seconds).
+     * @param newTimeout The new invocation timeout (in milliseconds).
      **/
     @Override
     public final ObjectPrx

--- a/matlab/lib/+Ice/ObjectPrx.m
+++ b/matlab/lib/+Ice/ObjectPrx.m
@@ -471,7 +471,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
             % ice_getInvocationTimeout - Returns the invocation timeout of
             %   this proxy.
             %
-            % Returns (int32) - The invocation timeout value (in seconds).
+            % Returns (int32) - The invocation timeout value (in milliseconds).
 
             obj.instantiate_();
             r = obj.iceCallWithResult('ice_getInvocationTimeout');
@@ -482,7 +482,7 @@ classdef ObjectPrx < IceInternal.WrapperObject
             %   this proxy, except for the invocation timeout.
             %
             % Parameters:
-            %   t (int32) - The new invocation timeout (in seconds).
+            %   t (int32) - The new invocation timeout (in milliseconds).
             %
             % Returns - The proxy with the new timeout.
 

--- a/swift/src/Ice/Proxy.swift
+++ b/swift/src/Ice/Proxy.swift
@@ -89,12 +89,12 @@ public protocol ObjectPrx: CustomStringConvertible, AnyObject {
 
     /// Returns the invocation timeout of this proxy.
     ///
-    /// - returns: `Int32` - The invocation timeout value (in seconds).
+    /// - returns: `Int32` - The invocation timeout value (in milliseconds).
     func ice_getInvocationTimeout() -> Int32
 
     /// Creates a new proxy that is identical to this proxy, except for the invocation timeout.
     ///
-    /// - parameter _: `Int32` - The new invocation timeout (in seconds).
+    /// - parameter _: `Int32` - The new invocation timeout (in milliseconds).
     ///
     /// - returns: A new proxy with the specified invocation timeout.
     func ice_invocationTimeout(_ timeout: Int32) -> Self


### PR DESCRIPTION
on the 3.7 branch.

Invocation timeouts are always in milliseconds.

See #4892.