### PR TITLE
Fix C# and Java TrustManager to reject connections on DN parse failure

### DIFF
--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/TrustManager.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/SSL/TrustManager.java
@@ -101,63 +101,70 @@ class TrustManager {
             X500Principal subjectDN = ((X509Certificate) info.certs[0]).getSubjectX500Principal();
             String subjectName = subjectDN.getName(X500Principal.RFC2253);
             assert subjectName != null;
+            // Decompose the subject DN into the RDNs.
+            if (_traceLevel > 0) {
+                if (info.incoming) {
+                    _communicator
+                        .getLogger()
+                        .trace(
+                            "Security",
+                            "trust manager evaluating client:\n"
+                                + "subject = "
+                                + subjectName
+                                + "\n"
+                                + "adapter = "
+                                + info.adapterName
+                                + "\n"
+                                + desc);
+                } else {
+                    _communicator
+                        .getLogger()
+                        .trace(
+                            "Security",
+                            "trust manager evaluating server:\n"
+                                + "subject = "
+                                + subjectName
+                                + "\n"
+                                + desc);
+                }
+            }
+
+            List<RFC2253.RDNPair> dn;
             try {
-                // Decompose the subject DN into the RDNs.
-                if (_traceLevel > 0) {
-                    if (info.incoming) {
-                        _communicator
-                            .getLogger()
-                            .trace(
-                                "Security",
-                                "trust manager evaluating client:\n"
-                                    + "subject = "
-                                    + subjectName
-                                    + "\n"
-                                    + "adapter = "
-                                    + info.adapterName
-                                    + "\n"
-                                    + desc);
-                    } else {
-                        _communicator
-                            .getLogger()
-                            .trace(
-                                "Security",
-                                "trust manager evaluating server:\n"
-                                    + "subject = "
-                                    + subjectName
-                                    + "\n"
-                                    + desc);
-                    }
-                }
-                List<RFC2253.RDNPair> dn = RFC2253.parseStrict(subjectName);
-
-                // Fail if we match anything in the reject set.
-                for (List<List<RFC2253.RDNPair>> matchSet : reject) {
-                    if (_traceLevel > 1) {
-                        StringBuilder s = new StringBuilder("trust manager rejecting PDNs:\n");
-                        stringify(matchSet, s);
-                        _communicator.getLogger().trace("Security", s.toString());
-                    }
-                    if (match(matchSet, dn)) {
-                        return false;
-                    }
-                }
-
-                // Succeed if we match anything in the accept set.
-                for (List<List<RFC2253.RDNPair>> matchSet : accept) {
-                    if (_traceLevel > 1) {
-                        StringBuilder s = new StringBuilder("trust manager accepting PDNs:\n");
-                        stringify(matchSet, s);
-                        _communicator.getLogger().trace("Security", s.toString());
-                    }
-                    if (match(matchSet, dn)) {
-                        return true;
-                    }
-                }
+                dn = RFC2253.parseStrict(subjectName);
             } catch (ParseException ex) {
-                String m = "Ice.SSL: unable to parse certificate DN `" + subjectName + "'\nreason: " + ex.getMessage();
-                _communicator.getLogger().warning(m);
+                _communicator
+                    .getLogger()
+                    .warning(
+                        "Ice.SSL: unable to parse certificate DN `"
+                            + subjectName
+                            + "'\nreason: "
+                            + ex.getMessage());
                 return false;
+            }
+
+            // Fail if we match anything in the reject set.
+            for (List<List<RFC2253.RDNPair>> matchSet : reject) {
+                if (_traceLevel > 1) {
+                    StringBuilder s = new StringBuilder("trust manager rejecting PDNs:\n");
+                    stringify(matchSet, s);
+                    _communicator.getLogger().trace("Security", s.toString());
+                }
+                if (match(matchSet, dn)) {
+                    return false;
+                }
+            }
+
+            // Succeed if we match anything in the accept set.
+            for (List<List<RFC2253.RDNPair>> matchSet : accept) {
+                if (_traceLevel > 1) {
+                    StringBuilder s = new StringBuilder("trust manager accepting PDNs:\n");
+                    stringify(matchSet, s);
+                    _communicator.getLogger().trace("Security", s.toString());
+                }
+                if (match(matchSet, dn)) {
+                    return true;
+                }
             }
 
             // At this point we accept the connection if there are no explicit accept rules.


### PR DESCRIPTION
## Summary

Fixed the TrustManager in C# and Java to properly handle the rare situation where Ice's strict RFC 2253
parser cannot parse a certificate's subject DN string produced by the platform's SSL stack
(`X500Principal.getName(RFC2253)` in Java, `X500DistinguishedName.Name` in C#).

Previously, the `ParseException` was caught in a block that wrapped the entire accept/reject evaluation
logic. After catching, execution fell through to `return accept.isEmpty()`. If only reject rules were
configured (no accept rules), the connection was silently accepted — effectively bypassing the
`IceSSL.TrustOnly` reject rules.

Note that the TrustManager runs after standard SSL/TLS certificate verification has already succeeded, so
the certificate is already trusted by the platform. This bug could only be triggered by a discrepancy
between the platform's DN serialization and Ice's strict RFC 2253 parser, not by a malformed certificate.

Fix: catch the `ParseException` immediately after parsing the DN and return `false` (reject), rather than
letting execution fall through.