### PR TITLE
Avoid thread-pool hop when SSL read/write completes synchronously

### DIFF
--- a/csharp/src/Ice/SSL/TransceiverI.cs
+++ b/csharp/src/Ice/SSL/TransceiverI.cs
@@ -111,6 +111,10 @@ internal sealed class TransceiverI : Ice.Internal.Transceiver
         try
         {
             _readResult = _sslStream.ReadAsync(buf.b.rawBytes(), buf.b.position(), buf.b.remaining());
+            if (_readResult.IsCompletedSuccessfully)
+            {
+                return true;
+            }
             _readResult.ContinueWith(
                 task => callback(state),
                 TaskScheduler.Default);
@@ -214,8 +218,12 @@ internal sealed class TransceiverI : Ice.Internal.Transceiver
         try
         {
             _writeResult = _sslStream.WriteAsync(buf.b.rawBytes(), buf.b.position(), buf.b.remaining());
-            _writeResult.ContinueWith(task => cb(state), TaskScheduler.Default);
             messageWritten = true;
+            if (_writeResult.IsCompletedSuccessfully)
+            {
+                return true;
+            }
+            _writeResult.ContinueWith(task => cb(state), TaskScheduler.Default);
             return false;
         }
         catch (IOException ex)
@@ -427,6 +435,10 @@ internal sealed class TransceiverI : Ice.Internal.Transceiver
             catch (AggregateException ex)
             {
                 throw ex.InnerException;
+            }
+            finally
+            {
+                _writeResult = null;
             }
         }
         catch (IOException ex)


### PR DESCRIPTION
Picks up the small, self-contained patch from https://github.com/zeroc-ice/ice/issues/5316#issuecomment-4433468645. The parent issue was closed as not-planned because the larger TLS regression lives elsewhere, but this slice is worth landing on its own:

- In `startRead` / `startWrite`, invoke the callback inline when `SslStream.ReadAsync` / `WriteAsync` completes synchronously, skipping the `ContinueWith(..., TaskScheduler.Default)` thread-pool hop.
- In `finishAuthenticate`, null `_writeResult` after `Wait()` so any future defensive check doesn't see a stale handshake task.