### PR TITLE
Enforce RFC 6455 control-frame limits in the WebSocket transport (3.7.12)

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -134,6 +134,10 @@ These are the changes since Ice 3.7.11.
 - The Glacier2 `crypt` permissions verifier now logs a warning at startup when its password file
   contains DES-style password hashes, which rely on a weak algorithm.
 
+- Fixed the WebSocket transport to enforce the RFC 6455 control-frame limits: a close, ping, or
+  pong frame that is fragmented or declares a payload larger than 125 bytes is now rejected before
+  any payload buffer is allocated, as is any frame with a non-zero reserved (RSV) bit.
+
 ## Swift Changes
 
 - Fixed `InputStream.readSize` to reject a negative size.

--- a/cpp/src/Ice/WSTransceiver.cpp
+++ b/cpp/src/Ice/WSTransceiver.cpp
@@ -1112,6 +1112,16 @@ IceInternal::WSTransceiver::preRead(Buffer& buf)
             _readOpCode = ch & 0xf;
 
             //
+            // No extension is negotiated, so the RSV1, RSV2, and RSV3 bits must all be 0.
+            //
+            if((ch & 0x70) != 0)
+            {
+                throw ProtocolException(__FILE__, __LINE__, "invalid WebSocket frame: RSV bits must be 0");
+            }
+
+            const bool finalFrame = (ch & FLAG_FINAL) == FLAG_FINAL;
+
+            //
             // Remember if last frame if we're going to read a data or
             // continuation frame, this is only for protocol
             // correctness checking purpose.
@@ -1122,7 +1132,7 @@ IceInternal::WSTransceiver::preRead(Buffer& buf)
                 {
                     throw ProtocolException(__FILE__, __LINE__, "invalid data frame, no FIN on previous frame");
                 }
-                _readLastFrame = (ch & FLAG_FINAL) == FLAG_FINAL;
+                _readLastFrame = finalFrame;
             }
             else if(_readOpCode == OP_CONT)
             {
@@ -1130,7 +1140,7 @@ IceInternal::WSTransceiver::preRead(Buffer& buf)
                 {
                     throw ProtocolException(__FILE__, __LINE__, "invalid continuation frame, previous frame FIN set");
                 }
-                _readLastFrame = (ch & FLAG_FINAL) == FLAG_FINAL;
+                _readLastFrame = finalFrame;
             }
 
             ch = static_cast<unsigned char>(*_readI++);
@@ -1153,6 +1163,26 @@ IceInternal::WSTransceiver::preRead(Buffer& buf)
             // 127:   The subsequent eight bytes contain the payload length
             //
             _readPayloadLength = (ch & 0x7f);
+
+            //
+            // RFC 6455 section 5.5: control frames (close, ping, and pong) must not be fragmented
+            // and must have a payload length of 125 bytes or less - they cannot use the 16-bit or
+            // 64-bit extended length encoding. Enforce this before allocating any payload buffer.
+            //
+            if(_readOpCode == OP_CLOSE || _readOpCode == OP_PING || _readOpCode == OP_PONG)
+            {
+                if(!finalFrame)
+                {
+                    throw ProtocolException(__FILE__, __LINE__,
+                                            "invalid WebSocket control frame: the FIN bit is not set");
+                }
+                if(_readPayloadLength > 125)
+                {
+                    throw ProtocolException(__FILE__, __LINE__,
+                                            "invalid WebSocket control frame: the payload length exceeds 125 bytes");
+                }
+            }
+
             if(_readPayloadLength < 126)
             {
                 _readHeaderLength = 0;

--- a/csharp/src/Ice/WSTransceiver.cs
+++ b/csharp/src/Ice/WSTransceiver.cs
@@ -990,6 +990,16 @@ namespace IceInternal
                     _readOpCode = ch & 0xf;
 
                     //
+                    // No extension is negotiated, so the RSV1, RSV2, and RSV3 bits must all be 0.
+                    //
+                    if((ch & 0x70) != 0)
+                    {
+                        throw new Ice.ProtocolException("invalid WebSocket frame: RSV bits must be 0");
+                    }
+
+                    bool finalFrame = (ch & FLAG_FINAL) == FLAG_FINAL;
+
+                    //
                     // Remember if last frame if we're going to read a data or
                     // continuation frame, this is only for protocol
                     // correctness checking purpose.
@@ -1000,7 +1010,7 @@ namespace IceInternal
                         {
                             throw new Ice.ProtocolException("invalid data frame, no FIN on previous frame");
                         }
-                        _readLastFrame = (ch & FLAG_FINAL) == FLAG_FINAL;
+                        _readLastFrame = finalFrame;
                     }
                     else if(_readOpCode == OP_CONT)
                     {
@@ -1008,7 +1018,7 @@ namespace IceInternal
                         {
                             throw new Ice.ProtocolException("invalid continuation frame, previous frame FIN set");
                         }
-                        _readLastFrame = (ch & FLAG_FINAL) == FLAG_FINAL;
+                        _readLastFrame = finalFrame;
                     }
 
                     ch = _readBuffer.b.get(_readBufferPos++);
@@ -1031,6 +1041,26 @@ namespace IceInternal
                     // 127:   The subsequent eight bytes contain the payload length
                     //
                     _readPayloadLength = (ch & 0x7f);
+
+                    //
+                    // RFC 6455 section 5.5: control frames (close, ping, and pong) must not be fragmented
+                    // and must have a payload length of 125 bytes or less - they cannot use the 16-bit
+                    // or 64-bit extended length encoding. Enforce this before allocating any payload
+                    // buffer.
+                    //
+                    if(_readOpCode == OP_CLOSE || _readOpCode == OP_PING || _readOpCode == OP_PONG)
+                    {
+                        if(!finalFrame)
+                        {
+                            throw new Ice.ProtocolException("invalid WebSocket control frame: the FIN bit is not set");
+                        }
+                        if(_readPayloadLength > 125)
+                        {
+                            throw new Ice.ProtocolException(
+                                "invalid WebSocket control frame: the payload length exceeds 125 bytes");
+                        }
+                    }
+
                     if(_readPayloadLength < 126)
                     {
                         _readHeaderLength = 0;

--- a/java-compat/src/Ice/src/main/java/IceInternal/WSTransceiver.java
+++ b/java-compat/src/Ice/src/main/java/IceInternal/WSTransceiver.java
@@ -844,6 +844,16 @@ final class WSTransceiver implements Transceiver
                 _readOpCode = ch & 0xf;
 
                 //
+                // No extension is negotiated, so the RSV1, RSV2, and RSV3 bits must all be 0.
+                //
+                if((ch & 0x70) != 0)
+                {
+                    throw new Ice.ProtocolException("invalid WebSocket frame: RSV bits must be 0");
+                }
+
+                final boolean finalFrame = (ch & FLAG_FINAL) == FLAG_FINAL;
+
+                //
                 // Remember if last frame if we're going to read a data or
                 // continuation frame, this is only for protocol
                 // correctness checking purpose.
@@ -854,7 +864,7 @@ final class WSTransceiver implements Transceiver
                     {
                         throw new Ice.ProtocolException("invalid data frame, no FIN on previous frame");
                     }
-                    _readLastFrame = (ch & FLAG_FINAL) == FLAG_FINAL;
+                    _readLastFrame = finalFrame;
                 }
                 else if(_readOpCode == OP_CONT)
                 {
@@ -862,7 +872,7 @@ final class WSTransceiver implements Transceiver
                     {
                         throw new Ice.ProtocolException("invalid continuation frame, previous frame FIN set");
                     }
-                    _readLastFrame = (ch & FLAG_FINAL) == FLAG_FINAL;
+                    _readLastFrame = finalFrame;
                 }
 
                 ch = _readBuffer.b.get(_readBufferPos++);
@@ -889,6 +899,27 @@ final class WSTransceiver implements Transceiver
                 // 127:   The subsequent eight bytes contain the payload length
                 //
                 _readPayloadLength = (ch & 0x7f);
+
+                //
+                // RFC 6455 section 5.5: control frames (close, ping, and pong) must not be fragmented
+                // and must have a payload length of 125 bytes or less - they cannot use the 16-bit
+                // or 64-bit extended length encoding. Enforce this before allocating any payload
+                // buffer.
+                //
+                if(_readOpCode == OP_CLOSE || _readOpCode == OP_PING || _readOpCode == OP_PONG)
+                {
+                    if(!finalFrame)
+                    {
+                        throw new Ice.ProtocolException(
+                            "invalid WebSocket control frame: the FIN bit is not set");
+                    }
+                    if(_readPayloadLength > 125)
+                    {
+                        throw new Ice.ProtocolException(
+                            "invalid WebSocket control frame: the payload length exceeds 125 bytes");
+                    }
+                }
+
                 if(_readPayloadLength < 126)
                 {
                     _readHeaderLength = 0;

--- a/java/src/Ice/src/main/java/com/zeroc/IceInternal/WSTransceiver.java
+++ b/java/src/Ice/src/main/java/com/zeroc/IceInternal/WSTransceiver.java
@@ -851,6 +851,16 @@ final class WSTransceiver implements Transceiver
                 _readOpCode = ch & 0xf;
 
                 //
+                // No extension is negotiated, so the RSV1, RSV2, and RSV3 bits must all be 0.
+                //
+                if((ch & 0x70) != 0)
+                {
+                    throw new com.zeroc.Ice.ProtocolException("invalid WebSocket frame: RSV bits must be 0");
+                }
+
+                final boolean finalFrame = (ch & FLAG_FINAL) == FLAG_FINAL;
+
+                //
                 // Remember if last frame if we're going to read a data or
                 // continuation frame, this is only for protocol
                 // correctness checking purpose.
@@ -861,7 +871,7 @@ final class WSTransceiver implements Transceiver
                     {
                         throw new com.zeroc.Ice.ProtocolException("invalid data frame, no FIN on previous frame");
                     }
-                    _readLastFrame = (ch & FLAG_FINAL) == FLAG_FINAL;
+                    _readLastFrame = finalFrame;
                 }
                 else if(_readOpCode == OP_CONT)
                 {
@@ -869,7 +879,7 @@ final class WSTransceiver implements Transceiver
                     {
                         throw new com.zeroc.Ice.ProtocolException("invalid continuation frame, previous frame FIN set");
                     }
-                    _readLastFrame = (ch & FLAG_FINAL) == FLAG_FINAL;
+                    _readLastFrame = finalFrame;
                 }
 
                 ch = _readBuffer.b.get(_readBufferPos++);
@@ -896,6 +906,27 @@ final class WSTransceiver implements Transceiver
                 // 127:   The subsequent eight bytes contain the payload length
                 //
                 _readPayloadLength = (ch & 0x7f);
+
+                //
+                // RFC 6455 section 5.5: control frames (close, ping, and pong) must not be fragmented
+                // and must have a payload length of 125 bytes or less - they cannot use the 16-bit
+                // or 64-bit extended length encoding. Enforce this before allocating any payload
+                // buffer.
+                //
+                if(_readOpCode == OP_CLOSE || _readOpCode == OP_PING || _readOpCode == OP_PONG)
+                {
+                    if(!finalFrame)
+                    {
+                        throw new com.zeroc.Ice.ProtocolException(
+                            "invalid WebSocket control frame: the FIN bit is not set");
+                    }
+                    if(_readPayloadLength > 125)
+                    {
+                        throw new com.zeroc.Ice.ProtocolException(
+                            "invalid WebSocket control frame: the payload length exceeds 125 bytes");
+                    }
+                }
+
                 if(_readPayloadLength < 126)
                 {
                     _readHeaderLength = 0;


### PR DESCRIPTION
Backport of #5335 to the 3.7 branch, part of the 3.7.12 security release.