### PR TITLE
Replace 'Rpc' String Option with 'IceRpc' Bool Option in the Slice Tool

### DIFF
--- a/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceCompilerTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceCompilerTask.cs
@@ -30,7 +30,7 @@ public abstract class SliceCompilerTask : ToolTask
     /// <summary>
     /// Specifies whether to pass '--icerpc' to 'slice2cs'.
     /// </summary>
-    public bool GenerateIceRpc { get; set; } = false;
+    public bool IceRpc { get; set; } = false;
 
     public string[] AdditionalOptions { get; set; } = Array.Empty<string>();
 
@@ -69,10 +69,10 @@ public abstract class SliceCompilerTask : ToolTask
             options["IncludeDirectories"] = value;
         }
 
-        value = item.GetMetadata("GenerateIceRpc");
+        value = item.GetMetadata("IceRpc");
         if (!string.IsNullOrEmpty(value))
         {
-            options["GenerateIceRpc"] = value;
+            options["IceRpc"] = value;
         }
 
         if (AdditionalOptions.Length > 0)
@@ -100,7 +100,7 @@ public abstract class SliceCompilerTask : ToolTask
             builder.AppendSwitchIfNotNull("-I", Path.GetFullPath(path));
         }
 
-        if (GenerateIceRpc)
+        if (IceRpc)
         {
             builder.AppendSwitch("--icerpc");
         }

--- a/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceDependTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceDependTask.cs
@@ -24,7 +24,7 @@ public abstract class SliceDependTask : Microsoft.Build.Utilities.Task
     /// <summary>
     /// Specifies whether to pass '--icerpc' to 'slice2cs'.
     /// </summary>
-    public bool GenerateIceRpc { get; set; } = false;
+    public bool IceRpc { get; set; } = false;
 
     [Output]
     public ITaskItem[] ComputedSources { get; private set; } = Array.Empty<ITaskItem>();
@@ -67,10 +67,10 @@ public abstract class SliceDependTask : Microsoft.Build.Utilities.Task
             options["IncludeDirectories"] = value;
         }
 
-        value = item.GetMetadata("GenerateIceRpc");
+        value = item.GetMetadata("IceRpc");
         if (!string.IsNullOrEmpty(value))
         {
-            options["GenerateIceRpc"] = value;
+            options["IceRpc"] = value;
         }
 
         value = item.GetMetadata("AdditionalOptions");

--- a/csharp/src/ZeroC.Ice.Slice.Tools/Slice2CSharpDependTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Slice2CSharpDependTask.cs
@@ -8,7 +8,7 @@ namespace ZeroC.Ice.Slice.Tools;
 public class Slice2CSharpDependTask : Common.SliceDependTask
 {
     protected override ITaskItem[] GeneratedItems(ITaskItem source) =>
-        GenerateIceRpc ?
+        IceRpc ?
             new ITaskItem[]
             {
                 new TaskItem(GetGeneratedPath(source, source.GetMetadata("OutputDir"), ".cs")),

--- a/csharp/src/ZeroC.Ice.Slice.Tools/Slice2CSharpTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Slice2CSharpTask.cs
@@ -17,7 +17,7 @@ public class Slice2CSharpTask : Common.SliceCompilerTask
         {
             string message = string.Format("Compiling {0} Generating -> ", source.GetMetadata("Identity"));
             message += Common.TaskUtil.MakeRelative(WorkingDirectory, GetGeneratedPath(source, OutputDir, ".cs"));
-            if (GenerateIceRpc)
+            if (IceRpc)
             {
                 message += ", " + Common.TaskUtil.MakeRelative(WorkingDirectory, GetGeneratedPath(source, OutputDir, ".IceRpc.cs"));
             }
@@ -26,7 +26,7 @@ public class Slice2CSharpTask : Common.SliceCompilerTask
     }
 
     protected override ITaskItem[] GeneratedItems(ITaskItem source) =>
-        GenerateIceRpc ?
+        IceRpc ?
             new ITaskItem[]
             {
                 new TaskItem(GetGeneratedPath(source, OutputDir, ".cs")),

--- a/csharp/src/ZeroC.Ice.Slice.Tools/SliceCompile.CSharp.xaml
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/SliceCompile.CSharp.xaml
@@ -50,9 +50,9 @@
     </StringListProperty>
 
     <BoolProperty
-        Name="GenerateIceRpc"
-        DisplayName="Generate IceRpc"
-        Description="Generate code for use with IceRpc projects.">
+        Name="IceRpc"
+        DisplayName="IceRpc"
+        Description="Generate code for use with IceRPC projects.">
         <BoolProperty.DataSource>
             <DataSource
                 Persistence="ProjectFile"

--- a/csharp/src/ZeroC.Ice.Slice.Tools/ZeroC.Ice.Slice.Tools.targets
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/ZeroC.Ice.Slice.Tools.targets
@@ -104,7 +104,7 @@
             WorkingDirectory      = "$(MSBuildProjectDirectory)"
             IceSliceToolsPath     = "$(_IceSliceToolsPathNormalized)"
             Sources               = "@(_SliceCompileNormalized)"
-            GenerateIceRpc        = "%(_SliceCompileNormalized.GenerateIceRpc)">
+            IceRpc                = "%(_SliceCompileNormalized.IceRpc)">
 
             <Output
                 ItemName          = "_SliceCompile"
@@ -121,7 +121,7 @@
             IceSliceToolsPath     = "$(_IceSliceToolsPathNormalized)"
             OutputDir             = "%(_SliceCompile.OutputDir)"
             IncludeDirectories    = "%(_SliceCompile.IncludeDirectories)"
-            GenerateIceRpc        = "%(_SliceCompile.GenerateIceRpc)"
+            IceRpc                = "%(_SliceCompile.IceRpc)"
             AdditionalOptions     = "%(_SliceCompile.AdditionalOptions)"
             Sources               = "@(_SliceCompile)"
             Condition             = "'%(_SliceCompile.BuildRequired)' == 'True'"/>


### PR DESCRIPTION
**Addendum**
The name of the new option was changed to just `IceRpc`, instead of `GenerateIceRpc`.

**Original**

This PR follows up on https://github.com/zeroc-ice/ice/pull/5251#discussion_r2956070194 and switches the `Rpc` option (a string) in the `SliceCompile` tool to `GenerateIceRpc` (a bool).

This is:
1) More in-line with how it's used in the tool
2) More in-line with the `slice2cs` CLI, where `icerpc` is a boolean flag.