### PR TITLE
Fix exception message when batch count is negative

### DIFF
--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -2317,13 +2317,12 @@ Ice::ConnectionI::idleCheck(const chrono::seconds& idleTimeout) noexcept
     {
         setState(
             StateClosed,
-            make_exception_ptr(
-                ConnectionAbortedException{
-                    __FILE__,
-                    __LINE__,
-                    "connection aborted by the idle check because it did not receive any bytes for " +
-                        to_string(idleTimeout.count()) + "s",
-                    false})); // closedByApplication: false
+            make_exception_ptr(ConnectionAbortedException{
+                __FILE__,
+                __LINE__,
+                "connection aborted by the idle check because it did not receive any bytes for " +
+                    to_string(idleTimeout.count()) + "s",
+                false})); // closedByApplication: false
     }
     // else, nothing to do
 }
@@ -2344,12 +2343,11 @@ Ice::ConnectionI::inactivityCheck() noexcept
         {
             setState(
                 StateClosing,
-                make_exception_ptr(
-                    ConnectionClosedException{
-                        __FILE__,
-                        __LINE__,
-                        "connection closed because it remained inactive for longer than the inactivity timeout",
-                        false}));
+                make_exception_ptr(ConnectionClosedException{
+                    __FILE__,
+                    __LINE__,
+                    "connection closed because it remained inactive for longer than the inactivity timeout",
+                    false}));
         }
     }
 }


### PR DESCRIPTION
Not sure why we were bothering to set the count to 0. 