### PR TITLE
Fix make hang during dotnet build (#5186)

### DIFF
--- a/csharp/Makefile
+++ b/csharp/Makefile
@@ -4,20 +4,22 @@ top_srcdir := ..
 
 include $(top_srcdir)/config/Make.rules
 
-DOTNETBUILDARGS = $(if $(filter yes,$(OPTIMIZE)),,/p:Configuration=Debug)
+# We use /p:UseSharedCompilation=false /nr:false to ensure msbuild doesn't leave processes behind
+# after the build (this causes make to hang).
+DOTNETARGS = /p:UseSharedCompilation=false /nr:false /m $(if $(filter yes,$(OPTIMIZE)),,/p:Configuration=Debug)
 
 all::
-	dotnet msbuild msbuild/ice.proj $(DOTNETBUILDARGS)
+	dotnet msbuild msbuild/ice.proj $(DOTNETARGS)
 
 tests::
-	dotnet msbuild msbuild/ice.proj $(DOTNETBUILDARGS)
+	dotnet msbuild msbuild/ice.proj $(DOTNETARGS)
 
 srcs::
-	dotnet msbuild msbuild/ice.proj $(DOTNETBUILDARGS) /t:BuildDist
+	dotnet msbuild msbuild/ice.proj $(DOTNETARGS) /t:BuildDist
 
 distclean:: clean
 clean::
-	dotnet msbuild msbuild/ice.proj /t:Clean
+	dotnet msbuild msbuild/ice.proj $(DOTNETARGS) /t:Clean
 
 install::
 	@echo nothing to install


### PR DESCRIPTION
Pass /p:UseSharedCompilation=false /nr:false /m to all dotnet msbuild invocations to prevent MSBuild from leaving processes behind after the build completes, which causes make to hang.

Fix #5186