### PR TITLE
Add --rpc none|ice|icerpc option to slice2cs

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -19,6 +19,7 @@
         "icegrid",
         "icegridadmin",
         "icegridnode",
+        "icerpc",
         "icestorm",
         "istr",
         "jgoodies",

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -2827,6 +2827,24 @@ Slice::InterfaceDef::operations() const
 }
 
 OperationList
+Slice::InterfaceDef::allOperations() const
+{
+    OperationList result = allInheritedOperations();
+
+    for (const auto& q : operations())
+    {
+        if (none_of(
+                result.begin(),
+                result.end(),
+                [name = q->name()](const auto& other) { return other->name() == name; }))
+        {
+            result.push_back(q);
+        }
+    }
+    return result;
+}
+
+OperationList
 Slice::InterfaceDef::allInheritedOperations() const
 {
     OperationList result;
@@ -2841,24 +2859,6 @@ Slice::InterfaceDef::allInheritedOperations() const
             {
                 result.push_back(q);
             }
-        }
-    }
-    return result;
-}
-
-OperationList
-Slice::InterfaceDef::allOperations() const
-{
-    OperationList result = allInheritedOperations();
-
-    for (const auto& q : operations())
-    {
-        if (none_of(
-                result.begin(),
-                result.end(),
-                [name = q->name()](const auto& other) { return other->name() == name; }))
-        {
-            result.push_back(q);
         }
     }
     return result;

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -2738,8 +2738,9 @@ Slice::InterfaceDef::createOperation(
                 break;
             }
         }
-        // Check the operations of the Object pseudo-interface.
-        if (!checkBaseOperationNames(name, {"ice_id", "ice_ids", "ice_ping", "ice_isA"}))
+
+        // Check the operations of the Object pseudo-interface unless we're generating code for Object itself.
+        if (scoped() != "::Ice::Object" && !checkBaseOperationNames(name, {"ice_id", "ice_ids", "ice_ping", "ice_isA"}))
         {
             hasConflictingIdentifier = true;
         }
@@ -2826,7 +2827,7 @@ Slice::InterfaceDef::operations() const
 }
 
 OperationList
-Slice::InterfaceDef::allOperations() const
+Slice::InterfaceDef::allInheritedOperations() const
 {
     OperationList result;
     for (const auto& p : _bases)
@@ -2842,6 +2843,13 @@ Slice::InterfaceDef::allOperations() const
             }
         }
     }
+    return result;
+}
+
+OperationList
+Slice::InterfaceDef::allOperations() const
+{
+    OperationList result = allInheritedOperations();
 
     for (const auto& q : operations())
     {

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -792,6 +792,7 @@ namespace Slice
         [[nodiscard]] InterfaceList allBases() const;
         [[nodiscard]] OperationList operations() const;
         [[nodiscard]] OperationList allOperations() const;
+        [[nodiscard]] OperationList allInheritedOperations() const;
         [[nodiscard]] std::string kindOf() const final;
         void visit(ParserVisitor* visitor) final;
 

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -34,12 +34,12 @@ Slice::Csharp::getNamespace(const ContainedPtr& p)
 }
 
 string
-Slice::Csharp::getUnqualified(const ContainedPtr& p, const string& ns, const string& prefix)
+Slice::Csharp::getUnqualified(const ContainedPtr& p, const string& ns, const string& prefix, const string& suffix)
 {
     string name = p->mappedName();
-    if (!prefix.empty())
+    if (!prefix.empty() || !suffix.empty())
     {
-        name = prefix + removeEscapePrefix(name);
+        name = prefix + removeEscapePrefix(name) + suffix;
     }
 
     // If contained is an operation, a field, or an enumerator, we use the enclosing type.
@@ -119,5 +119,84 @@ Slice::Csharp::writeDocLines(
             out << line;
         }
         out << "</" << closeTag.value_or(openTag) << ">";
+    }
+}
+
+Slice::Csharp::CsharpDocCommentFormatter::CsharpDocCommentFormatter(
+    function<pair<bool, string>(const string&, const ContainedPtr&, const SyntaxTreeBasePtr&)> linkFormatter)
+    : _linkFormatter(std::move(linkFormatter))
+{
+}
+
+void
+Slice::Csharp::CsharpDocCommentFormatter::preprocess(StringList& rawComment)
+{
+    for (auto& line : rawComment)
+    {
+        // Escape any XML special characters in the comment.
+        string::size_type pos = 0;
+        while ((pos = line.find_first_of("&<>", pos)) != string::npos)
+        {
+            switch (line[pos])
+            {
+                case '&':
+                    line.replace(pos, 1, "&amp;");
+                    break;
+                case '<':
+                    line.replace(pos, 1, "&lt;");
+                    break;
+                case '>':
+                    line.replace(pos, 1, "&gt;");
+                    break;
+            }
+            // Skip over the leading '&' character to avoid 'find'ing it again.
+            pos += 1;
+        }
+    }
+}
+
+string
+Slice::Csharp::CsharpDocCommentFormatter::formatCode(const string& rawText)
+{
+    return "<c>" + rawText + "</c>";
+}
+
+string
+Slice::Csharp::CsharpDocCommentFormatter::formatParamRef(const string& param)
+{
+    return "<paramref name=\"" + param + "\" />";
+}
+
+string
+Slice::Csharp::CsharpDocCommentFormatter::formatLink(
+    const string& rawLink,
+    const ContainedPtr& source,
+    const SyntaxTreeBasePtr& target)
+{
+    auto [mapToLink, qualifiedName] = _linkFormatter(rawLink, source, target);
+    if (mapToLink)
+    {
+        return "<see " + qualifiedName + " />";
+    }
+    else
+    {
+        return "<c>" + qualifiedName + "</c>";
+    }
+}
+
+string
+Slice::Csharp::CsharpDocCommentFormatter::formatSeeAlso(
+    const string& rawLink,
+    const ContainedPtr& source,
+    const SyntaxTreeBasePtr& target)
+{
+    auto [mapToLink, qualifiedName] = _linkFormatter(rawLink, source, target);
+    if (mapToLink)
+    {
+        return "<seealso " + qualifiedName + " />";
+    }
+    else
+    {
+        return "";
     }
 }

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -4,6 +4,7 @@
 #define CS_UTIL_H
 
 #include "../Ice/OutputUtil.h"
+#include "../Slice/DocCommentParser.h"
 #include "../Slice/Parser.h"
 
 namespace Slice::Csharp
@@ -11,8 +12,11 @@ namespace Slice::Csharp
     /// Returns the namespace of a Contained entity.
     [[nodiscard]] std::string getNamespace(const ContainedPtr& p);
 
-    [[nodiscard]] std::string
-    getUnqualified(const ContainedPtr& p, const std::string& ns, const std::string& prefix = "");
+    [[nodiscard]] std::string getUnqualified(
+        const ContainedPtr& p,
+        const std::string& ns,
+        const std::string& prefix = "",
+        const std::string& suffix = "");
 
     /// Removes a leading '@' character from the provided identifier (if one is present).
     [[nodiscard]] std::string removeEscapePrefix(const std::string& identifier);
@@ -34,6 +38,29 @@ namespace Slice::Csharp
         const std::string& openTag,
         const StringList& lines,
         const std::optional<std::string>& closeTag = std::nullopt);
+
+    class CsharpDocCommentFormatter final : public DocCommentFormatter
+    {
+    public:
+        CsharpDocCommentFormatter(
+            std::function<
+                std::pair<bool, std::string>(const std::string&, const ContainedPtr&, const SyntaxTreeBasePtr&)>
+                linkFormatter);
+
+        void preprocess(StringList& rawComment) final;
+        std::string formatCode(const std::string& rawText) final;
+        std::string formatParamRef(const std::string& param) final;
+
+        std::string
+        formatLink(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target) final;
+
+        std::string
+        formatSeeAlso(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target) final;
+
+    private:
+        std::function<std::pair<bool, std::string>(const std::string&, const ContainedPtr&, const SyntaxTreeBasePtr&)>
+            _linkFormatter;
+    };
 }
 
 #endif

--- a/cpp/src/slice2cs/CsVisitor.cpp
+++ b/cpp/src/slice2cs/CsVisitor.cpp
@@ -28,6 +28,24 @@ namespace
 
 Slice::CsVisitor::CsVisitor(Output& out) : _out(out) {}
 
+bool
+Slice::CsVisitor::visitModuleStart(const ModulePtr& p)
+{
+    namespacePrefixStart(p);
+    _out << sp;
+    _out << nl << "namespace " << p->mappedName();
+    _out << sb;
+
+    return true;
+}
+
+void
+Slice::CsVisitor::visitModuleEnd(const ModulePtr& p)
+{
+    _out << eb;
+    namespacePrefixEnd(p);
+}
+
 void
 Slice::CsVisitor::emitNonBrowsableAttribute()
 {

--- a/cpp/src/slice2cs/CsVisitor.h
+++ b/cpp/src/slice2cs/CsVisitor.h
@@ -14,6 +14,9 @@ namespace Slice
     public:
         CsVisitor(IceInternal::Output&);
 
+        bool visitModuleStart(const ModulePtr&) override;
+        void visitModuleEnd(const ModulePtr&) override;
+
     protected:
         void emitNonBrowsableAttribute();
 
@@ -45,10 +48,11 @@ namespace Slice
         writeOpDocComment(const OperationPtr& operation, const std::vector<std::string>& extraParams, bool isAsync);
         void writeParameterDocComments(const DocComment&, const ParameterList&);
 
+        IceInternal::Output& _out;
+
+    private:
         void namespacePrefixStart(const ModulePtr&);
         void namespacePrefixEnd(const ModulePtr&);
-
-        IceInternal::Output& _out;
     };
 }
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -63,6 +63,7 @@ Slice::Gen::Gen(const string& base, const string& dir, GenMode genMode, bool ena
 
     if (_genMode == GenMode::Ice)
     {
+        _out << sp;
         _out << nl << "[assembly:Ice.Slice(\"" << fileBase << ".ice\")]";
     }
     else
@@ -78,7 +79,6 @@ Slice::Gen::Gen(const string& base, const string& dir, GenMode genMode, bool ena
             _iceRpcOut << nl << "using ZeroC.Slice;";
             _iceRpcOut << nl << "using IceRpc.Slice;";
             _iceRpcOut << sp;
-            _iceRpcOut << nl << "[assembly:Slice(\"" << fileBase << ".ice\")]";
         }
     }
 }

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -7,6 +7,7 @@
 #include "CsMetadataValidator.h"
 #include "CsUtil.h"
 #include "Ice/StringUtil.h"
+#include "IceRpcVisitors.h"
 #include "IceVisitors.h"
 
 using namespace std;
@@ -14,7 +15,9 @@ using namespace Slice;
 using namespace Slice::Csharp;
 using namespace IceInternal;
 
-Slice::Gen::Gen(const string& base, const string& dir, bool enableAnalysis) : _enableAnalysis(enableAnalysis)
+Slice::Gen::Gen(const string& base, const string& dir, GenMode genMode, bool enableAnalysis)
+    : _genMode(genMode),
+      _enableAnalysis(enableAnalysis)
 {
     string fileBase = base;
     string::size_type pos = base.find_last_of("/\\");
@@ -23,9 +26,12 @@ Slice::Gen::Gen(const string& base, const string& dir, bool enableAnalysis) : _e
         fileBase = base.substr(pos + 1);
     }
     string file = fileBase + ".cs";
+    string iceRpcFile = fileBase + ".IceRpc.cs";
+
     if (!dir.empty())
     {
         file = dir + '/' + file;
+        iceRpcFile = dir + '/' + iceRpcFile;
     }
 
     _out.open(file.c_str());
@@ -36,49 +42,58 @@ Slice::Gen::Gen(const string& base, const string& dir, bool enableAnalysis) : _e
         throw FileException(os.str());
     }
     FileTracker::instance()->addFile(file);
-    printHeader();
 
-    if (!_enableAnalysis)
+    if (_genMode == GenMode::IceRpc)
     {
-        printGeneratedHeader(_out, fileBase + ".ice");
+        _iceRpcOut.open(iceRpcFile.c_str());
+        if (!_iceRpcOut)
+        {
+            ostringstream os;
+            os << "cannot open '" << iceRpcFile << "': " << IceInternal::errorToString(errno);
+            throw FileException(os.str());
+        }
+        FileTracker::instance()->addFile(iceRpcFile);
     }
 
-    _out << sp;
-    _out << nl << "#nullable enable";
-    _out << sp;
-    _out << nl << "[assembly:Ice.Slice(\"" << fileBase << ".ice\")]";
-
-    _out << sp;
-
-    if (_enableAnalysis)
+    printHeader(_out, fileBase + ".ice", _enableAnalysis);
+    if (_genMode == GenMode::IceRpc)
     {
-        // Disable some warnings when auto-generated is removed from the header. See printGeneratedHeader above.
-        _out << nl << "#pragma warning disable SA1403 // File may only contain a single namespace";
-        _out << nl << "#pragma warning disable SA1611 // The documentation for parameter x is missing";
-
-        _out << nl << "#pragma warning disable CA1041 // Provide a message for the ObsoleteAttribute that marks ...";
-        _out << nl << "#pragma warning disable CA1068 // Cancellation token as last parameter";
-        _out << nl << "#pragma warning disable CA1725 // Change parameter name istr_ to istr in order to match ...";
-
-        // Missing doc - only necessary for the tests.
-        _out << nl << "#pragma warning disable SA1602";
-        _out << nl << "#pragma warning disable SA1604";
-        _out << nl << "#pragma warning disable SA1605";
+        printHeader(_iceRpcOut, fileBase + ".ice", _enableAnalysis);
     }
 
-    _out << nl << "#pragma warning disable CS1591 // Missing XML Comment";
-    _out << nl << "#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment";
-    _out << nl << "#pragma warning disable CS0612 // Type or member is obsolete";
-    _out << nl << "#pragma warning disable CS0618 // Type or member is obsolete";
-    _out << nl << "#pragma warning disable CS0619 // Type or member is obsolete";
+    if (_genMode == GenMode::Ice)
+    {
+        _out << nl << "[assembly:Ice.Slice(\"" << fileBase << ".ice\")]";
+    }
+    else
+    {
+        _out << sp;
+        _out << nl << "using ZeroC.Slice;";
+        _out << sp;
+        _out << nl << "[assembly:Slice(\"" << fileBase << ".ice\")]";
+
+        if (_genMode == GenMode::IceRpc)
+        {
+            _iceRpcOut << sp;
+            _iceRpcOut << nl << "using ZeroC.Slice;";
+            _iceRpcOut << nl << "using IceRpc.Slice;";
+            _iceRpcOut << sp;
+            _iceRpcOut << nl << "[assembly:Slice(\"" << fileBase << ".ice\")]";
+        }
+    }
 }
 
 Slice::Gen::~Gen()
 {
     if (_out.isOpen())
     {
-        _out << '\n';
+        _out << nl;
         _out.close();
+    }
+    if (_iceRpcOut.isOpen())
+    {
+        _iceRpcOut << nl;
+        _iceRpcOut.close();
     }
 }
 
@@ -87,25 +102,74 @@ Slice::Gen::generate(const UnitPtr& p)
 {
     Slice::validateCsMetadata(p);
 
-    Slice::Ice::TypesVisitor typesVisitor(_out);
-    p->visit(&typesVisitor);
+    if (_genMode == GenMode::Ice)
+    {
+        Slice::Ice::TypesVisitor typesVisitor(_out);
+        p->visit(&typesVisitor);
 
-    Slice::Ice::ResultVisitor resultVisitor(_out);
-    p->visit(&resultVisitor);
+        Slice::Ice::ResultVisitor resultVisitor(_out);
+        p->visit(&resultVisitor);
 
-    // Default skeleton.
-    Slice::Ice::SkeletonVisitor skeletonVisitor(_out, false);
-    p->visit(&skeletonVisitor);
+        // Default skeleton.
+        Slice::Ice::SkeletonVisitor skeletonVisitor(_out, false);
+        p->visit(&skeletonVisitor);
 
-    // Async skeleton.
-    Slice::Ice::SkeletonVisitor asyncSkeletonVisitor(_out, true);
-    p->visit(&asyncSkeletonVisitor);
+        // Async skeleton.
+        Slice::Ice::SkeletonVisitor asyncSkeletonVisitor(_out, true);
+        p->visit(&asyncSkeletonVisitor);
+    }
+    else
+    {
+        Slice::IceRpc::TypesVisitor typesVisitor(_out);
+        p->visit(&typesVisitor);
+
+        if (_genMode == GenMode::IceRpc)
+        {
+            Slice::IceRpc::ProxyVisitor proxyVisitor(_iceRpcOut);
+            p->visit(&proxyVisitor);
+
+            Slice::IceRpc::SkeletonVisitor skeletonVisitor(_iceRpcOut);
+            p->visit(&skeletonVisitor);
+        }
+    }
 }
 
 void
-Slice::Gen::printHeader()
+Slice::Gen::printHeader(IceInternal::Output& out, const string& iceFile, bool enableAnalysis)
 {
-    _out << "// Copyright (c) ZeroC, Inc.";
-    _out << sp;
-    _out << nl << "// slice2cs version " << ICE_STRING_VERSION;
+    out << "// Copyright (c) ZeroC, Inc.";
+    out << sp;
+    out << nl << "// slice2cs version " << ICE_STRING_VERSION;
+
+    if (!enableAnalysis)
+    {
+        printGeneratedHeader(out, iceFile);
+    }
+
+    out << sp;
+    out << nl << "#nullable enable";
+    out << sp;
+
+    if (enableAnalysis)
+    {
+        // Disable some warnings when auto-generated is removed from the header. See printGeneratedHeader above.
+        out << nl << "#pragma warning disable SA1403 // File may only contain a single namespace";
+        out << nl << "#pragma warning disable SA1611 // The documentation for parameter x is missing";
+
+        out << nl << "#pragma warning disable CA1041 // Provide a message for the ObsoleteAttribute that marks ...";
+
+        out << nl << "#pragma warning disable CA1068 // Cancellation token as last parameter";
+        out << nl << "#pragma warning disable CA1725 // Change parameter name istr_ to istr in order to match ...";
+
+        // Missing doc - only necessary for the tests.
+        out << nl << "#pragma warning disable SA1602";
+        out << nl << "#pragma warning disable SA1604";
+        out << nl << "#pragma warning disable SA1605";
+    }
+
+    out << nl << "#pragma warning disable CS1591 // Missing XML Comment";
+    out << nl << "#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment";
+    out << nl << "#pragma warning disable CS0612 // Type or member is obsolete";
+    out << nl << "#pragma warning disable CS0618 // Type or member is obsolete";
+    out << nl << "#pragma warning disable CS0619 // Type or member is obsolete";
 }

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -8,20 +8,29 @@
 
 namespace Slice
 {
+    enum class GenMode
+    {
+        None,
+        Ice,
+        IceRpc
+    };
+
     class Gen final
     {
     public:
-        Gen(const std::string&, const std::string&, bool);
+        Gen(const std::string& base, const std::string& dir, GenMode genMode, bool enableAnalysis);
         Gen(const Gen&) = delete;
         ~Gen();
 
         void generate(const UnitPtr&);
 
     private:
+        const GenMode _genMode;
         IceInternal::Output _out;
-        bool _enableAnalysis;
+        IceInternal::Output _iceRpcOut;
+        const bool _enableAnalysis;
 
-        void printHeader();
+        static void printHeader(IceInternal::Output& out, const std::string& iceFile, bool enableAnalysis);
     };
 }
 

--- a/cpp/src/slice2cs/IceCsUtil.cpp
+++ b/cpp/src/slice2cs/IceCsUtil.cpp
@@ -1619,7 +1619,7 @@ Slice::Csharp::writeOptionalSequenceMarshalUnmarshalCode(
 }
 
 std::pair<bool, string>
-Slice::Csharp::csLinkFormatter(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target)
+Slice::Csharp::iceLinkFormatter(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target)
 {
     ostringstream result;
 
@@ -1692,77 +1692,4 @@ Slice::Csharp::csLinkFormatter(const string& rawLink, const ContainedPtr& source
     }
 
     return {true, result.str()};
-}
-
-void
-Slice::Csharp::IceDocCommentFormatter::preprocess(StringList& rawComment)
-{
-    for (auto& line : rawComment)
-    {
-        // Escape any XML special characters in the comment.
-        string::size_type pos = 0;
-        while ((pos = line.find_first_of("&<>", pos)) != string::npos)
-        {
-            switch (line[pos])
-            {
-                case '&':
-                    line.replace(pos, 1, "&amp;");
-                    break;
-                case '<':
-                    line.replace(pos, 1, "&lt;");
-                    break;
-                case '>':
-                    line.replace(pos, 1, "&gt;");
-                    break;
-            }
-            // Skip over the leading '&' character to avoid 'find'ing it again.
-            pos += 1;
-        }
-    }
-}
-
-string
-Slice::Csharp::IceDocCommentFormatter::formatCode(const string& rawText)
-{
-    return "<c>" + rawText + "</c>";
-}
-
-string
-Slice::Csharp::IceDocCommentFormatter::formatParamRef(const string& param)
-{
-    return "<paramref name=\"" + param + "\" />";
-}
-
-string
-Slice::Csharp::IceDocCommentFormatter::formatLink(
-    const string& rawLink,
-    const ContainedPtr& source,
-    const SyntaxTreeBasePtr& target)
-{
-    auto [mapToLink, qualifiedName] = Slice::Csharp::csLinkFormatter(rawLink, source, target);
-    if (mapToLink)
-    {
-        return "<see " + qualifiedName + " />";
-    }
-    else
-    {
-        return "<c>" + qualifiedName + "</c>";
-    }
-}
-
-string
-Slice::Csharp::IceDocCommentFormatter::formatSeeAlso(
-    const string& rawLink,
-    const ContainedPtr& source,
-    const SyntaxTreeBasePtr& target)
-{
-    auto [mapToLink, qualifiedName] = Slice::Csharp::csLinkFormatter(rawLink, source, target);
-    if (mapToLink)
-    {
-        return "<seealso " + qualifiedName + " />";
-    }
-    else
-    {
-        return "";
-    }
 }

--- a/cpp/src/slice2cs/IceCsUtil.cpp
+++ b/cpp/src/slice2cs/IceCsUtil.cpp
@@ -810,7 +810,7 @@ Slice::Csharp::writeSequenceMarshalUnmarshalCode(
     assert(cont);
     if (useHelper)
     {
-        string helperName = getUnqualified(seq, ns, "" , "Helper");
+        string helperName = getUnqualified(seq, ns, "", "Helper");
         if (marshal)
         {
             out << nl << helperName << ".write(" << stream << ", " << param << ");";

--- a/cpp/src/slice2cs/IceCsUtil.cpp
+++ b/cpp/src/slice2cs/IceCsUtil.cpp
@@ -83,7 +83,7 @@ Slice::Csharp::typeToString(const TypePtr& type, const string& ns, bool optional
     InterfaceDeclPtr proxy = dynamic_pointer_cast<InterfaceDecl>(type);
     if (proxy)
     {
-        return getUnqualified(proxy, ns) + "Prx?";
+        return getUnqualified(proxy, ns, "", "Prx") + "?";
     }
 
     SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
@@ -468,7 +468,7 @@ Slice::Csharp::writeMarshalUnmarshalCode(
     DictionaryPtr d = dynamic_pointer_cast<Dictionary>(type);
     if (d)
     {
-        helperName = getUnqualified(d, ns) + "Helper";
+        helperName = getUnqualified(d, ns, "", "Helper");
     }
     else
     {
@@ -810,7 +810,7 @@ Slice::Csharp::writeSequenceMarshalUnmarshalCode(
     assert(cont);
     if (useHelper)
     {
-        string helperName = getUnqualified(seq, ns) + "Helper";
+        string helperName = getUnqualified(seq, ns, "" , "Helper");
         if (marshal)
         {
             out << nl << helperName << ".write(" << stream << ", " << param << ");";
@@ -1323,11 +1323,11 @@ Slice::Csharp::writeSequenceMarshalUnmarshalCode(
     string helperName;
     if (dynamic_pointer_cast<InterfaceDecl>(type))
     {
-        helperName = getUnqualified(dynamic_pointer_cast<InterfaceDecl>(type), ns) + "PrxHelper";
+        helperName = getUnqualified(dynamic_pointer_cast<InterfaceDecl>(type), ns, "", "PrxHelper");
     }
     else
     {
-        helperName = getUnqualified(dynamic_pointer_cast<Contained>(type), ns) + "Helper";
+        helperName = getUnqualified(dynamic_pointer_cast<Contained>(type), ns, "", "Helper");
     }
 
     string func;
@@ -1654,13 +1654,13 @@ Slice::Csharp::iceLinkFormatter(const string& rawLink, const ContainedPtr& sourc
         if (auto operationTarget = dynamic_pointer_cast<Operation>(target))
         {
             // link to the method on the proxy interface
-            result << getUnqualified(operationTarget->interface(), sourceScope) << "Prx."
+            result << getUnqualified(operationTarget->interface(), sourceScope, "", "Prx") << "."
                    << operationTarget->mappedName() << "Async";
         }
         else if (auto interfaceTarget = dynamic_pointer_cast<InterfaceDecl>(target))
         {
             // link to the proxy interface
-            result << getUnqualified(interfaceTarget, sourceScope) << "Prx";
+            result << getUnqualified(interfaceTarget, sourceScope, "", "Prx");
         }
         else
         {

--- a/cpp/src/slice2cs/IceCsUtil.h
+++ b/cpp/src/slice2cs/IceCsUtil.h
@@ -82,19 +82,7 @@ namespace Slice::Csharp
     /// - @c false if the link was to a Slice element which isn't mapped in C#; @c true otherwise.
     /// - The C# formatted link.
     std::pair<bool, std::string>
-    csLinkFormatter(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target);
-
-    class IceDocCommentFormatter final : public DocCommentFormatter
-    {
-    public:
-        void preprocess(StringList& rawComment) final;
-        std::string formatCode(const std::string& rawText) final;
-        std::string formatParamRef(const std::string& param) final;
-        std::string
-        formatLink(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target) final;
-        std::string
-        formatSeeAlso(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target) final;
-    };
+    iceLinkFormatter(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target);
 }
 
 #endif

--- a/cpp/src/slice2cs/IceRpcCsUtil.cpp
+++ b/cpp/src/slice2cs/IceRpcCsUtil.cpp
@@ -96,47 +96,38 @@ Slice::Csharp::csFieldType(const TypePtr& type, const string& ns, bool optional)
     static const char* builtinTable[] =
         {"byte", "bool", "short", "int", "long", "float", "double", "string", "IceRpc.ServiceAddress?", "SliceClass?"};
 
-    BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
-    if (builtin)
+    if (auto builtin = dynamic_pointer_cast<Builtin>(type))
     {
         return builtinTable[builtin->kind()];
     }
-
-    ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
-    if (cl)
+    else if (auto cl = dynamic_pointer_cast<ClassDecl>(type))
     {
         assert(!optional); // Optional classes are disallowed by the parser.
         return getUnqualified(cl, ns) + "?";
     }
-
-    InterfaceDeclPtr proxy = dynamic_pointer_cast<InterfaceDecl>(type);
-    if (proxy)
+    else if (auto proxy = dynamic_pointer_cast<InterfaceDecl>(type))
     {
         return getUnqualified(proxy, ns, "", "Proxy") + "?";
     }
-
-    SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
-    if (seq)
+    else if (auto seq = dynamic_pointer_cast<Sequence>(type))
     {
         return "global::System.Collections.Generic.IList<" + csFieldType(seq->type(), ns) + ">";
     }
-
-    DictionaryPtr d = dynamic_pointer_cast<Dictionary>(type);
-    if (d)
+    else if (auto d = dynamic_pointer_cast<Dictionary>(type))
     {
         return "global::System.Collections.Generic.IDictionary<" + csFieldType(d->keyType(), ns) + ", " +
                csFieldType(d->valueType(), ns) + ">";
     }
-
-    // Struct, Enum
-    ContainedPtr contained = dynamic_pointer_cast<Contained>(type);
-    if (contained)
+    else if (auto contained = dynamic_pointer_cast<Contained>(type))
     {
+        // Struct, Enum
         return getUnqualified(contained, ns);
     }
-
-    assert(false);
-    return "???";
+    else
+    {
+        assert(false);
+        return "???";
+    }
 }
 
 string
@@ -148,8 +139,7 @@ Slice::Csharp::csIncomingParamType(const TypePtr& type, const string& ns, bool o
         return csIncomingParamType(type, ns) + "?";
     }
 
-    SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
-    if (seq)
+    if (auto seq = dynamic_pointer_cast<Sequence>(type))
     {
         if (auto metadata = seq->getMetadataArgs("cs:generic"))
         {
@@ -165,23 +155,22 @@ Slice::Csharp::csIncomingParamType(const TypePtr& type, const string& ns, bool o
         }
         return csFieldType(seq->type(), ns) + "[]";
     }
-
-    DictionaryPtr d = dynamic_pointer_cast<Dictionary>(type);
-    if (d)
+    else if (auto d = dynamic_pointer_cast<Dictionary>(type))
     {
         string typeName = d->getMetadataArgs("cs:generic").value_or("Dictionary");
         return "global::System.Collections.Generic." + typeName + "<" + csFieldType(d->keyType(), ns) + ", " +
                csFieldType(d->valueType(), ns) + ">";
     }
-
-    return csFieldType(type, ns);
+    else
+    {
+        return csFieldType(type, ns);
+    }
 }
 
 string
 Slice::Csharp::csOutgoingParamType(const TypePtr& type, const string& ns, bool optional)
 {
-    SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
-    if (seq)
+    if (auto seq = dynamic_pointer_cast<Sequence>(type))
     {
         bool hasGenericMetadata = seq->hasMetadata("cs:generic");
 
@@ -199,15 +188,15 @@ Slice::Csharp::csOutgoingParamType(const TypePtr& type, const string& ns, bool o
             return "global::System.Collections.Generic.IEnumerable<" + elementTypeStr + ">" + (optional ? "?" : "");
         }
     }
-
-    DictionaryPtr d = dynamic_pointer_cast<Dictionary>(type);
-    if (d)
+    else if (auto d = dynamic_pointer_cast<Dictionary>(type))
     {
         return "global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<" +
-               csFieldType(d->keyType(), ns) + ", " + csFieldType(d->valueType(), ns) + ">>" + (optional ? "?" : "");
+               csFieldType(d->keyType(), ns) + ", " + csFieldType(d->valueType(), ns) + ">>";
     }
-
-    return csFieldType(type, ns, optional);
+    else
+    {
+        return csFieldType(type, ns, optional);
+    }
 }
 
 string
@@ -235,13 +224,8 @@ Slice::Csharp::csRequired(const DataMemberPtr& field)
         return false;
     }
 
-    BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(field->type());
-    if (builtin)
-    {
-        return builtin->kind() == Builtin::KindString;
-    }
-
-    return dynamic_pointer_cast<Sequence>(field->type()) || dynamic_pointer_cast<Dictionary>(field->type());
+    return isString(field->type()) || dynamic_pointer_cast<Sequence>(field->type()) ||
+           dynamic_pointer_cast<Dictionary>(field->type());
 }
 
 void
@@ -267,45 +251,29 @@ Slice::Csharp::encodeField(
         "NullableServiceAddress",
         "NullableClass"};
 
-    BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
-    if (builtin)
+    if (auto builtin = dynamic_pointer_cast<Builtin>(type))
     {
         out << encoderName << ".Encode" << builtinTable[builtin->kind()] << "(" << fieldName << ")";
-        return;
     }
-
-    ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
-    if (cl)
+    else if (auto cl = dynamic_pointer_cast<ClassDecl>(type))
     {
         out << encoderName << ".EncodeNullableClass(" << fieldName << ")";
-        return;
     }
-
-    StructPtr st = dynamic_pointer_cast<Struct>(type);
-    if (st)
+    else if (auto st = dynamic_pointer_cast<Struct>(type))
     {
         out << fieldName << ".Encode(ref " << encoderName << ")";
-        return;
     }
-
-    InterfaceDeclPtr proxy = dynamic_pointer_cast<InterfaceDecl>(type);
-    if (proxy)
+    else if (auto proxy = dynamic_pointer_cast<InterfaceDecl>(type))
     {
         out << getUnqualified(proxy, ns, "", "ProxySliceEncoderExtensions") << ".EncodeNullable"
             << removeEscapePrefix(proxy->mappedName()) << "Proxy(ref " << encoderName << ", " << fieldName << ")";
-        return;
     }
-
-    EnumPtr en = dynamic_pointer_cast<Enum>(type);
-    if (en)
+    else if (auto en = dynamic_pointer_cast<Enum>(type))
     {
         out << getUnqualified(en, ns, "", "SliceEncoderExtensions") << ".Encode" << removeEscapePrefix(en->mappedName())
             << "(ref " << encoderName << ", " << fieldName << ")";
-        return;
     }
-
-    SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
-    if (seq)
+    else if (auto seq = dynamic_pointer_cast<Sequence>(type))
     {
         if (hasFixedSizeBuiltinElements(seq) && !seq->hasMetadata("cs:generic"))
         {
@@ -333,11 +301,8 @@ Slice::Csharp::encodeField(
             out << ")";
             out.dec();
         }
-        return;
     }
-
-    DictionaryPtr dict = dynamic_pointer_cast<Dictionary>(type);
-    if (dict)
+    else if (auto dict = dynamic_pointer_cast<Dictionary>(type))
     {
         TypePtr keyType = dict->keyType();
         TypePtr valueType = dict->valueType();
@@ -357,10 +322,11 @@ Slice::Csharp::encodeField(
         out.dec();
         out << ")";
         out.dec();
-        return;
     }
-
-    assert(false);
+    else
+    {
+        assert(false);
+    }
 }
 
 void
@@ -453,7 +419,7 @@ Slice::Csharp::encodeOptionalField(
 }
 
 void
-Slice::Csharp::decodeField(Output& out, const TypePtr& type, const string& ns, TypeContext)
+Slice::Csharp::decodeField(Output& out, const TypePtr& type, const string& ns)
 {
     assert(type);
 
@@ -469,46 +435,29 @@ Slice::Csharp::decodeField(Output& out, const TypePtr& type, const string& ns, T
         "NullableServiceAddress",
         "NullableClass<SliceClass>"};
 
-    BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
-    if (builtin)
+    if (auto builtin = dynamic_pointer_cast<Builtin>(type))
     {
         out << "decoder.Decode" << builtinTable[builtin->kind()] << "()";
-        return;
     }
-
-    ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
-    if (cl)
+    else if (auto cl = dynamic_pointer_cast<ClassDecl>(type))
     {
         out << "decoder.DecodeNullableClass<" << getUnqualified(cl, ns) << ">()";
-        return;
     }
-
-    StructPtr st = dynamic_pointer_cast<Struct>(type);
-    if (st)
+    else if (auto st = dynamic_pointer_cast<Struct>(type))
     {
         out << "new " << getUnqualified(st, ns) << "(ref decoder)";
-        return;
     }
-
-    InterfaceDeclPtr proxy = dynamic_pointer_cast<InterfaceDecl>(type);
-    if (proxy)
+    else if (auto proxy = dynamic_pointer_cast<InterfaceDecl>(type))
     {
         out << getUnqualified(proxy, ns, "", "ProxySliceDecoderExtensions") << ".DecodeNullable"
             << removeEscapePrefix(proxy->mappedName()) << "Proxy(ref decoder)";
-
-        return;
     }
-
-    EnumPtr en = dynamic_pointer_cast<Enum>(type);
-    if (en)
+    else if (auto en = dynamic_pointer_cast<Enum>(type))
     {
         out << getUnqualified(en, ns, "", "SliceDecoderExtensions") << ".Decode" << removeEscapePrefix(en->mappedName())
             << "(ref decoder)";
-        return;
     }
-
-    SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
-    if (seq)
+    else if (auto seq = dynamic_pointer_cast<Sequence>(type))
     {
         bool hasGenericMetadata = seq->hasMetadata("cs:generic");
 
@@ -544,15 +493,12 @@ Slice::Csharp::decodeField(Output& out, const TypePtr& type, const string& ns, T
             }
             out << nl << "(ref SliceDecoder decoder) => ";
             castToNestedFieldType(out, seq->type(), ns);
-            decodeField(out, seq->type(), ns, TypeContext::Field);
+            decodeField(out, seq->type(), ns);
             out << ")";
             out.dec();
         }
-        return;
     }
-
-    DictionaryPtr dict = dynamic_pointer_cast<Dictionary>(type);
-    if (dict)
+    else if (auto dict = dynamic_pointer_cast<Dictionary>(type))
     {
         TypePtr keyType = dict->keyType();
         TypePtr valueType = dict->valueType();
@@ -564,17 +510,18 @@ Slice::Csharp::decodeField(Output& out, const TypePtr& type, const string& ns, T
         out.inc();
         out << nl << "size => new " << csDict << "(size),";
         out << nl << "(ref SliceDecoder decoder) => ";
-        decodeField(out, keyType, ns, TypeContext::Field);
+        decodeField(out, keyType, ns);
         out << ",";
         out << nl << "(ref SliceDecoder decoder) => ";
         castToNestedFieldType(out, valueType, ns);
-        decodeField(out, valueType, ns, TypeContext::Field);
+        decodeField(out, valueType, ns);
         out << ")";
         out.dec();
-        return;
     }
-
-    assert(false);
+    else
+    {
+        assert(false);
+    }
 }
 
 void
@@ -587,7 +534,7 @@ Slice::Csharp::decodeOptionalField(Output& out, int tag, const TypePtr& type, co
     out << nl << "(ref SliceDecoder decoder) => ";
     // We need to cast to the optional type. This is especially important for value types.
     out << "(" << csType(type, ns, context) << "?)";
-    decodeField(out, type, ns, context);
+    decodeField(out, type, ns);
     out << ",";
     out << nl << "useTagEndMarker: " << (context == TypeContext::Field ? "true" : "false");
     out << ")";

--- a/cpp/src/slice2cs/IceRpcCsUtil.cpp
+++ b/cpp/src/slice2cs/IceRpcCsUtil.cpp
@@ -111,7 +111,7 @@ Slice::Csharp::csFieldType(const TypePtr& type, const string& ns, bool optional)
     InterfaceDeclPtr proxy = dynamic_pointer_cast<InterfaceDecl>(type);
     if (proxy)
     {
-        return getUnqualified(proxy, ns) + "Proxy?";
+        return getUnqualified(proxy, ns, "", "Proxy") + "?";
     }
 
     SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
@@ -290,7 +290,7 @@ Slice::Csharp::encodeField(
     InterfaceDeclPtr proxy = dynamic_pointer_cast<InterfaceDecl>(type);
     if (proxy)
     {
-        out << getUnqualified(proxy, ns) << "ProxySliceEncoderExtensions.EncodeNullable"
+        out << getUnqualified(proxy, ns, "", "ProxySliceEncoderExtensions") << ".EncodeNullable"
             << removeEscapePrefix(proxy->mappedName()) << "Proxy(ref " << encoderName << ", " << fieldName << ")";
         return;
     }
@@ -298,7 +298,7 @@ Slice::Csharp::encodeField(
     EnumPtr en = dynamic_pointer_cast<Enum>(type);
     if (en)
     {
-        out << getUnqualified(en, ns) << "SliceEncoderExtensions.Encode" << removeEscapePrefix(en->mappedName())
+        out << getUnqualified(en, ns, "", "SliceEncoderExtensions") << ".Encode" << removeEscapePrefix(en->mappedName())
             << "(ref " << encoderName << ", " << fieldName << ")";
         return;
     }
@@ -492,7 +492,7 @@ Slice::Csharp::decodeField(Output& out, const TypePtr& type, const string& ns, T
     InterfaceDeclPtr proxy = dynamic_pointer_cast<InterfaceDecl>(type);
     if (proxy)
     {
-        out << getUnqualified(proxy, ns) << "ProxySliceDecoderExtensions.DecodeNullable"
+        out << getUnqualified(proxy, ns, "", "ProxySliceDecoderExtensions") << ".DecodeNullable"
             << removeEscapePrefix(proxy->mappedName()) << "Proxy(ref decoder)";
 
         return;
@@ -501,7 +501,7 @@ Slice::Csharp::decodeField(Output& out, const TypePtr& type, const string& ns, T
     EnumPtr en = dynamic_pointer_cast<Enum>(type);
     if (en)
     {
-        out << getUnqualified(en, ns) << "SliceDecoderExtensions.Decode" << removeEscapePrefix(en->mappedName())
+        out << getUnqualified(en, ns, "", "SliceDecoderExtensions") << ".Decode" << removeEscapePrefix(en->mappedName())
             << "(ref decoder)";
         return;
     }

--- a/cpp/src/slice2cs/IceRpcCsUtil.cpp
+++ b/cpp/src/slice2cs/IceRpcCsUtil.cpp
@@ -1,0 +1,670 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "IceRpcCsUtil.h"
+#include "../Slice/Util.h"
+#include "CsUtil.h"
+
+#include <cassert>
+
+using namespace std;
+using namespace Slice;
+using namespace IceInternal;
+
+namespace
+{
+    [[nodiscard]] bool hasFixedSizeBuiltinElements(const SequencePtr& seq)
+    {
+        BuiltinPtr elementTypeBuiltin = dynamic_pointer_cast<Builtin>(seq->type());
+        return elementTypeBuiltin && !elementTypeBuiltin->isVariableLength();
+    }
+
+    [[nodiscard]] bool isBool(const TypePtr& type)
+    {
+        BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
+        return builtin && builtin->kind() == Builtin::KindBool;
+    }
+
+    [[nodiscard]] bool isString(const TypePtr& type)
+    {
+        BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
+        return builtin && builtin->kind() == Builtin::KindString;
+    }
+
+    // The TagFormat is the OptionalFormat + the OptimizedVSize enumerator.
+    [[nodiscard]] string getTagFormat(const TypePtr& type)
+    {
+        SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
+        string tagFormat = type->getOptionalFormat();
+        if (tagFormat == "VSize")
+        {
+            if (isString(type) || (seq && seq->type()->minWireSize() == 1))
+            {
+                tagFormat = "OptimizedVSize";
+            }
+        }
+        return tagFormat;
+    }
+
+    void castToNestedFieldType(Output& out, const TypePtr& type, const string& ns)
+    {
+        if (dynamic_pointer_cast<Sequence>(type) || dynamic_pointer_cast<Dictionary>(type))
+        {
+            out << "(" << Slice::Csharp::csFieldType(type, ns) << ")";
+        }
+        // else no need to cast
+    }
+}
+
+bool
+Slice::Csharp::isCsValueType(const TypePtr& type)
+{
+    BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
+    if (builtin)
+    {
+        switch (builtin->kind())
+        {
+            case Builtin::KindByte:
+            case Builtin::KindBool:
+            case Builtin::KindShort:
+            case Builtin::KindInt:
+            case Builtin::KindLong:
+            case Builtin::KindFloat:
+            case Builtin::KindDouble:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    return dynamic_pointer_cast<Enum>(type) || dynamic_pointer_cast<Struct>(type) ||
+           dynamic_pointer_cast<InterfaceDecl>(type);
+}
+
+string
+Slice::Csharp::csFieldType(const TypePtr& type, const string& ns, bool optional)
+{
+    assert(type);
+
+    if (optional && !isProxyType(type))
+    {
+        // Proxy types are mapped the same way for optional and non-optional types.
+        return csFieldType(type, ns) + "?";
+    }
+    // else, just use the regular mapping.
+
+    static const char* builtinTable[] =
+        {"byte", "bool", "short", "int", "long", "float", "double", "string", "IceRpc.ServiceAddress?", "SliceClass?"};
+
+    BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
+    if (builtin)
+    {
+        return builtinTable[builtin->kind()];
+    }
+
+    ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
+    if (cl)
+    {
+        assert(!optional); // Optional classes are disallowed by the parser.
+        return getUnqualified(cl, ns) + "?";
+    }
+
+    InterfaceDeclPtr proxy = dynamic_pointer_cast<InterfaceDecl>(type);
+    if (proxy)
+    {
+        return getUnqualified(proxy, ns) + "Proxy?";
+    }
+
+    SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
+    if (seq)
+    {
+        return "global::System.Collections.Generic.IList<" + csFieldType(seq->type(), ns) + ">";
+    }
+
+    DictionaryPtr d = dynamic_pointer_cast<Dictionary>(type);
+    if (d)
+    {
+        return "global::System.Collections.Generic.IDictionary<" + csFieldType(d->keyType(), ns) + ", " +
+               csFieldType(d->valueType(), ns) + ">";
+    }
+
+    // Struct, Enum
+    ContainedPtr contained = dynamic_pointer_cast<Contained>(type);
+    if (contained)
+    {
+        return getUnqualified(contained, ns);
+    }
+
+    assert(false);
+    return "???";
+}
+
+string
+Slice::Csharp::csIncomingParamType(const TypePtr& type, const string& ns, bool optional)
+{
+    if (optional && !isProxyType(type))
+    {
+        // Proxy types are mapped the same way for optional and non-optional types.
+        return csIncomingParamType(type, ns) + "?";
+    }
+
+    SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
+    if (seq)
+    {
+        if (auto metadata = seq->getMetadataArgs("cs:generic"))
+        {
+            const string& customType = *metadata;
+            if (customType == "List" || customType == "LinkedList" || customType == "Queue" || customType == "Stack")
+            {
+                return "global::System.Collections.Generic." + customType + "<" + csFieldType(seq->type(), ns) + ">";
+            }
+            else
+            {
+                return "global::" + customType + "<" + csFieldType(seq->type(), ns) + ">";
+            }
+        }
+        return csFieldType(seq->type(), ns) + "[]";
+    }
+
+    DictionaryPtr d = dynamic_pointer_cast<Dictionary>(type);
+    if (d)
+    {
+        string typeName = d->getMetadataArgs("cs:generic").value_or("Dictionary");
+        return "global::System.Collections.Generic." + typeName + "<" + csFieldType(d->keyType(), ns) + ", " +
+               csFieldType(d->valueType(), ns) + ">";
+    }
+
+    return csFieldType(type, ns);
+}
+
+string
+Slice::Csharp::csOutgoingParamType(const TypePtr& type, const string& ns, bool optional)
+{
+    SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
+    if (seq)
+    {
+        bool hasGenericMetadata = seq->hasMetadata("cs:generic");
+
+        BuiltinPtr elementTypeBuiltin = dynamic_pointer_cast<Builtin>(seq->type());
+        string elementTypeStr = csFieldType(seq->type(), ns);
+
+        if (elementTypeBuiltin && !elementTypeBuiltin->isVariableLength() && !hasGenericMetadata)
+        {
+            // If the underlying type is a fixed-size primitive, we map to `ReadOnlyMemory` instead,
+            // and the mapping is the same for optional and non-optional types.
+            return "global::System.ReadOnlyMemory<" + elementTypeStr + ">";
+        }
+        else
+        {
+            return "global::System.Collections.Generic.IEnumerable<" + elementTypeStr + ">" + (optional ? "?" : "");
+        }
+    }
+
+    DictionaryPtr d = dynamic_pointer_cast<Dictionary>(type);
+    if (d)
+    {
+        return "global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<" +
+               csFieldType(d->keyType(), ns) + ", " + csFieldType(d->valueType(), ns) + ">>" + (optional ? "?" : "");
+    }
+
+    return csFieldType(type, ns, optional);
+}
+
+string
+Slice::Csharp::csType(const TypePtr& type, const string& ns, TypeContext context, bool optional)
+{
+    switch (context)
+    {
+        case TypeContext::Field:
+            return csFieldType(type, ns, optional);
+        case TypeContext::IncomingParam:
+            return csIncomingParamType(type, ns, optional);
+        case TypeContext::OutgoingParam:
+            return csOutgoingParamType(type, ns, optional);
+        default:
+            assert(false);
+            return "???";
+    }
+}
+
+bool
+Slice::Csharp::csRequired(const DataMemberPtr& field)
+{
+    if (field->optional())
+    {
+        return false;
+    }
+
+    BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(field->type());
+    if (builtin)
+    {
+        return builtin->kind() == Builtin::KindString;
+    }
+
+    return dynamic_pointer_cast<Sequence>(field->type()) || dynamic_pointer_cast<Dictionary>(field->type());
+}
+
+void
+Slice::Csharp::encodeField(
+    Output& out,
+    const string& fieldName,
+    const TypePtr& type,
+    const string& ns,
+    TypeContext context,
+    const string& encoderName)
+{
+    assert(type);
+
+    static const char* builtinTable[] = {
+        "UInt8",
+        "Bool",
+        "Int16",
+        "Int32",
+        "Int64",
+        "Float",
+        "Double",
+        "String",
+        "NullableServiceAddress",
+        "NullableClass"};
+
+    BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
+    if (builtin)
+    {
+        out << encoderName << ".Encode" << builtinTable[builtin->kind()] << "(" << fieldName << ")";
+        return;
+    }
+
+    ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
+    if (cl)
+    {
+        out << encoderName << ".EncodeNullableClass(" << fieldName << ")";
+        return;
+    }
+
+    StructPtr st = dynamic_pointer_cast<Struct>(type);
+    if (st)
+    {
+        out << fieldName << ".Encode(ref " << encoderName << ")";
+        return;
+    }
+
+    InterfaceDeclPtr proxy = dynamic_pointer_cast<InterfaceDecl>(type);
+    if (proxy)
+    {
+        out << getUnqualified(proxy, ns) << "ProxySliceEncoderExtensions.EncodeNullable"
+            << removeEscapePrefix(proxy->mappedName()) << "Proxy(ref " << encoderName << ", " << fieldName << ")";
+        return;
+    }
+
+    EnumPtr en = dynamic_pointer_cast<Enum>(type);
+    if (en)
+    {
+        out << getUnqualified(en, ns) << "SliceEncoderExtensions.Encode" << removeEscapePrefix(en->mappedName())
+            << "(ref " << encoderName << ", " << fieldName << ")";
+        return;
+    }
+
+    SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
+    if (seq)
+    {
+        if (hasFixedSizeBuiltinElements(seq) && !seq->hasMetadata("cs:generic"))
+        {
+            if (context == TypeContext::OutgoingParam)
+            {
+                out << encoderName << ".EncodeSpan(" << fieldName << ".Span)";
+            }
+            else
+            {
+                out << encoderName << ".EncodeSequence(" << fieldName << ")";
+            }
+        }
+        else
+        {
+            TypePtr elementType = seq->type();
+
+            out << encoderName << ".EncodeSequence(";
+            out.inc();
+            out << nl << fieldName << ",";
+            out << nl << "(ref SliceEncoder encoder, " << csFieldType(elementType, ns) << " value) =>";
+            out << nl;
+            out.inc();
+            encodeField(out, "value", elementType, ns, TypeContext::Field, "encoder");
+            out.dec();
+            out << ")";
+            out.dec();
+        }
+        return;
+    }
+
+    DictionaryPtr dict = dynamic_pointer_cast<Dictionary>(type);
+    if (dict)
+    {
+        TypePtr keyType = dict->keyType();
+        TypePtr valueType = dict->valueType();
+        out << encoderName << ".EncodeDictionary(";
+        out.inc();
+        out << nl << fieldName << ",";
+        out << nl << "(ref SliceEncoder encoder, " << csFieldType(keyType, ns) << " key) =>";
+        out << nl;
+        out.inc();
+        encodeField(out, "key", keyType, ns, TypeContext::Field, "encoder");
+        out.dec();
+        out << ',';
+        out << nl << "(ref SliceEncoder encoder, " << csFieldType(valueType, ns) << " value) =>";
+        out << nl;
+        out.inc();
+        encodeField(out, "value", valueType, ns, TypeContext::Field, "encoder");
+        out.dec();
+        out << ")";
+        out.dec();
+        return;
+    }
+
+    assert(false);
+}
+
+void
+Slice::Csharp::encodeOptionalField(
+    Output& out,
+    int tag,
+    const string& fieldName,
+    const TypePtr& type,
+    const string& ns,
+    TypeContext context,
+    const string& encoderName)
+{
+    assert(type);
+
+    SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
+    bool readOnlyMemory = seq && hasFixedSizeBuiltinElements(seq) && !seq->hasMetadata("cs:generic") &&
+                          context == TypeContext::OutgoingParam;
+
+    string tagFormat = getTagFormat(type);
+
+    if (readOnlyMemory)
+    {
+        out << nl << "if (" << fieldName << ".Span != null)";
+    }
+    else if (isCsValueType(type))
+    {
+        out << nl << "if (" << fieldName << ".HasValue)";
+    }
+    else
+    {
+        out << nl << "if (" << fieldName << " is not null)";
+    }
+    out << sb;
+
+    if (tagFormat == "VSize" && ((seq && !readOnlyMemory) || dynamic_pointer_cast<Dictionary>(type)))
+    {
+        out << nl << "int count_ = " << fieldName << ".Count();"; // may be slow
+        out << sp;
+    }
+
+    out << nl << encoderName << ".EncodeTagged(";
+    out.inc();
+    out << nl << "tag: " << tag << ",";
+
+    if (tagFormat == "VSize")
+    {
+        // "size" overload
+        out << nl << "size: ";
+        if (auto st = dynamic_pointer_cast<Struct>(type))
+        {
+            out << st->minWireSize();
+        }
+        else if (readOnlyMemory)
+        {
+            out << encoderName << ".GetSizeLength(" << fieldName << ".Length) + " << seq->type()->minWireSize() << " * "
+                << fieldName << ".Length";
+        }
+        else if (seq)
+        {
+            out << encoderName << ".GetSizeLength(count_) + " << seq->type()->minWireSize() << " * count_";
+        }
+        else if (auto dict = dynamic_pointer_cast<Dictionary>(type))
+        {
+            out << encoderName << ".GetSizeLength(count_) + "
+                << (dict->keyType()->minWireSize() + dict->valueType()->minWireSize()) << " * count_";
+        }
+        else
+        {
+            // No other VSize.
+            assert(false);
+        }
+        out << ",";
+    }
+    else
+    {
+        // TagFormat overload
+        out << nl << "TagFormat." << tagFormat << ",";
+    }
+
+    out << nl << fieldName << (isCsValueType(type) ? ".Value" : "") << ",";
+    out << nl << "(ref SliceEncoder encoder, " << csType(type, ns, context) << " value) => ";
+    out.inc();
+    encodeField(out, "value", type, ns, context, "encoder");
+    out.dec();
+    out << ");";
+    out.dec();
+
+    out << eb;
+    // else, don't encode anything for null.
+}
+
+void
+Slice::Csharp::decodeField(Output& out, const TypePtr& type, const string& ns, TypeContext)
+{
+    assert(type);
+
+    static const char* builtinTable[] = {
+        "UInt8",
+        "Bool",
+        "Int16",
+        "Int32",
+        "Int64",
+        "Float",
+        "Double",
+        "String",
+        "NullableServiceAddress",
+        "NullableClass<SliceClass>"};
+
+    BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
+    if (builtin)
+    {
+        out << "decoder.Decode" << builtinTable[builtin->kind()] << "()";
+        return;
+    }
+
+    ClassDeclPtr cl = dynamic_pointer_cast<ClassDecl>(type);
+    if (cl)
+    {
+        out << "decoder.DecodeNullableClass<" << getUnqualified(cl, ns) << ">()";
+        return;
+    }
+
+    StructPtr st = dynamic_pointer_cast<Struct>(type);
+    if (st)
+    {
+        out << "new " << getUnqualified(st, ns) << "(ref decoder)";
+        return;
+    }
+
+    InterfaceDeclPtr proxy = dynamic_pointer_cast<InterfaceDecl>(type);
+    if (proxy)
+    {
+        out << getUnqualified(proxy, ns) << "ProxySliceDecoderExtensions.DecodeNullable"
+            << removeEscapePrefix(proxy->mappedName()) << "Proxy(ref decoder)";
+
+        return;
+    }
+
+    EnumPtr en = dynamic_pointer_cast<Enum>(type);
+    if (en)
+    {
+        out << getUnqualified(en, ns) << "SliceDecoderExtensions.Decode" << removeEscapePrefix(en->mappedName())
+            << "(ref decoder)";
+        return;
+    }
+
+    SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
+    if (seq)
+    {
+        bool hasGenericMetadata = seq->hasMetadata("cs:generic");
+
+        // The concrete type we create.
+        string csSeq = csIncomingParamType(seq, ns);
+
+        if (hasFixedSizeBuiltinElements(seq))
+        {
+            if (hasGenericMetadata)
+            {
+                out << "new " << csSeq << "(";
+            }
+
+            out << "decoder.DecodeSequence<" << Slice::Csharp::csFieldType(seq->type(), ns) << ">(";
+            if (isBool(seq->type()))
+            {
+                out << "checkElement: SliceDecoder.CheckBoolValue";
+            }
+            out << ")";
+
+            if (hasGenericMetadata)
+            {
+                out << ")";
+            }
+        }
+        else
+        {
+            out << "decoder.DecodeSequence(";
+            out.inc();
+            if (hasGenericMetadata)
+            {
+                out << nl << "sequenceFactory: size => new " << csSeq << "(size),";
+            }
+            out << nl << "(ref SliceDecoder decoder) => ";
+            castToNestedFieldType(out, seq->type(), ns);
+            decodeField(out, seq->type(), ns, TypeContext::Field);
+            out << ")";
+            out.dec();
+        }
+        return;
+    }
+
+    DictionaryPtr dict = dynamic_pointer_cast<Dictionary>(type);
+    if (dict)
+    {
+        TypePtr keyType = dict->keyType();
+        TypePtr valueType = dict->valueType();
+
+        // The concrete type we create.
+        string csDict = csIncomingParamType(dict, ns);
+
+        out << "decoder.DecodeDictionary(";
+        out.inc();
+        out << nl << "size => new " << csDict << "(size),";
+        out << nl << "(ref SliceDecoder decoder) => ";
+        decodeField(out, keyType, ns, TypeContext::Field);
+        out << ",";
+        out << nl << "(ref SliceDecoder decoder) => ";
+        castToNestedFieldType(out, valueType, ns);
+        decodeField(out, valueType, ns, TypeContext::Field);
+        out << ")";
+        out.dec();
+        return;
+    }
+
+    assert(false);
+}
+
+void
+Slice::Csharp::decodeOptionalField(Output& out, int tag, const TypePtr& type, const string& ns, TypeContext context)
+{
+    out << "decoder.DecodeTagged(";
+    out.inc();
+    out << nl << "tag: " << tag << ",";
+    out << nl << "TagFormat." << getTagFormat(type) << ",";
+    out << nl << "(ref SliceDecoder decoder) => ";
+    // We need to cast to the optional type. This is especially important for value types.
+    out << "(" << csType(type, ns, context) << "?)";
+    decodeField(out, type, ns, context);
+    out << ",";
+    out << nl << "useTagEndMarker: " << (context == TypeContext::Field ? "true" : "false");
+    out << ")";
+    out.dec();
+}
+
+std::pair<bool, string>
+Slice::Csharp::icerpcLinkFormatter(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target)
+{
+    ostringstream result;
+
+    if (auto builtinTarget = dynamic_pointer_cast<Builtin>(target))
+    {
+        string typeS = csFieldType(builtinTarget, "");
+        if (builtinTarget->kind() == Builtin::KindObjectProxy || builtinTarget->kind() == Builtin::KindValue)
+        {
+            // Remove trailing '?':
+            typeS.pop_back();
+            result << "cref=\"" << typeS << "\"";
+        }
+        else
+        {
+            // All other builtin types correspond to C# language keywords.
+            result << "langword=\"" << typeS << "\"";
+        }
+    }
+    else if (auto contained = dynamic_pointer_cast<Contained>(target))
+    {
+        string sourceScope = source->mappedScope(".");
+        sourceScope.pop_back(); // Remove the trailing '.' ns separator.
+
+        if (dynamic_pointer_cast<Sequence>(contained) || dynamic_pointer_cast<Dictionary>(contained))
+        {
+            // slice2cs doesn't generate C# types for sequences or dictionaries, so there's nothing to link to.
+            // So, we return 'false' to signal this, and just output the sequence or dictionary name.
+            return {false, getUnqualified(contained, sourceScope)};
+        }
+
+        result << "cref=\"";
+        if (auto operationTarget = dynamic_pointer_cast<Operation>(target))
+        {
+            // link to the method on the proxy interface
+            result << getUnqualified(operationTarget->interface(), sourceScope, "", "Proxy") << "."
+                   << operationTarget->mappedName() << "Async";
+        }
+        else if (auto interfaceTarget = dynamic_pointer_cast<InterfaceDecl>(target))
+        {
+            // link to the proxy interface
+            result << getUnqualified(interfaceTarget, sourceScope, "", "Proxy");
+        }
+        else
+        {
+            result << getUnqualified(contained, sourceScope);
+        }
+        result << "\"";
+    }
+    else
+    {
+        // Replace "::" by "." in the raw link. This is for the situation where the user passes a Slice type
+        // reference but (a) the source Slice file does not include this type and (b) there is no cs:identifier or
+        // other identifier renaming.
+        string targetS = rawLink;
+        // Replace any "::" ns separators with '.'s.
+        auto pos = targetS.find("::");
+        while (pos != string::npos)
+        {
+            targetS.replace(pos, 2, ".");
+            pos = targetS.find("::", pos);
+        }
+        // Replace any '#' ns separators with '.'s.
+        replace(targetS.begin(), targetS.end(), '#', '.');
+        // Remove any leading ns separators.
+        if (targetS.find('.') == 0)
+        {
+            targetS.erase(0, 1);
+        }
+        result << "cref=\"" << targetS << "\"";
+    }
+
+    return {true, result.str()};
+}

--- a/cpp/src/slice2cs/IceRpcCsUtil.cpp
+++ b/cpp/src/slice2cs/IceRpcCsUtil.cpp
@@ -4,6 +4,7 @@
 #include "../Slice/Util.h"
 #include "CsUtil.h"
 
+#include <algorithm>
 #include <cassert>
 
 using namespace std;

--- a/cpp/src/slice2cs/IceRpcCsUtil.cpp
+++ b/cpp/src/slice2cs/IceRpcCsUtil.cpp
@@ -631,7 +631,7 @@ Slice::Csharp::icerpcLinkFormatter(const string& rawLink, const ContainedPtr& so
         {
             // link to the method on the proxy interface
             result << getUnqualified(operationTarget->interface(), sourceScope, "", "Proxy") << "."
-                   << operationTarget->mappedName() << "Async";
+                   << removeEscapePrefix(operationTarget->mappedName()) << "Async";
         }
         else if (auto interfaceTarget = dynamic_pointer_cast<InterfaceDecl>(target))
         {

--- a/cpp/src/slice2cs/IceRpcCsUtil.cpp
+++ b/cpp/src/slice2cs/IceRpcCsUtil.cpp
@@ -397,7 +397,7 @@ Slice::Csharp::encodeOptionalField(
 
     if (tagFormat == "VSize" && ((seq && !readOnlyMemory) || dynamic_pointer_cast<Dictionary>(type)))
     {
-        out << nl << "int count_ = " << fieldName << ".Count();"; // may be slow
+        out << nl << "int count_ = global::System.Linq.Enumerable.Count(" << fieldName << ");"; // may be slow
         out << sp;
     }
 

--- a/cpp/src/slice2cs/IceRpcCsUtil.h
+++ b/cpp/src/slice2cs/IceRpcCsUtil.h
@@ -69,7 +69,7 @@ namespace Slice::Csharp
         const std::string& encoderName);
 
     /// Decodes a non-optional field.
-    void decodeField(::IceInternal::Output& out, const TypePtr& type, const std::string& ns, TypeContext context);
+    void decodeField(::IceInternal::Output& out, const TypePtr& type, const std::string& ns);
 
     /// Decodes an optional field.
     void decodeOptionalField(

--- a/cpp/src/slice2cs/IceRpcCsUtil.h
+++ b/cpp/src/slice2cs/IceRpcCsUtil.h
@@ -1,0 +1,93 @@
+// Copyright (c) ZeroC, Inc.
+
+#ifndef ICE_RPC_CS_UTIL_H
+#    define ICE_RPC _CS_UTIL_H
+
+#    include "../Ice/OutputUtil.h"
+#    include "../Slice/DocCommentParser.h"
+#    include "../Slice/Parser.h"
+
+// IceRPC-specific helper functions for C# code generation.
+
+namespace Slice::Csharp
+{
+    enum class TypeContext
+    {
+        Field,
+        IncomingParam,
+        OutgoingParam
+    };
+
+    /// Does this type maps to a value type in C#?
+    [[nodiscard]] bool isCsValueType(const TypePtr& type);
+
+    /// Maps a Slice type to a C# field type.
+    /// @param type The Slice type to map.
+    /// @param ns The current C# namespace.
+    /// @param optional Whether the field is optional.
+    /// @return The C# type for the field.
+    [[nodiscard]] std::string csFieldType(const TypePtr& type, const std::string& ns, bool optional = false);
+
+    /// Maps a Slice type to a C# incoming parameter type.
+    /// @param type The Slice type to map.
+    /// @param ns The current C# namespace.
+    /// @param optional Whether the parameter is optional.
+    /// @return The C# type for the incoming parameter.
+    [[nodiscard]] std::string csIncomingParamType(const TypePtr& type, const std::string& ns, bool optional = false);
+
+    /// Maps a Slice type to a C# outgoing parameter type.
+    /// @param type The Slice type to map.
+    /// @param ns The current C# namespace.
+    /// @param optional Whether the parameter is optional.
+    /// @return The C# type for the outgoing parameter.
+    [[nodiscard]] std::string csOutgoingParamType(const TypePtr& type, const std::string& ns, bool optional = false);
+
+    /// Maps a Slice type to a C# type based on TypeContext.
+    [[nodiscard]] std::string
+    csType(const TypePtr& type, const std::string& ns, TypeContext context, bool optional = false);
+
+    /// Returns whether the mapped C# field is required or not.
+    [[nodiscard]] bool csRequired(const DataMemberPtr& field);
+
+    /// Encodes a non-optional field.
+    void encodeField(
+        ::IceInternal::Output& out,
+        const std::string& fieldName,
+        const TypePtr& type,
+        const std::string& ns,
+        TypeContext context,
+        const std::string& encoderName);
+
+    /// Encodes an optional field.
+    void encodeOptionalField(
+        ::IceInternal::Output& out,
+        int tag,
+        const std::string& fieldName,
+        const TypePtr& type,
+        const std::string& ns,
+        TypeContext context,
+        const std::string& encoderName);
+
+    /// Decodes a non-optional field.
+    void decodeField(::IceInternal::Output& out, const TypePtr& type, const std::string& ns, TypeContext context);
+
+    /// Decodes an optional field.
+    void decodeOptionalField(
+        ::IceInternal::Output& out,
+        int tag,
+        const TypePtr& type,
+        const std::string& ns,
+        TypeContext context);
+
+    /// Converts a Slice-formatted link into a C# formatted link.
+    /// @param rawLink The reference's raw text, taken verbatim from the doc-comment.
+    /// @param source A pointer to the Slice element that the doc-comment (and reference) are written on.
+    /// @param target A pointer to the Slice element that is being referenced, or `nullptr` if it doesn't exist.
+    /// @returns A pair containing:
+    /// - @c false if the link was to a Slice element which isn't mapped in C#; @c true otherwise.
+    /// - The C# formatted link.
+    std::pair<bool, std::string>
+    icerpcLinkFormatter(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target);
+}
+
+#endif

--- a/cpp/src/slice2cs/IceRpcCsUtil.h
+++ b/cpp/src/slice2cs/IceRpcCsUtil.h
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 #ifndef ICE_RPC_CS_UTIL_H
-#    define ICE_RPC _CS_UTIL_H
+#    define ICE_RPC_CS_UTIL_H
 
 #    include "../Ice/OutputUtil.h"
 #    include "../Slice/DocCommentParser.h"

--- a/cpp/src/slice2cs/IceRpcCsUtil.h
+++ b/cpp/src/slice2cs/IceRpcCsUtil.h
@@ -1,11 +1,11 @@
 // Copyright (c) ZeroC, Inc.
 
 #ifndef ICE_RPC_CS_UTIL_H
-#    define ICE_RPC_CS_UTIL_H
+#define ICE_RPC_CS_UTIL_H
 
-#    include "../Ice/OutputUtil.h"
-#    include "../Slice/DocCommentParser.h"
-#    include "../Slice/Parser.h"
+#include "../Ice/OutputUtil.h"
+#include "../Slice/DocCommentParser.h"
+#include "../Slice/Parser.h"
 
 // IceRPC-specific helper functions for C# code generation.
 

--- a/cpp/src/slice2cs/IceRpcCsUtil.h
+++ b/cpp/src/slice2cs/IceRpcCsUtil.h
@@ -18,7 +18,7 @@ namespace Slice::Csharp
         OutgoingParam
     };
 
-    /// Does this type maps to a value type in C#?
+    /// Does this type map to a value type in C#?
     [[nodiscard]] bool isCsValueType(const TypePtr& type);
 
     /// Maps a Slice type to a C# field type.

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -904,14 +904,15 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(
         _out,
         "summary",
-        "Provides an extension method for <see cref=\"SliceEncoder\" /> to encode a <see cref=\"" + name +
-            "Proxy\" />.");
+        R"(Provides an extension method for <see cref="SliceEncoder" /> to encode a <see cref=")" + name +
+            R"(Proxy" />."))");
     _out << nl << "public static class " << name << "ProxySliceEncoderExtensions";
     _out << sb;
     writeDocLine(
         _out,
         "summary",
-        "Encodes a nullable <see cref=\"" + name + "Proxy\" /> as a nullable <see cref=\"IceRpc.ServiceAddress\" />.");
+        R"(Encodes a nullable <see cref=")" + name +
+            R"(Proxy" /> as a nullable <see cref="IceRpc.ServiceAddress" />.)");
     writeDocLine(_out, "param name=\"encoder\"", "The Slice encoder.", "param");
     writeDocLine(_out, "param name=\"proxy\"", "The proxy to encode as a service address (can be null).", "param");
     _out << nl << "public static void EncodeNullable" << name << "Proxy(this ref SliceEncoder encoder, " << name
@@ -925,16 +926,16 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(
         _out,
         "summary",
-        "Provides an extension method for <see cref=\"SliceDecoder\" /> to decode a <see cref=\"" + name +
-            "Proxy\" />.");
+        R"(Provides an extension method for <see cref="SliceDecoder" /> to decode a <see cref=")" + name +
+            R"(Proxy" />.)");
 
     _out << nl << "public static class " << name << "ProxySliceDecoderExtensions";
     _out << sb;
     writeDocLine(
         _out,
         "summary",
-        "Decodes a nullable <see cref=\"IceRpc.ServiceAddress\" /> into a nullable <see cref=\"" + name +
-            "Proxy\" />.");
+        R"(Decodes a nullable <see cref="IceRpc.ServiceAddress" /> into a nullable <see cref=")" + name +
+            R"(Proxy" />.)");
     writeDocLine(_out, "param name=\"decoder\"", "The Slice decoder.", "param");
     _out << nl << "public static " << name << "Proxy? DecodeNullable" << name
          << "Proxy(this ref SliceDecoder decoder) =>";
@@ -1161,7 +1162,7 @@ Slice::IceRpc::ProxyVisitor::writeProxyResponseClass(const InterfaceDefPtr& inte
                 _out << '(';
                 for (auto q = exceptionList.begin(); q != exceptionList.end(); ++q)
                 {
-                    ExceptionPtr exception = *q;
+                    const ExceptionPtr& exception = *q;
                     if (q != exceptionList.begin())
                     {
                         _out << " or ";

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -549,7 +549,7 @@ Slice::IceRpc::TypesVisitor::writePrimaryConstructor(
         _out << nl << "[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]";
     }
 
-    _out << nl << "public " << name << spar << ctorParams << epar;
+    _out << nl << "public " << escapedName << spar << ctorParams << epar;
     if (!baseParams.empty())
     {
         _out.inc();

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -130,7 +130,14 @@ namespace
         }
     }
 
-    void writeMethod(IceInternal::Output& out, const OperationPtr& operation, const std::string& ns, bool dispatch)
+    /// Writes the method signature for an operation, without access or semicolon.
+    /// @param out The output to write to.
+    /// @param operation The Slice operation being mapped to C#.
+    /// @param ns The current C# namespace.
+    /// @param dispatch If true, writes the signature for the dispatch method (with incoming parameter types and a
+    /// ValueTask return type); if false, writes the signature for the proxy method.
+    void
+    writeMethodSignature(IceInternal::Output& out, const OperationPtr& operation, const std::string& ns, bool dispatch)
     {
         TypeContext paramContext = dispatch ? TypeContext::IncomingParam : TypeContext::OutgoingParam;
 
@@ -211,7 +218,7 @@ Slice::IceRpc::TypesVisitor::visitStructEnd(const StructPtr& p)
     for (const auto& field : p->dataMembers())
     {
         _out << nl << "this." + field->mappedName() << " = ";
-        decodeField(_out, field->type(), ns, TypeContext::Field);
+        decodeField(_out, field->type(), ns);
         _out << ';';
     }
     _out << eb;
@@ -629,7 +636,7 @@ Slice::IceRpc::TypesVisitor::writeEncodeDecode(
         if (!field->optional())
         {
             _out << nl << "this." + field->mappedName() << " = ";
-            decodeField(_out, field->type(), ns, TypeContext::Field);
+            decodeField(_out, field->type(), ns);
             _out << ';';
         }
     }
@@ -821,18 +828,18 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     for (const auto& operation : p->allInheritedOperations())
     {
         _out << sp;
-        _out << nl << "/// <inheritdoc/>";
+        _out << nl << "/// <inheritdoc />";
         _out << nl << "public ";
 
         string featureParam = escapeParamName("features", operation->inParameters());
         string cancellationTokenParam = escapeParamName("cancellationToken", operation->inParameters());
 
-        writeMethod(_out, operation, ns, false);
+        writeMethodSignature(_out, operation, ns, false);
 
         _out << " =>";
         _out.inc();
         _out << nl << "(" << getUnqualified(operation->interface(), ns, "", "Proxy") << ")this."
-             << operation->mappedName();
+             << removeEscapePrefix(operation->mappedName()) << "Async";
         _out << spar;
         for (const auto& param : operation->inParameters())
         {
@@ -856,12 +863,14 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         string featureParam = escapeParamName("features", operation->inParameters());
         string cancellationTokenParam = escapeParamName("cancellationToken", operation->inParameters());
 
-        writeMethod(_out, operation, ns, false);
+        writeMethodSignature(_out, operation, ns, false);
 
         _out << " =>";
         _out.inc();
 
-        // There is no equivalent for [compress] in Ice-Slice.
+        // IceRPC-Slice provides a `[compress]` attribute to compress request/response payloads for requests/responses
+        // sent over the icerpc protocol. There is no equivalent for [compress] in Ice-Slice; this is not a serious
+        // limitation since Ice-Slice is used primarily with the ice protocol.
 
         _out << nl << "this.InvokeOperationAsync(";
         _out.inc();
@@ -905,7 +914,7 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         _out,
         "summary",
         R"(Provides an extension method for <see cref="SliceEncoder" /> to encode a <see cref=")" + name +
-            R"(Proxy" />."))");
+            R"(Proxy" />.")");
     _out << nl << "public static class " << name << "ProxySliceEncoderExtensions";
     _out << sb;
     writeDocLine(
@@ -913,8 +922,8 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "summary",
         R"(Encodes a nullable <see cref=")" + name +
             R"(Proxy" /> as a nullable <see cref="IceRpc.ServiceAddress" />.)");
-    writeDocLine(_out, "param name=\"encoder\"", "The Slice encoder.", "param");
-    writeDocLine(_out, "param name=\"proxy\"", "The proxy to encode as a service address (can be null).", "param");
+    writeDocLine(_out, R"(param name="encoder")", "The Slice encoder.", "param");
+    writeDocLine(_out, R"(param name="proxy")", "The proxy to encode as a service address (can be null).", "param");
     _out << nl << "public static void EncodeNullable" << name << "Proxy(this ref SliceEncoder encoder, " << name
          << "Proxy? proxy) =>";
     _out.inc();
@@ -936,7 +945,7 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         "summary",
         R"(Decodes a nullable <see cref="IceRpc.ServiceAddress" /> into a nullable <see cref=")" + name +
             R"(Proxy" />.)");
-    writeDocLine(_out, "param name=\"decoder\"", "The Slice decoder.", "param");
+    writeDocLine(_out, R"(param name="decoder")", "The Slice decoder.", "param");
     _out << nl << "public static " << name << "Proxy? DecodeNullable" << name
          << "Proxy(this ref SliceDecoder decoder) =>";
     _out.inc();
@@ -955,7 +964,7 @@ Slice::IceRpc::ProxyVisitor::visitOperation(const OperationPtr& p)
     // TODO: doc comment for operation
     emitObsoleteAttribute(p);
     _out << nl;
-    writeMethod(_out, p, ns, false);
+    writeMethodSignature(_out, p, ns, false);
     _out << ';';
 }
 
@@ -975,8 +984,8 @@ Slice::IceRpc::ProxyVisitor::writeProxyRequestClass(const InterfaceDefPtr& inter
             "summary",
             "Encodes the argument(s) of operation <c>" + operation->name() + "</c> into a request payload.");
         // TODO: param doc comments
-        writeDocLine(_out, "param name=\"encodeOptions\"", "The Slice encode options.", "param");
-        writeDocLine(_out, "returns", "The Slice-encoded payload.");
+        writeDocLine(_out, R"(param name="encodeOptions")", "The Slice encode options.", "param");
+        writeDocLine(_out, "returns", "The Slice-encoded payload.", "returns");
 
         _out << nl << "public static global::System.IO.Pipelines.PipeReader Encode"
              << removeEscapePrefix(operation->mappedName()) << "(";
@@ -1089,7 +1098,7 @@ Slice::IceRpc::ProxyVisitor::writeProxyResponseClass(const InterfaceDefPtr& inte
                 }
                 else
                 {
-                    decodeField(_out, returnParams.front()->type(), ns, TypeContext::IncomingParam);
+                    decodeField(_out, returnParams.front()->type(), ns);
                 }
             }
             else
@@ -1107,7 +1116,7 @@ Slice::IceRpc::ProxyVisitor::writeProxyResponseClass(const InterfaceDefPtr& inte
                     }
                     else
                     {
-                        decodeField(_out, param->type(), ns, TypeContext::IncomingParam);
+                        decodeField(_out, param->type(), ns);
                     }
                     _out << ';';
                 }
@@ -1289,7 +1298,7 @@ Slice::IceRpc::SkeletonVisitor::visitOperation(const OperationPtr& p)
     _out << ")]";
 
     _out << nl;
-    writeMethod(_out, p, ns, true);
+    writeMethodSignature(_out, p, ns, true);
     _out << ';';
 }
 
@@ -1350,7 +1359,7 @@ Slice::IceRpc::SkeletonVisitor::writeRequestClass(const InterfaceDefPtr& interfa
                 }
                 else
                 {
-                    decodeField(_out, inParameters.front()->type(), ns, TypeContext::IncomingParam);
+                    decodeField(_out, inParameters.front()->type(), ns);
                 }
             }
             else
@@ -1368,7 +1377,7 @@ Slice::IceRpc::SkeletonVisitor::writeRequestClass(const InterfaceDefPtr& interfa
                     }
                     else
                     {
-                        decodeField(_out, param->type(), ns, TypeContext::IncomingParam);
+                        decodeField(_out, param->type(), ns);
                     }
                     _out << ';';
                 }

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -1,0 +1,1486 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "IceRpcVisitors.h"
+#include "../Slice/Util.h"
+#include "CsUtil.h"
+#include "IceRpcCsUtil.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <iterator>
+
+using namespace std;
+using namespace Slice;
+using namespace Slice::Csharp;
+using namespace IceInternal;
+
+namespace
+{
+    // Returns paramName as-is or escaped if it conflicts with any of the parameter names in params.
+    // paramName does not start with an escape prefix.
+    string escapeParamName(string paramName, const ParameterList& params)
+    {
+        for (const auto& param : params)
+        {
+            if (param->mappedName() == paramName)
+            {
+                return paramName + "_";
+            }
+        }
+        return paramName;
+    }
+
+    // paramName does not start with an escape prefix.
+    string escapeCapitalizedParamName(string paramName, const ParameterList& params)
+    {
+        for (const auto& param : params)
+        {
+            if (toPascalCase(param->mappedName()) == paramName)
+            {
+                return paramName + "_";
+            }
+        }
+        return paramName;
+    }
+
+    string defaultServicePath(const InterfaceDefPtr& interface)
+    {
+        string path = interface->scoped().substr(2); // Remove leading '::'
+        string::size_type pos = 0;
+        while ((pos = path.find("::", pos)) != string::npos)
+        {
+            path.replace(pos, 2, ".");
+            pos += 1;
+        }
+
+        return "/" + path;
+    }
+
+    string classFormat(const OperationPtr& operation)
+    {
+        FormatType format = operation->format().value_or(FormatType::CompactFormat);
+        return format == FormatType::SlicedFormat ? "ClassFormat.Sliced" : "default";
+    }
+
+    void writeReturnTask(IceInternal::Output& out, const OperationPtr& operation, const string& taskType, bool dispatch)
+    {
+        string ns = getNamespace(operation->interface());
+
+        out << "global::System.Threading.Tasks." << taskType;
+
+        TypeContext returnContext = dispatch ? TypeContext::OutgoingParam : TypeContext::IncomingParam;
+
+        if (operation->returnsAnyValues())
+        {
+            out << '<';
+            ParameterList returnParams = operation->outParameters();
+            if (operation->returnType())
+            {
+                string returnParamName = escapeCapitalizedParamName("ReturnValue", returnParams);
+                returnParams.insert(returnParams.begin(), operation->returnParameter(returnParamName));
+            }
+
+            if (returnParams.size() == 1)
+            {
+                out << csType(returnParams.front()->type(), ns, returnContext, returnParams.front()->optional());
+            }
+            else
+            {
+                out << spar;
+                for (const auto& param : returnParams)
+                {
+                    out
+                        << (csType(param->type(), ns, returnContext, param->optional()) + " " +
+                            toPascalCase(param->mappedName()));
+                }
+                out << epar;
+            }
+            out << '>';
+        }
+    }
+
+    // A ValueTask that holds all the decoded in parameters,
+    void writeParamsValueTask(IceInternal::Output& out, const OperationPtr& operation)
+    {
+        string ns = getNamespace(operation->interface());
+
+        out << "global::System.Threading.Tasks.ValueTask";
+
+        ParameterList inParameters = operation->inParameters();
+        if (!inParameters.empty())
+        {
+            out << '<';
+            if (inParameters.size() == 1)
+            {
+                out << csIncomingParamType(inParameters.front()->type(), ns, inParameters.front()->optional());
+            }
+            else
+            {
+                out << spar;
+                for (const auto& param : inParameters)
+                {
+                    out
+                        << (csIncomingParamType(param->type(), ns, param->optional()) + " " +
+                            toPascalCase(param->mappedName()));
+                }
+                out << epar;
+            }
+            out << '>';
+        }
+    }
+
+    void writeMethod(IceInternal::Output& out, const OperationPtr& operation, const std::string& ns, bool dispatch)
+    {
+        TypeContext paramContext = dispatch ? TypeContext::IncomingParam : TypeContext::OutgoingParam;
+
+        string featuresParam = escapeParamName("features", operation->inParameters());
+        string cancellationTokenParam = escapeParamName("cancellationToken", operation->inParameters());
+
+        vector<string> extraParams;
+        if (dispatch)
+        {
+            extraParams = {
+                "IceRpc.Features.IFeatureCollection " + featuresParam,
+                "global::System.Threading.CancellationToken " + cancellationTokenParam};
+        }
+        else
+        {
+            extraParams = {
+                "IceRpc.Features.IFeatureCollection? " + featuresParam + " = null",
+                "global::System.Threading.CancellationToken " + cancellationTokenParam + " = default"};
+        }
+
+        writeReturnTask(out, operation, dispatch ? "ValueTask" : "Task", dispatch);
+        out << ' ' << removeEscapePrefix(operation->mappedName()) << "Async(";
+        out.inc();
+        for (const auto& param : operation->inParameters())
+        {
+            out << nl << csType(param->type(), ns, paramContext, param->optional()) << ' ' << param->mappedName()
+                << ',';
+        }
+
+        for (auto q = extraParams.begin(); q != extraParams.end();)
+        {
+            out << nl << *q;
+            if (++q != extraParams.end())
+            {
+                out << ',';
+            }
+        }
+        out << ')';
+        out.dec();
+    }
+}
+
+Slice::IceRpc::TypesVisitor::TypesVisitor(IceInternal::Output& out) : CsVisitor(out) {}
+
+bool
+Slice::IceRpc::TypesVisitor::visitStructStart(const StructPtr& p)
+{
+    _out << sp;
+    writeDocComment(p, "record struct");
+    emitObsoleteAttribute(p);
+    _out << nl << "public partial record struct " << p->mappedName();
+    _out << sb;
+    return true;
+}
+
+void
+Slice::IceRpc::TypesVisitor::visitStructEnd(const StructPtr& p)
+{
+    string escapedName = p->mappedName();
+    string ns = getNamespace(p);
+
+    bool hasRequiredField = writePrimaryConstructor(p, p->dataMembers(), {}, "struct");
+
+    // Decoding constructor.
+    _out << sp;
+    writeDocLine(
+        _out,
+        "summary",
+        "Initializes a new instance of the <see cref=\"" + escapedName + "\" /> struct from a SliceDecoder.");
+
+    if (hasRequiredField)
+    {
+        _out << nl << "[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]";
+    }
+
+    _out << nl << "public " << escapedName << "(ref SliceDecoder decoder)";
+    _out << sb;
+    for (const auto& field : p->dataMembers())
+    {
+        _out << nl << "this." + field->mappedName() << " = ";
+        decodeField(_out, field->type(), ns, TypeContext::Field);
+        _out << ';';
+    }
+    _out << eb;
+
+    // Encode method.
+    _out << sp;
+    writeDocLine(_out, "summary", "Encodes the fields of this struct with a Slice encoder.");
+
+    _out << nl << "public void Encode(ref SliceEncoder encoder)";
+    _out << sb;
+    for (const auto& field : p->dataMembers())
+    {
+        _out << nl;
+        encodeField(_out, "this." + field->mappedName(), field->type(), ns, TypeContext::Field, "encoder");
+        _out << ';';
+    }
+    _out << eb;
+
+    _out << eb;
+}
+
+bool
+Slice::IceRpc::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
+{
+    string ns = getNamespace(p);
+
+    _out << sp;
+    writeDocComment(p, "class");
+    emitObsoleteAttribute(p);
+    _out << nl << "[SliceTypeId(\"" << p->scoped() << "\")]";
+    if (p->compactId() != -1)
+    {
+        _out << nl << "[CompactSliceTypeId(" << p->compactId() << ")]";
+    }
+    _out << nl << "public partial class " << p->mappedName() << " : ";
+
+    ClassDefPtr base = p->base();
+    if (base)
+    {
+        _out << getUnqualified(base, ns);
+    }
+    else
+    {
+        _out << "SliceClass";
+    }
+    _out << sb;
+    return true;
+}
+
+void
+Slice::IceRpc::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
+{
+    string escapedName = p->mappedName();
+    string ns = getNamespace(p);
+
+    if (!p->dataMembers().empty())
+    {
+        _out << sp;
+    }
+    _out << nl << "private static readonly string SliceTypeId = typeof(" << escapedName << ").GetSliceTypeId()!;";
+    if (p->compactId() != -1)
+    {
+        _out << nl << "private static readonly int CompactSliceTypeId = typeof(" << escapedName
+             << ").GetCompactSliceTypeId()!.Value;";
+    }
+
+    if (!p->allDataMembers().empty())
+    {
+        DataMemberList allBaseFields;
+        if (p->base())
+        {
+            allBaseFields = p->base()->allDataMembers();
+        }
+
+        writePrimaryConstructor(p, p->dataMembers(), allBaseFields, "class");
+
+        // Public parameterless constructor.
+        _out << sp;
+        writeDocLine(_out, "summary", "Initializes a new instance of the <see cref=\"" + escapedName + "\" /> class.");
+        _out << nl << "public " << escapedName << "()";
+        _out << sb;
+        _out << eb;
+    }
+    // else, no need to generate any constructor.
+
+    writeEncodeDecode(p->compactId(), ns, p->base() != nullptr, p->dataMembers(), p->orderedOptionalDataMembers());
+
+    _out << eb;
+}
+
+bool
+Slice::IceRpc::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
+{
+    string ns = getNamespace(p);
+
+    _out << sp;
+    writeDocComment(p, "exception class");
+    emitObsoleteAttribute(p);
+    _out << nl << "[SliceTypeId(\"" << p->scoped() << "\")]";
+    _out << nl << "public partial class " << p->mappedName() << " : ";
+
+    ExceptionPtr base = p->base();
+    if (base)
+    {
+        _out << getUnqualified(base, ns);
+    }
+    else
+    {
+        _out << "SliceException";
+    }
+    _out << sb;
+    return true;
+}
+
+void
+Slice::IceRpc::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
+{
+    string escapedName = p->mappedName();
+    string ns = getNamespace(p);
+
+    if (!p->dataMembers().empty())
+    {
+        _out << sp;
+    }
+    _out << nl << "private static readonly string SliceTypeId = typeof(" << escapedName << ").GetSliceTypeId()!;";
+
+    if (!p->allDataMembers().empty())
+    {
+        DataMemberList allBaseFields;
+        if (p->base())
+        {
+            allBaseFields = p->base()->allDataMembers();
+        }
+
+        writePrimaryConstructor(p, p->dataMembers(), allBaseFields, "exception class");
+
+        // Public parameterless constructor.
+        _out << sp;
+        writeDocLine(
+            _out,
+            "summary",
+            "Initializes a new instance of the <see cref=\"" + escapedName + "\" /> exception class.");
+        _out << nl << "public " << escapedName << "()";
+        _out << sb;
+        _out << eb;
+    }
+    // else, no need to generate any constructor.
+
+    writeEncodeDecode(-1, ns, p->base() != nullptr, p->dataMembers(), p->orderedOptionalDataMembers());
+
+    _out << eb;
+}
+
+void
+Slice::IceRpc::TypesVisitor::visitDataMember(const DataMemberPtr& p)
+{
+    ContainedPtr cont = dynamic_pointer_cast<Contained>(p->container());
+    assert(cont);
+    string ns = getNamespace(cont);
+
+    _out << sp;
+    writeDocComment(p);
+    emitObsoleteAttribute(p);
+    emitAttributes(p);
+    _out << nl << "public ";
+    if (csRequired(p))
+    {
+        _out << "required ";
+    }
+    _out << csFieldType(p->type(), ns, p->optional()) << ' ' << p->mappedName() << " { get; set; }";
+}
+
+void
+Slice::IceRpc::TypesVisitor::visitEnum(const EnumPtr& p)
+{
+    string escapedName = p->mappedName();
+    string name = removeEscapePrefix(p->mappedName());
+    string ns = getNamespace(p);
+    EnumeratorList enumerators = p->enumerators();
+    const bool hasExplicitValues = p->hasExplicitValues();
+
+    _out << sp;
+    writeDocComment(p, "enum");
+    emitObsoleteAttribute(p);
+    emitAttributes(p);
+    _out << nl << "public enum " << escapedName;
+    _out << sb;
+    for (const auto& enumerator : enumerators)
+    {
+        if (!isFirstElement(enumerator))
+        {
+            _out << ',';
+            _out << sp;
+        }
+
+        writeDocComment(enumerator);
+        emitObsoleteAttribute(enumerator);
+        emitAttributes(enumerator);
+        _out << nl << enumerator->mappedName();
+        if (hasExplicitValues)
+        {
+            _out << " = " << enumerator->value();
+        }
+    }
+    _out << eb;
+
+    //
+    // XxxIntExtensions
+    //
+    _out << sp;
+    ostringstream intExtensionsComment;
+    intExtensionsComment << "Provides an extension method for creating " << getArticleFor(name) << " <see cref=\""
+                         << escapedName << "\" /> from an int.";
+    writeHelperDocComment(p, intExtensionsComment.str(), "enum helper class");
+    _out << nl << "public static class " << name << "IntExtensions";
+    _out << sb;
+
+    // When the number of enumerators is smaller than the distance between the min and max
+    // values, the values are not consecutive and we need to use a set to validate the value
+    // during decoding.
+    // Note that the values are not necessarily in order, e.g. we can use a simple range check
+    // for enum E { A = 3, B = 2, C = 1 } during decoding.
+    bool useSet = p->enumerators().size() < static_cast<size_t>(p->maxValue() - p->minValue() + 1);
+
+    if (useSet)
+    {
+        _out << nl
+             << "private static readonly global::System.Collections.Generic.HashSet<int> _enumeratorValues = new()";
+        _out.spar("{ ");
+        for (const auto& enumerator : enumerators)
+        {
+            _out << enumerator->value();
+        }
+        _out.epar(" };");
+        _out << sp;
+    }
+
+    // TODO: doc-comment
+    _out << nl << "public static " << escapedName << " As" << name << "(this int value) =>";
+    _out.inc();
+    if (useSet)
+    {
+        _out << nl << "_enumeratorValues.Contains(value) ? ";
+    }
+    else
+    {
+        _out << nl << "(value >= " << p->minValue() << " && value <= " << p->maxValue() << ") ? ";
+    }
+    _out << "(" << escapedName << ")value :";
+    _out.inc();
+    _out << nl << "throw new global::System.IO.InvalidDataException($\"Invalid value {value} for enum " << escapedName
+         << ".\");";
+    _out.dec();
+    _out.dec();
+    _out << eb;
+
+    //
+    // XxxSliceEncoderExtensions and XxxSliceDecoderExtensions
+    //
+    _out << sp;
+    ostringstream encoderExtensionsComment;
+    encoderExtensionsComment << "Provides an extension method for encoding " << getArticleFor(name) << " <see cref=\""
+                             << escapedName << "\" />.";
+    writeHelperDocComment(p, encoderExtensionsComment.str(), "enum helper class");
+    _out << nl << "public static class " << name << "SliceEncoderExtensions";
+    _out << sb;
+
+    // TODO: doc-comment
+    _out << nl << "public static void Encode" << name << "(this ref SliceEncoder encoder, " << escapedName
+         << " value) => encoder.EncodeSize((int)value);";
+    _out << eb;
+
+    _out << sp;
+    ostringstream decoderExtensionsComment;
+    decoderExtensionsComment << "Provides an extension method for decoding " << getArticleFor(name) << " <see cref=\""
+                             << escapedName << "\" />.";
+    writeHelperDocComment(p, decoderExtensionsComment.str(), "enum helper class");
+    _out << nl << "public static class " << name << "SliceDecoderExtensions";
+    _out << sb;
+
+    // TODO: doc-comment
+    _out << nl << "public static " << escapedName << " Decode" << name << "(this ref SliceDecoder decoder) => " << name
+         << "IntExtensions.As" << name << "(decoder.DecodeSize());";
+    _out << eb;
+}
+
+bool
+Slice::IceRpc::TypesVisitor::writePrimaryConstructor(
+    const ContainedPtr& p,
+    const DataMemberList& fields,
+    const DataMemberList& allBaseFields,
+    const string& kind)
+{
+    // Primary constructor with parameters for all fields.
+    string escapedName = p->mappedName();
+    string name = removeEscapePrefix(escapedName);
+    string ns = getNamespace(p);
+
+    _out << sp;
+    writeDocLine(
+        _out,
+        "summary",
+        "Initializes a new instance of the <see cref=\"" + escapedName + "\" /> " + kind + ".");
+
+    vector<string> ctorParams;
+    vector<string> baseParams;
+    vector<string> ctorPropertyInits;
+    bool hasRequiredField = false;
+
+    for (const auto& field : allBaseFields)
+    {
+        string paramName = field->customMappedName().value_or(toCamelCase(field->name()));
+        ctorParams.push_back(csFieldType(field->type(), ns, field->optional()) + " " + paramName);
+        if (csRequired(field))
+        {
+            hasRequiredField = true;
+        }
+        baseParams.push_back(paramName);
+    }
+
+    for (const auto& field : fields)
+    {
+        string paramName = field->customMappedName().value_or(toCamelCase(field->name()));
+        ctorParams.push_back(csFieldType(field->type(), ns, field->optional()) + " " + paramName);
+        if (csRequired(field))
+        {
+            hasRequiredField = true;
+        }
+
+        ctorPropertyInits.push_back("this." + field->mappedName() + " = " + paramName + ';');
+    }
+
+    if (hasRequiredField)
+    {
+        _out << nl << "[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]";
+    }
+
+    _out << nl << "public " << name << spar << ctorParams << epar;
+    if (!baseParams.empty())
+    {
+        _out.inc();
+        _out << nl << ": base" << spar << baseParams << epar;
+        _out.dec();
+    }
+
+    _out << sb;
+    for (const auto& propertyInit : ctorPropertyInits)
+    {
+        _out << nl << propertyInit;
+    }
+    _out << eb;
+    return hasRequiredField;
+}
+
+void
+Slice::IceRpc::TypesVisitor::writeEncodeDecode(
+    int compactId,
+    const string& ns,
+    bool hasBase,
+    const DataMemberList& fields,
+    const DataMemberList& orderedOptionalFields)
+{
+    _out << sp;
+    emitNonBrowsableAttribute();
+    _out << nl << "protected override void EncodeCore(ref SliceEncoder encoder)";
+    _out << sb;
+    _out << nl << "encoder.StartSlice(SliceTypeId";
+    if (compactId != -1)
+    {
+        _out << ", CompactSliceTypeId";
+    }
+    _out << ");";
+    // Encode non-optional fields
+    for (const auto& field : fields)
+    {
+        if (!field->optional())
+        {
+            _out << nl;
+            encodeField(_out, "this." + field->mappedName(), field->type(), ns, TypeContext::Field, "encoder");
+            _out << ';';
+        }
+    }
+    // Encode optional fields
+    for (const auto& field : orderedOptionalFields)
+    {
+        encodeOptionalField(
+            _out,
+            field->tag(),
+            "this." + field->mappedName(),
+            field->type(),
+            ns,
+            TypeContext::Field,
+            "encoder");
+    }
+
+    if (hasBase)
+    {
+        _out << nl << "encoder.EndSlice(false);";
+        _out << nl << "base.EncodeCore(ref encoder);";
+    }
+    else
+    {
+        _out << nl << "encoder.EndSlice(true);"; // last slice
+    }
+    _out << eb;
+
+    _out << sp;
+    emitNonBrowsableAttribute();
+    _out << nl << "protected override void DecodeCore(ref SliceDecoder decoder)";
+    _out << sb;
+    _out << nl << "decoder.StartSlice();";
+    // Decode non-optional fields
+    for (const auto& field : fields)
+    {
+        if (!field->optional())
+        {
+            _out << nl << "this." + field->mappedName() << " = ";
+            decodeField(_out, field->type(), ns, TypeContext::Field);
+            _out << ';';
+        }
+    }
+    // Decode optional fields
+    for (const auto& field : orderedOptionalFields)
+    {
+        _out << nl << "this." + field->mappedName() << " = ";
+        decodeOptionalField(_out, field->tag(), field->type(), ns, TypeContext::Field);
+        _out << ';';
+    }
+
+    _out << nl << "decoder.EndSlice();";
+    if (hasBase)
+    {
+        _out << nl << "base.DecodeCore(ref decoder);";
+    }
+    _out << eb;
+}
+
+Slice::IceRpc::ProxyVisitor::ProxyVisitor(IceInternal::Output& out) : CsVisitor(out) {}
+
+bool
+Slice::IceRpc::ProxyVisitor::visitModuleStart(const ModulePtr& p)
+{
+    if (!p->contains<InterfaceDef>())
+    {
+        return false;
+    }
+    return CsVisitor::visitModuleStart(p);
+}
+
+bool
+Slice::IceRpc::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
+{
+    string ns = getNamespace(p);
+    string escapedName = p->mappedName();
+    string name = removeEscapePrefix(escapedName);
+
+    // Generate the client interface.
+    _out << sp;
+    writeDocComment(p, "client-side interface");
+    emitObsoleteAttribute(p);
+    _out << nl << "public partial interface I" << name;
+    if (!p->bases().empty())
+    {
+        _out << " : ";
+        _out.spar("");
+        for (const auto& base : p->bases())
+        {
+            _out << getUnqualified(base, ns, "I");
+        }
+        _out.epar("");
+    }
+
+    _out << sb;
+
+    return true;
+}
+
+void
+Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
+{
+    string ns = getNamespace(p);
+    string escapedName = p->mappedName();
+    string name = removeEscapePrefix(escapedName);
+
+    _out << eb; // end of client interface
+
+    // Generate the proxy struct.
+    _out << sp;
+
+    writeDocLines(
+        _out,
+        "summary",
+        {"Implements <see cref=\"I" + name + "\" /> by making invocations on a remote IceRPC service.",
+         "This remote service must implement Slice interface <c>" + p->scoped() + "</c>."});
+
+    _out << nl << "[SliceTypeId(\"" << p->scoped() << "\")]";
+    emitObsoleteAttribute(p);
+    _out << nl << "public readonly partial record struct " << name << "Proxy : " << 'I' << name << ", IProxy";
+
+    _out << sb;
+
+    writeProxyRequestClass(p);
+    _out << sp;
+    writeProxyResponseClass(p);
+    _out << sp;
+
+    _out << nl << "/// <summary>Represents the default path for IceRPC services that implement Slice interface";
+    _out << nl << "/// <c>" << p->scoped() << "</c>.</summary>";
+    _out << nl << "public const string DefaultServicePath = \"" << defaultServicePath(p) << "\";";
+    _out << sp;
+    _out << nl << "/// <inheritdoc/>";
+    _out << nl << "public SliceEncodeOptions? EncodeOptions { get; init; }";
+    _out << sp;
+    _out << nl << "/// <inheritdoc/>";
+    _out << nl << "public required IceRpc.IInvoker Invoker { get; init; }";
+    _out << sp;
+    _out << nl << "/// <inheritdoc/>";
+    _out << nl << "public IceRpc.ServiceAddress ServiceAddress { get; init; } = _defaultServiceAddress;";
+    _out << sp;
+    _out << nl << "private static IceRpc.ServiceAddress _defaultServiceAddress =";
+    _out.inc();
+    _out << nl << "new(IceRpc.Protocol.IceRpc) { Path = DefaultServicePath };";
+    _out.dec();
+    _out << sp;
+    _out << nl << "private static readonly IActivator _defaultActivator =";
+    _out.inc();
+    _out << nl << "IActivator.FromAssembly(typeof(" << name << "Proxy).Assembly);";
+    _out.dec();
+
+    // Implicit base conversions
+    for (const auto& base : p->bases())
+    {
+        _out << sp;
+        string baseName = getUnqualified(base, ns) + "Proxy";
+        writeDocLine(_out, "summary", "Provides an implicit conversion to <see cref =\"" + baseName + "\" />.");
+
+        _out << nl << "public static implicit operator " << baseName << "(" << name << "Proxy proxy) =>";
+        _out.inc();
+        _out << nl
+             << "new() { EncodeOptions = proxy.EncodeOptions, Invoker = proxy.Invoker, ServiceAddress = "
+                "proxy.ServiceAddress };";
+        _out.dec();
+    }
+
+    // FromPath static method.
+    _out << sp;
+    _out << nl << "/// <summary>Creates a relative proxy from a path.</summary>";
+    _out << nl << "/// <param name=\"path\">The path.</param>";
+    _out << nl << "/// <returns>The new relative proxy.</returns>";
+    _out << nl << "public static " << name << "Proxy FromPath(string path) =>";
+    _out.inc();
+    _out << nl << "new(IceRpc.InvalidInvoker.Instance, new IceRpc.ServiceAddress { Path = path });";
+    _out.dec();
+
+    // Primary constructor (invoker, serviceAddress, encodeOptions).
+    _out << sp;
+    _out << nl << "/// <summary>Constructs a proxy from an invoker, a service address and encode options.</summary>";
+    _out << nl << "/// <param name=\"invoker\">The invocation pipeline of the proxy.</param>";
+    _out << nl
+         << "/// <param name=\"serviceAddress\">The service address. <see langword=\"null\" /> is equivalent to an "
+            "IceRPC service address";
+    _out << nl << "/// with path <see cref=\"DefaultServicePath\" />.</param>";
+    _out << nl
+         << "/// <param name=\"encodeOptions\">The encode options, used to customize the encoding of request "
+            "payloads.</param>";
+    _out << nl << "[System.Diagnostics.CodeAnalysis.SetsRequiredMembers]";
+    _out << nl << "public " << name << "Proxy(";
+    _out.inc();
+    _out << nl << "IceRpc.IInvoker invoker,";
+    _out << nl << "IceRpc.ServiceAddress? serviceAddress = null,";
+    _out << nl << "SliceEncodeOptions? encodeOptions = null)";
+    _out.dec();
+    _out << sb;
+    _out << nl << "Invoker = invoker;";
+    _out << nl << "ServiceAddress = serviceAddress ?? _defaultServiceAddress;";
+    _out << nl << "EncodeOptions = encodeOptions;";
+    _out << eb;
+
+    // Constructor (invoker, serviceAddressUri, encodeOptions).
+    _out << sp;
+    _out << nl
+         << "/// <summary>Constructs a proxy from an invoker, a service address URI and encode options.</summary>";
+    _out << nl << "/// <param name=\"invoker\">The invocation pipeline of the proxy.</param>";
+    _out << nl << "/// <param name=\"serviceAddressUri\">A URI that represents a service address.</param>";
+    _out << nl
+         << "/// <param name=\"encodeOptions\">The encode options, used to customize the encoding of request "
+            "payloads.</param>";
+    _out << nl << "[System.Diagnostics.CodeAnalysis.SetsRequiredMembers]";
+    _out << nl << "public " << name
+         << "Proxy(IceRpc.IInvoker invoker, System.Uri serviceAddressUri, SliceEncodeOptions? encodeOptions = null)";
+    _out.inc();
+    _out << nl << ": this(invoker, new IceRpc.ServiceAddress(serviceAddressUri), encodeOptions)";
+    _out.dec();
+    _out << sb;
+    _out << eb;
+
+    // Parameterless constructor.
+    _out << sp;
+    _out << nl
+         << "/// <summary>Constructs a proxy with an IceRPC service address with path <see cref=\"DefaultServicePath\" "
+            "/>.</summary>";
+    _out << nl << "public " << name << "Proxy()";
+    _out << sb;
+    _out << eb;
+
+    // Inherited operations
+    for (const auto& operation : p->allInheritedOperations())
+    {
+        _out << sp;
+        _out << nl << "/// <inheritdoc/>";
+        _out << nl << "public ";
+
+        string featureParam = escapeParamName("features", operation->inParameters());
+        string cancellationTokenParam = escapeParamName("cancellationToken", operation->inParameters());
+
+        writeMethod(_out, operation, ns, false);
+
+        _out << " =>";
+        _out.inc();
+        _out << nl << "(" << getUnqualified(operation->interface(), ns, "", "Proxy") << ")this."
+             << operation->mappedName();
+        _out << spar;
+        for (const auto& param : operation->inParameters())
+        {
+            _out << param->mappedName();
+        }
+
+        _out << featureParam << cancellationTokenParam;
+        _out << epar;
+        _out << ';';
+        _out.dec();
+    }
+
+    // My operations
+    for (const auto& operation : p->operations())
+    {
+        _out << sp;
+        _out << nl << "/// <inheritdoc/>";
+        _out << nl << "public ";
+
+        string operationName = removeEscapePrefix(operation->mappedName());
+        string featureParam = escapeParamName("features", operation->inParameters());
+        string cancellationTokenParam = escapeParamName("cancellationToken", operation->inParameters());
+
+        writeMethod(_out, operation, ns, false);
+
+        _out << " =>";
+        _out.inc();
+
+        // There is no equivalent for [compress] in Ice-Slice.
+
+        _out << nl << "this.InvokeOperationAsync(";
+        _out.inc();
+        _out << nl << "\"" << operation->name() << "\",";
+        if (operation->inParameters().empty())
+        {
+            _out << nl << "payload: Request.Encode" << operationName << "(encodeOptions: EncodeOptions),";
+        }
+        else
+        {
+            _out << nl << "payload: Request.Encode" << operationName;
+            _out << spar;
+            for (const auto& param : operation->inParameters())
+            {
+                _out << param->mappedName();
+            }
+            // TODO: escape encodeOptions
+            _out << "encodeOptions: EncodeOptions";
+            _out << epar;
+            _out << ',';
+        }
+        _out << nl << "payloadContinuation: null,";
+        _out << nl << "Response.Decode" << operationName << "Async,";
+        _out << nl << featureParam << ",";
+        if (operation->mode() == Operation::Idempotent)
+        {
+            _out << nl << "idempotent: true,";
+        }
+        // TODO: oneway attribute
+
+        _out << nl << "cancellationToken: " << cancellationTokenParam << ");";
+        _out.dec();
+
+        _out.dec();
+    }
+    _out << eb;
+
+    // Generate extension classes.
+    _out << sp;
+    writeDocLine(
+        _out,
+        "summary",
+        "Provides an extension method for <see cref=\"SliceEncoder\" /> to encode a <see cref=\"" + name +
+            "Proxy\" />.");
+    _out << nl << "public static class " << name << "ProxySliceEncoderExtensions";
+    _out << sb;
+    writeDocLine(
+        _out,
+        "summary",
+        "Encodes a nullable <see cref=\"" + name + "Proxy\" /> as a nullable <see cref=\"IceRpc.ServiceAddress\" />.");
+    writeDocLine(_out, "param name=\"encoder\"", "The Slice encoder.", "param");
+    writeDocLine(_out, "param name=\"proxy\"", "The proxy to encode as a service address (can be null).", "param");
+    _out << nl << "public static void EncodeNullable" << name << "Proxy(this ref SliceEncoder encoder, " << name
+         << "Proxy? proxy) =>";
+    _out.inc();
+    _out << nl << "encoder.EncodeNullableServiceAddress(proxy?.ServiceAddress);";
+    _out.dec();
+    _out << eb;
+
+    _out << sp;
+    writeDocLine(
+        _out,
+        "summary",
+        "Provides an extension method for <see cref=\"SliceDecoder\" /> to decode a <see cref=\"" + name +
+            "Proxy\" />.");
+
+    _out << nl << "public static class " << name << "ProxySliceDecoderExtensions";
+    _out << sb;
+    writeDocLine(
+        _out,
+        "summary",
+        "Decodes a nullable <see cref=\"IceRpc.ServiceAddress\" /> into a nullable <see cref=\"" + name +
+            "Proxy\" />.");
+    writeDocLine(_out, "param name=\"decoder\"", "The Slice decoder.", "param");
+    _out << nl << "public static " << name << "Proxy? DecodeNullable" << name
+         << "Proxy(this ref SliceDecoder decoder) =>";
+    _out.inc();
+    _out << nl << "decoder.DecodeNullableProxy<" << name << "Proxy>();";
+    _out.dec();
+    _out << eb;
+}
+
+void
+Slice::IceRpc::ProxyVisitor::visitOperation(const OperationPtr& p)
+{
+    string ns = getNamespace(p->interface());
+
+    _out << sp;
+
+    // TODO: doc comment for operation
+    emitObsoleteAttribute(p);
+    _out << nl;
+    writeMethod(_out, p, ns, false);
+    _out << ';';
+}
+
+void
+Slice::IceRpc::ProxyVisitor::writeProxyRequestClass(const InterfaceDefPtr& interface)
+{
+    string ns = getNamespace(interface);
+
+    writeDocLine(_out, "summary", "Provides static methods that encode operation arguments into request payloads.");
+    _out << nl << "public static class Request";
+    _out << sb;
+
+    for (const auto& operation : interface->operations())
+    {
+        writeDocLine(
+            _out,
+            "summary",
+            "Encodes the argument(s) of operation <c>" + operation->name() + "</c> into a request payload.");
+        // TODO: param doc comments
+        writeDocLine(_out, "param name=\"encodeOptions\"", "The Slice encode options.", "param");
+        writeDocLine(_out, "returns", "The Slice-encoded payload.");
+
+        _out << nl << "public static global::System.IO.Pipelines.PipeReader Encode"
+             << removeEscapePrefix(operation->mappedName()) << "(";
+
+        _out.inc();
+        for (const auto& param : operation->inParameters())
+        {
+            _out << nl << csOutgoingParamType(param->type(), ns, param->optional()) << ' ' << param->mappedName()
+                 << ',';
+        }
+        _out << nl << "SliceEncodeOptions? encodeOptions = null)";
+        _out.dec();
+        _out << sb;
+        if (operation->inParameters().empty())
+        {
+            _out << nl << "return IceRpc.EmptyPipeReader.Instance;";
+        }
+        else
+        {
+            _out << nl << "var pipe_ = new global::System.IO.Pipelines.Pipe(";
+            _out.inc();
+            _out << nl << "encodeOptions?.PipeOptions ?? SliceEncodeOptions.Default.PipeOptions);";
+            _out.dec();
+            _out << nl << "var encoder_ = new SliceEncoder(pipe_.Writer, SliceEncoding.Slice1, "
+                 << classFormat(operation) << ");";
+
+            for (const auto& param : operation->sortedInParameters())
+            {
+                if (param->optional())
+                {
+                    encodeOptionalField(
+                        _out,
+                        param->tag(),
+                        param->mappedName(),
+                        param->type(),
+                        ns,
+                        TypeContext::OutgoingParam,
+                        "encoder_");
+                }
+                else
+                {
+                    _out << nl;
+                    encodeField(_out, param->mappedName(), param->type(), ns, TypeContext::OutgoingParam, "encoder_");
+                    _out << ';';
+                }
+            }
+
+            _out << nl << "pipe_.Writer.Complete();";
+            _out << nl << "return pipe_.Reader;";
+        }
+        _out << eb;
+    }
+
+    _out << eb;
+}
+
+void
+Slice::IceRpc::ProxyVisitor::writeProxyResponseClass(const InterfaceDefPtr& interface)
+{
+    string ns = getNamespace(interface);
+
+    writeDocLine(
+        _out,
+        "summary",
+        "Provides a <see cref=\"ResponseDecodeFunc{T}\" /> for each operation defined in Slice interface <c>" +
+            interface->scoped() + "</c>.");
+    _out << nl << "public static class Response";
+    _out << sb;
+
+    for (const auto& operation : interface->operations())
+    {
+        writeDocLine(_out, "summary", "Decodes an incoming response for operation <c>" + operation->name() + "</c>.");
+        _out << nl << "public static async ";
+        writeReturnTask(_out, operation, "ValueTask", false);
+        _out << " Decode" << removeEscapePrefix(operation->mappedName()) << "Async(";
+        _out.inc();
+        _out << nl << "IceRpc.IncomingResponse response,";
+        _out << nl << "IceRpc.OutgoingRequest request,";
+        _out << nl << "IProxy sender,";
+        _out << nl << "global::System.Threading.CancellationToken cancellationToken)";
+        _out.dec();
+        _out << sb;
+
+        _out << nl << "try";
+        _out << sb;
+
+        if (operation->returnsAnyValues())
+        {
+            _out << nl << "return await response.DecodeReturnValueAsync(";
+            _out.inc();
+            _out << nl << "request,";
+            _out << nl << "SliceEncoding.Slice1,";
+            _out << nl << "sender,";
+            _out << nl << "(ref SliceDecoder decoder) => ";
+
+            string returnParamName = escapeParamName("returnValue", operation->outParameters());
+            ParameterList returnParams = operation->sortedReturnAndOutParameters(returnParamName);
+
+            if (returnParams.size() == 1)
+            {
+                // Simplified decoding function for a single return value.
+                if (returnParams.front()->optional())
+                {
+                    decodeOptionalField(
+                        _out,
+                        returnParams.front()->tag(),
+                        returnParams.front()->type(),
+                        ns,
+                        TypeContext::IncomingParam);
+                }
+                else
+                {
+                    decodeField(_out, returnParams.front()->type(), ns, TypeContext::IncomingParam);
+                }
+            }
+            else
+            {
+                _out << sb;
+
+                // Decode all return params
+                for (const auto& param : returnParams)
+                {
+                    _out << nl << csType(param->type(), ns, TypeContext::IncomingParam, param->optional()) << " sliceP_"
+                         << removeEscapePrefix(param->mappedName()) << " = ";
+                    if (param->optional())
+                    {
+                        decodeOptionalField(_out, param->tag(), param->type(), ns, TypeContext::IncomingParam);
+                    }
+                    else
+                    {
+                        decodeField(_out, param->type(), ns, TypeContext::IncomingParam);
+                    }
+                    _out << ';';
+                }
+
+                // Return tuple with the return value (if any) first.
+                _out << nl << "return " << spar;
+                if (operation->returnType())
+                {
+                    _out << ("sliceP_" + returnParamName);
+                }
+                for (const auto& param : returnParams)
+                {
+                    if (param->name() != returnParamName)
+                    {
+                        _out << ("sliceP_" + removeEscapePrefix(param->mappedName()));
+                    }
+                }
+                _out << epar << ";";
+
+                _out << eb;
+            }
+            _out << ',';
+
+            _out << nl << "_defaultActivator,";
+            _out << nl << "cancellationToken).ConfigureAwait(false);";
+            _out.dec();
+        }
+        else
+        {
+            _out << nl << "await response.DecodeVoidReturnValueAsync(";
+            _out.inc();
+            _out << nl << "request,";
+            _out << nl << "SliceEncoding.Slice1,";
+            _out << nl << "sender,";
+            _out << nl << "_defaultActivator,";
+            _out << nl << "cancellationToken).ConfigureAwait(false);";
+            _out.dec();
+        }
+
+        _out << eb;
+        _out << nl << "catch (SliceException exception)";
+        ExceptionList exceptionList = operation->throws();
+        if (!exceptionList.empty())
+        {
+            _out << " when (exception is not ";
+            if (exceptionList.size() == 1)
+            {
+                _out << getUnqualified(exceptionList.front(), ns);
+            }
+            else
+            {
+                _out << '(';
+                for (auto q = exceptionList.begin(); q != exceptionList.end(); ++q)
+                {
+                    ExceptionPtr exception = *q;
+                    if (q != exceptionList.begin())
+                    {
+                        _out << " or ";
+                    }
+                    _out << getUnqualified(exception, ns);
+                }
+                _out << ')';
+            }
+            _out << ')';
+        }
+        _out << sb;
+        _out << nl << "throw new global::System.IO.InvalidDataException(";
+        _out.inc();
+        _out << nl << "$\"Exception specification violation: response to a " << operation->name()
+             << " request carries an exception of type '{exception.GetType()}'.\", exception);";
+        _out.dec();
+        _out << eb;
+        _out << eb;
+    }
+
+    _out << eb;
+}
+
+Slice::IceRpc::SkeletonVisitor::SkeletonVisitor(IceInternal::Output& output) : CsVisitor(output) {}
+
+bool
+Slice::IceRpc::SkeletonVisitor::visitModuleStart(const ModulePtr& p)
+{
+    if (!p->contains<InterfaceDef>())
+    {
+        return false;
+    }
+    return CsVisitor::visitModuleStart(p);
+}
+
+bool
+Slice::IceRpc::SkeletonVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
+{
+    string ns = getNamespace(p);
+    string escapedName = p->mappedName();
+    string name = removeEscapePrefix(escapedName);
+
+    // Generate the server-side interface.
+    _out << sp;
+    writeDocComment(p, "server-side interface");
+    _out << nl << "[SliceTypeId(\"" << p->scoped() << "\")]";
+    _out << nl << "[IceRpc.DefaultServicePath(\"" << defaultServicePath(p) << "\")]";
+    emitObsoleteAttribute(p);
+    _out << nl << "public partial interface I" << name << "Service";
+    if (!p->bases().empty())
+    {
+        _out << " : ";
+        _out.spar("");
+        for (const auto& base : p->bases())
+        {
+            _out << getUnqualified(base, ns, "I", "Service");
+        }
+        _out.epar("");
+    }
+
+    _out << sb;
+
+    if (!p->operations().empty())
+    {
+        writeRequestClass(p);
+        _out << sp;
+        writeResponseClass(p);
+        _out << sp;
+        _out << nl << "private static readonly IActivator _defaultActivator =";
+        _out.inc();
+        _out << nl << "IActivator.FromAssembly(typeof(I" << name << "Service).Assembly);";
+        _out.dec();
+    }
+
+    // We don't generate the skeleton methods for ::Ice::Object, as we provide hand-written default implementations
+    // for these methods.
+    if (p->scoped() == "::Ice::Object")
+    {
+        _out << eb; // end of interface
+        return false;
+    }
+    else
+    {
+        return true;
+    }
+}
+
+void
+Slice::IceRpc::SkeletonVisitor::visitInterfaceDefEnd(const InterfaceDefPtr&)
+{
+    _out << eb;
+}
+
+void
+Slice::IceRpc::SkeletonVisitor::visitOperation(const OperationPtr& p)
+{
+    _out << sp;
+
+    string ns = getNamespace(p->interface());
+
+    // TODO: doc comment for operation
+
+    _out << nl << "[SliceOperation(\"" << p->name() << "\"";
+
+    if (p->hasMarshaledResult())
+    {
+        _out << ", EncodedReturn = true";
+    }
+    if (p->mode() == Operation::Idempotent)
+    {
+        _out << ", Idempotent = true";
+    }
+    ExceptionList exceptions = p->throws();
+    if (!exceptions.empty())
+    {
+        _out << ", ExceptionSpecification = new System.Type[] ";
+        _out.spar("{ ");
+        for (const auto& exception : exceptions)
+        {
+            _out << ("typeof(" + getUnqualified(exception, ns) + ")");
+        }
+        _out.epar(" }");
+    }
+    _out << ")]";
+
+    _out << nl;
+    writeMethod(_out, p, ns, true);
+    _out << ';';
+}
+
+void
+Slice::IceRpc::SkeletonVisitor::writeRequestClass(const InterfaceDefPtr& interface)
+{
+    string ns = getNamespace(interface);
+
+    writeDocLine(_out, "summary", "Provides static methods that decode request payloads.");
+
+    // Check if any of the base interfaces already has a Request class.
+    // A Rest class is generated for any interface that defines at least one operation.
+    _out << nl << "public static ";
+    if (!interface->allInheritedOperations().empty())
+    {
+        _out << "new ";
+    }
+    _out << "class Request";
+
+    _out << sb;
+
+    for (const auto& operation : interface->operations())
+    {
+        _out << sp;
+        writeDocLine(_out, "summary", "Decodes the request payload of operation <c>" + operation->name() + "</c>.");
+        // TODO: param doc comments
+        _out << nl << "public static ";
+        writeParamsValueTask(_out, operation);
+        _out << " Decode" << removeEscapePrefix(operation->mappedName()) << "Async(";
+        _out.inc();
+        _out << nl << "IceRpc.IncomingRequest request,";
+        _out << nl << "global::System.Threading.CancellationToken cancellationToken) =>";
+
+        ParameterList inParameters = operation->inParameters();
+
+        if (inParameters.empty())
+        {
+            _out << nl << "request.DecodeEmptyArgsAsync(SliceEncoding.Slice1, cancellationToken);";
+        }
+        else
+        {
+            _out << nl << "request.DecodeArgsAsync(";
+            _out.inc();
+            _out << nl << "SliceEncoding.Slice1,";
+            _out << nl << "(ref SliceDecoder decoder) => ";
+
+            if (inParameters.size() == 1)
+            {
+                // Simplified decoding function for a single parameter.
+                if (inParameters.front()->optional())
+                {
+                    decodeOptionalField(
+                        _out,
+                        inParameters.front()->tag(),
+                        inParameters.front()->type(),
+                        ns,
+                        TypeContext::IncomingParam);
+                }
+                else
+                {
+                    decodeField(_out, inParameters.front()->type(), ns, TypeContext::IncomingParam);
+                }
+            }
+            else
+            {
+                _out << sb;
+
+                // Decode all params (2 or more).
+                for (const auto& param : inParameters)
+                {
+                    _out << nl << csType(param->type(), ns, TypeContext::IncomingParam, param->optional()) << " sliceP_"
+                         << removeEscapePrefix(param->mappedName()) << " = ";
+                    if (param->optional())
+                    {
+                        decodeOptionalField(_out, param->tag(), param->type(), ns, TypeContext::IncomingParam);
+                    }
+                    else
+                    {
+                        decodeField(_out, param->type(), ns, TypeContext::IncomingParam);
+                    }
+                    _out << ';';
+                }
+
+                _out << nl << "return " << spar;
+                for (const auto& param : inParameters)
+                {
+                    _out << ("sliceP_" + removeEscapePrefix(param->mappedName()));
+                }
+                _out << epar << ";";
+
+                _out << eb;
+            }
+            _out << ',';
+
+            _out << nl << "_defaultActivator,";
+            _out << nl << "cancellationToken);";
+            _out.dec();
+        }
+        _out.dec();
+    }
+
+    _out << eb;
+}
+
+void
+Slice::IceRpc::SkeletonVisitor::writeResponseClass(const InterfaceDefPtr& interface)
+{
+    string ns = getNamespace(interface);
+
+    writeDocLine(_out, "summary", "Provides static methods that encode operation arguments into request payloads.");
+
+    // Check if any of the base interfaces already has a Response class.
+    // A Response class is generated for any interface that defines at least one operation.
+    _out << nl << "public static ";
+    if (!interface->allInheritedOperations().empty())
+    {
+        _out << "new ";
+    }
+    _out << "class Response";
+
+    _out << sb;
+
+    for (const auto& operation : interface->operations())
+    {
+        _out << sp;
+        writeDocLine(
+            _out,
+            "summary",
+            "Encodes the return value and out parameter(s) of operation <c>" + operation->name() +
+                "</c> into a response payload.");
+        // TODO: param doc comments
+        writeDocLine(_out, "param name=\"encodeOptions\"", "The Slice encode options.", "param");
+        writeDocLine(_out, "returns", "The Slice-encoded payload.");
+
+        _out << nl << "public static global::System.IO.Pipelines.PipeReader Encode"
+             << removeEscapePrefix(operation->mappedName()) << "(";
+
+        _out.inc();
+        string returnParamName = escapeParamName("returnValue", operation->outParameters());
+
+        if (operation->returnType())
+        {
+            _out << nl << csOutgoingParamType(operation->returnType(), ns, operation->returnIsOptional()) << ' '
+                 << returnParamName << ',';
+        }
+        for (const auto& param : operation->outParameters())
+        {
+            _out << nl << csOutgoingParamType(param->type(), ns, param->optional()) << ' ' << param->mappedName()
+                 << ',';
+        }
+        _out << nl << "SliceEncodeOptions? encodeOptions = null)";
+        _out.dec();
+        _out << sb;
+        if (operation->returnsAnyValues())
+        {
+            _out << nl << "var pipe_ = new global::System.IO.Pipelines.Pipe(";
+            _out.inc();
+            _out << nl << "encodeOptions?.PipeOptions ?? SliceEncodeOptions.Default.PipeOptions);";
+            _out.dec();
+            _out << nl << "var encoder_ = new SliceEncoder(pipe_.Writer, SliceEncoding.Slice1, "
+                 << classFormat(operation) << ");";
+
+            for (const auto& param : operation->sortedReturnAndOutParameters(returnParamName))
+            {
+                if (param->optional())
+                {
+                    encodeOptionalField(
+                        _out,
+                        param->tag(),
+                        param->mappedName(),
+                        param->type(),
+                        ns,
+                        TypeContext::OutgoingParam,
+                        "encoder_");
+                }
+                else
+                {
+                    _out << nl;
+                    encodeField(_out, param->mappedName(), param->type(), ns, TypeContext::OutgoingParam, "encoder_");
+                    _out << ';';
+                }
+            }
+
+            _out << nl << "pipe_.Writer.Complete();";
+            _out << nl << "return pipe_.Reader;";
+        }
+        else
+        {
+            _out << nl << "return IceRpc.EmptyPipeReader.Instance;";
+        }
+        _out << eb;
+    }
+
+    _out << eb;
+}

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -745,7 +745,7 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     for (const auto& base : p->bases())
     {
         _out << sp;
-        string baseName = getUnqualified(base, ns) + "Proxy";
+        string baseName = getUnqualified(base, ns, "", "Proxy");
         writeDocLine(_out, "summary", "Provides an implicit conversion to <see cref =\"" + baseName + "\" />.");
 
         _out << nl << "public static implicit operator " << baseName << "(" << name << "Proxy proxy) =>";

--- a/cpp/src/slice2cs/IceRpcVisitors.h
+++ b/cpp/src/slice2cs/IceRpcVisitors.h
@@ -1,0 +1,81 @@
+// Copyright (c) ZeroC, Inc.
+
+#ifndef ICE_RPC_VISITORS_H
+#define ICE_RPC_VISITORS_H
+
+#include "CsVisitor.h"
+
+// Visitors for generating C# code for IceRPC.
+
+namespace Slice::IceRpc
+{
+    /// Generates code for Slice types (including proxies) and Slice exceptions.
+    class TypesVisitor final : public CsVisitor
+    {
+    public:
+        TypesVisitor(IceInternal::Output&);
+
+        bool visitStructStart(const StructPtr&) final;
+        void visitStructEnd(const StructPtr&) final;
+
+        bool visitClassDefStart(const ClassDefPtr&) final;
+        void visitClassDefEnd(const ClassDefPtr&) final;
+
+        bool visitExceptionStart(const ExceptionPtr&) final;
+        void visitExceptionEnd(const ExceptionPtr&) final;
+
+        void visitDataMember(const DataMemberPtr&) final;
+
+        void visitEnum(const EnumPtr&) final;
+
+    private:
+        bool writePrimaryConstructor(
+            const ContainedPtr& p,
+            const DataMemberList& fields,
+            const DataMemberList& allBaseFields,
+            const std::string& kind);
+
+        void writeEncodeDecode(
+            int compactId,
+            const std::string& ns,
+            bool hasBase,
+            const DataMemberList& fields,
+            const DataMemberList& allBaseFields);
+    };
+
+    // Generates proxies.
+    class ProxyVisitor final : public CsVisitor
+    {
+    public:
+        ProxyVisitor(IceInternal::Output&);
+
+        bool visitModuleStart(const ModulePtr&) final;
+
+        bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
+        void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
+        void visitOperation(const OperationPtr&) final;
+
+    private:
+        void writeProxyRequestClass(const InterfaceDefPtr& interface);
+        void writeProxyResponseClass(const InterfaceDefPtr& interface);
+    };
+
+    // Generates skeleton interfaces.
+    class SkeletonVisitor final : public CsVisitor
+    {
+    public:
+        SkeletonVisitor(IceInternal::Output&);
+
+        bool visitModuleStart(const ModulePtr&) final;
+
+        bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
+        void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
+        void visitOperation(const OperationPtr&) final;
+
+    private:
+        void writeRequestClass(const InterfaceDefPtr& interface);
+        void writeResponseClass(const InterfaceDefPtr& interface);
+    };
+}
+
+#endif

--- a/cpp/src/slice2cs/IceVisitors.cpp
+++ b/cpp/src/slice2cs/IceVisitors.cpp
@@ -321,24 +321,6 @@ namespace
 Slice::Ice::TypesVisitor::TypesVisitor(IceInternal::Output& out) : CsVisitor(out) {}
 
 bool
-Slice::Ice::TypesVisitor::visitModuleStart(const ModulePtr& p)
-{
-    namespacePrefixStart(p);
-    _out << sp;
-    _out << nl << "namespace " << p->mappedName();
-    _out << sb;
-
-    return true;
-}
-
-void
-Slice::Ice::TypesVisitor::visitModuleEnd(const ModulePtr& p)
-{
-    _out << eb;
-    namespacePrefixEnd(p);
-}
-
-bool
 Slice::Ice::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
     string ns = getNamespace(p);
@@ -1809,21 +1791,11 @@ namespace
 bool
 Slice::Ice::ResultVisitor::visitModuleStart(const ModulePtr& p)
 {
-    if (hasResultType(p))
+    if (!hasResultType(p))
     {
-        namespacePrefixStart(p);
-        _out << sp << nl << "namespace " << p->mappedName();
-        _out << sb;
-        return true;
+        return false;
     }
-    return false;
-}
-
-void
-Slice::Ice::ResultVisitor::visitModuleEnd(const ModulePtr& p)
-{
-    _out << eb;
-    namespacePrefixEnd(p);
+    return CsVisitor::visitModuleStart(p);
 }
 
 void
@@ -1901,18 +1873,7 @@ Slice::Ice::SkeletonVisitor::visitModuleStart(const ModulePtr& p)
     {
         return false;
     }
-
-    namespacePrefixStart(p);
-    _out << sp << nl << "namespace " << p->mappedName();
-    _out << sb;
-    return true;
-}
-
-void
-Slice::Ice::SkeletonVisitor::visitModuleEnd(const ModulePtr& p)
-{
-    _out << eb;
-    namespacePrefixEnd(p);
+    return CsVisitor::visitModuleStart(p);
 }
 
 bool

--- a/cpp/src/slice2cs/IceVisitors.cpp
+++ b/cpp/src/slice2cs/IceVisitors.cpp
@@ -1073,7 +1073,7 @@ Slice::Ice::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     vector<string> baseInterfaces;
     for (const auto& base : p->bases())
     {
-        baseInterfaces.push_back(getUnqualified(base, ns) + "Prx");
+        baseInterfaces.push_back(getUnqualified(base, ns, "", "Prx"));
     }
 
     if (baseInterfaces.empty())

--- a/cpp/src/slice2cs/IceVisitors.h
+++ b/cpp/src/slice2cs/IceVisitors.h
@@ -15,8 +15,6 @@ namespace Slice::Ice
     public:
         TypesVisitor(IceInternal::Output&);
 
-        bool visitModuleStart(const ModulePtr&) final;
-        void visitModuleEnd(const ModulePtr&) final;
         bool visitClassDefStart(const ClassDefPtr&) final;
         void visitClassDefEnd(const ClassDefPtr&) final;
         bool visitExceptionStart(const ExceptionPtr&) final;
@@ -52,7 +50,7 @@ namespace Slice::Ice
         ResultVisitor(IceInternal::Output&);
 
         bool visitModuleStart(const ModulePtr&) final;
-        void visitModuleEnd(const ModulePtr&) final;
+
         void visitOperation(const OperationPtr&) final;
     };
 
@@ -63,7 +61,7 @@ namespace Slice::Ice
         SkeletonVisitor(IceInternal::Output& output, bool async);
 
         bool visitModuleStart(const ModulePtr&) final;
-        void visitModuleEnd(const ModulePtr&) final;
+
         bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
         void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
         void visitOperation(const OperationPtr&) final;

--- a/cpp/src/slice2cs/Main.cpp
+++ b/cpp/src/slice2cs/Main.cpp
@@ -208,7 +208,7 @@ compile(const vector<string>& argv)
             }
 
             UnitOptions unitOptions{};
-            if (genMode != Slice::GenMode::Ice)
+            if (genMode == Slice::GenMode::None || genMode == Slice::GenMode::IceRpc)
             {
                 unitOptions.defaultMappedName = [](const Contained& contained)
                 {

--- a/cpp/src/slice2cs/Main.cpp
+++ b/cpp/src/slice2cs/Main.cpp
@@ -158,7 +158,7 @@ compile(const vector<string>& argv)
     if (genMode == Slice::GenMode::None || genMode == Slice::GenMode::IceRpc)
     {
         // Both none and icerpc use the new mapping provided by IceRPC.
-        preprocessorArgs.push_back("-D__ICERPC__");
+        preprocessorArgs.emplace_back("-D__ICERPC__");
     }
 
     if (sliceFiles.empty())

--- a/cpp/src/slice2cs/Main.cpp
+++ b/cpp/src/slice2cs/Main.cpp
@@ -9,6 +9,7 @@
 #include "Gen.h"
 #include "Ice/CtrlCHandler.h"
 #include "IceCsUtil.h"
+#include "IceRpcCsUtil.h"
 
 #include <algorithm>
 #include <cassert>
@@ -43,6 +44,7 @@ usage(const string& n)
                   "-UNAME                   Remove any definition for NAME.\n"
                   "-IDIR                    Put DIR in the include file search path.\n"
                   "--output-dir DIR         Create files in the directory DIR.\n"
+                  "--rpc [none|ice|icerpc]  Generate code for the specified RPC framework. Default is 'ice'.\n"
                   "-d, --debug              Print debug messages.\n"
                   "--depend                 Generate Makefile dependencies.\n"
                   "--depend-xml             Generate dependencies in XML format.\n"
@@ -63,6 +65,7 @@ compile(const vector<string>& argv)
     opts.addOpt("U", "", IceInternal::Options::NeedArg, "", IceInternal::Options::Repeat);
     opts.addOpt("I", "", IceInternal::Options::NeedArg, "", IceInternal::Options::Repeat);
     opts.addOpt("", "output-dir", IceInternal::Options::NeedArg);
+    opts.addOpt("", "rpc", IceInternal::Options::NeedArg, "ice");
     opts.addOpt("", "depend");
     opts.addOpt("", "depend-xml");
     opts.addOpt("", "depend-file", IceInternal::Options::NeedArg, "");
@@ -129,6 +132,35 @@ compile(const vector<string>& argv)
 
     bool debug = opts.isSet("debug");
 
+    Slice::GenMode genMode;
+    string rpcArg = opts.optArg("rpc");
+    if (rpcArg == "none")
+    {
+        genMode = Slice::GenMode::None;
+    }
+    else if (rpcArg == "ice")
+    {
+        genMode = Slice::GenMode::Ice;
+    }
+    else if (rpcArg == "icerpc")
+    {
+        genMode = Slice::GenMode::IceRpc;
+    }
+    else
+    {
+        consoleErr << argv[0] << ": error: invalid argument for --rpc: " << rpcArg << endl;
+        if (!validate)
+        {
+            usage(argv[0]);
+        }
+        return EXIT_FAILURE;
+    }
+    if (genMode == Slice::GenMode::None || genMode == Slice::GenMode::IceRpc)
+    {
+        // Both none and icerpc use the new mapping provided by IceRPC.
+        preprocessorArgs.push_back("-D__ICERPC__");
+    }
+
     if (sliceFiles.empty())
     {
         consoleErr << argv[0] << ": error: no input file" << endl;
@@ -169,12 +201,30 @@ compile(const vector<string>& argv)
         {
             preprocessor = Preprocessor::create(argv[0], fileName, preprocessorArgs);
             FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2CS__");
+
             if (preprocessedHandle == nullptr)
             {
                 return EXIT_FAILURE;
             }
 
-            unit = Unit::createUnit("cs");
+            UnitOptions unitOptions{};
+            if (genMode != Slice::GenMode::Ice)
+            {
+                unitOptions.defaultMappedName = [](const Contained& contained)
+                {
+                    // Convert all names to pascal case except for parameters, which are converted to camel case.
+                    if (dynamic_cast<const Parameter*>(&contained))
+                    {
+                        return toCamelCase(contained.name());
+                    }
+                    else
+                    {
+                        return toPascalCase(contained.name());
+                    }
+                };
+            }
+
+            unit = Unit::createUnit("cs", unitOptions);
             int parseStatus = unit->parse(fileName, preprocessedHandle, debug);
 
             preprocessor->close();
@@ -195,10 +245,13 @@ compile(const vector<string>& argv)
             }
             else
             {
-                Slice::Csharp::IceDocCommentFormatter iceFormatter;
-                parseAllDocComments(unit, iceFormatter);
+                Slice::Csharp::CsharpDocCommentFormatter docCommentFormatter{
+                    genMode == Slice::GenMode::Ice ? Slice::Csharp::iceLinkFormatter
+                                                   : Slice::Csharp::icerpcLinkFormatter};
 
-                Gen gen(preprocessor->getBaseName(), output, enableAnalysis);
+                parseAllDocComments(unit, docCommentFormatter);
+
+                Gen gen(preprocessor->getBaseName(), output, genMode, enableAnalysis);
                 gen.generate(unit);
 
                 status |= unit->getStatus();

--- a/cpp/src/slice2cs/msbuild/slice2cs.vcxproj
+++ b/cpp/src/slice2cs/msbuild/slice2cs.vcxproj
@@ -68,7 +68,6 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>ICE_BUILDING_SLICE_COMPILERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-
     </ClCompile>
     <Link>
       <AdditionalDependencies>rpcrt4.lib;advapi32.lib;DbgHelp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -79,7 +78,6 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>ICE_BUILDING_SLICE_COMPILERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-
     </ClCompile>
     <Link>
       <AdditionalDependencies>rpcrt4.lib;advapi32.lib;DbgHelp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -90,7 +88,6 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>ICE_BUILDING_SLICE_COMPILERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-
     </ClCompile>
     <Link>
       <AdditionalDependencies>rpcrt4.lib;advapi32.lib;DbgHelp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -101,7 +98,6 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>ICE_BUILDING_SLICE_COMPILERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-
     </ClCompile>
     <Link>
       <AdditionalDependencies>rpcrt4.lib;advapi32.lib;DbgHelp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -113,6 +109,8 @@
     <ClCompile Include="..\CsVisitor.cpp" />
     <ClCompile Include="..\Gen.cpp" />
     <ClCompile Include="..\IceCsUtil.cpp" />
+    <ClCompile Include="..\IceRpcCsUtil.cpp" />
+    <ClCompile Include="..\IceRpcVisitors.cpp" />
     <ClCompile Include="..\IceVisitors.cpp" />
     <ClCompile Include="..\Main.cpp" />
   </ItemGroup>
@@ -125,6 +123,8 @@
     <ClInclude Include="..\CsVisitor.h" />
     <ClInclude Include="..\Gen.h" />
     <ClInclude Include="..\IceCsUtil.h" />
+    <ClInclude Include="..\IceRpcCsUtil.h" />
+    <ClInclude Include="..\IceRpcVisitors.h" />
     <ClInclude Include="..\IceVisitors.h" />
   </ItemGroup>
   <ItemGroup>

--- a/cpp/src/slice2cs/msbuild/slice2cs.vcxproj.filters
+++ b/cpp/src/slice2cs/msbuild/slice2cs.vcxproj.filters
@@ -36,6 +36,12 @@
     <ClCompile Include="..\IceVisitors.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\IceRpcCsUtil.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\IceRpcVisitors.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\Slice2Cs.rc">
@@ -59,6 +65,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\IceVisitors.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\IceRpcCsUtil.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\IceRpcVisitors.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceCompilerTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceCompilerTask.cs
@@ -27,6 +27,11 @@ public abstract class SliceCompilerTask : ToolTask
 
     public string[] IncludeDirectories { get; set; } = Array.Empty<string>();
 
+    /// <summary>
+    /// The RPC provider to generate code for, corresponds to the <c>--rpc</c> compiler option.
+    /// </summary>
+    public string Rpc { get; set; } = "ice";
+
     public string[] AdditionalOptions { get; set; } = Array.Empty<string>();
 
     [Output]
@@ -87,6 +92,11 @@ public abstract class SliceCompilerTask : ToolTask
         foreach (string path in IncludeDirectories)
         {
             builder.AppendSwitchIfNotNull("-I", Path.GetFullPath(path));
+        }
+
+        if (Rpc != "ice")
+        {
+            builder.AppendSwitchIfNotNull("--rpc ", Rpc);
         }
 
         foreach (string option in AdditionalOptions)

--- a/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceCompilerTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceCompilerTask.cs
@@ -69,6 +69,12 @@ public abstract class SliceCompilerTask : ToolTask
             options["IncludeDirectories"] = value;
         }
 
+        value = item.GetMetadata("Rpc");
+        if (!string.IsNullOrEmpty(value) && value != "ice")
+        {
+            options["Rpc"] = value;
+        }
+
         if (AdditionalOptions.Length > 0)
         {
             options["AdditionalOptions"] = string.Join(";", AdditionalOptions);
@@ -94,7 +100,7 @@ public abstract class SliceCompilerTask : ToolTask
             builder.AppendSwitchIfNotNull("-I", Path.GetFullPath(path));
         }
 
-        if (Rpc != "ice")
+        if (Rpc.Length > 0 && Rpc != "ice")
         {
             builder.AppendSwitchIfNotNull("--rpc ", Rpc);
         }

--- a/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceDependTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceDependTask.cs
@@ -66,11 +66,13 @@ public abstract class SliceDependTask : Microsoft.Build.Utilities.Task
         {
             options["IncludeDirectories"] = value;
         }
+
         value = item.GetMetadata("Rpc");
-        if (!string.IsNullOrEmpty(value))
+        if (!string.IsNullOrEmpty(value) && value != "ice")
         {
             options["Rpc"] = value;
         }
+
         value = item.GetMetadata("AdditionalOptions");
         if (!string.IsNullOrEmpty(value))
         {

--- a/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceDependTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceDependTask.cs
@@ -21,6 +21,11 @@ public abstract class SliceDependTask : Microsoft.Build.Utilities.Task
     [Required]
     public string WorkingDirectory { get; set; } = "";
 
+    /// <summary>
+    /// The RPC provider to generate code for, corresponds to the <c>--rpc</c> compiler option.
+    /// </summary>
+    public string Rpc { get; set; } = "ice";
+
     [Output]
     public ITaskItem[] ComputedSources { get; private set; } = Array.Empty<ITaskItem>();
 
@@ -61,6 +66,11 @@ public abstract class SliceDependTask : Microsoft.Build.Utilities.Task
         {
             options["IncludeDirectories"] = value;
         }
+        value = item.GetMetadata("Rpc");
+        if (!string.IsNullOrEmpty(value))
+        {
+            options["Rpc"] = value;
+        }
         value = item.GetMetadata("AdditionalOptions");
         if (!string.IsNullOrEmpty(value))
         {
@@ -70,6 +80,7 @@ public abstract class SliceDependTask : Microsoft.Build.Utilities.Task
                 options["AdditionalOptions"] = value;
             }
         }
+
         return options;
     }
 

--- a/csharp/src/ZeroC.Ice.Slice.Tools/Slice2CSharpDependTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Slice2CSharpDependTask.cs
@@ -8,10 +8,16 @@ namespace ZeroC.Ice.Slice.Tools;
 public class Slice2CSharpDependTask : Common.SliceDependTask
 {
     protected override ITaskItem[] GeneratedItems(ITaskItem source) =>
-        new ITaskItem[]
-        {
-            new TaskItem(GetGeneratedPath(source, source.GetMetadata("OutputDir"), ".cs")),
-        };
+        Rpc == "icerpc" ?
+            new ITaskItem[]
+            {
+                new TaskItem(GetGeneratedPath(source, source.GetMetadata("OutputDir"), ".cs")),
+                new TaskItem(GetGeneratedPath(source, source.GetMetadata("OutputDir"), ".IceRpc.cs"))
+            } :
+            new ITaskItem[]
+            {
+                new TaskItem(GetGeneratedPath(source, source.GetMetadata("OutputDir"), ".cs"))
+            };
 
     // Same as generated items but only returns the generated items that need to be compiled
     // for example it excludes C++ headers

--- a/csharp/src/ZeroC.Ice.Slice.Tools/Slice2CSharpTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Slice2CSharpTask.cs
@@ -17,6 +17,10 @@ public class Slice2CSharpTask : Common.SliceCompilerTask
         {
             string message = string.Format("Compiling {0} Generating -> ", source.GetMetadata("Identity"));
             message += Common.TaskUtil.MakeRelative(WorkingDirectory, GetGeneratedPath(source, OutputDir, ".cs"));
+            if (Rpc == "icerpc")
+            {
+                message += ", " + Common.TaskUtil.MakeRelative(WorkingDirectory, GetGeneratedPath(source, OutputDir, ".IceRpc.cs"));
+            }
             Log.LogMessage(MessageImportance.High, message);
         }
     }

--- a/csharp/src/ZeroC.Ice.Slice.Tools/Slice2CSharpTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Slice2CSharpTask.cs
@@ -22,8 +22,14 @@ public class Slice2CSharpTask : Common.SliceCompilerTask
     }
 
     protected override ITaskItem[] GeneratedItems(ITaskItem source) =>
-        new ITaskItem[]
-        {
-            new TaskItem(GetGeneratedPath(source, OutputDir, ".cs"))
-        };
+        Rpc == "icerpc" ?
+            new ITaskItem[]
+            {
+                new TaskItem(GetGeneratedPath(source, OutputDir, ".cs")),
+                new TaskItem(GetGeneratedPath(source, OutputDir, ".IceRpc.cs"))
+            } :
+            new ITaskItem[]
+            {
+                new TaskItem(GetGeneratedPath(source, OutputDir, ".cs"))
+            };
 }

--- a/csharp/src/ZeroC.Ice.Slice.Tools/SliceCompile.CSharp.xaml
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/SliceCompile.CSharp.xaml
@@ -51,8 +51,16 @@
 
     <EnumProperty Name="Rpc" DisplayName="RPC Provider" Description="Generate code for the specified RPC framework.">
         <EnumValue Name="none" DisplayName="None" />
-         <EnumValue Name="ice" DisplayName="Ice" />
+        <EnumValue Name="ice" DisplayName="Ice" />
         <EnumValue Name="icerpc" DisplayName="IceRPC" />
+        <EnumProperty.DataSource>
+            <DataSource
+                Persistence="ProjectFile"
+                ItemType="SliceCompile"
+                Label="SliceTools"
+                HasConfigurationCondition="false"
+                SourceOfDefaultValue="AfterContext"/>
+        </EnumProperty.DataSource>
     </EnumProperty>
 
     <StringListProperty

--- a/csharp/src/ZeroC.Ice.Slice.Tools/SliceCompile.CSharp.xaml
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/SliceCompile.CSharp.xaml
@@ -49,6 +49,12 @@
         </StringListProperty.DataSource>
     </StringListProperty>
 
+    <EnumProperty Name="Rpc" DisplayName="RPC Provider" Description="Generate code for the specified RPC framework.">
+        <EnumValue Name="none" DisplayName="None" />
+         <EnumValue Name="ice" DisplayName="Ice" />
+        <EnumValue Name="icerpc" DisplayName="IceRPC" />
+    </EnumProperty>
+
     <StringListProperty
         DisplayName="Additional Options"
         Name="AdditionalOptions"

--- a/csharp/src/ZeroC.Ice.Slice.Tools/ZeroC.Ice.Slice.Tools.targets
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/ZeroC.Ice.Slice.Tools.targets
@@ -104,7 +104,7 @@
             WorkingDirectory      = "$(MSBuildProjectDirectory)"
             IceSliceToolsPath     = "$(_IceSliceToolsPathNormalized)"
             Sources               = "@(_SliceCompileNormalized)"
-            Rpc                   = "%(SliceCompile.Rpc)">
+            Rpc                   = "%(_SliceCompileNormalized.Rpc)">
 
             <Output
                 ItemName          = "_SliceCompile"

--- a/csharp/src/ZeroC.Ice.Slice.Tools/ZeroC.Ice.Slice.Tools.targets
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/ZeroC.Ice.Slice.Tools.targets
@@ -103,7 +103,8 @@
         <Slice2CSharpDependTask
             WorkingDirectory      = "$(MSBuildProjectDirectory)"
             IceSliceToolsPath     = "$(_IceSliceToolsPathNormalized)"
-            Sources               = "@(_SliceCompileNormalized)">
+            Sources               = "@(_SliceCompileNormalized)"
+            Rpc                   = "%(SliceCompile.Rpc)">
 
             <Output
                 ItemName          = "_SliceCompile"
@@ -120,6 +121,7 @@
             IceSliceToolsPath     = "$(_IceSliceToolsPathNormalized)"
             OutputDir             = "%(_SliceCompile.OutputDir)"
             IncludeDirectories    = "%(_SliceCompile.IncludeDirectories)"
+            Rpc                   = "%(_SliceCompile.Rpc)"
             AdditionalOptions     = "%(_SliceCompile.AdditionalOptions)"
             Sources               = "@(_SliceCompile)"
             Condition             = "'%(_SliceCompile.BuildRequired)' == 'True'"/>
@@ -141,6 +143,7 @@
 
     <Target Name="SliceCompileClean" BeforeTargets="Clean">
         <Delete Files="@(SliceCompile->'%(OutputDir)\%(Filename).cs')"/>
+        <Delete Files="@(SliceCompile->'%(OutputDir)\%(Filename).IceRpc.cs')"/>
         <Delete Files="@(SliceCompile->'%(OutputDir)\SliceCompile.%(Filename).d')"/>
     </Target>
 </Project>


### PR DESCRIPTION
This PR updates slice2cs to generate code for either Ice (the default) or IceRPC.

The new option is as follows:
   --rpc none: generate code IceRPC's ZeroC.Slice (no IceRpc dependency; used to build the IceRpc core assembly)
   --rpc ice: generate code for Ice (the default)
   --rpc icerpc: generate code for the IceRPC+Slice integration (depends on IceRpc.Slice)

When you specify `--rpc icerpc`, slice2cs generates two files for each Filename.ice source file: Filename.cs and Filename.IceRpc.cs; otherwise, it only generates Filename.cs.

This PR also updates the C# ZeroC.Ice.Slice.Tools with a new `Rpc` option for the SliceCompiler and SliceDepend tasks.

You would typically enable it with:
```
  <ItemDefinitionGroup>
    <SliceCompile>
      <Rpc>icerpc</Rpc>
    </SliceCompile>
  </ItemDefinitionGroup>
```

The new generated code is largely the same as the code generated by slicec-cs in Slice1 mode.