### PR TITLE
Reject a batch request count larger than the message can contain (3.7.12)

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -121,6 +121,8 @@ These are the changes since Ice 3.7.11.
   - Fixed undefined behavior when unmarshaling a class or exception slice whose declared size is too
     small to hold its optional members.
   - Fixed the unmarshaling of IP endpoints to reject a port value outside the 0..65535 range.
+  - Fixed the unmarshaling of a batch request message to reject a request count larger than the
+    remaining message data could hold.
 
 ## Swift Changes
 

--- a/cpp/src/Ice/ConnectionI.cpp
+++ b/cpp/src/Ice/ConnectionI.cpp
@@ -3343,6 +3343,19 @@ Ice::ConnectionI::parseMessage(InputStream& stream, Int& invokeNum, Int& request
                         invokeNum = 0;
                         throw UnmarshalOutOfBoundsException(__FILE__, __LINE__);
                     }
+
+                    //
+                    // A batched request occupies at least 12 bytes on the wire (a 2-byte identity, a
+                    // 1-byte facet path, a 1-byte operation name, a 1-byte operation mode, a 1-byte
+                    // context, and a 6-byte parameters encapsulation). Reject a count larger than the
+                    // remaining message data could possibly hold.
+                    //
+                    const Int minBatchRequestSize = 12;
+                    if(invokeNum > (stream.b.end() - stream.i) / minBatchRequestSize)
+                    {
+                        invokeNum = 0;
+                        throw UnmarshalOutOfBoundsException(__FILE__, __LINE__);
+                    }
                     servantManager = _servantManager;
                     adapter = _adapter;
                     dispatchCount += invokeNum;

--- a/csharp/src/Ice/ConnectionI.cs
+++ b/csharp/src/Ice/ConnectionI.cs
@@ -2715,6 +2715,19 @@ namespace Ice
                                 info.invokeNum = 0;
                                 throw new UnmarshalOutOfBoundsException();
                             }
+
+                            //
+                            // A batched request occupies at least 12 bytes on the wire (a 2-byte identity, a
+                            // 1-byte facet path, a 1-byte operation name, a 1-byte operation mode, a 1-byte
+                            // context, and a 6-byte parameters encapsulation). Reject a count larger than the
+                            // remaining message data could possibly hold.
+                            //
+                            const int minBatchRequestSize = 12;
+                            if(info.invokeNum > (info.stream.size() - info.stream.pos()) / minBatchRequestSize)
+                            {
+                                info.invokeNum = 0;
+                                throw new UnmarshalOutOfBoundsException();
+                            }
                             info.servantManager = _servantManager;
                             info.adapter = _adapter;
                             info.messageDispatchCount += info.invokeNum;

--- a/java-compat/src/Ice/src/main/java/Ice/ConnectionI.java
+++ b/java-compat/src/Ice/src/main/java/Ice/ConnectionI.java
@@ -2732,6 +2732,19 @@ public final class ConnectionI extends IceInternal.EventHandler
                             info.invokeNum = 0;
                             throw new UnmarshalOutOfBoundsException();
                         }
+
+                        //
+                        // A batched request occupies at least 12 bytes on the wire (a 2-byte identity, a
+                        // 1-byte facet path, a 1-byte operation name, a 1-byte operation mode, a 1-byte
+                        // context, and a 6-byte parameters encapsulation). Reject a count larger than the
+                        // remaining message data could possibly hold.
+                        //
+                        final int minBatchRequestSize = 12;
+                        if(info.invokeNum > (info.stream.size() - info.stream.pos()) / minBatchRequestSize)
+                        {
+                            info.invokeNum = 0;
+                            throw new UnmarshalOutOfBoundsException();
+                        }
                         info.servantManager = _servantManager;
                         info.adapter = _adapter;
                         info.messageDispatchCount += info.invokeNum;

--- a/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
+++ b/java/src/Ice/src/main/java/com/zeroc/Ice/ConnectionI.java
@@ -2638,6 +2638,19 @@ public final class ConnectionI extends com.zeroc.IceInternal.EventHandler
                             info.invokeNum = 0;
                             throw new UnmarshalOutOfBoundsException();
                         }
+
+                        //
+                        // A batched request occupies at least 12 bytes on the wire (a 2-byte identity, a
+                        // 1-byte facet path, a 1-byte operation name, a 1-byte operation mode, a 1-byte
+                        // context, and a 6-byte parameters encapsulation). Reject a count larger than the
+                        // remaining message data could possibly hold.
+                        //
+                        final int minBatchRequestSize = 12;
+                        if(info.invokeNum > (info.stream.size() - info.stream.pos()) / minBatchRequestSize)
+                        {
+                            info.invokeNum = 0;
+                            throw new UnmarshalOutOfBoundsException();
+                        }
                         info.servantManager = _servantManager;
                         info.adapter = _adapter;
                         info.messageDispatchCount += info.invokeNum;

--- a/js/src/Ice/ConnectionI.js
+++ b/js/src/Ice/ConnectionI.js
@@ -1838,6 +1838,19 @@ class ConnectionI
                             info.invokeNum = 0;
                             throw new Ice.UnmarshalOutOfBoundsException();
                         }
+
+                        //
+                        // A batched request occupies at least 12 bytes on the wire (a 2-byte identity, a
+                        // 1-byte facet path, a 1-byte operation name, a 1-byte operation mode, a 1-byte
+                        // context, and a 6-byte parameters encapsulation). Reject a count larger than the
+                        // remaining message data could possibly hold.
+                        //
+                        const minBatchRequestSize = 12;
+                        if(info.invokeNum > (info.stream.size - info.stream.pos) / minBatchRequestSize)
+                        {
+                            info.invokeNum = 0;
+                            throw new Ice.UnmarshalOutOfBoundsException();
+                        }
                         info.servantManager = this._servantManager;
                         info.adapter = this._adapter;
                         this._dispatchCount += info.invokeNum;


### PR DESCRIPTION
Backport of #5340 to the 3.7 branch, part of the 3.7.12 security release.

#5348 (the Java batch-request error-message fix) has no 3.7 analogue: 3.7's `invokeNum < 0` path throws a plain `UnmarshalOutOfBoundsException` with no message string, so there is nothing to port. The new bounds check uses `UnmarshalOutOfBoundsException` to match that adjacent check, rather than 3.8's descriptive `MarshalException`.