### PR TITLE
Remove Number.isNaN polyfill for IE

### DIFF
--- a/js/src/Ice/Stream.js
+++ b/js/src/Ice/Stream.js
@@ -41,16 +41,6 @@ const SliceType =
 };
 
 //
-// Number.isNaN polyfill for compatibility with IE
-//
-// see: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN
-//
-Number.isNaN = Number.isNaN || function(value)
-{
-    return typeof value === "number" && isNaN(value);
-};
-
-//
 // InputStream
 //
 


### PR DESCRIPTION
All platforms supported by Ice 3.7.11 natively support Number.isNaN, so the IE compatibility polyfill is no longer needed.