### PR TITLE
Fix WebSocket URL construction for IPv6 and wss default port

### DIFF
--- a/js/packages/ice/src/Ice/WSTransceiver.js
+++ b/js/packages/ice/src/Ice/WSTransceiver.js
@@ -29,8 +29,9 @@ class WSTransceiver {
         this._writeReadyTimeout = 0;
 
         let url = secure ? "wss" : "ws";
-        url += "://" + addr.host;
-        if (addr.port !== 80) {
+        const isIPv6 = addr.host.indexOf(":") !== -1;
+        url += "://" + (isIPv6 ? `[${addr.host}]` : addr.host);
+        if (addr.port !== (secure ? 443 : 80)) {
             url += ":" + addr.port;
         }
         url += resource ? resource : "/";


### PR DESCRIPTION
## Summary
- Wrap IPv6 literal addresses in brackets when constructing WebSocket URLs, per RFC 3986/6455 (#5084)
- Use 443 as the default port for `wss` scheme instead of always using 80 (#5083)

Fixes #5083
Fixes #5084