### PR TITLE
Fix NuGet package tools directory structure for Linux and macOS

### DIFF
--- a/csharp/msbuild/zeroc.ice.net.csproj
+++ b/csharp/msbuild/zeroc.ice.net.csproj
@@ -67,9 +67,9 @@
         </Content>
 
         <!-- Tools directory (slice2cs compilers, iceboxnet, bzip2.dll) -->
-        <Content Include="obj\package\tools\**\*">
+        <Content Include="obj\package\tools\**">
             <Pack>true</Pack>
-            <PackagePath>tools\%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
+            <PackagePath>tools</PackagePath>
         </Content>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #4941