### PR TITLE
Harden the macOS SecureTransport defaults: ciphers, minimum TLS version, temporary keychain (3.7.12)

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -145,6 +145,17 @@ These are the changes since Ice 3.7.11.
 - Fixed a null pointer dereference in the IceGrid registry and Glacier2 router when creating an
   SSL-based session over a non-IP transport (such as Bluetooth).
 
+- Changed the macOS SSL transport to enable only forward-secret (ECDHE) cipher suites when no
+  ciphers are explicitly configured. An `IceSSL.Ciphers` setting still takes precedence.
+
+- Changed the macOS SSL transport to require TLS 1.2 or later, by changing the default value of
+  `IceSSL.ProtocolVersionMin` to `tls1_2`. An explicit `IceSSL.ProtocolVersionMin` setting still
+  takes precedence.
+
+- Changed the macOS SSL transport so that, when `IceSSL.Keychain` is not set, the certificate
+  configured with `IceSSL.CertFile` is imported into a temporary keychain (removed when the
+  communicator is destroyed) instead of the user's login keychain.
+
 ## Swift Changes
 
 - Fixed `InputStream.readSize` to reject a negative size.

--- a/cpp/src/IceSSL/SecureTransportEngine.cpp
+++ b/cpp/src/IceSSL/SecureTransportEngine.cpp
@@ -23,7 +23,15 @@
 #include <IceSSL/SSLEngine.h>
 #include <IceSSL/Util.h>
 
+#include <Ice/UUID.h>
+
 #include <regex.h>
+
+#include <cerrno>
+#include <climits>
+#include <cstring>
+#include <unistd.h>
+#include <vector>
 
 // Disable deprecation warnings from SecureTransport APIs
 #include <IceUtil/DisableWarnings.h>
@@ -816,6 +824,50 @@ IceSSL::SecureTransport::upCast(IceSSL::SecureTransport::SSLEngine* p)
     return p;
 }
 
+namespace
+{
+
+#if defined(ICE_USE_SECURE_TRANSPORT_MACOS)
+//
+// Create a private temporary directory to hold a short-lived keychain, and return its path. Uses
+// confstr(_CS_DARWIN_USER_TEMP_DIR) rather than $TMPDIR so the location can't be redirected through
+// the process environment.
+//
+string
+createTemporaryKeychainDirectory()
+{
+    char base[PATH_MAX];
+    size_t len = confstr(_CS_DARWIN_USER_TEMP_DIR, base, sizeof(base));
+    if(len == 0 || len > sizeof(base))
+    {
+        int error = errno;
+        ostringstream os;
+        os << "IceSSL: confstr(_CS_DARWIN_USER_TEMP_DIR) failed";
+        if(error != 0)
+        {
+            os << ": " << strerror(error);
+        }
+        throw PluginInitializationException(__FILE__, __LINE__, os.str());
+    }
+
+    string tmpl = string(base) + "ice-keychain-XXXXXX";
+    vector<char> buffer(tmpl.begin(), tmpl.end());
+    buffer.push_back('\0');
+
+    const char* dir = mkdtemp(&buffer[0]);
+    if(dir == 0)
+    {
+        int error = errno;
+        ostringstream os;
+        os << "IceSSL: mkdtemp failed: " << strerror(error);
+        throw PluginInitializationException(__FILE__, __LINE__, os.str());
+    }
+    return dir;
+}
+#endif
+
+}
+
 IceSSL::SecureTransport::SSLEngine::SSLEngine(const Ice::CommunicatorPtr& communicator) :
     IceSSL::SSLEngine(communicator),
     _certificateAuthorities(0),
@@ -823,6 +875,28 @@ IceSSL::SecureTransport::SSLEngine::SSLEngine(const Ice::CommunicatorPtr& commun
     _protocolVersionMax(kSSLProtocolUnknown),
     _protocolVersionMin(kSSLProtocolUnknown)
 {
+}
+
+IceSSL::SecureTransport::SSLEngine::~SSLEngine()
+{
+#if defined(ICE_USE_SECURE_TRANSPORT_MACOS)
+    if(!_temporaryKeychainDir.empty())
+    {
+        //
+        // Remove the temporary keychain and its enclosing directory created by initialize(). The
+        // cleanup lives in the destructor (not destroy()) so it also runs when initialize() throws
+        // after the directory has been created.
+        //
+        _chain.reset(0);
+        const string keychainPath = _temporaryKeychainDir + "/ice.keychain";
+        UniqueRef<SecKeychainRef> keychain;
+        if(SecKeychainOpen(keychainPath.c_str(), &keychain.get()) == noErr && keychain.get())
+        {
+            SecKeychainDelete(keychain.get());
+        }
+        rmdir(_temporaryKeychainDir.c_str());
+    }
+#endif
 }
 
 //
@@ -890,6 +964,19 @@ IceSSL::SecureTransport::SSLEngine::initialize()
 
     if(!certFile.empty())
     {
+#if defined(ICE_USE_SECURE_TRANSPORT_MACOS)
+        if(keychain.empty())
+        {
+            //
+            // Import the certificate into a temporary keychain rather than the user's login keychain.
+            // A private key in the login keychain cannot complete a forward-secret (ECDHE) handshake on
+            // the server side. The keychain and its enclosing directory are removed by the destructor.
+            //
+            _temporaryKeychainDir = createTemporaryKeychainDirectory();
+            keychain = _temporaryKeychainDir + "/ice.keychain";
+            keychainPassword = Ice::generateUUID();
+        }
+#endif
         vector<string> files;
         if(!IceUtilInternal::splitString(certFile, IceUtilInternal::pathsep, files) || files.size() > 2)
         {
@@ -1021,9 +1108,10 @@ IceSSL::SecureTransport::SSLEngine::initialize()
     }
 
     //
-    // The default min protocol version is set to TLS1.0 to avoid security issues with SSLv3
+    // The default min protocol version is TLS 1.2. SecureTransport otherwise negotiates down to TLS
+    // 1.0 on macOS. An explicit IceSSL.ProtocolVersionMin setting still takes precedence.
     //
-    const string protocolVersionMin = properties->getPropertyWithDefault("IceSSL.ProtocolVersionMin", "tls1_0");
+    const string protocolVersionMin = properties->getPropertyWithDefault("IceSSL.ProtocolVersionMin", "tls1_2");
     if(!protocolVersionMin.empty())
     {
         _protocolVersionMin = parseProtocol(protocolVersionMin);
@@ -1106,6 +1194,23 @@ IceSSL::SecureTransport::SSLEngine::newContext(bool incoming)
     if(!_ciphers.empty())
     {
         if((err = SSLSetEnabledCiphers(ssl, &_ciphers[0], _ciphers.size())))
+        {
+            throw SecurityException(__FILE__, __LINE__, "IceSSL: error while setting ciphers:\n" + sslErrorToString(err));
+        }
+    }
+    else
+    {
+        //
+        // When no ciphers are explicitly configured, enable only forward-secret cipher suites
+        // (ECDHE key exchange with AES-GCM). SecureTransport's own default set otherwise includes
+        // static-RSA suites (no forward secrecy) and 3DES (SWEET32).
+        //
+        const SSLCipherSuite ciphers[] = {
+            TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+            TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+            TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384};
+        if((err = SSLSetEnabledCiphers(ssl, ciphers, sizeof(ciphers) / sizeof(SSLCipherSuite))))
         {
             throw SecurityException(__FILE__, __LINE__, "IceSSL: error while setting ciphers:\n" + sslErrorToString(err));
         }

--- a/cpp/src/IceSSL/SecureTransportEngine.h
+++ b/cpp/src/IceSSL/SecureTransportEngine.h
@@ -24,6 +24,7 @@ class SSLEngine : public IceSSL::SSLEngine
 public:
 
     SSLEngine(const Ice::CommunicatorPtr&);
+    virtual ~SSLEngine();
 
     virtual void initialize();
     virtual void destroy();
@@ -40,6 +41,12 @@ private:
 
     IceInternal::UniqueRef<CFArrayRef> _certificateAuthorities;
     IceInternal::UniqueRef<CFArrayRef> _chain;
+
+#if defined(ICE_USE_SECURE_TRANSPORT_MACOS)
+    // Path of the temporary directory holding the imported certificate's keychain, removed by the
+    // destructor. Empty when IceSSL.Keychain is set or no certificate is configured.
+    std::string _temporaryKeychainDir;
+#endif
 
     SSLProtocol _protocolVersionMax;
     SSLProtocol _protocolVersionMin;

--- a/cpp/test/IceSSL/configuration/AllTests.cpp
+++ b/cpp/test/IceSSL/configuration/AllTests.cpp
@@ -398,8 +398,6 @@ private:
 };
 ICE_DEFINE_PTR(CertificateVerifierIPtr, CertificateVerifierI);
 
-int keychainN = 0;
-
 static PropertiesPtr
 createClientProps(const Ice::PropertiesPtr& defaultProps, bool p12)
 {
@@ -422,13 +420,6 @@ createClientProps(const Ice::PropertiesPtr& defaultProps, bool p12)
     }
     //result->setProperty("IceSSL.Trace.Security", "1");
     //result->setProperty("Ice.Trace.Network", "3");
-#ifdef ICE_USE_SECURE_TRANSPORT
-    ostringstream keychainName;
-    keychainName << "../certs/keychain/client" << keychainN++ << ".keychain";
-    const string keychainPassword = "password";
-    result->setProperty("IceSSL.Keychain", keychainName.str());
-    result->setProperty("IceSSL.KeychainPassword", keychainPassword);
-#endif
     return result;
 }
 
@@ -453,12 +444,6 @@ createServerProps(const Ice::PropertiesPtr& defaultProps, bool p12)
     }
     //result["Ice.Trace.Network"] = "3";
     //result["IceSSL.Trace.Security"] = "1";
-#ifdef ICE_USE_SECURE_TRANSPORT
-    ostringstream keychainName;
-    keychainName << "../certs/keychain/server" << keychainN << ".keychain";
-    result["IceSSL.Keychain"] = keychainName.str();
-    result["IceSSL.KeychainPassword"] = "password";
-#endif
     return result;
 }
 
@@ -1964,78 +1949,6 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             comm->destroy();
         }
 
-        //
-        // Skip the test if OpenSSL was build without SSL3 support
-        //
-#   if !defined(OPENSSL_NO_SSL3_METHOD) && defined(SSL3_VERSION)
-        //
-        // This should fail because the client only accept SSLv3 and the server
-        // use the default protocol set that disables SSLv3
-        //
-        {
-            InitializationData initData;
-            initData.properties = createClientProps(defaultProps, p12, "c_rsa_ca1", "cacert1");
-            initData.properties->setProperty("IceSSL.VerifyPeer", "0");
-            initData.properties->setProperty("IceSSL.Protocols", "ssl3");
-            CommunicatorPtr comm = initialize(initData);
-
-            Test::ServerFactoryPrxPtr fact = ICE_CHECKED_CAST(Test::ServerFactoryPrx, comm->stringToProxy(factoryRef));
-            test(fact);
-            Test::Properties d = createServerProps(defaultProps, p12, "s_rsa_ca1", "cacert1");
-            d["IceSSL.VerifyPeer"] = "0";
-            Test::ServerPrxPtr server = fact->createServer(d);
-            try
-            {
-                server->ice_ping();
-                test(false);
-            }
-            catch(const ProtocolException&)
-            {
-                // Expected on some platforms.
-            }
-            catch(const ConnectionLostException&)
-            {
-                // Expected on some platforms.
-            }
-            catch(const LocalException& ex)
-            {
-                cerr << ex << endl;
-                test(false);
-            }
-            fact->destroyServer(server);
-            comm->destroy();
-        }
-#   endif
-
-        //
-        // SSLv3 is now disabled by default with some SSL implementations.
-        //
-        // //
-        // // This should success because both have SSLv3 enabled
-        // //
-        // {
-        //     InitializationData initData;
-        //     initData.properties = createClientProps(defaultProps, p12, "", "cacert1");
-        //     initData.properties->setProperty("IceSSL.Protocols", "ssl3");
-        //     CommunicatorPtr comm = initialize(initData);
-
-        //     Test::ServerFactoryPrxPtr fact = ICE_CHECKED_CAST(Test::ServerFactoryPrx, comm->stringToProxy(factoryRef));
-        //     test(fact);
-        //     Test::Properties d = createServerProps(defaultProps, p12, "s_rsa_ca1", "");
-        //     d["IceSSL.VerifyPeer"] = "0";
-        //     d["IceSSL.Protocols"] = "ssl3, tls, tls1_1, tls1_2";
-        //     Test::ServerPrxPtr server = fact->createServer(d);
-        //     try
-        //     {
-        //         server->ice_ping();
-        //     }
-        //     catch(const LocalException& ex)
-        //     {
-        //         test(false);
-        //     }
-        //     fact->destroyServer(server);
-        //     comm->destroy();
-        // }
 #else
         //
         // In macOS we don't support IceSSL.Protocols as secure transport doesn't allow to set the enabled protocols
@@ -2094,7 +2007,7 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             d["IceSSL.Ciphers"] = "(DH_anon*)";
             d["IceSSL.VerifyPeer"] = "0";
             d["IceSSL.ProtocolVersionMax"] = "tls1";
-            d["IceSSL.ProtocolVersionMin"] = "ssl3";
+            d["IceSSL.ProtocolVersionMin"] = "tls1";
             server = fact->createServer(d);
             try
             {
@@ -2103,74 +2016,6 @@ allTests(Test::TestHelper* helper, const string& /*testDir*/, bool p12)
             catch(const LocalException& ex)
             {
                 cerr << ex << endl;
-                test(false);
-            }
-            fact->destroyServer(server);
-            comm->destroy();
-        }
-
-        //
-        // This should fail because the client only accept SSLv3 and the server
-        // use the default protocol set that disables SSLv3
-        //
-        {
-            InitializationData initData;
-            initData.properties = createClientProps(defaultProps, p12, "c_rsa_ca1", "cacert1");
-            initData.properties->setProperty("IceSSL.VerifyPeer", "0");
-            initData.properties->setProperty("IceSSL.ProtocolVersionMin", "ssl3");
-            initData.properties->setProperty("IceSSL.ProtocolVersionMax", "ssl3");
-            CommunicatorPtr comm = initialize(initData);
-
-            Test::ServerFactoryPrxPtr fact = ICE_CHECKED_CAST(Test::ServerFactoryPrx, comm->stringToProxy(factoryRef));
-            test(fact);
-            Test::Properties d = createServerProps(defaultProps, p12, "s_rsa_ca1", "cacert1");
-            d["IceSSL.VerifyPeer"] = "0";
-            Test::ServerPrxPtr server = fact->createServer(d);
-            try
-            {
-                server->ice_ping();
-                test(false);
-            }
-            catch(const ProtocolException&)
-            {
-                // Expected on some platforms.
-            }
-            catch(const ConnectionLostException&)
-            {
-                // Expected on some platforms.
-            }
-            catch(const LocalException& ex)
-            {
-                cerr << ex << endl;
-                test(false);
-            }
-            fact->destroyServer(server);
-            comm->destroy();
-        }
-
-        //
-        // This should succeed because both have SSLv3 enabled
-        //
-        {
-            InitializationData initData;
-            initData.properties = createClientProps(defaultProps, p12, "c_rsa_ca1", "cacert1");
-            initData.properties->setProperty("IceSSL.VerifyPeer", "0");
-            initData.properties->setProperty("IceSSL.ProtocolVersionMin", "ssl3");
-            initData.properties->setProperty("IceSSL.ProtocolVersionMax", "ssl3");
-            CommunicatorPtr comm = initialize(initData);
-
-            Test::ServerFactoryPrxPtr fact = ICE_CHECKED_CAST(Test::ServerFactoryPrx, comm->stringToProxy(factoryRef));
-            test(fact);
-            Test::Properties d = createServerProps(defaultProps, p12, "s_rsa_ca1", "cacert1");
-            d["IceSSL.VerifyPeer"] = "0";
-            d["IceSSL.ProtocolVersionMin"] = "ssl3";
-            Test::ServerPrxPtr server = fact->createServer(d);
-            try
-            {
-                server->ice_ping();
-            }
-            catch(const LocalException&)
-            {
                 test(false);
             }
             fact->destroyServer(server);

--- a/scripts/tests/IceSSL/configuration.py
+++ b/scripts/tests/IceSSL/configuration.py
@@ -25,8 +25,10 @@ class ConfigurationTestCase(ClientServerTestCase):
             self.ocspServer.start()
 
         if isinstance(platform, Darwin) and current.config.buildPlatform == "macosx":
+            # The default cert-import path no longer needs a pre-created keychain: when IceSSL.Keychain
+            # is unset, IceSSL creates a private temporary keychain itself. Find.keychain is still
+            # needed for the IceSSL.FindCert test.
             keychainPath = os.path.join(certsPath, "Find.keychain")
-            os.system("mkdir -p {0}".format(os.path.join(certsPath, "keychain")))
             os.system("security create-keychain -p password %s" % keychainPath)
             for cert in ["s_rsa_ca1.p12", "c_rsa_ca1.p12"]:
                 os.system("security import %s -f pkcs12 -A -P password -k %s" % (os.path.join(certsPath, cert), keychainPath))
@@ -59,7 +61,7 @@ class ConfigurationTestCase(ClientServerTestCase):
 
         certsPath = os.path.abspath(os.path.join(current.testsuite.getPath(), "..", "certs"))
         if isinstance(platform, Darwin) and current.config.buildPlatform == "macosx":
-            os.system("rm -rf {0} {1}".format(os.path.join(certsPath, "keychain"), os.path.join(certsPath, "Find.keychain")))
+            os.system("rm -rf {0}".format(os.path.join(certsPath, "Find.keychain")))
         elif current.config.openssl or platform.hasOpenSSL():
             for c in ["cacert1.pem", "cacert2.pem"]:
                 pem = os.path.join(certsPath, c)


### PR DESCRIPTION
Backport of #5349 (C2), #5342 (C1), and #5343 (C3) to the 3.7 branch, part of the 3.7.12 security release. Combined since all three modify the macOS IceSSL SecureTransport engine.

In 3.7 the engine only called `SSLSetEnabledCiphers`/`SSLSetProtocolVersionMin` when the corresponding property was set, so the **default** configuration was vulnerable:

- **#5349** — with no ciphers configured, SecureTransport used its default set (static-RSA, no forward secrecy, plus 3DES/SWEET32). The engine now enables only forward-secret ECDHE+AES-GCM suites by default.
- **#5342** — with no minimum protocol version configured, SecureTransport could negotiate down to TLS 1.0. The engine now requires TLS 1.2 by default.

An explicit `IceSSL.Ciphers` / `IceSSL.ProtocolVersionMin` setting still takes precedence.

- **#5343** — with the forward-secret default ciphers, a private key in the user's **login keychain** cannot complete an ECDHE handshake on the server side. So when `IceSSL.Keychain` is unset, the certificate is now imported into a private **temporary keychain** (created with `mkdtemp` under `_CS_DARWIN_USER_TEMP_DIR`, removed by the engine destructor) instead of the login keychain. C3 is what makes the C2 default actually usable on macOS.

**Behavior changes:** peers offering only static-RSA/3DES ciphers, or limited to TLS 1.0/1.1, can no longer connect to a macOS peer using the default configuration. The obsolete SSLv3 cases were removed from the `IceSSL/configuration` test (with forward-secret default ciphers an SSLv3 handshake has no compatible cipher suite), and the test no longer pre-creates per-test keychains.

Verified the full `IceSSL/configuration` suite passes on macOS. macOS C++ IceSSL only.