### PR TITLE
Test Ubuntu 26.04 DEB packages in CI

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -53,6 +53,13 @@ jobs:
             arch: arm64
             image_type: deb
 
+          - distribution: ubuntu26.04
+            arch: amd64
+            image_type: deb
+          - distribution: ubuntu26.04
+            arch: arm64
+            image_type: deb
+
           - distribution: debian12
             arch: amd64
             image_type: deb


### PR DESCRIPTION
Add ubuntu26.04 (amd64 and arm64) to the ci-linux test matrix.