### PR TITLE
Fix Glacier2 proxy address filter matching bugs

### DIFF
--- a/cpp/src/Glacier2/ProxyVerifier.cpp
+++ b/cpp/src/Glacier2/ProxyVerifier.cpp
@@ -181,7 +181,8 @@ namespace Glacier2
 
         bool match(const string& space, string::size_type& pos) override
         {
-            if (strncmp(space.c_str(), _criteria.c_str(), _criteria.size()) == 0)
+            if (pos + _criteria.size() <= space.size() &&
+                strncmp(space.c_str() + pos, _criteria.c_str(), _criteria.size()) == 0)
             {
                 pos += _criteria.size();
                 return true;
@@ -212,7 +213,7 @@ namespace Glacier2
             {
                 return false;
             }
-            pos = offset + _criteria.size() + 1;
+            pos = offset + _criteria.size();
             return true;
         }
 
@@ -279,7 +280,6 @@ namespace Glacier2
                     ostr << range.start << " up to " << range.end;
                 }
             }
-            ostr << ends;
             _description = ostr.str();
         }
 
@@ -351,26 +351,6 @@ namespace Glacier2
         }
     };
 
-    class EndsWithNumber final : public MatchesNumber
-    {
-    public:
-        EndsWithNumber(const vector<int>& values, const vector<Range>& ranges)
-            : MatchesNumber(values, ranges, "ends with ")
-        {
-        }
-
-        bool match(const string& space, string::size_type& pos) override
-        {
-            pos = space.find_last_not_of("0123456789", pos);
-            if (pos == space.size() - 1)
-            {
-                return false;
-            }
-
-            return MatchesNumber::match(space, pos);
-        }
-    };
-
     //
     // AddressMatcher factories abstract away the logic of which matching
     // objects need to be created depending on the state of the filter
@@ -425,9 +405,10 @@ namespace Glacier2
     public:
         AddressMatcher* create(const string& criteria) override { return new EndsWithString(criteria); }
 
-        AddressMatcher* create(const vector<int>& ports, const vector<Range>& ranges) override
+        AddressMatcher* create(const vector<int>&, const vector<Range>&) override
         {
-            return new EndsWithNumber(ports, ranges);
+            assert(false); // unreachable — groups are always processed inside the parser loop
+            return nullptr;
         }
     };
 

--- a/cpp/test/Glacier2/staticFiltering/test.py
+++ b/cpp/test/Glacier2/staticFiltering/test.py
@@ -292,6 +292,21 @@ class Glacier2StaticFilteringTestSuite(Glacier2TestSuite):
             ),
         ]
 
+        testcases.extend(
+            [
+                (
+                    "testing address filter with numeric range in hostname",
+                    ("12[7].0.0.*", "", "", "", "", ""),
+                    [
+                        (True, "hello:tcp -h 127.0.0.1 -p 12010"),
+                        (False, "hello:tcp -h 128.0.0.1 -p 12010"),
+                        (False, "hello:tcp -h 126.0.0.1 -p 12010"),
+                    ],
+                    [],
+                ),
+            ]
+        )
+
         if not limitedTests:
             testcases.extend(
                 [


### PR DESCRIPTION
## Summary

Fixed bugs in the Glacier2 proxy address filter matching (`ProxyVerifier.cpp`):

- **`MatchesString::match` ignored `pos` parameter**: always compared from position 0 instead of the
  current position, causing incorrect matching when a literal string followed a numeric range in an
  address filter (e.g., `12[7].0.0.*` would fail to match `127.0.0.1`). The practical impact is overly
  restrictive filtering — valid addresses would be incorrectly rejected.
- **`ContainsString::match` off-by-one**: advanced `pos` one character past the match end, which could
  cause subsequent matchers to skip a character.

Also includes minor cleanups:
- Removed dead `EndsWithNumber` class (unreachable code).
- Removed `std::ends` artifact that inserted an embedded null into trace output.
- Added bounds check in `MatchesString` using overflow-safe arithmetic.
- Added test case with numeric range in hostname (`12[7].0.0.*`).