### PR TITLE
Filter out non-operational interfaces (C#)

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -148,6 +148,8 @@ These are the changes since Ice 3.7.10.
 - Fixed a bug where C# connections did not correctly mark messages as sent.
   ([#4861](https://github.com/zeroc-ice/ice/pull/4861))
 
+- Filter-out non-operational network interfaces when listening on a multicast endpoint.
+
 - The minimum supported .NET Framework version is now 4.7.2. The minimum supported .NET Standard version
   remains 2.0. ([#4826](https://github.com/zeroc-ice/ice/pull/4826))
 

--- a/csharp/src/Ice/Network.cs
+++ b/csharp/src/Ice/Network.cs
@@ -834,20 +834,23 @@ namespace IceInternal
                 NetworkInterface[] nics = NetworkInterface.GetAllNetworkInterfaces();
                 foreach(NetworkInterface ni in nics)
                 {
-                    IPInterfaceProperties ipProps = ni.GetIPProperties();
-                    UnicastIPAddressInformationCollection uniColl = ipProps.UnicastAddresses;
-                    foreach(UnicastIPAddressInformation uni in uniColl)
+                    if (ni.OperationalStatus == OperationalStatus.Up)
                     {
-                        if((uni.Address.AddressFamily == AddressFamily.InterNetwork && protocol != EnableIPv6) ||
-                           (uni.Address.AddressFamily == AddressFamily.InterNetworkV6 && protocol != EnableIPv4))
+                        IPInterfaceProperties ipProps = ni.GetIPProperties();
+                        UnicastIPAddressInformationCollection uniColl = ipProps.UnicastAddresses;
+                        foreach(UnicastIPAddressInformation uni in uniColl)
                         {
-                            if(!addresses.Contains(uni.Address) &&
-                               (includeLoopback || !IPAddress.IsLoopback(uni.Address)))
+                            if((uni.Address.AddressFamily == AddressFamily.InterNetwork && protocol != EnableIPv6) ||
+                                (uni.Address.AddressFamily == AddressFamily.InterNetworkV6 && protocol != EnableIPv4))
                             {
-                                addresses.Add(uni.Address);
-                                if(singleAddressPerInterface)
+                                if(!addresses.Contains(uni.Address) &&
+                                (includeLoopback || !IPAddress.IsLoopback(uni.Address)))
                                 {
-                                    break;
+                                    addresses.Add(uni.Address);
+                                    if(singleAddressPerInterface)
+                                    {
+                                        break;
+                                    }
                                 }
                             }
                         }

--- a/csharp/src/Ice/Network.cs
+++ b/csharp/src/Ice/Network.cs
@@ -834,7 +834,7 @@ namespace IceInternal
                 NetworkInterface[] nics = NetworkInterface.GetAllNetworkInterfaces();
                 foreach(NetworkInterface ni in nics)
                 {
-                    if (ni.OperationalStatus == OperationalStatus.Up)
+                    if(ni.OperationalStatus == OperationalStatus.Up)
                     {
                         IPInterfaceProperties ipProps = ni.GetIPProperties();
                         UnicastIPAddressInformationCollection uniColl = ipProps.UnicastAddresses;
@@ -844,7 +844,7 @@ namespace IceInternal
                                 (uni.Address.AddressFamily == AddressFamily.InterNetworkV6 && protocol != EnableIPv4))
                             {
                                 if(!addresses.Contains(uni.Address) &&
-                                (includeLoopback || !IPAddress.IsLoopback(uni.Address)))
+                                    (includeLoopback || !IPAddress.IsLoopback(uni.Address)))
                                 {
                                     addresses.Add(uni.Address);
                                     if(singleAddressPerInterface)


### PR DESCRIPTION
See #4356.

I verified this fixes the ` csharp/IceDiscovery/hello` demo on Windows.