### PR TITLE
Fix dangling pointer in Schannel hostname verification

### DIFF
--- a/cpp/src/Ice/SSL/SchannelEngine.cpp
+++ b/cpp/src/Ice/SSL/SchannelEngine.cpp
@@ -1408,7 +1408,8 @@ Schannel::SSLEngine::validationCallback(
         extraPolicyPara.dwAuthType = incoming ? AUTHTYPE_CLIENT : AUTHTYPE_SERVER;
         // Disable because the policy only matches the CN of the certificate, not the SAN.
         extraPolicyPara.fdwChecks = SECURITY_FLAG_IGNORE_CERT_CN_INVALID;
-        extraPolicyPara.pwszServerName = const_cast<wchar_t*>(Ice::stringToWstring(host).c_str());
+        wstring hostW = Ice::stringToWstring(host);
+        extraPolicyPara.pwszServerName = const_cast<wchar_t*>(hostW.c_str());
 
         CERT_CHAIN_POLICY_PARA policyPara;
         memset(&policyPara, 0, sizeof(policyPara));


### PR DESCRIPTION
## Summary

Fixed a dangling pointer in Schannel hostname verification. `Ice::stringToWstring(host)` returned a
temporary `wstring` whose `.c_str()` was stored in `extraPolicyPara.pwszServerName`, but the temporary
was destroyed at the semicolon, leaving a dangling pointer read by `CertVerifyCertificateChainPolicy`.

Fix: store the `wstring` in a local variable to keep it alive through the API call.

In practice, the dangling pointer almost certainly still pointed at the correct string data since the
memory was just freed and the window before the API reads it is very small (a few lines of `memset` +
one function call). This is still undefined behavior and the fix is straightforward.

Fixes #5096