### PR TITLE
Reject connection with no certificate when creating a SSL-based session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ might need to be aware of.
   - [C++ Changes](#c-changes)
   - [C# Changes](#c-changes-1)
   - [Swift Changes](#swift-changes)
+  - [Ice Service Changes](#ice-service-changes)
 
 ## Changes in Ice 3.9.0
 
@@ -56,5 +57,9 @@ These are the changes since the [Ice 3.8.1] release.
 ### Swift Changes
 
 - Fixed `InputStream.readSize` to reject a negative size.
+
+### Ice Service Changes
+
+- Fixed IceGrid and Glacier2 SSL session creation to reject peer certificates with an empty subject DN.
 
 [Ice 3.8.1]: https://github.com/zeroc-ice/ice/blob/3.8/CHANGELOG-3.8.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ These are the changes since the [Ice 3.8.1] release.
 
 ### Ice Service Changes
 
-- Fixed IceGrid and Glacier2 SSL session creation to reject peer certificates with an empty subject DN.
+- Updated the creation of SSL-based sessions in IceGrid and Glacier2: a connection without a client certificate, or with
+  an empty DN, is now rejected before reaching the permissions verifier.
 
 [Ice 3.8.1]: https://github.com/zeroc-ice/ice/blob/3.8/CHANGELOG-3.8.md

--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -669,6 +669,16 @@ SessionRouterI::createSessionFromSecureConnectionAsync(
         {
             sslinfo.certs.push_back(Ice::SSL::encodeCertificate(info->peerCertificate));
             userDN = Ice::SSL::getSubjectName(info->peerCertificate);
+            if (userDN.empty())
+            {
+                exception(make_exception_ptr(PermissionDeniedException("empty user DN")));
+                return;
+            }
+        }
+        else
+        {
+            exception(make_exception_ptr(PermissionDeniedException("the client did not provide a certificate")));
+            return;
         }
     }
     catch (const Ice::SSL::CertificateEncodingException&)
@@ -679,12 +689,6 @@ SessionRouterI::createSessionFromSecureConnectionAsync(
     catch (const Ice::LocalException&)
     {
         exception(make_exception_ptr(PermissionDeniedException("connection exception")));
-        return;
-    }
-
-    if (userDN.empty())
-    {
-        exception(make_exception_ptr(PermissionDeniedException("empty user DN")));
         return;
     }
 

--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -682,6 +682,12 @@ SessionRouterI::createSessionFromSecureConnectionAsync(
         return;
     }
 
+    if (userDN.empty())
+    {
+        exception(make_exception_ptr(PermissionDeniedException("empty user DN")));
+        return;
+    }
+
     auto session = make_shared<SSLCreateSession>(
         std::move(response),
         std::move(exception),

--- a/cpp/src/IceGrid/RegistryI.cpp
+++ b/cpp/src/IceGrid/RegistryI.cpp
@@ -962,10 +962,6 @@ RegistryI::createSessionFromSecureConnection(const Current& current)
 
     string userDN;
     Glacier2::SSLInfo info = getSSLInfo(current.con, userDN);
-    if (userDN.empty())
-    {
-        throw PermissionDeniedException("empty user DN");
-    }
 
     try
     {
@@ -1010,10 +1006,6 @@ RegistryI::createAdminSessionFromSecureConnection(const Current& current)
 
     string userDN;
     Glacier2::SSLInfo info = getSSLInfo(current.con, userDN);
-    if (userDN.empty())
-    {
-        throw PermissionDeniedException("empty user DN");
-    }
 
     try
     {
@@ -1167,7 +1159,7 @@ RegistryI::getSSLInfo(const ConnectionPtr& connection, string& userDN)
         auto info = dynamic_pointer_cast<Ice::SSL::ConnectionInfo>(connection->getInfo());
         if (!info)
         {
-            throw PermissionDeniedException("not ssl connection");
+            throw PermissionDeniedException("not an ssl connection");
         }
 
         auto ipInfo = getIPConnectionInfo(info);
@@ -1179,6 +1171,15 @@ RegistryI::getSSLInfo(const ConnectionPtr& connection, string& userDN)
         {
             sslinfo.certs.push_back(Ice::SSL::encodeCertificate(info->peerCertificate));
             userDN = Ice::SSL::getSubjectName(info->peerCertificate);
+
+            if (userDN.empty())
+            {
+                throw PermissionDeniedException("empty user DN");
+            }
+        }
+        else
+        {
+            throw PermissionDeniedException("the client did not provide a certificate");
         }
     }
     catch (const Ice::SSL::CertificateEncodingException&)

--- a/cpp/src/IceGrid/RegistryI.cpp
+++ b/cpp/src/IceGrid/RegistryI.cpp
@@ -1010,6 +1010,11 @@ RegistryI::createAdminSessionFromSecureConnection(const Current& current)
 
     string userDN;
     Glacier2::SSLInfo info = getSSLInfo(current.con, userDN);
+    if (userDN.empty())
+    {
+        throw PermissionDeniedException("empty user DN");
+    }
+
     try
     {
         string reason;


### PR DESCRIPTION
This PR rejects the creation of SSL-based sessions when the client does not provide a certificate, or when the user DN in the certificate is empty.