### PR TITLE
Update FileLock open flags on non-Windows platforms

### DIFF
--- a/cpp/src/Ice/FileUtil.cpp
+++ b/cpp/src/Ice/FileUtil.cpp
@@ -350,7 +350,7 @@ IceInternal::unlink(const string& path)
 
 IceInternal::FileLock::FileLock(const std::string& path) : _path(path)
 {
-    _fd = ::open(path.c_str(), O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+    _fd = ::open(path.c_str(), O_RDWR | O_CREAT | O_NOFOLLOW, S_IRUSR | S_IWUSR);
     if (_fd < 0)
     {
         throw FileLockException(__FILE__, __LINE__, errno, _path);


### PR DESCRIPTION
A tiny fix to the internal FileLock class.