### PR TITLE
Fix Ice.Future wait bugs: timeout=0 and sent() on never-sent invocations

### DIFF
--- a/python/python/Ice/Future.py
+++ b/python/python/Ice/Future.py
@@ -124,6 +124,8 @@ class Future(Awaitable[_T]):
         timeout : int | float | None, optional
             Maximum time (in seconds) to wait for the result.
             If ``None`` (the default), this function waits indefinitely until the operation completes.
+            A timeout of ``0`` returns immediately (a non-blocking poll), raising :class:`Ice.TimeoutException`
+            if the result is not yet available.
 
         Returns
         -------
@@ -163,6 +165,8 @@ class Future(Awaitable[_T]):
         timeout : int | float | None, optional
             Maximum time (in seconds) to wait for the exception.
             If ``None`` (the default), this function waits indefinitely until the operation completes.
+            A timeout of ``0`` returns immediately (a non-blocking poll), raising :class:`Ice.TimeoutException`
+            if the operation has not yet completed.
 
         Returns
         -------

--- a/python/python/Ice/Future.py
+++ b/python/python/Ice/Future.py
@@ -245,7 +245,7 @@ class Future(Awaitable[_T]):
         # Must be called with _condition acquired
 
         while testFn():
-            if timeout:
+            if timeout is not None:
                 start = time.time()
                 self._condition.wait(timeout)
                 # Subtract the elapsed time so far from the timeout

--- a/python/python/Ice/InvocationFuture.py
+++ b/python/python/Ice/InvocationFuture.py
@@ -123,7 +123,9 @@ class InvocationFuture(Future):
             If the invocation was cancelled before it was sent.
         """
         with self._condition:
-            if not self._wait(timeout, lambda: not self._sent):
+            # Stop waiting once the invocation is sent, or once it completes without
+            # ever being sent (cancelled or failed before being sent).
+            if not self._wait(timeout, lambda: not self._sent and self._state == Future.StateRunning):
                 raise TimeoutException()
 
             if self._state == Future.StateCancelled:

--- a/python/python/Ice/InvocationFuture.py
+++ b/python/python/Ice/InvocationFuture.py
@@ -109,6 +109,8 @@ class InvocationFuture(Future):
         timeout : int | float | None, optional
             Maximum time (in seconds) to wait for the invocation to be sent.
             If ``None`` (the default), this function waits indefinitely.
+            A timeout of ``0`` returns immediately (a non-blocking poll), raising :class:`Ice.TimeoutException`
+            if the invocation has not yet been sent.
 
         Returns
         -------

--- a/python/test/Ice/ami/AllTests.py
+++ b/python/test/Ice/ami/AllTests.py
@@ -262,6 +262,34 @@ def allTestsFuture(helper: TestHelper, communicator: Ice.Communicator, collocate
 
     print("ok")
 
+    sys.stdout.write("testing future timeout... ")
+    sys.stdout.flush()
+
+    # result/exception with a zero or expired timeout must raise TimeoutException
+    # instead of waiting indefinitely.
+    runningFuture = Ice.Future()
+    try:
+        runningFuture.result(0)
+        test(False)
+    except Ice.TimeoutException:
+        pass
+    try:
+        runningFuture.exception(0)
+        test(False)
+    except Ice.TimeoutException:
+        pass
+    try:
+        runningFuture.result(0.01)
+        test(False)
+    except Ice.TimeoutException:
+        pass
+
+    runningFuture.set_result(15)
+    test(runningFuture.result(0) == 15)
+    test(runningFuture.exception(0) is None)
+
+    print("ok")
+
     sys.stdout.write("testing done callback... ")
     sys.stdout.flush()
 
@@ -795,6 +823,18 @@ def allTestsFuture(helper: TestHelper, communicator: Ice.Communicator, collocate
         p.ice_ping()
         test(not f1.is_sent() and f1.done())
         test(not f2.is_sent() and f2.done())
+
+        # sent() must not block once the invocation is cancelled before being sent.
+        try:
+            f1.sent(10)
+            test(False)
+        except Ice.InvocationCanceledException:
+            pass
+        try:
+            f2.sent(10)
+            test(False)
+        except Ice.InvocationCanceledException:
+            pass
 
         testController.holdAdapter()
 

--- a/python/test/Ice/ami/AllTests.py
+++ b/python/test/Ice/ami/AllTests.py
@@ -272,16 +272,19 @@ def allTestsFuture(helper: TestHelper, communicator: Ice.Communicator, collocate
         runningFuture.result(0)
         test(False)
     except Ice.TimeoutException:
+        # Expected: the future is still running, so the bounded wait must time out.
         pass
     try:
         runningFuture.exception(0)
         test(False)
     except Ice.TimeoutException:
+        # Expected: the future is still running, so the bounded wait must time out.
         pass
     try:
         runningFuture.result(0.01)
         test(False)
     except Ice.TimeoutException:
+        # Expected: the future is still running, so the bounded wait must time out.
         pass
 
     runningFuture.set_result(15)
@@ -826,14 +829,16 @@ def allTestsFuture(helper: TestHelper, communicator: Ice.Communicator, collocate
 
         # sent() must not block once the invocation is cancelled before being sent.
         try:
-            f1.sent(10)
+            f1.sent(2)
             test(False)
         except Ice.InvocationCanceledException:
+            # Expected: the invocation was cancelled before being sent.
             pass
         try:
-            f2.sent(10)
+            f2.sent(2)
             test(False)
         except Ice.InvocationCanceledException:
+            # Expected: the invocation was cancelled before being sent.
             pass
 
         testController.holdAdapter()


### PR DESCRIPTION
Two independent wait bugs in the Python `Future` classes:

- `Future._wait` distinguished bounded from unbounded waiting with `if timeout:`, which is false for `0`/`0.0`. The standard polling idiom `future.result(0)` / `future.exception(0)` therefore blocked indefinitely instead of raising `TimeoutException` immediately. Fixed with `if timeout is not None:`.

- `InvocationFuture.sent()` waited on the predicate `lambda: not self._sent`. When an invocation is cancelled (or fails) before ever being sent, `cancel()`/`set_exception()` flip the state and notify, but never set `_sent`, so `sent()` kept waiting forever and the documented `InvocationCanceledException` path was unreachable. The predicate now also terminates when the future leaves the running state.

Regression tests added to the `Ice/ami` suite: a serverless "future timeout" section covering `result(0)`/`exception(0)`/expired timeouts, and `sent()` checks on the existing cancel-before-send futures (which previously hung).

Fixes #5523
Fixes #5524