### PR TITLE
Add support for constants and default values (slice2cs --icerpc)

### DIFF
--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -69,6 +69,48 @@ Slice::Csharp::removeEscapePrefix(const string& identifier)
 }
 
 void
+Slice::Csharp::writeConstantValue(
+    Output& out,
+    const TypePtr& type,
+    const SyntaxTreeBasePtr& valueType,
+    const string& value,
+    const string& ns,
+    const string& fieldName)
+{
+    ConstPtr constant = dynamic_pointer_cast<Const>(valueType);
+    if (constant)
+    {
+        out << getUnqualified(constant, ns) << "." << fieldName;
+    }
+    else
+    {
+        BuiltinPtr bp = dynamic_pointer_cast<Builtin>(type);
+        if (bp && bp->kind() == Builtin::KindString)
+        {
+            out << "\"" << toStringLiteral(value, "\a\b\f\n\r\t\v\0", "", UCN, 0) << "\"";
+        }
+        else if (bp && bp->kind() == Builtin::KindLong)
+        {
+            out << value << "L";
+        }
+        else if (bp && bp->kind() == Builtin::KindFloat)
+        {
+            out << value << "F";
+        }
+        else if (dynamic_pointer_cast<Enum>(type))
+        {
+            EnumeratorPtr lte = dynamic_pointer_cast<Enumerator>(valueType);
+            assert(lte);
+            out << getUnqualified(lte, ns);
+        }
+        else
+        {
+            out << value;
+        }
+    }
+}
+
+void
 Slice::Csharp::writeDocLine(
     Output& out,
     const string& openTag,

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -97,6 +97,10 @@ Slice::Csharp::writeConstantValue(
         {
             out << value << "F";
         }
+        else if (bp && bp->kind() == Builtin::KindDouble)
+        {
+            out << value << "D";
+        }
         else if (dynamic_pointer_cast<Enum>(type))
         {
             EnumeratorPtr lte = dynamic_pointer_cast<Enumerator>(valueType);

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -27,7 +27,7 @@ namespace Slice::Csharp
     /// Writes a C# constant value.
     /// @param out The output to write to.
     /// @param type The type of the constant.
-    /// @param valueType The syntax tree node associated with the value. It can be null, an enumerator, or a const.
+    /// @param valueType The syntax tree node associated with the value. It can be null, an enumerator, or a constant.
     /// @param value The value of the constant, e.g. "42" or "SomeEnum.SomeValue".
     /// @param ns The namespace of the caller.
     /// @param fieldName The name of the mapped constant field (used when @p valueType is a const).

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -27,7 +27,7 @@ namespace Slice::Csharp
     /// Writes a C# constant value.
     /// @param out The output to write to.
     /// @param type The type of the constant.
-    /// @param valueType The syntax tree node associated with the value. It can be null, an enum, or a const.
+    /// @param valueType The syntax tree node associated with the value. It can be null, an enumerator, or a const.
     /// @param value The value of the constant, e.g. "42" or "SomeEnum.SomeValue".
     /// @param ns The namespace of the caller.
     /// @param fieldName The name of the mapped constant field (used when @p valueType is a const).

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -24,6 +24,21 @@ namespace Slice::Csharp
     /// Returns the namespace prefix of a Contained entity.
     [[nodiscard]] std::string getNamespacePrefix(const ContainedPtr& p);
 
+    /// Writes a C# constant value.
+    /// @param out The output to write to.
+    /// @param type The type of the constant.
+    /// @param valueType The syntax tree node associated with the value. It can be null, an enum, or a const.
+    /// @param value The value of the constant, e.g. "42" or "SomeEnum.SomeValue".
+    /// @param ns The namespace of the caller.
+    /// @param fieldName The name of the mapped constant field (used when @p valueType is a const).
+    void writeConstantValue(
+        IceInternal::Output& out,
+        const TypePtr& type,
+        const SyntaxTreeBasePtr& valueType,
+        const std::string& value,
+        const std::string& ns,
+        const std::string& fieldName = "value");
+
     /// Writes a one-line XML doc-comment.
     void writeDocLine(
         IceInternal::Output& out,

--- a/cpp/src/slice2cs/IceRpcCsUtil.cpp
+++ b/cpp/src/slice2cs/IceRpcCsUtil.cpp
@@ -223,8 +223,12 @@ Slice::Csharp::csRequired(const DataMemberPtr& field)
         return false;
     }
 
-    return isString(field->type()) || dynamic_pointer_cast<Sequence>(field->type()) ||
-           dynamic_pointer_cast<Dictionary>(field->type());
+    if (isString(field->type()))
+    {
+        return field->defaultValue() == nullopt;
+    }
+
+    return dynamic_pointer_cast<Sequence>(field->type()) || dynamic_pointer_cast<Dictionary>(field->type());
 }
 
 void

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -205,7 +205,8 @@ Slice::IceRpc::TypesVisitor::visitStructEnd(const StructPtr& p)
             _out << sp;
             writeDocLine(
                 _out,
-                "summary", "Initializes a new instance of the <see cref=\"" + escapedName + "\" /> struct.");
+                "summary",
+                "Initializes a new instance of the <see cref=\"" + escapedName + "\" /> struct.");
             _out << nl << "public " << escapedName << "()";
             _out << sb;
             _out << eb;

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -396,6 +396,20 @@ Slice::IceRpc::TypesVisitor::visitDataMember(const DataMemberPtr& p)
     {
         _out << " { get; set; }";
     }
+
+    if (p->defaultValue())
+    {
+        string defaultValue = *p->defaultValue();
+        BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(p->type());
+
+        // Don't explicitly initialize to default value.
+        if (!builtin || builtin->kind() == Builtin::KindString || (defaultValue != "0" && defaultValue != "false"))
+        {
+            _out << " = ";
+            writeConstantValue(_out, p->type(), p->defaultValueType(), defaultValue, ns);
+            _out << ';';
+        }
+    }
 }
 
 void
@@ -825,6 +839,21 @@ Slice::IceRpc::TypesVisitor::visitOperation(const OperationPtr& p)
     _out << nl;
     writeMethodSignature(_out, p, ns, false);
     _out << ';';
+}
+
+void
+Slice::IceRpc::TypesVisitor::visitConst(const ConstPtr& p)
+{
+    _out << sp;
+    writeIceRpcHelperDocComment(_out, p, "Provides the " + p->mappedName() + " constant.", "helper class");
+    emitAttributes(p);
+    _out << nl << accessModifier(p) << " static class " << p->mappedName();
+    _out << sb;
+    writeIceRpcDocComment(_out, p);
+    _out << nl << accessModifier(p) << " const " << csFieldType(p->type(), "") << " Value = ";
+    writeConstantValue(_out, p->type(), p->valueType(), p->value(), getNamespace(p), "Value");
+    _out << ';';
+    _out << eb;
 }
 
 bool

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -406,7 +406,7 @@ Slice::IceRpc::TypesVisitor::visitDataMember(const DataMemberPtr& p)
         if (!builtin || builtin->kind() == Builtin::KindString || (defaultValue != "0" && defaultValue != "false"))
         {
             _out << " = ";
-            writeConstantValue(_out, p->type(), p->defaultValueType(), defaultValue, ns);
+            writeConstantValue(_out, p->type(), p->defaultValueType(), defaultValue, ns, "Value");
             _out << ';';
         }
     }

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -844,14 +844,16 @@ Slice::IceRpc::TypesVisitor::visitOperation(const OperationPtr& p)
 void
 Slice::IceRpc::TypesVisitor::visitConst(const ConstPtr& p)
 {
+    string ns = getNamespace(p);
+
     _out << sp;
     writeIceRpcHelperDocComment(_out, p, "Provides the " + p->mappedName() + " constant.", "helper class");
     emitAttributes(p);
     _out << nl << accessModifier(p) << " static class " << p->mappedName();
     _out << sb;
     writeIceRpcDocComment(_out, p);
-    _out << nl << accessModifier(p) << " const " << csFieldType(p->type(), "") << " Value = ";
-    writeConstantValue(_out, p->type(), p->valueType(), p->value(), getNamespace(p), "Value");
+    _out << nl << accessModifier(p) << " const " << csFieldType(p->type(), ns) << " Value = ";
+    writeConstantValue(_out, p->type(), p->valueType(), p->value(), ns, "Value");
     _out << ';';
     _out << eb;
 }

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -197,6 +197,22 @@ Slice::IceRpc::TypesVisitor::visitStructEnd(const StructPtr& p)
     string escapedName = p->mappedName();
     string ns = getNamespace(p);
 
+    // We need an explicit public parameterless constructor if the struct has any default values.
+    for (const auto& field : p->dataMembers())
+    {
+        if (field->defaultValue())
+        {
+            _out << sp;
+            writeDocLine(
+                _out,
+                "summary", "Initializes a new instance of the <see cref=\"" + escapedName + "\" /> struct.");
+            _out << nl << "public " << escapedName << "()";
+            _out << sb;
+            _out << eb;
+            break;
+        }
+    }
+
     bool hasRequiredField = writePrimaryConstructor(p, p->dataMembers(), {}, "struct");
 
     // Decoding constructor.

--- a/cpp/src/slice2cs/IceRpcVisitors.h
+++ b/cpp/src/slice2cs/IceRpcVisitors.h
@@ -9,7 +9,7 @@
 
 namespace Slice::IceRpc
 {
-    /// Generates code for Slice types (including proxies) and Slice exceptions.
+    /// Generates code for Slice types (including proxies), Slice exceptions, and Slice constants.
     class TypesVisitor final : public CsVisitor
     {
     public:
@@ -31,6 +31,8 @@ namespace Slice::IceRpc
         bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
         void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
         void visitOperation(const OperationPtr&) final;
+
+        void visitConst(const ConstPtr&) final;
 
     private:
         bool writePrimaryConstructor(

--- a/cpp/src/slice2cs/IceVisitors.cpp
+++ b/cpp/src/slice2cs/IceVisitors.cpp
@@ -1007,7 +1007,7 @@ Slice::Ice::TypesVisitor::visitConst(const ConstPtr& p)
     _out << sb;
     writeIceDocComment(_out, p);
     _out << nl << accessModifier(p) << " const " << typeToString(p->type(), "") << " value = ";
-    writeConstantValue(p->type(), p->valueType(), p->value());
+    writeConstantValue(_out, p->type(), p->valueType(), p->value(), getNamespace(p));
     _out << ";";
     _out << eb;
 }
@@ -1065,7 +1065,7 @@ Slice::Ice::TypesVisitor::visitDataMember(const DataMemberPtr& p)
         if (!builtin || builtin->kind() == Builtin::KindString || (defaultValue != "0" && defaultValue != "false"))
         {
             _out << " = ";
-            writeConstantValue(p->type(), p->defaultValueType(), defaultValue);
+            writeConstantValue(_out, p->type(), p->defaultValueType(), defaultValue, ns);
             addSemicolon = true;
         }
     }
@@ -1624,45 +1624,6 @@ Slice::Ice::TypesVisitor::visitOperation(const OperationPtr& p)
         _out << inParams << ("global::System.Collections.Generic.Dictionary<string, string>? " + context + " = null")
              << ("global::System.IProgress<bool>? " + progress + " = null")
              << ("global::System.Threading.CancellationToken " + cancel + " = default") << epar << ";";
-    }
-}
-
-void
-Slice::Ice::TypesVisitor::writeConstantValue(
-    const TypePtr& type,
-    const SyntaxTreeBasePtr& valueType,
-    const string& value)
-{
-    ConstPtr constant = dynamic_pointer_cast<Const>(valueType);
-    if (constant)
-    {
-        _out << constant->mappedScoped(".") << ".value";
-    }
-    else
-    {
-        BuiltinPtr bp = dynamic_pointer_cast<Builtin>(type);
-        if (bp && bp->kind() == Builtin::KindString)
-        {
-            _out << "\"" << toStringLiteral(value, "\a\b\f\n\r\t\v\0", "", UCN, 0) << "\"";
-        }
-        else if (bp && bp->kind() == Builtin::KindLong)
-        {
-            _out << value << "L";
-        }
-        else if (bp && bp->kind() == Builtin::KindFloat)
-        {
-            _out << value << "F";
-        }
-        else if (dynamic_pointer_cast<Enum>(type))
-        {
-            EnumeratorPtr lte = dynamic_pointer_cast<Enumerator>(valueType);
-            assert(lte);
-            _out << lte->mappedScoped(".");
-        }
-        else
-        {
-            _out << value;
-        }
     }
 }
 

--- a/cpp/src/slice2cs/IceVisitors.h
+++ b/cpp/src/slice2cs/IceVisitors.h
@@ -33,7 +33,6 @@ namespace Slice::Ice
         void visitOperation(const OperationPtr&) final;
 
     private:
-        void writeConstantValue(const TypePtr&, const SyntaxTreeBasePtr&, const std::string&);
         void writeMarshalDataMember(const DataMemberPtr&, const std::string&, const std::string&, bool = false);
         void writeUnmarshalDataMember(const DataMemberPtr&, const std::string&, const std::string&, bool = false);
         void writeMarshaling(const ClassDefPtr&);

--- a/csharp/test/Ice/defaultValue/Test.ice
+++ b/csharp/test/Ice/defaultValue/Test.ice
@@ -48,7 +48,9 @@ module Test
         double zeroDotD = 0;
     }
 
+    /// My bool constant.
     const bool ConstBool = true;
+
     const byte ConstByte = 254;
     const short ConstShort = 16000;
     const int ConstInt = 3;

--- a/csharp/test/Ice/defaultValue/Test.ice
+++ b/csharp/test/Ice/defaultValue/Test.ice
@@ -69,7 +69,7 @@ module Test
     const float ConstZeroF = 0;
     const float ConstZeroDotF = 0.0;
     const double ConstZeroD = 0;
-    const double ConstZeroDotD = 0;
+    const double ConstZeroDotD = 0.0;
 
     struct Struct2
     {

--- a/csharp/test/Ice/defaultValue/Test.ice
+++ b/csharp/test/Ice/defaultValue/Test.ice
@@ -45,7 +45,7 @@ module Test
         float zeroF = 0;
         float zeroDotF = 0.0;
         double zeroD = 0;
-        double zeroDotD = 0;
+        double zeroDotD = 0.0;
     }
 
     /// My bool constant.
@@ -205,7 +205,7 @@ module Test
         float zeroF = 0;
         float zeroDotF = 0.0;
         double zeroD = 0;
-        double zeroDotD = 0;
+        double zeroDotD = 0.0;
     }
 
     exception DerivedEx extends BaseEx
@@ -237,7 +237,7 @@ module Test
         float zeroF = 0;
         float zeroDotF = 0.0;
         double zeroD = 0;
-        double zeroDotD = 0;
+        double zeroDotD = 0.0;
     }
 
     ["cs:property"]
@@ -258,7 +258,7 @@ module Test
         float zeroF = 0;
         float zeroDotF = 0.0;
         double zeroD = 0;
-        double zeroDotD = 0;
+        double zeroDotD = 0.0;
     }
 
     ["cs:property"]
@@ -279,7 +279,7 @@ module Test
         float zeroF = 0;
         float zeroDotF = 0.0;
         double zeroD = 0;
-        double zeroDotD = 0;
+        double zeroDotD = 0.0;
     }
 
     sequence<byte> ByteSeq;


### PR DESCRIPTION
Previously, we did not generate any code for constants and default values with the --icerpc option.