### PR TITLE
Clarify Schannel credentials callback docs and hRootStore handling

### DIFF
--- a/cpp/include/Ice/SSL/ClientAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ClientAuthenticationOptions.h
@@ -32,10 +32,13 @@ namespace Ice::SSL
         ///
         /// This callback is invoked by the SSL transport for each new outgoing connection before starting the SSL
         /// handshake to determine the appropriate client credentials. The callback must return a `SCH_CREDENTIALS` that
-        /// represents the client's credentials. The SSL transport takes ownership of the credentials' `paCred`
-        /// member and releases it when the connection is closed. The `hRootStore` from the returned credentials is not
-        /// used for certificate validation; use `trustedRootCertificates` or `serverCertificateValidationCallback`
-        /// instead.
+        /// represents the client's credentials. The returned credentials are passed to [AcquireCredentialsHandle] to
+        /// create the credential handle for the connection; see the Schannel documentation for details on the
+        /// available fields. The SSL transport takes ownership of the credentials' `paCred` and `hRootStore` members
+        /// and releases them when the connection is closed.
+        ///
+        /// Certificate validation is not performed through the returned credentials. Use `trustedRootCertificates`
+        /// or `serverCertificateValidationCallback` instead.
         ///
         /// @param host The target host name.
         /// @return The client SSL credentials.
@@ -44,9 +47,12 @@ namespace Ice::SSL
         /// @snippet Ice/SSL/SchannelClientAuthenticationOptions.cpp clientCertificateSelectionCallback
         ///
         /// @see [SCH_CREDENTIALS]
+        /// @see [AcquireCredentialsHandle]
         ///
         /// [SCH_CREDENTIALS]:
         /// https://learn.microsoft.com/en-us/windows/win32/api/schannel/ns-schannel-sch_credentials
+        /// [AcquireCredentialsHandle]:
+        /// https://learn.microsoft.com/en-us/windows/win32/secauthn/acquirecredentialshandle--schannel
         std::function<SCH_CREDENTIALS(const std::string& host)> clientCredentialsSelectionCallback;
 
         /// A callback invoked before initiating a new SSL handshake, providing an opportunity to customize the SSL

--- a/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
+++ b/cpp/include/Ice/SSL/ServerAuthenticationOptions.h
@@ -33,10 +33,13 @@ namespace Ice::SSL
         ///
         /// This callback is invoked by the SSL transport for each new incoming connection before starting the SSL
         /// handshake to determine the appropriate server credentials. The callback must return a `SCH_CREDENTIALS` that
-        /// represents the server's credentials. The SSL transport takes ownership of the credentials' `paCred`
-        /// member and releases it when the connection is closed. The `hRootStore` from the returned credentials is not
-        /// used for certificate validation; use `trustedRootCertificates` or `clientCertificateValidationCallback`
-        /// instead.
+        /// represents the server's credentials. The returned credentials are passed to [AcquireCredentialsHandle] to
+        /// create the credential handle for the connection; see the Schannel documentation for details on the
+        /// available fields. The SSL transport takes ownership of the credentials' `paCred` and `hRootStore` members
+        /// and releases them when the connection is closed.
+        ///
+        /// Certificate validation is not performed through the returned credentials. Use `trustedRootCertificates`
+        /// or `clientCertificateValidationCallback` instead.
         ///
         /// @param adapterName The name of the object adapter that accepted the connection.
         /// @return The server SSL credentials.
@@ -45,9 +48,12 @@ namespace Ice::SSL
         /// @snippet Ice/SSL/SchannelServerAuthenticationOptions.cpp serverCertificateSelectionCallback
         ///
         /// @see [SCH_CREDENTIALS]
+        /// @see [AcquireCredentialsHandle]
         ///
         /// [SCH_CREDENTIALS]:
         /// https://learn.microsoft.com/en-us/windows/win32/api/schannel/ns-schannel-sch_credentials
+        /// [AcquireCredentialsHandle]:
+        /// https://learn.microsoft.com/en-us/windows/win32/secauthn/acquirecredentialshandle--schannel
         std::function<SCH_CREDENTIALS(const std::string& adapterName)> serverCredentialsSelectionCallback;
 
         /// A callback invoked before initiating a new SSL handshake, providing an opportunity to customize the SSL

--- a/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
@@ -124,6 +124,11 @@ Schannel::TransceiverI::sslHandshake(SecBuffer* initialBuffer)
     {
         assert(!initialBuffer); // Always null for the initial handshake.
         _credentials = _localCredentialsSelectionCallback(_incoming ? _adapterName : _host);
+
+        // Set hRootStore for AcquireCredentialsHandle. Schannel uses hRootStore on the server side to specify
+        // the CAs trusted for client authentication (sent in the CertificateRequest message). This is not used
+        // for certificate validation — the transport handles validation separately using the chain engine.
+        // If the callback already provided an hRootStore, keep it; otherwise fall back to trustedRootCertificates.
         if (_rootStore && !_credentials.hRootStore)
         {
             _credentials.hRootStore = CertDuplicateStore(_rootStore);


### PR DESCRIPTION
## Summary

- Update the credentials selection callback documentation to explain that the returned `SCH_CREDENTIALS` are passed to `AcquireCredentialsHandle`, and link to the Schannel documentation for field details
- Clarify that certificate validation is not performed through the returned credentials — use `trustedRootCertificates` or the validation callback instead
- Add a comment in the transceiver explaining that `hRootStore` is used by Schannel for the server-side `CertificateRequest` CA list, not for the transport's own certificate validation

This replaces the previous documentation that said "hRootStore is not used" with a more accurate description: the credentials are passed through to `AcquireCredentialsHandle` where Schannel uses them as documented (e.g. `hRootStore` specifies trusted CAs for client authentication on the server side). The transport's own validation is a separate concern handled by the chain engine.

## Test plan

- [ ] Verify documentation renders correctly with Doxygen
- [ ] Existing Schannel SSL tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)