### PR TITLE
Warn against DES passwords at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ might need to be aware of.
   - [C++ Changes](#c-changes)
   - [C# Changes](#c-changes-1)
   - [Swift Changes](#swift-changes)
+  - [Ice Service Changes](#ice-service-changes)
 
 ## Changes in Ice 3.9.0
 
@@ -56,5 +57,10 @@ These are the changes since the [Ice 3.8.1] release.
 ### Swift Changes
 
 - Fixed `InputStream.readSize` to reject a negative size.
+
+### Ice Service Changes
+
+- Updated the Glacier2CryptPermissionsVerifier plug-in to issue a warning when the configured password file contains one
+  or more DES passwords.
 
 [Ice 3.8.1]: https://github.com/zeroc-ice/ice/blob/3.8/CHANGELOG-3.8.md

--- a/cpp/src/Glacier2/CryptPermissionsVerifier.cpp
+++ b/cpp/src/Glacier2/CryptPermissionsVerifier.cpp
@@ -66,7 +66,7 @@ namespace
         CommunicatorPtr _communicator;
     };
 
-    map<string, string> retrievePasswordMap(const string& file, LoggerPtr logger)
+    map<string, string> retrievePasswordMap(const string& file, const LoggerPtr& logger)
     {
         ifstream passwordFile(IceInternal::streamFilename(file).c_str());
         if (!passwordFile)

--- a/cpp/src/Glacier2/CryptPermissionsVerifier.cpp
+++ b/cpp/src/Glacier2/CryptPermissionsVerifier.cpp
@@ -97,7 +97,8 @@ namespace
             assert(!userId.empty());
             assert(!password.empty());
 
-            hasDESStylePassword = hasDESStylePassword || (password.find('$') == string::npos);
+            hasDESStylePassword =
+                hasDESStylePassword || (password.find('$') == string::npos && password.size() == 13);
 
             passwords.insert(make_pair(userId, password));
         }

--- a/cpp/src/Glacier2/CryptPermissionsVerifier.cpp
+++ b/cpp/src/Glacier2/CryptPermissionsVerifier.cpp
@@ -97,8 +97,7 @@ namespace
             assert(!userId.empty());
             assert(!password.empty());
 
-            hasDESStylePassword =
-                hasDESStylePassword || (password.find('$') == string::npos && password.size() == 13);
+            hasDESStylePassword = hasDESStylePassword || (password.find('$') == string::npos && password.size() == 13);
 
             passwords.insert(make_pair(userId, password));
         }

--- a/cpp/src/Glacier2/CryptPermissionsVerifier.cpp
+++ b/cpp/src/Glacier2/CryptPermissionsVerifier.cpp
@@ -478,7 +478,8 @@ namespace
                 string name = prop.first.substr(prefix.size());
                 Identity id = {Ice::generateUUID(), "Glacier2CryptPermissionsVerifier"};
                 auto prx = adapter->add(
-                    make_shared<CryptPermissionsVerifierI>(retrievePasswordMap(prop.second, _communicator->getLogger())),
+                    make_shared<CryptPermissionsVerifierI>(
+                        retrievePasswordMap(prop.second, _communicator->getLogger())),
                     id);
                 _communicator->getProperties()->setProperty(name, _communicator->proxyToString(prx));
             }

--- a/cpp/src/Glacier2/CryptPermissionsVerifier.cpp
+++ b/cpp/src/Glacier2/CryptPermissionsVerifier.cpp
@@ -97,10 +97,7 @@ namespace
             assert(!userId.empty());
             assert(!password.empty());
 
-            if (password.find('$') == string::npos)
-            {
-                hasDESStylePassword = true;
-            }
+            hasDESStylePassword = hasDESStylePassword || (password.find('$') == string::npos);
 
             passwords.insert(make_pair(userId, password));
         }

--- a/cpp/src/Glacier2/CryptPermissionsVerifier.cpp
+++ b/cpp/src/Glacier2/CryptPermissionsVerifier.cpp
@@ -66,7 +66,7 @@ namespace
         CommunicatorPtr _communicator;
     };
 
-    map<string, string> retrievePasswordMap(const string& file)
+    map<string, string> retrievePasswordMap(const string& file, LoggerPtr logger)
     {
         ifstream passwordFile(IceInternal::streamFilename(file).c_str());
         if (!passwordFile)
@@ -75,6 +75,8 @@ namespace
             throw Ice::InitializationException(__FILE__, __LINE__, "cannot open '" + file + "' for reading: " + err);
         }
         map<string, string> passwords;
+
+        bool hasDESStylePassword = false;
 
         while (true)
         {
@@ -94,8 +96,22 @@ namespace
 
             assert(!userId.empty());
             assert(!password.empty());
+
+            if (password.find('$') == string::npos)
+            {
+                hasDESStylePassword = true;
+            }
+
             passwords.insert(make_pair(userId, password));
         }
+
+        if (hasDESStylePassword)
+        {
+            Warning out(logger);
+            out << "The password file '" << file << "' contains one or more DES-style passwords. DES is a weak "
+                << "algorithm and should not be used in production. ";
+        }
+
         return passwords;
     }
 
@@ -464,7 +480,9 @@ namespace
             {
                 string name = prop.first.substr(prefix.size());
                 Identity id = {Ice::generateUUID(), "Glacier2CryptPermissionsVerifier"};
-                auto prx = adapter->add(make_shared<CryptPermissionsVerifierI>(retrievePasswordMap(prop.second)), id);
+                auto prx = adapter->add(
+                    make_shared<CryptPermissionsVerifierI>(retrievePasswordMap(prop.second, _communicator->getLogger())),
+                    id);
                 _communicator->getProperties()->setProperty(name, _communicator->proxyToString(prx));
             }
 


### PR DESCRIPTION
This PR updates the Glacier2CryptPermissionsVerifier plug-in to issue a warning when the configured password file contains old DES passwords.

DES passwords are not secure and should not be used in production.
