### PR TITLE
Use string converter when marshaling exceptions

### DIFF
--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -12,7 +12,7 @@
 #include "Ice/Properties.h"
 #include "IdleTimeoutTransceiverDecorator.h"
 #include "Instance.h"
-#include "ObjectAdapterI.h"   // For getThreadPool()
+#include "ObjectAdapterI.h" // For getThreadPool()
 #include "OutgoingResponseInternal.h"
 #include "ReferenceFactory.h" // For createProxy().
 #include "RequestHandler.h"   // For RetryException

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -13,6 +13,7 @@
 #include "IdleTimeoutTransceiverDecorator.h"
 #include "Instance.h"
 #include "ObjectAdapterI.h"   // For getThreadPool()
+#include "OutgoingResponseInternal.h"
 #include "ReferenceFactory.h" // For createProxy().
 #include "RequestHandler.h"   // For RetryException
 #include "ThreadPool.h"
@@ -3453,9 +3454,10 @@ Ice::ConnectionI::dispatchAll(
             {
                 // Received request on a connection without an object adapter.
                 sendResponse(
-                    makeOutgoingResponse(
+                    makeOutgoingResponseCore(
                         make_exception_ptr(ObjectNotExistException{__FILE__, __LINE__}),
-                        request.current()),
+                        request.current(),
+                        _instance.get()),
                     0);
             }
 

--- a/cpp/src/Ice/OutgoingResponse.cpp
+++ b/cpp/src/Ice/OutgoingResponse.cpp
@@ -2,9 +2,11 @@
 
 #include "Ice/OutgoingResponse.h"
 #include "Ice/Demangle.h"
+#include "Ice/Initialize.h"
 #include "Ice/LocalExceptions.h"
 #include "Ice/ObjectAdapter.h"
 #include "Ice/UserException.h"
+#include "OutgoingResponseInternal.h"
 #include "Protocol.h"
 
 #include <sstream>
@@ -29,131 +31,6 @@ namespace
         ostringstream os;
         os << "dispatch failed with " << typeId << ": " << what;
         return os.str();
-    }
-
-    // The "core" implementation of makeOutgoingResponse for exceptions. Note that it can throw an exception.
-    OutgoingResponse makeOutgoingResponseCore(std::exception_ptr exc, const Current& current)
-    {
-        assert(exc);
-        OutputStream ostr{currentProtocolEncoding};
-
-        if (current.requestId != 0)
-        {
-            ostr.writeBlob(replyHdr, sizeof(replyHdr));
-            ostr.write(current.requestId);
-        }
-        ReplyStatus replyStatus;
-        string exceptionId;
-        string exceptionDetails; // may include the stack trace.
-        string dispatchExceptionMessage;
-
-        try
-        {
-            rethrow_exception(exc);
-        }
-        catch (const UserException& ex)
-        {
-            // We keep exceptionId and exceptionDetails empty.
-
-            replyStatus = ReplyStatus::UserException;
-
-            if (current.requestId != 0)
-            {
-                ostr.write(replyStatus);
-                ostr.startEncapsulation(current.encoding, FormatType::SlicedFormat);
-                ostr.write(ex);
-                ostr.endEncapsulation();
-            }
-        }
-        catch (const DispatchException& ex)
-        {
-            exceptionId = ex.ice_id();
-            exceptionDetails = toString(ex); // can include a stack trace
-            replyStatus = ex.replyStatus();
-
-            if (replyStatus >= ReplyStatus::ObjectNotExist && replyStatus <= ReplyStatus::OperationNotExist)
-            {
-                if (current.requestId != 0) // only marshal response for two-way requests
-                {
-                    // The identity, facet, operation are often left unset at this point.
-                    Identity id;
-                    string facet;
-                    string operation;
-                    if (auto* rfe = dynamic_cast<const RequestFailedException*>(&ex))
-                    {
-                        id = rfe->id();
-                        facet = rfe->facet();
-                        operation = rfe->operation();
-                    }
-                    if (id.name.empty())
-                    {
-                        id = current.id;
-                        facet = current.facet;
-                    }
-                    if (operation.empty())
-                    {
-                        operation = current.operation;
-                    }
-
-                    ostr.write(replyStatus);
-                    ostr.write(id);
-
-                    if (facet.empty())
-                    {
-                        ostr.write(static_cast<string*>(nullptr), static_cast<string*>(nullptr));
-                    }
-                    else
-                    {
-                        ostr.write(&facet, &facet + 1);
-                    }
-                    ostr.write(operation, false);
-                }
-                // dispatchExceptionMessage remains empty: RequestFailedException does not carry a message and we
-                // don't include this message in OutgoingResponse.
-            }
-            else
-            {
-                dispatchExceptionMessage = ex.what();
-                // And marshal this exception after the last catch block.
-            }
-        }
-        catch (const LocalException& ex)
-        {
-            exceptionId = ex.ice_id();
-            exceptionDetails = toString(ex);
-            dispatchExceptionMessage = createDispatchExceptionMessage(exceptionId, ex.what());
-            replyStatus = ReplyStatus::UnknownLocalException;
-        }
-        catch (const std::exception& ex)
-        {
-            exceptionId = demangle(typeid(ex).name());
-            ostringstream str;
-            str << "c++ exception: " << ex.what();
-            exceptionDetails = str.str();
-            dispatchExceptionMessage = createDispatchExceptionMessage(exceptionId, ex.what());
-            replyStatus = ReplyStatus::UnknownException;
-        }
-        catch (...)
-        {
-            exceptionId = "unknown";
-            exceptionDetails = "c++ exception: unknown";
-            dispatchExceptionMessage = createDispatchExceptionMessage(exceptionId, "c++ exception");
-            replyStatus = ReplyStatus::UnknownException;
-        }
-
-        if (current.requestId != 0 && replyStatus > ReplyStatus::OperationNotExist)
-        {
-            // We can't use the generated code to marshal a possibly unknown reply status.
-            ostr.write(static_cast<uint8_t>(replyStatus));
-            ostr.write(dispatchExceptionMessage);
-        }
-
-        return OutgoingResponse{
-            replyStatus,
-            std::move(exceptionId),
-            std::move(exceptionDetails),
-            std::move(ostr),
-            current};
     }
 } // anonymous namespace
 
@@ -264,13 +141,136 @@ Ice::makeOutgoingResponse(bool ok, pair<const byte*, const byte*> encapsulation,
 OutgoingResponse
 Ice::makeOutgoingResponse(std::exception_ptr exc, const Current& current) noexcept
 {
+    IceInternal::Instance* instance = getInstance(current.adapter->getCommunicator()).get();
+
     try
     {
-        return makeOutgoingResponseCore(exc, current);
+        return makeOutgoingResponseCore(exc, current, instance);
     }
     catch (...)
     {
         // This could throw again, but then it's either a bug or we can't allocate anything.
-        return makeOutgoingResponseCore(current_exception(), current);
+        return makeOutgoingResponseCore(current_exception(), current, instance);
     }
+}
+
+// The "core" implementation of makeOutgoingResponse for exceptions. Note that it can throw an exception.
+OutgoingResponse
+Ice::makeOutgoingResponseCore(std::exception_ptr exc, const Current& current, Instance* instance)
+{
+    assert(exc);
+    OutputStream ostr{instance, currentProtocolEncoding};
+
+    if (current.requestId != 0)
+    {
+        ostr.writeBlob(replyHdr, sizeof(replyHdr));
+        ostr.write(current.requestId);
+    }
+    ReplyStatus replyStatus;
+    string exceptionId;
+    string exceptionDetails; // may include the stack trace.
+    string dispatchExceptionMessage;
+
+    try
+    {
+        rethrow_exception(exc);
+    }
+    catch (const UserException& ex)
+    {
+        // We keep exceptionId and exceptionDetails empty.
+
+        replyStatus = ReplyStatus::UserException;
+
+        if (current.requestId != 0)
+        {
+            ostr.write(replyStatus);
+            ostr.startEncapsulation(current.encoding, FormatType::SlicedFormat);
+            ostr.write(ex);
+            ostr.endEncapsulation();
+        }
+    }
+    catch (const DispatchException& ex)
+    {
+        exceptionId = ex.ice_id();
+        exceptionDetails = toString(ex); // can include a stack trace
+        replyStatus = ex.replyStatus();
+
+        if (replyStatus >= ReplyStatus::ObjectNotExist && replyStatus <= ReplyStatus::OperationNotExist)
+        {
+            if (current.requestId != 0) // only marshal response for two-way requests
+            {
+                // The identity, facet, operation are often left unset at this point.
+                Identity id;
+                string facet;
+                string operation;
+                if (auto* rfe = dynamic_cast<const RequestFailedException*>(&ex))
+                {
+                    id = rfe->id();
+                    facet = rfe->facet();
+                    operation = rfe->operation();
+                }
+                if (id.name.empty())
+                {
+                    id = current.id;
+                    facet = current.facet;
+                }
+                if (operation.empty())
+                {
+                    operation = current.operation;
+                }
+
+                ostr.write(replyStatus);
+                ostr.write(id);
+
+                if (facet.empty())
+                {
+                    ostr.write(static_cast<string*>(nullptr), static_cast<string*>(nullptr));
+                }
+                else
+                {
+                    ostr.write(&facet, &facet + 1);
+                }
+                ostr.write(operation, false);
+            }
+            // dispatchExceptionMessage remains empty: RequestFailedException does not carry a message and we
+            // don't include this message in OutgoingResponse.
+        }
+        else
+        {
+            dispatchExceptionMessage = ex.what();
+            // And marshal this exception after the last catch block.
+        }
+    }
+    catch (const LocalException& ex)
+    {
+        exceptionId = ex.ice_id();
+        exceptionDetails = toString(ex);
+        dispatchExceptionMessage = createDispatchExceptionMessage(exceptionId, ex.what());
+        replyStatus = ReplyStatus::UnknownLocalException;
+    }
+    catch (const std::exception& ex)
+    {
+        exceptionId = demangle(typeid(ex).name());
+        ostringstream str;
+        str << "c++ exception: " << ex.what();
+        exceptionDetails = str.str();
+        dispatchExceptionMessage = createDispatchExceptionMessage(exceptionId, ex.what());
+        replyStatus = ReplyStatus::UnknownException;
+    }
+    catch (...)
+    {
+        exceptionId = "unknown";
+        exceptionDetails = "c++ exception: unknown";
+        dispatchExceptionMessage = createDispatchExceptionMessage(exceptionId, "c++ exception");
+        replyStatus = ReplyStatus::UnknownException;
+    }
+
+    if (current.requestId != 0 && replyStatus > ReplyStatus::OperationNotExist)
+    {
+        // We can't use the generated code to marshal a possibly unknown reply status.
+        ostr.write(static_cast<uint8_t>(replyStatus));
+        ostr.write(dispatchExceptionMessage);
+    }
+
+    return OutgoingResponse{replyStatus, std::move(exceptionId), std::move(exceptionDetails), std::move(ostr), current};
 }

--- a/cpp/src/Ice/OutgoingResponseInternal.h
+++ b/cpp/src/Ice/OutgoingResponseInternal.h
@@ -14,10 +14,8 @@ namespace Ice
     /// implementation uses @p instance instead.
     /// @param instance The IceInternal::Instance object. Not null.
     /// @return The new response.
-    OutgoingResponse makeOutgoingResponseCore(
-        std::exception_ptr exception,
-        const Current& current,
-        IceInternal::Instance* instance);
-    }
+    OutgoingResponse
+    makeOutgoingResponseCore(std::exception_ptr exception, const Current& current, IceInternal::Instance* instance);
+}
 
 #endif

--- a/cpp/src/Ice/OutgoingResponseInternal.h
+++ b/cpp/src/Ice/OutgoingResponseInternal.h
@@ -1,0 +1,23 @@
+// Copyright (c) ZeroC, Inc.
+
+#ifndef ICE_OUTGOING_RESPONSE_INTERNAL_H
+#define ICE_OUTGOING_RESPONSE_INTERNAL_H
+
+#include "Ice/OutgoingResponse.h"
+
+namespace Ice
+{
+    /// @private
+    /// The "core" implementation of makeOutgoingResponse for exceptions. Note that it can throw an exception.
+    /// @param exception The exception to marshal into the response.
+    /// @param current A reference to the Current object of the request. @c current.adapter can be null here; the
+    /// implementation uses @p instance instead.
+    /// @param instance The IceInternal::Instance object. Not null.
+    /// @return The new response.
+    OutgoingResponse makeOutgoingResponseCore(
+        std::exception_ptr exception,
+        const Current& current,
+        IceInternal::Instance* instance);
+    }
+
+#endif


### PR DESCRIPTION
This PR fixes the marshaling of exceptions to correctly use the configured string/wstring converters (if any).

This is a follow-up to #5392.