### PR TITLE
Add Ubuntu 26.04 (resolute) DEB package support

### DIFF
--- a/.github/workflows/build-container-images.yml
+++ b/.github/workflows/build-container-images.yml
@@ -72,6 +72,14 @@ jobs:
             image: ice-deb-builder-ubuntu24.04
             dockerfile: packaging/deb/docker/Dockerfile
             base_image: ubuntu:24.04
+          - platform: amd64
+            image: ice-deb-builder-ubuntu26.04
+            dockerfile: packaging/deb/docker/Dockerfile
+            base_image: ubuntu:26.04
+          - platform: arm64
+            image: ice-deb-builder-ubuntu26.04
+            dockerfile: packaging/deb/docker/Dockerfile
+            base_image: ubuntu:26.04
 
     env:
       # On Red Hat-based images, we need to provide credentials to access the Red Hat repositories.
@@ -147,6 +155,7 @@ jobs:
           - ice-deb-builder-debian13
           - ice-deb-builder-sid
           - ice-deb-builder-ubuntu24.04
+          - ice-deb-builder-ubuntu26.04
           - ice-rpm-builder-amzn2023
           - ice-rpm-builder-el10
           - ice-rpm-builder-el9

--- a/.github/workflows/build-deb-ice-repo-packages.yml
+++ b/.github/workflows/build-deb-ice-repo-packages.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        distribution: [debian12, debian13, ubuntu24.04]
+        distribution: [debian12, debian13, ubuntu24.04, ubuntu26.04]
 
     steps:
       - name: Check out repository

--- a/.github/workflows/build-deb-packages.yml
+++ b/.github/workflows/build-deb-packages.yml
@@ -32,6 +32,12 @@ jobs:
           - distribution: ubuntu24.04
             arch: arm64
 
+          - distribution: ubuntu26.04
+            arch: amd64
+
+          - distribution: ubuntu26.04
+            arch: arm64
+
           - distribution: debian12
             arch: amd64
             deb_build_profiles: "nopython"

--- a/.github/workflows/publish-deb-packages.yml
+++ b/.github/workflows/publish-deb-packages.yml
@@ -35,6 +35,7 @@ jobs:
           - distribution: debian12
           - distribution: debian13
           - distribution: ubuntu24.04
+          - distribution: ubuntu26.04
     env:
       DISTRIBUTION: ${{ matrix.distribution }}
       CHANNEL: ${{ inputs.channel }}

--- a/packaging/common/codenames.sh
+++ b/packaging/common/codenames.sh
@@ -10,4 +10,5 @@ declare -A CODENAMES=(
     ["debian13"]="trixie"
     ["sid"]="sid"
     ["ubuntu24.04"]="noble"
+    ["ubuntu26.04"]="resolute"
 )


### PR DESCRIPTION
Add ubuntu26.04 to the DEB builder image, package build, repo package, and publish workflows, and map it to the resolute codename.

CI (ci-linux.yml) is intentionally left for a follow-up PR: it runs on pull_request and would fail until the ice-deb-builder-ubuntu26.04 image is built and pushed to GHCR.

Verified locally by building the ice-deb-builder image from ubuntu:26.04 and producing the full set of binary packages.