### PR TITLE
Fix Swift module documentation to describe client libraries accurately

### DIFF
--- a/swift/src/Glacier2/Glacier2.docc/Glacier2.md
+++ b/swift/src/Glacier2/Glacier2.docc/Glacier2.md
@@ -1,3 +1,3 @@
 # ``Glacier2``
 
-Glacier2 client library. Communicate through firewalls and across NATs.
+Glacier2 is a lightweight firewall traversal solution for Ice. This Swift library provides the client APIs for the Glacier2 service.

--- a/swift/src/IceGrid/IceGrid.docc/IceGrid.md
+++ b/swift/src/IceGrid/IceGrid.docc/IceGrid.md
@@ -1,3 +1,3 @@
 # ``IceGrid``
 
-IceGrid client library. Deploy and manage Ice servers.
+IceGrid is a location and activation service for Ice. This Swift library provides the client APIs for the IceGrid service.

--- a/swift/src/IceStorm/IceStorm.docc/IceStorm.md
+++ b/swift/src/IceStorm/IceStorm.docc/IceStorm.md
@@ -1,3 +1,3 @@
 # ``IceStorm``
 
-IceStorm client library. Lightweight publish/subscribe framework.
+IceStorm is an efficient publish/subscribe service for Ice. This Swift library provides the client APIs for the IceStorm service.


### PR DESCRIPTION
Updated Glacier2, IceStorm, and IceGrid using C# READMEs as a reference.

Closes #5037
