### PR TITLE
Reject invalid negative sizes in InputStream

### DIFF
--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -231,7 +231,11 @@ public final class InputStream {
         case .VSize:
             try skip(readSize())
         case .FSize:
-            try skip(read())
+            let sz: Int32 = try read()
+            if sz < 0 {
+                throw MarshalException("invalid negative size for optional field")
+            }
+            try skip(sz)
         case .Class:
             throw MarshalException("cannot skip an optional class")
         }
@@ -681,13 +685,13 @@ extension InputStream {
                 return try read()
             } else if enumMaxValue < 32767 {
                 let v: Int16 = try read()
-                guard v <= UInt8.max else {
+                guard 0 <= v && v <= UInt8.max else {
                     throw MarshalException("unexpected enumerator value")
                 }
                 return UInt8(v)
             } else {
                 let v: Int32 = try read()
-                guard v <= UInt8.max else {
+                guard 0 <= v && v <= UInt8.max else {
                     throw MarshalException("unexpected enumerator value")
                 }
                 return UInt8(v)

--- a/swift/src/Ice/InputStream.swift
+++ b/swift/src/Ice/InputStream.swift
@@ -295,6 +295,7 @@ public final class InputStream {
     ///
     /// - Parameter count: The number of bytes to skip.
     public func skip(_ count: Int32) throws {
+        precondition(count >= 0, "skip count is negative")
         try changePos(offset: Int(count))
     }
 


### PR DESCRIPTION
This PR adds extra validation to InputStream in Swift.

I think the fix is very minor and not worthy of a CHANGELOG entry.