### PR TITLE
Update azure/trusted-signing-action to v2

### DIFF
--- a/.github/actions/build-slice-compiler/action.yml
+++ b/.github/actions/build-slice-compiler/action.yml
@@ -28,13 +28,13 @@ runs:
 
     - name: Sign Compiler Artifact
       if: runner.os == 'Windows' && inputs.authenticode_sign == 'true'
-      uses: azure/trusted-signing-action@v0
+      uses: azure/trusted-signing-action@v2
       with:
         azure-tenant-id: ${{ env.AZURE_TENANT_ID }}
         azure-client-id: ${{ env.AZURE_CLIENT_ID }}
         azure-client-secret: ${{ env.AZURE_CLIENT_SECRET }}
         endpoint: https://eus.codesigning.azure.net/
-        trusted-signing-account-name: zeroc
+        signing-account-name: zeroc
         certificate-profile-name: zeroc-ice
         files: ${{ github.workspace }}\cpp\bin\x64\Release\${{ inputs.compiler_name }}.exe
         file-digest: SHA256

--- a/.github/workflows/build-cpp-windows-binaries.yml
+++ b/.github/workflows/build-cpp-windows-binaries.yml
@@ -60,13 +60,13 @@ jobs:
 
       - name: Sign C++ Binaries with Trusted Signing
         if: ${{ inputs.authenticode_sign }}
-        uses: azure/trusted-signing-action@v0
+        uses: azure/trusted-signing-action@v2
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
           endpoint: https://eus.codesigning.azure.net/
-          trusted-signing-account-name: zeroc
+          signing-account-name: zeroc
           certificate-profile-name: zeroc-ice
           files-folder: ./cpp/bin/${{ matrix.platform }}/${{ matrix.configuration }}
           files-folder-filter: exe,dll

--- a/.github/workflows/build-dotnet-packages.yml
+++ b/.github/workflows/build-dotnet-packages.yml
@@ -158,13 +158,13 @@ jobs:
 
       - name: Sign .NET Assemblies with Trusted Signing
         if: ${{ inputs.authenticode_sign }}
-        uses: azure/trusted-signing-action@v0
+        uses: azure/trusted-signing-action@v2
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
           endpoint: https://eus.codesigning.azure.net/
-          trusted-signing-account-name: zeroc
+          signing-account-name: zeroc
           certificate-profile-name: zeroc-ice
           files-catalog: ${{ github.workspace }}\catalog.txt
           file-digest: SHA256

--- a/.github/workflows/build-matlab-packages.yml
+++ b/.github/workflows/build-matlab-packages.yml
@@ -74,14 +74,14 @@ jobs:
           Add-Content -Path "${{ github.workspace }}\catalog.txt" -Value "cpp\bin\x64\Release\slice2matlab.exe"
 
       - name: Sign C++ Binaries
-        uses: azure/trusted-signing-action@v0
+        uses: azure/trusted-signing-action@v2
         if: runner.os == 'Windows' && inputs.authenticode_sign
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
           endpoint: https://eus.codesigning.azure.net/
-          trusted-signing-account-name: zeroc
+          signing-account-name: zeroc
           certificate-profile-name: zeroc-ice
           files-catalog: ${{ github.workspace }}\catalog.txt
           file-digest: SHA256

--- a/.github/workflows/build-windows-msi.yml
+++ b/.github/workflows/build-windows-msi.yml
@@ -115,13 +115,13 @@ jobs:
 
       - name: Sign MSI installer with Trusted Signing
         if: ${{ inputs.authenticode_sign }}
-        uses: azure/trusted-signing-action@v0
+        uses: azure/trusted-signing-action@v2
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
           endpoint: https://eus.codesigning.azure.net/
-          trusted-signing-account-name: zeroc
+          signing-account-name: zeroc
           certificate-profile-name: zeroc-ice
           files-folder: ./packaging/msi/
           files-folder-filter: msi


### PR DESCRIPTION
Bumps `azure/trusted-signing-action` from `v0` to `v2` on 3.7, matching what `main` uses for release code-signing (main's #5369 bumped these workflows to v2).

Unlike the other action bumps this is **not** a pure tag change: v2 renamed the `trusted-signing-account-name` input to `signing-account-name`. Both changes are applied together in all five places that sign Windows artifacts:

- `.github/actions/build-slice-compiler/action.yml`
- `.github/workflows/build-cpp-windows-binaries.yml`
- `.github/workflows/build-dotnet-packages.yml`
- `.github/workflows/build-matlab-packages.yml`
- `.github/workflows/build-windows-msi.yml`

All other inputs are unchanged and remain valid in v2 (verified against main's v2 usage). Split from #5435 because it touches release signing and required the input rename.