### PR TITLE
Avoid copies in proxyIdentityAndFacetLess comparator

### DIFF
--- a/cpp/src/Ice/ProxyFunctions.cpp
+++ b/cpp/src/Ice/ProxyFunctions.cpp
@@ -53,8 +53,8 @@ Ice::proxyIdentityAndFacetLess(const optional<ObjectPrx>& lhs, const optional<Ob
 {
     if (lhs && rhs)
     {
-        Identity lhsIdentity = lhs->ice_getIdentity();
-        Identity rhsIdentity = rhs->ice_getIdentity();
+        const Identity& lhsIdentity = lhs->ice_getIdentity();
+        const Identity& rhsIdentity = rhs->ice_getIdentity();
 
         if (lhsIdentity < rhsIdentity)
         {
@@ -65,8 +65,8 @@ Ice::proxyIdentityAndFacetLess(const optional<ObjectPrx>& lhs, const optional<Ob
             return false;
         }
 
-        string lhsFacet = lhs->ice_getFacet();
-        string rhsFacet = rhs->ice_getFacet();
+        const string& lhsFacet = lhs->ice_getFacet();
+        const string& rhsFacet = rhs->ice_getFacet();
 
         return lhsFacet < rhsFacet;
     }


### PR DESCRIPTION
Fixes #5380.

`proxyIdentityAndFacetLess` copied two `Identity` structs and two facet strings just to compare them, even though `ice_getIdentity()` returns `const Ice::Identity&` and `ice_getFacet()` returns `const std::string&`. This binds references instead:

```cpp
const Identity& lhsIdentity = lhs->ice_getIdentity();
const Identity& rhsIdentity = rhs->ice_getIdentity();
...
const string& lhsFacet = lhs->ice_getFacet();
const string& rhsFacet = rhs->ice_getFacet();
```

The references are valid for the duration of the comparison (the proxies outlive it), and this brings the function in line with the sibling comparators `proxyIdentityLess` and `proxyIdentityEqual`, which already operate on the references directly. This comparator is used as a `std::map`/`std::set` ordering, so it runs O(log n) times per container operation.

`.cpp`-only, binary-compatible, C++17-safe.