### PR TITLE
Add ["cs:internal"] and ["cs:readonly"] metadata directives to slice2cs

### DIFF
--- a/cpp/src/slice2cs/CsMetadataValidator.cpp
+++ b/cpp/src/slice2cs/CsMetadataValidator.cpp
@@ -74,6 +74,21 @@ Slice::validateCsMetadata(const UnitPtr& unit)
     };
     knownMetadata.emplace("cs:identifier", std::move(identifierInfo));
 
+    // "cs:internal"
+    MetadataInfo internalInfo = {
+        .validOn =
+            {typeid(InterfaceDecl),
+             typeid(ClassDecl),
+             typeid(Slice::Exception),
+             typeid(Struct),
+             typeid(Sequence),
+             typeid(Dictionary),
+             typeid(Enum),
+             typeid(Const)},
+        .acceptedArgumentKind = MetadataArgumentKind::NoArguments,
+    };
+    knownMetadata.emplace("cs:internal", std::move(internalInfo));
+
     // "cs:namespace"
     MetadataInfo namespaceInfo = {
         .validOn = {typeid(Module)},
@@ -105,6 +120,13 @@ Slice::validateCsMetadata(const UnitPtr& unit)
         .acceptedArgumentKind = MetadataArgumentKind::NoArguments,
     };
     knownMetadata.emplace("cs:property", std::move(propertyInfo));
+
+    // "cs:readonly"
+    MetadataInfo readonlyInfo = {
+        .validOn = {typeid(Struct)},
+        .acceptedArgumentKind = MetadataArgumentKind::NoArguments,
+    };
+    knownMetadata.emplace("cs:readonly", std::move(readonlyInfo));
 
     // Pass this information off to the parser's metadata validation logic.
     Slice::validateMetadata(unit, "cs", std::move(knownMetadata));

--- a/cpp/src/slice2cs/IceVisitors.cpp
+++ b/cpp/src/slice2cs/IceVisitors.cpp
@@ -317,10 +317,7 @@ namespace
         }
     }
 
-    string accessModifier(const ContainedPtr& p)
-    {
-        return p->hasMetadata("cs:internal") ? "internal" : "public";
-    }
+    string accessModifier(const ContainedPtr& p) { return p->hasMetadata("cs:internal") ? "internal" : "public"; }
 }
 
 Slice::Ice::TypesVisitor::TypesVisitor(IceInternal::Output& out) : CsVisitor(out) {}
@@ -811,8 +808,8 @@ Slice::Ice::TypesVisitor::visitStructStart(const StructPtr& p)
 
     writeDocComment(p, mappedType);
     emitObsoleteAttribute(p);
-    _out << nl << accessModifier(p) << " "
-        << (classMapping ? "sealed " : "") << modifier << "partial " << mappedType << ' ' << name;
+    _out << nl << accessModifier(p) << " " << (classMapping ? "sealed " : "") << modifier << "partial " << mappedType
+         << ' ' << name;
     _out << sb;
     return true;
 }
@@ -1410,7 +1407,8 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="communicator")", "The communicator.", "param");
     writeDocLine(_out, R"(param name="proxyString")", "The stringified proxy.", "param");
     writeDocLine(_out, "returns", "A new proxy.");
-    _out << nl << accessModifier(p) << " static " << name << "Prx createProxy(Ice.Communicator communicator, string proxyString) =>";
+    _out << nl << accessModifier(p) << " static " << name
+         << "Prx createProxy(Ice.Communicator communicator, string proxyString) =>";
     _out.inc();
     _out << nl << "new " << name << "PrxHelper(Ice.ObjectPrxHelper.createProxy(communicator, proxyString));";
     _out.dec();
@@ -1471,7 +1469,8 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="progress")", "The sent progress reporter.", "param");
     writeDocLine(_out, R"(param name="cancel")", "The cancellation token.", "param");
     writeDocLine(_out, "returns", checkedCastReturns.str());
-    _out << nl << accessModifier(p) << " static async global::System.Threading.Tasks.Task<" << name << "Prx?> checkedCastAsync";
+    _out << nl << accessModifier(p) << " static async global::System.Threading.Tasks.Task<" << name
+         << "Prx?> checkedCastAsync";
     _out.spar("(", true);
     _out << "Ice.ObjectPrx proxy"
          << "global::System.Collections.Generic.Dictionary<string, string>? context = null"
@@ -1490,7 +1489,8 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="progress")", "The sent progress reporter.", "param");
     writeDocLine(_out, R"(param name="cancel")", "The cancellation token.", "param");
     writeDocLine(_out, "returns", checkedCastWithFacetReturns.str());
-    _out << nl << accessModifier(p) << " static global::System.Threading.Tasks.Task<" << name << "Prx?> checkedCastAsync";
+    _out << nl << accessModifier(p) << " static global::System.Threading.Tasks.Task<" << name
+         << "Prx?> checkedCastAsync";
     _out.spar("(", true);
     _out << "Ice.ObjectPrx proxy"
          << "string facet"
@@ -1523,7 +1523,8 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="facet")", "The facet.", "param");
     writeDocLine(_out, "returns", "A new proxy with the requested type, or null if the source proxy is null.");
     _out << nl << "[return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(proxy))]";
-    _out << nl << accessModifier(p) << " static " << name << "Prx? uncheckedCast(Ice.ObjectPrx? proxy, string facet) =>";
+    _out << nl << accessModifier(p) << " static " << name
+         << "Prx? uncheckedCast(Ice.ObjectPrx? proxy, string facet) =>";
     _out.inc();
     _out << nl << "uncheckedCast(proxy?.ice_facet(facet));";
     _out.dec();
@@ -1875,7 +1876,8 @@ Slice::Ice::ResultVisitor::visitOperation(const OperationPtr& p)
         //
         // Marshaling constructor
         //
-        _out << nl << accessModifier(interface) << " " << name << spar << getOutParams(p, ns, true, false) << "Ice.Current current" << epar;
+        _out << nl << accessModifier(interface) << " " << name << spar << getOutParams(p, ns, true, false)
+             << "Ice.Current current" << epar;
         _out << sb;
         _out << nl << "_ostr = Ice.CurrentExtensions.startReplyStream(current);";
         _out << nl << "_ostr.startEncapsulation(current.encoding, " << opFormatTypeToString(p) << ");";

--- a/cpp/src/slice2cs/IceVisitors.cpp
+++ b/cpp/src/slice2cs/IceVisitors.cpp
@@ -316,6 +316,11 @@ namespace
             return "null";
         }
     }
+
+    string accessModifier(const ContainedPtr& p)
+    {
+        return p->hasMetadata("cs:internal") ? "internal" : "public";
+    }
 }
 
 Slice::Ice::TypesVisitor::TypesVisitor(IceInternal::Output& out) : CsVisitor(out) {}
@@ -334,7 +339,7 @@ Slice::Ice::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     {
         _out << nl << "[Ice.CompactSliceTypeId(" << p->compactId() << ")]";
     }
-    _out << nl << "public partial class " << p->mappedName() << " : ";
+    _out << nl << accessModifier(p) << " partial class " << p->mappedName() << " : ";
 
     if (base)
     {
@@ -357,6 +362,9 @@ Slice::Ice::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
     DataMemberList dataMembers = p->dataMembers();
     DataMemberList allDataMembers = p->allDataMembers();
     ClassDefPtr base = p->base();
+
+    // We keep all the constructors public, even with the cs:internal metadata. The parameterless constructor must be
+    // public for unmarshaling to work.
 
     _out << sp << nl << "partial void ice_initialize();";
     if (allDataMembers.empty())
@@ -496,19 +504,19 @@ Slice::Ice::TypesVisitor::visitSequence(const SequencePtr& p)
     ostringstream summary;
     summary << "Provides methods to marshal and unmarshal a <c>" << p->name() << "</c>.";
     writeHelperDocComment(p, summary.str(), "sequence helper class");
-    _out << nl << "public sealed class " << name << "Helper";
+    _out << nl << accessModifier(p) << " sealed class " << name << "Helper";
     _out << sb;
 
     _out << sp;
     writeMarshalDocComment(_out);
-    _out << nl << "public static void write(Ice.OutputStream ostr, " << typeS << " v)";
+    _out << nl << accessModifier(p) << " static void write(Ice.OutputStream ostr, " << typeS << " v)";
     _out << sb;
     writeSequenceMarshalUnmarshalCode(_out, p, ns, "v", true, false);
     _out << eb;
 
     _out << sp;
     writeUnmarshalDocComment(_out);
-    _out << nl << "public static " << typeS << " read(Ice.InputStream istr)";
+    _out << nl << accessModifier(p) << " static " << typeS << " read(Ice.InputStream istr)";
     _out << sb;
     _out << nl << typeS << " v;";
     writeSequenceMarshalUnmarshalCode(_out, p, ns, "v", false, false);
@@ -534,12 +542,12 @@ Slice::Ice::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     ostringstream summary;
     summary << "Provides methods to marshal and unmarshal a <c>" << p->name() << "</c>.";
     writeHelperDocComment(p, summary.str(), "dictionary helper class");
-    _out << nl << "public sealed class " << p->mappedName() << "Helper";
+    _out << nl << accessModifier(p) << " sealed class " << p->mappedName() << "Helper";
     _out << sb;
 
     _out << sp;
     writeMarshalDocComment(_out);
-    _out << nl << "public static void write(";
+    _out << nl << accessModifier(p) << " static void write(";
     _out << "Ice.OutputStream ostr, " << name << " v)";
     _out << sb;
     _out << nl << "if (v is null)";
@@ -561,7 +569,7 @@ Slice::Ice::TypesVisitor::visitDictionary(const DictionaryPtr& p)
 
     _out << sp;
     writeUnmarshalDocComment(_out);
-    _out << nl << "public static " << name << " read(Ice.InputStream istr)";
+    _out << nl << accessModifier(p) << " static " << name << " read(Ice.InputStream istr)";
     _out << sb;
     _out << nl << "int sz = istr.readSize();";
     _out << nl << "var r = new " << name << "();";
@@ -599,7 +607,7 @@ Slice::Ice::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     writeDocComment(p, "exception class");
     emitObsoleteAttribute(p);
     _out << nl << "[Ice.SliceTypeId(\"" << p->scoped() << "\")]";
-    _out << nl << "public partial class " << p->mappedName() << " : ";
+    _out << nl << accessModifier(p) << " partial class " << p->mappedName() << " : ";
     if (base)
     {
         _out << getUnqualified(base, ns);
@@ -621,6 +629,9 @@ Slice::Ice::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
     DataMemberList dataMembers = p->dataMembers();
     DataMemberList optionalMembers = p->orderedOptionalDataMembers();
     ExceptionPtr base = p->base();
+
+    // We keep all the constructors public, even with the cs:internal metadata. The parameterless constructor must be
+    // public for unmarshaling to work.
 
     if (!allDataMembers.empty())
     {
@@ -796,10 +807,12 @@ Slice::Ice::TypesVisitor::visitStructStart(const StructPtr& p)
     _out << sp;
 
     string mappedType = classMapping ? "record class" : "record struct";
+    string modifier = (p->hasMetadata("cs:readonly") && !classMapping) ? "readonly " : "";
 
     writeDocComment(p, mappedType);
     emitObsoleteAttribute(p);
-    _out << nl << "public " << (classMapping ? "sealed " : "") << "partial " << mappedType << ' ' << name;
+    _out << nl << accessModifier(p) << " "
+        << (classMapping ? "sealed " : "") << modifier << "partial " << mappedType << ' ' << name;
     _out << sb;
     return true;
 }
@@ -840,7 +853,7 @@ Slice::Ice::TypesVisitor::visitStructEnd(const StructPtr& p)
         {
             _out << sp;
             writeDocLine(_out, "summary", "Initializes a new instance of the <see cref=\"" + name + "\" /> class.");
-            _out << nl << "public " << name << spar << ctorParams << epar;
+            _out << nl << accessModifier(p) << ' ' << name << spar << ctorParams << epar;
             _out << sb;
             for (const auto& q : ctorParamNames)
             {
@@ -856,7 +869,7 @@ Slice::Ice::TypesVisitor::visitStructEnd(const StructPtr& p)
     // Primary constructor.
     _out << sp;
     writeDocLine(_out, "summary", "Initializes a new instance of the <see cref=\"" + name + "\" /> " + kind + ".");
-    _out << nl << "public " << name << spar;
+    _out << nl << accessModifier(p) << ' ' << name << spar;
     vector<string> parameters;
     for (const auto& q : dataMembers)
     {
@@ -893,7 +906,7 @@ Slice::Ice::TypesVisitor::visitStructEnd(const StructPtr& p)
         {
             _out << sp;
             writeDocLine(_out, "summary", "Initializes a new instance of the <see cref=\"" + name + "\" /> struct.");
-            _out << nl << "public " << name << "() => ice_initialize();";
+            _out << nl << accessModifier(p) << ' ' << name << "() => ice_initialize();";
         }
     }
 
@@ -903,7 +916,7 @@ Slice::Ice::TypesVisitor::visitStructEnd(const StructPtr& p)
         _out,
         "summary",
         "Initializes a new instance of the <see cref=\"" + name + "\" /> " + kind + " from an input stream.");
-    _out << nl << "public " << name << "(Ice.InputStream istr)";
+    _out << nl << accessModifier(p) << ' ' << name << "(Ice.InputStream istr)";
     _out << sb;
     for (const auto& q : dataMembers)
     {
@@ -914,7 +927,7 @@ Slice::Ice::TypesVisitor::visitStructEnd(const StructPtr& p)
 
     _out << sp;
     writeMarshalDocComment(_out);
-    _out << nl << "public static void ice_write(Ice.OutputStream ostr, " << name << " v)";
+    _out << nl << accessModifier(p) << " static void ice_write(Ice.OutputStream ostr, " << name << " v)";
     _out << sb;
     for (const auto& dataMember : dataMembers)
     {
@@ -924,7 +937,7 @@ Slice::Ice::TypesVisitor::visitStructEnd(const StructPtr& p)
 
     _out << sp;
     writeUnmarshalDocComment(_out);
-    _out << nl << "public static " << name << " ice_read(Ice.InputStream istr) => new(istr);";
+    _out << nl << accessModifier(p) << " static " << name << " ice_read(Ice.InputStream istr) => new(istr);";
     _out << eb;
 }
 
@@ -940,7 +953,7 @@ Slice::Ice::TypesVisitor::visitEnum(const EnumPtr& p)
     writeDocComment(p, "enum");
     emitObsoleteAttribute(p);
     emitAttributes(p);
-    _out << nl << "public enum " << name;
+    _out << nl << accessModifier(p) << " enum " << name;
     _out << sb;
     for (const auto& enumerator : enumerators)
     {
@@ -966,18 +979,18 @@ Slice::Ice::TypesVisitor::visitEnum(const EnumPtr& p)
     classComment << "Provides methods to marshal and unmarshal " << getArticleFor(name) << " <see cref=\"" << name
                  << "\" />.";
     writeHelperDocComment(p, classComment.str(), "enum helper class");
-    _out << nl << "public sealed class " << name << "Helper";
+    _out << nl << accessModifier(p) << " sealed class " << name << "Helper";
     _out << sb;
     _out << sp;
     writeMarshalDocComment(_out);
-    _out << nl << "public static void write(Ice.OutputStream ostr, " << name << " v)";
+    _out << nl << accessModifier(p) << " static void write(Ice.OutputStream ostr, " << name << " v)";
     _out << sb;
     writeMarshalUnmarshalCode(_out, p, ns, "v", true);
     _out << eb;
 
     _out << sp;
     writeUnmarshalDocComment(_out);
-    _out << nl << "public static " << name << " read(Ice.InputStream istr)";
+    _out << nl << accessModifier(p) << " static " << name << " read(Ice.InputStream istr)";
     _out << sb;
     _out << nl << name << " v;";
     writeMarshalUnmarshalCode(_out, p, ns, "v", false);
@@ -993,10 +1006,10 @@ Slice::Ice::TypesVisitor::visitConst(const ConstPtr& p)
     _out << sp;
     writeHelperDocComment(p, "Provides the " + p->mappedName() + " constant.", "helper class");
     emitAttributes(p);
-    _out << nl << "public abstract class " << p->mappedName();
+    _out << nl << accessModifier(p) << " abstract class " << p->mappedName();
     _out << sb;
     writeDocComment(p);
-    _out << nl << "public const " << typeToString(p->type(), "") << " value = ";
+    _out << nl << accessModifier(p) << " const " << typeToString(p->type(), "") << " value = ";
     writeConstantValue(p->type(), p->valueType(), p->value());
     _out << ";";
     _out << eb;
@@ -1011,20 +1024,37 @@ Slice::Ice::TypesVisitor::visitDataMember(const DataMemberPtr& p)
     StructPtr st = dynamic_pointer_cast<Struct>(cont);
     string ns = getNamespace(cont);
 
+    bool isReadOnly = st && st->hasMetadata("cs:readonly");
+
     _out << sp;
 
     string type = typeToString(p->type(), ns, p->optional());
+    bool addSemicolon = true;
 
     writeDocComment(p);
     emitObsoleteAttribute(p);
     emitAttributes(p);
-    _out << nl << "public " << type << ' ' << p->mappedName();
-
-    bool addSemicolon = true;
+    _out << nl << accessModifier(cont) << ' ';
     if (isProperty)
     {
-        _out << " { get; set; }";
+        _out << type << ' ' << p->mappedName();
+        if (isReadOnly)
+        {
+            _out << " { get; }";
+        }
+        else
+        {
+            _out << " { get; set; }";
+        }
         addSemicolon = false;
+    }
+    else
+    {
+        if (isReadOnly)
+        {
+            _out << "readonly ";
+        }
+        _out << type << ' ' << p->mappedName();
     }
 
     if (p->defaultValue())
@@ -1068,7 +1098,7 @@ Slice::Ice::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     notes << "Use the methods of this interface to invoke operations on a remote Ice object that implements <c>"
           << p->name() << "</c>.";
     writeDocComment(p, "proxy interface", notes.str());
-    _out << nl << "public partial interface " << p->mappedName() << "Prx : ";
+    _out << nl << accessModifier(p) << " partial interface " << p->mappedName() << "Prx : ";
 
     vector<string> baseInterfaces;
     for (const auto& base : p->bases())
@@ -1108,7 +1138,7 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     ostringstream summary;
     summary << "Helper class for proxy <see cref=\"" << name << "Prx\" />.";
     writeHelperDocComment(p, summary.str(), "proxy helper class");
-    _out << nl << "public sealed partial class " << name << "PrxHelper : "
+    _out << nl << accessModifier(p) << " sealed partial class " << name << "PrxHelper : "
          << "Ice.ObjectPrxHelperBase, " << name << "Prx";
     _out << sb;
 
@@ -1128,7 +1158,7 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         string context = getEscapedParamName(op->parameters(), "context");
 
         _out << sp;
-        _out << nl << "public " << retS << " " << opName;
+        _out << nl << "public " << retS << ' ' << opName;
         _out.spar("(", true);
         _out << params << ("global::System.Collections.Generic.Dictionary<string, string>? " + context + " = null")
              << epar;
@@ -1206,7 +1236,7 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         ExceptionList throws = op->throws();
         throws.sort(Slice::DerivedToBaseCompare());
 
-        // Write the public Async method.
+        // Write the public or internal Async method.
         _out << sp;
         _out << nl << "public global::System.Threading.Tasks.Task";
         if (!returnTypeS.empty())
@@ -1380,7 +1410,7 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="communicator")", "The communicator.", "param");
     writeDocLine(_out, R"(param name="proxyString")", "The stringified proxy.", "param");
     writeDocLine(_out, "returns", "A new proxy.");
-    _out << nl << "public static " << name << "Prx createProxy(Ice.Communicator communicator, string proxyString) =>";
+    _out << nl << accessModifier(p) << " static " << name << "Prx createProxy(Ice.Communicator communicator, string proxyString) =>";
     _out.inc();
     _out << nl << "new " << name << "PrxHelper(Ice.ObjectPrxHelper.createProxy(communicator, proxyString));";
     _out.dec();
@@ -1399,7 +1429,7 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="proxy")", "The source proxy.", "param");
     writeDocLine(_out, R"(param name="context")", "The request context.", "param");
     writeDocLine(_out, "returns", checkedCastReturns.str());
-    _out << nl << "public static " << name << "Prx? checkedCast";
+    _out << nl << accessModifier(p) << " static " << name << "Prx? checkedCast";
     _out.spar("(", true);
     _out << "Ice.ObjectPrx? proxy"
          << "global::System.Collections.Generic.Dictionary<string, string>? context = null";
@@ -1425,7 +1455,7 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="facet")", "The facet.", "param");
     writeDocLine(_out, R"(param name="context")", "The request context.", "param");
     writeDocLine(_out, "returns", checkedCastWithFacetReturns.str());
-    _out << nl << "public static " << name << "Prx? checkedCast";
+    _out << nl << accessModifier(p) << " static " << name << "Prx? checkedCast";
     _out.spar("(", true);
     _out << "Ice.ObjectPrx? proxy"
          << "string facet"
@@ -1441,7 +1471,7 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="progress")", "The sent progress reporter.", "param");
     writeDocLine(_out, R"(param name="cancel")", "The cancellation token.", "param");
     writeDocLine(_out, "returns", checkedCastReturns.str());
-    _out << nl << "public static async global::System.Threading.Tasks.Task<" << name << "Prx?> checkedCastAsync";
+    _out << nl << accessModifier(p) << " static async global::System.Threading.Tasks.Task<" << name << "Prx?> checkedCastAsync";
     _out.spar("(", true);
     _out << "Ice.ObjectPrx proxy"
          << "global::System.Collections.Generic.Dictionary<string, string>? context = null"
@@ -1460,7 +1490,7 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="progress")", "The sent progress reporter.", "param");
     writeDocLine(_out, R"(param name="cancel")", "The cancellation token.", "param");
     writeDocLine(_out, "returns", checkedCastWithFacetReturns.str());
-    _out << nl << "public static global::System.Threading.Tasks.Task<" << name << "Prx?> checkedCastAsync";
+    _out << nl << accessModifier(p) << " static global::System.Threading.Tasks.Task<" << name << "Prx?> checkedCastAsync";
     _out.spar("(", true);
     _out << "Ice.ObjectPrx proxy"
          << "string facet"
@@ -1478,7 +1508,7 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="proxy")", "The source proxy.", "param");
     writeDocLine(_out, "returns", "A new proxy with the requested type, or null if the source proxy is null.");
     _out << nl << "[return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(proxy))]";
-    _out << nl << "public static " << name << "Prx? uncheckedCast(Ice.ObjectPrx? proxy) =>";
+    _out << nl << accessModifier(p) << " static " << name << "Prx? uncheckedCast(Ice.ObjectPrx? proxy) =>";
     _out.inc();
     _out << nl << "proxy is not null ? new " << name << "PrxHelper(proxy) : null;";
     _out.dec();
@@ -1493,7 +1523,7 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="facet")", "The facet.", "param");
     writeDocLine(_out, "returns", "A new proxy with the requested type, or null if the source proxy is null.");
     _out << nl << "[return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(proxy))]";
-    _out << nl << "public static " << name << "Prx? uncheckedCast(Ice.ObjectPrx? proxy, string facet) =>";
+    _out << nl << accessModifier(p) << " static " << name << "Prx? uncheckedCast(Ice.ObjectPrx? proxy, string facet) =>";
     _out.inc();
     _out << nl << "uncheckedCast(proxy?.ice_facet(facet));";
     _out.dec();
@@ -1504,18 +1534,18 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out << sp;
     writeDocLine(_out, "summary", "Gets the type ID of the associated Slice interface.");
     writeDocLine(_out, "returns", staticId.str());
-    _out << nl << R"(public static string ice_staticId() => ")" << p->scoped() << R"(";)";
+    _out << nl << accessModifier(p) << R"( static string ice_staticId() => ")" << p->scoped() << R"(";)";
 
     _out << sp;
     writeMarshalDocComment(_out);
-    _out << nl << "public static void write(Ice.OutputStream ostr, " << name << "Prx? v)";
+    _out << nl << accessModifier(p) << " static void write(Ice.OutputStream ostr, " << name << "Prx? v)";
     _out << sb;
     _out << nl << "ostr.writeProxy(v);";
     _out << eb;
 
     _out << sp;
     writeUnmarshalDocComment(_out);
-    _out << nl << "public static " << name << "Prx? read(Ice.InputStream istr) =>";
+    _out << nl << accessModifier(p) << " static " << name << "Prx? read(Ice.InputStream istr) =>";
     _out.inc();
     _out << nl << "istr.readProxy() is Ice.ObjectPrx proxy ? new " << name << "PrxHelper(proxy) : null;";
     _out.dec();
@@ -1819,7 +1849,7 @@ Slice::Ice::ResultVisitor::visitOperation(const OperationPtr& p)
         }
 
         _out << sp;
-        _out << nl << "public record struct " << name;
+        _out << nl << accessModifier(interface) << " record struct " << name;
         _out << spar;
         if (ret)
         {
@@ -1839,13 +1869,13 @@ Slice::Ice::ResultVisitor::visitOperation(const OperationPtr& p)
         string name = resultStructName(interface->mappedName(), p->mappedName(), true);
 
         _out << sp;
-        _out << nl << "public readonly record struct " << name << " : Ice.MarshaledResult";
+        _out << nl << accessModifier(interface) << " readonly record struct " << name << " : Ice.MarshaledResult";
         _out << sb;
 
         //
         // Marshaling constructor
         //
-        _out << nl << "public " << name << spar << getOutParams(p, ns, true, false) << "Ice.Current current" << epar;
+        _out << nl << accessModifier(interface) << " " << name << spar << getOutParams(p, ns, true, false) << "Ice.Current current" << epar;
         _out << sb;
         _out << nl << "_ostr = Ice.CurrentExtensions.startReplyStream(current);";
         _out << nl << "_ostr.startEncapsulation(current.encoding, " << opFormatTypeToString(p) << ");";
@@ -1857,7 +1887,7 @@ Slice::Ice::ResultVisitor::visitOperation(const OperationPtr& p)
         _out << nl << "_ostr.endEncapsulation();";
         _out << eb;
         _out << sp;
-        _out << nl << "public Ice.OutputStream outputStream => _ostr;";
+        _out << nl << accessModifier(interface) << " Ice.OutputStream outputStream => _ostr;";
         _out << sp;
         _out << nl << "private readonly Ice.OutputStream _ostr;";
         _out << eb;
@@ -1893,7 +1923,7 @@ Slice::Ice::SkeletonVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     writeDocComment(p, "skeleton interface", notes.str());
     _out << nl << "[Ice.SliceTypeId(\"" << p->scoped() << "\")]";
-    _out << nl << "public partial interface " << name << " : ";
+    _out << nl << accessModifier(p) << " partial interface " << name << " : ";
 
     auto baseInterfaces = p->bases();
     if (baseInterfaces.empty())
@@ -1937,7 +1967,7 @@ Slice::Ice::SkeletonVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
             << "</c>.";
 
     writeHelperDocComment(p, summary.str(), "skeleton class", remarks.str());
-    _out << nl << "public abstract partial class " << name << "Disp_ : " << name;
+    _out << nl << accessModifier(p) << " abstract partial class " << name << "Disp_ : " << name;
 
     _out << sb;
 
@@ -1946,7 +1976,7 @@ Slice::Ice::SkeletonVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 
     writeDocLine(_out, "summary", "Gets the type ID of the associated Slice interface.");
     writeDocLine(_out, "returns", staticId.str());
-    _out << nl << R"(public static string ice_staticId() => ")" << p->scoped() << R"(";)";
+    _out << nl << accessModifier(p) << R"( static string ice_staticId() => ")" << p->scoped() << R"(";)";
 
     for (const auto& op : p->allOperations())
     {

--- a/cpp/src/slice2cs/IceVisitors.cpp
+++ b/cpp/src/slice2cs/IceVisitors.cpp
@@ -1233,7 +1233,7 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         ExceptionList throws = op->throws();
         throws.sort(Slice::DerivedToBaseCompare());
 
-        // Write the public or internal Async method.
+        // Write the public Async method.
         _out << sp;
         _out << nl << "public global::System.Threading.Tasks.Task";
         if (!returnTypeS.empty())

--- a/cpp/src/slice2cs/IceVisitors.cpp
+++ b/cpp/src/slice2cs/IceVisitors.cpp
@@ -808,7 +808,7 @@ Slice::Ice::TypesVisitor::visitStructStart(const StructPtr& p)
 
     writeDocComment(p, mappedType);
     emitObsoleteAttribute(p);
-    _out << nl << accessModifier(p) << " " << (classMapping ? "sealed " : "") << modifier << "partial " << mappedType
+    _out << nl << accessModifier(p) << ' ' << (classMapping ? "sealed " : "") << modifier << "partial " << mappedType
          << ' ' << name;
     _out << sb;
     return true;

--- a/cpp/src/slice2cs/IceVisitors.cpp
+++ b/cpp/src/slice2cs/IceVisitors.cpp
@@ -317,7 +317,10 @@ namespace
         }
     }
 
-    string accessModifier(const ContainedPtr& p) { return p->hasMetadata("cs:internal") ? "internal" : "public"; }
+    string accessModifier(const ContainedPtr& p)
+    {
+        return p->hasMetadata("cs:internal") ? "internal" : "public";
+    }
 }
 
 Slice::Ice::TypesVisitor::TypesVisitor(IceInternal::Output& out) : CsVisitor(out) {}
@@ -808,8 +811,8 @@ Slice::Ice::TypesVisitor::visitStructStart(const StructPtr& p)
 
     writeDocComment(p, mappedType);
     emitObsoleteAttribute(p);
-    _out << nl << accessModifier(p) << " " << (classMapping ? "sealed " : "") << modifier << "partial " << mappedType
-         << ' ' << name;
+    _out << nl << accessModifier(p) << " "
+        << (classMapping ? "sealed " : "") << modifier << "partial " << mappedType << ' ' << name;
     _out << sb;
     return true;
 }
@@ -1407,8 +1410,7 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="communicator")", "The communicator.", "param");
     writeDocLine(_out, R"(param name="proxyString")", "The stringified proxy.", "param");
     writeDocLine(_out, "returns", "A new proxy.");
-    _out << nl << accessModifier(p) << " static " << name
-         << "Prx createProxy(Ice.Communicator communicator, string proxyString) =>";
+    _out << nl << accessModifier(p) << " static " << name << "Prx createProxy(Ice.Communicator communicator, string proxyString) =>";
     _out.inc();
     _out << nl << "new " << name << "PrxHelper(Ice.ObjectPrxHelper.createProxy(communicator, proxyString));";
     _out.dec();
@@ -1469,8 +1471,7 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="progress")", "The sent progress reporter.", "param");
     writeDocLine(_out, R"(param name="cancel")", "The cancellation token.", "param");
     writeDocLine(_out, "returns", checkedCastReturns.str());
-    _out << nl << accessModifier(p) << " static async global::System.Threading.Tasks.Task<" << name
-         << "Prx?> checkedCastAsync";
+    _out << nl << accessModifier(p) << " static async global::System.Threading.Tasks.Task<" << name << "Prx?> checkedCastAsync";
     _out.spar("(", true);
     _out << "Ice.ObjectPrx proxy"
          << "global::System.Collections.Generic.Dictionary<string, string>? context = null"
@@ -1489,8 +1490,7 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="progress")", "The sent progress reporter.", "param");
     writeDocLine(_out, R"(param name="cancel")", "The cancellation token.", "param");
     writeDocLine(_out, "returns", checkedCastWithFacetReturns.str());
-    _out << nl << accessModifier(p) << " static global::System.Threading.Tasks.Task<" << name
-         << "Prx?> checkedCastAsync";
+    _out << nl << accessModifier(p) << " static global::System.Threading.Tasks.Task<" << name << "Prx?> checkedCastAsync";
     _out.spar("(", true);
     _out << "Ice.ObjectPrx proxy"
          << "string facet"
@@ -1523,8 +1523,7 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="facet")", "The facet.", "param");
     writeDocLine(_out, "returns", "A new proxy with the requested type, or null if the source proxy is null.");
     _out << nl << "[return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(proxy))]";
-    _out << nl << accessModifier(p) << " static " << name
-         << "Prx? uncheckedCast(Ice.ObjectPrx? proxy, string facet) =>";
+    _out << nl << accessModifier(p) << " static " << name << "Prx? uncheckedCast(Ice.ObjectPrx? proxy, string facet) =>";
     _out.inc();
     _out << nl << "uncheckedCast(proxy?.ice_facet(facet));";
     _out.dec();
@@ -1832,8 +1831,6 @@ Slice::Ice::ResultVisitor::visitModuleStart(const ModulePtr& p)
 void
 Slice::Ice::ResultVisitor::visitOperation(const OperationPtr& p)
 {
-    // The generated Result struct is always public (cs:internal has no effect).
-
     InterfaceDefPtr interface = p->interface();
     string ns = getNamespace(interface);
     ParameterList outParams = p->outParameters();
@@ -1852,7 +1849,7 @@ Slice::Ice::ResultVisitor::visitOperation(const OperationPtr& p)
         }
 
         _out << sp;
-        _out << nl << "public record struct " << name;
+        _out << nl << accessModifier(interface) << " record struct " << name;
         _out << spar;
         if (ret)
         {
@@ -1872,14 +1869,13 @@ Slice::Ice::ResultVisitor::visitOperation(const OperationPtr& p)
         string name = resultStructName(interface->mappedName(), p->mappedName(), true);
 
         _out << sp;
-        _out << nl << "public readonly record struct " << name << " : Ice.MarshaledResult";
+        _out << nl << accessModifier(interface) << " readonly record struct " << name << " : Ice.MarshaledResult";
         _out << sb;
 
         //
         // Marshaling constructor
         //
-        _out << nl << "public " << name << spar << getOutParams(p, ns, true, false)
-             << "Ice.Current current" << epar;
+        _out << nl << accessModifier(interface) << " " << name << spar << getOutParams(p, ns, true, false) << "Ice.Current current" << epar;
         _out << sb;
         _out << nl << "_ostr = Ice.CurrentExtensions.startReplyStream(current);";
         _out << nl << "_ostr.startEncapsulation(current.encoding, " << opFormatTypeToString(p) << ");";

--- a/cpp/src/slice2cs/IceVisitors.cpp
+++ b/cpp/src/slice2cs/IceVisitors.cpp
@@ -317,10 +317,7 @@ namespace
         }
     }
 
-    string accessModifier(const ContainedPtr& p)
-    {
-        return p->hasMetadata("cs:internal") ? "internal" : "public";
-    }
+    string accessModifier(const ContainedPtr& p) { return p->hasMetadata("cs:internal") ? "internal" : "public"; }
 }
 
 Slice::Ice::TypesVisitor::TypesVisitor(IceInternal::Output& out) : CsVisitor(out) {}
@@ -811,8 +808,8 @@ Slice::Ice::TypesVisitor::visitStructStart(const StructPtr& p)
 
     writeDocComment(p, mappedType);
     emitObsoleteAttribute(p);
-    _out << nl << accessModifier(p) << " "
-        << (classMapping ? "sealed " : "") << modifier << "partial " << mappedType << ' ' << name;
+    _out << nl << accessModifier(p) << " " << (classMapping ? "sealed " : "") << modifier << "partial " << mappedType
+         << ' ' << name;
     _out << sb;
     return true;
 }
@@ -1410,7 +1407,8 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="communicator")", "The communicator.", "param");
     writeDocLine(_out, R"(param name="proxyString")", "The stringified proxy.", "param");
     writeDocLine(_out, "returns", "A new proxy.");
-    _out << nl << accessModifier(p) << " static " << name << "Prx createProxy(Ice.Communicator communicator, string proxyString) =>";
+    _out << nl << accessModifier(p) << " static " << name
+         << "Prx createProxy(Ice.Communicator communicator, string proxyString) =>";
     _out.inc();
     _out << nl << "new " << name << "PrxHelper(Ice.ObjectPrxHelper.createProxy(communicator, proxyString));";
     _out.dec();
@@ -1471,7 +1469,8 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="progress")", "The sent progress reporter.", "param");
     writeDocLine(_out, R"(param name="cancel")", "The cancellation token.", "param");
     writeDocLine(_out, "returns", checkedCastReturns.str());
-    _out << nl << accessModifier(p) << " static async global::System.Threading.Tasks.Task<" << name << "Prx?> checkedCastAsync";
+    _out << nl << accessModifier(p) << " static async global::System.Threading.Tasks.Task<" << name
+         << "Prx?> checkedCastAsync";
     _out.spar("(", true);
     _out << "Ice.ObjectPrx proxy"
          << "global::System.Collections.Generic.Dictionary<string, string>? context = null"
@@ -1490,7 +1489,8 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="progress")", "The sent progress reporter.", "param");
     writeDocLine(_out, R"(param name="cancel")", "The cancellation token.", "param");
     writeDocLine(_out, "returns", checkedCastWithFacetReturns.str());
-    _out << nl << accessModifier(p) << " static global::System.Threading.Tasks.Task<" << name << "Prx?> checkedCastAsync";
+    _out << nl << accessModifier(p) << " static global::System.Threading.Tasks.Task<" << name
+         << "Prx?> checkedCastAsync";
     _out.spar("(", true);
     _out << "Ice.ObjectPrx proxy"
          << "string facet"
@@ -1523,7 +1523,8 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     writeDocLine(_out, R"(param name="facet")", "The facet.", "param");
     writeDocLine(_out, "returns", "A new proxy with the requested type, or null if the source proxy is null.");
     _out << nl << "[return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(proxy))]";
-    _out << nl << accessModifier(p) << " static " << name << "Prx? uncheckedCast(Ice.ObjectPrx? proxy, string facet) =>";
+    _out << nl << accessModifier(p) << " static " << name
+         << "Prx? uncheckedCast(Ice.ObjectPrx? proxy, string facet) =>";
     _out.inc();
     _out << nl << "uncheckedCast(proxy?.ice_facet(facet));";
     _out.dec();
@@ -1831,6 +1832,8 @@ Slice::Ice::ResultVisitor::visitModuleStart(const ModulePtr& p)
 void
 Slice::Ice::ResultVisitor::visitOperation(const OperationPtr& p)
 {
+    // The generated Result struct is always public (cs:internal has no effect).
+
     InterfaceDefPtr interface = p->interface();
     string ns = getNamespace(interface);
     ParameterList outParams = p->outParameters();
@@ -1849,7 +1852,7 @@ Slice::Ice::ResultVisitor::visitOperation(const OperationPtr& p)
         }
 
         _out << sp;
-        _out << nl << accessModifier(interface) << " record struct " << name;
+        _out << nl << "public record struct " << name;
         _out << spar;
         if (ret)
         {
@@ -1869,13 +1872,14 @@ Slice::Ice::ResultVisitor::visitOperation(const OperationPtr& p)
         string name = resultStructName(interface->mappedName(), p->mappedName(), true);
 
         _out << sp;
-        _out << nl << accessModifier(interface) << " readonly record struct " << name << " : Ice.MarshaledResult";
+        _out << nl << "public readonly record struct " << name << " : Ice.MarshaledResult";
         _out << sb;
 
         //
         // Marshaling constructor
         //
-        _out << nl << accessModifier(interface) << " " << name << spar << getOutParams(p, ns, true, false) << "Ice.Current current" << epar;
+        _out << nl << "public " << name << spar << getOutParams(p, ns, true, false)
+             << "Ice.Current current" << epar;
         _out << sb;
         _out << nl << "_ostr = Ice.CurrentExtensions.startReplyStream(current);";
         _out << nl << "_ostr.startEncapsulation(current.encoding, " << opFormatTypeToString(p) << ");";

--- a/cpp/src/slice2cs/IceVisitors.cpp
+++ b/cpp/src/slice2cs/IceVisitors.cpp
@@ -1889,7 +1889,7 @@ Slice::Ice::ResultVisitor::visitOperation(const OperationPtr& p)
         _out << nl << "_ostr.endEncapsulation();";
         _out << eb;
         _out << sp;
-        _out << nl << accessModifier(interface) << " Ice.OutputStream outputStream => _ostr;";
+        _out << nl << "public Ice.OutputStream outputStream => _ostr;";
         _out << sp;
         _out << nl << "private readonly Ice.OutputStream _ostr;";
         _out << eb;

--- a/cpp/src/slice2cs/IceVisitors.cpp
+++ b/cpp/src/slice2cs/IceVisitors.cpp
@@ -1021,7 +1021,9 @@ Slice::Ice::TypesVisitor::visitDataMember(const DataMemberPtr& p)
     StructPtr st = dynamic_pointer_cast<Struct>(cont);
     string ns = getNamespace(cont);
 
-    bool isReadOnly = st && st->hasMetadata("cs:readonly");
+    // We can't map class fields to read-only fields/properties because the 1.0 encoding requires "patching": the field
+    // is set later via a lambda, at the end of the unmarshaling process.
+    bool isReadOnly = st && st->hasMetadata("cs:readonly") && !p->type()->isClassType();
 
     _out << sp;
 

--- a/csharp/test/Ice/exceptions/Test.ice
+++ b/csharp/test/Ice/exceptions/Test.ice
@@ -28,6 +28,7 @@ module Test
         int cMem;
     }
 
+    ["cs:internal"]
     exception D
     {
         int dMem;

--- a/csharp/test/Ice/proxy/CI.cs
+++ b/csharp/test/Ice/proxy/CI.cs
@@ -4,9 +4,9 @@
 
 namespace Ice.proxy;
 
-public sealed class CI : Test.CDisp_, Ice.Object
+internal sealed class CI : Test.CDisp_, Ice.Object
 {
-    public CI()
+    internal CI()
     {
     }
 

--- a/csharp/test/Ice/proxy/Test.ice
+++ b/csharp/test/Ice/proxy/Test.ice
@@ -35,6 +35,7 @@ module Test
         B* b;
     }
 
+    ["cs:internal"]
     interface C extends A, B
     {
         C* opC(C* c);

--- a/csharp/test/Slice/structure/Test.ice
+++ b/csharp/test/Slice/structure/Test.ice
@@ -2,21 +2,23 @@
 
 module Test
 {
-    sequence<string> StringSeq;
-    ["cs:generic:List"]sequence<int> IntList;
-    dictionary<string, string> StringDict;
+    ["cs:internal"] sequence<string> StringSeq;
+    ["cs:generic:List", "cs:internal"] sequence<int> IntList;
+    ["cs:internal"] dictionary<string, string> StringDict;
 
+    ["cs:internal"]
     class C
     {
         int i;
     }
 
-    ["cs:class"]
+    ["cs:internal", "cs:readonly"]
     struct S1
     {
         string name;
     }
 
+    ["cs:internal"]
     struct S2
     {
         bool bo;

--- a/csharp/test/Slice/structure/Test.ice
+++ b/csharp/test/Slice/structure/Test.ice
@@ -11,6 +11,8 @@ module Test
     {
         int i;
     }
+    ["cs:internal"] sequence<C> CSeq;
+
 
     ["cs:internal", "cs:readonly"]
     struct S1
@@ -35,5 +37,35 @@ module Test
         S1 s;
         C cls;
         Object* prx;
+    }
+
+    ["cs:readonly", "cs:internal"]
+    struct S3
+    {
+        int x;
+        C cls; // Mapped to a read-write field.
+    }
+
+    ["cs:readonly", "cs:property", "cs:internal"]
+    struct S4
+    {
+        int x;
+        C cls; // Mapped to a get-set property.
+    }
+
+    ["cs:readonly", "cs:internal"]
+    struct S5
+    {
+        int x;
+        S3 s3; // Mapped to a read-only field.
+        CSeq seq; // Mapped to a read-only field.
+    }
+
+    ["cs:readonly", "cs:property", "cs:internal"]
+    struct S6
+    {
+        int x;
+        S4 s4; // Mapped to a get-only property.
+        CSeq seq; // Mapped to a get-only property.
     }
 }

--- a/csharp/test/Slice/structure/Test.ice
+++ b/csharp/test/Slice/structure/Test.ice
@@ -13,7 +13,6 @@ module Test
     }
     ["cs:internal"] sequence<C> CSeq;
 
-
     ["cs:internal", "cs:readonly"]
     struct S1
     {


### PR DESCRIPTION
This PR adds ["cs:internal"] and ["cs:readonly"] to slice2cs in Ice mode.

It's a partial fix for #5225.