### PR TITLE
Fix infinite loop in Slice compilers

### DIFF
--- a/cpp/src/Slice/DocCommentParser.cpp
+++ b/cpp/src/Slice/DocCommentParser.cpp
@@ -325,12 +325,24 @@ namespace
         const string linkTag = "{@link ";
 
         auto endpos = line.find('}', pos);
-        if (endpos != string::npos)
+        if (endpos == string::npos)
         {
-            // Extract the linked-to identifier.
+            // No closing brace was found. Emit a warning, then skip to the next line. This one is broken.
+            const string msg = "unterminated link tag: missing closing '}'";
+            p->unit()->warning(p->file(), p->line(), InvalidComment, msg);
+
+            pos = line.size();
+        }
+        else
+        {
+            // Extract the linked-to identifier, trimming any whitespace around it.
+            string linkText;
             auto identStart = line.find_first_not_of(" \t", pos + linkTag.size());
-            auto identEnd = line.find_last_not_of(" \t", endpos);
-            string linkText = line.substr(identStart, identEnd - identStart);
+            if (identStart < endpos)
+            {
+                auto identEnd = line.find_last_not_of(" \t", endpos - 1);
+                linkText = line.substr(identStart, identEnd - identStart + 1);
+            }
 
             // Then erase the entire '{@link foo}' tag from the comment.
             line.erase(pos, endpos - pos + 1);

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.err
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.err
@@ -26,3 +26,4 @@ WarningInvalidComment.ice:59: warning: ignoring duplicate doc-comment tag: '@ret
 WarningInvalidComment.ice:59: warning: '@throws DerivedFromDummy': this exception is not listed in the exception specification of 'stringOp'
 WarningInvalidComment.ice:59: warning: '@throws SomeOtherException': this exception is not listed in the exception specification of 'stringOp'
 WarningInvalidComment.ice:59: warning: ignoring duplicate doc-comment tag: '@throws CommentDummy'
+WarningInvalidComment.ice:64: warning: unterminated link tag: missing closing '}'

--- a/cpp/test/Slice/errorDetection/WarningInvalidComment.ice
+++ b/cpp/test/Slice/errorDetection/WarningInvalidComment.ice
@@ -58,4 +58,8 @@ module Test
         /// @throws CommentDummy should give a duplicate-tag warning.
         string stringOp(string name, int value, out byte myOut) throws CommentDummy;
     }
+
+    /// Unterminated link tag: {@link CommentDummy
+    /// But whitespace around the identifier is fine: {@link CommentDummy }
+    exception UnterminatedLink {}
 }


### PR DESCRIPTION
 on unterminated {@link doc-comment tag

formatLinkElement did nothing when a '{@link' tag had no closing '}' on the same line, leaving 'pos' unchanged. The caller loop then re-found the same tag at the same position forever, hanging every slice2* compiler at 100% CPU on such input.

Mirror formatCodeElement: emit an 'unterminated link tag' warning and skip the rest of the line. Also trim whitespace around the link identifier; the previous find_last_not_of started at the closing brace itself and never trimmed anything.