### PR TITLE
Reject a slice header too small for its optional members (3.7.12)

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -118,6 +118,8 @@ These are the changes since Ice 3.7.11.
 - Hardened the unmarshaling code to detect and reject invalid data sent by a peer:
   - Fixed an integer overflow in the sequence-size validation performed while unmarshaling.
   - Fixed an unbounded memory allocation when unmarshaling a proxy with a large endpoint count.
+  - Fixed undefined behavior when unmarshaling a class or exception slice whose declared size is too
+    small to hold its optional members.
 
 ## Swift Changes
 

--- a/cpp/src/Ice/InputStream.cpp
+++ b/cpp/src/Ice/InputStream.cpp
@@ -2443,7 +2443,11 @@ Ice::InputStream::EncapsDecoder11::startSlice()
     if(_current->sliceFlags & FLAG_HAS_SLICE_SIZE)
     {
         _stream->read(_current->sliceSize);
-        if(_current->sliceSize < 4)
+        // A slice with optional members carries at least the 1-byte end marker in its body, so its
+        // size (which includes the 4-byte size field) must be >= 5. We rely on this in skipSlice's
+        // slice-preservation logic, which excludes the end marker by stepping back one byte.
+        Ice::Int minSliceSize = (_current->sliceFlags & FLAG_HAS_OPTIONAL_MEMBERS) ? 5 : 4;
+        if(_current->sliceSize < minSliceSize)
         {
             throw UnmarshalOutOfBoundsException(__FILE__, __LINE__);
         }

--- a/csharp/src/Ice/InputStream.cs
+++ b/csharp/src/Ice/InputStream.cs
@@ -3580,7 +3580,12 @@ namespace Ice
                 if((_current.sliceFlags & Protocol.FLAG_HAS_SLICE_SIZE) != 0)
                 {
                     _current.sliceSize = _stream.readInt();
-                    if(_current.sliceSize < 4)
+                    // A slice with optional members carries at least the 1-byte end marker in its body,
+                    // so its size (which includes the 4-byte size field) must be >= 5. We rely on this in
+                    // skipSlice's slice-preservation logic, which excludes the end marker by stepping back
+                    // one byte.
+                    int minSliceSize = (_current.sliceFlags & Protocol.FLAG_HAS_OPTIONAL_MEMBERS) != 0 ? 5 : 4;
+                    if(_current.sliceSize < minSliceSize)
                     {
                         throw new UnmarshalOutOfBoundsException();
                     }

--- a/java-compat/src/Ice/src/main/java/Ice/InputStream.java
+++ b/java-compat/src/Ice/src/main/java/Ice/InputStream.java
@@ -2919,7 +2919,12 @@ public class InputStream
             if((_current.sliceFlags & IceInternal.Protocol.FLAG_HAS_SLICE_SIZE) != 0)
             {
                 _current.sliceSize = _stream.readInt();
-                if(_current.sliceSize < 4)
+                // A slice with optional members carries at least the 1-byte end marker in its body,
+                // so its size (which includes the 4-byte size field) must be >= 5. We rely on this in
+                // skipSlice's slice-preservation logic, which excludes the end marker by stepping back
+                // one byte.
+                int minSliceSize = (_current.sliceFlags & IceInternal.Protocol.FLAG_HAS_OPTIONAL_MEMBERS) != 0 ? 5 : 4;
+                if(_current.sliceSize < minSliceSize)
                 {
                     throw new UnmarshalOutOfBoundsException();
                 }

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/InputStream.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/InputStream.java
@@ -3034,7 +3034,12 @@ public class InputStream
             if((_current.sliceFlags & Protocol.FLAG_HAS_SLICE_SIZE) != 0)
             {
                 _current.sliceSize = _stream.readInt();
-                if(_current.sliceSize < 4)
+                // A slice with optional members carries at least the 1-byte end marker in its body,
+                // so its size (which includes the 4-byte size field) must be >= 5. We rely on this in
+                // skipSlice's slice-preservation logic, which excludes the end marker by stepping back
+                // one byte.
+                int minSliceSize = (_current.sliceFlags & Protocol.FLAG_HAS_OPTIONAL_MEMBERS) != 0 ? 5 : 4;
+                if(_current.sliceSize < minSliceSize)
                 {
                     throw new UnmarshalOutOfBoundsException();
                 }

--- a/js/src/Ice/Stream.js
+++ b/js/src/Ice/Stream.js
@@ -703,7 +703,14 @@ class EncapsDecoder11 extends EncapsDecoder
         if((this._current.sliceFlags & Protocol.FLAG_HAS_SLICE_SIZE) !== 0)
         {
             this._current.sliceSize = this._stream.readInt();
-            if(this._current.sliceSize < 4)
+            //
+            // A slice with optional members carries at least the 1-byte end marker in its body, so
+            // its size (which includes the 4-byte size field) must be >= 5. We rely on this in
+            // skipSlice's slice-preservation logic, which excludes the end marker by stepping back
+            // one byte.
+            //
+            const minSliceSize = (this._current.sliceFlags & Protocol.FLAG_HAS_OPTIONAL_MEMBERS) !== 0 ? 5 : 4;
+            if(this._current.sliceSize < minSliceSize)
             {
                 throw new Ice.UnmarshalOutOfBoundsException();
             }

--- a/matlab/lib/+IceInternal/EncapsDecoder11.m
+++ b/matlab/lib/+IceInternal/EncapsDecoder11.m
@@ -182,7 +182,16 @@ classdef EncapsDecoder11 < IceInternal.EncapsDecoder
             %
             if bitand(current.sliceFlags, Protocol.FLAG_HAS_SLICE_SIZE)
                 current.sliceSize = is.readInt();
-                if current.sliceSize < 4
+                % A slice with optional members carries at least the 1-byte end marker in its body,
+                % so its size (which includes the 4-byte size field) must be >= 5. We rely on this in
+                % skipSlice's slice-preservation logic, which excludes the end marker by stepping
+                % back one byte.
+                if bitand(current.sliceFlags, Protocol.FLAG_HAS_OPTIONAL_MEMBERS)
+                    minSliceSize = 5;
+                else
+                    minSliceSize = 4;
+                end
+                if current.sliceSize < minSliceSize
                     throw(Ice.UnmarshalOutOfBoundsException());
                 end
             else

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -1548,7 +1548,12 @@ private class EncapsDecoder11: EncapsDecoder {
         //
         if current.sliceFlags.contains(SliceFlags.FLAG_HAS_SLICE_SIZE) {
             current.sliceSize = try stream.read()
-            if current.sliceSize < 4 {
+            // A slice with optional members carries at least the 1-byte end marker in its body, so
+            // its size (which includes the 4-byte size field) must be >= 5. We rely on this in
+            // skipSlice's slice-preservation logic, which excludes the end marker by stepping back
+            // one byte.
+            let minSliceSize: Int32 = current.sliceFlags.contains(SliceFlags.FLAG_HAS_OPTIONAL_MEMBERS) ? 5 : 4
+            if current.sliceSize < minSliceSize {
                 throw UnmarshalOutOfBoundsException(reason: "invalid slice size")
             }
         } else {


### PR DESCRIPTION
Backport of #5339 to the 3.7 branch, part of the 3.7.12 security release.