### PR TITLE
Set default MSBuild platform to x64 and unify PropertyGroup style

### DIFF
--- a/cpp/msbuild/ice.proj
+++ b/cpp/msbuild/ice.proj
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <Import Project="$(MSBuildThisFileDirectory)\..\..\config\ice.version.props" />
-    <PropertyGroup Condition="'$(Configuration)' == ''">
-        <Configuration>Release</Configuration>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(Platform)' == ''">
-        <Platform>Win32</Platform>
+    <PropertyGroup>
+        <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
+        <Platform Condition="'$(Platform)' == ''">x64</Platform>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/ice.proj
+++ b/ice.proj
@@ -3,7 +3,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <Platform Condition="'$(Platform)' == ''">Win32</Platform>
+    <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
   </PropertyGroup>
 

--- a/java/msbuild/ice.proj
+++ b/java/msbuild/ice.proj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <Platform Condition="'$(Platform)' == ''">Win32</Platform>
+    <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
   </PropertyGroup>
 

--- a/js/msbuild/ice.proj
+++ b/js/msbuild/ice.proj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <NPM Condition="'$(NPM)' == ''">npm</NPM>
-    <Platform Condition="'$(Platform)' == ''">Win32</Platform>
+    <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
   </PropertyGroup>
 

--- a/matlab/BUILDING.md
+++ b/matlab/BUILDING.md
@@ -54,7 +54,9 @@ Now you're ready to build Ice for MATLAB:
 msbuild msbuild\ice.proj
 ```
 
-To build in debug mode instead:
+This builds Ice for MATLAB for the default configuration (i.e., `x64/Release`). Ice for MATLAB only supports the `x64` platform.
+
+To build in debug mode, set the `Configuration` property:
 
 ```shell
 msbuild msbuild\ice.proj /p:Configuration=Debug

--- a/python/BUILDING.md
+++ b/python/BUILDING.md
@@ -65,6 +65,8 @@ make
 MSBuild msbuild\ice.proj
 ```
 
+This builds Ice for Python for the default platform and configuration (i.e., `x64/Release`).
+
 By default, the Windows build uses the Python installation located at:
 
 * `C:\Program Files\Python314` for `x64` builds
@@ -76,13 +78,7 @@ If your Python installation is in a different location, set the `PythonHome` MSB
 MSBuild msbuild\ice.proj /p:PythonHome=C:\Python314
 ```
 
-To build a debug version for use with `python_d`, set the `Configuration` property to `Debug`:
-
-```shell
-MSBuild msbuild\ice.proj /p:Configuration=Debug
-```
-
-To change the target platform, use the `Platform` property. For example, to build for `Win32` in debug mode:
+You can select a different platform and configuration by setting the MSBuild `Platform` and `Configuration` properties. For example, to build for `Win32` in debug mode:
 
 ```shell
 MSBuild msbuild\ice.proj /p:Platform=Win32 /p:Configuration=Debug

--- a/python/msbuild/ice.proj
+++ b/python/msbuild/ice.proj
@@ -1,11 +1,8 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <PropertyGroup Condition="'$(Configuration)' == ''">
-        <Configuration>Release</Configuration>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(Platform)' == ''">
-      <Platform>Win32</Platform>
+    <PropertyGroup>
+        <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
+        <Platform Condition="'$(Platform)' == ''">x64</Platform>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
This PR updates the default Windows build platform to x64, this was already documented as the default but not consistently set in MSBuild project files.