### PR TITLE
Fix disabling of always-activation servers on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ These are the changes since the [Ice 3.8.1] release.
 ### General Changes
 
 - Removed the 'ice2slice' compiler
+- Fixed IceGrid so servers with activation="always" are no longer disabled after a startup failure when
+  IceGrid.Node.DisableOnFailure is set to 0 (the default).
 
 ### Slice Language Changes
 

--- a/cpp/src/IceGrid/ServerI.cpp
+++ b/cpp/src/IceGrid/ServerI.cpp
@@ -1390,11 +1390,9 @@ ServerI::disableOnFailure()
     }
 
     //
-    // If disable on failure is configured or if the activation mode
-    // is always and the server wasn't active at the time of the
-    // failure we disable the server.
+    // Disable the server only when disable-on-failure is configured.
     //
-    if (_disableOnFailure != 0s || (_activation == Always && (_state == Activating || _state == WaitForActivation)))
+    if (_disableOnFailure != 0s)
     {
         _previousActivation = _activation;
         _activation = Disabled;

--- a/cpp/test/IceGrid/activation/AllTests.cpp
+++ b/cpp/test/IceGrid/activation/AllTests.cpp
@@ -521,6 +521,24 @@ allTests(Test::TestHelper* helper)
         }
         pingers.resize(0);
 
+        // With IceGrid.Node.DisableOnFailure=0 (local node default), startup failures must not disable
+        // activation="always" servers.
+        Ice::ObjectPrx alwaysFailing(communicator, "fail-on-startup-always");
+        for (i = 0; i < 5; ++i)
+        {
+            this_thread::sleep_for(chrono::milliseconds(500));
+            test(admin->isServerEnabled("fail-on-startup-always"));
+            try
+            {
+                alwaysFailing->ice_ping();
+                test(false);
+            }
+            catch (const Ice::NoEndpointException&)
+            {
+            }
+        }
+        admin->enableServer("fail-on-startup-always", false);
+
         try
         {
             admin->startServer("invalid-pwd-no-oa");

--- a/cpp/test/IceGrid/activation/application.xml
+++ b/cpp/test/IceGrid/activation/application.xml
@@ -44,6 +44,7 @@
       <server-instance template="Server" id="server-activation-timeout" activation-delay="5" activation-timeout="3"/>
       <server-instance template="Server" id="server-deactivation-timeout" deactivation-delay="60" deactivation-timeout="3"/>
       <server-instance template="Server" id="fail-on-startup" fail-on-startup="1"/>
+      <server-instance template="Server" id="fail-on-startup-always" activation="always" fail-on-startup="1"/>
 
       <server id="invalid-exe" exe="server2" activation="on-demand">
         <adapter name="TestAdapter" endpoints="default">


### PR DESCRIPTION
Fixes #5306

Since its inception, IceGrid's `always` activation mode has had an undocumented (as far as I can tell) edge case in how it interacts with the [IceGrid.Node.DisableOnFailure](https://docs.zeroc.com/ice/3.8/csharp/icegrid-1#IceGrid.*-IceGrid.Node.DisableOnFailure) property.

If an "always" server failed during activation we disabled it. 

https://github.com/zeroc-ice/ice/blob/9311976c46dab00e462e70ca4e723823adb990e3/cpp/src/IceGrid/ServerI.cpp#L1397

As stated in the issue linked issue 

>  The current behavior contradicts the documented semantics of DisableOnFailure=0 ("the node does not disable servers") and is surprising — there's no good reason to treat a startup failure differently from a post-startup crash for always servers.

Simplify disableOnFailure() to only check the DisableOnFailure setting, remove logic that incorrectly disabled servers with activation="always" on startup failure

If approved, we should also decide if we want to backport this fix to 3.8. 