### PR TITLE
Fix Debian packaging lintian errors

### DIFF
--- a/.github/workflows/build-deb-packages.yml
+++ b/.github/workflows/build-deb-packages.yml
@@ -34,11 +34,11 @@ jobs:
 
           - distribution: debian12
             arch: amd64
-            deb_build_profiles: "no-python312"
+            deb_build_profiles: "nopython"
 
           - distribution: debian12
             arch: arm64
-            deb_build_profiles: "no-python312"
+            deb_build_profiles: "nopython"
 
           - distribution: debian13
             arch: amd64

--- a/ICE_LICENSE
+++ b/ICE_LICENSE
@@ -12,17 +12,6 @@ details.
 You should have received a copy of the GNU General Public License version
 2 along with this program; if not, see http://www.gnu.org/licenses.
 
-Linking Ice statically or dynamically with other software (such as a
-library, module or application) is making a combined work based on Ice.
-Thus, the terms and conditions of the GNU General Public License version
-2 cover this combined work.
-
-If such software can only be used together with Ice, then not only the
-combined work but the software itself is a work derived from Ice and as
-such shall be licensed under the terms of the GNU General Public License
-version 2. This includes the situation where Ice is only being used
-through an abstraction layer.
-
 As a special exception to the above, ZeroC grants to the copyright
 holders and contributors of the Mumble project (http://www.mumble.info)
 the permission to license the Ice-based software they contribute to

--- a/packaging/common/glacier2router.service
+++ b/packaging/common/glacier2router.service
@@ -4,7 +4,7 @@
 Description=Glacier2 router daemon
 Documentation=man:glacier2router(1)
 Documentation=https://docs.zeroc.com/ice/3.8/cpp/glacier2
-After=syslog.target network.target
+After=network.target
 
 [Service]
 ExecStart=/usr/bin/glacier2router --Ice.Config=/etc/glacier2router.conf

--- a/packaging/common/icegridnode.service
+++ b/packaging/common/icegridnode.service
@@ -4,7 +4,7 @@
 Description=IceGrid node daemon
 Documentation=man:icegridnode(1)
 Documentation=https://docs.zeroc.com/ice/3.8/cpp/icegridnode
-After=syslog.target network.target icegridregistry.service
+After=network.target icegridregistry.service
 
 [Service]
 ExecStart=/usr/bin/icegridnode --Ice.Config=/etc/icegridnode.conf

--- a/packaging/common/icegridregistry.service
+++ b/packaging/common/icegridregistry.service
@@ -5,7 +5,7 @@ Description=IceGrid registry daemon
 Documentation=man:icegridregistry(1)
 Documentation=https://docs.zeroc.com/ice/3.8/cpp/icegridregistry
 Before=icegridnode.service
-After=syslog.target network.target
+After=network.target
 
 [Service]
 ExecStart=/usr/bin/icegridregistry --Ice.Config=/etc/icegridregistry.conf

--- a/packaging/deb/build-package.sh
+++ b/packaging/deb/build-package.sh
@@ -29,15 +29,23 @@ fi
 
 UPSTREAM_VERSION=$(echo $ICE_VERSION | cut -f1 -d'-')
 
-# Generate a tarball of the current repository state for the given UPSTREAM_VERSION
+# Generate a tarball of the current repository state for the given UPSTREAM_VERSION, excluding files
+# listed in Files-Excluded in debian/copyright (pre-built Java binaries and other non-essential files).
 echo "Creating tarball for UPSTREAM_VERSION=$UPSTREAM_VERSION"
 cd /workspace/ice
 git config --global --add safe.directory /workspace/ice
-git archive --format=tar.gz -o /workspace/zeroc-ice_${UPSTREAM_VERSION}.orig.tar.gz HEAD
+git archive --format=tar.gz \
+    --prefix=zeroc-ice-${UPSTREAM_VERSION}/ \
+    -o /workspace/zeroc-ice_${UPSTREAM_VERSION}.orig.tar.gz \
+    HEAD \
+    ':(exclude)*/gradle/GRADLE_LICENSE' \
+    ':(exclude)*/gradle/wrapper/*' \
+    ':(exclude)*/gradlew*' \
+    ':(exclude)cpp/src/IceUtil/ConvertUTF.*'
 
 # Unpack the source tarball
 cd /workspace/build
-tar xzf ../zeroc-ice_${UPSTREAM_VERSION}.orig.tar.gz
+tar xzf ../zeroc-ice_${UPSTREAM_VERSION}.orig.tar.gz --strip-components=1
 
 # Build the source package (-S generates .dsc and .tar.gz files)
 dpkg-buildpackage -S

--- a/packaging/deb/build-package.sh
+++ b/packaging/deb/build-package.sh
@@ -38,11 +38,12 @@ git archive --format=tar.gz \
     --prefix=zeroc-ice-${UPSTREAM_VERSION}/ \
     -o /workspace/zeroc-ice_${UPSTREAM_VERSION}.orig.tar.gz \
     HEAD \
-    ':(exclude)*/gradle/GRADLE_LICENSE' \
-    ':(exclude)*/gradle/wrapper/*' \
-    ':(exclude)*/gradlew*' \
     ':(exclude)cpp/src/IceUtil/ConvertUTF.*' \
-    ':(exclude)packaging/rpm/*'
+    ':(exclude)cpp/msbuild/*' \
+    ':(exclude)csharp/*' \
+    ':(exclude)java/*' \
+    ':(exclude)packaging/rpm/*' \
+    ':(exclude)packaging/windows-installer/*'
 
 # Unpack the source tarball
 cd /workspace/build

--- a/packaging/deb/build-package.sh
+++ b/packaging/deb/build-package.sh
@@ -41,7 +41,8 @@ git archive --format=tar.gz \
     ':(exclude)*/gradle/GRADLE_LICENSE' \
     ':(exclude)*/gradle/wrapper/*' \
     ':(exclude)*/gradlew*' \
-    ':(exclude)cpp/src/IceUtil/ConvertUTF.*'
+    ':(exclude)cpp/src/IceUtil/ConvertUTF.*' \
+    ':(exclude)packaging/rpm/*'
 
 # Unpack the source tarball
 cd /workspace/build

--- a/packaging/deb/build-package.sh
+++ b/packaging/deb/build-package.sh
@@ -42,6 +42,7 @@ git archive --format=tar.gz \
     ':(exclude)cpp/msbuild/*' \
     ':(exclude)csharp/*' \
     ':(exclude)java/*' \
+    ':(exclude)js/*' \
     ':(exclude)packaging/rpm/*' \
     ':(exclude)packaging/windows-installer/*'
 

--- a/packaging/deb/build-package.sh
+++ b/packaging/deb/build-package.sh
@@ -38,6 +38,7 @@ git archive --format=tar.gz \
     --prefix=zeroc-ice-${UPSTREAM_VERSION}/ \
     -o /workspace/zeroc-ice_${UPSTREAM_VERSION}.orig.tar.gz \
     HEAD \
+    ':(exclude)ICE_LICENSE' \
     ':(exclude)cpp/src/IceUtil/ConvertUTF.*' \
     ':(exclude)cpp/msbuild/*' \
     ':(exclude)csharp/*' \

--- a/packaging/deb/debian/BUILDING.md
+++ b/packaging/deb/debian/BUILDING.md
@@ -55,12 +55,18 @@ export UPSTREAM_VERSION=$(echo $ICE_VERSION | cut -f1 -d'-')
 
 ### 4. Create Source Archive
 
-Generate the upstream tarball from the Git repository:
+Generate the upstream tarball from the Git repository, excluding files listed in
+`Files-Excluded` in `debian/copyright`:
 
 ```bash
 cd ice
 git archive --format=tar.gz --prefix=zeroc-ice-${UPSTREAM_VERSION}/ \
-    -o $HOME/packaging/zeroc-ice/zeroc-ice_${UPSTREAM_VERSION}.orig.tar.gz HEAD
+    -o $HOME/packaging/zeroc-ice/zeroc-ice_${UPSTREAM_VERSION}.orig.tar.gz \
+    HEAD \
+    ':(exclude)*/gradle/GRADLE_LICENSE' \
+    ':(exclude)*/gradle/wrapper/*' \
+    ':(exclude)*/gradlew*' \
+    ':(exclude)cpp/src/IceUtil/ConvertUTF.*'
 ```
 
 ### 5. Extract Source
@@ -80,10 +86,11 @@ Install the required build dependencies:
 sudo mk-build-deps -ir -t 'apt-get -y' debian/control
 ```
 
-**For Debian 12:** Use the `no-python312` build profile to exclude Python 3.12 support:
+**For Debian 12:** Use the `nopython` build profile to skip building the Python package (requires Python >= 3.12,
+which Debian 12 doesn't provide):
 
 ```bash
-sudo DEB_BUILD_PROFILES="no-python312" mk-build-deps -ir -t 'apt-get -y' debian/control
+sudo DEB_BUILD_PROFILES="nopython" mk-build-deps -ir -t 'apt-get -y' debian/control
 ```
 
 ### 7. Build Packages
@@ -96,10 +103,10 @@ Build the source package (generates .dsc and .tar.gz files):
 dpkg-buildpackage -S -uc -us
 ```
 
-**For Debian 12:** Use the `no-python312` build profile:
+**For Debian 12:** Use the `nopython` build profile:
 
 ```bash
-DEB_BUILD_PROFILES="no-python312" dpkg-buildpackage -S -uc -us
+DEB_BUILD_PROFILES="nopython" dpkg-buildpackage -S -uc -us
 ```
 
 #### Binary Packages
@@ -110,10 +117,10 @@ Build the binary packages:
 dpkg-buildpackage -b -uc -us
 ```
 
-**For Debian 12:** Use the `no-python312` build profile:
+**For Debian 12:** Use the `nopython` build profile:
 
 ```bash
-DEB_BUILD_PROFILES="no-python312" dpkg-buildpackage -b -uc -us
+DEB_BUILD_PROFILES="nopython" dpkg-buildpackage -b -uc -us
 ```
 
 The built packages will be available in the parent directory (`$HOME/packaging/zeroc-ice/`):

--- a/packaging/deb/debian/BUILDING.md
+++ b/packaging/deb/debian/BUILDING.md
@@ -67,6 +67,7 @@ git archive --format=tar.gz --prefix=zeroc-ice-${UPSTREAM_VERSION}/ \
     ':(exclude)cpp/msbuild/*' \
     ':(exclude)csharp/*' \
     ':(exclude)java/*' \
+    ':(exclude)js/*' \
     ':(exclude)packaging/rpm/*' \
     ':(exclude)packaging/windows-installer/*'
 ```

--- a/packaging/deb/debian/BUILDING.md
+++ b/packaging/deb/debian/BUILDING.md
@@ -63,11 +63,12 @@ cd ice
 git archive --format=tar.gz --prefix=zeroc-ice-${UPSTREAM_VERSION}/ \
     -o $HOME/packaging/zeroc-ice/zeroc-ice_${UPSTREAM_VERSION}.orig.tar.gz \
     HEAD \
-    ':(exclude)*/gradle/GRADLE_LICENSE' \
-    ':(exclude)*/gradle/wrapper/*' \
-    ':(exclude)*/gradlew*' \
     ':(exclude)cpp/src/IceUtil/ConvertUTF.*' \
-    ':(exclude)packaging/rpm/*'
+    ':(exclude)cpp/msbuild/*' \
+    ':(exclude)csharp/*' \
+    ':(exclude)java/*' \
+    ':(exclude)packaging/rpm/*' \
+    ':(exclude)packaging/windows-installer/*'
 ```
 
 ### 5. Extract Source

--- a/packaging/deb/debian/BUILDING.md
+++ b/packaging/deb/debian/BUILDING.md
@@ -63,6 +63,7 @@ cd ice
 git archive --format=tar.gz --prefix=zeroc-ice-${UPSTREAM_VERSION}/ \
     -o $HOME/packaging/zeroc-ice/zeroc-ice_${UPSTREAM_VERSION}.orig.tar.gz \
     HEAD \
+    ':(exclude)ICE_LICENSE' \
     ':(exclude)cpp/src/IceUtil/ConvertUTF.*' \
     ':(exclude)cpp/msbuild/*' \
     ':(exclude)csharp/*' \

--- a/packaging/deb/debian/BUILDING.md
+++ b/packaging/deb/debian/BUILDING.md
@@ -66,7 +66,8 @@ git archive --format=tar.gz --prefix=zeroc-ice-${UPSTREAM_VERSION}/ \
     ':(exclude)*/gradle/GRADLE_LICENSE' \
     ':(exclude)*/gradle/wrapper/*' \
     ':(exclude)*/gradlew*' \
-    ':(exclude)cpp/src/IceUtil/ConvertUTF.*'
+    ':(exclude)cpp/src/IceUtil/ConvertUTF.*' \
+    ':(exclude)packaging/rpm/*'
 ```
 
 ### 5. Extract Source

--- a/packaging/deb/debian/README
+++ b/packaging/deb/debian/README
@@ -13,7 +13,6 @@ php-zeroc-ice            Ice for PHP
 python3-zeroc-ice        Ice for Python [1]
 zeroc-dsnode             DataStorm server
 zeroc-glacier2           Glacier2 service
-zeroc-ice-ice2slice      The Ice to Slice compiler
 zeroc-ice-slice          Slice definition files
 zeroc-ice-utils          Admin utilities for Ice services
 zeroc-icebox             IceBox server for C++

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -2,7 +2,7 @@ zeroc-ice (3.8.1-1) unstable; urgency=medium
 
   * New upstream version 3.8.1
 
- -- José Gutiérrez de la Concha <jose@zeroc.com>  Thu, 26 Feb 2026 12:00:00 +0100
+ -- José Gutiérrez de la Concha <jose@zeroc.com>  Mon, 30 Mar 2026 12:00:00 +0200
 
 zeroc-ice (3.8.0-1) unstable; urgency=medium
 

--- a/packaging/deb/debian/control
+++ b/packaging/deb/debian/control
@@ -1,5 +1,6 @@
 Source: zeroc-ice
 Section: devel
+Priority: optional
 Maintainer: José Gutiérrez de la Concha <jose@zeroc.com>
 Uploaders: Ondřej Surý <ondrej@debian.org>
 Build-Depends: debhelper,
@@ -26,6 +27,7 @@ Build-Depends: debhelper,
                python3-setuptools,
                python3-passlib
 Standards-Version: 4.7.3
+Rules-Requires-Root: no
 Homepage: https://zeroc.com
 Vcs-Git: https://github.com/zeroc-ice/ice.git
 Vcs-Browser: https://github.com/zeroc-ice/ice
@@ -138,7 +140,6 @@ Description: Glacier2 router
 
 Package: zeroc-ice-slice
 Architecture: all
-Section: devel
 Depends: ${misc:Depends}
 Description: Slice files for Ice
  This package contains Slice files used by the Ice framework.

--- a/packaging/deb/debian/control
+++ b/packaging/deb/debian/control
@@ -1,6 +1,5 @@
 Source: zeroc-ice
 Section: devel
-Priority: optional
 Maintainer: José Gutiérrez de la Concha <jose@zeroc.com>
 Uploaders: Ondřej Surý <ondrej@debian.org>
 Build-Depends: debhelper,
@@ -8,10 +7,10 @@ Build-Depends: debhelper,
                dh-exec,
                dh-php (>= 0.20),
                dh-python,
-               libbluetooth-dev [!hurd-i386 !kfreebsd-i386 !kfreebsd-amd64],
+               libbluetooth-dev [!hurd-i386],
                libbz2-dev,
                libcrypt-dev,
-               libdbus-1-dev [!hurd-i386 !kfreebsd-i386 !kfreebsd-amd64],
+               libdbus-1-dev [!hurd-i386],
                libedit-dev,
                libexpat1-dev,
                liblmdb-dev,
@@ -22,11 +21,11 @@ Build-Depends: debhelper,
                openssl,
                php-all-dev,
                php-cli,
-               python3 (>= 3.12) <!no-python312>,
-               python3-dev (>= 3.12) <!no-python312>,
+               python3 (>= 3.12) <!nopython>,
+               python3-dev (>= 3.12) <!nopython>,
                python3-setuptools,
                python3-passlib
-Standards-Version: 4.7.2
+Standards-Version: 4.7.3
 Homepage: https://zeroc.com
 Vcs-Git: https://github.com/zeroc-ice/ice.git
 Vcs-Browser: https://github.com/zeroc-ice/ice
@@ -35,7 +34,7 @@ Package: libzeroc-ice-dev
 Architecture: any
 Section: libdevel
 Depends: libzeroc-ice3.8 (= ${binary:Version}),
-         zeroc-ice-slice (= ${binary:Version}),
+         zeroc-ice-slice (= ${source:Version}),
          libssl-dev,
          ${misc:Depends}
 Description: libraries and headers for developing Ice applications in C++
@@ -89,7 +88,7 @@ Package: php-zeroc-ice
 Architecture: any
 Section: php
 Depends: libzeroc-ice3.8 (= ${binary:Version}),
-         zeroc-ice-slice (= ${binary:Version}),
+         zeroc-ice-slice (= ${source:Version}),
          ${misc:Depends},
          ${php:Depends},
          ${shlibs:Depends}
@@ -103,11 +102,11 @@ Description: PHP extension for Ice
  your application logic.
 
 Package: python3-zeroc-ice
-Build-Profiles: <!no-python312>
+Build-Profiles: <!nopython>
 Architecture: any
 Section: python
 Depends: libzeroc-ice3.8 (= ${binary:Version}),
-         zeroc-ice-slice (= ${binary:Version}),
+         zeroc-ice-slice (= ${source:Version}),
          ${misc:Depends},
          ${python3:Depends},
          ${shlibs:Depends}
@@ -131,24 +130,6 @@ Description: Glacier2 router
  and a private network behind a firewall. With Glacier2, you only need to open
  one port in your firewall to make multiple back-end Ice servers reachable by
  remote Ice clients on the Internet.
- .
- Ice is a comprehensive RPC framework that helps you network your software
- with minimal effort. Ice takes care of all interactions with low-level
- network programming interfaces and allows you to focus your efforts on
- your application logic.
-
-Package: zeroc-ice-ice2slice
-Architecture: any
-Section: devel
-Depends: zeroc-ice-slice (= ${binary:Version}),
-         ${misc:Depends}
-Description: Ice to Slice compiler
- This package provides the ice2slice compiler. It converts Slice definitions
- written in ".ice" files into Slice definitions in ".slice" files.
- .
- The ".ice" format is the syntax understood by the Slice compilers included
- with Ice. The ".slice" format is the syntax understood by slicec, the Slice
- compiler provided by IceRPC
  .
  Ice is a comprehensive RPC framework that helps you network your software
  with minimal effort. Ice takes care of all interactions with low-level
@@ -250,19 +231,17 @@ Description: IceBridge service
 Package: zeroc-ice-compilers
 Architecture: all
 Section: oldlibs
-Priority: optional
-Depends: libzeroc-ice-dev (= ${binary:Version}),
-        python3-zeroc-ice (= ${binary:Version}) <!no-python312>,
-        php-zeroc-ice (= ${binary:Version}),
+Depends: libzeroc-ice-dev (>= ${source:Version}),
+        python3-zeroc-ice (>= ${source:Version}) <!nopython>,
+        php-zeroc-ice (>= ${source:Version}),
         ${misc:Depends}
-Description: transitional dummy package for Ice 3.7 all-dev metapackage
+Description: transitional dummy package for Ice 3.7 compilers metapackage
  This empty package ensures a smooth upgrade from Ice 3.7 by replacing
  the obsolete zeroc-ice-compilers. It can be safely removed.
 
 Package: zeroc-ice-all-dev
 Architecture: all
 Section: oldlibs
-Priority: optional
 Depends: ${misc:Depends}
 Description: transitional dummy package for Ice 3.7 all-dev metapackage
  This empty package ensures a smooth upgrade from Ice 3.7 by replacing
@@ -271,7 +250,6 @@ Description: transitional dummy package for Ice 3.7 all-dev metapackage
 Package: zeroc-ice-all-runtime
 Architecture: all
 Section: oldlibs
-Priority: optional
 Depends: ${misc:Depends}
 Description: transitional dummy package for Ice 3.7 all-runtime metapackage
  This empty package ensures a smooth upgrade from Ice 3.7 by replacing

--- a/packaging/deb/debian/copyright
+++ b/packaging/deb/debian/copyright
@@ -2,6 +2,8 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: ZeroC Ice
 Upstream-Contact: ZeroC Info <info@zeroc.com>
 Source: https://github.com/zeroc-ice/
+Comment: Repackaged to remove pre-built Java binaries (gradle-wrapper.jar) and
+ files not needed for the Debian build.
 Files-Excluded: */gradle/GRADLE_LICENSE */gradle/wrapper */gradlew* cpp/src/IceUtil/ConvertUTF.*
 
 Files: *
@@ -13,7 +15,7 @@ Copyright: 2003-2026 ZeroC, Inc.
            2016 Ondřej Surý
 License: GPL-2.0+exceptions
 
-Files: java/src/IceGridGUI/src/main/java/IceGridGUI/SimpleInternalFrame.java
+Files: java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SimpleInternalFrame.java
 Copyright: 2000-2005 JGoodies Karsten Lentzsch.
 License: BSD-3-clause
 

--- a/packaging/deb/debian/copyright
+++ b/packaging/deb/debian/copyright
@@ -3,7 +3,7 @@ Upstream-Name: ZeroC Ice
 Upstream-Contact: ZeroC Info <info@zeroc.com>
 Source: https://github.com/zeroc-ice/
 Comment: Repackaged to remove files not needed for the Debian build.
-Files-Excluded: cpp/src/IceUtil/ConvertUTF.* cpp/msbuild/* csharp/* java/* js/* packaging/rpm/* packaging/windows-installer/*
+Files-Excluded: ICE_LICENSE cpp/src/IceUtil/ConvertUTF.* cpp/msbuild/* csharp/* java/* js/* packaging/rpm/* packaging/windows-installer/*
 
 Files: *
 Copyright: 2003-2026 ZeroC, Inc.
@@ -59,17 +59,6 @@ License: GPL-2.0+exceptions
  .
  On Debian systems, the complete text of the GNU General Public
  License version 2 can be found in "/usr/share/common-licenses/GPL-2".
- .
- Linking Ice statically or dynamically with other software (such as a
- library, module or application) is making a combined work based on Ice.
- Thus, the terms and conditions of the GNU General Public License version
- 2 cover this combined work.
- .
- If such software can only be used together with Ice, then not only the
- combined work but the software itself is a work derived from Ice and as
- such shall be licensed under the terms of the GNU General Public License
- version 2. This includes the situation where Ice is only being used
- through an abstraction layer.
  .
  As a special exception to the above, ZeroC grants to the copyright
  holders and contributors of the Mumble project (http://www.mumble.info)

--- a/packaging/deb/debian/copyright
+++ b/packaging/deb/debian/copyright
@@ -4,7 +4,7 @@ Upstream-Contact: ZeroC Info <info@zeroc.com>
 Source: https://github.com/zeroc-ice/
 Comment: Repackaged to remove pre-built Java binaries (gradle-wrapper.jar) and
  files not needed for the Debian build.
-Files-Excluded: */gradle/GRADLE_LICENSE */gradle/wrapper */gradlew* cpp/src/IceUtil/ConvertUTF.*
+Files-Excluded: */gradle/GRADLE_LICENSE */gradle/wrapper */gradlew* cpp/src/IceUtil/ConvertUTF.* packaging/rpm/*
 
 Files: *
 Copyright: 2003-2026 ZeroC, Inc.
@@ -18,6 +18,49 @@ License: GPL-2.0+exceptions
 Files: java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SimpleInternalFrame.java
 Copyright: 2000-2005 JGoodies Karsten Lentzsch.
 License: BSD-3-clause
+
+Files: cpp/src/*/Grammar.cpp
+Copyright: 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation, Inc.
+License: GPL-3+-with-Bison-2.2-exception
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public License
+ version 3 can be found in "/usr/share/common-licenses/GPL-3".
+ .
+ As a special exception, you may create a larger work that contains
+ part or all of the Bison parser skeleton and distribute that work
+ under terms of your choice, so long as that work isn't itself a
+ parser generator using the skeleton or a modified version thereof
+ as a parser skeleton.  Alternatively, if you modify or redistribute
+ the parser skeleton itself, you may (at your option) remove this
+ special exception, which will cause the skeleton and the resulting
+ Bison output files to be licensed under the GNU General Public
+ License without this special exception.
+
+Files: csharp/docfx/template/public/main.css
+Copyright: Microsoft Corporation
+License: Expat
+
+Files: cpp/msbuild/THIRD_PARTY_LICENSE.txt
+       csharp/msbuild/THIRD_PARTY_LICENSE.txt
+       packaging/windows-installer/docs/THIRD_PARTY_LICENSE.txt
+Copyright: 1996-2010 Julian R Seward
+           1998-2000 Thai Open Source Software Center Ltd and Clark Cooper
+           2001-2017 Expat maintainers
+           1998, 2002-2008 Kiyoshi Matsui
+           1999-2003 The OpenLDAP Foundation
+           2011-2019 Howard Chu, Symas Corp.
+License: bzip2-1.0.6 and Expat and BSD-2-clause and OLDAP-2.8
+Comment: These files document the licenses of third-party libraries that may
+ be statically linked into Ice binaries.
 
 Files: cpp/test/IceUtil/unicode/*.utf*
 Copyright: Authors of cœur page on Wikipedia.fr as of May 25, 2016.
@@ -423,3 +466,116 @@ License: CC-BY-SA-3.0
     not granted under this License, such additional rights are deemed to be
     included in the License; this License is not intended to restrict the
     license of any rights under applicable law.
+
+License: Expat
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+License: BSD-2-clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ .
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ .
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+License: OLDAP-2.8
+ Redistribution and use of this software and associated documentation
+ ("Software"), with or without modification, are permitted provided
+ that the following conditions are met:
+ .
+ 1. Redistributions in source form must retain copyright statements
+    and notices,
+ .
+ 2. Redistributions in binary form must reproduce applicable copyright
+    statements and notices, this list of conditions, and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution, and
+ .
+ 3. Redistributions must contain a verbatim copy of this document.
+ .
+ The OpenLDAP Foundation may revise this license from time to time.
+ Each revision is distinguished by a version number.  You may use
+ this Software under terms of this license revision or under the
+ terms of any subsequent revision of the license.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE OPENLDAP FOUNDATION AND ITS
+ CONTRIBUTORS "AS IS" AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT
+ SHALL THE OPENLDAP FOUNDATION, ITS CONTRIBUTORS, OR THE AUTHOR(S)
+ OR OWNER(S) OF THE SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ .
+ The names of the authors and copyright holders must not be used in
+ advertising or otherwise to promote the sale, use or other dealing
+ in this Software without specific, written prior permission.  Title
+ to copyright in this Software shall at all times remain with copyright
+ holders.
+
+License: bzip2-1.0.6
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ .
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ .
+ 2. The origin of this software must not be misrepresented; you must
+    not claim that you wrote the original software.  If you use this
+    software in a product, an acknowledgment in the product
+    documentation would be appreciated but is not required.
+ .
+ 3. Altered source versions must be plainly marked as such, and must
+    not be misrepresented as being the original software.
+ .
+ 4. The name of the author may not be used to endorse or promote
+    products derived from this software without specific prior written
+    permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS
+ OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packaging/deb/debian/copyright
+++ b/packaging/deb/debian/copyright
@@ -2,9 +2,8 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: ZeroC Ice
 Upstream-Contact: ZeroC Info <info@zeroc.com>
 Source: https://github.com/zeroc-ice/
-Comment: Repackaged to remove pre-built Java binaries (gradle-wrapper.jar) and
- files not needed for the Debian build.
-Files-Excluded: */gradle/GRADLE_LICENSE */gradle/wrapper */gradlew* cpp/src/IceUtil/ConvertUTF.* packaging/rpm/*
+Comment: Repackaged to remove files not needed for the Debian build.
+Files-Excluded: cpp/src/IceUtil/ConvertUTF.* cpp/msbuild/* csharp/* java/* packaging/rpm/* packaging/windows-installer/*
 
 Files: *
 Copyright: 2003-2026 ZeroC, Inc.
@@ -14,10 +13,6 @@ Files: debian/*
 Copyright: 2003-2026 ZeroC, Inc.
            2016 Ondřej Surý
 License: GPL-2.0+exceptions
-
-Files: java/src/IceGridGUI/src/main/java/com/zeroc/IceGridGUI/SimpleInternalFrame.java
-Copyright: 2000-2005 JGoodies Karsten Lentzsch.
-License: BSD-3-clause
 
 Files: cpp/src/*/Grammar.cpp
 Copyright: 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation, Inc.
@@ -44,23 +39,6 @@ License: GPL-3+-with-Bison-2.2-exception
  special exception, which will cause the skeleton and the resulting
  Bison output files to be licensed under the GNU General Public
  License without this special exception.
-
-Files: csharp/docfx/template/public/main.css
-Copyright: Microsoft Corporation
-License: Expat
-
-Files: cpp/msbuild/THIRD_PARTY_LICENSE.txt
-       csharp/msbuild/THIRD_PARTY_LICENSE.txt
-       packaging/windows-installer/docs/THIRD_PARTY_LICENSE.txt
-Copyright: 1996-2010 Julian R Seward
-           1998-2000 Thai Open Source Software Center Ltd and Clark Cooper
-           2001-2017 Expat maintainers
-           1998, 2002-2008 Kiyoshi Matsui
-           1999-2003 The OpenLDAP Foundation
-           2011-2019 Howard Chu, Symas Corp.
-License: bzip2-1.0.6 and Expat and BSD-2-clause and OLDAP-2.8
-Comment: These files document the licenses of third-party libraries that may
- be statically linked into Ice binaries.
 
 Files: cpp/test/IceUtil/unicode/*.utf*
 Copyright: Authors of cœur page on Wikipedia.fr as of May 25, 2016.
@@ -116,34 +94,6 @@ License: GPL-2.0+exceptions
  If you modify this copy of Ice, you may extend any of the exceptions
  provided above to your version of Ice, but you are not obligated to
  so
-
-License: BSD-3-clause
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
- .
- 1. Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
- .
- 2. Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in
-    the documentation and/or other materials provided with the
-    distribution.
- .
- 3. Neither the name of the copyright holder nor the names of its
-    contributors may be used to endorse or promote products derived
-    from this software without specific prior written permission.
- .
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
- CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
- OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 License: CC-BY-SA-3.0
  CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL
@@ -466,116 +416,3 @@ License: CC-BY-SA-3.0
     not granted under this License, such additional rights are deemed to be
     included in the License; this License is not intended to restrict the
     license of any rights under applicable law.
-
-License: Expat
- Permission is hereby granted, free of charge, to any person obtaining
- a copy of this software and associated documentation files (the
- "Software"), to deal in the Software without restriction, including
- without limitation the rights to use, copy, modify, merge, publish,
- distribute, sublicense, and/or sell copies of the Software, and to
- permit persons to whom the Software is furnished to do so, subject to
- the following conditions:
- .
- The above copyright notice and this permission notice shall be included
- in all copies or substantial portions of the Software.
- .
- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
- CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
- TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
- SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-License: BSD-2-clause
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
- .
- 1. Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
- .
- 2. Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
- .
- THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR
- IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
- INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-License: OLDAP-2.8
- Redistribution and use of this software and associated documentation
- ("Software"), with or without modification, are permitted provided
- that the following conditions are met:
- .
- 1. Redistributions in source form must retain copyright statements
-    and notices,
- .
- 2. Redistributions in binary form must reproduce applicable copyright
-    statements and notices, this list of conditions, and the following
-    disclaimer in the documentation and/or other materials provided
-    with the distribution, and
- .
- 3. Redistributions must contain a verbatim copy of this document.
- .
- The OpenLDAP Foundation may revise this license from time to time.
- Each revision is distinguished by a version number.  You may use
- this Software under terms of this license revision or under the
- terms of any subsequent revision of the license.
- .
- THIS SOFTWARE IS PROVIDED BY THE OPENLDAP FOUNDATION AND ITS
- CONTRIBUTORS "AS IS" AND ANY EXPRESSED OR IMPLIED WARRANTIES,
- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
- AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT
- SHALL THE OPENLDAP FOUNDATION, ITS CONTRIBUTORS, OR THE AUTHOR(S)
- OR OWNER(S) OF THE SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
- INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- POSSIBILITY OF SUCH DAMAGE.
- .
- The names of the authors and copyright holders must not be used in
- advertising or otherwise to promote the sale, use or other dealing
- in this Software without specific, written prior permission.  Title
- to copyright in this Software shall at all times remain with copyright
- holders.
-
-License: bzip2-1.0.6
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
- .
- 1. Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
- .
- 2. The origin of this software must not be misrepresented; you must
-    not claim that you wrote the original software.  If you use this
-    software in a product, an acknowledgment in the product
-    documentation would be appreciated but is not required.
- .
- 3. Altered source versions must be plainly marked as such, and must
-    not be misrepresented as being the original software.
- .
- 4. The name of the author may not be used to endorse or promote
-    products derived from this software without specific prior written
-    permission.
- .
- THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS
- OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
- GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
- NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packaging/deb/debian/copyright
+++ b/packaging/deb/debian/copyright
@@ -3,7 +3,7 @@ Upstream-Name: ZeroC Ice
 Upstream-Contact: ZeroC Info <info@zeroc.com>
 Source: https://github.com/zeroc-ice/
 Comment: Repackaged to remove files not needed for the Debian build.
-Files-Excluded: cpp/src/IceUtil/ConvertUTF.* cpp/msbuild/* csharp/* java/* packaging/rpm/* packaging/windows-installer/*
+Files-Excluded: cpp/src/IceUtil/ConvertUTF.* cpp/msbuild/* csharp/* java/* js/* packaging/rpm/* packaging/windows-installer/*
 
 Files: *
 Copyright: 2003-2026 ZeroC, Inc.
@@ -14,7 +14,7 @@ Copyright: 2003-2026 ZeroC, Inc.
            2016 Ondřej Surý
 License: GPL-2.0+exceptions
 
-Files: cpp/src/*/Grammar.cpp
+Files: cpp/src/*/Grammar.cpp cpp/src/*/Grammar.h
 Copyright: 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation, Inc.
 License: GPL-3+-with-Bison-2.2-exception
  This program is free software: you can redistribute it and/or modify
@@ -40,7 +40,7 @@ License: GPL-3+-with-Bison-2.2-exception
  Bison output files to be licensed under the GNU General Public
  License without this special exception.
 
-Files: cpp/test/IceUtil/unicode/*.utf*
+Files: cpp/test/IceUtil/unicode/*
 Copyright: Authors of cœur page on Wikipedia.fr as of May 25, 2016.
 License: CC-BY-SA-3.0
 

--- a/packaging/deb/debian/gbp.conf
+++ b/packaging/deb/debian/gbp.conf
@@ -1,4 +1,0 @@
-[DEFAULT]
-debian-branch = main
-upstream-branch = upstream
-pristine-tar = True

--- a/packaging/deb/debian/libzeroc-ice-dev.lintian-overrides
+++ b/packaging/deb/debian/libzeroc-ice-dev.lintian-overrides
@@ -1,2 +1,2 @@
 # slice2cpp is statically linked with mcpp
-libzeroc-ice-dev: statically-linked-binary usr/bin/slice2cpp
+libzeroc-ice-dev: statically-linked-binary

--- a/packaging/deb/debian/libzeroc-ice3.8.lintian-overrides
+++ b/packaging/deb/debian/libzeroc-ice3.8.lintian-overrides
@@ -1,2 +1,2 @@
 # Package bundles multiple Ice libraries with different sonames
-libzeroc-ice3.8: package-name-doesnt-match-sonames libDataStorm3.8 libGlacier23.8 libIce3.8 libIceBT3.8 libIceBox3.8 libIceDiscovery3.8 libIceGrid3.8 libIceLocatorDiscovery3.8 libIceStorm3.8
+libzeroc-ice3.8: package-name-doesnt-match-sonames

--- a/packaging/deb/debian/patches/fix-manpage-typos.patch
+++ b/packaging/deb/debian/patches/fix-manpage-typos.patch
@@ -7,18 +7,22 @@ Last-Update: 2026-04-01
 --- a/man/man1/icegriddb.1
 +++ b/man/man1/icegriddb.1
 @@ -31,7 +31,7 @@
+ .TP
  .BR \-\-import " " FILE\fR
  .br
 -Import database from the specifed file.
 +Import database from the specified file.
 
  .TP
+ .BR \-\-export " " FILE\fR
 --- a/man/man1/icestormdb.1
 +++ b/man/man1/icestormdb.1
 @@ -36,7 +36,7 @@
+ .TP
  .BR \-\-import " " FILE\fR
  .br
 -Import database from the specifed file.
 +Import database from the specified file.
 
  .TP
+ .BR \-\-export " " FILE\fR

--- a/packaging/deb/debian/patches/fix-manpage-typos.patch
+++ b/packaging/deb/debian/patches/fix-manpage-typos.patch
@@ -13,7 +13,7 @@ Last-Update: 2026-04-01
 +Import database from the specified file.
 
  .TP
- --- a/man/man1/icestormdb.1
+--- a/man/man1/icestormdb.1
 +++ b/man/man1/icestormdb.1
 @@ -36,7 +36,7 @@
  .BR \-\-import " " FILE\fR

--- a/packaging/deb/debian/patches/fix-manpage-typos.patch
+++ b/packaging/deb/debian/patches/fix-manpage-typos.patch
@@ -1,0 +1,24 @@
+Description: Fix typo in icegriddb and icestormdb man pages
+ Fix "specifed" -> "specified" in the --import option description.
+Author: José Gutiérrez de la Concha <jose@zeroc.com>
+Origin: upstream, https://github.com/zeroc-ice/ice/commit/88dd46cc27fbab5d0d7cda4ae0b9bf4258ba085e
+Last-Update: 2026-04-01
+---
+--- a/man/man1/icegriddb.1
++++ b/man/man1/icegriddb.1
+@@ -31,7 +31,7 @@
+ .BR \-\-import " " FILE\fR
+ .br
+-Import database from the specifed file.
++Import database from the specified file.
+
+ .TP
+ --- a/man/man1/icestormdb.1
++++ b/man/man1/icestormdb.1
+@@ -36,7 +36,7 @@
+ .BR \-\-import " " FILE\fR
+ .br
+-Import database from the specifed file.
++Import database from the specified file.
+
+ .TP

--- a/packaging/deb/debian/patches/remove-ice2slice.patch
+++ b/packaging/deb/debian/patches/remove-ice2slice.patch
@@ -3,6 +3,7 @@ Description: Remove ice2slice from the build
  excludes it from the build so the zeroc-ice-ice2slice package can be
  dropped.
 Author: José Gutiérrez de la Concha <jose@zeroc.com>
+Origin: upstream, https://github.com/zeroc-ice/ice/commit/620380d9566ae9f20d0ef9010617107a5dbbb5cf
 Last-Update: 2026-03-30
 ---
 --- a/cpp/Makefile

--- a/packaging/deb/debian/patches/remove-ice2slice.patch
+++ b/packaging/deb/debian/patches/remove-ice2slice.patch
@@ -1,0 +1,20 @@
+Description: Remove ice2slice from the build
+ The ice2slice tool was removed upstream in commit 620380d9. This patch
+ excludes it from the build so the zeroc-ice-ice2slice package can be
+ dropped.
+Author: José Gutiérrez de la Concha <jose@zeroc.com>
+Last-Update: 2026-03-30
+---
+--- a/cpp/Makefile
++++ b/cpp/Makefile
+@@ -20,8 +20,8 @@
+
+ projects :=
+
+-# Create projects for all the Slice translators from src/slice2* and src/ice2slice.
+-slice_translators := $(wildcard $(lang_srcdir)/src/slice2*) $(lang_srcdir)/src/ice2slice
++# Create projects for all the Slice translators from src/slice2*.
++slice_translators := $(wildcard $(lang_srcdir)/src/slice2*)
+ $(foreach t, $(slice_translators), $(eval $(call create-translator-project,$(call project,$t))))
+
+ # Do not install Slice compilers that are not distributed via the OS packaging system.

--- a/packaging/deb/debian/patches/series
+++ b/packaging/deb/debian/patches/series
@@ -1,0 +1,1 @@
+remove-ice2slice.patch

--- a/packaging/deb/debian/patches/series
+++ b/packaging/deb/debian/patches/series
@@ -1,1 +1,2 @@
 remove-ice2slice.patch
+fix-manpage-typos.patch

--- a/packaging/deb/debian/php-zeroc-ice.lintian-overrides
+++ b/packaging/deb/debian/php-zeroc-ice.lintian-overrides
@@ -1,2 +1,2 @@
 # PHP extension module is statically linked with mcpp
-php-zeroc-ice: statically-linked-binary usr/lib/php/*/ice.so
+php-zeroc-ice: statically-linked-binary

--- a/packaging/deb/debian/python3-zeroc-ice.lintian-overrides
+++ b/packaging/deb/debian/python3-zeroc-ice.lintian-overrides
@@ -1,2 +1,2 @@
 # Python extension modules are statically linked with mcpp
-python3-zeroc-ice: statically-linked-binary usr/lib/python3/dist-packages/IcePy.*.so
+python3-zeroc-ice: statically-linked-binary

--- a/packaging/deb/debian/rules
+++ b/packaging/deb/debian/rules
@@ -113,10 +113,10 @@ override_dh_install:
 	install -m 0644 packaging/common/icegridregistry.conf $(DESTDIR)/etc/icegridregistry.conf
 
 	# Install service files from common directory
-	install -d -m 0755 $(DESTDIR)/lib/systemd/system
-	install -m 0644 packaging/common/glacier2router.service $(DESTDIR)/lib/systemd/system/glacier2router.service
-	install -m 0644 packaging/common/icegridnode.service $(DESTDIR)/lib/systemd/system/icegridnode.service
-	install -m 0644 packaging/common/icegridregistry.service $(DESTDIR)/lib/systemd/system/icegridregistry.service
+	install -d -m 0755 $(DESTDIR)/usr/lib/systemd/system
+	install -m 0644 packaging/common/glacier2router.service $(DESTDIR)/usr/lib/systemd/system/glacier2router.service
+	install -m 0644 packaging/common/icegridnode.service $(DESTDIR)/usr/lib/systemd/system/icegridnode.service
+	install -m 0644 packaging/common/icegridregistry.service $(DESTDIR)/usr/lib/systemd/system/icegridregistry.service
 
 	dh_install
 

--- a/packaging/deb/debian/rules
+++ b/packaging/deb/debian/rules
@@ -39,7 +39,7 @@ endif
 
 DHARGS	= --parallel --with php
 
-ifeq (,$(filter no-python312,$(DEB_BUILD_PROFILES)))
+ifeq (,$(filter nopython,$(DEB_BUILD_PROFILES)))
 	DHARGS += --with python3
 endif
 
@@ -50,7 +50,7 @@ MAKEOPTS = V=1 prefix=/usr DESTDIR=$(DESTDIR)
 
 override_dh_auto_build-arch:
 	$(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) LANGUAGES="cpp" CONFIGS="shared static" srcs
-ifeq (,$(filter no-python312,$(DEB_BUILD_PROFILES)))
+ifeq (,$(filter nopython,$(DEB_BUILD_PROFILES)))
 	$(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) PYTHON=python3 LANGUAGES="python" srcs
 endif
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
@@ -66,7 +66,7 @@ override_dh_auto_build-indep:
 
 override_dh_auto_install-arch:
 	$(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) LANGUAGES="cpp" CONFIGS="shared static" install
-ifeq (,$(filter no-python312,$(DEB_BUILD_PROFILES)))
+ifeq (,$(filter nopython,$(DEB_BUILD_PROFILES)))
 	$(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) PYTHON=python3 LANGUAGES="python" install
 endif
 	for v in $(PHP_VERSIONS); do \
@@ -78,7 +78,7 @@ override_dh_auto_install-indep:
 
 override_dh_auto_clean-arch:
 	$(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) LANGUAGES="cpp" CONFIGS="shared static" distclean
-ifeq (,$(filter no-python312,$(DEB_BUILD_PROFILES)))
+ifeq (,$(filter nopython,$(DEB_BUILD_PROFILES)))
 	$(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) PYTHON=python3 LANGUAGES="python" distclean
 endif
 	for v in $(PHP_VERSIONS); do \

--- a/packaging/deb/debian/watch
+++ b/packaging/deb/debian/watch
@@ -1,3 +1,3 @@
-version=4
+version=5
 opts="dversionmangle=s/\+dfsg\d*$// ,repacksuffix=+dfsg1"
 https://github.com/zeroc-ice/ice/tags /zeroc-ice/ice/archive/refs/tags/v([0-9]+)\.([0-9]+)\.([0-9]+)\.tar\.gz

--- a/packaging/deb/debian/watch
+++ b/packaging/deb/debian/watch
@@ -1,3 +1,0 @@
-version=5
-opts="dversionmangle=s/\+dfsg\d*$// ,repacksuffix=+dfsg1"
-https://github.com/zeroc-ice/ice/tags /zeroc-ice/ice/archive/refs/tags/v([0-9]+)\.([0-9]+)\.([0-9]+)\.tar\.gz

--- a/packaging/deb/debian/zeroc-glacier2.install
+++ b/packaging/deb/debian/zeroc-glacier2.install
@@ -1,4 +1,4 @@
 etc/glacier2router.conf
-lib/systemd/system/glacier2router.service
+usr/lib/systemd/system/glacier2router.service
 usr/bin/glacier2router
 usr/share/man/man1/glacier2router.1

--- a/packaging/deb/debian/zeroc-ice-ice2slice.install
+++ b/packaging/deb/debian/zeroc-ice-ice2slice.install
@@ -1,2 +1,0 @@
-usr/bin/ice2slice
-usr/share/man/man1/ice2slice.1

--- a/packaging/deb/debian/zeroc-ice-ice2slice.lintian-overrides
+++ b/packaging/deb/debian/zeroc-ice-ice2slice.lintian-overrides
@@ -1,2 +1,0 @@
-# ice2slice is statically linked with mcpp
-zeroc-ice-ice2slice: statically-linked-binary usr/bin/ice2slice

--- a/packaging/deb/debian/zeroc-icegrid.install
+++ b/packaging/deb/debian/zeroc-icegrid.install
@@ -1,7 +1,7 @@
 etc/icegridnode.conf
 etc/icegridregistry.conf
-lib/systemd/system/icegridnode.service
-lib/systemd/system/icegridregistry.service
+usr/lib/systemd/system/icegridnode.service
+usr/lib/systemd/system/icegridregistry.service
 usr/bin/icegridnode
 usr/bin/icegridregistry
 usr/share/ice/templates.xml

--- a/packaging/deb/debian/zeroc-icestorm.lintian-overrides
+++ b/packaging/deb/debian/zeroc-icestorm.lintian-overrides
@@ -1,2 +1,2 @@
 # Package contains multiple libraries with different sonames
-zeroc-icestorm: package-name-doesnt-match-sonames libIceStormService3.8
+zeroc-icestorm: package-name-doesnt-match-sonames

--- a/packaging/rpm/README
+++ b/packaging/rpm/README
@@ -18,7 +18,7 @@ icegrid                 IceGrid service
 icegridgui              IceGrid GUI application
 icestorm                IceStorm service
 libice-c++-devel        Ice for C++ headers and symlinks, and the Slice compiler for C++
-libice3.9-c++           Ice for C++ runtime libraries (includes plug-ins, DataStorm and client libraries for Ice services)
+libice3.8-c++           Ice for C++ runtime libraries (includes plug-ins, DataStorm and client libraries for Ice services)
 php-ice                 Ice for PHP [1]
 php8.4-ice              Ice for PHP [2]
 python3-ice             Ice for Python

--- a/packaging/rpm/ice.spec
+++ b/packaging/rpm/ice.spec
@@ -1,7 +1,7 @@
 # Copyright (c) ZeroC, Inc.
 
 # Major.minor version for library sonames and package names
-%define mmversion 3.9
+%define mmversion 3.8
 
 # Macro for creating the ice user and group
 %define create_ice_user() \


### PR DESCRIPTION
## Summary

Fix lintian errors reported on the [mentors.debian.net upload](https://mentors.debian.net/package/zeroc-ice/) for the 3.8.1-1 Debian package.

- Use standard `nopython` build profile instead of custom `no-python312`
- Fix `${binary:Version}` to `${source:Version}` for arch:all package dependencies
- Remove obsolete `kfreebsd` arch restrictions from Build-Depends
- Update `Standards-Version` to 4.7.3 and add `Rules-Requires-Root: no`
- Fix `SimpleInternalFrame.java` path in `debian/copyright`
- Add repackaging comment to `debian/copyright`
- Remove redundant `Section` field from `zeroc-ice-slice` package
- Exclude `Files-Excluded` files from orig tarball via `git archive` pathspecs
- Remove `zeroc-ice-ice2slice` package and add quilt patch to exclude it from the build
- Fix duplicate short description in transitional packages
- Use relaxed `(>=)` dependencies in `zeroc-ice-compilers` transitional package
- Add lintian step to CI workflow
- Update `BUILDING.md` and CI workflow with new profile name
