### PR TITLE
Update OperationMode and ReplyStatus for use by IceRPC

### DIFF
--- a/slice/Ice/OperationMode.ice
+++ b/slice/Ice/OperationMode.ice
@@ -12,10 +12,18 @@
 
 [["js:module:@zeroc/ice"]]
 
+#ifdef __ICERPC__
+// In IceRPC, OperationMode is an internal implementation detail of the ice protocol; the corresponding generated code
+// is not publicly visible.
+["cs:identifier:IceRpc.Internal"]
+#endif
 ["java:identifier:com.zeroc.Ice"]
 module Ice
 {
     /// Specifies if an operation is idempotent, which affects the retry behavior of the Ice client runtime.
+    #ifdef __ICERPC__
+    ["cs:internal"]
+    #endif
     enum OperationMode
     {
         /// A non-idempotent operation (the default). The Ice client runtime guarantees that it will not violate

--- a/slice/Ice/OperationMode.ice
+++ b/slice/Ice/OperationMode.ice
@@ -13,7 +13,7 @@
 [["js:module:@zeroc/ice"]]
 
 #ifdef __ICERPC__
-// In IceRPC, OperationMode is an internal implementation detail of the ice protocol; the corresponding generated code
+// In IceRPC, OperationMode is an internal implementation detail of the Ice protocol; the corresponding generated code
 // is not publicly visible.
 ["cs:identifier:IceRpc.Internal"]
 #endif

--- a/slice/Ice/ReplyStatus.ice
+++ b/slice/Ice/ReplyStatus.ice
@@ -12,12 +12,20 @@
 
 [["js:module:@zeroc/ice"]]
 
+#ifdef __ICERPC__
+// In IceRPC, ReplyStatus is an internal implementation detail of the ice protocol; the corresponding generated code is
+// not publicly visible.
+["cs:identifier:IceRpc.Internal"]
+#endif
 ["java:identifier:com.zeroc.Ice"]
 module Ice
 {
     /// Represents the status of a reply.
     /// A reply status can have any value in the range 0..255. Do not use this enum to marshal or unmarshal a reply
     /// status unless you know its value corresponds to one of the enumerators defined below.
+    #ifdef __ICERPC__
+    ["cs:internal"]
+    #endif
     enum ReplyStatus
     {
         /// The dispatch completed successfully.

--- a/slice/Ice/ReplyStatus.ice
+++ b/slice/Ice/ReplyStatus.ice
@@ -13,7 +13,7 @@
 [["js:module:@zeroc/ice"]]
 
 #ifdef __ICERPC__
-// In IceRPC, ReplyStatus is an internal implementation detail of the ice protocol; the corresponding generated code is
+// In IceRPC, ReplyStatus is an internal implementation detail of the Ice protocol; the corresponding generated code is
 // not publicly visible.
 ["cs:identifier:IceRpc.Internal"]
 #endif


### PR DESCRIPTION
These updates enums will replace enums with the same names in IceDefinitions.ice.