### PR TITLE
Update FileLock open flags on non-Windows platforms (3.7.12)

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -161,6 +161,10 @@ These are the changes since Ice 3.7.11.
   and therefore takes effect only when built against OpenSSL 1.1.0h or later. The macOS
   SecureTransport and Windows Schannel transports already reject it.
 
+- Hardened the internal file-lock used by IceGrid and IceStorm on non-Windows platforms: the lock
+  file is now created without group read/write permissions and is opened with `O_NOFOLLOW` so a
+  pre-existing symbolic link at the lock path is not followed.
+
 ## Swift Changes
 
 - Fixed `InputStream.readSize` to reject a negative size.

--- a/cpp/src/IceUtil/FileUtil.cpp
+++ b/cpp/src/IceUtil/FileUtil.cpp
@@ -417,7 +417,7 @@ IceUtilInternal::FileLock::FileLock(const std::string& path) :
     _fd(-1),
     _path(path)
 {
-    _fd = ::open(path.c_str(), O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+    _fd = ::open(path.c_str(), O_RDWR | O_CREAT | O_NOFOLLOW, S_IRUSR | S_IWUSR);
     if(_fd < 0)
     {
         throw IceUtil::FileLockException(__FILE__, __LINE__, errno, _path);


### PR DESCRIPTION
Backport of #5363 to the 3.7 branch, part of the 3.7.12 security release.

In 3.7 the `FileLock` lives in `cpp/src/IceUtil/FileUtil.cpp` rather than 3.8's `cpp/src/Ice/FileUtil.cpp`.