### PR TITLE
Reject a slice header too small for its optional members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ These are the changes since the [Ice 3.8.1] release.
 
 - Fixed an integer overflow in the sequence-size validation performed while unmarshaling.
 
+- Fixed the unmarshaling of classes and exceptions to reject a malformed sliced-format slice header.
+
 ### Slice Language Changes
 
 - Added the `["oneway"]` metadata directive for Slice operations. This directive can only be applied to operations that

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -1930,7 +1930,10 @@ Ice::InputStream::EncapsDecoder11::startSlice()
     if (_current->sliceFlags & FLAG_HAS_SLICE_SIZE)
     {
         _stream->read(_current->sliceSize);
-        if (_current->sliceSize < 4)
+        // A slice with optional members carries at least the 1-byte end marker in its body, so its
+        // size (which includes the 4-byte size field) must be >= 5.
+        int32_t minSliceSize = (_current->sliceFlags & FLAG_HAS_OPTIONAL_MEMBERS) ? 5 : 4;
+        if (_current->sliceSize < minSliceSize)
         {
             throw MarshalException{__FILE__, __LINE__, endOfBufferMessage};
         }

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -1931,7 +1931,8 @@ Ice::InputStream::EncapsDecoder11::startSlice()
     {
         _stream->read(_current->sliceSize);
         // A slice with optional members carries at least the 1-byte end marker in its body, so its
-        // size (which includes the 4-byte size field) must be >= 5.
+        // size (which includes the 4-byte size field) must be >= 5. We rely on this in skipSlice's
+        // slice-preservation logic, which excludes the end marker by stepping back one byte.
         int32_t minSliceSize = (_current->sliceFlags & FLAG_HAS_OPTIONAL_MEMBERS) ? 5 : 4;
         if (_current->sliceSize < minSliceSize)
         {

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -2594,7 +2594,10 @@ public sealed class InputStream
             if ((_current.sliceFlags & Protocol.FLAG_HAS_SLICE_SIZE) != 0)
             {
                 _current.sliceSize = _stream.readInt();
-                if (_current.sliceSize < 4)
+                // A slice with optional members carries at least the 1-byte end marker in its body,
+                // so its size (which includes the 4-byte size field) must be >= 5.
+                int minSliceSize = (_current.sliceFlags & Protocol.FLAG_HAS_OPTIONAL_MEMBERS) != 0 ? 5 : 4;
+                if (_current.sliceSize < minSliceSize)
                 {
                     throw new MarshalException(endOfBufferMessage);
                 }

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -2595,7 +2595,9 @@ public sealed class InputStream
             {
                 _current.sliceSize = _stream.readInt();
                 // A slice with optional members carries at least the 1-byte end marker in its body,
-                // so its size (which includes the 4-byte size field) must be >= 5.
+                // so its size (which includes the 4-byte size field) must be >= 5. We rely on this in
+                // skipSlice's slice-preservation logic, which excludes the end marker by stepping back
+                // one byte.
                 int minSliceSize = (_current.sliceFlags & Protocol.FLAG_HAS_OPTIONAL_MEMBERS) != 0 ? 5 : 4;
                 if (_current.sliceSize < minSliceSize)
                 {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -1939,7 +1939,10 @@ public final class InputStream {
             // Read the slice size if necessary.
             if ((_current.sliceFlags & Protocol.FLAG_HAS_SLICE_SIZE) != 0) {
                 _current.sliceSize = _stream.readInt();
-                if (_current.sliceSize < 4) {
+                // A slice with optional members carries at least the 1-byte end marker in its body,
+                // so its size (which includes the 4-byte size field) must be >= 5.
+                int minSliceSize = (_current.sliceFlags & Protocol.FLAG_HAS_OPTIONAL_MEMBERS) != 0 ? 5 : 4;
+                if (_current.sliceSize < minSliceSize) {
                     throw new MarshalException(END_OF_BUFFER_MESSAGE);
                 }
             } else {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -1940,7 +1940,9 @@ public final class InputStream {
             if ((_current.sliceFlags & Protocol.FLAG_HAS_SLICE_SIZE) != 0) {
                 _current.sliceSize = _stream.readInt();
                 // A slice with optional members carries at least the 1-byte end marker in its body,
-                // so its size (which includes the 4-byte size field) must be >= 5.
+                // so its size (which includes the 4-byte size field) must be >= 5. We rely on this in
+                // skipSlice's slice-preservation logic, which excludes the end marker by stepping back
+                // one byte.
                 int minSliceSize = (_current.sliceFlags & Protocol.FLAG_HAS_OPTIONAL_MEMBERS) != 0 ? 5 : 4;
                 if (_current.sliceSize < minSliceSize) {
                     throw new MarshalException(END_OF_BUFFER_MESSAGE);

--- a/js/packages/ice/src/Ice/InputStream.js
+++ b/js/packages/ice/src/Ice/InputStream.js
@@ -538,7 +538,10 @@ class EncapsDecoder11 extends EncapsDecoder {
         //
         if ((this._current.sliceFlags & Protocol.FLAG_HAS_SLICE_SIZE) !== 0) {
             this._current.sliceSize = this._stream.readInt();
-            if (this._current.sliceSize < 4) {
+            // A slice with optional members carries at least the 1-byte end marker in its body, so
+            // its size (which includes the 4-byte size field) must be >= 5.
+            const minSliceSize = (this._current.sliceFlags & Protocol.FLAG_HAS_OPTIONAL_MEMBERS) !== 0 ? 5 : 4;
+            if (this._current.sliceSize < minSliceSize) {
                 throw new MarshalException(endOfBufferMessage);
             }
         } else {

--- a/js/packages/ice/src/Ice/InputStream.js
+++ b/js/packages/ice/src/Ice/InputStream.js
@@ -539,7 +539,9 @@ class EncapsDecoder11 extends EncapsDecoder {
         if ((this._current.sliceFlags & Protocol.FLAG_HAS_SLICE_SIZE) !== 0) {
             this._current.sliceSize = this._stream.readInt();
             // A slice with optional members carries at least the 1-byte end marker in its body, so
-            // its size (which includes the 4-byte size field) must be >= 5.
+            // its size (which includes the 4-byte size field) must be >= 5. We rely on this in
+            // skipSlice's slice-preservation logic, which excludes the end marker by stepping back
+            // one byte.
             const minSliceSize = (this._current.sliceFlags & Protocol.FLAG_HAS_OPTIONAL_MEMBERS) !== 0 ? 5 : 4;
             if (this._current.sliceSize < minSliceSize) {
                 throw new MarshalException(endOfBufferMessage);

--- a/matlab/lib/+IceInternal/EncapsDecoder11.m
+++ b/matlab/lib/+IceInternal/EncapsDecoder11.m
@@ -151,7 +151,9 @@ classdef (Hidden) EncapsDecoder11 < IceInternal.EncapsDecoder
             if bitand(current.sliceFlags, Protocol.FLAG_HAS_SLICE_SIZE)
                 current.sliceSize = is.readInt();
                 % A slice with optional members carries at least the 1-byte end marker in its body,
-                % so its size (which includes the 4-byte size field) must be >= 5.
+                % so its size (which includes the 4-byte size field) must be >= 5. We rely on this in
+                % skipSlice's slice-preservation logic, which excludes the end marker by stepping
+                % back one byte.
                 if bitand(current.sliceFlags, Protocol.FLAG_HAS_OPTIONAL_MEMBERS)
                     minSliceSize = 5;
                 else

--- a/matlab/lib/+IceInternal/EncapsDecoder11.m
+++ b/matlab/lib/+IceInternal/EncapsDecoder11.m
@@ -150,7 +150,14 @@ classdef (Hidden) EncapsDecoder11 < IceInternal.EncapsDecoder
             %
             if bitand(current.sliceFlags, Protocol.FLAG_HAS_SLICE_SIZE)
                 current.sliceSize = is.readInt();
-                if current.sliceSize < 4
+                % A slice with optional members carries at least the 1-byte end marker in its body,
+                % so its size (which includes the 4-byte size field) must be >= 5.
+                if bitand(current.sliceFlags, Protocol.FLAG_HAS_OPTIONAL_MEMBERS)
+                    minSliceSize = 5;
+                else
+                    minSliceSize = 4;
+                end
+                if current.sliceSize < minSliceSize
                     throw(Ice.MarshalException('invalid slice size'));
                 end
             else

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -1414,7 +1414,10 @@ private class EncapsDecoder11: EncapsDecoder {
         //
         if current.sliceFlags.contains(SliceFlags.FLAG_HAS_SLICE_SIZE) {
             current.sliceSize = try stream.read()
-            if current.sliceSize < 4 {
+            // A slice with optional members carries at least the 1-byte end marker in its body, so
+            // its size (which includes the 4-byte size field) must be >= 5.
+            let minSliceSize: Int32 = current.sliceFlags.contains(.FLAG_HAS_OPTIONAL_MEMBERS) ? 5 : 4
+            if current.sliceSize < minSliceSize {
                 throw MarshalException("invalid slice size")
             }
         } else {

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -1415,7 +1415,9 @@ private class EncapsDecoder11: EncapsDecoder {
         if current.sliceFlags.contains(SliceFlags.FLAG_HAS_SLICE_SIZE) {
             current.sliceSize = try stream.read()
             // A slice with optional members carries at least the 1-byte end marker in its body, so
-            // its size (which includes the 4-byte size field) must be >= 5.
+            // its size (which includes the 4-byte size field) must be >= 5. We rely on this in
+            // skipSlice's slice-preservation logic, which excludes the end marker by stepping back
+            // one byte.
             let minSliceSize: Int32 = current.sliceFlags.contains(.FLAG_HAS_OPTIONAL_MEMBERS) ? 5 : 4
             if current.sliceSize < minSliceSize {
                 throw MarshalException("invalid slice size")


### PR DESCRIPTION
A sliced-format slice that sets the optional-members flag carries at least a 1-byte end marker, so its size must be >= 5. The 1.1 decoder now enforces this in C++, C#, Java, JavaScript, MATLAB, and Swift.