### PR TITLE
Fix Java SSLParameters overwrite that resets cipher suites and protocols

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/SSLEngine.java
@@ -315,7 +315,7 @@ public class SSLEngine {
         } else {
             // Enable the HTTPS hostname verification algorithm
             if (_checkCertName && _verifyPeer > 0 && host != null) {
-                SSLParameters params = new SSLParameters();
+                SSLParameters params = engine.getSSLParameters();
                 params.setEndpointIdentificationAlgorithm("HTTPS");
                 engine.setSSLParameters(params);
             }


### PR DESCRIPTION
## Summary
- Fix: use `engine.getSSLParameters()` instead of `new SSLParameters()` to preserve existing SSL engine settings when enabling HTTPS endpoint identification for `CheckCertName`
- This is consistent with the SNI code block at line 329 which already uses `engine.getSSLParameters()`

### Impact analysis
Java's `SSLEngine.setSSLParameters()` has null guards for several fields (cipher suites, protocols, server names, SNI matchers, algorithm constraints) — if the value in the `SSLParameters` is null, it is **not** applied. Since `new SSLParameters()` returns null for all of these, they are not actually reset.

However, some fields are **unconditionally** applied by `setSSLParameters()`:
- `needClientAuth` / `wantClientAuth` — reset to false (no impact for a client engine)
- `applicationProtocols` (ALPN) — reset to empty array
- `preferLocalCipherSuites` — reset to false
- `enableRetransmissions` — reset to true
- `maximumPacketSize` — reset to 0

The practical impact is limited for the current Ice codebase since Ice doesn't configure ALPN or these other fields. The fix is still the correct best practice — `getSSLParameters()` preserves all current engine state and is future-proof against new fields being added to `SSLParameters`.

### Code path
This bug only affects the property-based configuration path (when `clientSSLEngineFactory` is **not** set). When users provide a custom `clientSSLEngineFactory`, Ice's internal `createSSLEngine` is never called.