### PR TITLE
Enforce RFC 6455 control-frame limits in the WebSocket transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,10 @@ These are the changes since the [Ice 3.8.1] release.
 
 - Removed the 'ice2slice' compiler
 
-- Fixed the WebSocket transport to enforce RFC 6455 section 5.5 on control frames. A peer could
-  previously send a `ping`, `pong`, or `close` control frame declaring a payload of up to 2 GB,
-  which the receiver buffered before applying any size limit, leading to excessive memory
-  allocation. Control frames whose payload exceeds 125 bytes or that are fragmented are now
-  rejected with a `ProtocolException`. This affects the C++, C#, and Java mappings, as well as the
-  Python, Ruby, PHP, MATLAB, and Swift mappings, which build on the C++ core.
+- Fixed the WebSocket transport to enforce the RFC 6455 limits on control frames. A peer could previously send a
+  tiny `ping`, `pong`, or `close` frame declaring a multi-gigabyte payload that the receiver buffered before applying
+  any size limit. Control frames larger than 125 bytes or that are fragmented are now rejected with a
+  `ProtocolException`.
 
 ### Slice Language Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,7 @@ These are the changes since the [Ice 3.8.1] release.
 
 - Removed the 'ice2slice' compiler
 
-- Fixed the WebSocket transport to enforce the RFC 6455 limits on control frames. A peer could previously send a
-  tiny `ping`, `pong`, or `close` frame declaring a multi-gigabyte payload that the receiver buffered before applying
-  any size limit. Control frames larger than 125 bytes or that are fragmented are now rejected with a
-  `ProtocolException`.
+- Fixed the WebSocket transport to enforce the RFC 6455 limits on control frames.
 
 ### Slice Language Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ These are the changes since the [Ice 3.8.1] release.
 
 - Removed the 'ice2slice' compiler
 
+- Fixed the WebSocket transport to enforce RFC 6455 section 5.5 on control frames. A peer could
+  previously send a `ping`, `pong`, or `close` control frame declaring a payload of up to 2 GB,
+  which the receiver buffered before applying any size limit, leading to excessive memory
+  allocation. Control frames whose payload exceeds 125 bytes or that are fragmented are now
+  rejected with a `ProtocolException`. This affects the C++, C#, and Java mappings, as well as the
+  Python, Ruby, PHP, MATLAB, and Swift mappings, which build on the C++ core.
+
 ### Slice Language Changes
 
 - Added the `["oneway"]` metadata directive for Slice operations. This directive can only be applied to operations that

--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -1121,6 +1121,16 @@ IceInternal::WSTransceiver::preRead(Buffer& buf)
             _readOpCode = static_cast<int>(ch & byte{0xf});
 
             //
+            // No extension is negotiated, so the RSV1, RSV2 and RSV3 bits must all be 0.
+            //
+            if ((ch & byte{0x70}) != byte{0})
+            {
+                throw ProtocolException(__FILE__, __LINE__, "invalid WebSocket frame: RSV bits must be 0");
+            }
+
+            const bool finalFrame = (ch & byte{FLAG_FINAL}) == byte{FLAG_FINAL};
+
+            //
             // Remember if last frame if we're going to read a data or
             // continuation frame, this is only for protocol
             // correctness checking purpose.
@@ -1131,7 +1141,7 @@ IceInternal::WSTransceiver::preRead(Buffer& buf)
                 {
                     throw ProtocolException(__FILE__, __LINE__, "invalid data frame, no FIN on previous frame");
                 }
-                _readLastFrame = (ch & byte{FLAG_FINAL}) == byte{FLAG_FINAL};
+                _readLastFrame = finalFrame;
             }
             else if (_readOpCode == OP_CONT)
             {
@@ -1139,7 +1149,7 @@ IceInternal::WSTransceiver::preRead(Buffer& buf)
                 {
                     throw ProtocolException(__FILE__, __LINE__, "invalid continuation frame, previous frame FIN set");
                 }
-                _readLastFrame = (ch & byte{FLAG_FINAL}) == byte{FLAG_FINAL};
+                _readLastFrame = finalFrame;
             }
 
             ch = *_readI++;
@@ -1162,6 +1172,30 @@ IceInternal::WSTransceiver::preRead(Buffer& buf)
             // 127:   The subsequent eight bytes contain the payload length
             //
             _readPayloadLength = static_cast<size_t>((ch & byte{0x7f}));
+
+            //
+            // RFC 6455 section 5.5: control frames (close, ping and pong) must not be fragmented
+            // and must have a payload length of 125 bytes or less - they cannot use the 16-bit or
+            // 64-bit extended length encoding. Enforce this before allocating any payload buffer.
+            //
+            if (_readOpCode == OP_CLOSE || _readOpCode == OP_PING || _readOpCode == OP_PONG)
+            {
+                if (!finalFrame)
+                {
+                    throw ProtocolException(
+                        __FILE__,
+                        __LINE__,
+                        "invalid WebSocket control frame: the FIN bit is not set");
+                }
+                if (_readPayloadLength > 125)
+                {
+                    throw ProtocolException(
+                        __FILE__,
+                        __LINE__,
+                        "invalid WebSocket control frame: the payload length exceeds 125 bytes");
+                }
+            }
+
             if (_readPayloadLength < 126)
             {
                 _readHeaderLength = 0;

--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -1121,7 +1121,7 @@ IceInternal::WSTransceiver::preRead(Buffer& buf)
             _readOpCode = static_cast<int>(ch & byte{0xf});
 
             //
-            // No extension is negotiated, so the RSV1, RSV2 and RSV3 bits must all be 0.
+            // No extension is negotiated, so the RSV1, RSV2, and RSV3 bits must all be 0.
             //
             if ((ch & byte{0x70}) != byte{0})
             {
@@ -1174,7 +1174,7 @@ IceInternal::WSTransceiver::preRead(Buffer& buf)
             _readPayloadLength = static_cast<size_t>((ch & byte{0x7f}));
 
             //
-            // RFC 6455 section 5.5: control frames (close, ping and pong) must not be fragmented
+            // RFC 6455 section 5.5: control frames (close, ping, and pong) must not be fragmented
             // and must have a payload length of 125 bytes or less - they cannot use the 16-bit or
             // 64-bit extended length encoding. Enforce this before allocating any payload buffer.
             //

--- a/csharp/src/Ice/Internal/WSTransceiver.cs
+++ b/csharp/src/Ice/Internal/WSTransceiver.cs
@@ -964,6 +964,16 @@ internal sealed class WSTransceiver : Transceiver
                 _readOpCode = ch & 0xf;
 
                 //
+                // No extension is negotiated, so the RSV1, RSV2 and RSV3 bits must all be 0.
+                //
+                if ((ch & 0x70) != 0)
+                {
+                    throw new Ice.ProtocolException("invalid WebSocket frame: RSV bits must be 0");
+                }
+
+                bool finalFrame = (ch & FLAG_FINAL) == FLAG_FINAL;
+
+                //
                 // Remember if last frame if we're going to read a data or
                 // continuation frame, this is only for protocol
                 // correctness checking purpose.
@@ -974,7 +984,7 @@ internal sealed class WSTransceiver : Transceiver
                     {
                         throw new Ice.ProtocolException("invalid data frame, no FIN on previous frame");
                     }
-                    _readLastFrame = (ch & FLAG_FINAL) == FLAG_FINAL;
+                    _readLastFrame = finalFrame;
                 }
                 else if (_readOpCode == OP_CONT)
                 {
@@ -982,7 +992,7 @@ internal sealed class WSTransceiver : Transceiver
                     {
                         throw new Ice.ProtocolException("invalid continuation frame, previous frame FIN set");
                     }
-                    _readLastFrame = (ch & FLAG_FINAL) == FLAG_FINAL;
+                    _readLastFrame = finalFrame;
                 }
 
                 ch = _readBuffer.b.get(_readBufferPos++);
@@ -1005,6 +1015,26 @@ internal sealed class WSTransceiver : Transceiver
                 // 127:   The subsequent eight bytes contain the payload length
                 //
                 _readPayloadLength = ch & 0x7f;
+
+                //
+                // RFC 6455 section 5.5: control frames (close, ping and pong) must not be fragmented
+                // and must have a payload length of 125 bytes or less - they cannot use the 16-bit
+                // or 64-bit extended length encoding. Enforce this before allocating any payload
+                // buffer.
+                //
+                if (_readOpCode == OP_CLOSE || _readOpCode == OP_PING || _readOpCode == OP_PONG)
+                {
+                    if (!finalFrame)
+                    {
+                        throw new Ice.ProtocolException("invalid WebSocket control frame: the FIN bit is not set");
+                    }
+                    if (_readPayloadLength > 125)
+                    {
+                        throw new Ice.ProtocolException(
+                            "invalid WebSocket control frame: the payload length exceeds 125 bytes");
+                    }
+                }
+
                 if (_readPayloadLength < 126)
                 {
                     _readHeaderLength = 0;

--- a/csharp/src/Ice/Internal/WSTransceiver.cs
+++ b/csharp/src/Ice/Internal/WSTransceiver.cs
@@ -964,7 +964,7 @@ internal sealed class WSTransceiver : Transceiver
                 _readOpCode = ch & 0xf;
 
                 //
-                // No extension is negotiated, so the RSV1, RSV2 and RSV3 bits must all be 0.
+                // No extension is negotiated, so the RSV1, RSV2, and RSV3 bits must all be 0.
                 //
                 if ((ch & 0x70) != 0)
                 {
@@ -1017,7 +1017,7 @@ internal sealed class WSTransceiver : Transceiver
                 _readPayloadLength = ch & 0x7f;
 
                 //
-                // RFC 6455 section 5.5: control frames (close, ping and pong) must not be fragmented
+                // RFC 6455 section 5.5: control frames (close, ping, and pong) must not be fragmented
                 // and must have a payload length of 125 bytes or less - they cannot use the 16-bit
                 // or 64-bit extended length encoding. Enforce this before allocating any payload
                 // buffer.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSTransceiver.java
@@ -627,7 +627,7 @@ final class WSTransceiver implements Transceiver {
                 }
                 _readOpCode = ch & 0xf;
 
-                // No extension is negotiated, so the RSV1, RSV2 and RSV3 bits must all be 0.
+                // No extension is negotiated, so the RSV1, RSV2, and RSV3 bits must all be 0.
                 if ((ch & 0x70) != 0) {
                     throw new ProtocolException("invalid WebSocket frame: RSV bits must be 0");
                 }
@@ -667,7 +667,7 @@ final class WSTransceiver implements Transceiver {
                 // 127:   The subsequent eight bytes contain the payload length
                 _readPayloadLength = ch & 0x7f;
 
-                // RFC 6455 section 5.5: control frames (close, ping and pong) must not be fragmented
+                // RFC 6455 section 5.5: control frames (close, ping, and pong) must not be fragmented
                 // and must have a payload length of 125 bytes or less - they cannot use the 16-bit
                 // or 64-bit extended length encoding. Enforce this before allocating any payload
                 // buffer.

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSTransceiver.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/WSTransceiver.java
@@ -627,18 +627,25 @@ final class WSTransceiver implements Transceiver {
                 }
                 _readOpCode = ch & 0xf;
 
+                // No extension is negotiated, so the RSV1, RSV2 and RSV3 bits must all be 0.
+                if ((ch & 0x70) != 0) {
+                    throw new ProtocolException("invalid WebSocket frame: RSV bits must be 0");
+                }
+
+                final boolean finalFrame = (ch & FLAG_FINAL) == FLAG_FINAL;
+
                 // Remember if last frame if we're going to read a data or continuation frame,
                 // this is only for protocol correctness checking purpose.
                 if (_readOpCode == OP_DATA) {
                     if (!_readLastFrame) {
                         throw new ProtocolException("invalid data frame, no FIN on previous frame");
                     }
-                    _readLastFrame = (ch & FLAG_FINAL) == FLAG_FINAL;
+                    _readLastFrame = finalFrame;
                 } else if (_readOpCode == OP_CONT) {
                     if (_readLastFrame) {
                         throw new ProtocolException("invalid continuation frame, previous frame FIN set");
                     }
-                    _readLastFrame = (ch & FLAG_FINAL) == FLAG_FINAL;
+                    _readLastFrame = finalFrame;
                 }
 
                 ch = _readBuffer.b.get(_readBufferPos++);
@@ -659,6 +666,22 @@ final class WSTransceiver implements Transceiver {
                 // 126:   The subsequent two bytes contain the payload length
                 // 127:   The subsequent eight bytes contain the payload length
                 _readPayloadLength = ch & 0x7f;
+
+                // RFC 6455 section 5.5: control frames (close, ping and pong) must not be fragmented
+                // and must have a payload length of 125 bytes or less - they cannot use the 16-bit
+                // or 64-bit extended length encoding. Enforce this before allocating any payload
+                // buffer.
+                if (_readOpCode == OP_CLOSE || _readOpCode == OP_PING || _readOpCode == OP_PONG) {
+                    if (!finalFrame) {
+                        throw new ProtocolException(
+                            "invalid WebSocket control frame: the FIN bit is not set");
+                    }
+                    if (_readPayloadLength > 125) {
+                        throw new ProtocolException(
+                            "invalid WebSocket control frame: the payload length exceeds 125 bytes");
+                    }
+                }
+
                 if (_readPayloadLength < 126) {
                     _readHeaderLength = 0;
                 } else if (_readPayloadLength == 126) {


### PR DESCRIPTION
A WebSocket control frame (close, ping, pong) was length-decoded like a data frame, so a peer could send a tiny control frame declaring a payload of up to 2 GB. The receiver buffered the full declared payload before applying any size limit, allowing a remote, pre-authentication denial of service through memory exhaustion.

The transceivers now reject, before allocating any payload buffer, a control frame whose payload exceeds 125 bytes or that is fragmented (FIN bit clear), per RFC 6455 section 5.5. They also reject any frame with a non-zero RSV bit, since Ice negotiates no extension. Fixed in the C++, C#, and Java transceivers; the C++ fix also covers the Python, Ruby, PHP, MATLAB, and Swift mappings.