### PR TITLE
Reject peer-initiated TLS renegotiation in the OpenSSL transport (3.7.12)

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -156,6 +156,11 @@ These are the changes since Ice 3.7.11.
   configured with `IceSSL.CertFile` is imported into a temporary keychain (removed when the
   communicator is destroyed) instead of the user's login keychain.
 
+- The IceSSL OpenSSL transport now rejects peer-initiated TLS renegotiation, which is a
+  CPU-asymmetric denial-of-service primitive on TLS 1.2. This relies on `SSL_OP_NO_RENEGOTIATION`
+  and therefore takes effect only when built against OpenSSL 1.1.0h or later. The macOS
+  SecureTransport and Windows Schannel transports already reject it.
+
 ## Swift Changes
 
 - Fixed `InputStream.readSize` to reject a negative size.

--- a/cpp/src/IceSSL/OpenSSLEngine.cpp
+++ b/cpp/src/IceSSL/OpenSSLEngine.cpp
@@ -889,6 +889,15 @@ OpenSSL::SSLEngine::initialize()
         //
         SSL_CTX_set_ex_data(_ctx, 0, this);
 
+#ifdef SSL_OP_NO_RENEGOTIATION
+        //
+        // Reject peer-initiated TLS renegotiation: it is a CPU-asymmetric denial-of-service primitive
+        // on TLS 1.2 and is removed entirely in TLS 1.3. This is applied to application-supplied
+        // contexts as well. SSL_OP_NO_RENEGOTIATION requires OpenSSL 1.1.0h or later.
+        //
+        SSL_CTX_set_options(_ctx, SSL_OP_NO_RENEGOTIATION);
+#endif
+
         //
         // This is necessary for successful interop with Java. Without it, a Java
         // client would fail to reestablish a connection: the server gets the


### PR DESCRIPTION
Backport of #5350 to the 3.7 branch, part of the 3.7.12 security release.

Peer-initiated TLS renegotiation is a CPU-asymmetric denial-of-service primitive on TLS 1.2. The IceSSL OpenSSL engine never disabled it, so this sets `SSL_OP_NO_RENEGOTIATION` on the `SSL_CTX`, guarded with `#ifdef` since the option requires OpenSSL 1.1.0h or later (3.7 still supports older OpenSSL).

Unlike 3.8, the 3.7 Schannel transport has **no** renegotiation state machine: it already throws on `SEC_I_RENEGOTIATE` (grouped with `SEC_I_CONTEXT_EXPIRED`), tearing the connection down rather than renegotiating, so no Schannel change is needed. SecureTransport (macOS) likewise surfaces a renegotiation request as an SSL error.

C++ IceSSL only. The OpenSSL and Schannel engines are not built on macOS, so this is verified by review and CI (Linux/Windows).