### PR TITLE
Fix Debian packaging lintian errors and update copyright

### DIFF
--- a/.github/workflows/build-deb-packages.yml
+++ b/.github/workflows/build-deb-packages.yml
@@ -34,11 +34,11 @@ jobs:
 
           - distribution: debian12
             arch: amd64
-            deb_build_profiles: "no-python312"
+            deb_build_profiles: "nopython"
 
           - distribution: debian12
             arch: arm64
-            deb_build_profiles: "no-python312"
+            deb_build_profiles: "nopython"
 
           - distribution: debian13
             arch: amd64

--- a/ICE_LICENSE
+++ b/ICE_LICENSE
@@ -12,17 +12,6 @@ details.
 You should have received a copy of the GNU General Public License version
 2 along with this program; if not, see http://www.gnu.org/licenses.
 
-Linking Ice statically or dynamically with other software (such as a
-library, module or application) is making a combined work based on Ice.
-Thus, the terms and conditions of the GNU General Public License version
-2 cover this combined work.
-
-If such software can only be used together with Ice, then not only the
-combined work but the software itself is a work derived from Ice and as
-such shall be licensed under the terms of the GNU General Public License
-version 2. This includes the situation where Ice is only being used
-through an abstraction layer.
-
 As a special exception to the above, ZeroC grants to the copyright
 holders and contributors of the Mumble project (http://www.mumble.info)
 the permission to license the Ice-based software they contribute to

--- a/packaging/common/glacier2router.service
+++ b/packaging/common/glacier2router.service
@@ -4,7 +4,7 @@
 Description=Glacier2 router daemon
 Documentation=man:glacier2router(1)
 Documentation=https://docs.zeroc.com/ice/3.8/cpp/glacier2
-After=syslog.target network.target
+After=network.target
 
 [Service]
 ExecStart=/usr/bin/glacier2router --Ice.Config=/etc/glacier2router.conf

--- a/packaging/common/icegridnode.service
+++ b/packaging/common/icegridnode.service
@@ -4,7 +4,7 @@
 Description=IceGrid node daemon
 Documentation=man:icegridnode(1)
 Documentation=https://docs.zeroc.com/ice/3.8/cpp/icegridnode
-After=syslog.target network.target icegridregistry.service
+After=network.target icegridregistry.service
 
 [Service]
 ExecStart=/usr/bin/icegridnode --Ice.Config=/etc/icegridnode.conf

--- a/packaging/common/icegridregistry.service
+++ b/packaging/common/icegridregistry.service
@@ -5,7 +5,7 @@ Description=IceGrid registry daemon
 Documentation=man:icegridregistry(1)
 Documentation=https://docs.zeroc.com/ice/3.8/cpp/icegridregistry
 Before=icegridnode.service
-After=syslog.target network.target
+After=network.target
 
 [Service]
 ExecStart=/usr/bin/icegridregistry --Ice.Config=/etc/icegridregistry.conf

--- a/packaging/deb/build-package.sh
+++ b/packaging/deb/build-package.sh
@@ -29,15 +29,26 @@ fi
 
 UPSTREAM_VERSION=$(echo $ICE_VERSION | cut -f1 -d'-')
 
-# Generate a tarball of the current repository state for the given UPSTREAM_VERSION
+# Generate a tarball of the current repository state for the given UPSTREAM_VERSION, excluding files
+# listed in Files-Excluded in debian/copyright (pre-built Java binaries and other non-essential files).
 echo "Creating tarball for UPSTREAM_VERSION=$UPSTREAM_VERSION"
 cd /workspace/ice
 git config --global --add safe.directory /workspace/ice
-git archive --format=tar.gz -o /workspace/zeroc-ice_${UPSTREAM_VERSION}.orig.tar.gz HEAD
+git archive --format=tar.gz \
+    --prefix=zeroc-ice-${UPSTREAM_VERSION}/ \
+    -o /workspace/zeroc-ice_${UPSTREAM_VERSION}.orig.tar.gz \
+    HEAD \
+    ':(exclude)cpp/src/IceUtil/ConvertUTF.*' \
+    ':(exclude)cpp/msbuild/*' \
+    ':(exclude)csharp/*' \
+    ':(exclude)java/*' \
+    ':(exclude)js/*' \
+    ':(exclude)packaging/rpm/*' \
+    ':(exclude)packaging/windows-installer/*'
 
 # Unpack the source tarball
 cd /workspace/build
-tar xzf ../zeroc-ice_${UPSTREAM_VERSION}.orig.tar.gz
+tar xzf ../zeroc-ice_${UPSTREAM_VERSION}.orig.tar.gz --strip-components=1
 
 # Build the source package (-S generates .dsc and .tar.gz files)
 dpkg-buildpackage -S

--- a/packaging/deb/debian/BUILDING.md
+++ b/packaging/deb/debian/BUILDING.md
@@ -55,12 +55,21 @@ export UPSTREAM_VERSION=$(echo $ICE_VERSION | cut -f1 -d'-')
 
 ### 4. Create Source Archive
 
-Generate the upstream tarball from the Git repository:
+Generate the upstream tarball from the Git repository, excluding files listed in
+`Files-Excluded` in `debian/copyright`:
 
 ```bash
 cd ice
 git archive --format=tar.gz --prefix=zeroc-ice-${UPSTREAM_VERSION}/ \
-    -o $HOME/packaging/zeroc-ice/zeroc-ice_${UPSTREAM_VERSION}.orig.tar.gz HEAD
+    -o $HOME/packaging/zeroc-ice/zeroc-ice_${UPSTREAM_VERSION}.orig.tar.gz \
+    HEAD \
+    ':(exclude)cpp/src/IceUtil/ConvertUTF.*' \
+    ':(exclude)cpp/msbuild/*' \
+    ':(exclude)csharp/*' \
+    ':(exclude)java/*' \
+    ':(exclude)js/*' \
+    ':(exclude)packaging/rpm/*' \
+    ':(exclude)packaging/windows-installer/*'
 ```
 
 ### 5. Extract Source
@@ -80,10 +89,11 @@ Install the required build dependencies:
 sudo mk-build-deps -ir -t 'apt-get -y' debian/control
 ```
 
-**For Debian 12:** Use the `no-python312` build profile to exclude Python 3.12 support:
+**For Debian 12:** Use the `nopython` build profile to skip building the Python package (requires Python >= 3.12,
+which Debian 12 doesn't provide):
 
 ```bash
-sudo DEB_BUILD_PROFILES="no-python312" mk-build-deps -ir -t 'apt-get -y' debian/control
+sudo DEB_BUILD_PROFILES="nopython" mk-build-deps -ir -t 'apt-get -y' debian/control
 ```
 
 ### 7. Build Packages
@@ -96,10 +106,10 @@ Build the source package (generates .dsc and .tar.gz files):
 dpkg-buildpackage -S -uc -us
 ```
 
-**For Debian 12:** Use the `no-python312` build profile:
+**For Debian 12:** Use the `nopython` build profile:
 
 ```bash
-DEB_BUILD_PROFILES="no-python312" dpkg-buildpackage -S -uc -us
+DEB_BUILD_PROFILES="nopython" dpkg-buildpackage -S -uc -us
 ```
 
 #### Binary Packages
@@ -110,10 +120,10 @@ Build the binary packages:
 dpkg-buildpackage -b -uc -us
 ```
 
-**For Debian 12:** Use the `no-python312` build profile:
+**For Debian 12:** Use the `nopython` build profile:
 
 ```bash
-DEB_BUILD_PROFILES="no-python312" dpkg-buildpackage -b -uc -us
+DEB_BUILD_PROFILES="nopython" dpkg-buildpackage -b -uc -us
 ```
 
 The built packages will be available in the parent directory (`$HOME/packaging/zeroc-ice/`):

--- a/packaging/deb/debian/control
+++ b/packaging/deb/debian/control
@@ -8,10 +8,10 @@ Build-Depends: debhelper,
                dh-exec,
                dh-php (>= 0.20),
                dh-python,
-               libbluetooth-dev [!hurd-i386 !kfreebsd-i386 !kfreebsd-amd64],
+               libbluetooth-dev [!hurd-i386],
                libbz2-dev,
                libcrypt-dev,
-               libdbus-1-dev [!hurd-i386 !kfreebsd-i386 !kfreebsd-amd64],
+               libdbus-1-dev [!hurd-i386],
                libedit-dev,
                libexpat1-dev,
                liblmdb-dev,
@@ -22,11 +22,12 @@ Build-Depends: debhelper,
                openssl,
                php-all-dev,
                php-cli,
-               python3 (>= 3.12) <!no-python312>,
-               python3-dev (>= 3.12) <!no-python312>,
+               python3 (>= 3.12) <!nopython>,
+               python3-dev (>= 3.12) <!nopython>,
                python3-setuptools,
                python3-passlib
-Standards-Version: 4.7.2
+Standards-Version: 4.7.3
+Rules-Requires-Root: no
 Homepage: https://zeroc.com
 Vcs-Git: https://github.com/zeroc-ice/ice.git
 Vcs-Browser: https://github.com/zeroc-ice/ice
@@ -35,7 +36,7 @@ Package: libzeroc-ice-dev
 Architecture: any
 Section: libdevel
 Depends: libzeroc-ice3.8 (= ${binary:Version}),
-         zeroc-ice-slice (= ${binary:Version}),
+         zeroc-ice-slice (= ${source:Version}),
          libssl-dev,
          ${misc:Depends}
 Description: libraries and headers for developing Ice applications in C++
@@ -89,7 +90,7 @@ Package: php-zeroc-ice
 Architecture: any
 Section: php
 Depends: libzeroc-ice3.8 (= ${binary:Version}),
-         zeroc-ice-slice (= ${binary:Version}),
+         zeroc-ice-slice (= ${source:Version}),
          ${misc:Depends},
          ${php:Depends},
          ${shlibs:Depends}
@@ -103,11 +104,11 @@ Description: PHP extension for Ice
  your application logic.
 
 Package: python3-zeroc-ice
-Build-Profiles: <!no-python312>
+Build-Profiles: <!nopython>
 Architecture: any
 Section: python
 Depends: libzeroc-ice3.8 (= ${binary:Version}),
-         zeroc-ice-slice (= ${binary:Version}),
+         zeroc-ice-slice (= ${source:Version}),
          ${misc:Depends},
          ${python3:Depends},
          ${shlibs:Depends}
@@ -147,7 +148,6 @@ Description: Ice to Slice compiler
 
 Package: zeroc-ice-slice
 Architecture: all
-Section: devel
 Depends: ${misc:Depends}
 Description: Slice files for Ice
  This package contains Slice files used by the Ice framework.
@@ -240,19 +240,17 @@ Description: IceBridge service
 Package: zeroc-ice-compilers
 Architecture: all
 Section: oldlibs
-Priority: optional
-Depends: libzeroc-ice-dev (= ${binary:Version}),
-        python3-zeroc-ice (= ${binary:Version}) <!no-python312>,
-        php-zeroc-ice (= ${binary:Version}),
+Depends: libzeroc-ice-dev (>= ${source:Version}),
+        python3-zeroc-ice (>= ${source:Version}) <!nopython>,
+        php-zeroc-ice (>= ${source:Version}),
         ${misc:Depends}
-Description: transitional dummy package for Ice 3.7 all-dev metapackage
+Description: transitional dummy package for Ice 3.7 compilers metapackage
  This empty package ensures a smooth upgrade from Ice 3.7 by replacing
  the obsolete zeroc-ice-compilers. It can be safely removed.
 
 Package: zeroc-ice-all-dev
 Architecture: all
 Section: oldlibs
-Priority: optional
 Depends: ${misc:Depends}
 Description: transitional dummy package for Ice 3.7 all-dev metapackage
  This empty package ensures a smooth upgrade from Ice 3.7 by replacing
@@ -261,7 +259,6 @@ Description: transitional dummy package for Ice 3.7 all-dev metapackage
 Package: zeroc-ice-all-runtime
 Architecture: all
 Section: oldlibs
-Priority: optional
 Depends: ${misc:Depends}
 Description: transitional dummy package for Ice 3.7 all-runtime metapackage
  This empty package ensures a smooth upgrade from Ice 3.7 by replacing

--- a/packaging/deb/debian/copyright
+++ b/packaging/deb/debian/copyright
@@ -2,7 +2,8 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: ZeroC Ice
 Upstream-Contact: ZeroC Info <info@zeroc.com>
 Source: https://github.com/zeroc-ice/
-Files-Excluded: */gradle/GRADLE_LICENSE */gradle/wrapper */gradlew* cpp/src/IceUtil/ConvertUTF.*
+Comment: Repackaged to remove files not needed for the Debian build.
+Files-Excluded: cpp/src/IceUtil/ConvertUTF.* cpp/msbuild/* csharp/* java/* js/* packaging/rpm/* packaging/windows-installer/*
 
 Files: *
 Copyright: 2003-2026 ZeroC, Inc.
@@ -13,11 +14,33 @@ Copyright: 2003-2026 ZeroC, Inc.
            2016 Ondřej Surý
 License: GPL-2.0+exceptions
 
-Files: java/src/IceGridGUI/src/main/java/IceGridGUI/SimpleInternalFrame.java
-Copyright: 2000-2005 JGoodies Karsten Lentzsch.
-License: BSD-3-clause
+Files: cpp/src/*/Grammar.cpp cpp/src/*/Grammar.h
+Copyright: 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation, Inc.
+License: GPL-3+-with-Bison-2.2-exception
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public License
+ version 3 can be found in "/usr/share/common-licenses/GPL-3".
+ .
+ As a special exception, you may create a larger work that contains
+ part or all of the Bison parser skeleton and distribute that work
+ under terms of your choice, so long as that work isn't itself a
+ parser generator using the skeleton or a modified version thereof
+ as a parser skeleton.  Alternatively, if you modify or redistribute
+ the parser skeleton itself, you may (at your option) remove this
+ special exception, which will cause the skeleton and the resulting
+ Bison output files to be licensed under the GNU General Public
+ License without this special exception.
 
-Files: cpp/test/IceUtil/unicode/*.utf*
+Files: cpp/test/IceUtil/unicode/*
 Copyright: Authors of cœur page on Wikipedia.fr as of May 25, 2016.
 License: CC-BY-SA-3.0
 
@@ -36,17 +59,6 @@ License: GPL-2.0+exceptions
  .
  On Debian systems, the complete text of the GNU General Public
  License version 2 can be found in "/usr/share/common-licenses/GPL-2".
- .
- Linking Ice statically or dynamically with other software (such as a
- library, module or application) is making a combined work based on Ice.
- Thus, the terms and conditions of the GNU General Public License version
- 2 cover this combined work.
- .
- If such software can only be used together with Ice, then not only the
- combined work but the software itself is a work derived from Ice and as
- such shall be licensed under the terms of the GNU General Public License
- version 2. This includes the situation where Ice is only being used
- through an abstraction layer.
  .
  As a special exception to the above, ZeroC grants to the copyright
  holders and contributors of the Mumble project (http://www.mumble.info)
@@ -71,34 +83,6 @@ License: GPL-2.0+exceptions
  If you modify this copy of Ice, you may extend any of the exceptions
  provided above to your version of Ice, but you are not obligated to
  so
-
-License: BSD-3-clause
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
- .
- 1. Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
- .
- 2. Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in
-    the documentation and/or other materials provided with the
-    distribution.
- .
- 3. Neither the name of the copyright holder nor the names of its
-    contributors may be used to endorse or promote products derived
-    from this software without specific prior written permission.
- .
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
- CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
- OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 License: CC-BY-SA-3.0
  CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL

--- a/packaging/deb/debian/gbp.conf
+++ b/packaging/deb/debian/gbp.conf
@@ -1,4 +1,0 @@
-[DEFAULT]
-debian-branch = main
-upstream-branch = upstream
-pristine-tar = True

--- a/packaging/deb/debian/libzeroc-ice-dev.lintian-overrides
+++ b/packaging/deb/debian/libzeroc-ice-dev.lintian-overrides
@@ -1,2 +1,2 @@
 # slice2cpp is statically linked with mcpp
-libzeroc-ice-dev: statically-linked-binary usr/bin/slice2cpp
+libzeroc-ice-dev: statically-linked-binary

--- a/packaging/deb/debian/libzeroc-ice3.8.lintian-overrides
+++ b/packaging/deb/debian/libzeroc-ice3.8.lintian-overrides
@@ -1,2 +1,2 @@
 # Package bundles multiple Ice libraries with different sonames
-libzeroc-ice3.8: package-name-doesnt-match-sonames libDataStorm3.8 libGlacier23.8 libIce3.8 libIceBT3.8 libIceBox3.8 libIceDiscovery3.8 libIceGrid3.8 libIceLocatorDiscovery3.8 libIceStorm3.8
+libzeroc-ice3.8: package-name-doesnt-match-sonames

--- a/packaging/deb/debian/php-zeroc-ice.lintian-overrides
+++ b/packaging/deb/debian/php-zeroc-ice.lintian-overrides
@@ -1,2 +1,2 @@
 # PHP extension module is statically linked with mcpp
-php-zeroc-ice: statically-linked-binary usr/lib/php/*/ice.so
+php-zeroc-ice: statically-linked-binary

--- a/packaging/deb/debian/python3-zeroc-ice.lintian-overrides
+++ b/packaging/deb/debian/python3-zeroc-ice.lintian-overrides
@@ -1,2 +1,2 @@
 # Python extension modules are statically linked with mcpp
-python3-zeroc-ice: statically-linked-binary usr/lib/python3/dist-packages/IcePy.*.so
+python3-zeroc-ice: statically-linked-binary

--- a/packaging/deb/debian/rules
+++ b/packaging/deb/debian/rules
@@ -39,7 +39,7 @@ endif
 
 DHARGS	= --parallel --with php
 
-ifeq (,$(filter no-python312,$(DEB_BUILD_PROFILES)))
+ifeq (,$(filter nopython,$(DEB_BUILD_PROFILES)))
 	DHARGS += --with python3
 endif
 
@@ -50,7 +50,7 @@ MAKEOPTS = V=1 prefix=/usr DESTDIR=$(DESTDIR)
 
 override_dh_auto_build-arch:
 	$(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) LANGUAGES="cpp" CONFIGS="shared static" srcs
-ifeq (,$(filter no-python312,$(DEB_BUILD_PROFILES)))
+ifeq (,$(filter nopython,$(DEB_BUILD_PROFILES)))
 	$(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) PYTHON=python3 LANGUAGES="python" srcs
 endif
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
@@ -66,7 +66,7 @@ override_dh_auto_build-indep:
 
 override_dh_auto_install-arch:
 	$(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) LANGUAGES="cpp" CONFIGS="shared static" install
-ifeq (,$(filter no-python312,$(DEB_BUILD_PROFILES)))
+ifeq (,$(filter nopython,$(DEB_BUILD_PROFILES)))
 	$(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) PYTHON=python3 LANGUAGES="python" install
 endif
 	for v in $(PHP_VERSIONS); do \
@@ -78,7 +78,7 @@ override_dh_auto_install-indep:
 
 override_dh_auto_clean-arch:
 	$(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) LANGUAGES="cpp" CONFIGS="shared static" distclean
-ifeq (,$(filter no-python312,$(DEB_BUILD_PROFILES)))
+ifeq (,$(filter nopython,$(DEB_BUILD_PROFILES)))
 	$(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) PYTHON=python3 LANGUAGES="python" distclean
 endif
 	for v in $(PHP_VERSIONS); do \
@@ -113,10 +113,10 @@ override_dh_install:
 	install -m 0644 packaging/common/icegridregistry.conf $(DESTDIR)/etc/icegridregistry.conf
 
 	# Install service files from common directory
-	install -d -m 0755 $(DESTDIR)/lib/systemd/system
-	install -m 0644 packaging/common/glacier2router.service $(DESTDIR)/lib/systemd/system/glacier2router.service
-	install -m 0644 packaging/common/icegridnode.service $(DESTDIR)/lib/systemd/system/icegridnode.service
-	install -m 0644 packaging/common/icegridregistry.service $(DESTDIR)/lib/systemd/system/icegridregistry.service
+	install -d -m 0755 $(DESTDIR)/usr/lib/systemd/system
+	install -m 0644 packaging/common/glacier2router.service $(DESTDIR)/usr/lib/systemd/system/glacier2router.service
+	install -m 0644 packaging/common/icegridnode.service $(DESTDIR)/usr/lib/systemd/system/icegridnode.service
+	install -m 0644 packaging/common/icegridregistry.service $(DESTDIR)/usr/lib/systemd/system/icegridregistry.service
 
 	dh_install
 

--- a/packaging/deb/debian/watch
+++ b/packaging/deb/debian/watch
@@ -1,3 +1,0 @@
-version=4
-opts="dversionmangle=s/\+dfsg\d*$// ,repacksuffix=+dfsg1"
-https://github.com/zeroc-ice/ice/tags /zeroc-ice/ice/archive/refs/tags/v([0-9]+)\.([0-9]+)\.([0-9]+)\.tar\.gz

--- a/packaging/deb/debian/zeroc-glacier2.install
+++ b/packaging/deb/debian/zeroc-glacier2.install
@@ -1,4 +1,4 @@
 etc/glacier2router.conf
-lib/systemd/system/glacier2router.service
+usr/lib/systemd/system/glacier2router.service
 usr/bin/glacier2router
 usr/share/man/man1/glacier2router.1

--- a/packaging/deb/debian/zeroc-icegrid.install
+++ b/packaging/deb/debian/zeroc-icegrid.install
@@ -1,7 +1,7 @@
 etc/icegridnode.conf
 etc/icegridregistry.conf
-lib/systemd/system/icegridnode.service
-lib/systemd/system/icegridregistry.service
+usr/lib/systemd/system/icegridnode.service
+usr/lib/systemd/system/icegridregistry.service
 usr/bin/icegridnode
 usr/bin/icegridregistry
 usr/share/ice/templates.xml

--- a/packaging/deb/debian/zeroc-icestorm.lintian-overrides
+++ b/packaging/deb/debian/zeroc-icestorm.lintian-overrides
@@ -1,2 +1,2 @@
 # Package contains multiple libraries with different sonames
-zeroc-icestorm: package-name-doesnt-match-sonames libIceStormService3.8
+zeroc-icestorm: package-name-doesnt-match-sonames


### PR DESCRIPTION
This PR back-ports the latest Debian packages fixes from main, replaces #5271

- Install systemd services to /usr/lib/systemd/system/ (aliased-location)
- Fix mismatched lintian overrides by removing specific context
- Remove obsolete syslog.target from systemd service files
- Update debian/copyright with missing third-party attributions
- Exclude packaging/rpm/, java/, csharp/, js/, and Windows files from the Debian orig tarball
- Add Priority, Rules-Requires-Root, remove redundant Section fields
- Drop debian/watch and debian/gbp.conf

Hopefully with this fixes we will get 3.8.2 into debian official repository.