### PR TITLE
Fix JavaScript inactivity timeout missing seconds to milliseconds conversion

### DIFF
--- a/js/src/Ice/ConnectionI.js
+++ b/js/src/Ice/ConnectionI.js
@@ -74,7 +74,7 @@ export class ConnectionI {
         this._closeTimeout = options.closeTimeout * 1000; // Seconds to milliseconds.
         this._closeTimeoutId = undefined;
 
-        this._inactivityTimeout = options.inactivityTimeout;
+        this._inactivityTimeout = options.inactivityTimeout * 1000; // Seconds to milliseconds
         this._inactivityTimer = undefined;
 
         const initData = instance.initializationData();


### PR DESCRIPTION
## Summary

- Fix missing seconds to milliseconds conversion for `_inactivityTimeout` in `ConnectionI.js`

Closes #4956

## Test plan

- [ ] Manual testing with inactivity timeout configuration


🤖 Generated with [Claude Code](https://claude.com/claude-code)