### PR TITLE
Move Code-Gen Visitors out of 'Gen' Classes

### DIFF
--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -1183,10 +1183,7 @@ Slice::SliceLoaderVisitor::visitExceptionStart(const ExceptionPtr& p)
     return false;
 }
 
-Slice::ProxyVisitor::ProxyVisitor(Output& h, Output& c, string dllExport)
-    : H(h),
-      C(c),
-      _dllExport(std::move(dllExport))
+Slice::ProxyVisitor::ProxyVisitor(Output& h, Output& c, string dllExport) : H(h), C(c), _dllExport(std::move(dllExport))
 {
 }
 
@@ -2481,11 +2478,7 @@ Slice::DataDefVisitor::printFields(const DataMemberList& fields, bool firstField
     }
 }
 
-Slice::InterfaceVisitor::InterfaceVisitor(
-    IceInternal::Output& h,
-    IceInternal::Output& c,
-    string dllExport,
-    bool async)
+Slice::InterfaceVisitor::InterfaceVisitor(IceInternal::Output& h, IceInternal::Output& c, string dllExport, bool async)
     : H(h),
       C(c),
       _dllExport(std::move(dllExport)),

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -859,7 +859,7 @@ Slice::Gen::getSourceExt(string_view file, const UnitPtr& unit)
     return dc->getMetadataArgs("cpp:source-ext").value_or("");
 }
 
-Slice::Gen::ForwardDeclVisitor::ForwardDeclVisitor(Output& h, Output& c, string dllExport)
+Slice::ForwardDeclVisitor::ForwardDeclVisitor(Output& h, Output& c, string dllExport)
     : H(h),
       C(c),
       _dllExport(std::move(dllExport))
@@ -867,9 +867,9 @@ Slice::Gen::ForwardDeclVisitor::ForwardDeclVisitor(Output& h, Output& c, string 
 }
 
 bool
-Slice::Gen::ForwardDeclVisitor::visitModuleStart(const ModulePtr& p)
+Slice::ForwardDeclVisitor::visitModuleStart(const ModulePtr& p)
 {
-    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
+    _useWstring = Gen::setUseWstring(p, _useWstringHist, _useWstring);
     H << sp;
     writeDocSummary(H, p);
     H << nl << "namespace " << p->mappedName() << nl << '{';
@@ -878,15 +878,15 @@ Slice::Gen::ForwardDeclVisitor::visitModuleStart(const ModulePtr& p)
 }
 
 void
-Slice::Gen::ForwardDeclVisitor::visitModuleEnd(const ModulePtr&)
+Slice::ForwardDeclVisitor::visitModuleEnd(const ModulePtr&)
 {
     H.dec();
     H << nl << '}';
-    _useWstring = resetUseWstring(_useWstringHist);
+    _useWstring = Gen::resetUseWstring(_useWstringHist);
 }
 
 void
-Slice::Gen::ForwardDeclVisitor::visitClassDecl(const ClassDeclPtr& p)
+Slice::ForwardDeclVisitor::visitClassDecl(const ClassDeclPtr& p)
 {
     if (_firstElement)
     {
@@ -906,7 +906,7 @@ Slice::Gen::ForwardDeclVisitor::visitClassDecl(const ClassDeclPtr& p)
 }
 
 bool
-Slice::Gen::ForwardDeclVisitor::visitStructStart(const StructPtr& p)
+Slice::ForwardDeclVisitor::visitStructStart(const StructPtr& p)
 {
     if (_firstElement)
     {
@@ -922,7 +922,7 @@ Slice::Gen::ForwardDeclVisitor::visitStructStart(const StructPtr& p)
 }
 
 void
-Slice::Gen::ForwardDeclVisitor::visitInterfaceDecl(const InterfaceDeclPtr& p)
+Slice::ForwardDeclVisitor::visitInterfaceDecl(const InterfaceDeclPtr& p)
 {
     if (_firstElement)
     {
@@ -937,7 +937,7 @@ Slice::Gen::ForwardDeclVisitor::visitInterfaceDecl(const InterfaceDeclPtr& p)
 }
 
 void
-Slice::Gen::ForwardDeclVisitor::visitEnum(const EnumPtr& p)
+Slice::ForwardDeclVisitor::visitEnum(const EnumPtr& p)
 {
     if (_firstElement)
     {
@@ -1027,7 +1027,7 @@ Slice::Gen::ForwardDeclVisitor::visitEnum(const EnumPtr& p)
 }
 
 void
-Slice::Gen::ForwardDeclVisitor::visitSequence(const SequencePtr& p)
+Slice::ForwardDeclVisitor::visitSequence(const SequencePtr& p)
 {
     if (_firstElement)
     {
@@ -1069,7 +1069,7 @@ Slice::Gen::ForwardDeclVisitor::visitSequence(const SequencePtr& p)
 }
 
 void
-Slice::Gen::ForwardDeclVisitor::visitDictionary(const DictionaryPtr& p)
+Slice::ForwardDeclVisitor::visitDictionary(const DictionaryPtr& p)
 {
     if (_firstElement)
     {
@@ -1107,7 +1107,7 @@ Slice::Gen::ForwardDeclVisitor::visitDictionary(const DictionaryPtr& p)
 }
 
 void
-Slice::Gen::ForwardDeclVisitor::visitConst(const ConstPtr& p)
+Slice::ForwardDeclVisitor::visitConst(const ConstPtr& p)
 {
     if (_firstElement)
     {
@@ -1133,10 +1133,10 @@ Slice::Gen::ForwardDeclVisitor::visitConst(const ConstPtr& p)
     }
 }
 
-Slice::Gen::SliceLoaderVisitor::SliceLoaderVisitor(Output& c) : C(c) {}
+Slice::SliceLoaderVisitor::SliceLoaderVisitor(Output& c) : C(c) {}
 
 bool
-Slice::Gen::SliceLoaderVisitor::visitUnitStart(const UnitPtr& unit)
+Slice::SliceLoaderVisitor::visitUnitStart(const UnitPtr& unit)
 {
     if (unit->contains<ClassDef>() || unit->contains<Exception>())
     {
@@ -1151,14 +1151,14 @@ Slice::Gen::SliceLoaderVisitor::visitUnitStart(const UnitPtr& unit)
 }
 
 void
-Slice::Gen::SliceLoaderVisitor::visitUnitEnd(const UnitPtr&)
+Slice::SliceLoaderVisitor::visitUnitEnd(const UnitPtr&)
 {
     C.dec();
     C << nl << "}";
 }
 
 bool
-Slice::Gen::SliceLoaderVisitor::visitClassDefStart(const ClassDefPtr& p)
+Slice::SliceLoaderVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
     const string scopedName = p->mappedScoped("::", true);
     const string flatScopedName = p->mappedScoped("_", true);
@@ -1174,7 +1174,7 @@ Slice::Gen::SliceLoaderVisitor::visitClassDefStart(const ClassDefPtr& p)
 }
 
 bool
-Slice::Gen::SliceLoaderVisitor::visitExceptionStart(const ExceptionPtr& p)
+Slice::SliceLoaderVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
     const string scopedName = p->mappedScoped("::", true);
     const string flatScopedName = p->mappedScoped("_", true);
@@ -1183,7 +1183,7 @@ Slice::Gen::SliceLoaderVisitor::visitExceptionStart(const ExceptionPtr& p)
     return false;
 }
 
-Slice::Gen::ProxyVisitor::ProxyVisitor(Output& h, Output& c, string dllExport)
+Slice::ProxyVisitor::ProxyVisitor(Output& h, Output& c, string dllExport)
     : H(h),
       C(c),
       _dllExport(std::move(dllExport))
@@ -1191,14 +1191,14 @@ Slice::Gen::ProxyVisitor::ProxyVisitor(Output& h, Output& c, string dllExport)
 }
 
 bool
-Slice::Gen::ProxyVisitor::visitModuleStart(const ModulePtr& p)
+Slice::ProxyVisitor::visitModuleStart(const ModulePtr& p)
 {
     if (!p->contains<InterfaceDef>())
     {
         return false;
     }
 
-    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
+    _useWstring = Gen::setUseWstring(p, _useWstringHist, _useWstring);
 
     H << sp << nl << "namespace " << p->mappedName() << nl << '{';
     H.inc();
@@ -1206,16 +1206,16 @@ Slice::Gen::ProxyVisitor::visitModuleStart(const ModulePtr& p)
 }
 
 void
-Slice::Gen::ProxyVisitor::visitModuleEnd(const ModulePtr&)
+Slice::ProxyVisitor::visitModuleEnd(const ModulePtr&)
 {
     H.dec();
     H << nl << '}';
 
-    _useWstring = resetUseWstring(_useWstringHist);
+    _useWstring = Gen::resetUseWstring(_useWstringHist);
 }
 
 bool
-Slice::Gen::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
+Slice::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     if (_firstElement)
     {
@@ -1226,7 +1226,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         H << sp;
     }
 
-    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
+    _useWstring = Gen::setUseWstring(p, _useWstringHist, _useWstring);
 
     const string scope = p->mappedScope("::", true);
     const string prx = p->mappedName() + "Prx";
@@ -1326,7 +1326,7 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 }
 
 void
-Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
+Slice::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 {
     const string prx = p->mappedName() + "Prx";
     const string scopedPrx = p->mappedScoped("::") + "Prx";
@@ -1372,11 +1372,11 @@ Slice::Gen::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 
     H << eb << ';';
 
-    _useWstring = resetUseWstring(_useWstringHist);
+    _useWstring = Gen::resetUseWstring(_useWstringHist);
 }
 
 void
-Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
+Slice::ProxyVisitor::visitOperation(const OperationPtr& p)
 {
     const InterfaceDefPtr container = p->interface();
     const string opName = p->mappedName();
@@ -1633,7 +1633,7 @@ Slice::Gen::ProxyVisitor::visitOperation(const OperationPtr& p)
 }
 
 void
-Slice::Gen::ProxyVisitor::emitOperationImpl(
+Slice::ProxyVisitor::emitOperationImpl(
     const OperationPtr& p,
     const string& prefix,
     const vector<string>& outgoingAsyncParams)
@@ -1759,7 +1759,7 @@ Slice::Gen::ProxyVisitor::emitOperationImpl(
     C << ");" << eb;
 }
 
-Slice::Gen::DataDefVisitor::DataDefVisitor(IceInternal::Output& h, IceInternal::Output& c, string dllExport)
+Slice::DataDefVisitor::DataDefVisitor(IceInternal::Output& h, IceInternal::Output& c, string dllExport)
     : H(h),
       C(c),
       _dllExport(std::move(dllExport))
@@ -1767,21 +1767,21 @@ Slice::Gen::DataDefVisitor::DataDefVisitor(IceInternal::Output& h, IceInternal::
 }
 
 bool
-Slice::Gen::DataDefVisitor::visitModuleStart(const ModulePtr& p)
+Slice::DataDefVisitor::visitModuleStart(const ModulePtr& p)
 {
     if (!p->contains<Struct>() && !p->contains<ClassDef>() && !p->contains<Exception>())
     {
         return false;
     }
 
-    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
+    _useWstring = Gen::setUseWstring(p, _useWstringHist, _useWstring);
     H << sp << nl << "namespace " << p->mappedName() << nl << '{';
     H.inc();
     return true;
 }
 
 void
-Slice::Gen::DataDefVisitor::visitModuleEnd(const ModulePtr& p)
+Slice::DataDefVisitor::visitModuleEnd(const ModulePtr& p)
 {
     if (p->contains<Struct>())
     {
@@ -1800,11 +1800,11 @@ Slice::Gen::DataDefVisitor::visitModuleEnd(const ModulePtr& p)
 
     H.dec();
     H << nl << '}';
-    _useWstring = resetUseWstring(_useWstringHist);
+    _useWstring = Gen::resetUseWstring(_useWstringHist);
 }
 
 bool
-Slice::Gen::DataDefVisitor::visitStructStart(const StructPtr& p)
+Slice::DataDefVisitor::visitStructStart(const StructPtr& p)
 {
     if (_firstElement)
     {
@@ -1815,7 +1815,7 @@ Slice::Gen::DataDefVisitor::visitStructStart(const StructPtr& p)
         H << sp;
     }
 
-    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
+    _useWstring = Gen::setUseWstring(p, _useWstringHist, _useWstring);
 
     writeDocSummary(H, p, {.includeHeaderFile = true, .generatedType = "struct"});
     H << nl << "struct " << getDeprecatedAttribute(p) << p->mappedName();
@@ -1825,7 +1825,7 @@ Slice::Gen::DataDefVisitor::visitStructStart(const StructPtr& p)
 }
 
 void
-Slice::Gen::DataDefVisitor::visitStructEnd(const StructPtr& p)
+Slice::DataDefVisitor::visitStructEnd(const StructPtr& p)
 {
     H << sp;
     H << nl << "/// Creates a tuple with all the fields of this struct.";
@@ -1869,11 +1869,11 @@ Slice::Gen::DataDefVisitor::visitStructEnd(const StructPtr& p)
         C << eb;
     }
 
-    _useWstring = resetUseWstring(_useWstringHist);
+    _useWstring = Gen::resetUseWstring(_useWstringHist);
 }
 
 void
-Slice::Gen::DataDefVisitor::visitDataMember(const DataMemberPtr& p)
+Slice::DataDefVisitor::visitDataMember(const DataMemberPtr& p)
 {
     auto container = p->container();
     if (dynamic_pointer_cast<Struct>(container) || dynamic_pointer_cast<Exception>(container))
@@ -1884,7 +1884,7 @@ Slice::Gen::DataDefVisitor::visitDataMember(const DataMemberPtr& p)
 }
 
 bool
-Slice::Gen::DataDefVisitor::visitExceptionStart(const ExceptionPtr& p)
+Slice::DataDefVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
     if (_firstElement)
     {
@@ -1895,7 +1895,7 @@ Slice::Gen::DataDefVisitor::visitExceptionStart(const ExceptionPtr& p)
         H << sp;
     }
 
-    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
+    _useWstring = Gen::setUseWstring(p, _useWstringHist, _useWstring);
 
     const string name = p->mappedName();
     const string scope = p->mappedScope("::", true);
@@ -2087,7 +2087,7 @@ Slice::Gen::DataDefVisitor::visitExceptionStart(const ExceptionPtr& p)
 }
 
 void
-Slice::Gen::DataDefVisitor::visitExceptionEnd(const ExceptionPtr& p)
+Slice::DataDefVisitor::visitExceptionEnd(const ExceptionPtr& p)
 {
     const string scope = p->mappedScope("::", true);
     const string scoped = p->mappedScoped("::");
@@ -2136,11 +2136,11 @@ Slice::Gen::DataDefVisitor::visitExceptionEnd(const ExceptionPtr& p)
 
     H << eb << ';';
 
-    _useWstring = resetUseWstring(_useWstringHist);
+    _useWstring = Gen::resetUseWstring(_useWstringHist);
 }
 
 bool
-Slice::Gen::DataDefVisitor::visitClassDefStart(const ClassDefPtr& p)
+Slice::DataDefVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
     if (_firstElement)
     {
@@ -2151,7 +2151,7 @@ Slice::Gen::DataDefVisitor::visitClassDefStart(const ClassDefPtr& p)
         H << sp;
     }
 
-    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
+    _useWstring = Gen::setUseWstring(p, _useWstringHist, _useWstring);
 
     const string name = p->mappedName();
     const string scope = p->mappedScope("::", true);
@@ -2240,7 +2240,7 @@ Slice::Gen::DataDefVisitor::visitClassDefStart(const ClassDefPtr& p)
 }
 
 void
-Slice::Gen::DataDefVisitor::visitClassDefEnd(const ClassDefPtr& p)
+Slice::DataDefVisitor::visitClassDefEnd(const ClassDefPtr& p)
 {
     const string name = p->mappedName();
     const string scoped = p->mappedScoped("::");
@@ -2313,11 +2313,11 @@ Slice::Gen::DataDefVisitor::visitClassDefEnd(const ClassDefPtr& p)
 
     H << eb << ';';
 
-    _useWstring = resetUseWstring(_useWstringHist);
+    _useWstring = Gen::resetUseWstring(_useWstringHist);
 }
 
 bool
-Slice::Gen::DataDefVisitor::emitBaseInitializers(const ClassDefPtr& p)
+Slice::DataDefVisitor::emitBaseInitializers(const ClassDefPtr& p)
 {
     ClassDefPtr base = p->base();
     if (!base)
@@ -2349,7 +2349,7 @@ Slice::Gen::DataDefVisitor::emitBaseInitializers(const ClassDefPtr& p)
 }
 
 void
-Slice::Gen::DataDefVisitor::emitOneShotConstructor(const ClassDefPtr& p)
+Slice::DataDefVisitor::emitOneShotConstructor(const ClassDefPtr& p)
 {
     DataMemberList allDataMembers = p->allDataMembers();
 
@@ -2426,7 +2426,7 @@ Slice::Gen::DataDefVisitor::emitOneShotConstructor(const ClassDefPtr& p)
 }
 
 void
-Slice::Gen::DataDefVisitor::emitDataMember(const DataMemberPtr& p)
+Slice::DataDefVisitor::emitDataMember(const DataMemberPtr& p)
 {
     const string name = p->mappedName();
 
@@ -2463,7 +2463,7 @@ Slice::Gen::DataDefVisitor::emitDataMember(const DataMemberPtr& p)
 }
 
 void
-Slice::Gen::DataDefVisitor::printFields(const DataMemberList& fields, bool firstField)
+Slice::DataDefVisitor::printFields(const DataMemberList& fields, bool firstField)
 {
     for (const auto& field : fields)
     {
@@ -2481,7 +2481,7 @@ Slice::Gen::DataDefVisitor::printFields(const DataMemberList& fields, bool first
     }
 }
 
-Slice::Gen::InterfaceVisitor::InterfaceVisitor(
+Slice::InterfaceVisitor::InterfaceVisitor(
     IceInternal::Output& h,
     IceInternal::Output& c,
     string dllExport,
@@ -2494,30 +2494,30 @@ Slice::Gen::InterfaceVisitor::InterfaceVisitor(
 }
 
 bool
-Slice::Gen::InterfaceVisitor::visitModuleStart(const ModulePtr& p)
+Slice::InterfaceVisitor::visitModuleStart(const ModulePtr& p)
 {
     if (!p->contains<InterfaceDef>())
     {
         return false;
     }
 
-    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
+    _useWstring = Gen::setUseWstring(p, _useWstringHist, _useWstring);
     H << sp << nl << "namespace " << p->mappedName() << nl << '{';
     H.inc();
     return true;
 }
 
 void
-Slice::Gen::InterfaceVisitor::visitModuleEnd(const ModulePtr&)
+Slice::InterfaceVisitor::visitModuleEnd(const ModulePtr&)
 {
     H.dec();
     H << nl << '}';
 
-    _useWstring = resetUseWstring(_useWstringHist);
+    _useWstring = Gen::resetUseWstring(_useWstringHist);
 }
 
 bool
-Slice::Gen::InterfaceVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
+Slice::InterfaceVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     if (_firstElement)
     {
@@ -2528,7 +2528,7 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         H << sp;
     }
 
-    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
+    _useWstring = Gen::setUseWstring(p, _useWstringHist, _useWstring);
     const string name = prependSkeletonPrefix(p->mappedName());
     const string scope = p->mappedScope("::", true);
     const string scoped = p->mappedScope("::") + name;
@@ -2669,7 +2669,7 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 }
 
 void
-Slice::Gen::InterfaceVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
+Slice::InterfaceVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 {
     const string name = prependSkeletonPrefix(p->mappedName());
     const string scoped = p->mappedScope("::") + name;
@@ -2690,11 +2690,11 @@ Slice::Gen::InterfaceVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     H << nl << "/// A shared pointer to " << getArticleFor(name) << ' ' << name << ".";
     H << nl << "using " << name << "Ptr = std::shared_ptr<" << name << ">;";
 
-    _useWstring = resetUseWstring(_useWstringHist);
+    _useWstring = Gen::resetUseWstring(_useWstringHist);
 }
 
 void
-Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
+Slice::InterfaceVisitor::visitOperation(const OperationPtr& p)
 {
     const string name = p->mappedName();
     const InterfaceDefPtr container = p->interface();
@@ -3058,21 +3058,21 @@ Slice::Gen::InterfaceVisitor::visitOperation(const OperationPtr& p)
 }
 
 string
-Slice::Gen::InterfaceVisitor::skeletonPrefix() const
+Slice::InterfaceVisitor::skeletonPrefix() const
 {
     return _async ? "Async" : "";
 }
 
 string
-Slice::Gen::InterfaceVisitor::prependSkeletonPrefix(const string& name) const
+Slice::InterfaceVisitor::prependSkeletonPrefix(const string& name) const
 {
     return skeletonPrefix() + name;
 }
 
-Slice::Gen::StreamVisitor::StreamVisitor(Output& h) : H(h) {}
+Slice::StreamVisitor::StreamVisitor(Output& h) : H(h) {}
 
 bool
-Slice::Gen::StreamVisitor::visitModuleStart(const ModulePtr& m)
+Slice::StreamVisitor::visitModuleStart(const ModulePtr& m)
 {
     if (!m->contains<Struct>() && !m->contains<Enum>())
     {
@@ -3090,7 +3090,7 @@ Slice::Gen::StreamVisitor::visitModuleStart(const ModulePtr& m)
 }
 
 void
-Slice::Gen::StreamVisitor::visitModuleEnd(const ModulePtr& m)
+Slice::StreamVisitor::visitModuleEnd(const ModulePtr& m)
 {
     if (m->isTopLevel())
     {
@@ -3101,7 +3101,7 @@ Slice::Gen::StreamVisitor::visitModuleEnd(const ModulePtr& m)
 }
 
 bool
-Slice::Gen::StreamVisitor::visitStructStart(const StructPtr& p)
+Slice::StreamVisitor::visitStructStart(const StructPtr& p)
 {
     if (_firstElement)
     {
@@ -3128,7 +3128,7 @@ Slice::Gen::StreamVisitor::visitStructStart(const StructPtr& p)
 }
 
 void
-Slice::Gen::StreamVisitor::visitEnum(const EnumPtr& p)
+Slice::StreamVisitor::visitEnum(const EnumPtr& p)
 {
     if (_firstElement)
     {

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -53,159 +53,159 @@ namespace Slice
         std::vector<std::string> _includePaths;
         std::string _dllExport;
         std::string _dir;
+    };
 
-        // Visitors, in code-generation order.
+    // Visitors, in code-generation order.
 
-        /// Generates forward declarations for classes, proxies and structs. Also generates using aliases for sequences
-        /// and dictionaries, enum definitions and constants, and printTypeName helper functions for sequences and
-        /// dictionaries.
-        class ForwardDeclVisitor final : public ParserVisitor
-        {
-        public:
-            ForwardDeclVisitor(IceInternal::Output& h, IceInternal::Output& c, std::string dllExport);
-            ForwardDeclVisitor(const ForwardDeclVisitor&) = delete;
+    /// Generates forward declarations for classes, proxies and structs. Also generates using aliases for sequences
+    /// and dictionaries, enum definitions and constants, and printTypeName helper functions for sequences and
+    /// dictionaries.
+    class ForwardDeclVisitor final : public ParserVisitor
+    {
+    public:
+        ForwardDeclVisitor(IceInternal::Output& h, IceInternal::Output& c, std::string dllExport);
+        ForwardDeclVisitor(const ForwardDeclVisitor&) = delete;
 
-            bool visitModuleStart(const ModulePtr&) final;
-            void visitModuleEnd(const ModulePtr&) final;
-            void visitClassDecl(const ClassDeclPtr&) final;
-            void visitInterfaceDecl(const InterfaceDeclPtr&) final;
-            bool visitStructStart(const StructPtr&) final;
-            void visitSequence(const SequencePtr&) final;
-            void visitDictionary(const DictionaryPtr&) final;
-            void visitEnum(const EnumPtr&) final;
-            void visitConst(const ConstPtr&) final;
+        bool visitModuleStart(const ModulePtr&) final;
+        void visitModuleEnd(const ModulePtr&) final;
+        void visitClassDecl(const ClassDeclPtr&) final;
+        void visitInterfaceDecl(const InterfaceDeclPtr&) final;
+        bool visitStructStart(const StructPtr&) final;
+        void visitSequence(const SequencePtr&) final;
+        void visitDictionary(const DictionaryPtr&) final;
+        void visitEnum(const EnumPtr&) final;
+        void visitConst(const ConstPtr&) final;
 
-        private:
-            IceInternal::Output& H;
-            IceInternal::Output& C;
+    private:
+        IceInternal::Output& H;
+        IceInternal::Output& C;
 
-            std::string _dllExport;
-            TypeContext _useWstring{TypeContext::None};
-            std::list<TypeContext> _useWstringHist;
-            bool _firstElement{true};
-        };
+        std::string _dllExport;
+        TypeContext _useWstring{TypeContext::None};
+        std::list<TypeContext> _useWstringHist;
+        bool _firstElement{true};
+    };
 
-        /// Generates the code that registers classes and exceptions with the DefaultSliceLoader instance.
-        class SliceLoaderVisitor final : public ParserVisitor
-        {
-        public:
-            SliceLoaderVisitor(IceInternal::Output& c);
-            SliceLoaderVisitor(const SliceLoaderVisitor&) = delete;
+    /// Generates the code that registers classes and exceptions with the DefaultSliceLoader instance.
+    class SliceLoaderVisitor final : public ParserVisitor
+    {
+    public:
+        SliceLoaderVisitor(IceInternal::Output& c);
+        SliceLoaderVisitor(const SliceLoaderVisitor&) = delete;
 
-            bool visitUnitStart(const UnitPtr&) final;
-            void visitUnitEnd(const UnitPtr&) final;
-            bool visitClassDefStart(const ClassDefPtr&) final;
-            bool visitExceptionStart(const ExceptionPtr&) final;
+        bool visitUnitStart(const UnitPtr&) final;
+        void visitUnitEnd(const UnitPtr&) final;
+        bool visitClassDefStart(const ClassDefPtr&) final;
+        bool visitExceptionStart(const ExceptionPtr&) final;
 
-        private:
-            IceInternal::Output& C;
-        };
+    private:
+        IceInternal::Output& C;
+    };
 
-        /// Generates code for proxies. It needs to be generated before the code for structs, classes, and exceptions
-        /// because a data member with a proxy type (e.g., std::optional<GreeterPrx>) needs to see a complete type.
-        class ProxyVisitor final : public ParserVisitor
-        {
-        public:
-            ProxyVisitor(IceInternal::Output& h, IceInternal::Output& c, std::string dllExport);
-            ProxyVisitor(const ProxyVisitor&) = delete;
+    /// Generates code for proxies. It needs to be generated before the code for structs, classes, and exceptions
+    /// because a data member with a proxy type (e.g., std::optional<GreeterPrx>) needs to see a complete type.
+    class ProxyVisitor final : public ParserVisitor
+    {
+    public:
+        ProxyVisitor(IceInternal::Output& h, IceInternal::Output& c, std::string dllExport);
+        ProxyVisitor(const ProxyVisitor&) = delete;
 
-            bool visitModuleStart(const ModulePtr&) final;
-            void visitModuleEnd(const ModulePtr&) final;
-            bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
-            void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
-            void visitOperation(const OperationPtr&) final;
+        bool visitModuleStart(const ModulePtr&) final;
+        void visitModuleEnd(const ModulePtr&) final;
+        bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
+        void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
+        void visitOperation(const OperationPtr&) final;
 
-        private:
-            void emitOperationImpl(
-                const OperationPtr& p,
-                const std::string& prefix,
-                const std::vector<std::string>& outgoingAsyncParams);
+    private:
+        void emitOperationImpl(
+            const OperationPtr& p,
+            const std::string& prefix,
+            const std::vector<std::string>& outgoingAsyncParams);
 
-            IceInternal::Output& H;
-            IceInternal::Output& C;
+        IceInternal::Output& H;
+        IceInternal::Output& C;
 
-            std::string _dllExport;
-            TypeContext _useWstring{TypeContext::None};
-            std::list<TypeContext> _useWstringHist;
-            bool _firstElement{true};
-        };
+        std::string _dllExport;
+        TypeContext _useWstring{TypeContext::None};
+        std::list<TypeContext> _useWstringHist;
+        bool _firstElement{true};
+    };
 
-        /// Generates code for definitions with data members - structs, classes, and exceptions.
-        class DataDefVisitor final : public ParserVisitor
-        {
-        public:
-            DataDefVisitor(IceInternal::Output& h, IceInternal::Output& c, std::string dllExport);
-            DataDefVisitor(const DataDefVisitor&) = delete;
+    /// Generates code for definitions with data members - structs, classes, and exceptions.
+    class DataDefVisitor final : public ParserVisitor
+    {
+    public:
+        DataDefVisitor(IceInternal::Output& h, IceInternal::Output& c, std::string dllExport);
+        DataDefVisitor(const DataDefVisitor&) = delete;
 
-            bool visitModuleStart(const ModulePtr&) final;
-            void visitModuleEnd(const ModulePtr&) final;
-            bool visitStructStart(const StructPtr&) final;
-            void visitStructEnd(const StructPtr&) final;
-            bool visitExceptionStart(const ExceptionPtr&) final;
-            void visitExceptionEnd(const ExceptionPtr&) final;
-            bool visitClassDefStart(const ClassDefPtr&) final;
-            void visitClassDefEnd(const ClassDefPtr&) final;
-            void visitDataMember(const DataMemberPtr&) final;
+        bool visitModuleStart(const ModulePtr&) final;
+        void visitModuleEnd(const ModulePtr&) final;
+        bool visitStructStart(const StructPtr&) final;
+        void visitStructEnd(const StructPtr&) final;
+        bool visitExceptionStart(const ExceptionPtr&) final;
+        void visitExceptionEnd(const ExceptionPtr&) final;
+        bool visitClassDefStart(const ClassDefPtr&) final;
+        void visitClassDefEnd(const ClassDefPtr&) final;
+        void visitDataMember(const DataMemberPtr&) final;
 
-        private:
-            bool emitBaseInitializers(const ClassDefPtr& p);
-            void emitOneShotConstructor(const ClassDefPtr& p);
-            void emitDataMember(const DataMemberPtr& p);
+    private:
+        bool emitBaseInitializers(const ClassDefPtr& p);
+        void emitOneShotConstructor(const ClassDefPtr& p);
+        void emitDataMember(const DataMemberPtr& p);
 
-            void printFields(const DataMemberList& fields, bool firstField);
+        void printFields(const DataMemberList& fields, bool firstField);
 
-            IceInternal::Output& H;
-            IceInternal::Output& C;
+        IceInternal::Output& H;
+        IceInternal::Output& C;
 
-            std::string _dllExport;
-            TypeContext _useWstring{TypeContext::None};
-            std::list<TypeContext> _useWstringHist;
-            bool _firstElement{true};
-        };
+        std::string _dllExport;
+        TypeContext _useWstring{TypeContext::None};
+        std::list<TypeContext> _useWstringHist;
+        bool _firstElement{true};
+    };
 
-        /// Generates the skeleton classes that applications use to implement Ice objects.
-        class InterfaceVisitor final : public ParserVisitor
-        {
-        public:
-            InterfaceVisitor(IceInternal::Output& h, IceInternal::Output& c, std::string dllExport, bool async);
-            InterfaceVisitor(const InterfaceVisitor&) = delete;
+    /// Generates the skeleton classes that applications use to implement Ice objects.
+    class InterfaceVisitor final : public ParserVisitor
+    {
+    public:
+        InterfaceVisitor(IceInternal::Output& h, IceInternal::Output& c, std::string dllExport, bool async);
+        InterfaceVisitor(const InterfaceVisitor&) = delete;
 
-            bool visitModuleStart(const ModulePtr&) final;
-            void visitModuleEnd(const ModulePtr&) final;
-            bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
-            void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
-            void visitOperation(const OperationPtr&) final;
+        bool visitModuleStart(const ModulePtr&) final;
+        void visitModuleEnd(const ModulePtr&) final;
+        bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
+        void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
+        void visitOperation(const OperationPtr&) final;
 
-        private:
-            [[nodiscard]] std::string skeletonPrefix() const;
-            [[nodiscard]] std::string prependSkeletonPrefix(const std::string& name) const;
+    private:
+        [[nodiscard]] std::string skeletonPrefix() const;
+        [[nodiscard]] std::string prependSkeletonPrefix(const std::string& name) const;
 
-            IceInternal::Output& H;
-            IceInternal::Output& C;
-            std::string _dllExport;
-            bool _async;
+        IceInternal::Output& H;
+        IceInternal::Output& C;
+        std::string _dllExport;
+        bool _async;
 
-            TypeContext _useWstring{TypeContext::None};
-            std::list<TypeContext> _useWstringHist;
-            bool _firstElement{true};
-        };
+        TypeContext _useWstring{TypeContext::None};
+        std::list<TypeContext> _useWstringHist;
+        bool _firstElement{true};
+    };
 
-        /// Generates internal StreamHelper template specializations for enums and structs.
-        class StreamVisitor final : public ParserVisitor
-        {
-        public:
-            StreamVisitor(IceInternal::Output& h);
-            StreamVisitor(const StreamVisitor&) = delete;
+    /// Generates internal StreamHelper template specializations for enums and structs.
+    class StreamVisitor final : public ParserVisitor
+    {
+    public:
+        StreamVisitor(IceInternal::Output& h);
+        StreamVisitor(const StreamVisitor&) = delete;
 
-            bool visitModuleStart(const ModulePtr&) final;
-            void visitModuleEnd(const ModulePtr&) final;
-            bool visitStructStart(const StructPtr&) final;
-            void visitEnum(const EnumPtr&) final;
+        bool visitModuleStart(const ModulePtr&) final;
+        void visitModuleEnd(const ModulePtr&) final;
+        bool visitStructStart(const StructPtr&) final;
+        void visitEnum(const EnumPtr&) final;
 
-        private:
-            IceInternal::Output& H;
-            bool _firstElement{true};
-        };
+    private:
+        IceInternal::Output& H;
+        bool _firstElement{true};
     };
 }
 

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -2329,7 +2329,7 @@ Slice::JavaVisitor::writeParamDocComments(IceInternal::Output& out, const DataMe
     }
 }
 
-Slice::Gen::Gen(string base, string dir) : _base(std::move(base)), _dir(std::move(dir)) {}
+Slice::Gen::Gen(string dir) : _dir(std::move(dir)) {}
 
 Slice::Gen::~Gen() = default;
 
@@ -2350,10 +2350,10 @@ Slice::Gen::generate(const UnitPtr& unit)
     unit->visit(&asyncSkeletonVisitor);
 }
 
-Slice::Gen::TypesVisitor::TypesVisitor(const string& dir) : JavaVisitor(dir) {}
+Slice::TypesVisitor::TypesVisitor(const string& dir) : JavaVisitor(dir) {}
 
 bool
-Slice::Gen::TypesVisitor::visitModuleStart(const ModulePtr& p)
+Slice::TypesVisitor::visitModuleStart(const ModulePtr& p)
 {
     string prefix = getPackagePrefix(p);
     if (!prefix.empty() && p->isTopLevel()) // generate Marker class for top-level modules
@@ -2373,7 +2373,7 @@ Slice::Gen::TypesVisitor::visitModuleStart(const ModulePtr& p)
 }
 
 bool
-Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
+Slice::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
     string name = p->mappedName();
     ClassDefPtr base = p->base();
@@ -2411,7 +2411,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 }
 
 void
-Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
+Slice::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
 {
     Output& out = output();
     const string name = p->mappedName();
@@ -2661,7 +2661,7 @@ Slice::Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr& p)
 }
 
 bool
-Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
+Slice::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
     string name = p->mappedName();
     ExceptionPtr base = p->base();
@@ -2696,7 +2696,7 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 }
 
 void
-Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
+Slice::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
 {
     Output& out = output();
 
@@ -2936,7 +2936,7 @@ Slice::Gen::TypesVisitor::visitExceptionEnd(const ExceptionPtr& p)
 }
 
 bool
-Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
+Slice::TypesVisitor::visitStructStart(const StructPtr& p)
 {
     open(getUnqualified(p), p->file());
 
@@ -2957,7 +2957,7 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
 }
 
 void
-Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
+Slice::TypesVisitor::visitStructEnd(const StructPtr& p)
 {
     string package = getPackage(p);
 
@@ -3278,7 +3278,7 @@ Slice::Gen::TypesVisitor::visitStructEnd(const StructPtr& p)
 }
 
 void
-Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
+Slice::TypesVisitor::visitDataMember(const DataMemberPtr& p)
 {
     const ContainedPtr contained = dynamic_pointer_cast<Contained>(p->container());
 
@@ -3557,7 +3557,7 @@ Slice::Gen::TypesVisitor::visitDataMember(const DataMemberPtr& p)
 }
 
 void
-Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
+Slice::TypesVisitor::visitEnum(const EnumPtr& p)
 {
     string name = p->mappedName();
     string package = getPackage(p);
@@ -3739,7 +3739,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 }
 
 void
-Slice::Gen::TypesVisitor::visitSequence(const SequencePtr& p)
+Slice::TypesVisitor::visitSequence(const SequencePtr& p)
 {
     bool mappedToCustomType = p->hasMetadata("java:type");
     if (mapsToJavaBuiltinType(p->type()) && !mappedToCustomType)
@@ -3930,7 +3930,7 @@ Slice::Gen::TypesVisitor::visitSequence(const SequencePtr& p)
 }
 
 void
-Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
+Slice::TypesVisitor::visitDictionary(const DictionaryPtr& p)
 {
     string name = p->mappedName();
     string helper = getUnqualified(p) + "Helper";
@@ -4058,7 +4058,7 @@ Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
 }
 
 void
-Slice::Gen::TypesVisitor::visitConst(const ConstPtr& p)
+Slice::TypesVisitor::visitConst(const ConstPtr& p)
 {
     string package = getPackage(p);
     TypePtr type = p->type();
@@ -4086,7 +4086,7 @@ Slice::Gen::TypesVisitor::visitConst(const ConstPtr& p)
 }
 
 bool
-Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
+Slice::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     InterfaceList bases = p->bases();
     string package = getPackage(p);
@@ -4126,7 +4126,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 }
 
 void
-Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
+Slice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 {
     Output& out = output();
 
@@ -4318,7 +4318,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 }
 
 void
-Slice::Gen::TypesVisitor::visitOperation(const OperationPtr& p)
+Slice::TypesVisitor::visitOperation(const OperationPtr& p)
 {
     Output& out = output();
 
@@ -4376,10 +4376,10 @@ Slice::Gen::TypesVisitor::visitOperation(const OperationPtr& p)
     }
 }
 
-Slice::Gen::SkeletonVisitor::SkeletonVisitor(const string& dir, bool async) : JavaVisitor(dir), _async(async) {}
+Slice::SkeletonVisitor::SkeletonVisitor(const string& dir, bool async) : JavaVisitor(dir), _async(async) {}
 
 bool
-Slice::Gen::SkeletonVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
+Slice::SkeletonVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     string name = prependSkeletonPrefix(p->mappedName());
     InterfaceList bases = p->bases();
@@ -4413,7 +4413,7 @@ Slice::Gen::SkeletonVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 }
 
 void
-Slice::Gen::SkeletonVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
+Slice::SkeletonVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 {
     Output& out = output();
 
@@ -4690,7 +4690,7 @@ Slice::Gen::SkeletonVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 }
 
 void
-Slice::Gen::SkeletonVisitor::visitOperation(const OperationPtr& p)
+Slice::SkeletonVisitor::visitOperation(const OperationPtr& p)
 {
     //
     // Generate the operation signature for a servant.
@@ -4719,19 +4719,19 @@ Slice::Gen::SkeletonVisitor::visitOperation(const OperationPtr& p)
 }
 
 string
-Slice::Gen::SkeletonVisitor::skeletonPrefix() const
+Slice::SkeletonVisitor::skeletonPrefix() const
 {
     return _async ? "Async" : "";
 }
 
 string
-Slice::Gen::SkeletonVisitor::prependSkeletonPrefix(const string& name) const
+Slice::SkeletonVisitor::prependSkeletonPrefix(const string& name) const
 {
     return skeletonPrefix() + name;
 }
 
 string
-Slice::Gen::SkeletonVisitor::getDispatchResultType(const OperationPtr& op, const string& package, bool object) const
+Slice::SkeletonVisitor::getDispatchResultType(const OperationPtr& op, const string& package, bool object) const
 {
     if (op->hasMarshaledResult())
     {

--- a/cpp/src/slice2java/Gen.h
+++ b/cpp/src/slice2java/Gen.h
@@ -183,7 +183,7 @@ namespace Slice
     class Gen final
     {
     public:
-        Gen(std::string base, std::string dir);
+        Gen(std::string dir);
         Gen(const Gen&) = delete;
         ~Gen();
 
@@ -192,53 +192,52 @@ namespace Slice
         void generate(const UnitPtr& unit);
 
     private:
-        std::string _base;
         std::string _dir;
+    };
 
-        class TypesVisitor final : public JavaVisitor
-        {
-        public:
-            TypesVisitor(const std::string& dir);
+    class TypesVisitor final : public JavaVisitor
+    {
+    public:
+        TypesVisitor(const std::string& dir);
 
-            bool visitModuleStart(const ModulePtr&) final;
+        bool visitModuleStart(const ModulePtr&) final;
 
-            bool visitClassDefStart(const ClassDefPtr&) final;
-            void visitClassDefEnd(const ClassDefPtr&) final;
-            bool visitExceptionStart(const ExceptionPtr&) final;
-            void visitExceptionEnd(const ExceptionPtr&) final;
-            bool visitStructStart(const StructPtr&) final;
-            void visitStructEnd(const StructPtr&) final;
-            void visitDataMember(const DataMemberPtr&) final;
-            void visitEnum(const EnumPtr&) final;
-            void visitSequence(const SequencePtr&) final;
-            void visitDictionary(const DictionaryPtr&) final;
+        bool visitClassDefStart(const ClassDefPtr&) final;
+        void visitClassDefEnd(const ClassDefPtr&) final;
+        bool visitExceptionStart(const ExceptionPtr&) final;
+        void visitExceptionEnd(const ExceptionPtr&) final;
+        bool visitStructStart(const StructPtr&) final;
+        void visitStructEnd(const StructPtr&) final;
+        void visitDataMember(const DataMemberPtr&) final;
+        void visitEnum(const EnumPtr&) final;
+        void visitSequence(const SequencePtr&) final;
+        void visitDictionary(const DictionaryPtr&) final;
 
-            void visitConst(const ConstPtr&) final;
+        void visitConst(const ConstPtr&) final;
 
-            // Generate proxy classes
-            bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
-            void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
-            void visitOperation(const OperationPtr&) final;
-        };
+        // Generate proxy classes
+        bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
+        void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
+        void visitOperation(const OperationPtr&) final;
+    };
 
-        class SkeletonVisitor final : public JavaVisitor
-        {
-        public:
-            SkeletonVisitor(const std::string& dir, bool async);
+    class SkeletonVisitor final : public JavaVisitor
+    {
+    public:
+        SkeletonVisitor(const std::string& dir, bool async);
 
-            bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
-            void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
-            void visitOperation(const OperationPtr&) final;
+        bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
+        void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
+        void visitOperation(const OperationPtr&) final;
 
-        private:
-            [[nodiscard]] std::string skeletonPrefix() const;
-            [[nodiscard]] std::string prependSkeletonPrefix(const std::string& name) const;
+    private:
+        [[nodiscard]] std::string skeletonPrefix() const;
+        [[nodiscard]] std::string prependSkeletonPrefix(const std::string& name) const;
 
-            [[nodiscard]] std::string
-            getDispatchResultType(const OperationPtr& op, const std::string& package, bool object) const;
+        [[nodiscard]] std::string
+        getDispatchResultType(const OperationPtr& op, const std::string& package, bool object) const;
 
-            const bool _async;
-        };
+        const bool _async;
     };
 }
 

--- a/cpp/src/slice2java/Main.cpp
+++ b/cpp/src/slice2java/Main.cpp
@@ -199,7 +199,7 @@ namespace
                     JavaDocCommentFormatter formatter;
                     parseAllDocComments(unit, formatter);
 
-                    Gen gen(preprocessor->getBaseName(), output);
+                    Gen gen(output);
                     gen.generate(unit);
 
                     status |= unit->getStatus();

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -757,44 +757,44 @@ Slice::Gen::generate(const UnitPtr& unit)
     }
 }
 
-Slice::Gen::ImportVisitor::ImportVisitor(IceInternal::Output& out) : JsVisitor(out) {}
+Slice::ImportVisitor::ImportVisitor(IceInternal::Output& out) : JsVisitor(out) {}
 
 bool
-Slice::Gen::ImportVisitor::visitClassDefStart(const ClassDefPtr&)
+Slice::ImportVisitor::visitClassDefStart(const ClassDefPtr&)
 {
     _seenClass = true;
     return true;
 }
 
 bool
-Slice::Gen::ImportVisitor::visitInterfaceDefStart(const InterfaceDefPtr&)
+Slice::ImportVisitor::visitInterfaceDefStart(const InterfaceDefPtr&)
 {
     _seenInterface = true;
     return true;
 }
 
 bool
-Slice::Gen::ImportVisitor::visitStructStart(const StructPtr&)
+Slice::ImportVisitor::visitStructStart(const StructPtr&)
 {
     _seenStruct = true;
     return false;
 }
 
 void
-Slice::Gen::ImportVisitor::visitOperation(const OperationPtr&)
+Slice::ImportVisitor::visitOperation(const OperationPtr&)
 {
     _seenOperation = true;
 }
 
 bool
-Slice::Gen::ImportVisitor::visitExceptionStart(const ExceptionPtr&)
+Slice::ImportVisitor::visitExceptionStart(const ExceptionPtr&)
 {
     _seenUserException = true;
     return false;
 }
 
 void
-Slice::Gen::ImportVisitor::visitSequence(const SequencePtr& seq)
+Slice::ImportVisitor::visitSequence(const SequencePtr& seq)
 {
     BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(seq->type());
     if (builtin)
@@ -815,7 +815,7 @@ Slice::Gen::ImportVisitor::visitSequence(const SequencePtr& seq)
 }
 
 void
-Slice::Gen::ImportVisitor::visitDictionary(const DictionaryPtr& dict)
+Slice::ImportVisitor::visitDictionary(const DictionaryPtr& dict)
 {
     BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(dict->valueType());
     if (builtin)
@@ -836,13 +836,13 @@ Slice::Gen::ImportVisitor::visitDictionary(const DictionaryPtr& dict)
 }
 
 void
-Slice::Gen::ImportVisitor::visitEnum(const EnumPtr&)
+Slice::ImportVisitor::visitEnum(const EnumPtr&)
 {
     _seenEnum = true;
 }
 
 set<string>
-Slice::Gen::ImportVisitor::writeImports(
+Slice::ImportVisitor::writeImports(
     const UnitPtr& unit,
     const map<string, map<string, set<string>>>& nestedModulesByTopLevel)
 {
@@ -1128,14 +1128,14 @@ Slice::Gen::ImportVisitor::writeImports(
     return importedModules;
 }
 
-Slice::Gen::ExportsVisitor::ExportsVisitor(IceInternal::Output& out, set<string> importedModules)
+Slice::ExportsVisitor::ExportsVisitor(IceInternal::Output& out, set<string> importedModules)
     : JsVisitor(out),
       _importedModules(std::move(importedModules))
 {
 }
 
 bool
-Slice::Gen::ExportsVisitor::visitModuleStart(const ModulePtr& p)
+Slice::ExportsVisitor::visitModuleStart(const ModulePtr& p)
 {
     //
     // For a top-level module we write the following:
@@ -1190,18 +1190,18 @@ Slice::Gen::ExportsVisitor::visitModuleStart(const ModulePtr& p)
 }
 
 set<string>
-Slice::Gen::ExportsVisitor::exportedModules() const
+Slice::ExportsVisitor::exportedModules() const
 {
     return _exportedModules;
 }
 
-Slice::Gen::TypesVisitor::TypesVisitor(IceInternal::Output& out, string jsModule) : JsVisitor(out)
+Slice::TypesVisitor::TypesVisitor(IceInternal::Output& out, string jsModule) : JsVisitor(out)
 {
     _jsModule = std::move(jsModule);
 }
 
 bool
-Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
+Slice::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
     const string scopedName = p->mappedScoped(".");
     ClassDefPtr base = p->base();
@@ -1295,7 +1295,7 @@ Slice::Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 }
 
 bool
-Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
+Slice::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     const string serviceType = p->mappedScoped(".");
     const string proxyType = serviceType + "Prx";
@@ -1597,7 +1597,7 @@ Slice::Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 }
 
 void
-Slice::Gen::TypesVisitor::visitSequence(const SequencePtr& p)
+Slice::TypesVisitor::visitSequence(const SequencePtr& p)
 {
     // Stream helpers for sequences are lazy initialized as the required types might not be available until later.
     const string helperName = p->mappedScoped(".") + "Helper";
@@ -1617,7 +1617,7 @@ Slice::Gen::TypesVisitor::visitSequence(const SequencePtr& p)
 }
 
 bool
-Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
+Slice::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
     const string scopedName = p->mappedScoped(".");
     const ExceptionPtr base = p->base();
@@ -1727,7 +1727,7 @@ Slice::Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 }
 
 bool
-Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
+Slice::TypesVisitor::visitStructStart(const StructPtr& p)
 {
     const string scopedName = p->mappedScoped(".");
     const DataMemberList dataMembers = p->dataMembers();
@@ -1782,7 +1782,7 @@ Slice::Gen::TypesVisitor::visitStructStart(const StructPtr& p)
 }
 
 void
-Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
+Slice::TypesVisitor::visitDictionary(const DictionaryPtr& p)
 {
     const TypePtr keyType = p->keyType();
     const TypePtr valueType = p->valueType();
@@ -1816,7 +1816,7 @@ Slice::Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
 }
 
 void
-Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
+Slice::TypesVisitor::visitEnum(const EnumPtr& p)
 {
     const string scopedName = p->mappedScoped(".");
     _out << sp;
@@ -1851,7 +1851,7 @@ Slice::Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 }
 
 void
-Slice::Gen::TypesVisitor::visitConst(const ConstPtr& p)
+Slice::TypesVisitor::visitConst(const ConstPtr& p)
 {
     string scope = p->mappedScope(".");
     scope.pop_back(); // Remove the trailing '.' from the scope.
@@ -1867,7 +1867,7 @@ Slice::Gen::TypesVisitor::visitConst(const ConstPtr& p)
 }
 
 string
-Slice::Gen::TypesVisitor::encodeTypeForOperation(const TypePtr& type)
+Slice::TypesVisitor::encodeTypeForOperation(const TypePtr& type)
 {
     assert(type);
 
@@ -1931,7 +1931,7 @@ Slice::Gen::TypesVisitor::encodeTypeForOperation(const TypePtr& type)
     return "???";
 }
 
-Slice::Gen::TypeScriptImportVisitor::TypeScriptImportVisitor(
+Slice::TypeScriptImportVisitor::TypeScriptImportVisitor(
     IceInternal::Output& out,
     map<string, set<string>> importedTypesByInclude)
     : JsVisitor(out),
@@ -1940,7 +1940,7 @@ Slice::Gen::TypeScriptImportVisitor::TypeScriptImportVisitor(
 }
 
 void
-Slice::Gen::TypeScriptImportVisitor::addImport(const ContainedPtr& definition)
+Slice::TypeScriptImportVisitor::addImport(const ContainedPtr& definition)
 {
     const string definitionId = definition->mappedScoped(".");
 
@@ -1982,7 +1982,7 @@ Slice::Gen::TypeScriptImportVisitor::addImport(const ContainedPtr& definition)
 }
 
 bool
-Slice::Gen::TypeScriptImportVisitor::visitUnitStart(const UnitPtr& unit)
+Slice::TypeScriptImportVisitor::visitUnitStart(const UnitPtr& unit)
 {
     _module = getJavaScriptModule(unit->findDefinitionContext(unit->topLevelFile()));
     _filename = unit->topLevelFile();
@@ -2010,7 +2010,7 @@ Slice::Gen::TypeScriptImportVisitor::visitUnitStart(const UnitPtr& unit)
 }
 
 bool
-Slice::Gen::TypeScriptImportVisitor::visitClassDefStart(const ClassDefPtr& p)
+Slice::TypeScriptImportVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
     // Add imports required for the base class type.
     ClassDefPtr base = p->base();
@@ -2032,7 +2032,7 @@ Slice::Gen::TypeScriptImportVisitor::visitClassDefStart(const ClassDefPtr& p)
 }
 
 bool
-Slice::Gen::TypeScriptImportVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
+Slice::TypeScriptImportVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     // Add imports required for base interfaces types.
     for (const auto& base : p->bases())
@@ -2062,7 +2062,7 @@ Slice::Gen::TypeScriptImportVisitor::visitInterfaceDefStart(const InterfaceDefPt
 }
 
 bool
-Slice::Gen::TypeScriptImportVisitor::visitStructStart(const StructPtr& p)
+Slice::TypeScriptImportVisitor::visitStructStart(const StructPtr& p)
 {
     // Add imports required for data member types.
     for (const auto& dataMember : p->dataMembers())
@@ -2077,7 +2077,7 @@ Slice::Gen::TypeScriptImportVisitor::visitStructStart(const StructPtr& p)
 }
 
 bool
-Slice::Gen::TypeScriptImportVisitor::visitExceptionStart(const ExceptionPtr& p)
+Slice::TypeScriptImportVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
     // Add imports required for base exception types.
     if (ExceptionPtr base = p->base())
@@ -2097,7 +2097,7 @@ Slice::Gen::TypeScriptImportVisitor::visitExceptionStart(const ExceptionPtr& p)
 }
 
 void
-Slice::Gen::TypeScriptImportVisitor::visitSequence(const SequencePtr& seq)
+Slice::TypeScriptImportVisitor::visitSequence(const SequencePtr& seq)
 {
     // Add import required for the sequence element type.
     auto type = dynamic_pointer_cast<Contained>(seq->type());
@@ -2108,7 +2108,7 @@ Slice::Gen::TypeScriptImportVisitor::visitSequence(const SequencePtr& seq)
 }
 
 void
-Slice::Gen::TypeScriptImportVisitor::visitDictionary(const DictionaryPtr& dict)
+Slice::TypeScriptImportVisitor::visitDictionary(const DictionaryPtr& dict)
 {
     //
     // Add imports required for the dictionary key and value types
@@ -2127,7 +2127,7 @@ Slice::Gen::TypeScriptImportVisitor::visitDictionary(const DictionaryPtr& dict)
 }
 
 map<string, string>
-Slice::Gen::TypeScriptImportVisitor::writeImports()
+Slice::TypeScriptImportVisitor::writeImports()
 {
     _out << sp;
     for (const auto& moduleName : _importedModules)
@@ -2139,7 +2139,7 @@ Slice::Gen::TypeScriptImportVisitor::writeImports()
 }
 
 string
-Slice::Gen::TypeScriptVisitor::importPrefix(const string& scopedName) const
+Slice::TypeScriptVisitor::importPrefix(const string& scopedName) const
 {
     const auto it = _importedTypes.find(scopedName);
     if (it != _importedTypes.end())
@@ -2150,7 +2150,7 @@ Slice::Gen::TypeScriptVisitor::importPrefix(const string& scopedName) const
 }
 
 string
-Slice::Gen::TypeScriptVisitor::typeToTsString(const TypePtr& type, bool nullable, bool forParameter, bool optional)
+Slice::TypeScriptVisitor::typeToTsString(const TypePtr& type, bool nullable, bool forParameter, bool optional)
     const
 {
     if (!type)
@@ -2284,7 +2284,7 @@ Slice::Gen::TypeScriptVisitor::typeToTsString(const TypePtr& type, bool nullable
     return t;
 }
 
-Slice::Gen::TypeScriptVisitor::TypeScriptVisitor(
+Slice::TypeScriptVisitor::TypeScriptVisitor(
     IceInternal::Output& out,
     map<string, string> importedTypes,
     map<string, set<string>> importedTypesByInclude)
@@ -2295,7 +2295,7 @@ Slice::Gen::TypeScriptVisitor::TypeScriptVisitor(
 }
 
 bool
-Slice::Gen::TypeScriptVisitor::visitUnitStart(const UnitPtr& unit)
+Slice::TypeScriptVisitor::visitUnitStart(const UnitPtr& unit)
 {
     _module = getJavaScriptModule(unit->findDefinitionContext(unit->topLevelFile()));
     _iceImportPrefix = _module == "@zeroc/ice" ? "" : "__module__zeroc_ice.";
@@ -2308,7 +2308,7 @@ Slice::Gen::TypeScriptVisitor::visitUnitStart(const UnitPtr& unit)
 }
 
 void
-Slice::Gen::TypeScriptVisitor::visitUnitEnd(const UnitPtr&)
+Slice::TypeScriptVisitor::visitUnitEnd(const UnitPtr&)
 {
     set<string> globalModules;
     for (const auto& [key, value] : _importedTypes)
@@ -2335,7 +2335,7 @@ Slice::Gen::TypeScriptVisitor::visitUnitEnd(const UnitPtr&)
 }
 
 bool
-Slice::Gen::TypeScriptVisitor::visitModuleStart(const ModulePtr& p)
+Slice::TypeScriptVisitor::visitModuleStart(const ModulePtr& p)
 {
     // Track visited modules for nested module export detection.
     _visitedModules.insert(p->mappedScoped("."));
@@ -2365,7 +2365,7 @@ Slice::Gen::TypeScriptVisitor::visitModuleStart(const ModulePtr& p)
 }
 
 void
-Slice::Gen::TypeScriptVisitor::visitModuleEnd(const ModulePtr& p)
+Slice::TypeScriptVisitor::visitModuleEnd(const ModulePtr& p)
 {
     // Generate export imports for types in nested modules that don't exist in the current file.
     writeNestedModuleExports(p->mappedScoped("."));
@@ -2374,7 +2374,7 @@ Slice::Gen::TypeScriptVisitor::visitModuleEnd(const ModulePtr& p)
 }
 
 bool
-Slice::Gen::TypeScriptVisitor::visitClassDefStart(const ClassDefPtr& p)
+Slice::TypeScriptVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
     const DataMemberList dataMembers = p->dataMembers();
     const DataMemberList allDataMembers = p->allDataMembers();
@@ -2449,7 +2449,7 @@ namespace
 }
 
 void
-Slice::Gen::TypeScriptVisitor::writeOpDocSummary(Output& out, const OperationPtr& op, bool forDispatch)
+Slice::TypeScriptVisitor::writeOpDocSummary(Output& out, const OperationPtr& op, bool forDispatch)
 {
     out << nl << "/**";
 
@@ -2542,7 +2542,7 @@ Slice::Gen::TypeScriptVisitor::writeOpDocSummary(Output& out, const OperationPtr
 }
 
 void
-Slice::Gen::TypeScriptVisitor::writeNestedModuleExports(const string& currentModuleScope)
+Slice::TypeScriptVisitor::writeNestedModuleExports(const string& currentModuleScope)
 {
     // Export types from included files that are in nested modules not present in this file.
     // Re-exported types for modules that are visible in this file are handled by TypeScriptVisitor::visitModuleStart.
@@ -2648,7 +2648,7 @@ Slice::Gen::TypeScriptVisitor::writeNestedModuleExports(const string& currentMod
 }
 
 bool
-Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
+Slice::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     //
     // Define servant and proxy types.
@@ -2884,7 +2884,7 @@ Slice::Gen::TypeScriptVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 }
 
 bool
-Slice::Gen::TypeScriptVisitor::visitExceptionStart(const ExceptionPtr& p)
+Slice::TypeScriptVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
     const DataMemberList dataMembers = p->dataMembers();
     const DataMemberList allDataMembers = p->allDataMembers();
@@ -2939,7 +2939,7 @@ Slice::Gen::TypeScriptVisitor::visitExceptionStart(const ExceptionPtr& p)
 }
 
 bool
-Slice::Gen::TypeScriptVisitor::visitStructStart(const StructPtr& p)
+Slice::TypeScriptVisitor::visitStructStart(const StructPtr& p)
 {
     const string name = p->mappedName();
     const DataMemberList dataMembers = p->dataMembers();
@@ -3014,7 +3014,7 @@ Slice::Gen::TypeScriptVisitor::visitStructStart(const StructPtr& p)
 }
 
 void
-Slice::Gen::TypeScriptVisitor::visitSequence(const SequencePtr& p)
+Slice::TypeScriptVisitor::visitSequence(const SequencePtr& p)
 {
     const string name = p->mappedName();
 
@@ -3050,7 +3050,7 @@ Slice::Gen::TypeScriptVisitor::visitSequence(const SequencePtr& p)
 }
 
 void
-Slice::Gen::TypeScriptVisitor::visitDictionary(const DictionaryPtr& p)
+Slice::TypeScriptVisitor::visitDictionary(const DictionaryPtr& p)
 {
     const string name = p->mappedName();
     _out << sp;
@@ -3092,7 +3092,7 @@ Slice::Gen::TypeScriptVisitor::visitDictionary(const DictionaryPtr& p)
 }
 
 void
-Slice::Gen::TypeScriptVisitor::visitEnum(const EnumPtr& p)
+Slice::TypeScriptVisitor::visitEnum(const EnumPtr& p)
 {
     const string name = p->mappedName();
 
@@ -3118,7 +3118,7 @@ Slice::Gen::TypeScriptVisitor::visitEnum(const EnumPtr& p)
 }
 
 void
-Slice::Gen::TypeScriptVisitor::visitConst(const ConstPtr& p)
+Slice::TypeScriptVisitor::visitConst(const ConstPtr& p)
 {
     _out << sp;
     writeDocSummary(p, {.generatedType = "constant"});

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -2150,8 +2150,7 @@ Slice::TypeScriptVisitor::importPrefix(const string& scopedName) const
 }
 
 string
-Slice::TypeScriptVisitor::typeToTsString(const TypePtr& type, bool nullable, bool forParameter, bool optional)
-    const
+Slice::TypeScriptVisitor::typeToTsString(const TypePtr& type, bool nullable, bool forParameter, bool optional) const
 {
     if (!type)
     {

--- a/cpp/src/slice2js/Gen.h
+++ b/cpp/src/slice2js/Gen.h
@@ -114,148 +114,148 @@ namespace Slice
         std::string _fileBase;
         bool _useStdout;
         bool _typeScript;
+    };
 
-        class ImportVisitor final : public JsVisitor
-        {
-        public:
-            ImportVisitor(IceInternal::Output& out);
+    class ImportVisitor final : public JsVisitor
+    {
+    public:
+        ImportVisitor(IceInternal::Output& out);
 
-            bool visitClassDefStart(const ClassDefPtr&) final;
-            bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
-            bool visitStructStart(const StructPtr&) final;
-            void visitOperation(const OperationPtr&) final;
-            bool visitExceptionStart(const ExceptionPtr&) final;
-            void visitSequence(const SequencePtr&) final;
-            void visitDictionary(const DictionaryPtr&) final;
-            void visitEnum(const EnumPtr&) final;
+        bool visitClassDefStart(const ClassDefPtr&) final;
+        bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
+        bool visitStructStart(const StructPtr&) final;
+        void visitOperation(const OperationPtr&) final;
+        bool visitExceptionStart(const ExceptionPtr&) final;
+        void visitSequence(const SequencePtr&) final;
+        void visitDictionary(const DictionaryPtr&) final;
+        void visitEnum(const EnumPtr&) final;
 
-            // Emit the import statements for the given unit and return a list of the imported modules.
-            std::set<std::string> writeImports(
-                const UnitPtr& unit,
-                const std::map<std::string, std::map<std::string, std::set<std::string>>>& nestedModulesByTopLevel);
+        // Emit the import statements for the given unit and return a list of the imported modules.
+        std::set<std::string> writeImports(
+            const UnitPtr& unit,
+            const std::map<std::string, std::map<std::string, std::set<std::string>>>& nestedModulesByTopLevel);
 
-        private:
-            bool _seenClass{false};
-            bool _seenInterface{false};
-            bool _seenOperation{false};
-            bool _seenStruct{false};
-            bool _seenUserException{false};
-            bool _seenEnum{false};
-            bool _seenSeq{false};
-            bool _seenDict{false};
-            bool _seenObjectSeq{false};
-            bool _seenObjectProxySeq{false};
-            bool _seenObjectDict{false};
-            bool _seenObjectProxyDict{false};
-        };
+    private:
+        bool _seenClass{false};
+        bool _seenInterface{false};
+        bool _seenOperation{false};
+        bool _seenStruct{false};
+        bool _seenUserException{false};
+        bool _seenEnum{false};
+        bool _seenSeq{false};
+        bool _seenDict{false};
+        bool _seenObjectSeq{false};
+        bool _seenObjectProxySeq{false};
+        bool _seenObjectDict{false};
+        bool _seenObjectProxyDict{false};
+    };
 
-        class ExportsVisitor final : public JsVisitor
-        {
-        public:
-            ExportsVisitor(IceInternal::Output& out, std::set<std::string> importedModules);
+    class ExportsVisitor final : public JsVisitor
+    {
+    public:
+        ExportsVisitor(IceInternal::Output& out, std::set<std::string> importedModules);
 
-            bool visitModuleStart(const ModulePtr&) final;
+        bool visitModuleStart(const ModulePtr&) final;
 
-            [[nodiscard]] std::set<std::string> exportedModules() const;
+        [[nodiscard]] std::set<std::string> exportedModules() const;
 
-        private:
-            std::set<std::string> _importedModules;
-            std::set<std::string> _exportedModules;
-        };
+    private:
+        std::set<std::string> _importedModules;
+        std::set<std::string> _exportedModules;
+    };
 
-        class TypesVisitor final : public JsVisitor
-        {
-        public:
-            TypesVisitor(IceInternal::Output& out, std::string jsModule);
+    class TypesVisitor final : public JsVisitor
+    {
+    public:
+        TypesVisitor(IceInternal::Output& out, std::string jsModule);
 
-            bool visitClassDefStart(const ClassDefPtr&) final;
-            bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
-            bool visitExceptionStart(const ExceptionPtr&) final;
-            bool visitStructStart(const StructPtr&) final;
-            void visitSequence(const SequencePtr&) final;
-            void visitDictionary(const DictionaryPtr&) final;
-            void visitEnum(const EnumPtr&) final;
-            void visitConst(const ConstPtr&) final;
+        bool visitClassDefStart(const ClassDefPtr&) final;
+        bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
+        bool visitExceptionStart(const ExceptionPtr&) final;
+        bool visitStructStart(const StructPtr&) final;
+        void visitSequence(const SequencePtr&) final;
+        void visitDictionary(const DictionaryPtr&) final;
+        void visitEnum(const EnumPtr&) final;
+        void visitConst(const ConstPtr&) final;
 
-        private:
-            std::string encodeTypeForOperation(const TypePtr& type);
-        };
+    private:
+        std::string encodeTypeForOperation(const TypePtr& type);
+    };
 
-        class TypeScriptImportVisitor final : public JsVisitor
-        {
-        public:
-            TypeScriptImportVisitor(
-                IceInternal::Output& out,
-                std::map<std::string, std::set<std::string>> importedTypesByInclude);
+    class TypeScriptImportVisitor final : public JsVisitor
+    {
+    public:
+        TypeScriptImportVisitor(
+            IceInternal::Output& out,
+            std::map<std::string, std::set<std::string>> importedTypesByInclude);
 
-            bool visitUnitStart(const UnitPtr&) final;
-            bool visitClassDefStart(const ClassDefPtr&) final;
-            bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
-            bool visitStructStart(const StructPtr&) final;
-            bool visitExceptionStart(const ExceptionPtr&) final;
-            void visitSequence(const SequencePtr&) final;
-            void visitDictionary(const DictionaryPtr&) final;
+        bool visitUnitStart(const UnitPtr&) final;
+        bool visitClassDefStart(const ClassDefPtr&) final;
+        bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
+        bool visitStructStart(const StructPtr&) final;
+        bool visitExceptionStart(const ExceptionPtr&) final;
+        void visitSequence(const SequencePtr&) final;
+        void visitDictionary(const DictionaryPtr&) final;
 
-            // Emit the import statements for the given unit and return a map of the imported types per module.
-            std::map<std::string, std::string> writeImports();
+        // Emit the import statements for the given unit and return a map of the imported types per module.
+        std::map<std::string, std::string> writeImports();
 
-        private:
-            void addImport(const ContainedPtr&);
+    private:
+        void addImport(const ContainedPtr&);
 
-            // All modules imported by the current unit.
-            std::set<std::string> _importedModules;
-            // A map of imported types to their module name.
-            std::map<std::string, std::string> _importedTypes;
-            // The module name of the current unit.
-            std::string _module;
-            // The filename of the current unit.
-            std::string _filename;
-            // A map of include files to types for re-export (used to determine which files to import).
-            std::map<std::string, std::set<std::string>> _importedTypesByInclude;
-        };
+        // All modules imported by the current unit.
+        std::set<std::string> _importedModules;
+        // A map of imported types to their module name.
+        std::map<std::string, std::string> _importedTypes;
+        // The module name of the current unit.
+        std::string _module;
+        // The filename of the current unit.
+        std::string _filename;
+        // A map of include files to types for re-export (used to determine which files to import).
+        std::map<std::string, std::set<std::string>> _importedTypesByInclude;
+    };
 
-        class TypeScriptVisitor final : public JsVisitor
-        {
-        public:
-            TypeScriptVisitor(
-                IceInternal::Output& out,
-                std::map<std::string, std::string> importedTypes,
-                std::map<std::string, std::set<std::string>> importedTypesByInclude);
+    class TypeScriptVisitor final : public JsVisitor
+    {
+    public:
+        TypeScriptVisitor(
+            IceInternal::Output& out,
+            std::map<std::string, std::string> importedTypes,
+            std::map<std::string, std::set<std::string>> importedTypesByInclude);
 
-            bool visitUnitStart(const UnitPtr&) final;
-            void visitUnitEnd(const UnitPtr&) final;
-            bool visitModuleStart(const ModulePtr&) final;
-            void visitModuleEnd(const ModulePtr&) final;
-            bool visitClassDefStart(const ClassDefPtr&) final;
-            bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
-            bool visitExceptionStart(const ExceptionPtr&) final;
-            bool visitStructStart(const StructPtr&) final;
-            void visitSequence(const SequencePtr&) final;
-            void visitDictionary(const DictionaryPtr&) final;
-            void visitEnum(const EnumPtr&) final;
-            void visitConst(const ConstPtr&) final;
+        bool visitUnitStart(const UnitPtr&) final;
+        void visitUnitEnd(const UnitPtr&) final;
+        bool visitModuleStart(const ModulePtr&) final;
+        void visitModuleEnd(const ModulePtr&) final;
+        bool visitClassDefStart(const ClassDefPtr&) final;
+        bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
+        bool visitExceptionStart(const ExceptionPtr&) final;
+        bool visitStructStart(const StructPtr&) final;
+        void visitSequence(const SequencePtr&) final;
+        void visitDictionary(const DictionaryPtr&) final;
+        void visitEnum(const EnumPtr&) final;
+        void visitConst(const ConstPtr&) final;
 
-        private:
-            [[nodiscard]] std::string importPrefix(const std::string& scopedName) const;
-            [[nodiscard]] std::string
-            typeToTsString(const TypePtr& type, bool nullable = false, bool forParameter = false, bool optional = false)
-                const;
-            void writeOpDocSummary(IceInternal::Output& out, const OperationPtr& op, bool forDispatch);
-            void writeNestedModuleExports(const std::string& currentModuleScope);
+    private:
+        [[nodiscard]] std::string importPrefix(const std::string& scopedName) const;
+        [[nodiscard]] std::string
+        typeToTsString(const TypePtr& type, bool nullable = false, bool forParameter = false, bool optional = false)
+            const;
+        void writeOpDocSummary(IceInternal::Output& out, const OperationPtr& op, bool forDispatch);
+        void writeNestedModuleExports(const std::string& currentModuleScope);
 
-            // The module name of the current unit.
-            std::string _module;
-            // The import prefix for the "ice" module either empty string when building Ice or "__module__zeroc_ice."
-            std::string _iceImportPrefix;
-            // A map of imported types to their module name.
-            std::map<std::string, std::string> _importedTypes;
-            // A map of include files to the types they define (for generating nested module exports).
-            std::map<std::string, std::set<std::string>> _importedTypesByInclude;
-            // The set of modules visited in the current file (used to detect missing nested modules).
-            std::set<std::string> _visitedModules;
-            // Cache of types already exported (to prevent duplicates across nested module exports).
-            std::set<std::string> _exportedTypes;
-        };
+        // The module name of the current unit.
+        std::string _module;
+        // The import prefix for the "ice" module either empty string when building Ice or "__module__zeroc_ice."
+        std::string _iceImportPrefix;
+        // A map of imported types to their module name.
+        std::map<std::string, std::string> _importedTypes;
+        // A map of include files to the types they define (for generating nested module exports).
+        std::map<std::string, std::set<std::string>> _importedTypesByInclude;
+        // The set of modules visited in the current file (used to detect missing nested modules).
+        std::set<std::string> _visitedModules;
+        // Cache of types already exported (to prevent duplicates across nested module exports).
+        std::set<std::string> _exportedTypes;
     };
 }
 

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -83,7 +83,7 @@ Gen::Gen(const string& base, const string& dir)
     _out << nl << "import Foundation";
 }
 
-Gen::~Gen()
+Slice::Gen::~Gen()
 {
     if (_out.isOpen())
     {
@@ -93,7 +93,7 @@ Gen::~Gen()
 }
 
 void
-Gen::generate(const UnitPtr& unit)
+Slice::Gen::generate(const UnitPtr& unit)
 {
     validateSwiftMetadata(unit);
     validateSwiftModuleMappings(unit);
@@ -113,17 +113,17 @@ Gen::generate(const UnitPtr& unit)
 }
 
 void
-Gen::printHeader()
+Slice::Gen::printHeader()
 {
     _out << "// Copyright (c) ZeroC, Inc.";
     _out << sp;
     _out << nl << "// slice2swift version " << ICE_STRING_VERSION;
 }
 
-Gen::ImportVisitor::ImportVisitor(IceInternal::Output& o) : out(o) {}
+Slice::ImportVisitor::ImportVisitor(IceInternal::Output& o) : out(o) {}
 
 bool
-Gen::ImportVisitor::visitModuleStart(const ModulePtr& p)
+Slice::ImportVisitor::visitModuleStart(const ModulePtr& p)
 {
     // Always import Ice module first if not building Ice
     if (p->isTopLevel() && _imports.empty())
@@ -139,7 +139,7 @@ Gen::ImportVisitor::visitModuleStart(const ModulePtr& p)
 }
 
 bool
-Gen::ImportVisitor::visitClassDefStart(const ClassDefPtr& p)
+Slice::ImportVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
     // Add imports required for base class
     addImport(p->base(), p);
@@ -154,7 +154,7 @@ Gen::ImportVisitor::visitClassDefStart(const ClassDefPtr& p)
 }
 
 bool
-Gen::ImportVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
+Slice::ImportVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     // Add imports required for base interfaces
     InterfaceList bases = p->bases();
@@ -178,7 +178,7 @@ Gen::ImportVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 }
 
 bool
-Gen::ImportVisitor::visitStructStart(const StructPtr& p)
+Slice::ImportVisitor::visitStructStart(const StructPtr& p)
 {
     // Add imports required for data members
     for (const auto& dataMember : p->dataMembers())
@@ -190,7 +190,7 @@ Gen::ImportVisitor::visitStructStart(const StructPtr& p)
 }
 
 bool
-Gen::ImportVisitor::visitExceptionStart(const ExceptionPtr& p)
+Slice::ImportVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
     // Add imports required for base exceptions
     addImport(p->base(), p);
@@ -204,14 +204,14 @@ Gen::ImportVisitor::visitExceptionStart(const ExceptionPtr& p)
 }
 
 void
-Gen::ImportVisitor::visitSequence(const SequencePtr& seq)
+Slice::ImportVisitor::visitSequence(const SequencePtr& seq)
 {
     // Add import required for the sequence element type
     addImport(seq->type(), seq);
 }
 
 void
-Gen::ImportVisitor::visitDictionary(const DictionaryPtr& dict)
+Slice::ImportVisitor::visitDictionary(const DictionaryPtr& dict)
 {
     // Add imports required for the dictionary key and value types
     addImport(dict->keyType(), dict);
@@ -219,7 +219,7 @@ Gen::ImportVisitor::visitDictionary(const DictionaryPtr& dict)
 }
 
 void
-Gen::ImportVisitor::writeImports()
+Slice::ImportVisitor::writeImports()
 {
     for (const auto& import : _imports)
     {
@@ -228,7 +228,7 @@ Gen::ImportVisitor::writeImports()
 }
 
 void
-Gen::ImportVisitor::addImport(const SyntaxTreeBasePtr& p, const ContainedPtr& usedBy)
+Slice::ImportVisitor::addImport(const SyntaxTreeBasePtr& p, const ContainedPtr& usedBy)
 {
     // Only add imports for user defined constructs...
     auto definition = dynamic_pointer_cast<Contained>(p);
@@ -245,7 +245,7 @@ Gen::ImportVisitor::addImport(const SyntaxTreeBasePtr& p, const ContainedPtr& us
 }
 
 void
-Gen::ImportVisitor::addImport(const string& module)
+Slice::ImportVisitor::addImport(const string& module)
 {
     if (find(_imports.begin(), _imports.end(), module) == _imports.end())
     {
@@ -253,10 +253,10 @@ Gen::ImportVisitor::addImport(const string& module)
     }
 }
 
-Gen::TypesVisitor::TypesVisitor(IceInternal::Output& o) : out(o) {}
+Slice::TypesVisitor::TypesVisitor(IceInternal::Output& o) : out(o) {}
 
 bool
-Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
+Slice::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 {
     const string prefix = getClassResolverPrefix(p->unit());
     const string swiftModule = getSwiftModule(p->getTopLevelModule());
@@ -396,13 +396,13 @@ Gen::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 }
 
 void
-Gen::TypesVisitor::visitClassDefEnd(const ClassDefPtr&)
+Slice::TypesVisitor::visitClassDefEnd(const ClassDefPtr&)
 {
     out << eb;
 }
 
 bool
-Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
+Slice::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 {
     const string swiftModule = getSwiftModule(p->getTopLevelModule());
     const string name = getRelativeTypeString(p, swiftModule);
@@ -533,7 +533,7 @@ Gen::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 }
 
 bool
-Gen::TypesVisitor::visitStructStart(const StructPtr& p)
+Slice::TypesVisitor::visitStructStart(const StructPtr& p)
 {
     const string swiftModule = getSwiftModule(p->getTopLevelModule());
     const string name = getRelativeTypeString(p, swiftModule);
@@ -672,7 +672,7 @@ Gen::TypesVisitor::visitStructStart(const StructPtr& p)
 }
 
 void
-Gen::TypesVisitor::visitSequence(const SequencePtr& p)
+Slice::TypesVisitor::visitSequence(const SequencePtr& p)
 {
     const string swiftModule = getSwiftModule(p->getTopLevelModule());
     const string name = getRelativeTypeString(p, swiftModule);
@@ -828,7 +828,7 @@ Gen::TypesVisitor::visitSequence(const SequencePtr& p)
 }
 
 void
-Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
+Slice::TypesVisitor::visitDictionary(const DictionaryPtr& p)
 {
     const string swiftModule = getSwiftModule(p->getTopLevelModule());
     const string name = getRelativeTypeString(p, swiftModule);
@@ -978,7 +978,7 @@ Gen::TypesVisitor::visitDictionary(const DictionaryPtr& p)
 }
 
 void
-Gen::TypesVisitor::visitEnum(const EnumPtr& p)
+Slice::TypesVisitor::visitEnum(const EnumPtr& p)
 {
     const string swiftModule = getSwiftModule(p->getTopLevelModule());
     const string name = getRelativeTypeString(p, swiftModule);
@@ -1074,7 +1074,7 @@ Gen::TypesVisitor::visitEnum(const EnumPtr& p)
 }
 
 void
-Gen::TypesVisitor::visitConst(const ConstPtr& p)
+Slice::TypesVisitor::visitConst(const ConstPtr& p)
 {
     const TypePtr type = p->type();
     const string swiftModule = getSwiftModule(p->getTopLevelModule());
@@ -1087,7 +1087,7 @@ Gen::TypesVisitor::visitConst(const ConstPtr& p)
 }
 
 bool
-Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
+Slice::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     InterfaceList bases = p->bases();
 
@@ -1276,13 +1276,13 @@ Gen::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 }
 
 void
-Gen::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr&)
+Slice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr&)
 {
     out << eb;
 }
 
 void
-Gen::TypesVisitor::visitOperation(const OperationPtr& op)
+Slice::TypesVisitor::visitOperation(const OperationPtr& op)
 {
     const ParameterList inParams = op->inParameters();
     const bool returnsAnyValues = op->returnsAnyValues();
@@ -1365,10 +1365,10 @@ Gen::TypesVisitor::visitOperation(const OperationPtr& op)
     out << eb;
 }
 
-Gen::ServantVisitor::ServantVisitor(IceInternal::Output& o) : out(o) {}
+Slice::ServantVisitor::ServantVisitor(IceInternal::Output& o) : out(o) {}
 
 bool
-Gen::ServantVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
+Slice::ServantVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     const string swiftModule = getSwiftModule(p->getTopLevelModule());
     const string servant = getRelativeTypeString(p, swiftModule);
@@ -1405,13 +1405,13 @@ Gen::ServantVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 }
 
 void
-Gen::ServantVisitor::visitInterfaceDefEnd(const InterfaceDefPtr&)
+Slice::ServantVisitor::visitInterfaceDefEnd(const InterfaceDefPtr&)
 {
     out << eb;
 }
 
 void
-Gen::ServantVisitor::visitOperation(const OperationPtr& op)
+Slice::ServantVisitor::visitOperation(const OperationPtr& op)
 {
     const string swiftModule = getSwiftModule(op->getTopLevelModule());
 
@@ -1434,10 +1434,10 @@ Gen::ServantVisitor::visitOperation(const OperationPtr& op)
     }
 }
 
-Gen::ServantExtVisitor::ServantExtVisitor(IceInternal::Output& o) : out(o) {}
+Slice::ServantExtVisitor::ServantExtVisitor(IceInternal::Output& o) : out(o) {}
 
 bool
-Gen::ServantExtVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
+Slice::ServantExtVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 {
     const string swiftModule = getSwiftModule(p->getTopLevelModule());
     const string servant = getRelativeTypeString(p, swiftModule);
@@ -1520,13 +1520,13 @@ Gen::ServantExtVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 }
 
 void
-Gen::ServantExtVisitor::visitInterfaceDefEnd(const InterfaceDefPtr&)
+Slice::ServantExtVisitor::visitInterfaceDefEnd(const InterfaceDefPtr&)
 {
     out << eb;
 }
 
 void
-Gen::ServantExtVisitor::visitOperation(const OperationPtr& op)
+Slice::ServantExtVisitor::visitOperation(const OperationPtr& op)
 {
     const string opName = op->mappedName();
     const ParameterList inParams = op->inParameters();

--- a/cpp/src/slice2swift/Gen.h
+++ b/cpp/src/slice2swift/Gen.h
@@ -22,79 +22,79 @@ namespace Slice
     private:
         IceInternal::Output _out;
         std::string _fileBase;
+    };
 
-        class ImportVisitor final : public ParserVisitor
-        {
-        public:
-            ImportVisitor(IceInternal::Output&);
+    class ImportVisitor final : public ParserVisitor
+    {
+    public:
+        ImportVisitor(IceInternal::Output&);
 
-            bool visitModuleStart(const ModulePtr&) final;
-            bool visitClassDefStart(const ClassDefPtr&) final;
-            bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
-            bool visitStructStart(const StructPtr&) final;
-            bool visitExceptionStart(const ExceptionPtr&) final;
-            void visitSequence(const SequencePtr&) final;
-            void visitDictionary(const DictionaryPtr&) final;
+        bool visitModuleStart(const ModulePtr&) final;
+        bool visitClassDefStart(const ClassDefPtr&) final;
+        bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
+        bool visitStructStart(const StructPtr&) final;
+        bool visitExceptionStart(const ExceptionPtr&) final;
+        void visitSequence(const SequencePtr&) final;
+        void visitDictionary(const DictionaryPtr&) final;
 
-            void writeImports();
+        void writeImports();
 
-        private:
-            void addImport(const SyntaxTreeBasePtr& p, const ContainedPtr& usedBy);
-            void addImport(const std::string& module);
+    private:
+        void addImport(const SyntaxTreeBasePtr& p, const ContainedPtr& usedBy);
+        void addImport(const std::string& module);
 
-            IceInternal::Output& out;
-            std::vector<std::string> _imports;
-        };
+        IceInternal::Output& out;
+        std::vector<std::string> _imports;
+    };
 
-        class TypesVisitor final : public ParserVisitor
-        {
-        public:
-            TypesVisitor(IceInternal::Output&);
+    class TypesVisitor final : public ParserVisitor
+    {
+    public:
+        TypesVisitor(IceInternal::Output&);
 
-            bool visitExceptionStart(const ExceptionPtr&) final;
-            bool visitClassDefStart(const ClassDefPtr&) final;
-            void visitClassDefEnd(const ClassDefPtr&) final;
-            bool visitStructStart(const StructPtr&) final;
-            void visitSequence(const SequencePtr&) final;
-            void visitDictionary(const DictionaryPtr&) final;
-            void visitEnum(const EnumPtr&) final;
-            void visitConst(const ConstPtr&) final;
+        bool visitExceptionStart(const ExceptionPtr&) final;
+        bool visitClassDefStart(const ClassDefPtr&) final;
+        void visitClassDefEnd(const ClassDefPtr&) final;
+        bool visitStructStart(const StructPtr&) final;
+        void visitSequence(const SequencePtr&) final;
+        void visitDictionary(const DictionaryPtr&) final;
+        void visitEnum(const EnumPtr&) final;
+        void visitConst(const ConstPtr&) final;
 
-            bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
-            void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
-            void visitOperation(const OperationPtr&) final;
+        bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
+        void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
+        void visitOperation(const OperationPtr&) final;
 
-        private:
-            IceInternal::Output& out;
-        };
+    private:
+        IceInternal::Output& out;
+    };
 
-        // Generates the servant protocols.
-        class ServantVisitor final : public ParserVisitor
-        {
-        public:
-            ServantVisitor(IceInternal::Output&);
+    // Generates the servant protocols.
+    class ServantVisitor final : public ParserVisitor
+    {
+    public:
+        ServantVisitor(IceInternal::Output&);
 
-            bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
-            void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
-            void visitOperation(const OperationPtr&) final;
+        bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
+        void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
+        void visitOperation(const OperationPtr&) final;
 
-        private:
-            IceInternal::Output& out;
-        };
+    private:
+        IceInternal::Output& out;
+    };
 
-        // Generate extensions for the servant protocols.
-        class ServantExtVisitor final : public ParserVisitor
-        {
-        public:
-            ServantExtVisitor(IceInternal::Output&);
+    // Generate extensions for the servant protocols.
+    class ServantExtVisitor final : public ParserVisitor
+    {
+    public:
+        ServantExtVisitor(IceInternal::Output&);
 
-            bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
-            void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
-            void visitOperation(const OperationPtr&) final;
+        bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
+        void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
+        void visitOperation(const OperationPtr&) final;
 
-        private:
-            IceInternal::Output& out;
-        };
+    private:
+        IceInternal::Output& out;
     };
 }
 


### PR DESCRIPTION
The code-gen visitors for `slice2cpp`, `slice2java`, `slice2js`, and `slice2swift` all have this structure where we have a single top-level class named `Gen`, and all the visitors are nested classes inside `Gen`.

I don't see any reason for this structure though, none of them use any instance fields or methods on `Gen`...
So this PR moves the visitor classes out of `Gen` and makes them top-level, normal classes in the `Slice` namespace.
Since GitHub captures this poorly, all this means is:

1) Dedented the classes in their header files, after moving them out of `Gen`.
2) Removed the extra `Gen::` qualifier from the function implementations.