### PR TITLE
Fix IcePy marshal error paths that continued with a pending Python exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ might need to be aware of.
   - [General Changes](#general-changes)
   - [C# Changes](#c-changes)
   - [JavaScript Changes](#javascript-changes)
+  - [Python Changes](#python-changes)
 
 ## Changes in Ice 3.9.0
 
@@ -32,6 +33,12 @@ might need to be aware of.
 - Assigning an out-of-range or non-integer value to an `InputStream` or `OutputStream` position now throws a
   `RangeError` instead of being silently ignored, matching the buffer-position behavior of the other language
   mappings.
+
+### Python Changes
+
+- Fixed Ice for Python to reliably abort request marshaling when an invalid value is supplied for a sequence
+  parameter (such as a non-sequence argument), instead of continuing with a pending Python exception and sending a
+  corrupt or truncated request.
 
 These are the changes since the [Ice 3.8.2] release.
 

--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -921,9 +921,9 @@ int32_t
 IcePy::EnumInfo::valueForEnumerator(PyObject* p) const
 {
     int isInstance = PyObject_IsInstance(p, pythonType);
-    if (isInstance < 0)
+    if (isInstance == -1)
     {
-        assert(PyErr_Occurred()); // A custom __instancecheck__ raised; preserve the pending exception.
+        assert(PyErr_Occurred());
         return -1;
     }
     else if (isInstance == 0)
@@ -1113,7 +1113,7 @@ IcePy::StructInfo::marshal(
     const Ice::StringSeq*)
 {
     int isInstance = PyObject_IsInstance(p, pythonType);
-    if (isInstance < 0)
+    if (isInstance == -1)
     {
         assert(PyErr_Occurred());
         throw AbortMarshaling();
@@ -2560,9 +2560,8 @@ IcePy::ValueInfo::marshal(PyObject* p, Ice::OutputStream* os, ObjectMap* objectM
     }
 
     int isInstance = PyObject_IsInstance(p, pythonType);
-    if (isInstance < 0)
+    if (isInstance == -1)
     {
-        // A custom __instancecheck__ raised; propagate the pending Python exception.
         assert(PyErr_Occurred());
         throw AbortMarshaling();
     }
@@ -3022,9 +3021,8 @@ IcePy::ReadValueCallback::invoke(const std::shared_ptr<Ice::Value>& p)
         //
         PyObject* obj = reader->getObject(); // Borrowed reference.
         int isInstance = PyObject_IsInstance(obj, _info->pythonType);
-        if (isInstance < 0)
+        if (isInstance == -1)
         {
-            // A custom __instancecheck__ raised; propagate the pending Python exception.
             assert(PyErr_Occurred());
             throw AbortMarshaling();
         }
@@ -3052,9 +3050,8 @@ void
 IcePy::ExceptionInfo::marshal(PyObject* p, Ice::OutputStream* os, ObjectMap* objectMap)
 {
     int isInstance = PyObject_IsInstance(p, pythonType);
-    if (isInstance < 0)
+    if (isInstance == -1)
     {
-        // A custom __instancecheck__ raised; propagate the pending Python exception.
         assert(PyErr_Occurred());
         throw AbortMarshaling();
     }

--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -1293,7 +1293,7 @@ IcePy::SequenceInfo::marshal(
                     if (!fs.get())
                     {
                         assert(PyErr_Occurred());
-                        return;
+                        throw AbortMarshaling();
                     }
                     sz = PySequence_Fast_GET_SIZE(fs.get());
                 }
@@ -1317,7 +1317,8 @@ IcePy::SequenceInfo::marshal(
         PyObjectHandle fastSeq{PySequence_Fast(p, "expected a sequence value")};
         if (!fastSeq.get())
         {
-            return;
+            assert(PyErr_Occurred());
+            throw AbortMarshaling();
         }
 
         Py_ssize_t sz = PySequence_Fast_GET_SIZE(fastSeq.get());
@@ -1574,7 +1575,7 @@ IcePy::SequenceInfo::marshalPrimitiveSequence(const PrimitiveInfoPtr& pi, PyObje
     if (!fs.get())
     {
         assert(PyErr_Occurred());
-        return;
+        throw AbortMarshaling();
     }
 
     Py_ssize_t sz = 0;
@@ -2546,7 +2547,7 @@ IcePy::ValueInfo::marshal(PyObject* p, Ice::OutputStream* os, ObjectMap* objectM
         return;
     }
 
-    if (!PyObject_IsInstance(p, pythonType))
+    if (PyObject_IsInstance(p, pythonType) != 1)
     {
         PyErr_Format(PyExc_ValueError, "expected value of type %s", id.c_str());
         throw AbortMarshaling();
@@ -3001,7 +3002,7 @@ IcePy::ReadValueCallback::invoke(const std::shared_ptr<Ice::Value>& p)
         // Verify that the value's type is compatible with the formal type.
         //
         PyObject* obj = reader->getObject(); // Borrowed reference.
-        if (!PyObject_IsInstance(obj, _info->pythonType))
+        if (PyObject_IsInstance(obj, _info->pythonType) != 1)
         {
             throw MarshalException{
                 __FILE__,
@@ -3024,7 +3025,7 @@ IcePy::ReadValueCallback::invoke(const std::shared_ptr<Ice::Value>& p)
 void
 IcePy::ExceptionInfo::marshal(PyObject* p, Ice::OutputStream* os, ObjectMap* objectMap)
 {
-    if (!PyObject_IsInstance(p, pythonType))
+    if (PyObject_IsInstance(p, pythonType) != 1)
     {
         PyErr_Format(PyExc_ValueError, "expected exception %s", id.c_str());
         throw AbortMarshaling();

--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -2547,7 +2547,14 @@ IcePy::ValueInfo::marshal(PyObject* p, Ice::OutputStream* os, ObjectMap* objectM
         return;
     }
 
-    if (PyObject_IsInstance(p, pythonType) != 1)
+    int isInstance = PyObject_IsInstance(p, pythonType);
+    if (isInstance < 0)
+    {
+        // A custom __instancecheck__ raised; propagate the pending Python exception.
+        assert(PyErr_Occurred());
+        throw AbortMarshaling();
+    }
+    else if (isInstance == 0)
     {
         PyErr_Format(PyExc_ValueError, "expected value of type %s", id.c_str());
         throw AbortMarshaling();
@@ -3002,7 +3009,14 @@ IcePy::ReadValueCallback::invoke(const std::shared_ptr<Ice::Value>& p)
         // Verify that the value's type is compatible with the formal type.
         //
         PyObject* obj = reader->getObject(); // Borrowed reference.
-        if (PyObject_IsInstance(obj, _info->pythonType) != 1)
+        int isInstance = PyObject_IsInstance(obj, _info->pythonType);
+        if (isInstance < 0)
+        {
+            // A custom __instancecheck__ raised; propagate the pending Python exception.
+            assert(PyErr_Occurred());
+            throw AbortMarshaling();
+        }
+        else if (isInstance == 0)
         {
             throw MarshalException{
                 __FILE__,
@@ -3025,7 +3039,14 @@ IcePy::ReadValueCallback::invoke(const std::shared_ptr<Ice::Value>& p)
 void
 IcePy::ExceptionInfo::marshal(PyObject* p, Ice::OutputStream* os, ObjectMap* objectMap)
 {
-    if (PyObject_IsInstance(p, pythonType) != 1)
+    int isInstance = PyObject_IsInstance(p, pythonType);
+    if (isInstance < 0)
+    {
+        // A custom __instancecheck__ raised; propagate the pending Python exception.
+        assert(PyErr_Occurred());
+        throw AbortMarshaling();
+    }
+    else if (isInstance == 0)
     {
         PyErr_Format(PyExc_ValueError, "expected exception %s", id.c_str());
         throw AbortMarshaling();

--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -920,7 +920,13 @@ IcePy::EnumInfo::destroy()
 int32_t
 IcePy::EnumInfo::valueForEnumerator(PyObject* p) const
 {
-    if (PyObject_IsInstance(p, pythonType) != 1)
+    int isInstance = PyObject_IsInstance(p, pythonType);
+    if (isInstance < 0)
+    {
+        assert(PyErr_Occurred()); // A custom __instancecheck__ raised; preserve the pending exception.
+        return -1;
+    }
+    else if (isInstance == 0)
     {
         PyErr_Format(PyExc_ValueError, "expected value of type %s", id.c_str());
         return -1;
@@ -1106,7 +1112,13 @@ IcePy::StructInfo::marshal(
     bool optional,
     const Ice::StringSeq*)
 {
-    if (PyObject_IsInstance(p, pythonType) != 1)
+    int isInstance = PyObject_IsInstance(p, pythonType);
+    if (isInstance < 0)
+    {
+        assert(PyErr_Occurred());
+        throw AbortMarshaling();
+    }
+    else if (isInstance == 0)
     {
         PyErr_Format(PyExc_ValueError, "expected value of type %s", id.c_str());
         throw AbortMarshaling();

--- a/python/test/Ice/operations/Twoways.py
+++ b/python/test/Ice/operations/Twoways.py
@@ -246,24 +246,30 @@ def twoways(helper: TestHelper, p: Test.MyClassPrx) -> None:
         p.opByteS(123, 456)  # pyright: ignore
         test(False)
     except TypeError:
+        # Expected: a non-sequence argument for a sequence parameter must raise TypeError.
         pass
 
     try:
         p.opStringS(5, [])  # pyright: ignore
         test(False)
     except TypeError:
+        # Expected: a non-sequence argument for a sequence parameter must raise TypeError.
         pass
 
     try:
         p.opStringSS([42], [])  # pyright: ignore
         test(False)
     except TypeError:
+        # Expected: a non-sequence element of a sequence-of-sequence parameter must raise TypeError.
         pass
 
+    # The async path uses the same marshaling code; one case is enough to cover it (no extra
+    # permutations needed).
     try:
         p.opByteSAsync(123, 456)  # pyright: ignore
         test(False)
     except TypeError:
+        # Expected: a non-sequence argument for a sequence parameter must raise TypeError.
         pass
 
     # The connection must still be usable.

--- a/python/test/Ice/operations/Twoways.py
+++ b/python/test/Ice/operations/Twoways.py
@@ -239,6 +239,37 @@ def twoways(helper: TestHelper, p: Test.MyClassPrx) -> None:
         pass
 
     #
+    # Test passing non-sequence values for sequence parameters. The invocation must
+    # fail with a clean exception and must not write a corrupt message.
+    #
+    try:
+        p.opByteS(123, 456)  # pyright: ignore
+        test(False)
+    except TypeError:
+        pass
+
+    try:
+        p.opStringS(5, [])  # pyright: ignore
+        test(False)
+    except TypeError:
+        pass
+
+    try:
+        p.opStringSS([42], [])  # pyright: ignore
+        test(False)
+    except TypeError:
+        pass
+
+    try:
+        p.opByteSAsync(123, 456)  # pyright: ignore
+        test(False)
+    except TypeError:
+        pass
+
+    # The connection must still be usable.
+    p.ice_ping()
+
+    #
     # opString
     #
     r, s = p.opString("hello", "world")


### PR DESCRIPTION
Two groups of error-path fixes in `python/modules/IcePy/Types.cpp`:

- Three sequence-marshal error paths (`SequenceInfo::marshal` size-determination branch, its generic-element branch, and `SequenceInfo::marshalPrimitiveSequence`) returned with a Python exception pending instead of throwing `AbortMarshaling`. The marshaling driver detects per-parameter failure only by catching `AbortMarshaling`, so passing a non-sequence for a `sequence<T>` parameter produced a corrupt/truncated message that could reach the wire, with the original `TypeError` surfacing later misattributed to an unrelated call. They now throw `AbortMarshaling`, matching the null-item path in the same function.

- Three `if (!PyObject_IsInstance(...))` checks (`ValueInfo::marshal`, `ReadValueCallback::invoke`, `ExceptionInfo::marshal`) swallowed the `-1` error result and proceeded with a pending exception when a custom `__instancecheck__` raises. They now use the `!= 1` idiom already used by `StructInfo::marshal`.

Regression tests in the `Ice/operations` suite pass non-sequence values for sequence parameters (sync and async) and verify a clean `TypeError` plus a still-usable connection. Pre-fix, the corrupt message reached the server and the stale exception broke subsequent exception construction (`unable to create Python exception class for type ID ::Ice::UnknownLocalException`).

Fixes #5522
Fixes #5527