### PR TITLE
Use readAndCheckSeqSize for the proxy endpoint count (3.7.12)

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -117,6 +117,7 @@ These are the changes since Ice 3.7.11.
 
 - Hardened the unmarshaling code to detect and reject invalid data sent by a peer:
   - Fixed an integer overflow in the sequence-size validation performed while unmarshaling.
+  - Fixed an unbounded memory allocation when unmarshaling a proxy with a large endpoint count.
 
 ## Swift Changes
 

--- a/cpp/src/Ice/ReferenceFactory.cpp
+++ b/cpp/src/Ice/ReferenceFactory.cpp
@@ -593,7 +593,9 @@ IceInternal::ReferenceFactory::create(const Identity& ident, InputStream* s)
     vector<EndpointIPtr> endpoints;
     string adapterId;
 
-    Ice::Int sz = s->readSize();
+    // Each endpoint occupies at least 8 bytes on the wire (a 2-byte type plus a 6-byte minimum
+    // encapsulation), so readAndCheckSeqSize rejects an oversized count before we allocate.
+    Ice::Int sz = s->readAndCheckSeqSize(8);
 
     if(sz > 0)
     {

--- a/csharp/src/Ice/ReferenceFactory.cs
+++ b/csharp/src/Ice/ReferenceFactory.cs
@@ -605,7 +605,9 @@ namespace IceInternal
             EndpointI[] endpoints = null;
             string adapterId = "";
 
-            int sz = s.readSize();
+            // Each endpoint occupies at least 8 bytes on the wire (a 2-byte type plus a 6-byte minimum
+            // encapsulation), so readAndCheckSeqSize rejects an oversized count before we allocate.
+            int sz = s.readAndCheckSeqSize(8);
             if(sz > 0)
             {
                 endpoints = new EndpointI[sz];

--- a/java-compat/src/Ice/src/main/java/IceInternal/ReferenceFactory.java
+++ b/java-compat/src/Ice/src/main/java/IceInternal/ReferenceFactory.java
@@ -599,7 +599,9 @@ public final class ReferenceFactory
         EndpointI[] endpoints = null;
         String adapterId = null;
 
-        int sz = s.readSize();
+        // Each endpoint occupies at least 8 bytes on the wire (a 2-byte type plus a 6-byte minimum
+        // encapsulation), so readAndCheckSeqSize rejects an oversized count before we allocate.
+        int sz = s.readAndCheckSeqSize(8);
         if(sz > 0)
         {
             endpoints = new EndpointI[sz];

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/ReferenceFactory.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/ReferenceFactory.java
@@ -600,7 +600,9 @@ public final class ReferenceFactory
         EndpointI[] endpoints = null;
         String adapterId = null;
 
-        int sz = s.readSize();
+        // Each endpoint occupies at least 8 bytes on the wire (a 2-byte type plus a 6-byte minimum
+        // encapsulation), so readAndCheckSeqSize rejects an oversized count before we allocate.
+        int sz = s.readAndCheckSeqSize(8);
         if(sz > 0)
         {
             endpoints = new EndpointI[sz];


### PR DESCRIPTION
Backport of #5337 to the 3.7 branch, part of the 3.7.12 security release.