### PR TITLE
Remove hardcoded CertificateRevocationCheckMode from C# server SSL options

### DIFF
--- a/csharp/src/Ice/SSL/SSLEngine.cs
+++ b/csharp/src/Ice/SSL/SSLEngine.cs
@@ -274,7 +274,6 @@ internal class SSLEngine
             ServerCertificate = cert,
             ClientCertificateRequired = _verifyPeer > 0,
             RemoteCertificateValidationCallback = remoteCertificateValidationCallback,
-            CertificateRevocationCheckMode = X509RevocationMode.NoCheck
         };
 
         authenticationOptions.CertificateChainPolicy = new X509ChainPolicy();


### PR DESCRIPTION
## Summary
- `SslServerAuthenticationOptions` initializer hardcodes `CertificateRevocationCheckMode = X509RevocationMode.NoCheck`
- Since `CertificateChainPolicy` is always set, .NET [ignores `CertificateRevocationCheckMode`](https://learn.microsoft.com/en-us/dotnet/api/system.net.security.sslserverauthenticationoptions.certificatechainpolicy#remarks) — making this dead code
- The client path does not set `CertificateRevocationCheckMode` at all
- Fix: remove the dead initializer for clarity and consistency with the client path