### PR TITLE
Use Node 24 for npm trusted publishing

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/setup-node@v4
         if: ${{ inputs.quality == 'stable' }}
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Publish Release NPM Packages


### PR DESCRIPTION
Trusted publishing with OIDC requires npm >= 11.5.1 which ships with Node 24.