### PR TITLE
Fix multiple bugs in iceserviceinstall ServiceInstaller

### DIFF
--- a/cpp/src/iceserviceinstall/ServiceInstaller.cpp
+++ b/cpp/src/iceserviceinstall/ServiceInstaller.cpp
@@ -190,7 +190,7 @@ IceServiceInstaller::install(const PropertiesPtr& properties)
         }
     }
 
-    if (!_configFile.find("HKLM\\") == 0)
+    if (_configFile.find("HKLM\\") != 0)
     {
         grantPermissions(_configFile);
     }
@@ -245,7 +245,7 @@ IceServiceInstaller::install(const PropertiesPtr& properties)
     //
     // Get the full path of config file.
     //
-    if (!_configFile.find("HKLM\\") == 0)
+    if (_configFile.find("HKLM\\") != 0)
     {
         char fullPath[MAX_PATH];
         if (GetFullPathName(_configFile.c_str(), MAX_PATH, fullPath, 0) > MAX_PATH)
@@ -447,7 +447,7 @@ IceServiceInstaller::getServiceInstallerPath()
     }
 
     string path = wstringToString(buffer);
-    assert(path.find_last_of("/\\"));
+    assert(path.find_last_of("/\\") != string::npos);
     return path.substr(0, path.find_last_of("/\\"));
 }
 
@@ -804,13 +804,14 @@ IceServiceInstaller::addSource(const string& source, const string& log, const st
     // the "EventMessageFile" key should contain the path to this
     // DLL.
     //
+    wstring wResourceFile = stringToWstring(resourceFile);
     res = RegSetValueExW(
         key,
         L"EventMessageFile",
         0,
         REG_EXPAND_SZ,
-        reinterpret_cast<const BYTE*>(stringToWstring(resourceFile).c_str()),
-        static_cast<DWORD>(resourceFile.length() + 1) * sizeof(wchar_t));
+        reinterpret_cast<const BYTE*>(wResourceFile.c_str()),
+        static_cast<DWORD>((wResourceFile.length() + 1) * sizeof(wchar_t)));
 
     if (res == ERROR_SUCCESS)
     {

--- a/cpp/src/iceserviceinstall/ServiceInstaller.h
+++ b/cpp/src/iceserviceinstall/ServiceInstaller.h
@@ -29,7 +29,6 @@ public:
 private:
     void initializeSid(const std::string&);
 
-    bool fileExists(const std::string&) const;
     void grantPermissions(
         const std::string& path,
         SE_OBJECT_TYPE type = SE_FILE_OBJECT,


### PR DESCRIPTION
## Summary

- Fix operator precedence bug where `!_configFile.find("HKLM\\") == 0` was parsed as `(!_configFile.find("HKLM\\")) == 0`, inverting the starts-with test at two locations (#5123)
- Fix `assert` in `getServiceInstallerPath` to check `!= string::npos` instead of truthiness (#5125)
- Fix `RegSetValueExW` buffer overread for non-ASCII paths by computing size from the wide string length instead of the narrow string length (#5126)
- Remove dead `fileExists` declaration from `ServiceInstaller.h` (never defined)

## Test plan

- [ ] Verify iceserviceinstall builds on Windows
- [ ] Test service installation with file-based config (non-HKLM path) — `grantPermissions` and `GetFullPathName` should now be called correctly
- [ ] Test service installation with HKLM registry config path — should skip file operations
- [ ] Test with non-ASCII characters in resource file path to verify `RegSetValueExW` uses correct buffer size

🤖 Generated with [Claude Code](https://claude.com/claude-code)