### PR TITLE
Fix inverted null check in IcePy adapterFind

### DIFF
--- a/python/modules/IcePy/ObjectAdapter.cpp
+++ b/python/modules/IcePy/ObjectAdapter.cpp
@@ -909,7 +909,7 @@ adapterFind(ObjectAdapterObject* self, PyObject* args)
         return nullptr;
     }
 
-    if (!obj)
+    if (obj)
     {
         auto wrapper = dynamic_pointer_cast<ServantWrapper>(obj);
         assert(wrapper);

--- a/python/test/Ice/defaultServant/AllTests.py
+++ b/python/test/Ice/defaultServant/AllTests.py
@@ -15,6 +15,31 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator):
 
     servant = MyObjectI.MyObjectI()
 
+    # Test find/findFacet before any default servant is registered, since findServant
+    # falls back to default servants for identities not in the active servant map.
+    sys.stdout.write("testing find and findFacet... ")
+    sys.stdout.flush()
+
+    identity = Ice.Identity()
+    identity.name = "registered"
+
+    oa.add(servant, identity)
+    test(oa.find(identity) == servant)
+
+    missing = Ice.Identity()
+    missing.name = "unregistered"
+    test(oa.find(missing) is None)
+
+    oa.addFacet(servant, identity, "theFacet")
+    test(oa.findFacet(identity, "theFacet") == servant)
+    test(oa.findFacet(identity, "missingFacet") is None)
+
+    oa.removeFacet(identity, "theFacet")
+    oa.remove(identity)
+    test(oa.find(identity) is None)
+
+    print("ok")
+
     # Register default servant with category "foo"
     oa.addDefaultServant(servant, "foo")
 

--- a/python/test/Ice/defaultServant/AllTests.py
+++ b/python/test/Ice/defaultServant/AllTests.py
@@ -15,8 +15,6 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator):
 
     servant = MyObjectI.MyObjectI()
 
-    # Test find/findFacet before any default servant is registered, since findServant
-    # falls back to default servants for identities not in the active servant map.
     sys.stdout.write("testing find and findFacet... ")
     sys.stdout.flush()
 

--- a/python/test/Ice/defaultServant/AllTests.py
+++ b/python/test/Ice/defaultServant/AllTests.py
@@ -33,6 +33,7 @@ def allTests(helper: TestHelper, communicator: Ice.Communicator):
     oa.addFacet(servant, identity, "theFacet")
     test(oa.findFacet(identity, "theFacet") == servant)
     test(oa.findFacet(identity, "missingFacet") is None)
+    test(oa.findFacet(missing, "theFacet") is None)
 
     oa.removeFacet(identity, "theFacet")
     oa.remove(identity)


### PR DESCRIPTION
`adapterFind` in the IcePy extension had its null check inverted relative to its siblings (`adapterFindFacet`, `adapterFindByProxy`, `adapterFindDefaultServant`): `ObjectAdapter.find()` returned `None` when a servant was registered, and asserted (debug) / dereferenced a null pointer (release) for an unregistered identity.

This PR flips the check to `if (obj)`, matching the siblings, and adds a regression test to the `Ice/defaultServant` suite covering `find`/`findFacet` for both registered and unregistered identities. The test runs before any default servant is registered, since `findServant` falls back to default servants.

Fixes #5521