### PR TITLE
Fix private key loading loop always reading index 0

### DIFF
--- a/cpp/src/Ice/SSL/SecureTransportUtil.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportUtil.cpp
@@ -481,7 +481,7 @@ namespace
         UniqueRef<SecKeyRef> key;
         for (CFIndex i = 0; i < count; ++i)
         {
-            auto itemRef = static_cast<SecKeychainItemRef>(const_cast<void*>(CFArrayGetValueAtIndex(items.get(), 0)));
+            auto itemRef = static_cast<SecKeychainItemRef>(const_cast<void*>(CFArrayGetValueAtIndex(items.get(), i)));
             if (SecKeyGetTypeID() == CFGetTypeID(itemRef))
             {
                 key.retain(reinterpret_cast<SecKeyRef>(itemRef));


### PR DESCRIPTION
## Summary
- Fix loop bug in `SecureTransportUtil.cpp:484` where `CFArrayGetValueAtIndex(items.get(), 0)` should use the loop variable `i`
- The loop iterates with `i` but always reads index 0, so private keys not at index 0 are never found

Fixes #5096

## Test plan
- [ ] Run SecureTransport SSL tests on macOS
- [ ] Test with keychain items where the private key is not the first item

🤖 Generated with [Claude Code](https://claude.com/claude-code)