### PR TITLE
Reject Tags Greater than 30 Which are Encoded on a Single Byte

### DIFF
--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -1144,6 +1144,7 @@ Ice::InputStream::readOptImpl(int32_t readTag, OptionalFormat expectedFormat)
         auto tag = static_cast<int32_t>(v >> 3);
         if (tag > 30)
         {
+            // We check for '> 30' instead of '> 29' because 30 is special sentinel tag, handled by the next block.
             ostringstream os;
             os << "invalid tag '" << tag << "': tags larger than 29 must be encoded as a size";
             throw MarshalException(__FILE__, __LINE__, os.str());

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -1142,6 +1142,12 @@ Ice::InputStream::readOptImpl(int32_t readTag, OptionalFormat expectedFormat)
 
         auto format = static_cast<OptionalFormat>(v & 0x07); // First 3 bits.
         auto tag = static_cast<int32_t>(v >> 3);
+        if (tag > 30)
+        {
+            ostringstream os;
+            os << "invalid tag '" << tag << "': tags larger than 29 must be encoded as a size";
+            throw MarshalException(__FILE__, __LINE__, os.str());
+        }
         if (tag == 30)
         {
             tag = readSize();

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -1555,7 +1555,7 @@ public sealed class InputStream
         }
         catch (ArgumentException ex)
         {
-            throw new MarshalException("Invalid UTF8 string", ex);
+            throw new MarshalException("Invalid UTF8 string.", ex);
         }
     }
 
@@ -1859,7 +1859,8 @@ public sealed class InputStream
             int tag = v >> 3;
             if (tag > 30)
             {
-                throw new MarshalException($"invalid tag '{tag}': tags larger than 29 must be encoded as a size");
+                // We check for '> 30' instead of '> 29' because 30 is special sentinel tag, handled by the next block.
+                throw new MarshalException($"Invalid tag '{tag}': tags larger than 29 must be encoded as a size.");
             }
             if (tag == 30)
             {
@@ -1880,7 +1881,7 @@ public sealed class InputStream
             {
                 if (format != expectedFormat)
                 {
-                    throw new MarshalException($"invalid optional data member '{tag}': unexpected format");
+                    throw new MarshalException($"Invalid optional tag '{tag}': unexpected format.");
                 }
                 return true;
             }
@@ -1928,7 +1929,7 @@ public sealed class InputStream
             }
             case OptionalFormat.Class:
             {
-                throw new MarshalException("cannot skip an optional class");
+                throw new MarshalException("Cannot skip an optional class.");
             }
         }
     }
@@ -2169,7 +2170,7 @@ public sealed class InputStream
             int index = _stream.readInt();
             if (index > 0)
             {
-                throw new MarshalException("invalid object id");
+                throw new MarshalException("Invalid object id.");
             }
             index = -index;
 
@@ -2237,7 +2238,7 @@ public sealed class InputStream
                     // An oversight in the 1.0 encoding means there is no marker to indicate
                     // the last slice of an exception. As a result, we just try to read the
                     // next type ID, which raises MarshalException when the input buffer underflows.
-                    throw new MarshalException($"unknown exception type '{mostDerivedId}'");
+                    throw new MarshalException($"Unknown exception type '{mostDerivedId}'.");
                 }
             }
         }
@@ -2259,7 +2260,7 @@ public sealed class InputStream
                 int sz = _stream.readSize(); // For compatibility with the old AFM.
                 if (sz != 0)
                 {
-                    throw new MarshalException("invalid Object slice");
+                    throw new MarshalException("Invalid Object slice.");
                 }
                 endSlice();
             }
@@ -2346,7 +2347,7 @@ public sealed class InputStream
                 // If any entries remain in the patch map, the sender has sent an index for an instance, but failed
                 // to supply the instance.
                 //
-                throw new MarshalException("index for class received, but no instance");
+                throw new MarshalException("Index for class received, but no instance.");
             }
         }
 
@@ -2356,7 +2357,7 @@ public sealed class InputStream
 
             if (index <= 0)
             {
-                throw new MarshalException("invalid object id");
+                throw new MarshalException("Invalid object id.");
             }
 
             _sliceType = SliceType.ValueSlice;
@@ -2415,7 +2416,7 @@ public sealed class InputStream
 
             if (++_classGraphDepth > _classGraphDepthMax)
             {
-                throw new MarshalException("maximum class graph depth reached");
+                throw new MarshalException("Maximum class graph depth reached.");
             }
 
             //
@@ -2447,7 +2448,7 @@ public sealed class InputStream
             int index = _stream.readSize();
             if (index < 0)
             {
-                throw new MarshalException("invalid object id");
+                throw new MarshalException("Invalid object id.");
             }
             else if (index == 0)
             {
@@ -2509,7 +2510,7 @@ public sealed class InputStream
 
                 if ((_current.sliceFlags & Protocol.FLAG_IS_LAST_SLICE) != 0)
                 {
-                    throw new MarshalException($"Cannot unmarshal exception with type ID '{mostDerivedId}'");
+                    throw new MarshalException($"Cannot unmarshal exception with type ID '{mostDerivedId}'.");
                 }
 
                 startSlice();
@@ -2628,12 +2629,12 @@ public sealed class InputStream
                 //
                 if (indirectionTable.Length == 0)
                 {
-                    throw new MarshalException("empty indirection table");
+                    throw new MarshalException("Empty indirection table.");
                 }
                 if ((_current.indirectPatchList == null || _current.indirectPatchList.Count == 0) &&
                    (_current.sliceFlags & Protocol.FLAG_HAS_OPTIONAL_MEMBERS) == 0)
                 {
-                    throw new MarshalException("no references to indirection table");
+                    throw new MarshalException("No references to indirection table.");
                 }
 
                 //
@@ -2646,7 +2647,7 @@ public sealed class InputStream
                         Debug.Assert(e.index >= 0);
                         if (e.index >= indirectionTable.Length)
                         {
-                            throw new MarshalException("indirection out of range");
+                            throw new MarshalException("Indirection out of range.");
                         }
                         addPatchEntry(indirectionTable[e.index], e.patcher);
                     }
@@ -2830,7 +2831,7 @@ public sealed class InputStream
 
             if (++_classGraphDepth > _classGraphDepthMax)
             {
-                throw new MarshalException("maximum class graph depth reached");
+                throw new MarshalException("Maximum class graph depth reached.");
             }
 
             //
@@ -2846,7 +2847,7 @@ public sealed class InputStream
                 // If any entries remain in the patch map, the sender has sent an index for an instance, but failed
                 // to supply the instance.
                 //
-                throw new MarshalException("index for class received, but no instance");
+                throw new MarshalException("Index for class received, but no instance.");
             }
 
             cb?.Invoke(v);

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -1857,6 +1857,10 @@ public sealed class InputStream
 
             var format = (OptionalFormat)(v & 0x07); // First 3 bits.
             int tag = v >> 3;
+            if (tag > 30)
+            {
+                throw new MarshalException($"invalid tag '{tag}': tags larger than 29 must be encoded as a size");
+            }
             if (tag == 30)
             {
                 tag = readSize();
@@ -1876,7 +1880,7 @@ public sealed class InputStream
             {
                 if (format != expectedFormat)
                 {
-                    throw new MarshalException("invalid optional data member `" + tag + "': unexpected format");
+                    throw new MarshalException($"invalid optional data member '{tag}': unexpected format");
                 }
                 return true;
             }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -1327,6 +1327,10 @@ public final class InputStream {
 
             OptionalFormat format = OptionalFormat.valueOf(v & 0x07); // First 3 bits.
             int tag = v >> 3;
+            if (tag > 30)
+            {
+                throw new MarshalException("invalid tag '" + tag + "': tags larger than 29 must be encoded as a size");
+            }
             if (tag == 30) {
                 tag = readSize();
             }
@@ -1339,7 +1343,7 @@ public final class InputStream {
                 skipOptional(format); // Skip optional data members
             } else {
                 if (format != expectedFormat) {
-                    throw new MarshalException("invalid optional data member `" + tag + "': unexpected format");
+                    throw new MarshalException("invalid optional data member '" + tag + "': unexpected format");
                 }
                 return true;
             }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -1328,6 +1328,7 @@ public final class InputStream {
             OptionalFormat format = OptionalFormat.valueOf(v & 0x07); // First 3 bits.
             int tag = v >> 3;
             if (tag > 30) {
+                // We check for '> 30' instead of '> 29' because 30 is special sentinel tag, handled by the next block.
                 throw new MarshalException("invalid tag '" + tag + "': tags larger than 29 must be encoded as a size");
             }
             if (tag == 30) {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -1327,8 +1327,7 @@ public final class InputStream {
 
             OptionalFormat format = OptionalFormat.valueOf(v & 0x07); // First 3 bits.
             int tag = v >> 3;
-            if (tag > 30)
-            {
+            if (tag > 30) {
                 throw new MarshalException("invalid tag '" + tag + "': tags larger than 29 must be encoded as a size");
             }
             if (tag == 30) {

--- a/js/packages/ice/src/Ice/InputStream.js
+++ b/js/packages/ice/src/Ice/InputStream.js
@@ -1411,8 +1411,7 @@ export class InputStream {
 
             const format = OptionalFormat.valueOf(v & 0x07); // First 3 bits.
             let tag = v >> 3;
-            if (tag > 30)
-            {
+            if (tag > 30) {
                 throw new MarshalException(`invalid tag '${tag}': tags larger than 29 must be encoded as a size`);
             }
             if (tag === 30) {

--- a/js/packages/ice/src/Ice/InputStream.js
+++ b/js/packages/ice/src/Ice/InputStream.js
@@ -1412,6 +1412,7 @@ export class InputStream {
             const format = OptionalFormat.valueOf(v & 0x07); // First 3 bits.
             let tag = v >> 3;
             if (tag > 30) {
+                // We check for '> 30' instead of '> 29' because 30 is special sentinel tag, handled by the next block.
                 throw new MarshalException(`invalid tag '${tag}': tags larger than 29 must be encoded as a size`);
             }
             if (tag === 30) {

--- a/js/packages/ice/src/Ice/InputStream.js
+++ b/js/packages/ice/src/Ice/InputStream.js
@@ -1411,6 +1411,10 @@ export class InputStream {
 
             const format = OptionalFormat.valueOf(v & 0x07); // First 3 bits.
             let tag = v >> 3;
+            if (tag > 30)
+            {
+                throw new MarshalException(`invalid tag '${tag}': tags larger than 29 must be encoded as a size`);
+            }
             if (tag === 30) {
                 tag = this.readSize();
             }

--- a/matlab/lib/+Ice/InputStream.m
+++ b/matlab/lib/+Ice/InputStream.m
@@ -566,6 +566,7 @@ classdef InputStream < handle
                     format = bitand(v, uint8(7)); % First 3 bits.
                     tag = uint32(bitshift(v, -3));
                     if tag > 30
+                        % We check for '> 30' instead of '> 29' because 30 is special sentinel tag, handled by the next block.
                         throw(Ice.MarshalException(...
                             sprintf('invalid tag ''%d'': tags larger than 29 must be encoded as a size', tag)));
                     end

--- a/matlab/lib/+Ice/InputStream.m
+++ b/matlab/lib/+Ice/InputStream.m
@@ -565,6 +565,10 @@ classdef InputStream < handle
 
                     format = bitand(v, uint8(7)); % First 3 bits.
                     tag = uint32(bitshift(v, -3));
+                    if tag > 30
+                        throw(Ice.MarshalException(...
+                            sprintf('invalid tag ''%d'': tags larger than 29 must be encoded as a size', tag)));
+                    end
                     if tag == 30
                         tag = obj.readSize();
                     end

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -639,6 +639,7 @@ extension InputStream {
             }
             var tag = Int32(v >> 3)
             if tag > 30 {
+                // We check for '> 30' instead of '> 29' because 30 is special sentinel tag, handled by the next block.
                 throw MarshalException("invalid tag '\(tag)': tags larger than 29 must be encoded as a size")
             }
             if tag == 30 {

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -638,6 +638,9 @@ extension InputStream {
                 throw MarshalException("invalid optional format")
             }
             var tag = Int32(v >> 3)
+            if tag > 30 {
+                throw MarshalException("invalid tag '\(tag)': tags larger than 29 must be encoded as a size")
+            }
             if tag == 30 {
                 tag = try readSize()
             }
@@ -650,8 +653,7 @@ extension InputStream {
                 try skipOptional(format: format)  // Skip optional fields
             } else {
                 if format != expectedFormat {
-                    throw MarshalException(
-                        "invalid optional field `\(tag)': unexpected format")
+                    throw MarshalException("invalid optional field '\(tag)': unexpected format")
                 }
                 return true
             }


### PR DESCRIPTION
This PR fixes #5259.

This is how we encode tags in all languages:
 - If a tag is less than 30, we encode it on a single byte,
 - Else we write `0xF0` ('30'), then encode the tag as a size.

But on the decoding side, we have a gap in our logic.
We check if the tag is `30`, and if so, we decode a size. Otherwise we decode the tag as a single byte.
The tag data is sent on 5 bits, so it's possible values are between `0` and `31` (inclusive).
Hence: the decoder is ignoring the case when it receives `31`.

Receiving a tag value of `31` encoded on a single byte is a malformed tag, and we should reject it (what this PR does).
Right now, decoding such a value puts the decoder into various invalid states depending on what tags it was expecting to find.