### PR TITLE
Change null check for ReadOnlyMemory parameter (slice2cs --icerpc)

### DIFF
--- a/cpp/src/slice2cs/IceRpcCsUtil.cpp
+++ b/cpp/src/slice2cs/IceRpcCsUtil.cpp
@@ -339,9 +339,11 @@ Slice::Csharp::encodeOptionalField(
 
     if (readOnlyMemory)
     {
-        // A null ReadOnlyMemory is represented as a ReadOnlyMemory with a default Span. That's what you get when
-        // you construct a ReadOnlyMemory from a null array. Span != default when the ReadOnlyMemory is constructed
-        // from a non-null array, including an empty array.
+        // An outgoing sequence of fixed-size built-ins with no cs:generic metadata is mapped to ReadOnlyMemory<T>, not
+        // to a ReadOnlyMemory<T>?.
+        // A not-set value is represented by ReadOnlyMemory with a default Span. That's what you get when you construct
+        // a ReadOnlyMemory from a null array. Span != default when the ReadOnlyMemory is constructed from a non-null
+        // array, including an empty array.
         out << nl << "if (" << fieldName << ".Span != default)";
     }
     else if (isCsValueType(type))

--- a/cpp/src/slice2cs/IceRpcCsUtil.cpp
+++ b/cpp/src/slice2cs/IceRpcCsUtil.cpp
@@ -339,7 +339,10 @@ Slice::Csharp::encodeOptionalField(
 
     if (readOnlyMemory)
     {
-        out << nl << "if (" << fieldName << ".Span != null)";
+        // A null ReadOnlyMemory is represented as a ReadOnlyMemory with a default Span. That's what you get when
+        // you construct a ReadOnlyMemory from a null array. Span != default when the ReadOnlyMemory is constructed
+        // from a non-null array, including an empty array.
+        out << nl << "if (" << fieldName << ".Span != default)";
     }
     else if (isCsValueType(type))
     {


### PR DESCRIPTION
Using `!= default` is more readable than the current comparison with `null`. Also added comment.