### PR TITLE
Fix C++ build failures with recent Clang

### DIFF
--- a/cpp/src/IceGrid/NodeCache.cpp
+++ b/cpp/src/IceGrid/NodeCache.cpp
@@ -507,7 +507,7 @@ NodeEntry::getLoadInfoAndLoadFactor(const string& application, float& loadFactor
             // machine is the same as a load of 1 on a single process
             // machine.
             //
-            loadFactor = 1.0f / _session->getInfo()->nProcessors;
+            loadFactor = 1.0f / static_cast<float>(_session->getInfo()->nProcessors);
         }
         else
         {

--- a/cpp/src/IceGrid/NodeI.cpp
+++ b/cpp/src/IceGrid/NodeI.cpp
@@ -120,7 +120,7 @@ public:
     {
         if(_traceLevels->patch > 1 && totalSize > (1024 * 1024))
         {
-            int progress = static_cast<int>(static_cast<double>(totalProgress) / totalSize * 100.0);
+            int progress = static_cast<int>(static_cast<double>(totalProgress) / static_cast<double>(totalSize) * 100.0);
             progress /= 5;
             progress *= 5;
             if(progress != _lastProgress)

--- a/cpp/src/IceUtil/Time.cpp
+++ b/cpp/src/IceUtil/Time.cpp
@@ -144,7 +144,7 @@ IceUtil::Time::now(Clock clock)
         }
         return Time(tv.tv_sec * ICE_INT64(1000000) + tv.tv_usec);
 #elif defined(__APPLE__)
-        return Time(static_cast<IceUtil::Int64>(mach_absolute_time() * machMultiplier));
+        return Time(static_cast<IceUtil::Int64>(static_cast<double>(mach_absolute_time()) * machMultiplier));
 #else
         struct timespec ts;
         if(clock_gettime(CLOCK_MONOTONIC, &ts) < 0)
@@ -224,13 +224,13 @@ IceUtil::Time::toMicroSeconds() const
 double
 IceUtil::Time::toSecondsDouble() const
 {
-    return _usec / 1000000.0;
+    return static_cast<double>(_usec) / 1000000.0;
 }
 
 double
 IceUtil::Time::toMilliSecondsDouble() const
 {
-    return _usec / 1000.0;
+    return static_cast<double>(_usec) / 1000.0;
 }
 
 double
@@ -303,5 +303,5 @@ Time::Time(Int64 usec) :
 std::ostream&
 IceUtil::operator<<(std::ostream& out, const Time& tm)
 {
-    return out << tm.toMicroSeconds() / 1000000.0;
+    return out << static_cast<double>(tm.toMicroSeconds()) / 1000000.0;
 }

--- a/cpp/test/Ice/acm/TestI.h
+++ b/cpp/test/Ice/acm/TestI.h
@@ -69,7 +69,7 @@ private:
             }
         }
 
-        virtual void
+        void
         heartbeat(const Ice::ConnectionPtr&)
         {
             Lock sync(*this);

--- a/cpp/test/Ice/operations/BatchOneways.cpp
+++ b/cpp/test/Ice/operations/BatchOneways.cpp
@@ -22,7 +22,7 @@ public:
     {
     }
 
-    virtual void
+    void
     enqueue(const Ice::BatchRequest& request, Ice::Int count, Ice::Int size)
     {
         test(request.getOperation() == "opByteSOneway" || request.getOperation() == "ice_ping");

--- a/cpp/test/IceSSL/configuration/AllTests.cpp
+++ b/cpp/test/IceSSL/configuration/AllTests.cpp
@@ -278,7 +278,7 @@ public:
     {
     }
 
-    virtual string getPassword()
+    string getPassword()
     {
         ++_count;
         return _password;
@@ -308,7 +308,7 @@ public:
         reset();
     }
 
-    virtual bool
+    bool
     verify(const IceSSL::ConnectionInfoPtr& info)
     {
         if(info->certs.size() > 0)

--- a/cpp/test/IceUtil/uuid/Client.cpp
+++ b/cpp/test/IceUtil/uuid/Client.cpp
@@ -167,7 +167,7 @@ runTest(int threadCount, GenerateFunc func, long howMany, bool verbose, string n
     if(verbose)
     {
         cout << "Each " << name << " took an average of "
-             << (double) ((finish - start).toMicroSeconds()) / howMany
+             << (double) ((finish - start).toMicroSeconds()) / (double) howMany
              << " micro seconds to generate and insert into a set."
              << endl;
     }


### PR DESCRIPTION
A recent Clang (as on the `macos-26` CI image) treats several warnings as errors under `-Werror`, breaking the 3.7 macOS C++ build across the default and `cpp11-shared` mappings.

**`-Wimplicit-int-float-conversion`** — explicit casts at the int64/uint64/int → double/float sites:
- `IceUtil/Time.cpp` — `mach_absolute_time` scaling, `toSecondsDouble`, `toMilliSecondsDouble`, `operator<<`
- `IceGrid/NodeI.cpp` — patch progress percentage (`Long` → `double`)
- `IceGrid/NodeCache.cpp` — load-factor division (`Int` → `float`)
- `test/IceUtil/uuid/Client.cpp` — average-time report (`long` → `double`)

**`-Wunnecessary-virtual-specifier`** — drop the redundant `virtual` on `ICE_FINAL` test-class methods that introduce a new virtual in a final class under the C++11 mapping (they still override their base under the C++98 mapping):
- `test/Ice/acm/TestI.h` (`heartbeat`), `test/Ice/operations/BatchOneways.cpp` (`enqueue`), `test/IceSSL/configuration/AllTests.cpp` (`getPassword`, `verify`)

Verified locally with full default and `cpp11-shared` `srcs`+`tests` builds (Apple clang 21): no warnings remain in either mapping.