### PR TITLE
Use numpy.bool_ instead of the removed numpy.bool alias

### DIFF
--- a/python/python/Ice/_ArrayUtil.py
+++ b/python/python/Ice/_ArrayUtil.py
@@ -30,7 +30,9 @@ try:
     import numpy
 
     BuiltinNumpyTypes = [
-        numpy.bool,
+        # Use numpy.bool_, not the numpy.bool alias: the alias was removed in NumPy 1.24
+        # and only reintroduced in NumPy 2.0.
+        numpy.bool_,
         numpy.int8,
         numpy.int16,
         numpy.int32,


### PR DESCRIPTION
`Ice._ArrayUtil` referenced `numpy.bool`, a deprecated alias removed in NumPy 1.24 and only reintroduced in NumPy 2.0. On NumPy 1.24–1.26 (the only 1.x line supporting Python 3.12), the attribute access raises `AttributeError` — which the surrounding `try/except ImportError` does not catch — breaking the NumPy array mapping at first use. The stable spelling `numpy.bool_` works on all supported NumPy versions.

No new test: the breakage only manifests on NumPy 1.24–1.26, and the existing `Ice/custom` suite covers the NumPy array mapping (verified passing with this change).

Fixes #5526