### PR TITLE
Use a temporary keychain for the macOS SSL transport certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ These are the changes since the [Ice 3.8.1] release.
   certificate stores, chain engines, imported key sets, and `SSL_CTX` when the communicator is
   destroyed.
 
+- Changed the macOS SSL transport so that, when `IceSSL.Keychain` is not set, the certificate configured with
+  `IceSSL.CertFile` is imported into a temporary keychain (removed when the communicator is destroyed) instead of
+  the user's login keychain.
+
 - Changed the mapping of `@p [NAME]` tags which reference out parameters in Slice. These now generate `` `[NAME]` ``
   instead of `@p [NAME]`.
 

--- a/cpp/src/Ice/SSL/SecureTransportEngine.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportEngine.cpp
@@ -9,9 +9,16 @@
 #include "Ice/Logger.h"
 #include "Ice/Properties.h"
 #include "Ice/SSL/SSLException.h"
+#include "Ice/UUID.h"
 #include "SSLEngine.h"
 #include "SSLUtil.h"
 #include "SecureTransportUtil.h"
+
+#include <cerrno>
+#include <climits>
+#include <cstring>
+#include <unistd.h>
+#include <vector>
 
 // Disable deprecation warnings from SecureTransport APIs
 #include "../DisableWarnings.h"
@@ -547,6 +554,43 @@ namespace
             }
         }
     }
+
+#if defined(ICE_USE_SECURE_TRANSPORT_MACOS)
+    // Creates a private temporary directory to hold a short-lived keychain, and returns its path.
+    // Uses confstr(_CS_DARWIN_USER_TEMP_DIR) rather than $TMPDIR so the location can't be
+    // redirected through the process environment.
+    string createTemporaryKeychainDirectory()
+    {
+        char base[PATH_MAX];
+        size_t len = confstr(_CS_DARWIN_USER_TEMP_DIR, base, sizeof(base));
+        if (len == 0 || len > sizeof(base))
+        {
+            int error = errno;
+
+            ostringstream os;
+            os << "SSL transport: confstr(_CS_DARWIN_USER_TEMP_DIR) failed";
+            if (error != 0)
+            {
+                os << ": " << strerror(error);
+            }
+            throw InitializationException(__FILE__, __LINE__, os.str());
+        }
+
+        string tmpl = string{base} + "ice-keychain-XXXXXX";
+        vector<char> buffer(tmpl.begin(), tmpl.end());
+        buffer.push_back('\0');
+
+        char* dir = mkdtemp(buffer.data());
+        if (dir == nullptr)
+        {
+            int error = errno;
+            ostringstream os;
+            os << "SSL transport: mkdtemp failed: " << strerror(error);
+            throw InitializationException(__FILE__, __LINE__, os.str());
+        }
+        return dir;
+    }
+#endif
 }
 
 SecureTransport::SSLEngine::SSLEngine(const IceInternal::InstancePtr& instance)
@@ -556,7 +600,25 @@ SecureTransport::SSLEngine::SSLEngine(const IceInternal::InstancePtr& instance)
 {
 }
 
-SecureTransport::SSLEngine::~SSLEngine() = default;
+SecureTransport::SSLEngine::~SSLEngine()
+{
+#if defined(ICE_USE_SECURE_TRANSPORT_MACOS)
+    if (!_temporaryKeychainDir.empty())
+    {
+        // Remove the temporary keychain and its enclosing directory created by initialize().
+        // The cleanup lives in the destructor (not destroy()) so it also runs when initialize()
+        // throws after the directory has been created.
+        _chain.reset();
+        const string keychainPath = _temporaryKeychainDir + "/ice.keychain";
+        UniqueRef<SecKeychainRef> keychain;
+        if (SecKeychainOpen(keychainPath.c_str(), &keychain.get()) == noErr && keychain.get())
+        {
+            SecKeychainDelete(keychain.get());
+        }
+        rmdir(_temporaryKeychainDir.c_str());
+    }
+#endif
+}
 
 //
 // Setup the engine.
@@ -635,6 +697,18 @@ SecureTransport::SSLEngine::initialize()
             }
             keyFile = *resolved;
         }
+
+#if defined(ICE_USE_SECURE_TRANSPORT_MACOS)
+        if (keychain.empty())
+        {
+            // Import the certificate into a temporary keychain rather than the user's login keychain.
+            // A private key in the login keychain cannot complete a forward-secret (ECDHE) handshake
+            // on the server side. The keychain and its enclosing directory are removed by the destructor.
+            _temporaryKeychainDir = createTemporaryKeychainDirectory();
+            keychain = _temporaryKeychainDir + "/ice.keychain";
+            keychainPassword = Ice::generateUUID();
+        }
+#endif
 
         try
         {

--- a/cpp/src/Ice/SSL/SecureTransportEngine.h
+++ b/cpp/src/Ice/SSL/SecureTransportEngine.h
@@ -36,6 +36,12 @@ namespace Ice::SSL::SecureTransport
     private:
         IceInternal::UniqueRef<CFArrayRef> _certificateAuthorities;
         IceInternal::UniqueRef<CFArrayRef> _chain;
+
+#    if defined(ICE_USE_SECURE_TRANSPORT_MACOS)
+        // Path of the temporary directory holding the imported certificate's keychain, removed by the destructor.
+        // Empty when IceSSL.Keychain is set or no certificate is configured.
+        std::string _temporaryKeychainDir;
+#    endif
     };
 }
 #endif

--- a/cpp/test/IceSSL/configuration/AllTests.cpp
+++ b/cpp/test/IceSSL/configuration/AllTests.cpp
@@ -227,8 +227,6 @@ public:
 };
 #endif
 
-int keychainN = 0;
-
 static PropertiesPtr
 createClientProps(const Ice::PropertiesPtr& defaultProps, bool p12)
 {
@@ -244,13 +242,6 @@ createClientProps(const Ice::PropertiesPtr& defaultProps, bool p12)
     {
         result->setProperty("IceSSL.Password", "password");
     }
-#ifdef ICE_USE_SECURE_TRANSPORT
-    ostringstream keychainName;
-    keychainName << defaultDir << "/keychain/client" << keychainN++ << ".keychain";
-    const string keychainPassword = "password";
-    result->setProperty("IceSSL.Keychain", keychainName.str());
-    result->setProperty("IceSSL.KeychainPassword", keychainPassword);
-#endif
     return result;
 }
 
@@ -271,12 +262,6 @@ createServerProps(const Ice::PropertiesPtr& defaultProps, bool p12)
     {
         result["IceSSL.Password"] = "password";
     }
-#ifdef ICE_USE_SECURE_TRANSPORT
-    ostringstream keychainName;
-    keychainName << defaultDir << "/keychain/server" << keychainN << ".keychain";
-    result["IceSSL.Keychain"] = keychainName.str();
-    result["IceSSL.KeychainPassword"] = "password";
-#endif
     return result;
 }
 

--- a/scripts/tests/IceSSL/configuration.py
+++ b/scripts/tests/IceSSL/configuration.py
@@ -39,11 +39,9 @@ class ConfigurationTestCase(ClientServerTestCase):
             self.ocspServer.start()
 
         if isinstance(platform, Darwin) and current.config.buildPlatform == "macosx":
-            # Create the keychains directory for IceSSL tests.
-            keychainsPath = os.path.join(certsPath, "keychain")
-            os.makedirs(keychainsPath, exist_ok=True)
-
-            # Create find.keychain for IceSSL.FindCerts tests on macOS
+            # Create Find.keychain for IceSSL.FindCert tests on macOS. The default cert-import path no
+            # longer needs a pre-created keychain — when IceSSL.Keychain is unset, IceSSL creates a
+            # private temporary keychain itself.
             keychainPath = os.path.join(certsPath, "Find.keychain")
             os.system(f"security create-keychain -p password {keychainPath}")
             for cert in ["ca1/server.p12", "ca1/client.p12"]:
@@ -67,9 +65,6 @@ class ConfigurationTestCase(ClientServerTestCase):
             self.ocspServer.shutdown()
 
         if isinstance(platform, Darwin) and current.config.buildPlatform == "macosx":
-            keychainsPath = os.path.join(certsPath, "keychain")
-            os.system(f"rm -rf {keychainsPath}")
-
             findKeychain = os.path.join(certsPath, "Find.keychain")
             os.system(f"rm -rf {findKeychain}")
         elif current.config.openssl or platform.hasOpenSSL():


### PR DESCRIPTION
Import the certificate configured with IceSSL.CertFile into a temporary keychain instead of the user's login keychain. This applies when IceSSL.Keychain is not set.

This change is required to negotiate forward-secret (ECDHE) cipher suites on the server side: a private key in the login keychain cannot complete an ECDHE handshake, so with the previous default a macOS server could not use forward secrecy.