### PR TITLE
Fix string converter usage in OutputStream

### DIFF
--- a/cpp/include/Ice/OutputStream.h
+++ b/cpp/include/Ice/OutputStream.h
@@ -42,8 +42,9 @@ namespace Ice
         /// Constructs an OutputStream.
         /// @param encoding The encoding version to use.
         /// @param format The class format to use.
-        /// @param stringConverter The narrow string converter to use.
-        /// @param wstringConverter The wide string converter to use.
+        /// @param stringConverter The narrow string converter to use. @c nullptr means do not perform any conversion.
+        /// @param wstringConverter The wide string converter to use. @c nullptr is equivalent to the process wstring
+        /// converter.
         OutputStream(
             EncodingVersion encoding = Encoding_1_1,
             FormatType format = FormatType::CompactFormat,
@@ -66,8 +67,9 @@ namespace Ice
         /// stream will reallocate if the size of the marshaled data exceeds the application's buffer.
         /// @param encoding The encoding version to use.
         /// @param format The class format to use.
-        /// @param stringConverter The narrow string converter to use.
-        /// @param wstringConverter The wide string converter to use.
+        /// @param stringConverter The narrow string converter to use. @c nullptr means do not perform any conversion.
+        /// @param wstringConverter The wide string converter to use. @c nullptr is equivalent to the process wstring
+        /// converter.
         OutputStream(
             std::pair<const std::byte*, const std::byte*> bytes,
             EncodingVersion encoding = Encoding_1_1,
@@ -697,7 +699,7 @@ namespace Ice
         }
 
         StringConverterPtr _stringConverter;
-        WstringConverterPtr _wstringConverter;
+        WstringConverterPtr _wstringConverter; // never null
 
         //
         // The public stream API needs to attach data to a stream.

--- a/cpp/src/Ice/OutputStream.cpp
+++ b/cpp/src/Ice/OutputStream.cpp
@@ -68,6 +68,10 @@ Ice::OutputStream::OutputStream(
       _format(format),
       _currentEncaps(nullptr)
 {
+    if (!_wstringConverter)
+    {
+        _wstringConverter = getProcessWstringConverter();
+    }
 }
 
 Ice::OutputStream::OutputStream(
@@ -85,6 +89,11 @@ Ice::OutputStream::OutputStream(
       _currentEncaps(nullptr)
 {
     b.reset();
+
+    if (!_wstringConverter)
+    {
+        _wstringConverter = getProcessWstringConverter();
+    }
 }
 
 Ice::OutputStream::OutputStream(const CommunicatorPtr& communicator, EncodingVersion encoding)
@@ -104,6 +113,7 @@ Ice::OutputStream::OutputStream(Instance* instance, EncodingVersion encoding)
           instance->getStringConverter(),
           instance->getWstringConverter())
 {
+    assert(_wstringConverter);
 }
 
 Ice::OutputStream::OutputStream(OutputStream&& other) noexcept
@@ -116,6 +126,7 @@ Ice::OutputStream::OutputStream(OutputStream&& other) noexcept
       _currentEncaps(other._currentEncaps)
 {
     // Reset other to its default state.
+    other._wstringConverter = getProcessWstringConverter();
     other._closure = nullptr;
     other._encoding = Encoding_1_1;
     other._format = FormatType::CompactFormat;
@@ -140,6 +151,7 @@ Ice::OutputStream::operator=(OutputStream&& other) noexcept
         _currentEncaps = other._currentEncaps;
 
         // Reset other to its default state.
+        other._wstringConverter = getProcessWstringConverter();
         other._closure = nullptr;
         other._encoding = Encoding_1_1;
         other._format = FormatType::CompactFormat;
@@ -703,13 +715,7 @@ Ice::OutputStream::write(const char*)
 void
 Ice::OutputStream::writeConverted(const char* vdata, size_t vsize)
 {
-    StringConverterPtr stringConverter = _stringConverter;
-    if (!stringConverter)
-    {
-        stringConverter = getProcessStringConverter();
-    }
-
-    if (!stringConverter)
+    if (!_stringConverter)
     {
         // No converter installed; write the string as-is (assumed to be UTF-8 already).
         writeSize(static_cast<int32_t>(vsize));
@@ -735,7 +741,7 @@ Ice::OutputStream::writeConverted(const char* vdata, size_t vsize)
             auto sizePos = startOneByteSize();
 
             StreamUTF8BufferI buffer(*this);
-            byte* lastByte = stringConverter->toUTF8(vdata, vdata + vsize, buffer);
+            byte* lastByte = _stringConverter->toUTF8(vdata, vdata + vsize, buffer);
             if (lastByte != b.end())
             {
                 resize(static_cast<size_t>(lastByte - b.begin()));
@@ -750,7 +756,7 @@ Ice::OutputStream::writeConverted(const char* vdata, size_t vsize)
             auto sizePos = startSize();
 
             StreamUTF8BufferI buffer(*this);
-            byte* lastByte = stringConverter->toUTF8(vdata, vdata + vsize, buffer);
+            byte* lastByte = _stringConverter->toUTF8(vdata, vdata + vsize, buffer);
             if (lastByte != b.end())
             {
                 resize(static_cast<size_t>(lastByte - b.begin()));
@@ -803,13 +809,8 @@ Ice::OutputStream::write(wstring_view v)
 
         byte* lastByte = nullptr;
 
-        WstringConverterPtr wstringConverter = _wstringConverter;
-        if (!wstringConverter)
-        {
-            wstringConverter = getProcessWstringConverter();
-        }
-        assert(wstringConverter); // never null
-        lastByte = wstringConverter->toUTF8(v.data(), v.data() + v.size(), buffer);
+        assert(_wstringConverter);
+        lastByte = _wstringConverter->toUTF8(v.data(), v.data() + v.size(), buffer);
 
         if (lastByte != b.end())
         {


### PR DESCRIPTION
This PR fixes the string converter and wstring converter usage in the OutputStream implementation, to avoid retrieving the process-wide stringConverter (resp. wstringConverter) each time we marshal a string.

See #5387.

I didn't fix #5387 as suggested because `std::atomic<std::shared_ptr<T>>` is only available as of c++20, and Xcode clang on macos - that's supposed to support c++20 - doesn't actually provide this library feature.