### PR TITLE
Reject an IP endpoint port outside the 0..65535 range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ These are the changes since the [Ice 3.8.1] release.
 
 - Fixed the unmarshaling of batch requests to reject a request count larger than the message can hold.
 
+- Fixed the unmarshaling of IP endpoints to reject a port value outside the 0..65535 range.
+
 ### Slice Language Changes
 
 - Added the `["oneway"]` metadata directive for Slice operations. This directive can only be applied to operations that

--- a/cpp/src/Ice/IPEndpointI.cpp
+++ b/cpp/src/Ice/IPEndpointI.cpp
@@ -419,6 +419,10 @@ IceInternal::IPEndpointI::IPEndpointI(ProtocolInstancePtr instance, InputStream*
     s->read(const_cast<string&>(_host), false);
     const_cast<string&>(_normalizedHost) = normalizeIPv6Address(_host);
     s->read(const_cast<int32_t&>(_port));
+    if (_port < 0 || _port > 65535)
+    {
+        throw MarshalException{__FILE__, __LINE__, "port value '" + to_string(_port) + "' out of range in endpoint"};
+    }
 }
 
 IceInternal::EndpointHostResolver::EndpointHostResolver(const InstancePtr& instance)

--- a/cpp/src/Ice/IPEndpointI.cpp
+++ b/cpp/src/Ice/IPEndpointI.cpp
@@ -421,7 +421,7 @@ IceInternal::IPEndpointI::IPEndpointI(ProtocolInstancePtr instance, InputStream*
     s->read(const_cast<int32_t&>(_port));
     if (_port < 0 || _port > 65535)
     {
-        throw MarshalException{__FILE__, __LINE__, "port value '" + to_string(_port) + "' out of range in endpoint"};
+        throw MarshalException{__FILE__, __LINE__, "port value '" + to_string(_port) + "' is out of range"};
     }
 }
 

--- a/csharp/src/Ice/Internal/IPEndpointI.cs
+++ b/csharp/src/Ice/Internal/IPEndpointI.cs
@@ -33,6 +33,10 @@ public abstract class IPEndpointI : EndpointI
         host_ = s.readString();
         _normalizedHost = normalizeHost(host_);
         port_ = s.readInt();
+        if (port_ < 0 || port_ > 65535)
+        {
+            throw new MarshalException($"port value '{port_}' out of range in endpoint");
+        }
         sourceAddr_ = null;
         connectionId_ = "";
     }

--- a/csharp/src/Ice/Internal/IPEndpointI.cs
+++ b/csharp/src/Ice/Internal/IPEndpointI.cs
@@ -35,7 +35,7 @@ public abstract class IPEndpointI : EndpointI
         port_ = s.readInt();
         if (port_ < 0 || port_ > 65535)
         {
-            throw new MarshalException($"port value '{port_}' out of range in endpoint");
+            throw new MarshalException($"port value '{port_}' is out of range");
         }
         sourceAddr_ = null;
         connectionId_ = "";

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IPEndpointI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IPEndpointI.java
@@ -29,7 +29,15 @@ abstract class IPEndpointI extends EndpointI {
     }
 
     protected IPEndpointI(ProtocolInstance instance, InputStream s) {
-        this(instance, s.readString(), s.readInt(), null, "");
+        this(instance, s.readString(), readPort(s), null, "");
+    }
+
+    private static int readPort(InputStream s) {
+        int port = s.readInt();
+        if (port < 0 || port > 65535) {
+            throw new MarshalException("port value '" + port + "' out of range in endpoint");
+        }
+        return port;
     }
 
     @Override

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IPEndpointI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IPEndpointI.java
@@ -17,7 +17,7 @@ abstract class IPEndpointI extends EndpointI {
             InetSocketAddress sourceAddr,
             String connectionId) {
         if (port < 0 || port > 65535) {
-            throw new MarshalException("port value '" + port + "' out of range in endpoint");
+            throw new MarshalException("port value '" + port + "' is out of range");
         }
         _instance = instance;
         _host = host;

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IPEndpointI.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/IPEndpointI.java
@@ -16,6 +16,9 @@ abstract class IPEndpointI extends EndpointI {
             int port,
             InetSocketAddress sourceAddr,
             String connectionId) {
+        if (port < 0 || port > 65535) {
+            throw new MarshalException("port value '" + port + "' out of range in endpoint");
+        }
         _instance = instance;
         _host = host;
         _normalizedHost = normalizeHost(host);
@@ -29,15 +32,7 @@ abstract class IPEndpointI extends EndpointI {
     }
 
     protected IPEndpointI(ProtocolInstance instance, InputStream s) {
-        this(instance, s.readString(), readPort(s), null, "");
-    }
-
-    private static int readPort(InputStream s) {
-        int port = s.readInt();
-        if (port < 0 || port > 65535) {
-            throw new MarshalException("port value '" + port + "' out of range in endpoint");
-        }
-        return port;
+        this(instance, s.readString(), s.readInt(), null, "");
     }
 
     @Override

--- a/js/packages/ice/src/Ice/IPEndpointI.js
+++ b/js/packages/ice/src/Ice/IPEndpointI.js
@@ -192,7 +192,7 @@ export class IPEndpointI extends EndpointI {
         this._host = s.readString();
         this._port = s.readInt();
         if (this._port < 0 || this._port > 65535) {
-            throw new MarshalException(`port value '${this._port}' out of range in endpoint`);
+            throw new MarshalException(`port value '${this._port}' is out of range`);
         }
     }
 

--- a/js/packages/ice/src/Ice/IPEndpointI.js
+++ b/js/packages/ice/src/Ice/IPEndpointI.js
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 import { Address } from "./Address.js";
-import { ParseException } from "./LocalExceptions.js";
+import { MarshalException, ParseException } from "./LocalExceptions.js";
 import { HashUtil } from "./HashUtil.js";
 import { StringUtil } from "./StringUtil.js";
 import { EndpointI } from "./EndpointI.js";
@@ -191,6 +191,9 @@ export class IPEndpointI extends EndpointI {
     initWithStream(s) {
         this._host = s.readString();
         this._port = s.readInt();
+        if (this._port < 0 || this._port > 65535) {
+            throw new MarshalException(`port value '${this._port}' out of range in endpoint`);
+        }
     }
 
     checkOption(option, argument, str) {


### PR DESCRIPTION
## Summary

- C++, C#, Java, and JavaScript: validate the `port` field while unmarshaling an `IPEndpointI` and throw `MarshalException` if it falls outside 0..65535.
- Add a CHANGELOG entry under General Changes.

## Test plan

- [ ] CI green across language mappings