### PR TITLE
Move facet out of soon-discarded vector in IncomingRequest

### DIFF
--- a/cpp/src/Ice/IncomingRequest.cpp
+++ b/cpp/src/Ice/IncomingRequest.cpp
@@ -33,7 +33,7 @@ IncomingRequest::IncomingRequest(
         {
             throw MarshalException{__FILE__, __LINE__, "received facet path with more than one element"};
         }
-        _current.facet = facetPath[0];
+        _current.facet = std::move(facetPath[0]);
     }
 
     inputStream.read(_current.operation, false);


### PR DESCRIPTION
Fixes #5374.

`IncomingRequest` read the facet path into a local `vector<string>` and then **copied** `facetPath[0]` into `_current.facet`, even though the vector is discarded immediately afterward.

This moves the string instead:

```cpp
_current.facet = std::move(facetPath[0]);
```

`facetPath` is a local destroyed at the end of the enclosing `if` scope and `facetPath[0]` is not read after this point, so the move is sound. It saves one `std::string` heap allocation per dispatched request that carries a facet.

`.cpp`-only, binary-compatible, C++17-safe.