### PR TITLE
Fix integer overflow in readAndCheckSeqSize sequence-size guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ These are the changes since the [Ice 3.8.1] release.
   is now performed using 64-bit integers. This affects the C++, C#, Java, and Swift mappings, as well
   as the Python, Ruby, and PHP mappings, which build on the C++ core.
 
+- Fixed `InputStream.readSize` in the Swift mapping to reject a negative size, consistent with the
+  other mappings. A peer could otherwise send a negative size and crash the receiver.
+
 ### Slice Language Changes
 
 - Added the `["oneway"]` metadata directive for Slice operations. This directive can only be applied to operations that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,14 +23,9 @@ These are the changes since the [Ice 3.8.1] release.
 
 - Fixed an unbounded memory allocation when unmarshaling a proxy with a large endpoint count.
 
-- Fixed an integer overflow in the sequence-size validation performed while unmarshaling. A peer
-  could send a message with an oversized sequence size whose `size * minWireSize` product overflowed
-  a 32-bit integer, defeating the bounds check that guards sequence unmarshaling. The size arithmetic
-  is now performed using 64-bit integers. This affects the C++, C#, Java, and Swift mappings, as well
-  as the Python, Ruby, and PHP mappings, which build on the C++ core.
+- Fixed an integer overflow in the sequence-size validation performed while unmarshaling.
 
-- Fixed `InputStream.readSize` in the Swift mapping to reject a negative size, consistent with the
-  other mappings. A peer could otherwise send a negative size and crash the receiver.
+- Fixed `InputStream.readSize` in the Swift mapping to reject a negative size.
 
 ### Slice Language Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ These are the changes since the [Ice 3.8.1] release.
 
 - Fixed an unbounded memory allocation when unmarshaling a proxy with a large endpoint count.
 
+- Fixed an integer overflow in the sequence-size validation performed while unmarshaling. A peer
+  could send a message with an oversized sequence size whose `size * minWireSize` product overflowed
+  a 32-bit integer, defeating the bounds check that guards sequence unmarshaling. The size arithmetic
+  is now performed using 64-bit integers. This affects the C++, C#, Java, and Swift mappings, as well
+  as the Python, Ruby, and PHP mappings, which build on the C++ core.
+
 ### Slice Language Changes
 
 - Added the `["oneway"]` metadata directive for Slice operations. This directive can only be applied to operations that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ might need to be aware of.
   - [Slice Language Changes](#slice-language-changes)
   - [C++ Changes](#c-changes)
   - [C# Changes](#c-changes-1)
+  - [Swift Changes](#swift-changes)
 
 ## Changes in Ice 3.9.0
 
@@ -24,8 +25,6 @@ These are the changes since the [Ice 3.8.1] release.
 - Fixed an unbounded memory allocation when unmarshaling a proxy with a large endpoint count.
 
 - Fixed an integer overflow in the sequence-size validation performed while unmarshaling.
-
-- Fixed `InputStream.readSize` in the Swift mapping to reject a negative size.
 
 ### Slice Language Changes
 
@@ -42,5 +41,9 @@ These are the changes since the [Ice 3.8.1] release.
 
 - Changed the mapping of `@p [NAME]` tags which reference out parameters in Slice.
   These now generate `<c>[NAME]</c>` instead of `<paramref name="[NAME]" />`.
+
+### Swift Changes
+
+- Fixed `InputStream.readSize` to reject a negative size.
 
 [Ice 3.8.1]: https://github.com/zeroc-ice/ice/blob/3.8/CHANGELOG-3.8.md

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -929,8 +929,10 @@ namespace Ice
 
         void* _closure{nullptr};
 
-        int _startSeq{-1};
-        int _minSeqSize{0};
+        // The sequence-size bookkeeping is kept in 64-bit so that 'size * minWireSize' arithmetic
+        // cannot overflow and defeat the bounds check in readAndCheckSeqSize.
+        std::int64_t _startSeq{-1};
+        std::int64_t _minSeqSize{0};
 
         const SliceLoaderPtr _sliceLoader; // never null
 

--- a/cpp/include/Ice/InputStream.h
+++ b/cpp/include/Ice/InputStream.h
@@ -929,10 +929,8 @@ namespace Ice
 
         void* _closure{nullptr};
 
-        // The sequence-size bookkeeping is kept in 64-bit so that 'size * minWireSize' arithmetic
-        // cannot overflow and defeat the bounds check in readAndCheckSeqSize.
-        std::int64_t _startSeq{-1};
-        std::int64_t _minSeqSize{0};
+        int _startSeq{-1};
+        int _minSeqSize{0};
 
         const SliceLoaderPtr _sliceLoader; // never null
 

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -428,16 +428,16 @@ Ice::InputStream::readAndCheckSeqSize(int minSize)
     // the estimated remaining buffer size. This estimation is based on
     // the minimum size of the enclosing sequences, it's _minSeqSize.
     //
-    // The size arithmetic below is performed in 64-bit: 'sz' is peer-controlled (up to INT32_MAX)
-    // and 'sz * minSize' would otherwise overflow a 32-bit int and bypass the bounds check.
-    if (_startSeq == -1 || (i - b.begin()) > _startSeq + _minSeqSize)
+    // 'sz' is peer-controlled (up to INT32_MAX), so we compute the minimum size of this sequence in
+    // 64-bit: 'sz * minSize' would otherwise overflow a 32-bit int and bypass the bounds check below.
+    int64_t minSeqSize = static_cast<int64_t>(sz) * minSize;
+    if (_startSeq == -1 || i > (b.begin() + _startSeq + _minSeqSize))
     {
-        _startSeq = static_cast<int64_t>(i - b.begin());
-        _minSeqSize = static_cast<int64_t>(sz) * minSize;
+        _startSeq = static_cast<int>(i - b.begin());
     }
     else
     {
-        _minSeqSize += static_cast<int64_t>(sz) * minSize;
+        minSeqSize += _minSeqSize;
     }
 
     //
@@ -445,16 +445,13 @@ Ice::InputStream::readAndCheckSeqSize(int minSize)
     // possibly enclosed sequences), something is wrong with the marshaled
     // data: it's claiming having more data that what is possible to read.
     //
-    // We also reject any sequence whose minimum size exceeds INT32_MAX. The Ice
-    // protocol encodes a message size as a 32-bit integer, so no sequence can
-    // legitimately require more; this also keeps 'sz * minSize' within a 32-bit
-    // int for the callers that use the returned size to advance the stream.
-    //
-    if (_startSeq + _minSeqSize > static_cast<int64_t>(b.size()) || _minSeqSize > INT32_MAX)
+    if (_startSeq + minSeqSize > static_cast<int64_t>(b.size()))
     {
         throwUnmarshalOutOfBoundsException(__FILE__, __LINE__);
     }
 
+    // minSeqSize is now known to be <= b.size(), itself smaller than INT32_MAX.
+    _minSeqSize = static_cast<int>(minSeqSize);
     return sz;
 }
 

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -431,7 +431,10 @@ Ice::InputStream::readAndCheckSeqSize(int minSize)
     // 'sz' is peer-controlled (up to INT32_MAX), so we compute the minimum size of this sequence in
     // 64-bit: 'sz * minSize' would otherwise overflow a 32-bit int and bypass the bounds check below.
     int64_t minSeqSize = static_cast<int64_t>(sz) * minSize;
-    if (_startSeq == -1 || i > (b.begin() + _startSeq + _minSeqSize))
+
+    // '_startSeq + _minSeqSize' does not overflow: on the previous call, the bounds check below
+    // established this sum is <= b.size(), itself smaller than INT32_MAX.
+    if (_startSeq == -1 || (i - b.begin()) > _startSeq + _minSeqSize)
     {
         _startSeq = static_cast<int>(i - b.begin());
     }

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -428,14 +428,16 @@ Ice::InputStream::readAndCheckSeqSize(int minSize)
     // the estimated remaining buffer size. This estimation is based on
     // the minimum size of the enclosing sequences, it's _minSeqSize.
     //
-    if (_startSeq == -1 || i > (b.begin() + _startSeq + _minSeqSize))
+    // The size arithmetic below is performed in 64-bit: 'sz' is peer-controlled (up to INT32_MAX)
+    // and 'sz * minSize' would otherwise overflow a 32-bit int and bypass the bounds check.
+    if (_startSeq == -1 || (i - b.begin()) > _startSeq + _minSeqSize)
     {
-        _startSeq = static_cast<int>(i - b.begin());
-        _minSeqSize = sz * minSize;
+        _startSeq = static_cast<int64_t>(i - b.begin());
+        _minSeqSize = static_cast<int64_t>(sz) * minSize;
     }
     else
     {
-        _minSeqSize += sz * minSize;
+        _minSeqSize += static_cast<int64_t>(sz) * minSize;
     }
 
     //
@@ -443,7 +445,12 @@ Ice::InputStream::readAndCheckSeqSize(int minSize)
     // possibly enclosed sequences), something is wrong with the marshaled
     // data: it's claiming having more data that what is possible to read.
     //
-    if (_startSeq + _minSeqSize > static_cast<int>(b.size()))
+    // We also reject any sequence whose minimum size exceeds INT32_MAX. The Ice
+    // protocol encodes a message size as a 32-bit integer, so no sequence can
+    // legitimately require more; this also keeps 'sz * minSize' within a 32-bit
+    // int for the callers that use the returned size to advance the stream.
+    //
+    if (_startSeq + _minSeqSize > static_cast<int64_t>(b.size()) || _minSeqSize > INT32_MAX)
     {
         throwUnmarshalOutOfBoundsException(__FILE__, __LINE__);
     }

--- a/cpp/test/Ice/stream/Client.cpp
+++ b/cpp/test/Ice/stream/Client.cpp
@@ -1079,6 +1079,26 @@ allTests(Test::TestHelper* helper, const CustomSliceLoaderPtr& customSliceLoader
     }
 
     cout << "ok" << endl;
+
+    cout << "testing sequence size validation... " << flush;
+    {
+        // A peer-supplied sequence size must be validated so that 'size * minWireSize' cannot overflow
+        // a 32-bit int and defeat the bounds check in readAndCheckSeqSize.
+        Ice::OutputStream out(communicator);
+        out.writeSize(0x10000000); // 268435456; * 8 (the min wire size of a long) overflows a 32-bit int.
+        out.finished(data);
+
+        Ice::InputStream in(communicator, data);
+        try
+        {
+            in.readAndCheckSeqSize(8); // 8 is the min wire size of a sequence<long> element.
+            test(false);
+        }
+        catch (const Ice::MarshalException&)
+        {
+        }
+    }
+    cout << "ok" << endl;
 }
 
 class Client : public Test::TestHelper

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -118,7 +118,7 @@ public sealed class InputStream
         other._startSeq = _startSeq;
         _startSeq = tmpStartSeq;
 
-        long tmpMinSeqSize = other._minSeqSize;
+        int tmpMinSeqSize = other._minSeqSize;
         other._minSeqSize = _minSeqSize;
         _minSeqSize = tmpMinSeqSize;
 
@@ -491,17 +491,17 @@ public sealed class InputStream
         // the estimated remaining buffer size. This estimation is based on
         // the minimum size of the enclosing sequences, it's _minSeqSize.
         //
-        // The size arithmetic below is performed in 64-bit: 'sz' is peer-controlled (up to
-        // int.MaxValue) and 'sz * minSize' would otherwise overflow a 32-bit int and bypass the
-        // bounds check.
+        // 'sz' is peer-controlled (up to int.MaxValue), so we compute the minimum size of this
+        // sequence in 64-bit: 'sz * minSize' would overflow a 32-bit int and bypass the bounds check.
+        //
+        long minSeqSize = (long)sz * minSize;
         if (_startSeq == -1 || _buf.b.position() > (_startSeq + _minSeqSize))
         {
             _startSeq = _buf.b.position();
-            _minSeqSize = (long)sz * minSize;
         }
         else
         {
-            _minSeqSize += (long)sz * minSize;
+            minSeqSize += _minSeqSize;
         }
 
         //
@@ -509,15 +509,13 @@ public sealed class InputStream
         // possibly enclosed sequences), something is wrong with the marshaled
         // data: it's claiming having more data that what is possible to read.
         //
-        // We also reject any sequence whose minimum size exceeds int.MaxValue: the
-        // Ice protocol encodes a message size as a 32-bit integer, so no sequence
-        // can legitimately require more.
-        //
-        if (_startSeq + _minSeqSize > _buf.size() || _minSeqSize > int.MaxValue)
+        if (_startSeq + minSeqSize > _buf.size())
         {
             throw new MarshalException(endOfBufferMessage);
         }
 
+        // minSeqSize is now known to be <= _buf.size(), itself smaller than int.MaxValue.
+        _minSeqSize = (int)minSeqSize;
         return sz;
     }
 
@@ -3010,10 +3008,7 @@ public sealed class InputStream
     private readonly int _classGraphDepthMax;
 
     private int _startSeq = -1;
-
-    // Kept in 64-bit so that 'size * minWireSize' arithmetic cannot overflow and defeat the bounds
-    // check in readAndCheckSeqSize.
-    private long _minSeqSize;
+    private int _minSeqSize;
 
     private const string endOfBufferMessage = "Attempting to unmarshal past the end of the buffer.";
 }

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -118,7 +118,7 @@ public sealed class InputStream
         other._startSeq = _startSeq;
         _startSeq = tmpStartSeq;
 
-        int tmpMinSeqSize = other._minSeqSize;
+        long tmpMinSeqSize = other._minSeqSize;
         other._minSeqSize = _minSeqSize;
         _minSeqSize = tmpMinSeqSize;
 
@@ -491,14 +491,17 @@ public sealed class InputStream
         // the estimated remaining buffer size. This estimation is based on
         // the minimum size of the enclosing sequences, it's _minSeqSize.
         //
+        // The size arithmetic below is performed in 64-bit: 'sz' is peer-controlled (up to
+        // int.MaxValue) and 'sz * minSize' would otherwise overflow a 32-bit int and bypass the
+        // bounds check.
         if (_startSeq == -1 || _buf.b.position() > (_startSeq + _minSeqSize))
         {
             _startSeq = _buf.b.position();
-            _minSeqSize = sz * minSize;
+            _minSeqSize = (long)sz * minSize;
         }
         else
         {
-            _minSeqSize += sz * minSize;
+            _minSeqSize += (long)sz * minSize;
         }
 
         //
@@ -506,7 +509,11 @@ public sealed class InputStream
         // possibly enclosed sequences), something is wrong with the marshaled
         // data: it's claiming having more data that what is possible to read.
         //
-        if (_startSeq + _minSeqSize > _buf.size())
+        // We also reject any sequence whose minimum size exceeds int.MaxValue: the
+        // Ice protocol encodes a message size as a 32-bit integer, so no sequence
+        // can legitimately require more.
+        //
+        if (_startSeq + _minSeqSize > _buf.size() || _minSeqSize > int.MaxValue)
         {
             throw new MarshalException(endOfBufferMessage);
         }
@@ -3003,7 +3010,10 @@ public sealed class InputStream
     private readonly int _classGraphDepthMax;
 
     private int _startSeq = -1;
-    private int _minSeqSize;
+
+    // Kept in 64-bit so that 'size * minWireSize' arithmetic cannot overflow and defeat the bounds
+    // check in readAndCheckSeqSize.
+    private long _minSeqSize;
 
     private const string endOfBufferMessage = "Attempting to unmarshal past the end of the buffer.";
 }

--- a/csharp/test/Ice/stream/AllTests.cs
+++ b/csharp/test/Ice/stream/AllTests.cs
@@ -990,6 +990,27 @@ public class AllTests : global::Test.AllTests
         }
 
         output.WriteLine("ok");
+
+        output.Write("testing sequence size validation... ");
+        output.Flush();
+        {
+            // A peer-supplied sequence size must be validated so that 'size * minWireSize' cannot
+            // overflow a 32-bit int and defeat the bounds check in readAndCheckSeqSize.
+            outS = new Ice.OutputStream(communicator);
+            outS.writeSize(0x10000000); // 268435456; * 8 (the min wire size of a long) overflows a 32-bit int.
+            byte[] data = outS.finished();
+            inS = new Ice.InputStream(communicator, data);
+            try
+            {
+                inS.readAndCheckSeqSize(8); // 8 is the min wire size of a sequence<long> element.
+                test(false);
+            }
+            catch (Ice.MarshalException)
+            {
+            }
+        }
+
+        output.WriteLine("ok");
         return 0;
     }
 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -149,7 +149,7 @@ public final class InputStream {
         other._startSeq = _startSeq;
         _startSeq = tmpStartSeq;
 
-        int tmpMinSeqSize = other._minSeqSize;
+        long tmpMinSeqSize = other._minSeqSize;
         other._minSeqSize = _minSeqSize;
         _minSeqSize = tmpMinSeqSize;
 
@@ -462,16 +462,22 @@ public final class InputStream {
         // The goal of this check is to ensure that when we start un-marshaling a new sequence, we
         // check the minimal size of this new sequence against the estimated remaining buffer size.
         // This estimation is based on the minimum size of the enclosing sequences, it's _minSeqSize.
+        //
+        // The size arithmetic below is performed in 64-bit: 'sz' is peer-controlled (up to
+        // Integer.MAX_VALUE) and 'sz * minSize' would otherwise overflow a 32-bit int and bypass
+        // the bounds check.
         if (_startSeq == -1 || _buf.b.position() > (_startSeq + _minSeqSize)) {
             _startSeq = _buf.b.position();
-            _minSeqSize = sz * minSize;
+            _minSeqSize = (long) sz * minSize;
         } else {
-            _minSeqSize += sz * minSize;
+            _minSeqSize += (long) sz * minSize;
         }
 
         // If there isn't enough data to read on the stream for the sequence (and possibly enclosed sequences),
         // something is wrong with the marshaled data: it's claiming having more data that what is possible to read.
-        if (_startSeq + _minSeqSize > _buf.size()) {
+        // We also reject any sequence whose minimum size exceeds Integer.MAX_VALUE: the Ice protocol encodes a
+        // message size as a 32-bit integer, so no sequence can legitimately require more.
+        if (_startSeq + _minSeqSize > _buf.size() || _minSeqSize > Integer.MAX_VALUE) {
             throw new MarshalException(END_OF_BUFFER_MESSAGE);
         }
 
@@ -2303,7 +2309,10 @@ public final class InputStream {
     private final int _classGraphDepthMax;
 
     private int _startSeq = -1;
-    private int _minSeqSize;
+
+    // Kept in 64-bit so that 'size * minWireSize' arithmetic cannot overflow and defeat the bounds
+    // check in readAndCheckSeqSize.
+    private long _minSeqSize;
 
     private static final String END_OF_BUFFER_MESSAGE = "Attempting to unmarshal past the end of the buffer.";
 }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -149,7 +149,7 @@ public final class InputStream {
         other._startSeq = _startSeq;
         _startSeq = tmpStartSeq;
 
-        long tmpMinSeqSize = other._minSeqSize;
+        int tmpMinSeqSize = other._minSeqSize;
         other._minSeqSize = _minSeqSize;
         _minSeqSize = tmpMinSeqSize;
 
@@ -463,24 +463,23 @@ public final class InputStream {
         // check the minimal size of this new sequence against the estimated remaining buffer size.
         // This estimation is based on the minimum size of the enclosing sequences, it's _minSeqSize.
         //
-        // The size arithmetic below is performed in 64-bit: 'sz' is peer-controlled (up to
-        // Integer.MAX_VALUE) and 'sz * minSize' would otherwise overflow a 32-bit int and bypass
-        // the bounds check.
+        // 'sz' is peer-controlled (up to Integer.MAX_VALUE), so we compute the minimum size of this
+        // sequence in 64-bit: 'sz * minSize' would overflow a 32-bit int and bypass the bounds check.
+        long minSeqSize = (long) sz * minSize;
         if (_startSeq == -1 || _buf.b.position() > (_startSeq + _minSeqSize)) {
             _startSeq = _buf.b.position();
-            _minSeqSize = (long) sz * minSize;
         } else {
-            _minSeqSize += (long) sz * minSize;
+            minSeqSize += _minSeqSize;
         }
 
         // If there isn't enough data to read on the stream for the sequence (and possibly enclosed sequences),
         // something is wrong with the marshaled data: it's claiming having more data that what is possible to read.
-        // We also reject any sequence whose minimum size exceeds Integer.MAX_VALUE: the Ice protocol encodes a
-        // message size as a 32-bit integer, so no sequence can legitimately require more.
-        if (_startSeq + _minSeqSize > _buf.size() || _minSeqSize > Integer.MAX_VALUE) {
+        if (_startSeq + minSeqSize > _buf.size()) {
             throw new MarshalException(END_OF_BUFFER_MESSAGE);
         }
 
+        // minSeqSize is now known to be <= _buf.size(), itself smaller than Integer.MAX_VALUE.
+        _minSeqSize = (int) minSeqSize;
         return sz;
     }
 
@@ -2309,10 +2308,7 @@ public final class InputStream {
     private final int _classGraphDepthMax;
 
     private int _startSeq = -1;
-
-    // Kept in 64-bit so that 'size * minWireSize' arithmetic cannot overflow and defeat the bounds
-    // check in readAndCheckSeqSize.
-    private long _minSeqSize;
+    private int _minSeqSize;
 
     private static final String END_OF_BUFFER_MESSAGE = "Attempting to unmarshal past the end of the buffer.";
 }

--- a/java/test/src/main/java/test/Ice/stream/Client.java
+++ b/java/test/src/main/java/test/Ice/stream/Client.java
@@ -703,6 +703,23 @@ public class Client extends TestHelper {
             }
 
             printWriter.println("ok");
+
+            printWriter.print("testing sequence size validation... ");
+            printWriter.flush();
+            {
+                // A peer-supplied sequence size must be validated so that 'size * minWireSize' cannot
+                // overflow a 32-bit int and defeat the bounds check in readAndCheckSeqSize.
+                out = new OutputStream(communicator);
+                out.writeSize(0x10000000); // 268435456; * 8 (the min wire size of a long) overflows a 32-bit int.
+                byte[] data = out.finished();
+                in = new InputStream(communicator, data);
+                try {
+                    in.readAndCheckSeqSize(8); // 8 is the min wire size of a sequence<long> element.
+                    test(false);
+                } catch (MarshalException ex) {}
+            }
+
+            printWriter.println("ok");
         }
     }
 }

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -16,10 +16,8 @@ public final class InputStream {
 
     private var encaps: Encaps!
 
-    // Uses Int rather than Int32 so the 'size * minWireSize' arithmetic in readAndCheckSeqSize
-    // cannot overflow a 32-bit value and defeat the bounds check.
-    private var startSeq: Int = -1
-    private var minSeqSize: Int = 0
+    private var startSeq: Int32 = -1
+    private var minSeqSize: Int32 = 0
     private let classGraphDepthMax: Int32
 
     private let endOfBufferMessage = "attempting to unmarshal past the end of the buffer"
@@ -594,11 +592,14 @@ extension InputStream {
         // the estimated remaining buffer size. This estimation is based on
         // the minimum size of the enclosing sequences, it's minSeqSize.
         //
-        if startSeq == -1 || pos > (startSeq + minSeqSize) {
-            startSeq = pos
-            minSeqSize = sz * minSize
+        // 'sz' is peer-controlled (up to Int32.max), so we compute the minimum size of this
+        // sequence in 64-bit (Int): 'sz * minSize' would overflow a 32-bit value and bypass the
+        // bounds check.
+        var newMinSeqSize = sz * minSize
+        if startSeq == -1 || pos > Int(startSeq) + Int(minSeqSize) {
+            startSeq = Int32(pos)
         } else {
-            minSeqSize += sz * minSize
+            newMinSeqSize += Int(minSeqSize)
         }
 
         //
@@ -606,10 +607,12 @@ extension InputStream {
         // possibly enclosed sequences), something is wrong with the marshaled
         // data: it's claiming having more data that what is possible to read.
         //
-        if startSeq + minSeqSize > data.count {
+        if Int(startSeq) + newMinSeqSize > data.count {
             throw MarshalException(endOfBufferMessage)
         }
 
+        // newMinSeqSize is now known to be <= data.count, itself smaller than Int32.max.
+        minSeqSize = Int32(newMinSeqSize)
         return sz
     }
 

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -16,8 +16,8 @@ public final class InputStream {
 
     private var encaps: Encaps!
 
-    // Kept as 64-bit Int so that 'size * minWireSize' arithmetic cannot overflow (and trap on the
-    // Int32 conversion) and defeat the bounds check in readAndCheckSeqSize.
+    // Uses Int rather than Int32 so the 'size * minWireSize' arithmetic in readAndCheckSeqSize
+    // cannot overflow a 32-bit value and defeat the bounds check.
     private var startSeq: Int = -1
     private var minSeqSize: Int = 0
     private let classGraphDepthMax: Int32
@@ -554,7 +554,12 @@ extension InputStream {
     public func readSize() throws -> Int32 {
         let byteVal: UInt8 = try read()
         if byteVal == 255 {
-            return try read()
+            let v: Int32 = try read()
+            // A size is a non-negative value; reject a negative one encoded in the 5-byte form.
+            if v < 0 {
+                throw MarshalException(endOfBufferMessage)
+            }
+            return v
         } else {
             return Int32(byteVal)
         }

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -16,8 +16,10 @@ public final class InputStream {
 
     private var encaps: Encaps!
 
-    private var startSeq: Int32 = -1
-    private var minSeqSize: Int32 = 0
+    // Kept as 64-bit Int so that 'size * minWireSize' arithmetic cannot overflow (and trap on the
+    // Int32 conversion) and defeat the bounds check in readAndCheckSeqSize.
+    private var startSeq: Int = -1
+    private var minSeqSize: Int = 0
     private let classGraphDepthMax: Int32
 
     private let endOfBufferMessage = "attempting to unmarshal past the end of the buffer"
@@ -587,11 +589,14 @@ extension InputStream {
         // the estimated remaining buffer size. This estimation is based on
         // the minimum size of the enclosing sequences, it's minSeqSize.
         //
+        // The size arithmetic below is performed in 64-bit: 'sz' is peer-controlled (up to
+        // Int32.max) and 'sz * minSize' would otherwise overflow when converted to Int32, trapping
+        // the process or bypassing the bounds check.
         if startSeq == -1 || pos > (startSeq + minSeqSize) {
-            startSeq = Int32(pos)
-            minSeqSize = Int32(sz * minSize)
+            startSeq = pos
+            minSeqSize = sz * minSize
         } else {
-            minSeqSize += Int32(sz * minSize)
+            minSeqSize += sz * minSize
         }
 
         //
@@ -599,7 +604,11 @@ extension InputStream {
         // possibly enclosed sequences), something is wrong with the marshaled
         // data: it's claiming having more data that what is possible to read.
         //
-        if startSeq + minSeqSize > data.count {
+        // We also reject any sequence whose minimum size exceeds Int32.max: the Ice
+        // protocol encodes a message size as a 32-bit integer, so no sequence can
+        // legitimately require more.
+        //
+        if startSeq + minSeqSize > data.count || minSeqSize > Int(Int32.max) {
             throw MarshalException(endOfBufferMessage)
         }
 

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -593,13 +593,13 @@ extension InputStream {
         // the minimum size of the enclosing sequences, it's minSeqSize.
         //
         // 'sz' is peer-controlled (up to Int32.max), so we compute the minimum size of this
-        // sequence in 64-bit (Int): 'sz * minSize' would overflow a 32-bit value and bypass the
+        // sequence as an Int64: 'sz * minSize' would overflow a 32-bit value and bypass the
         // bounds check.
-        var newMinSeqSize = sz * minSize
-        if startSeq == -1 || pos > Int(startSeq) + Int(minSeqSize) {
+        var newMinSeqSize = Int64(sz) * Int64(minSize)
+        if startSeq == -1 || pos > Int(startSeq + minSeqSize) {
             startSeq = Int32(pos)
         } else {
-            newMinSeqSize += Int(minSeqSize)
+            newMinSeqSize += Int64(minSeqSize)
         }
 
         //
@@ -607,7 +607,7 @@ extension InputStream {
         // possibly enclosed sequences), something is wrong with the marshaled
         // data: it's claiming having more data that what is possible to read.
         //
-        if Int(startSeq) + newMinSeqSize > data.count {
+        if Int64(startSeq) + newMinSeqSize > Int64(data.count) {
             throw MarshalException(endOfBufferMessage)
         }
 

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -557,7 +557,7 @@ extension InputStream {
             let v: Int32 = try read()
             // A size is a non-negative value; reject a negative one encoded in the 5-byte form.
             if v < 0 {
-                throw MarshalException(endOfBufferMessage)
+                throw MarshalException("read invalid size: \(v)")
             }
             return v
         } else {
@@ -594,9 +594,6 @@ extension InputStream {
         // the estimated remaining buffer size. This estimation is based on
         // the minimum size of the enclosing sequences, it's minSeqSize.
         //
-        // The size arithmetic below is performed in 64-bit: 'sz' is peer-controlled (up to
-        // Int32.max) and 'sz * minSize' would otherwise overflow when converted to Int32, trapping
-        // the process or bypassing the bounds check.
         if startSeq == -1 || pos > (startSeq + minSeqSize) {
             startSeq = pos
             minSeqSize = sz * minSize
@@ -609,11 +606,7 @@ extension InputStream {
         // possibly enclosed sequences), something is wrong with the marshaled
         // data: it's claiming having more data that what is possible to read.
         //
-        // We also reject any sequence whose minimum size exceeds Int32.max: the Ice
-        // protocol encodes a message size as a 32-bit integer, so no sequence can
-        // legitimately require more.
-        //
-        if startSeq + minSeqSize > data.count || minSeqSize > Int(Int32.max) {
+        if startSeq + minSeqSize > data.count {
             throw MarshalException(endOfBufferMessage)
         }
 

--- a/swift/test/Ice/stream/Client.swift
+++ b/swift/test/Ice/stream/Client.swift
@@ -570,6 +570,19 @@ public class Client: TestHelperI, @unchecked Sendable {
                 try test(false)
             } catch is Ice.MarshalException {}
         }
+        do {
+            // A negative size encoded in the 5-byte form must be rejected, not returned to a caller
+            // that would trap allocating an array with a negative count.
+            outS = Ice.OutputStream(communicator: communicator)
+            outS.write(UInt8(255))  // size marker for the 5-byte encoding
+            outS.write(Int32(-1))  // a negative 32-bit size
+            let data = outS.finished()
+            inS = Ice.InputStream(communicator: communicator, bytes: data)
+            do {
+                _ = try inS.readSize()
+                try test(false)
+            } catch is Ice.MarshalException {}
+        }
         writer.writeLine("ok")
     }
 }

--- a/swift/test/Ice/stream/Client.swift
+++ b/swift/test/Ice/stream/Client.swift
@@ -562,11 +562,11 @@ public class Client: TestHelperI, @unchecked Sendable {
             // A peer-supplied sequence size must be validated so that 'size * minWireSize' cannot
             // overflow and defeat the bounds check in readAndCheckSeqSize.
             outS = Ice.OutputStream(communicator: communicator)
-            outS.write(size: Int32(0x10000000)) // 268435456; * 8 (the min wire size of a long) overflows Int32.
+            outS.write(size: Int32(0x1000_0000))  // 268435456; * 8 (the min wire size of a long) overflows Int32.
             let data = outS.finished()
             inS = Ice.InputStream(communicator: communicator, bytes: data)
             do {
-                _ = try inS.readAndCheckSeqSize(minSize: 8) // 8 is the min wire size of a sequence<long> element.
+                _ = try inS.readAndCheckSeqSize(minSize: 8)  // 8 is the min wire size of a sequence<long> element.
                 try test(false)
             } catch is Ice.MarshalException {}
         }

--- a/swift/test/Ice/stream/Client.swift
+++ b/swift/test/Ice/stream/Client.swift
@@ -556,5 +556,20 @@ public class Client: TestHelperI, @unchecked Sendable {
             try test(dict2["key2"]!!.s.e == MyEnum.enum3)
         }
         writer.writeLine("ok")
+
+        writer.write("testing sequence size validation... ")
+        do {
+            // A peer-supplied sequence size must be validated so that 'size * minWireSize' cannot
+            // overflow and defeat the bounds check in readAndCheckSeqSize.
+            outS = Ice.OutputStream(communicator: communicator)
+            outS.write(size: Int32(0x10000000)) // 268435456; * 8 (the min wire size of a long) overflows Int32.
+            let data = outS.finished()
+            inS = Ice.InputStream(communicator: communicator, bytes: data)
+            do {
+                _ = try inS.readAndCheckSeqSize(minSize: 8) // 8 is the min wire size of a sequence<long> element.
+                try test(false)
+            } catch is Ice.MarshalException {}
+        }
+        writer.writeLine("ok")
     }
 }


### PR DESCRIPTION
readAndCheckSeqSize computed 'size * minWireSize' in 32-bit, so a large peer-supplied sequence size overflowed and bypassed the bounds check that guards sequence unmarshaling, leading to excessive allocation (and, in C++, a potential out-of-bounds read).