### PR TITLE
Remove dead code and unused members in IceBT

### DIFF
--- a/cpp/src/IceBT/Engine.cpp
+++ b/cpp/src/IceBT/Engine.cpp
@@ -1220,9 +1220,6 @@ namespace IceBT
         RemoteDeviceMap _remoteDevices;
         string _defaultAdapterAddress;
         vector<thread> _connectThreads;
-
-        bool _discovering;
-        vector<function<void(const string&, const PropertyMap&)>> _discoveryCallbacks;
     };
 }
 

--- a/cpp/src/IceBT/Engine.h
+++ b/cpp/src/IceBT/Engine.h
@@ -9,6 +9,7 @@
 #include "IceBT/Plugin.h"
 #include "IceBT/Types.h"
 
+#include <atomic>
 #include <mutex>
 
 namespace IceBT
@@ -77,7 +78,7 @@ namespace IceBT
 
     private:
         const Ice::CommunicatorPtr _communicator;
-        bool _initialized{false};
+        std::atomic<bool> _initialized{false};
         mutable std::mutex _mutex;
         BluetoothServicePtr _service;
     };

--- a/cpp/src/IceBT/StreamSocket.h
+++ b/cpp/src/IceBT/StreamSocket.h
@@ -33,7 +33,6 @@ namespace IceBT
         void init(SOCKET);
 
         const InstancePtr _instance;
-        SocketAddress _addr;
         std::string _desc;
     };
     using StreamSocketPtr = std::shared_ptr<StreamSocket>;


### PR DESCRIPTION
## Summary
- Remove unused `_discovering` and `_discoveryCallbacks` members from `BluetoothService`.
- Remove unused `SocketAddress _addr` member from `StreamSocket`.
- Change `Engine::_initialized` from `bool` to `std::atomic<bool>` to ensure proper memory ordering between `initialize()` and `initialized()` which may be called from different threads.

Fixes #5131

## Test plan
- [ ] CI passes (Linux, since IceBT is Linux-only)