### PR TITLE
Clarify that hRootStore from credentials callback is not used for validation

### DIFF
--- a/cpp/include/Ice/SSL/ClientAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ClientAuthenticationOptions.h
@@ -32,10 +32,10 @@ namespace Ice::SSL
         ///
         /// This callback is invoked by the SSL transport for each new outgoing connection before starting the SSL
         /// handshake to determine the appropriate client credentials. The callback must return a `SCH_CREDENTIALS` that
-        /// represents the client's credentials. The SSL transport takes ownership of the credentials' `paCred` and
-        /// `hRootStore` members and releases them when the connection is closed. Note that the `hRootStore` from the
-        /// returned credentials is not used for certificate validation; use `trustedRootCertificates` or
-        /// `serverCertificateValidationCallback` instead.
+        /// represents the client's credentials. The SSL transport takes ownership of the credentials' `paCred`
+        /// member and releases it when the connection is closed. The `hRootStore` from the returned credentials is not
+        /// used for certificate validation; use `trustedRootCertificates` or `serverCertificateValidationCallback`
+        /// instead.
         ///
         /// @param host The target host name.
         /// @return The client SSL credentials.

--- a/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
@@ -33,10 +33,10 @@ namespace Ice::SSL
         ///
         /// This callback is invoked by the SSL transport for each new incoming connection before starting the SSL
         /// handshake to determine the appropriate server credentials. The callback must return a `SCH_CREDENTIALS` that
-        /// represents the server's credentials. The SSL transport takes ownership of the credentials' `paCred` and
-        /// `hRootStore` members and releases them when the connection is closed. Note that the `hRootStore` from the
-        /// returned credentials is not used for certificate validation; use `trustedRootCertificates` or
-        /// `clientCertificateValidationCallback` instead.
+        /// represents the server's credentials. The SSL transport takes ownership of the credentials' `paCred`
+        /// member and releases it when the connection is closed. The `hRootStore` from the returned credentials is not
+        /// used for certificate validation; use `trustedRootCertificates` or `clientCertificateValidationCallback`
+        /// instead.
         ///
         /// @param adapterName The name of the object adapter that accepted the connection.
         /// @return The server SSL credentials.


### PR DESCRIPTION
## Summary
- Document in both `SchannelServerAuthenticationOptions` and `SchannelClientAuthenticationOptions` that the `hRootStore` member of the `SCH_CREDENTIALS` returned by the credentials selection callback is not used for certificate validation
- Users should use `trustedRootCertificates` or the validation callback instead

Follows up on the discussion in #5121.