### PR TITLE
Remove SSLEngine::destroy and rely on the destructor for cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ These are the changes since the [Ice 3.8.1] release.
 
 - Changed the macOS SSL transport to enable only forward-secret (ECDHE) cipher suites.
 
+- Fixed a resource leak in the SSL engine. The Schannel and OpenSSL engines now release their
+  certificate stores, chain engines, imported key sets, and `SSL_CTX` when the communicator is
+  destroyed.
+
 - Changed the mapping of `@p [NAME]` tags which reference out parameters in Slice. These now generate `` `[NAME]` ``
   instead of `@p [NAME]`.
 

--- a/cpp/src/Ice/SSL/OpenSSLEngine.cpp
+++ b/cpp/src/Ice/SSL/OpenSSLEngine.cpp
@@ -72,7 +72,14 @@ namespace
 
 OpenSSL::SSLEngine::SSLEngine(const IceInternal::InstancePtr& instance) : Ice::SSL::SSLEngine(instance) {}
 
-OpenSSL::SSLEngine::~SSLEngine() = default;
+OpenSSL::SSLEngine::~SSLEngine()
+{
+    if (_ctx)
+    {
+        SSL_CTX_free(_ctx);
+        _ctx = nullptr;
+    }
+}
 
 void
 OpenSSL::SSLEngine::initialize()
@@ -508,14 +515,4 @@ string
 OpenSSL::SSLEngine::sslErrors() const
 {
     return getErrors();
-}
-
-void
-OpenSSL::SSLEngine::destroy()
-{
-    if (_ctx)
-    {
-        SSL_CTX_free(_ctx);
-        _ctx = nullptr;
-    }
 }

--- a/cpp/src/Ice/SSL/OpenSSLEngine.h
+++ b/cpp/src/Ice/SSL/OpenSSLEngine.h
@@ -17,10 +17,9 @@ namespace Ice::SSL::OpenSSL
     {
     public:
         SSLEngine(const IceInternal::InstancePtr&);
-        ~SSLEngine();
+        ~SSLEngine() override;
 
         void initialize() final;
-        void destroy() final;
         [[nodiscard]] std::string sslErrors() const;
         [[nodiscard]] std::string password() const { return _password; }
         [[nodiscard]] Ice::SSL::ClientAuthenticationOptions

--- a/cpp/src/Ice/SSL/SSLEngine.h
+++ b/cpp/src/Ice/SSL/SSLEngine.h
@@ -23,7 +23,7 @@ namespace Ice::SSL
     {
     public:
         SSLEngine(const IceInternal::InstancePtr&);
-        ~SSLEngine();
+        virtual ~SSLEngine();
 
         [[nodiscard]] Ice::LoggerPtr getLogger() const;
         [[nodiscard]] Ice::PropertiesPtr getProperties() const;
@@ -33,9 +33,6 @@ namespace Ice::SSL
 
         // Setup the engine.
         virtual void initialize() = 0;
-
-        // Destroy the engine.
-        virtual void destroy() = 0;
 
         // Verify peer certificate.
         virtual void verifyPeer(const ConnectionInfoPtr&) const;

--- a/cpp/src/Ice/SSL/SchannelEngine.cpp
+++ b/cpp/src/Ice/SSL/SchannelEngine.cpp
@@ -743,6 +743,56 @@ Schannel::SSLEngine::SSLEngine(const IceInternal::InstancePtr& instance)
 {
 }
 
+Schannel::SSLEngine::~SSLEngine()
+{
+    // Best-effort cleanup. We catch every exception (e.g. std::bad_alloc from the per-cert vector
+    // allocation below) so nothing escapes the destructor and triggers std::terminate.
+    try
+    {
+        if (_chainEngine && _chainEngine != HCCE_CURRENT_USER && _chainEngine != HCCE_LOCAL_MACHINE)
+        {
+            CertFreeCertificateChainEngine(_chainEngine);
+        }
+
+        if (_rootStore)
+        {
+            CertCloseStore(_rootStore, 0);
+        }
+
+        for (vector<PCCERT_CONTEXT>::const_iterator i = _importedCerts.begin(); i != _importedCerts.end(); ++i)
+        {
+            // Retrieve the certificate CERT_KEY_PROV_INFO_PROP_ID property, we use the CRYPT_KEY_PROV_INFO data to
+            // remove the key set associated with the certificate.
+            DWORD length = 0;
+            if (!CertGetCertificateContextProperty(*i, CERT_KEY_PROV_INFO_PROP_ID, 0, &length))
+            {
+                continue;
+            }
+            vector<char> buf(length);
+            if (!CertGetCertificateContextProperty(*i, CERT_KEY_PROV_INFO_PROP_ID, &buf[0], &length))
+            {
+                continue;
+            }
+            CRYPT_KEY_PROV_INFO* key = reinterpret_cast<CRYPT_KEY_PROV_INFO*>(&buf[0]);
+            HCRYPTPROV prov = 0;
+            CryptAcquireContextW(&prov, key->pwszContainerName, key->pwszProvName, key->dwProvType, CRYPT_DELETEKEYSET);
+        }
+
+        for (vector<PCCERT_CONTEXT>::const_iterator i = _allCerts.begin(); i != _allCerts.end(); ++i)
+        {
+            CertFreeCertificateContext(*i);
+        }
+
+        for (vector<HCERTSTORE>::const_iterator i = _stores.begin(); i != _stores.end(); ++i)
+        {
+            CertCloseStore(*i, 0);
+        }
+    }
+    catch (...)
+    {
+    }
+}
+
 void
 Schannel::SSLEngine::initialize()
 {
@@ -1207,49 +1257,6 @@ Schannel::SSLEngine::getCipherName(ALG_ID cipher) const
             os << "Unknown cipher: " << cipher;
             return os.str();
         }
-    }
-}
-
-void
-Schannel::SSLEngine::destroy()
-{
-    if (_chainEngine && _chainEngine != HCCE_CURRENT_USER && _chainEngine != HCCE_LOCAL_MACHINE)
-    {
-        CertFreeCertificateChainEngine(_chainEngine);
-    }
-
-    if (_rootStore)
-    {
-        CertCloseStore(_rootStore, 0);
-    }
-
-    for (vector<PCCERT_CONTEXT>::const_iterator i = _importedCerts.begin(); i != _importedCerts.end(); ++i)
-    {
-        // Retrieve the certificate CERT_KEY_PROV_INFO_PROP_ID property, we use the CRYPT_KEY_PROV_INFO data to remove
-        // the key set associated with the certificate.
-        DWORD length = 0;
-        if (!CertGetCertificateContextProperty(*i, CERT_KEY_PROV_INFO_PROP_ID, 0, &length))
-        {
-            continue;
-        }
-        vector<char> buf(length);
-        if (!CertGetCertificateContextProperty(*i, CERT_KEY_PROV_INFO_PROP_ID, &buf[0], &length))
-        {
-            continue;
-        }
-        CRYPT_KEY_PROV_INFO* key = reinterpret_cast<CRYPT_KEY_PROV_INFO*>(&buf[0]);
-        HCRYPTPROV prov = 0;
-        CryptAcquireContextW(&prov, key->pwszContainerName, key->pwszProvName, key->dwProvType, CRYPT_DELETEKEYSET);
-    }
-
-    for (vector<PCCERT_CONTEXT>::const_iterator i = _allCerts.begin(); i != _allCerts.end(); ++i)
-    {
-        CertFreeCertificateContext(*i);
-    }
-
-    for (vector<HCERTSTORE>::const_iterator i = _stores.begin(); i != _stores.end(); ++i)
-    {
-        CertCloseStore(*i, 0);
     }
 }
 

--- a/cpp/src/Ice/SSL/SchannelEngine.h
+++ b/cpp/src/Ice/SSL/SchannelEngine.h
@@ -22,16 +22,12 @@ namespace Ice::SSL::Schannel
     {
     public:
         SSLEngine(const IceInternal::InstancePtr&);
+        ~SSLEngine() override;
 
         //
         // Setup the engine.
         //
         void initialize() final;
-
-        //
-        // Destroy the engine.
-        //
-        void destroy() final;
 
         [[nodiscard]] std::string getCipherName(ALG_ID) const;
 

--- a/cpp/src/Ice/SSL/SecureTransportEngine.cpp
+++ b/cpp/src/Ice/SSL/SecureTransportEngine.cpp
@@ -651,14 +651,6 @@ SecureTransport::SSLEngine::initialize()
     }
 }
 
-//
-// Destroy the engine.
-//
-void
-SecureTransport::SSLEngine::destroy()
-{
-}
-
 ClientAuthenticationOptions
 SecureTransport::SSLEngine::createClientAuthenticationOptions(const string& host) const
 {

--- a/cpp/src/Ice/SSL/SecureTransportEngine.h
+++ b/cpp/src/Ice/SSL/SecureTransportEngine.h
@@ -20,10 +20,9 @@ namespace Ice::SSL::SecureTransport
     {
     public:
         SSLEngine(const IceInternal::InstancePtr&);
-        ~SSLEngine();
+        ~SSLEngine() override;
 
         void initialize() final;
-        void destroy() final;
 
         [[nodiscard]] Ice::SSL::ClientAuthenticationOptions
         createClientAuthenticationOptions(const std::string& host) const final;


### PR DESCRIPTION
## Summary

`Ice::SSL::SSLEngine::destroy()` is never called: `IceInternal::Instance` creates the engine, calls `initialize()`, and only releases the `shared_ptr` in `Instance::destroy()` (no explicit `_sslEngine->destroy()`). As a result, the cleanup in each subclass `destroy()` body never ran on shutdown, and never ran when `initialize()` itself threw.

- Move the OpenSSL `SSL_CTX_free(_ctx)` cleanup from `destroy()` into `~SSLEngine()`.
- Move the Schannel cleanup (chain engine, root store, imported cert keysets, cert contexts, stores) from `destroy()` into `~SSLEngine()`. Schannel previously had no destructor declared; one is now added explicitly.
- Drop `virtual void destroy() = 0;` from the base `Ice::SSL::SSLEngine`.
- Drop the now-empty `destroy()` override on `SecureTransport::SSLEngine`.

No call-site changes — nothing in the tree calls `destroy()` on an `SSLEngine`.

## Test plan

- [x] Local cpp build passes on macOS
- [ ] CI green on Windows (Schannel) and Linux (OpenSSL)