### PR TITLE
Simplify code generated by slice2cs --icerpc

### DIFF
--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -19,19 +19,17 @@ Slice::Gen::Gen(const string& base, const string& dir, GenMode genMode, bool ena
     : _genMode(genMode),
       _enableAnalysis(enableAnalysis)
 {
-    string fileBase = base;
+    _fileBase = base;
     string::size_type pos = base.find_last_of("/\\");
     if (pos != string::npos)
     {
-        fileBase = base.substr(pos + 1);
+        _fileBase = base.substr(pos + 1);
     }
-    string file = fileBase + ".cs";
-    string iceRpcFile = fileBase + ".IceRpc.cs";
+    string file = _genMode == GenMode::IceRpc ? _fileBase + ".IceRpc.cs" : _fileBase + ".cs";
 
     if (!dir.empty())
     {
         file = dir + '/' + file;
-        iceRpcFile = dir + '/' + iceRpcFile;
     }
 
     _out.open(file.c_str());
@@ -43,38 +41,17 @@ Slice::Gen::Gen(const string& base, const string& dir, GenMode genMode, bool ena
     }
     FileTracker::instance()->addFile(file);
 
+    printHeader(_fileBase + ".ice");
     if (_genMode == GenMode::IceRpc)
     {
-        _iceRpcOut.open(iceRpcFile.c_str());
-        if (!_iceRpcOut)
-        {
-            ostringstream os;
-            os << "cannot open '" << iceRpcFile << "': " << IceInternal::errorToString(errno);
-            throw FileException(os.str());
-        }
-        FileTracker::instance()->addFile(iceRpcFile);
-    }
-
-    printHeader(_out, fileBase + ".ice", _enableAnalysis);
-    if (_genMode == GenMode::IceRpc)
-    {
-        printHeader(_iceRpcOut, fileBase + ".ice", _enableAnalysis);
-
         _out << sp;
         _out << nl << "using IceRpc.Ice;";
         _out << nl << "using IceRpc.Ice.Codec;";
-        _out << sp;
-        _out << nl << "[assembly:Ice(\"" << fileBase << ".ice\")]";
-
-        _iceRpcOut << sp;
-        _iceRpcOut << nl << "using IceRpc.Ice;";
-        _iceRpcOut << nl << "using IceRpc.Ice.Codec;";
-        _iceRpcOut << nl << "using IceRpc.Ice.Operations;";
     }
     else
     {
         _out << sp;
-        _out << nl << "[assembly:Ice.Slice(\"" << fileBase << ".ice\")]";
+        _out << nl << "[assembly:Ice.Slice(\"" << _fileBase << ".ice\")]";
     }
 }
 
@@ -84,11 +61,6 @@ Slice::Gen::~Gen()
     {
         _out << nl;
         _out.close();
-    }
-    if (_iceRpcOut.isOpen())
-    {
-        _iceRpcOut << nl;
-        _iceRpcOut.close();
     }
 }
 
@@ -115,53 +87,52 @@ Slice::Gen::generate(const UnitPtr& p)
     }
     else
     {
-        Slice::IceRpc::TypesVisitor typesVisitor(_out);
+        // The types visitor must be the first visitor since it optionally generates a using directive for all
+        // visitors to use.
+        Slice::IceRpc::TypesVisitor typesVisitor(_out, _fileBase);
         p->visit(&typesVisitor);
 
-        Slice::IceRpc::ProxyVisitor proxyVisitor(_iceRpcOut);
-        p->visit(&proxyVisitor);
-
-        Slice::IceRpc::SkeletonVisitor skeletonVisitor(_iceRpcOut);
+        Slice::IceRpc::SkeletonVisitor skeletonVisitor(_out);
         p->visit(&skeletonVisitor);
     }
 }
 
 void
-Slice::Gen::printHeader(IceInternal::Output& out, const string& iceFile, bool enableAnalysis)
+Slice::Gen::printHeader(const string& iceFile)
 {
-    out << "// Copyright (c) ZeroC, Inc.";
-    out << sp;
-    out << nl << "// slice2cs version " << ICE_STRING_VERSION;
+    _out << "// Copyright (c) ZeroC, Inc.";
+    _out << sp;
+    _out << nl << "// slice2cs version " << ICE_STRING_VERSION;
 
-    if (!enableAnalysis)
+    if (!_enableAnalysis)
     {
-        printGeneratedHeader(out, iceFile);
+        printGeneratedHeader(_out, iceFile);
     }
 
-    out << sp;
-    out << nl << "#nullable enable";
-    out << sp;
+    _out << sp;
+    _out << nl << "#nullable enable";
+    _out << sp;
 
-    if (enableAnalysis)
+    if (_enableAnalysis)
     {
         // Disable some warnings when auto-generated is removed from the header. See printGeneratedHeader above.
-        out << nl << "#pragma warning disable SA1403 // File may only contain a single namespace";
-        out << nl << "#pragma warning disable SA1611 // The documentation for parameter x is missing";
+        _out << nl << "#pragma warning disable SA1403 // File may only contain a single namespace";
+        _out << nl << "#pragma warning disable SA1611 // The documentation for parameter x is missing";
 
-        out << nl << "#pragma warning disable CA1041 // Provide a message for the ObsoleteAttribute that marks ...";
+        _out << nl << "#pragma warning disable CA1041 // Provide a message for the ObsoleteAttribute that marks ...";
 
-        out << nl << "#pragma warning disable CA1068 // Cancellation token as last parameter";
-        out << nl << "#pragma warning disable CA1725 // Change parameter name istr_ to istr in order to match ...";
+        _out << nl << "#pragma warning disable CA1068 // Cancellation token as last parameter";
+        _out << nl << "#pragma warning disable CA1725 // Change parameter name istr_ to istr in order to match ...";
 
         // Missing doc - only necessary for the tests.
-        out << nl << "#pragma warning disable SA1602";
-        out << nl << "#pragma warning disable SA1604";
-        out << nl << "#pragma warning disable SA1605";
+        _out << nl << "#pragma warning disable SA1602";
+        _out << nl << "#pragma warning disable SA1604";
+        _out << nl << "#pragma warning disable SA1605";
     }
 
-    out << nl << "#pragma warning disable CS1591 // Missing XML Comment";
-    out << nl << "#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment";
-    out << nl << "#pragma warning disable CS0612 // Type or member is obsolete";
-    out << nl << "#pragma warning disable CS0618 // Type or member is obsolete";
-    out << nl << "#pragma warning disable CS0619 // Type or member is obsolete";
+    _out << nl << "#pragma warning disable CS1591 // Missing XML Comment";
+    _out << nl << "#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment";
+    _out << nl << "#pragma warning disable CS0612 // Type or member is obsolete";
+    _out << nl << "#pragma warning disable CS0618 // Type or member is obsolete";
+    _out << nl << "#pragma warning disable CS0619 // Type or member is obsolete";
 }

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -87,9 +87,15 @@ Slice::Gen::generate(const UnitPtr& p)
     }
     else
     {
-        // The types visitor must be the first visitor since it optionally generates a using directive for all
-        // visitors to use.
-        Slice::IceRpc::TypesVisitor typesVisitor(_out, _fileBase);
+        if (p->contains<InterfaceDef>())
+        {
+            // The proxy and skeleton code depends on this using directive.
+            _out << nl << "using IceRpc.Ice.Operations;";
+        }
+        _out << sp;
+        _out << nl << "[assembly:IceGeneratedCode(\"" << _fileBase << ".ice\")]";
+
+        Slice::IceRpc::TypesVisitor typesVisitor(_out);
         p->visit(&typesVisitor);
 
         Slice::IceRpc::SkeletonVisitor skeletonVisitor(_out);

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -26,10 +26,10 @@ namespace Slice
     private:
         const GenMode _genMode;
         IceInternal::Output _out;
-        IceInternal::Output _iceRpcOut;
         const bool _enableAnalysis;
+        std::string _fileBase;
 
-        static void printHeader(IceInternal::Output& out, const std::string& iceFile, bool enableAnalysis);
+        void printHeader(const std::string& iceFile);
     };
 }
 

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -182,26 +182,7 @@ namespace
     string accessModifier(const ContainedPtr& p) { return p->hasMetadata("cs:internal") ? "internal" : "public"; }
 }
 
-Slice::IceRpc::TypesVisitor::TypesVisitor(IceInternal::Output& out, std::string fileBase)
-    : CsVisitor(out),
-      _fileBase(std::move(fileBase))
-{
-}
-
-bool
-Slice::IceRpc::TypesVisitor::visitUnitStart(const UnitPtr& unit)
-{
-    if (unit->contains<InterfaceDef>())
-    {
-        // The proxy and skeleton code depends on this using directive.
-        _out << nl << "using IceRpc.Ice.Operations;";
-    }
-
-    _out << nl << "[assembly:IceGeneratedCode(\"" << _fileBase << ".ice\")]";
-    _out << sp;
-
-    return true;
-}
+Slice::IceRpc::TypesVisitor::TypesVisitor(IceInternal::Output& out) : CsVisitor(out) {}
 
 bool
 Slice::IceRpc::TypesVisitor::visitStructStart(const StructPtr& p)

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -182,7 +182,26 @@ namespace
     string accessModifier(const ContainedPtr& p) { return p->hasMetadata("cs:internal") ? "internal" : "public"; }
 }
 
-Slice::IceRpc::TypesVisitor::TypesVisitor(IceInternal::Output& out) : CsVisitor(out) {}
+Slice::IceRpc::TypesVisitor::TypesVisitor(IceInternal::Output& out, std::string fileBase)
+    : CsVisitor(out),
+      _fileBase(std::move(fileBase))
+{
+}
+
+bool
+Slice::IceRpc::TypesVisitor::visitUnitStart(const UnitPtr& unit)
+{
+    if (unit->contains<InterfaceDef>())
+    {
+        // The proxy and skeleton code depends on this using directive.
+        _out << nl << "using IceRpc.Ice.Operations;";
+    }
+
+    _out << nl << "[assembly:IceGeneratedCode(\"" << _fileBase << ".ice\")]";
+    _out << sp;
+
+    return true;
+}
 
 bool
 Slice::IceRpc::TypesVisitor::visitStructStart(const StructPtr& p)
@@ -519,170 +538,7 @@ Slice::IceRpc::TypesVisitor::visitEnum(const EnumPtr& p)
 }
 
 bool
-Slice::IceRpc::TypesVisitor::writePrimaryConstructor(
-    const ContainedPtr& p,
-    const DataMemberList& fields,
-    const DataMemberList& allBaseFields,
-    const string& kind)
-{
-    // Primary constructor with parameters for all fields.
-    string escapedName = p->mappedName();
-    string name = removeEscapePrefix(escapedName);
-    string ns = getNamespace(p);
-
-    _out << sp;
-    writeDocLine(
-        _out,
-        "summary",
-        "Initializes a new instance of the <see cref=\"" + escapedName + "\" /> " + kind + ".");
-
-    vector<string> ctorParams;
-    vector<string> baseParams;
-    vector<string> ctorPropertyInits;
-    bool hasRequiredField = false;
-
-    for (const auto& field : allBaseFields)
-    {
-        string paramName = field->customMappedName().value_or(toCamelCase(field->name()));
-        ctorParams.push_back(csFieldType(field->type(), ns, field->optional()) + " " + paramName);
-        if (csRequired(field))
-        {
-            hasRequiredField = true;
-        }
-        baseParams.push_back(paramName);
-    }
-
-    for (const auto& field : fields)
-    {
-        string paramName = field->customMappedName().value_or(toCamelCase(field->name()));
-        ctorParams.push_back(csFieldType(field->type(), ns, field->optional()) + " " + paramName);
-        if (csRequired(field))
-        {
-            hasRequiredField = true;
-        }
-
-        ctorPropertyInits.push_back("this." + field->mappedName() + " = " + paramName + ';');
-    }
-
-    if (hasRequiredField)
-    {
-        _out << nl << "[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]";
-    }
-
-    _out << nl << accessModifier(p) << ' ' << escapedName << spar << ctorParams << epar;
-    if (!baseParams.empty())
-    {
-        _out.inc();
-        _out << nl << ": base" << spar << baseParams << epar;
-        _out.dec();
-    }
-
-    _out << sb;
-    for (const auto& propertyInit : ctorPropertyInits)
-    {
-        _out << nl << propertyInit;
-    }
-    _out << eb;
-    return hasRequiredField;
-}
-
-void
-Slice::IceRpc::TypesVisitor::writeEncodeDecode(
-    int compactId,
-    const string& ns,
-    bool hasBase,
-    const DataMemberList& fields,
-    const DataMemberList& orderedOptionalFields)
-{
-    _out << sp;
-    emitNonBrowsableAttribute();
-    _out << nl << "protected override void EncodeCore(ref IceEncoder encoder)";
-    _out << sb;
-    _out << nl << "encoder.StartSlice(IceTypeId";
-    if (compactId != -1)
-    {
-        _out << ", CompactIceTypeId";
-    }
-    _out << ");";
-    // Encode non-optional fields
-    for (const auto& field : fields)
-    {
-        if (!field->optional())
-        {
-            _out << nl;
-            encodeField(_out, "this." + field->mappedName(), field->type(), ns, TypeContext::Field, "encoder");
-            _out << ';';
-        }
-    }
-    // Encode optional fields
-    for (const auto& field : orderedOptionalFields)
-    {
-        encodeOptionalField(
-            _out,
-            field->tag(),
-            "this." + field->mappedName(),
-            field->type(),
-            ns,
-            TypeContext::Field,
-            "encoder");
-    }
-
-    if (hasBase)
-    {
-        _out << nl << "encoder.EndSlice(false);";
-        _out << nl << "base.EncodeCore(ref encoder);";
-    }
-    else
-    {
-        _out << nl << "encoder.EndSlice(true);"; // last slice
-    }
-    _out << eb;
-
-    _out << sp;
-    emitNonBrowsableAttribute();
-    _out << nl << "protected override void DecodeCore(ref IceDecoder decoder)";
-    _out << sb;
-    _out << nl << "decoder.StartSlice();";
-    // Decode non-optional fields
-    for (const auto& field : fields)
-    {
-        if (!field->optional())
-        {
-            _out << nl << "this." + field->mappedName() << " = ";
-            decodeField(_out, field->type(), ns);
-            _out << ';';
-        }
-    }
-    // Decode optional fields
-    for (const auto& field : orderedOptionalFields)
-    {
-        _out << nl << "this." + field->mappedName() << " = ";
-        decodeOptionalField(_out, field->tag(), field->type(), ns, TypeContext::Field);
-        _out << ';';
-    }
-
-    _out << nl << "decoder.EndSlice();";
-    if (hasBase)
-    {
-        _out << nl << "base.DecodeCore(ref decoder);";
-    }
-    _out << eb;
-}
-
-Slice::IceRpc::ProxyVisitor::ProxyVisitor(IceInternal::Output& out) : CsVisitor(out) {}
-
-bool
-Slice::IceRpc::ProxyVisitor::visitModuleStart(const ModulePtr& p)
-{
-    if (!p->contains<InterfaceDef>())
-    {
-        return false;
-    }
-    return CsVisitor::visitModuleStart(p);
-}
-
-bool
-Slice::IceRpc::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
+Slice::IceRpc::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     string ns = getNamespace(p);
     string escapedName = p->mappedName();
@@ -710,7 +566,7 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 }
 
 void
-Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
+Slice::IceRpc::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 {
     string ns = getNamespace(p);
     string escapedName = p->mappedName();
@@ -970,7 +826,7 @@ Slice::IceRpc::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 }
 
 void
-Slice::IceRpc::ProxyVisitor::visitOperation(const OperationPtr& p)
+Slice::IceRpc::TypesVisitor::visitOperation(const OperationPtr& p)
 {
     string ns = getNamespace(p->interface());
 
@@ -983,8 +839,159 @@ Slice::IceRpc::ProxyVisitor::visitOperation(const OperationPtr& p)
     _out << ';';
 }
 
+bool
+Slice::IceRpc::TypesVisitor::writePrimaryConstructor(
+    const ContainedPtr& p,
+    const DataMemberList& fields,
+    const DataMemberList& allBaseFields,
+    const string& kind)
+{
+    // Primary constructor with parameters for all fields.
+    string escapedName = p->mappedName();
+    string name = removeEscapePrefix(escapedName);
+    string ns = getNamespace(p);
+
+    _out << sp;
+    writeDocLine(
+        _out,
+        "summary",
+        "Initializes a new instance of the <see cref=\"" + escapedName + "\" /> " + kind + ".");
+
+    vector<string> ctorParams;
+    vector<string> baseParams;
+    vector<string> ctorPropertyInits;
+    bool hasRequiredField = false;
+
+    for (const auto& field : allBaseFields)
+    {
+        string paramName = field->customMappedName().value_or(toCamelCase(field->name()));
+        ctorParams.push_back(csFieldType(field->type(), ns, field->optional()) + " " + paramName);
+        if (csRequired(field))
+        {
+            hasRequiredField = true;
+        }
+        baseParams.push_back(paramName);
+    }
+
+    for (const auto& field : fields)
+    {
+        string paramName = field->customMappedName().value_or(toCamelCase(field->name()));
+        ctorParams.push_back(csFieldType(field->type(), ns, field->optional()) + " " + paramName);
+        if (csRequired(field))
+        {
+            hasRequiredField = true;
+        }
+
+        ctorPropertyInits.push_back("this." + field->mappedName() + " = " + paramName + ';');
+    }
+
+    if (hasRequiredField)
+    {
+        _out << nl << "[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]";
+    }
+
+    _out << nl << accessModifier(p) << ' ' << escapedName << spar << ctorParams << epar;
+    if (!baseParams.empty())
+    {
+        _out.inc();
+        _out << nl << ": base" << spar << baseParams << epar;
+        _out.dec();
+    }
+
+    _out << sb;
+    for (const auto& propertyInit : ctorPropertyInits)
+    {
+        _out << nl << propertyInit;
+    }
+    _out << eb;
+    return hasRequiredField;
+}
+
 void
-Slice::IceRpc::ProxyVisitor::writeProxyRequestClass(const InterfaceDefPtr& interface)
+Slice::IceRpc::TypesVisitor::writeEncodeDecode(
+    int compactId,
+    const string& ns,
+    bool hasBase,
+    const DataMemberList& fields,
+    const DataMemberList& orderedOptionalFields)
+{
+    _out << sp;
+    emitNonBrowsableAttribute();
+    _out << nl << "protected override void EncodeCore(ref IceEncoder encoder)";
+    _out << sb;
+    _out << nl << "encoder.StartSlice(IceTypeId";
+    if (compactId != -1)
+    {
+        _out << ", CompactIceTypeId";
+    }
+    _out << ");";
+    // Encode non-optional fields
+    for (const auto& field : fields)
+    {
+        if (!field->optional())
+        {
+            _out << nl;
+            encodeField(_out, "this." + field->mappedName(), field->type(), ns, TypeContext::Field, "encoder");
+            _out << ';';
+        }
+    }
+    // Encode optional fields
+    for (const auto& field : orderedOptionalFields)
+    {
+        encodeOptionalField(
+            _out,
+            field->tag(),
+            "this." + field->mappedName(),
+            field->type(),
+            ns,
+            TypeContext::Field,
+            "encoder");
+    }
+
+    if (hasBase)
+    {
+        _out << nl << "encoder.EndSlice(false);";
+        _out << nl << "base.EncodeCore(ref encoder);";
+    }
+    else
+    {
+        _out << nl << "encoder.EndSlice(true);"; // last slice
+    }
+    _out << eb;
+
+    _out << sp;
+    emitNonBrowsableAttribute();
+    _out << nl << "protected override void DecodeCore(ref IceDecoder decoder)";
+    _out << sb;
+    _out << nl << "decoder.StartSlice();";
+    // Decode non-optional fields
+    for (const auto& field : fields)
+    {
+        if (!field->optional())
+        {
+            _out << nl << "this." + field->mappedName() << " = ";
+            decodeField(_out, field->type(), ns);
+            _out << ';';
+        }
+    }
+    // Decode optional fields
+    for (const auto& field : orderedOptionalFields)
+    {
+        _out << nl << "this." + field->mappedName() << " = ";
+        decodeOptionalField(_out, field->tag(), field->type(), ns, TypeContext::Field);
+        _out << ';';
+    }
+
+    _out << nl << "decoder.EndSlice();";
+    if (hasBase)
+    {
+        _out << nl << "base.DecodeCore(ref decoder);";
+    }
+    _out << eb;
+}
+
+void
+Slice::IceRpc::TypesVisitor::writeProxyRequestClass(const InterfaceDefPtr& interface)
 {
     string ns = getNamespace(interface);
 
@@ -1057,7 +1064,7 @@ Slice::IceRpc::ProxyVisitor::writeProxyRequestClass(const InterfaceDefPtr& inter
 }
 
 void
-Slice::IceRpc::ProxyVisitor::writeProxyResponseClass(const InterfaceDefPtr& interface)
+Slice::IceRpc::TypesVisitor::writeProxyResponseClass(const InterfaceDefPtr& interface)
 {
     string ns = getNamespace(interface);
 

--- a/cpp/src/slice2cs/IceRpcVisitors.h
+++ b/cpp/src/slice2cs/IceRpcVisitors.h
@@ -13,9 +13,7 @@ namespace Slice::IceRpc
     class TypesVisitor final : public CsVisitor
     {
     public:
-        TypesVisitor(IceInternal::Output& out, std::string fileBase);
-
-        bool visitUnitStart(const UnitPtr&) final;
+        TypesVisitor(IceInternal::Output& out);
 
         bool visitStructStart(const StructPtr&) final;
         void visitStructEnd(const StructPtr&) final;
@@ -50,8 +48,6 @@ namespace Slice::IceRpc
 
         void writeProxyRequestClass(const InterfaceDefPtr& interface);
         void writeProxyResponseClass(const InterfaceDefPtr& interface);
-
-        std::string _fileBase;
     };
 
     // Generates skeleton interfaces.

--- a/cpp/src/slice2cs/IceRpcVisitors.h
+++ b/cpp/src/slice2cs/IceRpcVisitors.h
@@ -13,7 +13,9 @@ namespace Slice::IceRpc
     class TypesVisitor final : public CsVisitor
     {
     public:
-        TypesVisitor(IceInternal::Output&);
+        TypesVisitor(IceInternal::Output& out, std::string fileBase);
+
+        bool visitUnitStart(const UnitPtr&) final;
 
         bool visitStructStart(const StructPtr&) final;
         void visitStructEnd(const StructPtr&) final;
@@ -28,6 +30,10 @@ namespace Slice::IceRpc
 
         void visitEnum(const EnumPtr&) final;
 
+        bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
+        void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
+        void visitOperation(const OperationPtr&) final;
+
     private:
         bool writePrimaryConstructor(
             const ContainedPtr& p,
@@ -41,23 +47,11 @@ namespace Slice::IceRpc
             bool hasBase,
             const DataMemberList& fields,
             const DataMemberList& allBaseFields);
-    };
 
-    // Generates proxies.
-    class ProxyVisitor final : public CsVisitor
-    {
-    public:
-        ProxyVisitor(IceInternal::Output&);
-
-        bool visitModuleStart(const ModulePtr&) final;
-
-        bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
-        void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
-        void visitOperation(const OperationPtr&) final;
-
-    private:
         void writeProxyRequestClass(const InterfaceDefPtr& interface);
         void writeProxyResponseClass(const InterfaceDefPtr& interface);
+
+        std::string _fileBase;
     };
 
     // Generates skeleton interfaces.

--- a/cpp/src/slice2cs/IceRpcVisitors.h
+++ b/cpp/src/slice2cs/IceRpcVisitors.h
@@ -46,7 +46,7 @@ namespace Slice::IceRpc
             const std::string& ns,
             bool hasBase,
             const DataMemberList& fields,
-            const DataMemberList& allBaseFields);
+            const DataMemberList& orderedOptionalFields);
 
         void writeProxyRequestClass(const InterfaceDefPtr& interface);
         void writeProxyResponseClass(const InterfaceDefPtr& interface);

--- a/cpp/src/slice2cs/Main.cpp
+++ b/cpp/src/slice2cs/Main.cpp
@@ -215,7 +215,8 @@ compile(const vector<string>& argv)
                 dependencyGenerator.addDependenciesFor(unit);
                 if (depend)
                 {
-                    string target = removeExtension(baseName(fileName)) + ".cs";
+                    string target = removeExtension(baseName(fileName)) +
+                                    (genMode == Slice::GenMode::IceRpc ? ".IceRpc.cs" : ".cs");
                     dependencyGenerator.writeMakefileDependencies(dependFile, unit->topLevelFile(), target);
                 }
                 // else XML dependencies are written below after all units have been processed.

--- a/csharp/src/ZeroC.Ice.Slice.Tools/Slice2CSharpDependTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Slice2CSharpDependTask.cs
@@ -8,16 +8,10 @@ namespace ZeroC.Ice.Slice.Tools;
 public class Slice2CSharpDependTask : Common.SliceDependTask
 {
     protected override ITaskItem[] GeneratedItems(ITaskItem source) =>
-        IceRpc ?
-            new ITaskItem[]
-            {
-                new TaskItem(GetGeneratedPath(source, source.GetMetadata("OutputDir"), ".cs")),
-                new TaskItem(GetGeneratedPath(source, source.GetMetadata("OutputDir"), ".IceRpc.cs"))
-            } :
-            new ITaskItem[]
-            {
-                new TaskItem(GetGeneratedPath(source, source.GetMetadata("OutputDir"), ".cs"))
-            };
+        new ITaskItem[]
+        {
+            new TaskItem(GetGeneratedPath(source, source.GetMetadata("OutputDir"), IceRpc ? ".IceRpc.cs" : ".cs"))
+        };
 
     // Same as generated items but only returns the generated items that need to be compiled
     // for example it excludes C++ headers

--- a/csharp/src/ZeroC.Ice.Slice.Tools/Slice2CSharpTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Slice2CSharpTask.cs
@@ -16,24 +16,16 @@ public class Slice2CSharpTask : Common.SliceCompilerTask
         foreach (ITaskItem source in Sources)
         {
             string message = string.Format("Compiling {0} Generating -> ", source.GetMetadata("Identity"));
-            message += Common.TaskUtil.MakeRelative(WorkingDirectory, GetGeneratedPath(source, OutputDir, ".cs"));
-            if (IceRpc)
-            {
-                message += ", " + Common.TaskUtil.MakeRelative(WorkingDirectory, GetGeneratedPath(source, OutputDir, ".IceRpc.cs"));
-            }
+            message += Common.TaskUtil.MakeRelative(
+                WorkingDirectory,
+                GetGeneratedPath(source, OutputDir, IceRpc ? ".IceRpc.cs" : ".cs"));
             Log.LogMessage(MessageImportance.High, message);
         }
     }
 
     protected override ITaskItem[] GeneratedItems(ITaskItem source) =>
-        IceRpc ?
-            new ITaskItem[]
-            {
-                new TaskItem(GetGeneratedPath(source, OutputDir, ".cs")),
-                new TaskItem(GetGeneratedPath(source, OutputDir, ".IceRpc.cs"))
-            } :
-            new ITaskItem[]
-            {
-                new TaskItem(GetGeneratedPath(source, OutputDir, ".cs"))
-            };
+        new ITaskItem[]
+        {
+            new TaskItem(GetGeneratedPath(source, OutputDir, IceRpc ? ".IceRpc.cs" : ".cs"))
+        };
 }


### PR DESCRIPTION
With this PR, slice2cs --icerpc generates a single file per .ice source file, fileBase.IceRpc.cs.

It also generates the `using IceRpc.Ice.Operations` only when the source Ice Slice file contains one or more interfaces, which simplifies the logic in icerpc-csharp (no need to ever delete .IceRpc.cs files).