### PR TITLE
Fix default value for IceSSL.RevocationCheckCacheOnly

### DIFF
--- a/config/PropertyNames.xml
+++ b/config/PropertyNames.xml
@@ -317,7 +317,7 @@
         <property name="KeystoreType" languages="java" />
         <property name="Password" languages="cpp,csharp,java" />
         <property name="RevocationCheck" languages="cpp" default="0"/>
-        <property name="RevocationCheckCacheOnly" languages="cpp" default="0" />
+        <property name="RevocationCheckCacheOnly" languages="cpp" default="1" />
         <property name="Trace.Security" languages="cpp,csharp,java" default="0" />
         <property name="TrustOnly" languages="cpp,csharp,java" />
         <property name="TrustOnly.Client" languages="cpp,csharp,java" />

--- a/cpp/src/Ice/PropertyNames.cpp
+++ b/cpp/src/Ice/PropertyNames.cpp
@@ -428,7 +428,7 @@ const Property IceSSLPropsData[] =
     Property{"KeyFile", "", false, false, nullptr},
     Property{"Password", "", false, false, nullptr},
     Property{"RevocationCheck", "0", false, false, nullptr},
-    Property{"RevocationCheckCacheOnly", "0", false, false, nullptr},
+    Property{"RevocationCheckCacheOnly", "1", false, false, nullptr},
     Property{"Trace.Security", "0", false, false, nullptr},
     Property{"TrustOnly", "", false, false, nullptr},
     Property{"TrustOnly.Client", "", false, false, nullptr},


### PR DESCRIPTION
This PR fixes the default value for IceSSL.RevocationCheckCacheOnly (C++ only): it's now 1 (meaning cache-only) instead of 0.

Fixes #2133.

Note that the documentation still needs to be fixed, preferably shortly before the 3.8.1 release: https://docs.zeroc.com/ice/3.8/cpp/icessl-1#IceSSL.*-IceSSL.RevocationCheckCacheOnly

The documentation is very bogus.
