### PR TITLE
Remove EncodedReturn attribute argument from slice2cs --icerpc

### DIFF
--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -1282,10 +1282,6 @@ Slice::IceRpc::SkeletonVisitor::visitOperation(const OperationPtr& p)
 
     _out << nl << "[IceOperation(\"" << p->name() << "\"";
 
-    if (p->hasMarshaledResult())
-    {
-        _out << ", EncodedReturn = true";
-    }
     if (p->mode() == Operation::Idempotent)
     {
         _out << ", Idempotent = true";


### PR DESCRIPTION
Part of the fix for https://github.com/icerpc/icerpc-csharp/issues/4339 