### PR TITLE
Replace dynamic_pointer_cast by static_pointer_cast where appropriate

### DIFF
--- a/cpp/src/DataStorm/DataElementI.cpp
+++ b/cpp/src/DataStorm/DataElementI.cpp
@@ -799,7 +799,7 @@ DataReaderI::initSamples(
     if (_onSamples)
     {
         _executor->queue(
-            [self = dynamic_pointer_cast<DataReaderI>(shared_from_this()), valid]
+            [self = static_pointer_cast<DataReaderI>(shared_from_this()), valid]
             {
                 for (const auto& s : valid)
                 {
@@ -932,7 +932,7 @@ DataReaderI::queue(
 
     if (_onSamples)
     {
-        _executor->queue([self = dynamic_pointer_cast<DataReaderI>(shared_from_this()), sample]
+        _executor->queue([self = static_pointer_cast<DataReaderI>(shared_from_this()), sample]
                          { self->_onSamples(sample); });
     }
 

--- a/cpp/src/DataStorm/SessionI.cpp
+++ b/cpp/src/DataStorm/SessionI.cpp
@@ -1365,13 +1365,13 @@ SubscriberSessionI::reconnect(NodePrx node)
         Trace out(_traceLevels->logger, _traceLevels->sessionCat);
         out << _id << ": trying to reconnect session with '" << node->ice_toString() << "'";
     }
-    _parent->createPublisherSession(node, nullptr, dynamic_pointer_cast<SubscriberSessionI>(shared_from_this()));
+    _parent->createPublisherSession(node, nullptr, static_pointer_cast<SubscriberSessionI>(shared_from_this()));
 }
 
 void
 SubscriberSessionI::remove()
 {
-    _parent->removeSubscriberSession(getNode(), dynamic_pointer_cast<SubscriberSessionI>(shared_from_this()), nullptr);
+    _parent->removeSubscriberSession(getNode(), static_pointer_cast<SubscriberSessionI>(shared_from_this()), nullptr);
 }
 
 PublisherSessionI::PublisherSessionI(
@@ -1397,11 +1397,11 @@ PublisherSessionI::reconnect(NodePrx node)
         Trace out(_traceLevels->logger, _traceLevels->sessionCat);
         out << _id << ": trying to reconnect session with '" << node->ice_toString() << "'";
     }
-    _parent->createSubscriberSession(node, nullptr, dynamic_pointer_cast<PublisherSessionI>(shared_from_this()));
+    _parent->createSubscriberSession(node, nullptr, static_pointer_cast<PublisherSessionI>(shared_from_this()));
 }
 
 void
 PublisherSessionI::remove()
 {
-    _parent->removePublisherSession(getNode(), dynamic_pointer_cast<PublisherSessionI>(shared_from_this()), nullptr);
+    _parent->removePublisherSession(getNode(), static_pointer_cast<PublisherSessionI>(shared_from_this()), nullptr);
 }

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -1012,7 +1012,7 @@ Ice::ConnectionI::setAdapter(const ObjectAdapterPtr& adapter)
     {
         // Go through the adapter to set the adapter on this connection
         // to ensure the object adapter is still active.
-        dynamic_pointer_cast<ObjectAdapterI>(adapter)->setAdapterOnConnection(shared_from_this());
+        static_pointer_cast<ObjectAdapterI>(adapter)->setAdapterOnConnection(shared_from_this());
     }
     else
     {

--- a/cpp/src/Ice/ConnectionI.h
+++ b/cpp/src/Ice/ConnectionI.h
@@ -72,7 +72,7 @@ namespace Ice
     public:
         std::shared_ptr<ConnectionI> shared_from_this()
         {
-            return std::dynamic_pointer_cast<ConnectionI>(IceInternal::EventHandler::shared_from_this());
+            return std::static_pointer_cast<ConnectionI>(IceInternal::EventHandler::shared_from_this());
         }
 
         struct OutgoingMessage

--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -549,7 +549,7 @@ IceInternal::FixedReference::changeConnectionId(string) const
 ReferencePtr
 IceInternal::FixedReference::changeConnection(Ice::ConnectionIPtr newConnection) const
 {
-    FixedReferencePtr r = dynamic_pointer_cast<FixedReference>(clone());
+    FixedReferencePtr r = static_pointer_cast<FixedReference>(clone());
     r->_fixedConnection = std::move(newConnection);
     return r;
 }
@@ -787,7 +787,7 @@ IceInternal::RoutableReference::changeEncoding(Ice::EncodingVersion encoding) co
     ReferencePtr r = Reference::changeEncoding(encoding);
     if (r.get() != const_cast<RoutableReference*>(this))
     {
-        LocatorInfoPtr& locInfo = dynamic_pointer_cast<RoutableReference>(r)->_locatorInfo;
+        LocatorInfoPtr& locInfo = static_pointer_cast<RoutableReference>(r)->_locatorInfo;
         if (locInfo && locInfo->getLocator()->ice_getEncodingVersion() != encoding)
         {
             locInfo = getInstance()->locatorManager()->get(locInfo->getLocator()->ice_encodingVersion(encoding));
@@ -809,7 +809,7 @@ IceInternal::RoutableReference::changeCompress(bool newCompress) const
         {
             newEndpoints.push_back(endpoint->compress(newCompress));
         }
-        dynamic_pointer_cast<RoutableReference>(r)->_endpoints = newEndpoints;
+        static_pointer_cast<RoutableReference>(r)->_endpoints = newEndpoints;
     }
     return r;
 }
@@ -817,7 +817,7 @@ IceInternal::RoutableReference::changeCompress(bool newCompress) const
 ReferencePtr
 IceInternal::RoutableReference::changeEndpoints(vector<EndpointIPtr> newEndpoints) const
 {
-    RoutableReferencePtr r = dynamic_pointer_cast<RoutableReference>(clone());
+    RoutableReferencePtr r = static_pointer_cast<RoutableReference>(clone());
     r->_endpoints = std::move(newEndpoints);
     r->applyOverrides(r->_endpoints);
     r->_adapterId.clear();
@@ -827,7 +827,7 @@ IceInternal::RoutableReference::changeEndpoints(vector<EndpointIPtr> newEndpoint
 ReferencePtr
 IceInternal::RoutableReference::changeAdapterId(string newAdapterId) const
 {
-    RoutableReferencePtr r = dynamic_pointer_cast<RoutableReference>(clone());
+    RoutableReferencePtr r = static_pointer_cast<RoutableReference>(clone());
     r->_adapterId = std::move(newAdapterId);
     r->_endpoints.clear();
     return r;
@@ -837,7 +837,7 @@ ReferencePtr
 IceInternal::RoutableReference::changeLocator(optional<LocatorPrx> newLocator) const
 {
     LocatorInfoPtr newLocatorInfo = newLocator ? getInstance()->locatorManager()->get(newLocator.value()) : nullptr;
-    RoutableReferencePtr r = dynamic_pointer_cast<RoutableReference>(clone());
+    RoutableReferencePtr r = static_pointer_cast<RoutableReference>(clone());
     r->_locatorInfo = std::move(newLocatorInfo);
     return r;
 }
@@ -846,7 +846,7 @@ ReferencePtr
 IceInternal::RoutableReference::changeRouter(optional<RouterPrx> newRouter) const
 {
     RouterInfoPtr newRouterInfo = newRouter ? getInstance()->routerManager()->get(newRouter.value()) : nullptr;
-    RoutableReferencePtr r = dynamic_pointer_cast<RoutableReference>(clone());
+    RoutableReferencePtr r = static_pointer_cast<RoutableReference>(clone());
     r->_routerInfo = std::move(newRouterInfo);
     return r;
 }
@@ -854,7 +854,7 @@ IceInternal::RoutableReference::changeRouter(optional<RouterPrx> newRouter) cons
 ReferencePtr
 IceInternal::RoutableReference::changeCollocationOptimized(bool newCollocationOptimized) const
 {
-    RoutableReferencePtr r = dynamic_pointer_cast<RoutableReference>(clone());
+    RoutableReferencePtr r = static_pointer_cast<RoutableReference>(clone());
     r->_collocationOptimized = newCollocationOptimized;
     return r;
 }
@@ -862,7 +862,7 @@ IceInternal::RoutableReference::changeCollocationOptimized(bool newCollocationOp
 ReferencePtr
 IceInternal::RoutableReference::changeCacheConnection(bool newCache) const
 {
-    RoutableReferencePtr r = dynamic_pointer_cast<RoutableReference>(clone());
+    RoutableReferencePtr r = static_pointer_cast<RoutableReference>(clone());
     r->_cacheConnection = newCache;
     return r;
 }
@@ -870,7 +870,7 @@ IceInternal::RoutableReference::changeCacheConnection(bool newCache) const
 ReferencePtr
 IceInternal::RoutableReference::changeEndpointSelection(EndpointSelectionType newType) const
 {
-    RoutableReferencePtr r = dynamic_pointer_cast<RoutableReference>(clone());
+    RoutableReferencePtr r = static_pointer_cast<RoutableReference>(clone());
     r->_endpointSelection = newType;
     return r;
 }
@@ -878,7 +878,7 @@ IceInternal::RoutableReference::changeEndpointSelection(EndpointSelectionType ne
 ReferencePtr
 IceInternal::RoutableReference::changeLocatorCacheTimeout(chrono::milliseconds timeout) const
 {
-    RoutableReferencePtr r = dynamic_pointer_cast<RoutableReference>(clone());
+    RoutableReferencePtr r = static_pointer_cast<RoutableReference>(clone());
     r->_locatorCacheTimeout = timeout;
     return r;
 }
@@ -886,7 +886,7 @@ IceInternal::RoutableReference::changeLocatorCacheTimeout(chrono::milliseconds t
 ReferencePtr
 IceInternal::RoutableReference::changeConnectionId(string id) const
 {
-    RoutableReferencePtr r = dynamic_pointer_cast<RoutableReference>(clone());
+    RoutableReferencePtr r = static_pointer_cast<RoutableReference>(clone());
     r->_connectionId = id;
     if (!_endpoints.empty()) // Also override the connection id on the endpoints.
     {
@@ -1259,7 +1259,7 @@ IceInternal::RoutableReference::getConnectionAsync(
     if (_routerInfo)
     {
         // If we route, we send everything to the router's client proxy endpoints.
-        auto self = dynamic_pointer_cast<RoutableReference>(const_cast<RoutableReference*>(this)->shared_from_this());
+        auto self = static_pointer_cast<RoutableReference>(const_cast<RoutableReference*>(this)->shared_from_this());
 
         _routerInfo->getClientEndpointsAsync(
             [self = std::move(self), response = std::move(response), exception](vector<EndpointIPtr> endpoints) mutable
@@ -1364,7 +1364,7 @@ IceInternal::RoutableReference::getConnectionNoRouterInfoAsync(
     if (_locatorInfo)
     {
         RoutableReferencePtr self =
-            dynamic_pointer_cast<RoutableReference>(const_cast<RoutableReference*>(this)->shared_from_this());
+            static_pointer_cast<RoutableReference>(const_cast<RoutableReference*>(this)->shared_from_this());
         _locatorInfo->getEndpoints(
             self,
             _locatorCacheTimeout,

--- a/cpp/src/Ice/SSL/SSLEndpointI.cpp
+++ b/cpp/src/Ice/SSL/SSLEndpointI.cpp
@@ -232,7 +232,7 @@ Ice::SSL::EndpointI::endpoint(const IceInternal::EndpointIPtr& delEndp) const
 {
     if (delEndp.get() == _delegate.get())
     {
-        return dynamic_pointer_cast<EndpointI>(const_cast<EndpointI*>(this)->shared_from_this());
+        return static_pointer_cast<EndpointI>(const_cast<EndpointI*>(this)->shared_from_this());
     }
     else
     {

--- a/cpp/src/Ice/TcpEndpointI.cpp
+++ b/cpp/src/Ice/TcpEndpointI.cpp
@@ -169,7 +169,7 @@ AcceptorPtr
 IceInternal::TcpEndpointI::acceptor(const string&, const optional<Ice::SSL::ServerAuthenticationOptions>&) const
 {
     return make_shared<TcpAcceptor>(
-        dynamic_pointer_cast<TcpEndpointI>(const_cast<TcpEndpointI*>(this)->shared_from_this()),
+        static_pointer_cast<TcpEndpointI>(const_cast<TcpEndpointI*>(this)->shared_from_this()),
         _instance,
         _host,
         _port);
@@ -181,7 +181,7 @@ IceInternal::TcpEndpointI::endpoint(const TcpAcceptorPtr& acceptor) const
     int port = acceptor->effectivePort();
     if (_port == port)
     {
-        return dynamic_pointer_cast<TcpEndpointI>(const_cast<TcpEndpointI*>(this)->shared_from_this());
+        return static_pointer_cast<TcpEndpointI>(const_cast<TcpEndpointI*>(this)->shared_from_this());
     }
     else
     {

--- a/cpp/src/Ice/UdpEndpointI.cpp
+++ b/cpp/src/Ice/UdpEndpointI.cpp
@@ -162,7 +162,7 @@ TransceiverPtr
 IceInternal::UdpEndpointI::transceiver() const
 {
     return make_shared<UdpTransceiver>(
-        dynamic_pointer_cast<UdpEndpointI>(const_cast<UdpEndpointI*>(this)->shared_from_this()),
+        static_pointer_cast<UdpEndpointI>(const_cast<UdpEndpointI*>(this)->shared_from_this()),
         _instance,
         _host,
         _port,
@@ -181,7 +181,7 @@ IceInternal::UdpEndpointI::endpoint(const UdpTransceiverPtr& transceiver) const
     int port = transceiver->effectivePort();
     if (port == _port)
     {
-        return dynamic_pointer_cast<UdpEndpointI>(const_cast<UdpEndpointI*>(this)->shared_from_this());
+        return static_pointer_cast<UdpEndpointI>(const_cast<UdpEndpointI*>(this)->shared_from_this());
     }
     else
     {

--- a/cpp/src/Ice/WSEndpoint.cpp
+++ b/cpp/src/Ice/WSEndpoint.cpp
@@ -298,7 +298,7 @@ IceInternal::WSEndpoint::endpoint(const EndpointIPtr& delEndp) const
 {
     if (delEndp.get() == _delegate.get())
     {
-        return dynamic_pointer_cast<WSEndpoint>(const_cast<WSEndpoint*>(this)->shared_from_this());
+        return static_pointer_cast<WSEndpoint>(const_cast<WSEndpoint*>(this)->shared_from_this());
     }
     else
     {

--- a/cpp/src/Ice/ios/StreamEndpointI.cpp
+++ b/cpp/src/Ice/ios/StreamEndpointI.cpp
@@ -284,7 +284,7 @@ IceObjC::StreamEndpointI::endpoint(const StreamAcceptorPtr& a) const
     int port = a->effectivePort();
     if (port == _port)
     {
-        return dynamic_pointer_cast<StreamEndpointI>(const_cast<StreamEndpointI*>(this)->shared_from_this());
+        return static_pointer_cast<StreamEndpointI>(const_cast<StreamEndpointI*>(this)->shared_from_this());
     }
     else
     {

--- a/cpp/src/IceGrid/SessionI.cpp
+++ b/cpp/src/IceGrid/SessionI.cpp
@@ -263,7 +263,7 @@ SessionI::destroyImpl(bool shutdown)
     {
         try
         {
-            allocation->release(dynamic_pointer_cast<SessionI>(shared_from_this()));
+            allocation->release(static_pointer_cast<SessionI>(shared_from_this()));
         }
         catch (const AllocationException&)
         {

--- a/cpp/src/Slice/Parser.cpp
+++ b/cpp/src/Slice/Parser.cpp
@@ -2199,13 +2199,13 @@ Slice::Module::getTopLevelModule() const
         return parent->getTopLevelModule();
     }
     // Reaching here means that this module is at the top-level! We return it.
-    return dynamic_pointer_cast<Module>(const_pointer_cast<Container>(shared_from_this()));
+    return static_pointer_cast<Module>(const_pointer_cast<Container>(shared_from_this()));
 }
 
 void
 Slice::Module::visit(ParserVisitor* visitor)
 {
-    auto self = dynamic_pointer_cast<Module>(shared_from_this());
+    auto self = static_pointer_cast<Module>(shared_from_this());
     if (visitor->visitModuleStart(self))
     {
         visitContents(visitor);
@@ -2480,7 +2480,7 @@ Slice::ClassDef::kindOf() const
 void
 Slice::ClassDef::visit(ParserVisitor* visitor)
 {
-    auto self = dynamic_pointer_cast<ClassDef>(shared_from_this());
+    auto self = static_pointer_cast<ClassDef>(shared_from_this());
     if (visitor->visitClassDefStart(self))
     {
         visitContents(visitor);
@@ -2925,7 +2925,7 @@ Slice::InterfaceDef::kindOf() const
 void
 Slice::InterfaceDef::visit(ParserVisitor* visitor)
 {
-    auto self = dynamic_pointer_cast<InterfaceDef>(shared_from_this());
+    auto self = static_pointer_cast<InterfaceDef>(shared_from_this());
     if (visitor->visitInterfaceDefStart(self))
     {
         visitContents(visitor);
@@ -3353,7 +3353,7 @@ Slice::Operation::kindOf() const
 void
 Slice::Operation::visit(ParserVisitor* visitor)
 {
-    visitor->visitOperation(dynamic_pointer_cast<Operation>(shared_from_this()));
+    visitor->visitOperation(static_pointer_cast<Operation>(shared_from_this()));
 }
 
 void
@@ -3589,7 +3589,7 @@ Slice::Exception::kindOf() const
 void
 Slice::Exception::visit(ParserVisitor* visitor)
 {
-    auto self = dynamic_pointer_cast<Exception>(shared_from_this());
+    auto self = static_pointer_cast<Exception>(shared_from_this());
     if (visitor->visitExceptionStart(self))
     {
         visitContents(visitor);
@@ -3744,7 +3744,7 @@ Slice::Struct::kindOf() const
 void
 Slice::Struct::visit(ParserVisitor* visitor)
 {
-    auto self = dynamic_pointer_cast<Struct>(shared_from_this());
+    auto self = static_pointer_cast<Struct>(shared_from_this());
     if (visitor->visitStructStart(self))
     {
         visitContents(visitor);
@@ -4078,7 +4078,7 @@ Slice::Enum::kindOf() const
 void
 Slice::Enum::visit(ParserVisitor* visitor)
 {
-    visitor->visitEnum(dynamic_pointer_cast<Enum>(shared_from_this()));
+    visitor->visitEnum(static_pointer_cast<Enum>(shared_from_this()));
 }
 
 void
@@ -4824,7 +4824,7 @@ Slice::Unit::destroy()
 void
 Slice::Unit::visit(ParserVisitor* visitor)
 {
-    auto self = dynamic_pointer_cast<Unit>(shared_from_this());
+    auto self = static_pointer_cast<Unit>(shared_from_this());
     if (visitor->visitUnitStart(self))
     {
         visitContents(visitor);
@@ -4853,7 +4853,7 @@ Slice::Unit::createBuiltin(Builtin::Kind kind)
     {
         return p->second;
     }
-    auto builtin = make_shared<Builtin>(dynamic_pointer_cast<Unit>(shared_from_this()), kind);
+    auto builtin = make_shared<Builtin>(static_pointer_cast<Unit>(shared_from_this()), kind);
     _builtins.insert(make_pair(kind, builtin));
     return builtin;
 }


### PR DESCRIPTION
This PR replaces a number of calls to dynamic_pointer_cast by calls to static_pointer_cast, usually in conjunction with a call to `shared_from_this()`.

Fixes #5373.