### PR TITLE
Fix Schannel certificate-context reference counting (IceSSL)

### DIFF
--- a/cpp/src/Ice/SSL/SchannelEngine.cpp
+++ b/cpp/src/Ice/SSL/SchannelEngine.cpp
@@ -788,7 +788,15 @@ Schannel::SSLEngine::~SSLEngine()
 
         for (vector<HCERTSTORE>::const_iterator i = _stores.begin(); i != _stores.end(); ++i)
         {
+#ifdef NDEBUG
             CertCloseStore(*i, 0);
+#else
+            // In debug builds, close the store with CERT_CLOSE_STORE_CHECK_FLAG to assert that every certificate
+            // context obtained from it was freed. The call returns false (last error CRYPT_E_PENDING_CLOSE) if any
+            // context is still outstanding, which catches certificate-reference leaks early.
+            const BOOL allContextsFreed = CertCloseStore(*i, CERT_CLOSE_STORE_CHECK_FLAG);
+            assert(allContextsFreed && "SSL transport: certificate context leaked (store closed with live contexts)");
+#endif
         }
     }
     catch (...)
@@ -1270,11 +1278,9 @@ Schannel::SSLEngine::createClientAuthenticationOptions(const string& host) const
         .clientCredentialsSelectionCallback =
             [this](const string&)
         {
-            for (const auto& cert : _allCerts)
-            {
-                CertDuplicateCertificateContext(cert);
-            }
-
+            // The caller (TransceiverI) duplicates each paCred context into its own list and frees those in close(),
+            // so the credentials we return must not bump the reference count here — doing so leaks one reference per
+            // certificate per connection and prevents the certificate store from ever closing cleanly.
             return SCH_CREDENTIALS{
                 .dwVersion = SCH_CREDENTIALS_VERSION,
                 .cCreds = static_cast<DWORD>(_allCerts.size()),
@@ -1315,11 +1321,9 @@ Schannel::SSLEngine::createServerAuthenticationOptions() const
             [this](const string&)
         {
             {
-                for (const auto& cert : _allCerts)
-                {
-                    CertDuplicateCertificateContext(cert);
-                }
-
+                // The caller (TransceiverI) duplicates each paCred context into its own list and frees those in
+                // close(), so the credentials we return must not bump the reference count here — doing so leaks one
+                // reference per certificate per connection and prevents the certificate store from closing cleanly.
                 return SCH_CREDENTIALS{
                     .dwVersion = SCH_CREDENTIALS_VERSION,
                     .cCreds = static_cast<DWORD>(_allCerts.size()),

--- a/cpp/src/Ice/SSL/SchannelEngine.cpp
+++ b/cpp/src/Ice/SSL/SchannelEngine.cpp
@@ -570,7 +570,10 @@ namespace
                          0,
                          next)) != 0)
                 {
-                    certs.push_back(next);
+                    // CertFindCertificateInStore frees the context passed as pPrevCertContext on the next iteration
+                    // (and frees the last one when it returns null). Duplicate the context to keep an owned reference
+                    // that remains valid after enumeration; these duplicates are released in the destructor.
+                    certs.push_back(CertDuplicateCertificateContext(next));
                 }
             } while (next);
             stores.push_back(store);

--- a/cpp/src/Ice/SSL/SchannelEngine.cpp
+++ b/cpp/src/Ice/SSL/SchannelEngine.cpp
@@ -568,7 +568,7 @@ namespace
                          0,
                          CERT_FIND_ANY,
                          0,
-                         next)) != 0)
+                         next)) != nullptr)
                 {
                     // CertFindCertificateInStore frees the context passed as pPrevCertContext on the next iteration
                     // (and frees the last one when it returns null). Duplicate the context to keep an owned reference


### PR DESCRIPTION
Fixes #5520.

This PR corrects certificate-context reference-count handling in the Schannel SSL engine. Note: this is **not** a use-after-free — the certificates handed to Schannel as credentials stay valid because the certificate store keeps them alive for the engine's lifetime. The real defects are reference-count errors:

1. **Credential-callback leak.** `createClientAuthenticationOptions` / `createServerAuthenticationOptions` bumped each certificate's reference count via `CertDuplicateCertificateContext` and discarded the result. The transceiver already takes its own reference (freed in `close()`), so the engine's bump leaked one `CERT_CONTEXT` reference per certificate per connection and kept the certificate store from closing cleanly. Removed the discarded duplicate loops.

2. **`findCertificates` ownership.** The `IceSSL.FindCert` enumeration loop retained each `PCCERT_CONTEXT`, but `CertFindCertificateInStore` frees the context passed as `pPrevCertContext` on the next call, so the engine stored references it had already released — leading to a teardown over-release in the destructor. Duplicate each context so the engine owns the references it stores, mirroring the file-based certificate path.

3. **Regression guard.** Added a debug-only `CERT_CLOSE_STORE_CHECK_FLAG` + `assert` in the engine destructor to catch certificate-reference leaks early.

Verified with the `IceSSL/configuration` test: before the fix, closing the store with `CERT_CLOSE_STORE_CHECK_FLAG` reported `CRYPT_E_PENDING_CLOSE` (outstanding contexts) on essentially every connection; after the fix every store closes clean and all tests pass.
