### PR TITLE
Fix DataStorm correctness bugs

### DIFF
--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -645,7 +645,7 @@ DataElementI::disconnect()
             const auto& k = ks.first;
             if (k.second < 0)
             {
-                listener.first.session->disconnectFromFilter(k.first, k.second, shared_from_this(), ks.second->id);
+                listener.first.session->disconnectFromFilter(k.first, -k.second, shared_from_this(), ks.second->id);
             }
             else
             {

--- a/cpp/src/DataStorm/DataElementI.h
+++ b/cpp/src/DataStorm/DataElementI.h
@@ -377,7 +377,7 @@ namespace DataStormI
 
         std::deque<std::shared_ptr<Sample>> _samples;
         std::shared_ptr<Sample> _last;
-        int _instanceCount;
+        int _instanceCount{0};
         DataStorm::DiscardPolicy _discardPolicy;
         std::chrono::time_point<std::chrono::system_clock> _lastSendTime;
         std::function<void(const std::shared_ptr<Sample>&)> _onSamples;

--- a/cpp/src/DataStorm/Node.cpp
+++ b/cpp/src/DataStorm/Node.cpp
@@ -92,9 +92,16 @@ Node::waitForShutdown() const noexcept
 Node&
 Node::operator=(Node&& node) noexcept
 {
-    _instance = std::move(node._instance);
-    _factory = std::move(node._factory);
-    _ownsCommunicator = node._ownsCommunicator;
+    if (this != &node)
+    {
+        if (_instance)
+        {
+            _instance->destroy(_ownsCommunicator);
+        }
+        _instance = std::move(node._instance);
+        _factory = std::move(node._factory);
+        _ownsCommunicator = node._ownsCommunicator;
+    }
     return *this;
 }
 

--- a/cpp/src/DataStorm/NodeI.cpp
+++ b/cpp/src/DataStorm/NodeI.cpp
@@ -668,6 +668,7 @@ void
 NodeI::forwardToPublishers(const ByteSeq& inParams, const Current& current) const
 {
     // Forward the invocation to all publishers with an active session, don't need to wait for the result.
+    lock_guard<mutex> lock(_mutex);
     assert(current.id == _publisherForwarder->ice_getIdentity());
     for (const auto& [_, publisher] : _publishers)
     {


### PR DESCRIPTION
## Summary
- **Data race**: Add missing `lock_guard<mutex>` in `NodeI::forwardToPublishers` which iterates `_publishers` without synchronization, unlike its counterpart `forwardToSubscribers`.
- **Resource leak**: Fix `Node::operator=(Node&&)` to destroy the previous instance before overwriting, preventing leaks of the communicator, adapters, timer, and connection manager.
- **Double-negation**: Fix `DataElementI::disconnect()` passing an already-negated filter element ID to `disconnectFromFilter`, which negates it again in `unsubscribeFromFilter` — the positive key fails to match filter entries stored under negative keys, silently orphaning the subscription.
- **Uninitialized member**: Initialize `DataReaderI::_instanceCount` to zero to avoid undefined behavior from reading an indeterminate value.

Fixes #5132

## Test plan
- [ ] CI passes
- [ ] DataStorm test suite passes