### PR TITLE
Add binary compatibility nightly workflow

### DIFF
--- a/.github/workflows/compat-nightly.yml
+++ b/.github/workflows/compat-nightly.yml
@@ -99,11 +99,6 @@ jobs:
             platform: x64
             build_flags: "/p:Platform=x64"
             test_flags: "--platform=x64"
-    env:
-      # Tests to exclude from binary compat testing. These are tests known to be sensitive to version details rather
-      # than ABI compatibility. Expand this list as false positives are discovered.
-      COMPAT_RFILTER: ""
-
     steps:
       # Checkout main at the workspace root to provide the composite actions from .github/actions/.
       - name: Checkout main
@@ -173,7 +168,7 @@ jobs:
           echo "Stable lib (before):"
           ls -la stable/cpp/lib/
           rm -rf stable/cpp/lib
-          cp -a head/cpp/lib stable/cpp/lib
+          cp -R head/cpp/lib stable/cpp/lib
           echo "Stable lib (after):"
           ls -la stable/cpp/lib/
         shell: bash


### PR DESCRIPTION
Add a new workflow that verifies binary backward compatibility on stable branches (3.8, 3.7). It builds tests from the latest stable tag, builds distribution libraries from branch HEAD, swaps the HEAD libraries into the stable test tree, and runs the C++ tests.