### PR TITLE
Backport ZeroC.Ice.Slice.Tools from main

### DIFF
--- a/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceCompilerTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceCompilerTask.cs
@@ -152,7 +152,8 @@ public abstract class SliceCompilerTask : ToolTask
 
                     // Save the dependencies for each source to a dependency file
                     //
-                    // Foo.ice -> $(OutputDir)/SliceCompile.Foo.d
+                    // Foo.ice            -> $(OutputDir)/SliceCompile.Foo.d
+                    // Foo.ice --icerpc   -> $(OutputDir)/SliceCompile.Foo.IceRpc.d
                     var doc = new XDocument(
                         new XDeclaration("1.0", "utf-8", "yes"),
                         new XElement("dependencies",
@@ -161,8 +162,9 @@ public abstract class SliceCompilerTask : ToolTask
                                 new XElement("options",
                                     GetOptions(source).Select(e => new XElement(e.Key, e.Value))))));
 
+                    string dependSuffix = IceRpc ? ".IceRpc.d" : ".d";
                     doc.Save(Path.Combine(OutputDir,
-                                            string.Format("SliceCompile.{0}.d", source.GetMetadata("Filename"))));
+                                            string.Format("SliceCompile.{0}{1}", source.GetMetadata("Filename"), dependSuffix)));
                     // Update the Inputs and Outputs metadata of the output sources, these info will be use to write
                     // the TLog files used by MSBuild to compute what has to be build.
                     inputs = inputs.Select(path => Path.GetFullPath(path)).ToList();

--- a/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceDependTask.cs
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/Common/SliceDependTask.cs
@@ -135,8 +135,9 @@ public abstract class SliceDependTask : Microsoft.Build.Utilities.Task
             var dependsDoc = new XmlDocument();
             if (skip)
             {
+                string dependSuffix = IceRpc ? ".IceRpc.d" : ".d";
                 var dependInfo = new FileInfo(Path.Combine(WorkingDirectory, source.GetMetadata("OutputDir"),
-                    string.Format("SliceCompile.{0}.d", Path.GetFileNameWithoutExtension(sourceInfo.Name))));
+                    string.Format("SliceCompile.{0}{1}", Path.GetFileNameWithoutExtension(sourceInfo.Name), dependSuffix)));
                 //
                 // Check that the depend file exists
                 //

--- a/csharp/src/ZeroC.Ice.Slice.Tools/ZeroC.Ice.Slice.Tools.targets
+++ b/csharp/src/ZeroC.Ice.Slice.Tools/ZeroC.Ice.Slice.Tools.targets
@@ -111,7 +111,7 @@
                 TaskParameter     = "ComputedSources"/>
 
             <Output
-                PropertyName      = "_SliceCompileGeneratedPaths"
+                ItemName          = "_SliceCompileGeneratedPaths"
                 TaskParameter     = "GeneratedCompiledPaths"/>
         </Slice2CSharpDependTask>
 
@@ -136,7 +136,7 @@
         -->
 
         <ItemGroup>
-            <Compile Include="$(_SliceCompileGeneratedPaths)"
+            <Compile Include="@(_SliceCompileGeneratedPaths)"
                      Exclude="@(Compile->'%(FullPath)');@(Compile->'%(Identity)')" />
         </ItemGroup>
     </Target>
@@ -145,5 +145,6 @@
         <Delete Files="@(SliceCompile->'%(OutputDir)\%(Filename).cs')"/>
         <Delete Files="@(SliceCompile->'%(OutputDir)\%(Filename).IceRpc.cs')"/>
         <Delete Files="@(SliceCompile->'%(OutputDir)\SliceCompile.%(Filename).d')"/>
+        <Delete Files="@(SliceCompile->'%(OutputDir)\SliceCompile.%(Filename).IceRpc.d')"/>
     </Target>
 </Project>


### PR DESCRIPTION
Backport 5efc47c975e from `main` to `3.8`. With this `ZeroC.Ice.Slice.Tools` and `slice2cs` are in sync with `main`. 