### PR TITLE
Fix icegriddb and icestormdb import failures

### DIFF
--- a/cpp/src/IceStorm/IceStormDB.cpp
+++ b/cpp/src/IceStorm/IceStormDB.cpp
@@ -124,8 +124,21 @@ run(const shared_ptr<Ice::Communicator>& communicator, const Ice::StringSeq& arg
         dbPath = opts.optArg("dbpath");
     }
 
+    int mapSizeValue = 0;
     string mapSizeStr = opts.optArg("mapsize");
-    size_t mapSize = IceDB::getMapSize(stoi(mapSizeStr));
+    if (!mapSizeStr.empty())
+    {
+        try
+        {
+            mapSizeValue = stoi(mapSizeStr);
+        }
+        catch (const std::exception&)
+        {
+            consoleErr << args[0] << ": invalid value '" << mapSizeStr << "' for --mapsize" << endl;
+            return 1;
+        }
+    }
+    size_t mapSize = IceDB::getMapSize(mapSizeValue);
 
     try
     {
@@ -170,7 +183,7 @@ run(const shared_ptr<Ice::Communicator>& communicator, const Ice::StringSeq& arg
             fs.seekg(0, ios::beg);
 
             vector<byte> buf;
-            buf.reserve(static_cast<size_t>(fileSize));
+            buf.resize(static_cast<size_t>(fileSize));
             fs.read(reinterpret_cast<char*>(buf.data()), fileSize);
             fs.close();
 

--- a/cpp/src/icegriddb/IceGridDB.cpp
+++ b/cpp/src/icegriddb/IceGridDB.cpp
@@ -202,8 +202,21 @@ run(const Ice::StringSeq& args, const CustomSliceLoaderPtr& customSliceLoader)
         dbPath = opts.optArg("dbpath");
     }
 
+    int mapSizeValue = 0;
     string mapSizeStr = opts.optArg("mapsize");
-    size_t mapSize = IceDB::getMapSize(stoi(mapSizeStr));
+    if (!mapSizeStr.empty())
+    {
+        try
+        {
+            mapSizeValue = stoi(mapSizeStr);
+        }
+        catch (const std::exception&)
+        {
+            consoleErr << args[0] << ": invalid value '" << mapSizeStr << "' for --mapsize" << endl;
+            return 1;
+        }
+    }
+    size_t mapSize = IceDB::getMapSize(mapSizeValue);
     customSliceLoader->setServerVersion(opts.optArg("server-version"));
 
     try
@@ -249,7 +262,7 @@ run(const Ice::StringSeq& args, const CustomSliceLoaderPtr& customSliceLoader)
             fs.seekg(0, ios::beg);
 
             vector<byte> buf;
-            buf.reserve(static_cast<size_t>(fileSize));
+            buf.resize(static_cast<size_t>(fileSize));
             fs.read(reinterpret_cast<char*>(buf.data()), fileSize);
             fs.close();
 

--- a/cpp/test/IceGrid/icegriddb/application.xml
+++ b/cpp/test/IceGrid/icegriddb/application.xml
@@ -1,0 +1,11 @@
+<icegrid>
+    <application name="Test">
+    <node name="localnode">
+        <server id="server" exe="${server.dir}/server" activation="manual">
+            <adapter name="TestAdapter" endpoints="default" id="TestAdapter">
+                <object identity="test" type="Test"/>
+            </adapter>
+        </server>
+    </node>
+    </application>
+</icegrid>

--- a/cpp/test/IceGrid/icegriddb/test.py
+++ b/cpp/test/IceGrid/icegriddb/test.py
@@ -1,0 +1,101 @@
+# Copyright (c) ZeroC, Inc.
+
+import filecmp
+import os
+import shutil
+
+from IceGridUtil import IceGridRegistryMaster, IceGridTestCase
+from Util import Mapping, ProcessFromBinDir, SimpleClient, TestSuite, Windows, platform
+
+
+class IceGridDb(ProcessFromBinDir, SimpleClient):
+    def __init__(self, quiet=True, *args, **kargs):
+        SimpleClient.__init__(
+            self,
+            exe="icegriddb",
+            quiet=quiet,
+            mapping=Mapping.getByName("cpp"),
+            *args,
+            **kargs,
+        )
+
+
+class IceGridDbExportImportTestCase(IceGridTestCase):
+    def __init__(self):
+        IceGridTestCase.__init__(
+            self,
+            name="icegriddb export/import",
+            icegridregistry=[IceGridRegistryMaster()],
+        )
+
+    def runClientSide(self, current):
+        testdir = current.testsuite.getPath()
+
+        # Shut down the node and registry to release the LMDB lock.
+        current.write("shutting down IceGrid... ")
+        self.runadmin(current, "node shutdown localnode")
+        self.icegridnode[0].stop(current, True)
+        self.runadmin(current, "registry shutdown Master")
+        self.icegridregistry[0].stop(current, True)
+        current.writeln("ok")
+
+        dbPath = self.icegridregistry[0].dbdir
+        exportFile1 = os.path.join(testdir, "export1.bin")
+        exportFile2 = os.path.join(testdir, "export2.bin")
+        importDir = os.path.join(testdir, "importdb")
+
+        try:
+            current.write("exporting database... ")
+            IceGridDb(args=["--export", exportFile1, "--dbpath", dbPath]).run(current)
+            current.writeln("ok")
+
+            current.write("importing database... ")
+            os.mkdir(importDir)
+            IceGridDb(args=["--import", exportFile1, "--dbpath", importDir]).run(current)
+            current.writeln("ok")
+
+            current.write("re-exporting imported database... ")
+            IceGridDb(args=["--export", exportFile2, "--dbpath", importDir]).run(current)
+            current.writeln("ok")
+
+            current.write("comparing export files... ")
+            if not filecmp.cmp(exportFile1, exportFile2, shallow=False):
+                raise RuntimeError("export files differ: {0} and {1}".format(exportFile1, exportFile2))
+            current.writeln("ok")
+
+            # Restart the registry from the imported database and verify with icegridadmin.
+            current.write("verifying imported database with icegridadmin... ")
+            shutil.rmtree(dbPath)
+            os.rename(importDir, dbPath)
+            importDir = None  # Moved, no longer needs cleanup
+
+            # Bypass setup() to preserve the imported database files.
+            self.icegridregistry[0].setup = lambda c: None
+            self.icegridregistry[0].start(current)
+
+            output = self.runadmin(current, "application list", quiet=True)
+            if "Test" not in output:
+                raise RuntimeError("expected 'Test' in application list, got: " + output)
+
+            self.runadmin(current, "registry shutdown Master")
+            self.icegridregistry[0].stop(current, True)
+            current.writeln("ok")
+        finally:
+            for f in [exportFile1, exportFile2]:
+                if os.path.exists(f):
+                    os.remove(f)
+            if importDir and os.path.exists(importDir):
+                shutil.rmtree(importDir)
+
+    def teardownClientSide(self, current, success):
+        # Registry and node are already shut down in runClientSide.
+        pass
+
+
+if isinstance(platform, Windows) or os.getuid() != 0:
+    TestSuite(
+        __file__,
+        [IceGridDbExportImportTestCase()],
+        runOnMainThread=True,
+        multihost=False,
+    )

--- a/cpp/test/IceStorm/icestormdb/test.py
+++ b/cpp/test/IceStorm/icestormdb/test.py
@@ -1,0 +1,106 @@
+# Copyright (c) ZeroC, Inc.
+
+import filecmp
+import os
+import shutil
+
+from IceStormUtil import IceStorm, IceStormTestCase
+from Util import Mapping, ProcessFromBinDir, SimpleClient, TestSuite
+
+
+class IceStormDb(ProcessFromBinDir, SimpleClient):
+    def __init__(self, quiet=True, *args, **kargs):
+        SimpleClient.__init__(
+            self,
+            exe="icestormdb",
+            quiet=quiet,
+            mapping=Mapping.getByName("cpp"),
+            *args,
+            **kargs,
+        )
+
+
+icestorm = IceStorm()
+
+
+class IceStormDbExportImportTestCase(IceStormTestCase):
+    def __init__(self):
+        IceStormTestCase.__init__(
+            self,
+            name="icestormdb export/import",
+            icestorm=icestorm,
+        )
+
+    def runClientSide(self, current):
+        testdir = current.testsuite.getPath()
+
+        current.write("creating topics... ")
+        self.runadmin(current, "create topic1 topic2 topic3")
+        current.writeln("ok")
+
+        # Shut down IceStorm to release the LMDB lock.
+        current.write("shutting down IceStorm... ")
+        self.shutdown(current)
+        self.icestorm[0].stop(current, True)
+        current.writeln("ok")
+
+        dbPath = self.icestorm[0].dbdir
+        exportFile1 = os.path.join(testdir, "export1.bin")
+        exportFile2 = os.path.join(testdir, "export2.bin")
+        importDir = os.path.join(testdir, "importdb")
+
+        try:
+            current.write("exporting database... ")
+            IceStormDb(args=["--export", exportFile1, "--dbpath", dbPath]).run(current)
+            current.writeln("ok")
+
+            current.write("importing database... ")
+            os.mkdir(importDir)
+            IceStormDb(args=["--import", exportFile1, "--dbpath", importDir]).run(current)
+            current.writeln("ok")
+
+            current.write("re-exporting imported database... ")
+            IceStormDb(args=["--export", exportFile2, "--dbpath", importDir]).run(current)
+            current.writeln("ok")
+
+            current.write("comparing export files... ")
+            if not filecmp.cmp(exportFile1, exportFile2, shallow=False):
+                raise RuntimeError("export files differ: {0} and {1}".format(exportFile1, exportFile2))
+            current.writeln("ok")
+
+            # Restart IceStorm from the imported database and verify with icestormadmin.
+            current.write("verifying imported database with icestormadmin... ")
+            shutil.rmtree(dbPath)
+            os.rename(importDir, dbPath)
+            importDir = None  # Moved, no longer needs cleanup
+
+            # Bypass setup() to preserve the imported database files.
+            self.icestorm[0].setup = lambda c: None
+            self.icestorm[0].start(current)
+
+            output = self.runadmin(current, "topics", quiet=True)
+            for topic in ["topic1", "topic2", "topic3"]:
+                if topic not in output:
+                    raise RuntimeError("expected '{0}' in topics, got: {1}".format(topic, output))
+
+            self.shutdown(current)
+            self.icestorm[0].stop(current, True)
+            current.writeln("ok")
+        finally:
+            for f in [exportFile1, exportFile2]:
+                if os.path.exists(f):
+                    os.remove(f)
+            if importDir and os.path.exists(importDir):
+                shutil.rmtree(importDir)
+
+    def teardownClientSide(self, current, success):
+        # IceStorm is already shut down in runClientSide.
+        pass
+
+
+TestSuite(
+    __file__,
+    [IceStormDbExportImportTestCase()],
+    runOnMainThread=True,
+    multihost=False,
+)


### PR DESCRIPTION
## Summary

- Fix `vector::reserve` → `vector::resize` in both `icegriddb` and `icestormdb` import code paths.
  `reserve` allocates capacity but leaves `size()` at 0, so the import always failed with a
  `MarshalException` (#5128).
- Handle empty `--mapsize` argument gracefully instead of crashing with `std::invalid_argument` from
  `stoi("")` when the option is provided without a value (#5124).
- Add integration tests for both tools that exercise the full round-trip: export → import → re-export →
  compare, then restart the service from the imported database and verify data with
  `icegridadmin`/`icestormadmin`.