### PR TITLE
Remove unused vinyl JS devDependency

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -29,7 +29,6 @@
                 "typedoc": "^0.28.19",
                 "typescript": "^6.0.3",
                 "typescript-eslint": "^8.59.4",
-                "vinyl": "^3.0.1",
                 "vite": "^8.0.14",
                 "webpack": "^5.106.2"
             },

--- a/js/package.json
+++ b/js/package.json
@@ -29,7 +29,6 @@
         "typedoc": "^0.28.19",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.4",
-        "vinyl": "^3.0.1",
         "vite": "^8.0.14",
         "webpack": "^5.106.2"
     },


### PR DESCRIPTION
vinyl is not imported by any source or build script 