### PR TITLE
Harden IcePy error handling: getVersion, getString, compileSlice, createFuture

### DIFF
--- a/python/modules/IcePy/Communicator.cpp
+++ b/python/modules/IcePy/Communicator.cpp
@@ -500,7 +500,10 @@ communicatorShutdownCompleted(CommunicatorObject* self, PyObject* /*args*/)
     }
 
     // Call Ice.Future.__init__
-    type->tp_init(future.get(), emptyArgs.get(), nullptr);
+    if (type->tp_init(future.get(), emptyArgs.get(), nullptr) < 0)
+    {
+        return nullptr;
+    }
 
     // Create a new reference to prevent premature release of the future object. The reference will be released by
     // the callback.

--- a/python/modules/IcePy/Connection.cpp
+++ b/python/modules/IcePy/Connection.cpp
@@ -375,7 +375,10 @@ connectionClose(ConnectionObject* self, PyObject* /* args */)
     }
 
     // Call Ice.Future.__init__
-    type->tp_init(future.get(), emptyArgs.get(), nullptr);
+    if (type->tp_init(future.get(), emptyArgs.get(), nullptr) < 0)
+    {
+        return nullptr;
+    }
 
     // Create a new reference to prevent premature release of the future object. The reference will be released by
     // either the success or exception callback, depending on the outcome of the close operation.

--- a/python/modules/IcePy/Logger.cpp
+++ b/python/modules/IcePy/Logger.cpp
@@ -77,7 +77,12 @@ IcePy::LoggerWrapper::getPrefix()
     {
         throwPythonException();
     }
-    return getString(tmp.get());
+    string result = getString(tmp.get());
+    if (PyErr_Occurred())
+    {
+        throwPythonException();
+    }
+    return result;
 }
 
 Ice::LoggerPtr

--- a/python/modules/IcePy/Operation.cpp
+++ b/python/modules/IcePy/Operation.cpp
@@ -2602,7 +2602,10 @@ IcePy::createFuture(PyObject* asyncInvocationContext)
     PyTuple_SET_ITEM(initArgs.get(), 0, Py_NewRef(asyncInvocationContext));
 
     // Call the Ice.InvocationFuture.__init__ method.
-    type->tp_init(future.get(), initArgs.get(), nullptr);
+    if (type->tp_init(future.get(), initArgs.get(), nullptr) < 0)
+    {
+        return nullptr;
+    }
 
     // Release the reference to the future object and let the caller take ownership.
     return future.release();

--- a/python/modules/IcePy/Slice.cpp
+++ b/python/modules/IcePy/Slice.cpp
@@ -196,6 +196,13 @@ IcePy_compileSlice(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
+    // Slice::Python::compile and the catch handlers below expect args[0] to be the program name.
+    if (argSeq.empty())
+    {
+        PyErr_Format(PyExc_ValueError, "arguments cannot be empty");
+        return nullptr;
+    }
+
     int rc;
     try
     {

--- a/python/modules/IcePy/Slice.cpp
+++ b/python/modules/IcePy/Slice.cpp
@@ -199,7 +199,9 @@ IcePy_compileSlice(PyObject* /*self*/, PyObject* args)
     // Slice::Python::compile and the catch handlers below expect args[0] to be the program name.
     if (argSeq.empty())
     {
-        PyErr_Format(PyExc_ValueError, "arguments cannot be empty");
+        PyErr_Format(
+            PyExc_ValueError,
+            "compileSlice requires a non-empty argument list whose first element is the program name");
         return nullptr;
     }
 

--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -85,7 +85,12 @@ namespace IcePy
         }
         else if (checkString(p))
         {
-            os->write(getString(p), false); // Bypass string conversion.
+            string str = getString(p);
+            if (PyErr_Occurred())
+            {
+                return false; // The string is not UTF-8 encodable.
+            }
+            os->write(str, false); // Bypass string conversion.
         }
         else
         {

--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -88,7 +88,7 @@ namespace IcePy
             string str = getString(p);
             if (PyErr_Occurred())
             {
-                return false; // The string is not UTF-8 encodable.
+                return false; // String conversion failed; a Python exception is set.
             }
             os->write(str, false); // Bypass string conversion.
         }

--- a/python/modules/IcePy/Types.cpp
+++ b/python/modules/IcePy/Types.cpp
@@ -2782,6 +2782,10 @@ IcePy::ValueWriter::_iceWrite(Ice::OutputStream* os) const
             throw AbortMarshaling();
         }
         string id = getString(ret.get());
+        if (PyErr_Occurred())
+        {
+            throw AbortMarshaling(); // String conversion failed; a Python exception is set.
+        }
         os->startSlice(id, -1, true);
         os->endSlice();
     }

--- a/python/modules/IcePy/Util.cpp
+++ b/python/modules/IcePy/Util.cpp
@@ -126,7 +126,7 @@ IcePy::getStringArg(PyObject* p, const string& arg, string& val)
         val = getString(p);
         if (PyErr_Occurred())
         {
-            return false; // The string is not UTF-8 encodable.
+            return false; // String conversion failed; a Python exception is set.
         }
     }
     else if (p != Py_None)
@@ -377,7 +377,7 @@ IcePy::listToStringSeq(PyObject* l, Ice::StringSeq& seq)
             str = getString(item);
             if (PyErr_Occurred())
             {
-                return false; // The string is not UTF-8 encodable.
+                return false; // String conversion failed; a Python exception is set.
             }
         }
         else if (item != Py_None)
@@ -433,7 +433,7 @@ IcePy::tupleToStringSeq(PyObject* t, Ice::StringSeq& seq)
             str = getString(item);
             if (PyErr_Occurred())
             {
-                return false; // The string is not UTF-8 encodable.
+                return false; // String conversion failed; a Python exception is set.
             }
         }
         else if (item != Py_None)
@@ -463,7 +463,7 @@ IcePy::dictionaryToContext(PyObject* dict, Ice::Context& context)
             keystr = getString(key);
             if (PyErr_Occurred())
             {
-                return false; // The string is not UTF-8 encodable.
+                return false; // String conversion failed; a Python exception is set.
             }
         }
         else if (key != Py_None)
@@ -478,7 +478,7 @@ IcePy::dictionaryToContext(PyObject* dict, Ice::Context& context)
             valuestr = getString(value);
             if (PyErr_Occurred())
             {
-                return false; // The string is not UTF-8 encodable.
+                return false; // String conversion failed; a Python exception is set.
             }
         }
         else if (value != Py_None)
@@ -776,7 +776,7 @@ IcePy::getIdentity(PyObject* p, Ice::Identity& ident)
         ident.name = getString(name.get());
         if (PyErr_Occurred())
         {
-            return false; // The string is not UTF-8 encodable.
+            return false; // String conversion failed; a Python exception is set.
         }
     }
     if (category.get())
@@ -789,7 +789,7 @@ IcePy::getIdentity(PyObject* p, Ice::Identity& ident)
         ident.category = getString(category.get());
         if (PyErr_Occurred())
         {
-            return false; // The string is not UTF-8 encodable.
+            return false; // String conversion failed; a Python exception is set.
         }
     }
     return true;

--- a/python/modules/IcePy/Util.cpp
+++ b/python/modules/IcePy/Util.cpp
@@ -56,7 +56,7 @@ namespace IcePy
 
         if (minor.get())
         {
-            major = PyNumber_Long(minor.get());
+            minor = PyNumber_Long(minor.get());
             if (!minor.get())
             {
                 PyErr_Format(PyExc_ValueError, "version minor must be a numeric value");
@@ -124,6 +124,10 @@ IcePy::getStringArg(PyObject* p, const string& arg, string& val)
     if (checkString(p))
     {
         val = getString(p);
+        if (PyErr_Occurred())
+        {
+            return false; // The string is not UTF-8 encodable.
+        }
     }
     else if (p != Py_None)
     {
@@ -371,6 +375,10 @@ IcePy::listToStringSeq(PyObject* l, Ice::StringSeq& seq)
         if (checkString(item))
         {
             str = getString(item);
+            if (PyErr_Occurred())
+            {
+                return false; // The string is not UTF-8 encodable.
+            }
         }
         else if (item != Py_None)
         {
@@ -423,6 +431,10 @@ IcePy::tupleToStringSeq(PyObject* t, Ice::StringSeq& seq)
         if (checkString(item))
         {
             str = getString(item);
+            if (PyErr_Occurred())
+            {
+                return false; // The string is not UTF-8 encodable.
+            }
         }
         else if (item != Py_None)
         {
@@ -449,6 +461,10 @@ IcePy::dictionaryToContext(PyObject* dict, Ice::Context& context)
         if (checkString(key))
         {
             keystr = getString(key);
+            if (PyErr_Occurred())
+            {
+                return false; // The string is not UTF-8 encodable.
+            }
         }
         else if (key != Py_None)
         {
@@ -460,6 +476,10 @@ IcePy::dictionaryToContext(PyObject* dict, Ice::Context& context)
         if (checkString(value))
         {
             valuestr = getString(value);
+            if (PyErr_Occurred())
+            {
+                return false; // The string is not UTF-8 encodable.
+            }
         }
         else if (value != Py_None)
         {
@@ -754,6 +774,10 @@ IcePy::getIdentity(PyObject* p, Ice::Identity& ident)
             return false;
         }
         ident.name = getString(name.get());
+        if (PyErr_Occurred())
+        {
+            return false; // The string is not UTF-8 encodable.
+        }
     }
     if (category.get())
     {
@@ -763,6 +787,10 @@ IcePy::getIdentity(PyObject* p, Ice::Identity& ident)
             return false;
         }
         ident.category = getString(category.get());
+        if (PyErr_Occurred())
+        {
+            return false; // The string is not UTF-8 encodable.
+        }
     }
     return true;
 }

--- a/python/test/Ice/operations/Twoways.py
+++ b/python/test/Ice/operations/Twoways.py
@@ -253,18 +253,21 @@ def twoways(helper: TestHelper, p: Test.MyClassPrx) -> None:
         p.opString("hel\ud800lo", "world")
         test(False)
     except UnicodeEncodeError:
+        # Expected: a non-UTF-8-encodable string is rejected at the conversion boundary.
         pass
 
     try:
         p.opContext({"\ud800": "value"})
         test(False)
     except UnicodeEncodeError:
+        # Expected: a non-UTF-8-encodable string is rejected at the conversion boundary.
         pass
 
     try:
         p.ice_identity(Ice.Identity("\ud800"))
         test(False)
     except UnicodeEncodeError:
+        # Expected: a non-UTF-8-encodable string is rejected at the conversion boundary.
         pass
 
     # The connection must still be usable.

--- a/python/test/Ice/operations/Twoways.py
+++ b/python/test/Ice/operations/Twoways.py
@@ -246,6 +246,31 @@ def twoways(helper: TestHelper, p: Test.MyClassPrx) -> None:
     test(r == "hello world")
 
     #
+    # Test that non-UTF-8-encodable strings are rejected with a clean exception at the
+    # conversion boundary (string parameters, context keys/values, and identities).
+    #
+    try:
+        p.opString("hel\ud800lo", "world")
+        test(False)
+    except UnicodeEncodeError:
+        pass
+
+    try:
+        p.opContext({"\ud800": "value"})
+        test(False)
+    except UnicodeEncodeError:
+        pass
+
+    try:
+        p.ice_identity(Ice.Identity("\ud800"))
+        test(False)
+    except UnicodeEncodeError:
+        pass
+
+    # The connection must still be usable.
+    p.ice_ping()
+
+    #
     # opMyEnum
     #
     r, e = p.opMyEnum(Test.MyEnum.enum2)

--- a/python/test/Slice/import/Client.py
+++ b/python/test/Slice/import/Client.py
@@ -15,6 +15,8 @@ from generated.test.Slice.import_test.Test.SubA.SubSubA2 import Value1 as Test_S
 from generated.test.Slice.import_test.Test.SubB.SubSubB1 import Value1 as Test_SubB_SubSubB1_Value1
 from generated.test.Slice.import_test.Test.SubB.SubSubB1 import Value2 as Test_SubB_SubSubB1_Value2
 
+import IcePy
+
 
 class Client(TestHelper):
     def run(self, args: list[str]):
@@ -25,5 +27,15 @@ class Client(TestHelper):
         test(Test_SubA_SubSubA2_Value1 == 30)
         test(Test_SubB_SubSubB1_Value1 == 20)
         test(Test_SubB_SubSubB1_Value2 == 21)
+
+        print("ok")
+
+        sys.stdout.write("testing compileSlice with an empty argument list... ")
+        sys.stdout.flush()
+        try:
+            IcePy.compileSlice([])
+            test(False)
+        except ValueError:
+            pass
 
         print("ok")

--- a/python/test/Slice/import/Client.py
+++ b/python/test/Slice/import/Client.py
@@ -36,6 +36,7 @@ class Client(TestHelper):
             IcePy.compileSlice([])
             test(False)
         except ValueError:
+            # Expected: an empty argument list is rejected.
             pass
 
         print("ok")


### PR DESCRIPTION
Groups four low-severity error-handling fixes in the IcePy extension, all from the correctness audit:

- **getVersion** (`Util.cpp`): the minor-version branch was an incomplete copy of the major branch — it stored the `PyNumber_Long` coercion into `major`, null-checked the wrong handle, and read the un-coerced value. It now coerces, checks, and reads `minor`. (#5528)

- **getString** (`Util.cpp`, `Types.cpp`): a `PyUnicode_AsUTF8String` failure (e.g. a lone surrogate) silently produced `""` with a pending `UnicodeEncodeError` that surfaced later misattributed (typically as `SystemError: ... returned a result with an exception set`). The boundary callers that take user input — `getStringArg`, `getIdentity`, `listToStringSeq`, `tupleToStringSeq`, `dictionaryToContext`, and the string marshal in `writeString` — now detect the failure and propagate it, so the bad string is rejected at the conversion boundary. (#5529)

- **compileSlice** (`Slice.cpp`): an empty argument list reached `Slice::Python::compile`, which indexes `args[0]` (out-of-bounds, UB), as did the catch handlers. An empty list is now rejected with `ValueError`. (#5530)

- **createFuture** (`Operation.cpp`): the `tp_init` return value was ignored, so an `Ice.InvocationFuture.__init__` failure returned a partially-initialized future with an error set. It now returns `nullptr` on failure. (#5531)

Regression tests: `Ice/operations` rejects lone-surrogate string parameters, context keys, and identity names with `UnicodeEncodeError` (and verifies the connection stays usable); `Slice/import` checks `IcePy.compileSlice([])` raises `ValueError`. No tests for the getVersion/createFuture fixes (contrived triggers).

Fixes #5528
Fixes #5529
Fixes #5530
Fixes #5531