### PR TITLE
Fix encoding version validation in ConnectionI.js

### DIFF
--- a/js/packages/ice/src/Ice/ConnectionI.js
+++ b/js/packages/ice/src/Ice/ConnectionI.js
@@ -491,7 +491,7 @@ export class ConnectionI {
                     encodingVersion._read(this._readStream);
                     if (
                         encodingVersion.major != Protocol.currentProtocolEncoding.major ||
-                        protocolVersion.minor != Protocol.currentProtocolEncoding.minor
+                        encodingVersion.minor != Protocol.currentProtocolEncoding.minor
                     ) {
                         throw new MarshalException(
                             `Invalid protocol encoding version in message header: ${encodingVersion.major}.${encodingVersion.minor}`,
@@ -1068,7 +1068,7 @@ export class ConnectionI {
         encodingVersion._read(this._readStream);
         if (
             encodingVersion.major != Protocol.currentProtocolEncoding.major ||
-            protocolVersion.minor != Protocol.currentProtocolEncoding.minor
+            encodingVersion.minor != Protocol.currentProtocolEncoding.minor
         ) {
             throw new MarshalException(
                 `Invalid protocol encoding version in message header: ${encodingVersion.major}.${encodingVersion.minor}`,


### PR DESCRIPTION
## Summary
- Fix two locations that incorrectly compare `protocolVersion.minor` instead of `encodingVersion.minor` when validating the encoding version in message headers (#5078)

Fixes #5078