### PR TITLE
Update Ice proxies generated by slice2cs for IceRPC

### DIFF
--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -795,13 +795,13 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     // Primary constructor (invoker, serviceAddress, encodeOptions).
     _out << sp;
     _out << nl << "/// <summary>Constructs a proxy from an invoker, a service address and encode options.</summary>";
-    _out << nl << "/// <param name=\"invoker\">The invocation pipeline of the proxy.</param>";
+    _out << nl << R"(/// <param name="invoker">The invocation pipeline of the proxy.</param>)";
     _out << nl
-         << "/// <param name=\"serviceAddress\">The service address. <see langword=\"null\" /> is equivalent to the ";
+         << R"(/// <param name="serviceAddress">The service address. <see langword="null" /> is equivalent to the )";
     _out << nl
-         << "/// default service address (protocol: <c>ice</c>, path: <see cref=\"DefaultServicePath\" />).</param>";
+         << R"(/// default service address (protocol: <c>ice</c>, path: <see cref="DefaultServicePath" />).</param>)";
     _out << nl
-         << "/// <param name=\"encodeOptions\">The encode options, used to customize the encoding of request "
+         << R"(/// <param name="encodeOptions">The encode options, used to customize the encoding of request )"
             "payloads.</param>";
     _out << nl << "[System.Diagnostics.CodeAnalysis.SetsRequiredMembers]";
     _out << nl << accessModifier(p) << ' ' << name << "Proxy(";
@@ -819,11 +819,11 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     // Constructor (invoker, serviceAddressUri, encodeOptions).
     _out << sp;
     _out << nl
-         << "/// <summary>Constructs a proxy from an invoker, a service address URI and encode options.</summary>";
-    _out << nl << "/// <param name=\"invoker\">The invocation pipeline of the proxy.</param>";
-    _out << nl << "/// <param name=\"serviceAddressUri\">A URI that represents a service address.</param>";
+         << R"(/// <summary>Constructs a proxy from an invoker, a service address URI and encode options.</summary>)";
+    _out << nl << R"(/// <param name="invoker">The invocation pipeline of the proxy.</param>)";
+    _out << nl << R"(/// <param name="serviceAddressUri">A URI that represents a service address.</param>)";
     _out << nl
-         << "/// <param name=\"encodeOptions\">The encode options, used to customize the encoding of request "
+         << R"(/// <param name="encodeOptions">The encode options, used to customize the encoding of request )"
             "payloads.</param>";
     _out << nl << "[System.Diagnostics.CodeAnalysis.SetsRequiredMembers]";
     _out << nl << accessModifier(p) << ' ' << name
@@ -839,8 +839,8 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     // This constructor does not generate [System.Diagnostics.CodeAnalysis.SetsRequiredMembers], so the caller must
     // initialize the required Invoker.
     _out << sp;
-    _out << nl << "/// <summary>Constructs a proxy that uses the default service address: its protocol is <c>ice</c>"
-         << nl << "/// and its path is <see cref=\"DefaultServicePath\" />.</summary>";
+    _out << nl << R"(/// <summary>Constructs a proxy that uses the default service address: its protocol is <c>ice</c>)"
+         << nl << R"(/// and its path is <see cref="DefaultServicePath" />.</summary>)";
     _out << nl << accessModifier(p) << ' ' << name << "Proxy()";
     _out << sb;
     _out << eb;

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -756,7 +756,7 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out << sp;
     _out << nl << "private static IceRpc.ServiceAddress _defaultServiceAddress =";
     _out.inc();
-    _out << nl << "new(IceRpc.Protocol.IceRpc) { Path = DefaultServicePath };";
+    _out << nl << "new(IceRpc.Protocol.Ice) { Path = DefaultServicePath };";
     _out.dec();
     _out << sp;
     _out << nl << "private static readonly IActivator _defaultActivator =";
@@ -779,24 +779,14 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         _out.dec();
     }
 
-    // FromPath static method.
-    _out << sp;
-    _out << nl << "/// <summary>Creates a relative proxy from a path.</summary>";
-    _out << nl << "/// <param name=\"path\">The path.</param>";
-    _out << nl << "/// <returns>The new relative proxy.</returns>";
-    _out << nl << accessModifier(p) << " static " << name << "Proxy FromPath(string path) =>";
-    _out.inc();
-    _out << nl << "new(IceRpc.InvalidInvoker.Instance, new IceRpc.ServiceAddress { Path = path });";
-    _out.dec();
-
     // Primary constructor (invoker, serviceAddress, encodeOptions).
     _out << sp;
     _out << nl << "/// <summary>Constructs a proxy from an invoker, a service address and encode options.</summary>";
     _out << nl << "/// <param name=\"invoker\">The invocation pipeline of the proxy.</param>";
     _out << nl
-         << "/// <param name=\"serviceAddress\">The service address. <see langword=\"null\" /> is equivalent to an "
-            "IceRPC service address";
-    _out << nl << "/// with path <see cref=\"DefaultServicePath\" />.</param>";
+         << "/// <param name=\"serviceAddress\">The service address. <see langword=\"null\" /> is equivalent to a "
+            "service address";
+    _out << nl << "/// for the ice protocol with path <see cref=\"DefaultServicePath\" />.</param>";
     _out << nl
          << "/// <param name=\"encodeOptions\">The encode options, used to customize the encoding of request "
             "payloads.</param>";
@@ -808,6 +798,15 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out << nl << "IceEncodeOptions? encodeOptions = null)";
     _out.dec();
     _out << sb;
+    // We can't encode/decode relative proxies with the Ice encoding, so we reject them. This constructor is called
+    // by the other constructor.
+    _out << nl << "if (serviceAddress is not null && serviceAddress.Protocol is null)";
+    _out << sb;
+    _out << nl
+         << R"(throw new System.ArgumentException("An Ice proxy's service address must have a non-null protocol.", )"
+         << "nameof(serviceAddress));";
+    _out << eb;
+
     _out << nl << "Invoker = invoker;";
     _out << nl << "ServiceAddress = serviceAddress ?? _defaultServiceAddress;";
     _out << nl << "EncodeOptions = encodeOptions;";
@@ -833,10 +832,10 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out << eb;
 
     // Parameterless constructor.
+    // Since we don't generate `[...SetsRequiredMembers]`, the caller needs to initialize the Invoker.
     _out << sp;
-    _out << nl
-         << "/// <summary>Constructs a proxy with an IceRPC service address with path <see cref=\"DefaultServicePath\" "
-            "/>.</summary>";
+    _out << nl << "/// <summary>Constructs a proxy with a service address for the ice protocol with path" << nl
+         << "/// <see cref=\"DefaultServicePath\" />.</summary>";
     _out << nl << accessModifier(p) << ' ' << name << "Proxy()";
     _out << sb;
     _out << eb;

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -819,7 +819,7 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     // Constructor (invoker, serviceAddressUri, encodeOptions).
     _out << sp;
     _out << nl
-         << R"(/// <summary>Constructs a proxy from an invoker, a service address URI and encode options.</summary>)";
+         << "/// <summary>Constructs a proxy from an invoker, a service address URI and encode options.</summary>";
     _out << nl << R"(/// <param name="invoker">The invocation pipeline of the proxy.</param>)";
     _out << nl << R"(/// <param name="serviceAddressUri">A URI that represents a service address.</param>)";
     _out << nl
@@ -839,7 +839,7 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     // This constructor does not generate [System.Diagnostics.CodeAnalysis.SetsRequiredMembers], so the caller must
     // initialize the required Invoker.
     _out << sp;
-    _out << nl << R"(/// <summary>Constructs a proxy that uses the default service address: its protocol is <c>ice</c>)"
+    _out << nl << "/// <summary>Constructs a proxy that uses the default service address: its protocol is <c>ice</c>"
          << nl << R"(/// and its path is <see cref="DefaultServicePath" />.</summary>)";
     _out << nl << accessModifier(p) << ' ' << name << "Proxy()";
     _out << sb;

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -832,7 +832,8 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out << eb;
 
     // Parameterless constructor.
-    // Since we don't generate `[...SetsRequiredMembers]`, the caller needs to initialize the Invoker.
+    // This constructor does not generate [System.Diagnostics.CodeAnalysis.SetsRequiredMembers], so the caller must
+    // initialize the required Invoker (for example, via an object initializer).
     _out << sp;
     _out << nl << "/// <summary>Constructs a proxy that uses the default service address: its protocol is <c>ice</c>"
          << nl << "/// and its path is <see cref=\"DefaultServicePath\" />.</summary>";

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -784,9 +784,9 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out << nl << "/// <summary>Constructs a proxy from an invoker, a service address and encode options.</summary>";
     _out << nl << "/// <param name=\"invoker\">The invocation pipeline of the proxy.</param>";
     _out << nl
-         << "/// <param name=\"serviceAddress\">The service address. <see langword=\"null\" /> is equivalent to a "
-            "service address";
-    _out << nl << "/// for the ice protocol with path <see cref=\"DefaultServicePath\" />.</param>";
+         << "/// <param name=\"serviceAddress\">The service address. <see langword=\"null\" /> is equivalent to the ";
+    _out << nl
+         << "/// default service address (protocol: <c>ice</c>, path: <see cref=\"DefaultServicePath\" />).</param>";
     _out << nl
          << "/// <param name=\"encodeOptions\">The encode options, used to customize the encoding of request "
             "payloads.</param>";
@@ -834,8 +834,8 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     // Parameterless constructor.
     // Since we don't generate `[...SetsRequiredMembers]`, the caller needs to initialize the Invoker.
     _out << sp;
-    _out << nl << "/// <summary>Constructs a proxy with a service address for the ice protocol with path" << nl
-         << "/// <see cref=\"DefaultServicePath\" />.</summary>";
+    _out << nl << "/// <summary>Constructs a proxy that uses the default service address: its protocol is <c>ice</c>"
+         << nl << "/// and its path is <see cref=\"DefaultServicePath\" />.</summary>";
     _out << nl << accessModifier(p) << ' ' << name << "Proxy()";
     _out << sb;
     _out << eb;

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -752,7 +752,20 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out << nl << "public required IceRpc.IInvoker Invoker { get; init; }";
     _out << sp;
     _out << nl << "/// <inheritdoc/>";
-    _out << nl << "public IceRpc.ServiceAddress ServiceAddress { get; init; } = _defaultServiceAddress;";
+    _out << nl << "public IceRpc.ServiceAddress ServiceAddress";
+    _out << sb;
+    _out << nl << "get;";
+    _out << nl << "init";
+    _out << sb;
+    _out << nl << "if (value.Protocol is null)";
+    _out << sb;
+    _out << nl
+         << R"(throw new System.ArgumentException("An Ice proxy's service address must have a non-null protocol.", )"
+         << "nameof(value));";
+    _out << eb;
+    _out << nl << "field = value;";
+    _out << eb;
+    _out << eb << " = _defaultServiceAddress;";
     _out << sp;
     _out << nl << "private static IceRpc.ServiceAddress _defaultServiceAddress =";
     _out.inc();
@@ -798,15 +811,6 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out << nl << "IceEncodeOptions? encodeOptions = null)";
     _out.dec();
     _out << sb;
-    // We can't encode/decode relative proxies with the Ice encoding, so we reject them. This constructor is called
-    // by the other constructor.
-    _out << nl << "if (serviceAddress is not null && serviceAddress.Protocol is null)";
-    _out << sb;
-    _out << nl
-         << R"(throw new System.ArgumentException("An Ice proxy's service address must have a non-null protocol.", )"
-         << "nameof(serviceAddress));";
-    _out << eb;
-
     _out << nl << "Invoker = invoker;";
     _out << nl << "ServiceAddress = serviceAddress ?? _defaultServiceAddress;";
     _out << nl << "EncodeOptions = encodeOptions;";
@@ -833,7 +837,7 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 
     // Parameterless constructor.
     // This constructor does not generate [System.Diagnostics.CodeAnalysis.SetsRequiredMembers], so the caller must
-    // initialize the required Invoker (for example, via an object initializer).
+    // initialize the required Invoker.
     _out << sp;
     _out << nl << "/// <summary>Constructs a proxy that uses the default service address: its protocol is <c>ice</c>"
          << nl << "/// and its path is <see cref=\"DefaultServicePath\" />.</summary>";


### PR DESCRIPTION
This PR updates the generated proxies as follows:
 - the default protocol is now ice instead of icerpc
 - remove FromPath (used to create relative proxies)
 - disallow relative proxies since they can't be encoded with Ice
