### PR TITLE
Update GitHub Actions: checkout v6, setup-matlab v3

### DIFF
--- a/.github/actions/setup-matlab/action.yml
+++ b/.github/actions/setup-matlab/action.yml
@@ -8,7 +8,7 @@ runs:
     #
     - name: Setup MATLAB
       id: setup-matlab
-      uses: matlab-actions/setup-matlab@v2
+      uses: matlab-actions/setup-matlab@v3
       with:
         release: "R2025b"
 

--- a/.github/workflows/build-brew-packages.yml
+++ b/.github/workflows/build-brew-packages.yml
@@ -35,7 +35,7 @@ jobs:
     if: ${{ inputs.quality == 'nightly' }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp

--- a/.github/workflows/build-container-images.yml
+++ b/.github/workflows/build-container-images.yml
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: ice
 
@@ -141,7 +141,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: ice
 

--- a/.github/workflows/build-cpp-nuget-packages.yml
+++ b/.github/workflows/build-cpp-nuget-packages.yml
@@ -27,7 +27,7 @@ jobs:
         platform-toolset: [v143, v142]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp

--- a/.github/workflows/build-cpp-windows-binaries.yml
+++ b/.github/workflows/build-cpp-windows-binaries.yml
@@ -33,7 +33,7 @@ jobs:
         platform-toolset: [v143, v142]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp

--- a/.github/workflows/build-deb-ice-repo-packages.yml
+++ b/.github/workflows/build-deb-ice-repo-packages.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: ice
 

--- a/.github/workflows/build-deb-packages.yml
+++ b/.github/workflows/build-deb-packages.yml
@@ -31,7 +31,7 @@ jobs:
       DEB_BUILD_OPTIONS: "nocheck parallel=4"
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: ice
 

--- a/.github/workflows/build-dotnet-packages.yml
+++ b/.github/workflows/build-dotnet-packages.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Download All slice2cs Compiler Artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/build-gem-packages.yml
+++ b/.github/workflows/build-gem-packages.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp

--- a/.github/workflows/build-icegridgui-jar.yml
+++ b/.github/workflows/build-icegridgui-jar.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp

--- a/.github/workflows/build-matlab-packages.yml
+++ b/.github/workflows/build-matlab-packages.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp

--- a/.github/workflows/build-maven-packages.yml
+++ b/.github/workflows/build-maven-packages.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp

--- a/.github/workflows/build-npm-packages.yml
+++ b/.github/workflows/build-npm-packages.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: ice
 

--- a/.github/workflows/build-pip-packages.yml
+++ b/.github/workflows/build-pip-packages.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Configure build
         id: configure

--- a/.github/workflows/build-rpm-ice-repo-packages.yml
+++ b/.github/workflows/build-rpm-ice-repo-packages.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: ice
 

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: ice
 

--- a/.github/workflows/build-swift-packages.yml
+++ b/.github/workflows/build-swift-packages.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp

--- a/.github/workflows/build-symbols-sources-store.yml
+++ b/.github/workflows/build-symbols-sources-store.yml
@@ -40,7 +40,7 @@ jobs:
         platform-toolset: [v143, v142]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set ICE_VERSION
         shell: bash

--- a/.github/workflows/build-windows-msi.yml
+++ b/.github/workflows/build-windows-msi.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -142,7 +142,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Load version info
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup C++
         uses: ./.github/actions/setup-cpp

--- a/.github/workflows/dispatch-nightly-release.yml
+++ b/.github/workflows/dispatch-nightly-release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Dispatch nightly build for main (2:00 UTC)
         if: github.event.schedule == '0 2 * * *'

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Check links
         uses: lycheeverse/lychee-action@v2

--- a/.github/workflows/prune-nightly-artifacts.yml
+++ b/.github/workflows/prune-nightly-artifacts.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Prune nightly artifacts
         env:

--- a/.github/workflows/publish-brew-packages.yml
+++ b/.github/workflows/publish-brew-packages.yml
@@ -36,7 +36,7 @@ jobs:
       QUALITY: ${{ inputs.quality }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Download Homebrew Bottle XCFramework artifacts
         env:

--- a/.github/workflows/publish-deb-packages.yml
+++ b/.github/workflows/publish-deb-packages.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: ice
 

--- a/.github/workflows/publish-maven-packages.yml
+++ b/.github/workflows/publish-maven-packages.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Download Java artifacts
         env:

--- a/.github/workflows/publish-swift-packages.yml
+++ b/.github/workflows/publish-swift-packages.yml
@@ -34,7 +34,7 @@ jobs:
     if: ${{ inputs.quality == 'nightly' }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Download SPM sources artifact
         env:

--- a/.github/workflows/publish-symbols-sources.yml
+++ b/.github/workflows/publish-symbols-sources.yml
@@ -65,7 +65,7 @@ jobs:
       S3_BUCKET: zeroc-sourcesandsymbols
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Windows Debug Tools
         uses: ./.github/actions/install-windows-debug-tools


### PR DESCRIPTION
Brings the 3.7 GitHub Actions versions in line with `main` for the two actions that had fallen behind:

- `actions/checkout`: `v5` → `v6` (32 references across the workflows).
- `matlab-actions/setup-matlab`: `v2` → `v3` (the `setup-matlab` composite action; matches main's e1f4b82798).

All other shared actions are already in sync. Pure version-tag changes, no input changes.

The `azure/trusted-signing-action` bump (`v0` → `v2`) is handled separately because it requires an input rename (`trusted-signing-account-name` → `signing-account-name`) and touches release code-signing.