### PR TITLE
Backport slice2cs --icerpc feature from main

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -19,6 +19,7 @@
         "icegrid",
         "icegridadmin",
         "icegridnode",
+        "icerpc",
         "icestorm",
         "istr",
         "jgoodies",

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -2738,8 +2738,9 @@ Slice::InterfaceDef::createOperation(
                 break;
             }
         }
-        // Check the operations of the Object pseudo-interface.
-        if (!checkBaseOperationNames(name, {"ice_id", "ice_ids", "ice_ping", "ice_isA"}))
+
+        // Check the operations of the Object pseudo-interface unless we're generating code for Object itself.
+        if (scoped() != "::Ice::Object" && !checkBaseOperationNames(name, {"ice_id", "ice_ids", "ice_ping", "ice_isA"}))
         {
             hasConflictingIdentifier = true;
         }
@@ -2828,6 +2829,24 @@ Slice::InterfaceDef::operations() const
 OperationList
 Slice::InterfaceDef::allOperations() const
 {
+    OperationList result = allInheritedOperations();
+
+    for (const auto& q : operations())
+    {
+        if (none_of(
+                result.begin(),
+                result.end(),
+                [name = q->name()](const auto& other) { return other->name() == name; }))
+        {
+            result.push_back(q);
+        }
+    }
+    return result;
+}
+
+OperationList
+Slice::InterfaceDef::allInheritedOperations() const
+{
     OperationList result;
     for (const auto& p : _bases)
     {
@@ -2840,17 +2859,6 @@ Slice::InterfaceDef::allOperations() const
             {
                 result.push_back(q);
             }
-        }
-    }
-
-    for (const auto& q : operations())
-    {
-        if (none_of(
-                result.begin(),
-                result.end(),
-                [name = q->name()](const auto& other) { return other->name() == name; }))
-        {
-            result.push_back(q);
         }
     }
     return result;

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -792,6 +792,7 @@ namespace Slice
         [[nodiscard]] InterfaceList allBases() const;
         [[nodiscard]] OperationList operations() const;
         [[nodiscard]] OperationList allOperations() const;
+        [[nodiscard]] OperationList allInheritedOperations() const;
         [[nodiscard]] std::string kindOf() const final;
         void visit(ParserVisitor* visitor) final;
 

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -34,12 +34,12 @@ Slice::Csharp::getNamespace(const ContainedPtr& p)
 }
 
 string
-Slice::Csharp::getUnqualified(const ContainedPtr& p, const string& ns, const string& prefix)
+Slice::Csharp::getUnqualified(const ContainedPtr& p, const string& ns, const string& prefix, const string& suffix)
 {
     string name = p->mappedName();
-    if (!prefix.empty())
+    if (!prefix.empty() || !suffix.empty())
     {
-        name = prefix + removeEscapePrefix(name);
+        name = prefix + removeEscapePrefix(name) + suffix;
     }
 
     // If contained is an operation, a field, or an enumerator, we use the enclosing type.
@@ -66,6 +66,52 @@ string
 Slice::Csharp::removeEscapePrefix(const string& identifier)
 {
     return identifier.find('@') == 0 ? identifier.substr(1) : identifier;
+}
+
+void
+Slice::Csharp::writeConstantValue(
+    Output& out,
+    const TypePtr& type,
+    const SyntaxTreeBasePtr& valueType,
+    const string& value,
+    const string& ns,
+    const string& fieldName)
+{
+    ConstPtr constant = dynamic_pointer_cast<Const>(valueType);
+    if (constant)
+    {
+        out << getUnqualified(constant, ns) << "." << fieldName;
+    }
+    else
+    {
+        BuiltinPtr bp = dynamic_pointer_cast<Builtin>(type);
+        if (bp && bp->kind() == Builtin::KindString)
+        {
+            out << "\"" << toStringLiteral(value, "\a\b\f\n\r\t\v\0", "", UCN, 0) << "\"";
+        }
+        else if (bp && bp->kind() == Builtin::KindLong)
+        {
+            out << value << "L";
+        }
+        else if (bp && bp->kind() == Builtin::KindFloat)
+        {
+            out << value << "F";
+        }
+        else if (bp && bp->kind() == Builtin::KindDouble)
+        {
+            out << value << "D";
+        }
+        else if (dynamic_pointer_cast<Enum>(type))
+        {
+            EnumeratorPtr lte = dynamic_pointer_cast<Enumerator>(valueType);
+            assert(lte);
+            out << getUnqualified(lte, ns);
+        }
+        else
+        {
+            out << value;
+        }
+    }
 }
 
 void
@@ -119,5 +165,114 @@ Slice::Csharp::writeDocLines(
             out << line;
         }
         out << "</" << closeTag.value_or(openTag) << ">";
+    }
+}
+
+void
+Slice::Csharp::writeParameterDocComments(Output& out, const DocComment& comment, const ParameterList& parameters)
+{
+    const auto& commentParameters = comment.parameters();
+    for (const auto& param : parameters)
+    {
+        auto q = commentParameters.find(param->name());
+        if (q != commentParameters.end())
+        {
+            ostringstream openTag;
+            openTag << "param name=\"" << removeEscapePrefix(param->mappedName()) << "\"";
+            writeDocLines(out, openTag.str(), q->second, "param");
+        }
+    }
+}
+
+void
+Slice::Csharp::writeSeeAlso(Output& out, const StringList& seeAlso)
+{
+    for (const auto& line : seeAlso)
+    {
+        // An empty line means that the see-also was referencing a Slice element which isn't mapped in C#.
+        // There's nothing we can do about this in C#, so we just skip it.
+        if (!line.empty())
+        {
+            out << nl << "/// " << line;
+        }
+    }
+}
+
+Slice::Csharp::CsharpDocCommentFormatter::CsharpDocCommentFormatter(
+    function<pair<bool, string>(const string&, const ContainedPtr&, const SyntaxTreeBasePtr&)> linkFormatter)
+    : _linkFormatter(std::move(linkFormatter))
+{
+}
+
+void
+Slice::Csharp::CsharpDocCommentFormatter::preprocess(StringList& rawComment)
+{
+    for (auto& line : rawComment)
+    {
+        // Escape any XML special characters in the comment.
+        string::size_type pos = 0;
+        while ((pos = line.find_first_of("&<>", pos)) != string::npos)
+        {
+            switch (line[pos])
+            {
+                case '&':
+                    line.replace(pos, 1, "&amp;");
+                    break;
+                case '<':
+                    line.replace(pos, 1, "&lt;");
+                    break;
+                case '>':
+                    line.replace(pos, 1, "&gt;");
+                    break;
+            }
+            // Skip over the leading '&' character to avoid 'find'ing it again.
+            pos += 1;
+        }
+    }
+}
+
+string
+Slice::Csharp::CsharpDocCommentFormatter::formatCode(const string& rawText)
+{
+    return "<c>" + rawText + "</c>";
+}
+
+string
+Slice::Csharp::CsharpDocCommentFormatter::formatParamRef(const string& param)
+{
+    return "<paramref name=\"" + param + "\" />";
+}
+
+string
+Slice::Csharp::CsharpDocCommentFormatter::formatLink(
+    const string& rawLink,
+    const ContainedPtr& source,
+    const SyntaxTreeBasePtr& target)
+{
+    auto [mapToLink, qualifiedName] = _linkFormatter(rawLink, source, target);
+    if (mapToLink)
+    {
+        return "<see " + qualifiedName + " />";
+    }
+    else
+    {
+        return "<c>" + qualifiedName + "</c>";
+    }
+}
+
+string
+Slice::Csharp::CsharpDocCommentFormatter::formatSeeAlso(
+    const string& rawLink,
+    const ContainedPtr& source,
+    const SyntaxTreeBasePtr& target)
+{
+    auto [mapToLink, qualifiedName] = _linkFormatter(rawLink, source, target);
+    if (mapToLink)
+    {
+        return "<seealso " + qualifiedName + " />";
+    }
+    else
+    {
+        return "";
     }
 }

--- a/cpp/src/slice2cs/CsUtil.h
+++ b/cpp/src/slice2cs/CsUtil.h
@@ -4,6 +4,7 @@
 #define CS_UTIL_H
 
 #include "../Ice/OutputUtil.h"
+#include "../Slice/DocCommentParser.h"
 #include "../Slice/Parser.h"
 
 namespace Slice::Csharp
@@ -11,14 +12,32 @@ namespace Slice::Csharp
     /// Returns the namespace of a Contained entity.
     [[nodiscard]] std::string getNamespace(const ContainedPtr& p);
 
-    [[nodiscard]] std::string
-    getUnqualified(const ContainedPtr& p, const std::string& ns, const std::string& prefix = "");
+    [[nodiscard]] std::string getUnqualified(
+        const ContainedPtr& p,
+        const std::string& ns,
+        const std::string& prefix = "",
+        const std::string& suffix = "");
 
     /// Removes a leading '@' character from the provided identifier (if one is present).
     [[nodiscard]] std::string removeEscapePrefix(const std::string& identifier);
 
     /// Returns the namespace prefix of a Contained entity.
     [[nodiscard]] std::string getNamespacePrefix(const ContainedPtr& p);
+
+    /// Writes a C# constant value.
+    /// @param out The output to write to.
+    /// @param type The type of the constant.
+    /// @param valueType The syntax tree node associated with the value. It can be null, an enumerator, or a constant.
+    /// @param value The value of the constant, e.g. "42" or "SomeEnum.SomeValue".
+    /// @param ns The namespace of the caller.
+    /// @param fieldName The name of the mapped constant field (used when @p valueType is a const).
+    void writeConstantValue(
+        IceInternal::Output& out,
+        const TypePtr& type,
+        const SyntaxTreeBasePtr& valueType,
+        const std::string& value,
+        const std::string& ns,
+        const std::string& fieldName = "value");
 
     /// Writes a one-line XML doc-comment.
     void writeDocLine(
@@ -34,6 +53,34 @@ namespace Slice::Csharp
         const std::string& openTag,
         const StringList& lines,
         const std::optional<std::string>& closeTag = std::nullopt);
+
+    void writeSeeAlso(IceInternal::Output& out, const StringList& seeAlso);
+
+    void
+    writeParameterDocComments(IceInternal::Output& out, const DocComment& comment, const ParameterList& parameters);
+
+    class CsharpDocCommentFormatter final : public DocCommentFormatter
+    {
+    public:
+        CsharpDocCommentFormatter(
+            std::function<
+                std::pair<bool, std::string>(const std::string&, const ContainedPtr&, const SyntaxTreeBasePtr&)>
+                linkFormatter);
+
+        void preprocess(StringList& rawComment) final;
+        std::string formatCode(const std::string& rawText) final;
+        std::string formatParamRef(const std::string& param) final;
+
+        std::string
+        formatLink(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target) final;
+
+        std::string
+        formatSeeAlso(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target) final;
+
+    private:
+        std::function<std::pair<bool, std::string>(const std::string&, const ContainedPtr&, const SyntaxTreeBasePtr&)>
+            _linkFormatter;
+    };
 }
 
 #endif

--- a/cpp/src/slice2cs/CsVisitor.cpp
+++ b/cpp/src/slice2cs/CsVisitor.cpp
@@ -10,23 +10,25 @@ using namespace Slice;
 using namespace Slice::Csharp;
 using namespace IceInternal;
 
-namespace
+Slice::CsVisitor::CsVisitor(Output& out) : _out(out) {}
+
+bool
+Slice::CsVisitor::visitModuleStart(const ModulePtr& p)
 {
-    void writeSeeAlso(Output& out, const StringList& seeAlso)
-    {
-        for (const auto& line : seeAlso)
-        {
-            // An empty line means that the see-also was referencing a Slice element which isn't mapped in C#.
-            // There's nothing we can do about this in C#, so we just skip it.
-            if (!line.empty())
-            {
-                out << nl << "/// " << line;
-            }
-        }
-    }
+    namespacePrefixStart(p);
+    _out << sp;
+    _out << nl << "namespace " << p->mappedName();
+    _out << sb;
+
+    return true;
 }
 
-Slice::CsVisitor::CsVisitor(Output& out) : _out(out) {}
+void
+Slice::CsVisitor::visitModuleEnd(const ModulePtr& p)
+{
+    _out << eb;
+    namespacePrefixEnd(p);
+}
 
 void
 Slice::CsVisitor::emitNonBrowsableAttribute()
@@ -63,129 +65,6 @@ Slice::CsVisitor::emitObsoleteAttribute(const ContainedPtr& p)
         else
         {
             _out << nl << "[global::System.Obsolete]";
-        }
-    }
-}
-
-void
-Slice::CsVisitor::writeDocComment(const ContainedPtr& p, const string& generatedType, const string& notes)
-{
-    const optional<DocComment>& comment = p->docComment();
-    StringList remarks;
-    if (comment)
-    {
-        writeDocLines(_out, "summary", comment->overview());
-        remarks = comment->remarks();
-    }
-
-    if (!generatedType.empty())
-    {
-        // If there's user-provided remarks, and a generated-type message, we introduce a paragraph between them.
-        if (!remarks.empty())
-        {
-            remarks.emplace_back("<para />");
-        }
-
-        remarks.push_back(
-            "The Slice compiler generated this " + generatedType + " from Slice " + p->kindOf() + " <c>" + p->scoped() +
-            "</c>.");
-        if (!notes.empty())
-        {
-            remarks.push_back(notes);
-        }
-    }
-
-    if (!remarks.empty())
-    {
-        writeDocLines(_out, "remarks", remarks);
-    }
-
-    if (comment)
-    {
-        writeSeeAlso(_out, comment->seeAlso());
-    }
-}
-
-void
-Slice::CsVisitor::writeHelperDocComment(
-    const ContainedPtr& p,
-    const string& comment,
-    const string& generatedType,
-    const string& notes)
-{
-    // Called only for module-level types.
-    assert(dynamic_pointer_cast<Module>(p->container()));
-    assert(!generatedType.empty());
-
-    writeDocLine(_out, "summary", comment);
-    _out << nl << "/// <remarks>" << "The Slice compiler generated this " << generatedType << " from Slice "
-         << p->kindOf() << " <c>" << p->scoped() << "</c>.";
-    if (!notes.empty())
-    {
-        _out << nl << "/// " << notes;
-    }
-    _out << "</remarks>";
-}
-
-void
-Slice::CsVisitor::writeOpDocComment(const OperationPtr& op, const vector<string>& extraParams, bool isAsync)
-{
-    const optional<DocComment>& comment = op->docComment();
-    if (!comment)
-    {
-        return;
-    }
-
-    writeDocLines(_out, "summary", comment->overview());
-
-    writeParameterDocComments(*comment, isAsync ? op->inParameters() : op->parameters());
-
-    for (const auto& extraParam : extraParams)
-    {
-        _out << nl << "/// " << extraParam;
-    }
-
-    if (isAsync)
-    {
-        _out << nl << "/// <returns>A task that represents the asynchronous operation.</returns>";
-    }
-    else if (op->returnType())
-    {
-        writeDocLines(_out, "returns", comment->returns());
-    }
-
-    for (const auto& [exceptionName, exceptionLines] : comment->exceptions())
-    {
-        string name = exceptionName;
-        ExceptionPtr ex = op->container()->lookupException(exceptionName, false);
-        if (ex)
-        {
-            name = ex->mappedScoped(".");
-        }
-
-        ostringstream openTag;
-        openTag << "exception cref=\"" << name << "\"";
-
-        writeDocLines(_out, openTag.str(), exceptionLines, "exception");
-    }
-
-    writeDocLines(_out, "remarks", comment->remarks());
-
-    writeSeeAlso(_out, comment->seeAlso());
-}
-
-void
-Slice::CsVisitor::writeParameterDocComments(const DocComment& comment, const ParameterList& parameters)
-{
-    const auto& commentParameters = comment.parameters();
-    for (const auto& param : parameters)
-    {
-        auto q = commentParameters.find(param->name());
-        if (q != commentParameters.end())
-        {
-            ostringstream openTag;
-            openTag << "param name=\"" << removeEscapePrefix(param->mappedName()) << "\"";
-            writeDocLines(_out, openTag.str(), q->second, "param");
         }
     }
 }

--- a/cpp/src/slice2cs/CsVisitor.h
+++ b/cpp/src/slice2cs/CsVisitor.h
@@ -14,6 +14,9 @@ namespace Slice
     public:
         CsVisitor(IceInternal::Output&);
 
+        bool visitModuleStart(const ModulePtr&) override;
+        void visitModuleEnd(const ModulePtr&) override;
+
     protected:
         void emitNonBrowsableAttribute();
 
@@ -22,33 +25,11 @@ namespace Slice
 
         void emitObsoleteAttribute(const ContainedPtr&);
 
-        /// Writes a doc-comment for the given Slice element, using this element's doc-comment, if any.
-        /// @param p The Slice element.
-        /// @param generatedType The kind of mapped element, used for the remarks. For example, "skeleton interface".
-        /// This function does not write any remarks when this argument is empty.
-        /// @param notes Optional notes included at the end of the remarks.
-        void
-        writeDocComment(const ContainedPtr& p, const std::string& generatedType = "", const std::string& notes = "");
+        IceInternal::Output& _out;
 
-        /// Writes a doc-comment for a helper class generated for a Slice element.
-        /// @param p The Slice element.
-        /// @param comment The summary.
-        /// @param generatedType The kind of mapped element, used for the remarks. Must not be empty.
-        /// @param notes Optional notes included at the end of the remarks.
-        void writeHelperDocComment(
-            const ContainedPtr& p,
-            const std::string& comment,
-            const std::string& generatedType,
-            const std::string& notes = "");
-
-        void
-        writeOpDocComment(const OperationPtr& operation, const std::vector<std::string>& extraParams, bool isAsync);
-        void writeParameterDocComments(const DocComment&, const ParameterList&);
-
+    private:
         void namespacePrefixStart(const ModulePtr&);
         void namespacePrefixEnd(const ModulePtr&);
-
-        IceInternal::Output& _out;
     };
 }
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -7,6 +7,7 @@
 #include "CsMetadataValidator.h"
 #include "CsUtil.h"
 #include "Ice/StringUtil.h"
+#include "IceRpcVisitors.h"
 #include "IceVisitors.h"
 
 using namespace std;
@@ -14,15 +15,18 @@ using namespace Slice;
 using namespace Slice::Csharp;
 using namespace IceInternal;
 
-Slice::Gen::Gen(const string& base, const string& dir, bool enableAnalysis) : _enableAnalysis(enableAnalysis)
+Slice::Gen::Gen(const string& base, const string& dir, GenMode genMode, bool enableAnalysis)
+    : _genMode(genMode),
+      _enableAnalysis(enableAnalysis)
 {
-    string fileBase = base;
+    _fileBase = base;
     string::size_type pos = base.find_last_of("/\\");
     if (pos != string::npos)
     {
-        fileBase = base.substr(pos + 1);
+        _fileBase = base.substr(pos + 1);
     }
-    string file = fileBase + ".cs";
+    string file = _genMode == GenMode::IceRpc ? _fileBase + ".IceRpc.cs" : _fileBase + ".cs";
+
     if (!dir.empty())
     {
         file = dir + '/' + file;
@@ -36,18 +40,83 @@ Slice::Gen::Gen(const string& base, const string& dir, bool enableAnalysis) : _e
         throw FileException(os.str());
     }
     FileTracker::instance()->addFile(file);
-    printHeader();
+
+    printHeader(_fileBase + ".ice");
+    if (_genMode == GenMode::IceRpc)
+    {
+        _out << sp;
+        _out << nl << "using IceRpc.Ice;";
+        _out << nl << "using IceRpc.Ice.Codec;";
+    }
+    else
+    {
+        _out << sp;
+        _out << nl << "[assembly:Ice.Slice(\"" << _fileBase << ".ice\")]";
+    }
+}
+
+Slice::Gen::~Gen()
+{
+    if (_out.isOpen())
+    {
+        _out << nl;
+        _out.close();
+    }
+}
+
+void
+Slice::Gen::generate(const UnitPtr& p)
+{
+    Slice::validateCsMetadata(p);
+
+    if (_genMode == GenMode::Ice)
+    {
+        Slice::Ice::TypesVisitor typesVisitor(_out);
+        p->visit(&typesVisitor);
+
+        Slice::Ice::ResultVisitor resultVisitor(_out);
+        p->visit(&resultVisitor);
+
+        // Default skeleton.
+        Slice::Ice::SkeletonVisitor skeletonVisitor(_out, false);
+        p->visit(&skeletonVisitor);
+
+        // Async skeleton.
+        Slice::Ice::SkeletonVisitor asyncSkeletonVisitor(_out, true);
+        p->visit(&asyncSkeletonVisitor);
+    }
+    else
+    {
+        if (p->contains<InterfaceDef>())
+        {
+            // The proxy and skeleton code depends on this using directive.
+            _out << nl << "using IceRpc.Ice.Operations;";
+        }
+        _out << sp;
+        _out << nl << "[assembly:IceGeneratedCode(\"" << _fileBase << ".ice\")]";
+
+        Slice::IceRpc::TypesVisitor typesVisitor(_out);
+        p->visit(&typesVisitor);
+
+        Slice::IceRpc::SkeletonVisitor skeletonVisitor(_out);
+        p->visit(&skeletonVisitor);
+    }
+}
+
+void
+Slice::Gen::printHeader(const string& iceFile)
+{
+    _out << "// Copyright (c) ZeroC, Inc.";
+    _out << sp;
+    _out << nl << "// slice2cs version " << ICE_STRING_VERSION;
 
     if (!_enableAnalysis)
     {
-        printGeneratedHeader(_out, fileBase + ".ice");
+        printGeneratedHeader(_out, iceFile);
     }
 
     _out << sp;
     _out << nl << "#nullable enable";
-    _out << sp;
-    _out << nl << "[assembly:Ice.Slice(\"" << fileBase << ".ice\")]";
-
     _out << sp;
 
     if (_enableAnalysis)
@@ -57,6 +126,7 @@ Slice::Gen::Gen(const string& base, const string& dir, bool enableAnalysis) : _e
         _out << nl << "#pragma warning disable SA1611 // The documentation for parameter x is missing";
 
         _out << nl << "#pragma warning disable CA1041 // Provide a message for the ObsoleteAttribute that marks ...";
+
         _out << nl << "#pragma warning disable CA1068 // Cancellation token as last parameter";
         _out << nl << "#pragma warning disable CA1725 // Change parameter name istr_ to istr in order to match ...";
 
@@ -71,41 +141,4 @@ Slice::Gen::Gen(const string& base, const string& dir, bool enableAnalysis) : _e
     _out << nl << "#pragma warning disable CS0612 // Type or member is obsolete";
     _out << nl << "#pragma warning disable CS0618 // Type or member is obsolete";
     _out << nl << "#pragma warning disable CS0619 // Type or member is obsolete";
-}
-
-Slice::Gen::~Gen()
-{
-    if (_out.isOpen())
-    {
-        _out << '\n';
-        _out.close();
-    }
-}
-
-void
-Slice::Gen::generate(const UnitPtr& p)
-{
-    Slice::validateCsMetadata(p);
-
-    Slice::Ice::TypesVisitor typesVisitor(_out);
-    p->visit(&typesVisitor);
-
-    Slice::Ice::ResultVisitor resultVisitor(_out);
-    p->visit(&resultVisitor);
-
-    // Default skeleton.
-    Slice::Ice::SkeletonVisitor skeletonVisitor(_out, false);
-    p->visit(&skeletonVisitor);
-
-    // Async skeleton.
-    Slice::Ice::SkeletonVisitor asyncSkeletonVisitor(_out, true);
-    p->visit(&asyncSkeletonVisitor);
-}
-
-void
-Slice::Gen::printHeader()
-{
-    _out << "// Copyright (c) ZeroC, Inc.";
-    _out << sp;
-    _out << nl << "// slice2cs version " << ICE_STRING_VERSION;
 }

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -8,20 +8,28 @@
 
 namespace Slice
 {
+    enum class GenMode
+    {
+        Ice,
+        IceRpc
+    };
+
     class Gen final
     {
     public:
-        Gen(const std::string&, const std::string&, bool);
+        Gen(const std::string& base, const std::string& dir, GenMode genMode, bool enableAnalysis);
         Gen(const Gen&) = delete;
         ~Gen();
 
         void generate(const UnitPtr&);
 
     private:
+        const GenMode _genMode;
         IceInternal::Output _out;
-        bool _enableAnalysis;
+        const bool _enableAnalysis;
+        std::string _fileBase;
 
-        void printHeader();
+        void printHeader(const std::string& iceFile);
     };
 }
 

--- a/cpp/src/slice2cs/IceCsUtil.cpp
+++ b/cpp/src/slice2cs/IceCsUtil.cpp
@@ -83,7 +83,7 @@ Slice::Csharp::typeToString(const TypePtr& type, const string& ns, bool optional
     InterfaceDeclPtr proxy = dynamic_pointer_cast<InterfaceDecl>(type);
     if (proxy)
     {
-        return getUnqualified(proxy, ns) + "Prx?";
+        return getUnqualified(proxy, ns, "", "Prx") + "?";
     }
 
     SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
@@ -468,7 +468,7 @@ Slice::Csharp::writeMarshalUnmarshalCode(
     DictionaryPtr d = dynamic_pointer_cast<Dictionary>(type);
     if (d)
     {
-        helperName = getUnqualified(d, ns) + "Helper";
+        helperName = getUnqualified(d, ns, "", "Helper");
     }
     else
     {
@@ -810,7 +810,7 @@ Slice::Csharp::writeSequenceMarshalUnmarshalCode(
     assert(cont);
     if (useHelper)
     {
-        string helperName = getUnqualified(seq, ns) + "Helper";
+        string helperName = getUnqualified(seq, ns, "", "Helper");
         if (marshal)
         {
             out << nl << helperName << ".write(" << stream << ", " << param << ");";
@@ -1323,11 +1323,11 @@ Slice::Csharp::writeSequenceMarshalUnmarshalCode(
     string helperName;
     if (dynamic_pointer_cast<InterfaceDecl>(type))
     {
-        helperName = getUnqualified(dynamic_pointer_cast<InterfaceDecl>(type), ns) + "PrxHelper";
+        helperName = getUnqualified(dynamic_pointer_cast<InterfaceDecl>(type), ns, "", "PrxHelper");
     }
     else
     {
-        helperName = getUnqualified(dynamic_pointer_cast<Contained>(type), ns) + "Helper";
+        helperName = getUnqualified(dynamic_pointer_cast<Contained>(type), ns, "", "Helper");
     }
 
     string func;
@@ -1618,8 +1618,168 @@ Slice::Csharp::writeOptionalSequenceMarshalUnmarshalCode(
     }
 }
 
+void
+Slice::Csharp::writeIceDocComment(
+    Output& out,
+    const ContainedPtr& p,
+    optional<string> generatedType,
+    const string& notes)
+{
+    const optional<DocComment>& comment = p->docComment();
+    StringList remarks;
+    if (comment)
+    {
+        writeDocLines(out, "summary", comment->overview());
+        remarks = comment->remarks();
+    }
+
+    if (generatedType.has_value())
+    {
+        // If there's user-provided remarks, and a generated-type message, we introduce a paragraph between them.
+        if (!remarks.empty())
+        {
+            remarks.emplace_back("<para />");
+        }
+
+        if (!notes.empty())
+        {
+            remarks.push_back(notes);
+        }
+
+        remarks.push_back(
+            "The Slice compiler generated this " + *generatedType + " from Slice " + p->kindOf() + " <c>" +
+            p->scoped() + "</c>.");
+    }
+
+    if (!remarks.empty())
+    {
+        writeDocLines(out, "remarks", remarks);
+    }
+
+    if (comment)
+    {
+        writeSeeAlso(out, comment->seeAlso());
+    }
+}
+
+void
+Slice::Csharp::writeIceHelperDocComment(
+    Output& out,
+    const ContainedPtr& p,
+    const string& comment,
+    const string& generatedType,
+    const string& notes)
+{
+    // Called only for module-level types.
+    assert(dynamic_pointer_cast<Module>(p->container()));
+    assert(!generatedType.empty());
+
+    writeDocLine(out, "summary", comment);
+    out << nl << "/// <remarks>";
+    if (!notes.empty())
+    {
+        out << notes;
+        out << nl << "/// ";
+    }
+
+    out << "The Slice compiler generated this " << generatedType << " from Slice " << p->kindOf() << " <c>"
+        << p->scoped() << "</c>.";
+
+    out << "</remarks>";
+}
+
+void
+Slice::Csharp::writeIceOpDocComment(
+    Output& out,
+    const OperationPtr& op,
+    const vector<string>& extraParams,
+    bool isAsync,
+    bool dispatch)
+{
+    const optional<DocComment>& comment = op->docComment();
+    if (!comment)
+    {
+        return;
+    }
+
+    writeDocLines(out, "summary", comment->overview());
+    writeParameterDocComments(out, *comment, isAsync ? op->inParameters() : op->parameters());
+
+    for (const auto& extraParam : extraParams)
+    {
+        out << nl << "/// " << extraParam;
+    }
+
+    if (isAsync)
+    {
+        if (op->returnsMultipleValues() || !op->returnsAnyValues())
+        {
+            if (dispatch)
+            {
+                out << nl << "/// <returns>A task that completes when the dispatch completes.</returns>";
+            }
+            else if (op->returnsData())
+            {
+                out << nl << "/// <returns>A task that completes when the response is received.</returns>";
+            }
+            else
+            {
+                out << nl
+                    << "/// <returns>For two-way invocations: a task that completes when the response is received.";
+                out << nl << "/// For one-way invocations: a task that completes when the request is sent.</returns>";
+            }
+        }
+        else if (op->returnType())
+        {
+            writeDocLines(out, "returns", comment->returns());
+        }
+        else
+        {
+            assert(op->outParameters().size() == 1);
+            const auto& commentParameters = comment->parameters();
+            auto q = commentParameters.find(op->outParameters().front()->name());
+            if (q != commentParameters.end())
+            {
+                writeDocLines(out, "returns", q->second);
+            }
+        }
+    }
+    else if (op->returnType())
+    {
+        writeDocLines(out, "returns", comment->returns());
+    }
+
+    for (const auto& [exceptionName, exceptionLines] : comment->exceptions())
+    {
+        string name = exceptionName;
+        ExceptionPtr ex = op->container()->lookupException(exceptionName, false);
+        if (ex)
+        {
+            name = ex->mappedScoped(".");
+        }
+
+        ostringstream openTag;
+        openTag << "exception cref=\"" << name << "\"";
+
+        if (dispatch || !isAsync)
+        {
+            writeDocLines(out, openTag.str(), exceptionLines, "exception");
+        }
+        else
+        {
+            StringList asyncExceptionLines{exceptionLines};
+            asyncExceptionLines.emplace_back(
+                "This exception is provided through the returned task; it's never thrown synchronously.");
+            writeDocLines(out, openTag.str(), asyncExceptionLines, "exception");
+        }
+    }
+
+    writeDocLines(out, "remarks", comment->remarks());
+    writeSeeAlso(out, comment->seeAlso());
+}
+
 std::pair<bool, string>
-Slice::Csharp::csLinkFormatter(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target)
+Slice::Csharp::iceLinkFormatter(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target)
 {
     ostringstream result;
 
@@ -1654,13 +1814,13 @@ Slice::Csharp::csLinkFormatter(const string& rawLink, const ContainedPtr& source
         if (auto operationTarget = dynamic_pointer_cast<Operation>(target))
         {
             // link to the method on the proxy interface
-            result << getUnqualified(operationTarget->interface(), sourceScope) << "Prx."
+            result << getUnqualified(operationTarget->interface(), sourceScope, "", "Prx") << "."
                    << operationTarget->mappedName() << "Async";
         }
         else if (auto interfaceTarget = dynamic_pointer_cast<InterfaceDecl>(target))
         {
             // link to the proxy interface
-            result << getUnqualified(interfaceTarget, sourceScope) << "Prx";
+            result << getUnqualified(interfaceTarget, sourceScope, "", "Prx");
         }
         else
         {
@@ -1692,77 +1852,4 @@ Slice::Csharp::csLinkFormatter(const string& rawLink, const ContainedPtr& source
     }
 
     return {true, result.str()};
-}
-
-void
-Slice::Csharp::IceDocCommentFormatter::preprocess(StringList& rawComment)
-{
-    for (auto& line : rawComment)
-    {
-        // Escape any XML special characters in the comment.
-        string::size_type pos = 0;
-        while ((pos = line.find_first_of("&<>", pos)) != string::npos)
-        {
-            switch (line[pos])
-            {
-                case '&':
-                    line.replace(pos, 1, "&amp;");
-                    break;
-                case '<':
-                    line.replace(pos, 1, "&lt;");
-                    break;
-                case '>':
-                    line.replace(pos, 1, "&gt;");
-                    break;
-            }
-            // Skip over the leading '&' character to avoid 'find'ing it again.
-            pos += 1;
-        }
-    }
-}
-
-string
-Slice::Csharp::IceDocCommentFormatter::formatCode(const string& rawText)
-{
-    return "<c>" + rawText + "</c>";
-}
-
-string
-Slice::Csharp::IceDocCommentFormatter::formatParamRef(const string& param)
-{
-    return "<paramref name=\"" + param + "\" />";
-}
-
-string
-Slice::Csharp::IceDocCommentFormatter::formatLink(
-    const string& rawLink,
-    const ContainedPtr& source,
-    const SyntaxTreeBasePtr& target)
-{
-    auto [mapToLink, qualifiedName] = Slice::Csharp::csLinkFormatter(rawLink, source, target);
-    if (mapToLink)
-    {
-        return "<see " + qualifiedName + " />";
-    }
-    else
-    {
-        return "<c>" + qualifiedName + "</c>";
-    }
-}
-
-string
-Slice::Csharp::IceDocCommentFormatter::formatSeeAlso(
-    const string& rawLink,
-    const ContainedPtr& source,
-    const SyntaxTreeBasePtr& target)
-{
-    auto [mapToLink, qualifiedName] = Slice::Csharp::csLinkFormatter(rawLink, source, target);
-    if (mapToLink)
-    {
-        return "<seealso " + qualifiedName + " />";
-    }
-    else
-    {
-        return "";
-    }
 }

--- a/cpp/src/slice2cs/IceCsUtil.h
+++ b/cpp/src/slice2cs/IceCsUtil.h
@@ -40,7 +40,7 @@ namespace Slice::Csharp
     // Generate code to marshal or unmarshal a type
     //
     void writeMarshalUnmarshalCode(
-        ::IceInternal::Output& out,
+        IceInternal::Output& out,
         const TypePtr& type,
         const std::string& ns,
         const std::string& param,
@@ -48,7 +48,7 @@ namespace Slice::Csharp
         const std::string& customStream = "");
 
     void writeOptionalMarshalUnmarshalCode(
-        ::IceInternal::Output& out,
+        IceInternal::Output& out,
         const TypePtr& type,
         const std::string& ns,
         const std::string& param,
@@ -57,7 +57,7 @@ namespace Slice::Csharp
         const std::string& customStream = "");
 
     void writeSequenceMarshalUnmarshalCode(
-        ::IceInternal::Output& out,
+        IceInternal::Output& out,
         const SequencePtr& seq,
         const std::string& ns,
         const std::string& param,
@@ -66,13 +66,47 @@ namespace Slice::Csharp
         const std::string& customStream = "");
 
     void writeOptionalSequenceMarshalUnmarshalCode(
-        ::IceInternal::Output& out,
+        IceInternal::Output& out,
         const SequencePtr& seq,
         const std::string& ns,
         const std::string& param,
         int tag,
         bool marshal,
         const std::string& customStream = "");
+
+    //
+    // Doc-comments
+    //
+
+    /// Writes a doc-comment for the given Slice element, using this element's doc-comment, if any.
+    /// @param p The Slice element.
+    /// @param generatedType The kind of mapped element, used for the remarks. For example, "skeleton interface".
+    /// This function does not write any remarks when this argument is nullopt.
+    /// @param notes Optional notes included after @p p's remarks.
+    void writeIceDocComment(
+        IceInternal::Output& out,
+        const ContainedPtr& p,
+        std::optional<std::string> generatedType = std::nullopt,
+        const std::string& notes = "");
+
+    /// Writes a doc-comment for a helper class generated for a Slice element.
+    /// @param p The Slice element.
+    /// @param comment The summary.
+    /// @param generatedType The kind of mapped element, used for the remarks. Must not be empty.
+    /// @param notes Optional notes included at the beginning of the remarks.
+    void writeIceHelperDocComment(
+        IceInternal::Output& out,
+        const ContainedPtr& p,
+        const std::string& comment,
+        const std::string& generatedType,
+        const std::string& notes = "");
+
+    void writeIceOpDocComment(
+        IceInternal::Output& out,
+        const OperationPtr& operation,
+        const std::vector<std::string>& extraParams,
+        bool isAsync,
+        bool dispatch);
 
     /// Converts a Slice-formatted link into a C# formatted link.
     /// @param rawLink The reference's raw text, taken verbatim from the doc-comment.
@@ -82,19 +116,7 @@ namespace Slice::Csharp
     /// - @c false if the link was to a Slice element which isn't mapped in C#; @c true otherwise.
     /// - The C# formatted link.
     std::pair<bool, std::string>
-    csLinkFormatter(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target);
-
-    class IceDocCommentFormatter final : public DocCommentFormatter
-    {
-    public:
-        void preprocess(StringList& rawComment) final;
-        std::string formatCode(const std::string& rawText) final;
-        std::string formatParamRef(const std::string& param) final;
-        std::string
-        formatLink(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target) final;
-        std::string
-        formatSeeAlso(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target) final;
-    };
+    iceLinkFormatter(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target);
 }
 
 #endif

--- a/cpp/src/slice2cs/IceRpcCsUtil.cpp
+++ b/cpp/src/slice2cs/IceRpcCsUtil.cpp
@@ -1,0 +1,833 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "IceRpcCsUtil.h"
+#include "../Slice/Util.h"
+#include "CsUtil.h"
+
+#include <algorithm>
+#include <cassert>
+
+using namespace std;
+using namespace Slice;
+using namespace IceInternal;
+
+namespace
+{
+    [[nodiscard]] bool hasFixedSizeBuiltinElements(const SequencePtr& seq)
+    {
+        BuiltinPtr elementTypeBuiltin = dynamic_pointer_cast<Builtin>(seq->type());
+        return elementTypeBuiltin && !elementTypeBuiltin->isVariableLength();
+    }
+
+    [[nodiscard]] bool isBool(const TypePtr& type)
+    {
+        BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
+        return builtin && builtin->kind() == Builtin::KindBool;
+    }
+
+    [[nodiscard]] bool isString(const TypePtr& type)
+    {
+        BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
+        return builtin && builtin->kind() == Builtin::KindString;
+    }
+
+    // The TagFormat is the OptionalFormat + the OptimizedVSize enumerator.
+    [[nodiscard]] string getTagFormat(const TypePtr& type)
+    {
+        SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
+        if (isString(type) || (seq && !seq->type()->isVariableLength() && seq->type()->minWireSize() == 1))
+        {
+            return "OptimizedVSize";
+        }
+        else
+        {
+            return type->getOptionalFormat();
+        }
+    }
+
+    void castToNestedFieldType(Output& out, const TypePtr& type, const string& ns)
+    {
+        if (auto seq = dynamic_pointer_cast<Sequence>(type))
+        {
+            auto metadata = seq->getMetadataArgs("cs:generic");
+            if (metadata && *metadata != "List")
+            {
+                // We only need to cast for the default sequence mapping and cs:generic:List, as they both map to
+                // IList<T>.
+                return;
+            }
+        }
+        else if (!dynamic_pointer_cast<Dictionary>(type))
+        {
+            return; // no need to cast
+        }
+        out << "(" << Slice::Csharp::csFieldType(type, ns) << ")";
+    }
+}
+
+bool
+Slice::Csharp::isCsValueType(const TypePtr& type)
+{
+    BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
+    if (builtin)
+    {
+        switch (builtin->kind())
+        {
+            case Builtin::KindByte:
+            case Builtin::KindBool:
+            case Builtin::KindShort:
+            case Builtin::KindInt:
+            case Builtin::KindLong:
+            case Builtin::KindFloat:
+            case Builtin::KindDouble:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    return dynamic_pointer_cast<Enum>(type) || dynamic_pointer_cast<Struct>(type) ||
+           dynamic_pointer_cast<InterfaceDecl>(type);
+}
+
+string
+Slice::Csharp::csFieldType(const TypePtr& type, const string& ns, bool optional)
+{
+    assert(type);
+
+    if (optional && !isProxyType(type))
+    {
+        // Proxy types are mapped the same way for optional and non-optional types.
+        return csFieldType(type, ns) + "?";
+    }
+    // else, just use the regular mapping.
+
+    static const char* builtinTable[] =
+        {"byte", "bool", "short", "int", "long", "float", "double", "string", "IceObjectProxy?", "IceClass?"};
+
+    if (auto builtin = dynamic_pointer_cast<Builtin>(type))
+    {
+        return builtinTable[builtin->kind()];
+    }
+    else if (auto cl = dynamic_pointer_cast<ClassDecl>(type))
+    {
+        assert(!optional); // Optional classes are disallowed by the parser.
+        return getUnqualified(cl, ns) + "?";
+    }
+    else if (auto proxy = dynamic_pointer_cast<InterfaceDecl>(type))
+    {
+        return getUnqualified(proxy, ns, "", "Proxy") + "?";
+    }
+    else if (auto seq = dynamic_pointer_cast<Sequence>(type))
+    {
+        if (auto metadata = seq->getMetadataArgs("cs:generic"))
+        {
+            const string& customType = *metadata;
+            if (customType == "LinkedList" || customType == "Queue" || customType == "Stack")
+            {
+                return "global::System.Collections.Generic." + customType + "<" + csFieldType(seq->type(), ns) + ">";
+            }
+            else if (customType != "List")
+            {
+                return "global::" + customType + "<" + csFieldType(seq->type(), ns) + ">";
+            }
+            // else use default mapping to IList below
+        }
+        return "global::System.Collections.Generic.IList<" + csFieldType(seq->type(), ns) + ">";
+    }
+    else if (auto d = dynamic_pointer_cast<Dictionary>(type))
+    {
+        return "global::System.Collections.Generic.IDictionary<" + csFieldType(d->keyType(), ns) + ", " +
+               csFieldType(d->valueType(), ns) + ">";
+    }
+    else if (auto contained = dynamic_pointer_cast<Contained>(type))
+    {
+        // Struct, Enum
+        return getUnqualified(contained, ns);
+    }
+    else
+    {
+        assert(false);
+        return "???";
+    }
+}
+
+string
+Slice::Csharp::csIncomingParamType(const TypePtr& type, const string& ns, bool optional)
+{
+    if (optional && !isProxyType(type))
+    {
+        // Proxy types are mapped the same way for optional and non-optional types.
+        return csIncomingParamType(type, ns) + "?";
+    }
+
+    if (auto seq = dynamic_pointer_cast<Sequence>(type))
+    {
+        if (auto metadata = seq->getMetadataArgs("cs:generic"))
+        {
+            const string& customType = *metadata;
+            if (customType == "List" || customType == "LinkedList" || customType == "Queue" || customType == "Stack")
+            {
+                return "global::System.Collections.Generic." + customType + "<" + csFieldType(seq->type(), ns) + ">";
+            }
+            else
+            {
+                return "global::" + customType + "<" + csFieldType(seq->type(), ns) + ">";
+            }
+        }
+        return csFieldType(seq->type(), ns) + "[]";
+    }
+    else if (auto d = dynamic_pointer_cast<Dictionary>(type))
+    {
+        string typeName = d->getMetadataArgs("cs:generic").value_or("Dictionary");
+        return "global::System.Collections.Generic." + typeName + "<" + csFieldType(d->keyType(), ns) + ", " +
+               csFieldType(d->valueType(), ns) + ">";
+    }
+    else
+    {
+        return csFieldType(type, ns);
+    }
+}
+
+string
+Slice::Csharp::csOutgoingParamType(const TypePtr& type, const string& ns, bool optional)
+{
+    if (auto seq = dynamic_pointer_cast<Sequence>(type))
+    {
+        bool hasGenericMetadata = seq->hasMetadata("cs:generic");
+
+        BuiltinPtr elementTypeBuiltin = dynamic_pointer_cast<Builtin>(seq->type());
+        string elementTypeStr = csFieldType(seq->type(), ns);
+
+        if (elementTypeBuiltin && !elementTypeBuiltin->isVariableLength() && !hasGenericMetadata)
+        {
+            // If the underlying type is a fixed-size primitive, we map to `ReadOnlyMemory` instead,
+            // and the mapping is the same for optional and non-optional types.
+            return "global::System.ReadOnlyMemory<" + elementTypeStr + ">";
+        }
+        else
+        {
+            return "global::System.Collections.Generic.IEnumerable<" + elementTypeStr + ">" + (optional ? "?" : "");
+        }
+    }
+    else if (auto d = dynamic_pointer_cast<Dictionary>(type))
+    {
+        return "global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<" +
+               csFieldType(d->keyType(), ns) + ", " + csFieldType(d->valueType(), ns) + ">>";
+    }
+    else
+    {
+        return csFieldType(type, ns, optional);
+    }
+}
+
+string
+Slice::Csharp::csType(const TypePtr& type, const string& ns, TypeContext context, bool optional)
+{
+    switch (context)
+    {
+        case TypeContext::Field:
+            return csFieldType(type, ns, optional);
+        case TypeContext::IncomingParam:
+            return csIncomingParamType(type, ns, optional);
+        case TypeContext::OutgoingParam:
+            return csOutgoingParamType(type, ns, optional);
+        default:
+            assert(false);
+            return "???";
+    }
+}
+
+bool
+Slice::Csharp::csRequired(const DataMemberPtr& field)
+{
+    if (field->optional())
+    {
+        return false;
+    }
+
+    if (isString(field->type()))
+    {
+        return field->defaultValue() == nullopt;
+    }
+
+    return dynamic_pointer_cast<Sequence>(field->type()) || dynamic_pointer_cast<Dictionary>(field->type());
+}
+
+void
+Slice::Csharp::encodeField(
+    Output& out,
+    const string& fieldName,
+    const TypePtr& type,
+    const string& ns,
+    TypeContext context,
+    const string& encoderName)
+{
+    assert(type);
+
+    static const char* builtinTable[] =
+        {"Byte", "Bool", "Short", "Int", "Long", "Float", "Double", "String", "IceObjectProxy", "Class"};
+
+    if (auto builtin = dynamic_pointer_cast<Builtin>(type))
+    {
+        out << encoderName << ".Encode" << builtinTable[builtin->kind()] << "(" << fieldName << ")";
+    }
+    else if (auto cl = dynamic_pointer_cast<ClassDecl>(type))
+    {
+        out << encoderName << ".EncodeClass(" << fieldName << ")";
+    }
+    else if (auto st = dynamic_pointer_cast<Struct>(type))
+    {
+        out << fieldName << ".Encode(ref " << encoderName << ")";
+    }
+    else if (auto proxy = dynamic_pointer_cast<InterfaceDecl>(type))
+    {
+        out << getUnqualified(proxy, ns, "", "ProxyIceEncoderExtensions") << ".Encode"
+            << removeEscapePrefix(proxy->mappedName()) << "Proxy(ref " << encoderName << ", " << fieldName << ")";
+    }
+    else if (auto en = dynamic_pointer_cast<Enum>(type))
+    {
+        out << getUnqualified(en, ns, "", "IceEncoderExtensions") << ".Encode" << removeEscapePrefix(en->mappedName())
+            << "(ref " << encoderName << ", " << fieldName << ")";
+    }
+    else if (auto seq = dynamic_pointer_cast<Sequence>(type))
+    {
+        if (hasFixedSizeBuiltinElements(seq) && !seq->hasMetadata("cs:generic"))
+        {
+            if (context == TypeContext::OutgoingParam)
+            {
+                out << encoderName << ".EncodeSpan(" << fieldName << ".Span)";
+            }
+            else
+            {
+                out << encoderName << ".EncodeSequence(" << fieldName << ")";
+            }
+        }
+        else
+        {
+            TypePtr elementType = seq->type();
+
+            out << encoderName << ".EncodeSequence(";
+            out.inc();
+            out << nl << fieldName << ",";
+            out << nl << "(ref IceEncoder encoder, " << csFieldType(elementType, ns) << " value) =>";
+            out << nl;
+            out.inc();
+            encodeField(out, "value", elementType, ns, TypeContext::Field, "encoder");
+            out.dec();
+            out << ")";
+            out.dec();
+        }
+    }
+    else if (auto dict = dynamic_pointer_cast<Dictionary>(type))
+    {
+        TypePtr keyType = dict->keyType();
+        TypePtr valueType = dict->valueType();
+        out << encoderName << ".EncodeDictionary(";
+        out.inc();
+        out << nl << fieldName << ",";
+        out << nl << "(ref IceEncoder encoder, " << csFieldType(keyType, ns) << " key) =>";
+        out << nl;
+        out.inc();
+        encodeField(out, "key", keyType, ns, TypeContext::Field, "encoder");
+        out.dec();
+        out << ',';
+        out << nl << "(ref IceEncoder encoder, " << csFieldType(valueType, ns) << " value) =>";
+        out << nl;
+        out.inc();
+        encodeField(out, "value", valueType, ns, TypeContext::Field, "encoder");
+        out.dec();
+        out << ")";
+        out.dec();
+    }
+    else
+    {
+        assert(false);
+    }
+}
+
+void
+Slice::Csharp::encodeOptionalField(
+    Output& out,
+    int tag,
+    const string& fieldName,
+    const TypePtr& type,
+    const string& ns,
+    TypeContext context,
+    const string& encoderName)
+{
+    assert(type);
+
+    SequencePtr seq = dynamic_pointer_cast<Sequence>(type);
+    bool readOnlyMemory = seq && hasFixedSizeBuiltinElements(seq) && !seq->hasMetadata("cs:generic") &&
+                          context == TypeContext::OutgoingParam;
+
+    string tagFormat = getTagFormat(type);
+
+    if (readOnlyMemory)
+    {
+        // An outgoing sequence of fixed-size built-ins with no cs:generic metadata is mapped to ReadOnlyMemory<T>, not
+        // to a ReadOnlyMemory<T>?.
+        // A not-set value is represented by ReadOnlyMemory with a default Span. That's what you get when you construct
+        // a ReadOnlyMemory from a null array. Span != default when the ReadOnlyMemory is constructed from a non-null
+        // array, including an empty array.
+        out << nl << "if (" << fieldName << ".Span != default)";
+    }
+    else if (isCsValueType(type))
+    {
+        out << nl << "if (" << fieldName << ".HasValue)";
+    }
+    else
+    {
+        out << nl << "if (" << fieldName << " is not null)";
+    }
+    out << sb;
+
+    if (tagFormat == "VSize" && ((seq && !readOnlyMemory) || dynamic_pointer_cast<Dictionary>(type)))
+    {
+        // Generate count_ variable.
+
+        if (context == TypeContext::OutgoingParam)
+        {
+            // Since fieldName is a regular parameter, we can assign a new variable into it.
+            out << nl << "if (!global::System.Linq.Enumerable.TryGetNonEnumeratedCount(" << fieldName
+                << ", out int count_))";
+            out << sb;
+            out << nl << "var array_ = global::System.Linq.Enumerable.ToArray(" << fieldName << ");";
+            out << nl << "count_ = array_.Length;";
+            out << nl << fieldName << " = array_;";
+            out << eb;
+        }
+        else
+        {
+            out << nl << "int count_ = " << fieldName << ".Count;";
+        }
+    }
+
+    out << nl << encoderName << ".EncodeTagged(";
+    out.inc();
+    out << nl << "tag: " << tag << ",";
+
+    if (tagFormat == "VSize")
+    {
+        // "size" overload
+        out << nl << "size: ";
+        if (auto st = dynamic_pointer_cast<Struct>(type))
+        {
+            out << st->minWireSize();
+        }
+        else if (readOnlyMemory)
+        {
+            out << "IceEncoder.GetSizeLength(" << fieldName << ".Length) + " << seq->type()->minWireSize() << " * "
+                << fieldName << ".Length";
+        }
+        else if (seq)
+        {
+            out << "IceEncoder.GetSizeLength(count_) + " << seq->type()->minWireSize() << " * count_";
+        }
+        else if (auto dict = dynamic_pointer_cast<Dictionary>(type))
+        {
+            out << "IceEncoder.GetSizeLength(count_) + "
+                << (dict->keyType()->minWireSize() + dict->valueType()->minWireSize()) << " * count_";
+        }
+        else
+        {
+            // No other VSize.
+            assert(false);
+        }
+        out << ",";
+    }
+    else
+    {
+        // TagFormat overload
+        out << nl << "TagFormat." << tagFormat << ",";
+    }
+
+    out << nl << fieldName << (isCsValueType(type) ? ".Value" : "") << ",";
+    out << nl << "(ref IceEncoder encoder, " << csType(type, ns, context) << " value) => ";
+    out.inc();
+    encodeField(out, "value", type, ns, context, "encoder");
+    out.dec();
+    out << ");";
+    out.dec();
+
+    out << eb;
+    // else, don't encode anything for null.
+}
+
+void
+Slice::Csharp::decodeField(Output& out, const TypePtr& type, const string& ns)
+{
+    assert(type);
+
+    static const char* builtinTable[] =
+        {"Byte", "Bool", "Short", "Int", "Long", "Float", "Double", "String", "IceObjectProxy", "Class<IceClass>"};
+
+    if (auto builtin = dynamic_pointer_cast<Builtin>(type))
+    {
+        out << "decoder.Decode" << builtinTable[builtin->kind()] << "()";
+    }
+    else if (auto cl = dynamic_pointer_cast<ClassDecl>(type))
+    {
+        out << "decoder.DecodeClass<" << getUnqualified(cl, ns) << ">()";
+    }
+    else if (auto st = dynamic_pointer_cast<Struct>(type))
+    {
+        out << "new " << getUnqualified(st, ns) << "(ref decoder)";
+    }
+    else if (auto proxy = dynamic_pointer_cast<InterfaceDecl>(type))
+    {
+        out << getUnqualified(proxy, ns, "", "ProxyIceDecoderExtensions") << ".Decode"
+            << removeEscapePrefix(proxy->mappedName()) << "Proxy(ref decoder)";
+    }
+    else if (auto en = dynamic_pointer_cast<Enum>(type))
+    {
+        out << getUnqualified(en, ns, "", "IceDecoderExtensions") << ".Decode" << removeEscapePrefix(en->mappedName())
+            << "(ref decoder)";
+    }
+    else if (auto seq = dynamic_pointer_cast<Sequence>(type))
+    {
+        if (auto metadata = seq->getMetadataArgs("cs:generic"))
+        {
+            const string& customType = *metadata;
+            if (customType == "Queue" || customType == "LinkedList" || customType == "List" || customType == "Stack")
+            {
+                out << "decoder.Decode" << customType << "(";
+                out.inc();
+                out << nl << "(ref IceDecoder decoder) => ";
+                castToNestedFieldType(out, seq->type(), ns);
+                decodeField(out, seq->type(), ns);
+                out << ")";
+                out.dec();
+            }
+            else
+            {
+                out << "decoder.DecodeCollection(";
+                out.inc();
+                out << nl << "collectionFactory: _ => new " << csIncomingParamType(seq, ns) << "(),";
+                out << nl << "addElement: (collection, element) => collection.Add(element),";
+                out << nl << "(ref IceDecoder decoder) => ";
+                castToNestedFieldType(out, seq->type(), ns);
+                decodeField(out, seq->type(), ns);
+                out << ")";
+                out.dec();
+            }
+        }
+        else if (hasFixedSizeBuiltinElements(seq))
+        {
+            out << "decoder.DecodeSequence<" << Slice::Csharp::csFieldType(seq->type(), ns) << ">(";
+            if (isBool(seq->type()))
+            {
+                out << "checkElement: IceDecoder.CheckBoolValue";
+            }
+            out << ")";
+        }
+        else
+        {
+            out << "decoder.DecodeSequence(";
+            out.inc();
+            out << nl << "(ref IceDecoder decoder) => ";
+            castToNestedFieldType(out, seq->type(), ns);
+            decodeField(out, seq->type(), ns);
+            out << ")";
+            out.dec();
+        }
+    }
+    else if (auto dict = dynamic_pointer_cast<Dictionary>(type))
+    {
+        TypePtr keyType = dict->keyType();
+        TypePtr valueType = dict->valueType();
+
+        // The concrete type we create.
+        string csDict = csIncomingParamType(dict, ns);
+
+        out << "decoder.DecodeDictionary(";
+        out.inc();
+        out << nl << "size => new " << csDict << "(size),";
+        out << nl << "(ref IceDecoder decoder) => ";
+        decodeField(out, keyType, ns);
+        out << ",";
+        out << nl << "(ref IceDecoder decoder) => ";
+        castToNestedFieldType(out, valueType, ns);
+        decodeField(out, valueType, ns);
+        out << ")";
+        out.dec();
+    }
+    else
+    {
+        assert(false);
+    }
+}
+
+void
+Slice::Csharp::decodeOptionalField(Output& out, int tag, const TypePtr& type, const string& ns, TypeContext context)
+{
+    out << "decoder.DecodeTagged(";
+    out.inc();
+    out << nl << "tag: " << tag << ",";
+    out << nl << "TagFormat." << getTagFormat(type) << ",";
+    out << nl << "(ref IceDecoder decoder) => ";
+    // We need to cast to the optional type unless it's already optional (i.e. a proxy). This is especially important
+    // for value types.
+    if (!isProxyType(type))
+    {
+        out << "(" << csType(type, ns, context) << "?)";
+    }
+    decodeField(out, type, ns);
+    out << ")";
+    out.dec();
+}
+
+void
+Slice::Csharp::writeIceRpcDocComment(
+    Output& out,
+    const ContainedPtr& p,
+    optional<string> generatedType,
+    const string& notes)
+{
+    const optional<DocComment>& comment = p->docComment();
+    StringList remarks;
+    if (comment)
+    {
+        writeDocLines(out, "summary", comment->overview());
+        remarks = comment->remarks();
+    }
+
+    if (generatedType.has_value())
+    {
+        // If there's user-provided remarks, and a generated-type message, we introduce a paragraph between them.
+        if (!remarks.empty())
+        {
+            remarks.emplace_back("<para />");
+        }
+
+        if (!notes.empty())
+        {
+            remarks.push_back(notes);
+        }
+        remarks.push_back(
+            "The Ice compiler generated this " + *generatedType + " from Ice " + p->kindOf() + " <c>" + p->scoped() +
+            "</c>.");
+    }
+
+    if (!remarks.empty())
+    {
+        writeDocLines(out, "remarks", remarks);
+    }
+
+    if (comment)
+    {
+        writeSeeAlso(out, comment->seeAlso());
+    }
+}
+
+void
+Slice::Csharp::writeIceRpcOpDocComment(Output& out, const OperationPtr& op, bool dispatch)
+{
+    const optional<DocComment>& comment = op->docComment();
+    if (!comment)
+    {
+        return;
+    }
+
+    writeDocLines(out, "summary", comment->overview());
+    writeParameterDocComments(out, *comment, op->inParameters());
+
+    // Extra params
+
+    string featuresParam = getEscapedParamName(op->inParameters(), "features");
+    string cancellationTokenParam = getEscapedParamName(op->inParameters(), "cancellationToken");
+
+    if (dispatch)
+    {
+        out << nl << "/// <param name=\"" << featuresParam << "\">The features of this dispatch.</param>";
+    }
+    else
+    {
+        out << nl << "/// <param name=\"" << featuresParam << "\">The features of this invocation.</param>";
+    }
+    out << nl << "/// <param name=\"" << cancellationTokenParam
+        << "\">A cancellation token that receives the cancellation requests.</param>";
+
+    if (op->returnsMultipleValues())
+    {
+        // This tuple description may be confusing if some doc-comments are missing; the user should fix the Ice
+        // doc-comments in this case.
+        out << nl << "/// <returns>A tuple with the following elements:";
+        out << nl << R"(/// <list type="bullet">)";
+        if (op->returnType())
+        {
+            writeDocLines(out, "item><description", comment->returns(), "description></item");
+        }
+        for (const auto& outParam : op->outParameters())
+        {
+            auto q = comment->parameters().find(outParam->name());
+            if (q != comment->parameters().end())
+            {
+                writeDocLines(out, "item><description", q->second, "description></item");
+            }
+        }
+        out << nl << "/// </list></returns>";
+    }
+    else if (op->returnType())
+    {
+        writeDocLines(out, "returns", comment->returns());
+    }
+    else if (op->outParameters().size() == 1)
+    {
+        auto q = comment->parameters().find(op->outParameters().front()->name());
+        if (q != comment->parameters().end())
+        {
+            writeDocLines(out, "returns", q->second);
+        }
+    }
+    else
+    {
+        // Returns nothing
+        if (dispatch)
+        {
+            out << nl << "/// <returns>A value task that completes when the dispatch completes.</returns>";
+        }
+        else
+        {
+            if (op->hasMetadata("oneway"))
+            {
+                out << nl << "/// <returns>A task that completes when the request is sent.</returns>";
+            }
+            else
+            {
+                out << nl << "/// <returns>A task that completes when the response is received.</returns>";
+            }
+        }
+    }
+
+    if (!dispatch)
+    {
+        writeDocLines(
+            out,
+            R"(exception cref="IceRpc.DispatchException")",
+            {"Thrown when the dispatch of the operation failed.",
+             "This exception is provided through the returned task; it's never thrown synchronously."},
+            "exception");
+    }
+
+    for (const auto& [exceptionName, exceptionLines] : comment->exceptions())
+    {
+        string name = exceptionName;
+        ExceptionPtr ex = op->container()->lookupException(exceptionName, false);
+        if (ex)
+        {
+            name = ex->mappedScoped(".");
+        }
+
+        ostringstream openTag;
+        openTag << "exception cref=\"" << name << "\"";
+
+        if (dispatch)
+        {
+            writeDocLines(out, openTag.str(), exceptionLines, "exception");
+        }
+        else
+        {
+            StringList asyncExceptionLines{exceptionLines};
+            asyncExceptionLines.emplace_back(
+                "This exception is provided through the returned task; it's never thrown synchronously.");
+            writeDocLines(out, openTag.str(), asyncExceptionLines, "exception");
+        }
+    }
+
+    writeDocLines(out, "remarks", comment->remarks());
+    writeSeeAlso(out, comment->seeAlso());
+}
+
+void
+Slice::Csharp::writeIceRpcHelperDocComment(
+    Output& out,
+    const ContainedPtr& p,
+    const string& comment,
+    const string& generatedType)
+{
+    // Called only for module-level types.
+    assert(dynamic_pointer_cast<Module>(p->container()));
+    assert(!generatedType.empty());
+
+    writeDocLine(out, "summary", comment);
+    out << nl << "/// <remarks>" << "The Ice compiler generated this " << generatedType << " from Ice " << p->kindOf()
+        << " <c>" << p->scoped() << "</c>.</remarks>";
+}
+
+std::pair<bool, string>
+Slice::Csharp::icerpcLinkFormatter(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target)
+{
+    ostringstream result;
+
+    if (auto builtinTarget = dynamic_pointer_cast<Builtin>(target))
+    {
+        string typeS = csFieldType(builtinTarget, "");
+        if (builtinTarget->kind() == Builtin::KindObjectProxy || builtinTarget->kind() == Builtin::KindValue)
+        {
+            // Remove trailing '?':
+            typeS.pop_back();
+            result << "cref=\"" << typeS << "\"";
+        }
+        else
+        {
+            // All other builtin types correspond to C# language keywords.
+            result << "langword=\"" << typeS << "\"";
+        }
+    }
+    else if (auto contained = dynamic_pointer_cast<Contained>(target))
+    {
+        string sourceScope = source->mappedScope(".");
+        sourceScope.pop_back(); // Remove the trailing '.' ns separator.
+
+        if (dynamic_pointer_cast<Sequence>(contained) || dynamic_pointer_cast<Dictionary>(contained))
+        {
+            // slice2cs doesn't generate C# types for sequences or dictionaries, so there's nothing to link to.
+            // So, we return 'false' to signal this, and just output the sequence or dictionary name.
+            return {false, getUnqualified(contained, sourceScope)};
+        }
+
+        result << "cref=\"";
+        if (auto operationTarget = dynamic_pointer_cast<Operation>(target))
+        {
+            // link to the method on the proxy interface
+            result << getUnqualified(operationTarget->interface(), sourceScope, "", "Proxy") << "."
+                   << removeEscapePrefix(operationTarget->mappedName()) << "Async";
+        }
+        else if (auto interfaceTarget = dynamic_pointer_cast<InterfaceDecl>(target))
+        {
+            // link to the proxy interface
+            result << getUnqualified(interfaceTarget, sourceScope, "", "Proxy");
+        }
+        else
+        {
+            result << getUnqualified(contained, sourceScope);
+        }
+        result << "\"";
+    }
+    else
+    {
+        // Replace "::" by "." in the raw link. This is for the situation where the user passes a Slice type
+        // reference but (a) the source Slice file does not include this type and (b) there is no cs:identifier or
+        // other identifier renaming.
+        string targetS = rawLink;
+        // Replace any "::" ns separators with '.'s.
+        auto pos = targetS.find("::");
+        while (pos != string::npos)
+        {
+            targetS.replace(pos, 2, ".");
+            pos = targetS.find("::", pos);
+        }
+        // Replace any '#' ns separators with '.'s.
+        replace(targetS.begin(), targetS.end(), '#', '.');
+        // Remove any leading ns separators.
+        if (targetS.find('.') == 0)
+        {
+            targetS.erase(0, 1);
+        }
+        result << "cref=\"" << targetS << "\"";
+    }
+
+    return {true, result.str()};
+}

--- a/cpp/src/slice2cs/IceRpcCsUtil.h
+++ b/cpp/src/slice2cs/IceRpcCsUtil.h
@@ -1,0 +1,120 @@
+// Copyright (c) ZeroC, Inc.
+
+#ifndef ICE_RPC_CS_UTIL_H
+#define ICE_RPC_CS_UTIL_H
+
+#include "../Ice/OutputUtil.h"
+#include "../Slice/DocCommentParser.h"
+#include "../Slice/Parser.h"
+
+// IceRPC-specific helper functions for C# code generation.
+
+namespace Slice::Csharp
+{
+    enum class TypeContext
+    {
+        Field,
+        IncomingParam,
+        OutgoingParam
+    };
+
+    /// Does this type map to a value type in C#?
+    [[nodiscard]] bool isCsValueType(const TypePtr& type);
+
+    /// Maps a Slice type to a C# field type.
+    /// @param type The Slice type to map.
+    /// @param ns The current C# namespace.
+    /// @param optional Whether the field is optional.
+    /// @return The C# type for the field.
+    [[nodiscard]] std::string csFieldType(const TypePtr& type, const std::string& ns, bool optional = false);
+
+    /// Maps a Slice type to a C# incoming parameter type.
+    /// @param type The Slice type to map.
+    /// @param ns The current C# namespace.
+    /// @param optional Whether the parameter is optional.
+    /// @return The C# type for the incoming parameter.
+    [[nodiscard]] std::string csIncomingParamType(const TypePtr& type, const std::string& ns, bool optional = false);
+
+    /// Maps a Slice type to a C# outgoing parameter type.
+    /// @param type The Slice type to map.
+    /// @param ns The current C# namespace.
+    /// @param optional Whether the parameter is optional.
+    /// @return The C# type for the outgoing parameter.
+    [[nodiscard]] std::string csOutgoingParamType(const TypePtr& type, const std::string& ns, bool optional = false);
+
+    /// Maps a Slice type to a C# type based on TypeContext.
+    [[nodiscard]] std::string
+    csType(const TypePtr& type, const std::string& ns, TypeContext context, bool optional = false);
+
+    /// Returns whether the mapped C# field is required or not.
+    [[nodiscard]] bool csRequired(const DataMemberPtr& field);
+
+    /// Encodes a non-optional field.
+    void encodeField(
+        ::IceInternal::Output& out,
+        const std::string& fieldName,
+        const TypePtr& type,
+        const std::string& ns,
+        TypeContext context,
+        const std::string& encoderName);
+
+    /// Encodes an optional field.
+    void encodeOptionalField(
+        ::IceInternal::Output& out,
+        int tag,
+        const std::string& fieldName,
+        const TypePtr& type,
+        const std::string& ns,
+        TypeContext context,
+        const std::string& encoderName);
+
+    /// Decodes a non-optional field.
+    void decodeField(::IceInternal::Output& out, const TypePtr& type, const std::string& ns);
+
+    /// Decodes an optional field.
+    void decodeOptionalField(
+        ::IceInternal::Output& out,
+        int tag,
+        const TypePtr& type,
+        const std::string& ns,
+        TypeContext context);
+
+    //
+    // Doc-comments
+    //
+
+    /// Writes a doc-comment for the given Slice element, using this element's doc-comment, if any.
+    /// @param p The Slice element.
+    /// @param generatedType The kind of mapped element, used for the remarks. For example, "server-side interface".
+    /// This function does not write any remarks when this argument is nullopt.
+    /// @param notes Optional notes included after @p p's remarks.
+    void writeIceRpcDocComment(
+        IceInternal::Output& out,
+        const ContainedPtr& p,
+        std::optional<std::string> generatedType = std::nullopt,
+        const std::string& notes = "");
+
+    /// Writes a doc-comment for a helper class generated for a Slice element.
+    /// @param p The Slice element.
+    /// @param comment The summary.
+    /// @param generatedType The kind of mapped element, used for the remarks. Never empty.
+    void writeIceRpcHelperDocComment(
+        IceInternal::Output& out,
+        const ContainedPtr& p,
+        const std::string& comment,
+        const std::string& generatedType);
+
+    void writeIceRpcOpDocComment(IceInternal::Output& out, const OperationPtr& operation, bool dispatch);
+
+    /// Converts a Slice-formatted link into a C# formatted link.
+    /// @param rawLink The reference's raw text, taken verbatim from the doc-comment.
+    /// @param source A pointer to the Slice element that the doc-comment (and reference) are written on.
+    /// @param target A pointer to the Slice element that is being referenced, or `nullptr` if it doesn't exist.
+    /// @returns A pair containing:
+    /// - @c false if the link was to a Slice element which isn't mapped in C#; @c true otherwise.
+    /// - The C# formatted link.
+    std::pair<bool, std::string>
+    icerpcLinkFormatter(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target);
+}
+
+#endif

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -1,0 +1,1595 @@
+// Copyright (c) ZeroC, Inc.
+
+#include "IceRpcVisitors.h"
+#include "../Slice/Util.h"
+#include "CsUtil.h"
+#include "IceRpcCsUtil.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <iterator>
+
+using namespace std;
+using namespace Slice;
+using namespace Slice::Csharp;
+using namespace IceInternal;
+
+namespace
+{
+    // Returns paramName as-is or escaped if it conflicts with any of the parameter names in params.
+    // paramName never starts with an escape prefix.
+    string escapeCapitalizedParamName(const ParameterList& params, string paramName)
+    {
+        for (const auto& param : params)
+        {
+            if (toPascalCase(param->mappedName()) == paramName)
+            {
+                return paramName + "_";
+            }
+        }
+        return paramName;
+    }
+
+    string defaultServicePath(const InterfaceDefPtr& interface)
+    {
+        string path = interface->scoped().substr(2); // Remove leading '::'
+        string::size_type pos = 0;
+        while ((pos = path.find("::", pos)) != string::npos)
+        {
+            path.replace(pos, 2, ".");
+            pos += 1;
+        }
+
+        return "/" + path;
+    }
+
+    string classFormat(const OperationPtr& operation)
+    {
+        FormatType format = operation->format().value_or(FormatType::CompactFormat);
+        return format == FormatType::SlicedFormat ? "ClassFormat.Sliced" : "default";
+    }
+
+    void writeReturnTask(IceInternal::Output& out, const OperationPtr& operation, const string& taskType, bool dispatch)
+    {
+        string ns = getNamespace(operation->interface());
+
+        out << "global::System.Threading.Tasks." << taskType;
+
+        TypeContext returnContext = dispatch ? TypeContext::OutgoingParam : TypeContext::IncomingParam;
+
+        if (operation->returnsAnyValues())
+        {
+            out << '<';
+            if (dispatch && operation->hasMarshaledResult())
+            {
+                out << "global::System.IO.Pipelines.PipeReader";
+            }
+            else
+            {
+                ParameterList returnParams = operation->outParameters();
+                if (operation->returnType())
+                {
+                    string returnParamName = escapeCapitalizedParamName(returnParams, "ReturnValue");
+                    returnParams.insert(returnParams.begin(), operation->returnParameter(returnParamName));
+                }
+
+                if (returnParams.size() == 1)
+                {
+                    out << csType(returnParams.front()->type(), ns, returnContext, returnParams.front()->optional());
+                }
+                else
+                {
+                    out << spar;
+                    for (const auto& param : returnParams)
+                    {
+                        out
+                            << (csType(param->type(), ns, returnContext, param->optional()) + " " +
+                                toPascalCase(param->mappedName()));
+                    }
+                    out << epar;
+                }
+            }
+            out << '>';
+        }
+    }
+
+    // A ValueTask that holds all the decoded in parameters,
+    void writeParamsValueTask(IceInternal::Output& out, const OperationPtr& operation)
+    {
+        string ns = getNamespace(operation->interface());
+
+        out << "global::System.Threading.Tasks.ValueTask";
+
+        ParameterList inParameters = operation->inParameters();
+        if (!inParameters.empty())
+        {
+            out << '<';
+            if (inParameters.size() == 1)
+            {
+                out << csIncomingParamType(inParameters.front()->type(), ns, inParameters.front()->optional());
+            }
+            else
+            {
+                out << spar;
+                for (const auto& param : inParameters)
+                {
+                    out
+                        << (csIncomingParamType(param->type(), ns, param->optional()) + " " +
+                            toPascalCase(param->mappedName()));
+                }
+                out << epar;
+            }
+            out << '>';
+        }
+    }
+
+    /// Writes the method signature for an operation, without access or semicolon.
+    /// @param out The output to write to.
+    /// @param operation The operation being mapped to C#.
+    /// @param ns The current C# namespace.
+    /// @param dispatch If true, writes the signature for the dispatch method (with incoming parameter types and a
+    /// ValueTask return type); if false, writes the signature for the proxy method.
+    void
+    writeMethodSignature(IceInternal::Output& out, const OperationPtr& operation, const std::string& ns, bool dispatch)
+    {
+        TypeContext paramContext = dispatch ? TypeContext::IncomingParam : TypeContext::OutgoingParam;
+
+        string featuresParam = getEscapedParamName(operation->inParameters(), "features");
+        string cancellationTokenParam = getEscapedParamName(operation->inParameters(), "cancellationToken");
+
+        vector<string> extraParams;
+        if (dispatch)
+        {
+            extraParams = {
+                "IceRpc.Features.IFeatureCollection " + featuresParam,
+                "global::System.Threading.CancellationToken " + cancellationTokenParam};
+        }
+        else
+        {
+            extraParams = {
+                "IceRpc.Features.IFeatureCollection? " + featuresParam + " = null",
+                "global::System.Threading.CancellationToken " + cancellationTokenParam + " = default"};
+        }
+
+        writeReturnTask(out, operation, dispatch ? "ValueTask" : "Task", dispatch);
+        out << ' ' << removeEscapePrefix(operation->mappedName()) << "Async(";
+        out.inc();
+        for (const auto& param : operation->inParameters())
+        {
+            out << nl << csType(param->type(), ns, paramContext, param->optional()) << ' ' << param->mappedName()
+                << ',';
+        }
+
+        for (auto q = extraParams.begin(); q != extraParams.end();)
+        {
+            out << nl << *q;
+            if (++q != extraParams.end())
+            {
+                out << ',';
+            }
+        }
+        out << ')';
+        out.dec();
+    }
+
+    string accessModifier(const ContainedPtr& p) { return p->hasMetadata("cs:internal") ? "internal" : "public"; }
+}
+
+Slice::IceRpc::TypesVisitor::TypesVisitor(IceInternal::Output& out) : CsVisitor(out) {}
+
+bool
+Slice::IceRpc::TypesVisitor::visitStructStart(const StructPtr& p)
+{
+    _out << sp;
+    writeIceRpcDocComment(_out, p, "record struct");
+    emitObsoleteAttribute(p);
+
+    _out << nl << accessModifier(p) << (p->hasMetadata("cs:readonly") ? " readonly" : "") << " partial record struct "
+         << p->mappedName();
+    _out << sb;
+    return true;
+}
+
+void
+Slice::IceRpc::TypesVisitor::visitStructEnd(const StructPtr& p)
+{
+    string escapedName = p->mappedName();
+    string ns = getNamespace(p);
+
+    // We need an explicit public parameterless constructor if the struct has any default values.
+    for (const auto& field : p->dataMembers())
+    {
+        if (field->defaultValue())
+        {
+            _out << sp;
+            writeDocLine(
+                _out,
+                "summary",
+                "Initializes a new instance of the <see cref=\"" + escapedName + "\" /> struct.");
+            _out << nl << "public " << escapedName << "()";
+            _out << sb;
+            _out << eb;
+            break;
+        }
+    }
+
+    bool hasRequiredField = writePrimaryConstructor(p, p->dataMembers(), {}, "struct");
+
+    // Decoding constructor.
+    _out << sp;
+    writeDocLine(
+        _out,
+        "summary",
+        "Initializes a new instance of the <see cref=\"" + escapedName + "\" /> struct from an IceDecoder.");
+
+    if (hasRequiredField)
+    {
+        _out << nl << "[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]";
+    }
+
+    _out << nl << accessModifier(p) << ' ' << escapedName << "(ref IceDecoder decoder)";
+    _out << sb;
+    for (const auto& field : p->dataMembers())
+    {
+        _out << nl << "this." + field->mappedName() << " = ";
+        decodeField(_out, field->type(), ns);
+        _out << ';';
+    }
+    _out << eb;
+
+    // Encode method.
+    _out << sp;
+    writeDocLine(_out, "summary", "Encodes the fields of this struct with an Ice encoder.");
+
+    _out << nl << accessModifier(p) << " readonly void Encode(ref IceEncoder encoder)";
+    _out << sb;
+    for (const auto& field : p->dataMembers())
+    {
+        _out << nl;
+        encodeField(_out, "this." + field->mappedName(), field->type(), ns, TypeContext::Field, "encoder");
+        _out << ';';
+    }
+    _out << eb;
+
+    _out << eb;
+}
+
+bool
+Slice::IceRpc::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
+{
+    string ns = getNamespace(p);
+
+    _out << sp;
+    writeIceRpcDocComment(_out, p, "class");
+    emitObsoleteAttribute(p);
+    _out << nl << "[IceTypeId(\"" << p->scoped() << "\")]";
+    if (p->compactId() != -1)
+    {
+        _out << nl << "[CompactIceTypeId(" << p->compactId() << ")]";
+    }
+    _out << nl << accessModifier(p) << " partial class " << p->mappedName() << " : ";
+
+    ClassDefPtr base = p->base();
+    if (base)
+    {
+        _out << getUnqualified(base, ns);
+    }
+    else
+    {
+        _out << "IceClass";
+    }
+    _out << sb;
+    return true;
+}
+
+void
+Slice::IceRpc::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
+{
+    string escapedName = p->mappedName();
+    string ns = getNamespace(p);
+
+    if (!p->dataMembers().empty())
+    {
+        _out << sp;
+    }
+    _out << nl << "private static readonly string IceTypeId = typeof(" << escapedName << ").GetIceTypeId()!;";
+    if (p->compactId() != -1)
+    {
+        _out << nl << "private static readonly int CompactIceTypeId = typeof(" << escapedName
+             << ").GetCompactIceTypeId()!.Value;";
+    }
+
+    if (!p->allDataMembers().empty())
+    {
+        DataMemberList allBaseFields;
+        if (p->base())
+        {
+            allBaseFields = p->base()->allDataMembers();
+        }
+
+        writePrimaryConstructor(p, p->dataMembers(), allBaseFields, "class");
+
+        // Public parameterless constructor. Must be public for decoding to work.
+        _out << sp;
+        writeDocLine(_out, "summary", "Initializes a new instance of the <see cref=\"" + escapedName + "\" /> class.");
+        _out << nl << "public " << escapedName << "()";
+        _out << sb;
+        _out << eb;
+    }
+    // else, no need to generate any constructor.
+
+    writeEncodeDecode(p->compactId(), ns, p->base() != nullptr, p->dataMembers(), p->orderedOptionalDataMembers());
+
+    _out << eb;
+}
+
+bool
+Slice::IceRpc::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
+{
+    string ns = getNamespace(p);
+
+    _out << sp;
+    writeIceRpcDocComment(_out, p, "exception class");
+    emitObsoleteAttribute(p);
+    _out << nl << "[IceTypeId(\"" << p->scoped() << "\")]";
+    _out << nl << accessModifier(p) << " partial class " << p->mappedName() << " : ";
+
+    ExceptionPtr base = p->base();
+    if (base)
+    {
+        _out << getUnqualified(base, ns);
+    }
+    else
+    {
+        _out << "IceException";
+    }
+    _out << sb;
+    return true;
+}
+
+void
+Slice::IceRpc::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
+{
+    string escapedName = p->mappedName();
+    string ns = getNamespace(p);
+
+    if (!p->dataMembers().empty())
+    {
+        _out << sp;
+    }
+    _out << nl << "private static readonly string IceTypeId = typeof(" << escapedName << ").GetIceTypeId()!;";
+
+    if (!p->allDataMembers().empty())
+    {
+        DataMemberList allBaseFields;
+        if (p->base())
+        {
+            allBaseFields = p->base()->allDataMembers();
+        }
+
+        writePrimaryConstructor(p, p->dataMembers(), allBaseFields, "exception class");
+
+        // Public parameterless constructor. Must be public for decoding to work.
+        _out << sp;
+        writeDocLine(
+            _out,
+            "summary",
+            "Initializes a new instance of the <see cref=\"" + escapedName + "\" /> exception class.");
+        _out << nl << "public " << escapedName << "()";
+        _out << sb;
+        _out << eb;
+    }
+    // else, no need to generate any constructor.
+
+    writeEncodeDecode(-1, ns, p->base() != nullptr, p->dataMembers(), p->orderedOptionalDataMembers());
+
+    _out << eb;
+}
+
+void
+Slice::IceRpc::TypesVisitor::visitDataMember(const DataMemberPtr& p)
+{
+    ContainedPtr cont = dynamic_pointer_cast<Contained>(p->container());
+    assert(cont);
+    string ns = getNamespace(cont);
+
+    _out << sp;
+    writeIceRpcDocComment(_out, p);
+    emitObsoleteAttribute(p);
+    emitAttributes(p);
+    _out << nl << accessModifier(cont) << ' ';
+    if (csRequired(p))
+    {
+        _out << "required ";
+    }
+    _out << csFieldType(p->type(), ns, p->optional()) << ' ' << p->mappedName();
+
+    if (cont->hasMetadata("cs:readonly"))
+    {
+        _out << " { get; init; }";
+    }
+    else
+    {
+        _out << " { get; set; }";
+    }
+
+    if (p->defaultValue())
+    {
+        string defaultValue = *p->defaultValue();
+        BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(p->type());
+
+        // Don't explicitly initialize to default value.
+        if (!builtin || builtin->kind() == Builtin::KindString || (defaultValue != "0" && defaultValue != "false"))
+        {
+            _out << " = ";
+            writeConstantValue(_out, p->type(), p->defaultValueType(), defaultValue, ns, "Value");
+            _out << ';';
+        }
+    }
+}
+
+void
+Slice::IceRpc::TypesVisitor::visitEnum(const EnumPtr& p)
+{
+    string escapedName = p->mappedName();
+    string name = removeEscapePrefix(p->mappedName());
+    string ns = getNamespace(p);
+    EnumeratorList enumerators = p->enumerators();
+    const bool hasExplicitValues = p->hasExplicitValues();
+
+    _out << sp;
+    writeIceRpcDocComment(_out, p, "enum");
+    emitObsoleteAttribute(p);
+    emitAttributes(p);
+    _out << nl << accessModifier(p) << " enum " << escapedName;
+    _out << sb;
+    for (const auto& enumerator : enumerators)
+    {
+        if (!isFirstElement(enumerator))
+        {
+            _out << ',';
+            _out << sp;
+        }
+
+        writeIceRpcDocComment(_out, enumerator);
+        emitObsoleteAttribute(enumerator);
+        emitAttributes(enumerator);
+        _out << nl << enumerator->mappedName();
+        if (hasExplicitValues)
+        {
+            _out << " = " << enumerator->value();
+        }
+    }
+    _out << eb;
+
+    //
+    // XxxIntExtensions
+    //
+    _out << sp;
+    ostringstream intExtensionsComment;
+    intExtensionsComment << "Provides an extension method for creating " << getArticleFor(name) << " <see cref=\""
+                         << escapedName << "\" /> from an int.";
+    writeIceRpcHelperDocComment(_out, p, intExtensionsComment.str(), "enum helper class");
+    _out << nl << accessModifier(p) << " static class " << name << "IntExtensions";
+    _out << sb;
+
+    // When the number of enumerators is smaller than the distance between the min and max
+    // values, the values are not consecutive and we need to use a set to validate the value
+    // during decoding.
+    // Note that the values are not necessarily in order, e.g. we can use a simple range check
+    // for enum E { A = 3, B = 2, C = 1 } during decoding.
+    bool useSet = p->enumerators().size() < static_cast<size_t>(p->maxValue() - p->minValue() + 1);
+
+    if (useSet)
+    {
+        _out << nl
+             << "private static readonly global::System.Collections.Generic.HashSet<int> _enumeratorValues = new()";
+        _out.spar("{ ");
+        for (const auto& enumerator : enumerators)
+        {
+            _out << enumerator->value();
+        }
+        _out.epar(" };");
+        _out << sp;
+    }
+
+    writeDocLine(_out, "summary", "Converts an integer value to the corresponding " + escapedName + " enumerator.");
+    writeDocLine(_out, R"(param name="value")", "The integer value to convert.", "param");
+    writeDocLine(_out, "returns", "The corresponding " + escapedName + " enumerator.");
+    writeDocLine(
+        _out,
+        R"(exception cref="System.IO.InvalidDataException")",
+        "Thrown if the integer value does not correspond to any enumerator of " + escapedName + ".",
+        "exception");
+    _out << nl << accessModifier(p) << " static " << escapedName << " As" << name << "(this int value) =>";
+    _out.inc();
+    if (useSet)
+    {
+        _out << nl << "_enumeratorValues.Contains(value) ? ";
+    }
+    else
+    {
+        _out << nl << "(value >= " << p->minValue() << " && value <= " << p->maxValue() << ") ? ";
+    }
+    _out << "(" << escapedName << ")value :";
+    _out.inc();
+    _out << nl << "throw new global::System.IO.InvalidDataException($\"Invalid value {value} for enum " << escapedName
+         << ".\");";
+    _out.dec();
+    _out.dec();
+    _out << eb;
+
+    //
+    // XxxIceEncoderExtensions and XxxIceDecoderExtensions
+    //
+    _out << sp;
+    ostringstream encoderExtensionsComment;
+    encoderExtensionsComment << "Provides an extension method for encoding " << getArticleFor(name) << " <see cref=\""
+                             << escapedName << "\" />.";
+    writeIceRpcHelperDocComment(_out, p, encoderExtensionsComment.str(), "enum helper class");
+    _out << nl << accessModifier(p) << " static class " << name << "IceEncoderExtensions";
+    _out << sb;
+
+    writeDocLine(_out, "summary", "Encodes an enumerator.");
+    writeDocLine(_out, R"(param name="encoder")", "The Ice encoder.", "param");
+    writeDocLine(_out, R"(param name="value")", "The enumerator value to encode.", "param");
+    _out << nl << accessModifier(p) << " static void Encode" << name << "(this ref IceEncoder encoder, " << escapedName
+         << " value) => encoder.EncodeSize((int)value);";
+    _out << eb;
+
+    _out << sp;
+    ostringstream decoderExtensionsComment;
+    decoderExtensionsComment << "Provides an extension method for decoding " << getArticleFor(name) << " <see cref=\""
+                             << escapedName << "\" />.";
+    writeIceRpcHelperDocComment(_out, p, decoderExtensionsComment.str(), "enum helper class");
+    _out << nl << accessModifier(p) << " static class " << name << "IceDecoderExtensions";
+    _out << sb;
+
+    writeDocLine(_out, "summary", "Decodes an enumerator.");
+    writeDocLine(_out, R"(param name="decoder")", "The Ice decoder.", "param");
+    writeDocLine(_out, "returns", "The decoded enumerator value.");
+    _out << nl << accessModifier(p) << " static " << escapedName << " Decode" << name
+         << "(this ref IceDecoder decoder) => " << name << "IntExtensions.As" << name << "(decoder.DecodeSize());";
+    _out << eb;
+}
+
+bool
+Slice::IceRpc::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
+{
+    string ns = getNamespace(p);
+    string escapedName = p->mappedName();
+    string name = removeEscapePrefix(escapedName);
+
+    // Generate the client interface.
+    _out << sp;
+    ostringstream notes;
+    notes << "Use the methods of this interface to invoke operations on a remote Ice service that implements <c>"
+          << p->name() << "</c>.";
+    writeIceRpcDocComment(_out, p, "client-side interface", notes.str());
+    emitObsoleteAttribute(p);
+    _out << nl << accessModifier(p) << " partial interface I" << name;
+    if (!p->bases().empty())
+    {
+        _out << " : ";
+        _out.spar("");
+        for (const auto& base : p->bases())
+        {
+            _out << getUnqualified(base, ns, "I");
+        }
+        _out.epar("");
+    }
+
+    _out << sb;
+
+    return true;
+}
+
+void
+Slice::IceRpc::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
+{
+    string ns = getNamespace(p);
+    string escapedName = p->mappedName();
+    string name = removeEscapePrefix(escapedName);
+
+    _out << eb; // end of client interface
+
+    // Generate the proxy struct.
+    _out << sp;
+
+    writeDocLines(
+        _out,
+        "summary",
+        {"Implements <see cref=\"I" + name + "\" /> by making invocations on a remote IceRPC service.",
+         "This remote service must implement Ice interface <c>" + p->scoped() + "</c>."});
+
+    _out << nl << "[IceTypeId(\"" << p->scoped() << "\")]";
+    emitObsoleteAttribute(p);
+    _out << nl << accessModifier(p) << " readonly partial record struct " << name << "Proxy : " << 'I' << name
+         << ", IIceProxy";
+
+    _out << sb;
+
+    writeProxyRequestClass(p);
+    _out << sp;
+    writeProxyResponseClass(p);
+    _out << sp;
+
+    // EncodeOptions, Invoker and ServiceAddress come from IIceProxy; they must be public.
+
+    _out << nl << "/// <summary>Represents the default path for IceRPC services that implement Ice interface";
+    _out << nl << "/// <c>" << p->scoped() << "</c>.</summary>";
+    _out << nl << accessModifier(p) << " const string DefaultServicePath = \"" << defaultServicePath(p) << "\";";
+    _out << sp;
+    _out << nl << "/// <inheritdoc/>";
+    _out << nl << "public IceEncodeOptions? EncodeOptions { get; init; }";
+    _out << sp;
+    _out << nl << "/// <inheritdoc/>";
+    _out << nl << "public required IceRpc.IInvoker Invoker { get; init; }";
+    _out << sp;
+    _out << nl << "/// <inheritdoc/>";
+    _out << nl << "public IceRpc.ServiceAddress ServiceAddress";
+    _out << sb;
+    _out << nl << "get;";
+    _out << nl << "init";
+    _out << sb;
+    _out << nl << "if (value.Protocol is null)";
+    _out << sb;
+    _out << nl
+         << R"(throw new System.ArgumentException("An Ice proxy's service address must have a non-null protocol.", )"
+         << "nameof(value));";
+    _out << eb;
+    _out << nl << "field = value;";
+    _out << eb;
+    _out << eb << " = _defaultServiceAddress;";
+    _out << sp;
+    _out << nl << "private static IceRpc.ServiceAddress _defaultServiceAddress =";
+    _out.inc();
+    _out << nl << "new(IceRpc.Protocol.Ice) { Path = DefaultServicePath };";
+    _out.dec();
+    _out << sp;
+    _out << nl << "private static readonly IActivator _defaultActivator =";
+    _out.inc();
+    _out << nl << "IActivator.FromAssembly(typeof(" << name << "Proxy).Assembly);";
+    _out.dec();
+
+    // Implicit base conversions
+    for (const auto& base : p->allBases())
+    {
+        _out << sp;
+        string baseName = getUnqualified(base, ns, "", "Proxy");
+        writeDocLine(_out, "summary", "Provides an implicit conversion to <see cref =\"" + baseName + "\" />.");
+
+        _out << nl << accessModifier(p) << " static implicit operator " << baseName << "(" << name << "Proxy proxy) =>";
+        _out.inc();
+        _out << nl
+             << "new() { EncodeOptions = proxy.EncodeOptions, Invoker = proxy.Invoker, ServiceAddress = "
+                "proxy.ServiceAddress };";
+        _out.dec();
+    }
+
+    // Primary constructor (invoker, serviceAddress, encodeOptions).
+    _out << sp;
+    _out << nl << "/// <summary>Constructs a proxy from an invoker, a service address and encode options.</summary>";
+    _out << nl << R"(/// <param name="invoker">The invocation pipeline of the proxy.</param>)";
+    _out << nl
+         << R"(/// <param name="serviceAddress">The service address. <see langword="null" /> is equivalent to the )";
+    _out << nl
+         << R"(/// default service address (protocol: <c>ice</c>, path: <see cref="DefaultServicePath" />).</param>)";
+    _out << nl
+         << R"(/// <param name="encodeOptions">The encode options, used to customize the encoding of request )"
+            "payloads.</param>";
+    _out << nl << "[System.Diagnostics.CodeAnalysis.SetsRequiredMembers]";
+    _out << nl << accessModifier(p) << ' ' << name << "Proxy(";
+    _out.inc();
+    _out << nl << "IceRpc.IInvoker invoker,";
+    _out << nl << "IceRpc.ServiceAddress? serviceAddress = null,";
+    _out << nl << "IceEncodeOptions? encodeOptions = null)";
+    _out.dec();
+    _out << sb;
+    _out << nl << "Invoker = invoker;";
+    _out << nl << "ServiceAddress = serviceAddress ?? _defaultServiceAddress;";
+    _out << nl << "EncodeOptions = encodeOptions;";
+    _out << eb;
+
+    // Constructor (invoker, serviceAddressUri, encodeOptions).
+    _out << sp;
+    _out << nl
+         << "/// <summary>Constructs a proxy from an invoker, a service address URI and encode options.</summary>";
+    _out << nl << R"(/// <param name="invoker">The invocation pipeline of the proxy.</param>)";
+    _out << nl << R"(/// <param name="serviceAddressUri">A URI that represents a service address.</param>)";
+    _out << nl
+         << R"(/// <param name="encodeOptions">The encode options, used to customize the encoding of request )"
+            "payloads.</param>";
+    _out << nl << "[System.Diagnostics.CodeAnalysis.SetsRequiredMembers]";
+    _out << nl << accessModifier(p) << ' ' << name
+         << "Proxy(IceRpc.IInvoker invoker, System.Uri serviceAddressUri, IceEncodeOptions? encodeOptions = "
+            "null)";
+    _out.inc();
+    _out << nl << ": this(invoker, new IceRpc.ServiceAddress(serviceAddressUri), encodeOptions)";
+    _out.dec();
+    _out << sb;
+    _out << eb;
+
+    // Parameterless constructor.
+    // This constructor does not generate [System.Diagnostics.CodeAnalysis.SetsRequiredMembers], so the caller must
+    // initialize the required Invoker.
+    _out << sp;
+    _out << nl << "/// <summary>Constructs a proxy that uses the default service address: its protocol is <c>ice</c>"
+         << nl << R"(/// and its path is <see cref="DefaultServicePath" />.</summary>)";
+    _out << nl << accessModifier(p) << ' ' << name << "Proxy()";
+    _out << sb;
+    _out << eb;
+
+    // Inherited operations
+    for (const auto& operation : p->allInheritedOperations())
+    {
+        // The implementation of interface methods must be public.
+        _out << sp;
+        _out << nl << "/// <inheritdoc />";
+        _out << nl << "public ";
+
+        string featureParam = getEscapedParamName(operation->inParameters(), "features");
+        string cancellationTokenParam = getEscapedParamName(operation->inParameters(), "cancellationToken");
+
+        writeMethodSignature(_out, operation, ns, false);
+
+        _out << " =>";
+        _out.inc();
+        _out << nl << "((" << getUnqualified(operation->interface(), ns, "", "Proxy") << ")this)."
+             << removeEscapePrefix(operation->mappedName()) << "Async";
+        _out << spar;
+        for (const auto& param : operation->inParameters())
+        {
+            _out << param->mappedName();
+        }
+
+        _out << featureParam << cancellationTokenParam;
+        _out << epar;
+        _out << ';';
+        _out.dec();
+    }
+
+    // My operations
+    for (const auto& operation : p->operations())
+    {
+        // The implementation of interface methods must be public.
+        _out << sp;
+        _out << nl << "/// <inheritdoc/>";
+        _out << nl << "public ";
+
+        string operationName = removeEscapePrefix(operation->mappedName());
+        string featureParam = getEscapedParamName(operation->inParameters(), "features");
+        string cancellationTokenParam = getEscapedParamName(operation->inParameters(), "cancellationToken");
+        string encodeOptionsParam = getEscapedParamName(operation->inParameters(), "encodeOptions");
+
+        writeMethodSignature(_out, operation, ns, false);
+
+        _out << " =>";
+        _out.inc();
+
+        // IceRPC-Slice provides a `[compress]` attribute to compress request/response payloads for requests/responses
+        // sent over the icerpc protocol. There is no equivalent for [compress] in Ice-Slice; this is not a serious
+        // limitation since Ice-Slice is used primarily with the ice protocol.
+
+        _out << nl << "this.InvokeOperationAsync(";
+        _out.inc();
+        _out << nl << "\"" << operation->name() << "\",";
+        if (operation->inParameters().empty())
+        {
+            _out << nl << "payload: Request.Encode" << operationName << "(" << encodeOptionsParam
+                 << ": EncodeOptions),";
+        }
+        else
+        {
+            _out << nl << "payload: Request.Encode" << operationName;
+            _out << spar;
+            for (const auto& param : operation->inParameters())
+            {
+                _out << param->mappedName();
+            }
+            _out << (encodeOptionsParam + ": EncodeOptions");
+            _out << epar;
+            _out << ',';
+        }
+        _out << nl << "Response.Decode" << operationName << "Async,";
+        _out << nl << featureParam << ",";
+        if (operation->mode() == Operation::Idempotent)
+        {
+            _out << nl << "idempotent: true,";
+        }
+        if (operation->hasMetadata("oneway"))
+        {
+            _out << nl << "oneway: true,";
+        }
+
+        _out << nl << "cancellationToken: " << cancellationTokenParam << ");";
+        _out.dec();
+
+        _out.dec();
+    }
+    _out << eb;
+
+    // Generate extension classes.
+    _out << sp;
+    writeDocLine(
+        _out,
+        "summary",
+        R"(Provides an extension method for <see cref="IceEncoder" /> to encode a <see cref=")" + name +
+            R"(Proxy" />.")");
+    _out << nl << accessModifier(p) << " static class " << name << "ProxyIceEncoderExtensions";
+    _out << sb;
+    writeDocLine(_out, "summary", R"(Encodes a <see cref=")" + name + R"(Proxy" /> instance.)");
+    writeDocLine(_out, R"(param name="encoder")", "The Ice encoder.", "param");
+    writeDocLine(_out, R"(param name="proxy")", "The proxy to encode (can be null).", "param");
+    _out << nl << accessModifier(p) << " static void Encode" << name << "Proxy(this ref IceEncoder encoder, " << name
+         << "Proxy? proxy) =>";
+    _out.inc();
+    _out << nl << "encoder.EncodeProxy(proxy);";
+    _out.dec();
+    _out << eb;
+
+    _out << sp;
+    writeDocLine(
+        _out,
+        "summary",
+        R"(Provides an extension method for <see cref="IceDecoder" /> to decode a nullable <see cref=")" + name +
+            R"(Proxy" /> instance.)");
+
+    _out << nl << accessModifier(p) << " static class " << name << "ProxyIceDecoderExtensions";
+    _out << sb;
+    writeDocLine(_out, "summary", R"(Decodes a nullable <see cref=")" + name + R"(Proxy" /> instance.)");
+    writeDocLine(_out, R"(param name="decoder")", "The Ice decoder.", "param");
+    _out << nl << accessModifier(p) << " static " << name << "Proxy? Decode" << name
+         << "Proxy(this ref IceDecoder decoder) =>";
+    _out.inc();
+    _out << nl << "decoder.DecodeProxy<" << name << "Proxy>();";
+    _out.dec();
+    _out << eb;
+}
+
+void
+Slice::IceRpc::TypesVisitor::visitOperation(const OperationPtr& p)
+{
+    string ns = getNamespace(p->interface());
+
+    _out << sp;
+    writeIceRpcOpDocComment(_out, p, false);
+    emitObsoleteAttribute(p);
+    _out << nl;
+    writeMethodSignature(_out, p, ns, false);
+    _out << ';';
+}
+
+void
+Slice::IceRpc::TypesVisitor::visitConst(const ConstPtr& p)
+{
+    string ns = getNamespace(p);
+
+    _out << sp;
+    writeIceRpcHelperDocComment(_out, p, "Provides the " + p->mappedName() + " constant.", "helper class");
+    _out << nl << accessModifier(p) << " static class " << p->mappedName();
+    _out << sb;
+    writeIceRpcDocComment(_out, p);
+    emitAttributes(p);
+    _out << nl << accessModifier(p) << " const " << csFieldType(p->type(), ns) << " Value = ";
+    writeConstantValue(_out, p->type(), p->valueType(), p->value(), ns, "Value");
+    _out << ';';
+    _out << eb;
+}
+
+bool
+Slice::IceRpc::TypesVisitor::writePrimaryConstructor(
+    const ContainedPtr& p,
+    const DataMemberList& fields,
+    const DataMemberList& allBaseFields,
+    const string& kind)
+{
+    // Primary constructor with parameters for all fields.
+    string escapedName = p->mappedName();
+    string name = removeEscapePrefix(escapedName);
+    string ns = getNamespace(p);
+
+    _out << sp;
+    writeDocLine(
+        _out,
+        "summary",
+        "Initializes a new instance of the <see cref=\"" + escapedName + "\" /> " + kind + ".");
+
+    vector<string> ctorParams;
+    vector<string> baseParams;
+    vector<string> ctorPropertyInits;
+    bool hasRequiredField = false;
+
+    for (const auto& field : allBaseFields)
+    {
+        string paramName = field->customMappedName().value_or(toCamelCase(field->name()));
+        ctorParams.push_back(csFieldType(field->type(), ns, field->optional()) + " " + paramName);
+        if (csRequired(field))
+        {
+            hasRequiredField = true;
+        }
+        baseParams.push_back(paramName);
+    }
+
+    for (const auto& field : fields)
+    {
+        string paramName = field->customMappedName().value_or(toCamelCase(field->name()));
+        ctorParams.push_back(csFieldType(field->type(), ns, field->optional()) + " " + paramName);
+        if (csRequired(field))
+        {
+            hasRequiredField = true;
+        }
+
+        ctorPropertyInits.push_back("this." + field->mappedName() + " = " + paramName + ';');
+    }
+
+    if (hasRequiredField)
+    {
+        _out << nl << "[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]";
+    }
+
+    _out << nl << accessModifier(p) << ' ' << escapedName << spar << ctorParams << epar;
+    if (!baseParams.empty())
+    {
+        _out.inc();
+        _out << nl << ": base" << spar << baseParams << epar;
+        _out.dec();
+    }
+
+    _out << sb;
+    for (const auto& propertyInit : ctorPropertyInits)
+    {
+        _out << nl << propertyInit;
+    }
+    _out << eb;
+    return hasRequiredField;
+}
+
+void
+Slice::IceRpc::TypesVisitor::writeEncodeDecode(
+    int compactId,
+    const string& ns,
+    bool hasBase,
+    const DataMemberList& fields,
+    const DataMemberList& orderedOptionalFields)
+{
+    _out << sp;
+    emitNonBrowsableAttribute();
+    _out << nl << "protected override void EncodeCore(ref IceEncoder encoder)";
+    _out << sb;
+    _out << nl << "encoder.StartSlice(IceTypeId";
+    if (compactId != -1)
+    {
+        _out << ", CompactIceTypeId";
+    }
+    _out << ");";
+    // Encode non-optional fields
+    for (const auto& field : fields)
+    {
+        if (!field->optional())
+        {
+            _out << nl;
+            encodeField(_out, "this." + field->mappedName(), field->type(), ns, TypeContext::Field, "encoder");
+            _out << ';';
+        }
+    }
+    // Encode optional fields
+    for (const auto& field : orderedOptionalFields)
+    {
+        encodeOptionalField(
+            _out,
+            field->tag(),
+            "this." + field->mappedName(),
+            field->type(),
+            ns,
+            TypeContext::Field,
+            "encoder");
+    }
+
+    if (hasBase)
+    {
+        _out << nl << "encoder.EndSlice(false);";
+        _out << nl << "base.EncodeCore(ref encoder);";
+    }
+    else
+    {
+        _out << nl << "encoder.EndSlice(true);"; // last slice
+    }
+    _out << eb;
+
+    _out << sp;
+    emitNonBrowsableAttribute();
+    _out << nl << "protected override void DecodeCore(ref IceDecoder decoder)";
+    _out << sb;
+    _out << nl << "decoder.StartSlice();";
+    // Decode non-optional fields
+    for (const auto& field : fields)
+    {
+        if (!field->optional())
+        {
+            _out << nl << "this." + field->mappedName() << " = ";
+            decodeField(_out, field->type(), ns);
+            _out << ';';
+        }
+    }
+    // Decode optional fields
+    for (const auto& field : orderedOptionalFields)
+    {
+        _out << nl << "this." + field->mappedName() << " = ";
+        decodeOptionalField(_out, field->tag(), field->type(), ns, TypeContext::Field);
+        _out << ';';
+    }
+
+    _out << nl << "decoder.EndSlice();";
+    if (hasBase)
+    {
+        _out << nl << "base.DecodeCore(ref decoder);";
+    }
+    _out << eb;
+}
+
+void
+Slice::IceRpc::TypesVisitor::writeProxyRequestClass(const InterfaceDefPtr& interface)
+{
+    string ns = getNamespace(interface);
+
+    writeDocLine(_out, "summary", "Provides static methods that encode operation arguments into request payloads.");
+    _out << nl << accessModifier(interface) << " static class Request";
+    _out << sb;
+
+    for (const auto& operation : interface->operations())
+    {
+        string encodeOptionsParam = getEscapedParamName(operation->inParameters(), "encodeOptions");
+
+        _out << sp;
+        writeDocLine(
+            _out,
+            "summary",
+            "Encodes the argument(s) of operation <c>" + operation->name() + "</c> into a request payload.");
+
+        if (operation->docComment().has_value())
+        {
+            writeParameterDocComments(_out, *operation->docComment(), operation->inParameters());
+            writeDocLine(_out, R"(param name=")" + encodeOptionsParam + R"(")", "The Ice encode options.", "param");
+            writeDocLine(_out, "returns", "The Ice-encoded payload.");
+        }
+
+        _out << nl << accessModifier(interface) << " static global::System.IO.Pipelines.PipeReader Encode"
+             << removeEscapePrefix(operation->mappedName()) << "(";
+
+        _out.inc();
+        for (const auto& param : operation->inParameters())
+        {
+            _out << nl << csOutgoingParamType(param->type(), ns, param->optional()) << ' ' << param->mappedName()
+                 << ',';
+        }
+        _out << nl << "IceEncodeOptions? " << encodeOptionsParam << " = null)";
+        _out.dec();
+        _out << sb;
+        if (operation->inParameters().empty())
+        {
+            _out << nl << "return IceRpc.EmptyPipeReader.Instance;";
+        }
+        else
+        {
+            _out << nl << "var pipe_ = new global::System.IO.Pipelines.Pipe(";
+            _out.inc();
+            _out << nl << encodeOptionsParam << "?.PipeOptions ?? IceEncodeOptions.Default.PipeOptions);";
+            _out.dec();
+            _out << nl << "var encoder_ = new IceEncoder(pipe_.Writer, " << classFormat(operation) << ");";
+
+            for (const auto& param : operation->sortedInParameters())
+            {
+                if (param->optional())
+                {
+                    encodeOptionalField(
+                        _out,
+                        param->tag(),
+                        param->mappedName(),
+                        param->type(),
+                        ns,
+                        TypeContext::OutgoingParam,
+                        "encoder_");
+                }
+                else
+                {
+                    _out << nl;
+                    encodeField(_out, param->mappedName(), param->type(), ns, TypeContext::OutgoingParam, "encoder_");
+                    _out << ';';
+                }
+            }
+
+            _out << nl << "pipe_.Writer.Complete();";
+            _out << nl << "return pipe_.Reader;";
+        }
+        _out << eb;
+    }
+
+    _out << eb;
+}
+
+void
+Slice::IceRpc::TypesVisitor::writeProxyResponseClass(const InterfaceDefPtr& interface)
+{
+    string ns = getNamespace(interface);
+
+    writeDocLine(
+        _out,
+        "summary",
+        "Provides a <see cref=\"ResponseDecodeFunc{T}\" /> for each operation defined in Ice interface <c>" +
+            interface->scoped() + "</c>.");
+    _out << nl << accessModifier(interface) << " static class Response";
+    _out << sb;
+
+    for (const auto& operation : interface->operations())
+    {
+        writeDocLine(_out, "summary", "Decodes an incoming response for operation <c>" + operation->name() + "</c>.");
+        writeDocLine(_out, R"(param name="response")", "The incoming response to decode.", "param");
+        writeDocLine(_out, R"(param name="request")", "The outgoing request.", "param");
+        writeDocLine(_out, R"(param name="sender")", "The proxy that sent the request.", "param");
+        writeDocLine(
+            _out,
+            R"(param name="cancellationToken")",
+            "A cancellation token that receives the cancellation requests.",
+            "param");
+        if (operation->returnsAnyValues())
+        {
+            writeDocLine(_out, "returns", "The decoded response payload.");
+        }
+        else
+        {
+            writeDocLine(
+                _out,
+                "returns",
+                "A value task that completes when the decoding of the response payload completes.");
+        }
+
+        _out << nl << accessModifier(interface) << " static async ";
+        writeReturnTask(_out, operation, "ValueTask", false);
+        _out << " Decode" << removeEscapePrefix(operation->mappedName()) << "Async(";
+        _out.inc();
+        _out << nl << "IceRpc.IncomingResponse response,";
+        _out << nl << "IceRpc.OutgoingRequest request,";
+        _out << nl << "IIceProxy sender,";
+        _out << nl << "global::System.Threading.CancellationToken cancellationToken)";
+        _out.dec();
+        _out << sb;
+
+        _out << nl << "try";
+        _out << sb;
+
+        if (operation->returnsAnyValues())
+        {
+            _out << nl << "return await response.DecodeReturnValueAsync(";
+            _out.inc();
+            _out << nl << "request,";
+            _out << nl << "sender,";
+            _out << nl << "(ref IceDecoder decoder) => ";
+
+            string returnParamName = getEscapedParamName(operation->outParameters(), "returnValue");
+            ParameterList returnParams = operation->sortedReturnAndOutParameters(returnParamName);
+
+            if (returnParams.size() == 1)
+            {
+                // Simplified decoding function for a single return value.
+                if (returnParams.front()->optional())
+                {
+                    decodeOptionalField(
+                        _out,
+                        returnParams.front()->tag(),
+                        returnParams.front()->type(),
+                        ns,
+                        TypeContext::IncomingParam);
+                }
+                else
+                {
+                    decodeField(_out, returnParams.front()->type(), ns);
+                }
+            }
+            else
+            {
+                _out << sb;
+
+                // Decode all return params
+                for (const auto& param : returnParams)
+                {
+                    _out << nl << csType(param->type(), ns, TypeContext::IncomingParam, param->optional()) << " sliceP_"
+                         << removeEscapePrefix(param->mappedName()) << " = ";
+                    if (param->optional())
+                    {
+                        decodeOptionalField(_out, param->tag(), param->type(), ns, TypeContext::IncomingParam);
+                    }
+                    else
+                    {
+                        decodeField(_out, param->type(), ns);
+                    }
+                    _out << ';';
+                }
+
+                // Return tuple with the return value (if any) first.
+                _out << nl << "return " << spar;
+                if (operation->returnType())
+                {
+                    _out << ("sliceP_" + returnParamName);
+                }
+                for (const auto& param : returnParams)
+                {
+                    if (param->name() != returnParamName)
+                    {
+                        _out << ("sliceP_" + removeEscapePrefix(param->mappedName()));
+                    }
+                }
+                _out << epar << ";";
+
+                _out << eb;
+            }
+            _out << ',';
+
+            _out << nl << "_defaultActivator,";
+            _out << nl << "cancellationToken).ConfigureAwait(false);";
+            _out.dec();
+        }
+        else
+        {
+            _out << nl << "await response.DecodeVoidReturnValueAsync(";
+            _out.inc();
+            _out << nl << "request,";
+            _out << nl << "sender,";
+            _out << nl << "_defaultActivator,";
+            _out << nl << "cancellationToken).ConfigureAwait(false);";
+            _out.dec();
+        }
+
+        _out << eb;
+        _out << nl << "catch (IceException exception)";
+        ExceptionList exceptionList = operation->throws();
+        if (!exceptionList.empty())
+        {
+            _out << " when (exception is not ";
+            if (exceptionList.size() == 1)
+            {
+                _out << getUnqualified(exceptionList.front(), ns);
+            }
+            else
+            {
+                _out << '(';
+                for (auto q = exceptionList.begin(); q != exceptionList.end(); ++q)
+                {
+                    const ExceptionPtr& exception = *q;
+                    if (q != exceptionList.begin())
+                    {
+                        _out << " or ";
+                    }
+                    _out << getUnqualified(exception, ns);
+                }
+                _out << ')';
+            }
+            _out << ')';
+        }
+        _out << sb;
+        _out << nl << "throw new global::System.IO.InvalidDataException(";
+        _out.inc();
+        _out << nl << "$\"Exception specification violation: response to a " << operation->name()
+             << " request carries an exception of type '{exception.GetType()}'.\", exception);";
+        _out.dec();
+        _out << eb;
+        _out << eb;
+    }
+
+    _out << eb;
+}
+
+Slice::IceRpc::SkeletonVisitor::SkeletonVisitor(IceInternal::Output& output) : CsVisitor(output) {}
+
+bool
+Slice::IceRpc::SkeletonVisitor::visitModuleStart(const ModulePtr& p)
+{
+    if (!p->contains<InterfaceDef>())
+    {
+        return false;
+    }
+    return CsVisitor::visitModuleStart(p);
+}
+
+bool
+Slice::IceRpc::SkeletonVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
+{
+    string ns = getNamespace(p);
+    string escapedName = p->mappedName();
+    string name = removeEscapePrefix(escapedName);
+
+    // Generate the server-side interface.
+    _out << sp;
+    ostringstream notes;
+    notes << R"(Apply <see cref="IceRpc.ServiceAttribute" /> to the partial class that implements this interface.)";
+    writeIceRpcDocComment(_out, p, "server-side interface", notes.str());
+    _out << nl << "[IceTypeId(\"" << p->scoped() << "\")]";
+    _out << nl << "[IceRpc.DefaultServicePath(\"" << defaultServicePath(p) << "\")]";
+    emitObsoleteAttribute(p);
+    _out << nl << accessModifier(p) << " partial interface I" << name << "Service";
+    if (!p->bases().empty())
+    {
+        _out << " : ";
+        _out.spar("");
+        for (const auto& base : p->bases())
+        {
+            _out << getUnqualified(base, ns, "I", "Service");
+        }
+        _out.epar("");
+    }
+
+    _out << sb;
+
+    if (!p->operations().empty())
+    {
+        writeRequestClass(p);
+        _out << sp;
+        writeResponseClass(p);
+        _out << sp;
+        _out << nl << "private static readonly IActivator _defaultActivator =";
+        _out.inc();
+        _out << nl << "IActivator.FromAssembly(typeof(I" << name << "Service).Assembly);";
+        _out.dec();
+    }
+
+    // We don't generate the skeleton methods for ::Ice::Object, as we provide hand-written default implementations
+    // for these methods.
+    if (p->scoped() == "::Ice::Object")
+    {
+        _out << eb; // end of interface
+        return false;
+    }
+    else
+    {
+        return true;
+    }
+}
+
+void
+Slice::IceRpc::SkeletonVisitor::visitInterfaceDefEnd(const InterfaceDefPtr&)
+{
+    _out << eb;
+}
+
+void
+Slice::IceRpc::SkeletonVisitor::visitOperation(const OperationPtr& p)
+{
+    string ns = getNamespace(p->interface());
+
+    _out << sp;
+    writeIceRpcOpDocComment(_out, p, true);
+    _out << nl << "[IceOperation(\"" << p->name() << "\"";
+
+    if (p->mode() == Operation::Idempotent)
+    {
+        _out << ", Idempotent = true";
+    }
+    ExceptionList exceptions = p->throws();
+    if (!exceptions.empty())
+    {
+        _out << ", ExceptionSpecification = new System.Type[] ";
+        _out.spar("{ ");
+        for (const auto& exception : exceptions)
+        {
+            _out << ("typeof(" + getUnqualified(exception, ns) + ")");
+        }
+        _out.epar(" }");
+    }
+    _out << ")]";
+
+    _out << nl;
+    writeMethodSignature(_out, p, ns, true);
+    _out << ';';
+}
+
+void
+Slice::IceRpc::SkeletonVisitor::writeRequestClass(const InterfaceDefPtr& interface)
+{
+    string ns = getNamespace(interface);
+
+    writeDocLine(_out, "summary", "Provides static methods that decode request payloads.");
+
+    // Check if any of the base interfaces already has a Request class.
+    // A Request class is generated for any interface that defines at least one operation.
+    _out << nl << accessModifier(interface) << " static ";
+    if (!interface->allInheritedOperations().empty())
+    {
+        _out << "new ";
+    }
+    _out << "class Request";
+
+    _out << sb;
+
+    for (const auto& operation : interface->operations())
+    {
+        _out << sp;
+        writeDocLine(_out, "summary", "Decodes the request payload of operation <c>" + operation->name() + "</c>.");
+        writeDocLine(_out, R"(param name="request")", "The incoming request.", "param");
+        writeDocLine(
+            _out,
+            R"(param name="cancellationToken")",
+            "A cancellation token that receives the cancellation requests.",
+            "param");
+
+        if (operation->returnsAnyValues())
+        {
+            writeDocLine(_out, "returns", "The decoded request payload.");
+        }
+        else
+        {
+            writeDocLine(
+                _out,
+                "returns",
+                "A value task that completes when the decoding of the request payload completes.");
+        }
+
+        _out << nl << accessModifier(interface) << " static ";
+        writeParamsValueTask(_out, operation);
+        _out << " Decode" << removeEscapePrefix(operation->mappedName()) << "Async(";
+        _out.inc();
+        _out << nl << "IceRpc.IncomingRequest request,";
+        _out << nl << "global::System.Threading.CancellationToken cancellationToken) =>";
+
+        ParameterList inParameters = operation->inParameters();
+
+        if (inParameters.empty())
+        {
+            _out << nl << "request.DecodeEmptyArgsAsync(cancellationToken);";
+        }
+        else
+        {
+            _out << nl << "request.DecodeArgsAsync(";
+            _out.inc();
+            _out << nl << "(ref IceDecoder decoder) => ";
+
+            if (inParameters.size() == 1)
+            {
+                // Simplified decoding function for a single parameter.
+                if (inParameters.front()->optional())
+                {
+                    decodeOptionalField(
+                        _out,
+                        inParameters.front()->tag(),
+                        inParameters.front()->type(),
+                        ns,
+                        TypeContext::IncomingParam);
+                }
+                else
+                {
+                    decodeField(_out, inParameters.front()->type(), ns);
+                }
+            }
+            else
+            {
+                _out << sb;
+
+                // Decode all params (2 or more).
+                for (const auto& param : inParameters)
+                {
+                    _out << nl << csType(param->type(), ns, TypeContext::IncomingParam, param->optional()) << " sliceP_"
+                         << removeEscapePrefix(param->mappedName()) << " = ";
+                    if (param->optional())
+                    {
+                        decodeOptionalField(_out, param->tag(), param->type(), ns, TypeContext::IncomingParam);
+                    }
+                    else
+                    {
+                        decodeField(_out, param->type(), ns);
+                    }
+                    _out << ';';
+                }
+
+                _out << nl << "return " << spar;
+                for (const auto& param : inParameters)
+                {
+                    _out << ("sliceP_" + removeEscapePrefix(param->mappedName()));
+                }
+                _out << epar << ";";
+
+                _out << eb;
+            }
+            _out << ',';
+
+            _out << nl << "_defaultActivator,";
+            _out << nl << "cancellationToken);";
+            _out.dec();
+        }
+        _out.dec();
+    }
+
+    _out << eb;
+}
+
+void
+Slice::IceRpc::SkeletonVisitor::writeResponseClass(const InterfaceDefPtr& interface)
+{
+    string ns = getNamespace(interface);
+
+    writeDocLine(_out, "summary", "Provides static methods that encode operation arguments into request payloads.");
+
+    // Check if any of the base interfaces already has a Response class.
+    // A Response class is generated for any interface that defines at least one operation.
+    _out << nl << accessModifier(interface) << " static ";
+    if (!interface->allInheritedOperations().empty())
+    {
+        _out << "new ";
+    }
+    _out << "class Response";
+
+    _out << sb;
+
+    for (const auto& operation : interface->operations())
+    {
+        string encodeOptionsParam = getEscapedParamName(operation->outParameters(), "encodeOptions");
+
+        _out << sp;
+        writeDocLine(
+            _out,
+            "summary",
+            "Encodes the return value and out parameter(s) of operation <c>" + operation->name() +
+                "</c> into a response payload.");
+
+        // We can't generate XML doc comments for the params (return and out) because they may contain @p
+        // references to in-parameters, and the corresponding paramref would not resolve.
+
+        _out << nl << accessModifier(interface) << " static global::System.IO.Pipelines.PipeReader Encode"
+             << removeEscapePrefix(operation->mappedName()) << "(";
+
+        _out.inc();
+        string returnParamName = getEscapedParamName(operation->outParameters(), "returnValue");
+
+        if (operation->returnType())
+        {
+            _out << nl << csOutgoingParamType(operation->returnType(), ns, operation->returnIsOptional()) << ' '
+                 << returnParamName << ',';
+        }
+        for (const auto& param : operation->outParameters())
+        {
+            _out << nl << csOutgoingParamType(param->type(), ns, param->optional()) << ' ' << param->mappedName()
+                 << ',';
+        }
+        _out << nl << "IceEncodeOptions? " << encodeOptionsParam << " = null)";
+        _out.dec();
+        _out << sb;
+        if (operation->returnsAnyValues())
+        {
+            _out << nl << "var pipe_ = new global::System.IO.Pipelines.Pipe(";
+            _out.inc();
+            _out << nl << encodeOptionsParam << "?.PipeOptions ?? IceEncodeOptions.Default.PipeOptions);";
+            _out.dec();
+            _out << nl << "var encoder_ = new IceEncoder(pipe_.Writer, " << classFormat(operation) << ");";
+
+            for (const auto& param : operation->sortedReturnAndOutParameters(returnParamName))
+            {
+                if (param->optional())
+                {
+                    encodeOptionalField(
+                        _out,
+                        param->tag(),
+                        param->mappedName(),
+                        param->type(),
+                        ns,
+                        TypeContext::OutgoingParam,
+                        "encoder_");
+                }
+                else
+                {
+                    _out << nl;
+                    encodeField(_out, param->mappedName(), param->type(), ns, TypeContext::OutgoingParam, "encoder_");
+                    _out << ';';
+                }
+            }
+
+            _out << nl << "pipe_.Writer.Complete();";
+            _out << nl << "return pipe_.Reader;";
+        }
+        else
+        {
+            _out << nl << "return IceRpc.EmptyPipeReader.Instance;";
+        }
+        _out << eb;
+    }
+
+    _out << eb;
+}

--- a/cpp/src/slice2cs/IceRpcVisitors.h
+++ b/cpp/src/slice2cs/IceRpcVisitors.h
@@ -1,0 +1,73 @@
+// Copyright (c) ZeroC, Inc.
+
+#ifndef ICE_RPC_VISITORS_H
+#define ICE_RPC_VISITORS_H
+
+#include "CsVisitor.h"
+
+// Visitors for generating C# code for IceRPC.
+
+namespace Slice::IceRpc
+{
+    /// Generates code for Slice types (including proxies), Slice exceptions, and Slice constants.
+    class TypesVisitor final : public CsVisitor
+    {
+    public:
+        TypesVisitor(IceInternal::Output& out);
+
+        bool visitStructStart(const StructPtr&) final;
+        void visitStructEnd(const StructPtr&) final;
+
+        bool visitClassDefStart(const ClassDefPtr&) final;
+        void visitClassDefEnd(const ClassDefPtr&) final;
+
+        bool visitExceptionStart(const ExceptionPtr&) final;
+        void visitExceptionEnd(const ExceptionPtr&) final;
+
+        void visitDataMember(const DataMemberPtr&) final;
+
+        void visitEnum(const EnumPtr&) final;
+
+        bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
+        void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
+        void visitOperation(const OperationPtr&) final;
+
+        void visitConst(const ConstPtr&) final;
+
+    private:
+        bool writePrimaryConstructor(
+            const ContainedPtr& p,
+            const DataMemberList& fields,
+            const DataMemberList& allBaseFields,
+            const std::string& kind);
+
+        void writeEncodeDecode(
+            int compactId,
+            const std::string& ns,
+            bool hasBase,
+            const DataMemberList& fields,
+            const DataMemberList& orderedOptionalFields);
+
+        void writeProxyRequestClass(const InterfaceDefPtr& interface);
+        void writeProxyResponseClass(const InterfaceDefPtr& interface);
+    };
+
+    // Generates skeleton interfaces.
+    class SkeletonVisitor final : public CsVisitor
+    {
+    public:
+        SkeletonVisitor(IceInternal::Output&);
+
+        bool visitModuleStart(const ModulePtr&) final;
+
+        bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
+        void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
+        void visitOperation(const OperationPtr&) final;
+
+    private:
+        void writeRequestClass(const InterfaceDefPtr& interface);
+        void writeResponseClass(const InterfaceDefPtr& interface);
+    };
+}
+
+#endif

--- a/cpp/src/slice2cs/IceVisitors.cpp
+++ b/cpp/src/slice2cs/IceVisitors.cpp
@@ -323,31 +323,13 @@ namespace
 Slice::Ice::TypesVisitor::TypesVisitor(IceInternal::Output& out) : CsVisitor(out) {}
 
 bool
-Slice::Ice::TypesVisitor::visitModuleStart(const ModulePtr& p)
-{
-    namespacePrefixStart(p);
-    _out << sp;
-    _out << nl << "namespace " << p->mappedName();
-    _out << sb;
-
-    return true;
-}
-
-void
-Slice::Ice::TypesVisitor::visitModuleEnd(const ModulePtr& p)
-{
-    _out << eb;
-    namespacePrefixEnd(p);
-}
-
-bool
 Slice::Ice::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
     string ns = getNamespace(p);
     ClassDefPtr base = p->base();
 
     _out << sp;
-    writeDocComment(p, "class");
+    writeIceDocComment(_out, p, "class");
     emitObsoleteAttribute(p);
     _out << nl << "[Ice.SliceTypeId(\"" << p->scoped() << "\")]";
     if (p->compactId() != -1)
@@ -518,7 +500,7 @@ Slice::Ice::TypesVisitor::visitSequence(const SequencePtr& p)
     _out << sp;
     ostringstream summary;
     summary << "Provides methods to marshal and unmarshal a <c>" << p->name() << "</c>.";
-    writeHelperDocComment(p, summary.str(), "sequence helper class");
+    writeIceHelperDocComment(_out, p, summary.str(), "sequence helper class");
     _out << nl << accessModifier(p) << " sealed class " << name << "Helper";
     _out << sb;
 
@@ -556,7 +538,7 @@ Slice::Ice::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     _out << sp;
     ostringstream summary;
     summary << "Provides methods to marshal and unmarshal a <c>" << p->name() << "</c>.";
-    writeHelperDocComment(p, summary.str(), "dictionary helper class");
+    writeIceHelperDocComment(_out, p, summary.str(), "dictionary helper class");
     _out << nl << accessModifier(p) << " sealed class " << p->mappedName() << "Helper";
     _out << sb;
 
@@ -619,7 +601,7 @@ Slice::Ice::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     ExceptionPtr base = p->base();
 
     _out << sp;
-    writeDocComment(p, "exception class");
+    writeIceDocComment(_out, p, "exception class");
     emitObsoleteAttribute(p);
     _out << nl << "[Ice.SliceTypeId(\"" << p->scoped() << "\")]";
     _out << nl << accessModifier(p) << " partial class " << p->mappedName() << " : ";
@@ -824,7 +806,7 @@ Slice::Ice::TypesVisitor::visitStructStart(const StructPtr& p)
     string mappedType = classMapping ? "record class" : "record struct";
     string modifier = (p->hasMetadata("cs:readonly") && !classMapping) ? "readonly " : "";
 
-    writeDocComment(p, mappedType);
+    writeIceDocComment(_out, p, mappedType);
     emitObsoleteAttribute(p);
     _out << nl << accessModifier(p) << ' ' << (classMapping ? "sealed " : "") << modifier << "partial " << mappedType
          << ' ' << name;
@@ -965,7 +947,7 @@ Slice::Ice::TypesVisitor::visitEnum(const EnumPtr& p)
     const bool hasExplicitValues = p->hasExplicitValues();
 
     _out << sp;
-    writeDocComment(p, "enum");
+    writeIceDocComment(_out, p, "enum");
     emitObsoleteAttribute(p);
     emitAttributes(p);
     _out << nl << accessModifier(p) << " enum " << name;
@@ -978,7 +960,7 @@ Slice::Ice::TypesVisitor::visitEnum(const EnumPtr& p)
             _out << sp;
         }
 
-        writeDocComment(enumerator);
+        writeIceDocComment(_out, enumerator);
         emitObsoleteAttribute(enumerator);
         emitAttributes(enumerator);
         _out << nl << enumerator->mappedName();
@@ -993,7 +975,7 @@ Slice::Ice::TypesVisitor::visitEnum(const EnumPtr& p)
     ostringstream classComment;
     classComment << "Provides methods to marshal and unmarshal " << getArticleFor(name) << " <see cref=\"" << name
                  << "\" />.";
-    writeHelperDocComment(p, classComment.str(), "enum helper class");
+    writeIceHelperDocComment(_out, p, classComment.str(), "enum helper class");
     _out << nl << accessModifier(p) << " sealed class " << name << "Helper";
     _out << sb;
     _out << sp;
@@ -1019,13 +1001,13 @@ void
 Slice::Ice::TypesVisitor::visitConst(const ConstPtr& p)
 {
     _out << sp;
-    writeHelperDocComment(p, "Provides the " + p->mappedName() + " constant.", "helper class");
-    emitAttributes(p);
+    writeIceHelperDocComment(_out, p, "Provides the " + p->mappedName() + " constant.", "helper class");
     _out << nl << accessModifier(p) << " abstract class " << p->mappedName();
     _out << sb;
-    writeDocComment(p);
+    writeIceDocComment(_out, p);
+    emitAttributes(p);
     _out << nl << accessModifier(p) << " const " << typeToString(p->type(), "") << " value = ";
-    writeConstantValue(p->type(), p->valueType(), p->value());
+    writeConstantValue(_out, p->type(), p->valueType(), p->value(), getNamespace(p));
     _out << ";";
     _out << eb;
 }
@@ -1048,7 +1030,7 @@ Slice::Ice::TypesVisitor::visitDataMember(const DataMemberPtr& p)
     string type = typeToString(p->type(), ns, p->optional());
     bool addSemicolon = true;
 
-    writeDocComment(p);
+    writeIceDocComment(_out, p);
     emitObsoleteAttribute(p);
     emitAttributes(p);
     _out << nl << accessModifier(cont) << ' ';
@@ -1083,7 +1065,7 @@ Slice::Ice::TypesVisitor::visitDataMember(const DataMemberPtr& p)
         if (!builtin || builtin->kind() == Builtin::KindString || (defaultValue != "0" && defaultValue != "false"))
         {
             _out << " = ";
-            writeConstantValue(p->type(), p->defaultValueType(), defaultValue);
+            writeConstantValue(_out, p->type(), p->defaultValueType(), defaultValue, ns);
             addSemicolon = true;
         }
     }
@@ -1114,13 +1096,13 @@ Slice::Ice::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     ostringstream notes;
     notes << "Use the methods of this interface to invoke operations on a remote Ice object that implements <c>"
           << p->name() << "</c>.";
-    writeDocComment(p, "proxy interface", notes.str());
+    writeIceDocComment(_out, p, "proxy interface", notes.str());
     _out << nl << accessModifier(p) << " partial interface " << p->mappedName() << "Prx : ";
 
     vector<string> baseInterfaces;
     for (const auto& base : p->bases())
     {
-        baseInterfaces.push_back(getUnqualified(base, ns) + "Prx");
+        baseInterfaces.push_back(getUnqualified(base, ns, "", "Prx"));
     }
 
     if (baseInterfaces.empty())
@@ -1154,7 +1136,7 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     _out << sp;
     ostringstream summary;
     summary << "Helper class for proxy <see cref=\"" << name << "Prx\" />.";
-    writeHelperDocComment(p, summary.str(), "proxy helper class");
+    writeIceHelperDocComment(_out, p, summary.str(), "proxy helper class");
     _out << nl << accessModifier(p) << " sealed partial class " << name << "PrxHelper : "
          << "Ice.ObjectPrxHelperBase, " << name << "Prx";
     _out << sb;
@@ -1615,7 +1597,7 @@ Slice::Ice::TypesVisitor::visitOperation(const OperationPtr& p)
         //
         string context = getEscapedParamName(p->parameters(), "context");
         _out << sp;
-        writeOpDocComment(p, {"<param name=\"" + context + "\">The request context.</param>"}, false);
+        writeIceOpDocComment(_out, p, {"<param name=\"" + context + "\">The request context.</param>"}, false, false);
         emitObsoleteAttribute(p);
         _out << nl << retS << " " << name;
         _out.spar("(", true);
@@ -1633,12 +1615,14 @@ Slice::Ice::TypesVisitor::visitOperation(const OperationPtr& p)
         string progress = getEscapedParamName(p->parameters(), "progress");
 
         _out << sp;
-        writeOpDocComment(
+        writeIceOpDocComment(
+            _out,
             p,
             {"<param name=\"" + context + "\">The request context.</param>",
              "<param name=\"" + progress + "\">The sent progress provider.</param>",
              "<param name=\"" + cancel + "\">A cancellation token that receives the cancellation requests.</param>"},
-            true);
+            true,
+            false);
         emitObsoleteAttribute(p);
         _out << nl << taskResultType(p, ns);
         _out << " " << name << "Async";
@@ -1646,45 +1630,6 @@ Slice::Ice::TypesVisitor::visitOperation(const OperationPtr& p)
         _out << inParams << ("global::System.Collections.Generic.Dictionary<string, string>? " + context + " = null")
              << ("global::System.IProgress<bool>? " + progress + " = null")
              << ("global::System.Threading.CancellationToken " + cancel + " = default") << epar << ";";
-    }
-}
-
-void
-Slice::Ice::TypesVisitor::writeConstantValue(
-    const TypePtr& type,
-    const SyntaxTreeBasePtr& valueType,
-    const string& value)
-{
-    ConstPtr constant = dynamic_pointer_cast<Const>(valueType);
-    if (constant)
-    {
-        _out << constant->mappedScoped(".") << ".value";
-    }
-    else
-    {
-        BuiltinPtr bp = dynamic_pointer_cast<Builtin>(type);
-        if (bp && bp->kind() == Builtin::KindString)
-        {
-            _out << "\"" << toStringLiteral(value, "\a\b\f\n\r\t\v\0", "", UCN, 0) << "\"";
-        }
-        else if (bp && bp->kind() == Builtin::KindLong)
-        {
-            _out << value << "L";
-        }
-        else if (bp && bp->kind() == Builtin::KindFloat)
-        {
-            _out << value << "F";
-        }
-        else if (dynamic_pointer_cast<Enum>(type))
-        {
-            EnumeratorPtr lte = dynamic_pointer_cast<Enumerator>(valueType);
-            assert(lte);
-            _out << lte->mappedScoped(".");
-        }
-        else
-        {
-            _out << value;
-        }
     }
 }
 
@@ -1848,21 +1793,11 @@ namespace
 bool
 Slice::Ice::ResultVisitor::visitModuleStart(const ModulePtr& p)
 {
-    if (hasResultType(p))
+    if (!hasResultType(p))
     {
-        namespacePrefixStart(p);
-        _out << sp << nl << "namespace " << p->mappedName();
-        _out << sb;
-        return true;
+        return false;
     }
-    return false;
-}
-
-void
-Slice::Ice::ResultVisitor::visitModuleEnd(const ModulePtr& p)
-{
-    _out << eb;
-    namespacePrefixEnd(p);
+    return CsVisitor::visitModuleStart(p);
 }
 
 void
@@ -1941,18 +1876,7 @@ Slice::Ice::SkeletonVisitor::visitModuleStart(const ModulePtr& p)
     {
         return false;
     }
-
-    namespacePrefixStart(p);
-    _out << sp << nl << "namespace " << p->mappedName();
-    _out << sb;
-    return true;
-}
-
-void
-Slice::Ice::SkeletonVisitor::visitModuleEnd(const ModulePtr& p)
-{
-    _out << eb;
-    namespacePrefixEnd(p);
+    return CsVisitor::visitModuleStart(p);
 }
 
 bool
@@ -1970,7 +1894,7 @@ Slice::Ice::SkeletonVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     notes << "Your servant class implements this interface by deriving from"
           << "<see cref=\"" << name << "Disp_\" /> or from the Disp_ class for a derived interface.";
 
-    writeDocComment(p, "skeleton interface", notes.str());
+    writeIceDocComment(_out, p, "skeleton interface", notes.str());
     _out << nl << "[Ice.SliceTypeId(\"" << p->scoped() << "\")]";
     _out << nl << accessModifier(p) << " partial interface " << name << " : ";
 
@@ -2015,7 +1939,7 @@ Slice::Ice::SkeletonVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     remarks << "Your servant class derives from this abstract class to implement Slice interface <c>" << p->name()
             << "</c>.";
 
-    writeHelperDocComment(p, summary.str(), "skeleton class", remarks.str());
+    writeIceHelperDocComment(_out, p, summary.str(), "skeleton class", remarks.str());
     _out << nl << accessModifier(p) << " abstract partial class " << name << "Disp_ : " << name;
 
     _out << sb;
@@ -2062,7 +1986,12 @@ Slice::Ice::SkeletonVisitor::visitOperation(const OperationPtr& op)
         _out << sp;
     }
 
-    writeOpDocComment(op, {"<param name=\"" + args.back() + "\">The Current object for the dispatch.</param>"}, amd);
+    writeIceOpDocComment(
+        _out,
+        op,
+        {"<param name=\"" + args.back() + "\">The Current object for the dispatch.</param>"},
+        amd,
+        true);
 
     emitObsoleteAttribute(op);
     _out << nl << retS << " " << opName;

--- a/cpp/src/slice2cs/IceVisitors.h
+++ b/cpp/src/slice2cs/IceVisitors.h
@@ -15,8 +15,6 @@ namespace Slice::Ice
     public:
         TypesVisitor(IceInternal::Output&);
 
-        bool visitModuleStart(const ModulePtr&) final;
-        void visitModuleEnd(const ModulePtr&) final;
         bool visitClassDefStart(const ClassDefPtr&) final;
         void visitClassDefEnd(const ClassDefPtr&) final;
         bool visitExceptionStart(const ExceptionPtr&) final;
@@ -35,7 +33,6 @@ namespace Slice::Ice
         void visitOperation(const OperationPtr&) final;
 
     private:
-        void writeConstantValue(const TypePtr&, const SyntaxTreeBasePtr&, const std::string&);
         void writeMarshalDataMember(const DataMemberPtr&, const std::string&, const std::string&, bool = false);
         void writeUnmarshalDataMember(const DataMemberPtr&, const std::string&, const std::string&, bool = false);
         void writeMarshaling(const ClassDefPtr&);
@@ -52,7 +49,7 @@ namespace Slice::Ice
         ResultVisitor(IceInternal::Output&);
 
         bool visitModuleStart(const ModulePtr&) final;
-        void visitModuleEnd(const ModulePtr&) final;
+
         void visitOperation(const OperationPtr&) final;
     };
 
@@ -63,7 +60,7 @@ namespace Slice::Ice
         SkeletonVisitor(IceInternal::Output& output, bool async);
 
         bool visitModuleStart(const ModulePtr&) final;
-        void visitModuleEnd(const ModulePtr&) final;
+
         bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
         void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
         void visitOperation(const OperationPtr&) final;

--- a/cpp/src/slice2cs/Main.cpp
+++ b/cpp/src/slice2cs/Main.cpp
@@ -9,6 +9,7 @@
 #include "Gen.h"
 #include "Ice/CtrlCHandler.h"
 #include "IceCsUtil.h"
+#include "IceRpcCsUtil.h"
 
 #include <algorithm>
 #include <cassert>
@@ -43,6 +44,7 @@ usage(const string& n)
                   "-UNAME                   Remove any definition for NAME.\n"
                   "-IDIR                    Put DIR in the include file search path.\n"
                   "--output-dir DIR         Create files in the directory DIR.\n"
+                  "--icerpc                 Generate code for use with IceRPC instead of Ice.\n"
                   "-d, --debug              Print debug messages.\n"
                   "--depend                 Generate Makefile dependencies.\n"
                   "--depend-xml             Generate dependencies in XML format.\n"
@@ -63,6 +65,7 @@ compile(const vector<string>& argv)
     opts.addOpt("U", "", IceInternal::Options::NeedArg, "", IceInternal::Options::Repeat);
     opts.addOpt("I", "", IceInternal::Options::NeedArg, "", IceInternal::Options::Repeat);
     opts.addOpt("", "output-dir", IceInternal::Options::NeedArg);
+    opts.addOpt("", "icerpc");
     opts.addOpt("", "depend");
     opts.addOpt("", "depend-xml");
     opts.addOpt("", "depend-file", IceInternal::Options::NeedArg, "");
@@ -129,6 +132,12 @@ compile(const vector<string>& argv)
 
     bool debug = opts.isSet("debug");
 
+    Slice::GenMode genMode = opts.isSet("icerpc") ? Slice::GenMode::IceRpc : Slice::GenMode::Ice;
+    if (genMode == Slice::GenMode::IceRpc)
+    {
+        preprocessorArgs.emplace_back("-D__ICERPC__");
+    }
+
     if (sliceFiles.empty())
     {
         consoleErr << argv[0] << ": error: no input file" << endl;
@@ -169,12 +178,30 @@ compile(const vector<string>& argv)
         {
             preprocessor = Preprocessor::create(argv[0], fileName, preprocessorArgs);
             FILE* preprocessedHandle = preprocessor->preprocess("-D__SLICE2CS__");
+
             if (preprocessedHandle == nullptr)
             {
                 return EXIT_FAILURE;
             }
 
-            unit = Unit::createUnit("cs");
+            UnitOptions unitOptions{};
+            if (genMode == Slice::GenMode::IceRpc)
+            {
+                unitOptions.defaultMappedName = [](const Contained& contained)
+                {
+                    // Convert all names to pascal case except for parameters, which are converted to camel case.
+                    if (dynamic_cast<const Parameter*>(&contained))
+                    {
+                        return toCamelCase(contained.name());
+                    }
+                    else
+                    {
+                        return toPascalCase(contained.name());
+                    }
+                };
+            }
+
+            unit = Unit::createUnit("cs", unitOptions);
             int parseStatus = unit->parse(fileName, preprocessedHandle, debug);
 
             preprocessor->close();
@@ -188,17 +215,21 @@ compile(const vector<string>& argv)
                 dependencyGenerator.addDependenciesFor(unit);
                 if (depend)
                 {
-                    string target = removeExtension(baseName(fileName)) + ".cs";
+                    string target = removeExtension(baseName(fileName)) +
+                                    (genMode == Slice::GenMode::IceRpc ? ".IceRpc.cs" : ".cs");
                     dependencyGenerator.writeMakefileDependencies(dependFile, unit->topLevelFile(), target);
                 }
                 // else XML dependencies are written below after all units have been processed.
             }
             else
             {
-                Slice::Csharp::IceDocCommentFormatter iceFormatter;
-                parseAllDocComments(unit, iceFormatter);
+                Slice::Csharp::CsharpDocCommentFormatter docCommentFormatter{
+                    genMode == Slice::GenMode::Ice ? Slice::Csharp::iceLinkFormatter
+                                                   : Slice::Csharp::icerpcLinkFormatter};
 
-                Gen gen(preprocessor->getBaseName(), output, enableAnalysis);
+                parseAllDocComments(unit, docCommentFormatter);
+
+                Gen gen(preprocessor->getBaseName(), output, genMode, enableAnalysis);
                 gen.generate(unit);
 
                 status |= unit->getStatus();

--- a/cpp/src/slice2cs/msbuild/slice2cs.vcxproj
+++ b/cpp/src/slice2cs/msbuild/slice2cs.vcxproj
@@ -68,7 +68,6 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>ICE_BUILDING_SLICE_COMPILERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-
     </ClCompile>
     <Link>
       <AdditionalDependencies>rpcrt4.lib;advapi32.lib;DbgHelp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -79,7 +78,6 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>ICE_BUILDING_SLICE_COMPILERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-
     </ClCompile>
     <Link>
       <AdditionalDependencies>rpcrt4.lib;advapi32.lib;DbgHelp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -90,7 +88,6 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>ICE_BUILDING_SLICE_COMPILERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-
     </ClCompile>
     <Link>
       <AdditionalDependencies>rpcrt4.lib;advapi32.lib;DbgHelp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -101,7 +98,6 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>ICE_BUILDING_SLICE_COMPILERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-
     </ClCompile>
     <Link>
       <AdditionalDependencies>rpcrt4.lib;advapi32.lib;DbgHelp.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -113,6 +109,8 @@
     <ClCompile Include="..\CsVisitor.cpp" />
     <ClCompile Include="..\Gen.cpp" />
     <ClCompile Include="..\IceCsUtil.cpp" />
+    <ClCompile Include="..\IceRpcCsUtil.cpp" />
+    <ClCompile Include="..\IceRpcVisitors.cpp" />
     <ClCompile Include="..\IceVisitors.cpp" />
     <ClCompile Include="..\Main.cpp" />
   </ItemGroup>
@@ -125,6 +123,8 @@
     <ClInclude Include="..\CsVisitor.h" />
     <ClInclude Include="..\Gen.h" />
     <ClInclude Include="..\IceCsUtil.h" />
+    <ClInclude Include="..\IceRpcCsUtil.h" />
+    <ClInclude Include="..\IceRpcVisitors.h" />
     <ClInclude Include="..\IceVisitors.h" />
   </ItemGroup>
   <ItemGroup>

--- a/cpp/src/slice2cs/msbuild/slice2cs.vcxproj.filters
+++ b/cpp/src/slice2cs/msbuild/slice2cs.vcxproj.filters
@@ -36,6 +36,12 @@
     <ClCompile Include="..\IceVisitors.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\IceRpcCsUtil.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\IceRpcVisitors.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\Slice2Cs.rc">
@@ -59,6 +65,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\IceVisitors.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\IceRpcCsUtil.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\IceRpcVisitors.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceCompilerTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceCompilerTask.cs
@@ -27,6 +27,11 @@ public abstract class SliceCompilerTask : ToolTask
 
     public string[] IncludeDirectories { get; set; } = Array.Empty<string>();
 
+    /// <summary>
+    /// Specifies whether to pass '--icerpc' to 'slice2cs'.
+    /// </summary>
+    public bool IceRpc { get; set; } = false;
+
     public string[] AdditionalOptions { get; set; } = Array.Empty<string>();
 
     [Output]
@@ -64,6 +69,12 @@ public abstract class SliceCompilerTask : ToolTask
             options["IncludeDirectories"] = value;
         }
 
+        value = item.GetMetadata("IceRpc");
+        if (!string.IsNullOrEmpty(value))
+        {
+            options["IceRpc"] = value;
+        }
+
         if (AdditionalOptions.Length > 0)
         {
             options["AdditionalOptions"] = string.Join(";", AdditionalOptions);
@@ -87,6 +98,11 @@ public abstract class SliceCompilerTask : ToolTask
         foreach (string path in IncludeDirectories)
         {
             builder.AppendSwitchIfNotNull("-I", Path.GetFullPath(path));
+        }
+
+        if (IceRpc)
+        {
+            builder.AppendSwitch("--icerpc");
         }
 
         foreach (string option in AdditionalOptions)

--- a/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceDependTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceDependTask.cs
@@ -21,6 +21,11 @@ public abstract class SliceDependTask : Microsoft.Build.Utilities.Task
     [Required]
     public string WorkingDirectory { get; set; } = "";
 
+    /// <summary>
+    /// Specifies whether to pass '--icerpc' to 'slice2cs'.
+    /// </summary>
+    public bool IceRpc { get; set; } = false;
+
     [Output]
     public ITaskItem[] ComputedSources { get; private set; } = Array.Empty<ITaskItem>();
 
@@ -61,6 +66,13 @@ public abstract class SliceDependTask : Microsoft.Build.Utilities.Task
         {
             options["IncludeDirectories"] = value;
         }
+
+        value = item.GetMetadata("IceRpc");
+        if (!string.IsNullOrEmpty(value))
+        {
+            options["IceRpc"] = value;
+        }
+
         value = item.GetMetadata("AdditionalOptions");
         if (!string.IsNullOrEmpty(value))
         {
@@ -70,6 +82,7 @@ public abstract class SliceDependTask : Microsoft.Build.Utilities.Task
                 options["AdditionalOptions"] = value;
             }
         }
+
         return options;
     }
 

--- a/csharp/src/ZeroC.Ice.Slice.Tools/Slice2CSharpDependTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Slice2CSharpDependTask.cs
@@ -10,7 +10,7 @@ public class Slice2CSharpDependTask : Common.SliceDependTask
     protected override ITaskItem[] GeneratedItems(ITaskItem source) =>
         new ITaskItem[]
         {
-            new TaskItem(GetGeneratedPath(source, source.GetMetadata("OutputDir"), ".cs")),
+            new TaskItem(GetGeneratedPath(source, source.GetMetadata("OutputDir"), IceRpc ? ".IceRpc.cs" : ".cs"))
         };
 
     // Same as generated items but only returns the generated items that need to be compiled

--- a/csharp/src/ZeroC.Ice.Slice.Tools/Slice2CSharpTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Slice2CSharpTask.cs
@@ -16,7 +16,9 @@ public class Slice2CSharpTask : Common.SliceCompilerTask
         foreach (ITaskItem source in Sources)
         {
             string message = string.Format("Compiling {0} Generating -> ", source.GetMetadata("Identity"));
-            message += Common.TaskUtil.MakeRelative(WorkingDirectory, GetGeneratedPath(source, OutputDir, ".cs"));
+            message += Common.TaskUtil.MakeRelative(
+                WorkingDirectory,
+                GetGeneratedPath(source, OutputDir, IceRpc ? ".IceRpc.cs" : ".cs"));
             Log.LogMessage(MessageImportance.High, message);
         }
     }
@@ -24,6 +26,6 @@ public class Slice2CSharpTask : Common.SliceCompilerTask
     protected override ITaskItem[] GeneratedItems(ITaskItem source) =>
         new ITaskItem[]
         {
-            new TaskItem(GetGeneratedPath(source, OutputDir, ".cs"))
+            new TaskItem(GetGeneratedPath(source, OutputDir, IceRpc ? ".IceRpc.cs" : ".cs"))
         };
 }

--- a/csharp/src/ZeroC.Ice.Slice.Tools/SliceCompile.CSharp.xaml
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/SliceCompile.CSharp.xaml
@@ -49,6 +49,20 @@
         </StringListProperty.DataSource>
     </StringListProperty>
 
+    <BoolProperty
+        Name="IceRpc"
+        DisplayName="IceRpc"
+        Description="Generate code for use with IceRPC projects.">
+        <BoolProperty.DataSource>
+            <DataSource
+                Persistence="ProjectFile"
+                ItemType="SliceCompile"
+                Label="SliceTools"
+                HasConfigurationCondition="false"
+                SourceOfDefaultValue="AfterContext"/>
+        </BoolProperty.DataSource>
+    </BoolProperty>
+
     <StringListProperty
         DisplayName="Additional Options"
         Name="AdditionalOptions"

--- a/csharp/src/ZeroC.Ice.Slice.Tools/ZeroC.Ice.Slice.Tools.targets
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/ZeroC.Ice.Slice.Tools.targets
@@ -103,7 +103,8 @@
         <Slice2CSharpDependTask
             WorkingDirectory      = "$(MSBuildProjectDirectory)"
             IceSliceToolsPath     = "$(_IceSliceToolsPathNormalized)"
-            Sources               = "@(_SliceCompileNormalized)">
+            Sources               = "@(_SliceCompileNormalized)"
+            IceRpc                = "%(_SliceCompileNormalized.IceRpc)">
 
             <Output
                 ItemName          = "_SliceCompile"
@@ -120,6 +121,7 @@
             IceSliceToolsPath     = "$(_IceSliceToolsPathNormalized)"
             OutputDir             = "%(_SliceCompile.OutputDir)"
             IncludeDirectories    = "%(_SliceCompile.IncludeDirectories)"
+            IceRpc                = "%(_SliceCompile.IceRpc)"
             AdditionalOptions     = "%(_SliceCompile.AdditionalOptions)"
             Sources               = "@(_SliceCompile)"
             Condition             = "'%(_SliceCompile.BuildRequired)' == 'True'"/>
@@ -141,6 +143,7 @@
 
     <Target Name="SliceCompileClean" BeforeTargets="Clean">
         <Delete Files="@(SliceCompile->'%(OutputDir)\%(Filename).cs')"/>
+        <Delete Files="@(SliceCompile->'%(OutputDir)\%(Filename).IceRpc.cs')"/>
         <Delete Files="@(SliceCompile->'%(OutputDir)\SliceCompile.%(Filename).d')"/>
     </Target>
 </Project>

--- a/csharp/test/Ice/defaultValue/Test.ice
+++ b/csharp/test/Ice/defaultValue/Test.ice
@@ -45,10 +45,12 @@ module Test
         float zeroF = 0;
         float zeroDotF = 0.0;
         double zeroD = 0;
-        double zeroDotD = 0;
+        double zeroDotD = 0.0;
     }
 
+    /// My bool constant.
     const bool ConstBool = true;
+
     const byte ConstByte = 254;
     const short ConstShort = 16000;
     const int ConstInt = 3;
@@ -67,7 +69,7 @@ module Test
     const float ConstZeroF = 0;
     const float ConstZeroDotF = 0.0;
     const double ConstZeroD = 0;
-    const double ConstZeroDotD = 0;
+    const double ConstZeroDotD = 0.0;
 
     struct Struct2
     {
@@ -203,7 +205,7 @@ module Test
         float zeroF = 0;
         float zeroDotF = 0.0;
         double zeroD = 0;
-        double zeroDotD = 0;
+        double zeroDotD = 0.0;
     }
 
     exception DerivedEx extends BaseEx
@@ -235,7 +237,7 @@ module Test
         float zeroF = 0;
         float zeroDotF = 0.0;
         double zeroD = 0;
-        double zeroDotD = 0;
+        double zeroDotD = 0.0;
     }
 
     ["cs:property"]
@@ -256,7 +258,7 @@ module Test
         float zeroF = 0;
         float zeroDotF = 0.0;
         double zeroD = 0;
-        double zeroDotD = 0;
+        double zeroDotD = 0.0;
     }
 
     ["cs:property"]
@@ -277,7 +279,7 @@ module Test
         float zeroF = 0;
         float zeroDotF = 0.0;
         double zeroD = 0;
-        double zeroDotD = 0;
+        double zeroDotD = 0.0;
     }
 
     sequence<byte> ByteSeq;

--- a/slice/Ice/Identity.ice
+++ b/slice/Ice/Identity.ice
@@ -16,6 +16,9 @@
 [["js:module:@zeroc/ice"]]
 
 /// The Ice RPC framework.
+#ifdef __ICERPC__
+["cs:identifier:IceRpc.Ice"]
+#endif
 ["java:identifier:com.zeroc.Ice"]
 module Ice
 {

--- a/slice/Ice/Locator.ice
+++ b/slice/Ice/Locator.ice
@@ -12,6 +12,9 @@
 
 #include "Identity.ice"
 
+#ifdef __ICERPC__
+["cs:identifier:IceRpc.Ice"]
+#endif
 ["java:identifier:com.zeroc.Ice"]
 module Ice
 {

--- a/slice/Ice/LocatorRegistry.ice
+++ b/slice/Ice/LocatorRegistry.ice
@@ -12,6 +12,9 @@
 
 #include "Locator.ice"
 
+#ifdef __ICERPC__
+["cs:identifier:IceRpc.Ice"]
+#endif
 ["java:identifier:com.zeroc.Ice"]
 module Ice
 {

--- a/slice/Ice/OperationMode.ice
+++ b/slice/Ice/OperationMode.ice
@@ -12,10 +12,18 @@
 
 [["js:module:@zeroc/ice"]]
 
+#ifdef __ICERPC__
+// In IceRPC, OperationMode is an internal implementation detail of the Ice protocol; the corresponding generated code
+// is not publicly visible.
+["cs:identifier:IceRpc.Internal"]
+#endif
 ["java:identifier:com.zeroc.Ice"]
 module Ice
 {
     /// Specifies if an operation is idempotent, which affects the retry behavior of the Ice client runtime.
+    #ifdef __ICERPC__
+    ["cs:internal"]
+    #endif
     enum OperationMode
     {
         /// A non-idempotent operation (the default). The Ice client runtime guarantees that it will not violate

--- a/slice/Ice/Process.ice
+++ b/slice/Ice/Process.ice
@@ -10,6 +10,9 @@
 
 #include "LocatorRegistry.ice"
 
+#ifdef __ICERPC__
+["cs:identifier:IceRpc.Ice"]
+#endif
 ["java:identifier:com.zeroc.Ice"]
 module Ice
 {

--- a/slice/Ice/ReplyStatus.ice
+++ b/slice/Ice/ReplyStatus.ice
@@ -12,12 +12,20 @@
 
 [["js:module:@zeroc/ice"]]
 
+#ifdef __ICERPC__
+// In IceRPC, ReplyStatus is an internal implementation detail of the Ice protocol; the corresponding generated code is
+// not publicly visible.
+["cs:identifier:IceRpc.Internal"]
+#endif
 ["java:identifier:com.zeroc.Ice"]
 module Ice
 {
     /// Represents the status of a reply.
     /// A reply status can have any value in the range 0..255. Do not use this enum to marshal or unmarshal a reply
     /// status unless you know its value corresponds to one of the enumerators defined below.
+    #ifdef __ICERPC__
+    ["cs:internal"]
+    #endif
     enum ReplyStatus
     {
         /// The dispatch completed successfully.


### PR DESCRIPTION
Cherry-picked from the following commits on main:

(cherry picked from commit 93d4a9d687e) Add --rpc none|ice|icerpc option to slice2cs (#5206)
(cherry picked from commit 8fec0add25f) Rename ZeroC.Slice -> ZeroC.Slice.Codec in generated code for IceRPC C# (#5229)
(cherry picked from commit 9c5cb3dd307) Update Slice files for compatibility with IceRPC (#5232)
(cherry picked from commit 7c116de9616) Add cs:internal and cs:readonly support for IceRPC generated code (#5234)
(cherry picked from commit dfaca9744f4) Update OperationMode and ReplyStatus for use by IceRPC (#5235)
(cherry picked from commit 870e5ac6fc6) Update slice2cs generated code for IceRPC (#5239)
(cherry picked from commit 169a8302c65) Update slice2cs for new IceRpc.Ice layout (#5245)
(cherry picked from commit cecd85079bd) Generate using IceRpc.Ice, reduce qualification (#5246)
(cherry picked from commit 7873d1a8d7c) Update slice2cs for IceRPC to use IceRpc.Ice.Codec (#5248)
(cherry picked from commit 2fe0665b4e7) Remove LINQ Count() from code generated by slice2cs for IceRPC (#5250)
(cherry picked from commit a8d03882840) Replace '--rpc xxx' flag in slice2cs with just '--icerpc'. (#5251)
(cherry picked from commit 32d11c5b7d6) Update IceProxy APIs generated by slice2cs for IceRPC (#5252)
(cherry picked from commit c5edf4c7dcf) Use Ice terminology for int, short etc in slice2cs for IceRPC (#5253)
(cherry picked from commit 13a6a122c22) Replace 'Rpc' String Option with 'IceRpc' Bool Option in the Slice Tool (#5254)
(cherry picked from commit daf7b5e3ace) Update Ice proxies generated by slice2cs for IceRPC (#5255)
(cherry picked from commit b244d886986) Simplify code generated by slice2cs --icerpc (#5256)
(cherry picked from commit cd4925dd8ad) Fix small bugs in slice2cs --icerpc
(cherry picked from commit fdee26aab3e) Remove payload continuation
(cherry picked from commit 8e85a69c55b) Fix marshaled-result bug in slice2cs --icerpc
(cherry picked from commit 068d65c8a7f) Remove EncodedReturn attribute argument (#5260)
(cherry picked from commit 51f85ca73eb) Fix bug in DecodeOptionalField (slice2cs --icerpc)
(cherry picked from commit 6e4fb735add) Fix incorrect OptimizedVSize computation in slice2cs --icerpc
(cherry picked from commit 98a89570255) Update slice2cs --icerpc to no not generate useTagEndMarker (#5266)
(cherry picked from commit 4cd1845bef1) Change null check for ReadOnlyMemory parameter (slice2cs --icerpc) (#5272)
(cherry picked from commit 882590e732d) Further split Ice/IceRpc doc-comment generation (#5274)
(cherry picked from commit 9bd4ce08b84) Update slice2cs doc-comment generation (#5275)
(cherry picked from commit e84c6848985) Add support for constants and default values (slice2cs --icerpc) (#5282)
(cherry picked from commit 12574a21319) Generate cs:attribute on the constant field, not the wrapper class (#5288) (#5294)
(cherry picked from commit d90181c7786) Fix cs:generic sequence mapping for IceRPC (#5297)
(cherry picked from commit c1cd64eb8a8) slicecs: add oneway support for IceRPC (#5224) (#5305)
