### PR TITLE
Have `rewrite` Fail Upon Parsing Errors

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -112,7 +112,9 @@ rewrite {
     activeRecipe('com.zeroc.IceRewriteRecipes')
     activeStyle('com.zeroc.IceRewriteStyle')
 
-    setExportDatatables(true)
+    exportDatatables = true
+    throwOnParseFailures = true
+
     exclusion(
         // OpenRewrite is technically capable of modifying Groovy and Kotlin files, but we are avoiding this for now.
         '**/*.gradle',

--- a/java/test/android/controller/build.gradle
+++ b/java/test/android/controller/build.gradle
@@ -141,7 +141,9 @@ rewrite {
     activeRecipe('com.zeroc.IceRewriteRecipes')
     activeStyle('com.zeroc.IceRewriteStyle')
 
-    setExportDatatables(true)
+    throwOnParseFailures = true
+    exportDatatables = true
+
     exclusion(
         // OpenRewrite is technically capable of modifying Groovy and Kotlin files, but we are avoiding this for now.
         '**/*.gradle',

--- a/java/tools/slice-tools/build.gradle.kts
+++ b/java/tools/slice-tools/build.gradle.kts
@@ -125,6 +125,8 @@ tasks.withType<Checkstyle>().configureEach {
 rewrite {
     activeRecipe("com.zeroc.IceRewriteRecipes")
     activeStyle("com.zeroc.IceRewriteStyle")
+
+    throwOnParseFailures = true
 }
 
 // Set whether or not 'rewriteDryRun' should be considered 'failed' when it would make changes.


### PR DESCRIPTION
This PR (in theory) fixes #4732.

`rewrite` is a tool we use to check our Java formatting, and sometimes, formatting mistakes will cause it to "fail to parse"
 a source file. Despite the seeming severity of this, gradle counts the task as "successful" when this happens.

Instead, we want any kind of formatting mistake, or parsing mistake, to trigger a build failure, so we see it in CI.
`rewrite` has an option to configure this: `throwOnParseFailures` (which defaults to false). This PR sets this option to `true`.

----

But...
Setting this to true makes no difference. To the best of my knowledge, there's actually a bug in the rewrite gradle plugin where it ignores this option. I opened an issue to address this with the plugin itself: https://github.com/openrewrite/rewrite-gradle-plugin/issues/441.
Regardless of the bug, we should be setting this option in our configuration.