### PR TITLE
Increase Ice/timeout test timeouts for SSL on Windows

### DIFF
--- a/cpp/test/Ice/timeout/AllTests.cpp
+++ b/cpp/test/Ice/timeout/AllTests.cpp
@@ -44,7 +44,8 @@ allTestsWithController(Test::TestHelper* helper, const ControllerPrx& controller
     // SSL is slower on Windows, use a multiplier for invocation timeouts that expect success.
     [[maybe_unused]] int sslMultiplier = 1;
 #ifdef _WIN32
-    if (helper->getTestProtocol().find("ssl") != string::npos)
+    string protocol = helper->getTestProtocol();
+    if (protocol == "ssl" || protocol == "wss")
     {
         sslMultiplier = 3;
     }

--- a/cpp/test/Ice/timeout/Client.cpp
+++ b/cpp/test/Ice/timeout/Client.cpp
@@ -25,7 +25,8 @@ Client::run(int argc, char** argv)
     // Use a longer timeout on Windows with SSL to account for the slower SSL handshake.
     string timeout = "1";
 #ifdef _WIN32
-    if (getTestProtocol(properties).find("ssl") != string::npos)
+    string protocol = getTestProtocol(properties);
+    if (protocol == "ssl" || protocol == "wss")
     {
         timeout = "3";
     }


### PR DESCRIPTION
## Summary
- The Ice/timeout C++ test fails intermittently on `cpp-win32-release on windows-2022` with the `ssl,Win32` config because the 1-second connect timeout is too tight for SSL handshakes on slow CI machines.
- Use a 3x multiplier for connect, close, and invocation timeouts when running with SSL on Windows.

## Test plan
- [ ] CI passes on `cpp-win32-release on windows-2022` with `ssl` config
- [ ] No regressions on other platforms/configs