### PR TITLE
Delete copy and move operations on ScopedCertificate wrappers

### DIFF
--- a/cpp/src/Ice/SSL/SSLEngine.cpp
+++ b/cpp/src/Ice/SSL/SSLEngine.cpp
@@ -59,8 +59,9 @@ Ice::SSL::SSLEngine::initialize()
     _securityTraceLevel = properties->getIcePropertyAsInt("IceSSL.Trace.Security");
     _securityTraceCategory = "Security";
 
-    _revocationCheckCacheOnly = properties->getIcePropertyAsInt("IceSSL.RevocationCheckCacheOnly") > 0;
-    _revocationCheck = properties->getIcePropertyAsInt("IceSSL.RevocationCheck");
+    const_cast<bool&>(_revocationCheckCacheOnly) =
+        properties->getIcePropertyAsInt("IceSSL.RevocationCheckCacheOnly") > 0;
+    const_cast<int&>(_revocationCheck) = properties->getIcePropertyAsInt("IceSSL.RevocationCheck");
 }
 
 void

--- a/cpp/src/Ice/SSL/SSLEngine.h
+++ b/cpp/src/Ice/SSL/SSLEngine.h
@@ -64,8 +64,8 @@ namespace Ice::SSL
         int _verifyPeer;
         int _securityTraceLevel;
         std::string _securityTraceCategory;
-        bool _revocationCheckCacheOnly{false};
-        int _revocationCheck{0};
+        const bool _revocationCheckCacheOnly{false};
+        const int _revocationCheck{0};
     };
 }
 


### PR DESCRIPTION
## Summary
- Delete copy constructor, copy assignment, move constructor, and move assignment on all three `ScopedCertificate` RAII wrappers to prevent potential double-free

Fixes #5099

## Test plan
- [ ] Build on all platforms
- [ ] Run SSL tests to verify no behavioral changes