### PR TITLE
Replace hardcoded pip-packages directory names with glob pattern

### DIFF
--- a/packaging/release/prepare-release-assets.sh
+++ b/packaging/release/prepare-release-assets.sh
@@ -47,14 +47,12 @@ rm -rf java-packages
 cp -v "${STAGING_DIR}/js-npm-packages"/*.tgz .
 
 # Include Python wheels and PIP source distributions.
-cp -v "${STAGING_DIR}/pip-packages-windows-2022-3.12"/zeroc_ice-*.whl .
-cp -v "${STAGING_DIR}/pip-packages-windows-2022-3.13"/zeroc_ice-*.whl .
-cp -v "${STAGING_DIR}/pip-packages-windows-2022-3.14"/zeroc_ice-*.whl .
-
-cp -v "${STAGING_DIR}/pip-packages-macos-26-3.12"/zeroc_ice-*.whl .
-cp -v "${STAGING_DIR}/pip-packages-macos-26-3.13"/zeroc_ice-*.whl .
-cp -v "${STAGING_DIR}/pip-packages-macos-26-3.14"/zeroc_ice-*.whl .
-cp -v "${STAGING_DIR}/pip-packages-macos-26-3.14"/zeroc_ice-*.tar.gz .
+pip_dirs=("${STAGING_DIR}"/pip-packages-*)
+for dir in "${pip_dirs[@]}"; do
+  cp -v "$dir"/zeroc_ice-*.whl .
+done
+# All directories contain equivalent sdist archives; upload only once.
+cp -v "${pip_dirs[0]}"/zeroc_ice-*.tar.gz .
 
 # IceGridGUI JAR package
 cp -v "${STAGING_DIR}/icegridgui-jar/icegridgui.jar" .


### PR DESCRIPTION
## Summary
- Replace 7 hardcoded `pip-packages-*` directory paths with a glob-based loop in `prepare-release-assets.sh`
- Wheels are copied from all `pip-packages-*` directories, and the sdist `.tar.gz` is copied once from the first match (all directories contain equivalent sdist archives)
- Consistent with how DEB and RPM packages are already handled in the same script

Closes #4766