### PR TITLE
Backport IceGrid bug fixes from 3.8 (#5174)

### DIFF
--- a/cpp/src/IceGrid/Database.cpp
+++ b/cpp/src/IceGrid/Database.cpp
@@ -1537,9 +1537,8 @@ Database::addOrUpdateObject(const ObjectInfo& info, Ice::Long dbSerial)
         {
             IceDB::ReadWriteTxn txn(_env);
 
-            Ice::Identity k;
             ObjectInfo v;
-            update = _objects.get(txn, k, v);
+            update = _objects.get(txn, id, v);
             if(update)
             {
                 _objectsByType.del(txn, v.type, v.proxy->ice_getIdentity());

--- a/cpp/src/IceGrid/DescriptorParser.cpp
+++ b/cpp/src/IceGrid/DescriptorParser.cpp
@@ -78,12 +78,16 @@ private:
 DescriptorHandler::DescriptorHandler(const string& filename, const Ice::CommunicatorPtr& communicator) :
     _communicator(communicator),
     _filename(filename),
+    _targetCounter(0),
     _isCurrentTargetDeployable(true),
+    _line(0),
+    _column(0),
     _currentCommunicator(0),
     _isTopLevel(true),
     _inAdapter(false),
     _inReplicaGroup(false),
-    _inDbEnv(false)
+    _inDbEnv(false),
+    _inDistrib(false)
 {
 }
 

--- a/cpp/src/IceGrid/NodeI.cpp
+++ b/cpp/src/IceGrid/NodeI.cpp
@@ -1218,10 +1218,6 @@ NodeI::canRemoveServerDirectory(const string& name)
         }
         serviceDataDirs.push_back(*p);
     }
-    if(!contents.empty())
-    {
-        return false;
-    }
 
     c = readDirectory(_serversDir + "/" + name + "/config");
     for(Ice::StringSeq::const_iterator p = c.begin() ; p != c.end(); ++p)

--- a/cpp/src/IceGrid/PluginFacadeI.cpp
+++ b/cpp/src/IceGrid/PluginFacadeI.cpp
@@ -278,6 +278,7 @@ RegistryPluginFacadeI::getReplicaGroupFilters(const string& id) const
 bool
 RegistryPluginFacadeI::hasReplicaGroupFilters() const
 {
+    Lock sync(*this);
     return !_replicaGroupFilters.empty();
 }
 
@@ -296,6 +297,7 @@ RegistryPluginFacadeI::getTypeFilters(const string& id) const
 bool
 RegistryPluginFacadeI::hasTypeFilters() const
 {
+    Lock sync(*this);
     return !_typeFilters.empty();
 }
 

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -819,9 +819,17 @@ ServerI::ServerI(const NodeIPtr& node, const ServerPrx& proxy, const string& ser
     _waitTime(wt),
     _serverDir(serversDir + "/" + id),
     _disableOnFailure(0),
+#ifndef _WIN32
+    _uid(static_cast<uid_t>(-1)),
+    _gid(static_cast<gid_t>(-1)),
+#endif
     _state(ServerI::Inactive),
     _activation(ServerI::Disabled),
+    _activationTimeout(0),
+    _deactivationTimeout(0),
     _failureTime(IceUtil::Time::now(IceUtil::Time::Monotonic)), // Ensure that _activation is init. in updateImpl().
+    _previousActivation(ServerI::Disabled),
+    _waitForReplication(false),
     _pid(0)
 {
     assert(_node->getActivator());
@@ -2245,7 +2253,7 @@ ServerI::updateImpl(const InternalServerDescriptorPtr& descriptor)
             _logs.push_back(_node->getPlatformInfo().getCwd() + '/' + path);
         }
     }
-    sort(_logs.begin(), _logs.begin());
+    sort(_logs.begin(), _logs.end());
 
     PropertyDescriptorSeqDict properties = getProperties(_desc);
     PropertyDescriptorSeq& props = properties["config"];
@@ -2624,7 +2632,7 @@ ServerI::checkAndUpdateUser(const InternalServerDescriptorPtr& desc, bool /*upda
 
         //
         // If the node isn't running as root and if the uid of the
-        // configured user is different from the uid of the userr
+        // configured user is different from the uid of the user
         // running the node we throw, a regular user can't run a
         // process as another user.
         //


### PR DESCRIPTION
- Fix LMDB lookup in Database::addOrUpdateObject using wrong variable
- Fix canRemoveServerDirectory always returning false for IceBox servers
- Fix sort no-op in ServerI::updateImpl (begin, begin -> begin, end)
- Fix data race in hasReplicaGroupFilters/hasTypeFilters (missing mutex)
- Add initializers for uninitialized members in ServerI and DescriptorHandler

Backport from 47520cfaf1