### PR TITLE
Update slice2cs doc-comment generation

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -123,6 +123,22 @@ Slice::Csharp::writeDocLines(
 }
 
 void
+Slice::Csharp::writeParameterDocComments(Output& out, const DocComment& comment, const ParameterList& parameters)
+{
+    const auto& commentParameters = comment.parameters();
+    for (const auto& param : parameters)
+    {
+        auto q = commentParameters.find(param->name());
+        if (q != commentParameters.end())
+        {
+            ostringstream openTag;
+            openTag << "param name=\"" << removeEscapePrefix(param->mappedName()) << "\"";
+            writeDocLines(out, openTag.str(), q->second, "param");
+        }
+    }
+}
+
+void
 Slice::Csharp::writeSeeAlso(Output& out, const StringList& seeAlso)
 {
     for (const auto& line : seeAlso)

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -41,6 +41,9 @@ namespace Slice::Csharp
 
     void writeSeeAlso(IceInternal::Output& out, const StringList& seeAlso);
 
+    void
+    writeParameterDocComments(IceInternal::Output& out, const DocComment& comment, const ParameterList& parameters);
+
     class CsharpDocCommentFormatter final : public DocCommentFormatter
     {
     public:

--- a/cpp/src/slice2cs/IceCsUtil.cpp
+++ b/cpp/src/slice2cs/IceCsUtil.cpp
@@ -1761,16 +1761,16 @@ Slice::Csharp::writeIceOpDocComment(
         ostringstream openTag;
         openTag << "exception cref=\"" << name << "\"";
 
-        if (isAsync && !dispatch)
+        if (dispatch || !isAsync)
         {
-            StringList asyncExceptionLines{exceptionLines};
-            asyncExceptionLines.push_back(
-                "This exception is provided through the returned task; it's never thrown synchronously.");
-            writeDocLines(out, openTag.str(), asyncExceptionLines, "exception");
+            writeDocLines(out, openTag.str(), exceptionLines, "exception");
         }
         else
         {
-            writeDocLines(out, openTag.str(), exceptionLines, "exception");
+            StringList asyncExceptionLines{exceptionLines};
+            asyncExceptionLines.emplace_back(
+                "This exception is provided through the returned task; it's never thrown synchronously.");
+            writeDocLines(out, openTag.str(), asyncExceptionLines, "exception");
         }
     }
 

--- a/cpp/src/slice2cs/IceCsUtil.cpp
+++ b/cpp/src/slice2cs/IceCsUtil.cpp
@@ -12,24 +12,6 @@ using namespace std;
 using namespace Slice;
 using namespace IceInternal;
 
-namespace
-{
-    void writeParameterDocComments(Output& out, const DocComment& comment, const ParameterList& parameters)
-    {
-        const auto& commentParameters = comment.parameters();
-        for (const auto& param : parameters)
-        {
-            auto q = commentParameters.find(param->name());
-            if (q != commentParameters.end())
-            {
-                ostringstream openTag;
-                openTag << "param name=\"" << Csharp::removeEscapePrefix(param->mappedName()) << "\"";
-                Csharp::writeDocLines(out, openTag.str(), q->second, "param");
-            }
-        }
-    }
-}
-
 string
 Slice::Csharp::toArrayAlloc(const string& decl, const string& size)
 {
@@ -1637,7 +1619,11 @@ Slice::Csharp::writeOptionalSequenceMarshalUnmarshalCode(
 }
 
 void
-Slice::Csharp::writeIceDocComment(Output& out, const ContainedPtr& p, const string& generatedType, const string& notes)
+Slice::Csharp::writeIceDocComment(
+    Output& out,
+    const ContainedPtr& p,
+    optional<string> generatedType,
+    const string& notes)
 {
     const optional<DocComment>& comment = p->docComment();
     StringList remarks;
@@ -1647,7 +1633,7 @@ Slice::Csharp::writeIceDocComment(Output& out, const ContainedPtr& p, const stri
         remarks = comment->remarks();
     }
 
-    if (!generatedType.empty())
+    if (generatedType.has_value())
     {
         // If there's user-provided remarks, and a generated-type message, we introduce a paragraph between them.
         if (!remarks.empty())
@@ -1655,13 +1641,14 @@ Slice::Csharp::writeIceDocComment(Output& out, const ContainedPtr& p, const stri
             remarks.emplace_back("<para />");
         }
 
-        remarks.push_back(
-            "The Slice compiler generated this " + generatedType + " from Slice " + p->kindOf() + " <c>" + p->scoped() +
-            "</c>.");
         if (!notes.empty())
         {
             remarks.push_back(notes);
         }
+
+        remarks.push_back(
+            "The Slice compiler generated this " + *generatedType + " from Slice " + p->kindOf() + " <c>" +
+            p->scoped() + "</c>.");
     }
 
     if (!remarks.empty())
@@ -1688,12 +1675,16 @@ Slice::Csharp::writeIceHelperDocComment(
     assert(!generatedType.empty());
 
     writeDocLine(out, "summary", comment);
-    out << nl << "/// <remarks>" << "The Slice compiler generated this " << generatedType << " from Slice "
-        << p->kindOf() << " <c>" << p->scoped() << "</c>.";
+    out << nl << "/// <remarks>";
     if (!notes.empty())
     {
-        out << nl << "/// " << notes;
+        out << notes;
+        out << nl << "/// ";
     }
+
+    out << "The Slice compiler generated this " << generatedType << " from Slice " << p->kindOf() << " <c>"
+        << p->scoped() << "</c>.";
+
     out << "</remarks>";
 }
 
@@ -1702,7 +1693,8 @@ Slice::Csharp::writeIceOpDocComment(
     Output& out,
     const OperationPtr& op,
     const vector<string>& extraParams,
-    bool isAsync)
+    bool isAsync,
+    bool dispatch)
 {
     const optional<DocComment>& comment = op->docComment();
     if (!comment)
@@ -1711,7 +1703,6 @@ Slice::Csharp::writeIceOpDocComment(
     }
 
     writeDocLines(out, "summary", comment->overview());
-
     writeParameterDocComments(out, *comment, isAsync ? op->inParameters() : op->parameters());
 
     for (const auto& extraParam : extraParams)
@@ -1721,7 +1712,37 @@ Slice::Csharp::writeIceOpDocComment(
 
     if (isAsync)
     {
-        out << nl << "/// <returns>A task that represents the asynchronous operation.</returns>";
+        if (op->returnsMultipleValues() || !op->returnsAnyValues())
+        {
+            if (dispatch)
+            {
+                out << nl << "/// <returns>A task that completes when the dispatch completes.</returns>";
+            }
+            else if (op->returnsData())
+            {
+                out << nl << "/// <returns>A task that completes when the response is received.</returns>";
+            }
+            else
+            {
+                out << nl
+                    << "/// <returns>For two-way invocations: a task that completes when the response is received.";
+                out << nl << "/// For one-way invocations: a task that completes when the request is sent.</returns>";
+            }
+        }
+        else if (op->returnType())
+        {
+            writeDocLines(out, "returns", comment->returns());
+        }
+        else
+        {
+            assert(op->outParameters().size() == 1);
+            const auto& commentParameters = comment->parameters();
+            auto q = commentParameters.find(op->outParameters().front()->name());
+            if (q != commentParameters.end())
+            {
+                writeDocLines(out, "returns", q->second);
+            }
+        }
     }
     else if (op->returnType())
     {
@@ -1740,11 +1761,20 @@ Slice::Csharp::writeIceOpDocComment(
         ostringstream openTag;
         openTag << "exception cref=\"" << name << "\"";
 
-        writeDocLines(out, openTag.str(), exceptionLines, "exception");
+        if (isAsync && !dispatch)
+        {
+            StringList asyncExceptionLines{exceptionLines};
+            asyncExceptionLines.push_back(
+                "This exception is provided through the returned task; it's never thrown synchronously.");
+            writeDocLines(out, openTag.str(), asyncExceptionLines, "exception");
+        }
+        else
+        {
+            writeDocLines(out, openTag.str(), exceptionLines, "exception");
+        }
     }
 
     writeDocLines(out, "remarks", comment->remarks());
-
     writeSeeAlso(out, comment->seeAlso());
 }
 

--- a/cpp/src/slice2cs/IceCsUtil.h
+++ b/cpp/src/slice2cs/IceCsUtil.h
@@ -82,7 +82,7 @@ namespace Slice::Csharp
     /// @param p The Slice element.
     /// @param generatedType The kind of mapped element, used for the remarks. For example, "skeleton interface".
     /// This function does not write any remarks when this argument is nullopt.
-    /// @param notes Optional notes included after @p p 's remarks.
+    /// @param notes Optional notes included after @p p's remarks.
     void writeIceDocComment(
         IceInternal::Output& out,
         const ContainedPtr& p,

--- a/cpp/src/slice2cs/IceCsUtil.h
+++ b/cpp/src/slice2cs/IceCsUtil.h
@@ -93,7 +93,7 @@ namespace Slice::Csharp
     /// @param p The Slice element.
     /// @param comment The summary.
     /// @param generatedType The kind of mapped element, used for the remarks. Must not be empty.
-    /// @param notes Optional notes includes at the beginning of the remarks.
+    /// @param notes Optional notes included at the beginning of the remarks.
     void writeIceHelperDocComment(
         IceInternal::Output& out,
         const ContainedPtr& p,

--- a/cpp/src/slice2cs/IceCsUtil.h
+++ b/cpp/src/slice2cs/IceCsUtil.h
@@ -81,12 +81,12 @@ namespace Slice::Csharp
     /// Writes a doc-comment for the given Slice element, using this element's doc-comment, if any.
     /// @param p The Slice element.
     /// @param generatedType The kind of mapped element, used for the remarks. For example, "skeleton interface".
-    /// This function does not write any remarks when this argument is empty.
+    /// This function does not write any remarks when this argument is nullopt.
     /// @param notes Optional notes included at the end of the remarks.
     void writeIceDocComment(
         IceInternal::Output& out,
         const ContainedPtr& p,
-        const std::string& generatedType = "",
+        std::optional<std::string> generatedType = std::nullopt,
         const std::string& notes = "");
 
     /// Writes a doc-comment for a helper class generated for a Slice element.
@@ -105,7 +105,8 @@ namespace Slice::Csharp
         IceInternal::Output& out,
         const OperationPtr& operation,
         const std::vector<std::string>& extraParams,
-        bool isAsync);
+        bool isAsync,
+        bool dispatch);
 
     /// Converts a Slice-formatted link into a C# formatted link.
     /// @param rawLink The reference's raw text, taken verbatim from the doc-comment.

--- a/cpp/src/slice2cs/IceCsUtil.h
+++ b/cpp/src/slice2cs/IceCsUtil.h
@@ -82,7 +82,7 @@ namespace Slice::Csharp
     /// @param p The Slice element.
     /// @param generatedType The kind of mapped element, used for the remarks. For example, "skeleton interface".
     /// This function does not write any remarks when this argument is nullopt.
-    /// @param notes Optional notes included at the end of the remarks.
+    /// @param notes Optional notes included after @p p 's remarks.
     void writeIceDocComment(
         IceInternal::Output& out,
         const ContainedPtr& p,
@@ -93,7 +93,7 @@ namespace Slice::Csharp
     /// @param p The Slice element.
     /// @param comment The summary.
     /// @param generatedType The kind of mapped element, used for the remarks. Must not be empty.
-    /// @param notes Optional notes included at the end of the remarks.
+    /// @param notes Optional notes includes at the beginning of the remarks.
     void writeIceHelperDocComment(
         IceInternal::Output& out,
         const ContainedPtr& p,

--- a/cpp/src/slice2cs/IceRpcCsUtil.cpp
+++ b/cpp/src/slice2cs/IceRpcCsUtil.cpp
@@ -548,7 +548,7 @@ void
 Slice::Csharp::writeIceRpcDocComment(
     Output& out,
     const ContainedPtr& p,
-    const string& generatedType,
+    optional<string> generatedType,
     const string& notes)
 {
     const optional<DocComment>& comment = p->docComment();
@@ -559,7 +559,7 @@ Slice::Csharp::writeIceRpcDocComment(
         remarks = comment->remarks();
     }
 
-    if (!generatedType.empty())
+    if (generatedType.has_value())
     {
         // If there's user-provided remarks, and a generated-type message, we introduce a paragraph between them.
         if (!remarks.empty())
@@ -567,13 +567,13 @@ Slice::Csharp::writeIceRpcDocComment(
             remarks.emplace_back("<para />");
         }
 
-        remarks.push_back(
-            "The Ice-Slice compiler generated this " + generatedType + " from Ice " + p->kindOf() + " <c>" +
-            p->scoped() + "</c>.");
         if (!notes.empty())
         {
             remarks.push_back(notes);
         }
+        remarks.push_back(
+            "The Ice compiler generated this " + *generatedType + " from Ice " + p->kindOf() + " <c>" + p->scoped() +
+            "</c>.");
     }
 
     if (!remarks.empty())
@@ -588,25 +588,132 @@ Slice::Csharp::writeIceRpcDocComment(
 }
 
 void
+Slice::Csharp::writeIceRpcOpDocComment(Output& out, const OperationPtr& op, bool dispatch)
+{
+    const optional<DocComment>& comment = op->docComment();
+    if (!comment)
+    {
+        return;
+    }
+
+    writeDocLines(out, "summary", comment->overview());
+    writeParameterDocComments(out, *comment, op->inParameters());
+
+    // Extra params
+
+    string featuresParam = getEscapedParamName(op->inParameters(), "features");
+    string cancellationTokenParam = getEscapedParamName(op->inParameters(), "cancellationToken");
+
+    if (dispatch)
+    {
+        out << nl << "/// <param name=\"" << featuresParam << "\">The features of this dispatch.</param>";
+    }
+    else
+    {
+        out << nl << "/// <param name=\"" << featuresParam << "\">The features of this invocation.</param>";
+    }
+    out << nl << "/// <param name=\"" << cancellationTokenParam
+        << "\">A cancellation token that receives the cancellation requests.</param>";
+
+    if (op->returnsMultipleValues())
+    {
+        // This tuple description may be confusing if some doc-comments are missing; the user should fix the Ice
+        // doc-comments in this case.
+        out << nl << "/// <returns>A tuple containing";
+        out << nl << R"(/// <list type="bullet">)";
+        if (op->returnType())
+        {
+            writeDocLines(out, "item><description", comment->returns());
+        }
+        for (const auto& outParam : op->outParameters())
+        {
+            auto q = comment->parameters().find(outParam->name());
+            if (q != comment->parameters().end())
+            {
+                writeDocLines(out, "item><description", q->second);
+            }
+        }
+        out << nl << "/// </list></returns>";
+    }
+    else if (op->returnType())
+    {
+        writeDocLines(out, "returns", comment->returns());
+    }
+    else if (op->outParameters().size() == 1)
+    {
+        auto q = comment->parameters().find(op->outParameters().front()->name());
+        if (q != comment->parameters().end())
+        {
+            writeDocLines(out, "returns", q->second);
+        }
+    }
+    else
+    {
+        // Returns nothing
+        if (dispatch)
+        {
+            out << nl << "/// <returns>A value task that completes when the dispatch completes.</returns>";
+        }
+        else
+        {
+            // TODO: check for oneway operations
+            out << nl << "/// <returns>A task that completes when the response is received.</returns>";
+        }
+    }
+
+    if (!dispatch)
+    {
+        writeDocLines(
+            out,
+            R"(exception cref="IceRpc.DispatchException")",
+            {"Thrown when the dispatch of the operation failed.",
+             "This exception is provided through the returned task; it's never thrown synchronously."},
+            "exception");
+    }
+
+    for (const auto& [exceptionName, exceptionLines] : comment->exceptions())
+    {
+        string name = exceptionName;
+        ExceptionPtr ex = op->container()->lookupException(exceptionName, false);
+        if (ex)
+        {
+            name = ex->mappedScoped(".");
+        }
+
+        ostringstream openTag;
+        openTag << "exception cref=\"" << name << "\"";
+
+        if (dispatch)
+        {
+            writeDocLines(out, openTag.str(), exceptionLines, "exception");
+        }
+        else
+        {
+            StringList asyncExceptionLines{exceptionLines};
+            asyncExceptionLines.push_back(
+                "This exception is provided through the returned task; it's never thrown synchronously.");
+            writeDocLines(out, openTag.str(), asyncExceptionLines, "exception");
+        }
+    }
+
+    writeDocLines(out, "remarks", comment->remarks());
+    writeSeeAlso(out, comment->seeAlso());
+}
+
+void
 Slice::Csharp::writeIceRpcHelperDocComment(
     Output& out,
     const ContainedPtr& p,
     const string& comment,
-    const string& generatedType,
-    const string& notes)
+    const string& generatedType)
 {
     // Called only for module-level types.
     assert(dynamic_pointer_cast<Module>(p->container()));
     assert(!generatedType.empty());
 
     writeDocLine(out, "summary", comment);
-    out << nl << "/// <remarks>" << "The Ice-Slice compiler generated this " << generatedType << " from Ice "
-        << p->kindOf() << " <c>" << p->scoped() << "</c>.";
-    if (!notes.empty())
-    {
-        out << nl << "/// " << notes;
-    }
-    out << "</remarks>";
+    out << nl << "/// <remarks>" << "The Ice compiler generated this " << generatedType << " from Ice " << p->kindOf()
+        << " <c>" << p->scoped() << "</c>.</remarks>";
 }
 
 std::pair<bool, string>

--- a/cpp/src/slice2cs/IceRpcCsUtil.cpp
+++ b/cpp/src/slice2cs/IceRpcCsUtil.cpp
@@ -619,7 +619,7 @@ Slice::Csharp::writeIceRpcOpDocComment(Output& out, const OperationPtr& op, bool
     {
         // This tuple description may be confusing if some doc-comments are missing; the user should fix the Ice
         // doc-comments in this case.
-        out << nl << "/// <returns>A tuple containing";
+        out << nl << "/// <returns>A tuple with the following elements:";
         out << nl << R"(/// <list type="bullet">)";
         if (op->returnType())
         {

--- a/cpp/src/slice2cs/IceRpcCsUtil.cpp
+++ b/cpp/src/slice2cs/IceRpcCsUtil.cpp
@@ -690,7 +690,7 @@ Slice::Csharp::writeIceRpcOpDocComment(Output& out, const OperationPtr& op, bool
         else
         {
             StringList asyncExceptionLines{exceptionLines};
-            asyncExceptionLines.push_back(
+            asyncExceptionLines.emplace_back(
                 "This exception is provided through the returned task; it's never thrown synchronously.");
             writeDocLines(out, openTag.str(), asyncExceptionLines, "exception");
         }

--- a/cpp/src/slice2cs/IceRpcCsUtil.cpp
+++ b/cpp/src/slice2cs/IceRpcCsUtil.cpp
@@ -623,14 +623,14 @@ Slice::Csharp::writeIceRpcOpDocComment(Output& out, const OperationPtr& op, bool
         out << nl << R"(/// <list type="bullet">)";
         if (op->returnType())
         {
-            writeDocLines(out, "item><description", comment->returns());
+            writeDocLines(out, "item><description", comment->returns(), "description></item");
         }
         for (const auto& outParam : op->outParameters())
         {
             auto q = comment->parameters().find(outParam->name());
             if (q != comment->parameters().end())
             {
-                writeDocLines(out, "item><description", q->second);
+                writeDocLines(out, "item><description", q->second, "description></item");
             }
         }
         out << nl << "/// </list></returns>";

--- a/cpp/src/slice2cs/IceRpcCsUtil.h
+++ b/cpp/src/slice2cs/IceRpcCsUtil.h
@@ -79,32 +79,34 @@ namespace Slice::Csharp
         const std::string& ns,
         TypeContext context);
 
+    std::string escapeParamName(std::string paramName, const ParameterList& params);
+
     //
     // Doc-comments
     //
 
     /// Writes a doc-comment for the given Slice element, using this element's doc-comment, if any.
     /// @param p The Slice element.
-    /// @param generatedType The kind of mapped element, used for the remarks. For example, "skeleton interface".
-    /// This function does not write any remarks when this argument is empty.
+    /// @param generatedType The kind of mapped element, used for the remarks. For example, "server-side interface".
+    /// This function does not write any remarks when this argument is nullopt.
     /// @param notes Optional notes included at the end of the remarks.
     void writeIceRpcDocComment(
         IceInternal::Output& out,
         const ContainedPtr& p,
-        const std::string& generatedType = "",
+        std::optional<std::string> generatedType = std::nullopt,
         const std::string& notes = "");
 
     /// Writes a doc-comment for a helper class generated for a Slice element.
     /// @param p The Slice element.
     /// @param comment The summary.
-    /// @param generatedType The kind of mapped element, used for the remarks. Must not be empty.
-    /// @param notes Optional notes included at the end of the remarks.
+    /// @param generatedType The kind of mapped element, used for the remarks. Never empty.
     void writeIceRpcHelperDocComment(
         IceInternal::Output& out,
         const ContainedPtr& p,
         const std::string& comment,
-        const std::string& generatedType,
-        const std::string& notes = "");
+        const std::string& generatedType);
+
+    void writeIceRpcOpDocComment(IceInternal::Output& out, const OperationPtr& operation, bool dispatch);
 
     /// Converts a Slice-formatted link into a C# formatted link.
     /// @param rawLink The reference's raw text, taken verbatim from the doc-comment.

--- a/cpp/src/slice2cs/IceRpcCsUtil.h
+++ b/cpp/src/slice2cs/IceRpcCsUtil.h
@@ -87,7 +87,7 @@ namespace Slice::Csharp
     /// @param p The Slice element.
     /// @param generatedType The kind of mapped element, used for the remarks. For example, "server-side interface".
     /// This function does not write any remarks when this argument is nullopt.
-    /// @param notes Optional notes included after @p p 's remarks.
+    /// @param notes Optional notes included after @p p's remarks.
     void writeIceRpcDocComment(
         IceInternal::Output& out,
         const ContainedPtr& p,

--- a/cpp/src/slice2cs/IceRpcCsUtil.h
+++ b/cpp/src/slice2cs/IceRpcCsUtil.h
@@ -87,7 +87,7 @@ namespace Slice::Csharp
     /// @param p The Slice element.
     /// @param generatedType The kind of mapped element, used for the remarks. For example, "server-side interface".
     /// This function does not write any remarks when this argument is nullopt.
-    /// @param notes Optional notes included at the end of the remarks.
+    /// @param notes Optional notes included after @p p 's remarks.
     void writeIceRpcDocComment(
         IceInternal::Output& out,
         const ContainedPtr& p,

--- a/cpp/src/slice2cs/IceRpcCsUtil.h
+++ b/cpp/src/slice2cs/IceRpcCsUtil.h
@@ -79,8 +79,6 @@ namespace Slice::Csharp
         const std::string& ns,
         TypeContext context);
 
-    std::string escapeParamName(std::string paramName, const ParameterList& params);
-
     //
     // Doc-comments
     //

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -467,7 +467,7 @@ Slice::IceRpc::TypesVisitor::visitEnum(const EnumPtr& p)
     writeDocLine(_out, "returns", "The corresponding " + escapedName + " enumerator.");
     writeDocLine(
         _out,
-        R"(exception name="System.IO.InvalidDataException")",
+        R"(exception cref="System.IO.InvalidDataException")",
         "Thrown if the integer value does not correspond to any enumerator of " + escapedName + ".",
         "exception");
     _out << nl << accessModifier(p) << " static " << escapedName << " As" << name << "(this int value) =>";

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -531,7 +531,10 @@ Slice::IceRpc::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     // Generate the client interface.
     _out << sp;
-    writeIceRpcDocComment(_out, p, "client-side interface");
+    ostringstream notes;
+    notes << "Use the methods of this interface to invoke operations on a remote Ice service that implements <c>"
+          << p->name() << "</c>.";
+    writeIceRpcDocComment(_out, p, "client-side interface", notes.str());
     emitObsoleteAttribute(p);
     _out << nl << accessModifier(p) << " partial interface I" << name;
     if (!p->bases().empty())
@@ -1246,7 +1249,9 @@ Slice::IceRpc::SkeletonVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     // Generate the server-side interface.
     _out << sp;
-    writeIceRpcDocComment(_out, p, "server-side interface");
+    ostringstream notes;
+    notes << R"(Apply <see cref="IceRpc.ServiceAttribute" /> to the partial class that implements this interface.)";
+    writeIceRpcDocComment(_out, p, "server-side interface", notes.str());
     _out << nl << "[IceTypeId(\"" << p->scoped() << "\")]";
     _out << nl << "[IceRpc.DefaultServicePath(\"" << defaultServicePath(p) << "\")]";
     emitObsoleteAttribute(p);

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -17,7 +17,8 @@ using namespace IceInternal;
 
 namespace
 {
-    // paramName does not start with an escape prefix.
+    // Returns paramName as-is or escaped if it conflicts with any of the parameter names in params.
+    // paramName never starts with an escape prefix.
     string escapeCapitalizedParamName(const ParameterList& params, string paramName)
     {
         for (const auto& param : params)

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -17,22 +17,8 @@ using namespace IceInternal;
 
 namespace
 {
-    // Returns paramName as-is or escaped if it conflicts with any of the parameter names in params.
     // paramName does not start with an escape prefix.
-    string escapeParamName(string paramName, const ParameterList& params)
-    {
-        for (const auto& param : params)
-        {
-            if (param->mappedName() == paramName)
-            {
-                return paramName + "_";
-            }
-        }
-        return paramName;
-    }
-
-    // paramName does not start with an escape prefix.
-    string escapeCapitalizedParamName(string paramName, const ParameterList& params)
+    string escapeCapitalizedParamName(const ParameterList& params, string paramName)
     {
         for (const auto& param : params)
         {
@@ -83,7 +69,7 @@ namespace
                 ParameterList returnParams = operation->outParameters();
                 if (operation->returnType())
                 {
-                    string returnParamName = escapeCapitalizedParamName("ReturnValue", returnParams);
+                    string returnParamName = escapeCapitalizedParamName(returnParams, "ReturnValue");
                     returnParams.insert(returnParams.begin(), operation->returnParameter(returnParamName));
                 }
 
@@ -148,8 +134,8 @@ namespace
     {
         TypeContext paramContext = dispatch ? TypeContext::IncomingParam : TypeContext::OutgoingParam;
 
-        string featuresParam = escapeParamName("features", operation->inParameters());
-        string cancellationTokenParam = escapeParamName("cancellationToken", operation->inParameters());
+        string featuresParam = getEscapedParamName(operation->inParameters(), "features");
+        string cancellationTokenParam = getEscapedParamName(operation->inParameters(), "cancellationToken");
 
         vector<string> extraParams;
         if (dispatch)
@@ -476,7 +462,14 @@ Slice::IceRpc::TypesVisitor::visitEnum(const EnumPtr& p)
         _out << sp;
     }
 
-    // TODO: doc-comment
+    writeDocLine(_out, "summary", "Converts an integer value to the corresponding " + escapedName + " enumerator.");
+    writeDocLine(_out, R"(param name="value")", "The integer value to convert.", "param");
+    writeDocLine(_out, "returns", "The corresponding " + escapedName + " enumerator.");
+    writeDocLine(
+        _out,
+        R"(exception name="System.IO.InvalidDataException")",
+        "Thrown if the integer value does not correspond to any enumerator of " + escapedName + ".",
+        "exception");
     _out << nl << accessModifier(p) << " static " << escapedName << " As" << name << "(this int value) =>";
     _out.inc();
     if (useSet)
@@ -506,7 +499,9 @@ Slice::IceRpc::TypesVisitor::visitEnum(const EnumPtr& p)
     _out << nl << accessModifier(p) << " static class " << name << "IceEncoderExtensions";
     _out << sb;
 
-    // TODO: doc-comment
+    writeDocLine(_out, "summary", "Encodes an enumerator.");
+    writeDocLine(_out, R"(param name="encoder")", "The Ice encoder.", "param");
+    writeDocLine(_out, R"(param name="value")", "The enumerator value to encode.", "param");
     _out << nl << accessModifier(p) << " static void Encode" << name << "(this ref IceEncoder encoder, " << escapedName
          << " value) => encoder.EncodeSize((int)value);";
     _out << eb;
@@ -519,7 +514,9 @@ Slice::IceRpc::TypesVisitor::visitEnum(const EnumPtr& p)
     _out << nl << accessModifier(p) << " static class " << name << "IceDecoderExtensions";
     _out << sb;
 
-    // TODO: doc-comment
+    writeDocLine(_out, "summary", "Decodes an enumerator.");
+    writeDocLine(_out, R"(param name="decoder")", "The Ice decoder.", "param");
+    writeDocLine(_out, "returns", "The decoded enumerator value.");
     _out << nl << accessModifier(p) << " static " << escapedName << " Decode" << name
          << "(this ref IceDecoder decoder) => " << name << "IntExtensions.As" << name << "(decoder.DecodeSize());";
     _out << eb;
@@ -697,8 +694,8 @@ Slice::IceRpc::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         _out << nl << "/// <inheritdoc />";
         _out << nl << "public ";
 
-        string featureParam = escapeParamName("features", operation->inParameters());
-        string cancellationTokenParam = escapeParamName("cancellationToken", operation->inParameters());
+        string featureParam = getEscapedParamName(operation->inParameters(), "features");
+        string cancellationTokenParam = getEscapedParamName(operation->inParameters(), "cancellationToken");
 
         writeMethodSignature(_out, operation, ns, false);
 
@@ -727,8 +724,9 @@ Slice::IceRpc::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         _out << nl << "public ";
 
         string operationName = removeEscapePrefix(operation->mappedName());
-        string featureParam = escapeParamName("features", operation->inParameters());
-        string cancellationTokenParam = escapeParamName("cancellationToken", operation->inParameters());
+        string featureParam = getEscapedParamName(operation->inParameters(), "features");
+        string cancellationTokenParam = getEscapedParamName(operation->inParameters(), "cancellationToken");
+        string encodeOptionsParam = getEscapedParamName(operation->inParameters(), "encodeOptions");
 
         writeMethodSignature(_out, operation, ns, false);
 
@@ -744,7 +742,8 @@ Slice::IceRpc::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         _out << nl << "\"" << operation->name() << "\",";
         if (operation->inParameters().empty())
         {
-            _out << nl << "payload: Request.Encode" << operationName << "(encodeOptions: EncodeOptions),";
+            _out << nl << "payload: Request.Encode" << operationName << "(" << encodeOptionsParam
+                 << ": EncodeOptions),";
         }
         else
         {
@@ -754,8 +753,7 @@ Slice::IceRpc::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
             {
                 _out << param->mappedName();
             }
-            // TODO: escape encodeOptions
-            _out << "encodeOptions: EncodeOptions";
+            _out << (encodeOptionsParam + ": EncodeOptions");
             _out << epar;
             _out << ',';
         }
@@ -818,8 +816,7 @@ Slice::IceRpc::TypesVisitor::visitOperation(const OperationPtr& p)
     string ns = getNamespace(p->interface());
 
     _out << sp;
-
-    // TODO: doc comment for operation
+    writeIceRpcOpDocComment(_out, p, false);
     emitObsoleteAttribute(p);
     _out << nl;
     writeMethodSignature(_out, p, ns, false);
@@ -988,13 +985,20 @@ Slice::IceRpc::TypesVisitor::writeProxyRequestClass(const InterfaceDefPtr& inter
 
     for (const auto& operation : interface->operations())
     {
+        string encodeOptionsParam = getEscapedParamName(operation->inParameters(), "encodeOptions");
+
+        _out << sp;
         writeDocLine(
             _out,
             "summary",
             "Encodes the argument(s) of operation <c>" + operation->name() + "</c> into a request payload.");
-        // TODO: param doc comments
-        writeDocLine(_out, R"(param name="encodeOptions")", "The Ice encode options.", "param");
-        writeDocLine(_out, "returns", "The Ice-encoded payload.", "returns");
+
+        if (operation->docComment().has_value())
+        {
+            writeParameterDocComments(_out, *operation->docComment(), operation->inParameters());
+            writeDocLine(_out, R"(param name=")" + encodeOptionsParam + R"(")", "The Ice encode options.", "param");
+            writeDocLine(_out, "returns", "The Ice-encoded payload.");
+        }
 
         _out << nl << accessModifier(interface) << " static global::System.IO.Pipelines.PipeReader Encode"
              << removeEscapePrefix(operation->mappedName()) << "(";
@@ -1005,7 +1009,7 @@ Slice::IceRpc::TypesVisitor::writeProxyRequestClass(const InterfaceDefPtr& inter
             _out << nl << csOutgoingParamType(param->type(), ns, param->optional()) << ' ' << param->mappedName()
                  << ',';
         }
-        _out << nl << "IceEncodeOptions? encodeOptions = null)";
+        _out << nl << "IceEncodeOptions? " << encodeOptionsParam << " = null)";
         _out.dec();
         _out << sb;
         if (operation->inParameters().empty())
@@ -1016,7 +1020,7 @@ Slice::IceRpc::TypesVisitor::writeProxyRequestClass(const InterfaceDefPtr& inter
         {
             _out << nl << "var pipe_ = new global::System.IO.Pipelines.Pipe(";
             _out.inc();
-            _out << nl << "encodeOptions?.PipeOptions ?? IceEncodeOptions.Default.PipeOptions);";
+            _out << nl << encodeOptionsParam << "?.PipeOptions ?? IceEncodeOptions.Default.PipeOptions);";
             _out.dec();
             _out << nl << "var encoder_ = new IceEncoder(pipe_.Writer, " << classFormat(operation) << ");";
 
@@ -1066,6 +1070,26 @@ Slice::IceRpc::TypesVisitor::writeProxyResponseClass(const InterfaceDefPtr& inte
     for (const auto& operation : interface->operations())
     {
         writeDocLine(_out, "summary", "Decodes an incoming response for operation <c>" + operation->name() + "</c>.");
+        writeDocLine(_out, R"(param name="response")", "The incoming response to decode.", "param");
+        writeDocLine(_out, R"(param name="request")", "The outgoing request.", "param");
+        writeDocLine(_out, R"(param name="sender")", "The proxy that sent the request.", "param");
+        writeDocLine(
+            _out,
+            R"(param name="cancellationToken")",
+            "A cancellation token that receives the cancellation requests.",
+            "param");
+        if (operation->returnsAnyValues())
+        {
+            writeDocLine(_out, "returns", "The decoded response payload.");
+        }
+        else
+        {
+            writeDocLine(
+                _out,
+                "returns",
+                "A value task that completes when the decoding of the response payload completes.");
+        }
+
         _out << nl << accessModifier(interface) << " static async ";
         writeReturnTask(_out, operation, "ValueTask", false);
         _out << " Decode" << removeEscapePrefix(operation->mappedName()) << "Async(";
@@ -1088,7 +1112,7 @@ Slice::IceRpc::TypesVisitor::writeProxyResponseClass(const InterfaceDefPtr& inte
             _out << nl << "sender,";
             _out << nl << "(ref IceDecoder decoder) => ";
 
-            string returnParamName = escapeParamName("returnValue", operation->outParameters());
+            string returnParamName = getEscapedParamName(operation->outParameters(), "returnValue");
             ParameterList returnParams = operation->sortedReturnAndOutParameters(returnParamName);
 
             if (returnParams.size() == 1)
@@ -1274,12 +1298,10 @@ Slice::IceRpc::SkeletonVisitor::visitInterfaceDefEnd(const InterfaceDefPtr&)
 void
 Slice::IceRpc::SkeletonVisitor::visitOperation(const OperationPtr& p)
 {
-    _out << sp;
-
     string ns = getNamespace(p->interface());
 
-    // TODO: doc comment for operation
-
+    _out << sp;
+    writeIceRpcOpDocComment(_out, p, true);
     _out << nl << "[IceOperation(\"" << p->name() << "\"";
 
     if (p->mode() == Operation::Idempotent)
@@ -1326,7 +1348,25 @@ Slice::IceRpc::SkeletonVisitor::writeRequestClass(const InterfaceDefPtr& interfa
     {
         _out << sp;
         writeDocLine(_out, "summary", "Decodes the request payload of operation <c>" + operation->name() + "</c>.");
-        // TODO: param doc comments
+        writeDocLine(_out, R"(param name="request")", "The incoming request.", "param");
+        writeDocLine(
+            _out,
+            R"(param name="cancellationToken")",
+            "A cancellation token that receives the cancellation requests.",
+            "param");
+
+        if (operation->returnsAnyValues())
+        {
+            writeDocLine(_out, "returns", "The decoded request payload.");
+        }
+        else
+        {
+            writeDocLine(
+                _out,
+                "returns",
+                "A value task that completes when the decoding of the request payload completes.");
+        }
+
         _out << nl << accessModifier(interface) << " static ";
         writeParamsValueTask(_out, operation);
         _out << " Decode" << removeEscapePrefix(operation->mappedName()) << "Async(";
@@ -1424,21 +1464,23 @@ Slice::IceRpc::SkeletonVisitor::writeResponseClass(const InterfaceDefPtr& interf
 
     for (const auto& operation : interface->operations())
     {
+        string encodeOptionsParam = getEscapedParamName(operation->outParameters(), "encodeOptions");
+
         _out << sp;
         writeDocLine(
             _out,
             "summary",
             "Encodes the return value and out parameter(s) of operation <c>" + operation->name() +
                 "</c> into a response payload.");
-        // TODO: param doc comments
-        writeDocLine(_out, "param name=\"encodeOptions\"", "The Ice encode options.", "param");
-        writeDocLine(_out, "returns", "The Ice-encoded payload.");
+
+        // We can't generate XML doc comments for the params (return and out) because they may contain @p
+        // references to in-parameters, and the corresponding paramref would not resolve.
 
         _out << nl << accessModifier(interface) << " static global::System.IO.Pipelines.PipeReader Encode"
              << removeEscapePrefix(operation->mappedName()) << "(";
 
         _out.inc();
-        string returnParamName = escapeParamName("returnValue", operation->outParameters());
+        string returnParamName = getEscapedParamName(operation->outParameters(), "returnValue");
 
         if (operation->returnType())
         {
@@ -1450,14 +1492,14 @@ Slice::IceRpc::SkeletonVisitor::writeResponseClass(const InterfaceDefPtr& interf
             _out << nl << csOutgoingParamType(param->type(), ns, param->optional()) << ' ' << param->mappedName()
                  << ',';
         }
-        _out << nl << "IceEncodeOptions? encodeOptions = null)";
+        _out << nl << "IceEncodeOptions? " << encodeOptionsParam << " = null)";
         _out.dec();
         _out << sb;
         if (operation->returnsAnyValues())
         {
             _out << nl << "var pipe_ = new global::System.IO.Pipelines.Pipe(";
             _out.inc();
-            _out << nl << "encodeOptions?.PipeOptions ?? IceEncodeOptions.Default.PipeOptions);";
+            _out << nl << encodeOptionsParam << "?.PipeOptions ?? IceEncodeOptions.Default.PipeOptions);";
             _out.dec();
             _out << nl << "var encoder_ = new IceEncoder(pipe_.Writer, " << classFormat(operation) << ");";
 

--- a/cpp/src/slice2cs/IceVisitors.cpp
+++ b/cpp/src/slice2cs/IceVisitors.cpp
@@ -1591,7 +1591,7 @@ Slice::Ice::TypesVisitor::visitOperation(const OperationPtr& p)
         //
         string context = getEscapedParamName(p->parameters(), "context");
         _out << sp;
-        writeIceOpDocComment(_out, p, {"<param name=\"" + context + "\">The request context.</param>"}, false);
+        writeIceOpDocComment(_out, p, {"<param name=\"" + context + "\">The request context.</param>"}, false, false);
         emitObsoleteAttribute(p);
         _out << nl << retS << " " << name;
         _out.spar("(", true);
@@ -1615,7 +1615,8 @@ Slice::Ice::TypesVisitor::visitOperation(const OperationPtr& p)
             {"<param name=\"" + context + "\">The request context.</param>",
              "<param name=\"" + progress + "\">The sent progress provider.</param>",
              "<param name=\"" + cancel + "\">A cancellation token that receives the cancellation requests.</param>"},
-            true);
+            true,
+            false);
         emitObsoleteAttribute(p);
         _out << nl << taskResultType(p, ns);
         _out << " " << name << "Async";
@@ -2022,7 +2023,8 @@ Slice::Ice::SkeletonVisitor::visitOperation(const OperationPtr& op)
         _out,
         op,
         {"<param name=\"" + args.back() + "\">The Current object for the dispatch.</param>"},
-        amd);
+        amd,
+        true);
 
     emitObsoleteAttribute(op);
     _out << nl << retS << " " << opName;


### PR DESCRIPTION
This PR updates the doc-comments generated by slice2cs, mostly for the icerpc gen mode.

It also adds the missing escaping for encodeOptions.