### PR TITLE
Skip Task.Run hop in ConnectionI.startAsync when not needed

### DIFF
--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -593,6 +593,19 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
             return false;
         }
 
+        if (_threadHopRequired)
+        {
+            // Run the I/O on a .NET ThreadPool thread so it survives the initiating Ice worker exiting.
+            // See ctor for when this is required.
+            Task.Run(doIO);
+        }
+        else
+        {
+            doIO();
+        }
+
+        return true;
+
         void doIO()
         {
             lock (_mutex)
@@ -653,19 +666,6 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                 }
             }
         }
-
-        if (_threadHopRequired)
-        {
-            // Run the I/O on a .NET ThreadPool thread so it survives the initiating Ice worker exiting.
-            // See ctor for when this is required.
-            Task.Run(doIO);
-        }
-        else
-        {
-            doIO();
-        }
-
-        return true;
     }
 
     public override bool finishAsync(int operation)
@@ -1433,7 +1433,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
             // SizeMax > 1, so in that combination we hop the I/O onto the .NET ThreadPool (whose threads are managed
             // by the runtime and not reaped while owning pending I/O). Other platforms and fixed-size Ice pools don't
             // need the hop. See startAsync.
-            _threadHopRequired = _isWindows && _threadPool.canShrink;
+            _threadHopRequired = AssemblyUtil.isWindows && _threadPool.canShrink;
             _threadPool.initialize(this);
         }
         catch (LocalException)
@@ -2855,10 +2855,6 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
         internal bool invokeSent;
         internal bool receivedReply;
     }
-
-    private static readonly bool _isWindows =
-        System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
-            System.Runtime.InteropServices.OSPlatform.Windows);
 
     private static readonly ConnectionState[] connectionStateMap = [
         ConnectionState.ConnectionStateValidating,   // StateNotInitialized

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -593,10 +593,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
             return false;
         }
 
-        // Run the IO operation on a .NET thread pool thread to ensure the IO operation won't be interrupted if the
-        // Ice thread pool thread is terminated (.NET Socket read/write fail with a SocketError.OperationAborted
-        // error if started from a thread which is later terminated).
-        Task.Run(() =>
+        void doIO()
         {
             lock (_mutex)
             {
@@ -655,7 +652,18 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                     completedCallback(this);
                 }
             }
-        });
+        }
+
+        if (_threadHopRequired)
+        {
+            // Run the I/O on a .NET ThreadPool thread so it survives the initiating Ice worker exiting.
+            // See ctor for when this is required.
+            Task.Run(doIO);
+        }
+        else
+        {
+            doIO();
+        }
 
         return true;
     }
@@ -1420,6 +1428,12 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                 // object adapter with its own thread pool.
                 _threadPool = instance.clientThreadPool();
             }
+            // On Windows, async socket I/O initiated on a thread that subsequently terminates is cancelled by the OS
+            // with SocketError.OperationAborted. The Ice thread pool can reap workers idle past ThreadIdleTime when
+            // SizeMax > 1, so in that combination we hop the I/O onto the .NET ThreadPool (whose threads are managed
+            // by the runtime and not reaped while owning pending I/O). Other platforms and fixed-size Ice pools don't
+            // need the hop. See startAsync.
+            _threadHopRequired = _isWindows && _threadPool.canShrink;
             _threadPool.initialize(this);
         }
         catch (LocalException)
@@ -2842,6 +2856,10 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
         internal bool receivedReply;
     }
 
+    private static readonly bool _isWindows =
+        System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+            System.Runtime.InteropServices.OSPlatform.Windows);
+
     private static readonly ConnectionState[] connectionStateMap = [
         ConnectionState.ConnectionStateValidating,   // StateNotInitialized
         ConnectionState.ConnectionStateValidating,   // StateNotValidated
@@ -2867,6 +2885,7 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
     private readonly Logger _logger;
     private readonly TraceLevels _traceLevels;
     private readonly Ice.Internal.ThreadPool _threadPool;
+    private readonly bool _threadHopRequired;
 
     private readonly TimeSpan _connectTimeout;
     private readonly TimeSpan _closeTimeout;

--- a/csharp/src/Ice/Internal/ThreadPool.cs
+++ b/csharp/src/Ice/Internal/ThreadPool.cs
@@ -360,6 +360,12 @@ public sealed class ThreadPool : System.Threading.Tasks.TaskScheduler
 
     public bool serialize() => _serialize;
 
+    // A worker thread can exit only when both conditions hold: the thread idle time is finite (so an idle worker
+    // can time out), and the pool can have more than one worker (so a worker is eligible to be reaped without
+    // dropping the pool below its floor of 1). Used by ConnectionI.startAsync to decide whether async I/O initiated
+    // on an Ice worker thread needs to be hopped onto a .NET ThreadPool thread to survive the worker's exit.
+    public bool canShrink => _threadIdleTime != Timeout.InfiniteTimeSpan && _sizeMax > 1;
+
     protected sealed override void QueueTask(
         System.Threading.Tasks.Task task) => execute(
             () => TryExecuteTask(task),


### PR DESCRIPTION
Follow-up to https://github.com/zeroc-ice/ice/issues/5316 and #5329. Captures the TLS-path latency win that issue closed without addressing.

## Background

`ConnectionI.startAsync` currently wraps every I/O dispatch in `Task.Run`, hopping the call onto a .NET ThreadPool thread. The wrap was added in #2360 (\"Back pressure fix from 3.7\") to defend against a real Windows-specific failure: async socket I/O is initiated on a thread and the OS implicitly cancels it with `SocketError.OperationAborted` if that thread later terminates. Ice ThreadPool workers can be reaped when idle past `Ice.ThreadPool.*.ThreadIdleTime`, so an Ice worker that dispatches I/O and then sits idle long enough can have its in-flight I/O killed.

## Observation

The defense is only required when **both** of these hold:

1. **Windows.** On Linux and macOS, .NET's async socket I/O uses `epoll` / `kqueue` with a dedicated `SocketAsyncEngine` thread that owns the readiness loop; the initiating thread's lifetime is irrelevant.
2. **The Ice thread pool can shrink.** Worker reaping requires `_threadIdleTime != Timeout.InfiniteTimeSpan` AND `_sizeMax > 1` (the shrink check is `_inUse < _threads.Count - 1`, which is unreachable when the floor of 1 worker is also the ceiling).

Both inputs are known at `ConnectionI` construction time. The default Ice thread pool (`Size = 1`, `SizeMax = Size = 1`) can never shrink, so default-config users on every platform have been paying the hop for nothing. Non-Windows users with multi-threaded pools pay it for nothing too.

## Change

- Expose `bool canShrink` on `ThreadPool` (`_threadIdleTime != Timeout.InfiniteTimeSpan && _sizeMax > 1`).
- In `ConnectionI`, cache `_threadHopRequired = _isWindows && _threadPool.canShrink` at construction.
- Refactor `startAsync` to hold its body in a local function, then dispatch via `Task.Run` only when `_threadHopRequired`; otherwise invoke inline. The local function is non-escaping on the inline path, so no closure allocation.

## Behavior matrix

| Platform | Pool config | Before | After |
|---|---|---|---|
| Windows | default (`SizeMax=1`) | `Task.Run` hop | inline |
| Windows | `SizeMax>1` | `Task.Run` hop | `Task.Run` hop (unchanged) |
| Linux/macOS | default | `Task.Run` hop | inline |
| Linux/macOS | `SizeMax>1` | `Task.Run` hop | inline |

## Test plan

- [ ] CI green on all platforms.
- [ ] `Ice/ami` test on Linux/macOS (default + multi-threaded pool).
- [ ] `Ice/ami` test on Windows with `Ice.ThreadPool.Client.SizeMax=4` (exercises the preserved `Task.Run` path).
- [ ] TLS `PingLatency` benchmark to confirm the ~22 µs recovery on default Linux/macOS.