### PR TITLE
Fix broken TerserWebpackPlugin link in js/README.md (#5326)

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -51,8 +51,8 @@ remove such statements. Different module bundlers provide different options, for
 
 - If using [esbuild], see [drop option][esbuild-drop], which allows removing console statements.
 - If using rollup, see the [@rollup/plugin-strip], which can remove specific function calls such as `console.assert`.
-- If using WebPack the [TerserWebpackPlugin] plugin can be configured to drop `console.assert`; see `drop_console` in
-[terser options].
+- If using WebPack, see [JavaScript Minification][webpack-js-minification]; the underlying Terser minifier can be
+configured to drop `console.assert` via `drop_console` in [terser options].
 
 [Examples]: https://github.com/zeroc-ice/ice-demos/tree/3.8/js
 [NPM Packages]: https://zeroc.com/ice/downloads/3.8/javascript
@@ -63,5 +63,5 @@ remove such statements. Different module bundlers provide different options, for
 [esbuild]: https://esbuild.github.io/
 [esbuild-drop]: https://esbuild.github.io/api/#drop
 [@rollup/plugin-strip]: https://github.com/rollup/plugins/tree/master/packages/strip
-[TerserWebpackPlugin]: https://webpack.js.org/plugins/terser-webpack-plugin/
+[webpack-js-minification]: https://docs.webpack.js.org/guides/production#javascript-minification
 [terser options]: https://terser.org/docs/options/


### PR DESCRIPTION
Cherry-picks #5326 (commit a032926188) onto 3.8.

The broken-link fix landed on `main` but was never cherry-picked to 3.8, so 3.8's `js/README.md` still pointed at the dead `TerserWebpackPlugin` page. The change is version-agnostic — it only updates the WebPack minification sentence and its link definition to point at the current `JavaScript Minification` webpack docs; the 3.8-specific links (examples, downloads, docs, API) are untouched.