### PR TITLE
Reject an IP endpoint port outside the 0..65535 range (3.7.12)

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -120,6 +120,7 @@ These are the changes since Ice 3.7.11.
   - Fixed an unbounded memory allocation when unmarshaling a proxy with a large endpoint count.
   - Fixed undefined behavior when unmarshaling a class or exception slice whose declared size is too
     small to hold its optional members.
+  - Fixed the unmarshaling of IP endpoints to reject a port value outside the 0..65535 range.
 
 ## Swift Changes
 

--- a/cpp/src/Ice/IPEndpointI.cpp
+++ b/cpp/src/Ice/IPEndpointI.cpp
@@ -531,6 +531,10 @@ IceInternal::IPEndpointI::IPEndpointI(const ProtocolInstancePtr& instance, Input
 {
     s->read(const_cast<string&>(_host), false);
     s->read(const_cast<Ice::Int&>(_port));
+    if(_port < 0 || _port > 65535)
+    {
+        throw MarshalException(__FILE__, __LINE__, "port value '" + std::to_string(_port) + "' is out of range");
+    }
 }
 
 IceInternal::EndpointHostResolver::EndpointHostResolver(const InstancePtr& instance) :

--- a/csharp/src/Ice/IPEndpointI.cs
+++ b/csharp/src/Ice/IPEndpointI.cs
@@ -37,6 +37,10 @@ namespace IceInternal
             instance_ = instance;
             host_ = s.readString();
             port_ = s.readInt();
+            if(port_ < 0 || port_ > 65535)
+            {
+                throw new Ice.MarshalException("port value '" + port_ + "' is out of range");
+            }
             sourceAddr_ = null;
             connectionId_ = "";
             _hashInitialized = false;

--- a/java-compat/src/Ice/src/main/java/IceInternal/IPEndpointI.java
+++ b/java-compat/src/Ice/src/main/java/IceInternal/IPEndpointI.java
@@ -32,6 +32,10 @@ public abstract class IPEndpointI extends EndpointI
         _instance = instance;
         _host = s.readString();
         _port = s.readInt();
+        if(_port < 0 || _port > 65535)
+        {
+            throw new Ice.MarshalException("port value '" + _port + "' is out of range");
+        }
         _sourceAddr = null;
         _connectionId = "";
         _hashInitialized = false;

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/IPEndpointI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/IPEndpointI.java
@@ -37,6 +37,10 @@ public abstract class IPEndpointI extends EndpointI
         _instance = instance;
         _host = s.readString();
         _port = s.readInt();
+        if(_port < 0 || _port > 65535)
+        {
+            throw new com.zeroc.Ice.MarshalException("port value '" + _port + "' is out of range");
+        }
         _sourceAddr = null;
         _connectionId = "";
         _hashInitialized = false;

--- a/js/src/Ice/IPEndpointI.js
+++ b/js/src/Ice/IPEndpointI.js
@@ -270,6 +270,10 @@ class IPEndpointI extends Ice.EndpointI
     {
         this._host = s.readString();
         this._port = s.readInt();
+        if(this._port < 0 || this._port > 65535)
+        {
+            throw new Ice.MarshalException("port value '" + this._port + "' is out of range");
+        }
     }
 
     checkOption(option, argument, str)


### PR DESCRIPTION
Backport of #5352 to the 3.7 branch, part of the 3.7.12 security release.