### PR TITLE
Fix Properties.js getPropertyAsList default and parse crash

### DIFF
--- a/js/packages/ice/src/Ice/Properties.js
+++ b/js/packages/ice/src/Ice/Properties.js
@@ -91,7 +91,7 @@ export class Properties {
     }
 
     getPropertyAsList(key) {
-        return this.getPropertyAsListWithDefault(key, 0);
+        return this.getPropertyAsListWithDefault(key, []);
     }
 
     getIcePropertyAsList(key) {
@@ -216,7 +216,7 @@ export class Properties {
     }
 
     parse(data) {
-        data.match(/[^\r\n]+/g).forEach(line => this.parseLine(line));
+        (data.match(/[^\r\n]+/g) ?? []).forEach(line => this.parseLine(line));
     }
 
     parseLine(line) {


### PR DESCRIPTION
## Summary
- Fix `getPropertyAsList` to pass `[]` instead of `0` as the default value (#5079)
- Fix `parse()` to handle `null` return from `String.match()` on empty/whitespace-only content (#5082)

## Test plan
- [ ] Verify `getPropertyAsList` returns an empty array when the property is not set
- [ ] Verify `parse("")` and `parse("\n")` do not throw

Fixes #5079
Fixes #5082

🤖 Generated with [Claude Code](https://claude.com/claude-code)