### PR TITLE
Backport IceStorm bug fixes from 3.8 (#5177)

### DIFF
--- a/cpp/src/IceStorm/NodeI.cpp
+++ b/cpp/src/IceStorm/NodeI.cpp
@@ -160,6 +160,7 @@ NodeI::NodeI(const InstancePtr& instance,
     _nodes(nodes),
     _state(NodeStateInactive),
     _updateCounter(0),
+    _coord(-1),
     _max(0),
     _generation(-1),
     _destroy(false)

--- a/cpp/src/IceStorm/Subscriber.cpp
+++ b/cpp/src/IceStorm/Subscriber.cpp
@@ -927,7 +927,7 @@ Subscriber::shutdown()
     IceUtil::Monitor<IceUtil::RecMutex>::Lock sync(_lock);
 
     _shutdown = true;
-    while(_outstanding > 0 && !_events.empty())
+    while(_outstanding > 0 || !_events.empty())
     {
         _lock.wait();
     }

--- a/cpp/src/IceStorm/TopicI.cpp
+++ b/cpp/src/IceStorm/TopicI.cpp
@@ -518,9 +518,9 @@ TopicImpl::subscribeAndGetPublisher(const QoS& qos, const Ice::ObjectPrx& obj)
             {
                 if(p != qos.begin())
                 {
-                    out << ',';
+                    out << ", ";
                 }
-
+                out << '[' << p->first << " = " << p->second << ']';
             }
             out << " subscriptions: ";
             trace(out, _instance, _subscribers);
@@ -1039,9 +1039,9 @@ TopicImpl::observerAddSubscriber(const LogUpdate& llu, const SubscriberRecord& r
             {
                 if(p != record.theQoS.begin())
                 {
-                    out << ',';
+                    out << ", ";
                 }
-                out << '[' << p->first << "," << p->second << ']';
+                out << '[' << p->first << " = " << p->second << ']';
             }
         }
         out << " llu: " << llu.generation << "/" << llu.iteration;

--- a/cpp/src/IceStorm/TopicManagerI.cpp
+++ b/cpp/src/IceStorm/TopicManagerI.cpp
@@ -587,17 +587,17 @@ TopicManagerImpl::getContent(LogUpdate& llu, TopicContentSeq& content)
     {
         Lock sync(*this);
         reap();
-    }
 
-    try
-    {
         content.clear();
         for(map<string, TopicImplPtr>::const_iterator p = _topics.begin(); p != _topics.end(); ++p)
         {
             TopicContent rec = p->second->getContent();
             content.push_back(rec);
         }
+    }
 
+    try
+    {
         IceDB::ReadOnlyTxn txn(_instance->dbEnv());
         _lluMap.get(txn, lluDbKey, llu);
     }

--- a/cpp/src/IceStorm/TransientTopicI.cpp
+++ b/cpp/src/IceStorm/TransientTopicI.cpp
@@ -285,9 +285,9 @@ TransientTopicImpl::subscribeAndGetPublisher(const QoS& qos, const Ice::ObjectPr
             {
                 if(p != qos.begin())
                 {
-                    out << ',';
+                    out << ", ";
                 }
-
+                out << '[' << p->first << " = " << p->second << ']';
             }
         }
     }


### PR DESCRIPTION
- Fix wrong wait condition (&& should be ||) in Subscriber::shutdown()
- Initialize uninitialized _coord member in NodeI
- Hold mutex during _topics iteration in getContent() to prevent data race
- Fix QoS trace output to include key-value pairs in subscribeAndGetPublisher


backport from 841c993c33