### PR TITLE
Replace '--rpc xxx' flag in slice2cs with just '--icerpc'.

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -59,28 +59,22 @@ Slice::Gen::Gen(const string& base, const string& dir, GenMode genMode, bool ena
     if (_genMode == GenMode::IceRpc)
     {
         printHeader(_iceRpcOut, fileBase + ".ice", _enableAnalysis);
-    }
 
-    if (_genMode == GenMode::Ice)
-    {
-        _out << sp;
-        _out << nl << "[assembly:Ice.Slice(\"" << fileBase << ".ice\")]";
-    }
-    else
-    {
         _out << sp;
         _out << nl << "using IceRpc.Ice;";
         _out << nl << "using IceRpc.Ice.Codec;";
         _out << sp;
         _out << nl << "[assembly:Ice(\"" << fileBase << ".ice\")]";
 
-        if (_genMode == GenMode::IceRpc)
-        {
-            _iceRpcOut << sp;
-            _iceRpcOut << nl << "using IceRpc.Ice;";
-            _iceRpcOut << nl << "using IceRpc.Ice.Codec;";
-            _iceRpcOut << nl << "using IceRpc.Ice.Operations;";
-        }
+        _iceRpcOut << sp;
+        _iceRpcOut << nl << "using IceRpc.Ice;";
+        _iceRpcOut << nl << "using IceRpc.Ice.Codec;";
+        _iceRpcOut << nl << "using IceRpc.Ice.Operations;";
+    }
+    else
+    {
+        _out << sp;
+        _out << nl << "[assembly:Ice.Slice(\"" << fileBase << ".ice\")]";
     }
 }
 
@@ -124,14 +118,11 @@ Slice::Gen::generate(const UnitPtr& p)
         Slice::IceRpc::TypesVisitor typesVisitor(_out);
         p->visit(&typesVisitor);
 
-        if (_genMode == GenMode::IceRpc)
-        {
-            Slice::IceRpc::ProxyVisitor proxyVisitor(_iceRpcOut);
-            p->visit(&proxyVisitor);
+        Slice::IceRpc::ProxyVisitor proxyVisitor(_iceRpcOut);
+        p->visit(&proxyVisitor);
 
-            Slice::IceRpc::SkeletonVisitor skeletonVisitor(_iceRpcOut);
-            p->visit(&skeletonVisitor);
-        }
+        Slice::IceRpc::SkeletonVisitor skeletonVisitor(_iceRpcOut);
+        p->visit(&skeletonVisitor);
     }
 }
 

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -10,7 +10,6 @@ namespace Slice
 {
     enum class GenMode
     {
-        None,
         Ice,
         IceRpc
     };

--- a/cpp/src/slice2cs/Main.cpp
+++ b/cpp/src/slice2cs/Main.cpp
@@ -44,7 +44,7 @@ usage(const string& n)
                   "-UNAME                   Remove any definition for NAME.\n"
                   "-IDIR                    Put DIR in the include file search path.\n"
                   "--output-dir DIR         Create files in the directory DIR.\n"
-                  "--rpc [none|ice|icerpc]  Generate code for the specified RPC framework. Default is 'ice'.\n"
+                  "--icerpc                 Generate code for use with IceRPC instead of Ice.\n"
                   "-d, --debug              Print debug messages.\n"
                   "--depend                 Generate Makefile dependencies.\n"
                   "--depend-xml             Generate dependencies in XML format.\n"
@@ -65,7 +65,7 @@ compile(const vector<string>& argv)
     opts.addOpt("U", "", IceInternal::Options::NeedArg, "", IceInternal::Options::Repeat);
     opts.addOpt("I", "", IceInternal::Options::NeedArg, "", IceInternal::Options::Repeat);
     opts.addOpt("", "output-dir", IceInternal::Options::NeedArg);
-    opts.addOpt("", "rpc", IceInternal::Options::NeedArg, "ice");
+    opts.addOpt("", "icerpc");
     opts.addOpt("", "depend");
     opts.addOpt("", "depend-xml");
     opts.addOpt("", "depend-file", IceInternal::Options::NeedArg, "");
@@ -132,32 +132,9 @@ compile(const vector<string>& argv)
 
     bool debug = opts.isSet("debug");
 
-    Slice::GenMode genMode;
-    string rpcArg = opts.optArg("rpc");
-    if (rpcArg == "none")
+    Slice::GenMode genMode = opts.isSet("icerpc") ? Slice::GenMode::IceRpc : Slice::GenMode::Ice;
+    if (genMode == Slice::GenMode::IceRpc)
     {
-        genMode = Slice::GenMode::None;
-    }
-    else if (rpcArg == "ice")
-    {
-        genMode = Slice::GenMode::Ice;
-    }
-    else if (rpcArg == "icerpc")
-    {
-        genMode = Slice::GenMode::IceRpc;
-    }
-    else
-    {
-        consoleErr << argv[0] << ": error: invalid argument for --rpc: " << rpcArg << endl;
-        if (!validate)
-        {
-            usage(argv[0]);
-        }
-        return EXIT_FAILURE;
-    }
-    if (genMode == Slice::GenMode::None || genMode == Slice::GenMode::IceRpc)
-    {
-        // Both none and icerpc use the new mapping provided by IceRPC.
         preprocessorArgs.emplace_back("-D__ICERPC__");
     }
 
@@ -208,7 +185,7 @@ compile(const vector<string>& argv)
             }
 
             UnitOptions unitOptions{};
-            if (genMode == Slice::GenMode::None || genMode == Slice::GenMode::IceRpc)
+            if (genMode == Slice::GenMode::IceRpc)
             {
                 unitOptions.defaultMappedName = [](const Contained& contained)
                 {

--- a/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceCompilerTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceCompilerTask.cs
@@ -28,7 +28,7 @@ public abstract class SliceCompilerTask : ToolTask
     public string[] IncludeDirectories { get; set; } = Array.Empty<string>();
 
     /// <summary>
-    /// The RPC provider to generate code for, corresponds to the <c>--rpc</c> compiler option.
+    /// The RPC provider to generate code for.
     /// </summary>
     public string Rpc { get; set; } = "ice";
 
@@ -102,7 +102,7 @@ public abstract class SliceCompilerTask : ToolTask
 
         if (Rpc.Length > 0 && Rpc != "ice")
         {
-            builder.AppendSwitchIfNotNull("--rpc ", Rpc);
+            builder.AppendSwitch("--icerpc");
         }
 
         foreach (string option in AdditionalOptions)

--- a/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceDependTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceDependTask.cs
@@ -22,7 +22,7 @@ public abstract class SliceDependTask : Microsoft.Build.Utilities.Task
     public string WorkingDirectory { get; set; } = "";
 
     /// <summary>
-    /// The RPC provider to generate code for, corresponds to the <c>--rpc</c> compiler option.
+    /// The RPC provider to generate code for.
     /// </summary>
     public string Rpc { get; set; } = "ice";
 

--- a/csharp/src/ZeroC.Ice.Slice.Tools/SliceCompile.CSharp.xaml
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/SliceCompile.CSharp.xaml
@@ -50,7 +50,6 @@
     </StringListProperty>
 
     <EnumProperty Name="Rpc" DisplayName="RPC Provider" Description="Generate code for the specified RPC framework.">
-        <EnumValue Name="none" DisplayName="None" />
         <EnumValue Name="ice" DisplayName="Ice" />
         <EnumValue Name="icerpc" DisplayName="IceRPC" />
         <EnumProperty.DataSource>


### PR DESCRIPTION
This PR simplifies the `--rpc` option in `slice2cs` (which takes an argument of either `none`, `ice`, or `icerpc`),
down to just `--icerpc` (with no arguments).

It effectively removes the `none` option, and maps `--rpc ice` -> `<empty>` and `--rpc icerpc` -> `--icerpc`.

----

I kept the GenMode enum because we like enums more than bools, even though we basically only ever use it as a bool.