### PR TITLE
Fix IceGrid GUI macOS app workflow when dmg_version is empty

### DIFF
--- a/.github/workflows/build-icegridgui-macos-app.yml
+++ b/.github/workflows/build-icegridgui-macos-app.yml
@@ -78,7 +78,11 @@ jobs:
 
       - name: Create DMG
         run: |
-          ./packaging/macos/create-icegridgui-dmg.sh "output/IceGrid GUI.app" output "${{ inputs.dmg_version }}" --sign --notarize
+          dmg_args=("output/IceGrid GUI.app" output --sign --notarize)
+          if [ -n "${{ inputs.dmg_version }}" ]; then
+            dmg_args+=(--version "${{ inputs.dmg_version }}")
+          fi
+          ./packaging/macos/create-icegridgui-dmg.sh "${dmg_args[@]}"
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}

--- a/packaging/macos/build-icegridgui-macos-app.sh
+++ b/packaging/macos/build-icegridgui-macos-app.sh
@@ -26,7 +26,7 @@ DEST_DIR="${2:?Usage: $0 <jar-path> <output-dir>}"
 
 # shellcheck source=../../config/version.env
 source "${REPO_ROOT}/config/version.env"
-APP_VERSION="${BASE_VERSION}"
+APP_VERSION="${BASE_VERSION:?BASE_VERSION must be defined in config/version.env}"
 
 JAVA_HOME="${JAVA_HOME:?JAVA_HOME must be set to a Java 17+ installation}"
 JPACKAGE="${JAVA_HOME}/bin/jpackage"

--- a/packaging/macos/create-icegridgui-dmg.sh
+++ b/packaging/macos/create-icegridgui-dmg.sh
@@ -4,15 +4,15 @@
 # sign and notarize it.
 #
 # Usage:
-#   ./create-icegridgui-dmg.sh <app-path> <output-dir> [version] [--sign [--notarize]]
+#   ./create-icegridgui-dmg.sh <app-path> <output-dir> [--version <version>] [--sign [--notarize]]
 #
 # Arguments:
-#   app-path      Path to "IceGrid GUI.app"
-#   output-dir    Directory where the DMG will be created
-#   version       Version string for the DMG filename (default: read from config/version.env)
-#   --sign        Sign the DMG
-#   --notarize    Also notarize and staple the DMG (requires APPLE_ID, APPLE_TEAM_ID,
-#                 and APPLE_APP_SPECIFIC_PASSWORD environment variables)
+#   app-path            Path to "IceGrid GUI.app"
+#   output-dir          Directory where the DMG will be created
+#   --version <version> Semver version string for the DMG filename (default: read from config/version.env)
+#   --sign              Sign the DMG
+#   --notarize          Also notarize and staple the DMG (requires APPLE_ID, APPLE_TEAM_ID,
+#                       and APPLE_APP_SPECIFIC_PASSWORD environment variables)
 #
 # Environment:
 #   SIGNING_IDENTITY              Code signing identity (default: "Developer ID Application: ZeroC, Inc. (U4TBVKNQ7F)")
@@ -22,7 +22,7 @@
 #
 # Example:
 #   ./create-icegridgui-dmg.sh "output/IceGrid GUI.app" output
-#   ./create-icegridgui-dmg.sh "output/IceGrid GUI.app" output 3.9.0 --sign --notarize
+#   ./create-icegridgui-dmg.sh "output/IceGrid GUI.app" output --version 3.9.0 --sign --notarize
 #
 
 set -euo pipefail
@@ -30,29 +30,37 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
-APP_PATH="${1:?Usage: $0 <app-path> <output-dir> [version] [--sign [--notarize]]}"
-OUTPUT_DIR="${2:?Usage: $0 <app-path> <output-dir> [version] [--sign [--notarize]]}"
+SEMVER_REGEX='^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?(\+[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?$'
+
+APP_PATH="${1:?Usage: $0 <app-path> <output-dir> [--version <version>] [--sign [--notarize]]}"
+OUTPUT_DIR="${2:?Usage: $0 <app-path> <output-dir> [--version <version>] [--sign [--notarize]]}"
 shift 2
 
-if [ -n "${1:-}" ]; then
-    VERSION="$1"
-    shift
-else
-    # shellcheck source=../../config/version.env
-    source "${REPO_ROOT}/config/version.env"
-    VERSION="${BASE_VERSION}"
-fi
-
+VERSION=""
 SIGN=false
 NOTARIZE=false
 while [ $# -gt 0 ]; do
     case "$1" in
+        --version)
+            VERSION="${2:?--version requires a value}"
+            if ! [[ "${VERSION}" =~ ${SEMVER_REGEX} ]]; then
+                echo "Error: '${VERSION}' is not a valid semver version" >&2
+                exit 1
+            fi
+            shift
+            ;;
         --sign) SIGN=true ;;
         --notarize) NOTARIZE=true ;;
         *) echo "Unknown option: $1" >&2; exit 1 ;;
     esac
     shift
 done
+
+if [ -z "${VERSION}" ]; then
+    # shellcheck source=../../config/version.env
+    source "${REPO_ROOT}/config/version.env"
+    VERSION="${BASE_VERSION:?BASE_VERSION must be set in config/version.env}"
+fi
 
 SIGNING_IDENTITY="${SIGNING_IDENTITY:-Developer ID Application: ZeroC, Inc. (U4TBVKNQ7F)}"
 


### PR DESCRIPTION
For stable releases, dmg_version is empty which caused create-icegridgui-dmg.sh to fail on the required version argument. Make dmg_version optional in both the workflow and the script, falling back to BASE_VERSION from version.env.

Also simplify build-icegridgui-macos-app.sh by always reading the version from version.env since jpackage requires a plain numeric version.