### PR TITLE
Remove dead IceGrid node tmp directory

### DIFF
--- a/cpp/src/IceGrid/IceGridNode.cpp
+++ b/cpp/src/IceGrid/IceGridNode.cpp
@@ -327,19 +327,15 @@ NodeService::startImpl(int argc, char* argv[], int& status)
         }
 
         createDirectory(dataPath + "servers");
-        createDirectory(dataPath + "tmp");
 
 #ifdef _WIN32
         //
-        // Make sure these directories are not indexed by the Windows
-        // indexing service (which can cause random "Access Denied"
-        // errors if indexing runs at the same time as the node is
-        // creating/deleting files).
+        // Make sure this directory is not indexed by the Windows indexing service (which can cause random
+        // "Access Denied" errors if indexing runs at the same time as the node is creating/deleting files).
         //
         try
         {
             setNoIndexingAttribute(dataPath + "servers");
-            setNoIndexingAttribute(dataPath + "tmp");
         }
         catch (const FileException& ex)
         {

--- a/cpp/src/IceGrid/NodeI.cpp
+++ b/cpp/src/IceGrid/NodeI.cpp
@@ -69,7 +69,6 @@ NodeI::NodeI(
 
     const_cast<string&>(_dataDir) = _platform.getDataDir();
     const_cast<string&>(_serversDir) = _dataDir + "/servers";
-    const_cast<string&>(_tmpDir) = _dataDir + "/tmp";
     const_cast<int&>(_waitTime) = props->getIcePropertyAsInt("IceGrid.Node.WaitTime");
     const_cast<string&>(_outputDir) = props->getIceProperty("IceGrid.Node.Output");
     const_cast<bool&>(_redirectErrToOut) = props->getIcePropertyAsInt("IceGrid.Node.RedirectErrToOut") > 0;

--- a/cpp/src/IceGrid/NodeI.h
+++ b/cpp/src/IceGrid/NodeI.h
@@ -175,7 +175,6 @@ namespace IceGrid
         PlatformInfo _platform;
         const std::string _dataDir;
         const std::string _serversDir;
-        const std::string _tmpDir;
         const std::shared_ptr<FileCache> _fileCache;
         PropertyDescriptorSeq _propertiesOverride;
 


### PR DESCRIPTION
## Summary

- The IceGrid node creates `<IceGrid.Node.Data>/tmp` on startup and stores the path in `NodeI::_tmpDir`. The field is never read anywhere in the tree — `grep -rn '_tmpDir\\|tmpDir\\(\\)\\|getTmpDir' cpp` returns no remaining hits after the deletion.
- This PR removes the directory creation, the matching Windows `setNoIndexingAttribute` call, and the dead `_tmpDir` member.

Found while triaging zeroc-ice/ice-audit#44. The broader tightening of node/server directory modes that the audit calls for needs a uid-aware fix (`Ice.UserAccountMapper`-resolved uid/gid + `chown` to that uid + `0700`) and is deferred to 3.9.0; that's tracked in the same audit issue at its `3.9.0` milestone. This PR is patch-safe because the directory has no readers.

## Test plan

- [ ] Full C++ build is clean (`make srcs` — verified locally on macOS).
- [ ] Existing IceGrid tests pass on Linux, macOS, and Windows in CI.