### PR TITLE
npm audit fix

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -6052,16 +6052,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/randombytes": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "^5.1.0"
-            }
-        },
         "node_modules/readable-stream": {
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -6474,16 +6464,6 @@
             },
             "engines": {
                 "node": ">= 10.13.0"
-            }
-        },
-        "node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "randombytes": "^2.1.0"
             }
         },
         "node_modules/set-function-length": {
@@ -6909,16 +6889,15 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.3.16",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-            "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+            "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jest-worker": "^27.4.5",
                 "schema-utils": "^4.3.0",
-                "serialize-javascript": "^6.0.2",
                 "terser": "^5.31.1"
             },
             "engines": {


### PR DESCRIPTION
Update terser-webpack-plugin from 5.3.16 to 5.4.0, which removes the serialize-javascript dependency and its transitive randombytes dependency from the package lock file.