### PR TITLE
Use slice2swift 3.8.0 artifact bundle

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "a3f51a6d358ff01827599889ec21637b58eac3b23622132836e1ed774b90f56d",
+  "originHash" : "17b3fe1bc76447ca7b611f83703debc194392a835971c87010aeb89c7e22dfd9",
   "pins" : [
-    {
-      "identity" : "mcpp",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/zeroc-ice/mcpp.git",
-      "state" : {
-        "branch" : "main",
-        "revision" : "0dbe51946cce23c692c59cf75909daf4fcdfd1d2"
-      }
-    },
     {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -76,7 +76,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "slice2swift",
-            path: "cpp/bin/slice2swift.artifactbundle.zip"
+            url: "https://download.zeroc.com/ice/3.8/slice2swift-3.8.0.artifactbundle.zip",
+            checksum: "afe82130f8ce3178896a56b8308eab5567312af86db395b6cb756d4bfa7c65ca"
         ),
         .plugin(
             name: "CompileSlice",


### PR DESCRIPTION
I uploaded a slice2swift artifact bundle build from v3.8.0 tag. 
This PR updates Package.swift in 3.8 branch to use the new artifact bundle.