### PR TITLE
Fix integer overflow in readAndCheckSeqSize sequence-size guard (3.7.12)

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -8,8 +8,11 @@ We recommend that you use the release notes as a guide for migrating your
 applications to this release, and the manual for complete details on a
 particular aspect of Ice.
 
-- [Changes in Ice 3.7.11](#changes-in-ice-3711)
+- [Changes in Ice 3.7.12](#changes-in-ice-3712)
   - [General Changes](#general-changes)
+  - [Swift Changes](#swift-changes)
+- [Changes in Ice 3.7.11](#changes-in-ice-3711)
+  - [General Changes](#general-changes-1)
   - [C++ Changes](#c-changes)
   - [C# Changes](#c-changes-1)
   - [Java Changes](#java-changes)
@@ -17,7 +20,7 @@ particular aspect of Ice.
   - [MATLAB Changes](#matlab-changes)
   - [Python Changes](#python-changes)
   - [Ruby Changes](#ruby-changes)
-  - [Swift Changes](#swift-changes)
+  - [Swift Changes](#swift-changes-1)
   - [IceSSL Changes](#icessl-changes)
   - [IceStorm Changes](#icestorm-changes)
 - [Changes in Ice 3.7.10](#changes-in-ice-3710)
@@ -32,7 +35,7 @@ particular aspect of Ice.
   - [PHP Changes](#php-changes)
   - [Python Changes](#python-changes-2)
   - [Ruby Changes](#ruby-changes-1)
-  - [Swift Changes](#swift-changes-1)
+  - [Swift Changes](#swift-changes-2)
 - [Changes in Ice 3.7.8](#changes-in-ice-378)
   - [C++ Changes](#c-changes-6)
   - [JavaScript Changes](#javascript-changes-1)
@@ -43,31 +46,31 @@ particular aspect of Ice.
   - [C++ Changes](#c-changes-7)
   - [Java Changes](#java-changes-3)
 - [Changes in Ice 3.7.6](#changes-in-ice-376)
-  - [General Changes](#general-changes-1)
+  - [General Changes](#general-changes-2)
   - [C++ Changes](#c-changes-8)
   - [Java Changes](#java-changes-4)
   - [JavaScript Changes](#javascript-changes-2)
-  - [Swift Changes](#swift-changes-2)
+  - [Swift Changes](#swift-changes-3)
 - [Changes in Ice 3.7.5](#changes-in-ice-375)
-  - [General Changes](#general-changes-2)
+  - [General Changes](#general-changes-3)
   - [C++ Changes](#c-changes-9)
   - [C# Changes](#c-changes-10)
   - [JavaScript Changes](#javascript-changes-3)
   - [PHP Changes](#php-changes-2)
   - [Python Changes](#python-changes-4)
   - [Ruby Changes](#ruby-changes-2)
-  - [Swift Changes](#swift-changes-3)
+  - [Swift Changes](#swift-changes-4)
 - [Changes in Ice 3.7.4](#changes-in-ice-374)
-  - [General Changes](#general-changes-3)
+  - [General Changes](#general-changes-4)
   - [C++ Changes](#c-changes-11)
   - [C# Changes](#c-changes-12)
   - [JavaScript Changes](#javascript-changes-4)
   - [MATLAB Changes](#matlab-changes-2)
   - [Python Changes](#python-changes-5)
   - [Ruby Changes](#ruby-changes-3)
-  - [Swift Changes](#swift-changes-4)
+  - [Swift Changes](#swift-changes-5)
 - [Changes in Ice 3.7.3](#changes-in-ice-373)
-  - [General Changes](#general-changes-4)
+  - [General Changes](#general-changes-5)
   - [C++ Changes](#c-changes-13)
   - [C# Changes](#c-changes-14)
   - [Java Changes](#java-changes-5)
@@ -75,7 +78,7 @@ particular aspect of Ice.
   - [MATLAB Changes](#matlab-changes-3)
   - [Python Changes](#python-changes-6)
 - [Changes in Ice 3.7.2](#changes-in-ice-372)
-  - [General Changes](#general-changes-5)
+  - [General Changes](#general-changes-6)
   - [C++ Changes](#c-changes-15)
   - [C# Changes](#c-changes-16)
   - [Java Changes](#java-changes-6)
@@ -85,7 +88,7 @@ particular aspect of Ice.
   - [PHP Changes](#php-changes-3)
   - [Python Changes](#python-changes-7)
 - [Changes in Ice 3.7.1](#changes-in-ice-371)
-  - [General Changes](#general-changes-6)
+  - [General Changes](#general-changes-7)
   - [C++ Changes](#c-changes-17)
   - [C# Changes](#c-changes-18)
   - [Java Changes](#java-changes-7)
@@ -96,7 +99,7 @@ particular aspect of Ice.
   - [Python Changes](#python-changes-8)
   - [Ruby Changes](#ruby-changes-4)
 - [Changes in Ice 3.7.0](#changes-in-ice-370)
-  - [General Changes](#general-changes-7)
+  - [General Changes](#general-changes-8)
   - [C++ Changes](#c-changes-19)
   - [C# Changes](#c-changes-20)
   - [Java Changes](#java-changes-8)
@@ -105,6 +108,19 @@ particular aspect of Ice.
   - [PHP Changes](#php-changes-5)
   - [Python Changes](#python-changes-9)
   - [Ruby Changes](#ruby-changes-5)
+
+# Changes in Ice 3.7.12
+
+These are the changes since Ice 3.7.11.
+
+## General Changes
+
+- Hardened the unmarshaling code to detect and reject invalid data sent by a peer:
+  - Fixed an integer overflow in the sequence-size validation performed while unmarshaling.
+
+## Swift Changes
+
+- Fixed `InputStream.readSize` to reject a negative size.
 
 # Changes in Ice 3.7.11
 

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -384,14 +384,19 @@ Ice::InputStream::readAndCheckSeqSize(int minSize)
     // the estimated remaining buffer size. This estimation is based on
     // the minimum size of the enclosing sequences, it's _minSeqSize.
     //
-    if(_startSeq == -1 || i > (b.begin() + _startSeq + _minSeqSize))
+    // 'sz' is peer-controlled (up to INT32_MAX), so we compute the minimum size of this sequence in
+    // 64-bit: 'sz * minSize' would otherwise overflow a 32-bit int and bypass the bounds check below.
+    Long minSeqSize = static_cast<Long>(sz) * minSize;
+
+    // '_startSeq + _minSeqSize' does not overflow: on the previous call, the bounds check below
+    // established this sum is <= b.size(), itself smaller than INT32_MAX.
+    if(_startSeq == -1 || (i - b.begin()) > _startSeq + _minSeqSize)
     {
         _startSeq = static_cast<int>(i - b.begin());
-        _minSeqSize = sz * minSize;
     }
     else
     {
-        _minSeqSize += sz * minSize;
+        minSeqSize += _minSeqSize;
     }
 
     //
@@ -399,10 +404,13 @@ Ice::InputStream::readAndCheckSeqSize(int minSize)
     // possibly enclosed sequences), something is wrong with the marshalled
     // data: it's claiming having more data that what is possible to read.
     //
-    if(_startSeq + _minSeqSize > static_cast<int>(b.size()))
+    if(_startSeq + minSeqSize > static_cast<Long>(b.size()))
     {
         throw UnmarshalOutOfBoundsException(__FILE__, __LINE__);
     }
+
+    // minSeqSize is now known to be <= b.size(), itself smaller than INT32_MAX.
+    _minSeqSize = static_cast<int>(minSeqSize);
 
     return sz;
 }

--- a/cpp/test/Ice/stream/Client.cpp
+++ b/cpp/test/Ice/stream/Client.cpp
@@ -1353,6 +1353,26 @@ allTests(Test::TestHelper* helper)
     }
 
     cout << "ok" << endl;
+
+    cout << "testing sequence size validation... " << flush;
+    {
+        // A peer-supplied sequence size must be validated so that 'size * minWireSize' cannot overflow
+        // a 32-bit int and defeat the bounds check in readAndCheckSeqSize.
+        Ice::OutputStream out(communicator);
+        out.writeSize(0x10000000); // 268435456; * 8 (the min wire size of a long) overflows a 32-bit int.
+        out.finished(data);
+
+        Ice::InputStream in(communicator, data);
+        try
+        {
+            in.readAndCheckSeqSize(8); // 8 is the min wire size of a sequence<long> element.
+            test(false);
+        }
+        catch(const Ice::UnmarshalOutOfBoundsException&)
+        {
+        }
+    }
+    cout << "ok" << endl;
 }
 
 class Client : public Test::TestHelper

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -840,14 +840,16 @@ namespace Ice
             // the estimated remaining buffer size. This estimation is based on
             // the minimum size of the enclosing sequences, it's _minSeqSize.
             //
+            // 'sz' is peer-controlled (up to int.MaxValue), so we compute the minimum size of this
+            // sequence in 64-bit: 'sz * minSize' would overflow a 32-bit int and bypass the bounds check.
+            long minSeqSize = (long)sz * minSize;
             if(_startSeq == -1 || _buf.b.position() > (_startSeq + _minSeqSize))
             {
                 _startSeq = _buf.b.position();
-                _minSeqSize = sz * minSize;
             }
             else
             {
-                _minSeqSize += sz * minSize;
+                minSeqSize += _minSeqSize;
             }
 
             //
@@ -855,11 +857,13 @@ namespace Ice
             // possibly enclosed sequences), something is wrong with the marshalled
             // data: it's claiming having more data that what is possible to read.
             //
-            if(_startSeq + _minSeqSize > _buf.size())
+            if(_startSeq + minSeqSize > _buf.size())
             {
                 throw new UnmarshalOutOfBoundsException();
             }
 
+            // minSeqSize is now known to be <= _buf.size(), itself smaller than int.MaxValue.
+            _minSeqSize = (int)minSeqSize;
             return sz;
         }
 

--- a/csharp/test/Ice/stream/AllTests.cs
+++ b/csharp/test/Ice/stream/AllTests.cs
@@ -1080,6 +1080,27 @@ namespace Ice
                 }
 
                 output.WriteLine("ok");
+
+                output.Write("testing sequence size validation... ");
+                output.Flush();
+                {
+                    // A peer-supplied sequence size must be validated so that 'size * minWireSize' cannot
+                    // overflow a 32-bit int and defeat the bounds check in readAndCheckSeqSize.
+                    outS = new Ice.OutputStream(communicator);
+                    outS.writeSize(0x10000000); // 268435456; * 8 (the min wire size of a long) overflows a 32-bit int.
+                    byte[] data = outS.finished();
+                    inS = new Ice.InputStream(communicator, data);
+                    try
+                    {
+                        inS.readAndCheckSeqSize(8); // 8 is the min wire size of a sequence<long> element.
+                        test(false);
+                    }
+                    catch(Ice.UnmarshalOutOfBoundsException)
+                    {
+                    }
+                }
+
+                output.WriteLine("ok");
                 return 0;
             }
         }

--- a/java-compat/src/Ice/src/main/java/Ice/InputStream.java
+++ b/java-compat/src/Ice/src/main/java/Ice/InputStream.java
@@ -872,14 +872,16 @@ public class InputStream
         // the estimated remaining buffer size. This estimation is based on
         // the minimum size of the enclosing sequences, it's _minSeqSize.
         //
+        // 'sz' is peer-controlled (up to Integer.MAX_VALUE), so we compute the minimum size of this
+        // sequence in 64-bit: 'sz * minSize' would overflow a 32-bit int and bypass the bounds check.
+        long minSeqSize = (long)sz * minSize;
         if(_startSeq == -1 || _buf.b.position() > (_startSeq + _minSeqSize))
         {
             _startSeq = _buf.b.position();
-            _minSeqSize = sz * minSize;
         }
         else
         {
-            _minSeqSize += sz * minSize;
+            minSeqSize += _minSeqSize;
         }
 
         //
@@ -887,11 +889,13 @@ public class InputStream
         // possibly enclosed sequences), something is wrong with the marshalled
         // data: it's claiming having more data that what is possible to read.
         //
-        if(_startSeq + _minSeqSize > _buf.size())
+        if(_startSeq + minSeqSize > _buf.size())
         {
             throw new UnmarshalOutOfBoundsException();
         }
 
+        // minSeqSize is now known to be <= _buf.size(), itself smaller than Integer.MAX_VALUE.
+        _minSeqSize = (int)minSeqSize;
         return sz;
     }
 

--- a/java-compat/test/src/main/java/test/Ice/stream/Client.java
+++ b/java-compat/test/src/main/java/test/Ice/stream/Client.java
@@ -846,6 +846,27 @@ public class Client extends test.TestHelper
             }
 
             printWriter.println("ok");
+
+            printWriter.print("testing sequence size validation... ");
+            printWriter.flush();
+            {
+                // A peer-supplied sequence size must be validated so that 'size * minWireSize' cannot
+                // overflow a 32-bit int and defeat the bounds check in readAndCheckSeqSize.
+                out = new Ice.OutputStream(comm);
+                out.writeSize(0x10000000); // 268435456; * 8 (the min wire size of a long) overflows a 32-bit int.
+                byte[] data = out.finished();
+                in = new Ice.InputStream(comm, data);
+                try
+                {
+                    in.readAndCheckSeqSize(8); // 8 is the min wire size of a sequence<long> element.
+                    test(false);
+                }
+                catch(Ice.UnmarshalOutOfBoundsException ex)
+                {
+                }
+            }
+
+            printWriter.println("ok");
         }
     }
 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -874,14 +874,16 @@ public class InputStream
         // the estimated remaining buffer size. This estimation is based on
         // the minimum size of the enclosing sequences, it's _minSeqSize.
         //
+        // 'sz' is peer-controlled (up to Integer.MAX_VALUE), so we compute the minimum size of this
+        // sequence in 64-bit: 'sz * minSize' would overflow a 32-bit int and bypass the bounds check.
+        long minSeqSize = (long)sz * minSize;
         if(_startSeq == -1 || _buf.b.position() > (_startSeq + _minSeqSize))
         {
             _startSeq = _buf.b.position();
-            _minSeqSize = sz * minSize;
         }
         else
         {
-            _minSeqSize += sz * minSize;
+            minSeqSize += _minSeqSize;
         }
 
         //
@@ -889,11 +891,13 @@ public class InputStream
         // possibly enclosed sequences), something is wrong with the marshalled
         // data: it's claiming having more data that what is possible to read.
         //
-        if(_startSeq + _minSeqSize > _buf.size())
+        if(_startSeq + minSeqSize > _buf.size())
         {
             throw new UnmarshalOutOfBoundsException();
         }
 
+        // minSeqSize is now known to be <= _buf.size(), itself smaller than Integer.MAX_VALUE.
+        _minSeqSize = (int)minSeqSize;
         return sz;
     }
 

--- a/java/test/src/main/java/test/Ice/stream/Client.java
+++ b/java/test/src/main/java/test/Ice/stream/Client.java
@@ -800,6 +800,27 @@ public class Client extends test.TestHelper
             }
 
             printWriter.println("ok");
+
+            printWriter.print("testing sequence size validation... ");
+            printWriter.flush();
+            {
+                // A peer-supplied sequence size must be validated so that 'size * minWireSize' cannot
+                // overflow a 32-bit int and defeat the bounds check in readAndCheckSeqSize.
+                out = new OutputStream(communicator);
+                out.writeSize(0x10000000); // 268435456; * 8 (the min wire size of a long) overflows a 32-bit int.
+                byte[] data = out.finished();
+                in = new InputStream(communicator, data);
+                try
+                {
+                    in.readAndCheckSeqSize(8); // 8 is the min wire size of a sequence<long> element.
+                    test(false);
+                }
+                catch(com.zeroc.Ice.UnmarshalOutOfBoundsException ex)
+                {
+                }
+            }
+
+            printWriter.println("ok");
         }
     }
 }

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -563,7 +563,12 @@ public extension InputStream {
     func readSize() throws -> Int32 {
         let byteVal: UInt8 = try read()
         if byteVal == 255 {
-            return try read()
+            let v: Int32 = try read()
+            // A size is a non-negative value; reject a negative one encoded in the 5-byte form.
+            if v < 0 {
+                throw MarshalException(reason: "read invalid size: \(v)")
+            }
+            return v
         } else {
             return Int32(byteVal)
         }
@@ -599,11 +604,17 @@ public extension InputStream {
         // the estimated remaining buffer size. This estimation is based on
         // the minimum size of the enclosing sequences, it's minSeqSize.
         //
-        if startSeq == -1 || pos > (startSeq + minSeqSize) {
+        // 'sz' is peer-controlled (up to Int32.max), so we compute the minimum size of this
+        // sequence as an Int64: 'sz * minSize' would otherwise overflow a 32-bit value and bypass
+        // the bounds check (and the Int32 conversion below would trap).
+        var newMinSeqSize = Int64(sz) * Int64(minSize)
+
+        // 'startSeq + minSeqSize' does not overflow: on the previous call, the bounds check below
+        // established this sum is <= data.count, itself smaller than Int32.max.
+        if startSeq == -1 || pos > Int(startSeq + minSeqSize) {
             startSeq = Int32(pos)
-            minSeqSize = Int32(sz * minSize)
         } else {
-            minSeqSize += Int32(sz * minSize)
+            newMinSeqSize += Int64(minSeqSize)
         }
 
         //
@@ -611,10 +622,12 @@ public extension InputStream {
         // possibly enclosed sequences), something is wrong with the marshalled
         // data: it's claiming having more data that what is possible to read.
         //
-        if startSeq + minSeqSize > data.count {
+        if Int64(startSeq) + newMinSeqSize > Int64(data.count) {
             throw UnmarshalOutOfBoundsException(reason: "bad sequence size")
         }
 
+        // newMinSeqSize is now known to be <= data.count, itself smaller than Int32.max.
+        minSeqSize = Int32(newMinSeqSize)
         return sz
     }
 

--- a/swift/test/Ice/stream/Client.swift
+++ b/swift/test/Ice/stream/Client.swift
@@ -587,5 +587,33 @@ public class Client: TestHelperI {
             try test(dict2["key2"]!!.s.e == MyEnum.enum3)
         }
         writer.writeLine("ok")
+
+        writer.write("testing sequence size validation... ")
+        do {
+            // A peer-supplied sequence size must be validated so that 'size * minWireSize' cannot
+            // overflow and defeat the bounds check in readAndCheckSeqSize.
+            outS = Ice.OutputStream(communicator: communicator)
+            outS.write(size: Int32(0x1000_0000))  // 268435456; * 8 (the min wire size of a long) overflows Int32.
+            let data = outS.finished()
+            inS = Ice.InputStream(communicator: communicator, bytes: data)
+            do {
+                _ = try inS.readAndCheckSeqSize(minSize: 8)  // 8 is the min wire size of a sequence<long> element.
+                try test(false)
+            } catch is Ice.UnmarshalOutOfBoundsException {}
+        }
+        do {
+            // A negative size encoded in the 5-byte form must be rejected, not returned to a caller
+            // that would trap allocating an array with a negative count.
+            outS = Ice.OutputStream(communicator: communicator)
+            outS.write(UInt8(255))  // size marker for the 5-byte encoding
+            outS.write(Int32(-1))  // a negative 32-bit size
+            let data = outS.finished()
+            inS = Ice.InputStream(communicator: communicator, bytes: data)
+            do {
+                _ = try inS.readSize()
+                try test(false)
+            } catch is Ice.MarshalException {}
+        }
+        writer.writeLine("ok")
     }
 }


### PR DESCRIPTION
Backport of #5334 to the 3.7 branch, part of the 3.7.12 security release.