### PR TITLE
Reject malformed entries in Glacier2 password files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,4 +98,8 @@ These are the changes since the [Ice 3.8.1] release.
 - Updated the Glacier2CryptPermissionsVerifier plug-in to issue a warning when the configured password file contains one
   or more DES passwords.
 
+- Updated the Glacier2CryptPermissionsVerifier plug-in to reject password files with malformed entries. Each line must
+  contain exactly two whitespace-separated tokens (user id and password hash); lines with extra fields were previously
+  parsed incorrectly without raising an error.
+
 [Ice 3.8.1]: https://github.com/zeroc-ice/ice/blob/3.8/CHANGELOG-3.8.md

--- a/cpp/src/Glacier2/CryptPermissionsVerifier.cpp
+++ b/cpp/src/Glacier2/CryptPermissionsVerifier.cpp
@@ -8,6 +8,7 @@
 
 #include <fstream>
 #include <mutex>
+#include <sstream>
 
 #if defined(__GLIBC__)
 #    include <crypt.h>
@@ -78,24 +79,31 @@ namespace
 
         bool hasDESStylePassword = false;
 
-        while (true)
+        string line;
+        size_t lineNumber = 0;
+        while (std::getline(passwordFile, line))
         {
+            ++lineNumber;
+            if (!line.empty() && line.back() == '\r')
+            {
+                line.pop_back();
+            }
+            if (line.find_first_not_of(" \t") == string::npos)
+            {
+                continue;
+            }
+
+            istringstream iss(line);
             string userId;
-            passwordFile >> userId;
-            if (!passwordFile)
-            {
-                break;
-            }
-
             string password;
-            passwordFile >> password;
-            if (!passwordFile)
+            string extra;
+            if (!(iss >> userId >> password) || (iss >> extra))
             {
-                break;
+                throw Ice::InitializationException(
+                    __FILE__,
+                    __LINE__,
+                    "malformed entry in password file '" + file + "' at line " + std::to_string(lineNumber));
             }
-
-            assert(!userId.empty());
-            assert(!password.empty());
 
             hasDESStylePassword = hasDESStylePassword || (password.find('$') == string::npos && password.size() == 13);
 


### PR DESCRIPTION
## Summary

- `Glacier2CryptPermissionsVerifier` now reads its password file line by line and throws `Ice::InitializationException` when a line does not contain exactly two whitespace-separated tokens.
- The previous code extracted tokens with `operator>>`, which silently misinterpreted lines containing extra fields (subsequent tokens were consumed as the next entry's user id, shifting all later entries).
- Blank/whitespace-only lines are skipped; trailing `\r` is stripped to support files with CRLF line endings.
- The exception message includes only the password file path and the offending line number — no content from the password file is included.

Addresses zeroc-ice/ice-audit#38.

## Test plan

- [ ] CI: existing Glacier2 / IceGrid tests pass on Linux, macOS, and Windows.
- [ ] Manual: a password file with a malformed line (`user pass extra`) now raises `InitializationException` instead of silently shifting later entries.
- [ ] Manual: blank lines and CRLF-terminated files still load successfully.