### PR TITLE
Avoid zero-filling the buffer in InputStream::read(vector<byte>&)

### DIFF
--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -481,15 +481,7 @@ Ice::InputStream::read(std::vector<byte>& v)
 {
     std::pair<const byte*, const byte*> p;
     read(p);
-    if (p.first != p.second)
-    {
-        v.resize(static_cast<size_t>(p.second - p.first));
-        copy(p.first, p.second, v.begin());
-    }
-    else
-    {
-        v.clear();
-    }
+    v.assign(p.first, p.second);
 }
 
 void


### PR DESCRIPTION
Fixes #5381.

`InputStream::read(std::vector<byte>&)` did `resize()` + `copy()`: `resize` value-initializes (zero-fills) every `std::byte`, and `copy` then overwrites all of them — two passes over the buffer. This replaces both branches with a single `assign`:

```cpp
std::pair<const byte*, const byte*> p;
read(p);
v.assign(p.first, p.second);
```

`assign` from the raw `const byte*` range does a single up-front allocation sized exactly to the range (the pointers are random-access iterators, so the library takes the sized path and does not reallocate incrementally), reuses existing capacity, and skips the zero-fill. The empty-range case yields an empty vector, matching the previous `clear()` branch.

This was independently verified against the C++17 standard wording, libc++'s `assign` dispatch, and the repo's clang-tidy config (no `performance-*`/`modernize-*` check objects). `sequence<byte>` is a very common payload type, so this scales with payload size.

`.cpp`-only, binary-compatible, C++17-safe.