### PR TITLE
More minor cleanup in the Slice compilers

### DIFF
--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -111,6 +111,58 @@ namespace
         }
         return true;
     }
+
+    /// Checks an identifier for illegal syntax and reports any errors that are present.
+    bool reportIllegalSuffixOrUnderscore(const string& identifier)
+    {
+        // check whether the identifier is scoped
+        size_t scopeIndex = identifier.rfind("::");
+        bool isScoped = scopeIndex != string::npos;
+        string name;
+        if (isScoped)
+        {
+            name = identifier.substr(scopeIndex + 2); // Only check the unscoped identifier for syntax
+        }
+        else
+        {
+            name = identifier;
+        }
+
+        assert(!name.empty());
+        bool isValid = true;
+
+        // check the identifier for reserved suffixes
+        static const string suffixBlacklist[] = {"Helper", "Holder", "Prx", "Ptr"};
+        for (const auto& i : suffixBlacklist)
+        {
+            if (name.find(i, name.size() - i.size()) != string::npos)
+            {
+                currentUnit->error("illegal identifier '" + name + "': '" + i + "' suffix is reserved");
+                isValid = false;
+                break;
+            }
+        }
+
+        // check the identifier for illegal underscores
+        size_t index = name.find('_');
+        if (index == 0)
+        {
+            currentUnit->error("illegal leading underscore in identifier '" + name + "'");
+            isValid = false;
+        }
+        else if (name.rfind('_') == (name.size() - 1))
+        {
+            currentUnit->error("illegal trailing underscore in identifier '" + name + "'");
+            isValid = false;
+        }
+        else if (name.find("__") != string::npos)
+        {
+            currentUnit->error("illegal double underscore in identifier '" + name + "'");
+            isValid = false;
+        }
+
+        return isValid;
+    }
 }
 
 namespace Slice
@@ -1595,9 +1647,9 @@ Slice::Container::lookupInterfaceDef(const string& identifier, bool emitErrors)
     TypePtr resolvedType = lookupType(identifier);
     if (resolvedType)
     {
-        if (auto interface = dynamic_pointer_cast<InterfaceDecl>(resolvedType))
+        if (auto interfaceDecl = dynamic_pointer_cast<InterfaceDecl>(resolvedType))
         {
-            if (InterfaceDefPtr def = interface->definition())
+            if (InterfaceDefPtr def = interfaceDecl->definition())
             {
                 return def;
             }
@@ -2923,7 +2975,7 @@ Slice::InterfaceDef::InterfaceDef(const ContainerPtr& container, const string& n
 // ----------------------------------------------------------------------
 
 InterfaceDefPtr
-Slice::Operation::interface() const
+Slice::Operation::parentInterface() const
 {
     return dynamic_pointer_cast<InterfaceDef>(_container);
 }
@@ -2955,7 +3007,7 @@ Slice::Operation::mode() const
 bool
 Slice::Operation::hasMarshaledResult() const
 {
-    InterfaceDefPtr intf = interface();
+    InterfaceDefPtr intf = parentInterface();
     assert(intf);
     if (intf->hasMetadata("marshaled-result") || hasMetadata("marshaled-result"))
     {

--- a/cpp/src/Slice/Parser.h
+++ b/cpp/src/Slice/Parser.h
@@ -700,7 +700,7 @@ namespace Slice
             std::int32_t returnTag,
             Mode mode);
 
-        [[nodiscard]] InterfaceDefPtr interface() const;
+        [[nodiscard]] InterfaceDefPtr parentInterface() const;
         [[nodiscard]] TypePtr returnType() const;
         [[nodiscard]] bool returnIsOptional() const;
         [[nodiscard]] std::int32_t returnTag() const;

--- a/cpp/src/Slice/SliceUtil.cpp
+++ b/cpp/src/Slice/SliceUtil.cpp
@@ -508,58 +508,6 @@ Slice::pluralKindOf(const ContainedPtr& p)
 }
 
 bool
-Slice::reportIllegalSuffixOrUnderscore(const string& identifier)
-{
-    // check whether the identifier is scoped
-    size_t scopeIndex = identifier.rfind("::");
-    bool isScoped = scopeIndex != string::npos;
-    string name;
-    if (isScoped)
-    {
-        name = identifier.substr(scopeIndex + 2); // Only check the unscoped identifier for syntax
-    }
-    else
-    {
-        name = identifier;
-    }
-
-    assert(!name.empty());
-    bool isValid = true;
-
-    // check the identifier for reserved suffixes
-    static const string suffixBlacklist[] = {"Helper", "Holder", "Prx", "Ptr"};
-    for (const auto& i : suffixBlacklist)
-    {
-        if (name.find(i, name.size() - i.size()) != string::npos)
-        {
-            currentUnit->error("illegal identifier '" + name + "': '" + i + "' suffix is reserved");
-            isValid = false;
-            break;
-        }
-    }
-
-    // check the identifier for illegal underscores
-    size_t index = name.find('_');
-    if (index == 0)
-    {
-        currentUnit->error("illegal leading underscore in identifier '" + name + "'");
-        isValid = false;
-    }
-    else if (name.rfind('_') == (name.size() - 1))
-    {
-        currentUnit->error("illegal trailing underscore in identifier '" + name + "'");
-        isValid = false;
-    }
-    else if (name.find("__") != string::npos)
-    {
-        currentUnit->error("illegal double underscore in identifier '" + name + "'");
-        isValid = false;
-    }
-
-    return isValid;
-}
-
-bool
 Slice::isProxyType(const TypePtr& type)
 {
     BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);

--- a/cpp/src/Slice/Util.h
+++ b/cpp/src/Slice/Util.h
@@ -70,9 +70,6 @@ namespace Slice
     /// @see Contained::kindOf
     std::string pluralKindOf(const ContainedPtr& p);
 
-    // Checks an identifier for illegal syntax and reports any errors that are present.
-    bool reportIllegalSuffixOrUnderscore(const std::string& identifier);
-
     bool isProxyType(const TypePtr& type);
 
     // Is this the first element defined in its container?

--- a/cpp/src/slice2cpp/CPlusPlusUtil.cpp
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.cpp
@@ -17,6 +17,8 @@ using namespace IceInternal;
 
 namespace
 {
+    using namespace Slice::Cpp;
+
     bool isTriviallyCopyable(const StructPtr& st)
     {
         assert(st);
@@ -334,10 +336,10 @@ namespace
     }
 }
 
-string Slice::paramPrefix = "iceP_"; // NOLINT(cert-err58-cpp)
+string Slice::Cpp::paramPrefix = "iceP_"; // NOLINT(cert-err58-cpp)
 
 char
-Slice::ToIfdef::operator()(char c)
+Slice::Cpp::ToIfdef::operator()(char c)
 {
     if (!isalnum(static_cast<unsigned char>(c)))
     {
@@ -350,7 +352,7 @@ Slice::ToIfdef::operator()(char c)
 }
 
 void
-Slice::printHeader(Output& out)
+Slice::Cpp::printHeader(Output& out)
 {
     out << "// Copyright (c) ZeroC, Inc.";
     out << sp;
@@ -358,7 +360,7 @@ Slice::printHeader(Output& out)
 }
 
 void
-Slice::printVersionCheck(Output& out)
+Slice::Cpp::printVersionCheck(Output& out)
 {
     out << "\n";
     out << "\n#ifndef ICE_DISABLE_VERSION";
@@ -389,7 +391,7 @@ Slice::printVersionCheck(Output& out)
 }
 
 void
-Slice::printDllExportStuff(Output& out, const string& dllExport)
+Slice::Cpp::printDllExportStuff(Output& out, const string& dllExport)
 {
     if (dllExport.size() && dllExport != "ICE_API")
     {
@@ -404,8 +406,34 @@ Slice::printDllExportStuff(Output& out, const string& dllExport)
     }
 }
 
+TypeContext
+Slice::Cpp::setUseWstring(const ContainedPtr& p, list<TypeContext>& hist, TypeContext typeCtx)
+{
+    hist.push_back(typeCtx);
+    if (auto argument = p->getMetadataArgs("cpp:type"))
+    {
+        if (argument == "wstring")
+        {
+            typeCtx = TypeContext::UseWstring;
+        }
+        else if (argument == "string")
+        {
+            typeCtx = TypeContext::None;
+        }
+    }
+    return typeCtx;
+}
+
+TypeContext
+Slice::Cpp::resetUseWstring(list<TypeContext>& hist)
+{
+    TypeContext use = hist.back();
+    hist.pop_back();
+    return use;
+}
+
 bool
-Slice::isMovable(const TypePtr& type)
+Slice::Cpp::isMovable(const TypePtr& type)
 {
     BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
     if (builtin)
@@ -434,7 +462,7 @@ Slice::isMovable(const TypePtr& type)
 }
 
 string
-Slice::getUnqualified(const string& type, const string& scope)
+Slice::Cpp::getUnqualified(const string& type, const string& scope)
 {
     if (type.find("::") != string::npos)
     {
@@ -457,7 +485,7 @@ Slice::getUnqualified(const string& type, const string& scope)
 }
 
 string
-Slice::typeToString(
+Slice::Cpp::typeToString(
     const TypePtr& type,
     bool optional,
     const string& scope,
@@ -544,7 +572,7 @@ Slice::typeToString(
 }
 
 string
-Slice::inputTypeToString(
+Slice::Cpp::inputTypeToString(
     const TypePtr& type,
     bool optional,
     const string& scope,
@@ -568,7 +596,7 @@ Slice::inputTypeToString(
 }
 
 string
-Slice::outputTypeToString(
+Slice::Cpp::outputTypeToString(
     const TypePtr& type,
     bool optional,
     const string& scope,
@@ -582,7 +610,7 @@ Slice::outputTypeToString(
 }
 
 string
-Slice::operationModeToString(Operation::Mode mode)
+Slice::Cpp::operationModeToString(Operation::Mode mode)
 {
     switch (mode)
     {
@@ -605,7 +633,7 @@ Slice::operationModeToString(Operation::Mode mode)
 }
 
 string
-Slice::opFormatTypeToString(const OperationPtr& op)
+Slice::Cpp::opFormatTypeToString(const OperationPtr& op)
 {
     optional<FormatType> opFormat = op->format();
     if (opFormat)
@@ -629,19 +657,19 @@ Slice::opFormatTypeToString(const OperationPtr& op)
 }
 
 void
-Slice::writeMarshalCode(Output& out, const ParameterList& params, const OperationPtr& op)
+Slice::Cpp::writeMarshalCode(Output& out, const ParameterList& params, const OperationPtr& op)
 {
     writeMarshalUnmarshalParams(out, params, op, true);
 }
 
 void
-Slice::writeUnmarshalCode(Output& out, const ParameterList& params, const OperationPtr& op)
+Slice::Cpp::writeUnmarshalCode(Output& out, const ParameterList& params, const OperationPtr& op)
 {
     writeMarshalUnmarshalParams(out, params, op, false);
 }
 
 void
-Slice::writeAllocateCode(
+Slice::Cpp::writeAllocateCode(
     Output& out,
     const ParameterList& params,
     const OperationPtr& op,
@@ -710,7 +738,7 @@ writeMarshalUnmarshalAllInHolder(
 }
 
 void
-Slice::writeStreamReader(Output& out, const StructPtr& p, const DataMemberList& dataMembers)
+Slice::Cpp::writeStreamReader(Output& out, const StructPtr& p, const DataMemberList& dataMembers)
 {
     string fullName = p->mappedScoped("::", true);
 
@@ -726,7 +754,7 @@ Slice::writeStreamReader(Output& out, const StructPtr& p, const DataMemberList& 
 }
 
 void
-Slice::readDataMembers(Output& out, const DataMemberList& dataMembers)
+Slice::Cpp::readDataMembers(Output& out, const DataMemberList& dataMembers)
 {
     assert(dataMembers.size() > 0);
 
@@ -738,7 +766,7 @@ Slice::readDataMembers(Output& out, const DataMemberList& dataMembers)
 }
 
 void
-Slice::writeDataMembers(Output& out, const DataMemberList& dataMembers)
+Slice::Cpp::writeDataMembers(Output& out, const DataMemberList& dataMembers)
 {
     assert(dataMembers.size() > 0);
 
@@ -750,7 +778,7 @@ Slice::writeDataMembers(Output& out, const DataMemberList& dataMembers)
 }
 
 void
-Slice::writeIceTuple(IceInternal::Output& out, const DataMemberList& dataMembers, TypeContext typeCtx)
+Slice::Cpp::writeIceTuple(IceInternal::Output& out, const DataMemberList& dataMembers, TypeContext typeCtx)
 {
     // Use an empty scope to get full qualified names from calls to typeToString.
     const string scope = "";
@@ -776,7 +804,7 @@ Slice::writeIceTuple(IceInternal::Output& out, const DataMemberList& dataMembers
 }
 
 string
-Slice::findMetadata(const MetadataList& metadata, TypeContext typeCtx)
+Slice::Cpp::findMetadata(const MetadataList& metadata, TypeContext typeCtx)
 {
     for (const auto& meta : metadata)
     {
@@ -810,7 +838,7 @@ Slice::findMetadata(const MetadataList& metadata, TypeContext typeCtx)
 }
 
 bool
-Slice::inWstringModule(const SequencePtr& seq)
+Slice::Cpp::inWstringModule(const SequencePtr& seq)
 {
     ContainerPtr cont = seq->container();
     while (cont)
@@ -837,7 +865,7 @@ Slice::inWstringModule(const SequencePtr& seq)
 }
 
 string
-Slice::cppLinkFormatter(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target)
+Slice::Cpp::cppLinkFormatter(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target)
 {
     if (target)
     {
@@ -874,7 +902,7 @@ Slice::cppLinkFormatter(const string& rawLink, const ContainedPtr& source, const
             // We opt for the syntax where operation names are qualified by what type they're defined on.
             // See: https://www.doxygen.nl/manual/autolink.html#linkfunc.
 
-            InterfaceDefPtr parent = operationTarget->interface();
+            InterfaceDefPtr parent = operationTarget->parentInterface();
             return getUnqualified(parent->mappedScoped("::", true) + "Prx", source->mappedScope("::", true)) +
                    "::" + operationTarget->mappedName();
         }
@@ -894,7 +922,7 @@ Slice::cppLinkFormatter(const string& rawLink, const ContainedPtr& source, const
 }
 
 void
-Slice::validateCppMetadata(const UnitPtr& unit)
+Slice::Cpp::validateCppMetadata(const UnitPtr& unit)
 {
     map<string, MetadataInfo> knownMetadata;
 

--- a/cpp/src/slice2cpp/CPlusPlusUtil.h
+++ b/cpp/src/slice2cpp/CPlusPlusUtil.h
@@ -7,7 +7,7 @@
 #include "../Slice/Parser.h"
 #include "TypeContext.h"
 
-namespace Slice
+namespace Slice::Cpp
 {
     extern std::string paramPrefix;
 
@@ -19,6 +19,9 @@ namespace Slice
     void printHeader(IceInternal::Output& out);
     void printVersionCheck(IceInternal::Output& out);
     void printDllExportStuff(IceInternal::Output& out, const std::string& dllExport);
+
+    TypeContext setUseWstring(const ContainedPtr& p, std::list<TypeContext>& hist, TypeContext typeCtx);
+    TypeContext resetUseWstring(std::list<TypeContext>& hist);
 
     bool isMovable(const TypePtr& type);
 

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -13,6 +13,7 @@
 
 using namespace std;
 using namespace Slice;
+using namespace Slice::Cpp;
 using namespace IceInternal;
 
 namespace
@@ -552,7 +553,7 @@ Slice::Gen::Gen(
     const vector<string>& includePaths,
     string dllExport,
     string dir)
-    : _base(std::move(base)),
+    : _base(Slice::baseName(base)),
       _headerExtension(std::move(headerExtension)),
       _sourceExtension(std::move(sourceExtension)),
       _extraHeaders(extraHeaders),
@@ -564,12 +565,6 @@ Slice::Gen::Gen(
     for (auto& includePath : _includePaths)
     {
         includePath = fullPath(includePath);
-    }
-
-    string::size_type pos = _base.find_last_of("/\\");
-    if (pos != string::npos)
-    {
-        _base.erase(0, pos + 1);
     }
 }
 
@@ -817,32 +812,6 @@ Slice::Gen::writeExtraHeaders(IceInternal::Output& out)
     }
 }
 
-TypeContext
-Slice::Gen::setUseWstring(const ContainedPtr& p, list<TypeContext>& hist, TypeContext typeCtx)
-{
-    hist.push_back(typeCtx);
-    if (auto argument = p->getMetadataArgs("cpp:type"))
-    {
-        if (argument == "wstring")
-        {
-            typeCtx = TypeContext::UseWstring;
-        }
-        else if (argument == "string")
-        {
-            typeCtx = TypeContext::None;
-        }
-    }
-    return typeCtx;
-}
-
-TypeContext
-Slice::Gen::resetUseWstring(list<TypeContext>& hist)
-{
-    TypeContext use = hist.back();
-    hist.pop_back();
-    return use;
-}
-
 string
 Slice::Gen::getHeaderExt(string_view file, const UnitPtr& unit)
 {
@@ -869,7 +838,7 @@ Slice::ForwardDeclVisitor::ForwardDeclVisitor(Output& h, Output& c, string dllEx
 bool
 Slice::ForwardDeclVisitor::visitModuleStart(const ModulePtr& p)
 {
-    _useWstring = Gen::setUseWstring(p, _useWstringHist, _useWstring);
+    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
     H << sp;
     writeDocSummary(H, p);
     H << nl << "namespace " << p->mappedName() << nl << '{';
@@ -882,7 +851,7 @@ Slice::ForwardDeclVisitor::visitModuleEnd(const ModulePtr&)
 {
     H.dec();
     H << nl << '}';
-    _useWstring = Gen::resetUseWstring(_useWstringHist);
+    _useWstring = resetUseWstring(_useWstringHist);
 }
 
 void
@@ -1195,7 +1164,7 @@ Slice::ProxyVisitor::visitModuleStart(const ModulePtr& p)
         return false;
     }
 
-    _useWstring = Gen::setUseWstring(p, _useWstringHist, _useWstring);
+    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
 
     H << sp << nl << "namespace " << p->mappedName() << nl << '{';
     H.inc();
@@ -1208,7 +1177,7 @@ Slice::ProxyVisitor::visitModuleEnd(const ModulePtr&)
     H.dec();
     H << nl << '}';
 
-    _useWstring = Gen::resetUseWstring(_useWstringHist);
+    _useWstring = resetUseWstring(_useWstringHist);
 }
 
 bool
@@ -1223,7 +1192,7 @@ Slice::ProxyVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         H << sp;
     }
 
-    _useWstring = Gen::setUseWstring(p, _useWstringHist, _useWstring);
+    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
 
     const string scope = p->mappedScope("::", true);
     const string prx = p->mappedName() + "Prx";
@@ -1369,13 +1338,13 @@ Slice::ProxyVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 
     H << eb << ';';
 
-    _useWstring = Gen::resetUseWstring(_useWstringHist);
+    _useWstring = resetUseWstring(_useWstringHist);
 }
 
 void
 Slice::ProxyVisitor::visitOperation(const OperationPtr& p)
 {
-    const InterfaceDefPtr container = p->interface();
+    const InterfaceDefPtr container = p->parentInterface();
     const string opName = p->mappedName();
     const string interfaceScope = container->mappedScope("::", true);
     const string interfaceName = container->mappedName();
@@ -1635,7 +1604,7 @@ Slice::ProxyVisitor::emitOperationImpl(
     const string& prefix,
     const vector<string>& outgoingAsyncParams)
 {
-    const InterfaceDefPtr container = p->interface();
+    const InterfaceDefPtr container = p->parentInterface();
     const string opName = p->mappedName();
     const string opImplName = prefix + opName;
     const string interfaceScope = container->mappedScope("::", true);
@@ -1771,7 +1740,7 @@ Slice::DataDefVisitor::visitModuleStart(const ModulePtr& p)
         return false;
     }
 
-    _useWstring = Gen::setUseWstring(p, _useWstringHist, _useWstring);
+    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
     H << sp << nl << "namespace " << p->mappedName() << nl << '{';
     H.inc();
     return true;
@@ -1797,7 +1766,7 @@ Slice::DataDefVisitor::visitModuleEnd(const ModulePtr& p)
 
     H.dec();
     H << nl << '}';
-    _useWstring = Gen::resetUseWstring(_useWstringHist);
+    _useWstring = resetUseWstring(_useWstringHist);
 }
 
 bool
@@ -1812,7 +1781,7 @@ Slice::DataDefVisitor::visitStructStart(const StructPtr& p)
         H << sp;
     }
 
-    _useWstring = Gen::setUseWstring(p, _useWstringHist, _useWstring);
+    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
 
     writeDocSummary(H, p, {.includeHeaderFile = true, .generatedType = "struct"});
     H << nl << "struct " << getDeprecatedAttribute(p) << p->mappedName();
@@ -1866,7 +1835,7 @@ Slice::DataDefVisitor::visitStructEnd(const StructPtr& p)
         C << eb;
     }
 
-    _useWstring = Gen::resetUseWstring(_useWstringHist);
+    _useWstring = resetUseWstring(_useWstringHist);
 }
 
 void
@@ -1892,7 +1861,7 @@ Slice::DataDefVisitor::visitExceptionStart(const ExceptionPtr& p)
         H << sp;
     }
 
-    _useWstring = Gen::setUseWstring(p, _useWstringHist, _useWstring);
+    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
 
     const string name = p->mappedName();
     const string scope = p->mappedScope("::", true);
@@ -2133,7 +2102,7 @@ Slice::DataDefVisitor::visitExceptionEnd(const ExceptionPtr& p)
 
     H << eb << ';';
 
-    _useWstring = Gen::resetUseWstring(_useWstringHist);
+    _useWstring = resetUseWstring(_useWstringHist);
 }
 
 bool
@@ -2148,7 +2117,7 @@ Slice::DataDefVisitor::visitClassDefStart(const ClassDefPtr& p)
         H << sp;
     }
 
-    _useWstring = Gen::setUseWstring(p, _useWstringHist, _useWstring);
+    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
 
     const string name = p->mappedName();
     const string scope = p->mappedScope("::", true);
@@ -2310,7 +2279,7 @@ Slice::DataDefVisitor::visitClassDefEnd(const ClassDefPtr& p)
 
     H << eb << ';';
 
-    _useWstring = Gen::resetUseWstring(_useWstringHist);
+    _useWstring = resetUseWstring(_useWstringHist);
 }
 
 bool
@@ -2494,7 +2463,7 @@ Slice::InterfaceVisitor::visitModuleStart(const ModulePtr& p)
         return false;
     }
 
-    _useWstring = Gen::setUseWstring(p, _useWstringHist, _useWstring);
+    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
     H << sp << nl << "namespace " << p->mappedName() << nl << '{';
     H.inc();
     return true;
@@ -2506,7 +2475,7 @@ Slice::InterfaceVisitor::visitModuleEnd(const ModulePtr&)
     H.dec();
     H << nl << '}';
 
-    _useWstring = Gen::resetUseWstring(_useWstringHist);
+    _useWstring = resetUseWstring(_useWstringHist);
 }
 
 bool
@@ -2521,7 +2490,7 @@ Slice::InterfaceVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         H << sp;
     }
 
-    _useWstring = Gen::setUseWstring(p, _useWstringHist, _useWstring);
+    _useWstring = setUseWstring(p, _useWstringHist, _useWstring);
     const string name = prependSkeletonPrefix(p->mappedName());
     const string scope = p->mappedScope("::", true);
     const string scoped = p->mappedScope("::") + name;
@@ -2683,14 +2652,14 @@ Slice::InterfaceVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
     H << nl << "/// A shared pointer to " << getArticleFor(name) << ' ' << name << ".";
     H << nl << "using " << name << "Ptr = std::shared_ptr<" << name << ">;";
 
-    _useWstring = Gen::resetUseWstring(_useWstringHist);
+    _useWstring = resetUseWstring(_useWstringHist);
 }
 
 void
 Slice::InterfaceVisitor::visitOperation(const OperationPtr& p)
 {
     const string name = p->mappedName();
-    const InterfaceDefPtr container = p->interface();
+    const InterfaceDefPtr container = p->parentInterface();
     const string interfaceScope = container->mappedScope("::", true);
 
     // The name of the enclosing class + "::".

--- a/cpp/src/slice2cpp/Gen.cpp
+++ b/cpp/src/slice2cpp/Gen.cpp
@@ -545,7 +545,7 @@ namespace
 }
 
 Slice::Gen::Gen(
-    string base,
+    const string& base,
     string headerExtension,
     string sourceExtension,
     const vector<string>& extraHeaders,

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -13,7 +13,7 @@ namespace Slice
     class Gen final
     {
     public:
-        Gen(std::string base,
+        Gen(const std::string& base,
             std::string headerExtension,
             std::string sourceExtension,
             const std::vector<std::string>& extraHeaders,

--- a/cpp/src/slice2cpp/Gen.h
+++ b/cpp/src/slice2cpp/Gen.h
@@ -28,9 +28,6 @@ namespace Slice
 
         void generate(const UnitPtr& unit);
 
-        static TypeContext setUseWstring(const ContainedPtr& p, std::list<TypeContext>& hist, TypeContext typeCtx);
-        static TypeContext resetUseWstring(std::list<TypeContext>& hist);
-
     private:
         void writeExtraHeaders(IceInternal::Output& out);
 

--- a/cpp/src/slice2cpp/Main.cpp
+++ b/cpp/src/slice2cpp/Main.cpp
@@ -40,12 +40,12 @@ class CppDocCommentFormatter final : public DocCommentFormatter
     string formatLink(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target) final
     {
         // We rely on Doxygen's autolink for C++.
-        return Slice::cppLinkFormatter(rawLink, source, target);
+        return Slice::Cpp::cppLinkFormatter(rawLink, source, target);
     }
 
     string formatSeeAlso(const string& rawLink, const ContainedPtr& source, const SyntaxTreeBasePtr& target) final
     {
-        return "@see " + Slice::cppLinkFormatter(rawLink, source, target);
+        return "@see " + Slice::Cpp::cppLinkFormatter(rawLink, source, target);
     }
 };
 

--- a/cpp/src/slice2cs/Gen.cpp
+++ b/cpp/src/slice2cs/Gen.cpp
@@ -17,14 +17,9 @@ using namespace IceInternal;
 
 Slice::Gen::Gen(const string& base, const string& dir, GenMode genMode, bool enableAnalysis)
     : _genMode(genMode),
-      _enableAnalysis(enableAnalysis)
+      _enableAnalysis(enableAnalysis),
+      _fileBase(Slice::baseName(base))
 {
-    _fileBase = base;
-    string::size_type pos = base.find_last_of("/\\");
-    if (pos != string::npos)
-    {
-        _fileBase = base.substr(pos + 1);
-    }
     string file = _genMode == GenMode::IceRpc ? _fileBase + ".IceRpc.cs" : _fileBase + ".cs";
 
     if (!dir.empty())

--- a/cpp/src/slice2cs/IceCsUtil.cpp
+++ b/cpp/src/slice2cs/IceCsUtil.cpp
@@ -135,7 +135,7 @@ Slice::Csharp::resultStructName(const string& className, const string& opName, b
 string
 Slice::Csharp::resultType(const OperationPtr& op, const string& ns, bool dispatch)
 {
-    InterfaceDefPtr interface = op->interface();
+    InterfaceDefPtr interface = op->parentInterface();
     if (dispatch && op->hasMarshaledResult())
     {
         return getUnqualified(interface, ns) + resultStructName("", op->mappedName(), true);
@@ -1814,7 +1814,7 @@ Slice::Csharp::iceLinkFormatter(const string& rawLink, const ContainedPtr& sourc
         if (auto operationTarget = dynamic_pointer_cast<Operation>(target))
         {
             // link to the method on the proxy interface
-            result << getUnqualified(operationTarget->interface(), sourceScope, "", "Prx") << "."
+            result << getUnqualified(operationTarget->parentInterface(), sourceScope, "", "Prx") << "."
                    << operationTarget->mappedName() << "Async";
         }
         else if (auto interfaceTarget = dynamic_pointer_cast<InterfaceDecl>(target))

--- a/cpp/src/slice2cs/IceRpcCsUtil.cpp
+++ b/cpp/src/slice2cs/IceRpcCsUtil.cpp
@@ -792,7 +792,7 @@ Slice::Csharp::icerpcLinkFormatter(const string& rawLink, const ContainedPtr& so
         if (auto operationTarget = dynamic_pointer_cast<Operation>(target))
         {
             // link to the method on the proxy interface
-            result << getUnqualified(operationTarget->interface(), sourceScope, "", "Proxy") << "."
+            result << getUnqualified(operationTarget->parentInterface(), sourceScope, "", "Proxy") << "."
                    << removeEscapePrefix(operationTarget->mappedName()) << "Async";
         }
         else if (auto interfaceTarget = dynamic_pointer_cast<InterfaceDecl>(target))

--- a/cpp/src/slice2cs/IceRpcVisitors.cpp
+++ b/cpp/src/slice2cs/IceRpcVisitors.cpp
@@ -52,7 +52,7 @@ namespace
 
     void writeReturnTask(IceInternal::Output& out, const OperationPtr& operation, const string& taskType, bool dispatch)
     {
-        string ns = getNamespace(operation->interface());
+        string ns = getNamespace(operation->parentInterface());
 
         out << "global::System.Threading.Tasks." << taskType;
 
@@ -97,7 +97,7 @@ namespace
     // A ValueTask that holds all the decoded in parameters,
     void writeParamsValueTask(IceInternal::Output& out, const OperationPtr& operation)
     {
-        string ns = getNamespace(operation->interface());
+        string ns = getNamespace(operation->parentInterface());
 
         out << "global::System.Threading.Tasks.ValueTask";
 
@@ -735,7 +735,7 @@ Slice::IceRpc::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 
         _out << " =>";
         _out.inc();
-        _out << nl << "((" << getUnqualified(operation->interface(), ns, "", "Proxy") << ")this)."
+        _out << nl << "((" << getUnqualified(operation->parentInterface(), ns, "", "Proxy") << ")this)."
              << removeEscapePrefix(operation->mappedName()) << "Async";
         _out << spar;
         for (const auto& param : operation->inParameters())
@@ -850,7 +850,7 @@ Slice::IceRpc::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 void
 Slice::IceRpc::TypesVisitor::visitOperation(const OperationPtr& p)
 {
-    string ns = getNamespace(p->interface());
+    string ns = getNamespace(p->parentInterface());
 
     _out << sp;
     writeIceRpcOpDocComment(_out, p, false);
@@ -1354,7 +1354,7 @@ Slice::IceRpc::SkeletonVisitor::visitInterfaceDefEnd(const InterfaceDefPtr&)
 void
 Slice::IceRpc::SkeletonVisitor::visitOperation(const OperationPtr& p)
 {
-    string ns = getNamespace(p->interface());
+    string ns = getNamespace(p->parentInterface());
 
     _out << sp;
     writeIceRpcOpDocComment(_out, p, true);

--- a/cpp/src/slice2cs/IceVisitors.cpp
+++ b/cpp/src/slice2cs/IceVisitors.cpp
@@ -1586,7 +1586,7 @@ Slice::Ice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 void
 Slice::Ice::TypesVisitor::visitOperation(const OperationPtr& p)
 {
-    string ns = getNamespace(p->interface());
+    string ns = getNamespace(p->parentInterface());
     string name = p->mappedName();
     vector<string> inParams = getInParams(p, ns);
     string retS = typeToString(p->returnType(), ns, p->returnIsOptional());
@@ -1803,7 +1803,7 @@ Slice::Ice::ResultVisitor::visitModuleStart(const ModulePtr& p)
 void
 Slice::Ice::ResultVisitor::visitOperation(const OperationPtr& p)
 {
-    InterfaceDefPtr interface = p->interface();
+    InterfaceDefPtr interface = p->parentInterface();
     string ns = getNamespace(interface);
     ParameterList outParams = p->outParameters();
     TypePtr ret = p->returnType();
@@ -1972,7 +1972,7 @@ Slice::Ice::SkeletonVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
 void
 Slice::Ice::SkeletonVisitor::visitOperation(const OperationPtr& op)
 {
-    InterfaceDefPtr interface = op->interface();
+    InterfaceDefPtr interface = op->parentInterface();
     string interfaceName = prependSkeletonPrefix(interface->mappedName());
     string ns = getNamespace(interface);
     const bool amd = _async || interface->hasMetadata("amd") || op->hasMetadata("amd");
@@ -2168,7 +2168,7 @@ Slice::Ice::SkeletonVisitor::writeDispatch(const InterfaceDefPtr& p)
         _out << sb;
         for (const auto& op : allOps)
         {
-            _out << nl << '"' << op->name() << "\" => " << getUnqualified(op->interface(), ns, skeletonPrefix())
+            _out << nl << '"' << op->name() << "\" => " << getUnqualified(op->parentInterface(), ns, skeletonPrefix())
                  << ".iceD_" << removeEscapePrefix(op->mappedName()) << "Async(this, request),";
         }
         for (const auto& opName : {"ice_id", "ice_ids", "ice_isA", "ice_ping"})
@@ -2191,7 +2191,7 @@ Slice::Ice::SkeletonVisitor::getDispatchParams(
     const string& ns)
 {
     string name = op->mappedName();
-    InterfaceDefPtr interface = op->interface();
+    InterfaceDefPtr interface = op->parentInterface();
     ParameterList parameterList;
 
     if (_async || interface->hasMetadata("amd") || op->hasMetadata("amd"))

--- a/cpp/src/slice2java/Gen.cpp
+++ b/cpp/src/slice2java/Gen.cpp
@@ -1331,7 +1331,7 @@ Slice::JavaVisitor::writeSyncIceInvokeMethods(
     const optional<DocComment>& dc)
 {
     const string name = p->mappedName();
-    const string package = getPackage(p->interface());
+    const string package = getPackage(p->parentInterface());
 
     const string resultType = getResultType(p, package, false);
 
@@ -1417,7 +1417,7 @@ Slice::JavaVisitor::writeAsyncIceInvokeMethods(
     const optional<DocComment>& dc)
 {
     const string name = p->mappedName();
-    const string package = getPackage(p->interface());
+    const string package = getPackage(p->parentInterface());
 
     const string resultType = getResultType(p, package, true);
     const string futureType = "java.util.concurrent.CompletableFuture<" + resultType + ">";
@@ -1461,7 +1461,7 @@ Slice::JavaVisitor::writeIceIHelperMethods(
     bool optionalMapping)
 {
     const string name = p->mappedName();
-    const string package = getPackage(p->interface());
+    const string package = getPackage(p->parentInterface());
 
     const string resultType = getResultType(p, package, true);
     const string futureImplType = "com.zeroc.Ice.OutgoingAsync<" + resultType + ">";
@@ -4322,7 +4322,7 @@ Slice::TypesVisitor::visitOperation(const OperationPtr& p)
 {
     Output& out = output();
 
-    const string package = getPackage(p->interface());
+    const string package = getPackage(p->parentInterface());
     const vector<string> params = getParamsProxy(p, package, false);
     const vector<string> paramsOpt = getParamsProxy(p, package, true);
     const bool sendsOptionals = p->sendsOptionals();
@@ -4672,7 +4672,7 @@ Slice::SkeletonVisitor::visitInterfaceDefEnd(const InterfaceDefPtr& p)
         for (const auto& op : allOps)
         {
             out << nl << "case \"" << op->name() << "\" -> "
-                << getUnqualified(op->interface(), package, skeletonPrefix()) << "._iceD_" << op->mappedName()
+                << getUnqualified(op->parentInterface(), package, skeletonPrefix()) << "._iceD_" << op->mappedName()
                 << "(this, request);";
         }
         for (const auto& opName : {"ice_id", "ice_ids", "ice_isA", "ice_ping"})
@@ -4735,7 +4735,7 @@ Slice::SkeletonVisitor::getDispatchResultType(const OperationPtr& op, const stri
 {
     if (op->hasMarshaledResult())
     {
-        const InterfaceDefPtr interface = op->interface();
+        const InterfaceDefPtr interface = op->parentInterface();
         assert(interface);
         string abs = getUnqualified(interface, package, skeletonPrefix());
         string name = op->mappedName();

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -602,7 +602,8 @@ Slice::Java::javaLinkFormatter(const string& rawLink, const ContainedPtr& source
     else if (auto operationTarget = dynamic_pointer_cast<Operation>(target))
     {
         // Link to the method on the proxy interface.
-        mappedLink = getUnqualified(operationTarget->parentInterface(), sourceScope) + "Prx#" + operationTarget->mappedName();
+        mappedLink =
+            getUnqualified(operationTarget->parentInterface(), sourceScope) + "Prx#" + operationTarget->mappedName();
     }
     else if (auto fieldTarget = dynamic_pointer_cast<DataMember>(target))
     {

--- a/cpp/src/slice2java/JavaUtil.cpp
+++ b/cpp/src/slice2java/JavaUtil.cpp
@@ -602,7 +602,7 @@ Slice::Java::javaLinkFormatter(const string& rawLink, const ContainedPtr& source
     else if (auto operationTarget = dynamic_pointer_cast<Operation>(target))
     {
         // Link to the method on the proxy interface.
-        mappedLink = getUnqualified(operationTarget->interface(), sourceScope) + "Prx#" + operationTarget->mappedName();
+        mappedLink = getUnqualified(operationTarget->parentInterface(), sourceScope) + "Prx#" + operationTarget->mappedName();
     }
     else if (auto fieldTarget = dynamic_pointer_cast<DataMember>(target))
     {

--- a/cpp/src/slice2js/Gen.cpp
+++ b/cpp/src/slice2js/Gen.cpp
@@ -601,17 +601,10 @@ Slice::JsVisitor::writeDocSummary(const ContainedPtr& p, const DocSummaryOptions
 Slice::Gen::Gen(const string& base, const string& dir, bool typeScript)
     : _javaScriptOutput(false, true), // No break before opening block in JS + short empty blocks
       _typeScriptOutput(false, true), // No break before opening block in TS + short empty blocks
+      _fileBase(Slice::baseName(base)),
       _useStdout(false),
       _typeScript(typeScript)
 {
-    _fileBase = base;
-
-    string::size_type pos = base.find_last_of("/\\");
-    if (pos != string::npos)
-    {
-        _fileBase = base.substr(pos + 1);
-    }
-
     string file = _fileBase + ".js";
 
     if (!dir.empty())
@@ -651,15 +644,10 @@ Slice::Gen::Gen(const string& base, const string& dir, bool typeScript)
 Slice::Gen::Gen(const string& base, ostream& out, bool typeScript)
     : _javaScriptOutput(out, false, true),
       _typeScriptOutput(out, false, true),
+      _fileBase(Slice::baseName(base)),
       _useStdout(true),
       _typeScript(typeScript)
 {
-    _fileBase = base;
-    string::size_type pos = base.find_last_of("/\\");
-    if (pos != string::npos)
-    {
-        _fileBase = base.substr(pos + 1);
-    }
 }
 
 Slice::Gen::~Gen()

--- a/cpp/src/slice2js/JsUtil.cpp
+++ b/cpp/src/slice2js/JsUtil.cpp
@@ -516,7 +516,7 @@ Slice::JavaScript::jsLinkFormatter(const string& rawLink, const ContainedPtr&, c
         {
             if (auto operationTarget = dynamic_pointer_cast<Operation>(target))
             {
-                string targetScoped = operationTarget->interface()->mappedScoped(".");
+                string targetScoped = operationTarget->parentInterface()->mappedScoped(".");
 
                 // link to the method on the proxy interface
                 result << targetScoped << "Prx." << operationTarget->mappedName();

--- a/cpp/src/slice2matlab/Gen.cpp
+++ b/cpp/src/slice2matlab/Gen.cpp
@@ -1212,7 +1212,7 @@ void
 CodeVisitor::visitOperation(const OperationPtr& op)
 {
     IceInternal::Output& out = *_out;
-    const string prxAbs = op->interface()->mappedScoped(".") + "Prx";
+    const string prxAbs = op->parentInterface()->mappedScoped(".") + "Prx";
 
     const ParameterList inParams = op->inParameters();
     const ParameterList sortedInParams = op->sortedInParameters();
@@ -3332,7 +3332,7 @@ Slice::matlabLinkFormatter(const string& rawLink, const ContainedPtr&, const Syn
         else if (auto opTarget = dynamic_pointer_cast<Operation>(target))
         {
             // Operation links should be of the form "<ScopedProxy>/<functionName>".
-            auto interfaceDef = opTarget->interface();
+            auto interfaceDef = opTarget->parentInterface();
             displayText = opTarget->mappedName();
             linkText = interfaceDef->mappedScoped(".") + "Prx" + "/" + displayText;
         }

--- a/cpp/src/slice2py/PythonUtil.cpp
+++ b/cpp/src/slice2py/PythonUtil.cpp
@@ -1001,9 +1001,9 @@ Slice::Python::ImportVisitor::addTypingImport(
         addTypingImport(dictionary->keyType(), source, forMarshaling);
         addTypingImport(dictionary->valueType(), source, forMarshaling);
     }
-    else if (auto interface = dynamic_pointer_cast<InterfaceDecl>(definition))
+    else if (auto interfaceDecl = dynamic_pointer_cast<InterfaceDecl>(definition))
     {
-        addTypingImport(interface->mappedScoped("."), interface->mappedName() + "Prx", source);
+        addTypingImport(interfaceDecl->mappedScoped("."), interfaceDecl->mappedName() + "Prx", source);
     }
     else if (auto contained = dynamic_pointer_cast<Contained>(definition))
     {
@@ -2399,7 +2399,7 @@ Slice::Python::CodeVisitor::writeOpDocstring(const OperationPtr& op, MethodKind 
         return;
     }
 
-    auto p = op->interface();
+    auto p = op->parentInterface();
 
     TypePtr returnType = op->returnType();
     ParameterList params = op->parameters();
@@ -2950,7 +2950,7 @@ Slice::Python::pyLinkFormatter(const string& rawLink, const ContainedPtr&, const
         }
         else if (auto operationTarget = dynamic_pointer_cast<Operation>(target))
         {
-            string targetScoped = operationTarget->interface()->mappedScoped(".");
+            string targetScoped = operationTarget->parentInterface()->mappedScoped(".");
 
             // link to the method on the proxy interface
             result << ":meth:`" << targetScoped << "Prx." << operationTarget->mappedName() << "Async`";

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -362,7 +362,8 @@ Slice::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     _out << eb;
 
     _out << sp;
-    _out << nl << "open override func _iceWriteImpl(to ostr: " << getUnqualified("Ice.OutputStream", swiftModule) << ")";
+    _out << nl << "open override func _iceWriteImpl(to ostr: " << getUnqualified("Ice.OutputStream", swiftModule)
+         << ")";
     _out << sb;
     _out << nl << "ostr.startSlice(typeId: " << name << ".ice_staticId(), compactId: " << p->compactId()
          << ", last: " << (!base ? "true" : "false") << ")";
@@ -465,7 +466,8 @@ Slice::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     _out << nl << "open override class func ice_staticId() -> Swift.String { \"" << p->scoped() << "\" }";
 
     _out << sp;
-    _out << nl << "open override func _iceWriteImpl(to ostr: " << getUnqualified("Ice.OutputStream", swiftModule) << ")";
+    _out << nl << "open override func _iceWriteImpl(to ostr: " << getUnqualified("Ice.OutputStream", swiftModule)
+         << ")";
     _out << sb;
     _out << nl << "ostr.startSlice(typeId: " << name
          << ".ice_staticId(), compactId: -1, last: " << (!base ? "true" : "false") << ")";

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -283,7 +283,7 @@ Slice::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
         // Same for compact ID.
         _out << sp;
         _out << nl << "@objc static func resolveTypeId" << prefix << "_" << to_string(p->compactId())
-            << "() -> AnyObject.Type";
+             << "() -> AnyObject.Type";
         _out << sb;
         _out << nl << name << ".self";
         _out << eb;
@@ -328,7 +328,7 @@ Slice::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 
     _out << sp;
     _out << nl << "open override func _iceReadImpl(from istr: " << getUnqualified("Ice.InputStream", swiftModule)
-        << ") throws";
+         << ") throws";
     _out << sb;
     _out << nl << "_ = try istr.startSlice()";
     if (!members.empty())
@@ -365,7 +365,7 @@ Slice::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
     _out << nl << "open override func _iceWriteImpl(to ostr: " << getUnqualified("Ice.OutputStream", swiftModule) << ")";
     _out << sb;
     _out << nl << "ostr.startSlice(typeId: " << name << ".ice_staticId(), compactId: " << p->compactId()
-        << ", last: " << (!base ? "true" : "false") << ")";
+         << ", last: " << (!base ? "true" : "false") << ")";
     for (const auto& member : members)
     {
         TypePtr type = member->type();
@@ -468,7 +468,7 @@ Slice::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
     _out << nl << "open override func _iceWriteImpl(to ostr: " << getUnqualified("Ice.OutputStream", swiftModule) << ")";
     _out << sb;
     _out << nl << "ostr.startSlice(typeId: " << name
-        << ".ice_staticId(), compactId: -1, last: " << (!base ? "true" : "false") << ")";
+         << ".ice_staticId(), compactId: -1, last: " << (!base ? "true" : "false") << ")";
     for (const auto& member : members)
     {
         if (!member->isOptional())
@@ -490,7 +490,7 @@ Slice::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
 
     _out << sp;
     _out << nl << "open override func _iceReadImpl(from istr: " << getUnqualified("Ice.InputStream", swiftModule)
-        << ") throws";
+         << ") throws";
     _out << sb;
     _out << nl << "_ = try istr.startSlice()";
     for (const auto& member : members)
@@ -746,7 +746,7 @@ Slice::TypesVisitor::visitSequence(const SequencePtr& p)
     _out << nl << "///   - tag: The numeric tag associated with the value.";
     _out << nl << "/// - Returns: The sequence read from the stream.";
     _out << nl << "public static func read(from istr: " << istr << ", tag: Swift.Int32) throws -> sending " << name
-        << "?";
+         << "?";
     _out << sb;
     _out << nl << "guard try istr.readOptional(tag: tag, expectedFormat: " << optionalFormat << ") else";
     _out << sb;
@@ -809,7 +809,7 @@ Slice::TypesVisitor::visitSequence(const SequencePtr& p)
         else
         {
             _out << nl << "if ostr.writeOptionalVSize(tag: tag, len: val.count, elemSize: " << p->type()->minWireSize()
-                << ")";
+                 << ")";
         }
         _out << sb;
         _out << nl << "write(to: ostr, value: val)";
@@ -858,7 +858,7 @@ Slice::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     if (p->valueType()->isClassType())
     {
         _out << nl << "nonisolated(unsafe) let e = " << getUnqualified("Ice.DictEntryArray", swiftModule) << "<"
-            << keyType << ", " << valueType << ">(size: sz)";
+             << keyType << ", " << valueType << ">(size: sz)";
         _out << nl << "for i in 0 ..< sz";
         _out << sb;
         string keyParam = "let key: " + keyType;
@@ -867,8 +867,8 @@ Slice::TypesVisitor::visitDictionary(const DictionaryPtr& p)
         _out << nl << "Swift.withUnsafeMutablePointer(to: &v[key, default:nil])";
         _out << sb;
         _out << nl << "e.values[i] = Ice.DictEntry<" << keyType << ", " << valueType << ">("
-            << "key: key, "
-            << "value: $0)";
+             << "key: key, "
+             << "value: $0)";
         _out << eb;
         writeMarshalUnmarshalCode(_out, p->valueType(), p, "e.values[i].value.pointee", false);
         _out << eb;
@@ -903,7 +903,7 @@ Slice::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     _out << nl << "///   - tag: The numeric tag associated with the value.";
     _out << nl << "/// - Returns: The dictionary read from the stream.";
     _out << nl << "public static func read(from istr: " << istr << ", tag: Swift.Int32) throws -> sending " << name
-        << "?";
+         << "?";
     _out << sb;
     _out << nl << "guard try istr.readOptional(tag: tag, expectedFormat: " << optionalFormat << ") else";
     _out << sb;
@@ -1144,7 +1144,7 @@ Slice::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         _out << "private ";
     }
     _out << "final class " << prxI << ": " << getUnqualified("Ice.ObjectPrxI", swiftModule) << ", " << prx
-        << ", @unchecked Sendable";
+         << ", @unchecked Sendable";
     _out << sb;
 
     _out << nl << "public override class func ice_staticId() -> Swift.String";
@@ -1167,7 +1167,7 @@ Slice::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << nl << "/// - Returns: A new proxy with the requested type.";
     _out << nl << "/// - Throws: `Ice.ParseException` if the proxy string is invalid.";
     _out << nl << "public func makeProxy(communicator: Ice.Communicator, proxyString: String, type: " << prx
-        << ".Protocol) throws -> " << prx;
+         << ".Protocol) throws -> " << prx;
     _out << sb;
     _out << nl << "try communicator.makeProxyImpl(proxyString) as " << prxI;
     _out << eb;
@@ -1177,8 +1177,8 @@ Slice::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     //
     _out << sp;
     _out << nl
-        << "/// Creates a new proxy from an existing proxy after confirming the target object's type via a remote "
-           "invocation.";
+         << "/// Creates a new proxy from an existing proxy after confirming the target object's type via a remote "
+            "invocation.";
     _out << nl << "///";
     _out << nl << "/// This call throws a local exception if a communication error occurs. You can optionally supply a";
     _out << nl << "/// facet name and a context map.";
@@ -1189,15 +1189,15 @@ Slice::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << nl << "///   - facet: The optional name of the desired facet.";
     _out << nl << "///   - context: The optional context dictionary for the remote invocation.";
     _out << nl
-        << "/// - Returns: A proxy with the requested type or nil if the target object does not support this type.";
+         << "/// - Returns: A proxy with the requested type or nil if the target object does not support this type.";
     _out << nl << "/// - Throws: `Ice.LocalException` if a communication error occurs.";
     _out << nl << "public func checkedCast" << spar << ("prx: " + getUnqualified("Ice.ObjectPrx", swiftModule))
-        << ("type: " + prx + ".Protocol") << ("facet: Swift.String? = nil")
-        << ("context: " + getUnqualified("Ice.Context", swiftModule) + "? = nil") << epar << " async throws -> " << prx
-        << "?";
+         << ("type: " + prx + ".Protocol") << ("facet: Swift.String? = nil")
+         << ("context: " + getUnqualified("Ice.Context", swiftModule) + "? = nil") << epar << " async throws -> " << prx
+         << "?";
     _out << sb;
     _out << nl << "return try await " << prxI << ".checkedCast(prx: prx, facet: facet, context: context) as " << prxI
-        << "?";
+         << "?";
     _out << eb;
 
     //
@@ -1212,7 +1212,7 @@ Slice::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     _out << nl << "///   - facet: The optional name of the desired facet.";
     _out << nl << "/// - Returns: A new proxy with the requested type.";
     _out << nl << "public func uncheckedCast" << spar << ("prx: " + getUnqualified("Ice.ObjectPrx", swiftModule))
-        << ("type: " + prx + ".Protocol") << ("facet: Swift.String? = nil") << epar << " -> " << prx;
+         << ("type: " + prx + ".Protocol") << ("facet: Swift.String? = nil") << epar << " -> " << prx;
     _out << sb;
     _out << nl << "return " << prxI << ".uncheckedCast(prx: prx, facet: facet) as " << prxI;
     _out << eb;
@@ -1312,7 +1312,7 @@ Slice::TypesVisitor::visitOperation(const OperationPtr& op)
         _out << nl << "if _impl.ice_isTwoway()";
         _out << sb;
         _out << nl << "throw " << getUnqualified("Ice.OnewayOnlyException", swiftModule) << "(operation: \""
-            << op->name() << "\")";
+             << op->name() << "\")";
         _out << eb;
     }
 
@@ -1460,28 +1460,28 @@ Slice::ServantExtVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 
     _out << sp;
     _out << nl
-        << "/// Dispatches an incoming request to one of the instance methods of the generated protocol, based on the "
-           "operation name carried by the request.";
+         << "/// Dispatches an incoming request to one of the instance methods of the generated protocol, based on the "
+            "operation name carried by the request.";
     _out << nl << "/// - Parameter request: The incoming request.";
     _out << nl << "/// - Returns: The outgoing response.";
     _out << nl << "public func dispatch(_ request: sending Ice.IncomingRequest) async throws -> Ice.OutgoingResponse"
-        << sb;
+         << sb;
     _out << nl << "try await Self.dispatch(self, request: request)";
     _out << eb;
 
     _out << sp;
     _out << nl
-        << "/// Dispatches an incoming request to one of the instance methods of the generated protocol, based on the "
-           "operation name carried by the request.";
+         << "/// Dispatches an incoming request to one of the instance methods of the generated protocol, based on the "
+            "operation name carried by the request.";
     _out << nl
-        << "/// Call this static method from the `dispatch` method of your servant class when you want to reuse a base "
-           "servant class in a derived servant class.";
+         << "/// Call this static method from the `dispatch` method of your servant class when you want to reuse a "
+            "base servant class in a derived servant class.";
     _out << nl << "/// - Parameters:";
     _out << nl << "///   - servant: The servant to dispatch the request to.";
     _out << nl << "///   - request: The incoming request.";
     _out << nl << "/// - Returns: The outgoing response.";
     _out << nl << "public static func dispatch(_ servant: " << servant
-        << ", request: sending Ice.IncomingRequest) async throws -> Ice.OutgoingResponse" << sb;
+         << ", request: sending Ice.IncomingRequest) async throws -> Ice.OutgoingResponse" << sb;
     _out << nl << "switch request.current.operation";
     _out << sb;
     _out.dec(); // to align case with switch
@@ -1493,7 +1493,7 @@ Slice::ServantExtVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         if (sliceName == "ice_id" || sliceName == "ice_ids" || sliceName == "ice_isA" || sliceName == "ice_ping")
         {
             _out << nl << "try await (servant as? Ice.Object ?? " << "Self.defaultObject)." << mappedDispatchName
-                << "(request)";
+                 << "(request)";
         }
         else
         {
@@ -1527,7 +1527,7 @@ Slice::ServantExtVisitor::visitOperation(const OperationPtr& op)
 
     _out << sp;
     _out << nl << "public func _iceD_" << removeEscaping(opName)
-        << "(_ request: Ice.IncomingRequest) async throws -> Ice.OutgoingResponse";
+         << "(_ request: Ice.IncomingRequest) async throws -> Ice.OutgoingResponse";
 
     _out << sb;
 
@@ -1572,7 +1572,7 @@ Slice::ServantExtVisitor::visitOperation(const OperationPtr& op)
     else
     {
         _out << nl << "return request.current.makeOutgoingResponse(result, formatType: " << opFormatTypeToString(op)
-            << ")";
+             << ")";
         _out << sb;
         _out << " ostr, value in ";
         writeMarshalAsyncOutParams(_out, op);

--- a/cpp/src/slice2swift/Gen.cpp
+++ b/cpp/src/slice2swift/Gen.cpp
@@ -1,5 +1,4 @@
 // Copyright (c) ZeroC, Inc.
-//
 
 #include "../Ice/OutputUtil.h"
 #include "../Slice/FileTracker.h"
@@ -51,15 +50,9 @@ namespace
 }
 
 Gen::Gen(const string& base, const string& dir)
-    : _out(false, true) // No break before opening block in Swift + short empty blocks
+    : _out(false, true), // No break before opening block in Swift + short empty blocks
+      _fileBase(Slice::baseName(base))
 {
-    _fileBase = base;
-    string::size_type pos = base.find_last_of("/\\");
-    if (pos != string::npos)
-    {
-        _fileBase = base.substr(pos + 1);
-    }
-
     string file = _fileBase + ".swift";
 
     if (!dir.empty())
@@ -120,7 +113,7 @@ Slice::Gen::printHeader()
     _out << nl << "// slice2swift version " << ICE_STRING_VERSION;
 }
 
-Slice::ImportVisitor::ImportVisitor(IceInternal::Output& o) : out(o) {}
+Slice::ImportVisitor::ImportVisitor(IceInternal::Output& out) : _out(out) {}
 
 bool
 Slice::ImportVisitor::visitModuleStart(const ModulePtr& p)
@@ -223,7 +216,7 @@ Slice::ImportVisitor::writeImports()
 {
     for (const auto& import : _imports)
     {
-        out << nl << "import " << import;
+        _out << nl << "import " << import;
     }
 }
 
@@ -253,7 +246,7 @@ Slice::ImportVisitor::addImport(const string& module)
     }
 }
 
-Slice::TypesVisitor::TypesVisitor(IceInternal::Output& o) : out(o) {}
+Slice::TypesVisitor::TypesVisitor(IceInternal::Output& out) : _out(out) {}
 
 bool
 Slice::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
@@ -278,81 +271,81 @@ Slice::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
         }
     }
 
-    out << sp;
-    out << nl << "public extension " << getUnqualified("Ice.DefaultSliceLoader", swiftModule);
-    out << sb;
-    out << nl << "@objc static func " << methodName.str() << "() -> AnyObject.Type";
-    out << sb;
-    out << nl << name << ".self";
-    out << eb;
+    _out << sp;
+    _out << nl << "public extension " << getUnqualified("Ice.DefaultSliceLoader", swiftModule);
+    _out << sb;
+    _out << nl << "@objc static func " << methodName.str() << "() -> AnyObject.Type";
+    _out << sb;
+    _out << nl << name << ".self";
+    _out << eb;
     if (p->compactId() != -1)
     {
         // Same for compact ID.
-        out << sp;
-        out << nl << "@objc static func resolveTypeId" << prefix << "_" << to_string(p->compactId())
+        _out << sp;
+        _out << nl << "@objc static func resolveTypeId" << prefix << "_" << to_string(p->compactId())
             << "() -> AnyObject.Type";
-        out << sb;
-        out << nl << name << ".self";
-        out << eb;
+        _out << sb;
+        _out << nl << name << ".self";
+        _out << eb;
     }
-    out << eb;
+    _out << eb;
 
-    out << sp;
-    writeDocSummary(out, p, "class");
-    writeSwiftAttributes(out, p->getMetadata());
-    out << nl << "open class " << name << ": ";
+    _out << sp;
+    writeDocSummary(_out, p, "class");
+    writeSwiftAttributes(_out, p->getMetadata());
+    _out << nl << "open class " << name << ": ";
     if (base)
     {
-        out << getRelativeTypeString(base, swiftModule);
+        _out << getRelativeTypeString(base, swiftModule);
     }
     else
     {
-        out << getUnqualified("Ice.Value", swiftModule);
+        _out << getUnqualified("Ice.Value", swiftModule);
     }
-    out << sb;
+    _out << sb;
 
     const DataMemberList members = p->dataMembers();
     const DataMemberList baseMembers = base ? base->allDataMembers() : DataMemberList();
     const DataMemberList allMembers = p->allDataMembers();
     const DataMemberList optionalMembers = p->orderedOptionalDataMembers();
 
-    writeMembers(out, members, p);
+    writeMembers(_out, members, p);
 
     if (!allMembers.empty())
     {
         if (!members.empty())
         {
-            writeDefaultInitializer(out, true, !base);
-            writeMemberwiseInitializer(out, members, baseMembers, allMembers, p, !base);
+            writeDefaultInitializer(_out, true, !base);
+            writeMemberwiseInitializer(_out, members, baseMembers, allMembers, p, !base);
         }
         // else inherit the base class initializers
     }
     // else inherit Value's initializer.
 
-    out << sp;
-    out << nl << "/// - Returns: The Slice type ID of the interface supported by this object.";
-    out << nl << "open override class func ice_staticId() -> Swift.String { \"" << p->scoped() << "\" }";
+    _out << sp;
+    _out << nl << "/// - Returns: The Slice type ID of the interface supported by this object.";
+    _out << nl << "open override class func ice_staticId() -> Swift.String { \"" << p->scoped() << "\" }";
 
-    out << sp;
-    out << nl << "open override func _iceReadImpl(from istr: " << getUnqualified("Ice.InputStream", swiftModule)
+    _out << sp;
+    _out << nl << "open override func _iceReadImpl(from istr: " << getUnqualified("Ice.InputStream", swiftModule)
         << ") throws";
-    out << sb;
-    out << nl << "_ = try istr.startSlice()";
+    _out << sb;
+    _out << nl << "_ = try istr.startSlice()";
     if (!members.empty())
     {
-        out << nl << "nonisolated(unsafe) let iceP_self = self";
+        _out << nl << "nonisolated(unsafe) let iceP_self = self";
 
         for (const auto& member : members)
         {
             if (!member->isOptional())
             {
-                writeMarshalUnmarshalCode(out, member->type(), p, "iceP_self." + member->mappedName(), false);
+                writeMarshalUnmarshalCode(_out, member->type(), p, "iceP_self." + member->mappedName(), false);
             }
         }
         for (const auto& member : optionalMembers)
         {
             writeMarshalUnmarshalCode(
-                out,
+                _out,
                 member->type(),
                 p,
                 "iceP_self." + member->mappedName(),
@@ -361,36 +354,36 @@ Slice::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
         }
     }
 
-    out << nl << "try istr.endSlice()";
+    _out << nl << "try istr.endSlice()";
     if (base)
     {
-        out << nl << "try super._iceReadImpl(from: istr);";
+        _out << nl << "try super._iceReadImpl(from: istr);";
     }
-    out << eb;
+    _out << eb;
 
-    out << sp;
-    out << nl << "open override func _iceWriteImpl(to ostr: " << getUnqualified("Ice.OutputStream", swiftModule) << ")";
-    out << sb;
-    out << nl << "ostr.startSlice(typeId: " << name << ".ice_staticId(), compactId: " << p->compactId()
+    _out << sp;
+    _out << nl << "open override func _iceWriteImpl(to ostr: " << getUnqualified("Ice.OutputStream", swiftModule) << ")";
+    _out << sb;
+    _out << nl << "ostr.startSlice(typeId: " << name << ".ice_staticId(), compactId: " << p->compactId()
         << ", last: " << (!base ? "true" : "false") << ")";
     for (const auto& member : members)
     {
         TypePtr type = member->type();
         if (!member->isOptional())
         {
-            writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->mappedName(), true);
+            writeMarshalUnmarshalCode(_out, member->type(), p, "self." + member->mappedName(), true);
         }
     }
     for (const auto& member : optionalMembers)
     {
-        writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->mappedName(), true, member->tag());
+        writeMarshalUnmarshalCode(_out, member->type(), p, "self." + member->mappedName(), true, member->tag());
     }
-    out << nl << "ostr.endSlice()";
+    _out << nl << "ostr.endSlice()";
     if (base)
     {
-        out << nl << "super._iceWriteImpl(to: ostr);";
+        _out << nl << "super._iceWriteImpl(to: ostr);";
     }
-    out << eb;
+    _out << eb;
 
     return true;
 }
@@ -398,7 +391,7 @@ Slice::TypesVisitor::visitClassDefStart(const ClassDefPtr& p)
 void
 Slice::TypesVisitor::visitClassDefEnd(const ClassDefPtr&)
 {
-    out << eb;
+    _out << eb;
 }
 
 bool
@@ -425,110 +418,110 @@ Slice::TypesVisitor::visitExceptionStart(const ExceptionPtr& p)
         }
     }
 
-    out << sp;
-    out << nl << "public extension " << getUnqualified("Ice.DefaultSliceLoader", swiftModule);
-    out << sb;
-    out << nl << "@objc static func " << methodName.str() << "() -> AnyObject.Type";
-    out << sb;
-    out << nl << name << ".self";
-    out << eb;
-    out << eb;
+    _out << sp;
+    _out << nl << "public extension " << getUnqualified("Ice.DefaultSliceLoader", swiftModule);
+    _out << sb;
+    _out << nl << "@objc static func " << methodName.str() << "() -> AnyObject.Type";
+    _out << sb;
+    _out << nl << name << ".self";
+    _out << eb;
+    _out << eb;
 
-    out << sp;
-    writeDocSummary(out, p, "exception class");
-    writeSwiftAttributes(out, p->getMetadata());
-    out << nl << "open class " << name << ": ";
+    _out << sp;
+    writeDocSummary(_out, p, "exception class");
+    writeSwiftAttributes(_out, p->getMetadata());
+    _out << nl << "open class " << name << ": ";
     if (base)
     {
-        out << getRelativeTypeString(base, swiftModule);
+        _out << getRelativeTypeString(base, swiftModule);
     }
     else
     {
-        out << getUnqualified("Ice.UserException", swiftModule);
+        _out << getUnqualified("Ice.UserException", swiftModule);
     }
-    out << ", @unchecked Sendable";
-    out << sb;
+    _out << ", @unchecked Sendable";
+    _out << sb;
 
     const DataMemberList members = p->dataMembers();
     const DataMemberList allMembers = p->allDataMembers();
     const DataMemberList baseMembers = base ? base->allDataMembers() : DataMemberList();
     const DataMemberList optionalMembers = p->orderedOptionalDataMembers();
 
-    writeMembers(out, members, p);
+    writeMembers(_out, members, p);
 
     if (!allMembers.empty())
     {
         if (!members.empty())
         {
-            writeDefaultInitializer(out, true, !base);
-            writeMemberwiseInitializer(out, members, baseMembers, allMembers, p, !base);
+            writeDefaultInitializer(_out, true, !base);
+            writeMemberwiseInitializer(_out, members, baseMembers, allMembers, p, !base);
         }
         // else inherit the base class initializers
     }
     // else inherit UserException's initializer.
 
-    out << sp;
-    out << nl << "/// - Returns: The Slice type ID of this exception.";
-    out << nl << "open override class func ice_staticId() -> Swift.String { \"" << p->scoped() << "\" }";
+    _out << sp;
+    _out << nl << "/// - Returns: The Slice type ID of this exception.";
+    _out << nl << "open override class func ice_staticId() -> Swift.String { \"" << p->scoped() << "\" }";
 
-    out << sp;
-    out << nl << "open override func _iceWriteImpl(to ostr: " << getUnqualified("Ice.OutputStream", swiftModule) << ")";
-    out << sb;
-    out << nl << "ostr.startSlice(typeId: " << name
+    _out << sp;
+    _out << nl << "open override func _iceWriteImpl(to ostr: " << getUnqualified("Ice.OutputStream", swiftModule) << ")";
+    _out << sb;
+    _out << nl << "ostr.startSlice(typeId: " << name
         << ".ice_staticId(), compactId: -1, last: " << (!base ? "true" : "false") << ")";
     for (const auto& member : members)
     {
         if (!member->isOptional())
         {
-            writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->mappedName(), true);
+            writeMarshalUnmarshalCode(_out, member->type(), p, "self." + member->mappedName(), true);
         }
     }
 
     for (const auto& member : optionalMembers)
     {
-        writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->mappedName(), true, member->tag());
+        writeMarshalUnmarshalCode(_out, member->type(), p, "self." + member->mappedName(), true, member->tag());
     }
-    out << nl << "ostr.endSlice()";
+    _out << nl << "ostr.endSlice()";
     if (base)
     {
-        out << nl << "super._iceWriteImpl(to: ostr);";
+        _out << nl << "super._iceWriteImpl(to: ostr);";
     }
-    out << eb;
+    _out << eb;
 
-    out << sp;
-    out << nl << "open override func _iceReadImpl(from istr: " << getUnqualified("Ice.InputStream", swiftModule)
+    _out << sp;
+    _out << nl << "open override func _iceReadImpl(from istr: " << getUnqualified("Ice.InputStream", swiftModule)
         << ") throws";
-    out << sb;
-    out << nl << "_ = try istr.startSlice()";
+    _out << sb;
+    _out << nl << "_ = try istr.startSlice()";
     for (const auto& member : members)
     {
         if (!member->isOptional())
         {
-            writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->mappedName(), false);
+            writeMarshalUnmarshalCode(_out, member->type(), p, "self." + member->mappedName(), false);
         }
     }
 
     for (const auto& member : optionalMembers)
     {
-        writeMarshalUnmarshalCode(out, member->type(), p, "self." + member->mappedName(), false, member->tag());
+        writeMarshalUnmarshalCode(_out, member->type(), p, "self." + member->mappedName(), false, member->tag());
     }
 
-    out << nl << "try istr.endSlice()";
+    _out << nl << "try istr.endSlice()";
     if (base)
     {
-        out << nl << "try super._iceReadImpl(from: istr);";
+        _out << nl << "try super._iceReadImpl(from: istr);";
     }
-    out << eb;
+    _out << eb;
 
     if (p->usesClasses() && !(base && base->usesClasses()))
     {
-        out << sp;
-        out << nl << "open override func _usesClasses() -> Swift.Bool" << sb;
-        out << nl << "return true";
-        out << eb;
+        _out << sp;
+        _out << nl << "open override func _usesClasses() -> Swift.Bool" << sb;
+        _out << nl << "return true";
+        _out << eb;
     }
 
-    out << eb;
+    _out << eb;
     return false;
 }
 
@@ -543,10 +536,10 @@ Slice::TypesVisitor::visitStructStart(const StructPtr& p)
     const string optionalFormat = getOptionalFormat(p);
 
     bool usesClasses = p->usesClasses();
-    out << sp;
-    writeDocSummary(out, p, usesClasses ? "class" : "struct");
-    writeSwiftAttributes(out, p->getMetadata());
-    out << nl << "public " << (usesClasses ? "final class " : "struct ") << name;
+    _out << sp;
+    writeDocSummary(_out, p, usesClasses ? "class" : "struct");
+    writeSwiftAttributes(_out, p->getMetadata());
+    _out << nl << "public " << (usesClasses ? "final class " : "struct ") << name;
 
     // Vector of protocols this struct conforms to.
     vector<string> structProtocols;
@@ -561,112 +554,112 @@ Slice::TypesVisitor::visitStructStart(const StructPtr& p)
 
     if (!structProtocols.empty())
     {
-        out << ": ";
-        out.spar("");
-        out << structProtocols;
-        out.epar("");
+        _out << ": ";
+        _out.spar("");
+        _out << structProtocols;
+        _out.epar("");
     }
 
-    out << sb;
+    _out << sb;
 
-    writeMembers(out, members, p);
-    writeDefaultInitializer(out, false, true);
-    writeMemberwiseInitializer(out, members, p);
+    writeMembers(_out, members, p);
+    writeDefaultInitializer(_out, false, true);
+    writeMemberwiseInitializer(_out, members, p);
 
-    out << eb;
+    _out << eb;
 
-    out << sp;
-    out << nl << "/// An `Ice.InputStream` extension to read `" << docName << "` structured values from the stream.";
-    out << nl << "public extension " << getUnqualified("Ice.InputStream", swiftModule);
-    out << sb;
+    _out << sp;
+    _out << nl << "/// An `Ice.InputStream` extension to read `" << docName << "` structured values from the stream.";
+    _out << nl << "public extension " << getUnqualified("Ice.InputStream", swiftModule);
+    _out << sb;
 
-    out << sp;
-    out << nl << "/// Read a `" << docName << "` structured value from the stream.";
-    out << nl << "///";
-    out << nl << "/// - Returns: The structured value read from the stream.";
-    out << nl << "func read() throws -> sending " << name;
-    out << sb;
+    _out << sp;
+    _out << nl << "/// Read a `" << docName << "` structured value from the stream.";
+    _out << nl << "///";
+    _out << nl << "/// - Returns: The structured value read from the stream.";
+    _out << nl << "func read() throws -> sending " << name;
+    _out << sb;
     if (usesClasses)
     {
-        out << nl << "nonisolated(unsafe) let";
+        _out << nl << "nonisolated(unsafe) let";
     }
     else
     {
-        out << nl << "var";
+        _out << nl << "var";
     }
-    out << " v = " << name << "()";
+    _out << " v = " << name << "()";
     for (const auto& member : members)
     {
-        writeMarshalUnmarshalCode(out, member->type(), p, "v." + member->mappedName(), false);
+        writeMarshalUnmarshalCode(_out, member->type(), p, "v." + member->mappedName(), false);
     }
-    out << nl << "return v";
-    out << eb;
+    _out << nl << "return v";
+    _out << eb;
 
-    out << sp;
-    out << nl << "/// Read an optional `" << docName << "?` structured value from the stream.";
-    out << nl << "///";
-    out << nl << "/// - Parameter tag: The numeric tag associated with the value.";
-    out << nl << "/// - Returns: The structured value read from the stream.";
-    out << nl << "func read(tag: Swift.Int32) throws -> sending " << name << "?";
-    out << sb;
-    out << nl << "guard try readOptional(tag: tag, expectedFormat: " << optionalFormat << ") else";
-    out << sb;
-    out << nl << "return nil";
-    out << eb;
+    _out << sp;
+    _out << nl << "/// Read an optional `" << docName << "?` structured value from the stream.";
+    _out << nl << "///";
+    _out << nl << "/// - Parameter tag: The numeric tag associated with the value.";
+    _out << nl << "/// - Returns: The structured value read from the stream.";
+    _out << nl << "func read(tag: Swift.Int32) throws -> sending " << name << "?";
+    _out << sb;
+    _out << nl << "guard try readOptional(tag: tag, expectedFormat: " << optionalFormat << ") else";
+    _out << sb;
+    _out << nl << "return nil";
+    _out << eb;
     if (p->isVariableLength())
     {
-        out << nl << "try skip(4)";
+        _out << nl << "try skip(4)";
     }
     else
     {
-        out << nl << "try skipSize()";
+        _out << nl << "try skipSize()";
     }
-    out << nl << "return try read() as " << name;
-    out << eb;
+    _out << nl << "return try read() as " << name;
+    _out << eb;
 
-    out << eb;
+    _out << eb;
 
-    out << sp;
-    out << nl << "/// An `Ice.OutputStream` extension to write `" << docName << "` structured values from the stream.";
-    out << nl << "public extension " << getUnqualified("Ice.OutputStream", swiftModule);
-    out << sb;
+    _out << sp;
+    _out << nl << "/// An `Ice.OutputStream` extension to write `" << docName << "` structured values from the stream.";
+    _out << nl << "public extension " << getUnqualified("Ice.OutputStream", swiftModule);
+    _out << sb;
 
-    out << nl << "/// Write a `" << docName << "` structured value to the stream.";
-    out << nl << "///";
-    out << nl << "/// - Parameter v: The value to write to the stream.";
-    out << nl << "func write(_ v: " << name << ")" << sb;
+    _out << nl << "/// Write a `" << docName << "` structured value to the stream.";
+    _out << nl << "///";
+    _out << nl << "/// - Parameter v: The value to write to the stream.";
+    _out << nl << "func write(_ v: " << name << ")" << sb;
     for (const auto& member : members)
     {
-        writeMarshalUnmarshalCode(out, member->type(), p, "v." + member->mappedName(), true);
+        writeMarshalUnmarshalCode(_out, member->type(), p, "v." + member->mappedName(), true);
     }
-    out << eb;
+    _out << eb;
 
-    out << sp;
-    out << nl << "/// Write an optional `" << docName << "?` structured value to the stream.";
-    out << nl << "///";
-    out << nl << "/// - Parameters:";
-    out << nl << "///   - tag: The numeric tag associated with the value.";
-    out << nl << "///   - value: The value to write to the stream.";
-    out << nl << "func write(tag: Swift.Int32, value: " << name << "?)" << sb;
-    out << nl << "if let v = value" << sb;
-    out << nl << "if writeOptional(tag: tag, format: " << optionalFormat << ")" << sb;
+    _out << sp;
+    _out << nl << "/// Write an optional `" << docName << "?` structured value to the stream.";
+    _out << nl << "///";
+    _out << nl << "/// - Parameters:";
+    _out << nl << "///   - tag: The numeric tag associated with the value.";
+    _out << nl << "///   - value: The value to write to the stream.";
+    _out << nl << "func write(tag: Swift.Int32, value: " << name << "?)" << sb;
+    _out << nl << "if let v = value" << sb;
+    _out << nl << "if writeOptional(tag: tag, format: " << optionalFormat << ")" << sb;
 
     if (p->isVariableLength())
     {
-        out << nl << "let pos = startSize()";
-        out << nl << "write(v)";
-        out << nl << "endSize(position: pos)";
+        _out << nl << "let pos = startSize()";
+        _out << nl << "write(v)";
+        _out << nl << "endSize(position: pos)";
     }
     else
     {
-        out << nl << "write(size: " << p->minWireSize() << ")";
-        out << nl << "write(v)";
+        _out << nl << "write(size: " << p->minWireSize() << ")";
+        _out << nl << "write(v)";
     }
-    out << eb;
-    out << eb;
-    out << eb;
+    _out << eb;
+    _out << eb;
+    _out << eb;
 
-    out << eb;
+    _out << eb;
 
     return false;
 }
@@ -681,17 +674,17 @@ Slice::TypesVisitor::visitSequence(const SequencePtr& p)
     const TypePtr type = p->type();
     BuiltinPtr builtin = dynamic_pointer_cast<Builtin>(type);
 
-    out << sp;
-    writeDocSummary(out, p);
-    out << nl << "public typealias " << name << " = ";
+    _out << sp;
+    writeDocSummary(_out, p);
+    _out << nl << "public typealias " << name << " = ";
 
     if (builtin && builtin->kind() == Builtin::KindByte)
     {
-        out << "Foundation.Data";
+        _out << "Foundation.Data";
     }
     else
     {
-        out << "[" << typeToString(type, p, false) << "]";
+        _out << "[" << typeToString(type, p, false) << "]";
     }
 
     if (builtin && builtin->kind() <= Builtin::KindString)
@@ -704,127 +697,127 @@ Slice::TypesVisitor::visitSequence(const SequencePtr& p)
 
     const string optionalFormat = getOptionalFormat(p);
 
-    out << sp;
-    out << nl << "/// Helper class to read and write `" << unescapedName << "` sequence values from";
-    out << nl << "/// `Ice.InputStream` and `Ice.OutputStream`.";
-    out << nl << "public struct " << unescapedName << "Helper";
-    out << sb;
+    _out << sp;
+    _out << nl << "/// Helper class to read and write `" << unescapedName << "` sequence values from";
+    _out << nl << "/// `Ice.InputStream` and `Ice.OutputStream`.";
+    _out << nl << "public struct " << unescapedName << "Helper";
+    _out << sb;
 
-    out << nl << "/// Read a `" << unescapedName << "` sequence from the stream.";
-    out << nl << "///";
-    out << nl << "/// - Parameter istr: The stream to read from.";
-    out << nl << "/// - Returns: The sequence read from the stream.";
-    out << nl << "public static func read(from istr: " << istr << ") throws -> sending " << name;
-    out << sb;
-    out << nl << "let sz = try istr.readAndCheckSeqSize(minSize: " << p->type()->minWireSize() << ")";
+    _out << nl << "/// Read a `" << unescapedName << "` sequence from the stream.";
+    _out << nl << "///";
+    _out << nl << "/// - Parameter istr: The stream to read from.";
+    _out << nl << "/// - Returns: The sequence read from the stream.";
+    _out << nl << "public static func read(from istr: " << istr << ") throws -> sending " << name;
+    _out << sb;
+    _out << nl << "let sz = try istr.readAndCheckSeqSize(minSize: " << p->type()->minWireSize() << ")";
 
     if (type->isClassType())
     {
-        out << nl << "nonisolated(unsafe) var v = " << name << "(repeating: nil, count: sz)";
-        out << nl << "for i in 0 ..< sz";
-        out << sb;
-        out << nl << "try Swift.withUnsafeMutablePointer(to: &v[i])";
-        out << sb;
-        out << " p in";
-        out << nl << "nonisolated(unsafe) let p = p";
-        writeMarshalUnmarshalCode(out, type, p, "p.pointee", false);
-        out << eb;
-        out << eb;
+        _out << nl << "nonisolated(unsafe) var v = " << name << "(repeating: nil, count: sz)";
+        _out << nl << "for i in 0 ..< sz";
+        _out << sb;
+        _out << nl << "try Swift.withUnsafeMutablePointer(to: &v[i])";
+        _out << sb;
+        _out << " p in";
+        _out << nl << "nonisolated(unsafe) let p = p";
+        writeMarshalUnmarshalCode(_out, type, p, "p.pointee", false);
+        _out << eb;
+        _out << eb;
     }
     else
     {
-        out << nl << "var v = " << name << "()";
-        out << nl << "v.reserveCapacity(sz)";
-        out << nl << "for _ in 0 ..< sz";
-        out << sb;
+        _out << nl << "var v = " << name << "()";
+        _out << nl << "v.reserveCapacity(sz)";
+        _out << nl << "for _ in 0 ..< sz";
+        _out << sb;
         string param = "let j: " + typeToString(p->type(), p);
-        writeMarshalUnmarshalCode(out, type, p, param, false);
-        out << nl << "v.append(j)";
-        out << eb;
+        writeMarshalUnmarshalCode(_out, type, p, param, false);
+        _out << nl << "v.append(j)";
+        _out << eb;
     }
-    out << nl << "return v";
-    out << eb;
+    _out << nl << "return v";
+    _out << eb;
 
-    out << sp;
-    out << nl << "/// Read an optional `" << unescapedName << "?` sequence from the stream.";
-    out << nl << "///";
-    out << nl << "/// - Parameters:";
-    out << nl << "///   - istr: The stream to read from.";
-    out << nl << "///   - tag: The numeric tag associated with the value.";
-    out << nl << "/// - Returns: The sequence read from the stream.";
-    out << nl << "public static func read(from istr: " << istr << ", tag: Swift.Int32) throws -> sending " << name
+    _out << sp;
+    _out << nl << "/// Read an optional `" << unescapedName << "?` sequence from the stream.";
+    _out << nl << "///";
+    _out << nl << "/// - Parameters:";
+    _out << nl << "///   - istr: The stream to read from.";
+    _out << nl << "///   - tag: The numeric tag associated with the value.";
+    _out << nl << "/// - Returns: The sequence read from the stream.";
+    _out << nl << "public static func read(from istr: " << istr << ", tag: Swift.Int32) throws -> sending " << name
         << "?";
-    out << sb;
-    out << nl << "guard try istr.readOptional(tag: tag, expectedFormat: " << optionalFormat << ") else";
-    out << sb;
-    out << nl << "return nil";
-    out << eb;
+    _out << sb;
+    _out << nl << "guard try istr.readOptional(tag: tag, expectedFormat: " << optionalFormat << ") else";
+    _out << sb;
+    _out << nl << "return nil";
+    _out << eb;
     if (p->type()->isVariableLength())
     {
-        out << nl << "try istr.skip(4)";
+        _out << nl << "try istr.skip(4)";
     }
     else if (p->type()->minWireSize() > 1)
     {
-        out << nl << "try istr.skipSize()";
+        _out << nl << "try istr.skipSize()";
     }
-    out << nl << "return try read(from: istr)";
-    out << eb;
+    _out << nl << "return try read(from: istr)";
+    _out << eb;
 
-    out << sp;
-    out << nl << "/// Write a `" << unescapedName << "` sequence to the stream.";
-    out << nl << "///";
-    out << nl << "/// - Parameters:";
-    out << nl << "///   - ostr: The stream to write to.";
-    out << nl << "///   - v: The sequence value to write to the stream.";
-    out << nl << "public static func write(to ostr: " << ostr << ", value v: " << name << ")";
-    out << sb;
-    out << nl << "ostr.write(size: v.count)";
-    out << nl << "for item in v";
-    out << sb;
-    writeMarshalUnmarshalCode(out, type, p, "item", true);
-    out << eb;
-    out << eb;
+    _out << sp;
+    _out << nl << "/// Write a `" << unescapedName << "` sequence to the stream.";
+    _out << nl << "///";
+    _out << nl << "/// - Parameters:";
+    _out << nl << "///   - ostr: The stream to write to.";
+    _out << nl << "///   - v: The sequence value to write to the stream.";
+    _out << nl << "public static func write(to ostr: " << ostr << ", value v: " << name << ")";
+    _out << sb;
+    _out << nl << "ostr.write(size: v.count)";
+    _out << nl << "for item in v";
+    _out << sb;
+    writeMarshalUnmarshalCode(_out, type, p, "item", true);
+    _out << eb;
+    _out << eb;
 
-    out << sp;
-    out << nl << "/// Write an optional `" << unescapedName << "?` sequence to the stream.";
-    out << nl << "///";
-    out << nl << "/// - Parameters:";
-    out << nl << "///   - ostr: The stream to write to.";
-    out << nl << "///   - tag: The numeric tag associated with the value.";
-    out << nl << "///   - v: The sequence value to write to the stream.";
-    out << nl << "public static func write(to ostr: " << ostr << ",  tag: Swift.Int32, value v: " << name << "?)";
-    out << sb;
-    out << nl << "guard let val = v else";
-    out << sb;
-    out << nl << "return";
-    out << eb;
+    _out << sp;
+    _out << nl << "/// Write an optional `" << unescapedName << "?` sequence to the stream.";
+    _out << nl << "///";
+    _out << nl << "/// - Parameters:";
+    _out << nl << "///   - ostr: The stream to write to.";
+    _out << nl << "///   - tag: The numeric tag associated with the value.";
+    _out << nl << "///   - v: The sequence value to write to the stream.";
+    _out << nl << "public static func write(to ostr: " << ostr << ",  tag: Swift.Int32, value v: " << name << "?)";
+    _out << sb;
+    _out << nl << "guard let val = v else";
+    _out << sb;
+    _out << nl << "return";
+    _out << eb;
     if (p->type()->isVariableLength())
     {
-        out << nl << "if ostr.writeOptional(tag: tag, format: " << optionalFormat << ")";
-        out << sb;
-        out << nl << "let pos = ostr.startSize()";
-        out << nl << "write(to: ostr, value: val)";
-        out << nl << "ostr.endSize(position: pos)";
-        out << eb;
+        _out << nl << "if ostr.writeOptional(tag: tag, format: " << optionalFormat << ")";
+        _out << sb;
+        _out << nl << "let pos = ostr.startSize()";
+        _out << nl << "write(to: ostr, value: val)";
+        _out << nl << "ostr.endSize(position: pos)";
+        _out << eb;
     }
     else
     {
         if (p->type()->minWireSize() == 1)
         {
-            out << nl << "if ostr.writeOptional(tag: tag, format: .VSize)";
+            _out << nl << "if ostr.writeOptional(tag: tag, format: .VSize)";
         }
         else
         {
-            out << nl << "if ostr.writeOptionalVSize(tag: tag, len: val.count, elemSize: " << p->type()->minWireSize()
+            _out << nl << "if ostr.writeOptionalVSize(tag: tag, len: val.count, elemSize: " << p->type()->minWireSize()
                 << ")";
         }
-        out << sb;
-        out << nl << "write(to: ostr, value: val)";
-        out << eb;
+        _out << sb;
+        _out << nl << "write(to: ostr, value: val)";
+        _out << eb;
     }
-    out << eb;
+    _out << eb;
 
-    out << eb;
+    _out << eb;
 }
 
 void
@@ -837,9 +830,9 @@ Slice::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     const string keyType = typeToString(p->keyType(), p, false);
     const string valueType = typeToString(p->valueType(), p, false);
 
-    out << sp;
-    writeDocSummary(out, p);
-    out << nl << "public typealias " << name << " = [" << keyType << ": " << valueType << "]";
+    _out << sp;
+    writeDocSummary(_out, p);
+    _out << nl << "public typealias " << name << " = [" << keyType << ": " << valueType << "]";
 
     const string ostr = getUnqualified("Ice.OutputStream", swiftModule);
     const string istr = getUnqualified("Ice.InputStream", swiftModule);
@@ -848,133 +841,133 @@ Slice::TypesVisitor::visitDictionary(const DictionaryPtr& p)
     const bool isVariableLength = p->keyType()->isVariableLength() || p->valueType()->isVariableLength();
     const size_t minWireSize = p->keyType()->minWireSize() + p->valueType()->minWireSize();
 
-    out << sp;
-    out << nl << "/// Helper class to read and write `" << unescapedName << "` dictionary values from";
-    out << nl << "/// `Ice.InputStream` and `Ice.OutputStream`.";
-    out << nl << "public struct " << unescapedName << "Helper";
-    out << sb;
+    _out << sp;
+    _out << nl << "/// Helper class to read and write `" << unescapedName << "` dictionary values from";
+    _out << nl << "/// `Ice.InputStream` and `Ice.OutputStream`.";
+    _out << nl << "public struct " << unescapedName << "Helper";
+    _out << sb;
 
-    out << nl << "/// Read a `" << unescapedName << "` dictionary from the stream.";
-    out << nl << "///";
-    out << nl << "/// - Parameter istr: The stream to read from.";
-    out << nl << "/// - Returns: The dictionary read from the stream.";
-    out << nl << "public static func read(from istr: " << istr << ") throws -> sending " << name;
-    out << sb;
-    out << nl << "let sz = try Swift.Int(istr.readSize())";
-    out << nl << "var v = " << name << "()";
+    _out << nl << "/// Read a `" << unescapedName << "` dictionary from the stream.";
+    _out << nl << "///";
+    _out << nl << "/// - Parameter istr: The stream to read from.";
+    _out << nl << "/// - Returns: The dictionary read from the stream.";
+    _out << nl << "public static func read(from istr: " << istr << ") throws -> sending " << name;
+    _out << sb;
+    _out << nl << "let sz = try Swift.Int(istr.readSize())";
+    _out << nl << "var v = " << name << "()";
     if (p->valueType()->isClassType())
     {
-        out << nl << "nonisolated(unsafe) let e = " << getUnqualified("Ice.DictEntryArray", swiftModule) << "<"
+        _out << nl << "nonisolated(unsafe) let e = " << getUnqualified("Ice.DictEntryArray", swiftModule) << "<"
             << keyType << ", " << valueType << ">(size: sz)";
-        out << nl << "for i in 0 ..< sz";
-        out << sb;
+        _out << nl << "for i in 0 ..< sz";
+        _out << sb;
         string keyParam = "let key: " + keyType;
-        writeMarshalUnmarshalCode(out, p->keyType(), p, keyParam, false);
-        out << nl << "v[key] = nil as " << valueType;
-        out << nl << "Swift.withUnsafeMutablePointer(to: &v[key, default:nil])";
-        out << sb;
-        out << nl << "e.values[i] = Ice.DictEntry<" << keyType << ", " << valueType << ">("
+        writeMarshalUnmarshalCode(_out, p->keyType(), p, keyParam, false);
+        _out << nl << "v[key] = nil as " << valueType;
+        _out << nl << "Swift.withUnsafeMutablePointer(to: &v[key, default:nil])";
+        _out << sb;
+        _out << nl << "e.values[i] = Ice.DictEntry<" << keyType << ", " << valueType << ">("
             << "key: key, "
             << "value: $0)";
-        out << eb;
-        writeMarshalUnmarshalCode(out, p->valueType(), p, "e.values[i].value.pointee", false);
-        out << eb;
+        _out << eb;
+        writeMarshalUnmarshalCode(_out, p->valueType(), p, "e.values[i].value.pointee", false);
+        _out << eb;
 
-        out << nl << "for i in 0..<sz" << sb;
-        out << nl << "Swift.withUnsafeMutablePointer(to: &v[e.values[i].key, default:nil])";
-        out << sb;
-        out << nl << "e.values[i].value = $0";
-        out << eb;
-        out << eb;
+        _out << nl << "for i in 0..<sz" << sb;
+        _out << nl << "Swift.withUnsafeMutablePointer(to: &v[e.values[i].key, default:nil])";
+        _out << sb;
+        _out << nl << "e.values[i].value = $0";
+        _out << eb;
+        _out << eb;
     }
     else
     {
-        out << nl << "for _ in 0 ..< sz";
-        out << sb;
+        _out << nl << "for _ in 0 ..< sz";
+        _out << sb;
         string keyParam = "let key: " + keyType;
-        writeMarshalUnmarshalCode(out, p->keyType(), p, keyParam, false);
+        writeMarshalUnmarshalCode(_out, p->keyType(), p, keyParam, false);
         string valueParam = "let value: " + typeToString(p->valueType(), p);
-        writeMarshalUnmarshalCode(out, p->valueType(), p, valueParam, false);
-        out << nl << "v[key] = value";
-        out << eb;
+        writeMarshalUnmarshalCode(_out, p->valueType(), p, valueParam, false);
+        _out << nl << "v[key] = value";
+        _out << eb;
     }
 
-    out << nl << "return v";
-    out << eb;
+    _out << nl << "return v";
+    _out << eb;
 
-    out << sp;
-    out << nl << "/// Read an optional `" << unescapedName << "?` dictionary from the stream.";
-    out << nl << "///";
-    out << nl << "/// - Parameters:";
-    out << nl << "///   - istr: The stream to read from.";
-    out << nl << "///   - tag: The numeric tag associated with the value.";
-    out << nl << "/// - Returns: The dictionary read from the stream.";
-    out << nl << "public static func read(from istr: " << istr << ", tag: Swift.Int32) throws -> sending " << name
+    _out << sp;
+    _out << nl << "/// Read an optional `" << unescapedName << "?` dictionary from the stream.";
+    _out << nl << "///";
+    _out << nl << "/// - Parameters:";
+    _out << nl << "///   - istr: The stream to read from.";
+    _out << nl << "///   - tag: The numeric tag associated with the value.";
+    _out << nl << "/// - Returns: The dictionary read from the stream.";
+    _out << nl << "public static func read(from istr: " << istr << ", tag: Swift.Int32) throws -> sending " << name
         << "?";
-    out << sb;
-    out << nl << "guard try istr.readOptional(tag: tag, expectedFormat: " << optionalFormat << ") else";
-    out << sb;
-    out << nl << "return nil";
-    out << eb;
+    _out << sb;
+    _out << nl << "guard try istr.readOptional(tag: tag, expectedFormat: " << optionalFormat << ") else";
+    _out << sb;
+    _out << nl << "return nil";
+    _out << eb;
     if (p->keyType()->isVariableLength() || p->valueType()->isVariableLength())
     {
-        out << nl << "try istr.skip(4)";
+        _out << nl << "try istr.skip(4)";
     }
     else
     {
-        out << nl << "try istr.skipSize()";
+        _out << nl << "try istr.skipSize()";
     }
-    out << nl << "return try read(from: istr)";
-    out << eb;
+    _out << nl << "return try read(from: istr)";
+    _out << eb;
 
-    out << sp;
-    out << nl << "/// Write a `" << unescapedName << "` dictionary to the stream.";
-    out << nl << "///";
-    out << nl << "/// - Parameters:";
-    out << nl << "///   - ostr: The stream to write to.";
-    out << nl << "///   - v: The dictionary value to write to the stream.";
-    out << nl << "public static func write(to ostr: " << ostr << ", value v: " << name << ")";
-    out << sb;
-    out << nl << "ostr.write(size: v.count)";
-    out << nl << "for (key, value) in v";
-    out << sb;
-    writeMarshalUnmarshalCode(out, p->keyType(), p, "key", true);
-    writeMarshalUnmarshalCode(out, p->valueType(), p, "value", true);
-    out << eb;
-    out << eb;
+    _out << sp;
+    _out << nl << "/// Write a `" << unescapedName << "` dictionary to the stream.";
+    _out << nl << "///";
+    _out << nl << "/// - Parameters:";
+    _out << nl << "///   - ostr: The stream to write to.";
+    _out << nl << "///   - v: The dictionary value to write to the stream.";
+    _out << nl << "public static func write(to ostr: " << ostr << ", value v: " << name << ")";
+    _out << sb;
+    _out << nl << "ostr.write(size: v.count)";
+    _out << nl << "for (key, value) in v";
+    _out << sb;
+    writeMarshalUnmarshalCode(_out, p->keyType(), p, "key", true);
+    writeMarshalUnmarshalCode(_out, p->valueType(), p, "value", true);
+    _out << eb;
+    _out << eb;
 
-    out << sp;
-    out << nl << "/// Write an optional `" << unescapedName << "?` dictionary to the stream.";
-    out << nl << "///";
-    out << nl << "/// - Parameters:";
-    out << nl << "///   - ostr: The stream to write to.";
-    out << nl << "///   - tag: The numeric tag associated with the value.";
-    out << nl << "///   - v: The dictionary value to write to the stream.";
-    out << nl << "public static func write(to ostr: " << ostr << ", tag: Swift.Int32, value v: " << name << "?)";
-    out << sb;
-    out << nl << "guard let val = v else";
-    out << sb;
-    out << nl << "return";
-    out << eb;
+    _out << sp;
+    _out << nl << "/// Write an optional `" << unescapedName << "?` dictionary to the stream.";
+    _out << nl << "///";
+    _out << nl << "/// - Parameters:";
+    _out << nl << "///   - ostr: The stream to write to.";
+    _out << nl << "///   - tag: The numeric tag associated with the value.";
+    _out << nl << "///   - v: The dictionary value to write to the stream.";
+    _out << nl << "public static func write(to ostr: " << ostr << ", tag: Swift.Int32, value v: " << name << "?)";
+    _out << sb;
+    _out << nl << "guard let val = v else";
+    _out << sb;
+    _out << nl << "return";
+    _out << eb;
     if (isVariableLength)
     {
-        out << nl << "if ostr.writeOptional(tag: tag, format: " << optionalFormat << ")";
-        out << sb;
-        out << nl << "let pos = ostr.startSize()";
-        out << nl << "write(to: ostr, value: val)";
-        out << nl << "ostr.endSize(position: pos)";
-        out << eb;
+        _out << nl << "if ostr.writeOptional(tag: tag, format: " << optionalFormat << ")";
+        _out << sb;
+        _out << nl << "let pos = ostr.startSize()";
+        _out << nl << "write(to: ostr, value: val)";
+        _out << nl << "ostr.endSize(position: pos)";
+        _out << eb;
     }
     else
     {
-        out << nl << "if ostr.writeOptionalVSize(tag: tag, len: val.count, elemSize: " << minWireSize << ")";
-        out << sb;
-        out << nl << "write(to: ostr, value: val)";
-        out << eb;
+        _out << nl << "if ostr.writeOptionalVSize(tag: tag, len: val.count, elemSize: " << minWireSize << ")";
+        _out << sb;
+        _out << nl << "write(to: ostr, value: val)";
+        _out << eb;
     }
-    out << eb;
+    _out << eb;
 
-    out << eb;
+    _out << eb;
 }
 
 void
@@ -987,90 +980,90 @@ Slice::TypesVisitor::visitEnum(const EnumPtr& p)
     const string enumType = p->maxValue() <= 0xFF ? "Swift.UInt8" : "Swift.Int32";
     const string optionalFormat = getOptionalFormat(p);
 
-    out << sp;
-    writeDocSummary(out, p, "enum");
-    writeSwiftAttributes(out, p->getMetadata());
-    out << nl << "public enum " << name << ": " << enumType << ", Swift.Sendable";
-    out << sb;
+    _out << sp;
+    writeDocSummary(_out, p, "enum");
+    writeSwiftAttributes(_out, p->getMetadata());
+    _out << nl << "public enum " << name << ": " << enumType << ", Swift.Sendable";
+    _out << sb;
 
     for (const auto& enumerator : enumerators)
     {
-        writeDocSummary(out, enumerator);
-        out << nl << "case " << enumerator->mappedName() << " = " << enumerator->value();
+        writeDocSummary(_out, enumerator);
+        _out << nl << "case " << enumerator->mappedName() << " = " << enumerator->value();
     }
 
-    out << nl << "public init()";
-    out << sb;
-    out << nl << "self = ." << (*enumerators.begin())->mappedName();
-    out << eb;
+    _out << nl << "public init()";
+    _out << sb;
+    _out << nl << "self = ." << (*enumerators.begin())->mappedName();
+    _out << eb;
 
-    out << eb;
+    _out << eb;
 
-    out << sp;
-    out << nl << "/// An `Ice.InputStream` extension to read `" << docName << "` enumerated values from the stream.";
-    out << nl << "public extension " << getUnqualified("Ice.InputStream", swiftModule);
-    out << sb;
+    _out << sp;
+    _out << nl << "/// An `Ice.InputStream` extension to read `" << docName << "` enumerated values from the stream.";
+    _out << nl << "public extension " << getUnqualified("Ice.InputStream", swiftModule);
+    _out << sb;
 
-    out << sp;
-    out << nl << "/// Read an enumerated value.";
-    out << nl << "///";
-    out << nl << "/// - Returns: The enumerated value.";
-    out << nl << "func read() throws -> " << name;
-    out << sb;
-    out << nl << "let rawValue: " << enumType << " = try read(enumMaxValue: " << p->maxValue() << ")";
-    out << nl << "guard let val = " << name << "(rawValue: rawValue) else";
-    out << sb;
-    out << nl << "throw " << getUnqualified("Ice.MarshalException", swiftModule) << "(\"invalid enum value\")";
-    out << eb;
-    out << nl << "return val";
-    out << eb;
+    _out << sp;
+    _out << nl << "/// Read an enumerated value.";
+    _out << nl << "///";
+    _out << nl << "/// - Returns: The enumerated value.";
+    _out << nl << "func read() throws -> " << name;
+    _out << sb;
+    _out << nl << "let rawValue: " << enumType << " = try read(enumMaxValue: " << p->maxValue() << ")";
+    _out << nl << "guard let val = " << name << "(rawValue: rawValue) else";
+    _out << sb;
+    _out << nl << "throw " << getUnqualified("Ice.MarshalException", swiftModule) << "(\"invalid enum value\")";
+    _out << eb;
+    _out << nl << "return val";
+    _out << eb;
 
-    out << sp;
-    out << nl << "/// Read an optional enumerated value from the stream.";
-    out << nl << "///";
-    out << nl << "/// - Parameter tag: The numeric tag associated with the value.";
-    out << nl << "/// - Returns: The enumerated value.";
-    out << nl << "func read(tag: Swift.Int32) throws -> " << name << "?";
-    out << sb;
-    out << nl << "guard try readOptional(tag: tag, expectedFormat: " << optionalFormat << ") else";
-    out << sb;
-    out << nl << "return nil";
-    out << eb;
-    out << nl << "return try read() as " << name;
-    out << eb;
+    _out << sp;
+    _out << nl << "/// Read an optional enumerated value from the stream.";
+    _out << nl << "///";
+    _out << nl << "/// - Parameter tag: The numeric tag associated with the value.";
+    _out << nl << "/// - Returns: The enumerated value.";
+    _out << nl << "func read(tag: Swift.Int32) throws -> " << name << "?";
+    _out << sb;
+    _out << nl << "guard try readOptional(tag: tag, expectedFormat: " << optionalFormat << ") else";
+    _out << sb;
+    _out << nl << "return nil";
+    _out << eb;
+    _out << nl << "return try read() as " << name;
+    _out << eb;
 
-    out << eb;
+    _out << eb;
 
-    out << sp;
-    out << nl << "/// An `Ice.OutputStream` extension to write `" << docName << "` enumerated values to the stream.";
-    out << nl << "public extension " << getUnqualified("Ice.OutputStream", swiftModule);
-    out << sb;
+    _out << sp;
+    _out << nl << "/// An `Ice.OutputStream` extension to write `" << docName << "` enumerated values to the stream.";
+    _out << nl << "public extension " << getUnqualified("Ice.OutputStream", swiftModule);
+    _out << sb;
 
-    out << sp;
-    out << nl << "/// Writes an enumerated value to the stream.";
-    out << nl << "///";
-    out << nl << "/// - Parameter v: The enumerator to write.";
-    out << nl << "func write(_ v: " << name << ")";
-    out << sb;
-    out << nl << "write(enum: v.rawValue, maxValue: " << p->maxValue() << ")";
-    out << eb;
+    _out << sp;
+    _out << nl << "/// Writes an enumerated value to the stream.";
+    _out << nl << "///";
+    _out << nl << "/// - Parameter v: The enumerator to write.";
+    _out << nl << "func write(_ v: " << name << ")";
+    _out << sb;
+    _out << nl << "write(enum: v.rawValue, maxValue: " << p->maxValue() << ")";
+    _out << eb;
 
-    out << sp;
-    out << nl << "/// Writes an optional enumerated value to the stream.";
-    out << nl << "///";
-    out << nl << "/// - Parameters:";
-    out << nl << "///   - tag: The numeric tag associated with the value.";
-    out << nl << "///   - value: The enumerator to write.";
-    out << nl << "func write(tag: Swift.Int32, value: " << name << "?)";
-    out << sb;
-    out << nl << "guard let v = value else";
-    out << sb;
-    out << nl << "return";
-    out << eb;
-    out << nl << "write(tag: tag, val: v.rawValue, maxValue: " << p->maxValue() << ")";
-    out << eb;
+    _out << sp;
+    _out << nl << "/// Writes an optional enumerated value to the stream.";
+    _out << nl << "///";
+    _out << nl << "/// - Parameters:";
+    _out << nl << "///   - tag: The numeric tag associated with the value.";
+    _out << nl << "///   - value: The enumerator to write.";
+    _out << nl << "func write(tag: Swift.Int32, value: " << name << "?)";
+    _out << sb;
+    _out << nl << "guard let v = value else";
+    _out << sb;
+    _out << nl << "return";
+    _out << eb;
+    _out << nl << "write(tag: tag, val: v.rawValue, maxValue: " << p->maxValue() << ")";
+    _out << eb;
 
-    out << eb;
+    _out << eb;
 }
 
 void
@@ -1080,10 +1073,10 @@ Slice::TypesVisitor::visitConst(const ConstPtr& p)
     const string swiftModule = getSwiftModule(p->getTopLevelModule());
     const string mappedName = getRelativeTypeString(p, swiftModule);
 
-    out << sp;
-    writeDocSummary(out, p, "constant");
-    out << nl << "public let " << mappedName << ": " << typeToString(type, p) << " = ";
-    writeConstantValue(out, type, p->valueType(), p->value(), swiftModule);
+    _out << sp;
+    writeDocSummary(_out, p, "constant");
+    _out << nl << "public let " << mappedName << ": " << typeToString(type, p) << " = ";
+    writeConstantValue(_out, type, p->valueType(), p->value(), swiftModule);
 }
 
 bool
@@ -1112,165 +1105,165 @@ Slice::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     }
     ids << "]";
 
-    out << sp;
-    out << nl << "/// Traits for Slice interface '" << p->name() << "'.";
-    out << nl << "public struct " << traits << ": " << getUnqualified("Ice.SliceTraits", swiftModule);
-    out << sb;
-    out << nl << "public static let staticIds = " << ids.str();
-    out << nl << "public static let staticId = \"" << p->scoped() << '"';
-    out << eb;
+    _out << sp;
+    _out << nl << "/// Traits for Slice interface '" << p->name() << "'.";
+    _out << nl << "public struct " << traits << ": " << getUnqualified("Ice.SliceTraits", swiftModule);
+    _out << sb;
+    _out << nl << "public static let staticIds = " << ids.str();
+    _out << nl << "public static let staticId = \"" << p->scoped() << '"';
+    _out << eb;
 
     // Proxy class
-    out << sp;
-    writeDocSummary(out, p, "proxy protocol");
-    out << nl << "public protocol " << prx << ": ";
+    _out << sp;
+    writeDocSummary(_out, p, "proxy protocol");
+    _out << nl << "public protocol " << prx << ": ";
     if (bases.size() == 0)
     {
-        out << getUnqualified("Ice.ObjectPrx", swiftModule);
+        _out << getUnqualified("Ice.ObjectPrx", swiftModule);
     }
     else
     {
-        out.spar("");
+        _out.spar("");
         for (const auto& baseInterface : bases)
         {
-            out << (removeEscaping(getRelativeTypeString(baseInterface, swiftModule)) + "Prx");
+            _out << (removeEscaping(getRelativeTypeString(baseInterface, swiftModule)) + "Prx");
         }
-        out.epar("");
+        _out.epar("");
     }
-    out << sb;
-    out << eb;
+    _out << sb;
+    _out << eb;
 
-    out << sp;
-    out << nl;
+    _out << sp;
+    _out << nl;
     if (swiftModule == "Ice")
     {
-        out << "internal ";
+        _out << "internal ";
     }
     else
     {
-        out << "private ";
+        _out << "private ";
     }
-    out << "final class " << prxI << ": " << getUnqualified("Ice.ObjectPrxI", swiftModule) << ", " << prx
+    _out << "final class " << prxI << ": " << getUnqualified("Ice.ObjectPrxI", swiftModule) << ", " << prx
         << ", @unchecked Sendable";
-    out << sb;
+    _out << sb;
 
-    out << nl << "public override class func ice_staticId() -> Swift.String";
-    out << sb;
-    out << nl << "return " << traits << ".staticId";
-    out << eb;
+    _out << nl << "public override class func ice_staticId() -> Swift.String";
+    _out << sb;
+    _out << nl << "return " << traits << ".staticId";
+    _out << eb;
 
-    out << eb;
+    _out << eb;
 
     //
     // makeProxy
     //
-    out << sp;
-    out << nl << "/// Makes a new proxy from a communicator and a proxy string.";
-    out << nl << "///";
-    out << nl << "/// - Parameters:";
-    out << nl << "///    - communicator: The communicator of the new proxy.";
-    out << nl << "///    - proxyString: The proxy string to parse.";
-    out << nl << "///    - type: The type of the new proxy.";
-    out << nl << "/// - Returns: A new proxy with the requested type.";
-    out << nl << "/// - Throws: `Ice.ParseException` if the proxy string is invalid.";
-    out << nl << "public func makeProxy(communicator: Ice.Communicator, proxyString: String, type: " << prx
+    _out << sp;
+    _out << nl << "/// Makes a new proxy from a communicator and a proxy string.";
+    _out << nl << "///";
+    _out << nl << "/// - Parameters:";
+    _out << nl << "///    - communicator: The communicator of the new proxy.";
+    _out << nl << "///    - proxyString: The proxy string to parse.";
+    _out << nl << "///    - type: The type of the new proxy.";
+    _out << nl << "/// - Returns: A new proxy with the requested type.";
+    _out << nl << "/// - Throws: `Ice.ParseException` if the proxy string is invalid.";
+    _out << nl << "public func makeProxy(communicator: Ice.Communicator, proxyString: String, type: " << prx
         << ".Protocol) throws -> " << prx;
-    out << sb;
-    out << nl << "try communicator.makeProxyImpl(proxyString) as " << prxI;
-    out << eb;
+    _out << sb;
+    _out << nl << "try communicator.makeProxyImpl(proxyString) as " << prxI;
+    _out << eb;
 
     //
     // checkedCast
     //
-    out << sp;
-    out << nl
+    _out << sp;
+    _out << nl
         << "/// Creates a new proxy from an existing proxy after confirming the target object's type via a remote "
            "invocation.";
-    out << nl << "///";
-    out << nl << "/// This call throws a local exception if a communication error occurs. You can optionally supply a";
-    out << nl << "/// facet name and a context map.";
-    out << nl << "///";
-    out << nl << "/// - Parameters:";
-    out << nl << "///   - prx: The source proxy.";
-    out << nl << "///   - type: The type of the new proxy.";
-    out << nl << "///   - facet: The optional name of the desired facet.";
-    out << nl << "///   - context: The optional context dictionary for the remote invocation.";
-    out << nl
+    _out << nl << "///";
+    _out << nl << "/// This call throws a local exception if a communication error occurs. You can optionally supply a";
+    _out << nl << "/// facet name and a context map.";
+    _out << nl << "///";
+    _out << nl << "/// - Parameters:";
+    _out << nl << "///   - prx: The source proxy.";
+    _out << nl << "///   - type: The type of the new proxy.";
+    _out << nl << "///   - facet: The optional name of the desired facet.";
+    _out << nl << "///   - context: The optional context dictionary for the remote invocation.";
+    _out << nl
         << "/// - Returns: A proxy with the requested type or nil if the target object does not support this type.";
-    out << nl << "/// - Throws: `Ice.LocalException` if a communication error occurs.";
-    out << nl << "public func checkedCast" << spar << ("prx: " + getUnqualified("Ice.ObjectPrx", swiftModule))
+    _out << nl << "/// - Throws: `Ice.LocalException` if a communication error occurs.";
+    _out << nl << "public func checkedCast" << spar << ("prx: " + getUnqualified("Ice.ObjectPrx", swiftModule))
         << ("type: " + prx + ".Protocol") << ("facet: Swift.String? = nil")
         << ("context: " + getUnqualified("Ice.Context", swiftModule) + "? = nil") << epar << " async throws -> " << prx
         << "?";
-    out << sb;
-    out << nl << "return try await " << prxI << ".checkedCast(prx: prx, facet: facet, context: context) as " << prxI
+    _out << sb;
+    _out << nl << "return try await " << prxI << ".checkedCast(prx: prx, facet: facet, context: context) as " << prxI
         << "?";
-    out << eb;
+    _out << eb;
 
     //
     // uncheckedCast
     //
-    out << sp;
-    out << nl << "/// Creates a new proxy from an existing proxy.";
-    out << nl << "///";
-    out << nl << "/// - Parameters:";
-    out << nl << "///   - prx: The source proxy.";
-    out << nl << "///   - type: The type of the new proxy.";
-    out << nl << "///   - facet: The optional name of the desired facet.";
-    out << nl << "/// - Returns: A new proxy with the requested type.";
-    out << nl << "public func uncheckedCast" << spar << ("prx: " + getUnqualified("Ice.ObjectPrx", swiftModule))
+    _out << sp;
+    _out << nl << "/// Creates a new proxy from an existing proxy.";
+    _out << nl << "///";
+    _out << nl << "/// - Parameters:";
+    _out << nl << "///   - prx: The source proxy.";
+    _out << nl << "///   - type: The type of the new proxy.";
+    _out << nl << "///   - facet: The optional name of the desired facet.";
+    _out << nl << "/// - Returns: A new proxy with the requested type.";
+    _out << nl << "public func uncheckedCast" << spar << ("prx: " + getUnqualified("Ice.ObjectPrx", swiftModule))
         << ("type: " + prx + ".Protocol") << ("facet: Swift.String? = nil") << epar << " -> " << prx;
-    out << sb;
-    out << nl << "return " << prxI << ".uncheckedCast(prx: prx, facet: facet) as " << prxI;
-    out << eb;
+    _out << sb;
+    _out << nl << "return " << prxI << ".uncheckedCast(prx: prx, facet: facet) as " << prxI;
+    _out << eb;
 
     //
     // ice_staticId
     //
-    out << sp;
-    out << nl << "/// Returns the Slice type id of the interface associated with this proxy type.";
-    out << nl << "///";
-    out << nl << "/// - Parameter type:  The proxy type to retrieve the type id.";
-    out << nl << "/// - Returns: The type id of the interface associated with this proxy type.";
-    out << nl << "public func ice_staticId" << spar << ("_ type: " + prx + ".Protocol") << epar << " -> Swift.String";
-    out << sb;
-    out << nl << "return " << traits << ".staticId";
-    out << eb;
+    _out << sp;
+    _out << nl << "/// Returns the Slice type id of the interface associated with this proxy type.";
+    _out << nl << "///";
+    _out << nl << "/// - Parameter type:  The proxy type to retrieve the type id.";
+    _out << nl << "/// - Returns: The type id of the interface associated with this proxy type.";
+    _out << nl << "public func ice_staticId" << spar << ("_ type: " + prx + ".Protocol") << epar << " -> Swift.String";
+    _out << sb;
+    _out << nl << "return " << traits << ".staticId";
+    _out << eb;
 
     //
     // InputStream extension
     //
-    out << sp;
-    out << nl << "/// Extension to `Ice.InputStream` class to support reading proxies of type";
-    out << nl << "/// `" << prx << "`.";
-    out << nl << "public extension " << getUnqualified("Ice.InputStream", swiftModule);
-    out << sb;
+    _out << sp;
+    _out << nl << "/// Extension to `Ice.InputStream` class to support reading proxies of type";
+    _out << nl << "/// `" << prx << "`.";
+    _out << nl << "public extension " << getUnqualified("Ice.InputStream", swiftModule);
+    _out << sb;
 
-    out << nl << "/// Extracts a proxy from the stream. The stream must have been initialized with a communicator.";
-    out << nl << "///";
-    out << nl << "/// - Parameter type: The type of the proxy to be extracted.";
-    out << nl << "/// - Returns: The extracted proxy.";
-    out << nl << "func read(_ type: " << prx << ".Protocol) throws -> " << prx << "?";
-    out << sb;
-    out << nl << "return try read() as " << prxI << "?";
-    out << eb;
+    _out << nl << "/// Extracts a proxy from the stream. The stream must have been initialized with a communicator.";
+    _out << nl << "///";
+    _out << nl << "/// - Parameter type: The type of the proxy to be extracted.";
+    _out << nl << "/// - Returns: The extracted proxy.";
+    _out << nl << "func read(_ type: " << prx << ".Protocol) throws -> " << prx << "?";
+    _out << sb;
+    _out << nl << "return try read() as " << prxI << "?";
+    _out << eb;
 
-    out << nl << "/// Extracts a proxy from the stream. The stream must have been initialized with a communicator.";
-    out << nl << "///";
-    out << nl << "/// - Parameters:";
-    out << nl << "///   - tag: The numeric tag associated with the value.";
-    out << nl << "///   - type: The type of the proxy to be extracted.";
-    out << nl << "/// - Returns: The extracted proxy.";
-    out << nl << "func read(tag: Swift.Int32, type: " << prx << ".Protocol) throws -> " << prx << "?";
-    out << sb;
-    out << nl << "return try read(tag: tag) as " << prxI << "?";
-    out << eb;
+    _out << nl << "/// Extracts a proxy from the stream. The stream must have been initialized with a communicator.";
+    _out << nl << "///";
+    _out << nl << "/// - Parameters:";
+    _out << nl << "///   - tag: The numeric tag associated with the value.";
+    _out << nl << "///   - type: The type of the proxy to be extracted.";
+    _out << nl << "/// - Returns: The extracted proxy.";
+    _out << nl << "func read(tag: Swift.Int32, type: " << prx << ".Protocol) throws -> " << prx << "?";
+    _out << sb;
+    _out << nl << "return try read(tag: tag) as " << prxI << "?";
+    _out << eb;
 
-    out << eb;
+    _out << eb;
 
-    out << sp;
-    out << nl << "public extension " << prx;
-    out << sb;
+    _out << sp;
+    _out << nl << "public extension " << prx;
+    _out << sb;
 
     return true;
 }
@@ -1278,7 +1271,7 @@ Slice::TypesVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 void
 Slice::TypesVisitor::visitInterfaceDefEnd(const InterfaceDefPtr&)
 {
-    out << eb;
+    _out << eb;
 }
 
 void
@@ -1288,27 +1281,27 @@ Slice::TypesVisitor::visitOperation(const OperationPtr& op)
     const bool returnsAnyValues = op->returnsAnyValues();
     const string swiftModule = getSwiftModule(op->getTopLevelModule());
 
-    out << sp;
-    writeOpDocSummary(out, op, false);
-    out << nl << "func " << op->mappedName();
-    out << spar;
+    _out << sp;
+    writeOpDocSummary(_out, op, false);
+    _out << nl << "func " << op->mappedName();
+    _out << spar;
     for (const auto& param : inParams)
     {
         const bool isOptional = param->isOptional();
         const string typeString = typeToString(param->type(), op, isOptional);
         const string paramName = "iceP_" + removeEscaping(param->mappedName());
         const string paramLabel = (inParams.size() == 1 ? "_" : param->mappedName());
-        out << (paramLabel + " " + paramName + ": " + typeString + (isOptional ? " = nil" : ""));
+        _out << (paramLabel + " " + paramName + ": " + typeString + (isOptional ? " = nil" : ""));
     }
-    out << "context: " + getUnqualified("Ice.Context", swiftModule) + "? = nil";
-    out << epar;
-    out << " async throws";
+    _out << "context: " + getUnqualified("Ice.Context", swiftModule) + "? = nil";
+    _out << epar;
+    _out << " async throws";
     if (returnsAnyValues)
     {
-        out << " -> " << operationReturnType(op);
+        _out << " -> " << operationReturnType(op);
     }
 
-    out << sb;
+    _out << sb;
 
     //
     // Invoke
@@ -1316,56 +1309,56 @@ Slice::TypesVisitor::visitOperation(const OperationPtr& op)
 
     if (op->hasMetadata("oneway"))
     {
-        out << nl << "if _impl.ice_isTwoway()";
-        out << sb;
-        out << nl << "throw " << getUnqualified("Ice.OnewayOnlyException", swiftModule) << "(operation: \""
+        _out << nl << "if _impl.ice_isTwoway()";
+        _out << sb;
+        _out << nl << "throw " << getUnqualified("Ice.OnewayOnlyException", swiftModule) << "(operation: \""
             << op->name() << "\")";
-        out << eb;
+        _out << eb;
     }
 
-    out << nl << "return try await _impl._invoke(";
+    _out << nl << "return try await _impl._invoke(";
 
-    out.useCurrentPosAsIndent();
-    out << "operation: \"" << op->name() << "\",";
-    out << nl << "mode: " << modeToString(op->mode()) << ",";
+    _out.useCurrentPosAsIndent();
+    _out << "operation: \"" << op->name() << "\",";
+    _out << nl << "mode: " << modeToString(op->mode()) << ",";
 
     if (op->format())
     {
-        out << nl << "format: " << opFormatTypeToString(op);
-        out << ",";
+        _out << nl << "format: " << opFormatTypeToString(op);
+        _out << ",";
     }
 
     if (!inParams.empty())
     {
-        out << nl << "write: ";
-        writeMarshalInParams(out, op);
-        out << ",";
+        _out << nl << "write: ";
+        writeMarshalInParams(_out, op);
+        _out << ",";
     }
 
     if (returnsAnyValues)
     {
-        out << nl << "read: read,";
+        _out << nl << "read: read,";
     }
 
     if (!op->throws().empty())
     {
-        out << nl << "userException:";
-        writeUnmarshalUserException(out, op);
-        out << ",";
+        _out << nl << "userException:";
+        writeUnmarshalUserException(_out, op);
+        _out << ",";
     }
 
-    out << nl << "context: context)";
+    _out << nl << "context: context)";
 
-    out.restoreIndent();
+    _out.restoreIndent();
 
     if (returnsAnyValues)
     {
-        writeUnmarshalOutParams(out, op);
+        writeUnmarshalOutParams(_out, op);
     }
-    out << eb;
+    _out << eb;
 }
 
-Slice::ServantVisitor::ServantVisitor(IceInternal::Output& o) : out(o) {}
+Slice::ServantVisitor::ServantVisitor(IceInternal::Output& out) : _out(out) {}
 
 bool
 Slice::ServantVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
@@ -1383,31 +1376,31 @@ Slice::ServantVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
         baseNames.push_back(getRelativeTypeString(base, swiftModule));
     }
 
-    out << sp;
-    writeDocSummary(out, p, "skeleton protocol");
-    out << nl << "public protocol " << servant << ": ";
+    _out << sp;
+    writeDocSummary(_out, p, "skeleton protocol");
+    _out << nl << "public protocol " << servant << ": ";
     if (baseNames.empty())
     {
-        out << getUnqualified("Ice.Dispatcher", swiftModule);
+        _out << getUnqualified("Ice.Dispatcher", swiftModule);
     }
     else
     {
-        out.spar("");
+        _out.spar("");
         for (const auto& baseName : baseNames)
         {
-            out << baseName;
+            _out << baseName;
         }
-        out.epar("");
+        _out.epar("");
     }
 
-    out << sb;
+    _out << sb;
     return true;
 }
 
 void
 Slice::ServantVisitor::visitInterfaceDefEnd(const InterfaceDefPtr&)
 {
-    out << eb;
+    _out << eb;
 }
 
 void
@@ -1415,26 +1408,26 @@ Slice::ServantVisitor::visitOperation(const OperationPtr& op)
 {
     const string swiftModule = getSwiftModule(op->getTopLevelModule());
 
-    out << sp;
-    writeOpDocSummary(out, op, true);
-    out << nl << "func " << op->mappedName();
-    out << spar;
+    _out << sp;
+    writeOpDocSummary(_out, op, true);
+    _out << nl << "func " << op->mappedName();
+    _out << spar;
     for (const auto& param : op->inParameters())
     {
         const string typeString = typeToString(param->type(), op, param->isOptional());
-        out << param->mappedName() + ": " + (param->type()->usesClasses() ? "sending " : "") + typeString;
+        _out << param->mappedName() + ": " + (param->type()->usesClasses() ? "sending " : "") + typeString;
     }
-    out << ("current: " + getUnqualified("Ice.Current", swiftModule));
-    out << epar;
+    _out << ("current: " + getUnqualified("Ice.Current", swiftModule));
+    _out << epar;
 
-    out << " async throws";
+    _out << " async throws";
     if (op->returnsAnyValues())
     {
-        out << " -> " << operationReturnType(op);
+        _out << " -> " << operationReturnType(op);
     }
 }
 
-Slice::ServantExtVisitor::ServantExtVisitor(IceInternal::Output& o) : out(o) {}
+Slice::ServantExtVisitor::ServantExtVisitor(IceInternal::Output& out) : _out(out) {}
 
 bool
 Slice::ServantExtVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
@@ -1444,12 +1437,12 @@ Slice::ServantExtVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     const string unescapedName = removeEscaping(servant);
     const string traits = unescapedName + "Traits";
 
-    out << sp;
-    out << nl << "extension " << servant;
-    out << sb;
-    out << nl << "private static var defaultObject: " << getUnqualified("Ice.Object", swiftModule) << sb;
-    out << nl << getUnqualified("Ice.DefaultObject", swiftModule) << "<" << traits << ">()";
-    out << eb;
+    _out << sp;
+    _out << nl << "extension " << servant;
+    _out << sb;
+    _out << nl << "private static var defaultObject: " << getUnqualified("Ice.Object", swiftModule) << sb;
+    _out << nl << getUnqualified("Ice.DefaultObject", swiftModule) << "<" << traits << ">()";
+    _out << eb;
 
     const OperationList allOps = p->allOperations();
 
@@ -1465,56 +1458,56 @@ Slice::ServantExtVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
     allOpNames.emplace_back("ice_isA", "ice_isA");
     allOpNames.emplace_back("ice_ping", "ice_ping");
 
-    out << sp;
-    out << nl
+    _out << sp;
+    _out << nl
         << "/// Dispatches an incoming request to one of the instance methods of the generated protocol, based on the "
            "operation name carried by the request.";
-    out << nl << "/// - Parameter request: The incoming request.";
-    out << nl << "/// - Returns: The outgoing response.";
-    out << nl << "public func dispatch(_ request: sending Ice.IncomingRequest) async throws -> Ice.OutgoingResponse"
+    _out << nl << "/// - Parameter request: The incoming request.";
+    _out << nl << "/// - Returns: The outgoing response.";
+    _out << nl << "public func dispatch(_ request: sending Ice.IncomingRequest) async throws -> Ice.OutgoingResponse"
         << sb;
-    out << nl << "try await Self.dispatch(self, request: request)";
-    out << eb;
+    _out << nl << "try await Self.dispatch(self, request: request)";
+    _out << eb;
 
-    out << sp;
-    out << nl
+    _out << sp;
+    _out << nl
         << "/// Dispatches an incoming request to one of the instance methods of the generated protocol, based on the "
            "operation name carried by the request.";
-    out << nl
+    _out << nl
         << "/// Call this static method from the `dispatch` method of your servant class when you want to reuse a base "
            "servant class in a derived servant class.";
-    out << nl << "/// - Parameters:";
-    out << nl << "///   - servant: The servant to dispatch the request to.";
-    out << nl << "///   - request: The incoming request.";
-    out << nl << "/// - Returns: The outgoing response.";
-    out << nl << "public static func dispatch(_ servant: " << servant
+    _out << nl << "/// - Parameters:";
+    _out << nl << "///   - servant: The servant to dispatch the request to.";
+    _out << nl << "///   - request: The incoming request.";
+    _out << nl << "/// - Returns: The outgoing response.";
+    _out << nl << "public static func dispatch(_ servant: " << servant
         << ", request: sending Ice.IncomingRequest) async throws -> Ice.OutgoingResponse" << sb;
-    out << nl << "switch request.current.operation";
-    out << sb;
-    out.dec(); // to align case with switch
+    _out << nl << "switch request.current.operation";
+    _out << sb;
+    _out.dec(); // to align case with switch
     for (const auto& [sliceName, mappedName] : allOpNames)
     {
         const string mappedDispatchName = "_iceD_" + removeEscaping(mappedName);
-        out << nl << "case \"" << sliceName << "\":";
-        out.inc();
+        _out << nl << "case \"" << sliceName << "\":";
+        _out.inc();
         if (sliceName == "ice_id" || sliceName == "ice_ids" || sliceName == "ice_isA" || sliceName == "ice_ping")
         {
-            out << nl << "try await (servant as? Ice.Object ?? " << "Self.defaultObject)." << mappedDispatchName
+            _out << nl << "try await (servant as? Ice.Object ?? " << "Self.defaultObject)." << mappedDispatchName
                 << "(request)";
         }
         else
         {
-            out << nl << "try await servant." << mappedDispatchName << "(request)";
+            _out << nl << "try await servant." << mappedDispatchName << "(request)";
         }
 
-        out.dec();
+        _out.dec();
     }
-    out << nl << "default:";
-    out.inc();
-    out << nl << "throw Ice.OperationNotExistException()";
+    _out << nl << "default:";
+    _out.inc();
+    _out << nl << "throw Ice.OperationNotExistException()";
     // missing dec to compensate for the extra dec after switch sb
-    out << eb;
-    out << eb;
+    _out << eb;
+    _out << eb;
 
     return true;
 }
@@ -1522,7 +1515,7 @@ Slice::ServantExtVisitor::visitInterfaceDefStart(const InterfaceDefPtr& p)
 void
 Slice::ServantExtVisitor::visitInterfaceDefEnd(const InterfaceDefPtr&)
 {
-    out << eb;
+    _out << eb;
 }
 
 void
@@ -1532,59 +1525,59 @@ Slice::ServantExtVisitor::visitOperation(const OperationPtr& op)
     const ParameterList inParams = op->inParameters();
     const bool returnsAnyValues = op->returnsAnyValues();
 
-    out << sp;
-    out << nl << "public func _iceD_" << removeEscaping(opName)
+    _out << sp;
+    _out << nl << "public func _iceD_" << removeEscaping(opName)
         << "(_ request: Ice.IncomingRequest) async throws -> Ice.OutgoingResponse";
 
-    out << sb;
+    _out << sb;
 
     if (op->mode() == Operation::Mode::Normal)
     {
-        out << nl << "try request.current.checkNonIdempotent()";
+        _out << nl << "try request.current.checkNonIdempotent()";
     }
 
     if (inParams.empty())
     {
-        out << nl << "_ = try request.inputStream.skipEmptyEncapsulation()";
+        _out << nl << "_ = try request.inputStream.skipEmptyEncapsulation()";
     }
     else
     {
-        out << nl << "let istr = request.inputStream";
-        out << nl << "_ = try istr.startEncapsulation()";
-        writeUnmarshalInParams(out, op);
+        _out << nl << "let istr = request.inputStream";
+        _out << nl << "_ = try istr.startEncapsulation()";
+        writeUnmarshalInParams(_out, op);
     }
 
-    out << nl;
+    _out << nl;
     if (returnsAnyValues)
     {
-        out << "let result = ";
+        _out << "let result = ";
     }
 
-    out << "try await self." << opName;
-    out << spar;
+    _out << "try await self." << opName;
+    _out << spar;
     for (const auto& param : inParams)
     {
         // The swift compiler reports an error if you escape an argument label when calling a function.
         // So we always need to remove escaping here.
         const string paramName = removeEscaping(param->mappedName());
-        out << (paramName + ": iceP_" + paramName);
+        _out << (paramName + ": iceP_" + paramName);
     }
-    out << "current: request.current";
-    out << epar;
+    _out << "current: request.current";
+    _out << epar;
 
     if (!returnsAnyValues)
     {
-        out << nl << "return request.current.makeEmptyOutgoingResponse()";
+        _out << nl << "return request.current.makeEmptyOutgoingResponse()";
     }
     else
     {
-        out << nl << "return request.current.makeOutgoingResponse(result, formatType: " << opFormatTypeToString(op)
+        _out << nl << "return request.current.makeOutgoingResponse(result, formatType: " << opFormatTypeToString(op)
             << ")";
-        out << sb;
-        out << " ostr, value in ";
-        writeMarshalAsyncOutParams(out, op);
-        out << eb;
+        _out << sb;
+        _out << " ostr, value in ";
+        writeMarshalAsyncOutParams(_out, op);
+        _out << eb;
     }
 
-    out << eb;
+    _out << eb;
 }

--- a/cpp/src/slice2swift/Gen.h
+++ b/cpp/src/slice2swift/Gen.h
@@ -27,7 +27,7 @@ namespace Slice
     class ImportVisitor final : public ParserVisitor
     {
     public:
-        ImportVisitor(IceInternal::Output&);
+        ImportVisitor(IceInternal::Output& out);
 
         bool visitModuleStart(const ModulePtr&) final;
         bool visitClassDefStart(const ClassDefPtr&) final;
@@ -43,14 +43,14 @@ namespace Slice
         void addImport(const SyntaxTreeBasePtr& p, const ContainedPtr& usedBy);
         void addImport(const std::string& module);
 
-        IceInternal::Output& out;
+        IceInternal::Output& _out;
         std::vector<std::string> _imports;
     };
 
     class TypesVisitor final : public ParserVisitor
     {
     public:
-        TypesVisitor(IceInternal::Output&);
+        TypesVisitor(IceInternal::Output& out);
 
         bool visitExceptionStart(const ExceptionPtr&) final;
         bool visitClassDefStart(const ClassDefPtr&) final;
@@ -66,35 +66,35 @@ namespace Slice
         void visitOperation(const OperationPtr&) final;
 
     private:
-        IceInternal::Output& out;
+        IceInternal::Output& _out;
     };
 
     // Generates the servant protocols.
     class ServantVisitor final : public ParserVisitor
     {
     public:
-        ServantVisitor(IceInternal::Output&);
+        ServantVisitor(IceInternal::Output& out);
 
         bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
         void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
         void visitOperation(const OperationPtr&) final;
 
     private:
-        IceInternal::Output& out;
+        IceInternal::Output& _out;
     };
 
     // Generate extensions for the servant protocols.
     class ServantExtVisitor final : public ParserVisitor
     {
     public:
-        ServantExtVisitor(IceInternal::Output&);
+        ServantExtVisitor(IceInternal::Output& out);
 
         bool visitInterfaceDefStart(const InterfaceDefPtr&) final;
         void visitInterfaceDefEnd(const InterfaceDefPtr&) final;
         void visitOperation(const OperationPtr&) final;
 
     private:
-        IceInternal::Output& out;
+        IceInternal::Output& _out;
     };
 }
 


### PR DESCRIPTION
This PR:
- Moves some functions which are only used in one file/scope to the place where they're used.
- Renames `Operation::interface()` to `Operation::parentInterface()`
  More on this later
- Moves the contents of `CPlusPlusUtil` to the `Slice::Cpp` namespace, instead of just the `Slice` namespace.
  This is what we do for all the other `xxxUtil` files. C++ was the only exception.
- Updates some constructors to use the `Slice::baseName` util function which was added, but only used for python.
- Fixes a variable name in `slice2swift`. We had a private variable named `out`, which I updated to `_out` (since it's private).
   We omitted the underscore to avoid conflicting with the _other_ `_out` on `Gen`, from things were nested in it...

----

Why change `interface()` to `parentInterface()`?

Windows platforms actually defines `interface` to be `struct`. No seriously. If you type "interface", right click it, and "Go To Definition" on Windows, it takes you to these two lines of code in the system include files:
```
#define __STRUCT__ struct
#define interface __STRUCT__
```

Because of this, my VsCode C++ extension has always hated our use of the identifier `interface`, and will show any files using it as having errors, even though they compile fine. But it's annoying that I can't tell if a file really has errors, or just this `interface` issue.
By changing the name, for the first time in a while, my VsCode shows no errors in our C++ code.

