### PR TITLE
Specify TaskFactory=TaskHostFactory for source builds

### DIFF
--- a/.github/workflows/build-dotnet-packages.yml
+++ b/.github/workflows/build-dotnet-packages.yml
@@ -102,12 +102,10 @@ jobs:
           "IcePackageVersion=${{ inputs.ice_version }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
 
-      # Build .NET assemblies. We shutdown the MSBuild server to avoid issues with the signing step. For example ZeroC.Ice.Slice.Tools.dll
-      # might remain in used by the MSBuild server and cannot be signed.
+      # Build .NET assemblies.
       - name: Pack .NET Packages
         run: |
           dotnet msbuild csharp\msbuild\ice.proj /t:BuildDist /p:Configuration=Release
-          dotnet build-server shutdown
 
       - name: Collect Files to Sign
         if: ${{ inputs.authenticode_sign }}

--- a/cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/ZeroC.Ice.Slice.Tools.Cpp.props
+++ b/cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/ZeroC.Ice.Slice.Tools.Cpp.props
@@ -7,6 +7,9 @@
             <!-- Use the Slice compiler from this NuGet package -->
             <PropertyGroup>
                 <IceToolsPath>$(MSBuildThisFileDirectory)..\tools\</IceToolsPath>
+
+                <!-- AssemblyTaskFactory is the default value when no TaskFactory is specified -->
+                <SliceToolsTaskFactory>AssemblyTaskFactory</SliceToolsTaskFactory>
             </PropertyGroup>
         </When>
         <Otherwise>

--- a/cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/ZeroC.Ice.Slice.Tools.Cpp.props
+++ b/cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/ZeroC.Ice.Slice.Tools.Cpp.props
@@ -13,6 +13,9 @@
             <PropertyGroup >
                 <!-- Use the Slice compiler from this Source distribution -->
                 <IceToolsPath>$(MSBuildThisFileDirectory)..\..\..\cpp\bin\x64\$(Configuration)</IceToolsPath>
+
+                <!-- Force task to run out of process to avoid issues with files in use -->
+                <SliceToolsTaskFactory>TaskHostFactory</SliceToolsTaskFactory>
             </PropertyGroup>
         </Otherwise>
     </Choose>

--- a/cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/ZeroC.Ice.Slice.Tools.Cpp.targets
+++ b/cpp/tools/ZeroC.Ice.Slice.Tools.Cpp/ZeroC.Ice.Slice.Tools.Cpp.targets
@@ -30,8 +30,14 @@
     </Choose>
 
     <!-- Import the MSBuild tasks required to compile Slice files using the slice2cpp compiler. -->
-    <UsingTask TaskName="ZeroC.Ice.Slice.Tools.Cpp.Slice2CppTask" AssemblyFile="$(SliceToolsAssembly)"/>
-    <UsingTask TaskName="ZeroC.Ice.Slice.Tools.Cpp.Slice2CppDependTask" AssemblyFile="$(SliceToolsAssembly)"/>
+    <UsingTask
+        TaskName="ZeroC.Ice.Slice.Tools.Cpp.Slice2CppTask"
+        TaskFactory="$(SliceToolsTaskFactory)"
+        AssemblyFile="$(SliceToolsAssembly)"/>
+    <UsingTask
+        TaskName="ZeroC.Ice.Slice.Tools.Cpp.Slice2CppDependTask"
+        TaskFactory="$(SliceToolsTaskFactory)"
+        AssemblyFile="$(SliceToolsAssembly)"/>
 
     <PropertyGroup>
         <EnableDefaultSliceCompileItems Condition="'$(EnableDefaultSliceCompileItems)' == ''">true</EnableDefaultSliceCompileItems>

--- a/csharp/BUILDING.md
+++ b/csharp/BUILDING.md
@@ -2,14 +2,15 @@
 
 ## Table of contents
 
-- [Prerequisites](#prerequisites)
-- [Build roadmap](#build-roadmap)
-- [Building Ice for C#](#building-ice-for-c)
-- [Running the tests](#running-the-tests)
-- [Creating and publishing NuGet packages](#creating-and-publishing-nuget-packages)
-  - [Slice tools](#slice-tools)
-- [Generating the API reference](#generating-the-api-reference)
-- [Shutting down background MSBuild servers](#shutting-down-background-msbuild-servers)
+- [Building Ice for C# from source](#building-ice-for-c-from-source)
+  - [Table of contents](#table-of-contents)
+  - [Prerequisites](#prerequisites)
+  - [Build roadmap](#build-roadmap)
+  - [Building Ice for C#](#building-ice-for-c)
+  - [Running the Tests](#running-the-tests)
+  - [Creating and publishing NuGet packages](#creating-and-publishing-nuget-packages)
+    - [Slice tools](#slice-tools)
+  - [Generating the API reference](#generating-the-api-reference)
 
 ## Prerequisites
 
@@ -104,13 +105,4 @@ This command generates the API reference into the `docfx\_site` directory. Start
 
 ```shell
 docfx serve docfx/_site
-```
-
-## Shutting down background MSBuild servers
-
-You may occasionally encounter errors when cleaning and building because background MSBuild servers use/lock the
-`ZeroC.Ice.Slice.Tools` assembly. When this happens, you can shutdown these MSBuild servers with:
-
-```shell
-dotnet build-server shutdown
 ```

--- a/csharp/BUILDING.md
+++ b/csharp/BUILDING.md
@@ -1,16 +1,12 @@
-# Building Ice for C# from source
+# Building Ice for C# from source <!-- omit in toc -->
 
-## Table of contents
-
-- [Building Ice for C# from source](#building-ice-for-c-from-source)
-  - [Table of contents](#table-of-contents)
-  - [Prerequisites](#prerequisites)
-  - [Build roadmap](#build-roadmap)
-  - [Building Ice for C#](#building-ice-for-c)
-  - [Running the Tests](#running-the-tests)
-  - [Creating and publishing NuGet packages](#creating-and-publishing-nuget-packages)
-    - [Slice tools](#slice-tools)
-  - [Generating the API reference](#generating-the-api-reference)
+- [Prerequisites](#prerequisites)
+- [Build roadmap](#build-roadmap)
+- [Building Ice for C#](#building-ice-for-c)
+- [Running the Tests](#running-the-tests)
+- [Creating and publishing NuGet packages](#creating-and-publishing-nuget-packages)
+  - [Slice tools](#slice-tools)
+- [Generating the API reference](#generating-the-api-reference)
 
 ## Prerequisites
 

--- a/csharp/Makefile
+++ b/csharp/Makefile
@@ -1,23 +1,18 @@
 # Copyright (c) ZeroC, Inc.
 
-#
-# We use /p:UseSharedCompilation=false /nr:false to ensure msbuild doesn't leave processes behind
-# after the build (this causes make to hang).
-#
-DOTNETARGS = /p:UseSharedCompilation=false /nr:false /m
 DOTNETBUILDARGS = $(if $(filter $(OPTIMIZE),no),/p:Configuration=Debug)
 
 all:
-	dotnet msbuild msbuild/ice.proj $(DOTNETARGS) $(DOTNETBUILDARGS)
+	dotnet msbuild msbuild/ice.proj $(DOTNETBUILDARGS)
 
 tests:
-	dotnet msbuild msbuild/ice.proj $(DOTNETARGS) $(DOTNETBUILDARGS)
+	dotnet msbuild msbuild/ice.proj $(DOTNETBUILDARGS)
 
 srcs:
-	dotnet msbuild msbuild/ice.proj $(DOTNETARGS) $(DOTNETBUILDARGS) /t:BuildDist
+	dotnet msbuild msbuild/ice.proj $(DOTNETBUILDARGS) /t:BuildDist
 
 distclean clean:
-	dotnet msbuild msbuild/ice.proj $(DOTNETARGS) /t:Clean
+	dotnet msbuild msbuild/ice.proj /t:Clean
 
 install::
 	@echo nothing to install

--- a/csharp/src/ZeroC.Ice.Slice.Tools/ZeroC.Ice.Slice.Tools.props
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/ZeroC.Ice.Slice.Tools.props
@@ -17,6 +17,9 @@
             <!-- Use the Slice compiler from this NuGet package -->
             <PropertyGroup>
                 <IceToolsPath>$(MSBuildThisFileDirectory)..\tools\$(IceOSName)-$(IceOSArch)\</IceToolsPath>
+
+                <!-- AssemblyTaskFactory is the default value when no TaskFactory is specified -->
+                <SliceToolsTaskFactory>AssemblyTaskFactory</SliceToolsTaskFactory>
             </PropertyGroup>
         </When>
         <Otherwise>

--- a/csharp/src/ZeroC.Ice.Slice.Tools/ZeroC.Ice.Slice.Tools.props
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/ZeroC.Ice.Slice.Tools.props
@@ -25,6 +25,9 @@
                 <SliceToolsSourceBuild>true</SliceToolsSourceBuild>
                 <IceToolsPath>$(MSBuildThisFileDirectory)..\..\..\cpp\bin\</IceToolsPath>
                 <IceToolsPath Condition="'$(IceOSName)' == 'windows'">$(IceToolsPath)x64\$(Configuration)\</IceToolsPath>
+
+                <!-- Force task to run out of process to avoid issues with files in use -->
+                <SliceToolsTaskFactory>TaskHostFactory</SliceToolsTaskFactory>
             </PropertyGroup>
         </Otherwise>
     </Choose>

--- a/csharp/src/ZeroC.Ice.Slice.Tools/ZeroC.Ice.Slice.Tools.targets
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/ZeroC.Ice.Slice.Tools.targets
@@ -35,8 +35,14 @@
     </ItemGroup>
 
     <!-- Import the MSBuild tasks required to compile Slice files using the slice2cs compiler. -->
-    <UsingTask TaskName="ZeroC.Ice.Slice.Tools.Slice2CSharpTask" AssemblyFile="$(SliceToolsAssembly)"/>
-    <UsingTask TaskName="ZeroC.Ice.Slice.Tools.Slice2CSharpDependTask" AssemblyFile="$(SliceToolsAssembly)"/>
+    <UsingTask
+        TaskName="ZeroC.Ice.Slice.Tools.Slice2CSharpTask"
+        TaskFactory="$(SliceToolsTaskFactory)"
+        AssemblyFile="$(SliceToolsAssembly)"/>
+    <UsingTask
+        TaskName="ZeroC.Ice.Slice.Tools.Slice2CSharpDependTask"
+        TaskFactory="$(SliceToolsTaskFactory)"
+        AssemblyFile="$(SliceToolsAssembly)"/>
 
     <PropertyGroup>
         <EnableDefaultSliceCompileItems Condition="'$(EnableDefaultSliceCompileItems)' == ''">true</EnableDefaultSliceCompileItems>


### PR DESCRIPTION
This PR updates C# source builds (all platforms) and C++ source builds (Windows) to specify TaskFactory=TaskHostFactory for the ZeroC.Ice.Slice.Tools[.Cpp] tasks.

Fixes #4931 