### PR TITLE
Generate cs:attribute on the constant field, not the wrapper class 

### DIFF
--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -865,10 +865,10 @@ Slice::IceRpc::TypesVisitor::visitConst(const ConstPtr& p)
 
     _out << sp;
     writeIceRpcHelperDocComment(_out, p, "Provides the " + p->mappedName() + " constant.", "helper class");
-    emitAttributes(p);
     _out << nl << accessModifier(p) << " static class " << p->mappedName();
     _out << sb;
     writeIceRpcDocComment(_out, p);
+    emitAttributes(p);
     _out << nl << accessModifier(p) << " const " << csFieldType(p->type(), ns) << " Value = ";
     writeConstantValue(_out, p->type(), p->valueType(), p->value(), ns, "Value");
     _out << ';';

--- a/cpp/src/slice2cs/IceVisitors.cpp
+++ b/cpp/src/slice2cs/IceVisitors.cpp
@@ -1002,10 +1002,10 @@ Slice::Ice::TypesVisitor::visitConst(const ConstPtr& p)
 {
     _out << sp;
     writeIceHelperDocComment(_out, p, "Provides the " + p->mappedName() + " constant.", "helper class");
-    emitAttributes(p);
     _out << nl << accessModifier(p) << " abstract class " << p->mappedName();
     _out << sb;
     writeIceDocComment(_out, p);
+    emitAttributes(p);
     _out << nl << accessModifier(p) << " const " << typeToString(p->type(), "") << " value = ";
     writeConstantValue(_out, p->type(), p->valueType(), p->value(), getNamespace(p));
     _out << ";";


### PR DESCRIPTION
Fix #5288