### PR TITLE
Fix Objective-C build warnings

### DIFF
--- a/objective-c/test/Common/TestCommon.m
+++ b/objective-c/test/Common/TestCommon.m
@@ -211,7 +211,7 @@ serverReady(id<ICECommunicator> c)
 }
 
 void
-serverStop()
+serverStop(void)
 {
     @try
     {

--- a/objective-c/test/Ice/ami/AllTests.m
+++ b/objective-c/test/Ice/ami/AllTests.m
@@ -797,7 +797,7 @@ amiAllTests(id<ICECommunicator> communicator, BOOL collocated)
     {
         [testController holdAdapter];
 
-        id<ICEAsyncResult> r;
+        id<ICEAsyncResult> r = nil;
         ICEByte buf[10024];
         ICEByteSeq* seq = [ICEByteSeq dataWithBytes:buf length:sizeof(buf)];
         for(int i = 0; i < 200; ++i) // 2MB


### PR DESCRIPTION
## Summary
- Add `void` to `serverStop()` function prototype to fix `-Wstrict-prototypes` warning
- Initialize variable `r` to `nil` to fix `-Wconditional-uninitialized` warning

Fixes #4953

## Test plan
- [ ] Verify Objective-C tests build without warnings on macOS/iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)