### PR TITLE
Make Microsoft.Win32.Registry a private dependency

### DIFF
--- a/csharp/src/Ice/ice.csproj
+++ b/csharp/src/Ice/ice.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
       <PackageReference Include="zeroc.icebuilder.msbuild" Version="5.0.9" PrivateAssets="All" />
       <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-      <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+      <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" PrivateAssets="All" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
   <Import Project="$(MSBuildThisFileDirectory)../../msbuild/ice.sign.targets" />
 </Project>


### PR DESCRIPTION
This prevents the package from being listed as a transitive dependency in the published NuGet package. The Registry APIs are available at runtime on both supported platforms (.NET 8 and .NET Framework 4.7.1).