### PR TITLE
Pin a minimum TLS version for the macOS SSL transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ These are the changes since the [Ice 3.8.1] release.
 
 ### C++ Changes
 
+- Added the `IceSSL.ProtocolVersionMin` and `IceSSL.ProtocolVersionMax` properties to configure the range of TLS
+  protocol versions accepted by the macOS SSL transport. `IceSSL.ProtocolVersionMin` defaults to `tls1_2`.
+
 - Changed the mapping of `@p [NAME]` tags which reference out parameters in Slice. These now generate `` `[NAME]` ``
   instead of `@p [NAME]`.
 

--- a/config/PropertyNames.xml
+++ b/config/PropertyNames.xml
@@ -316,6 +316,8 @@
         <property name="KeystorePassword" languages="java" />
         <property name="KeystoreType" languages="java" />
         <property name="Password" languages="cpp,csharp,java" />
+        <property name="ProtocolVersionMax" languages="cpp" />
+        <property name="ProtocolVersionMin" languages="cpp" default="tls1_2" />
         <property name="RevocationCheck" languages="cpp" default="0"/>
         <property name="RevocationCheckCacheOnly" languages="cpp" default="1" />
         <property name="Trace.Security" languages="cpp,csharp,java" default="0" />

--- a/cpp/src/Ice/PropertyNames.cpp
+++ b/cpp/src/Ice/PropertyNames.cpp
@@ -427,6 +427,8 @@ const Property IceSSLPropsData[] =
     Property{"KeychainPassword", "", false, false, nullptr},
     Property{"KeyFile", "", false, false, nullptr},
     Property{"Password", "", false, false, nullptr},
+    Property{"ProtocolVersionMax", "", false, false, nullptr},
+    Property{"ProtocolVersionMin", "tls1_2", false, false, nullptr},
     Property{"RevocationCheck", "0", false, false, nullptr},
     Property{"RevocationCheckCacheOnly", "1", false, false, nullptr},
     Property{"Trace.Security", "0", false, false, nullptr},
@@ -444,7 +446,7 @@ const PropertyArray PropertyNames::IceSSLProps
     .prefixOnly=false,
     .isOptIn=false,
     .properties=IceSSLPropsData,
-    .length=21
+    .length=23
 };
 
 const Property IceStormPropsData[] =

--- a/cpp/src/Ice/SSL/SecureTransportEngine.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportEngine.cpp
@@ -9,6 +9,7 @@
 #include "Ice/Logger.h"
 #include "Ice/Properties.h"
 #include "Ice/SSL/SSLException.h"
+#include "Ice/StringUtil.h"
 #include "SSLEngine.h"
 #include "SSLUtil.h"
 #include "SecureTransportUtil.h"
@@ -547,12 +548,41 @@ namespace
             }
         }
     }
+
+    // Maps an IceSSL.ProtocolVersionMin/Max property value to a SecureTransport SSLProtocol constant.
+    // Only the TLS versions SecureTransport can negotiate are recognized; the API supports neither
+    // SSLv3 nor TLS 1.3.
+    SSLProtocol parseProtocol(const string& protocol)
+    {
+        const string p = IceInternal::toUpper(protocol);
+        if (p == "TLS" || p == "TLS1" || p == "TLSV1" || p == "TLS1_0" || p == "TLSV1_0")
+        {
+            return kTLSProtocol1;
+        }
+        else if (p == "TLS1_1" || p == "TLSV1_1")
+        {
+            return kTLSProtocol11;
+        }
+        else if (p == "TLS1_2" || p == "TLSV1_2")
+        {
+            return kTLSProtocol12;
+        }
+        else
+        {
+            throw InitializationException(
+                __FILE__,
+                __LINE__,
+                "SSL transport: unrecognized protocol version '" + protocol + "'");
+        }
+    }
 }
 
 SecureTransport::SSLEngine::SSLEngine(const IceInternal::InstancePtr& instance)
     : Ice::SSL::SSLEngine(instance),
       _certificateAuthorities(nullptr),
-      _chain(nullptr)
+      _chain(nullptr),
+      _protocolVersionMin(kSSLProtocolUnknown),
+      _protocolVersionMax(kSSLProtocolUnknown)
 {
 }
 
@@ -649,6 +679,21 @@ SecureTransport::SSLEngine::initialize()
     {
         _chain.reset(findCertificateChain(keychain, keychainPassword, findCert));
     }
+
+    // Pin the negotiated TLS protocol version range. SecureTransport otherwise negotiates down to
+    // TLS 1.0 on macOS; IceSSL.ProtocolVersionMin defaults to tls1_2. IceSSL.ProtocolVersionMax is
+    // unset by default, leaving the upper bound to SecureTransport.
+    const string protocolVersionMin = properties->getIceProperty("IceSSL.ProtocolVersionMin");
+    if (!protocolVersionMin.empty())
+    {
+        _protocolVersionMin = parseProtocol(protocolVersionMin);
+    }
+
+    const string protocolVersionMax = properties->getIceProperty("IceSSL.ProtocolVersionMax");
+    if (!protocolVersionMax.empty())
+    {
+        _protocolVersionMax = parseProtocol(protocolVersionMax);
+    }
 }
 
 //
@@ -739,6 +784,30 @@ SecureTransport::SSLEngine::newContext(bool incoming) const
             __FILE__,
             __LINE__,
             "SSL transport: error while setting SSL option:\n" + sslErrorToString(err));
+    }
+
+    if (_protocolVersionMin != kSSLProtocolUnknown)
+    {
+        err = SSLSetProtocolVersionMin(ssl, _protocolVersionMin);
+        if (err != noErr)
+        {
+            throw SecurityException(
+                __FILE__,
+                __LINE__,
+                "SSL transport: error while setting minimum protocol version:\n" + sslErrorToString(err));
+        }
+    }
+
+    if (_protocolVersionMax != kSSLProtocolUnknown)
+    {
+        err = SSLSetProtocolVersionMax(ssl, _protocolVersionMax);
+        if (err != noErr)
+        {
+            throw SecurityException(
+                __FILE__,
+                __LINE__,
+                "SSL transport: error while setting maximum protocol version:\n" + sslErrorToString(err));
+        }
     }
 
     return ssl;

--- a/cpp/src/Ice/SSL/SecureTransportEngine.h
+++ b/cpp/src/Ice/SSL/SecureTransportEngine.h
@@ -37,6 +37,11 @@ namespace Ice::SSL::SecureTransport
     private:
         IceInternal::UniqueRef<CFArrayRef> _certificateAuthorities;
         IceInternal::UniqueRef<CFArrayRef> _chain;
+
+        // The TLS protocol version range applied to every SSL context. kSSLProtocolUnknown means the
+        // corresponding bound is left to the SecureTransport default.
+        SSLProtocol _protocolVersionMin;
+        SSLProtocol _protocolVersionMax;
     };
 }
 #endif


### PR DESCRIPTION
Adds the `IceSSL.ProtocolVersionMin` and `IceSSL.ProtocolVersionMax` properties to the macOS SecureTransport engine, restoring configuration that existed in 3.7. `IceSSL.ProtocolVersionMin` defaults to `tls1_2`.

Without an explicit floor, the SecureTransport API negotiates down to TLS 1.0/1.1 on macOS — unlike Schannel and OpenSSL, where the platform already enforces a TLS 1.2 minimum. The new default closes that gap; the two properties let an operator widen or narrow the accepted range. Only the TLS versions SecureTransport can negotiate (1.0/1.1/1.2) are recognized.

### Verification

Empirical `nmap --script ssl-enum-ciphers` against an Ice SSL server on macOS:

| Config | TLS versions offered |
|---|---|
| Default | TLS 1.2 only |
| `ProtocolVersionMin=tls1_0` | TLS 1.0 / 1.1 / 1.2 |
| `Min=tls1_0 Max=tls1_1` | TLS 1.0 / 1.1 |
| invalid value | clean `InitializationException` |

Binary compatible — suitable for cherry-pick to 3.8.