### PR TITLE
Replace assert with runtime check for peer trust in SecureTransport

### DIFF
--- a/cpp/src/Ice/SSL/SecureTransportEngine.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportEngine.cpp
@@ -750,7 +750,10 @@ SecureTransport::SSLEngine::validationCallback(SecTrustRef trust, const Connecti
 {
     OSStatus err = noErr;
     UniqueRef<CFErrorRef> trustErr;
-    assert(trust);
+    if (!trust)
+    {
+        throw SecurityException(__FILE__, __LINE__, "SSL transport: peer trust is null");
+    }
 
     // Do not allow to fetch missing intermediate certificates from the network.
     if ((err = SecTrustSetNetworkFetchAllowed(trust, false)))


### PR DESCRIPTION
## Summary
- Replace `assert(trust)` with a runtime `SecurityException` check in `SecureTransportEngine.cpp` `validationCallback`
- `assert` is compiled out in release builds (`NDEBUG`), which would cause undefined behavior if `trust` is null

Fixes #5097

## Test plan
- [ ] Run SecureTransport SSL tests on macOS
- [ ] Verify certificate validation still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)