### PR TITLE
Fix RoutableReference::operator< strict weak ordering violation

### DIFF
--- a/cpp/src/Ice/Reference.cpp
+++ b/cpp/src/Ice/Reference.cpp
@@ -1200,7 +1200,12 @@ IceInternal::RoutableReference::operator<(const Reference& r) const noexcept
     {
         return true;
     }
-    else if (rhs->_endpoints < _endpoints)
+    else if (lexicographical_compare(
+                 rhs->_endpoints.begin(),
+                 rhs->_endpoints.end(),
+                 _endpoints.begin(),
+                 _endpoints.end(),
+                 Ice::TargetCompare<shared_ptr<EndpointI>, std::less>()))
     {
         return false;
     }


### PR DESCRIPTION
Fixes #5546.

`RoutableReference::operator<` compared the endpoint lists by value in the forward direction (`TargetCompare`, which dereferences the `shared_ptr<EndpointI>`) but by raw `shared_ptr` address in the reverse direction (`std::vector<shared_ptr<EndpointI>>::operator<`). That asymmetry violates the strict-weak-ordering contract, which is undefined behavior for the `std::set`/`std::map` containers that order `Reference`/`ObjectPrx` objects — including the internal `LocatorManager` and `RouterManager` tables. Two references equal in every earlier-compared field but differing in endpoints could satisfy both `a < b` and `b < a`.

This uses the value-based `TargetCompare` lexicographical compare in both directions, making `operator<` consistent with `operator==` and `std::hash<EndpointI>`, which already compare endpoints by value.
