### PR TITLE
Fix typo in icegriddb and icestormdb man pages

### DIFF
--- a/man/man1/icegriddb.1
+++ b/man/man1/icegriddb.1
@@ -31,7 +31,7 @@ Display the Ice version.
 .TP
 .BR \-\-import " " FILE\fR
 .br
-Import database from the specifed file.
+Import database from the specified file.
 
 .TP
 .BR \-\-export " " FILE\fR

--- a/man/man1/icestormdb.1
+++ b/man/man1/icestormdb.1
@@ -36,7 +36,7 @@ Display the Ice version.
 .TP
 .BR \-\-import " " FILE\fR
 .br
-Import database from the specifed file.
+Import database from the specified file.
 
 .TP
 .BR \-\-export " " FILE\fR


### PR DESCRIPTION
Fix "specifed" → "specified" in the `--import` option description in `icegriddb.1` and `icestormdb.1` man pages