### PR TITLE
Fix Java/C# RFC2253 tautological conditions and off-by-one in hex parsing

### DIFF
--- a/csharp/src/Ice/SSL/RFC2253.cs
+++ b/csharp/src/Ice/SSL/RFC2253.cs
@@ -131,7 +131,7 @@ internal class RFC2253
                     {
                         throw new ParseException("unescape: invalid escape sequence");
                     }
-                    if (special.Contains(data[pos], StringComparison.Ordinal) || data[pos] != '\\' || data[pos] != '"')
+                    if (special.Contains(data[pos], StringComparison.Ordinal) || data[pos] == '\\' || data[pos] == '"')
                     {
                         result.Append(data[pos]);
                         ++pos;
@@ -167,7 +167,7 @@ internal class RFC2253
     private static char unescapeHex(string data, int pos)
     {
         Debug.Assert(pos < data.Length);
-        if (pos + 2 >= data.Length)
+        if (pos + 2 > data.Length)
         {
             throw new ParseException("unescape: invalid hex pair");
         }
@@ -400,8 +400,8 @@ internal class RFC2253
             throw new ParseException("invalid escape format (unexpected end of data)");
         }
 
-        if (special.Contains(data[pos], StringComparison.Ordinal) || data[pos] != '\\' ||
-           data[pos] != '"')
+        if (special.Contains(data[pos], StringComparison.Ordinal) || data[pos] == '\\' ||
+           data[pos] == '"')
         {
             result += data[pos];
             ++pos;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/RFC2253.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/RFC2253.java
@@ -258,8 +258,8 @@ class RFC2253 {
         }
 
         if (special.indexOf(state.data.charAt(state.pos)) != -1
-            || state.data.charAt(state.pos) != '\\'
-            || state.data.charAt(state.pos) != '"') {
+            || state.data.charAt(state.pos) == '\\'
+            || state.data.charAt(state.pos) == '"') {
             result += state.data.charAt(state.pos);
             ++state.pos;
             return result;


### PR DESCRIPTION
## Summary
- **Java RFC2253.java parsePair()**: Fix tautological condition `!= '\\' || != '"'` (always true) that makes hex pair parsing dead code. Change to `== '\\' || == '"'`.
- **C# RFC2253.cs unescape()**: Same tautological bug — hex pair unescaping is dead code.
- **C# RFC2253.cs parsePair()**: Same tautological bug — hex pair parsing is dead code.
- **C# RFC2253.cs unescapeHex()**: Fix off-by-one `pos + 2 >= data.Length` that rejects valid hex pairs at end of string. Should be `pos + 2 > data.Length`.

Same family of bugs as C++ PR #5103.

Closes #5113

## Test plan
- [ ] Verify Java and C# SSL tests pass
- [ ] Test with certificates containing hex-escaped DN components
- [ ] Verify trust manager DN matching works with hex pairs in subject DN

🤖 Generated with [Claude Code](https://claude.com/claude-code)