### PR TITLE
Reject a batch request count larger than the message can contain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ These are the changes since the [Ice 3.8.1] release.
 
 - Fixed the unmarshaling of classes and exceptions to reject a malformed sliced-format slice header.
 
+- Fixed the unmarshaling of batch requests to reject a request count larger than the message can hold.
+
 ### Slice Language Changes
 
 - Added the `["oneway"]` metadata directive for Slice operations. This directive can only be applied to operations that

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -3260,6 +3260,22 @@ Ice::ConnectionI::parseMessage(int32_t& upcallCount, function<bool(InputStream&)
                             "received batch request with " + to_string(requestCount) + " batches"};
                     }
 
+                    // A batched request occupies at least 12 bytes on the wire (a 2-byte identity, a
+                    // 1-byte facet path, a 1-byte operation name, a 1-byte operation mode, a 1-byte
+                    // context, and a 6-byte parameters encapsulation). Reject a count larger than the
+                    // remaining message data could possibly hold. The message size is already capped
+                    // at Ice.MessageSizeMax (<= INT32_MAX bytes), so this also keeps requestCount well
+                    // within range when it is accumulated into the dispatch counters below.
+                    constexpr int32_t minBatchRequestSize = 12;
+                    if (requestCount > (stream.b.end() - stream.i) / minBatchRequestSize)
+                    {
+                        throw MarshalException{
+                            __FILE__,
+                            __LINE__,
+                            "received batch request with " + to_string(requestCount) +
+                                " batches, more than the message can contain"};
+                    }
+
                     upcall = [self = shared_from_this(), requestCount, adapter, compress](InputStream& messageStream)
                     {
                         self->dispatchAll(messageStream, requestCount, requestId, compress, adapter);

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -2332,6 +2332,20 @@ public sealed class ConnectionI : Internal.EventHandler, CancellationHandler, Co
                         {
                             throw new MarshalException($"Received batch request with {requestCount} batches.");
                         }
+
+                        // A batched request occupies at least 12 bytes on the wire (a 2-byte identity, a 1-byte
+                        // facet path, a 1-byte operation name, a 1-byte operation mode, a 1-byte context, and a
+                        // 6-byte parameters encapsulation). Reject a count larger than the remaining message
+                        // data could possibly hold. The message size is already capped at Ice.MessageSizeMax
+                        // (<= int.MaxValue bytes), so this also keeps requestCount well within range when it is
+                        // accumulated into the dispatch counters below.
+                        const int minBatchRequestSize = 12;
+                        if (requestCount > (info.stream.size() - info.stream.pos()) / minBatchRequestSize)
+                        {
+                            throw new MarshalException(
+                                $"Received batch request with {requestCount} batches, more than the message can contain.");
+                        }
+
                         info.requestCount = requestCount;
                         info.adapter = _adapter;
                         info.upcallCount += info.requestCount;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -1765,6 +1765,21 @@ public final class ConnectionI extends EventHandler implements Connection, Cance
                             info.requestCount = 0;
                             throw new MarshalException("Received batch request with " + info.requestCount + "batches.");
                         }
+
+                        // A batched request occupies at least 12 bytes on the wire (a 2-byte identity, a 1-byte
+                        // facet path, a 1-byte operation name, a 1-byte operation mode, a 1-byte context, and a
+                        // 6-byte parameters encapsulation). Reject a count larger than the remaining message
+                        // data could possibly hold. The message size is already capped at Ice.MessageSizeMax
+                        // (<= Integer.MAX_VALUE bytes), so this also keeps requestCount well within range when
+                        // it is accumulated into the dispatch counters below.
+                        final int minBatchRequestSize = 12;
+                        if (info.requestCount > (info.stream.size() - info.stream.pos()) / minBatchRequestSize) {
+                            throw new MarshalException(
+                                "Received batch request with "
+                                    + info.requestCount
+                                    + " batches, more than the message can contain.");
+                        }
+
                         info.adapter = _adapter;
                         info.upcallCount += info.requestCount;
 

--- a/js/packages/ice/src/Ice/ConnectionI.js
+++ b/js/packages/ice/src/Ice/ConnectionI.js
@@ -1291,9 +1291,21 @@ export class ConnectionI {
                     } else {
                         TraceUtil.traceRecv(info.stream, this, this._logger, this._traceLevels);
                         const requestCount = info.stream.readInt();
-                        if (info.requestCount < 0) {
+                        if (requestCount < 0) {
                             throw new MarshalException(`Received batch request with ${requestCount} batches.`);
                         }
+
+                        // A batched request occupies at least 12 bytes on the wire (a 2-byte identity, a 1-byte
+                        // facet path, a 1-byte operation name, a 1-byte operation mode, a 1-byte context, and a
+                        // 6-byte parameters encapsulation). Reject a count larger than the remaining message
+                        // data could possibly hold.
+                        const minBatchRequestSize = 12;
+                        if (requestCount > (info.stream.size - info.stream.pos) / minBatchRequestSize) {
+                            throw new MarshalException(
+                                `Received batch request with ${requestCount} batches, more than the message can contain.`,
+                            );
+                        }
+
                         info.requestCount = requestCount;
                         info.adapter = this._adapter;
                         this._upcallCount += info.requestCount;


### PR DESCRIPTION
Validate the batch request count against the remaining message data before accumulating it into the dispatch counters.