### PR TITLE
Dispose Ice.SSL.SSLEngine from Internal.Instance.destroy()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ These are the changes since the [Ice 3.8.1] release.
 - Changed the mapping of `@p [NAME]` tags which reference out parameters in Slice. These now generate `<c>[NAME]</c>`
   instead of `<paramref name="[NAME]" />`.
 
+- Fixed a resource leak in the SSL engine. The certificates loaded from `IceSSL.CertFile` and `IceSSL.CAs` are now
+  disposed when the communicator is destroyed, instead of waiting for the GC to finalize them.
+
 ### Swift Changes
 
 - Fixed `InputStream.readSize` to reject a negative size.

--- a/csharp/src/Ice/Internal/Instance.cs
+++ b/csharp/src/Ice/Internal/Instance.cs
@@ -22,7 +22,7 @@ public sealed class BufSizeWarnInfo
 }
 
 // CA1001: Instance holds an IDisposable _sslEngine but follows Ice's destroy()-based
-// lifecycle instead of IDisposable. The engine is disposed from destroy().
+// lifecycle instead of IDisposable.
 #pragma warning disable CA1001
 public sealed class Instance
 #pragma warning restore CA1001
@@ -1139,10 +1139,6 @@ public sealed class Instance
         //
         _pluginManager?.destroy();
 
-        // Release the X509Certificate2 instances held by the SSL engine before the Instance goes
-        // away; the certificate handles would otherwise linger until the GC finalizes them.
-        _sslEngine?.Dispose();
-
         lock (_mutex)
         {
             _objectAdapterFactory = null;
@@ -1160,6 +1156,7 @@ public sealed class Instance
             _endpointFactoryManager = null;
             _pluginManager = null;
 
+            _sslEngine?.Dispose();
             _sslEngine = null;
 
             _adminAdapter = null;

--- a/csharp/src/Ice/Internal/Instance.cs
+++ b/csharp/src/Ice/Internal/Instance.cs
@@ -21,7 +21,11 @@ public sealed class BufSizeWarnInfo
     public int rcvSize;
 }
 
+// CA1001: Instance holds an IDisposable _sslEngine but follows Ice's destroy()-based
+// lifecycle instead of IDisposable. The engine is disposed from destroy().
+#pragma warning disable CA1001
 public sealed class Instance
+#pragma warning restore CA1001
 {
     private class ObserverUpdaterI : Ice.Instrumentation.ObserverUpdater
     {
@@ -1135,6 +1139,10 @@ public sealed class Instance
         //
         _pluginManager?.destroy();
 
+        // Release the X509Certificate2 instances held by the SSL engine before the Instance goes
+        // away; the certificate handles would otherwise linger until the GC finalizes them.
+        _sslEngine?.Dispose();
+
         lock (_mutex)
         {
             _objectAdapterFactory = null;
@@ -1151,6 +1159,8 @@ public sealed class Instance
             _locatorManager = null;
             _endpointFactoryManager = null;
             _pluginManager = null;
+
+            _sslEngine = null;
 
             _adminAdapter = null;
             _adminFacets.Clear();

--- a/csharp/src/Ice/SSL/SSLEngine.cs
+++ b/csharp/src/Ice/SSL/SSLEngine.cs
@@ -10,7 +10,7 @@ using System.Text;
 
 namespace Ice.SSL;
 
-internal class SSLEngine
+internal class SSLEngine : IDisposable
 {
     internal SSLEngine(Ice.Communicator communicator)
     {
@@ -19,6 +19,29 @@ internal class SSLEngine
         _securityTraceLevel = _communicator.getProperties().getIcePropertyAsInt("IceSSL.Trace.Security");
         _securityTraceCategory = "Security";
         _trustManager = new TrustManager(_communicator);
+    }
+
+    public void Dispose()
+    {
+        // Release the unmanaged key handles that back each X509Certificate2. The certificate
+        // collection itself isn't IDisposable, so we have to walk its contents.
+        if (_certs is not null)
+        {
+            foreach (X509Certificate2 cert in _certs)
+            {
+                cert.Dispose();
+            }
+            _certs = null;
+        }
+
+        if (_caCerts is not null)
+        {
+            foreach (X509Certificate2 cert in _caCerts)
+            {
+                cert.Dispose();
+            }
+            _caCerts = null;
+        }
     }
 
     internal void initialize()
@@ -535,7 +558,11 @@ internal class SSLEngine
     }
 
     private readonly Ice.Communicator _communicator;
+
+    // CA2213: _logger is borrowed from the communicator; the communicator owns its lifecycle.
+#pragma warning disable CA2213
     private readonly Ice.Logger _logger;
+#pragma warning restore CA2213
     private readonly int _securityTraceLevel;
     private readonly string _securityTraceCategory;
     private string _defaultDir;


### PR DESCRIPTION
## Summary

Mirrors the C++ fix in #5355 for the .NET mapping. Before this change, the `X509Certificate2` instances stored in `Ice.SSL.SSLEngine._certs` and `_caCerts` were never disposed — the unmanaged certificate key handles (CryptoAPI / OpenSSL, depending on platform) lingered on the engine until the GC eventually finalized them. Apps that churn communicators or hold many certificates accumulated unmanaged handles between GC passes.

- `Ice.SSL.SSLEngine` now implements `IDisposable`. `Dispose()` walks `_certs` and `_caCerts` and disposes each certificate, then nulls the collections.
- `Internal.Instance.destroy()` calls `_sslEngine?.Dispose()` after the plugin manager is destroyed, and nulls the `_sslEngine` field alongside the other component fields under the mutex.
- Suppressed CA1001 on `Internal.Instance` (Ice uses its own `destroy()` lifecycle, not `IDisposable`) and CA2213 on `SSLEngine._logger` (borrowed from the communicator, not owned).

## Test plan

- [x] `csharp` solution builds with 0 warnings, 0 errors
- [x] Local run of `csharp` IceSSL/configuration suite: 1 succeeded
- [ ] CI green