### PR TITLE
Fix exception chaining to use { cause: ex } consistently

### DIFF
--- a/js/packages/ice/src/Ice/Protocol.js
+++ b/js/packages/ice/src/Ice/Protocol.js
@@ -186,7 +186,7 @@ function stringToMajor(str) {
         }
         return majVersion;
     } catch (ex) {
-        throw new ParseException(`invalid version value in '${str}'`, ex);
+        throw new ParseException(`invalid version value in '${str}'`, { cause: ex });
     }
 }
 
@@ -203,7 +203,7 @@ function stringToMinor(str) {
         }
         return minVersion;
     } catch (ex) {
-        throw new ParseException(`invalid version value in '${str}'`, ex);
+        throw new ParseException(`invalid version value in '${str}'`, { cause: ex });
     }
 }
 

--- a/js/packages/ice/src/Ice/ReferenceFactory.js
+++ b/js/packages/ice/src/Ice/ReferenceFactory.js
@@ -210,7 +210,7 @@ export class ReferenceFactory {
                     try {
                         facet = StringUtil.unescapeString(argument, 0, argument.length);
                     } catch (ex) {
-                        throw new ParseException(`invalid facet in ${s}': `, ex);
+                        throw new ParseException(`invalid facet in ${s}': `, { cause: ex });
                     }
 
                     break;
@@ -272,7 +272,7 @@ export class ReferenceFactory {
                     try {
                         encoding = stringToEncodingVersion(argument);
                     } catch (e) {
-                        throw new ParseException(`invalid encoding version '${argument}' in '${s}'`, e);
+                        throw new ParseException(`invalid encoding version '${argument}' in '${s}'`, { cause: e });
                     }
                     break;
                 }
@@ -287,7 +287,7 @@ export class ReferenceFactory {
                     } catch (
                         e // ParseException
                     ) {
-                        throw new ParseException(`invalid protocol version '${argument}' in '${s}'`, e);
+                        throw new ParseException(`invalid protocol version '${argument}' in '${s}'`, { cause: e });
                     }
                     break;
                 }
@@ -397,7 +397,7 @@ export class ReferenceFactory {
             try {
                 adapter = StringUtil.unescapeString(adapterstr, 0, adapterstr.length);
             } catch (ex) {
-                throw new ParseException(`invalid adapter id in '${s}'`, ex);
+                throw new ParseException(`invalid adapter id in '${s}'`, { cause: ex });
             }
             if (adapter.length === 0) {
                 throw new ParseException(`empty adapter id in '${s}'`);


### PR DESCRIPTION
## Summary
- Fix 6 call sites in `Protocol.js` and `ReferenceFactory.js` that pass the original exception directly as the second argument to `ParseException` constructors instead of wrapping it in `{ cause: ex }` (#5085)

## Test plan
- [ ] Verify that exceptions thrown from version parsing preserve the original cause
- [ ] Verify that exceptions thrown from proxy string parsing preserve the original cause

Fixes #5085

🤖 Generated with [Claude Code](https://claude.com/claude-code)