### PR TITLE
Use readAndCheckSeqSize for the proxy endpoint count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ These are the changes since the [Ice 3.8.1] release.
 
 - Fixed the WebSocket transport to enforce the RFC 6455 limits on control frames.
 
+- Fixed an unbounded memory allocation when unmarshaling a proxy with a large endpoint count.
+
 ### Slice Language Changes
 
 - Added the `["oneway"]` metadata directive for Slice operations. This directive can only be applied to operations that

--- a/cpp/src/Ice/ReferenceFactory.cpp
+++ b/cpp/src/Ice/ReferenceFactory.cpp
@@ -610,7 +610,9 @@ IceInternal::ReferenceFactory::create(Identity ident, InputStream* s)
     vector<EndpointIPtr> endpoints;
     string adapterId;
 
-    int32_t sz = s->readSize();
+    // Each endpoint occupies at least 8 bytes on the wire (a 2-byte type plus a 6-byte minimum
+    // encapsulation), so readAndCheckSeqSize rejects an oversized count before we allocate.
+    int32_t sz = s->readAndCheckSeqSize(8);
 
     if (sz > 0)
     {

--- a/csharp/src/Ice/Internal/ReferenceFactory.cs
+++ b/csharp/src/Ice/Internal/ReferenceFactory.cs
@@ -568,7 +568,9 @@ internal class ReferenceFactory
         EndpointI[] endpoints = null;
         string adapterId = "";
 
-        int sz = s.readSize();
+        // Each endpoint occupies at least 8 bytes on the wire (a 2-byte type plus a 6-byte minimum
+        // encapsulation), so readAndCheckSeqSize rejects an oversized count before we allocate.
+        int sz = s.readAndCheckSeqSize(8);
         if (sz > 0)
         {
             endpoints = new EndpointI[sz];

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ReferenceFactory.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ReferenceFactory.java
@@ -436,7 +436,9 @@ final class ReferenceFactory {
         EndpointI[] endpoints = null;
         String adapterId = null;
 
-        int sz = s.readSize();
+        // Each endpoint occupies at least 8 bytes on the wire (a 2-byte type plus a 6-byte minimum
+        // encapsulation), so readAndCheckSeqSize rejects an oversized count before we allocate.
+        int sz = s.readAndCheckSeqSize(8);
         if (sz > 0) {
             endpoints = new EndpointI[sz];
             for (int i = 0; i < sz; i++) {


### PR DESCRIPTION
This validates the count against the buffer before allocating, consistent with how Ice unmarshals sequences.