### PR TITLE
Fix MCPP RPM download for el9 and el10 distributions

### DIFF
--- a/.github/workflows/publish-rpm-packages.yml
+++ b/.github/workflows/publish-rpm-packages.yml
@@ -53,7 +53,7 @@ jobs:
             --dir staging
 
           # If building for RHEL 9 or 10, also download MCPP RPMs.
-          if [[ "$DISTRIBUTION" == "rhel9" || "$DISTRIBUTION" == "rhel10" ]]; then
+          if [[ "$DISTRIBUTION" == "el9" || "$DISTRIBUTION" == "el10" ]]; then
             echo "Also downloading MCPP RPMs for $DISTRIBUTION..."
 
             # MCPP packages
@@ -65,7 +65,7 @@ jobs:
 
             # gh doesn't automatically extract release downloads
             pushd staging/mcpp > /dev/null
-            unzip -q ${MCPP_PACKAGES}.zip
+            for zip in ${MCPP_PACKAGES}.zip; do unzip -q "$zip"; done
             popd > /dev/null
           fi
 


### PR DESCRIPTION
## Summary
- Fix condition to use correct distribution names (`el9`/`el10` instead of `rhel9`/`rhel10`) so MCPP packages are actually downloaded
- Fix `unzip` command to handle multiple zip files (aarch64 and x86_64) by using a `for` loop instead of passing all files as arguments

The original condition `"$DISTRIBUTION" == "rhel9"` never matched because the matrix uses `el9`/`el10`, so MCPP packages were silently skipped.

## Test plan
- [x] Verified fix with workflow run: https://github.com/zeroc-ice/ice/actions/runs/21281540954

🤖 Generated with [Claude Code](https://claude.com/claude-code)