### PR TITLE
Fix alignment-unsafe 16-bit reads and writes in the WebSocket transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ These are the changes since the [Ice 3.8.1] release.
 
 ### C++ Changes
 
+- Fixed alignment-unsafe 16-bit reads and writes in the WebSocket transport.
+
 - Changed the macOS SSL transport to require TLS 1.2 or later.
 
 - Changed the mapping of `@p [NAME]` tags which reference out parameters in Slice. These now generate `` `[NAME]` ``

--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -1228,7 +1228,10 @@ IceInternal::WSTransceiver::preRead(Buffer& buf)
 
             if (_readPayloadLength == 126)
             {
-                _readPayloadLength = static_cast<size_t>(ntohs(*reinterpret_cast<uint16_t*>(_readI)));
+                // memcpy avoids the alignment UB of a direct uint16_t* dereference on _readI.
+                uint16_t length;
+                memcpy(&length, _readI, sizeof(length));
+                _readPayloadLength = static_cast<size_t>(ntohs(length));
                 _readI += 2;
             }
             else if (_readPayloadLength == 127)
@@ -1501,8 +1504,9 @@ IceInternal::WSTransceiver::preWrite(Buffer& buf)
         {
             prepareWriteHeader(OP_CLOSE, 2);
 
-            // Write closing reason
-            *reinterpret_cast<uint16_t*>(_writeBuffer.i) = htons(static_cast<uint16_t>(_closingReason));
+            // Write closing reason. memcpy avoids the alignment UB of a direct uint16_t* store.
+            const uint16_t reason = htons(static_cast<uint16_t>(_closingReason));
+            memcpy(_writeBuffer.i, &reason, sizeof(reason));
             if (!_incoming)
             {
                 *_writeBuffer.i++ ^= _writeMask[0];
@@ -1722,7 +1726,9 @@ IceInternal::WSTransceiver::prepareWriteHeader(uint8_t opCode, IceInternal::Buff
         // Use an extra 16 bits to encode the payload length.
         //
         *_writeBuffer.i++ = byte{126};
-        *reinterpret_cast<uint16_t*>(_writeBuffer.i) = htons(static_cast<uint16_t>(payloadLength));
+        // memcpy avoids the alignment UB of a direct uint16_t* store.
+        const uint16_t length = htons(static_cast<uint16_t>(payloadLength));
+        memcpy(_writeBuffer.i, &length, sizeof(length));
         _writeBuffer.i += 2;
     }
     else if (payloadLength > USHRT_MAX)


### PR DESCRIPTION
Replace three `reinterpret_cast<uint16_t*>` dereferences on the byte-aligned WebSocket frame buffer with `memcpy`-based loads/stores. The cast pattern is undefined behavior under the C++ standard and triggers a hardware alignment trap (`SIGBUS`) on strict-alignment architectures (ARMv7, some ARMv8, SPARC) when the buffer position is not 2-byte aligned. The 64-bit length path in the same file already uses byte-wise helpers (`ice_htonll` / `ice_nlltoh`); the 16-bit sites are aligned with that pattern.

x86/x64 behavior is unchanged — the compiler emits a single load/store for `memcpy` of a fixed 2-byte size.

Resolves zeroc-ice/ice-audit#32.