### PR TITLE
Add Support for `*` in Links to Control Whether it Links to a Proxy or a Servant Type

### DIFF
--- a/cpp/src/Slice/DocCommentParser.cpp
+++ b/cpp/src/Slice/DocCommentParser.cpp
@@ -237,8 +237,19 @@ namespace
 
     /// Returns a pointer to the Slice element referenced by `linkText`, relative to the scope of `source`.
     /// If the link cannot be resolved, `nullptr` is returned instead.
+    ///
+    /// @remark For classes and interfaces, the resolved type will always be an `xxxDecl` and never an `xxxDef`.
     SyntaxTreeBasePtr resolveDocLink(string linkText, const ContainedPtr& source)
     {
+        assert(!linkText.empty());
+
+        // If the link ends with '*' (i.e. the syntax for linking to a proxy), remove it so we can lookup the type.
+        bool useProxyType = linkText.back() == '*';
+        if (useProxyType)
+        {
+            linkText.pop_back();
+        }
+
         // First we check if the link is to a builtin type.
         if (auto kind = Builtin::kindFromString(linkText))
         {
@@ -253,20 +264,33 @@ namespace
         }
 
         // Perform the actual lookup.
+        ContainedList results;
         auto separatorPos = linkText.find('#');
         if (separatorPos == 0)
         {
             // If the link starts with '#', it is explicitly relative to the `linkSourceScope` container.
-            ContainedList results = source->unit()->findContents(linkSourceScope->thisScope() + linkText.substr(1));
-            return (results.empty() ? nullptr : results.front());
+            results = source->unit()->findContents(linkSourceScope->thisScope() + linkText.substr(1));
         }
-        else if (separatorPos != string::npos)
+        else
         {
-            // If the link has a '#' anywhere else, convert it to '::' so we can look it up.
-            linkText.replace(separatorPos, 1, "::");
+            if (separatorPos != string::npos)
+            {
+                // If the link has a '#' anywhere else, convert it to '::' so we can look it up.
+                linkText.replace(separatorPos, 1, "::");
+            }
+            results = linkSourceScope->lookupContained(linkText, false);
         }
-        ContainedList results = linkSourceScope->lookupContained(linkText, false);
-        return (results.empty() ? nullptr : results.front());
+        // We want to use the first match, if there were any.
+        ContainedPtr result = (results.empty() ? nullptr : results.front());
+
+        // If the link ended with '*', emit a warning if the link was to a non-interface.
+        if (useProxyType && result && !dynamic_pointer_cast<InterfaceDecl>(result))
+        {
+            string msg = "'*' cannot be used with '" + result->name() + "' as it is not an interface";
+            source->unit()->warning(source->file(), source->line(), InvalidComment, msg);
+        }
+
+        return result;
     }
 
     /// Formats a code-span starting at \p pos.
@@ -334,6 +358,14 @@ namespace
 
             // Then erase the entire '{@link foo}' tag from the comment.
             line.erase(pos, endpos - pos + 1);
+
+            // If the user is missing a target after '@link', emit a warning and don't attempt a lookup.
+            if (linkText.empty())
+            {
+                const string msg = "missing link target after '" + linkTag + "' tag";
+                p->unit()->warning(p->file(), p->line(), InvalidComment, msg);
+                return;
+            }
 
             // Attempt to resolve the link, and issue a warning if the link is invalid.
             SyntaxTreeBasePtr linkTarget = resolveDocLink(linkText, p);
@@ -452,7 +484,7 @@ DocCommentParser::parseDocCommentFor(const ContainedPtr& p)
         while (true)
         {
             // We check for all inline tags all at the same time, to prevent overlap.
-            // For example: `@p hello` should _only_ be a code-span, not also a param-ref.
+            // For example: 'this `@p hello` is good' should _only_ have a code-span, not also a param-ref.
             size_t nextBacktickPos = line.find('`', pos);
             size_t nextLinkPos = line.find("{@link ", pos);
             size_t nextParamrefPos = line.find("@p", pos);

--- a/cpp/src/Slice/Grammar.cpp
+++ b/cpp/src/Slice/Grammar.cpp
@@ -4067,7 +4067,7 @@ namespace
         }
         if (!interface && expectInterfaceType)
         {
-            string msg = "'" + name + "' must be an interface";
+            string msg = "'*' cannot be used with '" + name + "' as it is not an interface";
             currentUnit->error(msg);
         }
 

--- a/cpp/src/Slice/Grammar.y
+++ b/cpp/src/Slice/Grammar.y
@@ -1711,7 +1711,7 @@ namespace
         }
         if (!interface && expectInterfaceType)
         {
-            string msg = "'" + name + "' must be an interface";
+            string msg = "'*' cannot be used with '" + name + "' as it is not an interface";
             currentUnit->error(msg);
         }
 

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -865,8 +865,8 @@ Slice::cppLinkFormatter(const string& rawLink, const ContainedPtr& source, const
         }
         if (auto interfaceTarget = dynamic_pointer_cast<InterfaceDecl>(target))
         {
-            // Links to Slice interfaces should always point to the generated proxy type, not the servant type.
-            return getUnqualified(interfaceTarget->mappedScoped("::", true) + "Prx", source->mappedScope("::", true));
+            string suffix = rawLink.back() == '*' ? "Prx" : "";
+            return getUnqualified(interfaceTarget->mappedScoped("::", true) + suffix, source->mappedScope("::", true));
         }
         if (auto operationTarget = dynamic_pointer_cast<Operation>(target))
         {

--- a/cpp/src/slice2cs/IceCsUtil.cpp
+++ b/cpp/src/slice2cs/IceCsUtil.cpp
@@ -1657,10 +1657,10 @@ Slice::Csharp::iceLinkFormatter(const string& rawLink, const ContainedPtr& sourc
             result << getUnqualified(operationTarget->interface(), sourceScope, "", "Prx") << "."
                    << operationTarget->mappedName() << "Async";
         }
-        else if (auto interfaceTarget = dynamic_pointer_cast<InterfaceDecl>(target))
+        else if (dynamic_pointer_cast<InterfaceDecl>(target) && rawLink.back() == '*')
         {
             // link to the proxy interface
-            result << getUnqualified(interfaceTarget, sourceScope, "", "Prx");
+            result << getUnqualified(contained, sourceScope, "", "Prx");
         }
         else
         {

--- a/cpp/src/slice2cs/IceRpcCsUtil.cpp
+++ b/cpp/src/slice2cs/IceRpcCsUtil.cpp
@@ -572,14 +572,14 @@ Slice::Csharp::icerpcLinkFormatter(const string& rawLink, const ContainedPtr& so
         result << "cref=\"";
         if (auto operationTarget = dynamic_pointer_cast<Operation>(target))
         {
-            // link to the method on the proxy interface
+            // link to the method on the proxy interface.
             result << getUnqualified(operationTarget->interface(), sourceScope, "", "Proxy") << "."
                    << removeEscapePrefix(operationTarget->mappedName()) << "Async";
         }
-        else if (auto interfaceTarget = dynamic_pointer_cast<InterfaceDecl>(target))
+        else if (dynamic_pointer_cast<InterfaceDecl>(target) && rawLink.back() == '*')
         {
             // link to the proxy interface
-            result << getUnqualified(interfaceTarget, sourceScope, "", "Proxy");
+            result << getUnqualified(contained, sourceScope, "", "Proxy");
         }
         else
         {

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -612,8 +612,7 @@ Slice::Java::javaLinkFormatter(const string& rawLink, const ContainedPtr& source
     }
     else if (auto interfaceTarget = dynamic_pointer_cast<InterfaceDecl>(target))
     {
-        // Link to the proxy interface.
-        mappedLink = getUnqualified(interfaceTarget, sourceScope) + "Prx";
+        mappedLink = getUnqualified(interfaceTarget, sourceScope) + (rawLink.back() == '*' ? "Prx" : "");
     }
     else if (auto contained = dynamic_pointer_cast<Contained>(target))
     {

--- a/cpp/src/slice2js/JsUtil.cpp
+++ b/cpp/src/slice2js/JsUtil.cpp
@@ -516,22 +516,19 @@ Slice::JavaScript::jsLinkFormatter(const string& rawLink, const ContainedPtr&, c
         {
             if (auto operationTarget = dynamic_pointer_cast<Operation>(target))
             {
+                // link to the method on the proxy interface.
                 string targetScoped = operationTarget->interface()->mappedScoped(".");
-
-                // link to the method on the proxy interface
                 result << targetScoped << "Prx." << operationTarget->mappedName();
             }
             else
             {
                 string targetScoped = dynamic_pointer_cast<Contained>(target)->mappedScoped(".");
-                if (dynamic_pointer_cast<InterfaceDecl>(target))
+                result << targetScoped;
+
+                if (dynamic_pointer_cast<InterfaceDecl>(target) && rawLink.back() == '*')
                 {
-                    // link to the proxy interface
-                    result << targetScoped << "Prx";
-                }
-                else
-                {
-                    result << targetScoped;
+                    // link to the proxy interface.
+                    result << "Prx";
                 }
             }
         }

--- a/cpp/src/slice2matlab/Gen.cpp
+++ b/cpp/src/slice2matlab/Gen.cpp
@@ -3318,7 +3318,8 @@ Slice::matlabLinkFormatter(const string& rawLink, const ContainedPtr&, const Syn
             displayText = opTarget->mappedName();
             linkText = interfaceDef->mappedScoped(".") + "Prx" + "/" + displayText;
         }
-        else if (dynamic_pointer_cast<InterfaceDecl>(target) && rawLink.back() == '*')
+        // Don't check for trailing '*', since MATLAB _only_ generates proxy types, not servant types.
+        else if (dynamic_pointer_cast<InterfaceDecl>(target))
         {
             displayText = contained->mappedName() + "Prx";
             linkText = contained->mappedScoped(".") + "Prx";

--- a/cpp/src/slice2matlab/Gen.cpp
+++ b/cpp/src/slice2matlab/Gen.cpp
@@ -3318,7 +3318,7 @@ Slice::matlabLinkFormatter(const string& rawLink, const ContainedPtr&, const Syn
             displayText = opTarget->mappedName();
             linkText = interfaceDef->mappedScoped(".") + "Prx" + "/" + displayText;
         }
-        else if (dynamic_pointer_cast<InterfaceDecl>(target))
+        else if (dynamic_pointer_cast<InterfaceDecl>(target) && rawLink.back() == '*')
         {
             displayText = contained->mappedName() + "Prx";
             linkText = contained->mappedScoped(".") + "Prx";

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2963,11 +2963,13 @@ Slice::Python::pyLinkFormatter(const string& rawLink, const ContainedPtr&, const
         {
             string targetScoped = dynamic_pointer_cast<Contained>(target)->mappedScoped(".");
             result << ":class:`" << targetScoped;
-            if (dynamic_pointer_cast<InterfaceDecl>(target))
+
+            if (dynamic_pointer_cast<InterfaceDecl>(target) && rawLink.back() == '*')
             {
                 // link to the proxy interface
                 result << "Prx";
             }
+
             result << "`";
         }
     }

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstring>
 #include <regex>
 
 using namespace std;

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -349,7 +349,7 @@ Slice::Swift::swiftLinkFormatter(const string& rawLink, const ContainedPtr& sour
         // possible a user only declared an interface, and didn't define it, so we can't assume the `Def` exists.
         if (dynamic_pointer_cast<InterfaceDecl>(contained) && !useProxyType)
         {
-            mappedLink.erase(mappedLink.length() - 3);
+            mappedLink.erase(mappedLink.length() - strlen("Prx"));
         }
 
         // DocC does not support cross-module linking.

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -302,6 +302,7 @@ Slice::Swift::swiftLinkFormatter(const string& rawLink, const ContainedPtr& sour
     if (auto contained = dynamic_pointer_cast<Contained>(target))
     {
         string nameSuffix;
+        bool useProxyType = rawLink.back() == '*';
 
         // If the link is to a data member or an enumerator, we store its name in `nameSuffix`, then navigate up to
         // its parent. Due to the flat nature of Swift, we always need to work up to something defined in a module.
@@ -327,17 +328,12 @@ Slice::Swift::swiftLinkFormatter(const string& rawLink, const ContainedPtr& sour
             }
             nameSuffix += "context:)";
 
-            // Move up a level to the interface type.
-            // Afterwards, we are guaranteed to hit the 'interfaceDef' branch underneath this block.
-            contained = dynamic_pointer_cast<Contained>(contained->container());
+            // Move up a level to the interface-declaration type.
+            contained = operation->interface()->declaration();
             assert(contained);
-        }
 
-        // If the link involves an interface definition, we need to switch to its declaration.
-        // The code-gen considers `Def` the servant type, and `Decl` the proxy type. We want to link to the proxy.
-        if (auto interfaceDef = dynamic_pointer_cast<InterfaceDef>(contained))
-        {
-            contained = interfaceDef->declaration();
+            // We always link to methods on the proxy type, never the servant.
+            useProxyType = true;
         }
 
         const string sourceModule = Slice::Swift::getSwiftModule(source->getTopLevelModule());
@@ -347,6 +343,14 @@ Slice::Swift::swiftLinkFormatter(const string& rawLink, const ContainedPtr& sour
         // DocC uses forward slashes to separate symbols instead of periods.
         string mappedLink = Slice::Swift::getRelativeTypeString(contained, sourceModule) + nameSuffix;
         std::replace(mappedLink.begin(), mappedLink.end(), '.', '/');
+
+        // Unfortunately, we always have to get the mapped name of the proxy type, then fix it afterwards.
+        // The code-gen takes `InterfaceDecl` to mean "a proxy" and `InterfaceDef` to mean "a servant". But it's
+        // possible a user only declared an interface, and didn't define it, so we can't assume the `Def` exists.
+        if (dynamic_pointer_cast<InterfaceDecl>(contained) && !useProxyType)
+        {
+            mappedLink.erase(mappedLink.length() - 3);
+        }
 
         // DocC does not support cross-module linking.
         // So we can only generate a DocC link (using double back-ticks) if the source and target are in the same

--- a/cpp/test/Slice/errorDetection/WrongProxyType.err
+++ b/cpp/test/Slice/errorDetection/WrongProxyType.err
@@ -1,6 +1,6 @@
-WrongProxyType.ice:10: 'Seq' must be an interface
-WrongProxyType.ice:11: 'Seq' must be an interface
-WrongProxyType.ice:12: 'Seq' must be an interface
-WrongProxyType.ice:14: 'Dict' must be an interface
-WrongProxyType.ice:15: 'Dict' must be an interface
-WrongProxyType.ice:16: 'Dict' must be an interface
+WrongProxyType.ice:10: '*' cannot be used with 'Seq' as it is not an interface
+WrongProxyType.ice:11: '*' cannot be used with 'Seq' as it is not an interface
+WrongProxyType.ice:12: '*' cannot be used with 'Seq' as it is not an interface
+WrongProxyType.ice:14: '*' cannot be used with 'Dict' as it is not an interface
+WrongProxyType.ice:15: '*' cannot be used with 'Dict' as it is not an interface
+WrongProxyType.ice:16: '*' cannot be used with 'Dict' as it is not an interface

--- a/slice/Glacier2/PermissionsVerifier.ice
+++ b/slice/Glacier2/PermissionsVerifier.ice
@@ -23,7 +23,7 @@ module Glacier2
     }
 
     /// Represents an object that checks user permissions. The Glacier2 router and other services use a
-    /// {@link PermissionsVerifier} proxy when the user is authenticated using a user ID and password.
+    /// {@link PermissionsVerifier*} when the user is authenticated using a user ID and password.
     interface PermissionsVerifier
     {
         /// Checks if a user is authorized to establish a session.
@@ -39,7 +39,7 @@ module Glacier2
     }
 
     /// Represents an object that checks user permissions. The Glacier2 router and other services use an
-    /// {@link SSLPermissionsVerifier} proxy when the user is authenticated through an SSL certificate.
+    /// {@link SSLPermissionsVerifier*} when the user is authenticated through an SSL certificate.
     interface SSLPermissionsVerifier
     {
         /// Checks if a user is authorized to establish a session.


### PR DESCRIPTION
This PR just adds support for the syntax, it doesn't go through and update all the `@see` and `@link` we have.
(Except for `PermissionsVerifier` so it's at least being a little tested). Will open a follow-up PR to update the rest.
```slice
module MyModule {
    /// This will link to a `Foo`: {@link Foo}
    /// This will link to a `FooPrx`: {@link Foo*}.
    interface Foo {}
}
```
The same logic applies to `@see` tags as well.

With regards to client-only languages: we don't generate doc-comments at all for PHP and Ruby, which just leaves MATLAB.
In MATLAB, the `*` is effectively ignored. You will always get the proxy type, since there's no servant type to link to.