### PR TITLE
Fix multiple bugs in iceserviceinstall ServiceInstaller (#5127)

### DIFF
--- a/cpp/src/iceserviceinstall/ServiceInstaller.cpp
+++ b/cpp/src/iceserviceinstall/ServiceInstaller.cpp
@@ -191,7 +191,7 @@ IceServiceInstaller::install(const PropertiesPtr& properties)
         }
     }
 
-    if(!_configFile.find("HKLM\\") == 0)
+    if(_configFile.find("HKLM\\") != 0)
     {
         grantPermissions(_configFile);
     }
@@ -242,7 +242,7 @@ IceServiceInstaller::install(const PropertiesPtr& properties)
     //
     // Get the full path of config file.
     //
-    if(!_configFile.find("HKLM\\") == 0)
+    if(_configFile.find("HKLM\\") != 0)
     {
         char fullPath[MAX_PATH];
         if(GetFullPathName(_configFile.c_str(), MAX_PATH, fullPath, 0) > MAX_PATH)
@@ -430,7 +430,7 @@ IceServiceInstaller::getServiceInstallerPath()
     }
 
     string path = wstringToString(buffer);
-    assert(path.find_last_of("/\\"));
+    assert(path.find_last_of("/\\") != string::npos);
     return path.substr(0, path.find_last_of("/\\"));
 }
 
@@ -773,9 +773,10 @@ IceServiceInstaller::addSource(const string& source, const string& log, const st
     // the "EventMessageFile" key should contain the path to this
     // DLL.
     //
+    wstring wResourceFile = stringToWstring(resourceFile);
     res = RegSetValueExW(key, L"EventMessageFile", 0, REG_EXPAND_SZ,
-                         reinterpret_cast<const BYTE*>(stringToWstring(resourceFile).c_str()),
-                         static_cast<DWORD>(resourceFile.length() + 1) * sizeof(wchar_t));
+                         reinterpret_cast<const BYTE*>(wResourceFile.c_str()),
+                         static_cast<DWORD>((wResourceFile.length() + 1) * sizeof(wchar_t)));
 
     if(res == ERROR_SUCCESS)
     {

--- a/cpp/src/iceserviceinstall/ServiceInstaller.h
+++ b/cpp/src/iceserviceinstall/ServiceInstaller.h
@@ -34,7 +34,6 @@ private:
 
     void initializeSid(const std::string&);
 
-    bool fileExists(const std::string&) const;
     void grantPermissions(const std::string& path, SE_OBJECT_TYPE type = SE_FILE_OBJECT,
                      bool inherit = false, DWORD desiredAccess = GENERIC_READ) const;
     bool mkdir(const std::string&) const;


### PR DESCRIPTION
- Fix operator precedence bug where `!_configFile.find("HKLM\\") == 0` was parsed as `(!_configFile.find("HKLM\\")) == 0`, inverting the starts-with test at lines 193 and 248 (#5123)
- Fix assert in getServiceInstallerPath to check `!= string::npos` instead of truthiness (#5125)
- Fix RegSetValueExW buffer overread for non-ASCII paths by computing the size from the wide string length instead of the narrow string length (#5126)
- Remove dead `fileExists` declaration from ServiceInstaller.h

Backport from 4ed20edd6e