### PR TITLE
Remove duplicate initialization in InputStream move assignment

### DIFF
--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -143,8 +143,6 @@ Ice::InputStream::operator=(InputStream&& other) noexcept
         _closure = other._closure;
         _startSeq = other._startSeq;
         _minSeqSize = other._minSeqSize;
-        _startSeq = -1;
-        _minSeqSize = 0;
         resetEncapsulation();
 
         // Reset other to its default state.


### PR DESCRIPTION
The move assignment operator was incorrectly resetting `_startSeq` and
`_minSeqSize` immediately after copying them from the source object.
