### PR TITLE
Fix unzip command when multiple MCPP zip files match glob pattern

### DIFF
--- a/.github/workflows/publish-rpm-packages.yml
+++ b/.github/workflows/publish-rpm-packages.yml
@@ -66,7 +66,7 @@ jobs:
             --dir staging/mcpp
           # gh doesn't automatically extract release downloads
           pushd staging/mcpp > /dev/null
-          unzip -q ${MCPP_PACKAGES}.zip
+          for zip in ${MCPP_PACKAGES}.zip; do unzip -q "$zip"; done
           popd > /dev/null
 
       - name: Create RPM repository


### PR DESCRIPTION
## Summary
- Fix `unzip` command in publish-rpm-packages workflow that fails when glob pattern matches multiple files
- When the glob `rpm-packages-3.7-el10-*` expands to multiple zip files (aarch64 and x86_64), `unzip` interprets the second filename as a file to extract from the first archive
- Use a `for` loop to process each zip file separately

## Test plan
- [x] Verified fix with workflow run: https://github.com/zeroc-ice/ice/actions/runs/21281170371

🤖 Generated with [Claude Code](https://claude.com/claude-code)