### PR TITLE
Check for null IP connection info in IceGrid and Glacier2 (3.7.12)

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -142,6 +142,9 @@ These are the changes since Ice 3.7.11.
   the client provides no certificate or a certificate with an empty subject DN. Previously the
   IceGrid admin-session path accepted such connections.
 
+- Fixed a null pointer dereference in the IceGrid registry and Glacier2 router when creating an
+  SSL-based session over a non-IP transport (such as Bluetooth).
+
 ## Swift Changes
 
 - Fixed `InputStream.readSize` to reject a negative size.

--- a/cpp/src/Glacier2/SessionRouterI.cpp
+++ b/cpp/src/Glacier2/SessionRouterI.cpp
@@ -853,10 +853,22 @@ SessionRouterI::createSessionFromSecureConnection_async(
             return;
         }
         Ice::IPConnectionInfoPtr ipInfo = getIPConnectionInfo(info);
-        sslinfo.remotePort = ipInfo->remotePort;
-        sslinfo.remoteHost = ipInfo->remoteAddress;
-        sslinfo.localPort = ipInfo->localPort;
-        sslinfo.localHost = ipInfo->localAddress;
+        if(ipInfo)
+        {
+            sslinfo.remotePort = ipInfo->remotePort;
+            sslinfo.remoteHost = ipInfo->remoteAddress;
+            sslinfo.localPort = ipInfo->localPort;
+            sslinfo.localHost = ipInfo->localAddress;
+        }
+        else
+        {
+            //
+            // Not an IP connection, for example, a Bluetooth connection.
+            //
+            sslinfo.remotePort = 0;
+            sslinfo.localPort = 0;
+            // the hosts remain empty
+        }
         sslinfo.cipher = info->cipher;
         for(std::vector<IceSSL::CertificatePtr>::const_iterator i = info->certs.begin(); i != info->certs.end(); ++i)
         {

--- a/cpp/src/IceGrid/RegistryI.cpp
+++ b/cpp/src/IceGrid/RegistryI.cpp
@@ -1310,10 +1310,22 @@ RegistryI::getSSLInfo(const ConnectionPtr& connection, string& userDN)
         }
 
         Ice::IPConnectionInfoPtr ipInfo = getIPConnectionInfo(info);
-        sslinfo.remotePort = ipInfo->remotePort;
-        sslinfo.remoteHost = ipInfo->remoteAddress;
-        sslinfo.localPort = ipInfo->localPort;
-        sslinfo.localHost = ipInfo->localAddress;
+        if(ipInfo)
+        {
+            sslinfo.remotePort = ipInfo->remotePort;
+            sslinfo.remoteHost = ipInfo->remoteAddress;
+            sslinfo.localPort = ipInfo->localPort;
+            sslinfo.localHost = ipInfo->localAddress;
+        }
+        else
+        {
+            //
+            // Not an IP connection, for example, a Bluetooth connection.
+            //
+            sslinfo.remotePort = 0;
+            sslinfo.localPort = 0;
+            // the hosts remain empty
+        }
         sslinfo.cipher = info->cipher;
         for(std::vector<IceSSL::CertificatePtr>::const_iterator i = info->certs.begin(); i != info->certs.end(); ++i)
         {


### PR DESCRIPTION
Backport of #5364 to the 3.7 branch, part of the 3.7.12 security release.

Touches the same files as #5427 (B4); the two will conflict at merge but resolve trivially (different lines within `getSSLInfo`).