### PR TITLE
Backport IceBridge dispatch queuing bug fix from 3.8 (#5179)

### DIFF
--- a/cpp/src/IceBridge/IceBridge.cpp
+++ b/cpp/src/IceBridge/IceBridge.cpp
@@ -544,10 +544,10 @@ BridgeI::ice_invoke_async(const AMD_Object_ice_invokePtr& cb,
                                                          &GetConnectionCallback::exception);
                 target->begin_ice_getConnection(d);
             }
-            catch(const Exception& ex)
+            catch(const Ice::CommunicatorDestroyedException& ex)
             {
-                _connections.erase(current.con);
-                bc->outgoingException(ex);
+                // The only exception thrown synchronously should be CommunicatorDestroyedException, 
+                // and we can ignore it since it means the service is being shutdown.
                 cb->ice_exception(ex);
                 return;
             }


### PR DESCRIPTION
- Clean up BridgeConnection from _connections map and notify it of the exception when begin_ice_getConnection throws synchronously, preventing subsequent dispatches on the same connection from queuing indefinitely
- Replace cerr with consoleErr for consistent error reporting

Backport from 59b81f6f37