### PR TITLE
Cleanup JavaScript Buffer API

### DIFF
--- a/js/src/Ice/Buffer.js
+++ b/js/src/Ice/Buffer.js
@@ -9,9 +9,6 @@ const bufferOverflowExceptionMsg = "BufferOverflowException";
 const bufferUnderflowExceptionMsg = "BufferUnderflowException";
 const indexOutOfBoundsExceptionMsg = "IndexOutOfBoundsException";
 
-// Singleton TextEncoder for UTF-8 string encoding
-const textEncoder = new TextEncoder();
-
 class Buffer
 {
     constructor(buffer)
@@ -217,16 +214,6 @@ class Buffer
         this._position += 4;
         this.v.setInt32(this._position, v.high, true);
         this._position += 4;
-    }
-
-    writeString(stream, v)
-    {
-        const encoded = textEncoder.encode(v);
-        stream.writeSize(encoded.length);
-        this.expand(encoded.length);
-        new Uint8Array(this.b, this._position, encoded.length).set(encoded);
-        this._position += encoded.length;
-        this._limit = this._position;
     }
 
     get()

--- a/js/src/Ice/Stream.js
+++ b/js/src/Ice/Stream.js
@@ -21,6 +21,9 @@ require("../Ice/UnknownSlicedValue");
 require("../Ice/Value");
 require("../Ice/Version");
 
+// Singleton TextEncoder for UTF-8 string encoding
+const textEncoder = new TextEncoder();
+
 const ArrayUtil = Ice.ArrayUtil;
 const Debug = Ice.Debug;
 const ExUtil = Ice.ExUtil;
@@ -3185,7 +3188,10 @@ class OutputStream
         }
         else
         {
-            this._buf.writeString(this, v);
+            const encoded = textEncoder.encode(v);
+            this.writeSize(encoded.length);
+            this.expand(encoded.length);
+            this._buf.putArray(encoded);
         }
     }
 


### PR DESCRIPTION
## Summary
- Port of d6a2b650b248ffe1d3b1979e3e34598ebf25a56d to 3.7
- Move string encoding logic from `Buffer` to `OutputStream`, removing `writeString` from `Buffer` and the singleton `TextEncoder` that was only used by it
- The encoding is now inlined in `OutputStream.writeString` using `textEncoder.encode()` + `putArray()`