### PR TITLE
Fix missing WS and UDP endpoint registration in PyPI package

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -81,6 +81,7 @@ else:
 # All the /**/ macros are necessary only on Windows
 define_macros = [
     ("ICE_STATIC_LIBS", None),
+    ("ICE_PYPI", None),
     ("ICE_BUILDING_SRC", None),
     ("ICE_BUILDING_ICE", None),
     ("ICE_BUILDING_ICESSL", None),


### PR DESCRIPTION
## Summary
- Add `ICE_PYPI` macro to `define_macros` in `python/setup.py`
- This enables registration of WS and UDP endpoint factories when building the PyPI package

The conditional compilation in `cpp/src/Ice/RegisterPluginsInit.cpp` requires `ICE_PYPI` to be defined for static builds to register these endpoint factories.

Fixes #4943

## Test plan
- [x] Build PyPI package and verify WS endpoints work
- [x] Verify UDP endpoints also work

🤖 Generated with [Claude Code](https://claude.com/claude-code)