### PR TITLE
Properly Handle `@p` Tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ might need to be aware of.
 
 - [Changes in Ice 3.9.0](#changes-in-ice-390)
   - [General Changes](#general-changes)
-  - [Slice Language Changes](#slice-language-changes)
 
 ## Changes in Ice 3.9.0
 
@@ -18,7 +17,3 @@ These are the changes since the [Ice 3.8.1] release.
 - Removed the 'ice2slice' compiler
 
 [Ice 3.8.1]: https://github.com/zeroc-ice/ice/blob/3.8/CHANGELOG-3.8.md
-
-### Slice Language Changes
-
-- Removed support for using `@p` tags in doc-comments to reference out parameters.

--- a/cpp/src/Slice/DocCommentParser.cpp
+++ b/cpp/src/Slice/DocCommentParser.cpp
@@ -60,9 +60,9 @@ DocCommentFormatter::formatCode(const string& rawText)
 }
 
 string
-DocCommentFormatter::formatParamRef(const string& param)
+DocCommentFormatter::formatParamRef(const string& paramName, const ParameterPtr&)
 {
-    return formatCode(param);
+    return formatCode(paramName);
 }
 
 string
@@ -397,19 +397,19 @@ namespace
         // Extract the parameter's name and check if matches an operation parameter.
         // If it does, make sure to use the mapped name instead of the Slice name.
         string parameterName = line.substr(nameStart, nameEnd - nameStart);
+        ParameterPtr parameterPtr = nullptr;
         if (auto operationTarget = dynamic_pointer_cast<Operation>(p))
         {
-            bool doesParameterExist = false;
             for (const auto& param : operationTarget->parameters())
             {
                 if (param->name() == parameterName)
                 {
                     parameterName = param->mappedName();
-                    doesParameterExist = true;
+                    parameterPtr = param;
                     break;
                 }
             }
-            if (!doesParameterExist)
+            if (parameterPtr == nullptr)
             {
                 string opName = operationTarget->name();
                 string msg = "No parameter named '" + parameterName + "' exists on operation '" + opName + "'";
@@ -422,7 +422,7 @@ namespace
         }
 
         // Format the parameter's name and insert it in-place of the original '@p name'.
-        const string formattedParamName = formatter.formatParamRef(parameterName);
+        const string formattedParamName = formatter.formatParamRef(parameterName, parameterPtr);
         line.erase(pos, nameEnd - pos);
         line.insert(pos, formattedParamName);
 

--- a/cpp/src/Slice/DocCommentParser.cpp
+++ b/cpp/src/Slice/DocCommentParser.cpp
@@ -404,15 +404,7 @@ namespace
             {
                 if (param->name() == parameterName)
                 {
-                    if (param->isOutParam())
-                    {
-                        string msg = "'out' parameters cannot be referenced with '@p' tags";
-                        p->unit()->warning(p->file(), p->line(), InvalidComment, msg);
-                    }
-                    else
-                    {
-                        parameterName = param->mappedName();
-                    }
+                    parameterName = param->mappedName();
                     doesParameterExist = true;
                     break;
                 }

--- a/cpp/src/Slice/DocCommentParser.h
+++ b/cpp/src/Slice/DocCommentParser.h
@@ -27,12 +27,13 @@ namespace Slice
         [[nodiscard]] virtual std::string formatCode(const std::string& rawText);
 
         /// This function is called by the doc-comment parser to map '@p' tags into each language's syntax.
-        /// @param param The mapped name of the parameter that is being referenced.
+        /// @param paramName The mapped name of the parameter that is being referenced.
+        /// @param paramPtr A pointer to the parameter object that is being referenced.
         /// @return A properly formatted parameters reference in the target language. The doc-comment parser will
         /// replace the entire "@p <rawParamName>" string with the returned value.
         //
         // By default we just emit the parameter's name in code formatting.
-        [[nodiscard]] virtual std::string formatParamRef(const std::string& param);
+        [[nodiscard]] virtual std::string formatParamRef(const std::string& paramName, const ParameterPtr& paramPtr);
 
         /// This function is called by the doc-comment parser to map doc-links ('{@link <rawLink>}') into each
         /// language's syntax.

--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -25,7 +25,7 @@ namespace
 
 class CppDocCommentFormatter final : public DocCommentFormatter
 {
-    string formatParamRef(const string& param) final { return "@p " + param; }
+    string formatParamRef(const string& paramName, const ParameterPtr&) final { return "@p " + paramName; }
 
     string formatLink(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target) final
     {

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -238,9 +238,16 @@ Slice::Csharp::CsharpDocCommentFormatter::formatCode(const string& rawText)
 }
 
 string
-Slice::Csharp::CsharpDocCommentFormatter::formatParamRef(const string& param)
+Slice::Csharp::CsharpDocCommentFormatter::formatParamRef(const string& paramName, const ParameterPtr& paramPtr)
 {
-    return "<paramref name=\"" + param + "\" />";
+    if (paramPtr->isOutParam())
+    {
+        return formatCode(paramName);
+    }
+    else
+    {
+        return "<paramref name=\"" + paramName + "\" />";
+    }
 }
 
 string

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -240,7 +240,7 @@ Slice::Csharp::CsharpDocCommentFormatter::formatCode(const string& rawText)
 string
 Slice::Csharp::CsharpDocCommentFormatter::formatParamRef(const string& paramName, const ParameterPtr& paramPtr)
 {
-    if (paramPtr->isOutParam())
+    if (paramPtr && paramPtr->isOutParam())
     {
         return formatCode(paramName);
     }

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -69,7 +69,7 @@ namespace Slice::Csharp
 
         void preprocess(StringList& rawComment) final;
         std::string formatCode(const std::string& rawText) final;
-        std::string formatParamRef(const std::string& param) final;
+        std::string formatParamRef(const std::string& paramName, const ParameterPtr& paramPtr) final;
 
         std::string
         formatLink(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target) final;

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.err
@@ -19,10 +19,10 @@ WarningInvalidComment.ice:47: warning: '@param NoParam' does not correspond to a
 WarningInvalidComment.ice:47: warning: '@return' is only valid on operations with non-void return types
 WarningInvalidComment.ice:47: warning: '@throws FakeException': no exception with this name could be found from the current scope
 WarningInvalidComment.ice:47: warning: '@throws CommentDummy': this exception is not listed in the exception specification of 'voidOp'
-WarningInvalidComment.ice:58: warning: missing parameter name after '@p' tag
-WarningInvalidComment.ice:58: warning: ignoring duplicate doc-comment tag: '@param value'
-WarningInvalidComment.ice:58: warning: '@param namess' does not correspond to any parameter in operation 'stringOp'
-WarningInvalidComment.ice:58: warning: ignoring duplicate doc-comment tag: '@return'
-WarningInvalidComment.ice:58: warning: '@throws DerivedFromDummy': this exception is not listed in the exception specification of 'stringOp'
-WarningInvalidComment.ice:58: warning: '@throws SomeOtherException': this exception is not listed in the exception specification of 'stringOp'
-WarningInvalidComment.ice:58: warning: ignoring duplicate doc-comment tag: '@throws CommentDummy'
+WarningInvalidComment.ice:59: warning: missing parameter name after '@p' tag
+WarningInvalidComment.ice:59: warning: ignoring duplicate doc-comment tag: '@param value'
+WarningInvalidComment.ice:59: warning: '@param namess' does not correspond to any parameter in operation 'stringOp'
+WarningInvalidComment.ice:59: warning: ignoring duplicate doc-comment tag: '@return'
+WarningInvalidComment.ice:59: warning: '@throws DerivedFromDummy': this exception is not listed in the exception specification of 'stringOp'
+WarningInvalidComment.ice:59: warning: '@throws SomeOtherException': this exception is not listed in the exception specification of 'stringOp'
+WarningInvalidComment.ice:59: warning: ignoring duplicate doc-comment tag: '@throws CommentDummy'

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.err
@@ -19,11 +19,10 @@ WarningInvalidComment.ice:47: warning: '@param NoParam' does not correspond to a
 WarningInvalidComment.ice:47: warning: '@return' is only valid on operations with non-void return types
 WarningInvalidComment.ice:47: warning: '@throws FakeException': no exception with this name could be found from the current scope
 WarningInvalidComment.ice:47: warning: '@throws CommentDummy': this exception is not listed in the exception specification of 'voidOp'
-WarningInvalidComment.ice:59: warning: 'out' parameters cannot be referenced with '@p' tags
-WarningInvalidComment.ice:59: warning: missing parameter name after '@p' tag
-WarningInvalidComment.ice:59: warning: ignoring duplicate doc-comment tag: '@param value'
-WarningInvalidComment.ice:59: warning: '@param namess' does not correspond to any parameter in operation 'stringOp'
-WarningInvalidComment.ice:59: warning: ignoring duplicate doc-comment tag: '@return'
-WarningInvalidComment.ice:59: warning: '@throws DerivedFromDummy': this exception is not listed in the exception specification of 'stringOp'
-WarningInvalidComment.ice:59: warning: '@throws SomeOtherException': this exception is not listed in the exception specification of 'stringOp'
-WarningInvalidComment.ice:59: warning: ignoring duplicate doc-comment tag: '@throws CommentDummy'
+WarningInvalidComment.ice:58: warning: missing parameter name after '@p' tag
+WarningInvalidComment.ice:58: warning: ignoring duplicate doc-comment tag: '@param value'
+WarningInvalidComment.ice:58: warning: '@param namess' does not correspond to any parameter in operation 'stringOp'
+WarningInvalidComment.ice:58: warning: ignoring duplicate doc-comment tag: '@return'
+WarningInvalidComment.ice:58: warning: '@throws DerivedFromDummy': this exception is not listed in the exception specification of 'stringOp'
+WarningInvalidComment.ice:58: warning: '@throws SomeOtherException': this exception is not listed in the exception specification of 'stringOp'
+WarningInvalidComment.ice:58: warning: ignoring duplicate doc-comment tag: '@throws CommentDummy'

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.ice
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.ice
@@ -46,8 +46,9 @@ module Test
         /// @throws CommentDummy should give a not-thrown-by-this-operation warning.
         void voidOp();
 
-        /// @param value no warning, because this ia a real parameter. @p
-        /// @param value should give a duplicate-tag warning. But This is fine: @p value.
+        /// We disallow linking to out parameters like @p myOut
+        /// @param value no warning, because this is a real parameter. @p
+        /// @param value should give a duplicate-tag warning. But this is fine: @p value.
         /// @param namess should give a no-matching-parameter warning.
         /// @return Something because it's non-void.
         /// @return Should give a duplicate-tag warning.
@@ -55,6 +56,6 @@ module Test
         /// @throws CommentDummy should be fine, this matches the exception specification.
         /// @throws SomeOtherException should give a not-thrown-by-this-operation warning.
         /// @throws CommentDummy should give a duplicate-tag warning.
-        string stringOp(string name, int value) throws CommentDummy;
+        string stringOp(string name, int value, out byte myOut) throws CommentDummy;
     }
 }

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.ice
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.ice
@@ -46,9 +46,8 @@ module Test
         /// @throws CommentDummy should give a not-thrown-by-this-operation warning.
         void voidOp();
 
-        /// We disallow linking to out parameters like @p myOut
-        /// @param value no warning, because this is a real parameter. @p
-        /// @param value should give a duplicate-tag warning. But this is fine: @p value.
+        /// @param value no warning, because this ia a real parameter. @p
+        /// @param value should give a duplicate-tag warning. But This is fine: @p value.
         /// @param namess should give a no-matching-parameter warning.
         /// @return Something because it's non-void.
         /// @return Should give a duplicate-tag warning.
@@ -56,6 +55,6 @@ module Test
         /// @throws CommentDummy should be fine, this matches the exception specification.
         /// @throws SomeOtherException should give a not-thrown-by-this-operation warning.
         /// @throws CommentDummy should give a duplicate-tag warning.
-        string stringOp(string name, int value, out byte myOut) throws CommentDummy;
+        string stringOp(string name, int value) throws CommentDummy;
     }
 }

--- a/slice/Ice/Metrics.ice
+++ b/slice/Ice/Metrics.ice
@@ -92,7 +92,7 @@ module IceMX
         /// @param view The name of the metrics view.
         /// @param timestamp The local time of the process when the metrics objects were retrieved.
         /// @return The metrics view data, a dictionary of metric maps for each metrics class configured with the view.
-        /// The `timestamp` allows the client to compute averages which are not dependent of the invocation latency for
+        /// The @p timestamp allows the client to compute averages which are not dependent of the invocation latency for
         /// this operation.
         /// @throws UnknownMetricsView Thrown when the metrics view cannot be found.
         ["format:sliced"]

--- a/slice/Ice/Metrics.ice
+++ b/slice/Ice/Metrics.ice
@@ -92,7 +92,7 @@ module IceMX
         /// @param view The name of the metrics view.
         /// @param timestamp The local time of the process when the metrics objects were retrieved.
         /// @return The metrics view data, a dictionary of metric maps for each metrics class configured with the view.
-        /// The @p timestamp allows the client to compute averages which are not dependent of the invocation latency for
+        /// The @p timestamp allows the client to compute averages which are not dependent on the invocation latency for
         /// this operation.
         /// @throws UnknownMetricsView Thrown when the metrics view cannot be found.
         ["format:sliced"]

--- a/slice/Ice/Router.ice
+++ b/slice/Ice/Router.ice
@@ -21,7 +21,7 @@ module Ice
         /// router. If a null proxy is returned, the client will forward requests to the router's endpoints.
         /// @param hasRoutingTable Indicates whether or not the router supports a routing table. If `true`, the Ice
         /// runtime will call {@link addProxies} to populate the routing table. The Ice runtime assumes the router has
-        /// a routing table when `hasRoutingTable` is not set.
+        /// a routing table when @p hasRoutingTable is not set.
         /// @return The router's client proxy.
         /// @remark Introduced in Ice 3.7.
         ["cpp:const"]


### PR DESCRIPTION
#5280 flat-out disallowed `@p` to reference out parameters, but this is overly restrictive.
Instead, this PR reverts #5280, and modifies each language to properly handle `@p` on out tags in their own way.

For C++, this means keeping `@p` tags as-is. For every other language, it's mapped to use code-formatting instead,