### PR TITLE
Fix Schannel to use callback's hRootStore for certificate validation

### DIFF
--- a/cpp/include/Ice/SSL/ClientAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ClientAuthenticationOptions.h
@@ -32,10 +32,13 @@ namespace Ice::SSL
         ///
         /// This callback is invoked by the SSL transport for each new outgoing connection before starting the SSL
         /// handshake to determine the appropriate client credentials. The callback must return a `SCH_CREDENTIALS` that
-        /// represents the client's credentials. The SSL transport takes ownership of the credentials' `paCred`
-        /// member and releases it when the connection is closed. The `hRootStore` from the returned credentials is not
-        /// used for certificate validation; use `trustedRootCertificates` or `serverCertificateValidationCallback`
-        /// instead.
+        /// represents the client's credentials. The SSL transport takes ownership of the credentials' `paCred` and
+        /// `hRootStore` members and releases them when the connection is closed.
+        ///
+        /// If the returned credentials include an `hRootStore`, it takes precedence over `trustedRootCertificates` for
+        /// server certificate validation. This allows the callback to dynamically select the trusted root certificates
+        /// on a per-connection basis. When `hRootStore` is not set by the callback, `trustedRootCertificates` is used
+        /// instead; if neither is set, the system's default root certificates are used.
         ///
         /// @param host The target host name.
         /// @return The client SSL credentials.
@@ -59,6 +62,8 @@ namespace Ice::SSL
         /// The trusted root certificates used for validating the server's certificate chain. If this field is set, the
         /// server's certificate chain is validated against these certificates; otherwise, the system's default root
         /// certificates are used.
+        ///
+        /// If the credentials selection callback returns an `hRootStore`, that store takes precedence over this field.
         ///
         /// Example of setting `trustedRootCertificates`:
         /// @snippet Ice/SSL/SchannelClientAuthenticationOptions.cpp trustedRootCertificates

--- a/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
@@ -33,10 +33,13 @@ namespace Ice::SSL
         ///
         /// This callback is invoked by the SSL transport for each new incoming connection before starting the SSL
         /// handshake to determine the appropriate server credentials. The callback must return a `SCH_CREDENTIALS` that
-        /// represents the server's credentials. The SSL transport takes ownership of the credentials' `paCred`
-        /// member and releases it when the connection is closed. The `hRootStore` from the returned credentials is not
-        /// used for certificate validation; use `trustedRootCertificates` or `clientCertificateValidationCallback`
-        /// instead.
+        /// represents the server's credentials. The SSL transport takes ownership of the credentials' `paCred` and
+        /// `hRootStore` members and releases them when the connection is closed.
+        ///
+        /// If the returned credentials include an `hRootStore`, it takes precedence over `trustedRootCertificates` for
+        /// client certificate validation. This allows the callback to dynamically select the trusted root certificates
+        /// on a per-connection basis. When `hRootStore` is not set by the callback, `trustedRootCertificates` is used
+        /// instead; if neither is set, the system's default root certificates are used.
         ///
         /// @param adapterName The name of the object adapter that accepted the connection.
         /// @return The server SSL credentials.
@@ -63,6 +66,8 @@ namespace Ice::SSL
         /// The trusted root certificates used for validating the client's certificate chain. If this field is set, the
         /// client's certificate chain is validated against these certificates; otherwise, the system's default root
         /// certificates are used.
+        ///
+        /// If the credentials selection callback returns an `hRootStore`, that store takes precedence over this field.
         ///
         /// Example of setting `trustedRootCertificates`:
         /// @snippet Ice/SSL/SchannelServerAuthenticationOptions.cpp trustedRootCertificates

--- a/cpp/src/Ice/SSL/SchannelTransceiverI.h
+++ b/cpp/src/Ice/SSL/SchannelTransceiverI.h
@@ -105,11 +105,11 @@ namespace Ice::SSL::Schannel
         HCERTSTORE _rootStore;
         CtxtHandle _ssl;
 
-        // The chain engine used to verify the peer certificate. If the user has not provided a remote certificate
-        // validation callback, we use this chain engine to validate the peer certificate.
-        // When the user provides a trusted root certificates stores, this chain engine is configured to exclusively
-        // trust the users provided root store.
+        // The chain engine used to verify the peer certificate with the default validation callback. Created lazily
+        // during the SSL handshake from _credentials.hRootStore so that it respects the root store provided by the
+        // credentials selection callback.
         HCERTCHAINENGINE _chainEngine;
+        bool _initDefaultChainEngine;
     };
     using TransceiverIPtr = std::shared_ptr<TransceiverI>;
 }


### PR DESCRIPTION
## Summary

- Defer chain engine creation from constructor to SSL handshake time so it uses the final `hRootStore` value from `_credentials` (which may have been set by the credentials selection callback)
- The callback's `hRootStore` now takes precedence over `trustedRootCertificates` for certificate validation on both client and server sides
- Update documentation in `ClientAuthenticationOptions.h` and `ServerAuthenticationOptions.h` to reflect the `hRootStore` precedence behavior
- Add 4 new Schannel tests: basic callback `hRootStore` usage (client + server) and precedence over `trustedRootCertificates` (client + server)

## Test plan

- [ ] Build on Windows and run IceSSL configuration tests
- [ ] Verify the 4 new tests pass: `clientValidatesServerSettingCallbackRootStore`, `serverValidatesClientSettingCallbackRootStore`, `clientValidatesServerCallbackRootStoreTakesPrecedence`, `serverValidatesClientCallbackRootStoreTakesPrecedence`
- [ ] Verify existing Schannel tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)