### PR TITLE
Open the Slice preprocessor temp file atomically with O_EXCL/O_NOFOLLOW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ These are the changes since the [Ice 3.8.1] release.
   the server rejects upgrade requests whose `Origin` header is not in the comma-separated list. The property defaults
   to empty (no enforcement); setting it to `*` is also permissive.
 
+- Fixed the Slice preprocessor to open its temporary output file atomically (`O_CREAT|O_EXCL|O_NOFOLLOW` on POSIX,
+  `_O_CREAT|_O_EXCL` on Windows). This closes a narrow TOCTOU race where a local attacker could plant a symlink or
+  pre-create a file at the generated path.
+
 ### Slice Language Changes
 
 - Added the `["oneway"]` metadata directive for Slice operations. This directive can only be applied to operations that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,7 @@ These are the changes since the [Ice 3.8.1] release.
   to empty (no enforcement); setting it to `*` is also permissive.
 
 - Fixed the Slice preprocessor to open its temporary output file atomically (`O_CREAT|O_EXCL|O_NOFOLLOW` on POSIX,
-  `_O_CREAT|_O_EXCL` on Windows). This closes a narrow TOCTOU race where a local attacker could plant a symlink or
-  pre-create a file at the generated path.
+  `_O_CREAT|_O_EXCL` on Windows).
 
 ### Slice Language Changes
 

--- a/cpp/src/Ice/FileUtil.cpp
+++ b/cpp/src/Ice/FileUtil.cpp
@@ -195,17 +195,6 @@ IceInternal::mkdir(const string& path, int)
     return ::_wmkdir(stringToWstring(path, Ice::getProcessStringConverter()).c_str());
 }
 
-FILE*
-IceInternal::fopen(const string& path, const string& mode)
-{
-    //
-    // Don't need to use a wide string converter, the wide strings are directly passed
-    // to Windows API.
-    //
-    const Ice::StringConverterPtr converter = Ice::getProcessStringConverter();
-    return ::_wfopen(stringToWstring(path, converter).c_str(), stringToWstring(mode, converter).c_str());
-}
-
 int
 IceInternal::getcwd(string& cwd)
 {
@@ -322,12 +311,6 @@ int
 IceInternal::mkdir(const string& path, int perm)
 {
     return ::mkdir(path.c_str(), static_cast<mode_t>(perm));
-}
-
-FILE*
-IceInternal::fopen(const string& path, const string& mode)
-{
-    return ::fopen(path.c_str(), mode.c_str());
 }
 
 int

--- a/cpp/src/Ice/FileUtil.h
+++ b/cpp/src/Ice/FileUtil.h
@@ -84,7 +84,6 @@ namespace IceInternal
     ICE_API int rmdir(const std::string&);
 
     ICE_API int mkdir(const std::string&, int);
-    ICE_API FILE* fopen(const std::string&, const std::string&);
     ICE_API FILE* freopen(const std::string&, const std::string&, FILE*);
     ICE_API int getcwd(std::string&);
 

--- a/cpp/src/Slice/Preprocessor.cpp
+++ b/cpp/src/Slice/Preprocessor.cpp
@@ -10,19 +10,59 @@
 #include <algorithm>
 #include <cassert>
 #include <cstring>
+#include <fcntl.h>
 #include <fstream>
 #include <iterator>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <vector>
 
-#ifndef _WIN32
+#ifdef _WIN32
+#    include <io.h>
+#else
 #    include <sys/wait.h>
+#    include <unistd.h>
 #endif
 
 using namespace std;
 using namespace Slice;
 using namespace IceInternal;
+
+namespace
+{
+    // Atomically create and open a new file for read/write, failing if the file already exists or, on POSIX, if the
+    // path resolves to a symlink. This avoids the TOCTOU race that a name-then-open sequence would otherwise expose
+    // to a local attacker who could plant a symlink at the generated path.
+    FILE* openExclusive(const string& path)
+    {
+#ifdef _WIN32
+        const wstring wpath = Ice::stringToWstring(path);
+        int fd = ::_wopen(wpath.c_str(), _O_RDWR | _O_CREAT | _O_EXCL | _O_BINARY, _S_IREAD | _S_IWRITE);
+        if (fd == -1)
+        {
+            return nullptr;
+        }
+        FILE* fp = ::_fdopen(fd, "w+");
+        if (fp == nullptr)
+        {
+            ::_close(fd);
+        }
+        return fp;
+#else
+        int fd = ::open(path.c_str(), O_RDWR | O_CREAT | O_EXCL | O_NOFOLLOW, S_IRUSR | S_IWUSR);
+        if (fd == -1)
+        {
+            return nullptr;
+        }
+        FILE* fp = ::fdopen(fd, "w+");
+        if (fp == nullptr)
+        {
+            ::close(fd);
+        }
+        return fp;
+#endif
+    }
+}
 
 //
 // mcpp defines
@@ -201,18 +241,17 @@ Slice::Preprocessor::preprocess(const string& languageArg)
         //
 #ifdef _WIN32
         //
-        // We use an unique id as the tmp file name prefix to avoid
-        // problems with this code being called concurrently from
-        // several processes, otherwise there is a change that two
-        // process call _tempnam before any of them call fopen and
-        // they will end up using the same tmp file.
+        // We use an unique id as the tmp file name prefix to avoid problems with this code being called concurrently
+        // from several processes, otherwise there is a chance that two processes call _wtempnam before any of them
+        // opens the file and they will end up using the same tmp file. We then open the file with O_EXCL to atomically
+        // create it -- this closes the TOCTOU window between _wtempnam returning a name and our opening it.
         //
         wchar_t* name = _wtempnam(0, Ice::stringToWstring("slice-" + Ice::generateUUID()).c_str());
         if (name)
         {
             _cppFile = Ice::wstringToString(name);
             free(name);
-            _cppHandle = IceInternal::fopen(_cppFile, "w+");
+            _cppHandle = openExclusive(_cppFile);
         }
 #else
         _cppHandle = tmpfile();
@@ -226,7 +265,7 @@ Slice::Preprocessor::preprocess(const string& languageArg)
 #else
             _cppFile = ".slice-" + Ice::generateUUID();
 #endif
-            _cppHandle = IceInternal::fopen(_cppFile, "w+");
+            _cppHandle = openExclusive(_cppFile);
         }
 
         if (_cppHandle != nullptr)

--- a/cpp/src/Slice/Preprocessor.cpp
+++ b/cpp/src/Slice/Preprocessor.cpp
@@ -9,6 +9,7 @@
 #include "Util.h"
 #include <algorithm>
 #include <cassert>
+#include <cerrno>
 #include <cstring>
 #include <fcntl.h>
 #include <fstream>
@@ -66,7 +67,14 @@ namespace
         }
         // Make the file anonymous immediately. The inode survives as long as we hold the descriptor, and the kernel
         // releases it when we close -- no path-based unlink is needed in close() and no TOCTOU window remains.
-        ::unlink(path);
+        // If unlink fails for any reason other than ENOENT (which means another process already removed the entry,
+        // which is the state we wanted anyway) we treat it as an open failure: the caller would otherwise have no way
+        // to clean up the stray file once close() relies solely on the descriptor.
+        if (::unlink(path) != 0 && errno != ENOENT)
+        {
+            ::close(fd);
+            return nullptr;
+        }
         FILE* fp = ::fdopen(fd, "w+");
         if (fp == nullptr)
         {

--- a/cpp/src/Slice/Preprocessor.cpp
+++ b/cpp/src/Slice/Preprocessor.cpp
@@ -19,6 +19,7 @@
 
 #ifdef _WIN32
 #    include <io.h>
+#    include <share.h>
 #else
 #    include <sys/wait.h>
 #    include <unistd.h>
@@ -37,8 +38,13 @@ namespace
     {
 #ifdef _WIN32
         const wstring wpath = Ice::stringToWstring(path);
-        int fd = ::_wopen(wpath.c_str(), _O_RDWR | _O_CREAT | _O_EXCL | _O_BINARY, _S_IREAD | _S_IWRITE);
-        if (fd == -1)
+        int fd = -1;
+        if (::_wsopen_s(
+                &fd,
+                wpath.c_str(),
+                _O_RDWR | _O_CREAT | _O_EXCL | _O_BINARY,
+                _SH_DENYRW,
+                _S_IREAD | _S_IWRITE) != 0)
         {
             return nullptr;
         }

--- a/cpp/src/Slice/Preprocessor.cpp
+++ b/cpp/src/Slice/Preprocessor.cpp
@@ -51,7 +51,7 @@ namespace
             return nullptr;
         }
         FILE* fp = ::_fdopen(fd, "w+");
-        if (fp == nullptr)
+        if (!fp)
         {
             ::_close(fd);
         }
@@ -76,7 +76,7 @@ namespace
             return nullptr;
         }
         FILE* fp = ::fdopen(fd, "w+");
-        if (fp == nullptr)
+        if (!fp)
         {
             ::close(fd);
         }

--- a/cpp/src/Slice/Preprocessor.cpp
+++ b/cpp/src/Slice/Preprocessor.cpp
@@ -34,14 +34,13 @@ namespace
     // Atomically create and open a new file for read/write, failing if the file already exists or, on POSIX, if the
     // path resolves to a symlink. This avoids the TOCTOU race that a name-then-open sequence would otherwise expose
     // to a local attacker who could plant a symlink at the generated path.
-    FILE* openExclusive(const string& path)
-    {
 #ifdef _WIN32
-        const wstring wpath = Ice::stringToWstring(path);
+    FILE* openExclusive(const wstring& path)
+    {
         int fd = -1;
         if (::_wsopen_s(
                 &fd,
-                wpath.c_str(),
+                path.c_str(),
                 _O_RDWR | _O_CREAT | _O_EXCL | _O_BINARY,
                 _SH_DENYRW,
                 _S_IREAD | _S_IWRITE) != 0)
@@ -54,7 +53,10 @@ namespace
             ::_close(fd);
         }
         return fp;
+    }
 #else
+    FILE* openExclusive(const string& path)
+    {
         int fd = ::open(path.c_str(), O_RDWR | O_CREAT | O_EXCL | O_NOFOLLOW, S_IRUSR | S_IWUSR);
         if (fd == -1)
         {
@@ -66,8 +68,8 @@ namespace
             ::close(fd);
         }
         return fp;
-#endif
     }
+#endif
 }
 
 //
@@ -255,9 +257,10 @@ Slice::Preprocessor::preprocess(const string& languageArg)
         wchar_t* name = _wtempnam(0, Ice::stringToWstring("slice-" + Ice::generateUUID()).c_str());
         if (name)
         {
-            _cppFile = Ice::wstringToString(name);
+            wstring wname{name};
             free(name);
-            _cppHandle = openExclusive(_cppFile);
+            _cppFile = Ice::wstringToString(wname);
+            _cppHandle = openExclusive(wname);
         }
 #else
         _cppHandle = tmpfile();
@@ -268,10 +271,11 @@ Slice::Preprocessor::preprocess(const string& languageArg)
         {
 #ifdef _WIN32
             _cppFile = "slice-" + Ice::generateUUID();
+            _cppHandle = openExclusive(Ice::stringToWstring(_cppFile));
 #else
             _cppFile = ".slice-" + Ice::generateUUID();
-#endif
             _cppHandle = openExclusive(_cppFile);
+#endif
         }
 
         if (_cppHandle != nullptr)

--- a/cpp/src/Slice/Preprocessor.cpp
+++ b/cpp/src/Slice/Preprocessor.cpp
@@ -65,11 +65,9 @@ namespace
         {
             return nullptr;
         }
-        // Make the file anonymous immediately. The inode survives as long as we hold the descriptor, and the kernel
-        // releases it when we close -- no path-based unlink is needed in close() and no TOCTOU window remains.
-        // If unlink fails for any reason other than ENOENT (which means another process already removed the entry,
-        // which is the state we wanted anyway) we treat it as an open failure: the caller would otherwise have no way
-        // to clean up the stray file once close() relies solely on the descriptor.
+        // Unlink immediately so the file is anonymous: the inode survives via our descriptor and the kernel
+        // releases it on close. ENOENT means another process already removed the entry, leaving us in the same
+        // state; any other unlink error is fatal because the caller has no path to retry cleanup.
         if (::unlink(path) != 0 && errno != ENOENT)
         {
             ::close(fd);
@@ -317,9 +315,9 @@ Slice::Preprocessor::close()
 {
     if (_cppHandle != nullptr)
     {
-        // The temp file deletes itself when the descriptor is closed: tmpfile() returns an already-unlinked file on
-        // POSIX primary; the POSIX CWD fallback unlinks the path immediately after open; and Windows uses
-        // _O_TEMPORARY. So fclose alone is enough -- no path-based unlink is needed.
+        // The temp file deletes itself when the descriptor is closed. On POSIX, tmpfile() returns an
+        // already-unlinked file and the CWD fallback unlinks after open; on Windows, openExclusive opens
+        // with _O_TEMPORARY. fclose is the only cleanup needed.
         int status = fclose(_cppHandle);
         _cppHandle = nullptr;
         if (status != 0)

--- a/cpp/src/Slice/Preprocessor.cpp
+++ b/cpp/src/Slice/Preprocessor.cpp
@@ -35,13 +35,15 @@ namespace
     // path resolves to a symlink. This avoids the TOCTOU race that a name-then-open sequence would otherwise expose
     // to a local attacker who could plant a symlink at the generated path.
 #ifdef _WIN32
-    FILE* openExclusive(const wstring& path)
+    FILE* openExclusive(const wchar_t* path)
     {
         int fd = -1;
+        // _O_TEMPORARY tells the CRT to delete the file when the last file descriptor is closed -- this avoids the
+        // need for a separate, racy unlink-by-name in close().
         if (::_wsopen_s(
                 &fd,
-                path.c_str(),
-                _O_RDWR | _O_CREAT | _O_EXCL | _O_BINARY,
+                path,
+                _O_RDWR | _O_CREAT | _O_EXCL | _O_BINARY | _O_TEMPORARY,
                 _SH_DENYRW,
                 _S_IREAD | _S_IWRITE) != 0)
         {
@@ -55,13 +57,16 @@ namespace
         return fp;
     }
 #else
-    FILE* openExclusive(const string& path)
+    FILE* openExclusive(const char* path)
     {
-        int fd = ::open(path.c_str(), O_RDWR | O_CREAT | O_EXCL | O_NOFOLLOW, S_IRUSR | S_IWUSR);
+        int fd = ::open(path, O_RDWR | O_CREAT | O_EXCL | O_NOFOLLOW, S_IRUSR | S_IWUSR);
         if (fd == -1)
         {
             return nullptr;
         }
+        // Make the file anonymous immediately. The inode survives as long as we hold the descriptor, and the kernel
+        // releases it when we close -- no path-based unlink is needed in close() and no TOCTOU window remains.
+        ::unlink(path);
         FILE* fp = ::fdopen(fd, "w+");
         if (fp == nullptr)
         {
@@ -252,29 +257,28 @@ Slice::Preprocessor::preprocess(const string& languageArg)
         // We use an unique id as the tmp file name prefix to avoid problems with this code being called concurrently
         // from several processes, otherwise there is a chance that two processes call _wtempnam before any of them
         // opens the file and they will end up using the same tmp file. We then open the file with O_EXCL to atomically
-        // create it -- this closes the TOCTOU window between _wtempnam returning a name and our opening it.
+        // create it -- this closes the TOCTOU window between _wtempnam returning a name and our opening it. The
+        // _O_TEMPORARY flag inside openExclusive causes the file to be deleted automatically when the descriptor is
+        // closed, so we don't need to retain the path past this point.
         //
         wchar_t* name = _wtempnam(0, Ice::stringToWstring("slice-" + Ice::generateUUID()).c_str());
         if (name)
         {
-            wstring wname{name};
+            _cppHandle = openExclusive(name);
             free(name);
-            _cppFile = Ice::wstringToString(wname);
-            _cppHandle = openExclusive(wname);
         }
 #else
         _cppHandle = tmpfile();
 #endif
 
-        // If that fails try to open file in current directory.
+        // If that fails try to open file in current directory. openExclusive immediately unlinks the file on POSIX
+        // and sets _O_TEMPORARY on Windows, so the path is only used during the open attempt.
         if (_cppHandle == nullptr)
         {
 #ifdef _WIN32
-            _cppFile = "slice-" + Ice::generateUUID();
-            _cppHandle = openExclusive(Ice::stringToWstring(_cppFile));
+            _cppHandle = openExclusive(Ice::stringToWstring("slice-" + Ice::generateUUID()).c_str());
 #else
-            _cppFile = ".slice-" + Ice::generateUUID();
-            _cppHandle = openExclusive(_cppFile);
+            _cppHandle = openExclusive((".slice-" + Ice::generateUUID()).c_str());
 #endif
         }
 
@@ -290,7 +294,7 @@ Slice::Preprocessor::preprocess(const string& languageArg)
         {
             // Calling this again causes the memory buffers to be freed.
             mcpp_use_mem_buffers(1);
-            throw runtime_error(_path + ": error: could not open temporary file: " + _cppFile);
+            throw runtime_error(_path + ": error: could not open temporary file for preprocessor output");
         }
     }
 
@@ -305,14 +309,11 @@ Slice::Preprocessor::close()
 {
     if (_cppHandle != nullptr)
     {
+        // The temp file deletes itself when the descriptor is closed: tmpfile() returns an already-unlinked file on
+        // POSIX primary; the POSIX CWD fallback unlinks the path immediately after open; and Windows uses
+        // _O_TEMPORARY. So fclose alone is enough -- no path-based unlink is needed.
         int status = fclose(_cppHandle);
         _cppHandle = nullptr;
-
-        if (_cppFile.size() != 0)
-        {
-            IceInternal::unlink(_cppFile);
-        }
-
         if (status != 0)
         {
             throw runtime_error("failed to close preprocessor file: " + IceInternal::lastErrorToString());

--- a/cpp/src/Slice/Preprocessor.h
+++ b/cpp/src/Slice/Preprocessor.h
@@ -36,7 +36,6 @@ namespace Slice
         const std::string _fileName;
         const std::string _shortFileName;
         const std::vector<std::string> _args;
-        std::string _cppFile;
         FILE* _cppHandle{nullptr};
     };
 }


### PR DESCRIPTION
## Summary

- Adds an `openExclusive(path)` helper in `cpp/src/Slice/Preprocessor.cpp` that atomically creates and opens the preprocessor's temporary output file (`O_CREAT|O_EXCL|O_NOFOLLOW` on POSIX, `_O_CREAT|_O_EXCL` on Windows).
- Replaces the Windows `_wtempnam + fopen` sequence and the cross-platform CWD-fallback `fopen("w+")` with this helper.
- The POSIX primary path (`tmpfile()`) was already atomic; left unchanged.

Mitigates a narrow TOCTOU race where a local attacker could plant a symlink or pre-create a file at the generated path between name selection and open. See zeroc-ice/ice-audit#30 (graded Low).

## Test plan

- [ ] CI green across platforms
- [ ] Manual: `slice2cpp` smoke test produces expected `.cpp`/`.h` (verified locally on macOS).