### PR TITLE
Fix WebSocket URL construction for IPv6 and wss default port

### DIFF
--- a/js/src/Ice/WSTransceiver.js
+++ b/js/src/Ice/WSTransceiver.js
@@ -390,8 +390,9 @@ if (typeof WebSocket !== 'undefined')
         {
             const transceiver = new WSTransceiver(instance);
             let url = secure ? "wss" : "ws";
-            url += "://" + addr.host;
-            if(addr.port !== 80)
+            const isIPv6 = addr.host.indexOf(":") !== -1;
+            url += "://" + (isIPv6 ? `[${addr.host}]` : addr.host);
+            if(addr.port !== (secure ? 443 : 80))
             {
                 url += ":" + addr.port;
             }


### PR DESCRIPTION
## Summary

Backport of #5086 from 3.8 to 3.7.

- Wrap IPv6 literal addresses in brackets per RFC 3986/6455 when constructing WebSocket URLs
- Use 443 as the default port for `wss` instead of 80

Without this fix, WebSocket connections to IPv6 addresses produce malformed URLs (e.g., `wss://::1:443/` instead of `wss://[::1]/`), and `wss` connections on port 443 unnecessarily include the port in the URL.

## Test plan

- [ ] JavaScript WebSocket tests with IPv6 endpoints
- [ ] JavaScript WebSocket tests with wss on default port 443