### PR TITLE
Initialize SSL member variables to prevent undefined behavior

### DIFF
--- a/cpp/src/Ice/SSL/SSLEngine.h
+++ b/cpp/src/Ice/SSL/SSLEngine.h
@@ -60,9 +60,9 @@ namespace Ice::SSL
 
         std::string _password;
 
-        bool _checkCertName;
-        int _verifyPeer;
-        int _securityTraceLevel;
+        bool _checkCertName{false};
+        int _verifyPeer{0};
+        int _securityTraceLevel{0};
         std::string _securityTraceCategory;
         const bool _revocationCheckCacheOnly{false};
         const int _revocationCheck{0};

--- a/cpp/src/Ice/SSL/SecureTransportTransceiverI.h
+++ b/cpp/src/Ice/SSL/SecureTransportTransceiverI.h
@@ -72,7 +72,7 @@ namespace Ice::SSL::SecureTransport
             SSLWantWrite = 0x2
         };
 
-        mutable std::uint8_t _tflags;
+        mutable std::uint8_t _tflags{0};
         IceInternal::UniqueRef<SecCertificateRef> _peerCertificate;
         size_t _buffered;
         std::function<void(SSLContextRef, const std::string&)> _sslNewSessionCallback;


### PR DESCRIPTION
## Summary
- Add in-class initializer `{0}` to `_tflags` in `SecureTransportTransceiverI.h` — controls SSL I/O read/write state flags
- Add in-class initializers to `_checkCertName`, `_verifyPeer`, `_securityTraceLevel` in `SSLEngine.h` — only set in `initialize()`, previously undefined if read before that

Fixes #5097

## Test plan
- [ ] Run SSL tests across all platforms
- [ ] Verify no behavioral changes in normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)