### PR TITLE
Move cherry-picked changelog entries into the Ice 3.8.2 section

### DIFF
--- a/CHANGELOG-3.8.md
+++ b/CHANGELOG-3.8.md
@@ -6,22 +6,25 @@ comprehensive report of every change we made in a release, it does provide detai
 might need to be aware of.
 
 - [Changes in Ice 3.8.2](#changes-in-ice-382)
+  - [General Changes](#general-changes)
   - [Slice Language Changes](#slice-language-changes)
   - [C++ Changes](#c-changes)
   - [C# Changes](#c-changes-1)
+  - [Swift Changes](#swift-changes)
+  - [Ice Service Changes](#ice-service-changes)
 - [Changes in Ice 3.8.1](#changes-in-ice-381)
-  - [General Changes](#general-changes)
+  - [General Changes](#general-changes-1)
   - [IceSSL Changes](#icessl-changes)
   - [C++ Changes](#c-changes-2)
   - [JavaScript Changes](#javascript-changes)
   - [Python Changes](#python-changes)
-  - [Swift Changes](#swift-changes)
-  - [Ice Service Changes](#ice-service-changes)
+  - [Swift Changes](#swift-changes-1)
+  - [Ice Service Changes](#ice-service-changes-1)
     - [Glacier2](#glacier2)
     - [IceDiscovery](#icediscovery)
   - [Packaging Changes](#packaging-changes)
 - [Changes in Ice 3.8.0](#changes-in-ice-380)
-  - [General Changes](#general-changes-1)
+  - [General Changes](#general-changes-2)
   - [Packaging Changes](#packaging-changes-1)
   - [Slice Language Changes](#slice-language-changes-1)
   - [IceSSL Changes](#icessl-changes-1)
@@ -39,8 +42,8 @@ might need to be aware of.
   - [PHP Changes](#php-changes)
   - [Python Changes](#python-changes-1)
   - [Ruby Changes](#ruby-changes)
-  - [Swift Changes](#swift-changes-1)
-  - [Ice Service Changes](#ice-service-changes-1)
+  - [Swift Changes](#swift-changes-2)
+  - [Ice Service Changes](#ice-service-changes-2)
     - [DataStorm](#datastorm)
     - [Glacier2](#glacier2-1)
     - [IceBox](#icebox)
@@ -51,6 +54,31 @@ might need to be aware of.
 ## Changes in Ice 3.8.2
 
 These are the changes since the Ice 3.8.1 release.
+
+### General Changes
+
+- Removed the 'ice2slice' compiler
+
+- Fixed the WebSocket transport to enforce the RFC 6455 limits on control frames.
+
+- Fixed an unbounded memory allocation when unmarshaling a proxy with a large endpoint count.
+
+- Fixed an integer overflow in the sequence-size validation performed while unmarshaling.
+
+- Fixed the unmarshaling of classes and exceptions to reject a malformed sliced-format slice header.
+
+- Fixed the unmarshaling of batch requests to reject a request count larger than the message can hold.
+
+- Fixed the unmarshaling of IP endpoints to reject a port value outside the 0..65535 range.
+
+- Fixed the unmarshaling of class indirection tables to reject a zero-valued entry.
+
+- Added the `<AdapterName>.AllowedOrigins` object adapter property. When set on an adapter with a WebSocket endpoint,
+  the server rejects upgrade requests whose `Origin` header is not in the comma-separated list. The property defaults
+  to empty (no enforcement); setting it to `*` is also permissive.
+
+- Fixed the Slice preprocessor to open its temporary output file atomically (`O_CREAT|O_EXCL|O_NOFOLLOW` on POSIX,
+  `_O_CREAT|_O_EXCL` on Windows).
 
 ### Slice Language Changes
 
@@ -64,10 +92,59 @@ These are the changes since the Ice 3.8.1 release.
 - Changed the mapping of `@p [NAME]` tags which reference out parameters in Slice.
   These now generate `` `[NAME]` `` instead of `@p [NAME]`.
 
+- Fixed alignment-unsafe 16-bit reads and writes in the WebSocket transport.
+
+- Changed the macOS SSL transport to require TLS 1.2 or later.
+
+- Changed the macOS SSL transport to enable only forward-secret (ECDHE) cipher suites.
+
+- Fixed a resource leak in the SSL engine. The Schannel and OpenSSL engines now release their
+  certificate stores, chain engines, imported key sets, and `SSL_CTX` when the communicator is
+  destroyed.
+
+- Changed the macOS SSL transport so that, when `IceSSL.Keychain` is not set, the certificate configured with
+  `IceSSL.CertFile` is imported into a temporary keychain (removed when the communicator is destroyed) instead of
+  the user's login keychain.
+
+- Rejected peer-initiated TLS renegotiation in the OpenSSL SSL engine and on the server side of Schannel-based SSL
+  connections. This applies to all SSL-based transports (`ssl`, `wss`, `bts`).
+
 ### C# Changes
 
 - Changed the mapping of `@p [NAME]` tags which reference out parameters in Slice.
   These now generate `<c>[NAME]</c>` instead of `<paramref name="[NAME]" />`.
+
+- Added the `--icerpc` flag to `slice2cs`. When set, `slice2cs` generates C# code for
+  [IceRPC](https://github.com/icerpc/icerpc-csharp) instead of Ice. The `ZeroC.Ice.Slice.Tools` MSBuild integration
+  exposes this flag via the `IceRpc` boolean item metadata on `SliceCompile` items.
+
+- Added the `["cs:internal"]` metadata directive. When applied to a Slice definition, the generated C# type is emitted
+  with the `internal` access modifier instead of `public`.
+
+- Added the `["cs:readonly"]` metadata directive. When applied to a Slice struct, the generated C# struct is emitted
+  as a `readonly` struct.
+
+- Fixed a resource leak in the SSL engine. The certificates loaded from `IceSSL.CertFile` and `IceSSL.CAs` are now
+  disposed when the communicator is destroyed, instead of waiting for the GC to finalize them.
+
+### Swift Changes
+
+- Fixed `InputStream.readSize` to reject a negative size.
+
+### Ice Service Changes
+
+- Updated the creation of SSL-based sessions in IceGrid and Glacier2: a connection without a client certificate, or with
+  an empty DN, is now rejected before reaching the permissions verifier.
+
+- Updated the Glacier2CryptPermissionsVerifier plug-in to issue a warning when the configured password file contains one
+  or more DES passwords.
+
+- Fixed the Glacier2CryptPermissionsVerifier plug-in to compare hashed passwords in constant time, removing a timing
+  side-channel that could leak bytes of the stored hash.
+
+- Updated the Glacier2CryptPermissionsVerifier plug-in to reject password files with malformed entries. Each line must
+  contain exactly two whitespace-separated tokens (user id and password hash); lines with extra fields were previously
+  parsed incorrectly without raising an error.
 
 ## Changes in Ice 3.8.1
 

--- a/CHANGELOG-3.8.md
+++ b/CHANGELOG-3.8.md
@@ -57,7 +57,7 @@ These are the changes since the Ice 3.8.1 release.
 
 ### General Changes
 
-- Removed the 'ice2slice' compiler
+- Removed the `ice2slice` compiler.
 
 - Fixed the WebSocket transport to enforce the RFC 6455 limits on control frames.
 


### PR DESCRIPTION
## Description

The recent security/hardening fixes (and a few earlier feature changes) were cherry-picked from `main` into the `3.8` branch. This PR records those changes in the **Ice 3.8.2** section of `CHANGELOG-3.8.md`.

Added subsections **General Changes**, **Swift Changes**, and **Ice Service Changes**, and appended entries to the existing **C++** and **C#** subsections. The table-of-contents anchors for the duplicate `General Changes`, `Swift Changes`, and `Ice Service Changes` headings (3.8.1 → `-1`, 3.8.0 → `-2`) were renumbered accordingly. The `["oneway"]` and `@p`-tag entries were already present and are unchanged.

A companion PR removes these same entries from main's `Ice 3.9.0` changelog (we keep in `main` only entries that were *not* cherry-picked).