### PR TITLE
Add IceBT library to RPM distributions

### DIFF
--- a/packaging/rpm/ice.spec
+++ b/packaging/rpm/ice.spec
@@ -60,12 +60,8 @@ BuildRequires: pkgconfig(openssl)
 BuildRequires: pkgconfig(bzip2)
 BuildRequires: pkgconfig(lmdb)
 BuildRequires: pkgconfig(libsystemd)
-
-# Bluetooth transport is only built for RHEL distributions
-%if "%{dist}" != ".amzn2023"
 BuildRequires: pkgconfig(bluez)
 BuildRequires: pkgconfig(dbus-1)
-%endif
 
 # Amazon Linux 2023 does not provide pkgconfig(mcpp)
 %if "%{dist}" == ".amzn2023"
@@ -425,9 +421,7 @@ cp -p java/lib/icegridgui.jar %{buildroot}%{_javadir}/icegridgui.jar
 %{_libdir}/libDataStorm.so.*
 %{_libdir}/libGlacier2.so.*
 %{_libdir}/libIce.so.*
-%if "%{dist}" != ".amzn2023"
 %{_libdir}/libIceBT.so.*
-%endif
 %{_libdir}/libIceBox.so.*
 %{_libdir}/libIceDiscovery.so.*
 %{_libdir}/libIceGrid.so.*
@@ -464,9 +458,7 @@ exit 0
 %{_libdir}/libDataStorm.so
 %{_libdir}/libGlacier2.so
 %{_libdir}/libIce.so
-%if "%{dist}" != ".amzn2023"
 %{_libdir}/libIceBT.so
-%endif
 %{_libdir}/libIceBox.so
 %{_libdir}/libIceDiscovery.so
 %{_libdir}/libIceGrid.so
@@ -475,9 +467,7 @@ exit 0
 %{_includedir}/DataStorm
 %{_includedir}/Glacier2
 %{_includedir}/Ice
-%if "%{dist}" != ".amzn2023"
 %{_includedir}/IceBT
-%endif
 %{_includedir}/IceBox
 %{_includedir}/IceDiscovery
 %{_includedir}/IceGrid


### PR DESCRIPTION
## Summary
- Add IceBT (Bluetooth transport) library to the RPM packages for el9 and el10 distributions
- Add conditional `BuildRequires` for `bluez` and `dbus-1` (excluded on amzn2023)
- Add `libIceBT.so` to `libice3.9-c++` runtime and `libice-c++-devel` packages
- No Makefile or Dockerfile changes needed — the build system already conditionally compiles IceBT when bluez/dbus are detected

Closes #4749

RPM build with the changes https://github.com/zeroc-ice/ice/actions/runs/21822246350