### PR TITLE
Spring Cleaning of the Slice Compilers

### DIFF
--- a/cpp/src/Slice/MetadataValidation.cpp
+++ b/cpp/src/Slice/MetadataValidation.cpp
@@ -67,7 +67,7 @@ Slice::misappliedMetadataMessage(const MetadataPtr& metadata, const SyntaxTreeBa
 }
 
 void
-Slice::validateMetadata(const UnitPtr& p, string_view prefix, map<string, MetadataInfo> knownMetadata)
+Slice::validateMetadata(const UnitPtr& unit, string_view prefix, map<string, MetadataInfo> knownMetadata)
 {
     // We want to perform all the metadata validation in the same pass, to keep all the diagnostics in order.
     // So, we add all the language-agnostic metadata validation into the provided list.
@@ -156,7 +156,7 @@ Slice::validateMetadata(const UnitPtr& p, string_view prefix, map<string, Metada
 
     // Then we pass this list off the internal visitor, which performs the heavy lifting.
     auto visitor = MetadataVisitor(prefix, std::move(knownMetadata));
-    p->visit(&visitor);
+    unit->visit(&visitor);
 }
 
 MetadataVisitor::MetadataVisitor(string_view language, map<string, MetadataInfo> knownMetadata)
@@ -167,11 +167,11 @@ MetadataVisitor::MetadataVisitor(string_view language, map<string, MetadataInfo>
 }
 
 bool
-MetadataVisitor::visitUnitStart(const UnitPtr& p)
+MetadataVisitor::visitUnitStart(const UnitPtr& unit)
 {
-    DefinitionContextPtr dc = p->findDefinitionContext(p->topLevelFile());
+    DefinitionContextPtr dc = unit->findDefinitionContext(unit->topLevelFile());
     assert(dc);
-    dc->setMetadata(validate(dc->getMetadata(), p));
+    dc->setMetadata(validate(dc->getMetadata(), unit));
     return true;
 }
 

--- a/cpp/src/Slice/MetadataValidation.h
+++ b/cpp/src/Slice/MetadataValidation.h
@@ -95,7 +95,7 @@ namespace Slice
     std::string misappliedMetadataMessage(const MetadataPtr& metadata, const SyntaxTreeBasePtr& p);
 
     /// Validates all the metadata in the provided Unit against a map of known metadata.
-    /// @param unit The unit who's metadata should be validated.
+    /// @param unit The unit whose metadata should be validated.
     /// @param prefix Which language's metadata should be validated. Any metadata that starts with a different
     ///               language prefix than this one will be ignored. Note that metadata without any language prefix
     ///               (i.e. parser metadata) is always checked.

--- a/cpp/src/Slice/MetadataValidation.h
+++ b/cpp/src/Slice/MetadataValidation.h
@@ -95,12 +95,13 @@ namespace Slice
     std::string misappliedMetadataMessage(const MetadataPtr& metadata, const SyntaxTreeBasePtr& p);
 
     /// Validates all the metadata in the provided Unit against a map of known metadata.
-    /// @param p The unit who's metadata should be validated.
+    /// @param unit The unit who's metadata should be validated.
     /// @param prefix Which language's metadata should be validated. Any metadata that starts with a different
     ///               language prefix than this one will be ignored. Note that metadata without any language prefix
     ///               (i.e. parser metadata) is always checked.
     /// @param knownMetadata A map containing the directives that should be validated, and information describing
     ///                      the various constraints and conditions that should be upheld for it and its arguments.
-    void validateMetadata(const UnitPtr& unit, std::string_view prefix, std::map<std::string, MetadataInfo> knownMetadata);
+    void
+    validateMetadata(const UnitPtr& unit, std::string_view prefix, std::map<std::string, MetadataInfo> knownMetadata);
 }
 #endif

--- a/cpp/src/Slice/MetadataValidation.h
+++ b/cpp/src/Slice/MetadataValidation.h
@@ -101,6 +101,6 @@ namespace Slice
     ///               (i.e. parser metadata) is always checked.
     /// @param knownMetadata A map containing the directives that should be validated, and information describing
     ///                      the various constraints and conditions that should be upheld for it and its arguments.
-    void validateMetadata(const UnitPtr& p, std::string_view prefix, std::map<std::string, MetadataInfo> knownMetadata);
+    void validateMetadata(const UnitPtr& unit, std::string_view prefix, std::map<std::string, MetadataInfo> knownMetadata);
 }
 #endif

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -48,7 +48,7 @@ namespace
     DataMemberList filterOrderedOptionalDataMembers(const DataMemberList& members)
     {
         DataMemberList result;
-        copy_if(members.begin(), members.end(), back_inserter(result), [](const auto& p) { return p->optional(); });
+        copy_if(members.begin(), members.end(), back_inserter(result), [](const auto& p) { return p->isOptional(); });
         result.sort(compareTag<DataMemberPtr>);
         return result;
     }
@@ -563,7 +563,7 @@ Slice::Builtin::kindAsString() const
     return builtinTable[_kind];
 }
 
-optional<Slice::Builtin::Kind>
+optional<Builtin::Kind>
 Slice::Builtin::kindFromString(string_view str)
 {
     // Object is an alias for Value that we don't put in the builtinTable.
@@ -749,7 +749,7 @@ Slice::Contained::getMetadataArgs(string_view directive) const
     return nullopt;
 }
 
-std::optional<FormatType>
+optional<FormatType>
 Slice::Contained::parseFormatMetadata() const
 {
     if (auto metadata = getMetadataArgs("format"))
@@ -2310,7 +2310,7 @@ Slice::ClassDef::createDataMember(
         // Validate the tag.
         for (const auto& q : dataMembers())
         {
-            if (q->optional() && tag == q->tag())
+            if (q->isOptional() && tag == q->tag())
             {
                 unit()->error("tag for optional data member '" + name + "' is already in use");
                 break;
@@ -2615,7 +2615,7 @@ Slice::InterfaceDecl::addPartition(
 // list of lists, with each member list containing the operation
 // names defined by the interfaces in each partition.
 //
-Slice::InterfaceDecl::StringPartitionList
+InterfaceDecl::StringPartitionList
 Slice::InterfaceDecl::toStringPartitionList(const GraphPartitionList& partitions)
 {
     StringPartitionList spl;
@@ -3004,7 +3004,7 @@ Slice::Operation::createParameter(const string& name, const TypePtr& type, bool 
         {
             for (const auto& param : parameters())
             {
-                if (param->optional() && param->tag() == tag)
+                if (param->isOptional() && param->tag() == tag)
                 {
                     unit()->error(msg);
                     break;
@@ -3053,7 +3053,7 @@ Slice::Operation::sortedInParameters() const
     ParameterList required, optional;
     for (const auto& param : inParameters())
     {
-        if (param->optional())
+        if (param->isOptional())
         {
             optional.push_back(param);
         }
@@ -3128,7 +3128,7 @@ Slice::Operation::sortedReturnAndOutParameters(const string& returnName)
     // First sort each parameter into either 'required' or 'optional'.
     for (auto i = required.begin(); i != required.end();)
     {
-        if ((*i)->optional())
+        if ((*i)->isOptional())
         {
             optional.push_back(*i);
             i = required.erase(i);
@@ -3258,7 +3258,7 @@ Slice::Operation::sendsOptionals() const
 {
     for (const auto& i : inParameters())
     {
-        if (i->optional())
+        if (i->isOptional())
         {
             return true;
         }
@@ -3271,7 +3271,7 @@ Slice::Operation::receivesOptionals() const
 {
     for (const auto& i : outParameters())
     {
-        if (i->optional())
+        if (i->isOptional())
         {
             return true;
         }
@@ -3279,10 +3279,10 @@ Slice::Operation::receivesOptionals() const
     return returnIsOptional();
 }
 
-std::optional<FormatType>
+optional<FormatType>
 Slice::Operation::format() const
 {
-    std::optional<FormatType> format = parseFormatMetadata();
+    optional<FormatType> format = parseFormatMetadata();
     if (!format)
     {
         ContainedPtr cont = dynamic_pointer_cast<Contained>(container());
@@ -3407,7 +3407,7 @@ Slice::Exception::createDataMember(
         // Validate the tag.
         for (const auto& q : dataMembers())
         {
-            if (q->optional() && tag == q->tag())
+            if (q->isOptional() && tag == q->tag())
             {
                 unit()->error("tag for optional data member '" + name + "' is already in use");
                 break;
@@ -4167,7 +4167,7 @@ Slice::Parameter::setIsOutParam()
 }
 
 bool
-Slice::Parameter::optional() const
+Slice::Parameter::isOptional() const
 {
     return _optional;
 }
@@ -4214,7 +4214,7 @@ Slice::DataMember::type() const
 }
 
 bool
-Slice::DataMember::optional() const
+Slice::DataMember::isOptional() const
 {
     return _optional;
 }
@@ -4256,7 +4256,7 @@ Slice::DataMember::DataMember(
     bool isOptional,
     int32_t tag,
     SyntaxTreeBasePtr defaultValueType,
-    std::optional<string> defaultValueString)
+    optional<string> defaultValueString)
     : Contained(container, name),
       _type(std::move(type)),
       _optional(isOptional),
@@ -4391,7 +4391,7 @@ Slice::Unit::currentLine() const
 }
 
 int
-Slice::Unit::setCurrentFile(std::string currentFile, int lineNumber)
+Slice::Unit::setCurrentFile(string currentFile, int lineNumber)
 {
     assert(!currentFile.empty());
 
@@ -4677,12 +4677,12 @@ Slice::Unit::findContents(const string& scopedName) const
 }
 
 void
-Slice::Unit::addTypeId(int32_t compactId, const std::string& typeId)
+Slice::Unit::addTypeId(int32_t compactId, const string& typeId)
 {
     _typeIds.insert(make_pair(compactId, typeId));
 }
 
-std::string
+string
 Slice::Unit::getTypeId(int32_t compactId) const
 {
     auto p = _typeIds.find(compactId);

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -692,7 +692,14 @@ namespace Slice
             Idempotent = 2
         };
 
-        Operation(const ContainerPtr&, const std::string&, TypePtr, bool, std::int32_t, Mode);
+        Operation(
+            const ContainerPtr& container,
+            const std::string& name,
+            TypePtr returnType,
+            bool returnIsOptional,
+            std::int32_t returnTag,
+            Mode mode);
+
         [[nodiscard]] InterfaceDefPtr interface() const;
         [[nodiscard]] TypePtr returnType() const;
         [[nodiscard]] bool returnIsOptional() const;
@@ -1027,7 +1034,7 @@ namespace Slice
         [[nodiscard]] TypePtr type() const;
         [[nodiscard]] bool isOutParam() const;
         void setIsOutParam();
-        [[nodiscard]] bool optional() const;
+        [[nodiscard]] bool isOptional() const;
         [[nodiscard]] std::int32_t tag() const;
         [[nodiscard]] std::string kindOf() const final;
 
@@ -1056,7 +1063,7 @@ namespace Slice
             SyntaxTreeBasePtr defaultValueType,
             std::optional<std::string> defaultValueString);
         [[nodiscard]] TypePtr type() const;
-        [[nodiscard]] bool optional() const;
+        [[nodiscard]] bool isOptional() const;
         [[nodiscard]] std::int32_t tag() const;
 
         // defaultValue() and defaultValueType() are either both null (no default value) or both non-null.

--- a/cpp/src/Slice/SliceUtil.cpp
+++ b/cpp/src/Slice/SliceUtil.cpp
@@ -489,7 +489,7 @@ Slice::getArticleFor(const string& s)
     return (vowels.find_first_of(s[0]) != string::npos) ? "an" : "a";
 }
 
-std::string
+string
 Slice::pluralKindOf(const ContainedPtr& p)
 {
     string kindOf = p->kindOf();
@@ -635,7 +635,7 @@ Slice::getFirstSentence(const StringList& lines)
 }
 
 string
-Slice::getEscapedParamName(const ParameterList& params, std::string_view param)
+Slice::getEscapedParamName(const ParameterList& params, string_view param)
 {
     for (const auto& p : params)
     {
@@ -650,14 +650,14 @@ Slice::getEscapedParamName(const ParameterList& params, std::string_view param)
 string
 Slice::getTypeScopedName(const TypePtr& type)
 {
-    if (auto builtin = std::dynamic_pointer_cast<Builtin>(type))
+    if (auto builtin = dynamic_pointer_cast<Builtin>(type))
     {
         return builtin->kindAsString();
     }
     else
     {
         // a type is either built-in or contained
-        auto contained = std::dynamic_pointer_cast<Contained>(type);
+        auto contained = dynamic_pointer_cast<Contained>(type);
         assert(contained);
         return contained->scoped();
     }
@@ -755,7 +755,7 @@ Slice::DependencyGenerator::writeMakefileDependencies(
 }
 
 void
-Slice::DependencyGenerator::writeXMLDependencies(const std::string& dependFile)
+Slice::DependencyGenerator::writeXMLDependencies(const string& dependFile)
 {
     ostringstream os;
     os << R"(<?xml version="1.0" encoding="UTF-8"?>)";
@@ -777,7 +777,7 @@ Slice::DependencyGenerator::writeXMLDependencies(const std::string& dependFile)
 }
 
 void
-Slice::DependencyGenerator::writeJSONDependencies(const std::string& dependFile)
+Slice::DependencyGenerator::writeJSONDependencies(const string& dependFile)
 {
     ostringstream os;
     os << "{";

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -121,14 +121,14 @@ namespace
 
     // TODO this is probably unnecessary. Search for `orderedOptionalDataMembers` in 'libSlice'.
     /// Split data members in required and optional members; the optional members are sorted in tag order.
-    std::pair<DataMemberList, DataMemberList> split(const DataMemberList& dataMembers)
+    pair<DataMemberList, DataMemberList> split(const DataMemberList& dataMembers)
     {
         DataMemberList requiredMembers;
         DataMemberList optionalMembers;
 
         for (const auto& q : dataMembers)
         {
-            if (q->optional())
+            if (q->isOptional())
             {
                 optionalMembers.push_back(q);
             }
@@ -190,7 +190,7 @@ namespace
         ParameterList optionals;
         for (const auto& param : params)
         {
-            if (param->optional())
+            if (param->isOptional())
             {
                 optionals.push_back(param);
             }
@@ -434,7 +434,7 @@ Slice::isMovable(const TypePtr& type)
 }
 
 string
-Slice::getUnqualified(const std::string& type, const std::string& scope)
+Slice::getUnqualified(const string& type, const string& scope)
 {
     if (type.find("::") != string::npos)
     {
@@ -650,7 +650,7 @@ Slice::writeAllocateCode(
 {
     for (const auto& param : params)
     {
-        string s = typeToString(param->type(), param->optional(), clScope, param->getMetadata(), typeCtx);
+        string s = typeToString(param->type(), param->isOptional(), clScope, param->getMetadata(), typeCtx);
         out << nl << s << ' ' << paramPrefix << param->mappedName() << ';';
     }
 
@@ -762,7 +762,7 @@ Slice::writeIceTuple(IceInternal::Output& out, const DataMemberList& dataMembers
             out << ", ";
         }
         out << "const ";
-        out << typeToString((*q)->type(), (*q)->optional(), scope, (*q)->getMetadata(), typeCtx) << "&";
+        out << typeToString((*q)->type(), (*q)->isOptional(), scope, (*q)->getMetadata(), typeCtx) << "&";
     }
     out << "> ice_tuple() const";
 
@@ -894,7 +894,7 @@ Slice::cppLinkFormatter(const string& rawLink, const ContainedPtr& source, const
 }
 
 void
-Slice::validateCppMetadata(const UnitPtr& u)
+Slice::validateCppMetadata(const UnitPtr& unit)
 {
     map<string, MetadataInfo> knownMetadata;
 
@@ -1082,5 +1082,5 @@ Slice::validateCppMetadata(const UnitPtr& u)
     knownMetadata.emplace("cpp:type", typeInfo);
 
     // Pass this information off to the parser's metadata validation logic.
-    Slice::validateMetadata(u, "cpp", std::move(knownMetadata));
+    Slice::validateMetadata(unit, "cpp", std::move(knownMetadata));
 }

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -16,65 +16,65 @@ namespace Slice
         char operator()(char);
     };
 
-    void printHeader(IceInternal::Output&);
-    void printVersionCheck(IceInternal::Output&);
-    void printDllExportStuff(IceInternal::Output&, const std::string&);
+    void printHeader(IceInternal::Output& out);
+    void printVersionCheck(IceInternal::Output& out);
+    void printDllExportStuff(IceInternal::Output& out, const std::string& dllExport);
 
-    bool isMovable(const TypePtr&);
+    bool isMovable(const TypePtr& type);
 
-    std::string getUnqualified(const std::string&, const std::string&);
+    std::string getUnqualified(const std::string& type, const std::string& scope);
 
     /// Gets the C++ type for a Slice parameter or field.
     std::string typeToString(
-        const TypePtr&,
-        bool,
-        const std::string& = "",
-        const MetadataList& = MetadataList(),
-        TypeContext = TypeContext::None);
+        const TypePtr& type,
+        bool optional,
+        const std::string& scope = "",
+        const MetadataList& metadata = MetadataList(),
+        TypeContext typeCtx = TypeContext::None);
 
     // TODO: find a better name.
     /// Gets the C++ type for a Slice parameter to be marshaled.
     std::string inputTypeToString(
-        const TypePtr&,
-        bool,
-        const std::string& = "",
-        const MetadataList& = MetadataList(),
-        TypeContext = TypeContext::None);
+        const TypePtr& type,
+        bool optional,
+        const std::string& scope = "",
+        const MetadataList& metadata = MetadataList(),
+        TypeContext typeCtx = TypeContext::None);
 
     // TODO: find a better name.
     /// Gets the C++ type for a Slice out parameter when mapped to a C++ out parameter.
     std::string outputTypeToString(
-        const TypePtr&,
-        bool,
-        const std::string& = "",
-        const MetadataList& = MetadataList(),
-        TypeContext = TypeContext::None);
+        const TypePtr& type,
+        bool optional,
+        const std::string& scope = "",
+        const MetadataList& metadata = MetadataList(),
+        TypeContext typeCtx = TypeContext::None);
 
-    std::string operationModeToString(Operation::Mode);
-    std::string opFormatTypeToString(const OperationPtr&);
+    std::string operationModeToString(Operation::Mode mode);
+    std::string opFormatTypeToString(const OperationPtr& op);
 
-    void writeMarshalCode(IceInternal::Output&, const ParameterList&, const OperationPtr&);
-    void writeUnmarshalCode(IceInternal::Output&, const ParameterList&, const OperationPtr&);
+    void writeMarshalCode(IceInternal::Output& out, const ParameterList& params, const OperationPtr& op);
+    void writeUnmarshalCode(IceInternal::Output& out, const ParameterList& params, const OperationPtr& op);
     void
-    writeAllocateCode(IceInternal::Output&, const ParameterList&, const OperationPtr&, const std::string&, TypeContext);
+    writeAllocateCode(IceInternal::Output& out, const ParameterList& params, const OperationPtr& op, const std::string& clScope, TypeContext typeCtx);
 
     /// Writes the StreamReader specialization for a struct.
-    void writeStreamReader(IceInternal::Output&, const StructPtr&, const DataMemberList&);
+    void writeStreamReader(IceInternal::Output& out, const StructPtr& p, const DataMemberList& dataMembers);
 
     /// Reads or writes the data members of a class or exception slice.
-    void readDataMembers(IceInternal::Output&, const DataMemberList&);
-    void writeDataMembers(IceInternal::Output&, const DataMemberList&);
+    void readDataMembers(IceInternal::Output& out, const DataMemberList& dataMembers);
+    void writeDataMembers(IceInternal::Output& out, const DataMemberList& dataMembers);
 
-    void writeIceTuple(IceInternal::Output&, const DataMemberList&, TypeContext);
+    void writeIceTuple(IceInternal::Output& out, const DataMemberList& dataMembers, TypeContext typeCtx);
 
-    std::string findMetadata(const MetadataList&, TypeContext = TypeContext::None);
-    bool inWstringModule(const SequencePtr&);
+    std::string findMetadata(const MetadataList& metadata, TypeContext typeCtx = TypeContext::None);
+    bool inWstringModule(const SequencePtr& seq);
 
     /// Returns a doxygen formatted link to the provided Slice identifier.
     std::string
     cppLinkFormatter(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target);
 
-    void validateCppMetadata(const UnitPtr&);
+    void validateCppMetadata(const UnitPtr& unit);
 }
 
 #endif

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -55,8 +55,12 @@ namespace Slice
 
     void writeMarshalCode(IceInternal::Output& out, const ParameterList& params, const OperationPtr& op);
     void writeUnmarshalCode(IceInternal::Output& out, const ParameterList& params, const OperationPtr& op);
-    void
-    writeAllocateCode(IceInternal::Output& out, const ParameterList& params, const OperationPtr& op, const std::string& clScope, TypeContext typeCtx);
+    void writeAllocateCode(
+        IceInternal::Output& out,
+        const ParameterList& params,
+        const OperationPtr& op,
+        const std::string& clScope,
+        TypeContext typeCtx);
 
     /// Writes the StreamReader specialization for a struct.
     void writeStreamReader(IceInternal::Output& out, const StructPtr& p, const DataMemberList& dataMembers);

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1663,7 +1663,8 @@ Slice::Gen::ProxyVisitor::emitOperationImpl(
 
     for (const auto& q : inParams)
     {
-        string typeString = inputTypeToString(q->type(), q->isOptional(), interfaceScope, q->getMetadata(), _useWstring);
+        string typeString =
+            inputTypeToString(q->type(), q->isOptional(), interfaceScope, q->getMetadata(), _useWstring);
 
         inParamsS.push_back(typeString);
         inParamsImplDecl.push_back(typeString + ' ' + paramPrefix + q->mappedName());
@@ -2362,8 +2363,13 @@ Slice::Gen::DataDefVisitor::emitOneShotConstructor(const ClassDefPtr& p)
 
         for (const auto& dataMember : allDataMembers)
         {
-            string typeName =
-                typeToString(dataMember->type(), dataMember->isOptional(), scope, dataMember->getMetadata(), _useWstring);
+            string typeName = typeToString(
+                dataMember->type(),
+                dataMember->isOptional(),
+                scope,
+                dataMember->getMetadata(),
+                _useWstring);
+
             allParameters.push_back(typeName + " " + dataMember->mappedName());
             if (const auto& comment = dataMember->docComment())
             {
@@ -2433,8 +2439,8 @@ Slice::Gen::DataDefVisitor::emitDataMember(const DataMemberPtr& p)
     }
 
     writeDocSummary(H, p);
-    H << nl << getDeprecatedAttribute(p) << typeToString(p->type(), p->isOptional(), scope, p->getMetadata(), _useWstring)
-      << ' ' << name;
+    H << nl << getDeprecatedAttribute(p)
+      << typeToString(p->type(), p->isOptional(), scope, p->getMetadata(), _useWstring) << ' ' << name;
 
     if (p->defaultValue())
     {
@@ -2784,8 +2790,13 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
                 args.push_back(condMove(isMovable(type) && !isOutParam, prefixedParamName));
             }
 
-            string responseTypeS =
-                inputTypeToString(param->type(), param->isOptional(), interfaceScope, param->getMetadata(), _useWstring);
+            string responseTypeS = inputTypeToString(
+                param->type(),
+                param->isOptional(),
+                interfaceScope,
+                param->getMetadata(),
+                _useWstring);
+
             responseParams.push_back(responseTypeS + " " + paramName);
             responseParamsDecl.push_back(responseTypeS + " " + prefixedParamName);
             responseParamsImplDecl.push_back(responseTypeS + " " + prefixedParamName);

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -529,7 +529,7 @@ namespace
         for (const auto& param : p->outParameters())
         {
             elements.push_back(
-                typeToString(param->type(), param->optional(), scope, param->getMetadata(), typeContext));
+                typeToString(param->type(), param->isOptional(), scope, param->getMetadata(), typeContext));
         }
         return elements;
     }
@@ -586,20 +586,20 @@ Slice::Gen::~Gen()
 }
 
 void
-Slice::Gen::generate(const UnitPtr& p)
+Slice::Gen::generate(const UnitPtr& unit)
 {
-    string_view file = p->topLevelFile();
-    DefinitionContextPtr dc = p->findDefinitionContext(file);
+    string_view file = unit->topLevelFile();
+    DefinitionContextPtr dc = unit->findDefinitionContext(file);
     assert(dc);
 
     // Give precedence to header-ext/source-ext file metadata.
-    string headerExtension = getHeaderExt(file, p);
+    string headerExtension = getHeaderExt(file, unit);
     if (!headerExtension.empty())
     {
         _headerExtension = headerExtension;
     }
 
-    string sourceExtension = getSourceExt(file, p);
+    string sourceExtension = getSourceExt(file, unit);
     if (!sourceExtension.empty())
     {
         _sourceExtension = sourceExtension;
@@ -659,7 +659,7 @@ Slice::Gen::generate(const UnitPtr& p)
     H << "\n#define " << s << "_";
     H << '\n';
 
-    validateCppMetadata(p);
+    validateCppMetadata(unit);
 
     C << sp;
 
@@ -689,9 +689,9 @@ Slice::Gen::generate(const UnitPtr& p)
         H << "\n#include <Ice/Ice.h>";
     }
 
-    for (const string& includeFile : p->includeFiles())
+    for (const string& includeFile : unit->includeFiles())
     {
-        string extension = getHeaderExt(includeFile, p);
+        string extension = getHeaderExt(includeFile, unit);
         if (extension.empty())
         {
             extension = _headerExtension;
@@ -764,29 +764,29 @@ Slice::Gen::generate(const UnitPtr& p)
 
     {
         ForwardDeclVisitor forwardDeclVisitor(H, C, _dllExport);
-        p->visit(&forwardDeclVisitor);
+        unit->visit(&forwardDeclVisitor);
 
         SliceLoaderVisitor sliceLoaderVisitor(C);
-        p->visit(&sliceLoaderVisitor);
+        unit->visit(&sliceLoaderVisitor);
 
         ProxyVisitor proxyVisitor(H, C, _dllExport);
-        p->visit(&proxyVisitor);
+        unit->visit(&proxyVisitor);
 
         DataDefVisitor dataDefVisitor(H, C, _dllExport);
-        p->visit(&dataDefVisitor);
+        unit->visit(&dataDefVisitor);
 
         // Generate the default (usually synchronous) skeletons.
         InterfaceVisitor interfaceVisitor(H, C, _dllExport, false);
-        p->visit(&interfaceVisitor);
+        unit->visit(&interfaceVisitor);
 
         // Generate the async skeletons.
         InterfaceVisitor asyncInterfaceVisitor(H, C, _dllExport, true);
-        p->visit(&asyncInterfaceVisitor);
+        unit->visit(&asyncInterfaceVisitor);
 
         if (!dc->hasMetadata("cpp:no-stream"))
         {
             StreamVisitor streamVisitor(H);
-            p->visit(&streamVisitor);
+            unit->visit(&streamVisitor);
         }
     }
 }
@@ -844,17 +844,17 @@ Slice::Gen::resetUseWstring(list<TypeContext>& hist)
 }
 
 string
-Slice::Gen::getHeaderExt(string_view file, const UnitPtr& ut)
+Slice::Gen::getHeaderExt(string_view file, const UnitPtr& unit)
 {
-    DefinitionContextPtr dc = ut->findDefinitionContext(file);
+    DefinitionContextPtr dc = unit->findDefinitionContext(file);
     assert(dc);
     return dc->getMetadataArgs("cpp:header-ext").value_or("");
 }
 
 string
-Slice::Gen::getSourceExt(string_view file, const UnitPtr& ut)
+Slice::Gen::getSourceExt(string_view file, const UnitPtr& unit)
 {
-    DefinitionContextPtr dc = ut->findDefinitionContext(file);
+    DefinitionContextPtr dc = unit->findDefinitionContext(file);
     assert(dc);
     return dc->getMetadataArgs("cpp:source-ext").value_or("");
 }
@@ -1422,14 +1422,14 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
         if (q->isOutParam())
         {
             string outputTypeString =
-                outputTypeToString(q->type(), q->optional(), interfaceScope, metadata, _useWstring);
+                outputTypeToString(q->type(), q->isOptional(), interfaceScope, metadata, _useWstring);
 
             paramsDecl.push_back(outputTypeString + ' ' + paramName);
             paramsImplDecl.push_back(outputTypeString + ' ' + prefixedParamName);
         }
         else
         {
-            string typeString = inputTypeToString(q->type(), q->optional(), interfaceScope, metadata, _useWstring);
+            string typeString = inputTypeToString(q->type(), q->isOptional(), interfaceScope, metadata, _useWstring);
 
             paramsDecl.push_back(typeString + ' ' + paramName);
             paramsImplDecl.push_back(typeString + ' ' + prefixedParamName);
@@ -1636,7 +1636,7 @@ void
 Slice::Gen::ProxyVisitor::emitOperationImpl(
     const OperationPtr& p,
     const string& prefix,
-    const std::vector<std::string>& outgoingAsyncParams)
+    const vector<string>& outgoingAsyncParams)
 {
     const InterfaceDefPtr container = p->interface();
     const string opName = p->mappedName();
@@ -1659,11 +1659,11 @@ Slice::Gen::ProxyVisitor::emitOperationImpl(
         outParamsHasOpt |= p->returnIsOptional();
     }
     outParamsHasOpt |=
-        std::any_of(outParams.begin(), outParams.end(), [](const ParameterPtr& q) { return q->optional(); });
+        std::any_of(outParams.begin(), outParams.end(), [](const ParameterPtr& q) { return q->isOptional(); });
 
     for (const auto& q : inParams)
     {
-        string typeString = inputTypeToString(q->type(), q->optional(), interfaceScope, q->getMetadata(), _useWstring);
+        string typeString = inputTypeToString(q->type(), q->isOptional(), interfaceScope, q->getMetadata(), _useWstring);
 
         inParamsS.push_back(typeString);
         inParamsImplDecl.push_back(typeString + ' ' + paramPrefix + q->mappedName());
@@ -1910,7 +1910,7 @@ Slice::Gen::DataDefVisitor::visitExceptionStart(const ExceptionPtr& p)
     for (const auto& dataMember : allDataMembers)
     {
         string typeName =
-            typeToString(dataMember->type(), dataMember->optional(), scope, dataMember->getMetadata(), _useWstring);
+            typeToString(dataMember->type(), dataMember->isOptional(), scope, dataMember->getMetadata(), _useWstring);
         allParameters.push_back(typeName + " " + dataMember->mappedName());
 
         if (const auto& comment = dataMember->docComment())
@@ -2363,7 +2363,7 @@ Slice::Gen::DataDefVisitor::emitOneShotConstructor(const ClassDefPtr& p)
         for (const auto& dataMember : allDataMembers)
         {
             string typeName =
-                typeToString(dataMember->type(), dataMember->optional(), scope, dataMember->getMetadata(), _useWstring);
+                typeToString(dataMember->type(), dataMember->isOptional(), scope, dataMember->getMetadata(), _useWstring);
             allParameters.push_back(typeName + " " + dataMember->mappedName());
             if (const auto& comment = dataMember->docComment())
             {
@@ -2433,14 +2433,14 @@ Slice::Gen::DataDefVisitor::emitDataMember(const DataMemberPtr& p)
     }
 
     writeDocSummary(H, p);
-    H << nl << getDeprecatedAttribute(p) << typeToString(p->type(), p->optional(), scope, p->getMetadata(), _useWstring)
+    H << nl << getDeprecatedAttribute(p) << typeToString(p->type(), p->isOptional(), scope, p->getMetadata(), _useWstring)
       << ' ' << name;
 
     if (p->defaultValue())
     {
         H << '{';
         // We don't want to generate `string{""}` because it uses a constructor that is not noexcept.
-        if (!p->defaultValue()->empty() || p->optional())
+        if (!p->defaultValue()->empty() || p->isOptional())
         {
             writeConstantValue(
                 H,
@@ -2767,7 +2767,7 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
             params.push_back(
                 typeToString(
                     type,
-                    param->optional(),
+                    param->isOptional(),
                     interfaceScope,
                     param->getMetadata(),
                     _useWstring | TypeContext::UnmarshalParamZeroCopy) +
@@ -2779,13 +2779,13 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
             if (!p->hasMarshaledResult() && !amd)
             {
                 params.push_back(
-                    outputTypeToString(type, param->optional(), interfaceScope, param->getMetadata(), _useWstring) +
+                    outputTypeToString(type, param->isOptional(), interfaceScope, param->getMetadata(), _useWstring) +
                     " " + paramName);
                 args.push_back(condMove(isMovable(type) && !isOutParam, prefixedParamName));
             }
 
             string responseTypeS =
-                inputTypeToString(param->type(), param->optional(), interfaceScope, param->getMetadata(), _useWstring);
+                inputTypeToString(param->type(), param->isOptional(), interfaceScope, param->getMetadata(), _useWstring);
             responseParams.push_back(responseTypeS + " " + paramName);
             responseParamsDecl.push_back(responseTypeS + " " + prefixedParamName);
             responseParamsImplDecl.push_back(responseTypeS + " " + prefixedParamName);

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -13,26 +13,26 @@ namespace Slice
     class Gen final
     {
     public:
-        Gen(std::string,
-            std::string,
-            std::string,
-            const std::vector<std::string>&,
-            std::string,
-            const std::vector<std::string>&,
-            std::string,
-            std::string);
+        Gen(std::string base,
+            std::string headerExtension,
+            std::string sourceExtension,
+            const std::vector<std::string>& extraHeaders,
+            std::string include,
+            const std::vector<std::string>& includePaths,
+            std::string dllExport,
+            std::string dir);
         ~Gen();
 
         Gen(const Gen&) = delete;
         Gen& operator=(const Gen&) = delete;
 
-        void generate(const UnitPtr&);
+        void generate(const UnitPtr& unit);
 
-        static TypeContext setUseWstring(const ContainedPtr&, std::list<TypeContext>&, TypeContext);
-        static TypeContext resetUseWstring(std::list<TypeContext>&);
+        static TypeContext setUseWstring(const ContainedPtr& p, std::list<TypeContext>& hist, TypeContext typeCtx);
+        static TypeContext resetUseWstring(std::list<TypeContext>& hist);
 
     private:
-        void writeExtraHeaders(IceInternal::Output&);
+        void writeExtraHeaders(IceInternal::Output& out);
 
         /// Returns the header extension defined in the file metadata for a given file,
         /// or an empty string if no file metadata was found.
@@ -62,7 +62,7 @@ namespace Slice
         class ForwardDeclVisitor final : public ParserVisitor
         {
         public:
-            ForwardDeclVisitor(IceInternal::Output&, IceInternal::Output&, std::string);
+            ForwardDeclVisitor(IceInternal::Output& h, IceInternal::Output& c, std::string dllExport);
             ForwardDeclVisitor(const ForwardDeclVisitor&) = delete;
 
             bool visitModuleStart(const ModulePtr&) final;
@@ -89,7 +89,7 @@ namespace Slice
         class SliceLoaderVisitor final : public ParserVisitor
         {
         public:
-            SliceLoaderVisitor(IceInternal::Output&);
+            SliceLoaderVisitor(IceInternal::Output& c);
             SliceLoaderVisitor(const SliceLoaderVisitor&) = delete;
 
             bool visitUnitStart(const UnitPtr&) final;
@@ -106,7 +106,7 @@ namespace Slice
         class ProxyVisitor final : public ParserVisitor
         {
         public:
-            ProxyVisitor(IceInternal::Output&, IceInternal::Output&, std::string);
+            ProxyVisitor(IceInternal::Output& h, IceInternal::Output& c, std::string dllExport);
             ProxyVisitor(const ProxyVisitor&) = delete;
 
             bool visitModuleStart(const ModulePtr&) final;
@@ -134,7 +134,7 @@ namespace Slice
         class DataDefVisitor final : public ParserVisitor
         {
         public:
-            DataDefVisitor(IceInternal::Output&, IceInternal::Output&, std::string);
+            DataDefVisitor(IceInternal::Output& h, IceInternal::Output& c, std::string dllExport);
             DataDefVisitor(const DataDefVisitor&) = delete;
 
             bool visitModuleStart(const ModulePtr&) final;
@@ -148,9 +148,9 @@ namespace Slice
             void visitDataMember(const DataMemberPtr&) final;
 
         private:
-            bool emitBaseInitializers(const ClassDefPtr&);
-            void emitOneShotConstructor(const ClassDefPtr&);
-            void emitDataMember(const DataMemberPtr&);
+            bool emitBaseInitializers(const ClassDefPtr& p);
+            void emitOneShotConstructor(const ClassDefPtr& p);
+            void emitDataMember(const DataMemberPtr& p);
 
             void printFields(const DataMemberList& fields, bool firstField);
 
@@ -194,7 +194,7 @@ namespace Slice
         class StreamVisitor final : public ParserVisitor
         {
         public:
-            StreamVisitor(IceInternal::Output&);
+            StreamVisitor(IceInternal::Output& h);
             StreamVisitor(const StreamVisitor&) = delete;
 
             bool visitModuleStart(const ModulePtr&) final;

--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -190,7 +190,7 @@ compile(const vector<string>& argv)
     Ice::CtrlCHandler ctrlCHandler;
     ctrlCHandler.setCallback(interruptedCallback);
 
-    std::map<string, StringList> dependencyMap;
+    map<string, StringList> dependencyMap;
 
     DependencyGenerator dependencyGenerator;
 

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -115,11 +115,7 @@ Slice::Csharp::writeConstantValue(
 }
 
 void
-Slice::Csharp::writeDocLine(
-    Output& out,
-    const string& openTag,
-    const string& comment,
-    const optional<string>& closeTag)
+Slice::Csharp::writeDocLine(Output& out, const string& openTag, const string& comment, const optional<string>& closeTag)
 {
     if (comment.empty())
     {

--- a/cpp/src/slice2cs/CsUtil.cpp
+++ b/cpp/src/slice2cs/CsUtil.cpp
@@ -119,7 +119,7 @@ Slice::Csharp::writeDocLine(
     Output& out,
     const string& openTag,
     const string& comment,
-    const std::optional<string>& closeTag)
+    const optional<string>& closeTag)
 {
     if (comment.empty())
     {

--- a/cpp/src/slice2cs/CsVisitor.h
+++ b/cpp/src/slice2cs/CsVisitor.h
@@ -12,7 +12,7 @@ namespace Slice
     class CsVisitor : public ParserVisitor
     {
     public:
-        CsVisitor(IceInternal::Output&);
+        CsVisitor(IceInternal::Output& out);
 
         bool visitModuleStart(const ModulePtr&) override;
         void visitModuleEnd(const ModulePtr&) override;
@@ -21,15 +21,15 @@ namespace Slice
         void emitNonBrowsableAttribute();
 
         /// Generates C# attributes from any 'cs:attribute' metadata.
-        void emitAttributes(const ContainedPtr&);
+        void emitAttributes(const ContainedPtr& p);
 
-        void emitObsoleteAttribute(const ContainedPtr&);
+        void emitObsoleteAttribute(const ContainedPtr& p);
 
         IceInternal::Output& _out;
 
     private:
-        void namespacePrefixStart(const ModulePtr&);
-        void namespacePrefixEnd(const ModulePtr&);
+        void namespacePrefixStart(const ModulePtr& p);
+        void namespacePrefixEnd(const ModulePtr& p);
     };
 }
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -65,29 +65,29 @@ Slice::Gen::~Gen()
 }
 
 void
-Slice::Gen::generate(const UnitPtr& p)
+Slice::Gen::generate(const UnitPtr& unit)
 {
-    Slice::validateCsMetadata(p);
+    Slice::validateCsMetadata(unit);
 
     if (_genMode == GenMode::Ice)
     {
         Slice::Ice::TypesVisitor typesVisitor(_out);
-        p->visit(&typesVisitor);
+        unit->visit(&typesVisitor);
 
         Slice::Ice::ResultVisitor resultVisitor(_out);
-        p->visit(&resultVisitor);
+        unit->visit(&resultVisitor);
 
         // Default skeleton.
         Slice::Ice::SkeletonVisitor skeletonVisitor(_out, false);
-        p->visit(&skeletonVisitor);
+        unit->visit(&skeletonVisitor);
 
         // Async skeleton.
         Slice::Ice::SkeletonVisitor asyncSkeletonVisitor(_out, true);
-        p->visit(&asyncSkeletonVisitor);
+        unit->visit(&asyncSkeletonVisitor);
     }
     else
     {
-        if (p->contains<InterfaceDef>())
+        if (unit->contains<InterfaceDef>())
         {
             // The proxy and skeleton code depends on this using directive.
             _out << nl << "using IceRpc.Ice.Operations;";
@@ -96,10 +96,10 @@ Slice::Gen::generate(const UnitPtr& p)
         _out << nl << "[assembly:IceGeneratedCode(\"" << _fileBase << ".ice\")]";
 
         Slice::IceRpc::TypesVisitor typesVisitor(_out);
-        p->visit(&typesVisitor);
+        unit->visit(&typesVisitor);
 
         Slice::IceRpc::SkeletonVisitor skeletonVisitor(_out);
-        p->visit(&skeletonVisitor);
+        unit->visit(&skeletonVisitor);
     }
 }
 

--- a/cpp/src/slice2cs/Gen.h
+++ b/cpp/src/slice2cs/Gen.h
@@ -21,7 +21,7 @@ namespace Slice
         Gen(const Gen&) = delete;
         ~Gen();
 
-        void generate(const UnitPtr&);
+        void generate(const UnitPtr& unit);
 
     private:
         const GenMode _genMode;

--- a/cpp/src/slice2cs/IceCsUtil.cpp
+++ b/cpp/src/slice2cs/IceCsUtil.cpp
@@ -155,7 +155,7 @@ Slice::Csharp::resultType(const OperationPtr& op, const string& ns, bool dispatc
         }
         else
         {
-            t = typeToString(outParams.front()->type(), ns, outParams.front()->optional());
+            t = typeToString(outParams.front()->type(), ns, outParams.front()->isOptional());
         }
     }
 
@@ -219,7 +219,7 @@ Slice::Csharp::isValueType(const TypePtr& type)
 bool
 Slice::Csharp::isMappedToNonNullableReference(const DataMemberPtr& p)
 {
-    if (p->optional())
+    if (p->isOptional())
     {
         return false;
     }
@@ -244,7 +244,7 @@ Slice::Csharp::isMappedToNonNullableReference(const DataMemberPtr& p)
 bool
 Slice::Csharp::isMappedToRequiredField(const DataMemberPtr& p)
 {
-    if (p->optional())
+    if (p->isOptional())
     {
         return false;
     }
@@ -1778,7 +1778,7 @@ Slice::Csharp::writeIceOpDocComment(
     writeSeeAlso(out, comment->seeAlso());
 }
 
-std::pair<bool, string>
+pair<bool, string>
 Slice::Csharp::iceLinkFormatter(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target)
 {
     ostringstream result;

--- a/cpp/src/slice2cs/IceRpcCsUtil.cpp
+++ b/cpp/src/slice2cs/IceRpcCsUtil.cpp
@@ -241,7 +241,7 @@ Slice::Csharp::csType(const TypePtr& type, const string& ns, TypeContext context
 bool
 Slice::Csharp::csRequired(const DataMemberPtr& field)
 {
-    if (field->optional())
+    if (field->isOptional())
     {
         return false;
     }
@@ -750,7 +750,7 @@ Slice::Csharp::writeIceRpcHelperDocComment(
         << " <c>" << p->scoped() << "</c>.</remarks>";
 }
 
-std::pair<bool, string>
+pair<bool, string>
 Slice::Csharp::icerpcLinkFormatter(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target)
 {
     ostringstream result;

--- a/cpp/src/slice2cs/IceRpcCsUtil.h
+++ b/cpp/src/slice2cs/IceRpcCsUtil.h
@@ -69,7 +69,7 @@ namespace Slice::Csharp
         const std::string& encoderName);
 
     /// Decodes a non-optional field.
-    void decodeField(::IceInternal::Output& out, const TypePtr& type, const std::string& ns);
+    void decodeField(IceInternal::Output& out, const TypePtr& type, const std::string& ns);
 
     /// Decodes an optional field.
     void decodeOptionalField(

--- a/cpp/src/slice2cs/IceRpcCsUtil.h
+++ b/cpp/src/slice2cs/IceRpcCsUtil.h
@@ -51,7 +51,7 @@ namespace Slice::Csharp
 
     /// Encodes a non-optional field.
     void encodeField(
-        ::IceInternal::Output& out,
+        IceInternal::Output& out,
         const std::string& fieldName,
         const TypePtr& type,
         const std::string& ns,
@@ -60,7 +60,7 @@ namespace Slice::Csharp
 
     /// Encodes an optional field.
     void encodeOptionalField(
-        ::IceInternal::Output& out,
+        IceInternal::Output& out,
         int tag,
         const std::string& fieldName,
         const TypePtr& type,
@@ -73,7 +73,7 @@ namespace Slice::Csharp
 
     /// Decodes an optional field.
     void decodeOptionalField(
-        ::IceInternal::Output& out,
+        IceInternal::Output& out,
         int tag,
         const TypePtr& type,
         const std::string& ns,

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -76,7 +76,7 @@ namespace
 
                 if (returnParams.size() == 1)
                 {
-                    out << csType(returnParams.front()->type(), ns, returnContext, returnParams.front()->optional());
+                    out << csType(returnParams.front()->type(), ns, returnContext, returnParams.front()->isOptional());
                 }
                 else
                 {
@@ -84,7 +84,7 @@ namespace
                     for (const auto& param : returnParams)
                     {
                         out
-                            << (csType(param->type(), ns, returnContext, param->optional()) + " " +
+                            << (csType(param->type(), ns, returnContext, param->isOptional()) + " " +
                                 toPascalCase(param->mappedName()));
                     }
                     out << epar;
@@ -107,7 +107,7 @@ namespace
             out << '<';
             if (inParameters.size() == 1)
             {
-                out << csIncomingParamType(inParameters.front()->type(), ns, inParameters.front()->optional());
+                out << csIncomingParamType(inParameters.front()->type(), ns, inParameters.front()->isOptional());
             }
             else
             {
@@ -115,7 +115,7 @@ namespace
                 for (const auto& param : inParameters)
                 {
                     out
-                        << (csIncomingParamType(param->type(), ns, param->optional()) + " " +
+                        << (csIncomingParamType(param->type(), ns, param->isOptional()) + " " +
                             toPascalCase(param->mappedName()));
                 }
                 out << epar;
@@ -131,7 +131,7 @@ namespace
     /// @param dispatch If true, writes the signature for the dispatch method (with incoming parameter types and a
     /// ValueTask return type); if false, writes the signature for the proxy method.
     void
-    writeMethodSignature(IceInternal::Output& out, const OperationPtr& operation, const std::string& ns, bool dispatch)
+    writeMethodSignature(IceInternal::Output& out, const OperationPtr& operation, const string& ns, bool dispatch)
     {
         TypeContext paramContext = dispatch ? TypeContext::IncomingParam : TypeContext::OutgoingParam;
 
@@ -157,7 +157,7 @@ namespace
         out.inc();
         for (const auto& param : operation->inParameters())
         {
-            out << nl << csType(param->type(), ns, paramContext, param->optional()) << ' ' << param->mappedName()
+            out << nl << csType(param->type(), ns, paramContext, param->isOptional()) << ' ' << param->mappedName()
                 << ',';
         }
 
@@ -403,7 +403,7 @@ Slice::IceRpc::TypesVisitor::visitDataMember(const DataMemberPtr& p)
     {
         _out << "required ";
     }
-    _out << csFieldType(p->type(), ns, p->optional()) << ' ' << p->mappedName();
+    _out << csFieldType(p->type(), ns, p->isOptional()) << ' ' << p->mappedName();
 
     if (cont->hasMetadata("cs:readonly"))
     {
@@ -901,7 +901,7 @@ Slice::IceRpc::TypesVisitor::writePrimaryConstructor(
     for (const auto& field : allBaseFields)
     {
         string paramName = field->customMappedName().value_or(toCamelCase(field->name()));
-        ctorParams.push_back(csFieldType(field->type(), ns, field->optional()) + " " + paramName);
+        ctorParams.push_back(csFieldType(field->type(), ns, field->isOptional()) + " " + paramName);
         if (csRequired(field))
         {
             hasRequiredField = true;
@@ -912,7 +912,7 @@ Slice::IceRpc::TypesVisitor::writePrimaryConstructor(
     for (const auto& field : fields)
     {
         string paramName = field->customMappedName().value_or(toCamelCase(field->name()));
-        ctorParams.push_back(csFieldType(field->type(), ns, field->optional()) + " " + paramName);
+        ctorParams.push_back(csFieldType(field->type(), ns, field->isOptional()) + " " + paramName);
         if (csRequired(field))
         {
             hasRequiredField = true;
@@ -964,7 +964,7 @@ Slice::IceRpc::TypesVisitor::writeEncodeDecode(
     // Encode non-optional fields
     for (const auto& field : fields)
     {
-        if (!field->optional())
+        if (!field->isOptional())
         {
             _out << nl;
             encodeField(_out, "this." + field->mappedName(), field->type(), ns, TypeContext::Field, "encoder");
@@ -1003,7 +1003,7 @@ Slice::IceRpc::TypesVisitor::writeEncodeDecode(
     // Decode non-optional fields
     for (const auto& field : fields)
     {
-        if (!field->optional())
+        if (!field->isOptional())
         {
             _out << nl << "this." + field->mappedName() << " = ";
             decodeField(_out, field->type(), ns);
@@ -1058,7 +1058,7 @@ Slice::IceRpc::TypesVisitor::writeProxyRequestClass(const InterfaceDefPtr& inter
         _out.inc();
         for (const auto& param : operation->inParameters())
         {
-            _out << nl << csOutgoingParamType(param->type(), ns, param->optional()) << ' ' << param->mappedName()
+            _out << nl << csOutgoingParamType(param->type(), ns, param->isOptional()) << ' ' << param->mappedName()
                  << ',';
         }
         _out << nl << "IceEncodeOptions? " << encodeOptionsParam << " = null)";
@@ -1078,7 +1078,7 @@ Slice::IceRpc::TypesVisitor::writeProxyRequestClass(const InterfaceDefPtr& inter
 
             for (const auto& param : operation->sortedInParameters())
             {
-                if (param->optional())
+                if (param->isOptional())
                 {
                     encodeOptionalField(
                         _out,
@@ -1170,7 +1170,7 @@ Slice::IceRpc::TypesVisitor::writeProxyResponseClass(const InterfaceDefPtr& inte
             if (returnParams.size() == 1)
             {
                 // Simplified decoding function for a single return value.
-                if (returnParams.front()->optional())
+                if (returnParams.front()->isOptional())
                 {
                     decodeOptionalField(
                         _out,
@@ -1191,9 +1191,9 @@ Slice::IceRpc::TypesVisitor::writeProxyResponseClass(const InterfaceDefPtr& inte
                 // Decode all return params
                 for (const auto& param : returnParams)
                 {
-                    _out << nl << csType(param->type(), ns, TypeContext::IncomingParam, param->optional()) << " sliceP_"
+                    _out << nl << csType(param->type(), ns, TypeContext::IncomingParam, param->isOptional()) << " sliceP_"
                          << removeEscapePrefix(param->mappedName()) << " = ";
-                    if (param->optional())
+                    if (param->isOptional())
                     {
                         decodeOptionalField(_out, param->tag(), param->type(), ns, TypeContext::IncomingParam);
                     }
@@ -1443,7 +1443,7 @@ Slice::IceRpc::SkeletonVisitor::writeRequestClass(const InterfaceDefPtr& interfa
             if (inParameters.size() == 1)
             {
                 // Simplified decoding function for a single parameter.
-                if (inParameters.front()->optional())
+                if (inParameters.front()->isOptional())
                 {
                     decodeOptionalField(
                         _out,
@@ -1464,9 +1464,9 @@ Slice::IceRpc::SkeletonVisitor::writeRequestClass(const InterfaceDefPtr& interfa
                 // Decode all params (2 or more).
                 for (const auto& param : inParameters)
                 {
-                    _out << nl << csType(param->type(), ns, TypeContext::IncomingParam, param->optional()) << " sliceP_"
+                    _out << nl << csType(param->type(), ns, TypeContext::IncomingParam, param->isOptional()) << " sliceP_"
                          << removeEscapePrefix(param->mappedName()) << " = ";
-                    if (param->optional())
+                    if (param->isOptional())
                     {
                         decodeOptionalField(_out, param->tag(), param->type(), ns, TypeContext::IncomingParam);
                     }
@@ -1543,7 +1543,7 @@ Slice::IceRpc::SkeletonVisitor::writeResponseClass(const InterfaceDefPtr& interf
         }
         for (const auto& param : operation->outParameters())
         {
-            _out << nl << csOutgoingParamType(param->type(), ns, param->optional()) << ' ' << param->mappedName()
+            _out << nl << csOutgoingParamType(param->type(), ns, param->isOptional()) << ' ' << param->mappedName()
                  << ',';
         }
         _out << nl << "IceEncodeOptions? " << encodeOptionsParam << " = null)";
@@ -1559,7 +1559,7 @@ Slice::IceRpc::SkeletonVisitor::writeResponseClass(const InterfaceDefPtr& interf
 
             for (const auto& param : operation->sortedReturnAndOutParameters(returnParamName))
             {
-                if (param->optional())
+                if (param->isOptional())
                 {
                     encodeOptionalField(
                         _out,

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -130,8 +130,7 @@ namespace
     /// @param ns The current C# namespace.
     /// @param dispatch If true, writes the signature for the dispatch method (with incoming parameter types and a
     /// ValueTask return type); if false, writes the signature for the proxy method.
-    void
-    writeMethodSignature(IceInternal::Output& out, const OperationPtr& operation, const string& ns, bool dispatch)
+    void writeMethodSignature(IceInternal::Output& out, const OperationPtr& operation, const string& ns, bool dispatch)
     {
         TypeContext paramContext = dispatch ? TypeContext::IncomingParam : TypeContext::OutgoingParam;
 
@@ -1191,8 +1190,8 @@ Slice::IceRpc::TypesVisitor::writeProxyResponseClass(const InterfaceDefPtr& inte
                 // Decode all return params
                 for (const auto& param : returnParams)
                 {
-                    _out << nl << csType(param->type(), ns, TypeContext::IncomingParam, param->isOptional()) << " sliceP_"
-                         << removeEscapePrefix(param->mappedName()) << " = ";
+                    _out << nl << csType(param->type(), ns, TypeContext::IncomingParam, param->isOptional())
+                         << " sliceP_" << removeEscapePrefix(param->mappedName()) << " = ";
                     if (param->isOptional())
                     {
                         decodeOptionalField(_out, param->tag(), param->type(), ns, TypeContext::IncomingParam);
@@ -1464,8 +1463,8 @@ Slice::IceRpc::SkeletonVisitor::writeRequestClass(const InterfaceDefPtr& interfa
                 // Decode all params (2 or more).
                 for (const auto& param : inParameters)
                 {
-                    _out << nl << csType(param->type(), ns, TypeContext::IncomingParam, param->isOptional()) << " sliceP_"
-                         << removeEscapePrefix(param->mappedName()) << " = ";
+                    _out << nl << csType(param->type(), ns, TypeContext::IncomingParam, param->isOptional())
+                         << " sliceP_" << removeEscapePrefix(param->mappedName()) << " = ";
                     if (param->isOptional())
                     {
                         decodeOptionalField(_out, param->tag(), param->type(), ns, TypeContext::IncomingParam);

--- a/cpp/src/slice2cs/IceRpcVisitors.h
+++ b/cpp/src/slice2cs/IceRpcVisitors.h
@@ -56,7 +56,7 @@ namespace Slice::IceRpc
     class SkeletonVisitor final : public CsVisitor
     {
     public:
-        SkeletonVisitor(IceInternal::Output&);
+        SkeletonVisitor(IceInternal::Output& output);
 
         bool visitModuleStart(const ModulePtr&) final;
 

--- a/cpp/src/slice2cs/IceVisitors.cpp
+++ b/cpp/src/slice2cs/IceVisitors.cpp
@@ -40,7 +40,7 @@ namespace
             {
                 param = "out ";
             }
-            param += typeToString(q->type(), ns, q->optional()) + " " + q->mappedName();
+            param += typeToString(q->type(), ns, q->isOptional()) + " " + q->mappedName();
             params.push_back(param);
         }
         return params;
@@ -52,7 +52,7 @@ namespace
         for (const auto& q : op->inParameters())
         {
             string param = (internal ? ("iceP_" + removeEscapePrefix(q->mappedName())) : q->mappedName());
-            params.push_back(typeToString(q->type(), ns, q->optional()) + " " + param);
+            params.push_back(typeToString(q->type(), ns, q->isOptional()) + " " + param);
         }
         return params;
     }
@@ -76,7 +76,7 @@ namespace
             {
                 s = "out ";
             }
-            s += typeToString(q->type(), ns, q->optional()) + ' ' + q->mappedName();
+            s += typeToString(q->type(), ns, q->isOptional()) + ' ' + q->mappedName();
             params.push_back(s);
         }
 
@@ -157,7 +157,7 @@ namespace
                 param = paramPrefix + param;
             }
 
-            if (pli->optional())
+            if (pli->isOptional())
             {
                 optionals.push_back(pli);
             }
@@ -381,7 +381,7 @@ Slice::Ice::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
         for (const auto& q : allDataMembers)
         {
             string memberName = q->mappedName();
-            string memberType = typeToString(q->type(), ns, q->optional());
+            string memberType = typeToString(q->type(), ns, q->isOptional());
             parameters.push_back(memberType + " " + memberName);
 
             // The secondary constructor initializes the fields that would be marked "required" if we generated the
@@ -640,7 +640,7 @@ Slice::Ice::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
         for (const auto& q : allDataMembers)
         {
             string memberName = q->mappedName();
-            string memberType = typeToString(q->type(), ns, q->optional());
+            string memberType = typeToString(q->type(), ns, q->isOptional());
             parameters.push_back(memberType + " " + memberName);
 
             // The secondary constructor initializes the fields that would be marked "required" if we generated the
@@ -740,7 +740,7 @@ Slice::Ice::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
     _out << nl << "ostr_.startSlice(\"" << scoped << "\", -1, " << (!base ? "true" : "false") << ");";
     for (const auto& dataMember : dataMembers)
     {
-        if (!dataMember->optional())
+        if (!dataMember->isOptional())
         {
             writeMarshalDataMember(dataMember, dataMember->mappedName(), ns);
         }
@@ -766,7 +766,7 @@ Slice::Ice::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
 
     for (const auto& dataMember : dataMembers)
     {
-        if (!dataMember->optional())
+        if (!dataMember->isOptional())
         {
             writeUnmarshalDataMember(dataMember, dataMember->mappedName(), ns);
         }
@@ -1027,7 +1027,7 @@ Slice::Ice::TypesVisitor::visitDataMember(const DataMemberPtr& p)
 
     _out << sp;
 
-    string type = typeToString(p->type(), ns, p->optional());
+    string type = typeToString(p->type(), ns, p->isOptional());
     bool addSemicolon = true;
 
     writeIceDocComment(_out, p);
@@ -1069,7 +1069,7 @@ Slice::Ice::TypesVisitor::visitDataMember(const DataMemberPtr& p)
             addSemicolon = true;
         }
     }
-    else if (!p->optional())
+    else if (!p->isOptional())
     {
         BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(p->type());
         if (builtin && builtin->kind() == Builtin::KindString)
@@ -1384,7 +1384,7 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
             else
             {
                 TypePtr t = outParams.front()->type();
-                _out << nl << typeToString(t, ns, (outParams.front()->optional())) << " iceP_"
+                _out << nl << typeToString(t, ns, (outParams.front()->isOptional())) << " iceP_"
                      << removeEscapePrefix(outParams.front()->mappedName()) << (t->isClassType() ? " = null;" : ";");
             }
 
@@ -1640,7 +1640,7 @@ Slice::Ice::TypesVisitor::writeMarshalDataMember(
     const string& ns,
     bool forStruct)
 {
-    if (member->optional())
+    if (member->isOptional())
     {
         assert(!forStruct);
         writeOptionalMarshalUnmarshalCode(_out, member->type(), ns, name, member->tag(), true, "ostr_");
@@ -1677,7 +1677,7 @@ Slice::Ice::TypesVisitor::writeUnmarshalDataMember(
         param = "this." + name;
     }
 
-    if (member->optional())
+    if (member->isOptional())
     {
         assert(!forStruct);
         writeOptionalMarshalUnmarshalCode(_out, member->type(), ns, param, member->tag(), false, "istr_");
@@ -1707,7 +1707,7 @@ Slice::Ice::TypesVisitor::writeMarshaling(const ClassDefPtr& p)
     _out << nl << "ostr_.startSlice(ice_staticId(), " << p->compactId() << (!base ? ", true" : ", false") << ");";
     for (const auto& member : members)
     {
-        if (!member->optional())
+        if (!member->isOptional())
         {
             writeMarshalDataMember(member, member->mappedName(), ns);
         }
@@ -1730,7 +1730,7 @@ Slice::Ice::TypesVisitor::writeMarshaling(const ClassDefPtr& p)
     _out << nl << "istr_.startSlice();";
     for (const auto& member : members)
     {
-        if (!member->optional())
+        if (!member->isOptional())
         {
             writeUnmarshalDataMember(member, member->mappedName(), ns);
         }
@@ -1830,7 +1830,7 @@ Slice::Ice::ResultVisitor::visitOperation(const OperationPtr& p)
 
         for (const auto& q : outParams)
         {
-            _out << (typeToString(q->type(), ns, q->optional()) + " " + q->mappedName());
+            _out << (typeToString(q->type(), ns, q->isOptional()) + " " + q->mappedName());
         }
         _out << epar;
         _out << ";";
@@ -2026,7 +2026,7 @@ Slice::Ice::SkeletonVisitor::visitOperation(const OperationPtr& op)
         for (const auto& pli : inParams)
         {
             string param = "iceP_" + removeEscapePrefix(pli->mappedName());
-            string typeS = typeToString(pli->type(), ns, pli->optional());
+            string typeS = typeToString(pli->type(), ns, pli->isOptional());
 
             _out << nl << typeS << ' ' << param << (pli->type()->isClassType() ? " = null;" : ";");
         }
@@ -2108,7 +2108,7 @@ Slice::Ice::SkeletonVisitor::visitOperation(const OperationPtr& op)
     {
         for (const auto& pli : outParams)
         {
-            string typeS = typeToString(pli->type(), ns, pli->optional());
+            string typeS = typeToString(pli->type(), ns, pli->isOptional());
             _out << nl << typeS << " iceP_" << removeEscapePrefix(pli->mappedName()) << ";";
         }
         _out << nl;

--- a/cpp/src/slice2cs/IceVisitors.h
+++ b/cpp/src/slice2cs/IceVisitors.h
@@ -13,7 +13,7 @@ namespace Slice::Ice
     class TypesVisitor final : public CsVisitor
     {
     public:
-        TypesVisitor(IceInternal::Output&);
+        TypesVisitor(IceInternal::Output& out);
 
         bool visitClassDefStart(const ClassDefPtr&) final;
         void visitClassDefEnd(const ClassDefPtr&) final;
@@ -33,12 +33,12 @@ namespace Slice::Ice
         void visitOperation(const OperationPtr&) final;
 
     private:
-        void writeMarshalDataMember(const DataMemberPtr&, const std::string&, const std::string&, bool = false);
-        void writeUnmarshalDataMember(const DataMemberPtr&, const std::string&, const std::string&, bool = false);
-        void writeMarshaling(const ClassDefPtr&);
+        void writeMarshalDataMember(const DataMemberPtr& member, const std::string& name, const std::string& ns, bool forStruct = false);
+        void writeUnmarshalDataMember(const DataMemberPtr& member, const std::string& name, const std::string& ns, bool forStruct = false);
+        void writeMarshaling(const ClassDefPtr& p);
 
         /// Writes "= null!" for non-nullable fields (Slice class and exception only).
-        void writeDataMemberInitializers(const DataMemberList&);
+        void writeDataMemberInitializers(const DataMemberList& dataMembers);
     };
 
     /// Generates Result record structs for any operation that returns multiple values or a marshaled result; does not
@@ -46,7 +46,7 @@ namespace Slice::Ice
     class ResultVisitor final : public CsVisitor
     {
     public:
-        ResultVisitor(IceInternal::Output&);
+        ResultVisitor(IceInternal::Output& out);
 
         bool visitModuleStart(const ModulePtr&) final;
 
@@ -57,7 +57,7 @@ namespace Slice::Ice
     class SkeletonVisitor final : public CsVisitor
     {
     public:
-        SkeletonVisitor(IceInternal::Output& output, bool async);
+        SkeletonVisitor(IceInternal::Output& out, bool async);
 
         bool visitModuleStart(const ModulePtr&) final;
 
@@ -66,17 +66,17 @@ namespace Slice::Ice
         void visitOperation(const OperationPtr&) final;
 
     private:
-        void writeDispatch(const InterfaceDefPtr&);
+        void writeDispatch(const InterfaceDefPtr& p);
 
         std::string getDispatchParams(
-            const OperationPtr&,
-            std::string&,
-            std::vector<std::string>&,
-            std::vector<std::string>&,
-            const std::string&);
+            const OperationPtr& op,
+            std::string& retS,
+            std::vector<std::string>& params,
+            std::vector<std::string>& args,
+            const std::string& ns);
 
         [[nodiscard]] std::string skeletonPrefix() const;
-        [[nodiscard]] std::string prependSkeletonPrefix(const std::string&) const;
+        [[nodiscard]] std::string prependSkeletonPrefix(const std::string& name) const;
         const bool _async;
     };
 }

--- a/cpp/src/slice2cs/IceVisitors.h
+++ b/cpp/src/slice2cs/IceVisitors.h
@@ -33,8 +33,16 @@ namespace Slice::Ice
         void visitOperation(const OperationPtr&) final;
 
     private:
-        void writeMarshalDataMember(const DataMemberPtr& member, const std::string& name, const std::string& ns, bool forStruct = false);
-        void writeUnmarshalDataMember(const DataMemberPtr& member, const std::string& name, const std::string& ns, bool forStruct = false);
+        void writeMarshalDataMember(
+            const DataMemberPtr& member,
+            const std::string& name,
+            const std::string& ns,
+            bool forStruct = false);
+        void writeUnmarshalDataMember(
+            const DataMemberPtr& member,
+            const std::string& name,
+            const std::string& ns,
+            bool forStruct = false);
         void writeMarshaling(const ClassDefPtr& p);
 
         /// Writes "= null!" for non-nullable fields (Slice class and exception only).

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -892,7 +892,7 @@ Slice::JavaVisitor::writeResultTypeMarshalUnmarshalCode(
 
     for (const auto& param : op->sortedReturnAndOutParameters(retval))
     {
-        const bool isOptional = param->optional();
+        const bool isOptional = param->isOptional();
         const string name = paramPrefix + param->mappedName();
         const string patchParams = isMarshaling ? getPatcher(param->type(), package, name) : "";
 
@@ -970,7 +970,7 @@ Slice::JavaVisitor::writeResultType(
             }
         }
         out << nl << "public "
-            << typeToString(outParam->type(), TypeModeIn, package, outParam->getMetadata(), true, outParam->optional())
+            << typeToString(outParam->type(), TypeModeIn, package, outParam->getMetadata(), true, outParam->isOptional())
             << ' ' << outParam->mappedName() << ';';
         out << sp;
     }
@@ -1058,7 +1058,7 @@ Slice::JavaVisitor::writeResultType(
                         package,
                         outParam->getMetadata(),
                         true,
-                        !generateMandatoryOnly && outParam->optional()) +
+                        !generateMandatoryOnly && outParam->isOptional()) +
                     " " + outParam->mappedName());
         }
         out << epar;
@@ -1079,7 +1079,7 @@ Slice::JavaVisitor::writeResultType(
         {
             const string name = outParam->mappedName();
             out << nl << "this." << name << " = ";
-            if (outParam->optional() && generateMandatoryOnly)
+            if (outParam->isOptional() && generateMandatoryOnly)
             {
                 out << ofFactory(outParam->type()) << "(" << name << ");";
             }
@@ -1181,10 +1181,10 @@ Slice::JavaVisitor::writeMarshaledResultType(
                     package,
                     outParam->getMetadata(),
                     true,
-                    outParam->optional()) +
+                    outParam->isOptional()) +
                 " " + outParam->mappedName());
 
-        hasOpt = hasOpt || outParam->optional();
+        hasOpt = hasOpt || outParam->isOptional();
     }
     out << currentParam << epar;
     out << sb;
@@ -1263,7 +1263,7 @@ Slice::JavaVisitor::writeMarshaledResultType(
         }
         for (const auto& outParam : outParams)
         {
-            if (outParam->optional())
+            if (outParam->isOptional())
             {
                 out << ofFactory(outParam->type()) + "(" + outParam->mappedName() + ")";
             }
@@ -1528,8 +1528,8 @@ Slice::JavaVisitor::writeMarshalProxyParams(
             out,
             package,
             param->type(),
-            param->optional(),
-            param->optional() && optionalMapping,
+            param->isOptional(),
+            param->isOptional() && optionalMapping,
             param->tag(),
             "iceP_" + param->mappedName(),
             true,
@@ -1580,7 +1580,7 @@ Slice::JavaVisitor::writeUnmarshalProxyResults(Output& out, const string& packag
         else
         {
             assert(outParams.size() == 1);
-            isOptional = outParams.front()->optional();
+            isOptional = outParams.front()->isOptional();
             type = outParams.front()->type();
             tag = outParams.front()->tag();
             metadata = outParams.front()->getMetadata();
@@ -1659,7 +1659,7 @@ Slice::JavaVisitor::writeMarshalServantResults(
         else
         {
             assert(params.size() == 1);
-            isOptional = params.front()->optional();
+            isOptional = params.front()->isOptional();
             type = params.front()->type();
             tag = params.front()->tag();
             metadata = params.front()->getMetadata();
@@ -1705,7 +1705,7 @@ Slice::JavaVisitor::writeThrowsClause(
 void
 Slice::JavaVisitor::writeMarshalDataMember(Output& out, const string& package, const DataMemberPtr& member, int& iter)
 {
-    const bool isOptional = member->optional();
+    const bool isOptional = member->isOptional();
     const bool forStruct = dynamic_pointer_cast<Struct>(member->container()) != nullptr;
     const string memberName = (forStruct ? "this." : "") + member->mappedName();
 
@@ -1742,7 +1742,7 @@ void
 Slice::JavaVisitor::writeUnmarshalDataMember(Output& out, const string& package, const DataMemberPtr& member, int& iter)
 {
     const TypePtr& type = member->type();
-    const bool isOptional = member->optional();
+    const bool isOptional = member->isOptional();
     const bool forStruct = (bool)dynamic_pointer_cast<Struct>(member->container());
     const string stream = forStruct ? "istr" : "istr_";
     assert(!isOptional || !forStruct);           // optional members aren't allowed in structs.
@@ -1879,7 +1879,7 @@ Slice::JavaVisitor::writeDataMemberInitializers(Output& out, const DataMemberLis
         TypePtr t = member->type();
         if (member->defaultValue())
         {
-            if (member->optional())
+            if (member->isOptional())
             {
                 string capName = member->mappedName();
                 capName[0] = static_cast<char>(toupper(static_cast<unsigned char>(capName[0])));
@@ -2332,20 +2332,20 @@ Slice::Gen::Gen(string base, string dir) : _base(std::move(base)), _dir(std::mov
 Slice::Gen::~Gen() = default;
 
 void
-Slice::Gen::generate(const UnitPtr& p)
+Slice::Gen::generate(const UnitPtr& unit)
 {
-    validateJavaMetadata(p);
+    validateJavaMetadata(unit);
 
     TypesVisitor typesVisitor(_dir);
-    p->visit(&typesVisitor);
+    unit->visit(&typesVisitor);
 
     // Generate the default skeletons.
     SkeletonVisitor skeletonVisitor(_dir, false);
-    p->visit(&skeletonVisitor);
+    unit->visit(&skeletonVisitor);
 
     // Generate the async skeletons.
     SkeletonVisitor asyncSkeletonVisitor(_dir, true);
-    p->visit(&asyncSkeletonVisitor);
+    unit->visit(&asyncSkeletonVisitor);
 }
 
 Slice::Gen::TypesVisitor::TypesVisitor(const string& dir) : JavaVisitor(dir) {}
@@ -2423,7 +2423,7 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
     DataMemberList requiredMembers;
     for (const auto& member : allDataMembers)
     {
-        if (!member->optional())
+        if (!member->isOptional())
         {
             requiredMembers.push_back(member);
         }
@@ -2484,7 +2484,7 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
                     bool hasBaseRequired = false;
                     for (const auto& baseDataMember : baseDataMembers)
                     {
-                        if (!baseDataMember->optional())
+                        if (!baseDataMember->isOptional())
                         {
                             hasBaseRequired = true;
                             break;
@@ -2496,7 +2496,7 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
                         vector<string> baseParamNames;
                         for (const auto& baseDataMember : baseDataMembers)
                         {
-                            if (!baseDataMember->optional())
+                            if (!baseDataMember->isOptional())
                             {
                                 baseParamNames.push_back(baseDataMember->mappedName());
                             }
@@ -2507,7 +2507,7 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
 
                 for (const auto& member : members)
                 {
-                    if (!member->optional())
+                    if (!member->isOptional())
                     {
                         string paramName = member->mappedName();
                         out << nl << "this." << paramName << " = " << paramName << ';';
@@ -2549,7 +2549,7 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
             for (const auto& member : members)
             {
                 string paramName = member->mappedName();
-                if (member->optional())
+                if (member->isOptional())
                 {
                     string capName = paramName;
                     capName[0] = static_cast<char>(toupper(static_cast<unsigned char>(capName[0])));
@@ -2605,7 +2605,7 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
     out << nl << "ostr_.startSlice(ice_staticId(), " << p->compactId() << (!base ? ", true" : ", false") << ");";
     for (const auto& member : members)
     {
-        if (!member->optional())
+        if (!member->isOptional())
         {
             writeMarshalDataMember(out, package, member, iter);
         }
@@ -2634,7 +2634,7 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
     out << nl << "istr_.startSlice();";
     for (const auto& member : members)
     {
-        if (!member->optional())
+        if (!member->isOptional())
         {
             writeUnmarshalDataMember(out, package, member, iter);
         }
@@ -2714,7 +2714,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
     DataMemberList optionalMembers = p->orderedOptionalDataMembers();
     for (const auto& member : allDataMembers)
     {
-        if (!member->optional())
+        if (!member->isOptional())
         {
             requiredMembers.push_back(member);
         }
@@ -2741,7 +2741,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
                 bool hasBaseRequired = false;
                 for (const auto& member : baseDataMembers)
                 {
-                    if (!member->optional())
+                    if (!member->isOptional())
                     {
                         hasBaseRequired = true;
                         break;
@@ -2776,7 +2776,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
                         vector<string> baseParamNames;
                         for (const auto& member : baseDataMembers)
                         {
-                            if (!member->optional())
+                            if (!member->isOptional())
                             {
                                 baseParamNames.push_back(member->mappedName());
                             }
@@ -2787,7 +2787,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
 
                 for (const auto& member : members)
                 {
-                    if (!member->optional())
+                    if (!member->isOptional())
                     {
                         string paramName = member->mappedName();
                         out << nl << "this." << paramName << " = " << paramName << ';';
@@ -2833,7 +2833,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
             for (const auto& member : members)
             {
                 string paramName = member->mappedName();
-                if (member->optional())
+                if (member->isOptional())
                 {
                     string capName = paramName;
                     capName[0] = static_cast<char>(toupper(static_cast<unsigned char>(capName[0])));
@@ -2868,7 +2868,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
     iter = 0;
     for (const auto& member : members)
     {
-        if (!member->optional())
+        if (!member->isOptional())
         {
             writeMarshalDataMember(out, package, member, iter);
         }
@@ -2896,7 +2896,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
     iter = 0;
     for (const auto& member : members)
     {
-        if (!member->optional())
+        if (!member->isOptional())
         {
             writeUnmarshalDataMember(out, package, member, iter);
         }
@@ -3282,7 +3282,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
 
     const string name = p->mappedName();
     const bool getSet = p->hasMetadata("java:getset") || contained->hasMetadata("java:getset");
-    const bool isOptional = p->optional();
+    const bool isOptional = p->isOptional();
     const TypePtr type = p->type();
     const BuiltinPtr b = dynamic_pointer_cast<Builtin>(type);
     const bool classType = type->isClassType();
@@ -4518,14 +4518,14 @@ Slice::Gen::SkeletonVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
                 const TypePtr paramType = param->type();
                 if (paramType->isClassType())
                 {
-                    assert(!param->optional()); // Optional classes are disallowed by the parser.
+                    assert(!param->isOptional()); // Optional classes are disallowed by the parser.
                     allocatePatcher(out, paramType, package, "icePP_" + param->mappedName());
                     values.push_back(param);
                 }
                 else
                 {
                     const string typeS =
-                        typeToString(paramType, TypeModeIn, package, param->getMetadata(), true, param->optional());
+                        typeToString(paramType, TypeModeIn, package, param->getMetadata(), true, param->isOptional());
                     out << nl << typeS << " iceP_" << param->mappedName() << ';';
                 }
             }
@@ -4542,8 +4542,8 @@ Slice::Gen::SkeletonVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
                     out,
                     package,
                     param->type(),
-                    param->optional(),
-                    param->optional(),
+                    param->isOptional(),
+                    param->isOptional(),
                     param->tag(),
                     paramName,
                     false,
@@ -4561,7 +4561,7 @@ Slice::Gen::SkeletonVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
             for (const auto& value : values)
             {
                 out << nl;
-                out << typeToString(value->type(), TypeModeIn, package, value->getMetadata(), true, value->optional());
+                out << typeToString(value->type(), TypeModeIn, package, value->getMetadata(), true, value->isOptional());
                 out << " iceP_" << value->mappedName() << " = icePP_" << value->mappedName() << ".value;";
             }
         }

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -969,9 +969,11 @@ Slice::JavaVisitor::writeResultType(
                 out << nl << " */";
             }
         }
-        out << nl << "public "
-            << typeToString(outParam->type(), TypeModeIn, package, outParam->getMetadata(), true, outParam->isOptional())
-            << ' ' << outParam->mappedName() << ';';
+
+        string typeString =
+            typeToString(outParam->type(), TypeModeIn, package, outParam->getMetadata(), true, outParam->isOptional());
+
+        out << nl << "public " << typeString << ' ' << outParam->mappedName() << ';';
         out << sp;
     }
 
@@ -4560,9 +4562,11 @@ Slice::Gen::SkeletonVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 
             for (const auto& value : values)
             {
+                string typeString =
+                    typeToString(value->type(), TypeModeIn, package, value->getMetadata(), true, value->isOptional());
+
                 out << nl;
-                out << typeToString(value->type(), TypeModeIn, package, value->getMetadata(), true, value->isOptional());
-                out << " iceP_" << value->mappedName() << " = icePP_" << value->mappedName() << ".value;";
+                out << typeString << " iceP_" << value->mappedName() << " = icePP_" << value->mappedName() << ".value;";
             }
         }
         else

--- a/cpp/src/slice2java/Gen.h
+++ b/cpp/src/slice2java/Gen.h
@@ -143,7 +143,10 @@ namespace Slice
             const std::string& package);
 
         /// Generate assignment statements for those data members that have default values.
-        static void writeDataMemberInitializers(IceInternal::Output& out, const DataMemberList& members, const std::string& package);
+        static void writeDataMemberInitializers(
+            IceInternal::Output& out,
+            const DataMemberList& members,
+            const std::string& package);
 
         //
         // Handle doc comments.
@@ -165,7 +168,11 @@ namespace Slice
             const std::optional<DocComment>& dc,
             bool async,
             const std::string& contextParam);
-        static void writeServantOpDocComment(IceInternal::Output& out, const OperationPtr& p, const std::string& package, bool async);
+        static void writeServantOpDocComment(
+            IceInternal::Output& out,
+            const OperationPtr& p,
+            const std::string& package,
+            bool async);
         static void writeSeeAlso(IceInternal::Output& out, const StringList& seeAlso);
         static void writeParamDocComments(IceInternal::Output& out, const DataMemberList& members);
 

--- a/cpp/src/slice2java/Gen.h
+++ b/cpp/src/slice2java/Gen.h
@@ -136,53 +136,53 @@ namespace Slice
 
         /// Write a constant or default value initializer.
         static void writeConstantValue(
-            IceInternal::Output&,
-            const TypePtr&,
-            const SyntaxTreeBasePtr&,
-            const std::string&,
-            const std::string&);
+            IceInternal::Output& out,
+            const TypePtr& type,
+            const SyntaxTreeBasePtr& valueType,
+            const std::string& value,
+            const std::string& package);
 
         /// Generate assignment statements for those data members that have default values.
-        static void writeDataMemberInitializers(IceInternal::Output&, const DataMemberList&, const std::string&);
+        static void writeDataMemberInitializers(IceInternal::Output& out, const DataMemberList& members, const std::string& package);
 
         //
         // Handle doc comments.
         //
         static void writeExceptionDocComment(IceInternal::Output& out, const OperationPtr& op, const DocComment& dc);
         static void writeRemarksDocComment(IceInternal::Output& out, const StringList& remarks);
-        static void writeHiddenDocComment(IceInternal::Output&);
-        static void writeDocCommentLines(IceInternal::Output&, const StringList&);
-        static void writeDocCommentLines(IceInternal::Output&, const std::string&);
+        static void writeHiddenDocComment(IceInternal::Output& out);
+        static void writeDocCommentLines(IceInternal::Output& out, const StringList& lines);
+        static void writeDocCommentLines(IceInternal::Output& out, const std::string& text);
         static void writeDocComment(
-            IceInternal::Output&,
-            const ContainedPtr&,
+            IceInternal::Output& out,
+            const ContainedPtr& p,
             const std::optional<std::string>& generatedType = std::nullopt);
-        static void writeDocComment(IceInternal::Output&, const std::string&);
+        static void writeDocComment(IceInternal::Output& out, const std::string& text);
         static void writeProxyOpDocComment(
-            IceInternal::Output&,
-            const OperationPtr&,
-            const std::string&,
-            const std::optional<DocComment>&,
-            bool,
-            const std::string&);
-        static void writeServantOpDocComment(IceInternal::Output&, const OperationPtr&, const std::string&, bool);
+            IceInternal::Output& out,
+            const OperationPtr& p,
+            const std::string& package,
+            const std::optional<DocComment>& dc,
+            bool async,
+            const std::string& contextParam);
+        static void writeServantOpDocComment(IceInternal::Output& out, const OperationPtr& p, const std::string& package, bool async);
         static void writeSeeAlso(IceInternal::Output& out, const StringList& seeAlso);
         static void writeParamDocComments(IceInternal::Output& out, const DataMemberList& members);
 
     protected:
-        JavaVisitor(const std::string&);
+        JavaVisitor(const std::string& dir);
     };
 
     class Gen final
     {
     public:
-        Gen(std::string, std::string);
+        Gen(std::string base, std::string dir);
         Gen(const Gen&) = delete;
         ~Gen();
 
         Gen& operator=(const Gen&) = delete;
 
-        void generate(const UnitPtr&);
+        void generate(const UnitPtr& unit);
 
     private:
         std::string _base;
@@ -191,7 +191,7 @@ namespace Slice
         class TypesVisitor final : public JavaVisitor
         {
         public:
-            TypesVisitor(const std::string&);
+            TypesVisitor(const std::string& dir);
 
             bool visitModuleStart(const ModulePtr&) final;
 

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -75,7 +75,7 @@ Slice::Java::getResultType(const OperationPtr& op, const string& package, bool o
             {
                 assert(outParams.size() == 1);
                 type = outParams.front()->type();
-                optional = outParams.front()->optional();
+                optional = outParams.front()->isOptional();
             }
         }
         if (type)
@@ -112,7 +112,7 @@ Slice::Java::getParamsProxy(const OperationPtr& op, const string& package, bool 
             package,
             param->getMetadata(),
             true,
-            optionalMapping && param->optional());
+            optionalMapping && param->isOptional());
         params.push_back(typeString + ' ' + (internal ? "iceP_" : "") + param->mappedName());
     }
     return params;
@@ -268,7 +268,7 @@ Slice::Java::getPackage(const ContainedPtr& contained)
 }
 
 string
-Slice::Java::getUnqualified(const std::string& type, const std::string& package)
+Slice::Java::getUnqualified(const string& type, const string& package)
 {
     if (type.find('.') != string::npos && type.find(package) == 0 && type.find('.', package.size() + 1) == string::npos)
     {
@@ -589,7 +589,7 @@ Slice::Java::getSequenceTypes(
     return false;
 }
 
-std::pair<bool, string>
+pair<bool, string>
 Slice::Java::javaLinkFormatter(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target)
 {
     string sourceScope = getPackage(source);
@@ -635,7 +635,7 @@ Slice::Java::javaLinkFormatter(const string& rawLink, const ContainedPtr& source
 }
 
 void
-Slice::Java::validateJavaMetadata(const UnitPtr& u)
+Slice::Java::validateJavaMetadata(const UnitPtr& unit)
 {
     map<string, MetadataInfo> knownMetadata;
 
@@ -798,7 +798,7 @@ Slice::Java::validateJavaMetadata(const UnitPtr& u)
     knownMetadata.emplace("java:UserException", std::move(userExceptionInfo));
 
     // Pass this information off to the parser's metadata validation logic.
-    Slice::validateMetadata(u, "java", std::move(knownMetadata));
+    Slice::validateMetadata(unit, "java", std::move(knownMetadata));
 }
 
 Slice::Java::JavaOutput::JavaOutput() : Output(false, false) {}

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -137,7 +137,7 @@ namespace Slice::Java
         /// @param cls The class name (including an optional leading package).
         /// @param prefix Specifies a directory prefix in which to generate the class.
         /// @param sliceFile The Slice file that the class is being generated from.
-        void openClass(const std::string& cls, const std::string& prefix, const std::string& sliceFile = std::string());
+        void openClass(const std::string& cls, const std::string& prefix, const std::string& sliceFile);
 
         void printHeader();
     };

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -124,26 +124,20 @@ namespace Slice::Java
     std::pair<bool, std::string>
     javaLinkFormatter(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target);
 
-    void validateJavaMetadata(const UnitPtr&);
+    void validateJavaMetadata(const UnitPtr& unit);
 
     class JavaOutput final : public ::IceInternal::Output
     {
     public:
         JavaOutput();
 
-        //
-        // Open a file to hold the source for a Java class. The first
-        // argument is the class name (including an optional leading
-        // package). Intermediate directories will be created as
-        // necessary to open the file in the package. The second
-        // argument specifies a directory prefix in which to locate
-        // the class.
-        //
-        // After successfully opening the file, the function invokes
-        // printHeader() and then emits a "package" statement if
-        // necessary.
-        //
-        void openClass(const std::string&, const std::string&, const std::string& = std::string());
+        /// Open a file to hold the source for a Java class. After successfully opening the file,
+        /// the function invokes `printHeader()` and then emits a "package" statement if necessary.
+        /// Intermediate directories will be created as necessary to open the file in the package.
+        /// @param cls The class name (including an optional leading package).
+        /// @param prefix Specifies a directory prefix in which to generate the class.
+        /// @param sliceFile The Slice file that the class is being generated from.
+        void openClass(const std::string& cls, const std::string& prefix, const std::string& sliceFile = std::string());
 
         void printHeader();
     };
@@ -158,7 +152,7 @@ namespace Slice::Java
 
         void close();
 
-        JavaGenerator(std::string);
+        JavaGenerator(std::string dir);
 
         /// Creates a new '.java' file (and any necessary intermediate directories) for generating 'qualifiedEntity's
         /// source code into. After calling this function, `_out` will be set to write into this new file.

--- a/cpp/src/slice2java/JavaUtil.h
+++ b/cpp/src/slice2java/JavaUtil.h
@@ -126,7 +126,7 @@ namespace Slice::Java
 
     void validateJavaMetadata(const UnitPtr& unit);
 
-    class JavaOutput final : public ::IceInternal::Output
+    class JavaOutput final : public IceInternal::Output
     {
     public:
         JavaOutput();
@@ -164,7 +164,7 @@ namespace Slice::Java
 
     private:
         std::string _dir;
-        ::IceInternal::Output* _out{nullptr};
+        IceInternal::Output* _out{nullptr};
     };
 }
 

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -263,7 +263,7 @@ Slice::IncludeAggregationVisitor::addImportedType(const ContainedPtr& definition
     }
 }
 
-std::optional<std::string>
+optional<string>
 Slice::IncludeAggregationVisitor::resolveDirectInclude(const DefinitionContextPtr& dc) const
 {
     auto it = _transitiveToDirectInclude.find(dc->resolvedFilename());
@@ -354,17 +354,17 @@ Slice::IncludeAggregationVisitor::visitEnum(const EnumPtr& p)
     addImportedType(p);
 }
 
-const std::map<std::string, std::map<std::string, std::set<std::string>>>&
+const map<string, map<string, set<string>>>&
 Slice::IncludeAggregationVisitor::nestedModulesByTopLevel() const
 {
     return _nestedModulesByTopLevel;
 }
 
-std::map<std::string, std::set<std::string>>
-Slice::IncludeAggregationVisitor::importedTypesByTopLevel(const std::string& topLevelFile) const
+map<string, set<string>>
+Slice::IncludeAggregationVisitor::importedTypesByTopLevel(const string& topLevelFile) const
 {
     auto it = _importedTypesByTopLevel.find(topLevelFile);
-    return it != _importedTypesByTopLevel.end() ? it->second : std::map<std::string, std::set<std::string>>{};
+    return it != _importedTypesByTopLevel.end() ? it->second : map<string, set<string>>{};
 }
 
 bool
@@ -382,7 +382,7 @@ Slice::JsVisitor::writeMarshalDataMembers(const DataMemberList& dataMembers, con
 {
     for (const auto& dataMember : dataMembers)
     {
-        if (!dataMember->optional())
+        if (!dataMember->isOptional())
         {
             writeMarshalUnmarshalCode(_out, dataMember->type(), "this." + dataMember->mappedName(), true, _jsModule);
         }
@@ -405,7 +405,7 @@ Slice::JsVisitor::writeUnmarshalDataMembers(const DataMemberList& dataMembers, c
 {
     for (const auto& dataMember : dataMembers)
     {
-        if (!dataMember->optional())
+        if (!dataMember->isOptional())
         {
             writeMarshalUnmarshalCode(_out, dataMember->type(), "this." + dataMember->mappedName(), false, _jsModule);
         }
@@ -433,7 +433,7 @@ Slice::JsVisitor::writeOneShotConstructorArguments(const DataMemberList& members
         {
             value = writeConstantValue(member->type(), member->defaultValueType(), *member->defaultValue());
         }
-        else if (member->optional())
+        else if (member->isOptional())
         {
             value = "undefined";
         }
@@ -648,7 +648,7 @@ Slice::Gen::Gen(const string& base, const string& dir, bool typeScript)
     }
 }
 
-Slice::Gen::Gen(const string& base, const string& /*dir*/, bool typeScript, ostream& out)
+Slice::Gen::Gen(const string& base, ostream& out, bool typeScript)
     : _javaScriptOutput(out, false, true),
       _typeScriptOutput(out, false, true),
       _useStdout(true),
@@ -678,11 +678,11 @@ Slice::Gen::~Gen()
 }
 
 void
-Slice::Gen::generate(const UnitPtr& p)
+Slice::Gen::generate(const UnitPtr& unit)
 {
-    validateJsMetadata(p);
+    validateJsMetadata(unit);
 
-    string module = getJavaScriptModule(p->findDefinitionContext(p->topLevelFile()));
+    string module = getJavaScriptModule(unit->findDefinitionContext(unit->topLevelFile()));
 
     if (_useStdout)
     {
@@ -700,21 +700,21 @@ Slice::Gen::generate(const UnitPtr& p)
 
     {
         IncludeAggregationVisitor moduleVisitor;
-        p->visit(&moduleVisitor);
+        unit->visit(&moduleVisitor);
 
         ImportVisitor importVisitor(_javaScriptOutput);
-        p->visit(&importVisitor);
-        set<string> importedModules = importVisitor.writeImports(p, moduleVisitor.nestedModulesByTopLevel());
+        unit->visit(&importVisitor);
+        set<string> importedModules = importVisitor.writeImports(unit, moduleVisitor.nestedModulesByTopLevel());
 
         ExportsVisitor exportsVisitor(_javaScriptOutput, importedModules);
-        p->visit(&exportsVisitor);
+        unit->visit(&exportsVisitor);
         set<string> exportedModules = exportsVisitor.exportedModules();
 
         set<string> seenModules = importedModules;
         seenModules.merge(exportedModules);
 
         TypesVisitor typesVisitor(_javaScriptOutput, module);
-        p->visit(&typesVisitor);
+        unit->visit(&typesVisitor);
     }
 
     if (_useStdout)
@@ -737,16 +737,16 @@ Slice::Gen::generate(const UnitPtr& p)
         printGeneratedHeader(_typeScriptOutput, _fileBase + ".ice");
 
         IncludeAggregationVisitor moduleVisitor;
-        p->visit(&moduleVisitor);
+        unit->visit(&moduleVisitor);
 
-        map<string, set<string>> importedTypesByInclude = moduleVisitor.importedTypesByTopLevel(p->topLevelFile());
+        map<string, set<string>> importedTypesByInclude = moduleVisitor.importedTypesByTopLevel(unit->topLevelFile());
 
         TypeScriptImportVisitor importVisitor(_typeScriptOutput, importedTypesByInclude);
-        p->visit(&importVisitor);
+        unit->visit(&importVisitor);
         map<string, string> importedTypes = importVisitor.writeImports();
 
         TypeScriptVisitor typeScriptVisitor(_typeScriptOutput, importedTypes, importedTypesByInclude);
-        p->visit(&typeScriptVisitor);
+        unit->visit(&typeScriptVisitor);
 
         if (_useStdout)
         {
@@ -843,11 +843,11 @@ Slice::Gen::ImportVisitor::visitEnum(const EnumPtr&)
 
 set<string>
 Slice::Gen::ImportVisitor::writeImports(
-    const UnitPtr& p,
-    const std::map<std::string, std::map<std::string, std::set<std::string>>>& nestedModulesByTopLevel)
+    const UnitPtr& unit,
+    const map<string, map<string, set<string>>>& nestedModulesByTopLevel)
 {
     // The JavaScript module we are building as specified by "js:module:" metadata.
-    string jsModule = getJavaScriptModule(p->findDefinitionContext(p->topLevelFile()));
+    string jsModule = getJavaScriptModule(unit->findDefinitionContext(unit->topLevelFile()));
 
     // The set of top-level modules that we need to import in the generated JavaScript code.
     set<string> importedModules = {"Ice"};
@@ -931,18 +931,18 @@ Slice::Gen::ImportVisitor::writeImports(
     // Group the top-level modules from each included file by their JavaScript import path.
     // Imports from files in the same js:module (or without a js:module) are tracked as "local" for aggregation.
     set<string> localImports;
-    for (const auto& included : p->includeFiles())
+    for (const auto& included : unit->includeFiles())
     {
-        set<string> sliceTopLevelModules = p->getTopLevelModules(included);
+        set<string> sliceTopLevelModules = unit->getTopLevelModules(included);
 
         // The JavaScript module corresponding to the 'js:module' metadata in the included file.
-        string jsImportedModule = getJavaScriptModule(p->findDefinitionContext(included));
+        string jsImportedModule = getJavaScriptModule(unit->findDefinitionContext(included));
 
         if (jsModule == jsImportedModule || jsImportedModule.empty())
         {
             // For Slice modules mapped to the same JavaScript module, or Slice files that doesn't use "js:module".
             // We import them using their Slice include relative path.
-            string f = toRelativePath(removeExtension(included) + ".js", p->topLevelFile());
+            string f = toRelativePath(removeExtension(included) + ".js", unit->topLevelFile());
             imports[f] = sliceTopLevelModules;
             localImports.insert(f);
 
@@ -1074,7 +1074,7 @@ Slice::Gen::ImportVisitor::writeImports(
     // This must be done in a top-down order.
     // Foo.Bar = { ...Foo_Bar_1.Bar, ...Foo_Bar_2.Bar, ... }
     // Foo.Bar.Baz = { ...Foo_Bar_1.Bar.Baz, ...Foo_Bar_2.Bar.Baz, ... }
-    auto it = nestedModulesByTopLevel.find(p->topLevelFile());
+    auto it = nestedModulesByTopLevel.find(unit->topLevelFile());
     if (it != nestedModulesByTopLevel.end())
     {
         auto& nestedModulesByIncludeKey = it->second;
@@ -1093,11 +1093,11 @@ Slice::Gen::ImportVisitor::writeImports(
         }
 
         // Sort by nesting depth (number of dots) to aggregate parent modules before their children.
-        std::vector<std::string> sortedNestedModules(uniqueNestedModules.begin(), uniqueNestedModules.end());
+        vector<string> sortedNestedModules(uniqueNestedModules.begin(), uniqueNestedModules.end());
         std::sort(
             sortedNestedModules.begin(),
             sortedNestedModules.end(),
-            [](const std::string& a, const std::string& b)
+            [](const string& a, const string& b)
             {
                 auto dotsA = std::count(a.begin(), a.end(), '.');
                 auto dotsB = std::count(b.begin(), b.end(), '.');
@@ -1128,7 +1128,7 @@ Slice::Gen::ImportVisitor::writeImports(
     return importedModules;
 }
 
-Slice::Gen::ExportsVisitor::ExportsVisitor(::IceInternal::Output& out, std::set<std::string> importedModules)
+Slice::Gen::ExportsVisitor::ExportsVisitor(IceInternal::Output& out, set<string> importedModules)
     : JsVisitor(out),
       _importedModules(std::move(importedModules))
 {
@@ -1493,7 +1493,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                     {
                         _out << ", true";
                     }
-                    if ((*pli)->optional())
+                    if ((*pli)->isOptional())
                     {
                         if (!isObj)
                         {
@@ -1526,7 +1526,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                     {
                         _out << ", true";
                     }
-                    if ((*pli)->optional())
+                    if ((*pli)->isOptional())
                     {
                         if (!isObj)
                         {
@@ -1933,7 +1933,7 @@ Slice::Gen::TypesVisitor::encodeTypeForOperation(const TypePtr& type)
 
 Slice::Gen::TypeScriptImportVisitor::TypeScriptImportVisitor(
     IceInternal::Output& out,
-    std::map<std::string, std::set<std::string>> importedTypesByInclude)
+    map<string, set<string>> importedTypesByInclude)
     : JsVisitor(out),
       _importedTypesByInclude(std::move(importedTypesByInclude))
 {
@@ -2126,7 +2126,7 @@ Slice::Gen::TypeScriptImportVisitor::visitDictionary(const DictionaryPtr& dict)
     }
 }
 
-std::map<std::string, std::string>
+map<string, string>
 Slice::Gen::TypeScriptImportVisitor::writeImports()
 {
     _out << sp;
@@ -2139,9 +2139,9 @@ Slice::Gen::TypeScriptImportVisitor::writeImports()
 }
 
 string
-Slice::Gen::TypeScriptVisitor::importPrefix(const string& s) const
+Slice::Gen::TypeScriptVisitor::importPrefix(const string& scopedName) const
 {
-    const auto it = _importedTypes.find(s);
+    const auto it = _importedTypes.find(scopedName);
     if (it != _importedTypes.end())
     {
         return it->second;
@@ -2286,8 +2286,8 @@ Slice::Gen::TypeScriptVisitor::typeToTsString(const TypePtr& type, bool nullable
 
 Slice::Gen::TypeScriptVisitor::TypeScriptVisitor(
     IceInternal::Output& out,
-    std::map<std::string, std::string> importedTypes,
-    std::map<std::string, std::set<std::string>> importedTypesByInclude)
+    map<string, string> importedTypes,
+    map<string, set<string>> importedTypesByInclude)
     : JsVisitor(out),
       _importedTypes(std::move(importedTypes)),
       _importedTypesByInclude(std::move(importedTypesByInclude))
@@ -2415,7 +2415,7 @@ Slice::Gen::TypeScriptVisitor::visitClassDefStart(const ClassDefPtr& p)
         {
             _out << sp;
             writeDocSummary(dataMember);
-            const string optionalModifier = dataMember->optional() ? "?" : "";
+            const string optionalModifier = dataMember->isOptional() ? "?" : "";
             _out << nl << dataMember->mappedName() << optionalModifier << ": "
                  << typeToTsString(dataMember->type(), true) << ";";
         }
@@ -2439,7 +2439,7 @@ namespace
 
         for (; it != params.end(); ++it)
         {
-            if (!(*it)->optional())
+            if (!(*it)->isOptional())
             {
                 return false;
             }
@@ -2515,7 +2515,7 @@ Slice::Gen::TypeScriptVisitor::writeOpDocSummary(Output& out, const OperationPtr
             auto q = paramDoc.find(param->name());
             if (q != paramDoc.end())
             {
-                out << nl << " * - " << typeToTsString(param->type(), true, false, param->optional()) << " : ";
+                out << nl << " * - " << typeToTsString(param->type(), true, false, param->isOptional()) << " : ";
                 writeDocLines(out, q->second, false, "   ");
             }
         }
@@ -2705,10 +2705,10 @@ Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         {
             // TypeScript doesn't allow optional parameters with '?' prefix before required parameters.
             const string optionalPrefix =
-                param->optional() && areRemainingParamsOptional(paramList, param->name()) ? "?" : "";
+                param->isOptional() && areRemainingParamsOptional(paramList, param->name()) ? "?" : "";
             _out
                 << (param->mappedName() + optionalPrefix + ": " +
-                    typeToTsString(param->type(), true, true, param->optional()));
+                    typeToTsString(param->type(), true, true, param->isOptional()));
         }
         _out << "context?: Map<string, string>";
         _out << epar;
@@ -2721,7 +2721,7 @@ Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         else if ((ret && outParams.empty()) || (!ret && outParams.size() == 1))
         {
             TypePtr t = ret ? ret : outParams.front()->type();
-            bool optional = ret ? op->returnIsOptional() : outParams.front()->optional();
+            bool optional = ret ? op->returnIsOptional() : outParams.front()->isOptional();
             _out << "<" << typeToTsString(t, true, false, optional) << ">";
         }
         else
@@ -2734,7 +2734,7 @@ Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
             for (auto i = outParams.begin(); i != outParams.end();)
             {
-                _out << typeToTsString((*i)->type(), true, false, (*i)->optional());
+                _out << typeToTsString((*i)->type(), true, false, (*i)->isOptional());
                 if (++i != outParams.end())
                 {
                     _out << ", ";
@@ -2823,7 +2823,7 @@ Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         _out << nl << "abstract " << op->mappedName() << spar;
         for (const auto& param : inParams)
         {
-            _out << (param->mappedName() + ": " + typeToTsString(param->type(), true, true, param->optional()));
+            _out << (param->mappedName() + ": " + typeToTsString(param->type(), true, true, param->isOptional()));
         }
         _out << ("current: " + _iceImportPrefix + "Ice.Current");
         _out << epar << ": ";
@@ -2848,7 +2848,7 @@ Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
             for (auto i = outParams.begin(); i != outParams.end();)
             {
-                os << typeToTsString((*i)->type(), true, false, (*i)->optional());
+                os << typeToTsString((*i)->type(), true, false, (*i)->isOptional());
                 if (++i != outParams.end())
                 {
                     os << ", ";
@@ -2927,7 +2927,7 @@ Slice::Gen::TypeScriptVisitor::visitExceptionStart(const ExceptionPtr& p)
         {
             _out << sp;
             writeDocSummary(dataMember);
-            const string optionalModifier = dataMember->optional() ? "?" : "";
+            const string optionalModifier = dataMember->isOptional() ? "?" : "";
             _out << nl << dataMember->mappedName() << optionalModifier << ": "
                  << typeToTsString(dataMember->type(), true) << ";";
         }

--- a/cpp/src/slice2js/Gen.h
+++ b/cpp/src/slice2js/Gen.h
@@ -22,32 +22,32 @@ namespace Slice
     class JsVisitor : public ParserVisitor
     {
     public:
-        JsVisitor(::IceInternal::Output& output);
+        JsVisitor(IceInternal::Output& output);
         ~JsVisitor() override;
 
     protected:
-        void writeMarshalDataMembers(const DataMemberList&, const DataMemberList&);
-        void writeUnmarshalDataMembers(const DataMemberList&, const DataMemberList&);
+        void writeMarshalDataMembers(const DataMemberList& dataMembers, const DataMemberList& optionalMembers);
+        void writeUnmarshalDataMembers(const DataMemberList& dataMembers, const DataMemberList& optionalMembers);
         void writeOneShotConstructorArguments(const DataMemberList& members);
 
-        std::string getValue(const TypePtr&);
+        std::string getValue(const TypePtr& type);
 
-        std::string writeConstantValue(const TypePtr&, const SyntaxTreeBasePtr&, const std::string&);
+        std::string writeConstantValue(const TypePtr& type, const SyntaxTreeBasePtr& valueType, const std::string& value);
 
         /// Generates and outputs a doc-summary for Slice definition @p p.
         /// @param p The Slice definition to be documented.
         /// @param options Options that control how the doc-summary is generated.
         void writeDocSummary(const ContainedPtr& p, const DocSummaryOptions& options = {});
 
-        ::IceInternal::Output& _out;
+        IceInternal::Output& _out;
         std::string _jsModule;
     };
 
     class IncludeAggregationVisitor : public ParserVisitor
     {
     public:
-        bool visitUnitStart(const UnitPtr& unit) final;
-        void visitModuleEnd(const ModulePtr& module) final;
+        bool visitUnitStart(const UnitPtr&) final;
+        void visitModuleEnd(const ModulePtr&) final;
 
         bool visitClassDefStart(const ClassDefPtr&) final;
         bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
@@ -98,13 +98,13 @@ namespace Slice
     class Gen final
     {
     public:
-        Gen(const std::string&, const std::string&, bool);
+        Gen(const std::string& base, const std::string& dir, bool typeScript);
 
-        Gen(const std::string&, const std::string&, bool, std::ostream&);
+        Gen(const std::string& base, std::ostream& out, bool typeScript);
 
         ~Gen();
 
-        void generate(const UnitPtr&);
+        void generate(const UnitPtr& unit);
 
     private:
         IceInternal::Output _javaScriptOutput;
@@ -117,7 +117,7 @@ namespace Slice
         class ImportVisitor final : public JsVisitor
         {
         public:
-            ImportVisitor(::IceInternal::Output&);
+            ImportVisitor(IceInternal::Output& out);
 
             bool visitClassDefStart(const ClassDefPtr&) final;
             bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
@@ -130,7 +130,7 @@ namespace Slice
 
             // Emit the import statements for the given unit and return a list of the imported modules.
             std::set<std::string>
-            writeImports(const UnitPtr&, const std::map<std::string, std::map<std::string, std::set<std::string>>>&);
+            writeImports(const UnitPtr& unit, const std::map<std::string, std::map<std::string, std::set<std::string>>>& nestedModulesByTopLevel);
 
         private:
             bool _seenClass{false};
@@ -150,15 +150,13 @@ namespace Slice
         class ExportsVisitor final : public JsVisitor
         {
         public:
-            ExportsVisitor(::IceInternal::Output&, std::set<std::string>);
+            ExportsVisitor(IceInternal::Output& out, std::set<std::string> importedModules);
 
             bool visitModuleStart(const ModulePtr&) final;
 
             [[nodiscard]] std::set<std::string> exportedModules() const;
 
         private:
-            std::string encodeTypeForOperation(const TypePtr&);
-
             std::set<std::string> _importedModules;
             std::set<std::string> _exportedModules;
         };
@@ -166,7 +164,7 @@ namespace Slice
         class TypesVisitor final : public JsVisitor
         {
         public:
-            TypesVisitor(::IceInternal::Output&, std::string jsModule);
+            TypesVisitor(IceInternal::Output& out, std::string jsModule);
 
             bool visitClassDefStart(const ClassDefPtr&) final;
             bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
@@ -178,13 +176,13 @@ namespace Slice
             void visitConst(const ConstPtr&) final;
 
         private:
-            std::string encodeTypeForOperation(const TypePtr&);
+            std::string encodeTypeForOperation(const TypePtr& type);
         };
 
         class TypeScriptImportVisitor final : public JsVisitor
         {
         public:
-            TypeScriptImportVisitor(::IceInternal::Output&, std::map<std::string, std::set<std::string>>);
+            TypeScriptImportVisitor(IceInternal::Output& out, std::map<std::string, std::set<std::string>> importedTypesByInclude);
 
             bool visitUnitStart(const UnitPtr&) final;
             bool visitClassDefStart(const ClassDefPtr&) final;
@@ -216,9 +214,9 @@ namespace Slice
         {
         public:
             TypeScriptVisitor(
-                ::IceInternal::Output&,
-                std::map<std::string, std::string>,
-                std::map<std::string, std::set<std::string>>);
+                IceInternal::Output& out,
+                std::map<std::string, std::string> importedTypes,
+                std::map<std::string, std::set<std::string>> importedTypesByInclude);
 
             bool visitUnitStart(const UnitPtr&) final;
             void visitUnitEnd(const UnitPtr&) final;
@@ -234,11 +232,9 @@ namespace Slice
             void visitConst(const ConstPtr&) final;
 
         private:
-            [[nodiscard]] std::string importPrefix(const std::string&) const;
-            [[nodiscard]] std::string
-            typeToTsString(const TypePtr&, bool nullable = false, bool forParameter = false, bool optional = false)
-                const;
-            void writeOpDocSummary(::IceInternal::Output& out, const OperationPtr& op, bool forDispatch);
+            [[nodiscard]] std::string importPrefix(const std::string& scopedName) const;
+            [[nodiscard]] std::string typeToTsString(const TypePtr& type, bool nullable = false, bool forParameter = false, bool optional = false) const;
+            void writeOpDocSummary(IceInternal::Output& out, const OperationPtr& op, bool forDispatch);
             void writeNestedModuleExports(const std::string& currentModuleScope);
 
             // The module name of the current unit.

--- a/cpp/src/slice2js/Gen.h
+++ b/cpp/src/slice2js/Gen.h
@@ -32,7 +32,8 @@ namespace Slice
 
         std::string getValue(const TypePtr& type);
 
-        std::string writeConstantValue(const TypePtr& type, const SyntaxTreeBasePtr& valueType, const std::string& value);
+        std::string
+        writeConstantValue(const TypePtr& type, const SyntaxTreeBasePtr& valueType, const std::string& value);
 
         /// Generates and outputs a doc-summary for Slice definition @p p.
         /// @param p The Slice definition to be documented.
@@ -129,8 +130,9 @@ namespace Slice
             void visitEnum(const EnumPtr&) final;
 
             // Emit the import statements for the given unit and return a list of the imported modules.
-            std::set<std::string>
-            writeImports(const UnitPtr& unit, const std::map<std::string, std::map<std::string, std::set<std::string>>>& nestedModulesByTopLevel);
+            std::set<std::string> writeImports(
+                const UnitPtr& unit,
+                const std::map<std::string, std::map<std::string, std::set<std::string>>>& nestedModulesByTopLevel);
 
         private:
             bool _seenClass{false};
@@ -182,7 +184,9 @@ namespace Slice
         class TypeScriptImportVisitor final : public JsVisitor
         {
         public:
-            TypeScriptImportVisitor(IceInternal::Output& out, std::map<std::string, std::set<std::string>> importedTypesByInclude);
+            TypeScriptImportVisitor(
+                IceInternal::Output& out,
+                std::map<std::string, std::set<std::string>> importedTypesByInclude);
 
             bool visitUnitStart(const UnitPtr&) final;
             bool visitClassDefStart(const ClassDefPtr&) final;
@@ -233,7 +237,9 @@ namespace Slice
 
         private:
             [[nodiscard]] std::string importPrefix(const std::string& scopedName) const;
-            [[nodiscard]] std::string typeToTsString(const TypePtr& type, bool nullable = false, bool forParameter = false, bool optional = false) const;
+            [[nodiscard]] std::string
+            typeToTsString(const TypePtr& type, bool nullable = false, bool forParameter = false, bool optional = false)
+                const;
             void writeOpDocSummary(IceInternal::Output& out, const OperationPtr& op, bool forDispatch);
             void writeNestedModuleExports(const std::string& currentModuleScope);
 

--- a/cpp/src/slice2js/JsUtil.cpp
+++ b/cpp/src/slice2js/JsUtil.cpp
@@ -420,7 +420,7 @@ Slice::JavaScript::writeOptionalMarshalUnmarshalCode(
     }
 }
 
-std::string
+string
 Slice::JavaScript::getHelper(const TypePtr& type, const string& currentJsModule)
 {
     BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
@@ -557,7 +557,7 @@ Slice::JavaScript::jsLinkFormatter(const string& rawLink, const ContainedPtr&, c
 }
 
 void
-Slice::JavaScript::validateJsMetadata(const UnitPtr& u)
+Slice::JavaScript::validateJsMetadata(const UnitPtr& unit)
 {
     map<string, MetadataInfo> knownMetadata;
 
@@ -596,5 +596,5 @@ Slice::JavaScript::validateJsMetadata(const UnitPtr& u)
     knownMetadata.emplace("js:identifier", std::move(identifierInfo));
 
     // Pass this information off to the parser's metadata validation logic.
-    Slice::validateMetadata(u, "js", std::move(knownMetadata));
+    Slice::validateMetadata(unit, "js", std::move(knownMetadata));
 }

--- a/cpp/src/slice2js/JsUtil.h
+++ b/cpp/src/slice2js/JsUtil.h
@@ -47,7 +47,7 @@ namespace Slice::JavaScript
     std::string
     jsLinkFormatter(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target);
 
-    void validateJsMetadata(const UnitPtr&);
+    void validateJsMetadata(const UnitPtr& unit);
 }
 
 #endif

--- a/cpp/src/slice2js/Main.cpp
+++ b/cpp/src/slice2js/Main.cpp
@@ -239,7 +239,7 @@ compile(const vector<string>& argv)
 
                 if (useStdout)
                 {
-                    Gen gen(preprocessor->getBaseName(), output, typeScript, cout);
+                    Gen gen(preprocessor->getBaseName(), cout, typeScript);
                     gen.generate(unit);
                 }
                 else

--- a/cpp/src/slice2matlab/Gen.cpp
+++ b/cpp/src/slice2matlab/Gen.cpp
@@ -367,8 +367,7 @@ namespace
         }
     }
 
-    template<class T>
-    void writePropertiesSummary(IceInternal::Output& out, const string& name, const list<T>& list)
+    template<class T> void writePropertiesSummary(IceInternal::Output& out, const string& name, const list<T>& list)
     {
         if (!list.empty())
         {

--- a/cpp/src/slice2matlab/Gen.cpp
+++ b/cpp/src/slice2matlab/Gen.cpp
@@ -166,7 +166,7 @@ namespace
         {
             return constantValue(m->type(), m->defaultValueType(), *m->defaultValue());
         }
-        else if (m->optional() && !isProxyType(m->type()))
+        else if (m->isOptional() && !isProxyType(m->type()))
         {
             // We don't distinguish between unset and "null" (empty) for proxy types. We always use empty for them.
             return "IceInternal.UnsetI.Instance";
@@ -368,7 +368,7 @@ namespace
     }
 
     template<class T>
-    void writePropertiesSummary(IceInternal::Output& out, const string& name, const std::list<T>& list)
+    void writePropertiesSummary(IceInternal::Output& out, const string& name, const list<T>& list)
     {
         if (!list.empty())
         {
@@ -703,7 +703,7 @@ namespace
 
         // We can't specify a type for optional parameter because we can't represent "not set" with the same MATLAB
         // type.
-        if (!param->optional())
+        if (!param->isOptional())
         {
             if (auto seq = dynamic_pointer_cast<Sequence>(type))
             {
@@ -856,7 +856,7 @@ namespace
 
     void documentArgument(IceInternal::Output& out, const ParameterPtr& param, const string& name, StringList docLines)
     {
-        documentArgumentOrProperty(out, name, param->type(), param->optional(), std::move(docLines), true);
+        documentArgumentOrProperty(out, name, param->type(), param->isOptional(), std::move(docLines), true);
     }
 
     void documentProperty(IceInternal::Output& out, const DataMemberPtr& field)
@@ -866,7 +866,7 @@ namespace
             out,
             toUpper(field->mappedName()),
             field->type(),
-            field->optional(),
+            field->isOptional(),
             doc ? doc->overview() : StringList{},
             false);
 
@@ -1057,7 +1057,7 @@ CodeVisitor::visitClassDefEnd(const ClassDefPtr& p)
         for (const auto& convertMember : convertMembers)
         {
             string m = "obj." + convertMember->mappedName();
-            convertValueType(out, m, m, convertMember->type(), convertMember->optional());
+            convertValueType(out, m, m, convertMember->type(), convertMember->isOptional());
         }
         if (base)
         {
@@ -1080,7 +1080,7 @@ CodeVisitor::visitClassDefEnd(const ClassDefPtr& p)
     out << nl << "os.startSlice('" << scoped << "', " << p->compactId() << (!base ? ", true" : ", false") << ");";
     for (const auto& member : members)
     {
-        if (!member->optional())
+        if (!member->isOptional())
         {
             marshal(out, "os", "obj." + member->mappedName(), member->type(), false, 0);
         }
@@ -1101,7 +1101,7 @@ CodeVisitor::visitClassDefEnd(const ClassDefPtr& p)
     out << nl << "is.startSlice();";
     for (const auto& dm : members)
     {
-        if (!dm->optional())
+        if (!dm->isOptional())
         {
             if (dm->type()->isClassType())
             {
@@ -1293,7 +1293,7 @@ CodeVisitor::visitOperation(const OperationPtr& op)
         }
         for (const auto& param : sortedInParams)
         {
-            marshal(out, "os_", param->mappedName(), param->type(), param->optional(), param->tag());
+            marshal(out, "os_", param->mappedName(), param->type(), param->isOptional(), param->tag());
         }
         if (op->sendsClasses())
         {
@@ -1348,7 +1348,7 @@ CodeVisitor::visitOperation(const OperationPtr& op)
             {
                 paramString = paramName;
             }
-            unmarshal(out, "is_", paramString, paramType, param->optional(), param->tag());
+            unmarshal(out, "is_", paramString, paramType, param->isOptional(), param->tag());
 
             if (needsConversion(paramType))
             {
@@ -1371,7 +1371,7 @@ CodeVisitor::visitOperation(const OperationPtr& op)
         for (const auto& param : convertParams)
         {
             const string paramName = param->mappedName();
-            convertValueType(out, paramName, paramName, param->type(), param->optional());
+            convertValueType(out, paramName, paramName, param->type(), param->isOptional());
         }
     }
 
@@ -1416,7 +1416,7 @@ CodeVisitor::visitOperation(const OperationPtr& op)
         }
         for (const auto& param : sortedInParams)
         {
-            marshal(out, "os_", param->mappedName(), param->type(), param->optional(), param->tag());
+            marshal(out, "os_", param->mappedName(), param->type(), param->isOptional(), param->tag());
         }
         if (op->sendsClasses())
         {
@@ -1451,7 +1451,7 @@ CodeVisitor::visitOperation(const OperationPtr& op)
             {
                 paramString = paramName;
             }
-            unmarshal(out, "is_", paramString, paramType, param->optional(), param->tag());
+            unmarshal(out, "is_", paramString, paramType, param->isOptional(), param->tag());
         }
         if (op->returnsClasses())
         {
@@ -1470,7 +1470,7 @@ CodeVisitor::visitOperation(const OperationPtr& op)
             {
                 ostringstream dest;
                 dest << "varargout{" << i << "}";
-                convertValueType(out, dest.str(), paramName, param->type(), param->optional());
+                convertValueType(out, dest.str(), paramName, param->type(), param->isOptional());
             }
             else
             {
@@ -1777,7 +1777,7 @@ CodeVisitor::visitExceptionEnd(const ExceptionPtr& p)
         for (const auto& convertMember : convertMembers)
         {
             string m = "obj." + convertMember->mappedName();
-            convertValueType(out, m, m, convertMember->type(), convertMember->optional());
+            convertValueType(out, m, m, convertMember->type(), convertMember->isOptional());
         }
         if (base && base->usesClasses())
         {
@@ -1798,7 +1798,7 @@ CodeVisitor::visitExceptionEnd(const ExceptionPtr& p)
     for (const auto& dm : members)
     {
         const string m = dm->mappedName();
-        if (!dm->optional())
+        if (!dm->isOptional())
         {
             if (dm->type()->isClassType())
             {
@@ -2059,7 +2059,7 @@ CodeVisitor::visitDataMember(const DataMemberPtr& p)
     // We also can't specify a type for class fields (in structs and exceptions, because we convert them in place;
     // we do the same for class fields in classes for consistency). Likewise, we can't specify a type for fields
     // that use classes (but are not classes), since we convert them in place.
-    if (!p->optional() && !type->usesClasses())
+    if (!p->isOptional() && !type->usesClasses())
     {
         if (auto seq = dynamic_pointer_cast<Sequence>(type))
         {
@@ -2773,7 +2773,7 @@ CodeVisitor::closeClass()
 }
 
 string
-CodeVisitor::getOperationMode(Slice::Operation::Mode mode)
+CodeVisitor::getOperationMode(Operation::Mode mode)
 {
     switch (mode)
     {
@@ -3314,7 +3314,7 @@ CodeVisitor::convertStruct(IceInternal::Output& out, const StructPtr& p, const s
     }
 }
 
-std::pair<std::string, std::string>
+pair<string, string>
 Slice::matlabLinkFormatter(const string& rawLink, const ContainedPtr&, const SyntaxTreeBasePtr& target)
 {
     string displayText; // The hyperlink text that will be visible to the user.

--- a/cpp/src/slice2matlab/Gen.h
+++ b/cpp/src/slice2matlab/Gen.h
@@ -48,8 +48,18 @@ namespace Slice
         std::string getOptionalFormat(const TypePtr& type);
         std::string getFormatType(FormatType type);
 
-        void marshal(IceInternal::Output& out, const std::string& stream, const std::string& v, const TypePtr& type, bool optional, std::int32_t tag);
-        void unmarshal(IceInternal::Output& out, const std::string& stream, const std::string& v, const TypePtr& type, bool optional, std::int32_t tag);
+        void marshal(IceInternal::Output& out,
+            const std::string& stream,
+            const std::string& v,
+            const TypePtr& type,
+            bool optional,
+            std::int32_t tag);
+        void unmarshal(IceInternal::Output& out,
+            const std::string& stream,
+            const std::string& v,
+            const TypePtr& type,
+            bool optional,
+            std::int32_t tag);
 
         void unmarshalStruct(IceInternal::Output& out, const StructPtr& p, const std::string& v);
         void convertStruct(IceInternal::Output& out, const StructPtr& p, const std::string& v);

--- a/cpp/src/slice2matlab/Gen.h
+++ b/cpp/src/slice2matlab/Gen.h
@@ -43,17 +43,16 @@ namespace Slice
         //
         // Convert an operation mode into a string.
         //
-        std::string getOperationMode(Operation::Mode);
+        std::string getOperationMode(Operation::Mode mode);
 
-        std::string getOptionalFormat(const TypePtr&);
-        std::string getFormatType(FormatType);
+        std::string getOptionalFormat(const TypePtr& type);
+        std::string getFormatType(FormatType type);
 
-        void marshal(IceInternal::Output&, const std::string&, const std::string&, const TypePtr&, bool, std::int32_t);
-        void
-        unmarshal(IceInternal::Output&, const std::string&, const std::string&, const TypePtr&, bool, std::int32_t);
+        void marshal(IceInternal::Output& out, const std::string& stream, const std::string& v, const TypePtr& type, bool optional, std::int32_t tag);
+        void unmarshal(IceInternal::Output& out, const std::string& stream, const std::string& v, const TypePtr& type, bool optional, std::int32_t tag);
 
-        void unmarshalStruct(IceInternal::Output&, const StructPtr&, const std::string&);
-        void convertStruct(IceInternal::Output&, const StructPtr&, const std::string&);
+        void unmarshalStruct(IceInternal::Output& out, const StructPtr& p, const std::string& v);
+        void convertStruct(IceInternal::Output& out, const StructPtr& p, const std::string& v);
 
         const std::string _dir;
 

--- a/cpp/src/slice2matlab/Gen.h
+++ b/cpp/src/slice2matlab/Gen.h
@@ -48,13 +48,15 @@ namespace Slice
         std::string getOptionalFormat(const TypePtr& type);
         std::string getFormatType(FormatType type);
 
-        void marshal(IceInternal::Output& out,
+        void marshal(
+            IceInternal::Output& out,
             const std::string& stream,
             const std::string& v,
             const TypePtr& type,
             bool optional,
             std::int32_t tag);
-        void unmarshal(IceInternal::Output& out,
+        void unmarshal(
+            IceInternal::Output& out,
             const std::string& stream,
             const std::string& v,
             const TypePtr& type,

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -77,7 +77,7 @@ namespace
 class CodeVisitor final : public ParserVisitor
 {
 public:
-    CodeVisitor(IceInternal::Output&);
+    CodeVisitor(IceInternal::Output& out);
 
     bool visitModuleStart(const ModulePtr&) final;
     void visitModuleEnd(const ModulePtr&) final;
@@ -95,25 +95,25 @@ public:
 
 private:
     // Return the PHP variable for the given object's type.
-    string getTypeVar(const ContainedPtr&);
+    string getTypeVar(const ContainedPtr& p);
 
-    string getType(const TypePtr&);
+    string getType(const TypePtr& p);
 
     // Write a default value for a given type.
-    void writeDefaultValue(const DataMemberPtr&);
+    void writeDefaultValue(const DataMemberPtr& m);
 
     // Write a member assignment statement for a constructor.
     void writeAssign(const DataMemberPtr& member);
 
     // Write constant value.
-    void writeConstantValue(const TypePtr&, const SyntaxTreeBasePtr&, const string&);
+    void writeConstantValue(const TypePtr& type, const SyntaxTreeBasePtr& valueType, const string& value);
 
     /// Write constructor parameters with default values.
     void writeConstructorParams(const DataMemberList& members);
 
     Output& _out;
     set<string> _classHistory;
-    std::stack<string> _parentNamespaces;
+    stack<string> _parentNamespaces;
 };
 
 // CodeVisitor implementation.
@@ -313,6 +313,7 @@ CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
         _out << "array(";
         for (auto q = members.begin(); q != members.end(); ++q)
         {
+            const bool isOptional = (*q)->isOptional();
             if (q != members.begin())
             {
                 _out << ',';
@@ -320,7 +321,7 @@ CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
             _out.inc();
             _out << nl << "array('" << (*q)->mappedName() << "', ";
             _out << getType((*q)->type());
-            _out << ", " << ((*q)->optional() ? "true" : "false") << ", " << ((*q)->optional() ? (*q)->tag() : 0)
+            _out << ", " << (isOptional ? "true" : "false") << ", " << (isOptional ? (*q)->tag() : 0)
                  << ')';
             _out.dec();
         }
@@ -458,7 +459,7 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                     }
                     _out << "array(";
                     _out << getType((*t)->type());
-                    if ((*t)->optional())
+                    if ((*t)->isOptional())
                     {
                         _out << ", " << (*t)->tag();
                     }
@@ -489,7 +490,7 @@ CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
                     }
                     _out << "array(";
                     _out << getType((*t)->type());
-                    if ((*t)->optional())
+                    if ((*t)->isOptional())
                     {
                         _out << ", " << (*t)->tag();
                     }
@@ -632,6 +633,7 @@ CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
         _out << "array(";
         for (auto dmli = members.begin(); dmli != members.end(); ++dmli)
         {
+            const bool isOptional = (*dmli)->isOptional();
             if (dmli != members.begin())
             {
                 _out << ',';
@@ -639,8 +641,7 @@ CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
             _out.inc();
             _out << nl << "array('" << (*dmli)->mappedName() << "', ";
             _out << getType((*dmli)->type());
-            _out << ", " << ((*dmli)->optional() ? "true" : "false") << ", "
-                 << ((*dmli)->optional() ? (*dmli)->tag() : 0) << ')';
+            _out << ", " << (isOptional ? "true" : "false") << ", " << (isOptional ? (*dmli)->tag() : 0) << ')';
             _out.dec();
         }
         _out << ')';
@@ -972,23 +973,23 @@ CodeVisitor::writeConstantValue(const TypePtr& type, const SyntaxTreeBasePtr& va
     }
     else
     {
-        Slice::BuiltinPtr b = dynamic_pointer_cast<Builtin>(type);
-        Slice::EnumPtr en = dynamic_pointer_cast<Enum>(type);
+        BuiltinPtr b = dynamic_pointer_cast<Builtin>(type);
+        EnumPtr en = dynamic_pointer_cast<Enum>(type);
         if (b)
         {
             switch (b->kind())
             {
-                case Slice::Builtin::KindBool:
-                case Slice::Builtin::KindByte:
-                case Slice::Builtin::KindShort:
-                case Slice::Builtin::KindInt:
-                case Slice::Builtin::KindFloat:
-                case Slice::Builtin::KindDouble:
+                case Builtin::KindBool:
+                case Builtin::KindByte:
+                case Builtin::KindShort:
+                case Builtin::KindInt:
+                case Builtin::KindFloat:
+                case Builtin::KindDouble:
                 {
                     _out << value;
                     break;
                 }
-                case Slice::Builtin::KindLong:
+                case Builtin::KindLong:
                 {
                     int64_t l = std::stoll(value, nullptr, 0); // NOLINT(clang-analyzer-deadcode.DeadStores)
                     // The platform's 'long' type may not be 64 bits, so we store 64-bit values as a string.
@@ -1002,14 +1003,14 @@ CodeVisitor::writeConstantValue(const TypePtr& type, const SyntaxTreeBasePtr& va
                     }
                     break;
                 }
-                case Slice::Builtin::KindString:
+                case Builtin::KindString:
                 {
                     // PHP 7.x also supports an EC6UCN-like notation, see: https://wiki.php.net/rfc/unicode_escape
                     _out << "\"" << toStringLiteral(value, "\f\n\r\t\v\x1b", "$", Octal, 0) << "\"";
                     break;
                 }
-                case Slice::Builtin::KindObjectProxy:
-                case Slice::Builtin::KindValue:
+                case Builtin::KindObjectProxy:
+                case Builtin::KindValue:
                     assert(false);
             }
         }
@@ -1043,7 +1044,7 @@ CodeVisitor::writeConstructorParams(const DataMemberList& members)
         {
             writeConstantValue(member->type(), member->defaultValueType(), *member->defaultValue());
         }
-        else if (member->optional())
+        else if (member->isOptional())
         {
             _out << "\\Ice\\None";
         }
@@ -1055,7 +1056,7 @@ CodeVisitor::writeConstructorParams(const DataMemberList& members)
 }
 
 static void
-generate(const UnitPtr& un, bool all, const vector<string>& includePaths, Output& out)
+generate(const UnitPtr& unit, bool all, const vector<string>& includePaths, Output& out)
 {
     if (!all)
     {
@@ -1065,7 +1066,7 @@ generate(const UnitPtr& un, bool all, const vector<string>& includePaths, Output
             path = fullPath(path);
         }
 
-        StringList includes = un->includeFiles();
+        StringList includes = unit->includeFiles();
         if (!includes.empty())
         {
             out << sp;
@@ -1080,10 +1081,10 @@ generate(const UnitPtr& un, bool all, const vector<string>& includePaths, Output
         }
     }
 
-    validatePhpMetadata(un);
+    validatePhpMetadata(unit);
 
     CodeVisitor codeVisitor(out);
-    un->visit(&codeVisitor);
+    unit->visit(&codeVisitor);
 
     out << nl; // Trailing newline.
 }

--- a/cpp/src/slice2php/Main.cpp
+++ b/cpp/src/slice2php/Main.cpp
@@ -321,8 +321,7 @@ CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
             _out.inc();
             _out << nl << "array('" << (*q)->mappedName() << "', ";
             _out << getType((*q)->type());
-            _out << ", " << (isOptional ? "true" : "false") << ", " << (isOptional ? (*q)->tag() : 0)
-                 << ')';
+            _out << ", " << (isOptional ? "true" : "false") << ", " << (isOptional ? (*q)->tag() : 0) << ')';
             _out.dec();
         }
         _out << ')';

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -106,7 +106,7 @@ Slice::Python::getImportAlias(
 string
 Slice::Python::getImportAlias(
     const ContainedPtr& source,
-    const std::map<std::string, std::string>& allImports,
+    const map<string, string>& allImports,
     const string& moduleName,
     const string& name)
 {
@@ -413,7 +413,7 @@ Slice::Python::CodeVisitor::returnTypeHint(const OperationPtr& operation, Method
 
         for (const auto& param : outParameters)
         {
-            os << typeToTypeHintString(param->type(), param->optional(), source, forMarshaling, param->getMetadata());
+            os << typeToTypeHintString(param->type(), param->isOptional(), source, forMarshaling, param->getMetadata());
             if (param != outParameters.back())
             {
                 os << ", ";
@@ -435,7 +435,7 @@ Slice::Python::CodeVisitor::returnTypeHint(const OperationPtr& operation, Method
     {
         const auto& param = outParameters.front();
         returnTypeHint =
-            typeToTypeHintString(param->type(), param->optional(), source, forMarshaling, param->getMetadata());
+            typeToTypeHintString(param->type(), param->isOptional(), source, forMarshaling, param->getMetadata());
     }
     else
     {
@@ -518,14 +518,14 @@ Slice::Python::writeHeader(IceInternal::Output& out)
 }
 
 void
-Slice::Python::writePackageIndex(const std::map<std::string, std::set<std::string>>& imports, IceInternal::Output& out)
+Slice::Python::writePackageIndex(const map<string, set<string>>& imports, IceInternal::Output& out)
 {
     out << sp;
     writeHeader(out);
     if (!imports.empty())
     {
         out << sp;
-        std::list<string> allDefinitions;
+        list<string> allDefinitions;
         for (const auto& [moduleName, definitions] : imports)
         {
             for (const auto& name : definitions)
@@ -610,8 +610,8 @@ Slice::Python::ImportVisitor::visitDataMember(const DataMemberPtr& p)
 
     // Import 'field' from dataclasses to initialize non-optional Struct, Dictionary, and Sequence members.
     // These types cannot use direct field initializers.
-    if (!p->optional() && (dynamic_pointer_cast<Struct>(type) || dynamic_pointer_cast<Sequence>(type) ||
-                           dynamic_pointer_cast<Dictionary>(type)))
+    if (!p->isOptional() && (dynamic_pointer_cast<Struct>(type) || dynamic_pointer_cast<Sequence>(type) ||
+                             dynamic_pointer_cast<Dictionary>(type)))
     {
         addRuntimeImport("dataclasses", "field", parent);
     }
@@ -1203,7 +1203,7 @@ Slice::Python::CodeVisitor::writeOperations(const InterfaceDefPtr& p, Output& ou
         {
             out
                 << (param->mappedName() + ": " +
-                    typeToTypeHintString(param->type(), param->optional(), p, false, param->getMetadata()));
+                    typeToTypeHintString(param->type(), param->isOptional(), p, false, param->getMetadata()));
         }
 
         const string currentParamName = getEscapedParamName(operation->parameters(), "current");
@@ -1433,14 +1433,14 @@ Slice::Python::CodeVisitor::visitDataMember(const DataMemberPtr& p)
     const string fieldAlias = getImportAlias(parent, "dataclasses", "field");
 
     out << nl << p->mappedName() << ": "
-        << typeToTypeHintString(p->type(), p->optional(), parent, false, p->getMetadata());
+        << typeToTypeHintString(p->type(), p->isOptional(), parent, false, p->getMetadata());
 
     if (p->defaultValue())
     {
         out << " = ";
         writeConstantValue(parent, p->type(), p->defaultValueType(), *p->defaultValue(), out);
     }
-    else if (p->optional())
+    else if (p->isOptional())
     {
         out << " = None";
     }
@@ -1601,7 +1601,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         ParameterPtr lastRequiredParameter;
         for (const auto& q : operation->inParameters())
         {
-            if (!q->optional())
+            if (!q->isOptional())
             {
                 lastRequiredParameter = q;
             }
@@ -1617,7 +1617,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             }
             string param = q->mappedName();
             inParams.append(param);
-            param += ": " + typeToTypeHintString(q->type(), q->optional(), p, true);
+            param += ": " + typeToTypeHintString(q->type(), q->isOptional(), p, true);
             if (afterLastRequiredParameter)
             {
                 param += " = None";
@@ -1840,7 +1840,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             writeMetadata(param->getMetadata(), out);
             out << ", " << getMetaType(param->type());
             out << ", ";
-            if (param->optional())
+            if (param->isOptional())
             {
                 out << "True, " << param->tag();
             }
@@ -1868,7 +1868,7 @@ Slice::Python::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             writeMetadata(param->getMetadata(), out);
             out << ", " << getMetaType(param->type());
             out << ", ";
-            if (param->optional())
+            if (param->isOptional())
             {
                 out << "True, " << param->tag();
             }
@@ -2074,8 +2074,9 @@ Slice::Python::CodeVisitor::writeMetaTypeDataMembers(
         out << ", " << getMetaType(member->type());
         if (includeOptional)
         {
-            out << ", " << (member->optional() ? "True" : "False");
-            out << ", " << (member->optional() ? member->tag() : 0);
+            const bool isOptional = member->isOptional();
+            out << ", " << (isOptional ? "True" : "False");
+            out << ", " << (isOptional ? member->tag() : 0);
         }
         out << ')';
     }
@@ -2131,7 +2132,7 @@ Slice::Python::CodeVisitor::writeConstantValue(
     {
         out << getImportAlias(source, constant);
     }
-    else if (auto builtin = dynamic_pointer_cast<Slice::Builtin>(type))
+    else if (auto builtin = dynamic_pointer_cast<Builtin>(type))
     {
         switch (builtin->kind())
         {
@@ -2163,7 +2164,7 @@ Slice::Python::CodeVisitor::writeConstantValue(
                 assert(false);
         }
     }
-    else if (auto enumeration = dynamic_pointer_cast<Slice::Enum>(type))
+    else if (auto enumeration = dynamic_pointer_cast<Enum>(type))
     {
         EnumeratorPtr enumerator = dynamic_pointer_cast<Enumerator>(valueType);
         assert(enumerator);
@@ -2197,7 +2198,7 @@ Slice::Python::getAll(const ContainedPtr& definition)
     return all;
 }
 
-Slice::MetadataPtr
+MetadataPtr
 Slice::Python::getSequenceMetadata(const SequencePtr& seq, const MetadataList& localMetadata)
 {
     auto sequenceMetaData =
@@ -2348,7 +2349,7 @@ Slice::Python::CodeVisitor::writeDocstring(const ContainedPtr& p, Output& out, c
         for (const auto& field : fields)
         {
             out << nl << field->mappedName() << " : "
-                << typeToTypeHintString(field->type(), field->optional(), p, false);
+                << typeToTypeHintString(field->type(), field->isOptional(), p, false);
             auto q = fieldDocs.find(field->name());
             if (q != fieldDocs.end())
             {
@@ -2459,7 +2460,7 @@ Slice::Python::CodeVisitor::writeOpDocstring(const OperationPtr& op, MethodKind 
         for (const auto& param : inParams)
         {
             out << nl << param->mappedName() << " : "
-                << typeToTypeHintString(param->type(), param->optional(), p, methodKind != MethodKind::Dispatch);
+                << typeToTypeHintString(param->type(), param->isOptional(), p, methodKind != MethodKind::Dispatch);
             const auto r = parametersDoc.find(param->name());
             if (r != parametersDoc.end())
             {
@@ -2543,7 +2544,7 @@ Slice::Python::CodeVisitor::writeOpDocstring(const OperationPtr& op, MethodKind 
             for (const auto& param : outParams)
             {
                 out << nl << "        - "
-                    << typeToTypeHintString(param->type(), param->optional(), p, methodKind == MethodKind::Dispatch);
+                    << typeToTypeHintString(param->type(), param->isOptional(), p, methodKind == MethodKind::Dispatch);
                 const auto r = parametersDoc.find(param->name());
                 if (r != parametersDoc.end())
                 {
@@ -2574,7 +2575,7 @@ Slice::Python::CodeVisitor::writeOpDocstring(const OperationPtr& op, MethodKind 
         {
             assert(outParams.size() == 1);
             const auto& param = outParams.front();
-            out << nl << typeToTypeHintString(param->type(), param->optional(), p, methodKind == MethodKind::Dispatch);
+            out << nl << typeToTypeHintString(param->type(), param->isOptional(), p, methodKind == MethodKind::Dispatch);
             const auto r = parametersDoc.find(param->name());
             if (r != parametersDoc.end())
             {
@@ -2736,8 +2737,8 @@ namespace
 
 Slice::Python::CompilationResult
 Slice::Python::compile(
-    const std::string& programName,
-    const std::unique_ptr<DependencyGenerator>& dependencyGenerator,
+    const string& programName,
+    const unique_ptr<DependencyGenerator>& dependencyGenerator,
     PackageVisitor& packageVisitor,
     const vector<string>& files,
     const vector<string>& preprocessorArgs,
@@ -3074,7 +3075,7 @@ Slice::Python::validatePythonMetadata(const UnitPtr& unit)
              typeid(Enum),
              typeid(Enumerator),
              typeid(Const),
-             typeid(Slice::Parameter),
+             typeid(Parameter),
              typeid(DataMember)},
         .acceptedArgumentKind = MetadataArgumentKind::SingleArgument,
     };
@@ -3152,7 +3153,7 @@ namespace
 }
 
 int
-Slice::Python::compile(const std::vector<std::string>& args)
+Slice::Python::compile(const vector<string>& args)
 {
     const string programName = args[0]; // NOLINT(performance-unnecessary-copy-initialization)
 
@@ -3319,7 +3320,7 @@ Slice::Python::compile(const std::vector<std::string>& args)
     }
     else if (!listArg.empty())
     {
-        std::set<string> generated;
+        set<string> generated;
 
         for (const auto& [source, files] : packageVisitor.generated())
         {

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -2575,7 +2575,8 @@ Slice::Python::CodeVisitor::writeOpDocstring(const OperationPtr& op, MethodKind 
         {
             assert(outParams.size() == 1);
             const auto& param = outParams.front();
-            out << nl << typeToTypeHintString(param->type(), param->isOptional(), p, methodKind == MethodKind::Dispatch);
+            out << nl;
+            out << typeToTypeHintString(param->type(), param->isOptional(), p, methodKind == MethodKind::Dispatch);
             const auto r = parametersDoc.find(param->name());
             if (r != parametersDoc.end())
             {

--- a/cpp/src/slice2py/PythonUtil.h
+++ b/cpp/src/slice2py/PythonUtil.h
@@ -185,7 +185,7 @@ namespace Slice::Python
     std::vector<std::string> getAll(const ContainedPtr& definition);
 
     /// Get sequence metadata associated with the given sequence and any local metadata.
-    Slice::MetadataPtr getSequenceMetadata(const SequencePtr& seq, const MetadataList& localMetadata);
+    MetadataPtr getSequenceMetadata(const SequencePtr& seq, const MetadataList& localMetadata);
 
     /// Splits a fully qualified name (FQN) into its Module and Name components.
     /// @param fqn The fully qualified name to split.
@@ -233,7 +233,7 @@ namespace Slice::Python
     pyLinkFormatter(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target);
 
     /// Validates the Slice Python metadata for the given unit.
-    void validatePythonMetadata(const UnitPtr&);
+    void validatePythonMetadata(const UnitPtr& unit);
 
     // Collects Python definitions for each generated Python package.
     // Each package corresponds to a Slice module and includes an `__init__.py` file that re-exports selected
@@ -431,10 +431,10 @@ namespace Slice::Python
         std::string operationReturnTypeHint(const OperationPtr& operation, MethodKind methodKind);
 
         // Emit Python code for operations
-        void writeOperations(const InterfaceDefPtr&, IceInternal::Output&);
+        void writeOperations(const InterfaceDefPtr& p, IceInternal::Output& out);
 
         // Write Python metadata as a tuple.
-        void writeMetadata(const MetadataList&, IceInternal::Output&);
+        void writeMetadata(const MetadataList& metadata, IceInternal::Output& out);
 
         // Write the data members meta-info for a meta type declaration.
         void writeMetaTypeDataMembers(
@@ -445,10 +445,10 @@ namespace Slice::Python
         // Write a constant value.
         void writeConstantValue(
             const ContainedPtr& source,
-            const TypePtr&,
-            const SyntaxTreeBasePtr&,
-            const std::string&,
-            IceInternal::Output&);
+            const TypePtr& type,
+            const SyntaxTreeBasePtr& valueType,
+            const std::string& value,
+            IceInternal::Output& out);
 
         /// Writes the provided @p remarks in its own subheading in the current comment (if @p remarks is non-empty).
         void writeRemarksDocComment(const StringList& remarks, bool needsNewline, IceInternal::Output& out);
@@ -460,7 +460,7 @@ namespace Slice::Python
 
         void writeEnumeratorDocstring(const EnumeratorPtr& p, IceInternal::Output& out);
 
-        void writeOpDocstring(const OperationPtr&, MethodKind, IceInternal::Output&);
+        void writeOpDocstring(const OperationPtr& op, MethodKind methodKind, IceInternal::Output& out);
 
         std::string getImportAlias(const ContainedPtr& source, const SyntaxTreeBasePtr& definition);
         std::string

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -416,8 +416,7 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             isFirst = false;
             _out << '[';
             writeType(param->type());
-            _out << ", " << (isOptional ? "true" : "false") << ", " << (isOptional ? param->tag() : 0)
-                 << ']';
+            _out << ", " << (isOptional ? "true" : "false") << ", " << (isOptional ? param->tag() : 0) << ']';
         }
         _out << "], [";
         isFirst = true;
@@ -431,8 +430,7 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             isFirst = false;
             _out << '[';
             writeType(param->type());
-            _out << ", " << (isOptional ? "true" : "false") << ", " << (isOptional ? param->tag() : 0)
-                 << ']';
+            _out << ", " << (isOptional ? "true" : "false") << ", " << (isOptional ? param->tag() : 0) << ']';
         }
         _out << "], ";
         TypePtr returnType = op->returnType();
@@ -558,8 +556,7 @@ Slice::Ruby::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
         }
         _out << "[\"" << getMappedName(*dmli) << "\", ";
         writeType((*dmli)->type());
-        _out << ", " << (isOptional ? "true" : "false") << ", " << (isOptional ? (*dmli)->tag() : 0)
-             << ']';
+        _out << ", " << (isOptional ? "true" : "false") << ", " << (isOptional ? (*dmli)->tag() : 0) << ']';
     }
     if (members.size() > 1)
     {

--- a/cpp/src/slice2rb/RubyUtil.cpp
+++ b/cpp/src/slice2rb/RubyUtil.cpp
@@ -241,13 +241,14 @@ Slice::Ruby::CodeVisitor::visitClassDefStart(const ClassDefPtr& p)
     }
     for (auto q = members.begin(); q != members.end(); ++q)
     {
+        const bool isOptional = (*q)->isOptional();
         if (q != members.begin())
         {
             _out << ',' << nl;
         }
         _out << "['" << getMappedName(*q) << "', ";
         writeType((*q)->type());
-        _out << ", " << ((*q)->optional() ? "true" : "false") << ", " << ((*q)->optional() ? (*q)->tag() : 0) << ']';
+        _out << ", " << (isOptional ? "true" : "false") << ", " << (isOptional ? (*q)->tag() : 0) << ']';
     }
     if (members.size() > 1)
     {
@@ -407,6 +408,7 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         bool isFirst = true;
         for (const auto& param : op->inParameters())
         {
+            const bool isOptional = param->isOptional();
             if (!isFirst)
             {
                 _out << ", ";
@@ -414,13 +416,14 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             isFirst = false;
             _out << '[';
             writeType(param->type());
-            _out << ", " << (param->optional() ? "true" : "false") << ", " << (param->optional() ? param->tag() : 0)
+            _out << ", " << (isOptional ? "true" : "false") << ", " << (isOptional ? param->tag() : 0)
                  << ']';
         }
         _out << "], [";
         isFirst = true;
         for (const auto& param : op->outParameters())
         {
+            const bool isOptional = param->isOptional();
             if (!isFirst)
             {
                 _out << ", ";
@@ -428,7 +431,7 @@ Slice::Ruby::CodeVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
             isFirst = false;
             _out << '[';
             writeType(param->type());
-            _out << ", " << (param->optional() ? "true" : "false") << ", " << (param->optional() ? param->tag() : 0)
+            _out << ", " << (isOptional ? "true" : "false") << ", " << (isOptional ? param->tag() : 0)
                  << ']';
         }
         _out << "], ";
@@ -548,13 +551,14 @@ Slice::Ruby::CodeVisitor::visitExceptionStart(const ExceptionPtr& p)
     //
     for (auto dmli = members.begin(); dmli != members.end(); ++dmli)
     {
+        const bool isOptional = (*dmli)->isOptional();
         if (dmli != members.begin())
         {
             _out << ',' << nl;
         }
         _out << "[\"" << getMappedName(*dmli) << "\", ";
         writeType((*dmli)->type());
-        _out << ", " << ((*dmli)->optional() ? "true" : "false") << ", " << ((*dmli)->optional() ? (*dmli)->tag() : 0)
+        _out << ", " << (isOptional ? "true" : "false") << ", " << (isOptional ? (*dmli)->tag() : 0)
              << ']';
     }
     if (members.size() > 1)
@@ -1039,7 +1043,7 @@ Slice::Ruby::CodeVisitor::writeConstructorParams(const DataMemberList& members)
         {
             writeConstantValue(member->type(), member->defaultValueType(), *member->defaultValue());
         }
-        else if (member->optional())
+        else if (member->isOptional())
         {
             _out << "Ice::Unset";
         }

--- a/cpp/src/slice2rb/RubyUtil.h
+++ b/cpp/src/slice2rb/RubyUtil.h
@@ -9,11 +9,8 @@
 namespace Slice::Ruby
 {
     /// Generates Ruby code for the provided translation unit.
-    void generate(
-        const UnitPtr& unit,
-        bool all,
-        const std::vector<std::string>& includePaths,
-        IceInternal::Output& out);
+    void
+    generate(const UnitPtr& unit, bool all, const std::vector<std::string>& includePaths, IceInternal::Output& out);
 
     /// This enum is used by ::getMappedName to control the casing of the identifier it returns.
     enum IdentStyle

--- a/cpp/src/slice2rb/RubyUtil.h
+++ b/cpp/src/slice2rb/RubyUtil.h
@@ -12,7 +12,7 @@ namespace Slice::Ruby
     void
     generate(const UnitPtr& unit, bool all, const std::vector<std::string>& includePaths, IceInternal::Output& out);
 
-    /// This enum is used by ::getMappedName to control the casing of the identifier it returns.
+    /// This enum is used by `getMappedName` to control the casing of the identifier it returns.
     enum IdentStyle
     {
         /// No change will be made to the mapped identifier.
@@ -31,13 +31,13 @@ namespace Slice::Ruby
     std::string getMappedName(const ContainedPtr& p, IdentStyle style = IdentNormal);
 
     /// Returns the fully-qualified mapped-identifier of the provided Slice element.
-    /// This is equivalent to calling ::getMappedName on @p p and all it's containers.
+    /// This is equivalent to calling `getMappedName` on @p p and all it's containers.
     std::string getAbsolute(const ContainedPtr& p);
 
-    /// Equivalent to ::getMappedName but with "T_" preprended to the name.
+    /// Equivalent to `getMappedName` but with "T_" preprended to the name.
     std::string getMetaTypeName(const ContainedPtr& p);
 
-    /// Equivalent to ::getAbsolute but with "T_" preprended to the name.
+    /// Equivalent to `getAbsolute` but with "T_" preprended to the name.
     std::string getMetaTypeReference(const ContainedPtr& p);
 
     /// Emits a comment header for a generated file.

--- a/cpp/src/slice2rb/RubyUtil.h
+++ b/cpp/src/slice2rb/RubyUtil.h
@@ -10,7 +10,7 @@ namespace Slice::Ruby
 {
     /// Generates Ruby code for the provided translation unit.
     void generate(
-        const Slice::UnitPtr& unit,
+        const UnitPtr& unit,
         bool all,
         const std::vector<std::string>& includePaths,
         IceInternal::Output& out);
@@ -31,17 +31,17 @@ namespace Slice::Ruby
     /// Returns the mapped name of the provided Slice element.
     /// If the element has 'ruby:identifier' metadata on it, the metadata's argument is returned as-is.
     /// Otherwise, the slice name is returned, after its casing has been fixed according to the provided @p style.
-    std::string getMappedName(const Slice::ContainedPtr& p, IdentStyle style = IdentNormal);
+    std::string getMappedName(const ContainedPtr& p, IdentStyle style = IdentNormal);
 
     /// Returns the fully-qualified mapped-identifier of the provided Slice element.
     /// This is equivalent to calling ::getMappedName on @p p and all it's containers.
-    std::string getAbsolute(const Slice::ContainedPtr& p);
+    std::string getAbsolute(const ContainedPtr& p);
 
     /// Equivalent to ::getMappedName but with "T_" preprended to the name.
-    std::string getMetaTypeName(const Slice::ContainedPtr& p);
+    std::string getMetaTypeName(const ContainedPtr& p);
 
     /// Equivalent to ::getAbsolute but with "T_" preprended to the name.
-    std::string getMetaTypeReference(const Slice::ContainedPtr& p);
+    std::string getMetaTypeReference(const ContainedPtr& p);
 
     /// Emits a comment header for a generated file.
     void printHeader(IceInternal::Output& out);

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -1364,7 +1364,7 @@ Gen::TypesVisitor::visitOperation(const OperationPtr& op)
     out << eb;
 }
 
-Gen::ServantVisitor::ServantVisitor(::IceInternal::Output& o) : out(o) {}
+Gen::ServantVisitor::ServantVisitor(IceInternal::Output& o) : out(o) {}
 
 bool
 Gen::ServantVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
@@ -1433,7 +1433,7 @@ Gen::ServantVisitor::visitOperation(const OperationPtr& op)
     }
 }
 
-Gen::ServantExtVisitor::ServantExtVisitor(::IceInternal::Output& o) : out(o) {}
+Gen::ServantExtVisitor::ServantExtVisitor(IceInternal::Output& o) : out(o) {}
 
 bool
 Gen::ServantExtVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -20,9 +20,9 @@ using namespace IceInternal;
 
 namespace
 {
-    string getClassResolverPrefix(const UnitPtr& p)
+    string getClassResolverPrefix(const UnitPtr& unit)
     {
-        DefinitionContextPtr dc = p->findDefinitionContext(p->topLevelFile());
+        DefinitionContextPtr dc = unit->findDefinitionContext(unit->topLevelFile());
         assert(dc);
         return dc->getMetadataArgs("swift:class-resolver-prefix").value_or("");
     }
@@ -93,23 +93,23 @@ Gen::~Gen()
 }
 
 void
-Gen::generate(const UnitPtr& p)
+Gen::generate(const UnitPtr& unit)
 {
-    validateSwiftMetadata(p);
-    validateSwiftModuleMappings(p);
+    validateSwiftMetadata(unit);
+    validateSwiftModuleMappings(unit);
 
     ImportVisitor importVisitor(_out);
-    p->visit(&importVisitor);
+    unit->visit(&importVisitor);
     importVisitor.writeImports();
 
     TypesVisitor typesVisitor(_out);
-    p->visit(&typesVisitor);
+    unit->visit(&typesVisitor);
 
     ServantVisitor servantVisitor(_out);
-    p->visit(&servantVisitor);
+    unit->visit(&servantVisitor);
 
     ServantExtVisitor servantExtVisitor(_out);
-    p->visit(&servantExtVisitor);
+    unit->visit(&servantExtVisitor);
 }
 
 void
@@ -344,7 +344,7 @@ Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 
         for (const auto& member : members)
         {
-            if (!member->optional())
+            if (!member->isOptional())
             {
                 writeMarshalUnmarshalCode(out, member->type(), p, "iceP_self." + member->mappedName(), false);
             }
@@ -376,7 +376,7 @@ Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     for (const auto& member : members)
     {
         TypePtr type = member->type();
-        if (!member->optional())
+        if (!member->isOptional())
         {
             writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->mappedName(), true);
         }
@@ -478,7 +478,7 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
         << ".ice_staticId(), compactId: -1, last: " << (!base ? "true" : "false") << ")";
     for (const auto& member : members)
     {
-        if (!member->optional())
+        if (!member->isOptional())
         {
             writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->mappedName(), true);
         }
@@ -502,7 +502,7 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     out << nl << "_ = try istr.startSlice()";
     for (const auto& member : members)
     {
-        if (!member->optional())
+        if (!member->isOptional())
         {
             writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->mappedName(), false);
         }
@@ -1294,7 +1294,7 @@ Gen::TypesVisitor::visitOperation(const OperationPtr& op)
     out << spar;
     for (const auto& param : inParams)
     {
-        const bool isOptional = param->optional();
+        const bool isOptional = param->isOptional();
         const string typeString = typeToString(param->type(), op, isOptional);
         const string paramName = "iceP_" + removeEscaping(param->mappedName());
         const string paramLabel = (inParams.size() == 1 ? "_" : param->mappedName());
@@ -1420,7 +1420,7 @@ Gen::ServantVisitor::visitOperation(const OperationPtr& op)
     out << spar;
     for (const auto& param : op->inParameters())
     {
-        const string typeString = typeToString(param->type(), op, param->optional());
+        const string typeString = typeToString(param->type(), op, param->isOptional());
         out << param->mappedName() + ": " + (param->type()->usesClasses() ? "sending " : "") + typeString;
     }
     out << ("current: " + getUnqualified("Ice.Current", swiftModule));

--- a/cpp/src/slice2swift/Gen.h
+++ b/cpp/src/slice2swift/Gen.h
@@ -10,13 +10,13 @@ namespace Slice
     class Gen final
     {
     public:
-        Gen(const std::string&, const std::string&);
+        Gen(const std::string& base, const std::string& dir);
         Gen(const Gen&) = delete;
         ~Gen();
 
         Gen& operator=(const Gen&) = delete;
 
-        void generate(const UnitPtr&);
+        void generate(const UnitPtr& unit);
         void printHeader();
 
     private:

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -1214,7 +1214,7 @@ Slice::Swift::operationReturnDeclaration(const OperationPtr& op)
 }
 
 void
-Slice::Swift::writeMarshalInParams(::IceInternal::Output& out, const OperationPtr& op)
+Slice::Swift::writeMarshalInParams(IceInternal::Output& out, const OperationPtr& op)
 {
     // Marshal parameters in this order '(required..., optional...)'.
 
@@ -1234,7 +1234,7 @@ Slice::Swift::writeMarshalInParams(::IceInternal::Output& out, const OperationPt
 }
 
 void
-Slice::Swift::writeMarshalAsyncOutParams(::IceInternal::Output& out, const OperationPtr& op)
+Slice::Swift::writeMarshalAsyncOutParams(IceInternal::Output& out, const OperationPtr& op)
 {
     // Marshal parameters in this order '(required..., optional...)'.
 
@@ -1256,7 +1256,7 @@ Slice::Swift::writeMarshalAsyncOutParams(::IceInternal::Output& out, const Opera
 }
 
 void
-Slice::Swift::writeUnmarshalOutParams(::IceInternal::Output& out, const OperationPtr& op)
+Slice::Swift::writeUnmarshalOutParams(IceInternal::Output& out, const OperationPtr& op)
 {
     // We need a separate nested function for the nonisolated(unsafe) variable when unmarshaling classes.
 
@@ -1321,7 +1321,7 @@ Slice::Swift::writeUnmarshalOutParams(::IceInternal::Output& out, const Operatio
 }
 
 void
-Slice::Swift::writeUnmarshalInParams(::IceInternal::Output& out, const OperationPtr& op)
+Slice::Swift::writeUnmarshalInParams(IceInternal::Output& out, const OperationPtr& op)
 {
     // Unmarshal parameters in this order '(required..., optional...)'.
 
@@ -1350,7 +1350,7 @@ Slice::Swift::writeUnmarshalInParams(::IceInternal::Output& out, const Operation
 }
 
 void
-Slice::Swift::writeUnmarshalUserException(::IceInternal::Output& out, const OperationPtr& op)
+Slice::Swift::writeUnmarshalUserException(IceInternal::Output& out, const OperationPtr& op)
 {
     const string swiftModule = getSwiftModule(op->getTopLevelModule());
 
@@ -1380,7 +1380,7 @@ Slice::Swift::writeUnmarshalUserException(::IceInternal::Output& out, const Oper
 }
 
 void
-Slice::Swift::writeSwiftAttributes(::IceInternal::Output& out, const MetadataList& metadata)
+Slice::Swift::writeSwiftAttributes(IceInternal::Output& out, const MetadataList& metadata)
 {
     for (const auto& meta : metadata)
     {

--- a/cpp/src/slice2swift/SwiftUtil.cpp
+++ b/cpp/src/slice2swift/SwiftUtil.cpp
@@ -368,7 +368,7 @@ Slice::Swift::swiftLinkFormatter(const string& rawLink, const ContainedPtr& sour
 }
 
 void
-Slice::Swift::validateSwiftMetadata(const UnitPtr& u)
+Slice::Swift::validateSwiftMetadata(const UnitPtr& unit)
 {
     map<string, MetadataInfo> knownMetadata;
 
@@ -426,7 +426,7 @@ Slice::Swift::validateSwiftMetadata(const UnitPtr& u)
     knownMetadata.emplace("swift:module", moduleInfo);
 
     // Pass this information off to the parser's metadata validation logic.
-    Slice::validateMetadata(u, "swift", std::move(knownMetadata));
+    Slice::validateMetadata(unit, "swift", std::move(knownMetadata));
 }
 
 void
@@ -799,7 +799,7 @@ Slice::Swift::writeMemberwiseInitializer(
                 out << ", ";
             }
 
-            out << m->mappedName() << ": " << typeToString(m->type(), p, m->optional());
+            out << m->mappedName() << ": " << typeToString(m->type(), p, m->isOptional());
             if (m->defaultValueType())
             {
                 out << " = ";
@@ -809,7 +809,7 @@ Slice::Swift::writeMemberwiseInitializer(
                     m->defaultValueType(),
                     m->defaultValue().value_or(""),
                     getSwiftModule(p->getTopLevelModule()),
-                    m->optional());
+                    m->isOptional());
             }
         }
         out << ")";
@@ -844,7 +844,7 @@ Slice::Swift::writeMembers(IceInternal::Output& out, const DataMemberList& membe
         TypePtr type = member->type();
 
         const string memberName = member->mappedName();
-        string memberType = typeToString(type, p, member->optional());
+        string memberType = typeToString(type, p, member->isOptional());
 
         // If the member type is equal to the member name, create a local type alias to avoid ambiguity.
         string alias;
@@ -866,7 +866,7 @@ Slice::Swift::writeMembers(IceInternal::Output& out, const DataMemberList& membe
                 member->defaultValueType(),
                 member->defaultValue().value_or(""),
                 swiftModule,
-                member->optional());
+                member->isOptional());
         }
         else
         {
@@ -1166,7 +1166,7 @@ Slice::Swift::operationReturnType(const OperationPtr& op)
             os << (*q)->mappedName() << ": ";
         }
 
-        os << typeToString((*q)->type(), *q, (*q)->optional());
+        os << typeToString((*q)->type(), *q, (*q)->isOptional());
     }
 
     if (returnIsTuple)
@@ -1177,7 +1177,7 @@ Slice::Swift::operationReturnType(const OperationPtr& op)
     return os.str();
 }
 
-std::string
+string
 Slice::Swift::operationReturnDeclaration(const OperationPtr& op)
 {
     ostringstream os;
@@ -1276,7 +1276,7 @@ Slice::Swift::writeUnmarshalOutParams(::IceInternal::Output& out, const Operatio
     for (const auto& param : op->sortedReturnAndOutParameters(getEscapedParamName(op->outParameters(), "returnValue")))
     {
         const TypePtr paramType = param->type();
-        const string typeString = typeToString(paramType, op, param->optional());
+        const string typeString = typeToString(paramType, op, param->isOptional());
         const string paramName = "iceP_" + removeEscaping(param->mappedName());
         string paramString;
         if (paramType->isClassType())
@@ -1329,7 +1329,7 @@ Slice::Swift::writeUnmarshalInParams(::IceInternal::Output& out, const Operation
     {
         const TypePtr paramType = param->type();
         const string paramName = "iceP_" + removeEscaping(param->mappedName());
-        const string typeString = typeToString(paramType, op, param->optional());
+        const string typeString = typeToString(paramType, op, param->isOptional());
         string paramString;
         if (paramType->isClassType())
         {

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -79,12 +79,12 @@ namespace Slice::Swift
         std::int32_t tag = -1);
 
     bool usesMarshalHelper(const TypePtr& type);
-    void writeMarshalInParams(::IceInternal::Output& out, const OperationPtr& op);
-    void writeMarshalAsyncOutParams(::IceInternal::Output& out, const OperationPtr& op);
-    void writeUnmarshalInParams(::IceInternal::Output& out, const OperationPtr& op);
-    void writeUnmarshalOutParams(::IceInternal::Output& out, const OperationPtr& op);
-    void writeUnmarshalUserException(::IceInternal::Output& out, const OperationPtr& op);
-    void writeSwiftAttributes(::IceInternal::Output& out, const MetadataList& metadata);
+    void writeMarshalInParams(IceInternal::Output& out, const OperationPtr& op);
+    void writeMarshalAsyncOutParams(IceInternal::Output& out, const OperationPtr& op);
+    void writeUnmarshalInParams(IceInternal::Output& out, const OperationPtr& op);
+    void writeUnmarshalOutParams(IceInternal::Output& out, const OperationPtr& op);
+    void writeUnmarshalUserException(IceInternal::Output& out, const OperationPtr& op);
+    void writeSwiftAttributes(IceInternal::Output& out, const MetadataList& metadata);
 }
 
 #endif

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -10,40 +10,40 @@ using StringPairList = std::list<std::pair<std::string, std::string>>;
 
 namespace Slice::Swift
 {
-    std::string getSwiftModule(const ModulePtr&, std::string&);
-    std::string getSwiftModule(const ModulePtr&);
+    std::string getSwiftModule(const ModulePtr& module, std::string& swiftPrefix);
+    std::string getSwiftModule(const ModulePtr& module);
 
     /// Returns a DocC formatted link for the given Slice identifier.
     std::string
     swiftLinkFormatter(const std::string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target);
 
-    void validateSwiftMetadata(const UnitPtr&);
+    void validateSwiftMetadata(const UnitPtr& unit);
 
     // Swift only allows 1 package per file, so this function checks that if there are multiple top-level-modules
     // within a single Slice file, that they all map to the same Swift package.
-    void validateSwiftModuleMappings(const UnitPtr&);
+    void validateSwiftModuleMappings(const UnitPtr& unit);
 
     /// Removes any Swift escaping from the provided identifier (any leading or trailing backticks will be removed).
     std::string removeEscaping(std::string ident);
 
     void writeDocSummary(
-        IceInternal::Output&,
-        const ContainedPtr&,
+        IceInternal::Output& out,
+        const ContainedPtr& p,
         const std::optional<std::string>& generatedType = std::nullopt);
 
-    void writeOpDocSummary(IceInternal::Output&, const OperationPtr&, bool);
+    void writeOpDocSummary(IceInternal::Output& out, const OperationPtr& p, bool dispatch);
 
-    std::string paramLabel(const std::string&, const ParameterList&);
-    std::string operationReturnType(const OperationPtr&);
-    std::string operationReturnDeclaration(const OperationPtr&);
+    std::string paramLabel(const std::string& param, const ParameterList& params);
+    std::string operationReturnType(const OperationPtr& op);
+    std::string operationReturnDeclaration(const OperationPtr& op);
 
-    std::string typeToString(const TypePtr&, const ContainedPtr&, bool = false);
+    std::string typeToString(const TypePtr& type, const ContainedPtr& usedBy, bool optional = false);
 
-    std::string getUnqualified(const std::string&, const std::string&);
-    std::string modeToString(Operation::Mode);
-    std::string getOptionalFormat(const TypePtr&);
+    std::string getUnqualified(const std::string& type, const std::string& localModule);
+    std::string modeToString(Operation::Mode opMode);
+    std::string getOptionalFormat(const TypePtr& type);
 
-    bool isNullableType(const TypePtr&);
+    bool isNullableType(const TypePtr& type);
 
     /// Returns a string representing the Swift type `contained` maps to.
     ///
@@ -51,40 +51,40 @@ namespace Slice::Swift
     /// Otherwise, the type-string is qualified relative to `currentModule`.
     std::string getRelativeTypeString(const ContainedPtr& contained, const std::string& currentModule = "");
 
-    std::string getValue(const std::string&, const TypePtr&);
+    std::string getValue(const std::string& swiftModule, const TypePtr& type);
     void writeConstantValue(
         IceInternal::Output& out,
-        const TypePtr&,
-        const SyntaxTreeBasePtr&,
-        const std::string&,
-        const std::string&,
+        const TypePtr& type,
+        const SyntaxTreeBasePtr& valueType,
+        const std::string& value,
+        const std::string& swiftModule,
         bool optional = false);
-    void writeDefaultInitializer(IceInternal::Output&, bool, bool);
-    void writeMemberwiseInitializer(IceInternal::Output&, const DataMemberList&, const ContainedPtr&);
+    void writeDefaultInitializer(IceInternal::Output& out, bool required, bool rootClass);
+    void writeMemberwiseInitializer(IceInternal::Output& out, const DataMemberList& members, const ContainedPtr& p);
     void writeMemberwiseInitializer(
-        IceInternal::Output&,
-        const DataMemberList&,
-        const DataMemberList&,
-        const DataMemberList&,
-        const ContainedPtr&,
+        IceInternal::Output& out,
+        const DataMemberList& members,
+        const DataMemberList& baseMembers,
+        const DataMemberList& allMembers,
+        const ContainedPtr& p,
         bool rootClass);
-    void writeMembers(IceInternal::Output&, const DataMemberList&, const ContainedPtr&);
+    void writeMembers(IceInternal::Output& out, const DataMemberList& members, const ContainedPtr& p);
 
     void writeMarshalUnmarshalCode(
-        ::IceInternal::Output&,
-        const TypePtr&,
-        const ContainedPtr&,
-        const std::string&,
-        bool,
-        std::int32_t = -1);
+        ::IceInternal::Output& out,
+        const TypePtr& type,
+        const ContainedPtr& p,
+        const std::string& param,
+        bool marshal,
+        std::int32_t tag = -1);
 
-    bool usesMarshalHelper(const TypePtr&);
-    void writeMarshalInParams(::IceInternal::Output&, const OperationPtr&);
-    void writeMarshalAsyncOutParams(::IceInternal::Output&, const OperationPtr&);
-    void writeUnmarshalInParams(::IceInternal::Output&, const OperationPtr&);
-    void writeUnmarshalOutParams(::IceInternal::Output&, const OperationPtr&);
-    void writeUnmarshalUserException(::IceInternal::Output& out, const OperationPtr&);
-    void writeSwiftAttributes(::IceInternal::Output&, const MetadataList&);
+    bool usesMarshalHelper(const TypePtr& type);
+    void writeMarshalInParams(::IceInternal::Output& out, const OperationPtr& op);
+    void writeMarshalAsyncOutParams(::IceInternal::Output& out, const OperationPtr& op);
+    void writeUnmarshalInParams(::IceInternal::Output& out, const OperationPtr& op);
+    void writeUnmarshalOutParams(::IceInternal::Output& out, const OperationPtr& op);
+    void writeUnmarshalUserException(::IceInternal::Output& out, const OperationPtr& op);
+    void writeSwiftAttributes(::IceInternal::Output& out, const MetadataList& metadata);
 }
 
 #endif

--- a/cpp/src/slice2swift/SwiftUtil.h
+++ b/cpp/src/slice2swift/SwiftUtil.h
@@ -71,7 +71,7 @@ namespace Slice::Swift
     void writeMembers(IceInternal::Output& out, const DataMemberList& members, const ContainedPtr& p);
 
     void writeMarshalUnmarshalCode(
-        ::IceInternal::Output& out,
+        IceInternal::Output& out,
         const TypePtr& type,
         const ContainedPtr& p,
         const std::string& param,


### PR DESCRIPTION
This PR is an exercise in consistency: a cleaning-up of small things that I've been wanting to do a little while:
- Changed the name of `UnitPtr` parameters to `unit` everywhere (instead of a mix of `u`, `un`, `ut`, `p`, and `unit`)
- Renamed `optional()` to `isOptional()` for correctness and to avoid ambiguity with `std::optional`
- Removes unnecessary overqualification (`Slice::` and `std::` in source files which are `using Slice` or `using std`)
  - Except for function calls like `std::move`, `std::stoll`, etc.
  - And except for `Slice::Exception`, which we always qualify to avoid any confusion with real exceptions
- Removed any leading `::` global scope markers (like `::IceInternal::Output` -> `IceInternal::Output`)
- Adds missing parameter names to the header files
  - Except for deleted functions, copy/move constructors, and the visitXXX functions