### PR TITLE
Pin a minimum TLS version for the macOS SSL transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ These are the changes since the [Ice 3.8.1] release.
 
 ### C++ Changes
 
+- Changed the macOS SSL transport to require TLS 1.2 or later.
+
 - Changed the mapping of `@p [NAME]` tags which reference out parameters in Slice. These now generate `` `[NAME]` ``
   instead of `@p [NAME]`.
 

--- a/cpp/src/Ice/SSL/SecureTransportEngine.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportEngine.cpp
@@ -741,6 +741,16 @@ SecureTransport::SSLEngine::newContext(bool incoming) const
             "SSL transport: error while setting SSL option:\n" + sslErrorToString(err));
     }
 
+    // Require TLS 1.2 or later. SecureTransport otherwise negotiates down to TLS 1.0 on macOS.
+    err = SSLSetProtocolVersionMin(ssl, kTLSProtocol12);
+    if (err != noErr)
+    {
+        throw SecurityException(
+            __FILE__,
+            __LINE__,
+            "SSL transport: error while setting the minimum protocol version:\n" + sslErrorToString(err));
+    }
+
     return ssl;
 }
 


### PR DESCRIPTION
Require TLS 1.2 or later in the SecureTransport engine; SecureTransport otherwise negotiates down to TLS 1.0 on macOS.

Replaces #5341