### PR TITLE
Remove unused foojay-resolver-convention plugin

### DIFF
--- a/java/settings.gradle
+++ b/java/settings.gradle
@@ -4,10 +4,6 @@ pluginManagement {
     includeBuild "./tools/slice-tools"
 }
 
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
-}
-
 // Source projects
 include ':ice'
 project(':ice').projectDir = new File('src/com.zeroc.ice')


### PR DESCRIPTION
## What
Removes the `org.gradle.toolchains.foojay-resolver-convention` plugin from `java/settings.gradle`.

## Why
This plugin registers the Foojay Disco API as a JDK download source for Gradle's Java **toolchain auto-provisioning** — it only does anything when a build requests a toolchain (`java { toolchain { languageVersion = ... } }`).

The only such toolchain block was removed in #4797 ("Do not require a specific Java toolchain"). The resolver was then added shortly after, bundled into the large release-workflow PR #4798. With no toolchain requested anywhere under `java/` (verified: the plugin line was the sole `toolchain`/`languageVersion` reference, and no `gradle.properties` enables `auto-download`), the resolver is never consulted — it's dead config.

This restores `settings.gradle` to its pre-#4798 state (byte-identical to the 3.8 branch).

## Testing
Static verification only (no toolchain consumers remain). The Java build does not pin a toolchain and uses `targetJavaRelease` via `--release`, which is unaffected.