### PR TITLE
Add job-level timeout to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,7 @@ jobs:
             build_cpp_and_python: true
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 180
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add a 180-minute (3 hour) job-level timeout to the CI workflow
- Prevents CI jobs from running indefinitely when individual steps hang
- Individual step timeouts exist but the job itself had no timeout, allowing it to run for GitHub's default 6-hour limit

See https://github.com/zeroc-ice/ice/actions/runs/20866364167/job/60004932749 where a job ran for ~6 hours before being cancelled.

Closes #4873

## Test plan
- [ ] CI workflow runs successfully with the new timeout

🤖 Generated with [Claude Code](https://claude.ai/code)