### PR TITLE
Fix RFC2253 hex pair parsing and unescaping

### DIFF
--- a/cpp/src/Ice/SSL/RFC2253.cpp
+++ b/cpp/src/Ice/SSL/RFC2253.cpp
@@ -146,7 +146,7 @@ RFC2253::unescape(const string& data)
                 {
                     throw ParseException(__FILE__, __LINE__, "unescape: invalid escape sequence");
                 }
-                if (special.find(data[pos]) != string::npos || data[pos] != '\\' || data[pos] != '"')
+                if (special.find(data[pos]) != string::npos || data[pos] == '\\' || data[pos] == '"')
                 {
                     result += data[pos];
                     ++pos;
@@ -185,7 +185,7 @@ static char
 unescapeHex(const string& data, size_t pos)
 {
     assert(pos < data.size());
-    if (pos + 2 >= data.size())
+    if (pos + 2 > data.size())
     {
         throw Ice::ParseException(__FILE__, __LINE__, "unescape: invalid hex pair");
     }
@@ -431,7 +431,7 @@ parsePair(const string& data, size_t& pos)
         throw Ice::ParseException(__FILE__, __LINE__, "invalid escape format (unexpected end of data)");
     }
 
-    if (special.find(data[pos]) != string::npos || data[pos] != '\\' || data[pos] != '"')
+    if (special.find(data[pos]) != string::npos || data[pos] == '\\' || data[pos] == '"')
     {
         result += data[pos];
         ++pos;


### PR DESCRIPTION
## Summary
- Fix tautological conditions in `unescape()` and `parsePair()` in `RFC2253.cpp` where `!= '\\' || != '"'` was always true, making hex pair handling dead code
- Fix off-by-one in `unescapeHex()` bounds check that rejected valid hex pairs at end of string
- These bugs affect DN matching used by TrustManager for accept/reject decisions

Fixes #5096

## Test plan
- [ ] Run SSL trust manager tests
- [ ] Test with certificates containing hex-escaped DN values
- [ ] Verify TrustManager accept/reject rules work correctly with hex-encoded DNs

🤖 Generated with [Claude Code](https://claude.com/claude-code)