### PR TITLE
Standardize Platform and Configuration defaults to x64/Release

### DIFF
--- a/cpp/msbuild/ice.proj
+++ b/cpp/msbuild/ice.proj
@@ -1,15 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <PropertyGroup Condition="'$(Configuration)' == ''">
-        <Configuration>Release</Configuration>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(Platform)' == ''">
-        <Platform>Win32</Platform>
-    </PropertyGroup>
-
     <PropertyGroup>
+        <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
+        <Platform Condition="'$(Platform)' == ''">x64</Platform>
         <VCTargetsPath Condition="'$(VCTargetsPath)' == ''">C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0</VCTargetsPath>
         <DefaultPlatformToolset Condition="'$(VisualStudioVersion)' == '10.0' And  '$(DefaultPlatformToolset)' == ''">v100</DefaultPlatformToolset>
         <IceTestSolution>ice.test.sln</IceTestSolution>

--- a/java-compat/gradle.properties
+++ b/java-compat/gradle.properties
@@ -62,14 +62,14 @@ devRepo =
 // `Win32`. This is required to locate the slice2java compiler in the
 // platform-dependent directory.
 //
-cppPlatform =
+cppPlatform = x64
 
 //
 // The configuration used by the C++ builds. Supported values are `Debug`
 // and `Release`. This is required to locate the slice2java compiler in
 // the configuration-dependent directory.
 //
-cppConfiguration =
+cppConfiguration = Release
 
 //
 // Gradle build properties

--- a/java-compat/msbuild/ice.proj
+++ b/java-compat/msbuild/ice.proj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <Platform Condition="'$(Platform)' == ''">Win32</Platform>
+    <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
   </PropertyGroup>
 

--- a/java/gradle.properties
+++ b/java/gradle.properties
@@ -83,7 +83,7 @@ devRepo =
 // `Win32`, that is required to locate the slice2java compiler in the
 // platform depend directory.
 //
-cppPlatform =
+cppPlatform = x64
 
 //
 // The configuration uses by the C++ builds, supported values are `Debug`
@@ -91,7 +91,7 @@ cppPlatform =
 // the configuration depend
 // directory.
 //
-cppConfiguration =
+cppConfiguration = Release
 
 //
 // Gradle build properties

--- a/java/msbuild/ice.proj
+++ b/java/msbuild/ice.proj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <Platform Condition="'$(Platform)' == ''">Win32</Platform>
+    <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
   </PropertyGroup>
 

--- a/js/msbuild/ice.proj
+++ b/js/msbuild/ice.proj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <NPM Condition="'$(NPM)' == ''">npm</NPM>
-    <Platform Condition="'$(Platform)' == ''">Win32</Platform>
+    <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
   </PropertyGroup>
 

--- a/php/msbuild/ice.proj
+++ b/php/msbuild/ice.proj
@@ -1,7 +1,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <PropertyGroup>
-        <Platform Condition="'$(Platform)' == ''">Win32</Platform>
+        <Platform Condition="'$(Platform)' == ''">x64</Platform>
         <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
     </PropertyGroup>
 

--- a/python/msbuild/ice.proj
+++ b/python/msbuild/ice.proj
@@ -1,14 +1,8 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <PropertyGroup Condition="'$(Configuration)' == ''">
-        <Configuration>Release</Configuration>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(Platform)' == ''">
-      <Platform>Win32</Platform>
-    </PropertyGroup>
-
     <PropertyGroup>
+        <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
+        <Platform Condition="'$(Platform)' == ''">x64</Platform>
         <IceHome>$(MSBuildThisFileDirectory)..\..</IceHome>
         <IceToolsPath>$(IceHome)\cpp\bin\$(Platform)\$(Configuration)</IceToolsPath>
     </PropertyGroup>


### PR DESCRIPTION
Update all MSBuild ice.proj files and Gradle properties to consistently default to x64 platform and Release configuration, matching the top-level ice.proj defaults.