### PR TITLE
Simplify DN escaping in SecureTransport

### DIFF
--- a/cpp/src/Ice/SSL/SecureTransportUtil.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportUtil.cpp
@@ -72,23 +72,9 @@ namespace
         ostringstream os;
         for (char i : name)
         {
-            switch (i)
+            if (i == ',' || i == '=' || i == '+' || i == '<' || i == '>' || i == '#' || i == ';')
             {
-                case ',':
-                case '=':
-                case '+':
-                case '<':
-                case '>':
-                case '#':
-                case ';':
-                {
-                    os << '\\';
-                    [[fallthrough]];
-                }
-                default:
-                {
-                    break;
-                }
+                os << '\\';
             }
             os << i;
         }


### PR DESCRIPTION
## Summary
- Replace switch/fallthrough with a simple `if` statement in `escapeX509Name` in `SecureTransportUtil.cpp`
- The switch was unnecessarily complex — special character cases fell through to `default: break`, which is equivalent to an `if` check

Fixes #5099

## Test plan
- [ ] Build on macOS to verify no compiler warnings
- [ ] Run SecureTransport SSL tests