### PR TITLE
Add setup-cpp action to test-pip-package workflow

### DIFF
--- a/.github/workflows/test-pip-package.yml
+++ b/.github/workflows/test-pip-package.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Setup C++
+        uses: ./.github/actions/setup-cpp
+
       - name: Setup Python
         uses: ./.github/actions/setup-python
 


### PR DESCRIPTION
## Summary
- Add missing `setup-cpp` action to the test-pip-package workflow to install native build dependencies (mcpp, lmdb, etc.)

## Background
The workflow was failing on all platforms because the PIP package build requires native dependencies to compile the Slice compilers and Ice C++ library:
- **Ubuntu**: `libmcpp-dev` and other dev packages
- **macOS**: `mcpp` and `lmdb` via Homebrew  
- **Windows**: MSBuild setup

## Test plan
- [ ] Verify CI passes on ubuntu-24.04, macos-26, and windows-2022