### PR TITLE
Reject peer-initiated TLS renegotiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ These are the changes since the [Ice 3.8.1] release.
   `IceSSL.CertFile` is imported into a temporary keychain (removed when the communicator is destroyed) instead of
   the user's login keychain.
 
+- Rejected peer-initiated TLS renegotiation in the OpenSSL SSL engine and on the server side of Schannel-based SSL
+  connections. This applies to all SSL-based transports (`ssl`, `wss`, `bts`).
+
 - Changed the mapping of `@p [NAME]` tags which reference out parameters in Slice. These now generate `` `[NAME]` ``
   instead of `@p [NAME]`.
 

--- a/cpp/src/Ice/SSL/OpenSSLEngine.cpp
+++ b/cpp/src/Ice/SSL/OpenSSLEngine.cpp
@@ -98,6 +98,10 @@ OpenSSL::SSLEngine::initialize()
             throw InitializationException(__FILE__, __LINE__, "IceSSL: unable to create SSL context:\n" + sslErrors());
         }
 
+        // Reject peer-initiated TLS renegotiation: it is a CPU-asymmetric denial-of-service primitive
+        // on TLS 1.2 and is removed entirely in TLS 1.3.
+        SSL_CTX_set_options(_ctx, SSL_OP_NO_RENEGOTIATION);
+
         // Check for a default directory. We look in this directory for files mentioned in the configuration.
         const string defaultDir = properties->getIceProperty("IceSSL.DefaultDir");
 

--- a/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
+++ b/cpp/src/Ice/SSL/SchannelTransceiverI.cpp
@@ -552,6 +552,15 @@ Schannel::TransceiverI::decryptMessage(IceInternal::Buffer& buffer)
         }
         else if (err == SEC_I_RENEGOTIATE)
         {
+            if (_incoming)
+            {
+                // Reject peer-initiated TLS renegotiation on the server side: it is a CPU-asymmetric
+                // denial-of-service primitive on TLS 1.2 and is removed entirely in TLS 1.3.
+                throw ProtocolException(
+                    __FILE__,
+                    __LINE__,
+                    "SSL transport: peer-initiated TLS renegotiation is not supported on the server side.");
+            }
             if (_sslConnectionRenegotiating)
             {
                 throw ProtocolException(


### PR DESCRIPTION
Disable peer-initiated TLS renegotiation in the OpenSSL and Schannel SSL transports:

- **OpenSSL**: set `SSL_OP_NO_RENEGOTIATION` on the `SSL_CTX`.
- **Schannel**: `SEC_I_RENEGOTIATE` now throws `ProtocolException` instead of entering the renegotiation state machine. The now-unreachable renegotiation-handling code (`_sslConnectionRenegotiating`, `_extraBuffer`, the two handshake re-entry paths) is removed in the same change.

The SecureTransport (macOS) transport doesn't expose renegotiation to Ice — `SSLRead` returns the request as an SSL error, which already throws `ProtocolException`. No change needed there.

Resolves zeroc-ice/ice-audit#20.