### PR TITLE
Update slice2cs --icerpc to not generate useTagEndMarker

### DIFF
--- a/cpp/src/slice2cs/IceRpcCsUtil.cpp
+++ b/cpp/src/slice2cs/IceRpcCsUtil.cpp
@@ -535,8 +535,6 @@ Slice::Csharp::decodeOptionalField(Output& out, int tag, const TypePtr& type, co
         out << "(" << csType(type, ns, context) << "?)";
     }
     decodeField(out, type, ns);
-    out << ",";
-    out << nl << "useTagEndMarker: " << (context == TypeContext::Field ? "true" : "false");
     out << ")";
     out.dec();
 }


### PR DESCRIPTION
This is the companion PR for https://github.com/icerpc/icerpc-csharp/pull/4351