### PR TITLE
Add el9 and amzn2023 to CI Linux matrix with Python 3.12 for tests

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -20,12 +20,30 @@ jobs:
       matrix:
         include:
           # RPM-based distributions
+          - distribution: el9
+            arch: x86_64
+            image_type: rpm
+            python: python3.12
+          - distribution: el9
+            arch: aarch64
+            image_type: rpm
+            python: python3.12
+
           - distribution: el10
             arch: x86_64
             image_type: rpm
           - distribution: el10
             arch: aarch64
             image_type: rpm
+
+          - distribution: amzn2023
+            arch: x86_64
+            image_type: rpm
+            python: python3.12
+          - distribution: amzn2023
+            arch: aarch64
+            image_type: rpm
+            python: python3.12
 
           # DEB-based distributions
           - distribution: ubuntu24.04
@@ -84,7 +102,7 @@ jobs:
               # - IceUtil/priority, Ice/threadPoolPriority: require CAP_SYS_NICE for thread priorities
               # - Glacier2/*: require the passlib Python module
               # - IceSSL/configuration: requires the openssl CLI tool
-              python3 allTests.py --workers=4 --debug --continue \
+              ${{ matrix.python || 'python3' }} allTests.py --workers=4 --debug --continue \
                 --rfilter='IceUtil/priority|Ice/threadPoolPriority|Glacier2/|IceSSL/configuration'
             "
 


### PR DESCRIPTION
## Summary
- Add el9 (x86_64, aarch64) and amzn2023 (x86_64, aarch64) to the `ci-linux.yml` test matrix
- Use `python3.12` for the test runner on these distributions, since their default `python3` is 3.9 which lacks the `match` statement used by test scripts
- Other distributions default to `python3` as before

Fixes #5016

🤖 Generated with [Claude Code](https://claude.com/claude-code)