### PR TITLE
Reject connection with no certificate when creating an SSL-based session (3.7.12)

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -138,6 +138,10 @@ These are the changes since Ice 3.7.11.
   pong frame that is fragmented or declares a payload larger than 125 bytes is now rejected before
   any payload buffer is allocated, as is any frame with a non-zero reserved (RSV) bit.
 
+- Fixed the IceGrid registry and Glacier2 router to reject the creation of an SSL-based session when
+  the client provides no certificate or a certificate with an empty subject DN. Previously the
+  IceGrid admin-session path accepted such connections.
+
 ## Swift Changes
 
 - Fixed `InputStream.readSize` to reject a negative size.

--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -865,6 +865,16 @@ SessionRouterI::createSessionFromSecureConnection_async(
         if(info->certs.size() > 0)
         {
             userDN = info->certs[0]->getSubjectDN();
+            if(userDN.empty())
+            {
+                amdCB->ice_exception(PermissionDeniedException("empty user DN"));
+                return;
+            }
+        }
+        else
+        {
+            amdCB->ice_exception(PermissionDeniedException("the client did not provide a certificate"));
+            return;
         }
     }
     catch(const IceSSL::CertificateEncodingException&)

--- a/cpp/src/IceGrid/RegistryI.cpp
+++ b/cpp/src/IceGrid/RegistryI.cpp
@@ -1056,10 +1056,6 @@ RegistryI::createSessionFromSecureConnection(const Current& current)
 
     string userDN;
     Glacier2::SSLInfo info = getSSLInfo(current.con, userDN);
-    if(userDN.empty())
-    {
-        throw PermissionDeniedException("empty user DN");
-    }
 
     try
     {
@@ -1326,6 +1322,14 @@ RegistryI::getSSLInfo(const ConnectionPtr& connection, string& userDN)
         if(info->certs.size() > 0)
         {
             userDN = info->certs[0]->getSubjectDN();
+            if(userDN.empty())
+            {
+                throw PermissionDeniedException("empty user DN");
+            }
+        }
+        else
+        {
+            throw PermissionDeniedException("the client did not provide a certificate");
         }
     }
     catch(const IceSSL::CertificateEncodingException&)


### PR DESCRIPTION
Backport of #5345 to the 3.7 branch, part of the 3.7.12 security release.

3.7 uses the standalone IceSSL plugin rather than the integrated `Ice::SSL` engine, so this is a re-implementation: the IceGrid check is centralized in `getSSLInfo` (covering both the user and admin session paths), and the Glacier2 path uses the 3.7 AMD callback style.