### PR TITLE
Reject a zero entry in a class indirection table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ These are the changes since the [Ice 3.8.1] release.
 
 - Fixed the unmarshaling of IP endpoints to reject a port value outside the 0..65535 range.
 
+- Fixed the unmarshaling of class indirection tables to reject a zero-valued entry.
+
 ### Slice Language Changes
 
 - Added the `["oneway"]` metadata directive for Slice operations. This directive can only be applied to operations that

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -1961,7 +1961,12 @@ Ice::InputStream::EncapsDecoder11::endSlice()
         IndexList indirectionTable(static_cast<size_t>(_stream->readAndCheckSeqSize(1)));
         for (auto& p : indirectionTable)
         {
-            p = readInstance(_stream->readSize(), nullptr, nullptr);
+            int32_t i = _stream->readSize();
+            if (i <= 0)
+            {
+                throw MarshalException(__FILE__, __LINE__, "invalid indirection-table index");
+            }
+            p = readInstance(i, nullptr, nullptr);
         }
 
         //
@@ -2070,7 +2075,12 @@ Ice::InputStream::EncapsDecoder11::skipSlice()
         table.resize(static_cast<size_t>(_stream->readAndCheckSeqSize(1)));
         for (auto& entry : table)
         {
-            entry = readInstance(_stream->readSize(), nullptr, nullptr);
+            int32_t i = _stream->readSize();
+            if (i <= 0)
+            {
+                throw MarshalException(__FILE__, __LINE__, "invalid indirection-table index");
+            }
+            entry = readInstance(i, nullptr, nullptr);
         }
     }
 }

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -1961,12 +1961,7 @@ Ice::InputStream::EncapsDecoder11::endSlice()
         IndexList indirectionTable(static_cast<size_t>(_stream->readAndCheckSeqSize(1)));
         for (auto& p : indirectionTable)
         {
-            int32_t index = _stream->readSize();
-            if (index <= 0)
-            {
-                throw MarshalException(__FILE__, __LINE__, "invalid indirection-table index");
-            }
-            p = readInstance(index, nullptr, nullptr);
+            p = readInstance(_stream->readSize(), nullptr, nullptr);
         }
 
         //
@@ -2075,12 +2070,7 @@ Ice::InputStream::EncapsDecoder11::skipSlice()
         table.resize(static_cast<size_t>(_stream->readAndCheckSeqSize(1)));
         for (auto& entry : table)
         {
-            int32_t index = _stream->readSize();
-            if (index <= 0)
-            {
-                throw MarshalException(__FILE__, __LINE__, "invalid indirection-table index");
-            }
-            entry = readInstance(index, nullptr, nullptr);
+            entry = readInstance(_stream->readSize(), nullptr, nullptr);
         }
     }
 }
@@ -2102,7 +2092,10 @@ Ice::InputStream::EncapsDecoder11::readOptional(int32_t readTag, Ice::OptionalFo
 int32_t
 Ice::InputStream::EncapsDecoder11::readInstance(int32_t index, const PatchFunc& patchFunc, void* patchAddr)
 {
-    assert(index > 0);
+    if (index <= 0)
+    {
+        throw MarshalException(__FILE__, __LINE__, "invalid class instance index");
+    }
 
     if (index > 1)
     {

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -1961,12 +1961,12 @@ Ice::InputStream::EncapsDecoder11::endSlice()
         IndexList indirectionTable(static_cast<size_t>(_stream->readAndCheckSeqSize(1)));
         for (auto& p : indirectionTable)
         {
-            int32_t i = _stream->readSize();
-            if (i <= 0)
+            int32_t index = _stream->readSize();
+            if (index <= 0)
             {
                 throw MarshalException(__FILE__, __LINE__, "invalid indirection-table index");
             }
-            p = readInstance(i, nullptr, nullptr);
+            p = readInstance(index, nullptr, nullptr);
         }
 
         //
@@ -2075,12 +2075,12 @@ Ice::InputStream::EncapsDecoder11::skipSlice()
         table.resize(static_cast<size_t>(_stream->readAndCheckSeqSize(1)));
         for (auto& entry : table)
         {
-            int32_t i = _stream->readSize();
-            if (i <= 0)
+            int32_t index = _stream->readSize();
+            if (index <= 0)
             {
                 throw MarshalException(__FILE__, __LINE__, "invalid indirection-table index");
             }
-            entry = readInstance(i, nullptr, nullptr);
+            entry = readInstance(index, nullptr, nullptr);
         }
     }
 }

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -2629,12 +2629,7 @@ public sealed class InputStream
                 int[] indirectionTable = new int[_stream.readAndCheckSeqSize(1)];
                 for (int i = 0; i < indirectionTable.Length; ++i)
                 {
-                    int index = _stream.readSize();
-                    if (index <= 0)
-                    {
-                        throw new MarshalException("invalid indirection-table index");
-                    }
-                    indirectionTable[i] = readInstance(index, null);
+                    indirectionTable[i] = readInstance(_stream.readSize(), null);
                 }
 
                 //
@@ -2755,12 +2750,7 @@ public sealed class InputStream
                 int[] indirectionTable = new int[_stream.readAndCheckSeqSize(1)];
                 for (int i = 0; i < indirectionTable.Length; ++i)
                 {
-                    int index = _stream.readSize();
-                    if (index <= 0)
-                    {
-                        throw new MarshalException("invalid indirection-table index");
-                    }
-                    indirectionTable[i] = readInstance(index, null);
+                    indirectionTable[i] = readInstance(_stream.readSize(), null);
                 }
                 _current.indirectionTables.Add(indirectionTable);
             }
@@ -2785,7 +2775,10 @@ public sealed class InputStream
 
         private int readInstance(int index, System.Action<Value>? cb)
         {
-            Debug.Assert(index > 0);
+            if (index <= 0)
+            {
+                throw new MarshalException("invalid class instance index");
+            }
 
             if (index > 1)
             {

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -2629,7 +2629,12 @@ public sealed class InputStream
                 int[] indirectionTable = new int[_stream.readAndCheckSeqSize(1)];
                 for (int i = 0; i < indirectionTable.Length; ++i)
                 {
-                    indirectionTable[i] = readInstance(_stream.readSize(), null);
+                    int index = _stream.readSize();
+                    if (index <= 0)
+                    {
+                        throw new MarshalException("invalid indirection-table index");
+                    }
+                    indirectionTable[i] = readInstance(index, null);
                 }
 
                 //
@@ -2750,7 +2755,12 @@ public sealed class InputStream
                 int[] indirectionTable = new int[_stream.readAndCheckSeqSize(1)];
                 for (int i = 0; i < indirectionTable.Length; ++i)
                 {
-                    indirectionTable[i] = readInstance(_stream.readSize(), null);
+                    int index = _stream.readSize();
+                    if (index <= 0)
+                    {
+                        throw new MarshalException("invalid indirection-table index");
+                    }
+                    indirectionTable[i] = readInstance(index, null);
                 }
                 _current.indirectionTables.Add(indirectionTable);
             }

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -1964,7 +1964,11 @@ public final class InputStream {
                 // The table is written as a sequence<size> to conserve space.
                 int[] indirectionTable = new int[_stream.readAndCheckSeqSize(1)];
                 for (int i = 0; i < indirectionTable.length; i++) {
-                    indirectionTable[i] = readInstance(_stream.readSize(), null);
+                    int index = _stream.readSize();
+                    if (index <= 0) {
+                        throw new MarshalException("invalid indirection-table index");
+                    }
+                    indirectionTable[i] = readInstance(index, null);
                 }
 
                 // Sanity checks. If there are optional members, it's possible that not all instance
@@ -2057,7 +2061,11 @@ public final class InputStream {
             if ((_current.sliceFlags & Protocol.FLAG_HAS_INDIRECTION_TABLE) != 0) {
                 int[] indirectionTable = new int[_stream.readAndCheckSeqSize(1)];
                 for (int i = 0; i < indirectionTable.length; i++) {
-                    indirectionTable[i] = readInstance(_stream.readSize(), null);
+                    int index = _stream.readSize();
+                    if (index <= 0) {
+                        throw new MarshalException("invalid indirection-table index");
+                    }
+                    indirectionTable[i] = readInstance(index, null);
                 }
                 _current.indirectionTables.add(indirectionTable);
             } else {

--- a/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/com.zeroc.ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -1964,11 +1964,7 @@ public final class InputStream {
                 // The table is written as a sequence<size> to conserve space.
                 int[] indirectionTable = new int[_stream.readAndCheckSeqSize(1)];
                 for (int i = 0; i < indirectionTable.length; i++) {
-                    int index = _stream.readSize();
-                    if (index <= 0) {
-                        throw new MarshalException("invalid indirection-table index");
-                    }
-                    indirectionTable[i] = readInstance(index, null);
+                    indirectionTable[i] = readInstance(_stream.readSize(), null);
                 }
 
                 // Sanity checks. If there are optional members, it's possible that not all instance
@@ -2061,11 +2057,7 @@ public final class InputStream {
             if ((_current.sliceFlags & Protocol.FLAG_HAS_INDIRECTION_TABLE) != 0) {
                 int[] indirectionTable = new int[_stream.readAndCheckSeqSize(1)];
                 for (int i = 0; i < indirectionTable.length; i++) {
-                    int index = _stream.readSize();
-                    if (index <= 0) {
-                        throw new MarshalException("invalid indirection-table index");
-                    }
-                    indirectionTable[i] = readInstance(index, null);
+                    indirectionTable[i] = readInstance(_stream.readSize(), null);
                 }
                 _current.indirectionTables.add(indirectionTable);
             } else {
@@ -2084,7 +2076,9 @@ public final class InputStream {
         }
 
         private int readInstance(int index, Consumer<Value> cb) {
-            assert (index > 0);
+            if (index <= 0) {
+                throw new MarshalException("invalid class instance index");
+            }
 
             if (index > 1) {
                 if (cb != null) {

--- a/js/packages/ice/src/Ice/InputStream.js
+++ b/js/packages/ice/src/Ice/InputStream.js
@@ -567,7 +567,11 @@ class EncapsDecoder11 extends EncapsDecoder {
             //
             const length = this._stream.readAndCheckSeqSize(1);
             for (let i = 0; i < length; ++i) {
-                indirectionTable[i] = this.readInstance(this._stream.readSize(), null);
+                const index = this._stream.readSize();
+                if (index <= 0) {
+                    throw new MarshalException("invalid indirection-table index");
+                }
+                indirectionTable[i] = this.readInstance(index, null);
             }
 
             //
@@ -661,7 +665,11 @@ class EncapsDecoder11 extends EncapsDecoder {
             const length = this._stream.readAndCheckSeqSize(1);
             const indirectionTable = [];
             for (let i = 0; i < length; ++i) {
-                indirectionTable[i] = this.readInstance(this._stream.readSize(), null);
+                const index = this._stream.readSize();
+                if (index <= 0) {
+                    throw new MarshalException("invalid indirection-table index");
+                }
+                indirectionTable[i] = this.readInstance(index, null);
             }
             this._current.indirectionTables.push(indirectionTable);
         } else {

--- a/js/packages/ice/src/Ice/InputStream.js
+++ b/js/packages/ice/src/Ice/InputStream.js
@@ -567,11 +567,7 @@ class EncapsDecoder11 extends EncapsDecoder {
             //
             const length = this._stream.readAndCheckSeqSize(1);
             for (let i = 0; i < length; ++i) {
-                const index = this._stream.readSize();
-                if (index <= 0) {
-                    throw new MarshalException("invalid indirection-table index");
-                }
-                indirectionTable[i] = this.readInstance(index, null);
+                indirectionTable[i] = this.readInstance(this._stream.readSize(), null);
             }
 
             //
@@ -665,11 +661,7 @@ class EncapsDecoder11 extends EncapsDecoder {
             const length = this._stream.readAndCheckSeqSize(1);
             const indirectionTable = [];
             for (let i = 0; i < length; ++i) {
-                const index = this._stream.readSize();
-                if (index <= 0) {
-                    throw new MarshalException("invalid indirection-table index");
-                }
-                indirectionTable[i] = this.readInstance(index, null);
+                indirectionTable[i] = this.readInstance(this._stream.readSize(), null);
             }
             this._current.indirectionTables.push(indirectionTable);
         } else {
@@ -689,7 +681,9 @@ class EncapsDecoder11 extends EncapsDecoder {
     }
 
     readInstance(index, cb) {
-        console.assert(index > 0);
+        if (index <= 0) {
+            throw new MarshalException("invalid class instance index");
+        }
 
         let v = null;
 

--- a/matlab/lib/+IceInternal/EncapsDecoder11.m
+++ b/matlab/lib/+IceInternal/EncapsDecoder11.m
@@ -186,11 +186,7 @@ classdef (Hidden) EncapsDecoder11 < IceInternal.EncapsDecoder
                 sz = is.readAndCheckSeqSize(1);
                 indirectionTable = cell(1, sz);
                 for i = 1:sz
-                    index = is.readSize();
-                    if index <= 0
-                        throw(Ice.MarshalException('invalid indirection-table index'));
-                    end
-                    indirectionTable{i} = obj.readInstance(index, []);
+                    indirectionTable{i} = obj.readInstance(is.readSize(), []);
                 end
 
                 %
@@ -277,11 +273,7 @@ classdef (Hidden) EncapsDecoder11 < IceInternal.EncapsDecoder
                 sz = is.readAndCheckSeqSize(1);
                 indirectionTable = cell(1, sz);
                 for i = 1:sz
-                    index = is.readSize();
-                    if index <= 0
-                        throw(Ice.MarshalException('invalid indirection-table index'));
-                    end
-                    indirectionTable{i} = obj.readInstance(index, []);
+                    indirectionTable{i} = obj.readInstance(is.readSize(), []);
                 end
                 current.indirectionTables{end + 1} = indirectionTable;
             else
@@ -292,7 +284,9 @@ classdef (Hidden) EncapsDecoder11 < IceInternal.EncapsDecoder
     methods (Access = private)
         function r = readInstance(obj, index, cb)
             import IceInternal.Protocol;
-            %assert(index > 0);
+            if index <= 0
+                throw(Ice.MarshalException('invalid class instance index'));
+            end
 
             if index > 1
                 if ~isempty(cb)

--- a/matlab/lib/+IceInternal/EncapsDecoder11.m
+++ b/matlab/lib/+IceInternal/EncapsDecoder11.m
@@ -186,7 +186,11 @@ classdef (Hidden) EncapsDecoder11 < IceInternal.EncapsDecoder
                 sz = is.readAndCheckSeqSize(1);
                 indirectionTable = cell(1, sz);
                 for i = 1:sz
-                    indirectionTable{i} = obj.readInstance(is.readSize(), []);
+                    index = is.readSize();
+                    if index <= 0
+                        throw(Ice.MarshalException('invalid indirection-table index'));
+                    end
+                    indirectionTable{i} = obj.readInstance(index, []);
                 end
 
                 %
@@ -273,7 +277,11 @@ classdef (Hidden) EncapsDecoder11 < IceInternal.EncapsDecoder
                 sz = is.readAndCheckSeqSize(1);
                 indirectionTable = cell(1, sz);
                 for i = 1:sz
-                    indirectionTable{i} = obj.readInstance(is.readSize(), []);
+                    index = is.readSize();
+                    if index <= 0
+                        throw(Ice.MarshalException('invalid indirection-table index'));
+                    end
+                    indirectionTable{i} = obj.readInstance(index, []);
                 end
                 current.indirectionTables{end + 1} = indirectionTable;
             else

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -1441,11 +1441,7 @@ private class EncapsDecoder11: EncapsDecoder {
                 repeating: 0, count: Int(stream.readAndCheckSeqSize(minSize: 1)))
 
             for i in 0..<indirectionTable.count {
-                let index = try stream.readSize()
-                if index <= 0 {
-                    throw MarshalException("invalid indirection-table index")
-                }
-                indirectionTable[i] = try readInstance(index: index, cb: nil)
+                indirectionTable[i] = try readInstance(index: stream.readSize(), cb: nil)
             }
 
             //
@@ -1535,11 +1531,7 @@ private class EncapsDecoder11: EncapsDecoder {
                 repeating: 0, count: Int(stream.readAndCheckSeqSize(minSize: 1)))
 
             for i in 0..<indirectionTable.count {
-                let index = try stream.readSize()
-                if index <= 0 {
-                    throw MarshalException("invalid indirection-table index")
-                }
-                indirectionTable[i] = try readInstance(index: index, cb: nil)
+                indirectionTable[i] = try readInstance(index: stream.readSize(), cb: nil)
             }
             current.indirectionTables.append(indirectionTable)
         } else {
@@ -1557,7 +1549,9 @@ private class EncapsDecoder11: EncapsDecoder {
     }
 
     func readInstance(index: Int32, cb: Callback?) throws -> Int32 {
-        precondition(index > 0)
+        if index <= 0 {
+            throw MarshalException("invalid class instance index")
+        }
 
         if index > 1 {
             if let cb = cb {

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -1441,7 +1441,11 @@ private class EncapsDecoder11: EncapsDecoder {
                 repeating: 0, count: Int(stream.readAndCheckSeqSize(minSize: 1)))
 
             for i in 0..<indirectionTable.count {
-                indirectionTable[i] = try readInstance(index: stream.readSize(), cb: nil)
+                let index = try stream.readSize()
+                if index <= 0 {
+                    throw MarshalException("invalid indirection-table index")
+                }
+                indirectionTable[i] = try readInstance(index: index, cb: nil)
             }
 
             //
@@ -1531,7 +1535,11 @@ private class EncapsDecoder11: EncapsDecoder {
                 repeating: 0, count: Int(stream.readAndCheckSeqSize(minSize: 1)))
 
             for i in 0..<indirectionTable.count {
-                indirectionTable[i] = try readInstance(index: stream.readSize(), cb: nil)
+                let index = try stream.readSize()
+                if index <= 0 {
+                    throw MarshalException("invalid indirection-table index")
+                }
+                indirectionTable[i] = try readInstance(index: index, cb: nil)
             }
             current.indirectionTables.append(indirectionTable)
         } else {


### PR DESCRIPTION
## Summary

- In `EncapsDecoder11::endSlice` and `EncapsDecoder11::skipSlice` (C++, C#, Java), check the value returned by `readSize()` for each indirection-table entry and throw `MarshalException` if it is `<= 0`. Mirrors the validation that the public `read(...)` entry point already performs, so the private `readInstance` helper's `index > 0` precondition holds for every caller.
- Without this guard a wire-encoded zero indirection-table index reaches `assert(index > 0)` in `readInstance` — which aborts debug builds (remote DoS in debug mode) and silently synthesizes a new instance ID in release builds.

## Test plan

- [ ] CI green across language mappings