### PR TITLE
Update instructions for installing Ice 3.7 nightly pip packages

### DIFF
--- a/NIGHTLY.md
+++ b/NIGHTLY.md
@@ -168,20 +168,10 @@ sudo apt-get install php-zeroc-ice
 
 The nightly package for all platforms (Linux, macOS, Windows) is available from the ZeroC PyPI nightly repository.
 
-To install the latest zeroc-ice nightly package, add the following lines to your requirements.txt:
+To install the latest zeroc-ice 3.7 nightly package:
 
 ```shell
-# Use ZeroC nightly repository as the main index for pip
---index-url https://download.zeroc.com/nexus/repository/pypi-3.7-nightly/simple/
-
-# Allow installing packages from the official PyPI index if not found in the ZeroC repository
---extra-index-url https://pypi.org/simple/
-
-# Enable installation of pre-release versions (required for nightly builds)
---pre
-
-# Specify the zeroc-ice package (latest nightly version)
-zeroc-ice
+pip install --pre --index-url https://download.zeroc.com/nexus/repository/pypi-3.7-nightly/simple/ zeroc-ice
 ```
 
 #### Linux <!-- omit in toc -->


### PR DESCRIPTION
- The previous command with extra index, would pick 3.8.0 from PyPi index.
- Using a range version with multiple index doesn't work well. It doesn't merge the version from several indexes.


Tested on macOS and Windows with venv:

## macOS

```
jose@mac Documents % python -m venv test-venv
jose@mac Documents % source ./test-venv/bin/activate
(test-venv) jose@mac Documents % pip install --pre --index-url https://download.zeroc.com/nexus/repository/pypi-3.7-nightly/simple/ zeroc-ice
Looking in indexes: https://download.zeroc.com/nexus/repository/pypi-3.7-nightly/simple/
Collecting zeroc-ice
  Downloading https://download.zeroc.com/nexus/repository/pypi-3.7-nightly/packages/zeroc-ice/3.7.11.dev202601271/zeroc_ice-3.7.11.dev202601271-cp313-cp313-macosx_10_13_universal2.whl (5.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5.0/5.0 MB 7.5 MB/s  0:00:00
Installing collected packages: zeroc-ice
Successfully installed zeroc-ice-3.7.11.dev202601271
```

## Windows

```
C:\Users\jose\Documents>python -m venv test-venv

C:\Users\jose\Documents>test-venv\Scripts\activate

(test-venv) C:\Users\jose\Documents>   pip install --pre --index-url https://download.zeroc.com/nexus/repository/pypi-3.7-nightly/simple/ zeroc-ice
Looking in indexes: https://download.zeroc.com/nexus/repository/pypi-3.7-nightly/simple/
Collecting zeroc-ice
  Downloading https://download.zeroc.com/nexus/repository/pypi-3.7-nightly/packages/zeroc-ice/3.7.11.dev202601271/zeroc_ice-3.7.11.dev202601271-cp314-cp314-win_amd64.whl (18.9 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 18.9/18.9 MB 12.3 MB/s  0:00:01
Installing collected packages: zeroc-ice
Successfully installed zeroc-ice-3.7.11.dev202601271
```