### PR TITLE
Cleanup of checkTwowayOnly

### DIFF
--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -6,7 +6,6 @@ using Ice.Internal;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 
-
 namespace Ice;
 
 /// <summary>

--- a/csharp/src/Ice/Proxy.cs
+++ b/csharp/src/Ice/Proxy.cs
@@ -6,6 +6,7 @@ using Ice.Internal;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 
+
 namespace Ice;
 
 /// <summary>
@@ -605,7 +606,6 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
         OutgoingAsyncCompletionCallback completed,
         bool synchronous)
     {
-        iceCheckAsyncTwowayOnly(_ice_isA_name);
         getOutgoingAsync<bool>(completed).invoke(
             _ice_isA_name,
             OperationMode.Idempotent,
@@ -721,7 +721,6 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
         OutgoingAsyncCompletionCallback completed,
         bool synchronous)
     {
-        iceCheckAsyncTwowayOnly(_ice_ids_name);
         getOutgoingAsync<string[]>(completed).invoke(
             _ice_ids_name,
             OperationMode.Idempotent,
@@ -1512,20 +1511,6 @@ public abstract class ObjectPrxHelperBase : ObjectPrx
         if (!ice_isTwoway())
         {
             throw new TwowayOnlyException(name);
-        }
-    }
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public void iceCheckAsyncTwowayOnly(string name)
-    {
-        //
-        // No mutex lock necessary, there is nothing mutable in this
-        // operation.
-        //
-
-        if (!ice_isTwoway())
-        {
-            throw new ArgumentException("`" + name + "' can only be called with a twoway proxy");
         }
     }
 

--- a/js/packages/ice/src/Ice/ObjectPrxExtensions.js
+++ b/js/packages/ice/src/Ice/ObjectPrxExtensions.js
@@ -302,7 +302,7 @@ ObjectPrx.prototype._getReference = function () {
     return this._reference;
 };
 
-ObjectPrx.prototype._checkAsyncTwowayOnly = function (name) {
+ObjectPrx.prototype._checkTwowayOnly = function (name) {
     if (!this.ice_isTwoway()) {
         throw new TwowayOnlyException(name);
     }
@@ -349,7 +349,7 @@ ObjectPrx.prototype.ice_instanceof = function (T) {
 //
 ObjectPrx._invoke = function (p, name, mode, fmt, ctx, marshalFn, unmarshalFn, userEx, args) {
     if (unmarshalFn !== null || userEx.length > 0) {
-        p._checkAsyncTwowayOnly(name);
+        p._checkTwowayOnly(name);
     }
 
     const r = new OutgoingAsync(p, name, res => {


### PR DESCRIPTION
- Remove iceCheckAsyncTwowayOnly in C#
- Rename _checkAsyncTwowayOnly to _checkTwowayOnly
  in JavaScript ObjectPrx

Fixes #5293
