### PR TITLE
Fix Debian file conflict and binary-indep FTBFS

### DIFF
--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,14 @@
+zeroc-ice (3.8.1-2) unstable; urgency=medium
+
+  * Add Breaks/Replaces on zeroc-ice-compilers (<< 3.8) to libzeroc-ice-dev,
+    php-zeroc-ice, and python3-zeroc-ice to fix undeclared file conflict
+    (Closes: #1136630)
+  * Fix FTBFS for binary-indep builds: install Slice files in
+    override_dh_auto_install-indep so zeroc-ice-slice can be built
+    independently of arch-dependent packages
+
+ -- José Gutiérrez de la Concha <jose@zeroc.com>  Thu, 14 May 2026 12:00:00 +0200
+
 zeroc-ice (3.8.1-1) unstable; urgency=medium
 
   * New upstream version 3.8.1

--- a/packaging/deb/debian/control
+++ b/packaging/deb/debian/control
@@ -39,6 +39,8 @@ Depends: libzeroc-ice3.8 (= ${binary:Version}),
          zeroc-ice-slice (= ${source:Version}),
          libssl-dev,
          ${misc:Depends}
+Breaks: zeroc-ice-compilers (<< 3.8)
+Replaces: zeroc-ice-compilers (<< 3.8)
 Description: libraries and headers for developing Ice applications in C++
  This package contains the libraries and headers needed for developing
  Ice applications in C++.
@@ -95,6 +97,8 @@ Depends: libzeroc-ice3.8 (= ${binary:Version}),
          ${php:Depends},
          ${shlibs:Depends}
 Provides: ${php:Provides}
+Breaks: zeroc-ice-compilers (<< 3.8)
+Replaces: zeroc-ice-compilers (<< 3.8)
 Description: PHP extension for Ice
  This package contains a PHP extension for communicating with Ice.
  .
@@ -112,6 +116,8 @@ Depends: libzeroc-ice3.8 (= ${binary:Version}),
          ${misc:Depends},
          ${python3:Depends},
          ${shlibs:Depends}
+Breaks: zeroc-ice-compilers (<< 3.8)
+Replaces: zeroc-ice-compilers (<< 3.8)
 Description: Python 3 extension for Ice
  This package contains a Python 3 extension for communication with Ice.
  .

--- a/packaging/deb/debian/rules
+++ b/packaging/deb/debian/rules
@@ -74,7 +74,7 @@ endif
 	done
 
 override_dh_auto_install-indep:
-	# No installation needed for Arch: all packages
+	$(MAKE) $(MAKEOPTS) install-slice
 
 override_dh_auto_clean-arch:
 	$(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) LANGUAGES="cpp" CONFIGS="shared static" distclean


### PR DESCRIPTION
This PRs brings a few fixes from 3.8.1-2 which I have uploaded to Debian

https://tracker.debian.org/news/1752313/accepted-zeroc-ice-381-2-source-into-unstable/
With the fix for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1136630