### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/actions/install-windows-debug-tools/action.yml
+++ b/.github/actions/install-windows-debug-tools/action.yml
@@ -31,7 +31,7 @@ runs:
 
     - name: Upload SDK install log
       if: failure()
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: sdk-install-log
         path: ${{ runner.temp }}/sdk.log

--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Oracle Java 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: "oracle"
         java-version: "17"

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/build-brew-packages.yml
+++ b/.github/workflows/build-brew-packages.yml
@@ -68,7 +68,7 @@ jobs:
           ./packaging/brew/update-nightly-tap.sh "${{ inputs.channel }}" "${{ inputs.quality }}" "${{ inputs.ice_version }}" "${{ steps.icegridgui.outputs.icegridgui_dmg_sha256 }}"
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: homebrew-bottle
           path: |

--- a/.github/workflows/build-cpp-nuget-packages.yml
+++ b/.github/workflows/build-cpp-nuget-packages.yml
@@ -52,7 +52,7 @@ jobs:
         working-directory: cpp/msbuild
 
       - name: Upload NuGet Packages
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: windows-cpp-nuget-packages
           path: |

--- a/.github/workflows/build-cpp-swift-deps.yml
+++ b/.github/workflows/build-cpp-swift-deps.yml
@@ -67,7 +67,7 @@ jobs:
           cp cpp/bin/slice2swift-*.artifactbundle.zip staging/
 
       - name: Upload C++ Dependencies for Swift
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: cpp-swift-deps
           path: staging/

--- a/.github/workflows/build-cpp-windows-binaries.yml
+++ b/.github/workflows/build-cpp-windows-binaries.yml
@@ -58,7 +58,7 @@ jobs:
           timestamp-digest: SHA256
 
       - name: Upload C++ Build
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: windows-cpp-${{ matrix.platform }}-${{ matrix.configuration }}-build
           path: |
@@ -69,7 +69,7 @@ jobs:
             cpp/src/**/msbuild/**/${{ matrix.platform }}/${{ matrix.configuration }}/*.h
 
       - name: Upload C++ Slice Tools
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         # We only need to upload the Slice Tools once (Release x64 build) which are included in the Nuget packages
         if: ${{ matrix.configuration == 'Release' && matrix.platform == 'x64' }}
         with:

--- a/.github/workflows/build-deb-ice-repo-packages.yml
+++ b/.github/workflows/build-deb-ice-repo-packages.yml
@@ -65,7 +65,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: deb-packages-${{ matrix.distribution }}
           path: |

--- a/.github/workflows/build-deb-packages.yml
+++ b/.github/workflows/build-deb-packages.yml
@@ -94,7 +94,7 @@ jobs:
         shell: bash
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: deb-packages-${{ matrix.distribution }}-${{ matrix.arch }}
           path: |

--- a/.github/workflows/build-dotnet-packages.yml
+++ b/.github/workflows/build-dotnet-packages.yml
@@ -59,7 +59,7 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
 
       - name: Upload Compiler Artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: slice2cs-${{ matrix.target }}
           path: ${{ matrix.artifact-path }}
@@ -138,7 +138,7 @@ jobs:
           SLICE2CS_STAGING_PATH: "${{ github.workspace }}\\tools"
 
       - name: Upload NuGet Packages
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: dotnet-nuget-packages
           path: |

--- a/.github/workflows/build-gem-packages.yml
+++ b/.github/workflows/build-gem-packages.yml
@@ -39,7 +39,7 @@ jobs:
         run: rake
 
       - name: Upload Gem Packages
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: gem-packages
           path: ruby/zeroc-ice-*.gem

--- a/.github/workflows/build-icegridgui-jar.yml
+++ b/.github/workflows/build-icegridgui-jar.yml
@@ -44,7 +44,7 @@ jobs:
         working-directory: java
 
       - name: Upload IceGrid GUI JAR
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: icegridgui-jar-${{ runner.os }}
           path: |

--- a/.github/workflows/build-icegridgui-macos-app.yml
+++ b/.github/workflows/build-icegridgui-macos-app.yml
@@ -89,7 +89,7 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
 
       - name: Upload IceGrid GUI macOS App
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: icegridgui-macos-app
           path: |

--- a/.github/workflows/build-java-packages.yml
+++ b/.github/workflows/build-java-packages.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: java
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: java-packages
           path: |

--- a/.github/workflows/build-matlab-packages.yml
+++ b/.github/workflows/build-matlab-packages.yml
@@ -86,7 +86,7 @@ jobs:
         if: runner.os == 'Windows'
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: matlab-packages-${{ matrix.os }}
           path: matlab/toolbox/*.mltbx

--- a/.github/workflows/build-npm-packages.yml
+++ b/.github/workflows/build-npm-packages.yml
@@ -63,7 +63,7 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
 
       - name: Upload Compiler Artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: slice2js-${{ matrix.target }}
           path: ${{ matrix.artifact-path }}
@@ -134,7 +134,7 @@ jobs:
         working-directory: ice/js/packages/slice2js
 
       - name: Upload NPM Packages
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: js-npm-packages
           path: |

--- a/.github/workflows/build-pip-packages.yml
+++ b/.github/workflows/build-pip-packages.yml
@@ -41,7 +41,7 @@ jobs:
         run: python3 -m build --sdist
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: pip-sdist
           path: python/dist/zeroc_ice-*.tar.gz
@@ -105,7 +105,7 @@ jobs:
           pip wheel (Get-ChildItem sdist\*.tar.gz).FullName --no-deps -w dist/
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: pip-packages-${{ matrix.os }}-${{ matrix.python-version }}
           path: dist/zeroc_ice-*.whl

--- a/.github/workflows/build-rpm-ice-repo-packages.yml
+++ b/.github/workflows/build-rpm-ice-repo-packages.yml
@@ -65,7 +65,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: rpm-packages-${{ matrix.distribution }}
           path: |

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -54,7 +54,7 @@ jobs:
             /workspace/ice/packaging/rpm/build-package.sh
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: rpm-packages-${{ matrix.distribution }}-${{ matrix.arch }}
           path: |

--- a/.github/workflows/build-slice-tools-packages.yml
+++ b/.github/workflows/build-slice-tools-packages.yml
@@ -62,7 +62,7 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
 
       - name: Upload Compiler Artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: slice2java-${{ matrix.target }}
           path: ${{ matrix.artifact-path }}
@@ -120,7 +120,7 @@ jobs:
         working-directory: ice/java/tools/slice-tools
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: slice-tools-packages
           path: |

--- a/.github/workflows/build-symbols-sources-store.yml
+++ b/.github/workflows/build-symbols-sources-store.yml
@@ -93,7 +93,7 @@ jobs:
             /compress
 
       - name: Upload Symbols and Sources
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: windows-symbols-sources
           path: |
@@ -103,7 +103,7 @@ jobs:
       # Use symbols-sources as the root directory so that the unzipped artifact as a pdb directory.
       # This means we need to exclude the symbols and sources directories.
       - name: Upload Indexed PDBs
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: windows-indexed-pdbs
           path: |

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -127,7 +127,7 @@ jobs:
           timestamp-digest: SHA256
 
       - name: Upload Installer
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: windows-installer
           path: |

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -114,7 +114,7 @@ jobs:
             "
 
       - name: Upload test logs
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: test-logs-${{ matrix.distribution }}-${{ matrix.arch }}
           path: cpp/**/*.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,7 @@ jobs:
         if: matrix.config == 'release' && runner.os == 'macOS'
 
       - name: Upload test logs
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: test-logs-${{ matrix.config }}-${{ matrix.os }}
           path: ${{ '.' }}/**/*.log
@@ -311,7 +311,7 @@ jobs:
         shell: bash
 
       - name: Upload Linux crash dump reports
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: crash-dumps-${{ matrix.config }}-${{ matrix.os }}
           path: ${{ github.workspace }}/LinuxDumpReports/*
@@ -319,7 +319,7 @@ jobs:
         if: runner.os == 'Linux' && always()
 
       - name: Upload macOS crash diagnostics
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: crash-diagnostics-${{ matrix.config }}-${{ matrix.os }}
           path: ~/Library/Logs/DiagnosticReports/*.ips
@@ -340,7 +340,7 @@ jobs:
               --cdb "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe"
 
       - name: Upload Windows crash dump reports
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: crash-dumps-${{ matrix.config }}-${{ matrix.os }}
           path: ${{ github.workspace }}/LocalDumpReports/*

--- a/.github/workflows/compat-nightly.yml
+++ b/.github/workflows/compat-nightly.yml
@@ -182,7 +182,7 @@ jobs:
             ${{ matrix.os == 'ubuntu-24.04' && '--languages=cpp,csharp,java' || '--languages=cpp' }}
 
       - name: Upload test results
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: compat-test-results-${{ matrix.os }}
           path: |

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash
 
       - name: Upload Analyzer Report
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: matlab-analyzer-report
           path: ./matlab/config/result.json

--- a/.github/workflows/test-pip-package.yml
+++ b/.github/workflows/test-pip-package.yml
@@ -41,7 +41,7 @@ jobs:
         run: python -m build --sdist
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: sdist
           path: python/dist/zeroc_ice-*.tar.gz


### PR DESCRIPTION
- Bump actions/upload-artifact from v5 to v6
- Bump actions/setup-java from v4 to v5
- Bump actions/setup-python from v5 to v6

`microsoft/setup-msbuild` has an open issue to update to Node.js 24. See https://github.com/microsoft/setup-msbuild/issues/144